### PR TITLE
Fix: preserve share link hash across auth redirect

### DIFF
--- a/hub-client/src/main.tsx
+++ b/hub-client/src/main.tsx
@@ -3,6 +3,13 @@ import { createRoot } from 'react-dom/client'
 import { GoogleOAuthProvider } from '@react-oauth/google'
 import './index.css'
 import App from './App.tsx'
+import { savePreAuthHash, restorePreAuthHash } from './utils/routing'
+
+// Pre-auth hash preservation for the Google OAuth redirect flow.
+// On first visit: save the hash (e.g., #/share/...) before React clears it.
+// On return from auth: restore it so the share route is processed normally.
+// Order matters: restore first (consumes saved value), then save current.
+restorePreAuthHash() || savePreAuthHash();
 
 const GOOGLE_CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID;
 

--- a/hub-client/src/utils/routing.test.ts
+++ b/hub-client/src/utils/routing.test.ts
@@ -1,13 +1,15 @@
 /**
  * Tests for URL routing utilities.
  */
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
 import {
   parseHashRoute,
   buildHashRoute,
   buildShareableUrl,
   routesEqual,
   sameFile,
+  savePreAuthHash,
+  restorePreAuthHash,
   DEFAULT_SYNC_SERVER,
   type Route,
   type ShareRoute,
@@ -481,5 +483,130 @@ describe('sameFile', () => {
         { type: 'file', projectId: 'abc', filePath: 'index.qmd' }
       )
     ).toBe(false);
+  });
+});
+
+// ── Pre-Auth Hash Preservation ──────────────────────────────────
+
+describe('savePreAuthHash / restorePreAuthHash', () => {
+  const originalWindow = globalThis.window;
+  let mockHash: string;
+  let mockStorage: Map<string, string>;
+
+  beforeEach(() => {
+    mockHash = '';
+    mockStorage = new Map();
+
+    // @ts-expect-error - mocking window in node environment
+    globalThis.window = {
+      location: {
+        get hash() { return mockHash; },
+        set hash(v: string) { mockHash = v; },
+      },
+    };
+
+    // @ts-expect-error - mocking sessionStorage in node environment
+    globalThis.sessionStorage = {
+      getItem: (key: string) => mockStorage.get(key) ?? null,
+      setItem: (key: string, value: string) => { mockStorage.set(key, value); },
+      removeItem: (key: string) => { mockStorage.delete(key); },
+      clear: () => { mockStorage.clear(); },
+    };
+  });
+
+  afterEach(() => {
+    // @ts-expect-error - restoring window
+    globalThis.window = originalWindow;
+  });
+
+  it('saves a share link hash and restores it on empty hash', () => {
+    mockHash = '#/share/4XyZabc123?server=wss%3A%2F%2Fsync.automerge.org';
+    savePreAuthHash();
+
+    // Simulate post-auth redirect to "/"
+    mockHash = '';
+    const restored = restorePreAuthHash();
+
+    expect(restored).toBe('#/share/4XyZabc123?server=wss%3A%2F%2Fsync.automerge.org');
+    expect(mockHash).toBe('#/share/4XyZabc123?server=wss%3A%2F%2Fsync.automerge.org');
+  });
+
+  it('restores when current hash is #/', () => {
+    mockHash = '#/share/abc123';
+    savePreAuthHash();
+
+    mockHash = '#/';
+    const restored = restorePreAuthHash();
+
+    expect(restored).toBe('#/share/abc123');
+  });
+
+  it('does not save empty hash', () => {
+    mockHash = '';
+    savePreAuthHash();
+
+    expect(mockStorage.has('quarto-hub-pre-auth-hash')).toBe(false);
+  });
+
+  it('does not save #/ hash', () => {
+    mockHash = '#/';
+    savePreAuthHash();
+
+    expect(mockStorage.has('quarto-hub-pre-auth-hash')).toBe(false);
+  });
+
+  it('does not restore if current hash is already meaningful', () => {
+    mockHash = '#/share/original';
+    savePreAuthHash();
+
+    mockHash = '#/project/some-id';
+    const restored = restorePreAuthHash();
+
+    expect(restored).toBeNull();
+    expect(mockHash).toBe('#/project/some-id');
+  });
+
+  it('clears sessionStorage after restore', () => {
+    mockHash = '#/share/abc123';
+    savePreAuthHash();
+    expect(mockStorage.has('quarto-hub-pre-auth-hash')).toBe(true);
+
+    mockHash = '';
+    restorePreAuthHash();
+
+    expect(mockStorage.has('quarto-hub-pre-auth-hash')).toBe(false);
+  });
+
+  it('clears sessionStorage even when not restored (hash already set)', () => {
+    mockHash = '#/share/abc123';
+    savePreAuthHash();
+
+    mockHash = '#/project/other';
+    restorePreAuthHash();
+
+    expect(mockStorage.has('quarto-hub-pre-auth-hash')).toBe(false);
+  });
+
+  it('returns null when nothing was saved', () => {
+    mockHash = '';
+    const restored = restorePreAuthHash();
+    expect(restored).toBeNull();
+  });
+
+  it('matches main.tsx usage: restore-or-save short-circuit', () => {
+    // Phase 1: first visit with share link — restore returns null, save captures hash
+    mockHash = '#/share/4XyZabc123?server=wss%3A%2F%2Fsync.automerge.org';
+    restorePreAuthHash() || savePreAuthHash();
+
+    expect(mockStorage.get('quarto-hub-pre-auth-hash'))
+      .toBe('#/share/4XyZabc123?server=wss%3A%2F%2Fsync.automerge.org');
+
+    // Phase 2: return from auth redirect — restore succeeds, save is skipped
+    mockHash = '';
+    restorePreAuthHash() || savePreAuthHash();
+
+    expect(mockHash).toBe('#/share/4XyZabc123?server=wss%3A%2F%2Fsync.automerge.org');
+    // sessionStorage should be clean and not re-saved
+    expect(mockStorage.has('quarto-hub-pre-auth-hash')).toBe(false);
   });
 });

--- a/hub-client/src/utils/routing.ts
+++ b/hub-client/src/utils/routing.ts
@@ -344,6 +344,53 @@ export function routesEqual(a: Route, b: Route): boolean {
   }
 }
 
+// ============================================================================
+// Pre-Auth Hash Preservation
+// ============================================================================
+
+/** sessionStorage key used to preserve the hash across auth redirects. */
+const PRE_AUTH_HASH_KEY = 'quarto-hub-pre-auth-hash';
+
+/**
+ * Save the current hash fragment to sessionStorage.
+ *
+ * Call this when the login screen is shown so that the hash (e.g., a
+ * `#/share/...` link) survives the Google OAuth redirect roundtrip.
+ * The server redirects back to `/` after auth, which loses the hash.
+ */
+export function savePreAuthHash(): void {
+  const hash = window.location.hash;
+  if (hash && hash !== '#' && hash !== '#/') {
+    sessionStorage.setItem(PRE_AUTH_HASH_KEY, hash);
+  }
+}
+
+/**
+ * Restore a previously saved hash fragment after auth redirect.
+ *
+ * Call this early at startup (before React mounts). If a hash was saved
+ * and the current URL has no meaningful hash, it is restored.
+ *
+ * @returns The restored hash, or null if nothing was restored.
+ */
+export function restorePreAuthHash(): string | null {
+  const saved = sessionStorage.getItem(PRE_AUTH_HASH_KEY);
+  if (!saved) return null;
+
+  sessionStorage.removeItem(PRE_AUTH_HASH_KEY);
+
+  if (!window.location.hash || window.location.hash === '#' || window.location.hash === '#/') {
+    window.location.hash = saved;
+    return saved;
+  }
+
+  return null;
+}
+
+// ============================================================================
+// Route Comparison
+// ============================================================================
+
 /**
  * Check if two routes point to the same file (ignoring anchor).
  *


### PR DESCRIPTION
Fixes #31.

Share link hash is lost during Google OAuth redirect because the server redirects back to `/` after auth, and hash fragments are never sent to the server.

## Approach

Before React mounts, `main.tsx` runs `restorePreAuthHash() || savePreAuthHash()`:

- **First visit** (share link, not authed): restore finds nothing, save captures hash to `sessionStorage`
- **Return from auth** (hash is empty): restore finds saved hash, sets it back, skips save

## Security

The `indexDocId` acts like a bearer token. Storing it in `sessionStorage` does not widen the attack surface: any XSS that can read `sessionStorage` can already read `window.location.hash` on the initial page load when the token is in the address bar. During the Google auth roundtrip, the token sits in `sessionStorage` but no JS is running on the origin (the browser has navigated away). On return, `restorePreAuthHash()` removes it from `sessionStorage` before React mounts.