### PR TITLE
hub-client: apply theme on login screen and after logout

### DIFF
--- a/hub-client/changelog.md
+++ b/hub-client/changelog.md
@@ -15,6 +15,10 @@ be in reverse chronological order (latest first).
 
 -->
 
+### 2026-05-21
+
+- [`6c84696d`](https://github.com/quarto-dev/q2/commits/6c84696d): Login screen and post-logout view now respect the saved `colorScheme` preference (and system `prefers-color-scheme`) instead of always rendering light on first visit and inheriting the previous session's class after logout.
+
 ### 2026-05-15
 
 - [`e9399093`](https://github.com/quarto-dev/q2/commits/e9399093): Authorship pill in the replay bar now animates with a rotating rainbow border while attribution data is being generated, so large documents give visible feedback that work is happening before the colours appear in the preview.

--- a/hub-client/src/App.tsx
+++ b/hub-client/src/App.tsx
@@ -16,7 +16,6 @@ function DevHarnessLazy({ page }: { page: string }) {
 import Editor from './components/Editor';
 import Toast from './components/Toast';
 import { ViewModeProvider } from './components/ViewModeContext';
-import { ThemeProvider } from './components/ThemeContext';
 import { LoginScreen } from './components/auth/LoginScreen';
 import {
   connect,
@@ -568,11 +567,7 @@ function App() {
   // Dev harness: render components in isolation for visual testing.
   // Only available in development builds; the DevRoute type is never parsed in production.
   if (route.type === 'dev') {
-    return (
-      <ThemeProvider>
-        <DevHarnessLazy page={route.page} />
-      </ThemeProvider>
-    );
+    return <DevHarnessLazy page={route.page} />;
   }
 
   // Show project set setup/migration screen if needed
@@ -611,7 +606,7 @@ function App() {
   }
 
   return (
-    <ThemeProvider>
+    <>
       {!project ? (
         <ProjectSelector
           onSelectProject={handleSelectProject}
@@ -654,7 +649,7 @@ function App() {
         visible={showSaveToast}
         onHide={() => setShowSaveToast(false)}
       />
-    </ThemeProvider>
+    </>
   );
 }
 

--- a/hub-client/src/main.tsx
+++ b/hub-client/src/main.tsx
@@ -7,6 +7,7 @@ import App from './App.tsx'
 import { savePreAuthHash, restorePreAuthHash } from './utils/routing'
 import { AuthProviderRoot, noopAuthProvider } from './auth/AuthProvider'
 import { googleAuthProvider } from './auth/GoogleAuthProvider'
+import { ThemeProvider } from './components/ThemeContext'
 
 // Pre-auth hash preservation for the Google OAuth redirect flow.
 // On first visit: save the hash (e.g., #/share/...) before React clears it.
@@ -31,7 +32,9 @@ const authProvider = GOOGLE_CLIENT_ID ? googleAuthProvider : noopAuthProvider;
 
 const root = (
   <StrictMode>
-    <App />
+    <ThemeProvider>
+      <App />
+    </ThemeProvider>
   </StrictMode>
 );
 


### PR DESCRIPTION
Fixes #228.

- Login screen rendered light on first visit and stayed dark after logout, regardless of saved preference.
- Root cause: `ThemeProvider` was mounted inside App's post-login branches only, so the login screen fell back to light defaults (the class set during a prior session persisted on logout because the provider's `useEffect` has no cleanup.
- Fix: hoist `ThemeProvider` into `main.tsx` so it wraps every branch of `App`. Saved `colorScheme` and system `prefers-color-scheme` now apply consistently across auth states.