### PR TITLE
Improve cargo xtask dev-setup: cmake detection and xtask self-build lock

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,14 @@ brew install llvm
 
 This only needs to be done once. The build scripts locate it automatically in the standard Homebrew paths (`/opt/homebrew/opt/llvm` on Apple Silicon, `/usr/local/opt/llvm` on Intel).
 
+### cmake (required for `cargo build --workspace`)
+
+The `quarto-highlight` crate enables the `wasm` feature on `tree-sitter`, which pulls in `wasmtime-c-api-impl` as a transitive dependency. Its `build.rs` shells out to `cmake`, so `cmake` must be on `PATH` for any full workspace build. Any modern version works. `cargo dev-setup` checks this and warns if needed.
+
+- **Windows**: `scoop install cmake` (or `winget install Kitware.CMake`)
+- **macOS**: `brew install cmake` (bundled alongside `brew install llvm` above if you installed it for WASM)
+- **Linux**: `apt install cmake` (Debian/Ubuntu) or `dnf install cmake` (Fedora/RHEL)
+
 ### Pandoc 3.6+ (optional)
 
 Four tests in the `pampa` crate compare output against Pandoc. These tests require Pandoc 3.6 or later and will fail when Pandoc is missing or too old. `cargo dev-setup` checks this and warns if needed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ This only needs to be done once. The build scripts locate it automatically in th
 The `quarto-highlight` crate enables the `wasm` feature on `tree-sitter`, which pulls in `wasmtime-c-api-impl` as a transitive dependency. Its `build.rs` shells out to `cmake`, so `cmake` must be on `PATH` for any full workspace build. Any modern version works. `cargo dev-setup` checks this and warns if needed.
 
 - **Windows**: `scoop install cmake` (or `winget install Kitware.CMake`)
-- **macOS**: `brew install cmake` (bundled alongside `brew install llvm` above if you installed it for WASM)
+- **macOS**: `brew install cmake` (separate from the `brew install llvm` step above)
 - **Linux**: `apt install cmake` (Debian/Ubuntu) or `dnf install cmake` (Fedora/RHEL)
 
 ### Pandoc 3.6+ (optional)

--- a/crates/xtask/src/dev_setup.rs
+++ b/crates/xtask/src/dev_setup.rs
@@ -146,9 +146,62 @@ pub fn run() -> Result<()> {
         println!("Installed {installed} tool(s), {already} already present.");
     }
 
+    check_cmake();
     check_pandoc();
 
     Ok(())
+}
+
+/// Check for cmake (required — `cargo build --workspace` pulls in
+/// wasmtime-c-api-impl transitively via quarto-highlight, and its build.rs
+/// shells out to cmake).
+fn check_cmake() {
+    let output = Command::new("cmake").arg("--version").output();
+
+    let ok = matches!(&output, Ok(o) if o.status.success());
+    if !ok {
+        println!(
+            "\n  WARNING: cmake not found. `cargo build --workspace` will fail.\n  \
+             cmake is required transitively by quarto-highlight (wasmtime-c-api-impl).\n  \
+             Install:"
+        );
+        for line in cmake_install_hints() {
+            println!("    {line}");
+        }
+        return;
+    }
+
+    let output = output.expect("checked Ok above");
+    let first_line = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .next()
+        .unwrap_or("cmake")
+        .trim()
+        .to_string();
+    println!("\n  {first_line} — detected");
+}
+
+/// Platform-specific cmake install commands. Order matters: preferred first.
+fn cmake_install_hints() -> &'static [&'static str] {
+    #[cfg(windows)]
+    {
+        &["scoop install cmake", "winget install Kitware.CMake"]
+    }
+    #[cfg(target_os = "macos")]
+    {
+        &["brew install cmake"]
+    }
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        &[
+            "apt install cmake    # Debian/Ubuntu",
+            "dnf install cmake    # Fedora/RHEL",
+        ]
+    }
+    #[cfg(not(any(windows, unix)))]
+    {
+        &["See https://cmake.org/download/"]
+    }
 }
 
 /// Check for Pandoc 3.6+ (optional — needed only for pampa comparison tests).

--- a/crates/xtask/src/dev_setup.rs
+++ b/crates/xtask/src/dev_setup.rs
@@ -156,22 +156,15 @@ pub fn run() -> Result<()> {
 /// wasmtime-c-api-impl transitively via quarto-highlight, and its build.rs
 /// shells out to cmake).
 fn check_cmake() {
-    let output = Command::new("cmake").arg("--version").output();
-
-    let ok = matches!(&output, Ok(o) if o.status.success());
-    if !ok {
-        println!(
-            "\n  WARNING: cmake not found. `cargo build --workspace` will fail.\n  \
-             cmake is required transitively by quarto-highlight (wasmtime-c-api-impl).\n  \
-             Install:"
-        );
-        for line in cmake_install_hints() {
-            println!("    {line}");
-        }
+    let Ok(output) = Command::new("cmake").arg("--version").output() else {
+        warn_cmake_missing();
+        return;
+    };
+    if !output.status.success() {
+        warn_cmake_missing();
         return;
     }
 
-    let output = output.expect("checked Ok above");
     let first_line = String::from_utf8_lossy(&output.stdout)
         .lines()
         .next()
@@ -179,6 +172,17 @@ fn check_cmake() {
         .trim()
         .to_string();
     println!("\n  {first_line} — detected");
+}
+
+fn warn_cmake_missing() {
+    println!(
+        "\n  Warning: cmake not found. `cargo build --workspace` will fail.\n  \
+         cmake is required transitively by quarto-highlight (wasmtime-c-api-impl).\n  \
+         Install:"
+    );
+    for line in cmake_install_hints() {
+        println!("    {line}");
+    }
 }
 
 /// Platform-specific cmake install commands. Order matters: preferred first.

--- a/crates/xtask/src/verify.rs
+++ b/crates/xtask/src/verify.rs
@@ -109,9 +109,7 @@ pub fn run(config: &VerifyConfig) -> Result<()> {
         );
         // On Windows, Cargo cannot re-link target/debug/xtask.exe while the
         // currently-running xtask holds a file lock on it. Linux/macOS
-        // tolerate overwriting a running binary. Step 5 (nextest) still
-        // compiles xtask as a test binary on all platforms, so xtask's
-        // warnings coverage is preserved.
+        // tolerate overwriting a running binary.
         #[cfg(windows)]
         let build_args: &[&str] = &["build", "--workspace", "--exclude", "xtask"];
         #[cfg(not(windows))]
@@ -124,6 +122,20 @@ pub fn run(config: &VerifyConfig) -> Result<()> {
             rustflags,
             "Rust build failed",
         )?;
+
+        // On Windows we excluded xtask above; `cargo check -p xtask` still
+        // gives xtask the `-D warnings` pass without relinking the running
+        // exe (cargo check doesn't produce a binary). This keeps xtask
+        // validated even under `cargo xtask verify --skip-rust-tests`.
+        #[cfg(windows)]
+        run_command(
+            "cargo",
+            &["check", "-p", "xtask"],
+            &project_root,
+            rustflags,
+            "xtask check failed",
+        )?;
+
         println!("✓ Rust build complete");
     } else {
         println!("\n━━━ Step 3/{}: Skipping Rust build ━━━\n", TOTAL_STEPS);

--- a/crates/xtask/src/verify.rs
+++ b/crates/xtask/src/verify.rs
@@ -107,9 +107,19 @@ pub fn run(config: &VerifyConfig) -> Result<()> {
                 ""
             }
         );
+        // On Windows, Cargo cannot re-link target/debug/xtask.exe while the
+        // currently-running xtask holds a file lock on it. Linux/macOS
+        // tolerate overwriting a running binary. Step 5 (nextest) still
+        // compiles xtask as a test binary on all platforms, so xtask's
+        // warnings coverage is preserved.
+        #[cfg(windows)]
+        let build_args: &[&str] = &["build", "--workspace", "--exclude", "xtask"];
+        #[cfg(not(windows))]
+        let build_args: &[&str] = &["build", "--workspace"];
+
         run_command(
             "cargo",
-            &["build", "--workspace"],
+            build_args,
             &project_root,
             rustflags,
             "Rust build failed",


### PR DESCRIPTION
Two cross-platform dev-ergonomics fixes surfaced while verifying PR #109 on Windows. Both are orthogonal to the WASM work.

## Background

`quarto-highlight` (already on main) enables the `wasm` feature on `tree-sitter` for native builds. That pulls in `wasmtime-c-api-impl` as a transitive dependency, whose `build.rs` shells out to cmake. Result: cmake is now a hard prerequisite for `cargo build --workspace` on every platform. GitHub Actions runners have it pre-installed. Local dev boxes frequently do not.

## Fix 1 — `check_cmake()` in `dev_setup.rs`

Follows the existing `check_pandoc()` pattern. Detects cmake via `cmake --version`. If missing, prints a warning with platform-specific install commands (scoop/winget on Windows, brew on macOS, apt/dnf on Linux). No version floor — any modern cmake works for wasmtime-c-api. Warning only; `cargo dev-setup` still exits 0.

## Fix 2 — `cfg(windows)`-gated `--exclude xtask` in `verify.rs` step 3

On Windows, Cargo could not re-link `target/debug/xtask.exe` while the currently-running xtask held a file lock on it (`Accès refusé (os error 5)`). Linux/macOS tolerate overwriting a running binary, so the fix is Windows-only.

To avoid creating a gap where `cargo xtask verify --skip-rust-tests` on Windows would never compile or check xtask at all, a follow-up `cargo check -p xtask` runs on Windows. `cargo check` does not relink, so no file lock, and xtask still gets the `-D warnings` pass.

## Fix 3 — `CONTRIBUTING.md` cmake section

Added after the existing macOS Homebrew LLVM section, with per-platform install commands.

## Test plan

- [x] `cargo xtask dev-setup` reports `cmake version 4.3.2 — detected` on Windows
- [x] `cargo xtask verify --skip-rust-tests --skip-hub-build --skip-hub-tests --skip-treesitter-tests --skip-trace-viewer-build --skip-trace-viewer-tests` completes step 3 on Windows without the `os error 5` file lock
- [x] `cargo nextest run -p xtask` — 9/9 tests pass
- [x] `RUSTFLAGS="-D warnings" cargo check -p xtask` passes
- [x] Full `cargo nextest run --workspace` on Linux/macOS CI

Tracked in beads bd-tjbr.