### PR TITLE
chore: upgrade @automerge/automerge to 3.2.6 across npm workspace

### DIFF
--- a/hub-client/changelog.md
+++ b/hub-client/changelog.md
@@ -17,6 +17,7 @@ be in reverse chronological order (latest first).
 
 ### 2026-06-10
 
+- [`a7bb7a08`](https://github.com/quarto-dev/q2/commits/a7bb7a08): Upgrade Automerge to 3.2.6, substantially reducing memory usage when loading documents.
 - [`867bebaa`](https://github.com/quarto-dev/q2/commits/867bebaa): The q2-debug and editor reveal-deck renderers now draw their reveal.js CSS from the same vendored copy `q2 render` embeds, so deck styling cannot drift between the preview surfaces and rendered output.
 - [`8146aa35`](https://github.com/quarto-dev/q2/commits/8146aa35): KaTeX is now pinned to one exact version (0.16.28) across rendered output (CDN link) and the preview's bundled copy, so math renders identically in both and no longer changes when the CDN's `latest` advances.
 - [`fa2cf019`](https://github.com/quarto-dev/q2/commits/fa2cf019): Opening a document after the sign-in session has expired now cleanly aborts and triggers a silent renewal, instead of opening the document with a randomized collaboration identity.

--- a/hub-client/package.json
+++ b/hub-client/package.json
@@ -31,6 +31,7 @@
     "bootstrap-test-fixtures": "npx tsx e2e/scripts/regenerate-fixtures.ts"
   },
   "dependencies": {
+    "@automerge/automerge": "^3.2.6",
     "@automerge/automerge-repo": "^2.5.6",
     "@automerge/automerge-repo-network-websocket": "^2.5.6",
     "@automerge/automerge-repo-react-hooks": "2.5.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
       "version": "0.0.0",
       "hasInstallScript": true,
       "dependencies": {
+        "@automerge/automerge": "^3.2.6",
         "@automerge/automerge-repo": "^2.5.6",
         "@automerge/automerge-repo-network-websocket": "^2.5.6",
         "@automerge/automerge-repo-react-hooks": "2.5.6",
@@ -136,13 +137,10 @@
       "license": "ISC"
     },
     "node_modules/@automerge/automerge": {
-      "version": "2.2.9",
-      "resolved": "https://registry.npmjs.org/@automerge/automerge/-/automerge-2.2.9.tgz",
-      "integrity": "sha512-6HM52Ops79hAQBWMg/t0MNfGOdEiXyenQjO9F1hKZq0RWDsMLpPa1SzRy/C4/4UyX67sTHuA5CwBpH34SpfZlA==",
-      "license": "MIT",
-      "dependencies": {
-        "uuid": "^9.0.0"
-      }
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@automerge/automerge/-/automerge-3.2.6.tgz",
+      "integrity": "sha512-9/GXXfYYWNVGpnbRrGQzTNU4fWZ3XaEMeEg0OrpK4pvlQSpkmUBoirEb/4TMK6BwMysZGV5Yeneq3wwc7RNGfg==",
+      "license": "MIT"
     },
     "node_modules/@automerge/automerge-repo": {
       "version": "2.5.6",
@@ -8011,9 +8009,9 @@
       }
     },
     "node_modules/katex": {
-      "version": "0.16.47",
-      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
-      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "version": "0.16.28",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.28.tgz",
+      "integrity": "sha512-YHzO7721WbmAL6Ov1uzN/l5mY5WWWhJBSW+jq4tkfZfsxmo1hu6frS0EOswvjBUnWE6NtjEs48SFn5CQESRLZg==",
       "funding": [
         "https://opencollective.com/katex",
         "https://github.com/sponsors/katex"
@@ -12549,7 +12547,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@automerge/automerge": "^2.2.9",
+        "@automerge/automerge": "^3.2.6",
         "@automerge/automerge-repo": "^2.5.1",
         "@quarto/pandoc-types": "*",
         "@quarto/preview-renderer": "*",
@@ -12614,7 +12612,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@automerge/automerge": "^2.2.9",
+        "@automerge/automerge": "^3.2.6",
         "@automerge/automerge-repo": "^2.5.1",
         "@automerge/automerge-repo-network-websocket": "^2.5.1",
         "@automerge/automerge-repo-storage-indexeddb": "^2.5.4",

--- a/ts-packages/preview-runtime/package.json
+++ b/ts-packages/preview-runtime/package.json
@@ -40,7 +40,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@automerge/automerge": "^2.2.9",
+    "@automerge/automerge": "^3.2.6",
     "@automerge/automerge-repo": "^2.5.1",
     "@quarto/pandoc-types": "*",
     "@quarto/preview-renderer": "*",

--- a/ts-packages/quarto-sync-client/package.json
+++ b/ts-packages/quarto-sync-client/package.json
@@ -28,7 +28,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@automerge/automerge": "^2.2.9",
+    "@automerge/automerge": "^3.2.6",
     "@automerge/automerge-repo": "^2.5.1",
     "@automerge/automerge-repo-network-websocket": "^2.5.1",
     "@automerge/automerge-repo-storage-indexeddb": "^2.5.4",


### PR DESCRIPTION
Upgrades @automerge/automerge from 2.2.9 to 3.2.6 (pins in quarto-sync-client and preview-runtime, plus an explicit dependency in hub-client, which previously imported it undeclared).

- Automerge 2.x expands documents into an uncompressed in-memory representation at load time, which could OOM the WASM instance during `loadIncremental` — surfacing as an intermittent "Unreachable code should not be executed" trap when opening a project.
- Automerge 3 keeps the compressed representation at runtime (upstream reports >10x memory reduction) and is format-compatible

Automerge-repo 2.5.6 already accepts it (`2.2.8 - 3`). All ts-package and hub-client builds and test suites pass.