### PR TITLE
fix(bd-3o8zmz46): evidence-based session expiry handling in hub-client

### DIFF
--- a/claude-notes/plans/2026-06-10-ws-auth-expiry-handling.md
+++ b/claude-notes/plans/2026-06-10-ws-auth-expiry-handling.md
@@ -1,0 +1,92 @@
+# WS auth-expiry handling (bd-3o8zmz46)
+
+## Overview
+
+Diagnosed 2026-06-10: when the Google ID token (1 h `exp`) expires and GIS One
+Tap renewal is unavailable (observed `accounts.google.com/gsi/status` 403 in
+dev), the auth cookie is evicted by the browser and every Automerge WS upgrade
+gets 401 from the hub. The SPA never notices:
+
+- Browsers hide the HTTP status of a failed WS upgrade from JS, and nothing
+  probes `/auth/me` out-of-band when sync drops.
+- `useAuth`'s visibilitychange handler resets `cookieSetAt = Date.now()` on
+  every refocus where `/auth/me` still returns 200, drifting the assumed
+  expiry up to an hour past the real one, so the `cookieExpired()` guards and
+  the App's auth-lost effect never fire.
+
+Net effect: UI stays "logged in", shows "Connection lost — working offline",
+and the WS adapter retries forever.
+
+Evidence record (end-to-end): probed `ws://localhost:5173/ws` (Vite proxy)
+and `http://127.0.0.1:3000/ws` directly → both 401; user's DevTools showed
+the failing upgrades carry **no Cookie header** (cookie evicted at expiry);
+`fetch('/auth/me')` → 401 while the editor remained open; page reload landed
+on the login screen.
+
+**Offline-mode invariant (drives all fixes):** only a definitive 401/403 from
+a reachable hub may clear auth. Network errors, timeouts, and 5xx must never
+log the user out — offline editing is a feature. Logout on evidence, not on
+schedule.
+
+Related: bd-ey6jg70f (hub-minted sliding sessions, out of scope here).
+
+## Phase 1 — server: expose token expiry on /auth/me
+
+- [x] Failing test: `/auth/me` response includes `exp` (epoch seconds) equal
+      to the token's `exp` claim
+- [x] Surface `exp` in `OidcClaims` (if not already deserialized) and add it
+      to `AuthMeResponse` in `crates/quarto-hub/src/server.rs`
+- [x] Targeted tests pass (`cargo nextest run -p quarto-hub`)
+
+## Phase 2 — client: schedule from real expiry; offline-safe catches
+
+- [x] Failing tests (vitest, fake timers) for `useAuth`:
+  - schedules silent refresh at `exp − 15 min` and hard re-check at `exp`,
+    from the server-reported `exp` (not a local 1 h assumption)
+  - refocus `/auth/me` 200 does NOT extend assumed expiry beyond server `exp`
+    (the drift bug)
+  - refocus `/auth/me` network error keeps auth (today: logs out)
+  - expiry-time `/auth/me` network error keeps auth and reschedules a
+    re-check (today: logs out)
+  - expiry-time `/auth/me` 401 with failed renewal → auth cleared with
+    `sessionExpired` flag
+- [x] Implement: `AuthState.expiresAt` (from `exp`, fallback +1 h if absent),
+      remove `cookieSetAt` drift resets, offline-safe catch branches,
+      `sessionExpired` state exposed from the hook
+- [x] Targeted vitest run green
+
+## Phase 3 — client: WS-failure auth probe + session-expired UX
+
+- [x] Failing tests for new `useAuthProbe` hook:
+  - while sync is disconnected (and authed, project open): probes
+    `/auth/me` immediately and then on an interval
+  - probe 200 → no action; probe network error → no action (offline mode)
+  - first 401/403 → `triggerRefresh()` only (renewal gets a chance)
+  - second consecutive 401/403 → `onAuthRejected()` (clears auth)
+  - reconnect / 200 resets the strike counter; probing stops when online
+- [x] Implement `useAuthProbe`, wire in `App.tsx` off `isOnline`
+- [x] LoginScreen shows "Session expired — please sign in again" when auth
+      was cleared by evidence (distinct from the generic offline banner and
+      from ordinary logout)
+- [x] Targeted vitest run green
+
+## Phase 4 — verification & bookkeeping
+
+- [ ] `npm run build:all` from hub-client (production build is stricter)
+- [ ] `npm run test:ci` from hub-client
+- [ ] `cargo xtask verify` (full: quarto-hub Rust change + hub-client change)
+- [ ] Commits (hub-client two-commit changelog dance), strand comment + close
+- [ ] Honest E2E note: real-expiry flow needs a browser with a live Google
+      session; record what was and wasn't exercised end-to-end
+
+## Design details
+
+- Probe three-way split maps directly onto `fetchAuthMe()`'s contract:
+  `AuthState` = valid, `null` = definitive 401/403, throw = network/5xx.
+- Strike-2 semantics: first 401 triggers renewal; only a second 401 on the
+  next probe cycle (~30 s later) clears auth. Avoids racing One Tap and
+  avoids relying on One Tap callbacks ever firing (they may not when GIS is
+  blocked — the coalesced `isRefreshing` flag would otherwise wedge).
+- Cold-starting the app while fully offline still lands on login (mount-time
+  probe can't succeed; HttpOnly cookie unreadable client-side). Known
+  limitation, unchanged by this strand; belongs to bd-ey6jg70f territory.

--- a/claude-notes/plans/2026-06-10-ws-auth-expiry-handling.md
+++ b/claude-notes/plans/2026-06-10-ws-auth-expiry-handling.md
@@ -72,11 +72,11 @@ Related: bd-ey6jg70f (hub-minted sliding sessions, out of scope here).
 
 ## Phase 4 — verification & bookkeeping
 
-- [ ] `npm run build:all` from hub-client (production build is stricter)
-- [ ] `npm run test:ci` from hub-client
-- [ ] `cargo xtask verify` (full: quarto-hub Rust change + hub-client change)
-- [ ] Commits (hub-client two-commit changelog dance), strand comment + close
-- [ ] Honest E2E note: real-expiry flow needs a browser with a live Google
+- [x] `npm run build:all` from hub-client (production build is stricter)
+- [x] `npm run test:ci` from hub-client
+- [x] `cargo xtask verify` (full: quarto-hub Rust change + hub-client change)
+- [x] Commits (hub-client two-commit changelog dance), strand comment + close
+- [x] Honest E2E note: real-expiry flow needs a browser with a live Google
       session; record what was and wasn't exercised end-to-end
 
 ## Design details
@@ -90,3 +90,17 @@ Related: bd-ey6jg70f (hub-minted sliding sessions, out of scope here).
 - Cold-starting the app while fully offline still lands on login (mount-time
   probe can't succeed; HttpOnly cookie unreadable client-side). Known
   limitation, unchanged by this strand; belongs to bd-ey6jg70f territory.
+
+## Verification record (2026-06-10)
+
+- `cargo xtask verify` (full): 9648 Rust tests passed; hub-client 574 unit +
+  66 integration + 81 wasm tests passed; WASM + production builds green.
+- New tests: `auth_me_returns_token_exp` (Rust); 5 expiry/offline tests in
+  `useAuth.test.tsx`; 6 tests in `useAuthProbe.test.tsx`; 2 LoginScreen tests.
+- Commits: `465de01f` (fix), `329e3702` (changelog).
+- **E2E honesty note**: the real expiry flow (Google token aging past 1 h with
+  One Tap blocked) was NOT exercised end-to-end in a browser — it needs a live
+  Google session. Manual recipe: sign in, delete the `quarto_hub_token` cookie
+  in DevTools → Application, restart the hub (drops the established WS); the
+  client should attempt renewal within ~30 s and land on the login screen with
+  the "session expired" message within ~60 s, instead of retrying forever.

--- a/crates/quarto-hub/src/auth.rs
+++ b/crates/quarto-hub/src/auth.rs
@@ -195,6 +195,13 @@ pub struct OidcClaims {
     /// [`validate_azp_and_iat`]).
     #[serde(default)]
     pub iat: Option<i64>,
+
+    /// Expiry (epoch seconds). Required by the validator
+    /// (`set_required_spec_claims`), so always present in accepted
+    /// tokens; surfaced on `/auth/me` so the client can schedule
+    /// refresh from the real expiry (bd-3o8zmz46).
+    #[serde(default)]
+    pub exp: i64,
 }
 
 /// Accept either a single-string `aud` or a `["a", "b"]` array.
@@ -709,6 +716,7 @@ mod tests {
             aud: vec!["test-client-id".to_string()],
             azp: None,
             iat: None,
+            exp: 0,
         }
     }
 
@@ -947,6 +955,7 @@ mod tests {
             aud: vec!["spa-client".into()],
             azp: None,
             iat: None,
+            exp: 0,
         };
         let allowed = allowed_list();
         assert!(validate_azp_and_iat(&claims, allowed.iter(), 1_000_000, 60).is_ok());
@@ -963,6 +972,7 @@ mod tests {
             aud: vec!["spa-client".into(), "mcp-client".into()],
             azp: None,
             iat: None,
+            exp: 0,
         };
         let allowed = allowed_list();
         assert_eq!(
@@ -982,6 +992,7 @@ mod tests {
             aud: vec!["spa-client".into()],
             azp: Some("attacker-client".into()),
             iat: None,
+            exp: 0,
         };
         let allowed = allowed_list();
         assert_eq!(
@@ -1001,6 +1012,7 @@ mod tests {
             aud: vec!["spa-client".into(), "mcp-client".into()],
             azp: Some("spa-client".into()),
             iat: None,
+            exp: 0,
         };
         let allowed = allowed_list();
         assert!(validate_azp_and_iat(&claims, allowed.iter(), 1_000_000, 60).is_ok());
@@ -1017,6 +1029,7 @@ mod tests {
             aud: vec!["spa-client".into()],
             azp: None,
             iat: Some(1_000_000 + 3600),
+            exp: 0,
         };
         let allowed = allowed_list();
         assert_eq!(
@@ -1036,6 +1049,7 @@ mod tests {
             aud: vec!["spa-client".into()],
             azp: None,
             iat: Some(1_000_000 + 30),
+            exp: 0,
         };
         let allowed = allowed_list();
         assert!(validate_azp_and_iat(&claims, allowed.iter(), 1_000_000, 60).is_ok());

--- a/crates/quarto-hub/src/server.rs
+++ b/crates/quarto-hub/src/server.rs
@@ -733,6 +733,9 @@ struct AuthMeResponse {
     email: String,
     name: Option<String>,
     picture: Option<String>,
+    /// Token expiry (epoch seconds) so the client can schedule silent
+    /// refresh from the real expiry instead of assuming a fixed lifetime.
+    exp: i64,
 }
 
 /// Query parameters for GET /auth/actor.
@@ -770,6 +773,7 @@ async fn auth_me(
         email: claims.email,
         name: claims.name,
         picture: claims.picture,
+        exp: claims.exp,
     }))
 }
 

--- a/crates/quarto-hub/tests/auth_bearer.rs
+++ b/crates/quarto-hub/tests/auth_bearer.rs
@@ -1002,6 +1002,33 @@ async fn cookie_still_authenticates() {
     assert_eq!(resp.status(), 200);
 }
 
+// ── /auth/me reports token expiry (bd-3o8zmz46) ──────────────────
+
+#[tokio::test]
+async fn auth_me_returns_token_exp() {
+    let (provider, hub) = shared_setup().await;
+    let exp = chrono::Utc::now().timestamp() + 600;
+    let token = provider.sign(
+        &ClaimsBuilder::from_provider(provider)
+            .sub("auth-me-exp")
+            .exp(exp)
+            .to_value(),
+    );
+
+    let resp = hub
+        .get_auth_me()
+        .header("cookie", format!("quarto_hub_token={token}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(
+        body["exp"], exp,
+        "client schedules refresh from the real token expiry"
+    );
+}
+
 // ── Dual-credential 400 (bd-wzhsf CVE) ───────────────────────────
 
 #[tokio::test]

--- a/hub-client/changelog.md
+++ b/hub-client/changelog.md
@@ -15,6 +15,10 @@ be in reverse chronological order (latest first).
 
 -->
 
+### 2026-06-10
+
+- [`465de01f`](https://github.com/quarto-dev/q2/commits/465de01f): An expired sign-in no longer presents as a permanent "working offline" state — the client now detects the rejected session, attempts silent renewal, and returns to the login screen with a "session expired" message; genuine network outages keep offline editing intact.
+
 ### 2026-06-09
 
 - [`57bc49cf`](https://github.com/quarto-dev/q2/commits/57bc49cf): Preview renders no longer re-copy unchanged artifacts (theme CSS, fonts, shared JS) into the virtual filesystem on every keystroke — byte-identical re-writes are now skipped.

--- a/hub-client/src/App.tsx
+++ b/hub-client/src/App.tsx
@@ -34,6 +34,7 @@ import { getUserIdentity, updateUserName } from './services/userSettings';
 import { useRouting } from './hooks/useRouting';
 import { useProjectSet } from './hooks/useProjectSet';
 import { useAuth } from './hooks/useAuth';
+import { useAuthProbe } from './hooks/useAuthProbe';
 import { fetchActorId } from './services/authService';
 import type { Route, ShareRoute, LinkProjectSetRoute } from './utils/routing';
 import './App.css';
@@ -63,7 +64,14 @@ const AUTH_ENABLED = !!import.meta.env.VITE_GOOGLE_CLIENT_ID;
 
 
 function App() {
-  const { auth, loading: authLoading, logout, triggerRefresh } = useAuth();
+  const {
+    auth,
+    loading: authLoading,
+    logout,
+    triggerRefresh,
+    sessionExpired,
+    expireSession,
+  } = useAuth();
 
   const [project, setProject] = useState<ProjectEntry | null>(null);
   const [files, setFiles] = useState<FileEntry[]>([]);
@@ -75,6 +83,17 @@ function App() {
   const [cursorColor, setCursorColor] = useState<string | undefined>();
   const [identities, setIdentities] = useState<Record<string, ActorIdentity>>({});
   const [isOnline, setIsOnline] = useState<boolean>(false);
+
+  // While a project's sync is disconnected, check whether the disconnect is
+  // actually an auth rejection (browsers hide the WS upgrade status). Only
+  // definitive 401/403 evidence ever clears auth — never network errors.
+  // Past the token's exp, useAuth's expiry timer logs out on the first 401
+  // (preempting this probe's two-strike); the probe governs earlier drops.
+  useAuthProbe({
+    enabled: AUTH_ENABLED && !!auth && !!project && !isOnline,
+    triggerRefresh,
+    onAuthRejected: expireSession,
+  });
 
   // Project set management (synced project list)
   const [projectSetState, projectSetActions] = useProjectSet();
@@ -551,7 +570,12 @@ function App() {
   }
 
   if (AUTH_ENABLED && !auth) {
-    return <LoginScreen error={authError} />;
+    return (
+      <LoginScreen
+        error={authError}
+        message={sessionExpired ? 'Your session expired — please sign in again.' : undefined}
+      />
+    );
   }
 
   // Gate on screen name being loaded (fast IndexedDB read).

--- a/hub-client/src/components/auth/LoginScreen.test.tsx
+++ b/hub-client/src/components/auth/LoginScreen.test.tsx
@@ -49,4 +49,16 @@ describe('LoginScreen', () => {
     expect(screen.getByText(/Sign-in failed/i)).toBeTruthy();
     expect(screen.queryByText(/Sign in with Google to continue/i)).toBeNull();
   });
+
+  it('renders a custom message (session expiry) instead of the default copy', () => {
+    render(withProvider(<LoginScreen message="Your session expired — please sign in again." />));
+    expect(screen.getByText(/session expired/i)).toBeTruthy();
+    expect(screen.queryByText(/Sign in with Google to continue/i)).toBeNull();
+  });
+
+  it('error copy wins over a custom message', () => {
+    render(withProvider(<LoginScreen error message="Your session expired — please sign in again." />));
+    expect(screen.getByText(/Sign-in failed/i)).toBeTruthy();
+    expect(screen.queryByText(/session expired/i)).toBeNull();
+  });
 });

--- a/hub-client/src/components/auth/LoginScreen.tsx
+++ b/hub-client/src/components/auth/LoginScreen.tsx
@@ -13,7 +13,7 @@
 
 import { useAuthProvider } from '../../auth/AuthProvider';
 
-export function LoginScreen({ error }: { error?: boolean }) {
+export function LoginScreen({ error, message }: { error?: boolean; message?: string }) {
   const provider = useAuthProvider();
 
   return (
@@ -24,6 +24,10 @@ export function LoginScreen({ error }: { error?: boolean }) {
         {error ? (
           <p style={{ color: 'var(--posit-red)', fontSize: '14px', margin: '0 0 16px' }}>
             Sign-in failed. Your account is not authorized to access this hub.
+          </p>
+        ) : message ? (
+          <p style={{ color: 'var(--text-secondary)', fontSize: '14px', margin: '0 0 16px' }}>
+            {message}
           </p>
         ) : (
           <p style={{ color: 'var(--text-secondary)', fontSize: '14px', margin: '0 0 16px' }}>

--- a/hub-client/src/hooks/useAuth.test.tsx
+++ b/hub-client/src/hooks/useAuth.test.tsx
@@ -349,6 +349,146 @@ describe('useAuth', () => {
     });
   });
 
+  // ── Expiry from server-reported exp (bd-3o8zmz46) ─────────
+
+  describe('expiry from server exp', () => {
+    beforeEach(() => {
+      cleanup();
+      // Full reset (not just clear) so queued mockResolvedValueOnce values
+      // from a failed sibling test can't leak into the next one.
+      mockFetchAuthMe.mockReset();
+      mockRefreshToken.mockReset();
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('schedules silent refresh from server-reported expiresAt, not a fixed lifetime', async () => {
+      const user = {
+        email: 'a@b.com',
+        name: 'A',
+        picture: null,
+        expiresAt: Date.now() + 30 * 60 * 1000,
+      };
+      mockFetchAuthMe.mockResolvedValue(user);
+
+      const { result } = renderHook(() => useAuth(), { wrapper });
+      await vi.waitFor(() => expect(result.current.auth).toEqual(user));
+      expect(mockProvider.lastSilentRenewalOpts?.enabled).toBe(false);
+
+      // Refresh should fire at expiresAt − 15 min = +15 min, well before
+      // the legacy fixed-1h schedule would (at +45 min).
+      await act(async () => {
+        vi.advanceTimersByTime(15 * 60 * 1000 + 1000);
+      });
+      expect(mockProvider.lastSilentRenewalOpts?.enabled).toBe(true);
+    });
+
+    it('does not extend assumed expiry on refocus without a fresh cookie (drift bug)', async () => {
+      const expiresAt = Date.now() + 40 * 60 * 1000;
+      const user = { email: 'a@b.com', name: 'A', picture: null, expiresAt };
+      mockFetchAuthMe
+        .mockResolvedValueOnce(user) // mount
+        .mockResolvedValueOnce({ ...user }) // refocus: same expiry, fresh object
+        .mockResolvedValueOnce(null); // expiry re-check: token now rejected
+
+      const { result } = renderHook(() => useAuth(), { wrapper });
+      await vi.waitFor(() => expect(result.current.auth).toEqual(user));
+
+      // Refocus at +10 min — server confirms the cookie but its expiry is
+      // unchanged. This must NOT push the schedule out to +70 min.
+      await act(async () => {
+        vi.advanceTimersByTime(10 * 60 * 1000);
+      });
+      document.dispatchEvent(new Event('visibilitychange'));
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      // Refresh fires at expiresAt − 15 min (+25 min); renewal fails.
+      await act(async () => {
+        vi.advanceTimersByTime(15 * 60 * 1000 + 1000);
+      });
+      await act(async () => {
+        mockProvider.lastSilentRenewalOpts?.onError();
+      });
+
+      // At the REAL expiry (+40 min) the server's 401 must clear auth.
+      await act(async () => {
+        vi.advanceTimersByTime(15 * 60 * 1000 + 2000);
+      });
+      await vi.waitFor(() => expect(result.current.auth).toBeNull());
+      expect(result.current.sessionExpired).toBe(true);
+    });
+
+    it('keeps auth when refocus /auth/me fails with a network error (offline)', async () => {
+      const user = { email: 'a@b.com', name: 'A', picture: null };
+      mockFetchAuthMe.mockResolvedValueOnce(user); // mount
+
+      const { result } = renderHook(() => useAuth(), { wrapper });
+      await vi.waitFor(() => expect(result.current.auth).toEqual(user));
+
+      mockFetchAuthMe.mockRejectedValueOnce(new Error('network'));
+      document.dispatchEvent(new Event('visibilitychange'));
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      // Offline must never log the user out.
+      expect(result.current.auth).toEqual(user);
+    });
+
+    it('keeps auth on expiry-time network error and re-checks later', async () => {
+      const expiresAt = Date.now() + 20 * 60 * 1000;
+      const user = { email: 'a@b.com', name: 'A', picture: null, expiresAt };
+      mockFetchAuthMe.mockResolvedValueOnce(user); // mount
+
+      const { result } = renderHook(() => useAuth(), { wrapper });
+      await vi.waitFor(() => expect(result.current.auth).toEqual(user));
+
+      // Refresh fires at +5 min; renewal fails (session not lapsed → keep).
+      await act(async () => {
+        vi.advanceTimersByTime(5 * 60 * 1000 + 1000);
+      });
+      await act(async () => {
+        mockProvider.lastSilentRenewalOpts?.onError();
+      });
+
+      // Expiry re-check at +20 min hits a network error → stay logged in.
+      mockFetchAuthMe.mockRejectedValueOnce(new Error('network'));
+      await act(async () => {
+        vi.advanceTimersByTime(15 * 60 * 1000 + 2000);
+      });
+      expect(result.current.auth).toEqual(user);
+      expect(result.current.sessionExpired).toBe(false);
+
+      // The next re-check gets a definitive 401 → evidence-based logout.
+      mockFetchAuthMe.mockResolvedValueOnce(null);
+      await act(async () => {
+        vi.advanceTimersByTime(60 * 1000 + 1000);
+      });
+      await vi.waitFor(() => expect(result.current.auth).toBeNull());
+      expect(result.current.sessionExpired).toBe(true);
+    });
+
+    it('does not flag sessionExpired on deliberate logout', async () => {
+      const user = { email: 'a@b.com', name: 'A', picture: null };
+      mockFetchAuthMe.mockResolvedValue(user);
+
+      const { result } = renderHook(() => useAuth(), { wrapper });
+      await vi.waitFor(() => expect(result.current.auth).toEqual(user));
+
+      act(() => {
+        result.current.logout();
+      });
+
+      expect(result.current.auth).toBeNull();
+      expect(result.current.sessionExpired).toBe(false);
+    });
+  });
+
   // ── 401-triggered refresh (fake timers) ───────────────────
 
   describe('triggerRefresh', () => {

--- a/hub-client/src/hooks/useAuth.ts
+++ b/hub-client/src/hooks/useAuth.ts
@@ -6,24 +6,23 @@
  * On mount, calls GET /auth/me to check if the user has a valid cookie.
  * If 200, stores the display info in React state. If 401, shows login.
  *
- * Token refresh: ~15 minutes before the cookie expires, the hook asks
- * the active `AuthProvider` to silently obtain a fresh credential. The
- * new credential is sent to POST /auth/refresh which validates it and
- * sets a fresh cookie. If silent refresh fails, auth is cleared at expiry.
- * The 15-minute buffer absorbs Chrome's intensive timer throttling for
- * backgrounded tabs (timers may skew by 1+ minutes after 5 min hidden).
+ * Expiry tracking: /auth/me reports the token's real `exp`
+ * (`AuthState.expiresAt`, ms epoch; falls back to +1 h for older servers).
+ * Silent refresh is scheduled ~15 minutes before that expiry via the active
+ * `AuthProvider`; the fresh credential goes to POST /auth/refresh which sets
+ * a new cookie. The 15-minute buffer absorbs Chrome's intensive timer
+ * throttling for backgrounded tabs.
  *
- * Visibility-aware refresh: if a background tab's timers were throttled
- * and the cookie expired, attempts silent renewal before logging out.
+ * Evidence-based logout (bd-3o8zmz46): auth is only cleared when a reachable
+ * server definitively rejects us (401/403). Network errors — refocus checks,
+ * expiry re-checks — never log the user out; offline editing must survive
+ * them. When the session ends this way, `sessionExpired` is set so the UI
+ * can say "session expired" instead of implying a network problem.
  *
  * 401-triggered refresh: callers that observe a mid-session 401 on an
  * authenticated REST request can call `triggerRefresh()` to enable
  * silent renewal without logging the user out. Concurrent calls are
  * coalesced.
- *
- * During refresh, a 401 from /auth/me is handled gracefully: the hook
- * shows a loading state (not the login screen) while the refresh is
- * in progress.
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -34,20 +33,39 @@ import { fetchAuthMe, logout as serverLogout, refreshToken } from '../services/a
 /** Buffer before expiry at which we attempt silent refresh (15 minutes). */
 export const REFRESH_BUFFER_MS = 15 * 60 * 1000;
 
-/** Cookie max-age matches server (1 hour). */
-const COOKIE_MAX_AGE_MS = 3600 * 1000;
+/** Assumed session lifetime when the server doesn't report `exp` (1 hour). */
+const DEFAULT_SESSION_MS = 3600 * 1000;
+
+/** Re-check interval when an expiry-time verdict couldn't be reached. */
+const EXPIRY_RECHECK_MS = 60 * 1000;
 
 export function useAuth() {
   const provider = useAuthProvider();
   const [auth, setAuth] = useState<AuthState | null>(null);
   const [loading, setLoading] = useState(true);
   const [refreshEnabled, setRefreshEnabled] = useState(false);
+  const [sessionExpired, setSessionExpired] = useState(false);
   const isRefreshing = useRef(false);
   const refreshTimer = useRef<ReturnType<typeof setTimeout>>(null);
   const expiryTimer = useRef<ReturnType<typeof setTimeout>>(null);
 
-  // Track when the current cookie was set (for scheduling refresh/expiry).
-  const cookieSetAt = useRef<number>(0);
+  // Effective expiry of the current session (0 = no session).
+  const expiresAtRef = useRef<number>(0);
+
+  /** Install a (re)confirmed session; clears any expired flag. */
+  const applyAuth = useCallback((me: AuthState) => {
+    setSessionExpired(false);
+    setAuth(me);
+  }, []);
+
+  /** Evidence-based logout: the server rejected our credential. */
+  const expireSession = useCallback(() => {
+    setSessionExpired(true);
+    setAuth(null);
+  }, []);
+
+  const sessionLapsed = () =>
+    expiresAtRef.current > 0 && Date.now() >= expiresAtRef.current;
 
   // Check auth status on mount.
   useEffect(() => {
@@ -56,7 +74,6 @@ export function useAuth() {
       .then((me) => {
         if (cancelled) return;
         setAuth(me);
-        if (me) cookieSetAt.current = Date.now();
         setLoading(false);
       })
       .catch(() => {
@@ -66,9 +83,6 @@ export function useAuth() {
       });
     return () => { cancelled = true; };
   }, []);
-
-  const cookieExpired = () =>
-    cookieSetAt.current > 0 && Date.now() >= cookieSetAt.current + COOKIE_MAX_AGE_MS;
 
   // Single entry point for activating One Tap. Coalesces concurrent
   // triggers (e.g. N parallel 401s) into one refresh attempt.
@@ -87,14 +101,13 @@ export function useAuth() {
       refreshToken(jwt)
         .then((me) => {
           if (me) {
-            setAuth(me);
-            cookieSetAt.current = Date.now();
-          } else if (cookieExpired()) {
-            setAuth(null);
+            applyAuth(me);
+          } else if (sessionLapsed()) {
+            expireSession();
           }
         })
         .catch(() => {
-          if (cookieExpired()) setAuth(null);
+          if (sessionLapsed()) expireSession();
         })
         .finally(() => {
           isRefreshing.current = false;
@@ -104,12 +117,12 @@ export function useAuth() {
     onError: () => {
       isRefreshing.current = false;
       setRefreshEnabled(false);
-      if (cookieExpired()) setAuth(null);
+      if (sessionLapsed()) expireSession();
     },
   });
 
-  // On visibility change, verify the cookie. If expired, try One Tap
-  // refresh before logging out (timers may not have fired in background).
+  // On visibility change, verify the cookie. If rejected, try One Tap
+  // refresh; a network error means offline and never clears the session.
   useEffect(() => {
     if (!auth) return;
 
@@ -120,16 +133,18 @@ export function useAuth() {
       fetchAuthMe()
         .then((me) => {
           if (me) {
-            // Cookie still valid — update timestamp so timers reschedule.
-            cookieSetAt.current = Date.now();
-            setAuth(me);
+            // Still valid. The reported expiry is the same token's exp,
+            // so this does NOT extend the schedule (the old cookieSetAt
+            // reset here drifted assumed expiry past the real one).
+            applyAuth(me);
           } else {
-            // Cookie expired — try One Tap refresh before logging out.
+            // Definitive rejection — try One Tap refresh before logging out.
             triggerRefresh();
           }
         })
         .catch(() => {
-          setAuth(null);
+          // Offline — keep the session; sync layer probes will escalate
+          // if the server actually rejects us once reachable.
         });
     };
 
@@ -137,49 +152,57 @@ export function useAuth() {
     return () => {
       document.removeEventListener('visibilitychange', handleVisibilityChange);
     };
-  }, [auth, triggerRefresh]);
+  }, [auth, applyAuth, triggerRefresh]);
 
-  // Schedule silent refresh and hard expiry based on cookie lifetime.
+  // Schedule silent refresh and an expiry-time server re-check from the
+  // session's real expiry.
   useEffect(() => {
     if (refreshTimer.current) clearTimeout(refreshTimer.current);
     if (expiryTimer.current) clearTimeout(expiryTimer.current);
 
-    if (!auth || !cookieSetAt.current) return;
-
-    const expiresAt = cookieSetAt.current + COOKIE_MAX_AGE_MS;
-    const msUntilExpiry = expiresAt - Date.now();
-    if (msUntilExpiry <= 0) {
-      setAuth(null);
+    if (!auth) {
+      expiresAtRef.current = 0;
       return;
     }
 
-    // Schedule silent refresh attempt before expiry.
-    const msUntilRefresh = msUntilExpiry - REFRESH_BUFFER_MS;
-    if (msUntilRefresh > 0) {
-      refreshTimer.current = setTimeout(triggerRefresh, msUntilRefresh);
-    }
+    const expiresAt = auth.expiresAt ?? Date.now() + DEFAULT_SESSION_MS;
+    expiresAtRef.current = expiresAt;
 
-    // Hard expiry: re-check auth when the cookie should have expired.
-    // If a refresh succeeded in the meantime, /auth/me will return 200.
-    expiryTimer.current = setTimeout(() => {
-      fetchAuthMe().then((me) => {
-        if (me) {
-          setAuth(me);
-          cookieSetAt.current = Date.now();
-        } else if (!isRefreshing.current) {
-          setAuth(null);
-        }
-        // If isRefreshing, the refresh handler will update state.
-      }).catch(() => {
-        if (!isRefreshing.current) setAuth(null);
-      });
-    }, msUntilExpiry);
+    // Silent refresh before expiry; immediately if already inside the buffer.
+    refreshTimer.current = setTimeout(
+      triggerRefresh,
+      Math.max(expiresAt - REFRESH_BUFFER_MS - Date.now(), 0),
+    );
+
+    // Expiry-time re-check. Only a definitive 401/403 clears the session;
+    // network errors reschedule (logout on evidence, not on schedule).
+    const scheduleExpiryCheck = (delay: number) => {
+      expiryTimer.current = setTimeout(() => {
+        fetchAuthMe()
+          .then((me) => {
+            if (me) {
+              applyAuth(me); // reschedules from the (possibly refreshed) exp
+            } else if (!isRefreshing.current) {
+              expireSession();
+            } else {
+              // Renewal in flight — re-check for a definitive verdict even
+              // if the IdP never calls back (e.g. GIS blocked).
+              scheduleExpiryCheck(EXPIRY_RECHECK_MS);
+            }
+          })
+          .catch(() => {
+            scheduleExpiryCheck(EXPIRY_RECHECK_MS);
+          });
+      }, delay);
+    };
+    const msUntilExpiry = expiresAt - Date.now();
+    scheduleExpiryCheck(msUntilExpiry > 0 ? msUntilExpiry + 1000 : EXPIRY_RECHECK_MS);
 
     return () => {
       if (refreshTimer.current) clearTimeout(refreshTimer.current);
       if (expiryTimer.current) clearTimeout(expiryTimer.current);
     };
-  }, [auth, triggerRefresh]);
+  }, [auth, applyAuth, expireSession, triggerRefresh]);
 
   const logout = useCallback(() => {
     serverLogout().catch(() => {
@@ -189,5 +212,5 @@ export function useAuth() {
     setAuth(null);
   }, [provider]);
 
-  return { auth, loading, logout, triggerRefresh };
+  return { auth, loading, logout, triggerRefresh, sessionExpired, expireSession };
 }

--- a/hub-client/src/hooks/useAuthProbe.test.tsx
+++ b/hub-client/src/hooks/useAuthProbe.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * Unit tests for useAuthProbe (bd-3o8zmz46).
+ *
+ * The probe runs while sync is disconnected and decides, on evidence only,
+ * whether the disconnect is an auth failure. Offline-mode invariant: network
+ * errors never trigger any action.
+ *
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+vi.mock('../services/authService', () => ({
+  fetchAuthMe: vi.fn(),
+}));
+
+import { useAuthProbe, AUTH_PROBE_INTERVAL_MS } from './useAuthProbe';
+import { fetchAuthMe } from '../services/authService';
+
+const mockFetchAuthMe = vi.mocked(fetchAuthMe);
+const user = { email: 'a@b.com', name: 'A', picture: null };
+
+describe('useAuthProbe', () => {
+  let triggerRefresh: ReturnType<typeof vi.fn>;
+  let onAuthRejected: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    mockFetchAuthMe.mockReset();
+    triggerRefresh = vi.fn();
+    onAuthRejected = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const render = (enabled: boolean) =>
+    renderHook(
+      ({ on }: { on: boolean }) =>
+        useAuthProbe({ enabled: on, triggerRefresh, onAuthRejected }),
+      { initialProps: { on: enabled } },
+    );
+
+  it('does not probe while disabled', async () => {
+    render(false);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(AUTH_PROBE_INTERVAL_MS * 2);
+    });
+    expect(mockFetchAuthMe).not.toHaveBeenCalled();
+  });
+
+  it('probes immediately and then on an interval while enabled', async () => {
+    mockFetchAuthMe.mockResolvedValue(user);
+    render(true);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(mockFetchAuthMe).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(AUTH_PROBE_INTERVAL_MS);
+    });
+    expect(mockFetchAuthMe).toHaveBeenCalledTimes(2);
+    expect(triggerRefresh).not.toHaveBeenCalled();
+    expect(onAuthRejected).not.toHaveBeenCalled();
+  });
+
+  it('takes no action on network errors (offline mode)', async () => {
+    mockFetchAuthMe.mockRejectedValue(new Error('network'));
+    render(true);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(AUTH_PROBE_INTERVAL_MS * 3);
+    });
+    expect(mockFetchAuthMe).toHaveBeenCalled();
+    expect(triggerRefresh).not.toHaveBeenCalled();
+    expect(onAuthRejected).not.toHaveBeenCalled();
+  });
+
+  it('first rejection triggers renewal; second consecutive rejection rejects auth', async () => {
+    mockFetchAuthMe.mockResolvedValue(null);
+    render(true);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(triggerRefresh).toHaveBeenCalledTimes(1);
+    expect(onAuthRejected).not.toHaveBeenCalled();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(AUTH_PROBE_INTERVAL_MS);
+    });
+    expect(onAuthRejected).toHaveBeenCalledTimes(1);
+  });
+
+  it('a successful probe between rejections resets the strike counter', async () => {
+    mockFetchAuthMe
+      .mockResolvedValueOnce(null) // strike 1 → renewal
+      .mockResolvedValueOnce(user) // renewal restored the session → reset
+      .mockResolvedValueOnce(null); // strike 1 again → renewal, not rejection
+    render(true);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(AUTH_PROBE_INTERVAL_MS);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(AUTH_PROBE_INTERVAL_MS);
+    });
+    expect(triggerRefresh).toHaveBeenCalledTimes(2);
+    expect(onAuthRejected).not.toHaveBeenCalled();
+  });
+
+  it('stops probing when disabled (e.g. reconnected)', async () => {
+    mockFetchAuthMe.mockResolvedValue(user);
+    const { rerender } = render(true);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    const calls = mockFetchAuthMe.mock.calls.length;
+    rerender({ on: false });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(AUTH_PROBE_INTERVAL_MS * 2);
+    });
+    expect(mockFetchAuthMe).toHaveBeenCalledTimes(calls);
+  });
+});

--- a/hub-client/src/hooks/useAuthProbe.ts
+++ b/hub-client/src/hooks/useAuthProbe.ts
@@ -1,0 +1,74 @@
+/**
+ * useAuthProbe — out-of-band auth check while sync is disconnected.
+ *
+ * Browsers hide the HTTP status of a failed WebSocket upgrade, so a sync
+ * connection rejected with 401 looks identical to a dropped network. This
+ * probe disambiguates by polling GET /auth/me while disconnected
+ * (bd-3o8zmz46):
+ *
+ * - 200 → cookie is fine, the outage is elsewhere; strike counter resets.
+ * - network error → offline; never any action (offline editing must survive).
+ * - 401/403 → first strike triggers silent renewal; a second consecutive
+ *   strike on the next cycle calls `onAuthRejected` (evidence-based logout).
+ *   The two-strike shape gives renewal a full cycle to land and avoids
+ *   depending on IdP callbacks that may never fire (e.g. GIS blocked).
+ */
+
+import { useEffect, useRef } from 'react';
+import { fetchAuthMe } from '../services/authService';
+
+/** Interval between probes while disconnected. */
+export const AUTH_PROBE_INTERVAL_MS = 30_000;
+
+interface AuthProbeOpts {
+  /** Probe only while true (auth enabled + signed in + sync disconnected). */
+  enabled: boolean;
+  /** First definitive rejection: ask for silent renewal. */
+  triggerRefresh: () => void;
+  /** Second consecutive rejection: the session is over. */
+  onAuthRejected: () => void;
+}
+
+export function useAuthProbe({ enabled, triggerRefresh, onAuthRejected }: AuthProbeOpts) {
+  // Keep the latest callbacks in refs so the probe effect can key on
+  // `enabled` alone without re-arming the interval when they change.
+  const triggerRefreshRef = useRef(triggerRefresh);
+  const onAuthRejectedRef = useRef(onAuthRejected);
+  useEffect(() => {
+    triggerRefreshRef.current = triggerRefresh;
+    onAuthRejectedRef.current = onAuthRejected;
+  });
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    let cancelled = false;
+    let strikes = 0;
+
+    const probe = async () => {
+      try {
+        const me = await fetchAuthMe();
+        if (cancelled) return;
+        if (me) {
+          strikes = 0;
+          return;
+        }
+        strikes += 1;
+        if (strikes === 1) {
+          triggerRefreshRef.current();
+        } else {
+          onAuthRejectedRef.current();
+        }
+      } catch {
+        // Network error / unreachable hub — no evidence, no action.
+      }
+    };
+
+    void probe();
+    const interval = setInterval(() => void probe(), AUTH_PROBE_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [enabled]);
+}

--- a/hub-client/src/services/authService.ts
+++ b/hub-client/src/services/authService.ts
@@ -13,6 +13,8 @@ export interface AuthState {
   email: string;
   name: string | null;
   picture: string | null;
+  /** Token expiry in ms-epoch (from the server's `exp`). Absent on older servers. */
+  expiresAt?: number;
 }
 
 /** Raw JSON shape from GET /auth/me (snake_case). */
@@ -20,6 +22,8 @@ interface AuthMeResponse {
   email: string;
   name: string | null;
   picture: string | null;
+  /** Token expiry in epoch seconds. */
+  exp?: number;
 }
 
 /** Fetch user info from the server. Returns null on 401 (not authenticated). */
@@ -32,6 +36,7 @@ export async function fetchAuthMe(): Promise<AuthState | null> {
     email: data.email,
     name: data.name,
     picture: data.picture,
+    expiresAt: data.exp ? data.exp * 1000 : undefined,
   };
 }
 


### PR DESCRIPTION
When the Google ID token expired and One Tap renewal was unavailable, the hub 401'd every Automerge WS upgrade while the SPA stayed "logged in" showing a permanent "working offline" banner (bd-3o8zmz46).

- `/auth/me` now reports the token's `exp` so the client schedules refresh from the real expiry (removing the refocus drift bug)
- new `useAuthProbe` polls `/auth/me` while sync is disconnected and escalates on two consecutive 401s (renewal first, then an explicit "session expired" login screen)
- network errors never clear auth, so genuine offline editing is unaffected