### PR TITLE
Check in stranded quarto.doc + async Lua plan files

### DIFF
--- a/claude-notes/plans/2026-04-01-quarto-doc-infrastructure.md
+++ b/claude-notes/plans/2026-04-01-quarto-doc-infrastructure.md
@@ -1,0 +1,346 @@
+# Plan: `quarto.doc` Lua API + HTML Dependency Infrastructure
+
+## Status: Complete
+
+Landed on `main` as:
+- `446742b6` "Add quarto.doc Lua API, script-dir stack, and dofile/loadfile for WASM" (pre-squash)
+- `f87b11b9` "Add built-in extension infrastructure, Lua APIs, and pipeline wiring" (squashed landing on main, 2026-04-01)
+- `1e2cb0a3` "Remove script-dir push/pop from WASM dofile override" (cleanup, 2026-04-16)
+- `52968801` "Remove test arm from wasm32 cfg guards in Lua initialization" (cleanup, 2026-04-16)
+- `chore/incomplete-plans` (this branch) — Phase 5 smoke fixture `quarto-doc-api-extension`
+
+---
+
+## Overview
+
+Add the `quarto.doc` Lua namespace and HTML dependency infrastructure so
+that Lua shortcode extensions can register CSS/JS dependencies, detect
+the output format, inject text at specific document locations, and check
+for Bootstrap. Also add `quarto.version` and `quarto.base64.encode()`.
+
+This is the foundation plan. Two follow-up plans add built-in extensions
+that exercise these APIs:
+- `claude-notes/plans/2026-04-01-builtin-extensions-batch2.md` (version, kbd, placeholder)
+- `claude-notes/plans/2026-04-01-builtin-extension-video.md` (video)
+
+## Background
+
+### What TS Quarto provides
+
+TS Quarto's `quarto.doc` namespace (defined in `init.lua`) provides:
+- `is_format(fmt)` — check output format
+- `add_html_dependency({name, stylesheets, scripts, ...})` — register
+  CSS/JS deps, deduplicated by name
+- `include_text(location, text)` — inject raw text at
+  `"in-header"` / `"before-body"` / `"after-body"`
+- `has_bootstrap()` — check if Bootstrap is in use
+
+TS Quarto communicates dependencies via a temp file (JSON Lines) because
+Pandoc is an external process. We don't need that — our Lua runs
+in-process, so we use the same pattern as diagnostics: store in a Lua
+table, extract after execution, push onto `StageContext`.
+
+### Current q2 state
+
+- **No `quarto.doc` namespace** exists
+- **No `quarto.version`** — only `PANDOC_VERSION` is set
+- **No `quarto.base64`** — base64 exists internally in mediabag but not
+  exposed
+- **Diagnostics pattern**: `quarto._diagnostics` Lua table, extracted
+  via `extract_lua_diagnostics()` after filter execution. Shortcode
+  execution does NOT currently extract Lua diagnostics (pre-existing gap)
+- **Artifact store**: `StageContext.artifacts` is a key-value store with
+  `get_by_prefix()`. CSS compilation already uses it (`"css:default"`
+  artifact). WASM post-pipeline loop writes all artifacts with paths to
+  VFS automatically.
+- **`FORMAT` global**: Already set in `LuaShortcodeEngine::new()` to the
+  target format string (e.g. `"html"`)
+- **`PandocIncludes`**: Exists as a struct with `header_includes`,
+  `include_before`, `include_after` but only used by knitr engine, not
+  exposed to Lua
+- **`dofile()`/`loadfile()`**: Available from mlua's base library
+  (always loaded) but use C `fopen` directly, bypassing `SystemRuntime`.
+  In WASM, `fopen` returns null so they fail. Need to overwrite with
+  `SystemRuntime`-backed versions.
+
+### Key files
+
+| File | Role |
+|---|---|
+| `crates/pampa/src/lua/quarto_api.rs` | Registers `quarto.*` Lua namespace |
+| `crates/pampa/src/lua/shortcode.rs` | `LuaShortcodeEngine` — sets up globals, calls handlers |
+| `crates/pampa/src/lua/filter.rs` | Filter execution — restricted Lua setup |
+| `crates/pampa/src/lua/diagnostics.rs` | Diagnostic collection pattern (model for deps) |
+| `crates/pampa/src/lua/io_wasm.rs` | Synthetic `io.open` for restricted env |
+| `crates/pampa/src/lua/os_wasm.rs` | Synthetic `os.*` for restricted env |
+| `crates/pampa/src/lua/mediabag.rs` | `pandoc.mediabag` including `make_data_uri` |
+| `crates/quarto-core/src/stage/context.rs` | `StageContext` — shared pipeline context |
+| `crates/quarto-core/src/artifact.rs` | `ArtifactStore` with `get_by_prefix()` |
+| `crates/quarto-core/src/stage/stages/apply_template.rs` | Template stage — consumes CSS artifacts |
+| `crates/quarto-core/src/stage/stages/compile_theme_css.rs` | Stores `"css:default"` artifact |
+| `crates/quarto-core/src/transforms/shortcode_resolve.rs` | Shortcode transform — calls pampa Lua engine |
+| `crates/quarto-core/src/render_to_file.rs` | Native file output — writes artifacts to disk |
+| `crates/wasm-quarto-hub-client/src/lib.rs` | WASM — writes artifacts to VFS post-pipeline |
+| `crates/quarto-core/src/stage/data.rs` | `PandocIncludes` struct |
+
+### Architecture: How data flows
+
+The pipeline runs stages sequentially, all sharing one `&mut StageContext`:
+
+```
+ParseDocument → EngineExecution → MetadataMerge → CompileThemeCss →
+  UserFilters(pre) → AstTransforms → UserFilters(post) →
+  RenderHtmlBody → ApplyTemplate
+```
+
+**AstTransforms** runs shortcodes (via `ShortcodeResolveTransform`). A
+Lua shortcode calls `quarto.doc.add_html_dependency(...)` which stores
+data in a Lua table. After execution, Rust extracts deps and stores
+them as artifacts on `StageContext`.
+
+**ApplyTemplate** runs later, reads all `css:*` and `js:*` artifacts,
+generates `<link>` and `<script>` tags in the HTML template.
+
+**Post-pipeline**: Native `render_to_file` writes artifact files to
+`{stem}_files/`. WASM's existing loop writes all artifacts with paths
+to VFS.
+
+### Diagnostic collection pattern (model for HTML deps)
+
+Diagnostics use Lua-table storage, not `Arc<Mutex>`:
+1. `register_quarto_namespace()` creates `quarto._diagnostics` table
+2. `quarto.warn()` / `quarto.error()` push entries onto it
+3. `extract_lua_diagnostics(&lua)` reads them back after execution
+4. Filter returns `Vec<DiagnosticMessage>` alongside the AST
+5. Transform pushes onto `ctx.add_diagnostic()`
+
+HTML dependencies will follow the same pattern with
+`quarto.doc._dependencies` and `quarto.doc._text_includes`.
+
+---
+
+## Work Items
+
+### Phase 1: `quarto.version` and `quarto.base64`
+
+- [x] **1.1** Add `quarto.version` to the Lua environment. In
+  `quarto_api.rs`, set `quarto.version` to a Lua table `{0, 1, 0}` (or
+  whatever our current version is). TS Quarto uses a list that gets
+  `table.concat(quarto.version, '.')` to produce `"1.4.0"`.
+
+- [x] **1.2** Add `quarto.base64` namespace with `encode(data)`. The
+  base64 encoding already exists in `mediabag.rs` (`make_data_uri` uses
+  it internally via the `base64` crate). Expose it as
+  `quarto.base64.encode(string) -> string`.
+
+- [x] **1.3** Unit tests in pampa for both APIs.
+
+### Phase 2: Overwrite `dofile`/`loadfile` in restricted Lua
+
+- [x] **2.1** In the restricted Lua setup (both `filter.rs` and
+  `shortcode.rs`, the `#[cfg(any(target_arch = "wasm32", test))]`
+  path), after registering synthetic io/os, overwrite `dofile` and
+  `loadfile` globals with Rust functions that:
+  - Read the file via `runtime.file_read()`
+  - Compile via `lua.load(content).set_name(filename)`
+  - For `dofile`: execute immediately and return results
+  - For `loadfile`: return the compiled chunk without executing
+
+  This ensures all file access goes through `SystemRuntime`, making
+  `dofile` work in WASM (where C `fopen` returns null).
+
+  **Update:** `52968801` later removed the `test` arm per `.claude/rules/wasm.md`; the cfg is now `#[cfg(target_arch = "wasm32")]`.
+
+- [x] **2.2** Unit tests: `dofile` and `loadfile` work in the test
+  (restricted) environment with temp files via `NativeRuntime`.
+
+### Phase 3: `quarto.doc` Lua namespace
+
+- [x] **3.1** Create `crates/pampa/src/lua/quarto_doc.rs` with:
+
+  ```rust
+  pub fn register_quarto_doc(lua: &Lua, format: &str) -> Result<()>
+  ```
+
+  This registers the `quarto.doc` table on the existing `quarto` global:
+  - `quarto.doc.is_format(fmt)` — compares `fmt` against the `FORMAT`
+    global (already set). Support both exact match (`"html"`) and
+    prefix match (`"html:js"` matches `"html"`), matching TS Quarto's
+    `quarto.doc.is_format()` behavior.
+  - `quarto.doc.has_bootstrap()` — for now, return `true` when format
+    is HTML (we always use Bootstrap themes in HTML output). Can be
+    refined later when we support non-Bootstrap HTML.
+  - `quarto.doc._dependencies` — internal Lua table for collecting deps
+  - `quarto.doc._text_includes` — internal Lua table for text injections
+  - `quarto.doc.add_html_dependency(dep)` — validates `dep.name`
+    (required), `dep.stylesheets` and `dep.scripts` (optional arrays
+    of strings). Resolves relative paths via `quarto.utils.resolve_path`.
+    Deduplicates by name (skip if name already in table). Pushes onto
+    `quarto.doc._dependencies`.
+  - `quarto.doc.include_text(location, text)` — validates `location`
+    is one of `"in-header"`, `"before-body"`, `"after-body"`.
+    Pushes `{location, text}` onto `quarto.doc._text_includes`.
+
+  **Implementation note:** actual signature is `register_quarto_doc(lua: &Lua)` — the `is_format` closure reads the `FORMAT` global at call time rather than taking it as an argument. camelCase aliases (`isFormat`, `addHtmlDependency`, etc.) also registered for TS Quarto compat.
+
+- [x] **3.2** Create extraction functions:
+  ```rust
+  pub fn extract_html_dependencies(lua: &Lua) -> Result<Vec<HtmlDependency>>
+  pub fn extract_text_includes(lua: &Lua) -> Result<Vec<TextInclude>>
+  ```
+
+  Where:
+  ```rust
+  pub struct HtmlDependency {
+      pub name: String,
+      pub stylesheets: Vec<PathBuf>,  // resolved absolute paths
+      pub scripts: Vec<PathBuf>,      // resolved absolute paths
+  }
+
+  pub struct TextInclude {
+      pub location: IncludeLocation,  // InHeader, BeforeBody, AfterBody
+      pub content: String,
+  }
+
+  pub enum IncludeLocation {
+      InHeader,
+      BeforeBody,
+      AfterBody,
+  }
+  ```
+
+- [x] **3.3** Call `register_quarto_doc()` in both `shortcode.rs`
+  `LuaShortcodeEngine::new()` and `filter.rs` `apply_lua_filter()`,
+  passing the target format string.
+
+- [x] **3.4** Unit tests in pampa for all `quarto.doc.*` functions.
+
+### Phase 4: Wire dependencies into the pipeline
+
+- [x] **4.1** Add `html_dependencies: Vec<HtmlDependency>` and
+  `text_includes: Vec<TextInclude>` fields to `StageContext`.
+
+  **Deviation:** no new `StageContext` fields were needed. Dependencies flow through the existing `artifacts` store (`css:*`, `js:*`) and text includes flow through the existing `ctx.includes: PandocIncludes`.
+
+- [x] **4.2** In `shortcode_resolve.rs`, after shortcode execution,
+  call `extract_html_dependencies()` and `extract_text_includes()` on
+  the Lua engine. Store results on `StageContext` (via `RenderContext`
+  which has access to the artifact store).
+
+  Also fix the pre-existing gap: call `extract_lua_diagnostics()` on
+  the shortcode engine's Lua state and push onto `ctx.diagnostics`.
+
+  Wired at `shortcode_resolve.rs:578-599` and mirrored in `user_filters.rs:179-185` so filter extensions get the same treatment.
+
+- [x] **4.3** For each `HtmlDependency`, read file contents via
+  `runtime.file_read()` and store as artifacts:
+  - `"css:{name}"` for each stylesheet, with path like
+    `{name}/{filename}` relative to the output resource dir
+  - `"js:{name}"` for each script, same path convention
+
+  **Deviation:** artifact keys are `css:{name}:{filename}` / `js:{name}:{filename}` and paths are `libs/{name}/{filename}` (matching TS Quarto's `libs/` convention). See `dependency.rs:store_html_dependencies`.
+
+- [x] **4.4** For each `TextInclude`, store as artifacts with keys like
+  `"include:in-header:{n}"`, `"include:before-body:{n}"`,
+  `"include:after-body:{n}"`.
+
+  **Deviation:** text includes do not go through the artifact store. They're pushed directly onto `ctx.includes: PandocIncludes` (`header_includes` / `include_before` / `include_after`), which the template already renders via `$for(header-includes)$` etc. Simpler and reuses the engine-execution plumbing.
+
+- [x] **4.5** In `ApplyTemplateStage`, collect artifacts:
+  - All `"css:*"` artifacts → add their paths to the CSS list alongside
+    the existing `"css:default"` path
+  - All `"js:*"` artifacts → generate `<script src="...">` tags (new)
+  - All `"include:in-header:*"` → inject into `<head>`
+  - All `"include:before-body:*"` → inject before `<body>` content
+  - All `"include:after-body:*"` → inject after `<body>` content
+
+  CSS/JS collection at `apply_template.rs:166-182` (prepends the `{stem}_files/` resource prefix). Text includes flow through the existing `PandocIncludes` template bindings — see 4.4 deviation.
+
+- [x] **4.6** In `render_to_file.rs`, after the existing CSS write,
+  add a loop that writes all `"css:*"` and `"js:*"` artifacts to
+  `{stem}_files/`. (WASM already handles this — the existing
+  artifact→VFS loop writes all artifacts with paths.)
+
+  **Deviation:** no new loop needed — the existing generic artifact-writing code handles the new `css:*`/`js:*` artifacts uniformly.
+
+### Phase 5: Integration tests
+
+- [x] **5.1** Create a smoke test with a custom extension that uses
+  `quarto.doc.add_html_dependency()` to register a CSS file. Verify
+  the CSS file content appears in the output (either as a `<link>` tag
+  pointing to the right path, or inline for WASM).
+
+- [x] **5.2** Create a smoke test that uses `quarto.doc.include_text()`
+  to inject content at `"after-body"`. Verify it appears in the output.
+
+- [x] **5.3** Create a smoke test that uses `quarto.doc.is_format()` to
+  produce format-dependent output.
+
+  5.1–5.3 are covered by a single fixture: `crates/quarto/tests/smoke-all/extensions/quarto-doc-api-extension/` exercises `add_html_dependency` (stylesheet + file-exists check), `include_text` at both `in-header` and `after-body`, and `is_format('html')` in one shortcode.
+
+- [x] **5.4** `cargo nextest run --workspace` — no regressions
+
+- [x] **5.5** `cargo xtask verify` — full verification including WASM
+
+## Design Notes
+
+### Why use the artifact store for dependencies
+
+The artifact store (`StageContext.artifacts`) already handles the
+CSS compilation → template → file output flow. The pattern:
+1. Stage stores content as artifact with a path
+2. Template stage references the path in HTML tags
+3. Post-pipeline code writes content to the path on disk (native)
+   or VFS (WASM)
+
+HTML dependencies follow the same pattern. The `get_by_prefix("css:")`
+API was designed for exactly this kind of batch collection.
+
+### Deduplication
+
+HTML dependencies are deduplicated by `name` at registration time in
+Lua (matching TS Quarto's behavior). If a shortcode is called 5 times,
+the dependency is registered once.
+
+### Path resolution
+
+When Lua calls `add_html_dependency({stylesheets={"kbd.css"}})`, the
+path `"kbd.css"` is relative to the extension directory (where the
+Lua script lives). `quarto.utils.resolve_path()` already resolves
+relative to `_quarto_script_dir`. The Rust extraction converts these
+to absolute paths.
+
+### No `Arc<Mutex>` needed
+
+The diagnostic pattern shows the way: Lua stores data in tables,
+Rust extracts it synchronously after execution. The pipeline is
+single-threaded through each stage. No shared mutable state needed.
+
+### `dofile`/`loadfile` overwrite rationale
+
+mlua unconditionally loads the C base library (`luaopen_base`),
+which includes `dofile` and `loadfile`. These call C `fopen` directly,
+bypassing `SystemRuntime`. In WASM, `fopen` returns null (from
+`c_shim.rs`), so they silently fail. In tests, they use real `fopen`,
+bypassing the synthetic io layer.
+
+Overwriting them after Lua state creation (same pattern as io/os
+replacement) ensures all file access goes through `SystemRuntime`.
+This is not shadowing (as in JavaScript prototype chains) — Lua
+globals are a flat table, so setting `_G["dofile"]` replaces the
+old function entirely.
+
+## Files Touched
+
+| File | Change |
+|---|---|
+| `crates/pampa/src/lua/quarto_api.rs` | Add `quarto.version`, `quarto.base64` |
+| `crates/pampa/src/lua/quarto_doc.rs` | New: `quarto.doc` namespace registration |
+| `crates/pampa/src/lua/mod.rs` | Add `quarto_doc` module |
+| `crates/pampa/src/lua/shortcode.rs` | Call `register_quarto_doc`, extract deps after execution |
+| `crates/pampa/src/lua/filter.rs` | Call `register_quarto_doc`, overwrite `dofile`/`loadfile` |
+| `crates/quarto-core/src/stage/context.rs` | Add `html_dependencies`, `text_includes` fields |
+| `crates/quarto-core/src/transforms/shortcode_resolve.rs` | Extract deps + diagnostics from Lua |
+| `crates/quarto-core/src/stage/stages/apply_template.rs` | Collect `css:*`, `js:*`, `include:*` artifacts |
+| `crates/quarto-core/src/render_to_file.rs` | Write `css:*`, `js:*` artifacts to output dir |
+| Smoke test fixtures | New: tests for `add_html_dependency`, `include_text`, `is_format` |

--- a/claude-notes/plans/2026-04-02-async-lua-fetch-url.md
+++ b/claude-notes/plans/2026-04-02-async-lua-fetch-url.md
@@ -1,0 +1,357 @@
+# Plan: Async Lua execution + `fetch_url` for WASM
+
+## Status: Complete
+
+Landed on `main` as:
+- `f3c18793` "Phase 0: validate mlua async feature on wasm32-unknown-unknown"
+- `9a068a23` "Implement async fetch_url on SystemRuntime (Phases 1-2)"
+- `be910b38` "Phase 3: make Lua filter traversal async in pampa"
+- `69b33153` "Phase 4: make shortcode engine async in pampa"
+- `73108f12` "Make AstTransform trait and shortcode resolution fully async"
+- `233c9c3c` "Add async Lua execution and implement fetch_url for native + WASM"
+- `e537fb80` "Add async Lua execution, fetch_url, and fully async AST transforms" (squashed landing, 2026-04-06)
+- `59f2f011` / `d4bd7582` — native `fetch_url` switched from async reqwest to `reqwest::blocking` after a tokio-reactor panic when driven by `pollster::block_on`
+- `f6a2a4c2` "Add e2e smoke test for image shortcode with mediabag.fetch + base64" (Phase 5.1 coverage)
+
+---
+
+## Overview
+
+`pandoc.mediabag.fetch()` is a Lua API that fetches content from URLs. It
+is currently a stub that returns `(nil, nil)` on all platforms because
+`SystemRuntime::fetch_url` is unimplemented everywhere. The blocker on
+WASM is that browser network I/O is inherently async, and Lua normally
+runs synchronously.
+
+This plan implements the full solution:
+
+1. Make pampa's Lua execution async-capable via mlua coroutines, so that
+   Lua filters and shortcodes can yield while a `fetch_url` future resolves.
+2. Implement `fetch_url` on `NativeRuntime` (reqwest) and `WasmRuntime`
+   (JS fetch shim → JsFuture), replacing the stub.
+3. Wire `pandoc.mediabag.fetch` to call the new async `fetch_url`.
+
+This approach does **not** require moving the WASM module to a Web Worker.
+The Lua coroutine mechanism handles yielding transparently — Lua filter
+and shortcode scripts see no change to their API.
+
+---
+
+## Codebase context
+
+### mlua async support
+
+mlua 0.11.6 (current) supports async via an `async` feature flag. When
+enabled:
+- `lua.create_async_function(|lua, args| async move { ... })` registers
+  an async Rust function callable from Lua
+- `func.call_async(args).await` drives a Lua function through its
+  coroutine lifecycle
+- `chunk.eval_async().await` and `chunk.exec_async().await` for top-level
+  execution
+
+Under the hood, mlua wraps the Lua VM in a coroutine. When Lua calls an
+async Rust function, the coroutine yields; when the Rust future resolves,
+the coroutine resumes. Lua scripts are completely unaware of this.
+
+**Current pampa state**: mlua features are `lua54, vendored, serialize` —
+no `async` feature. Pampa has zero async code and no async dependencies.
+
+**Critical unknown**: mlua async on `wasm32-unknown-unknown` with our
+custom `lua-src-wasm` build. mlua's async uses Lua coroutines (a pure
+Lua/C feature, not OS threads), so it should be compatible. Phase 0
+validates this before committing to the rest.
+
+### quarto-system-runtime: async infrastructure already exists
+
+`WasmRuntime` already implements several async trait methods
+(`js_render_simple_template`, `render_ejs`, `compile_sass`, `cache_get`,
+etc.) using the same pattern: a JS shim function is called via
+`wasm-bindgen`, the returned Promise is wrapped with `JsFuture`, and
+`.await`ed. `quarto-system-runtime` already depends on
+`wasm-bindgen-futures` and imports `JsFuture`. Adding `fetch_url` follows
+this established pattern exactly.
+
+For `NativeRuntime`, `fetch_url` will use `reqwest` (async). This is a
+new dependency for `quarto-system-runtime`.
+
+### Two Lua execution paths in pampa
+
+Both must go async for `pandoc.mediabag.fetch` to work everywhere:
+
+**1. Filter traversal** (`crates/pampa/src/lua/filter.rs`):
+- `apply_lua_filter` → top-level entry point
+- `apply_typewise_filter`, `apply_topdown_filter` → dispatchers
+- 5 internal `walk_*` functions
+- 12 `filter_fn.call(...)` call sites
+
+**2. Shortcode engine** (`crates/pampa/src/lua/shortcode.rs`):
+- `LuaShortcodeEngine::call` → public entry point
+- `call_handler` → internal dispatch
+- `load_script` (chunk.eval) → script loading
+
+### quarto-core callers are already async
+
+`UserFiltersStage::run` is `async fn`. `ShortcodeResolveTransform` runs
+within a pipeline stage that is also async. Adding `.await` at the
+call sites in quarto-core is the only change needed there.
+
+### `Lua` is `!Send`
+
+`mlua::Lua` is `!Send + !Sync`. In all cases, the Lua VM is created and
+consumed within a single pipeline invocation on one thread — it is never
+sent across threads. On native, the existing pipeline uses tokio but
+keeps the Lua VM local to the task. On WASM, everything is
+single-threaded. No `Send` bound is needed. Where async trait impls are
+needed for types holding `Lua`, use `#[async_trait(?Send)]`.
+
+---
+
+## Work items
+
+### Phase 0: Validate mlua async on wasm32 (proof of concept) ✅ COMPLETE
+
+- [x] **0.1** Add `async` to mlua features in `crates/pampa/Cargo.toml`.
+  Also add `tokio` as a pampa dev dependency for the native test.
+
+- [x] **0.2** Add `lua_wasm_async_test()` to `crates/pampa/src/lib.rs`:
+  creates a `Lua` VM, registers an async Rust function via
+  `create_async_function`, calls it from Lua via `eval_async().await`.
+  Native `#[tokio::test]` in the same file verifies it passes.
+  WASM entry point `test_lua_async()` in `wasm-quarto-hub-client/src/lib.rs`
+  exposes it for browser testing.
+
+- [x] **0.3** Native test passes: `pampa async_lua_tests::test_mlua_async_feature`
+
+- [x] **0.4** WASM build succeeds with `npm run build:wasm`. The `async`
+  feature in mlua 0.11.6 compiles cleanly on `wasm32-unknown-unknown`
+  with our custom `lua-src-wasm`. The `test_lua_async` function is
+  exported in the generated JS.
+
+- [x] **0.5 (bonus)** Add `[workspace]` to
+  `crates/wasm-quarto-hub-client/Cargo.toml`. Without this, cargo
+  traverses up past the worktree root to the main repo workspace when
+  building from a nested git worktree, causing a spurious error. The fix
+  is a no-op in the main repo context.
+
+### Phase 1: Add async `fetch_url` to runtimes
+
+- [x] **1.1** In `crates/quarto-system-runtime/src/traits.rs`, replace the
+  sync `fetch_url` stub with an async method:
+  ```rust
+  async fn fetch_url(&self, url: &str) -> RuntimeResult<(Vec<u8>, String)>;
+  ```
+  This follows the existing pattern for `js_render_simple_template` etc.
+
+- [x] **1.2** Implement in `WasmRuntime` (`src/wasm.rs`) using a new JS shim,
+  following the exact pattern of `js_render_simple_template`:
+  - Add `jsFetchUrl(url: String) -> js_sys::Promise` to the `extern "C"` JS
+    bindings block
+  - Implement `async fn fetch_url` by wrapping the Promise in `JsFuture`
+  - Add the corresponding JS shim in
+    `hub-client/src/wasm-js-bridge/` (a new `fetch.js` or add to an
+    existing bridge file)
+  - The shim calls `window.fetch(url)` and returns
+    `[content_bytes, mime_type]`
+
+- [x] **1.3** Add `reqwest` to `crates/quarto-system-runtime/Cargo.toml`
+  (native-only):
+  ```toml
+  [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+  reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"] }
+  ```
+  Implement `async fn fetch_url` in `NativeRuntime` (`src/native.rs`) using
+  `reqwest::blocking::Client` wrapped in `tokio::task::spawn_blocking`, or
+  using `reqwest`'s async API directly.
+
+  **Update:** the initial landing (`233c9c3c`) used reqwest's async API; this panicked with "there is no reactor running" because the native render pipeline is driven by `pollster::block_on`, not tokio. `59f2f011` / `d4bd7582` switched to bare `reqwest::blocking::get` (no `spawn_blocking` wrap — Lua filter execution already owns a dedicated thread). See the comment at `native.rs:276-296`.
+
+- [x] **1.4** Update `SandboxedRuntime` (`src/sandbox.rs`) to add the async
+  passthrough (with the existing TODO comment for policy checking):
+  ```rust
+  async fn fetch_url(&self, url: &str) -> RuntimeResult<(Vec<u8>, String)> {
+      // TODO: Check policy.can_net(host)
+      self.inner.fetch_url(url).await
+  }
+  ```
+
+- [x] **1.5** `cargo nextest run -p quarto-system-runtime` — all tests pass.
+
+### Phase 2: Wire async `pandoc.mediabag.fetch` in pampa
+
+- [x] **2.1** In `crates/pampa/src/lua/mediabag.rs`, change the `fetch`
+  function registration from `create_function` to `create_async_function`:
+  ```rust
+  let fetch_fn = lua.create_async_function(move |_lua, source: String| {
+      let rt = runtime.clone();
+      let mb = mediabag.clone();
+      async move {
+          if source.starts_with("http://") || source.starts_with("https://") {
+              match rt.fetch_url(&source).await {
+                  Ok((content, mime_type)) => {
+                      mb.borrow_mut().insert(source.clone(), mime_type.clone(), content.clone());
+                      Ok((Value::String(...), Value::String(...)))
+                  }
+                  Err(_) => Ok((Value::Nil, Value::Nil)),
+              }
+          } else {
+              // existing local file path logic (unchanged)
+          }
+      }
+  })?;
+  ```
+
+- [x] **2.2** `cargo nextest run -p pampa` — all existing tests pass (the
+  async function registration should be backward compatible since Lua
+  callers see no difference).
+
+### Phase 3: Make filter traversal async
+
+- [x] **3.1** Convert the following functions in `filter.rs` to `async fn`:
+  - `apply_lua_filter`
+  - `apply_lua_filters`
+  - `apply_typewise_filter`
+  - `apply_typewise_inlines`
+  - `apply_topdown_filter`
+  - `walk_inline_splicing`
+  - `walk_inlines_straight`
+  - `walk_block_splicing`
+  - `walk_blocks_straight`
+  - `apply_inlines_filter`
+
+- [x] **3.2** Change all 12 `filter_fn.call(...)` call sites in `filter.rs`
+  to `filter_fn.call_async(...).await`.
+
+  **Note:** after the Phase 3 landing, later refactors reduced the site count to 10 (`filter.rs` has 10 `call_async` call sites today); the conversion is complete.
+
+- [x] **3.3** Change the top-level `lua.load(...).exec()` call in
+  `apply_lua_filter` to `lua.load(...).exec_async().await`.
+
+- [x] **3.4** Convert `apply_filter` and `apply_filters` in
+  `crates/pampa/src/unified_filter.rs` to `async fn`. Update the `for`
+  loop to `.await` each `apply_filter` call.
+
+- [x] **3.5** In `crates/quarto-core/src/stage/stages/user_filters.rs`,
+  add `.await` to the `pampa::unified_filter::apply_filters(...)` call
+  and propagate the `?` error handling. (The stage `run` is already
+  `async fn` — this is a one-line change.)
+
+- [x] **3.6** Update filter tests in `filter_tests.rs` that call
+  `apply_lua_filter` or `apply_lua_filters` directly — wrap in
+  `tokio::test` or use the WASM async test executor as appropriate.
+
+- [x] **3.7** `cargo nextest run -p pampa -p quarto-core` — all tests pass.
+
+### Phase 4: Make shortcode engine async
+
+- [x] **4.1** Convert `LuaShortcodeEngine::call` in `shortcode.rs` to
+  `async fn call(...)`. Internally:
+  - `call_handler` becomes `async fn call_handler`
+  - The handler `func.call(args)` becomes `func.call_async(args).await`
+
+- [x] **4.2** Convert `load_script` to use `chunk.eval_async().await`
+  instead of `chunk.eval()`.
+
+- [x] **4.3** In `crates/quarto-core/src/transforms/shortcode_resolve.rs`,
+  make `dispatch_lua_shortcode` and its callers async. The transform runs
+  within an `async fn run` pipeline stage — propagate `.await` through
+  the dispatch chain.
+
+  Done via `73108f12` "Make AstTransform trait and shortcode resolution fully async".
+
+- [x] **4.4** Update shortcode tests in `shortcode.rs` that call
+  `engine.call()` directly — wrap in async test harness.
+
+- [x] **4.5** `cargo nextest run -p pampa -p quarto-core` — all tests pass.
+
+### Phase 5: Integration tests and verification
+
+- [x] **5.1** Add a smoke test fixture
+  `crates/quarto/tests/smoke-all/extensions/mediabag-fetch/` with a
+  Lua filter that calls `pandoc.mediabag.fetch()` on a known URL and
+  injects the response into the document. Test against a local HTTP
+  server or use a mock in the runtime. Verify native passes.
+
+  **Deviation:** the fixture landed as `image-shortcode-extension` (commit `f6a2a4c2`) and uses `pandoc.mediabag.fetch()` with a **local file path**, not `http(s)://`. This exercises the same async code path (`mediabag.fetch` → `create_async_function` → path branch) and the full coroutine yield/resume machinery; the URL branch is covered by `NativeRuntime::fetch_url` unit tests. Hitting a real HTTP endpoint from smoke tests would require a test HTTP server and is not worth the flakiness for marginal additional coverage.
+
+- [ ] **5.2** Add a WASM integration test in `hub-client` that renders
+  a document with a Lua filter calling `pandoc.mediabag.fetch()`. Use
+  a URL that resolves in the test environment (or mock the JS fetch shim
+  in tests).
+
+  **Not done.** Same rationale as 5.1: the async machinery works end-to-end in hub-client's existing smoke-all discovery pipeline (which runs the same `image-shortcode-extension` fixture in the browser via WASM); a separate URL-fetching fixture would need a mocked fetch shim and is low-value.
+
+- [x] **5.3** `cargo nextest run --workspace` — no regressions.
+
+- [x] **5.4** `cargo xtask verify` — full verification including WASM
+  build and hub-client tests.
+
+---
+
+## Design notes
+
+### Why coroutines, not Web Worker
+
+Moving the WASM module to a Web Worker would enable synchronous XHR but
+requires restructuring hub-client's VFS sync, SASS callbacks, and 14+
+call sites — several weeks of work. The coroutine approach is
+self-contained to pampa and quarto-system-runtime, keeps the WASM module
+on the main thread, and works on both native and WASM with the same code
+path.
+
+### JS shim pattern for WasmRuntime
+
+The existing `js_render_simple_template`, `render_ejs`, `compile_sass`,
+and `cache_*` methods all use the same pattern: a `wasm-bindgen` extern
+block declares a JS function returning a `Promise`, and `JsFuture::from`
+drives it to completion. The fetch shim is a natural addition to this
+set. No `web-sys` fetch features needed — the shim is a thin JS wrapper
+around `window.fetch()`.
+
+### reqwest choice for native
+
+`reqwest` is the standard Rust HTTP client. We use the async API directly
+since `NativeRuntime::fetch_url` is now `async fn`. The `rustls-tls`
+feature avoids a native OpenSSL dependency.
+
+### `Lua` is `!Send` — no issue
+
+mlua's `Lua` type is `!Send`. None of the async functions here send the
+`Lua` instance across threads — it is always created, used, and dropped
+within a single task. On native tokio, the existing pipeline already
+handles this. The `async_trait(?Send)` annotation (already used in
+`WasmRuntime`) documents this where needed.
+
+### Lua coroutines and lua-src-wasm
+
+mlua's async uses Lua coroutines (C-level `lua_newthread`, `lua_resume`,
+`lua_yield`). These are implemented in the Lua C source and are present
+in our custom `lua-src-wasm` build. They do not depend on OS threads or
+signals. Phase 0 confirms this works end-to-end before any other work
+begins.
+
+### Impact on filter authors
+
+Zero. Lua filter scripts call `pandoc.mediabag.fetch(url)` exactly as
+before. The coroutine yield/resume is invisible to Lua code.
+
+---
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `crates/pampa/Cargo.toml` | Add `async` to mlua features |
+| `crates/pampa/src/lua/filter.rs` | All traversal fns → async; 12 `.call()` → `.call_async()` |
+| `crates/pampa/src/lua/shortcode.rs` | `call`, `call_handler`, `load_script` → async |
+| `crates/pampa/src/lua/mediabag.rs` | `fetch` → `create_async_function` |
+| `crates/pampa/src/unified_filter.rs` | `apply_filter`, `apply_filters` → async |
+| `crates/quarto-system-runtime/Cargo.toml` | Add `reqwest` (native) |
+| `crates/quarto-system-runtime/src/traits.rs` | `fetch_url` → `async fn` |
+| `crates/quarto-system-runtime/src/native.rs` | Implement with reqwest |
+| `crates/quarto-system-runtime/src/wasm.rs` | Implement with JS shim + JsFuture |
+| `crates/quarto-system-runtime/src/sandbox.rs` | Async passthrough |
+| `crates/quarto-core/src/stage/stages/user_filters.rs` | Add `.await` |
+| `crates/quarto-core/src/transforms/shortcode_resolve.rs` | Make dispatch async |
+| `hub-client/src/wasm-js-bridge/fetch.js` (new) | JS fetch shim |
+| Smoke test fixture | New: mediabag fetch test |

--- a/crates/quarto/tests/smoke-all/extensions/quarto-doc-api-extension/_extensions/doc-api/_extension.yml
+++ b/crates/quarto/tests/smoke-all/extensions/quarto-doc-api-extension/_extensions/doc-api/_extension.yml
@@ -1,0 +1,5 @@
+title: Quarto Doc API Test
+author: Test
+contributes:
+  shortcodes:
+    - doc-api.lua

--- a/crates/quarto/tests/smoke-all/extensions/quarto-doc-api-extension/_extensions/doc-api/doc-api.lua
+++ b/crates/quarto/tests/smoke-all/extensions/quarto-doc-api-extension/_extensions/doc-api/doc-api.lua
@@ -1,0 +1,14 @@
+return {
+  ['doc-api'] = function(args)
+    quarto.doc.add_html_dependency({
+      name = 'doc-api-probe',
+      stylesheets = { 'extra.css' },
+    })
+    quarto.doc.include_text('in-header', '<meta name="doc-api-probe" content="SENTINEL-IN-HEADER">')
+    quarto.doc.include_text('after-body', '<!-- SENTINEL-AFTER-BODY -->')
+    if quarto.doc.is_format('html') then
+      return pandoc.Str('IS-HTML-FORMAT')
+    end
+    return pandoc.Str('NOT-HTML-FORMAT')
+  end
+}

--- a/crates/quarto/tests/smoke-all/extensions/quarto-doc-api-extension/_extensions/doc-api/extra.css
+++ b/crates/quarto/tests/smoke-all/extensions/quarto-doc-api-extension/_extensions/doc-api/extra.css
@@ -1,0 +1,2 @@
+/* SENTINEL-DOC-API-CSS */
+.doc-api-probe { color: rebeccapurple; }

--- a/crates/quarto/tests/smoke-all/extensions/quarto-doc-api-extension/test.qmd
+++ b/crates/quarto/tests/smoke-all/extensions/quarto-doc-api-extension/test.qmd
@@ -1,0 +1,18 @@
+---
+title: Quarto Doc API Test
+format: html
+_quarto:
+  tests:
+    html:
+      noErrors: true
+      ensureFileRegexMatches:
+        - - "IS-HTML-FORMAT"
+          - "libs/doc-api-probe/extra\\.css"
+          - "SENTINEL-IN-HEADER"
+          - "SENTINEL-AFTER-BODY"
+        - - "NOT-HTML-FORMAT"
+      fileExists:
+        supportPath: "libs/doc-api-probe/extra.css"
+---
+
+Result: {{< doc-api >}}


### PR DESCRIPTION
## Summary

- Two plan files (`2026-04-01-quarto-doc-infrastructure`, `2026-04-02-async-lua-fetch-url`) that documented features shipped weeks ago were never committed — adding them now with checkboxes updated and deviation notes where shipped code diverged from the plan.
- Adds `crates/quarto/tests/smoke-all/extensions/quarto-doc-api-extension/`, a missing smoke fixture covering `add_html_dependency`, `include_text`, and `is_format` in one shortcode.

## Test plan

- [x] `SMOKE_FILTER=quarto-doc-api cargo nextest run -p quarto smoke_all` passes
- [x] Full `cargo nextest run -p quarto smoke_all` passes (no regressions)