### PR TITLE
Fix: prevent remote edits from being silently deleted on concurrent updates

### DIFF
--- a/hub-client/src/App.tsx
+++ b/hub-client/src/App.tsx
@@ -373,12 +373,14 @@ function App() {
   }, [navigateToProjectSelector]);
 
   const handleContentChange = useCallback((path: string, content: string) => {
+    // updateFileContent fires handle.change(), which synchronously triggers the
+    // 'change' event on the DocHandle. The registered changeHandler calls
+    // callbacks.onFileChanged with the true merged Automerge document state,
+    // which propagates to setFileContents via onFileContent. Setting fileContents
+    // directly here with the raw editor content would overwrite that merged state,
+    // causing concurrent remote edits to be silently deleted by subsequent
+    // updateText calls that diff against the stale Monaco content.
     updateFileContent(path, content);
-    setFileContents((prev) => {
-      const next = new Map(prev);
-      next.set(path, content);
-      return next;
-    });
   }, []);
 
   const handleProjectCreated = useCallback(async (

--- a/ts-packages/quarto-sync-client/src/client.ts
+++ b/ts-packages/quarto-sync-client/src/client.ts
@@ -461,9 +461,11 @@ export function createSyncClient(callbacks: SyncClientCallbacks, astOptions?: AS
       updateText(doc, ['text'], content);
     });
 
-    // Notify callback (local change)
-    callbacks.onFileChanged(path, content, []);
-    tryParseAndNotify(path, content);
+    // onFileChanged and tryParseAndNotify are called by the 'change' event handler
+    // registered in subscribeToFile/subscribeToFileInternal, which passes the true
+    // merged Automerge document state. Calling them again here with the raw editor
+    // content would overwrite the merged state in fileContents, causing concurrent
+    // remote edits to be silently deleted on the next updateFileContent call.
   }
 
   /**


### PR DESCRIPTION
Fixes #74.

When two people edit the same file at the same time, the second person's changes could get silently thrown away.                   

What was happening: When you type in the editor, two things happen: (1) your edit gets merged into the shared document via Automerge, and (2) the app updates its local copy of the file content. The problem was that step 2 was overwriting the local copy with just your text — ignoring any changes the other person made in the meantime. The next time you typed, the app would compare against that stale copy and effectively erase the other person's work.

We removed the redundant local state update in App.tsx and the redundant callback in the sync client. Both were unnecessary because the Automerge change handler already pushes the correctly-merged document state back to the app. Now there's only one source of truth for file content — the merged Automerge document — so remote edits can't get lost.