### PR TITLE
ci: pin rust-toolchain.toml to nightly-2026-04-28 (bd-at72)

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,13 @@
 [toolchain]
-channel = "nightly"
+# bd-at72: pinned to the last-known-good nightly. The nightly published on
+# 2026-05-11 (rustc commit 4b0c9d76a, dated 2026-05-10) introduced a
+# regression that SIGSEGVs in LLVM ThinLTO codegen at opt-level=3 when
+# building this workspace for wasm32-unknown-unknown. The crash hits
+# multiple crates (quarto-pandoc-types, quarto-ast-reconcile, tokio) and
+# escalates: rustc keeps suggesting larger RUST_MIN_STACK values without
+# actually fixing the underlying overflow. Pinning is the durable fix
+# until the upstream regression is resolved; bump the date when nightly
+# stabilizes again.
+channel = "nightly-2026-04-28"
 components = ["rust-src","rustfmt", "clippy"]
 targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
## Summary

The `TS Test Suite` workflow has been failing on every push to `main` since 2026-05-10 with SIGSEGV in `rustc` nightly during the `wasm32-unknown-unknown` release build. The first iteration of this PR tried two `RUST_MIN_STACK` bumps (16 MB, then 32 MB) — both worked exactly long enough to expose a deeper crash, with `rustc`'s own hint escalating to 64 MB and the SIGSEGV moving between `quarto-pandoc-types`, `quarto-ast-reconcile`, and `tokio`. That's not a fixed-size stack deficit; it's a regression in some `rustc` / LLVM pass.

To isolate the trigger, I installed two dated nightlies side-by-side (`nightly-2026-04-28` and `nightly-2026-05-11`) and built `wasm-quarto-hub-client` against each. `nightly-2026-04-28` (rustc commit `52b6e2c20`, 2026-04-27) builds cleanly in 38 seconds. `nightly-2026-05-11` (commit `4b0c9d76a`, 2026-05-10) SIGSEGVs reliably with the same backtrace shape CI sees — through `FPPassManager::runOnModule` and `LLVMRustWriteOutputFile`, i.e. inside LLVM optimization codegen. CI was pulling the broken nightly because `rustup` fetches the latest unfdated nightly on every clean run; local environments don't reproduce because their cached nightly predates 2026-05-10.

This PR pins `rust-toolchain.toml` to `nightly-2026-04-28` — the date matches what the team already has cached locally, so it should be byte-for-byte the same `rustc` everyone is currently running. The earlier `RUST_MIN_STACK` env-var changes in the workflow files have been dropped; the pin replaces them entirely. We'll bump the pinned date once upstream resolves the regression (tracked in [bd-at72](https://github.com/quarto-dev/q2/issues?q=bd-at72)).

## Test plan

- [x] Local reproduction of the CI failure with `nightly-2026-05-11` — confirmed SIGSEGV
- [x] Local `cargo xtask verify` (full) with the pinned `nightly-2026-04-28` — passes
- [ ] CI on this PR — expected to be green
- [ ] Once merged, rebase #176 onto main and confirm its CI also goes green

Closes bd-at72.
