### PR TITLE
Add workflow_dispatch trigger to CI workflows

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -1,5 +1,6 @@
 name: Test Suite
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/ts-test-suite.yml
+++ b/.github/workflows/ts-test-suite.yml
@@ -1,5 +1,6 @@
 name: TS Test Suite
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
Enables manual triggering of both the Rust test suite and the TS/WASM test suite
from the Actions UI or `gh workflow run`.

Needed to verify whether the nightly Rust regression (externref vs i32 in WASM builds)
affects main — see #116 for context.