### PR TITLE
Add TS CPU-profile analyzer and hub-client profiling docs

### DIFF
--- a/claude-notes/instructions/performance-profiling.md
+++ b/claude-notes/instructions/performance-profiling.md
@@ -168,6 +168,132 @@ come up. Prefer this over adding subcommands to the user-facing
 `quarto` CLI, because these drivers should not appear as user
 features.
 
+### Profiling hub-client TypeScript code
+
+When the hotspot lives in `hub-client/src/` (attribution, presence,
+render pipeline, etc.) rather than in Rust, the playbook still applies
+but the toolchain is different. Use Node's built-in CPU profiler on a
+standalone driver — **not vitest**.
+
+**Two gotchas that will eat your session if you don't know them:**
+
+1. `NODE_OPTIONS=--cpu-prof npm run bench` appears to work but only
+   profiles the npm and vitest orchestration processes. Vitest's fork
+   pool drops the flag, so the actual worker writes no profile. Don't
+   waste time trying to plumb `execArgv` through `poolOptions.forks`
+   either — the result is still empty. Run the driver directly with
+   `node --cpu-prof` and skip vitest entirely.
+2. Any production code that yields via `requestIdleCallback` will show
+   ~99 % `(idle)` in the profile because Node falls back to
+   `setTimeout(0)` per yield. Override it at the top of the driver
+   before importing the code under test:
+
+   ```js
+   globalThis.requestIdleCallback = (cb) => {
+     cb({ didTimeout: false, timeRemaining: () => 50 });
+     return 0;
+   };
+   ```
+
+   Seen in attribution profiling (2026-04-23): vitest reported ~1 s per
+   1M-char build, actual CPU was 15 ms — the other 985 ms was
+   `setTimeout(0)` round trips. Profiling without the override
+   measures the scheduler, not your code.
+
+**Standalone driver template.** Place under `/tmp/<target>-perf/` or
+similar — these are throwaway per-session, like the Rust native-proxy
+fixtures. The pieces:
+
+- **Shim files** for any external packages you need to stub. Each shim
+  is a normal ESM module that exports the subset of the API the code
+  under test imports, with hooks the driver controls:
+
+  ```js
+  // shim-someDep.mjs
+  let impl = () => [];
+  export function setImpl(fn) { impl = fn; }
+  export function someApiFn(...args) { return impl(...args); }
+  ```
+
+- **Resolve hook** that redirects the package specifier to the shim:
+
+  ```js
+  // resolve-hook.mjs
+  import { fileURLToPath } from 'node:url';
+  import { dirname, join } from 'node:path';
+  const here = dirname(fileURLToPath(import.meta.url));
+  const shim = 'file://' + join(here, 'shim-someDep.mjs');
+  export async function resolve(specifier, context, next) {
+    if (specifier === '@scope/some-dep') {
+      return { url: shim, shortCircuit: true, format: 'module' };
+    }
+    return next(specifier, context);
+  }
+  ```
+
+- **Register bootstrap** that installs the hook on startup:
+
+  ```js
+  // register.mjs
+  import { register } from 'node:module';
+  register('./resolve-hook.mjs', import.meta.url);
+  ```
+
+- **Driver** that dynamically imports the code under test (it has to
+  be dynamic, not static, so the register hook is in place first):
+
+  ```js
+  // driver.mjs
+  globalThis.requestIdleCallback = (cb) => { cb({ didTimeout: false, timeRemaining: () => 50 }); return 0; };
+  const mod = await import(new URL('../../hub-client/src/services/<module>.ts', import.meta.url).href);
+  const shim = await import('./shim-someDep.mjs');
+  shim.setImpl(/* mock that returns workload patches */);
+  // ... call mod.hotFunction() in a timed loop over scaled fixtures
+  ```
+
+**Invocation:**
+
+```bash
+node \
+  --cpu-prof --cpu-prof-dir=/tmp/q2-ts-perf --cpu-prof-interval=200 \
+  --enable-source-maps \
+  --import tsx/esm \
+  --import /path/to/register.mjs \
+  /path/to/driver.mjs
+```
+
+`tsx/esm` (already hoisted at repo-root `node_modules/`) is what lets
+Node load `.ts` files directly. `--cpu-prof-interval=200` (µs) is a
+finer default than Node's 1 ms — useful because the actual work after
+removing the yield overhead is often only tens of ms per iteration.
+
+**Analysis:** `hub-client/scripts/perf/analyze-cpuprofile.mjs` is the
+TS counterpart of `crates/perf-harness/scripts/analyze_profile.py`.
+Reads a `.cpuprofile`, prints a top-N self-time table and
+bucketed-by-origin totals. Add `--include <substring>` once per code
+area of interest:
+
+```bash
+node hub-client/scripts/perf/analyze-cpuprofile.mjs \
+  /tmp/q2-ts-perf/CPU.*.0.001.cpuprofile --top 30 \
+  --include /src/services/<module>
+```
+
+**Caveats:**
+
+- Node writes one `.cpuprofile` per process/thread. Main-thread output
+  ends in `.0.001.cpuprofile`; tsx's loader worker writes a `.1.002`
+  sibling you can ignore.
+- Frame line numbers often show as `:1` because V8's profile doesn't
+  pick up tsx's source maps. Function names are accurate; for precise
+  line-level hotspots, pre-transpile to `.js` with inline maps and
+  profile that.
+- This is a *native proxy* in the Rust-playbook sense, with the same
+  limitation: anything you shim (e.g. `@automerge/automerge`'s `diff`)
+  disappears from the profile. Design your workload accordingly — if
+  the real bottleneck is inside the shimmed dep, you'll need a
+  browser profile to see it.
+
 ### 4. Read the numbers before designing the fix
 
 Put the numbers in a table with expected shapes next to them. If you

--- a/claude-notes/instructions/performance-profiling.md
+++ b/claude-notes/instructions/performance-profiling.md
@@ -200,56 +200,28 @@ standalone driver — **not vitest**.
    `setTimeout(0)` round trips. Profiling without the override
    measures the scheduler, not your code.
 
-**Standalone driver template.** Place under `/tmp/<target>-perf/` or
-similar — these are throwaway per-session, like the Rust native-proxy
-fixtures. The pieces:
+**Standalone driver template.** Throwaway files under
+`/tmp/<target>-perf/`, same way the Rust native-proxy fixtures are
+throwaway. The minimum is a single **driver** that overrides
+`requestIdleCallback` as above, imports the code under test, and
+calls the hot function in a timed loop over scaled fixtures.
 
-- **Shim files** for any external packages you need to stub. Each shim
-  is a normal ESM module that exports the subset of the API the code
-  under test imports, with hooks the driver controls:
+If you also need to shim an ESM dep (e.g. to bypass
+`@automerge/automerge`'s `diff`), add three more pieces, and change the
+driver to import the code under test **dynamically** (`await
+import(...)`) — a static import would resolve before the register hook
+lands:
 
-  ```js
-  // shim-someDep.mjs
-  let impl = () => [];
-  export function setImpl(fn) { impl = fn; }
-  export function someApiFn(...args) { return impl(...args); }
-  ```
-
-- **Resolve hook** that redirects the package specifier to the shim:
-
-  ```js
-  // resolve-hook.mjs
-  import { fileURLToPath } from 'node:url';
-  import { dirname, join } from 'node:path';
-  const here = dirname(fileURLToPath(import.meta.url));
-  const shim = 'file://' + join(here, 'shim-someDep.mjs');
-  export async function resolve(specifier, context, next) {
-    if (specifier === '@scope/some-dep') {
-      return { url: shim, shortCircuit: true, format: 'module' };
-    }
-    return next(specifier, context);
-  }
-  ```
-
-- **Register bootstrap** that installs the hook on startup:
-
-  ```js
-  // register.mjs
-  import { register } from 'node:module';
-  register('./resolve-hook.mjs', import.meta.url);
-  ```
-
-- **Driver** that dynamically imports the code under test (it has to
-  be dynamic, not static, so the register hook is in place first):
-
-  ```js
-  // driver.mjs
-  globalThis.requestIdleCallback = (cb) => { cb({ didTimeout: false, timeRemaining: () => 50 }); return 0; };
-  const mod = await import(new URL('../../hub-client/src/services/<module>.ts', import.meta.url).href);
-  const shim = await import('./shim-someDep.mjs');
-  shim.setImpl(/* mock that returns workload patches */);
-  // ... call mod.hotFunction() in a timed loop over scaled fixtures
-  ```
+- A **shim** — plain ESM module exporting the API slice the code under
+  test imports, plus a setter so the driver can swap in the workload
+  (e.g. `export function setImpl(fn) { impl = fn }`).
+- A **resolve hook** that redirects the real specifier to the shim URL,
+  returning `{ url, shortCircuit: true, format: 'module' }`.
+  `shortCircuit: true` is required.
+- A **register bootstrap** — two lines calling
+  `register('./resolve-hook.mjs', import.meta.url)`. Passed via Node's
+  `--import` flag (see invocation below) so the hook is active before
+  any `import` resolves.
 
 **Invocation:**
 

--- a/hub-client/scripts/perf/analyze-cpuprofile.mjs
+++ b/hub-client/scripts/perf/analyze-cpuprofile.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+// Self-time aggregator for V8 `.cpuprofile` files.
+//
+// TypeScript counterpart to `crates/perf-harness/scripts/analyze_profile.py`
+// — same intent (read a profile, emit a top-N self-time table) but for
+// Node's `--cpu-prof` output rather than samply's JSON.
+//
+// Usage:
+//   node analyze-cpuprofile.mjs <path-to-.cpuprofile> [--top N] [--include GLOB ...]
+//
+// --include adds a custom bucket: any frame whose callFrame.url contains
+// the literal substring GLOB is tallied into a bucket named after it. Pass
+// multiple times to compare, e.g.:
+//   --include /src/services/attribution --include /src/components/Editor
+//
+// Profile format reference:
+//   https://v8.dev/docs/profile (nodes / samples / timeDeltas)
+
+import fs from 'node:fs';
+import process from 'node:process';
+
+function parseArgs(argv) {
+  const args = { file: null, top: 30, includes: [] };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--top') args.top = Number(argv[++i]);
+    else if (a === '--include') args.includes.push(argv[++i]);
+    else if (!args.file) args.file = a;
+    else throw new Error(`unexpected arg: ${a}`);
+  }
+  if (!args.file) {
+    console.error('usage: analyze-cpuprofile.mjs <profile> [--top N] [--include SUBSTR ...]');
+    process.exit(1);
+  }
+  return args;
+}
+
+function labelFor(node) {
+  const cf = node.callFrame;
+  const name = cf.functionName || '(anonymous)';
+  const url = cf.url || '';
+  const short = url
+    .replace(/^file:\/\//, '')
+    .replace(/^.*\/(src|node_modules|dist|scripts)\//, '$1/');
+  const loc = url ? `${short}:${(cf.lineNumber ?? 0) + 1}` : '';
+  return loc ? `${name}  ${loc}` : name;
+}
+
+function defaultBucket(node) {
+  const url = node.callFrame.url || '';
+  const name = node.callFrame.functionName || '';
+  if (!url && (name === '(garbage collector)' || name === '(program)' || name === '(idle)')) {
+    return 'runtime';
+  }
+  if (!url || url.startsWith('node:')) return 'runtime';
+  if (url.includes('/node_modules/')) return 'deps';
+  return 'app';
+}
+
+function bucketFor(node, includes) {
+  const url = node.callFrame.url || '';
+  for (const sub of includes) if (url.includes(sub)) return sub;
+  return defaultBucket(node);
+}
+
+const args = parseArgs(process.argv.slice(2));
+const profile = JSON.parse(fs.readFileSync(args.file, 'utf8'));
+const { nodes, samples, timeDeltas } = profile;
+const nodeById = new Map(nodes.map(n => [n.id, n]));
+
+const self = new Map();
+let total = 0;
+for (let i = 0; i < samples.length; i++) {
+  const id = samples[i];
+  const dt = timeDeltas[i] || 0;
+  self.set(id, (self.get(id) || 0) + dt);
+  total += dt;
+}
+
+const ranked = [...self.entries()]
+  .filter(([id]) => nodeById.has(id))
+  .map(([id, t]) => ({ id, t, node: nodeById.get(id) }))
+  .sort((a, b) => b.t - a.t);
+
+const pct = t => (100 * t / total).toFixed(1).padStart(5);
+const ms = t => (t / 1000).toFixed(1).padStart(7);
+
+console.log(`${args.file}`);
+console.log(`samples=${samples.length}  total=${(total / 1000).toFixed(1)} ms`);
+
+console.log(`\nTop ${args.top} self-time frames:`);
+console.log('  pct       ms  frame');
+for (const e of ranked.slice(0, args.top)) {
+  console.log(`${pct(e.t)}% ${ms(e.t)}  ${labelFor(e.node)}`);
+}
+
+const buckets = new Map();
+for (const e of ranked) {
+  const k = bucketFor(e.node, args.includes);
+  buckets.set(k, (buckets.get(k) || 0) + e.t);
+}
+console.log('\nBy origin:');
+for (const [k, t] of [...buckets.entries()].sort((a, b) => b[1] - a[1])) {
+  console.log(`${pct(t)}% ${ms(t)}  ${k}`);
+}
+
+for (const sub of args.includes) {
+  const matches = ranked.filter(e => (e.node.callFrame.url || '').includes(sub));
+  if (!matches.length) continue;
+  console.log(`\nFrames matching "${sub}":`);
+  for (const e of matches) console.log(`${pct(e.t)}% ${ms(e.t)}  ${labelFor(e.node)}`);
+}


### PR DESCRIPTION
Extends the perf-profiling playbook with a TypeScript section covering two gotchas surfaced while profiling the attribution code on `feat/node-attribution`: 
1. `NODE_OPTIONS=--cpu-prof` on `npm run bench` only profiles vitest's orchestration processes, not the fork-pool worker.
2. Any code that yields via `requestIdleCallback` shows as 99% `(idle)` unless overridden with a synchronous stub, masking real CPU time (in the attribution case, 985 ms of `setTimeout(0)` round trips hid behind a 15 ms CPU workload).

Documents the standalone `node --cpu-prof` + `--import tsx/esm` + resolve-hook pattern as the workaround, and adds `hub-client/scripts/perf/analyze-cpuprofile.mjs` as the TS counterpart to `crates/perf-harness/scripts/analyze_profile.py`.

No per-target drivers are committed — the template in the playbook is what generalizes.