### PR TITLE
fix(pampa): detect parse errors without the per-lex tree-sitter logger (bd-b7eb7)

### DIFF
--- a/claude-notes/instructions/performance-profiling.md
+++ b/claude-notes/instructions/performance-profiling.md
@@ -159,6 +159,45 @@ top-N self-time table. The head of the script documents both the
 profile format and the samply sidecar structure — if samply's format
 changes, patch there.
 
+#### When the hotspot is in a system library, use `sample`
+
+samply's `.syms.json` sidecar symbolicates **our** binary, but it does
+**not** resolve system libraries (`libsystem_c.dylib`,
+`libsystem_malloc.dylib`, …). Frames inside them show up as bare
+addresses (`0x4a83 [libsystem_c.dylib]`). If a hotspot — or, in a
+multithreaded profile, the frame *holding a contended lock* — lands in a
+system library, the address tells you nothing, and **guessing what it is
+will burn your session.**
+
+macOS ships `sample`, which symbolicates system libraries from the dyld
+shared cache:
+
+```bash
+target/release-perf/<binary> <args> &   # or run it and grab the pid
+sample $! 4 -file /tmp/s.txt            # sample the live process for 4s
+# then read /tmp/s.txt — system frames now have names
+```
+
+Real example (bd-b7eb7): a multithreaded `q2 render` showed ~75 %
+`__ulock_wait2`/`os_unfair_lock` with the waits charged to tree-sitter's
+`ts_lexer__advance`, and the libc frame below it unsymbolicated. We
+**guessed "malloc" and it was wrong** — swapping in mimalloc (both as
+`#[global_allocator]` *and* via `tree_sitter::set_allocator` for the C
+allocations) changed nothing. `sample` revealed the truth:
+`ts_lexer__advance → snprintf → __vfprintf → localeconv_l` — the
+contended lock was the **global locale lock**, taken by `snprintf`
+formatting tree-sitter's per-lex logger string, not the allocator.
+
+Lessons:
+- **A negative result from a cheap fix (swap the allocator) is decisive
+  evidence**, not a dead end — it ruled out an entire class of cause.
+- When samply leaves a hot/lock-holding frame as a system-lib address,
+  reach for `sample` (or Instruments) before theorizing.
+- `#[global_allocator]` only intercepts **Rust** allocations; a C library
+  vendored into the build (tree-sitter) calls libc `malloc` directly
+  unless separately redirected (`ts_set_allocator`). Don't assume a Rust
+  allocator swap covers C-side allocation.
+
 ### Where native drivers live
 
 `crates/perf-harness/` — an internal (non-published, `publish = false`)

--- a/crates/pampa/src/readers/qmd.rs
+++ b/crates/pampa/src/readers/qmd.rs
@@ -63,14 +63,17 @@ pub fn read<T: Write>(
     Vec<quarto_error_reporting::DiagnosticMessage>,
 > {
     let mut parser = MarkdownParser::default();
-    let mut fast_log_observer = quarto_parse_errors::TreeSitterLogObserverFast::default();
     let mut log_observer = quarto_parse_errors::TreeSitterLogObserver::default();
 
-    parser.parser.set_logger(Some(Box::new(|log_type, message| {
-        if log_type == LogType::Parse {
-            fast_log_observer.log(log_type, message);
-        }
-    })));
+    // PERF (bd-b7eb7): do NOT attach a logger on the happy-path parse. When
+    // *any* logger is set, tree-sitter's lexer formats a debug string with
+    // snprintf for every lex action — and on macOS snprintf locks the global
+    // locale (localeconv_l), serializing all parser threads (~75% lock-wait
+    // under 16 threads; see claude-notes/research/2026-05-31-q2-render-perf-*).
+    // Instead we read tree-sitter's own error signal via
+    // `MarkdownTree::had_parse_error` (progress-callback `ParseState::has_error`
+    // + final-tree `has_error`), and attach the logger only for the diagnostic
+    // re-parse below, which runs only when the document actually has errors.
 
     // inefficient, but safe: if no trailing newline, add one
     if !input_bytes.ends_with(b"\n") {
@@ -102,7 +105,7 @@ pub fn read<T: Write>(
         .source_context
         .add_file(filename.to_string(), Some(input_str));
 
-    if fast_log_observer.had_errors() {
+    if tree.had_parse_error() {
         parser.parser.set_logger(Some(Box::new(|log_type, message| {
             if log_type == LogType::Parse {
                 log_observer.log(log_type, message);

--- a/crates/quarto-parse-errors/src/lib.rs
+++ b/crates/quarto-parse-errors/src/lib.rs
@@ -122,8 +122,8 @@ pub use error_table::{
 };
 
 pub use tree_sitter_log::{
-    ConsumedToken, ProcessMessage, TreeSitterLogObserver, TreeSitterLogObserverFast,
-    TreeSitterLogObserverTrait, TreeSitterLogState, TreeSitterParseLog, TreeSitterProcessLog,
+    ConsumedToken, ProcessMessage, TreeSitterLogObserver, TreeSitterLogObserverTrait,
+    TreeSitterLogState, TreeSitterParseLog, TreeSitterProcessLog,
 };
 
 pub use error_generation::{

--- a/crates/quarto-parse-errors/src/tree_sitter_log.rs
+++ b/crates/quarto-parse-errors/src/tree_sitter_log.rs
@@ -94,25 +94,6 @@ pub trait TreeSitterLogObserverTrait {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-/// Fast log observer that only tracks whether errors occurred (no detailed state).
-#[derive(Default)]
-pub struct TreeSitterLogObserverFast {
-    pub saw_error: bool,
-}
-
-impl TreeSitterLogObserverTrait for TreeSitterLogObserverFast {
-    fn had_errors(&self) -> bool {
-        self.saw_error
-    }
-    fn log(&mut self, _log_type: tree_sitter::LogType, message: &str) {
-        if message.starts_with("detect_error") {
-            self.saw_error = true
-        }
-    }
-}
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
 /// Full log observer that captures detailed parse state for error message generation.
 pub struct TreeSitterLogObserver {
     pub parses: Vec<TreeSitterParseLog>,

--- a/crates/tree-sitter-qmd/bindings/rust/parser.rs
+++ b/crates/tree-sitter-qmd/bindings/rust/parser.rs
@@ -3,10 +3,14 @@
  * Copyright (c) 2025 Posit, PBC
  */
 
+use std::cell::Cell;
 use std::num::NonZeroU16;
+use std::ops::ControlFlow;
 
 use crate::LANGUAGE;
-use tree_sitter::{InputEdit, Language, Node, Parser, Point, Tree, TreeCursor};
+use tree_sitter::{
+    InputEdit, Language, Node, ParseOptions, ParseState, Parser, Point, Tree, TreeCursor,
+};
 
 /// A parser that produces [`MarkdownTree`]s.
 ///
@@ -142,15 +146,18 @@ impl<'a> MarkdownCursor<'a> {
     }
 }
 
-/// An object that holds a combined markdown tree.
+/// An object that holds the parsed (unified) markdown tree.
 #[derive(Debug, Clone)]
 pub struct MarkdownTree {
     block_tree: Tree,
+    /// Whether tree-sitter entered error-correction mode at any point during
+    /// the parse, captured via the `parse_with_options` progress callback's
+    /// [`ParseState::has_error`]. See [`MarkdownTree::had_parse_error`].
+    entered_error_recovery: bool,
 }
 
 impl MarkdownTree {
-    /// Edit the block tree and inline trees to keep them in sync with source code that has been
-    /// edited.
+    /// Edit the tree to keep it in sync with source code that has been edited.
     ///
     /// You must describe the edit both in terms of byte offsets and in terms of
     /// row/column coordinates.
@@ -161,6 +168,29 @@ impl MarkdownTree {
     /// Returns the block tree for the parsed document
     pub fn block_tree(&self) -> &Tree {
         &self.block_tree
+    }
+
+    /// Whether the document had a parse error.
+    ///
+    /// True if tree-sitter entered error-correction mode during the parse
+    /// (`entered_error_recovery`, from the progress callback) OR the final tree
+    /// contains an ERROR/MISSING node ([`Node::has_error`]). Together these are
+    /// a faithful, cheap replacement for the old parse-log "detect_error"
+    /// detection — without the per-lex `snprintf` the logger incurred (bd-b7eb7).
+    /// The tree check backstops the callback, which can miss an error in the
+    /// final operations before the parse ends (the callback fires only every N
+    /// operations).
+    ///
+    /// DESIGN NOTE: tree-sitter-qmd declares **no `conflicts:`** in its grammar,
+    /// so the generated parser is deterministic LR. tree-sitter's GLR
+    /// nondeterministic multiple-stack mechanism is therefore only ever
+    /// exercised during *error recovery* — never for benign grammar ambiguity.
+    /// So `ParseState::has_error` (set when *all* stack versions are in error)
+    /// corresponds to a genuine parse error, not a speculative branch that will
+    /// be pruned. Keep the grammar conflict-free so this invariant holds; if
+    /// `conflicts:` is ever introduced, revisit this error detection.
+    pub fn had_parse_error(&self) -> bool {
+        self.entered_error_recovery || self.block_tree.root_node().has_error()
     }
 
     /// Create a new [`MarkdownCursor`] starting from the root of the tree.
@@ -221,9 +251,30 @@ impl MarkdownParser {
         parser
             .set_language(block_language)
             .expect("Could not load block grammar");
-        let block_tree =
-            parser.parse_with_options(callback, old_tree.map(|tree| &tree.block_tree), None)?;
-        Some(MarkdownTree { block_tree })
+
+        // Detect whether the parser enters error-correction mode WITHOUT
+        // attaching a tree-sitter logger. A logger makes tree-sitter `snprintf`
+        // a debug string for every lex action, and on macOS `snprintf` locks
+        // the global locale (`localeconv_l`), serializing all parser threads
+        // (bd-b7eb7). The progress callback fires only every N operations and
+        // does no formatting, so it is effectively free.
+        let saw_error = Cell::new(false);
+        let mut progress = |state: &ParseState| {
+            if state.has_error() {
+                saw_error.set(true);
+            }
+            ControlFlow::Continue(())
+        };
+        let options = ParseOptions::new().progress_callback(&mut progress);
+        let block_tree = parser.parse_with_options(
+            callback,
+            old_tree.map(|tree| &tree.block_tree),
+            Some(options),
+        )?;
+        Some(MarkdownTree {
+            block_tree,
+            entered_error_recovery: saw_error.get(),
+        })
     }
 
     /// Parse a slice of UTF8 text.

--- a/crates/tree-sitter-qmd/tree-sitter-markdown/grammar.js
+++ b/crates/tree-sitter-qmd/tree-sitter-markdown/grammar.js
@@ -122,6 +122,23 @@ const PANDOC_REGEX_STR =
                 regexBracket("[_]" + afterUnderscoreRegex)
             ) + "*");
 
+// DESIGN INVARIANT — no `conflicts:`.
+//
+// This grammar intentionally declares NO `conflicts:` rules, so tree-sitter
+// generates a deterministic LR parser. tree-sitter's GLR nondeterministic
+// multiple-stack mechanism is therefore only ever exercised during *error
+// recovery*, never for benign grammar ambiguity. Lexing ambiguities are
+// resolved deterministically by the external scanner / token precedence, not
+// by GLR.
+//
+// Downstream code relies on this: the qmd reader detects parse errors via
+// `ParseState::has_error` (the parser's "all stack versions are in error"
+// flag, surfaced through the `parse_with_options` progress callback) instead
+// of the old per-lex logger. Because there is no speculative branching outside
+// error recovery, `has_error` corresponds to a genuine parse error rather than
+// a speculative branch that will be pruned. See
+// `crates/tree-sitter-qmd/bindings/rust/parser.rs::MarkdownTree::had_parse_error`
+// and bd-b7eb7. If you ever add `conflicts:`, revisit that error detection.
 module.exports = grammar({
     name: 'markdown',
 


### PR DESCRIPTION
## Summary

The qmd reader (`crates/pampa/src/readers/qmd.rs::read`) attached a tree-sitter `set_logger` callback on **every** parse. When *any* logger is set, tree-sitter formats a debug string with `snprintf` for every lex action — and on macOS `snprintf` locks the global locale (`localeconv_l`). Under multithreaded project renders (rayon, ~16 workers) that locale lock serializes all parser threads.

## How it was found

Profiled a large **healthy** project (401 docs / 8.2 MB, no errors) — the case we most want fast. A fresh multithreaded render spent **~75% of samples** in `__ulock_wait2`/`__ulock_wake`/`os_unfair_lock`, call chain:

```
ts_lexer__advance → snprintf → __vfprintf → localeconv_l → os_unfair_lock
```

16 threads bought only ~1.2× wall-clock; `sys` time ~37 s. It is **not** the allocator — swapping mimalloc both as `#[global_allocator]` *and* via `tree_sitter::set_allocator` changed nothing. The locale-lock culprit was found with macOS `sample` (which symbolicates system libraries, unlike samply's sidecar).

## Fix

Parse the happy path with **no logger**, and detect whether tree-sitter entered error-correction mode via its own public signal — the `parse_with_options` progress callback's **`ParseState::has_error`** — combined with the final tree's `Node::has_error` (which backstops an error in the last few ops before parse end). The logger is attached only for the diagnostic **re-parse**, which runs only when the document has an error. Encapsulated in `MarkdownTree::had_parse_error`. The previous, ineffective `TreeSitterLogObserverFast` (its cheap callback didn't help — the `snprintf` is inside tree-sitter, before the callback) is removed.

**Why `has_error` is reliable here:** tree-sitter-qmd declares **no `conflicts:`**, so the parser is deterministic LR and GLR multiple-stack speculation only occurs during error recovery — `has_error` therefore means a genuine error, not a speculative branch that will be pruned. This invariant is now documented in `grammar.js` and `parser.rs`.

## Results (large healthy project, `release-perf`)

| metric | before | after |
| --- | --- | --- |
| 16-thread render | 8.04 s | **3.71 s** (2.2×) |
| 16-thread `sys` | 36.83 s | **1.37 s** (27×) |
| pass-1 @ 16 threads | 2935 ms | **426 ms** (scales ~6.4× on 16 cores) |
| single-thread render | 9.71 s | **6.0 s** (1.6×) |

## Correctness

- Error-corpus snapshot tests (json / text / ariadne / locations) pass.
- The real 565-file qmd-plans corpus reports the **same 140 error files** — exact parity with the previous log-based detection.
- Full `cargo xtask verify` (Rust workspace + WASM/hub build + hub tests) passes.

## Notes

- Also documents the profiling lesson (use macOS `sample` for system-lib frames; a Rust `#[global_allocator]` doesn't cover a vendored C library's libc `malloc`) in `claude-notes/instructions/performance-profiling.md`.
- Full investigation: `claude-notes/research/2026-05-31-q2-render-perf-qmd-plans.md` (lands separately with the website experiment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)