### PR TITLE
Replace OT cursor tracking with Automerge cursors in presence

### DIFF
--- a/claude-notes/plans/2026-04-21-automerge-cursors-for-presence.md
+++ b/claude-notes/plans/2026-04-21-automerge-cursors-for-presence.md
@@ -1,0 +1,481 @@
+# Replace OT cursor tracking with Automerge cursors in hub-client presence
+
+Beads: TBD (tracks [issue #113](https://github.com/quarto-dev/q2/issues/113))
+
+## Overview
+
+Hub-client's presence system (`hub-client/src/hooks/usePresence.ts`) currently
+broadcasts remote cursor/selection positions as raw character offsets and then
+runs hand-rolled operational transformation locally on every
+`onDidChangeContent` to keep stored offsets valid between presence ticks. The
+OT code includes two heuristic guards (`anticipatingEditRef` and a
+same-line check) that exist solely to paper over the async gap between
+presence messages and matching content changes.
+
+Issue #113 suggests replacing this with [Automerge
+cursors](https://automerge.org/automerge/automerge/struct.Cursor.html). The
+file content is already an Automerge Text sequence edited via `splice(doc,
+['text'], ...)` (`ts-packages/quarto-sync-client/src/client.ts:538`), so a
+cursor anchored to `['text']` is the natural position-stable token: it
+shifts automatically under concurrent edits and resolves, on the receiver,
+to a valid offset in *their* current doc state.
+
+The JS binding gives us exactly what we need:
+
+- `A.getCursor(doc, ['text'], position: number | 'start' | 'end', move?: 'before' | 'after'): Cursor` (string)
+- `A.getCursorPosition(doc, ['text'], cursor): number`
+
+### Goals
+
+1. Delete the OT machinery (`transformOffset`, `PeerCursorState` OT fields,
+   the `onDidChangeContent` OT effect, `anticipatingEditRef`, and the
+   same-line guard). Keep `modelVersion` (still needed to drive
+   re-resolution of Automerge cursors when the doc changes — see
+   "Receiver path").
+2. Preserve the fix from PR #94 (deletion in one paragraph must not shift
+   remote cursors in subsequent paragraphs).
+3. Leave the wire-level regression surface the same or better: in particular,
+   no new cursor flicker on the typing-plus-lag scenario the anticipation
+   code was protecting against.
+
+### Non-goals
+
+- Changing the transport (still Automerge ephemeral messaging).
+- Changing how selections are modelled beyond "two cursors, start and end".
+- Any server-side changes.
+
+## Design sketch
+
+### Wire format change
+
+`PresenceMessage` (`hub-client/src/services/presenceService.ts:30`) currently
+carries:
+
+```ts
+cursor: number | null;
+selection: { start: number; end: number } | null;
+```
+
+Change to:
+
+```ts
+cursor: string | null;                                // Automerge Cursor
+selection: { start: string; end: string } | null;     // two cursors
+```
+
+Cursor strings are opaque; both ends of the wire treat them as blobs and
+only resolve on the receiver's own doc.
+
+**Mixed-version rollout.** This is a breaking wire-format change for
+ephemeral presence messages. During the window between deploy and all
+clients refreshing:
+
+- Old clients receiving new messages interpret `cursor` as a number and
+  pass the string through `model.getPositionAt(...)`, which coerces to
+  `NaN`. The existing `try { ... } catch {}` around decoration placement
+  in `usePresence.ts` swallows the error, so the old client silently drops
+  the new client's cursor decoration.
+- New clients receiving old messages pass a number into
+  `A.getCursorPosition`, which throws `RangeError`. Phase 3's per-peer
+  `try/catch (RangeError) { continue; }` swallows it — the new client
+  silently drops the old client's cursor decoration.
+
+Net effect: mixed-version peers can't see each other's cursors, but no
+one crashes and decorations recover as soon as both sides are on new
+code. Ephemeral messages are not persisted, so nothing lingers past a
+refresh. This is acceptable for the hub-client's auto-update model; no
+schema-version field or transitional dual-send is added.
+
+### Sender path
+
+In `presenceService.ts`, `updatePresence(cursorOffset, selectionRange)` still
+receives Monaco offsets (callers in `usePresence.ts:466-476` don't change).
+Inside the service, convert each offset to an Automerge cursor using the
+current `state.currentHandle.doc()` (`docSync()` is deprecated as of
+`@automerge/automerge-repo` 2.5.1 — see
+`node_modules/@automerge/automerge-repo/dist/DocHandle.d.ts:79-83`):
+
+```ts
+const doc = state.currentHandle.doc();
+const cursor = offset !== null ? A.getCursor(doc, ['text'], offset) : null;
+```
+
+**Ordering is already satisfied by the existing architecture** (no fix
+needed, but worth verifying with a regression test — see Phase 4):
+
+Monaco fires `onDidChangeModelContent` synchronously before
+`onDidChangeCursorSelection`. The content path
+(`useAutomergeSync.ts:155-163` `handleEditorChange` → `App.tsx:429-431`
+`handleContentOperations` → `automergeSync.ts:185-186`
+`applyEditorOperations` → `ts-packages/quarto-sync-client/src/client.ts:535-540`
+`handle.change(doc => splice(...))`) is entirely synchronous. By the
+time the cursor-selection handler in `usePresence.ts:480` runs, the
+Automerge doc already reflects the edit. So any `handle.doc()` +
+`A.getCursor(...)` call from `broadcastPresence` — whether it fires
+immediately on the throttle boundary or from the trailing-edge
+`setTimeout` — sees post-edit state.
+
+The previously stated fallback (sender broadcasts cursor anchored to
+pre-edit position, self-heals on next tick) is therefore moot in the
+current architecture. Phase 4 adds a regression test to prevent a
+future refactor from breaking this invariant.
+
+### Receiver path
+
+`handleEphemeralMessage` stores the cursor/selection strings as received
+(no offset resolution). `PresenceState.cursor` becomes `string | null`
+and `PresenceState.selection` becomes `{ start: string; end: string } |
+null` — the same types as the wire. Resolution to numeric offsets
+happens inside `usePresence.ts`, per-render, against the current local
+doc:
+
+```ts
+let offset: number;
+try {
+  offset = A.getCursorPosition(doc, ['text'], cursor);
+} catch {
+  // Cursor references an op we haven't synced yet; skip decoration
+  // until the content change arrives and a re-render resolves it.
+  continue;
+}
+```
+
+`getCursorPosition` throws `RangeError` when the cursor references an op
+the local doc doesn't have (see
+`node_modules/@automerge/automerge/dist/mjs/next_slim.js:373-382`).
+Treat the throw as "not yet resolvable" and drop the decoration for this
+render; the next `onDidChangeContent` after the op syncs will re-render
+successfully.
+
+`usePresence.ts` becomes much simpler:
+
+- No `PeerCursorState` map, no OT effect, no `anticipatingEditRef`.
+- On each render (triggered by `remoteUsers` change *and* by an
+  `onDidChangeContent`-driven bump), resolve each peer's cursor/selection
+  strings against the current doc and place Monaco decorations.
+- Keep a minimal `modelVersion` bump from `onDidChangeContent`, but for a
+  different reason than today: stored cursor strings don't change, but
+  their *resolved offsets* do when the underlying doc changes (local or
+  remote). Without a re-render, decorations would stick at stale offsets
+  until the next presence message arrived. Remote edits reach this path
+  via `automergeSync.ts`' `immediateFileChangeCallback`, which applies
+  remote diffs to Monaco and triggers `onDidChangeContent`, so the same
+  bump covers both local and remote edits.
+
+#### New coupling: `usePresence.ts` → `automergeSync.ts`
+
+Today, `usePresence.ts` talks only to `presenceService.ts`. To resolve
+cursor strings it now needs the current Automerge doc, which lives on
+the handle returned by `automergeSync`'s `getFileHandle(path)`. Rather
+than push resolution into `presenceService` (which would need to
+re-resolve whenever the doc changes, duplicating the `modelVersion`
+bump), add an import in `usePresence.ts`:
+
+```ts
+import { getFileHandle } from '../services/automergeSync';
+// ...
+const handle = getFileHandle(currentFilePath);
+const doc = handle?.doc();
+```
+
+This is a minor coupling increase but keeps resolution co-located with
+the render that consumes it.
+
+### Edge cases
+
+Resolved empirically against `@automerge/automerge` 2.2.9 with a probe
+script (node REPL + `A.getCursor`/`getCursorPosition` on `A.from({text:
+''})` etc.):
+
+- **Cursor at EOF**: no bias needed. `getCursor(doc, ['text'], docLength)`
+  returns the sentinel `"e"` (end) which tracks the end of the sequence
+  through subsequent insertions automatically. The `move` bias turns out
+  not to matter at EOF — default, `'after'`, and `'before'` all produce
+  the same result.
+- **Empty doc**: `getCursor(doc, ['text'], 0)` on empty text returns the
+  `"e"` sentinel and resolves back to 0. Works fine, no special case.
+- **Past EOF**: `getCursor(doc, ['text'], 999)` on a short doc doesn't
+  throw — it clamps and returns the end sentinel. Robust to offset drift
+  at the sender if it ever happens.
+- **Mid-doc bias (cursor and selection start)**: default `move` is
+  `'after'` (`node_modules/@automerge/automerge/dist/wasm_types.d.ts:32-34`),
+  which anchors to the character *at* the given offset, so subsequent
+  insertions-at-that-offset push the cursor forward (the cursor stays on
+  the logical character). This is the behaviour we want for carets and
+  for the **start** of a selection — no need to pass `move` explicitly.
+- **Selection end**: pass `move: 'before'`. With the default `'after'`,
+  inserts at the end boundary would be swept into the selection ("the
+  selection grows to include chars I just typed at its edge"), which is
+  surprising UX. `'before'` anchors to the character *just before* the
+  end boundary, so inserts at the boundary stay *outside* the selection.
+- **Selection collapsed** (`start === end`): treat as cursor-only, same as
+  today.
+- **Peer on a file we don't have the doc for yet**: can't resolve; drop the
+  decoration until the doc arrives. Today's code has the equivalent
+  behaviour through `getFileHandle(filePath)` returning null.
+
+### What `anticipatingEditRef` and the same-line guard did, and why we don't
+### need them anymore
+
+Both exist because, with offset-based presence, a fresh presence message
+from peer A carrying a *post-insert* offset could arrive before A's content
+change synced into our doc. The OT code would then wrongly shift the
+already-post-insert offset again when the content change landed.
+
+With Automerge cursors, the receiver *always* resolves against its own
+current doc state. If A's content change hasn't arrived, one of two
+things happens when we call `getCursorPosition`:
+
+1. The cursor references an op *we already have* (typical — Automerge
+   sync tends to deliver ops in causal order). Resolves to a sensible
+   offset in our pre-insert text.
+2. The cursor references an op *we haven't received yet*.
+   `getCursorPosition` throws `RangeError`
+   (`node_modules/@automerge/automerge/dist/mjs/next_slim.js:373-382`).
+   We catch and skip the decoration for this render. Automerge does
+   **not** have a documented "resolve to nearest known position"
+   fallback; an unknown cursor throws.
+
+In either case, once the content change syncs, the next render
+(triggered by `onDidChangeContent` via `immediateFileChangeCallback`)
+resolves the same cursor to the correct offset. No double-shift is
+possible because we never shift — we query.
+
+## Test plan (written first, TDD)
+
+### Phase 1 tests — lock in PR #94 behaviour before refactoring
+
+File: `hub-client/src/hooks/usePresence.test.ts` (new).
+
+These tests exercise the hook against a mocked Monaco editor + mocked
+Automerge doc and assert on the decoration positions the hook would apply.
+
+- [ ] **Test: deletion in an earlier paragraph does not shift a remote
+      cursor in a later paragraph** — the original #9 regression. Set up a
+      three-paragraph document, place a remote cursor in paragraph 3,
+      delete two characters from paragraph 1 locally, assert the remote
+      cursor's resolved offset decreases by 2 (i.e., it tracks the same
+      logical character).
+- [ ] **Test: local insertion before a remote cursor shifts it forward**
+      by the inserted length.
+- [ ] **Test: local deletion across a remote cursor clamps it to the end
+      of the replacement text**.
+- [ ] **Test: remote cursor arrives before its corresponding content
+      change** — the race that `anticipatingEditRef` guards today. Simulate
+      a presence update that anticipates a 1-char insertion, then deliver
+      the content change, and assert the cursor ends at the right offset
+      without double-shift.
+- [ ] **Test: remote cursor at end-of-line, presence before content
+      change** — the scenario PR #110 (3bd3ebc0) fixed with the same-line
+      guard. Simulate a peer typing a character at EOL, deliver the
+      presence update (with post-edit offset) before the content change,
+      and assert the remote cursor decoration does not appear on the
+      following line at any point. Under OT this exercises the same-line
+      guard; under Automerge cursors it's impossible by construction
+      (an unsynced op either resolves in the current doc or throws and we
+      skip). Locking it in guards against a future regression.
+
+These tests must pass on the current OT implementation *before* starting
+the refactor. If any fail, fix the test or surface the bug via a separate
+issue first.
+
+### Phase 2 tests — presenceService wire-format tests
+
+File: `hub-client/src/services/presenceService.test.ts` (extend).
+
+- [ ] **Test: broadcast carries cursor as an Automerge cursor string, not
+      a number**. Mock `getFileHandle` to return a fake handle with
+      `doc()` returning a doc with a known `['text']`; call
+      `updatePresence(5, null)`; assert the ephemeral message's `cursor`
+      field is a string whose `A.getCursorPosition` resolves back to 5.
+- [ ] **Test: selection carries start+end cursor strings** that resolve
+      back to the original range. Assert `selection.end` was created
+      with `move: 'before'` by appending a character at the original
+      end-offset and confirming the resolved end does *not* move past
+      the appended character.
+- [ ] **Test: null cursor/selection pass through as null**.
+- [ ] **Test: broadcast is a no-op if the handle is unavailable** — we
+      can't make a cursor without a doc; skip the broadcast rather than
+      crash (matches today's behaviour when `state.currentHandle` is
+      null).
+- [ ] **Test: broadcast is a no-op if `handle.doc()` throws** — mock a
+      handle whose `doc()` throws (simulating the deleted/unavailable
+      case flagged in `DocHandle.d.ts`); assert `broadcast` is not
+      called and no exception escapes `broadcastPresence`.
+- [ ] **Test: incoming ephemeral messages store cursor strings unchanged**
+      in `remotePresences`.
+
+### Phase 3 tests — end-to-end race scenarios
+
+Extend Phase 1 tests to verify the new implementation:
+
+- [ ] **Test: presence-before-content-change no longer needs anticipation**.
+      Receive a presence message whose cursor string references an op
+      not yet present in our doc; assert that `getCursorPosition` throws
+      `RangeError` and the hook skips the decoration for this render
+      (no crash, no other peers' decorations affected). Then apply the
+      content change and assert the cursor resolves to the intended
+      offset on the next render.
+- [ ] **Test: two concurrent remote edits** — two peers insert into the
+      same paragraph. Assert a third peer's cursor, anchored after the
+      insertions, ends at the correct offset regardless of merge order.
+      This was not testable under OT because the OT code assumed a single
+      linear stream of local edits.
+
+## Work Items
+
+### Phase 1 — characterise current behaviour
+
+- [ ] Create `hub-client/src/hooks/usePresence.test.ts` with a minimal
+      Monaco + Automerge test harness (mock `@monaco-editor/react`, use a
+      real Automerge doc for fidelity).
+- [ ] Write the five Phase-1 tests above (four PR #94 tests plus the
+      PR #110 EOL regression test) and verify they pass on the current
+      OT implementation.
+- [ ] Commit as "test: cover OT cursor tracking race cases before refactor".
+
+### Phase 2 — presenceService wire-format change + usePresence.ts rewrite
+
+**Phases 2 and 3 land as a single commit.** Splitting them leaves an
+intermediate state that doesn't typecheck: as soon as
+`PresenceState.cursor` becomes `string | null`, the OT code in
+`usePresence.ts` (which does numeric arithmetic on `state.cursor` and
+compares `state.lastPresenceCursor !== user.cursor`) is nonsense. The
+refactor is structured as two phases below for clarity of review, but
+the work items are ordered so the code compiles continuously: update
+the types and broadcast path, then immediately delete the OT machinery
+in the *same* commit.
+
+- [ ] Change `PresenceMessage.cursor` to `string | null` and
+      `PresenceMessage.selection` to `{ start: string; end: string } | null`.
+- [ ] Change `PresenceState.cursor` to `string | null` and
+      `PresenceState.selection` to `{ start: string; end: string } | null`
+      (same types as the wire — the service stores what it received).
+      Update all consumers to reflect the new types; numeric resolution
+      moves into `usePresence.ts` in Phase 3.
+- [ ] Update `broadcastPresence` to call `A.getCursor` with the current
+      handle's `doc()` (not `docSync()` — deprecated in
+      `@automerge/automerge-repo` 2.5.1) before sending. Use default
+      `move: 'after'` for the caret and for `selection.start`; use
+      `move: 'before'` for `selection.end`.
+- [ ] Handle both the handle-unavailable and doc-unavailable cases: skip
+      the broadcast when `state.currentHandle` is null (as today) *and*
+      wrap the `handle.doc()` call in `try/catch` — per
+      `node_modules/@automerge/automerge-repo/dist/DocHandle.d.ts:76`,
+      `doc()` throws on deleted or unavailable documents. A thrown
+      `doc()` should be a silent skip, matching the handle-null
+      behaviour; a stale or absent doc isn't a crash-worthy condition
+      in a 50 ms-throttled broadcaster. Empty doc is not a special
+      case: `A.getCursor(doc, ['text'], 0)` on empty text returns the
+      end sentinel per the probe script — verify at test time.
+- [ ] Write and pass the Phase-2 tests.
+- [ ] Continue immediately into Phase 3 in the same commit — do *not*
+      commit wire-format changes in isolation (see phase-merge note
+      above).
+
+### Phase 3 — usePresence.ts simplification (same commit as Phase 2)
+
+- [ ] Delete `transformOffset`, `PeerCursorState`, `peerStateRef`,
+      `anticipatingEditRef`, the `onDidChangeContent` OT effect, and the
+      same-line guard.
+- [ ] Keep the `modelVersion` state + `onDidChangeContent` bump (still
+      needed — see "Design sketch → Receiver path") but slim the effect
+      down to only the bump, no OT loop. Update the comment to reflect
+      the new role ("re-resolve Automerge cursors against the updated
+      doc").
+- [ ] Add `import { getFileHandle } from '../services/automergeSync'`
+      (new coupling — see "Design sketch → Receiver path → New
+      coupling"). In the render effect, obtain the doc via
+      `getFileHandle(currentFilePath)?.doc()`. Wrap the `doc()` call in
+      try/catch as well — `DocHandle.d.ts` flags `doc()` as throwing on
+      deleted/unavailable docs, and a throw here would kill the render
+      effect for every peer, not just the unsynced one. On throw, bail
+      out of this render (no decorations applied); the next content
+      change or `remoteUsers` update re-runs the effect.
+- [ ] In the render effect, call `A.getCursorPosition(doc, ['text'],
+      cursor)` for each peer's stored cursor/selection strings and place
+      Monaco decorations from the resolved offsets. Wrap each call in
+      `try/catch (RangeError)` and `continue` on throw — an unsynced
+      cursor should drop the decoration for this render, not crash the
+      effect or block other peers' decorations.
+- [ ] Add Phase-3 tests and verify them pass.
+- [ ] Verify Phase-1 tests still pass under the new implementation.
+- [ ] Commit as "refactor(presence): replace OT offset tracking with
+      Automerge cursors (fixes #113)".
+
+### Phase 4 — sender-side ordering regression test
+
+Ordering is already satisfied by the existing architecture (see "Design
+sketch → Sender path"): Monaco fires content changes synchronously
+before cursor-selection changes, and the content path through
+`handleEditorChange` → `applyEditorOperations` → `splice(...)` is fully
+synchronous. This phase locks that invariant in with a test so a future
+refactor can't quietly break it.
+
+- [ ] Add a test in `hub-client/src/services/presenceService.test.ts`
+      that drives a synthetic Monaco edit (via the mocked editor +
+      `handleEditorChange` path) immediately followed by a cursor
+      broadcast, and asserts the broadcast cursor string resolves to
+      the post-edit offset on a separate receiver doc. If the sender
+      read pre-edit state, the cursor would resolve to a stale offset
+      and the test would fail.
+- [ ] Commit as "test(presence): lock in sender-side cursor ordering".
+
+### Phase 5 — verification and changelog
+
+- [ ] Run `cd hub-client && npm run build:all` (per CLAUDE.md this is
+      stricter than vitest + tsc --noEmit).
+- [ ] Run `cd hub-client && npm run test:ci`.
+- [ ] Run `cargo xtask verify --skip-rust-tests` to confirm the
+      hub-client build and tests pass in the xtask harness. (We skip
+      Rust tests because this is a pure TS change — `quarto-sync-client`
+      is a TypeScript package under `ts-packages/`, not a Rust crate, so
+      Rust test behaviour cannot regress from this work.)
+- [ ] Run the hub-client dev server, open two browser tabs against the
+      same project, type in one tab, and verify remote cursor behaviour
+      by eye — specifically the scenarios PR #94 added: deleting in one
+      paragraph while another peer has a cursor in a later paragraph.
+- [ ] **Performance check**: profile keystroke latency in the hub-client
+      dev server before and after the refactor, using Chrome devtools'
+      Performance panel.
+      - **Simulating peers**: open 3 browser tabs against the same
+        project (two peers + one recorder). Move the cursor to different
+        locations in the two non-recording tabs so their cursor
+        decorations render on the recorder. This exercises the
+        per-render resolution loop over multiple peers.
+      - **Document**: use a ~10k-char qmd file (copy a real project
+        README or a paragraph-repeated fixture; commit as
+        `hub-client/test-fixtures/perf-10k.qmd` if one doesn't exist).
+      - **Measurement**: on the recorder, start the Performance panel
+        recording, hold a key to auto-repeat for ~5 s in the editor,
+        stop recording, and read the mean "Scripting" time per
+        keystroke.
+      - **Target**: the added cost of
+        `getCursor`/`getCursorPosition` WASM calls should be well under
+        1 ms per keystroke. Investigate if it exceeds that.
+- [ ] **Only if the profile shows regression**: add a per-peer resolved-
+      offset cache (`Map<peerId, number>`) in `usePresence.ts`, invalidated
+      when (a) the peer's incoming cursor string changes, or (b)
+      `onDidChangeContent` fires. This avoids re-resolving the same cursor
+      on every render without reintroducing OT or the anticipation
+      heuristic. Do not add this speculatively — it's a small amount of
+      state that's easy to get wrong, and the plan's whole point is to
+      delete such state.
+- [ ] Commit the Automerge cursor-semantics probe script as an
+      executable fixture at
+      `hub-client/src/services/automergeCursor.probe.test.ts` (a vitest
+      file that asserts the edge-case behaviours enumerated in "Design
+      sketch → Edge cases": EOF, empty doc, past-EOF clamp, mid-doc
+      bias, selection-end `'before'` bias). This pins the behaviour to
+      our pinned `@automerge/automerge` version and makes future
+      upgrades catchable via CI.
+- [ ] Two-commit workflow for `hub-client/changelog.md`: first commit the
+      refactor, then a second commit adding a changelog entry with the
+      refactor's hash under today's date header.
+
+## Open questions
+
+All three pre-implementation questions were resolved empirically against
+`@automerge/automerge` 2.2.9 with a probe script; see "Edge cases" and
+"Design sketch → Receiver path" above. No open questions remain at plan
+time. If implementation surfaces new ones, add them here.

--- a/claude-notes/plans/2026-04-21-automerge-cursors-for-presence.md
+++ b/claude-notes/plans/2026-04-21-automerge-cursors-for-presence.md
@@ -203,11 +203,19 @@ script (node REPL + `A.getCursor`/`getCursorPosition` on `A.from({text:
   insertions-at-that-offset push the cursor forward (the cursor stays on
   the logical character). This is the behaviour we want for carets and
   for the **start** of a selection — no need to pass `move` explicitly.
-- **Selection end**: pass `move: 'before'`. With the default `'after'`,
-  inserts at the end boundary would be swept into the selection ("the
-  selection grows to include chars I just typed at its edge"), which is
-  surprising UX. `'before'` anchors to the character *just before* the
-  end boundary, so inserts at the boundary stay *outside* the selection.
+- **Selection end**: the plan originally called for `move: 'before'` to
+  prevent the selection from growing when a char is inserted at the end
+  boundary. **A re-probe against the pinned `@automerge/automerge` 2.2.9
+  during implementation showed this does not work as documented in that
+  version**: `'before'` and `'after'` produce different cursor strings
+  (`N@…` vs `-N@…`) but resolve to *identical* positions after both
+  single-doc insertions and merged concurrent insertions. The `'before'`
+  bias is a no-op in the current binding. If a future Automerge upgrade
+  fixes this, the Phase 5 probe fixture will catch the change and we can
+  revisit; for now, use the default `'after'` for both selection
+  boundaries. The observable consequence is that inserts at the end
+  boundary grow a remote peer's selection — the OT path today has no
+  boundary-aware logic either, so this is not a regression.
 - **Selection collapsed** (`start === end`): treat as cursor-only, same as
   today.
 - **Peer on a file we don't have the doc for yet**: can't resolve; drop the
@@ -289,10 +297,10 @@ File: `hub-client/src/services/presenceService.test.ts` (extend).
       `updatePresence(5, null)`; assert the ephemeral message's `cursor`
       field is a string whose `A.getCursorPosition` resolves back to 5.
 - [ ] **Test: selection carries start+end cursor strings** that resolve
-      back to the original range. Assert `selection.end` was created
-      with `move: 'before'` by appending a character at the original
-      end-offset and confirming the resolved end does *not* move past
-      the appended character.
+      back to the original range. (The originally-planned assertion about
+      `move: 'before'` preventing the end from growing on boundary inserts
+      was dropped — the `move` parameter is a no-op in Automerge 2.2.9.
+      See "Design sketch → Edge cases → Selection end".)
 - [ ] **Test: null cursor/selection pass through as null**.
 - [ ] **Test: broadcast is a no-op if the handle is unavailable** — we
       can't make a cursor without a doc; skip the broadcast rather than
@@ -356,8 +364,10 @@ in the *same* commit.
 - [ ] Update `broadcastPresence` to call `A.getCursor` with the current
       handle's `doc()` (not `docSync()` — deprecated in
       `@automerge/automerge-repo` 2.5.1) before sending. Use default
-      `move: 'after'` for the caret and for `selection.start`; use
-      `move: 'before'` for `selection.end`.
+      `move: 'after'` for all cursors (caret, selection.start,
+      selection.end). The `move: 'before'` call originally planned for
+      selection.end was dropped — see "Design sketch → Edge cases →
+      Selection end" for the re-probe finding.
 - [ ] Handle both the handle-unavailable and doc-unavailable cases: skip
       the broadcast when `state.currentHandle` is null (as today) *and*
       wrap the `handle.doc()` call in `try/catch` — per

--- a/claude-notes/plans/2026-04-21-automerge-cursors-for-presence.md
+++ b/claude-notes/plans/2026-04-21-automerge-cursors-for-presence.md
@@ -258,22 +258,22 @@ File: `hub-client/src/hooks/usePresence.test.ts` (new).
 These tests exercise the hook against a mocked Monaco editor + mocked
 Automerge doc and assert on the decoration positions the hook would apply.
 
-- [ ] **Test: deletion in an earlier paragraph does not shift a remote
+- [x] **Test: deletion in an earlier paragraph does not shift a remote
       cursor in a later paragraph** — the original #9 regression. Set up a
       three-paragraph document, place a remote cursor in paragraph 3,
       delete two characters from paragraph 1 locally, assert the remote
       cursor's resolved offset decreases by 2 (i.e., it tracks the same
       logical character).
-- [ ] **Test: local insertion before a remote cursor shifts it forward**
+- [x] **Test: local insertion before a remote cursor shifts it forward**
       by the inserted length.
-- [ ] **Test: local deletion across a remote cursor clamps it to the end
+- [x] **Test: local deletion across a remote cursor clamps it to the end
       of the replacement text**.
-- [ ] **Test: remote cursor arrives before its corresponding content
+- [x] **Test: remote cursor arrives before its corresponding content
       change** — the race that `anticipatingEditRef` guards today. Simulate
       a presence update that anticipates a 1-char insertion, then deliver
       the content change, and assert the cursor ends at the right offset
       without double-shift.
-- [ ] **Test: remote cursor at end-of-line, presence before content
+- [x] **Test: remote cursor at end-of-line, presence before content
       change** — the scenario PR #110 (3bd3ebc0) fixed with the same-line
       guard. Simulate a peer typing a character at EOL, deliver the
       presence update (with post-edit offset) before the content change,
@@ -291,40 +291,40 @@ issue first.
 
 File: `hub-client/src/services/presenceService.test.ts` (extend).
 
-- [ ] **Test: broadcast carries cursor as an Automerge cursor string, not
+- [x] **Test: broadcast carries cursor as an Automerge cursor string, not
       a number**. Mock `getFileHandle` to return a fake handle with
       `doc()` returning a doc with a known `['text']`; call
       `updatePresence(5, null)`; assert the ephemeral message's `cursor`
       field is a string whose `A.getCursorPosition` resolves back to 5.
-- [ ] **Test: selection carries start+end cursor strings** that resolve
+- [x] **Test: selection carries start+end cursor strings** that resolve
       back to the original range. (The originally-planned assertion about
       `move: 'before'` preventing the end from growing on boundary inserts
       was dropped — the `move` parameter is a no-op in Automerge 2.2.9.
       See "Design sketch → Edge cases → Selection end".)
-- [ ] **Test: null cursor/selection pass through as null**.
-- [ ] **Test: broadcast is a no-op if the handle is unavailable** — we
+- [x] **Test: null cursor/selection pass through as null**.
+- [x] **Test: broadcast is a no-op if the handle is unavailable** — we
       can't make a cursor without a doc; skip the broadcast rather than
       crash (matches today's behaviour when `state.currentHandle` is
       null).
-- [ ] **Test: broadcast is a no-op if `handle.doc()` throws** — mock a
+- [x] **Test: broadcast is a no-op if `handle.doc()` throws** — mock a
       handle whose `doc()` throws (simulating the deleted/unavailable
       case flagged in `DocHandle.d.ts`); assert `broadcast` is not
       called and no exception escapes `broadcastPresence`.
-- [ ] **Test: incoming ephemeral messages store cursor strings unchanged**
+- [x] **Test: incoming ephemeral messages store cursor strings unchanged**
       in `remotePresences`.
 
 ### Phase 3 tests — end-to-end race scenarios
 
 Extend Phase 1 tests to verify the new implementation:
 
-- [ ] **Test: presence-before-content-change no longer needs anticipation**.
+- [x] **Test: presence-before-content-change no longer needs anticipation**.
       Receive a presence message whose cursor string references an op
       not yet present in our doc; assert that `getCursorPosition` throws
       `RangeError` and the hook skips the decoration for this render
       (no crash, no other peers' decorations affected). Then apply the
       content change and assert the cursor resolves to the intended
       offset on the next render.
-- [ ] **Test: two concurrent remote edits** — two peers insert into the
+- [x] **Test: two concurrent remote edits** — two peers insert into the
       same paragraph. Assert a third peer's cursor, anchored after the
       insertions, ends at the correct offset regardless of merge order.
       This was not testable under OT because the OT code assumed a single
@@ -334,13 +334,13 @@ Extend Phase 1 tests to verify the new implementation:
 
 ### Phase 1 — characterise current behaviour
 
-- [ ] Create `hub-client/src/hooks/usePresence.test.ts` with a minimal
+- [x] Create `hub-client/src/hooks/usePresence.test.ts` with a minimal
       Monaco + Automerge test harness (mock `@monaco-editor/react`, use a
       real Automerge doc for fidelity).
-- [ ] Write the five Phase-1 tests above (four PR #94 tests plus the
+- [x] Write the five Phase-1 tests above (four PR #94 tests plus the
       PR #110 EOL regression test) and verify they pass on the current
       OT implementation.
-- [ ] Commit as "test: cover OT cursor tracking race cases before refactor".
+- [x] Commit as "test: cover OT cursor tracking race cases before refactor".
 
 ### Phase 2 — presenceService wire-format change + usePresence.ts rewrite
 
@@ -354,21 +354,21 @@ the work items are ordered so the code compiles continuously: update
 the types and broadcast path, then immediately delete the OT machinery
 in the *same* commit.
 
-- [ ] Change `PresenceMessage.cursor` to `string | null` and
+- [x] Change `PresenceMessage.cursor` to `string | null` and
       `PresenceMessage.selection` to `{ start: string; end: string } | null`.
-- [ ] Change `PresenceState.cursor` to `string | null` and
+- [x] Change `PresenceState.cursor` to `string | null` and
       `PresenceState.selection` to `{ start: string; end: string } | null`
       (same types as the wire — the service stores what it received).
       Update all consumers to reflect the new types; numeric resolution
       moves into `usePresence.ts` in Phase 3.
-- [ ] Update `broadcastPresence` to call `A.getCursor` with the current
+- [x] Update `broadcastPresence` to call `A.getCursor` with the current
       handle's `doc()` (not `docSync()` — deprecated in
       `@automerge/automerge-repo` 2.5.1) before sending. Use default
       `move: 'after'` for all cursors (caret, selection.start,
       selection.end). The `move: 'before'` call originally planned for
       selection.end was dropped — see "Design sketch → Edge cases →
       Selection end" for the re-probe finding.
-- [ ] Handle both the handle-unavailable and doc-unavailable cases: skip
+- [x] Handle both the handle-unavailable and doc-unavailable cases: skip
       the broadcast when `state.currentHandle` is null (as today) *and*
       wrap the `handle.doc()` call in `try/catch` — per
       `node_modules/@automerge/automerge-repo/dist/DocHandle.d.ts:76`,
@@ -378,22 +378,22 @@ in the *same* commit.
       in a 50 ms-throttled broadcaster. Empty doc is not a special
       case: `A.getCursor(doc, ['text'], 0)` on empty text returns the
       end sentinel per the probe script — verify at test time.
-- [ ] Write and pass the Phase-2 tests.
-- [ ] Continue immediately into Phase 3 in the same commit — do *not*
+- [x] Write and pass the Phase-2 tests.
+- [x] Continue immediately into Phase 3 in the same commit — do *not*
       commit wire-format changes in isolation (see phase-merge note
       above).
 
 ### Phase 3 — usePresence.ts simplification (same commit as Phase 2)
 
-- [ ] Delete `transformOffset`, `PeerCursorState`, `peerStateRef`,
+- [x] Delete `transformOffset`, `PeerCursorState`, `peerStateRef`,
       `anticipatingEditRef`, the `onDidChangeContent` OT effect, and the
       same-line guard.
-- [ ] Keep the `modelVersion` state + `onDidChangeContent` bump (still
+- [x] Keep the `modelVersion` state + `onDidChangeContent` bump (still
       needed — see "Design sketch → Receiver path") but slim the effect
       down to only the bump, no OT loop. Update the comment to reflect
       the new role ("re-resolve Automerge cursors against the updated
       doc").
-- [ ] Add `import { getFileHandle } from '../services/automergeSync'`
+- [x] Add `import { getFileHandle } from '../services/automergeSync'`
       (new coupling — see "Design sketch → Receiver path → New
       coupling"). In the render effect, obtain the doc via
       `getFileHandle(currentFilePath)?.doc()`. Wrap the `doc()` call in
@@ -402,15 +402,15 @@ in the *same* commit.
       effect for every peer, not just the unsynced one. On throw, bail
       out of this render (no decorations applied); the next content
       change or `remoteUsers` update re-runs the effect.
-- [ ] In the render effect, call `A.getCursorPosition(doc, ['text'],
+- [x] In the render effect, call `A.getCursorPosition(doc, ['text'],
       cursor)` for each peer's stored cursor/selection strings and place
       Monaco decorations from the resolved offsets. Wrap each call in
       `try/catch (RangeError)` and `continue` on throw — an unsynced
       cursor should drop the decoration for this render, not crash the
       effect or block other peers' decorations.
-- [ ] Add Phase-3 tests and verify them pass.
-- [ ] Verify Phase-1 tests still pass under the new implementation.
-- [ ] Commit as "refactor(presence): replace OT offset tracking with
+- [x] Add Phase-3 tests and verify them pass.
+- [x] Verify Phase-1 tests still pass under the new implementation.
+- [x] Commit as "refactor(presence): replace OT offset tracking with
       Automerge cursors (fixes #113)".
 
 ### Phase 4 — sender-side ordering regression test
@@ -422,21 +422,21 @@ before cursor-selection changes, and the content path through
 synchronous. This phase locks that invariant in with a test so a future
 refactor can't quietly break it.
 
-- [ ] Add a test in `hub-client/src/services/presenceService.test.ts`
+- [x] Add a test in `hub-client/src/services/presenceService.test.ts`
       that drives a synthetic Monaco edit (via the mocked editor +
       `handleEditorChange` path) immediately followed by a cursor
       broadcast, and asserts the broadcast cursor string resolves to
       the post-edit offset on a separate receiver doc. If the sender
       read pre-edit state, the cursor would resolve to a stale offset
       and the test would fail.
-- [ ] Commit as "test(presence): lock in sender-side cursor ordering".
+- [x] Commit as "test(presence): lock in sender-side cursor ordering".
 
 ### Phase 5 — verification and changelog
 
-- [ ] Run `cd hub-client && npm run build:all` (per CLAUDE.md this is
+- [x] Run `cd hub-client && npm run build:all` (per CLAUDE.md this is
       stricter than vitest + tsc --noEmit).
-- [ ] Run `cd hub-client && npm run test:ci`.
-- [ ] Run `cargo xtask verify --skip-rust-tests` to confirm the
+- [x] Run `cd hub-client && npm run test:ci`.
+- [x] Run `cargo xtask verify --skip-rust-tests` to confirm the
       hub-client build and tests pass in the xtask harness. (We skip
       Rust tests because this is a pure TS change — `quarto-sync-client`
       is a TypeScript package under `ts-packages/`, not a Rust crate, so
@@ -471,7 +471,7 @@ refactor can't quietly break it.
       heuristic. Do not add this speculatively — it's a small amount of
       state that's easy to get wrong, and the plan's whole point is to
       delete such state.
-- [ ] Commit the Automerge cursor-semantics probe script as an
+- [x] Commit the Automerge cursor-semantics probe script as an
       executable fixture at
       `hub-client/src/services/automergeCursor.probe.test.ts` (a vitest
       file that asserts the edge-case behaviours enumerated in "Design
@@ -479,7 +479,7 @@ refactor can't quietly break it.
       bias, selection-end `'before'` bias). This pins the behaviour to
       our pinned `@automerge/automerge` version and makes future
       upgrades catchable via CI.
-- [ ] Two-commit workflow for `hub-client/changelog.md`: first commit the
+- [x] Two-commit workflow for `hub-client/changelog.md`: first commit the
       refactor, then a second commit adding a changelog entry with the
       refactor's hash under today's date header.
 

--- a/hub-client/src/hooks/usePresence.test.ts
+++ b/hub-client/src/hooks/usePresence.test.ts
@@ -1,22 +1,30 @@
 /**
  * Tests for usePresence hook.
  *
- * These tests exercise the hook against a mocked Monaco editor and a mocked
- * presenceService, asserting the cursor/selection decorations the hook
- * applies under various race scenarios that PR #94 (OT cursor tracking) and
- * PR #110 (EOL same-line guard) introduced. The assertions are written at the
- * level of observable decoration positions so they survive the Automerge-
- * cursor refactor planned in issue #113.
+ * These tests exercise the hook against a mocked Monaco editor, a mocked
+ * presenceService, and a real `@automerge/automerge` doc (via a stub
+ * file-handle). They assert that cursor/selection decorations resolve to
+ * the right Monaco offsets under various race scenarios that PR #94
+ * (cursor tracking across concurrent edits) and PR #110 (cross-line flash
+ * at EOL) introduced — plus the new race scenarios that Automerge cursor
+ * resolution enables (presence-before-content-change, concurrent remote
+ * edits).
  *
  * @vitest-environment jsdom
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
+import { next as A } from '@automerge/automerge';
+import type { Doc } from '@automerge/automerge';
 
-// The mocked presenceService lets tests control the remote-presence stream.
-// We capture the subscriber passed to onPresenceChange and fire it
-// imperatively via `emitPresences` below.
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+// `presenceService` is mocked so tests can drive the remote-presence stream
+// directly via `emitPresences` instead of going through the ephemeral-message
+// round trip.
 let presenceCallback: ((presences: PresenceState[]) => void) | null = null;
 
 vi.mock('../services/presenceService', () => ({
@@ -35,8 +43,27 @@ vi.mock('../services/presenceService', () => ({
   }),
 }));
 
+// `automergeSync.getFileHandle` is mocked to return a stub handle wrapping
+// the `localDoc` held below. Tests mutate `localDoc` through the mock
+// editor's helpers, which also notify the hook via onDidChangeContent.
+let localDoc: Doc<{ text: string }> = A.from({ text: '' });
+let handleThrows = false;
+
+vi.mock('../services/automergeSync', () => ({
+  getFileHandle: vi.fn(() => ({
+    doc: () => {
+      if (handleThrows) throw new Error('handle unavailable');
+      return localDoc;
+    },
+  })),
+}));
+
 import { usePresence } from './usePresence';
 import type { PresenceState } from '../services/presenceService';
+
+// ---------------------------------------------------------------------------
+// Mock Monaco editor
+// ---------------------------------------------------------------------------
 
 interface MonacoChange {
   rangeOffset: number;
@@ -58,13 +85,17 @@ interface DecorationRecord {
 /**
  * Minimal Monaco editor mock. Supports offset<->position conversion on text
  * with embedded newlines, records decorations by id, and allows tests to
- * drive `onDidChangeContent` via `_applyEdit`.
+ * drive `onDidChangeContent` via `_applyEdit` / `_syncDoc`. Both helpers
+ * keep `localDoc` and the mock's displayed text in lockstep so that cursors
+ * created against `localDoc` resolve to the same position Monaco renders.
  */
 function createMockEditor(initialText: string) {
   let text = initialText;
   let nextId = 1;
   const contentCallbacks: Array<(e: { changes: MonacoChange[] }) => void> = [];
   const decorations = new Map<string, DecorationRecord>();
+
+  localDoc = A.from({ text: initialText });
 
   const lineStartOffsets = (t: string): number[] => {
     const offsets = [0];
@@ -102,7 +133,7 @@ function createMockEditor(initialText: string) {
     },
   };
 
-  const editor = {
+  return {
     getModel: () => model,
     getSelection: () => null,
     deltaDecorations(oldIds: string[], newDecos: DecorationRecord[]): string[] {
@@ -118,9 +149,36 @@ function createMockEditor(initialText: string) {
     onDidChangeCursorSelection() {
       return { dispose: () => {} };
     },
+    /**
+     * Apply an edit to `localDoc` and the mock's displayed text, then fire
+     * onDidChangeContent so the hook re-resolves cursors. Models both local
+     * typing and remote ops that have synced into our doc — either way the
+     * hook sees the same thing: doc advanced + content change fired.
+     */
     _applyEdit(rangeOffset: number, rangeLength: number, newText: string): void {
       text = text.slice(0, rangeOffset) + newText + text.slice(rangeOffset + rangeLength);
+      localDoc = A.change(localDoc, (d) => A.splice(d, ['text'], rangeOffset, rangeLength, newText));
       const change: MonacoChange = { rangeOffset, rangeLength, text: newText, range: null };
+      for (const cb of [...contentCallbacks]) cb({ changes: [change] });
+    },
+    /**
+     * Replace `localDoc` with a doc the test constructed externally (e.g.
+     * the result of `A.merge`), update the mock's displayed text, and fire a
+     * whole-buffer content change so the hook re-resolves cursors. Used when
+     * the test needs to install a doc state that isn't easily expressed as a
+     * single splice against the current state.
+     */
+    _syncDoc(newDoc: Doc<{ text: string }>): void {
+      const oldLen = text.length;
+      const newText = newDoc.text;
+      text = newText;
+      localDoc = newDoc;
+      const change: MonacoChange = {
+        rangeOffset: 0,
+        rangeLength: oldLen,
+        text: newText,
+        range: null,
+      };
       for (const cb of [...contentCallbacks]) cb({ changes: [change] });
     },
     _cursorDecorationsFor(peerId: string): DecorationRecord[] {
@@ -136,8 +194,14 @@ function createMockEditor(initialText: string) {
       );
     },
   };
+}
 
-  return editor;
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function cursorAt(offset: number): string {
+  return A.getCursor(localDoc, ['text'], offset);
 }
 
 function makePresence(overrides: Partial<PresenceState>): PresenceState {
@@ -160,11 +224,6 @@ function emitPresences(presences: PresenceState[]): void {
   });
 }
 
-/**
- * Resolve the first cursor decoration's start position back to a character
- * offset against the editor's *current* model text. Returns null if no
- * cursor decoration is present.
- */
 function cursorOffset(
   decos: DecorationRecord[],
   editor: ReturnType<typeof createMockEditor>,
@@ -177,9 +236,15 @@ function cursorOffset(
   });
 }
 
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
 describe('usePresence — remote cursor tracking across content edits', () => {
   beforeEach(() => {
     presenceCallback = null;
+    handleThrows = false;
+    localDoc = A.from({ text: '' });
   });
 
   afterEach(() => {
@@ -195,15 +260,14 @@ describe('usePresence — remote cursor tracking across content edits', () => {
       result.current.onEditorMount(editor as never);
     });
 
-    emitPresences([makePresence({ peerId: 'remote-1', cursor: 14 })]);
+    emitPresences([makePresence({ peerId: 'remote-1', cursor: cursorAt(14) })]);
     expect(cursorOffset(editor._cursorDecorationsFor('remote-1'), editor)).toBe(14);
 
-    // Local deletion of 2 chars at the start of paragraph 1.
     act(() => {
       editor._applyEdit(0, 2, '');
     });
 
-    // Remote cursor must still reference the same logical character: 14 - 2 = 12.
+    // Remote cursor still references the same logical character: 14 - 2 = 12.
     expect(cursorOffset(editor._cursorDecorationsFor('remote-1'), editor)).toBe(12);
   });
 
@@ -215,7 +279,7 @@ describe('usePresence — remote cursor tracking across content edits', () => {
       result.current.onEditorMount(editor as never);
     });
 
-    emitPresences([makePresence({ peerId: 'remote-1', cursor: 6 })]); // 'w'
+    emitPresences([makePresence({ peerId: 'remote-1', cursor: cursorAt(6) })]); // 'w'
 
     act(() => {
       editor._applyEdit(0, 0, 'XYZ');
@@ -232,10 +296,11 @@ describe('usePresence — remote cursor tracking across content edits', () => {
       result.current.onEditorMount(editor as never);
     });
 
-    emitPresences([makePresence({ peerId: 'remote-1', cursor: 5 })]); // 'f'
+    emitPresences([makePresence({ peerId: 'remote-1', cursor: cursorAt(5) })]); // 'f'
 
-    // Replace offsets [2, 7) ("cdefg") with "X". Cursor was inside the
-    // deleted range and should clamp to editStart + newText.length = 3.
+    // Replace offsets [2, 7) ("cdefg") with "X". The char the cursor was
+    // anchored to is deleted; Automerge collapses the cursor to
+    // editStart + newText.length = 3.
     act(() => {
       editor._applyEdit(2, 5, 'X');
     });
@@ -243,39 +308,39 @@ describe('usePresence — remote cursor tracking across content edits', () => {
     expect(cursorOffset(editor._cursorDecorationsFor('remote-1'), editor)).toBe(3);
   });
 
-  it('remote cursor arrives before its content change: no double-shift', () => {
-    // Peer will insert "X" at offset 5 (EOF of "hello"), moving their cursor
-    // from 5 to 6. The presence message carries the post-insert offset and
-    // can arrive before the content change syncs into our doc.
-    const editor = createMockEditor('hello');
+  it('remote cursor arrives before its content change: final position is correct, no double-shift', () => {
+    // Peer's cursor moves from 6 (in "hello world") to 7 (in "hello Xworld"
+    // after they insert "X" at offset 6). Simulate the presence update with
+    // the post-edit cursor arriving before the content change.
+    const editor = createMockEditor('hello world');
 
     const { result } = renderHook(() => usePresence('test.qmd'));
     act(() => {
       result.current.onEditorMount(editor as never);
     });
 
-    emitPresences([makePresence({ peerId: 'remote-1', cursor: 5 })]);
-    expect(cursorOffset(editor._cursorDecorationsFor('remote-1'), editor)).toBe(5);
+    emitPresences([makePresence({ peerId: 'remote-1', cursor: cursorAt(6) })]);
+    expect(cursorOffset(editor._cursorDecorationsFor('remote-1'), editor)).toBe(6);
 
-    // Presence update with the anticipated post-edit offset (6) arrives first.
-    emitPresences([makePresence({ peerId: 'remote-1', cursor: 6 })]);
+    // Sender forks, applies the edit, builds the post-edit cursor. Cloning
+    // leaves `localDoc` untouched so the hook can still resolve against it.
+    const senderPostEdit = A.change(A.clone(localDoc), (d) =>
+      A.splice(d, ['text'], 6, 0, 'X'),
+    );
+    const anticipatedCursor = A.getCursor(senderPostEdit, ['text'], 7);
+    emitPresences([makePresence({ peerId: 'remote-1', cursor: anticipatedCursor })]);
 
-    // Then the corresponding content change lands.
+    // The op syncs into our doc.
     act(() => {
-      editor._applyEdit(5, 0, 'X');
+      editor._applyEdit(6, 0, 'X');
     });
 
-    // After both events, the decoration must be at offset 6 — not 7, which
-    // would be the tell-tale double-shift if OT advanced an already-advanced
-    // offset.
-    expect(cursorOffset(editor._cursorDecorationsFor('remote-1'), editor)).toBe(6);
+    // Final state: post-edit doc "hello Xworld", cursor at offset 7. The
+    // same cursor string must never produce a "double-shift" value (8).
+    expect(cursorOffset(editor._cursorDecorationsFor('remote-1'), editor)).toBe(7);
   });
 
   it('remote cursor at end-of-line, presence before content change: decoration never appears on the following line (PR #110)', () => {
-    // Doc "aa\nbb": offset 2 is end of line 1, offset 3 is start of line 2.
-    // Peer types "X" at offset 2. The post-edit cursor offset (3) maps to
-    // line 2 col 1 in the *pre-edit* doc — a cross-line flash if rendered
-    // naively.
     const editor = createMockEditor('aa\nbb');
 
     const { result } = renderHook(() => usePresence('test.qmd'));
@@ -293,10 +358,16 @@ describe('usePresence — remote cursor tracking across content edits', () => {
       }
     };
 
-    emitPresences([makePresence({ peerId: 'remote-1', cursor: 2 })]);
+    emitPresences([makePresence({ peerId: 'remote-1', cursor: cursorAt(2) })]);
     assertNotOnLine2('initial');
 
-    emitPresences([makePresence({ peerId: 'remote-1', cursor: 3 })]);
+    // Peer types "X" at offset 2. Their post-edit cursor is at offset 3 in
+    // their post-edit doc. Send that cursor before the content syncs.
+    const senderPostEdit = A.change(A.clone(localDoc), (d) =>
+      A.splice(d, ['text'], 2, 0, 'X'),
+    );
+    const anticipatedCursor = A.getCursor(senderPostEdit, ['text'], 3);
+    emitPresences([makePresence({ peerId: 'remote-1', cursor: anticipatedCursor })]);
     assertNotOnLine2('after presence, before content change');
 
     act(() => {
@@ -309,5 +380,98 @@ describe('usePresence — remote cursor tracking across content edits', () => {
     expect(decos).toHaveLength(1);
     expect(decos[0].range.startLineNumber).toBe(1);
     expect(decos[0].range.startColumn).toBe(4);
+  });
+});
+
+describe('usePresence — Automerge-cursor race scenarios', () => {
+  beforeEach(() => {
+    presenceCallback = null;
+    handleThrows = false;
+    localDoc = A.from({ text: '' });
+  });
+
+  afterEach(() => {
+    document.head.querySelectorAll('style[id^="presence-user-"]').forEach((s) => s.remove());
+  });
+
+  it('cursor referencing an op not yet synced: decoration skipped, resolves once op arrives', () => {
+    // Peer inserts "XY" at offset 2 and places their cursor at offset 3 in
+    // their post-edit doc — which anchors (default 'after') to the 'Y' they
+    // just inserted. That cursor cannot resolve on our pre-edit doc because
+    // the 'Y' op hasn't synced yet.
+    const editor = createMockEditor('hello');
+
+    const { result } = renderHook(() => usePresence('test.qmd'));
+    act(() => {
+      result.current.onEditorMount(editor as never);
+    });
+
+    const senderPostEdit = A.change(A.clone(localDoc), (d) =>
+      A.splice(d, ['text'], 2, 0, 'XY'),
+    );
+    const unsyncedCursor = A.getCursor(senderPostEdit, ['text'], 3);
+
+    emitPresences([makePresence({ peerId: 'remote-1', cursor: unsyncedCursor })]);
+
+    // The hook caught the RangeError and dropped the decoration for this
+    // render rather than placing it at a stale offset.
+    expect(editor._cursorDecorationsFor('remote-1')).toHaveLength(0);
+
+    // Now the sender's ops sync into our doc. In production this happens
+    // via Automerge sync and preserves op-ids; `_syncDoc` here installs the
+    // sender's post-edit doc directly so the same cursor string resolves.
+    act(() => {
+      editor._syncDoc(senderPostEdit);
+    });
+
+    // Post-sync state: "heXYllo", cursor at offset 3 (anchored to 'Y').
+    expect(cursorOffset(editor._cursorDecorationsFor('remote-1'), editor)).toBe(3);
+  });
+
+  it('two concurrent remote edits: third peer cursor anchored in base resolves to merged offset', () => {
+    // Base: "hello". Two peers insert concurrently at offset 5 with
+    // different actor ids. Third peer anchored to EOF of the base tracks
+    // through the merge.
+    const editor = createMockEditor('hello');
+
+    const { result } = renderHook(() => usePresence('test.qmd'));
+    act(() => {
+      result.current.onEditorMount(editor as never);
+    });
+
+    const peerCCursor = A.getCursor(localDoc, ['text'], 5); // EOF ('e' sentinel)
+
+    const peerAFork = A.change(A.clone(localDoc), (d) =>
+      A.splice(d, ['text'], 5, 0, 'X'),
+    );
+    const peerBFork = A.change(A.clone(localDoc), (d) =>
+      A.splice(d, ['text'], 5, 0, 'Y'),
+    );
+    const merged = A.merge(peerAFork, peerBFork);
+    expect(merged.text.length).toBe(7);
+    const expectedOffset = A.getCursorPosition(merged, ['text'], peerCCursor);
+
+    act(() => {
+      editor._syncDoc(merged);
+    });
+
+    emitPresences([makePresence({ peerId: 'peer-c', cursor: peerCCursor })]);
+
+    expect(cursorOffset(editor._cursorDecorationsFor('peer-c'), editor)).toBe(expectedOffset);
+  });
+
+  it('drops the decoration (no crash) when the file handle is unavailable', () => {
+    const editor = createMockEditor('hello');
+    handleThrows = true;
+
+    const { result } = renderHook(() => usePresence('test.qmd'));
+    act(() => {
+      result.current.onEditorMount(editor as never);
+    });
+
+    // Build a cursor before flipping the flag so at least it's syntactically
+    // valid; the flag turns the handle stub into one whose `doc()` throws.
+    emitPresences([makePresence({ peerId: 'remote-1', cursor: 'e' })]);
+    expect(editor._cursorDecorationsFor('remote-1')).toHaveLength(0);
   });
 });

--- a/hub-client/src/hooks/usePresence.test.ts
+++ b/hub-client/src/hooks/usePresence.test.ts
@@ -1,0 +1,313 @@
+/**
+ * Tests for usePresence hook.
+ *
+ * These tests exercise the hook against a mocked Monaco editor and a mocked
+ * presenceService, asserting the cursor/selection decorations the hook
+ * applies under various race scenarios that PR #94 (OT cursor tracking) and
+ * PR #110 (EOL same-line guard) introduced. The assertions are written at the
+ * level of observable decoration positions so they survive the Automerge-
+ * cursor refactor planned in issue #113.
+ *
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+// The mocked presenceService lets tests control the remote-presence stream.
+// We capture the subscriber passed to onPresenceChange and fire it
+// imperatively via `emitPresences` below.
+let presenceCallback: ((presences: PresenceState[]) => void) | null = null;
+
+vi.mock('../services/presenceService', () => ({
+  initPresence: vi.fn().mockResolvedValue(undefined),
+  cleanupPresence: vi.fn(),
+  setCurrentFile: vi.fn(),
+  updatePresence: vi.fn(),
+  refreshIdentity: vi.fn().mockResolvedValue(undefined),
+  getLocalPeerId: vi.fn(() => 'local-peer'),
+  onPresenceChange: vi.fn((cb: (presences: PresenceState[]) => void) => {
+    presenceCallback = cb;
+    cb([]);
+    return () => {
+      presenceCallback = null;
+    };
+  }),
+}));
+
+import { usePresence } from './usePresence';
+import type { PresenceState } from '../services/presenceService';
+
+interface MonacoChange {
+  rangeOffset: number;
+  rangeLength: number;
+  text: string;
+  range: unknown;
+}
+
+interface DecorationRecord {
+  range: {
+    startLineNumber: number;
+    startColumn: number;
+    endLineNumber: number;
+    endColumn: number;
+  };
+  options: { className?: string };
+}
+
+/**
+ * Minimal Monaco editor mock. Supports offset<->position conversion on text
+ * with embedded newlines, records decorations by id, and allows tests to
+ * drive `onDidChangeContent` via `_applyEdit`.
+ */
+function createMockEditor(initialText: string) {
+  let text = initialText;
+  let nextId = 1;
+  const contentCallbacks: Array<(e: { changes: MonacoChange[] }) => void> = [];
+  const decorations = new Map<string, DecorationRecord>();
+
+  const lineStartOffsets = (t: string): number[] => {
+    const offsets = [0];
+    for (let i = 0; i < t.length; i++) {
+      if (t[i] === '\n') offsets.push(i + 1);
+    }
+    return offsets;
+  };
+
+  const model = {
+    getValue: () => text,
+    getValueLength: () => text.length,
+    getPositionAt(offset: number) {
+      const starts = lineStartOffsets(text);
+      const clamped = Math.max(0, Math.min(offset, text.length));
+      let line = 0;
+      for (let i = 0; i < starts.length; i++) {
+        if (clamped >= starts[i]) line = i;
+      }
+      return { lineNumber: line + 1, column: clamped - starts[line] + 1 };
+    },
+    getOffsetAt(pos: { lineNumber: number; column: number }): number {
+      const starts = lineStartOffsets(text);
+      const line = Math.max(0, Math.min(pos.lineNumber - 1, starts.length - 1));
+      return starts[line] + pos.column - 1;
+    },
+    onDidChangeContent(cb: (e: { changes: MonacoChange[] }) => void) {
+      contentCallbacks.push(cb);
+      return {
+        dispose: () => {
+          const i = contentCallbacks.indexOf(cb);
+          if (i >= 0) contentCallbacks.splice(i, 1);
+        },
+      };
+    },
+  };
+
+  const editor = {
+    getModel: () => model,
+    getSelection: () => null,
+    deltaDecorations(oldIds: string[], newDecos: DecorationRecord[]): string[] {
+      for (const id of oldIds) decorations.delete(id);
+      const newIds: string[] = [];
+      for (const d of newDecos) {
+        const id = `dec${nextId++}`;
+        decorations.set(id, d);
+        newIds.push(id);
+      }
+      return newIds;
+    },
+    onDidChangeCursorSelection() {
+      return { dispose: () => {} };
+    },
+    _applyEdit(rangeOffset: number, rangeLength: number, newText: string): void {
+      text = text.slice(0, rangeOffset) + newText + text.slice(rangeOffset + rangeLength);
+      const change: MonacoChange = { rangeOffset, rangeLength, text: newText, range: null };
+      for (const cb of [...contentCallbacks]) cb({ changes: [change] });
+    },
+    _cursorDecorationsFor(peerId: string): DecorationRecord[] {
+      const safe = peerId.replace(/[^a-zA-Z0-9]/g, '-');
+      return Array.from(decorations.values()).filter(
+        (d) => d.options.className === `presence-cursor-${safe}`,
+      );
+    },
+    _selectionDecorationsFor(peerId: string): DecorationRecord[] {
+      const safe = peerId.replace(/[^a-zA-Z0-9]/g, '-');
+      return Array.from(decorations.values()).filter(
+        (d) => d.options.className === `presence-selection-${safe}`,
+      );
+    },
+  };
+
+  return editor;
+}
+
+function makePresence(overrides: Partial<PresenceState>): PresenceState {
+  return {
+    peerId: 'remote-1',
+    userId: 'user-1',
+    userName: 'Alice',
+    userColor: '#ff0000',
+    filePath: 'test.qmd',
+    cursor: null,
+    selection: null,
+    lastSeen: Date.now(),
+    ...overrides,
+  };
+}
+
+function emitPresences(presences: PresenceState[]): void {
+  act(() => {
+    presenceCallback?.(presences);
+  });
+}
+
+/**
+ * Resolve the first cursor decoration's start position back to a character
+ * offset against the editor's *current* model text. Returns null if no
+ * cursor decoration is present.
+ */
+function cursorOffset(
+  decos: DecorationRecord[],
+  editor: ReturnType<typeof createMockEditor>,
+): number | null {
+  if (decos.length === 0) return null;
+  const d = decos[0];
+  return editor.getModel().getOffsetAt({
+    lineNumber: d.range.startLineNumber,
+    column: d.range.startColumn,
+  });
+}
+
+describe('usePresence — remote cursor tracking across content edits', () => {
+  beforeEach(() => {
+    presenceCallback = null;
+  });
+
+  afterEach(() => {
+    document.head.querySelectorAll('style[id^="presence-user-"]').forEach((s) => s.remove());
+  });
+
+  it('deletion in an earlier paragraph does not shift a remote cursor in a later paragraph (PR #94)', () => {
+    // "abcdef\n\nghi\n\njkl" — 'k' (later paragraph) is at offset 14.
+    const editor = createMockEditor('abcdef\n\nghi\n\njkl');
+
+    const { result } = renderHook(() => usePresence('test.qmd'));
+    act(() => {
+      result.current.onEditorMount(editor as never);
+    });
+
+    emitPresences([makePresence({ peerId: 'remote-1', cursor: 14 })]);
+    expect(cursorOffset(editor._cursorDecorationsFor('remote-1'), editor)).toBe(14);
+
+    // Local deletion of 2 chars at the start of paragraph 1.
+    act(() => {
+      editor._applyEdit(0, 2, '');
+    });
+
+    // Remote cursor must still reference the same logical character: 14 - 2 = 12.
+    expect(cursorOffset(editor._cursorDecorationsFor('remote-1'), editor)).toBe(12);
+  });
+
+  it('local insertion before a remote cursor shifts it forward by the inserted length', () => {
+    const editor = createMockEditor('hello world');
+
+    const { result } = renderHook(() => usePresence('test.qmd'));
+    act(() => {
+      result.current.onEditorMount(editor as never);
+    });
+
+    emitPresences([makePresence({ peerId: 'remote-1', cursor: 6 })]); // 'w'
+
+    act(() => {
+      editor._applyEdit(0, 0, 'XYZ');
+    });
+
+    expect(cursorOffset(editor._cursorDecorationsFor('remote-1'), editor)).toBe(9);
+  });
+
+  it('local deletion across a remote cursor clamps it to the end of the replacement text', () => {
+    const editor = createMockEditor('abcdefgh');
+
+    const { result } = renderHook(() => usePresence('test.qmd'));
+    act(() => {
+      result.current.onEditorMount(editor as never);
+    });
+
+    emitPresences([makePresence({ peerId: 'remote-1', cursor: 5 })]); // 'f'
+
+    // Replace offsets [2, 7) ("cdefg") with "X". Cursor was inside the
+    // deleted range and should clamp to editStart + newText.length = 3.
+    act(() => {
+      editor._applyEdit(2, 5, 'X');
+    });
+
+    expect(cursorOffset(editor._cursorDecorationsFor('remote-1'), editor)).toBe(3);
+  });
+
+  it('remote cursor arrives before its content change: no double-shift', () => {
+    // Peer will insert "X" at offset 5 (EOF of "hello"), moving their cursor
+    // from 5 to 6. The presence message carries the post-insert offset and
+    // can arrive before the content change syncs into our doc.
+    const editor = createMockEditor('hello');
+
+    const { result } = renderHook(() => usePresence('test.qmd'));
+    act(() => {
+      result.current.onEditorMount(editor as never);
+    });
+
+    emitPresences([makePresence({ peerId: 'remote-1', cursor: 5 })]);
+    expect(cursorOffset(editor._cursorDecorationsFor('remote-1'), editor)).toBe(5);
+
+    // Presence update with the anticipated post-edit offset (6) arrives first.
+    emitPresences([makePresence({ peerId: 'remote-1', cursor: 6 })]);
+
+    // Then the corresponding content change lands.
+    act(() => {
+      editor._applyEdit(5, 0, 'X');
+    });
+
+    // After both events, the decoration must be at offset 6 — not 7, which
+    // would be the tell-tale double-shift if OT advanced an already-advanced
+    // offset.
+    expect(cursorOffset(editor._cursorDecorationsFor('remote-1'), editor)).toBe(6);
+  });
+
+  it('remote cursor at end-of-line, presence before content change: decoration never appears on the following line (PR #110)', () => {
+    // Doc "aa\nbb": offset 2 is end of line 1, offset 3 is start of line 2.
+    // Peer types "X" at offset 2. The post-edit cursor offset (3) maps to
+    // line 2 col 1 in the *pre-edit* doc — a cross-line flash if rendered
+    // naively.
+    const editor = createMockEditor('aa\nbb');
+
+    const { result } = renderHook(() => usePresence('test.qmd'));
+    act(() => {
+      result.current.onEditorMount(editor as never);
+    });
+
+    const assertNotOnLine2 = (label: string) => {
+      const decos = editor._cursorDecorationsFor('remote-1');
+      for (const d of decos) {
+        expect(
+          d.range.startLineNumber,
+          `${label}: cursor decoration must not be on line 2`,
+        ).not.toBe(2);
+      }
+    };
+
+    emitPresences([makePresence({ peerId: 'remote-1', cursor: 2 })]);
+    assertNotOnLine2('initial');
+
+    emitPresences([makePresence({ peerId: 'remote-1', cursor: 3 })]);
+    assertNotOnLine2('after presence, before content change');
+
+    act(() => {
+      editor._applyEdit(2, 0, 'X');
+    });
+    assertNotOnLine2('after content change');
+
+    // Final state: "aaX\nbb" with cursor at offset 3 → line 1, col 4.
+    const decos = editor._cursorDecorationsFor('remote-1');
+    expect(decos).toHaveLength(1);
+    expect(decos[0].range.startLineNumber).toBe(1);
+    expect(decos[0].range.startColumn).toBe(4);
+  });
+});

--- a/hub-client/src/hooks/usePresence.ts
+++ b/hub-client/src/hooks/usePresence.ts
@@ -4,12 +4,17 @@
  * React hook for integrating presence features with the Monaco editor.
  * Handles cursor tracking, remote cursor rendering, and presence state management.
  *
- * Uses Monaco's native decoration APIs instead of external libraries for compatibility
- * with @monaco-editor/react's CDN-loaded Monaco instance.
+ * Remote cursor positions arrive as Automerge cursor strings (see
+ * `presenceService.ts`) and are resolved to numeric Monaco offsets against
+ * the current local doc on every render. Automerge cursors are anchored
+ * to specific ops in the text sequence, so they track their logical
+ * position through concurrent and local edits without needing hand-rolled
+ * operational transformation on the receiver.
  */
 
 import { useEffect, useLayoutEffect, useRef, useCallback, useState } from 'react';
 import type * as Monaco from 'monaco-editor';
+import { next as A } from '@automerge/automerge';
 import {
   initPresence,
   cleanupPresence,
@@ -20,6 +25,7 @@ import {
   getLocalPeerId,
   type PresenceState,
 } from '../services/presenceService';
+import { getFileHandle } from '../services/automergeSync';
 
 /**
  * Options for the usePresence hook.
@@ -106,37 +112,6 @@ function ensureUserCursorStyle(peerId: string, color: string, userName: string):
 }
 
 /**
- * Shift a character offset to account for a single edit.
- * Offsets after the edit move by delta; offsets inside the replaced range
- * clamp to the end of the replacement text; offsets before are unchanged.
- */
-function transformOffset(
-  offset: number,
-  editStart: number,
-  oldEnd: number,
-  newEnd: number,
-  delta: number,
-): number {
-  if (offset >= oldEnd) return offset + delta;
-  if (offset > editStart) return newEnd;
-  return offset;
-}
-
-/**
- * Per-peer OT state for remote cursor/selection tracking.
- */
-interface PeerCursorState {
-  /** OT-adjusted cursor offset */
-  cursor: number;
-  /** Last raw cursor value from the presence network */
-  lastPresenceCursor: number;
-  /** OT-adjusted selection range (absent if peer has no selection) */
-  selection?: { start: number; end: number };
-  /** Last raw selection from the presence network */
-  lastPresenceSelection?: { start: number; end: number };
-}
-
-/**
  * Remove a user's cursor styles when they leave.
  */
 function removeUserCursorStyle(peerId: string): void {
@@ -172,23 +147,14 @@ export function usePresence(
   // Track decoration IDs for cleanup
   const decorationIdsRef = useRef<string[]>([]);
 
-  // Track if we've initialized
-  const initializedRef = useRef(false);
-
-  // Track model version to re-render decorations when content changes.
-  // Decorations are recreated from character offsets on each render, so we
-  // must re-render after every content change to keep them in sync.
+  // Track model version to re-resolve Automerge cursors against the
+  // updated doc after every content change. The stored cursor strings
+  // don't change, but their resolved offsets do once local or remote
+  // edits land in the Automerge doc — we need a re-render to pick up
+  // the new offsets. Remote edits reach this path via
+  // `immediateFileChangeCallback` in `automergeSync.ts`, which applies
+  // diffs to Monaco and triggers `onDidChangeContent`.
   const [modelVersion, setModelVersion] = useState(0);
-
-  // Per-peer OT state: adjusted offsets and last raw presence values.
-  // Between presence updates, content edits shift `cursor`/`selection` so
-  // decorations stay at the correct logical position.  `lastPresence*`
-  // fields detect genuinely new presence updates vs. OT drift.
-  const peerStateRef = useRef<Map<string, PeerCursorState>>(new Map());
-
-  // Peers whose cursor already reflects an edit whose content change hasn't
-  // arrived yet.  The OT handler skips these once to avoid double-shifting.
-  const anticipatingEditRef = useRef<Set<string>>(new Set());
 
   // Track which peerIds have active styles, for cleanup
   const activePeerStylesRef = useRef<Set<string>>(new Set());
@@ -202,13 +168,10 @@ export function usePresence(
   useEffect(() => {
     if (!enabled) return;
 
-    initPresence().then(() => {
-      initializedRef.current = true;
-    });
+    initPresence();
 
     return () => {
       cleanupPresence();
-      initializedRef.current = false;
     };
   }, [enabled]);
 
@@ -229,40 +192,16 @@ export function usePresence(
     return unsubscribe;
   }, [enabled]);
 
-  // Transform remote cursor/selection offsets on every content change (OT).
-  // Each edit shifts offsets that fall after it, and clamps offsets inside
-  // the deleted range to the end of the replacement text.  This keeps
-  // decorations at their correct logical positions between presence updates.
+  // Bump modelVersion on every content change so the render effect
+  // re-resolves Automerge cursors against the updated doc state. This
+  // replaces the hand-rolled OT loop that previously lived here.
   useEffect(() => {
     if (!editor) return;
 
     const model = editor.getModel();
     if (!model) return;
 
-    const disposable = model.onDidChangeContent((e) => {
-      // Peers whose presence arrived before this content change already have
-      // post-edit offsets — skip OT for them for this entire event.
-      const skip = new Set(anticipatingEditRef.current);
-      anticipatingEditRef.current.clear();
-
-      for (const change of e.changes) {
-        const editStart = change.rangeOffset;
-        const oldEnd = editStart + change.rangeLength;
-        const newEnd = editStart + change.text.length;
-        const delta = change.text.length - change.rangeLength;
-
-        for (const [peerId, state] of peerStateRef.current) {
-          if (skip.has(peerId)) continue;
-          state.cursor = transformOffset(state.cursor, editStart, oldEnd, newEnd, delta);
-          if (state.selection) {
-            state.selection = {
-              start: transformOffset(state.selection.start, editStart, oldEnd, newEnd, delta),
-              end: transformOffset(state.selection.end, editStart, oldEnd, newEnd, delta),
-            };
-          }
-        }
-      }
-
+    const disposable = model.onDidChangeContent(() => {
       setModelVersion((v) => v + 1);
     });
 
@@ -270,24 +209,34 @@ export function usePresence(
   }, [editor]);
 
   // Render remote cursors and selections using Monaco decorations.
-  // useLayoutEffect ensures decorations are updated before the browser paints,
-  // preventing flicker from Monaco's auto-shifted decorations being visible.
+  // useLayoutEffect ensures decorations update before the browser paints,
+  // preventing visible shifting of auto-adjusted Monaco decorations.
   useLayoutEffect(() => {
     if (!editor || !enabled) return;
 
     const model = editor.getModel();
     if (!model) return;
 
+    // Automerge cursor strings are resolved against the current local
+    // Automerge doc. If we don't have a handle yet (file not synced) or
+    // the handle can't produce a doc (deleted/unavailable), we can't
+    // place decorations — bail out and wait for the next render, which
+    // will fire when remoteUsers or modelVersion changes.
+    const handle = currentFilePath ? getFileHandle(currentFilePath) : null;
+    let doc: A.Doc<{ text: string }> | null = null;
+    try {
+      doc = handle ? (handle.doc() as A.Doc<{ text: string }>) : null;
+    } catch {
+      doc = null;
+    }
+    if (!doc) return;
+
     const localPeerId = getLocalPeerId();
-
-    // Build new decorations
-    const newDecorations: Monaco.editor.IModelDeltaDecoration[] = [];
-
     const docLength = model.getValueLength();
     const currentPeerIds = new Set<string>();
+    const newDecorations: Monaco.editor.IModelDeltaDecoration[] = [];
 
     for (const user of remoteUsers) {
-      // Skip our own presence
       if (user.peerId === localPeerId) continue;
 
       const safePeerId = sanitizePeerId(user.peerId);
@@ -295,126 +244,64 @@ export function usePresence(
       ensureUserCursorStyle(safePeerId, user.userColor, user.userName);
       activePeerStylesRef.current.add(safePeerId);
 
-      // --- Cursor decoration (OT-adjusted) ---
+      // --- Cursor decoration ---
       if (user.cursor !== null) {
+        let cursorOffset: number;
         try {
-          let state = peerStateRef.current.get(user.peerId);
-          const isNewPresence = !state || state.lastPresenceCursor !== user.cursor;
-
-          let cursorToRender: number;
-          if (isNewPresence) {
-            // If OT hasn't shifted the cursor since the previous presence
-            // update, the corresponding content change hasn't arrived yet.
-            // Only anticipate for small forward movements (typing); large
-            // jumps or backward moves are navigation and won't produce a
-            // matching content change.
-            const cursorDelta = user.cursor - (state?.lastPresenceCursor ?? user.cursor);
-            if (state && state.cursor === state.lastPresenceCursor &&
-                cursorDelta > 0 && cursorDelta <= 2) {
-              anticipatingEditRef.current.add(user.peerId);
-            }
-
-            const prevCursor = state?.cursor;
-
-            // New presence update — adopt the authoritative offset
-            cursorToRender = user.cursor;
-            if (state) {
-              state.cursor = user.cursor;
-              state.lastPresenceCursor = user.cursor;
-            } else {
-              state = { cursor: user.cursor, lastPresenceCursor: user.cursor };
-              peerStateRef.current.set(user.peerId, state);
-            }
-
-            // If a small forward move would place the cursor on a different
-            // line, the content change likely hasn't arrived yet and the
-            // offset maps to the wrong line.  Render at the old position;
-            // the content change will trigger a correct re-render.
-            if (prevCursor !== undefined &&
-                cursorDelta > 0 && cursorDelta <= 2 &&
-                cursorToRender <= docLength && prevCursor <= docLength &&
-                model.getPositionAt(cursorToRender).lineNumber !==
-                model.getPositionAt(prevCursor).lineNumber) {
-              cursorToRender = prevCursor;
-            }
-          } else {
-            // No new update — use the OT-shifted value
-            cursorToRender = state!.cursor;
-          }
-
-          if (cursorToRender < 0 || cursorToRender > docLength) {
-            continue;
-          }
-
-          const position = model.getPositionAt(cursorToRender);
-          newDecorations.push({
-            range: {
-              startLineNumber: position.lineNumber,
-              startColumn: position.column,
-              endLineNumber: position.lineNumber,
-              endColumn: position.column,
-            },
-            options: {
-              className: `presence-cursor-${safePeerId}`,
-              hoverMessage: { value: user.userName },
-              stickiness: 1, // NeverGrowsWhenTypingAtEdges
-            },
-          });
+          cursorOffset = A.getCursorPosition(doc, ['text'], user.cursor);
         } catch {
-          // Ignore invalid positions
+          // Cursor references an op we haven't synced yet — skip this
+          // render; the next onDidChangeContent after the op arrives
+          // will re-run and resolve successfully.
+          continue;
         }
-      } else {
-        peerStateRef.current.delete(user.peerId);
+
+        if (cursorOffset < 0 || cursorOffset > docLength) continue;
+
+        const position = model.getPositionAt(cursorOffset);
+        newDecorations.push({
+          range: {
+            startLineNumber: position.lineNumber,
+            startColumn: position.column,
+            endLineNumber: position.lineNumber,
+            endColumn: position.column,
+          },
+          options: {
+            className: `presence-cursor-${safePeerId}`,
+            hoverMessage: { value: user.userName },
+            stickiness: 1, // NeverGrowsWhenTypingAtEdges
+          },
+        });
       }
 
-      // --- Selection decoration (OT-adjusted) ---
+      // --- Selection decoration ---
       if (user.selection && user.selection.start !== user.selection.end) {
+        let startOffset: number;
+        let endOffset: number;
         try {
-          const state = peerStateRef.current.get(user.peerId);
-          if (!state) continue;
-
-          const lastSel = state.lastPresenceSelection;
-          const isNewSel = !lastSel ||
-            lastSel.start !== user.selection.start ||
-            lastSel.end !== user.selection.end;
-
-          let selToRender: { start: number; end: number };
-          if (isNewSel) {
-            selToRender = user.selection;
-            state.selection = { ...user.selection };
-            state.lastPresenceSelection = { ...user.selection };
-          } else {
-            selToRender = state.selection ?? user.selection;
-          }
-
-          if (selToRender.end > docLength) {
-            continue;
-          }
-
-          const startPos = model.getPositionAt(selToRender.start);
-          const endPos = model.getPositionAt(selToRender.end);
-          newDecorations.push({
-            range: {
-              startLineNumber: startPos.lineNumber,
-              startColumn: startPos.column,
-              endLineNumber: endPos.lineNumber,
-              endColumn: endPos.column,
-            },
-            options: {
-              className: `presence-selection-${safePeerId}`,
-              hoverMessage: { value: `${user.userName}'s selection` },
-              stickiness: 1,
-            },
-          });
+          startOffset = A.getCursorPosition(doc, ['text'], user.selection.start);
+          endOffset = A.getCursorPosition(doc, ['text'], user.selection.end);
         } catch {
-          // Ignore invalid positions
+          continue;
         }
-      } else {
-        const state = peerStateRef.current.get(user.peerId);
-        if (state) {
-          delete state.selection;
-          delete state.lastPresenceSelection;
-        }
+        if (startOffset === endOffset) continue;
+        if (endOffset > docLength || startOffset < 0) continue;
+
+        const startPos = model.getPositionAt(startOffset);
+        const endPos = model.getPositionAt(endOffset);
+        newDecorations.push({
+          range: {
+            startLineNumber: startPos.lineNumber,
+            startColumn: startPos.column,
+            endLineNumber: endPos.lineNumber,
+            endColumn: endPos.column,
+          },
+          options: {
+            className: `presence-selection-${safePeerId}`,
+            hoverMessage: { value: `${user.userName}'s selection` },
+            stickiness: 1,
+          },
+        });
       }
     }
 
@@ -438,15 +325,12 @@ export function usePresence(
         editor.deltaDecorations(decorationIdsRef.current, []);
         decorationIdsRef.current = [];
       }
-      // Clean up all injected style elements
       for (const peerId of activePeerStylesRef.current) {
         removeUserCursorStyle(peerId);
       }
       activePeerStylesRef.current.clear();
     };
-  // modelVersion triggers a re-render after every content change so that
-  // OT-adjusted offsets are used to reposition decorations.
-  }, [editor, enabled, remoteUsers, modelVersion]);
+  }, [editor, enabled, remoteUsers, modelVersion, currentFilePath]);
 
   // Track local cursor/selection changes
   useEffect(() => {
@@ -462,10 +346,8 @@ export function usePresence(
         return;
       }
 
-      // Convert Monaco position to offset
       const cursorOffset = model.getOffsetAt(selection.getPosition());
 
-      // Check if there's a selection (not just cursor)
       let selectionRange: { start: number; end: number } | null = null;
       if (!selection.isEmpty()) {
         const startOffset = model.getOffsetAt(selection.getStartPosition());
@@ -476,7 +358,6 @@ export function usePresence(
       updatePresence(cursorOffset, selectionRange);
     };
 
-    // Subscribe to cursor/selection changes
     const disposable = editor.onDidChangeCursorSelection(handleCursorChange);
 
     // Send initial position
@@ -487,7 +368,6 @@ export function usePresence(
     };
   }, [editor, enabled, currentFilePath]);
 
-  // Memoized refresh function
   const handleRefreshIdentity = useCallback(async () => {
     await refreshIdentity();
   }, []);

--- a/hub-client/src/services/automergeCursor.probe.test.ts
+++ b/hub-client/src/services/automergeCursor.probe.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Probe fixture for `@automerge/automerge` cursor semantics.
+ *
+ * Pins the cursor behaviours that `presenceService.ts` + `usePresence.ts`
+ * rely on to the currently-installed Automerge version (2.2.9 at the time
+ * of writing). If any of these behaviours change in a future upgrade,
+ * CI will fail here and we can revisit the presence design explicitly
+ * rather than discover the regression via user reports of misplaced
+ * remote cursors.
+ *
+ * Covers the edge cases enumerated in
+ * `claude-notes/plans/2026-04-21-automerge-cursors-for-presence.md`
+ * under "Design sketch → Edge cases".
+ */
+
+import { describe, it, expect } from 'vitest';
+import { next as A } from '@automerge/automerge';
+
+describe('automerge cursor semantics probe (pins @automerge/automerge 2.2.9 behaviour)', () => {
+  it('EOF cursor: offset === length returns the "e" sentinel and tracks through appends', () => {
+    let doc = A.from({ text: 'hello' });
+    const eof = A.getCursor(doc, ['text'], 5);
+    expect(eof).toBe('e');
+    expect(A.getCursorPosition(doc, ['text'], eof)).toBe(5);
+    doc = A.change(doc, (d) => A.splice(d, ['text'], 5, 0, 'X'));
+    expect(A.getCursorPosition(doc, ['text'], eof)).toBe(6);
+  });
+
+  it('empty doc: cursor at offset 0 is the "e" sentinel and tracks through inserts', () => {
+    let doc = A.from({ text: '' });
+    const c = A.getCursor(doc, ['text'], 0);
+    expect(c).toBe('e');
+    expect(A.getCursorPosition(doc, ['text'], c)).toBe(0);
+    doc = A.change(doc, (d) => A.splice(d, ['text'], 0, 0, 'hello'));
+    expect(A.getCursorPosition(doc, ['text'], c)).toBe(5);
+  });
+
+  it('past-EOF offset clamps to the end sentinel (does not throw)', () => {
+    const doc = A.from({ text: 'hello' });
+    const c = A.getCursor(doc, ['text'], 999);
+    expect(c).toBe('e');
+    expect(A.getCursorPosition(doc, ['text'], c)).toBe(5);
+  });
+
+  it('mid-doc cursor with default bias: inserts at the cursor offset push the cursor forward', () => {
+    let doc = A.from({ text: 'hello' });
+    const c = A.getCursor(doc, ['text'], 3);
+    expect(A.getCursorPosition(doc, ['text'], c)).toBe(3);
+    doc = A.change(doc, (d) => A.splice(d, ['text'], 3, 0, 'X'));
+    expect(A.getCursorPosition(doc, ['text'], c)).toBe(4);
+  });
+
+  it('deletion across a cursor collapses it to editStart + replacement length', () => {
+    let doc = A.from({ text: 'abcdefgh' });
+    const c = A.getCursor(doc, ['text'], 5); // 'f'
+    doc = A.change(doc, (d) => A.splice(d, ['text'], 2, 5, 'X'));
+    expect(doc.text).toBe('abXh');
+    expect(A.getCursorPosition(doc, ['text'], c)).toBe(3);
+  });
+
+  it('cursor anchored to a char not present in the receiver doc throws RangeError', () => {
+    const base = A.from({ text: 'hello' });
+    // Sender forks the doc and inserts a new char; cursor anchors to that
+    // char. The receiver's doc doesn't have the sender's op yet.
+    const sender = A.change(A.clone(base), (d) => A.splice(d, ['text'], 2, 0, 'XY'));
+    const unsyncedCursor = A.getCursor(sender, ['text'], 3); // anchors to 'Y'
+    expect(() => A.getCursorPosition(base, ['text'], unsyncedCursor)).toThrow(RangeError);
+  });
+
+  it('move bias: "before" and "after" produce different cursor strings but resolve identically for insertions in the current Automerge version', () => {
+    // NOTE: the plan originally expected `move: 'before'` to keep a
+    // selection-end cursor from being swept forward by inserts at the
+    // boundary. In 2.2.9 this is a no-op — both biases resolve to the
+    // same position after mid-doc and EOF inserts. If a future Automerge
+    // upgrade fixes this, this test will fail and we should revisit the
+    // broadcast path in `presenceService.ts`.
+    let doc = A.from({ text: 'hello' });
+    const after = A.getCursor(doc, ['text'], 4, 'after');
+    const before = A.getCursor(doc, ['text'], 4, 'before');
+    expect(after).not.toBe(before); // strings differ
+    doc = A.change(doc, (d) => A.splice(d, ['text'], 4, 0, 'X'));
+    expect(A.getCursorPosition(doc, ['text'], after)).toBe(
+      A.getCursorPosition(doc, ['text'], before),
+    );
+  });
+});

--- a/hub-client/src/services/presenceService.test.ts
+++ b/hub-client/src/services/presenceService.test.ts
@@ -499,4 +499,35 @@ describe('presenceService — Automerge cursor wire format', () => {
     expect(typeof msg.cursor).toBe('string');
     expect(A.getCursorPosition(doc, ['text'], msg.cursor!)).toBe(0);
   });
+
+  it('reads the post-edit doc when a content change is applied before the cursor broadcast', async () => {
+    // Regression guard for the Monaco/Automerge ordering contract: Monaco
+    // fires onDidChangeModelContent synchronously before
+    // onDidChangeCursorSelection, and the former's handler applies a
+    // synchronous splice to the Automerge doc. By the time
+    // broadcastPresence calls handle.doc(), the post-edit state must be
+    // what it sees — otherwise the cursor string encodes a pre-edit offset
+    // and every receiver resolves it to the wrong char.
+    //
+    // We pick a scenario where pre-edit vs post-edit reads yield
+    // *distinguishable* cursor strings: inserting "XY" at offset 2 in
+    // "hello" and broadcasting cursor offset 3 (between X and Y). With
+    // post-edit read, the cursor anchors to 'Y' (a new op) → resolves to
+    // 3. With pre-edit read, it anchors to 'l' (offset 3 in "hello") →
+    // resolves to 4 in the post-edit doc, a different position.
+    await initPresence();
+    const preEdit = A.from({ text: 'hello' });
+    let current = preEdit;
+    const broadcast = vi.fn();
+    installHandle({ broadcast, doc: () => current });
+
+    current = A.change(A.clone(preEdit), (d) => A.splice(d, ['text'], 2, 0, 'XY'));
+    updatePresence(3, null);
+    flushBroadcast();
+
+    const msg = broadcast.mock.calls[0][0] as { cursor: string | null };
+    // Resolves to 3 on a separate receiver doc that has synced the same
+    // post-edit state. If we read pre-edit, this would be 4.
+    expect(A.getCursorPosition(current, ['text'], msg.cursor!)).toBe(3);
+  });
 });

--- a/hub-client/src/services/presenceService.test.ts
+++ b/hub-client/src/services/presenceService.test.ts
@@ -7,6 +7,8 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { next as A } from '@automerge/automerge';
+import type { Doc } from '@automerge/automerge';
 import {
   initPresence,
   cleanupPresence,
@@ -34,7 +36,8 @@ vi.mock('./userSettings', () => ({
   }),
 }));
 
-// Mock the automergeSync module
+// Mock the automergeSync module. Tests that need a live handle install one
+// into state.currentHandle directly via `_getStateForTesting`.
 vi.mock('./automergeSync', () => ({
   getFileHandle: vi.fn().mockReturnValue(null),
 }));
@@ -184,7 +187,7 @@ describe('presenceService', () => {
         userName: 'User 1',
         userColor: '#ff0000',
         filePath: 'file1.qmd',
-        cursor: 10,
+        cursor: 'cursor-stub',
         selection: null,
         lastSeen: Date.now(),
       });
@@ -264,7 +267,8 @@ describe('presenceService', () => {
     });
 
     it('should return remote presences when present', () => {
-      // Manually add remote presence for testing
+      // Manually add remote presence for testing. Cursor/selection values
+      // here are opaque Automerge cursor strings — see PresenceState docs.
       const state = _getStateForTesting();
       state.remotePresences.set('peer-1', {
         peerId: 'peer-1',
@@ -272,15 +276,15 @@ describe('presenceService', () => {
         userName: 'Alice',
         userColor: '#ff0000',
         filePath: 'index.qmd',
-        cursor: 42,
-        selection: { start: 40, end: 45 },
+        cursor: 'cursor-42',
+        selection: { start: 'cursor-40', end: 'cursor-45' },
         lastSeen: Date.now(),
       });
 
       const presences = getRemotePresences();
       expect(presences).toHaveLength(1);
       expect(presences[0].userName).toBe('Alice');
-      expect(presences[0].cursor).toBe(42);
+      expect(presences[0].cursor).toBe('cursor-42');
     });
   });
 
@@ -302,7 +306,7 @@ describe('presenceService', () => {
         userName: 'Stale User',
         userColor: '#cccccc',
         filePath: 'index.qmd',
-        cursor: 0,
+        cursor: 'cursor-stub',
         selection: null,
         lastSeen: Date.now() - 2000, // 2 seconds ago (stale)
       });
@@ -323,7 +327,7 @@ describe('presenceService', () => {
         userName: 'Fresh User',
         userColor: '#00ff00',
         filePath: 'index.qmd',
-        cursor: 10,
+        cursor: 'cursor-stub',
         selection: null,
         lastSeen: Date.now(),
       });
@@ -361,5 +365,138 @@ describe('presenceService', () => {
 
       expect(peerId1).not.toBe(peerId2);
     });
+  });
+});
+
+// ===========================================================================
+// Broadcast wire format: Automerge cursor strings
+// ===========================================================================
+
+/**
+ * Stub DocHandle sufficient for broadcastPresence's needs: `doc()` returning
+ * a text doc, `broadcast` capturing the outgoing message.
+ */
+function createStubHandle(doc: Doc<{ text: string }>, opts: { docThrows?: boolean } = {}) {
+  const broadcast = vi.fn();
+  return {
+    broadcast,
+    doc: () => {
+      if (opts.docThrows) throw new Error('handle unavailable');
+      return doc;
+    },
+  };
+}
+
+/**
+ * Install a stub handle into presence state. `setCurrentFile` goes through
+ * `getFileHandle`; here we poke the state directly so the test can control
+ * exactly which doc the broadcast sees.
+ */
+function installHandle(handle: { broadcast: ReturnType<typeof vi.fn> }) {
+  const state = _getStateForTesting();
+  (state as { currentHandle: unknown }).currentHandle = handle;
+  (state as { currentFilePath: string }).currentFilePath = 'test.qmd';
+  return handle;
+}
+
+/** Flush the throttled broadcast timer so tests can inspect the message. */
+function flushBroadcast() {
+  // broadcastThrottleMs defaults to 50; advance well past it.
+  vi.advanceTimersByTime(100);
+}
+
+describe('presenceService — Automerge cursor wire format', () => {
+  beforeEach(() => {
+    _resetForTesting();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    cleanupPresence();
+    vi.useRealTimers();
+  });
+
+  it('broadcasts cursor as an Automerge cursor string that resolves back to the original offset', async () => {
+    await initPresence();
+    const doc = A.from({ text: 'hello world' });
+    const handle = installHandle(createStubHandle(doc));
+
+    updatePresence(5, null);
+    flushBroadcast();
+
+    expect(handle.broadcast).toHaveBeenCalledTimes(1);
+    const msg = handle.broadcast.mock.calls[0][0] as { cursor: string | null };
+    expect(typeof msg.cursor).toBe('string');
+    expect(A.getCursorPosition(doc, ['text'], msg.cursor!)).toBe(5);
+  });
+
+  it('broadcasts selection as {start, end} cursor strings that resolve back to the range', async () => {
+    await initPresence();
+    const doc = A.from({ text: 'hello world' });
+    const handle = installHandle(createStubHandle(doc));
+
+    updatePresence(2, { start: 2, end: 7 });
+    flushBroadcast();
+
+    const msg = handle.broadcast.mock.calls[0][0] as {
+      selection: { start: string; end: string } | null;
+    };
+    expect(msg.selection).not.toBeNull();
+    expect(A.getCursorPosition(doc, ['text'], msg.selection!.start)).toBe(2);
+    expect(A.getCursorPosition(doc, ['text'], msg.selection!.end)).toBe(7);
+  });
+
+  it('broadcasts null cursor and null selection through as null', async () => {
+    await initPresence();
+    const doc = A.from({ text: 'hello' });
+    const handle = installHandle(createStubHandle(doc));
+
+    updatePresence(null, null);
+    flushBroadcast();
+
+    expect(handle.broadcast).toHaveBeenCalledTimes(1);
+    const msg = handle.broadcast.mock.calls[0][0] as {
+      cursor: string | null;
+      selection: unknown;
+    };
+    expect(msg.cursor).toBeNull();
+    expect(msg.selection).toBeNull();
+  });
+
+  it('does not broadcast when no handle is available', async () => {
+    await initPresence();
+    // No installHandle — state.currentHandle stays null.
+    updatePresence(5, null);
+    flushBroadcast();
+
+    const state = _getStateForTesting();
+    expect(state.localCursor).toBe(5);
+    // We have no handle to assert on; the test is primarily asserting no
+    // exception escaped broadcastPresence (reached this line at all).
+    expect(true).toBe(true);
+  });
+
+  it('does not broadcast (and does not throw) when handle.doc() throws', async () => {
+    await initPresence();
+    const doc = A.from({ text: 'hello' });
+    const handle = installHandle(createStubHandle(doc, { docThrows: true }));
+
+    updatePresence(5, null);
+    flushBroadcast();
+
+    expect(handle.broadcast).not.toHaveBeenCalled();
+  });
+
+  it('handles an empty text doc: getCursor on offset 0 resolves back to 0', async () => {
+    await initPresence();
+    const doc = A.from({ text: '' });
+    const handle = installHandle(createStubHandle(doc));
+
+    updatePresence(0, null);
+    flushBroadcast();
+
+    const msg = handle.broadcast.mock.calls[0][0] as { cursor: string | null };
+    expect(typeof msg.cursor).toBe('string');
+    expect(A.getCursorPosition(doc, ['text'], msg.cursor!)).toBe(0);
   });
 });

--- a/hub-client/src/services/presenceService.ts
+++ b/hub-client/src/services/presenceService.ts
@@ -6,12 +6,19 @@
  */
 
 import type { DocHandle, DocHandleEphemeralMessagePayload } from '@automerge/automerge-repo';
+import { next as A } from '@automerge/automerge';
 import { getFileHandle } from './automergeSync';
 import { getUserIdentity } from './userSettings';
 import type { UserSettings } from './storage/types';
 
 /**
  * Presence state for a remote user.
+ *
+ * `cursor` and `selection` carry Automerge cursor strings
+ * (see `A.getCursor` / `A.getCursorPosition`) — opaque tokens anchored to
+ * the current file's `['text']` sequence. The receiver resolves them to
+ * numeric offsets against its own local doc; this is what keeps remote
+ * cursors stable under concurrent edits without hand-rolled OT.
  */
 export interface PresenceState {
   peerId: string;
@@ -19,13 +26,14 @@ export interface PresenceState {
   userName: string;
   userColor: string;
   filePath: string;
-  cursor: number | null;
-  selection: { start: number; end: number } | null;
+  cursor: string | null;
+  selection: { start: string; end: string } | null;
   lastSeen: number;
 }
 
 /**
- * Presence message broadcast via ephemeral messaging.
+ * Presence message broadcast via ephemeral messaging. Same wire shape as
+ * {@link PresenceState}'s cursor fields — see PresenceState doc comment.
  */
 interface PresenceMessage {
   type: 'presence';
@@ -33,8 +41,8 @@ interface PresenceMessage {
   userId: string;
   userName: string;
   userColor: string;
-  cursor: number | null;
-  selection: { start: number; end: number } | null;
+  cursor: string | null;
+  selection: { start: string; end: string } | null;
 }
 
 /**
@@ -376,14 +384,35 @@ function broadcastPresence(): void {
     return;
   }
 
+  // Convert the raw editor offsets we've been accumulating into Automerge
+  // cursors, anchored to the current doc's `['text']` sequence. `doc()`
+  // throws on deleted/unavailable handles; a throw here during a 50 ms
+  // throttled tick should be a silent skip, not a crash.
+  let cursor: string | null = null;
+  let selection: { start: string; end: string } | null = null;
+  try {
+    const doc = state.currentHandle.doc();
+    if (state.localCursor !== null) {
+      cursor = A.getCursor(doc, ['text'], state.localCursor);
+    }
+    if (state.localSelection !== null) {
+      selection = {
+        start: A.getCursor(doc, ['text'], state.localSelection.start),
+        end: A.getCursor(doc, ['text'], state.localSelection.end),
+      };
+    }
+  } catch {
+    return;
+  }
+
   const message: PresenceMessage = {
     type: 'presence',
     peerId: state.peerId,
     userId: state.identity.userId,
     userName: state.identity.userName,
     userColor: state.identity.userColor,
-    cursor: state.localCursor,
-    selection: state.localSelection,
+    cursor,
+    selection,
   };
 
   state.currentHandle.broadcast(message);


### PR DESCRIPTION
Fixes #113.

Remote cursor/selection positions now travel as Automerge cursor strings anchored to `['text']` and resolve on the receiver against its local doc. Deletes the hand-rolled OT machinery in `usePresence.ts` (`transformOffset`, `peerStateRef`, `anticipatingEditRef`, same-line guard, OT `onDidChangeContent` effect); `modelVersion` stays as a re-render trigger.