### PR TITLE
Avoid nondeterministic diagnostic message (#222)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4138,6 +4138,7 @@ dependencies = [
 name = "quarto-parse-errors"
 version = "0.1.0"
 dependencies = [
+ "hashlink",
  "quarto-error-message-macros",
  "quarto-error-reporting",
  "quarto-source-map",

--- a/claude-notes/issue-reports/222/repro.qmd
+++ b/claude-notes/issue-reports/222/repro.qmd
@@ -1,0 +1,1 @@
+The "_blank" word.

--- a/claude-notes/issue-reports/222/triage.md
+++ b/claude-notes/issue-reports/222/triage.md
@@ -9,9 +9,9 @@
 
 ## Summary
 
-Reproduced. The tree-sitter parse trace is byte-identical across runs (verified across 15 runs), so the GLR parser itself is deterministic on this input. **All of the nondeterminism is downstream**, in `quarto-parse-errors`: a `HashMap<usize, TreeSitterProcessLog>` keyed by GLR version number is iterated by `.values()` to extract diagnostic states, and a `(row, column)` dedupe drops every state but the first. With three GLR branches all hitting `detect_error` at `(row=0, col=18)`, whichever HashMap bucket is iterated first wins. Default `RandomState` randomizes per process. Confirmed by swapping `HashMap` → `BTreeMap` locally — 30/30 runs then produce Variant A. Fix is one line; the recommendation below sticks with BTreeMap, but lists the alternatives and the audit obligations.
+Reproduced. The tree-sitter parse trace is byte-identical across runs (verified across 15 runs), so the GLR parser itself is deterministic on this input. **All of the nondeterminism is downstream**, in `quarto-parse-errors`: a `HashMap<usize, TreeSitterProcessLog>` keyed by GLR version number is iterated by `.values()` to extract diagnostic states, and a `(row, column)` dedupe drops every state but the first. With three GLR branches all hitting `detect_error` at `(row=0, col=18)`, whichever HashMap bucket is iterated first wins. Default `RandomState` randomizes per process. Confirmed by swapping `HashMap` → both `BTreeMap` and `hashlink::LinkedHashMap` locally — each gives 30/30 runs the same diagnostic (Variant A). Fix is one line; the recommendation below uses `LinkedHashMap` to match the convention already used elsewhere in the workspace.
 
-The user's clarification on the ticket is "either diagnostic is acceptable, as long as the tie is always broken consistently to one of them." Both `HashMap`→`BTreeMap` (deterministically pick lowest GLR version) and `HashMap`→sort-then-iterate satisfy that.
+The user's clarification on the ticket is "either diagnostic is acceptable, as long as the tie is always broken consistently to one of them." Both `LinkedHashMap` (preserves insertion order — tree-sitter inserts version 0 first) and `BTreeMap` (sorts by key — version 0 is lowest) satisfy that. They give identical output on this input because tree-sitter inserts GLR versions in numeric order.
 
 ## Reproduction
 
@@ -75,9 +75,12 @@ The final `sort_by_key` on `start_offset` is a red herring: the first diagnostic
 
 ### Step 3 — confirm the fix
 
-Local experimental change to `tree_sitter_log.rs`: `use std::collections::BTreeMap as HashMap;` (so `processes` becomes a `BTreeMap<usize, …>` everywhere it's used).
+Two local experimental changes to `tree_sitter_log.rs`, each tried independently:
 
-Result: 30/30 runs produce Variant A (Q-2-5 Underscore Emphasis). BTreeMap iterates keys in ascending order ⇒ GLR version 0 wins ⇒ Variant A. Reverted the change before recording this triage.
+1. `use std::collections::BTreeMap as HashMap;` — 30/30 runs produce Variant A. BTreeMap iterates keys in ascending order ⇒ GLR version 0 wins.
+2. `use hashlink::LinkedHashMap as HashMap;` (plus `hashlink = "0.11"` added to `crates/quarto-parse-errors/Cargo.toml`) — 30/30 runs produce Variant A. LinkedHashMap preserves insertion order; tree-sitter inserts version 0 first on this trace, so version 0 wins.
+
+Both reverted before recording this triage. Recommended fix is LinkedHashMap because the rest of the workspace already uses `hashlink::LinkedHashMap` for the same kind of deterministic-iteration requirement (8 crates, including `crates/pampa/src/readers/json.rs`).
 
 ### Step 4 — audit for other order-dependent HashMap/HashSet in the diagnostic path
 
@@ -101,13 +104,14 @@ So the production fix is one site. The audit conclusion is that there is no othe
 - *Is the tree-sitter parse non-deterministic?* No. Trace is byte-identical across 15 runs.
 - *Is the variation only in the second diagnostic?* Yes. The first diagnostic (Q-2-11 at col 13) comes from a process that hits its `detect_error` at a different `(row, column)` than the others (col 12-ish vs col 18), so the dedupe doesn't apply. Only the col-18 trio competes.
 - *Does the final `sort_by_key` matter?* No. The first/second diagnostics are at different columns, so sorting never reorders them.
-- *Is BTreeMap (version 0 wins) the right tie-break?* Acceptable per the user's clarification ("either diagnostic is acceptable, as long as the tie is always broken consistently"). Variant A is also the trace's "main line" (version 0 is the version that continued through the recovery), so it has weak intuitive grounding.
+- *Is "GLR version 0 wins" the right tie-break?* Acceptable per the user's clarification ("either diagnostic is acceptable, as long as the tie is always broken consistently"). Variant A is also the trace's "main line" (version 0 is the version that continued through the recovery), so it has weak intuitive grounding.
+- *LinkedHashMap or BTreeMap?* LinkedHashMap, to stay consistent with the workspace's existing convention for "iteration order must be deterministic" containers (see `pampa/src/readers/json.rs`, plus 7 other crates using `hashlink`). On this trace they produce identical output because tree-sitter inserts GLR versions in numeric order.
 
 ## Outcome / recommended next step
 
 Filed bd-hwdlq with the fix scope:
 
-1. **Fix**: change `processes: HashMap<usize, TreeSitterProcessLog>` to `BTreeMap<usize, TreeSitterProcessLog>` in `crates/quarto-parse-errors/src/tree_sitter_log.rs:48`. Localized, one import + one type swap. Adjust `processes: HashMap::new()` at the call sites accordingly (or keep an `HashMap as` re-alias).
+1. **Fix**: change `processes: HashMap<usize, TreeSitterProcessLog>` to `hashlink::LinkedHashMap<usize, TreeSitterProcessLog>` in `crates/quarto-parse-errors/src/tree_sitter_log.rs:48`. Localized: one import swap (`use std::collections::HashMap;` → `use hashlink::LinkedHashMap as HashMap;` keeps the in-file name `HashMap` working), one initializer (`HashMap::new()` at line 181 stays compiled-the-same thanks to the alias), and `hashlink = "0.11"` added to `crates/quarto-parse-errors/Cargo.toml`. No other call sites need to change.
 
 2. **Regression test**: add a test that parses the issue-222 input N times in-process (e.g. N=20) and asserts that all N runs produce byte-identical diagnostic output. The test will fail on the current code (probabilistically — N=20 has ≥99.9% chance of failure with the observed 63/37 split) and pass under the fix. Place under `crates/pampa/tests/` or in a new test on `quarto-parse-errors`.
 

--- a/claude-notes/issue-reports/222/triage.md
+++ b/claude-notes/issue-reports/222/triage.md
@@ -1,0 +1,153 @@
+# Issue #222 — Non-deterministic diagnostic output
+
+- **GitHub**: https://github.com/quarto-dev/q2/issues/222
+- **Reporter**: @rundel (Colin Rundel), 2026-05-21
+- **Triage date**: 2026-05-20
+- **Worktree**: `.worktrees/issue-222` (branch `issue-222`, based on `main` @ `99e7f89c`)
+- **Beads issue**: bd-hwdlq
+- **Scope**: the variable second diagnostic (Q-2-5 Underscore vs. second Q-2-11 Double Quote) on the reported input. Both variants share the same first diagnostic, which is not in scope.
+
+## Summary
+
+Reproduced. The tree-sitter parse trace is byte-identical across runs (verified across 15 runs), so the GLR parser itself is deterministic on this input. **All of the nondeterminism is downstream**, in `quarto-parse-errors`: a `HashMap<usize, TreeSitterProcessLog>` keyed by GLR version number is iterated by `.values()` to extract diagnostic states, and a `(row, column)` dedupe drops every state but the first. With three GLR branches all hitting `detect_error` at `(row=0, col=18)`, whichever HashMap bucket is iterated first wins. Default `RandomState` randomizes per process. Confirmed by swapping `HashMap` → `BTreeMap` locally — 30/30 runs then produce Variant A. Fix is one line; the recommendation below sticks with BTreeMap, but lists the alternatives and the audit obligations.
+
+The user's clarification on the ticket is "either diagnostic is acceptable, as long as the tie is always broken consistently to one of them." Both `HashMap`→`BTreeMap` (deterministically pick lowest GLR version) and `HashMap`→sort-then-iterate satisfy that.
+
+## Reproduction
+
+```bash
+printf -- 'The "_blank" word.' | cargo run --bin pampa -- --no-prune-errors
+```
+
+Run repeatedly. Across 30 runs at `99e7f89c` on macOS arm64:
+
+| Variant | Second diagnostic | Count |
+|---|---|---|
+| A | `Q-2-5` Unclosed Underscore Emphasis @ col 19 | 19 / 30 (63%) |
+| B | `Q-2-11` Unclosed Double Quote with opener at col 5 @ col 19 | 11 / 30 (37%) |
+
+The first diagnostic — `Q-2-11` Unclosed Double Quote with opener at col 13 — is the same in both.
+
+Fixture: `repro.qmd` next to this file.
+
+## Investigation
+
+### Step 1 — is the tree-sitter parse itself deterministic?
+
+Captured the verbose tree-sitter parse trace (`-v`) into `/tmp/issue222/run-1.txt … run-15.txt`. Diffed the trace portion (`tree-sitter parse:` … `---`) across all 15 runs. **Byte-identical, every pair.** Runs that produced Variant A and runs that produced Variant B have the same parse trace.
+
+This rules out tree-sitter (the upstream C library), the `tree-sitter-qmd` grammar, and the GLR scheduling — those all run identically every time. The trace itself records three concurrent GLR versions (`version_count:3`) splitting at column 12 after the `_whitespace` recovery, then condensing at the close of the block.
+
+### Step 2 — where does the variation enter?
+
+The diagnostic generator pulls error states off the parse log, not off the final concrete syntax tree:
+
+- `crates/pampa/src/readers/qmd.rs:124` calls `produce_diagnostic_messages(input_bytes, &log_observer, …)`.
+- `crates/quarto-parse-errors/src/error_generation.rs:43-62`:
+
+  ```rust
+  for parse in &tree_sitter_log.parses {
+      for process_log in parse.processes.values() {     // <-- HashMap iteration
+          for state in process_log.error_states.iter() {
+              if seen_errors.contains(&(state.row, state.column)) {
+                  continue;
+              }
+              seen_errors.insert((state.row, state.column));
+              let diagnostic = error_diagnostic_from_parse_state(…);
+              result.push(diagnostic);
+          }
+      }
+  }
+  result.sort_by_key(|diag| diag.location.as_ref().map_or(0, |loc| loc.start_offset()));
+  ```
+
+- `crates/quarto-parse-errors/src/tree_sitter_log.rs:48`:
+
+  ```rust
+  pub processes: HashMap<usize, TreeSitterProcessLog>,
+  ```
+
+  with `use std::collections::HashMap` at line 11. Default `RandomState` ⇒ iteration order varies per process.
+
+The three GLR branches each push a `ProcessMessage` to their own `error_states` at the same `(row=0, column=18)` (this is what tree-sitter reports for col 19 1-indexed). The dedupe lets exactly one through. *Which one* depends on HashMap iteration order — which is the bug.
+
+The final `sort_by_key` on `start_offset` is a red herring: the first diagnostic is at col 13, the second at col 19, so the sort never changes the order; it just confirms the second slot is always "whatever survives the dedupe."
+
+### Step 3 — confirm the fix
+
+Local experimental change to `tree_sitter_log.rs`: `use std::collections::BTreeMap as HashMap;` (so `processes` becomes a `BTreeMap<usize, …>` everywhere it's used).
+
+Result: 30/30 runs produce Variant A (Q-2-5 Underscore Emphasis). BTreeMap iterates keys in ascending order ⇒ GLR version 0 wins ⇒ Variant A. Reverted the change before recording this triage.
+
+### Step 4 — audit for other order-dependent HashMap/HashSet in the diagnostic path
+
+Grep across `crates/quarto-parse-errors/`, `crates/pampa/src/readers/`, and `crates/quarto-error-reporting/`. Findings:
+
+- `tree_sitter_log.rs:48` — `processes: HashMap<usize, _>`. **Iterated in `error_generation.rs:44` and `tree_sitter_log.rs:72` (`is_good`).** The `is_good` iteration is a boolean AND over all values — order-independent. The `error_generation.rs:44` iteration is the bug.
+- `error_generation.rs:40` — `seen_errors: HashSet<(usize, usize)>`. Used only for `contains` / `insert`. Set membership is order-independent.
+- `error_generation.rs:358` and `pampa/.../qmd_error_messages.rs:100` — both reach into `parse.processes[&0]` (hardcoded GLR version 0). Already deterministic.
+- `error_generation.rs:648` — `kept_set: HashSet<usize>` built from a `kept_indices` Vec; used for membership only.
+- `error_generation.rs:666` — HashMap inside a unit test. Not user-facing.
+
+So the production fix is one site. The audit conclusion is that there is no other latent non-determinism in this pipeline.
+
+## Localization
+
+- **The bug**: `crates/quarto-parse-errors/src/tree_sitter_log.rs:48` (HashMap declaration) → `crates/quarto-parse-errors/src/error_generation.rs:44` (iteration site).
+- **Working analogue**: `error_generation.rs:361` and `qmd_error_messages.rs:103` already pin to `parse.processes[&0]`, which sidesteps the issue but loses information from non-zero GLR versions. Fine for the JSON-corpus path which only needs the main parse; not appropriate for `produce_diagnostic_messages` which needs to see all versions.
+
+## Open questions — resolved during triage
+
+- *Is the tree-sitter parse non-deterministic?* No. Trace is byte-identical across 15 runs.
+- *Is the variation only in the second diagnostic?* Yes. The first diagnostic (Q-2-11 at col 13) comes from a process that hits its `detect_error` at a different `(row, column)` than the others (col 12-ish vs col 18), so the dedupe doesn't apply. Only the col-18 trio competes.
+- *Does the final `sort_by_key` matter?* No. The first/second diagnostics are at different columns, so sorting never reorders them.
+- *Is BTreeMap (version 0 wins) the right tie-break?* Acceptable per the user's clarification ("either diagnostic is acceptable, as long as the tie is always broken consistently"). Variant A is also the trace's "main line" (version 0 is the version that continued through the recovery), so it has weak intuitive grounding.
+
+## Outcome / recommended next step
+
+Filed bd-hwdlq with the fix scope:
+
+1. **Fix**: change `processes: HashMap<usize, TreeSitterProcessLog>` to `BTreeMap<usize, TreeSitterProcessLog>` in `crates/quarto-parse-errors/src/tree_sitter_log.rs:48`. Localized, one import + one type swap. Adjust `processes: HashMap::new()` at the call sites accordingly (or keep an `HashMap as` re-alias).
+
+2. **Regression test**: add a test that parses the issue-222 input N times in-process (e.g. N=20) and asserts that all N runs produce byte-identical diagnostic output. The test will fail on the current code (probabilistically — N=20 has ≥99.9% chance of failure with the observed 63/37 split) and pass under the fix. Place under `crates/pampa/tests/` or in a new test on `quarto-parse-errors`.
+
+3. **Audit follow-up** *(optional, not required for this fix)*: grep for `HashMap<.*Log\|HashMap<.*Diagnostic\|HashMap<.*Error` across the crate tree and verify each iteration site either preserves insertion order or sorts. We did the diagnostic-path audit here; broader codebase audit is orthogonal.
+
+## Verification commands used
+
+```bash
+# Pre-flight (Rust side only — hub-client tests fail on this fresh worktree
+# due to wasm-quarto-hub-client not being built, unrelated to issue #222)
+cargo xtask verify --skip-hub-build --skip-hub-tests --skip-shared-package-tests \
+                   --skip-trace-viewer-build --skip-trace-viewer-tests \
+                   --skip-q2-preview-spa-build
+
+# Reproduce (with variant counter)
+for i in $(seq 1 30); do
+  out=$(printf -- 'The "_blank" word.' | cargo run --bin pampa --quiet -- --no-prune-errors 2>&1)
+  if echo "$out" | grep -q "Q-2-5"; then echo "A"; else echo "B"; fi
+done | sort | uniq -c
+
+# Trace determinism check
+for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
+  printf -- 'The "_blank" word.' | cargo run --bin pampa --quiet -- --no-prune-errors -v \
+    > /tmp/issue222/run-$i.txt 2>&1
+done
+for i in 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
+  diff -q <(awk '/tree-sitter parse:/,/^---$/' /tmp/issue222/run-1.txt) \
+          <(awk '/tree-sitter parse:/,/^---$/' /tmp/issue222/run-$i.txt)
+done
+
+# Fix-confirmation experiment (REVERTED before committing this triage):
+#   `use std::collections::HashMap;` -> `use std::collections::BTreeMap as HashMap;`
+#   in crates/quarto-parse-errors/src/tree_sitter_log.rs
+#   then re-run the variant counter -> 30/30 Variant A.
+```
+
+## Cross-references
+
+- Issue: https://github.com/quarto-dev/q2/issues/222
+- Reporter: @rundel
+- Code: `crates/quarto-parse-errors/src/{tree_sitter_log.rs, error_generation.rs}`
+- Caller: `crates/pampa/src/readers/qmd.rs:124`
+- Project rule on HashMap nondeterminism: noted in passing in the conversation; no explicit `CLAUDE.md` rule yet (recommend one if the audit follow-up surfaces more instances).

--- a/claude-notes/plans/2026-05-20-issue-222-deterministic-diagnostics.md
+++ b/claude-notes/plans/2026-05-20-issue-222-deterministic-diagnostics.md
@@ -1,0 +1,102 @@
+# Plan: deterministic diagnostic output (GH issue #222)
+
+## Overview
+
+Diagnosis is captured in `claude-notes/issue-reports/222/triage.md`.
+
+Short version: GLR parses produce multiple `TreeSitterProcessLog` entries
+keyed by version number; they're held in
+`HashMap<usize, TreeSitterProcessLog>` (`crates/quarto-parse-errors/src/tree_sitter_log.rs:48`)
+and iterated with `.values()` in
+`produce_diagnostic_messages` (`crates/quarto-parse-errors/src/error_generation.rs:44`).
+A `(row, column)` dedupe means whichever version is iterated first
+wins. Default `RandomState` makes that order vary per process.
+
+The user clarification on the GH issue: *either diagnostic is
+acceptable, as long as the tie is always broken consistently to one of
+them.*
+
+## Work Items
+
+Phase 1 — test first (TDD).
+
+- [ ] Write a regression test that parses the issue-222 input N times
+      and asserts byte-identical diagnostic output across runs.
+      Decide N: 20 is more than enough — at the observed 63/37 split,
+      P(all-same) < 1e-4.
+- [ ] Place the test where it actually exercises the diagnostic path
+      end-to-end. Two candidates:
+      - `crates/pampa/tests/` driving `readers::qmd::read`
+        (matches the "test the real binary path" guidance in
+        `CLAUDE.md` § End-to-end verification);
+      - `crates/quarto-parse-errors/` driving
+        `produce_diagnostic_messages` directly (smaller, faster).
+      Pick pampa-side — that's what the binary uses. A small unit-level
+      test in quarto-parse-errors is fine *in addition*, not as a
+      replacement.
+- [ ] Run the test and confirm it fails on `99e7f89c`.
+
+Phase 2 — fix.
+
+- [ ] Swap `HashMap<usize, TreeSitterProcessLog>` for
+      `BTreeMap<usize, TreeSitterProcessLog>` in
+      `tree_sitter_log.rs`. Touches the field declaration, the import,
+      and the `HashMap::new()` initializer at line 181. Iteration sites
+      keep working without modification (BTreeMap implements the same
+      `.values()` / `.iter()` API and indexing).
+- [ ] Run the regression test, confirm it passes.
+- [ ] Run the full pampa test suite (`cargo nextest run -p pampa
+      -p quarto-parse-errors`).
+- [ ] Run `cargo xtask verify --skip-hub-build` (Rust + tree-sitter
+      legs at minimum). If the hub-build leg is needed for CI,
+      the maintainer can run the full verify before merge.
+
+Phase 3 — guardrail.
+
+- [ ] Decide whether to add a `CLAUDE.md` note (or a `.claude/rules/`
+      rule) about: "containers iterated to produce user-visible output
+      must have deterministic iteration order — prefer `BTreeMap` /
+      `Vec` over `HashMap` when iteration is observable."
+      Discuss with the user before writing.
+
+## Open questions for the user (before implementing)
+
+1. **Tie-break direction.** BTreeMap picks the lowest version key
+   (here, GLR version 0 ⇒ Variant A, the "underscore-emphasis" diag).
+   Acceptable per the GH clarification, but is there a reason to
+   prefer the highest version, or a non-version-based tie-break
+   (e.g. lexically earliest, fewest skips)? Default
+   recommendation: lowest version. It's the path tree-sitter
+   considered first (and Pandoc broadly agrees on this case — it
+   parses `_blank` inside the quote as text, not as emphasis open,
+   *because* the quote isn't closed, but only Quarto reports both
+   problems).
+
+2. **Scope of the regression test.** Is it acceptable to add a test
+   that loops N times in-process? Two concerns:
+   - Slow tests: at the observed pampa parse cost this is negligible
+     (~ms per run), so 20 runs ≈ 20-30 ms. Should be safe.
+   - Flakiness: if we fix the root cause, the test is deterministic;
+     if the fix regresses, it'll fail every time we run CI. Net win.
+
+3. **Wider HashMap audit.** Should we file a follow-up beads issue to
+   audit every `HashMap<*>` iteration in user-facing output paths
+   (writers, diagnostic emission, source maps), or treat that as
+   out-of-scope for this fix?
+
+Once the user signs off on these, proceed with Phase 1.
+
+## Notes
+
+- `processes` is also iterated by `TreeSitterParseLog::is_good`
+  (`tree_sitter_log.rs:72`). That's a boolean reduction (`all` over
+  process is_good) — order-independent. The BTreeMap swap is a no-op
+  there.
+- BTreeMap's performance characteristics differ from HashMap (O(log n)
+  vs amortized O(1) lookup), but `processes` is at most a handful of
+  entries (one per concurrent GLR version, typically 1-3). Performance
+  is irrelevant at this size.
+- We retain the `(row, column)` dedupe. Reconsidering it (e.g.
+  emitting all distinct GLR interpretations) is a separate question;
+  the user has explicitly said "either diagnostic is acceptable" so
+  the dedupe stays.

--- a/claude-notes/plans/2026-05-20-issue-222-deterministic-diagnostics.md
+++ b/claude-notes/plans/2026-05-20-issue-222-deterministic-diagnostics.md
@@ -20,32 +20,27 @@ them.*
 
 Phase 1 — test first (TDD).
 
-- [ ] Write a regression test that parses the issue-222 input N times
-      and asserts byte-identical diagnostic output across runs.
-      Decide N: 20 is more than enough — at the observed 63/37 split,
-      P(all-same) < 1e-4.
-- [ ] Place the test where it actually exercises the diagnostic path
-      end-to-end. Two candidates:
-      - `crates/pampa/tests/` driving `readers::qmd::read`
-        (matches the "test the real binary path" guidance in
-        `CLAUDE.md` § End-to-end verification);
-      - `crates/quarto-parse-errors/` driving
-        `produce_diagnostic_messages` directly (smaller, faster).
-      Pick pampa-side — that's what the binary uses. A small unit-level
-      test in quarto-parse-errors is fine *in addition*, not as a
-      replacement.
-- [ ] Run the test and confirm it fails on `99e7f89c`.
+- [x] Write a regression test that parses the issue-222 input N times
+      and asserts byte-identical diagnostic output across runs. Used
+      N=50 (P(all-same by chance) < 1e-10 at the observed 63/37 split).
+- [x] Place the test in `crates/pampa/tests/`. File:
+      `test_diagnostic_determinism.rs`. Drives `readers::qmd::read`,
+      so it exercises the same path the `pampa` binary uses.
+- [x] Run the test on `99e7f89c` — confirmed fails (the test's
+      assertion message shows the Variant A vs Variant B
+      divergence directly).
 
 Phase 2 — fix.
 
-- [ ] Swap `HashMap<usize, TreeSitterProcessLog>` for
+- [x] Swap `HashMap<usize, TreeSitterProcessLog>` for
       `hashlink::LinkedHashMap<usize, TreeSitterProcessLog>` in
-      `tree_sitter_log.rs`. Touches the field declaration, the import,
-      the `HashMap::new()` initializer at line 181, and a one-line
-      addition to `crates/quarto-parse-errors/Cargo.toml`
-      (`hashlink = "0.11"`). Iteration sites keep working without
-      modification (LinkedHashMap implements `.values()` / `.iter()`
-      / indexing the same way).
+      `tree_sitter_log.rs`. Done via `use hashlink::LinkedHashMap as
+      HashMap;` so the in-file name `HashMap` keeps working at every
+      use site. Also had to swap the import in `error_generation.rs`'s
+      test module (`use hashlink::LinkedHashMap as HashMap;`) — the
+      `processes` field is now typed `LinkedHashMap`, so the test
+      builder's `HashMap::new()` literal had to match.
+      Added `hashlink = "0.11"` to `crates/quarto-parse-errors/Cargo.toml`.
 
       Rationale for LinkedHashMap over BTreeMap: it's the data
       structure the rest of the workspace already reaches for when
@@ -66,20 +61,31 @@ Phase 2 — fix.
       version *before* a lower-numbered one after a condense; nothing
       in the captured trace suggests that happens, but the audit
       should keep an eye out.
-- [ ] Run the regression test, confirm it passes.
-- [ ] Run the full pampa test suite (`cargo nextest run -p pampa
-      -p quarto-parse-errors`).
-- [ ] Run `cargo xtask verify --skip-hub-build` (Rust + tree-sitter
-      legs at minimum). If the hub-build leg is needed for CI,
-      the maintainer can run the full verify before merge.
+- [x] Run the regression test, confirm it passes. (50/50 runs
+      produce identical diagnostic text.)
+- [x] Run the full pampa test suite (`cargo nextest run -p pampa
+      -p quarto-parse-errors`) — 3792 passed, 2 skipped.
+- [x] Run `cargo xtask verify` Rust + tree-sitter legs — green.
+      Hub-build + JS legs skipped (pre-existing local
+      `wasm-quarto-hub-client` package-not-found state, unrelated to
+      issue #222); the maintainer should run the full verify before
+      merge to confirm the WASM build.
+
+End-to-end check: `printf -- 'The "_blank" word.' | cargo run --bin
+pampa -- --no-prune-errors` was run 30 times against the patched
+binary. Result: 30/30 Variant A (Q-2-11 at col 13 + Q-2-5 at col 19).
+Diagnostic visually inspected.
 
 Phase 3 — guardrail.
 
-- [ ] Decide whether to add a `CLAUDE.md` note (or a `.claude/rules/`
+- [x] Decide whether to add a `CLAUDE.md` note (or a `.claude/rules/`
       rule) about: "containers iterated to produce user-visible output
-      must have deterministic iteration order — prefer `BTreeMap` /
-      `Vec` over `HashMap` when iteration is observable."
-      Discuss with the user before writing.
+      must have deterministic iteration order — prefer
+      `hashlink::LinkedHashMap` / `BTreeMap` / `Vec` over `HashMap`
+      when iteration is observable."
+      Resolution: rolled into the follow-up audit issue (bd-x5tx2)
+      so the rule lands together with the broader audit, rather than
+      as a standalone codification step here.
 
 ## Open questions for the user (before implementing)
 
@@ -104,9 +110,12 @@ Phase 3 — guardrail.
 3. **Wider HashMap audit.** Should we file a follow-up beads issue to
    audit every `HashMap<*>` iteration in user-facing output paths
    (writers, diagnostic emission, source maps), or treat that as
-   out-of-scope for this fix?
+   out-of-scope for this fix? **Resolved: filed bd-x5tx2
+   (discovered-from bd-hwdlq).**
 
-Once the user signs off on these, proceed with Phase 1.
+User signed off on all three (2026-05-21): tie-break direction is
+irrelevant as long as it's predictable, test goes in
+`crates/pampa/tests`, audit follow-up filed.
 
 ## Notes
 

--- a/claude-notes/plans/2026-05-20-issue-222-deterministic-diagnostics.md
+++ b/claude-notes/plans/2026-05-20-issue-222-deterministic-diagnostics.md
@@ -39,11 +39,33 @@ Phase 1 — test first (TDD).
 Phase 2 — fix.
 
 - [ ] Swap `HashMap<usize, TreeSitterProcessLog>` for
-      `BTreeMap<usize, TreeSitterProcessLog>` in
+      `hashlink::LinkedHashMap<usize, TreeSitterProcessLog>` in
       `tree_sitter_log.rs`. Touches the field declaration, the import,
-      and the `HashMap::new()` initializer at line 181. Iteration sites
-      keep working without modification (BTreeMap implements the same
-      `.values()` / `.iter()` API and indexing).
+      the `HashMap::new()` initializer at line 181, and a one-line
+      addition to `crates/quarto-parse-errors/Cargo.toml`
+      (`hashlink = "0.11"`). Iteration sites keep working without
+      modification (LinkedHashMap implements `.values()` / `.iter()`
+      / indexing the same way).
+
+      Rationale for LinkedHashMap over BTreeMap: it's the data
+      structure the rest of the workspace already reaches for when
+      iteration order has to be deterministic — 8 crates depend on
+      `hashlink` (quarto-pandoc-types, quarto-ast-reconcile,
+      quarto-core, comrak-to-pandoc, quarto-citeproc, pampa,
+      quarto-highlight, plus the reconcile-viewer experiment).
+      `pampa/src/readers/json.rs` uses `LinkedHashMap<String, _>` for
+      the same kind of "iteration order matters" reason. Sticking with
+      the established pattern is preferred.
+
+      For *this particular bug* either choice gives the same observable
+      output: tree-sitter inserts GLR versions in numeric order (0, 1,
+      2 on the issue-222 trace), and the lowest version wins under
+      both BTreeMap (sorted) and LinkedHashMap (insertion). Both
+      experimentally produce 30/30 Variant A. The two would only
+      diverge if tree-sitter ever introduced a brand-new high-numbered
+      version *before* a lower-numbered one after a condense; nothing
+      in the captured trace suggests that happens, but the audit
+      should keep an eye out.
 - [ ] Run the regression test, confirm it passes.
 - [ ] Run the full pampa test suite (`cargo nextest run -p pampa
       -p quarto-parse-errors`).
@@ -61,16 +83,16 @@ Phase 3 — guardrail.
 
 ## Open questions for the user (before implementing)
 
-1. **Tie-break direction.** BTreeMap picks the lowest version key
-   (here, GLR version 0 ⇒ Variant A, the "underscore-emphasis" diag).
-   Acceptable per the GH clarification, but is there a reason to
-   prefer the highest version, or a non-version-based tie-break
-   (e.g. lexically earliest, fewest skips)? Default
-   recommendation: lowest version. It's the path tree-sitter
-   considered first (and Pandoc broadly agrees on this case — it
-   parses `_blank` inside the quote as text, not as emphasis open,
-   *because* the quote isn't closed, but only Quarto reports both
-   problems).
+1. **Tie-break direction.** LinkedHashMap picks the version inserted
+   first (here, GLR version 0 ⇒ Variant A, the
+   "underscore-emphasis" diag). Acceptable per the GH clarification,
+   but is there a reason to prefer the highest version, or a
+   non-version-based tie-break (e.g. lexically earliest, fewest
+   skips)? Default recommendation: first-inserted (version 0). It's
+   the path tree-sitter considered first — and on this input Pandoc
+   broadly agrees on the spirit of it (parses `_blank` inside the
+   quote as text, not as emphasis open, *because* the quote isn't
+   closed); only Quarto reports both problems.
 
 2. **Scope of the regression test.** Is it acceptable to add a test
    that loops N times in-process? Two concerns:
@@ -90,12 +112,11 @@ Once the user signs off on these, proceed with Phase 1.
 
 - `processes` is also iterated by `TreeSitterParseLog::is_good`
   (`tree_sitter_log.rs:72`). That's a boolean reduction (`all` over
-  process is_good) — order-independent. The BTreeMap swap is a no-op
-  there.
-- BTreeMap's performance characteristics differ from HashMap (O(log n)
-  vs amortized O(1) lookup), but `processes` is at most a handful of
-  entries (one per concurrent GLR version, typically 1-3). Performance
-  is irrelevant at this size.
+  process is_good) — order-independent. The LinkedHashMap swap is a
+  no-op there.
+- LinkedHashMap keeps amortized O(1) insert/lookup (it's a HashMap
+  backed by a doubly-linked list for iteration order); performance
+  is a wash. `processes` is at most a handful of entries anyway.
 - We retain the `(row, column)` dedupe. Reconsidering it (e.g.
   emitting all distinct GLR interpretations) is a separate question;
   the user has explicitly said "either diagnostic is acceptable" so

--- a/crates/pampa/tests/test_diagnostic_determinism.rs
+++ b/crates/pampa/tests/test_diagnostic_determinism.rs
@@ -1,0 +1,63 @@
+/*
+ * test_diagnostic_determinism.rs
+ * Copyright (c) 2026 Posit, PBC
+ *
+ * Regression test for GitHub issue #222 (bd-hwdlq): pampa diagnostic
+ * output must be deterministic across runs on the same input.
+ *
+ * The underlying bug was that GLR parse versions were held in a
+ * `HashMap<usize, TreeSitterProcessLog>` and iterated by `.values()`
+ * in `produce_diagnostic_messages`. A `(row, column)` dedupe meant
+ * whichever GLR version was iterated first won — and HashMap with
+ * default RandomState varies that order per process.
+ *
+ * Each call to `readers::qmd::read` creates fresh `HashMap`s with
+ * fresh seeds, so N independent invocations exercise N independent
+ * iteration orders. Comparing the rendered diagnostic text across
+ * N runs catches the bug with overwhelming probability.
+ */
+
+use pampa::readers;
+
+fn render_diagnostics(input: &str) -> String {
+    let input_bytes = input.as_bytes();
+    let mut output = Vec::new();
+    let result = readers::qmd::read(input_bytes, false, "test.qmd", &mut output, false, None);
+
+    let diagnostics = result.expect_err("issue-222 input must produce parse errors");
+
+    let mut source_context = quarto_source_map::SourceContext::new();
+    source_context.add_file("test.qmd".to_string(), Some(input.to_string()));
+
+    diagnostics
+        .iter()
+        .map(|d| d.to_text(Some(&source_context)))
+        .collect::<Vec<_>>()
+        .join("\n---\n")
+}
+
+#[test]
+fn issue_222_diagnostics_are_deterministic_across_runs() {
+    // Issue #222 repro: this input triggers a GLR parse with 3 concurrent
+    // versions, all of which detect_error at (row=0, col=18). The dedupe
+    // by (row, column) then picks exactly one — and before the fix, which
+    // one varied per process.
+    let input = "The \"_blank\" word.\n";
+
+    // 50 runs. At the originally observed ~63/37 split between the two
+    // variants, the probability that all 50 runs *happen* to land on the
+    // same variant by chance is (0.63)^50 + (0.37)^50 < 1e-10. So this
+    // test, if the bug is present, fails essentially every time.
+    let runs = 50;
+    let first = render_diagnostics(input);
+    for i in 2..=runs {
+        let next = render_diagnostics(input);
+        assert_eq!(
+            first, next,
+            "Diagnostic output for issue #222 input must be identical across runs;\n\
+             run 1 vs run {i} differs.\n\
+             === run 1 ===\n{first}\n\
+             === run {i} ===\n{next}\n"
+        );
+    }
+}

--- a/crates/quarto-parse-errors/Cargo.toml
+++ b/crates/quarto-parse-errors/Cargo.toml
@@ -17,6 +17,7 @@ tree-sitter = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = "1.0"
 quarto-error-message-macros = { path = "./error-message-macros" }
+hashlink = "0.11"
 
 [lints]
 workspace = true

--- a/crates/quarto-parse-errors/src/error_generation.rs
+++ b/crates/quarto-parse-errors/src/error_generation.rs
@@ -663,7 +663,7 @@ mod tests {
     use crate::tree_sitter_log::{
         ProcessMessage, TreeSitterLogObserver, TreeSitterParseLog, TreeSitterProcessLog,
     };
-    use std::collections::HashMap;
+    use hashlink::LinkedHashMap as HashMap;
 
     /// Build a minimal observer whose parse log carries one error
     /// state at the given (row, column). The state-machine numbers

--- a/crates/quarto-parse-errors/src/tree_sitter_log.rs
+++ b/crates/quarto-parse-errors/src/tree_sitter_log.rs
@@ -8,7 +8,13 @@
 //! This module provides utilities to capture and analyze tree-sitter's internal
 //! parse state, enabling high-quality error message generation.
 
-use std::collections::HashMap;
+// `processes` is iterated by `produce_diagnostic_messages` to extract per-GLR-version
+// error states, and a downstream `(row, column)` dedupe means whichever version is
+// visited first wins. A plain `HashMap` with default `RandomState` randomized that
+// order per process — see GitHub issue #222 / bd-hwdlq. `LinkedHashMap` preserves
+// insertion order (tree-sitter inserts version 0 first), which keeps the diagnostic
+// output deterministic across runs.
+use hashlink::LinkedHashMap as HashMap;
 
 /// State of the tree-sitter log observer during parsing.
 #[derive(Debug, PartialEq, Eq, Clone)]


### PR DESCRIPTION
Replaces HashMap with LinkedHashMap when choosing which diagnostic to pick to avoid nondeterminism.

Closes #222.