### PR TITLE
GitHub release assets for q2: installers + minisign + bundled quarto-hub.com MCP defaults (bd-c6l13j79)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,521 @@
+# Release pipeline (bd-c6l13j79): tag push (or manual dispatch on an
+# existing tag) → web payloads → 5-target binary build → checksummed,
+# signed artifacts → GitHub Release.
+#
+# Ported from cscheid/braid's release.yml (study copy in
+# external-sources/braid). The artifact naming and checksum layout is a
+# contract with install.sh (encoded by
+# crates/quarto/tests/integration/bootstrap_sh.rs):
+#
+#   q2-<version>-<platform>.tar.gz          single member: q2
+#   q2-<version>-<platform>.tar.gz.sha256   "<sha256>  <filename>"
+#   q2-<version>-<platform>.tar.gz.minisig  minisign (Ed25519) signature;
+#                                           trusted comment = the archive
+#                                           filename (replay protection —
+#                                           install.sh compares it)
+#   checksums.sha256                        all .sha256 lines, combined
+#
+# <version> has no "v" prefix in filenames; the tag does (v0.1.0 →
+# q2-0.1.0-darwin_arm64.tar.gz).
+#
+# q2 deltas from braid:
+#
+# - A functional q2 binary embeds THREE payloads via include_dir!:
+#   the hub MCP bundle (quarto-mcp-launcher), the preview SPA
+#   (quarto-preview), and the trace viewer (quarto-trace-server). A
+#   build without them succeeds but ships placeholders (the 2026-05-20
+#   stale-embed incident class) — the per-target "verify binary" step
+#   fails the release if any placeholder is detected.
+# - The `web-payloads` job builds the target-INDEPENDENT payloads once
+#   (WASM → preview SPA, trace viewer; the WASM toolchain is heavy and
+#   identical for every target). The MCP bundle is built per target:
+#   its keyring native addons must match the *user's* platform
+#   (KEYRING_PLATFORMS; see ts-packages/quarto-hub-mcp/scripts/
+#   stage-keyring.mjs).
+# - The bundled quarto-hub.com OAuth defaults (QUARTO_HUB_BUNDLED_*)
+#   are injected from repo secrets/vars into the cargo build env —
+#   release builds only; see crates/quarto-mcp-launcher/src/defaults.rs
+#   for why the Desktop-app client secret is safe to embed.
+# - Linux targets are static musl; openssl is built from source via the
+#   musl-scoped `openssl-sys/vendored` dep in crates/quarto/Cargo.toml.
+#   If musl turns out unbuildable (aws-lc-sys is the known risk), flip
+#   the matrix targets to *-unknown-linux-gnu — plan D4.
+#
+# Signing key: MINISIGN_SECRET_KEY repo secret; the public half is pinned
+# in install.sh (MINISIGN_PUBKEY) and README. The sign step verifies its
+# output against the key extracted from install.sh, so a secret/pinned-key
+# mismatch fails the release instead of shipping unverifiable artifacts.
+#
+# Plan: claude-notes/plans/2026-06-12-q2-github-releases-bundled-mcp.md
+
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing tag to (re-)release, e.g. v0.1.0'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.event.inputs.tag || github.ref }}
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  preflight:
+    name: Verify tag matches Cargo.toml
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: github.repository == 'quarto-dev/q2'
+    outputs:
+      tag: ${{ steps.version.outputs.tag }}
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # On workflow_dispatch the default ref is the branch; build
+          # from the requested tag so artifacts match what we verify.
+          ref: ${{ github.event.inputs.tag || github.ref }}
+      - id: version
+        env:
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+        run: |
+          TAG="${INPUT_TAG:-$GITHUB_REF_NAME}"
+          CARGO_VERSION=$(grep -m1 '^version' Cargo.toml | sed 's/.*"\(.*\)".*/\1/')
+          if [ "v$CARGO_VERSION" != "$TAG" ]; then
+            echo "::error::tag $TAG does not match workspace Cargo.toml version $CARGO_VERSION"
+            exit 1
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$CARGO_VERSION" >> "$GITHUB_OUTPUT"
+          echo "Releasing $TAG (version $CARGO_VERSION)"
+
+  # Target-independent embedded payloads, built once: the WASM module
+  # (wasm32, same bytes for every release target), the preview SPA that
+  # consumes it, and the trace viewer. Toolchain steps mirror
+  # hub-client-e2e.yml (the canonical WASM CI setup).
+  web-payloads:
+    name: Build web payloads (SPA + trace viewer)
+    needs: preflight
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.preflight.outputs.tag }}
+
+      - name: Set up Rust nightly
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          targets: wasm32-unknown-unknown
+          components: rust-src
+
+      - name: Set up Clang
+        uses: egor-tensin/setup-clang@v2
+        with:
+          version: latest
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: release-web-payloads
+          cache-on-failure: true
+
+      # build-wasm.js verifies wasm-bindgen CLI matches the version
+      # pinned in Cargo.lock; install that exact version.
+      - name: Install wasm-bindgen-cli
+        run: |
+          VERSION=$(awk '/^name = "wasm-bindgen"$/{getline; gsub(/version = |"/, ""); print; exit}' Cargo.lock)
+          echo "Installing wasm-bindgen-cli $VERSION"
+          cargo install -f wasm-bindgen-cli --version "$VERSION"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: npm ci
+        run: npm ci
+
+      - name: Build WASM (hub-client)
+        run: npm run build:wasm
+        working-directory: hub-client
+
+      # Same npm invocations as `cargo xtask build-trace-viewer` /
+      # `build-q2-preview-spa`, without compiling xtask on this runner.
+      - name: Build trace-viewer
+        run: npm run build
+        working-directory: trace-viewer
+
+      - name: Build q2-preview-spa
+        run: npm run build
+        working-directory: q2-preview-spa
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: web-payloads
+          path: |
+            trace-viewer/dist
+            q2-preview-spa/dist
+          retention-days: 7
+          if-no-files-found: error
+
+  build:
+    name: Build (${{ matrix.platform }})
+    needs: [preflight, web-payloads]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # keyring: the @napi-rs/keyring platform addons staged into
+          # the MCP bundle. They must match the *user's node* on the
+          # target platform — both libc flavors on linux (glibc + Alpine
+          # node), both mac archs (Rosetta mismatch: x64 q2 under an
+          # arm64 node and vice versa), both win archs (arm64 Windows
+          # runs x64 q2 under emulation with a native arm64 node).
+          - platform: linux_amd64
+            target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+            ext: tar.gz
+            keyring: linux-x64-gnu,linux-x64-musl
+          - platform: linux_arm64
+            target: aarch64-unknown-linux-musl
+            os: ubuntu-24.04-arm
+            ext: tar.gz
+            keyring: linux-arm64-gnu,linux-arm64-musl
+          - platform: darwin_amd64
+            target: x86_64-apple-darwin
+            os: macos-15  # arm64 runner; the x86_64 binary runs under Rosetta
+            ext: tar.gz
+            keyring: darwin-x64,darwin-arm64
+          - platform: darwin_arm64
+            target: aarch64-apple-darwin
+            os: macos-15
+            ext: tar.gz
+            keyring: darwin-arm64,darwin-x64
+          - platform: windows_amd64
+            target: x86_64-pc-windows-msvc
+            os: windows-latest
+            ext: zip
+            keyring: win32-x64-msvc,win32-arm64-msvc
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.preflight.outputs.tag }}
+
+      - name: Set up Rust nightly
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install musl-tools
+        if: contains(matrix.target, 'musl')
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: release-${{ matrix.target }}
+
+      # Defender real-time scanning inspects every object/rlib/exe the
+      # compiler writes; excluding the workspace cuts the MSVC build
+      # time markedly.
+      - name: Exclude workspace from Defender scanning
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: Add-MpPreference -ExclusionPath "${{ github.workspace }}"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: npm ci
+        run: npm ci
+
+      # Target-independent payloads from the web-payloads job, placed
+      # where the include_dir! build scripts look for them.
+      - uses: actions/download-artifact@v8
+        with:
+          name: web-payloads
+          path: .
+
+      # Per-target payload: the MCP bundle, with keyring addons for the
+      # *target's* users (esbuild compiles workspace TS from source;
+      # missing addon packages are fetched via npm pack at the loader's
+      # locked version).
+      - name: Build hub MCP bundle
+        shell: bash
+        env:
+          KEYRING_PLATFORMS: ${{ matrix.keyring }}
+        run: npm run bundle -w ts-packages/quarto-hub-mcp
+
+      # The bundled quarto-hub.com defaults. Secrets here are masked in
+      # logs; they are public-client credentials (RFC 8252) kept out of
+      # the repo only to avoid GOCSPX- scanners — see
+      # crates/quarto-mcp-launcher/src/defaults.rs.
+      - name: Build release binary
+        shell: bash
+        env:
+          QUARTO_HUB_BUNDLED_CLIENT_ID: ${{ secrets.QUARTO_HUB_MCP_CLIENT_ID }}
+          QUARTO_HUB_BUNDLED_CLIENT_SECRET: ${{ secrets.QUARTO_HUB_MCP_CLIENT_SECRET }}
+          QUARTO_HUB_BUNDLED_SERVER: ${{ vars.QUARTO_HUB_SERVER }}
+        run: |
+          for VAR in QUARTO_HUB_BUNDLED_CLIENT_ID QUARTO_HUB_BUNDLED_CLIENT_SECRET QUARTO_HUB_BUNDLED_SERVER; do
+            if [ -z "${!VAR}" ]; then
+              echo "::error::$VAR is empty — release builds must carry the bundled hub defaults (repo secrets/vars)"
+              exit 1
+            fi
+          done
+          cargo build --release --locked --target ${{ matrix.target }} -p quarto
+
+      # Every target in the matrix can execute on its runner (musl
+      # binaries are static; darwin x86_64 runs under Rosetta; windows
+      # runs natively), so these checks are unconditional. `shell: bash`
+      # uses Git Bash on the windows runner.
+      #
+      # Beyond braid's version check, this is the anti-stale-embed /
+      # anti-placeholder gate: a release binary must carry a real MCP
+      # bundle (with the target's keyring addons), real bundled hub
+      # defaults, and real SPA payloads.
+      - name: Verify binary (version, embeds, bundled defaults)
+        shell: bash
+        run: |
+          BIN="./target/${{ matrix.target }}/release/q2"
+          [ "$RUNNER_OS" = "Windows" ] && BIN="$BIN.exe"
+
+          RAW=$("$BIN" --version)
+          ACTUAL="${RAW##* }"
+          if [ "$ACTUAL" != "${{ needs.preflight.outputs.version }}" ]; then
+            echo "::error::binary reports '$RAW', expected version ${{ needs.preflight.outputs.version }}"
+            exit 1
+          fi
+
+          INFO=$("$BIN" mcp --launcher-info)
+          printf '%s\n' "$INFO"
+          FAIL=0
+          if printf '%s' "$INFO" | grep -q "PLACEHOLDER"; then
+            echo "::error::release binary embeds the placeholder MCP bundle"
+            FAIL=1
+          fi
+          for VAR in QUARTO_HUB_MCP_CLIENT_ID QUARTO_HUB_MCP_CLIENT_SECRET QUARTO_HUB_SERVER; do
+            if ! printf '%s' "$INFO" | grep -q "default $VAR: bundled"; then
+              echo "::error::$VAR is not reported as bundled in the release binary"
+              FAIL=1
+            fi
+          done
+          IFS=',' read -ra PLATFORMS <<< "${{ matrix.keyring }}"
+          for P in "${PLATFORMS[@]}"; do
+            if ! printf '%s' "$INFO" | grep -q "keyring-$P"; then
+              echo "::error::MCP bundle is missing keyring addon for $P"
+              FAIL=1
+            fi
+          done
+          exit $FAIL
+
+      # Unix targets ship a .tar.gz of the `q2` binary.
+      - name: Package archive + checksum (tar.gz)
+        if: matrix.ext == 'tar.gz'
+        shell: bash
+        run: |
+          ARCHIVE="q2-${{ needs.preflight.outputs.version }}-${{ matrix.platform }}.tar.gz"
+          tar -czf "$ARCHIVE" -C "target/${{ matrix.target }}/release" q2
+          if command -v sha256sum >/dev/null; then
+            sha256sum "$ARCHIVE" > "$ARCHIVE.sha256"
+            sha256sum -c "$ARCHIVE.sha256"
+          else
+            shasum -a 256 "$ARCHIVE" > "$ARCHIVE.sha256"
+            shasum -a 256 -c "$ARCHIVE.sha256"
+          fi
+
+      # Windows ships a .zip of q2.exe. The .sha256 is written in GNU
+      # coreutils format ("<lowercase-hash>  <file>", LF-terminated, no
+      # BOM) so the ubuntu combine job's `sha256sum -c` accepts it
+      # alongside the unix lines.
+      - name: Package archive + checksum (zip)
+        if: matrix.ext == 'zip'
+        shell: pwsh
+        run: |
+          $version = "${{ needs.preflight.outputs.version }}"
+          $archive = "q2-$version-${{ matrix.platform }}.zip"
+          Compress-Archive -Path "target/${{ matrix.target }}/release/q2.exe" -DestinationPath $archive
+          $hash = (Get-FileHash -Algorithm SHA256 $archive).Hash.ToLower()
+          [System.IO.File]::WriteAllText((Join-Path (Get-Location) "$archive.sha256"), "$hash  $archive`n")
+
+      - name: Install minisign
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          case "$RUNNER_OS" in
+            macOS)  brew install minisign ;;
+            Linux)  sudo apt-get update && sudo apt-get install -y minisign ;;
+          esac
+
+      # Trusted comment = archive filename: it is part of the signed
+      # payload, and install.sh compares it against the file they asked
+      # for, so a signature cannot be replayed from another artifact.
+      # Skipped for Windows: install.ps1 does not verify signatures
+      # (SHA-256 only), so the .zip has no .minisig consumer today.
+      - name: Sign archive (minisign, Ed25519)
+        if: runner.os != 'Windows'
+        shell: bash
+        env:
+          MINISIGN_SECRET_KEY: ${{ secrets.MINISIGN_SECRET_KEY }}
+        run: |
+          ARCHIVE="q2-${{ needs.preflight.outputs.version }}-${{ matrix.platform }}.${{ matrix.ext }}"
+          key="$(mktemp)"
+          trap 'rm -f "$key"' EXIT
+          chmod 600 "$key"
+          printf '%s\n' "$MINISIGN_SECRET_KEY" > "$key"
+          minisign -Sm "$ARCHIVE" -s "$key" -t "$ARCHIVE"
+          # Verify with the public key pinned in install.sh: a mismatch
+          # between the repo secret and the pinned key fails the release
+          # here instead of shipping artifacts no installer can verify.
+          PUBKEY="$(sed -n 's/^MINISIGN_PUBKEY="\(.*\)"$/\1/p' install.sh)"
+          test -n "$PUBKEY"
+          minisign -Vm "$ARCHIVE" -P "$PUBKEY"
+
+      # Unix archives include a .minisig; the Windows zip does not (no consumer).
+      - uses: actions/upload-artifact@v7
+        if: matrix.ext == 'tar.gz'
+        with:
+          name: q2-${{ matrix.platform }}
+          path: |
+            q2-${{ needs.preflight.outputs.version }}-${{ matrix.platform }}.tar.gz
+            q2-${{ needs.preflight.outputs.version }}-${{ matrix.platform }}.tar.gz.sha256
+            q2-${{ needs.preflight.outputs.version }}-${{ matrix.platform }}.tar.gz.minisig
+          retention-days: 7
+          if-no-files-found: error
+
+      - uses: actions/upload-artifact@v7
+        if: matrix.ext == 'zip'
+        with:
+          name: q2-${{ matrix.platform }}
+          path: |
+            q2-${{ needs.preflight.outputs.version }}-${{ matrix.platform }}.zip
+            q2-${{ needs.preflight.outputs.version }}-${{ matrix.platform }}.zip.sha256
+          retention-days: 7
+          if-no-files-found: error
+
+  release:
+    name: Create GitHub Release
+    needs: [preflight, build]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.preflight.outputs.tag }}
+          fetch-depth: 0  # changelog needs the previous tag
+
+      - uses: actions/download-artifact@v8
+        with:
+          path: artifacts
+          merge-multiple: true
+          pattern: q2-*
+
+      - name: Validate all platforms present, combine and verify checksums
+        run: |
+          cd artifacts
+          VERSION="${{ needs.preflight.outputs.version }}"
+          MISSING=()
+          # "<platform>:<ext>" — Windows ships .zip, the rest .tar.gz.
+          # The .zip has no .minisig: install.ps1 does not verify signatures.
+          for entry in linux_amd64:tar.gz linux_arm64:tar.gz \
+                       darwin_amd64:tar.gz darwin_arm64:tar.gz \
+                       windows_amd64:zip; do
+            platform="${entry%%:*}"; ext="${entry##*:}"
+            required=("q2-${VERSION}-${platform}.${ext}" \
+                      "q2-${VERSION}-${platform}.${ext}.sha256")
+            [ "$ext" != "zip" ] && required+=("q2-${VERSION}-${platform}.${ext}.minisig")
+            for f in "${required[@]}"; do
+              [ -f "$f" ] || MISSING+=("$f")
+            done
+          done
+          if [ ${#MISSING[@]} -gt 0 ]; then
+            echo "::error::missing release files: ${MISSING[*]}"
+            exit 1
+          fi
+          cat -- *.sha256 | sort -k2 > checksums.sha256
+          sha256sum -c checksums.sha256
+          cat checksums.sha256
+
+      - name: Generate release notes
+        env:
+          TAG: ${{ needs.preflight.outputs.tag }}
+          VERSION: ${{ needs.preflight.outputs.version }}
+        run: |
+          PUBKEY="$(sed -n 's/^MINISIGN_PUBKEY="\(.*\)"$/\1/p' install.sh)"
+          PREV_TAG=$(git describe --tags --abbrev=0 "$TAG^" 2>/dev/null || true)
+          {
+            echo "> **Experimental.** q2 is under active development and not ready for production use."
+            echo
+            echo "## Install"
+            echo
+            echo '```sh'
+            echo "curl -fsSL https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/main/install.sh | bash"
+            echo '```'
+            echo
+            echo "On Windows (PowerShell):"
+            echo
+            echo '```powershell'
+            echo "irm https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/main/install.ps1 | iex"
+            echo '```'
+            echo
+            echo "\`q2 mcp\` (the Quarto Hub MCP server) needs [Node.js](https://nodejs.org) 24+ at runtime;"
+            echo "everything else works standalone. Hub connection defaults for quarto-hub.com are built in."
+            echo
+            echo "| Platform | File |"
+            echo "|---|---|"
+            echo "| Linux x86_64 (static musl) | \`q2-${VERSION}-linux_amd64.tar.gz\` |"
+            echo "| Linux ARM64 (static musl) | \`q2-${VERSION}-linux_arm64.tar.gz\` |"
+            echo "| macOS Intel | \`q2-${VERSION}-darwin_amd64.tar.gz\` |"
+            echo "| macOS Apple Silicon | \`q2-${VERSION}-darwin_arm64.tar.gz\` |"
+            echo "| Windows x86_64 | \`q2-${VERSION}-windows_amd64.zip\` |"
+            echo
+            echo "**Verify a manual download** (Unix archives are signed with [minisign](https://jedisct1.github.io/minisign/), Ed25519):"
+            echo
+            echo '```sh'
+            echo "minisign -Vm q2-${VERSION}-<platform>.tar.gz -P ${PUBKEY}"
+            echo '```'
+            echo
+            echo "The trusted comment should name exactly the file you downloaded."
+            echo "Checksums (all platforms): \`sha256sum -c checksums.sha256 --ignore-missing\`"
+            echo
+            echo "## Changes"
+            echo
+            if [ -n "$PREV_TAG" ]; then
+              git log --pretty='- %s (%h)' "${PREV_TAG}..${TAG}"
+            else
+              git log --pretty='- %s (%h)' "$TAG" | head -50
+            fi
+          } > notes.md
+          cat notes.md
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.preflight.outputs.tag }}
+        run: |
+          PRERELEASE=()
+          case "$TAG" in *-*) PRERELEASE=(--prerelease) ;; esac
+          gh release create "$TAG" \
+            --title "q2 $TAG" \
+            --notes-file notes.md \
+            --verify-tag \
+            "${PRERELEASE[@]}" \
+            artifacts/q2-*.tar.gz artifacts/q2-*.tar.gz.sha256 \
+            artifacts/q2-*.tar.gz.minisig \
+            artifacts/q2-*.zip artifacts/q2-*.zip.sha256 \
+            artifacts/checksums.sha256

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -107,6 +107,18 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install tree-sitter-cli
 
+      # The installer test suite (crates/quarto/tests/integration/
+      # bootstrap_sh.rs) REQUIRES minisign — signature verification is
+      # part of the release-artifact contract and absence fails loudly
+      # rather than skipping (bd-c6l13j79).
+      - name: Set up minisign (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get install -y minisign
+
+      - name: Set up minisign (macOS)
+        if: runner.os == 'macOS'
+        run: brew install minisign
+
       # Free disk space on Linux runners (14 GB SSD is tight for Rust monorepo).
       # `remove_tool_cache: true` is safe — no step in this job uses /opt/hostedtoolcache/
       # (no setup-node, setup-python, etc.). See claude-notes/2026-04-28-ci-disk-space-and-profile-ci.md.

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,7 @@ CLAUDE.local.md
 # marker (which only names the project) is intentionally NOT ignored.
 .braid.toml
 .braid-stragglers.jsonl
+
+# Release signing keypair — NEVER commit (secret half lives in GH secrets + password manager)
+/q2-release.key
+/q2-release.pub

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3291,6 +3291,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "openssl-src"
+version = "300.6.1+3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3298,6 +3307,7 @@ checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -3830,6 +3840,7 @@ dependencies = [
  "async-trait",
  "clap",
  "open",
+ "openssl-sys",
  "pampa",
  "pollster",
  "quarto-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3850,6 +3850,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2 0.11.0",
  "tempfile",
  "tokio",
  "tracing",

--- a/README.md
+++ b/README.md
@@ -6,6 +6,48 @@
 
 This repository is a Rust implementation of the next version of [Quarto](https://quarto.org). The goal is to replace parts of the TypeScript/Deno runtime with a unified Rust implementation.
 
+## Installing
+
+> Release binaries are experimental, like everything else here — they
+> exist so the team and early testers don't need a full Rust + Node
+> toolchain.
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/quarto-dev/q2/main/install.sh | bash
+```
+
+On Windows (PowerShell):
+
+```powershell
+irm https://raw.githubusercontent.com/quarto-dev/q2/main/install.ps1 | iex
+```
+
+The installer downloads the release archive for your platform, verifies
+its SHA-256 checksum **and** its Ed25519 signature ([minisign](https://jedisct1.github.io/minisign/),
+required — `brew install minisign` / `apt install minisign`), and
+installs `q2` to `~/.local/bin` (override with `--dest` or
+`Q2_INSTALL_DIR`). The signing public key, pinned in `install.sh`:
+
+```
+RWR2A9ILpZX1kVF3Q6uk5TRus8FDM25H2F+KKKHEuqlxv+JJSLyPalvN
+```
+
+To verify a manually downloaded archive:
+
+```sh
+minisign -Vm q2-<version>-<platform>.tar.gz -P RWR2A9ILpZX1kVF3Q6uk5TRus8FDM25H2F+KKKHEuqlxv+JJSLyPalvN
+```
+
+The trusted comment should name exactly the file you downloaded.
+
+`q2 mcp` (the Quarto Hub MCP server) additionally needs
+[Node.js](https://nodejs.org) 24+ at runtime; release binaries come
+with the MCP server and quarto-hub.com connection defaults built in, so
+no further configuration is needed. Private hub operators can still
+point elsewhere via the `QUARTO_HUB_MCP_CLIENT_ID`,
+`QUARTO_HUB_MCP_CLIENT_SECRET`, and `QUARTO_HUB_SERVER` environment
+variables, which always win over the built-in defaults.
+
 ## Building
 
 Requires Rust nightly (edition 2024).

--- a/claude-notes/plans/2026-06-12-q2-github-releases-bundled-mcp.md
+++ b/claude-notes/plans/2026-06-12-q2-github-releases-bundled-mcp.md
@@ -332,21 +332,40 @@ same code path with the same mechanism).
 
 ### Phase 3 — Release workflow
 
-- [ ] `.github/workflows/release.yml` adapted from braid: preflight
+- [x] `.github/workflows/release.yml` adapted from braid: preflight
       tag/version check; matrix (linux_amd64, linux_arm64, darwin_amd64,
       darwin_arm64, windows_amd64); Defender exclusion on Windows;
       archive + sha256; minisign (trusted comment = filename) +
       self-verify vs install.sh pin; combined checksums.sha256;
-      `gh release create`
-- [ ] Bundle-before-build ordering per D2: node setup → `npm ci` →
-      `cargo xtask build-hub-mcp-bundle` (with D3's cross-target
-      handling) → `cargo build --release --locked -p quarto`
-- [ ] Bundled-defaults injection: pass `QUARTO_HUB_BUNDLED_*` from
-      secrets/vars into the cargo build env, **release workflow only**
-- [ ] Per-platform workflow assertions: binary version matches tag;
-      `q2 mcp --launcher-info` shows non-placeholder bundle, bundled
-      defaults present, keyring package matches target platform
-- [ ] Release-notes generation (braid's table format, adjusted)
+      `gh release create` (actionlint-clean)
+- [x] Bundle-before-build ordering per D2 — **expanded**: a functional
+      q2 embeds THREE payloads (MCP bundle, preview SPA, trace viewer).
+      New `web-payloads` job builds the target-independent ones once
+      (WASM toolchain mirrors hub-client-e2e.yml: nightly + rust-src +
+      clang + lockfile-pinned wasm-bindgen-cli) and the matrix downloads
+      them; the MCP bundle builds per target with `KEYRING_PLATFORMS`
+- [x] Bundled-defaults injection from secrets/vars in the release
+      workflow only, with a fail-fast guard if any value is empty
+- [x] Per-platform workflow assertions: binary `--version` equals the
+      tag version; `q2 mcp --launcher-info` shows non-placeholder
+      bundle, `default …: bundled` ×3, and a keyring addon per entry in
+      the target's KEYRING_PLATFORMS list
+- [x] Release-notes generation (braid's table, experimental banner,
+      node-24 note for `q2 mcp`, pubkey extracted from install.sh)
+- [x] musl TLS: `[target.'cfg(target_env = "musl")']`
+      `openssl-sys = { features = ["vendored"] }` in crates/quarto
+      (Cargo.lock updated — release builds are `--locked`)
+
+**Phase 3 decision record (2026-06-12).**
+- **CLI version contract changed** (Carlos, in-session): `q2 --version`
+  now reports the real workspace version (`quarto 0.1.0`) instead of
+  the `99.9.9-dev` extension-compatibility placeholder — release
+  artifacts must be verifiable against their tag, and Lua-side
+  `quarto.version` already reported {0,1,0}. TDD'd in
+  `quarto-util/src/version.rs` (red first). Consequence: extension
+  minimum-quarto-version checks will see 0.1.0; accepted for now.
+- The `99.9.9` strings in `error_catalog.json` / `docs/errors/` are
+  `since_version` markers — a separate concern, deliberately untouched.
 
 ### Phase 4 — End-to-end verification (per CLAUDE.md, before declaring done)
 

--- a/claude-notes/plans/2026-06-12-q2-github-releases-bundled-mcp.md
+++ b/claude-notes/plans/2026-06-12-q2-github-releases-bundled-mcp.md
@@ -299,14 +299,36 @@ same code path with the same mechanism).
 
 ### Phase 2 — Installer scripts + offline tests
 
-- [ ] Adapt `install.sh` from braid (OWNER/REPO/BINARY_NAME=q2, new
+- [x] Adapt `install.sh` from braid (OWNER/REPO/BINARY_NAME=q2, new
       pinned pubkey); keep `--print-platform`, refusal paths, atomic
       install, trusted-comment check
-- [ ] Adapt `install.ps1` (checksum-only, matching braid's Windows story
+- [x] Adapt `install.ps1` (checksum-only, matching braid's Windows story
       — note the signature gap)
-- [ ] Port braid's `bootstrap_sh.rs` offline test (`--artifact-url
+- [x] Port braid's `bootstrap_sh.rs` offline test (`--artifact-url
       file://` + `--checksum`) into a workspace integration test
-- [ ] README install section + manual-verification instructions
+- [x] README install section + manual-verification instructions
+
+**Phase 2 record (2026-06-12).** Decisions made during the port:
+- Archive layout is **flat** (binary only) since the MCP bundle is
+  embedded in the binary — no `~/.local/share` payload dir needed;
+  install dir defaults to `~/.local/bin`, exactly like braid.
+- Env vars renamed: `Q2_REPO_OWNER`/`Q2_REPO_NAME`/`Q2_MINISIGN`/
+  `Q2_INSTALL_DIR`.
+- Unsupported-platform advice says `--from-source` (braid said `cargo
+  install --git`, which is untested for this workspace's bin layout).
+- `--from-source` builds the MCP bundle when npm is available
+  (`npm install && npm run bundle -w ts-packages/quarto-hub-mcp`),
+  loudly warns + proceeds without it otherwise (`q2 mcp`
+  non-functional, everything else works).
+- Test home: `crates/quarto/tests/integration/bootstrap_sh.rs` (32
+  tests; `pub mod bootstrap_sh;` registered alphabetized in main.rs;
+  `sha2 = "0.11"` added to quarto dev-deps — 0.11 dropped LowerHex on
+  digests, hence a local `sha256_hex` helper). All 32 pass locally;
+  shellcheck-clean verified (shellcheck installed here).
+- `test-suite.yml` gains minisign install steps (apt/brew) — the suite
+  requires it loudly rather than skipping (braid's contract, kept).
+- README gains an Installing section (pinned pubkey, manual
+  verification, node 24+ note for `q2 mcp`, env-var override story).
 
 ### Phase 3 — Release workflow
 

--- a/claude-notes/plans/2026-06-12-q2-github-releases-bundled-mcp.md
+++ b/claude-notes/plans/2026-06-12-q2-github-releases-bundled-mcp.md
@@ -1,0 +1,358 @@
+# GitHub release assets for q2, with bundled quarto-hub.com MCP defaults
+
+**Strand:** bd-c6l13j79
+**Date:** 2026-06-12 (rewritten same day after PR #277 / bd-81cfshmw landed — see "Scope changes" below)
+**Reference implementation:** `external-sources/braid` (release.yml + install.sh + install.ps1 + minisign)
+**Related:** bd-3tak0lyy (npx publish channel, deferred), bd-81cfshmw (q2 mcp launcher, shipped)
+
+## Overview
+
+Today, running the quarto-hub MCP requires building the monorepo from
+source **plus** three operator-distributed env vars
+(`QUARTO_HUB_MCP_CLIENT_ID`, `QUARTO_HUB_MCP_CLIENT_SECRET`,
+`QUARTO_HUB_SERVER`). The goal is to reduce that to: **install q2 + node,
+done** — for users of the canonical quarto-hub.com hub.
+
+Two pieces of work:
+
+1. **Binary distribution.** Adopt the cscheid/braid release mechanism
+   (tag-triggered GitHub Actions workflow → per-platform archives → SHA-256
+   checksums → minisign Ed25519 signatures → GitHub Release, consumed by
+   `install.sh` / `install.ps1` with a pinned public key). Source:
+   `external-sources/braid/.github/workflows/release.yml`,
+   `external-sources/braid/install.sh`, `external-sources/braid/install.ps1`.
+
+2. **Bundled OAuth defaults.** The release CI embeds the quarto-hub.com
+   Google OAuth Desktop-app client credentials and server URL into the
+   released q2 binary as *defaults*, injected by the `q2 mcp` launcher
+   into the node child's environment. Env vars keep working and always
+   win, so private hub operators are unaffected; source builds without
+   the CI values behave exactly like today.
+
+## Scope changes after PR #277 (bd-81cfshmw)
+
+The first draft of this plan assumed `q2 mcp` didn't exist and proposed
+building it. PR #277 landed the whole launcher the same day, with a
+*different* (better-tested) architecture than the draft proposed. What
+that removes from this plan:
+
+- ~~`q2 mcp` subcommand~~ — shipped: `crates/quarto/src/commands/mcp.rs`
+  → `crates/quarto-mcp-launcher`. Thin launcher; TS server stays the
+  canonical implementation. Design doc:
+  `claude-notes/plans/2026-06-11-q2-mcp-hub-auth.md`.
+- ~~"ship `mcp/` dir inside the release archive"~~ — the bundle is
+  **embedded in the q2 binary** (`include_dir!` of
+  `ts-packages/quarto-hub-mcp/dist-bundle/`, built by
+  `cargo xtask build-hub-mcp-bundle`) and extracted at runtime to a
+  per-user cache with locking + GC. **Release archives therefore contain
+  only the q2 binary**, and install.sh stays as simple as braid's.
+- ~~esbuild/keyring spike~~ — solved: `scripts/bundle.mjs` bundles to a
+  single `index.mjs` (automerge steered to its base64-wasm entrypoint),
+  with `@napi-rs/keyring` external as a mini `node_modules` carrying the
+  platform `.node` package(s).
+- ~~node discovery/version policy spike~~ — solved: `node.rs`
+  (`MIN_NODE_MAJOR`, `QUARTO_NODE` override), bundle targets node24.
+- ~~placeholder/no-bundle error story~~ — solved: build.rs embeds a
+  `BUNDLE_NOT_BUILT` placeholder when dist-bundle/ is absent; `q2 mcp`
+  fails with an actionable message; `q2 mcp --launcher-info` reports
+  bundle hash + build-info (the stale-embed tripwire).
+
+What remains is exactly: the release pipeline, the bundled-defaults
+injection, the installers, and end-to-end verification.
+
+### Why embedding the "secret" is OK (settled in session 2026-06-12)
+
+The Google OAuth client is type **Desktop app**. Per RFC 8252 and Google's
+own docs, its `client_secret` is a public client credential — it cannot
+authenticate anything, and every major CLI (gcloud, gh, rclone) ships its
+equivalent inside the artifact. Security comes from user consent + PKCE +
+loopback redirect, not from the secret. We inject the values at CI time
+(GitHub Actions secrets) rather than committing them **purely** to avoid
+Google/GitHub automated `GOCSPX-` scanners flagging the public repo and
+auto-revoking the client — an operational concern, not a security one.
+
+## Architecture decisions
+
+### D1. Defaults live in the Rust launcher, injected into the node child env
+
+`option_env!("QUARTO_HUB_BUNDLED_CLIENT_ID")` (+ `_CLIENT_SECRET`,
+`_SERVER`) in `quarto-mcp-launcher`. `delegate.rs` builds the child
+`Command` — add `cmd.env(var, default)` there for each variable the user
+has **not** set to a non-empty value (match `readNonEmpty` semantics in
+`oauth-config.ts`: empty/whitespace counts as unset). Rationale:
+
+- Zero TS changes: `oauth-config.ts` and `index.ts` keep reading env
+  vars; their error messages stay the single source of truth.
+- One injection point (release CI → rustc env), no generated JS config.
+- `option_env!` means fresh-clone `cargo build` needs no secrets and no
+  placeholders; PR CI never sees the values; only the release workflow
+  sets them.
+- Resolution order per variable: user env (set & non-empty) →
+  compiled-in default (release builds) → unset (source builds; the TS
+  server errors with its existing message).
+
+`q2 mcp --launcher-info` additionally reports, per variable:
+`env` / `bundled` / `absent` (value elided for the secret). This is both
+the user-debugging surface and the release-workflow assertion hook.
+
+Note `--launcher-info` handling in `lib.rs::run` returns before
+delegation, so the injection code paths are launcher-internal and
+testable without node.
+
+### D2. Release archive layout: binary only
+
+The MCP bundle is inside the binary (see scope changes), so archives are
+braid-shaped: `q2-<version>-<platform>.tar.gz` containing the single `q2`
+member (`.zip` with `q2.exe` on Windows). install.sh needs only
+s/braid/q2/ + the new pinned pubkey + repo coordinates.
+
+**Critical workflow ordering:** the release matrix must run
+`npm ci` (repo root) + `cargo xtask build-hub-mcp-bundle` **before**
+`cargo build`, or the binary ships the `BUNDLE_NOT_BUILT` placeholder.
+Assert per-platform in the workflow: `q2 mcp --launcher-info` must NOT
+report `PLACEHOLDER`, must report a bundle-hash, and must report all
+three defaults as `bundled` (in the release workflow) — this is the
+2026-05-20 stale-embed incident class, caught at release time.
+
+### D3. Cross-target keyring wrinkle (NEW — replaces the old S2 spike)
+
+`scripts/bundle.mjs` copies the `@napi-rs/keyring` platform package(s)
+found in the **build host's** `node_modules`. The `.node` addon is loaded
+at runtime by the *user's* node, so the embedded mini node_modules must
+match the **target** platform of the q2 binary, not the runner's. Native
+runners (linux_amd64, linux_arm64, darwin_arm64, windows_amd64) are fine.
+**darwin_amd64 built on an arm64 macos-15 runner (braid's matrix) is the
+cross case**: npm installs keyring-darwin-arm64, the x86_64 user needs
+keyring-darwin-x64.
+
+**Spike S1:** pick one of
+(a) supplemental `npm install --cpu=x64 --os=darwin @napi-rs/keyring-darwin-x64`
+    (npm supports cross-platform optional-dep fetch via `--cpu`/`--os`),
+(b) have bundle.mjs accept a target-platform argument and verify the
+    right platform package is present (fail closed — extend its existing
+    `copied` sanity check),
+(c) ship both darwin keyring packages in the darwin bundles.
+Whichever lands, add a workflow assertion that the embedded bundle's
+`build-info.json` `keyringPackages` includes the target platform.
+
+### D4. Linux build target: spike musl, fall back to gnu
+
+braid ships static musl. q2's dep tree is much larger (tokio, axum,
+tree-sitter C, …). **Spike S2:** try `x86_64-unknown-linux-musl` for
+`-p quarto`; if it fights back, ship gnu built on the oldest supported
+ubuntu runner (glibc floor) and note the floor in release notes. Timebox:
+one day.
+
+### D5. Signing: new minisign keypair, dedicated to quarto-dev/q2
+
+Do **not** reuse the braid key — different project, different blast
+radius. Passwordless keypair (`minisign -GW`) because CI can't answer
+prompts; secret half lives only in the `MINISIGN_SECRET_KEY` repo secret
+(+ password-manager copy). Public half pinned in `install.sh`, README,
+release notes. Keep braid's release-time self-check (sign, then verify
+against the pubkey extracted from install.sh, so a mismatch fails the
+release) and replay protection (trusted comment = archive filename,
+compared by install.sh).
+
+### D6. Versioning / tagging
+
+Workspace `Cargo.toml` version (currently `0.1.0`) is the source of
+truth; tag `vX.Y.Z` must match (braid's preflight job, ported). First
+release `v0.1.0`, marked pre-release.
+
+### D7. Out of scope
+
+- npm publish of the bundle (bd-3tak0lyy, deferred on public-release
+  readiness).
+- Homebrew/Scoop/WinGet manifests.
+- Hub-brokered auth (hub as OAuth AS, RFC 7591 DCR) — the long-term
+  replacement for bundled credentials; see
+  `claude-notes/plans/2026-05-28-hub-mcp-loopback-pkce.md` future work.
+- macOS notarization / Windows Authenticode. install.sh users are fine;
+  double-click users are not a target yet.
+
+## Operator setup (Carlos's side — blocks Phase 3 dry-run only)
+
+1. Generate the release signing keypair (one time, trusted machine):
+   ```sh
+   minisign -GW -p q2-release.pub -s q2-release.key
+   ```
+   Store both halves in the team password manager. `-W` (no password) is
+   required for non-interactive CI signing.
+2. Upload to quarto-dev/q2 (requires repo admin):
+   ```sh
+   gh secret set MINISIGN_SECRET_KEY --repo quarto-dev/q2 < q2-release.key
+   gh secret set QUARTO_HUB_MCP_CLIENT_ID --repo quarto-dev/q2
+   gh secret set QUARTO_HUB_MCP_CLIENT_SECRET --repo quarto-dev/q2
+   gh variable set QUARTO_HUB_SERVER --repo quarto-dev/q2 --body "wss://quarto-hub.com/ws"
+   ```
+   The OAuth values go in *secrets* not because they're confidential
+   (see above) but to keep them masked in logs and away from scanners.
+   The server URL is a plain Actions *variable*.
+3. Delete the local `q2-release.key` once stored.
+4. Confirm the bundled client id is in the hub's
+   `--additional-audiences` (it already is — same client id as today's
+   env-var distribution).
+
+## Phases & work items
+
+### Phase 0 — Spikes (timeboxed)
+
+- [x] S1: darwin_amd64 keyring cross-target strategy (D3); record the
+      chosen mechanism + exact commands here
+- [x] S2: musl build spike for `-p quarto` (D4); record outcome here
+- [x] Operator setup complete (secrets + variable + keypair)
+
+**S1 outcome (2026-06-12).** Mechanism (b) from D3, generalized: extend
+`scripts/bundle.mjs` with an optional `KEYRING_PLATFORMS` list (e.g.
+`darwin-arm64,darwin-x64`). For each requested platform: copy the
+locally installed `@napi-rs/keyring-<plat>` if present (today's
+behavior, keeps dev offline); otherwise fetch the **exact version of
+the installed loader package** via `npm pack @napi-rs/keyring-<plat>@<ver>`
+and extract the tarball's `package/` into the bundle's mini
+node_modules. Fail closed if a requested platform can't be staged.
+Verified on this arm64 mac: `npm pack @napi-rs/keyring-darwin-x64@1.3.0`
+→ 254 KB tgz containing `keyring.darwin-x64.node` (Mach-O x86_64), no
+platform checks interfere. The loader package does full runtime
+platform/arch/musl detection, so co-staged platform packages coexist by
+design (`bundle.mjs` even documents multi-platform staging already).
+Platform packages are ~250–500 KB each (12 exist for v1.3.0).
+Per-target staging lists (also covers the Rosetta/libc mismatch cases —
+the addon must match the **user's node**, not the q2 binary):
+  - linux_amd64 → `linux-x64-gnu,linux-x64-musl`
+  - linux_arm64 → `linux-arm64-gnu,linux-arm64-musl`
+  - darwin_amd64 / darwin_arm64 → `darwin-x64,darwin-arm64` (identical)
+  - windows_amd64 → `win32-x64-msvc,win32-arm64-msvc`
+`build-info.json` already records `keyringPackages` → workflow asserts
+the expected list per target.
+
+**S2 outcome (2026-06-12).** Static analysis of
+`cargo tree --target x86_64-unknown-linux-musl -p quarto`:
+- `openssl-sys` enters via samod (quarto-dev fork) → tokio-tungstenite
+  `native-tls`. Fix: `[target.'cfg(target_env = "musl")']`
+  `openssl-sys = { features = ["vendored"] }` in `crates/quarto`
+  (static openssl built from source; needs perl+make, present on
+  ubuntu runners).
+- Second risk: `aws-lc-sys` (rustls crypto provider) — compiles C via
+  cmake; musl support exists but is historically finicky.
+- Everything else C-flavored (mlua-sys, tree-sitter, ring) is
+  musl-clean.
+Decision: release matrix attempts **musl + vendored openssl** first;
+the workflow keeps the linux target as a matrix variable so falling
+back to gnu (oldest-ubuntu glibc floor, still vendored openssl to
+avoid a runtime libssl dep) is a one-line change. Final verdict at the
+Phase 4 dry-run — cross-compiling musl from this mac is not worth the
+toolchain setup. Longer-term sound alternative if both bite: move
+samod's tungstenite feature to rustls (we own the fork) — file a
+strand if needed.
+
+**Operator setup verified (2026-06-12):** `gh secret list` shows
+MINISIGN_SECRET_KEY, QUARTO_HUB_MCP_CLIENT_ID,
+QUARTO_HUB_MCP_CLIENT_SECRET; `gh variable list` shows
+QUARTO_HUB_SERVER=wss://quarto-hub.com/ws. Minisign pubkey (pinned in
+install.sh, key ID 91F595A50BD20376):
+`RWR2A9ILpZX1kVF3Q6uk5TRus8FDM25H2F+KKKHEuqlxv+JJSLyPalvN`.
+`q2-release.{key,pub}` were found sitting in the repo root —
+**gitignored now**; Carlos to move the secret half to the password
+manager and delete locally.
+
+### Phase 1 — Bundled defaults in the launcher (TDD)
+
+- [x] Tests first: env-merge tests — user-env wins; empty/whitespace env
+      treated as unset (mirror `readNonEmpty`); absent bundled → variable
+      not injected; values never printed (sources only). Pure-logic tests
+      live in `src/defaults.rs` `#[cfg(test)]` (the crate's precedent —
+      `bundle.rs`); the un-exec-able delegation path is covered via a
+      `build_command` seam with `get_envs()` assertions in `delegate.rs`.
+- [x] `option_env!` plumbing for `QUARTO_HUB_BUNDLED_{CLIENT_ID,CLIENT_SECRET,SERVER}`
+      (`src/defaults.rs`) + injection via `delegate::build_command`
+      (single point ahead of the Unix-exec/Windows-spawn split)
+- [x] `--launcher-info` reports `default <VAR>: env|bundled|absent`
+      (also for placeholder builds — defaults are a property of the
+      binary, not the bundle; values uniformly elided)
+- [x] End-to-end check vs a local build with TEST values baked
+      (real secret never touches a local build)
+
+**Phase 1 end-to-end record (2026-06-12).** Built with
+`QUARTO_HUB_BUNDLED_CLIENT_ID=test-client-id.apps.googleusercontent.com
+QUARTO_HUB_BUNDLED_CLIENT_SECRET=TEST-not-a-real-secret
+QUARTO_HUB_BUNDLED_SERVER=wss://example.invalid/ws cargo build --bin q2`.
+Observed (output inspected):
+- shell with Carlos's real exports → `default …: env` ×3 (user wins);
+- `env -u …` all three → `default …: bundled` ×3;
+- `QUARTO_HUB_MCP_CLIENT_ID=""` → still `bundled` (blank = unset);
+- fake `QUARTO_NODE` child dump, no user env →
+  `child CLIENT_ID=test-client-id.apps.googleusercontent.com`,
+  `child CLIENT_SECRET=TEST-not-a-real-secret`,
+  `child SERVER=wss://example.invalid/ws`;
+- same + `QUARTO_HUB_SERVER=ws://localhost:3030/ws` → child sees the
+  user server, bundled id/secret (per-variable independence);
+- rebuild **without** the env vars → `default …: absent` ×3 and empty
+  child env (fresh-clone path; also proves cargo env-dep tracking
+  rebuilds on `option_env!` changes in both directions — no build.rs
+  plumbing needed).
+35/35 tests pass in `quarto-mcp-launcher` (9 new defaults + 2 new
+delegate seam tests). Note: a *real* `q2 mcp` connect against
+quarto-hub.com with release-injected values is deliberately deferred to
+Phase 4 (that's the artifact-level check; locally it would exercise the
+same code path with the same mechanism).
+
+### Phase 2 — Installer scripts + offline tests
+
+- [ ] Adapt `install.sh` from braid (OWNER/REPO/BINARY_NAME=q2, new
+      pinned pubkey); keep `--print-platform`, refusal paths, atomic
+      install, trusted-comment check
+- [ ] Adapt `install.ps1` (checksum-only, matching braid's Windows story
+      — note the signature gap)
+- [ ] Port braid's `bootstrap_sh.rs` offline test (`--artifact-url
+      file://` + `--checksum`) into a workspace integration test
+- [ ] README install section + manual-verification instructions
+
+### Phase 3 — Release workflow
+
+- [ ] `.github/workflows/release.yml` adapted from braid: preflight
+      tag/version check; matrix (linux_amd64, linux_arm64, darwin_amd64,
+      darwin_arm64, windows_amd64); Defender exclusion on Windows;
+      archive + sha256; minisign (trusted comment = filename) +
+      self-verify vs install.sh pin; combined checksums.sha256;
+      `gh release create`
+- [ ] Bundle-before-build ordering per D2: node setup → `npm ci` →
+      `cargo xtask build-hub-mcp-bundle` (with D3's cross-target
+      handling) → `cargo build --release --locked -p quarto`
+- [ ] Bundled-defaults injection: pass `QUARTO_HUB_BUNDLED_*` from
+      secrets/vars into the cargo build env, **release workflow only**
+- [ ] Per-platform workflow assertions: binary version matches tag;
+      `q2 mcp --launcher-info` shows non-placeholder bundle, bundled
+      defaults present, keyring package matches target platform
+- [ ] Release-notes generation (braid's table format, adjusted)
+
+### Phase 4 — End-to-end verification (per CLAUDE.md, before declaring done)
+
+- [ ] Dry-run the workflow (workflow_dispatch on a test tag or fork);
+      download artifacts for all five platforms
+- [ ] `install.sh` one-liner on a clean machine/container → `q2 --version`
+- [ ] `q2 mcp` with **no env vars set** connects to quarto-hub.com:
+      browser consent → token → `connect_project` + `read_file` against a
+      real project from an MCP client config with no `env` block
+- [ ] Env-override check: `QUARTO_HUB_SERVER=ws://localhost:…` against a
+      local hub still works (private-operator path unbroken)
+- [ ] darwin_amd64 artifact specifically: keyring loads on an x86_64 mac
+      (or under Rosetta `arch -x86_64 node`) — the D3 cross case
+- [ ] Record invocations + observed output in this plan
+
+## Risks / open questions
+
+- **D3 cross-target keyring** is the main new risk; fail-closed assertion
+  in the workflow regardless of chosen mechanism.
+- **musl** (S2) may be a non-starter for q2's dep tree; gnu fallback in D4.
+- **Windows signature gap**: install.ps1 verifies checksums only
+  (matches braid). Acceptable for v1; note it.
+- **Key compromise story**: anyone with quarto-dev/q2 admin can read the
+  passwordless signing key. Same trust model as braid; document rotation
+  (new keypair → update install.sh pin → re-sign current release).
+- **Tag-push releases use repo secrets** — fine (fork PRs never see
+  secrets; tag pushes are maintainer-only).
+- **Release builds embed whatever dist-bundle/ exists** — the workflow
+  builds it fresh in the same job, and the launcher-info assertion guards
+  the ordering; local/dev builds remain subject to the stale-embed
+  caveat documented in CLAUDE.md.

--- a/crates/quarto-mcp-launcher/src/defaults.rs
+++ b/crates/quarto-mcp-launcher/src/defaults.rs
@@ -1,0 +1,247 @@
+//! Bundled quarto-hub.com OAuth defaults (bd-c6l13j79).
+//!
+//! Release builds of q2 compile in default values for the three
+//! environment variables the TS MCP server reads
+//! (`QUARTO_HUB_MCP_CLIENT_ID`, `QUARTO_HUB_MCP_CLIENT_SECRET`,
+//! `QUARTO_HUB_SERVER`), so users of the canonical quarto-hub.com hub
+//! need zero configuration. The values are injected into the **node
+//! child's environment** at delegation time; the TS server's env-var
+//! sourcing (`oauth-config.ts`, `index.ts`) is unchanged and remains
+//! the single source of truth for errors and semantics.
+//!
+//! Sourcing rules, per variable:
+//! - a user env var that is set and non-blank always wins (private hub
+//!   operators are unaffected);
+//! - a set-but-blank env var counts as **unset**, mirroring
+//!   `readNonEmpty` in `oauth-config.ts` (there is deliberately no
+//!   "force absent" escape — to target a different hub, set real
+//!   values);
+//! - otherwise the compiled-in default applies, when present.
+//!
+//! The defaults enter at *compile* time via `option_env!` on
+//! `QUARTO_HUB_BUNDLED_{CLIENT_ID,CLIENT_SECRET,SERVER}` — set only by
+//! the release workflow (from GitHub secrets/vars). Fresh-clone and PR
+//! builds compile with no bundled values and behave exactly like
+//! today: the TS server errors, naming the required env vars. (rustc
+//! records `option_env!` reads in dep-info, so changing the build env
+//! correctly triggers a rebuild; no build.rs plumbing is needed.)
+//!
+//! Note the Desktop-app OAuth `client_secret` is a *public client*
+//! credential (RFC 8252): embedding it is the industry-standard
+//! distribution for native apps (gcloud, gh, rclone) and is not a
+//! secrecy boundary. It is still elided from all output to keep
+//! GOCSPX- scanners quiet.
+
+/// The env var the TS server reads → the compiled-in default, if any.
+pub struct BundledDefault {
+    pub var: &'static str,
+    pub bundled: Option<&'static str>,
+    /// Elide the value from every diagnostic surface.
+    pub secret: bool,
+}
+
+/// The three hub-connection variables, with whatever defaults this
+/// binary was built with.
+pub fn bundled_defaults() -> [BundledDefault; 3] {
+    [
+        BundledDefault {
+            var: "QUARTO_HUB_MCP_CLIENT_ID",
+            bundled: option_env!("QUARTO_HUB_BUNDLED_CLIENT_ID"),
+            secret: false,
+        },
+        BundledDefault {
+            var: "QUARTO_HUB_MCP_CLIENT_SECRET",
+            bundled: option_env!("QUARTO_HUB_BUNDLED_CLIENT_SECRET"),
+            secret: true,
+        },
+        BundledDefault {
+            var: "QUARTO_HUB_SERVER",
+            bundled: option_env!("QUARTO_HUB_BUNDLED_SERVER"),
+            secret: false,
+        },
+    ]
+}
+
+/// Where a variable's effective value comes from, for `--launcher-info`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Source {
+    /// User env var, set and non-blank: nothing injected.
+    Env,
+    /// No usable user value; the compiled-in default will be injected.
+    Bundled,
+    /// No usable user value and no compiled-in default: the TS server
+    /// will error with its own message.
+    Absent,
+}
+
+impl std::fmt::Display for Source {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Source::Env => "env",
+            Source::Bundled => "bundled",
+            Source::Absent => "absent",
+        })
+    }
+}
+
+/// `readNonEmpty` (oauth-config.ts) semantics: set and non-blank.
+fn usable(value: Option<&str>) -> bool {
+    matches!(value, Some(v) if !v.trim().is_empty())
+}
+
+/// Classify one variable given the user's env value.
+pub fn classify(user_value: Option<&str>, bundled: Option<&str>) -> Source {
+    if usable(user_value) {
+        Source::Env
+    } else if bundled.is_some() {
+        Source::Bundled
+    } else {
+        Source::Absent
+    }
+}
+
+/// The (var, value) pairs to inject into the node child's environment:
+/// exactly the variables classified [`Source::Bundled`].
+pub fn injections(
+    defaults: &[BundledDefault],
+    env_lookup: impl Fn(&str) -> Option<String>,
+) -> Vec<(&'static str, &'static str)> {
+    defaults
+        .iter()
+        .filter_map(|d| {
+            let user = env_lookup(d.var);
+            match classify(user.as_deref(), d.bundled) {
+                Source::Bundled => Some((d.var, d.bundled.expect("Bundled implies Some"))),
+                Source::Env | Source::Absent => None,
+            }
+        })
+        .collect()
+}
+
+/// (var, source) for every variable, for `--launcher-info`. Values are
+/// never included — sources only.
+pub fn sources(
+    defaults: &[BundledDefault],
+    env_lookup: impl Fn(&str) -> Option<String>,
+) -> Vec<(&'static str, Source)> {
+    defaults
+        .iter()
+        .map(|d| {
+            let user = env_lookup(d.var);
+            (d.var, classify(user.as_deref(), d.bundled))
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fake(var: &'static str, bundled: Option<&'static str>) -> BundledDefault {
+        BundledDefault {
+            var,
+            bundled,
+            secret: false,
+        }
+    }
+
+    fn env_of<'a>(pairs: &'a [(&'a str, &'a str)]) -> impl Fn(&str) -> Option<String> + 'a {
+        move |k| {
+            pairs
+                .iter()
+                .find(|(name, _)| *name == k)
+                .map(|(_, v)| v.to_string())
+        }
+    }
+
+    #[test]
+    fn user_env_wins_over_bundled() {
+        let defaults = [fake("VAR_A", Some("bundled-a"))];
+        let inj = injections(&defaults, env_of(&[("VAR_A", "user-a")]));
+        assert!(inj.is_empty(), "user value set: nothing to inject");
+        let src = sources(&defaults, env_of(&[("VAR_A", "user-a")]));
+        assert_eq!(src, vec![("VAR_A", Source::Env)]);
+    }
+
+    #[test]
+    fn unset_env_gets_bundled_value() {
+        let defaults = [fake("VAR_A", Some("bundled-a"))];
+        let inj = injections(&defaults, env_of(&[]));
+        assert_eq!(inj, vec![("VAR_A", "bundled-a")]);
+        let src = sources(&defaults, env_of(&[]));
+        assert_eq!(src, vec![("VAR_A", Source::Bundled)]);
+    }
+
+    #[test]
+    fn empty_env_treated_as_unset_like_read_non_empty() {
+        // oauth-config.ts readNonEmpty: "" and whitespace count as unset.
+        let defaults = [fake("VAR_A", Some("bundled-a"))];
+        for blank in ["", "   ", "\t\n"] {
+            let inj = injections(&defaults, env_of(&[("VAR_A", blank)]));
+            assert_eq!(
+                inj,
+                vec![("VAR_A", "bundled-a")],
+                "blank {blank:?} must behave like unset"
+            );
+        }
+    }
+
+    #[test]
+    fn absent_bundled_injects_nothing() {
+        // Source builds: no compiled-in defaults, no injection — the TS
+        // server's own MissingOAuthConfigError surfaces unchanged.
+        let defaults = [fake("VAR_A", None)];
+        let inj = injections(&defaults, env_of(&[]));
+        assert!(inj.is_empty());
+        let src = sources(&defaults, env_of(&[]));
+        assert_eq!(src, vec![("VAR_A", Source::Absent)]);
+    }
+
+    #[test]
+    fn absent_bundled_with_user_env_is_env() {
+        let defaults = [fake("VAR_A", None)];
+        let src = sources(&defaults, env_of(&[("VAR_A", "user-a")]));
+        assert_eq!(src, vec![("VAR_A", Source::Env)]);
+    }
+
+    #[test]
+    fn variables_resolve_independently() {
+        let defaults = [
+            fake("VAR_A", Some("bundled-a")),
+            fake("VAR_B", Some("bundled-b")),
+            fake("VAR_C", None),
+        ];
+        let env = env_of(&[("VAR_A", "user-a")]);
+        let inj = injections(&defaults, &env);
+        assert_eq!(inj, vec![("VAR_B", "bundled-b")]);
+        let src = sources(&defaults, &env);
+        assert_eq!(
+            src,
+            vec![
+                ("VAR_A", Source::Env),
+                ("VAR_B", Source::Bundled),
+                ("VAR_C", Source::Absent),
+            ]
+        );
+    }
+
+    #[test]
+    fn real_defaults_cover_exactly_the_three_hub_vars() {
+        let vars: Vec<&str> = bundled_defaults().iter().map(|d| d.var).collect();
+        assert_eq!(
+            vars,
+            vec![
+                "QUARTO_HUB_MCP_CLIENT_ID",
+                "QUARTO_HUB_MCP_CLIENT_SECRET",
+                "QUARTO_HUB_SERVER",
+            ]
+        );
+        // Only the client secret is elision-worthy.
+        let secrets: Vec<&str> = bundled_defaults()
+            .iter()
+            .filter(|d| d.secret)
+            .map(|d| d.var)
+            .collect();
+        assert_eq!(secrets, vec!["QUARTO_HUB_MCP_CLIENT_SECRET"]);
+    }
+}

--- a/crates/quarto-mcp-launcher/src/delegate.rs
+++ b/crates/quarto-mcp-launcher/src/delegate.rs
@@ -21,11 +21,36 @@ use std::fs::File;
 use std::path::Path;
 use std::process::Command;
 
-/// Returns only on failure to launch (Unix) or with the child's exit
-/// code (Windows). The caller turns the code into `process::exit`.
-pub fn delegate(node: &Path, entry: &Path, args: &[String], lock: File) -> Result<i32> {
+/// Assemble the child command: `node <entry> [args…]`, inheriting the
+/// parent environment plus `extra_env` (the bundled hub defaults — see
+/// `defaults.rs`; the caller has already resolved user-env precedence,
+/// so everything in `extra_env` is set unconditionally). Split from
+/// [`delegate`] because the Unix path execs and can never be observed
+/// by a test.
+pub(crate) fn build_command(
+    node: &Path,
+    entry: &Path,
+    args: &[String],
+    extra_env: &[(&str, &str)],
+) -> Command {
     let mut cmd = Command::new(node);
     cmd.arg(entry).args(args);
+    for (var, value) in extra_env {
+        cmd.env(var, value);
+    }
+    cmd
+}
+
+/// Returns only on failure to launch (Unix) or with the child's exit
+/// code (Windows). The caller turns the code into `process::exit`.
+pub fn delegate(
+    node: &Path,
+    entry: &Path,
+    args: &[String],
+    extra_env: &[(&str, &str)],
+    lock: File,
+) -> Result<i32> {
+    let mut cmd = build_command(node, entry, args, extra_env);
 
     #[cfg(unix)]
     {
@@ -60,5 +85,65 @@ pub fn delegate(node: &Path, entry: &Path, args: &[String], lock: File) -> Resul
         // Keep the lock alive for the child's whole lifetime.
         drop(lock);
         Ok(status.code().unwrap_or(1))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::OsStr;
+    use std::path::PathBuf;
+
+    fn env_of(cmd: &Command) -> Vec<(String, String)> {
+        cmd.get_envs()
+            .filter_map(|(k, v)| {
+                Some((
+                    k.to_string_lossy().into_owned(),
+                    v?.to_string_lossy().into_owned(),
+                ))
+            })
+            .collect()
+    }
+
+    #[test]
+    fn build_command_shape_is_node_entry_args() {
+        let cmd = build_command(
+            &PathBuf::from("/usr/bin/node"),
+            &PathBuf::from("/cache/index.mjs"),
+            &["--server".to_string(), "ws://x".to_string()],
+            &[],
+        );
+        assert_eq!(cmd.get_program(), OsStr::new("/usr/bin/node"));
+        let args: Vec<_> = cmd.get_args().map(|a| a.to_string_lossy()).collect();
+        assert_eq!(args, vec!["/cache/index.mjs", "--server", "ws://x"]);
+        assert!(env_of(&cmd).is_empty(), "no injections requested");
+    }
+
+    #[test]
+    fn build_command_sets_extra_env_on_the_child() {
+        let cmd = build_command(
+            &PathBuf::from("node"),
+            &PathBuf::from("index.mjs"),
+            &[],
+            &[
+                ("QUARTO_HUB_MCP_CLIENT_ID", "id-123"),
+                ("QUARTO_HUB_SERVER", "wss://quarto-hub.com/ws"),
+            ],
+        );
+        assert_eq!(
+            env_of(&cmd),
+            vec![
+                ("QUARTO_HUB_MCP_CLIENT_ID".to_string(), "id-123".to_string()),
+                (
+                    "QUARTO_HUB_SERVER".to_string(),
+                    "wss://quarto-hub.com/ws".to_string()
+                ),
+            ]
+        );
+        // Inherited environment is untouched: no env_clear, no removals.
+        assert!(
+            cmd.get_envs().all(|(_, v)| v.is_some()),
+            "no variable removals expected"
+        );
     }
 }

--- a/crates/quarto-mcp-launcher/src/lib.rs
+++ b/crates/quarto-mcp-launcher/src/lib.rs
@@ -18,12 +18,14 @@
 
 mod bundle;
 mod cache;
+mod defaults;
 mod delegate;
 mod node;
 
 pub use cache::{
     DEFAULT_MAX_AGE, ExtractedBundle, LAST_USED_FILE, LOCK_FILE, extract_and_lock, gc,
 };
+pub use defaults::{BundledDefault, Source, bundled_defaults, classify, injections, sources};
 pub use node::{Discovery, MIN_NODE_MAJOR, NodeError, NodeInfo, find_node, parse_version};
 
 use anyhow::{Result, bail};
@@ -57,10 +59,15 @@ pub fn run(args: &[String]) -> Result<i32> {
     cache::gc(&cache_root, &hash, cache::DEFAULT_MAX_AGE);
 
     let node = node::find_node(&node::Discovery::from_env())?;
+    // Bundled quarto-hub.com defaults (release builds only): injected
+    // into the child env for any hub variable the user hasn't set.
+    let hub_defaults = defaults::bundled_defaults();
+    let extra_env = defaults::injections(&hub_defaults, |var| std::env::var(var).ok());
     delegate::delegate(
         &node.path,
         &extracted.dir.join("index.mjs"),
         args,
+        &extra_env,
         extracted.lock,
     )
 }
@@ -77,6 +84,15 @@ fn cache_root() -> Result<PathBuf> {
 /// extracts, and which node would run it.
 fn launcher_info() -> Result<String> {
     let mut out = String::new();
+    // Hub-connection variable sources (env / bundled / absent). Values
+    // are never printed: the source is the diagnostic, and the release
+    // workflow asserts `: bundled` on all three. Reported even for
+    // placeholder builds — the defaults are a property of the binary,
+    // not of the embedded bundle.
+    let hub_defaults = defaults::bundled_defaults();
+    for (var, source) in defaults::sources(&hub_defaults, |v| std::env::var(v).ok()) {
+        out.push_str(&format!("default {var}: {source}\n"));
+    }
     if bundle::is_placeholder() {
         out.push_str("bundle: PLACEHOLDER (run `cargo xtask build-hub-mcp-bundle` and rebuild)\n");
         return Ok(out);

--- a/crates/quarto-source-map/src/source_info.rs
+++ b/crates/quarto-source-map/src/source_info.rs
@@ -156,7 +156,7 @@ impl SourceInfo {
     /// method) so that `unwrap_or_default()` and `#[derive(Default)]` still
     /// compile; those are caught by separate grep tooling.
     #[deprecated(
-        since = "0.x",
+        since = "0.1.0",
         note = "Use SourceInfo::for_test() in tests, or the appropriate Generated{by: <kind>} in production. See provenance-contract.md."
     )]
     #[doc(hidden)]

--- a/crates/quarto-util/src/version.rs
+++ b/crates/quarto-util/src/version.rs
@@ -1,29 +1,18 @@
 //! Version handling for Quarto
 //!
-//! This module implements the versioning strategy where:
-//! - Cargo.toml version: 0.x.y (idiomatic Rust, signals instability)
-//! - CLI reported version: 99.9.9-dev (for extension compatibility)
+//! The CLI reports the workspace Cargo.toml version (e.g. "0.1.0").
 //!
-//! When the crate version is 2.x.y or higher, the CLI will report the actual version.
+//! History: until 2026-06-12 the CLI reported a "99.9.9-dev"
+//! placeholder while the crate version was 0.x, so extensions with
+//! minimum-quarto-version checks would always pass against dev builds.
+//! With binary releases (bd-c6l13j79) the version must be verifiable
+//! against the release tag, and the Lua-side `quarto.version` already
+//! reported the real {0,1,0}; Carlos chose the real version and
+//! accepted the consequences for extension minimum-version checks.
 
-/// Development version used for compatibility with extensions
-const DEV_VERSION: &str = "99.9.9-dev";
-
-/// Get the version string that should be reported by the CLI
-///
-/// During development (version 0.x.y), this returns "99.9.9-dev" to ensure
-/// compatibility with all existing Quarto extensions while clearly indicating
-/// this is a development build.
-///
-/// Once released as 2.0.0+, this will return the actual version.
+/// Get the version string that should be reported by the CLI.
 pub fn cli_version() -> &'static str {
-    let cargo_version = env!("CARGO_PKG_VERSION");
-
-    if cargo_version.starts_with("0.") {
-        DEV_VERSION
-    } else {
-        cargo_version
-    }
+    env!("CARGO_PKG_VERSION")
 }
 
 /// Get the Cargo package version (for internal use)
@@ -36,13 +25,13 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_cli_version() {
-        let version = cli_version();
-        // During development, should be dev version
-        assert!(
-            version == DEV_VERSION || version.starts_with("2."),
-            "CLI version should be either dev version or 2.x.y"
-        );
+    fn test_cli_version_is_the_cargo_version() {
+        // Decision 2026-06-12 (bd-c6l13j79): the CLI reports the real
+        // workspace version (e.g. "0.1.0"), not the old 99.9.9-dev
+        // placeholder, so release artifacts are verifiable against
+        // their tag. Carlos accepted the minimum-quarto-version
+        // consequences for extensions.
+        assert_eq!(cli_version(), env!("CARGO_PKG_VERSION"));
     }
 
     #[test]

--- a/crates/quarto/Cargo.toml
+++ b/crates/quarto/Cargo.toml
@@ -50,6 +50,7 @@ open = "5"
 [dev-dependencies]
 tempfile = "3"
 pampa.workspace = true
+sha2 = "0.11"
 walkdir.workspace = true
 
 [lints]

--- a/crates/quarto/Cargo.toml
+++ b/crates/quarto/Cargo.toml
@@ -47,6 +47,14 @@ open = "5"
 
 [build-dependencies]
 
+# Static-musl release builds (release plan D4, bd-c6l13j79): samod →
+# tokio-tungstenite(native-tls) → openssl-sys needs an openssl to link,
+# and no musl-built system openssl exists on the runners — build it
+# from source into the static binary. cfg-scoped so native dev builds
+# (glibc/macOS/Windows) are untouched.
+[target.'cfg(target_env = "musl")'.dependencies]
+openssl-sys = { version = "0.9", features = ["vendored"] }
+
 [dev-dependencies]
 tempfile = "3"
 pampa.workspace = true

--- a/crates/quarto/tests/integration/bootstrap_sh.rs
+++ b/crates/quarto/tests/integration/bootstrap_sh.rs
@@ -1,0 +1,1016 @@
+//! E2E tests for install.sh, the curl|bash installer (bd-c6l13j79).
+//!
+//! Unix-only: the harness runs `bash install.sh` and shims `uname` with
+//! executable shell scripts, so the whole suite is gated to `cfg(unix)`.
+//! The Windows installer (install.ps1) is checksum-only and smoke-tested
+//! by the release workflow instead.
+//!
+//! Ported from cscheid/braid's installer test harness
+//! (external-sources/braid/crates/braid/tests/bootstrap_sh.rs), offline
+//! by construction: every install path is exercised through
+//! `--artifact-url file://...` plus `--checksum`, so no test here
+//! touches the network. (One ignored test validates real version
+//! resolution once releases exist; the plan's Phase 4 runs it.)
+//!
+//! The suite REQUIRES minisign on the host (CI installs it; locally:
+//! `brew install minisign` / `apt-get install minisign`). A silent
+//! skip-if-missing would leave the signature contract unguarded, so
+//! absence is a loud failure instead — braid's deliberate choice, kept.
+//!
+//! Plan: claude-notes/plans/2026-06-12-q2-github-releases-bundled-mcp.md
+//!
+//! Filename note: this test must not contain `install`/`setup`/`update`/
+//! `patch` in its name — Windows UAC installer-detection refuses to
+//! launch exes whose filename matches that heuristic (os error 740).
+//! The integration binary is named `integration`, but keep the module
+//! name boring anyway. Hence `bootstrap_sh`.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::sync::OnceLock;
+
+use sha2::{Digest, Sha256};
+
+/// Lowercase hex of a SHA-256 over `bytes` (sha2 0.11's digest array
+/// no longer implements LowerHex).
+fn sha256_hex(bytes: &[u8]) -> String {
+    Sha256::digest(bytes)
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect()
+}
+
+fn repo_root() -> PathBuf {
+    // CARGO_MANIFEST_DIR is crates/quarto regardless of this file's
+    // location inside tests/integration/.
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .unwrap()
+}
+
+fn install_sh() -> PathBuf {
+    repo_root().join("install.sh")
+}
+
+/// A sandbox for one installer run: its own HOME, dest dir, and a
+/// deterministic PATH (system tool dirs only, optionally prefixed with a
+/// shim dir so tests can fake `uname`).
+struct Sandbox {
+    tmp: tempfile::TempDir,
+}
+
+const SYSTEM_PATH: &str = "/usr/bin:/bin:/usr/sbin:/sbin";
+
+impl Sandbox {
+    fn new() -> Sandbox {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::create_dir_all(tmp.path().join("home")).unwrap();
+        Sandbox { tmp }
+    }
+
+    fn home(&self) -> PathBuf {
+        self.tmp.path().join("home")
+    }
+
+    /// Install destination. Deliberately not created up front: the
+    /// installer must create it.
+    fn dest(&self) -> PathBuf {
+        self.tmp.path().join("bin")
+    }
+
+    fn installed_binary(&self) -> PathBuf {
+        self.dest().join("q2")
+    }
+
+    fn run(&self, args: &[&str]) -> Output {
+        self.run_env(args, &[])
+    }
+
+    fn run_env(&self, args: &[&str], envs: &[(&str, &str)]) -> Output {
+        let mut cmd = Command::new("bash");
+        cmd.arg(install_sh())
+            .args(args)
+            .env_clear()
+            .env("HOME", self.home())
+            // minisign is appended (not prepended) so system tools keep
+            // priority; on Linux it is usually in /usr/bin already.
+            .env("PATH", default_sandbox_path());
+        for (k, v) in envs {
+            cmd.env(k, v);
+        }
+        cmd.output().unwrap()
+    }
+
+    /// Write a fake `uname` responding to -s/-m, and return a PATH that
+    /// resolves it first.
+    fn uname_shim(&self, os: &str, arch: &str) -> String {
+        let shim = self.tmp.path().join("shim");
+        fs::create_dir_all(&shim).unwrap();
+        let uname = shim.join("uname");
+        fs::write(
+            &uname,
+            format!(
+                "#!/bin/sh\ncase \"${{1:-}}\" in\n  -m) echo \"{arch}\" ;;\n  *) echo \"{os}\" ;;\nesac\n"
+            ),
+        )
+        .unwrap();
+        fs::set_permissions(&uname, fs::Permissions::from_mode(0o755)).unwrap();
+        format!("{}:{}", shim.display(), SYSTEM_PATH)
+    }
+}
+
+fn stdout(out: &Output) -> String {
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+fn stderr(out: &Output) -> String {
+    String::from_utf8_lossy(&out.stderr).into_owned()
+}
+
+fn assert_success(out: &Output) {
+    assert!(
+        out.status.success(),
+        "expected success, got {:?}\nstdout: {}\nstderr: {}",
+        out.status,
+        stdout(out),
+        stderr(out)
+    );
+}
+
+fn assert_failure(out: &Output) {
+    assert!(
+        !out.status.success(),
+        "expected failure, got success\nstdout: {}\nstderr: {}",
+        stdout(out),
+        stderr(out)
+    );
+}
+
+/// Build a release-shaped artifact: a tar.gz containing a single
+/// executable named `q2` (a shell script standing in for the real
+/// binary). Returns the artifact's file:// URL and its SHA-256.
+fn make_artifact(dir: &Path) -> (String, String) {
+    let payload = dir.join("payload");
+    fs::create_dir_all(&payload).unwrap();
+    let bin = payload.join("q2");
+    fs::write(&bin, "#!/bin/sh\necho \"q2 0.0.0-test\"\n").unwrap();
+    fs::set_permissions(&bin, fs::Permissions::from_mode(0o755)).unwrap();
+
+    let archive = dir.join("q2-0.0.0-test.tar.gz");
+    let status = Command::new("tar")
+        .args(["-czf"])
+        .arg(&archive)
+        .arg("-C")
+        .arg(&payload)
+        .arg("q2")
+        .status()
+        .unwrap();
+    assert!(status.success(), "tar failed");
+
+    let sha = sha256_hex(&fs::read(&archive).unwrap());
+    (format!("file://{}", archive.display()), sha)
+}
+
+fn dest_arg(sb: &Sandbox) -> String {
+    sb.dest().display().to_string()
+}
+
+// --- minisign test helpers ---------------------------------------------------
+//
+// Signatures are part of the artifact contract, so the suite REQUIRES
+// minisign on the host (CI installs it; locally: `brew install minisign`
+// or `apt-get install minisign`). A silent skip-if-missing would leave
+// the contract unguarded, so absence is a loud failure instead.
+
+fn minisign_bin() -> &'static Path {
+    static BIN: OnceLock<PathBuf> = OnceLock::new();
+    BIN.get_or_init(|| {
+        let out = Command::new("which")
+            .arg("minisign")
+            .output()
+            .expect("run `which`");
+        assert!(
+            out.status.success(),
+            "installer tests require minisign \
+             (brew install minisign / apt-get install minisign)"
+        );
+        PathBuf::from(String::from_utf8(out.stdout).unwrap().trim())
+    })
+}
+
+/// Sandbox PATH: system dirs plus (appended) the host minisign's
+/// directory, which on macOS lives outside SYSTEM_PATH.
+fn default_sandbox_path() -> String {
+    format!(
+        "{}:{}",
+        SYSTEM_PATH,
+        minisign_bin().parent().unwrap().display()
+    )
+}
+
+/// A throwaway unencrypted signing keypair (the shape CI uses).
+struct TestKey {
+    key_file: PathBuf,
+    pub_key: String,
+}
+
+impl TestKey {
+    fn generate(dir: &Path) -> TestKey {
+        fs::create_dir_all(dir).unwrap();
+        let pub_file = dir.join("test-minisign.pub");
+        let key_file = dir.join("test-minisign.key");
+        let out = Command::new(minisign_bin())
+            .args(["-G", "-W", "-f", "-p"])
+            .arg(&pub_file)
+            .arg("-s")
+            .arg(&key_file)
+            .output()
+            .unwrap();
+        assert!(
+            out.status.success(),
+            "minisign -G failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        // .pub layout: an untrusted-comment line, then the key itself.
+        let pub_key = fs::read_to_string(&pub_file)
+            .unwrap()
+            .lines()
+            .nth(1)
+            .unwrap()
+            .trim()
+            .to_owned();
+        TestKey { key_file, pub_key }
+    }
+
+    /// Sign `file` with the given trusted comment, producing `file.minisig`.
+    fn sign_with_comment(&self, file: &Path, comment: &str) {
+        let out = Command::new(minisign_bin())
+            .arg("-Sm")
+            .arg(file)
+            .arg("-s")
+            .arg(&self.key_file)
+            .args(["-t", comment])
+            .output()
+            .unwrap();
+        assert!(
+            out.status.success(),
+            "minisign -Sm failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
+    /// Sign `file` the way release.yml does: trusted comment = filename.
+    fn sign(&self, file: &Path) {
+        self.sign_with_comment(file, file.file_name().unwrap().to_str().unwrap());
+    }
+}
+
+/// `make_artifact` plus a valid signature under a fresh keypair.
+/// Returns (artifact url, sha256, public key for --minisign-pubkey).
+fn make_signed_artifact(dir: &Path) -> (String, String, String) {
+    let (url, sha) = make_artifact(dir);
+    let key = TestKey::generate(dir);
+    key.sign(Path::new(url.strip_prefix("file://").unwrap()));
+    (url, sha, key.pub_key)
+}
+
+// --- help & argument handling ----------------------------------------------
+
+#[test]
+fn help_lists_every_flag_and_exits_zero() {
+    let sb = Sandbox::new();
+    let out = sb.run(&["--help"]);
+    assert_success(&out);
+    let text = stdout(&out);
+    for flag in [
+        "--version",
+        "--dest",
+        "--artifact-url",
+        "--checksum",
+        "--insecure-skip-checksum",
+        "--minisign-pubkey",
+        "--insecure-skip-signature",
+        "--from-source",
+        "--uninstall",
+        "--print-platform",
+        "--quiet",
+        "--help",
+        "Q2_INSTALL_DIR",
+    ] {
+        assert!(text.contains(flag), "--help is missing {flag}\n{text}");
+    }
+}
+
+#[test]
+fn unknown_flag_is_an_error_naming_the_flag() {
+    let sb = Sandbox::new();
+    let out = sb.run(&["--frobnicate"]);
+    assert_failure(&out);
+    assert!(
+        stderr(&out).contains("--frobnicate"),
+        "stderr: {}",
+        stderr(&out)
+    );
+}
+
+// --- platform detection ------------------------------------------------------
+
+#[test]
+fn detects_linux_amd64() {
+    let sb = Sandbox::new();
+    let path = sb.uname_shim("Linux", "x86_64");
+    let out = sb.run_env(&["--print-platform"], &[("PATH", &path)]);
+    assert_success(&out);
+    assert_eq!(stdout(&out).trim(), "linux_amd64");
+}
+
+#[test]
+fn detects_linux_arm64_from_aarch64() {
+    let sb = Sandbox::new();
+    let path = sb.uname_shim("Linux", "aarch64");
+    let out = sb.run_env(&["--print-platform"], &[("PATH", &path)]);
+    assert_success(&out);
+    assert_eq!(stdout(&out).trim(), "linux_arm64");
+}
+
+#[test]
+fn detects_darwin_arm64() {
+    let sb = Sandbox::new();
+    let path = sb.uname_shim("Darwin", "arm64");
+    let out = sb.run_env(&["--print-platform"], &[("PATH", &path)]);
+    assert_success(&out);
+    assert_eq!(stdout(&out).trim(), "darwin_arm64");
+}
+
+#[test]
+fn detects_darwin_amd64() {
+    let sb = Sandbox::new();
+    let path = sb.uname_shim("Darwin", "x86_64");
+    let out = sb.run_env(&["--print-platform"], &[("PATH", &path)]);
+    assert_success(&out);
+    assert_eq!(stdout(&out).trim(), "darwin_amd64");
+}
+
+#[test]
+fn unsupported_os_dies_pointing_at_from_source() {
+    let sb = Sandbox::new();
+    let path = sb.uname_shim("SunOS", "x86_64");
+    let out = sb.run_env(&["--print-platform"], &[("PATH", &path)]);
+    assert_failure(&out);
+    assert!(
+        stderr(&out).contains("--from-source"),
+        "stderr: {}",
+        stderr(&out)
+    );
+}
+
+#[test]
+fn unsupported_arch_dies_pointing_at_from_source() {
+    let sb = Sandbox::new();
+    let path = sb.uname_shim("Linux", "mips64");
+    let out = sb.run_env(&["--print-platform"], &[("PATH", &path)]);
+    assert_failure(&out);
+    assert!(
+        stderr(&out).contains("--from-source"),
+        "stderr: {}",
+        stderr(&out)
+    );
+}
+
+// --- install from a local artifact -------------------------------------------
+
+#[test]
+fn installs_from_local_artifact_with_checksum() {
+    let sb = Sandbox::new();
+    let (url, sha, pk) = make_signed_artifact(sb.tmp.path());
+    let out = sb.run(&[
+        "--artifact-url",
+        &url,
+        "--checksum",
+        &sha,
+        "--minisign-pubkey",
+        &pk,
+        "--dest",
+        &dest_arg(&sb),
+    ]);
+    assert_success(&out);
+
+    let bin = sb.installed_binary();
+    assert!(bin.is_file(), "binary not installed at {bin:?}");
+    let mode = fs::metadata(&bin).unwrap().permissions().mode();
+    assert_eq!(mode & 0o111, 0o111, "binary not executable: mode {mode:o}");
+
+    let run = Command::new(&bin).output().unwrap();
+    assert_eq!(String::from_utf8_lossy(&run.stdout).trim(), "q2 0.0.0-test");
+
+    // Progress goes to stderr; stdout stays clean for scripting.
+    assert_eq!(stdout(&out), "", "stdout should be empty");
+    assert!(
+        stderr(&out).contains("checksum verified"),
+        "stderr: {}",
+        stderr(&out)
+    );
+    assert!(
+        stderr(&out).contains("signature verified"),
+        "stderr: {}",
+        stderr(&out)
+    );
+}
+
+#[test]
+fn creates_dest_directory_if_missing() {
+    let sb = Sandbox::new();
+    let (url, sha, pk) = make_signed_artifact(sb.tmp.path());
+    let deep = sb.tmp.path().join("a/b/c");
+    let out = sb.run(&[
+        "--artifact-url",
+        &url,
+        "--checksum",
+        &sha,
+        "--minisign-pubkey",
+        &pk,
+        "--dest",
+        &deep.display().to_string(),
+    ]);
+    assert_success(&out);
+    assert!(deep.join("q2").is_file());
+}
+
+#[test]
+fn checksum_mismatch_fails_and_installs_nothing() {
+    let sb = Sandbox::new();
+    let (url, _sha) = make_artifact(sb.tmp.path());
+    let wrong = "0".repeat(64);
+    let out = sb.run(&[
+        "--artifact-url",
+        &url,
+        "--checksum",
+        &wrong,
+        "--dest",
+        &dest_arg(&sb),
+    ]);
+    assert_failure(&out);
+    assert!(
+        stderr(&out).contains("mismatch"),
+        "stderr: {}",
+        stderr(&out)
+    );
+
+    // Nothing installed — not the binary, not a partial file.
+    if sb.dest().exists() {
+        let leftovers: Vec<_> = fs::read_dir(sb.dest()).unwrap().collect();
+        assert!(leftovers.is_empty(), "dest not empty: {leftovers:?}");
+    }
+}
+
+#[test]
+fn malformed_checksum_is_rejected() {
+    let sb = Sandbox::new();
+    let (url, _sha) = make_artifact(sb.tmp.path());
+    let out = sb.run(&[
+        "--artifact-url",
+        &url,
+        "--checksum",
+        "not-a-sha",
+        "--dest",
+        &dest_arg(&sb),
+    ]);
+    assert_failure(&out);
+    assert!(!sb.installed_binary().exists());
+}
+
+#[test]
+fn missing_checksum_refuses_to_install() {
+    let sb = Sandbox::new();
+    let (url, _sha) = make_artifact(sb.tmp.path());
+    // No --checksum and no .sha256 sidecar: fail closed.
+    let out = sb.run(&["--artifact-url", &url, "--dest", &dest_arg(&sb)]);
+    assert_failure(&out);
+    // The escape hatch must be shown in its curl|bash position — "re-run
+    // with <flag>" alone leaves piped users guessing where it goes.
+    assert!(
+        stderr(&out).contains("bash -s -- --insecure-skip-checksum"),
+        "refusal should show the escape hatch in a full re-run line\nstderr: {}",
+        stderr(&out)
+    );
+    assert!(!sb.installed_binary().exists());
+}
+
+#[test]
+fn insecure_skip_checksum_installs_with_loud_warning() {
+    let sb = Sandbox::new();
+    let (url, _sha, pk) = make_signed_artifact(sb.tmp.path());
+    let out = sb.run(&[
+        "--artifact-url",
+        &url,
+        "--insecure-skip-checksum",
+        "--minisign-pubkey",
+        &pk,
+        "--dest",
+        &dest_arg(&sb),
+    ]);
+    assert_success(&out);
+    assert!(sb.installed_binary().is_file());
+    assert!(
+        stderr(&out).to_lowercase().contains("unverified"),
+        "warning should say the install is unverified\nstderr: {}",
+        stderr(&out)
+    );
+}
+
+#[test]
+fn checksum_sidecar_file_is_used_automatically() {
+    let sb = Sandbox::new();
+    let (url, sha, pk) = make_signed_artifact(sb.tmp.path());
+    let archive_path = url.strip_prefix("file://").unwrap();
+    fs::write(
+        format!("{archive_path}.sha256"),
+        format!(
+            "{sha}  {}\n",
+            Path::new(archive_path)
+                .file_name()
+                .unwrap()
+                .to_string_lossy()
+        ),
+    )
+    .unwrap();
+
+    let out = sb.run(&[
+        "--artifact-url",
+        &url,
+        "--minisign-pubkey",
+        &pk,
+        "--dest",
+        &dest_arg(&sb),
+    ]);
+    assert_success(&out);
+    assert!(sb.installed_binary().is_file());
+    assert!(
+        stderr(&out).contains("checksum verified"),
+        "stderr: {}",
+        stderr(&out)
+    );
+}
+
+#[test]
+fn install_is_idempotent() {
+    let sb = Sandbox::new();
+    let (url, sha, pk) = make_signed_artifact(sb.tmp.path());
+    let args = [
+        "--artifact-url",
+        url.as_str(),
+        "--checksum",
+        &sha,
+        "--minisign-pubkey",
+        &pk,
+    ];
+    let dest = dest_arg(&sb);
+
+    for _ in 0..2 {
+        let mut all = args.to_vec();
+        all.extend_from_slice(&["--dest", &dest]);
+        assert_success(&sb.run(&all));
+    }
+    let run = Command::new(sb.installed_binary()).output().unwrap();
+    assert_eq!(String::from_utf8_lossy(&run.stdout).trim(), "q2 0.0.0-test");
+}
+
+#[test]
+fn archive_without_q2_binary_fails_cleanly() {
+    let sb = Sandbox::new();
+    // An archive containing some other file, but no `q2`. Signed, so
+    // the failure exercised is extraction, not verification.
+    let payload = sb.tmp.path().join("other-payload");
+    fs::create_dir_all(&payload).unwrap();
+    fs::write(payload.join("README"), "not a binary\n").unwrap();
+    let archive = sb.tmp.path().join("q2-bogus.tar.gz");
+    assert!(
+        Command::new("tar")
+            .args(["-czf"])
+            .arg(&archive)
+            .arg("-C")
+            .arg(&payload)
+            .arg("README")
+            .status()
+            .unwrap()
+            .success()
+    );
+    let sha = sha256_hex(&fs::read(&archive).unwrap());
+    let key = TestKey::generate(sb.tmp.path());
+    key.sign(&archive);
+
+    let url = format!("file://{}", archive.display());
+    let out = sb.run(&[
+        "--artifact-url",
+        &url,
+        "--checksum",
+        &sha,
+        "--minisign-pubkey",
+        &key.pub_key,
+        "--dest",
+        &dest_arg(&sb),
+    ]);
+    assert_failure(&out);
+    assert!(!sb.installed_binary().exists());
+}
+
+// --- signature verification ---------------------------------------------------
+
+#[test]
+fn missing_minisig_refuses_to_install() {
+    let sb = Sandbox::new();
+    let (url, sha) = make_artifact(sb.tmp.path()); // checksummed but unsigned
+    let key = TestKey::generate(sb.tmp.path());
+    let out = sb.run(&[
+        "--artifact-url",
+        &url,
+        "--checksum",
+        &sha,
+        "--minisign-pubkey",
+        &key.pub_key,
+        "--dest",
+        &dest_arg(&sb),
+    ]);
+    assert_failure(&out);
+    // Full re-run line, not just the flag name (see checksum twin above).
+    assert!(
+        stderr(&out).contains("bash -s -- --insecure-skip-signature"),
+        "refusal should show the escape hatch in a full re-run line\nstderr: {}",
+        stderr(&out)
+    );
+    assert!(!sb.installed_binary().exists());
+}
+
+#[test]
+fn insecure_skip_signature_installs_with_loud_warning() {
+    let sb = Sandbox::new();
+    let (url, sha) = make_artifact(sb.tmp.path()); // unsigned
+    let out = sb.run(&[
+        "--artifact-url",
+        &url,
+        "--checksum",
+        &sha,
+        "--insecure-skip-signature",
+        "--dest",
+        &dest_arg(&sb),
+    ]);
+    assert_success(&out);
+    assert!(sb.installed_binary().is_file());
+    assert!(
+        stderr(&out).to_lowercase().contains("unverified"),
+        "warning should say the signature went unverified\nstderr: {}",
+        stderr(&out)
+    );
+    // Checksum verification must still have happened.
+    assert!(
+        stderr(&out).contains("checksum verified"),
+        "stderr: {}",
+        stderr(&out)
+    );
+}
+
+#[test]
+fn tampered_archive_fails_signature_and_installs_nothing() {
+    let sb = Sandbox::new();
+    let (url, _sha, pk) = make_signed_artifact(sb.tmp.path());
+    let archive = PathBuf::from(url.strip_prefix("file://").unwrap());
+
+    // Re-create the archive with different contents, keeping the old
+    // .minisig; hand the installer the *new* checksum so only the
+    // signature can catch the swap (the compromised-release scenario).
+    let payload = sb.tmp.path().join("evil-payload");
+    fs::create_dir_all(&payload).unwrap();
+    let bin = payload.join("q2");
+    fs::write(&bin, "#!/bin/sh\necho \"q2 6.6.6-evil\"\n").unwrap();
+    fs::set_permissions(&bin, fs::Permissions::from_mode(0o755)).unwrap();
+    assert!(
+        Command::new("tar")
+            .args(["-czf"])
+            .arg(&archive)
+            .arg("-C")
+            .arg(&payload)
+            .arg("q2")
+            .status()
+            .unwrap()
+            .success()
+    );
+    let new_sha = sha256_hex(&fs::read(&archive).unwrap());
+
+    let out = sb.run(&[
+        "--artifact-url",
+        &url,
+        "--checksum",
+        &new_sha,
+        "--minisign-pubkey",
+        &pk,
+        "--dest",
+        &dest_arg(&sb),
+    ]);
+    assert_failure(&out);
+    assert!(!sb.installed_binary().exists());
+}
+
+#[test]
+fn wrong_public_key_fails() {
+    let sb = Sandbox::new();
+    let (url, sha, _pk) = make_signed_artifact(sb.tmp.path());
+    let other = TestKey::generate(&sb.tmp.path().join("other-key-dir"));
+    let out = sb.run(&[
+        "--artifact-url",
+        &url,
+        "--checksum",
+        &sha,
+        "--minisign-pubkey",
+        &other.pub_key,
+        "--dest",
+        &dest_arg(&sb),
+    ]);
+    assert_failure(&out);
+    assert!(!sb.installed_binary().exists());
+}
+
+#[test]
+fn trusted_comment_mismatch_fails() {
+    let sb = Sandbox::new();
+    // Validly signed — but as a *different* artifact name. A signature
+    // replayed from another (e.g. older) release must not verify.
+    let (url, sha) = make_artifact(sb.tmp.path());
+    let archive = PathBuf::from(url.strip_prefix("file://").unwrap());
+    let key = TestKey::generate(sb.tmp.path());
+    key.sign_with_comment(&archive, "q2-0.0.0-other.tar.gz");
+
+    let out = sb.run(&[
+        "--artifact-url",
+        &url,
+        "--checksum",
+        &sha,
+        "--minisign-pubkey",
+        &key.pub_key,
+        "--dest",
+        &dest_arg(&sb),
+    ]);
+    assert_failure(&out);
+    assert!(
+        stderr(&out).contains("trusted comment"),
+        "failure should explain the comment mismatch\nstderr: {}",
+        stderr(&out)
+    );
+    assert!(!sb.installed_binary().exists());
+}
+
+#[test]
+fn missing_minisign_tool_refuses_with_install_guidance() {
+    let sb = Sandbox::new();
+    let (url, sha, pk) = make_signed_artifact(sb.tmp.path());
+    // Q2_MINISIGN points at a nonexistent binary: equivalent to a
+    // machine with no minisign, regardless of what /usr/bin holds.
+    let out = sb.run_env(
+        &[
+            "--artifact-url",
+            &url,
+            "--checksum",
+            &sha,
+            "--minisign-pubkey",
+            &pk,
+            "--dest",
+            &dest_arg(&sb),
+        ],
+        &[("Q2_MINISIGN", "/nonexistent/minisign")],
+    );
+    assert_failure(&out);
+    let err = stderr(&out);
+    assert!(
+        err.contains("minisign"),
+        "should name the missing tool\nstderr: {err}"
+    );
+    assert!(
+        err.contains("install"),
+        "should give install guidance\nstderr: {err}"
+    );
+    assert!(
+        err.contains("bash -s -- --insecure-skip-signature"),
+        "should show the escape hatch in a full re-run line\nstderr: {err}"
+    );
+    assert!(!sb.installed_binary().exists());
+}
+
+// --- dest resolution ---------------------------------------------------------
+
+#[test]
+fn q2_install_dir_env_overrides_default_dest() {
+    let sb = Sandbox::new();
+    let (url, sha, pk) = make_signed_artifact(sb.tmp.path());
+    let env_dest = sb.tmp.path().join("env-bin");
+    let out = sb.run_env(
+        &[
+            "--artifact-url",
+            &url,
+            "--checksum",
+            &sha,
+            "--minisign-pubkey",
+            &pk,
+        ],
+        &[("Q2_INSTALL_DIR", &env_dest.display().to_string())],
+    );
+    assert_success(&out);
+    assert!(env_dest.join("q2").is_file());
+}
+
+#[test]
+fn dest_flag_beats_q2_install_dir_env() {
+    let sb = Sandbox::new();
+    let (url, sha, pk) = make_signed_artifact(sb.tmp.path());
+    let env_dest = sb.tmp.path().join("env-bin");
+    let out = sb.run_env(
+        &[
+            "--artifact-url",
+            &url,
+            "--checksum",
+            &sha,
+            "--minisign-pubkey",
+            &pk,
+            "--dest",
+            &dest_arg(&sb),
+        ],
+        &[("Q2_INSTALL_DIR", &env_dest.display().to_string())],
+    );
+    assert_success(&out);
+    assert!(sb.installed_binary().is_file());
+    assert!(!env_dest.exists());
+}
+
+// --- PATH advice -------------------------------------------------------------
+
+#[test]
+fn warns_when_dest_is_not_on_path() {
+    let sb = Sandbox::new();
+    let (url, sha, pk) = make_signed_artifact(sb.tmp.path());
+    let out = sb.run(&[
+        "--artifact-url",
+        &url,
+        "--checksum",
+        &sha,
+        "--minisign-pubkey",
+        &pk,
+        "--dest",
+        &dest_arg(&sb),
+    ]);
+    assert_success(&out);
+    assert!(
+        stderr(&out).contains("PATH"),
+        "expected PATH advice\nstderr: {}",
+        stderr(&out)
+    );
+}
+
+#[test]
+fn no_path_warning_when_dest_is_on_path() {
+    let sb = Sandbox::new();
+    let (url, sha, pk) = make_signed_artifact(sb.tmp.path());
+    let path = format!("{}:{}", sb.dest().display(), default_sandbox_path());
+    let out = sb.run_env(
+        &[
+            "--artifact-url",
+            &url,
+            "--checksum",
+            &sha,
+            "--minisign-pubkey",
+            &pk,
+            "--dest",
+            &dest_arg(&sb),
+        ],
+        &[("PATH", &path)],
+    );
+    assert_success(&out);
+    assert!(
+        !stderr(&out).contains("PATH"),
+        "unexpected PATH advice\nstderr: {}",
+        stderr(&out)
+    );
+}
+
+// --- quiet mode ----------------------------------------------------------------
+
+#[test]
+fn quiet_successful_install_prints_nothing() {
+    let sb = Sandbox::new();
+    let (url, sha, pk) = make_signed_artifact(sb.tmp.path());
+    // dest on PATH so there is no legitimate warning to print.
+    let path = format!("{}:{}", sb.dest().display(), default_sandbox_path());
+    let out = sb.run_env(
+        &[
+            "--quiet",
+            "--artifact-url",
+            &url,
+            "--checksum",
+            &sha,
+            "--minisign-pubkey",
+            &pk,
+            "--dest",
+            &dest_arg(&sb),
+        ],
+        &[("PATH", &path)],
+    );
+    assert_success(&out);
+    assert_eq!(stdout(&out), "");
+    assert_eq!(stderr(&out), "");
+    assert!(sb.installed_binary().is_file());
+}
+
+#[test]
+fn quiet_still_reports_errors() {
+    let sb = Sandbox::new();
+    let (url, _sha) = make_artifact(sb.tmp.path());
+    let wrong = "0".repeat(64);
+    let out = sb.run(&[
+        "--quiet",
+        "--artifact-url",
+        &url,
+        "--checksum",
+        &wrong,
+        "--dest",
+        &dest_arg(&sb),
+    ]);
+    assert_failure(&out);
+    assert!(
+        !stderr(&out).is_empty(),
+        "errors must print even under --quiet"
+    );
+}
+
+// --- uninstall -----------------------------------------------------------------
+
+#[test]
+fn uninstall_removes_the_binary() {
+    let sb = Sandbox::new();
+    let (url, sha, pk) = make_signed_artifact(sb.tmp.path());
+    let dest = dest_arg(&sb);
+    assert_success(&sb.run(&[
+        "--artifact-url",
+        &url,
+        "--checksum",
+        &sha,
+        "--minisign-pubkey",
+        &pk,
+        "--dest",
+        &dest,
+    ]));
+    assert!(sb.installed_binary().is_file());
+
+    assert_success(&sb.run(&["--uninstall", "--dest", &dest]));
+    assert!(!sb.installed_binary().exists());
+}
+
+#[test]
+fn uninstall_when_nothing_installed_succeeds_with_notice() {
+    let sb = Sandbox::new();
+    let out = sb.run(&["--uninstall", "--dest", &dest_arg(&sb)]);
+    assert_success(&out);
+    assert!(
+        !stderr(&out).is_empty(),
+        "expected a nothing-to-remove notice"
+    );
+}
+
+// --- script hygiene ------------------------------------------------------------
+
+#[test]
+fn shellcheck_clean_if_available() {
+    let shellcheck = Command::new("shellcheck").arg("--version").output();
+    if shellcheck.is_err() {
+        eprintln!("shellcheck not installed; skipping");
+        return;
+    }
+    let out = Command::new("shellcheck")
+        .arg("--severity=style")
+        .arg(install_sh())
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "shellcheck findings:\n{}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+}
+
+// --- network (run manually / in plan Phase 4 once a release exists) -------------
+
+#[test]
+#[ignore = "needs a published GitHub release; run in plan Phase 4"]
+fn resolves_latest_version_from_github() {
+    let sb = Sandbox::new();
+    // Plain install with no --version/--artifact-url: resolves the latest
+    // release, downloads, verifies the published .sha256, installs.
+    let out = sb.run(&["--dest", &dest_arg(&sb)]);
+    assert_success(&out);
+    let run = Command::new(sb.installed_binary())
+        .arg("--version")
+        .output()
+        .unwrap();
+    assert!(String::from_utf8_lossy(&run.stdout).contains("q2"));
+}

--- a/crates/quarto/tests/integration/bootstrap_sh.rs
+++ b/crates/quarto/tests/integration/bootstrap_sh.rs
@@ -1012,5 +1012,6 @@ fn resolves_latest_version_from_github() {
         .arg("--version")
         .output()
         .unwrap();
-    assert!(String::from_utf8_lossy(&run.stdout).contains("q2"));
+    // Output shape: "quarto <workspace-version>" (quarto-util/src/version.rs).
+    assert!(String::from_utf8_lossy(&run.stdout).contains("quarto"));
 }

--- a/crates/quarto/tests/integration/main.rs
+++ b/crates/quarto/tests/integration/main.rs
@@ -2,6 +2,7 @@
 //! See bd-xvdop / claude-notes/plans/2026-05-28-integration-test-consolidation.md.
 
 pub mod attribution_cli_e2e;
+pub mod bootstrap_sh;
 pub mod get_config_cli;
 pub mod json_errors;
 pub mod preview_cli;

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,116 @@
+#!/usr/bin/env pwsh
+# q2 Windows installer — the PowerShell counterpart to install.sh.
+#
+#   irm https://raw.githubusercontent.com/quarto-dev/q2/main/install.ps1 | iex
+#
+# Downloads the published release zip for x86_64 Windows, verifies its
+# SHA-256 against the published checksum, and installs q2.exe. Mirrors
+# install.sh's contract (same artifact naming, same checksum file
+# format). Signature verification is checksum-only on Windows for now —
+# minisign has no ubiquitous Windows install path; noted in the plan
+# (claude-notes/plans/2026-06-12-q2-github-releases-bundled-mcp.md).
+#
+# Note `q2 mcp` additionally needs Node.js 24+ at runtime.
+#
+# Flags (for testing / non-default installs):
+#   -Version v0.1.0      install a specific tag instead of the latest
+#   -Dest <dir>          install directory (default: %USERPROFILE%\.local\bin)
+#   -ArtifactUrl <u>     override the download (a URL or a local path — the
+#                        local path form is what the CI smoke test uses)
+#   -Checksum <hex>      expected sha256; skips fetching the .sha256 file
+#   -NoVerify            skip checksum verification (discouraged)
+[CmdletBinding()]
+param(
+    [string]$Version,
+    [string]$Dest,
+    [string]$ArtifactUrl,
+    [string]$Checksum,
+    [switch]$NoVerify
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$Owner = 'quarto-dev'
+$Repo = 'q2'
+$Platform = 'windows_amd64'
+$UA = @{ 'User-Agent' = 'q2-install' }
+
+function Die([string]$msg) { Write-Error "q2 install: $msg"; exit 1 }
+function Step([string]$msg) { Write-Host "-> $msg" }
+
+# q2 ships an x86_64 Windows binary; ARM64 Windows runs it under
+# emulation, so we don't hard-block on architecture.
+if (-not [System.Environment]::Is64BitOperatingSystem) {
+    Die 'only 64-bit Windows is supported'
+}
+
+if (-not $Dest) { $Dest = Join-Path $env:USERPROFILE '.local\bin' }
+
+# Fetch a URL or copy a local path (so -ArtifactUrl can be a file for
+# offline testing) into $out.
+function Get-Artifact([string]$src, [string]$out) {
+    if (Test-Path -LiteralPath $src) {
+        Copy-Item -LiteralPath $src -Destination $out -Force
+    }
+    else {
+        Invoke-WebRequest -Uri $src -OutFile $out -Headers $UA
+    }
+}
+
+if (-not $Version -and -not $ArtifactUrl) {
+    Step 'resolving latest release...'
+    $rel = Invoke-RestMethod -Uri "https://api.github.com/repos/$Owner/$Repo/releases/latest" -Headers $UA
+    $Version = $rel.tag_name
+    if (-not $Version) { Die 'could not determine the latest release; pass -Version vX.Y.Z' }
+}
+if ($Version) { Step "release: $Version" }
+
+$bare = if ($Version) { $Version -replace '^v', '' } else { '' }
+$archive = "q2-$bare-$Platform.zip"
+if (-not $ArtifactUrl) {
+    $ArtifactUrl = "https://github.com/$Owner/$Repo/releases/download/$Version/$archive"
+}
+
+$work = Join-Path ([System.IO.Path]::GetTempPath()) ("q2-install-" + [System.Guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path $work | Out-Null
+try {
+    $zip = Join-Path $work $archive
+    Step "downloading $archive..."
+    Get-Artifact $ArtifactUrl $zip
+
+    if (-not $NoVerify) {
+        if (-not $Checksum) {
+            # The published "<hash>  <file>" line, same format as install.sh.
+            $sumFile = Join-Path $work "$archive.sha256"
+            Get-Artifact "$ArtifactUrl.sha256" $sumFile
+            $Checksum = ((Get-Content -Raw $sumFile) -split '\s+')[0]
+        }
+        $actual = (Get-FileHash -Algorithm SHA256 -LiteralPath $zip).Hash.ToLower()
+        if ($actual -ne $Checksum.ToLower()) {
+            Die "checksum mismatch for $archive`n  expected $($Checksum.ToLower())`n  got      $actual"
+        }
+        Step 'checksum verified'
+    }
+
+    Expand-Archive -LiteralPath $zip -DestinationPath $work -Force
+    $exe = Join-Path $work 'q2.exe'
+    if (-not (Test-Path -LiteralPath $exe)) { Die 'archive did not contain q2.exe' }
+
+    New-Item -ItemType Directory -Force -Path $Dest | Out-Null
+    Copy-Item -LiteralPath $exe -Destination (Join-Path $Dest 'q2.exe') -Force
+    Step "installed $(Join-Path $Dest 'q2.exe')"
+}
+finally {
+    Remove-Item -Recurse -Force -LiteralPath $work -ErrorAction SilentlyContinue
+}
+
+# PATH hint (don't mutate the user's PATH silently).
+$userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+if (-not $userPath -or ($userPath -split ';' -notcontains $Dest)) {
+    Write-Warning "$Dest is not on your PATH. Add it for your user with:"
+    Write-Host "  [Environment]::SetEnvironmentVariable('Path', ([Environment]::GetEnvironmentVariable('Path','User') + ';$Dest'), 'User')"
+    Write-Host '  (then open a new terminal)'
+}
+
+Step ('done: ' + (& (Join-Path $Dest 'q2.exe') --version))

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,493 @@
+#!/usr/bin/env bash
+#
+# q2 installer — downloads a release binary, verifies its checksum
+# and Ed25519 signature, and installs it atomically.
+#
+# One-liner:
+#   curl -fsSL https://raw.githubusercontent.com/quarto-dev/q2/main/install.sh | bash
+#
+# Pass options after `bash -s --`:
+#   curl -fsSL .../install.sh | bash -s -- --dest ~/bin
+#
+# Ported from cscheid/braid's installer (bd-c6l13j79; design notes in
+# claude-notes/plans/2026-06-12-q2-github-releases-bundled-mcp.md):
+#   - Non-interactive by construction: the script never reads stdin, so
+#     it is safe under `curl | bash` and in CI, and needs none of the
+#     piped-stdin re-exec machinery larger installers carry.
+#   - Checksum verification is mandatory. Installing an unverified
+#     binary requires the explicit --insecure-skip-checksum flag.
+#   - Signature verification is mandatory too: a checksum proves
+#     integrity, not authenticity — whoever can replace the artifact on
+#     the release can replace its .sha256 alongside. Each archive is
+#     signed with minisign (Ed25519); the public key is pinned in this
+#     script, which ships from the main branch — a trust path an
+#     attacker with mere release-asset access cannot touch. minisign is
+#     packaged everywhere (brew/apt/dnf/apk/...), so absence is a
+#     refusal with install guidance, not a silent downgrade;
+#     --insecure-skip-signature is the explicit escape hatch.
+#   - Tested by crates/quarto/tests/integration/bootstrap_sh.rs,
+#     offline, through --artifact-url file:// + --checksum.
+#
+# Note `q2 mcp` additionally needs Node.js 24+ at runtime (the MCP
+# server is embedded in the binary but runs on your node). Everything
+# else in q2 works without node.
+
+set -euo pipefail
+umask 022
+
+# ============================================================================
+# Configuration
+# ============================================================================
+OWNER="${Q2_REPO_OWNER:-quarto-dev}"
+REPO="${Q2_REPO_NAME:-q2}"
+BINARY_NAME="q2"
+
+# The q2 release signing key (minisign/Ed25519, key ID 91F595A50BD20376).
+# Generated 2026-06-12; signs releases from v0.1.0 on. Also published in
+# the README and in release notes.
+MINISIGN_PUBKEY="RWR2A9ILpZX1kVF3Q6uk5TRus8FDM25H2F+KKKHEuqlxv+JJSLyPalvN"
+# Test hook: lets the test suite simulate a machine without minisign.
+# No weaker than PATH, which an attacker in this position also controls.
+MINISIGN_BIN="${Q2_MINISIGN:-minisign}"
+
+VERSION=""
+DEST=""
+ARTIFACT_URL=""
+CHECKSUM=""
+INSECURE_SKIP_CHECKSUM=0
+INSECURE_SKIP_SIGNATURE=0
+FROM_SOURCE=0
+UNINSTALL=0
+PRINT_PLATFORM=0
+QUIET=0
+
+MAX_RETRIES=3
+DOWNLOAD_TIMEOUT=300
+
+# ============================================================================
+# Output: progress to stderr (stdout stays clean for scripting); colors
+# only when stderr is a terminal. --quiet silences progress, never
+# warnings or errors.
+# ============================================================================
+if [ -t 2 ]; then
+    RED=$'\033[0;31m' GREEN=$'\033[0;32m' YELLOW=$'\033[1;33m' BLUE=$'\033[0;34m' NC=$'\033[0m'
+else
+    RED="" GREEN="" YELLOW="" BLUE="" NC=""
+fi
+
+log_step()    { [ "$QUIET" -eq 1 ] || printf '%s\n' "${BLUE}→${NC} $*" >&2; }
+log_success() { [ "$QUIET" -eq 1 ] || printf '%s\n' "${GREEN}✓${NC} $*" >&2; }
+log_warn()    { printf '%s\n' "${YELLOW}q2 installer:${NC} $*" >&2; }
+log_error()   { printf '%s\n' "${RED}q2 installer:${NC} $*" >&2; }
+die()         { log_error "$@"; exit 1; }
+
+# A full copy-pasteable re-run line. Refusals that say "re-run with
+# <flag>" must show where the flag goes: under curl|bash that is after
+# `bash -s --`, which nothing else on screen makes guessable.
+rerun_line() {
+    printf 'curl -fsSL https://raw.githubusercontent.com/%s/%s/main/install.sh | bash -s -- %s' \
+        "$OWNER" "$REPO" "$*"
+}
+
+usage() {
+    cat <<EOF
+q2 installer — install the q2 binary from GitHub releases
+
+Usage:
+  curl -fsSL https://raw.githubusercontent.com/${OWNER}/${REPO}/main/install.sh | bash
+  curl -fsSL .../install.sh | bash -s -- [OPTIONS]
+
+Options:
+  --version vX.Y.Z          Install a specific version (default: latest release)
+  --dest DIR                Install directory (default: ~/.local/bin)
+  --artifact-url URL        Install from a specific artifact URL (file:// works)
+  --checksum SHA256         Expected SHA-256 of the artifact
+  --insecure-skip-checksum  Allow installation when no checksum is available
+  --minisign-pubkey KEY     minisign public key to verify signatures against
+                            (default: the q2 release key pinned in this script)
+  --insecure-skip-signature Skip Ed25519 signature verification
+  --from-source             Build with cargo from a fresh clone instead
+  --uninstall               Remove the installed binary
+  --print-platform          Print the detected platform string and exit
+  --quiet                   Suppress progress output (warnings/errors still print)
+  --help                    Show this help
+
+Environment:
+  Q2_INSTALL_DIR            Override the default install directory
+                            (the --dest flag wins over it)
+
+Supported platforms: linux_amd64, linux_arm64, darwin_amd64,
+darwin_arm64. Windows users: use install.ps1 instead. On anything
+else, re-run with --from-source (requires Rust; node+npm too if you
+want \`q2 mcp\`).
+EOF
+}
+
+# ============================================================================
+# Argument parsing. Unknown flags are errors: a typo silently ignored is
+# how a --checksun install ends up unverified.
+# ============================================================================
+need_value() { [ "$2" -ge 2 ] || die "$1 needs a value (see --help)"; }
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --version)   need_value "$1" $#; VERSION="$2"; shift 2 ;;
+        --version=*) VERSION="${1#*=}"; shift ;;
+        --dest)      need_value "$1" $#; DEST="$2"; shift 2 ;;
+        --dest=*)    DEST="${1#*=}"; shift ;;
+        --artifact-url)   need_value "$1" $#; ARTIFACT_URL="$2"; shift 2 ;;
+        --artifact-url=*) ARTIFACT_URL="${1#*=}"; shift ;;
+        --checksum)   need_value "$1" $#; CHECKSUM="$2"; shift 2 ;;
+        --checksum=*) CHECKSUM="${1#*=}"; shift ;;
+        --insecure-skip-checksum) INSECURE_SKIP_CHECKSUM=1; shift ;;
+        --minisign-pubkey)   need_value "$1" $#; MINISIGN_PUBKEY="$2"; shift 2 ;;
+        --minisign-pubkey=*) MINISIGN_PUBKEY="${1#*=}"; shift ;;
+        --insecure-skip-signature) INSECURE_SKIP_SIGNATURE=1; shift ;;
+        --from-source)    FROM_SOURCE=1; shift ;;
+        --uninstall)      UNINSTALL=1; shift ;;
+        --print-platform) PRINT_PLATFORM=1; shift ;;
+        --quiet|-q)       QUIET=1; shift ;;
+        -h|--help)        usage; exit 0 ;;
+        *) die "unknown option: $1 (see --help)" ;;
+    esac
+done
+
+# Dest precedence: --dest flag > Q2_INSTALL_DIR > ~/.local/bin.
+if [ -z "$DEST" ]; then
+    if [ -n "${Q2_INSTALL_DIR:-}" ]; then
+        DEST="$Q2_INSTALL_DIR"
+    elif [ -n "${HOME:-}" ]; then
+        DEST="$HOME/.local/bin"
+    else
+        die "HOME is not set; pass --dest DIR"
+    fi
+fi
+
+# ============================================================================
+# Platform detection: os × arch is the whole story.
+# ============================================================================
+detect_platform() {
+    local os arch
+    case "$(uname -s)" in
+        Linux*)  os="linux" ;;
+        Darwin*) os="darwin" ;;
+        *) die "unsupported OS: $(uname -s) — re-run with --from-source (requires Rust)" ;;
+    esac
+    case "$(uname -m)" in
+        x86_64|amd64)  arch="amd64" ;;
+        aarch64|arm64) arch="arm64" ;;
+        *) die "unsupported architecture: $(uname -m) — re-run with --from-source (requires Rust)" ;;
+    esac
+    printf '%s_%s\n' "$os" "$arch"
+}
+
+# ============================================================================
+# Version resolution: GitHub API first, releases/latest redirect as the
+# fallback. Failure is an error (no implicit source build: surprising a
+# user with a multi-minute compile is worse than asking them to re-run
+# with --from-source).
+# ============================================================================
+resolve_version() {
+    [ -n "$VERSION" ] && return 0
+
+    log_step "resolving latest release..."
+    local tag=""
+    tag=$(curl -fsSL --connect-timeout 10 --max-time 30 \
+        -H "Accept: application/vnd.github+json" \
+        "https://api.github.com/repos/${OWNER}/${REPO}/releases/latest" 2>/dev/null \
+        | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' | head -n 1) || true
+
+    if [ -z "$tag" ]; then
+        tag=$(curl -fsSL -o /dev/null -w '%{url_effective}' \
+            "https://github.com/${OWNER}/${REPO}/releases/latest" 2>/dev/null \
+            | sed 's|.*/tag/||') || true
+    fi
+
+    case "$tag" in
+        v[0-9]*) VERSION="$tag"; log_step "latest release: $VERSION" ;;
+        *) die "could not determine the latest release; pass --version vX.Y.Z or --from-source" ;;
+    esac
+}
+
+# ============================================================================
+# Download: curl only (preinstalled on macOS, universal on Linux dev
+# boxes; a wget fallback would double every download path). Partial
+# downloads land in a .part file and are moved into place only on
+# success. curl natively honors HTTPS_PROXY et al.
+# ============================================================================
+download_file() {
+    local url="$1" dest="$2" attempt=1
+    command -v curl >/dev/null 2>&1 || die "curl is required (https://curl.se)"
+
+    while :; do
+        if curl -fL --silent --show-error --retry 2 \
+            --connect-timeout 30 --max-time "$DOWNLOAD_TIMEOUT" \
+            -o "${dest}.part" "$url" 2>/dev/null; then
+            mv -f "${dest}.part" "$dest"
+            return 0
+        fi
+        rm -f "${dest}.part"
+        [ "$attempt" -ge "$MAX_RETRIES" ] && return 1
+        attempt=$((attempt + 1))
+        log_step "download failed; retrying ($attempt/$MAX_RETRIES)..."
+        sleep 2
+    done
+}
+
+# ============================================================================
+# Checksum verification: fail closed. A missing checksum aborts the
+# install unless --insecure-skip-checksum says otherwise, explicitly.
+# ============================================================================
+sha256_of() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" | awk '{print $1}'
+    elif command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$1" | awk '{print $1}'
+    else
+        return 1
+    fi
+}
+
+verify_checksum() {
+    local file="$1" expected="$2" name="$3"
+
+    if [ -z "$expected" ]; then
+        if [ "$INSECURE_SKIP_CHECKSUM" -eq 1 ]; then
+            log_warn "no checksum available for $name; installing UNVERIFIED (--insecure-skip-checksum)"
+            return 0
+        fi
+        die "no checksum available for $name; refusing to install an unverified binary.
+  Pass --checksum SHA256, provide ${name}.sha256 next to the artifact,
+  or (not recommended) skip verification — flags go after \`bash -s --\`:
+    $(rerun_line --insecure-skip-checksum)"
+    fi
+
+    case "$expected" in
+        *[!0-9a-fA-F]*) die "invalid SHA-256 checksum: $expected" ;;
+    esac
+    [ "${#expected}" -eq 64 ] || die "invalid SHA-256 checksum (need 64 hex digits): $expected"
+
+    local actual
+    if ! actual=$(sha256_of "$file"); then
+        if [ "$INSECURE_SKIP_CHECKSUM" -eq 1 ]; then
+            log_warn "no SHA-256 tool found; installing UNVERIFIED (--insecure-skip-checksum)"
+            return 0
+        fi
+        die "no SHA-256 tool found (need sha256sum or shasum)"
+    fi
+
+    if [ "$expected" != "$actual" ]; then
+        die "checksum mismatch for $name:
+  expected: $expected
+  got:      $actual"
+    fi
+    log_success "checksum verified"
+}
+
+# ============================================================================
+# Signature verification: Ed25519 via minisign, against the public key
+# pinned at the top of this script. Mandatory, like checksums: skipping
+# requires the explicit --insecure-skip-signature flag. The trusted
+# comment must equal the archive filename (Zig's discipline), so a
+# validly signed *different* artifact — say, an older release — cannot
+# be replayed under this name.
+# ============================================================================
+verify_signature() {
+    local file="$1" sig="$2" name="$3"
+
+    if [ "$INSECURE_SKIP_SIGNATURE" -eq 1 ]; then
+        log_warn "signature NOT checked; authenticity UNVERIFIED (--insecure-skip-signature)"
+        return 0
+    fi
+
+    command -v "$MINISIGN_BIN" >/dev/null 2>&1 || die "minisign is required to verify the release signature. Install it first:
+    brew install minisign         (macOS)
+    sudo apt install minisign     (Debian/Ubuntu)
+    sudo dnf install minisign     (Fedora)
+    apk add minisign              (Alpine)
+  then re-run this script — or (not recommended) skip signature
+  verification; flags go after \`bash -s --\`:
+    $(rerun_line --insecure-skip-signature)"
+
+    [ -f "$sig" ] || die "no signature (.minisig) available for $name; refusing to install.
+  Provide ${name}.minisig next to the artifact, or (not recommended)
+  skip signature verification — flags go after \`bash -s --\`:
+    $(rerun_line --insecure-skip-signature)"
+
+    local verify_out
+    if ! verify_out=$("$MINISIGN_BIN" -Vm "$file" -x "$sig" -P "$MINISIGN_PUBKEY" 2>&1); then
+        die "signature verification FAILED for $name:
+$verify_out
+  The artifact was not signed by the q2 release key. Do not install it."
+    fi
+
+    local comment
+    comment=$(printf '%s\n' "$verify_out" | sed -n 's/^Trusted comment: //p')
+    if [ "$comment" != "$name" ]; then
+        die "trusted comment mismatch for $name:
+  expected: $name
+  got:      $comment
+  The signature is valid but for a different artifact (possibly an older
+  release replayed under this name). Do not install it."
+    fi
+    log_success "signature verified (trusted comment: $comment)"
+}
+
+# ============================================================================
+# Atomic install: write next to the destination, then rename. A crash
+# mid-install can never leave a truncated binary on PATH.
+# ============================================================================
+install_binary() {
+    local src="$1"
+    mkdir -p "$DEST"
+    local tmp_dest="$DEST/$BINARY_NAME.tmp.$$"
+    if ! install -m 0755 "$src" "$tmp_dest"; then
+        rm -f "$tmp_dest"
+        die "failed to write to $DEST (permissions?)"
+    fi
+    mv -f "$tmp_dest" "$DEST/$BINARY_NAME"
+}
+
+# ============================================================================
+# Release install: download, verify, extract, install.
+# ============================================================================
+install_from_artifact() {
+    local platform="$1" url archive_name
+
+    if [ -n "$ARTIFACT_URL" ]; then
+        url="$ARTIFACT_URL"
+        archive_name="$(basename "$ARTIFACT_URL")"
+    else
+        resolve_version
+        local tag="v${VERSION#v}" ver="${VERSION#v}"
+        archive_name="${BINARY_NAME}-${ver}-${platform}.tar.gz"
+        url="https://github.com/${OWNER}/${REPO}/releases/download/${tag}/${archive_name}"
+    fi
+
+    log_step "downloading $archive_name..."
+    download_file "$url" "$TMP/$archive_name" || die "download failed: $url"
+
+    local expected=""
+    if [ -n "$CHECKSUM" ]; then
+        expected="${CHECKSUM%% *}"
+    elif download_file "${url}.sha256" "$TMP/expected.sha256"; then
+        expected="$(awk '{print $1; exit}' "$TMP/expected.sha256")"
+    fi
+    verify_checksum "$TMP/$archive_name" "$expected" "$archive_name"
+
+    local sig="$TMP/$archive_name.minisig"
+    if [ "$INSECURE_SKIP_SIGNATURE" -eq 0 ]; then
+        download_file "${url}.minisig" "$sig" || true # absence handled below
+    fi
+    verify_signature "$TMP/$archive_name" "$sig" "$archive_name"
+
+    log_step "extracting..."
+    mkdir -p "$TMP/extract"
+    tar -xzf "$TMP/$archive_name" -C "$TMP/extract" \
+        || die "could not extract $archive_name"
+
+    [ -f "$TMP/extract/$BINARY_NAME" ] \
+        || die "archive does not contain a '$BINARY_NAME' binary"
+
+    install_binary "$TMP/extract/$BINARY_NAME"
+    log_success "installed $DEST/$BINARY_NAME"
+}
+
+# ============================================================================
+# Source build: explicit opt-in only. Requires an existing Rust
+# toolchain; this script does not install one behind your back. The
+# embedded hub MCP bundle additionally needs node+npm — built when
+# available, loudly skipped when not (`q2 mcp` is then non-functional,
+# everything else works).
+# ============================================================================
+build_from_source() {
+    command -v git >/dev/null 2>&1 || die "git is required for --from-source"
+    command -v cargo >/dev/null 2>&1 \
+        || die "cargo is required for --from-source; install Rust via https://rustup.rs and re-run"
+
+    local clone_args=(--quiet --depth 1)
+    [ -n "$VERSION" ] && clone_args+=(--branch "v${VERSION#v}")
+
+    log_step "cloning ${OWNER}/${REPO}..."
+    git clone "${clone_args[@]}" "https://github.com/${OWNER}/${REPO}.git" "$TMP/src" \
+        || die "clone failed"
+
+    if command -v npm >/dev/null 2>&1; then
+        log_step "building the hub MCP bundle (npm)..."
+        (cd "$TMP/src" && npm install --no-audit --no-fund --silent \
+            && npm run bundle -w ts-packages/quarto-hub-mcp --silent) \
+            || die "MCP bundle build failed"
+    else
+        log_warn "npm not found: building without the hub MCP bundle (\`q2 mcp\` will be non-functional; everything else works)"
+    fi
+
+    log_step "building with cargo (this may take several minutes)..."
+    (cd "$TMP/src" && CARGO_TARGET_DIR="$TMP/target" cargo build --release --quiet -p quarto) \
+        || die "build failed"
+
+    [ -f "$TMP/target/release/$BINARY_NAME" ] || die "binary not found after build"
+    install_binary "$TMP/target/release/$BINARY_NAME"
+    log_success "installed $DEST/$BINARY_NAME (source build)"
+}
+
+# ============================================================================
+# PATH advice. Printed, never applied: this script does not edit shell
+# rc files.
+# ============================================================================
+warn_path() {
+    case ":$PATH:" in
+        *:"$DEST":*) ;;
+        *) log_warn "$DEST is not on your PATH; add it with:
+  export PATH=\"$DEST:\$PATH\"" ;;
+    esac
+}
+
+do_uninstall() {
+    if [ -f "$DEST/$BINARY_NAME" ]; then
+        rm -f "$DEST/$BINARY_NAME"
+        log_success "removed $DEST/$BINARY_NAME"
+    else
+        log_warn "nothing to remove at $DEST/$BINARY_NAME"
+    fi
+}
+
+# ============================================================================
+# Main
+# ============================================================================
+TMP=""
+cleanup() { [ -n "$TMP" ] && rm -rf "$TMP"; return 0; }
+trap cleanup EXIT
+
+main() {
+    if [ "$PRINT_PLATFORM" -eq 1 ]; then
+        detect_platform
+        exit 0
+    fi
+    if [ "$UNINSTALL" -eq 1 ]; then
+        do_uninstall
+        exit 0
+    fi
+
+    TMP=$(mktemp -d)
+
+    if [ "$FROM_SOURCE" -eq 1 ]; then
+        log_step "install directory: $DEST"
+        build_from_source
+    else
+        local platform
+        platform=$(detect_platform)
+        log_step "platform: $platform"
+        log_step "install directory: $DEST"
+        install_from_artifact "$platform"
+    fi
+
+    warn_path
+
+    local installed_version
+    installed_version=$("$DEST/$BINARY_NAME" --version 2>/dev/null || echo "unknown")
+    log_success "done: $installed_version"
+}
+
+# The braces make bash parse this whole block before executing it, so a
+# `curl | bash` download truncated mid-script can never run half of main.
+{ main "$@"; }

--- a/ts-packages/quarto-hub-mcp/scripts/bundle.mjs
+++ b/ts-packages/quarto-hub-mcp/scripts/bundle.mjs
@@ -37,17 +37,12 @@
 
 import * as esbuild from 'esbuild';
 import { execFileSync } from 'node:child_process';
-import {
-  cpSync,
-  mkdirSync,
-  readdirSync,
-  rmSync,
-  writeFileSync,
-  existsSync,
-} from 'node:fs';
+import { mkdirSync, rmSync, writeFileSync, existsSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+
+import { parsePlatformList, stageKeyring } from './stage-keyring.mjs';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const pkgRoot = join(here, '..');
@@ -105,30 +100,22 @@ await esbuild.build({
 });
 
 // --- ship the keyring addon as a mini node_modules ---------------------
-// Copy the loader package plus every installed platform package. On a
-// normal dev machine that's exactly one platform; a CI machine staging
-// multiple platforms copies what it has.
+// The staged platform packages must match the **release target's**
+// users, not the build host: release jobs request explicit platforms
+// via KEYRING_PLATFORMS (e.g. "darwin-x64,darwin-arm64"), fetched at
+// the loader's exact version when not installed locally. Unset (dev
+// machines): stage every installed platform package — exactly one on
+// a normal dev box. Rules + fail-closed checks live in
+// scripts/stage-keyring.mjs (unit-tested in src/keyring-staging.test.ts).
 const napiSrcDir = join(
   dirname(require.resolve('@napi-rs/keyring/package.json')),
   '..',
 );
-const napiOutDir = join(outDir, 'node_modules', '@napi-rs');
-mkdirSync(napiOutDir, { recursive: true });
-const copied = [];
-for (const entry of readdirSync(napiSrcDir)) {
-  if (entry === 'keyring' || entry.startsWith('keyring-')) {
-    cpSync(join(napiSrcDir, entry), join(napiOutDir, entry), {
-      recursive: true,
-      dereference: true,
-    });
-    copied.push(entry);
-  }
-}
-if (!copied.includes('keyring') || copied.length < 2) {
-  throw new Error(
-    `expected @napi-rs/keyring plus at least one platform package, got: ${copied.join(', ')}`,
-  );
-}
+const copied = stageKeyring({
+  napiSrcDir,
+  outNapiDir: join(outDir, 'node_modules', '@napi-rs'),
+  platforms: parsePlatformList(process.env['KEYRING_PLATFORMS']),
+});
 
 // --- build stamp --------------------------------------------------------
 // Diagnosability guard against the stale-embed trap: the launcher and

--- a/ts-packages/quarto-hub-mcp/scripts/stage-keyring.mjs
+++ b/ts-packages/quarto-hub-mcp/scripts/stage-keyring.mjs
@@ -1,0 +1,136 @@
+/**
+ * Stage the `@napi-rs/keyring` loader + platform addon packages into a
+ * bundle's mini node_modules (bd-c6l13j79; split out of bundle.mjs so
+ * the staging rules are unit-testable with an injectable fetcher).
+ *
+ * The `.node` addon is loaded at runtime by the *user's* node, so the
+ * staged platform packages must match the **release target**, not the
+ * build host. Release jobs request explicit platforms via
+ * `KEYRING_PLATFORMS` (e.g. `darwin-x64,darwin-arm64`); packages not
+ * installed locally are fetched with `npm pack` at the loader's exact
+ * version. Without an explicit request, every locally installed
+ * platform package is staged (the original dev behavior: one package
+ * on a dev machine, whatever the lockfile installed).
+ *
+ * Fail-closed: a requested platform that can neither be copied nor
+ * fetched aborts the bundle. The keyring loader does full runtime
+ * platform/arch/libc detection, so co-staged platforms coexist by
+ * design.
+ */
+
+import { execFileSync } from 'node:child_process';
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+} from 'node:fs';
+import * as os from 'node:os';
+import { join } from 'node:path';
+
+/** Parse `KEYRING_PLATFORMS`-style input: comma-separated, trimmed,
+ * empty entries dropped; `undefined`/blank → null (= "no explicit
+ * request", stage what's installed). */
+export function parsePlatformList(raw) {
+  if (raw === undefined || raw === null) return null;
+  const list = raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  return list.length > 0 ? list : null;
+}
+
+/** The loader package's exact version — fetched platform packages must
+ * match it (napi-rs publishes loader + addons in lockstep). */
+export function keyringVersion(napiSrcDir) {
+  const pkgJson = join(napiSrcDir, 'keyring', 'package.json');
+  return JSON.parse(readFileSync(pkgJson, 'utf8')).version;
+}
+
+/** Default fetcher: `npm pack <name>@<version>` into a temp dir, then
+ * extract the tarball's `package/` to `destDir`. Network-touching; the
+ * tests inject a fake instead. */
+export function npmPackFetcher(name, version, destDir) {
+  const tmp = mkdtempSync(join(os.tmpdir(), 'keyring-fetch-'));
+  try {
+    execFileSync('npm', ['pack', `${name}@${version}`, '--silent'], {
+      cwd: tmp,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    const tgz = readdirSync(tmp).find((f) => f.endsWith('.tgz'));
+    if (!tgz) throw new Error(`npm pack produced no tarball for ${name}@${version}`);
+    // tar is universal on the runners we build on (incl. Windows bsdtar).
+    execFileSync('tar', ['-xzf', tgz], { cwd: tmp });
+    const payload = join(tmp, 'package');
+    if (!existsSync(join(payload, 'package.json'))) {
+      throw new Error(`tarball for ${name}@${version} lacks package/package.json`);
+    }
+    cpSync(payload, destDir, { recursive: true });
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Stage loader + platform packages from `napiSrcDir` (the installed
+ * `node_modules/@napi-rs`) into `outNapiDir`.
+ *
+ * @param {object} opts
+ * @param {string} opts.napiSrcDir  installed @napi-rs directory
+ * @param {string} opts.outNapiDir  destination @napi-rs directory
+ * @param {string[]|null} opts.platforms  explicit platform list
+ *   (e.g. ['darwin-x64']) or null for "all installed"
+ * @param {(name: string, version: string, destDir: string) => void} [opts.fetchPackage]
+ *   fetcher for platforms not installed locally (default: npm pack)
+ * @returns {string[]} sorted staged package directory names
+ */
+export function stageKeyring({ napiSrcDir, outNapiDir, platforms, fetchPackage = npmPackFetcher }) {
+  if (!existsSync(join(napiSrcDir, 'keyring', 'package.json'))) {
+    throw new Error(`@napi-rs/keyring loader not found under ${napiSrcDir} — run npm install`);
+  }
+  mkdirSync(outNapiDir, { recursive: true });
+
+  const installed = readdirSync(napiSrcDir).filter(
+    (entry) => entry === 'keyring' || entry.startsWith('keyring-'),
+  );
+  const wanted =
+    platforms === null
+      ? installed
+      : ['keyring', ...platforms.map((p) => `keyring-${p}`)];
+
+  const staged = [];
+  for (const entry of [...new Set(wanted)]) {
+    const dest = join(outNapiDir, entry);
+    if (installed.includes(entry)) {
+      cpSync(join(napiSrcDir, entry), dest, { recursive: true, dereference: true });
+    } else {
+      const version = keyringVersion(napiSrcDir);
+      try {
+        fetchPackage(`@napi-rs/${entry}`, version, dest);
+      } catch (err) {
+        throw new Error(
+          `failed to stage @napi-rs/${entry}@${version} (not installed locally, fetch failed): ${err.message}`,
+        );
+      }
+    }
+    staged.push(entry);
+  }
+
+  // Fail closed: every platform package must actually carry its addon.
+  for (const entry of staged) {
+    if (entry === 'keyring') continue;
+    const hasAddon = readdirSync(join(outNapiDir, entry)).some((f) => f.endsWith('.node'));
+    if (!hasAddon) {
+      throw new Error(`staged @napi-rs/${entry} contains no .node addon — refusing to bundle`);
+    }
+  }
+  if (!staged.includes('keyring') || staged.length < 2) {
+    throw new Error(
+      `expected @napi-rs/keyring plus at least one platform package, got: ${staged.join(', ')}`,
+    );
+  }
+  return staged.sort();
+}

--- a/ts-packages/quarto-hub-mcp/src/keyring-staging.test.ts
+++ b/ts-packages/quarto-hub-mcp/src/keyring-staging.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Unit tests for scripts/stage-keyring.mjs (bd-c6l13j79): the staging
+ * rules for the keyring loader + platform addon packages that ship
+ * inside the bundle's mini node_modules.
+ *
+ * Offline by construction: fixture @napi-rs trees are fabricated in a
+ * temp dir and the network fetcher is injected as a fake. The real
+ * `npm pack` fetcher is exercised by the release workflow (whose
+ * launcher-info assertion checks the staged platform list per target).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+// @ts-expect-error — plain .mjs module without type declarations
+import { parsePlatformList, keyringVersion, stageKeyring } from '../scripts/stage-keyring.mjs';
+
+let tmp: string;
+let srcDir: string;
+let outDir: string;
+
+/** Fabricate an installed @napi-rs/<name> package. */
+function installPackage(name: string, opts: { version?: string; addon?: boolean } = {}) {
+  const dir = path.join(srcDir, name);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, 'package.json'),
+    JSON.stringify({ name: `@napi-rs/${name}`, version: opts.version ?? '1.3.0' }),
+  );
+  if (opts.addon) {
+    fs.writeFileSync(path.join(dir, `keyring.${name.replace(/^keyring-/, '')}.node`), 'ELF-ish');
+  }
+}
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'keyring-staging-test-'));
+  srcDir = path.join(tmp, 'src', '@napi-rs');
+  outDir = path.join(tmp, 'out', '@napi-rs');
+  fs.mkdirSync(srcDir, { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+describe('parsePlatformList', () => {
+  it('returns null for unset/blank (= stage what is installed)', () => {
+    expect(parsePlatformList(undefined)).toBeNull();
+    expect(parsePlatformList('')).toBeNull();
+    expect(parsePlatformList('  ')).toBeNull();
+  });
+
+  it('splits, trims, and drops empties', () => {
+    expect(parsePlatformList('darwin-x64, darwin-arm64 ,,')).toEqual([
+      'darwin-x64',
+      'darwin-arm64',
+    ]);
+  });
+});
+
+describe('keyringVersion', () => {
+  it('reads the loader package version', () => {
+    installPackage('keyring', { version: '9.9.9' });
+    expect(keyringVersion(srcDir)).toBe('9.9.9');
+  });
+});
+
+describe('stageKeyring', () => {
+  it('without an explicit list, stages loader + every installed platform', () => {
+    installPackage('keyring');
+    installPackage('keyring-darwin-arm64', { addon: true });
+    const staged = stageKeyring({ napiSrcDir: srcDir, outNapiDir: outDir, platforms: null });
+    expect(staged).toEqual(['keyring', 'keyring-darwin-arm64']);
+    expect(fs.existsSync(path.join(outDir, 'keyring', 'package.json'))).toBe(true);
+    expect(
+      fs.existsSync(path.join(outDir, 'keyring-darwin-arm64', 'keyring.darwin-arm64.node')),
+    ).toBe(true);
+  });
+
+  it('explicit list: stages exactly loader + requested platforms, not other installed ones', () => {
+    installPackage('keyring');
+    installPackage('keyring-darwin-arm64', { addon: true });
+    installPackage('keyring-linux-x64-gnu', { addon: true });
+    const staged = stageKeyring({
+      napiSrcDir: srcDir,
+      outNapiDir: outDir,
+      platforms: ['darwin-arm64'],
+    });
+    expect(staged).toEqual(['keyring', 'keyring-darwin-arm64']);
+    expect(fs.existsSync(path.join(outDir, 'keyring-linux-x64-gnu'))).toBe(false);
+  });
+
+  it('fetches requested platforms that are not installed, at the loader version', () => {
+    installPackage('keyring', { version: '1.3.0' });
+    installPackage('keyring-darwin-arm64', { addon: true });
+    const fetched: Array<[string, string]> = [];
+    const staged = stageKeyring({
+      napiSrcDir: srcDir,
+      outNapiDir: outDir,
+      platforms: ['darwin-arm64', 'darwin-x64'],
+      fetchPackage: (name: string, version: string, destDir: string) => {
+        fetched.push([name, version]);
+        fs.mkdirSync(destDir, { recursive: true });
+        fs.writeFileSync(path.join(destDir, 'package.json'), '{}');
+        fs.writeFileSync(path.join(destDir, 'keyring.darwin-x64.node'), 'ELF-ish');
+      },
+    });
+    expect(fetched).toEqual([['@napi-rs/keyring-darwin-x64', '1.3.0']]);
+    expect(staged).toEqual(['keyring', 'keyring-darwin-arm64', 'keyring-darwin-x64']);
+  });
+
+  it('fails closed when a requested platform cannot be fetched', () => {
+    installPackage('keyring');
+    installPackage('keyring-darwin-arm64', { addon: true });
+    expect(() =>
+      stageKeyring({
+        napiSrcDir: srcDir,
+        outNapiDir: outDir,
+        platforms: ['linux-riscv64-gnu'],
+        fetchPackage: () => {
+          throw new Error('registry unreachable');
+        },
+      }),
+    ).toThrow(/keyring-linux-riscv64-gnu.*fetch failed.*registry unreachable/);
+  });
+
+  it('fails closed when a staged platform package lacks its .node addon', () => {
+    installPackage('keyring');
+    installPackage('keyring-darwin-arm64', { addon: false });
+    expect(() =>
+      stageKeyring({ napiSrcDir: srcDir, outNapiDir: outDir, platforms: ['darwin-arm64'] }),
+    ).toThrow(/no \.node addon/);
+  });
+
+  it('fails when the loader itself is missing', () => {
+    installPackage('keyring-darwin-arm64', { addon: true });
+    expect(() =>
+      stageKeyring({ napiSrcDir: srcDir, outNapiDir: outDir, platforms: null }),
+    ).toThrow(/loader not found/);
+  });
+
+  it('fails when nothing but the loader would be staged', () => {
+    installPackage('keyring');
+    expect(() =>
+      stageKeyring({ napiSrcDir: srcDir, outNapiDir: outDir, platforms: null }),
+    ).toThrow(/at least one platform package/);
+  });
+});


### PR DESCRIPTION
Adopts cscheid/braid's release mechanism for q2 and bakes the quarto-hub.com connection defaults into release binaries, so colleagues install **q2 + node** and run the MCP with zero configuration — no more out-of-band env-var distribution.

Plan: `claude-notes/plans/2026-06-12-q2-github-releases-bundled-mcp.md` · Strand: bd-c6l13j79

## What's here

- **Bundled OAuth defaults** (`crates/quarto-mcp-launcher`): release CI compiles `QUARTO_HUB_BUNDLED_{CLIENT_ID,CLIENT_SECRET,SERVER}` in via `option_env!`; the launcher injects them into the node child env for any variable the user hasn't set (blank = unset, mirroring `readNonEmpty` in oauth-config.ts). User env always wins; source builds behave exactly as before. `q2 mcp --launcher-info` reports per-variable `env|bundled|absent`. The Desktop-app `client_secret` is a public client credential (RFC 8252) — embedding matches gcloud/gh/rclone practice; CI-injection only keeps `GOCSPX-` scanners off the repo.
- **Installers**: `install.sh` (checksum + minisign Ed25519, both mandatory/fail-closed, trusted comment = filename) and `install.ps1` (checksum-only), ported from braid; pinned pubkey `91F595A50BD20376`. 32 offline tests in `crates/quarto/tests/integration/bootstrap_sh.rs`; `test-suite.yml` installs minisign.
- **Target-aware keyring staging** (`ts-packages/quarto-hub-mcp/scripts/stage-keyring.mjs`): `KEYRING_PLATFORMS` pins which `@napi-rs/keyring` native addons ship in the bundle — they must match the *user's* node, and the darwin_amd64 release builds on an arm64 runner. Missing addons fetched via `npm pack` at the loader's locked version; fail-closed. 10 offline unit tests.
- **Release workflow** (`.github/workflows/release.yml`): tag-triggered, preflight tag↔version check, a `web-payloads` job building the target-independent embeds once (WASM → preview SPA, trace viewer), 5-target matrix (linux musl x2, darwin x2, windows), per-target anti-placeholder/anti-stale-embed verification (`--launcher-info` must show a real bundle, bundled defaults ×3, and the target's keyring addons), sha256 + minisign + self-verify against the install.sh pin, combined checksums, `gh release create`.
- **CLI version contract change** (decided in-session): `q2 --version` now reports the real workspace version (`quarto 0.1.0`) instead of the `99.9.9-dev` placeholder — release artifacts must be verifiable against their tag, and Lua-side `quarto.version` already reported `{0,1,0}`. Extension minimum-version checks will see 0.1.0; accepted for now.
- **musl TLS**: `openssl-sys/vendored` scoped to `cfg(target_env = "musl")` (samod → tokio-tungstenite(native-tls) needs openssl; static linux builds get it from source).

## Verification

- Full workspace suite after the version change: **10038/10038 passed**.
- Clean-env `cargo xtask verify`: **all steps green** (the hub-mcp suite fails if `QUARTO_HUB_MCP_*` operator credentials are exported in the shell — pre-existing hermeticity gap, filed as bd-n6dhrz4j).
- Launcher defaults verified end-to-end against a local build with test values baked in (child-env dump via fake `QUARTO_NODE`; user-override and absent-defaults paths included).
- Cross-platform keyring fetch verified on an arm64 mac: staged a Mach-O x86_64 addon via `npm pack`.
- The release workflow itself is actionlint-clean but **unexercised** — after merge, pushing tag `v0.1.0` is the dry run (plan Phase 4). Static-musl (aws-lc-sys) is the known risk; fallback to gnu is a one-line matrix change (plan D4).

## Discovered work filed

- bd-n6dhrz4j — hub-mcp tests not hermetic against exported operator credentials
- bd-3up1mf8c — pre-existing deny-level clippy error in quarto-core capture_splice.rs

🤖 Generated with [Claude Code](https://claude.com/claude-code)