### PR TITLE
fix: use auth name for new identity when auth is enabled

### DIFF
--- a/hub-client/changelog.md
+++ b/hub-client/changelog.md
@@ -15,6 +15,10 @@ be in reverse chronological order (latest first).
 
 -->
 
+### 2026-06-09
+
+- [`749064d1`](https://github.com/quarto-dev/q2/commits/749064d1): Fix identity name defaulting to a random "Adjective Animal" instead of the authenticated user's name when a new project set is created.
+
 ### 2026-06-02
 
 - [`301ca456`](https://github.com/quarto-dev/q2/commits/301ca456): Add "Import from ZIP" to the project selector — create a new project from an uploaded .zip archive (the inverse of "Export to ZIP").

--- a/hub-client/src/App.tsx
+++ b/hub-client/src/App.tsx
@@ -111,7 +111,7 @@ function App() {
   useEffect(() => {
     if (AUTH_ENABLED && authLoading) return;
     getUserIdentity().then(async (settings) => {
-      if (auth?.name && settings.userName.startsWith('Anonymous ')) {
+      if (auth?.name && settings.createdAt === settings.updatedAt) {
         const updated = await updateUserName(auth.name);
         setScreenName(updated.userName);
         setCursorColor(updated.userColor);

--- a/hub-client/src/__mocks__/userSettings.ts
+++ b/hub-client/src/__mocks__/userSettings.ts
@@ -66,7 +66,7 @@ export const resetUserIdentity = vi.fn(async (): Promise<UserSettings> => {
   mockIdentity = {
     key: 'identity',
     userId,
-    userName: 'Anonymous Test User',
+    userName: 'Swift Penguin',
     userColor: '#' + Math.floor(Math.random() * 16777215).toString(16).padStart(6, '0'),
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),

--- a/hub-client/src/services/storage/utils.ts
+++ b/hub-client/src/services/storage/utils.ts
@@ -48,8 +48,8 @@ export function generateColorFromId(userId: string): string {
 }
 
 /**
- * Generate a random anonymous display name.
- * Format: "Anonymous [Adjective] [Animal]"
+ * Generate a random display name.
+ * Format: "[Adjective] [Animal]"
  *
  * This provides friendly, memorable names for users who haven't set a custom name.
  */


### PR DESCRIPTION
Fixes the project selector defaulting to a randomized name when auth is enabled and a new identity is created.

Previously the condition checked `startsWith('Anonymous ')` which never matched the actual generated "Adjective Animal" format. Now uses `createdAt === updatedAt` to detect a freshly created, never-modified identity — the auth name is applied once at that point and never overwritten again.