### PR TITLE
get ci running on 4 targets

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -16,7 +16,7 @@ jobs:
   test-suite:
     strategy:
       matrix:
-        os: [ubuntu-latest-8x, macos-latest]
+        os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     
     name: Run test suite

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -9,6 +9,9 @@ on:
       - main
       - kyoto
 
+env:
+  PANDOC_VERSION: "3.8.3"
+
 jobs:
   test-suite:
     strategy:
@@ -60,18 +63,19 @@ jobs:
         with:
           tool: cargo-insta
 
-      # Pandoc setup
+      # Pandoc setup (pinned to match Quarto 1.9)
       - name: Set up Pandoc (Linux)
         if: runner.os == 'Linux'
-        run: | 
-          curl -LO https://github.com/jgm/pandoc/releases/download/3.7.0.2/pandoc-3.7.0.2-1-amd64.deb
-          sudo dpkg -i pandoc-3.7.0.2-1-amd64.deb
+        run: |
+          curl -LO "https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/pandoc-${PANDOC_VERSION}-1-amd64.deb"
+          sudo dpkg -i "pandoc-${PANDOC_VERSION}-1-amd64.deb"
         shell: bash
 
       - name: Set up Pandoc (macOS)
         if: runner.os == 'macOS'
         run: |
-          brew install pandoc
+          curl -LO "https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/pandoc-${PANDOC_VERSION}-arm64-macOS.pkg"
+          sudo installer -pkg "pandoc-${PANDOC_VERSION}-arm64-macOS.pkg" -target /
         shell: bash
 
       # tree-sitter setup

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -15,6 +15,7 @@ env:
 jobs:
   test-suite:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ts-test-suite.yml
+++ b/.github/workflows/ts-test-suite.yml
@@ -16,9 +16,7 @@ jobs:
   test-suite:
     strategy:
       matrix:
-        os: 
-        #   - ubuntu-latest-8x
-          - macos-latest
+        os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     
     name: Run test suite

--- a/.github/workflows/ts-test-suite.yml
+++ b/.github/workflows/ts-test-suite.yml
@@ -15,6 +15,7 @@ env:
 jobs:
   test-suite:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ts-test-suite.yml
+++ b/.github/workflows/ts-test-suite.yml
@@ -9,6 +9,9 @@ on:
       - main
       - kyoto
 
+env:
+  PANDOC_VERSION: "3.8.3"
+
 jobs:
   test-suite:
     strategy:
@@ -62,18 +65,19 @@ jobs:
         with:
           tool: cargo-insta
 
-      # Pandoc setup
+      # Pandoc setup (pinned to match Quarto 1.9)
       - name: Set up Pandoc (Linux)
         if: runner.os == 'Linux'
-        run: | 
-          curl -LO https://github.com/jgm/pandoc/releases/download/3.7.0.2/pandoc-3.7.0.2-1-amd64.deb
-          sudo dpkg -i pandoc-3.7.0.2-1-amd64.deb
+        run: |
+          curl -LO "https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/pandoc-${PANDOC_VERSION}-1-amd64.deb"
+          sudo dpkg -i "pandoc-${PANDOC_VERSION}-1-amd64.deb"
         shell: bash
 
       - name: Set up Pandoc (macOS)
         if: runner.os == 'macOS'
         run: |
-          brew install pandoc
+          curl -LO "https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/pandoc-${PANDOC_VERSION}-arm64-macOS.pkg"
+          sudo installer -pkg "pandoc-${PANDOC_VERSION}-arm64-macOS.pkg" -target /
         shell: bash
 
       # tree-sitter setup

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2678,6 +2678,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "walkdir",
 ]
 
 [[package]]
@@ -2970,10 +2971,9 @@ name = "quarto-test"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "pampa",
  "quarto-core",
+ "quarto-error-reporting",
  "quarto-system-runtime",
- "quarto-yaml",
  "regex",
  "serde",
  "serde_yaml",

--- a/crates/quarto-core/src/lib.rs
+++ b/crates/quarto-core/src/lib.rs
@@ -43,6 +43,8 @@ pub mod format;
 pub mod pipeline;
 pub mod project;
 pub mod render;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod render_to_file;
 pub mod resources;
 pub mod stage;
 pub mod template;
@@ -64,4 +66,10 @@ pub use transform::{AstTransform, TransformPipeline};
 pub use transforms::{
     CalloutResolveTransform, CalloutTransform, MetadataNormalizeTransform,
     ResourceCollectorTransform, TitleBlockTransform,
+};
+
+// Re-export render-to-file types (native only)
+#[cfg(not(target_arch = "wasm32"))]
+pub use render_to_file::{
+    RenderToFileOptions, RenderToFileResult, render_document_to_file, render_to_file,
 };

--- a/crates/quarto-core/src/render_to_file.rs
+++ b/crates/quarto-core/src/render_to_file.rs
@@ -1,0 +1,613 @@
+/*
+ * render_to_file.rs
+ * Copyright (c) 2025 Posit, PBC
+ *
+ * High-level render orchestration that writes output to files.
+ */
+
+//! High-level render-to-file orchestration.
+//!
+//! This module provides the complete render pipeline that:
+//! 1. Reads input document
+//! 2. Creates output directory and resources (CSS, etc.)
+//! 3. Runs the render pipeline
+//! 4. Writes output files
+//!
+//! This is the function that both the CLI and test infrastructure use,
+//! ensuring consistent behavior across all render paths.
+//!
+//! # Simple Usage
+//!
+//! For simple cases (single file, auto-discover project):
+//!
+//! ```ignore
+//! use quarto_core::render_to_file::{render_to_file, RenderToFileOptions};
+//! use quarto_system_runtime::NativeRuntime;
+//! use std::sync::Arc;
+//!
+//! let runtime = Arc::new(NativeRuntime::new());
+//! let options = RenderToFileOptions::default();
+//!
+//! let result = render_to_file(
+//!     Path::new("document.qmd"),
+//!     "html",
+//!     &options,
+//!     runtime,
+//! )?;
+//! ```
+//!
+//! # Advanced Usage (CLI)
+//!
+//! For multi-file projects where you want to discover once and render many:
+//!
+//! ```ignore
+//! use quarto_core::render_to_file::{render_document_to_file, RenderToFileOptions};
+//! use quarto_core::project::ProjectContext;
+//!
+//! // Discover project once
+//! let project = ProjectContext::discover(&input_path, &runtime)?;
+//!
+//! // Render each document
+//! for doc in &project.files {
+//!     let result = render_document_to_file(
+//!         &doc.input,
+//!         "html",
+//!         &options,
+//!         Some(&project),
+//!         runtime.clone(),
+//!     )?;
+//! }
+//! ```
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use tracing::{debug, warn};
+
+use quarto_system_runtime::SystemRuntime;
+
+use crate::error::QuartoError;
+use crate::format::{extract_format_metadata, Format};
+use crate::pipeline::{render_qmd_to_html, HtmlRenderConfig, RenderOutput};
+use crate::project::{DocumentInfo, ProjectContext};
+use crate::render::{BinaryDependencies, RenderContext};
+use crate::resources::{self, HtmlResourcePaths};
+use crate::Result;
+
+/// Options for rendering a document to a file.
+#[derive(Debug, Clone, Default)]
+pub struct RenderToFileOptions {
+    /// Explicit output path. If None, derived from input path.
+    pub output_path: Option<PathBuf>,
+    /// Explicit output directory. If None, same directory as input.
+    pub output_dir: Option<PathBuf>,
+    /// Suppress informational messages (logging).
+    pub quiet: bool,
+}
+
+/// Result of rendering a document to a file.
+#[derive(Debug)]
+pub struct RenderToFileResult {
+    /// Path to the output file.
+    pub output_path: PathBuf,
+    /// Path to the resources directory (e.g., `document_files/`).
+    pub resources_dir: PathBuf,
+    /// The full render output including HTML and diagnostics.
+    pub render_output: RenderOutput,
+}
+
+/// Render a QMD document to a file (simple API).
+///
+/// This is the simplest entry point for rendering documents. It automatically
+/// discovers the project context and handles all setup.
+///
+/// For multi-file projects where you want to discover once and render many files,
+/// use [`render_document_to_file`] instead.
+///
+/// # Arguments
+///
+/// * `input_path` - Path to the input QMD file
+/// * `format` - Output format name (e.g., "html")
+/// * `options` - Render options
+/// * `runtime` - System runtime for file operations
+///
+/// # Returns
+///
+/// Returns the render result with output path and diagnostics.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn render_to_file(
+    input_path: &Path,
+    format: &str,
+    options: &RenderToFileOptions,
+    runtime: Arc<dyn SystemRuntime>,
+) -> Result<RenderToFileResult> {
+    render_document_to_file(input_path, format, options, None, runtime)
+}
+
+/// Render a QMD document to a file (advanced API).
+///
+/// This function accepts an optional pre-discovered `ProjectContext`, which is
+/// useful when rendering multiple files in a project - you discover once and
+/// render many times without re-discovering for each file.
+///
+/// # Arguments
+///
+/// * `input_path` - Path to the input QMD file
+/// * `format` - Output format name (e.g., "html")
+/// * `options` - Render options
+/// * `project` - Optional pre-discovered project context. If None, discovers automatically.
+/// * `runtime` - System runtime for file operations
+///
+/// # Returns
+///
+/// Returns the render result with output path and diagnostics.
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - The input file cannot be read
+/// - Project discovery fails (when project is None)
+/// - Resource writing fails
+/// - The render pipeline fails
+/// - The output file cannot be written
+#[cfg(not(target_arch = "wasm32"))]
+pub fn render_document_to_file(
+    input_path: &Path,
+    format: &str,
+    options: &RenderToFileOptions,
+    project: Option<&ProjectContext>,
+    runtime: Arc<dyn SystemRuntime>,
+) -> Result<RenderToFileResult> {
+    debug!("Rendering: {}", input_path.display());
+
+    // Read input file
+    let input_bytes = runtime.file_read(input_path).map_err(|e| {
+        QuartoError::other(format!(
+            "Failed to read input file {}: {}",
+            input_path.display(),
+            e
+        ))
+    })?;
+
+    let input_str = std::str::from_utf8(&input_bytes)
+        .map_err(|e| QuartoError::other(format!("Input file contains invalid UTF-8: {}", e)))?;
+
+    // Use provided project or discover
+    let discovered_project;
+    let project = match project {
+        Some(p) => p,
+        None => {
+            discovered_project = ProjectContext::discover(input_path, runtime.as_ref())?;
+            &discovered_project
+        }
+    };
+
+    // Extract format-specific metadata from frontmatter (toc, theme, etc.)
+    let format_metadata = extract_format_metadata(input_str, format).unwrap_or_else(|e| {
+        warn!("Failed to extract format metadata: {}. Using defaults.", e);
+        serde_json::Value::Null
+    });
+
+    // Determine output paths
+    let (output_path, output_dir, output_stem) =
+        determine_output_paths(input_path, format, options)?;
+
+    // Create output directory
+    runtime.dir_create(&output_dir, true).map_err(|e| {
+        QuartoError::other(format!(
+            "Failed to create output directory {}: {}",
+            output_dir.display(),
+            e
+        ))
+    })?;
+
+    // Write resources (CSS) with theme support
+    let resource_paths = write_themed_resources(
+        input_str,
+        input_path,
+        &output_dir,
+        &output_stem,
+        runtime.as_ref(),
+        options.quiet,
+    )?;
+
+    // Set up render context with format that includes extracted metadata
+    let doc_info = DocumentInfo::from_path(input_path);
+    let render_format = format_from_name(format).with_metadata(format_metadata);
+    let binaries = BinaryDependencies::new();
+    let mut ctx = RenderContext::new(project, &doc_info, &render_format, &binaries);
+
+    // Configure the pipeline with CSS paths
+    let config = HtmlRenderConfig {
+        css_paths: &resource_paths.css,
+        template: None,
+    };
+
+    // Run the render pipeline
+    let render_output = pollster::block_on(render_qmd_to_html(
+        &input_bytes,
+        &input_path.to_string_lossy(),
+        &mut ctx,
+        &config,
+        runtime.clone(),
+    ))?;
+
+    // Write output HTML
+    runtime
+        .file_write(&output_path, render_output.html.as_bytes())
+        .map_err(|e| {
+            QuartoError::other(format!(
+                "Failed to write output file {}: {}",
+                output_path.display(),
+                e
+            ))
+        })?;
+
+    debug!("Output: {}", output_path.display());
+
+    Ok(RenderToFileResult {
+        output_path,
+        resources_dir: resource_paths.resource_dir,
+        render_output,
+    })
+}
+
+/// Determine output paths from input path and options.
+fn determine_output_paths(
+    input_path: &Path,
+    format: &str,
+    options: &RenderToFileOptions,
+) -> Result<(PathBuf, PathBuf, String)> {
+    // Determine file extension
+    let extension = match format {
+        "html" => "html",
+        "pdf" => "pdf",
+        "docx" => "docx",
+        "latex" | "tex" => "tex",
+        "typst" => "typ",
+        _ => "html",
+    };
+
+    // Get input stem
+    let stem = input_path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .ok_or_else(|| QuartoError::other("Could not determine input filename stem"))?
+        .to_string();
+
+    // Determine output path
+    let output_path = if let Some(ref explicit_path) = options.output_path {
+        explicit_path.clone()
+    } else {
+        let base_dir = options
+            .output_dir
+            .clone()
+            .or_else(|| input_path.parent().map(|p| p.to_path_buf()))
+            .unwrap_or_else(|| PathBuf::from("."));
+
+        base_dir.join(format!("{}.{}", stem, extension))
+    };
+
+    // Determine output directory
+    let output_dir = output_path
+        .parent()
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| PathBuf::from("."));
+
+    // Get output stem (may differ from input stem if explicit output path given)
+    let output_stem = output_path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or(&stem)
+        .to_string();
+
+    Ok((output_path, output_dir, output_stem))
+}
+
+/// Convert a format name to a Format instance.
+fn format_from_name(name: &str) -> Format {
+    match name {
+        "html" => Format::html(),
+        "pdf" => Format::pdf(),
+        "docx" => Format::docx(),
+        _ => Format::html(),
+    }
+}
+
+// ============================================================================
+// Theme Support (Native Only)
+// ============================================================================
+
+/// Write HTML resources with theme support.
+///
+/// Extracts theme configuration from frontmatter and compiles SASS accordingly.
+/// Falls back to default CSS if no theme is specified or if compilation fails.
+#[cfg(not(target_arch = "wasm32"))]
+fn write_themed_resources(
+    content: &str,
+    input_path: &Path,
+    output_dir: &Path,
+    stem: &str,
+    runtime: &dyn SystemRuntime,
+    quiet: bool,
+) -> Result<HtmlResourcePaths> {
+    use quarto_sass::ThemeContext;
+
+    // Try to extract theme config from frontmatter
+    let theme_config = match extract_theme_config(content) {
+        Ok(Some(config)) => {
+            if !quiet {
+                debug!("Theme configuration found: {:?}", config);
+            }
+            config
+        }
+        Ok(None) => {
+            debug!("No theme specified, using default CSS");
+            return resources::write_html_resources(output_dir, stem, runtime);
+        }
+        Err(e) => {
+            warn!(
+                "Failed to parse theme configuration: {}. Using default CSS.",
+                e
+            );
+            return resources::write_html_resources(output_dir, stem, runtime);
+        }
+    };
+
+    // Create theme context with the document's directory
+    let document_dir = input_path
+        .parent()
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| PathBuf::from("."));
+    let context = ThemeContext::new(document_dir, runtime);
+
+    // Try to compile themed CSS
+    match resources::write_html_resources_with_sass(
+        output_dir,
+        stem,
+        &theme_config,
+        &context,
+        runtime,
+    ) {
+        Ok(paths) => {
+            if !quiet {
+                debug!("Compiled theme CSS successfully");
+            }
+            Ok(paths)
+        }
+        Err(e) => {
+            warn!("Theme CSS compilation failed: {}. Using default CSS.", e);
+            resources::write_html_resources(output_dir, stem, runtime)
+        }
+    }
+}
+
+/// Extract theme configuration from QMD frontmatter.
+///
+/// Parses the YAML frontmatter and extracts the `format.html.theme` value.
+/// Returns `Ok(None)` if no theme is specified.
+///
+/// TODO(ConfigValue): DELETE THIS FUNCTION. Replace all calls with:
+/// ```ignore
+/// let theme_config = ThemeConfig::from_config_value(&merged_config)?;
+/// ```
+#[cfg(not(target_arch = "wasm32"))]
+fn extract_theme_config(content: &str) -> Result<Option<quarto_sass::ThemeConfig>> {
+    // Find YAML frontmatter
+    let trimmed = content.trim_start();
+    if !trimmed.starts_with("---") {
+        return Ok(None);
+    }
+
+    // Find closing ---
+    let after_first = &trimmed[3..];
+    let end_pos = match after_first.find("\n---") {
+        Some(pos) => pos,
+        None => return Ok(None),
+    };
+
+    // Parse YAML
+    let yaml_str = &after_first[..end_pos].trim();
+    let yaml_value: serde_yaml::Value = serde_yaml::from_str(yaml_str)
+        .map_err(|e| QuartoError::other(format!("Failed to parse YAML frontmatter: {}", e)))?;
+
+    // Navigate to format.html.theme
+    let theme_value = yaml_value
+        .get("format")
+        .and_then(|f| f.get("html"))
+        .and_then(|h| h.get("theme"));
+
+    let theme_value = match theme_value {
+        Some(v) => v,
+        None => return Ok(None),
+    };
+
+    // Convert to ThemeConfig
+    let config = theme_value_to_config(theme_value)?;
+    Ok(Some(config))
+}
+
+/// Convert a serde_yaml::Value theme specification to ThemeConfig.
+///
+/// TODO(ConfigValue): DELETE THIS FUNCTION.
+#[cfg(not(target_arch = "wasm32"))]
+fn theme_value_to_config(value: &serde_yaml::Value) -> Result<quarto_sass::ThemeConfig> {
+    use quarto_sass::{ThemeConfig, ThemeSpec};
+
+    match value {
+        serde_yaml::Value::String(s) => {
+            let spec = ThemeSpec::parse(s)
+                .map_err(|e| QuartoError::other(format!("Invalid theme '{}': {}", s, e)))?;
+            Ok(ThemeConfig::new(vec![spec], true))
+        }
+        serde_yaml::Value::Sequence(arr) => {
+            let mut themes = Vec::new();
+            for v in arr {
+                if let Some(s) = v.as_str() {
+                    let spec = ThemeSpec::parse(s)
+                        .map_err(|e| QuartoError::other(format!("Invalid theme '{}': {}", s, e)))?;
+                    themes.push(spec);
+                }
+            }
+            if themes.is_empty() {
+                return Err(QuartoError::other("Empty theme array"));
+            }
+            Ok(ThemeConfig::new(themes, true))
+        }
+        serde_yaml::Value::Null => Ok(ThemeConfig::default_bootstrap()),
+        _ => Err(QuartoError::other(
+            "Invalid theme value: expected string, array, or null",
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use quarto_system_runtime::NativeRuntime;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_determine_output_paths_default() {
+        let input = Path::new("/project/doc.qmd");
+        let options = RenderToFileOptions::default();
+
+        let (output, dir, stem) = determine_output_paths(input, "html", &options).unwrap();
+
+        assert_eq!(output, PathBuf::from("/project/doc.html"));
+        assert_eq!(dir, PathBuf::from("/project"));
+        assert_eq!(stem, "doc");
+    }
+
+    #[test]
+    fn test_determine_output_paths_explicit_output() {
+        let input = Path::new("/project/doc.qmd");
+        let options = RenderToFileOptions {
+            output_path: Some(PathBuf::from("/out/custom.html")),
+            ..Default::default()
+        };
+
+        let (output, dir, stem) = determine_output_paths(input, "html", &options).unwrap();
+
+        assert_eq!(output, PathBuf::from("/out/custom.html"));
+        assert_eq!(dir, PathBuf::from("/out"));
+        assert_eq!(stem, "custom");
+    }
+
+    #[test]
+    fn test_determine_output_paths_output_dir() {
+        let input = Path::new("/project/doc.qmd");
+        let options = RenderToFileOptions {
+            output_dir: Some(PathBuf::from("/out")),
+            ..Default::default()
+        };
+
+        let (output, dir, stem) = determine_output_paths(input, "html", &options).unwrap();
+
+        assert_eq!(output, PathBuf::from("/out/doc.html"));
+        assert_eq!(dir, PathBuf::from("/out"));
+        assert_eq!(stem, "doc");
+    }
+
+    #[test]
+    fn test_render_to_file_creates_output() {
+        let temp = TempDir::new().unwrap();
+        let input_path = temp.path().join("test.qmd");
+
+        // Create a minimal QMD file
+        fs::write(
+            &input_path,
+            r#"---
+title: Test
+---
+
+Hello world.
+"#,
+        )
+        .unwrap();
+
+        let runtime = Arc::new(NativeRuntime::new());
+        let options = RenderToFileOptions::default();
+
+        let result = render_to_file(&input_path, "html", &options, runtime).unwrap();
+
+        // Check output file was created
+        assert!(result.output_path.exists());
+        assert!(result.output_path.ends_with("test.html"));
+
+        // Check resources directory was created
+        assert!(result.resources_dir.exists());
+        assert!(result.resources_dir.ends_with("test_files"));
+
+        // Check HTML contains expected content
+        let html = fs::read_to_string(&result.output_path).unwrap();
+        assert!(html.contains("Hello world"));
+        assert!(html.contains("<title>"));
+    }
+
+    #[test]
+    fn test_render_to_file_with_theme() {
+        let temp = TempDir::new().unwrap();
+        let input_path = temp.path().join("themed.qmd");
+
+        // Create a QMD file with theme
+        fs::write(
+            &input_path,
+            r#"---
+title: Themed Doc
+format:
+  html:
+    theme: cosmo
+---
+
+Themed content.
+"#,
+        )
+        .unwrap();
+
+        let runtime = Arc::new(NativeRuntime::new());
+        let options = RenderToFileOptions::default();
+
+        let result = render_to_file(&input_path, "html", &options, runtime).unwrap();
+
+        // Check CSS was generated
+        let css_path = result.resources_dir.join("styles.css");
+        assert!(css_path.exists());
+
+        // Check it contains Bootstrap classes (from cosmo theme)
+        let css = fs::read_to_string(&css_path).unwrap();
+        assert!(css.contains(".btn"));
+    }
+
+    #[test]
+    fn test_render_document_to_file_with_project() {
+        let temp = TempDir::new().unwrap();
+        let input_path = temp.path().join("doc.qmd");
+
+        fs::write(
+            &input_path,
+            r#"---
+title: Doc
+---
+
+Content.
+"#,
+        )
+        .unwrap();
+
+        let runtime = Arc::new(NativeRuntime::new());
+
+        // Pre-discover project
+        let project = ProjectContext::discover(&input_path, runtime.as_ref()).unwrap();
+
+        let options = RenderToFileOptions::default();
+
+        // Render with pre-discovered project
+        let result =
+            render_document_to_file(&input_path, "html", &options, Some(&project), runtime)
+                .unwrap();
+
+        assert!(result.output_path.exists());
+    }
+}

--- a/crates/quarto-test/Cargo.toml
+++ b/crates/quarto-test/Cargo.toml
@@ -15,10 +15,9 @@ serde.workspace = true
 serde_yaml.workspace = true
 regex.workspace = true
 
-quarto-yaml.workspace = true
 quarto-core.workspace = true
+quarto-error-reporting.workspace = true
 quarto-system-runtime.workspace = true
-pampa.workspace = true
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/quarto-test/src/runner.rs
+++ b/crates/quarto-test/src/runner.rs
@@ -14,7 +14,7 @@ use anyhow::{Context, Result};
 use serde_yaml::Value;
 
 use crate::assertions::{LogLevel, LogMessage, VerifyContext};
-use crate::spec::{TestSpec, parse_test_specs};
+use crate::spec::{parse_test_specs, TestSpec};
 
 /// Result of running tests on a single file.
 #[derive(Debug)]
@@ -203,18 +203,25 @@ fn run_format_tests(input_path: &Path, spec: &TestSpec) -> Result<Vec<FailureDet
 
 /// Render a document to the specified format.
 ///
+/// Uses `quarto_core::render_to_file` which runs the full staged pipeline:
+/// - ParseDocumentStage: QMD → Pandoc AST
+/// - EngineExecutionStage: Execute code cells (skipped when execute=false)
+/// - AstTransformsStage: Project metadata merging + all transforms
+/// - RenderHtmlBodyStage: AST → HTML body
+/// - ApplyTemplateStage: Apply HTML template
+///
+/// This also writes resources (CSS) to the `_files` directory.
+///
 /// Returns a RenderOutput with the output path, any error, and captured messages.
 fn render_document(input_path: &Path, format: &str) -> RenderOutput {
-    use quarto_core::{
-        BinaryDependencies, CalloutResolveTransform, CalloutTransform, DocumentInfo,
-        MetadataNormalizeTransform, ProjectContext, RenderContext, RenderOptions,
-        ResourceCollectorTransform, TransformPipeline,
-    };
+    use std::sync::Arc;
+
+    use quarto_core::render_to_file::{render_to_file, RenderToFileOptions};
     use quarto_system_runtime::NativeRuntime;
 
     let mut messages = Vec::new();
 
-    // Determine output path
+    // Determine expected output path (for error reporting if render fails early)
     let output_dir = input_path.parent().unwrap_or(Path::new("."));
     let stem = input_path
         .file_stem()
@@ -227,221 +234,54 @@ fn render_document(input_path: &Path, format: &str) -> RenderOutput {
         "docx" => "docx",
         "latex" | "tex" => "tex",
         "typst" => "typ",
-        _ => "html", // Default to HTML
+        _ => "html",
     };
 
-    let output_path = output_dir.join(format!("{}.{}", stem, extension));
+    let fallback_output_path = output_dir.join(format!("{}.{}", stem, extension));
 
     // Create runtime
-    let runtime = NativeRuntime::new();
+    let runtime = Arc::new(NativeRuntime::new());
 
-    // Read input
-    let input_content = match fs::read(input_path) {
-        Ok(content) => content,
-        Err(e) => {
-            let error_msg = format!("failed to read: {}: {}", input_path.display(), e);
-            messages.push(LogMessage {
-                level: LogLevel::Error,
-                message: error_msg.clone(),
-            });
-            return RenderOutput {
-                output_path,
-                error: Some(error_msg),
-                messages,
-            };
-        }
+    // Render using the shared render_to_file function
+    let options = RenderToFileOptions {
+        quiet: true, // Don't log to console during tests
+        ..Default::default()
     };
 
-    // Parse QMD
-    let input_path_str = input_path.to_string_lossy();
-    let mut output_stream = std::io::sink();
-
-    let (mut pandoc, _context, warnings) = match pampa::readers::qmd::read(
-        &input_content,
-        false, // loose mode
-        &input_path_str,
-        &mut output_stream,
-        true, // track source locations
-        None, // file_id
-    ) {
-        Ok(result) => result,
-        Err(diagnostics) => {
-            let error_msg = format!(
-                "parse errors:\n{}",
-                diagnostics
-                    .iter()
-                    .map(|d| d.to_text(None))
-                    .collect::<Vec<_>>()
-                    .join("\n")
-            );
-            messages.push(LogMessage {
-                level: LogLevel::Error,
-                message: error_msg.clone(),
-            });
-            return RenderOutput {
-                output_path,
-                error: Some(error_msg),
-                messages,
-            };
-        }
-    };
-
-    // Capture warnings from parsing
-    for warning in warnings {
-        messages.push(LogMessage {
-            level: LogLevel::Warn,
-            message: warning.title.clone(),
-        });
-    }
-
-    // Set up render context
-    let project = match ProjectContext::discover(input_path, &runtime) {
-        Ok(p) => p,
-        Err(e) => {
-            let error_msg = format!("failed to discover project context: {}", e);
-            messages.push(LogMessage {
-                level: LogLevel::Error,
-                message: error_msg.clone(),
-            });
-            return RenderOutput {
-                output_path,
-                error: Some(error_msg),
-                messages,
-            };
-        }
-    };
-    let doc_info = DocumentInfo::from_path(input_path);
-    let render_format = format_from_name(format);
-    let binaries = BinaryDependencies::new();
-    let options = RenderOptions {
-        verbose: false,
-        execute: false,
-        use_freeze: false,
-        output_path: Some(output_path.clone()),
-    };
-    let mut ctx =
-        RenderContext::new(&project, &doc_info, &render_format, &binaries).with_options(options);
-
-    // Run transform pipeline
-    let mut pipeline = TransformPipeline::new();
-    pipeline.push(Box::new(CalloutTransform::new()));
-    pipeline.push(Box::new(CalloutResolveTransform::new()));
-    pipeline.push(Box::new(MetadataNormalizeTransform::new()));
-    pipeline.push(Box::new(ResourceCollectorTransform::new()));
-    if let Err(e) = pipeline.execute(&mut pandoc, &mut ctx) {
-        let error_msg = format!("transform pipeline failed: {}", e);
-        messages.push(LogMessage {
-            level: LogLevel::Error,
-            message: error_msg.clone(),
-        });
-        return RenderOutput {
-            output_path,
-            error: Some(error_msg),
-            messages,
-        };
-    }
-
-    // Get output directory and stem
-    let output_stem = output_path.file_stem().unwrap().to_str().unwrap();
-
-    // Write resources
-    let resource_paths =
-        match quarto_core::resources::write_html_resources(output_dir, output_stem, &runtime) {
-            Ok(paths) => paths,
-            Err(e) => {
-                let error_msg = format!("failed to write resources: {}", e);
-                messages.push(LogMessage {
-                    level: LogLevel::Error,
-                    message: error_msg.clone(),
-                });
-                return RenderOutput {
-                    output_path,
-                    error: Some(error_msg),
-                    messages,
+    match render_to_file(input_path, format, &options, runtime) {
+        Ok(result) => {
+            // Capture diagnostics as log messages
+            for diag in &result.render_output.diagnostics {
+                let level = match diag.kind {
+                    quarto_error_reporting::DiagnosticKind::Error => LogLevel::Error,
+                    quarto_error_reporting::DiagnosticKind::Warning => LogLevel::Warn,
+                    quarto_error_reporting::DiagnosticKind::Info => LogLevel::Info,
+                    quarto_error_reporting::DiagnosticKind::Note => LogLevel::Debug,
                 };
+                messages.push(LogMessage {
+                    level,
+                    message: diag.title.clone(),
+                });
             }
-        };
 
-    // Render HTML body using pampa's HTML writer
-    let mut body_buf = Vec::new();
-    if let Err(e) = pampa::writers::html::write_blocks_to(&pandoc.blocks, &mut body_buf) {
-        let error_msg = format!("failed to render HTML body: {}", e);
-        messages.push(LogMessage {
-            level: LogLevel::Error,
-            message: error_msg.clone(),
-        });
-        return RenderOutput {
-            output_path,
-            error: Some(error_msg),
-            messages,
-        };
-    }
-    let body = String::from_utf8_lossy(&body_buf).into_owned();
-
-    // Render with template
-    let html = match quarto_core::template::render_with_resources(
-        &body,
-        &pandoc.meta,
-        &resource_paths.css,
-    ) {
-        Ok(h) => h,
+            RenderOutput {
+                output_path: result.output_path,
+                error: None,
+                messages,
+            }
+        }
         Err(e) => {
-            let error_msg = format!("failed to apply template: {}", e);
+            let error_msg = e.to_string();
             messages.push(LogMessage {
                 level: LogLevel::Error,
                 message: error_msg.clone(),
             });
-            return RenderOutput {
-                output_path,
+            RenderOutput {
+                output_path: fallback_output_path,
                 error: Some(error_msg),
                 messages,
-            };
+            }
         }
-    };
-
-    // Write output
-    if let Err(e) = fs::create_dir_all(output_dir) {
-        let error_msg = format!("failed to create output directory: {}", e);
-        messages.push(LogMessage {
-            level: LogLevel::Error,
-            message: error_msg.clone(),
-        });
-        return RenderOutput {
-            output_path,
-            error: Some(error_msg),
-            messages,
-        };
-    }
-    if let Err(e) = fs::write(&output_path, html) {
-        let error_msg = format!("failed to write output: {}", e);
-        messages.push(LogMessage {
-            level: LogLevel::Error,
-            message: error_msg.clone(),
-        });
-        return RenderOutput {
-            output_path,
-            error: Some(error_msg),
-            messages,
-        };
-    }
-
-    // Success!
-    RenderOutput {
-        output_path,
-        error: None,
-        messages,
-    }
-}
-
-/// Convert a format name string to a Format instance.
-fn format_from_name(name: &str) -> quarto_core::Format {
-    use quarto_core::Format;
-    match name {
-        "html" => Format::html(),
-        "pdf" => Format::pdf(),
-        "docx" => Format::docx(),
-        // Default to HTML for unknown formats
-        _ => Format::html(),
     }
 }
 

--- a/crates/quarto/Cargo.toml
+++ b/crates/quarto/Cargo.toml
@@ -35,6 +35,7 @@ serde_yaml.workspace = true
 [dev-dependencies]
 tempfile = "3"
 pampa.workspace = true
+walkdir.workspace = true
 
 [lints]
 workspace = true

--- a/crates/quarto/src/commands/render.rs
+++ b/crates/quarto/src/commands/render.rs
@@ -10,31 +10,20 @@
 //! This module implements the `quarto render` command, which renders
 //! QMD files to various output formats.
 //!
-//! ## MVP Scope
-//!
-//! The initial implementation supports:
-//! - Single file rendering
-//! - HTML output (native Rust pipeline, no Pandoc)
-//! - Basic document structure
-//! - SASS theme compilation (Bootstrap/Bootswatch themes)
-//!
-//! Not yet supported:
-//! - Code execution
-//! - Navigation (navbar, sidebar, footer)
-//! - Multi-file projects
-//! - Non-HTML formats
+//! The actual render logic is in `quarto_core::render_to_file`. This module
+//! handles CLI-specific concerns: argument parsing, console output, and
+//! special error handling.
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
-use tracing::{debug, info, warn};
+use tracing::info;
 
 use quarto_core::{
-    BinaryDependencies, DocumentInfo, Format, FormatIdentifier, HtmlRenderConfig, ProjectContext,
-    QuartoError, RenderContext, RenderOptions, extract_format_metadata, render_qmd_to_html,
+    render_document_to_file, Format, FormatIdentifier, ProjectContext, QuartoError,
+    RenderToFileOptions,
 };
-use quarto_sass::{ThemeConfig, ThemeContext, ThemeSpec};
 use quarto_system_runtime::{NativeRuntime, SystemRuntime};
 
 /// Arguments for the render command
@@ -80,10 +69,8 @@ pub fn execute(args: RenderArgs) -> Result<()> {
     }
 
     // Determine format
-    let format = match &args.to {
-        Some(format_str) => resolve_format(format_str)?,
-        None => Format::html(), // Default to HTML
-    };
+    let format_str = args.to.as_deref().unwrap_or("html");
+    let format = resolve_format(format_str)?;
 
     // Only HTML is supported in MVP
     if !format.identifier.is_native() {
@@ -93,7 +80,7 @@ pub fn execute(args: RenderArgs) -> Result<()> {
         );
     }
 
-    // Discover project context
+    // Discover project context (once for all files)
     let project = ProjectContext::discover(&input_path, &runtime)
         .context("Failed to discover project context")?;
 
@@ -109,12 +96,50 @@ pub fn execute(args: RenderArgs) -> Result<()> {
         }
     }
 
-    // Set up binary dependencies
-    let binaries = BinaryDependencies::discover(&runtime);
+    // Set up render options
+    let options = RenderToFileOptions {
+        output_path: args.output.as_ref().map(PathBuf::from),
+        output_dir: args.output_dir.as_ref().map(PathBuf::from),
+        quiet: args.quiet,
+    };
 
-    // Render each file
+    // Create Arc runtime for the render function
+    let runtime_arc: Arc<dyn quarto_system_runtime::SystemRuntime> = Arc::new(NativeRuntime::new());
+
+    // Render each file in the project
     for doc_info in &project.files {
-        render_document(doc_info, &project, &format, &binaries, &args, &runtime)?;
+        // Use the shared render function
+        let result = match render_document_to_file(
+            &doc_info.input,
+            format_str,
+            &options,
+            Some(&project),
+            runtime_arc.clone(),
+        ) {
+            Ok(result) => result,
+            Err(QuartoError::Parse(parse_error)) => {
+                // Parse errors have rich ariadne formatting with their own "Error:" prefix.
+                // Print directly to avoid anyhow adding a duplicate prefix.
+                eprintln!("{}", parse_error);
+                std::process::exit(1);
+            }
+            Err(e) => return Err(anyhow::anyhow!("{}", e)),
+        };
+
+        // Report diagnostics with full ariadne-style source context
+        if !args.quiet && !result.render_output.diagnostics.is_empty() {
+            for diagnostic in &result.render_output.diagnostics {
+                // Use the source context for rich error rendering with source snippets
+                eprintln!(
+                    "{}",
+                    diagnostic.to_text(Some(&result.render_output.source_context))
+                );
+            }
+        }
+
+        if !args.quiet {
+            info!("Output: {}", result.output_path.display());
+        }
     }
 
     Ok(())
@@ -122,11 +147,6 @@ pub fn execute(args: RenderArgs) -> Result<()> {
 
 /// Resolve format string to Format (without metadata)
 fn resolve_format(format_str: &str) -> Result<Format> {
-    resolve_format_with_metadata(format_str, serde_json::Value::Null)
-}
-
-/// Resolve format string to Format with metadata
-fn resolve_format_with_metadata(format_str: &str, metadata: serde_json::Value) -> Result<Format> {
     let identifier =
         FormatIdentifier::try_from(format_str).map_err(|e| anyhow::anyhow!("{}", e))?;
 
@@ -145,347 +165,8 @@ fn resolve_format_with_metadata(format_str: &str, metadata: serde_json::Value) -
         }
         .to_string(),
         native_pipeline: identifier.is_native(),
-        metadata,
+        metadata: serde_json::Value::Null,
     })
-}
-
-/// Render a single document
-fn render_document(
-    doc_info: &DocumentInfo,
-    project: &ProjectContext,
-    format: &Format,
-    binaries: &BinaryDependencies,
-    args: &RenderArgs,
-    runtime: &dyn SystemRuntime,
-) -> Result<()> {
-    debug!("Rendering: {}", doc_info.input.display());
-
-    // Read input file early (we need it for format metadata extraction)
-    let input_bytes = runtime.file_read(&doc_info.input).map_err(|e| {
-        anyhow::anyhow!(
-            "Failed to read input file {}: {}",
-            doc_info.input.display(),
-            e
-        )
-    })?;
-
-    // Convert to string for metadata extraction (needed for YAML parsing)
-    let input_str =
-        std::str::from_utf8(&input_bytes).context("Input file contains invalid UTF-8")?;
-
-    // Extract format-specific metadata from frontmatter (e.g., toc, toc-depth)
-    let format_metadata = extract_format_metadata(input_str, "html").unwrap_or_else(|e| {
-        warn!("Failed to extract format metadata: {}. Using defaults.", e);
-        serde_json::Value::Null
-    });
-
-    // Create format with the extracted metadata
-    let format_with_metadata = Format {
-        identifier: format.identifier.clone(),
-        output_extension: format.output_extension.clone(),
-        native_pipeline: format.native_pipeline,
-        metadata: format_metadata,
-    };
-
-    // Create render context with the format that has metadata
-    let options = RenderOptions {
-        verbose: !args.quiet,
-        execute: false, // MVP: no code execution
-        use_freeze: false,
-        output_path: args.output.as_ref().map(PathBuf::from),
-    };
-
-    let mut ctx = RenderContext::new(project, doc_info, &format_with_metadata, binaries)
-        .with_options(options);
-
-    // Determine output path (needed before rendering for CSS resource paths)
-    let output_path = determine_output_path(&ctx, args)?;
-
-    // Create output directory if needed
-    let output_dir = output_path
-        .parent()
-        .ok_or_else(|| anyhow::anyhow!("Could not determine output directory"))?;
-    runtime.dir_create(output_dir, true).map_err(|e| {
-        anyhow::anyhow!(
-            "Failed to create output directory {}: {}",
-            output_dir.display(),
-            e
-        )
-    })?;
-
-    // Get the output stem for resource directory naming
-    let output_stem = output_path
-        .file_stem()
-        .and_then(|s| s.to_str())
-        .ok_or_else(|| anyhow::anyhow!("Could not determine output filename stem"))?;
-
-    // Extract theme configuration from frontmatter and write resources
-    let resource_paths = write_themed_resources(
-        input_str,
-        &doc_info.input,
-        output_dir,
-        output_stem,
-        runtime,
-        args.quiet,
-    )?;
-
-    // Use the unified pipeline to render
-    let input_path_str = doc_info.input.to_string_lossy();
-    let config = HtmlRenderConfig {
-        css_paths: &resource_paths.css,
-        template: None,
-    };
-
-    // Create Arc runtime for the async pipeline
-    let runtime_arc: Arc<dyn SystemRuntime> = Arc::new(NativeRuntime::new());
-
-    // Use pollster to run the async pipeline synchronously (expects bytes)
-    let output = match pollster::block_on(render_qmd_to_html(
-        &input_bytes,
-        &input_path_str,
-        &mut ctx,
-        &config,
-        runtime_arc,
-    )) {
-        Ok(output) => output,
-        Err(QuartoError::Parse(parse_error)) => {
-            // Parse errors have rich ariadne formatting with their own "Error:" prefix.
-            // Print directly to avoid anyhow adding a duplicate prefix.
-            eprintln!("{}", parse_error);
-            std::process::exit(1);
-        }
-        Err(e) => return Err(anyhow::anyhow!("{}", e)),
-    };
-
-    // Report diagnostics with full ariadne-style source context
-    if !args.quiet && !output.diagnostics.is_empty() {
-        for diagnostic in &output.diagnostics {
-            // Use the source context for rich error rendering with source snippets
-            eprintln!("{}", diagnostic.to_text(Some(&output.source_context)));
-        }
-    }
-
-    // Write output
-    runtime
-        .file_write(&output_path, output.html.as_bytes())
-        .map_err(|e| {
-            anyhow::anyhow!(
-                "Failed to write output file {}: {}",
-                output_path.display(),
-                e
-            )
-        })?;
-
-    if !args.quiet {
-        info!("Output: {}", output_path.display());
-    }
-
-    Ok(())
-}
-
-/// Determine the output path for a render
-fn determine_output_path(ctx: &RenderContext, args: &RenderArgs) -> Result<PathBuf> {
-    // Priority: --output > --output-dir > format default
-    if let Some(output) = &args.output {
-        return Ok(PathBuf::from(output));
-    }
-
-    let base_output = ctx.output_path();
-
-    if let Some(output_dir) = &args.output_dir {
-        // Use output-dir with the filename from the input
-        let filename = base_output
-            .file_name()
-            .ok_or_else(|| anyhow::anyhow!("Could not determine output filename"))?;
-        return Ok(PathBuf::from(output_dir).join(filename));
-    }
-
-    Ok(base_output)
-}
-
-// ============================================================================
-// Theme Support
-// ============================================================================
-//
-// TODO(ConfigValue): This section manually parses YAML frontmatter to extract
-// theme configuration. When the render pipeline adopts ConfigValue-based
-// configuration (merged project + document config), replace:
-//
-// 1. `extract_theme_config()` - Use `ThemeConfig::from_config_value(&merged_config)`
-//    instead of manual YAML parsing
-//
-// 2. `theme_value_to_config()` - No longer needed; ThemeConfig::from_config_value
-//    handles all the conversion logic
-//
-// 3. The `input_str` parameter to `write_themed_resources()` - Replace with
-//    a reference to the merged ConfigValue from RenderContext
-//
-// See: quarto-sass/src/config.rs for the ConfigValue-based API
-// Plan: claude-notes/plans/2026-01-24-phase7-sass-render-integration.md
-// ============================================================================
-
-/// Write HTML resources with theme support.
-///
-/// Extracts theme configuration from frontmatter and compiles SASS accordingly.
-/// Falls back to default CSS if no theme is specified or if compilation fails.
-///
-/// TODO(ConfigValue): Replace `content` parameter with `config: &ConfigValue`
-/// from merged project/document configuration, then use
-/// `ThemeConfig::from_config_value(config)` instead of `extract_theme_config()`.
-fn write_themed_resources(
-    content: &str,
-    input_path: &Path,
-    output_dir: &Path,
-    stem: &str,
-    runtime: &dyn SystemRuntime,
-    quiet: bool,
-) -> Result<quarto_core::resources::HtmlResourcePaths> {
-    // Try to extract theme config from frontmatter
-    let theme_config = match extract_theme_config(content) {
-        Ok(Some(config)) => {
-            if !quiet {
-                debug!("Theme configuration found: {:?}", config);
-            }
-            config
-        }
-        Ok(None) => {
-            // No theme specified - use default static CSS
-            debug!("No theme specified, using default CSS");
-            return quarto_core::resources::write_html_resources(output_dir, stem, runtime)
-                .context("Failed to write default HTML resources");
-        }
-        Err(e) => {
-            // Failed to parse - warn and fall back to default
-            warn!(
-                "Failed to parse theme configuration: {}. Using default CSS.",
-                e
-            );
-            return quarto_core::resources::write_html_resources(output_dir, stem, runtime)
-                .context("Failed to write default HTML resources");
-        }
-    };
-
-    // Create theme context with the document's directory
-    let document_dir = input_path
-        .parent()
-        .map(|p| p.to_path_buf())
-        .unwrap_or_else(|| PathBuf::from("."));
-    let context = ThemeContext::new(document_dir, runtime);
-
-    // Try to compile themed CSS
-    match quarto_core::resources::write_html_resources_with_sass(
-        output_dir,
-        stem,
-        &theme_config,
-        &context,
-        runtime,
-    ) {
-        Ok(paths) => {
-            if !quiet {
-                info!("Compiled theme CSS successfully");
-            }
-            Ok(paths)
-        }
-        Err(e) => {
-            // Compilation failed - warn and fall back to default
-            warn!("Theme CSS compilation failed: {}. Using default CSS.", e);
-            quarto_core::resources::write_html_resources(output_dir, stem, runtime)
-                .context("Failed to write fallback HTML resources")
-        }
-    }
-}
-
-/// Extract theme configuration from QMD frontmatter.
-///
-/// Parses the YAML frontmatter and extracts the `format.html.theme` value.
-/// Returns `Ok(None)` if no theme is specified.
-///
-/// TODO(ConfigValue): DELETE THIS FUNCTION. Replace all calls with:
-/// ```ignore
-/// let theme_config = ThemeConfig::from_config_value(&merged_config)?;
-/// ```
-/// The merged ConfigValue from RenderContext already has the parsed and
-/// merged configuration from both project (_quarto.yml) and document frontmatter.
-fn extract_theme_config(content: &str) -> Result<Option<ThemeConfig>> {
-    // Find YAML frontmatter
-    let trimmed = content.trim_start();
-    if !trimmed.starts_with("---") {
-        return Ok(None);
-    }
-
-    // Find closing ---
-    let after_first = &trimmed[3..];
-    let end_pos = match after_first.find("\n---") {
-        Some(pos) => pos,
-        None => return Ok(None), // Unclosed frontmatter
-    };
-
-    // Parse YAML
-    let yaml_str = &after_first[..end_pos].trim();
-    let yaml_value: serde_yaml::Value =
-        serde_yaml::from_str(yaml_str).context("Failed to parse YAML frontmatter")?;
-
-    // Navigate to format.html.theme
-    let theme_value = yaml_value
-        .get("format")
-        .and_then(|f| f.get("html"))
-        .and_then(|h| h.get("theme"));
-
-    let theme_value = match theme_value {
-        Some(v) => v,
-        None => return Ok(None), // No theme specified
-    };
-
-    // Convert to ThemeConfig
-    let config = theme_value_to_config(theme_value)?;
-    Ok(Some(config))
-}
-
-/// Convert a serde_yaml::Value theme specification to ThemeConfig.
-///
-/// TODO(ConfigValue): DELETE THIS FUNCTION. This duplicates logic already in
-/// `ThemeConfig::from_config_value()` in quarto-sass/src/config.rs.
-fn theme_value_to_config(value: &serde_yaml::Value) -> Result<ThemeConfig> {
-    match value {
-        serde_yaml::Value::String(s) => {
-            // Single theme name: "darkly"
-            let spec =
-                ThemeSpec::parse(s).map_err(|e| anyhow::anyhow!("Invalid theme '{}': {}", s, e))?;
-            Ok(ThemeConfig::new(vec![spec], true))
-        }
-        serde_yaml::Value::Sequence(arr) => {
-            // Array of themes: ["darkly", "custom.scss"]
-            let mut themes = Vec::new();
-            for v in arr {
-                if let Some(s) = v.as_str() {
-                    let spec = ThemeSpec::parse(s)
-                        .map_err(|e| anyhow::anyhow!("Invalid theme '{}': {}", s, e))?;
-                    themes.push(spec);
-                }
-            }
-            if themes.is_empty() {
-                anyhow::bail!("Empty theme array");
-            }
-            Ok(ThemeConfig::new(themes, true))
-        }
-        serde_yaml::Value::Null => {
-            // Explicit null - use default Bootstrap
-            Ok(ThemeConfig::default_bootstrap())
-        }
-        _ => {
-            anyhow::bail!("Invalid theme value: expected string, array, or null");
-        }
-    }
-}
-
-/// Escape HTML special characters
-#[cfg(test)]
-fn html_escape(s: &str) -> String {
-    s.replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
-        .replace('"', "&quot;")
-        .replace('\'', "&#39;")
 }
 
 #[cfg(test)]
@@ -512,12 +193,5 @@ mod tests {
     fn test_resolve_format_unknown() {
         let result = resolve_format("unknown");
         assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_html_escape() {
-        assert_eq!(html_escape("Hello & World"), "Hello &amp; World");
-        assert_eq!(html_escape("<script>"), "&lt;script&gt;");
-        assert_eq!(html_escape("\"quoted\""), "&quot;quoted&quot;");
     }
 }

--- a/crates/quarto/tests/smoke_all.rs
+++ b/crates/quarto/tests/smoke_all.rs
@@ -4,61 +4,103 @@
  *
  * Integration tests for smoke-all document tests.
  *
- * These tests wrap the quarto-test infrastructure so that smoke-all
- * tests appear in `cargo nextest run` output.
+ * This test harness automatically discovers all .qmd files in the smoke-all/
+ * directory and runs their embedded test specifications via quarto-test.
  */
 
 use std::path::Path;
 
-use quarto_test::{TestResult, run_test_file};
+use quarto_test::{run_test_file, TestResult};
+use walkdir::WalkDir;
 
-/// Helper macro to generate smoke-all test functions.
+/// Run all smoke-all tests by discovering .qmd files in the smoke-all directory.
 ///
-/// Usage:
-/// ```ignore
-/// smoke_test!(test_name, "relative/path/to/file.qmd");
-/// ```
-macro_rules! smoke_test {
-    ($name:ident, $path:literal) => {
-        #[test]
-        fn $name() {
-            let manifest_dir = env!("CARGO_MANIFEST_DIR");
-            let path = Path::new(manifest_dir).join("tests/smoke-all").join($path);
+/// This test walks the smoke-all/ directory tree, finds all .qmd files,
+/// and runs each one through the quarto-test infrastructure. All failures
+/// are collected and reported together.
+#[test]
+fn smoke_all() {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let smoke_all_dir = Path::new(manifest_dir).join("tests/smoke-all");
 
-            let path = path.canonicalize().unwrap_or_else(|e| {
-                panic!("Failed to resolve path {}: {}", path.display(), e);
-            });
+    if !smoke_all_dir.exists() {
+        panic!("smoke-all directory not found: {}", smoke_all_dir.display());
+    }
 
-            match run_test_file(&path) {
-                Ok(TestResult::Pass) => {}
-                Ok(TestResult::Skipped(reason)) => {
-                    eprintln!("Test skipped: {}", reason);
-                }
-                Ok(TestResult::Fail(failures)) => {
-                    let messages: Vec<String> = failures
-                        .iter()
-                        .map(|f| format!("{} [{}]: {}", f.format, f.assertion, f.message))
-                        .collect();
-                    panic!("Test failed:\n{}", messages.join("\n"));
-                }
-                Err(e) => {
-                    panic!("Test error: {}", e);
-                }
+    // Discover all .qmd files
+    let mut test_files: Vec<_> = WalkDir::new(&smoke_all_dir)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().is_some_and(|ext| ext == "qmd"))
+        .map(|e| e.path().to_path_buf())
+        .collect();
+
+    // Sort for deterministic ordering
+    test_files.sort();
+
+    if test_files.is_empty() {
+        panic!(
+            "No .qmd files found in smoke-all directory: {}",
+            smoke_all_dir.display()
+        );
+    }
+
+    eprintln!("Running {} smoke-all tests...\n", test_files.len());
+
+    let mut passed = 0;
+    let mut skipped = 0;
+    let mut failures: Vec<(String, String)> = Vec::new();
+
+    for path in &test_files {
+        // Get relative path for display
+        let rel_path = path
+            .strip_prefix(&smoke_all_dir)
+            .unwrap_or(path)
+            .display()
+            .to_string();
+
+        match run_test_file(path) {
+            Ok(TestResult::Pass) => {
+                eprintln!("  ✓ {}", rel_path);
+                passed += 1;
+            }
+            Ok(TestResult::Skipped(reason)) => {
+                eprintln!("  ⊘ {} (skipped: {})", rel_path, reason);
+                skipped += 1;
+            }
+            Ok(TestResult::Fail(test_failures)) => {
+                let messages: Vec<String> = test_failures
+                    .iter()
+                    .map(|f| format!("    {} [{}]: {}", f.format, f.assertion, f.message))
+                    .collect();
+                let detail = messages.join("\n");
+                eprintln!("  ✗ {}\n{}", rel_path, detail);
+                failures.push((rel_path, detail));
+            }
+            Err(e) => {
+                let detail = format!("    error: {}", e);
+                eprintln!("  ✗ {}\n{}", rel_path, detail);
+                failures.push((rel_path, detail));
             }
         }
-    };
+    }
+
+    eprintln!();
+    eprintln!(
+        "Results: {} passed, {} skipped, {} failed",
+        passed,
+        skipped,
+        failures.len()
+    );
+
+    if !failures.is_empty() {
+        eprintln!("\nFailures:");
+        for (path, detail) in &failures {
+            eprintln!("\n  {}:\n{}", path, detail);
+        }
+        panic!(
+            "{} smoke-all test(s) failed (see output above)",
+            failures.len()
+        );
+    }
 }
-
-// ============================================================================
-// Smoke-all tests
-//
-// Add new tests here as you create smoke-all/*.qmd files.
-// ============================================================================
-
-smoke_test!(basic_render, "basic-render.qmd");
-smoke_test!(callout_note, "callout-note.qmd");
-smoke_test!(clean_render, "clean-render.qmd");
-smoke_test!(code_block, "code-block.qmd");
-smoke_test!(expected_error, "expected-error.qmd");
-smoke_test!(no_extra_files, "no-extra-files.qmd");
-smoke_test!(output_files, "output-files.qmd");

--- a/hub-client/scripts/build-wasm.js
+++ b/hub-client/scripts/build-wasm.js
@@ -7,7 +7,7 @@
  */
 
 import { spawn } from 'child_process';
-import { existsSync } from 'fs';
+import { existsSync, rmSync } from 'fs';
 import { dirname, join, resolve } from 'path';
 import { fileURLToPath } from 'url';
 import { platform } from 'os';
@@ -38,6 +38,13 @@ function findLlvmPath() {
 function buildWasm() {
   return new Promise((resolve, reject) => {
     console.log('Building wasm-quarto-hub-client...');
+
+    // Clean pkg/ directory to avoid wasm-pack EEXIST errors
+    const pkgDir = join(wasmCrate, 'pkg');
+    if (existsSync(pkgDir)) {
+      console.log('Cleaning existing pkg/ directory...');
+      rmSync(pkgDir, { recursive: true });
+    }
 
     // Set up environment
     const env = { ...process.env };


### PR DESCRIPTION
I started with one fix, and then figured why not just get it all running.

I will probably use PRs and see them run in CI before merging most of the time.

We were using unpinned Pandoc on macos via homebrew, but pampa does not claim to be compatible with now Pandoc 3.9, only 3.8.

Standardize on 3.8.3, what Quarto 1.9 is using.