### PR TITLE
Fix list-table cell with multiple blocks round-tripping cleanly (#183)

### DIFF
--- a/claude-notes/issue-reports/183/exp-single-codeblock.qmd
+++ b/claude-notes/issue-reports/183/exp-single-codeblock.qmd
@@ -1,0 +1,6 @@
+::: {.list-table}
+- - foo
+  - ```python
+    x
+    ```
+:::

--- a/claude-notes/issue-reports/183/exp-two-paras.qmd
+++ b/claude-notes/issue-reports/183/exp-two-paras.qmd
@@ -1,0 +1,6 @@
+::: {.list-table}
+- - foo
+  - Add values:
+
+    Then more text.
+:::

--- a/claude-notes/issue-reports/183/expected-output.qmd
+++ b/claude-notes/issue-reports/183/expected-output.qmd
@@ -1,0 +1,9 @@
+::: {.list-table}
+
+* - foo
+  - Add values:
+
+    ```python
+    x
+    ```
+:::

--- a/claude-notes/issue-reports/183/observed-output.qmd
+++ b/claude-notes/issue-reports/183/observed-output.qmd
@@ -1,0 +1,9 @@
+::: {.list-table}
+
+* - foo
+  - 
+    Add values:
+    ```python
+    x
+    ```
+:::

--- a/claude-notes/issue-reports/183/repro.qmd
+++ b/claude-notes/issue-reports/183/repro.qmd
@@ -1,0 +1,8 @@
+::: {.list-table}
+- - foo
+  - Add values:
+
+    ```python
+    x
+    ```
+:::

--- a/claude-notes/issue-reports/183/triage.md
+++ b/claude-notes/issue-reports/183/triage.md
@@ -190,6 +190,24 @@ This mirrors what the writer already does for top-level loose bullet lists (and 
 
 Filed bd-oxsr (see § Cross-references). Fix is small, single-file (`crates/pampa/src/writers/qmd.rs`), TDD-able through `tests/roundtrip_tests/qmd-json-qmd` with the three fixtures already captured under `claude-notes/issue-reports/183/`.
 
+### Fix applied — 2026-05-14
+
+Fix landed on this branch. Plan: `claude-notes/plans/2026-05-14-list-table-multiblock-cell-fix.md`.
+
+Summary of the change in `crates/pampa/src/writers/qmd.rs`:
+
+- Replaced the cell-emission block in `write_list_table` (~lines 1069-1116 of the pre-fix file) with a uniform three-shape algorithm: empty cell / first block is `Plain`/`Paragraph` / first block is anything else. Subsequent blocks (2nd … nth) within any cell are emitted as blank-line-separated 4-space-indented stanzas.
+- Added two helpers: `write_cell_block_on_marker_line` (for the first block when it is not `Plain`/`Paragraph` — puts its first line on the marker line, indents continuation lines) and `write_cell_block_indented` (for every subsequent block).
+
+One refinement vs. the triage's original fix sketch: the case where the first block is non-`Plain`/non-`Paragraph` (e.g. a `CodeBlock`-only cell) does **not** leave the marker line empty followed by a blank line — that shape introduced a phantom empty `Paragraph` in the reparsed AST. Instead the block's first line continues the marker line, mirroring how a regular CommonMark list item with non-`Plain` content looks. Verified by probing the reader before committing.
+
+Validated:
+
+- `test_qmd_roundtrip_consistency` (was the regression sentinel): all three new fixtures green.
+- `cargo nextest run --workspace`: 8859/8859 pass.
+- End-to-end CLI repro: writer output for the bug-report input round-trips back to a byte-identical AST.
+- No snapshot deltas: the change does not affect any existing `list-table-*` snapshot (all use single-`Plain` cells, an unchanged path).
+
 ## Verification commands used
 
 ```bash

--- a/claude-notes/issue-reports/183/triage.md
+++ b/claude-notes/issue-reports/183/triage.md
@@ -1,0 +1,232 @@
+# Issue #183 — qmd writer emits list-table cell with multiple blocks as a broken bullet item
+
+- **GitHub**: https://github.com/quarto-dev/q2/issues/183
+- **Reporter**: @rundel (Colin Rundel), 2026-05-11
+- **Triage date**: 2026-05-14
+- **Worktree**: `.worktrees/issue-183` (branch `issue-183`, based on `main` @ `76b8fe3e`)
+- **Beads issue**: bd-oxsr
+- **Scope**: Writer bug in `write_list_table` (qmd writer). Related to #174 and #180 only in the broad category of "writer produces qmd that the reader rejects"; mechanism is independent.
+
+## Summary
+
+A `.list-table` div is parsed into a real `Table`. When any cell holds **more than one block** (e.g. a `Para` followed by a `CodeBlock`), the qmd writer emits the inner row-marker line with **no inline content** (`  - \n`) and then writes every block in the cell at 4-space indent with **no blank-line separation between blocks**. The resulting shape is rejected by the qmd reader, so the writer output fails to round-trip and any document containing this pattern cannot be regenerated. Reproduced at HEAD `76b8fe3e`. Root cause is local to the multi-block / non-Plain-non-Para path in `write_list_table` in `crates/pampa/src/writers/qmd.rs:1075-1115`. Fix scope is small and contained.
+
+## Reproduction
+
+Repro file: `claude-notes/issue-reports/183/repro.qmd`
+
+```qmd
+::: {.list-table}
+- - foo
+  - Add values:
+
+    ```python
+    x
+    ```
+:::
+```
+
+### Parse (Pandoc AST)
+
+```
+$ cargo run --bin pampa -- claude-notes/issue-reports/183/repro.qmd
+[ Table … [Row … [Cell … [Para [Str "foo"]],
+                  Cell … [Para [Str "Add", Space, Str "values:"],
+                          CodeBlock ( "" , ["python"] , [] ) "x"]] …] ]
+```
+
+Two cells; the second cell holds **two blocks** — a `Para` and a `CodeBlock`.
+
+### Writer output (observed)
+
+`claude-notes/issue-reports/183/observed-output.qmd`:
+
+```qmd
+::: {.list-table}
+
+* - foo
+  -
+    Add values:
+    ```python
+    x
+    ```
+:::
+```
+
+Two distinct defects:
+
+1. **Empty inner-marker line** — `  - ` (followed by a trailing space and newline) instead of putting the first `Para` inline with the marker.
+2. **No blank line between blocks** — `Add values:` (a `Para`) is followed immediately by the opening `` ```python `` fence on the next indented line, with no blank line separating them.
+
+### Re-parse of writer output (observed failure)
+
+```
+$ cargo run --bin pampa -- claude-notes/issue-reports/183/observed-output.qmd
+Error: Parse error  (line 5, col 5 — `Add`)
+```
+
+The reader does not accept the writer's emitted shape.
+
+### Hand-fixed shape (round-trips cleanly)
+
+`claude-notes/issue-reports/183/expected-output.qmd`:
+
+```qmd
+::: {.list-table}
+
+* - foo
+  - Add values:
+
+    ```python
+    x
+    ```
+:::
+```
+
+Re-parsing this hand-fixed shape yields the same AST as the original input:
+
+```
+[ Table … [Row … [Cell … [Para [Str "foo"]],
+                  Cell … [Para [Str "Add", Space, Str "values:"],
+                          CodeBlock ( "" , ["python"] , [] ) "x"]] …] ]
+```
+
+So the reader is fine; only the writer is wrong.
+
+## Bug surface — what triggers it
+
+Three cell shapes were exercised. Two trigger the bug, one does not:
+
+| Cell content                         | Writer emits empty marker line | Roundtrips? | Path in writer |
+|---                                   |---                             |---          |---             |
+| Single `Plain` / `Para`              | no                             | yes         | line 1078-1089 |
+| Single non-`Plain`/non-`Para` block (e.g. `CodeBlock`) | **yes**       | **no**      | line 1090-1100 (`other` arm) |
+| Multiple blocks                      | **yes**                        | **no**      | line 1102-1113 (`else` arm) |
+
+Both broken paths share the same two defects:
+
+- They `writeln!(buf)?` immediately after writing `- `, so the marker line ends up empty.
+- They emit each block back-to-back with no blank-line separator between blocks within the cell.
+
+Fixture for the single-non-Para case: `claude-notes/issue-reports/183/exp-single-codeblock.qmd`.
+Fixture for the two-paragraph case: `claude-notes/issue-reports/183/exp-two-paras.qmd`.
+
+The two-paragraph fixture also fails to round-trip and confirms that the missing blank line — not anything code-block-specific — is the second defect: any two consecutive blocks at indent-4 collapse into a single paragraph or otherwise misparse.
+
+## Localization
+
+**File**: `crates/pampa/src/writers/qmd.rs`
+**Function**: `write_list_table` (introduced at line 937)
+
+The two broken arms are:
+
+```rust
+// crates/pampa/src/writers/qmd.rs:1078-1115 (excerpted)
+
+if cell.content.len() == 1 {
+    match &cell.content[0] {
+        Block::Plain(plain) => { /* inline — OK */ }
+        Block::Paragraph(para) => { /* inline — OK */ }
+        other => {
+            writeln!(buf)?;          // ← writes "- \n" — defect #1 (empty marker line)
+            let mut block_buf = Vec::<u8>::new();
+            write_block(other, &mut block_buf, ctx)?;
+            let content = String::from_utf8_lossy(&block_buf);
+            for line in content.lines() {
+                writeln!(buf, "    {}", line)?;
+            }
+            continue;
+        }
+    }
+} else {
+    // Multiple blocks — write on new lines with indentation
+    writeln!(buf)?;                  // ← defect #1 again
+    for block in &cell.content {
+        let mut block_buf = Vec::<u8>::new();
+        write_block(block, &mut block_buf, ctx)?;
+        let content = String::from_utf8_lossy(&block_buf);
+        for line in content.lines() {
+            writeln!(buf, "    {}", line)?;
+        }
+        // ← defect #2: no blank-line separator between consecutive blocks
+    }
+    continue;
+}
+```
+
+The analogous *working* model — first block inline with the marker, blank line, then remaining blocks indented — is how regular markdown loose bullet lists handle multi-block items. The single-`Para`/single-`Plain` arms already do the first half (inline emission); the rest of the fix is to extend that treatment into the other two arms.
+
+## Fix sketch (for the beads issue)
+
+In `write_list_table`'s cell-emission loop:
+
+1. **Multi-block case**: if the first block is `Plain` or `Paragraph`, emit its inlines on the marker line. Then for each subsequent block (or for all blocks if the first wasn't `Plain`/`Paragraph`):
+   - emit a blank line
+   - emit the block at 4-space indent
+2. **Single non-Plain/non-Para case**: same shape — empty inline content on the marker line is OK only if it's `[]`-marked, otherwise write a blank line first, then the indented block. (The hand-fixed fixture shows the blank-line variant reparses cleanly; the `[]` variant should be checked but is likely unnecessary if defect #2 is also fixed.)
+
+In both cases, between any two consecutive blocks inside one cell, emit a blank line.
+
+This mirrors what the writer already does for top-level loose bullet lists (and what issues #174/#180 are about for *those* writers — but those bugs are separate).
+
+## Open questions — resolved during triage
+
+**Q1**: Is the reader at fault? Maybe it should accept the writer's current shape.
+**Experiment**: Hand-fixed the writer output and re-parsed it (`expected-output.qmd`). It produces the original AST. So the reader is correct for the canonical loose-list-item shape; the writer is the one producing an off-spec form.
+**Conclusion**: Writer-side fix only.
+
+**Q2**: Is this purely a `.list-table` problem, or does it affect regular nested bullet lists too?
+**Experiment**: Inspected the writer code path. `write_list_table` is the only caller of this particular multi-block / 4-space-indent emission. Regular `BulletList` emission lives elsewhere (and has its own loose/tight bugs — see #174 — but the mechanism is independent).
+**Conclusion**: Scoped to `write_list_table`. #174 is related in *symptom* but is in a different code path.
+
+**Q3**: Does the bug fire for a single non-`Plain`/non-`Para` block (e.g. a row with one cell that's just a code block)?
+**Experiment**: `exp-single-codeblock.qmd`.
+**Conclusion**: Yes — the `other` arm at line 1090 has defect #1 too. Both the single-non-Para arm and the multi-block arm need the same fix.
+
+**Q4**: Should the writer prefer a pipe table for these tables that don't need list-table features?
+**Conclusion**: Out of scope. The `should_use_pipe_table` decision (line 874) already opts cells with `CodeBlock`/multi-block content into list-table, which is correct. The bug is that the list-table writer emits a broken shape for the cases where list-table is the only option.
+
+## Outcome / recommended next step
+
+Filed bd-oxsr (see § Cross-references). Fix is small, single-file (`crates/pampa/src/writers/qmd.rs`), TDD-able through `tests/roundtrip_tests/qmd-json-qmd` with the three fixtures already captured under `claude-notes/issue-reports/183/`.
+
+## Verification commands used
+
+```bash
+gh issue view 183 --repo quarto-dev/q2 --json title,body,author,createdAt,labels,comments
+
+# Pre-flight (in main checkout)
+cargo xtask verify --skip-hub-build
+
+# In the worktree
+cargo xtask verify --skip-hub-build --skip-hub-tests
+
+# Reproduce
+cargo run --bin pampa -- claude-notes/issue-reports/183/repro.qmd
+cargo run --bin pampa -- -t qmd claude-notes/issue-reports/183/repro.qmd
+cargo run --bin pampa -- -t qmd claude-notes/issue-reports/183/repro.qmd \
+  | tee claude-notes/issue-reports/183/observed-output.qmd
+cargo run --bin pampa -- claude-notes/issue-reports/183/observed-output.qmd  # parse error
+
+# Side fixtures
+cargo run --bin pampa -- claude-notes/issue-reports/183/exp-single-codeblock.qmd
+cargo run --bin pampa -- -t qmd claude-notes/issue-reports/183/exp-single-codeblock.qmd
+cargo run --bin pampa -- claude-notes/issue-reports/183/exp-two-paras.qmd
+cargo run --bin pampa -- -t qmd claude-notes/issue-reports/183/exp-two-paras.qmd
+
+# Hand-fixed shape
+cargo run --bin pampa -- claude-notes/issue-reports/183/expected-output.qmd
+```
+
+## Cross-references
+
+- **bd-oxsr** — beads issue filed from this triage. Carries the fix-scope description and TDD plan.
+- GitHub #174 — loose-bullet-list writer drops looseness when a nested sublist is present. Related symptom (round-trip failure caused by writer output), independent code path.
+- GitHub #180 — Figure-then-Para spacing bug. CLOSED. Same family ("writer emits qmd the reader rejects"), independent code path.
+- `crates/pampa/CLAUDE.md` — mandatory TDD checklist for any fix in this crate.
+- `crates/pampa/src/writers/qmd.rs:937` — `write_list_table` (target of the fix).
+- `crates/pampa/src/writers/qmd.rs:1124-1128` — incremental-writer coupling note: tables are always fully rewritten, so the fix does not need to handle incremental splicing.
+- Reporter-cited quarto-web usages (real-world hits):
+  - `docs/extensions/lua-api.qmd:292`
+  - `docs/blog/posts/2026-03-24-1.9-release/index.qmd:91`
+  - `docs/blog/posts/2026-03-24-1.9-release/index.qmd:114`

--- a/claude-notes/plans/2026-05-14-list-table-multiblock-cell-fix.md
+++ b/claude-notes/plans/2026-05-14-list-table-multiblock-cell-fix.md
@@ -1,0 +1,109 @@
+# Fix: qmd writer emits list-table cell with multiple blocks as broken bullet item
+
+- **Issue**: GitHub #183
+- **Beads**: bd-oxsr
+- **Worktree**: `.worktrees/issue-183` (branch `issue-183`)
+- **Triage**: `claude-notes/issue-reports/183/triage.md`
+- **Started**: 2026-05-14
+
+## Overview
+
+`write_list_table` in `crates/pampa/src/writers/qmd.rs:937` produces qmd that the reader rejects whenever a `.list-table` cell contains either (a) multiple blocks or (b) a single block that is not `Plain`/`Paragraph`. Two defects in the cell-emission paths (lines 1090-1100 and 1102-1113):
+
+1. The `-` marker line is left empty (`writeln!(buf)?` runs immediately after the marker is written).
+2. Consecutive blocks within a cell are emitted at indent-4 with no blank-line separator.
+
+The canonical valid shape — first `Plain`/`Paragraph` inline with the marker, blank line, then subsequent blocks at indent-4 — round-trips cleanly (`claude-notes/issue-reports/183/expected-output.qmd`).
+
+## TDD ground rules (from `crates/pampa/CLAUDE.md`)
+
+1. Write the failing test.
+2. Confirm it fails as expected.
+3. Implement the fix.
+4. Confirm the test passes.
+5. Run `cargo nextest run --workspace` for regressions.
+6. End-to-end exercise the binary on the original repro.
+
+## Work Items
+
+### Phase 1 — Failing tests
+
+- [x] **1.1** Copy `repro.qmd` (multi-block: Para + CodeBlock) into the round-trip suite as `list_table_cell_para_then_codeblock.qmd`.
+- [x] **1.2** Copy `exp-single-codeblock.qmd` (single non-Para/non-Plain block) into the round-trip suite as `list_table_cell_single_codeblock.qmd`.
+- [x] **1.3** Copy `exp-two-paras.qmd` (two consecutive Paragraphs in one cell) into the round-trip suite as `list_table_cell_two_paragraphs.qmd`.
+- [x] **1.4** Run `cargo nextest run -p pampa test_qmd_roundtrip_consistency` — confirmed `test_qmd_roundtrip_consistency` panics on `list_table_cell_para_then_codeblock.qmd` because the regenerated qmd fails to parse. Test driver aborts on first failure, so the other two were verified via CLI.
+- [x] **1.5** CLI repros for all three confirm the same observed shape (empty marker line + no blank-line separator → parse error on re-read).
+
+### Phase 2 — Implementation
+
+- [x] **2.1** Refactor the cell-emission block in `write_list_table` to handle three shapes uniformly. One change vs. the original plan: for the "first block is non-Plain/non-Para" case, the block's **first line goes on the marker line** (e.g. `  - \`\`\`python`) rather than leaving the marker line empty and using a blank line. Probing showed that the empty-marker + blank-line shape introduces a phantom empty `Para` in the parsed AST (mismatching the original), whereas the first-line-on-marker shape round-trips cleanly. Implementation uses two helpers: `write_cell_block_on_marker_line` (first block, non-Plain/non-Para) and `write_cell_block_indented` (every subsequent block).
+- [x] **2.2** Fixtures from Phase 1 pass — `test_qmd_roundtrip_consistency` green.
+- [x] **2.3** `table_list_colspan.qmd` still passes — Plain-content cells unaffected.
+- [x] **2.4** Surveyed all `list-table-*.qmd` snapshots — every existing one uses single-Plain cells; none touch the code paths the fix changed.
+
+### Phase 3 — Verification
+
+- [x] **3.1** `cargo nextest run -p pampa` — 3687 tests, all pass.
+- [x] **3.2** `cargo nextest run --workspace` — 8859 tests, all pass (qmd-syntax-helper green: 93/93).
+- [x] **3.3** `cargo xtask verify --skip-hub-build --skip-hub-tests` — one unrelated pre-existing failure (`tree-sitter-qmd` GFM example 209); confirmed by stashing the change and re-running on `main`. Not introduced by this fix.
+- [x] **3.4** End-to-end through pampa CLI: writer output for the original repro round-trips back to the byte-identical AST as the original input. Captured in transcript.
+- [x] **3.5** No snapshot diffs (`git status` shows only the writer source file + new fixtures + plan doc). All existing list-table snapshots use single-Plain cells and are untouched.
+
+### Phase 4 — Close-out
+
+- [ ] **4.1** Update the triage doc with the actual fix.
+- [ ] **4.2** Stage and commit on `issue-183` branch.
+- [ ] **4.3** Update bd-oxsr (close with summary).
+- [ ] **4.4** Sync beads, commit JSONL on `main`.
+- [ ] **4.5** Wait for user approval before pushing.
+
+## Design notes
+
+### Cell shape after the fix
+
+```rust
+match cell.content.split_first() {
+    None                                       => /* empty cell */,
+    Some((Block::Plain(_) | Block::Paragraph(_), rest)) => {
+        emit_inlines_on_marker_line();
+        for block in rest {
+            emit_blank_line();
+            emit_indented_block(block);
+        }
+    }
+    Some((first, rest)) => {
+        // no inlines on marker line — leave it as just "- "
+        // emit first as the first indented stanza
+        emit_blank_line();
+        emit_indented_block(first);
+        for block in rest {
+            emit_blank_line();
+            emit_indented_block(block);
+        }
+    }
+}
+```
+
+A single function `emit_indented_block(block)` keeps the indentation logic in one place.
+
+### Why a blank line for the all-non-Para case
+
+CommonMark loose-list rule: a list item with non-Plain block content needs a blank line before that content for the indented block to be recognized as belonging to the item. The reader currently enforces this — `expected-output.qmd` round-trips, the observed-output does not.
+
+### `[]` placeholder for non-Para first blocks?
+
+An alternative shape for the "non-Para first block" case would be `* - []` (empty span placeholder) followed by blank line and indented block. The current code only uses `[]` when no attributes are needed AND the cell is empty. Adding `[]` for non-Para first blocks would be a stylistic preference, not a correctness one. The blank-line-before-indented-block shape is what the canonical hand-fixed fixture uses and what TS Pandoc would round-trip cleanly. Stick with that.
+
+### What this fix does NOT touch
+
+- `should_use_pipe_table` decision logic (untouched).
+- Loose/tight bullet list writer (#174) — different code path.
+- Incremental writer registry (tables are always fully rewritten — see comment at line 1124).
+
+## Risk / blast radius
+
+- Single function (`write_list_table`).
+- Touched by:
+  - `tests/roundtrip_tests/qmd-json-qmd/table_list_colspan.qmd` (existing fixture — single Plain content).
+  - Any snapshot using `.list-table` in `crates/pampa/tests/snapshots/`.
+- Downstream consumer `qmd-syntax-helper` may have grid-table → list-table tests with multi-block cells; flag for review.

--- a/crates/pampa/src/writers/qmd.rs
+++ b/crates/pampa/src/writers/qmd.rs
@@ -928,6 +928,55 @@ fn alignment_to_char(align: &Alignment) -> char {
     }
 }
 
+/// Emit a list-table cell block whose first line continues on the inner
+/// bullet's marker line; continuation lines are indented to column 4 so the
+/// block stays inside the cell. Used for the first block of a cell when that
+/// block is not Plain/Paragraph (e.g. CodeBlock, BlockQuote, Div).
+fn write_cell_block_on_marker_line(
+    block: &crate::pandoc::Block,
+    buf: &mut dyn std::io::Write,
+    ctx: &mut QmdWriterContext,
+) -> std::io::Result<()> {
+    let mut block_buf = Vec::<u8>::new();
+    write_block(block, &mut block_buf, ctx)?;
+    let content = String::from_utf8_lossy(&block_buf);
+    let mut lines = content.lines();
+    if let Some(first_line) = lines.next() {
+        writeln!(buf, "{}", first_line)?;
+    } else {
+        writeln!(buf)?;
+    }
+    for line in lines {
+        if line.is_empty() {
+            writeln!(buf)?;
+        } else {
+            writeln!(buf, "    {}", line)?;
+        }
+    }
+    Ok(())
+}
+
+/// Emit a list-table cell block as a 4-space-indented stanza. Used for every
+/// block past the first in a cell (the first is handled inline on the marker
+/// line by the caller).
+fn write_cell_block_indented(
+    block: &crate::pandoc::Block,
+    buf: &mut dyn std::io::Write,
+    ctx: &mut QmdWriterContext,
+) -> std::io::Result<()> {
+    let mut block_buf = Vec::<u8>::new();
+    write_block(block, &mut block_buf, ctx)?;
+    let content = String::from_utf8_lossy(&block_buf);
+    for line in content.lines() {
+        if line.is_empty() {
+            writeln!(buf)?;
+        } else {
+            writeln!(buf, "    {}", line)?;
+        }
+    }
+    Ok(())
+}
+
 /// Write a table as a list-table div.
 /// This format supports multi-line cells, rowspan, colspan, etc.
 ///
@@ -1066,54 +1115,46 @@ fn write_list_table(
                 write!(buf, "}} ")?;
             }
 
-            // Write cell content
+            // Write cell content. Three shapes:
+            //   - empty cell: marker line carries the `[]` (or attr) placeholder only.
+            //   - first block is Plain/Paragraph: inlines on the marker line; any
+            //     subsequent blocks emit as blank-line-separated indented stanzas.
+            //   - first block is anything else (CodeBlock, BlockQuote, Div, …):
+            //     the block's opening line continues the marker line and
+            //     continuation lines indent to column 4 — same shape a regular
+            //     CommonMark list item uses for non-Plain content.
+            // The blank line before each non-first block is what makes the inner
+            // list item "loose" so the reader treats indented content as part of
+            // the cell.
             if cell.content.is_empty() {
-                // Empty cell - write empty span to mark it
                 if !needs_attrs {
                     write!(buf, "[]")?;
                 }
+                writeln!(buf)?;
             } else {
-                // Write cell content inline if single block with simple content
-                // Otherwise write as nested blocks
-                if cell.content.len() == 1 {
-                    match &cell.content[0] {
-                        Block::Plain(plain) => {
-                            for inline in &plain.content {
-                                write_inline(inline, buf, ctx)?;
-                            }
+                let (first, rest) = cell.content.split_first().unwrap();
+                match first {
+                    Block::Plain(p) => {
+                        for inline in &p.content {
+                            write_inline(inline, buf, ctx)?;
                         }
-                        Block::Paragraph(para) => {
-                            for inline in &para.content {
-                                write_inline(inline, buf, ctx)?;
-                            }
-                        }
-                        other => {
-                            writeln!(buf)?;
-                            // Indent the block content
-                            let mut block_buf = Vec::<u8>::new();
-                            write_block(other, &mut block_buf, ctx)?;
-                            let content = String::from_utf8_lossy(&block_buf);
-                            for line in content.lines() {
-                                writeln!(buf, "    {}", line)?;
-                            }
-                            continue; // Skip the newline at the end since we already wrote it
-                        }
+                        writeln!(buf)?;
                     }
-                } else {
-                    // Multiple blocks - write on new lines with indentation
-                    writeln!(buf)?;
-                    for block in &cell.content {
-                        let mut block_buf = Vec::<u8>::new();
-                        write_block(block, &mut block_buf, ctx)?;
-                        let content = String::from_utf8_lossy(&block_buf);
-                        for line in content.lines() {
-                            writeln!(buf, "    {}", line)?;
+                    Block::Paragraph(p) => {
+                        for inline in &p.content {
+                            write_inline(inline, buf, ctx)?;
                         }
+                        writeln!(buf)?;
                     }
-                    continue; // Skip the newline at the end since we already wrote it
+                    _ => {
+                        write_cell_block_on_marker_line(first, buf, ctx)?;
+                    }
+                }
+                for block in rest {
+                    writeln!(buf)?; // blank-line separator
+                    write_cell_block_indented(block, buf, ctx)?;
                 }
             }
-            writeln!(buf)?;
         }
     }
 

--- a/crates/pampa/tests/roundtrip_tests/qmd-json-qmd/list_table_cell_para_then_codeblock.qmd
+++ b/crates/pampa/tests/roundtrip_tests/qmd-json-qmd/list_table_cell_para_then_codeblock.qmd
@@ -1,0 +1,8 @@
+::: {.list-table}
+- - foo
+  - Add values:
+
+    ```python
+    x
+    ```
+:::

--- a/crates/pampa/tests/roundtrip_tests/qmd-json-qmd/list_table_cell_single_codeblock.qmd
+++ b/crates/pampa/tests/roundtrip_tests/qmd-json-qmd/list_table_cell_single_codeblock.qmd
@@ -1,0 +1,6 @@
+::: {.list-table}
+- - foo
+  - ```python
+    x
+    ```
+:::

--- a/crates/pampa/tests/roundtrip_tests/qmd-json-qmd/list_table_cell_two_paragraphs.qmd
+++ b/crates/pampa/tests/roundtrip_tests/qmd-json-qmd/list_table_cell_two_paragraphs.qmd
@@ -1,0 +1,6 @@
+::: {.list-table}
+- - foo
+  - Add values:
+
+    Then more text.
+:::


### PR DESCRIPTION
## Summary

- `write_list_table` previously emitted an empty inner `-` marker followed by 4-space-indented blocks with no blank-line separator whenever a list-table cell held more than one block, or a single non-`Plain`/non-`Paragraph` block. The reader rejected that shape, so documents containing such cells could not be regenerated from the AST.
- The cell-content emission is now a uniform three-shape algorithm covering empty cells, cells whose first block is `Plain`/`Paragraph` (inlines go on the marker line), and cells whose first block is anything else (its first line continues the marker line; continuation lines indent to column 4). Subsequent blocks always emit as blank-line-separated 4-space-indented stanzas.
- Closes #183.

## Why this shape

The blank-line separator before non-first blocks is what makes the inner list item "loose" so the reader treats indented content as part of the cell.

For the first-block-is-not-`Plain`/`Paragraph` case, the natural alternative — leave the marker line empty, blank line, then indented block — was tried and rejected: the reader parses that as the cell containing an extra empty `Paragraph` ahead of the real block, which breaks AST round-trip. Putting the block's first line on the marker line mirrors how a regular CommonMark list item with non-`Plain` content looks, and round-trips byte-identically.

## Test plan

- [x] `cargo nextest run -p pampa` — 3687/3687 pass, including three new round-trip fixtures (`list_table_cell_para_then_codeblock.qmd`, `list_table_cell_single_codeblock.qmd`, `list_table_cell_two_paragraphs.qmd`) added under `crates/pampa/tests/roundtrip_tests/qmd-json-qmd/`. Confirmed-failing before the fix, passing after.
- [x] `cargo nextest run --workspace` — 8859/8859 pass (qmd-syntax-helper green).
- [x] End-to-end CLI: `cargo run --bin pampa -- -t qmd <fixture>.qmd | cargo run --bin pampa --` returns the same AST as the original input, verified for all three new fixtures plus the bug-report's original repro.
- [x] No snapshot drift — every existing `list-table-*` snapshot uses single-`Plain` cells, an unchanged code path.

## Notes for review

- Triage record: `claude-notes/issue-reports/183/triage.md`.
- Implementation plan: `claude-notes/plans/2026-05-14-list-table-multiblock-cell-fix.md`.
- Beads issue: bd-oxsr (closed).
- `cargo xtask verify --skip-hub-build --skip-hub-tests` surfaces one unrelated, pre-existing failure (`tree-sitter-qmd` GFM example 209) present on `main` too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)