### PR TITLE
fix(xtask): run npm through cmd /C so it resolves on Windows

### DIFF
--- a/crates/xtask/src/build_all.rs
+++ b/crates/xtask/src/build_all.rs
@@ -18,7 +18,6 @@
 
 use anyhow::{Context, Result, bail};
 use std::path::Path;
-use std::process::Command;
 
 /// Configuration for the build-all command.
 #[derive(Default)]
@@ -248,13 +247,13 @@ fn run_command(
     rustflags: Option<&str>,
     error_msg: &str,
 ) -> Result<()> {
-    let mut cmd = Command::new(program);
-    cmd.args(args).current_dir(dir);
-    // Nested cargo/npm: strip the outer `cargo xtask`'s package env vars so a
+    // `nested_command` strips the outer `cargo xtask`'s package env vars so a
     // child cargo doesn't spuriously rebuild q2's TLS-stack closure (an
-    // inherited CARGO_MANIFEST_DIR flips the `ring` build script dirty). See
-    // `util::strip_inherited_cargo_env` (bd-awchm8w7).
-    crate::util::strip_inherited_cargo_env(&mut cmd);
+    // inherited CARGO_MANIFEST_DIR flips the `ring` build script dirty;
+    // bd-awchm8w7), and on Windows runs `.cmd` shims like npm through `cmd /C`
+    // so they resolve at all.
+    let mut cmd = crate::util::nested_command(program);
+    cmd.args(args).current_dir(dir);
 
     if let Some(flags) = rustflags {
         cmd.env("RUSTFLAGS", flags);

--- a/crates/xtask/src/build_hub_mcp_bundle.rs
+++ b/crates/xtask/src/build_hub_mcp_bundle.rs
@@ -16,7 +16,8 @@
 
 use anyhow::{Context, Result, bail};
 use std::path::PathBuf;
-use std::process::Command;
+
+use crate::util::nested_command;
 
 pub fn run() -> Result<()> {
     let project_root = find_project_root()?;
@@ -29,7 +30,7 @@ pub fn run() -> Result<()> {
     }
 
     println!("━━━ Building quarto-hub-mcp bundle ━━━");
-    let status = Command::new("npm")
+    let status = nested_command("npm")
         .args(["run", "bundle"])
         .current_dir(&pkg_dir)
         .status()

--- a/crates/xtask/src/build_q2_preview_spa.rs
+++ b/crates/xtask/src/build_q2_preview_spa.rs
@@ -9,7 +9,8 @@
 
 use anyhow::{Context, Result, bail};
 use std::path::PathBuf;
-use std::process::Command;
+
+use crate::util::nested_command;
 
 pub fn run() -> Result<()> {
     let project_root = find_project_root()?;
@@ -22,7 +23,7 @@ pub fn run() -> Result<()> {
     }
 
     println!("━━━ Building q2-preview-spa ━━━");
-    let status = Command::new("npm")
+    let status = nested_command("npm")
         .args(["run", "build"])
         .current_dir(&spa_dir)
         .status()

--- a/crates/xtask/src/build_trace_viewer.rs
+++ b/crates/xtask/src/build_trace_viewer.rs
@@ -6,7 +6,8 @@
 
 use anyhow::{Context, Result, bail};
 use std::path::PathBuf;
-use std::process::Command;
+
+use crate::util::nested_command;
 
 pub fn run() -> Result<()> {
     let project_root = find_project_root()?;
@@ -19,7 +20,7 @@ pub fn run() -> Result<()> {
     }
 
     println!("━━━ Building trace-viewer SPA ━━━");
-    let status = Command::new("npm")
+    let status = nested_command("npm")
         .args(["run", "build"])
         .current_dir(&trace_viewer_dir)
         .status()

--- a/crates/xtask/src/util.rs
+++ b/crates/xtask/src/util.rs
@@ -77,12 +77,42 @@ pub fn strip_inherited_cargo_env(cmd: &mut Command) -> &mut Command {
     cmd
 }
 
+/// Programs that on Windows ship as `.cmd`/`.bat` shims rather than a
+/// `.exe` (npm, npx, …). `Command::new("npm")` fails on Windows with
+/// "program not found": the bare name carries no extension and
+/// `std::process::Command` does NOT search `PATHEXT` to discover the
+/// `.cmd` (only `.exe` may be specified without its extension). The
+/// established fix — used by Tauri's `cross_command` and wasm-pack's
+/// `new_command` — is to trampoline through `cmd /C <program>`, letting
+/// Windows resolve the real `npm.cmd` via `PATHEXT`. Our args are
+/// trusted literals, so the `cmd.exe`/`.bat` argument-escaping hazard
+/// (CVE-2024-24576) does not apply.
+#[cfg(windows)]
+const WINDOWS_CMD_SHIMS: &[&str] = &["npm", "npx"];
+
 /// Construct a [`Command`] for `program` with the inherited cargo package env
 /// vars already stripped (see [`strip_inherited_cargo_env`]). This is the
 /// preferred constructor for any nested `cargo`/`npm` invocation from an xtask
 /// subcommand.
+///
+/// On Windows a `program` that is a `.cmd` shim (see [`WINDOWS_CMD_SHIMS`])
+/// is run through `cmd /C` so it resolves at all; `.exe` programs such as
+/// `cargo` are invoked directly.
 pub fn nested_command(program: &str) -> Command {
-    let mut cmd = Command::new(program);
+    let mut cmd;
+    #[cfg(windows)]
+    {
+        if WINDOWS_CMD_SHIMS.contains(&program) {
+            cmd = Command::new("cmd");
+            cmd.args(["/C", program]);
+        } else {
+            cmd = Command::new(program);
+        }
+    }
+    #[cfg(not(windows))]
+    {
+        cmd = Command::new(program);
+    }
     strip_inherited_cargo_env(&mut cmd);
     cmd
 }
@@ -140,6 +170,29 @@ mod tests {
         let cmd = nested_command("cargo");
         let env = env_overrides(&cmd);
         assert_eq!(env.get("CARGO_MANIFEST_DIR"), Some(&None));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn nested_command_trampolines_npm_through_cmd_on_windows() {
+        // `Command::new("npm")` cannot find `npm.cmd` on Windows; the
+        // program must become `cmd /C npm` so PATHEXT resolves the shim.
+        let cmd = nested_command("npm");
+        assert_eq!(cmd.get_program(), "cmd");
+        let args: Vec<_> = cmd
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(args, vec!["/C", "npm"]);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn nested_command_leaves_exe_programs_direct_on_windows() {
+        // `cargo` is a real `.exe`; it must not be wrapped in `cmd /C`.
+        let cmd = nested_command("cargo");
+        assert_eq!(cmd.get_program(), "cargo");
+        assert_eq!(cmd.get_args().count(), 0);
     }
 
     #[test]

--- a/crates/xtask/src/verify.rs
+++ b/crates/xtask/src/verify.rs
@@ -21,7 +21,6 @@
 //! 14. q2-preview-spa Playwright E2E (only when --e2e is set)
 
 use anyhow::{Context, Result, bail};
-use std::process::Command;
 
 use crate::lint;
 use crate::test;
@@ -602,13 +601,13 @@ fn run_command(
     rustflags: Option<&str>,
     error_msg: &str,
 ) -> Result<()> {
-    let mut cmd = Command::new(program);
-    cmd.args(args).current_dir(dir);
-    // Nested cargo/npm: strip the outer `cargo xtask`'s package env vars so a
+    // `nested_command` strips the outer `cargo xtask`'s package env vars so a
     // child cargo doesn't spuriously rebuild q2's TLS-stack closure (an
-    // inherited CARGO_MANIFEST_DIR flips the `ring` build script dirty). See
-    // `util::strip_inherited_cargo_env` (bd-awchm8w7).
-    crate::util::strip_inherited_cargo_env(&mut cmd);
+    // inherited CARGO_MANIFEST_DIR flips the `ring` build script dirty;
+    // bd-awchm8w7), and on Windows runs `.cmd` shims like npm through `cmd /C`
+    // so they resolve at all.
+    let mut cmd = crate::util::nested_command(program);
+    cmd.args(args).current_dir(dir);
 
     if let Some(flags) = rustflags {
         cmd.env("RUSTFLAGS", flags);


### PR DESCRIPTION
On Windows, every npm-spawning xtask subcommand fails with "program not found": `build-hub-mcp-bundle`, `build-q2-preview-spa`, `build-trace-viewer`, `build-all`, and `verify`. npm ships as `npm.cmd`, and Rust's `std::process::Command` does not search `PATHEXT` or resolve an extensionless name to its `.cmd` shim — only `.exe` may omit its extension. The Mac/Linux CI never exercised this path, so it went unnoticed.

## Fix

Trampoline npm through `cmd /C npm`, letting Windows resolve the real shim via `PATHEXT`. This matches what Tauri (`cross_command`) and wasm-pack (`new_command`) settled on, both having explicitly rejected appending `.cmd`. The logic is centralized in `util::nested_command` behind a small shim allowlist, so `.exe` programs such as cargo are still invoked directly and every call site keeps passing the bare name.

The npm args here are trusted literals, so the cmd/.bat argument-escaping hazard (CVE-2024-24576) does not apply.

## Test Plan

- [x] On Windows, `cargo xtask build-hub-mcp-bundle` runs npm (previously "program not found")
- [ ] On macOS/Linux, npm-spawning xtask commands still work and cargo is unaffected
- [x] `cargo nextest run -p xtask` passes