### PR TITLE
feat(cli): q2 --version prints 'q2 (quarto 2) 0.1.0' (bd-qyjsncfx)

### DIFF
--- a/crates/quarto-util/src/version.rs
+++ b/crates/quarto-util/src/version.rs
@@ -15,6 +15,17 @@ pub fn cli_version() -> &'static str {
     env!("CARGO_PKG_VERSION")
 }
 
+/// The display form for the q2 CLI's `--version` value: clap renders
+/// `"<command name> <version>"`, so with command name "q2" this yields
+/// `q2 (quarto 2) 0.1.0` — "(quarto 2)" disambiguates from TS Quarto
+/// (bd-qyjsncfx). `&'static str` via `concat!` because the workspace
+/// clap has no `string` feature (owned values). The release workflow
+/// parses the LAST whitespace token of the output as the bare version;
+/// anything appended here must keep the version last.
+pub fn cli_version_display() -> &'static str {
+    concat!("(quarto 2) ", env!("CARGO_PKG_VERSION"))
+}
+
 /// Get the Cargo package version (for internal use)
 pub fn cargo_version() -> &'static str {
     env!("CARGO_PKG_VERSION")
@@ -38,5 +49,20 @@ mod tests {
     fn test_cargo_version() {
         let version = cargo_version();
         assert!(!version.is_empty(), "Cargo version should not be empty");
+    }
+
+    #[test]
+    fn display_form_is_the_decorated_cli_version() {
+        // The concat! in cli_version_display() and the env! in
+        // cli_version() must never drift apart.
+        assert_eq!(
+            cli_version_display(),
+            format!("(quarto 2) {}", cli_version())
+        );
+        // Release-workflow contract: the bare version is the last token.
+        assert_eq!(
+            cli_version_display().split_whitespace().last(),
+            Some(cli_version())
+        );
     }
 }

--- a/crates/quarto/src/main.rs
+++ b/crates/quarto/src/main.rs
@@ -11,8 +11,12 @@ use quarto_core::attribution::AttributionMode;
 mod commands;
 
 #[derive(Parser)]
-#[command(name = "quarto")]
-#[command(version = quarto_util::cli_version())]
+// "q2" is the actual binary name (and what usage/help should show);
+// "(quarto 2)" in the version string disambiguates from TS Quarto, so
+// `q2 --version` prints "q2 (quarto 2) 0.1.0" (bd-qyjsncfx). The LAST
+// token must stay the bare version — release.yml's verify step parses it.
+#[command(name = "q2")]
+#[command(version = quarto_util::cli_version_display())]
 #[command(about = "Quarto CLI", long_about = None)]
 struct Cli {
     /// Increase log verbosity. Repeat for more detail:

--- a/crates/quarto/tests/integration/main.rs
+++ b/crates/quarto/tests/integration/main.rs
@@ -11,5 +11,6 @@ pub mod render_integration;
 pub mod revealjs_cli;
 pub mod smoke_all;
 pub mod trace_cli;
+pub mod version_cli;
 
 fn main() {}

--- a/crates/quarto/tests/integration/version_cli.rs
+++ b/crates/quarto/tests/integration/version_cli.rs
@@ -1,0 +1,42 @@
+//! `q2 --version` output contract (bd-qyjsncfx).
+//!
+//! Display: "q2 (quarto 2) <workspace-version>" — "q2" is what users
+//! type, "(quarto 2)" disambiguates from TS Quarto, and the version is
+//! the real workspace version (decision 2026-06-12, bd-c6l13j79; no
+//! placeholder).
+//!
+//! The LAST whitespace-separated token must remain the bare version:
+//! release.yml's verify step parses `${RAW##* }` and compares it to
+//! the tag. Breaking that token breaks releases.
+
+use std::process::Command;
+
+fn version_output(flag: &str) -> String {
+    let out = Command::new(env!("CARGO_BIN_EXE_q2"))
+        .arg(flag)
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "{flag} exited nonzero");
+    String::from_utf8(out.stdout).unwrap()
+}
+
+#[test]
+fn version_output_names_q2_and_quarto_2() {
+    let text = version_output("--version");
+    assert_eq!(
+        text.trim(),
+        format!("q2 (quarto 2) {}", env!("CARGO_PKG_VERSION"))
+    );
+}
+
+#[test]
+fn short_flag_matches_long_flag() {
+    assert_eq!(version_output("-V"), version_output("--version"));
+}
+
+#[test]
+fn last_token_is_the_bare_version_for_release_workflow_parsing() {
+    let text = version_output("--version");
+    let last = text.split_whitespace().last().unwrap();
+    assert_eq!(last, env!("CARGO_PKG_VERSION"));
+}


### PR DESCRIPTION
Per Carlos: `quarto 0.1.0` is ambiguous next to TS Quarto; `q2 (quarto 2) 0.1.0` is clearer.

- clap command name `quarto` → `q2`: the version line becomes `q2 (quarto 2) …`, and `--help` usage lines now show the actual binary name (`Usage: q2 [OPTIONS] <COMMAND>` instead of `Usage: quarto …`).
- The version value is decorated as `(quarto 2) <version>`, assembled at compile time in `quarto_util::cli_version_display()` (workspace clap lacks the `string` feature for owned values; version policy stays in quarto-util). A unit test guards the `concat!`/`cli_version()` coupling.
- **Release-workflow contract preserved and now tested**: `release.yml`'s verify step parses the *last* whitespace token of `--version` output as the bare version — `tests/integration/version_cli.rs` encodes that, plus the exact display string and `-V`/`--version` parity (TDD, display test red first).
- The hand-written `Usage: quarto call …` strings in `q2 call` are unrelated to clap and untouched.

Verified by running the binary: `q2 --version` → `q2 (quarto 2) 0.1.0`. Full workspace suite: 10033/10033 passed; clippy/fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)