### PR TITLE
refactor(auth): introduce OidcProvider enum and generic CSRF dispatch

### DIFF
--- a/crates/quarto-hub/src/auth.rs
+++ b/crates/quarto-hub/src/auth.rs
@@ -23,6 +23,18 @@ use tokio_util::sync::CancellationToken;
 /// Default image domain for Google profile pictures.
 const DEFAULT_IMAGE_DOMAIN: &str = "lh3.googleusercontent.com";
 
+/// The identity provider behind an [`AuthConfig`].
+///
+/// Derived from the issuer URL at construction time. Add a new variant here
+/// when wiring up a new provider — the compiler will enforce handling it in
+/// every `match` that dispatches on provider-specific behaviour.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OidcProvider {
+    Google,
+    /// Any other OIDC-compliant provider.
+    Generic,
+}
+
 /// Authentication configuration.
 ///
 /// Construct via [`AuthConfig::new()`] which validates the issuer URL
@@ -43,6 +55,8 @@ pub struct AuthConfig {
     pub image_domains: Vec<String>,
     pub allowed_emails: Option<Vec<String>>,
     pub allowed_domains: Option<Vec<String>>,
+    /// Identity provider, derived from `issuer` at construction time.
+    pub provider: OidcProvider,
 }
 
 impl AuthConfig {
@@ -50,7 +64,8 @@ impl AuthConfig {
     ///
     /// - `issuer` must be a well-formed HTTPS URL.
     /// - Each image domain must be a bare hostname (no scheme, no path).
-    /// - If `image_domains` is empty, defaults to Google's profile picture CDN.
+    /// - If `image_domains` is empty and the issuer is Google, defaults to
+    ///   Google's profile picture CDN. For other providers, empty means empty.
     pub fn new(
         client_id: String,
         additional_audiences: Vec<String>,
@@ -69,8 +84,14 @@ impl AuthConfig {
             ));
         }
 
+        let provider = if issuer.trim_end_matches('/') == "https://accounts.google.com" {
+            OidcProvider::Google
+        } else {
+            OidcProvider::Generic
+        };
+
         // Apply default and validate image domains.
-        let image_domains = if image_domains.is_empty() {
+        let image_domains = if image_domains.is_empty() && provider == OidcProvider::Google {
             vec![DEFAULT_IMAGE_DOMAIN.to_string()]
         } else {
             for domain in &image_domains {
@@ -86,6 +107,7 @@ impl AuthConfig {
             image_domains,
             allowed_emails,
             allowed_domains,
+            provider,
         })
     }
 
@@ -95,11 +117,31 @@ impl AuthConfig {
         std::iter::once(&self.client_id).chain(self.additional_audiences.iter())
     }
 
-    /// Whether the configured issuer is Google (`https://accounts.google.com`).
+    /// Whether to register the `POST /auth/callback` route for this provider.
     ///
-    /// Used to gate Google-specific endpoints like `/auth/callback`.
-    pub fn is_google_issuer(&self) -> bool {
-        self.issuer.trim_end_matches('/') == "https://accounts.google.com"
+    /// Returns `true` for providers that deliver credentials via an
+    /// auto-submitting HTML form POST (`response_mode=form_post` or equivalent).
+    /// Add new form-POST providers here as they are implemented.
+    pub fn uses_form_post_callback(&self) -> bool {
+        match self.provider {
+            OidcProvider::Google => true,
+            OidcProvider::Generic => false,
+        }
+    }
+
+    /// CSRF validation strategy for `POST /auth/callback`.
+    ///
+    /// Each provider uses a different mechanism to bind the callback to the
+    /// originating browser session. See [`CallbackCsrfMode`].
+    pub fn callback_csrf_mode(&self) -> CallbackCsrfMode {
+        match self.provider {
+            OidcProvider::Google => CallbackCsrfMode::GoogleDoubleSubmit,
+            // Non-Google form_post providers need a hub-set signed cookie on
+            // the pre-flight endpoint. Not yet implemented; fails safe.
+            OidcProvider::Generic => CallbackCsrfMode::OidcState {
+                cookie_name: "oidc_state",
+            },
+        }
     }
 
     /// Extract the CSP origin (`scheme://host[:port]`) from the validated issuer URL.
@@ -550,6 +592,34 @@ pub async fn build_auth_state_from_parts(
         _refresh_handle: refresh_handle,
         _cancellation_token: cancellation_token,
     })
+}
+
+/// CSRF validation strategy for `POST /auth/callback`.
+///
+/// Returned by [`AuthConfig::callback_csrf_mode()`]. The handler dispatches on
+/// this value so adding a new provider only requires a new variant here and a
+/// match arm in `validate_callback_csrf` — the callback handler itself is
+/// unchanged.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CallbackCsrfMode {
+    /// Google's double-submit cookie pattern: the `g_csrf_token` value in the
+    /// POST form body must equal the `g_csrf_token` cookie set by GIS on the
+    /// hub origin before navigation.
+    GoogleDoubleSubmit,
+    /// Standard OIDC `state` parameter checked against a hub-set signed cookie.
+    ///
+    /// The hub must set a signed `SameSite=Strict; HttpOnly` cookie named
+    /// `cookie_name` on the pre-flight redirect endpoint, containing the
+    /// expected `state` value. The callback verifies the cookie signature and
+    /// compares it to the `state` form field.
+    ///
+    /// **Not yet implemented.** The pre-flight endpoint and signing key are
+    /// deferred; the callback handler returns an error for this variant until
+    /// they are in place.
+    OidcState {
+        /// Name of the hub-set signed cookie carrying the expected state value.
+        cookie_name: &'static str,
+    },
 }
 
 /// Validate that TLS is accounted for when auth is enabled.
@@ -1063,6 +1133,20 @@ mod tests {
     }
 
     #[test]
+    fn auth_config_non_google_empty_image_domains_stays_empty() {
+        let config = AuthConfig::new(
+            "client-id".to_string(),
+            Vec::new(),
+            "https://login.microsoftonline.com/tenant/v2.0".to_string(),
+            vec![],
+            None,
+            None,
+        )
+        .unwrap();
+        assert!(config.image_domains.is_empty());
+    }
+
+    #[test]
     fn auth_config_rejects_invalid_image_domain() {
         let result = AuthConfig::new(
             "client-id".to_string(),
@@ -1121,16 +1205,16 @@ mod tests {
         assert_eq!(audiences[2], "another");
     }
 
-    // ── is_google_issuer ──────────────────────────────────────────
+    // ── OidcProvider detection ────────────────────────────────────
 
     #[test]
-    fn is_google_issuer_true() {
+    fn provider_google_for_google_issuer() {
         let config = make_config(None, None);
-        assert!(config.is_google_issuer());
+        assert_eq!(config.provider, OidcProvider::Google);
     }
 
     #[test]
-    fn is_google_issuer_with_trailing_slash() {
+    fn provider_google_with_trailing_slash() {
         let config = AuthConfig::new(
             "client-id".to_string(),
             Vec::new(),
@@ -1140,11 +1224,11 @@ mod tests {
             None,
         )
         .unwrap();
-        assert!(config.is_google_issuer());
+        assert_eq!(config.provider, OidcProvider::Google);
     }
 
     #[test]
-    fn is_google_issuer_false_for_azure() {
+    fn provider_generic_for_non_google_issuer() {
         let config = AuthConfig::new(
             "client-id".to_string(),
             Vec::new(),
@@ -1154,7 +1238,7 @@ mod tests {
             None,
         )
         .unwrap();
-        assert!(!config.is_google_issuer());
+        assert_eq!(config.provider, OidcProvider::Generic);
     }
 
     // ── signing_algorithm ─────────────────────────────────────────
@@ -1391,6 +1475,59 @@ mod tests {
         let id1 = sub_to_actor_id_for_project(&[1u8; 32], "user123", "automerge:abc");
         let id2 = sub_to_actor_id_for_project(&[2u8; 32], "user123", "automerge:abc");
         assert_ne!(id1, id2);
+    }
+
+    // ── callback_csrf_mode / uses_form_post_callback ──────────────
+
+    fn make_config_with_issuer(issuer: &str) -> AuthConfig {
+        AuthConfig::new(
+            "client-id".to_string(),
+            Vec::new(),
+            issuer.to_string(),
+            Vec::new(),
+            None,
+            None,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn google_issuer_uses_double_submit_csrf() {
+        let config = make_config_with_issuer("https://accounts.google.com");
+        assert_eq!(
+            config.callback_csrf_mode(),
+            CallbackCsrfMode::GoogleDoubleSubmit
+        );
+    }
+
+    #[test]
+    fn google_issuer_trailing_slash_uses_double_submit_csrf() {
+        let config = make_config_with_issuer("https://accounts.google.com/");
+        assert_eq!(
+            config.callback_csrf_mode(),
+            CallbackCsrfMode::GoogleDoubleSubmit
+        );
+    }
+
+    #[test]
+    fn non_google_issuer_uses_oidc_state_csrf() {
+        let config = make_config_with_issuer("https://login.example.com");
+        assert!(matches!(
+            config.callback_csrf_mode(),
+            CallbackCsrfMode::OidcState { .. }
+        ));
+    }
+
+    #[test]
+    fn google_issuer_uses_form_post_callback() {
+        let config = make_config_with_issuer("https://accounts.google.com");
+        assert!(config.uses_form_post_callback());
+    }
+
+    #[test]
+    fn non_google_issuer_does_not_use_form_post_callback() {
+        let config = make_config_with_issuer("https://login.example.com");
+        assert!(!config.uses_form_post_callback());
     }
 
     #[test]

--- a/crates/quarto-hub/src/server.rs
+++ b/crates/quarto-hub/src/server.rs
@@ -637,55 +637,78 @@ async fn update_document(
     }
 }
 
-/// Google-frontend-specific OAuth2 redirect callback form data.
+/// Form data for `POST /auth/callback`.
 ///
-/// When `GoogleLogin` uses `ux_mode="redirect"`, Google POSTs the credential
-/// JWT and a CSRF token to the `login_uri` after the user authenticates.
-///
-/// This form structure is specific to Google's Sign-In library. Non-Google
-/// OIDC frontends should use `POST /auth/refresh` instead.
+/// Providers that use `response_mode=form_post` (or equivalent) POST a
+/// credential JWT plus a provider-specific CSRF field. Fields are optional at
+/// the struct level; `validate_callback_csrf` enforces which ones are required
+/// for the active provider.
 #[derive(Deserialize)]
 struct AuthCallbackForm {
     credential: String,
-    g_csrf_token: String,
+    /// Google double-submit CSRF token (GIS `ux_mode=redirect`). Present only
+    /// for Google providers.
+    g_csrf_token: Option<String>,
 }
 
-/// Handle Google-frontend-specific OAuth2 redirect callback.
+/// Validate the CSRF token for `POST /auth/callback`.
 ///
-/// Receives the credential JWT from Google's POST, validates the CSRF token
-/// and the JWT itself, then sets an HttpOnly cookie and redirects to `/`.
+/// Dispatches to the provider-specific check determined by `mode`:
 ///
-/// Validating the JWT here (not just in subsequent API calls) prevents
-/// setting a cookie with a bogus credential.
+/// - `GoogleDoubleSubmit`: the `g_csrf_token` form value must equal the
+///   `g_csrf_token` cookie set by GIS on the hub origin before navigation.
+/// - `OidcState`: not yet implemented; returns `false` so the callback fails
+///   safe until the pre-flight endpoint and signing key are in place.
+fn validate_callback_csrf(
+    mode: &auth::CallbackCsrfMode,
+    form: &AuthCallbackForm,
+    headers: &HeaderMap,
+) -> bool {
+    match mode {
+        auth::CallbackCsrfMode::GoogleDoubleSubmit => {
+            let Some(token) = form.g_csrf_token.as_deref().filter(|t| !t.is_empty()) else {
+                return false;
+            };
+            let cookie_csrf = headers
+                .get("cookie")
+                .and_then(|v| v.to_str().ok())
+                .and_then(|cookies| {
+                    cookies
+                        .split(';')
+                        .filter_map(|s| cookie::Cookie::parse(s.trim()).ok())
+                        .find(|c| c.name() == "g_csrf_token")
+                        .map(|c| c.value().to_owned())
+                });
+            cookie_csrf.as_deref() == Some(token)
+        }
+        auth::CallbackCsrfMode::OidcState { .. } => {
+            // Stateful validation requires a hub-set signed cookie from a
+            // pre-flight endpoint that does not yet exist. Fail safe.
+            false
+        }
+    }
+}
+
+/// Handle `POST /auth/callback` — credential delivery via form POST.
 ///
-/// **Google-specific**: This endpoint is tightly coupled to Google's Sign-In
-/// library (which controls the POST body and `g_csrf_token` cookie). Non-Google
-/// OIDC frontends should use `POST /auth/refresh` instead — it accepts a JWT
-/// via JSON POST, validates through the full JWKS/issuer/allowlist pipeline,
-/// and is protected by the standard `X-Requested-With` CSRF check.
+/// Registered for providers where [`AuthConfig::uses_form_post_callback()`]
+/// returns `true`. Validates the provider-specific CSRF token, then validates
+/// the credential JWT and sets an HttpOnly cookie.
 ///
-/// **CSRF**: This endpoint is excluded from the `X-Requested-With` CSRF
-/// check because it receives a cross-origin POST from Google's servers.
-/// Google's own `g_csrf_token` cookie provides CSRF protection instead.
+/// **CSRF**: excluded from the `X-Requested-With` check because the POST
+/// originates from the IdP (cross-origin). Provider-specific CSRF is handled
+/// by [`validate_callback_csrf`] instead.
 async fn auth_callback(
     State(ctx): State<SharedContext>,
     headers: HeaderMap,
     Form(form): Form<AuthCallbackForm>,
 ) -> impl IntoResponse {
-    // Validate CSRF: g_csrf_token cookie must match the form value.
-    // Google sets this cookie and includes the same value in the POST body.
-    let cookie_csrf = headers
-        .get("cookie")
-        .and_then(|v| v.to_str().ok())
-        .and_then(|cookies| {
-            cookies
-                .split(';')
-                .filter_map(|s| cookie::Cookie::parse(s.trim()).ok())
-                .find(|c| c.name() == "g_csrf_token")
-                .map(|c| c.value().to_owned())
-        });
+    let mode = ctx
+        .auth_config()
+        .map(|c| c.callback_csrf_mode())
+        .unwrap_or(auth::CallbackCsrfMode::GoogleDoubleSubmit);
 
-    if form.g_csrf_token.is_empty() || cookie_csrf.as_deref() != Some(form.g_csrf_token.as_str()) {
+    if !validate_callback_csrf(&mode, &form, &headers) {
         return Redirect::to("/?auth_error").into_response();
     }
 
@@ -1041,9 +1064,12 @@ pub async fn build_router_with_state(ctx: SharedContext) -> Result<Router<Shared
         router = router.route("/", get(ws_handler));
     }
 
-    // Google-specific redirect callback: only registered when the issuer is Google.
-    // Non-Google OIDC frontends should use POST /auth/refresh instead.
-    if ctx.auth_config().is_some_and(|c| c.is_google_issuer()) {
+    // Register the form-POST callback route for providers that use it.
+    // Add new providers by returning true from AuthConfig::uses_form_post_callback().
+    if ctx
+        .auth_config()
+        .is_some_and(|c| c.uses_form_post_callback())
+    {
         router = router.route("/auth/callback", post(auth_callback));
     }
 
@@ -1662,17 +1688,117 @@ mod tests {
     // ── AuthCallbackForm ──────────────────────────────────────────
 
     #[test]
-    fn auth_callback_form_deserializes() {
-        // AuthCallbackForm is used by axum's Form extractor which parses
-        // URL-encoded POST bodies. Verify it has the expected fields by
-        // deserializing from JSON (same serde derive).
+    fn auth_callback_form_google_deserializes() {
         let form: AuthCallbackForm = serde_json::from_value(serde_json::json!({
             "credential": "eyJhbGciOiJSUzI1NiJ9.test",
             "g_csrf_token": "abc123"
         }))
         .unwrap();
         assert_eq!(form.credential, "eyJhbGciOiJSUzI1NiJ9.test");
-        assert_eq!(form.g_csrf_token, "abc123");
+        assert_eq!(form.g_csrf_token.as_deref(), Some("abc123"));
+    }
+
+    #[test]
+    fn auth_callback_form_oidc_deserializes() {
+        // `state` is an extra field serde ignores — the struct only holds fields
+        // it actually uses. Verify credential and absent g_csrf_token.
+        let form: AuthCallbackForm = serde_json::from_value(serde_json::json!({
+            "credential": "eyJhbGciOiJSUzI1NiJ9.test",
+            "state": "random-state-value"
+        }))
+        .unwrap();
+        assert_eq!(form.credential, "eyJhbGciOiJSUzI1NiJ9.test");
+        assert!(form.g_csrf_token.is_none());
+    }
+
+    // ── validate_callback_csrf ────────────────────────────────────
+
+    fn google_csrf_form(token: &str) -> AuthCallbackForm {
+        AuthCallbackForm {
+            credential: "cred".to_string(),
+            g_csrf_token: Some(token.to_string()),
+        }
+    }
+
+    fn oidc_state_form(_state: &str) -> AuthCallbackForm {
+        AuthCallbackForm {
+            credential: "cred".to_string(),
+            g_csrf_token: None,
+        }
+    }
+
+    #[test]
+    fn google_double_submit_accepts_matching_token() {
+        let form = google_csrf_form("tok123");
+        let headers = headers_with(&[("cookie", "g_csrf_token=tok123")]);
+        assert!(validate_callback_csrf(
+            &auth::CallbackCsrfMode::GoogleDoubleSubmit,
+            &form,
+            &headers
+        ));
+    }
+
+    #[test]
+    fn google_double_submit_rejects_mismatched_token() {
+        let form = google_csrf_form("tok123");
+        let headers = headers_with(&[("cookie", "g_csrf_token=other")]);
+        assert!(!validate_callback_csrf(
+            &auth::CallbackCsrfMode::GoogleDoubleSubmit,
+            &form,
+            &headers
+        ));
+    }
+
+    #[test]
+    fn google_double_submit_rejects_missing_form_token() {
+        let form = AuthCallbackForm {
+            credential: "cred".to_string(),
+            g_csrf_token: None,
+        };
+        let headers = headers_with(&[("cookie", "g_csrf_token=tok123")]);
+        assert!(!validate_callback_csrf(
+            &auth::CallbackCsrfMode::GoogleDoubleSubmit,
+            &form,
+            &headers
+        ));
+    }
+
+    #[test]
+    fn google_double_submit_rejects_empty_form_token() {
+        let form = google_csrf_form("");
+        let headers = headers_with(&[("cookie", "g_csrf_token=tok123")]);
+        assert!(!validate_callback_csrf(
+            &auth::CallbackCsrfMode::GoogleDoubleSubmit,
+            &form,
+            &headers
+        ));
+    }
+
+    #[test]
+    fn google_double_submit_rejects_missing_cookie() {
+        let form = google_csrf_form("tok123");
+        let headers = HeaderMap::new();
+        assert!(!validate_callback_csrf(
+            &auth::CallbackCsrfMode::GoogleDoubleSubmit,
+            &form,
+            &headers
+        ));
+    }
+
+    #[test]
+    fn oidc_state_fails_safe_until_implemented() {
+        // OidcState is a placeholder: the pre-flight endpoint and signed cookie
+        // that would make this check stateful do not exist yet. Validate that
+        // the callback always rejects rather than silently passing.
+        let form = oidc_state_form("any-state");
+        let headers = headers_with(&[("cookie", "oidc_state=any-state")]);
+        assert!(!validate_callback_csrf(
+            &auth::CallbackCsrfMode::OidcState {
+                cookie_name: "oidc_state"
+            },
+            &form,
+            &headers
+        ));
     }
 
     // ── format_peer_info ──────────────────────────────────────────

--- a/crates/quarto-hub/tests/auth_bearer.rs
+++ b/crates/quarto-hub/tests/auth_bearer.rs
@@ -340,6 +340,7 @@ impl TestHub {
             image_domains: vec!["lh3.googleusercontent.com".to_string()],
             allowed_emails: None,
             allowed_domains: None,
+            provider: auth::OidcProvider::Generic,
         };
 
         // Standalone HubContext so we don't need a project on disk.
@@ -461,6 +462,7 @@ async fn allowlist_setup() -> &'static (MockOidcProvider, TestHub) {
                 image_domains: vec!["lh3.googleusercontent.com".to_string()],
                 allowed_emails: None,
                 allowed_domains: Some(vec!["posit.co".to_string()]),
+                provider: auth::OidcProvider::Generic,
             };
 
             let temp = tempfile::TempDir::new().unwrap();
@@ -922,6 +924,7 @@ async fn secure_setup() -> &'static (MockOidcProvider, TestHub) {
                 image_domains: vec!["lh3.googleusercontent.com".to_string()],
                 allowed_emails: None,
                 allowed_domains: None,
+                provider: auth::OidcProvider::Generic,
             };
 
             let temp = tempfile::TempDir::new().unwrap();

--- a/hub-client/src/services/authService.ts
+++ b/hub-client/src/services/authService.ts
@@ -70,7 +70,7 @@ export async function logout(): Promise<void> {
 }
 
 /**
- * Send a fresh Google JWT to the server for validation and cookie refresh.
+ * Send a fresh OIDC ID token to the server for validation and cookie refresh.
  * Returns the updated user info on success, null on auth failure.
  */
 export async function refreshToken(credential: string): Promise<AuthState | null> {


### PR DESCRIPTION
**Provider abstraction**
- Replace `is_google_issuer()` with an `OidcProvider` enum (`Google` / `Generic`) stored on `AuthConfig`; dispatch methods are now exhaustive `match` blocks so new variants produce compile errors at unhandled sites

**CSRF dispatch**
- Extract `validate_callback_csrf` in `server.rs`; `OidcState` variant fails safe until the pre-flight signed-cookie mechanism is implemented

**Fixes and cleanup**
- `DEFAULT_IMAGE_DOMAIN` fallback only applied for Google; non-Google providers with empty `image_domains` now get an empty list
- Remove unused `state` field from `AuthCallbackForm`
- Fix stale "Google JWT" comment in `authService.ts`