### PR TITLE
Fix crash when slide index exceeds available slides after deletion

### DIFF
--- a/hub-client/src/components/ReactAstSlideRenderer.tsx
+++ b/hub-client/src/components/ReactAstSlideRenderer.tsx
@@ -174,7 +174,7 @@ export function SlideAst({ astJson, currentFilePath, onNavigateToDocument, curre
           }}
         >
           {slides.length > 0
-            ? renderSlide(slides[currentSlide], currentFilePath, onNavigateToDocument)
+            ? renderSlide(slides[Math.min(currentSlide, slides.length - 1)], currentFilePath, onNavigateToDocument)
             : null}
         </div>
       </AspectRatioScaler>


### PR DESCRIPTION
Fixes #58. Clamps the slide index to the valid range before rendering.

When a large deletion shrinks the document, the AST may produce fewer slides than before, but `currentSlide` still holds the old index. Accessing `slides[currentSlide]` out of bounds returns `undefined` and crashes the page.

The fix uses `Math.min(currentSlide, slides.length - 1)` to fall back to the last available slide.

I came across this while developing another feature I'm working on. This should fix at least one cause of #58, there could always be others. fyi @vezwork 