### PR TITLE
Fix Q-2-35 misfire on list-item continuations (#196)

### DIFF
--- a/claude-notes/issue-reports/196/exp-bullet-list.qmd
+++ b/claude-notes/issue-reports/196/exp-bullet-list.qmd
@@ -1,0 +1,3 @@
+*   Outer:
+    
+    ![](img.png){.border}

--- a/claude-notes/issue-reports/196/exp-no-trailing-ws.qmd
+++ b/claude-notes/issue-reports/196/exp-no-trailing-ws.qmd
@@ -1,0 +1,3 @@
+4)  Outer:
+
+    ![](img.png){.border}

--- a/claude-notes/issue-reports/196/exp-tab-on-blank.qmd
+++ b/claude-notes/issue-reports/196/exp-tab-on-blank.qmd
@@ -1,0 +1,3 @@
+4)  Outer:
+	
+    ![](img.png){.border}

--- a/claude-notes/issue-reports/196/exp-trailing-ws-text.qmd
+++ b/claude-notes/issue-reports/196/exp-trailing-ws-text.qmd
@@ -1,0 +1,3 @@
+4)  Outer:
+    
+    second paragraph text

--- a/claude-notes/issue-reports/196/exp-two-trailing-spaces.qmd
+++ b/claude-notes/issue-reports/196/exp-two-trailing-spaces.qmd
@@ -1,0 +1,3 @@
+4)  Outer:
+  
+    ![](img.png){.border}

--- a/claude-notes/issue-reports/196/repro.qmd
+++ b/claude-notes/issue-reports/196/repro.qmd
@@ -1,0 +1,3 @@
+4)  Outer:
+    
+    ![](img.png){.border}

--- a/claude-notes/issue-reports/196/triage.md
+++ b/claude-notes/issue-reports/196/triage.md
@@ -1,0 +1,120 @@
+# Issue #196 — Reader rejects valid 4-space-indented list-item continuations as a parse error
+
+- **GitHub:** https://github.com/quarto-dev/q2/issues/196
+- **Reporter:** @rundel (Colin Rundel)
+- **Status:** Confirmed regression introduced by PR #194 (closes #184, Q-2-35).
+- **Verdict:** Real bug. Filed as bd-3mgb (discovered-from bd-7l1u, the Q-2-35 implementation).
+- **Worktree branch:** `issue-196` at `.worktrees/issue-196/`.
+
+## Scope
+
+A single regression. No sub-bugs bundled in the report.
+
+## Repro
+
+```text
+4)  Outer:
+    
+    ![](img.png){.border}
+```
+
+The blank line on row 2 contains four trailing spaces (hex dump: `20 20 20 20 0a`). With `pampa` reading from stdin:
+
+```
+$ cargo run --bin pampa -- < repro.qmd
+Error: Parse error
+   ╭─[ <stdin>:3:5 ]
+   │
+ 3 │     ![](img.png){.border}
+   │     ┬
+   │     ╰── unexpected character or token here
+───╯
+```
+
+Expected (pre-#194 behaviour, reported by @rundel): an `OrderedList` whose single item contains two `Para` children — verified locally against `exp-no-trailing-ws.qmd`, which strips the trailing whitespace and parses cleanly to:
+
+```
+[ OrderedList (4, Decimal, OneParen) [[Para [Str "Outer:"], Para [Image (...) [] ("img.png" , "")]]] ]
+```
+
+## Fixtures (all under `claude-notes/issue-reports/196/`)
+
+| File                              | Trailing whitespace on blank line       | Result        |
+| --------------------------------- | --------------------------------------- | ------------- |
+| `repro.qmd`                       | 4 spaces                                | **Parse error** |
+| `exp-no-trailing-ws.qmd`          | none (pure `\n\n`)                      | Parses OK     |
+| `exp-two-trailing-spaces.qmd`     | 2 spaces                                | Parses OK     |
+| `exp-tab-on-blank.qmd`            | 1 tab (= 4 columns of indentation)      | **Parse error** |
+| `exp-trailing-ws-text.qmd`        | 4 spaces, continuation is plain text    | **Parse error** |
+| `exp-bullet-list.qmd`             | 4 spaces, bullet list (`*`) instead of `4)` | **Parse error** |
+
+Conclusions:
+
+1. The trigger is the **amount** of trailing whitespace on the intervening blank line, not the kind of continuation content. The threshold is exactly 4 columns (a tab counts).
+2. The bug is generic across list marker kinds (ordered, bullet) and content kinds (image, text).
+3. The continuation line is **not** the issue — its indent is the standard 4 spaces required for a list-item continuation. Stripping trailing whitespace from the blank line above (a no-op for the AST) makes the same continuation line parse.
+
+## Root cause (confirmed by tree-sitter trace)
+
+PR #194 added an `INDENTED_CODE_BLOCK_DISALLOWED` external token in `crates/tree-sitter-qmd/tree-sitter-markdown/src/scanner.c:2128`:
+
+```c
+// Parse any preceeding whitespace and remember its length.
+for (;;) {
+    if (lexer->lookahead == ' ' || lexer->lookahead == '\t') {
+        s->indentation += advance(s, lexer);
+    } else {
+        break;
+    }
+}
+
+// Q-2-35: ...
+if (s->indentation >= 4 &&
+    (valid_symbols[ATX_H1_MARKER] || valid_symbols[BLANK_LINE_START]) &&
+    lexer->lookahead != '\n' && lexer->lookahead != '\r') {
+    mark_end(s, lexer);
+    EMIT_TOKEN(INDENTED_CODE_BLOCK_DISALLOWED);
+}
+```
+
+Running `pampa -v` on `repro.qmd` shows the scanner emitting that token during the recovery path while at `row:2`:
+
+```
+recover_to_previous state:345, depth:2
+...
+lex_external state:5, row:2, column:16
+lexed_lookahead sym:_indented_code_block_error, size:0
+detect_error lookahead:_indented_code_block_error
+```
+
+So the regression is specifically the new check firing where it shouldn't. The PR's own description listed the cases the conservative gate was meant to skip — and "list-item continuations after a blank line" was one of them. What the gate misses is the case where the blank line itself carries enough whitespace to push `s->indentation >= 4`: after consuming the blank line, the scanner re-enters at the continuation line with state that makes `valid_symbols[ATX_H1_MARKER] || valid_symbols[BLANK_LINE_START]` true (parser is at a block-start position) and the freshly accumulated indentation `>= 4`, so it fires the indented-block error.
+
+@rundel's diagnosis lands exactly here: *"the regression is in the column accounting around whitespace-only lines inside list items rather than in the indented-code-block detector itself — Q-2-35 would have surfaced as `[Q-2-35] Indented code blocks are not supported`, not a bare 'Parse error'."* The Q-2-35 user-facing message is keyed on a specific `(state, sym)` pair in `quarto-parse-errors`; the recovery state hit here (`state:5`) is not in that table, which is also why the error renders as a generic "unexpected character or token" instead of the friendly Q-2-35 message.
+
+## Severity
+
+High. The reporter has three real-world hits in `quarto-dev/quarto-web`:
+
+- https://github.com/quarto-dev/quarto-web/blob/baeab38627fcc3f3a9ea3ca3ea689ece413df65d/docs/authoring/diagrams.qmd#L98
+- https://github.com/quarto-dev/quarto-web/blob/baeab38627fcc3f3a9ea3ca3ea689ece413df65d/docs/extensions/engine.qmd#L92
+- https://github.com/quarto-dev/quarto-web/blob/baeab38627fcc3f3a9ea3ca3ea689ece413df65d/docs/publishing/netlify.qmd#L119
+
+Editors commonly insert trailing whitespace on indented blank lines (auto-indent on Enter), so the input pattern is realistic. The failure mode is total parse rejection, not a degraded render — every document with this pattern is unreadable to Rust Quarto.
+
+## Where the fix should land
+
+Tree-sitter scanner in `crates/tree-sitter-qmd/tree-sitter-markdown/src/scanner.c` around line 2128. The detector needs to distinguish "true block-start with 4+ leading spaces of content" from "list-item lazy continuation whose preceding blank line contained whitespace". The PR's intent was already to skip the latter; the gate just doesn't express that condition.
+
+Possible angles (for the fix session, not this triage):
+
+1. **Reset/decrement `s->indentation` when entering through the BLANK_LINE_START path of the previous scan.** If the blank-line case at line 2150 cleared any accumulated indentation, the next call would start fresh. Need to verify whether that is sound elsewhere.
+2. **Tighten the gate so it does not fire when inside an open list item that is awaiting a continuation paragraph.** The list-item container state should be inspectable; if the parser would accept a list continuation here, the indented-code-block check should defer.
+3. **Add a corpus test for trailing-whitespace blank lines** to whichever fix is chosen, and a positive Q-2-35 regression to confirm the original PR's diagnostic still fires on real top-level indented blocks.
+
+The reporter's note about a `(state, sym)` mapping miss (the bare "Parse error" instead of Q-2-35) is a separate observation — once the false-positive is silenced, that mapping question goes away for this input. No need to widen the error corpus to cover the recovery state if we stop emitting the token in the first place.
+
+## What I did not do
+
+- I did not write a fix. This is a triage record.
+- I did not add a tree-sitter corpus regression test. That belongs to the fix PR (TDD: red test first).
+- I did not run `cargo xtask verify` on the worktree to full green; only the Rust legs were exercised. Hub-client tests fail with `vitest: command not found` because no `npm install` has been run in this clone. The bug is scanner-only; hub-client is not in scope.

--- a/claude-notes/plans/2026-05-14-issue-196-list-continuation-regression.md
+++ b/claude-notes/plans/2026-05-14-issue-196-list-continuation-regression.md
@@ -1,0 +1,95 @@
+# Fix issue #196: list-item continuation regression from PR #194 (bd-3mgb)
+
+- **GitHub:** https://github.com/quarto-dev/q2/issues/196
+- **Beads:** bd-3mgb (discovered-from bd-7l1u, the Q-2-35 implementation)
+- **Worktree branch:** `issue-196`
+- **Triage:** `claude-notes/issue-reports/196/triage.md`
+
+## Goal
+
+Restore correct parsing of list-item continuations when the intervening blank line carries ≥4 columns of trailing whitespace, **without weakening** the original Q-2-35 detection of true 4-space-indented code blocks added by PR #194.
+
+A successful fix:
+
+1. Makes the reporter's `repro.qmd` parse to `[ OrderedList ... [Para "Outer:", Para Image] ]` again.
+2. Leaves every existing Q-2-35 positive case (`Q-2-35-basic.qmd`, `Q-2-35-more-than-four.qmd`, `Q-2-35-tab-indent.qmd`, `Q-2-35-indented-blockquote.qmd`) still emitting the friendly diagnostic.
+3. Adds a tree-sitter corpus regression so the bug cannot return silently.
+4. Passes full `cargo nextest run --workspace` and `cargo xtask verify --skip-hub-build`.
+
+## Constraints
+
+- The fix lives in the scanner (`crates/tree-sitter-qmd/tree-sitter-markdown/src/scanner.c`). The Rust readers / error-corpus mapping are downstream of this signal and should not change.
+- The PR description's "conservative gate" intent — the gate fires *only* at true block-start positions outside container-continuation contexts — is the right design. The current implementation undershoots that intent; we tighten it.
+- No hacky workarounds (per CLAUDE.md). The fix must be a sound shift to the gate's domain, not a special case on `repro.qmd`.
+
+## Phase 0 — Setup
+
+- [x] Worktree exists at `.worktrees/issue-196/`, on branch `issue-196`. Triage commit landed.
+- [x] Beads `bd-3mgb` claimed (`in_progress`).
+- [x] Plan doc written (this file).
+
+## Phase 1 — TDD: failing test first
+
+Per CLAUDE.md, the test goes in first and must be observed failing before any code change.
+
+- [x] Added three tree-sitter corpus cases to `crates/tree-sitter-qmd/tree-sitter-markdown/test/corpus/qmd.txt` — ordered-list (image continuation), bullet-list (text continuation), and tab-indent variants. All three failed initially with the same shape: root `ERROR` node, list marker captured, first paragraph captured, second paragraph dropped.
+- [x] Pure-Rust regression skipped — the tree-sitter corpus cases plus the end-to-end CLI verification in Phase 5 cover the same ground without duplicating fixtures across crates.
+
+## Phase 2 — Diagnosis with evidence
+
+The triage doc identified candidate fix angles. Phase 2's job was to pick the right one with evidence, not opinion.
+
+- [x] Surveyed the 30 `s->indentation` reset/accumulate sites in `scanner.c`. Resets happen at line-ending (line 2293, 2495), at SOFT_LINE_ENDING (line 2375, 2470), inside container matchers, inside parser-specific paths, and at deserialization. The whitespace-consumption loop at line 2103 uses `+=`, so any stale value from a previous call persists across mid-line `scan()` invocations.
+- [x] Confirmed the gate sits inside `static bool scan(...)` (the workhorse called from `tree_sitter_markdown_external_scanner_scan`). The function does NOT reset `s->indentation` on entry — the architecture relies on the line-ending reset to fire between lines.
+- [x] Instrumented the gate with an `fprintf` dumping `(s->indentation, valid_symbols[ATX_H1_MARKER], valid_symbols[BLANK_LINE_START], valid_symbols[BLOCK_CONTINUATION], s->open_blocks.size, s->matched, s->column, s->state, lexer->lookahead)`. Ran the instrumented parser on (a) the reporter's `repro.qmd` (misfire), (b) `Q-2-35-basic.qmd` (legit top-level), (c) a synthesized in-list 8-space indent case (legit nested Q-2-35).
+- [x] **Decision** — pick **(B)**, the BLOCK_CONTINUATION discriminator, refined to `valid_symbols[BLOCK_CONTINUATION] && s->open_blocks.size > 0`.
+
+### Why (B) wins
+
+The trace data showed a clean separator:
+
+| Case                                       | indentation | ATX | BLANK | CONT | open_blocks | should fire? |
+| ------------------------------------------ | ----------- | --- | ----- | ---- | ----------- | ------------ |
+| Q-2-35 top-level (`Before.\n\n    foo`)    | 4           | 1   | 0     | **1**| **0**       | yes ✓        |
+| Q-2-35 in-list (`4)  ...\n\n        bar`)  | 4           | 1   | 0     | **0**| 1           | yes ✓        |
+| Misfire (`4)  ...\n    \n    !`)           | 4           | 1   | 0     | **1**| **1**       | no ✗         |
+
+The misfire is uniquely identified by `BLOCK_CONTINUATION valid` *plus* `open_blocks.size > 0`. In that state the parser still owes the line a container-continuation absorption — the indent has not yet been confirmed as "extra". Either flag alone overcounts (BLOCK_CONTINUATION is also valid for legit top-level Q-2-35, where `open_blocks.size == 0`; `open_blocks.size > 0` alone would miss the in-list Q-2-35).
+
+### Why (A) and (C) lose
+
+- **(A)** Resetting `s->indentation = 0` at the top of `scan()` would break `match()` for LIST_ITEM (line 533–542), which expects `s->indentation` to accumulate across its own internal whitespace loop and reach `list_item_indentation` before subtracting. Across-the-board resets touch every container-matching path; the blast radius is the whole grammar.
+- **(C)** Tracking "did the whitespace loop consume bytes this call" suppresses the recovery-state mid-line misfire but does NOT suppress the start-of-line misfire (where the loop *does* consume the 4 spaces because match_line was not entered — STATE_MATCHING was unset by the preceding blank-line path). Confirmed by the trace: the bad case at start of row 2 has `s->indentation = 4` *as the result of the loop running on this call*. So (C) alone is necessary but not sufficient.
+
+(B) addresses the start-of-line misfire (BLOCK_CONTINUATION valid + open blocks → defer) AND the recovery-state mid-line misfire (BLOCK_CONTINUATION valid + open blocks → defer) without disturbing the legitimate paths.
+
+## Phase 3 — Implementation
+
+- [x] Edited `scanner.c` gate at line 2128 to add `!(valid_symbols[BLOCK_CONTINUATION] && s->open_blocks.size > 0)`. Replaced the explanatory comment block with one that records the discriminator from the trace and why the alternatives lose.
+- [x] Ran `tree-sitter generate` to regenerate `parser.c`.
+- [x] `tree-sitter test`: 483/483 (was 480 + 3 new tests). All four existing Q-2-35 positive cases (`Q-2-35: 4-space indent rejected`, `Q-2-35: tab indent rejected`, and corresponding negatives) still fire / pass unchanged. GFM Example 209 unchanged.
+
+## Phase 4 — Workspace verification
+
+- [x] `cargo nextest run -p pampa` — 3686/3686 passed, 2 skipped.
+- [x] `cargo nextest run --workspace` — 8863/8863 passed, 195 skipped.
+- [x] `cargo xtask verify --skip-hub-build --skip-hub-tests --skip-trace-viewer-build --skip-trace-viewer-tests` — all 9 steps green. (Hub-client / trace-viewer skipped because no `npm install` has been run in this clone; their builds need `vitest` / `tsc` which is a bootstrap issue independent of this fix.)
+
+## Phase 5 — End-to-end CLI check
+
+- [x] `cargo run --bin pampa -- < claude-notes/issue-reports/196/repro.qmd` →
+  `[ OrderedList (4, Decimal, OneParen) [[Para [Str "Outer:"], Para [Image ( "" , ["border"] , [] ) [] ("img.png" , "")]]] ]` — exactly the pre-#194 shape the reporter cited.
+- [x] Same correct shape for `exp-tab-on-blank.qmd`, `exp-bullet-list.qmd` (yields `BulletList` instead), and `exp-trailing-ws-text.qmd`.
+- [x] All three real-world quarto-web files cited in issue #196 (diagrams.qmd, engine.qmd, netlify.qmd) parse cleanly end-to-end.
+- [x] All four `Q-2-35-*.qmd` case files still emit the friendly `[Q-2-35] Indented code blocks are not supported` diagnostic.
+
+## Phase 6 — Commit, sync, close
+
+- [ ] Commit the fix on `issue-196` (separate from the triage commit).
+- [ ] `br close bd-3mgb --reason "<one-line summary + commit hash>"` from main, sync, commit `.beads/issues.jsonl`.
+- [ ] Stop. Ask the user before pushing.
+
+## Out of scope
+
+- Improving the Q-2-35 friendly-error mapping table to cover additional `(state, sym)` pairs. The reporter noted this as a secondary observation, but once we stop emitting `INDENTED_CODE_BLOCK_DISALLOWED` in the regression case, the mapping question becomes moot for this input. If a separate audit of recovery-state mappings is warranted, it gets its own beads issue.
+- Refactoring or simplifying the broader scanner state machine. The 30 sites that touch `s->indentation` are evidence that this code is fragile, but a full audit is out of scope for a regression fix.

--- a/crates/tree-sitter-qmd/tree-sitter-markdown/src/scanner.c
+++ b/crates/tree-sitter-qmd/tree-sitter-markdown/src/scanner.c
@@ -2117,16 +2117,36 @@ static bool scan(Scanner *s, TSLexer *lexer, const bool *valid_symbols) {
     // the line terminator) — those are handled by the BLANK_LINE_START case
     // in the switch below.
     //
-    // The conservative gate (block-start only, not BLOCK_CONTINUATION) is
-    // deliberate. Lazy paragraph continuations and lazy list-item
-    // continuations have leading whitespace silently dropped today but
-    // preserve document structure, so they are not the structural bug from
-    // issue #184. Multi-line shortcodes also reach this scanner with
-    // BLOCK_CONTINUATION valid; firing on them would be a false positive.
-    // Same emission pattern as TRIPLE_STAR (Q-2-32); see grammar.js
-    // (`_indented_code_block_error`).
+    // Container-continuation guard (issue #196). The original gate (PR #194)
+    // fired whenever ATX_H1_MARKER or BLANK_LINE_START was valid, on the
+    // theory that those signals alone identified a true block-start
+    // position. That undershoots: inside an open list-item, the parser
+    // accepts a fresh block start *and* expects a continuation indent on
+    // the same scan call. If the whitespace loop above consumed what was
+    // actually the list-item continuation indent — for instance because
+    // STATE_MATCHING was not set on this call (preceding blank line carried
+    // trailing whitespace ≥ list_item_indentation, exercising a path that
+    // skips match_line) — `s->indentation >= 4` reflects the *continuation*
+    // indent, not extra indent layered on top of it.
+    //
+    // The reliable discriminator from a trace of the misfire vs. the
+    // intended Q-2-35 cases is `valid_symbols[BLOCK_CONTINUATION] &&
+    // s->open_blocks.size > 0`. With at least one open container *and*
+    // BLOCK_CONTINUATION valid, the parser still owes the line a
+    // continuation absorption — the indent has not yet been confirmed as
+    // "extra". Q-2-35 should defer in that case. When open_blocks is empty
+    // (genuine top-level indented block) or BLOCK_CONTINUATION is invalid
+    // (in-list indent has already been absorbed and the leftover is true
+    // extra indent), the gate still fires as intended.
+    //
+    // Lazy paragraph continuations and multi-line shortcodes are filtered
+    // out higher up by ATX_H1_MARKER / BLANK_LINE_START being invalid in
+    // their parser states. The new guard layers on top of that, not in
+    // place of it. Same emission pattern as TRIPLE_STAR (Q-2-32); see
+    // grammar.js (`_indented_code_block_error`).
     if (s->indentation >= 4 &&
         (valid_symbols[ATX_H1_MARKER] || valid_symbols[BLANK_LINE_START]) &&
+        !(valid_symbols[BLOCK_CONTINUATION] && s->open_blocks.size > 0) &&
         lexer->lookahead != '\n' && lexer->lookahead != '\r') {
         mark_end(s, lexer);
         EMIT_TOKEN(INDENTED_CODE_BLOCK_DISALLOWED);

--- a/crates/tree-sitter-qmd/tree-sitter-markdown/test/corpus/qmd.txt
+++ b/crates/tree-sitter-qmd/tree-sitter-markdown/test/corpus/qmd.txt
@@ -963,3 +963,66 @@ Hello.
           (pandoc_str)
           (pandoc_soft_break)
           (pandoc_str))))
+================================================================================
+Q-2-35 negative: list-item continuation after blank line with trailing 4 spaces (issue #196)
+================================================================================
+4)  Outer:
+    
+    ![](img.png){.border}
+--------------------------------------------------------------------------------
+    (document
+      (section
+        (pandoc_list
+          (list_item
+            (list_marker_parenthesis)
+            (pandoc_paragraph
+              (pandoc_str)
+              (pandoc_str)
+              (block_continuation))
+            (pandoc_paragraph
+              (pandoc_image
+                (target
+                  (url))
+                (attribute_specifier
+                  (commonmark_specifier
+                    (attribute_class)))))))))
+================================================================================
+Q-2-35 negative: bullet-list-item continuation after blank line with trailing 4 spaces (issue #196)
+================================================================================
+*   Outer:
+    
+    Second paragraph.
+--------------------------------------------------------------------------------
+    (document
+      (section
+        (pandoc_list
+          (list_item
+            (list_marker_star)
+            (pandoc_paragraph
+              (pandoc_str)
+              (pandoc_str)
+              (block_continuation))
+            (pandoc_paragraph
+              (pandoc_str)
+              (pandoc_space)
+              (pandoc_str))))))
+================================================================================
+Q-2-35 negative: list-item continuation after blank line with a tab (issue #196)
+================================================================================
+1)  Outer:
+	
+    Second paragraph.
+--------------------------------------------------------------------------------
+    (document
+      (section
+        (pandoc_list
+          (list_item
+            (list_marker_parenthesis)
+            (pandoc_paragraph
+              (pandoc_str)
+              (pandoc_str)
+              (block_continuation))
+            (pandoc_paragraph
+              (pandoc_str)
+              (pandoc_space)
+              (pandoc_str))))))


### PR DESCRIPTION
Closes #196.

PR #194's `INDENTED_CODE_BLOCK_DISALLOWED` external token mis-fired on list-item continuation lines whose preceding blank line carried ≥ 4 columns of trailing whitespace (4+ spaces or a tab), producing a generic "Parse error" where the pre-#194 behaviour produced an `OrderedList` AST with two `Para` children.

## Root cause

The intended block-start gate (`ATX_H1_MARKER || BLANK_LINE_START` valid) is true inside an open list item: the parser accepts a fresh block start, but it *also* still owes the line a container-continuation absorption. In that state, `s->indentation >= 4` reflects the *continuation* indent, not extra indent layered on top of it.

Trace data revealed a clean discriminator:

| Case                                       | indent | ATX | BLANK | CONT | open | should fire? |
| ------------------------------------------ | ------ | --- | ----- | ---- | ---- | ------------ |
| Q-2-35 top-level (`Before.\n\n    foo`)    | 4      | 1   | 0     | 1    | **0**| yes ✓        |
| Q-2-35 in-list 8-space indent              | 4      | 1   | 0     | **0**| 1    | yes ✓        |
| Misfire from #196                          | 4      | 1   | 0     | **1**| **1**| no ✗         |

The misfire is uniquely identified by `BLOCK_CONTINUATION valid` **AND** `open_blocks.size > 0`. Either flag alone overcounts. The fix adds that conjunction to the gate's negative side.

## Approach

One line in `scanner.c`'s `scan()` (around line 2128) plus an explanatory comment block. `parser.c` regenerated via `tree-sitter generate` is byte-identical (no externals signature change).

### Alternatives considered and why they lose

- **Reset `s->indentation = 0` at the top of `scan()`** — breaks `match()` for LIST_ITEM (lines 533–542), which expects the value to accumulate across its own internal whitespace loop. Blast radius is the entire grammar.
- **Track "did the whitespace loop consume bytes this call?"** — suppresses the recovery-state mid-line misfire but does NOT suppress the start-of-line misfire (where the loop *does* consume the 4 spaces because `match_line` was not entered — `STATE_MATCHING` was unset by the preceding blank-line path). Necessary but not sufficient.

## Test plan

- [x] Three new tree-sitter corpus cases under `Q-2-35 negative: list-item continuation ...` (ordered, bullet, tab variants). All three fail at HEAD before the fix; all three pass after.
- [x] `tree-sitter test` — 483/483 (was 480/480 + 3 new; no other regressions).
- [x] `cargo nextest run -p pampa` — 3686/3686.
- [x] `cargo nextest run --workspace` — 8863/8863.
- [x] `cargo xtask verify --skip-hub-build --skip-hub-tests --skip-trace-viewer-build --skip-trace-viewer-tests` — all 9 applicable steps green. (Hub-client / trace-viewer skipped because no `npm install` has been run in this clone; bootstrap issue independent of this fix.)
- [x] All four existing `Q-2-35-*.qmd` case files still emit `[Q-2-35] Indented code blocks are not supported`.
- [x] Reporter's `repro.qmd` end-to-end via `pampa`:
  ```
  [ OrderedList (4, Decimal, OneParen) [[Para [Str "Outer:"], Para [Image (...) [] ("img.png" , "")]]] ]
  ```
- [x] All three real-world `quarto-web` files cited in #196 (`diagrams.qmd`, `engine.qmd`, `netlify.qmd`) parse cleanly end-to-end.

## Files of interest

- Fix: `crates/tree-sitter-qmd/tree-sitter-markdown/src/scanner.c` (gate at line 2128)
- Tree-sitter regression: `crates/tree-sitter-qmd/tree-sitter-markdown/test/corpus/qmd.txt`
- Triage: `claude-notes/issue-reports/196/triage.md` + minimal repro and side-by-side fixtures
- Plan: `claude-notes/plans/2026-05-14-issue-196-list-continuation-regression.md`

## Snapshot test impact

No `.snap` files added or modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)