### PR TITLE
Remove script-dir push/pop from WASM dofile override

### DIFF
--- a/claude-notes/designs/lua-wasm.md
+++ b/claude-notes/designs/lua-wasm.md
@@ -273,7 +273,18 @@ This is sufficient for Quarto's Lua filter API — filters use `pandoc.*`
 constructors (registered by our Rust code) and standard string/table/math
 operations.
 
-### 6. SystemRuntime threading for VFS-based filter reading
+### 6. `dofile`/`loadfile` overrides for VFS
+
+On native, Lua's C `dofile`/`loadfile` use `fopen` to read files. On WASM,
+`fopen` returns null (stub in `c_shim.rs`), so `dofile_wasm.rs` overrides both
+globals with Rust implementations backed by `SystemRuntime::file_read_string()`.
+
+The overrides handle file I/O only — they resolve relative paths against the
+current script dir (for VFS compatibility) but do not push/pop the script-dir
+stack. This matches native Lua and Pandoc/TS Quarto behavior, where `dofile`
+does not affect path resolution for nested calls.
+
+### 7. SystemRuntime threading for VFS-based filter reading
 
 The Lua filter engine previously used `std::fs::read_to_string()` to read
 filter files. On WASM, there's no filesystem — files live in the VFS. The fix
@@ -376,7 +387,8 @@ pcall, and end-to-end filter through the full render pipeline.
   VFS for filters that read auxiliary data files.
 
 - **`require()` support**: Could implement a VFS-backed module loader so
-  filters can `require` other Lua files from the project.
+  filters can `require` other Lua files from the project. (`dofile`/`loadfile`
+  already work via VFS — see component 6.)
 
 - **Streaming compilation**: Lua source is compiled to bytecode on every render.
   Could cache compiled bytecode in the VFS for frequently-used filters.

--- a/claude-notes/plans/2026-04-01-lua-api-quarto-doc.md
+++ b/claude-notes/plans/2026-04-01-lua-api-quarto-doc.md
@@ -152,43 +152,31 @@ executing script file, tracked via the script-dir stack.
   - `shortcode.rs`: push the handler's script dir before each handler
     call, pop after
 
-- [x] **2.2** In the restricted Lua setup path
-  (`#[cfg(any(target_arch = "wasm32", test))]`) in both `filter.rs`
-  and `shortcode.rs`, after registering synthetic io/os, overwrite
-  `dofile` and `loadfile` globals with Rust functions that:
-  - Read the file via `runtime.file_read_string()` (need string
-    content for Lua source)
-  - **Push** the loaded file's directory onto the script-dir stack
-    before execution, **pop** after (so that nested `resolve_path`
-    calls resolve against the loaded file's directory)
+- [x] **2.2** On WASM (`#[cfg(target_arch = "wasm32")]`), overwrite
+  `dofile` and `loadfile` globals with Rust functions that read files
+  via `runtime.file_read_string()` (since C `fopen` returns null on
+  WASM). These overrides handle file I/O only — they do NOT modify
+  the script-dir stack, matching native Lua and Pandoc/TS Quarto
+  behavior.
   - Compile via `lua.load(content).set_name(filename)`
   - For `dofile`: execute immediately and return all results
   - For `loadfile`: return the compiled chunk without executing
-    (no stack push/pop — the chunk hasn't run yet; the caller may
-    run it later)
   - On error, `loadfile` returns `(nil, error_message)` matching Lua
     semantics; `dofile` propagates the error
 
-  The native code path is left alone — C `fopen` works fine there and
-  we don't need to force all file access through `SystemRuntime` on
-  native.
+  The native code path is left alone — C `fopen` works fine there.
 
   **Path resolution for dofile/loadfile**: resolve relative paths
   against the current script dir (top of stack), matching
   `resolve_path` behavior. If the stack is empty, use the path as-is.
-  In the restricted env (WASM/test), also apply the `/project/` prefix
-  for paths that aren't absolute, matching `io_wasm.rs` conventions.
+  On WASM, also apply the `/project/` prefix for paths that aren't
+  absolute, matching `io_wasm.rs` conventions.
 
 - [x] **2.3** Unit tests:
   - `dofile("path/to/script.lua")` executes and returns values
   - `loadfile("path/to/script.lua")` returns a callable chunk
   - `dofile` with nonexistent file returns an error
   - `loadfile` with nonexistent file returns `(nil, error_message)`
-  - Test in both filter and shortcode contexts
-  - **Script-dir stack test**: extension in `/ext/` calls
-    `dofile("/ext/helpers/ui.lua")`, and `ui.lua` calls
-    `quarto.utils.resolve_path("style.css")` — should resolve to
-    `/ext/helpers/style.css`, not `/ext/style.css`
 
 ### Phase 3: `quarto.doc` namespace
 
@@ -392,17 +380,19 @@ queries fall through to exact match only.
 TS Quarto maintains a Lua-side stack of script file paths
 (`scriptFile = {}`) via `_quarto.withScriptFile(file, callback)`. The
 `scriptDir()` function returns the directory of the topmost entry.
-This is needed because extensions can `dofile()` helpers from
-subdirectories, and those helpers may register dependencies with
-relative paths that should resolve against their own directory.
+This is used for resolving relative paths in `add_html_dependency`
+and `resolve_path`.
 
 Our previous flat `_quarto_script_dir` global would resolve all paths
-against the outermost script's directory, which is wrong when a helper
-in a subdirectory registers a dependency.
+against the outermost script's directory, which is wrong when nested
+script execution changes the active directory.
 
 We implement the stack in Lua (matching TS Quarto) with push/pop
-functions callable from both Lua and Rust. The `dofile` override
-pushes the loaded file's directory before execution and pops after.
+functions callable from both Lua and Rust. The stack is managed by
+`filter.rs` (push at filter setup, pop after) and `shortcode.rs`
+(push/pop around each handler call). `dofile` does NOT push/pop —
+it uses whatever script dir the caller set, matching native Lua and
+Pandoc/TS Quarto behavior.
 
 ### `add_html_dependency` field support
 
@@ -413,21 +403,16 @@ we emit a "not yet supported" diagnostic via `quarto.warn()` so the
 user knows the field was ignored. For completely unknown fields, we
 error — this catches typos and prevents silent data loss.
 
-### `dofile`/`loadfile` — restricted env only
+### `dofile`/`loadfile` — WASM file I/O only
 
 On native, the C `fopen`-based implementations work fine. We only
-overwrite in the restricted Lua environment (`#[cfg(any(target_arch =
-"wasm32", test))]`) where C file I/O doesn't work. This matches the
-pattern used for `io.open` (in `io_wasm.rs`) and `os.*` (in
-`os_wasm.rs`).
+overwrite on WASM (`#[cfg(target_arch = "wasm32")]`) where C file I/O
+doesn't work. This matches the pattern used for `io.open` (in
+`io_wasm.rs`) and `os.*` (in `os_wasm.rs`).
 
-Note: `loadfile` does NOT push/pop the script-dir stack — it returns
-an unexecuted chunk. The stack push/pop happens when `dofile` executes
-the chunk. If the user calls `loadfile` then manually executes the
-chunk, paths will resolve against whatever script dir is current at
-execution time — this matches TS Quarto's behavior (only
-`withScriptFile` manages the stack, and only `dofile`-like paths use
-it).
+The overrides handle file I/O only — they do not modify the script-dir
+stack, matching native Lua and Pandoc/TS Quarto behavior. Neither
+Pandoc nor TS Quarto provides script-dir tracking for raw `dofile()`.
 
 ### Return type unchanged in Plan A
 

--- a/crates/pampa/src/lua/dofile_wasm.rs
+++ b/crates/pampa/src/lua/dofile_wasm.rs
@@ -1,18 +1,16 @@
 /*
  * dofile_wasm.rs
  *
- * Override `dofile` and `loadfile` globals for WASM and test environments.
+ * Override `dofile` and `loadfile` globals for WASM environments.
  *
  * On native, the C `fopen`-based implementations from mlua's base library
  * work fine. On WASM, `fopen` returns null (from `c_shim.rs`), so we need
  * Rust implementations backed by SystemRuntime.
  *
- * `dofile` pushes the loaded file's directory onto the script-dir stack
- * before execution and pops after, so that nested `resolve_path` calls
- * resolve against the loaded file's directory.
- *
- * `loadfile` does NOT push/pop — it returns an unexecuted chunk. The
- * script dir at execution time determines path resolution.
+ * These overrides handle file I/O only. They do NOT modify the script-dir
+ * stack — path resolution during execution uses whatever script dir was
+ * set by the caller (filter.rs or shortcode.rs), matching native Lua and
+ * Pandoc/TS Quarto behavior.
  */
 
 use std::path::Path;
@@ -20,7 +18,7 @@ use std::sync::Arc;
 
 use mlua::{Lua, MultiValue, Result, Value};
 
-use super::quarto_api::{current_script_dir, pop_script_dir, push_script_dir};
+use super::quarto_api::current_script_dir;
 use super::runtime::SystemRuntime;
 
 /// Resolve a path for dofile/loadfile in the restricted environment.
@@ -46,7 +44,7 @@ fn resolve_dofile_path(lua: &Lua, path: &str) -> Result<String> {
 
 /// Register `dofile` and `loadfile` overrides for the restricted Lua environment.
 pub fn register_wasm_dofile(lua: &Lua, runtime: Arc<dyn SystemRuntime>) -> Result<()> {
-    // dofile(path) — read, compile, push script dir, execute, pop, return results
+    // dofile(path) — read, compile, execute, return results
     let rt = runtime.clone();
     lua.globals().set(
         "dofile",
@@ -57,21 +55,7 @@ pub fn register_wasm_dofile(lua: &Lua, runtime: Arc<dyn SystemRuntime>) -> Resul
                 mlua::Error::runtime(format!("dofile: cannot read '{}': {}", path, e))
             })?;
 
-            let chunk = lua.load(&content).set_name(&path);
-
-            // Push the loaded file's directory onto the script-dir stack
-            let file_dir = Path::new(&resolved)
-                .parent()
-                .unwrap_or(Path::new(""))
-                .to_string_lossy()
-                .to_string();
-            push_script_dir(lua, &file_dir)?;
-
-            let result = chunk.eval::<MultiValue>();
-
-            pop_script_dir(lua)?;
-
-            result
+            lua.load(&content).set_name(&path).eval::<MultiValue>()
         })?,
     )?;
 
@@ -111,7 +95,6 @@ mod tests {
     use crate::pandoc::ASTContext;
     use crate::pandoc::*;
     use std::fs;
-    use std::path::Path;
     use std::sync::Arc;
     use tempfile::TempDir;
 
@@ -271,68 +254,6 @@ end
         match &filtered.blocks[0] {
             Block::Paragraph(p) => match &p.content[0] {
                 Inline::Str(s) => assert_eq!(s.text, "nil-plus-error"),
-                other => panic!("Expected Str, got {:?}", other),
-            },
-            other => panic!("Expected Paragraph, got {:?}", other),
-        }
-    }
-
-    // This test requires register_wasm_dofile (which pushes/pops the script-dir
-    // stack around dofile calls). On native, the C Lua dofile doesn't interact
-    // with the stack, so resolve_path resolves against the top-level filter dir.
-    // The WASM dofile reimplementation provides this feature; adding it to native
-    // is tracked as a follow-up improvement.
-    #[tokio::test]
-    #[cfg_attr(not(target_arch = "wasm32"), ignore)]
-    async fn test_dofile_script_dir_stack() {
-        // Extension in /ext/ calls dofile("helpers/ui.lua"), and ui.lua calls
-        // quarto.utils.resolve_path("style.css") — should resolve to
-        // /ext/helpers/style.css, not /ext/style.css
-        let dir = TempDir::new().unwrap();
-
-        // Create helpers subdirectory
-        let helpers_dir = dir.path().join("helpers");
-        fs::create_dir(&helpers_dir).unwrap();
-
-        let helper_path = helpers_dir.join("ui.lua");
-        fs::write(
-            &helper_path,
-            r#"return quarto.utils.resolve_path("style.css")"#,
-        )
-        .unwrap();
-
-        let filter_path = dir.path().join("filter.lua");
-        fs::write(
-            &filter_path,
-            &format!(
-                r#"
-local resolved = dofile("{}")
-function Str(elem)
-    return pandoc.Str(resolved)
-end
-"#,
-                helper_path.to_string_lossy().replace('\\', "/")
-            ),
-        )
-        .unwrap();
-
-        let pandoc = empty_pandoc();
-        let context = ASTContext::new();
-        let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-            .await
-            .unwrap()
-            .pandoc;
-
-        match &filtered.blocks[0] {
-            Block::Paragraph(p) => match &p.content[0] {
-                Inline::Str(s) => {
-                    let expected = helpers_dir.join("style.css").to_string_lossy().to_string();
-                    assert_eq!(
-                        quarto_util::to_forward_slashes(Path::new(&s.text)),
-                        quarto_util::to_forward_slashes(Path::new(&expected)),
-                        "resolve_path inside dofile'd helper should resolve against helper's dir"
-                    );
-                }
                 other => panic!("Expected Str, got {:?}", other),
             },
             other => panic!("Expected Paragraph, got {:?}", other),


### PR DESCRIPTION
## Summary

- Remove script-dir stack push/pop from the WASM `dofile` override in `dofile_wasm.rs`, making it a pure file I/O shim
- Remove the `test_dofile_script_dir_stack` test that validated the removed behavior
- Update plan (`2026-04-01-lua-api-quarto-doc.md`) and design doc (`lua-wasm.md`) to reflect the change

## Context

The WASM `dofile` override was pushing/popping the script-dir stack around each call, causing `resolve_path` inside dofile'd scripts to resolve relative to the loaded file's directory. Native Lua's C `dofile` doesn't do this, nor do Pandoc or TS Quarto. No built-in extension relies on this behavior — the video extension's `dofile` call passes an already-resolved absolute path.

This eliminates the behavioral divergence by aligning WASM with native: option (2) from the issue discussion.

Closes #112

## Test plan

- [x] `cargo nextest run -p pampa` — 3700 passed, 2 skipped
- [x] `cargo nextest run --workspace` — 7263 passed, 195 skipped
- [x] `cargo build --workspace` — clean