### PR TITLE
pampa - make quarto-system-runtime optional via `filters` feature

### DIFF
--- a/crates/pampa/Cargo.toml
+++ b/crates/pampa/Cargo.toml
@@ -25,10 +25,14 @@ cargo-fuzz = true
 default = ["terminal-support", "json-filter", "lua-filter", "template-fs"]
 terminal-support = ["dep:crossterm", "dep:supports-hyperlinks"]
 terminal-hyperlinks = ["dep:supports-hyperlinks"]
+# Enable filter pipeline support (pulls in quarto-system-runtime / deno_core / v8).
+# Parser-only consumers can disable this with `default-features = false` to avoid
+# the v8 link dependency, which is problematic in shared-library builds on Linux.
+filters = ["dep:quarto-system-runtime"]
 # Enable JSON filter support (requires subprocess spawning, disable for WASM)
-json-filter = []
+json-filter = ["filters"]
 # Enable Lua filter support (disable for WASM, where mlua is not available)
-lua-filter = ["dep:mlua"]
+lua-filter = ["filters", "dep:mlua"]
 # Enable filesystem-based template resolution (disable for WASM)
 template-fs = []
 
@@ -49,7 +53,7 @@ quarto-ast-reconcile = { path = "../quarto-ast-reconcile" }
 quarto-doctemplate = { workspace = true }
 quarto-citeproc = { path = "../quarto-citeproc" }
 quarto-csl = { path = "../quarto-csl" }
-quarto-system-runtime = { workspace = true }
+quarto-system-runtime = { workspace = true, optional = true }
 regex = { version = "1.12.3", features = ["unicode"] }
 clap = { version = "4.5", features = ["derive"] }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/pampa/README.md
+++ b/crates/pampa/README.md
@@ -84,6 +84,22 @@ We will, aspirationally, treat unintentional differences as bugs.
 The "reader" syntax allows users to recover the exact Pandoc markdown behavior when desired.
 With this feature, however, other quarto-markdown conveniences will be absent: no error messages, source tracking, etc.
 
+## Library usage
+
+When used as a library, pampa's default features include filter support
+(`json-filter`, `lua-filter`), which transitively pull in
+`quarto-system-runtime` and `deno_core`. Parser-only consumers (e.g. tooling
+that only needs the qmd reader and writers) can opt out:
+
+```toml
+[dependencies]
+pampa = { ..., default-features = false }
+```
+
+This drops the v8 link dependency, which avoids shared-library link failures
+on Linux x86_64 (`R_X86_64_TPOFF32` against v8 TLS symbols) for consumers
+building a `cdylib`.
+
 ## Current state
 
 Parses [quarto-web](https://github.com/quarto-dev/quarto-web) with a small number of changes

--- a/crates/pampa/src/lib.rs
+++ b/crates/pampa/src/lib.rs
@@ -6,6 +6,7 @@
  * Copyright (c) 2025 Posit, PBC
  */
 
+#[cfg(feature = "filters")]
 pub mod citeproc_filter;
 pub mod errors;
 pub mod filter_context;
@@ -21,6 +22,7 @@ pub mod template;
 pub mod toc;
 pub mod transforms;
 pub mod traversals;
+#[cfg(feature = "filters")]
 pub mod unified_filter;
 pub mod utils;
 pub mod wasm_entry_points;


### PR DESCRIPTION
### Context 

I've been playing around with building an R wrapper around q2/pampa and I've run into an issue building it on linux. See https://github.com/rundel/q2r if interested.

### Issue

Library consumers of pampa that use only the parser and writer cannot build on Linux. `pampa::unified_filter` is unconditionally exposed from `lib.rs` and imports `quarto_system_runtime::SystemRuntime`, which transitively pulls `deno_core` and the `v8` prebuilt static archive. `default-features = false` on `pampa` does not drop this — `quarto-system-runtime` is a non-optional workspace dep. 

The Linux x86_64 v8 static was compiled with the local-exec TLS model, so linking it into a consumer's `cdylib` fails. macOS escapes this because Mach-O TLS goes through a runtime descriptor lookup that's identical in executables and dylibs.

````
$ cargo tree --no-default-features -i deno_core
deno_core v0.376.0
└── quarto-system-runtime v0.1.0
    └── pampa v0.0.0
        └── <consumer-cdylib>

$ cargo build --lib   # consumer crate-type = ["cdylib", "staticlib"]
/usr/bin/ld: target/debug/libconsumer.a(api.o): relocation R_X86_64_TPOFF32 against
  hidden symbol `_ZN2v88internal18g_current_isolate_E' can not be used when making
  a shared object
/usr/bin/ld: failed to set dynamic section sizes: bad value
collect2: error: ld returned 1 exit status
````

### Sketch of fix

Feature-gate `quarto-system-runtime` in `crates/pampa/Cargo.toml` (mark `optional = true`), add a `filters` feature that pulls it in, gate `pub mod unified_filter;` and `pub mod citeproc_filter;` in `crates/pampa/src/lib.rs` behind that feature, and make the existing `json-filter` and `lua-filter` features depend on `filters`. Default features stay as today, so binary and existing library consumers see no change. Parser-only consumers can then opt out with `default-features = false`.
