### PR TITLE
fix(footnotes): honor reference-location from front matter (bd-9ez3ngt1)

### DIFF
--- a/crates/quarto-core/src/render_to_file.rs
+++ b/crates/quarto-core/src/render_to_file.rs
@@ -555,6 +555,40 @@ mod tests {
         assert_eq!(stem, "doc");
     }
 
+    /// bd-9ez3ngt1: `reference-location` set in YAML front matter must be
+    /// honored end-to-end. In document-metadata context a bare YAML string is
+    /// parsed as markdown and stored as `ConfigValueKind::PandocInlines`, so
+    /// the transform's `meta.get("reference-location").as_str()` returned
+    /// `None` and silently fell back to the `document` default. With
+    /// `as_plain_text()` the value resolves, so `reference-location: margin`
+    /// produces a `margin-note` reference and NO document footnotes section.
+    #[test]
+    fn test_render_to_file_honors_margin_reference_location() {
+        let temp = TempDir::new().unwrap();
+        let input_path = temp.path().join("margin.qmd");
+
+        fs::write(
+            &input_path,
+            "---\nformat: html\nreference-location: margin\n---\nRef.^[the body]\n",
+        )
+        .unwrap();
+
+        let runtime = Arc::new(NativeRuntime::new());
+        let options = RenderToFileOptions::default();
+
+        let result = render_to_file(&input_path, "html", &options, runtime).unwrap();
+        let html = fs::read_to_string(&result.output_path).unwrap();
+
+        assert!(
+            html.contains("margin-note"),
+            "expected margin-note class for reference-location: margin; got:\n{html}"
+        );
+        assert!(
+            !html.contains("doc-endnotes"),
+            "margin mode must NOT emit a document footnotes section; got:\n{html}"
+        );
+    }
+
     #[test]
     fn test_render_to_file_creates_output() {
         let temp = TempDir::new().unwrap();

--- a/crates/quarto-core/src/transforms/appendix.rs
+++ b/crates/quarto-core/src/transforms/appendix.rs
@@ -88,9 +88,12 @@ impl AppendixStructureTransform {
 
     /// Get the reference-location configuration.
     fn get_reference_location(meta: &ConfigValue) -> ReferenceLocation {
+        // Use `as_plain_text` (not `as_str`): front-matter string values are
+        // stored as `ConfigValueKind::PandocInlines` in document-metadata
+        // context, for which `as_str` returns `None`. (bd-9ez3ngt1)
         meta.get("reference-location")
-            .and_then(|v| v.as_str())
-            .map(ReferenceLocation::from_str)
+            .and_then(|v| v.as_plain_text())
+            .map(|s| ReferenceLocation::from_str(&s))
             .unwrap_or_default()
     }
 

--- a/crates/quarto-core/src/transforms/footnotes.rs
+++ b/crates/quarto-core/src/transforms/footnotes.rs
@@ -74,9 +74,13 @@ impl FootnotesTransform {
 
     /// Get the reference-location configuration from merged metadata.
     fn get_reference_location(meta: &ConfigValue) -> ReferenceLocation {
+        // Use `as_plain_text` (not `as_str`): in document-metadata context a
+        // bare YAML string value is parsed as markdown and stored as
+        // `ConfigValueKind::PandocInlines`, for which `as_str` returns `None`.
+        // `as_plain_text` handles both the inline and scalar forms. (bd-9ez3ngt1)
         meta.get("reference-location")
-            .and_then(|v| v.as_str())
-            .map(ReferenceLocation::from_str)
+            .and_then(|v| v.as_plain_text())
+            .map(|s| ReferenceLocation::from_str(&s))
             .unwrap_or_default()
     }
 }


### PR DESCRIPTION
## Summary

`reference-location` set in document YAML front matter was **silently ignored** for every placement (top-level, nested under `format.html`) and every value (`margin`/`block`/`section`) — rendering always fell back to the `document` default. So `reference-location: margin` produced a document footnotes section instead of margin notes, and `block`/`section` were misrendered as `document`.

## Root cause

In document-metadata context a bare YAML string value is parsed as **markdown** and stored as `ConfigValueKind::PandocInlines`, not `Scalar(String)` (this is the deliberate design that lets users write `title: this is **exciting**!`). `ConfigValue::as_str()` returns `None` for `PandocInlines`, so `get_reference_location`'s `meta.get("reference-location").and_then(|v| v.as_str())` yielded `None` and defaulted to `Document`.

Confirmed by dumping the value the transform actually sees at runtime in the real `q2 render` pipeline:

```
reference-location: margin       -> kind=PandocInlines, as_str()=None, as_plain_text()=Some("margin")
reference-location: !str margin  -> kind=Scalar,        as_str()=Some("margin")
```

(The `!str` tag is a working-but-undocumented escape hatch today.)

## Fix

Read the value with `as_plain_text()` — which handles both `Scalar(String)` and `PandocInlines` — in the `get_reference_location` of **both** `FootnotesTransform` (`transforms/footnotes.rs`) and `AppendixStructureTransform` (`transforms/appendix.rs`). This matches the convention already established for metadata strings in `filter_resolve.rs` (with the comment *"handle both Scalar(String) and PandocInlines forms"*) and `document_profile.rs`.

## Tests

- E2E `test_render_to_file_honors_margin_reference_location` (`render_to_file.rs`), driving the real CLI `render_to_file` path. Confirmed failing pre-fix.

## Verification

- `quarto-core`: 2177 passed; workspace: 9559 passed; full `cargo xtask verify` (strict build + WASM/hub-client build + hub tests): green.
- Real `q2 render`:
  - `reference-location: margin` → `margin-note` class, **no** `doc-endnotes` section.
  - default (no key) → `doc-endnotes` section (**unchanged**).
  - `reference-location: block` → now detected; `FootnotesTransform` no-ops (detailed block/section numbering remains bd-1kly's domain).

## Notes

- Distinct from #264 (named `[^id]` footnote refs, bd-po3gn41h) and from bd-1kly (block/section numbering). Discovered while verifying #264's margin-mode parity.
- The broader pattern — reading metadata string options with `as_str()` instead of `as_plain_text()` — may affect other options (e.g. some appendix license/copyright reads). Out of scope here; worth a separate sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)