### PR TITLE
Reduce test-suite CI disk usage with profile.ci and runner cleanup

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -114,22 +114,16 @@ jobs:
         shell: bash
         run: cargo xtask lint
 
-      # Build and test
-      # Deny warnings in CI so they don't accumulate silently
-      - name: Build
-        shell: bash
-        run: cargo build
-        env:
-          RUSTFLAGS: "-D warnings"
-
       - name: Test block tree-sitter grammar
         shell: bash
         run: |
           cd crates/tree-sitter-qmd/tree-sitter-markdown
           tree-sitter test
 
+      # `ci` profile + `--all-targets` makes a separate `cargo build` redundant.
+      # See claude-notes/2026-04-28-ci-disk-space-and-profile-ci.md.
       - name: Test Rust code
         shell: bash
-        run: cargo nextest run
+        run: cargo nextest run --all-targets --cargo-profile ci
         env:
           RUSTFLAGS: "-D warnings"

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -100,7 +100,9 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install tree-sitter-cli
 
-      # Free disk space on Linux runners (14 GB SSD is tight for Rust monorepo)
+      # Free disk space on Linux runners (14 GB SSD is tight for Rust monorepo).
+      # `remove_tool_cache: true` is safe — no step in this job uses /opt/hostedtoolcache/
+      # (no setup-node, setup-python, etc.). See claude-notes/2026-04-28-ci-disk-space-and-profile-ci.md.
       - name: Free disk space
         if: runner.os == 'Linux'
         uses: endersonmenezes/free-disk-space@7901478139cff6e9d44df5972fd8ab8fcade4db1 # v3
@@ -108,6 +110,14 @@ jobs:
           remove_android: true
           remove_dotnet: true
           remove_haskell: true
+          remove_tool_cache: true
+
+      - name: Prune Docker images
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          sudo docker image prune --all --force
+          sudo docker builder prune -a --force
 
       # Custom lint checks (before build to fail fast)
       - name: Run custom lints

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -130,10 +130,12 @@ jobs:
           cd crates/tree-sitter-qmd/tree-sitter-markdown
           tree-sitter test
 
-      # `ci` profile + `--all-targets` makes a separate `cargo build` redundant.
+      # `ci` profile + `--tests` makes a separate `cargo build` redundant.
+      # `--tests` (not `--all-targets`) excludes benches — `quarto-yaml` declares
+      # `harness = false` benches that nextest can't enumerate as tests.
       # See claude-notes/2026-04-28-ci-disk-space-and-profile-ci.md.
       - name: Test Rust code
         shell: bash
-        run: cargo nextest run --all-targets --cargo-profile ci
+        run: cargo nextest run --tests --cargo-profile ci
         env:
           RUSTFLAGS: "-D warnings"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -277,6 +277,17 @@ lua-src = { path = "crates/lua-src-wasm" }
 # https://github.com/wasm-bindgen/wasm-bindgen/issues/3451#issuecomment-1562982835
 opt-level = "s"
 
+# CI-only profile (used by `.github/workflows/test-suite.yml`). Strips
+# debuginfo to fit GHA disk. Locally, omit `--cargo-profile ci` to get
+# full debuginfo via the default `dev` profile.
+# See claude-notes/2026-04-28-ci-disk-space-and-profile-ci.md.
+[profile.ci]
+inherits = "dev"
+debug = "line-tables-only"
+
+[profile.ci.package."*"]
+debug = false
+
 # Release-like profile with debug info preserved for profilers (samply, etc.).
 # Used by perf-harness drivers; see claude-notes/instructions/performance-profiling.md.
 [profile.release-perf]

--- a/claude-notes/2026-04-28-ci-disk-space-and-profile-ci.md
+++ b/claude-notes/2026-04-28-ci-disk-space-and-profile-ci.md
@@ -12,6 +12,7 @@ If you stumbled here from a `target/` directory growing unexpectedly, or wondere
 - The default `dev` profile emits full debuginfo, which roughly **doubles** `target/` size on a workspace this big.
 - We added a `[profile.ci]` profile (inherits from `dev`, strips most debuginfo) and the CI workflow uses it via `cargo nextest run --cargo-profile ci`.
 - We also removed the redundant `cargo build` step from CI — `cargo nextest run` already builds everything `cargo build` does, plus the test artifacts.
+- We freed ~10 GB more on the runner by enabling `remove_tool_cache: true` on the existing free-disk-space step (no step uses `/opt/hostedtoolcache/`) and by pruning Docker images at the start of the job.
 - **Locally, nothing changed.** `cargo build`, `cargo test`, and `cargo nextest run` (without `--cargo-profile ci`) still use the default `dev` profile with full debuginfo.
 
 ## What triggered this
@@ -20,7 +21,9 @@ Run [25062065055](https://github.com/quarto-dev/q2/actions/runs/25062065055/job/
 
 The previous mitigation (PR #55, 2026-03-17) bought us several months of headroom; the workspace has since grown past it.
 
-## Two simultaneous changes
+## The two changes that need explaining
+
+The runner-side cleanup (tool_cache + docker prune) is mechanical — see the workflow file. The two changes worth documenting in detail are the Cargo profile and the workflow build/test consolidation.
 
 ### Change 1: `[profile.ci]` Cargo profile
 
@@ -113,17 +116,17 @@ And per the [Cargo book on `cargo test`](https://doc.rust-lang.org/cargo/command
 
 The Cargo book notes that bin compilation happens "as unit tests" by default and the **standalone bin artifact** is only built "if integration tests are built and required features are available". For a workspace with integration tests anywhere, this is non-issue — all binaries get compiled. We pass `--all-targets` to be explicit and remove the conditional.
 
-## Why we didn't also do this (yet)
+## All the cleanup levers we used
 
-For reference, when this got designed there were three Tier-1 options. We picked the first two:
-
-| Option | Disk saving | Why we did/didn't include it |
+| Lever | Disk saving | Status |
 |---|---|---|
-| A. `[profile.ci]` debuginfo strip | ~30–50% of `target/` | **Included.** Biggest single lever, preserves panic backtraces. |
-| B. Drop redundant `cargo build` | Multi-GB peak reduction | **Included.** Verified equivalent to current behavior with `--all-targets`. |
-| C. `tool_cache: true` on free-disk-space | ~6 GB | **Held in reserve.** Safe (test-suite job uses neither Node, Python, nor `/opt/hostedtoolcache/`), but if A+B is enough we don't need it. |
-
-If we hit space pressure again, the next step is C. After that, `swap_storage: true` (~4 GB, mild OOM risk for heavy linkers), `docker prune` (~3–8 GB), or finally a paid larger runner (Posit `ubuntu-latest-4x`, 150 GB SSD, $0.012/min) or `ubuntu-24.04-arm` (45 GB free, free for public repos, requires arm64 Rust toolchain).
+| A. `[profile.ci]` debuginfo strip | ~30–50% of `target/` | Done. Biggest single lever, preserves panic backtraces. |
+| B. Drop redundant `cargo build` | Multi-GB peak reduction | Done. Verified equivalent via `--all-targets`. |
+| C. `remove_tool_cache: true` on free-disk-space | ~6 GB | Done. Safe — no step uses `/opt/hostedtoolcache/`. |
+| D. `docker image prune` + `docker builder prune` | ~3–8 GB | Done. Pre-pulled docker images aren't used by this job. |
+| E. `remove_swap: true` on free-disk-space | ~4 GB | Held in reserve — small OOM risk for heavy linkers (deno_core, large LTO). |
+| F. `df -h` diagnostic step | 0 GB | Held in reserve — adds log noise; useful for next failure triage if disk pressure returns. |
+| G. Larger runner | 150 GB / 45 GB | Held in reserve — Posit `ubuntu-latest-4x` ($0.012/min) or `ubuntu-24.04-arm` (free for public repos, requires arm64 Rust toolchain). |
 
 ## Cross-references
 

--- a/claude-notes/2026-04-28-ci-disk-space-and-profile-ci.md
+++ b/claude-notes/2026-04-28-ci-disk-space-and-profile-ci.md
@@ -1,0 +1,141 @@
+# CI disk space and the `[profile.ci]` Cargo profile
+
+Date: 2026-04-28
+
+This note explains why the q2 workspace has a `[profile.ci]` Cargo profile that is **only** used in `.github/workflows/test-suite.yml`, what's different from the default `dev` profile, and how to recover the full debug info when reproducing a CI failure locally.
+
+If you stumbled here from a `target/` directory growing unexpectedly, or wondered why CI uses `--cargo-profile ci`, this is the right page.
+
+## TL;DR
+
+- CI on `ubuntu-latest` has very little disk space (~14 GB free after the runner image, partially recovered by a cleanup action).
+- The default `dev` profile emits full debuginfo, which roughly **doubles** `target/` size on a workspace this big.
+- We added a `[profile.ci]` profile (inherits from `dev`, strips most debuginfo) and the CI workflow uses it via `cargo nextest run --cargo-profile ci`.
+- We also removed the redundant `cargo build` step from CI — `cargo nextest run` already builds everything `cargo build` does, plus the test artifacts.
+- **Locally, nothing changed.** `cargo build`, `cargo test`, and `cargo nextest run` (without `--cargo-profile ci`) still use the default `dev` profile with full debuginfo.
+
+## What triggered this
+
+Run [25062065055](https://github.com/quarto-dev/q2/actions/runs/25062065055/job/73418747660?pr=139) (PR #139, ubuntu-latest) failed with `No space left on device` during `cargo nextest run`, even though the existing `endersonmenezes/free-disk-space` step had already freed **18.8 GB** (Android 10.4 + .NET 4.6 + Haskell 3.7).
+
+The previous mitigation (PR #55, 2026-03-17) bought us several months of headroom; the workspace has since grown past it.
+
+## Two simultaneous changes
+
+### Change 1: `[profile.ci]` Cargo profile
+
+Added to root `Cargo.toml`:
+
+```toml
+[profile.ci]
+inherits = "dev"
+debug = "line-tables-only"
+
+[profile.ci.package."*"]
+debug = false
+```
+
+What this does:
+
+- `inherits = "dev"` — start from the `dev` profile, including the existing `opt-level = "s"` wasm-bindgen workaround.
+- `debug = "line-tables-only"` — emit only enough debug info for backtraces to show **file and line numbers**. Variable values and function-parameter info are dropped.
+- `[profile.ci.package."*"] debug = false` — strip debug info entirely from **all dependencies**. Deps dominate `target/` size on this workspace, so this is where the bulk of the saving comes from.
+
+#### What's lost in CI panic logs
+
+Backtraces still show file/line per frame. They no longer show:
+
+- Variable values
+- Function-parameter values
+- The full type names of generic instantiations beyond what rustc records as part of the symbol
+
+In practice, panic output in CI logs only ever showed file/line anyway — variables aren't included unless you're attached with `gdb`/`lldb`. So this is essentially zero observable change for CI-log-only debugging.
+
+#### How to get full debuginfo back locally
+
+Just **don't pass `--cargo-profile ci`**. Every default cargo command uses the `dev` profile, which is unchanged:
+
+```bash
+# Full debuginfo (default behavior, unchanged)
+cargo build
+cargo test
+cargo nextest run
+
+# CI profile (matches what GitHub Actions runs)
+cargo nextest run --cargo-profile ci
+```
+
+If you want to **reproduce a CI failure** under a debugger or with `RUST_BACKTRACE=full` and need rich frame info, run with the default `dev` profile. The `[profile.ci]` block does not affect any other profile.
+
+#### Why `line-tables-only` instead of `debug = 0`
+
+`line-tables-only` keeps file:line info in panic backtraces — readable in CI logs, no debugger needed.
+`debug = 0` would drop that too, leaving only hex addresses, which makes any unexpected CI failure much harder to triage.
+
+The disk savings between `line-tables-only` and `debug = 0` are minor (line tables are tiny relative to full debug info). The big saving is on dependencies, where we use `debug = false` because deps are usually irrelevant to triaging q2-specific failures.
+
+### Change 2: Removed the redundant `cargo build` step in CI
+
+The old workflow had:
+
+```yaml
+- name: Build
+  run: cargo build
+  env:
+    RUSTFLAGS: "-D warnings"
+
+- name: Test Rust code
+  run: cargo nextest run
+  env:
+    RUSTFLAGS: "-D warnings"
+```
+
+Per the [nextest design docs](https://nexte.st/docs/design/how-it-works/):
+
+> "cargo-nextest first builds all test binaries with `cargo test --no-run`"
+
+And per the [Cargo book on `cargo test`](https://doc.rust-lang.org/cargo/commands/cargo-test.html#target-selection), the default target selection includes `--lib --bins --tests`. Adding `--all-targets` makes the equivalence to `cargo build --all-targets` explicit:
+
+```yaml
+- name: Test Rust code
+  run: cargo nextest run --all-targets --cargo-profile ci
+  env:
+    RUSTFLAGS: "-D warnings"
+```
+
+#### Why this is safe (verified)
+
+1. **Compilation coverage is the same.** `cargo nextest run --all-targets` builds `--lib --bins --tests --benches --examples` — a strict superset of what `cargo build --all-targets` builds. Removing `cargo build` does not skip any compilation.
+2. **`-D warnings` still fires.** `RUSTFLAGS` is a rustc env var, applied to every rustc invocation regardless of which cargo subcommand drives the build. Nextest invokes `cargo test --no-run` internally, which picks up `RUSTFLAGS` exactly as `cargo build` would.
+3. **The redundancy that disappears:** `cargo build` and `cargo nextest run` share `target/debug/` (or in our case `target/ci/`) but **not artifacts** — library crates compiled with `--cfg test` have a different fingerprint and produce **separate `.rlib`s** alongside the dev-build ones. With ~35 crates, that duplication ran into multi-GB at peak disk.
+
+#### Edge case to be aware of
+
+The Cargo book notes that bin compilation happens "as unit tests" by default and the **standalone bin artifact** is only built "if integration tests are built and required features are available". For a workspace with integration tests anywhere, this is non-issue — all binaries get compiled. We pass `--all-targets` to be explicit and remove the conditional.
+
+## Why we didn't also do this (yet)
+
+For reference, when this got designed there were three Tier-1 options. We picked the first two:
+
+| Option | Disk saving | Why we did/didn't include it |
+|---|---|---|
+| A. `[profile.ci]` debuginfo strip | ~30–50% of `target/` | **Included.** Biggest single lever, preserves panic backtraces. |
+| B. Drop redundant `cargo build` | Multi-GB peak reduction | **Included.** Verified equivalent to current behavior with `--all-targets`. |
+| C. `tool_cache: true` on free-disk-space | ~6 GB | **Held in reserve.** Safe (test-suite job uses neither Node, Python, nor `/opt/hostedtoolcache/`), but if A+B is enough we don't need it. |
+
+If we hit space pressure again, the next step is C. After that, `swap_storage: true` (~4 GB, mild OOM risk for heavy linkers), `docker prune` (~3–8 GB), or finally a paid larger runner (Posit `ubuntu-latest-4x`, 150 GB SSD, $0.012/min) or `ubuntu-24.04-arm` (45 GB free, free for public repos, requires arm64 Rust toolchain).
+
+## Cross-references
+
+- Previous CI cleanup: [PR #55](https://github.com/quarto-dev/q2/pull/55) (Mar 2026)
+- Failed run that triggered this work: [run 25062065055](https://github.com/quarto-dev/q2/actions/runs/25062065055/job/73418747660?pr=139)
+- Local Windows precedent (same pattern via `~/.cargo/config.toml`): see `memory://main/docs/rust-disk-space-strategy-for-windows-with-worktrees`
+- Open follow-up tracking: `memory://main/tasks/optimize-q2-ci-workflow-disk-usage`
+
+## External sources
+
+- nextest: [How it works](https://nexte.st/docs/design/how-it-works/) — confirms nextest delegates compilation to `cargo test --no-run`.
+- Cargo book: [`cargo test` target selection](https://doc.rust-lang.org/cargo/commands/cargo-test.html#target-selection) — what gets built by default.
+- Cargo book: [Profiles](https://doc.rust-lang.org/cargo/reference/profiles.html) — `inherits`, `debug` levels, per-package overrides.
+- Kobzol, June 2025: [Reducing Cargo target directory size with `-Zno-embed-metadata`](https://kobzol.github.io/rust/rustc/2025/06/02/reduce-cargo-target-dir-size-with-z-no-embed-metadata.html) — measured ~2× target size from debuginfo on a comparable workspace.
+- `endersonmenezes/free-disk-space` action documentation — option semantics for `tool_cache`, `swap_storage`, etc.

--- a/claude-notes/2026-04-28-ci-disk-space-and-profile-ci.md
+++ b/claude-notes/2026-04-28-ci-disk-space-and-profile-ci.md
@@ -12,7 +12,7 @@ If you stumbled here from a `target/` directory growing unexpectedly, or wondere
 - The default `dev` profile emits full debuginfo, which roughly **doubles** `target/` size on a workspace this big.
 - We added a `[profile.ci]` profile (inherits from `dev`, strips most debuginfo) and the CI workflow uses it via `cargo nextest run --cargo-profile ci`.
 - We also removed the redundant `cargo build` step from CI — `cargo nextest run --tests` already builds everything `cargo build` does, plus the test artifacts. (We initially tried `--all-targets` but that pulls in `harness = false` benches which nextest can't enumerate as tests; `--tests` is the correct flag.)
-- We freed ~10 GB more on the runner by enabling `remove_tool_cache: true` on the existing free-disk-space step (no step uses `/opt/hostedtoolcache/`) and by pruning Docker images at the start of the job.
+- We freed ~10 GB more on the runner by enabling `remove_tool_cache: true` on the existing free-disk-space step (no step uses `/opt/hostedtoolcache/`) and by pruning Docker images right after that step.
 - **Locally, nothing changed.** `cargo build`, `cargo test`, and `cargo nextest run` (without `--cargo-profile ci`) still use the default `dev` profile with full debuginfo.
 
 ## What triggered this
@@ -161,7 +161,7 @@ If a future test wants `cargo run --` style command-driving with output assertio
 | Lever | Disk saving | Status |
 |---|---|---|
 | A. `[profile.ci]` debuginfo strip | ~30–50% of `target/` | Done. Biggest single lever, preserves panic backtraces. |
-| B. Drop redundant `cargo build` | Multi-GB peak reduction | Done. Verified equivalent via `--all-targets`. |
+| B. Drop redundant `cargo build` | Multi-GB peak reduction | Done via `cargo nextest run --tests`. |
 | C. `remove_tool_cache: true` on free-disk-space | ~6 GB | Done. Safe — no step uses `/opt/hostedtoolcache/`. |
 | D. `docker image prune` + `docker builder prune` | ~3–8 GB | Done. Pre-pulled docker images aren't used by this job. |
 | E. `remove_swap: true` on free-disk-space | ~4 GB | Held in reserve — small OOM risk for heavy linkers (deno_core, large LTO). |

--- a/claude-notes/2026-04-28-ci-disk-space-and-profile-ci.md
+++ b/claude-notes/2026-04-28-ci-disk-space-and-profile-ci.md
@@ -11,7 +11,7 @@ If you stumbled here from a `target/` directory growing unexpectedly, or wondere
 - CI on `ubuntu-latest` has very little disk space (~14 GB free after the runner image, partially recovered by a cleanup action).
 - The default `dev` profile emits full debuginfo, which roughly **doubles** `target/` size on a workspace this big.
 - We added a `[profile.ci]` profile (inherits from `dev`, strips most debuginfo) and the CI workflow uses it via `cargo nextest run --cargo-profile ci`.
-- We also removed the redundant `cargo build` step from CI — `cargo nextest run` already builds everything `cargo build` does, plus the test artifacts.
+- We also removed the redundant `cargo build` step from CI — `cargo nextest run --tests` already builds everything `cargo build` does, plus the test artifacts. (We initially tried `--all-targets` but that pulls in `harness = false` benches which nextest can't enumerate as tests; `--tests` is the correct flag.)
 - We freed ~10 GB more on the runner by enabling `remove_tool_cache: true` on the existing free-disk-space step (no step uses `/opt/hostedtoolcache/`) and by pruning Docker images at the start of the job.
 - **Locally, nothing changed.** `cargo build`, `cargo test`, and `cargo nextest run` (without `--cargo-profile ci`) still use the default `dev` profile with full debuginfo.
 
@@ -97,24 +97,32 @@ Per the [nextest design docs](https://nexte.st/docs/design/how-it-works/):
 
 > "cargo-nextest first builds all test binaries with `cargo test --no-run`"
 
-And per the [Cargo book on `cargo test`](https://doc.rust-lang.org/cargo/commands/cargo-test.html#target-selection), the default target selection includes `--lib --bins --tests`. Adding `--all-targets` makes the equivalence to `cargo build --all-targets` explicit:
+And per the [Cargo book on `cargo build`](https://doc.rust-lang.org/cargo/commands/cargo-build.html#target-selection), `--tests` builds "all targets that have the `test = true` manifest flag set. By default this includes the library and binaries built as unittests, and integration tests. Be aware that this will also build any required dependencies, so the lib target may be built twice (once as a unittest, and once as a dependency for binaries, integration tests, etc.)."
+
+That last clause is the key one — it confirms test-mode and non-test-mode rlibs are separate artifacts, which is what `cargo nextest run --tests` produces in one shot:
 
 ```yaml
 - name: Test Rust code
-  run: cargo nextest run --all-targets --cargo-profile ci
+  run: cargo nextest run --tests --cargo-profile ci
   env:
     RUSTFLAGS: "-D warnings"
 ```
 
-#### Why this is safe (verified)
+#### Why `--tests`, not `--all-targets`
 
-1. **Compilation coverage is the same.** `cargo nextest run --all-targets` builds `--lib --bins --tests --benches --examples` — a strict superset of what `cargo build --all-targets` builds. Removing `cargo build` does not skip any compilation.
+`--all-targets` is officially defined as `--lib --bins --tests --benches --examples`. We tried it first, but it caused CI to fail on `quarto-yaml`'s benches: `crates/quarto-yaml/benches/{memory_overhead,scaling_overhead}.rs` are declared `harness = false` and print prose reports rather than libtest output. Nextest enumerates each bench binary with `--list --format terse` and errors on the unrecognized output (`line "..." did not end with the string ": test" or ": benchmark"`).
+
+The previous CI never built benches anyway — plain `cargo build` excludes them by default — so `--tests` matches the prior coverage exactly while still consolidating compilation into one nextest-driven step.
+
+#### Why this is safe (verified against Cargo docs)
+
+1. **Compilation coverage matches what `cargo build` was producing.** `cargo nextest run --tests` builds the lib (both as unittest and as a non-test dep for bins/integration tests), all bins (also as unittests), and all integration tests. That is a strict superset of plain `cargo build`'s default targets (lib + bins, non-test). Examples without `test = true` and benches were not built before either.
 2. **`-D warnings` still fires.** `RUSTFLAGS` is a rustc env var, applied to every rustc invocation regardless of which cargo subcommand drives the build. Nextest invokes `cargo test --no-run` internally, which picks up `RUSTFLAGS` exactly as `cargo build` would.
 3. **The redundancy that disappears:** `cargo build` and `cargo nextest run` share `target/debug/` (or in our case `target/ci/`) but **not artifacts** — library crates compiled with `--cfg test` have a different fingerprint and produce **separate `.rlib`s** alongside the dev-build ones. With ~35 crates, that duplication ran into multi-GB at peak disk.
 
 #### Edge case to be aware of
 
-The Cargo book notes that bin compilation happens "as unit tests" by default and the **standalone bin artifact** is only built "if integration tests are built and required features are available". For a workspace with integration tests anywhere, this is non-issue — all binaries get compiled. We pass `--all-targets` to be explicit and remove the conditional.
+`--tests` skips any target whose manifest sets `test = false`. The only such target in this repo is `crates/pampa/fuzz` (libfuzzer-sys is Linux/macOS only, so the crate is `exclude`d from the workspace — `cargo build` at workspace level wasn't building it either). If a future bin is added with `test = false` and is expected to be compile-checked in CI, either drop the `test = false`, add a separate `cargo build` step for that bin, or revisit this decision.
 
 ## All the cleanup levers we used
 

--- a/claude-notes/2026-04-28-ci-disk-space-and-profile-ci.md
+++ b/claude-notes/2026-04-28-ci-disk-space-and-profile-ci.md
@@ -124,6 +124,38 @@ The previous CI never built benches anyway — plain `cargo build` excludes them
 
 `--tests` skips any target whose manifest sets `test = false`. The only such target in this repo is `crates/pampa/fuzz` (libfuzzer-sys is Linux/macOS only, so the crate is `exclude`d from the workspace — `cargo build` at workspace level wasn't building it either). If a future bin is added with `test = false` and is expected to be compile-checked in CI, either drop the `test = false`, add a separate `cargo build` step for that bin, or revisit this decision.
 
+### Change 3: Profile-aware binary discovery in `quarto-lsp` integration test
+
+`crates/quarto-lsp/tests/integration_test.rs` spawns the `q2` binary as a subprocess. The previous code hardcoded `target/debug/q2`, which broke under `--cargo-profile ci` (binary lands at `target/ci/q2`).
+
+#### Why this isn't a misuse of profiles
+
+`[profile.ci]` is a fully-supported Cargo pattern. The test was simply unaware of profiles. Cargo's `CARGO_BIN_EXE_<name>` env var would normally provide the production-bin path, but it's **package-scoped** — set only for integration tests in the same package as the bin. Our LSP test lives in `quarto-lsp` while the bin is defined in `quarto`, so that env var is never set here.
+
+#### The fix
+
+Derive the profile directory from the test binary's own location:
+
+```rust
+let binary_path = std::env::current_exe()
+    .unwrap()
+    .parent().unwrap()   // target/<profile>/deps
+    .parent().unwrap()   // target/<profile>
+    .join("q2")
+    .with_extension(std::env::consts::EXE_EXTENSION);
+```
+
+Cargo always places the test binary in `target/<profile>/deps/`, so backing up two parents lands in the same `target/<profile>/` directory where the production `q2` is built. Profile-correct on Linux/macOS/Windows without env-var coupling or mtime heuristics.
+
+#### Why not `assert_cmd`
+
+`assert_cmd::cargo::cargo_bin("q2")` is the idiomatic crate-based answer and does exactly the same thing internally (with friendlier error handling and Windows `.exe` suffix logic). We chose the stdlib version for this fix because:
+
+- The LSP test does **not** use any of `assert_cmd`'s value — no `.assert()`, no stdout/stderr matchers, no exit-code checks. It speaks JSON-RPC over stdio.
+- The only function we'd touch is `cargo_bin()`, replacing 4 lines of stdlib with one dev-dep.
+
+If a future test wants `cargo run --` style command-driving with output assertions, **switch to `assert_cmd` then** — `cargo_bin()` is its standard binary-discovery helper and pays for itself once `.assert()` joins the picture.
+
 ## All the cleanup levers we used
 
 | Lever | Disk saving | Status |

--- a/crates/quarto-lsp/tests/integration_test.rs
+++ b/crates/quarto-lsp/tests/integration_test.rs
@@ -104,21 +104,20 @@ impl LspTestHarness {
     }
 
     /// Get the quarto binary path.
-    /// Expects the binary to already be built (e.g. by `cargo build` or
-    /// `cargo nextest run`). Avoids running `cargo build` here because
-    /// nextest runs each test in a separate process, so the OnceLock
-    /// doesn't help — each process would redundantly check all
-    /// dependencies for staleness, adding ~30-60s per test.
+    /// Derives the profile directory from the test binary's own location
+    /// (`target/<profile>/deps/<test>`), so it works under any cargo profile
+    /// (`dev`, `ci`, `release`, …) without hardcoding `debug`.
+    /// See claude-notes/2026-04-28-ci-disk-space-and-profile-ci.md.
     fn get_binary_path() -> &'static PathBuf {
         BINARY_PATH.get_or_init(|| {
-            let manifest_dir = env!("CARGO_MANIFEST_DIR");
-            let workspace_root = std::path::Path::new(manifest_dir)
+            let binary_path = std::env::current_exe()
+                .expect("current_exe failed")
                 .parent()
-                .unwrap()
+                .expect("test binary has no parent dir")
                 .parent()
-                .unwrap();
-
-            let binary_path = workspace_root.join("target").join("debug").join("q2");
+                .expect("deps/ has no parent dir")
+                .join("q2")
+                .with_extension(std::env::consts::EXE_EXTENSION);
             assert!(
                 binary_path.exists(),
                 "q2 binary not found at {:?}. Run `cargo build -p quarto` first.",


### PR DESCRIPTION
The test-suite workflow on ubuntu-latest hit "No space left on device" during `cargo nextest run`, even with the existing free-disk-space step already reclaiming 18.8 GB. The workspace has grown past PR #55's mitigation.

## Root Cause

Two compounding pressures:

1. The default `[profile.dev]` emits full debuginfo (`debug = 2`), which roughly doubles `target/` size on a workspace this big. Dependencies dominate `target/` and carry no useful debug info for triaging q2 failures.

2. The workflow had both `cargo build` and `cargo nextest run` steps. Library crates compiled with `--cfg test` have a different fingerprint than dev builds and produce separate `.rlib` artifacts in `target/<profile>/`. With ~35 crates that runs into multi-GB duplication at peak disk.

## Fix

Four independent levers, applied in one workflow change:

- Add `[profile.ci]` to the workspace `Cargo.toml` (inherits from `dev`, `debug = "line-tables-only"` on the workspace, `debug = false` on all dependencies). Local builds keep full debuginfo via the unchanged `dev` profile.
- Replace `cargo build` + `cargo nextest run` with a single `cargo nextest run --tests --cargo-profile ci`. Per the [nextest design docs](https://nexte.st/docs/design/how-it-works/), nextest delegates compilation to `cargo test --no-run`, which makes the separate `cargo build` step redundant: the lib + bins + integration-tests that `--tests` selects strictly supersede `cargo build`'s default targets (lib + bins, non-test). `--tests` rather than `--all-targets` because `quarto-yaml`'s `harness = false` benches print prose reports that nextest can't enumerate as tests; the prior workflow never built benches anyway, so coverage matches. `RUSTFLAGS=-D warnings` continues to apply (it's a rustc env var, picked up regardless of which cargo subcommand drives the build).
- Enable `remove_tool_cache: true` on the existing `endersonmenezes/free-disk-space` step (~6 GB more). Verified safe: pre-installed rustup data lives in `/etc/skel/.{rustup,cargo}` and `dtolnay/rust-toolchain` installs to `~/.rustup/toolchains/`, neither of which is in `/opt/hostedtoolcache/`.
- Add `docker image prune --all --force` + `docker builder prune -a --force` (~3-8 GB more). Pre-pulled docker images aren't used by this job.

Full rationale, measured numbers, and held-in-reserve options (swap removal, df -h diagnostic, larger runner) are in `claude-notes/2026-04-28-ci-disk-space-and-profile-ci.md`.
