### PR TITLE
Free disk space and remove orphaned WASM setup from CI

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -95,52 +95,19 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install tree-sitter-cli
 
+      # Free disk space on Linux runners (14 GB SSD is tight for Rust monorepo)
+      - name: Free disk space
+        if: runner.os == 'Linux'
+        uses: endersonmenezes/free-disk-space@7901478139cff6e9d44df5972fd8ab8fcade4db1 # v3
+        with:
+          remove_android: true
+          remove_dotnet: true
+          remove_haskell: true
+
       # Custom lint checks (before build to fail fast)
       - name: Run custom lints
         shell: bash
         run: cargo xtask lint
-
-      # TypeScript workspace build
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '24'
-          cache: 'npm'
-
-      - name: Install npm dependencies
-        shell: bash
-        run: npm ci
-
-      # WASM build for hub-client (must happen before TypeScript build)
-      - name: Set up Clang (Linux)
-        if: runner.os == 'Linux'
-        uses: egor-tensin/setup-clang@v1
-        with:
-          version: latest
-          platform: x64
-
-      - name: Set up LLVM (macOS)
-        if: runner.os == 'macOS'
-        run: brew install llvm
-        shell: bash
-
-      - name: Install wasm-pack
-        shell: bash
-        run: cargo install wasm-pack
-
-      # - name: Build WASM module
-      #   shell: bash
-      #   run: |
-      #     cd crates/wasm-quarto-hub-client
-      #     if [ "$RUNNER_OS" = "macOS" ]; then
-      #       export PATH="/opt/homebrew/opt/llvm/bin:/usr/local/opt/llvm/bin:$PATH"
-      #     fi
-      #     export CFLAGS_wasm32_unknown_unknown="-I$(pwd)/wasm-sysroot -Wbad-function-cast -Wcast-function-type -fno-builtin -DHAVE_ENDIAN_H"
-      #     wasm-pack build --target web
-
-      # - name: Build TypeScript packages
-      #   shell: bash
-      #   run: npm run build
 
       # Build and test
       # Deny warnings in CI so they don't accumulate silently
@@ -161,9 +128,3 @@ jobs:
         run: cargo nextest run
         env:
           RUSTFLAGS: "-D warnings"
-
-      # - name: Run hub-client tests
-      #   shell: bash
-      #   run: |
-      #     cd hub-client
-      #     npm run test:ci

--- a/claude-notes/plans/2026-03-17-ci-optimize-disk-usage.md
+++ b/claude-notes/plans/2026-03-17-ci-optimize-disk-usage.md
@@ -1,0 +1,36 @@
+# Plan: CI Optimization Steps 1 & 2
+
+## Overview
+
+The q2 test-suite CI workflow ran out of disk on ubuntu-latest (14 GB SSD) during run 23156000998. This plan implements the first two optimization steps from `memory://main/tasks/optimize-q2-ci-workflow-disk-usage`.
+
+Key discovery: `ts-test-suite.yml` (a separate workflow on the same triggers) already handles the WASM/hub-client build. The setup steps in `test-suite.yml` (Node.js, npm ci, Clang/LLVM, wasm-pack) were orphaned when those steps were moved to `ts-test-suite.yml` on Jan 29, 2026.
+
+## Work Items
+
+- [x] Add `endersonmenezes/free-disk-space` action (SHA-pinned to v3, Linux-only) after tree-sitter setup
+- [x] Remove orphaned WASM/hub-client setup steps (Node.js, npm ci, Clang, LLVM, wasm-pack, commented-out build steps)
+- [x] Remove commented-out hub-client test step
+- [x] Validate YAML syntax
+- [x] Confirm `ts-test-suite.yml` unchanged
+- [x] Create follow-up basic-memory task: consolidate workflows (`memory://main/tasks/consolidate-q2-ci-workflows`)
+- [x] Commit, push, create PR (https://github.com/quarto-dev/q2/pull/55)
+
+## Details
+
+### Steps removed from test-suite.yml
+
+| Step | Why safe |
+|------|----------|
+| Set up Node.js | ts-test-suite.yml has this |
+| Install npm dependencies | ts-test-suite.yml has this |
+| Set up Clang (Linux) | ts-test-suite.yml has this |
+| Set up LLVM (macOS) | ts-test-suite.yml has this |
+| Install wasm-pack | ts-test-suite.yml has this |
+| Build WASM module (commented) | ts-test-suite.yml runs this actively |
+| Build TypeScript packages (commented) | Covered by npm run build:all in ts-test-suite.yml |
+| Run hub-client tests (commented) | Commented out, no coverage change |
+
+### Follow-up (out of scope)
+
+Consolidate the two workflows per `claude-notes/plans/2026-01-12-wasm-ci-tests.md`: move WASM build into `test-suite.yml` as a separate parallel job, delete `ts-test-suite.yml`.


### PR DESCRIPTION
The test-suite workflow ran out of disk on ubuntu-latest (14 GB SSD).

## Changes

1. Add `endersonmenezes/free-disk-space` (v3, SHA-pinned, Linux-only) to reclaim space from Android, .NET, and Haskell toolchains.

2. Remove orphaned WASM/hub-client setup steps (Node.js, npm ci, Clang/LLVM, wasm-pack, and commented-out build/test steps) left behind when those steps moved to `ts-test-suite.yml` on Jan 29 (bf7e8f42..5f7ca839). This eliminates ~5 minutes of unnecessary tool installation and significant disk usage.

`ts-test-suite.yml` runs on the same triggers and actively builds the WASM module, so no coverage is lost.

## Test plan

- [x] Verify both workflows trigger on this PR
- [x] Verify `test-suite.yml` passes (Rust build + tests, lints, tree-sitter)
- [x] Verify `ts-test-suite.yml` passes (WASM build, hub-client)
- [x] Confirm Linux runner no longer runs out of disk