### PR TITLE
fix(install.ps1): use throw instead of Write-Error in Die()

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -36,7 +36,7 @@ $Repo = 'q2'
 $Platform = 'windows_amd64'
 $UA = @{ 'User-Agent' = 'q2-install' }
 
-function Die([string]$msg) { Write-Error "q2 install: $msg"; exit 1 }
+function Die([string]$msg) { throw "q2 install: $msg" }
 function Step([string]$msg) { Write-Host "-> $msg" }
 
 # q2 ships an x86_64 Windows binary; ARM64 Windows runs it under


### PR DESCRIPTION
With `$ErrorActionPreference = 'Stop'`, `Write-Error` throws immediately and `exit 1` is dead code. In an `irm | iex` session, `exit 1` (if it were reached) would close the user's interactive PowerShell window; `throw` is the safe idiom for embedded execution and produces a cleaner error message.