### PR TITLE
OT-based cursor tracking for collaborative presence

### DIFF
--- a/hub-client/src/hooks/usePresence.ts
+++ b/hub-client/src/hooks/usePresence.ts
@@ -78,6 +78,23 @@ function ensureCursorStyle(color: string, odorId: string): void {
 }
 
 /**
+ * Shift a character offset to account for a single edit.
+ * Offsets after the edit move by delta; offsets inside the replaced range
+ * clamp to the end of the replacement text; offsets before are unchanged.
+ */
+function transformOffset(
+  offset: number,
+  editStart: number,
+  oldEnd: number,
+  newEnd: number,
+  delta: number,
+): number {
+  if (offset >= oldEnd) return offset + delta;
+  if (offset > editStart) return newEnd;
+  return offset;
+}
+
+/**
  * Convert a color to a safe CSS class identifier.
  */
 function colorToId(color: string): string {
@@ -189,26 +206,18 @@ export function usePresence(
         const newEnd = editStart + change.text.length;
         const delta = change.text.length - change.rangeLength;
 
-        // --- cursors ---
         for (const [peerId, offset] of adjustedCursorsRef.current) {
           if (skip.has(peerId)) continue;
-          if (offset >= oldEnd) {
-            adjustedCursorsRef.current.set(peerId, offset + delta);
-          } else if (offset > editStart) {
-            adjustedCursorsRef.current.set(peerId, newEnd);
-          }
+          adjustedCursorsRef.current.set(
+            peerId, transformOffset(offset, editStart, oldEnd, newEnd, delta));
         }
 
-        // --- selections ---
         for (const [peerId, sel] of adjustedSelectionsRef.current) {
           if (skip.has(peerId)) continue;
-          const s = sel.start >= oldEnd ? sel.start + delta
-            : sel.start > editStart ? newEnd
-            : sel.start;
-          const end = sel.end >= oldEnd ? sel.end + delta
-            : sel.end > editStart ? newEnd
-            : sel.end;
-          adjustedSelectionsRef.current.set(peerId, { start: s, end });
+          adjustedSelectionsRef.current.set(peerId, {
+            start: transformOffset(sel.start, editStart, oldEnd, newEnd, delta),
+            end: transformOffset(sel.end, editStart, oldEnd, newEnd, delta),
+          });
         }
       }
 

--- a/hub-client/src/hooks/usePresence.ts
+++ b/hub-client/src/hooks/usePresence.ts
@@ -95,6 +95,20 @@ function transformOffset(
 }
 
 /**
+ * Per-peer OT state for remote cursor/selection tracking.
+ */
+interface PeerCursorState {
+  /** OT-adjusted cursor offset */
+  cursor: number;
+  /** Last raw cursor value from the presence network */
+  lastPresenceCursor: number;
+  /** OT-adjusted selection range (absent if peer has no selection) */
+  selection?: { start: number; end: number };
+  /** Last raw selection from the presence network */
+  lastPresenceSelection?: { start: number; end: number };
+}
+
+/**
  * Convert a color to a safe CSS class identifier.
  */
 function colorToId(color: string): string {
@@ -130,22 +144,14 @@ export function usePresence(
   // must re-render after every content change to keep them in sync.
   const [modelVersion, setModelVersion] = useState(0);
 
-  // Operational-transform adjusted cursor offsets for each remote peer.
-  // Between presence updates, content edits shift these offsets so that
-  // decorations stay at the correct logical position even when the document
-  // length changes (e.g. a deletion in paragraph 1 shouldn't move a cursor
-  // in paragraph 2).
-  const adjustedCursorsRef = useRef<Map<string, number>>(new Map());
-  const adjustedSelectionsRef = useRef<Map<string, { start: number; end: number }>>(new Map());
-
-  // Last raw presence values received from the network.  Used to detect when
-  // a genuinely new presence update has arrived (as opposed to OT drift).
-  const lastPresenceCursorRef = useRef<Map<string, number>>(new Map());
-  const lastPresenceSelRef = useRef<Map<string, { start: number; end: number }>>(new Map());
+  // Per-peer OT state: adjusted offsets and last raw presence values.
+  // Between presence updates, content edits shift `cursor`/`selection` so
+  // decorations stay at the correct logical position.  `lastPresence*`
+  // fields detect genuinely new presence updates vs. OT drift.
+  const peerStateRef = useRef<Map<string, PeerCursorState>>(new Map());
 
   // Peers whose cursor already reflects an edit whose content change hasn't
-  // arrived yet.  The OT handler must skip these once so it doesn't
-  // double-shift the offset.
+  // arrived yet.  The OT handler skips these once to avoid double-shifting.
   const anticipatingEditRef = useRef<Set<string>>(new Set());
 
   // Callback for when editor mounts
@@ -206,18 +212,15 @@ export function usePresence(
         const newEnd = editStart + change.text.length;
         const delta = change.text.length - change.rangeLength;
 
-        for (const [peerId, offset] of adjustedCursorsRef.current) {
+        for (const [peerId, state] of peerStateRef.current) {
           if (skip.has(peerId)) continue;
-          adjustedCursorsRef.current.set(
-            peerId, transformOffset(offset, editStart, oldEnd, newEnd, delta));
-        }
-
-        for (const [peerId, sel] of adjustedSelectionsRef.current) {
-          if (skip.has(peerId)) continue;
-          adjustedSelectionsRef.current.set(peerId, {
-            start: transformOffset(sel.start, editStart, oldEnd, newEnd, delta),
-            end: transformOffset(sel.end, editStart, oldEnd, newEnd, delta),
-          });
+          state.cursor = transformOffset(state.cursor, editStart, oldEnd, newEnd, delta);
+          if (state.selection) {
+            state.selection = {
+              start: transformOffset(state.selection.start, editStart, oldEnd, newEnd, delta),
+              end: transformOffset(state.selection.end, editStart, oldEnd, newEnd, delta),
+            };
+          }
         }
       }
 
@@ -251,8 +254,8 @@ export function usePresence(
       // --- Cursor decoration (OT-adjusted) ---
       if (user.cursor !== null) {
         try {
-          const lastRaw = lastPresenceCursorRef.current.get(user.peerId);
-          const isNewPresence = lastRaw === undefined || lastRaw !== user.cursor;
+          let state = peerStateRef.current.get(user.peerId);
+          const isNewPresence = !state || state.lastPresenceCursor !== user.cursor;
 
           let cursorToRender: number;
           if (isNewPresence) {
@@ -261,20 +264,24 @@ export function usePresence(
             // Only anticipate for small forward movements (typing); large
             // jumps or backward moves are navigation and won't produce a
             // matching content change.
-            const prevAdjusted = adjustedCursorsRef.current.get(user.peerId);
-            const cursorDelta = user.cursor - (lastRaw ?? user.cursor);
-            if (lastRaw !== undefined && prevAdjusted === lastRaw &&
+            const cursorDelta = user.cursor - (state?.lastPresenceCursor ?? user.cursor);
+            if (state && state.cursor === state.lastPresenceCursor &&
                 cursorDelta > 0 && cursorDelta <= 2) {
               anticipatingEditRef.current.add(user.peerId);
             }
 
             // New presence update — adopt the authoritative offset
             cursorToRender = user.cursor;
-            adjustedCursorsRef.current.set(user.peerId, user.cursor);
-            lastPresenceCursorRef.current.set(user.peerId, user.cursor);
+            if (state) {
+              state.cursor = user.cursor;
+              state.lastPresenceCursor = user.cursor;
+            } else {
+              state = { cursor: user.cursor, lastPresenceCursor: user.cursor };
+              peerStateRef.current.set(user.peerId, state);
+            }
           } else {
             // No new update — use the OT-shifted value
-            cursorToRender = adjustedCursorsRef.current.get(user.peerId) ?? user.cursor;
+            cursorToRender = state.cursor;
           }
 
           if (cursorToRender < 0 || cursorToRender > docLength) {
@@ -299,26 +306,27 @@ export function usePresence(
           // Ignore invalid positions
         }
       } else {
-        adjustedCursorsRef.current.delete(user.peerId);
-        lastPresenceCursorRef.current.delete(user.peerId);
+        peerStateRef.current.delete(user.peerId);
       }
 
       // --- Selection decoration (OT-adjusted) ---
       if (user.selection && user.selection.start !== user.selection.end) {
         try {
-          const lastSel = lastPresenceSelRef.current.get(user.peerId);
-          const isNewSel =
-            lastSel === undefined ||
+          const state = peerStateRef.current.get(user.peerId);
+          if (!state) continue;
+
+          const lastSel = state.lastPresenceSelection;
+          const isNewSel = !lastSel ||
             lastSel.start !== user.selection.start ||
             lastSel.end !== user.selection.end;
 
           let selToRender: { start: number; end: number };
           if (isNewSel) {
             selToRender = user.selection;
-            adjustedSelectionsRef.current.set(user.peerId, { ...user.selection });
-            lastPresenceSelRef.current.set(user.peerId, { ...user.selection });
+            state.selection = { ...user.selection };
+            state.lastPresenceSelection = { ...user.selection };
           } else {
-            selToRender = adjustedSelectionsRef.current.get(user.peerId) ?? user.selection;
+            selToRender = state.selection ?? user.selection;
           }
 
           if (selToRender.end > docLength) {
@@ -344,8 +352,11 @@ export function usePresence(
           // Ignore invalid positions
         }
       } else {
-        adjustedSelectionsRef.current.delete(user.peerId);
-        lastPresenceSelRef.current.delete(user.peerId);
+        const state = peerStateRef.current.get(user.peerId);
+        if (state) {
+          delete state.selection;
+          delete state.lastPresenceSelection;
+        }
       }
     }
 

--- a/hub-client/src/hooks/usePresence.ts
+++ b/hub-client/src/hooks/usePresence.ts
@@ -108,18 +108,28 @@ export function usePresence(
   // Track if we've initialized
   const initializedRef = useRef(false);
 
-  // Track model version to re-render decorations when content changes
-  // This is needed because decorations are created based on character offsets,
-  // and Monaco auto-shifts decorations when text is inserted. By tracking
-  // model changes, we can recalculate decoration positions after content syncs.
+  // Track model version to re-render decorations when content changes.
+  // Decorations are recreated from character offsets on each render, so we
+  // must re-render after every content change to keep them in sync.
   const [modelVersion, setModelVersion] = useState(0);
 
-  // Track previous cursor state to optimize single-char edits and reduce flicker.
-  // When presence arrives before document sync, we pre-compensate the cursor position
-  // so that Monaco's auto-shift lands it in the correct place. This avoids the need
-  // for a second render pass to correct the position.
-  const prevCursorsRef = useRef<Map<string, number>>(new Map());
-  const cursorModelLengthRef = useRef<Map<string, number>>(new Map());
+  // Operational-transform adjusted cursor offsets for each remote peer.
+  // Between presence updates, content edits shift these offsets so that
+  // decorations stay at the correct logical position even when the document
+  // length changes (e.g. a deletion in paragraph 1 shouldn't move a cursor
+  // in paragraph 2).
+  const adjustedCursorsRef = useRef<Map<string, number>>(new Map());
+  const adjustedSelectionsRef = useRef<Map<string, { start: number; end: number }>>(new Map());
+
+  // Last raw presence values received from the network.  Used to detect when
+  // a genuinely new presence update has arrived (as opposed to OT drift).
+  const lastPresenceCursorRef = useRef<Map<string, number>>(new Map());
+  const lastPresenceSelRef = useRef<Map<string, { start: number; end: number }>>(new Map());
+
+  // Peers whose cursor already reflects an edit whose content change hasn't
+  // arrived yet.  The OT handler must skip these once so it doesn't
+  // double-shift the offset.
+  const anticipatingEditRef = useRef<Set<string>>(new Set());
 
   // Callback for when editor mounts
   const onEditorMount = useCallback((mountedEditor: Monaco.editor.IStandaloneCodeEditor) => {
@@ -157,16 +167,52 @@ export function usePresence(
     return unsubscribe;
   }, [enabled]);
 
-  // Track model content changes to trigger decoration recalculation
-  // This ensures decorations are repositioned after document syncs
+  // Transform remote cursor/selection offsets on every content change (OT).
+  // Each edit shifts offsets that fall after it, and clamps offsets inside
+  // the deleted range to the end of the replacement text.  This keeps
+  // decorations at their correct logical positions between presence updates.
   useEffect(() => {
     if (!editor) return;
 
     const model = editor.getModel();
     if (!model) return;
 
-    const disposable = model.onDidChangeContent(() => {
-      setModelVersion(v => v + 1);
+    const disposable = model.onDidChangeContent((e) => {
+      // Peers whose presence arrived before this content change already have
+      // post-edit offsets — skip OT for them for this entire event.
+      const skip = new Set(anticipatingEditRef.current);
+      anticipatingEditRef.current.clear();
+
+      for (const change of e.changes) {
+        const editStart = change.rangeOffset;
+        const oldEnd = editStart + change.rangeLength;
+        const newEnd = editStart + change.text.length;
+        const delta = change.text.length - change.rangeLength;
+
+        // --- cursors ---
+        for (const [peerId, offset] of adjustedCursorsRef.current) {
+          if (skip.has(peerId)) continue;
+          if (offset >= oldEnd) {
+            adjustedCursorsRef.current.set(peerId, offset + delta);
+          } else if (offset > editStart) {
+            adjustedCursorsRef.current.set(peerId, newEnd);
+          }
+        }
+
+        // --- selections ---
+        for (const [peerId, sel] of adjustedSelectionsRef.current) {
+          if (skip.has(peerId)) continue;
+          const s = sel.start >= oldEnd ? sel.start + delta
+            : sel.start > editStart ? newEnd
+            : sel.start;
+          const end = sel.end >= oldEnd ? sel.end + delta
+            : sel.end > editStart ? newEnd
+            : sel.end;
+          adjustedSelectionsRef.current.set(peerId, { start: s, end });
+        }
+      }
+
+      setModelVersion((v) => v + 1);
     });
 
     return () => disposable.dispose();
@@ -193,49 +239,35 @@ export function usePresence(
       const colorId = colorToId(user.userColor);
       ensureCursorStyle(user.userColor, colorId);
 
-      // Add cursor decoration
+      // --- Cursor decoration (OT-adjusted) ---
       if (user.cursor !== null) {
         try {
-          const prevCursor = prevCursorsRef.current.get(user.peerId);
-          const cursorModelLength = cursorModelLengthRef.current.get(user.peerId) ?? docLength;
+          const lastRaw = lastPresenceCursorRef.current.get(user.peerId);
+          const isNewPresence = lastRaw === undefined || lastRaw !== user.cursor;
 
-          let cursorToRender = user.cursor;
-
-          // Pre-compensation for single-char (and small multi-char) inserts:
-          // When presence arrives before document sync, the cursor position is based
-          // on the NEW document state, but our model still has the OLD state.
-          // If we render at user.cursor, Monaco will shift the decoration when the
-          // document syncs, causing a flicker.
-          //
-          // Instead, we render at (prevCursor + modelDelta). This way, when Monaco
-          // shifts the decoration due to the insert, it lands at the correct position.
-          //
-          // Example: prevCursor=50, user.cursor=51 (typed 1 char), model unchanged yet
-          // - cursorDelta=1, modelDelta=0
-          // - We render at 50. When char inserts at 50, decoration shifts to 51. Correct!
-          //
-          // IMPORTANT: Only apply this for small cursor movements (1-2 chars).
-          // Larger movements are likely navigation (clicking, arrow keys), not typing.
-          // We don't want to pre-compensate for navigation since no document change is coming.
-          const MAX_TYPING_DELTA = 2;
-
-          if (prevCursor !== undefined) {
-            const cursorDelta = user.cursor - prevCursor;
-            const modelDelta = docLength - cursorModelLength;
-
-            // Only pre-compensate for small forward movements (likely typing)
-            if (cursorDelta > 0 && cursorDelta <= MAX_TYPING_DELTA && modelDelta < cursorDelta) {
-              cursorToRender = prevCursor + modelDelta;
+          let cursorToRender: number;
+          if (isNewPresence) {
+            // If OT hasn't shifted the cursor since the previous presence
+            // update, the corresponding content change hasn't arrived yet.
+            // Only anticipate for small forward movements (typing); large
+            // jumps or backward moves are navigation and won't produce a
+            // matching content change.
+            const prevAdjusted = adjustedCursorsRef.current.get(user.peerId);
+            const cursorDelta = user.cursor - (lastRaw ?? user.cursor);
+            if (lastRaw !== undefined && prevAdjusted === lastRaw &&
+                cursorDelta > 0 && cursorDelta <= 2) {
+              anticipatingEditRef.current.add(user.peerId);
             }
+
+            // New presence update — adopt the authoritative offset
+            cursorToRender = user.cursor;
+            adjustedCursorsRef.current.set(user.peerId, user.cursor);
+            lastPresenceCursorRef.current.set(user.peerId, user.cursor);
+          } else {
+            // No new update — use the OT-shifted value
+            cursorToRender = adjustedCursorsRef.current.get(user.peerId) ?? user.cursor;
           }
 
-          // Update tracking state when cursor changes
-          if (user.cursor !== prevCursor) {
-            prevCursorsRef.current.set(user.peerId, user.cursor);
-            cursorModelLengthRef.current.set(user.peerId, docLength);
-          }
-
-          // Skip if out of bounds after adjustment
           if (cursorToRender < 0 || cursorToRender > docLength) {
             continue;
           }
@@ -257,20 +289,35 @@ export function usePresence(
         } catch {
           // Ignore invalid positions
         }
+      } else {
+        adjustedCursorsRef.current.delete(user.peerId);
+        lastPresenceCursorRef.current.delete(user.peerId);
       }
 
-      // Add selection decoration (simpler handling - no pre-compensation needed
-      // since typing usually clears selection, and selection changes are less
-      // frequent than cursor movements)
+      // --- Selection decoration (OT-adjusted) ---
       if (user.selection && user.selection.start !== user.selection.end) {
         try {
-          // Skip if selection extends beyond document length
-          if (user.selection.end > docLength) {
+          const lastSel = lastPresenceSelRef.current.get(user.peerId);
+          const isNewSel =
+            lastSel === undefined ||
+            lastSel.start !== user.selection.start ||
+            lastSel.end !== user.selection.end;
+
+          let selToRender: { start: number; end: number };
+          if (isNewSel) {
+            selToRender = user.selection;
+            adjustedSelectionsRef.current.set(user.peerId, { ...user.selection });
+            lastPresenceSelRef.current.set(user.peerId, { ...user.selection });
+          } else {
+            selToRender = adjustedSelectionsRef.current.get(user.peerId) ?? user.selection;
+          }
+
+          if (selToRender.end > docLength) {
             continue;
           }
 
-          const startPos = model.getPositionAt(user.selection.start);
-          const endPos = model.getPositionAt(user.selection.end);
+          const startPos = model.getPositionAt(selToRender.start);
+          const endPos = model.getPositionAt(selToRender.end);
           newDecorations.push({
             range: {
               startLineNumber: startPos.lineNumber,
@@ -287,6 +334,9 @@ export function usePresence(
         } catch {
           // Ignore invalid positions
         }
+      } else {
+        adjustedSelectionsRef.current.delete(user.peerId);
+        lastPresenceSelRef.current.delete(user.peerId);
       }
     }
 
@@ -303,9 +353,8 @@ export function usePresence(
         decorationIdsRef.current = [];
       }
     };
-  // Note: modelVersion is included to recalculate decorations after content changes.
-  // This prevents the off-by-one cursor issue caused by Monaco auto-shifting decorations
-  // when the decoration effect runs before the content-sync effect.
+  // modelVersion triggers a re-render after every content change so that
+  // OT-adjusted offsets are used to reposition decorations.
   }, [editor, enabled, remoteUsers, modelVersion]);
 
   // Track local cursor/selection changes

--- a/hub-client/src/hooks/usePresence.ts
+++ b/hub-client/src/hooks/usePresence.ts
@@ -281,7 +281,7 @@ export function usePresence(
             }
           } else {
             // No new update — use the OT-shifted value
-            cursorToRender = state.cursor;
+            cursorToRender = state!.cursor;
           }
 
           if (cursorToRender < 0 || cursorToRender > docLength) {


### PR DESCRIPTION
Fixes #9. Deletion in one paragraph no longer shifts remote cursors in subsequent paragraphs.

Remote cursor positions are now adjusted locally via operational transformation (shifting stored character offsets by the length delta of each edit, based on whether the edit falls before, inside, or after the cursor) instead of being rendered from stale network offsets. When the document changes (local or remote edits), each tracked cursor/selection offset is shifted accordingly, keeping decorations at their correct logical position between presence updates.

Key details:
- `PeerCursorState` tracks OT-adjusted offsets and last-raw-presence values per peer, so we can distinguish a genuinely new presence message from a re-render of an already-shifted value
- `anticipatingEditRef` prevents double-shifting when a presence message arrives before its corresponding document change (e.g. a remote user types and we receive their new cursor position before the inserted character syncs): restricted to small forward cursor movements to avoid false positives from navigation clicks
- Removes the old pre-compensation heuristic (`prevCursorsRef`, `cursorModelLengthRef`, `MAX_TYPING_DELTA`)