### PR TITLE
Fix replay drawer toggle to close when clicked

### DIFF
--- a/hub-client/changelog.md
+++ b/hub-client/changelog.md
@@ -13,6 +13,10 @@ be in reverse chronological order (latest first).
 
 -->
 
+### 2026-04-29
+
+- [`dcac202d`](https://github.com/quarto-dev/q2/commits/dcac202d): Fix replay drawer toggle so clicking the chevron or title closes the drawer
+
 ### 2026-04-24
 
 - [`542a1686`](https://github.com/quarto-dev/q2/commits/542a1686): Defer remote edit application and presence notifications while the tab is hidden to avoid replay-animation on refocus

--- a/hub-client/src/components/ReplayDrawer.test.tsx
+++ b/hub-client/src/components/ReplayDrawer.test.tsx
@@ -179,6 +179,12 @@ describe('ReplayDrawer', () => {
       expect(controls.exit).toHaveBeenCalled();
     });
 
+    it('clicking the toggle calls controls.exit()', () => {
+      render(<ReplayDrawer state={activeState} controls={controls} />);
+      fireEvent.click(screen.getByText('Replay'));
+      expect(controls.exit).toHaveBeenCalled();
+    });
+
     it('header row does not exit on click', () => {
       render(<ReplayDrawer state={activeState} controls={controls} />);
       // Clicking the position text in the header should not trigger exit

--- a/hub-client/src/components/ReplayDrawer.tsx
+++ b/hub-client/src/components/ReplayDrawer.tsx
@@ -159,10 +159,15 @@ export default function ReplayDrawer({ state, controls, disabled, identities }: 
       tabIndex={0}
     >
       <div className="replay-drawer__header">
-        <span className="replay-drawer__toggle">
+        <button
+          type="button"
+          className="replay-drawer__toggle"
+          onClick={controls.exit}
+          aria-label="Collapse replay"
+        >
           <span className="replay-drawer__chevron">&#x25BC;</span>
           <span>Replay</span>
-        </span>
+        </button>
 
         <button
           className="replay-drawer__handle"


### PR DESCRIPTION
Fixes #142

The chevron+title element opens the collapsed drawer but was an inert `<span>` when expanded, so only the centered handle bar closed it. Convert the expanded-state toggle to a `<button>` that calls `controls.exit`, restoring symmetry with the collapsed state.