### PR TITLE
fix(release): linux gnu fallback — rusty_v8 has no musl prebuilts (bd-c6l13j79, dry-run iteration 2)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,10 +36,12 @@
 #   are injected from repo secrets/vars into the cargo build env —
 #   release builds only; see crates/quarto-mcp-launcher/src/defaults.rs
 #   for why the Desktop-app client secret is safe to embed.
-# - Linux targets are static musl; openssl is built from source via the
-#   musl-scoped `openssl-sys/vendored` dep in crates/quarto/Cargo.toml.
-#   If musl turns out unbuildable (aws-lc-sys is the known risk), flip
-#   the matrix targets to *-unknown-linux-gnu — plan D4.
+# - Linux targets are gnu on the oldest available runners (glibc 2.35
+#   floor). Static musl is impossible for q2: rusty_v8 (deno_core →
+#   quarto-system-runtime) publishes no musl prebuilt archives — both
+#   musl legs 404'd in the v0.1.0 dry-run (run 27449454203). The linux
+#   legs build with `--features vendored-openssl` so the binary has no
+#   runtime libssl dependency (plan D4).
 #
 # Signing key: MINISIGN_SECRET_KEY repo secret; the public half is pinned
 # in install.sh (MINISIGN_PUBKEY) and README. The sign step verifies its
@@ -184,31 +186,40 @@ jobs:
           # node), both mac archs (Rosetta mismatch: x64 q2 under an
           # arm64 node and vice versa), both win archs (arm64 Windows
           # runs x64 q2 under emulation with a native arm64 node).
+          # cargo_flags: linux legs vendor openssl (no runtime libssl
+          # dep); macOS/Windows TLS is security-framework/schannel, no
+          # openssl involved. ubuntu-22.04 runners set the glibc floor
+          # at 2.35.
           - platform: linux_amd64
-            target: x86_64-unknown-linux-musl
-            os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            os: ubuntu-22.04
             ext: tar.gz
             keyring: linux-x64-gnu,linux-x64-musl
+            cargo_flags: --features vendored-openssl
           - platform: linux_arm64
-            target: aarch64-unknown-linux-musl
-            os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            os: ubuntu-22.04-arm
             ext: tar.gz
             keyring: linux-arm64-gnu,linux-arm64-musl
+            cargo_flags: --features vendored-openssl
           - platform: darwin_amd64
             target: x86_64-apple-darwin
             os: macos-15  # arm64 runner; the x86_64 binary runs under Rosetta
             ext: tar.gz
             keyring: darwin-x64,darwin-arm64
+            cargo_flags: ''
           - platform: darwin_arm64
             target: aarch64-apple-darwin
             os: macos-15
             ext: tar.gz
             keyring: darwin-arm64,darwin-x64
+            cargo_flags: ''
           - platform: windows_amd64
             target: x86_64-pc-windows-msvc
             os: windows-latest
             ext: zip
             keyring: win32-x64-msvc,win32-arm64-msvc
+            cargo_flags: ''
     steps:
       - uses: actions/checkout@v6
         with:
@@ -229,10 +240,6 @@ jobs:
       - name: Add ${{ matrix.target }} to the pinned toolchain
         shell: bash
         run: rustup target add ${{ matrix.target }}
-
-      - name: Install musl-tools
-        if: contains(matrix.target, 'musl')
-        run: sudo apt-get update && sudo apt-get install -y musl-tools
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -289,7 +296,7 @@ jobs:
               exit 1
             fi
           done
-          cargo build --release --locked --target ${{ matrix.target }} -p quarto
+          cargo build --release --locked --target ${{ matrix.target }} -p quarto ${{ matrix.cargo_flags }}
 
       # Every target in the matrix can execute on its runner (musl
       # binaries are static; darwin x86_64 runs under Rosetta; windows
@@ -489,8 +496,8 @@ jobs:
             echo
             echo "| Platform | File |"
             echo "|---|---|"
-            echo "| Linux x86_64 (static musl) | \`q2-${VERSION}-linux_amd64.tar.gz\` |"
-            echo "| Linux ARM64 (static musl) | \`q2-${VERSION}-linux_arm64.tar.gz\` |"
+            echo "| Linux x86_64 (glibc 2.35+) | \`q2-${VERSION}-linux_amd64.tar.gz\` |"
+            echo "| Linux ARM64 (glibc 2.35+) | \`q2-${VERSION}-linux_arm64.tar.gz\` |"
             echo "| macOS Intel | \`q2-${VERSION}-darwin_amd64.tar.gz\` |"
             echo "| macOS Apple Silicon | \`q2-${VERSION}-darwin_arm64.tar.gz\` |"
             echo "| Windows x86_64 | \`q2-${VERSION}-windows_amd64.zip\` |"

--- a/claude-notes/plans/2026-06-12-q2-github-releases-bundled-mcp.md
+++ b/claude-notes/plans/2026-06-12-q2-github-releases-bundled-mcp.md
@@ -393,6 +393,31 @@ legs failed, two distinct causes:
 darwin_arm64 (only leg whose target is host-default) ran the furthest —
 its outcome validates the downstream pipeline (defaults injection,
 verify gate, packaging, signing).
+
+*Iteration 1 fixes:* PR #279 (merged as `8f44bcbb`): explicit
+`rustup target add` step; `shell: true` npm spawn on Windows in
+npmPackFetcher. darwin_arm64 then passed END-TO-END in iteration 1 —
+bundle, bundled defaults (verify gate green), tar.gz + sha256, minisign
+sign + self-verify all confirmed working on a real runner.
+
+*Iteration 2 (run 27449454203, tag re-pushed at `8f44bcbb`):*
+darwin_arm64 ✓ again. **Both linux musl legs failed with HTTP 404
+downloading the rusty_v8 prebuilt static library** — rusty_v8
+(deno_core → quarto-system-runtime → pampa/quarto-core) publishes no
+musl archives, and building V8 from source in CI is a non-starter. So
+**D4's musl plan is dead for q2 — not openssl/aws-lc, but the JS
+engine braid doesn't have.** Resolution (D4 fallback, adjusted):
+- linux legs → `*-unknown-linux-gnu` on ubuntu-22.04 / ubuntu-22.04-arm
+  (glibc 2.35 floor; documented in the release-notes table);
+- new `vendored-openssl` cargo feature on `crates/quarto`
+  (`dep:openssl-sys` + `openssl-sys/vendored`), enabled only by the
+  linux release legs via a `cargo_flags` matrix field, so release
+  binaries never depend on the host's libssl and dev builds are
+  untouched (replaces the musl-scoped dep table);
+- musl-tools step dropped.
+Alpine users: gnu binaries need gcompat; acceptable for now (the
+keyring bundle still ships musl addons for users running musl node
+against a gcompat'd q2 — 500 KB of insurance).
 - [ ] `install.sh` one-liner on a clean machine/container → `q2 --version`
 - [ ] `q2 mcp` with **no env vars set** connects to quarto-hub.com:
       browser consent → token → `connect_project` + `read_file` against a

--- a/crates/quarto/Cargo.toml
+++ b/crates/quarto/Cargo.toml
@@ -44,16 +44,22 @@ tempfile = "3"
 # `xdg-open` on Linux, `cmd /C start` on Windows). No heavy transitive
 # tree.
 open = "5"
+# Only via the vendored-openssl feature (see [features]); never a
+# direct code dependency.
+openssl-sys = { version = "0.9", optional = true }
 
 [build-dependencies]
 
-# Static-musl release builds (release plan D4, bd-c6l13j79): samod →
-# tokio-tungstenite(native-tls) → openssl-sys needs an openssl to link,
-# and no musl-built system openssl exists on the runners — build it
-# from source into the static binary. cfg-scoped so native dev builds
-# (glibc/macOS/Windows) are untouched.
-[target.'cfg(target_env = "musl")'.dependencies]
-openssl-sys = { version = "0.9", features = ["vendored"] }
+[features]
+# Release-build knob (plan D4, bd-c6l13j79): samod →
+# tokio-tungstenite(native-tls) → openssl-sys links openssl on Linux;
+# without this feature the binary picks up a runtime dependency on the
+# build host's libssl. The release workflow's linux legs enable it so
+# openssl is built from source and linked statically; dev builds are
+# untouched. (Static *musl* is off the table entirely: rusty_v8, via
+# deno_core → quarto-system-runtime, publishes no musl prebuilt
+# archives — both linux legs 404'd in the v0.1.0 dry-run.)
+vendored-openssl = ["dep:openssl-sys", "openssl-sys/vendored"]
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
Iteration 2 of the v0.1.0 dry-run ([run 27449454203](https://github.com/quarto-dev/q2/actions/runs/27449454203)) confirmed both iteration-1 fixes: **darwin_arm64, darwin_amd64, and windows_amd64 all passed end-to-end** (cross-compile under Rosetta, the verify gate, real `npm pack` keyring fetches incl. win32-arm64, packaging, signing).

The two linux legs failed with **HTTP 404 downloading the rusty_v8 prebuilt static library**: rusty_v8 (`deno_core` → `quarto-system-runtime` → pampa/quarto-core) publishes no musl archives, and building V8 from source in CI is a non-starter. Static musl was braid's luxury — braid ships no JS engine. Plan D4's fallback, adjusted:

- linux legs → `x86_64/aarch64-unknown-linux-gnu` on **ubuntu-22.04 / ubuntu-22.04-arm** (glibc 2.35 floor, documented in the release-notes table)
- new **`vendored-openssl`** feature on `crates/quarto` (`dep:openssl-sys` + `openssl-sys/vendored`), enabled only by the linux release legs via a `cargo_flags` matrix field — release binaries carry no runtime libssl dependency; dev builds untouched (replaces the musl-scoped dep table from #278)
- musl-tools step dropped; keyring bundles still ship the musl addons (gcompat'd Alpine users running musl node)

actionlint clean; feature graph verified (`cargo tree --features vendored-openssl --target x86_64-unknown-linux-gnu -i openssl-sys` → vendored); default build unaffected; `Cargo.lock` unchanged.

After merge: re-push tag `v0.1.0` for iteration 3 — the linux legs' first actual compile (vendored openssl + aws-lc-sys on gnu are both well-trodden).

🤖 Generated with [Claude Code](https://claude.com/claude-code)