### PR TITLE
fix(hub-client): abandon document open on auth failure

### DIFF
--- a/hub-client/changelog.md
+++ b/hub-client/changelog.md
@@ -17,6 +17,7 @@ be in reverse chronological order (latest first).
 
 ### 2026-06-10
 
+- [`fa2cf019`](https://github.com/quarto-dev/q2/commits/fa2cf019): Opening a document after the sign-in session has expired now cleanly aborts and triggers a silent renewal, instead of opening the document with a randomized collaboration identity.
 - [`465de01f`](https://github.com/quarto-dev/q2/commits/465de01f): An expired sign-in no longer presents as a permanent "working offline" state — the client now detects the rejected session, attempts silent renewal, and returns to the login screen with a "session expired" message; genuine network outages keep offline editing intact.
 
 ### 2026-06-09

--- a/hub-client/src/App.tsx
+++ b/hub-client/src/App.tsx
@@ -35,7 +35,7 @@ import { useRouting } from './hooks/useRouting';
 import { useProjectSet } from './hooks/useProjectSet';
 import { useAuth } from './hooks/useAuth';
 import { useAuthProbe } from './hooks/useAuthProbe';
-import { fetchActorId } from './services/authService';
+import { resolveActorId as resolveActorIdRequest } from './services/authService';
 import type { Route, ShareRoute, LinkProjectSetRoute } from './utils/routing';
 import './App.css';
 
@@ -103,19 +103,13 @@ function App() {
   const projectSetStateRef = useRef(projectSetState);
   projectSetStateRef.current = projectSetState;
 
-  // Fetch per-project actor ID. On 401 (mid-session expiry), trigger a
-  // silent refresh and return undefined — the caller's action is abandoned
-  // for this attempt, while One Tap either restores the session in place
-  // or eventually clears auth via its onError path.
-  const resolveActorId = useCallback(async (indexDocId: string): Promise<string | undefined | null> => {
-    if (!AUTH_ENABLED) return undefined;
-    const id = await fetchActorId(indexDocId);
-    if (id === null) {
-      triggerRefresh();
-      return undefined;
-    }
-    return id;
-  }, [triggerRefresh]);
+  // Resolve the per-project actor ID before opening a document. See
+  // `resolveActorIdRequest` for the three-valued contract; callers abandon
+  // the open only on `null` (auth failure), proceed on `string`/`undefined`.
+  const resolveActorId = useCallback(
+    (indexDocId: string) => resolveActorIdRequest(indexDocId, AUTH_ENABLED, triggerRefresh),
+    [triggerRefresh],
+  );
 
   // Capture auth error from redirect query param (once, before URL is cleaned).
   const [authError] = useState(() => {

--- a/hub-client/src/services/authService.test.ts
+++ b/hub-client/src/services/authService.test.ts
@@ -9,7 +9,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-import { fetchAuthMe, fetchActorId, logout, refreshToken } from './authService';
+import { fetchAuthMe, fetchActorId, resolveActorId, logout, refreshToken } from './authService';
 
 describe('authService', () => {
   beforeEach(() => {
@@ -210,6 +210,79 @@ describe('authService', () => {
       const id1 = await fetchActorId('automerge:proj1');
       const id2 = await fetchActorId('automerge:proj2');
       expect(id1).not.toBe(id2);
+    });
+  });
+
+  // ── resolveActorId ───────────────────────────────────────────
+  //
+  // Three-valued contract the document-open callers depend on:
+  //   string    → open with this actor ID
+  //   undefined → auth disabled; open with no (random) actor ID
+  //   null      → auth failure; abandon the open (callers guard `=== null`)
+
+  describe('resolveActorId', () => {
+    it('returns undefined and skips the network when auth is disabled', async () => {
+      const onSessionExpired = vi.fn();
+      const result = await resolveActorId('automerge:abc', false, onSessionExpired);
+
+      expect(result).toBeUndefined();
+      expect(fetch).not.toHaveBeenCalled();
+      expect(onSessionExpired).not.toHaveBeenCalled();
+    });
+
+    it('returns the actor ID on success without triggering refresh', async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ actor_id: 'abcd1234' }),
+      } as Response);
+      const onSessionExpired = vi.fn();
+
+      const result = await resolveActorId('automerge:abc', true, onSessionExpired);
+
+      expect(result).toBe('abcd1234');
+      expect(onSessionExpired).not.toHaveBeenCalled();
+    });
+
+    it('returns null (abandon) and triggers refresh on 401', async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        ok: false,
+        status: 401,
+      } as Response);
+      const onSessionExpired = vi.fn();
+
+      const result = await resolveActorId('automerge:abc', true, onSessionExpired);
+
+      // null, NOT undefined: callers' `if (id === null) return` must fire so
+      // the document open is abandoned while the refresh races in the background.
+      expect(result).toBeNull();
+      expect(onSessionExpired).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns null (abandon) and triggers refresh on 403', async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        ok: false,
+        status: 403,
+      } as Response);
+      const onSessionExpired = vi.fn();
+
+      const result = await resolveActorId('automerge:abc', true, onSessionExpired);
+
+      expect(result).toBeNull();
+      expect(onSessionExpired).toHaveBeenCalledTimes(1);
+    });
+
+    it('propagates non-401/403 errors without triggering refresh', async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        ok: false,
+        status: 500,
+      } as Response);
+      const onSessionExpired = vi.fn();
+
+      await expect(
+        resolveActorId('automerge:abc', true, onSessionExpired),
+      ).rejects.toThrow('/auth/actor failed: 500');
+      expect(onSessionExpired).not.toHaveBeenCalled();
     });
   });
 });

--- a/hub-client/src/services/authService.ts
+++ b/hub-client/src/services/authService.ts
@@ -65,6 +65,32 @@ export async function fetchActorId(projectId: string): Promise<string | null> {
   return data.actor_id;
 }
 
+/**
+ * Resolve the per-project actor ID for a document open. Three-valued contract
+ * the callers depend on:
+ *   - string    → actor ID resolved; open with it
+ *   - undefined → auth disabled; open with no (random) actor ID
+ *   - null      → auth failure (401/403); abandon the open
+ *
+ * On auth failure we fire `onSessionExpired` (a silent refresh) and return
+ * `null` so callers' `=== null` guard abandons this attempt; One Tap either
+ * restores the session in place or eventually clears auth via its onError path.
+ * Throws propagate (e.g. 500) so callers' try/catch surfaces a connection error.
+ */
+export async function resolveActorId(
+  indexDocId: string,
+  authEnabled: boolean,
+  onSessionExpired: () => void,
+): Promise<string | undefined | null> {
+  if (!authEnabled) return undefined;
+  const id = await fetchActorId(indexDocId);
+  if (id === null) {
+    onSessionExpired();
+    return null;
+  }
+  return id;
+}
+
 /** Clear the auth cookie server-side. */
 export async function logout(): Promise<void> {
   await fetch('/auth/logout', {


### PR DESCRIPTION
When a sign-in session expired mid-use, opening any document silently succeeded with the wrong collaboration identity. The document-open paths call `resolveActorId` and bail out only when it returns `null`.

But on a 401/403, `resolveActorId` returned `undefined` — not `null` — so the guard never fired. This is only when the code had already started a token refresh and meant to abandon the attempt.

The fix moves `resolveActorId` into `authService` with an explicit three-valued contract:

- `string` → actor ID resolved; open with it
- `undefined` → auth disabled; open with no actor ID
- `null` → auth failure; abandon the open

Returning `null` on a 401/403 makes the existing `=== null` guard fire, so the open is cleanly abandoned while the silent refresh runs.

Regression from 465de01f (bd-3o8zmz46); covered by new unit tests for the contract.
