### PR TITLE
fix(metadata): read front-matter string options via as_plain_text (bd-y89ihf0i)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -486,6 +486,7 @@ cargo xtask lint --quiet   # Only show errors
 ### Current Lint Rules
 
 - **external-sources-in-macro**: Detects references to `external-sources/` in compile-time macros like `include_dir!`, `include_str!`, `include_bytes!`. These break builds because `external-sources/` is not version-controlled.
+- **metadata-as-str**: Detects `meta.get("key")…as_str()` reads of document metadata. A bare YAML string in front-matter context is stored as `ConfigValueKind::PandocInlines`, for which `ConfigValue::as_str()` returns `None` — silently dropping the option. Use `as_plain_text()` instead (handles both `Scalar(String)` and `PandocInlines`). Only flags chains whose `.get(<string literal>)` receiver is a metadata expression (final identifier `meta`/`metadata`); internal map reads and test code are skipped. Suppress a deliberate scalar-only read with a `// lint:allow(metadata-as-str)` comment on the line or the line above. Introduced with bd-y89ihf0i.
 
 ### Adding New Lint Rules
 

--- a/claude-notes/plans/2026-06-09-metadata-as-str-audit.md
+++ b/claude-notes/plans/2026-06-09-metadata-as-str-audit.md
@@ -1,0 +1,261 @@
+# Audit: metadata string reads using `as_str()` that should use `as_plain_text()`
+
+**Strand:** bd-y89ihf0i (task, p2; labels: footnotes, tech-debt)
+**Discovered from:** bd-9ez3ngt1 (PR #265, reference-location front matter)
+**Date:** 2026-06-09
+
+## Overview
+
+In **document-metadata context**, a bare YAML string value is parsed as
+markdown and stored as `ConfigValueKind::PandocInlines`, **not**
+`Scalar(String)` (see `quarto-pandoc-types/src/config_value.rs:189-195`).
+Consequences for the two string accessors:
+
+- `ConfigValue::as_str()` (config_value.rs:641-649) returns `None` for
+  `PandocInlines`.
+- `ConfigValue::as_plain_text()` (config_value.rs:675-684) handles **both**
+  `Scalar(String)` and `PandocInlines`.
+
+So any **user-authored front-matter string option** read with `as_str()` is
+**silently ignored** unless the user writes the undocumented `!str` escape tag.
+This is the exact class of bug that broke `reference-location` entirely
+(bd-9ez3ngt1 / PR #265).
+
+This plan sweeps the remaining call sites, switches the genuine
+user-front-matter reads to `as_plain_text()` (each with a failing
+end-to-end regression test first, per TDD), and adds a `cargo xtask lint`
+rule to prevent recurrence.
+
+### Decision criterion (per call site)
+
+- **SWITCH** `as_str()` → `as_plain_text()` when the value is a user-authored
+  front-matter/metadata STRING that could reasonably be written as a bare
+  scalar, and markdown-in-value is harmless because we only want its text.
+- **LEAVE** `as_str()` when the code deliberately distinguishes a scalar
+  string from inlines, when the value is internal (AST `plain_data`, attrs,
+  computed config, `serde_json::Value`), or when it is a test assertion on
+  transform-generated data.
+
+## Branch base & sequencing
+
+**Decision (user, 2026-06-09): stack on the #265 branch.**
+
+Base this work on `bugfix/bd-9ez3ngt1-reference-location-front-matter`
+(fetched; remote tip `a35df31a`). That branch already fixes
+`footnotes.rs:78` and `appendix.rs:92` (reference-location) and adds the
+`render_to_file` regression-test template we mirror below. By stacking, the
+"already fixed" sites are present in-tree and both fixes ship together.
+
+```bash
+git fetch origin bugfix/bd-9ez3ngt1-reference-location-front-matter
+git switch -c beads/bd-y89ihf0i-metadata-as-str-audit \
+  origin/bugfix/bd-9ez3ngt1-reference-location-front-matter
+```
+
+**Do NOT redo** `footnotes.rs:78` / `appendix.rs:92` — they are fixed on the
+base branch.
+
+## Confirmed classification
+
+Verified by reading each site (not a blanket replace). Line numbers are on
+`main` / the #265 base; re-confirm after switching branches.
+
+### SWITCH — real user-front-matter reads (~10 sites)
+
+| File | Line | Option | Notes |
+|------|------|--------|-------|
+| `transforms/appendix.rs` | 80 | `appendix-style` | bare scalar |
+| `transforms/appendix.rs` | 275 | `license` (bare-string form) | nested: also map `.text`/`.type` |
+| `transforms/appendix.rs` | 282 | `license.text` / `license.type` | |
+| `transforms/appendix.rs` | 324 | `copyright` (bare-string form) | nested: also map `.statement`/`.holder` |
+| `transforms/appendix.rs` | 331 | `copyright.statement` / `.holder` | |
+| `transforms/appendix.rs` | 374 | `citation.url` | bare URL scalar → PandocInlines |
+| `transforms/toc_generate.rs` | 91 | `toc: auto` comparison | use `.as_plain_text().as_deref() == Some("auto")` |
+| `transforms/toc_generate.rs` | 117 | `toc-title` | |
+| `format.rs` | 311 | `theme` (`none`/`pandoc`) in `is_minimal_html` | **Not in seed — found by the lint.** Bare `theme: none`/`pandoc` silently failed to trigger minimal mode. List/map themes still yield `None` (correct). Unit-tested. |
+| `transforms/code_block_generate.rs` | 118 | `code-copy` (string values) | `as_bool` fast-path stays; only `always` string affected. **No e2e observable** — Hover/Always emit identical markup and Q2 hardcodes the hover SCSS `$code-copy-selector`; tested via a `PandocInlines` unit test on `resolve_default_copy_mode`. Fix prevents a latent bug once the selector is wired. |
+
+**Removed from SWITCH after per-site verification:**
+
+- `transforms/shortcode_resolve.rs:169` (`config_value_to_inlines`, the
+  `{{< meta key >}}` shortcode) → **LEAVE**. The `as_str()` is a fast-path;
+  `PandocInlines` is explicitly handled at line 192 (`inlines.clone()`), so a
+  bare front-matter string already resolves. Switching to `as_plain_text()`
+  would be a **regression** — it would flatten inline markdown the meta
+  shortcode should preserve (e.g. emphasis in a subtitle). Same fast-path +
+  explicit-`PandocInlines`-handling shape as title_block/metadata_normalize.
+
+### LEAVE — verified not a bug
+
+| File | Line(s) | Reason |
+|------|---------|--------|
+| `transforms/title_block.rs` | 132 | `as_str()` is a fast-path; the next `match` explicitly handles `PandocInlines`/`PandocBlocks`. Already correct. |
+| `transforms/metadata_normalize.rs` | 98 | Same fast-path + `match` pattern as title_block. Already correct. |
+| `transforms/shortcode_resolve.rs` | 169 | Fast-path; `PandocInlines` handled at line 192 (`inlines.clone()`). Switching would flatten inline formatting the `meta` shortcode must preserve — a regression. |
+| `transforms/metadata_normalize.rs` | 330, 371, 414 | `#[cfg(test)]` asserts on generated `pagetitle`. |
+| `transforms/website_canonical_url.rs` | 153, 205, 230 | All under `#[cfg(test)]` (mod starts line 114). Production reads `website.site-url` via `website_config::website_site_url`, which **already** uses `as_plain_text()`. |
+| `transforms/callout_resolve.rs` | 559 | Operates on `serde_json::Value`, not `ConfigValue`. |
+| `transforms/crossref_render.rs` | 228, 234, 325, 331, 661, 667 | Internal CustomNode `plain_data` (ref_type/kind/identifier). |
+| `transforms/crossref_index.rs` | 252, 321, 326 | Internal CustomNode `plain_data`. |
+
+## Phases
+
+### Phase 0 — Branch setup
+- [x] Fetch + branch off the #265 head (commands above) — branch
+      `beads/bd-y89ihf0i-metadata-as-str-audit` off `a35df31a`
+- [x] `cargo build -p quarto-core` to confirm green base — clean.
+      Confirmed #265 fixes present (footnotes.rs:82, appendix.rs reference-location).
+      NOTE: line numbers shifted vs. the table above due to #265's added
+      comments — re-grep current lines per site during Phase 2.
+
+### Phase 1 — TDD: failing regression tests (write & confirm-fail FIRST)
+
+Mirror the #265 template in `crates/quarto-core/src/render_to_file.rs`
+(`mod tests`): write a bare front-matter string, render end-to-end via
+`render_to_file`, assert on the produced HTML. Each test MUST fail on the
+base branch before its accessor is switched.
+
+All 7 e2e tests added to `crates/quarto-core/src/render_to_file.rs` `mod tests`;
+code-copy is a unit test in `code_block_generate.rs`.
+
+- [x] `appendix-style`: `appendix-style: plain` + `::: {.appendix}` div →
+      container `id="quarto-appendix" class="plain"`
+      (`test_render_to_file_honors_appendix_style_plain`)
+- [x] `license`: bare `license: CC BY-SA 4.0` → `quarto-reuse` section + text
+      (`test_render_to_file_honors_license_string`)
+- [x] `license.text`: `license:\n  text: My Custom Reuse Terms` → text appears
+      (`test_render_to_file_honors_license_nested_text`)
+- [x] `copyright`: bare `copyright: Copyright 2026 ACME Corp` → `quarto-copyright` + text
+      (`test_render_to_file_honors_copyright_string`)
+- [x] `citation.url`: `citation:\n  url: https://example.com/cite` →
+      "For attribution" + url in output (`test_render_to_file_honors_citation_url`)
+- [x] `toc: auto` (bare) → output contains generated TOC (`nav-link`)
+      (`test_render_to_file_honors_toc_auto_string`)
+- [x] `toc-title: My Custom Contents` (bare) → custom title replaces default
+      (`test_render_to_file_honors_toc_title`)
+- [x] `code-copy: always` as `PandocInlines` → `CopyMode::Always`
+      (`resolve_default_copy_always_inlines_is_always`; unit test — no e2e
+      observable, see SWITCH-table note)
+- [x] Ran the new tests pre-fix: all 7 e2e + the code-copy unit test FAILED for
+      the expected reason (`as_str()` → `None` → default). TDD step 2 ✓.
+
+### Phase 2 — Switch accessors (one site at a time)
+- [x] appendix.rs: appendix-style (80), license (278/285), copyright (327/334),
+      citation.url (377) — all → `as_plain_text`, with bd-y89ihf0i comments.
+      Map-form license/copyright still fall through correctly (`as_plain_text`
+      returns `None` for `Map`, same as `as_str` did).
+- [x] toc_generate.rs: 91 (`.as_plain_text().as_deref() == Some("auto")`), 117
+- [x] code_block_generate.rs: 118 (string branch → `as_plain_text`)
+- [x] shortcode_resolve.rs: 169 — **left as_str** (verified correct; switching
+      would regress, see classification)
+- [x] Re-ran Phase 1 tests post-fix: all 35 in scope pass. TDD step 4 ✓.
+
+### Phase 3 — Lint rule (recurrence prevention)
+
+**Decision (user, 2026-06-09): include the lint in this strand.**
+
+New rule `crates/xtask/src/lint/metadata_as_str.rs` (syn-AST based, mirrors
+`external_sources.rs`):
+- [x] `check(path, content)` parses with `syn` and visits method calls.
+- [x] Flags `<meta>.get("<lit>")…as_str()` in three shapes: direct
+      `.as_str()`, `.and_then(|v| v.as_str())`, `.map(|v| v.as_str())`.
+- [x] **Solved the false-positive problem with a receiver heuristic** rather
+      than a naive textual scan: only flags when the `.get(<string literal>)`
+      receiver is a *metadata expression* — a path/field whose final identifier
+      is `meta`/`metadata` (the codebase convention: `meta`, `ast.meta`,
+      `doc.ast.meta`). Internal `node.plain_data.get(..)`, `serde_json` reads,
+      and attr maps are NOT flagged because their receiver isn't `meta`.
+- [x] Skips `#[cfg(test)]` modules and `#[test]`/`#[tokio::test]` fns (test
+      asserts legitimately read generated scalars).
+- [x] Allowlist marker `// lint:allow(metadata-as-str)` on the line or the
+      line above suppresses a deliberate scalar-only read.
+- [x] Wired into `lint/mod.rs::check_file()`; 12 unit tests for the rule.
+- [x] Documented in CLAUDE.md "Current Lint Rules".
+- [x] `cargo xtask lint` passes clean (815 files) — **zero allowlist
+      annotations needed** after the fixes, because the receiver heuristic +
+      test-skipping leaves no production false positives.
+- [x] Verified the lint *catches* a regression: temporarily reverting the
+      toc-title fix made `cargo xtask lint` fail pointing at the exact line.
+
+**The lint paid off immediately:** it surfaced a real bug *not* in the seed
+inventory — `crates/quarto-core/src/format.rs:311`, `is_minimal_html` reading
+`meta.get("theme").as_str()`. A bare `theme: none` / `theme: pandoc` was
+silently not triggering minimal mode. Fixed (→ `as_plain_text`) with a
+`PandocInlines` unit test (`format::tests::test_is_minimal_html_theme_none_as_inlines`),
+revert-verified to fail without the fix. NOTE: the e2e effect is partly masked
+— `theme: none` already suppresses Bootstrap CSS/JS via the independent
+`ThemeConfig::suppress_bootstrap` path; the isolated `is_minimal_html` effect
+is minimal-template selection. Unit test is the regression of record.
+
+### Phase 4 — Full verification
+- [x] `cargo build --workspace` — clean
+- [x] `cargo nextest run --workspace` — 9580 passed, 196 skipped, 0 failed
+- [x] `cargo xtask lint` — clean (815 files)
+- [x] `cargo xtask verify` (full) — all 12 steps passed, including the WASM
+      hub-client build + tests
+- [x] End-to-end through the real `q2` binary (see record below)
+
+## Notes / open items
+
+- **shortcode_resolve.rs:169** is the least-certain SWITCH — confirm the value
+  read really is user front-matter (vs. an internal inlines container) before
+  changing it. If internal, move to LEAVE and note here.
+- **`!str` escape tag** is a working-but-undocumented escape hatch. Out of
+  scope here; the proper fix is the accessor switch. (A separate docs/behavior
+  question — whether bare strings *should* parse as inlines in metadata — is
+  not in this strand.)
+- The `extract_plain_text` duplication noted in `metadata_normalize.rs:103`
+  (bd-zzke consolidation candidate) is out of scope.
+
+## End-to-end verification record
+
+**Invocation** (2026-06-09): a single fixture exercising six fixed options, all
+written as bare front-matter strings, rendered with the real binary:
+
+```bash
+cargo run --bin q2 -- render .tmp-e2e/audit.qmd
+```
+
+Fixture front matter:
+```yaml
+toc: auto
+toc-title: On This Page
+license: CC BY-SA 4.0
+copyright: Copyright 2026 ACME Corp
+appendix-style: plain
+citation:
+  url: https://example.com/cite
+```
+
+**Observed in the generated HTML (inspected via grep):**
+
+| Option | Evidence in output |
+|--------|--------------------|
+| `toc-title` | `<h2 ... id="toc-title">On This Page</h2>` — and **no** "Table of Contents" |
+| `toc: auto` | TOC rendered (`nav-link` anchors present) |
+| `license` | `quarto-reuse` section containing `CC BY-SA 4.0` |
+| `copyright` | `quarto-copyright` section containing `Copyright 2026 ACME Corp` |
+| `appendix-style: plain` | `<div id="quarto-appendix" class="plain">` |
+| `citation.url` | "For attribution, please cite this work as:" + link to `example.com/cite` |
+
+All six render correctly with bare strings (they were silently dropped/defaulted
+before the fix). Output was inspected directly; the temp fixture was removed.
+
+`theme: none` (the lint-surfaced 7th fix) is covered by a unit test; its e2e
+effect is masked by `ThemeConfig::suppress_bootstrap` (see Phase 3 note).
+
+## Status
+
+All phases complete. Net change:
+- **7 accessor fixes** (`as_str` → `as_plain_text`): appendix-style, license
+  (+nested text/type), copyright (+nested statement/holder), citation.url,
+  toc:auto, toc-title, code-copy, theme.
+- **9 regression tests** (7 e2e in `render_to_file.rs`, 1 unit in
+  `code_block_generate.rs`, 1 unit in `format.rs`), each revert-verified to
+  fail without its fix.
+- **New `metadata-as-str` lint** (12 unit tests) + CLAUDE.md doc.
+- **3 sites verified as correct-and-left**: `title_block.rs:132`,
+  `metadata_normalize.rs:98`, `shortcode_resolve.rs:169`.
+
+Remaining before merge: stage/commit, then request push approval (the branch
+stacks on the open #265).

--- a/crates/quarto-core/src/format.rs
+++ b/crates/quarto-core/src/format.rs
@@ -430,7 +430,12 @@ pub fn is_minimal_html(meta: &ConfigValue) -> bool {
         return true;
     }
 
-    if let Some(theme) = meta.get("theme").and_then(|v| v.as_str()) {
+    // `as_plain_text` (not `as_str`): a bare `theme: none` / `theme: pandoc`
+    // front-matter string is stored as `ConfigValueKind::PandocInlines`, for
+    // which `as_str` returns `None`, so minimal mode was silently not applied.
+    // A theme *list* or *map* still yields `None` (correct — not "none"/"pandoc").
+    // (bd-y89ihf0i)
+    if let Some(theme) = meta.get("theme").and_then(|v| v.as_plain_text()) {
         if theme == "none" || theme == "pandoc" {
             return true;
         }
@@ -927,6 +932,24 @@ mod tests {
     fn test_is_minimal_html_theme_bootstrap() {
         let meta = meta_with(vec![entry("theme", ConfigValue::new_string("cosmo", si()))]);
         assert!(!is_minimal_html(&meta));
+    }
+
+    /// bd-y89ihf0i: a bare `theme: none` front-matter string is stored as
+    /// `PandocInlines`, not `Scalar(String)`. With `as_str()` this resolved to
+    /// `None`, so minimal mode was silently NOT applied; `as_plain_text` fixes
+    /// it. (Surfaced by the `metadata-as-str` lint, not the original seed.)
+    #[test]
+    fn test_is_minimal_html_theme_none_as_inlines() {
+        use quarto_pandoc_types::inline::{Inline, Str};
+        let theme = ConfigValue::new_inlines(
+            vec![Inline::Str(Str {
+                text: "none".to_string(),
+                source_info: si(),
+            })],
+            si(),
+        );
+        let meta = meta_with(vec![entry("theme", theme)]);
+        assert!(is_minimal_html(&meta));
     }
 
     #[test]

--- a/crates/quarto-core/src/render_to_file.rs
+++ b/crates/quarto-core/src/render_to_file.rs
@@ -618,6 +618,236 @@ mod tests {
         );
     }
 
+    // ── bd-y89ihf0i: front-matter string options must resolve through
+    //    `as_plain_text()` ───────────────────────────────────────────────
+    //
+    // Each option below is a user-authored metadata string that, in
+    // document-metadata context, is parsed as markdown and stored as
+    // `ConfigValueKind::PandocInlines`. Reading it with `as_str()` returns
+    // `None`, so the feature is silently dropped. These end-to-end tests write
+    // the option as a bare front-matter string and assert the rendered HTML
+    // reflects it. They FAIL on `as_str()` and PASS on `as_plain_text()`.
+
+    /// `license: <string>` (bare) must produce the appendix "Reuse" section.
+    /// With `as_str()` the bare value is `PandocInlines`, so
+    /// `create_license_section` drops the section entirely.
+    #[test]
+    fn test_render_to_file_honors_license_string() {
+        let temp = TempDir::new().unwrap();
+        let input_path = temp.path().join("license.qmd");
+        fs::write(
+            &input_path,
+            "---\nformat: html\nlicense: CC BY-SA 4.0\n---\nBody.\n",
+        )
+        .unwrap();
+
+        let runtime = Arc::new(NativeRuntime::new());
+        let result = render_to_file(
+            &input_path,
+            "html",
+            &RenderToFileOptions::default(),
+            runtime,
+        )
+        .unwrap();
+        let html = fs::read_to_string(&result.output_path).unwrap();
+
+        assert!(
+            html.contains("quarto-reuse"),
+            "expected a quarto-reuse license section for bare `license:` string; got:\n{html}"
+        );
+        assert!(
+            html.contains("CC BY-SA 4.0"),
+            "expected the license text in output; got:\n{html}"
+        );
+    }
+
+    /// `license:` with a nested `text:` bare string must resolve.
+    #[test]
+    fn test_render_to_file_honors_license_nested_text() {
+        let temp = TempDir::new().unwrap();
+        let input_path = temp.path().join("license_nested.qmd");
+        fs::write(
+            &input_path,
+            "---\nformat: html\nlicense:\n  text: My Custom Reuse Terms\n---\nBody.\n",
+        )
+        .unwrap();
+
+        let runtime = Arc::new(NativeRuntime::new());
+        let result = render_to_file(
+            &input_path,
+            "html",
+            &RenderToFileOptions::default(),
+            runtime,
+        )
+        .unwrap();
+        let html = fs::read_to_string(&result.output_path).unwrap();
+
+        assert!(
+            html.contains("My Custom Reuse Terms"),
+            "expected nested license.text in output; got:\n{html}"
+        );
+    }
+
+    /// `copyright: <string>` (bare) must produce the appendix "Copyright" section.
+    #[test]
+    fn test_render_to_file_honors_copyright_string() {
+        let temp = TempDir::new().unwrap();
+        let input_path = temp.path().join("copyright.qmd");
+        fs::write(
+            &input_path,
+            "---\nformat: html\ncopyright: Copyright 2026 ACME Corp\n---\nBody.\n",
+        )
+        .unwrap();
+
+        let runtime = Arc::new(NativeRuntime::new());
+        let result = render_to_file(
+            &input_path,
+            "html",
+            &RenderToFileOptions::default(),
+            runtime,
+        )
+        .unwrap();
+        let html = fs::read_to_string(&result.output_path).unwrap();
+
+        assert!(
+            html.contains("quarto-copyright"),
+            "expected a quarto-copyright section for bare `copyright:` string; got:\n{html}"
+        );
+        assert!(
+            html.contains("Copyright 2026 ACME Corp"),
+            "expected the copyright text in output; got:\n{html}"
+        );
+    }
+
+    /// `citation:` with a nested `url:` bare string must produce the
+    /// "For attribution" citation link.
+    #[test]
+    fn test_render_to_file_honors_citation_url() {
+        let temp = TempDir::new().unwrap();
+        let input_path = temp.path().join("citation.qmd");
+        fs::write(
+            &input_path,
+            "---\nformat: html\ncitation:\n  url: https://example.com/cite\n---\nBody.\n",
+        )
+        .unwrap();
+
+        let runtime = Arc::new(NativeRuntime::new());
+        let result = render_to_file(
+            &input_path,
+            "html",
+            &RenderToFileOptions::default(),
+            runtime,
+        )
+        .unwrap();
+        let html = fs::read_to_string(&result.output_path).unwrap();
+
+        assert!(
+            html.contains("For attribution"),
+            "expected the citation-url attribution text; got:\n{html}"
+        );
+        assert!(
+            html.contains("example.com/cite"),
+            "expected the citation url in output; got:\n{html}"
+        );
+    }
+
+    /// `appendix-style: plain` (bare) must set the appendix container class to
+    /// `plain`. A user `::: {.appendix}` div forces a container regardless of
+    /// other metadata. With `as_str()` the bare value falls back to the
+    /// `default` style.
+    #[test]
+    fn test_render_to_file_honors_appendix_style_plain() {
+        let temp = TempDir::new().unwrap();
+        let input_path = temp.path().join("appendix_style.qmd");
+        fs::write(
+            &input_path,
+            "---\nformat: html\nappendix-style: plain\n---\nBody.\n\n::: {.appendix}\nExtra material.\n:::\n",
+        )
+        .unwrap();
+
+        let runtime = Arc::new(NativeRuntime::new());
+        let result = render_to_file(
+            &input_path,
+            "html",
+            &RenderToFileOptions::default(),
+            runtime,
+        )
+        .unwrap();
+        let html = fs::read_to_string(&result.output_path).unwrap();
+
+        assert!(
+            html.contains("quarto-appendix"),
+            "expected an appendix container; got:\n{html}"
+        );
+        assert!(
+            html.contains(r#"id="quarto-appendix" class="plain""#)
+                || html.contains(r#"class="plain" id="quarto-appendix""#),
+            "expected appendix container with class `plain` for bare `appendix-style: plain`; got:\n{html}"
+        );
+    }
+
+    /// `toc: auto` (bare string) must trigger TOC generation. With `as_str()`
+    /// the bare value is `PandocInlines`, so the `== Some("auto")` comparison
+    /// fails and no TOC is generated.
+    #[test]
+    fn test_render_to_file_honors_toc_auto_string() {
+        let temp = TempDir::new().unwrap();
+        let input_path = temp.path().join("toc_auto.qmd");
+        fs::write(
+            &input_path,
+            "---\nformat: html\ntoc: auto\n---\nIntro.\n\n## A Section\n\nText.\n",
+        )
+        .unwrap();
+
+        let runtime = Arc::new(NativeRuntime::new());
+        let result = render_to_file(
+            &input_path,
+            "html",
+            &RenderToFileOptions::default(),
+            runtime,
+        )
+        .unwrap();
+        let html = fs::read_to_string(&result.output_path).unwrap();
+
+        assert!(
+            html.contains("nav-link"),
+            "expected a generated TOC (nav-link) for `toc: auto`; got:\n{html}"
+        );
+    }
+
+    /// `toc-title: <string>` (bare) must appear as the TOC heading. With
+    /// `as_str()` the bare value is `PandocInlines`, so it falls back to the
+    /// default "Table of Contents".
+    #[test]
+    fn test_render_to_file_honors_toc_title() {
+        let temp = TempDir::new().unwrap();
+        let input_path = temp.path().join("toc_title.qmd");
+        fs::write(
+            &input_path,
+            "---\nformat: html\ntoc: true\ntoc-title: My Custom Contents\n---\nIntro.\n\n## A Section\n\nText.\n",
+        )
+        .unwrap();
+
+        let runtime = Arc::new(NativeRuntime::new());
+        let result = render_to_file(
+            &input_path,
+            "html",
+            &RenderToFileOptions::default(),
+            runtime,
+        )
+        .unwrap();
+        let html = fs::read_to_string(&result.output_path).unwrap();
+
+        assert!(
+            html.contains("My Custom Contents"),
+            "expected the custom toc-title in output; got:\n{html}"
+        );
+        assert!(
+            !html.contains("Table of Contents"),
+            "custom toc-title must replace the default; got:\n{html}"
+        );
+    }
+
     #[test]
     fn test_render_to_file_creates_output() {
         let temp = TempDir::new().unwrap();

--- a/crates/quarto-core/src/transforms/appendix.rs
+++ b/crates/quarto-core/src/transforms/appendix.rs
@@ -77,8 +77,11 @@ impl AppendixStructureTransform {
             .map(|v| {
                 if let Some(b) = v.as_bool() {
                     AppendixStyle::from_bool(b)
-                } else if let Some(s) = v.as_str() {
-                    AppendixStyle::from_str(s)
+                } else if let Some(s) = v.as_plain_text() {
+                    // `as_plain_text` (not `as_str`): a bare front-matter string
+                    // is stored as `ConfigValueKind::PandocInlines`, for which
+                    // `as_str` returns `None`. (bd-y89ihf0i)
+                    AppendixStyle::from_str(&s)
                 } else {
                     AppendixStyle::default()
                 }
@@ -274,16 +277,18 @@ fn create_appendix_container(sections: Blocks, style_class: &str) -> Block {
 fn create_license_section(meta: &ConfigValue) -> Option<Block> {
     let license = meta.get("license")?;
 
-    // License can be a string (e.g., "CC BY") or an object with more details
-    let license_text = if let Some(s) = license.as_str() {
-        s.to_string()
+    // License can be a string (e.g., "CC BY") or an object with more details.
+    // `as_plain_text` (not `as_str`): bare front-matter strings are stored as
+    // `ConfigValueKind::PandocInlines`, for which `as_str` returns `None`,
+    // silently dropping the section. (bd-y89ihf0i)
+    let license_text = if let Some(s) = license.as_plain_text() {
+        s
     } else {
         // Try to get "text" or "type" field
         license
             .get("text")
             .or_else(|| license.get("type"))
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string())?
+            .and_then(|v| v.as_plain_text())?
     };
 
     let source_info = SourceInfo::default();
@@ -323,16 +328,18 @@ fn create_license_section(meta: &ConfigValue) -> Option<Block> {
 fn create_copyright_section(meta: &ConfigValue) -> Option<Block> {
     let copyright = meta.get("copyright")?;
 
-    // Copyright can be a string or an object
-    let copyright_text = if let Some(s) = copyright.as_str() {
-        s.to_string()
+    // Copyright can be a string or an object. `as_plain_text` (not `as_str`):
+    // bare front-matter strings are stored as `ConfigValueKind::PandocInlines`,
+    // for which `as_str` returns `None`, silently dropping the section.
+    // (bd-y89ihf0i)
+    let copyright_text = if let Some(s) = copyright.as_plain_text() {
+        s
     } else {
         // Try to get "holder" or "statement" field
         copyright
             .get("statement")
             .or_else(|| copyright.get("holder"))
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string())?
+            .and_then(|v| v.as_plain_text())?
     };
 
     let source_info = SourceInfo::default();
@@ -373,8 +380,11 @@ fn create_citation_section(meta: &ConfigValue) -> Option<Block> {
     let citation = meta.get("citation")?;
 
     // Citation metadata typically includes how to cite this document
-    // It can have various formats - for now, look for a "url" or create a simple reference
-    let citation_url = citation.get("url").and_then(|v| v.as_str());
+    // It can have various formats - for now, look for a "url" or create a simple reference.
+    // `as_plain_text` (not `as_str`): a bare front-matter URL string is stored
+    // as `ConfigValueKind::PandocInlines`, for which `as_str` returns `None`.
+    // (bd-y89ihf0i)
+    let citation_url = citation.get("url").and_then(|v| v.as_plain_text());
 
     let source_info = SourceInfo::default();
 

--- a/crates/quarto-core/src/transforms/code_block_generate.rs
+++ b/crates/quarto-core/src/transforms/code_block_generate.rs
@@ -115,8 +115,12 @@ pub fn resolve_default_copy_mode(meta: &quarto_pandoc_types::ConfigValue) -> Cop
     if let Some(b) = value.as_bool() {
         return if b { CopyMode::Always } else { CopyMode::Off };
     }
-    if let Some(s) = value.as_str() {
-        return match s {
+    // `as_plain_text` (not `as_str`): a bare `code-copy: always` (or `hover`)
+    // front-matter string is stored as `ConfigValueKind::PandocInlines`, for
+    // which `as_str` returns `None`, silently downgrading `always` to the
+    // `hover` fallback. (bd-y89ihf0i)
+    if let Some(s) = value.as_plain_text() {
+        return match s.as_str() {
             "hover" => CopyMode::Hover,
             "false" => CopyMode::Off,
             "true" | "always" => CopyMode::Always,
@@ -405,6 +409,16 @@ mod tests {
         quarto_pandoc_types::ConfigValueKind::Scalar(yaml_rust2::Yaml::String(s.to_string()))
     }
 
+    /// A `code-copy` value as it is actually stored after a bare front-matter
+    /// string is parsed as markdown: `PandocInlines`, not `Scalar(String)`.
+    fn yaml_inlines(s: &str) -> quarto_pandoc_types::ConfigValueKind {
+        use quarto_pandoc_types::inline::{Inline, Str};
+        quarto_pandoc_types::ConfigValueKind::PandocInlines(vec![Inline::Str(Str {
+            text: s.to_string(),
+            source_info: quarto_source_map::SourceInfo::default(),
+        })])
+    }
+
     #[tokio::test]
     async fn generate_decorates_bare_codeblock_under_default_copy_hover() {
         // Phase 2: with `code-copy` unset, the doc default is Hover.
@@ -590,6 +604,24 @@ mod tests {
     #[test]
     fn resolve_default_copy_always_string_is_always() {
         let meta = meta_with_code_copy(yaml_str("always"));
+        assert_eq!(resolve_default_copy_mode(&meta), CopyMode::Always);
+    }
+
+    /// bd-y89ihf0i: in real document-metadata context a bare
+    /// `code-copy: always` is parsed as markdown and stored as
+    /// `PandocInlines`, NOT `Scalar(String)`. With `as_str()` this resolved to
+    /// `None` and silently fell through to the `hover` default; `as_plain_text`
+    /// resolves it to `always`.
+    ///
+    /// NOTE: the Hover→Always distinction has no end-to-end HTML observable
+    /// today — both emit identical markup and Q2 hardcodes the hover
+    /// `$code-copy-selector` in SCSS (see `resources/scss/bootstrap/
+    /// _bootstrap-rules.scss`). This unit test is therefore the mechanical
+    /// regression for the accessor fix; an e2e test cannot distinguish the
+    /// modes until the selector is wired from the document option.
+    #[test]
+    fn resolve_default_copy_always_inlines_is_always() {
+        let meta = meta_with_code_copy(yaml_inlines("always"));
         assert_eq!(resolve_default_copy_mode(&meta), CopyMode::Always);
     }
 

--- a/crates/quarto-core/src/transforms/toc_generate.rs
+++ b/crates/quarto-core/src/transforms/toc_generate.rs
@@ -86,9 +86,13 @@ impl AstTransform for TocGenerateTransform {
 
         // Check if TOC auto-generation is requested.
         // Read from ast.meta which contains merged project + document metadata.
+        // `as_plain_text` (not `as_str`): a bare `toc: auto` front-matter string
+        // is stored as `ConfigValueKind::PandocInlines`, for which `as_str`
+        // returns `None`, so the `== "auto"` comparison silently failed.
+        // (bd-y89ihf0i)
         let should_generate = match ast.meta.get("toc") {
             Some(v) if v.as_bool() == Some(true) => true,
-            Some(v) if v.as_str() == Some("auto") => true,
+            Some(v) if v.as_plain_text().as_deref() == Some("auto") => true,
             _ => false,
         };
 
@@ -110,12 +114,13 @@ impl AstTransform for TocGenerateTransform {
             .and_then(|v| v.as_int())
             .unwrap_or(3) as i32;
 
-        // Default title is "Table of Contents" if not specified
+        // Default title is "Table of Contents" if not specified.
+        // `as_plain_text` (not `as_str`): a bare `toc-title` front-matter string
+        // is stored as `ConfigValueKind::PandocInlines`. (bd-y89ihf0i)
         let title = ast
             .meta
             .get("toc-title")
-            .and_then(|v| v.as_str())
-            .map(String::from)
+            .and_then(|v| v.as_plain_text())
             .or_else(|| Some("Table of Contents".to_string()));
 
         let config = TocConfig { depth, title };

--- a/crates/xtask/src/lint/metadata_as_str.rs
+++ b/crates/xtask/src/lint/metadata_as_str.rs
@@ -1,0 +1,412 @@
+//! Lint rule: don't read metadata strings with `as_str()`.
+//!
+//! In document-metadata context a bare YAML string value is parsed as markdown
+//! and stored as `ConfigValueKind::PandocInlines`, **not** `Scalar(String)`.
+//! `ConfigValue::as_str()` returns `None` for `PandocInlines`, so a
+//! user-authored front-matter option read with `as_str()` is **silently
+//! ignored** unless the user writes the undocumented `!str` escape tag. The
+//! correct accessor is `as_plain_text()`, which handles both forms.
+//!
+//! This bug broke `reference-location` (bd-9ez3ngt1) and a sweep
+//! (bd-y89ihf0i) found the same class in `appendix-style`, `license`,
+//! `copyright`, `citation.url`, `toc`/`toc-title`, `code-copy`, and `theme`.
+//!
+//! ## What this rule flags
+//!
+//! A chain that reads a metadata key and immediately calls `as_str()`:
+//!
+//! ```ignore
+//! meta.get("toc-title").and_then(|v| v.as_str())   // flagged
+//! meta.get("theme").as_str()                        // flagged
+//! ast.meta.get("license").map(|v| v.as_str())       // flagged
+//! ```
+//!
+//! The receiver of `.get(<string literal>)` must be a *metadata expression* —
+//! a path or field access whose final identifier is `meta` or `metadata`
+//! (the codebase convention for the merged document metadata, e.g. `meta`,
+//! `ast.meta`, `doc.ast.meta`). Internal map reads (`node.plain_data.get(..)`,
+//! a `serde_json::Value`, attribute maps) are NOT flagged — their receiver is
+//! not a metadata expression.
+//!
+//! Code inside `#[cfg(test)]` modules and `#[test]` / `#[tokio::test]`
+//! functions is skipped (test asserts legitimately inspect generated scalars).
+//!
+//! ## Suppressing a legitimate site
+//!
+//! Some sites deliberately read a scalar and handle `PandocInlines`
+//! separately (a fast-path before an explicit `match`). Mark those with a
+//! comment on the offending line or the line above:
+//!
+//! ```ignore
+//! // lint:allow(metadata-as-str) — fast-path; PandocInlines handled below
+//! if let Some(s) = meta.get("x").and_then(|v| v.as_str()) { ... }
+//! ```
+
+use std::path::Path;
+
+use anyhow::Result;
+use proc_macro2::Span;
+use syn::visit::Visit;
+use syn::{Expr, ExprMethodCall, File, ImplItemFn, ItemFn, ItemMod, Lit};
+
+use super::Violation;
+
+/// The name of this lint rule.
+const RULE_NAME: &str = "metadata-as-str";
+
+/// The marker that suppresses a violation on a line (or the line above).
+const ALLOW_MARKER: &str = "lint:allow(metadata-as-str)";
+
+/// Final-identifier names that mark an expression as "document metadata".
+const METADATA_IDENTS: &[&str] = &["meta", "metadata"];
+
+/// Check a file for metadata reads using `as_str()`.
+pub fn check(path: &Path, content: &str) -> Result<Vec<Violation>> {
+    let syntax_tree: File = match syn::parse_file(content) {
+        Ok(tree) => tree,
+        Err(e) => {
+            eprintln!(
+                "Warning: Could not parse {}: {} (skipping)",
+                path.display(),
+                e
+            );
+            return Ok(Vec::new());
+        }
+    };
+
+    let mut visitor = MetaVisitor {
+        violations: Vec::new(),
+        file_path: path.to_path_buf(),
+        lines: content.lines().map(|l| l.to_string()).collect(),
+    };
+    visitor.visit_file(&syntax_tree);
+    Ok(visitor.violations)
+}
+
+struct MetaVisitor {
+    violations: Vec<Violation>,
+    file_path: std::path::PathBuf,
+    lines: Vec<String>,
+}
+
+impl MetaVisitor {
+    fn span_to_location(&self, span: Span) -> (usize, usize) {
+        let start = span.start();
+        (start.line, start.column + 1)
+    }
+
+    /// True if the line at `line` (1-indexed) or the line above carries the
+    /// allow marker.
+    fn is_allowed(&self, line: usize) -> bool {
+        let on = line
+            .checked_sub(1)
+            .and_then(|i| self.lines.get(i))
+            .is_some_and(|l| l.contains(ALLOW_MARKER));
+        let above = line
+            .checked_sub(2)
+            .and_then(|i| self.lines.get(i))
+            .is_some_and(|l| l.contains(ALLOW_MARKER));
+        on || above
+    }
+
+    fn record(&mut self, span: Span) {
+        let (line, column) = self.span_to_location(span);
+        if self.is_allowed(line) {
+            return;
+        }
+        self.violations.push(Violation {
+            file: self.file_path.clone(),
+            line,
+            column,
+            rule: RULE_NAME,
+            message: "metadata string read with `as_str()`; a bare front-matter \
+                      string is stored as `PandocInlines`, for which `as_str()` \
+                      returns `None`"
+                .to_string(),
+            suggestion: Some(
+                "Use `as_plain_text()` instead (it handles both `Scalar(String)` \
+                 and `PandocInlines`). If this site deliberately reads a scalar and \
+                 handles `PandocInlines` elsewhere, add `// lint:allow(metadata-as-str)` \
+                 with a reason."
+                    .to_string(),
+            ),
+        });
+    }
+
+    /// Inspect a method call for the `meta.get("k") … as_str()` shape.
+    fn inspect_call(&mut self, call: &ExprMethodCall) {
+        let method = call.method.to_string();
+        match method.as_str() {
+            // Direct chain: `<meta-get>.as_str()`
+            "as_str" => {
+                if is_metadata_get(&call.receiver) {
+                    self.record(call.method.span());
+                }
+            }
+            // Closure forms: `<meta-get>.and_then(|v| v.as_str())` / `.map(...)`
+            "and_then" | "map" => {
+                if is_metadata_get(&call.receiver) && closure_calls_as_str(call) {
+                    self.record(call.method.span());
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+/// True if `expr` is `<metadata>.get(<string literal>)`.
+fn is_metadata_get(expr: &Expr) -> bool {
+    let Expr::MethodCall(call) = expr else {
+        return false;
+    };
+    if call.method != "get" {
+        return false;
+    }
+    // Exactly one argument, a string literal.
+    if call.args.len() != 1 {
+        return false;
+    }
+    let is_str_lit = matches!(
+        call.args.first(),
+        Some(Expr::Lit(lit)) if matches!(&lit.lit, Lit::Str(_))
+    );
+    is_str_lit && is_metadata_expr(&call.receiver)
+}
+
+/// True if `expr`'s final identifier is a metadata name (`meta`/`metadata`).
+/// Covers `meta`, `ast.meta`, `doc.ast.meta`, `self.metadata`, etc.
+fn is_metadata_expr(expr: &Expr) -> bool {
+    match expr {
+        Expr::Path(p) => p
+            .path
+            .segments
+            .last()
+            .is_some_and(|s| METADATA_IDENTS.contains(&s.ident.to_string().as_str())),
+        Expr::Field(f) => match &f.member {
+            syn::Member::Named(ident) => METADATA_IDENTS.contains(&ident.to_string().as_str()),
+            syn::Member::Unnamed(_) => false,
+        },
+        // `(&meta).get(..)` / `meta.clone().get(..)` are not the convention.
+        _ => false,
+    }
+}
+
+/// True if `call` (an `and_then`/`map`) has a closure argument whose body
+/// calls `.as_str()` somewhere.
+fn closure_calls_as_str(call: &ExprMethodCall) -> bool {
+    call.args.iter().any(|arg| {
+        if let Expr::Closure(closure) = arg {
+            let mut finder = AsStrFinder { found: false };
+            finder.visit_expr(&closure.body);
+            finder.found
+        } else {
+            false
+        }
+    })
+}
+
+/// Finds any `.as_str()` call within an expression subtree.
+struct AsStrFinder {
+    found: bool,
+}
+
+impl<'ast> Visit<'ast> for AsStrFinder {
+    fn visit_expr_method_call(&mut self, call: &'ast ExprMethodCall) {
+        if call.method == "as_str" {
+            self.found = true;
+        }
+        syn::visit::visit_expr_method_call(self, call);
+    }
+}
+
+/// True if the attribute list marks test-only code we should skip.
+fn is_test_attrs(attrs: &[syn::Attribute]) -> bool {
+    attrs.iter().any(|attr| {
+        let path = attr.path();
+        // `#[test]`
+        if path.is_ident("test") {
+            return true;
+        }
+        // `#[tokio::test]`, `#[async_std::test]`, etc.
+        if path.segments.last().is_some_and(|s| s.ident == "test") {
+            return true;
+        }
+        // `#[cfg(test)]`
+        if path.is_ident("cfg") {
+            let mut is_cfg_test = false;
+            // Best-effort: parse the nested meta list looking for `test`.
+            let _ = attr.parse_nested_meta(|nested| {
+                if nested.path.is_ident("test") {
+                    is_cfg_test = true;
+                }
+                Ok(())
+            });
+            return is_cfg_test;
+        }
+        false
+    })
+}
+
+impl<'ast> Visit<'ast> for MetaVisitor {
+    fn visit_item_mod(&mut self, node: &'ast ItemMod) {
+        if is_test_attrs(&node.attrs) {
+            return; // skip `#[cfg(test)] mod tests { ... }`
+        }
+        syn::visit::visit_item_mod(self, node);
+    }
+
+    fn visit_item_fn(&mut self, node: &'ast ItemFn) {
+        if is_test_attrs(&node.attrs) {
+            return;
+        }
+        syn::visit::visit_item_fn(self, node);
+    }
+
+    fn visit_impl_item_fn(&mut self, node: &'ast ImplItemFn) {
+        if is_test_attrs(&node.attrs) {
+            return;
+        }
+        syn::visit::visit_impl_item_fn(self, node);
+    }
+
+    fn visit_expr_method_call(&mut self, node: &'ast ExprMethodCall) {
+        self.inspect_call(node);
+        syn::visit::visit_expr_method_call(self, node);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn run(code: &str) -> Vec<Violation> {
+        check(Path::new("test.rs"), code).unwrap()
+    }
+
+    #[test]
+    fn flags_and_then_as_str_on_meta() {
+        let code = r#"
+            fn f(meta: &ConfigValue) {
+                let _ = meta.get("toc-title").and_then(|v| v.as_str());
+            }
+        "#;
+        let v = run(code);
+        assert_eq!(v.len(), 1, "expected one violation, got {v:?}");
+        assert_eq!(v[0].rule, "metadata-as-str");
+    }
+
+    #[test]
+    fn flags_direct_as_str_on_meta() {
+        let code = r#"
+            fn f(meta: &ConfigValue) {
+                let _ = meta.get("theme").as_str();
+            }
+        "#;
+        assert_eq!(run(code).len(), 1);
+    }
+
+    #[test]
+    fn flags_map_as_str_on_nested_meta() {
+        let code = r#"
+            fn f(ast: &Pandoc) {
+                let _ = ast.meta.get("license").map(|v| v.as_str());
+            }
+        "#;
+        assert_eq!(run(code).len(), 1);
+    }
+
+    #[test]
+    fn flags_deeply_nested_meta_receiver() {
+        let code = r#"
+            fn f(doc: &Doc) {
+                let _ = doc.ast.meta.get("copyright").and_then(|v| v.as_str());
+            }
+        "#;
+        assert_eq!(run(code).len(), 1);
+    }
+
+    #[test]
+    fn ignores_as_plain_text() {
+        let code = r#"
+            fn f(meta: &ConfigValue) {
+                let _ = meta.get("toc-title").and_then(|v| v.as_plain_text());
+            }
+        "#;
+        assert!(run(code).is_empty());
+    }
+
+    #[test]
+    fn ignores_non_metadata_receiver() {
+        // Internal map / plain_data reads must not be flagged.
+        let code = r#"
+            fn f(node: &CustomNode) {
+                let _ = node.plain_data.get("ref_type").and_then(|v| v.as_str());
+                let _ = json.get("$schema").and_then(|v| v.as_str());
+            }
+        "#;
+        assert!(run(code).is_empty());
+    }
+
+    #[test]
+    fn ignores_meta_as_str_without_get() {
+        // The fast-path `meta.as_str()` (value is itself the metadata scalar)
+        // is a different shape and not flagged — those sites handle
+        // PandocInlines via an explicit match.
+        let code = r#"
+            fn f(meta: &ConfigValue) {
+                if let Some(s) = meta.as_str() { let _ = s; }
+            }
+        "#;
+        assert!(run(code).is_empty());
+    }
+
+    #[test]
+    fn skips_test_modules() {
+        let code = r#"
+            #[cfg(test)]
+            mod tests {
+                fn helper(meta: &ConfigValue) {
+                    let _ = meta.get("canonical-url").and_then(|v| v.as_str());
+                }
+            }
+        "#;
+        assert!(run(code).is_empty());
+    }
+
+    #[test]
+    fn skips_test_functions() {
+        let code = r#"
+            #[test]
+            fn a_test(meta: &ConfigValue) {
+                let _ = meta.get("title").and_then(|v| v.as_str());
+            }
+        "#;
+        assert!(run(code).is_empty());
+    }
+
+    #[test]
+    fn respects_allow_marker_on_line() {
+        let code = r#"
+            fn f(meta: &ConfigValue) {
+                let _ = meta.get("x").and_then(|v| v.as_str()); // lint:allow(metadata-as-str)
+            }
+        "#;
+        assert!(run(code).is_empty());
+    }
+
+    #[test]
+    fn respects_allow_marker_on_line_above() {
+        let code = r#"
+            fn f(meta: &ConfigValue) {
+                // lint:allow(metadata-as-str) — intentional scalar fast-path
+                let _ = meta.get("x").and_then(|v| v.as_str());
+            }
+        "#;
+        assert!(run(code).is_empty());
+    }
+
+    #[test]
+    fn ignores_unparseable_file() {
+        assert!(run("this is not valid rust {{{{").is_empty());
+    }
+}

--- a/crates/xtask/src/lint/mod.rs
+++ b/crates/xtask/src/lint/mod.rs
@@ -4,6 +4,7 @@
 //! Each lint rule is implemented as a separate submodule.
 
 mod external_sources;
+mod metadata_as_str;
 
 use std::path::{Path, PathBuf};
 
@@ -200,6 +201,7 @@ fn check_file(path: &Path) -> Result<Vec<Violation>> {
 
     // Run each lint rule
     violations.extend(external_sources::check(path, &content)?);
+    violations.extend(metadata_as_str::check(path, &content)?);
 
     Ok(violations)
 }


### PR DESCRIPTION
## Summary

Sweep for the class of bug fixed in #265: a user-authored metadata string read with `ConfigValue::as_str()` instead of `as_plain_text()`. In document-metadata context a bare YAML string is parsed as markdown and stored as `ConfigValueKind::PandocInlines`, for which `as_str()` returns `None` — so the option is **silently ignored** unless the user writes the undocumented `!str` tag.

Each site was judged individually (not a blanket replace).

## Accessor fixes (`as_str` → `as_plain_text`)

| Site | Option(s) |
|------|-----------|
| `appendix.rs` | `appendix-style`, `license` (+nested `text`/`type`), `copyright` (+nested `statement`/`holder`), `citation.url` |
| `toc_generate.rs` | `toc: auto`, `toc-title` |
| `code_block_generate.rs` | `code-copy` (string branch) |
| `format.rs` | `theme: none`/`pandoc` in `is_minimal_html` — **not in the seed inventory; surfaced by the new lint** |

Map/list forms still resolve to `None` exactly as before (correct); only the bare-string case changes behavior.

## Verified correct and deliberately left as `as_str`

`title_block.rs:132`, `metadata_normalize.rs:98`, `shortcode_resolve.rs:169` — each is a fast-path `as_str` followed by explicit `PandocInlines` handling. Switching the meta-shortcode one would *regress* (flatten inline formatting the shortcode should preserve).

## New lint: `metadata-as-str`

`cargo xtask lint` rule (syn-AST) that flags `<meta>.get("k")…as_str()` only when the `.get` receiver is a metadata expression (final ident `meta`/`metadata`), skips test code, and honors a `// lint:allow(metadata-as-str)` marker. Passes clean with zero allowlist annotations needed; documented in CLAUDE.md. It immediately surfaced the `theme` bug above.

## Notes

- **`code-copy: always`** has no end-to-end observable today (Q2 hardcodes the hover `$code-copy-selector` in SCSS; Hover/Always emit identical markup). The fix prevents a latent bug and is covered by a `PandocInlines` unit test.
- **`theme: none`** e2e effect is partly masked by the independent `ThemeConfig::suppress_bootstrap` path; the isolated `is_minimal_html` effect is minimal-template selection. Unit-tested.

## Testing

- 9 regression tests (7 end-to-end in `render_to_file.rs`, unit tests for code-copy and theme), **each revert-verified to fail without its fix** (TDD).
- 12 unit tests for the lint rule.
- Full `cargo xtask verify` green (incl. WASM hub-client build/tests); 9580 workspace tests pass.
- **End-to-end via the `q2` binary**: rendered a fixture with all six visible options as bare front-matter strings and inspected the HTML (`toc-title`→"On This Page", `quarto-reuse`+license text, `quarto-copyright`, `class="plain"` appendix, citation link, generated TOC).

Plan: `claude-notes/plans/2026-06-09-metadata-as-str-audit.md`. Strand: bd-y89ihf0i (discovered-from bd-9ez3ngt1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)