### PR TITLE
Fix temp dir name collision causing flaky test on CI

### DIFF
--- a/crates/quarto-system-runtime/Cargo.toml
+++ b/crates/quarto-system-runtime/Cargo.toml
@@ -17,6 +17,8 @@ serde_json.workspace = true
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # For binary lookup on PATH
 which = "8.0"
+# Safe temp directory creation (random names, no collisions under parallel execution)
+tempfile = "3.24"
 # SASS compilation (pure Rust, ~2x faster than dart-sass)
 grass.workspace = true
 

--- a/crates/quarto-system-runtime/src/native.rs
+++ b/crates/quarto-system-runtime/src/native.rs
@@ -166,18 +166,14 @@ impl SystemRuntime for NativeRuntime {
     }
 
     fn temp_dir(&self, template: &str) -> RuntimeResult<TempDir> {
-        // Create a unique temp directory in the system temp directory
-        let base = std::env::temp_dir();
-        let unique_name = format!(
-            "{}_{}",
-            template,
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_nanos())
-                .unwrap_or(0)
-        );
-        let path = base.join(unique_name);
-        fs::create_dir_all(&path)?;
+        // Use tempfile::Builder for unique directory names that are safe
+        // under parallel execution (e.g. cargo nextest). The previous
+        // timestamp-based naming could collide across concurrent processes.
+        let dir = tempfile::Builder::new()
+            .prefix(&format!("{}_", template))
+            .tempdir()
+            .map_err(RuntimeError::from)?;
+        let path = dir.into_path(); // take ownership of the path, we manage cleanup via TempDir
         Ok(TempDir::new(path))
     }
 

--- a/crates/quarto-system-runtime/src/native.rs
+++ b/crates/quarto-system-runtime/src/native.rs
@@ -173,7 +173,7 @@ impl SystemRuntime for NativeRuntime {
             .prefix(&format!("{}_", template))
             .tempdir()
             .map_err(RuntimeError::from)?;
-        let path = dir.into_path(); // take ownership of the path, we manage cleanup via TempDir
+        let path = dir.keep(); // take ownership of the path, we manage cleanup via our TempDir
         Ok(TempDir::new(path))
     }
 


### PR DESCRIPTION
NativeRuntime::temp_dir used a nanosecond timestamp for uniqueness, which could collide when cargo nextest runs tests as parallel processes. Switch to tempfile::Builder which uses random names.