### PR TITLE
hub-client: harden silent auth refresh

### DIFF
--- a/hub-client/src/App.tsx
+++ b/hub-client/src/App.tsx
@@ -63,7 +63,7 @@ const AUTH_ENABLED = !!import.meta.env.VITE_GOOGLE_CLIENT_ID;
 
 
 function App() {
-  const { auth, loading: authLoading, logout } = useAuth();
+  const { auth, loading: authLoading, logout, triggerRefresh } = useAuth();
 
   const [project, setProject] = useState<ProjectEntry | null>(null);
   const [files, setFiles] = useState<FileEntry[]>([]);
@@ -84,13 +84,19 @@ function App() {
   const projectSetStateRef = useRef(projectSetState);
   projectSetStateRef.current = projectSetState;
 
-  // Fetch per-project actor ID; calls logout and returns null on session expiry.
+  // Fetch per-project actor ID. On 401 (mid-session expiry), trigger a
+  // silent refresh and return undefined — the caller's action is abandoned
+  // for this attempt, while One Tap either restores the session in place
+  // or eventually clears auth via its onError path.
   const resolveActorId = useCallback(async (indexDocId: string): Promise<string | undefined | null> => {
     if (!AUTH_ENABLED) return undefined;
     const id = await fetchActorId(indexDocId);
-    if (id === null) logout();
+    if (id === null) {
+      triggerRefresh();
+      return undefined;
+    }
     return id;
-  }, [logout]);
+  }, [triggerRefresh]);
 
   // Capture auth error from redirect query param (once, before URL is cleaned).
   const [authError] = useState(() => {

--- a/hub-client/src/hooks/useAuth.test.ts
+++ b/hub-client/src/hooks/useAuth.test.ts
@@ -29,12 +29,14 @@ vi.mock('../services/authService', () => ({
   refreshToken: vi.fn(),
 }));
 
-import { useAuth } from './useAuth';
+import { useAuth, REFRESH_BUFFER_MS } from './useAuth';
 import {
   fetchAuthMe,
   logout as serverLogout,
   refreshToken,
 } from '../services/authService';
+
+const COOKIE_MAX_AGE_MS = 3600 * 1000;
 
 const mockFetchAuthMe = vi.mocked(fetchAuthMe);
 const mockServerLogout = vi.mocked(serverLogout);
@@ -289,19 +291,19 @@ describe('useAuth', () => {
         expect(result.current.auth).toEqual(user),
       );
 
-      // Advance past the refresh point (55 min). The refresh timer sets
+      // Advance past the refresh point. The refresh timer sets
       // isRefreshing=true and enables One Tap. Simulate One Tap failing
       // (no active Google session), which resets isRefreshing=false.
       await act(async () => {
-        vi.advanceTimersByTime(55 * 60 * 1000 + 100);
+        vi.advanceTimersByTime(COOKIE_MAX_AGE_MS - REFRESH_BUFFER_MS + 100);
       });
       await act(async () => {
         oneTapCallbacks.onError?.();
       });
 
-      // Advance past cookie max-age (remaining ~5 min)
+      // Advance past cookie max-age (remaining buffer).
       await act(async () => {
-        vi.advanceTimersByTime(5 * 60 * 1000 + 100);
+        vi.advanceTimersByTime(REFRESH_BUFFER_MS + 100);
       });
 
       await vi.waitFor(() =>
@@ -333,6 +335,128 @@ describe('useAuth', () => {
       await vi.waitFor(() =>
         expect(result.current.auth).toEqual(freshUser),
       );
+    });
+  });
+
+  // ── 401-triggered refresh (fake timers) ───────────────────
+
+  describe('triggerRefresh', () => {
+    beforeEach(() => {
+      cleanup();
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('enables One Tap when called while auth is still considered valid', async () => {
+      const user = { email: 'a@b.com', name: 'A', picture: null };
+      mockFetchAuthMe.mockResolvedValue(user);
+
+      const { result } = renderHook(() => useAuth());
+      await vi.waitFor(() => expect(result.current.auth).toEqual(user));
+
+      // Cookie freshly set on mount — One Tap initially disabled.
+      expect(oneTapCallbacks.disabled).toBe(true);
+
+      act(() => {
+        result.current.triggerRefresh();
+      });
+
+      expect(oneTapCallbacks.disabled).toBe(false);
+    });
+
+    it('coalesces concurrent triggerRefresh() calls into a single One Tap attempt', async () => {
+      const user = { email: 'a@b.com', name: 'A', picture: null };
+      mockFetchAuthMe.mockResolvedValue(user);
+
+      const { result } = renderHook(() => useAuth());
+      await vi.waitFor(() => expect(result.current.auth).toEqual(user));
+
+      // Multiple concurrent calls (e.g. parallel fetchActorId 401s).
+      act(() => {
+        result.current.triggerRefresh();
+        result.current.triggerRefresh();
+        result.current.triggerRefresh();
+      });
+
+      // One Tap is enabled exactly once; refreshEnabled stayed true.
+      expect(oneTapCallbacks.disabled).toBe(false);
+
+      // Resolve the One Tap success path; isRefreshing resets, One Tap disables.
+      mockRefreshToken.mockResolvedValue(user);
+      await act(async () => {
+        oneTapCallbacks.onSuccess?.({ credential: 'fresh.jwt' });
+      });
+      await vi.waitFor(() => expect(oneTapCallbacks.disabled).toBe(true));
+
+      // A subsequent triggerRefresh re-enables (proving the gate cleared).
+      act(() => {
+        result.current.triggerRefresh();
+      });
+      expect(oneTapCallbacks.disabled).toBe(false);
+    });
+
+    it('updates auth and refreshes cookieSetAt on successful One Tap', async () => {
+      const user = { email: 'a@b.com', name: 'A', picture: null };
+      const refreshedUser = {
+        email: 'a@b.com',
+        name: 'A Refreshed',
+        picture: null,
+      };
+      mockFetchAuthMe.mockResolvedValue(user);
+
+      const { result } = renderHook(() => useAuth());
+      await vi.waitFor(() => expect(result.current.auth).toEqual(user));
+
+      // Pretend cookie has aged most of the way to expiry. After successful
+      // refresh, cookieSetAt should be reset to "now" so the next refresh
+      // timer fires ~ (max-age - buffer) from this moment, not immediately.
+      await act(async () => {
+        vi.advanceTimersByTime(COOKIE_MAX_AGE_MS - REFRESH_BUFFER_MS - 60_000);
+      });
+
+      act(() => {
+        result.current.triggerRefresh();
+      });
+
+      mockRefreshToken.mockResolvedValue(refreshedUser);
+      await act(async () => {
+        oneTapCallbacks.onSuccess?.({ credential: 'fresh.jwt' });
+      });
+
+      await vi.waitFor(() =>
+        expect(result.current.auth).toEqual(refreshedUser),
+      );
+
+      // Drive time forward past the *old* expiry. If cookieSetAt was refreshed,
+      // auth survives. If it wasn't, the expiry timer would have already cleared it.
+      mockFetchAuthMe.mockResolvedValue(refreshedUser);
+      await act(async () => {
+        vi.advanceTimersByTime(60_000 + 100);
+      });
+      expect(result.current.auth).toEqual(refreshedUser);
+    });
+
+    it('does not clear auth on One Tap onError when the cookie is still valid', async () => {
+      const user = { email: 'a@b.com', name: 'A', picture: null };
+      mockFetchAuthMe.mockResolvedValue(user);
+
+      const { result } = renderHook(() => useAuth());
+      await vi.waitFor(() => expect(result.current.auth).toEqual(user));
+
+      // Cookie was just set on mount, so cookieExpired() is false.
+      act(() => {
+        result.current.triggerRefresh();
+      });
+
+      await act(async () => {
+        oneTapCallbacks.onError?.();
+      });
+
+      // Auth should be preserved — Google session may be gone but our cookie is still good.
+      expect(result.current.auth).toEqual(user);
     });
   });
 });

--- a/hub-client/src/hooks/useAuth.ts
+++ b/hub-client/src/hooks/useAuth.ts
@@ -68,6 +68,14 @@ export function useAuth() {
   const cookieExpired = () =>
     cookieSetAt.current > 0 && Date.now() >= cookieSetAt.current + COOKIE_MAX_AGE_MS;
 
+  // Single entry point for activating One Tap. Coalesces concurrent
+  // triggers (e.g. N parallel 401s) into one refresh attempt.
+  const triggerRefresh = useCallback(() => {
+    if (isRefreshing.current) return;
+    isRefreshing.current = true;
+    setRefreshEnabled(true);
+  }, []);
+
   // One Tap: disabled until refreshEnabled is set. When enabled with
   // auto_select, it silently returns a credential if the user has an
   // active Google session — no UI shown.
@@ -121,8 +129,7 @@ export function useAuth() {
             setAuth(me);
           } else {
             // Cookie expired — try One Tap refresh before logging out.
-            isRefreshing.current = true;
-            setRefreshEnabled(true);
+            triggerRefresh();
           }
         })
         .catch(() => {
@@ -134,7 +141,7 @@ export function useAuth() {
     return () => {
       document.removeEventListener('visibilitychange', handleVisibilityChange);
     };
-  }, [auth]);
+  }, [auth, triggerRefresh]);
 
   // Schedule silent refresh and hard expiry based on cookie lifetime.
   useEffect(() => {
@@ -153,10 +160,7 @@ export function useAuth() {
     // Schedule silent refresh attempt before expiry.
     const msUntilRefresh = msUntilExpiry - REFRESH_BUFFER_MS;
     if (msUntilRefresh > 0) {
-      refreshTimer.current = setTimeout(() => {
-        isRefreshing.current = true;
-        setRefreshEnabled(true);
-      }, msUntilRefresh);
+      refreshTimer.current = setTimeout(triggerRefresh, msUntilRefresh);
     }
 
     // Hard expiry: re-check auth when the cookie should have expired.
@@ -179,22 +183,13 @@ export function useAuth() {
       if (refreshTimer.current) clearTimeout(refreshTimer.current);
       if (expiryTimer.current) clearTimeout(expiryTimer.current);
     };
-  }, [auth]);
+  }, [auth, triggerRefresh]);
 
   const logout = useCallback(() => {
     serverLogout().catch(() => {
       // Best-effort server logout; clear client state regardless.
     });
     setAuth(null);
-  }, []);
-
-  // Imperative refresh trigger for callers that detect a mid-session 401
-  // on an authenticated REST request. Coalesces concurrent calls so that
-  // N parallel 401s produce a single One Tap attempt.
-  const triggerRefresh = useCallback(() => {
-    if (isRefreshing.current) return;
-    isRefreshing.current = true;
-    setRefreshEnabled(true);
   }, []);
 
   return { auth, loading, logout, triggerRefresh };

--- a/hub-client/src/hooks/useAuth.ts
+++ b/hub-client/src/hooks/useAuth.ts
@@ -6,13 +6,19 @@
  * On mount, calls GET /auth/me to check if the user has a valid cookie.
  * If 200, stores the display info in React state. If 401, shows login.
  *
- * Token refresh: ~5 minutes before the token expires, the hook enables
+ * Token refresh: ~15 minutes before the cookie expires, the hook enables
  * Google One Tap with `auto_select` to silently obtain a fresh credential.
  * The new credential is sent to POST /auth/refresh which validates it and
  * sets a fresh cookie. If silent refresh fails, auth is cleared at expiry.
+ * The 15-minute buffer absorbs Chrome's intensive timer throttling for
+ * backgrounded tabs (timers may skew by 1+ minutes after 5 min hidden).
  *
  * Visibility-aware refresh: if a background tab's timers were throttled
  * and the cookie expired, attempts a One Tap refresh before logging out.
+ *
+ * 401-triggered refresh: callers that observe a mid-session 401 on an
+ * authenticated REST request can call `triggerRefresh()` to enable One Tap
+ * without logging the user out. Concurrent calls are coalesced.
  *
  * During refresh, a 401 from /auth/me is handled gracefully: the hook
  * shows a loading state (not the login screen) while the refresh is
@@ -24,8 +30,8 @@ import { useGoogleOneTapLogin } from '@react-oauth/google';
 import type { AuthState } from '../services/authService';
 import { fetchAuthMe, logout as serverLogout, refreshToken } from '../services/authService';
 
-/** Buffer before expiry at which we attempt silent refresh (5 minutes). */
-const REFRESH_BUFFER_MS = 5 * 60 * 1000;
+/** Buffer before expiry at which we attempt silent refresh (15 minutes). */
+export const REFRESH_BUFFER_MS = 15 * 60 * 1000;
 
 /** Cookie max-age matches server (1 hour). */
 const COOKIE_MAX_AGE_MS = 3600 * 1000;
@@ -182,5 +188,14 @@ export function useAuth() {
     setAuth(null);
   }, []);
 
-  return { auth, loading, logout };
+  // Imperative refresh trigger for callers that detect a mid-session 401
+  // on an authenticated REST request. Coalesces concurrent calls so that
+  // N parallel 401s produce a single One Tap attempt.
+  const triggerRefresh = useCallback(() => {
+    if (isRefreshing.current) return;
+    isRefreshing.current = true;
+    setRefreshEnabled(true);
+  }, []);
+
+  return { auth, loading, logout, triggerRefresh };
 }


### PR DESCRIPTION
Follow-up to #119 in fixing #118.

Two improvements to the hub-client's silent token refresh:
                                                                         
 1. Buffer 5 min → 15 min. Chrome throttles timers in backgrounded tabs and the 5 min cushion before cookie expiry was too thin — refresh could fire after the cookie was already dead.                  
2. Mid-session 401 no longer logs you out. If `fetchActorId` 401s mid-session, the app now triggers a silent refresh instead of calling `logout()`. You only get kicked to the login screen if Google itself refuses to re-issue a credential.                        
                                                                            
`useAuth` now exposes a `triggerRefresh()` method that callers can invoke when they observe a 401. Concurrent calls coalesce to a single refresh attempt, so N parallel 401s don't fire N silent sign-ins.

No server-side changes.