### PR TITLE
fix(pampa): treat parse as clean when tree has no ERROR nodes

### DIFF
--- a/crates/pampa/src/readers/qmd.rs
+++ b/crates/pampa/src/readers/qmd.rs
@@ -120,28 +120,33 @@ pub fn read<T: Write>(
             writeln!(output_stream, "---").unwrap();
         });
         if log_observer.had_errors() {
-            // Produce structured DiagnosticMessage objects with proper source locations
-            let mut diagnostics = produce_diagnostic_messages(
-                input_bytes,
-                &log_observer,
-                filename,
-                &context.source_context,
-            );
+            use crate::readers::qmd_error_messages::{
+                collect_error_node_ranges, get_outer_error_nodes, prune_diagnostics_by_error_nodes,
+            };
 
-            // Prune diagnostics based on ERROR nodes if enabled
-            if prune_errors {
-                use crate::readers::qmd_error_messages::{
-                    collect_error_node_ranges, get_outer_error_nodes,
-                    prune_diagnostics_by_error_nodes,
-                };
+            // GLR speculative parsing can hit detect_error in dead branches
+            // while another branch reaches accept cleanly. When that happens,
+            // the final tree has no ERROR nodes and the parse is genuinely
+            // successful — we should not report speculative errors from dead
+            // branches. Use the presence of ERROR nodes in the tree as the
+            // ground truth for whether the parse actually failed.
+            let error_nodes = collect_error_node_ranges(&tree);
+            if !error_nodes.is_empty() {
+                let mut diagnostics = produce_diagnostic_messages(
+                    input_bytes,
+                    &log_observer,
+                    filename,
+                    &context.source_context,
+                );
 
-                let error_nodes = collect_error_node_ranges(&tree);
-                let outer_nodes = get_outer_error_nodes(&error_nodes);
-                diagnostics =
-                    prune_diagnostics_by_error_nodes(diagnostics, &error_nodes, &outer_nodes);
+                if prune_errors {
+                    let outer_nodes = get_outer_error_nodes(&error_nodes);
+                    diagnostics =
+                        prune_diagnostics_by_error_nodes(diagnostics, &error_nodes, &outer_nodes);
+                }
+
+                return Err(diagnostics);
             }
-
-            return Err(diagnostics);
         }
     }
 

--- a/crates/pampa/tests/test_glr_dead_branch_speculation.rs
+++ b/crates/pampa/tests/test_glr_dead_branch_speculation.rs
@@ -1,0 +1,41 @@
+use pampa::readers;
+
+fn assert_parses_cleanly(input: &str, filename: &str) {
+    let mut content = input.to_string();
+    if !content.ends_with('\n') {
+        content.push('\n');
+    }
+
+    let result = readers::qmd::read(
+        content.as_bytes(),
+        false,
+        filename,
+        &mut std::io::sink(),
+        true,
+        None,
+    );
+
+    if let Err(diagnostics) = result {
+        let mut source_context = quarto_source_map::SourceContext::new();
+        source_context.add_file(filename.to_string(), Some(content.clone()));
+        let render_options = quarto_error_reporting::TextRenderOptions {
+            enable_hyperlinks: false,
+        };
+        let mut output = String::new();
+        for diagnostic in &diagnostics {
+            output
+                .push_str(&diagnostic.to_text_with_options(Some(&source_context), &render_options));
+            output.push('\n');
+        }
+        panic!("Expected clean parse for input:\n{content}\nGot diagnostics:\n{output}");
+    }
+}
+
+#[test]
+fn nested_double_quote_inside_emphasis_parses_cleanly() {
+    // `*a" b."*` is `<em>a"b."</em>` where the two `"` form a paired
+    // double-quote span. GLR speculation hits detect_error in dead
+    // branches; the parse as a whole accepts cleanly and the resulting
+    // tree has no ERROR nodes, so no diagnostics should be reported.
+    assert_parses_cleanly("*a\" b.\"*\n", "nested-double-quote-in-emphasis.qmd");
+}


### PR DESCRIPTION
This fix was buried in #217 - surfacing it as its own PR.

GLR speculative parsing can hit `detect_error` in dead branches while another branch reaches accept cleanly. Previously the qmd reader reported diagnostics whenever `log_observer.had_errors()` was true, including the speculative errors from those dead branches, even when the resulting tree was free of ERROR nodes.

Use the presence of `ERROR` nodes in the final tree as the ground truth for whether the parse actually failed. When `had_errors()` is true but `collect_error_node_ranges(&tree)` is empty, fall through to the success path.

Visible fix: `*a" b."*` now parses cleanly as `<em>a"b."</em>` (the two `"` form a paired double-quote span); previously it emitted a spurious "unclosed `*`" diagnostic for the outer emphasis.

Tests
-----
New regression file `crates/pampa/tests/test_glr_dead_branch_speculation.rs` with `nested_double_quote_inside_emphasis_parses_cleanly` verifying `*a" b."*` produces no diagnostics. Verified failing on main HEAD prior to the fix, passing after.

`cargo nextest run -p pampa` → 3760 passed.