### PR TITLE
feat(pampa): better diagnostic for line breaks in inline link destinations

### DIFF
--- a/crates/pampa/resources/error-corpus/Q-2-37.json
+++ b/crates/pampa/resources/error-corpus/Q-2-37.json
@@ -1,0 +1,29 @@
+{
+  "code": "Q-2-37",
+  "title": "Line break in link destination",
+  "message": "An inline link destination cannot contain a line break.",
+  "notes": [],
+  "hints": [
+    "Remove the line break inside the link's `(...)` destination and keep the URL on a single line."
+  ],
+  "cases": [
+    {
+      "name": "after-scheme",
+      "description": "Newline immediately after the scheme `://` of an inline link destination.",
+      "content": "[text](https://\nexample.com/path)\n",
+      "captures": []
+    },
+    {
+      "name": "mid-destination",
+      "description": "Newline within the host portion of an inline link destination.",
+      "content": "[text](https://example.\ncom/path)\n",
+      "captures": []
+    },
+    {
+      "name": "before-close-paren",
+      "description": "Newline immediately before the closing `)` of an inline link destination.",
+      "content": "[text](https://example.com/path\n)\n",
+      "captures": []
+    }
+  ]
+}

--- a/crates/pampa/resources/error-corpus/_autogen-table.json
+++ b/crates/pampa/resources/error-corpus/_autogen-table.json
@@ -17763,6 +17763,57 @@
     "name": "Q-2-36/comma-and-kv"
   },
   {
+    "state": 2619,
+    "sym": "shortcode_name",
+    "row": 1,
+    "column": 0,
+    "errorInfo": {
+      "code": "Q-2-37",
+      "title": "Line break in link destination",
+      "message": "An inline link destination cannot contain a line break.",
+      "captures": [],
+      "notes": [],
+      "hints": [
+        "Remove the line break inside the link's `(...)` destination and keep the URL on a single line."
+      ]
+    },
+    "name": "Q-2-37/after-scheme"
+  },
+  {
+    "state": 2619,
+    "sym": "shortcode_name",
+    "row": 1,
+    "column": 0,
+    "errorInfo": {
+      "code": "Q-2-37",
+      "title": "Line break in link destination",
+      "message": "An inline link destination cannot contain a line break.",
+      "captures": [],
+      "notes": [],
+      "hints": [
+        "Remove the line break inside the link's `(...)` destination and keep the URL on a single line."
+      ]
+    },
+    "name": "Q-2-37/mid-destination"
+  },
+  {
+    "state": 2619,
+    "sym": "_close_block",
+    "row": 1,
+    "column": 0,
+    "errorInfo": {
+      "code": "Q-2-37",
+      "title": "Line break in link destination",
+      "message": "An inline link destination cannot contain a line break.",
+      "captures": [],
+      "notes": [],
+      "hints": [
+        "Remove the line break inside the link's `(...)` destination and keep the URL on a single line."
+      ]
+    },
+    "name": "Q-2-37/before-close-paren"
+  },
+  {
     "state": 1671,
     "sym": "_close_block",
     "row": 0,

--- a/crates/pampa/resources/error-corpus/case-files/Q-2-37-after-scheme.qmd
+++ b/crates/pampa/resources/error-corpus/case-files/Q-2-37-after-scheme.qmd
@@ -1,0 +1,2 @@
+[text](https://
+example.com/path)

--- a/crates/pampa/resources/error-corpus/case-files/Q-2-37-before-close-paren.qmd
+++ b/crates/pampa/resources/error-corpus/case-files/Q-2-37-before-close-paren.qmd
@@ -1,0 +1,2 @@
+[text](https://example.com/path
+)

--- a/crates/pampa/resources/error-corpus/case-files/Q-2-37-mid-destination.qmd
+++ b/crates/pampa/resources/error-corpus/case-files/Q-2-37-mid-destination.qmd
@@ -1,0 +1,2 @@
+[text](https://example.
+com/path)

--- a/crates/pampa/tests/test_link_destination_linebreak.rs
+++ b/crates/pampa/tests/test_link_destination_linebreak.rs
@@ -1,0 +1,80 @@
+use pampa::readers;
+
+fn render_diagnostics(input: &str, filename: &str) -> String {
+    let mut content = input.to_string();
+    if !content.ends_with('\n') {
+        content.push('\n');
+    }
+
+    let result = readers::qmd::read(
+        content.as_bytes(),
+        false,
+        filename,
+        &mut std::io::sink(),
+        true,
+        None,
+    );
+
+    let diagnostics = match result {
+        Ok(_) => panic!("Expected diagnostics for input:\n{content}"),
+        Err(d) => d,
+    };
+
+    let mut source_context = quarto_source_map::SourceContext::new();
+    source_context.add_file(filename.to_string(), Some(content));
+
+    let render_options = quarto_error_reporting::TextRenderOptions {
+        enable_hyperlinks: false,
+    };
+
+    let mut output = String::new();
+    for diagnostic in &diagnostics {
+        output.push_str(&diagnostic.to_text_with_options(Some(&source_context), &render_options));
+        output.push('\n');
+    }
+    output
+}
+
+#[test]
+fn line_break_after_scheme_emits_q_2_37() {
+    let input = "[text](https://\nexample.com/path)\n";
+    let output = render_diagnostics(input, "linebreak-after-scheme.qmd");
+
+    assert!(
+        output.contains("Q-2-37") || output.contains("Line break in link destination"),
+        "Diagnostic should identify line-break-in-link-destination case. Got:\n{output}"
+    );
+}
+
+#[test]
+fn line_break_mid_destination_emits_q_2_37() {
+    let input = "[text](https://example.\ncom/path)\n";
+    let output = render_diagnostics(input, "linebreak-mid-dest.qmd");
+
+    assert!(
+        output.contains("Q-2-37") || output.contains("Line break in link destination"),
+        "Diagnostic should identify line-break-in-link-destination case. Got:\n{output}"
+    );
+}
+
+#[test]
+fn line_break_before_close_paren_emits_q_2_37() {
+    let input = "[text](https://example.com/path\n)\n";
+    let output = render_diagnostics(input, "linebreak-before-close-paren.qmd");
+
+    assert!(
+        output.contains("Q-2-37") || output.contains("Line break in link destination"),
+        "Diagnostic should identify line-break-in-link-destination case. Got:\n{output}"
+    );
+}
+
+#[test]
+fn quarto_web_penguins_example_emits_q_2_37() {
+    let input = "A simple example based on Allison Horst's [Palmer Penguins](https://\nallisonhorst.github.io/palmerpenguins/) dataset. Here we look at how penguin body mass varies across both sex and species.\n";
+    let output = render_diagnostics(input, "penguins.qmd");
+
+    assert!(
+        output.contains("Q-2-37") || output.contains("Line break in link destination"),
+        "Diagnostic should identify line-break-in-link-destination case. Got:\n{output}"
+    );
+}


### PR DESCRIPTION
When an inline link destination contains a hard line break (e.g. `[text](https://\nhost/path)`), pampa rejected the input with a generic "unexpected character or token here" message. CommonMark forbids line breaks in inline link destinations, so the rejection is correct, but the message is unhelpful.

This adds a Q-2-37 corpus entry covering the (LR state, lookahead) pairs the parser hits when a newline appears inside a link destination (state 2619 with both `shortcode_name` and `_close_block` lookaheads). Pampa now emits a specific message naming the cause and a single hint.

Output:

```
  Error: [Q-2-37] Line break in link destination
     ╭─[ file.qmd:2:1 ]
     │
   2 │ allisonhorst.github.io/palmerpenguins/) dataset.
     │ ──────┬─────
     │       ╰─────── An inline link destination cannot contain a line break.
  ───╯
  ℹ Remove the line break inside the link's `(...)` destination and keep the URL on a single line.
```

A new regression test (`tests/test_link_destination_linebreak.rs`) covers the bug-report fixture plus three minimal variants (newline after the scheme, mid-destination, before the closing `)`). The existing `test_error_corpus_*` tests automatically exercise the three generated case files.


The error location seems not ideal but I was not able to fix that without subjecting the codebase to much more significant changes than seemed warranted so I will leave that up to you to address.