### PR TITLE
ci: disable Swatinem rust-cache cache-bin to fix intermittent macOS failures

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -59,6 +59,13 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
+          # cache-bin: false avoids clobbering the freshly-installed
+          # ~/.cargo/bin/{cargo,rustup,...} with stale proxies from a
+          # previous run. Intermittently broke macOS CI on 2026-05-14
+          # with `cargo xtask … → rustup-init: unexpected argument`.
+          # cargo-nextest / cargo-insta re-install via taiki-e/install-
+          # action's prebuilts each run, which is cheap (~1-2s).
+          cache-bin: false
           shared-key: "rust-test-suite"
 
       # Cache cargo-nextest and insta separately to avoid reinstalling


### PR DESCRIPTION
## Summary
- macOS test-suite job has failed intermittently today with `cargo xtask lint` → `error: unexpected argument 'xtask' found / Usage: rustup-init[EXE] [OPTIONS]`.
- Root cause: `Swatinem/rust-cache@v2`'s default `cache-bin: true` caches `~/.cargo/bin/` (including the rustup proxies). After `dtolnay/rust-toolchain@nightly` installs rustup 1.29.0, the cache-restore step in the same workflow overwrites the freshly-installed proxies with content from an older saved cache; some saved-versus-fresh combinations make `cargo` land in installer mode.
- Fix: set `cache-bin: false`. `cargo-nextest` / `cargo-insta` re-install via `taiki-e/install-action` prebuilts each run (~1–2s each). Negligible compared to the registry / target caching that is unaffected.

Observed failures:
- https://github.com/quarto-dev/q2/actions/runs/25886076035 (push to main, 21:14 UTC)
- https://github.com/quarto-dev/q2/actions/runs/25888844085 (PR #198, 22:17 UTC)

Same prefix-key cache hit in both; failure consistently lands at the first `cargo` invocation after the cache-restore step.

`hub-client-e2e.yml` is left untouched — Ubuntu-only, no observed failure there, and disabling `cache-bin` would force `cargo install wasm-pack` to rebuild from source on every run, a real cost.

## Test plan
- [ ] Re-run the workflow on this branch (the very act of opening this PR triggers it). The PR's own CI is the test — green-on-macOS means the fix works.
- [ ] After merge, watch the next few macOS runs on main and #198 for the same error; absence is the confirmation.

Closes bd-u50w sibling issue bd-p7uk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)