### PR TITLE
update runtimelib and jupyter-protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4116,9 +4116,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sdd"
-version = "4.7.1"
+version = "4.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d76abfc0d935c801b468ec10db65ae132a593c42fc0c0290c89e5e1a7a010b6"
+checksum = "ad20a1163c2e98ae516f75128a9de6a6283b6fd67a2d30533ac7514a0e67cf46"
 
 [[package]]
 name = "sec1"
@@ -4426,9 +4426,9 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smol_str"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f7a918bd2a9951d18ee6e48f076843e8e73a9a5d22cf05bcd4b7a81bdd04e17"
+checksum = "4aaa7368fcf4852a4c2dd92df0cace6a71f2091ca0a23391ce7f3a31833f1523"
 dependencies = [
  "borsh",
  "serde_core",

--- a/crates/quarto-core/Cargo.toml
+++ b/crates/quarto-core/Cargo.toml
@@ -39,8 +39,8 @@ regex = "1.12"
 quarto-sass.workspace = true
 
 # Jupyter engine dependencies (native only)
-runtimelib = { version = "1.0", features = ["tokio-runtime"] }
-jupyter-protocol = "1.0"
+runtimelib = { version = "1.4", features = ["tokio-runtime"] }
+jupyter-protocol = "1.4"
 tokio = { version = "1", features = ["sync", "time", "rt-multi-thread", "process", "fs", "net", "io-util"] }
 uuid.workspace = true
 base64.workspace = true


### PR DESCRIPTION
This upgrades `runtimelib` from 1.0 to 1.4 and upgrades `jupyter-protocol` from 1.0 to 1.4.

You can view the [full `jupyter-protocol` crate CHANGELOG on GitHub](https://github.com/runtimed/runtimed/blob/main/crates/jupyter-protocol/CHANGELOG.md). The main changes are improved compatibility with kernels that omit or deivate from spec required fields. There's more defensive deserialization for those cases.

On the runtimelib side, `.split()` is now supported on the Jupyter shell channel to make it so reader and writer can be owned separately. I haven't looked at your code deeply enough to see if you can make use of it. Within Zed and Deno it made the code cleaner and allowed us to drop extra tasks and channels.

On the nbformat side, it now supports v3 notebook parsing and upconversion to v4. There are also some fixes to handle both string and array for cell source (noticed with how JetBrains writes out notebooks, still valid nbformat).