### PR TITLE
hub-client: move toggle buttons to top header bar

### DIFF
--- a/hub-client/src/components/Editor.css
+++ b/hub-client/src/components/Editor.css
@@ -188,11 +188,9 @@
 
 /* Pane divider between editor and preview */
 .pane-divider {
-  position: relative;
   width: 1px;
   background: #1f3460;
   flex-shrink: 0;
-  overflow: visible;
 }
 
 .editor-pane {

--- a/hub-client/src/components/Editor.tsx
+++ b/hub-client/src/components/Editor.tsx
@@ -34,7 +34,6 @@ import ProjectTab from './tabs/ProjectTab';
 import StatusTab from './tabs/StatusTab';
 import SettingsTab from './tabs/SettingsTab';
 import AboutTab from './tabs/AboutTab';
-import ViewToggleControl from './ViewToggleControl';
 import { useViewMode } from './ViewModeContext';
 import MarkdownSummary from './MarkdownSummary';
 import ReplayDrawer from './ReplayDrawer';
@@ -924,11 +923,9 @@ export default function Editor({ project, files, fileContents, onDisconnect, onC
           </div>
         )}
 
-        {/* Divider with view toggle control */}
+        {/* Pane divider */}
         {!isFullscreenPreview && (
-          <div className="pane-divider">
-            <ViewToggleControl />
-          </div>
+          <div className="pane-divider" />
         )}
 
         <div className={`pane preview-pane${isFullscreenPreview ? ' fullscreen' : ''}`}>

--- a/hub-client/src/components/MinimalHeader.css
+++ b/hub-client/src/components/MinimalHeader.css
@@ -12,6 +12,9 @@
 .header-left {
   flex: 1;
   min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 12px;
 }
 
 .minimal-header .file-path {

--- a/hub-client/src/components/MinimalHeader.tsx
+++ b/hub-client/src/components/MinimalHeader.tsx
@@ -5,6 +5,7 @@
  * and project name with navigation on the right.
  */
 
+import ViewToggleControl from './ViewToggleControl';
 import './MinimalHeader.css';
 
 interface MinimalHeaderProps {
@@ -28,6 +29,7 @@ export default function MinimalHeader({
   return (
     <header className="minimal-header">
       <div className="header-left">
+        <ViewToggleControl />
         {currentFilePath ? (
           <span className="file-path">{currentFilePath}</span>
         ) : (

--- a/hub-client/src/components/ViewToggleControl.css
+++ b/hub-client/src/components/ViewToggleControl.css
@@ -1,20 +1,8 @@
 .view-toggle-control {
-  position: absolute;
-  bottom: 16px;
-  left: 50%;
-  transform: translateX(-50%);
-  z-index: 100;
   display: flex;
-  flex-direction: column;
-  gap: 1px;
-  padding: 8px 12px;
-  opacity: 0.35;
-  transition: opacity 0.2s ease;
-}
-
-.view-toggle-control:hover,
-.view-toggle-control:focus-within {
-  opacity: 1;
+  flex-direction: row;
+  align-items: center;
+  gap: 2px;
 }
 
 .view-toggle-btn {

--- a/hub-client/src/components/ViewToggleControl.tsx
+++ b/hub-client/src/components/ViewToggleControl.tsx
@@ -2,7 +2,7 @@ import { useViewMode } from './ViewModeContext';
 import './ViewToggleControl.css';
 
 /**
- * Compact vertical toggle on the pane divider.
+ * Compact horizontal view toggle at the top of the sidebar.
  * Three small square buttons with layout-split icons.
  */
 export default function ViewToggleControl() {


### PR DESCRIPTION
@vezwork I saw that you moved the toggle buttons in 120af93, but felt they looked like they were attached to the replay drawer. Are you ok with the version in this PR? Or feel free to amend if you have better ideas.