### PR TITLE
(hub-client) Fix paste handling to prevent Monaco snippet expansion artefacts

### DIFF
--- a/hub-client/src/components/Editor.tsx
+++ b/hub-client/src/components/Editor.tsx
@@ -961,6 +961,9 @@ export default function Editor({ project, files, fileContents, onDisconnect, onC
               wordWrap: 'on',
               padding: { top: 16 },
               scrollBeyondLastLine: false,
+              // Disable paste-as to prevent snippet expansion (e.g., URLs from browser
+              // address bar being pasted with $0 appended). See quarto-dev/kyoto#3.
+              pasteAs: { enabled: false },
             }}
           />
         </div>


### PR DESCRIPTION
Fixes #3. Disable Monaco's paste-as feature to fix URLs from browser address bar being pasted with $0 appended.
