### PR TITLE
feat: q2 render --fail-fast — stop at the first error (bd-gi25b)

### DIFF
--- a/crates/quarto-core/src/project/orchestrator.rs
+++ b/crates/quarto-core/src/project/orchestrator.rs
@@ -444,6 +444,11 @@ pub struct ProjectRenderSummary<O = RenderToFileResult> {
     /// non-fatal warnings (e.g. missing favicon source) — failures
     /// surface as a returned `Err` instead.
     pub project_diagnostics: Vec<DiagnosticMessage>,
+    /// `true` when the render was cut short because `--fail-fast` was
+    /// set and at least one per-document error was seen. The reported
+    /// failures are then **not** exhaustive — remaining files were not
+    /// checked. Always `false` without `--fail-fast`.
+    pub stopped_early: bool,
 }
 
 impl<O> ProjectRenderSummary<O> {
@@ -549,6 +554,10 @@ pub struct ProjectPipeline<'a, R: Pass2Renderer> {
     /// supplies its own implementation via
     /// [`Self::with_renderer`].
     renderer: R,
+    /// Stop the render as soon as the first per-document error is
+    /// seen (Pass-1 or Pass-2). Default `false` (best-effort:
+    /// render everything, report all failures at the end).
+    fail_fast: bool,
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -602,6 +611,7 @@ impl<'a, R: Pass2Renderer> ProjectPipeline<'a, R> {
             mode: RenderMode::Full,
             project_artifacts: crate::artifact::ArtifactStore::new(),
             renderer,
+            fail_fast: false,
         }
     }
 
@@ -610,6 +620,13 @@ impl<'a, R: Pass2Renderer> ProjectPipeline<'a, R> {
     /// calling [`run`](Self::run).
     pub fn with_mode(mut self, mode: RenderMode) -> Self {
         self.mode = mode;
+        self
+    }
+
+    /// Stop the render as soon as the first per-document error is seen
+    /// (Pass-1 or Pass-2), instead of best-effort rendering everything.
+    pub fn with_fail_fast(mut self, fail_fast: bool) -> Self {
+        self.fail_fast = fail_fast;
         self
     }
 
@@ -633,6 +650,20 @@ impl<'a, R: Pass2Renderer> ProjectPipeline<'a, R> {
 
         let (profiles, pass1_failures) = self.pass_one().await;
         let index = Arc::new(ProjectIndex::new(profiles));
+
+        // Fail-fast barrier: if Pass-1 surfaced any error, stop before
+        // running the `pre_render` hook, Pass-2, `post_render`, resource
+        // copy, and the manifest write. We report the failures we have
+        // and flag the summary as truncated.
+        if self.fail_fast && !pass1_failures.is_empty() {
+            return Ok(ProjectRenderSummary {
+                outputs: Vec::new(),
+                pass1_failures,
+                pass2_failures: Vec::new(),
+                project_diagnostics: initial_diagnostics,
+                stopped_early: true,
+            });
+        }
 
         // Map hook errors through so the caller sees exactly which
         // hook failed. The plan specifies hook failures abort the
@@ -747,11 +778,13 @@ impl<'a, R: Pass2Renderer> ProjectPipeline<'a, R> {
             )?;
         }
 
+        let stopped_early = self.fail_fast && !pass2_failures.is_empty();
         Ok(ProjectRenderSummary {
             outputs,
             pass1_failures,
             pass2_failures,
             project_diagnostics,
+            stopped_early,
         })
     }
 
@@ -839,10 +872,12 @@ impl<'a, R: Pass2Renderer> ProjectPipeline<'a, R> {
         // per-doc future. Native keeps the sync `pass_one_dispatch` for
         // rayon compatibility.
         #[cfg(not(target_arch = "wasm32"))]
-        let (profiles, failures) = pass_one_dispatch(&self.runtime, self.project, &self.format);
+        let (profiles, failures) =
+            pass_one_dispatch(&self.runtime, self.project, &self.format, self.fail_fast);
         #[cfg(target_arch = "wasm32")]
         let (profiles, failures) =
-            pass_one_dispatch_async(&self.runtime, self.project, &self.format).await;
+            pass_one_dispatch_async(&self.runtime, self.project, &self.format, self.fail_fast)
+                .await;
         // bd-m7x9s Phase 0: feed the `perf.pass1` gauge with cumulative
         // doc count and wall time. `pass1_profile_with_cache`
         // increments the thread-set; here we add the per-`pass_one`
@@ -1006,7 +1041,14 @@ impl<'a, R: Pass2Renderer> ProjectPipeline<'a, R> {
                 .await
             {
                 Ok(result) => outputs.push(result),
-                Err(e) => failures.push(file_failure_from_error(doc_info.input.clone(), e)),
+                Err(e) => {
+                    failures.push(file_failure_from_error(doc_info.input.clone(), e));
+                    // Fail-fast: stop rendering the rest of the project
+                    // at the first render error.
+                    if self.fail_fast {
+                        break;
+                    }
+                }
             }
         }
         (outputs, failures)
@@ -1070,15 +1112,16 @@ fn pass_one_dispatch(
     runtime: &Arc<dyn SystemRuntime>,
     project: &ProjectContext,
     format: &Format,
+    fail_fast: bool,
 ) -> (
     Vec<crate::document_profile::DocumentProfile>,
     Vec<FileFailure>,
 ) {
     let workers = pass1_worker_count();
     if workers == 1 || project.files.len() <= 1 {
-        return pass_one_dispatch_sequential(runtime, project, format);
+        return pass_one_dispatch_sequential(runtime, project, format, fail_fast);
     }
-    pass_one_dispatch_parallel(runtime, project, format, workers)
+    pass_one_dispatch_parallel(runtime, project, format, workers, fail_fast)
 }
 
 /// Sequential fan-out — the pre-Phase-2 behavior. Used:
@@ -1090,6 +1133,7 @@ fn pass_one_dispatch_sequential(
     runtime: &Arc<dyn SystemRuntime>,
     project: &ProjectContext,
     format: &Format,
+    fail_fast: bool,
 ) -> (
     Vec<crate::document_profile::DocumentProfile>,
     Vec<FileFailure>,
@@ -1099,7 +1143,14 @@ fn pass_one_dispatch_sequential(
     for doc_info in &project.files {
         match pollster::block_on(pass1_profile_with_cache(runtime, project, format, doc_info)) {
             Ok(profile) => profiles.push(profile),
-            Err(e) => failures.push(file_failure_from_error(doc_info.input.clone(), e)),
+            Err(e) => {
+                failures.push(file_failure_from_error(doc_info.input.clone(), e));
+                // Fail-fast: stop at the first error in document order.
+                // This path is deterministic (single-threaded).
+                if fail_fast {
+                    break;
+                }
+            }
         }
     }
     (profiles, failures)
@@ -1118,6 +1169,7 @@ async fn pass_one_dispatch_async(
     runtime: &Arc<dyn SystemRuntime>,
     project: &ProjectContext,
     format: &Format,
+    fail_fast: bool,
 ) -> (
     Vec<crate::document_profile::DocumentProfile>,
     Vec<FileFailure>,
@@ -1127,7 +1179,12 @@ async fn pass_one_dispatch_async(
     for doc_info in &project.files {
         match pass1_profile_with_cache(runtime, project, format, doc_info).await {
             Ok(profile) => profiles.push(profile),
-            Err(e) => failures.push(file_failure_from_error(doc_info.input.clone(), e)),
+            Err(e) => {
+                failures.push(file_failure_from_error(doc_info.input.clone(), e));
+                if fail_fast {
+                    break;
+                }
+            }
         }
     }
     (profiles, failures)
@@ -1157,6 +1214,7 @@ fn pass_one_dispatch_parallel(
     project: &ProjectContext,
     format: &Format,
     workers: usize,
+    fail_fast: bool,
 ) -> (
     Vec<crate::document_profile::DocumentProfile>,
     Vec<FileFailure>,
@@ -1166,6 +1224,10 @@ fn pass_one_dispatch_parallel(
     enum DocOutcome {
         Profile(crate::document_profile::DocumentProfile),
         Failure(FileFailure),
+        /// Fail-fast short-circuit: another worker already errored, so
+        /// this document was never parsed. Folded away (no profile, no
+        /// failure) when reducing outcomes.
+        Skipped,
     }
 
     // Build a local rayon pool sized to `workers` so `QUARTO_JOBS`
@@ -1186,8 +1248,15 @@ fn pass_one_dispatch_parallel(
         // Pool construction failed (extremely rare — typically an
         // OOM or thread-limit signal from the OS). Degrade to the
         // sequential path rather than aborting the render.
-        Err(_) => return pass_one_dispatch_sequential(runtime, project, format),
+        Err(_) => return pass_one_dispatch_sequential(runtime, project, format, fail_fast),
     };
+
+    // Fail-fast abort flag. A plain local `AtomicBool` is `Sync`, so
+    // `&aborted` can be captured by reference in the rayon closure
+    // without an `Arc`. rayon does not cancel running tasks, so a few
+    // in-flight workers may still error after this is set — accepted
+    // per the fail-fast contract.
+    let aborted = std::sync::atomic::AtomicBool::new(false);
 
     let mut outcomes: Vec<DocOutcome> = Vec::with_capacity(project.files.len());
     pool.install(|| {
@@ -1201,6 +1270,11 @@ fn pass_one_dispatch_parallel(
             .files
             .par_iter()
             .map(|doc_info| {
+                // Fail-fast: if another worker has already errored,
+                // skip parsing this document entirely.
+                if fail_fast && aborted.load(std::sync::atomic::Ordering::Relaxed) {
+                    return DocOutcome::Skipped;
+                }
                 let input = doc_info.input.clone();
                 // catch_unwind so a panic in
                 // `pass1_profile_with_cache` (e.g. tree-sitter
@@ -1215,8 +1289,16 @@ fn pass_one_dispatch_parallel(
                 }));
                 match result {
                     Ok(Ok(profile)) => DocOutcome::Profile(profile),
-                    Ok(Err(e)) => DocOutcome::Failure(file_failure_from_error(input, e)),
+                    Ok(Err(e)) => {
+                        if fail_fast {
+                            aborted.store(true, std::sync::atomic::Ordering::Relaxed);
+                        }
+                        DocOutcome::Failure(file_failure_from_error(input, e))
+                    }
                     Err(panic_payload) => {
+                        if fail_fast {
+                            aborted.store(true, std::sync::atomic::Ordering::Relaxed);
+                        }
                         let msg = panic_message(&panic_payload);
                         DocOutcome::Failure(file_failure_from_error(
                             input,
@@ -1236,6 +1318,9 @@ fn pass_one_dispatch_parallel(
         match outcome {
             DocOutcome::Profile(p) => profiles.push(p),
             DocOutcome::Failure(f) => failures.push(f),
+            // Fail-fast skip: contributed neither a profile nor a
+            // failure. Dropped here.
+            DocOutcome::Skipped => {}
         }
     }
     (profiles, failures)

--- a/crates/quarto-core/tests/integration/fail_fast.rs
+++ b/crates/quarto-core/tests/integration/fail_fast.rs
@@ -1,0 +1,225 @@
+/*
+ * tests/integration/fail_fast.rs
+ * Copyright (c) 2026 Posit, PBC
+ *
+ * `q2 render --fail-fast` orchestrator tests (bd-gi25b).
+ */
+
+//! Integration tests for the fail-fast project-render mode.
+//!
+//! These drive a real `ProjectPipeline` against a temp project
+//! directory (same shape as `incremental_rebuild.rs`) and assert the
+//! `--fail-fast` contract:
+//!
+//! - Sequential (`QUARTO_JOBS=1`): stops at the first error in
+//!   document order; `stopped_early` is set; fewer files are rendered
+//!   than the project contains.
+//! - Clean project: `--fail-fast` is a no-op — everything renders,
+//!   `stopped_early == false`.
+//! - Without `--fail-fast`: all errors are reported (regression guard
+//!   for the default best-effort behavior).
+//!
+//! `QUARTO_JOBS` is set via `std::env::set_var`. Under nextest each
+//! `#[test]` runs in its own process, so the env mutation is
+//! process-local and does not leak into sibling tests — acceptable
+//! here even though `set_var` is otherwise a shared-state hazard.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use tempfile::TempDir;
+
+use quarto_core::format::Format;
+use quarto_core::project::ProjectContext;
+use quarto_core::project::orchestrator::{ProjectPipeline, project_type_for};
+use quarto_core::render_to_file::RenderToFileOptions;
+use quarto_system_runtime::{NativeRuntime, SystemRuntime};
+
+fn canonical(p: &std::path::Path) -> PathBuf {
+    p.canonicalize().unwrap_or_else(|_| p.to_path_buf())
+}
+
+fn write(p: &std::path::Path, contents: &str) {
+    if let Some(parent) = p.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(p, contents).unwrap();
+}
+
+fn runtime_with_cache(project_dir: &std::path::Path) -> Arc<dyn SystemRuntime> {
+    Arc::new(NativeRuntime::with_cache_dir(
+        project_dir.join(".quarto/cache"),
+    ))
+}
+
+/// Run one full project render with the given `fail_fast` setting.
+fn render_project_fail_fast(
+    project_dir: &std::path::Path,
+    runtime: Arc<dyn SystemRuntime>,
+    fail_fast: bool,
+) -> quarto_core::project::orchestrator::ProjectRenderSummary {
+    let mut project =
+        ProjectContext::discover(project_dir, runtime.as_ref()).expect("discover project");
+    let options = RenderToFileOptions::default();
+    let project_type = project_type_for(&project);
+    let mut pipeline = ProjectPipeline::new(
+        &mut project,
+        project_type,
+        Format::html(),
+        "html",
+        &options,
+        runtime.clone(),
+    )
+    .with_fail_fast(fail_fast);
+    pollster::block_on(pipeline.run()).expect("project render")
+}
+
+/// Sequential fail-fast: an early file (in `project.files` order) has
+/// a parse error; later files are clean. With `QUARTO_JOBS=1` the
+/// dispatch is deterministic and breaks at the first error, so it
+/// produces strictly fewer outputs than the clean-file count and flags
+/// `stopped_early`.
+#[test]
+fn fail_fast_sequential_stops_at_first_error() {
+    // Force the deterministic single-threaded dispatch.
+    // SAFETY/scope: process-local under nextest (one process per test).
+    unsafe {
+        std::env::set_var("QUARTO_JOBS", "1");
+    }
+
+    let temp = TempDir::new().unwrap();
+    let project_dir = canonical(temp.path());
+
+    write(
+        &project_dir.join("_quarto.yml"),
+        "project:\n  type: website\n  output-dir: _site\n",
+    );
+    // `a.qmd` sorts first and has an unclosed `_` emphasis → Pass-1
+    // parse error. The remaining files are clean.
+    write(
+        &project_dir.join("a.qmd"),
+        "---\ntitle: A\n---\n\nLorem ipsum _dolor\n",
+    );
+    write(
+        &project_dir.join("b.qmd"),
+        "---\ntitle: B\n---\n\nClean b.\n",
+    );
+    write(
+        &project_dir.join("c.qmd"),
+        "---\ntitle: C\n---\n\nClean c.\n",
+    );
+    write(
+        &project_dir.join("d.qmd"),
+        "---\ntitle: D\n---\n\nClean d.\n",
+    );
+
+    let runtime = runtime_with_cache(&project_dir);
+    let summary = render_project_fail_fast(&project_dir, runtime, true);
+
+    assert!(
+        !summary.pass1_failures.is_empty(),
+        "fail-fast should report at least one Pass-1 failure; got none"
+    );
+    assert!(
+        summary.stopped_early,
+        "summary.stopped_early should be true under fail-fast with an error"
+    );
+    // There are 4 project files. The early error means Pass-2 never
+    // runs (the run() barrier returns after Pass-1), so no outputs are
+    // produced — strictly fewer than the 3 clean files.
+    assert!(
+        summary.outputs.len() < 3,
+        "fail-fast should stop early and render fewer than the clean-file count; \
+         got {} outputs",
+        summary.outputs.len()
+    );
+
+    unsafe {
+        std::env::remove_var("QUARTO_JOBS");
+    }
+}
+
+/// A clean project under `--fail-fast` renders everything and does not
+/// flag `stopped_early` — the flag is a no-op on error-free projects.
+#[test]
+fn fail_fast_clean_project_renders_all() {
+    let temp = TempDir::new().unwrap();
+    let project_dir = canonical(temp.path());
+
+    write(
+        &project_dir.join("_quarto.yml"),
+        "project:\n  type: website\n  output-dir: _site\n",
+    );
+    write(
+        &project_dir.join("index.qmd"),
+        "---\ntitle: Home\n---\n\nHello.\n",
+    );
+    write(
+        &project_dir.join("about.qmd"),
+        "---\ntitle: About\n---\n\nAbout us.\n",
+    );
+
+    let runtime = runtime_with_cache(&project_dir);
+    let summary = render_project_fail_fast(&project_dir, runtime, true);
+
+    assert!(
+        summary.pass1_failures.is_empty() && summary.pass2_failures.is_empty(),
+        "clean project should have no failures: pass1={:?} pass2={:?}",
+        summary.pass1_failures,
+        summary.pass2_failures
+    );
+    assert!(
+        !summary.stopped_early,
+        "stopped_early must be false for a clean project under --fail-fast"
+    );
+    assert_eq!(
+        summary.outputs.len(),
+        2,
+        "all pages should render with --fail-fast on a clean project"
+    );
+}
+
+/// Regression: WITHOUT `--fail-fast`, the default best-effort behavior
+/// reports every error. Two files each with a parse error → both
+/// reported, `stopped_early` stays false.
+#[test]
+fn no_fail_fast_reports_all_errors() {
+    // Sequential so we deterministically see both files processed.
+    unsafe {
+        std::env::set_var("QUARTO_JOBS", "1");
+    }
+
+    let temp = TempDir::new().unwrap();
+    let project_dir = canonical(temp.path());
+
+    write(
+        &project_dir.join("_quarto.yml"),
+        "project:\n  type: website\n  output-dir: _site\n",
+    );
+    write(
+        &project_dir.join("a.qmd"),
+        "---\ntitle: A\n---\n\nLorem _ipsum\n",
+    );
+    write(
+        &project_dir.join("b.qmd"),
+        "---\ntitle: B\n---\n\nDolor _sit\n",
+    );
+
+    let runtime = runtime_with_cache(&project_dir);
+    let summary = render_project_fail_fast(&project_dir, runtime, false);
+
+    assert_eq!(
+        summary.pass1_failures.len(),
+        2,
+        "without --fail-fast both files' errors should be reported; got {:?}",
+        summary.pass1_failures
+    );
+    assert!(
+        !summary.stopped_early,
+        "stopped_early must be false without --fail-fast"
+    );
+
+    unsafe {
+        std::env::remove_var("QUARTO_JOBS");
+    }
+}

--- a/crates/quarto-core/tests/integration/main.rs
+++ b/crates/quarto-core/tests/integration/main.rs
@@ -16,6 +16,7 @@ pub mod brand_render;
 pub mod crossref_fixtures;
 pub mod document_profile_pipeline;
 pub mod engine_merge;
+pub mod fail_fast;
 pub mod include_resolve_pipeline;
 pub mod incremental_rebuild;
 pub mod jupyter_integration;

--- a/crates/quarto/src/commands/render.rs
+++ b/crates/quarto/src/commands/render.rs
@@ -79,6 +79,12 @@ pub struct RenderArgs {
     /// `crates/quarto-error-reporting/schemas/`. Exit codes are
     /// unchanged.
     pub json_errors: bool,
+    /// Stop rendering as soon as the first per-document error occurs
+    /// (Pass-1 or Pass-2), instead of best-effort rendering everything.
+    /// Threaded into the orchestrator via
+    /// [`ProjectPipeline::with_fail_fast`]. Useful for an iterative
+    /// fix loop. Exit code is unchanged (any failure → non-zero).
+    pub fail_fast: bool,
 }
 
 /// What to render after argument classification.
@@ -616,7 +622,8 @@ fn execute_single_doc(
         &format_str,
         options,
         runtime_arc.clone(),
-    );
+    )
+    .with_fail_fast(args.fail_fast);
 
     let summary = match pollster::block_on(pipeline.run()) {
         Ok(s) => s,
@@ -677,7 +684,8 @@ fn execute_project(
         format_str,
         options,
         runtime_arc.clone(),
-    );
+    )
+    .with_fail_fast(args.fail_fast);
 
     if let Some(target_set) = targets {
         let set: std::collections::HashSet<PathBuf> = target_set.into_iter().collect();
@@ -825,6 +833,15 @@ fn print_render_diagnostics_text(
         if !quiet {
             info!("Output: {}", result.output_path.display());
         }
+    }
+
+    // bd-gi25b: when `--fail-fast` cut the render short, tell the user
+    // the report isn't exhaustive. Only the text path carries this
+    // note — the `--json-errors` path gets no extra field (a
+    // programmatic caller passing `--fail-fast` already knows the
+    // semantics).
+    if summary.stopped_early {
+        eprintln!("note: stopped at first error (--fail-fast); remaining files not checked");
     }
 }
 

--- a/crates/quarto/src/main.rs
+++ b/crates/quarto/src/main.rs
@@ -162,6 +162,12 @@ enum Commands {
         /// `crates/quarto-error-reporting/schemas/`). bd-iey8o.
         #[arg(long = "json-errors")]
         json_errors: bool,
+
+        /// Stop rendering as soon as the first error occurs (Pass-1 or
+        /// Pass-2), instead of best-effort rendering everything. Useful
+        /// for an iterative fix loop.
+        #[arg(long = "fail-fast")]
+        fail_fast: bool,
     },
 
     /// Start a live preview of a Quarto document or project.
@@ -577,6 +583,7 @@ fn main() -> Result<()> {
             debug,
             attribution,
             json_errors,
+            fail_fast,
             ..
         } => commands::render::execute(commands::render::RenderArgs {
             inputs,
@@ -589,6 +596,7 @@ fn main() -> Result<()> {
             debug,
             attribution,
             json_errors,
+            fail_fast,
         }),
         Commands::Preview {
             path,


### PR DESCRIPTION
## Summary

`q2 render` is best-effort: it renders everything and reports all failures at the end. That's slow for the iterative **find an error → fix it → re-render** loop — on the qmd-plans corpus (565 files, 140 with errors) a full render is **4.4 s** even though you only need the first error.

`--fail-fast` stops as soon as **any** per-document error is seen (pass-1 or pass-2).

## Measured (qmd-plans, release build)

| mode | wall | errors reported |
| --- | --- | --- |
| baseline (no flag) | 4.41 s | full render, 425/565 |
| `--fail-fast` (16 threads) | **~0.11 s** | 6–10 (raced before abort), note shown |
| `--fail-fast QUARTO_JOBS=1` | **0.08 s** | exactly 1, deterministic |

≈ **40× / 55× faster** to surface an error.

## Semantics

Hard stop at the first error. Under multithreading we accept that a **few** errors may be reported (in-flight rayon tasks that race before the abort flag is observed) and that **which** error surfaces is nondeterministic. Contract: *if the project has any error, `--fail-fast` reports ≥1 and exits non-zero without rendering the rest.* `QUARTO_JOBS=1` is deterministic (first error in file order — also the fastest "one error at a time" mode). Default (no flag) behavior is unchanged.

## Implementation

- `ProjectPipeline::with_fail_fast(bool)` builder + `fail_fast` field.
- **Pass-1** parallel fan-out: a local `AtomicBool` checked at the rayon `map` entry (skip remaining docs once any worker errors; new `DocOutcome::Skipped`, folded away). Sequential + WASM-async paths `break` on first error. Order-preservation (`collect_into_vec`) intact.
- `run()` returns immediately after pass-1 if it aborted — skips `pre_render` / pass-2 / `post_render` / resource-copy / manifest.
- **Pass-2** (already sequential) `break`s on the first render error.
- `ProjectRenderSummary.stopped_early` drives a **text-only** note: `note: stopped at first error (--fail-fast); remaining files not checked`. The `--json-errors` path is unchanged (a programmatic caller passing `--fail-fast` already knows the semantics).
- Per-document only; no project-hook logic changes.

## Tests

`crates/quarto-core/tests/integration/fail_fast.rs`: sequential stop-at-first-error, clean-project no-op, and a no-flag "reports all" regression guard. Full `cargo xtask verify` (Rust workspace + WASM/hub build + hub tests) passes; no regressions (incl. `pass_one_preserves_input_order`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)