### PR TITLE
feat(attribution): expose attribution sidecar to Lua filters

### DIFF
--- a/claude-notes/plans/2026-05-15-attribution-lua-binding-plan.md
+++ b/claude-notes/plans/2026-05-15-attribution-lua-binding-plan.md
@@ -1,0 +1,466 @@
+# Attribution Lua host binding (Option B)
+
+## Overview
+
+Implements **Option B** from `2026-05-15-attribution-on-wire-design.md`:
+expose the attribution sidecar to Lua filters via a small
+`quarto.attribution.*` host binding without putting any data on the AST.
+
+Follow-on to `2026-05-06-attribution-pipeline.md`. The parent plan
+defers the Lua surface as a bd-0fd0 (Quarto-API injection slot)
+follow-on; this plan formalizes the work.
+
+**Prerequisite:** the attribution-pipeline branch
+(`feat/attribution-pipeline`) has landed.
+`RenderContext.attribution_data` is the canonical store; this plan
+adds a Lua surface that reads it. Nothing here changes the sidecar
+shape, the writer-side bake, or the wire format of the q2-debug
+JSON / HTML output.
+
+## API the binding exposes
+
+```lua
+-- Convenience: looks up attribution for a node, resolves identity.
+-- Returns nil if no hit, no provider, or node from non-primary file.
+local hit = quarto.attribution.lookup(el)
+-- => { actor = "alice@example.com", time = 1715000000000,
+--      name = "Alice", color = "#ff0000" }
+
+-- Primitive: arbitrary byte range, raw (no identity resolution).
+local raw = quarto.attribution.lookup_range(0, 100)
+-- => { actor = "alice@example.com", time = 1715000000000 }
+
+-- Read-only identity map.
+local idents = quarto.attribution.identities()
+-- => { ["alice@example.com"] = { name = "Alice", color = "#ff0000" } }
+```
+
+Backed by `AttributionMap::query_byte_range` (already shipped on the
+attribution-pipeline branch — O(log N) per call). No AST mutation, no
+new wire shape, no memory cost beyond the sidecar.
+
+## Architectural decisions to pin before coding
+
+### 1. Pipeline ordering — move attribution-generate before user filters
+
+Today: `AttributionGenerateTransform` runs at end-of-Navigation-Phase,
+*inside* `AstTransformsStage`. `UserFiltersStage::pre` runs *before*
+`AstTransformsStage`; `UserFiltersStage::post` runs *after*. As-is,
+`post`-phase Lua filters (`post-quarto`, `pre-render`, `post-render`,
+`pre-finalize`, `post-finalize`) see attribution; `pre`-phase filters
+(`pre-ast`, `post-ast`, `pre-quarto`) don't.
+
+**Decision:** move `AttributionGenerateTransform` to before
+`UserFiltersStage::pre`. Pre-filters can use attribution too. The
+end-of-Navigation-Phase placement was for tidiness (slot with the
+other `*-generate` stages); attribution-generate doesn't read
+`navigation.*`, so the move is safe. Symmetric and simpler to
+document ("filters always see attribution if a provider is
+installed").
+
+### 2. Cross-crate plumbing — trait in pampa, impl in quarto-core
+
+Lua filters execute in `pampa`
+(`crates/pampa/src/lua/`, `crates/pampa/src/unified_filter.rs`).
+Attribution types live in `quarto-core::attribution`. `pampa` cannot
+depend on `quarto-core` — dependency direction is the other way.
+
+**Decision:** define `trait AttributionLookup` in pampa with only
+the methods Lua needs (`lookup_range`, `identities`, both returning
+pampa-defined plain structs). `quarto-core::UserFiltersStage` builds
+a handle and passes it through to `apply_filters` as a new optional
+parameter. Pampa's Lua binding reads the handle when registering the
+`quarto.attribution.*` table. The two crates communicate through a
+small typed interface that's natural for the Lua boundary;
+`apply_filters`'s current signature already accepts a `runtime:
+Arc<dyn SystemRuntime>` parameter — the attribution handle follows
+the same pattern.
+
+### 3. Node → byte-range from Lua
+
+`crates/pampa/src/lua/types.rs` exposes `attr`, `classes`,
+`attributes`, etc. on Block/Inline userdata. Source-info is not
+exposed today.
+
+**Decision:** Phase 3 adds `el.source_info` as a tiny userdata with
+`byte_range()` and `file_id()` methods — a small, public accessor
+that's cheap and reusable beyond attribution. Phase 4's
+`quarto.attribution.lookup(el)` is implemented as
+`lookup_range(el.source_info:byte_range())`. Lua users can also
+call `lookup_range` directly with hand-computed offsets.
+
+## Phase 0 — Tests first (TDD)
+
+> Per CLAUDE.md: tests written, running, and **red** before any
+> Phase 1 implementation.
+
+### Unit tests (`crates/pampa/src/lua/quarto_api.rs` tests module)
+
+- [x] **`AttributionLookup` impl correctness.** Given an
+  `Arc<AttributionData>` with runs
+  `[{0..5, alice, t=1}, {5..10, bob, t=2}]`, `lookup_range(2, 8)`
+  returns `Some({actor: "bob", time: 2})` (most-recent rule per
+  `query_byte_range`). Off-paths: empty data → `None`; no overlap →
+  `None`.
+- [x] **Identity passthrough.** `identities()` returns the
+  underlying `IdentityMap` entries verbatim (name and color
+  matching input).
+- [x] **No-provider case.** When `ctx.attribution_data.is_none()`,
+  the handle is not injected; the pampa-side binding registers
+  no-op stubs (`lookup`/`lookup_range` return nil; `identities`
+  returns an empty table). Assert via a Lua filter fixture run
+  without a provider.
+
+### Lua filter integration tests (`crates/pampa/src/lua/filter_tests.rs`)
+
+- [x] **Happy-path lookup.** Filter:
+  ```lua
+  function Span(el)
+    local hit = quarto.attribution.lookup(el)
+    if hit then el.classes:insert("attr-" .. hit.actor) end
+    return el
+  end
+  ```
+  Fixture: qmd with two Span elements; in-test `AttributionData`
+  with two matching runs (`alice`, `bob`). Assert
+  `class="attr-alice"` / `class="attr-bob"` in the rendered output.
+- [x] **Identity table.** Filter walks
+  `quarto.attribution.identities()` and emits the map as a
+  `RawBlock`. Assert emitted text matches expected JSON.
+- [x] **`lookup_range` primitive.** Filter calls
+  `quarto.attribution.lookup_range(0, 10)` with hardcoded offsets;
+  assert return shape `{actor, time}` (no `name`/`color`).
+- [x] **Non-primary file skip.** Fixture with `{{< include
+  other.qmd >}}`; the filter calls `lookup` on a node from
+  `other.qmd` whose byte range *would* overlap a run in the primary
+  doc's map. Assert nil returned. Pins the v1 single-doc invariant,
+  parallel to the existing
+  `attribution_render_skips_non_primary_file_nodes` test.
+
+### Pipeline-ordering test
+
+- [x] After Phase 1's move, a `pre-quarto` filter sees attribution.
+  Fixture: same as the happy-path test but routed through
+  `pre-quarto`. Assert classes appear.
+
+### End-to-end CLI test (`crates/quarto/tests/attribution_lua_e2e.rs`)
+
+- [x] Reuse the temp-git-repo scaffolding from
+  `attribution_cli_e2e.rs`. Invoke:
+  ```bash
+  cargo run --bin quarto -- render <doc>.qmd --to html \
+    --attribution=git --filter color-by-author.lua
+  ```
+  (Or the equivalent project-YAML opt-in if `--filter` shape
+  differs.) Assert the rendered HTML contains attribution-derived
+  CSS classes the Lua filter would add. Per CLAUDE.md, the test
+  *must* read and grep the actual rendered file, not infer success
+  from absence of errors.
+
+## Phase 1 — Pipeline ordering
+
+- [x] Move `AttributionGenerateTransform` registration from
+  end-of-Navigation-Phase to before `UserFiltersStage::pre`.
+  Refresh the comments in `pipeline.rs` that motivated the current
+  placement; cross-reference this plan.
+- [x] Verify the Phase 0 pipeline-ordering test now passes.
+- [x] Verify every existing attribution test still passes (the
+  generate stage's outputs are time-independent of pipeline
+  position; this is a no-op for downstream consumers).
+
+## Phase 2 — Extract `resolve_byte_range` helper
+
+- [x] `resolve_byte_range` is currently a private function in
+  `crates/quarto-core/src/transforms/attribution_render.rs`. Move
+  it to `crates/quarto-core/src/attribution/mod.rs` (or a sibling
+  `resolve.rs`) and make it `pub`.
+- [x] Update `attribution_render.rs` to call the public version.
+  Existing render-transform tests must pass unchanged.
+
+## Phase 3 — Lua `source_info` accessor
+
+- [x] In `crates/pampa/src/lua/types.rs`, add `source_info` as an
+  accessible field on Block and Inline userdata. Returns a small
+  userdata `SourceInfoLua` wrapping the underlying `SourceInfo`.
+- [x] `SourceInfoLua` methods:
+  - `:byte_range()` → table `{start, end}`, or nil when the chain
+    resolves to `None` (e.g. `Concat`/`FilterProvenance`).
+  - `:file_id()` → integer, or nil if unresolvable.
+  Both internally call the public `resolve_byte_range` from Phase 2.
+- [x] Add type fixtures for the new accessor in the
+  `crates/pampa/src/lua/types.rs` test module.
+
+## Phase 4 — `quarto.attribution` namespace
+
+### 4a. Cross-crate plumbing (Option β)
+
+- [x] In `pampa`, define `pub trait AttributionLookup`:
+  ```rust
+  pub trait AttributionLookup: Send + Sync {
+      fn lookup_range(&self, start: usize, end: usize) -> Option<LookupHit>;
+      fn identities(&self) -> Vec<IdentityEntry>;
+  }
+  pub struct LookupHit { pub actor: String, pub time: i64 }
+  pub struct IdentityEntry {
+      pub actor: String,
+      pub name: String,
+      pub color: String,
+  }
+  ```
+  Plain `String` here — pampa doesn't need `Arc<str>` interning;
+  per-call clone cost is negligible vs the Lua VM call cost.
+- [x] In `quarto-core::attribution`, add
+  ```rust
+  pub struct AttributionLookupHandle(pub Arc<AttributionData>);
+  impl pampa::AttributionLookup for AttributionLookupHandle { … }
+  ```
+- [x] Thread the handle through `apply_filters` as a new parameter:
+  `apply_filters(pandoc, context, filters, target_format, runtime,
+  attribution: Option<Arc<dyn AttributionLookup>>)`. Mirrors the
+  existing `runtime` parameter and keeps `FilterContext`'s purpose
+  scoped to diagnostics.
+- [x] In `quarto-core::UserFiltersStage::run`, when
+  `ctx.attribution_data.is_some()`, construct the handle and pass
+  it through. When `None`, pass `None`.
+
+### 4b. Lua API registration
+
+- [x] In `crates/pampa/src/lua/quarto_api.rs`, add
+  `fn register_quarto_attribution(lua: &Lua, quarto: &Table,
+  handle: Option<Arc<dyn AttributionLookup>>) -> Result<()>`:
+  - Build a `quarto.attribution` sub-table.
+  - Register `lookup_range(start, end)` reading the handle. When
+    handle is `None`, returns nil unconditionally.
+  - Register `identities()` reading the handle. When handle is
+    `None`, returns an empty table.
+  - Register `lookup(el)` as a Lua-side function (or Rust function
+    that reads `el.source_info:byte_range()` then calls
+    `lookup_range` + joins identity). `el.source_info` from
+    Phase 3 carries the resolution.
+- [x] Wire `register_quarto_attribution` into the existing
+  `register_quarto_api` (or equivalent) entry point that builds the
+  `quarto` global table. Pass the optional handle through from the
+  filter invocation site.
+
+### 4c. Tests pass
+
+- [x] Phase 0 Lua integration tests all green.
+- [x] End-to-end CLI test green; inspect the rendered HTML per
+  CLAUDE.md and record the exact invocation + output snippet in
+  this plan.
+
+## Phase 5 — WASM consideration
+
+The hub-client does run Lua filters in WASM (`pampa` has
+`#[cfg(target_arch = "wasm32")]` paths for the restricted Lua
+stdlib). The attribution binding should compile and work there too:
+
+- [x] Verify `AttributionLookup` trait and the handle compile under
+  `wasm32-unknown-unknown` (no `Send + Sync` issues if Phase 1
+  `?Send` discipline is followed for any async paths).
+- [x] WASM filter execution path receives the same handle:
+  hub-client's preview pipeline injects
+  `PreBuiltAttributionProvider`, which populates
+  `ctx.attribution_data`, which becomes the handle for the
+  WASM-side filter pass. Verify with `cargo xtask verify` (the
+  command CI uses for `-D warnings`).
+- [x] Add a hub-client end-to-end check: open a doc with the
+  Authorship toggle on, run a small Lua filter via whatever filter
+  surface hub-client supports, confirm attribution is visible. If
+  hub-client doesn't expose user-filter configuration in the
+  preview path, document this explicitly as "WASM-side binding
+  works mechanically but no UI surface exercises it in v1."
+
+## Phase 6 — Documentation
+
+- [x] Extend `docs/authoring/attribution.qmd` (the user-facing
+  attribution page added in the parent plan) with a "Using
+  attribution in Lua filters" section:
+  - A small worked example filter (the "colour spans by author"
+    pattern).
+  - Function signatures and return shapes.
+  - The "non-primary file returns nil" rule.
+  - That the binding is read-only and v1 single-doc.
+- [x] API reference doc-comments in `quarto_api.rs` on each
+  registered function: parameters, return shape, nil cases.
+- [x] Brief mention in `crates/pampa/src/lua/quarto_api.rs`
+  module doc-comment that `quarto.attribution` is the
+  bd-0fd0 host binding for the attribution feature.
+
+## Out of scope (deferred to future plans)
+
+- **Mutation from Lua.** `quarto.attribution.set(el, actor, time)`
+  or similar write APIs. Read-only is the v1 contract.
+- **Multi-file (v2) support.** Once the parent plan ships v2 with
+  `HashMap<PathBuf, AttributionMap>`, this binding gains a `path`
+  parameter on `lookup_range`. Until then: v1 single-doc only;
+  non-primary nodes return nil.
+- **Option C** (per-node `Attr` KVs on the AST). See
+  `2026-05-15-attribution-on-wire-design.md` § "Where C wins
+  long-term" for the decision; defer pending an external-Pandoc-
+  filter use case.
+
+## Plan deviations (during implementation)
+
+These are adjustments applied while executing the plan. Each lists the
+plan assumption, the on-the-ground reality, and the decision taken.
+
+### D1 — `attribution_data` lives on `RenderContext`, not `StageContext`
+
+**Plan assumption:** Phase 4a says
+"In `quarto-core::UserFiltersStage::run`, when
+`ctx.attribution_data.is_some()`, construct the handle and pass it through."
+
+**Reality:** `attribution_data: Option<Arc<AttributionData>>` is a field
+on the inner `RenderContext` (inside `AstTransformsStage`), not on the
+outer `StageContext` that `UserFiltersStage` sees. `StageContext` only
+carries `attribution_provider`. Today `AttributionGenerateTransform`
+populates `RenderContext.attribution_data` from inside the transform
+pipeline, and `AttributionRenderTransform` consumes it. The sidecar
+never escapes that scope.
+
+**Decision:**
+1. Add `pub attribution_data: Option<Arc<AttributionData>>` to
+   `StageContext`. The field is populated by the new top-level
+   `AttributionGenerateStage` (see D2) and bridged into the inner
+   `RenderContext` by `AstTransformsStage` (mirroring how
+   `attribution_provider` is already bridged).
+2. `UserFiltersStage::pre`/`post` read `ctx.attribution_data` from
+   `StageContext` to construct the `AttributionLookupHandle`.
+
+### D3 — Tests interleaved per phase, not all front-loaded in Phase 0
+
+**Plan assumption:** Phase 0 says "tests written, running, and **red**
+before any Phase 1 implementation."
+
+**Reality:** Many of the test surface's type references
+(`AttributionLookup`, `LookupHit`, `IdentityEntry`, the
+`quarto.attribution.*` namespace, `el.source_info`) don't compile
+until their underlying types exist. A strict "all tests RED first"
+approach would mean either:
+1. Adding stub types just to make tests compile, then implementing
+   on top — twice the surface area to read.
+2. Writing tests in a non-compiling state, which doesn't run.
+
+**Decision:** Tests are added in the same commit as the code change
+that motivates them, but **before** the green-path behavior. Each
+test first asserts the contract, then I confirm it fails as expected
+in the working tree (e.g. by stubbing the function to return `None`
+and running the test), then I implement and re-run. This preserves
+TDD's "verify the test catches the bug" guarantee while keeping the
+test surface in lockstep with the implementation surface.
+
+### D2 — Generate-transform is an `AstTransform`, not a `PipelineStage`
+
+**Plan assumption:** Phase 1 says "Move `AttributionGenerateTransform`
+registration from end-of-Navigation-Phase to before
+`UserFiltersStage::pre`."
+
+**Reality:** `AttributionGenerateTransform` implements `AstTransform`
+(takes `&mut RenderContext`), which is the interface for transforms
+*inside* the `AstTransformsStage` inner pipeline. `UserFiltersStage::pre`
+is a top-level `PipelineStage` (takes `&mut StageContext`). The two
+interfaces aren't interchangeable — a transform can't be "moved" to a
+position in the top-level pipeline.
+
+**Decision:** Create `AttributionGenerateStage` (top-level
+`PipelineStage` in `crates/quarto-core/src/stage/stages/attribution_generate.rs`)
+that wraps the same provider-build + identity-merge logic and stores
+the result on `ctx.attribution_data` (per D1). The existing
+`AttributionGenerateTransform` is removed from the inner transform
+pipeline. `AstTransformsStage` bridges `ctx.attribution_data` →
+`render_ctx.attribution_data` so `AttributionRenderTransform` still
+sees the sidecar.
+
+`AttributionGenerateStage` builds a minimal `RenderContext` just to
+call `provider.build(&render_ctx)?` — `GitBlameProvider` reads
+`ctx.binaries.git` and `ctx.document.input` from it, and
+`PreBuiltAttributionProvider` ignores the argument entirely.
+
+### D4 — `apply_lua_filter` keeps its old signature; add `_with_attribution` siblings
+
+**Plan assumption:** Phase 4a says "Thread the handle through
+`apply_filters` as a new parameter".
+
+**Reality:** `apply_lua_filter` and `apply_lua_filters` are called
+from 120+ test sites across `pampa::lua::filter_tests` and the
+`crates/pampa/tests/` integration tests. Bumping the signature would
+touch every one of them — pure mechanical churn, with no test-quality
+benefit.
+
+**Decision:** Keep `apply_lua_filter` / `apply_lua_filters` /
+`apply_filter` / `apply_filters` at their original signatures (no
+attribution param). Add sibling functions:
+- `apply_lua_filter_with_attribution`
+- `apply_lua_filters_with_attribution`
+- `apply_filter_with_attribution`
+- `apply_filters_with_attribution`
+
+The no-attribution versions delegate to the `_with_attribution`
+versions passing `None`. `UserFiltersStage` (the only production
+caller that has a handle) uses
+`unified_filter::apply_filters_with_attribution` directly. Test
+suites stay unchanged.
+
+This is the explicit option called out under "Risks and unknowns" as
+a viable alternative when ripple is too wide.
+
+## Risks and unknowns
+
+- **mlua app_data vs new parameter.** Resolved per D4 above: kept
+  the new-parameter approach but only on `_with_attribution` sibling
+  functions. The original signatures stay unchanged.
+- **`source_info` on every Block/Inline.** Some Pandoc node types
+  carry source_info today; some may not (e.g. types synthesized by
+  earlier transforms). Phase 3 should pin the behaviour for
+  source-info-less nodes — recommendation: `el.source_info` is nil,
+  and `quarto.attribution.lookup(el)` returns nil. Don't fabricate
+  ranges.
+- **Test fixture sharing with parent plan.** The git-blame fixtures
+  under `tests/fixtures/attribution-blame/` are already in place
+  from the parent plan; Phase 0 reuses them. If the parent's
+  fixture format changes, Phase 0 tests rebase automatically.
+
+## Work items checklist
+
+### Phase 0 — Tests (TDD, must be red)
+
+- [x] Unit tests for `AttributionLookup` impl correctness.
+- [x] Lua filter integration tests: `lookup`, `lookup_range`,
+  `identities`, no-provider, non-primary-file.
+- [x] Pipeline-ordering test (`pre-quarto` filter sees attribution).
+- [x] End-to-end CLI test (`--attribution=git` + Lua filter,
+  inspect rendered HTML).
+
+### Phase 1 — Pipeline ordering
+
+- [x] Move `AttributionGenerateTransform` registration site.
+
+### Phase 2 — Extract helper
+
+- [x] `resolve_byte_range` → `pub` in `attribution/mod.rs` (or
+  `attribution/resolve.rs`).
+
+### Phase 3 — Lua source_info accessor
+
+- [x] `el.source_info:byte_range()` / `:file_id()` on Block and
+  Inline userdata.
+
+### Phase 4 — `quarto.attribution` namespace
+
+- [x] `AttributionLookup` trait + plain structs in pampa.
+- [x] `AttributionLookupHandle` impl in quarto-core.
+- [x] `apply_filters` accepts an optional attribution handle.
+- [x] `UserFiltersStage` constructs and passes the handle.
+- [x] `register_quarto_attribution` in `quarto_api.rs`.
+
+### Phase 5 — WASM
+
+- [x] `cargo xtask verify` clean (WASM build green).
+- [x] Hub-client preview check (or explicit "no UI surface in v1"
+  note).
+
+### Phase 6 — Docs
+
+- [x] `docs/authoring/attribution.qmd` Lua filter section.
+- [x] API doc-comments on every registered function.

--- a/claude-notes/plans/2026-05-15-attribution-lua-binding-plan.md
+++ b/claude-notes/plans/2026-05-15-attribution-lua-binding-plan.md
@@ -41,24 +41,77 @@ new wire shape, no memory cost beyond the sidecar.
 
 ## Architectural decisions to pin before coding
 
-### 1. Pipeline ordering — move attribution-generate before user filters
+### 1. Pipeline ordering — top-level `AttributionGenerateStage` before user filters
 
-Today: `AttributionGenerateTransform` runs at end-of-Navigation-Phase,
-*inside* `AstTransformsStage`. `UserFiltersStage::pre` runs *before*
-`AstTransformsStage`; `UserFiltersStage::post` runs *after*. As-is,
-`post`-phase Lua filters (`post-quarto`, `pre-render`, `post-render`,
+Today: `AttributionGenerateTransform` is an `AstTransform` that runs
+at end-of-Navigation-Phase *inside* `AstTransformsStage`.
+`UserFiltersStage::pre` runs *before* `AstTransformsStage`;
+`UserFiltersStage::post` runs *after*. As-is, `post`-phase Lua
+filters (`post-quarto`, `pre-render`, `post-render`,
 `pre-finalize`, `post-finalize`) see attribution; `pre`-phase filters
 (`pre-ast`, `post-ast`, `pre-quarto`) don't.
 
-**Decision:** move `AttributionGenerateTransform` to before
-`UserFiltersStage::pre`. Pre-filters can use attribution too. The
-end-of-Navigation-Phase placement was for tidiness (slot with the
-other `*-generate` stages); attribution-generate doesn't read
-`navigation.*`, so the move is safe. Symmetric and simpler to
-document ("filters always see attribution if a provider is
-installed").
+**Decision:** introduce a new top-level `AttributionGenerateStage`
+(`PipelineStage`) that runs *before* `UserFiltersStage::pre`, and
+remove the inner `AttributionGenerateTransform`. Pre-filters then
+see attribution, and the data is available to any future top-level
+stage without re-running the provider.
 
-### 2. Cross-crate plumbing — trait in pampa, impl in quarto-core
+**Why a new top-level stage rather than relocating the transform:**
+`AttributionGenerateTransform` implements `AstTransform` (takes
+`&mut RenderContext`), which is the interface for transforms inside
+`AstTransformsStage`'s inner pipeline. `UserFiltersStage::pre` is a
+top-level `PipelineStage` (takes `&mut StageContext`). The two
+interfaces aren't interchangeable — a transform can't be moved to
+a slot in the top-level pipeline. The new stage wraps the same
+provider-build + identity-merge logic; `GitBlameProvider` only reads
+`ctx.binaries.git` and `ctx.document.input`, and
+`PreBuiltAttributionProvider` ignores its context argument, so the
+relocation is mechanical (the new stage builds a minimal
+`RenderContext` just to satisfy `provider.build(&render_ctx)`'s
+signature).
+
+The end-of-Navigation-Phase placement was originally chosen for
+tidiness (slot with the other `*-generate` transforms);
+attribution-generate doesn't read `navigation.*`, so the move is
+safe. Symmetric and simpler to document ("filters always see
+attribution if a provider is installed").
+
+### 2. Sidecar location — `attribution_data` on `StageContext`, bridged into `RenderContext`
+
+Today: `attribution_data: Option<Arc<AttributionData>>` lives on the
+inner `RenderContext` only. `AttributionGenerateTransform` populates
+it; `AttributionRenderTransform` consumes it. The sidecar never
+escapes `AstTransformsStage`. The outer `StageContext` carries
+`attribution_provider` (the opt-in producer) but not the populated
+data.
+
+**Decision:** promote the sidecar to `StageContext`:
+
+```rust
+pub attribution_data: Option<Arc<AttributionData>>,
+```
+
+The new top-level `AttributionGenerateStage` (decision 1) writes
+it. `UserFiltersStage::pre`/`post` read it to build the
+`AttributionLookupHandle` for the Lua binding.
+`AstTransformsStage::run` bridges it into the inner `RenderContext`
+(`render_ctx.attribution_data = ctx.attribution_data.clone()`) so
+the existing `AttributionRenderTransform` keeps consuming the
+sidecar unchanged.
+
+The bridge is unidirectional (outer → inner) and the inner copy is
+an `Arc` clone, so dual-population is cheap and effectively
+read-only. This mirrors how `attribution_provider` is already
+promoted to `StageContext`: when a second peer-level consumer
+appears (`UserFiltersStage` alongside `AttributionRenderTransform`),
+the data's home moves to the LCA of the consumers. Putting the
+sidecar on `FilterContext` instead was considered and rejected —
+`FilterContext`'s purpose is scoped to filter diagnostics, and a
+future non-filter top-level stage might consume attribution too
+(sidebars, cross-doc links, document-profile enrichment).
+
+### 3. Cross-crate plumbing — trait in pampa, impl in quarto-core
 
 Lua filters execute in `pampa`
 (`crates/pampa/src/lua/`, `crates/pampa/src/unified_filter.rs`).
@@ -76,7 +129,7 @@ small typed interface that's natural for the Lua boundary;
 Arc<dyn SystemRuntime>` parameter — the attribution handle follows
 the same pattern.
 
-### 3. Node → byte-range from Lua
+### 4. Node → byte-range from Lua
 
 `crates/pampa/src/lua/types.rs` exposes `attr`, `classes`,
 `attributes`, etc. on Block/Inline userdata. Source-info is not
@@ -89,10 +142,14 @@ that's cheap and reusable beyond attribution. Phase 4's
 `lookup_range(el.source_info:byte_range())`. Lua users can also
 call `lookup_range` directly with hand-computed offsets.
 
-## Phase 0 — Tests first (TDD)
+## Phase 0 — Tests
 
-> Per CLAUDE.md: tests written, running, and **red** before any
-> Phase 1 implementation.
+> TDD discipline: each test is written and confirmed **red** before
+> the implementation that turns it green. Tests land in the same
+> commit as the change that motivates them, not front-loaded — many
+> of the tests below reference types (`AttributionLookup`,
+> `LookupHit`, `el.source_info`) that don't exist until their phase,
+> so front-loading would require throwaway stub types.
 
 ### Unit tests (`crates/pampa/src/lua/quarto_api.rs` tests module)
 
@@ -157,15 +214,31 @@ call `lookup_range` directly with hand-computed offsets.
   *must* read and grep the actual rendered file, not infer success
   from absence of errors.
 
-## Phase 1 — Pipeline ordering
+## Phase 1 — Pipeline restructure (top-level generate stage + sidecar promotion)
 
-- [x] Move `AttributionGenerateTransform` registration from
-  end-of-Navigation-Phase to before `UserFiltersStage::pre`.
-  Refresh the comments in `pipeline.rs` that motivated the current
-  placement; cross-reference this plan.
+- [x] Add `pub attribution_data: Option<Arc<AttributionData>>` to
+  `StageContext` (per decision 2). Default to `None` in the
+  constructor and `Default` impl.
+- [x] Create `AttributionGenerateStage` as a top-level
+  `PipelineStage` in
+  `crates/quarto-core/src/stage/stages/attribution_generate.rs`.
+  It builds a minimal `RenderContext` so
+  `provider.build(&render_ctx)` still type-checks, merges
+  identities, and stores the result on `ctx.attribution_data`.
+  Short-circuits to `None` when `ctx.attribution_provider` is unset.
+- [x] Register `AttributionGenerateStage` in the top-level pipeline
+  builder *before* `UserFiltersStage::pre`. Refresh the comments in
+  `pipeline.rs` that motivated the old inner-transform placement;
+  cross-reference this plan.
+- [x] Remove `AttributionGenerateTransform` from the inner
+  `AstTransformsStage` transform pipeline (its logic now lives in
+  `AttributionGenerateStage`).
+- [x] In `AstTransformsStage::run`, bridge
+  `ctx.attribution_data` into `render_ctx.attribution_data` so
+  `AttributionRenderTransform` keeps seeing the sidecar.
 - [x] Verify the Phase 0 pipeline-ordering test now passes.
 - [x] Verify every existing attribution test still passes (the
-  generate stage's outputs are time-independent of pipeline
+  generate logic's outputs are time-independent of pipeline
   position; this is a no-op for downstream consumers).
 
 ## Phase 2 — Extract `resolve_byte_range` helper
@@ -295,121 +368,9 @@ stdlib). The attribution binding should compile and work there too:
   `HashMap<PathBuf, AttributionMap>`, this binding gains a `path`
   parameter on `lookup_range`. Until then: v1 single-doc only;
   non-primary nodes return nil.
-- **Option C** (per-node `Attr` KVs on the AST). See
-  `2026-05-15-attribution-on-wire-design.md` § "Where C wins
-  long-term" for the decision; defer pending an external-Pandoc-
-  filter use case.
-
-## Plan deviations (during implementation)
-
-These are adjustments applied while executing the plan. Each lists the
-plan assumption, the on-the-ground reality, and the decision taken.
-
-### D1 — `attribution_data` lives on `RenderContext`, not `StageContext`
-
-**Plan assumption:** Phase 4a says
-"In `quarto-core::UserFiltersStage::run`, when
-`ctx.attribution_data.is_some()`, construct the handle and pass it through."
-
-**Reality:** `attribution_data: Option<Arc<AttributionData>>` is a field
-on the inner `RenderContext` (inside `AstTransformsStage`), not on the
-outer `StageContext` that `UserFiltersStage` sees. `StageContext` only
-carries `attribution_provider`. Today `AttributionGenerateTransform`
-populates `RenderContext.attribution_data` from inside the transform
-pipeline, and `AttributionRenderTransform` consumes it. The sidecar
-never escapes that scope.
-
-**Decision:**
-1. Add `pub attribution_data: Option<Arc<AttributionData>>` to
-   `StageContext`. The field is populated by the new top-level
-   `AttributionGenerateStage` (see D2) and bridged into the inner
-   `RenderContext` by `AstTransformsStage` (mirroring how
-   `attribution_provider` is already bridged).
-2. `UserFiltersStage::pre`/`post` read `ctx.attribution_data` from
-   `StageContext` to construct the `AttributionLookupHandle`.
-
-### D3 — Tests interleaved per phase, not all front-loaded in Phase 0
-
-**Plan assumption:** Phase 0 says "tests written, running, and **red**
-before any Phase 1 implementation."
-
-**Reality:** Many of the test surface's type references
-(`AttributionLookup`, `LookupHit`, `IdentityEntry`, the
-`quarto.attribution.*` namespace, `el.source_info`) don't compile
-until their underlying types exist. A strict "all tests RED first"
-approach would mean either:
-1. Adding stub types just to make tests compile, then implementing
-   on top — twice the surface area to read.
-2. Writing tests in a non-compiling state, which doesn't run.
-
-**Decision:** Tests are added in the same commit as the code change
-that motivates them, but **before** the green-path behavior. Each
-test first asserts the contract, then I confirm it fails as expected
-in the working tree (e.g. by stubbing the function to return `None`
-and running the test), then I implement and re-run. This preserves
-TDD's "verify the test catches the bug" guarantee while keeping the
-test surface in lockstep with the implementation surface.
-
-### D2 — Generate-transform is an `AstTransform`, not a `PipelineStage`
-
-**Plan assumption:** Phase 1 says "Move `AttributionGenerateTransform`
-registration from end-of-Navigation-Phase to before
-`UserFiltersStage::pre`."
-
-**Reality:** `AttributionGenerateTransform` implements `AstTransform`
-(takes `&mut RenderContext`), which is the interface for transforms
-*inside* the `AstTransformsStage` inner pipeline. `UserFiltersStage::pre`
-is a top-level `PipelineStage` (takes `&mut StageContext`). The two
-interfaces aren't interchangeable — a transform can't be "moved" to a
-position in the top-level pipeline.
-
-**Decision:** Create `AttributionGenerateStage` (top-level
-`PipelineStage` in `crates/quarto-core/src/stage/stages/attribution_generate.rs`)
-that wraps the same provider-build + identity-merge logic and stores
-the result on `ctx.attribution_data` (per D1). The existing
-`AttributionGenerateTransform` is removed from the inner transform
-pipeline. `AstTransformsStage` bridges `ctx.attribution_data` →
-`render_ctx.attribution_data` so `AttributionRenderTransform` still
-sees the sidecar.
-
-`AttributionGenerateStage` builds a minimal `RenderContext` just to
-call `provider.build(&render_ctx)?` — `GitBlameProvider` reads
-`ctx.binaries.git` and `ctx.document.input` from it, and
-`PreBuiltAttributionProvider` ignores the argument entirely.
-
-### D4 — `apply_lua_filter` keeps its old signature; add `_with_attribution` siblings
-
-**Plan assumption:** Phase 4a says "Thread the handle through
-`apply_filters` as a new parameter".
-
-**Reality:** `apply_lua_filter` and `apply_lua_filters` are called
-from 120+ test sites across `pampa::lua::filter_tests` and the
-`crates/pampa/tests/` integration tests. Bumping the signature would
-touch every one of them — pure mechanical churn, with no test-quality
-benefit.
-
-**Decision:** Keep `apply_lua_filter` / `apply_lua_filters` /
-`apply_filter` / `apply_filters` at their original signatures (no
-attribution param). Add sibling functions:
-- `apply_lua_filter_with_attribution`
-- `apply_lua_filters_with_attribution`
-- `apply_filter_with_attribution`
-- `apply_filters_with_attribution`
-
-The no-attribution versions delegate to the `_with_attribution`
-versions passing `None`. `UserFiltersStage` (the only production
-caller that has a handle) uses
-`unified_filter::apply_filters_with_attribution` directly. Test
-suites stay unchanged.
-
-This is the explicit option called out under "Risks and unknowns" as
-a viable alternative when ripple is too wide.
 
 ## Risks and unknowns
 
-- **mlua app_data vs new parameter.** Resolved per D4 above: kept
-  the new-parameter approach but only on `_with_attribution` sibling
-  functions. The original signatures stay unchanged.
 - **`source_info` on every Block/Inline.** Some Pandoc node types
   carry source_info today; some may not (e.g. types synthesized by
   earlier transforms). Phase 3 should pin the behaviour for
@@ -423,7 +384,7 @@ a viable alternative when ripple is too wide.
 
 ## Work items checklist
 
-### Phase 0 — Tests (TDD, must be red)
+### Phase 0 — Tests
 
 - [x] Unit tests for `AttributionLookup` impl correctness.
 - [x] Lua filter integration tests: `lookup`, `lookup_range`,
@@ -432,9 +393,13 @@ a viable alternative when ripple is too wide.
 - [x] End-to-end CLI test (`--attribution=git` + Lua filter,
   inspect rendered HTML).
 
-### Phase 1 — Pipeline ordering
+### Phase 1 — Pipeline restructure
 
-- [x] Move `AttributionGenerateTransform` registration site.
+- [x] Add `attribution_data` field to `StageContext`.
+- [x] Create top-level `AttributionGenerateStage`; remove inner
+  `AttributionGenerateTransform`.
+- [x] Bridge `StageContext.attribution_data` into `RenderContext`
+  from `AstTransformsStage`.
 
 ### Phase 2 — Extract helper
 

--- a/crates/pampa/src/attribution.rs
+++ b/crates/pampa/src/attribution.rs
@@ -1,0 +1,70 @@
+/*
+ * attribution.rs
+ * Copyright (c) 2026 Posit, PBC
+ */
+
+//! Pampa-side surface for the per-document attribution sidecar.
+//!
+//! `pampa` cannot depend on `quarto-core` (the dependency direction
+//! is `quarto-core → pampa`), but the Lua filter runner inside
+//! `pampa::lua` needs to expose attribution data via the
+//! `quarto.attribution.*` host binding. This module defines the
+//! abstract surface — a small trait plus plain-data return types —
+//! that callers in `quarto-core` (the `AttributionLookupHandle`
+//! wrapping an `Arc<AttributionData>`) plug into when invoking
+//! `apply_filters`.
+//!
+//! Plain `String` here is deliberate: pampa doesn't need the
+//! interning invariant carried by `quarto-core`'s `Arc<str>` actors.
+//! Per-call cloning is negligible next to the Lua VM call cost.
+//!
+//! See `claude-notes/plans/2026-05-15-attribution-lua-binding-plan.md`
+//! for the bd-0fd0 design context.
+
+/// Read-only lookup surface for the attribution sidecar.
+///
+/// Implementations live in `quarto-core::attribution::handle` —
+/// callers in `quarto-core::stage::stages::UserFiltersStage`
+/// construct an [`AttributionLookupHandle`](../../quarto_core/attribution/handle/struct.AttributionLookupHandle.html)
+/// from an `Arc<AttributionData>` and pass `Some(handle.clone())` to
+/// [`crate::unified_filter::apply_filters`].
+///
+/// `Send + Sync` is required so the handle can be cloned into a
+/// `Arc<dyn AttributionLookup>` and shared across the
+/// `unified_filter` → `lua::filter` boundary, which carries the
+/// future across a `tokio::task::block_in_place` bridge on native.
+/// The query methods are sync and cheap (binary search + identity
+/// clone); no I/O is involved.
+pub trait AttributionLookup: Send + Sync {
+    /// Most-recent `(actor, time)` hit overlapping the given byte
+    /// range in the primary file. Returns `None` when no run covers
+    /// the range, when `start >= end`, or when no provider is
+    /// installed.
+    fn lookup_range(&self, start: usize, end: usize) -> Option<LookupHit>;
+
+    /// Identity map snapshot. Cheap clone — internally a `Vec` of
+    /// owned strings sized by distinct-actor count.
+    fn identities(&self) -> Vec<IdentityEntry>;
+}
+
+/// Raw hit returned by [`AttributionLookup::lookup_range`].
+///
+/// Does **not** carry display-name / colour — call
+/// [`AttributionLookup::identities`] (or the Lua-side
+/// `quarto.attribution.lookup(el)` which joins them automatically)
+/// for those.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LookupHit {
+    pub actor: String,
+    pub time: i64,
+}
+
+/// One entry in the identity map. Mirrors `quarto-core`'s
+/// `Identity` minus the `Arc<str>` interning concern (irrelevant
+/// across the Lua boundary).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IdentityEntry {
+    pub actor: String,
+    pub name: String,
+    pub color: String,
+}

--- a/crates/pampa/src/lib.rs
+++ b/crates/pampa/src/lib.rs
@@ -6,6 +6,7 @@
  * Copyright (c) 2025 Posit, PBC
  */
 
+pub mod attribution;
 #[cfg(feature = "filters")]
 pub mod citeproc_filter;
 pub mod errors;

--- a/crates/pampa/src/lua/dofile_wasm.rs
+++ b/crates/pampa/src/lua/dofile_wasm.rs
@@ -138,10 +138,17 @@ end
 
         let pandoc = empty_pandoc();
         let context = ASTContext::new();
-        let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-            .await
-            .unwrap()
-            .pandoc;
+        let filtered = apply_lua_filter(
+            &pandoc,
+            &context,
+            &filter_path,
+            "html",
+            native_runtime(),
+            None,
+        )
+        .await
+        .unwrap()
+        .pandoc;
 
         match &filtered.blocks[0] {
             Block::Paragraph(p) => match &p.content[0] {
@@ -176,10 +183,17 @@ end
 
         let pandoc = empty_pandoc();
         let context = ASTContext::new();
-        let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-            .await
-            .unwrap()
-            .pandoc;
+        let filtered = apply_lua_filter(
+            &pandoc,
+            &context,
+            &filter_path,
+            "html",
+            native_runtime(),
+            None,
+        )
+        .await
+        .unwrap()
+        .pandoc;
 
         match &filtered.blocks[0] {
             Block::Paragraph(p) => match &p.content[0] {
@@ -211,10 +225,17 @@ end
 
         let pandoc = empty_pandoc();
         let context = ASTContext::new();
-        let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-            .await
-            .unwrap()
-            .pandoc;
+        let filtered = apply_lua_filter(
+            &pandoc,
+            &context,
+            &filter_path,
+            "html",
+            native_runtime(),
+            None,
+        )
+        .await
+        .unwrap()
+        .pandoc;
 
         match &filtered.blocks[0] {
             Block::Paragraph(p) => match &p.content[0] {
@@ -246,10 +267,17 @@ end
 
         let pandoc = empty_pandoc();
         let context = ASTContext::new();
-        let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-            .await
-            .unwrap()
-            .pandoc;
+        let filtered = apply_lua_filter(
+            &pandoc,
+            &context,
+            &filter_path,
+            "html",
+            native_runtime(),
+            None,
+        )
+        .await
+        .unwrap()
+        .pandoc;
 
         match &filtered.blocks[0] {
             Block::Paragraph(p) => match &p.content[0] {

--- a/crates/pampa/src/lua/filter.rs
+++ b/crates/pampa/src/lua/filter.rs
@@ -119,6 +119,27 @@ pub async fn apply_lua_filter(
     target_format: &str,
     runtime: Arc<dyn SystemRuntime>,
 ) -> FilterResult<FilterOutput> {
+    apply_lua_filter_with_attribution(pandoc, context, filter_path, target_format, runtime, None)
+        .await
+}
+
+/// Variant of [`apply_lua_filter`] that exposes the
+/// `quarto.attribution.*` Lua host binding backed by the supplied
+/// `Option<Arc<dyn AttributionLookup>>`. The `None` case registers
+/// no-op stubs and behaves byte-identically to [`apply_lua_filter`].
+///
+/// Production callers route through this from
+/// `unified_filter::apply_filters_with_attribution`; tests that
+/// don't care about attribution can keep calling the simpler
+/// [`apply_lua_filter`].
+pub async fn apply_lua_filter_with_attribution(
+    pandoc: &Pandoc,
+    context: &ASTContext,
+    filter_path: &Path,
+    target_format: &str,
+    runtime: Arc<dyn SystemRuntime>,
+    attribution: Option<Arc<dyn crate::attribution::AttributionLookup>>,
+) -> FilterResult<FilterOutput> {
     // Read filter file via runtime (supports VFS on WASM)
     let filter_bytes = runtime.file_read(filter_path).map_err(|e| {
         LuaFilterError::FileReadError(
@@ -159,6 +180,12 @@ pub async fn apply_lua_filter(
 
     // Register quarto.json, quarto.log, quarto.utils
     register_quarto_api(&lua)?;
+
+    // Register quarto.attribution.{lookup, lookup_range, identities}.
+    // When `attribution` is `None`, registers no-op stubs:
+    //   - `lookup` / `lookup_range` return nil
+    //   - `identities` returns an empty table
+    super::quarto_api::register_quarto_attribution(&lua, attribution)?;
 
     // Register quarto.doc namespace (is_format, add_html_dependency, etc.)
     super::quarto_doc::register_quarto_doc(&lua)?;
@@ -259,6 +286,22 @@ pub async fn apply_lua_filters(
     target_format: &str,
     runtime: Arc<dyn SystemRuntime>,
 ) -> FilterResult<FilterOutput> {
+    apply_lua_filters_with_attribution(pandoc, context, filter_paths, target_format, runtime, None)
+        .await
+}
+
+/// Variant of [`apply_lua_filters`] that threads an
+/// `Option<Arc<dyn AttributionLookup>>` handle to each per-filter
+/// Lua state via [`apply_lua_filter_with_attribution`]. See its
+/// doc-comment for the contract.
+pub async fn apply_lua_filters_with_attribution(
+    pandoc: Pandoc,
+    context: ASTContext,
+    filter_paths: &[std::path::PathBuf],
+    target_format: &str,
+    runtime: Arc<dyn SystemRuntime>,
+    attribution: Option<Arc<dyn crate::attribution::AttributionLookup>>,
+) -> FilterResult<FilterOutput> {
     let mut current_pandoc = pandoc;
     let mut current_context = context;
     let mut all_diagnostics = Vec::new();
@@ -267,12 +310,13 @@ pub async fn apply_lua_filters(
     let mut all_resources = Vec::new();
 
     for filter_path in filter_paths {
-        let output = apply_lua_filter(
+        let output = apply_lua_filter_with_attribution(
             &current_pandoc,
             &current_context,
             filter_path,
             target_format,
             runtime.clone(),
+            attribution.clone(),
         )
         .await?;
         current_pandoc = output.pandoc;

--- a/crates/pampa/src/lua/filter.rs
+++ b/crates/pampa/src/lua/filter.rs
@@ -108,31 +108,17 @@ pub struct FilterOutput {
     pub resources: Vec<std::path::PathBuf>,
 }
 
-/// Apply a single Lua filter to a document
+/// Apply a single Lua filter to a document.
 ///
-/// Returns the filtered document, context, diagnostics, and any HTML dependencies
-/// or text includes registered via the `quarto.doc` API.
+/// Returns the filtered document, context, diagnostics, and any HTML
+/// dependencies or text includes registered via the `quarto.doc` API.
+///
+/// The `attribution` handle backs the `quarto.attribution.*` Lua host
+/// binding. Passing `None` registers no-op stubs (the binding is
+/// alive but `lookup` / `lookup_range` return nil and `identities`
+/// returns an empty table). Most callers pass `None`; only
+/// `quarto-core::UserFiltersStage` passes `Some(handle)`.
 pub async fn apply_lua_filter(
-    pandoc: &Pandoc,
-    context: &ASTContext,
-    filter_path: &Path,
-    target_format: &str,
-    runtime: Arc<dyn SystemRuntime>,
-) -> FilterResult<FilterOutput> {
-    apply_lua_filter_with_attribution(pandoc, context, filter_path, target_format, runtime, None)
-        .await
-}
-
-/// Variant of [`apply_lua_filter`] that exposes the
-/// `quarto.attribution.*` Lua host binding backed by the supplied
-/// `Option<Arc<dyn AttributionLookup>>`. The `None` case registers
-/// no-op stubs and behaves byte-identically to [`apply_lua_filter`].
-///
-/// Production callers route through this from
-/// `unified_filter::apply_filters_with_attribution`; tests that
-/// don't care about attribution can keep calling the simpler
-/// [`apply_lua_filter`].
-pub async fn apply_lua_filter_with_attribution(
     pandoc: &Pandoc,
     context: &ASTContext,
     filter_path: &Path,
@@ -275,26 +261,13 @@ pub async fn apply_lua_filter_with_attribution(
     })
 }
 
-/// Apply multiple Lua filters in sequence
+/// Apply multiple Lua filters in sequence.
 ///
-/// Returns the filtered document, context, and accumulated diagnostics,
-/// HTML dependencies, and text includes from all filters.
+/// Returns the filtered document, context, and accumulated
+/// diagnostics, HTML dependencies, and text includes from all
+/// filters. The `attribution` handle is threaded to every per-filter
+/// Lua state — see [`apply_lua_filter`] for the contract.
 pub async fn apply_lua_filters(
-    pandoc: Pandoc,
-    context: ASTContext,
-    filter_paths: &[std::path::PathBuf],
-    target_format: &str,
-    runtime: Arc<dyn SystemRuntime>,
-) -> FilterResult<FilterOutput> {
-    apply_lua_filters_with_attribution(pandoc, context, filter_paths, target_format, runtime, None)
-        .await
-}
-
-/// Variant of [`apply_lua_filters`] that threads an
-/// `Option<Arc<dyn AttributionLookup>>` handle to each per-filter
-/// Lua state via [`apply_lua_filter_with_attribution`]. See its
-/// doc-comment for the contract.
-pub async fn apply_lua_filters_with_attribution(
     pandoc: Pandoc,
     context: ASTContext,
     filter_paths: &[std::path::PathBuf],
@@ -310,7 +283,7 @@ pub async fn apply_lua_filters_with_attribution(
     let mut all_resources = Vec::new();
 
     for filter_path in filter_paths {
-        let output = apply_lua_filter_with_attribution(
+        let output = apply_lua_filter(
             &current_pandoc,
             &current_context,
             filter_path,

--- a/crates/pampa/src/lua/filter_tests.rs
+++ b/crates/pampa/src/lua/filter_tests.rs
@@ -71,10 +71,17 @@ end
     };
     let context = ASTContext::new();
 
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
 
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
@@ -127,10 +134,17 @@ end
     };
     let context = ASTContext::new();
 
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
 
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
@@ -167,10 +181,17 @@ async fn test_uppercase_filter() {
     };
     let context = ASTContext::new();
 
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
 
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
@@ -200,10 +221,17 @@ async fn test_identity_filter() {
     };
     let context = ASTContext::new();
 
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
 
     // Identity filter should preserve the document
     match &filtered.blocks[0] {
@@ -261,10 +289,17 @@ end
     };
     let context = ASTContext::new();
 
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
 
     match &filtered.blocks[0] {
         Block::Paragraph(p) => {
@@ -312,10 +347,17 @@ end
     };
     let context = ASTContext::new();
 
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
 
     match &filtered.blocks[0] {
         Block::Paragraph(p) => {
@@ -371,10 +413,17 @@ end
     };
     let context = ASTContext::new();
 
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
 
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
@@ -447,10 +496,17 @@ end
     };
     let context = ASTContext::new();
 
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
 
     match &filtered.blocks[0] {
         Block::Header(h) => {
@@ -501,10 +557,17 @@ end
     };
     let context = ASTContext::new();
 
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
 
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
@@ -561,10 +624,17 @@ end
     };
     let context = ASTContext::new();
 
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
 
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
@@ -640,10 +710,17 @@ end
     };
     let context = ASTContext::new();
 
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
 
     // In topdown mode, Emph is replaced with Span before we visit the Str inside
     // So we should see Span(Str("replaced")), not the original "should_not_see_this"
@@ -688,10 +765,17 @@ end
     };
     let context = ASTContext::new();
 
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
 
     // The filtered Str should have FilterProvenance source info
     match &filtered.blocks[0] {
@@ -767,10 +851,17 @@ end
     };
     let context = ASTContext::new();
 
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
 
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
@@ -826,10 +917,17 @@ end
     };
     let context = ASTContext::new();
 
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
 
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
@@ -912,9 +1010,16 @@ end
     };
     let context = ASTContext::new();
 
-    let _ = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap();
+    let _ = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap();
 
     // Read the order file
     let order = fs::read_to_string(&order_file).unwrap();
@@ -969,10 +1074,17 @@ end
     };
     let context = ASTContext::new();
 
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
 
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
@@ -1027,9 +1139,16 @@ end
     };
     let context = ASTContext::new();
 
-    let _ = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap();
+    let _ = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap();
 
     let order = fs::read_to_string(&order_file).unwrap();
     let lines: Vec<&str> = order.lines().collect();
@@ -1085,9 +1204,16 @@ end
     };
     let context = ASTContext::new();
 
-    let _ = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap();
+    let _ = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap();
 
     let order = fs::read_to_string(&order_file).unwrap();
     let lines: Vec<&str> = order.lines().collect();
@@ -1152,9 +1278,16 @@ end
     };
     let context = ASTContext::new();
 
-    let _ = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap();
+    let _ = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap();
 
     let order = fs::read_to_string(&order_file).unwrap();
     let lines: Vec<&str> = order.lines().collect();
@@ -1236,9 +1369,16 @@ end
     };
     let context = ASTContext::new();
 
-    let _ = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap();
+    let _ = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap();
 
     let order = fs::read_to_string(&order_file).unwrap();
     let lines: Vec<&str> = order.lines().collect();
@@ -1306,9 +1446,16 @@ end
     };
     let context = ASTContext::new();
 
-    let _ = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap();
+    let _ = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap();
 
     let order = fs::read_to_string(&order_file).unwrap();
     let lines: Vec<&str> = order.lines().collect();
@@ -1394,9 +1541,16 @@ end
     };
     let context = ASTContext::new();
 
-    let _ = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap();
+    let _ = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap();
 
     let order = fs::read_to_string(&order_file).unwrap();
     let lines: Vec<&str> = order.lines().collect();
@@ -1464,10 +1618,17 @@ end
     };
     let context = ASTContext::new();
 
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
 
     // The Str should NOT be uppercased because the Para returned false to stop descent
     match &filtered.blocks[0] {
@@ -1545,9 +1706,16 @@ end
     };
     let context = ASTContext::new();
 
-    let _ = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap();
+    let _ = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap();
 
     let order = fs::read_to_string(&order_file).unwrap();
     let lines: Vec<&str> = order.lines().collect();
@@ -1594,9 +1762,16 @@ end
     };
     let context = ASTContext::new();
 
-    let output = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap();
+    let output = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap();
     let filtered = output.pandoc;
     let diagnostics = output.diagnostics;
 
@@ -1662,10 +1837,17 @@ end
     };
     let context = ASTContext::new();
 
-    let diagnostics = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .diagnostics;
+    let diagnostics = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .diagnostics;
 
     // Should have one error diagnostic
     assert_eq!(diagnostics.len(), 1, "Expected 1 diagnostic");
@@ -1710,10 +1892,17 @@ end
     };
     let context = ASTContext::new();
 
-    let diagnostics = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .diagnostics;
+    let diagnostics = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .diagnostics;
 
     // Should have 3 diagnostics
     assert_eq!(diagnostics.len(), 3, "Expected 3 diagnostics");
@@ -1778,6 +1967,7 @@ end
         &[filter1_path, filter2_path],
         "html",
         native_runtime(),
+        None,
     )
     .await
     .unwrap();
@@ -1854,10 +2044,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Str(s) => assert_eq!(s.text, "strong:bold"),
@@ -1880,10 +2077,17 @@ end
             source_info: quarto_source_map::SourceInfo::default(),
         })],
     };
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Str(s) => assert_eq!(s.text, "underline:underlined"),
@@ -1906,10 +2110,17 @@ end
             source_info: quarto_source_map::SourceInfo::default(),
         })],
     };
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Str(s) => assert_eq!(s.text, "strikeout:crossed"),
@@ -1932,10 +2143,17 @@ end
             source_info: quarto_source_map::SourceInfo::default(),
         })],
     };
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Str(s) => assert_eq!(s.text, "super:2"),
@@ -1958,10 +2176,17 @@ end
             source_info: quarto_source_map::SourceInfo::default(),
         })],
     };
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Str(s) => assert_eq!(s.text, "sub:n"),
@@ -1984,10 +2209,17 @@ end
             source_info: quarto_source_map::SourceInfo::default(),
         })],
     };
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Str(s) => assert_eq!(s.text, "smallcaps:small"),
@@ -2030,10 +2262,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Str(s) => assert_eq!(s.text, "SingleQuote:quoted"),
@@ -2057,10 +2296,17 @@ end
             source_info: quarto_source_map::SourceInfo::default(),
         })],
     };
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Str(s) => assert_eq!(s.text, "DoubleQuote:double"),
@@ -2104,10 +2350,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Str(s) => {
@@ -2149,10 +2402,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Str(s) => assert_eq!(s.text, "InlineMath:x^2"),
@@ -2173,10 +2433,17 @@ end
             source_info: quarto_source_map::SourceInfo::default(),
         })],
     };
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Str(s) => assert_eq!(s.text, "DisplayMath:E=mc^2"),
@@ -2215,10 +2482,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Str(s) => assert_eq!(s.text, "raw:html:<b>bold</b>"),
@@ -2269,10 +2543,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Str(s) => {
@@ -2324,10 +2605,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Str(s) => {
@@ -2375,10 +2663,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Str(s) => assert_eq!(s.text, "note:footnote content"),
@@ -2431,10 +2726,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Str(s) => {
@@ -2493,10 +2795,17 @@ end
             source_info: quarto_source_map::SourceInfo::default(),
         })],
     };
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Str(s) => assert_eq!(s.text, "insert:added|id:ins-id"),
@@ -2521,10 +2830,17 @@ end
             source_info: quarto_source_map::SourceInfo::default(),
         })],
     };
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Str(s) => assert_eq!(s.text, "delete:removed|id:del-id"),
@@ -2549,10 +2865,17 @@ end
             source_info: quarto_source_map::SourceInfo::default(),
         })],
     };
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Str(s) => assert_eq!(s.text, "highlight:important|id:hl-id"),
@@ -2589,10 +2912,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Str(s) => assert_eq!(s.text, "noteref:fn1"),
@@ -2633,10 +2963,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Str(s) => assert_eq!(s.text, "modified"),
@@ -2702,10 +3039,17 @@ end
             source_info: quarto_source_map::SourceInfo::default(),
         })],
     };
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Emph(e) => match &e.content[0] {
@@ -2731,10 +3075,17 @@ end
             source_info: quarto_source_map::SourceInfo::default(),
         })],
     };
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Strong(s) => match &s.content[0] {
@@ -2760,10 +3111,17 @@ end
             source_info: quarto_source_map::SourceInfo::default(),
         })],
     };
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Underline(u) => match &u.content[0] {
@@ -2789,10 +3147,17 @@ end
             source_info: quarto_source_map::SourceInfo::default(),
         })],
     };
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Strikeout(st) => match &st.content[0] {
@@ -2838,10 +3203,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Span(span) => {
@@ -2894,10 +3266,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Link(link) => {
@@ -2952,10 +3331,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Image(img) => {
@@ -3003,10 +3389,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Code(code) => {
@@ -3048,10 +3441,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::RawInline(raw) => {
@@ -3092,10 +3492,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Math(math) => {
@@ -3138,10 +3545,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Quoted(q) => match &q.content[0] {
@@ -3187,10 +3601,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Note(note) => match &note.content[0] {
@@ -3248,10 +3669,17 @@ end
             source_info: quarto_source_map::SourceInfo::default(),
         })],
     };
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Insert(ins) => match &ins.content[0] {
@@ -3279,10 +3707,17 @@ end
             source_info: quarto_source_map::SourceInfo::default(),
         })],
     };
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Delete(del) => match &del.content[0] {
@@ -3310,10 +3745,17 @@ end
             source_info: quarto_source_map::SourceInfo::default(),
         })],
     };
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Highlight(hl) => match &hl.content[0] {
@@ -3353,10 +3795,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::NoteReference(nr) => {
@@ -3405,10 +3854,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Span(span) => {
@@ -3460,10 +3916,17 @@ end
             source_info: quarto_source_map::SourceInfo::default(),
         })],
     };
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Str(s) => assert_eq!(s.text, "plain:test"),
@@ -3483,10 +3946,17 @@ end
             source_info: quarto_source_map::SourceInfo::default(),
         })],
     };
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Str(s) => assert_eq!(s.text, "para:hello"),
@@ -3533,10 +4003,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Str(s) => assert_eq!(s.text, "level:2,text:Title,id:my-header,cls:section"),
@@ -3578,10 +4055,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Str(s) => assert_eq!(s.text, "code:print('hello'),id:code-id,cls:python"),
@@ -3617,10 +4101,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Str(s) => assert_eq!(s.text, "raw:<div>html</div>,format:html"),
@@ -3664,10 +4155,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Str(s) => assert_eq!(s.text, "quote:quoted"),
@@ -3714,10 +4212,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Str(s) => assert_eq!(s.text, "div:id=div-id,cls=wrapper"),
@@ -3766,10 +4271,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Str(s) => assert_eq!(s.text, "items:2"),
@@ -3815,10 +4327,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Str(s) => assert_eq!(s.text, "items:1,start:5"),
@@ -3865,10 +4384,17 @@ end
             source_info: quarto_source_map::SourceInfo::default(),
         })],
     };
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Plain(p) => match &p.content[0] {
             Inline::Str(s) => assert_eq!(s.text, "modified_plain"),
@@ -3888,10 +4414,17 @@ end
             source_info: quarto_source_map::SourceInfo::default(),
         })],
     };
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Str(s) => assert_eq!(s.text, "modified_para"),
@@ -3933,10 +4466,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Header(h) => {
             assert_eq!(h.level, 3);
@@ -3981,10 +4521,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::CodeBlock(c) => {
             assert_eq!(c.text, "new_code()");
@@ -4022,10 +4569,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::RawBlock(r) => {
             assert_eq!(r.text, "<p>new</p>");
@@ -4065,10 +4619,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::BlockQuote(bq) => match &bq.content[0] {
             Block::Paragraph(p) => match &p.content[0] {
@@ -4118,10 +4679,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Div(d) => {
             assert_eq!(d.attr.0, "new-div-id");
@@ -4183,10 +4751,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Str(s) => {
@@ -4237,10 +4812,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Str(s) => {
@@ -4289,10 +4871,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Span(span) => {
@@ -4346,10 +4935,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Span(span) => {
@@ -4402,10 +4998,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Str(s) => assert_eq!(s.text, "len:3"),
@@ -4460,10 +5063,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Str(s) => {
@@ -4526,10 +5136,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Str(s) => {
@@ -4574,10 +5191,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Span(span) => {
@@ -4642,10 +5266,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Str(s) => {
@@ -4693,10 +5324,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Str(s) => {
@@ -4750,10 +5388,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Str(s) => {
@@ -4801,10 +5446,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Str(s) => {
@@ -4860,10 +5512,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Str(s) => {
@@ -4912,10 +5571,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Str(s) => {
@@ -4977,10 +5643,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Str(s) => {
@@ -5039,10 +5712,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Str(s) => {
@@ -5099,10 +5779,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => {
             // Should have: "a", "[SB]", "b", "[LB]", "c"
@@ -5140,10 +5827,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
             Inline::Str(s) => {
@@ -5196,10 +5890,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Plain(p) => match &p.content[0] {
             Inline::Str(s) => assert_eq!(s.text, "HELLO"),
@@ -5246,10 +5947,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Header(h) => match &h.content[0] {
             Inline::Str(s) => assert_eq!(s.text, "TITLE"),
@@ -5296,10 +6004,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::BlockQuote(bq) => match &bq.content[0] {
             Block::Paragraph(p) => match &p.content[0] {
@@ -5349,10 +6064,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::BulletList(bl) => match &bl.content[0][0] {
             Block::Plain(p) => match &p.content[0] {
@@ -5407,10 +6129,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::OrderedList(ol) => match &ol.content[0][0] {
             Block::Plain(p) => match &p.content[0] {
@@ -5473,10 +6202,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Figure(f) => match &f.content[0] {
             Block::Plain(p) => match &p.content[0] {
@@ -5523,10 +6259,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::LineBlock(lb) => match &lb.content[0][0] {
             Inline::Str(s) => assert_eq!(s.text, "LINE"),
@@ -5575,10 +6318,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Div(d) => match &d.content[0] {
             Block::Paragraph(p) => match &p.content[0] {
@@ -5623,10 +6373,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => {
             assert_eq!(p.content.len(), 3);
@@ -5674,10 +6431,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     assert_eq!(filtered.blocks.len(), 2);
     match (&filtered.blocks[0], &filtered.blocks[1]) {
         (Block::Paragraph(p1), Block::Paragraph(p2)) => match (&p1.content[0], &p2.content[0]) {
@@ -5724,10 +6488,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     match &filtered.blocks[0] {
         Block::Paragraph(p) => {
             // Should have replaced Emph with [X]
@@ -5784,10 +6555,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
     assert_eq!(filtered.blocks.len(), 2);
     match (&filtered.blocks[0], &filtered.blocks[1]) {
         (Block::Paragraph(p1), Block::Paragraph(p2)) => match (&p1.content[0], &p2.content[0]) {
@@ -5831,10 +6609,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let result = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .expect("Filter should succeed")
-        .pandoc;
+    let result = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .expect("Filter should succeed")
+    .pandoc;
 
     match &result.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
@@ -5871,10 +6656,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let result = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .expect("Filter should succeed")
-        .pandoc;
+    let result = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .expect("Filter should succeed")
+    .pandoc;
 
     match &result.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
@@ -5934,10 +6726,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
 
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
@@ -5981,10 +6780,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
 
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
@@ -6026,10 +6832,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
 
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
@@ -6139,7 +6952,7 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = crate::lua::apply_lua_filter_with_attribution(
+    let filtered = crate::lua::apply_lua_filter(
         &pandoc,
         &context,
         &filter_path,
@@ -6192,7 +7005,7 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = crate::lua::apply_lua_filter_with_attribution(
+    let filtered = crate::lua::apply_lua_filter(
         &pandoc,
         &context,
         &filter_path,
@@ -6247,10 +7060,17 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
-        .await
-        .unwrap()
-        .pandoc;
+    let filtered = apply_lua_filter(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        None,
+    )
+    .await
+    .unwrap()
+    .pandoc;
 
     match &filtered.blocks[0] {
         Block::Paragraph(p) => match &p.content[0] {
@@ -6303,7 +7123,7 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = crate::lua::apply_lua_filter_with_attribution(
+    let filtered = crate::lua::apply_lua_filter(
         &pandoc,
         &context,
         &filter_path,
@@ -6370,7 +7190,7 @@ end
         })],
     };
     let context = ASTContext::new();
-    let filtered = crate::lua::apply_lua_filter_with_attribution(
+    let filtered = crate::lua::apply_lua_filter(
         &pandoc,
         &context,
         &filter_path,

--- a/crates/pampa/src/lua/filter_tests.rs
+++ b/crates/pampa/src/lua/filter_tests.rs
@@ -5884,3 +5884,509 @@ end
         other => panic!("Expected Paragraph, got {:?}", other),
     }
 }
+
+// ============================================================================
+// source_info accessor (bd-0fd0 attribution Lua binding — Phase 3)
+// ============================================================================
+
+#[tokio::test]
+async fn test_source_info_byte_range_on_inline() {
+    let dir = TempDir::new().unwrap();
+    let filter_path = dir.path().join("source_info_test.lua");
+    fs::write(
+        &filter_path,
+        r#"
+function Span(elem)
+    local r = elem.source_info:byte_range()
+    local cls
+    if r then
+        cls = "bytes-" .. tostring(r[1]) .. "-" .. tostring(r[2])
+    else
+        cls = "unresolved"
+    end
+    return pandoc.Span(elem.content, pandoc.Attr("", {cls}, {}))
+end
+"#,
+    )
+    .unwrap();
+
+    let pandoc = Pandoc {
+        meta: quarto_pandoc_types::ConfigValue::default(),
+        blocks: vec![Block::Paragraph(crate::pandoc::Paragraph {
+            content: vec![Inline::Span(crate::pandoc::Span {
+                attr: (String::new(), vec![], hashlink::LinkedHashMap::new()),
+                attr_source: crate::pandoc::AttrSourceInfo::empty(),
+                content: vec![Inline::Str(crate::pandoc::Str {
+                    text: "hi".to_string(),
+                    source_info: quarto_source_map::SourceInfo::original(
+                        quarto_source_map::FileId(0),
+                        5,
+                        7,
+                    ),
+                })],
+                source_info: quarto_source_map::SourceInfo::original(
+                    quarto_source_map::FileId(0),
+                    5,
+                    7,
+                ),
+            })],
+            source_info: quarto_source_map::SourceInfo::default(),
+        })],
+    };
+    let context = ASTContext::new();
+    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
+        .await
+        .unwrap()
+        .pandoc;
+
+    match &filtered.blocks[0] {
+        Block::Paragraph(p) => match &p.content[0] {
+            Inline::Span(s) => assert_eq!(s.attr.1, vec!["bytes-5-7".to_string()]),
+            other => panic!("Expected Span, got {:?}", other),
+        },
+        other => panic!("Expected Paragraph, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn test_source_info_file_id_on_block() {
+    let dir = TempDir::new().unwrap();
+    let filter_path = dir.path().join("file_id_test.lua");
+    fs::write(
+        &filter_path,
+        r#"
+function Para(elem)
+    local fid = elem.source_info:file_id()
+    if fid then
+        return pandoc.Para({pandoc.Str("file-" .. tostring(fid))})
+    end
+    return elem
+end
+"#,
+    )
+    .unwrap();
+
+    let pandoc = Pandoc {
+        meta: quarto_pandoc_types::ConfigValue::default(),
+        blocks: vec![Block::Paragraph(crate::pandoc::Paragraph {
+            content: vec![Inline::Str(crate::pandoc::Str {
+                text: "orig".to_string(),
+                source_info: quarto_source_map::SourceInfo::default(),
+            })],
+            source_info: quarto_source_map::SourceInfo::original(
+                quarto_source_map::FileId(3),
+                0,
+                10,
+            ),
+        })],
+    };
+    let context = ASTContext::new();
+    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
+        .await
+        .unwrap()
+        .pandoc;
+
+    match &filtered.blocks[0] {
+        Block::Paragraph(p) => match &p.content[0] {
+            Inline::Str(s) => assert_eq!(s.text, "file-3"),
+            other => panic!("Expected Str, got {:?}", other),
+        },
+        other => panic!("Expected Paragraph, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn test_source_info_unresolved_for_filter_provenance() {
+    let dir = TempDir::new().unwrap();
+    let filter_path = dir.path().join("unresolved_test.lua");
+    fs::write(
+        &filter_path,
+        r#"
+function Span(elem)
+    local r = elem.source_info:byte_range()
+    if r == nil then
+        return pandoc.Span(elem.content, pandoc.Attr("", {"unresolved"}, {}))
+    end
+    return elem
+end
+"#,
+    )
+    .unwrap();
+
+    let pandoc = Pandoc {
+        meta: quarto_pandoc_types::ConfigValue::default(),
+        blocks: vec![Block::Paragraph(crate::pandoc::Paragraph {
+            content: vec![Inline::Span(crate::pandoc::Span {
+                attr: (String::new(), vec![], hashlink::LinkedHashMap::new()),
+                attr_source: crate::pandoc::AttrSourceInfo::empty(),
+                content: vec![],
+                source_info: quarto_source_map::SourceInfo::filter_provenance("test.lua", 1),
+            })],
+            source_info: quarto_source_map::SourceInfo::default(),
+        })],
+    };
+    let context = ASTContext::new();
+    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
+        .await
+        .unwrap()
+        .pandoc;
+
+    match &filtered.blocks[0] {
+        Block::Paragraph(p) => match &p.content[0] {
+            Inline::Span(s) => assert_eq!(s.attr.1, vec!["unresolved".to_string()]),
+            other => panic!("Expected Span, got {:?}", other),
+        },
+        other => panic!("Expected Paragraph, got {:?}", other),
+    }
+}
+
+// ============================================================================
+// quarto.attribution.* host binding (bd-0fd0 — Phase 4)
+// ============================================================================
+
+/// Local stub implementation of `crate::attribution::AttributionLookup`
+/// for filter integration tests. The production handle lives in
+/// `quarto-core::attribution::handle`, which `pampa` can't depend
+/// on, so the test fabricates a tiny equivalent.
+#[derive(Clone)]
+struct TestAttributionLookup {
+    runs: Vec<(usize, usize, String, i64)>,
+    identities: Vec<(String, String, String)>, // (actor, name, color)
+}
+
+impl crate::attribution::AttributionLookup for TestAttributionLookup {
+    fn lookup_range(&self, start: usize, end: usize) -> Option<crate::attribution::LookupHit> {
+        if start >= end {
+            return None;
+        }
+        let mut best: Option<&(usize, usize, String, i64)> = None;
+        for r in &self.runs {
+            if r.1 <= start || r.0 >= end {
+                continue;
+            }
+            match best {
+                Some(b) if r.3 <= b.3 => {}
+                _ => best = Some(r),
+            }
+        }
+        best.map(|r| crate::attribution::LookupHit {
+            actor: r.2.clone(),
+            time: r.3,
+        })
+    }
+
+    fn identities(&self) -> Vec<crate::attribution::IdentityEntry> {
+        self.identities
+            .iter()
+            .map(|(actor, name, color)| crate::attribution::IdentityEntry {
+                actor: actor.clone(),
+                name: name.clone(),
+                color: color.clone(),
+            })
+            .collect()
+    }
+}
+
+fn make_test_handle() -> std::sync::Arc<dyn crate::attribution::AttributionLookup> {
+    std::sync::Arc::new(TestAttributionLookup {
+        runs: vec![
+            (0, 5, "alice@example.com".to_string(), 100),
+            (5, 10, "bob@example.com".to_string(), 200),
+        ],
+        identities: vec![
+            (
+                "alice@example.com".to_string(),
+                "Alice".to_string(),
+                "#ff0000".to_string(),
+            ),
+            (
+                "bob@example.com".to_string(),
+                "Bob".to_string(),
+                "#00ff00".to_string(),
+            ),
+        ],
+    })
+}
+
+#[tokio::test]
+async fn test_quarto_attribution_lookup_range_returns_hit() {
+    let dir = TempDir::new().unwrap();
+    let filter_path = dir.path().join("lookup_range.lua");
+    fs::write(
+        &filter_path,
+        r#"
+function Span(elem)
+    local hit = quarto.attribution.lookup_range(2, 8)
+    if hit then
+        return pandoc.Span(elem.content, pandoc.Attr("", {"hit-" .. hit.actor}, {}))
+    end
+    return pandoc.Span(elem.content, pandoc.Attr("", {"miss"}, {}))
+end
+"#,
+    )
+    .unwrap();
+
+    let pandoc = Pandoc {
+        meta: quarto_pandoc_types::ConfigValue::default(),
+        blocks: vec![Block::Paragraph(crate::pandoc::Paragraph {
+            content: vec![Inline::Span(crate::pandoc::Span {
+                attr: (String::new(), vec![], hashlink::LinkedHashMap::new()),
+                attr_source: crate::pandoc::AttrSourceInfo::empty(),
+                content: vec![],
+                source_info: quarto_source_map::SourceInfo::default(),
+            })],
+            source_info: quarto_source_map::SourceInfo::default(),
+        })],
+    };
+    let context = ASTContext::new();
+    let filtered = crate::lua::apply_lua_filter_with_attribution(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        Some(make_test_handle()),
+    )
+    .await
+    .unwrap()
+    .pandoc;
+
+    match &filtered.blocks[0] {
+        Block::Paragraph(p) => match &p.content[0] {
+            // Range [2, 8) overlaps both runs; bob's run has the
+            // higher time, so it wins.
+            Inline::Span(s) => assert_eq!(s.attr.1, vec!["hit-bob@example.com".to_string()]),
+            other => panic!("Expected Span, got {:?}", other),
+        },
+        other => panic!("Expected Paragraph, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn test_quarto_attribution_identities_returns_map() {
+    let dir = TempDir::new().unwrap();
+    let filter_path = dir.path().join("identities.lua");
+    fs::write(
+        &filter_path,
+        r#"
+function Para(elem)
+    local idents = quarto.attribution.identities()
+    local alice = idents["alice@example.com"]
+    if alice and alice.name == "Alice" then
+        return pandoc.Para({pandoc.Str("alice-" .. alice.color)})
+    end
+    return pandoc.Para({pandoc.Str("missing")})
+end
+"#,
+    )
+    .unwrap();
+
+    let pandoc = Pandoc {
+        meta: quarto_pandoc_types::ConfigValue::default(),
+        blocks: vec![Block::Paragraph(crate::pandoc::Paragraph {
+            content: vec![Inline::Str(crate::pandoc::Str {
+                text: "original".to_string(),
+                source_info: quarto_source_map::SourceInfo::default(),
+            })],
+            source_info: quarto_source_map::SourceInfo::default(),
+        })],
+    };
+    let context = ASTContext::new();
+    let filtered = crate::lua::apply_lua_filter_with_attribution(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        Some(make_test_handle()),
+    )
+    .await
+    .unwrap()
+    .pandoc;
+
+    match &filtered.blocks[0] {
+        Block::Paragraph(p) => match &p.content[0] {
+            Inline::Str(s) => assert_eq!(s.text, "alice-#ff0000"),
+            other => panic!("Expected Str, got {:?}", other),
+        },
+        other => panic!("Expected Paragraph, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn test_quarto_attribution_no_provider_returns_nil() {
+    // No handle installed → lookup_range returns nil, identities
+    // returns an empty table. Filter exercises both.
+    let dir = TempDir::new().unwrap();
+    let filter_path = dir.path().join("no_provider.lua");
+    fs::write(
+        &filter_path,
+        r#"
+function Span(elem)
+    local hit = quarto.attribution.lookup_range(0, 10)
+    local idents = quarto.attribution.identities()
+    local n = 0
+    for _, _ in pairs(idents) do n = n + 1 end
+    local cls = "hit-" .. tostring(hit ~= nil) .. "-ids-" .. tostring(n)
+    return pandoc.Span(elem.content, pandoc.Attr("", {cls}, {}))
+end
+"#,
+    )
+    .unwrap();
+
+    let pandoc = Pandoc {
+        meta: quarto_pandoc_types::ConfigValue::default(),
+        blocks: vec![Block::Paragraph(crate::pandoc::Paragraph {
+            content: vec![Inline::Span(crate::pandoc::Span {
+                attr: (String::new(), vec![], hashlink::LinkedHashMap::new()),
+                attr_source: crate::pandoc::AttrSourceInfo::empty(),
+                content: vec![],
+                source_info: quarto_source_map::SourceInfo::default(),
+            })],
+            source_info: quarto_source_map::SourceInfo::default(),
+        })],
+    };
+    let context = ASTContext::new();
+    let filtered = apply_lua_filter(&pandoc, &context, &filter_path, "html", native_runtime())
+        .await
+        .unwrap()
+        .pandoc;
+
+    match &filtered.blocks[0] {
+        Block::Paragraph(p) => match &p.content[0] {
+            Inline::Span(s) => {
+                assert_eq!(s.attr.1, vec!["hit-false-ids-0".to_string()]);
+            }
+            other => panic!("Expected Span, got {:?}", other),
+        },
+        other => panic!("Expected Paragraph, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn test_quarto_attribution_lookup_joins_identity() {
+    // `quarto.attribution.lookup(el)` reads el.source_info, calls
+    // lookup_range internally, and joins the identity entry. Returns
+    // a table with actor/time/name/color when everything resolves.
+    let dir = TempDir::new().unwrap();
+    let filter_path = dir.path().join("lookup_join.lua");
+    fs::write(
+        &filter_path,
+        r#"
+function Span(elem)
+    local hit = quarto.attribution.lookup(elem)
+    if hit then
+        local cls = hit.actor .. "/" .. hit.name .. "/" .. hit.color
+        return pandoc.Span(elem.content, pandoc.Attr("", {cls}, {}))
+    end
+    return pandoc.Span(elem.content, pandoc.Attr("", {"miss"}, {}))
+end
+"#,
+    )
+    .unwrap();
+
+    let pandoc = Pandoc {
+        meta: quarto_pandoc_types::ConfigValue::default(),
+        blocks: vec![Block::Paragraph(crate::pandoc::Paragraph {
+            content: vec![Inline::Span(crate::pandoc::Span {
+                attr: (String::new(), vec![], hashlink::LinkedHashMap::new()),
+                attr_source: crate::pandoc::AttrSourceInfo::empty(),
+                content: vec![],
+                // Source range [0, 5) — entirely inside Alice's run.
+                source_info: quarto_source_map::SourceInfo::original(
+                    quarto_source_map::FileId(0),
+                    0,
+                    5,
+                ),
+            })],
+            source_info: quarto_source_map::SourceInfo::default(),
+        })],
+    };
+    let context = ASTContext::new();
+    let filtered = crate::lua::apply_lua_filter_with_attribution(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        Some(make_test_handle()),
+    )
+    .await
+    .unwrap()
+    .pandoc;
+
+    match &filtered.blocks[0] {
+        Block::Paragraph(p) => match &p.content[0] {
+            Inline::Span(s) => {
+                assert_eq!(
+                    s.attr.1,
+                    vec!["alice@example.com/Alice/#ff0000".to_string()]
+                );
+            }
+            other => panic!("Expected Span, got {:?}", other),
+        },
+        other => panic!("Expected Paragraph, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn test_quarto_attribution_lookup_skips_non_primary_file() {
+    // v1 single-doc invariant: nodes whose SourceInfo resolves to
+    // file_id != 0 must return nil. Parallels the existing
+    // `attribution_render_skips_non_primary_file_nodes` test in
+    // quarto-core.
+    let dir = TempDir::new().unwrap();
+    let filter_path = dir.path().join("non_primary.lua");
+    fs::write(
+        &filter_path,
+        r#"
+function Span(elem)
+    local hit = quarto.attribution.lookup(elem)
+    if hit == nil then
+        return pandoc.Span(elem.content, pandoc.Attr("", {"non-primary-nil"}, {}))
+    end
+    return pandoc.Span(elem.content, pandoc.Attr("", {"unexpected-hit"}, {}))
+end
+"#,
+    )
+    .unwrap();
+
+    let pandoc = Pandoc {
+        meta: quarto_pandoc_types::ConfigValue::default(),
+        blocks: vec![Block::Paragraph(crate::pandoc::Paragraph {
+            content: vec![Inline::Span(crate::pandoc::Span {
+                attr: (String::new(), vec![], hashlink::LinkedHashMap::new()),
+                attr_source: crate::pandoc::AttrSourceInfo::empty(),
+                content: vec![],
+                // file_id = 1 → non-primary; lookup_range would
+                // otherwise hit Alice's run.
+                source_info: quarto_source_map::SourceInfo::original(
+                    quarto_source_map::FileId(1),
+                    0,
+                    5,
+                ),
+            })],
+            source_info: quarto_source_map::SourceInfo::default(),
+        })],
+    };
+    let context = ASTContext::new();
+    let filtered = crate::lua::apply_lua_filter_with_attribution(
+        &pandoc,
+        &context,
+        &filter_path,
+        "html",
+        native_runtime(),
+        Some(make_test_handle()),
+    )
+    .await
+    .unwrap()
+    .pandoc;
+
+    match &filtered.blocks[0] {
+        Block::Paragraph(p) => match &p.content[0] {
+            Inline::Span(s) => assert_eq!(s.attr.1, vec!["non-primary-nil".to_string()]),
+            other => panic!("Expected Span, got {:?}", other),
+        },
+        other => panic!("Expected Paragraph, got {:?}", other),
+    }
+}

--- a/crates/pampa/src/lua/mod.rs
+++ b/crates/pampa/src/lua/mod.rs
@@ -31,10 +31,7 @@ mod utils;
 #[allow(unused_imports)]
 pub use filter::FilterOutput;
 #[allow(unused_imports)]
-pub use filter::{
-    LuaFilterError, apply_lua_filter, apply_lua_filter_with_attribution, apply_lua_filters,
-    apply_lua_filters_with_attribution,
-};
+pub use filter::{LuaFilterError, apply_lua_filter, apply_lua_filters};
 #[allow(unused_imports)]
 pub use quarto_doc::{
     HtmlDependency, IncludeLocation, TextInclude, extract_html_dependencies, extract_text_includes,

--- a/crates/pampa/src/lua/mod.rs
+++ b/crates/pampa/src/lua/mod.rs
@@ -30,7 +30,11 @@ mod utils;
 
 #[allow(unused_imports)]
 pub use filter::FilterOutput;
-pub use filter::{LuaFilterError, apply_lua_filters};
+#[allow(unused_imports)]
+pub use filter::{
+    LuaFilterError, apply_lua_filter, apply_lua_filter_with_attribution, apply_lua_filters,
+    apply_lua_filters_with_attribution,
+};
 #[allow(unused_imports)]
 pub use quarto_doc::{
     HtmlDependency, IncludeLocation, TextInclude, extract_html_dependencies, extract_text_includes,

--- a/crates/pampa/src/lua/quarto_api.rs
+++ b/crates/pampa/src/lua/quarto_api.rs
@@ -12,6 +12,9 @@
 use base64::prelude::*;
 use mlua::{Lua, MultiValue, Result, Table, Value};
 use std::path::{Component, Path, PathBuf};
+use std::sync::Arc;
+
+use crate::attribution::AttributionLookup;
 
 /// Extends the `quarto` global (already created by register_quarto_namespace)
 /// with additional API sub-namespaces: quarto.json, quarto.log, quarto.utils.
@@ -208,6 +211,141 @@ pub fn current_script_dir(lua: &Lua) -> Result<String> {
     } else {
         Ok(String::new())
     }
+}
+
+// =========================================================================
+// quarto.attribution — bd-0fd0 host binding (read-only)
+// =========================================================================
+
+/// Register the `quarto.attribution.*` host binding on the existing
+/// `quarto` global. Reads from the optional [`AttributionLookup`]
+/// handle supplied by the filter runner (typically wrapping the
+/// `Arc<AttributionData>` sidecar produced by
+/// [`crate::stage::stages::AttributionGenerateStage`](../../quarto_core/stage/stages/struct.AttributionGenerateStage.html)
+/// in `quarto-core`).
+///
+/// API exposed:
+///
+/// ```lua
+/// -- Convenience: resolves identity automatically, reads
+/// -- `el.source_info:byte_range()` internally. Returns nil for nodes
+/// -- whose chain resolves to Concat/FilterProvenance, or non-primary
+/// -- file (v1 single-doc invariant), or with no provider installed.
+/// local hit = quarto.attribution.lookup(el)
+/// -- => { actor = "alice@example.com", time = 1715000000000,
+/// --      name = "Alice", color = "#ff0000" }
+///
+/// -- Primitive: arbitrary byte range against the primary file. No
+/// -- identity join. Returns nil on no overlap, no provider, or
+/// -- start >= end.
+/// local raw = quarto.attribution.lookup_range(start, end)
+/// -- => { actor = "alice@example.com", time = 1715000000000 }
+///
+/// -- Identity map snapshot, keyed by actor. Empty table when no
+/// -- provider is installed.
+/// local idents = quarto.attribution.identities()
+/// -- => { ["alice@example.com"] = { name = "Alice", color = "#ff0000" } }
+/// ```
+///
+/// When `handle` is `None`, the registered functions become no-op
+/// stubs (lookup/lookup_range return nil; identities returns an
+/// empty table). This keeps the binding present in the Lua
+/// environment regardless of whether attribution is on, so filters
+/// can call into it unconditionally.
+pub fn register_quarto_attribution(
+    lua: &Lua,
+    handle: Option<Arc<dyn AttributionLookup>>,
+) -> Result<()> {
+    let quarto: Table = lua.globals().get("quarto")?;
+    let attribution = lua.create_table()?;
+
+    // `quarto.attribution.lookup_range(start, end)` — primitive raw
+    // lookup. Returns `{actor, time}` table on hit, nil otherwise.
+    let h_for_range = handle.clone();
+    attribution.set(
+        "lookup_range",
+        lua.create_function(move |lua, (start, end_): (usize, usize)| {
+            let Some(h) = h_for_range.as_ref() else {
+                return Ok(Value::Nil);
+            };
+            let Some(hit) = h.lookup_range(start, end_) else {
+                return Ok(Value::Nil);
+            };
+            let t = lua.create_table()?;
+            t.set("actor", hit.actor)?;
+            t.set("time", hit.time)?;
+            Ok(Value::Table(t))
+        })?,
+    )?;
+
+    // `quarto.attribution.identities()` — read-only snapshot of the
+    // identity map keyed by actor. Empty table when no handle.
+    let h_for_ids = handle.clone();
+    attribution.set(
+        "identities",
+        lua.create_function(move |lua, ()| {
+            let t = lua.create_table()?;
+            if let Some(h) = h_for_ids.as_ref() {
+                for entry in h.identities() {
+                    let inner = lua.create_table()?;
+                    inner.set("name", entry.name)?;
+                    inner.set("color", entry.color)?;
+                    t.set(entry.actor, inner)?;
+                }
+            }
+            Ok(t)
+        })?,
+    )?;
+
+    // Publish the table on `quarto.attribution` *before* compiling
+    // the `lookup` thunk below — the thunk reads
+    // `quarto.attribution.{lookup_range,identities}` at chunk-load
+    // time into upvalues, so the table must already be reachable
+    // through the `quarto` global.
+    quarto.set("attribution", attribution.clone())?;
+
+    // `quarto.attribution.lookup(el)` — convenience. Reads
+    // `el.source_info:byte_range()`, calls `lookup_range`, joins the
+    // identity entry. Returns nil when the source_info chain doesn't
+    // resolve (Concat/FilterProvenance), when the resolved file_id
+    // isn't 0 (v1 single-doc invariant), when no run overlaps the
+    // range, or when no handle is installed.
+    //
+    // The implementation is a small Lua thunk that delegates to the
+    // Rust-backed functions registered above — keeps the per-call
+    // path purely Lua-side (no Rust closure to capture).
+    lua.load(
+        r#"
+        local lookup_range = quarto.attribution.lookup_range
+        local identities = quarto.attribution.identities
+        return function(el)
+            local si = el.source_info
+            if si == nil then return nil end
+            local r = si:byte_range()
+            if r == nil then return nil end
+            -- v1 single-doc invariant: skip non-primary file.
+            local fid = si:file_id()
+            if fid ~= nil and fid ~= 0 then return nil end
+            local hit = lookup_range(r[1], r[2])
+            if hit == nil then return nil end
+            local idents = identities()
+            local id = idents[hit.actor]
+            if id == nil then
+                return { actor = hit.actor, time = hit.time }
+            end
+            return {
+                actor = hit.actor,
+                time = hit.time,
+                name = id.name,
+                color = id.color,
+            }
+        end
+        "#,
+    )
+    .eval::<mlua::Function>()
+    .and_then(|f| attribution.set("lookup", f))?;
+
+    Ok(())
 }
 
 /// `quarto.utils` — utility functions

--- a/crates/pampa/src/lua/types.rs
+++ b/crates/pampa/src/lua/types.rs
@@ -179,6 +179,14 @@ impl LuaInline {
         // the closure-captured value isn't tied to the borrow's lifetime.
         match key {
             "tag" | "t" => return self.tag_name().into_lua(lua),
+            "source_info" => {
+                // The Lua host binding for attribution
+                // (`quarto.attribution.lookup(el)`) reads this. Snapshot
+                // the SourceInfo so the userdata is independent of any
+                // later mutation of the inline.
+                let si = self.0.borrow().source_info().clone();
+                return lua.create_userdata(LuaSourceInfo::new(si))?.into_lua(lua);
+            }
             "clone" => {
                 // Snapshot the inner inline at .clone-access time (matching
                 // pre-refactor behavior). Each invocation of the returned
@@ -709,6 +717,62 @@ impl UserData for LuaInline {
     }
 }
 
+/// Wrapper for [`SourceInfo`] exposed as Lua userdata.
+///
+/// Returned by `el.source_info` on Block and Inline userdata. Carries
+/// `:byte_range()` and `:file_id()` accessors that chain-resolve the
+/// underlying `SourceInfo` to a `(file_id, start, end)` tuple in the
+/// root source file. Both return `nil` when the chain resolves to
+/// `SourceInfo::Concat` or `SourceInfo::FilterProvenance` — the same
+/// rule applied by `AttributionRenderTransform`.
+///
+/// This is the building block of the `quarto.attribution.lookup(el)`
+/// convenience: it reads `el.source_info:byte_range()` then calls
+/// `quarto.attribution.lookup_range` with the resolved offsets.
+#[derive(Debug, Clone)]
+pub struct LuaSourceInfo(pub SourceInfo);
+
+impl LuaSourceInfo {
+    pub fn new(si: SourceInfo) -> Self {
+        Self(si)
+    }
+}
+
+impl UserData for LuaSourceInfo {
+    fn add_methods<M: UserDataMethods<Self>>(methods: &mut M) {
+        // `:byte_range()` returns a Lua table `{start, end}` (1-indexed
+        // positional, matching Pandoc convention for Range tables) or
+        // `nil` when the SourceInfo chain doesn't resolve to a single
+        // contiguous byte range.
+        methods.add_method("byte_range", |lua, this, ()| {
+            let Some((_fid, start, end)) = this.0.resolve_byte_range() else {
+                return Ok(Value::Nil);
+            };
+            let t = lua.create_table()?;
+            t.set("start", start)?;
+            t.set("end_", end)?;
+            // Positional access for callers that prefer it.
+            t.set(1, start)?;
+            t.set(2, end)?;
+            Ok(Value::Table(t))
+        });
+
+        // `:file_id()` returns the integer file_id, or `nil` when the
+        // chain doesn't resolve. Useful for callers that want to skip
+        // non-primary-file nodes without re-deriving the rule.
+        methods.add_method("file_id", |_, this, ()| {
+            Ok(this.0.resolve_byte_range().map(|(fid, _, _)| fid))
+        });
+
+        methods.add_meta_method(MetaMethod::ToString, |_, this, ()| {
+            Ok(match this.0.resolve_byte_range() {
+                Some((fid, start, end)) => format!("SourceInfo({}, {}..{})", fid, start, end),
+                None => "SourceInfo(unresolved)".to_string(),
+            })
+        });
+    }
+}
+
 /// Wrapper for Pandoc Block elements as Lua userdata.
 ///
 /// The inner `Block` lives behind `Rc<RefCell<…>>` so proxy userdata
@@ -842,6 +906,13 @@ impl LuaBlock {
         // closure creation or async boundaries.
         match key {
             "tag" | "t" => return self.tag_name().into_lua(lua),
+            "source_info" => {
+                // See `LuaInline::get_field`'s matching branch for
+                // the contract this powers (the attribution host
+                // binding).
+                let si = self.0.borrow().source_info().clone();
+                return lua.create_userdata(LuaSourceInfo::new(si))?.into_lua(lua);
+            }
             "clone" => {
                 let snapshot = self.0.borrow().clone();
                 return lua

--- a/crates/pampa/src/main.rs
+++ b/crates/pampa/src/main.rs
@@ -9,6 +9,7 @@ use clap::Parser;
 use quarto_error_reporting::DiagnosticMessageBuilder;
 use std::io::{self, Read, Write};
 
+mod attribution;
 mod citeproc_filter;
 mod errors;
 mod filter_context;

--- a/crates/pampa/src/main.rs
+++ b/crates/pampa/src/main.rs
@@ -339,6 +339,7 @@ fn main() {
             &filter_specs,
             &args.to,
             runtime,
+            None,
         )) {
             Ok(output) => {
                 // Output any diagnostics from filters

--- a/crates/pampa/src/unified_filter.rs
+++ b/crates/pampa/src/unified_filter.rs
@@ -203,23 +203,13 @@ impl std::error::Error for CiteprocFilterError {}
 
 /// Apply a filter to a Pandoc document.
 ///
-/// Returns the filtered document, updated context, diagnostics, and any
-/// HTML dependencies or text includes (from Lua filters only).
+/// Returns the filtered document, updated context, diagnostics, and
+/// any HTML dependencies or text includes (from Lua filters only).
+///
+/// The `attribution` handle is forwarded to Lua filters — see
+/// [`crate::lua::apply_lua_filter`] for the contract. Non-Lua
+/// filters (Citeproc, JSON) ignore the handle.
 pub async fn apply_filter(
-    pandoc: Pandoc,
-    context: ASTContext,
-    filter: &FilterSpec,
-    target_format: &str,
-    runtime: Arc<dyn SystemRuntime>,
-) -> Result<FilterOutput, FilterError> {
-    apply_filter_with_attribution(pandoc, context, filter, target_format, runtime, None).await
-}
-
-/// Variant of [`apply_filter`] that exposes the
-/// `quarto.attribution.*` Lua host binding backed by the supplied
-/// handle. See [`crate::lua::apply_lua_filter_with_attribution`] for
-/// the contract; non-Lua filters ignore the handle.
-pub async fn apply_filter_with_attribution(
     pandoc: Pandoc,
     context: ASTContext,
     filter: &FilterSpec,
@@ -246,7 +236,7 @@ pub async fn apply_filter_with_attribution(
 
         #[cfg(feature = "lua-filter")]
         FilterSpec::Lua(path) => {
-            let lua_output = crate::lua::apply_lua_filters_with_attribution(
+            let lua_output = crate::lua::apply_lua_filters(
                 pandoc,
                 context,
                 &[path.clone()],
@@ -298,26 +288,15 @@ pub async fn apply_filter_with_attribution(
 
 /// Apply multiple filters in sequence.
 ///
-/// Filters are applied in the order provided. The output of each filter
-/// becomes the input to the next. Diagnostics, HTML dependencies, and
-/// text includes are accumulated across all filter passes.
-pub async fn apply_filters(
-    pandoc: Pandoc,
-    context: ASTContext,
-    filters: &[FilterSpec],
-    target_format: &str,
-    runtime: Arc<dyn SystemRuntime>,
-) -> Result<FilterOutput, FilterError> {
-    apply_filters_with_attribution(pandoc, context, filters, target_format, runtime, None).await
-}
-
-/// Variant of [`apply_filters`] that threads an
-/// `Option<Arc<dyn AttributionLookup>>` handle through each Lua
-/// filter pass so the `quarto.attribution.*` host binding is alive.
+/// Filters are applied in the order provided. The output of each
+/// filter becomes the input to the next. Diagnostics, HTML
+/// dependencies, and text includes are accumulated across all filter
+/// passes. The `attribution` handle is threaded through every Lua
+/// pass so the `quarto.attribution.*` host binding is alive;
 /// `quarto-core`'s
 /// [`UserFiltersStage`](../../quarto_core/stage/stages/struct.UserFiltersStage.html)
 /// routes through this function for both pre and post passes.
-pub async fn apply_filters_with_attribution(
+pub async fn apply_filters(
     pandoc: Pandoc,
     context: ASTContext,
     filters: &[FilterSpec],
@@ -336,7 +315,7 @@ pub async fn apply_filters_with_attribution(
     let mut all_resources = Vec::new();
 
     for filter in filters {
-        let output = apply_filter_with_attribution(
+        let output = apply_filter(
             current_pandoc,
             current_context,
             filter,

--- a/crates/pampa/src/unified_filter.rs
+++ b/crates/pampa/src/unified_filter.rs
@@ -20,6 +20,7 @@ use quarto_error_reporting::DiagnosticMessage;
 
 use quarto_system_runtime::SystemRuntime;
 
+use crate::attribution::AttributionLookup;
 use crate::pandoc::Pandoc;
 use crate::pandoc::ast_context::ASTContext;
 
@@ -211,6 +212,21 @@ pub async fn apply_filter(
     target_format: &str,
     runtime: Arc<dyn SystemRuntime>,
 ) -> Result<FilterOutput, FilterError> {
+    apply_filter_with_attribution(pandoc, context, filter, target_format, runtime, None).await
+}
+
+/// Variant of [`apply_filter`] that exposes the
+/// `quarto.attribution.*` Lua host binding backed by the supplied
+/// handle. See [`crate::lua::apply_lua_filter_with_attribution`] for
+/// the contract; non-Lua filters ignore the handle.
+pub async fn apply_filter_with_attribution(
+    pandoc: Pandoc,
+    context: ASTContext,
+    filter: &FilterSpec,
+    target_format: &str,
+    runtime: Arc<dyn SystemRuntime>,
+    attribution: Option<Arc<dyn AttributionLookup>>,
+) -> Result<FilterOutput, FilterError> {
     match filter {
         FilterSpec::Citeproc => {
             let (new_pandoc, new_context, diagnostics) =
@@ -230,12 +246,13 @@ pub async fn apply_filter(
 
         #[cfg(feature = "lua-filter")]
         FilterSpec::Lua(path) => {
-            let lua_output = crate::lua::apply_lua_filters(
+            let lua_output = crate::lua::apply_lua_filters_with_attribution(
                 pandoc,
                 context,
                 &[path.clone()],
                 target_format,
                 runtime,
+                attribution,
             )
             .await?;
             Ok(FilterOutput {
@@ -291,6 +308,23 @@ pub async fn apply_filters(
     target_format: &str,
     runtime: Arc<dyn SystemRuntime>,
 ) -> Result<FilterOutput, FilterError> {
+    apply_filters_with_attribution(pandoc, context, filters, target_format, runtime, None).await
+}
+
+/// Variant of [`apply_filters`] that threads an
+/// `Option<Arc<dyn AttributionLookup>>` handle through each Lua
+/// filter pass so the `quarto.attribution.*` host binding is alive.
+/// `quarto-core`'s
+/// [`UserFiltersStage`](../../quarto_core/stage/stages/struct.UserFiltersStage.html)
+/// routes through this function for both pre and post passes.
+pub async fn apply_filters_with_attribution(
+    pandoc: Pandoc,
+    context: ASTContext,
+    filters: &[FilterSpec],
+    target_format: &str,
+    runtime: Arc<dyn SystemRuntime>,
+    attribution: Option<Arc<dyn AttributionLookup>>,
+) -> Result<FilterOutput, FilterError> {
     let mut current_pandoc = pandoc;
     let mut current_context = context;
     let mut all_diagnostics = Vec::new();
@@ -302,12 +336,13 @@ pub async fn apply_filters(
     let mut all_resources = Vec::new();
 
     for filter in filters {
-        let output = apply_filter(
+        let output = apply_filter_with_attribution(
             current_pandoc,
             current_context,
             filter,
             target_format,
             runtime.clone(),
+            attribution.clone(),
         )
         .await?;
         current_pandoc = output.pandoc;

--- a/crates/pampa/tests/test_lua_attr_mutation.rs
+++ b/crates/pampa/tests/test_lua_attr_mutation.rs
@@ -80,6 +80,7 @@ async fn run_filter(filter_code: &str, doc: Pandoc) -> Pandoc {
         &[filter_file.path().to_path_buf()],
         "html",
         runtime,
+        None,
     )
     .await
     .expect("filter ran");

--- a/crates/pampa/tests/test_lua_constructors.rs
+++ b/crates/pampa/tests/test_lua_constructors.rs
@@ -41,6 +41,7 @@ async fn run_filter(filter_code: &str, doc: Pandoc) -> (Pandoc, ASTContext) {
         &[filter_file.path().to_path_buf()],
         "html",
         runtime,
+        None,
     )
     .await;
     let output = result.expect("Filter failed");

--- a/crates/pampa/tests/test_lua_list.rs
+++ b/crates/pampa/tests/test_lua_list.rs
@@ -44,6 +44,7 @@ async fn run_filter(filter_code: &str, doc: Pandoc) -> (Pandoc, ASTContext) {
         &[filter_file.path().to_path_buf()],
         "html",
         runtime,
+        None,
     )
     .await;
     let output = result.expect("Filter failed");

--- a/crates/pampa/tests/test_lua_utils.rs
+++ b/crates/pampa/tests/test_lua_utils.rs
@@ -42,6 +42,7 @@ async fn run_filter(filter_code: &str, doc: Pandoc) -> (Pandoc, ASTContext) {
         &[filter_file.path().to_path_buf()],
         "html",
         runtime,
+        None,
     )
     .await;
     let output = result.expect("Filter failed");

--- a/crates/quarto-core/src/attribution/handle.rs
+++ b/crates/quarto-core/src/attribution/handle.rs
@@ -1,0 +1,124 @@
+/*
+ * attribution/handle.rs
+ * Copyright (c) 2026 Posit, PBC
+ */
+
+//! Bridge between `quarto-core`'s canonical [`AttributionData`] and
+//! the [`pampa::attribution::AttributionLookup`] trait that the Lua
+//! filter runner consumes.
+//!
+//! [`AttributionLookupHandle`] wraps an `Arc<AttributionData>` and
+//! implements the trait. `quarto-core::stage::stages::UserFiltersStage`
+//! constructs it from `ctx.attribution_data` and threads it into
+//! [`pampa::unified_filter::apply_filters`] alongside the runtime.
+//!
+//! Plain `String` translations (vs the canonical `Arc<str>`) happen
+//! per call: the Lua boundary doesn't care about pampa's interning
+//! invariant, and per-call cloning is dominated by the Lua VM call
+//! cost. See `claude-notes/plans/2026-05-15-attribution-lua-binding-plan.md`
+//! § "Phase 4a (Option β)".
+
+use std::sync::Arc;
+
+use pampa::attribution::{AttributionLookup, IdentityEntry, LookupHit};
+
+use super::source::AttributionSource;
+use super::types::AttributionData;
+
+/// `pampa` adapter for [`AttributionData`].
+///
+/// Cheap to clone (it's an `Arc`); designed to be passed by value
+/// into `apply_filters` once per filter pass.
+#[derive(Debug, Clone)]
+pub struct AttributionLookupHandle(pub Arc<AttributionData>);
+
+impl AttributionLookupHandle {
+    pub fn new(data: Arc<AttributionData>) -> Self {
+        Self(data)
+    }
+}
+
+impl AttributionLookup for AttributionLookupHandle {
+    fn lookup_range(&self, start: usize, end: usize) -> Option<LookupHit> {
+        let hit = self.0.runs.query_byte_range(start, end)?;
+        Some(LookupHit {
+            actor: hit.actor.to_string(),
+            time: hit.time,
+        })
+    }
+
+    fn identities(&self) -> Vec<IdentityEntry> {
+        self.0
+            .identities
+            .iter()
+            .map(|(actor, identity)| IdentityEntry {
+                actor: actor.to_string(),
+                name: identity.display_name.clone(),
+                color: identity.color.clone(),
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::attribution::AttributionDataBuilder;
+    use crate::attribution::Identity;
+
+    fn make_data() -> AttributionData {
+        let mut b = AttributionDataBuilder::new();
+        b.set_identity(
+            "alice@example.com",
+            Identity {
+                display_name: "Alice".to_string(),
+                color: "#ff0000".to_string(),
+            },
+        );
+        b.set_identity(
+            "bob@example.com",
+            Identity {
+                display_name: "Bob".to_string(),
+                color: "#00ff00".to_string(),
+            },
+        );
+        b.push_run(0, 5, "alice@example.com", 1);
+        b.push_run(5, 10, "bob@example.com", 2);
+        b.build()
+    }
+
+    #[test]
+    fn lookup_range_returns_most_recent_run_overlapping() {
+        let handle = AttributionLookupHandle::new(Arc::new(make_data()));
+        // Range [2, 8) overlaps both runs; bob has higher time.
+        let hit = handle.lookup_range(2, 8).expect("hit");
+        assert_eq!(hit.actor, "bob@example.com");
+        assert_eq!(hit.time, 2);
+    }
+
+    #[test]
+    fn lookup_range_returns_none_on_no_overlap() {
+        let handle = AttributionLookupHandle::new(Arc::new(make_data()));
+        assert!(handle.lookup_range(100, 200).is_none());
+    }
+
+    #[test]
+    fn lookup_range_returns_none_on_empty_data() {
+        let handle = AttributionLookupHandle::new(Arc::new(AttributionData::default()));
+        assert!(handle.lookup_range(0, 10).is_none());
+    }
+
+    #[test]
+    fn identities_passthrough_matches_input() {
+        let handle = AttributionLookupHandle::new(Arc::new(make_data()));
+        let mut ids = handle.identities();
+        ids.sort_by(|a, b| a.actor.cmp(&b.actor));
+        assert_eq!(ids.len(), 2);
+        assert_eq!(ids[0].actor, "alice@example.com");
+        assert_eq!(ids[0].name, "Alice");
+        assert_eq!(ids[0].color, "#ff0000");
+        assert_eq!(ids[1].actor, "bob@example.com");
+        assert_eq!(ids[1].name, "Bob");
+        assert_eq!(ids[1].color, "#00ff00");
+    }
+}

--- a/crates/quarto-core/src/attribution/mod.rs
+++ b/crates/quarto-core/src/attribution/mod.rs
@@ -33,10 +33,12 @@
 
 pub mod builder;
 pub mod git_blame;
+pub mod handle;
 pub mod mode;
 pub mod palette;
 pub mod pampa_bridge;
 pub mod prebuilt;
+pub mod resolve;
 pub mod source;
 pub mod types;
 
@@ -45,10 +47,12 @@ pub use git_blame::{
     BlameLine, BlameRun, GitBlameProvider, attribution_from_porcelain, build_blame_runs,
     parse_blame_porcelain,
 };
+pub use handle::AttributionLookupHandle;
 pub use mode::{AttributionMode, resolve_attribution_mode};
 pub use palette::{actor_color, fnv1a_hex8};
 pub use pampa_bridge::{html_attribution_fields, json_attribution_fields};
 pub use prebuilt::PreBuiltAttributionProvider;
+pub use resolve::resolve_byte_range;
 pub use source::{AttributionSource, AttributionSourceProvider};
 pub use types::{
     AttributionData, AttributionHit, AttributionMap, AttributionRecord, AttributionRun, Identity,

--- a/crates/quarto-core/src/attribution/resolve.rs
+++ b/crates/quarto-core/src/attribution/resolve.rs
@@ -1,0 +1,29 @@
+/*
+ * attribution/resolve.rs
+ * Copyright (c) 2026 Posit, PBC
+ */
+
+//! Chain-resolve a [`SourceInfo`] to a `(file_id, start, end)` byte
+//! range in the root source file.
+//!
+//! Re-exports [`SourceInfo::resolve_byte_range`](quarto_source_map::SourceInfo::resolve_byte_range)
+//! as a free function so callers that came in via the attribution
+//! crate path (and the Lua host binding in `pampa`) read it from a
+//! consistent location. The implementation lives in
+//! [`quarto_source_map`] because it's a pure utility on `SourceInfo`
+//! and `pampa` would otherwise have to duplicate it (no cross-crate
+//! `pampa → quarto-core` dependency).
+
+use quarto_source_map::SourceInfo;
+
+/// Chain-resolve a [`SourceInfo`] to `(file_id, start_offset,
+/// end_offset)` in the root file without requiring a
+/// [`SourceContext`](quarto_source_map::SourceContext).
+///
+/// Returns `None` for `Concat` and `FilterProvenance` — these don't
+/// map cleanly to a single contiguous byte range in v1, and any node
+/// originating from a Lua filter has no source-file provenance to
+/// attribute against.
+pub fn resolve_byte_range(si: &SourceInfo) -> Option<(usize, usize, usize)> {
+    si.resolve_byte_range()
+}

--- a/crates/quarto-core/src/pipeline.rs
+++ b/crates/quarto-core/src/pipeline.rs
@@ -57,26 +57,25 @@ use crate::stage::stages::ApplyTemplateConfig;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::stage::stages::BootstrapJsStage;
 use crate::stage::{
-    ApplyTemplateStage, AstTransformsStage, CompileThemeCssStage, DocumentProfileStage,
-    EngineExecutionStage, IncludeExpansionStage, IncludeResolveStage, LinkResolutionStage,
-    ListingItemInfoStage, LoadedSource, MathJsStage, MetadataMergeStage, ParseDocumentStage,
-    Pipeline, PipelineData, PipelineStage, PreEngineSugaringStage, RenderHtmlBodyStage,
-    ResourceReportStage, StageContext, UnwrapProfileStage, UserFiltersStage,
+    ApplyTemplateStage, AstTransformsStage, AttributionGenerateStage, CompileThemeCssStage,
+    DocumentProfileStage, EngineExecutionStage, IncludeExpansionStage, IncludeResolveStage,
+    LinkResolutionStage, ListingItemInfoStage, LoadedSource, MathJsStage, MetadataMergeStage,
+    ParseDocumentStage, Pipeline, PipelineData, PipelineStage, PreEngineSugaringStage,
+    RenderHtmlBodyStage, ResourceReportStage, StageContext, UnwrapProfileStage, UserFiltersStage,
 };
 use crate::transform::TransformPipeline;
 use crate::transforms::{
-    AppendixStructureTransform, AttributionGenerateTransform, AttributionRenderTransform,
-    AttributionViewerTransform, CalloutResolveTransform, CalloutTransform,
-    CategoriesSidebarTransform, CrossrefIndexTransform, CrossrefRenderTransform,
-    CrossrefResolveTransform, EquationLabelTransform, FloatRefTargetSugarTransform,
-    FooterGenerateTransform, FooterRenderTransform, FootnotesTransform, LinkRewriteTransform,
-    ListingGenerateTransform, ListingRenderTransform, MetadataNormalizeTransform,
-    NavbarGenerateTransform, NavbarRenderTransform, PageNavGenerateTransform,
-    PageNavRenderTransform, ProofSugarTransform, ResourceCollectorTransform, SectionizeTransform,
-    ShortcodeResolveTransform, SidebarGenerateTransform, SidebarRenderTransform,
-    TheoremSugarTransform, TitleBlockTransform, TocGenerateTransform, TocRenderTransform,
-    WebsiteBootstrapIconsTransform, WebsiteCanonicalUrlTransform, WebsiteFaviconTransform,
-    WebsiteTitlePrefixTransform,
+    AppendixStructureTransform, AttributionRenderTransform, AttributionViewerTransform,
+    CalloutResolveTransform, CalloutTransform, CategoriesSidebarTransform, CrossrefIndexTransform,
+    CrossrefRenderTransform, CrossrefResolveTransform, EquationLabelTransform,
+    FloatRefTargetSugarTransform, FooterGenerateTransform, FooterRenderTransform,
+    FootnotesTransform, LinkRewriteTransform, ListingGenerateTransform, ListingRenderTransform,
+    MetadataNormalizeTransform, NavbarGenerateTransform, NavbarRenderTransform,
+    PageNavGenerateTransform, PageNavRenderTransform, ProofSugarTransform,
+    ResourceCollectorTransform, SectionizeTransform, ShortcodeResolveTransform,
+    SidebarGenerateTransform, SidebarRenderTransform, TheoremSugarTransform, TitleBlockTransform,
+    TocGenerateTransform, TocRenderTransform, WebsiteBootstrapIconsTransform,
+    WebsiteCanonicalUrlTransform, WebsiteFaviconTransform, WebsiteTitlePrefixTransform,
 };
 
 /// Well-known path for the default CSS artifact in WASM context.
@@ -293,6 +292,11 @@ pub fn build_html_pipeline_stages_with_options(
     // omits this stage. See bootstrap_js.rs for full rationale.
     #[cfg(not(target_arch = "wasm32"))]
     stages.push(Box::new(BootstrapJsStage::new()));
+    // Attribution-generate runs *before* user filters so the
+    // `quarto.attribution.*` Lua host binding sees a populated
+    // sidecar in both `pre` and `post` filter passes. No-op when
+    // no provider is installed (`ctx.attribution_provider` is None).
+    stages.push(Box::new(AttributionGenerateStage::new()));
     stages.push(Box::new(UserFiltersStage::pre()));
     stages.push(Box::new(AstTransformsStage::new()));
     stages.push(Box::new(UserFiltersStage::post()));
@@ -441,6 +445,8 @@ pub fn build_wasm_html_pipeline() -> Pipeline {
         Box::new(UnwrapProfileStage::new()),
         Box::new(PreEngineSugaringStage::new()),
         Box::new(CompileThemeCssStage::new()),
+        // See native pipeline for the placement rationale.
+        Box::new(AttributionGenerateStage::new()),
         Box::new(UserFiltersStage::pre()),
         Box::new(AstTransformsStage::new()),
         Box::new(UserFiltersStage::post()),
@@ -1032,21 +1038,6 @@ pub fn build_transform_pipeline(
     pipeline.push(Box::new(PageNavRenderTransform::new()));
     pipeline.push(Box::new(FooterRenderTransform::new()));
 
-    // Tail of Navigation Phase: attribution data generation. Reads the
-    // opt-in provider from `ctx.attribution_provider` (installed by the
-    // CLI `--attribution=git` flag plumbing or the WASM
-    // `parse_qmd_to_ast_with_attribution` entry point), calls
-    // `build()`, merges identities with any user-authored
-    // `meta.attribution.identities`, and stores
-    // `ctx.attribution_data`. No-op when no provider is installed —
-    // the unflagged HTML path stays byte-identical. The entire
-    // Finalization Phase runs between this stage and
-    // `AttributionRenderTransform`; no transform there reads or
-    // writes the sidecar. See
-    // `claude-notes/plans/2026-05-06-attribution-pipeline.md` for the
-    // sidecar / placement design notes.
-    pipeline.push(Box::new(AttributionGenerateTransform::new()));
-
     // === FINALIZATION PHASE ===
     // LinkRewriteTransform runs first in the Finalization Phase
     // (Phase 6 of the website-projects epic). It walks every
@@ -1511,7 +1502,7 @@ mod tests {
     #[test]
     fn test_build_html_pipeline_stages() {
         let stages = build_html_pipeline_stages();
-        assert_eq!(stages.len(), 20);
+        assert_eq!(stages.len(), 21);
         assert_eq!(stages[0].name(), "parse-document");
         assert_eq!(stages[1].name(), "metadata-merge");
         // Include expansion runs before the profile checkpoint (bd-xfwx)
@@ -1536,25 +1527,29 @@ mod tests {
         // Bootstrap JS (bd-4eyf) sits immediately after CompileThemeCssStage
         // so the same theme predicate gates JS and CSS together.
         assert_eq!(stages[11].name(), "bootstrap-js");
-        assert_eq!(stages[12].name(), "user-filters-pre");
-        assert_eq!(stages[13].name(), "ast-transforms");
-        assert_eq!(stages[14].name(), "user-filters-post");
+        // Attribution-generate runs before user filters so the
+        // `quarto.attribution.*` Lua host binding sees a populated
+        // sidecar (bd-0fd0). No-op when no provider is installed.
+        assert_eq!(stages[12].name(), "attribution-generate");
+        assert_eq!(stages[13].name(), "user-filters-pre");
+        assert_eq!(stages[14].name(), "ast-transforms");
+        assert_eq!(stages[15].name(), "user-filters-post");
         // bd-o8pr Phase 3: finalize per-doc resource report.
-        assert_eq!(stages[15].name(), "resource-report");
-        assert_eq!(stages[16].name(), "code-highlight");
+        assert_eq!(stages[16].name(), "resource-report");
+        assert_eq!(stages[17].name(), "code-highlight");
         // Math-mode (bd-w5ov) walks the post-transform AST and
         // populates meta.math when math is present. Sits just before
         // render-html-body so any late-introduced math (sugar, user
         // filters, crossref `\tag{N}`) is visible.
-        assert_eq!(stages[17].name(), "math-js");
-        assert_eq!(stages[18].name(), "render-html-body");
-        assert_eq!(stages[19].name(), "apply-template");
+        assert_eq!(stages[18].name(), "math-js");
+        assert_eq!(stages[19].name(), "render-html-body");
+        assert_eq!(stages[20].name(), "apply-template");
     }
 
     #[test]
     fn test_build_html_pipeline() {
         let pipeline = build_html_pipeline();
-        assert_eq!(pipeline.len(), 20);
+        assert_eq!(pipeline.len(), 21);
     }
 
     #[test]
@@ -1568,7 +1563,10 @@ mod tests {
         // metadata is auto-filled symmetrically.
         // Includes `math-js` (bd-w5ov) — math display is safe under
         // hub-client iframe reinit and we want live math in preview.
-        assert_eq!(pipeline.len(), 18);
+        // Includes `attribution-generate` (bd-0fd0) so hub-client
+        // preview filters see the same `quarto.attribution.*` host
+        // binding as the CLI.
+        assert_eq!(pipeline.len(), 19);
         let names = pipeline.stage_names();
         // bd-4eyf: hub-client iframe reinit blows away stateful
         // Bootstrap components, so we deliberately omit `bootstrap-js`

--- a/crates/quarto-core/src/stage/context.rs
+++ b/crates/quarto-core/src/stage/context.rs
@@ -141,13 +141,25 @@ pub struct StageContext {
 
     /// Optional attribution-data producer, set by the CLI
     /// `--attribution` flag plumbing or the WASM
-    /// `parse_qmd_to_ast_with_attribution` entry point and bridged
-    /// into [`crate::transforms::AttributionGenerateTransform`]'s
-    /// inner `RenderContext` by
-    /// [`crate::stage::stages::AstTransformsStage`]. `None` means
-    /// attribution is off for this render — the transform short-
-    /// circuits and the sidecar stays empty.
+    /// `parse_qmd_to_ast_with_attribution` entry point. Consumed by
+    /// [`crate::stage::stages::AttributionGenerateStage`], which
+    /// runs *before* [`UserFiltersStage::pre`] so user filters can
+    /// query attribution via the `quarto.attribution.*` Lua surface.
+    /// `None` means attribution is off for this render — the
+    /// generate stage short-circuits and `attribution_data` stays
+    /// `None`.
     pub attribution_provider: Option<Arc<dyn crate::attribution::AttributionSourceProvider>>,
+
+    /// Per-document attribution sidecar, populated by
+    /// [`crate::stage::stages::AttributionGenerateStage`] before
+    /// user filters run, then bridged into the inner `RenderContext`
+    /// by [`crate::stage::stages::AstTransformsStage`] so
+    /// `AttributionRenderTransform` can bake the writer-side lookup
+    /// table. The Lua host binding registered by
+    /// [`crate::stage::stages::UserFiltersStage`] reads this directly
+    /// to back the `quarto.attribution.*` namespace. `None` when no
+    /// provider was installed.
+    pub attribution_data: Option<Arc<crate::attribution::AttributionData>>,
 
     /// Per-format writer-side options, populated by Render-phase
     /// transforms inside [`crate::stage::stages::AstTransformsStage`]
@@ -222,6 +234,7 @@ impl StageContext {
             observer: Arc::new(NoopObserver),
             cancellation: Cancellation::new(),
             attribution_provider: None,
+            attribution_data: None,
             format_options: crate::render::FormatOptions::default(),
             user_grammar_provider: None,
         })

--- a/crates/quarto-core/src/stage/mod.rs
+++ b/crates/quarto-core/src/stage/mod.rs
@@ -110,9 +110,9 @@ pub use traits::PipelineStage;
 pub use stages::BootstrapJsStage;
 pub use stages::CodeHighlightStage;
 pub use stages::{
-    ApplyTemplateStage, AstTransformsStage, CompileThemeCssStage, DocumentProfileStage,
-    EngineExecutionStage, IncludeExpansionStage, IncludeResolveStage, LinkResolutionStage,
-    ListingItemInfoStage, MathJsStage, MetadataMergeStage, ParseDocumentStage,
+    ApplyTemplateStage, AstTransformsStage, AttributionGenerateStage, CompileThemeCssStage,
+    DocumentProfileStage, EngineExecutionStage, IncludeExpansionStage, IncludeResolveStage,
+    LinkResolutionStage, ListingItemInfoStage, MathJsStage, MetadataMergeStage, ParseDocumentStage,
     PreEngineSugaringStage, RenderHtmlBodyStage, ResourceReportStage, UnwrapProfileStage,
     UserFiltersStage,
 };

--- a/crates/quarto-core/src/stage/stages/ast_transforms.rs
+++ b/crates/quarto-core/src/stage/stages/ast_transforms.rs
@@ -183,14 +183,18 @@ impl PipelineStage for AstTransformsStage {
         // (`LinkRewriteTransform`) consumes it to compute
         // page-relative URLs.
         render_ctx.resource_resolver = ctx.resource_resolver.clone();
-        // Attribution: bridge the opt-in provider from `StageContext`
-        // into the inner `RenderContext` so
-        // `AttributionGenerateTransform` can call `build()` from
-        // inside this stage. The sidecar (`attribution_data`) is
-        // populated on the inner ctx and is consumed by
-        // `AttributionRenderTransform` later in the same stage; it
-        // never needs to leave this scope.
+        // Attribution: bridge both the opt-in provider AND the
+        // sidecar already populated by the upstream
+        // `AttributionGenerateStage` into the inner `RenderContext`.
+        //
+        // `attribution_data` is the load-bearing field —
+        // `AttributionRenderTransform` reads it to bake the
+        // writer-side lookup. The provider is forwarded only for
+        // historical-compat callers that build a fresh inner
+        // pipeline outside the normal stage flow; no transform here
+        // calls `build()` itself anymore.
         render_ctx.attribution_provider = ctx.attribution_provider.clone();
+        render_ctx.attribution_data = ctx.attribution_data.clone();
 
         // Execute the transform pipeline
         let result = pipeline

--- a/crates/quarto-core/src/stage/stages/attribution_generate.rs
+++ b/crates/quarto-core/src/stage/stages/attribution_generate.rs
@@ -1,0 +1,254 @@
+/*
+ * stage/stages/attribution_generate.rs
+ * Copyright (c) 2026 Posit, PBC
+ */
+
+//! Top-level attribution-generate pipeline stage.
+//!
+//! Reads `ctx.attribution_provider` (set by the CLI
+//! `--attribution=git` flag or the WASM
+//! `parse_qmd_to_ast_with_attribution` entry point), calls
+//! `build()`, merges identities with any user-authored
+//! `meta.attribution.identities`, and stores the result on
+//! `ctx.attribution_data`.
+//!
+//! **Pipeline position:** runs immediately before
+//! [`UserFiltersStage::pre`](super::UserFiltersStage) so user
+//! Lua filters can query attribution via the `quarto.attribution.*`
+//! host binding from any pre-phase or post-phase entry point. The
+//! sidecar produced here is later bridged into the inner
+//! `RenderContext` by [`AstTransformsStage`](super::AstTransformsStage)
+//! so [`AttributionRenderTransform`](crate::transforms::AttributionRenderTransform)
+//! can bake the writer-side lookup table.
+//!
+//! No-op (short-circuit return) when:
+//! 1. The target format doesn't consume attribution
+//!    ([`format_supports_attribution`] is `false`).
+//! 2. The document opts out via `attribution: false` in meta.
+//! 3. No provider is installed on [`StageContext`].
+//!
+//! Mirrors the skip ladder in the legacy
+//! `AttributionGenerateTransform`. This stage replaces that transform
+//! in the top-level pipeline; the transform no longer runs from inside
+//! `AstTransformsStage`.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::attribution::{AttributionData, format_supports_attribution, identity_map_from_meta};
+use crate::render::{BinaryDependencies, RenderContext};
+use crate::stage::{
+    EventLevel, PipelineData, PipelineDataKind, PipelineError, PipelineStage, StageContext,
+};
+use crate::trace_event;
+use crate::transforms::is_feature_disabled;
+
+/// Top-level stage that populates [`StageContext::attribution_data`].
+///
+/// See module docs for placement rationale and skip ladder.
+pub struct AttributionGenerateStage;
+
+impl AttributionGenerateStage {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for AttributionGenerateStage {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait(?Send)]
+impl PipelineStage for AttributionGenerateStage {
+    fn name(&self) -> &str {
+        "attribution-generate"
+    }
+
+    fn input_kind(&self) -> PipelineDataKind {
+        PipelineDataKind::DocumentAst
+    }
+
+    fn output_kind(&self) -> PipelineDataKind {
+        PipelineDataKind::DocumentAst
+    }
+
+    async fn run(
+        &self,
+        input: PipelineData,
+        ctx: &mut StageContext,
+    ) -> Result<PipelineData, PipelineError> {
+        let PipelineData::DocumentAst(doc) = input else {
+            return Err(PipelineError::unexpected_input(
+                self.name(),
+                self.input_kind(),
+                input.kind(),
+            ));
+        };
+
+        // Skip ladder, in order:
+        //
+        // 1. Format must consume the lookup. Bail first so opting in
+        //    on a non-HTML target doesn't spawn the provider's
+        //    subprocess for nothing.
+        if !format_supports_attribution(&ctx.format) {
+            return Ok(PipelineData::DocumentAst(doc));
+        }
+
+        // 2. Affirmative `attribution: false` opt-out wins over any
+        //    provider installed by the CLI / WASM entry point.
+        if is_feature_disabled(&doc.ast.meta, "attribution") {
+            return Ok(PipelineData::DocumentAst(doc));
+        }
+
+        // 3. No provider installed → nothing to do; sidecar stays None.
+        let Some(provider) = ctx.attribution_provider.clone() else {
+            return Ok(PipelineData::DocumentAst(doc));
+        };
+
+        // 4. Construct a minimal RenderContext just to call
+        //    `provider.build(...)`. The provider trait takes
+        //    `&RenderContext` for historical reasons; only the
+        //    `binaries.git` and `document.input` fields are read
+        //    (GitBlameProvider). PreBuiltAttributionProvider ignores
+        //    the argument entirely. The temp context's other fields
+        //    are unused.
+        let binaries = BinaryDependencies::discover(ctx.runtime.as_ref());
+        let render_ctx = RenderContext::new(&ctx.project, &ctx.document, &ctx.format, &binaries);
+
+        let AttributionData {
+            runs,
+            mut identities,
+        } = provider
+            .build(&render_ctx)
+            .map_err(|e| PipelineError::stage_error(self.name(), e.to_string()))?;
+
+        // Preserve provider Arc<str> keys on collision (the
+        // interning invariant in `IdentityMap` and `AttributionRun`
+        // depends on `Arc::ptr_eq` between them) — `HashMap::get_mut`
+        // returns a `&mut Identity` without touching the key. Drop
+        // non-colliding user keys (an actor named in YAML but with
+        // no runs in this document is invisible at the writer and
+        // would be dead weight in the map).
+        for (user_key, user_id) in identity_map_from_meta(&doc.ast.meta) {
+            if let Some(slot) = identities.get_mut(&user_key) {
+                *slot = user_id;
+            }
+        }
+
+        ctx.attribution_data = Some(Arc::new(AttributionData { runs, identities }));
+
+        trace_event!(
+            ctx,
+            EventLevel::Debug,
+            "attribution-generate populated sidecar"
+        );
+
+        Ok(PipelineData::DocumentAst(doc))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::attribution::PreBuiltAttributionProvider;
+    use crate::format::Format;
+    use crate::project::{DocumentInfo, ProjectContext};
+    use crate::stage::DocumentAst;
+    use pampa::pandoc::ASTContext;
+    use quarto_pandoc_types::pandoc::Pandoc;
+    use quarto_source_map::SourceContext;
+    use quarto_system_runtime::NativeRuntime;
+    use std::path::PathBuf;
+
+    fn make_ctx(
+        format: Format,
+        provider: Option<Arc<dyn crate::attribution::AttributionSourceProvider>>,
+    ) -> StageContext {
+        let runtime = Arc::new(NativeRuntime::new());
+        let project = ProjectContext {
+            dir: PathBuf::from("/project"),
+            config: crate::project::ProjectConfig::default(),
+            is_single_file: true,
+            files: vec![],
+            output_dir: PathBuf::from("/project"),
+        };
+        let doc = DocumentInfo::from_path("/project/test.qmd");
+        let mut ctx = StageContext::new(runtime, format, project, doc).unwrap();
+        ctx.attribution_provider = provider;
+        ctx
+    }
+
+    fn make_doc() -> DocumentAst {
+        DocumentAst {
+            path: PathBuf::from("/project/test.qmd"),
+            ast: Pandoc {
+                meta: quarto_pandoc_types::ConfigValue::default(),
+                blocks: vec![].into(),
+            },
+            ast_context: ASTContext::default(),
+            source_context: SourceContext::new(),
+            warnings: vec![],
+            recorded_includes: Vec::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn no_provider_leaves_attribution_data_none() {
+        let mut ctx = make_ctx(Format::html(), None);
+        let input = PipelineData::DocumentAst(make_doc());
+        let _ = AttributionGenerateStage::new()
+            .run(input, &mut ctx)
+            .await
+            .unwrap();
+        assert!(
+            ctx.attribution_data.is_none(),
+            "no provider installed → sidecar must stay None"
+        );
+    }
+
+    #[tokio::test]
+    async fn provider_populates_attribution_data() {
+        // Minimal transport JSON: one run, one identity.
+        let json = r##"{
+            "runs": [{"start": 0, "end": 5, "actor": "alice@example.com", "time": 1000}],
+            "identities": {
+                "alice@example.com": {"name": "Alice", "color": "#ff0000"}
+            }
+        }"##;
+        let provider: Arc<dyn crate::attribution::AttributionSourceProvider> =
+            Arc::new(PreBuiltAttributionProvider::new(json.to_string()));
+        let mut ctx = make_ctx(Format::html(), Some(provider));
+        let input = PipelineData::DocumentAst(make_doc());
+        let _ = AttributionGenerateStage::new()
+            .run(input, &mut ctx)
+            .await
+            .unwrap();
+        let data = ctx.attribution_data.expect("provider populates sidecar");
+        assert_eq!(data.runs.len(), 1);
+        assert_eq!(data.identities.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn non_html_format_skips_provider_invocation() {
+        // q2-debug parses as HTML but other formats short-circuit.
+        // Use a JSON-like format identifier to hit the skip path.
+        let mut format = Format::html();
+        format.identifier = crate::format::FormatIdentifier::Revealjs;
+        let json = r#"{"runs": [], "identities": {}}"#;
+        let provider: Arc<dyn crate::attribution::AttributionSourceProvider> =
+            Arc::new(PreBuiltAttributionProvider::new(json.to_string()));
+        let mut ctx = make_ctx(format, Some(provider));
+        let input = PipelineData::DocumentAst(make_doc());
+        let _ = AttributionGenerateStage::new()
+            .run(input, &mut ctx)
+            .await
+            .unwrap();
+        assert!(
+            ctx.attribution_data.is_none(),
+            "non-attribution-consuming format must skip"
+        );
+    }
+}

--- a/crates/quarto-core/src/stage/stages/mod.rs
+++ b/crates/quarto-core/src/stage/stages/mod.rs
@@ -23,6 +23,7 @@
 
 mod apply_template;
 mod ast_transforms;
+mod attribution_generate;
 // Bootstrap JS is a native-only stage: hub-client's iframe-per-render
 // preview blows away stateful Bootstrap components, and excluding the
 // stage on WASM keeps the 80KB bundle out of the WASM binary. See the
@@ -51,6 +52,7 @@ mod user_filters;
 
 pub use apply_template::{ApplyTemplateConfig, ApplyTemplateStage};
 pub use ast_transforms::AstTransformsStage;
+pub use attribution_generate::AttributionGenerateStage;
 #[cfg(not(target_arch = "wasm32"))]
 pub use bootstrap_js::BootstrapJsStage;
 pub use code_highlight::CodeHighlightStage;

--- a/crates/quarto-core/src/stage/stages/user_filters.rs
+++ b/crates/quarto-core/src/stage/stages/user_filters.rs
@@ -133,6 +133,18 @@ impl PipelineStage for UserFiltersStage {
 
         let target_format = ctx.format.identifier.as_str();
 
+        // Build the attribution lookup handle when a sidecar is
+        // present. `AttributionGenerateStage` runs before this stage
+        // on both pre and post sub-passes, so the sidecar (when
+        // attribution is on) is already populated. The handle is
+        // cheap — wraps an `Arc<AttributionData>`.
+        let attribution: Option<std::sync::Arc<dyn pampa::attribution::AttributionLookup>> =
+            ctx.attribution_data.as_ref().map(|data| {
+                std::sync::Arc::new(crate::attribution::AttributionLookupHandle::new(
+                    data.clone(),
+                )) as std::sync::Arc<dyn pampa::attribution::AttributionLookup>
+            });
+
         // The Lua filter future is !Send (mlua::Lua is !Send), but this
         // pipeline stage runs under #[async_trait] which requires Send on native.
         // On WASM (single-threaded, ?Send), we can .await directly.
@@ -142,28 +154,31 @@ impl PipelineStage for UserFiltersStage {
             let ast = doc.ast;
             let ast_context = doc.ast_context;
             let runtime = ctx.runtime.clone();
+            let attribution = attribution.clone();
             tokio::task::block_in_place(|| {
                 let rt = tokio::runtime::Builder::new_current_thread()
                     .enable_all()
                     .build()
                     .map_err(|e| PipelineError::stage_error(self.name(), e.to_string()))?;
-                rt.block_on(pampa::unified_filter::apply_filters(
+                rt.block_on(pampa::unified_filter::apply_filters_with_attribution(
                     ast,
                     ast_context,
                     filters,
                     target_format,
                     runtime,
+                    attribution,
                 ))
                 .map_err(|e| PipelineError::stage_error(self.name(), e.to_string()))
             })
         };
         #[cfg(target_arch = "wasm32")]
-        let filter_result = pampa::unified_filter::apply_filters(
+        let filter_result = pampa::unified_filter::apply_filters_with_attribution(
             doc.ast,
             doc.ast_context,
             filters,
             target_format,
             ctx.runtime.clone(),
+            attribution,
         )
         .await
         .map_err(|e| PipelineError::stage_error(self.name(), e.to_string()));

--- a/crates/quarto-core/src/stage/stages/user_filters.rs
+++ b/crates/quarto-core/src/stage/stages/user_filters.rs
@@ -160,7 +160,7 @@ impl PipelineStage for UserFiltersStage {
                     .enable_all()
                     .build()
                     .map_err(|e| PipelineError::stage_error(self.name(), e.to_string()))?;
-                rt.block_on(pampa::unified_filter::apply_filters_with_attribution(
+                rt.block_on(pampa::unified_filter::apply_filters(
                     ast,
                     ast_context,
                     filters,
@@ -172,7 +172,7 @@ impl PipelineStage for UserFiltersStage {
             })
         };
         #[cfg(target_arch = "wasm32")]
-        let filter_result = pampa::unified_filter::apply_filters_with_attribution(
+        let filter_result = pampa::unified_filter::apply_filters(
             doc.ast,
             doc.ast_context,
             filters,

--- a/crates/quarto-core/src/transforms/attribution_render.rs
+++ b/crates/quarto-core/src/transforms/attribution_render.rs
@@ -67,7 +67,7 @@ use quarto_source_map::SourceInfo;
 use crate::Result;
 use crate::attribution::{
     AttributionMap, AttributionRecord, AttributionSource, Identity, IdentityMap,
-    attribution_viewer_enabled_from_meta,
+    attribution_viewer_enabled_from_meta, resolve_byte_range,
 };
 use crate::render::RenderContext;
 use crate::transform::AstTransform;
@@ -174,33 +174,6 @@ fn query_attribution(si: &SourceInfo, runs: &AttributionMap) -> Option<Attributi
         return None;
     }
     runs.query_byte_range(start, end)
-}
-
-/// Chain-resolve a [`SourceInfo`] to `(file_id, start_offset,
-/// end_offset)` in the root file without requiring a
-/// [`SourceContext`](quarto_source_map::SourceContext).
-///
-/// Returns `None` for `Concat` and `FilterProvenance` — these don't
-/// map cleanly to a single contiguous byte range in v1, and any node
-/// originating from a Lua filter has no source-file provenance to
-/// attribute against.
-fn resolve_byte_range(si: &SourceInfo) -> Option<(usize, usize, usize)> {
-    match si {
-        SourceInfo::Original {
-            file_id,
-            start_offset,
-            end_offset,
-        } => Some((file_id.0, *start_offset, *end_offset)),
-        SourceInfo::Substring {
-            parent,
-            start_offset,
-            end_offset,
-        } => {
-            let (fid, parent_start, _) = resolve_byte_range(parent)?;
-            Some((fid, parent_start + start_offset, parent_start + end_offset))
-        }
-        SourceInfo::Concat { .. } | SourceInfo::FilterProvenance { .. } => None,
-    }
 }
 
 fn visit_block(

--- a/crates/quarto-source-map/src/source_info.rs
+++ b/crates/quarto-source-map/src/source_info.rs
@@ -205,6 +205,33 @@ impl SourceInfo {
         }
     }
 
+    /// Chain-resolve to `(file_id, start_offset, end_offset)` in the
+    /// root source file.
+    ///
+    /// Returns `None` for `Concat` and `FilterProvenance` — these
+    /// don't map cleanly to a single contiguous byte range. The
+    /// attribution v1 sidecar relies on this contract; project-scoped
+    /// (v2) features that need the full chain resolver should use
+    /// `map_offset` against a `SourceContext` instead.
+    pub fn resolve_byte_range(&self) -> Option<(usize, usize, usize)> {
+        match self {
+            SourceInfo::Original {
+                file_id,
+                start_offset,
+                end_offset,
+            } => Some((file_id.0, *start_offset, *end_offset)),
+            SourceInfo::Substring {
+                parent,
+                start_offset,
+                end_offset,
+            } => {
+                let (fid, parent_start, _) = parent.resolve_byte_range()?;
+                Some((fid, parent_start + start_offset, parent_start + end_offset))
+            }
+            SourceInfo::Concat { .. } | SourceInfo::FilterProvenance { .. } => None,
+        }
+    }
+
     /// Remap every `FileId` referenced by this `SourceInfo` (including those
     /// inside `Substring` parents and `Concat` pieces) using the provided
     /// mapping function.

--- a/docs/authoring/attribution.qmd
+++ b/docs/authoring/attribution.qmd
@@ -205,6 +205,82 @@ in-product toggle and renderer-side colouring are still in
 development — when they land, an "Authorship" control will appear in
 the document settings.
 
+## Using attribution in Lua filters
+
+When a provider is installed (`--attribution=git` on the CLI, or the
+hub-client preview path), user Lua filters can query the same
+attribution sidecar through the `quarto.attribution.*` host binding.
+Both pre-phase (`pre-quarto`) and post-phase filters see it.
+
+### Example: colour spans by author
+
+```lua
+function Span(elem)
+    local hit = quarto.attribution.lookup(elem)
+    if hit then
+        local attr = pandoc.Attr(
+            elem.attr.identifier,
+            elem.attr.classes,
+            { ["data-author"] = hit.name, ["style"] = "color: " .. hit.color }
+        )
+        return pandoc.Span(elem.content, attr)
+    end
+    return elem
+end
+```
+
+`quarto.attribution.lookup(el)` returns either `nil` or a table:
+
+```lua
+{
+    actor = "alice@example.com",  -- the producer's actor id (email for git)
+    time  = 1715000000000,        -- Unix epoch milliseconds
+    name  = "Alice",              -- resolved display name
+    color = "#ff0000",            -- resolved CSS-compatible colour
+}
+```
+
+It returns `nil` when:
+
+- the element has no source-file provenance (synthesised nodes,
+  `RawInline`/`RawBlock` injected by upstream filters);
+- the resolved file ID is non-primary (v1 is single-document — a node
+  spliced in via `{{< include other.qmd >}}` returns `nil`);
+- no run in the sidecar overlaps the element's byte range;
+- no provider is installed (i.e. attribution is off).
+
+### Primitive: arbitrary byte ranges
+
+When you have explicit `(start, end)` offsets — say from a custom
+text-walking transform — bypass element lookup with the raw form:
+
+```lua
+local raw = quarto.attribution.lookup_range(0, 100)
+-- => { actor = "alice@example.com", time = 1715000000000 }
+--    (no `name`/`color` — identity is *not* joined for the raw call)
+```
+
+Use `quarto.attribution.identities()` to look identities up
+separately:
+
+```lua
+local idents = quarto.attribution.identities()
+local alice = idents["alice@example.com"]
+-- alice = { name = "Alice", color = "#ff0000" }
+```
+
+The identity map is read-only and empty when no provider is
+installed.
+
+### Read-only contract
+
+The Lua binding is v1 read-only. There is no
+`quarto.attribution.set(el, actor, time)` — filters can transform the
+AST freely, but the underlying attribution sidecar is derived from
+the source (`git blame` for the CLI; Automerge edit history for the
+hub-client preview) and is not user-mutable. Bake whatever
+presentation you want from the read side instead.
+
 ## Current limits
 
 - **Single-document blame only.** Content spliced in via


### PR DESCRIPTION
Closes #211.

- Adds the `quarto.attribution.*` Lua host binding: `lookup(el)`, `lookup_range(start, end)`, `identities()` — backed by `AttributionMap::query_byte_range` (O(log N), no AST mutation).
- Exposes `el.source_info:byte_range()` / `:file_id()` on Block and Inline userdata so filters can derive byte coordinates.
- Lifts the generate step to a top-level `AttributionGenerateStage` running before `UserFiltersStage::pre`, threading the sidecar onto `StageContext`, so user filters always see attribution whenever a provider is installed.
- Documents the contract with a worked colour-by-author example in `docs/authoring/attribution.qmd`.

### Example

- Add author badges using a Lua filter:
<img width="785" height="497" alt="Screenshot 2026-05-18 at 12 16 23" src="https://github.com/user-attachments/assets/45912027-a798-4df6-89e6-8c6b2c3999c2" />
