### PR TITLE
Fix preview unmount/remount cycle on every keystroke

### DIFF
--- a/hub-client/src/components/PreviewRouter.tsx
+++ b/hub-client/src/components/PreviewRouter.tsx
@@ -77,7 +77,6 @@ export default function PreviewRouter(props: PreviewRouterProps) {
 
         if (result.success) {
           const format = getQ2Format(result.ast);
-          console.log("FORMAT", format)
           setReactFormat(format);
           props.onFormatChange?.(format);
         } else {


### PR DESCRIPTION
Fixes #57. (I _think_ I was also encountering this when working on #54).

PreviewRouter was setting `isChecking=true` on every content change, which unmounted the Preview component while `parseQmdToAst` ran, then remounted it from scratch.

On not-small documents this created a feedback loop where fast typing kept destroying and recreating the preview faster than it could render. 

Now only the initial format check (and file switches) show the loading state. Subsequent re-checks run in the background while Preview stays mounted.

--

Note: there's probably more that can be done for performance, but this is likely the main culprit.