### PR TITLE
Synthesize format key in merged metadata

### DIFF
--- a/crates/quarto-core/src/format.rs
+++ b/crates/quarto-core/src/format.rs
@@ -97,11 +97,94 @@ impl TryFrom<&str> for FormatIdentifier {
     }
 }
 
+/// Known base formats that can appear as suffixes in extension format strings.
+const KNOWN_BASE_FORMATS: &[&str] = &[
+    "html",
+    "pdf",
+    "docx",
+    "epub",
+    "typst",
+    "revealjs",
+    "gfm",
+    "commonmark",
+];
+
+/// Result of parsing a format string like "acm-html" or "html".
+#[derive(Debug, Clone, PartialEq)]
+pub struct FormatDescriptor {
+    /// The base format (e.g., "html" from "acm-html", or "html" from "html")
+    pub base_format: String,
+    /// The extension name, if present (e.g., Some("acm") from "acm-html")
+    pub extension_name: Option<String>,
+}
+
+/// Parse a format descriptor string into base format and optional extension.
+///
+/// Splits on the LAST hyphen that produces a known base format suffix.
+/// "acm-html" -> base="html", extension=Some("acm")
+/// "my-journal-html" -> base="html", extension=Some("my-journal")
+/// "q2-slides" -> base="q2-slides", extension=None (no known base suffix)
+/// "html" -> base="html", extension=None
+pub fn parse_format_descriptor(format_str: &str) -> FormatDescriptor {
+    // Try splitting from the right to find a known base format
+    for (i, _) in format_str.rmatch_indices('-') {
+        let suffix = &format_str[i + 1..];
+        if KNOWN_BASE_FORMATS.contains(&suffix) {
+            let prefix = &format_str[..i];
+            if !prefix.is_empty() {
+                return FormatDescriptor {
+                    base_format: suffix.to_string(),
+                    extension_name: Some(prefix.to_string()),
+                };
+            }
+        }
+    }
+    FormatDescriptor {
+        base_format: format_str.to_string(),
+        extension_name: None,
+    }
+}
+
+/// Builtin pseudo-formats that map to a known base format.
+/// Temporary bridge until the extensions system provides this mapping.
+/// Each entry should become an extension when that system lands.
+fn builtin_pseudo_format(name: &str) -> Option<&'static str> {
+    match name {
+        "q2-slides" => Some("html"),
+        _ => None,
+    }
+}
+
+/// Map a FormatIdentifier to its output file extension.
+fn output_extension_for(id: FormatIdentifier) -> String {
+    match id {
+        FormatIdentifier::Html => "html",
+        FormatIdentifier::Pdf => "pdf",
+        FormatIdentifier::Docx => "docx",
+        FormatIdentifier::Epub => "epub",
+        FormatIdentifier::Typst => "pdf",
+        FormatIdentifier::Revealjs => "html",
+        FormatIdentifier::Gfm => "md",
+        FormatIdentifier::CommonMark => "md",
+        FormatIdentifier::Custom(_) => "html",
+    }
+    .to_string()
+}
+
 /// A complete format specification
 #[derive(Debug, Clone)]
 pub struct Format {
     /// Format identifier
     pub identifier: FormatIdentifier,
+
+    /// The original format string (e.g., "q2-slides", "acm-html", "html")
+    pub target_format: String,
+
+    /// Extension name, if this is an extension format (e.g., Some("acm") for "acm-html")
+    pub extension_name: Option<String>,
+
+    /// Human-readable display name (e.g., "HTML", "q2-slides")
+    pub display_name: String,
 
     /// Output file extension (without leading dot)
     pub output_extension: String,
@@ -115,6 +198,9 @@ impl Format {
     pub fn html() -> Self {
         Self {
             identifier: FormatIdentifier::Html,
+            target_format: "html".to_string(),
+            extension_name: None,
+            display_name: "HTML".to_string(),
             output_extension: "html".to_string(),
             native_pipeline: true,
         }
@@ -124,6 +210,9 @@ impl Format {
     pub fn pdf() -> Self {
         Self {
             identifier: FormatIdentifier::Pdf,
+            target_format: "pdf".to_string(),
+            extension_name: None,
+            display_name: "PDF".to_string(),
             output_extension: "pdf".to_string(),
             native_pipeline: false,
         }
@@ -133,9 +222,66 @@ impl Format {
     pub fn docx() -> Self {
         Self {
             identifier: FormatIdentifier::Docx,
+            target_format: "docx".to_string(),
+            extension_name: None,
+            display_name: "DOCX".to_string(),
             output_extension: "docx".to_string(),
             native_pipeline: false,
         }
+    }
+
+    /// Parse a format string into a Format.
+    ///
+    /// Accepts:
+    /// - Known base formats: "html", "pdf", "docx", etc.
+    /// - Extension-style formats: "acm-html", "my-journal-pdf"
+    /// - Builtin pseudo-formats: "q2-slides" (temporary, until extensions)
+    ///
+    /// Returns Err for unrecognized format strings.
+    pub fn from_format_string(format_str: &str) -> Result<Self, String> {
+        // 1. Try as a known base format directly
+        if let Ok(identifier) = FormatIdentifier::try_from(format_str) {
+            return Ok(Self {
+                identifier,
+                target_format: format_str.to_string(),
+                extension_name: None,
+                display_name: identifier.as_str().to_uppercase(),
+                output_extension: output_extension_for(identifier),
+                native_pipeline: identifier.is_native(),
+            });
+        }
+
+        // 2. Try as extension-style: "acm-html" -> base "html", extension "acm"
+        // Note: For pseudo-formats like "q2-slides", parse_format_descriptor returns
+        // base_format="q2-slides" (no known suffix), so the try_from below fails
+        // just like step 1. This is intentional — step 3 handles pseudo-formats.
+        let desc = parse_format_descriptor(format_str);
+        if let Ok(identifier) = FormatIdentifier::try_from(desc.base_format.as_str()) {
+            return Ok(Self {
+                identifier,
+                target_format: format_str.to_string(),
+                extension_name: desc.extension_name,
+                display_name: format_str.to_string(),
+                output_extension: output_extension_for(identifier),
+                native_pipeline: identifier.is_native(),
+            });
+        }
+
+        // 3. Try as a builtin pseudo-format: "q2-slides" -> base "html"
+        if let Some(base) = builtin_pseudo_format(format_str) {
+            let identifier = FormatIdentifier::try_from(base).unwrap();
+            return Ok(Self {
+                identifier,
+                target_format: format_str.to_string(),
+                extension_name: None,
+                display_name: format_str.to_string(),
+                output_extension: output_extension_for(identifier),
+                native_pipeline: identifier.is_native(),
+            });
+        }
+
+        // 4. Unknown format
+        Err(format!("Unknown format: {}", format_str))
     }
 
     /// Check if this format is HTML-based
@@ -403,6 +549,9 @@ mod tests {
         let format = Format::html();
 
         assert_eq!(format.identifier, FormatIdentifier::Html);
+        assert_eq!(format.target_format, "html");
+        assert_eq!(format.extension_name, None);
+        assert_eq!(format.display_name, "HTML");
         assert_eq!(format.output_extension, "html");
         assert!(format.native_pipeline);
     }
@@ -412,6 +561,9 @@ mod tests {
         let format = Format::pdf();
 
         assert_eq!(format.identifier, FormatIdentifier::Pdf);
+        assert_eq!(format.target_format, "pdf");
+        assert_eq!(format.extension_name, None);
+        assert_eq!(format.display_name, "PDF");
         assert_eq!(format.output_extension, "pdf");
         assert!(!format.native_pipeline);
     }
@@ -421,6 +573,9 @@ mod tests {
         let format = Format::docx();
 
         assert_eq!(format.identifier, FormatIdentifier::Docx);
+        assert_eq!(format.target_format, "docx");
+        assert_eq!(format.extension_name, None);
+        assert_eq!(format.display_name, "DOCX");
         assert_eq!(format.output_extension, "docx");
         assert!(!format.native_pipeline);
     }
@@ -476,6 +631,9 @@ mod tests {
         let format = Format::default();
 
         assert_eq!(format.identifier, FormatIdentifier::Html);
+        assert_eq!(format.target_format, "html");
+        assert_eq!(format.extension_name, None);
+        assert_eq!(format.display_name, "HTML");
         assert_eq!(format.output_extension, "html");
         assert!(format.native_pipeline);
     }
@@ -486,8 +644,153 @@ mod tests {
         let cloned = original.clone();
 
         assert_eq!(original.identifier, cloned.identifier);
+        assert_eq!(original.target_format, cloned.target_format);
+        assert_eq!(original.extension_name, cloned.extension_name);
+        assert_eq!(original.display_name, cloned.display_name);
         assert_eq!(original.output_extension, cloned.output_extension);
         assert_eq!(original.native_pipeline, cloned.native_pipeline);
+    }
+
+    // === parse_format_descriptor tests ===
+
+    #[test]
+    fn test_parse_format_descriptor_plain() {
+        let d = parse_format_descriptor("html");
+        assert_eq!(d.base_format, "html");
+        assert_eq!(d.extension_name, None);
+    }
+
+    #[test]
+    fn test_parse_format_descriptor_extension() {
+        let d = parse_format_descriptor("acm-html");
+        assert_eq!(d.base_format, "html");
+        assert_eq!(d.extension_name, Some("acm".to_string()));
+    }
+
+    #[test]
+    fn test_parse_format_descriptor_multi_hyphen() {
+        let d = parse_format_descriptor("my-journal-pdf");
+        assert_eq!(d.base_format, "pdf");
+        assert_eq!(d.extension_name, Some("my-journal".to_string()));
+    }
+
+    #[test]
+    fn test_parse_format_descriptor_unknown_suffix() {
+        let d = parse_format_descriptor("q2-slides");
+        assert_eq!(d.base_format, "q2-slides");
+        assert_eq!(d.extension_name, None);
+    }
+
+    #[test]
+    fn test_parse_format_descriptor_empty() {
+        let d = parse_format_descriptor("");
+        assert_eq!(d.base_format, "");
+        assert_eq!(d.extension_name, None);
+    }
+
+    #[test]
+    fn test_parse_format_descriptor_hyphen_only() {
+        let d = parse_format_descriptor("-");
+        assert_eq!(d.extension_name, None);
+    }
+
+    #[test]
+    fn test_parse_format_descriptor_trailing_hyphen() {
+        let d = parse_format_descriptor("html-");
+        assert_eq!(d.base_format, "html-");
+        assert_eq!(d.extension_name, None);
+    }
+
+    #[test]
+    fn test_parse_format_descriptor_leading_hyphen() {
+        let d = parse_format_descriptor("-html");
+        assert_eq!(d.base_format, "-html");
+        assert_eq!(d.extension_name, None);
+    }
+
+    // === from_format_string tests ===
+
+    #[test]
+    fn test_from_format_string_known_base() {
+        let f = Format::from_format_string("html").unwrap();
+        assert_eq!(f.identifier, FormatIdentifier::Html);
+        assert_eq!(f.target_format, "html");
+        assert_eq!(f.extension_name, None);
+        assert_eq!(f.display_name, "HTML");
+        assert_eq!(f.output_extension, "html");
+    }
+
+    #[test]
+    fn test_from_format_string_extension() {
+        let f = Format::from_format_string("acm-pdf").unwrap();
+        assert_eq!(f.identifier, FormatIdentifier::Pdf);
+        assert_eq!(f.target_format, "acm-pdf");
+        assert_eq!(f.extension_name, Some("acm".to_string()));
+        assert_eq!(f.output_extension, "pdf");
+    }
+
+    #[test]
+    fn test_from_format_string_pseudo_format() {
+        let f = Format::from_format_string("q2-slides").unwrap();
+        assert_eq!(f.identifier, FormatIdentifier::Html);
+        assert_eq!(f.target_format, "q2-slides");
+        assert_eq!(f.extension_name, None);
+        assert_eq!(f.output_extension, "html");
+        assert!(f.native_pipeline);
+    }
+
+    #[test]
+    fn test_from_format_string_typst_extension() {
+        let f = Format::from_format_string("typst").unwrap();
+        assert_eq!(f.identifier, FormatIdentifier::Typst);
+        assert_eq!(f.output_extension, "pdf");
+    }
+
+    #[test]
+    fn test_from_format_string_revealjs() {
+        let f = Format::from_format_string("revealjs").unwrap();
+        assert_eq!(f.output_extension, "html");
+    }
+
+    #[test]
+    fn test_from_format_string_gfm() {
+        let f = Format::from_format_string("gfm").unwrap();
+        assert_eq!(f.output_extension, "md");
+    }
+
+    #[test]
+    fn test_from_format_string_unknown_errors() {
+        assert!(Format::from_format_string("unknown").is_err());
+        assert!(Format::from_format_string("htlm").is_err());
+    }
+
+    #[test]
+    fn test_from_format_string_error_message() {
+        let err = Format::from_format_string("htlm").unwrap_err();
+        assert!(
+            err.contains("htlm"),
+            "error should include the bad format name"
+        );
+    }
+
+    #[test]
+    fn test_from_format_string_empty_string() {
+        assert!(Format::from_format_string("").is_err());
+    }
+
+    #[test]
+    fn test_from_format_string_hyphen_only() {
+        assert!(Format::from_format_string("-").is_err());
+    }
+
+    #[test]
+    fn test_from_format_string_trailing_hyphen() {
+        assert!(Format::from_format_string("html-").is_err());
+    }
+
+    #[test]
+    fn test_from_format_string_leading_hyphen() {
+        assert!(Format::from_format_string("-html").is_err());
     }
 
     // === is_minimal_html tests ===

--- a/crates/quarto-core/src/render_to_file.rs
+++ b/crates/quarto-core/src/render_to_file.rs
@@ -198,7 +198,7 @@ pub fn render_document_to_file(
 
     // Set up render context
     let doc_info = DocumentInfo::from_path(input_path);
-    let render_format = format_from_name(format);
+    let render_format = format_from_name(format)?;
     let binaries = BinaryDependencies::new();
     let mut ctx = RenderContext::new(project, &doc_info, &render_format, &binaries);
 
@@ -307,13 +307,8 @@ fn determine_output_paths(
 }
 
 /// Convert a format name to a Format instance.
-fn format_from_name(name: &str) -> Format {
-    match name {
-        "html" => Format::html(),
-        "pdf" => Format::pdf(),
-        "docx" => Format::docx(),
-        _ => Format::html(),
-    }
+fn format_from_name(name: &str) -> Result<Format> {
+    Format::from_format_string(name).map_err(|e| QuartoError::other(e).into())
 }
 
 #[cfg(test)]

--- a/crates/quarto-core/src/stage/stages/metadata_merge.rs
+++ b/crates/quarto-core/src/stage/stages/metadata_merge.rs
@@ -215,6 +215,20 @@ impl PipelineStage for MetadataMergeStage {
         // Note: If materialization fails (shouldn't happen with well-formed configs),
         // we silently continue with the original document metadata.
 
+        // Inject resolved format name into merged metadata.
+        // The Format struct doesn't cross the WASM serialization boundary,
+        // so we communicate the format name via the metadata map.
+        // In quarto-cli this is done via Format.identifier.kTargetFormat
+        // and QUARTO_FILTER_PARAMS; we use the metadata map instead.
+        if let ConfigValueKind::Map(ref mut entries) = doc.ast.meta.value {
+            entries.retain(|e| e.key != "format");
+            entries.push(ConfigMapEntry {
+                key: "format".to_string(),
+                key_source: SourceInfo::default(),
+                value: ConfigValue::new_string(&ctx.format.target_format, SourceInfo::default()),
+            });
+        }
+
         Ok(PipelineData::DocumentAst(doc))
     }
 }
@@ -531,8 +545,12 @@ mod tests {
 
         // toc should be inherited from project's format.html settings
         assert_eq!(result.ast.meta.get("toc").unwrap().as_bool(), Some(true));
-        // format key should be removed (flattened)
-        assert!(result.ast.meta.get("format").is_none());
+        // format name should be injected after merge
+        assert_eq!(
+            result.ast.meta.get("format").unwrap().as_str(),
+            Some("html"),
+            "format name should be injected after merge"
+        );
     }
 
     #[tokio::test]
@@ -636,8 +654,12 @@ mod tests {
         );
         // documentclass from pdf format should NOT be present
         assert!(result.ast.meta.get("documentclass").is_none());
-        // format key should be removed
-        assert!(result.ast.meta.get("format").is_none());
+        // format name should be injected after merge
+        assert_eq!(
+            result.ast.meta.get("format").unwrap().as_str(),
+            Some("html"),
+            "format name should be injected after merge"
+        );
     }
 
     #[tokio::test]
@@ -1005,8 +1027,255 @@ mod tests {
             result.ast.meta.get("source-location").unwrap().as_str(),
             Some("full")
         );
-        // format key should be removed (flattened)
-        assert!(result.ast.meta.get("format").is_none());
+        // format name should be injected after merge
+        assert_eq!(
+            result.ast.meta.get("format").unwrap().as_str(),
+            Some("html"),
+            "format name should be injected after merge"
+        );
+    }
+
+    // ============================================================================
+    // Format name preservation tests
+    // ============================================================================
+
+    #[tokio::test]
+    async fn test_format_name_preserved_simple_string() {
+        // Document has format: q2-slides (simple string)
+        // After merge, format key should be preserved so hub-client can detect it
+        let runtime = Arc::new(MockRuntime);
+
+        let project = ProjectContext {
+            dir: PathBuf::from("/project"),
+            config: ProjectConfig::default(),
+            is_single_file: true,
+            files: vec![],
+            output_dir: PathBuf::from("/project"),
+        };
+        let doc = DocumentInfo::from_path("/project/test.qmd");
+        let format = Format::from_format_string("q2-slides").unwrap();
+
+        let mut ctx = StageContext::new(runtime, format, project, doc).unwrap();
+        let stage = MetadataMergeStage::new();
+
+        // Document has format: q2-slides
+        let doc_metadata = config_map(vec![
+            ("title", config_str("My Slides")),
+            ("format", config_str("q2-slides")),
+        ]);
+        let doc_ast = DocumentAst {
+            path: PathBuf::from("/project/test.qmd"),
+            ast: Pandoc {
+                meta: doc_metadata,
+                ..Default::default()
+            },
+            ast_context: pampa::pandoc::ASTContext::default(),
+            source_context: SourceContext::new(),
+            warnings: vec![],
+        };
+
+        let input = PipelineData::DocumentAst(doc_ast);
+        let output = stage.run(input, &mut ctx).await.unwrap();
+        let result = output.into_document_ast().unwrap();
+
+        // title should be preserved
+        assert_eq!(
+            result.ast.meta.get("title").unwrap().as_str(),
+            Some("My Slides")
+        );
+        // format name should be preserved as a string
+        assert!(
+            result.ast.meta.get("format").is_some(),
+            "format key must be preserved after metadata merge"
+        );
+        assert_eq!(
+            result.ast.meta.get("format").unwrap().as_str(),
+            Some("q2-slides"),
+            "format value must be 'q2-slides'"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_format_name_preserved_map_format() {
+        // Document has format: { html: { toc: true } }
+        // After merge, format key should contain "html"
+        let runtime = Arc::new(MockRuntime);
+
+        let project = ProjectContext {
+            dir: PathBuf::from("/project"),
+            config: ProjectConfig::default(),
+            is_single_file: true,
+            files: vec![],
+            output_dir: PathBuf::from("/project"),
+        };
+        let doc = DocumentInfo::from_path("/project/test.qmd");
+        let format = Format::html();
+
+        let mut ctx = StageContext::new(runtime, format, project, doc).unwrap();
+        let stage = MetadataMergeStage::new();
+
+        // Document has format: { html: { toc: true } }
+        let doc_metadata = config_map(vec![(
+            "format",
+            config_map(vec![("html", config_map(vec![("toc", config_bool(true))]))]),
+        )]);
+        let doc_ast = DocumentAst {
+            path: PathBuf::from("/project/test.qmd"),
+            ast: Pandoc {
+                meta: doc_metadata,
+                ..Default::default()
+            },
+            ast_context: pampa::pandoc::ASTContext::default(),
+            source_context: SourceContext::new(),
+            warnings: vec![],
+        };
+
+        let input = PipelineData::DocumentAst(doc_ast);
+        let output = stage.run(input, &mut ctx).await.unwrap();
+        let result = output.into_document_ast().unwrap();
+
+        // toc should be flattened
+        assert_eq!(result.ast.meta.get("toc").unwrap().as_bool(), Some(true));
+        // format name should be preserved
+        assert!(
+            result.ast.meta.get("format").is_some(),
+            "format key must be preserved after metadata merge"
+        );
+        assert_eq!(
+            result.ast.meta.get("format").unwrap().as_str(),
+            Some("html"),
+            "format value must be 'html' (the matched format key)"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_format_name_injected_when_no_format_key() {
+        // Document has no format key at all — should still get format: "html" injected
+        let runtime = Arc::new(MockRuntime);
+
+        let project = ProjectContext {
+            dir: PathBuf::from("/project"),
+            config: ProjectConfig::default(),
+            is_single_file: true,
+            files: vec![],
+            output_dir: PathBuf::from("/project"),
+        };
+        let doc = DocumentInfo::from_path("/project/test.qmd");
+        let format = Format::html();
+
+        let mut ctx = StageContext::new(runtime, format, project, doc).unwrap();
+        let stage = MetadataMergeStage::new();
+
+        let doc_metadata = config_map(vec![("title", config_str("No Format"))]);
+        let doc_ast = DocumentAst {
+            path: PathBuf::from("/project/test.qmd"),
+            ast: Pandoc {
+                meta: doc_metadata,
+                ..Default::default()
+            },
+            ast_context: pampa::pandoc::ASTContext::default(),
+            source_context: SourceContext::new(),
+            warnings: vec![],
+        };
+
+        let input = PipelineData::DocumentAst(doc_ast);
+        let output = stage.run(input, &mut ctx).await.unwrap();
+        let result = output.into_document_ast().unwrap();
+
+        assert_eq!(
+            result.ast.meta.get("format").unwrap().as_str(),
+            Some("html"),
+            "format name should be injected even when document has no format key"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_format_name_preserved_extension_format() {
+        // format: acm-html with Format::from_format_string("acm-html")
+        let runtime = Arc::new(MockRuntime);
+
+        let project = ProjectContext {
+            dir: PathBuf::from("/project"),
+            config: ProjectConfig::default(),
+            is_single_file: true,
+            files: vec![],
+            output_dir: PathBuf::from("/project"),
+        };
+        let doc = DocumentInfo::from_path("/project/test.qmd");
+        let format = Format::from_format_string("acm-html").unwrap();
+
+        let mut ctx = StageContext::new(runtime, format, project, doc).unwrap();
+        let stage = MetadataMergeStage::new();
+
+        let doc_metadata = config_map(vec![
+            ("title", config_str("ACM Paper")),
+            ("format", config_str("acm-html")),
+        ]);
+        let doc_ast = DocumentAst {
+            path: PathBuf::from("/project/test.qmd"),
+            ast: Pandoc {
+                meta: doc_metadata,
+                ..Default::default()
+            },
+            ast_context: pampa::pandoc::ASTContext::default(),
+            source_context: SourceContext::new(),
+            warnings: vec![],
+        };
+
+        let input = PipelineData::DocumentAst(doc_ast);
+        let output = stage.run(input, &mut ctx).await.unwrap();
+        let result = output.into_document_ast().unwrap();
+
+        assert_eq!(
+            result.ast.meta.get("format").unwrap().as_str(),
+            Some("acm-html"),
+            "format name should be the target_format from StageContext"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_format_injection_uses_context_not_document() {
+        // Document has format: unknown-garbage but StageContext has Format::html()
+        // The injected format should be "html" (from ctx), not "unknown-garbage"
+        let runtime = Arc::new(MockRuntime);
+
+        let project = ProjectContext {
+            dir: PathBuf::from("/project"),
+            config: ProjectConfig::default(),
+            is_single_file: true,
+            files: vec![],
+            output_dir: PathBuf::from("/project"),
+        };
+        let doc = DocumentInfo::from_path("/project/test.qmd");
+        let format = Format::html();
+
+        let mut ctx = StageContext::new(runtime, format, project, doc).unwrap();
+        let stage = MetadataMergeStage::new();
+
+        let doc_metadata = config_map(vec![
+            ("title", config_str("Bad Format")),
+            ("format", config_str("unknown-garbage")),
+        ]);
+        let doc_ast = DocumentAst {
+            path: PathBuf::from("/project/test.qmd"),
+            ast: Pandoc {
+                meta: doc_metadata,
+                ..Default::default()
+            },
+            ast_context: pampa::pandoc::ASTContext::default(),
+            source_context: SourceContext::new(),
+            warnings: vec![],
+        };
+
+        let input = PipelineData::DocumentAst(doc_ast);
+        let output = stage.run(input, &mut ctx).await.unwrap();
+        let result = output.into_document_ast().unwrap();
+
+        assert_eq!(
+            result.ast.meta.get("format").unwrap().as_str(),
+            Some("html"),
+            "injected format should come from ctx.format.target_format, not document"
+        );
     }
 
     #[tokio::test]
@@ -1146,10 +1415,11 @@ mod tests {
             Some(true),
             "format.html.toc should be flattened to top-level toc for single-file renders"
         );
-        // format key should be removed
-        assert!(
-            result.ast.meta.get("format").is_none(),
-            "format key should be removed after flattening"
+        // format name should be injected after merge
+        assert_eq!(
+            result.ast.meta.get("format").unwrap().as_str(),
+            Some("html"),
+            "format name should be injected after merge"
         );
     }
 }

--- a/crates/quarto/src/commands/render.rs
+++ b/crates/quarto/src/commands/render.rs
@@ -21,8 +21,7 @@ use anyhow::{Context, Result};
 use tracing::info;
 
 use quarto_core::{
-    Format, FormatIdentifier, ProjectContext, QuartoError, RenderToFileOptions,
-    render_document_to_file,
+    Format, ProjectContext, QuartoError, RenderToFileOptions, render_document_to_file,
 };
 use quarto_system_runtime::{NativeRuntime, SystemRuntime};
 
@@ -153,30 +152,13 @@ pub fn execute(args: RenderArgs) -> Result<()> {
 
 /// Resolve format string to Format (without metadata)
 fn resolve_format(format_str: &str) -> Result<Format> {
-    let identifier =
-        FormatIdentifier::try_from(format_str).map_err(|e| anyhow::anyhow!("{}", e))?;
-
-    Ok(Format {
-        identifier,
-        output_extension: match identifier {
-            FormatIdentifier::Html => "html",
-            FormatIdentifier::Pdf => "pdf",
-            FormatIdentifier::Docx => "docx",
-            FormatIdentifier::Epub => "epub",
-            FormatIdentifier::Typst => "pdf",
-            FormatIdentifier::Revealjs => "html",
-            FormatIdentifier::Gfm => "md",
-            FormatIdentifier::CommonMark => "md",
-            FormatIdentifier::Custom(_) => "html",
-        }
-        .to_string(),
-        native_pipeline: identifier.is_native(),
-    })
+    Format::from_format_string(format_str).map_err(|e| anyhow::anyhow!("{}", e))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use quarto_core::FormatIdentifier;
 
     #[test]
     fn test_resolve_format_html() {

--- a/crates/wasm-quarto-hub-client/src/lib.rs
+++ b/crates/wasm-quarto-hub-client/src/lib.rs
@@ -494,6 +494,42 @@ fn create_wasm_project_context(path: &Path) -> ProjectContext {
     }
 }
 
+/// Detect the format string from QMD content's YAML frontmatter.
+/// Returns the format name (e.g., "q2-slides", "html", "acm-html")
+/// or "html" as default when no format key is present.
+fn detect_format_from_content(content: &str) -> String {
+    let trimmed = content.trim_start();
+    if !trimmed.starts_with("---") {
+        return "html".to_string();
+    }
+    let after_first = &trimmed[3..];
+    let end = after_first.find("\n---");
+    let yaml_str = match end {
+        Some(pos) => &after_first[..pos],
+        None => return "html".to_string(),
+    };
+    let docs = match yaml_rust2::YamlLoader::load_from_str(yaml_str) {
+        Ok(docs) => docs,
+        Err(_) => return "html".to_string(),
+    };
+    let doc = match docs.first() {
+        Some(doc) => doc,
+        None => return "html".to_string(),
+    };
+    match doc["format"] {
+        yaml_rust2::Yaml::String(ref s) => s.clone(),
+        yaml_rust2::Yaml::Hash(ref map) => {
+            // yaml-rust2 preserves insertion order (uses LinkedHashMap)
+            map.keys()
+                .next()
+                .and_then(|k| k.as_str())
+                .unwrap_or("html")
+                .to_string()
+        }
+        _ => "html".to_string(),
+    }
+}
+
 /// Parse QMD content to Pandoc AST JSON using the unified pipeline.
 ///
 /// This function uses the same pipeline infrastructure as `render_qmd_to_html`,
@@ -522,7 +558,21 @@ pub async fn parse_qmd_to_ast(content: &str) -> String {
     let doc = DocumentInfo::from_path(path);
     let binaries = BinaryDependencies::new();
 
-    let format = Format::html();
+    let format_str = detect_format_from_content(content);
+    let format = match Format::from_format_string(&format_str) {
+        Ok(f) => f,
+        Err(e) => {
+            return serde_json::to_string(&AstResponse {
+                success: false,
+                ast: None,
+                qmd: None,
+                error: Some(e),
+                diagnostics: None,
+                warnings: None,
+            })
+            .unwrap_or_default();
+        }
+    };
 
     let options = RenderOptions {
         verbose: false,
@@ -679,7 +729,21 @@ pub async fn render_qmd(path: &str) -> String {
     let doc = DocumentInfo::from_path(path);
     let binaries = BinaryDependencies::new();
 
-    let format = Format::html();
+    let content_str = std::str::from_utf8(&content).unwrap_or("");
+    let format_str = detect_format_from_content(content_str);
+    let format = match Format::from_format_string(&format_str) {
+        Ok(f) => f,
+        Err(e) => {
+            return serde_json::to_string(&RenderResponse {
+                success: false,
+                error: Some(e),
+                html: None,
+                diagnostics: None,
+                warnings: None,
+            })
+            .unwrap();
+        }
+    };
 
     let options = RenderOptions {
         verbose: false,
@@ -764,7 +828,20 @@ pub async fn render_qmd_content(content: &str, _template_bundle: &str) -> String
     let doc = DocumentInfo::from_path(path);
     let binaries = BinaryDependencies::new();
 
-    let format = Format::html();
+    let format_str = detect_format_from_content(content);
+    let format = match Format::from_format_string(&format_str) {
+        Ok(f) => f,
+        Err(e) => {
+            return serde_json::to_string(&RenderResponse {
+                success: false,
+                error: Some(e),
+                html: None,
+                diagnostics: None,
+                warnings: None,
+            })
+            .unwrap_or_default();
+        }
+    };
 
     let options = RenderOptions {
         verbose: false,

--- a/hub-client/src/components/PreviewRouter.tsx
+++ b/hub-client/src/components/PreviewRouter.tsx
@@ -31,7 +31,13 @@ interface PreviewRouterProps {
 function hasQ2SlidesFormat(astJson: string): boolean {
   try {
     const ast = JSON.parse(astJson);
-    return 'q2-slides' === ast?.meta?.format?.c?.[0]?.c;
+    const fmt = ast?.meta?.format;
+    if (!fmt) return false;
+    // MetaString: { t: "MetaString", c: "q2-slides" }
+    if (fmt.t === 'MetaString') return fmt.c === 'q2-slides';
+    // MetaInlines: { t: "MetaInlines", c: [{ t: "Str", c: "q2-slides" }] }
+    if (fmt.t === 'MetaInlines') return fmt.c?.[0]?.c === 'q2-slides';
+    return false;
   } catch (err) {
     console.error('[PreviewRouter] Failed to parse AST:', err);
     return false;

--- a/hub-client/src/services/formatDetection.wasm.test.ts
+++ b/hub-client/src/services/formatDetection.wasm.test.ts
@@ -1,0 +1,181 @@
+/**
+ * WASM End-to-End Tests for format detection
+ *
+ * These tests verify that format detection from YAML frontmatter works
+ * correctly through the WASM entry points, and that the format name
+ * is injected into the merged metadata.
+ *
+ * Run with: npm run test:wasm
+ */
+
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import { readFile } from 'fs/promises';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+interface WasmModule {
+  default: (input?: BufferSource) => Promise<void>;
+  vfs_add_file: (path: string, content: string) => string;
+  vfs_clear: () => string;
+  vfs_set_runtime_metadata: (yaml: string) => string;
+  parse_qmd_to_ast: (content: string) => Promise<string>;
+  render_qmd: (path: string) => Promise<string>;
+  render_qmd_content: (content: string, template: string) => Promise<string>;
+}
+
+interface AstResponse {
+  success: boolean;
+  ast?: string;
+  qmd?: string;
+  error?: string;
+  diagnostics?: unknown[];
+  warnings?: unknown[];
+}
+
+interface RenderResponse {
+  success: boolean;
+  html?: string;
+  error?: string;
+  diagnostics?: unknown[];
+  warnings?: unknown[];
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function getMetaFormat(ast: any): string | undefined {
+  const fmt = ast?.meta?.format;
+  if (!fmt) return undefined;
+  // MetaString: { t: "MetaString", c: "html" }
+  if (fmt.t === 'MetaString') return fmt.c;
+  // MetaInlines: { t: "MetaInlines", c: [{ t: "Str", c: "html" }] }
+  if (fmt.t === 'MetaInlines') return fmt.c?.[0]?.c;
+  return undefined;
+}
+
+let wasm: WasmModule;
+
+beforeAll(async () => {
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const wasmDir = join(__dirname, '../../wasm-quarto-hub-client');
+  const wasmPath = join(wasmDir, 'wasm_quarto_hub_client_bg.wasm');
+  const wasmBytes = await readFile(wasmPath);
+
+  wasm = (await import('wasm-quarto-hub-client')) as unknown as WasmModule;
+  await wasm.default(wasmBytes);
+});
+
+beforeEach(() => {
+  wasm.vfs_clear();
+  wasm.vfs_set_runtime_metadata('');
+});
+
+describe('format detection via parse_qmd_to_ast', () => {
+  it('detects format: q2-slides', async () => {
+    const content = '---\nformat: q2-slides\ntitle: My Slides\n---\n\n# Slide 1\n';
+    const response: AstResponse = JSON.parse(await wasm.parse_qmd_to_ast(content));
+    expect(response.success).toBe(true);
+    const ast = JSON.parse(response.ast!);
+    expect(getMetaFormat(ast)).toBe('q2-slides');
+  });
+
+  it('detects format: html', async () => {
+    const content = '---\nformat: html\ntitle: Doc\n---\n\n# Hello\n';
+    const response: AstResponse = JSON.parse(await wasm.parse_qmd_to_ast(content));
+    expect(response.success).toBe(true);
+    const ast = JSON.parse(response.ast!);
+    expect(getMetaFormat(ast)).toBe('html');
+  });
+
+  it('defaults to html when no format key', async () => {
+    const content = '---\ntitle: No Format\n---\n\n# Hello\n';
+    const response: AstResponse = JSON.parse(await wasm.parse_qmd_to_ast(content));
+    expect(response.success).toBe(true);
+    const ast = JSON.parse(response.ast!);
+    expect(getMetaFormat(ast)).toBe('html');
+  });
+
+  it('detects format from map: format: { html: { toc: true } }', async () => {
+    const content = '---\nformat:\n  html:\n    toc: true\n---\n\n# Hello\n';
+    const response: AstResponse = JSON.parse(await wasm.parse_qmd_to_ast(content));
+    expect(response.success).toBe(true);
+    const ast = JSON.parse(response.ast!);
+    expect(getMetaFormat(ast)).toBe('html');
+  });
+
+  it('defaults to html with no frontmatter', async () => {
+    const content = '# Just Markdown\n\nNo frontmatter at all.\n';
+    const response: AstResponse = JSON.parse(await wasm.parse_qmd_to_ast(content));
+    expect(response.success).toBe(true);
+    const ast = JSON.parse(response.ast!);
+    expect(getMetaFormat(ast)).toBe('html');
+  });
+
+  it('defaults to html with malformed YAML', async () => {
+    const content = '---\n{bad yaml\n---\n\n# Hello\n';
+    const response: AstResponse = JSON.parse(await wasm.parse_qmd_to_ast(content));
+    // Should fall back to html, not fail on format detection
+    expect(response.success).toBe(true);
+    const ast = JSON.parse(response.ast!);
+    expect(getMetaFormat(ast)).toBe('html');
+  });
+
+  it('returns error for unknown format', async () => {
+    const content = '---\nformat: unknown-garbage\n---\n\n# Hello\n';
+    const response: AstResponse = JSON.parse(await wasm.parse_qmd_to_ast(content));
+    expect(response.success).toBe(false);
+    expect(response.error).toContain('Unknown format');
+  });
+
+  it('returns error for empty format string', async () => {
+    // format: "" (empty string) is represented as format: '' in YAML
+    const content = "---\nformat: ''\n---\n\n# Hello\n";
+    const response: AstResponse = JSON.parse(await wasm.parse_qmd_to_ast(content));
+    expect(response.success).toBe(false);
+    expect(response.error).toContain('Unknown format');
+  });
+});
+
+describe('format detection via render_qmd', () => {
+  it('detects format: q2-slides from VFS file', async () => {
+    wasm.vfs_add_file(
+      '/project/slides.qmd',
+      '---\nformat: q2-slides\ntitle: My Slides\n---\n\n# Slide 1\n'
+    );
+
+    const response: RenderResponse = JSON.parse(
+      await wasm.render_qmd('/project/slides.qmd')
+    );
+    expect(response.success).toBe(true);
+  });
+
+  it('returns error for unknown format in VFS file', async () => {
+    wasm.vfs_add_file(
+      '/project/doc.qmd',
+      '---\nformat: totally-bogus\n---\n\n# Hello\n'
+    );
+
+    const response: RenderResponse = JSON.parse(
+      await wasm.render_qmd('/project/doc.qmd')
+    );
+    expect(response.success).toBe(false);
+    expect(response.error).toContain('Unknown format');
+  });
+});
+
+describe('format detection via render_qmd_content', () => {
+  it('detects format: q2-slides from content', async () => {
+    const content = '---\nformat: q2-slides\ntitle: My Slides\n---\n\n# Slide 1\n';
+    const response: RenderResponse = JSON.parse(
+      await wasm.render_qmd_content(content, '')
+    );
+    expect(response.success).toBe(true);
+  });
+
+  it('returns error for unknown format from content', async () => {
+    const content = '---\nformat: totally-bogus\n---\n\n# Hello\n';
+    const response: RenderResponse = JSON.parse(
+      await wasm.render_qmd_content(content, '')
+    );
+    expect(response.success).toBe(false);
+    expect(response.error).toContain('Unknown format');
+  });
+});


### PR DESCRIPTION
Here's the fix for 

```
format: q2-slides
```

We are now merging and flattening all metadata, and in the process we lost the format name.

This PR restores it by always setting `format` as string. This is necessary because there is are no longer any side channels - everything must be communicated through the metadata.

This PR also validates the format name - previously we silently fell back to HTML in the native runtime, and ignored the format name and always used HTML in the wasm runtime.

Since `q2-slides` (or something like it) will eventually be a format extension, explicitly validate it as a pseudo-format.

(Glad to relax these restrictions if this seems too strict.)


## Summary

- MetadataMergeStage now injects `format: "<target_format>"` into merged metadata after flattening, so the format name crosses the WASM serialization boundary via the AST
- `Format` struct gains `target_format`, `extension_name`, `display_name` fields and a `from_format_string()` constructor supporting base formats, extension formats (`acm-html`), and pseudo-formats (`q2-slides`)
- WASM entry points detect format from YAML frontmatter instead of hardcoding HTML
- PreviewRouter updated to handle `MetaString` serialization shape
- Unknown format strings now error instead of silently falling back to HTML

Fixes hub-client q2-slides detection broken after PR #30.

## Test plan

- [x] 19 new `format.rs` unit tests (parse_format_descriptor, from_format_string edge cases)
- [x] 5 new + 4 updated metadata_merge tests (format injection, extension formats, context vs document)
- [x] 12 new WASM integration tests (`formatDetection.wasm.test.ts`)
- [x] Full Rust workspace: 6664 tests pass
- [x] Full WASM suite: 52 tests pass (including 35 smoke-all fixtures)
- [x] Manual: open hub-client with a `format: q2-slides` document, verify slides renderer activates