### PR TITLE
Update GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -9,7 +9,7 @@ jobs:
     name: Build WASM Artifacts
     
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Rust nightly
         uses: dtolnay/rust-toolchain@nightly
 
@@ -21,7 +21,7 @@ jobs:
           sudo apt-get install -y build-essential curl file git
 
       - name: Set up Clang
-        uses: egor-tensin/setup-clang@v1
+        uses: egor-tensin/setup-clang@v2
         with:
           version: latest
           platform: x64
@@ -52,7 +52,7 @@ jobs:
     
       # upload artifacts
       - name: Upload WASM Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wasm-qmd-parser
           path: crates/wasm-qmd-parser/pkg

--- a/.github/workflows/hub-client-e2e.yml
+++ b/.github/workflows/hub-client-e2e.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Fix mtimes for build caching
       - name: Restore file modification times
@@ -39,7 +39,7 @@ jobs:
           targets: wasm32-unknown-unknown
 
       - name: Set up Clang
-        uses: egor-tensin/setup-clang@v1
+        uses: egor-tensin/setup-clang@v2
         with:
           version: latest
 
@@ -61,7 +61,7 @@ jobs:
 
       # Node.js and dependencies
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'npm'
@@ -129,7 +129,7 @@ jobs:
 
       # Upload test artifacts on failure
       - name: Upload Playwright report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: playwright-report

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -29,7 +29,7 @@ jobs:
     
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Fix mtimes IMMEDIATELY after checkout, before anything else
       - name: Restore file modification times

--- a/.github/workflows/ts-test-suite.yml
+++ b/.github/workflows/ts-test-suite.yml
@@ -29,7 +29,7 @@ jobs:
     
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Fix mtimes IMMEDIATELY after checkout, before anything else
       - name: Restore file modification times
@@ -100,7 +100,7 @@ jobs:
 
       # TypeScript workspace build
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'npm'
@@ -112,7 +112,7 @@ jobs:
       # WASM build for hub-client (must happen before TypeScript build)
       - name: Set up Clang (Linux)
         if: runner.os == 'Linux'
-        uses: egor-tensin/setup-clang@v1
+        uses: egor-tensin/setup-clang@v2
         with:
           version: latest
           platform: x64

--- a/crates/lua-src-wasm/.github/workflows/main.yml
+++ b/crates/lua-src-wasm/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
         - target: wasm32-wasip2
           os: ubuntu-latest
     steps:
-    - uses: actions/checkout@main
+    - uses: actions/checkout@v6
     - uses: ./.github/actions/setup-deps
       with:
         target: ${{ matrix.target }}
@@ -78,7 +78,7 @@ jobs:
         - target: wasm32-wasip2
           os: ubuntu-latest
     steps:
-    - uses: actions/checkout@main
+    - uses: actions/checkout@v6
     - uses: ./.github/actions/setup-deps
       with:
         target: ${{ matrix.target }}
@@ -101,7 +101,7 @@ jobs:
         - os: windows-latest
           target: x86_64-pc-windows-msvc
     steps:
-    - uses: actions/checkout@main
+    - uses: actions/checkout@v6
     - uses: ./.github/actions/setup-deps
       with:
         target: ${{ matrix.target }}
@@ -113,7 +113,7 @@ jobs:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@main
+    - uses: actions/checkout@v6
     - uses: dtolnay/rust-toolchain@stable
       with:
         components: rustfmt


### PR DESCRIPTION
All CI actions were on older major versions. Updated to current:

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | v6 |
| `actions/upload-artifact` | v4 | v7 |
| `actions/setup-node` | v4 | v6 |
| `egor-tensin/setup-clang` | v1 | v2 |

Also pins `lua-src-wasm` checkout from `@main` to `@v6` for reproducibility.

Actions already on latest: `Swatinem/rust-cache@v2`, `taiki-e/install-action@v2`, `endersonmenezes/free-disk-space` (pinned commit = v3), `dtolnay/rust-toolchain` (branch refs by design).