### PR TITLE
fix(release): pinned-toolchain targets + Windows npm spawn (bd-c6l13j79, dry-run iteration 1)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,6 +219,17 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      # The toolchain action adds the target to the *latest* nightly,
+      # but cargo resolves the dated nightly pinned in
+      # rust-toolchain.toml (bd-at72) — which auto-installs with only
+      # its own declared targets. Add the matrix target to the pinned
+      # toolchain explicitly, or every cross/musl build dies with
+      # E0463 "can't find crate for core" (v0.1.0 dry-run, run
+      # 27448388974).
+      - name: Add ${{ matrix.target }} to the pinned toolchain
+        shell: bash
+        run: rustup target add ${{ matrix.target }}
+
       - name: Install musl-tools
         if: contains(matrix.target, 'musl')
         run: sudo apt-get update && sudo apt-get install -y musl-tools

--- a/claude-notes/plans/2026-06-12-q2-github-releases-bundled-mcp.md
+++ b/claude-notes/plans/2026-06-12-q2-github-releases-bundled-mcp.md
@@ -371,6 +371,28 @@ same code path with the same mechanism).
 
 - [ ] Dry-run the workflow (workflow_dispatch on a test tag or fork);
       download artifacts for all five platforms
+
+**Phase 4 log.** PR #278 (all 5 CI checks green) squash-merged to main
+by Carlos as `31222946` on 2026-06-12. Tag `v0.1.0` pushed at that
+commit; release run:
+https://github.com/quarto-dev/q2/actions/runs/27448388974
+
+*Iteration 1 (run 27448388974):* preflight ✓, web-payloads ✓ (WASM +
+SPA + trace viewer built cleanly on the release runner). Four matrix
+legs failed, two distinct causes:
+1. linux_amd64 / linux_arm64 / darwin_amd64 — `E0463 can't find crate
+   for core/std`: the dtolnay action adds the matrix target to the
+   *latest* nightly, but cargo resolves the dated nightly pinned in
+   `rust-toolchain.toml` (bd-at72), which auto-installs with only its
+   declared targets (wasm32). web-payloads only survived because wasm32
+   is in the pin's own `targets`. Fix: explicit `rustup target add` step.
+2. windows_amd64 — `spawnSync npm ENOENT` in stage-keyring's
+   npmPackFetcher fetching keyring-win32-arm64-msvc: npm is `npm.cmd`
+   on Windows; execFileSync needs `shell: true` (+ Node ≥20.12 rejects
+   .cmd without it). Fix in npmPackFetcher.
+darwin_arm64 (only leg whose target is host-default) ran the furthest —
+its outcome validates the downstream pipeline (defaults injection,
+verify gate, packaging, signing).
 - [ ] `install.sh` one-liner on a clean machine/container → `q2 --version`
 - [ ] `q2 mcp` with **no env vars set** connects to quarto-hub.com:
       browser consent → token → `connect_project` + `read_file` against a

--- a/ts-packages/quarto-hub-mcp/scripts/stage-keyring.mjs
+++ b/ts-packages/quarto-hub-mcp/scripts/stage-keyring.mjs
@@ -56,9 +56,16 @@ export function keyringVersion(napiSrcDir) {
 export function npmPackFetcher(name, version, destDir) {
   const tmp = mkdtempSync(join(os.tmpdir(), 'keyring-fetch-'));
   try {
-    execFileSync('npm', ['pack', `${name}@${version}`, '--silent'], {
+    // On Windows npm is npm.cmd, which execFileSync cannot spawn
+    // without a shell (ENOENT; and Node ≥20.12 rejects .cmd without
+    // shell:true outright). Arguments here are fixed package
+    // specifiers, so shell quoting is not a concern. Seen in the
+    // v0.1.0 dry-run (run 27448388974, windows_amd64 leg).
+    const windows = process.platform === 'win32';
+    execFileSync(windows ? 'npm.cmd' : 'npm', ['pack', `${name}@${version}`, '--silent'], {
       cwd: tmp,
       stdio: ['ignore', 'pipe', 'pipe'],
+      shell: windows,
     });
     const tgz = readdirSync(tmp).find((f) => f.endsWith('.tgz'));
     if (!tgz) throw new Error(`npm pack produced no tarball for ${name}@${version}`);


### PR DESCRIPTION
Two fixes from the v0.1.0 release dry-run ([run 27448388974](https://github.com/quarto-dev/q2/actions/runs/27448388974)):

1. **linux_amd64 / linux_arm64 / darwin_amd64** failed with `E0463: can't find crate for core` — the dtolnay toolchain action adds the matrix target to the *latest* nightly, but cargo resolves the dated nightly pinned in `rust-toolchain.toml` (bd-at72), which auto-installs with only its own declared targets (that's also why `web-payloads` passed: wasm32 is in the pin). Fix: explicit `rustup target add ${{ matrix.target }}` step against the pinned toolchain.
2. **windows_amd64** failed with `spawnSync npm ENOENT` while `stage-keyring.mjs` fetched the non-host `keyring-win32-arm64-msvc` addon — npm is `npm.cmd` on Windows and `execFileSync` needs `shell: true` (Node ≥20.12 rejects `.cmd` without it). Arguments are fixed package specifiers, so no shell-quoting exposure.

Meanwhile **darwin_arm64 passed end-to-end**, validating everything downstream: per-target MCP bundle with both darwin keyring addons, bundled-defaults injection (verify gate saw `default …: bundled` ×3, no placeholders), tar.gz + sha256, minisign signing self-verified against the install.sh pinned key.

Keyring staging tests 10/10; real darwin-x64 `npm pack` fetch re-verified locally; actionlint clean. After merge: delete and re-push tag `v0.1.0` for iteration 2 (remaining known risk: the musl legs haven't compiled aws-lc-sys/vendored-openssl yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)