### PR TITLE
Drop .sh filter dispatch on Windows

### DIFF
--- a/crates/pampa/src/json_filter.rs
+++ b/crates/pampa/src/json_filter.rs
@@ -608,6 +608,7 @@ printf '\xff\xfe'  # Invalid UTF-8 bytes
             "#!/usr/bin/env python3\nimport sys\nsys.stdin.read()\nsys.stdout.buffer.write(b'\\xff\\xfe')\n",
         )
         .unwrap();
+        make_executable(&filter_path);
 
         let pandoc = Pandoc {
             meta: quarto_pandoc_types::ConfigValue::default(),


### PR DESCRIPTION
Follow-up to #89. The bash dispatch for `.sh` filters doesn't work on Windows because
path translation varies across bash variants — WSL uses `/mnt/c/`, Git Bash uses `/c/`,
Cygwin uses `/cygdrive/c/`. Rather than detecting and handling each variant, drop `.sh`
dispatch on Windows entirely since it's not a realistic user scenario.

- Remove `find_bash()` and the `.sh`/`.bash` match arm from `build_filter_command`
- Convert `test_invalid_utf8_filter` to use a Python script (cross-platform)
- Add `test_invalid_utf8_filter_sh` with `#[cfg(unix)]` for Unix coverage