### PR TITLE
feat(hub-client): opt-in HTTPS dev server for mobile/network testing

### DIFF
--- a/hub-client/README.md
+++ b/hub-client/README.md
@@ -55,6 +55,28 @@ This is the same check that runs before `dev:fresh`, but without starting the de
 
 **Important:** Plain `tsc --noEmit` without `-p tsconfig.app.json` uses different settings and may miss errors that will break at runtime. Always use `npm run typecheck` or `npm run preflight`.
 
+### Testing on Mobile / Other Devices
+
+By default the dev server only accepts connections from `localhost`. To test on a phone or tablet on the same network, you need two things:
+
+1. **Expose the server on the network** (`--host`)
+2. **Serve over HTTPS** — browsers treat `http://<ip>` as an insecure context and block APIs like `crypto.randomUUID()` and `crypto.subtle`, causing a blank white page
+
+Start the server with both:
+
+```bash
+VITE_HTTPS=1 npm run dev:fresh -- --host
+```
+
+Vite will print the network HTTPS URL to open on your device:
+
+```
+➜  Local:   https://localhost:5173/
+➜  Network: https://192.168.x.x:5173/
+```
+
+The certificate is self-signed, so the browser will show a security warning on first visit. Click through it ("Advanced" → "Proceed") — this is expected for local development.
+
 ### When to Rebuild WASM
 
 You need to rebuild the WASM module (`npm run build:wasm` or `npm run dev:fresh`) when:

--- a/hub-client/package.json
+++ b/hub-client/package.json
@@ -62,6 +62,7 @@
     "@types/react": "^19.2.5",
     "@types/react-dom": "^19.2.3",
     "@types/ws": "^8.18.1",
+    "@vitejs/plugin-basic-ssl": "^2.3.0",
     "@vitejs/plugin-react": "^5.1.1",
     "@vitest/coverage-v8": "^4.0.17",
     "common-tags": "^1.8.2",

--- a/hub-client/vite.config.ts
+++ b/hub-client/vite.config.ts
@@ -4,6 +4,7 @@ import react from '@vitejs/plugin-react'
 import wasm from 'vite-plugin-wasm'
 import compression from 'compression'
 import { VitePWA } from 'vite-plugin-pwa'
+import basicSsl from '@vitejs/plugin-basic-ssl'
 import path from 'path'
 import { readFileSync } from 'fs'
 import { execSync } from 'child_process'
@@ -62,6 +63,7 @@ export default defineConfig({
   plugins: [
     react(),
     wasm(),
+    ...(process.env.VITE_HTTPS === '1' ? [basicSsl()] : []),
     attributionViewerCssPlugin(),
     {
       // vite preview's static-file middleware does not gzip by default,

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,6 +68,7 @@
         "@types/react": "^19.2.5",
         "@types/react-dom": "^19.2.3",
         "@types/ws": "^8.18.1",
+        "@vitejs/plugin-basic-ssl": "^2.3.0",
         "@vitejs/plugin-react": "^5.1.1",
         "@vitest/coverage-v8": "^4.0.17",
         "common-tags": "^1.8.2",
@@ -4217,6 +4218,19 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@vitejs/plugin-basic-ssl": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-basic-ssl/-/plugin-basic-ssl-2.3.0.tgz",
+      "integrity": "sha512-bdyo8rB3NnQbikdMpHaML9Z1OZPBu6fFOBo+OtxsBlvMJtysWskmBcnbIDhUqgC8tcxNv/a+BcV5U+2nQMm1OQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/@vitejs/plugin-react": {
@@ -12096,6 +12110,7 @@
         "@quarto/preview-renderer": "*",
         "@quarto/quarto-automerge-schema": "*",
         "@quarto/quarto-sync-client": "*",
+        "fast-diff": "^1.3.0",
         "web-tree-sitter": "^0.26.8"
       },
       "devDependencies": {


### PR DESCRIPTION
With this, I was able to test, in Firefox on an Android tablet over my local network:

* creating a project
* creating a q2-preview document 
* add some text to the document
* edit the text in q2-preview
* reflected back in doc

There were some automerge timing glitches but it all worked!

## Summary

- Adds `@vitejs/plugin-basic-ssl` as a dev dependency
- Activates the plugin only when `VITE_HTTPS=1` is set, so the default dev workflow is unchanged
- Documents the workflow in `hub-client/README.md` under a new "Testing on Mobile / Other Devices" section

## Motivation

When accessing the Vite dev server by IP address (e.g. from a phone on the same WiFi), the browser treats `http://192.168.x.x` as an insecure context and refuses to run `crypto.randomUUID()` and `crypto.subtle` — APIs the app calls at startup. The result is a blank white page with no visible error.

Serving over HTTPS fixes this. The self-signed cert triggers a one-time browser warning, which is acceptable for local dev.

## Usage

\`\`\`bash
VITE_HTTPS=1 npm run dev:fresh -- --host
\`\`\`

Vite will print the `https://192.168.x.x:5173/` network URL to open on the device. Accept the self-signed cert warning on first visit.

## Test plan

- [x] `npm run dev:fresh` (no env var) still starts on HTTP — no regression
- [x] `VITE_HTTPS=1 npm run dev:fresh -- --host` serves HTTPS and is reachable from a device on the same network
- [x] App loads and renders correctly on mobile (verified on Firefox/Android and Safari/iOS)