### PR TITLE
fix(bd-jv5u083l): renewal verdict deadline unwedges expiry logout

### DIFF
--- a/hub-client/changelog.md
+++ b/hub-client/changelog.md
@@ -15,6 +15,10 @@ be in reverse chronological order (latest first).
 
 -->
 
+### 2026-06-11
+
+- [`1ecc1d8c`](https://github.com/quarto-dev/q2/commits/1ecc1d8c): Sessions whose silent sign-in renewal never completes (e.g. Google One Tap blocked) now correctly reach the login screen at token expiry, instead of silently losing both the expiry logout and all future renewal attempts.
+
 ### 2026-06-10
 
 - [`a7bb7a08`](https://github.com/quarto-dev/q2/commits/a7bb7a08): Upgrade Automerge to 3.2.6, substantially reducing memory usage when loading documents.

--- a/hub-client/src/hooks/useAuth.test.tsx
+++ b/hub-client/src/hooks/useAuth.test.tsx
@@ -322,6 +322,36 @@ describe('useAuth', () => {
       );
     });
 
+    it('clears auth at expiry even when the renewal never settles (wedged IdP)', async () => {
+      const user = { email: 'a@b.com', name: 'A', picture: null };
+      mockFetchAuthMe
+        .mockResolvedValueOnce(user) // mount check
+        .mockResolvedValueOnce(null); // expiry re-check
+
+      const { result } = renderHook(() => useAuth(), { wrapper });
+      await vi.waitFor(() =>
+        expect(result.current.auth).toEqual(user),
+      );
+
+      // Refresh point: renewal is triggered, but the IdP never calls back
+      // (GIS blocked / FedCM — neither onCredential nor onError fires).
+      await act(async () => {
+        vi.advanceTimersByTime(COOKIE_MAX_AGE_MS - REFRESH_BUFFER_MS + 100);
+      });
+      expect(mockProvider.lastSilentRenewalOpts?.enabled).toBe(true);
+
+      // The verdict deadline must settle isRefreshing so the expiry
+      // re-check can still reach its logout verdict.
+      await act(async () => {
+        vi.advanceTimersByTime(REFRESH_BUFFER_MS + 100);
+      });
+
+      await vi.waitFor(() =>
+        expect(result.current.auth).toBeNull(),
+      );
+      expect(result.current.sessionExpired).toBe(true);
+    });
+
     it('keeps auth if server confirms valid cookie at expiry', async () => {
       const user = { email: 'a@b.com', name: 'A', picture: null };
       const freshUser = {

--- a/hub-client/src/hooks/useAuth.ts
+++ b/hub-client/src/hooks/useAuth.ts
@@ -39,6 +39,9 @@ const DEFAULT_SESSION_MS = 3600 * 1000;
 /** Re-check interval when an expiry-time verdict couldn't be reached. */
 const EXPIRY_RECHECK_MS = 60 * 1000;
 
+/** Time the IdP gets to settle a renewal before it counts as failed (30 s). */
+export const REFRESH_VERDICT_TIMEOUT_MS = 30 * 1000;
+
 export function useAuth() {
   const provider = useAuthProvider();
   const [auth, setAuth] = useState<AuthState | null>(null);
@@ -48,6 +51,7 @@ export function useAuth() {
   const isRefreshing = useRef(false);
   const refreshTimer = useRef<ReturnType<typeof setTimeout>>(null);
   const expiryTimer = useRef<ReturnType<typeof setTimeout>>(null);
+  const refreshDeadline = useRef<ReturnType<typeof setTimeout>>(null);
 
   // Effective expiry of the current session (0 = no session).
   const expiresAtRef = useRef<number>(0);
@@ -84,13 +88,27 @@ export function useAuth() {
     return () => { cancelled = true; };
   }, []);
 
+  /** A renewal settled (success, failure, or deadline) — clear the in-flight gate. */
+  const settleRefresh = useCallback(() => {
+    if (refreshDeadline.current) clearTimeout(refreshDeadline.current);
+    refreshDeadline.current = null;
+    isRefreshing.current = false;
+  }, []);
+
   // Single entry point for activating One Tap. Coalesces concurrent
   // triggers (e.g. N parallel 401s) into one refresh attempt.
   const triggerRefresh = useCallback(() => {
     if (isRefreshing.current) return;
     isRefreshing.current = true;
     setRefreshEnabled(true);
-  }, []);
+    // The IdP may never call back (GIS blocked / FedCM policies). Without a
+    // deadline, isRefreshing wedges true for the tab's lifetime: the expiry
+    // re-check never reaches a verdict and refocus/retry are disabled.
+    refreshDeadline.current = setTimeout(() => {
+      settleRefresh();
+      setRefreshEnabled(false);
+    }, REFRESH_VERDICT_TIMEOUT_MS);
+  }, [settleRefresh]);
 
   // Silent renewal via the active AuthProvider. The provider collapses
   // "renewal returned no usable credential" into onError, so the consumer
@@ -110,16 +128,21 @@ export function useAuth() {
           if (sessionLapsed()) expireSession();
         })
         .finally(() => {
-          isRefreshing.current = false;
+          settleRefresh();
         });
       setRefreshEnabled(false);
     },
     onError: () => {
-      isRefreshing.current = false;
+      settleRefresh();
       setRefreshEnabled(false);
       if (sessionLapsed()) expireSession();
     },
   });
+
+  // Clear any pending renewal deadline on unmount.
+  useEffect(() => () => {
+    if (refreshDeadline.current) clearTimeout(refreshDeadline.current);
+  }, []);
 
   // On visibility change, verify the cookie. If rejected, try One Tap
   // refresh; a network error means offline and never clears the session.

--- a/hub-client/src/hooks/useAuth.ts
+++ b/hub-client/src/hooks/useAuth.ts
@@ -49,8 +49,6 @@ export function useAuth() {
   const [refreshEnabled, setRefreshEnabled] = useState(false);
   const [sessionExpired, setSessionExpired] = useState(false);
   const isRefreshing = useRef(false);
-  const refreshTimer = useRef<ReturnType<typeof setTimeout>>(null);
-  const expiryTimer = useRef<ReturnType<typeof setTimeout>>(null);
   const refreshDeadline = useRef<ReturnType<typeof setTimeout>>(null);
 
   // Effective expiry of the current session (0 = no session).
@@ -95,6 +93,12 @@ export function useAuth() {
     isRefreshing.current = false;
   }, []);
 
+  /** Renewal failed without a hub verdict — settle and stand One Tap down. */
+  const abandonRenewal = useCallback(() => {
+    settleRefresh();
+    setRefreshEnabled(false);
+  }, [settleRefresh]);
+
   // Single entry point for activating One Tap. Coalesces concurrent
   // triggers (e.g. N parallel 401s) into one refresh attempt.
   const triggerRefresh = useCallback(() => {
@@ -104,11 +108,8 @@ export function useAuth() {
     // The IdP may never call back (GIS blocked / FedCM policies). Without a
     // deadline, isRefreshing wedges true for the tab's lifetime: the expiry
     // re-check never reaches a verdict and refocus/retry are disabled.
-    refreshDeadline.current = setTimeout(() => {
-      settleRefresh();
-      setRefreshEnabled(false);
-    }, REFRESH_VERDICT_TIMEOUT_MS);
-  }, [settleRefresh]);
+    refreshDeadline.current = setTimeout(abandonRenewal, REFRESH_VERDICT_TIMEOUT_MS);
+  }, [abandonRenewal]);
 
   // Silent renewal via the active AuthProvider. The provider collapses
   // "renewal returned no usable credential" into onError, so the consumer
@@ -133,8 +134,7 @@ export function useAuth() {
       setRefreshEnabled(false);
     },
     onError: () => {
-      settleRefresh();
-      setRefreshEnabled(false);
+      abandonRenewal();
       if (sessionLapsed()) expireSession();
     },
   });
@@ -180,9 +180,6 @@ export function useAuth() {
   // Schedule silent refresh and an expiry-time server re-check from the
   // session's real expiry.
   useEffect(() => {
-    if (refreshTimer.current) clearTimeout(refreshTimer.current);
-    if (expiryTimer.current) clearTimeout(expiryTimer.current);
-
     if (!auth) {
       expiresAtRef.current = 0;
       return;
@@ -192,15 +189,16 @@ export function useAuth() {
     expiresAtRef.current = expiresAt;
 
     // Silent refresh before expiry; immediately if already inside the buffer.
-    refreshTimer.current = setTimeout(
+    const refreshTimer = setTimeout(
       triggerRefresh,
       Math.max(expiresAt - REFRESH_BUFFER_MS - Date.now(), 0),
     );
 
     // Expiry-time re-check. Only a definitive 401/403 clears the session;
     // network errors reschedule (logout on evidence, not on schedule).
+    let expiryTimer: ReturnType<typeof setTimeout>;
     const scheduleExpiryCheck = (delay: number) => {
-      expiryTimer.current = setTimeout(() => {
+      expiryTimer = setTimeout(() => {
         fetchAuthMe()
           .then((me) => {
             if (me) {
@@ -222,8 +220,8 @@ export function useAuth() {
     scheduleExpiryCheck(msUntilExpiry > 0 ? msUntilExpiry + 1000 : EXPIRY_RECHECK_MS);
 
     return () => {
-      if (refreshTimer.current) clearTimeout(refreshTimer.current);
-      if (expiryTimer.current) clearTimeout(expiryTimer.current);
+      clearTimeout(refreshTimer);
+      clearTimeout(expiryTimer);
     };
   }, [auth, applyAuth, expireSession, triggerRefresh]);
 


### PR DESCRIPTION
## Background

How the hub client manages session expiry today (`useAuth`):

1. On page load, `GET /auth/me` checks whether the auth cookie is valid; a 401 shows the login screen.
2. Fifteen minutes before the token expires, the client asks Google One Tap for a fresh credential ("silent renewal") and exchanges it for a new cookie via `POST /auth/refresh`.
3. At the expiry time itself, the client re-checks `/auth/me`. A definitive 401 logs the user out (with a "session expired" message); a network error keeps the session and re-checks every 60 seconds — so offline editing survives expiry, and the dead session is adjudicated as soon as the hub is reachable again.
4. While a renewal is in flight, the client sets an `isRefreshing` flag so that concurrent triggers coalesce, the tab-refocus check stands down, and the expiry re-check waits for the renewal's verdict instead of logging the user out underneath it.

## The bug

Step 4 assumed the identity provider always answers. It doesn't: if the One Tap prompt never fires (script blocked by an ad blocker, FedCM / third-party-cookie policies, unregistered origin — we've observed `gsi/status` 403 in dev), neither the success nor the error callback ever runs, and `isRefreshing` stays true for the lifetime of the tab. Everything gated on that flag then silently dies:

- the at-expiry re-check loops forever "waiting for a verdict" — the user is never logged out at expiry;
- the refocus check early-returns — no recovery when the tab regains focus;
- every later `triggerRefresh()` is a no-op — no retry, ever.

So in exactly the environments where silent renewal can't work, the client neither renews nor logs out, until a full page reload or a websocket drop.

## The fix

A 30-second verdict deadline on the in-flight renewal. If the provider hasn't settled by then, the renewal counts as failed and the flag clears, so the expiry re-check reaches its verdict normally: 401 → logout, network error → keep waiting.

The regression test mounts a session, lets the renewal trigger, and never settles it; it fails on `main` (the session survives expiry) and passes with the fix.