### PR TITLE
Cleanup PR caches on close

### DIFF
--- a/.github/workflows/cleanup-caches.yml
+++ b/.github/workflows/cleanup-caches.yml
@@ -16,7 +16,7 @@ jobs:
           echo "::group::Fetching cache list for PR #${{ github.event.pull_request.number }}"
           echo "Branch ref: $BRANCH"
 
-          # Get all caches for this PR ref
+          # Get up to 1000 caches for this PR ref
           cacheList=$(gh cache list --ref $BRANCH --limit 1000 --json id,key,sizeInBytes)
           cacheCount=$(echo "$cacheList" | jq '. | length')
 
@@ -45,10 +45,10 @@ jobs:
               echo "Deleting cache ID: $cacheKey"
               if gh cache delete $cacheKey; then
                 echo "  ✓ Successfully deleted cache $cacheKey"
-                ((deleted++))
+                deleted=$((deleted+1))
               else
                 echo "  ✗ Failed to delete cache $cacheKey"
-                ((failed++))
+                failed=$((failed+1))
               fi
           done
 


### PR DESCRIPTION
## Summary

- Add workflow to automatically delete GitHub Actions caches when a PR is closed or merged
- Rust build caches are ~700 MB each and accumulate per PR branch, with the repo currently at ~10 GB (the GitHub limit)
- Uses `gh cache list --ref refs/pull/<N>/merge` to scope deletions to only the closed PR's caches — main branch and other PR caches are never touched

## How it works

Caches created by `Swatinem/rust-cache` and `actions/cache` are scoped to the git ref that triggered the workflow. For PRs, that ref is `refs/pull/<N>/merge`. The cleanup workflow lists caches under that ref and deletes them by ID, logging sizes and results.

Adapted from quarto-dev/quarto-cli's equivalent workflow.