### PR TITLE
Fix runtimelib deprecation warning

### DIFF
--- a/crates/quarto-core/src/engine/jupyter/daemon.rs
+++ b/crates/quarto-core/src/engine/jupyter/daemon.rs
@@ -153,13 +153,21 @@ impl JupyterDaemon {
         // 6. Create ZeroMQ socket connections
         let session_id = Uuid::new_v4().to_string();
 
-        let shell_socket =
-            runtimelib::create_client_shell_connection(&connection_info, &session_id)
-                .await
-                .map_err(|e| JupyterError::SocketError {
-                    socket_type: "shell".to_string(),
-                    message: e.to_string(),
-                })?;
+        let peer_identity = runtimelib::peer_identity_for_session(&session_id)
+            .map_err(|e| JupyterError::SocketError {
+                socket_type: "shell".to_string(),
+                message: e.to_string(),
+            })?;
+        let shell_socket = runtimelib::create_client_shell_connection_with_identity(
+            &connection_info,
+            &session_id,
+            peer_identity,
+        )
+        .await
+        .map_err(|e| JupyterError::SocketError {
+            socket_type: "shell".to_string(),
+            message: e.to_string(),
+        })?;
 
         let iopub_socket =
             runtimelib::create_client_iopub_connection(&connection_info, "", &session_id)


### PR DESCRIPTION
Fix deprecated `runtimelib::create_client_shell_connection` call by migrating to `create_client_shell_connection_with_identity` with a `PeerIdentity` from `peer_identity_for_session`.

```
error: use of deprecated function                                         
  `runtimelib::create_client_shell_connection`: Use                         
  create_client_shell_connection_with_identity with a PeerIdentity from         
  peer_identity_for_session instead                                         
     --> crates/quarto-core/src/engine/jupyter/daemon.rs:157:25                 
      |                                                                     
  157 |                                                                     
  runtimelib::create_client_shell_connection(&connection_info, &session_id) 
      |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^              
      |                                                                     
      = note: `-D deprecated` implied by `-D warnings`                      
      = help: to override `-D warnings` add `#[allow(deprecated)]`          
                                                                            
     Compiling quarto-hub v0.1.0                                            
  (/home/runner/work/q2/q2/crates/quarto-hub)
```