### PR TITLE
fix(hub-mcp): quote OAuth URL when opening browser on Windows

### DIFF
--- a/ts-packages/quarto-hub-mcp/src/auth/browser.test.ts
+++ b/ts-packages/quarto-hub-mcp/src/auth/browser.test.ts
@@ -3,6 +3,7 @@
  * one) and abort-kills-subprocess behaviour.
  */
 
+import { spawnSync } from 'node:child_process';
 import { EventEmitter } from 'node:events';
 import { describe, it, expect, vi } from 'vitest';
 
@@ -16,6 +17,7 @@ describe('browserOpenSpec', () => {
     expect(browserOpenSpec('darwin', URL_WITH_AMP)).toEqual({
       command: 'open',
       args: [URL_WITH_AMP],
+      windowsVerbatimArguments: false,
     });
   });
 
@@ -23,16 +25,50 @@ describe('browserOpenSpec', () => {
     expect(browserOpenSpec('linux', URL_WITH_AMP)).toEqual({
       command: 'xdg-open',
       args: [URL_WITH_AMP],
+      windowsVerbatimArguments: false,
     });
   });
 
-  it('uses cmd.exe /c start "" "<url>" on Windows', () => {
-    // The empty placeholder title and the single quoted URL argv element
-    // are what keep `&` from being treated as a statement separator.
+  it('quotes the URL and passes argv verbatim on Windows', () => {
+    // The URL must be wrapped in literal double quotes so `cmd.exe`
+    // leaves `&` alone; Node would not quote it otherwise (no spaces),
+    // and a bare `&` splits the command, dropping `redirect_uri`.
     expect(browserOpenSpec('win32', URL_WITH_AMP)).toEqual({
       command: 'cmd.exe',
-      args: ['/c', 'start', '', URL_WITH_AMP],
+      args: ['/c', 'start', '""', `"${URL_WITH_AMP}"`],
+      windowsVerbatimArguments: true,
     });
+  });
+});
+
+// Regression guard for the "Missing required parameter: redirect_uri"
+// bug: an OAuth URL pushed through `cmd.exe` must survive its `&`
+// statement-separator parsing intact. Runs only on Windows, where the
+// real `cmd.exe` is available.
+describe.runIf(process.platform === 'win32')('Windows cmd.exe arg passing', () => {
+  it('preserves the full URL through cmd.exe (no & truncation)', () => {
+    const url = new URL('https://accounts.google.com/o/oauth2/v2/auth');
+    url.searchParams.set('response_type', 'code');
+    url.searchParams.set('client_id', 'x.apps.googleusercontent.com');
+    url.searchParams.set('redirect_uri', 'http://127.0.0.1:53017/callback');
+    url.searchParams.set('scope', 'openid email profile');
+    url.searchParams.set('state', 'abc');
+    const full = url.toString();
+
+    const spec = browserOpenSpec('win32', full);
+    // Echo the trailing argv (the `""` placeholder title + the quoted
+    // URL) that the real command passes to `start`, instead of launching
+    // a browser. If `&` split the command, stderr would carry
+    // "'client_id' is not recognized" and stdout would be truncated; if
+    // the URL weren't quoted, the placeholder/URL token boundary would
+    // collapse. We assert both survive intact.
+    const trailing = spec.args.slice(2); // ['""', '"<url>"']
+    const r = spawnSync('cmd.exe', ['/c', 'echo', ...trailing], {
+      encoding: 'utf8',
+      windowsVerbatimArguments: spec.windowsVerbatimArguments,
+    });
+    expect(r.stderr).toBe('');
+    expect(r.stdout.trim()).toBe(`"" "${full}"`);
   });
 });
 

--- a/ts-packages/quarto-hub-mcp/src/auth/browser.ts
+++ b/ts-packages/quarto-hub-mcp/src/auth/browser.ts
@@ -13,6 +13,13 @@ import { spawn, type ChildProcess } from 'node:child_process';
 export interface BrowserOpenSpec {
   readonly command: string;
   readonly args: readonly string[];
+  /**
+   * Whether to spawn with `windowsVerbatimArguments`. Only the Windows
+   * spec sets this `true`: it has already wrapped the URL in literal
+   * double quotes, so Node must pass argv through verbatim rather than
+   * re-quoting it.
+   */
+  readonly windowsVerbatimArguments: boolean;
 }
 
 /**
@@ -23,7 +30,20 @@ export interface BrowserOpenSpec {
  *
  * Two gotchas the naive `start <url>` form gets wrong:
  *   1. `cmd.exe` treats `&` as a statement separator and OAuth URLs are
- *      dense with `&`; quoting the URL prevents that interpretation.
+ *      dense with `&`. The URL must reach `cmd.exe` wrapped in double
+ *      quotes so the `&` stays literal. Node's default
+ *      (`windowsVerbatimArguments: false`) only quotes an argv element
+ *      when it contains a space, tab, or `"` — an OAuth URL contains
+ *      none of those, so Node leaves it bare and `cmd.exe` splits the
+ *      command at the first `&` (dropping `redirect_uri` and everything
+ *      after it). We therefore quote the URL ourselves and pass argv
+ *      verbatim. Double quotes neutralise `&`, `|`, `<`, `>`, `(`, `)`
+ *      but NOT `%`: `cmd.exe` still performs `%VAR%` expansion inside
+ *      quotes. The percent-encoded URL (`%3A`, `%2F`, …) survives only
+ *      because no environment variable is named like a two-hex-digit
+ *      token (`3A`, `2F`, …). That holds for every real Windows
+ *      environment; the dynamic URL fields (`state`, `code_challenge`)
+ *      are base64url and never contain `%` at all.
  *   2. `start`'s first *quoted* argument is the window title, not the
  *      URL. The empty `""` is a placeholder title so the quoted URL is
  *      parsed as the target.
@@ -31,12 +51,16 @@ export interface BrowserOpenSpec {
 export function browserOpenSpec(platform: NodeJS.Platform, url: string): BrowserOpenSpec {
   switch (platform) {
     case 'darwin':
-      return { command: 'open', args: [url] };
+      return { command: 'open', args: [url], windowsVerbatimArguments: false };
     case 'win32':
-      return { command: 'cmd.exe', args: ['/c', 'start', '', url] };
+      return {
+        command: 'cmd.exe',
+        args: ['/c', 'start', '""', `"${url}"`],
+        windowsVerbatimArguments: true,
+      };
     default:
       // Linux and other Unix-likes.
-      return { command: 'xdg-open', args: [url] };
+      return { command: 'xdg-open', args: [url], windowsVerbatimArguments: false };
   }
 }
 
@@ -60,14 +84,16 @@ export interface OpenBrowserOptions {
 export function openBrowser(url: string, opts: OpenBrowserOptions = {}): ChildProcess | undefined {
   const platform = opts.platform ?? process.platform;
   const spawnFn = opts.spawnFn ?? spawn;
-  const { command, args } = browserOpenSpec(platform, url);
+  const { command, args, windowsVerbatimArguments } = browserOpenSpec(platform, url);
   let child: ChildProcess;
   try {
     child = spawnFn(command, args as string[], {
       stdio: 'ignore',
-      // Single argv element per arg, no shell — the URL is never passed
-      // through a shell that could re-interpret its metacharacters.
-      windowsVerbatimArguments: false,
+      // No shell is involved on any platform. On Windows the URL is
+      // pre-quoted in the argv (see browserOpenSpec) and must be passed
+      // verbatim so `cmd.exe` sees the literal double quotes that keep
+      // `&` from splitting the command.
+      windowsVerbatimArguments,
     });
   } catch {
     return undefined;


### PR DESCRIPTION
On Windows, `q2 mcp`'s `authenticate` tool opened the browser to a truncated Google authorization URL — everything after the first `&` was dropped — so sign-in failed with "Erreur 400 : invalid_request — Missing required parameter: redirect_uri" before the user could authenticate.

## Root Cause

The browser launcher built `cmd.exe /c start "" <url>` and spawned it with `windowsVerbatimArguments: false`. Node only wraps an argv element in double quotes when it contains a space, tab, or `"`; an OAuth URL has none of those, so the URL reached `cmd.exe` bare. `cmd.exe` then treats `&` as a statement separator and split the command at the first one, dropping `redirect_uri` and every later parameter before `start` ever saw them.

## Fix

Quote the URL and spawn with `windowsVerbatimArguments: true` so the `&` separators stay literal. Double quotes do not neutralise cmd's `%VAR%` expansion, but the percent-encoded URL is safe because no real environment variable is named like a two-hex-digit token, and the dynamic base64url fields (`state`, `code_challenge`) contain no `%`.

## Test Plan

- [x] `npm test -- src/auth/browser.test.ts` in `ts-packages/quarto-hub-mcp` passes, including the Windows-only cmd.exe round-trip regression test
- [x] On Windows, the `authenticate` browser opens the full URL (`redirect_uri`/`client_id`/`scope` present) instead of truncating at the first `&`