### PR TITLE
feat(hub-mcp): add wait_for_change long-poll tool

### DIFF
--- a/ts-packages/quarto-hub-mcp/README.md
+++ b/ts-packages/quarto-hub-mcp/README.md
@@ -16,6 +16,61 @@ The design lives in
 operators registering a hub for end-user use should consult
 [`claude-notes/instructions/hub-mcp-operator-runbook.md`](../../claude-notes/instructions/hub-mcp-operator-runbook.md).
 
+## Tools
+
+Once configured, the agent has the tools below. Each operates on a project
+identified by its Automerge **index document ID**, passed as the `project`
+argument.
+
+### Reading
+
+| Tool | What it does |
+|------|--------------|
+| `connect_project` | Connect to a project by its index doc ID; returns the file list. Triggers the sign-in flow if the hub requires auth. |
+| `list_files` | List the files in a connected project. |
+| `read_file` | Read a text file's content. |
+| `wait_for_change` | **Long-poll**: block until a file is edited by any collaborator, then return its new content (see below). |
+
+### Writing
+
+| Tool | What it does |
+|------|--------------|
+| `write_file` | Replace a text file's entire content (creates it if absent). |
+| `patch_file` | Replace one unique substring in a text file. |
+| `create_file` | Create a new text file. |
+| `delete_file` | Delete a file. |
+| `rename_file` | Rename / move a file. |
+| `create_project` | Create a new project on the sync server with optional initial files. |
+
+The write tools are hidden when the server is started with `--read-only`.
+
+### Authentication
+
+`authenticate` and `authenticate_clear` are present only when the OAuth env
+vars are configured (see [Setup](#setup)). On a no-auth hub they are unused.
+
+### `wait_for_change` — reacting to a live collaborator
+
+`wait_for_change` lets an agent respond to another editor without busy-polling
+`read_file`. It blocks until the watched `path` changes, then returns
+`{ changed: true, content, hash }`; on timeout it returns
+`{ changed: false, hash }`, so the agent just calls again to keep watching.
+
+```jsonc
+wait_for_change({
+  project: "<index-doc-id>",
+  path: "report.qmd",
+  timeout_seconds: 25,    // optional, clamped to 1–55
+  since_hash: "sha256:…"  // optional — see below
+})
+```
+
+Pass the `hash` from the previous result back as `since_hash`: if the file
+already differs from it, the call returns **immediately**. This closes the gap
+between polls, so an edit that lands *between* two `wait_for_change` calls is
+never missed. The tool is read-only and is available even in `--read-only`
+mode.
+
 ## Setup
 
 You need two values from your hub operator:

--- a/ts-packages/quarto-hub-mcp/src/connection-manager.test.ts
+++ b/ts-packages/quarto-hub-mcp/src/connection-manager.test.ts
@@ -586,6 +586,103 @@ describe('lastObservedAuthMode state machine', () => {
 });
 
 // ---------------------------------------------------------------------------
+// waitForChange (long-poll)
+// ---------------------------------------------------------------------------
+
+/**
+ * Sync-client factory that captures the callbacks object so a test can
+ * drive `onFileChanged` / `onFileRemoved` to simulate remote edits. The
+ * `connect` stub seeds one text file ('test.qmd' = 'hello') via
+ * `onFileAdded`, mirroring a real initial sync.
+ */
+function capturingSyncClientFactory() {
+  let captured: SyncClientCallbacks | undefined;
+  const factory = (cbs: SyncClientCallbacks): SyncClient => {
+    captured = cbs;
+    const stub: Partial<SyncClient> = {
+      connect: vi.fn(async () => {
+        cbs.onFileAdded?.('test.qmd', { type: 'text', text: 'hello' });
+        return [];
+      }) as unknown as SyncClient['connect'],
+      disconnect: vi.fn().mockResolvedValue(undefined) as unknown as SyncClient['disconnect'],
+    };
+    return stub as SyncClient;
+  };
+  return { factory, cbs: () => captured! };
+}
+
+describe('waitForChange (long-poll)', () => {
+  it('resolves when the watched file changes', async () => {
+    const fetchSpy = scriptedFetch([200]);
+    const cap = capturingSyncClientFactory();
+    const mgr = new ConnectionManager({
+      serverUrl: 'wss://hub.example.com/ws',
+      fetch: fetchSpy.fetch,
+      syncClientFactory: cap.factory,
+    });
+    await mgr.connect('idx-1');
+
+    const pending = mgr.waitForChange('idx-1', 'test.qmd', 5000);
+    // Simulate a remote edit arriving on the watched path.
+    cap.cbs().onFileChanged('test.qmd', 'hello world', []);
+
+    const res = await pending;
+    expect(res.changed).toBe(true);
+    expect(res.payload?.type).toBe('text');
+    expect((res.payload as { type: 'text'; text: string }).text).toBe('hello world');
+    expect(res.hash).toMatch(/^sha256:/);
+  });
+
+  it('times out with changed=false when nothing changes', async () => {
+    const fetchSpy = scriptedFetch([200]);
+    const cap = capturingSyncClientFactory();
+    const mgr = new ConnectionManager({
+      serverUrl: 'wss://hub.example.com/ws',
+      fetch: fetchSpy.fetch,
+      syncClientFactory: cap.factory,
+    });
+    await mgr.connect('idx-1');
+
+    const res = await mgr.waitForChange('idx-1', 'test.qmd', 20);
+    expect(res.changed).toBe(false);
+  });
+
+  it('returns immediately when since_hash differs from current (gap-close)', async () => {
+    const fetchSpy = scriptedFetch([200]);
+    const cap = capturingSyncClientFactory();
+    const mgr = new ConnectionManager({
+      serverUrl: 'wss://hub.example.com/ws',
+      fetch: fetchSpy.fetch,
+      syncClientFactory: cap.factory,
+    });
+    await mgr.connect('idx-1');
+
+    // No onFileChanged fired; current is the seeded 'hello'. A stale
+    // baseline hash means a change already happened in the gap → resolve now.
+    const res = await mgr.waitForChange('idx-1', 'test.qmd', 5000, 'sha256:stale');
+    expect(res.changed).toBe(true);
+    expect((res.payload as { type: 'text'; text: string }).text).toBe('hello');
+  });
+
+  it('ignores changes to other paths', async () => {
+    const fetchSpy = scriptedFetch([200]);
+    const cap = capturingSyncClientFactory();
+    const mgr = new ConnectionManager({
+      serverUrl: 'wss://hub.example.com/ws',
+      fetch: fetchSpy.fetch,
+      syncClientFactory: cap.factory,
+    });
+    await mgr.connect('idx-1');
+
+    const pending = mgr.waitForChange('idx-1', 'test.qmd', 40);
+    // A change to a different file must not satisfy the waiter.
+    cap.cbs().onFileChanged('other.qmd', 'nope', []);
+    const res = await pending;
+    expect(res.changed).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Redaction invariants
 // ---------------------------------------------------------------------------
 

--- a/ts-packages/quarto-hub-mcp/src/connection-manager.ts
+++ b/ts-packages/quarto-hub-mcp/src/connection-manager.ts
@@ -23,6 +23,8 @@
  * not require auth.
  */
 
+import { createHash } from 'node:crypto';
+
 import {
   createSyncClient,
   type SyncClient,
@@ -83,9 +85,58 @@ export interface ConnectionManagerDeps {
   readonly probePath?: string;
 }
 
+/**
+ * A one-shot listener registered by {@link ConnectionManager.waitForChange}.
+ * Fired (and removed) the next time the watched `path` changes.
+ */
+interface ChangeWaiter {
+  path: string;
+  fire: (payload: FilePayload | null) => void;
+}
+
 interface ProjectState {
   client: SyncClient;
   files: Map<string, FilePayload>;
+  /** Pending long-poll waiters, keyed implicitly by their `path` field. */
+  waiters: Set<ChangeWaiter>;
+}
+
+/**
+ * Result of a {@link ConnectionManager.waitForChange} long-poll.
+ * `changed: false` means the call timed out with no edit observed.
+ * `payload: null` means the file was removed.
+ */
+export interface ChangeResult {
+  changed: boolean;
+  payload: FilePayload | null;
+  /** sha256 (`sha256:<hex>`) of the payload, or null when absent/removed. */
+  hash: string | null;
+}
+
+/** Content hash used for the long-poll gap-close check. */
+function hashPayload(p: FilePayload | undefined | null): string | null {
+  if (!p) return null;
+  const h = createHash('sha256');
+  if (p.type === 'text') h.update(p.text, 'utf8');
+  else h.update(Buffer.from(p.data));
+  return `sha256:${h.digest('hex')}`;
+}
+
+/**
+ * Fire (and remove) every waiter registered for `path`, handing it the
+ * new payload (`null` on removal). Other paths' waiters are untouched.
+ */
+function fireWaiters(
+  waiters: Set<ChangeWaiter>,
+  path: string,
+  payload: FilePayload | null,
+): void {
+  for (const w of [...waiters]) {
+    if (w.path === path) {
+      waiters.delete(w);
+      w.fire(payload);
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -172,18 +223,25 @@ export class ConnectionManager {
     const auth = await this.resolveAuthForConnect();
 
     const files = new Map<string, FilePayload>();
+    const waiters = new Set<ChangeWaiter>();
     const callbacks: SyncClientCallbacks = {
       onFileAdded(path: string, file: FilePayload) {
         files.set(path, file);
+        fireWaiters(waiters, path, file);
       },
       onFileChanged(path: string, text: string, _patches: Patch[]) {
-        files.set(path, { type: 'text', text });
+        const payload: FilePayload = { type: 'text', text };
+        files.set(path, payload);
+        fireWaiters(waiters, path, payload);
       },
       onBinaryChanged(path: string, data: Uint8Array, mimeType: string) {
-        files.set(path, { type: 'binary', data, mimeType });
+        const payload: FilePayload = { type: 'binary', data, mimeType };
+        files.set(path, payload);
+        fireWaiters(waiters, path, payload);
       },
       onFileRemoved(path: string) {
         files.delete(path);
+        fireWaiters(waiters, path, null);
       },
       onError(err: Error) {
         console.error(
@@ -206,9 +264,54 @@ export class ConnectionManager {
       auth,
     );
 
-    const state: ProjectState = { client, files };
+    const state: ProjectState = { client, files, waiters };
     this.projects.set(indexDocId, state);
     return state;
+  }
+
+  /**
+   * Long-poll: resolve the next time `path` changes in the project, or
+   * after `timeoutMs` with `changed: false`. Connects first if needed.
+   *
+   * `sinceHash` closes the gap between polls: if the file already differs
+   * from the caller's last-known hash, the change is returned immediately
+   * (so an edit that lands between two `waitForChange` calls is never
+   * missed). Pass back the `hash` from the previous result each call.
+   */
+  async waitForChange(
+    indexDocId: string,
+    path: string,
+    timeoutMs: number,
+    sinceHash?: string,
+  ): Promise<ChangeResult> {
+    // Register the waiter synchronously when already connected so an edit
+    // arriving immediately after the call can't slip through the await gap.
+    // (First-time connects still pay one await; `sinceHash` covers that gap.)
+    const state = this.projects.get(indexDocId) ?? (await this.connect(indexDocId));
+
+    const current = state.files.get(path);
+    const currentHash = hashPayload(current);
+    // Gap-close: a change already happened relative to the caller's baseline.
+    if (sinceHash !== undefined && sinceHash !== currentHash) {
+      return { changed: true, payload: current ?? null, hash: currentHash };
+    }
+
+    return await new Promise<ChangeResult>((resolve) => {
+      let timer: ReturnType<typeof setTimeout>;
+      const waiter: ChangeWaiter = {
+        path,
+        fire: (payload) => {
+          clearTimeout(timer);
+          resolve({ changed: true, payload, hash: hashPayload(payload) });
+        },
+      };
+      state.waiters.add(waiter);
+      timer = setTimeout(() => {
+        state.waiters.delete(waiter);
+        const latest = state.files.get(path);
+        resolve({ changed: false, payload: latest ?? null, hash: hashPayload(latest) });
+      }, timeoutMs);
+    });
   }
 
   /**
@@ -222,18 +325,25 @@ export class ConnectionManager {
     const auth = await this.resolveAuthForConnect();
 
     const tempFiles = new Map<string, FilePayload>();
+    const waiters = new Set<ChangeWaiter>();
     const callbacks: SyncClientCallbacks = {
       onFileAdded(path: string, file: FilePayload) {
         tempFiles.set(path, file);
+        fireWaiters(waiters, path, file);
       },
       onFileChanged(path: string, text: string, _patches: Patch[]) {
-        tempFiles.set(path, { type: 'text', text });
+        const payload: FilePayload = { type: 'text', text };
+        tempFiles.set(path, payload);
+        fireWaiters(waiters, path, payload);
       },
       onBinaryChanged(path: string, data: Uint8Array, mimeType: string) {
-        tempFiles.set(path, { type: 'binary', data, mimeType });
+        const payload: FilePayload = { type: 'binary', data, mimeType };
+        tempFiles.set(path, payload);
+        fireWaiters(waiters, path, payload);
       },
       onFileRemoved(path: string) {
         tempFiles.delete(path);
+        fireWaiters(waiters, path, null);
       },
     };
 
@@ -248,7 +358,7 @@ export class ConnectionManager {
       auth,
     });
 
-    const state: ProjectState = { client, files: tempFiles };
+    const state: ProjectState = { client, files: tempFiles, waiters };
     this.projects.set(result.indexDocId, state);
     return { indexDocId: result.indexDocId, files: result.files };
   }

--- a/ts-packages/quarto-hub-mcp/src/hub-mcp.test.ts
+++ b/ts-packages/quarto-hub-mcp/src/hub-mcp.test.ts
@@ -45,6 +45,7 @@ describe('MCP protocol', () => {
       'patch_file',
       'read_file',
       'rename_file',
+      'wait_for_change',
       'write_file',
     ]);
   });
@@ -99,6 +100,7 @@ describe('MCP protocol (read-only mode)', () => {
       'connect_project',
       'list_files',
       'read_file',
+      'wait_for_change',
     ]);
   });
 

--- a/ts-packages/quarto-hub-mcp/src/tools.ts
+++ b/ts-packages/quarto-hub-mcp/src/tools.ts
@@ -79,6 +79,35 @@ function getReadTools(): Tool[] {
       },
       annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
     },
+    {
+      name: 'wait_for_change',
+      description:
+        'Long-poll: block until a file in the project is edited by any collaborator, then return its ' +
+        'new content. Returns as soon as a change is observed, or after `timeout_seconds` with ' +
+        '`changed: false` (re-call to keep watching). The result includes a `hash`; pass it back as ' +
+        '`since_hash` on the next call so an edit landing between calls is never missed. Lets an agent ' +
+        'react to a live collaborator without busy-polling read_file.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          project: { type: 'string', description: 'The automerge index document ID of the project' },
+          path: { type: 'string', description: 'The file path within the project to watch' },
+          timeout_seconds: {
+            type: 'number',
+            description: 'Max seconds to block before returning changed=false (default 25, clamped to 1-55)',
+            default: 25,
+          },
+          since_hash: {
+            type: 'string',
+            description:
+              'Optional hash from a prior result. If the file already differs from it, returns immediately ' +
+              '(closes the gap between polls).',
+          },
+        },
+        required: ['project', 'path'],
+      },
+      annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: false },
+    },
   ];
 }
 
@@ -198,6 +227,8 @@ async function handleTool(
       return handleListFiles(args, manager);
     case 'read_file':
       return handleReadFile(args, manager);
+    case 'wait_for_change':
+      return handleWaitForChange(args, manager);
     case 'write_file':
       return handleWriteFile(args, manager);
     case 'patch_file':
@@ -250,6 +281,46 @@ async function handleReadFile(args: ToolArgs, manager: ConnectionManager): Promi
     return error(`Error: ${path} is a binary file. Use read_binary_file_metadata instead.`);
   }
   return text(payload.text);
+}
+
+async function handleWaitForChange(args: ToolArgs, manager: ConnectionManager): Promise<CallToolResult> {
+  const project = args.project as string;
+  const path = args.path as string;
+  const rawTimeout = typeof args.timeout_seconds === 'number' ? args.timeout_seconds : 25;
+  const timeoutSec = Math.max(1, Math.min(55, rawTimeout));
+  const sinceHash = typeof args.since_hash === 'string' ? args.since_hash : undefined;
+
+  const result = await manager.waitForChange(project, path, timeoutSec * 1000, sinceHash);
+
+  if (!result.changed) {
+    return text(
+      JSON.stringify(
+        {
+          changed: false,
+          path,
+          hash: result.hash,
+          message: `No change within ${timeoutSec}s. Call wait_for_change again (pass this hash as since_hash) to keep watching.`,
+        },
+        null,
+        2,
+      ),
+    );
+  }
+  if (result.payload === null) {
+    return text(JSON.stringify({ changed: true, removed: true, path }, null, 2));
+  }
+  if (result.payload.type === 'binary') {
+    return text(
+      JSON.stringify(
+        { changed: true, path, type: 'binary', mimeType: result.payload.mimeType, hash: result.hash },
+        null,
+        2,
+      ),
+    );
+  }
+  return text(
+    JSON.stringify({ changed: true, path, hash: result.hash, content: result.payload.text }, null, 2),
+  );
 }
 
 async function handleWriteFile(args: ToolArgs, manager: ConnectionManager): Promise<CallToolResult> {


### PR DESCRIPTION
## What

Adds a `wait_for_change` tool to the Quarto Hub MCP server: a **long-poll** that blocks until a watched file is edited by any collaborator, then returns its new content. This lets an agent react to a live collaborator without busy-polling `read_file`.

```jsonc
wait_for_change({
  project: "<index-doc-id>",
  path: "report.qmd",
  timeout_seconds: 25,    // optional, clamped to 1–55
  since_hash: "sha256:…"  // optional — gap-close, see below
})
```

- Returns `{ changed: true, content, hash }` on an edit, or `{ changed: false, hash }` on timeout (caller just re-calls to keep watching).
- **`since_hash`** closes the gap between polls: if the file already differs from the caller's last-known hash, the call returns immediately — so an edit landing *between* two calls is never missed.
- Read-only tool; available even under `--read-only`.

## Why

Built for agent-in-the-loop collaborative-editing testing — having an agent edit a Hub doc as a second author while a human edits the same file. Polling `read_file` either busy-loops or, if throttled to the disk-flush cycle, lags ~30s. `wait_for_change` reacts in ~1s off the live Automerge sync stream the connection already receives.

## Implementation

`ConnectionManager.waitForChange()` registers a one-shot waiter against the existing `onFileChanged` / `onFileRemoved` sync callbacks and resolves with the new payload (or times out). No new sync machinery — it taps the live `files` map the manager already maintains.

## Tests

- 4 new `ConnectionManager` unit tests: resolve-on-change, timeout, gap-close via `since_hash`, and other-path isolation.
- Protocol tests updated to assert the tool is registered (read-write + read-only lists) — these spawn the real built `dist/index.js`.
- Full suite: **163 passing, 2 skipped**.
- **Verified live end-to-end** against a running hub: watch → collaborator edits in the browser → agent appends to the doc → re-arm, across several rounds, no misses.

## Docs

README gains a **Tools** section documenting every tool, with a subsection on `wait_for_change` semantics (long-poll + `since_hash`).

## Notes / follow-ups (not in this PR)

- Wiring this package's vitest suite into CI is tracked by #250 ("Wire most workspace TS test suites into CI"), which already lists `quarto-hub-mcp` among the suites to fold in. The network-dependent `live:` tests here (they hit `sync.automerge.org`) will need gating when that happens.
- A live two-client integration test (mirroring `sync-test-harness/concurrent-editing.test.ts`) would complement the unit tests; deferred.
