### PR TITLE
Attempt silent token refresh on visibility change before logging out

### DIFF
--- a/hub-client/src/hooks/useAuth.test.ts
+++ b/hub-client/src/hooks/useAuth.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { renderHook, act, waitFor } from '@testing-library/react';
+import { renderHook, act, waitFor, cleanup } from '@testing-library/react';
 
 // Track the One Tap callback so tests can invoke it manually.
 let oneTapCallbacks: {
@@ -167,6 +167,103 @@ describe('useAuth', () => {
         expect(result.current.auth).toEqual(refreshedUser),
       );
       expect(mockRefreshToken).toHaveBeenCalledWith('fresh.jwt.token');
+    });
+  });
+
+  // ── Visibility-triggered refresh (fake timers) ────────────
+
+  describe('visibility-triggered refresh', () => {
+    beforeEach(() => {
+      // Unmount hooks from previous tests so their visibilitychange
+      // listeners don't interfere with ours.
+      cleanup();
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('attempts One Tap refresh when tab becomes visible with expired cookie', async () => {
+      const user = { email: 'a@b.com', name: 'A', picture: null };
+      const refreshedUser = { email: 'a@b.com', name: 'Refreshed', picture: null };
+      mockFetchAuthMe.mockResolvedValueOnce(user); // mount
+
+      const { result } = renderHook(() => useAuth());
+      await vi.waitFor(() => expect(result.current.auth).toEqual(user));
+
+      // Next /auth/me returns null (cookie expired)
+      mockFetchAuthMe.mockResolvedValueOnce(null);
+      mockRefreshToken.mockResolvedValue(refreshedUser);
+
+      // Dispatch the event, then flush async handler + React updates separately.
+      document.dispatchEvent(new Event('visibilitychange'));
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      // One Tap should be enabled for refresh
+      expect(oneTapCallbacks.disabled).toBe(false);
+
+      // Simulate One Tap returning a fresh credential
+      await act(async () => {
+        oneTapCallbacks.onSuccess?.({ credential: 'fresh.jwt' });
+      });
+
+      await vi.waitFor(() => expect(result.current.auth).toEqual(refreshedUser));
+    });
+
+    it('clears auth when One Tap fails after visibility-triggered refresh', async () => {
+      const user = { email: 'a@b.com', name: 'A', picture: null };
+      mockFetchAuthMe.mockResolvedValueOnce(user); // mount
+
+      const { result } = renderHook(() => useAuth());
+      await vi.waitFor(() => expect(result.current.auth).toEqual(user));
+
+      // Jump Date.now() past cookie lifetime (simulates long idle)
+      vi.setSystemTime(Date.now() + 3600 * 1000 + 1000);
+
+      // Next /auth/me returns null (cookie expired)
+      mockFetchAuthMe.mockResolvedValueOnce(null);
+
+      document.dispatchEvent(new Event('visibilitychange'));
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      // Simulate One Tap failing (no active Google session)
+      await act(async () => {
+        oneTapCallbacks.onError?.();
+      });
+
+      await vi.waitFor(() => expect(result.current.auth).toBeNull());
+    });
+
+    it('clears auth when refreshToken returns null after visibility-triggered refresh', async () => {
+      const user = { email: 'a@b.com', name: 'A', picture: null };
+      mockFetchAuthMe.mockResolvedValueOnce(user); // mount
+
+      const { result } = renderHook(() => useAuth());
+      await vi.waitFor(() => expect(result.current.auth).toEqual(user));
+
+      // Jump Date.now() past cookie lifetime (simulates long idle)
+      vi.setSystemTime(Date.now() + 3600 * 1000 + 1000);
+
+      // Next /auth/me returns null (cookie expired)
+      mockFetchAuthMe.mockResolvedValueOnce(null);
+
+      document.dispatchEvent(new Event('visibilitychange'));
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      // One Tap returns a credential, but server rejects it
+      mockRefreshToken.mockResolvedValue(null);
+      await act(async () => {
+        oneTapCallbacks.onSuccess?.({ credential: 'rejected.jwt' });
+      });
+
+      await vi.waitFor(() => expect(result.current.auth).toBeNull());
     });
   });
 

--- a/hub-client/src/hooks/useAuth.ts
+++ b/hub-client/src/hooks/useAuth.ts
@@ -11,6 +11,9 @@
  * The new credential is sent to POST /auth/refresh which validates it and
  * sets a fresh cookie. If silent refresh fails, auth is cleared at expiry.
  *
+ * Visibility-aware refresh: if a background tab's timers were throttled
+ * and the cookie expired, attempts a One Tap refresh before logging out.
+ *
  * During refresh, a 401 from /auth/me is handled gracefully: the hook
  * shows a loading state (not the login screen) while the refresh is
  * in progress.
@@ -56,6 +59,9 @@ export function useAuth() {
     return () => { cancelled = true; };
   }, []);
 
+  const cookieExpired = () =>
+    cookieSetAt.current > 0 && Date.now() >= cookieSetAt.current + COOKIE_MAX_AGE_MS;
+
   // One Tap: disabled until refreshEnabled is set. When enabled with
   // auto_select, it silently returns a credential if the user has an
   // active Google session — no UI shown.
@@ -67,30 +73,33 @@ export function useAuth() {
             if (me) {
               setAuth(me);
               cookieSetAt.current = Date.now();
+            } else if (cookieExpired()) {
+              setAuth(null);
             }
           })
           .catch(() => {
-            // Refresh failed — let hard expiry handle it.
+            if (cookieExpired()) setAuth(null);
           })
           .finally(() => {
             isRefreshing.current = false;
           });
       } else {
         isRefreshing.current = false;
+        if (cookieExpired()) setAuth(null);
       }
       setRefreshEnabled(false);
     },
     onError: () => {
       isRefreshing.current = false;
       setRefreshEnabled(false);
+      if (cookieExpired()) setAuth(null);
     },
     auto_select: true,
     disabled: !refreshEnabled,
   });
 
-  // When the tab becomes visible again, check if the cookie is still valid.
-  // Browsers throttle/suspend setTimeout in background tabs, so the refresh
-  // and expiry timers may not fire before the cookie actually expires.
+  // On visibility change, verify the cookie. If expired, try One Tap
+  // refresh before logging out (timers may not have fired in background).
   useEffect(() => {
     if (!auth) return;
 
@@ -105,7 +114,9 @@ export function useAuth() {
             cookieSetAt.current = Date.now();
             setAuth(me);
           } else {
-            setAuth(null);
+            // Cookie expired — try One Tap refresh before logging out.
+            isRefreshing.current = true;
+            setRefreshEnabled(true);
           }
         })
         .catch(() => {


### PR DESCRIPTION
## Summary

Fixes #118.

When a background tab becomes visible after the auth cookie has expired, the `visibilitychange` handler now attempts a silent Google One Tap refresh before logging the user out.

Previously, the handler only called `/auth/me` — if the cookie had expired, it immediately cleared auth and showed the login screen. This was fine on Chrome (which keeps background timers running long enough for the 55-minute refresh timer to fire), but Safari and Firefox aggressively throttle/suspend timers in background tabs, so the refresh never happened.

The server's `/auth/refresh` endpoint validates the **new** Google credential, not the existing cookie, so this works even after the cookie has fully expired.

If the One Tap refresh also fails (e.g. Google session expired too), the user is logged out as before. The failure paths use a `cookieExpired()` timestamp check rather than tracking refresh origin, so the same logic works correctly for both timer-triggered and visibility-triggered refreshes.