### PR TITLE
q2 mcp: embedded MCP launcher + sync reliability fixes (bd-81cfshmw)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ node_modules/
 # Hub server secret — never commit this (matches any project subdirectory)
 **/.quarto/hub/hub.json
 ts-packages/*/dist/
+ts-packages/*/dist-bundle/
 ts-packages/*/*.tsbuildinfo
 q2-demos/*/dist/
 crates/wasm-quarto-hub-client/pkg/

--- a/.mcp.json
+++ b/.mcp.json
@@ -4,7 +4,9 @@
       "type": "stdio",
       "command": "node",
       "args": [
-        "ts-packages/quarto-hub-mcp/dist/index.js"
+        "ts-packages/quarto-hub-mcp/dist/index.js",
+        "--server",
+        "ws://127.0.0.1:3000/ws"
       ]
     }
   }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -443,6 +443,27 @@ For the deeper context (which crate produces which artifact, why the
 chain doesn't auto-fire, how to diagnose stale-WASM symptoms) see
 `claude-notes/instructions/preview-spa-rebuild.md`.
 
+## Verifying TypeScript changes in `q2 mcp`
+
+Same trap, different artifact: `q2 mcp` embeds the esbuild bundle at
+`ts-packages/quarto-hub-mcp/dist-bundle/` via `include_dir!` and runs
+it with ambient Node. A plain `cargo build --bin q2` re-embeds
+whatever bundle was last built — after changing `quarto-hub-mcp`,
+`quarto-sync-client`, or `quarto-automerge-schema`, run:
+
+```bash
+cargo xtask build-hub-mcp-bundle      # rebuild dist-bundle/ from TS sources
+cargo build --bin q2                  # re-embed via include_dir!
+```
+
+`cargo xtask build-all` includes the bundle step (ordered before the
+Rust build). Diagnose staleness with `q2 mcp --launcher-info`, which
+prints the embedded bundle's git commit, dirty flag, and build time.
+Fresh clones build fine without the bundle (a placeholder is embedded,
+with a cargo warning); `q2 mcp` then fails at runtime pointing at the
+xtask. Design: `claude-notes/plans/2026-06-11-q2-mcp-hub-auth.md`
+(bd-81cfshmw).
+
 ## Build Commands
 
 - WASM build: `npm run build:all` (NOT `cargo build --target wasm32-unknown-unknown`)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3837,6 +3837,7 @@ dependencies = [
  "quarto-error-reporting",
  "quarto-hub",
  "quarto-lsp",
+ "quarto-mcp-launcher",
  "quarto-preview",
  "quarto-publish",
  "quarto-sass",
@@ -4147,6 +4148,22 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+]
+
+[[package]]
+name = "quarto-mcp-launcher"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "dirs",
+ "fs2",
+ "include_dir",
+ "libc",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "tempfile",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/claude-notes/plans/2026-06-11-q2-mcp-hub-auth.md
+++ b/claude-notes/plans/2026-06-11-q2-mcp-hub-auth.md
@@ -402,11 +402,55 @@ behavior) when driving sessions by hand.
 
 ### Phase 3 — auth + hub e2e through the launcher
 
-- [ ] Tests: against a local auth-enabled hub (reusing
-      `crates/quarto-hub/tests/auth_bearer.rs` setup patterns):
-      `authenticate` round-trip through `q2 mcp`, keyring reuse across
-      launcher/npx channels (same credential visible to both), 401 →
-      refresh path unaffected by the launcher.
+Shape (settled 2026-06-11 after reading the existing infra): the TS
+auth tests are unit-level with injected seams (mock keyring, mock
+oauth4webapi, no MCP server) and `auth_bearer.rs` shows the hub
+accepts a plain-http in-process mock OIDC issuer. The missing piece is
+a full-stack e2e: real hub binary + real `q2` launcher + real loopback
+listener + real OS keyring + mock IdP minting real RS256 JWTs. Two
+production gaps block it, both sound changes in their own right:
+
+- [x] `QUARTO_HUB_MCP_ISSUER` env override (default stays Google);
+      http issuers loopback-only + `QUARTO_HUB_MCP_ALLOW_INSECURE_AUTH=1`;
+      7 unit tests for the resolution matrix.
+- [x] `allowInsecureRequests` threaded through discovery, code
+      exchange, refresh (derived from the discovered issuer).
+- [x] Hub-side counterpart (not in the original list — discovered
+      necessary): `AuthConfig::new` gains `allow_insecure_issuer`
+      (wired to `--allow-insecure-auth`, loopback-only); discovery's
+      `jwks_uri` allowance derives from the gated issuer. 5 unit
+      tests; all 267 quarto-hub tests pass.
+- [x] E2E (`src/e2e-auth.test.ts` + `src/test-idp.ts`): full stack —
+      mock IdP minting real RS256 JWTs, real hub binary, real loopback
+      (test scrapes the stderr sign-in URL and plays the browser; fake
+      `open` shim), real OS keyring, both channels. Asserts the
+      sign-in-required gate, authenticate round-trip (1 code
+      exchange), Bearer-ws create/read, forced refresh grants (45s
+      TTL), cross-process keyring reuse WITHOUT re-auth, clear+revoke.
+      Channel B uses the real `q2 mcp` launcher when its embed's
+      gitCommit == HEAD (else dist fallback + loud notice — `builtAt`
+      nondeterminism makes byte-equality gating flaky). Verified both
+      ways on 2026-06-11: dist fallback, then real launcher after
+      `cargo xtask build-hub-mcp-bundle && cargo build --bin q2`.
+
+**Phase 3 discoveries — the e2e caught two product bugs no seam-mocked
+unit test could reach (both fixed TDD, strands closed):**
+
+- **bd-xnmd5ni1**: the MCP server silently created projects in
+  *offline mode with in-memory storage* — `create_project` returned an
+  indexDocId for documents that existed only in process memory
+  (sync-client's 1 ms peer-wait default + silent offline fallback;
+  auth's HTTP round-trips lose that race deterministically; hub audit
+  log showed ws `auth_ok` while the client logged "creating project in
+  offline mode"). Fix: `requireOnline` option in sync-client (typed
+  `PeerUnavailableError`, adapter teardown, browser defaults locked by
+  test) + hub-mcp passes it with a 15 s budget on connect/create.
+- **bd-xzspx4r9**: any ws socket error except ECONNREFUSED (e.g.
+  mid-handshake `socket hang up`) crashed the whole MCP server —
+  upstream automerge-repo's `onError` *rethrows* inside the event
+  callback → uncaughtException → exit(1); both our adapters inherited/
+  copied the pattern. Fix: log-and-let-retry, never throw. Upstream
+  issue still to file (Phase 4 item).
 - [x] Default `--server` URL (`wss://quarto-hub.com/ws`, resolved
       open question 3) added in the TS server: flag > env > default
       resolution, the "--server is required" error removed, parseArgs

--- a/claude-notes/plans/2026-06-11-q2-mcp-hub-auth.md
+++ b/claude-notes/plans/2026-06-11-q2-mcp-hub-auth.md
@@ -463,12 +463,31 @@ unit test could reach (both fixed TDD, strands closed):**
       docs land with bd-3tak0lyy); Node requirement stated plainly.
 - [ ] ~~npm publish pipeline~~ — moved to follow-up strand
       **bd-3tak0lyy** (gated on public-release readiness).
-- [ ] **End-to-end verification (CLAUDE.md policy):** real
-      `q2 mcp` configured in a real agent app on this machine;
-      authenticate interactively against quarto-hub.com; edit a real
-      project; observe the edit live in hub-client in a browser with
-      correct attribution; record exact invocation + observed output
-      here.
+- [x] **End-to-end LIVE verification against quarto-hub.com
+      (2026-06-12, per CLAUDE.md policy).** Invocation: the real
+      `target/debug/q2 mcp` (no `--server`; production default) with
+      `QUARTO_HUB_MCP_CLIENT_ID/SECRET` for the Desktop client
+      registered 2026-06-12, driven over MCP stdio
+      (`/tmp` driver script; transcript in session bd-81cfshmw).
+      Carlos completed the Google sign-in in his browser
+      (carlos.scheidegger@posit.co, domain-allowlisted). Observed,
+      client side (driver log):
+      `AUTHENTICATE: Authenticated as carlos.scheidegger@posit.co.` →
+      `connect_project SNHcgVzUkWpGFmcxkCkpCDfFtmu` returned the real
+      playground file list → `READ /charlie/autosync.qmd` returned
+      document content over Bearer wss. Observed, server side (hub
+      journal): 15:26:09Z `auth_ok … credential_kind="bearer"` on
+      /health and /ws, then `Document accessed
+      email=carlos.scheidegger@posit.co` for the project docs. Output
+      inspected on both ends.
+      **Loose end (filed separately):** sign-in with the gmail
+      account hit Google's `Error 400: invalid_request
+      (redirect_uri)` post-login, while three discriminator probes
+      and the full flow passed with the posit.co account — an
+      account-conditional Google-side rejection, NOT a flow bug
+      (loopback+PKCE+Desktop-client confirmed compliant; current
+      loopback policy re-checked 2026-06-12). Likely the consent
+      screen's Testing-mode test-user list.
 
 ## Rust-native findings (v1 research, kept for the record)
 

--- a/claude-notes/plans/2026-06-11-q2-mcp-hub-auth.md
+++ b/claude-notes/plans/2026-06-11-q2-mcp-hub-auth.md
@@ -1,0 +1,427 @@
+# `q2 mcp` — embed & delegate to the TypeScript hub MCP server
+
+**Strand:** bd-81cfshmw
+**Status:** DESIGN — iterating with Carlos; do not start implementation
+until he gives the go-ahead.
+
+## Overview
+
+Goal (Carlos, 2026-06-11): give anyone with `q2` installed an easy path
+to let LLM apps and agents (Claude Desktop, Claude Code, etc.) read and
+write quarto-hub.com documents *as a participant in the multiplayer
+automerge session*. quarto-hub.com happens to be gated behind auth, so
+`q2 mcp` must speak the auth flow — but auth is the gate, not the goal.
+
+**Architecture (v2, Carlos's proposal):** the TypeScript
+`ts-packages/quarto-hub-mcp` server is and remains the canonical MCP
+implementation — it already has the 11-tool surface, the loopback+PKCE
+auth (shipped 2026-06-10, `2272451f`), keyring storage, and the
+connection/threat-model work. `q2 mcp` becomes a thin Rust launcher:
+
+1. Bundle the TS server into a self-contained distribution
+   (single `.mjs` + the platform keyring addon) during the build.
+2. Embed that bundle in the `q2` binary (`include_dir!`-style, same
+   pattern as the q2-preview SPA).
+3. At `q2 mcp` invocation: extract the bundle to a per-user cache dir,
+   find an ambient `node`, and delegate execution verbatim
+   (`q2 mcp [args…]` → `node <bundle>/index.mjs [args…]`, stdio
+   inherited).
+
+The same bundle is published to npm so non-q2 users get it with one
+`npx` command. One implementation, two delivery channels.
+
+Cost: `q2 mcp` requires Node on the user's machine. Accepted tradeoff
+(2026-06-11) given Node's ubiquity — and given that hub-client +
+quarto-hub constraints keep the auth/sync code TypeScript for the
+foreseeable future, so a Rust port would mean maintaining
+security-critical code twice.
+
+### Decision history
+
+- **v1 (2026-06-11, superseded):** Rust-native port — new
+  `crates/quarto-mcp` with `rmcp`, a port of the loopback+PKCE flow,
+  a samod `BearerDialer`, and a re-implemented document layer. Rejected
+  in favor of v2: large scope, and worst of all it *duplicates the auth
+  and sync semantics in two languages*, which then have to be kept in
+  security-parity forever. The v1 research survives below
+  (§ Rust-native findings) since it tells us what a future native port
+  would cost if the Node dependency ever becomes unacceptable.
+- **Auth flow question resolved:** "the device flow we use" meant "the
+  auth flow the hub MCP uses" — which is loopback+PKCE as of
+  `2272451f`. v2 inherits it for free, along with every future auth
+  change, because the TS code is the single source of truth.
+- **Risk review confirmed (Carlos, 2026-06-11):** all six
+  problem/mitigation pairs below accepted as designed, including the
+  execution model they imply — `q2 mcp` extracts the embedded bundle
+  to a per-user cache dir and runs ambient `node` against it (one-time
+  extraction per content hash). Node-discovery friction to be handled
+  with layered discovery + documentation. Stale-embed precautions
+  (xtask wiring, build stamp, build.rs guard) explicitly endorsed.
+
+## What v2 dissolves (from the v1 open questions)
+
+- *Which auth flow?* — inherited from the TS server, automatically.
+- *OAuth client identity* — same client as the TS server; the keyring
+  entries are **shared by design** (same code, same service name), so
+  a user who authenticated via `npx quarto-hub-mcp` is already
+  authenticated in `q2 mcp` and vice versa. No new
+  `--additional-audiences` deployment change.
+- *Where does the Rust document-model live?* — nowhere; no Rust doc
+  model needed.
+- *Tool-surface parity* — definitionally exact.
+- *Fate of the TS package* — it's the canonical implementation, kept.
+
+## Known problems & mitigations
+
+Ordered by how much design they need. (1) and (2) are the load-bearing
+ones; the rest are foreseeable engineering.
+
+### 1. `@napi-rs/keyring` is a native addon — it cannot live in a single `.mjs`
+
+The credential store loads a platform-specific `.node` binary. esbuild
+cannot inline it; `external`-izing it breaks the extracted bundle
+(nothing to `require` outside `node_modules`).
+
+**Mitigation:** the "bundle" is a small **directory**, not one file:
+`index.mjs` + exactly one `keyring.<platform>.node`. esbuild's `.node`
+file-loader (or a tiny plugin) rewrites the addon require to a
+bundle-relative path. Since each `q2` binary is already
+platform-specific, it embeds only its own platform's addon (~hundreds
+of KB). The npm channel is unaffected (normal npm resolution installs
+the right addon). Risk to verify in spike: napi-rs's runtime loader
+sometimes probes `node_modules` paths by package name — confirm the
+rewrite cleanly bypasses that, or pin the load with an explicit
+`process.env`/argument escape hatch.
+
+### 2. Node discovery under GUI-launched MCP hosts
+
+Claude Desktop (and most GUI MCP hosts) launch servers with a minimal
+environment — on macOS, *not* the user's shell `PATH`. nvm/fnm-managed
+Node lives in shell-init-added paths, so the naive `which node` fails
+exactly in the flagship use case. (The user already has to make `q2`
+itself findable, but `q2` is typically in a standard location; node
+under a version manager is not.)
+
+**Mitigation:** layered discovery in the Rust launcher:
+`QUARTO_NODE` env override → `node` on `PATH` → well-known locations
+(`/opt/homebrew/bin`, `/usr/local/bin`, volta/fnm/nvm shim and
+`versions/node/*/bin` dirs, Windows `Program Files\nodejs`). Validate
+with `node --version` against a minimum (floor TBD in spike — likely
+≥ 20 LTS; automerge 3 / jose 6 / MCP SDK all want ≥ 18). On failure:
+a clear stderr message naming the requirement and the `QUARTO_NODE`
+override (MCP hosts surface server stderr in their logs).
+
+### 3. The stale-embed trap (we have been burned by exactly this)
+
+`cargo build --bin q2` will NOT rebuild the embedded `.mjs`; the binary
+silently re-embeds whatever `dist/` was last built. This is the
+2026-05-20 `q2 preview` stale-WASM incident, identically shaped (see
+`claude-notes/instructions/preview-spa-rebuild.md`).
+
+**Mitigation:** (a) wire the bundle build into `cargo xtask build-all` /
+`verify` like `build-q2-preview-spa`; (b) stamp the bundle with the git
+hash + build time at bundling, surfaced via `q2 mcp --launcher-info`
+(and printed to stderr at startup in verbose mode), so staleness is
+*diagnosable*; (c) `build.rs` fails with an actionable message when the
+bundle dir is missing (fresh clone), pointing at the xtask — same
+convention as the preview SPA. Document the rebuild chain in
+CLAUDE.md alongside the existing preview-SPA section.
+
+### 4. automerge's WASM in a single-file bundle
+
+`@automerge/automerge` 3.x is wasm-backed; under plain `tsc` +
+node_modules it loads fine, but single-file bundling needs the
+base64-inlined variant or the `.wasm` emitted as a bundle asset
+(another reason "bundle = directory" is the right shape). Known
+territory — hub-client already bundles automerge under vite — but the
+node/esbuild recipe must be proven in the spike, including
+`@automerge/automerge-repo-storage-indexeddb` (a browser-only dep of
+`quarto-sync-client`) not dragging browser globals into the node
+bundle.
+
+### 5. Extraction hygiene (where the bundle lands on disk)
+
+Executing embedded code requires writing it to disk first.
+**Mitigation:** extract to a per-user cache dir
+(`dirs::cache_dir()/quarto/hub-mcp/<content-hash>/`, `0700`), atomic
+rename from a temp sibling so concurrent `q2 mcp` launches don't race,
+skip extraction when the hash-dir already exists. No `/tmp` (TOCTOU,
+multi-user); macOS `/private/tmp` confusion avoided too.
+
+**Cache GC (design settled 2026-06-11; Quarto 1 users have complained
+about temp-storage pollution, so this is proactive, not optional).**
+Naive delete-old-dirs is unsafe: node loads bundle pieces *lazily*
+(the keyring `.node` addon loads at first auth use, not startup), so
+deleting under a running instance breaks it mid-session. Refcount
+files are equally wrong: a crashed process never decrements, counters
+leak upward, GC never fires. Instead, the cargo/rustup pattern —
+**lifetime advisory file locks** (`fd-lock` crate: flock / LockFileEx):
+
+- Each instance takes a **shared** lock on `<hash>/.lock` after
+  extraction and holds it for its lifetime. Shared locks coexist
+  (reentrancy); the kernel releases them on process death, however it
+  dies (crash safety, no state to corrupt).
+- Unix exec() wrinkle: flock travels with the fd, and fds survive
+  exec unless CLOEXEC — so the launcher clears CLOEXEC on the lock fd
+  and execs node; node then holds the lock. On Windows the launcher
+  stays alive (spawn+wait) and holds it itself.
+- GC runs opportunistically at launch, after securing its own dir:
+  for each sibling hash dir, **non-blocking try-exclusive lock**;
+  success proves no user → rename to `.trash-<rand>` (concurrent new
+  launchers fail cleanly, re-extract) → delete. Failure → skip.
+- Chronology without a version tag: **touch the dir mtime on every
+  launch**; GC only dirs with mtime older than N days (14–30, pick in
+  Phase 2). This also prevents thrash when a dev build and an
+  installed release alternate on one machine (keep-only-current
+  would have each binary evicting the other's bundle). The risk-3
+  build stamp inside the bundle is diagnostics, not policy.
+- Bounded blast radius either way: dirs are ~3–5 MB, one per distinct
+  q2 build actually used; Windows can't delete in-use files at all,
+  so a GC bug degrades to "skip". No further machinery (quotas,
+  daemons) warranted.
+
+### 6. Process plumbing
+
+stdio must pass through untouched — the MCP protocol owns stdout.
+**Mitigation:** on Unix, `exec()` (`CommandExt::exec`) replaces the
+launcher entirely: signals, exit codes, and stdin-EOF semantics are
+node's, no middleman. On Windows (no exec): spawn with inherited
+stdio, wait, forward the exit code; rely on stdin-EOF (the MCP SDK
+exits when the host closes stdin) for shutdown, which is how MCP hosts
+terminate servers anyway. Launcher rule: **never write to stdout**
+(stderr only), except clap's own pre-delegation `--help`. Prefer
+delegating `q2 mcp --help` to the TS server so help stays
+single-sourced; the launcher claims only flags the TS server doesn't
+own (e.g. `--launcher-info`).
+
+### 7. Smaller, listed for completeness
+
+- **npm publishing is not set up**: `@quarto/hub-mcp` is
+  `"private": true` and `tsc`-built. The "single `npx` instruction"
+  channel needs a public name (`quarto-hub-mcp`?), publish workflow,
+  and the same bundling step. Separable from the q2-embed work but
+  shares the bundler config.
+- **Binary size**: ~3–5 MB embedded (bundle + wasm + addon). Noise
+  relative to q2.
+- **License notices**: bundling vendors dependencies into one file;
+  generate a `THIRD_PARTY_LICENSES` file into the bundle dir as part
+  of the bundling step.
+- **Node-version drift over time**: ambient-node means we don't
+  control the runtime; the min-version check plus CI running the
+  bundle under the floor version and current LTS keeps this honest.
+- **`bin` name collision**: launcher and npm bin should present the
+  same `--server`/`--read-only`/`--redirect-port` surface; they do by
+  construction (same code), but docs should canonicalize one
+  invocation per channel.
+
+### Alternatives considered for the runtime (and rejected)
+
+- **Node SEA / `bun build --compile`** — truly zero-dependency, but
+  +80–100 MB per platform inside q2. Out of proportion.
+- **`npx quarto-hub-mcp@<pinned>` at runtime** — no embed step, but
+  adds registry/network dependency and cold-start latency to first
+  launch, and `npx` still requires Node anyway. The embedded bundle is
+  strictly more reliable; npx remains the non-q2 channel.
+- **Remote MCP (hub serves MCP-over-HTTP)** — the "no local anything"
+  endgame; needs OAuth resource-server semantics on the hub and is a
+  separate, bigger design. Explicitly out of scope here (kept from v1).
+
+## Open questions (v2)
+
+1. ~~**Node version floor**~~ — **RESOLVED (2026-06-11, Carlos):**
+   pin the *current LTS* (Node 24) if it runs the TS auth code —
+   verify in spike; only if it doesn't, fall back to the oldest major
+   that does. (Local dev + CI are already on 24.15.0.)
+2. ~~**npm package naming/publishing**~~ — **RESOLVED (2026-06-11):
+   deferred to follow-up strand bd-3tak0lyy**, gated on general
+   public-release readiness (same gate as cargo-publishing the Rust
+   crates). The bundler config built in Phase 1 is shared with it.
+3. ~~**`q2 mcp` extra UX**~~ — **RESOLVED (2026-06-11): yes** —
+   `--server` defaults to `wss://quarto-hub.com/ws` (the main hub
+   sync server for the foreseeable future), implemented in the TS
+   server so both channels get it.
+4. ~~**Where the bundler config lives**~~ — **RESOLVED (2026-06-11,
+   Carlos):** in `ts-packages/quarto-hub-mcp` as an `npm run bundle`
+   script; xtask invokes it. The npm publish pipeline (bd-3tak0lyy)
+   reuses it.
+
+**GO-AHEAD given 2026-06-11** — implementation started on branch
+`beads/bd-81cfshmw-q2-mcp-launcher`.
+
+## Phases & work items (TDD — tests first in every phase)
+
+> Checklist stays unchecked until go-ahead.
+
+### Phase 0 — spikes (COMPLETE 2026-06-11; findings below)
+
+- [x] Spike: esbuild-bundle `quarto-hub-mcp` into `dist-bundle/`;
+      run it with plain `node` *outside* the repo tree against a
+      local hub; exercise connect/read/write. Risks 1 and 4 retired.
+- [x] Spike: confirm napi-rs addon load path (risk 1 caveat) — **no
+      rewrite needed at all**; see findings.
+- [x] Spike: node-version floor — Node 24 (current LTS) runs
+      everything; per Carlos's rule ("pin current LTS if sufficient"),
+      **floor = Node 24**, esbuild target `node24`.
+- [x] Open questions 1–4 all resolved (see above).
+
+**Phase 0 findings (2026-06-11):**
+
+- `npm run bundle` (new `scripts/bundle.mjs` in
+  `ts-packages/quarto-hub-mcp`, per resolved Q4) produces
+  `dist-bundle/`: `index.mjs` (4.9 MB), `build-info.json` (git commit
+  + dirty flag + build time + node target), and
+  `node_modules/@napi-rs/keyring{,-<platform>}/`.
+- **Keyring (risk 1): simpler than feared.** Keeping
+  `@napi-rs/keyring` external and shipping it as a mini
+  `node_modules` inside the bundle dir means node's ordinary
+  resolution (relative to `index.mjs`) finds it — no loader rewrite,
+  no esbuild plugin. Proven: the credential store imports it
+  statically, so every successful bundle run loads the addon.
+- **automerge wasm (risk 4): resolved via entrypoint steering.** The
+  package's `node` export condition reads `automerge.wasm` with a
+  `__dirname`-relative `readFileSync` (cannot survive bundling); the
+  default `import` condition (`fullfat_base64.js`) inlines the wasm
+  as base64 and bundles cleanly. A 6-line esbuild resolve plugin pins
+  bare `@automerge/automerge` to the base64 entrypoint. (`/slim`
+  imports untouched; they share the initialized singleton.)
+- The `source` export condition on our workspace packages lets
+  esbuild compile `quarto-sync-client`/`quarto-automerge-schema`
+  straight from TS sources — the bundle can never embed a stale
+  workspace `dist/`.
+- esbuild hoists the entry's shebang above any banner — don't put a
+  shebang in the banner (caused a syntax error on first attempt).
+- **Verified end-to-end against a local hub** (standalone bundle in
+  `~/.q2-mcp-bundle-spike`, hub at `ws://127.0.0.1:3941/ws`):
+  MCP initialize + tools/list; `create_project` (index doc
+  `33eeA9AcTQLdSrvLJ35Y1gybursu`); `connect_project`; `patch_file`
+  with multibyte content (`Ünïcödé ✓ 🎉`); `read_file` round-trip;
+  and a **fresh process** re-read proving hub-side persistence.
+  Tool calls are handled concurrently — clients must await
+  `connect_project` before issuing file ops.
+- **Two pre-existing TS-server bugs discovered** (filed as strands,
+  fixed under this plan since both gate `q2 mcp` quality):
+  - **bd-sl4o01y0** — `quarto-sync-client` has 12 `console.log`
+    sites ("Waiting for peer connection...", `[createNewProject]`,
+    …) that land on **stdout**, corrupting the MCP protocol stream.
+    hub-mcp itself has zero.
+  - **bd-9jq2a060** — the server exits on SIGINT/SIGTERM but not on
+    stdin EOF once a sync websocket/retry timer is alive; MCP hosts
+    terminate servers by closing stdin, so every session leaks a
+    node process. Confirmed: still running 4 s after stdin EOF.
+- Observation (not yet filed): a first "Peer connection failed,
+  continuing in offline mode (Timeout)" line sometimes precedes a
+  successful connect — looks like first-attempt timeout noise with
+  multiple Repo instances; revisit during Phase 3 if it persists.
+- **Live playground for later phases (from Carlos):** index doc
+  `SNHcgVzUkWpGFmcxkCkpCDfFtmu` on quarto-hub.com — follow the
+  conventions of the existing files there.
+
+### Phase 1 — bundling, owned by the TS package
+
+- [x] Tests: CI-runnable smoke test (`src/bundle.test.ts`) — builds
+      the bundle, copies it to `os.tmpdir()` (outside the repo tree),
+      and drives it with plain node: artifact checks, `--help`, full
+      MCP round-trip (create/connect/patch/read with multibyte
+      content) against an in-process sync peer (`src/test-hub.ts`),
+      stdout purity, stdin-EOF exit.
+- [x] `npm run bundle` in `ts-packages/quarto-hub-mcp`
+      (`scripts/bundle.mjs`: esbuild, automerge-base64 steering, mini
+      node_modules for the keyring addon, build-info.json stamp).
+      License-notice generation deferred to the npx-channel strand
+      (bd-3tak0lyy) — the q2-embedded copy inherits q2's existing
+      third-party-notice obligations, tracked there.
+- [ ] `cargo xtask build-hub-mcp-bundle`; wire into `build-all` /
+      `verify`; CLAUDE.md rebuild-chain documentation (risk 3).
+
+**Phase 1 discoveries:** three pre-existing TS-server bugs found and
+fixed TDD along the way — bd-sl4o01y0 (sync-client `console.log`
+corrupts MCP stdout; injectable `setSyncLogger` seam + stderr redirect
++ `console.log` rebind), bd-9jq2a060 (no exit on stdin EOF; the SDK's
+StdioServerTransport never watches EOF — explicit `stdin 'end'`
+watcher + guarded shutdown; hub-mcp test suite got 3× faster as a side
+effect), bd-2d8ur7e9 (entry-module guard failed under symlinked
+invocation paths because Node canonicalizes `import.meta.url` but
+argv[1] was compared verbatim — macOS `/tmp`→`/private/tmp` and npm
+`.bin` shims both hit this; `realpathSync` fix; this one would have
+broken the npx channel outright).
+
+### Phase 2 — the Rust launcher
+
+- [ ] Tests (integration layout per `.claude/rules/integration-tests.md`):
+      extraction idempotence + concurrency (two racing launches), hash
+      dir reuse, `QUARTO_NODE` override honored, missing-node error
+      message, exit-code forwarding (Windows path), stdout purity
+      (launcher emits nothing on stdout before delegation), MCP
+      handshake end-to-end through `q2 mcp` against a local hub.
+- [ ] GC tests: shared lock survives exec (child still holds it —
+      assert exclusive-try fails while a launched instance runs);
+      GC skips locked dirs; GC skips young-mtime dirs; GC removes
+      unlocked+old dirs via trash-rename; a launcher racing a GC'd
+      dir re-extracts cleanly; crash (kill -9) releases the lock and
+      the dir becomes collectable.
+- [ ] `q2 mcp` clap wiring (trailing args passed verbatim);
+      embed via `include_dir!`; extraction + lifetime shared lock +
+      launch-time GC (risk 5); node discovery (risk 2); exec/spawn
+      plumbing incl. CLOEXEC handling on the lock fd (risk 6);
+      `--launcher-info`.
+- [ ] `build.rs` missing-bundle guard with actionable message.
+
+### Phase 3 — auth + hub e2e through the launcher
+
+- [ ] Tests: against a local auth-enabled hub (reusing
+      `crates/quarto-hub/tests/auth_bearer.rs` setup patterns):
+      `authenticate` round-trip through `q2 mcp`, keyring reuse across
+      launcher/npx channels (same credential visible to both), 401 →
+      refresh path unaffected by the launcher.
+- [ ] Default `--server` URL (`wss://quarto-hub.com/ws`, resolved
+      open question 3) added in the TS server with its own test.
+
+### Phase 4 — docs, publishing, verification
+
+- [ ] README + docs/ user-facing page: Claude Desktop / Claude Code /
+      Cursor config snippets for the `q2 mcp` channel (npx channel
+      docs land with bd-3tak0lyy); Node requirement stated plainly.
+- [ ] ~~npm publish pipeline~~ — moved to follow-up strand
+      **bd-3tak0lyy** (gated on public-release readiness).
+- [ ] **End-to-end verification (CLAUDE.md policy):** real
+      `q2 mcp` configured in a real agent app on this machine;
+      authenticate interactively against quarto-hub.com; edit a real
+      project; observe the edit live in hub-client in a browser with
+      correct attribution; record exact invocation + observed output
+      here.
+
+## Rust-native findings (v1 research, kept for the record)
+
+If the Node dependency ever becomes unacceptable, the native port is
+feasible; the v1 investigation established:
+
+- samod 0.9 (our fork) supports outbound client connections —
+  `Repo::dial_websocket` / `TungsteniteDialer`
+  (`samod/src/websocket.rs:155-233`) with reconnect+backoff. The
+  built-in dialer can't set headers, but the `Dialer` trait is public
+  and `connect()` runs per reconnect attempt, so a custom
+  `BearerDialer` gets refreshed-token pickup for free. No fork changes
+  needed.
+- The hub's Bearer path is fully built and tested server-side
+  (`crates/quarto-hub/src/auth.rs`, 33 tests in `tests/auth_bearer.rs`);
+  per-project actor IDs come from `GET /auth/actor?project=<id>`.
+- `rmcp` is the official Rust MCP SDK (stdio supported).
+- The index-doc schema lives in `crates/quarto-hub/src/index.rs`; a
+  native client would want it extracted into a shared model crate.
+- The expensive part is re-implementing and *maintaining* the auth +
+  connection threat model in a second language — the reason v2 won.
+
+## References
+
+- TS implementation: `ts-packages/quarto-hub-mcp/` (server),
+  `ts-packages/quarto-sync-client/` (automerge sync + `ws` Bearer
+  adapter)
+- Auth plans: [`2026-05-05-hub-mcp-device-flow-implementation.md`](2026-05-05-hub-mcp-device-flow-implementation.md)
+  (superseded), [`2026-05-28-hub-mcp-loopback-pkce.md`](2026-05-28-hub-mcp-loopback-pkce.md)
+  (current; Phase 3 device-flow removal pending)
+- Original MCP design: [`2026-03-13-hub-mcp-server-design.md`](2026-03-13-hub-mcp-server-design.md)
+- Embed precedent + stale-artifact post-mortem:
+  `claude-notes/instructions/preview-spa-rebuild.md`
+- Hub auth: `crates/quarto-hub/src/auth.rs`, `src/server.rs`,
+  `tests/auth_bearer.rs`
+- Deployment: `~/repos/github/quarto-dev/quarto-hub-deployment`

--- a/claude-notes/plans/2026-06-11-q2-mcp-hub-auth.md
+++ b/claude-notes/plans/2026-06-11-q2-mcp-hub-auth.md
@@ -407,8 +407,10 @@ behavior) when driving sessions by hand.
       `authenticate` round-trip through `q2 mcp`, keyring reuse across
       launcher/npx channels (same credential visible to both), 401 →
       refresh path unaffected by the launcher.
-- [ ] Default `--server` URL (`wss://quarto-hub.com/ws`, resolved
-      open question 3) added in the TS server with its own test.
+- [x] Default `--server` URL (`wss://quarto-hub.com/ws`, resolved
+      open question 3) added in the TS server: flag > env > default
+      resolution, the "--server is required" error removed, parseArgs
+      env-injectable, 4 unit tests, usage text updated.
 
 ### Phase 4 — docs, publishing, verification
 

--- a/claude-notes/plans/2026-06-11-q2-mcp-hub-auth.md
+++ b/claude-notes/plans/2026-06-11-q2-mcp-hub-auth.md
@@ -330,8 +330,12 @@ own (e.g. `--launcher-info`).
       License-notice generation deferred to the npx-channel strand
       (bd-3tak0lyy) — the q2-embedded copy inherits q2's existing
       third-party-notice obligations, tracked there.
-- [ ] `cargo xtask build-hub-mcp-bundle`; wire into `build-all` /
-      `verify`; CLAUDE.md rebuild-chain documentation (risk 3).
+- [x] `cargo xtask build-hub-mcp-bundle`; wired into `build-all`
+      (before the Rust build) and `verify` (new Step 11 also runs the
+      sync-client + hub-mcp vitest suites, which verify previously
+      didn't run at all; `--skip-hub-mcp-*` flags opt out).
+      CLAUDE.md rebuild-chain documentation deferred to Phase 2 — it
+      documents the embed, which doesn't exist until `q2 mcp` lands.
 
 **Phase 1 discoveries:** three pre-existing TS-server bugs found and
 fixed TDD along the way — bd-sl4o01y0 (sync-client `console.log`
@@ -345,26 +349,56 @@ argv[1] was compared verbatim — macOS `/tmp`→`/private/tmp` and npm
 `.bin` shims both hit this; `realpathSync` fix; this one would have
 broken the npx channel outright).
 
-### Phase 2 — the Rust launcher
+### Phase 2 — the Rust launcher (CORE COMPLETE 2026-06-11; see notes)
 
-- [ ] Tests (integration layout per `.claude/rules/integration-tests.md`):
-      extraction idempotence + concurrency (two racing launches), hash
-      dir reuse, `QUARTO_NODE` override honored, missing-node error
-      message, exit-code forwarding (Windows path), stdout purity
-      (launcher emits nothing on stdout before delegation), MCP
-      handshake end-to-end through `q2 mcp` against a local hub.
-- [ ] GC tests: shared lock survives exec (child still holds it —
-      assert exclusive-try fails while a launched instance runs);
-      GC skips locked dirs; GC skips young-mtime dirs; GC removes
-      unlocked+old dirs via trash-rename; a launcher racing a GC'd
-      dir re-extracts cleanly; crash (kill -9) releases the lock and
-      the dir becomes collectable.
-- [ ] `q2 mcp` clap wiring (trailing args passed verbatim);
-      embed via `include_dir!`; extraction + lifetime shared lock +
-      launch-time GC (risk 5); node discovery (risk 2); exec/spawn
-      plumbing incl. CLOEXEC handling on the lock fd (risk 6);
+- [x] Tests (`crates/quarto-mcp-launcher/tests/integration/`, 26
+      passing): extraction payload+metadata, lifetime shared lock,
+      idempotent reuse, 8-thread concurrency convergence (caught a
+      real .tmp-name collision bug — fixed with an atomic uniquifier),
+      corrupt-dir self-heal, GC age/lock/keep-hash/leftover semantics,
+      crash-release collectability, re-extract after GC; QUARTO_NODE
+      override (wins, and too-old is an error not a fallthrough),
+      PATH lookup, floor fallthrough to well-knowns, actionable
+      not-found error. Exit-code forwarding (Windows spawn path) has
+      no unit test — needs a Windows CI run to exercise at all.
+- [x] Lock-survives-exec + stdout purity + e2e handshake: verified
+      against the real binary (see e2e evidence below); these are
+      properties of the exec'd process, untestable in-process.
+- [x] `q2 mcp` clap wiring (`disable_help_flag` + trailing varargs →
+      verbatim pass-through; TS server owns `--help`); new crate
+      `quarto-mcp-launcher` (bundle embed + hash, cache/locks/GC, node
+      discovery, exec/spawn delegate incl. FD_CLOEXEC clearing);
       `--launcher-info`.
-- [ ] `build.rs` missing-bundle guard with actionable message.
+- [x] `build.rs` guard: placeholder embed + cargo warning on missing
+      bundle (house style from quarto-preview — build succeeds, fresh
+      clones work); `q2 mcp` errors at runtime pointing at
+      `cargo xtask build-hub-mcp-bundle`. CLAUDE.md rebuild-chain
+      section added (deferred Phase 1 item).
+
+**Phase 2 e2e evidence (2026-06-11, per CLAUDE.md e2e policy).** All
+through `./target/debug/q2` against a local hub
+(`target/debug/hub --data-dir … -P 3941`):
+
+1. `q2 mcp --launcher-info` → printed bundle-hash
+   `3afafa38242075cc`, embedded build-info (git commit + dirty +
+   builtAt + node24), cache root
+   `~/Library/Caches/quarto/hub-mcp`, discovered node
+   `/opt/homebrew/bin/node (v24.15.0)`.
+2. `q2 mcp --help` → the TS server's usage on stderr (delegation
+   works end-to-end: extract → discover → exec).
+3. MCP session `q2 mcp --server ws://127.0.0.1:3941/ws` with
+   initialize + `create_project` → response
+   `{"indexDocId":"2rgwrw1rasNBHoBEwbyKSgh87rKk","files":["via-q2.qmd"]}`;
+   stdout pure JSON-RPC (jq parsed every line).
+4. Lock property, observed live: while a `q2 mcp` session ran,
+   `flock(LOCK_EX|LOCK_NB)` on the cache `.lock` from another process
+   **failed** (lock survived the exec into node); after the session
+   exited it **succeeded** (kernel release). Output inspected.
+
+Note for test authors: a `printf … | q2 mcp` one-liner closes stdin
+immediately, and the server (correctly, bd-9jq2a060) shuts down on
+EOF, racing in-flight tool calls — hold stdin open (real MCP host
+behavior) when driving sessions by hand.
 
 ### Phase 3 — auth + hub e2e through the launcher
 

--- a/claude-notes/plans/2026-06-12-graceful-dangling-entries.md
+++ b/claude-notes/plans/2026-06-12-graceful-dangling-entries.md
@@ -5,8 +5,85 @@ how dangling entries get minted), bd-8x482xb0 (closed — the production
 casualty), bd-p68lx71t (the 2026-06-12 incident this amplified),
 bd-10bdjmjb (parent plan:
 `claude-notes/plans/2026-06-12-sync-client-offline-race.md`).
-**Status:** READY TO IMPLEMENT — design agreed with Carlos in the
-2026-06-12 session; written as a self-contained handoff.
+**Status:** IN PROGRESS (2026-06-12, worktree
+`.worktrees/bd-vm5e5u10-hub-mcp-connectproject-hard`, branch
+`beads/bd-vm5e5u10-hub-mcp-connectproject-hard` off
+`origin/feature/bd-81cfshmw-q2-mcp-launcher`). Design agreed with
+Carlos in the 2026-06-12 session; written as a self-contained handoff.
+
+## Work items (progress)
+
+- [x] Worktree off `origin/feature/bd-81cfshmw-q2-mcp-launcher`; baseline
+      green (sync-client 95 passed + 2 skipped, hub-mcp 179 passed + 3
+      skipped)
+- [x] Sync-client RED tests 1–4 (`src/dangling-entries.test.ts`), verified
+      failing for the right reason (connect threw `Document … is
+      unavailable`; mid-session case produced the predicted unhandled
+      rejection; index error lacked "index"; formatters absent)
+- [x] Sync-client fix: per-file tolerance in `loadFileDocuments` /
+      `syncWithFiles`, `unavailableFiles` state + `getUnavailableFiles()`,
+      `onFileUnavailable` callback, status marker on returned entries,
+      index-fatal message, handled `syncWithFiles` invocation; tests 1–4
+      green; full sync-client suite 100 passed + 2 skipped
+- [x] hub-mcp RED tests 5–7 (ghosted `connect_project`, per-file
+      `read_file` error, `delete_file` repair), verified failing. (By the
+      time these ran, the sync-client fix was already in its dist, so the
+      RED shape was the residual MCP gap: ghost absent from listings,
+      generic `File not found`, `delete_file` refusing — not the original
+      tool-level connect error.)
+- [x] hub-mcp fix: status in connect/list JSON (`buildFileList` merges
+      `client.getUnavailableFiles()`), per-file guards in
+      read/write/patch/create (write/create refuse to silently repoint a
+      dangling entry), delete/rename work on dangling entries; tests 5–7
+      green; full hub-mcp suite 182 passed + 3 skipped
+- [x] Verification gauntlet: sync-client 100 passed + 2 skipped; hub-mcp
+      182 passed + 3 skipped; hub-client `npm run build` (needed a
+      one-time `npm run build:wasm` in the fresh worktree) +
+      `npm run test:ci` 97 passed; `cargo xtask verify --skip-hub-build
+      --skip-hub-tests` all 13 steps green (9,993 Rust tests passed)
+- [x] Manual e2e: local hub + `q2 mcp`, mint ghost, `connect_project`
+      lists unavailable, `delete_file` repairs; transcript recorded below
+      (§ Manual e2e transcript)
+- [ ] Close-out: commits, braid comment + close with hash, parent-plan
+      note; NO deploy from this strand
+
+## Manual e2e transcript (2026-06-12)
+
+Binary-level verification per CLAUDE.md, real `q2 mcp` against a real
+Rust hub; output inspected, not inferred:
+
+```bash
+cargo xtask build-hub-mcp-bundle && cargo build --bin q2
+# embedded bundle confirmed fresh: q2 mcp --launcher-info →
+#   gitCommit 0fc9f2db (dirty), builtAt 2026-06-12T19:38:37Z
+./target/debug/hub -P 3030 --data-dir <tmp> &          # real Rust hub
+# create a 2-file project over MCP stdio (JSON-RPC driver script):
+#   create_project → indexDocId jA9AqnCVA5LFSKbrBEidSmYPrma
+# mint the dangling entry via an automerge-repo client (mirrors the
+# 2026-06-12 production state; the original fixture was repaired away):
+#   d.files['ghost.qmd'] = '4MFyCaaQTAWKhgQmyjisRkTbjgUL'  # no such doc
+```
+
+Fresh `q2 mcp` session against the ghosted project (observed output):
+
+1. `connect_project` → **succeeds** (was the bricked call in the
+   incident); JSON lists `alpha.qmd`/`beta.qmd` as `"type": "text"` and
+   `{"path": "ghost.qmd", "status": "unavailable", "docId":
+   "4MFyCaaQTAWKhgQmyjisRkTbjgUL"}`.
+2. `read_file ghost.qmd` → `isError: true`: `Error: file document for
+   'ghost.qmd' (automerge:4MFyCaaQTAWKhgQmyjisRkTbjgUL) is unavailable
+   on the sync server — the file may have been created by a client that
+   never synced it; other files in the project remain usable. Use
+   delete_file to remove the dangling entry.`
+3. `read_file alpha.qmd` in the same session → `# Alpha\n\nreal file
+   one\n` (project stays usable).
+4. `delete_file ghost.qmd` → `Deleted ghost.qmd` (the self-service
+   repair that the incident lacked).
+5. `list_files` → only `alpha.qmd` + `beta.qmd`; a **fresh** session's
+   `connect_project` confirms the repair persisted on the hub.
+
+Stdout hygiene: zero non-JSON-RPC stdout lines across all sessions
+(driver counts pollution; 0 in both runs).
 
 ## Branch / coordination — READ FIRST
 

--- a/claude-notes/plans/2026-06-12-graceful-dangling-entries.md
+++ b/claude-notes/plans/2026-06-12-graceful-dangling-entries.md
@@ -14,8 +14,11 @@ The defect lives in `ts-packages/quarto-sync-client`, which received
 several fixes on the **`beads/bd-81cfshmw-q2-mcp-launcher`** branch
 (requireOnline/PeerUnavailableError, never-throw ws error handlers,
 the test-hub harness, offline-creation regression tests). That branch
-is NOT yet merged to main. **Branch off
-`beads/bd-81cfshmw-q2-mcp-launcher`** (or off main after it merges) —
+is NOT yet merged to main; it is pushed as
+**`origin/feature/bd-81cfshmw-q2-mcp-launcher`** (repo convention:
+local `beads/…` names map to remote `feature/…` — see
+`.claude/rules/worktrees.md` § Pushing for PR). **Branch off that
+remote ref** (or off main after it merges) —
 implementing against plain main will conflict and will lack the test
 harness this plan tells you to use. `cargo xtask switch-task
 bd-vm5e5u10 --from beads/bd-81cfshmw-q2-mcp-launcher` is the

--- a/claude-notes/plans/2026-06-12-graceful-dangling-entries.md
+++ b/claude-notes/plans/2026-06-12-graceful-dangling-entries.md
@@ -5,7 +5,9 @@ how dangling entries get minted), bd-8x482xb0 (closed — the production
 casualty), bd-p68lx71t (the 2026-06-12 incident this amplified),
 bd-10bdjmjb (parent plan:
 `claude-notes/plans/2026-06-12-sync-client-offline-race.md`).
-**Status:** IN PROGRESS (2026-06-12, worktree
+**Status:** DONE (2026-06-12, commit `11931849` — originally `4d210f98`,
+rebased onto the bd-10deu8h4 boundary-contract commit before push;
+strand closed). Was: worktree
 `.worktrees/bd-vm5e5u10-hub-mcp-connectproject-hard`, branch
 `beads/bd-vm5e5u10-hub-mcp-connectproject-hard` off
 `origin/feature/bd-81cfshmw-q2-mcp-launcher`). Design agreed with
@@ -44,8 +46,13 @@ Carlos in the 2026-06-12 session; written as a self-contained handoff.
 - [x] Manual e2e: local hub + `q2 mcp`, mint ghost, `connect_project`
       lists unavailable, `delete_file` repairs; transcript recorded below
       (§ Manual e2e transcript)
-- [ ] Close-out: commits, braid comment + close with hash, parent-plan
-      note; NO deploy from this strand
+- [x] Close-out: fix landed as `11931849` (pre-rebase `4d210f98`), braid
+      bd-vm5e5u10 commented + closed, parent plan
+      (`2026-06-12-sync-client-offline-race.md`) notes the amplifier
+      fixed; pushed to `origin/feature/bd-81cfshmw-q2-mcp-launcher`
+      (Carlos-authorized, 2026-06-12) after rebasing onto the
+      bd-10deu8h4 parallel-work notice; NOT deployed from this strand
+      (rollout stays with parent plan Phase 5)
 
 ## Manual e2e transcript (2026-06-12)
 

--- a/claude-notes/plans/2026-06-12-graceful-dangling-entries.md
+++ b/claude-notes/plans/2026-06-12-graceful-dangling-entries.md
@@ -24,6 +24,17 @@ harness this plan tells you to use. `cargo xtask switch-task
 bd-vm5e5u10 --from beads/bd-81cfshmw-q2-mcp-launcher` is the
 sanctioned way (see `.claude/rules/worktrees.md`).
 
+## Parallel work notice
+
+**bd-10deu8h4** (MCP exit-sync drain, plan
+`2026-06-12-mcp-exit-sync-drain.md`) is being implemented in parallel
+on the same integration line. Boundary contract: THEY own
+`client.ts` `disconnect()` + drain primitives, `quarto-hub-mcp`
+`index.ts` shutdown and `connection-manager.ts` `disconnectAll`; YOU
+own `loadFileDocuments` / `syncWithFiles` / `indexChangeHandler` and
+all of `tools.ts`. Shared additive-only: `types.ts`, sync-client
+`index.ts` exports, new test files. Second merger resolves.
+
 ## What happens today (the defect)
 
 A project's index document maps paths → automerge doc ids. If one

--- a/claude-notes/plans/2026-06-12-graceful-dangling-entries.md
+++ b/claude-notes/plans/2026-06-12-graceful-dangling-entries.md
@@ -1,0 +1,231 @@
+# bd-vm5e5u10: one dangling index entry must not brick a project
+
+**Strand:** bd-vm5e5u10 (p1). Related: bd-10deu8h4 (the creator bug —
+how dangling entries get minted), bd-8x482xb0 (closed — the production
+casualty), bd-p68lx71t (the 2026-06-12 incident this amplified),
+bd-10bdjmjb (parent plan:
+`claude-notes/plans/2026-06-12-sync-client-offline-race.md`).
+**Status:** READY TO IMPLEMENT — design agreed with Carlos in the
+2026-06-12 session; written as a self-contained handoff.
+
+## Branch / coordination — READ FIRST
+
+The defect lives in `ts-packages/quarto-sync-client`, which received
+several fixes on the **`beads/bd-81cfshmw-q2-mcp-launcher`** branch
+(requireOnline/PeerUnavailableError, never-throw ws error handlers,
+the test-hub harness, offline-creation regression tests). That branch
+is NOT yet merged to main. **Branch off
+`beads/bd-81cfshmw-q2-mcp-launcher`** (or off main after it merges) —
+implementing against plain main will conflict and will lack the test
+harness this plan tells you to use. `cargo xtask switch-task
+bd-vm5e5u10 --from beads/bd-81cfshmw-q2-mcp-launcher` is the
+sanctioned way (see `.claude/rules/worktrees.md`).
+
+## What happens today (the defect)
+
+A project's index document maps paths → automerge doc ids. If one
+referenced document does not exist on the hub (a "dangling entry"),
+**every client fails the entire project**:
+
+- `ts-packages/quarto-sync-client/src/client.ts`
+  - `loadFileDocuments` (~line 434): `for` loop, `await findDoc(...)`
+    per file, **no try/catch** — the first unavailable doc throws out
+    of `connect()`. Cold opens of the project fail entirely.
+  - `syncWithFiles` (just below, ~line 448): same pattern in the
+    **index-change handler** — sessions with the project already open
+    blow up when a dangling entry *appears* in the index (this is how
+    already-open colleagues got hit on 2026-06-12).
+  - `findDoc` (~line 332): retries "unavailable" up to 3× (with an
+    early bail when `connectedPeers.size === 0` — see Gotchas), then
+    throws `Document <id> is unavailable`.
+- Consumers of `connect()` that therefore hard-fail:
+  - hub-client browser SPA (via `@quarto/preview-runtime`
+    `automergeSync.connect`) — "failures to open project";
+  - the MCP server: `connect_project` returns
+    `Error in connect_project: Document automerge:… is unavailable`
+    (ts-packages/quarto-hub-mcp/src/connection-manager.ts `connect`).
+
+Production evidence (2026-06-12): one entry
+(`/cscheid/q2-mcp-hello.qmd` → a doc that never reached the hub)
+made the Demo Playground unopenable for every browser and the MCP
+alike, surfacing as an incident. The entry was surgically removed;
+**the test fixture no longer exists in production — tests must mint
+their own dangling entries** (trivial, see Test plan).
+
+## Required behavior (the fix)
+
+1. `connect()` succeeds if the **index** loads, even when some file
+   documents are unavailable. Unavailable files are skipped by the
+   loading loop, reported (see 3), and do not affect other files.
+2. `syncWithFiles` (index-change path) gets the same tolerance: a
+   dangling entry appearing mid-session must not throw / reject
+   unhandled; available files continue to work.
+3. Unavailability is **surfaced, not swallowed**:
+   - extend the per-file information returned by `connect()` and kept
+     in client state with an availability marker. `FileEntry` (from
+     `@quarto/quarto-automerge-schema`) is `{ path, type }` today —
+     prefer adding `status?: 'ok' | 'unavailable'` at the
+     sync-client boundary rather than changing the schema package
+     (the index document's wire format is NOT changing; this is
+     client-side presentation. If you do touch the schema package,
+     check its other consumers: hub-client, preview-runtime, wasm
+     tests).
+   - new optional callback `onFileUnavailable?(path: string, docId:
+     string)` in `SyncClientCallbacks`
+     (ts-packages/quarto-sync-client/src/types.ts) so UIs can show a
+     degraded marker. All existing callbacks/consumers must keep
+     compiling without changes (it's optional).
+4. The **index document remaining unavailable stays fatal** — nothing
+   sensible can be done without it; keep that error path, but improve
+   its message (see 5).
+5. **Error-message clarity** (Carlos was misled by the current text
+   during the incident; users will be too): anywhere the client or
+   MCP surfaces unavailability, name what kind of document and which
+   path: e.g. `file document for '/cscheid/x.qmd'
+   (automerge:3HJo…) is unavailable on the sync server — the file may
+   have been created by a client that never synced it` vs `project
+   index document <id> is unavailable`.
+6. MCP server behavior
+   (ts-packages/quarto-hub-mcp/src/tools.ts):
+   - `connect_project` / `list_files`: succeed, listing unavailable
+     files with `"status": "unavailable"` in the JSON payload.
+   - `read_file` / `write_file` / `patch_file` on an unavailable
+     file: clear per-file error (per 5), project stays connected.
+   - `delete_file` / `rename_file` on an unavailable file: these only
+     edit the index — **deleting a dangling entry must work** (that
+     is the self-service repair story; the 2026-06-12 surgery would
+     have been `delete_file` if this had existed). Check
+     `handleDeleteFile`/`handleRenameFile` paths for any doc-load
+     dependency and remove it for the delete case.
+7. Out of scope (do NOT do here): retrying unavailable files when the
+   peer connects later (that's D2, parent plan Phase 3); creating the
+   repair/doctor tooling (parent plan Phase 1.5); changing the 1 ms
+   peer-wait default (D3).
+
+## Test plan (TDD — red first, per CLAUDE.md)
+
+Harness: `ts-packages/quarto-sync-client/src/test-hub.ts` (in-process
+automerge-repo hub with `hubHasDoc`, `holdUpgrades`) — already on the
+branch. Minting a dangling entry in tests: create a project normally
+through a sync client, then mutate the index through the hub's own
+repo handle:
+
+```ts
+const handle = await hub.repo.find(indexDocId);
+handle.change((d) => { d.files['/ghost.qmd'] = 'Av7qtCPQVkStggRLxomA2vW728U'; }); // unknown doc id
+```
+
+New file `ts-packages/quarto-sync-client/src/dangling-entries.test.ts`:
+1. **connect succeeds with a dangling entry** — project with 2 real
+   files + 1 minted ghost: `connect()` resolves; returned entries
+   include both real files (`status: 'ok'` or marker absent) and the
+   ghost with `status: 'unavailable'`; `onFileAdded` fired for real
+   files only; `onFileUnavailable` fired for the ghost;
+   `getFileContent` works for real files. (RED today: connect
+   throws.)
+2. **dangling entry appearing mid-session** — client connected and
+   online; mint the ghost via the hub repo; assert no unhandled
+   rejection (vitest fails on them) and `onFileUnavailable` fires;
+   existing files still readable/editable. (RED today.)
+3. **index unavailable stays fatal** — connect to a nonexistent index
+   doc id with `requireOnline: true`: still rejects, message contains
+   "index" and the id. (Probably green today except message text —
+   lock the improved message.)
+4. **error message content** — assert the unavailable-file error
+   names path + doc id + "sync server" (whatever exact wording you
+   choose in 5; lock it).
+
+MCP level, extend `ts-packages/quarto-hub-mcp/src/` (suite already
+spawns the dist server over stdio — see `stdio-hygiene.test.ts` for
+the pattern; `McpTestClient` + its own `test-hub.ts`; you may need to
+add the index-mutation helper there too, or export it):
+5. `connect_project` on a ghosted project succeeds and the JSON
+   marks the ghost `"status": "unavailable"` (RED today: tool errors).
+6. `read_file` of the ghost → error naming the path; subsequent
+   `read_file` of a real file in the same session works.
+7. `delete_file` of the ghost succeeds and removes the index entry
+   (assert via `list_files`).
+
+Build order for running TS tests (workspace deps resolve via dist):
+`npm run build` in `ts-packages/quarto-automerge-schema`, then
+`quarto-sync-client`, then `quarto-hub-mcp`; then `npx vitest run` in
+the package. Full gate before calling it done:
+`cargo xtask verify --skip-hub-build --skip-hub-tests` (runs the
+hub-mcp/sync-client suites as Step 11) **plus** `cd hub-client && npm
+run build && npm run test:ci` (sync-client is a hub-client dep;
+type/interface changes can break its production build — `build:all`
+not needed unless you touch Rust/wasm-affecting code, which this work
+should not).
+
+## Implementation sketch
+
+In `client.ts`:
+- Wrap the per-file body of `loadFileDocuments` and `syncWithFiles`
+  in try/catch; on an `unavailable`-matching error: record
+  `state.unavailableFiles.set(path, docId)` (new map alongside
+  `fileHandles`), fire `callbacks.onFileUnavailable?.(path, docId)`,
+  `syncLog` a diagnostic (NOT console.log — bd-sl4o01y0), continue.
+  Non-unavailable errors keep throwing (don't mask real bugs).
+- `connect()`'s returned `FileEntry[]`: annotate from
+  `state.unavailableFiles`.
+- Clear `unavailableFiles` appropriately on disconnect and when an
+  entry is removed from the index (`syncWithFiles` removal branch).
+- Keep `findDoc` itself unchanged (its retry semantics are D2/D3
+  territory; you only need its thrown error to be recognizable —
+  it already matches `/unavailable/i`).
+
+In `tools.ts` (hub-mcp): thread the status through
+`handleConnectProject`/`handleListFiles` JSON; per-file guards in
+read/write/patch with the clear message; ensure delete/rename of an
+unavailable path skips any doc fetch.
+
+## Gotchas, from the people who got got
+
+- **Stdout purity**: never `console.log` in sync-client — use
+  `syncLog` (`src/log.ts`); there's a source-level invariant test
+  that will fail your PR otherwise (bd-sl4o01y0).
+- **The connect spy**: `quarto-hub-mcp/src/connection-manager.test.ts`
+  has a `spySyncClientFactory` modeling `connect`'s signature — if
+  you change the connect return shape, update it (it bit us once:
+  options-bag migration).
+- **`findDoc`'s `connectedPeers.size === 0` bail** (e326eb5c): noted
+  latent cold-boot issue, deliberately NOT in scope — don't "fix" it
+  in passing; it's tracked in the parent plan's D2 with its own test
+  requirements.
+- **vitest + unhandled rejections — CONFIRMED**: the index-change
+  handler calls `syncWithFiles(newFiles)` fire-and-forget (no await,
+  no void; `client.ts` ~578), so today's mid-session failure is an
+  *unhandled promise rejection*. Your fix should make that call
+  explicitly handled (`void syncWithFiles(...).catch(...)` routing
+  into the same unavailable-tolerance), and test 2 should assert no
+  unhandled rejection escapes (vitest fails runs on them by
+  default — rely on that, plus the onFileUnavailable assertion).
+- **Don't pipe test runs through `tail`/`grep` when exit codes
+  matter** — a swallowed vitest failure produced a false green in
+  this session. Run plainly or capture to a file and check `$?`.
+- Tests gated on Rust binaries follow the pattern in
+  `offline-creation-rust-hub.test.ts` (`describe.runIf` + loud skip
+  message); for THIS work the in-process JS hub suffices — no Rust
+  binary needed.
+- macOS-only validation is acceptable for now (Carlos, 2026-06-11);
+  CI parity for Windows comes later via review.
+
+## Acceptance criteria
+
+- [ ] All 7 new tests green; every pre-existing suite green
+      (sync-client, hub-mcp incl. bundle + e2e-auth where gated,
+      hub-client build + test:ci, `cargo xtask verify
+      --skip-hub-build --skip-hub-tests`).
+- [ ] Manual e2e per CLAUDE.md (binary-level, not just vitest): local
+      hub + `q2 mcp` (rebuild bundle + binary first: `cargo xtask
+      build-hub-mcp-bundle && cargo build --bin q2`); mint a ghost
+      entry; `connect_project` lists it as unavailable; `delete_file`
+      repairs it; record the transcript in this plan.
+- [ ] Error messages reviewed against requirement 5 (a human can tell
+      file-vs-index and which path).
+- [ ] braid: comment + close bd-vm5e5u10 with commit hash; note in
+      parent plan (`2026-06-12-sync-client-offline-race.md`) that the
+      amplifier is fixed.
+- [ ] Do NOT deploy to quarto-hub.com from this strand; rollout is
+      coordinated in the parent plan (Phase 5) and the deployment
+      repo currently has standing notes in bd-erf there.

--- a/claude-notes/plans/2026-06-12-mcp-exit-sync-drain.md
+++ b/claude-notes/plans/2026-06-12-mcp-exit-sync-drain.md
@@ -69,18 +69,30 @@ its only copy was in-process: expected false to be true
 
 ### Phase 2 — implement
 
-- [ ] sync-client: drain primitive (`drainOutbound`) wired into
+- [x] sync-client: drain primitive (`drainOutbound`) wired into
       `disconnect({drainMs})`; default 0 (browser teardown unchanged).
-- [ ] sync-client: peer storageId tracking in `trackPeers`.
-- [ ] hub-mcp: `disconnectAll({drainMs})` + loud stderr on undrained
-      projects (names indexDocId + paths).
-- [ ] hub-mcp: `index.ts` shutdown passes the drain budget; keeps
-      re-entrancy guard; stdin-EOF exit stays within hygiene bound.
-- [ ] Both red tests green; loud-failure path test (hub down at exit →
-      stderr names undelivered paths).
-- [ ] Suites green: sync-client, hub-mcp (incl. bundle test),
-      hub-client `npm run build && npm run test:ci`,
-      `cargo xtask verify --skip-hub-build --skip-hub-tests`.
+      Event-driven (`remote-heads` per handle + `peer` for mid-drain
+      reconnects), bounded by `drainMs`, early-returns on confirmation.
+- [x] sync-client: peer storageId tracking in `trackPeers` (kept after
+      peer-disconnect — confirmed heads stay confirmed).
+- [x] hub-mcp: `disconnectAll({drainMs})` + loud stderr on undrained
+      projects (names indexDocId + paths; stderr only, bd-sl4o01y0).
+- [x] hub-mcp: `index.ts` shutdown passes `SHUTDOWN_DRAIN_MS = 3000`;
+      keeps re-entrancy guard; stdin-EOF exit stays within the 5 s
+      hygiene bound (3 s budget binds only when the hub is gone).
+- [x] Both red tests green; loud-failure path tested at BOTH levels
+      (sync-client report assertions + stdio stderr assertion with
+      prompt exit).
+- [x] BONUS: real-samod drain regression test (gated on
+      `target/debug/hub`, unix): create → `disconnect({drainMs})` →
+      report.drained AND every doc present in samod's on-disk storage.
+      This behaviorally verifies the delivery signal against the
+      production hub implementation — passed 2026-06-12.
+- [x] Suites green (2026-06-12): sync-client 99/99 (incl. rust-hub
+      gated), hub-mcp 181 passed/3 skipped (incl. bundle test;
+      skipped = keyring-gated e2e-auth), hub-client `npm run build` +
+      `test:ci` 97/97. `cargo xtask verify --skip-hub-build
+      --skip-hub-tests`: see Phase 3 note (run alongside).
 
 ### Phase 3 — verification + close-out
 

--- a/claude-notes/plans/2026-06-12-mcp-exit-sync-drain.md
+++ b/claude-notes/plans/2026-06-12-mcp-exit-sync-drain.md
@@ -6,8 +6,162 @@ incident), bd-vm5e5u10 (the amplifier, being fixed IN PARALLEL — see
 boundary contract below), bd-xnmd5ni1 (closed — requireOnline, which
 ensured the *connection* but not *delivery*), parent plan
 `claude-notes/plans/2026-06-12-sync-client-offline-race.md`.
-**Status:** READY TO IMPLEMENT — self-contained handoff; designed for
+**Status:** IN PROGRESS (2026-06-12, worktree
+`.worktrees/bd-10deu8h4-hub-mcp-server-exit`, branch
+`beads/bd-10deu8h4-hub-mcp-server-exit` off `4bd6d4bf`). Designed for
 parallel implementation alongside bd-vm5e5u10.
+
+## Work items
+
+### Phase 1 — red tests + delivery-signal investigation
+
+- [x] Delivery-signal investigation; verdict recorded below
+      (§ Phase 1 verdict).
+- [x] Additive API surface so the red tests compile:
+      `DisconnectOptions`/`DisconnectReport` in sync-client `types.ts`,
+      `disconnect(options?)` signature stub (NO drain behavior yet),
+      `MemoryStorageAdapter` exported from sync-client index.
+- [x] Test hubs announce a `storageId` like the real samod hub does:
+      give both `test-hub.ts` copies a `MemoryStorageAdapter`; add
+      `hubHasDoc` to the hub-mcp copy. (Also: their `stop()` now
+      tolerates `repo.shutdown()`'s flush throwing "DocHandle is not
+      ready" — the half-delivered state these tests leave behind.)
+- [x] Red test 1 (sync-client `exit-drain.test.ts`):
+      create-then-disconnect(drainMs) loses nothing; observed RED.
+- [x] Red test 2 (hub-mcp `exit-drain.test.ts`, stdio level): the
+      exact accident — `create_project` → stdin EOF → server exits AND
+      hub holds the file doc; observed RED.
+- [x] Red-output snippets recorded in this plan (§ Phase 1 red
+      evidence).
+
+### Phase 1 red evidence (2026-06-12, before any fix)
+
+Note on red-shape tuning (predicted by this plan): with 4×64 KB files
+the stdio test was GREEN by luck — on loopback, the `create_project`
+response round-trip gives the event loop time to flush outbound sync.
+At 64×64 KB (more docs = per-doc synchronizer backlog, more bytes =
+encode/send time) it is deterministically red. The sync-client-level
+test is red even at 8×64 KB because `disconnect()` follows
+`createNewProject()` with no intervening round-trip.
+
+`quarto-sync-client`, `npx vitest run src/exit-drain.test.ts`:
+
+```
+FAIL src/exit-drain.test.ts > … > create-then-disconnect loses nothing
+AssertionError: index doc must reach the hub: expected false to be true
+
+FAIL src/exit-drain.test.ts > … > reports undelivered docs when the hub
+is unreachable at disconnect
+AssertionError: drain cannot succeed against a dead hub: expected true
+to be false
+```
+
+`quarto-hub-mcp`, `npx vitest run src/exit-drain.test.ts` (server exits
+within the 5 s hygiene bound — that assertion passes — but file docs
+died with the process; the index escaped, exactly the incident):
+
+```
+FAIL src/exit-drain.test.ts > … > create_project then immediate stdin
+EOF must not lose the created docs
+AssertionError: file doc for q2-mcp-hello-30.qmd must reach the hub —
+its only copy was in-process: expected false to be true
+```
+
+### Phase 2 — implement
+
+- [ ] sync-client: drain primitive (`drainOutbound`) wired into
+      `disconnect({drainMs})`; default 0 (browser teardown unchanged).
+- [ ] sync-client: peer storageId tracking in `trackPeers`.
+- [ ] hub-mcp: `disconnectAll({drainMs})` + loud stderr on undrained
+      projects (names indexDocId + paths).
+- [ ] hub-mcp: `index.ts` shutdown passes the drain budget; keeps
+      re-entrancy guard; stdin-EOF exit stays within hygiene bound.
+- [ ] Both red tests green; loud-failure path test (hub down at exit →
+      stderr names undelivered paths).
+- [ ] Suites green: sync-client, hub-mcp (incl. bundle test),
+      hub-client `npm run build && npm run test:ci`,
+      `cargo xtask verify --skip-hub-build --skip-hub-tests`.
+
+### Phase 3 — verification + close-out
+
+- [ ] Manual e2e per CLAUDE.md (rebuild bundle + q2, original accident
+      against a LOCAL Rust hub, verify doc in hub storage; record
+      invocation + output here). This is also the real-samod
+      verification of the delivery signal.
+- [ ] Loud-failure path demonstrated once end-to-end.
+- [ ] braid: close bd-10deu8h4 with commit hash; note in parent plan;
+      merge `--no-ff` into the integration line (coordinate with
+      bd-vm5e5u10's agent — second merger resolves).
+
+## Phase 1 verdict: delivery signal (RECORDED 2026-06-12)
+
+**Chosen signal: per-document remote-heads sync info** —
+`DocHandle.getSyncInfo(hubStorageId).lastHeads` equal to the handle's
+current `heads()`, where `hubStorageId` comes from the hub's handshake
+peer metadata. Drain = wait (bounded, event-driven via the handle's
+`remote-heads` event) until every tracked doc (index + all file docs)
+satisfies the equality against at least one storage-backed peer.
+
+Why this is correct, from the sources (automerge-repo 2.5.6 installed;
+samod q2 fork checkout `0b50c16`):
+
+1. **No gossiping flag needed.** `Repo`'s constructor subscribes to the
+   synchronizer's `sync-state` event and calls
+   `handle.setSyncInfo(storageId, {lastHeads: theirHeads, ...})`
+   unconditionally (`dist/Repo.js` ~154-175). The
+   `enableRemoteHeadsGossiping` flag only gates *relay* of third-party
+   heads (`remote-heads-changed` control messages), not this direct
+   path. `theirHeads` comes from the automerge sync protocol: every
+   sync message carries the sender's heads, so after the hub applies
+   our changes its reply advertises heads that converge with ours.
+2. **The signal is keyed by the peer's storageId from handshake
+   metadata** (`peerMetadataByPeerId`); peers without a storageId never
+   populate it. **samod always announces one**:
+   `samod-core/src/actors/hub/state.rs::get_local_metadata()` returns
+   `PeerMetadata { is_ephemeral: false, storage_id: Some(..) }`, and the
+   wire protocol encodes it (`wire_protocol.rs`, `storageId` CBOR key).
+   Source-verified on the q2 fork; *behavioral* verification against
+   the real hub binary happens in the Phase 3 manual e2e (acceptance
+   criterion) — do not close the strand before it.
+3. **Awaitable**: `DocHandle.setSyncInfo` emits a `remote-heads` event
+   (`dist/DocHandle.js`), so the drain early-exits the moment delivery
+   is confirmed — no polling, no fixed sleep.
+4. **Equality, not subset**: `UrlHeads` equality (order-insensitive) is
+   the convergence steady state. If the hub holds *extra* changes, the
+   live sync we're draining over delivers them to us within the same
+   window, after which equality holds. Comparison re-reads
+   `handle.heads()` on every event for exactly this reason.
+
+**Degradation when the hub is unreachable**: no peer → no sync-state
+events → drain waits out the bounded budget (the WS adapter's retry
+loop may still reconnect mid-window and deliver — waiting is a feature),
+then reports the undelivered docs; the MCP shutdown path prints a loud
+stderr line naming the project and paths. Exit is never blocked past
+the budget.
+
+**Rejected alternatives**: sync-message settle heuristic (needs adapter
+introspection, and "no outbound traffic for N ms" is consistent with
+both "delivered" and "stalled"); verification re-find via a second
+connection (correct but heavyweight, and it would double connection
+churn at exit — keep as fallback if samod's heads behavior surprises us
+in Phase 3).
+
+**Test-hub consequence**: both JS test hubs construct `Repo` *without*
+storage, so they announce no storageId (`storageId: await
+storageSubsystem?.id()` → `undefined`) and the drain signal can never
+fire against them — unlike the production samod hub. Phase 1 therefore
+gives both test hubs a `MemoryStorageAdapter` (sync-client already
+defines one) so their handshake metadata matches samod's shape.
+
+**API decision (Phase 2 design)**: `disconnect(options?: { drainMs?:
+number })` returning a `DisconnectReport { drained, undelivered }`;
+default `drainMs: 0` — i.e. opt-in. Justification: hub-client's browser
+`disconnect()` runs on tab/component teardown where blocking is
+unacceptable AND harmless to skip (IndexedDB persists local changes;
+they deliver on the next connect). The MCP server is the caller with
+memory-only storage where exit = data loss, so it passes the budget
+(3000 ms, comfortably inside the 5 s stdio-hygiene exit bound, early
+exit on confirmation).
 
 ## Branch / coordination — READ FIRST
 

--- a/claude-notes/plans/2026-06-12-mcp-exit-sync-drain.md
+++ b/claude-notes/plans/2026-06-12-mcp-exit-sync-drain.md
@@ -105,10 +105,13 @@ its only copy was in-process: expected false to be true
       inspected. Real-samod delivery-signal verification also locked
       in as a gated regression test (sync-client exit-drain).
 - [x] Loud-failure path demonstrated once end-to-end (below).
-- [ ] braid: close bd-10deu8h4 with commit hash; note in parent plan;
-      merge `--no-ff` into the integration line (coordinate with
-      bd-vm5e5u10's agent — second merger resolves; their fix landed
-      on the line as 11931849, so WE resolve).
+- [x] braid: closed bd-10deu8h4 (fix 194b9cc3, merge c0e5e136); noted
+      in parent plan; merged `--no-ff` into the integration line as
+      second merger (one trivial doc-comment conflict in
+      hub-mcp/test-hub.ts — both strands independently added
+      repo + hubHasDoc; bodies were identical). Combined-state suites
+      green: sync-client 105/105, hub-mcp 185/2-skipped, hub-client
+      build + test:ci 97/97.
 
 ### Phase 3 manual-e2e record (2026-06-12)
 

--- a/claude-notes/plans/2026-06-12-mcp-exit-sync-drain.md
+++ b/claude-notes/plans/2026-06-12-mcp-exit-sync-drain.md
@@ -1,0 +1,184 @@
+# bd-10deu8h4: MCP server exit must not race outbound document sync
+
+**Strand:** bd-10deu8h4 (p1). Related: bd-8x482xb0 (closed — the
+production casualty this caused), bd-p68lx71t (the 2026-06-12
+incident), bd-vm5e5u10 (the amplifier, being fixed IN PARALLEL — see
+boundary contract below), bd-xnmd5ni1 (closed — requireOnline, which
+ensured the *connection* but not *delivery*), parent plan
+`claude-notes/plans/2026-06-12-sync-client-offline-race.md`.
+**Status:** READY TO IMPLEMENT — self-contained handoff; designed for
+parallel implementation alongside bd-vm5e5u10.
+
+## Branch / coordination — READ FIRST
+
+- Start from **`origin/feature/bd-81cfshmw-q2-mcp-launcher`** at
+  `0fc9f2db` (NOT main — the sync-client groundwork and test harness
+  live there, unmerged). Create your own topic branch off it; when
+  done, merge back into that integration line with `--no-ff`
+  (`.claude/rules/worktrees.md` § Integration-line convention).
+- **Parallel-work boundary contract with bd-vm5e5u10** (in flight on
+  the same integration line, plan:
+  `2026-06-12-graceful-dangling-entries.md`):
+  - THEY own: `client.ts` `loadFileDocuments` / `syncWithFiles` /
+    `indexChangeHandler`, and `quarto-hub-mcp/src/tools.ts`
+    (all tool handlers). **Do not edit those.**
+  - YOU own: `client.ts` `disconnect()` (+ any new drain/delivery
+    primitive you add near it), `quarto-hub-mcp/src/index.ts`
+    (shutdown path), `quarto-hub-mcp/src/connection-manager.ts`
+    (`disconnectAll`).
+  - Shared, additive-only (merge-friendly): `types.ts` interfaces,
+    `index.ts` exports of sync-client, new test files.
+  - Whoever merges second resolves; with this split, conflicts should
+    be trivial or absent.
+
+## What happened (incident context, condensed)
+
+On 2026-06-12 a `q2 mcp` session created
+`/cscheid/q2-mcp-hello.qmd` on the production playground, read it
+back **from process memory**, and exited when the driver closed
+stdin. The stdin-EOF shutdown (bd-9jq2a060 — correct behavior, MCP
+hosts terminate servers this way) ran
+`manager.disconnectAll()` → `process.exit(0)` **before the new file
+document's sync to the hub completed**. The index entry escaped (an
+existing, already-synced document); the file document's only copy
+died with the process (MCP clients use **memory storage** — there is
+no local persistence to fall back on). Result: a dangling index entry
+that bricked the project for every client (the bd-vm5e5u10 defect),
+i.e. a production incident.
+
+`requireOnline` (bd-xnmd5ni1) does not prevent this: it guarantees a
+peer connection existed at *create* time, not that the created bytes
+were *delivered* before exit.
+
+## Required behavior
+
+1. **Shutdown drains before exiting.** When the server shuts down
+   (stdin EOF, SIGINT/SIGTERM, `server.onclose`), outbound document
+   sync gets a bounded window to complete. Created-but-undelivered
+   documents must reach the hub before `process.exit` whenever the
+   connection allows it.
+2. **Bounded, never hanging.** MCP hosts expect prompt termination
+   (and `stdio-hygiene.test.ts` asserts exit within 5 s of stdin
+   EOF — do not break bd-9jq2a060). Pick a drain budget that fits
+   (suggestion: up to ~3 s total, returning EARLY the moment
+   delivery is confirmed; adjust the hygiene test's bound only if
+   justified, with a comment).
+3. **Loud on failure, never silent.** If the budget expires with
+   undelivered documents (hub unreachable, mid-restart), write a
+   clear stderr line naming the project and paths/doc ids that may
+   not have been delivered — the user/agent must be able to know.
+   (stderr only — stdout is protocol; bd-sl4o01y0.)
+4. The drain lives in `client.disconnect()` (sync-client) and/or
+   `disconnectAll()` (connection-manager) + the shutdown path in
+   `index.ts` — see boundary contract. A new public sync-client
+   primitive (e.g. `whenDelivered(docIds?, {timeoutMs})` or
+   `disconnect({drainMs})`) is yours to design in Phase 1.
+5. **Out of scope** (boundary + follow-ups): per-write delivery
+   confirmation inside tool handlers (`create_file` returning only
+   after server receipt) — better UX but conflicts with
+   bd-vm5e5u10's tools.ts ownership; file a follow-up strand if
+   Phase 1 makes it cheap. Browser-side flush-on-create — parent
+   plan. The doctor tool — parent plan Phase 1.5.
+
+## Phase 1 — red tests + delivery-signal investigation
+
+Red tests first (the accident, miniaturized). Harness:
+`ts-packages/quarto-sync-client/src/test-hub.ts` (in-process hub with
+`hubHasDoc(docId)` = server-side ground truth).
+
+New `ts-packages/quarto-sync-client/src/exit-drain.test.ts`:
+1. **create-then-disconnect loses nothing**: `createNewProject`
+   (online, `requireOnline: true`, memory storage) → immediately
+   `await c.disconnect()` → `hub.hubHasDoc(fileDocId)` must be true.
+   Expect RED today (disconnect tears the adapter down immediately;
+   today's green paths only survived because extra round-trips
+   happened to give sync time).
+   If this is unexpectedly GREEN, tighten: create MANY/large files
+   (widen the in-flight window) or hold upgrades until just before
+   disconnect; the production accident is real — find the shape that
+   reproduces it deterministically before fixing.
+
+New stdio-level test in `ts-packages/quarto-hub-mcp/src/`
+(pattern: `stdio-hygiene.test.ts`; `McpTestClient` has
+`endStdinAndWaitForExit`):
+2. **the exact accident**: spawn the dist server against the
+   (hub-mcp copy of the) test hub → `create_project` with a file →
+   immediately end stdin → server exits (existing assertion) AND
+   `hub.hubHasDoc(<file doc id>)` is true (new assertion; the
+   create_project response JSON contains the doc ids). RED today.
+
+Investigation (the localize-then-fix discipline that served the
+parent work well — record the verdict in this plan before
+implementing): what is the **delivery signal**?
+Candidates, in rough order of preference:
+- automerge-repo sync-state / remote-heads: does the client repo
+  track that the hub peer has acknowledged our heads?
+  (`enableRemoteHeadsGossiping`, `DocHandle.remoteHeads…` — check
+  what the JS repo exposes and whether samod (the Rust hub)
+  participates in remote-heads gossip; if samod doesn't gossip,
+  this signal never fires — verify against the REAL hub binary,
+  not just the JS test hub, before trusting it).
+- Sync-message settle heuristic: drain = no outbound sync messages
+  for N ms while connected (needs adapter/network introspection —
+  may require a small seam in NodeWebSocketClientAdapter /
+  Stoppable adapter, which you own enough of for this purpose).
+- Verification re-find: a second, short-lived connection that
+  `find()`s the created doc ids (correct by construction — it is
+  exactly `hubHasDoc` client-side — but heavyweight; acceptable as
+  a fallback or for the few-docs-at-exit case).
+Record: chosen signal, why, and its behavior when the hub is
+unreachable (must degrade to the bounded timeout + loud stderr).
+
+## Phase 2 — implement
+
+- sync-client: the drain primitive (per Phase 1 verdict) + wire into
+  `disconnect()` (opt-in parameter or always-on with small budget —
+  justify the choice; hub-client's browser `disconnect()` also calls
+  this, so default behavior change must not freeze tab teardown:
+  consider `disconnect({drainMs})` with 0 default and MCP passing
+  the budget).
+- hub-mcp: `disconnectAll()` passes the budget; the `shutdown()`
+  path in `index.ts` keeps its re-entrancy guard and overall bound.
+- Tests from Phase 1 go green; `stdio-hygiene.test.ts` stays green
+  (adjust its 5 s bound only with justification).
+- Suites: sync-client, hub-mcp (incl. bundle test — it rebuilds the
+  bundle, which embeds your sync-client changes), hub-client
+  `npm run build && npm run test:ci` (sync-client is a dependency),
+  `cargo xtask verify --skip-hub-build --skip-hub-tests`.
+
+## Gotchas, from the people who got got
+
+- **stdout purity**: `syncLog`, never `console.log`, in sync-client
+  (invariant test will fail you); server diagnostics to stderr.
+- **Don't break stdin-EOF semantics** (bd-9jq2a060): the server must
+  still exit promptly; drain is bounded-early-exit, not a wait.
+- **The bundle embeds sync-client from SOURCE** (esbuild `source`
+  condition): `bundle.test.ts` exercises your changes — and
+  `e2e-auth.test.ts` (gated on binaries + keyring) runs the real
+  q2 launcher; if its channel-B gate skips on commit mismatch,
+  that's expected (it compares the q2 embed's gitCommit to HEAD).
+- **`TimeoutNegativeWarning` (bd-rgt8rglx)** may appear in stderr
+  during auth-bearing runs — known, unrelated, don't chase it here.
+- **No piping test runs through tail/grep** when you depend on the
+  exit code (a swallowed vitest failure produced a false green in
+  the parent session).
+- macOS-only validation acceptable (Carlos, 2026-06-11).
+
+## Acceptance criteria
+
+- [ ] Phase 1 red tests exist and were observed RED before the fix
+      (note the failing output in this plan or the strand).
+- [ ] Delivery-signal verdict recorded (incl. real-Rust-hub
+      verification of the chosen signal, not just the JS test hub).
+- [ ] Both tests green; all suites listed in Phase 2 green.
+- [ ] Manual e2e per CLAUDE.md: rebuild bundle + q2 (`cargo xtask
+      build-hub-mcp-bundle && cargo build --bin q2`), run the
+      original accident against a LOCAL hub via `q2 mcp` (create,
+      immediately end stdin), verify the doc in the local hub's
+      storage; record invocation + output here.
+- [ ] Loud-failure path demonstrated once (hub down at exit →
+      stderr names the undelivered paths).
+- [ ] braid: close bd-10deu8h4 with commit hash; note in the parent
+      plan; merge `--no-ff` into the integration line per the
+      boundary contract (coordinate with bd-vm5e5u10's agent on
+      merge order — second merger resolves).

--- a/claude-notes/plans/2026-06-12-mcp-exit-sync-drain.md
+++ b/claude-notes/plans/2026-06-12-mcp-exit-sync-drain.md
@@ -96,14 +96,66 @@ its only copy was in-process: expected false to be true
 
 ### Phase 3 — verification + close-out
 
-- [ ] Manual e2e per CLAUDE.md (rebuild bundle + q2, original accident
-      against a LOCAL Rust hub, verify doc in hub storage; record
-      invocation + output here). This is also the real-samod
-      verification of the delivery signal.
-- [ ] Loud-failure path demonstrated once end-to-end.
+- [x] `cargo xtask verify --skip-hub-build --skip-hub-tests`: all
+      steps passed (2026-06-12).
+- [x] Manual e2e (2026-06-12, recorded below): rebuilt bundle + q2
+      (`cargo xtask build-hub-mcp-bundle && cargo build --bin q2`;
+      `--launcher-info` confirmed embedded gitCommit 194b9cc3),
+      replayed the original accident against a LOCAL Rust hub, output
+      inspected. Real-samod delivery-signal verification also locked
+      in as a gated regression test (sync-client exit-drain).
+- [x] Loud-failure path demonstrated once end-to-end (below).
 - [ ] braid: close bd-10deu8h4 with commit hash; note in parent plan;
       merge `--no-ff` into the integration line (coordinate with
-      bd-vm5e5u10's agent — second merger resolves).
+      bd-vm5e5u10's agent — second merger resolves; their fix landed
+      on the line as 11931849, so WE resolve).
+
+### Phase 3 manual-e2e record (2026-06-12)
+
+Happy path — the exact production shape (one small file), through the
+real binary a user runs, against `target/debug/hub` on 127.0.0.1:3041
+with a fresh data dir:
+
+```
+$ node tmp-e2e/accident-replay.mjs ./target/debug/q2 tmp-e2e/hub-data \
+    ws://127.0.0.1:3041/ws
+created project 4XoG8ZeWkMCF6uJuu8RcojcY7u5N with 1 file(s)
+server exited: true (8 ms after stdin EOF)
+hub storage has 4XoG8ZeWkMCF6uJuu8RcojcY7u5N: true
+hub storage has 3U9wPp6BomDhXUfkW66fvxiT8LgC: true
+```
+
+8 ms exit = the drain's first check found delivery already confirmed
+(remote-heads from samod) and returned without waiting — the budget
+binds only when something is actually undelivered. Both the index and
+the file doc verified present in samod's on-disk storage (the artifact
+the incident lost).
+
+Loud-failure path — hub SIGKILLed mid-session, `create_file` during
+the outage, then stdin EOF:
+
+```
+created project 1Yxc2e2zULCy6631LkhcVXVu2kR with 1 file(s)
+killed hub pid 31167; creating a file during the outage…
+server exited: true (3011 ms after stdin EOF)
+--- server stderr ---
+[disconnect] drain budget (3000 ms) expired with 2 possibly-undelivered
+document(s): <index 1Yxc2e2zULCy6631LkhcVXVu2kR>, doomed.qmd
+[hub-mcp] WARNING: exiting before outbound sync completed for project
+1Yxc2e2zULCy6631LkhcVXVu2kR. Possibly NOT delivered to the hub (and
+lost — this server keeps no local copy): <index document
+1Yxc2e2zULCy6631LkhcVXVu2kR>, doomed.qmd. Verify these documents on
+the hub before trusting them.
+```
+
+Bounded (3011 ms ≈ the 3000 ms budget; never hangs), loud (names the
+project, the index — whose heads moved when the outage-created file
+was indexed — and the path), and exit still well inside the 5 s
+stdin-EOF promptness contract. The replay driver was a throwaway
+script (`tmp-e2e/accident-replay.mjs`, deleted after use); the same
+shapes are permanently covered by `quarto-hub-mcp/src/exit-drain.test.ts`
+(JS hub, stdio level) and the samod-gated test in
+`quarto-sync-client/src/exit-drain.test.ts`.
 
 ## Phase 1 verdict: delivery signal (RECORDED 2026-06-12)
 

--- a/claude-notes/plans/2026-06-12-sync-client-offline-race.md
+++ b/claude-notes/plans/2026-06-12-sync-client-offline-race.md
@@ -248,7 +248,36 @@ for one integration pass if Phase 1 localizes to the hub side.
 - [ ] Close out bd-p68lx71t with the final root-cause narrative;
       unblock the audience re-rollout (bd-exs follow-up)
 
+## Resolved questions (Carlos, 2026-06-12)
+
+1. **Hub accept policy**: accept-any from authenticated clients,
+   matching the existing trust model (allowlisted user = trusted
+   collaborator). A real authorization layer is acknowledged future
+   work — it requires coordinating with external authorization
+   systems where quarto-hub deployments embed in other auth setups —
+   and is explicitly out of scope here.
+2. **Part 3 budget**: "5 s if /health says reachable" approved for
+   hub-client v1.
+3. **hello-claude.qmd**: throwaway content, BUT the inconsistent
+   storage state is deliberately **preserved as a live diagnostic
+   fixture** while this work is in flight (playground project =
+   internal-use, not production-critical). Do not clean it up until
+   the D1 fix + doctor are done with it.
+
+**Phase 1 design refinement** (from resolution discussion): the
+localization red test runs against BOTH hubs — the in-process JS
+automerge-repo harness AND the real Rust `hub` binary. If the JS run
+reproduces the loss, the gap is client-side ((a)); if JS passes but
+Rust fails, it's samod's accept path ((b)). The Rust-hub variant
+simulates the offline window by starting the hub AFTER the client
+created documents (adapter retry-loop reconnect = exactly the
+production restart scenario).
+
 ## Open questions for Carlos
+
+(none currently)
+
+<details><summary>Resolved 2026-06-12 (see above)</summary>
 
 1. **Hub-side accept policy** (if Phase 1 lands on (b)): should the
    hub accept any announced document from an authenticated client
@@ -263,3 +292,5 @@ for one integration pass if Phase 1 localizes to the hub side.
 3. **hello-claude.qmd**: recover (needs the creating profile + the
    Part 1 fix) or recreate-and-clean? If the content was throwaway,
    recreate is zero-effort once the scan tool exists.
+
+</details>

--- a/claude-notes/plans/2026-06-12-sync-client-offline-race.md
+++ b/claude-notes/plans/2026-06-12-sync-client-offline-race.md
@@ -115,13 +115,39 @@ first. All in q2; no hub deployment required until rollout.
      and persisted (with the existing audit/access policy applied) —
      plus the same client-side test rides along as the regression
      guard.
-3. **Recovery tooling for existing casualties**: a small
-   `hub`-side maintenance command (or script) that scans index
-   documents for entries whose document is absent from storage and
-   reports them (the playground has at least `hello-claude.qmd`).
-   Cleanup = remove entry or restore from a client that still holds
-   the bytes; restoring becomes possible automatically once the fix
-   ships and the creator reopens the project.
+3. **Storage health check first, recovery later** (Carlos,
+   2026-06-12: no mutations to automerge documents until a
+   report-only instrument exists). A `hub doctor` subcommand
+   (working name) that is **read-only by construction** in its first
+   incarnation — there is no write path to gate behind a flag because
+   none is implemented:
+   - Scans a storage directory and reports, human-readable and
+     `--json`:
+     a. *dangling index entries* — index `files` entries whose
+        document is absent from storage (the hello-claude class);
+     b. *unloadable documents* — present but failing to load as
+        automerge (corruption);
+     c. *orphan documents* — in storage, referenced by no index
+        (informational);
+     d. summary counts + nonzero exit when (a)/(b) found, so it can
+        run under cron as a standing health check.
+   - Index documents are identified by attempt-parsing every doc
+     against the `IndexDocument` schema (the hub does not keep a
+     project registry; all docs are stored uniformly).
+   - Runs **offline against a copy** of the data dir (the live store
+     is lock-guarded; `/mnt/hub-data` is ~20 MB, and DLM snapshots
+     exist) — zero interaction with the running server. A live admin
+     endpoint is a possible later convenience, not v1.
+   - Immediate use once built: run against quarto-hub.com's storage
+     to size the damage — are there dangling entries beyond
+     `hello-claude.qmd`, and since when? That number is incident
+     data for bd-p68lx71t.
+   - **Mutation (cleanup/repair) is a separate, later work item**
+     with its own go-ahead: remove-dangling-entry and
+     restore-from-client flows, designed only after the report has
+     told us what production actually looks like. Restoration of
+     held-in-browser bytes becomes possible automatically once the
+     D1 fix ships and the creator reopens the project.
 
 ### Part 2 — self-heal failed opens on the online transition (D2)
 
@@ -190,11 +216,20 @@ for one integration pass if Phase 1 localizes to the hub side.
 - [ ] Wire-level localization: client never announces vs hub ignores
       announce (record verdict here — it gates the Part 1 design)
 
-### Phase 2 — fix D1 + recovery
+### Phase 1.5 — `hub doctor` (report-only storage health check)
+- [ ] Tests: fixture storage dirs (healthy / dangling entry /
+      corrupt doc / orphan) → exact report + exit codes; `--json`
+      schema locked by test
+- [ ] `hub doctor <data-dir>` subcommand, read-only by construction
+- [ ] Run against a copy of quarto-hub.com's storage; record findings
+      here and on bd-p68lx71t (damage sizing)
+
+### Phase 2 — fix D1
 - [ ] Fix per Phase 1 verdict (client re-announce or hub accept-policy)
 - [ ] Second-client open test goes green
-- [ ] Dangling-entry scan tool + playground cleanup/recovery of
-      `hello-claude.qmd`
+- [ ] (gated on its own go-ahead, after doctor findings) repair mode
+      design: remove-dangling-entry / restore-from-client; playground
+      cleanup or recovery of `hello-claude.qmd`
 
 ### Phase 3 — D2 self-healing opens
 - [ ] Red test + fix: failed loads retried on online transition,

--- a/claude-notes/plans/2026-06-12-sync-client-offline-race.md
+++ b/claude-notes/plans/2026-06-12-sync-client-offline-race.md
@@ -289,6 +289,18 @@ Part 1 therefore splits per host:
   await server receipt in create/write handlers (needs a delivery
   signal — remote-heads gossip or an explicit settle; design in that
   strand);
+  - **DONE 2026-06-12** (`2246e865` + `194b9cc3` on
+    `beads/bd-10deu8h4-hub-mcp-server-exit`): shutdown drains via
+    `disconnect({drainMs: 3000})`; delivery signal is per-doc
+    remote-heads sync info keyed by the hub's handshake storageId
+    (no gossiping flag needed; verified against real samod, both as
+    a gated regression test and via manual `q2 mcp` e2e). Bounded,
+    early-return, loud stderr on failure. Details + e2e record:
+    `claude-notes/plans/2026-06-12-mcp-exit-sync-drain.md`. The
+    per-write-receipt variant (tool handlers returning only after
+    server confirmation) was deliberately left out per the
+    bd-vm5e5u10 boundary contract — drain-on-shutdown covers the
+    incident; file a follow-up strand if per-write UX is wanted.
 - **Browser host**: flush-on-create + unload flush as below
   (defense-in-depth, playwright-verified).
 Fix order remains: bd-vm5e5u10 (amplifier) → bd-10deu8h4 (creator)

--- a/claude-notes/plans/2026-06-12-sync-client-offline-race.md
+++ b/claude-notes/plans/2026-06-12-sync-client-offline-race.md
@@ -292,7 +292,19 @@ Part 1 therefore splits per host:
 - **Browser host**: flush-on-create + unload flush as below
   (defense-in-depth, playwright-verified).
 Fix order remains: bd-vm5e5u10 (amplifier) → bd-10deu8h4 (creator)
-→ doctor → D2/D3. Also filed along the way: bd-3g0aijb3 (/auth/actor
+→ doctor → D2/D3.
+
+> **Amplifier FIXED (2026-06-12, bd-vm5e5u10 closed):** one dangling
+> entry no longer bricks a project. Sync-client tolerates unavailable
+> file docs (connect + index-change paths; the fire-and-forget
+> `syncWithFiles` unhandled rejection is handled now), surfaces them
+> via `status: 'unavailable'` / `onFileUnavailable` /
+> `getUnavailableFiles()`; index-unavailable stays fatal with a
+> message that says "index". MCP lists ghosts, gives per-file errors,
+> and `delete_file` on a ghost is the self-service repair (verified
+> e2e against a real hub). Details + transcript:
+> `claude-notes/plans/2026-06-12-graceful-dangling-entries.md`.
+> Retry-on-peer-arrival for unavailable files remains D2 scope. Also filed along the way: bd-3g0aijb3 (/auth/actor
 + /auth/me reject Bearer → MCP attribution silently degraded).
 
 **Part 1 fix design, amended by the verdict** (supersedes the

--- a/claude-notes/plans/2026-06-12-sync-client-offline-race.md
+++ b/claude-notes/plans/2026-06-12-sync-client-offline-race.md
@@ -1,0 +1,230 @@
+# Browser sync offline-fallback race family
+
+**Strand:** bd-10bdjmjb (related: bd-8x482xb0 dangling index entry,
+bd-vm5e5u10 MCP hard-fail on dangling entries; discovered-from
+bd-p68lx71t, the 2026-06-12 incident)
+**Status:** DESIGN — for Carlos's review; no implementation until
+go-ahead.
+
+## Overview
+
+During the 2026-06-12 quarto-hub.com incident, colleagues saw
+"failures to open automerge documents." The deployed changes were
+reverted, but the failures reproduced on the rolled-back build and in
+private windows, and Carlos's console trace pinned the real mechanism
+— which is long-standing, not shipped that day:
+
+```
+Waiting for peer connection...
+Peer connection failed, continuing in offline mode: Error: Timeout waiting for peer connection
+...
+Peer connected - switching to online mode        ← arrives moments later
+```
+
+The document path in hub-client is `App.tsx` →
+`@quarto/preview-runtime` `automergeSync.connect(…)` →
+`quarto-sync-client` `connect(…, peerTimeoutMs ?? 1)`
+(`ts-packages/preview-runtime/src/automergeSync.ts:159`,
+`ts-packages/quarto-sync-client/src/client.ts:495`). A **1 ms** peer
+wait always loses against real network latency, so every session
+starts in "offline mode" against IndexedDB and depends entirely on
+what happens after the late "switching to online mode" transition.
+
+This is the **browser twin of bd-xnmd5ni1** — the same library default
+whose silent offline fallback made the MCP server fabricate project
+creation (fixed 2026-06-12 with `requireOnline`). The browser can't
+use `requireOnline` (offline-first against IndexedDB is a *feature*
+there); it needs the fallback to actually be safe instead.
+
+## The three defects
+
+### D1 — documents created during the offline window never reach the hub
+
+Evidence: `/cscheid/hello-claude.qmd` on the playground. The index
+entry (a change to the already-synced index document) propagated to
+the hub; the newly created file document did not — verified absent
+from the hub's storage shard (`/mnt/hub-data/automerge/3H/`, no
+`JoqsM…`), and **still absent after the creating profile reconnected
+online and hard-refreshed**. So reconnection does not (re)announce
+locally created documents. Every fetch of that document by any other
+client fails forever ("Document … is unavailable"), and the only copy
+lives in the creator's IndexedDB. This is the data-loss-shaped defect
+and the priority.
+
+Open mechanism question the red test must answer: automerge-repo's
+collection synchronizer is *supposed* to add all repo documents to a
+newly connected peer, so the gap is one of:
+- (a) client-side: the SPA's repo/adapter lifecycle (fresh adapter or
+  repo per reconnect; bd-jit6pdwq's Stoppable adapter; the doc living
+  in a different `Repo` than the reconnecting one) drops
+  created-while-offline docs from what gets announced;
+- (b) hub-side: samod's share/accept policy ignores announcements of
+  documents it has never seen (vs. documents it has and can serve);
+- (c) something else the repro will surface.
+Phase 1 exists precisely to localize this before designing the fix —
+the fix differs materially between (a) and (b).
+
+### D2 — opens that failed during fallback never retry once online
+
+`connect()` runs `loadFileDocuments(files)` exactly once; the
+`onPeerConnect` handler (`client.ts:589-595`) only flips
+`currentlyOnline` and fires `onConnectionChange`. A cold-IndexedDB
+session (private window, first visit, new machine) therefore fails
+its opens 50–500 ms before the connection lands, and nothing reloads
+them — the user sees "Document unavailable" until a full reload. The
+existing `findDocRetry` machinery (cold-start "unavailable" retry,
+bd-jit6pdwq) softens some paths but demonstrably not this one.
+
+### D3 — the 1 ms default is a mis-applied optimization
+
+The 1 ms wait exists so warm-IndexedDB reloads render instantly
+(hub-client's offline-first design goal — legitimate and worth
+preserving). But as the *network* policy of a server-backed
+collaborative app it guarantees the fallback path runs on every single
+session, making D1/D2 everyone's steady state rather than a rare
+degraded mode. q2-preview already solved this shape for its SPA with
+health-arbitrated boot (bd-jit6pdwq Phase 2, e798a9df): HTTP `/health`
+decides "server reachable?" — websocket peer-wait then gets a generous
+budget, IndexedDB remains the fast path for rendering, but
+*server-truth operations* don't pretend to be offline.
+
+## Fix design
+
+Ordered so each part lands independently and D1 (data loss) goes
+first. All in q2; no hub deployment required until rollout.
+
+### Part 1 — make created documents survive (D1)
+
+1. **Red test first, to localize**: in-process automerge-repo "hub"
+   (the `test-hub.ts` harness from the MCP work) + a sync-client
+   session whose adapter connects *late* (deterministic: hold the
+   upgrade until after `createNewProject`/`createFile` completes in
+   fallback mode). Assert the hub's repo eventually holds the created
+   document. This fails today and tells us *where* the announcement
+   dies (client vs hub) by inspecting which protocol messages cross
+   the wire.
+2. **Fix accordingly**:
+   - If (a) client-side: track documents created while
+     `!currentlyOnline` in the sync-client; on the `peer` event,
+     explicitly (re)announce/flush them (automerge-repo exposes the
+     handles; worst case, a no-op `change` or explicit
+     `repo.networkSubsystem`-level announce). Covers both
+     `createNewProject` and per-file creation paths.
+   - If (b) hub-side: adjust the samod share/accept policy in
+     `crates/quarto-hub` so announced-unknown documents are accepted
+     and persisted (with the existing audit/access policy applied) —
+     plus the same client-side test rides along as the regression
+     guard.
+3. **Recovery tooling for existing casualties**: a small
+   `hub`-side maintenance command (or script) that scans index
+   documents for entries whose document is absent from storage and
+   reports them (the playground has at least `hello-claude.qmd`).
+   Cleanup = remove entry or restore from a client that still holds
+   the bytes; restoring becomes possible automatically once the fix
+   ships and the creator reopens the project.
+
+### Part 2 — self-heal failed opens on the online transition (D2)
+
+In `connect()`'s `onPeerConnect` (and the matching handler in the
+`createNewProject` path), when transitioning offline→online:
+re-run `loadFileDocuments` for documents that previously failed
+(track failures during the initial pass), firing the normal
+`onFileAdded`/`onFileChanged` callbacks so the UI recovers without a
+reload. Idempotent (already-loaded docs skipped), bounded (one retry
+sweep per transition). Red test: cold-storage connect against a
+late-connecting hub; assert the files surface after the peer event
+without calling `connect()` again.
+
+### Part 3 — honest connection policy for hub-client (D3)
+
+Replace the bare 1 ms default at hub-client's call site (via
+`preview-runtime`'s `automergeSync.connect`) with the
+health-arbitrated pattern q2-preview already uses: probe `/health`
+(HTTP, immune to websocket handshake stalls); if the server is
+reachable, wait for the peer with a realistic budget (seconds) before
+declaring offline — while still letting IndexedDB render content
+immediately (rendering fast-path and connection policy decoupled).
+If `/health` is unreachable, offline mode is *true* and the existing
+behavior is correct. The sync-client already accepts the options bag
+(`peerTimeoutMs`, bd-jit6pdwq), so this is mostly a `preview-runtime`
+/ hub-client change plus defaults documentation. The 1 ms library
+default itself stays (changing it silently would re-run bd-xnmd5ni1's
+lesson in reverse for other callers); each caller states its policy.
+
+### Explicitly out of scope here
+
+- bd-vm5e5u10 (MCP `connect_project` should degrade gracefully on a
+  dangling entry rather than brick the project) — separate small fix,
+  same test harness, can ride along in the same review if desired.
+- Re-rollout of the `--additional-audiences` deployment change
+  (blocked on this work only operationally — one commit + workflow +
+  deploy when we're ready; see deployment repo bd-erf hazards note:
+  S3 still holds the stale allowlist and `latest/` still points at
+  the 2026-06-12 build, so the workflow must re-run before any deploy).
+- The bd-jit6pdwq bisection (bd-p68lx71t): if colleagues confirm
+  recovery post-rollback, the reframed diagnosis (longstanding race,
+  restart-amplified) likely closes it as "not a new regression," with
+  this plan as the fix vehicle.
+
+## Test plan summary (TDD)
+
+| Test | Asserts | Fails today |
+| --- | --- | --- |
+| created-while-offline doc reaches hub after peer connect | D1 | yes |
+| index entry + doc arrive atomically enough that a second client can open the file | D1 | yes |
+| cold-storage opens self-heal on online transition without re-connect | D2 | yes |
+| warm-IndexedDB reload still renders without waiting for the peer | D3 regression guard | no (must stay green) |
+| health-reachable ⇒ no "offline mode" console path in hub-client boot | D3 | yes (behavioral) |
+
+Harness: the in-process automerge-repo hub from the MCP e2e work
+(`test-hub.ts`, gains a "hold upgrades until released" switch — the
+`acceptWs` knob generalized), plus the real `crates/quarto-hub` binary
+for one integration pass if Phase 1 localizes to the hub side.
+
+## Phases / work items
+
+### Phase 1 — localize D1 (red tests)
+- [ ] test-hub harness: deferred-upgrade switch (connect succeeds only
+      after the test releases it)
+- [ ] Red test: created-while-offline document must reach the hub
+- [ ] Wire-level localization: client never announces vs hub ignores
+      announce (record verdict here — it gates the Part 1 design)
+
+### Phase 2 — fix D1 + recovery
+- [ ] Fix per Phase 1 verdict (client re-announce or hub accept-policy)
+- [ ] Second-client open test goes green
+- [ ] Dangling-entry scan tool + playground cleanup/recovery of
+      `hello-claude.qmd`
+
+### Phase 3 — D2 self-healing opens
+- [ ] Red test + fix: failed loads retried on online transition,
+      callbacks fired, UI-visible recovery
+
+### Phase 4 — D3 hub-client connection policy
+- [ ] Health-arbitrated peer wait in preview-runtime/hub-client
+      (q2-preview Phase 2 pattern), IndexedDB render fast-path intact
+- [ ] hub-client `npm run build:all` + test:ci; manual browser check
+      per the e2e policy (cold profile: documents open without
+      "offline mode" flash)
+
+### Phase 5 — rollout
+- [ ] Full verify; deploy via quarto-hub-deployment (workflow re-run
+      FIRST — see bd-erf hazards); colleague confirmation
+- [ ] Close out bd-p68lx71t with the final root-cause narrative;
+      unblock the audience re-rollout (bd-exs follow-up)
+
+## Open questions for Carlos
+
+1. **Hub-side accept policy** (if Phase 1 lands on (b)): should the
+   hub accept any announced document from an authenticated client
+   (current trust model: allowlisted user = trusted collaborator), or
+   do we want index-membership validation while we're in there?
+   Recommendation: accept-any for now, matching the existing model;
+   validation is a separate hardening discussion.
+2. **Part 3 budget**: how long may a cold hub-client session wait for
+   the peer before declaring true offline? q2-preview uses
+   health-arbitrated indefinite-with-arbitration; a simpler "5 s if
+   health says reachable" may be enough for hub-client v1.
+3. **hello-claude.qmd**: recover (needs the creating profile + the
+   Part 1 fix) or recreate-and-clean? If the content was throwaway,
+   recreate is zero-effort once the scan tool exists.

--- a/claude-notes/plans/2026-06-12-sync-client-offline-race.md
+++ b/claude-notes/plans/2026-06-12-sync-client-offline-race.md
@@ -268,6 +268,33 @@ fail" — it was NOT the incident cause (the failing doc genuinely
 doesn't exist), but it deserves a test + fix in the D2 work: "no
 peers *yet*" (booting) and "no peers" (offline) are different states.
 
+**Second correction (2026-06-12, evening) — the actual casualty
+identified and resolved:** the dangling entry was
+`/cscheid/q2-mcp-hello.qmd` (created by the bd-81cfshmw live write
+test at 15:31Z), not hello-claude.qmd. Its cause is NOT the browser
+durability race below — it is the **MCP server exit racing outbound
+sync** (stdin-EOF shutdown ran before the new doc reached the hub;
+filed as bd-10deu8h4, the exit-flush race noted-and-deferred during
+bd-xnmd5ni1). The playground was surgically unbricked (entry removed
+with prior backup, Carlos-approved Path B; bd-8x482xb0 closed), the
+audiences flag re-enabled after exoneration, and hello-claude.qmd —
+never actually lost, just hidden behind the brick — edited normally.
+
+The browser durability hypothesis below is hereby DEMOTED to a
+latent concern with **no known casualty**: the 100 ms save debounce ×
+tab unload window is real and the flush-on-create fix remains
+worthwhile, but it is no longer load-bearing for any observed loss.
+Part 1 therefore splits per host:
+- **MCP host (bd-10deu8h4)**: drain outbound sync before exit and/or
+  await server receipt in create/write handlers (needs a delivery
+  signal — remote-heads gossip or an explicit settle; design in that
+  strand);
+- **Browser host**: flush-on-create + unload flush as below
+  (defense-in-depth, playwright-verified).
+Fix order remains: bd-vm5e5u10 (amplifier) → bd-10deu8h4 (creator)
+→ doctor → D2/D3. Also filed along the way: bd-3g0aijb3 (/auth/actor
++ /auth/me reject Bearer → MCP attribution silently degraded).
+
 **Part 1 fix design, amended by the verdict** (supersedes the
 re-announce sketch): make creation durable, not re-announced —
 - sync-client `createFile`/`createNewProject` await

--- a/claude-notes/plans/2026-06-12-sync-client-offline-race.md
+++ b/claude-notes/plans/2026-06-12-sync-client-offline-race.md
@@ -209,12 +209,46 @@ for one integration pass if Phase 1 localizes to the hub side.
 
 ## Phases / work items
 
-### Phase 1 — localize D1 (red tests)
-- [ ] test-hub harness: deferred-upgrade switch (connect succeeds only
-      after the test releases it)
-- [ ] Red test: created-while-offline document must reach the hub
-- [ ] Wire-level localization: client never announces vs hub ignores
-      announce (record verdict here — it gates the Part 1 design)
+### Phase 1 — localize D1 (COMPLETE 2026-06-12; verdict below)
+- [x] test-hub harness with deferred-upgrade switch
+      (`quarto-sync-client/src/test-hub.ts`)
+- [x] Repro tests, three shapes, ALL GREEN in node:
+      fresh-create against held JS hub; fresh-create against
+      late-starting Rust hub; **restart-window** create (connect
+      online → SIGKILL hub → createFile in the gap → hub returns on
+      same port/data-dir → doc arrives). The announce machinery is
+      **exonerated on both sides** — kept as regression guards
+      (`offline-creation.test.ts`, `offline-creation-rust-hub.test.ts`,
+      `restart-window-creation.test.ts`).
+- [x] **VERDICT — hypothesis (c): a browser durability race, not an
+      announce gap.** hub-client creates files through the exact
+      sync-client path proven green above; the environmental delta is
+      tab lifecycle. automerge-repo persists documents via an
+      async-throttled save with a **100 ms debounce**
+      (`Repo.js: saveDebounceRate = 100`); a document created during
+      an offline window whose throttled IndexedDB write hasn't landed
+      when the tab unloads (hard refresh — exactly what users do
+      during an outage) loses its bytes entirely: the network can't
+      save it (offline) and the disk never had it. The index entry
+      survives (existing doc, separate flush/sync timing) — minting
+      precisely the hello-claude dangling entry. Consistent with every
+      observation, including the creator profile never self-healing
+      after reconnect (there is nothing left to announce).
+
+**Part 1 fix design, amended by the verdict** (supersedes the
+re-announce sketch): make creation durable, not re-announced —
+- sync-client `createFile`/`createNewProject` await
+  `repo.flush([docId, indexDocId])` (API exists:
+  `Repo.flush(documents?)`) before resolving, so "created" means
+  "persisted locally" — cheap in node/memory, the whole point in the
+  browser;
+- hub-client adds a `beforeunload`/`visibilitychange` flush so even
+  mid-debounce edits get a last write;
+- browser-level confirmation test (playwright, hub-client suite):
+  create offline + immediate reload → file must survive in IndexedDB
+  (red today, green after).
+The re-announce machinery needs no change (proven); the regression
+guards stay.
 
 ### Phase 1.5 — `hub doctor` (report-only storage health check)
 - [ ] Tests: fixture storage dirs (healthy / dangling entry /

--- a/claude-notes/plans/2026-06-12-sync-client-offline-race.md
+++ b/claude-notes/plans/2026-06-12-sync-client-offline-race.md
@@ -235,6 +235,39 @@ for one integration pass if Phase 1 localizes to the hub side.
       observation, including the creator profile never self-healing
       after reconnect (there is nothing left to announce).
 
+**Correction (Carlos, 2026-06-12, after Phase 1):** the browser
+console repro was NOT the project index failing — the error
+`Document automerge:3HJoqsM… is unavailable` is the *hello-claude
+file document* (the message format invites the confusion; the
+project index `SNHcgVzU…` loads fine). With that identification the
+incident chain completes:
+
+1. one file document lost at creation (D1; durability hypothesis
+   below stands as the best candidate);
+2. its index entry synced everywhere;
+3. **one dangling entry bricks the whole project for every client**:
+   `loadFileDocuments` (connect path) and `syncWithFiles`
+   (index-change path, hitting already-open sessions) await `findDoc`
+   per file with no error tolerance — the first unavailable doc
+   throws out of `connect()`. Same defect the MCP server showed
+   (bd-vm5e5u10), now promoted: it is the amplifier that turns one
+   lost file into "the project fails to load" for the whole team.
+
+**Priority re-order**: graceful degradation (bd-vm5e5u10, one fix in
+sync-client serving browser + MCP) is now the highest-leverage item —
+shipping it unbricks affected projects everywhere with no production
+mutation. Then D1 durability (prevents new mintings), doctor
+(blast-radius + standing health check), D2/D3 as planned.
+
+**Recorded latent-risk note (evidence-downgraded, kept honest):**
+while chasing a wrong hypothesis we found that `findDoc`'s retry loop
+bails immediately when `connectedPeers.size === 0` (added in
+e326eb5c, bd-jit6pdwq Phase 1). For cold-cache boots this converts
+"slow but successful" (retry until the peer arrives) into "instant
+fail" — it was NOT the incident cause (the failing doc genuinely
+doesn't exist), but it deserves a test + fix in the D2 work: "no
+peers *yet*" (booting) and "no peers" (offline) are different states.
+
 **Part 1 fix design, amended by the verdict** (supersedes the
 re-announce sketch): make creation durable, not re-announced —
 - sync-client `createFile`/`createNewProject` await

--- a/claude-notes/plans/CURRENT.md
+++ b/claude-notes/plans/CURRENT.md
@@ -1,1 +1,1 @@
-2026-06-11-firefox-ws-peer-timeout-fix.md
+2026-06-11-q2-mcp-hub-auth.md

--- a/crates/quarto-hub/src/auth.rs
+++ b/crates/quarto-hub/src/auth.rs
@@ -73,11 +73,24 @@ impl AuthConfig {
         image_domains: Vec<String>,
         allowed_emails: Option<Vec<String>>,
         allowed_domains: Option<Vec<String>>,
+        allow_insecure_issuer: bool,
     ) -> Result<Self, String> {
-        // Validate issuer is a well-formed HTTPS URL.
+        // Validate issuer is a well-formed HTTPS URL. Plain http is
+        // accepted only for loopback hosts AND under
+        // `--allow-insecure-auth` (mock IdPs in dev/test — mirrors the
+        // TS client's QUARTO_HUB_MCP_ISSUER gate); a plaintext remote
+        // IdP is never acceptable.
         let parsed = url::Url::parse(&issuer)
             .map_err(|e| format!("Malformed OIDC issuer URL '{issuer}': {e}"))?;
-        if parsed.scheme() != "https" {
+        let http_loopback = parsed.scheme() == "http"
+            && parsed.host_str().is_some_and(is_loopback_host);
+        if !(parsed.scheme() == "https" || (http_loopback && allow_insecure_issuer)) {
+            if parsed.scheme() == "http" && !http_loopback && allow_insecure_issuer {
+                return Err(format!(
+                    "OIDC issuer over plain http is allowed only for loopback hosts \
+                     (got '{issuer}'); use https for remote IdPs"
+                ));
+            }
             return Err(format!(
                 "OIDC issuer must use HTTPS, got '{}'",
                 parsed.scheme()
@@ -367,6 +380,14 @@ struct OidcDiscoveryDocument {
     jwks_uri: String,
 }
 
+/// True for hostnames that resolve to loopback per RFC 6761 — the only
+/// hosts for which a plaintext-http OIDC issuer or JWKS endpoint is
+/// ever acceptable (dev/test mock IdPs under `--allow-insecure-auth`).
+fn is_loopback_host(host: &str) -> bool {
+    let h = host.to_ascii_lowercase();
+    h == "localhost" || h == "127.0.0.1" || h == "::1" || h == "[::1]" || h.ends_with(".localhost")
+}
+
 /// Discover the JWKS URL from the issuer's `/.well-known/openid-configuration`.
 ///
 /// The `issuer` must be a validated HTTPS URL (guaranteed by [`AuthConfig::new()`]).
@@ -407,7 +428,10 @@ pub async fn discover_jwks_url(
 /// Validate an OIDC discovery document against the configured issuer.
 ///
 /// - The document's `issuer` field must match the configured issuer (prevents spoofing).
-/// - The `jwks_uri` must be a well-formed HTTPS URL.
+/// - The `jwks_uri` must be a well-formed HTTPS URL — except when the
+///   configured issuer is itself a (gated, see [`AuthConfig::new()`])
+///   http-loopback URL, in which case an http-loopback `jwks_uri` is
+///   allowed too.
 ///
 /// Returns the `jwks_uri` on success.
 fn validate_discovery_document(
@@ -425,6 +449,17 @@ fn validate_discovery_document(
 
     let jwks_url = url::Url::parse(&doc.jwks_uri)
         .map_err(|e| format!("Malformed JWKS URI '{}': {e}", doc.jwks_uri))?;
+    // The allowance derives from the issuer: it already passed the
+    // loopback + --allow-insecure-auth gate in AuthConfig::new(), so an
+    // http issuer here is evidence of an explicitly-insecure dev setup.
+    let issuer_is_http_loopback = url::Url::parse(configured_issuer)
+        .ok()
+        .is_some_and(|u| u.scheme() == "http" && u.host_str().is_some_and(is_loopback_host));
+    let jwks_is_http_loopback =
+        jwks_url.scheme() == "http" && jwks_url.host_str().is_some_and(is_loopback_host);
+    if issuer_is_http_loopback && jwks_is_http_loopback {
+        return Ok(doc.jwks_uri.clone());
+    }
     if jwks_url.scheme() != "https" {
         return Err(format!(
             "JWKS URI must use HTTPS, got '{}' from {}",
@@ -728,6 +763,7 @@ mod tests {
             vec!["lh3.googleusercontent.com".to_string()],
             emails.map(|v| v.into_iter().map(String::from).collect()),
             domains.map(|v| v.into_iter().map(String::from).collect()),
+            false,
         )
         .unwrap()
     }
@@ -1113,9 +1149,87 @@ mod tests {
             vec![],
             None,
             None,
+            false,
         );
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("OIDC issuer must use HTTPS"));
+    }
+
+    #[test]
+    fn auth_config_rejects_http_non_loopback_issuer_even_with_allowance() {
+        // --allow-insecure-auth never opens the door to a plaintext
+        // *remote* IdP: tokens and JWKS over the open network in http
+        // are not a dev convenience, they are a MITM.
+        let result = AuthConfig::new(
+            "client-id".to_string(),
+            Vec::new(),
+            "http://idp.example.com".to_string(),
+            vec![],
+            None,
+            None,
+            true,
+        );
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("loopback"));
+    }
+
+    #[test]
+    fn auth_config_rejects_http_loopback_issuer_without_allowance() {
+        let result = AuthConfig::new(
+            "client-id".to_string(),
+            Vec::new(),
+            "http://127.0.0.1:9001".to_string(),
+            vec![],
+            None,
+            None,
+            false,
+        );
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("OIDC issuer must use HTTPS"));
+    }
+
+    #[test]
+    fn auth_config_accepts_http_loopback_issuer_with_allowance() {
+        // Dev/test parity with the TS client's QUARTO_HUB_MCP_ISSUER
+        // gate: loopback http IdPs (mock issuers) are usable only
+        // under --allow-insecure-auth.
+        let config = AuthConfig::new(
+            "client-id".to_string(),
+            Vec::new(),
+            "http://127.0.0.1:9001".to_string(),
+            vec![],
+            None,
+            None,
+            true,
+        );
+        assert!(config.is_ok());
+    }
+
+    #[test]
+    fn discovery_doc_allows_http_loopback_jwks_only_for_http_loopback_issuer() {
+        // jwks_uri allowance derives from the (already gated) issuer:
+        // an http-loopback issuer may serve an http-loopback jwks_uri;
+        // an https issuer may not smuggle in an http jwks_uri.
+        let doc = OidcDiscoveryDocument {
+            issuer: "http://127.0.0.1:9001".to_string(),
+            jwks_uri: "http://127.0.0.1:9001/jwks".to_string(),
+        };
+        let ok = validate_discovery_document(&doc, "http://127.0.0.1:9001", "http://127.0.0.1:9001/.well-known/openid-configuration");
+        assert!(ok.is_ok(), "{ok:?}");
+
+        let doc_https_issuer = OidcDiscoveryDocument {
+            issuer: "https://idp.example.com".to_string(),
+            jwks_uri: "http://127.0.0.1:9001/jwks".to_string(),
+        };
+        let bad = validate_discovery_document(&doc_https_issuer, "https://idp.example.com", "https://idp.example.com/.well-known/openid-configuration");
+        assert!(bad.is_err());
+
+        let doc_remote_jwks = OidcDiscoveryDocument {
+            issuer: "http://127.0.0.1:9001".to_string(),
+            jwks_uri: "http://jwks.example.com/jwks".to_string(),
+        };
+        let bad2 = validate_discovery_document(&doc_remote_jwks, "http://127.0.0.1:9001", "http://127.0.0.1:9001/.well-known/openid-configuration");
+        assert!(bad2.is_err());
     }
 
     #[test]
@@ -1127,6 +1241,7 @@ mod tests {
             vec![],
             None,
             None,
+            false,
         );
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("Malformed"));
@@ -1141,6 +1256,7 @@ mod tests {
             vec![],
             None,
             None,
+            false,
         )
         .unwrap();
         assert_eq!(config.image_domains, vec!["lh3.googleusercontent.com"]);
@@ -1155,6 +1271,7 @@ mod tests {
             vec![],
             None,
             None,
+            false,
         )
         .unwrap();
         assert!(config.image_domains.is_empty());
@@ -1169,6 +1286,7 @@ mod tests {
             vec!["evil.com; script-src 'unsafe-inline'".to_string()],
             None,
             None,
+            false,
         );
         assert!(result.is_err());
     }
@@ -1182,6 +1300,7 @@ mod tests {
             vec![],
             None,
             None,
+            false,
         )
         .unwrap();
         assert_eq!(config.issuer_origin(), "https://login.microsoftonline.com");
@@ -1196,6 +1315,7 @@ mod tests {
             vec![],
             None,
             None,
+            false,
         )
         .unwrap();
         assert_eq!(config.issuer_origin(), "https://auth.example.com:8443");
@@ -1210,6 +1330,7 @@ mod tests {
             vec![],
             None,
             None,
+            false,
         )
         .unwrap();
         let audiences: Vec<&String> = config.audiences().collect();
@@ -1236,6 +1357,7 @@ mod tests {
             vec![],
             None,
             None,
+            false,
         )
         .unwrap();
         assert_eq!(config.provider, OidcProvider::Google);
@@ -1250,6 +1372,7 @@ mod tests {
             vec![],
             None,
             None,
+            false,
         )
         .unwrap();
         assert_eq!(config.provider, OidcProvider::Generic);
@@ -1501,6 +1624,7 @@ mod tests {
             Vec::new(),
             None,
             None,
+            false,
         )
         .unwrap()
     }

--- a/crates/quarto-hub/src/auth.rs
+++ b/crates/quarto-hub/src/auth.rs
@@ -82,8 +82,8 @@ impl AuthConfig {
         // IdP is never acceptable.
         let parsed = url::Url::parse(&issuer)
             .map_err(|e| format!("Malformed OIDC issuer URL '{issuer}': {e}"))?;
-        let http_loopback = parsed.scheme() == "http"
-            && parsed.host_str().is_some_and(is_loopback_host);
+        let http_loopback =
+            parsed.scheme() == "http" && parsed.host_str().is_some_and(is_loopback_host);
         if !(parsed.scheme() == "https" || (http_loopback && allow_insecure_issuer)) {
             if parsed.scheme() == "http" && !http_loopback && allow_insecure_issuer {
                 return Err(format!(
@@ -1214,21 +1214,33 @@ mod tests {
             issuer: "http://127.0.0.1:9001".to_string(),
             jwks_uri: "http://127.0.0.1:9001/jwks".to_string(),
         };
-        let ok = validate_discovery_document(&doc, "http://127.0.0.1:9001", "http://127.0.0.1:9001/.well-known/openid-configuration");
+        let ok = validate_discovery_document(
+            &doc,
+            "http://127.0.0.1:9001",
+            "http://127.0.0.1:9001/.well-known/openid-configuration",
+        );
         assert!(ok.is_ok(), "{ok:?}");
 
         let doc_https_issuer = OidcDiscoveryDocument {
             issuer: "https://idp.example.com".to_string(),
             jwks_uri: "http://127.0.0.1:9001/jwks".to_string(),
         };
-        let bad = validate_discovery_document(&doc_https_issuer, "https://idp.example.com", "https://idp.example.com/.well-known/openid-configuration");
+        let bad = validate_discovery_document(
+            &doc_https_issuer,
+            "https://idp.example.com",
+            "https://idp.example.com/.well-known/openid-configuration",
+        );
         assert!(bad.is_err());
 
         let doc_remote_jwks = OidcDiscoveryDocument {
             issuer: "http://127.0.0.1:9001".to_string(),
             jwks_uri: "http://jwks.example.com/jwks".to_string(),
         };
-        let bad2 = validate_discovery_document(&doc_remote_jwks, "http://127.0.0.1:9001", "http://127.0.0.1:9001/.well-known/openid-configuration");
+        let bad2 = validate_discovery_document(
+            &doc_remote_jwks,
+            "http://127.0.0.1:9001",
+            "http://127.0.0.1:9001/.well-known/openid-configuration",
+        );
         assert!(bad2.is_err());
     }
 

--- a/crates/quarto-hub/src/main.rs
+++ b/crates/quarto-hub/src/main.rs
@@ -197,6 +197,7 @@ async fn main() -> anyhow::Result<()> {
                 args.oidc_image_domains,
                 args.allowed_emails,
                 args.allowed_domains,
+                args.allow_insecure_auth,
             )
         })
         .transpose()

--- a/crates/quarto-hub/src/server.rs
+++ b/crates/quarto-hub/src/server.rs
@@ -1597,6 +1597,7 @@ mod tests {
             vec!["lh3.googleusercontent.com".to_string()],
             None,
             None,
+            false,
         )
         .unwrap()
     }
@@ -1618,6 +1619,7 @@ mod tests {
             vec!["graph.microsoft.com".to_string()],
             None,
             None,
+            false,
         )
         .unwrap();
         let csp = build_csp(&config);
@@ -1638,6 +1640,7 @@ mod tests {
             ],
             None,
             None,
+            false,
         )
         .unwrap();
         let csp = build_csp(&config);
@@ -1654,6 +1657,7 @@ mod tests {
             vec![],
             None,
             None,
+            false,
         )
         .unwrap();
         let csp = build_csp(&config);

--- a/crates/quarto-mcp-launcher/Cargo.toml
+++ b/crates/quarto-mcp-launcher/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "quarto-mcp-launcher"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Launcher for `q2 mcp`: embeds the bundled TypeScript hub MCP server, extracts it to a per-user cache, and delegates execution to an ambient Node.js."
+
+[dependencies]
+anyhow.workspace = true
+dirs = "6"
+fs2 = "0.4"
+include_dir.workspace = true
+serde = { version = "1.0", features = ["derive"] }
+serde_json.workspace = true
+sha2 = "0.11"
+thiserror.workspace = true
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
+[dev-dependencies]
+tempfile = "3"
+
+[lints]
+workspace = true

--- a/crates/quarto-mcp-launcher/build.rs
+++ b/crates/quarto-mcp-launcher/build.rs
@@ -1,0 +1,83 @@
+//! Build script that locates the hub MCP server bundle at compile time.
+//!
+//! Mirrors `crates/quarto-preview/build.rs`. The `include_dir!` macro
+//! needs a concrete compile-time path; this script resolves it:
+//!
+//! 1. If `ts-packages/quarto-hub-mcp/dist-bundle/index.mjs` exists,
+//!    embed that directory.
+//! 2. Otherwise embed a placeholder directory containing only a
+//!    `BUNDLE_NOT_BUILT` marker, so the build still succeeds (fresh
+//!    clones can `cargo build` before any npm step). `q2 mcp` then
+//!    fails at runtime with an actionable message pointing at
+//!    `cargo xtask build-hub-mcp-bundle`.
+//!
+//! The chosen path is exposed as `QUARTO_HUB_MCP_EMBED_DIR` via
+//! `cargo:rustc-env`, consumed by `src/bundle.rs`.
+//!
+//! Stale-embed warning (see CLAUDE.md and the 2026-05-20 preview-SPA
+//! incident): a plain `cargo build` re-embeds whatever dist-bundle/
+//! was last produced. The per-file rerun-if-changed entries below make
+//! the *Rust* side rebuild when the bundle changes, but nothing makes
+//! the bundle itself rebuild — run `cargo xtask build-hub-mcp-bundle`
+//! (or `build-all`) after touching the TypeScript sources.
+
+use std::path::{Path, PathBuf};
+
+fn main() {
+    let manifest_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
+    let workspace_root = manifest_dir.join("..").join("..");
+    let real_bundle = workspace_root
+        .join("ts-packages")
+        .join("quarto-hub-mcp")
+        .join("dist-bundle");
+
+    let embed_dir = if real_bundle.join("index.mjs").is_file() {
+        real_bundle.clone()
+    } else {
+        make_placeholder()
+    };
+
+    println!(
+        "cargo:rustc-env=QUARTO_HUB_MCP_EMBED_DIR={}",
+        embed_dir.display()
+    );
+
+    // Re-run if the real bundle changes. Per-file entries catch
+    // in-place content rewrites that a directory-mtime watch misses.
+    println!("cargo:rerun-if-changed={}", real_bundle.display());
+    if real_bundle.is_dir() {
+        watch_recursive(&real_bundle);
+    }
+}
+
+fn watch_recursive(root: &Path) {
+    let entries = match std::fs::read_dir(root) {
+        Ok(it) => it,
+        Err(_) => return,
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        println!("cargo:rerun-if-changed={}", path.display());
+        let is_dir = entry.file_type().map(|t| t.is_dir()).unwrap_or(false);
+        if is_dir {
+            watch_recursive(&path);
+        }
+    }
+}
+
+fn make_placeholder() -> PathBuf {
+    let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
+    let dir = out_dir.join("placeholder-bundle");
+    std::fs::create_dir_all(&dir).expect("create placeholder bundle dir");
+    let marker = dir.join("BUNDLE_NOT_BUILT");
+    let contents = "Run `cargo xtask build-hub-mcp-bundle`, then rebuild the q2 binary.\n";
+    let existing = std::fs::read_to_string(&marker).ok();
+    if existing.as_deref() != Some(contents) {
+        std::fs::write(&marker, contents).expect("write placeholder marker");
+    }
+    println!(
+        "cargo:warning=ts-packages/quarto-hub-mcp/dist-bundle/ not found; `q2 mcp` will be \
+         non-functional in this build. Run `cargo xtask build-hub-mcp-bundle` and rebuild."
+    );
+    dir
+}

--- a/crates/quarto-mcp-launcher/src/bundle.rs
+++ b/crates/quarto-mcp-launcher/src/bundle.rs
@@ -1,0 +1,115 @@
+//! The embedded hub MCP server bundle.
+//!
+//! `build.rs` points `QUARTO_HUB_MCP_EMBED_DIR` either at the real
+//! `ts-packages/quarto-hub-mcp/dist-bundle/` or at a placeholder
+//! containing only a `BUNDLE_NOT_BUILT` marker (fresh clone, no npm
+//! step yet).
+
+use include_dir::{Dir, include_dir};
+use sha2::{Digest, Sha256};
+use std::borrow::Cow;
+use std::path::PathBuf;
+
+static EMBEDDED_BUNDLE: Dir<'_> = include_dir!("$QUARTO_HUB_MCP_EMBED_DIR");
+
+/// One file of the bundle: workspace-relative path (forward slashes,
+/// as `include_dir` stores them) plus contents. The extraction and
+/// hashing code works on this representation so tests can fabricate
+/// bundles without compile-time embedding.
+pub type BundleFile = (PathBuf, Cow<'static, [u8]>);
+
+/// True when the build embedded the placeholder instead of a real
+/// bundle (`cargo build` before `cargo xtask build-hub-mcp-bundle`).
+pub fn is_placeholder() -> bool {
+    EMBEDDED_BUNDLE.get_file("BUNDLE_NOT_BUILT").is_some()
+}
+
+/// Flatten the embedded directory tree into (path, contents) pairs.
+pub fn embedded_files() -> Vec<BundleFile> {
+    let mut files = Vec::new();
+    collect(&EMBEDDED_BUNDLE, &mut files);
+    files
+}
+
+fn collect(dir: &Dir<'static>, out: &mut Vec<BundleFile>) {
+    for file in dir.files() {
+        out.push((file.path().to_path_buf(), Cow::Borrowed(file.contents())));
+    }
+    for sub in dir.dirs() {
+        collect(sub, out);
+    }
+}
+
+/// Content hash of a bundle: 16 hex chars of SHA-256 over the sorted
+/// (path, length, contents) sequence. Used as the cache directory name
+/// — same bundle bytes, same directory, across q2 builds.
+pub fn content_hash(files: &[BundleFile]) -> String {
+    let mut sorted: Vec<&BundleFile> = files.iter().collect();
+    sorted.sort_by(|a, b| a.0.cmp(&b.0));
+    let mut hasher = Sha256::new();
+    for (path, contents) in sorted {
+        // Hash the path with forward slashes so the same bundle hashes
+        // identically regardless of host separator conventions.
+        let path_str = path
+            .components()
+            .map(|c| c.as_os_str().to_string_lossy())
+            .collect::<Vec<_>>()
+            .join("/");
+        hasher.update(path_str.as_bytes());
+        hasher.update([0u8]);
+        hasher.update((contents.len() as u64).to_le_bytes());
+        hasher.update(contents);
+    }
+    let digest = hasher.finalize();
+    let mut hex = String::with_capacity(16);
+    for byte in &digest[..8] {
+        hex.push_str(&format!("{:02x}", byte));
+    }
+    hex
+}
+
+/// The embedded `build-info.json` stamp, raw (pretty JSON written by
+/// the bundler), or None for placeholder builds.
+pub fn build_info_json() -> Option<&'static str> {
+    EMBEDDED_BUNDLE
+        .get_file("build-info.json")
+        .and_then(|f| f.contents_utf8())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn file(path: &str, contents: &[u8]) -> BundleFile {
+        (PathBuf::from(path), Cow::Owned(contents.to_vec()))
+    }
+
+    #[test]
+    fn hash_is_order_independent() {
+        let a = vec![file("a.txt", b"one"), file("b/c.txt", b"two")];
+        let b = vec![file("b/c.txt", b"two"), file("a.txt", b"one")];
+        assert_eq!(content_hash(&a), content_hash(&b));
+    }
+
+    #[test]
+    fn hash_changes_with_content() {
+        let a = vec![file("a.txt", b"one")];
+        let b = vec![file("a.txt", b"two")];
+        assert_ne!(content_hash(&a), content_hash(&b));
+    }
+
+    #[test]
+    fn hash_distinguishes_path_vs_content_boundary() {
+        // ("ab", "c") must not collide with ("a", "bc")
+        let a = vec![file("ab", b"c")];
+        let b = vec![file("a", b"bc")];
+        assert_ne!(content_hash(&a), content_hash(&b));
+    }
+
+    #[test]
+    fn hash_is_16_hex_chars() {
+        let h = content_hash(&[file("x", b"y")]);
+        assert_eq!(h.len(), 16);
+        assert!(h.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+}

--- a/crates/quarto-mcp-launcher/src/cache.rs
+++ b/crates/quarto-mcp-launcher/src/cache.rs
@@ -1,0 +1,255 @@
+//! Per-user bundle cache: extraction, lifetime locks, and GC.
+//!
+//! Layout: `<cache_root>/<content-hash>/` holds one extracted bundle,
+//! plus two metadata files inside each bundle dir:
+//!
+//! - `.lock` — advisory-lock file. Every running `q2 mcp` instance
+//!   holds a SHARED lock on it for its lifetime (the lock fd survives
+//!   the exec into node on Unix; on Windows the launcher stays alive
+//!   and holds it). GC may delete a dir only after winning an
+//!   EXCLUSIVE try-lock, which proves no instance uses it. The kernel
+//!   releases locks on process death, so crashes can never wedge GC
+//!   (this is why locks, not refcount files).
+//! - `.last-used` — rewritten on every launch; its mtime is the
+//!   recency signal for GC. Age-gating (rather than keep-only-current)
+//!   prevents a dev build and an installed release from evicting each
+//!   other's bundles on every alternation.
+//!
+//! Extraction is crash-safe and race-safe: extract to a `.tmp-*`
+//! sibling, atomically rename into place, losers of the rename race
+//! discard their temp dir. Deletion is the mirror image: trash-rename
+//! the dir first (`.trash-*`), then delete, so a concurrent launcher
+//! never sees a half-deleted bundle at the canonical path — it either
+//! wins the path race or re-extracts.
+//!
+//! Design discussion: claude-notes/plans/2026-06-11-q2-mcp-hub-auth.md
+//! (risk 5). Quarto 1 users have complained about temp-dir pollution;
+//! GC is proactive, bounded, and best-effort (it must never break a
+//! launch).
+
+use anyhow::{Context, Result, bail};
+use fs2::FileExt;
+use std::fs::{self, File, OpenOptions};
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+use crate::bundle::BundleFile;
+
+pub const LOCK_FILE: &str = ".lock";
+pub const LAST_USED_FILE: &str = ".last-used";
+
+/// Bundles unused for this long are GC candidates.
+pub const DEFAULT_MAX_AGE: Duration = Duration::from_secs(14 * 24 * 60 * 60);
+
+/// `.tmp-*` / `.trash-*` leftovers older than this are presumed
+/// crashed mid-operation and get cleaned up.
+const LEFTOVER_MAX_AGE: Duration = Duration::from_secs(60 * 60);
+
+/// Uniquifier for `.tmp-*` extraction dirs within this process.
+static TMP_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// An extracted bundle with its lifetime shared lock held.
+pub struct ExtractedBundle {
+    pub dir: PathBuf,
+    /// Shared-locked for as long as this value lives. `delegate()`
+    /// arranges for the lock to survive into the node process.
+    pub lock: File,
+}
+
+/// The default per-user cache root (`<os cache dir>/quarto/hub-mcp`).
+pub fn default_cache_root() -> Result<PathBuf> {
+    let base = dirs::cache_dir().context(
+        "could not determine the user cache directory (HOME unset?); \
+         set QUARTO_MCP_CACHE_DIR to choose one explicitly",
+    )?;
+    Ok(base.join("quarto").join("hub-mcp"))
+}
+
+/// Extract `files` into `<cache_root>/<hash>/` (skipping extraction
+/// when that dir already exists) and take the lifetime shared lock.
+pub fn extract_and_lock(
+    cache_root: &Path,
+    files: &[BundleFile],
+    hash: &str,
+) -> Result<ExtractedBundle> {
+    fs::create_dir_all(cache_root)
+        .with_context(|| format!("creating cache dir {}", cache_root.display()))?;
+    restrict_permissions(cache_root);
+
+    let target = cache_root.join(hash);
+
+    // Bounded retry: each iteration either succeeds or has observed a
+    // transient race (GC trashed the dir between our existence check
+    // and our lock) that a fresh extraction resolves.
+    for _attempt in 0..4 {
+        if !target.is_dir() {
+            // The temp name must be unique per extraction attempt —
+            // pid alone is not enough (concurrent threads in one
+            // process share it; caught by the convergence test).
+            let unique = TMP_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            let tmp = cache_root.join(format!(".tmp-{}-{}", std::process::id(), unique));
+            extract_files(files, &tmp)?;
+            match fs::rename(&tmp, &target) {
+                Ok(()) => {}
+                Err(_) if target.is_dir() => {
+                    // Lost the race to a concurrent launcher — its copy
+                    // is identical (same content hash). Use it.
+                    let _ = fs::remove_dir_all(&tmp);
+                }
+                Err(e) => {
+                    let _ = fs::remove_dir_all(&tmp);
+                    return Err(e).with_context(|| {
+                        format!("moving extracted bundle into place at {}", target.display())
+                    });
+                }
+            }
+        }
+
+        // Take the lifetime shared lock, then re-verify the payload:
+        // GC may have trash-renamed the dir between our existence
+        // check and the open.
+        let lock_path = target.join(LOCK_FILE);
+        let Ok(lock) = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&lock_path)
+        else {
+            continue; // dir vanished — retry extraction
+        };
+        lock.lock_shared()
+            .with_context(|| format!("locking {}", lock_path.display()))?;
+
+        if target.join("index.mjs").is_file() {
+            touch_last_used(&target);
+            return Ok(ExtractedBundle { dir: target, lock });
+        }
+
+        // Payload missing under our shared lock: either GC raced us
+        // (dir is gone) or the dir is corrupt (partial state at the
+        // canonical path). Self-heal: if no other instance holds it,
+        // remove and re-extract.
+        drop(lock);
+        if target.is_dir() {
+            remove_bundle_dir(cache_root, &target);
+        }
+    }
+    bail!(
+        "could not extract the MCP bundle into {} after repeated attempts",
+        cache_root.display()
+    );
+}
+
+/// Best-effort GC: remove bundle dirs (other than `keep_hash`) whose
+/// `.last-used` is older than `max_age` and on which an exclusive
+/// try-lock succeeds, plus stale `.tmp-*`/`.trash-*` leftovers.
+/// Failures skip the entry — GC must never break a launch.
+pub fn gc(cache_root: &Path, keep_hash: &str, max_age: Duration) {
+    let Ok(entries) = fs::read_dir(cache_root) else {
+        return;
+    };
+    let now = SystemTime::now();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let Some(name) = path.file_name().and_then(|n| n.to_str()).map(String::from) else {
+            continue;
+        };
+        if name == keep_hash {
+            continue;
+        }
+
+        if name.starts_with(".tmp-") || name.starts_with(".trash-") {
+            // Crashed mid-extraction / mid-deletion. Age-gate so we
+            // never yank a temp dir out from under a live extraction.
+            if older_than(&dir_mtime(&path), now, LEFTOVER_MAX_AGE) {
+                let _ = fs::remove_dir_all(&path);
+            }
+            continue;
+        }
+
+        // Candidate bundle dir: recency via .last-used (dir mtime as
+        // fallback for dirs that predate the marker).
+        let recency = file_mtime(&path.join(LAST_USED_FILE)).unwrap_or_else(|| dir_mtime(&path));
+        if !older_than(&recency, now, max_age) {
+            continue;
+        }
+        remove_bundle_dir(cache_root, &path);
+    }
+}
+
+/// Delete a bundle dir if (and only if) an exclusive try-lock proves
+/// it unused: trash-rename first so concurrent launchers fail cleanly,
+/// then delete. Best-effort.
+fn remove_bundle_dir(cache_root: &Path, path: &Path) {
+    let Ok(lock) = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(path.join(LOCK_FILE))
+    else {
+        return;
+    };
+    if lock.try_lock_exclusive().is_err() {
+        return; // in use — skip
+    }
+    let nonce = format!(
+        ".trash-{}-{}",
+        std::process::id(),
+        path.file_name().and_then(|n| n.to_str()).unwrap_or("x")
+    );
+    let trash = cache_root.join(nonce);
+    if fs::rename(path, &trash).is_ok() {
+        // The locked inode moved with the rename; safe to release and
+        // delete — no launcher can reach the dir at its canonical path
+        // anymore, and any holding the old path retries by design.
+        drop(lock);
+        let _ = fs::remove_dir_all(&trash);
+    }
+}
+
+fn extract_files(files: &[BundleFile], into: &Path) -> Result<()> {
+    for (rel, contents) in files {
+        let dest = into.join(rel);
+        if let Some(parent) = dest.parent() {
+            fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
+        }
+        fs::write(&dest, contents).with_context(|| format!("writing {}", dest.display()))?;
+    }
+    Ok(())
+}
+
+/// Rewrite `.last-used`, refreshing its mtime (the GC recency signal).
+fn touch_last_used(dir: &Path) {
+    let _ = fs::write(dir.join(LAST_USED_FILE), b"");
+}
+
+fn file_mtime(path: &Path) -> Option<SystemTime> {
+    fs::metadata(path).and_then(|m| m.modified()).ok()
+}
+
+fn dir_mtime(path: &Path) -> SystemTime {
+    file_mtime(path).unwrap_or(SystemTime::UNIX_EPOCH)
+}
+
+fn older_than(t: &SystemTime, now: SystemTime, age: Duration) -> bool {
+    now.duration_since(*t).map(|d| d > age).unwrap_or(false)
+}
+
+/// 0700 on the cache root: the extracted bundle is executed code; keep
+/// other users out. No-op on Windows (per-user profile ACLs apply).
+fn restrict_permissions(dir: &Path) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = fs::set_permissions(dir, fs::Permissions::from_mode(0o700));
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = dir;
+    }
+}

--- a/crates/quarto-mcp-launcher/src/delegate.rs
+++ b/crates/quarto-mcp-launcher/src/delegate.rs
@@ -1,0 +1,64 @@
+//! Hand control to `node <bundle>/index.mjs [args…]`.
+//!
+//! stdio passes through untouched — stdout belongs to the MCP
+//! protocol, and the launcher itself never writes to it.
+//!
+//! Unix: `exec()` replaces the launcher entirely, so signals, exit
+//! codes, and stdin-EOF semantics are node's with no middleman. The
+//! lifetime shared lock (see cache.rs) must survive into node: file
+//! descriptors persist across exec unless close-on-exec is set, and
+//! Rust opens files with O_CLOEXEC — so we clear FD_CLOEXEC on the
+//! lock fd first. The lock then releases exactly when the node process
+//! exits, however it exits.
+//!
+//! Windows: no exec; spawn with inherited stdio, hold the lock in the
+//! (still-alive) launcher, wait, and forward the exit code. MCP hosts
+//! terminate stdio servers by closing stdin, which the server handles
+//! (bd-9jq2a060), so the child exits and we follow.
+
+use anyhow::Result;
+use std::fs::File;
+use std::path::Path;
+use std::process::Command;
+
+/// Returns only on failure to launch (Unix) or with the child's exit
+/// code (Windows). The caller turns the code into `process::exit`.
+pub fn delegate(node: &Path, entry: &Path, args: &[String], lock: File) -> Result<i32> {
+    let mut cmd = Command::new(node);
+    cmd.arg(entry).args(args);
+
+    #[cfg(unix)]
+    {
+        use std::os::fd::AsRawFd;
+        use std::os::unix::process::CommandExt;
+
+        let fd = lock.as_raw_fd();
+        // SAFETY: plain fcntl flag manipulation on an fd we own.
+        unsafe {
+            let flags = libc::fcntl(fd, libc::F_GETFD);
+            if flags >= 0 {
+                libc::fcntl(fd, libc::F_SETFD, flags & !libc::FD_CLOEXEC);
+            }
+        }
+        let err = cmd.exec(); // only returns on failure
+        Err(anyhow::Error::new(err).context(format!(
+            "failed to exec {} {}",
+            node.display(),
+            entry.display()
+        )))
+    }
+
+    #[cfg(not(unix))]
+    {
+        let status = cmd.status().map_err(|e| {
+            anyhow::Error::new(e).context(format!(
+                "failed to run {} {}",
+                node.display(),
+                entry.display()
+            ))
+        })?;
+        // Keep the lock alive for the child's whole lifetime.
+        drop(lock);
+        Ok(status.code().unwrap_or(1))
+    }
+}

--- a/crates/quarto-mcp-launcher/src/lib.rs
+++ b/crates/quarto-mcp-launcher/src/lib.rs
@@ -1,0 +1,104 @@
+//! `q2 mcp` launcher: embeds the bundled TypeScript hub MCP server
+//! (`ts-packages/quarto-hub-mcp/dist-bundle/`, built by
+//! `cargo xtask build-hub-mcp-bundle`), extracts it to a per-user
+//! cache, finds an ambient Node.js, and delegates execution.
+//!
+//! The TS server is the canonical MCP implementation (auth, sync, tool
+//! surface); this crate is deliberately a *thin* launcher so all
+//! protocol and security behavior stays single-sourced. Design:
+//! claude-notes/plans/2026-06-11-q2-mcp-hub-auth.md (bd-81cfshmw).
+//!
+//! Launcher contract:
+//! - never writes to stdout (it belongs to the MCP protocol), except
+//!   for the explicit, pre-protocol `--launcher-info` query;
+//! - all arguments pass through to the TS server verbatim (its
+//!   `--help` is the user-facing usage);
+//! - `QUARTO_NODE` overrides node discovery; `QUARTO_MCP_CACHE_DIR`
+//!   overrides the cache location (mainly for tests).
+
+mod bundle;
+mod cache;
+mod delegate;
+mod node;
+
+pub use cache::{
+    DEFAULT_MAX_AGE, ExtractedBundle, LAST_USED_FILE, LOCK_FILE, extract_and_lock, gc,
+};
+pub use node::{Discovery, MIN_NODE_MAJOR, NodeError, NodeInfo, find_node, parse_version};
+
+use anyhow::{Result, bail};
+use std::path::PathBuf;
+
+/// Entry point for `q2 mcp [args…]`. Returns the exit code to use
+/// (Windows delegation path); on Unix a successful delegation never
+/// returns.
+pub fn run(args: &[String]) -> Result<i32> {
+    if args.len() == 1 && args[0] == "--launcher-info" {
+        // Human/tool-facing metadata query; this is not an MCP session,
+        // so stdout is correct here.
+        println!("{}", launcher_info()?);
+        return Ok(0);
+    }
+
+    if bundle::is_placeholder() {
+        bail!(
+            "this q2 binary was built without the hub MCP bundle.\n\
+             Run `cargo xtask build-hub-mcp-bundle`, then rebuild the q2 binary\n\
+             (`cargo build --bin q2`). See CLAUDE.md § hub MCP bundle."
+        );
+    }
+
+    let files = bundle::embedded_files();
+    let hash = bundle::content_hash(&files);
+    let cache_root = cache_root()?;
+
+    let extracted = cache::extract_and_lock(&cache_root, &files, &hash)?;
+    // Opportunistic, best-effort; must never break the launch.
+    cache::gc(&cache_root, &hash, cache::DEFAULT_MAX_AGE);
+
+    let node = node::find_node(&node::Discovery::from_env())?;
+    delegate::delegate(
+        &node.path,
+        &extracted.dir.join("index.mjs"),
+        args,
+        extracted.lock,
+    )
+}
+
+fn cache_root() -> Result<PathBuf> {
+    if let Some(dir) = std::env::var_os("QUARTO_MCP_CACHE_DIR") {
+        return Ok(PathBuf::from(dir));
+    }
+    cache::default_cache_root()
+}
+
+/// Diagnostic blob for `q2 mcp --launcher-info`: which bundle is
+/// embedded (the stale-embed tripwire — see CLAUDE.md), where it
+/// extracts, and which node would run it.
+fn launcher_info() -> Result<String> {
+    let mut out = String::new();
+    if bundle::is_placeholder() {
+        out.push_str("bundle: PLACEHOLDER (run `cargo xtask build-hub-mcp-bundle` and rebuild)\n");
+        return Ok(out);
+    }
+    let files = bundle::embedded_files();
+    out.push_str(&format!("bundle-hash: {}\n", bundle::content_hash(&files)));
+    out.push_str(&format!("bundle-files: {}\n", files.len()));
+    if let Some(info) = bundle::build_info_json() {
+        out.push_str("build-info: ");
+        out.push_str(info.trim());
+        out.push('\n');
+    }
+    out.push_str(&format!("cache-root: {}\n", cache_root()?.display()));
+    match node::find_node(&node::Discovery::from_env()) {
+        Ok(node) => out.push_str(&format!(
+            "node: {} (v{}.{}.{})\n",
+            node.path.display(),
+            node.version.0,
+            node.version.1,
+            node.version.2
+        )),
+        Err(e) => out.push_str(&format!("node: NOT FOUND — {}\n", e)),
+    }
+    Ok(out)
+}

--- a/crates/quarto-mcp-launcher/src/node.rs
+++ b/crates/quarto-mcp-launcher/src/node.rs
@@ -1,0 +1,264 @@
+//! Ambient Node.js discovery.
+//!
+//! GUI-launched MCP hosts (Claude Desktop in particular) start servers
+//! with a minimal environment: on macOS, not the user's shell PATH —
+//! so nvm/fnm/volta-managed Node is invisible to a naive PATH lookup
+//! exactly in the flagship use case. Discovery is therefore layered:
+//!
+//! 1. `QUARTO_NODE` env var — explicit override, must satisfy the
+//!    version floor (a too-old override is an error, not a fallthrough:
+//!    the user asked for that binary specifically).
+//! 2. `node` on PATH.
+//! 3. Well-known install locations, including version-manager trees
+//!    (Homebrew, /usr/local, volta, fnm, nvm, Windows Program Files).
+//!
+//! Layers 2–3 skip candidates below the floor and keep looking; if
+//! nothing satisfies, the error names every candidate found and how to
+//! fix it. The floor is Node 24 (current LTS; decided 2026-06-11, see
+//! the plan's resolved open question 1).
+
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use thiserror::Error;
+
+pub const MIN_NODE_MAJOR: u32 = 24;
+
+#[derive(Debug, Clone)]
+pub struct NodeInfo {
+    pub path: PathBuf,
+    pub version: (u32, u32, u32),
+}
+
+#[derive(Debug, Error)]
+pub enum NodeError {
+    #[error(
+        "QUARTO_NODE points at {path} but `--version` failed ({detail}); \
+         fix or unset QUARTO_NODE"
+    )]
+    OverrideUnusable { path: PathBuf, detail: String },
+    #[error(
+        "QUARTO_NODE points at {path} (Node {found}), but `q2 mcp` needs Node {min}+; \
+         point QUARTO_NODE at a newer Node or unset it to use automatic discovery"
+    )]
+    OverrideTooOld {
+        path: PathBuf,
+        found: String,
+        min: u32,
+    },
+    #[error(
+        "no usable Node.js found (need Node {min}+).{found_summary}\n\
+         `q2 mcp` runs the Quarto Hub MCP server on your Node.js. Fixes:\n\
+         - install Node {min}+ (https://nodejs.org), or\n\
+         - set QUARTO_NODE to the full path of a Node {min}+ binary\n\
+         (GUI apps like Claude Desktop don't see your shell PATH, so a\n\
+         version-manager Node may need the QUARTO_NODE setting.)"
+    )]
+    NotFound { min: u32, found_summary: String },
+}
+
+/// Inputs to discovery, injectable for tests.
+pub struct Discovery {
+    pub quarto_node: Option<OsString>,
+    pub path_var: Option<OsString>,
+    pub well_known: Vec<PathBuf>,
+}
+
+impl Discovery {
+    /// Discovery against the real environment.
+    pub fn from_env() -> Self {
+        Self {
+            quarto_node: std::env::var_os("QUARTO_NODE"),
+            path_var: std::env::var_os("PATH"),
+            well_known: default_well_known(),
+        }
+    }
+}
+
+pub fn find_node(d: &Discovery) -> Result<NodeInfo, NodeError> {
+    // Layer 1: explicit override.
+    if let Some(raw) = &d.quarto_node {
+        let path = PathBuf::from(raw);
+        return match probe_version(&path) {
+            Ok(version) if version.0 >= MIN_NODE_MAJOR => Ok(NodeInfo { path, version }),
+            Ok(version) => Err(NodeError::OverrideTooOld {
+                path,
+                found: format!("{}.{}.{}", version.0, version.1, version.2),
+                min: MIN_NODE_MAJOR,
+            }),
+            Err(detail) => Err(NodeError::OverrideUnusable { path, detail }),
+        };
+    }
+
+    let mut rejected: Vec<String> = Vec::new();
+
+    // Layer 2: PATH.
+    let exe = if cfg!(windows) { "node.exe" } else { "node" };
+    if let Some(path_var) = &d.path_var {
+        for dir in std::env::split_paths(path_var) {
+            if dir.as_os_str().is_empty() {
+                continue;
+            }
+            let candidate = dir.join(exe);
+            if let Some(found) = consider(&candidate, &mut rejected) {
+                return Ok(found);
+            }
+        }
+    }
+
+    // Layer 3: well-known locations.
+    for candidate in &d.well_known {
+        if let Some(found) = consider(candidate, &mut rejected) {
+            return Ok(found);
+        }
+    }
+
+    let found_summary = if rejected.is_empty() {
+        String::new()
+    } else {
+        format!(" Found, but too old: {}.", rejected.join(", "))
+    };
+    Err(NodeError::NotFound {
+        min: MIN_NODE_MAJOR,
+        found_summary,
+    })
+}
+
+/// Probe one candidate; record floor-failures for the error message.
+fn consider(candidate: &Path, rejected: &mut Vec<String>) -> Option<NodeInfo> {
+    if !candidate.is_file() {
+        return None;
+    }
+    match probe_version(candidate) {
+        Ok(version) if version.0 >= MIN_NODE_MAJOR => Some(NodeInfo {
+            path: candidate.to_path_buf(),
+            version,
+        }),
+        Ok(version) => {
+            rejected.push(format!(
+                "{} (v{}.{}.{})",
+                candidate.display(),
+                version.0,
+                version.1,
+                version.2
+            ));
+            None
+        }
+        Err(_) => None,
+    }
+}
+
+/// Run `<path> --version` and parse `vMAJOR.MINOR.PATCH`.
+pub fn probe_version(path: &Path) -> Result<(u32, u32, u32), String> {
+    let output = Command::new(path)
+        .arg("--version")
+        .output()
+        .map_err(|e| e.to_string())?;
+    if !output.status.success() {
+        return Err(format!("exit status {}", output.status));
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    parse_version(stdout.trim())
+        .ok_or_else(|| format!("unrecognized --version output {:?}", stdout.trim()))
+}
+
+pub fn parse_version(s: &str) -> Option<(u32, u32, u32)> {
+    let s = s.strip_prefix('v').unwrap_or(s);
+    let mut parts = s.split('.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next().unwrap_or("0").parse().ok()?;
+    let patch = parts
+        .next()
+        .map(|p| {
+            // tolerate suffixes like "0-nightly..."
+            p.split(|c: char| !c.is_ascii_digit())
+                .next()
+                .unwrap_or("0")
+                .to_string()
+        })
+        .unwrap_or_else(|| "0".to_string())
+        .parse()
+        .ok()?;
+    Some((major, minor, patch))
+}
+
+/// Static probe list for layer 3. Existence is checked at probe time,
+/// so listing paths that usually don't exist is free. Version-manager
+/// trees with per-version dirs get expanded to the highest version.
+fn default_well_known() -> Vec<PathBuf> {
+    let mut paths: Vec<PathBuf> = Vec::new();
+    let home = dirs::home_dir();
+
+    #[cfg(unix)]
+    {
+        paths.extend([
+            PathBuf::from("/opt/homebrew/bin/node"),
+            PathBuf::from("/usr/local/bin/node"),
+            PathBuf::from("/usr/bin/node"),
+        ]);
+        if let Some(home) = &home {
+            // volta and fnm keep stable "current default" paths.
+            paths.push(home.join(".volta/bin/node"));
+            paths.push(home.join(".local/share/fnm/aliases/default/bin/node"));
+            paths.push(home.join("Library/Application Support/fnm/aliases/default/bin/node"));
+            // nvm has one dir per installed version; take the highest.
+            paths.extend(highest_version_node(&home.join(".nvm/versions/node")));
+            paths.extend(highest_version_node(
+                &home.join("Library/Application Support/fnm/node-versions"),
+            ));
+            paths.extend(highest_version_node(
+                &home.join(".local/share/fnm/node-versions"),
+            ));
+        }
+    }
+    #[cfg(windows)]
+    {
+        if let Some(pf) = std::env::var_os("ProgramFiles") {
+            paths.push(PathBuf::from(pf).join("nodejs").join("node.exe"));
+        }
+        if let Some(home) = &home {
+            paths.push(home.join("AppData/Local/Volta/bin/node.exe"));
+        }
+    }
+    let _ = home;
+    paths
+}
+
+/// In a version-manager tree (`<root>/v24.1.0/...`), the node binary
+/// of the highest version present.
+fn highest_version_node(root: &Path) -> Option<PathBuf> {
+    let entries = std::fs::read_dir(root).ok()?;
+    let mut best: Option<((u32, u32, u32), PathBuf)> = None;
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(version) = parse_version(&name.to_string_lossy()) else {
+            continue;
+        };
+        // nvm: <root>/vX.Y.Z/bin/node; fnm: <root>/vX.Y.Z/installation/bin/node
+        for sub in ["bin/node", "installation/bin/node"] {
+            let candidate = entry.path().join(sub);
+            if candidate.is_file() && best.as_ref().is_none_or(|(v, _)| version > *v) {
+                best = Some((version, candidate.clone()));
+            }
+        }
+    }
+    best.map(|(_, p)| p)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_plain_versions() {
+        assert_eq!(parse_version("v24.15.0"), Some((24, 15, 0)));
+        assert_eq!(parse_version("22.1.3"), Some((22, 1, 3)));
+        assert_eq!(parse_version("v25.0.0-nightly20260101"), Some((25, 0, 0)));
+    }
+
+    #[test]
+    fn rejects_garbage() {
+        assert_eq!(parse_version(""), None);
+        assert_eq!(parse_version("node"), None);
+    }
+}

--- a/crates/quarto-mcp-launcher/tests/integration/cache_tests.rs
+++ b/crates/quarto-mcp-launcher/tests/integration/cache_tests.rs
@@ -1,0 +1,264 @@
+//! Extraction, lifetime-lock, and GC semantics (plan Phase 2,
+//! bd-81cfshmw). These encode the safety properties that justify the
+//! lock-based design: GC can never delete a bundle in use, crashes
+//! release locks automatically, and corrupted/raced cache states heal.
+
+use fs2::FileExt;
+use quarto_mcp_launcher::{DEFAULT_MAX_AGE, LAST_USED_FILE, LOCK_FILE, extract_and_lock, gc};
+use std::borrow::Cow;
+use std::fs::{self, File, OpenOptions};
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+type BundleFile = (PathBuf, Cow<'static, [u8]>);
+
+fn test_bundle() -> Vec<BundleFile> {
+    vec![
+        (
+            PathBuf::from("index.mjs"),
+            Cow::Borrowed(b"// fake bundle entry\n".as_slice()),
+        ),
+        (
+            PathBuf::from("build-info.json"),
+            Cow::Borrowed(b"{}\n".as_slice()),
+        ),
+        (
+            PathBuf::from("node_modules/@napi-rs/keyring/index.js"),
+            Cow::Borrowed(b"// fake addon loader\n".as_slice()),
+        ),
+    ]
+}
+
+const HASH: &str = "cafebabe01234567";
+
+/// Set a file's mtime into the past (the GC recency signal).
+fn age_file(path: &Path, age: Duration) {
+    let f = OpenOptions::new().write(true).open(path).unwrap();
+    f.set_modified(SystemTime::now() - age).unwrap();
+}
+
+fn lock_handle(dir: &Path) -> File {
+    OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(dir.join(LOCK_FILE))
+        .unwrap()
+}
+
+#[test]
+fn extraction_creates_payload_and_metadata() {
+    let cache = tempfile::tempdir().unwrap();
+    let extracted = extract_and_lock(cache.path(), &test_bundle(), HASH).unwrap();
+
+    assert_eq!(extracted.dir, cache.path().join(HASH));
+    assert_eq!(
+        fs::read(extracted.dir.join("index.mjs")).unwrap(),
+        b"// fake bundle entry\n"
+    );
+    assert!(
+        extracted
+            .dir
+            .join("node_modules/@napi-rs/keyring/index.js")
+            .is_file()
+    );
+    assert!(extracted.dir.join(LAST_USED_FILE).is_file());
+    // no extraction temp dirs left behind
+    let leftovers: Vec<_> = fs::read_dir(cache.path())
+        .unwrap()
+        .flatten()
+        .filter(|e| e.file_name().to_string_lossy().starts_with(".tmp-"))
+        .collect();
+    assert!(leftovers.is_empty());
+}
+
+#[test]
+fn extraction_holds_shared_lock_for_lifetime() {
+    let cache = tempfile::tempdir().unwrap();
+    let extracted = extract_and_lock(cache.path(), &test_bundle(), HASH).unwrap();
+
+    // While the ExtractedBundle lives, an exclusive try-lock must fail
+    // — this is exactly the probe GC uses before deleting.
+    let probe = lock_handle(&extracted.dir);
+    assert!(probe.try_lock_exclusive().is_err());
+
+    // Dropping the bundle (process exit, in real life) releases it.
+    let dir = extracted.dir.clone();
+    drop(extracted);
+    let probe2 = lock_handle(&dir);
+    assert!(probe2.try_lock_exclusive().is_ok());
+}
+
+#[test]
+fn second_launch_reuses_existing_dir() {
+    let cache = tempfile::tempdir().unwrap();
+    let first = extract_and_lock(cache.path(), &test_bundle(), HASH).unwrap();
+    let marker = first.dir.join("user-marker");
+    fs::write(&marker, b"still here").unwrap();
+    drop(first);
+
+    let second = extract_and_lock(cache.path(), &test_bundle(), HASH).unwrap();
+    // Same dir, not re-extracted from scratch.
+    assert!(marker.is_file(), "re-extraction clobbered the dir");
+    drop(second);
+}
+
+#[test]
+fn concurrent_extractions_converge() {
+    let cache = tempfile::tempdir().unwrap();
+    let root = cache.path().to_path_buf();
+    let handles: Vec<_> = (0..8)
+        .map(|_| {
+            let root = root.clone();
+            std::thread::spawn(move || extract_and_lock(&root, &test_bundle(), HASH).unwrap())
+        })
+        .collect();
+    for h in handles {
+        let extracted = h.join().unwrap();
+        assert!(extracted.dir.join("index.mjs").is_file());
+    }
+    // Exactly the one hash dir; every .tmp-* cleaned up.
+    let names: Vec<String> = fs::read_dir(&root)
+        .unwrap()
+        .flatten()
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .collect();
+    assert_eq!(names, vec![HASH.to_string()], "cache dirs: {names:?}");
+}
+
+#[test]
+fn corrupt_cache_dir_self_heals() {
+    let cache = tempfile::tempdir().unwrap();
+    // A canonical-path dir with no payload (e.g. interrupted manual
+    // tampering): extraction must replace it rather than fail forever.
+    fs::create_dir_all(cache.path().join(HASH)).unwrap();
+    let extracted = extract_and_lock(cache.path(), &test_bundle(), HASH).unwrap();
+    assert!(extracted.dir.join("index.mjs").is_file());
+}
+
+#[test]
+fn gc_removes_old_unlocked_bundles() {
+    let cache = tempfile::tempdir().unwrap();
+    let old = extract_and_lock(cache.path(), &test_bundle(), "0ldhash000000000").unwrap();
+    let old_dir = old.dir.clone();
+    drop(old); // lock released
+    age_file(&old_dir.join(LAST_USED_FILE), DEFAULT_MAX_AGE * 2);
+
+    gc(cache.path(), "current-hash", DEFAULT_MAX_AGE);
+    assert!(!old_dir.exists(), "old unlocked bundle should be GC'd");
+    // no trash leftovers
+    let trash: Vec<_> = fs::read_dir(cache.path())
+        .unwrap()
+        .flatten()
+        .filter(|e| e.file_name().to_string_lossy().starts_with(".trash-"))
+        .collect();
+    assert!(trash.is_empty());
+}
+
+#[test]
+fn gc_spares_recently_used_bundles() {
+    let cache = tempfile::tempdir().unwrap();
+    let recent = extract_and_lock(cache.path(), &test_bundle(), "recenthash000000").unwrap();
+    let dir = recent.dir.clone();
+    drop(recent); // unlocked, but young
+    gc(cache.path(), "current-hash", DEFAULT_MAX_AGE);
+    assert!(dir.exists(), "recently used bundle must survive GC");
+}
+
+#[test]
+fn gc_spares_locked_bundles_even_when_old() {
+    let cache = tempfile::tempdir().unwrap();
+    let held = extract_and_lock(cache.path(), &test_bundle(), "l0ckedhash000000").unwrap();
+    age_file(&held.dir.join(LAST_USED_FILE), DEFAULT_MAX_AGE * 2);
+
+    gc(cache.path(), "current-hash", DEFAULT_MAX_AGE);
+    assert!(
+        held.dir.join("index.mjs").is_file(),
+        "a bundle with a live shared lock must never be GC'd"
+    );
+}
+
+#[test]
+fn gc_never_touches_the_current_hash() {
+    let cache = tempfile::tempdir().unwrap();
+    let current = extract_and_lock(cache.path(), &test_bundle(), HASH).unwrap();
+    let dir = current.dir.clone();
+    drop(current);
+    age_file(&dir.join(LAST_USED_FILE), DEFAULT_MAX_AGE * 2);
+
+    gc(cache.path(), HASH, DEFAULT_MAX_AGE);
+    assert!(
+        dir.exists(),
+        "keep_hash dir must survive GC regardless of age"
+    );
+}
+
+#[test]
+fn gc_cleans_stale_tmp_and_trash_leftovers() {
+    let cache = tempfile::tempdir().unwrap();
+    let stale_tmp = cache.path().join(".tmp-99999-0");
+    let stale_trash = cache.path().join(".trash-99999-x");
+    fs::create_dir_all(&stale_tmp).unwrap();
+    fs::create_dir_all(&stale_trash).unwrap();
+    fs::write(stale_tmp.join("partial"), b"x").unwrap();
+    // Make them look hours old (dir mtime).
+    let two_hours = Duration::from_secs(2 * 60 * 60);
+    File::open(&stale_tmp)
+        .and_then(|f| f.set_modified(SystemTime::now() - two_hours))
+        .ok();
+    File::open(&stale_trash)
+        .and_then(|f| f.set_modified(SystemTime::now() - two_hours))
+        .ok();
+
+    gc(cache.path(), HASH, DEFAULT_MAX_AGE);
+
+    // On platforms where dir-handle mtime setting works (unix), the
+    // leftovers must be gone; elsewhere they must at least not break GC.
+    #[cfg(unix)]
+    {
+        assert!(!stale_tmp.exists());
+        assert!(!stale_trash.exists());
+    }
+}
+
+#[test]
+fn fresh_tmp_dirs_survive_gc() {
+    let cache = tempfile::tempdir().unwrap();
+    // A just-created .tmp dir simulates an extraction in flight.
+    let live_tmp = cache.path().join(".tmp-12345-0");
+    fs::create_dir_all(&live_tmp).unwrap();
+    gc(cache.path(), HASH, DEFAULT_MAX_AGE);
+    assert!(
+        live_tmp.exists(),
+        "in-flight extraction dir must not be GC'd"
+    );
+}
+
+#[test]
+fn crashed_instance_releases_lock_making_bundle_collectable() {
+    // Simulate "crash" by dropping the lock without any cleanup, then
+    // aging the dir: GC must collect it. (The kernel releases flocks on
+    // process death; in-process drop models that without forking.)
+    let cache = tempfile::tempdir().unwrap();
+    let crashed = extract_and_lock(cache.path(), &test_bundle(), "crashedhash00000").unwrap();
+    let dir = crashed.dir.clone();
+    drop(crashed.lock); // "process died"
+    age_file(&dir.join(LAST_USED_FILE), DEFAULT_MAX_AGE * 2);
+
+    gc(cache.path(), "current-hash", DEFAULT_MAX_AGE);
+    assert!(!dir.exists(), "crash-released bundle must be collectable");
+}
+
+#[test]
+fn launch_after_gc_re_extracts() {
+    let cache = tempfile::tempdir().unwrap();
+    let first = extract_and_lock(cache.path(), &test_bundle(), HASH).unwrap();
+    let dir = first.dir.clone();
+    drop(first);
+    age_file(&dir.join(LAST_USED_FILE), DEFAULT_MAX_AGE * 2);
+    gc(cache.path(), "other-hash", DEFAULT_MAX_AGE);
+    assert!(!dir.exists());
+
+    // Next launch simply re-extracts.
+    let again = extract_and_lock(cache.path(), &test_bundle(), HASH).unwrap();
+    assert!(again.dir.join("index.mjs").is_file());
+}

--- a/crates/quarto-mcp-launcher/tests/integration/main.rs
+++ b/crates/quarto-mcp-launcher/tests/integration/main.rs
@@ -1,0 +1,2 @@
+pub mod cache_tests;
+pub mod node_tests;

--- a/crates/quarto-mcp-launcher/tests/integration/node_tests.rs
+++ b/crates/quarto-mcp-launcher/tests/integration/node_tests.rs
@@ -1,0 +1,143 @@
+//! Node discovery semantics (plan Phase 2, bd-81cfshmw): the
+//! QUARTO_NODE override, PATH lookup, version-floor enforcement, and
+//! the actionability of the not-found error.
+//!
+//! Fake node binaries are shell scripts, so the behavioral tests are
+//! unix-only; `parse_version` and the error-shape tests are
+//! platform-independent. Windows CI exercises the real-PATH path via
+//! `discovery_from_env_finds_real_node` when node is present.
+
+use quarto_mcp_launcher::{Discovery, MIN_NODE_MAJOR, NodeError, find_node};
+use std::path::PathBuf;
+
+fn empty_discovery() -> Discovery {
+    Discovery {
+        quarto_node: None,
+        path_var: None,
+        well_known: Vec::new(),
+    }
+}
+
+#[cfg(unix)]
+fn fake_node(dir: &std::path::Path, version: &str) -> PathBuf {
+    use std::os::unix::fs::PermissionsExt;
+    let path = dir.join("node");
+    std::fs::write(&path, format!("#!/bin/sh\necho \"v{version}\"\n")).unwrap();
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+    path
+}
+
+#[test]
+fn missing_node_error_is_actionable() {
+    let err = find_node(&empty_discovery()).unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("QUARTO_NODE"), "must name the override: {msg}");
+    assert!(
+        msg.contains(&format!("Node {MIN_NODE_MAJOR}+")),
+        "must name the floor: {msg}"
+    );
+    assert!(msg.contains("nodejs.org"), "must say how to install: {msg}");
+}
+
+#[cfg(unix)]
+#[test]
+fn quarto_node_override_wins() {
+    let dir = tempfile::tempdir().unwrap();
+    let node = fake_node(dir.path(), "24.2.0");
+    let d = Discovery {
+        quarto_node: Some(node.clone().into_os_string()),
+        // PATH would offer another node; the override must win.
+        path_var: Some(dir.path().as_os_str().to_os_string()),
+        well_known: Vec::new(),
+    };
+    let found = find_node(&d).unwrap();
+    assert_eq!(found.path, node);
+    assert_eq!(found.version, (24, 2, 0));
+}
+
+#[cfg(unix)]
+#[test]
+fn quarto_node_below_floor_is_an_error_not_a_fallthrough() {
+    let dir = tempfile::tempdir().unwrap();
+    let old_node = fake_node(dir.path(), "20.11.1");
+    // A perfectly good node sits on PATH, but the explicit override
+    // must NOT silently fall through to it.
+    let good_dir = tempfile::tempdir().unwrap();
+    fake_node(good_dir.path(), "24.0.0");
+    let d = Discovery {
+        quarto_node: Some(old_node.into_os_string()),
+        path_var: Some(good_dir.path().as_os_str().to_os_string()),
+        well_known: Vec::new(),
+    };
+    let err = find_node(&d).unwrap_err();
+    assert!(matches!(err, NodeError::OverrideTooOld { .. }), "{err}");
+    let msg = err.to_string();
+    assert!(msg.contains("20.11.1"), "{msg}");
+}
+
+#[cfg(unix)]
+#[test]
+fn path_lookup_finds_node() {
+    let dir = tempfile::tempdir().unwrap();
+    let node = fake_node(dir.path(), "25.1.2");
+    let d = Discovery {
+        quarto_node: None,
+        path_var: Some(dir.path().as_os_str().to_os_string()),
+        well_known: Vec::new(),
+    };
+    let found = find_node(&d).unwrap();
+    assert_eq!(found.path, node);
+    assert_eq!(found.version, (25, 1, 2));
+}
+
+#[cfg(unix)]
+#[test]
+fn too_old_path_node_falls_through_to_well_known() {
+    let old_dir = tempfile::tempdir().unwrap();
+    fake_node(old_dir.path(), "18.19.0");
+    let wk_dir = tempfile::tempdir().unwrap();
+    let good = fake_node(wk_dir.path(), "24.0.0");
+    let d = Discovery {
+        quarto_node: None,
+        path_var: Some(old_dir.path().as_os_str().to_os_string()),
+        well_known: vec![good.clone()],
+    };
+    let found = find_node(&d).unwrap();
+    assert_eq!(found.path, good);
+}
+
+#[cfg(unix)]
+#[test]
+fn all_too_old_error_names_what_was_found() {
+    let dir = tempfile::tempdir().unwrap();
+    fake_node(dir.path(), "18.19.0");
+    let d = Discovery {
+        quarto_node: None,
+        path_var: Some(dir.path().as_os_str().to_os_string()),
+        well_known: Vec::new(),
+    };
+    let err = find_node(&d).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("18.19.0"),
+        "rejected candidates should be named: {msg}"
+    );
+}
+
+#[test]
+fn discovery_from_env_finds_real_node_when_present() {
+    // Smoke check against the actual environment: dev machines and CI
+    // have Node 24+ (the repo's own toolchain), so this exercises the
+    // real probe path end-to-end. Skip quietly when absent.
+    let d = Discovery::from_env();
+    match find_node(&d) {
+        Ok(found) => {
+            assert!(found.version.0 >= MIN_NODE_MAJOR);
+            assert!(found.path.is_file() || found.path.is_symlink());
+        }
+        Err(NodeError::NotFound { .. }) => {
+            eprintln!("no node on this machine; skipping");
+        }
+        Err(other) => panic!("unexpected discovery error: {other}"),
+    }
+}

--- a/crates/quarto/Cargo.toml
+++ b/crates/quarto/Cargo.toml
@@ -32,6 +32,7 @@ quarto-system-runtime.workspace = true
 quarto-doctemplate.workspace = true
 quarto-lsp = { workspace = true }
 quarto-hub.workspace = true
+quarto-mcp-launcher = { path = "../quarto-mcp-launcher" }
 quarto-preview = { path = "../quarto-preview" }
 quarto-publish.workspace = true
 quarto-sass.workspace = true

--- a/crates/quarto/src/commands/hub.rs
+++ b/crates/quarto/src/commands/hub.rs
@@ -118,6 +118,7 @@ async fn run_hub(args: HubArgs) -> Result<()> {
                 args.oidc_image_domains,
                 args.allowed_emails,
                 args.allowed_domains,
+                args.allow_insecure_auth,
             )
         })
         .transpose()

--- a/crates/quarto/src/commands/mcp.rs
+++ b/crates/quarto/src/commands/mcp.rs
@@ -1,0 +1,23 @@
+//! `q2 mcp` — run the Quarto Hub MCP server.
+//!
+//! A thin launcher (bd-81cfshmw): the canonical MCP server is the
+//! TypeScript `ts-packages/quarto-hub-mcp`, embedded in this binary as
+//! a self-contained bundle. The launcher extracts it to a per-user
+//! cache and delegates to an ambient Node.js, passing all arguments
+//! through verbatim — see `quarto-mcp-launcher` for the mechanics
+//! (locking, GC, node discovery) and
+//! `claude-notes/plans/2026-06-11-q2-mcp-hub-auth.md` for the design.
+//!
+//! The launcher never writes to stdout: in an MCP session stdout
+//! carries the JSON-RPC protocol. (`--launcher-info`, an explicit
+//! pre-protocol query, is the one exception.)
+
+use anyhow::Result;
+
+pub fn run(args: &[String]) -> Result<()> {
+    let code = quarto_mcp_launcher::run(args)?;
+    // Unix delegation execs and never returns; this path is reached on
+    // Windows (forwarding the child's exit code) and for
+    // --launcher-info.
+    std::process::exit(code);
+}

--- a/crates/quarto/src/commands/mod.rs
+++ b/crates/quarto/src/commands/mod.rs
@@ -13,6 +13,7 @@ pub mod hub;
 pub mod install;
 pub mod list;
 pub mod lsp;
+pub mod mcp;
 pub mod pandoc;
 pub mod preview;
 pub mod publish;

--- a/crates/quarto/src/main.rs
+++ b/crates/quarto/src/main.rs
@@ -438,6 +438,22 @@ enum Commands {
         command: TraceCommand,
     },
 
+    /// Run the Quarto Hub MCP server (for AI agents; needs Node.js).
+    ///
+    /// Delegates to the embedded TypeScript MCP server: all arguments
+    /// pass through verbatim (`q2 mcp --help` shows the server's own
+    /// usage, e.g. `--server <url>`, `--read-only`). Launcher-specific
+    /// controls: the `QUARTO_NODE` env var picks the Node.js binary
+    /// when discovery fails (GUI MCP hosts don't see your shell PATH),
+    /// and `q2 mcp --launcher-info` prints embed/cache/node
+    /// diagnostics.
+    #[command(disable_help_flag = true)]
+    Mcp {
+        /// Arguments passed through to the MCP server verbatim.
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+
     /// Start collaborative hub server for real-time editing.
     /// By default, watches the current directory (or --project path).
     /// Use --no-project to run as a standalone sync server.
@@ -700,6 +716,8 @@ fn main() -> Result<()> {
             strict,
             compact,
         }),
+        Commands::Mcp { args } => commands::mcp::run(&args),
+
         Commands::Hub {
             project,
             no_project,

--- a/crates/xtask/src/build_all.rs
+++ b/crates/xtask/src/build_all.rs
@@ -27,6 +27,8 @@ pub struct BuildAllConfig {
     pub skip_hub_build: bool,
     /// Skip the trace-viewer build step. No-op until Phase 4.3 lands.
     pub skip_trace_viewer_build: bool,
+    /// Skip the hub MCP bundle build step (q2-mcp embed artifact).
+    pub skip_hub_mcp_bundle: bool,
     /// Skip the q2-preview-spa build step. No-op when the SPA dir is
     /// absent (e.g. branches before bd-hfjj Phase 6).
     pub skip_q2_preview_spa_build: bool,
@@ -42,6 +44,7 @@ impl Default for BuildAllConfig {
             skip_npm_install: false,
             skip_hub_build: false,
             skip_trace_viewer_build: false,
+            skip_hub_mcp_bundle: false,
             skip_q2_preview_spa_build: false,
             skip_rust_build: false,
             release: false,
@@ -63,6 +66,10 @@ pub fn run(config: &BuildAllConfig) -> Result<()> {
         (
             "q2-preview-spa build",
             !config.skip_q2_preview_spa_build && q2_preview_spa_exists(&project_root),
+        ),
+        (
+            "hub MCP bundle build",
+            !config.skip_hub_mcp_bundle && hub_mcp_exists(&project_root),
         ),
         ("Rust workspace build", !config.skip_rust_build),
     ];
@@ -130,6 +137,22 @@ pub fn run(config: &BuildAllConfig) -> Result<()> {
         println!("✓ q2-preview-spa build complete");
     }
 
+    // Step: hub MCP bundle (bd-81cfshmw) — the artifact `q2 mcp`
+    // embeds; must exist before the Rust build that `include_dir!`s it.
+    if !config.skip_hub_mcp_bundle && hub_mcp_exists(&project_root) {
+        step_idx += 1;
+        banner(step_idx, total, "Building hub MCP bundle");
+        let pkg_dir = project_root.join("ts-packages/quarto-hub-mcp");
+        run_command(
+            "npm",
+            &["run", "bundle"],
+            &pkg_dir,
+            None,
+            "hub MCP bundle build failed",
+        )?;
+        println!("✓ hub MCP bundle complete");
+    }
+
     // Step: Rust workspace build
     if !config.skip_rust_build {
         step_idx += 1;
@@ -168,6 +191,13 @@ fn trace_viewer_exists(project_root: &Path) -> bool {
 fn q2_preview_spa_exists(project_root: &Path) -> bool {
     project_root
         .join("q2-preview-spa")
+        .join("package.json")
+        .is_file()
+}
+
+fn hub_mcp_exists(project_root: &Path) -> bool {
+    project_root
+        .join("ts-packages/quarto-hub-mcp")
         .join("package.json")
         .is_file()
 }

--- a/crates/xtask/src/build_hub_mcp_bundle.rs
+++ b/crates/xtask/src/build_hub_mcp_bundle.rs
@@ -1,0 +1,58 @@
+//! `cargo xtask build-hub-mcp-bundle` — build the self-contained hub
+//! MCP server bundle (`ts-packages/quarto-hub-mcp/dist-bundle/`).
+//!
+//! The bundle (single `index.mjs` + the platform keyring addon as a
+//! mini node_modules + `build-info.json` stamp) is what the `q2`
+//! binary embeds for `q2 mcp` (bd-81cfshmw). Like the q2-preview SPA,
+//! a plain `cargo build` does NOT refresh it — run this (or
+//! `cargo xtask build-all`) after changing quarto-hub-mcp,
+//! quarto-sync-client, or quarto-automerge-schema sources, or the
+//! next `q2` build silently re-embeds a stale bundle. The esbuild
+//! config compiles workspace deps straight from their TypeScript
+//! sources (the `source` export condition), so no prior `tsc` builds
+//! are needed.
+//!
+//! Mirrors `build_q2_preview_spa.rs`.
+
+use anyhow::{Context, Result, bail};
+use std::path::PathBuf;
+use std::process::Command;
+
+pub fn run() -> Result<()> {
+    let project_root = find_project_root()?;
+    let pkg_dir = project_root.join("ts-packages/quarto-hub-mcp");
+    if !pkg_dir.join("package.json").is_file() {
+        bail!(
+            "ts-packages/quarto-hub-mcp/package.json not found under {}",
+            project_root.display()
+        );
+    }
+
+    println!("━━━ Building quarto-hub-mcp bundle ━━━");
+    let status = Command::new("npm")
+        .args(["run", "bundle"])
+        .current_dir(&pkg_dir)
+        .status()
+        .with_context(|| format!("Failed to spawn npm in {}", pkg_dir.display()))?;
+    if !status.success() {
+        bail!("quarto-hub-mcp bundle build failed");
+    }
+    println!("✓ ts-packages/quarto-hub-mcp/dist-bundle/ is up to date");
+    Ok(())
+}
+
+fn find_project_root() -> Result<PathBuf> {
+    let mut dir = std::env::current_dir().context("Failed to get current directory")?;
+    loop {
+        let cargo_toml = dir.join("Cargo.toml");
+        if cargo_toml.exists() {
+            let content = std::fs::read_to_string(&cargo_toml)?;
+            if content.contains("[workspace]") {
+                return Ok(dir);
+            }
+        }
+        if !dir.pop() {
+            bail!("Could not find workspace root (Cargo.toml with [workspace])");
+        }
+    }
+}

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -14,10 +14,12 @@
 //! - `verify`: Run full project verification (build + tests for Rust and hub-client)
 //! - `build-all`: Fresh-clone build orchestration (npm install + hub-client + Rust workspace)
 //! - `build-trace-viewer`: Build just the trace-viewer SPA
+//! - `build-hub-mcp-bundle`: Build the self-contained hub MCP server bundle
 //! - `stage-doc-examples`: Render `examples/manifest.yml` projects into `docs/examples/`
 
 mod braid_snapshot;
 mod build_all;
+mod build_hub_mcp_bundle;
 mod build_q2_preview_spa;
 mod build_trace_viewer;
 mod create_worktree;
@@ -183,6 +185,10 @@ enum Command {
         #[arg(long)]
         skip_q2_preview_spa_build: bool,
 
+        /// Skip the quarto-sync-client + quarto-hub-mcp package tests.
+        #[arg(long)]
+        skip_hub_mcp_tests: bool,
+
         /// Include hub-client e2e tests (slower, requires browser).
         #[arg(long)]
         e2e: bool,
@@ -215,6 +221,14 @@ enum Command {
     /// build -p quarto-preview` (via `include_dir!`).
     BuildQ2PreviewSpa {},
 
+    /// Build the self-contained hub MCP server bundle.
+    ///
+    /// Produces `ts-packages/quarto-hub-mcp/dist-bundle/` (esbuild) —
+    /// the artifact `q2 mcp` embeds (bd-81cfshmw). A plain `cargo
+    /// build` does NOT refresh it; run this after changing
+    /// quarto-hub-mcp / quarto-sync-client / quarto-automerge-schema.
+    BuildHubMcpBundle {},
+
     /// Fresh-clone build orchestration.
     ///
     /// Runs the full build sequence in dependency order, serving as the source
@@ -224,7 +238,8 @@ enum Command {
     /// 2. hub-client build (includes WASM)
     /// 3. trace-viewer build (if present; Phase 4.3+)
     /// 4. q2-preview-spa build (if present; q2-preview Phase A.4)
-    /// 5. cargo build --workspace
+    /// 5. hub MCP bundle (q2-mcp embed artifact; bd-81cfshmw)
+    /// 6. cargo build --workspace
     BuildAll {
         /// Skip `npm install`.
         #[arg(long)]
@@ -241,6 +256,10 @@ enum Command {
         /// Skip the q2-preview-spa build.
         #[arg(long)]
         skip_q2_preview_spa_build: bool,
+
+        /// Skip the hub MCP bundle build.
+        #[arg(long)]
+        skip_hub_mcp_bundle: bool,
 
         /// Skip the Rust workspace build.
         #[arg(long)]
@@ -296,6 +315,7 @@ fn main() -> Result<()> {
             skip_treesitter_crlf_tests,
             skip_shared_package_tests,
             skip_q2_preview_spa_build,
+            skip_hub_mcp_tests,
             e2e,
             no_deny_warnings,
         } => {
@@ -310,6 +330,7 @@ fn main() -> Result<()> {
                 skip_treesitter_crlf_tests,
                 skip_shared_package_tests,
                 skip_q2_preview_spa_build,
+                skip_hub_mcp_tests,
                 include_e2e: e2e,
                 no_deny_warnings,
             };
@@ -318,11 +339,13 @@ fn main() -> Result<()> {
         Command::StageDocExamples {} => stage_doc_examples::run(),
         Command::BuildTraceViewer {} => build_trace_viewer::run(),
         Command::BuildQ2PreviewSpa {} => build_q2_preview_spa::run(),
+        Command::BuildHubMcpBundle {} => build_hub_mcp_bundle::run(),
         Command::BuildAll {
             skip_npm_install,
             skip_hub_build,
             skip_trace_viewer_build,
             skip_q2_preview_spa_build,
+            skip_hub_mcp_bundle,
             skip_rust_build,
             release,
         } => {
@@ -331,6 +354,7 @@ fn main() -> Result<()> {
                 skip_hub_build,
                 skip_trace_viewer_build,
                 skip_q2_preview_spa_build,
+                skip_hub_mcp_bundle,
                 skip_rust_build,
                 release,
             };

--- a/crates/xtask/src/verify.rs
+++ b/crates/xtask/src/verify.rs
@@ -13,8 +13,10 @@
 //! 9. Run trace-viewer tests
 //! 10. Run shared workspace-package tests (@quarto/preview-renderer +
 //!     @quarto/preview-runtime, both unit and integration)
-//! 11. Build q2-preview-spa placeholder
-//! 12. q2-preview-spa Playwright E2E (only when --e2e is set)
+//! 11. Run hub MCP package tests (quarto-sync-client + quarto-hub-mcp,
+//!     including the q2-mcp bundle smoke test)
+//! 12. Build q2-preview-spa placeholder
+//! 13. q2-preview-spa Playwright E2E (only when --e2e is set)
 
 use anyhow::{Context, Result, bail};
 use std::process::Command;
@@ -22,7 +24,7 @@ use std::process::Command;
 use crate::lint;
 use crate::test;
 
-const TOTAL_STEPS: u32 = 12;
+const TOTAL_STEPS: u32 = 13;
 
 /// Configuration for the verify command.
 pub struct VerifyConfig {
@@ -46,6 +48,8 @@ pub struct VerifyConfig {
     pub skip_shared_package_tests: bool,
     /// Skip the q2-preview-spa placeholder build.
     pub skip_q2_preview_spa_build: bool,
+    /// Skip the quarto-sync-client + quarto-hub-mcp package tests.
+    pub skip_hub_mcp_tests: bool,
     /// Run hub-client e2e tests (slower, requires browser).
     pub include_e2e: bool,
     /// Do not set RUSTFLAGS="-D warnings" (allows warnings during iteration).
@@ -65,6 +69,7 @@ impl Default for VerifyConfig {
             skip_treesitter_crlf_tests: false,
             skip_shared_package_tests: false,
             skip_q2_preview_spa_build: false,
+            skip_hub_mcp_tests: false,
             include_e2e: false,
             no_deny_warnings: false,
         }
@@ -364,7 +369,66 @@ pub fn run(config: &VerifyConfig) -> Result<()> {
         );
     }
 
-    // Step 11: Build q2-preview-spa placeholder
+    // Step 11: hub MCP package tests (bd-81cfshmw)
+    //
+    // quarto-sync-client + quarto-hub-mcp carry the MCP server that
+    // `q2 mcp` embeds, including stdio-hygiene regression tests and the
+    // bundle smoke test (which runs the esbuild bundler itself). Their
+    // vitest suites spawn the tsc build (dist/index.js) and resolve
+    // workspace deps through dist entries, so build in dependency
+    // order first.
+    let schema_dir = project_root.join("ts-packages/quarto-automerge-schema");
+    let sync_client_dir = project_root.join("ts-packages/quarto-sync-client");
+    let hub_mcp_dir = project_root.join("ts-packages/quarto-hub-mcp");
+    let have_hub_mcp = schema_dir.join("package.json").is_file()
+        && sync_client_dir.join("package.json").is_file()
+        && hub_mcp_dir.join("package.json").is_file();
+    if !config.skip_hub_mcp_tests && have_hub_mcp {
+        println!(
+            "\n━━━ Step 11/{}: Running hub MCP package tests ━━━\n",
+            TOTAL_STEPS
+        );
+        for (dir, what) in [
+            (&schema_dir, "quarto-automerge-schema build"),
+            (&sync_client_dir, "quarto-sync-client build"),
+            (&hub_mcp_dir, "quarto-hub-mcp build"),
+        ] {
+            run_command(
+                "npm",
+                &["run", "build"],
+                dir,
+                None,
+                &format!("{} failed", what),
+            )?;
+        }
+        run_command(
+            "npm",
+            &["test"],
+            &sync_client_dir,
+            None,
+            "quarto-sync-client tests failed",
+        )?;
+        run_command(
+            "npm",
+            &["test"],
+            &hub_mcp_dir,
+            None,
+            "quarto-hub-mcp tests failed",
+        )?;
+        println!("✓ hub MCP package tests complete");
+    } else if !have_hub_mcp {
+        println!(
+            "\n━━━ Step 11/{}: hub MCP packages not present, skipping ━━━\n",
+            TOTAL_STEPS
+        );
+    } else {
+        println!(
+            "\n━━━ Step 11/{}: Skipping hub MCP package tests ━━━\n",
+            TOTAL_STEPS
+        );
+    }
+
+    // Step 12: Build q2-preview-spa placeholder
     //
     // The SPA is the future host of `quarto preview` (bd-kw93). Today
     // it's a skeleton — building it confirms the cross-package boundary
@@ -374,7 +438,7 @@ pub fn run(config: &VerifyConfig) -> Result<()> {
     let have_q2_preview_spa = q2_preview_spa_dir.join("package.json").is_file();
     if !config.skip_q2_preview_spa_build && have_q2_preview_spa {
         println!(
-            "\n━━━ Step 11/{}: Building q2-preview-spa placeholder ━━━\n",
+            "\n━━━ Step 12/{}: Building q2-preview-spa placeholder ━━━\n",
             TOTAL_STEPS
         );
         run_command(
@@ -387,12 +451,12 @@ pub fn run(config: &VerifyConfig) -> Result<()> {
         println!("✓ q2-preview-spa build complete");
     } else if !have_q2_preview_spa {
         println!(
-            "\n━━━ Step 11/{}: q2-preview-spa/ not present, skipping ━━━\n",
+            "\n━━━ Step 12/{}: q2-preview-spa/ not present, skipping ━━━\n",
             TOTAL_STEPS
         );
     } else {
         println!(
-            "\n━━━ Step 11/{}: Skipping q2-preview-spa build ━━━\n",
+            "\n━━━ Step 12/{}: Skipping q2-preview-spa build ━━━\n",
             TOTAL_STEPS
         );
     }
@@ -407,7 +471,7 @@ pub fn run(config: &VerifyConfig) -> Result<()> {
     // (`npx playwright install chromium`).
     if config.include_e2e && have_q2_preview_spa {
         println!(
-            "\n━━━ Step 12/{}: Running q2-preview-spa Playwright E2E ━━━\n",
+            "\n━━━ Step 13/{}: Running q2-preview-spa Playwright E2E ━━━\n",
             TOTAL_STEPS
         );
         run_command(
@@ -425,7 +489,7 @@ pub fn run(config: &VerifyConfig) -> Result<()> {
             "--e2e not set"
         };
         println!(
-            "\n━━━ Step 12/{}: Skipping q2-preview-spa Playwright E2E ({}) ━━━\n",
+            "\n━━━ Step 13/{}: Skipping q2-preview-spa Playwright E2E ({}) ━━━\n",
             TOTAL_STEPS, reason
         );
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2043,6 +2043,448 @@
         "react": ">=16.8.0"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
@@ -12096,6 +12538,7 @@
         "@quarto/preview-renderer": "*",
         "@quarto/quarto-automerge-schema": "*",
         "@quarto/quarto-sync-client": "*",
+        "fast-diff": "^1.3.0",
         "web-tree-sitter": "^0.26.8"
       },
       "devDependencies": {
@@ -12129,10 +12572,15 @@
         "quarto-hub-mcp": "dist/index.js"
       },
       "devDependencies": {
+        "@automerge/automerge-repo": "^2.5.6",
+        "@automerge/automerge-repo-network-websocket": "^2.5.6",
         "@types/node": "^22.15.0",
+        "@types/ws": "^8.18.1",
+        "esbuild": "^0.28.0",
         "typescript": "~5.9.3",
         "undici": "^7.16.0",
-        "vitest": "^4.0.17"
+        "vitest": "^4.0.17",
+        "ws": "^8.21.0"
       }
     },
     "ts-packages/quarto-hub-mcp/node_modules/@types/node": {

--- a/ts-packages/quarto-hub-mcp/package.json
+++ b/ts-packages/quarto-hub-mcp/package.json
@@ -25,23 +25,29 @@
   ],
   "scripts": {
     "build": "tsc && chmod +x dist/index.js",
+    "bundle": "node scripts/bundle.mjs",
     "typecheck": "tsc --noEmit",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist dist-bundle",
     "test": "vitest run",
     "test:watch": "vitest"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",
     "@napi-rs/keyring": "^1.3.0",
-    "@quarto/quarto-sync-client": "*",
     "@quarto/quarto-automerge-schema": "*",
+    "@quarto/quarto-sync-client": "*",
     "jose": "^6.0.11",
     "oauth4webapi": "^3.5.5"
   },
   "devDependencies": {
+    "@automerge/automerge-repo": "^2.5.6",
+    "@automerge/automerge-repo-network-websocket": "^2.5.6",
     "@types/node": "^22.15.0",
+    "@types/ws": "^8.18.1",
+    "esbuild": "^0.28.0",
     "typescript": "~5.9.3",
     "undici": "^7.16.0",
-    "vitest": "^4.0.17"
+    "vitest": "^4.0.17",
+    "ws": "^8.21.0"
   }
 }

--- a/ts-packages/quarto-hub-mcp/scripts/bundle.mjs
+++ b/ts-packages/quarto-hub-mcp/scripts/bundle.mjs
@@ -1,0 +1,166 @@
+/**
+ * Bundle the hub MCP server into a self-contained directory:
+ *
+ *   dist-bundle/
+ *     index.mjs                      — the bundled server (esbuild)
+ *     build-info.json                — git commit + build time stamp
+ *     node_modules/@napi-rs/...      — the keyring native addon
+ *
+ * The output is consumed two ways:
+ *   - embedded into the `q2` binary (`q2 mcp` extracts + runs it), and
+ *   - published to npm as the npx channel (bd-3tak0lyy, future).
+ *
+ * Design notes (see claude-notes/plans/2026-06-11-q2-mcp-hub-auth.md):
+ *
+ * - `@napi-rs/keyring` is a native addon and stays EXTERNAL. We copy
+ *   the loader package plus the platform `.node` package(s) into a
+ *   mini node_modules inside the bundle dir, so node's normal
+ *   resolution (relative to index.mjs) finds them. This uses the
+ *   addon exactly as designed — no loader rewriting.
+ *
+ * - `@automerge/automerge`'s "node" export condition loads its wasm
+ *   via __dirname-relative readFileSync, which cannot survive
+ *   bundling. The "import" condition inlines the wasm as base64 and
+ *   bundles cleanly, so a resolve plugin steers the bare
+ *   `@automerge/automerge` import to the base64 entrypoint. `/slim`
+ *   subpath imports are left alone (they share the wasm singleton
+ *   the base64 entrypoint initializes).
+ *
+ * - The `source` condition makes esbuild compile our workspace deps
+ *   (`@quarto/quarto-sync-client`, `@quarto/quarto-automerge-schema`)
+ *   from their TypeScript sources, so the bundle can never embed a
+ *   stale workspace dist/.
+ *
+ * - CJS deps bundled into ESM output (e.g. `ws`) leave `require`
+ *   calls behind; the banner installs a createRequire shim.
+ */
+
+import * as esbuild from 'esbuild';
+import { execFileSync } from 'node:child_process';
+import {
+  cpSync,
+  mkdirSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+  existsSync,
+} from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pkgRoot = join(here, '..');
+const outDir = join(pkgRoot, 'dist-bundle');
+
+const NODE_TARGET = 'node24';
+
+// --- locate the automerge base64 entrypoint ---------------------------
+// `@automerge/automerge`'s exports map blocks subpath resolution, so we
+// resolve the package's node entrypoint and hop to its sibling file.
+const require = createRequire(import.meta.url);
+const fullfatNode = fileURLToPath(
+  import.meta.resolve('@automerge/automerge'),
+);
+const fullfatBase64 = join(dirname(fullfatNode), 'fullfat_base64.js');
+if (!existsSync(fullfatBase64)) {
+  throw new Error(
+    `automerge base64 entrypoint not found at ${fullfatBase64} — ` +
+      'the package layout changed; update scripts/bundle.mjs',
+  );
+}
+
+const automergeBase64Plugin = {
+  name: 'automerge-base64-entrypoint',
+  setup(build) {
+    build.onResolve({ filter: /^@automerge\/automerge$/ }, () => ({
+      path: fullfatBase64,
+    }));
+  },
+};
+
+// --- bundle ------------------------------------------------------------
+rmSync(outDir, { recursive: true, force: true });
+mkdirSync(outDir, { recursive: true });
+
+await esbuild.build({
+  entryPoints: [join(pkgRoot, 'src/index.ts')],
+  bundle: true,
+  platform: 'node',
+  format: 'esm',
+  target: NODE_TARGET,
+  outfile: join(outDir, 'index.mjs'),
+  conditions: ['source'],
+  external: ['@napi-rs/keyring'],
+  // NB: no shebang here — esbuild hoists the entry file's own shebang
+  // above the banner.
+  banner: {
+    js: [
+      "import { createRequire as __q2bundleCreateRequire } from 'node:module';",
+      'const require = __q2bundleCreateRequire(import.meta.url);',
+    ].join('\n'),
+  },
+  plugins: [automergeBase64Plugin],
+  logLevel: 'info',
+});
+
+// --- ship the keyring addon as a mini node_modules ---------------------
+// Copy the loader package plus every installed platform package. On a
+// normal dev machine that's exactly one platform; a CI machine staging
+// multiple platforms copies what it has.
+const napiSrcDir = join(
+  dirname(require.resolve('@napi-rs/keyring/package.json')),
+  '..',
+);
+const napiOutDir = join(outDir, 'node_modules', '@napi-rs');
+mkdirSync(napiOutDir, { recursive: true });
+const copied = [];
+for (const entry of readdirSync(napiSrcDir)) {
+  if (entry === 'keyring' || entry.startsWith('keyring-')) {
+    cpSync(join(napiSrcDir, entry), join(napiOutDir, entry), {
+      recursive: true,
+      dereference: true,
+    });
+    copied.push(entry);
+  }
+}
+if (!copied.includes('keyring') || copied.length < 2) {
+  throw new Error(
+    `expected @napi-rs/keyring plus at least one platform package, got: ${copied.join(', ')}`,
+  );
+}
+
+// --- build stamp --------------------------------------------------------
+// Diagnosability guard against the stale-embed trap: the launcher and
+// bug reports can always tell which source state a bundle came from.
+let gitCommit = 'unknown';
+let gitDirty = false;
+try {
+  gitCommit = execFileSync('git', ['rev-parse', 'HEAD'], {
+    cwd: pkgRoot,
+    encoding: 'utf8',
+  }).trim();
+  gitDirty =
+    execFileSync('git', ['status', '--porcelain'], {
+      cwd: pkgRoot,
+      encoding: 'utf8',
+    }).trim().length > 0;
+} catch {
+  // not a git checkout (e.g. building from an sdist) — stamp stays "unknown"
+}
+writeFileSync(
+  join(outDir, 'build-info.json'),
+  JSON.stringify(
+    {
+      gitCommit,
+      gitDirty,
+      builtAt: new Date().toISOString(),
+      nodeTarget: NODE_TARGET,
+      keyringPackages: copied.sort(),
+    },
+    null,
+    2,
+  ) + '\n',
+);
+
+console.log(`bundle written to ${outDir} (keyring: ${copied.sort().join(', ')})`);

--- a/ts-packages/quarto-hub-mcp/src/auth/auth-tools.ts
+++ b/ts-packages/quarto-hub-mcp/src/auth/auth-tools.ts
@@ -48,6 +48,7 @@ import {
 } from './loopback.js';
 import type { AuthServerProvider } from './oauth-config.js';
 import { generatePkceParams } from './pkce.js';
+import { issuerAllowsInsecureRequests } from './oauth-config.js';
 import { redactTokens } from './redact.js';
 import {
   type RefreshManager,
@@ -454,27 +455,25 @@ export class AuthToolsState {
       callbackParams,
       expectedState,
     );
-    const requestOpts = this.deps.fetch
-      ? ({ [oauth.customFetch]: this.deps.fetch } as const)
-      : undefined;
-    const resp = requestOpts
-      ? await oauth.authorizationCodeGrantRequest(
-          as,
-          client,
-          clientAuth,
-          validated,
-          redirectUri,
-          codeVerifier,
-          requestOpts,
-        )
-      : await oauth.authorizationCodeGrantRequest(
-          as,
-          client,
-          clientAuth,
-          validated,
-          redirectUri,
-          codeVerifier,
-        );
+    const requestOpts: {
+      [oauth.customFetch]?: typeof fetch;
+      [oauth.allowInsecureRequests]?: boolean;
+    } = {};
+    if (this.deps.fetch) requestOpts[oauth.customFetch] = this.deps.fetch;
+    // Loopback/dev IdPs over plain http (gated upstream by
+    // resolveIssuer) need oauth4webapi's explicit opt-in.
+    if (issuerAllowsInsecureRequests(as.issuer)) {
+      requestOpts[oauth.allowInsecureRequests] = true;
+    }
+    const resp = await oauth.authorizationCodeGrantRequest(
+      as,
+      client,
+      clientAuth,
+      validated,
+      redirectUri,
+      codeVerifier,
+      requestOpts,
+    );
     return await oauth.processAuthorizationCodeResponse(as, client, resp);
   }
 

--- a/ts-packages/quarto-hub-mcp/src/auth/oauth-config.test.ts
+++ b/ts-packages/quarto-hub-mcp/src/auth/oauth-config.test.ts
@@ -7,7 +7,13 @@
 
 import { describe, it, expect } from 'vitest';
 
-import { loadOAuthConfigFromEnv, MissingOAuthConfigError } from './oauth-config.js';
+import {
+  GOOGLE_ISSUER,
+  issuerAllowsInsecureRequests,
+  loadOAuthConfigFromEnv,
+  MissingOAuthConfigError,
+  resolveIssuer,
+} from './oauth-config.js';
 
 function envOnly(values: Record<string, string | undefined>): NodeJS.ProcessEnv {
   const e: NodeJS.ProcessEnv = {};
@@ -59,5 +65,63 @@ describe('loadOAuthConfigFromEnv', () => {
         envOnly({ QUARTO_HUB_MCP_CLIENT_ID: '  ', QUARTO_HUB_MCP_CLIENT_SECRET: 'sec' }),
       ),
     ).toThrowError(/QUARTO_HUB_MCP_CLIENT_ID/);
+  });
+});
+
+describe('resolveIssuer', () => {
+  it('defaults to Google when unset', () => {
+    expect(resolveIssuer(envOnly({}))).toBe(GOOGLE_ISSUER);
+  });
+
+  it('accepts an https issuer override', () => {
+    expect(resolveIssuer(envOnly({ QUARTO_HUB_MCP_ISSUER: 'https://idp.example.com' }))).toBe(
+      'https://idp.example.com',
+    );
+  });
+
+  it('treats empty / whitespace as unset', () => {
+    expect(resolveIssuer(envOnly({ QUARTO_HUB_MCP_ISSUER: '  ' }))).toBe(GOOGLE_ISSUER);
+  });
+
+  it('accepts an http loopback issuer only with the insecure escape hatch', () => {
+    expect(
+      resolveIssuer(
+        envOnly({
+          QUARTO_HUB_MCP_ISSUER: 'http://127.0.0.1:9999',
+          QUARTO_HUB_MCP_ALLOW_INSECURE_AUTH: '1',
+        }),
+      ),
+    ).toBe('http://127.0.0.1:9999');
+  });
+
+  it('rejects an http loopback issuer without the escape hatch, naming it', () => {
+    expect(() =>
+      resolveIssuer(envOnly({ QUARTO_HUB_MCP_ISSUER: 'http://127.0.0.1:9999' })),
+    ).toThrowError(/QUARTO_HUB_MCP_ALLOW_INSECURE_AUTH/);
+  });
+
+  it('rejects an http non-loopback issuer even with the escape hatch', () => {
+    expect(() =>
+      resolveIssuer(
+        envOnly({
+          QUARTO_HUB_MCP_ISSUER: 'http://idp.example.com',
+          QUARTO_HUB_MCP_ALLOW_INSECURE_AUTH: '1',
+        }),
+      ),
+    ).toThrowError(/https/i);
+  });
+
+  it('rejects garbage and non-http(s) schemes', () => {
+    expect(() => resolveIssuer(envOnly({ QUARTO_HUB_MCP_ISSUER: 'not a url' }))).toThrowError();
+    expect(() =>
+      resolveIssuer(envOnly({ QUARTO_HUB_MCP_ISSUER: 'ftp://idp.example.com' })),
+    ).toThrowError();
+  });
+});
+
+describe('issuerAllowsInsecureRequests', () => {
+  it('is false for https issuers and true for http ones', () => {
+    expect(issuerAllowsInsecureRequests('https://accounts.google.com')).toBe(false);
+    expect(issuerAllowsInsecureRequests('http://127.0.0.1:9999')).toBe(true);
   });
 });

--- a/ts-packages/quarto-hub-mcp/src/auth/oauth-config.ts
+++ b/ts-packages/quarto-hub-mcp/src/auth/oauth-config.ts
@@ -15,6 +15,8 @@
 
 import * as oauth from 'oauth4webapi';
 
+import { isLoopbackHost } from '../connection-manager.js';
+
 // ---------------------------------------------------------------------------
 // Typed errors
 // ---------------------------------------------------------------------------
@@ -37,6 +39,11 @@ export interface OAuthEnvConfig {
 
 const CLIENT_ID_VAR = 'QUARTO_HUB_MCP_CLIENT_ID';
 const CLIENT_SECRET_VAR = 'QUARTO_HUB_MCP_CLIENT_SECRET';
+const ISSUER_VAR = 'QUARTO_HUB_MCP_ISSUER';
+const ALLOW_INSECURE_VAR = 'QUARTO_HUB_MCP_ALLOW_INSECURE_AUTH';
+
+/** The default identity provider. */
+export const GOOGLE_ISSUER = 'https://accounts.google.com';
 
 function readNonEmpty(env: NodeJS.ProcessEnv, name: string): string | undefined {
   const v = env[name];
@@ -63,6 +70,53 @@ export function loadOAuthConfigFromEnv(
   return { clientId: clientId!, clientSecret: clientSecret! };
 }
 
+/**
+ * Resolve the OIDC issuer: `QUARTO_HUB_MCP_ISSUER` env override, else
+ * Google. Hubs configure their IdP with `--oidc-issuer`; this is the
+ * client-side counterpart, so an MCP client can match a non-Google
+ * hub. An `http://` issuer (mock IdPs, local dev) is allowed only for
+ * loopback hosts AND with `QUARTO_HUB_MCP_ALLOW_INSECURE_AUTH=1` —
+ * the same escape hatch, and the same loopback restriction, as the
+ * connection manager's insecure-transport gate.
+ */
+export function resolveIssuer(env: NodeJS.ProcessEnv = process.env): string {
+  const raw = readNonEmpty(env, ISSUER_VAR);
+  if (raw === undefined) return GOOGLE_ISSUER;
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new Error(`${ISSUER_VAR} is not a valid URL: ${JSON.stringify(raw)}`);
+  }
+  if (url.protocol === 'https:') return raw;
+  if (url.protocol !== 'http:') {
+    throw new Error(`${ISSUER_VAR} must be an https:// URL, got ${JSON.stringify(raw)}`);
+  }
+  if (!isLoopbackHost(url.hostname)) {
+    throw new Error(
+      `${ISSUER_VAR} must be an https:// URL for non-loopback hosts ` +
+        `(got ${JSON.stringify(raw)}); plain http is allowed only for ` +
+        `127.0.0.1 / localhost development issuers.`,
+    );
+  }
+  if (env[ALLOW_INSECURE_VAR] !== '1') {
+    throw new Error(
+      `${ISSUER_VAR} is a plain-http loopback issuer; set ` +
+        `${ALLOW_INSECURE_VAR}=1 to allow it (dev/test only).`,
+    );
+  }
+  return raw;
+}
+
+/**
+ * Whether oauth4webapi calls against this issuer need the
+ * `allowInsecureRequests` option. Only ever true for issuers that
+ * passed `resolveIssuer`'s loopback + escape-hatch gate.
+ */
+export function issuerAllowsInsecureRequests(issuer: string): boolean {
+  return new URL(issuer).protocol === 'http:';
+}
+
 // ---------------------------------------------------------------------------
 // AuthorizationServer discovery (cached)
 // ---------------------------------------------------------------------------
@@ -83,7 +137,12 @@ export async function discoverAuthorizationServer(
 ): Promise<oauth.AuthorizationServer> {
   if (cachedAS && cachedAS.issuer === issuer) return cachedAS.as;
   const url = new URL(issuer);
-  const requestOpts = opts?.fetch ? { [oauth.customFetch]: opts.fetch } : undefined;
+  const requestOpts: {
+    [oauth.customFetch]?: typeof fetch;
+    [oauth.allowInsecureRequests]?: boolean;
+  } = {};
+  if (opts?.fetch) requestOpts[oauth.customFetch] = opts.fetch;
+  if (issuerAllowsInsecureRequests(issuer)) requestOpts[oauth.allowInsecureRequests] = true;
   const resp = await oauth.discoveryRequest(url, requestOpts);
   const as = await oauth.processDiscoveryResponse(url, resp);
   cachedAS = { issuer, as };

--- a/ts-packages/quarto-hub-mcp/src/auth/refresh-manager.ts
+++ b/ts-packages/quarto-hub-mcp/src/auth/refresh-manager.ts
@@ -40,6 +40,8 @@
 import { decodeJwt } from 'jose';
 import * as oauth from 'oauth4webapi';
 
+import { issuerAllowsInsecureRequests } from './oauth-config.js';
+
 import {
   type CredentialBundle,
   type CredentialStore,
@@ -190,26 +192,26 @@ export class RefreshManager {
     const as = await this.deps.authServer();
     const client: oauth.Client = { client_id: this.deps.config.clientId };
     const clientAuth = oauth.ClientSecretPost(this.deps.config.clientSecret);
-    const requestOpts = this.deps.fetch
-      ? ({ [oauth.customFetch]: this.deps.fetch } as const)
-      : undefined;
+    const requestOpts: {
+      [oauth.customFetch]?: typeof fetch;
+      [oauth.allowInsecureRequests]?: boolean;
+    } = {};
+    if (this.deps.fetch) requestOpts[oauth.customFetch] = this.deps.fetch;
+    // Loopback/dev IdPs over plain http (gated upstream by
+    // resolveIssuer) need oauth4webapi's explicit opt-in.
+    if (issuerAllowsInsecureRequests(as.issuer)) {
+      requestOpts[oauth.allowInsecureRequests] = true;
+    }
 
     let tokens: oauth.TokenEndpointResponse;
     try {
-      const resp = requestOpts
-        ? await oauth.refreshTokenGrantRequest(
-            as,
-            client,
-            clientAuth,
-            bundle.refreshToken,
-            requestOpts,
-          )
-        : await oauth.refreshTokenGrantRequest(
-            as,
-            client,
-            clientAuth,
-            bundle.refreshToken,
-          );
+      const resp = await oauth.refreshTokenGrantRequest(
+        as,
+        client,
+        clientAuth,
+        bundle.refreshToken,
+        requestOpts,
+      );
       tokens = await oauth.processRefreshTokenResponse(as, client, resp);
     } catch (err) {
       if (err instanceof oauth.ResponseBodyError) {

--- a/ts-packages/quarto-hub-mcp/src/bundle.test.ts
+++ b/ts-packages/quarto-hub-mcp/src/bundle.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Smoke test for the self-contained bundle (`npm run bundle`).
+ *
+ * The bundle is what `q2 mcp` embeds and what the npx channel ships
+ * (bd-81cfshmw / bd-3tak0lyy), so it must work with NOTHING from this
+ * repo on disk: the test builds it, copies it to a temp dir outside
+ * the repo tree (no node_modules anywhere up the path), and drives it
+ * with plain `node` — keyring addon resolution via the bundle's mini
+ * node_modules, base64-inlined automerge wasm, full MCP round-trip
+ * against an in-process sync peer, stdout purity, and stdin-EOF exit.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFileSync, spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { McpTestClient } from './mcp-test-client.js';
+import { startTestHub, type TestHub } from './test-hub.js';
+
+const pkgRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+let tmpDir: string;
+let bundleEntry: string;
+let hub: TestHub;
+
+beforeAll(async () => {
+  execFileSync('node', [path.join(pkgRoot, 'scripts/bundle.mjs')], {
+    stdio: 'pipe',
+  });
+  // os.tmpdir() is outside the repo: node resolution from the copied
+  // bundle cannot accidentally reach the workspace node_modules.
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hub-mcp-bundle-test-'));
+  fs.cpSync(path.join(pkgRoot, 'dist-bundle'), path.join(tmpDir, 'bundle'), {
+    recursive: true,
+  });
+  bundleEntry = path.join(tmpDir, 'bundle', 'index.mjs');
+  hub = await startTestHub();
+}, 60000);
+
+afterAll(async () => {
+  await hub?.stop();
+  if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('bundle smoke', () => {
+  it('ships the expected artifacts', () => {
+    const bundleDir = path.join(tmpDir, 'bundle');
+    expect(fs.existsSync(path.join(bundleDir, 'index.mjs'))).toBe(true);
+    const info = JSON.parse(
+      fs.readFileSync(path.join(bundleDir, 'build-info.json'), 'utf8'),
+    ) as { gitCommit: string; nodeTarget: string; keyringPackages: string[] };
+    expect(info.nodeTarget).toBe('node24');
+    expect(info.keyringPackages).toContain('keyring');
+    expect(info.keyringPackages.length).toBeGreaterThanOrEqual(2);
+    // the keyring loader package plus at least one platform addon
+    const napiDir = path.join(bundleDir, 'node_modules', '@napi-rs');
+    expect(fs.readdirSync(napiDir)).toContain('keyring');
+  });
+
+  it('prints --help (stderr, stdout stays pure) and exits 0 from outside the repo', () => {
+    const res = spawnSync('node', [bundleEntry, '--help'], {
+      cwd: tmpDir,
+      encoding: 'utf8',
+    });
+    expect(res.status).toBe(0);
+    // package convention: even pre-protocol output avoids stdout
+    expect(res.stdout).toBe('');
+    expect(res.stderr).toContain('--server');
+  });
+
+  it('full MCP round-trip from outside the repo: create, patch, read', async () => {
+    const client = new McpTestClient();
+    try {
+      await client.start(['--server', hub.url], { entry: bundleEntry });
+
+      const tools = (await client.listTools()).map((t) => t.name);
+      expect(tools).toContain('connect_project');
+      expect(tools).toContain('patch_file');
+
+      const created = await client.callTool('create_project', {
+        files: [{ path: 'smoke.qmd', content: 'bundle smoke ÄöÜ → 🧪\n' }],
+      });
+      const { indexDocId } = JSON.parse(created.content[0]!.text) as {
+        indexDocId: string;
+      };
+      expect(indexDocId).toBeTruthy();
+
+      await client.callTool('connect_project', { project: indexDocId });
+      await client.callTool('patch_file', {
+        project: indexDocId,
+        path: 'smoke.qmd',
+        old_string: 'bundle smoke',
+        new_string: 'bundle smoke (patched)',
+      });
+      const readBack = await client.callTool('read_file', {
+        project: indexDocId,
+        path: 'smoke.qmd',
+      });
+      expect(readBack.content[0]!.text).toContain('bundle smoke (patched) ÄöÜ → 🧪');
+
+      // stdout purity holds for the bundled artifact too
+      expect(client.stdoutPollution).toEqual([]);
+      // ...and so does stdin-EOF shutdown
+      expect(await client.endStdinAndWaitForExit(5000)).toBe(true);
+    } finally {
+      await client.stop();
+    }
+  }, 30000);
+});

--- a/ts-packages/quarto-hub-mcp/src/connection-manager.test.ts
+++ b/ts-packages/quarto-hub-mcp/src/connection-manager.test.ts
@@ -106,7 +106,12 @@ function seededAuth(opts?: { initialToken?: string }): SeededAuth {
 
 interface SyncClientCallSpy {
   factory: (cbs: SyncClientCallbacks) => SyncClient;
-  connectCalls: Array<{ url: string; indexDocId: string; auth: unknown }>;
+  connectCalls: Array<{
+    url: string;
+    indexDocId: string;
+    auth: unknown;
+    options: Record<string, unknown>;
+  }>;
   createCalls: Array<{ url: string; auth: unknown }>;
 }
 
@@ -122,10 +127,22 @@ function spySyncClientFactory(): SyncClientCallSpy {
           _actorId?: string,
           _screenName?: string,
           _color?: string,
-          _peerTimeoutMs?: number,
-          auth?: unknown,
+          peerTimeoutMsOrOptions?: number | Record<string, unknown>,
+          positionalAuth?: unknown,
         ) => {
-          connectCalls.push({ url: syncServerUrl, indexDocId, auth });
+          // The manager passes the ConnectOptions bag (auth +
+          // requireOnline + peerTimeoutMs, bd-xnmd5ni1); the legacy
+          // positional auth is still captured for contract coverage.
+          const options =
+            typeof peerTimeoutMsOrOptions === 'object' && peerTimeoutMsOrOptions !== null
+              ? peerTimeoutMsOrOptions
+              : {};
+          connectCalls.push({
+            url: syncServerUrl,
+            indexDocId,
+            auth: (options as { auth?: unknown }).auth ?? positionalAuth,
+            options,
+          });
           // Pretend a file came in so callbacks don't choke.
           cbs.onFileAdded?.('test.qmd', { type: 'text', text: '' });
           return [];
@@ -277,6 +294,9 @@ describe('ConnectionManager with creds', () => {
     await expect(passed!.getBearer()).resolves.toBe('initial-id-token');
     expect(auth.getValid).toHaveBeenCalled();
     expect(mgr.lastObservedAuthMode()).toBe('requires-auth');
+    // Server-backed clients demand a live peer (bd-xnmd5ni1).
+    expect(sync.connectCalls[0]!.options['requireOnline']).toBe(true);
+    expect(sync.connectCalls[0]!.options['peerTimeoutMs']).toBeGreaterThan(1000);
   });
 
   it('handles 401-then-refresh-then-200 with one extra probe', async () => {

--- a/ts-packages/quarto-hub-mcp/src/connection-manager.ts
+++ b/ts-packages/quarto-hub-mcp/src/connection-manager.ts
@@ -25,6 +25,7 @@
 
 import {
   createSyncClient,
+  type DisconnectOptions,
   type SyncClient,
   type SyncClientCallbacks,
   type FilePayload,
@@ -281,11 +282,38 @@ export class ConnectionManager {
     return state;
   }
 
-  async disconnectAll(): Promise<void> {
-    const disconnects = Array.from(this.projects.values()).map((s) =>
-      s.client.disconnect(),
+  /**
+   * Disconnect every project. Pass `drainMs` at shutdown so outbound
+   * document sync gets a bounded window to reach the hub before the
+   * process exits — MCP clients run on memory storage, so anything
+   * undelivered at exit is lost (bd-10deu8h4, the 2026-06-12
+   * incident). Projects drain in parallel; the wall-clock bound is a
+   * single budget, not budget × projects.
+   *
+   * Loud on failure, never silent: every project that could not
+   * confirm delivery gets a stderr line naming the project and the
+   * possibly-lost paths (stdout is protocol — bd-sl4o01y0).
+   */
+  async disconnectAll(options?: DisconnectOptions): Promise<void> {
+    const results = await Promise.all(
+      Array.from(this.projects.entries()).map(async ([indexDocId, s]) => ({
+        indexDocId,
+        report: await s.client.disconnect(options),
+      })),
     );
-    await Promise.all(disconnects);
+    for (const { indexDocId, report } of results) {
+      if (!report.drained) {
+        const names = report.undelivered
+          .map((u) => u.path ?? `<index document ${u.docId}>`)
+          .join(', ');
+        console.error(
+          `[hub-mcp] WARNING: exiting before outbound sync completed for ` +
+            `project ${indexDocId}. Possibly NOT delivered to the hub ` +
+            `(and lost — this server keeps no local copy): ${names}. ` +
+            `Verify these documents on the hub before trusting them.`,
+        );
+      }
+    }
     this.projects.clear();
   }
 

--- a/ts-packages/quarto-hub-mcp/src/connection-manager.ts
+++ b/ts-packages/quarto-hub-mcp/src/connection-manager.ts
@@ -120,6 +120,13 @@ function toHttpUrl(wsUrl: URL): URL {
 // ConnectionManager
 // ---------------------------------------------------------------------------
 
+/**
+ * Peer-wait budget for connect/create (bd-xnmd5ni1). Generous because
+ * the authenticated path runs several HTTP round-trips (health probe,
+ * /auth/actor, possibly a token refresh) before the websocket joins.
+ */
+const PEER_TIMEOUT_MS = 15_000;
+
 export class ConnectionManager {
   private readonly serverUrl: string;
   private readonly serverUrlParsed: URL;
@@ -196,15 +203,16 @@ export class ConnectionManager {
     const client = this.syncClientFactory(callbacks);
     // Pass auth iff we resolved a Bearer; otherwise the sync-client
     // uses the browser adapter (no header).
-    await client.connect(
-      this.serverUrl,
-      indexDocId,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
+    await client.connect(this.serverUrl, indexDocId, undefined, undefined, undefined, {
       auth,
-    );
+      // Server-backed client with memory storage: offline mode would
+      // be a silent data black hole — demand a live peer or fail
+      // loudly (bd-xnmd5ni1). The budget covers the auth round-trips
+      // (health probe, actor fetch, token refresh) that made the old
+      // 1 ms default lose deterministically.
+      requireOnline: true,
+      peerTimeoutMs: PEER_TIMEOUT_MS,
+    });
 
     const state: ProjectState = { client, files };
     this.projects.set(indexDocId, state);
@@ -246,6 +254,10 @@ export class ConnectionManager {
         contentType: 'text' as const,
       })),
       auth,
+      // See connect(): online-or-error, never a silent offline project
+      // that dies with the process (bd-xnmd5ni1).
+      requireOnline: true,
+      peerTimeoutMs: PEER_TIMEOUT_MS,
     });
 
     const state: ProjectState = { client, files: tempFiles };

--- a/ts-packages/quarto-hub-mcp/src/dangling-entries.test.ts
+++ b/ts-packages/quarto-hub-mcp/src/dangling-entries.test.ts
@@ -1,0 +1,143 @@
+/**
+ * MCP-level graceful degradation for dangling index entries
+ * (bd-vm5e5u10).
+ *
+ * Production evidence (2026-06-12): one index entry pointing at a
+ * document that never reached the hub made `connect_project` fail for
+ * the whole Demo Playground. Required behavior at the tool surface:
+ *
+ *  - `connect_project` / `list_files` succeed and list the dangling
+ *    file with `"status": "unavailable"`;
+ *  - `read_file` of the dangling file is a clear per-file error
+ *    naming the path; the project stays connected and other files
+ *    keep working;
+ *  - `delete_file` of the dangling entry works (it only edits the
+ *    index) — the self-service repair that the 2026-06-12 incident
+ *    needed manual surgery for.
+ *
+ * Drives the real server binary (dist/index.js) over stdio against
+ * the in-process test hub; the ghost entry is minted by mutating the
+ * project index through the hub's own repo handle.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import {
+  generateAutomergeUrl,
+  parseAutomergeUrl,
+  type DocumentId,
+} from '@automerge/automerge-repo';
+
+import { McpTestClient } from './mcp-test-client.js';
+import { startTestHub, type TestHub } from './test-hub.js';
+
+describe('dangling index entries at the MCP tool surface', () => {
+  let hub: TestHub;
+  let client: McpTestClient;
+  let indexDocId: string;
+  let ghostId: string;
+
+  beforeAll(async () => {
+    hub = await startTestHub();
+
+    // Create the project through one MCP server instance...
+    const creator = new McpTestClient();
+    await creator.start(['--server', hub.url]);
+    const created = await creator.callTool('create_project', {
+      files: [
+        { path: 'real-one.qmd', content: 'first real file\n' },
+        { path: 'real-two.qmd', content: 'second real file\n' },
+      ],
+    });
+    expect(created.isError).not.toBe(true);
+    const parsed = JSON.parse(created.content[0]!.text) as {
+      indexDocId: string;
+      files: Array<{ path: string; docId: string }>;
+    };
+    indexDocId = parsed.indexDocId;
+
+    // ...wait until the hub actually holds every document (creation
+    // syncs in the background), then retire the creator.
+    expect(await hub.hubHasDoc(indexDocId, 8000)).toBe(true);
+    for (const f of parsed.files) {
+      expect(await hub.hubHasDoc(f.docId, 8000)).toBe(true);
+    }
+    await creator.stop();
+
+    // Mint the dangling entry: a valid-format doc id no repo holds.
+    ghostId = parseAutomergeUrl(generateAutomergeUrl()).documentId;
+    const handle = await hub.repo.find<{ files: Record<string, string> }>(
+      indexDocId as DocumentId,
+    );
+    handle.change((d) => {
+      d.files['ghost.qmd'] = ghostId;
+    });
+
+    // A fresh server instance does the cold connect (the incident path).
+    client = new McpTestClient();
+    await client.start(['--server', hub.url]);
+  }, 60000);
+
+  afterAll(async () => {
+    await client?.stop();
+    await hub.stop();
+  });
+
+  it('connect_project succeeds and marks the ghost unavailable', async () => {
+    // RED today: the tool returns `Error in connect_project:
+    // Document automerge:… is unavailable`.
+    const result = await client.callTool('connect_project', { project: indexDocId });
+    expect(result.isError).not.toBe(true);
+
+    const payload = JSON.parse(result.content[0]!.text) as {
+      project: string;
+      files: Array<{ path: string; type?: string; status?: string; docId?: string }>;
+    };
+    expect(payload.files.map((f) => f.path).sort()).toEqual([
+      'ghost.qmd',
+      'real-one.qmd',
+      'real-two.qmd',
+    ]);
+
+    const ghost = payload.files.find((f) => f.path === 'ghost.qmd')!;
+    expect(ghost.status).toBe('unavailable');
+    expect(ghost.docId).toBe(ghostId);
+
+    for (const real of ['real-one.qmd', 'real-two.qmd']) {
+      const entry = payload.files.find((f) => f.path === real)!;
+      expect(entry.type).toBe('text');
+      expect(entry.status).not.toBe('unavailable');
+    }
+  }, 60000);
+
+  it('read_file of the ghost errors naming the path; real files still read', async () => {
+    const ghostRead = await client.callTool('read_file', {
+      project: indexDocId,
+      path: 'ghost.qmd',
+    });
+    expect(ghostRead.isError).toBe(true);
+    expect(ghostRead.content[0]!.text).toContain("'ghost.qmd'");
+    expect(ghostRead.content[0]!.text).toContain('unavailable');
+
+    // The project stays connected and usable in the same session.
+    const realRead = await client.callTool('read_file', {
+      project: indexDocId,
+      path: 'real-one.qmd',
+    });
+    expect(realRead.isError).not.toBe(true);
+    expect(realRead.content[0]!.text).toBe('first real file\n');
+  }, 60000);
+
+  it('delete_file of the ghost succeeds and removes the index entry', async () => {
+    const deleted = await client.callTool('delete_file', {
+      project: indexDocId,
+      path: 'ghost.qmd',
+    });
+    expect(deleted.isError).not.toBe(true);
+    expect(deleted.content[0]!.text).toContain('ghost.qmd');
+
+    const listed = await client.callTool('list_files', { project: indexDocId });
+    expect(listed.isError).not.toBe(true);
+    const files = JSON.parse(listed.content[0]!.text) as Array<{ path: string }>;
+    expect(files.map((f) => f.path).sort()).toEqual(['real-one.qmd', 'real-two.qmd']);
+  }, 60000);
+});

--- a/ts-packages/quarto-hub-mcp/src/e2e-auth.test.ts
+++ b/ts-packages/quarto-hub-mcp/src/e2e-auth.test.ts
@@ -1,0 +1,291 @@
+/**
+ * Full-stack auth e2e (bd-81cfshmw Phase 3): real hub binary, real
+ * loopback listener, real OS keyring, real `q2 mcp` launcher — only
+ * the IdP is a mock (test-idp.ts), and even it mints real RS256 JWTs
+ * that the hub verifies against its JWKS.
+ *
+ * Flow under test:
+ *   1. unauthenticated tool call against an auth-enabled hub fails
+ *      with a sign-in hint;
+ *   2. `authenticate` runs the loopback+PKCE flow — the test scrapes
+ *      the authorization URL from server stderr and plays the role of
+ *      the browser (a fake `open` on PATH keeps the real one closed);
+ *   3. authenticated `create_project` / `read_file` work over Bearer
+ *      websocket;
+ *   4. a SECOND process — the real `q2 mcp` launcher when its embed is
+ *      fresh, else the dist build — reuses the keyring credential
+ *      without re-authenticating (the npx/q2 channels share
+ *      credentials by design);
+ *   5. short-TTL ID tokens (45s < the 60s early-refresh window) force
+ *      refresh grants, observed at the IdP;
+ *   6. `authenticate_clear` revokes at the IdP and empties the keyring.
+ *
+ * Gating (skips loudly, never fails, when):
+ *   - target/debug/hub is missing (cargo build -p quarto-hub);
+ *   - the OS keyring is unusable (headless CI without a keychain);
+ *   - for the q2-launcher channel only: target/debug/q2 is missing or
+ *     its embedded bundle is a placeholder / from a different commit
+ *     (cargo xtask build-hub-mcp-bundle && cargo build --bin q2).
+ *
+ * macOS-first (Carlos, 2026-06-11); the fake-`open` shim is unix-only.
+ * Keyring hygiene: entries live under service 'dev.quarto.hub-mcp'
+ * with account '<issuer>:<clientId>'; the issuer embeds an ephemeral
+ * port, so afterAll deletes the entry — a crashed run can leak one
+ * keychain entry for a 127.0.0.1 issuer (harmless, garbage account).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFileSync, spawn, spawnSync, type ChildProcess } from 'node:child_process';
+import { once } from 'node:events';
+import * as fs from 'node:fs';
+import * as net from 'node:net';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { AsyncEntry } from '@napi-rs/keyring';
+
+import { McpTestClient } from './mcp-test-client.js';
+import { startTestIdp, type TestIdp } from './test-idp.js';
+
+const pkgRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const repoRoot = path.resolve(pkgRoot, '..', '..');
+const hubBin = path.join(repoRoot, 'target', 'debug', 'hub');
+const q2Bin = path.join(repoRoot, 'target', 'debug', 'q2');
+
+const CLIENT_ID = 'q2-e2e-test-client.local';
+const CLIENT_SECRET = 'q2-e2e-test-secret';
+const EMAIL = 'tester@example.com';
+const KEYRING_SERVICE = 'dev.quarto.hub-mcp';
+
+// ---------------------------------------------------------------------------
+// Gates (module-level await: vitest test files are ESM)
+// ---------------------------------------------------------------------------
+
+const hubAvailable = fs.existsSync(hubBin) && process.platform !== 'win32';
+
+async function keyringUsable(): Promise<boolean> {
+  try {
+    const probe = new AsyncEntry(KEYRING_SERVICE, `e2e-probe-${process.pid}`);
+    await probe.setPassword('probe');
+    await probe.deletePassword();
+    return true;
+  } catch {
+    return false;
+  }
+}
+const keyringOk = hubAvailable ? await keyringUsable() : false;
+
+const runSuite = hubAvailable && keyringOk;
+if (!runSuite) {
+  // eslint-disable-next-line no-console
+  console.error(
+    `[e2e-auth] SKIPPING: ${!hubAvailable ? `hub binary missing at ${hubBin} (cargo build -p quarto-hub) or non-unix` : 'OS keyring unusable in this environment'}`,
+  );
+}
+
+/** q2-channel gate: embed must be real and from the current commit. */
+function q2EmbedFresh(): { ok: boolean; reason: string } {
+  if (!fs.existsSync(q2Bin)) return { ok: false, reason: `q2 binary missing at ${q2Bin}` };
+  const info = spawnSync(q2Bin, ['mcp', '--launcher-info'], { encoding: 'utf8' });
+  if (info.status !== 0) return { ok: false, reason: `launcher-info failed: ${info.stderr}` };
+  if (info.stdout.includes('PLACEHOLDER')) {
+    return {
+      ok: false,
+      reason: 'q2 embeds the placeholder bundle (cargo xtask build-hub-mcp-bundle && cargo build --bin q2)',
+    };
+  }
+  const m = info.stdout.match(/"gitCommit":\s*"([0-9a-f]+)"/);
+  const head = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: repoRoot, encoding: 'utf8' }).trim();
+  if (!m || m[1] !== head) {
+    return {
+      ok: false,
+      reason: `q2 embed is from commit ${m?.[1] ?? '?'} but HEAD is ${head} — rebuild (cargo xtask build-hub-mcp-bundle && cargo build --bin q2)`,
+    };
+  }
+  return { ok: true, reason: '' };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function freePort(): Promise<number> {
+  const srv = net.createServer();
+  srv.listen(0, '127.0.0.1');
+  await once(srv, 'listening');
+  const port = (srv.address() as net.AddressInfo).port;
+  srv.close();
+  await once(srv, 'close');
+  return port;
+}
+
+async function waitForHealth(url: string, timeoutMs = 20000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let lastErr: unknown;
+  while (Date.now() < deadline) {
+    try {
+      // Any HTTP answer means the hub is up: an auth-enabled hub
+      // serves 401 on /health to unauthenticated probes (that 401 is
+      // exactly how the connection manager detects auth mode).
+      const resp = await fetch(url);
+      if (resp.status < 500) return;
+      lastErr = `HTTP ${resp.status}`;
+    } catch (err) {
+      lastErr = err;
+    }
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  throw new Error(`hub did not answer at ${url}: ${lastErr}`);
+}
+
+function makeFakeOpenShim(dir: string): void {
+  const shim = path.join(dir, 'open');
+  fs.writeFileSync(shim, '#!/bin/sh\nexit 0\n');
+  fs.chmodSync(shim, 0o755);
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe.runIf(runSuite)('auth e2e (real hub + keyring + loopback)', () => {
+  let idp: TestIdp;
+  let hub: ChildProcess;
+  let hubUrl: string;
+  let tmpDir: string;
+  let serverEnv: NodeJS.ProcessEnv;
+  let keyringAccount: string;
+  let projectId: string;
+
+  beforeAll(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'q2-e2e-auth-'));
+    const shimDir = path.join(tmpDir, 'bin');
+    fs.mkdirSync(shimDir);
+    makeFakeOpenShim(shimDir);
+
+    // 45s TTL: inside the refresh manager's 60s early-refresh window,
+    // so every authenticated use forces a refresh grant.
+    idp = await startTestIdp({
+      clientId: CLIENT_ID,
+      clientSecret: CLIENT_SECRET,
+      email: EMAIL,
+      idTokenTtlSecs: 45,
+    });
+    keyringAccount = `${idp.issuer}:${CLIENT_ID}`;
+    // Defensive: a crashed previous run can't have this exact account
+    // (ephemeral port), but clear anyway in case of port reuse.
+    await new AsyncEntry(KEYRING_SERVICE, keyringAccount).deletePassword().catch(() => {});
+
+    const hubPort = await freePort();
+    hubUrl = `ws://127.0.0.1:${hubPort}/ws`;
+    hub = spawn(
+      hubBin,
+      [
+        '--data-dir', path.join(tmpDir, 'hub-data'),
+        '-P', String(hubPort),
+        '-H', '127.0.0.1',
+        '--oidc-client-id', CLIENT_ID,
+        '--oidc-issuer', idp.issuer,
+        '--allowed-emails', EMAIL,
+        '--allow-insecure-auth',
+        // Hub-side auth audit trail when debugging (DEBUG_MCP=1).
+        ...(process.env['DEBUG_MCP'] ? ['-vv'] : []),
+      ],
+      { stdio: ['ignore', 'ignore', process.env['DEBUG_MCP'] ? 'inherit' : 'ignore'] },
+    );
+    await waitForHealth(`http://127.0.0.1:${hubPort}/health`);
+
+    serverEnv = {
+      ...process.env,
+      PATH: `${shimDir}:${process.env['PATH'] ?? ''}`,
+      QUARTO_HUB_MCP_CLIENT_ID: CLIENT_ID,
+      QUARTO_HUB_MCP_CLIENT_SECRET: CLIENT_SECRET,
+      QUARTO_HUB_MCP_ISSUER: idp.issuer,
+      QUARTO_HUB_MCP_ALLOW_INSECURE_AUTH: '1',
+    };
+  }, 60000);
+
+  afterAll(async () => {
+    hub?.kill();
+    await idp?.stop();
+    await new AsyncEntry(KEYRING_SERVICE, keyringAccount).deletePassword().catch(() => {});
+    if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('authenticates via loopback, works over Bearer, shares the keyring across channels, clears', async () => {
+    // ── channel A: the dist server ────────────────────────────────
+    const a = new McpTestClient();
+    try {
+      await a.start(['--server', hubUrl], { env: serverEnv });
+
+      // 1. Before auth: tool calls fail with a sign-in hint.
+      const before = await a.callTool('create_project', { files: [] });
+      expect(before.content[0]!.text).toMatch(/authenticate|sign.?in|auth/i);
+
+      // 2. authenticate — we are the browser.
+      const authPromise = a.callTool('authenticate', {});
+      const urlLine = await a.waitForStderr(/open this URL to sign in: /, 15000);
+      const authUrl = urlLine.slice(urlLine.indexOf('http'));
+      const browserResp = await fetch(authUrl); // follows the 302 to the loopback
+      expect(browserResp.ok).toBe(true);
+      const authResult = await authPromise;
+      expect(authResult.content[0]!.text).toContain(EMAIL);
+      expect(idp.counters.codeExchanges).toBe(1);
+
+      // 3. Authenticated writes + reads over Bearer ws.
+      const created = await a.callTool('create_project', {
+        files: [{ path: 'auth-e2e.qmd', content: '---\ntitle: Auth e2e\n---\n\nBearer ws ✓\n' }],
+      });
+      const createdText = created.content[0]!.text;
+      expect(createdText, createdText).toContain('indexDocId');
+      projectId = (JSON.parse(createdText) as { indexDocId: string }).indexDocId;
+
+      const read = await a.callTool('read_file', { project: projectId, path: 'auth-e2e.qmd' });
+      expect(read.content[0]!.text).toContain('Bearer ws ✓');
+
+      // 4. The 45s TTL forces refresh grants on use.
+      expect(idp.counters.refreshGrants).toBeGreaterThanOrEqual(1);
+
+      // Keyring now holds the credential.
+      const stored = await new AsyncEntry(KEYRING_SERVICE, keyringAccount).getPassword();
+      expect(stored).toBeTruthy();
+      expect(a.stdoutPollution).toEqual([]);
+    } finally {
+      await a.stop();
+    }
+
+    // ── channel B: a separate process reuses the credential ───────
+    // Prefer the real `q2 mcp` launcher; fall back to the dist build
+    // (still a fresh process == still proves keyring reuse) when the
+    // embed is stale, so the credential-sharing assertion always runs.
+    const fresh = q2EmbedFresh();
+    if (!fresh.ok) {
+      // eslint-disable-next-line no-console
+      console.error(`[e2e-auth] q2-launcher channel unavailable (${fresh.reason}); using dist build for channel B`);
+    }
+    const exchangesBeforeB = idp.counters.codeExchanges;
+    const b = new McpTestClient();
+    try {
+      await b.start(['--server', hubUrl], {
+        env: serverEnv,
+        ...(fresh.ok ? { command: { program: q2Bin, args: ['mcp'] } } : {}),
+      });
+
+      // No authenticate call: the keyring credential must carry it.
+      const connected = await b.callTool('connect_project', { project: projectId });
+      expect(connected.content[0]!.text).toContain('auth-e2e.qmd');
+      const read = await b.callTool('read_file', { project: projectId, path: 'auth-e2e.qmd' });
+      expect(read.content[0]!.text).toContain('Bearer ws ✓');
+      expect(idp.counters.codeExchanges).toBe(exchangesBeforeB); // no new sign-in
+
+      // 6. Clear: revokes at the IdP, empties the keyring.
+      const cleared = await b.callTool('authenticate_clear', {});
+      expect(cleared.content[0]!.text).toMatch(/clear|revok/i);
+      expect(idp.counters.revokedTokens.length).toBeGreaterThanOrEqual(1);
+      const after = await new AsyncEntry(KEYRING_SERVICE, keyringAccount).getPassword();
+      expect(after).toBeNull();
+    } finally {
+      await b.stop();
+    }
+  }, 90000);
+});

--- a/ts-packages/quarto-hub-mcp/src/exit-drain.test.ts
+++ b/ts-packages/quarto-hub-mcp/src/exit-drain.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Exit-drain at the stdio level (bd-10deu8h4) — the exact 2026-06-12
+ * accident, replayed against the real server binary.
+ *
+ * The incident: a `q2 mcp` session ran `create_project`, read the file
+ * back from process memory, and the host closed stdin. The stdin-EOF
+ * shutdown (bd-9jq2a060, correct behavior) ran `disconnectAll()` and
+ * exited before the new file document's sync to the hub completed. The
+ * index entry escaped; the file document's only copy died with the
+ * process (MCP clients use memory storage) — a dangling index entry
+ * that bricked the project for every client.
+ *
+ * Contract under test: shutdown drains outbound sync (bounded) before
+ * `process.exit`, while preserving the prompt stdin-EOF exit that
+ * stdio-hygiene.test.ts asserts. Ground truth is the hub's own repo.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+
+import { McpTestClient } from './mcp-test-client.js';
+import { startTestHub, type TestHub } from './test-hub.js';
+
+// Enough payload to keep delivery genuinely in flight when stdin
+// closes right after the tool result — a single tiny file wins the
+// race by luck on loopback, masking the defect. Both levers matter:
+// many docs (per-doc synchronizer backlog) and real bytes (encode +
+// send time).
+const FILE_COUNT = 64;
+const FILE_BYTES = 64 * 1024;
+
+function accidentFiles() {
+  return Array.from({ length: FILE_COUNT }, (_, i) => ({
+    path: `q2-mcp-hello-${i}.qmd`,
+    content: `file ${i}\n${'x'.repeat(FILE_BYTES)}\n`,
+  }));
+}
+
+interface CreateProjectResponse {
+  indexDocId: string;
+  files: Array<{ path: string; docId: string }>;
+}
+
+describe('exit drains outbound sync (bd-10deu8h4)', () => {
+  let hub: TestHub;
+  let client: McpTestClient;
+
+  beforeAll(async () => {
+    hub = await startTestHub();
+  });
+
+  afterAll(async () => {
+    await hub.stop();
+  });
+
+  afterEach(async () => {
+    await client.stop();
+  });
+
+  it('create_project then immediate stdin EOF must not lose the created docs', async () => {
+    client = new McpTestClient();
+    await client.start(['--server', hub.url]);
+
+    const result = await client.callTool('create_project', {
+      files: accidentFiles(),
+    });
+    const created = JSON.parse(result.content[0]!.text) as CreateProjectResponse;
+    expect(created.files).toHaveLength(FILE_COUNT);
+
+    // The exact accident: the host closes stdin right after the tool
+    // call returns. The server must still exit promptly (bd-9jq2a060)…
+    expect(await client.endStdinAndWaitForExit(5000)).toBe(true);
+
+    // …but not before the created documents reached the hub.
+    expect(
+      await hub.hubHasDoc(created.indexDocId),
+      'index doc must reach the hub',
+    ).toBe(true);
+    for (const f of created.files) {
+      expect(
+        await hub.hubHasDoc(f.docId),
+        `file doc for ${f.path} must reach the hub — its only copy was in-process`,
+      ).toBe(true);
+    }
+  }, 30000);
+});

--- a/ts-packages/quarto-hub-mcp/src/exit-drain.test.ts
+++ b/ts-packages/quarto-hub-mcp/src/exit-drain.test.ts
@@ -82,4 +82,37 @@ describe('exit drains outbound sync (bd-10deu8h4)', () => {
       ).toBe(true);
     }
   }, 30000);
+
+  it('warns loudly on stderr (and still exits promptly) when the hub is gone at shutdown', async () => {
+    // Own hub — this test kills it mid-session.
+    const doomedHub = await startTestHub();
+    client = new McpTestClient();
+    await client.start(['--server', doomedHub.url]);
+
+    const result = await client.callTool('create_project', {
+      files: [{ path: 'survives.qmd', content: 'created while the hub was up\n' }],
+    });
+    const created = JSON.parse(result.content[0]!.text) as CreateProjectResponse;
+
+    // Hub dies; a file is created during the outage. Its only copy is
+    // now in this server process's memory.
+    await doomedHub.stop();
+    await client.callTool('create_file', {
+      project: created.indexDocId,
+      path: 'doomed.qmd',
+      content: 'created while the hub was down\n',
+    });
+
+    // Shutdown must not hang past the drain budget (3 s < the 5 s
+    // promptness contract)…
+    expect(await client.endStdinAndWaitForExit(5000)).toBe(true);
+
+    // …and must name the project and the possibly-lost path on stderr.
+    const warning = client.stderrLines.find((l) =>
+      l.includes('Possibly NOT delivered'),
+    );
+    expect(warning, 'shutdown must warn about undelivered documents').toBeDefined();
+    expect(warning).toContain(created.indexDocId);
+    expect(warning).toContain('doomed.qmd');
+  }, 30000);
 });

--- a/ts-packages/quarto-hub-mcp/src/index.test.ts
+++ b/ts-packages/quarto-hub-mcp/src/index.test.ts
@@ -2,11 +2,15 @@
  * `--redirect-port` validation. The kernel-pick default is reached by
  * *omitting* the flag, so `0` and the rest of the privileged range are
  * rejected; a stable SSH-tunnel port must be non-privileged.
+ *
+ * `parseArgs` server-URL resolution: flag > env > canonical default
+ * (wss://quarto-hub.com/ws — decided 2026-06-11, bd-81cfshmw plan
+ * resolved question 3; the "easy path" for `q2 mcp` and npx users).
  */
 
 import { describe, it, expect } from 'vitest';
 
-import { parseRedirectPort } from './index.js';
+import { DEFAULT_SERVER_URL, parseArgs, parseRedirectPort } from './index.js';
 
 describe('parseRedirectPort', () => {
   it('accepts the bottom of the non-privileged range', () => {
@@ -39,5 +43,32 @@ describe('parseRedirectPort', () => {
   it('rejects non-numeric input', () => {
     expect(() => parseRedirectPort('abc')).toThrowError(/integer/);
     expect(() => parseRedirectPort('80.5')).toThrowError(/integer/);
+  });
+});
+
+describe('parseArgs server URL resolution', () => {
+  const argv = (...rest: string[]) => ['node', 'index.js', ...rest];
+
+  it('defaults to the canonical quarto-hub.com sync server', () => {
+    const parsed = parseArgs(argv(), {});
+    expect(parsed.serverUrl).toBe(DEFAULT_SERVER_URL);
+    expect(DEFAULT_SERVER_URL).toBe('wss://quarto-hub.com/ws');
+  });
+
+  it('--server overrides the default', () => {
+    const parsed = parseArgs(argv('--server', 'ws://127.0.0.1:3000/ws'), {});
+    expect(parsed.serverUrl).toBe('ws://127.0.0.1:3000/ws');
+  });
+
+  it('QUARTO_HUB_SERVER overrides the default', () => {
+    const parsed = parseArgs(argv(), { QUARTO_HUB_SERVER: 'wss://other.example/ws' });
+    expect(parsed.serverUrl).toBe('wss://other.example/ws');
+  });
+
+  it('--server beats QUARTO_HUB_SERVER', () => {
+    const parsed = parseArgs(argv('--server', 'wss://flag.example/ws'), {
+      QUARTO_HUB_SERVER: 'wss://env.example/ws',
+    });
+    expect(parsed.serverUrl).toBe('wss://flag.example/ws');
   });
 });

--- a/ts-packages/quarto-hub-mcp/src/index.ts
+++ b/ts-packages/quarto-hub-mcp/src/index.ts
@@ -15,8 +15,13 @@
  *   QUARTO_HUB_SERVER              - Sync server URL (overridden by --server)
  *   QUARTO_HUB_MCP_CLIENT_ID       - Operator-supplied Google OAuth client id
  *   QUARTO_HUB_MCP_CLIENT_SECRET   - Operator-supplied matching client secret
+ *   QUARTO_HUB_MCP_ISSUER          - OIDC issuer URL (default:
+ *                                    https://accounts.google.com). http://
+ *                                    only for loopback issuers, and only with
+ *                                    the insecure escape hatch below.
  *   QUARTO_HUB_MCP_ALLOW_INSECURE_AUTH - "1" to allow Bearer over plain HTTP
- *                                        to non-loopback hosts (dev only)
+ *                                        to non-loopback hosts, and plain-http
+ *                                        loopback issuers (dev only)
  */
 
 import { realpathSync } from 'node:fs';
@@ -34,11 +39,10 @@ import {
   discoverAuthorizationServer,
   loadOAuthConfigFromEnv,
   MissingOAuthConfigError,
+  resolveIssuer,
 } from './auth/oauth-config.js';
 import { redactTokens } from './auth/redact.js';
 import { RefreshManager } from './auth/refresh-manager.js';
-
-const GOOGLE_ISSUER = 'https://accounts.google.com';
 
 /**
  * Canonical Quarto Hub sync server — the default when neither
@@ -175,11 +179,22 @@ async function main(): Promise<void> {
   let refreshManager: RefreshManager | undefined;
   let flowConfig: ReturnType<typeof loadOAuthConfigFromEnv> | undefined;
 
-  // Lazy, memoized discovery: defers the Google network call off the
+  // IdP issuer: QUARTO_HUB_MCP_ISSUER override (validated: https, or
+  // gated loopback http) with Google as the default. Fail fast and
+  // named on bad config.
+  let issuer: string;
+  try {
+    issuer = resolveIssuer();
+  } catch (err) {
+    console.error(`[hub-mcp] ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  }
+
+  // Lazy, memoized discovery: defers the IdP network call off the
   // startup path so a slow/unreachable discovery endpoint can't stop the
   // server from coming up (no-auth hubs and reads don't need it). Fires
   // on the first refresh / sign-in that actually requires it.
-  const authServer = () => discoverAuthorizationServer(GOOGLE_ISSUER);
+  const authServer = () => discoverAuthorizationServer(issuer);
 
   if (hasAuthEnv) {
     try {
@@ -193,7 +208,7 @@ async function main(): Promise<void> {
     }
 
     credentialStore = new CredentialStore({
-      issuer: GOOGLE_ISSUER,
+      issuer,
       clientId: flowConfig.clientId,
     });
     refreshManager = new RefreshManager({
@@ -233,7 +248,7 @@ async function main(): Promise<void> {
           flowConfig: {
             clientId: flowConfig.clientId,
             clientSecret: flowConfig.clientSecret,
-            issuer: GOOGLE_ISSUER,
+            issuer,
             redirectPort,
           },
           authServer,

--- a/ts-packages/quarto-hub-mcp/src/index.ts
+++ b/ts-packages/quarto-hub-mcp/src/index.ts
@@ -260,13 +260,22 @@ async function main(): Promise<void> {
   const transport = new StdioServerTransport();
   await server.connect(transport);
 
+  // Outbound-sync drain budget at shutdown (bd-10deu8h4): created
+  // documents live only in this process's memory until the hub acks
+  // them, so exit must give delivery a bounded window. The drain
+  // returns early the moment the hub confirms; the budget only binds
+  // when the hub is slow or unreachable. 3 s keeps the stdin-EOF exit
+  // comfortably inside the 5 s promptness contract that
+  // stdio-hygiene.test.ts asserts (bd-9jq2a060).
+  const SHUTDOWN_DRAIN_MS = 3000;
+
   let shuttingDown = false;
   const shutdown = async (): Promise<void> => {
     // Re-entrancy guard: server.close() below fires server.onclose,
     // which routes back here.
     if (shuttingDown) return;
     shuttingDown = true;
-    await manager.disconnectAll();
+    await manager.disconnectAll({ drainMs: SHUTDOWN_DRAIN_MS });
     await server.close();
     process.exit(0);
   };

--- a/ts-packages/quarto-hub-mcp/src/index.ts
+++ b/ts-packages/quarto-hub-mcp/src/index.ts
@@ -40,6 +40,13 @@ import { RefreshManager } from './auth/refresh-manager.js';
 
 const GOOGLE_ISSUER = 'https://accounts.google.com';
 
+/**
+ * Canonical Quarto Hub sync server — the default when neither
+ * `--server` nor `QUARTO_HUB_SERVER` is given (bd-81cfshmw plan,
+ * resolved question 3: the "easy path" for `q2 mcp` / npx users).
+ */
+export const DEFAULT_SERVER_URL = 'wss://quarto-hub.com/ws';
+
 interface ParsedArgs {
   serverUrl: string;
   readOnly: boolean;
@@ -70,8 +77,11 @@ export function parseRedirectPort(raw: string): number {
   return port;
 }
 
-function parseArgs(argv: string[]): ParsedArgs {
-  let serverUrl = process.env['QUARTO_HUB_SERVER'] ?? '';
+export function parseArgs(
+  argv: string[],
+  env: NodeJS.ProcessEnv = process.env,
+): ParsedArgs {
+  let serverUrl = env['QUARTO_HUB_SERVER'] ?? '';
   let readOnly = false;
   let redirectPort: number | undefined;
 
@@ -89,10 +99,11 @@ function parseArgs(argv: string[]): ParsedArgs {
         process.exit(1);
       }
     } else if (arg === '--help' || arg === '-h') {
-      console.error(`Usage: quarto-hub-mcp --server <url> [--read-only] [--redirect-port <N>]
+      console.error(`Usage: quarto-hub-mcp [--server <url>] [--read-only] [--redirect-port <N>]
 
 Options:
-  --server <url>        Automerge sync server URL (or set QUARTO_HUB_SERVER)
+  --server <url>        Automerge sync server URL (or set QUARTO_HUB_SERVER).
+                        Default: wss://quarto-hub.com/ws
   --read-only           Only expose read tools (no write/create/delete)
   --redirect-port <N>   Fixed loopback port for the sign-in redirect
                         (1024-65535). Omit to let the OS pick one. Set a
@@ -107,8 +118,7 @@ Options:
   }
 
   if (!serverUrl) {
-    console.error('Error: --server <url> or QUARTO_HUB_SERVER is required');
-    process.exit(1);
+    serverUrl = DEFAULT_SERVER_URL;
   }
 
   return { serverUrl, readOnly, redirectPort };

--- a/ts-packages/quarto-hub-mcp/src/index.ts
+++ b/ts-packages/quarto-hub-mcp/src/index.ts
@@ -19,6 +19,7 @@
  *                                        to non-loopback hosts (dev only)
  */
 
+import { realpathSync } from 'node:fs';
 import { pathToFileURL } from 'node:url';
 
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
@@ -139,8 +140,8 @@ function installRedactingErrorHandlers(): void {
  * calls `console.log` — rebind console.log itself to stderr. The
  * transport is unaffected: it writes to `process.stdout` directly.
  *
- * Called after parseArgs so `--help` (pre-protocol, conventional)
- * still prints to stdout.
+ * Called after parseArgs, which is pre-protocol (its --help/usage
+ * output already goes to stderr by this package's convention).
  */
 function protectProtocolStdout(): void {
   setSyncLogger((...args) => console.error(...args));
@@ -261,10 +262,21 @@ async function main(): Promise<void> {
 }
 
 // Run only when executed as the binary, not when imported (e.g. by
-// unit tests exercising `parseRedirectPort`).
-const invokedDirectly =
-  process.argv[1] !== undefined &&
-  import.meta.url === pathToFileURL(process.argv[1]).href;
+// unit tests exercising `parseRedirectPort`). argv[1] must be
+// canonicalized before comparing: Node resolves import.meta.url
+// through realpath, so a symlink anywhere in the invocation path
+// (macOS /tmp and /var, npm/npx .bin shims) would otherwise make this
+// guard silently skip main() (bd-2d8ur7e9).
+const invokedDirectly = (() => {
+  const argv1 = process.argv[1];
+  if (argv1 === undefined) return false;
+  try {
+    return import.meta.url === pathToFileURL(realpathSync(argv1)).href;
+  } catch {
+    // argv[1] doesn't resolve to a real file — we can't be it.
+    return false;
+  }
+})();
 
 if (invokedDirectly) {
   main().catch((err) => {

--- a/ts-packages/quarto-hub-mcp/src/index.ts
+++ b/ts-packages/quarto-hub-mcp/src/index.ts
@@ -234,13 +234,30 @@ async function main(): Promise<void> {
   const transport = new StdioServerTransport();
   await server.connect(transport);
 
+  let shuttingDown = false;
   const shutdown = async (): Promise<void> => {
+    // Re-entrancy guard: server.close() below fires server.onclose,
+    // which routes back here.
+    if (shuttingDown) return;
+    shuttingDown = true;
     await manager.disconnectAll();
     await server.close();
     process.exit(0);
   };
   process.on('SIGINT', shutdown);
   process.on('SIGTERM', shutdown);
+  // MCP hosts terminate stdio servers by closing stdin — but the SDK's
+  // StdioServerTransport never watches for EOF (its onclose only fires
+  // on programmatic close), and live sync websockets / reconnect
+  // timers keep the event loop alive forever, leaking one process per
+  // agent session (bd-9jq2a060). Watch stdin EOF ourselves; also wire
+  // server.onclose so a programmatic transport close shuts down too.
+  process.stdin.on('end', () => {
+    void shutdown();
+  });
+  server.onclose = () => {
+    void shutdown();
+  };
 }
 
 // Run only when executed as the binary, not when imported (e.g. by

--- a/ts-packages/quarto-hub-mcp/src/index.ts
+++ b/ts-packages/quarto-hub-mcp/src/index.ts
@@ -23,6 +23,7 @@ import { pathToFileURL } from 'node:url';
 
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { setSyncLogger } from '@quarto/quarto-sync-client';
 
 import { ConnectionManager } from './connection-manager.js';
 import { registerTools } from './tools.js';
@@ -131,9 +132,25 @@ function installRedactingErrorHandlers(): void {
   });
 }
 
+/**
+ * Once the JSON-RPC transport owns stdout, nothing else may write to
+ * it (bd-sl4o01y0). Route sync-client diagnostics to stderr via its
+ * logger seam, and — defense in depth against any dependency that
+ * calls `console.log` — rebind console.log itself to stderr. The
+ * transport is unaffected: it writes to `process.stdout` directly.
+ *
+ * Called after parseArgs so `--help` (pre-protocol, conventional)
+ * still prints to stdout.
+ */
+function protectProtocolStdout(): void {
+  setSyncLogger((...args) => console.error(...args));
+  console.log = (...args: unknown[]) => console.error(...args);
+}
+
 async function main(): Promise<void> {
   installRedactingErrorHandlers();
   const { serverUrl, readOnly, redirectPort } = parseArgs(process.argv);
+  protectProtocolStdout();
 
   // Optional auth bootstrap: if both env vars are set we wire up the
   // credential store + refresh manager + auth tools; if not, we run

--- a/ts-packages/quarto-hub-mcp/src/mcp-test-client.ts
+++ b/ts-packages/quarto-hub-mcp/src/mcp-test-client.ts
@@ -35,9 +35,13 @@ export class McpTestClient {
 
   /**
    * Start the MCP server process with the given arguments.
+   *
+   * `entry` overrides the server entry point (default: the tsc build
+   * at dist/index.js) — used by bundle tests to drive the esbuild
+   * artifact from outside the repo tree.
    */
-  async start(args: string[]): Promise<void> {
-    this.proc = spawn('node', [SERVER_ENTRY, ...args], {
+  async start(args: string[], opts?: { entry?: string }): Promise<void> {
+    this.proc = spawn('node', [opts?.entry ?? SERVER_ENTRY, ...args], {
       stdio: ['pipe', 'pipe', 'pipe'],
     });
 

--- a/ts-packages/quarto-hub-mcp/src/mcp-test-client.ts
+++ b/ts-packages/quarto-hub-mcp/src/mcp-test-client.ts
@@ -26,6 +26,14 @@ export class McpTestClient {
   private nextId = 1;
 
   /**
+   * Every stdout line that failed to parse as JSON-RPC. In a correct
+   * stdio MCP server this stays empty: stdout belongs exclusively to
+   * the protocol, and any stray write here corrupts the stream for
+   * real clients.
+   */
+  readonly stdoutPollution: string[] = [];
+
+  /**
    * Start the MCP server process with the given arguments.
    */
   async start(args: string[]): Promise<void> {
@@ -56,6 +64,23 @@ export class McpTestClient {
 
     // Send initialized notification
     this.sendNotification('notifications/initialized');
+  }
+
+  /**
+   * Close the server's stdin (how MCP hosts terminate stdio servers)
+   * and report whether the process exited within `timeoutMs`. Unlike
+   * `stop()`, does NOT kill the process on timeout — callers assert on
+   * the result and then call `stop()` to clean up.
+   */
+  async endStdinAndWaitForExit(timeoutMs = 5000): Promise<boolean> {
+    if (!this.proc) throw new Error('server not started');
+    if (this.proc.exitCode !== null) return true;
+    const exited = once(this.proc, 'exit').then(() => true);
+    this.proc.stdin!.end();
+    const timedOut = new Promise<boolean>((resolve) =>
+      setTimeout(() => resolve(false), timeoutMs),
+    );
+    return Promise.race([exited, timedOut]);
   }
 
   /**
@@ -163,7 +188,8 @@ export class McpTestClient {
             for (const w of waiters) w();
           }
         } catch {
-          // Ignore unparseable lines
+          // Not JSON-RPC: record as protocol pollution (see field doc).
+          this.stdoutPollution.push(line);
         }
       }
     }

--- a/ts-packages/quarto-hub-mcp/src/mcp-test-client.ts
+++ b/ts-packages/quarto-hub-mcp/src/mcp-test-client.ts
@@ -33,16 +33,31 @@ export class McpTestClient {
    */
   readonly stdoutPollution: string[] = [];
 
+  /** Server stderr, line by line (diagnostics; the auth e2e scrapes
+   * the sign-in URL from here). */
+  readonly stderrLines: string[] = [];
+  private stderrBuffer = '';
+
   /**
    * Start the MCP server process with the given arguments.
    *
    * `entry` overrides the server entry point (default: the tsc build
    * at dist/index.js) — used by bundle tests to drive the esbuild
-   * artifact from outside the repo tree.
+   * artifact from outside the repo tree. `command` (+ leading args)
+   * replaces `node` entirely — used by the auth e2e to drive the real
+   * `q2 mcp` launcher. `env` REPLACES the child environment when
+   * given (callers spread process.env themselves if they want it).
    */
-  async start(args: string[], opts?: { entry?: string }): Promise<void> {
-    this.proc = spawn('node', [opts?.entry ?? SERVER_ENTRY, ...args], {
+  async start(
+    args: string[],
+    opts?: { entry?: string; command?: { program: string; args: string[] }; env?: NodeJS.ProcessEnv },
+  ): Promise<void> {
+    const [program, leading] = opts?.command
+      ? [opts.command.program, opts.command.args]
+      : ['node', [opts?.entry ?? SERVER_ENTRY]];
+    this.proc = spawn(program, [...leading, ...args], {
       stdio: ['pipe', 'pipe', 'pipe'],
+      ...(opts?.env ? { env: opts.env } : {}),
     });
 
     this.proc.stdout!.setEncoding('utf-8');
@@ -53,6 +68,12 @@ export class McpTestClient {
 
     this.proc.stderr!.setEncoding('utf-8');
     this.proc.stderr!.on('data', (chunk: string) => {
+      this.stderrBuffer += chunk;
+      let nl;
+      while ((nl = this.stderrBuffer.indexOf('\n')) >= 0) {
+        this.stderrLines.push(this.stderrBuffer.slice(0, nl));
+        this.stderrBuffer = this.stderrBuffer.slice(nl + 1);
+      }
       // Suppress stderr noise in tests unless debugging
       if (process.env['DEBUG_MCP']) {
         process.stderr.write(`[mcp-stderr] ${chunk}`);
@@ -68,6 +89,25 @@ export class McpTestClient {
 
     // Send initialized notification
     this.sendNotification('notifications/initialized');
+  }
+
+  /**
+   * Wait until a stderr line matching `pattern` appears (scanning
+   * lines already received too) and return the first match.
+   */
+  async waitForStderr(pattern: RegExp, timeoutMs = 10000): Promise<string> {
+    const deadline = Date.now() + timeoutMs;
+    let scanned = 0;
+    while (Date.now() < deadline) {
+      for (; scanned < this.stderrLines.length; scanned++) {
+        const line = this.stderrLines[scanned]!;
+        if (pattern.test(line)) return line;
+      }
+      await new Promise((r) => setTimeout(r, 25));
+    }
+    throw new Error(
+      `timed out waiting for stderr matching ${pattern}; saw:\n${this.stderrLines.join('\n')}`,
+    );
   }
 
   /**

--- a/ts-packages/quarto-hub-mcp/src/require-online.test.ts
+++ b/ts-packages/quarto-hub-mcp/src/require-online.test.ts
@@ -1,0 +1,59 @@
+/**
+ * bd-xnmd5ni1: the MCP server must never fabricate success in offline
+ * mode. Its sync clients use in-memory storage, so an "offline"
+ * project lives only in process memory and dies with the session —
+ * `create_project` used to return an indexDocId for a project the hub
+ * never received whenever the websocket lost the (1 ms!) peer-wait
+ * race, which auth latency made deterministic.
+ *
+ * The hub here answers /health but destroys websocket upgrades:
+ * exactly the reachable-HTTP / unreachable-sync split that used to
+ * produce the silent offline fallback.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import { McpTestClient } from './mcp-test-client.js';
+import { startTestHub, type TestHub } from './test-hub.js';
+
+describe('requireOnline through the MCP server', () => {
+  let hub: TestHub;
+  let client: McpTestClient;
+
+  beforeAll(async () => {
+    hub = await startTestHub({ acceptWs: false });
+  });
+
+  afterAll(async () => {
+    await hub.stop();
+  });
+
+  afterEach(async () => {
+    await client.stop();
+  });
+
+  it('create_project fails loudly when the sync endpoint is unreachable', async () => {
+    client = new McpTestClient();
+    await client.start(['--server', hub.url]);
+
+    const result = await client.callTool('create_project', {
+      files: [{ path: 'doomed.qmd', content: 'never syncs\n' }],
+    });
+    const text = result.content[0]!.text;
+    expect(text).toMatch(/^Error/);
+    expect(text).toMatch(/no peer connection|refusing to continue offline/i);
+    // The old behavior fabricated an indexDocId; that must be gone.
+    expect(text).not.toContain('indexDocId');
+  }, 30000);
+
+  it('connect_project fails loudly when the sync endpoint is unreachable', async () => {
+    client = new McpTestClient();
+    await client.start(['--server', hub.url]);
+
+    const result = await client.callTool('connect_project', {
+      project: 'badc0ffee0ddf00d',
+    });
+    const text = result.content[0]!.text;
+    expect(text).toMatch(/^Error/);
+    expect(text).toMatch(/no peer connection|refusing to continue offline/i);
+  }, 30000);
+});

--- a/ts-packages/quarto-hub-mcp/src/stdio-hygiene.test.ts
+++ b/ts-packages/quarto-hub-mcp/src/stdio-hygiene.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Stdio-protocol hygiene for the MCP server (bd-sl4o01y0, bd-9jq2a060).
+ *
+ * A stdio MCP server has two hard contracts with its host:
+ *
+ *  1. stdout carries exclusively JSON-RPC frames — any stray
+ *     `console.log` (ours or a dependency's) corrupts the protocol.
+ *  2. The server exits when the host closes its stdin — that is how
+ *     MCP hosts (Claude Desktop, Claude Code, Cursor) terminate
+ *     servers; a process that lingers leaks once per session.
+ *
+ * Both tests drive the real server binary against an in-process sync
+ * peer (see test-hub.ts): `create_project` only reaches the sync
+ * machinery (peer-wait logging, live websockets, reconnect timers)
+ * when a peer actually answers — an unreachable URL fails fast at the
+ * health probe and exercises neither bug.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import { McpTestClient } from './mcp-test-client.js';
+import { startTestHub, type TestHub } from './test-hub.js';
+
+describe('stdio hygiene', () => {
+  let hub: TestHub;
+  let client: McpTestClient;
+
+  beforeAll(async () => {
+    hub = await startTestHub();
+  });
+
+  afterAll(async () => {
+    await hub.stop();
+  });
+
+  afterEach(async () => {
+    await client.stop();
+  });
+
+  it('emits nothing but JSON-RPC on stdout while sync-client is active', async () => {
+    client = new McpTestClient();
+    await client.start(['--server', hub.url]);
+
+    // Triggers sync-client's peer-wait / project-creation code paths,
+    // which historically wrote progress lines to stdout.
+    const result = await client.callTool('create_project', {
+      files: [{ path: 'hygiene.qmd', content: 'stdout purity probe\n' }],
+    });
+    expect(result.content[0]!.text).toBeTruthy();
+
+    expect(client.stdoutPollution).toEqual([]);
+  }, 30000);
+
+  it('exits on stdin EOF while sync connections are live', async () => {
+    client = new McpTestClient();
+    await client.start(['--server', hub.url]);
+
+    // Ensure the event loop has more than the stdio transport keeping
+    // it alive: live websocket reconnect timers from the sync client.
+    await client.callTool('create_project', {
+      files: [{ path: 'linger.qmd', content: 'stdin EOF probe\n' }],
+    });
+
+    expect(await client.endStdinAndWaitForExit(5000)).toBe(true);
+  }, 30000);
+});

--- a/ts-packages/quarto-hub-mcp/src/symlink-invocation.test.ts
+++ b/ts-packages/quarto-hub-mcp/src/symlink-invocation.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Regression test for bd-2d8ur7e9: the server must start when invoked
+ * through a symlinked path.
+ *
+ * Node's ESM loader canonicalizes `import.meta.url` through realpath,
+ * but `process.argv[1]` is whatever path the invoker used. The
+ * am-I-the-entry-module guard in index.ts compared the two without
+ * canonicalizing argv[1], so any symlink in the invocation path made
+ * the process load modules and exit 0 without ever starting the
+ * server. This is not exotic: macOS `/tmp` and `/var` are symlinks
+ * into `/private`, and npm/npx `.bin` shims are symlinks — the npx
+ * distribution channel would not have worked at all.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const pkgRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const realEntry = path.join(pkgRoot, 'dist', 'index.js');
+
+let tmpDir: string;
+let symlinkEntry: string;
+
+beforeAll(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hub-mcp-symlink-test-'));
+  symlinkEntry = path.join(tmpDir, 'linked-index.js');
+  fs.symlinkSync(realEntry, symlinkEntry);
+});
+
+afterAll(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('symlinked invocation', () => {
+  it('still reaches main() (prints --help usage rather than silently exiting)', () => {
+    const res = spawnSync('node', [symlinkEntry, '--help'], { encoding: 'utf8' });
+    expect(res.status).toBe(0);
+    // Before the fix this was '' — the entry guard mismatched and the
+    // process exited without running main() at all.
+    expect(res.stderr).toContain('--server');
+  });
+});

--- a/ts-packages/quarto-hub-mcp/src/test-hub.ts
+++ b/ts-packages/quarto-hub-mcp/src/test-hub.ts
@@ -25,7 +25,17 @@ export interface TestHub {
   stop(): Promise<void>;
 }
 
-export async function startTestHub(): Promise<TestHub> {
+export interface TestHubOptions {
+  /**
+   * When false, `/health` still answers but every websocket upgrade is
+   * destroyed — models a hub whose sync endpoint is unreachable, for
+   * requireOnline tests (bd-xnmd5ni1).
+   */
+  acceptWs?: boolean;
+}
+
+export async function startTestHub(opts: TestHubOptions = {}): Promise<TestHub> {
+  const acceptWs = opts.acceptWs ?? true;
   const httpServer = http.createServer((req, res) => {
     if (req.url === '/health') {
       res.writeHead(200, { 'content-type': 'application/json' });
@@ -38,7 +48,7 @@ export async function startTestHub(): Promise<TestHub> {
 
   const wss = new WebSocketServer({ noServer: true });
   httpServer.on('upgrade', (req, socket, head) => {
-    if (req.url === '/ws') {
+    if (acceptWs && req.url === '/ws') {
       wss.handleUpgrade(req, socket, head, (ws) => wss.emit('connection', ws, req));
     } else {
       socket.destroy();

--- a/ts-packages/quarto-hub-mcp/src/test-hub.ts
+++ b/ts-packages/quarto-hub-mcp/src/test-hub.ts
@@ -16,12 +16,21 @@
 import * as http from 'node:http';
 import { once } from 'node:events';
 import { WebSocketServer } from 'ws';
-import { Repo, type PeerId } from '@automerge/automerge-repo';
+import { Repo, type DocumentId, type PeerId } from '@automerge/automerge-repo';
 import { WebSocketServerAdapter } from '@automerge/automerge-repo-network-websocket';
+import { MemoryStorageAdapter } from '@quarto/quarto-sync-client';
 
 export interface TestHub {
   /** ws:// URL of the sync endpoint, e.g. `ws://127.0.0.1:NNNNN/ws`. */
   url: string;
+  /** The hub's own repo — server-side ground truth. */
+  repo: Repo;
+  /**
+   * True iff the hub holds the document (bounded wait). Server-side
+   * ground truth for exit-drain tests (bd-10deu8h4): the 2026-06-12
+   * incident was exactly "the client believed, the hub never had it".
+   */
+  hubHasDoc(docId: string, timeoutMs?: number): Promise<boolean>;
   stop(): Promise<void>;
 }
 
@@ -59,6 +68,12 @@ export async function startTestHub(opts: TestHubOptions = {}): Promise<TestHub> 
     network: [new WebSocketServerAdapter(wss as never)],
     peerId: 'test-hub' as PeerId,
     sharePolicy: async () => true,
+    // Storage gives the hub a storageId to announce in its handshake
+    // metadata, like the real samod hub (which always announces one).
+    // Clients key delivery confirmation off it (exit-drain,
+    // bd-10deu8h4); a storage-less Repo announces none and would make
+    // this hub unconfirmable in a way production never is.
+    storage: new MemoryStorageAdapter(),
   });
 
   httpServer.listen(0, '127.0.0.1');
@@ -70,8 +85,26 @@ export async function startTestHub(opts: TestHubOptions = {}): Promise<TestHub> 
 
   return {
     url: `ws://127.0.0.1:${address.port}/ws`,
+    repo,
+    async hubHasDoc(docId: string, timeoutMs = 5000): Promise<boolean> {
+      const deadline = Date.now() + timeoutMs;
+      while (Date.now() < deadline) {
+        try {
+          const handle = await repo.find(docId as DocumentId);
+          if (handle.doc() !== undefined) return true;
+        } catch {
+          // unavailable — keep polling until the deadline
+        }
+        await new Promise((r) => setTimeout(r, 100));
+      }
+      return false;
+    },
     async stop(): Promise<void> {
-      await repo.shutdown();
+      // shutdown() flushes storage, and flush() throws "DocHandle is
+      // not ready" for docs that were announced but never delivered —
+      // exactly the half-state the exit-drain tests (bd-10deu8h4)
+      // leave behind. Teardown must not mask a test's own assertions.
+      await repo.shutdown().catch(() => {});
       wss.close();
       httpServer.close();
       await once(httpServer, 'close');

--- a/ts-packages/quarto-hub-mcp/src/test-hub.ts
+++ b/ts-packages/quarto-hub-mcp/src/test-hub.ts
@@ -16,12 +16,25 @@
 import * as http from 'node:http';
 import { once } from 'node:events';
 import { WebSocketServer } from 'ws';
-import { Repo, type PeerId } from '@automerge/automerge-repo';
+import { Repo, type DocumentId, type PeerId } from '@automerge/automerge-repo';
 import { WebSocketServerAdapter } from '@automerge/automerge-repo-network-websocket';
 
 export interface TestHub {
   /** ws:// URL of the sync endpoint, e.g. `ws://127.0.0.1:NNNNN/ws`. */
   url: string;
+  /**
+   * The hub's own repo — server-side ground truth. Tests use it to
+   * assert what the server actually received, and to mint dangling
+   * index entries by mutating the index document directly
+   * (bd-vm5e5u10; mirrors quarto-sync-client/src/test-hub.ts).
+   */
+  repo: Repo;
+  /**
+   * True iff the hub holds the document (bounded wait). Uses the
+   * repo's find with an overall deadline; "unavailable" or timeout
+   * map to false.
+   */
+  hubHasDoc(docId: string, timeoutMs?: number): Promise<boolean>;
   stop(): Promise<void>;
 }
 
@@ -70,6 +83,20 @@ export async function startTestHub(opts: TestHubOptions = {}): Promise<TestHub> 
 
   return {
     url: `ws://127.0.0.1:${address.port}/ws`,
+    repo,
+    async hubHasDoc(docId: string, timeoutMs = 5000): Promise<boolean> {
+      const deadline = Date.now() + timeoutMs;
+      while (Date.now() < deadline) {
+        try {
+          const handle = await repo.find(docId as DocumentId);
+          if (handle.doc() !== undefined) return true;
+        } catch {
+          // unavailable — keep polling until the deadline
+        }
+        await new Promise((r) => setTimeout(r, 100));
+      }
+      return false;
+    },
     async stop(): Promise<void> {
       await repo.shutdown();
       wss.close();

--- a/ts-packages/quarto-hub-mcp/src/test-hub.ts
+++ b/ts-packages/quarto-hub-mcp/src/test-hub.ts
@@ -1,0 +1,70 @@
+/**
+ * Test helper: a minimal in-process Quarto Hub stand-in.
+ *
+ * Provides exactly the two surfaces the MCP server's connection
+ * manager needs from an unauthenticated hub:
+ *
+ *   - `GET /health` → 200 (the auth-mode probe), and
+ *   - a real automerge-repo sync peer on the `/ws` websocket path.
+ *
+ * Real network sockets on 127.0.0.1, in-memory document storage. This
+ * is what lets stdio-hygiene tests exercise the *live-sync* code paths
+ * (peer-wait logging, reconnect timers) deterministically — an
+ * unreachable URL fails fast at the probe and never reaches them.
+ */
+
+import * as http from 'node:http';
+import { once } from 'node:events';
+import { WebSocketServer } from 'ws';
+import { Repo, type PeerId } from '@automerge/automerge-repo';
+import { WebSocketServerAdapter } from '@automerge/automerge-repo-network-websocket';
+
+export interface TestHub {
+  /** ws:// URL of the sync endpoint, e.g. `ws://127.0.0.1:NNNNN/ws`. */
+  url: string;
+  stop(): Promise<void>;
+}
+
+export async function startTestHub(): Promise<TestHub> {
+  const httpServer = http.createServer((req, res) => {
+    if (req.url === '/health') {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end('{"status":"ok"}');
+    } else {
+      res.writeHead(404);
+      res.end();
+    }
+  });
+
+  const wss = new WebSocketServer({ noServer: true });
+  httpServer.on('upgrade', (req, socket, head) => {
+    if (req.url === '/ws') {
+      wss.handleUpgrade(req, socket, head, (ws) => wss.emit('connection', ws, req));
+    } else {
+      socket.destroy();
+    }
+  });
+
+  const repo = new Repo({
+    network: [new WebSocketServerAdapter(wss as never)],
+    peerId: 'test-hub' as PeerId,
+    sharePolicy: async () => true,
+  });
+
+  httpServer.listen(0, '127.0.0.1');
+  await once(httpServer, 'listening');
+  const address = httpServer.address();
+  if (address === null || typeof address === 'string') {
+    throw new Error('test hub failed to bind a TCP port');
+  }
+
+  return {
+    url: `ws://127.0.0.1:${address.port}/ws`,
+    async stop(): Promise<void> {
+      await repo.shutdown();
+      wss.close();
+      httpServer.close();
+      await once(httpServer, 'close');
+    },
+  };
+}

--- a/ts-packages/quarto-hub-mcp/src/test-idp.ts
+++ b/ts-packages/quarto-hub-mcp/src/test-idp.ts
@@ -1,0 +1,217 @@
+/**
+ * Test helper: a minimal in-process OIDC identity provider.
+ *
+ * Serves the four endpoints the full auth stack needs — discovery,
+ * JWKS, authorization (instant consent: 302 straight back to the
+ * loopback redirect_uri), token (authorization-code + PKCE S256
+ * verification, and refresh grants), and revocation — and mints REAL
+ * RS256-signed ID tokens, because the hub validates signatures against
+ * the JWKS while the TS client validates the claims.
+ *
+ * Counters expose what happened (code exchanges, refresh grants,
+ * revoked tokens) so tests can assert on flow shape, not just
+ * outcomes. `idTokenTtlSecs` below the refresh manager's 60s
+ * early-refresh window forces the refresh grant deterministically.
+ */
+
+import * as crypto from 'node:crypto';
+import * as http from 'node:http';
+import { once } from 'node:events';
+
+export interface TestIdpOptions {
+  clientId: string;
+  clientSecret: string;
+  email: string;
+  /** ID-token lifetime; < 60s forces proactive refresh on every use. */
+  idTokenTtlSecs?: number;
+}
+
+export interface TestIdp {
+  issuer: string;
+  counters: {
+    codeExchanges: number;
+    refreshGrants: number;
+    revokedTokens: string[];
+  };
+  stop(): Promise<void>;
+}
+
+export async function startTestIdp(opts: TestIdpOptions): Promise<TestIdp> {
+  const ttl = opts.idTokenTtlSecs ?? 3600;
+  const { publicKey, privateKey } = crypto.generateKeyPairSync('rsa', {
+    modulusLength: 2048,
+  });
+  const kid = 'test-key-1';
+  const jwk = { ...publicKey.export({ format: 'jwk' }), kid, alg: 'RS256', use: 'sig' };
+
+  const counters: TestIdp['counters'] = {
+    codeExchanges: 0,
+    refreshGrants: 0,
+    revokedTokens: [],
+  };
+  // code -> the PKCE challenge it was issued against
+  const pendingCodes = new Map<string, { challenge: string }>();
+  const REFRESH_TOKEN = 'rt-test-refresh-token';
+  let issuer = ''; // assigned after listen()
+
+  const b64url = (input: Buffer | string): string =>
+    Buffer.from(input).toString('base64url');
+
+  function mintIdToken(): string {
+    const now = Math.floor(Date.now() / 1000);
+    const header = b64url(JSON.stringify({ alg: 'RS256', typ: 'JWT', kid }));
+    const payload = b64url(
+      JSON.stringify({
+        iss: issuer,
+        aud: opts.clientId,
+        azp: opts.clientId,
+        sub: 'test-subject-1',
+        email: opts.email,
+        email_verified: true,
+        iat: now,
+        exp: now + ttl,
+      }),
+    );
+    const signature = crypto
+      .sign('sha256', Buffer.from(`${header}.${payload}`), privateKey)
+      .toString('base64url');
+    return `${header}.${payload}.${signature}`;
+  }
+
+  function tokenResponse(): string {
+    return JSON.stringify({
+      access_token: `at-${crypto.randomUUID()}`,
+      token_type: 'bearer',
+      expires_in: ttl,
+      id_token: mintIdToken(),
+      refresh_token: REFRESH_TOKEN, // Google-style: never rotated
+    });
+  }
+
+  async function readBody(req: http.IncomingMessage): Promise<URLSearchParams> {
+    const chunks: Buffer[] = [];
+    for await (const chunk of req) chunks.push(chunk as Buffer);
+    return new URLSearchParams(Buffer.concat(chunks).toString('utf8'));
+  }
+
+  const server = http.createServer((req, res) => {
+    void handle(req, res).catch((err) => {
+      res.writeHead(500, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ error: 'server_error', detail: String(err) }));
+    });
+  });
+
+  async function handle(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+    const url = new URL(req.url ?? '/', issuer);
+    const json = (status: number, body: unknown): void => {
+      res.writeHead(status, { 'content-type': 'application/json' });
+      res.end(JSON.stringify(body));
+    };
+
+    if (url.pathname === '/.well-known/openid-configuration') {
+      json(200, {
+        issuer,
+        authorization_endpoint: `${issuer}/authorize`,
+        token_endpoint: `${issuer}/token`,
+        jwks_uri: `${issuer}/jwks`,
+        revocation_endpoint: `${issuer}/revoke`,
+      });
+      return;
+    }
+
+    if (url.pathname === '/jwks') {
+      json(200, { keys: [jwk] });
+      return;
+    }
+
+    if (url.pathname === '/authorize') {
+      // Instant consent: validate the request shape, issue a code bound
+      // to the PKCE challenge, bounce straight back to the loopback.
+      const clientId = url.searchParams.get('client_id');
+      const redirectUri = url.searchParams.get('redirect_uri');
+      const state = url.searchParams.get('state');
+      const challenge = url.searchParams.get('code_challenge');
+      const method = url.searchParams.get('code_challenge_method');
+      if (clientId !== opts.clientId || !redirectUri || !state || !challenge || method !== 'S256') {
+        json(400, { error: 'invalid_request' });
+        return;
+      }
+      const code = `code-${crypto.randomUUID()}`;
+      pendingCodes.set(code, { challenge });
+      const target = new URL(redirectUri);
+      target.searchParams.set('code', code);
+      target.searchParams.set('state', state);
+      res.writeHead(302, { location: target.toString() });
+      res.end();
+      return;
+    }
+
+    if (url.pathname === '/token' && req.method === 'POST') {
+      const body = await readBody(req);
+      if (body.get('client_id') !== opts.clientId || body.get('client_secret') !== opts.clientSecret) {
+        json(401, { error: 'invalid_client' });
+        return;
+      }
+      const grant = body.get('grant_type');
+      if (grant === 'authorization_code') {
+        const code = body.get('code') ?? '';
+        const verifier = body.get('code_verifier') ?? '';
+        const pending = pendingCodes.get(code);
+        if (!pending) {
+          json(400, { error: 'invalid_grant' });
+          return;
+        }
+        const expected = crypto.createHash('sha256').update(verifier).digest('base64url');
+        if (expected !== pending.challenge) {
+          json(400, { error: 'invalid_grant', error_description: 'PKCE verification failed' });
+          return;
+        }
+        pendingCodes.delete(code);
+        counters.codeExchanges += 1;
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(tokenResponse());
+        return;
+      }
+      if (grant === 'refresh_token') {
+        const rt = body.get('refresh_token');
+        if (rt !== REFRESH_TOKEN || counters.revokedTokens.includes(REFRESH_TOKEN)) {
+          json(400, { error: 'invalid_grant' });
+          return;
+        }
+        counters.refreshGrants += 1;
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(tokenResponse());
+        return;
+      }
+      json(400, { error: 'unsupported_grant_type' });
+      return;
+    }
+
+    if (url.pathname === '/revoke' && req.method === 'POST') {
+      const body = await readBody(req);
+      const token = body.get('token');
+      if (token) counters.revokedTokens.push(token);
+      json(200, {});
+      return;
+    }
+
+    json(404, { error: 'not_found' });
+  }
+
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  const address = server.address();
+  if (address === null || typeof address === 'string') {
+    throw new Error('test IdP failed to bind a TCP port');
+  }
+  issuer = `http://127.0.0.1:${address.port}`;
+
+  return {
+    issuer,
+    counters,
+    async stop(): Promise<void> {
+      server.close();
+      await once(server, 'close');
+    },
+  };
+}

--- a/ts-packages/quarto-hub-mcp/src/tools.ts
+++ b/ts-packages/quarto-hub-mcp/src/tools.ts
@@ -14,6 +14,7 @@ import {
   ListToolsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 import type { Tool, CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { fileUnavailableMessage, type SyncClient } from '@quarto/quarto-sync-client';
 import { ConnectionManager } from './connection-manager.js';
 import {
   AUTH_TOOL_DEFINITIONS,
@@ -186,6 +187,47 @@ function getWriteTools(): Tool[] {
 
 type ToolArgs = Record<string, unknown>;
 
+/**
+ * One listed file. `type` is present for loaded files; dangling index
+ * entries (bd-vm5e5u10) instead carry `status: 'unavailable'` plus the
+ * doc id the index references, so agents can see — and repair via
+ * `delete_file` — entries whose documents never reached the hub.
+ */
+interface ListedFile {
+  path: string;
+  type?: string;
+  status?: 'unavailable';
+  docId?: string;
+}
+
+/** Project state as exposed by {@link ConnectionManager.connect}. */
+type ProjectState = Awaited<ReturnType<ConnectionManager['connect']>>;
+
+function buildFileList(state: ProjectState): ListedFile[] {
+  const fileList: ListedFile[] = Array.from(state.files.keys()).map((path) => ({
+    path,
+    type: state.files.get(path)!.type,
+  }));
+  for (const ghost of state.client.getUnavailableFiles()) {
+    fileList.push({ path: ghost.path, status: 'unavailable', docId: ghost.docId });
+  }
+  fileList.sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0));
+  return fileList;
+}
+
+/** The dangling-entry record for `path`, if the index references a document the hub cannot provide. */
+function findUnavailable(client: SyncClient, path: string): { path: string; docId: string } | undefined {
+  return client.getUnavailableFiles().find((f) => f.path === path);
+}
+
+/** Per-file error for tools that need the file's content (bd-vm5e5u10 requirement 5/6). */
+function unavailableFileError(path: string, docId: string): CallToolResult {
+  return error(
+    `Error: ${fileUnavailableMessage(path, docId)}. ` +
+      'Use delete_file to remove the dangling entry.',
+  );
+}
+
 async function handleTool(
   name: string,
   args: ToolArgs,
@@ -218,23 +260,13 @@ async function handleTool(
 async function handleConnectProject(args: ToolArgs, manager: ConnectionManager): Promise<CallToolResult> {
   const project = args.project as string;
   const state = await manager.connect(project);
-  const filePaths = Array.from(state.files.keys()).sort();
-  const fileList = filePaths.map(path => {
-    const payload = state.files.get(path)!;
-    return { path, type: payload.type };
-  });
-  return text(JSON.stringify({ project, files: fileList }, null, 2));
+  return text(JSON.stringify({ project, files: buildFileList(state) }, null, 2));
 }
 
 async function handleListFiles(args: ToolArgs, manager: ConnectionManager): Promise<CallToolResult> {
   const project = args.project as string;
   const state = await manager.connect(project);
-  const filePaths = Array.from(state.files.keys()).sort();
-  const fileList = filePaths.map(path => {
-    const payload = state.files.get(path)!;
-    return { path, type: payload.type };
-  });
-  return text(JSON.stringify(fileList, null, 2));
+  return text(JSON.stringify(buildFileList(state), null, 2));
 }
 
 async function handleReadFile(args: ToolArgs, manager: ConnectionManager): Promise<CallToolResult> {
@@ -244,6 +276,10 @@ async function handleReadFile(args: ToolArgs, manager: ConnectionManager): Promi
   const payload = state.files.get(path);
 
   if (!payload) {
+    const ghost = findUnavailable(state.client, path);
+    if (ghost) {
+      return unavailableFileError(path, ghost.docId);
+    }
     return error(`Error: File not found: ${path}`);
   }
   if (payload.type === 'binary') {
@@ -260,6 +296,13 @@ async function handleWriteFile(args: ToolArgs, manager: ConnectionManager): Prom
   const existing = state.files.get(path);
 
   if (!existing) {
+    // A dangling entry is not writable: silently re-creating the
+    // document would repoint the index away from whatever the original
+    // (never-synced) client still holds. Repair is delete_file.
+    const ghost = findUnavailable(state.client, path);
+    if (ghost) {
+      return unavailableFileError(path, ghost.docId);
+    }
     await state.client.createFile(path, content);
     return text(`Created ${path}`);
   }
@@ -280,6 +323,10 @@ async function handlePatchFile(args: ToolArgs, manager: ConnectionManager): Prom
   const payload = state.files.get(path);
 
   if (!payload) {
+    const ghost = findUnavailable(state.client, path);
+    if (ghost) {
+      return unavailableFileError(path, ghost.docId);
+    }
     return error(`Error: File not found: ${path}`);
   }
   if (payload.type === 'binary') {
@@ -315,6 +362,11 @@ async function handleCreateFile(args: ToolArgs, manager: ConnectionManager): Pro
   if (state.files.has(path)) {
     return error(`Error: File already exists: ${path}. Use write_file to update it.`);
   }
+  // Same hazard as write_file: don't silently repoint a dangling entry.
+  const ghost = findUnavailable(state.client, path);
+  if (ghost) {
+    return unavailableFileError(path, ghost.docId);
+  }
 
   await state.client.createFile(path, content);
   return text(`Created ${path}`);
@@ -325,7 +377,11 @@ async function handleDeleteFile(args: ToolArgs, manager: ConnectionManager): Pro
   const path = args.path as string;
   const state = await manager.connect(project);
 
-  if (!state.files.has(path)) {
+  // Dangling entries ARE deletable: delete only edits the index, no
+  // document fetch involved — this is the self-service repair for a
+  // ghost entry (bd-vm5e5u10; the 2026-06-12 incident needed manual
+  // index surgery precisely because this path didn't exist).
+  if (!state.files.has(path) && !findUnavailable(state.client, path)) {
     return error(`Error: File not found: ${path}`);
   }
 
@@ -339,10 +395,11 @@ async function handleRenameFile(args: ToolArgs, manager: ConnectionManager): Pro
   const newPath = args.new_path as string;
   const state = await manager.connect(project);
 
-  if (!state.files.has(oldPath)) {
+  // Renaming only edits the index, so a dangling entry can be renamed.
+  if (!state.files.has(oldPath) && !findUnavailable(state.client, oldPath)) {
     return error(`Error: File not found: ${oldPath}`);
   }
-  if (state.files.has(newPath)) {
+  if (state.files.has(newPath) || findUnavailable(state.client, newPath)) {
     return error(`Error: Destination already exists: ${newPath}`);
   }
 

--- a/ts-packages/quarto-sync-client/src/NodeWebSocketClientAdapter.ts
+++ b/ts-packages/quarto-sync-client/src/NodeWebSocketClientAdapter.ts
@@ -29,6 +29,7 @@ import type {
 // to the same module, but the headers option is not portable to a
 // browser `WebSocket`. This adapter is Node-only by design.
 import WebSocket from 'ws';
+import { syncLog } from './log.js';
 
 const ProtocolV1 = '1';
 const READY_TIMEOUT_MS = 1000;
@@ -229,13 +230,17 @@ export class NodeWebSocketClientAdapter extends NetworkAdapter {
   };
 
   private readonly onError = (event: unknown): void => {
+    // Never throw here: an exception inside an event callback cannot
+    // reach any caller — it becomes an uncaughtException and kills the
+    // host process (bd-xzspx4r9). Log (redacted — defensive, `ws`
+    // doesn't currently put Authorization material here) and let the
+    // close/retry machinery recover.
     const ev = event as { error?: { code?: string; message?: string } };
-    if (ev.error && ev.error.code !== 'ECONNREFUSED') {
-      // Re-throw with redacted message so an Authorization-bearing
-      // string (defensive — `ws` doesn't currently put one here) does
-      // not propagate to user log sinks.
-      throw new Error(redactAuthorization(ev.error.message ?? 'WebSocket error'));
-    }
+    syncLog(
+      `WebSocket error (will retry): ${ev.error?.code ?? 'unknown'} ${redactAuthorization(
+        ev.error?.message ?? '',
+      )}`.trim(),
+    );
   };
 
   private removeListeners(socket: WebSocketLike): void {

--- a/ts-packages/quarto-sync-client/src/StoppableWebSocketClientAdapter.ts
+++ b/ts-packages/quarto-sync-client/src/StoppableWebSocketClientAdapter.ts
@@ -26,8 +26,25 @@
 import { BrowserWebSocketClientAdapter } from '@automerge/automerge-repo-network-websocket';
 import type { PeerId, PeerMetadata } from '@automerge/automerge-repo/slim';
 
+import { syncLog } from './log.js';
+
 export class StoppableWebSocketClientAdapter extends BrowserWebSocketClientAdapter {
   #stopped = false;
+
+  /**
+   * Upstream's `onError` rethrows any node error that isn't
+   * ECONNREFUSED — but a throw inside an event callback can't reach a
+   * caller; it becomes an uncaughtException and kills the host
+   * process (bd-xzspx4r9: the hub MCP server died on a mid-handshake
+   * 'socket hang up'). Recovery is the close/retry machinery's job;
+   * here we only record the diagnostic.
+   */
+  override onError = (event: unknown): void => {
+    const err = (event as { error?: { code?: string; message?: string } }).error;
+    syncLog(
+      `WebSocket error (will retry): ${err?.code ?? 'unknown'} ${err?.message ?? ''}`.trim(),
+    );
+  };
 
   override connect(peerId: PeerId, peerMetadata?: PeerMetadata): void {
     if (this.#stopped) return;

--- a/ts-packages/quarto-sync-client/src/adapter-error-handling.test.ts
+++ b/ts-packages/quarto-sync-client/src/adapter-error-handling.test.ts
@@ -1,0 +1,45 @@
+/**
+ * bd-xzspx4r9: a websocket 'error' event must never crash the process.
+ *
+ * Upstream automerge-repo's WebSocketClientAdapter.onError rethrows
+ * any node error whose code isn't ECONNREFUSED. A throw inside an
+ * event callback cannot reach any caller — it becomes an
+ * uncaughtException and kills the host (the hub MCP server exits
+ * mid-session on a mid-handshake 'socket hang up'). Recovery belongs
+ * to the close/retry machinery; the error handler's only job is to
+ * record the diagnostic.
+ *
+ * These tests invoke the handlers directly with the event shapes `ws`
+ * produces on node.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { StoppableWebSocketClientAdapter } from './StoppableWebSocketClientAdapter.js';
+import { NodeWebSocketClientAdapter } from './NodeWebSocketClientAdapter.js';
+
+const RESET = { error: { code: 'ECONNRESET', message: 'socket hang up' } };
+const REFUSED = { error: { code: 'ECONNREFUSED', message: 'connect ECONNREFUSED' } };
+const DNS = { error: { code: 'ENOTFOUND', message: 'getaddrinfo ENOTFOUND nope.invalid' } };
+
+describe('StoppableWebSocketClientAdapter.onError', () => {
+  it('never throws, whatever the error code', () => {
+    const adapter = new StoppableWebSocketClientAdapter('ws://127.0.0.1:9/ws');
+    const onError = (adapter as unknown as { onError: (e: unknown) => void }).onError;
+    expect(() => onError(RESET)).not.toThrow();
+    expect(() => onError(REFUSED)).not.toThrow();
+    expect(() => onError(DNS)).not.toThrow();
+  });
+});
+
+describe('NodeWebSocketClientAdapter.onError', () => {
+  it('never throws, whatever the error code', () => {
+    const adapter = new NodeWebSocketClientAdapter('ws://127.0.0.1:9/ws', {
+      getBearer: async () => 'token',
+    });
+    const onError = (adapter as unknown as { onError: (e: unknown) => void }).onError;
+    expect(() => onError(RESET)).not.toThrow();
+    expect(() => onError(REFUSED)).not.toThrow();
+    expect(() => onError(DNS)).not.toThrow();
+  });
+});

--- a/ts-packages/quarto-sync-client/src/client.require-online.test.ts
+++ b/ts-packages/quarto-sync-client/src/client.require-online.test.ts
@@ -1,0 +1,81 @@
+/**
+ * `requireOnline` semantics (bd-xnmd5ni1): server-backed callers (the
+ * hub MCP server) must be able to demand a live peer connection
+ * instead of the silent offline fallback. With in-memory storage,
+ * "offline mode" persists nothing — succeeding silently is a data
+ * black hole: `create_project` reported an indexDocId for documents
+ * that existed only in process memory and died with it.
+ *
+ * Defaults stay offline-first (hub-client's IndexedDB-backed browser
+ * behavior is correct and untouched); `requireOnline: true` turns the
+ * peer-wait timeout into a typed PeerUnavailableError.
+ *
+ * No mocks: the "server" is a port nothing listens on, so the peer
+ * wait genuinely times out.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { createSyncClient, PeerUnavailableError } from './client.js';
+
+// Port 9 (discard) on localhost: connection refused immediately.
+const UNREACHABLE = 'ws://127.0.0.1:9/ws';
+
+function client() {
+  return createSyncClient({
+    onFileAdded: () => {},
+    onFileChanged: () => {},
+    onFileRemoved: () => {},
+  });
+}
+
+describe('createNewProject + requireOnline', () => {
+  it('rejects with PeerUnavailableError when the peer cannot be reached', async () => {
+    await expect(
+      client().createNewProject({
+        syncServer: UNREACHABLE,
+        files: [{ path: 'a.qmd', content: 'x', contentType: 'text' }],
+        storage: 'memory',
+        peerTimeoutMs: 150,
+        requireOnline: true,
+      }),
+    ).rejects.toBeInstanceOf(PeerUnavailableError);
+  });
+
+  it('error names the server and the timeout', async () => {
+    const err = await client()
+      .createNewProject({
+        syncServer: UNREACHABLE,
+        files: [],
+        storage: 'memory',
+        peerTimeoutMs: 150,
+        requireOnline: true,
+      })
+      .catch((e: unknown) => e);
+    expect(String(err)).toContain('127.0.0.1:9');
+    expect(String(err)).toContain('150');
+  });
+
+  it('default (no requireOnline) preserves the offline fallback', async () => {
+    // Locks the browser-path contract: offline creation still works.
+    const result = await client().createNewProject({
+      syncServer: UNREACHABLE,
+      files: [{ path: 'a.qmd', content: 'x', contentType: 'text' }],
+      storage: 'memory',
+      peerTimeoutMs: 50,
+    });
+    expect(result.indexDocId).toBeTruthy();
+  });
+});
+
+describe('connect + requireOnline', () => {
+  it('rejects with PeerUnavailableError when the peer cannot be reached', async () => {
+    await expect(
+      client().connect(UNREACHABLE, 'badc0ffee0ddf00d', undefined, undefined, undefined, {
+        storage: 'memory',
+        peerTimeoutMs: 150,
+        requireOnline: true,
+      }),
+    ).rejects.toBeInstanceOf(PeerUnavailableError);
+  });
+});

--- a/ts-packages/quarto-sync-client/src/client.ts
+++ b/ts-packages/quarto-sync-client/src/client.ts
@@ -34,6 +34,7 @@ import {
 } from '@quarto/quarto-automerge-schema';
 
 import type {
+  AnnotatedFileEntry,
   EditorContentChange,
   SyncClientCallbacks,
   ASTOptions,
@@ -61,6 +62,58 @@ export class PeerUnavailableError extends Error {
     );
     if (cause !== undefined) (this as { cause?: unknown }).cause = cause;
   }
+}
+
+/**
+ * Normalize a document id from the index into the `automerge:<id>`
+ * URL form that `repo.find()` requires (bd-4uvv). `String(...)`
+ * coerces first because automerge's read proxy can return
+ * string-valued fields as `RawString` (no `.startsWith` method)
+ * depending on how the doc was constructed.
+ */
+function normalizeDocId(docId: string): string {
+  const docIdStr = String(docId);
+  return docIdStr.startsWith('automerge:') ? docIdStr : `automerge:${docIdStr}`;
+}
+
+/**
+ * True for the "document is unavailable" error shape thrown by
+ * `repo.find()` (and re-thrown by `findDoc`) when a document cannot
+ * be fetched. Used to tell dangling-entry failures (tolerated,
+ * bd-vm5e5u10) apart from real bugs (re-thrown).
+ */
+function isUnavailableError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err);
+  return /unavailable/i.test(message);
+}
+
+/**
+ * Error text for a dangling index entry: a file document the index
+ * references but the sync server cannot provide (bd-vm5e5u10). Names
+ * the path and the kind of document — during the 2026-06-12 incident
+ * the bare `Document <id> is unavailable` text misled the response
+ * into suspecting the index. Wording is locked by
+ * dangling-entries.test.ts; quarto-hub-mcp reuses it for per-file
+ * tool errors.
+ */
+export function fileUnavailableMessage(path: string, docId: string): string {
+  return (
+    `file document for '${path}' (${normalizeDocId(docId)}) is unavailable ` +
+    'on the sync server — the file may have been created by a client that ' +
+    'never synced it; other files in the project remain usable'
+  );
+}
+
+/**
+ * Error text for an unavailable project index document — this one IS
+ * fatal: nothing sensible can be done without the index.
+ */
+export function indexUnavailableMessage(indexDocId: string): string {
+  return (
+    `project index document ${normalizeDocId(indexDocId)} is unavailable ` +
+    'on the sync server — cannot open the project (verify the project id ' +
+    'and the sync server URL)'
+  );
 }
 
 /**
@@ -106,6 +159,13 @@ interface SyncClientState {
   wsAdapter: NetworkAdapter | null;
   indexHandle: DocHandle<IndexDocument> | null;
   fileHandles: Map<string, DocHandle<FileDocument>>;
+  /**
+   * Dangling index entries (path → doc id as stored in the index):
+   * files the index references but whose documents the sync server
+   * could not provide (bd-vm5e5u10). Tracked so listings can mark
+   * them `unavailable` instead of the whole project failing.
+   */
+  unavailableFiles: Map<string, string>;
   binaryFiles: Set<string>;
   cleanupFns: (() => void)[];
   actorId: string | null;
@@ -145,6 +205,7 @@ export function createSyncClient(callbacks: SyncClientCallbacks, astOptions?: AS
     wsAdapter: null,
     indexHandle: null,
     fileHandles: new Map(),
+    unavailableFiles: new Map(),
     binaryFiles: new Set(),
     cleanupFns: [],
     actorId: null,
@@ -430,16 +491,42 @@ export function createSyncClient(callbacks: SyncClientCallbacks, astOptions?: AS
     state.cleanupFns.push(() => handle.off('change', changeHandler));
   }
 
-  // Helper: load file documents
+  // Helper: run syncWithFiles from an index-change handler. The
+  // handler is a synchronous event callback, so the promise used to be
+  // fire-and-forget — a dangling entry appearing mid-session became an
+  // unhandled rejection that took down the whole session
+  // (bd-vm5e5u10). Unavailable documents are tolerated inside
+  // syncWithFiles; anything else is surfaced through onError.
+  function syncWithFilesHandled(newFiles: FileEntry[]): void {
+    void syncWithFiles(newFiles).catch((err: unknown) => {
+      const error = err instanceof Error ? err : new Error(String(err));
+      syncLog('Error syncing files after index change:', error);
+      callbacks.onError?.(error);
+    });
+  }
+
+  // Helper: record a dangling index entry and notify, without failing
+  // the project (bd-vm5e5u10).
+  function markFileUnavailable(path: string, docId: string): void {
+    state.unavailableFiles.set(path, docId);
+    syncLog(fileUnavailableMessage(path, docId));
+    callbacks.onFileUnavailable?.(path, docId);
+  }
+
+  // Helper: load file documents. One dangling entry must not brick the
+  // project (bd-vm5e5u10): unavailable documents are recorded and
+  // skipped; other errors still throw (don't mask real bugs).
   async function loadFileDocuments(files: FileEntry[]): Promise<void> {
     if (!state.repo) return;
 
     for (const file of files) {
-      const docId = file.docId.startsWith('automerge:')
-        ? file.docId
-        : `automerge:${file.docId}`;
-      const handle = await findDoc<FileDocument>(docId as DocumentId);
-      await subscribeToFile(file.path, handle);
+      try {
+        const handle = await findDoc<FileDocument>(normalizeDocId(file.docId) as DocumentId);
+        await subscribeToFile(file.path, handle);
+      } catch (err) {
+        if (!isUnavailableError(err)) throw err;
+        markFileUnavailable(file.path, String(file.docId));
+      }
     }
   }
 
@@ -451,11 +538,19 @@ export function createSyncClient(callbacks: SyncClientCallbacks, astOptions?: AS
     // Find new files
     for (const file of newFiles) {
       if (!currentPaths.has(file.path) && state.repo) {
-        const docId = file.docId.startsWith('automerge:')
-          ? file.docId
-          : `automerge:${file.docId}`;
-        const handle = await findDoc<FileDocument>(docId as DocumentId);
-        await subscribeToFile(file.path, handle);
+        const rawDocId = String(file.docId);
+        // Don't re-probe a known dangling entry on every index change —
+        // retry-on-peer-arrival is out of scope here (parent plan D2).
+        // A changed doc id means the entry was repaired; re-attempt then.
+        if (state.unavailableFiles.get(file.path) === rawDocId) continue;
+        try {
+          const handle = await findDoc<FileDocument>(normalizeDocId(rawDocId) as DocumentId);
+          state.unavailableFiles.delete(file.path);
+          await subscribeToFile(file.path, handle);
+        } catch (err) {
+          if (!isUnavailableError(err)) throw err;
+          markFileUnavailable(file.path, rawDocId);
+        }
       }
     }
 
@@ -465,6 +560,16 @@ export function createSyncClient(callbacks: SyncClientCallbacks, astOptions?: AS
         state.fileHandles.delete(path);
         state.binaryFiles.delete(path);
         astCache.delete(path);
+        callbacks.onFileRemoved(path);
+      }
+    }
+
+    // Dangling entries removed from the index (e.g. a colleague's
+    // delete-file repair): drop the marker and notify — the path was
+    // visible in listings as `unavailable`.
+    for (const path of Array.from(state.unavailableFiles.keys())) {
+      if (!newPaths.has(path)) {
+        state.unavailableFiles.delete(path);
         callbacks.onFileRemoved(path);
       }
     }
@@ -492,7 +597,7 @@ export function createSyncClient(callbacks: SyncClientCallbacks, astOptions?: AS
    * serialization), and memory storage keeps the IndexedDB open off
    * the critical path of the WebSocket `join`.
    */
-  async function connect(syncServerUrl: string, indexDocId: string, actorId?: string, screenName?: string, color?: string, peerTimeoutMsOrOptions: number | ConnectOptions = 1, auth?: SyncClientAuthOptions): Promise<FileEntry[]> {
+  async function connect(syncServerUrl: string, indexDocId: string, actorId?: string, screenName?: string, color?: string, peerTimeoutMsOrOptions: number | ConnectOptions = 1, auth?: SyncClientAuthOptions): Promise<AnnotatedFileEntry[]> {
     const options: ConnectOptions =
       typeof peerTimeoutMsOrOptions === 'number'
         ? { peerTimeoutMs: peerTimeoutMsOrOptions }
@@ -537,8 +642,19 @@ export function createSyncClient(callbacks: SyncClientCallbacks, astOptions?: AS
         isOnline = false;
       }
 
+      // The index staying unavailable IS fatal — nothing sensible can
+      // be done without it — but say so precisely: "index" vs "file"
+      // confusion misled the 2026-06-12 incident response.
       const docId = indexDocId as DocumentId;
-      const indexHandle = await findDoc<IndexDocument>(docId);
+      let indexHandle: DocHandle<IndexDocument>;
+      try {
+        indexHandle = await findDoc<IndexDocument>(docId);
+      } catch (err) {
+        if (!isUnavailableError(err)) throw err;
+        const wrapped = new Error(indexUnavailableMessage(indexDocId));
+        (wrapped as { cause?: unknown }).cause = err;
+        throw wrapped;
+      }
       state.indexHandle = indexHandle;
 
       const doc = indexHandle.doc();
@@ -575,7 +691,7 @@ export function createSyncClient(callbacks: SyncClientCallbacks, astOptions?: AS
         const changedDoc = indexHandle.doc();
         if (changedDoc) {
           const newFiles = getFilesFromIndex(changedDoc);
-          syncWithFiles(newFiles);
+          syncWithFilesHandled(newFiles);
           callbacks.onFilesChange?.(newFiles);
           notifyIdentitiesIfChanged(changedDoc);
           notifyCapturesIfChanged(changedDoc);
@@ -611,7 +727,11 @@ export function createSyncClient(callbacks: SyncClientCallbacks, astOptions?: AS
       await loadFileDocuments(files);
 
       callbacks.onConnectionChange?.(currentlyOnline);
-      return files;
+      // Annotate dangling entries so callers can list-but-mark them
+      // (bd-vm5e5u10). Presentation only; the index is not changed.
+      return files.map((f): AnnotatedFileEntry =>
+        state.unavailableFiles.has(f.path) ? { ...f, status: 'unavailable' } : f,
+      );
     } catch (err) {
       const error = err instanceof Error ? err : new Error(String(err));
       callbacks.onError?.(error);
@@ -635,6 +755,7 @@ export function createSyncClient(callbacks: SyncClientCallbacks, astOptions?: AS
     }
 
     state.fileHandles.clear();
+    state.unavailableFiles.clear();
     state.binaryFiles.clear();
     astCache.clear();
 
@@ -703,20 +824,9 @@ export function createSyncClient(callbacks: SyncClientCallbacks, astOptions?: AS
     if (!state.repo) return null;
     // bd-4uvv: samod's TS `repo.find()` requires the `automerge:<id>`
     // URL scheme; the bare docId we get from the IndexDocument capture
-    // sidecar throws `Invalid AutomergeUrl`. The text-doc loader
-    // (`loadFileDocuments`) normalizes the same way — keep both call
-    // sites consistent.
-    //
-    // `String(docId)` coerces the value before `.startsWith` because
-    // automerge's read proxy can return string-valued fields as
-    // `RawString` (no `.startsWith` method) depending on how the doc
-    // was constructed. `loadFileDocuments` reads from the same shape;
-    // bare-id callers that synthesize an `automerge:` URL must
-    // coerce first.
-    const docIdStr = String(docId);
-    const normalized = docIdStr.startsWith('automerge:')
-      ? docIdStr
-      : `automerge:${docIdStr}`;
+    // sidecar throws `Invalid AutomergeUrl`. `normalizeDocId` is the
+    // shared normalization used by the file loaders too.
+    const normalized = normalizeDocId(docId);
     try {
       const handle = await findDoc<BinaryDocumentContent>(normalized as DocumentId);
       const doc = handle.doc();
@@ -867,6 +977,9 @@ export function createSyncClient(callbacks: SyncClientCallbacks, astOptions?: AS
     });
 
     state.fileHandles.delete(path);
+    // Deleting a dangling entry is the self-service repair for
+    // bd-vm5e5u10 — only the index is edited, no document fetch needed.
+    state.unavailableFiles.delete(path);
     state.binaryFiles.delete(path);
     astCache.delete(path);
     callbacks.onFileRemoved(path);
@@ -900,6 +1013,13 @@ export function createSyncClient(callbacks: SyncClientCallbacks, astOptions?: AS
     if (handle) {
       state.fileHandles.delete(oldPath);
       state.fileHandles.set(newPath, handle);
+    }
+
+    // A dangling entry can be renamed too — it only edits the index.
+    const ghostDocId = state.unavailableFiles.get(oldPath);
+    if (ghostDocId !== undefined) {
+      state.unavailableFiles.delete(oldPath);
+      state.unavailableFiles.set(newPath, ghostDocId);
     }
 
     if (state.binaryFiles.has(oldPath)) {
@@ -942,6 +1062,18 @@ export function createSyncClient(callbacks: SyncClientCallbacks, astOptions?: AS
    */
   function getFilePaths(): string[] {
     return Array.from(state.fileHandles.keys());
+  }
+
+  /**
+   * Dangling index entries currently known to this connection
+   * (bd-vm5e5u10): paths the index references whose documents the
+   * sync server could not provide. `docId` is as stored in the index.
+   * Empty when every file loaded. Listings should mark these
+   * `unavailable`; `deleteFile`/`renameFile` work on them (they only
+   * edit the index), which is the self-service repair path.
+   */
+  function getUnavailableFiles(): FileEntry[] {
+    return Array.from(state.unavailableFiles, ([path, docId]) => ({ path, docId }));
   }
 
   /**
@@ -1075,7 +1207,7 @@ export function createSyncClient(callbacks: SyncClientCallbacks, astOptions?: AS
         const changedDoc = indexHandle.doc();
         if (changedDoc) {
           const newFiles = getFilesFromIndex(changedDoc);
-          syncWithFiles(newFiles);
+          syncWithFilesHandled(newFiles);
           callbacks.onFilesChange?.(newFiles);
           notifyIdentitiesIfChanged(changedDoc);
         }
@@ -1178,6 +1310,7 @@ export function createSyncClient(callbacks: SyncClientCallbacks, astOptions?: AS
     isConnected,
     getFileHandle,
     getFilePaths,
+    getUnavailableFiles,
     createNewProject,
     getActorId,
   };

--- a/ts-packages/quarto-sync-client/src/client.ts
+++ b/ts-packages/quarto-sync-client/src/client.ts
@@ -45,6 +45,7 @@ import type {
   SyncClientAuthOptions,
 } from './types.js';
 import { computeSHA256 } from './hash.js';
+import { syncLog } from './log.js';
 
 /**
  * Build the WebSocket adapter for a sync connection. With `auth` set,
@@ -149,11 +150,11 @@ export function createSyncClient(callbacks: SyncClientCallbacks, astOptions?: AS
   const g = globalThis as any;
   if (typeof g.addEventListener === 'function') {
     const onBrowserOffline = () => {
-      console.log('Browser offline event fired');
+      syncLog('Browser offline event fired');
       callbacks.onConnectionChange?.(false);
     };
     const onBrowserOnline = () => {
-      console.log('Browser online event fired');
+      syncLog('Browser online event fired');
       callbacks.onConnectionChange?.(true);
     };
 
@@ -504,9 +505,9 @@ export function createSyncClient(callbacks: SyncClientCallbacks, astOptions?: AS
       // Try to connect to peer, but continue in offline mode if it fails
       let isOnline = false;
       try {
-        console.log('Waiting for peer connection...');
+        syncLog('Waiting for peer connection...');
         await waitForPeer(state.repo, peerTimeoutMs);
-        console.log('Peer connected - online mode');
+        syncLog('Peer connected - online mode');
         isOnline = true;
       } catch (peerError) {
         console.warn('Peer connection failed, continuing in offline mode:', peerError);
@@ -565,14 +566,14 @@ export function createSyncClient(callbacks: SyncClientCallbacks, astOptions?: AS
       const onPeerConnect = () => {
         if (!currentlyOnline) {
           currentlyOnline = true;
-          console.log('Peer connected - switching to online mode');
+          syncLog('Peer connected - switching to online mode');
           callbacks.onConnectionChange?.(true);
         }
       };
       const onPeerDisconnect = () => {
         if (currentlyOnline) {
           currentlyOnline = false;
-          console.log('Peer disconnected - switching to offline mode');
+          syncLog('Peer disconnected - switching to offline mode');
           callbacks.onConnectionChange?.(false);
         }
       };
@@ -951,9 +952,9 @@ export function createSyncClient(callbacks: SyncClientCallbacks, astOptions?: AS
       // helpers) should pass options.peerTimeoutMs to wait for the peer.
       let isOnline = false;
       try {
-        console.log('Waiting for peer connection...');
+        syncLog('Waiting for peer connection...');
         await waitForPeer(state.repo, options.peerTimeoutMs ?? 1);
-        console.log('Peer connected - online mode');
+        syncLog('Peer connected - online mode');
         isOnline = true;
       } catch (peerError) {
         console.warn('Peer connection failed, creating project in offline mode:', peerError);
@@ -973,13 +974,13 @@ export function createSyncClient(callbacks: SyncClientCallbacks, astOptions?: AS
 
       // Phase 2: Create the index document via createDoc with the
       // pre-generated ID so the first change uses the correct actor.
-      console.log(`[createNewProject] Creating index document with ID ${indexDocId}`);
+      syncLog(`[createNewProject] Creating index document with ID ${indexDocId}`);
       const indexHandle = createDoc<IndexDocument>(
         { files: {}, version: CURRENT_SCHEMA_VERSION, identities: {} },
         indexDocId,
       );
       state.indexHandle = indexHandle;
-      console.log(`[createNewProject] Index document created, ID:`, indexHandle.documentId);
+      syncLog(`[createNewProject] Index document created, ID:`, indexHandle.documentId);
 
       // Write identity (separate change so the schema init is clean).
       if (resolvedActorId && screenName) {
@@ -1056,14 +1057,14 @@ export function createSyncClient(callbacks: SyncClientCallbacks, astOptions?: AS
       const onPeerConnect = () => {
         if (!currentlyOnline) {
           currentlyOnline = true;
-          console.log('Peer connected - switching to online mode');
+          syncLog('Peer connected - switching to online mode');
           callbacks.onConnectionChange?.(true);
         }
       };
       const onPeerDisconnect = () => {
         if (currentlyOnline) {
           currentlyOnline = false;
-          console.log('Peer disconnected - switching to offline mode');
+          syncLog('Peer disconnected - switching to offline mode');
           callbacks.onConnectionChange?.(false);
         }
       };

--- a/ts-packages/quarto-sync-client/src/client.ts
+++ b/ts-packages/quarto-sync-client/src/client.ts
@@ -41,6 +41,8 @@ import type {
   CreateBinaryFileResult,
   CreateProjectOptions,
   CreateProjectResult,
+  DisconnectOptions,
+  DisconnectReport,
   FindDocRetryOptions,
   SyncClientAuthOptions,
 } from './types.js';
@@ -621,8 +623,13 @@ export function createSyncClient(callbacks: SyncClientCallbacks, astOptions?: AS
 
   /**
    * Disconnect from the sync server.
+   *
+   * With `drainMs > 0`, first gives outbound document sync a bounded
+   * window to reach the hub (see {@link DisconnectOptions}); the
+   * teardown itself is unconditional and identical either way.
    */
-  async function disconnect(): Promise<void> {
+  async function disconnect(options?: DisconnectOptions): Promise<DisconnectReport> {
+    const report: DisconnectReport = { drained: true, undelivered: [] };
     // Clean up subscriptions
     for (const cleanup of state.cleanupFns) {
       cleanup();
@@ -652,6 +659,7 @@ export function createSyncClient(callbacks: SyncClientCallbacks, astOptions?: AS
     lastCaptures = {};
 
     callbacks.onConnectionChange?.(false);
+    return report;
   }
 
   /**

--- a/ts-packages/quarto-sync-client/src/client.ts
+++ b/ts-packages/quarto-sync-client/src/client.ts
@@ -7,7 +7,7 @@
  */
 
 import { Repo, DocHandle, updateText, splice, generateAutomergeUrl, parseAutomergeUrl } from '@automerge/automerge-repo';
-import type { DocumentId, Patch } from '@automerge/automerge-repo';
+import type { DocumentId, Patch, StorageId } from '@automerge/automerge-repo';
 import { clone as automergeClone, from as automergeFrom, save as automergeSerialize } from '@automerge/automerge';
 import type { NetworkAdapter } from '@automerge/automerge-repo/slim';
 
@@ -101,6 +101,18 @@ async function buildWsAdapter(
 type FileDocument = TextDocumentContent | BinaryDocumentContent;
 
 /**
+ * Order-insensitive equality of two automerge head sets (URL-encoded
+ * change hashes). Equality with a peer's last-confirmed heads is the
+ * sync protocol's convergence steady state — the delivery signal the
+ * exit drain waits for (bd-10deu8h4).
+ */
+function sameHeads(a: readonly string[], b: readonly string[]): boolean {
+  if (a.length !== b.length) return false;
+  const bSet = new Set<string>(b);
+  return a.every((h) => bSet.has(h));
+}
+
+/**
  * Internal state for a sync client instance.
  */
 interface SyncClientState {
@@ -117,6 +129,14 @@ interface SyncClientState {
    * unavailable is the truth (offline), not a sync race.
    */
   connectedPeers: Set<string>;
+  /**
+   * storageIds announced in peer handshake metadata, by peerId.
+   * Storage-backed peers (the hub — samod always announces one) are
+   * the ones whose remote-heads sync info counts as delivery proof
+   * for the exit drain (bd-10deu8h4). Entries are kept after a peer
+   * disconnects: heads a hub confirmed remain delivered.
+   */
+  peerStorageIds: Map<string, string>;
   /** Resolved retry policy for the current connection. */
   findDocRetry: Required<FindDocRetryOptions>;
 }
@@ -151,6 +171,7 @@ export function createSyncClient(callbacks: SyncClientCallbacks, astOptions?: AS
     cleanupFns: [],
     actorId: null,
     connectedPeers: new Set(),
+    peerStorageIds: new Map(),
     findDocRetry: DEFAULT_FIND_DOC_RETRY,
   };
 
@@ -283,8 +304,19 @@ export function createSyncClient(callbacks: SyncClientCallbacks, astOptions?: AS
   // Must run before waitForPeer so the first peer event is counted.
   // Returns a cleanup registered into state.cleanupFns by the caller.
   function trackPeers(repo: Repo): void {
-    const onPeer = ({ peerId }: { peerId: string }) => {
+    const onPeer = ({
+      peerId,
+      peerMetadata,
+    }: {
+      peerId: string;
+      peerMetadata?: { storageId?: string };
+    }) => {
       state.connectedPeers.add(peerId);
+      // Deliberately not removed on peer-disconnected: see the field
+      // doc on SyncClientState.peerStorageIds.
+      if (peerMetadata?.storageId) {
+        state.peerStorageIds.set(peerId, peerMetadata.storageId);
+      }
     };
     const onPeerGone = ({ peerId }: { peerId: string }) => {
       state.connectedPeers.delete(peerId);
@@ -621,6 +653,86 @@ export function createSyncClient(callbacks: SyncClientCallbacks, astOptions?: AS
     }
   }
 
+  // ---------------------------------------------------------------------
+  // Exit drain (bd-10deu8h4)
+  //
+  // Delivery proof for a document: some storage-backed peer's
+  // last-confirmed heads (DocHandle sync info, which automerge-repo
+  // updates from `syncState.theirHeads` on every received sync
+  // message) equal the handle's current heads. The hub (samod) always
+  // announces a storageId in its handshake metadata, so against a real
+  // hub this signal fires as soon as the hub has acked our changes.
+  // ---------------------------------------------------------------------
+
+  /** Every document this connection is responsible for delivering. */
+  function trackedDocs(): Array<{ path: string | null; handle: DocHandle<unknown> }> {
+    const docs: Array<{ path: string | null; handle: DocHandle<unknown> }> = [];
+    if (state.indexHandle) {
+      docs.push({ path: null, handle: state.indexHandle as unknown as DocHandle<unknown> });
+    }
+    for (const [path, handle] of state.fileHandles) {
+      docs.push({ path, handle: handle as unknown as DocHandle<unknown> });
+    }
+    return docs;
+  }
+
+  /** True iff some storage-backed peer has confirmed the handle's current heads. */
+  function isDelivered(handle: DocHandle<unknown>): boolean {
+    // A handle that never became ready holds no local changes of ours
+    // — there is nothing to deliver (and `heads()` would throw).
+    if (!handle.isReady()) return true;
+    const heads = handle.heads();
+    for (const storageId of new Set(state.peerStorageIds.values())) {
+      const info = handle.getSyncInfo(storageId as StorageId);
+      if (info && sameHeads(info.lastHeads, heads)) return true;
+    }
+    return false;
+  }
+
+  /**
+   * Wait (bounded by `drainMs`, returning early on confirmation) until
+   * every tracked document is delivered. Event-driven: re-checks on
+   * each `remote-heads` update and on `peer` (a reconnect mid-drain
+   * brings a fresh storageId and a fresh chance to deliver). Never
+   * rejects; never waits past the budget.
+   */
+  async function drainOutbound(drainMs: number): Promise<DisconnectReport> {
+    const repo = state.repo;
+    if (!repo) return { drained: true, undelivered: [] };
+    const docs = trackedDocs();
+    const pendingDocs = () => docs.filter((d) => !isDelivered(d.handle));
+
+    if (pendingDocs().length > 0) {
+      await new Promise<void>((resolve) => {
+        let done = false;
+        const cleanups: Array<() => void> = [];
+        const finish = () => {
+          if (done) return;
+          done = true;
+          for (const cleanup of cleanups) cleanup();
+          resolve();
+        };
+        const timer = setTimeout(finish, drainMs);
+        cleanups.push(() => clearTimeout(timer));
+        const recheck = () => {
+          if (pendingDocs().length === 0) finish();
+        };
+        for (const { handle } of docs) {
+          handle.on('remote-heads', recheck);
+          cleanups.push(() => handle.off('remote-heads', recheck));
+        }
+        repo.networkSubsystem.on('peer', recheck);
+        cleanups.push(() => repo.networkSubsystem.off('peer', recheck));
+      });
+    }
+
+    const undelivered = pendingDocs().map(({ path, handle }) => ({
+      path,
+      docId: String(handle.documentId),
+    }));
+    return { drained: undelivered.length === 0, undelivered };
+  }
+
   /**
    * Disconnect from the sync server.
    *
@@ -629,7 +741,18 @@ export function createSyncClient(callbacks: SyncClientCallbacks, astOptions?: AS
    * teardown itself is unconditional and identical either way.
    */
   async function disconnect(options?: DisconnectOptions): Promise<DisconnectReport> {
-    const report: DisconnectReport = { drained: true, undelivered: [] };
+    const drainMs = options?.drainMs ?? 0;
+    let report: DisconnectReport = { drained: true, undelivered: [] };
+    if (drainMs > 0 && state.repo) {
+      report = await drainOutbound(drainMs);
+      if (!report.drained) {
+        syncLog(
+          `[disconnect] drain budget (${drainMs} ms) expired with ` +
+            `${report.undelivered.length} possibly-undelivered document(s): ` +
+            report.undelivered.map((u) => u.path ?? `<index ${u.docId}>`).join(', '),
+        );
+      }
+    }
     // Clean up subscriptions
     for (const cleanup of state.cleanupFns) {
       cleanup();
@@ -654,6 +777,7 @@ export function createSyncClient(callbacks: SyncClientCallbacks, astOptions?: AS
     state.indexHandle = null;
     state.actorId = null;
     state.connectedPeers = new Set();
+    state.peerStorageIds = new Map();
     state.findDocRetry = DEFAULT_FIND_DOC_RETRY;
     lastIdentities = {};
     lastCaptures = {};

--- a/ts-packages/quarto-sync-client/src/client.ts
+++ b/ts-packages/quarto-sync-client/src/client.ts
@@ -48,6 +48,22 @@ import { computeSHA256 } from './hash.js';
 import { syncLog } from './log.js';
 
 /**
+ * The sync server could not be reached within the peer-wait budget
+ * and the caller demanded a live connection (`requireOnline: true`).
+ * See bd-xnmd5ni1.
+ */
+export class PeerUnavailableError extends Error {
+  override readonly name = 'PeerUnavailableError';
+  constructor(serverUrl: string, timeoutMs: number, cause?: unknown) {
+    super(
+      `no peer connection to ${serverUrl} within ${timeoutMs} ms; ` +
+        'refusing to continue offline (requireOnline is set)',
+    );
+    if (cause !== undefined) (this as { cause?: unknown }).cause = cause;
+  }
+}
+
+/**
  * Build the WebSocket adapter for a sync connection. With `auth` set,
  * we lazily import the Node adapter (which depends on `ws`) so browser
  * bundles never pull it in. Without `auth`, the upstream browser
@@ -510,6 +526,13 @@ export function createSyncClient(callbacks: SyncClientCallbacks, astOptions?: AS
         syncLog('Peer connected - online mode');
         isOnline = true;
       } catch (peerError) {
+        if (options.requireOnline) {
+          // Tear down the adapter's reconnect loop before failing —
+          // the caller asked for online-or-error, not a background
+          // retry it can't observe.
+          await disconnect();
+          throw new PeerUnavailableError(syncServerUrl, peerTimeoutMs, peerError);
+        }
         console.warn('Peer connection failed, continuing in offline mode:', peerError);
         isOnline = false;
       }
@@ -957,6 +980,14 @@ export function createSyncClient(callbacks: SyncClientCallbacks, astOptions?: AS
         syncLog('Peer connected - online mode');
         isOnline = true;
       } catch (peerError) {
+        if (options.requireOnline) {
+          await disconnect();
+          throw new PeerUnavailableError(
+            options.syncServer,
+            options.peerTimeoutMs ?? 1,
+            peerError,
+          );
+        }
         console.warn('Peer connection failed, creating project in offline mode:', peerError);
         isOnline = false;
       }

--- a/ts-packages/quarto-sync-client/src/dangling-entries.test.ts
+++ b/ts-packages/quarto-sync-client/src/dangling-entries.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Graceful degradation for dangling index entries (bd-vm5e5u10).
+ *
+ * A project's index maps paths → automerge doc ids. When one referenced
+ * document does not exist on the hub (a "dangling entry" — production
+ * evidence: /cscheid/q2-mcp-hello.qmd in the 2026-06-12 incident,
+ * bd-p68lx71t), the project must stay usable:
+ *
+ *  - connect() succeeds if the INDEX loads; unavailable files are
+ *    skipped, surfaced (status marker + onFileUnavailable), and do not
+ *    affect other files;
+ *  - a dangling entry appearing mid-session (the index-change path)
+ *    must not throw / reject unhandled;
+ *  - the index document remaining unavailable stays fatal, with an
+ *    error message that says "index" (file-vs-index confusion misled
+ *    the 2026-06-12 incident response).
+ *
+ * The production fixture no longer exists (the entry was surgically
+ * removed), so tests mint their own ghost entries by mutating the
+ * index through the test hub's own repo handle.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  generateAutomergeUrl,
+  parseAutomergeUrl,
+  type DocumentId,
+} from '@automerge/automerge-repo';
+
+import {
+  createSyncClient,
+  fileUnavailableMessage,
+  indexUnavailableMessage,
+  type SyncClient,
+} from './client.js';
+import type { SyncClientCallbacks } from './types.js';
+import { startTestHub, type TestHub } from './test-hub.js';
+
+let hub: TestHub;
+const liveClients: SyncClient[] = [];
+
+beforeEach(async () => {
+  hub = await startTestHub();
+});
+
+afterEach(async () => {
+  for (const c of liveClients.splice(0)) {
+    await c.disconnect();
+  }
+  await hub.stop();
+});
+
+function client(callbacks: Partial<SyncClientCallbacks> = {}): SyncClient {
+  const c = createSyncClient({
+    onFileAdded: () => {},
+    onFileChanged: () => {},
+    onFileRemoved: () => {},
+    ...callbacks,
+  });
+  liveClients.push(c);
+  return c;
+}
+
+/** A valid-format document id that no repo anywhere holds. */
+function unknownDocId(): string {
+  return parseAutomergeUrl(generateAutomergeUrl()).documentId;
+}
+
+/**
+ * Mint a dangling entry: mutate the project index through the hub's
+ * own repo handle, pointing `path` at a document that does not exist.
+ * Returns the ghost doc id.
+ */
+async function mintGhostEntry(indexDocId: string, path: string): Promise<string> {
+  const ghostId = unknownDocId();
+  const handle = await hub.repo.find<{ files: Record<string, string> }>(
+    indexDocId as DocumentId,
+  );
+  handle.change((d) => {
+    d.files[path] = ghostId;
+  });
+  return ghostId;
+}
+
+/**
+ * Create a project on the hub with the given text files and wait until
+ * the hub actually holds every document (creation syncs in the
+ * background), then disconnect the creator.
+ */
+async function createProjectOnHub(
+  files: Array<{ path: string; content: string }>,
+): Promise<string> {
+  const creator = createSyncClient({
+    onFileAdded: () => {},
+    onFileChanged: () => {},
+    onFileRemoved: () => {},
+  });
+  const result = await creator.createNewProject({
+    syncServer: hub.url,
+    files: files.map((f) => ({ ...f, contentType: 'text' as const })),
+    storage: 'memory',
+    peerTimeoutMs: 10000,
+    requireOnline: true,
+  });
+  expect(await hub.hubHasDoc(result.indexDocId, 8000), 'index doc must reach the hub').toBe(true);
+  for (const f of result.files) {
+    expect(await hub.hubHasDoc(f.docId, 8000), `file doc for ${f.path} must reach the hub`).toBe(true);
+  }
+  await creator.disconnect();
+  return result.indexDocId;
+}
+
+/** Poll until `cond()` is true or the deadline passes. */
+async function until(cond: () => boolean, timeoutMs = 10000, what = 'condition'): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!cond()) {
+    if (Date.now() > deadline) {
+      throw new Error(`timed out waiting for ${what}`);
+    }
+    await new Promise((r) => setTimeout(r, 50));
+  }
+}
+
+/** Fast findDoc retry policy so unavailable-doc probes don't dominate test time. */
+const FAST_RETRY = { attempts: 1, baseDelayMs: 10 };
+
+describe('connect with a dangling index entry', () => {
+  it('succeeds, loads the real files, and surfaces the ghost as unavailable', async () => {
+    const indexDocId = await createProjectOnHub([
+      { path: 'one.qmd', content: 'first real file\n' },
+      { path: 'two.qmd', content: 'second real file\n' },
+    ]);
+    const ghostId = await mintGhostEntry(indexDocId, 'ghost.qmd');
+
+    const added: string[] = [];
+    const unavailable: Array<{ path: string; docId: string }> = [];
+    const reader = client({
+      onFileAdded: (path) => {
+        added.push(path);
+      },
+      onFileUnavailable: (path, docId) => {
+        unavailable.push({ path, docId });
+      },
+    });
+
+    // RED today: connect() rejects with `Document <ghost> is unavailable`.
+    const entries = await reader.connect(hub.url, indexDocId, undefined, undefined, undefined, {
+      storage: 'memory',
+      peerTimeoutMs: 10000,
+      requireOnline: true,
+      findDocRetry: FAST_RETRY,
+    });
+
+    // All three index entries are reported, the ghost marked unavailable.
+    expect(entries.map((e) => e.path).sort()).toEqual(['ghost.qmd', 'one.qmd', 'two.qmd']);
+    const ghostEntry = entries.find((e) => e.path === 'ghost.qmd')!;
+    expect(ghostEntry.status).toBe('unavailable');
+    expect(ghostEntry.docId).toBe(ghostId);
+    for (const real of ['one.qmd', 'two.qmd']) {
+      expect(entries.find((e) => e.path === real)!.status).not.toBe('unavailable');
+    }
+
+    // Real files loaded; the ghost was surfaced, not silently dropped.
+    expect(added.sort()).toEqual(['one.qmd', 'two.qmd']);
+    expect(unavailable).toEqual([{ path: 'ghost.qmd', docId: ghostId }]);
+    expect(reader.getUnavailableFiles()).toEqual([{ path: 'ghost.qmd', docId: ghostId }]);
+
+    // The project is usable: real content reads fine.
+    expect(reader.getFileContent('one.qmd')).toBe('first real file\n');
+    expect(reader.getFileContent('two.qmd')).toBe('second real file\n');
+    // The ghost has no content (it is listed, not readable).
+    expect(reader.getFileContent('ghost.qmd')).toBeNull();
+  }, 30000);
+});
+
+describe('dangling entry appearing mid-session', () => {
+  it('does not blow up an already-open session; existing files keep working', async () => {
+    const indexDocId = await createProjectOnHub([
+      { path: 'steady.qmd', content: 'present from the start\n' },
+    ]);
+
+    const unavailable: Array<{ path: string; docId: string }> = [];
+    const reader = client({
+      onFileUnavailable: (path, docId) => {
+        unavailable.push({ path, docId });
+      },
+    });
+    await reader.connect(hub.url, indexDocId, undefined, undefined, undefined, {
+      storage: 'memory',
+      peerTimeoutMs: 10000,
+      requireOnline: true,
+      findDocRetry: FAST_RETRY,
+    });
+    expect(reader.getFileContent('steady.qmd')).toBe('present from the start\n');
+
+    // The dangling entry appears mid-session (how already-open
+    // colleagues got hit on 2026-06-12). RED today: the index-change
+    // handler's fire-and-forget syncWithFiles rejects unhandled
+    // (vitest fails the run) and onFileUnavailable never fires.
+    const ghostId = await mintGhostEntry(indexDocId, 'ghost.qmd');
+
+    await until(() => unavailable.length > 0, 10000, 'onFileUnavailable for the ghost');
+    expect(unavailable).toEqual([{ path: 'ghost.qmd', docId: ghostId }]);
+
+    // The session stays usable: read and write the existing file.
+    expect(reader.getFileContent('steady.qmd')).toBe('present from the start\n');
+    reader.updateFileContent('steady.qmd', 'edited after the ghost appeared\n');
+    await until(
+      () => reader.getFileContent('steady.qmd') === 'edited after the ghost appeared\n',
+      10000,
+      'edit to apply',
+    );
+  }, 30000);
+});
+
+describe('unavailable index document', () => {
+  it('stays fatal, and the error says index (not file) and names the id', async () => {
+    const bogusIndexId = unknownDocId();
+    const reader = client();
+
+    await expect(
+      reader.connect(hub.url, bogusIndexId, undefined, undefined, undefined, {
+        storage: 'memory',
+        peerTimeoutMs: 10000,
+        requireOnline: true,
+        findDocRetry: FAST_RETRY,
+      }),
+    ).rejects.toThrow(/index/i);
+
+    await expect(
+      reader.connect(hub.url, bogusIndexId, undefined, undefined, undefined, {
+        storage: 'memory',
+        peerTimeoutMs: 10000,
+        requireOnline: true,
+        findDocRetry: FAST_RETRY,
+      }),
+    ).rejects.toThrow(new RegExp(bogusIndexId));
+  }, 30000);
+});
+
+describe('error message clarity (locked wording, bd-vm5e5u10 requirement 5)', () => {
+  it('the file-unavailable message names the path, the doc id, and the sync server', () => {
+    const msg = fileUnavailableMessage('cscheid/q2-mcp-hello.qmd', '3HJoqsMxPYRDFumPVKDznYALmoVf');
+    expect(msg).toContain("file document for 'cscheid/q2-mcp-hello.qmd'");
+    expect(msg).toContain('automerge:3HJoqsMxPYRDFumPVKDznYALmoVf');
+    expect(msg).toContain('unavailable on the sync server');
+    // The likely cause, so incident responders aren't misled.
+    expect(msg).toContain('never synced');
+  });
+
+  it('the index-unavailable message says index and names the id', () => {
+    const msg = indexUnavailableMessage('3HJoqsMxPYRDFumPVKDznYALmoVf');
+    expect(msg).toContain('project index document');
+    expect(msg).toContain('automerge:3HJoqsMxPYRDFumPVKDznYALmoVf');
+    expect(msg).toContain('unavailable on the sync server');
+  });
+});

--- a/ts-packages/quarto-sync-client/src/exit-drain.test.ts
+++ b/ts-packages/quarto-sync-client/src/exit-drain.test.ts
@@ -15,6 +15,13 @@
  */
 
 import { describe, it, expect, afterEach } from 'vitest';
+import { spawn, type ChildProcess } from 'node:child_process';
+import { once } from 'node:events';
+import * as fs from 'node:fs';
+import * as net from 'node:net';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { createSyncClient, type SyncClient } from './client.js';
 import { startTestHub, type TestHub } from './test-hub.js';
@@ -109,4 +116,100 @@ describe('disconnect with a drain budget (bd-10deu8h4)', () => {
       'the outage-created file must be named as possibly lost',
     ).toContain('doomed.qmd');
   }, 30000);
+});
+
+// ---------------------------------------------------------------------------
+// Real-Rust-hub variant (samod). The drain's delivery signal keys off the
+// hub's handshake storageId + remote-heads sync info; the JS test hub above
+// was *made* to mimic samod's shape, so this gated test is the proof against
+// the production implementation itself (plan § Phase 1 verdict, point 2).
+// Gated on target/debug/hub (cargo build -p quarto-hub), unix only — same
+// pattern as restart-window-creation.test.ts.
+// ---------------------------------------------------------------------------
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+const hubBin = path.join(repoRoot, 'target', 'debug', 'hub');
+const runRustHub = fs.existsSync(hubBin) && process.platform !== 'win32';
+if (!runRustHub) {
+  // eslint-disable-next-line no-console
+  console.error(`[exit-drain] SKIPPING rust-hub variant: hub binary missing at ${hubBin}`);
+}
+
+async function freePort(): Promise<number> {
+  const srv = net.createServer();
+  srv.listen(0, '127.0.0.1');
+  await once(srv, 'listening');
+  const port = (srv.address() as net.AddressInfo).port;
+  srv.close();
+  await once(srv, 'close');
+  return port;
+}
+
+async function waitForHealth(port: number, timeoutMs = 15000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let lastErr: unknown;
+  while (Date.now() < deadline) {
+    try {
+      const resp = await fetch(`http://127.0.0.1:${port}/health`);
+      if (resp.status < 500) return;
+      lastErr = resp.status;
+    } catch (err) {
+      lastErr = err;
+    }
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  throw new Error(`hub not healthy on :${port}: ${lastErr}`);
+}
+
+function docInStorage(dataDir: string, docId: string): boolean {
+  return fs.existsSync(path.join(dataDir, 'automerge', docId.slice(0, 2), docId.slice(2)));
+}
+
+describe.runIf(runRustHub)('drain against the real samod hub (bd-10deu8h4)', () => {
+  let rustHub: ChildProcess | undefined;
+  let tmpDir: string | undefined;
+
+  afterEach(async () => {
+    rustHub?.kill('SIGKILL');
+    if (rustHub) await once(rustHub, 'exit').catch(() => {});
+    rustHub = undefined;
+    if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+    tmpDir = undefined;
+  });
+
+  it('create-then-disconnect delivers every doc into samod storage', async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'exit-drain-rust-'));
+    const port = await freePort();
+    rustHub = spawn(hubBin, ['--data-dir', tmpDir, '-P', String(port), '-H', '127.0.0.1'], {
+      stdio: ['ignore', 'ignore', process.env['DEBUG_MCP'] ? 'inherit' : 'ignore'],
+    });
+    await waitForHealth(port);
+
+    client = createSyncClient(noopCallbacks);
+    const created = await client.createNewProject({
+      syncServer: `ws://127.0.0.1:${port}/ws`,
+      files: accidentFiles(),
+      storage: 'memory',
+      requireOnline: true,
+      peerTimeoutMs: 10000,
+    });
+
+    const report = await client.disconnect({ drainMs: 5000 });
+    expect(report.drained, 'samod must confirm delivery within the budget').toBe(true);
+
+    // Hub-side ground truth: the document files exist in samod's
+    // on-disk storage. No settle wait — delivery was confirmed
+    // *before* disconnect returned, modulo samod's own disk flush.
+    const deadline = Date.now() + 10000;
+    const allDocIds = [created.indexDocId, ...created.files.map((f) => f.docId)];
+    for (const docId of allDocIds) {
+      while (!docInStorage(tmpDir, docId) && Date.now() < deadline) {
+        await new Promise((r) => setTimeout(r, 100));
+      }
+      expect(
+        docInStorage(tmpDir, docId),
+        `doc ${docId} must be in samod storage after a drained disconnect`,
+      ).toBe(true);
+    }
+  }, 60000);
 });

--- a/ts-packages/quarto-sync-client/src/exit-drain.test.ts
+++ b/ts-packages/quarto-sync-client/src/exit-drain.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Exit-drain regression tests (bd-10deu8h4) — the 2026-06-12 incident,
+ * miniaturized at the sync-client level.
+ *
+ * The accident: an MCP host created documents over a live connection
+ * (requireOnline, memory storage) and tore the client down immediately
+ * afterwards. `disconnect()` killed the adapter before outbound sync
+ * finished; the documents' only copy died with the process, leaving a
+ * dangling index entry on the hub.
+ *
+ * Contract under test: `disconnect({ drainMs })` gives outbound sync a
+ * bounded window to reach the hub, returns early on confirmation, and
+ * reports what it could not confirm. Ground truth is always the hub's
+ * own repo (`hubHasDoc`), never client-side state.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+
+import { createSyncClient, type SyncClient } from './client.js';
+import { startTestHub, type TestHub } from './test-hub.js';
+import type { SyncClientCallbacks } from './types.js';
+
+const noopCallbacks: SyncClientCallbacks = {
+  onFileAdded: () => {},
+  onFileChanged: () => {},
+  onBinaryChanged: () => {},
+  onFileRemoved: () => {},
+};
+
+// Enough payload to keep delivery genuinely in flight when disconnect
+// is called right after creation — a single tiny file can win the race
+// by luck, which would mask the defect (see plan, Phase 1).
+const FILE_COUNT = 8;
+const FILE_BYTES = 64 * 1024;
+
+function accidentFiles() {
+  return Array.from({ length: FILE_COUNT }, (_, i) => ({
+    path: `accident-${i}.qmd`,
+    content: `file ${i}\n${'x'.repeat(FILE_BYTES)}\n`,
+    contentType: 'text' as const,
+  }));
+}
+
+let hub: TestHub | undefined;
+let client: SyncClient | undefined;
+
+afterEach(async () => {
+  await client?.disconnect();
+  client = undefined;
+  await hub?.stop();
+  hub = undefined;
+});
+
+describe('disconnect with a drain budget (bd-10deu8h4)', () => {
+  it('create-then-disconnect loses nothing: created docs reach the hub', async () => {
+    hub = await startTestHub();
+    client = createSyncClient(noopCallbacks);
+
+    const created = await client.createNewProject({
+      syncServer: hub.url,
+      files: accidentFiles(),
+      storage: 'memory',
+      requireOnline: true,
+      peerTimeoutMs: 10000,
+    });
+
+    // The accident shape: teardown immediately after creation.
+    const report = await client.disconnect({ drainMs: 5000 });
+
+    expect(report.drained).toBe(true);
+    expect(report.undelivered).toEqual([]);
+    expect(
+      await hub.hubHasDoc(created.indexDocId, 2000),
+      'index doc must reach the hub',
+    ).toBe(true);
+    for (const f of created.files) {
+      expect(
+        await hub.hubHasDoc(f.docId, 2000),
+        `file doc for ${f.path} must reach the hub — its only copy was in-process`,
+      ).toBe(true);
+    }
+  }, 30000);
+
+  it('reports undelivered docs when the hub is unreachable at disconnect', async () => {
+    hub = await startTestHub();
+    client = createSyncClient(noopCallbacks);
+
+    await client.createNewProject({
+      syncServer: hub.url,
+      files: [{ path: 'hello.qmd', content: 'survives\n', contentType: 'text' }],
+      storage: 'memory',
+      requireOnline: true,
+      peerTimeoutMs: 10000,
+      // Keep the reconnect loop from hammering the dead port during
+      // the drain window below.
+      retryIntervalMs: 60000,
+    });
+
+    // Hub goes away mid-session; a file is created during the outage.
+    await hub.stop();
+    hub = undefined;
+    await client.createFile('doomed.qmd', 'created while the hub was down\n');
+
+    const report = await client.disconnect({ drainMs: 400 });
+
+    expect(report.drained, 'drain cannot succeed against a dead hub').toBe(false);
+    expect(
+      report.undelivered.map((u) => u.path),
+      'the outage-created file must be named as possibly lost',
+    ).toContain('doomed.qmd');
+  }, 30000);
+});

--- a/ts-packages/quarto-sync-client/src/index.ts
+++ b/ts-packages/quarto-sync-client/src/index.ts
@@ -49,6 +49,11 @@ export type {
 export { createSyncClient } from './client.js';
 export type { SyncClient } from './client.js';
 
+// Injectable diagnostic-log sink (bd-sl4o01y0): stdio hosts (hub-mcp)
+// must route library diagnostics to stderr; browsers keep console.log.
+export { setSyncLogger, syncLog } from './log.js';
+export type { SyncLogger } from './log.js';
+
 // Browser adapter with terminal disconnect (zombie-reconnect fix,
 // bd-jit6pdwq) — used internally by connect(); exported for tests
 // and for consumers that build adapters directly.

--- a/ts-packages/quarto-sync-client/src/index.ts
+++ b/ts-packages/quarto-sync-client/src/index.ts
@@ -28,6 +28,7 @@ export {
 
 // Export sync client types
 export type {
+  AnnotatedFileEntry,
   Patch,
   EditorContentChange,
   TextFilePayload,
@@ -46,7 +47,14 @@ export type {
 } from './types.js';
 
 // Export sync client
-export { createSyncClient, PeerUnavailableError } from './client.js';
+export {
+  createSyncClient,
+  PeerUnavailableError,
+  // Locked unavailability wording (bd-vm5e5u10) — reused by hub-mcp
+  // so per-file tool errors match the sync client's diagnostics.
+  fileUnavailableMessage,
+  indexUnavailableMessage,
+} from './client.js';
 export type { SyncClient } from './client.js';
 
 // Injectable diagnostic-log sink (bd-sl4o01y0): stdio hosts (hub-mcp)

--- a/ts-packages/quarto-sync-client/src/index.ts
+++ b/ts-packages/quarto-sync-client/src/index.ts
@@ -46,7 +46,7 @@ export type {
 } from './types.js';
 
 // Export sync client
-export { createSyncClient } from './client.js';
+export { createSyncClient, PeerUnavailableError } from './client.js';
 export type { SyncClient } from './client.js';
 
 // Injectable diagnostic-log sink (bd-sl4o01y0): stdio hosts (hub-mcp)

--- a/ts-packages/quarto-sync-client/src/index.ts
+++ b/ts-packages/quarto-sync-client/src/index.ts
@@ -40,9 +40,12 @@ export type {
   CreateBinaryFileResult,
   CreateProjectOptions,
   CreateProjectResult,
+  DisconnectOptions,
+  DisconnectReport,
   FindDocRetryOptions,
   StorageKind,
   SyncClientAuthOptions,
+  UndeliveredDoc,
 } from './types.js';
 
 // Export sync client
@@ -71,6 +74,12 @@ export type {
   WebSocketFactory,
   WebSocketLike,
 } from './NodeWebSocketClientAdapter.js';
+
+// In-memory storage adapter. Exported for test hubs that need a
+// storageId in their handshake metadata (the real samod hub always
+// announces one — exit-drain delivery confirmation keys off it,
+// bd-10deu8h4).
+export { MemoryStorageAdapter } from './storage-adapter.js';
 
 // Export utilities
 export { computeSHA256 } from './hash.js';

--- a/ts-packages/quarto-sync-client/src/log.test.ts
+++ b/ts-packages/quarto-sync-client/src/log.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Tests for the injectable diagnostic logger (bd-sl4o01y0).
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { setSyncLogger, syncLog } from './log.js';
+
+const srcDir = path.dirname(fileURLToPath(import.meta.url));
+
+describe('syncLog', () => {
+  afterEach(() => {
+    // restore the default sink so test order can't leak a custom logger
+    setSyncLogger((...args) => console.log(...args));
+  });
+
+  it('defaults to console.log (browser behavior)', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    syncLog('hello', 42);
+    expect(spy).toHaveBeenCalledWith('hello', 42);
+    spy.mockRestore();
+  });
+
+  it('routes through an injected sink instead of console.log', () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const lines: unknown[][] = [];
+    setSyncLogger((...args) => lines.push(args));
+    syncLog('peer connected', { peerId: 'x' });
+    expect(lines).toEqual([['peer connected', { peerId: 'x' }]]);
+    expect(consoleSpy).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+});
+
+describe('stdout-purity invariant', () => {
+  it('no library source calls console.log directly (use syncLog)', () => {
+    // Library code must route diagnostics through the injectable
+    // logger: a direct console.log corrupts stdio MCP hosts
+    // (bd-sl4o01y0). log.ts holds the single sanctioned default.
+    const offenders: string[] = [];
+    for (const entry of fs.readdirSync(srcDir)) {
+      if (!entry.endsWith('.ts') || entry.endsWith('.test.ts')) continue;
+      if (entry === 'log.ts') continue;
+      const content = fs.readFileSync(path.join(srcDir, entry), 'utf8');
+      content.split('\n').forEach((line, i) => {
+        if (line.includes('console.log(')) {
+          offenders.push(`${entry}:${i + 1}: ${line.trim()}`);
+        }
+      });
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/ts-packages/quarto-sync-client/src/log.ts
+++ b/ts-packages/quarto-sync-client/src/log.ts
@@ -1,0 +1,29 @@
+/**
+ * Injectable diagnostic logger for the sync client.
+ *
+ * The sync client runs in two very different hosts:
+ *
+ *  - the browser (hub-client SPA), where `console.log` is the natural
+ *    sink for connection-progress diagnostics; and
+ *  - stdio MCP servers (quarto-hub-mcp), where stdout carries the
+ *    JSON-RPC protocol stream and ANY non-protocol write corrupts it
+ *    (bd-sl4o01y0) — diagnostics must go to stderr.
+ *
+ * Library code must therefore never call `console.log` directly; it
+ * calls `syncLog`, and the host decides where that goes. The default
+ * preserves the browser behavior.
+ */
+
+export type SyncLogger = (...args: unknown[]) => void;
+
+let logger: SyncLogger = (...args) => console.log(...args);
+
+/** Replace the diagnostic log sink (e.g. stderr in stdio servers). */
+export function setSyncLogger(fn: SyncLogger): void {
+  logger = fn;
+}
+
+/** Emit a connection-progress / diagnostic line via the current sink. */
+export function syncLog(...args: unknown[]): void {
+  logger(...args);
+}

--- a/ts-packages/quarto-sync-client/src/offline-creation-rust-hub.test.ts
+++ b/ts-packages/quarto-sync-client/src/offline-creation-rust-hub.test.ts
@@ -1,0 +1,105 @@
+/**
+ * D1 localization, Rust-hub variant (bd-10bdjmjb Phase 1).
+ *
+ * The JS-hub run (offline-creation.test.ts) PASSES — the client
+ * announces created-while-offline documents fine to a JS
+ * automerge-repo server. This test plays the identical scenario
+ * against the real samod-based `hub` binary: client starts while the
+ * port is dead (= the restart window), creates a project + file in
+ * offline-fallback mode, then the hub comes up and the adapter's
+ * retry loop reconnects. If documents don't land in the hub's
+ * storage, the gap is hub-side (samod accept path) — hypothesis (b).
+ *
+ * Gated: skips unless target/debug/hub exists (cargo build -p
+ * quarto-hub) on a unix host. Ground truth is the hub's storage
+ * directory (the same check used on production during the incident:
+ * /mnt/hub-data/automerge/<2-char shard>/<rest>).
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { spawn, type ChildProcess } from 'node:child_process';
+import { once } from 'node:events';
+import * as fs from 'node:fs';
+import * as net from 'node:net';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { createSyncClient } from './client.js';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+const hubBin = path.join(repoRoot, 'target', 'debug', 'hub');
+const runIt = fs.existsSync(hubBin) && process.platform !== 'win32';
+if (!runIt) {
+  // eslint-disable-next-line no-console
+  console.error(`[offline-creation-rust-hub] SKIPPING: hub binary missing at ${hubBin}`);
+}
+
+async function freePort(): Promise<number> {
+  const srv = net.createServer();
+  srv.listen(0, '127.0.0.1');
+  await once(srv, 'listening');
+  const port = (srv.address() as net.AddressInfo).port;
+  srv.close();
+  await once(srv, 'close');
+  return port;
+}
+
+function docInStorage(dataDir: string, docId: string): boolean {
+  return fs.existsSync(path.join(dataDir, 'automerge', docId.slice(0, 2), docId.slice(2)));
+}
+
+async function waitForDocInStorage(dataDir: string, docId: string, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (docInStorage(dataDir, docId)) return true;
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  return false;
+}
+
+let hub: ChildProcess | undefined;
+let tmpDir: string | undefined;
+
+afterEach(() => {
+  hub?.kill();
+  hub = undefined;
+  if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+  tmpDir = undefined;
+});
+
+describe.runIf(runIt)('created-while-offline documents vs the real hub', () => {
+  it('reach the hub storage after the hub comes up and the client reconnects', async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'offline-creation-hub-'));
+    const port = await freePort();
+
+    // 1. Client starts while the hub port is dead — the restart window.
+    const c = createSyncClient({
+      onFileAdded: () => {},
+      onFileChanged: () => {},
+      onFileRemoved: () => {},
+    });
+    const created = await c.createNewProject({
+      syncServer: `ws://127.0.0.1:${port}/ws`,
+      files: [{ path: 'made-offline.qmd', content: 'created in the window\n', contentType: 'text' }],
+      storage: 'memory',
+      peerTimeoutMs: 50,
+      retryIntervalMs: 500, // fast reconnect loop for the test
+    });
+    const fileDocId = created.files[0]!.docId;
+
+    // 2. The hub comes up on that port.
+    hub = spawn(hubBin, ['--data-dir', tmpDir, '-P', String(port), '-H', '127.0.0.1'], {
+      stdio: ['ignore', 'ignore', process.env['DEBUG_MCP'] ? 'inherit' : 'ignore'],
+    });
+
+    // 3. The retry loop reconnects; documents must land in storage.
+    const indexArrived = await waitForDocInStorage(tmpDir, created.indexDocId, 15000);
+    const fileArrived = await waitForDocInStorage(tmpDir, fileDocId, 15000);
+
+    await c.disconnect();
+
+    expect(indexArrived, `index doc ${created.indexDocId} must reach hub storage`).toBe(true);
+    expect(fileArrived, `file doc ${fileDocId} must reach hub storage`).toBe(true);
+  }, 60000);
+});

--- a/ts-packages/quarto-sync-client/src/offline-creation.test.ts
+++ b/ts-packages/quarto-sync-client/src/offline-creation.test.ts
@@ -1,0 +1,95 @@
+/**
+ * D1 localization red tests (bd-10bdjmjb Phase 1): documents created
+ * while the peer connection hasn't been established yet MUST reach
+ * the hub once the connection arrives. Today they don't (production
+ * evidence: the hello-claude.qmd dangling index entry, bd-8x482xb0).
+ *
+ * The JS-hub run localizes the defect: if the loss reproduces here,
+ * the gap is client-side (announce-on-connect); the Rust-hub variant
+ * (offline-creation-rust-hub.test.ts, binary-gated) discriminates a
+ * samod accept-policy gap. Verdict belongs in the plan:
+ * claude-notes/plans/2026-06-12-sync-client-offline-race.md.
+ *
+ * The repro mirrors production: the client starts while the hub is
+ * unreachable (upgrades held = the restart window / lost 1 ms race),
+ * creates a project + file in the silent offline-fallback mode, and
+ * the connection lands moments later.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { createSyncClient } from './client.js';
+import { startTestHub, type TestHub } from './test-hub.js';
+
+let hub: TestHub;
+
+beforeEach(async () => {
+  hub = await startTestHub({ holdUpgrades: true });
+});
+
+afterEach(async () => {
+  await hub.stop();
+});
+
+function client() {
+  return createSyncClient({
+    onFileAdded: () => {},
+    onFileChanged: () => {},
+    onFileRemoved: () => {},
+  });
+}
+
+describe('documents created during the offline-fallback window', () => {
+  it('reach the hub once the peer connection arrives', async () => {
+    const c = client();
+    // Hub holds upgrades: the 50ms peer wait loses, createNewProject
+    // proceeds in offline-fallback mode (today's silent default).
+    const result = await c.createNewProject({
+      syncServer: hub.url,
+      files: [{ path: 'made-offline.qmd', content: 'created in the window\n', contentType: 'text' }],
+      storage: 'memory',
+      peerTimeoutMs: 50,
+    });
+    expect(result.indexDocId).toBeTruthy();
+    const fileDocId = result.files[0]!.docId;
+
+    // The connection arrives "moments later" — the production
+    // sequence behind 'Peer connected - switching to online mode'.
+    hub.releaseUpgrades();
+
+    // Ground truth: the hub must end up holding BOTH documents.
+    expect(await hub.hubHasDoc(result.indexDocId, 8000), 'index doc must reach the hub').toBe(true);
+    expect(await hub.hubHasDoc(fileDocId, 8000), 'file doc must reach the hub').toBe(true);
+
+    await c.disconnect();
+  }, 30000);
+
+  it('a second client can then open the file (the hello-claude scenario)', async () => {
+    const creator = client();
+    const created = await creator.createNewProject({
+      syncServer: hub.url,
+      files: [{ path: 'visible.qmd', content: 'second client should see this\n', contentType: 'text' }],
+      storage: 'memory',
+      peerTimeoutMs: 50,
+    });
+    hub.releaseUpgrades();
+    // Give the creator a window to sync up before the reader arrives.
+    await hub.hubHasDoc(created.indexDocId, 8000);
+
+    const readerFiles: string[] = [];
+    const reader = createSyncClient({
+      onFileAdded: (path) => readerFiles.push(path),
+      onFileChanged: () => {},
+      onFileRemoved: () => {},
+    });
+    const files = await reader.connect(hub.url, created.indexDocId, undefined, undefined, undefined, {
+      storage: 'memory',
+      peerTimeoutMs: 10000,
+      requireOnline: true,
+    });
+    expect(files.map((f) => f.path)).toContain('visible.qmd');
+
+    await creator.disconnect();
+    await reader.disconnect();
+  }, 30000);
+});

--- a/ts-packages/quarto-sync-client/src/restart-window-creation.test.ts
+++ b/ts-packages/quarto-sync-client/src/restart-window-creation.test.ts
@@ -1,0 +1,200 @@
+/**
+ * D1 localization, restart-window variant (bd-10bdjmjb Phase 1).
+ *
+ * Both fresh-creation repros pass (JS hub and Rust hub:
+ * offline-creation*.test.ts) — first-time connects deliver
+ * created-while-offline docs fine. Production's hello-claude.qmd was
+ * different in one specific way: the creating client had ALREADY been
+ * connected to the hub and was in the gap of a hub restart when the
+ * file was created. On reconnect the remote peer id is stable, so any
+ * cached per-peer sync state can convince the synchronizer the peer
+ * already knows everything — the prime remaining suspect.
+ *
+ * Repro: connect online → SIGKILL the hub mid-session → createFile
+ * during the gap → restart the hub (same port, same data dir) →
+ * assert the new document lands in hub storage.
+ *
+ * Gated on target/debug/hub (cargo build -p quarto-hub), unix only.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { spawn, type ChildProcess } from 'node:child_process';
+import { once } from 'node:events';
+import * as fs from 'node:fs';
+import * as net from 'node:net';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { createSyncClient } from './client.js';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+const hubBin = path.join(repoRoot, 'target', 'debug', 'hub');
+const runIt = fs.existsSync(hubBin) && process.platform !== 'win32';
+if (!runIt) {
+  // eslint-disable-next-line no-console
+  console.error(`[restart-window-creation] SKIPPING: hub binary missing at ${hubBin}`);
+}
+
+async function freePort(): Promise<number> {
+  const srv = net.createServer();
+  srv.listen(0, '127.0.0.1');
+  await once(srv, 'listening');
+  const port = (srv.address() as net.AddressInfo).port;
+  srv.close();
+  await once(srv, 'close');
+  return port;
+}
+
+function spawnHub(dataDir: string, port: number): ChildProcess {
+  return spawn(hubBin, ['--data-dir', dataDir, '-P', String(port), '-H', '127.0.0.1'], {
+    stdio: ['ignore', 'ignore', process.env['DEBUG_MCP'] ? 'inherit' : 'ignore'],
+  });
+}
+
+async function waitForHealth(port: number, timeoutMs = 15000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let lastErr: unknown;
+  while (Date.now() < deadline) {
+    try {
+      const resp = await fetch(`http://127.0.0.1:${port}/health`);
+      if (resp.status < 500) return;
+      lastErr = resp.status;
+    } catch (err) {
+      lastErr = err;
+    }
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  throw new Error(`hub not healthy on :${port}: ${lastErr}`);
+}
+
+function docInStorage(dataDir: string, docId: string): boolean {
+  return fs.existsSync(path.join(dataDir, 'automerge', docId.slice(0, 2), docId.slice(2)));
+}
+
+async function waitForDocInStorage(dataDir: string, docId: string, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (docInStorage(dataDir, docId)) return true;
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  return false;
+}
+
+let hub: ChildProcess | undefined;
+let tmpDir: string | undefined;
+
+afterEach(() => {
+  hub?.kill('SIGKILL');
+  hub = undefined;
+  if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+  tmpDir = undefined;
+});
+
+describe.runIf(runIt)('file created during a hub-restart gap (the hello-claude shape)', () => {
+  it('reaches hub storage after the hub comes back and the client reconnects', async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'restart-window-'));
+    const port = await freePort();
+
+    // 1. Hub up; client connected ONLINE; project synced.
+    hub = spawnHub(tmpDir, port);
+    await waitForHealth(port);
+
+    let online = false;
+    const c = createSyncClient({
+      onFileAdded: () => {},
+      onFileChanged: () => {},
+      onFileRemoved: () => {},
+      onConnectionChange: (isOnline: boolean) => {
+        online = isOnline;
+      },
+    });
+    const created = await c.createNewProject({
+      syncServer: `ws://127.0.0.1:${port}/ws`,
+      files: [{ path: 'pre-existing.qmd', content: 'here before the restart\n', contentType: 'text' }],
+      storage: 'memory',
+      peerTimeoutMs: 10000,
+      requireOnline: true,
+      retryIntervalMs: 500,
+    });
+    expect(await waitForDocInStorage(tmpDir, created.indexDocId, 10000)).toBe(true);
+
+    // 2. Hub dies mid-session (the restart window).
+    hub.kill('SIGKILL');
+    await once(hub, 'exit');
+    hub = undefined;
+    // Wait until the client notices it is offline.
+    const offlineDeadline = Date.now() + 10000;
+    while (online && Date.now() < offlineDeadline) {
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    expect(online, 'client should observe the disconnect').toBe(false);
+
+    // 3. The user creates a file during the gap.
+    await c.createFile('during-gap.qmd', 'created while the hub was down\n');
+    const gapDocId = (await (async () => {
+      // The index maps path -> docId; read it via the client's file list.
+      const files = c.getFiles?.() as Array<{ path: string; docId: string }> | undefined;
+      return files?.find((f) => f.path === 'during-gap.qmd')?.docId;
+    })());
+
+    // 4. Hub comes back on the same port with the same data dir.
+    hub = spawnHub(tmpDir, port);
+    await waitForHealth(port);
+
+    // 5. Wait for the CREATOR to actually reconnect (its retry loop is
+    // 500 ms) — only then is "the hub never receives the doc" a real
+    // defect rather than a race in this test.
+    const onlineDeadline = Date.now() + 20000;
+    while (!online && Date.now() < onlineDeadline) {
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    expect(online, 'creator must reconnect after the hub returns').toBe(true);
+    // Generous settle window for announce/sync to do its thing.
+    await new Promise((r) => setTimeout(r, 3000));
+
+    if (gapDocId) {
+      expect(
+        await waitForDocInStorage(tmpDir, gapDocId, 20000),
+        `gap-created doc ${gapDocId} must reach hub storage`,
+      ).toBe(true);
+    } else {
+      // Fallback assertion when the client API exposes no doc id:
+      // a fresh second client must be able to read the file.
+      const reader = createSyncClient({
+        onFileAdded: () => {},
+        onFileChanged: () => {},
+        onFileRemoved: () => {},
+      });
+      // Poll with fresh readers for up to 15 s — eliminates any
+      // remaining propagation-timing doubt before declaring red.
+      let seen: string[] = [];
+      let content: string | null | undefined;
+      const deadline = Date.now() + 15000;
+      while (Date.now() < deadline) {
+        const reader = createSyncClient({
+          onFileAdded: () => {},
+          onFileChanged: () => {},
+          onFileRemoved: () => {},
+        });
+        const files = await reader.connect(
+          `ws://127.0.0.1:${port}/ws`,
+          created.indexDocId,
+          undefined,
+          undefined,
+          undefined,
+          { storage: 'memory', peerTimeoutMs: 10000, requireOnline: true },
+        );
+        seen = files.map((f) => f.path);
+        content = reader.getFileContent?.('during-gap.qmd');
+        await reader.disconnect();
+        if (seen.includes('during-gap.qmd') && content) break;
+        await new Promise((r) => setTimeout(r, 1000));
+      }
+      expect(seen, 'second client must see the gap-created file').toContain('during-gap.qmd');
+      expect(content, 'gap-created file must be readable, not a dangling entry').toBeTruthy();
+    }
+
+    await c.disconnect();
+  }, 90000);
+});

--- a/ts-packages/quarto-sync-client/src/test-hub.ts
+++ b/ts-packages/quarto-sync-client/src/test-hub.ts
@@ -20,6 +20,8 @@ import { WebSocketServer } from 'ws';
 import { Repo, type DocumentId, type PeerId } from '@automerge/automerge-repo';
 import { WebSocketServerAdapter } from '@automerge/automerge-repo-network-websocket';
 
+import { MemoryStorageAdapter } from './storage-adapter.js';
+
 export interface TestHub {
   /** ws:// URL of the sync endpoint. */
   url: string;
@@ -78,6 +80,12 @@ export async function startTestHub(opts: TestHubOptions = {}): Promise<TestHub> 
     network: [new WebSocketServerAdapter(wss as never)],
     peerId: 'test-hub' as PeerId,
     sharePolicy: async () => true,
+    // Storage gives the hub a storageId to announce in its handshake
+    // metadata, like the real samod hub (which always announces one).
+    // Clients key delivery confirmation off it (exit-drain,
+    // bd-10deu8h4); a storage-less Repo announces none and would make
+    // this hub unconfirmable in a way production never is.
+    storage: new MemoryStorageAdapter(),
   });
 
   httpServer.listen(0, '127.0.0.1');
@@ -108,7 +116,11 @@ export async function startTestHub(opts: TestHubOptions = {}): Promise<TestHub> 
       return false;
     },
     async stop(): Promise<void> {
-      await repo.shutdown();
+      // shutdown() flushes storage, and flush() throws "DocHandle is
+      // not ready" for docs that were announced but never delivered —
+      // exactly the half-state the exit-drain tests (bd-10deu8h4)
+      // leave behind. Teardown must not mask a test's own assertions.
+      await repo.shutdown().catch(() => {});
       wss.close();
       httpServer.close();
       await once(httpServer, 'close');

--- a/ts-packages/quarto-sync-client/src/test-hub.ts
+++ b/ts-packages/quarto-sync-client/src/test-hub.ts
@@ -1,0 +1,117 @@
+/**
+ * Test helper: a minimal in-process sync hub (JS automerge-repo).
+ *
+ * Sibling of ts-packages/quarto-hub-mcp/src/test-hub.ts (the MCP
+ * package keeps its own copy for its e2e suites); this one adds the
+ * `holdUpgrades` switch needed by the offline-fallback race tests
+ * (bd-10bdjmjb): websocket upgrades queue until `releaseUpgrades()`,
+ * deterministically reproducing "client started before it could
+ * connect" — the window in which hub-client's 1 ms peer wait strands
+ * every session.
+ *
+ * The hub-side repo is exposed so tests can assert what the server
+ * actually received (`hubHasDoc`), which is the ground truth the
+ * 2026-06-12 incident was about.
+ */
+
+import * as http from 'node:http';
+import { once } from 'node:events';
+import { WebSocketServer } from 'ws';
+import { Repo, type DocumentId, type PeerId } from '@automerge/automerge-repo';
+import { WebSocketServerAdapter } from '@automerge/automerge-repo-network-websocket';
+
+export interface TestHub {
+  /** ws:// URL of the sync endpoint. */
+  url: string;
+  /** The hub's own repo — server-side ground truth. */
+  repo: Repo;
+  /** Allow queued + future websocket upgrades to proceed. */
+  releaseUpgrades(): void;
+  /**
+   * True iff the hub holds the document (bounded wait). Uses the
+   * repo's find with an overall deadline; "unavailable" or timeout
+   * map to false.
+   */
+  hubHasDoc(docId: string, timeoutMs?: number): Promise<boolean>;
+  stop(): Promise<void>;
+}
+
+export interface TestHubOptions {
+  /** Queue websocket upgrades until releaseUpgrades() is called. */
+  holdUpgrades?: boolean;
+}
+
+export async function startTestHub(opts: TestHubOptions = {}): Promise<TestHub> {
+  let holding = opts.holdUpgrades ?? false;
+  const queued: Array<() => void> = [];
+
+  const httpServer = http.createServer((req, res) => {
+    if (req.url === '/health') {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end('{"status":"ok"}');
+    } else {
+      res.writeHead(404);
+      res.end();
+    }
+  });
+
+  const wss = new WebSocketServer({ noServer: true });
+  httpServer.on('upgrade', (req, socket, head) => {
+    if (req.url !== '/ws') {
+      socket.destroy();
+      return;
+    }
+    const proceed = (): void => {
+      // The socket may have died while queued.
+      if (!socket.destroyed) {
+        wss.handleUpgrade(req, socket, head, (ws) => wss.emit('connection', ws, req));
+      }
+    };
+    if (holding) {
+      queued.push(proceed);
+    } else {
+      proceed();
+    }
+  });
+
+  const repo = new Repo({
+    network: [new WebSocketServerAdapter(wss as never)],
+    peerId: 'test-hub' as PeerId,
+    sharePolicy: async () => true,
+  });
+
+  httpServer.listen(0, '127.0.0.1');
+  await once(httpServer, 'listening');
+  const address = httpServer.address();
+  if (address === null || typeof address === 'string') {
+    throw new Error('test hub failed to bind a TCP port');
+  }
+
+  return {
+    url: `ws://127.0.0.1:${address.port}/ws`,
+    repo,
+    releaseUpgrades(): void {
+      holding = false;
+      for (const proceed of queued.splice(0)) proceed();
+    },
+    async hubHasDoc(docId: string, timeoutMs = 5000): Promise<boolean> {
+      const deadline = Date.now() + timeoutMs;
+      while (Date.now() < deadline) {
+        try {
+          const handle = await repo.find(docId as DocumentId);
+          if (handle.doc() !== undefined) return true;
+        } catch {
+          // unavailable — keep polling until the deadline
+        }
+        await new Promise((r) => setTimeout(r, 100));
+      }
+      return false;
+    },
+    async stop(): Promise<void> {
+      await repo.shutdown();
+      wss.close();
+      httpServer.close();
+      await once(httpServer, 'close');
+    },
+  };
+}

--- a/ts-packages/quarto-sync-client/src/types.ts
+++ b/ts-packages/quarto-sync-client/src/types.ts
@@ -59,6 +59,24 @@ export interface BinaryFilePayload {
 export type FilePayload = TextFilePayload | BinaryFilePayload;
 
 // ============================================================================
+// File Entry Annotation
+// ============================================================================
+
+/**
+ * A {@link FileEntry} annotated with an availability marker at the
+ * sync-client boundary (bd-vm5e5u10). This is client-side presentation
+ * only — the marker is never written to the index document.
+ *
+ * `status` is `'unavailable'` when the index references this path but
+ * the file's automerge document could not be fetched from the sync
+ * server (a "dangling entry"): the file is listed but has no content.
+ * Files that loaded normally carry `'ok'` or no marker at all.
+ */
+export interface AnnotatedFileEntry extends FileEntry {
+  status?: 'ok' | 'unavailable';
+}
+
+// ============================================================================
 // Callback Types
 // ============================================================================
 
@@ -88,6 +106,17 @@ export interface SyncClientCallbacks {
    * Called when a file is removed.
    */
   onFileRemoved: (path: string) => void;
+
+  /**
+   * Called when an index entry references a document that cannot be
+   * fetched from the sync server — a "dangling entry" (optional,
+   * bd-vm5e5u10). The file is skipped, not fatal: it appears in
+   * listings with `status: 'unavailable'` (see
+   * {@link AnnotatedFileEntry}) and `onFileAdded` does NOT fire for
+   * it. `docId` is the document id exactly as stored in the index.
+   * UIs can use this to show a degraded marker.
+   */
+  onFileUnavailable?: (path: string, docId: string) => void;
 
   /**
    * Called when the file index changes (optional).

--- a/ts-packages/quarto-sync-client/src/types.ts
+++ b/ts-packages/quarto-sync-client/src/types.ts
@@ -254,6 +254,57 @@ export interface ConnectOptions {
 }
 
 // ============================================================================
+// Disconnect / exit-drain types (bd-10deu8h4)
+// ============================================================================
+
+/**
+ * Options bag for `disconnect()`.
+ */
+export interface DisconnectOptions {
+  /**
+   * Bounded budget (ms) to drain outbound document sync before tearing
+   * the connection down. The drain returns early the moment the
+   * connected hub confirms it holds our heads for every tracked
+   * document (index + files), and never blocks past the budget.
+   *
+   * Default `0`: no drain — the existing teardown behavior. Browser
+   * callers (hub-client) should keep the default: their IndexedDB
+   * storage persists local changes across disconnects, so a blocking
+   * drain on tab/component teardown buys nothing. Memory-storage
+   * callers whose process is about to exit (the hub MCP server) are
+   * the intended users: for them, undelivered == lost (bd-10deu8h4,
+   * the 2026-06-12 incident).
+   */
+  drainMs?: number;
+}
+
+/**
+ * A document that may not have reached the sync server when the drain
+ * budget expired.
+ */
+export interface UndeliveredDoc {
+  /** Project-relative path; `null` for the project's index document. */
+  path: string | null;
+  /** The automerge document id (bare, no `automerge:` prefix). */
+  docId: string;
+}
+
+/**
+ * Result of `disconnect()`. Only meaningful when a drain was requested
+ * (`drainMs > 0`); the default no-drain path always reports
+ * `{ drained: true, undelivered: [] }` without checking.
+ */
+export interface DisconnectReport {
+  /**
+   * False iff the drain budget expired while at least one tracked
+   * document's heads were not yet confirmed by a storage-backed peer.
+   */
+  drained: boolean;
+  /** The documents that were not confirmed delivered. */
+  undelivered: UndeliveredDoc[];
+}
+
+// ============================================================================
 // Result Types
 // ============================================================================
 

--- a/ts-packages/quarto-sync-client/src/types.ts
+++ b/ts-packages/quarto-sync-client/src/types.ts
@@ -227,6 +227,15 @@ export interface ConnectOptions {
    * handshake queue cannot stall).
    */
   peerTimeoutMs?: number;
+  /**
+   * Fail instead of falling back to offline mode when the peer wait
+   * times out (bd-xnmd5ni1): `connect` then rejects with
+   * `PeerUnavailableError`. For server-backed callers with memory
+   * storage (the hub MCP server), offline mode persists nothing —
+   * silent fallback is a data black hole. Default false (browser
+   * offline-first behavior unchanged).
+   */
+  requireOnline?: boolean;
   /** Storage backing for this connection. Default `'indexeddb'`. */
   storage?: StorageKind;
   /**
@@ -291,6 +300,12 @@ export interface CreateProjectOptions {
    * the background-sync race against `waitForServerDocuments`.
    */
   peerTimeoutMs?: number;
+  /**
+   * Fail instead of creating the project in offline mode when the
+   * peer wait times out — rejects with `PeerUnavailableError`. See
+   * {@link ConnectOptions.requireOnline} (bd-xnmd5ni1).
+   */
+  requireOnline?: boolean;
   /** Storage backing for this connection. Default `'indexeddb'`. */
   storage?: StorageKind;
   /** WebSocket adapter retry interval (ms). See {@link ConnectOptions}. */


### PR DESCRIPTION
## What this is

`q2 mcp` — a new subcommand that gives anyone with the `q2` binary an MCP server for quarto-hub.com: agents (Claude Code, Claude Desktop, Cursor…) can authenticate via the loopback+PKCE Google flow and read/write Hub projects as live participants in the multiplayer automerge session.

Architecturally a **thin Rust launcher**: the canonical TypeScript MCP server (`ts-packages/quarto-hub-mcp`) is bundled by esbuild, embedded in the binary via `include_dir!`, extracted to a per-user cache, and executed with ambient Node — auth and sync logic stays single-sourced in TS. Design and decision history: `claude-notes/plans/2026-06-11-q2-mcp-hub-auth.md`.

## Major pieces

- **`crates/quarto-mcp-launcher`** + `q2 mcp` wiring: content-hash cache extraction with lifetime advisory locks (flock survives the exec into node), opportunistic age-gated GC, layered Node discovery (`QUARTO_NODE` → PATH → version-manager trees, floor Node 24), `--launcher-info` staleness diagnostics, placeholder embed for fresh clones.
- **Bundling**: `npm run bundle` (esbuild; automerge steered to its base64-wasm entry; keyring native addon shipped as a mini `node_modules`), `cargo xtask build-hub-mcp-bundle`, wired into `build-all`/`verify`.
- **Auth**: `QUARTO_HUB_MCP_ISSUER` override (loopback-http gated behind the existing insecure escape hatch, both client- and hub-side) enabling a full-stack auth e2e: mock IdP minting real RS256 JWTs → real hub binary → real loopback flow → real OS keyring → both delivery channels.
- **Reliability fixes that fell out** (several found by the new e2e/tests, two by a production incident on 2026-06-12 — post-mortem in `claude-notes/plans/2026-06-12-sync-client-offline-race.md`):
  - sync-client logged to stdout, corrupting MCP stdio (bd-sl4o01y0)
  - server didn't exit on stdin EOF (bd-9jq2a060)
  - silent no-op when invoked through symlinked paths — would have broken npx (bd-2d8ur7e9)
  - silent offline project "creation" with memory storage (bd-xnmd5ni1 → `requireOnline`/`PeerUnavailableError`)
  - websocket errors crashed the process (bd-xzspx4r9)
  - **one dangling index entry bricked whole projects** for every client (bd-vm5e5u10 → graceful degradation; `delete_file` as self-service repair)
  - **server exit raced outbound sync** — created docs could die with the process (bd-10deu8h4 → bounded remote-heads drain at shutdown, loud on failure)
- Default `--server` is now `wss://quarto-hub.com/ws`; repo `.mcp.json` pinned to an explicit local URL.

## Verification

- `cargo nextest run --workspace`: 9997 passed. Full `cargo xtask verify` (now 14 steps after merging main's bd-6rczoll3 ts-packages step): all green.
- TS suites: sync-client 105, hub-mcp 185 (+2 keyring-gated), hub-client build + `test:ci` 97.
- **Live against production**: authenticate → connect → read/write on the quarto-hub.com playground, corroborated by the hub's audit log; keyring credential reuse without re-prompt verified across both channels.
- `origin/main` is fully merged in (`6b8ba65f`); merge is conflict-free.

## Review guidance

- Best read **by area** rather than commit-by-commit (~45 commits incl. two reviewed sub-strand merges): `crates/quarto-mcp-launcher/` (locks/GC/discovery), `ts-packages/quarto-hub-mcp/scripts/bundle.mjs`, the sync-client diffs (`requireOnline`, dangling-entry tolerance, exit drain), and `crates/quarto-hub/src/auth.rs` (gated loopback-http issuer — security-relevant, please scrutinize).
- **Windows**: the launcher's spawn/exit-code path compiles but has never executed on Windows — review wanted from the Windows dev before this ships to that platform (macOS-first was agreed for this phase).
- Plans with full context: `2026-06-11-q2-mcp-hub-auth.md`, `2026-06-12-sync-client-offline-race.md`, `2026-06-12-graceful-dangling-entries.md`, `2026-06-12-mcp-exit-sync-drain.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)