### PR TITLE
RevealJS themes & authoring features: Quarto 1 → Quarto 2 (reveal.js 6)

### DIFF
--- a/claude-notes/plans/2026-06-16-revealjs-themes-q1-to-q2.md
+++ b/claude-notes/plans/2026-06-16-revealjs-themes-q1-to-q2.md
@@ -2,10 +2,10 @@
 
 **Strand:** bd-yown2ts4
 **Branch:** `feature/revealjs-q1-themes` (epic integration line; stages land on sub-branches)
-**Status (2026-06-16):** Stages A/B/C **merged** to `feature/revealjs-q1-themes`.
-Stage D (bd-j8qoyc0s) in progress on branch `beads/bd-j8qoyc0s-reveal-brand-callouts`
-(off feature, **unmerged**): D1 callouts + D2 brand done; **D3/D4/D5 remain** —
-see "## Handoff for next session" at the bottom.
+**Status (2026-06-16):** Stages A/B/C **and** Stage D's D1 (callouts) + D2 (brand)
+are merged to `feature/revealjs-q1-themes`, which is **pushed to `origin`**.
+Stage D (bd-j8qoyc0s) continues: **D3/D4/D5 remain** — see "## Handoff for next
+session" at the bottom (a fresh-clone agent branches off `feature` for these).
 
 ---
 
@@ -15,11 +15,14 @@ see "## Handoff for next session" at the bottom.
 key context is above. Repo: `/Users/cscheid/rooms/room-1/q2`.
 
 ### Where things are
-- On disk you should be (or `git switch` to) branch
-  **`beads/bd-j8qoyc0s-reveal-brand-callouts`** (off `feature/revealjs-q1-themes`).
-  Stages A/B/C are merged to `feature`; D1+D2 are committed on this branch but
-  **NOT yet merged**. Check `git log --oneline -6`; latest D commits are
-  `ebbdd732` (D1 callouts), `a80b28de` (D2 brand).
+- **Stages A/B/C AND Stage D's D1+D2 are all merged to `feature/revealjs-q1-themes`,
+  which is pushed to `origin` (quarto-dev/q2).** Clone the repo, `git checkout
+  feature/revealjs-q1-themes`, and **create a fresh continuation branch off it**
+  for the rest of Stage D (e.g. `git switch -c beads/bd-j8qoyc0s-reveal-stage-d-cont`).
+  (The original local `beads/bd-j8qoyc0s-reveal-brand-callouts` branch is not
+  pushed; its content equals `feature` now that D1/D2 are merged.)
+- Latest D commits on `feature`: `ebbdd732` (D1 callouts), `a80b28de` (D2 brand),
+  then plan/handoff doc commits + the Stage-D merge commit. `git log --oneline -8`.
 - **Done:** D1 callouts (pure SCSS), D2 `_brand.yml` (config plumbing). See the
   Stage D checklist above for exactly what landed.
 - **Remaining: D3 (footer/logo), D4 (auto-stretch), D5 (docs).** Both D3 and D4
@@ -92,9 +95,11 @@ key context is above. Repo: `/Users/cscheid/rooms/room-1/q2`.
   runs for `q2-slides`; check `pipeline.rs` `Q2_PREVIEW_TRANSFORM_EXCLUDED`
   (~line 1314). The *styling* still won't be in preview. State this honestly when
   reporting "done".
-- **Git**: branch is off `feature/revealjs-q1-themes`. When Stage D is complete,
-  merge `--no-ff` into feature and `braid close bd-j8qoyc0s`. **Never push without
-  explicit user permission.** Commit message trailer:
+- **Git**: branch your continuation off `feature/revealjs-q1-themes`. When the
+  remaining Stage D work is complete, merge `--no-ff` into `feature` and
+  `braid close bd-j8qoyc0s`. `feature` is already on `origin`; **push only with
+  explicit user permission** (the D1/D2 push was explicitly authorized — don't
+  assume standing permission for D3+). Commit message trailer:
   `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
 
 ### Key files

--- a/claude-notes/plans/2026-06-16-revealjs-themes-q1-to-q2.md
+++ b/claude-notes/plans/2026-06-16-revealjs-themes-q1-to-q2.md
@@ -494,16 +494,34 @@ TDD; commit per increment._
       green. **Deferred to Stage D** (need markup/consumer/plugins): light/dark
       sentinel, footer/logo, panels/tabsets, callouts, code-annotation, tippy.
 
-### Stage D — brand + callouts + parity hardening + docs (bd-j8qoyc0s)
-- [ ] `_brand.yml` integration; **callouts** (the big one — depends on the C2 helper
-      foundation + revealjs callout AST output, bd-1kor9); panels/tabsets
-- [ ] Fancy title slide (authors/affiliations/ORCID/email — needs author-metadata
-      normalization); `logo:`/`footer:`; `auto-stretch`; reveal plugin foundation
-      (menu/notes/line-highlight) — from the 2026-06-16 audit backlog
-- [ ] Render/preview parity hardening; keep the vendored-asset drift guard meaningful
-- [ ] **Docs (D1 caveat):** user-facing guide on the theming variables and a
-      "migrating a Quarto-1 revealjs theme to Q2" how-to, incl. the `--r-*`
-      runtime escape hatch (docs/ site — render with `q2`, not Q1). Open a doc strand.
+### Stage D — brand + callouts + title/footer/logo + docs (bd-j8qoyc0s)
+
+**Scope set 2026-06-16** after the audit. Three audit items are **deferred to
+their own strands** (not part of Stage D):
+- light/dark theme integration → **bd-904h9kmt** (Q2 lacks Q1's light/dark
+  story broadly; the `/*! dark */` sentinel waits on that design).
+- code-annotation styling → **bd-h176qcgp** (wants dedicated design time).
+- reveal plugin foundation (menu/notes/line-highlight) → **bd-buwhvpc2**.
+
+Remaining Stage D scope (concrete decomposition pending the prerequisite
+investigation, 2026-06-16):
+- [ ] **Callouts** — the highest-value "feels like Quarto" element (helper
+      foundation from C2 is in place). Verify whether Q2 emits `.callout` markup
+      for reveal first (else AST work; cf. bd-1kor9).
+- [ ] **`_brand.yml` integration** — thread a resolved brand layer into
+      `assemble_reveal_scss` (quarto-sass `brand_layer.rs` has reveal hooks).
+- [ ] **Fancy title slide** — authors/affiliations/ORCID/email (likely needs
+      author-metadata normalization).
+- [ ] **`footer:` / `logo:`** — markup injection (reveal transform) + SCSS.
+- [ ] **`auto-stretch`** (default on in Q1) — single-image slides → `.r-stretch`.
+- [ ] **panels/tabsets** SCSS (state TBD by investigation).
+- [ ] Render/preview parity hardening; keep the vendored-asset drift guard meaningful.
+- [ ] **Docs (D1 caveat):** user-facing guide on the theming variables + a
+      "migrating a Quarto-1 revealjs theme to Q2" how-to incl. the `--r-*` runtime
+      escape hatch (docs/ site — render with `q2`, not Q1). Open a doc strand.
+
+_(A concrete per-increment decomposition + branch will be added once the
+prerequisite investigation lands.)_
 
 ---
 

--- a/claude-notes/plans/2026-06-16-revealjs-themes-q1-to-q2.md
+++ b/claude-notes/plans/2026-06-16-revealjs-themes-q1-to-q2.md
@@ -1,0 +1,360 @@
+# RevealJS themes: Quarto 1 → Quarto 2 (reveal.js 6)
+
+**Strand:** bd-yown2ts4
+**Branch:** `feature/revealjs-q1-themes` (epic integration line; stages land on sub-branches)
+**Status:** Study phase + toolchain experiment complete; decisions D1–D5 resolved
+(2026-06-16). **Awaiting user go-ahead to begin Stage A implementation.**
+
+## Overview
+
+Quarto 2 ships reveal.js 6 but currently exposes only a single precompiled
+`white.css` and no SCSS theme-layer system. For Quarto 1 users the output
+feels unfamiliar — title-slide placement, bullet-point alignment, and the
+general theme set all differ from what they're used to. The goal of this work
+is to bring Quarto 1's revealjs themes and theming **defaults** into Quarto 2
+so the output feels "at home" for Q1 users — *not* a pixel-perfect port, but
+close enough in feel.
+
+### The adaptation diagram
+
+```
+"native" reveal.js 5 themes  --adapted into-->  Quarto 1
+"native" reveal.js 6 themes  --used directly-->  Quarto 2   (← the problem)
+```
+
+We want a theming system for reveal.js 6 that feels native to Quarto 2 — an
+arrow **Quarto 1 → Quarto 2**. To draw that arrow well we must also understand
+the **reveal.js 5 → 6** relationship, so the "used directly" arrow for Q2 can
+become an "adapted into" arrow in the same sense Q1 adapted reveal 5.
+
+---
+
+## Assessment (study phase, 2026-06-16)
+
+Three parallel source studies: Q2's current state, reveal.js 5→6 theming
+differences, and how Q1 adapts reveal themes. The findings converge cleanly.
+
+### 0. Versions
+
+| | reveal.js | Theming approach |
+|---|---|---|
+| **Quarto 1** | **5.1.0** (vendored) | full SCSS layer system + 12 adapted themes + 1116-line `quarto.scss` |
+| **Quarto 2 (now)** | **6.0.0** (vendored) | precompiled stock `white.css` only; reveal bypasses SCSS entirely |
+| reveal latest 5.x | 5.2.1 | — |
+| reveal target | 6.0.1 | — |
+
+### 1. What Quarto 2 has today
+
+- **reveal branch short-circuits before SCSS.** `CompileThemeCssStage`
+  (`crates/quarto-core/src/stage/stages/compile_theme_css.rs:267-276`) returns
+  immediately for `FormatIdentifier::Revealjs`, calling
+  `register_reveal_assets` and skipping the entire Bootstrap/SCSS path.
+- **One theme, hardcoded.** `resolve_theme_name`
+  (`crates/quarto-core/src/revealjs/assemble.rs:43-48`) collapses *every* theme
+  name to `"white"`. Any `theme:` value renders as white.
+- **The only Quarto-authored reveal CSS is 1.5 KB.** `quarto-reveal.css` has
+  `.columns`/`.column`, `.aside`, and footnote rules — **no title-slide rules,
+  no list/bullet rules.** So title placement and bullet alignment come purely
+  from reveal core + stock `white.css` defaults. *That is exactly why they feel
+  un-Quarto.*
+- **Assets are vendored + linked, not compiled.** `assemble.rs` embeds
+  `reset.css`, `reveal.css`, `theme/white.css`, `quarto-reveal.css`,
+  `reveal.js` via `include_str!`, registered as cascade-ordered artifacts
+  (`1-reset → 2-reveal → 3-theme-<name> → 4-quarto-reveal`).
+- **Q2 *does* have a full SCSS subsystem** — the `quarto-sass` crate — with the
+  exact same 5-region layer machinery as Q1 (`uses`/`functions`/`defaults`/
+  `mixins`/`rules`, with `defaults` reversed so higher-priority `!default`
+  wins; `crates/quarto-sass/src/layer.rs`, `bundle.rs`). It compiles via
+  `grass` natively and dart-sass on WASM. **But it is Bootstrap-centric** —
+  `assemble_scss` always loads the Bootstrap framework layer + Quarto layer. It
+  is wired for `format: html`, never for reveal.
+- **Hard constraint — render/preview parity.** `q2 render` links the vendored
+  CSS; `q2 preview` uses `@revealjs/react` importing the npm `reveal.js`. A
+  drift-guard test (`assemble.rs:377-404`) asserts the vendored assets are
+  byte-identical to the npm package. Any theming mechanism must serve both
+  paths.
+- **Existing roadmap.** `claude-notes/plans/2026-06-08-revealjs-presentations.md`
+  explicitly deferred "Full Quarto-1 `quarto.scss` + 12-theme + brand parity"
+  to **Phase 7 — Theming parity**, noting Q1 is on reveal 5.1.0 and the SCSS
+  must be ported forward. **This plan is that Phase 7.**
+
+### 2. reveal.js 5 → 6: what changed for theming
+
+**The visual output of stock themes is essentially unchanged.** Same colors,
+same layout, same core CSS. No themes added or removed (dracula, black-contrast,
+white-contrast were *already* in 5.2.1). Core `reveal.scss`/`layout.scss` diffs
+are almost entirely Prettier reformatting + Sass-module compliance — **no layout
+drift**. So "feels different" is **not** caused by reveal core changing.
+
+What *did* change is **how themes are authored/compiled** (compile-time only):
+
+| Change | 5.x | 6.x | Impact |
+|---|---|---|---|
+| Sass variable names | `$backgroundColor`, `$mainColor`, `$headingColor`… (camelCase) | `$background-color`, `$main-color`, `$heading-color`… (**kebab-case**) | ⚠ breaking for any code that sets reveal vars |
+| Theme authoring API | `@import "template/settings"` + reassign globals | `@use 'template/settings' with (...)` (module system) | ⚠ breaking |
+| `:root` exposer | separate `template/exposer.scss` | folded into `settings.scss` | path reference gone |
+| Theme dir layout | `css/theme/source/*.scss` | `css/theme/*.scss` (flattened) | path change |
+| Background | single `$backgroundColor` + `bodyBackground()` mixin | split `$background` (shorthand/gradient) + `$background-color` (solid); mixin removed | gradients via var now |
+| Gradient mixins | `radial-gradient()` etc. (vendor shims) | removed; use native CSS | minor |
+| Build | Gulp + legacy `sass.render` | Vite + modern compiler | Q2 uses `grass`/dart-sass, irrelevant |
+
+**The runtime `--r-*` CSS custom-property contract is STABLE 5↔6** (only net
+addition: `--r-background`). reveal 6's `theme.scss` styles everything in terms
+of `var(--r-*)`, which `settings.scss` emits into `:root`. A theme that
+overrides `--r-*` is forward-compatible across both versions.
+
+> ✅ **Toolchain verified (2026-06-16).** The "⚠ breaking" above is about *Q1's
+> hand-written themes* needing migration — **not** about our compiler. We run
+> `grass` 0.13.4 natively (dart-sass on WASM). A throwaway probe compiled **all
+> 14 reveal-6 stock themes** through `grass::from_string` with the reveal theme
+> dir on the load path. Every theme compiled, exercising the full reveal-6
+> module API: `@use 'template/settings' with (...)` (configured modules),
+> `@use 'sass:color'` + `color.scale()`, namespaced `@use 'template/mixins' as
+> mixins` + `@include mixins.dark-bg-text-color()`, and `@import url(...)`
+> passthrough. Output was correct (`white` → `--r-main-color:#222`,
+> `--r-heading-text-transform:uppercase`, etc.). So `grass`'s module support is
+> sufficient for reveal 6; the migration cost is on the *content* of Q1's
+> themes, not on the build. (Probe deleted after recording; reproduce by
+> compiling `external-sources/reveal.js/css/theme/*.scss` with that dir as a
+> load path.)
+>
+> ⚠ **Implementation note for Stage A:** reveal 6's `@use 'template/settings'
+> with (...)` needs configuration values *at the `@use` site*, which fights our
+> layered-`!default` merge model (where higher-priority layers override via
+> `!default` reversal). Q1 sidestepped this by **not** using reveal's
+> `settings.scss` as a framework layer — it hand-ported settings into
+> `quarto.scss`. We will likely do the same: port reveal 6's `settings.scss`
+> `:root{--r-*}` emission into our Quarto reveal layer (now trivially
+> kebab-case), and use reveal's `theme.scss` as the rules framework. This is a
+> Stage-A design detail, not a blocker.
+
+### 3. How Quarto 1 adapts reveal themes (the arrow we're copying)
+
+- **5-region layered SCSS** (identical convention to Q2's `quarto-sass`).
+- **Q1 invents its own kebab-case vocabulary** (`$body-bg`, `$body-color`,
+  `$presentation-heading-color`, `$presentation-slide-text-align`, …) in the
+  `scss:defaults` layer, then `quarto.scss` **maps those to reveal 5's
+  camelCase** (`$backgroundColor`, `$headingColor`, …). Per-theme files never
+  touch reveal's variable names.
+- **Adapted themes are minimal.** `default.scss` is one line; `dark.scss` is
+  four vars; `league.scss`/`dracula.scss` are the elaborate ones. Theme
+  resolution aliases `white→default`, `black→dark`.
+- **`quarto.scss` (1116 lines) is the heart**: defaults vocabulary + kebab→
+  camelCase mapping + ~850 lines of rules (title slide, code blocks,
+  blockquotes, callouts, `.smaller` system, columns, panels, asides, task
+  lists, kbd, light/dark sentinel).
+- **Split SCSS compilation + `exposer.scss` bridge** — Q1's load-bearing design
+  decision. (NB: "split" here = two *separate Sass-compiler invocations*; this
+  is unrelated to Q2's "pass 1 / pass 2" project-render phases.) The theme is
+  compiled in its **own Sass invocation** *before* Pandoc (full variable scope →
+  output `quarto-{hash}.css`); format `sass-bundles` are compiled in a
+  **second, separate Sass invocation** *later*, where the theme's Sass variables
+  are **not** in scope. The two invocations are bridged only by `exposer.scss`
+  writing theme values to `:root --r-*`, with cross-format rules using
+  `var(--r-background-color, $body-bg)` (runtime value for reveal, compile-time
+  fallback for Bootstrap). **This split is the single most important thing to
+  consciously replicate or deliberately avoid in Q2** (see Decision D1).
+
+### 4. Root cause of the two specific complaints
+
+Both are **explicit Q1 departures from reveal defaults** that Q2 simply doesn't
+make (because Q2 has no Quarto reveal layer):
+
+1. **Bullet/paragraph alignment.** reveal defaults slides to **center**
+   (`.reveal .slides`). Q1 sets `$presentation-slide-text-align: left`
+   (`quarto.scss:71, 316`). Without it, Q2 inherits reveal's centered look.
+2. **Headings.** reveal defaults `$heading-text-transform: uppercase`. Q1 sets
+   `$presentation-heading-text-transform: none` (`quarto.scss:58`). Without it,
+   Q2 shows uppercase headings.
+3. **Title slide** (bonus). Q1 centers the title slide while body slides are
+   left, and shrinks the title `h1` to h2 size (1.6em) except in linear-nav
+   mode (`quarto.scss:307-326`). Q2 has none of this.
+
+> ⚠ **To verify on the Q2 side** (not yet confirmed by running the binary):
+> render a deck and confirm Q2 currently shows centered bullets + uppercase
+> headings. This is the cheap empirical check before designing.
+
+### 5. The lucky convergence
+
+reveal 6 independently moved to **kebab-case Sass variables** and a **stable
+`--r-*` runtime contract** — i.e. it adopted exactly the shape Q1 built by hand
+for reveal 5. Consequences:
+
+- Q1's kebab→camelCase mapping section in `quarto.scss` **largely collapses** —
+  Q2 can map `$presentation-*` straight to reveal 6's kebab `$heading-color`
+  etc., or skip the indirection and override `--r-*` directly.
+- Because reveal 6 themes read only `--r-*`, **a single unified Sass compilation
+  may suffice** for Q2: compile reveal's `settings`+`theme` (emitting
+  `:root --r-*`) together with the Quarto layer's rules (which use
+  `var(--r-*, fallback)`) in **one** `quarto-sass` invocation. This could let us
+  *avoid* Q1's split-compilation complexity (Decision D1).
+
+---
+
+## Proposed approach
+
+A staged port, smallest-feeling-fix first.
+
+### Stage A — Quarto reveal layer (fixes the "feels wrong" defaults)
+
+Port the **defaults + core rules** of Q1's `quarto.scss` into a Quarto reveal
+SCSS layer compiled through `quarto-sass`, targeting reveal 6 variable names.
+Prioritize the items that close the perceived gap:
+- `slide-text-align: left`, `heading-text-transform: none`
+- title-slide layout (centered, h1→h2 sizing)
+- list/bullet alignment, block margins, font sizing, code-block styling
+
+This alone should make a *white* deck feel like Q1.
+
+### Stage B — Theme set + selection plumbing
+
+- Adapt Q1's 12 themes to reveal-6 kebab-case `@use ... with (...)` form (or
+  `--r-*` overrides), as `quarto-sass` `defaults` layers.
+- Replace the hardcoded `resolve_theme_name` with real theme resolution: built-in
+  names, `white→default`/`black→dark` aliases, and user `theme: [name, custom.scss]`
+  arrays. Wire a **reveal variant of `assemble_scss`** (reveal framework layer
+  instead of Bootstrap) into the reveal branch of `CompileThemeCssStage`.
+
+### Stage C — Parity + extras
+
+- Render/preview parity (compiled theme served to both paths; keep the drift
+  guard meaningful).
+- `_brand.yml` integration, callouts/panels/tabsets/`.smaller`, light/dark
+  sentinel — as needed for "at home" feel.
+
+### Decisions (resolved 2026-06-16)
+
+- **D1 — RESOLVED: single unified SCSS compilation.** One `quarto-sass`
+  invocation assembles reveal framework + Quarto reveal layer + theme, treated
+  as a conscious, documented divergence from Q1's split model.
+  **Caveat (user):** because the variable surface is now *ours*, we must ship
+  **documentation/guidance/examples** covering (a) what the theming variables
+  are, and (b) how to adapt an existing Quarto-1 revealjs customization to Q2.
+  → tracked as a Stage-C doc deliverable + a doc strand.
+- **D2 — RESOLVED: keep Q1's `$presentation-*` / `$body-*` vocabulary**
+  (Option 1). Full consequence analysis below; the deciding factors are
+  cross-format brand/theme sharing and zero user-migration, and the fact that
+  Option 2 unlocks essentially *no* capability that Option 1 forecloses (the
+  runtime `--r-*` custom properties are emitted either way, so power users keep
+  a runtime escape hatch regardless).
+- **D3 — RESOLVED: ship Stage A alone first**, then B, then C — each on its own
+  branch off the `feature/revealjs-q1-themes` integration line, so the user can
+  check out and experiment with each stage independently.
+- **D4 — RESOLVED: accept both naming schemes**, aliasing `white→default` /
+  `black→dark` as Q1 does.
+- **D5 — RESOLVED: acceptance bar is "feels at home," not pixel-perfect.** Q2 is
+  also still missing Q1+reveal features (code annotations, transitions for
+  executable-output slides, etc.), so pixel parity is not achievable now anyway.
+  Simplify wherever reveal 6 already does the right thing.
+
+#### D2 consequence analysis (why keep `$presentation-*`)
+
+What Q1's `$presentation-*` / `$body-*` vocabulary actually *is*: a curated
+Quarto-owned variable layer that (i) **shares names with HTML/Bootstrap theming**
+(`$body-bg`, `$body-color`, `$link-color`, `$font-family-sans-serif/-monospace`),
+(ii) adds **presentation-specific knobs** reveal has no direct name for
+(`$presentation-slide-text-align`, `$presentation-title-slide-text-align`,
+`$presentation-font-size-root`, …), and (iii) **insulates users from reveal's own
+variable names**. Q1 maps these to reveal's vars in `quarto.scss`.
+
+**Option 1 — keep `$presentation-*` (CHOSEN).**
+- *Ongoing maintenance cost in Q2:* a single small mapping layer
+  (`$presentation-*`/`$body-*` → reveal-6 kebab vars), ~30–50 lines, that must be
+  re-checked when we bump reveal.js (one checklist item on a reveal upgrade) and
+  extended when we choose to surface a new reveal knob. This is the *same kind*
+  of curation we already do for Bootstrap variables, so it is bounded, familiar,
+  and localized to one file. The abstraction is a curated subset: if reveal adds
+  a knob we haven't mapped, users reach it via raw `--r-*` overrides or custom
+  rules until we add it — completeness of the Quarto vocabulary is on us.
+- *Benefits:* **cross-format theme/brand sharing** — set `$body-bg` /
+  `$link-color` once and it applies to HTML *and* reveal; `_brand.yml` "just
+  works" because brand emits these shared names (this is core to Quarto's value
+  prop). **Migration-free for Q1 users** — existing `theme: custom.scss` files
+  written against `$presentation-*`/`$body-*` keep working unchanged, which is
+  the whole point of this epic. **Future-proof** — when reveal renames its vars
+  again (as 5→6 did), only our one mapping file changes, not user themes.
+
+**Option 2 — expose reveal-6 kebab vars directly (NOT chosen).**
+- *What it means for themes:* new/edited themes are authored against reveal's own
+  `$heading-color`/`$main-color` (essentially vanilla reveal theme format), so
+  they are more directly portable to/from upstream reveal, and we invent/maintain
+  no Quarto vocabulary.
+- *What it costs existing users:* their `$presentation-*`/`$body-*` customizations
+  **break** and must be rewritten against reveal's names — i.e. users must learn
+  reveal internals, the opposite of "feel at home." It also **re-couples** user
+  themes to reveal's naming, so the next reveal rename breaks them again.
+- *Does it unlock new functionality?* **Essentially no.** Because reveal 6 emits
+  the entire variable surface as runtime `--r-*` custom properties regardless of
+  which Sass vocabulary we expose, every reveal knob is reachable at runtime
+  under Option 1 too (via `:root { --r-…: … }` overrides). Option 2's only
+  genuine upside is *lag-free, uncurated* access to the full reveal Sass surface
+  without us maintaining a mapping — but that upside is largely neutralized by
+  the `--r-*` runtime escape hatch, while its downside (breaking every Q1 theme)
+  is exactly what the epic exists to avoid. We also wouldn't even escape the
+  mapping work: `_brand.yml` → reveal still needs a brand→reveal bridge, so the
+  mapping cost reappears in the brand layer.
+
+**Net:** the choice is *not* about capability (both can reach everything via
+`--r-*`); it is about **who bears migration cost** and **cross-format
+consistency**. Option 1 puts a small, bounded maintenance cost on us and keeps
+Q1 users (and `_brand.yml`) working unchanged. Decision: **Option 1.** We will
+still *document* the underlying reveal `--r-*` properties as the supported
+runtime escape hatch for power users.
+
+---
+
+## Work items
+
+_D-series resolved 2026-06-16. Stages land separately on branches off
+`feature/revealjs-q1-themes`. TDD: tests first. **Implementation not yet
+greenlit** — awaiting user go-ahead._
+
+### Study phase
+- [x] Q2 current revealjs rendering + theming state
+- [x] reveal.js 5 vs 6 theming differences
+- [x] Quarto 1's revealjs theme adaptation + SCSS layers
+- [x] **Empirically confirmed** Q2's current centered-bullets + uppercase-headings
+      via a real `q2 render` + Chrome computed-style inspection (2026-06-16).
+      Deck: two H2 slides with bullet lists. Findings on the first slide:
+      `h2` → `text-transform: uppercase`, `text-align: center`, `font-size: 67px`;
+      `.reveal .slides` → `text-align: center` (the `ul` is `display:inline-block;
+      text-align:left`, so it centers as a block → classic reveal centered look).
+      Confirms §4: both differences are reveal defaults Q2 doesn't override.
+
+### Stage A — Quarto reveal layer (own branch)
+- [ ] Reveal variant of `assemble_scss` in `quarto-sass` (reveal framework layer,
+      not Bootstrap; single unified compilation per D1)
+- [ ] Port reveal-6 `settings.scss` `:root{--r-*}` emission into the Quarto reveal
+      layer (kebab-case); use reveal `theme.scss` as the rules framework
+      (see §2 implementation note — avoids the `@use ... with` vs layered-`!default` clash)
+- [ ] Define the `$presentation-*`/`$body-*` → reveal-6 kebab mapping layer (D2)
+- [ ] Wire reveal branch of `CompileThemeCssStage` to compile the Quarto reveal layer
+- [ ] Port Q1 `quarto.scss` defaults + core rules → reveal-6 layer (TDD: snapshot
+      the compiled CSS; assert `text-align:left`, no `uppercase`, title-slide rules)
+- [ ] End-to-end verify through `q2 render` AND `q2 preview` (parity); re-run the
+      Chrome computed-style check from the study phase to confirm the flip
+
+### Stage B — theme set + selection (own branch)
+- [ ] Adapt 12 themes to reveal-6 form (kebab vars / `--r-*`), as `defaults` layers
+- [ ] Real theme resolution (built-ins, `white→default`/`black→dark` aliases,
+      user `theme: [name, custom.scss]` arrays) — replace hardcoded `resolve_theme_name`
+- [ ] Tests per theme
+- [ ] Font handling (reveal themes `@import url(./fonts/…)`; decide vendor vs link)
+
+### Stage C — parity + extras + docs (own branch)
+- [ ] `_brand.yml` integration, callouts/panels/tabsets/`.smaller`, light/dark sentinel
+- [ ] Render/preview parity hardening; keep the vendored-asset drift guard meaningful
+- [ ] **Docs (D1 caveat):** user-facing guide on the theming variables and a
+      "migrating a Quarto-1 revealjs theme to Q2" how-to, incl. the `--r-*`
+      runtime escape hatch (docs/ site — render with `q2`, not Q1). Open a doc strand.
+
+## References
+
+- `claude-notes/plans/2026-06-08-revealjs-presentations.md` (Phase 7 deferral)
+- `external-sources/quarto-cli/src/core/sass.ts` (layer merge + defaults reversal)
+- `external-sources/quarto-cli/src/format/reveal/format-reveal-theme.ts` (bundler, split SCSS compilation)
+- `external-sources/quarto-cli/src/resources/formats/revealjs/quarto.scss` (master)
+- `external-sources/quarto-cli/src/resources/formats/revealjs/themes/*.scss`
+- `external-sources/quarto-cli/llm-docs/sass-theming-architecture.md` (Q1's split SCSS compilation + exposer; the Q1 doc itself calls this "two-pass")
+- `external-sources/reveal.js/css/theme/template/{settings,theme,mixins}.scss` (reveal 6)
+- Q2: `crates/quarto-core/src/revealjs/`, `crates/quarto-core/src/stage/stages/compile_theme_css.rs`, `crates/quarto-sass/src/{layer,bundle}.rs`, `resources/revealjs/`

--- a/claude-notes/plans/2026-06-16-revealjs-themes-q1-to-q2.md
+++ b/claude-notes/plans/2026-06-16-revealjs-themes-q1-to-q2.md
@@ -407,11 +407,50 @@ Sub-steps (TDD — test first each time):
       `center` class.
 
 ### Stage B — theme set + selection (own branch)
-- [ ] Adapt 12 themes to reveal-6 form (kebab vars / `--r-*`), as `defaults` layers
-- [ ] Real theme resolution (built-ins, `white→default`/`black→dark` aliases,
-      user `theme: [name, custom.scss]` arrays) — replace hardcoded `resolve_theme_name`
-- [ ] Tests per theme
-- [ ] Font handling (reveal themes `@import url(./fonts/…)`; decide vendor vs link)
+
+**Per-deck themes in websites WORK like `format: html` (corrected 2026-06-16).**
+Each document render has its own `StageContext.artifacts`; `ApplyTemplateStage`
+collects `css:revealjs:*` from *that* store only, so a deck links exactly the
+theme it registered. Project-scoped artifacts drain into the orchestrator's
+`project_artifacts` accumulator (`pass_two`) for one deduped flush to
+`site_libs/`. HTML keys its theme by **content fingerprint** (`css:theme:<hash>`)
+so different themes get different files and identical themes dedup — reveal will
+do the same. (An earlier note here wrongly claimed reveal cross-links decks; that
+was a wrong mental model — `ctx.artifacts` is per-document, not project-wide.)
+
+- [x] **Theme artifact keyed by content fingerprint**: `css:revealjs:3-theme-<hash>`
+      → `theme-<hash>.css` (replaced the fixed `3-theme-white`, reusing
+      `theme_fingerprint`). `3-theme-` prefix keeps cascade order. Same theme →
+      one shared file; different themes → distinct files; each deck links its own
+      (per-document `ctx.artifacts`). Matches HTML; future-proof for Stage-C
+      brand/per-deck vars. Tests: `register_reveal_assets_keys_theme_by_content_fingerprint`,
+      and the two-deck website test now asserts exactly one shared `theme-<hash>.css`.
+- [x] Adapted the 12 themes → `resources/scss/revealjs/themes/*.scss`: kebab-case
+      for direct reveal-var sets (`$overlayElementBgColor` →
+      `$overlay-element-bg-color`); `bodyBackground()`/`radial-gradient` →
+      `$background: radial-gradient(...)`. Renamed dracula's local `$background`
+      palette var → `$drac-background` (collides with reveal-6's `$background`).
+- [x] Reveal theme resolution (`crates/quarto-core/src/revealjs/theme.rs`):
+      parse `theme:` (string|array|absent→`default`); built-in (12 names +
+      `white→default`/`black→dark` via `quarto_sass::resolve_reveal_theme_name`)
+      vs user `.scss` (reuse `load_custom_theme`). Unknown/missing → loud stage
+      error. `resolve_reveal_theme_name`/`load_reveal_theme_layer` added to
+      quarto-sass; `resolve_theme_name`/`theme_css` removed.
+- [x] `assemble_reveal_scss(&[SassLayer])` merges theme layers via `merge_layers`;
+      `compile_reveal_theme_css(runtime, minified, &[layer], &[load_path])`;
+      stage `compile_reveal` helper + reveal branch updated to resolve→compile→
+      register.
+- [x] Tests: 6 per-theme/alias/unknown tests in `reveal_theme_test.rs`; resolution
+      unit tests in `theme.rs`; integration `revealjs_named_theme_is_compiled_and_selected`
+      (`theme: dark`). Full quarto-sass+quarto-core suites + `cargo xtask verify`
+      (incl. WASM) green.
+- [x] **Font handling (B7 decision):** kept Q1's Google-CDN `@import`s; converted
+      local `./fonts/league-gothic/…` → League Gothic Google-Fonts CDN; default
+      theme stays system-font (Helvetica). Offline/self-contained font bundling
+      deferred to Stage C.
+- [x] E2E + Chrome: `theme: dark` (#191919 bg, white text, blue links) and
+      `theme: dracula` (#282a36 bg, purple headings, cyan bullets, orange bold,
+      yellow italic) render faithfully, top-aligned/left-aligned.
 
 ### Stage C — parity + extras + docs (own branch)
 - [ ] `_brand.yml` integration, callouts/panels/tabsets/`.smaller`, light/dark sentinel

--- a/claude-notes/plans/2026-06-16-revealjs-themes-q1-to-q2.md
+++ b/claude-notes/plans/2026-06-16-revealjs-themes-q1-to-q2.md
@@ -713,25 +713,46 @@ Increments (by value × unblocked-ness; TDD; commit per increment):
       registered in the reveal branch after `RevealFootnotesTransform`) adds reveal's
       core `.r-stretch` class to single-image slides. Default-on; `auto-stretch: false`
       opt-out. Pure AST (no Quarto SCSS — `.r-stretch` is reveal-core).
-      **Scope is conservative — narrower than Q1's `applyStretch`:** stretches only
-      when the slide body (ignoring the heading) is exactly ONE block that is a
-      `Paragraph` wrapping a single `Image` or a `Figure` wrapping a single image. Q1
-      also stretches a lone image on a text-bearing slide and does DOM hoisting of the
-      `<img>` to section level + caption re-insertion; we do neither (single-image
-      slides don't need it, and Chrome E2E confirmed reveal sizes the nested
-      `<p><img class=r-stretch>` correctly without hoisting). Opt-outs ported:
+      **Scope matches Q1's `applyStretch`** (refined during D5 — the first cut was
+      over-conservative; the auto-stretch example's natural "heading + a sentence +
+      a diagram" slide didn't stretch, which Q1 does). Stretches when a slide holds
+      exactly ONE image (peripheral `.notes`/`.aside` aside), carries no `.aside`, and
+      that image sits in a *standalone* top-level block (a `Paragraph` whose only
+      inline is the image, or a `Figure`). Sibling blocks (heading, explanatory
+      paragraphs) are allowed — reveal sizes the image to the space they leave. An
+      image among inline text, nested in a `.column`/layout/fragment div, or a
+      multi-image slide is skipped. We do NOT do Q1's DOM hoisting (`<img>` → section
+      child + caption re-insert); Chrome E2E confirmed reveal sizes the nested
+      `<p><img class=r-stretch>` / figure image correctly without it. Opt-outs ported:
       `.nostretch` on slide or image (image class consumed), `.absolute`, already
       `.stretch`/`.r-stretch`, and explicit sizing (Q1 guards only `height`; we also
-      guard `width` — conservative). 11 unit tests + integration
-      `revealjs_auto_stretch_single_image_slides` (lone/sized/inline/opt-out). E2E:
-      `q2 render` + Chrome confirmed the lone image fills the slide (350px of an 816px
-      container) while a `width=200` image stays small. Full verify incl. WASM green.
+      guard `width` — conservative). 14 unit tests + integration
+      `revealjs_auto_stretch_single_image_slides` (lone / amid-text / sized / inline /
+      opt-out). E2E: `q2 render` + Chrome confirmed the lone image fills the slide
+      (350px of an 816px container) while a `width=200` image stays small. Full verify
+      incl. WASM green.
       _(Preview-parity caveat: the transform runs only in the `is_revealjs` branch,
       which the `q2-slides` preview pseudo-format does not enter, so preview does not
       auto-stretch. Same gap class as D3.)_
-- [ ] **D5. Docs (D1 caveat).** User-facing guide on the theming variables + a
-      "migrating a Quarto-1 revealjs theme to Q2" how-to incl. the `--r-*` runtime
-      escape hatch (docs/ site — render with `q2`, not Q1). Open a doc strand.
+- [x] **D5. Docs (partial — feature docs done; deep theming guide deferred).**
+      **DONE 2026-06-16 (this session)** for the agreed scope: documented theme
+      selection, footer/logo (D3), and auto-stretch (D4) in
+      `docs/presentations/revealjs/index.qmd`, each with prose + a minimal runnable
+      example (`examples/presentations/09-themes`, `10-footer-logo`, `11-auto-stretch`)
+      embedded via `.embed-example-iframe` (the established pattern). Registered the
+      three in `examples/manifest.yml` + the examples `README.md` table; fixed the
+      page's stale "themes/transitions not available" callout. Extended
+      `cargo xtask stage-doc-examples` to stage top-level **image** assets (so
+      image-using examples' logos/figures resolve in the embed). Prose written with
+      the reader-expectations methodology (Gopen & Swan). E2E: `q2 render docs/`
+      (165/166; the 1 error is a pre-existing broken link in `brand.qmd`, unrelated)
+      + Chrome confirmed the new sections render and the footer/logo demo iframe shows
+      the live deck with footer + logo. Full verify incl. WASM green.
+      **Deferred (separate page + own pass): the deep theming-variables guide**
+      (`$presentation-*`/`$body-*`, custom themes, `_brand.yml`, the `--r-*` runtime
+      escape hatch) + the "migrating a Quarto-1 revealjs theme to Q2" how-to. Per the
+      user, this goes on a dedicated `docs/presentations/revealjs/theming.qmd` page.
+      Open a doc strand for it.
 
 **Preview-parity caveat (carry to Stage E / a parity pass):** SCSS-only features
 (callouts, brand) render correctly via `q2 render` but NOT in the `q2-slides`

--- a/claude-notes/plans/2026-06-16-revealjs-themes-q1-to-q2.md
+++ b/claude-notes/plans/2026-06-16-revealjs-themes-q1-to-q2.md
@@ -708,10 +708,27 @@ Increments (by value × unblocked-ness; TDD; commit per increment):
       Confirm `UserFiltersStage` runs filters for reveal and add a test exercising a
       filter that manipulates footer/logo (or meta generally) on a reveal deck. Open
       a strand; do NOT block D3 on it.
-- [ ] **D4. `auto-stretch` (new AST transform).** Transform after
-      `RevealSlidesTransform` detecting single-image slides → add `.r-stretch`
-      (reveal-core class; default-on with a config toggle). Mostly AST; styling is
-      reveal-native.
+- [x] **D4. `auto-stretch` (new AST transform). DONE 2026-06-16 (this session).**
+      `RevealAutoStretchTransform` (`crates/quarto-core/src/revealjs/auto_stretch.rs`,
+      registered in the reveal branch after `RevealFootnotesTransform`) adds reveal's
+      core `.r-stretch` class to single-image slides. Default-on; `auto-stretch: false`
+      opt-out. Pure AST (no Quarto SCSS — `.r-stretch` is reveal-core).
+      **Scope is conservative — narrower than Q1's `applyStretch`:** stretches only
+      when the slide body (ignoring the heading) is exactly ONE block that is a
+      `Paragraph` wrapping a single `Image` or a `Figure` wrapping a single image. Q1
+      also stretches a lone image on a text-bearing slide and does DOM hoisting of the
+      `<img>` to section level + caption re-insertion; we do neither (single-image
+      slides don't need it, and Chrome E2E confirmed reveal sizes the nested
+      `<p><img class=r-stretch>` correctly without hoisting). Opt-outs ported:
+      `.nostretch` on slide or image (image class consumed), `.absolute`, already
+      `.stretch`/`.r-stretch`, and explicit sizing (Q1 guards only `height`; we also
+      guard `width` — conservative). 11 unit tests + integration
+      `revealjs_auto_stretch_single_image_slides` (lone/sized/inline/opt-out). E2E:
+      `q2 render` + Chrome confirmed the lone image fills the slide (350px of an 816px
+      container) while a `width=200` image stays small. Full verify incl. WASM green.
+      _(Preview-parity caveat: the transform runs only in the `is_revealjs` branch,
+      which the `q2-slides` preview pseudo-format does not enter, so preview does not
+      auto-stretch. Same gap class as D3.)_
 - [ ] **D5. Docs (D1 caveat).** User-facing guide on the theming variables + a
       "migrating a Quarto-1 revealjs theme to Q2" how-to incl. the `--r-*` runtime
       escape hatch (docs/ site — render with `q2`, not Q1). Open a doc strand.

--- a/claude-notes/plans/2026-06-16-revealjs-themes-q1-to-q2.md
+++ b/claude-notes/plans/2026-06-16-revealjs-themes-q1-to-q2.md
@@ -395,6 +395,16 @@ Sub-steps (TDD — test first each time):
       Stage C (bd-j8qoyc0s). No automated parity test breaks (the hub-client
       parity test mocks the CSS imports; `preview_render_css_parity.rs` covers
       Bootstrap, not reveal).
+- [x] **A8.** Vertical alignment parity (found during user experimentation).
+      Q1 defaults reveal `center: false` (slides top-align; reveal's own default
+      is `true`) and re-centers the title slide via a per-slide `.center` class
+      (`format-reveal.ts`). Q2 wrongly defaulted `center: true`. Fixed:
+      `reveal_config_json` now defaults `center: false`; `build_title_slide`
+      adds the `center` class to the title-slide section. TDD (config test +
+      title-slide-class test); E2E + Chrome confirmed body slides top-align
+      (`top:18`, no inline offset) while the title slide stays centered (reveal
+      applies `top` from the `.center` class). `.reveal` carries no global
+      `center` class.
 
 ### Stage B — theme set + selection (own branch)
 - [ ] Adapt 12 themes to reveal-6 form (kebab vars / `--r-*`), as `defaults` layers

--- a/claude-notes/plans/2026-06-16-revealjs-themes-q1-to-q2.md
+++ b/claude-notes/plans/2026-06-16-revealjs-themes-q1-to-q2.md
@@ -2,10 +2,111 @@
 
 **Strand:** bd-yown2ts4
 **Branch:** `feature/revealjs-q1-themes` (epic integration line; stages land on sub-branches)
-**Status:** Stage A (bd-r9mkybwl) + Stage B (bd-n697m7u7) implemented, verified, and
-**merged** to `feature/revealjs-q1-themes` (2026-06-16). Running a Q1/reveal-5
-look-and-feel audit (below) before deciding Stage C scope vs implementing
-additional parity features.
+**Status (2026-06-16):** Stages A/B/C **merged** to `feature/revealjs-q1-themes`.
+Stage D (bd-j8qoyc0s) in progress on branch `beads/bd-j8qoyc0s-reveal-brand-callouts`
+(off feature, **unmerged**): D1 callouts + D2 brand done; **D3/D4/D5 remain** —
+see "## Handoff for next session" at the bottom.
+
+---
+
+## Handoff for next session (Stage D continuation)
+
+**You are continuing Stage D (strand bd-j8qoyc0s).** Read this whole plan first;
+key context is above. Repo: `/Users/cscheid/rooms/room-1/q2`.
+
+### Where things are
+- On disk you should be (or `git switch` to) branch
+  **`beads/bd-j8qoyc0s-reveal-brand-callouts`** (off `feature/revealjs-q1-themes`).
+  Stages A/B/C are merged to `feature`; D1+D2 are committed on this branch but
+  **NOT yet merged**. Check `git log --oneline -6`; latest D commits are
+  `ebbdd732` (D1 callouts), `a80b28de` (D2 brand).
+- **Done:** D1 callouts (pure SCSS), D2 `_brand.yml` (config plumbing). See the
+  Stage D checklist above for exactly what landed.
+- **Remaining: D3 (footer/logo), D4 (auto-stretch), D5 (docs).** Both D3 and D4
+  are **new reveal AST transforms** — more Rust than D1/D2.
+
+### Deferred — do NOT build these in Stage D (each has its own strand)
+- light/dark integration **bd-904h9kmt**; code-annotation **bd-h176qcgp**;
+  reveal plugins **bd-buwhvpc2**; fancy title slide **bd-tntzuvzl** (blocked on a
+  deferred author-model normalization epic); panels/tabsets **bd-ewfppclm**
+  (greenfield).
+
+### D3 — footer / logo (new AST transform + SCSS)
+- Add a reveal transform (e.g. `crates/quarto-core/src/revealjs/footer_logo.rs`),
+  register it in `pipeline.rs` `build_transform_pipeline` reveal branch
+  (~lines 1105-1121) **after `RevealSlidesTransform`** (so the slide `<section>`
+  tree exists), export from `revealjs/mod.rs`.
+- Read `logo:` / `footer:` from `ast.meta`; inject `<img class="slide-logo">`
+  and a `.footer` Div (Q1 emits `::: {.footer .footer-default}`). Q1 ref:
+  `external-sources/quarto-cli/src/format/reveal/format-reveal.ts:402-424`.
+- SCSS: port footer styling (Q1 `quarto.scss:570-592`, muted + `.has-dark/light-
+  background` variants) and `.slide-logo` positioning into
+  `resources/scss/revealjs/quarto-revealjs.scss`. (Footer SCSS was deferred from
+  C3 precisely because the markup didn't exist yet.)
+- **Scope note:** Q1 places footer/logo on *every* slide via its quarto-support
+  reveal *plugin*. Q2 ships no plugins (deferred), so do the simple thing: a
+  single deck-level `.footer` fixed at the bottom via CSS (reveal shows it on all
+  slides) + a positioned `.slide-logo`. Document the difference; don't pull in a
+  plugin.
+
+### D4 — auto-stretch (new AST transform)
+- Another reveal transform after `RevealSlidesTransform`. Walk each slide
+  `section`; if it contains a *single* image (one `Para`/`Figure` wrapping one
+  `Image`, ignoring the heading), add class `r-stretch` to it. Default-ON with a
+  `auto-stretch: false` opt-out (Q1 schema default is true). `.r-stretch` is a
+  reveal-core CSS class — **no Quarto SCSS needed**. Q1 ref: `format-reveal.ts`
+  `applyStretch` (~949-1060). Skip slides with multiple blocks or images that
+  already carry explicit sizing / `.r-stretch`.
+
+### D5 — docs (open a doc strand)
+- `docs/` is a **Quarto-2 website — render/preview with `cargo run --bin q2 -- …`,
+  never the system `quarto`.** Write a user-facing guide on the reveal theming
+  variables (`$presentation-*` / `$body-*`) + a "migrating a Quarto-1 revealjs
+  theme to Q2" how-to, incl. the `--r-*` runtime escape hatch.
+
+### Conventions / gotchas (non-negotiable)
+- **TDD**: write the test first, watch it fail, then implement. Use
+  `cargo nextest run` (never `cargo test`); never pipe nextest through `tail`.
+- After each increment run `cargo xtask verify --skip-hub-tests` (SCSS is
+  embedded in `quarto-sass` and transforms live in `quarto-core` — **both feed
+  the WASM build**, so the WASM leg must pass). Commit per increment.
+- **End-to-end verify through the real binary**: `cargo run --bin q2 -- render
+  <fixture>.qmd`, inspect the output, and use the Chrome DevTools MCP (navigate
+  `file://…`, `evaluate_script` for computed styles, `take_screenshot`). After
+  re-rendering, **reload with `ignoreCache:true`** — hash navigation alone does
+  NOT reload the document. Use a project-local temp dir (e.g. `.tmp-reveal-check`)
+  and delete it when done.
+- **External Sources Policy**: never reference `external-sources/` at compile
+  time — read it for porting, but vendor anything needed.
+- **reveal.js 6 uses kebab-case Sass vars.** The Quarto reveal layer
+  (`resources/scss/revealjs/quarto-revealjs.scss`) defines the `$presentation-*`/
+  `$body-*` vocabulary, maps it to reveal-6 kebab vars, and has the helper
+  foundation (`shift_to_dark`, `shift-color`, `make/undo-smaller-font-size`,
+  `colorToRGB`, `str-replace`).
+- **hub-client changelog**: required ONLY if you change a file under
+  `hub-client/` (two-commit workflow per CLAUDE.md). D3/D4 are `quarto-core` →
+  likely no hub-client change → no changelog.
+- **Preview parity caveat**: SCSS-only features render via `q2 render` but not in
+  the `q2-slides` preview SPA (it imports stock `white.css`). D3/D4 add *markup*
+  via AST transforms — that markup WILL appear in preview if the transform also
+  runs for `q2-slides`; check `pipeline.rs` `Q2_PREVIEW_TRANSFORM_EXCLUDED`
+  (~line 1314). The *styling* still won't be in preview. State this honestly when
+  reporting "done".
+- **Git**: branch is off `feature/revealjs-q1-themes`. When Stage D is complete,
+  merge `--no-ff` into feature and `braid close bd-j8qoyc0s`. **Never push without
+  explicit user permission.** Commit message trailer:
+  `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+
+### Key files
+- Reveal transforms: `crates/quarto-core/src/revealjs/{transform,slides,columns,footnotes,theme,assemble,mod}.rs`
+- Pipeline (reveal branch + preview-excluded list): `crates/quarto-core/src/pipeline.rs`
+- Reveal SCSS layer: `resources/scss/revealjs/quarto-revealjs.scss`
+- Reveal SCSS assembly/compile: `crates/quarto-sass/src/{bundle,compile,config,brand_layer}.rs`
+- Reveal config (`Reveal.initialize`): `crates/quarto-core/src/revealjs/assemble.rs` (`reveal_config_json`)
+- Tests: `crates/quarto-core/tests/integration/{revealjs_format,revealjs_features}.rs`,
+  `crates/quarto-sass/tests/integration/reveal_theme_test.rs`
+- Q1 references: `external-sources/quarto-cli/src/format/reveal/format-reveal.ts`,
+  `external-sources/quarto-cli/src/resources/formats/revealjs/quarto.scss`
 
 ## Overview
 

--- a/claude-notes/plans/2026-06-16-revealjs-themes-q1-to-q2.md
+++ b/claude-notes/plans/2026-06-16-revealjs-themes-q1-to-q2.md
@@ -321,18 +321,80 @@ greenlit** — awaiting user go-ahead._
       text-align:left`, so it centers as a block → classic reveal centered look).
       Confirms §4: both differences are reveal defaults Q2 doesn't override.
 
-### Stage A — Quarto reveal layer (own branch)
-- [ ] Reveal variant of `assemble_scss` in `quarto-sass` (reveal framework layer,
-      not Bootstrap; single unified compilation per D1)
-- [ ] Port reveal-6 `settings.scss` `:root{--r-*}` emission into the Quarto reveal
-      layer (kebab-case); use reveal `theme.scss` as the rules framework
-      (see §2 implementation note — avoids the `@use ... with` vs layered-`!default` clash)
-- [ ] Define the `$presentation-*`/`$body-*` → reveal-6 kebab mapping layer (D2)
-- [ ] Wire reveal branch of `CompileThemeCssStage` to compile the Quarto reveal layer
-- [ ] Port Q1 `quarto.scss` defaults + core rules → reveal-6 layer (TDD: snapshot
-      the compiled CSS; assert `text-align:left`, no `uppercase`, title-slide rules)
-- [ ] End-to-end verify through `q2 render` AND `q2 preview` (parity); re-run the
-      Chrome computed-style check from the study phase to confirm the flip
+### Stage A — Quarto reveal layer (branch `beads/bd-r9mkybwl-reveal-scss-layer`)
+
+**Architecture (sound, unified-compilation per D1).** A reveal assembly in
+`quarto-sass` mirroring the Bootstrap one, but with a **reveal framework layer**
+instead of Bootstrap. Layers, assembled with the existing 5-region order
+(`defaults` reversed):
+
+- **reveal framework layer** (vendored locally — External Sources Policy):
+  - `defaults` = reveal-6 `settings.scss` `$kebab: … !default` declarations
+    (the low-priority fallbacks: `#bbb`, `uppercase`, etc.)
+  - `rules` = the `:root{--r-*: #{$kebab}}` emitter (split out of settings so it
+    runs *after* defaults collapse) **then** reveal `theme.scss` rules (`var(--r-*)`)
+  - `mixins` = reveal `mixins.scss` (`light/dark-bg-text-color`)
+  - `uses` = `@use 'sass:color'`, `@use 'sass:meta'` (settings needs `color.scale`)
+- **Quarto reveal layer** (ported from Q1 `quarto.scss`, Stage-A subset):
+  - `defaults` = `$presentation-*`/`$body-*` vocabulary (D2) **+** the
+    Q1 mapping section converted to reveal-6 **kebab** names
+    (`$background-color: $body-bg !default;` etc.) so Quarto values flow into `--r-*`
+  - `rules` = the look-fixing overrides: `$presentation-slide-text-align: left`,
+    `heading-text-transform: none`, title-slide layout (centered, h1→h2 size),
+    list/heading/spacing/basic code-block rules
+- **theme layer** = none in Stage A (white-equivalent is the Quarto defaults);
+  real themes are Stage B.
+
+Sub-steps (TDD — test first each time):
+- [x] **A1.** Vendored reveal-6 theme template SCSS locally under
+      `resources/scss/revealjs/reveal-template/` (settings split into
+      `_settings-vars.scss` + `_expose.scss` `:root` emitter, `_theme.scss`,
+      `_mixins.scss`). Provenance in `resources/scss/revealjs/README.md`.
+      (Landed under `resources/scss/revealjs/`, alongside the crate's other
+      embedded SCSS, rather than the originally-noted `resources/revealjs/scss/`.)
+- [x] **A2.** `quarto-sass`: `load_reveal_framework` + `load_quarto_reveal_layer` +
+      `assemble_reveal_scss()` (reuses the shared `assemble_scss` ordering).
+      7 unit/integration tests in `reveal_theme_test.rs` — all green: layer load;
+      grass compile; `--r-main-color:#222`, `--r-background-color:#fff`,
+      `--r-link-color:#2a76dd` (collision case); `--r-heading-text-transform:none`
+      + no `uppercase`; `text-align:left`; `#title-slide` centered.
+- [x] **A3.** Authored `resources/scss/revealjs/quarto-revealjs.scss`. Discovered
+      a useful simplification: in reveal 6 `$link-color`/`$link-color-hover`/
+      `$selection-color` coincide with reveal's own kebab names, so those need no
+      mapping line — set the Quarto default once and it feeds the `:root` emitter.
+- [x] **A4.** `compile_reveal_theme_css()` in `quarto-sass/compile.rs`
+      (native `grass`, WASM dart-sass). Self-contained: no embedded load paths
+      (only built-in `sass:color`/`sass:meta`).
+- [x] **A5.** Wired `CompileThemeCssStage` reveal branch via a cfg-split
+      `compile_reveal` helper; `register_reveal_assets` now takes
+      `compiled_theme_css: Option<&str>` (`Some` = compiled theme in the
+      `3-theme-*` slot; `None` = vendored stock fallback on compile failure).
+      `RevealAsset.content` is now `Cow<'static, str>`. `reset.css` + core
+      `reveal.css` stay vendored; **`quarto-reveal.css` kept separate** (it's
+      columns/aside/footnotes, orthogonal to theming). Integration test
+      `revealjs_theme_slot_is_compiled_quarto_theme` (reads the flushed theme).
+- [x] **A6.** E2E verified through `q2 render` + Chrome computed styles:
+      content slide `h2` → `text-transform:none`, `text-align:left`; `.reveal
+      .slides` → `text-align:left`; title slide centered, title h1 → 1.6em (h2
+      size). Screenshots confirm the Quarto-1 feel (mixed-case left-aligned
+      content; centered h2-sized title). Font falls back to system Helvetica
+      (Source Sans Pro bundling is the Stage B item).
+- [x] **A7.** `q2 preview` parity assessed. **Stage A converges the render path
+      ONLY.** The reveal branch keys on `FormatIdentifier::Revealjs`; the preview
+      pseudo-format `q2-slides` is `(Html, preview)` and never enters it. The SPA
+      (`hub-client/.../RevealjsReactAstSlideRenderer.tsx`, `q2-debug/entry.tsx`)
+      **statically imports the vendored stock `resources/revealjs/theme/white.css`**
+      at build time, so preview still shows the centered/uppercase reveal look.
+      ⚠ **This re-introduces a render/preview divergence that bd-4b7f1hr7
+      deliberately removed** by pointing both at the same vendored files. The
+      divergence is intentional + temporary for staged delivery (D3). Converging
+      preview (Stage C) means feeding the *compiled* Quarto reveal theme to the
+      SPA — likely by precompiling the default Quarto reveal theme to a committed
+      static CSS asset that both the render default and the SPA import, with the
+      runtime compile reserved for non-default themes/brand/user vars. Tracked on
+      Stage C (bd-j8qoyc0s). No automated parity test breaks (the hub-client
+      parity test mocks the CSS imports; `preview_render_css_parity.rs` covers
+      Bootstrap, not reveal).
 
 ### Stage B — theme set + selection (own branch)
 - [ ] Adapt 12 themes to reveal-6 form (kebab vars / `--r-*`), as `defaults` layers

--- a/claude-notes/plans/2026-06-16-revealjs-themes-q1-to-q2.md
+++ b/claude-notes/plans/2026-06-16-revealjs-themes-q1-to-q2.md
@@ -514,20 +514,21 @@ Two more items moved to their own strands after the investigation:
 Stage D branch: `beads/bd-j8qoyc0s-reveal-brand-callouts` off `feature/revealjs-q1-themes`.
 Increments (by value × unblocked-ness; TDD; commit per increment):
 
-- [ ] **D1. Callouts (pure SCSS).** Q2 **already emits identical `.callout` markup
-      for reveal** (`CalloutTransform`+`CalloutResolveTransform` run before the
-      reveal branch — `pipeline.rs:1073-1074`); the reveal SCSS layer just has no
-      `.callout` rules. Port Q1 `quarto.scss:873-1116` callout rules + `$callout-*`
-      defaults into `quarto-revealjs.scss` (helpers `shift-color`/`shift_to_dark`/
-      `colorToRGB` already present from C2). Source: also `resources/scss/bootstrap/
-      _bootstrap-rules.scss:1759+` (icon SVG map). No Rust. _(bd-1kor9's "needs
-      reveal callout AST" premise is already satisfied.)_
-- [ ] **D2. `_brand.yml` integration (config plumbing).** `brand_to_layers`
-      already emits reveal `presentation-*` vars; the reveal compile path just
-      never resolves brand. Thread a brand layer through: stage reveal branch
-      (resolve brand like HTML, `compile_theme_css.rs:421-441`) →
-      `resolve_reveal_theme` → `assemble_reveal_scss` → `compile_reveal_theme_css`
-      (+ the `compile_reveal` helper). TDD: brand vars reach `--r-*`.
+- [x] **D1. Callouts (pure SCSS).** Ported Q1 `quarto.scss:873-1116` (base rules,
+      simple/default layouts, the `$callouts` map with per-type accent + inlined
+      recolored Bootstrap-icon SVGs, default-title `shift_to_dark` bg) into
+      `quarto-revealjs.scss`. Added `$callout-*`/`$table-border-color` defaults,
+      `sass:map` use, and a local `str-replace` fn. Q2 already emits identical
+      `.callout` markup for reveal — pure SCSS, no AST work. TDD +
+      E2E (Chrome: note/tip/warning render with colored borders, recolored icons,
+      titled vs simple). Commit ebbdd732.
+- [x] **D2. `_brand.yml` integration (config plumbing).** New
+      `quarto_sass::resolve_brand_layers` (extract `brand:` → typed Brand →
+      layers, independent of Bootstrap theme parsing); reveal branch resolves it
+      against the project dir and appends brand layers LAST (highest priority).
+      Fixed brand's reveal base-font mapping `$mainFont`→`$main-font` (reveal-6
+      kebab). TDD: `revealjs_brand_yml_flows_into_theme`. E2E confirmed
+      `--r-link-color:#c00` + `--r-main-font:Georgia`. Commit a80b28de.
 - [ ] **D3. `footer:` / `logo:` (new AST transform).** New reveal transform after
       `RevealSlidesTransform` (`pipeline.rs:1109`) injecting `<img class="slide-logo">`
       + `.footer` Div from `logo:`/`footer:` meta; + SCSS (footer muted/bg-aware;

--- a/claude-notes/plans/2026-06-16-revealjs-themes-q1-to-q2.md
+++ b/claude-notes/plans/2026-06-16-revealjs-themes-q1-to-q2.md
@@ -503,25 +503,49 @@ their own strands** (not part of Stage D):
 - code-annotation styling → **bd-h176qcgp** (wants dedicated design time).
 - reveal plugin foundation (menu/notes/line-highlight) → **bd-buwhvpc2**.
 
-Remaining Stage D scope (concrete decomposition pending the prerequisite
-investigation, 2026-06-16):
-- [ ] **Callouts** — the highest-value "feels like Quarto" element (helper
-      foundation from C2 is in place). Verify whether Q2 emits `.callout` markup
-      for reveal first (else AST work; cf. bd-1kor9).
-- [ ] **`_brand.yml` integration** — thread a resolved brand layer into
-      `assemble_reveal_scss` (quarto-sass `brand_layer.rs` has reveal hooks).
-- [ ] **Fancy title slide** — authors/affiliations/ORCID/email (likely needs
-      author-metadata normalization).
-- [ ] **`footer:` / `logo:`** — markup injection (reveal transform) + SCSS.
-- [ ] **`auto-stretch`** (default on in Q1) — single-image slides → `.r-stretch`.
-- [ ] **panels/tabsets** SCSS (state TBD by investigation).
-- [ ] Render/preview parity hardening; keep the vendored-asset drift guard meaningful.
-- [ ] **Docs (D1 caveat):** user-facing guide on the theming variables + a
+**Prerequisite investigation (2026-06-16) findings drive this decomposition.**
+Two more items moved to their own strands after the investigation:
+- Fancy title slide → **bd-tntzuvzl**: BLOCKED on author-metadata normalization
+  (Q2 drops all structured author fields — `document_profile.rs:742-744`; needs
+  the deferred author-model epic first).
+- panels/tabsets → **bd-ewfppclm**: greenfield (no tabset transform in Q2 for any
+  format); lowest priority.
+
+Stage D branch: `beads/bd-j8qoyc0s-reveal-brand-callouts` off `feature/revealjs-q1-themes`.
+Increments (by value × unblocked-ness; TDD; commit per increment):
+
+- [ ] **D1. Callouts (pure SCSS).** Q2 **already emits identical `.callout` markup
+      for reveal** (`CalloutTransform`+`CalloutResolveTransform` run before the
+      reveal branch — `pipeline.rs:1073-1074`); the reveal SCSS layer just has no
+      `.callout` rules. Port Q1 `quarto.scss:873-1116` callout rules + `$callout-*`
+      defaults into `quarto-revealjs.scss` (helpers `shift-color`/`shift_to_dark`/
+      `colorToRGB` already present from C2). Source: also `resources/scss/bootstrap/
+      _bootstrap-rules.scss:1759+` (icon SVG map). No Rust. _(bd-1kor9's "needs
+      reveal callout AST" premise is already satisfied.)_
+- [ ] **D2. `_brand.yml` integration (config plumbing).** `brand_to_layers`
+      already emits reveal `presentation-*` vars; the reveal compile path just
+      never resolves brand. Thread a brand layer through: stage reveal branch
+      (resolve brand like HTML, `compile_theme_css.rs:421-441`) →
+      `resolve_reveal_theme` → `assemble_reveal_scss` → `compile_reveal_theme_css`
+      (+ the `compile_reveal` helper). TDD: brand vars reach `--r-*`.
+- [ ] **D3. `footer:` / `logo:` (new AST transform).** New reveal transform after
+      `RevealSlidesTransform` (`pipeline.rs:1109`) injecting `<img class="slide-logo">`
+      + `.footer` Div from `logo:`/`footer:` meta; + SCSS (footer muted/bg-aware;
+      logo positioning). _(Per-slide JS placement that Q1's plugin does is out of
+      scope — Q2 ships no plugins; the markup + CSS gets us the look.)_
+- [ ] **D4. `auto-stretch` (new AST transform).** Transform after
+      `RevealSlidesTransform` detecting single-image slides → add `.r-stretch`
+      (reveal-core class; default-on with a config toggle). Mostly AST; styling is
+      reveal-native.
+- [ ] **D5. Docs (D1 caveat).** User-facing guide on the theming variables + a
       "migrating a Quarto-1 revealjs theme to Q2" how-to incl. the `--r-*` runtime
       escape hatch (docs/ site — render with `q2`, not Q1). Open a doc strand.
 
-_(A concrete per-increment decomposition + branch will be added once the
-prerequisite investigation lands.)_
+**Preview-parity caveat (carry to Stage E / a parity pass):** SCSS-only features
+(callouts, brand) render correctly via `q2 render` but NOT in the `q2-slides`
+preview SPA (it statically imports stock `white.css`; `callout-resolve` is also
+excluded from preview transforms — `pipeline.rs:1314`). Render is the Stage D
+target; full preview convergence is its own follow-up.
 
 ---
 

--- a/claude-notes/plans/2026-06-16-revealjs-themes-q1-to-q2.md
+++ b/claude-notes/plans/2026-06-16-revealjs-themes-q1-to-q2.md
@@ -473,15 +473,26 @@ TDD; commit per increment._
       integration `slideNumber` assertion. E2E: `q2 render` + Chrome
       `Reveal.getConfig()` confirmed. Full verify (incl. hub build) green.
       Commits 37061765 (code) + 3cea68ce (hub changelog).
-- [ ] **C2. Sass-helper foundation.** Port Q1 `quarto.scss` helpers into the
-      reveal layer: `quarto-color.blackness/.scale`, `quarto-math.pow`,
-      `shift-color`, `shift_to_dark`, `make/undo-smaller-font-size` (Q1
-      `quarto.scss:204-258`). Unblocks the C3 SCSS items.
-- [ ] **C3. SCSS quick-wins** (port from `quarto.scss`): `.has-light/dark-background`
-      text switching; code-block border/scroll/max-height; `.smaller` system;
-      light/dark sentinel `/*! dark */` (+ a Q2 consumer for code-highlight mode);
-      blockquote restyle; kbd; slide-number; figure/caption; column gutters; link
-      styling. Per-item tests (compiled CSS assertions) + E2E spot-checks.
+- [x] **C2. Sass-helper foundation.** Ported into the Quarto reveal layer:
+      `colorToRGB`/`tint`/`shade`/`shift-color` functions; `shift_to_dark`
+      (kebab `$background-color` + `quarto-color.blackness`),
+      `make/undo-smaller-font-size` (`quarto-math.pow`). Added the
+      `quarto-color`/`quarto-math` `@use`s + supporting defaults
+      (`$code-block-theme-dark-threshhold`, border/gray vars). Probed `grass`
+      first — it supports `color.blackness`/`color.scale`/`math.pow`/`mix`.
+- [x] **C3. SCSS quick-wins** ported from `quarto.scss`: `.has-light/dark-background`
+      text+link+code recoloring; code-block border + full-width + scrollable
+      `max-height`; `.smaller` system (global + per-slide, headings keep size via
+      `undo-smaller-font-size`); blockquote restyle (left accent border, not
+      italic-centered); kbd keycaps (`shift_to_dark` background); slide-number
+      (muted, bg-aware); figure captions; multi-column gutters; ordered-list
+      `type=` + task-list checkboxes; edge nav-control spacing; link
+      weight/decoration; `--r-*` code-font custom properties. Tests:
+      `quick_wins_compile_and_emit`, `shift_to_dark_picks_dark_value_on_dark_theme`.
+      E2E + Chrome: code block, blockquote, kbd, `.smaller`, and dark-background
+      legibility all render faithfully. Full `cargo xtask verify` (incl. WASM)
+      green. **Deferred to Stage D** (need markup/consumer/plugins): light/dark
+      sentinel, footer/logo, panels/tabsets, callouts, code-annotation, tippy.
 
 ### Stage D — brand + callouts + parity hardening + docs (bd-j8qoyc0s)
 - [ ] `_brand.yml` integration; **callouts** (the big one — depends on the C2 helper

--- a/claude-notes/plans/2026-06-16-revealjs-themes-q1-to-q2.md
+++ b/claude-notes/plans/2026-06-16-revealjs-themes-q1-to-q2.md
@@ -461,15 +461,18 @@ _Inserted before the brand/callouts/docs stage per the 2026-06-16 audit decision
 `beads/bd-jxyqjf15-reveal-config-and-quickwins` off `feature/revealjs-q1-themes`.
 TDD; commit per increment._
 
-- [ ] **C1. Reveal config defaults.** Port Q1's opinionated default block into
-      `reveal_config_json` (`transition:"none"`, `width:1050`, `height:700`,
-      `margin:0.1`, `navigationMode:"linear"`, `controlsLayout:"edges"`,
-      `controlsTutorial:false`, `history:true`, `backgroundTransition:"none"`,
-      `fragmentInURL:false`, `pdfSeparateFragments:false`, `hashOneBasedIndex:false`)
-      — each overridable by front-matter. `slideNumber` `c/t`/`h.v` rewrite +
-      quoting. Fix `RevealDeck.tsx` preview parity (`center:false`,
-      `transition:"none"`, width/height). TDD: config snapshot; Chrome confirms
-      no animation + edges controls.
+- [x] **C1. Reveal config defaults.** Ported Q1's opinionated block into
+      `reveal_config_json` (transition/backgroundTransition:none, center:false,
+      1050×700, margin:0.1, navigationMode:linear, controlsLayout:edges,
+      controlsTutorial:false, history:true, fragmentInURL/pdfSeparateFragments/
+      hashOneBasedIndex:false) — each front-matter-overridable. `slideNumber`
+      true→`c/t`(linear)/`h.v`(vertical); width/height accept `%` strings. Fixed
+      preview parity in **both** `RevealDeck.tsx` and `RevealjsReactAstSlideRenderer.tsx`
+      (center:false, transition:none, margin:0.1, linear nav, edge controls).
+      TDD: `config_defaults_match_quarto1` + vertical-nav/override tests;
+      integration `slideNumber` assertion. E2E: `q2 render` + Chrome
+      `Reveal.getConfig()` confirmed. Full verify (incl. hub build) green.
+      Commits 37061765 (code) + 3cea68ce (hub changelog).
 - [ ] **C2. Sass-helper foundation.** Port Q1 `quarto.scss` helpers into the
       reveal layer: `quarto-color.blackness/.scale`, `quarto-math.pow`,
       `shift-color`, `shift_to_dark`, `make/undo-smaller-font-size` (Q1

--- a/claude-notes/plans/2026-06-16-revealjs-themes-q1-to-q2.md
+++ b/claude-notes/plans/2026-06-16-revealjs-themes-q1-to-q2.md
@@ -635,11 +635,79 @@ Increments (by value × unblocked-ness; TDD; commit per increment):
       Fixed brand's reveal base-font mapping `$mainFont`→`$main-font` (reveal-6
       kebab). TDD: `revealjs_brand_yml_flows_into_theme`. E2E confirmed
       `--r-link-color:#c00` + `--r-main-font:Georgia`. Commit a80b28de.
-- [ ] **D3. `footer:` / `logo:` (new AST transform).** New reveal transform after
-      `RevealSlidesTransform` (`pipeline.rs:1109`) injecting `<img class="slide-logo">`
-      + `.footer` Div from `logo:`/`footer:` meta; + SCSS (footer muted/bg-aware;
-      logo positioning). _(Per-slide JS placement that Q1's plugin does is out of
-      scope — Q2 ships no plugins; the markup + CSS gets us the look.)_
+- [x] **D3. `footer:` / `logo:` (generate-reuse + reveal render + slot + scaffold).**
+      **DONE 2026-06-16 (this session).** Implemented as designed below; full
+      `cargo xtask verify --skip-hub-tests` (incl. WASM build) green; E2E through
+      `q2 render` + Chrome confirmed footer/logo are `position: fixed`, direct
+      children of `.reveal` outside `.slides`, footer link rendered, `has-logo`
+      set. Files: `crates/quarto-core/src/revealjs/footer_logo.rs` (alias + render
+      transforms, 12 unit tests), `pipeline.rs` (`footer_render_stage` selector +
+      reveal alias registration), `revealjs/assemble.rs` (scaffold reads slots),
+      `resources/scss/revealjs/quarto-revealjs.scss` (SCSS). Integration:
+      `revealjs_footer_and_logo_render_outside_slides` (via `footer:` alias) +
+      `revealjs_page_footer_key_drives_footer` (canonical key). SCSS:
+      `footer_and_logo_compile_and_emit`.
+
+      **Design settled with the user 2026-06-16 (this session); supersedes both the
+      original "AST transform into `ast.blocks`" sketch AND this session's first
+      "scaffold reads raw meta" pass.**
+
+      *Why not inject into `ast.blocks`:* reveal.js applies CSS `transform` to
+      `.slides` and every `<section>` (verified in vendored `reveal.css`), so a
+      `position: fixed` element nested there resolves against the transformed
+      ancestor, not the viewport — it would NOT stay fixed. The deck-level footer/
+      logo must be **direct children of `.reveal`, outside `.slides`** (where Q1's
+      quarto-support *plugin* relocates them at runtime; Q2 ships no plugin so the
+      scaffold places them statically).
+
+      *Why a transform + meta-slot rather than the scaffold reading `footer:`/`logo:`
+      directly:* user-defined filters must be able to manipulate these entries the
+      same way they manipulate navbar/sidebar/TOC/footer in `format: html`. That
+      contract lives in the **generate → `rendered.*` slot → template** flow, not in
+      late scaffold reads. The pipeline already runs user filters around the AST
+      transforms (`UserFiltersStage::pre` → `AstTransformsStage` → `…::post`,
+      pipeline.rs:318-320), so routing footer/logo through that machinery makes the
+      contract real.
+
+      *Architecture (generate = format-agnostic, render = format-specific):*
+      - **Reuse** the format-agnostic `FooterGenerateTransform` (`page-footer:` →
+        `navigation.footer`, already registered unconditionally → already runs for
+        reveal). A small reveal-scoped **alias** transform maps Q1's `footer:` →
+        `page-footer:` (when `page-footer:` absent) *before* generate, so a bare Q1
+        `footer:` flows through the same generate (string → `center` region).
+      - A reveal-specific **render** transform reads `navigation.footer` (the
+        `center` region; left/right deferred per decision) → reveal `.footer
+        .footer-default` markup → slot `rendered.reveal.footer`; and reads `logo:`
+        (no format-agnostic logo-generate exists — logo is reveal-specific) →
+        `<img class="slide-logo">` → slot `rendered.reveal.logo`. Each render is
+        skipped if its slot is already populated (override hook). Footer inline
+        content (links/emphasis) renders via the pampa HTML writer; `.qmd` hrefs in
+        a Text-region footer pass through unrewritten (parity with html's
+        FooterRender, which defers Text-region rewriting).
+      - **Gate** the html `FooterRenderTransform` off for reveal via a localized
+        format→stage selection helper (`footer_render_stage(format)`), chosen so the
+        reveal render writes its own `rendered.reveal.*` slot without colliding with
+        html's `rendered.navigation.footer` skip-hook. This helper is the first small
+        step toward format-driven pipeline composition (vs. scattering `is_revealjs`
+        checks) — intentionally localized, not a framework.
+      - **Scaffold** (`render_revealjs_document`) reads `rendered.reveal.footer`/
+        `rendered.reveal.logo` and places them outside `.slides`; `.reveal` gains
+        `has-logo` when the logo slot is present (drives slide-number repositioning,
+        matching Q1).
+      - **SCSS** (done): footer colors (muted + `.has-dark/light-background`
+        variants, `quarto.scss`:570-592) + footer/logo positioning + responsive
+        sizing (`plugins/support/footer.css`) in `quarto-revealjs.scss`. The
+        `.has-dark/light-background` recoloring is **dormant without a plugin** (Q1
+        toggles those classes per-slide); ported for forward-compat with bd-buwhvpc2.
+      _(Out of scope, plugin/other-strand territory: per-slide footers,
+      `data-footer="false"` overrides, runtime relocation, brand/object-form logos,
+      left/right footer regions for reveal.)_
+- [ ] **D3-Lua. User Lua filters in revealjs (own phase / strand — bd-ocxnva1f).** General goal:
+      Lua filters should work for reveal decks (the footer/logo slot design above
+      *enables* this, but end-to-end filter support may be harder than it looks).
+      Confirm `UserFiltersStage` runs filters for reveal and add a test exercising a
+      filter that manipulates footer/logo (or meta generally) on a reveal deck. Open
+      a strand; do NOT block D3 on it.
 - [ ] **D4. `auto-stretch` (new AST transform).** Transform after
       `RevealSlidesTransform` detecting single-image slides → add `.r-stretch`
       (reveal-core class; default-on with a config toggle). Mostly AST; styling is

--- a/claude-notes/plans/2026-06-16-revealjs-themes-q1-to-q2.md
+++ b/claude-notes/plans/2026-06-16-revealjs-themes-q1-to-q2.md
@@ -2,8 +2,10 @@
 
 **Strand:** bd-yown2ts4
 **Branch:** `feature/revealjs-q1-themes` (epic integration line; stages land on sub-branches)
-**Status:** Study phase + toolchain experiment complete; decisions D1–D5 resolved
-(2026-06-16). **Awaiting user go-ahead to begin Stage A implementation.**
+**Status:** Stage A (bd-r9mkybwl) + Stage B (bd-n697m7u7) implemented, verified, and
+**merged** to `feature/revealjs-q1-themes` (2026-06-16). Running a Q1/reveal-5
+look-and-feel audit (below) before deciding Stage C scope vs implementing
+additional parity features.
 
 ## Overview
 
@@ -458,6 +460,82 @@ was a wrong mental model — `ctx.artifacts` is per-document, not project-wide.)
 - [ ] **Docs (D1 caveat):** user-facing guide on the theming variables and a
       "migrating a Quarto-1 revealjs theme to Q2" how-to, incl. the `--r-*`
       runtime escape hatch (docs/ site — render with `q2`, not Q1). Open a doc strand.
+
+---
+
+## Q1/reveal-5 look-and-feel audit (2026-06-16)
+
+Done after Stage B at the user's request, prompted by the `center` bug (A8) —
+which showed the study-phase assumption "Q2's reveal config matches Q1" was
+false. Full evidence-based audit of Q1's revealjs look-and-feel surface vs Q2
+(post-A+B). **Decision pending: implement a subset of these vs proceed to Stage C
+as originally scoped.**
+
+### Headline finding (same class as the `center` bug)
+
+**`transition` defaults to `"slide"` in Q2 but `"none"` in Q1**
+(`format-reveal.ts:357`; schema `document-reveal-transitions.yml:6`). Q2 decks
+animate on every slide change; Q1 decks don't. Immediately visible. Q2 emits only
+**8** reveal config keys; Q1 seeds an **opinionated default block** (gated on
+`revealjs-config != "default"`, `format-reveal.ts:343-361`) the user effectively
+gets. Divergent/missing defaults Q2 should adopt:
+
+| Key | Q1 default | Q2 today |
+|---|---|---|
+| `transition` | `"none"` | `"slide"` ⚠ |
+| `width` / `height` | `1050` / `700` | unset (reveal `960`/`700`) |
+| `margin` | `0.1` | unset (reveal `0.04`) |
+| `navigationMode` | `"linear"` | unset (`"default"`) — also drives the title-h1 sizing rule |
+| `controlsLayout` | `"edges"` | unset (`"bottom-right"`) |
+| `controlsTutorial` | `false` | unset (`true` — bouncing arrows appear) |
+| `history` | `true` | unset (`false`) |
+| `backgroundTransition` | `"none"` | unset (`"fade"`) |
+| `fragmentInURL` / `pdfSeparateFragments` | `false` | unset (`true`) |
+| `slideNumber` | rewritten to `"c/t"`/`"h.v"` then quoted (`:336-340,516-519`) | raw bool/string passthrough |
+
+⚠ **Preview parity bug:** `RevealDeck.tsx:158-171` hardcodes `center: true` +
+`transition: 'slide'` — contradicts render's `center:false` + (corrected)
+`transition:"none"`. Fix alongside.
+
+### SCSS systems not yet ported from `quarto.scss` (highest-value)
+
+- **Callouts** (`quarto.scss:873-1116`) — *very high* impact ("the #1 feels-like-Quarto element"), **large**; needs the Sass-helper foundation + revealjs callout AST output (bd-1kor9).
+- **`.has-light/dark-background` text switching** (117-123, 269-305) — *high* (legibility on contrasting bg), **small SCSS**.
+- **Code-block border/scroll/max-height** (328-373) — *high* (recognizable), **small-medium SCSS**.
+- **`.smaller` font-scaling** (240-250, 488-549) — *high* (`smaller:true` ubiquitous), **medium**; needs `make/undo-smaller` mixins.
+- **Light/dark sentinel** `/*! dark */` (669-677) — *high (functional)*: renderer greps it to pick the code-highlight theme. Small emit + a Q2 consumer.
+- **Blockquote restyle** (385-400), **kbd** (841-856), **slide-number** (594-604), **figure/caption** (606-613), **multi-column gutters** (551-563), **link/brand** (865-871), **code-annotation** (735-824), **ol type/task-lists** (679-727) — mostly *medium/small* pure SCSS.
+- **Foundational prerequisite:** the high-value SCSS items depend on porting Q1's Sass helpers (`quarto-color.blackness/.scale`, `quarto-math.pow`, `shift-color`, `shift_to_dark`, `make/undo-smaller-font-size`; `quarto.scss:204-258`). **Port this helper layer once first** — it unblocks the whole SCSS batch.
+
+### Chrome / transform / plugin gaps
+
+- **Fancy title slide** (authors/affiliations/ORCID/email; `title-fancy/`) — *high*, **medium-large**; needs author-metadata normalization (AST) + template + SCSS. Q2 has only single-author plain text.
+- **`auto-stretch`** (default **true**) — single-image slides → `.r-stretch`; without it images overflow. *Medium-high*, AST/transform.
+- **`logo:` / `footer:`** — markup injection (transform) + per-slide JS placement + SCSS. *Medium(-high)*.
+- **Plugins: Q2 ships ZERO reveal plugins** in the render scaffold (no `plugins:` array). Q1 bundles menu (default), notes/search/zoom, line-highlight, pdfexport. Speaker view (S), menu, code-line stepping all absent. *Medium*, JS-plugin foundation. (Notes follow-up: bd-0qaarvzx.)
+- **Footnotes/refs trailing-slide treatment** (`.smaller .scrollable` + title; `format-reveal.ts:770-808`) — Q2 coalesces footnotes but lacks this. *Medium*, transform.
+- **`output-location: slide`**, slide backgrounds (`data-background-*`), citation→`#/references` rewriting — Tier-3, *medium/low*.
+
+### Prioritized shortlist
+
+**Quick wins (high impact / low effort):**
+1. Config defaults: `transition:"none"` + the full opinionated block; `slideNumber` `c/t` rewrite+quoting; fix `RevealDeck.tsx` to match. *(config, small-medium)*
+2. `.has-light/dark-background` text switching. *(SCSS, small)*
+3. Code-block border/scroll/max-height. *(SCSS, small-medium)*
+4. Blockquote restyle; kbd; slide-number; figure-caption; column gutters; link styling. *(SCSS, small each)*
+5. `.smaller` system + light/dark sentinel. *(SCSS, medium; needs helper layer)*
+
+**Larger efforts (high value, phase them):** callouts; fancy title slide; footer+logo; auto-stretch; plugin foundation (menu/notes/line-highlight). The **Sass-helper foundation** is the prerequisite to sequence first.
+
+### Suggested re-scoping (proposal — awaiting user decision)
+
+The audit suggests inserting a **config-defaults fix + Sass-helper foundation +
+SCSS quick-wins** stage *before* the originally-scoped Stage C, because:
+- the `transition`/config divergences are as user-visible as the `center` bug and cheap to fix;
+- the SCSS quick-wins (legibility, code blocks, `.smaller`) are high "at home" payoff;
+- the helper foundation unblocks both the quick-wins and the larger Stage-C items (callouts).
+
+Stage C's brand + callouts + docs would then build on that foundation.
 
 ## References
 

--- a/claude-notes/plans/2026-06-16-revealjs-themes-q1-to-q2.md
+++ b/claude-notes/plans/2026-06-16-revealjs-themes-q1-to-q2.md
@@ -454,8 +454,38 @@ was a wrong mental model — `ctx.artifacts` is per-document, not project-wide.)
       `theme: dracula` (#282a36 bg, purple headings, cyan bullets, orange bold,
       yellow italic) render faithfully, top-aligned/left-aligned.
 
-### Stage C — parity + extras + docs (own branch)
-- [ ] `_brand.yml` integration, callouts/panels/tabsets/`.smaller`, light/dark sentinel
+### Stage C — config defaults + Sass-helper foundation + SCSS quick-wins (bd-jxyqjf15)
+
+_Inserted before the brand/callouts/docs stage per the 2026-06-16 audit decision
+(user chose "config fixes + quick-wins first"). Branch
+`beads/bd-jxyqjf15-reveal-config-and-quickwins` off `feature/revealjs-q1-themes`.
+TDD; commit per increment._
+
+- [ ] **C1. Reveal config defaults.** Port Q1's opinionated default block into
+      `reveal_config_json` (`transition:"none"`, `width:1050`, `height:700`,
+      `margin:0.1`, `navigationMode:"linear"`, `controlsLayout:"edges"`,
+      `controlsTutorial:false`, `history:true`, `backgroundTransition:"none"`,
+      `fragmentInURL:false`, `pdfSeparateFragments:false`, `hashOneBasedIndex:false`)
+      — each overridable by front-matter. `slideNumber` `c/t`/`h.v` rewrite +
+      quoting. Fix `RevealDeck.tsx` preview parity (`center:false`,
+      `transition:"none"`, width/height). TDD: config snapshot; Chrome confirms
+      no animation + edges controls.
+- [ ] **C2. Sass-helper foundation.** Port Q1 `quarto.scss` helpers into the
+      reveal layer: `quarto-color.blackness/.scale`, `quarto-math.pow`,
+      `shift-color`, `shift_to_dark`, `make/undo-smaller-font-size` (Q1
+      `quarto.scss:204-258`). Unblocks the C3 SCSS items.
+- [ ] **C3. SCSS quick-wins** (port from `quarto.scss`): `.has-light/dark-background`
+      text switching; code-block border/scroll/max-height; `.smaller` system;
+      light/dark sentinel `/*! dark */` (+ a Q2 consumer for code-highlight mode);
+      blockquote restyle; kbd; slide-number; figure/caption; column gutters; link
+      styling. Per-item tests (compiled CSS assertions) + E2E spot-checks.
+
+### Stage D — brand + callouts + parity hardening + docs (bd-j8qoyc0s)
+- [ ] `_brand.yml` integration; **callouts** (the big one — depends on the C2 helper
+      foundation + revealjs callout AST output, bd-1kor9); panels/tabsets
+- [ ] Fancy title slide (authors/affiliations/ORCID/email — needs author-metadata
+      normalization); `logo:`/`footer:`; `auto-stretch`; reveal plugin foundation
+      (menu/notes/line-highlight) — from the 2026-06-16 audit backlog
 - [ ] Render/preview parity hardening; keep the vendored-asset drift guard meaningful
 - [ ] **Docs (D1 caveat):** user-facing guide on the theming variables and a
       "migrating a Quarto-1 revealjs theme to Q2" how-to, incl. the `--r-*`

--- a/crates/quarto-core/src/pipeline.rs
+++ b/crates/quarto-core/src/pipeline.rs
@@ -1057,6 +1057,24 @@ fn capture_untransformed_ast_json(content: &[u8], source_name: &str) -> Option<S
 /// 18. `AppendixStructureTransform` - Consolidate appendix content into container
 /// 19. `CrossrefRenderTransform` - Resolve crossref custom nodes to final HTML structure
 /// 20. `ResourceCollectorTransform` - Collect image dependencies
+/// Select the format-specific footer-render stage.
+///
+/// Footer *generation* is format-agnostic (`FooterGenerateTransform` →
+/// `navigation.footer`); footer *rendering* is not. `format: html` emits
+/// page-footer chrome into `rendered.navigation.footer`; `format: revealjs`
+/// emits a deck-level `.footer`/`.slide-logo` into `rendered.reveal.*` (and so
+/// must *not* run the html render, whose "skip if slot populated" hook keys a
+/// different slot). This is the one place that maps format → render stage; see
+/// the call site for why it's the seam a future format-driven composition layer
+/// would grow from.
+fn footer_render_stage(is_revealjs: bool) -> Box<dyn crate::transform::AstTransform> {
+    if is_revealjs {
+        Box::new(crate::revealjs::RevealFooterLogoTransform::new())
+    } else {
+        Box::new(FooterRenderTransform::new())
+    }
+}
+
 pub fn build_transform_pipeline(
     shortcode_paths: Vec<std::path::PathBuf>,
     extensions: Vec<crate::extension::types::Extension>,
@@ -1107,6 +1125,11 @@ pub fn build_transform_pipeline(
         // construction (the column Divs are still flat at this point).
         pipeline.push(Box::new(crate::revealjs::RevealColumnsTransform::new()));
         pipeline.push(Box::new(crate::revealjs::RevealSlidesTransform::new()));
+        // Alias Quarto-1's reveal `footer:` → `page-footer:` so it flows
+        // through the format-agnostic `FooterGenerateTransform` below. Must run
+        // before that generate (and it only touches metadata, so its position
+        // relative to slide construction is irrelevant).
+        pipeline.push(Box::new(crate::revealjs::RevealFooterAliasTransform::new()));
     } else {
         pipeline.push(Box::new(TitleBlockTransform::new()));
         pipeline.push(Box::new(SectionizeTransform::new()));
@@ -1209,7 +1232,14 @@ pub fn build_transform_pipeline(
     pipeline.push(Box::new(NavbarRenderTransform::new()));
     pipeline.push(Box::new(SidebarRenderTransform::new()));
     pipeline.push(Box::new(PageNavRenderTransform::new()));
-    pipeline.push(Box::new(FooterRenderTransform::new()));
+    // Footer *generation* (above) is format-agnostic; footer *rendering* is
+    // format-specific — html emits page-footer chrome, revealjs emits a
+    // deck-level `.footer`/`.slide-logo` into `rendered.reveal.*`. Selecting the
+    // render stage by format here (rather than scattering `is_revealjs` checks)
+    // is a deliberately small first step toward format-driven pipeline
+    // composition: as more "non-`html` HTML formats" appear, this is the seam
+    // where a format → stage-sequence mapping would grow.
+    pipeline.push(footer_render_stage(is_revealjs));
 
     // === FINALIZATION PHASE ===
     // LinkRewriteTransform runs first in the Finalization Phase

--- a/crates/quarto-core/src/pipeline.rs
+++ b/crates/quarto-core/src/pipeline.rs
@@ -1141,6 +1141,11 @@ pub fn build_transform_pipeline(
         // `Div#footnotes`), so it must run *after* it. Pure AST → benefits
         // render and preview alike. See `revealjs::footnotes`.
         pipeline.push(Box::new(crate::revealjs::RevealFootnotesTransform::new()));
+        // Auto-stretch single-image slides (add reveal's `.r-stretch`). Runs
+        // *after* footnote/aside coalescing so a slide that gained a coalesced
+        // aside has >1 body block and is correctly skipped. Default-on, gated
+        // by `auto-stretch: false`. See `revealjs::auto_stretch`.
+        pipeline.push(Box::new(crate::revealjs::RevealAutoStretchTransform::new()));
     }
     // Example-iframe embeds (bd-z1smhvuo / bd-t3cert81). Sugars
     // `Div.embed-example-iframe[file=…]` into a `CustomNode("ExampleEmbed")`.

--- a/crates/quarto-core/src/revealjs/assemble.rs
+++ b/crates/quarto-core/src/revealjs/assemble.rs
@@ -19,6 +19,8 @@
 //! Tier-1 scope: linked (non-inlined) assets, additional themes, and plugins
 //! are later phases of the revealjs epic.
 
+use std::borrow::Cow;
+
 use quarto_pandoc_types::ConfigValue;
 
 use crate::artifact::{Artifact, ArtifactScope, ArtifactStore};
@@ -76,8 +78,10 @@ pub struct RevealAsset {
     pub key_suffix: String,
     /// Output filename under the `revealjs/` lib dir.
     pub filename: String,
-    /// Embedded byte content.
-    pub content: &'static str,
+    /// Asset content: `Borrowed` for the vendored static assets (reset, core
+    /// reveal CSS/JS, quarto-reveal overrides); `Owned` for the theme slot when
+    /// it carries a freshly-compiled Quarto reveal theme.
+    pub content: Cow<'static, str>,
     /// MIME type for the artifact.
     pub content_type: &'static str,
     pub kind: RevealAssetKind,
@@ -89,41 +93,51 @@ pub struct RevealAsset {
 /// `Artifact` (key `css:revealjs:<suffix>` / `js:revealjs:<suffix>`, path
 /// `revealjs/<filename>`) so they flow through the same `site_libs` flush +
 /// dedup as `format: html`'s bootstrap/theme deps.
-pub fn reveal_assets(theme: &str) -> Vec<RevealAsset> {
+///
+/// `compiled_theme_css` supplies the **theme slot** (`3-theme-*`): `Some(css)`
+/// uses a freshly-compiled Quarto reveal theme (the normal path since Stage A of
+/// bd-r9mkybwl); `None` falls back to the vendored stock theme CSS
+/// ([`theme_css`]) — used if reveal-theme compilation fails so a deck still
+/// renders.
+pub fn reveal_assets(theme: &str, compiled_theme_css: Option<&str>) -> Vec<RevealAsset> {
     let resolved = resolve_theme_name(theme);
+    let theme_content: Cow<'static, str> = match compiled_theme_css {
+        Some(css) => Cow::Owned(css.to_string()),
+        None => Cow::Borrowed(theme_css(resolved)),
+    };
     vec![
         RevealAsset {
             key_suffix: "1-reset".to_string(),
             filename: "reset.css".to_string(),
-            content: REVEAL_RESET_CSS,
+            content: Cow::Borrowed(REVEAL_RESET_CSS),
             content_type: "text/css",
             kind: RevealAssetKind::Css,
         },
         RevealAsset {
             key_suffix: "2-reveal".to_string(),
             filename: "reveal.css".to_string(),
-            content: REVEAL_CSS,
+            content: Cow::Borrowed(REVEAL_CSS),
             content_type: "text/css",
             kind: RevealAssetKind::Css,
         },
         RevealAsset {
             key_suffix: format!("3-theme-{resolved}"),
             filename: format!("theme-{resolved}.css"),
-            content: theme_css(resolved),
+            content: theme_content,
             content_type: "text/css",
             kind: RevealAssetKind::Css,
         },
         RevealAsset {
             key_suffix: "4-quarto-reveal".to_string(),
             filename: "quarto-reveal.css".to_string(),
-            content: QUARTO_REVEAL_CSS,
+            content: Cow::Borrowed(QUARTO_REVEAL_CSS),
             content_type: "text/css",
             kind: RevealAssetKind::Css,
         },
         RevealAsset {
             key_suffix: "reveal".to_string(),
             filename: "reveal.js".to_string(),
-            content: REVEAL_JS,
+            content: Cow::Borrowed(REVEAL_JS),
             content_type: "application/javascript",
             kind: RevealAssetKind::Js,
         },
@@ -139,8 +153,16 @@ pub fn reveal_assets(theme: &str) -> Vec<RevealAsset> {
 /// Called from `CompileThemeCssStage`'s reveal branch — the pipeline point that
 /// already establishes a document's CSS-framework artifacts (and where the
 /// Bootstrap theme path is skipped for reveal).
-pub fn register_reveal_assets(artifacts: &mut ArtifactStore, theme: &str) {
-    for asset in reveal_assets(theme) {
+///
+/// `compiled_theme_css` is the freshly-compiled Quarto reveal theme for the
+/// theme slot; pass `None` to fall back to the vendored stock theme CSS (see
+/// [`reveal_assets`]).
+pub fn register_reveal_assets(
+    artifacts: &mut ArtifactStore,
+    theme: &str,
+    compiled_theme_css: Option<&str>,
+) {
+    for asset in reveal_assets(theme, compiled_theme_css) {
         let prefix = match asset.kind {
             RevealAssetKind::Css => "css",
             RevealAssetKind::Js => "js",
@@ -409,7 +431,8 @@ mod tests {
         use std::path::Path;
 
         let mut store = ArtifactStore::new();
-        register_reveal_assets(&mut store, "white");
+        // None → stock vendored theme CSS in the theme slot (the fallback path).
+        register_reveal_assets(&mut store, "white", None);
 
         // CSS artifacts, keyed so sorted order == cascade order.
         let mut css: Vec<&str> = store
@@ -466,7 +489,7 @@ mod tests {
     fn register_reveal_assets_unknown_theme_falls_back_to_white() {
         use crate::artifact::ArtifactStore;
         let mut store = ArtifactStore::new();
-        register_reveal_assets(&mut store, "no-such-theme");
+        register_reveal_assets(&mut store, "no-such-theme", None);
         assert!(store.get("css:revealjs:3-theme-white").is_some());
         assert!(store.get("css:revealjs:3-theme-no-such-theme").is_none());
     }

--- a/crates/quarto-core/src/revealjs/assemble.rs
+++ b/crates/quarto-core/src/revealjs/assemble.rs
@@ -170,10 +170,12 @@ fn escape_html(s: &str) -> String {
 
 /// Build the `Reveal.initialize(...)` config object from merged metadata.
 ///
-/// Maps Quarto/Pandoc option names to reveal.js config keys (camelCase). Only
-/// Tier-1 options are wired; unknown keys are ignored. Defaults match Quarto 1
-/// (controls/progress/hash on, `center` OFF so slides top-align, `slide`
-/// transition).
+/// Maps Quarto/Pandoc option names to reveal.js config keys (camelCase) and
+/// seeds Quarto 1's **opinionated default block** (`format-reveal.ts:343-361`),
+/// which differs from reveal's own defaults in user-visible ways: no slide
+/// transition, top-aligned slides (`center:false`), a 1050×700 deck with a 0.1
+/// margin, linear navigation, edge controls, no controls tutorial. Each option
+/// is overridable from front-matter (kebab-case keys, e.g. `controls-layout`).
 fn reveal_config_json(meta: &ConfigValue) -> String {
     let mut map = serde_json::Map::new();
 
@@ -188,26 +190,46 @@ fn reveal_config_json(meta: &ConfigValue) -> String {
     fn int_opt(meta: &ConfigValue, key: &str) -> Option<i64> {
         meta.get(key).and_then(|v| v.as_int())
     }
+    // No `as_f64` on ConfigValue; accept an int or a parseable numeric string.
+    fn float_opt(meta: &ConfigValue, key: &str) -> Option<f64> {
+        let v = meta.get(key)?;
+        if let Some(i) = v.as_int() {
+            return Some(i as f64);
+        }
+        v.as_plain_text().and_then(|s| s.trim().parse::<f64>().ok())
+    }
 
-    // Booleans with Quarto-1 defaults.
+    // Booleans — Quarto-1 opinionated defaults. `center: false` top-aligns
+    // slides (reveal's own default is true); the title slide is re-centered via
+    // a per-slide `.center` class (see `build_title_slide`).
     for (key, reveal_key, default) in [
         ("controls", "controls", true),
         ("progress", "progress", true),
-        // Quarto 1 default: slides top-align vertically (reveal's own default
-        // is true). The title slide is re-centered via a per-slide `.center`
-        // class (see `build_title_slide`), matching Q1's format-reveal.ts.
         ("center", "center", false),
         ("hash", "hash", true),
+        ("history", "history", true),
+        ("controls-tutorial", "controlsTutorial", false),
+        ("hash-one-based-index", "hashOneBasedIndex", false),
+        ("fragment-in-url", "fragmentInURL", false),
+        ("pdf-separate-fragments", "pdfSeparateFragments", false),
     ] {
         let value = bool_opt(meta, key).unwrap_or(default);
         map.insert(reveal_key.to_string(), serde_json::Value::Bool(value));
     }
 
-    // Transition (string), default "slide".
-    let transition = str_opt(meta, "transition").unwrap_or_else(|| "slide".to_string());
+    // Strings — Quarto-1 opinionated defaults (no transition, edge controls).
+    let navigation_mode = str_opt(meta, "navigation-mode").unwrap_or_else(|| "linear".to_string());
+    for (key, reveal_key, default) in [
+        ("transition", "transition", "none"),
+        ("background-transition", "backgroundTransition", "none"),
+        ("controls-layout", "controlsLayout", "edges"),
+    ] {
+        let value = str_opt(meta, key).unwrap_or_else(|| default.to_string());
+        map.insert(reveal_key.to_string(), serde_json::Value::String(value));
+    }
     map.insert(
-        "transition".to_string(),
-        serde_json::Value::String(transition),
+        "navigationMode".to_string(),
+        serde_json::Value::String(navigation_mode.clone()),
     );
     if let Some(speed) = str_opt(meta, "transition-speed") {
         map.insert(
@@ -216,21 +238,41 @@ fn reveal_config_json(meta: &ConfigValue) -> String {
         );
     }
 
-    // slide-number: either a bool or a format string (e.g. "c/t").
+    // Deck dimensions + margin — Quarto-1 opinionated defaults (1050×700, 0.1).
+    // width/height accept an int or a percentage string (e.g. "100%").
+    for (key, reveal_key, default) in [("width", "width", 1050), ("height", "height", 700)] {
+        let value = int_opt(meta, key).map(serde_json::Value::from).or_else(|| {
+            str_opt(meta, key)
+                .filter(|s| s.ends_with('%'))
+                .map(serde_json::Value::String)
+        });
+        map.insert(
+            reveal_key.to_string(),
+            value.unwrap_or_else(|| serde_json::Value::from(default)),
+        );
+    }
+    map.insert(
+        "margin".to_string(),
+        serde_json::Value::from(float_opt(meta, "margin").unwrap_or(0.1)),
+    );
+
+    // slide-number: Quarto 1 rewrites `true` → "c/t" (linear navigation) or
+    // "h.v" (vertical), and passes a format string through. Default: off.
     if let Some(v) = meta.get("slide-number") {
         if let Some(b) = v.as_bool() {
-            map.insert("slideNumber".to_string(), serde_json::Value::Bool(b));
+            if b {
+                let vertical = matches!(navigation_mode.as_str(), "default" | "grid");
+                let fmt = if vertical { "h.v" } else { "c/t" };
+                map.insert(
+                    "slideNumber".to_string(),
+                    serde_json::Value::String(fmt.to_string()),
+                );
+            } else {
+                map.insert("slideNumber".to_string(), serde_json::Value::Bool(false));
+            }
         } else if let Some(s) = v.as_plain_text() {
             map.insert("slideNumber".to_string(), serde_json::Value::String(s));
         }
-    }
-
-    // Explicit deck dimensions.
-    if let Some(w) = int_opt(meta, "width") {
-        map.insert("width".to_string(), serde_json::Value::from(w));
-    }
-    if let Some(h) = int_opt(meta, "height") {
-        map.insert("height".to_string(), serde_json::Value::from(h));
     }
 
     serde_json::to_string_pretty(&serde_json::Value::Object(map))
@@ -351,7 +393,19 @@ mod tests {
         // per-slide `.center` class, see build_title_slide).
         assert_eq!(v["center"], serde_json::json!(false));
         assert_eq!(v["hash"], serde_json::json!(true));
-        assert_eq!(v["transition"], serde_json::json!("slide"));
+        // Quarto 1's opinionated block: no transition, 1050x700 / margin 0.1,
+        // linear navigation, edge controls, no controls tutorial.
+        assert_eq!(v["transition"], serde_json::json!("none"));
+        assert_eq!(v["backgroundTransition"], serde_json::json!("none"));
+        assert_eq!(v["width"], serde_json::json!(1050));
+        assert_eq!(v["height"], serde_json::json!(700));
+        assert_eq!(v["margin"], serde_json::json!(0.1));
+        assert_eq!(v["navigationMode"], serde_json::json!("linear"));
+        assert_eq!(v["controlsLayout"], serde_json::json!("edges"));
+        assert_eq!(v["controlsTutorial"], serde_json::json!(false));
+        assert_eq!(v["history"], serde_json::json!(true));
+        assert_eq!(v["fragmentInURL"], serde_json::json!(false));
+        assert_eq!(v["pdfSeparateFragments"], serde_json::json!(false));
     }
 
     #[test]
@@ -359,8 +413,36 @@ mod tests {
         let m = meta(vec![("transition", s("fade")), ("slide-number", b(true))]);
         let cfg = reveal_config_json(&m);
         let compact: String = cfg.chars().filter(|c| !c.is_whitespace()).collect();
+        // Front-matter overrides the opinionated default.
         assert!(compact.contains("\"transition\":\"fade\""));
-        assert!(compact.contains("\"slideNumber\":true"));
+        // slide-number: true → Quarto's "c/t" format (linear navigation default).
+        assert!(compact.contains("\"slideNumber\":\"c/t\""));
+    }
+
+    #[test]
+    fn config_slide_number_vertical_navigation_uses_h_dot_v() {
+        let m = meta(vec![
+            ("slide-number", b(true)),
+            ("navigation-mode", s("grid")),
+        ]);
+        let cfg = reveal_config_json(&m);
+        let compact: String = cfg.chars().filter(|c| !c.is_whitespace()).collect();
+        assert!(compact.contains("\"slideNumber\":\"h.v\""));
+        assert!(compact.contains("\"navigationMode\":\"grid\""));
+    }
+
+    #[test]
+    fn config_front_matter_overrides_opinionated_defaults() {
+        let m = meta(vec![
+            ("transition", s("slide")),
+            ("controls-layout", s("bottom-right")),
+            ("history", b(false)),
+        ]);
+        let cfg = reveal_config_json(&m);
+        let v: serde_json::Value = serde_json::from_str(&cfg).unwrap();
+        assert_eq!(v["transition"], serde_json::json!("slide"));
+        assert_eq!(v["controlsLayout"], serde_json::json!("bottom-right"));
+        assert_eq!(v["history"], serde_json::json!(false));
     }
 
     /// CSS/JS URLs as the stage + resolver would hand them to the

--- a/crates/quarto-core/src/revealjs/assemble.rs
+++ b/crates/quarto-core/src/revealjs/assemble.rs
@@ -279,6 +279,35 @@ fn reveal_config_json(meta: &ConfigValue) -> String {
         .unwrap_or_else(|_| "{}".to_string())
 }
 
+/// Collect the deck-level footer + logo markup to place as **direct children of
+/// `.reveal`** (outside `.slides`).
+///
+/// The markup is *pre-rendered* by [`RevealFooterLogoTransform`](super::RevealFooterLogoTransform)
+/// into the `rendered.reveal.footer` / `rendered.reveal.logo` metadata slots
+/// (footer routed through the format-agnostic `FooterGenerateTransform`; logo
+/// from `logo:`). The scaffold only *places* it: footer/logo must be direct
+/// children of `.reveal`, outside `.slides`, because reveal.js applies CSS
+/// `transform` to `.slides`/`<section>`, under which a `position: fixed` element
+/// resolves against the transformed ancestor rather than the viewport. Quarto 1
+/// relocates the markup at runtime with its quarto-support reveal *plugin*;
+/// Quarto 2 ships no plugin, so we place the single deck-level elements
+/// statically here.
+///
+/// Returns `(markup, has_logo)`. `markup` is empty when neither slot is set;
+/// `has_logo` drives the `.reveal.has-logo` class (slide-number repositioning).
+fn footer_logo_html(meta: &ConfigValue) -> (String, bool) {
+    let logo = meta
+        .get_path(&["rendered", "reveal", "logo"])
+        .and_then(|v| v.as_str());
+    let footer = meta
+        .get_path(&["rendered", "reveal", "footer"])
+        .and_then(|v| v.as_str());
+
+    // Logo first, then footer (matches Quarto 1's after-body order).
+    let parts: Vec<&str> = [logo, footer].into_iter().flatten().collect();
+    (parts.join("\n"), logo.is_some())
+}
+
 /// Assemble the reveal.js HTML document, **linking** its CSS/JS assets.
 ///
 /// * `body` — the rendered slide sections (the inner HTML of `.slides`).
@@ -305,6 +334,20 @@ pub fn render_revealjs_document(
         .unwrap_or_default();
     let config = reveal_config_json(meta);
 
+    // Deck-level footer/logo live OUTSIDE `.slides` (see `footer_logo_html`).
+    let (footer_logo, has_logo) = footer_logo_html(meta);
+    let reveal_class = if has_logo {
+        "reveal has-logo"
+    } else {
+        "reveal"
+    };
+    // Emit on its own line only when present, so an empty deck stays clean.
+    let footer_logo_block = if footer_logo.is_empty() {
+        String::new()
+    } else {
+        format!("\n{footer_logo}")
+    };
+
     let links = css_urls
         .iter()
         .map(|url| format!(r#"<link rel="stylesheet" href="{}">"#, attr_escape(url)))
@@ -326,10 +369,10 @@ pub fn render_revealjs_document(
 {links}
 </head>
 <body>
-<div class="reveal">
+<div class="{reveal_class}">
 <div class="slides">
 {body}
-</div>
+</div>{footer_logo_block}
 </div>
 {scripts}
 <script>
@@ -339,8 +382,10 @@ Reveal.initialize({config});
 </html>
 "#,
         title = escape_html(&title),
+        reveal_class = reveal_class,
         links = links,
         body = body,
+        footer_logo_block = footer_logo_block,
         scripts = scripts,
         config = config,
     )
@@ -589,6 +634,70 @@ mod tests {
             theme_key(&b),
             theme_key(&b2),
             "identical CSS → identical key (dedup)"
+        );
+    }
+
+    /// A metadata map carrying a pre-rendered `rendered.reveal.<key>` slot, as
+    /// `RevealFooterLogoTransform` would have populated it.
+    fn meta_with_slot(slot: &str, html: &str) -> ConfigValue {
+        let mut m = meta(vec![("title", s("T"))]);
+        m.insert_path(&["rendered", "reveal", slot], s(html));
+        m
+    }
+
+    /// The index where `.slides` closes — everything the deck-level footer/logo
+    /// places must come *after* this (outside `.slides`) but before `.reveal`
+    /// closes, so reveal's slide transforms don't break their fixed positioning.
+    fn slides_close_idx(html: &str) -> usize {
+        let slides_open = html.find(r#"<div class="slides">"#).expect("slides open");
+        // the first `</div>` after the slides open closes `.slides`
+        slides_open + html[slides_open..].find("</div>").expect("slides close")
+    }
+
+    #[test]
+    fn footer_slot_placed_outside_slides() {
+        let m = meta_with_slot(
+            "footer",
+            r#"<div class="footer footer-default">© 2026</div>"#,
+        );
+        let html = render_revealjs_document("<section></section>", &m, &sample_css(), &sample_js());
+        let footer_at = html
+            .find(r#"<div class="footer footer-default">"#)
+            .expect("footer placed");
+        assert!(
+            footer_at > slides_close_idx(&html),
+            "footer must be placed after `.slides` closes (outside it)"
+        );
+    }
+
+    #[test]
+    fn logo_slot_placed_outside_slides_and_marks_reveal() {
+        let m = meta_with_slot("logo", r#"<img class="slide-logo" src="logo.png">"#);
+        let html = render_revealjs_document("<section></section>", &m, &sample_css(), &sample_js());
+        let logo_at = html.find(r#"class="slide-logo""#).expect("logo placed");
+        assert!(
+            logo_at > slides_close_idx(&html),
+            "logo must be placed after `.slides` closes (outside it)"
+        );
+        // `.reveal` gains `has-logo` so slide-number repositioning kicks in.
+        assert!(
+            html.contains(r#"<div class="reveal has-logo">"#),
+            "reveal element should carry `has-logo` when the logo slot is set"
+        );
+    }
+
+    #[test]
+    fn no_slots_emits_no_markup_and_no_has_logo() {
+        let m = meta(vec![("title", s("T"))]);
+        let html = render_revealjs_document("<section></section>", &m, &sample_css(), &sample_js());
+        assert!(!html.contains("slide-logo"), "no logo markup expected");
+        assert!(
+            !html.contains("footer-default"),
+            "no footer markup expected"
+        );
+        assert!(
+            html.contains(r#"<div class="reveal">"#),
+            "reveal element has no has-logo class without a logo slot"
         );
     }
 

--- a/crates/quarto-core/src/revealjs/assemble.rs
+++ b/crates/quarto-core/src/revealjs/assemble.rs
@@ -34,28 +34,9 @@ const THEME_WHITE_CSS: &str = include_str!("../../../../resources/revealjs/theme
 /// the same file. Keep render/preview in sync by editing only the one file.
 const QUARTO_REVEAL_CSS: &str = include_str!("../../../../resources/revealjs/quarto-reveal.css");
 
-/// Default reveal theme when `theme:` is absent. Consumed by
-/// `RevealAssetsStage` to pick the theme artifact.
-pub const DEFAULT_THEME: &str = "white";
-
-/// Resolve a requested theme name to the canonical name we actually ship.
-/// Tier-1 ships only `white`; unknown themes fall back to it. Returning the
-/// **resolved** name (not the requested one) keeps the artifact key/filename
-/// stable so two decks that both fall back to `white` dedup to one copy.
-fn resolve_theme_name(theme: &str) -> &'static str {
-    match theme {
-        "white" => "white",
-        _ => "white",
-    }
-}
-
-/// Theme CSS bytes for a *resolved* theme name (see [`resolve_theme_name`]).
-fn theme_css(resolved: &str) -> &'static str {
-    match resolved {
-        "white" => THEME_WHITE_CSS,
-        _ => THEME_WHITE_CSS,
-    }
-}
+/// Default reveal theme when `theme:` is absent. The reveal theme *resolver*
+/// (`crate::revealjs::theme`) defaults to this; `white` aliases to it.
+pub const DEFAULT_THEME: &str = "default";
 
 /// Kind of a vendored reveal asset (decides the `css:` / `js:` artifact key
 /// prefix and the emitted tag).
@@ -94,17 +75,23 @@ pub struct RevealAsset {
 /// `revealjs/<filename>`) so they flow through the same `site_libs` flush +
 /// dedup as `format: html`'s bootstrap/theme deps.
 ///
-/// `compiled_theme_css` supplies the **theme slot** (`3-theme-*`): `Some(css)`
-/// uses a freshly-compiled Quarto reveal theme (the normal path since Stage A of
-/// bd-r9mkybwl); `None` falls back to the vendored stock theme CSS
-/// ([`theme_css`]) — used if reveal-theme compilation fails so a deck still
-/// renders.
-pub fn reveal_assets(theme: &str, compiled_theme_css: Option<&str>) -> Vec<RevealAsset> {
-    let resolved = resolve_theme_name(theme);
+/// `compiled_theme_css` supplies the **theme slot** (`3-theme-<fingerprint>`):
+/// `Some(css)` uses a freshly-compiled Quarto reveal theme (the normal path);
+/// `None` falls back to the vendored stock reveal theme CSS — used if
+/// reveal-theme compilation fails so a deck still renders.
+///
+/// The theme slot's key/filename carry a **content fingerprint** of the theme
+/// CSS (like `format: html`'s `css:theme:<hash>`). This makes per-deck themes in
+/// a website work correctly: identical themes dedup to one shared file; distinct
+/// themes get distinct files and each deck links its own (collected per-document
+/// from that deck's `StageContext.artifacts`). The `3-theme-` prefix keeps the
+/// CSS cascade order (between `2-reveal` and `4-quarto-reveal`).
+pub fn reveal_assets(compiled_theme_css: Option<&str>) -> Vec<RevealAsset> {
     let theme_content: Cow<'static, str> = match compiled_theme_css {
         Some(css) => Cow::Owned(css.to_string()),
-        None => Cow::Borrowed(theme_css(resolved)),
+        None => Cow::Borrowed(THEME_WHITE_CSS),
     };
+    let fingerprint = crate::stage::stages::theme_fingerprint(&theme_content);
     vec![
         RevealAsset {
             key_suffix: "1-reset".to_string(),
@@ -121,8 +108,8 @@ pub fn reveal_assets(theme: &str, compiled_theme_css: Option<&str>) -> Vec<Revea
             kind: RevealAssetKind::Css,
         },
         RevealAsset {
-            key_suffix: format!("3-theme-{resolved}"),
-            filename: format!("theme-{resolved}.css"),
+            key_suffix: format!("3-theme-{fingerprint}"),
+            filename: format!("theme-{fingerprint}.css"),
             content: theme_content,
             content_type: "text/css",
             kind: RevealAssetKind::Css,
@@ -157,12 +144,8 @@ pub fn reveal_assets(theme: &str, compiled_theme_css: Option<&str>) -> Vec<Revea
 /// `compiled_theme_css` is the freshly-compiled Quarto reveal theme for the
 /// theme slot; pass `None` to fall back to the vendored stock theme CSS (see
 /// [`reveal_assets`]).
-pub fn register_reveal_assets(
-    artifacts: &mut ArtifactStore,
-    theme: &str,
-    compiled_theme_css: Option<&str>,
-) {
-    for asset in reveal_assets(theme, compiled_theme_css) {
+pub fn register_reveal_assets(artifacts: &mut ArtifactStore, compiled_theme_css: Option<&str>) {
+    for asset in reveal_assets(compiled_theme_css) {
         let prefix = match asset.kind {
             RevealAssetKind::Css => "css",
             RevealAssetKind::Js => "js",
@@ -439,9 +422,14 @@ mod tests {
 
         let mut store = ArtifactStore::new();
         // None → stock vendored theme CSS in the theme slot (the fallback path).
-        register_reveal_assets(&mut store, "white", None);
+        register_reveal_assets(&mut store, None);
 
-        // CSS artifacts, keyed so sorted order == cascade order.
+        // The theme slot is keyed by a content fingerprint of the stock theme.
+        let theme_fp = crate::stage::stages::theme_fingerprint(THEME_WHITE_CSS);
+        let theme_key = format!("css:revealjs:3-theme-{theme_fp}");
+
+        // CSS artifacts, keyed so sorted order == cascade order
+        // (1-reset < 2-reveal < 3-theme-<fp> < 4-quarto-reveal).
         let mut css: Vec<&str> = store
             .get_by_prefix("css:revealjs:")
             .into_iter()
@@ -453,7 +441,7 @@ mod tests {
             vec![
                 "css:revealjs:1-reset",
                 "css:revealjs:2-reveal",
-                "css:revealjs:3-theme-white",
+                theme_key.as_str(),
                 "css:revealjs:4-quarto-reveal",
             ]
         );
@@ -475,11 +463,11 @@ mod tests {
         );
         assert_eq!(reveal.as_str(), Some(REVEAL_CSS));
 
-        // theme artifact carries the resolved theme name + the theme bytes.
-        let theme = store.get("css:revealjs:3-theme-white").unwrap();
+        // theme artifact: fingerprinted path + the (fallback stock) theme bytes.
+        let theme = store.get(&theme_key).unwrap();
         assert_eq!(
             theme.path.as_deref(),
-            Some(Path::new("revealjs/theme-white.css"))
+            Some(Path::new(&*format!("revealjs/theme-{theme_fp}.css")))
         );
         assert_eq!(theme.as_str(), Some(THEME_WHITE_CSS));
 
@@ -490,15 +478,36 @@ mod tests {
         assert_eq!(core.as_str(), Some(REVEAL_JS));
     }
 
-    /// An unknown theme falls back to `white` for both content AND
-    /// key/filename, so two decks requesting unknown themes still dedup.
+    /// Distinct theme CSS → distinct fingerprinted keys (so per-deck themes in a
+    /// website don't collide); identical theme CSS → identical key (dedups).
     #[test]
-    fn register_reveal_assets_unknown_theme_falls_back_to_white() {
+    fn register_reveal_assets_keys_theme_by_content_fingerprint() {
         use crate::artifact::ArtifactStore;
-        let mut store = ArtifactStore::new();
-        register_reveal_assets(&mut store, "no-such-theme", None);
-        assert!(store.get("css:revealjs:3-theme-white").is_some());
-        assert!(store.get("css:revealjs:3-theme-no-such-theme").is_none());
+
+        let mut a = ArtifactStore::new();
+        register_reveal_assets(&mut a, Some(".reveal{color:red}"));
+        let mut b = ArtifactStore::new();
+        register_reveal_assets(&mut b, Some(".reveal{color:blue}"));
+        let mut b2 = ArtifactStore::new();
+        register_reveal_assets(&mut b2, Some(".reveal{color:blue}"));
+
+        let theme_key = |s: &ArtifactStore| {
+            s.get_by_prefix("css:revealjs:3-theme-")
+                .into_iter()
+                .map(|(k, _)| k.to_string())
+                .next()
+                .unwrap()
+        };
+        assert_ne!(
+            theme_key(&a),
+            theme_key(&b),
+            "different CSS → different keys"
+        );
+        assert_eq!(
+            theme_key(&b),
+            theme_key(&b2),
+            "identical CSS → identical key (dedup)"
+        );
     }
 
     #[test]

--- a/crates/quarto-core/src/revealjs/assemble.rs
+++ b/crates/quarto-core/src/revealjs/assemble.rs
@@ -189,7 +189,8 @@ fn escape_html(s: &str) -> String {
 ///
 /// Maps Quarto/Pandoc option names to reveal.js config keys (camelCase). Only
 /// Tier-1 options are wired; unknown keys are ignored. Defaults match Quarto 1
-/// (controls/progress/center/hash on, `slide` transition).
+/// (controls/progress/hash on, `center` OFF so slides top-align, `slide`
+/// transition).
 fn reveal_config_json(meta: &ConfigValue) -> String {
     let mut map = serde_json::Map::new();
 
@@ -209,7 +210,10 @@ fn reveal_config_json(meta: &ConfigValue) -> String {
     for (key, reveal_key, default) in [
         ("controls", "controls", true),
         ("progress", "progress", true),
-        ("center", "center", true),
+        // Quarto 1 default: slides top-align vertically (reveal's own default
+        // is true). The title slide is re-centered via a per-slide `.center`
+        // class (see `build_title_slide`), matching Q1's format-reveal.ts.
+        ("center", "center", false),
         ("hash", "hash", true),
     ] {
         let value = bool_opt(meta, key).unwrap_or(default);
@@ -359,7 +363,10 @@ mod tests {
         let v: serde_json::Value = serde_json::from_str(&cfg).unwrap();
         assert_eq!(v["controls"], serde_json::json!(true));
         assert_eq!(v["progress"], serde_json::json!(true));
-        assert_eq!(v["center"], serde_json::json!(true));
+        // Quarto 1 defaults center:false — body slides top-align vertically
+        // (reveal's own default is true; the title slide is re-centered via a
+        // per-slide `.center` class, see build_title_slide).
+        assert_eq!(v["center"], serde_json::json!(false));
         assert_eq!(v["hash"], serde_json::json!(true));
         assert_eq!(v["transition"], serde_json::json!("slide"));
     }

--- a/crates/quarto-core/src/revealjs/auto_stretch.rs
+++ b/crates/quarto-core/src/revealjs/auto_stretch.rs
@@ -1,0 +1,460 @@
+/*
+ * revealjs/auto_stretch.rs
+ * Copyright (c) 2026 Posit, PBC
+ *
+ * RevealAutoStretchTransform: add `.r-stretch` to single-image slides.
+ */
+
+//! Auto-stretch single-image slides (Stage D4).
+//!
+//! Quarto 1 sizes a lone slide image to fill the available vertical space by
+//! adding reveal's core `.r-stretch` class (`format-reveal.ts` `applyStretch`).
+//! Without it, a large image overflows the slide. This transform ports the
+//! **default-on** behavior, gated by `auto-stretch: false` (Q1's schema default
+//! is `true`).
+//!
+//! `.r-stretch` is a **reveal-core** class — no Quarto SCSS is needed. This is
+//! therefore a pure AST transform: it adds the class to the image and lets
+//! reveal's own layout size it.
+//!
+//! Scope (conservative, matching this stage's plan; **narrower than Q1**):
+//! a slide qualifies only when its content — *ignoring the slide heading* — is
+//! exactly **one** block that is a `Paragraph` wrapping a single `Image`, or a
+//! `Figure` wrapping a single `Image`. Q1 is more aggressive (it stretches a
+//! lone image even on a slide that also has text); we stretch only
+//! single-image slides, where overflow is the real problem and there is no text
+//! for the stretch to collide with.
+//!
+//! Opt-outs (ported from Q1 `applyStretch`):
+//! - `auto-stretch: false` in metadata — disables the whole transform.
+//! - a slide section with class `.nostretch`.
+//! - an image with class `.nostretch` (the class is removed and the image
+//!   skipped) or `.absolute`, or one already carrying `.stretch`/`.r-stretch`.
+//! - an image with **explicit sizing**. Q1 guards only `height`; we also guard
+//!   `width` (attribute or inline `style`), so an author who deliberately sized
+//!   an image is never overridden — a small, sound divergence in the
+//!   conservative direction.
+//!
+//! Runs after `RevealSlidesTransform` (the `<section>` tree must exist) and
+//! after `RevealFootnotesTransform` (so a slide with a coalesced footnote/aside
+//! has >1 body block and is naturally skipped). WASM-safe (pure AST).
+
+use quarto_pandoc_types::block::{Block, Div, Figure};
+use quarto_pandoc_types::inline::{Image, Inline};
+use quarto_pandoc_types::pandoc::Pandoc;
+
+use crate::Result;
+use crate::render::RenderContext;
+use crate::transform::AstTransform;
+
+const STRETCH_CLASS: &str = "r-stretch";
+
+/// Transform that adds `.r-stretch` to single-image reveal slides.
+pub struct RevealAutoStretchTransform;
+
+impl RevealAutoStretchTransform {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for RevealAutoStretchTransform {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait::async_trait(?Send)]
+impl AstTransform for RevealAutoStretchTransform {
+    fn name(&self) -> &str {
+        "reveal-auto-stretch"
+    }
+
+    async fn transform(&self, ast: &mut Pandoc, _ctx: &mut RenderContext) -> Result<()> {
+        let auto_stretch = ast
+            .meta
+            .get("auto-stretch")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
+        walk_sections(&mut ast.blocks, auto_stretch);
+        Ok(())
+    }
+}
+
+/// Walk the slide tree, applying stretch to qualifying leaf sections and
+/// recursing into stacks (whose direct children are nested sections).
+fn walk_sections(blocks: &mut [Block], auto_stretch: bool) {
+    for block in blocks {
+        if let Block::Div(div) = block {
+            if is_section(div) {
+                maybe_stretch_section(div, auto_stretch);
+            }
+            // Recurse so nested (vertical-stack) sections are reached. A stack's
+            // own body is nested sections, so `maybe_stretch_section` no-ops on
+            // it (not a single image block) before we descend.
+            walk_sections(&mut div.content, auto_stretch);
+        }
+    }
+}
+
+fn is_section(div: &Div) -> bool {
+    div.attr.1.iter().any(|c| c == "section")
+}
+
+/// Add `.r-stretch` to the lone image of a single-image leaf slide, honoring
+/// the opt-outs. No-op for stacks, multi-block slides, sized/opted-out images.
+fn maybe_stretch_section(div: &mut Div, auto_stretch: bool) {
+    // Per-slide opt-out.
+    if div.attr.1.iter().any(|c| c == "nostretch") {
+        return;
+    }
+
+    // The slide body is everything but the heading(s). Exactly one body block
+    // qualifies a single-image slide.
+    let body: Vec<usize> = div
+        .content
+        .iter()
+        .enumerate()
+        .filter(|(_, b)| !matches!(b, Block::Header(_)))
+        .map(|(i, _)| i)
+        .collect();
+    if body.len() != 1 {
+        return;
+    }
+
+    let Some(image) = body_image_mut(&mut div.content[body[0]]) else {
+        return;
+    };
+
+    // Per-image opt-outs. `.nostretch` is consumed (removed) per Q1.
+    if let Some(pos) = image.attr.1.iter().position(|c| c == "nostretch") {
+        image.attr.1.remove(pos);
+        return;
+    }
+    if image.attr.1.iter().any(|c| c == "absolute") {
+        return;
+    }
+    if image
+        .attr
+        .1
+        .iter()
+        .any(|c| c == STRETCH_CLASS || c == "stretch")
+    {
+        return; // already stretched (explicit or idempotent re-run)
+    }
+    if has_explicit_size(image) {
+        return;
+    }
+
+    if auto_stretch {
+        image.attr.1.push(STRETCH_CLASS.to_string());
+    }
+}
+
+/// A mutable reference to the slide's lone image, when the body block is a
+/// `Paragraph` whose only inline is an `Image`, or a `Figure` wrapping exactly
+/// one image. Otherwise `None`.
+fn body_image_mut(block: &mut Block) -> Option<&mut Image> {
+    match block {
+        Block::Paragraph(p) if p.content.len() == 1 => match &mut p.content[0] {
+            Inline::Image(img) => Some(img),
+            _ => None,
+        },
+        Block::Figure(f) if count_figure_images(f) == 1 => figure_image_mut(f),
+        _ => None,
+    }
+}
+
+/// Count `Image` inlines directly inside a figure's `Paragraph`/`Plain` blocks.
+fn count_figure_images(f: &Figure) -> usize {
+    f.content
+        .iter()
+        .map(|b| match b {
+            Block::Paragraph(p) => image_count(&p.content),
+            Block::Plain(p) => image_count(&p.content),
+            _ => 0,
+        })
+        .sum()
+}
+
+fn image_count(inlines: &[Inline]) -> usize {
+    inlines
+        .iter()
+        .filter(|i| matches!(i, Inline::Image(_)))
+        .count()
+}
+
+/// First `Image` mutable ref inside a figure's `Paragraph`/`Plain` blocks.
+fn figure_image_mut(f: &mut Figure) -> Option<&mut Image> {
+    for b in &mut f.content {
+        let inlines = match b {
+            Block::Paragraph(p) => &mut p.content,
+            Block::Plain(p) => &mut p.content,
+            _ => continue,
+        };
+        for inline in inlines {
+            if let Inline::Image(img) = inline {
+                return Some(img);
+            }
+        }
+    }
+    None
+}
+
+/// Whether the image already carries explicit `width`/`height` sizing (an attr
+/// key or an inline `style` declaration). Such images are left untouched.
+fn has_explicit_size(image: &Image) -> bool {
+    let kvs = &image.attr.2;
+    if kvs.contains_key("width") || kvs.contains_key("height") {
+        return true;
+    }
+    if let Some(style) = kvs.get("style") {
+        let s = style.to_ascii_lowercase();
+        if s.contains("height:") || s.contains("width:") {
+            return true;
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hashlink::LinkedHashMap;
+    use quarto_pandoc_types::Caption;
+    use quarto_pandoc_types::attr::{AttrSourceInfo, TargetSourceInfo};
+    use quarto_pandoc_types::block::{Figure, Header, Paragraph};
+    use quarto_pandoc_types::inline::Str;
+    use quarto_source_map::{By, SourceInfo};
+
+    fn si() -> SourceInfo {
+        SourceInfo::generated(By::revealjs())
+    }
+
+    fn image(classes: &[&str], kvs: &[(&str, &str)]) -> Inline {
+        let mut m = LinkedHashMap::new();
+        for (k, v) in kvs {
+            m.insert(k.to_string(), v.to_string());
+        }
+        Inline::Image(Image {
+            attr: (
+                String::new(),
+                classes.iter().map(|s| s.to_string()).collect(),
+                m,
+            ),
+            content: vec![],
+            target: ("pic.png".to_string(), String::new()),
+            source_info: si(),
+            attr_source: AttrSourceInfo::empty(),
+            target_source: TargetSourceInfo::empty(),
+        })
+    }
+
+    fn para(inlines: Vec<Inline>) -> Block {
+        Block::Paragraph(Paragraph {
+            content: inlines,
+            source_info: si(),
+        })
+    }
+
+    fn header() -> Block {
+        Block::Header(Header {
+            level: 2,
+            attr: (String::new(), vec![], LinkedHashMap::new()),
+            content: vec![Inline::Str(Str {
+                text: "Slide".to_string(),
+                source_info: si(),
+            })],
+            source_info: si(),
+            attr_source: AttrSourceInfo::empty(),
+        })
+    }
+
+    fn section(classes: &[&str], content: Vec<Block>) -> Block {
+        let mut cls = vec!["section".to_string()];
+        cls.extend(classes.iter().map(|s| s.to_string()));
+        Block::Div(Div {
+            attr: (String::new(), cls, LinkedHashMap::new()),
+            content,
+            source_info: si(),
+            attr_source: AttrSourceInfo::empty(),
+        })
+    }
+
+    fn figure(blocks: Vec<Block>) -> Block {
+        Block::Figure(Figure {
+            attr: (String::new(), vec![], LinkedHashMap::new()),
+            caption: Caption {
+                short: None,
+                long: None,
+                source_info: si(),
+            },
+            content: blocks,
+            source_info: si(),
+            attr_source: AttrSourceInfo::empty(),
+        })
+    }
+
+    /// Classes on the lone image of the first section, after running the walk.
+    fn stretch_classes(mut blocks: Vec<Block>, auto_stretch: bool) -> Vec<String> {
+        walk_sections(&mut blocks, auto_stretch);
+        let Block::Div(div) = &blocks[0] else {
+            panic!("expected section");
+        };
+        // find the image anywhere in the section
+        fn find(blocks: &[Block]) -> Option<&Image> {
+            for b in blocks {
+                match b {
+                    Block::Paragraph(p) => {
+                        for i in &p.content {
+                            if let Inline::Image(img) = i {
+                                return Some(img);
+                            }
+                        }
+                    }
+                    Block::Plain(p) => {
+                        for i in &p.content {
+                            if let Inline::Image(img) = i {
+                                return Some(img);
+                            }
+                        }
+                    }
+                    Block::Figure(f) => {
+                        if let Some(img) = find(&f.content) {
+                            return Some(img);
+                        }
+                    }
+                    Block::Div(d) => {
+                        if let Some(img) = find(&d.content) {
+                            return Some(img);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            None
+        }
+        find(&div.content).expect("image present").attr.1.clone()
+    }
+
+    #[test]
+    fn lone_paragraph_image_gets_stretch() {
+        let blocks = vec![section(&[], vec![header(), para(vec![image(&[], &[])])])];
+        assert!(stretch_classes(blocks, true).contains(&"r-stretch".to_string()));
+    }
+
+    #[test]
+    fn figure_image_gets_stretch() {
+        let blocks = vec![section(
+            &[],
+            vec![header(), figure(vec![para(vec![image(&[], &[])])])],
+        )];
+        assert!(stretch_classes(blocks, true).contains(&"r-stretch".to_string()));
+    }
+
+    #[test]
+    fn image_without_heading_gets_stretch() {
+        let blocks = vec![section(&[], vec![para(vec![image(&[], &[])])])];
+        assert!(stretch_classes(blocks, true).contains(&"r-stretch".to_string()));
+    }
+
+    #[test]
+    fn auto_stretch_false_disables() {
+        let blocks = vec![section(&[], vec![header(), para(vec![image(&[], &[])])])];
+        assert!(!stretch_classes(blocks, false).contains(&"r-stretch".to_string()));
+    }
+
+    #[test]
+    fn multi_block_slide_skipped() {
+        // heading + image + a second paragraph → not single-image.
+        let blocks = vec![section(
+            &[],
+            vec![
+                header(),
+                para(vec![image(&[], &[])]),
+                para(vec![Inline::Str(Str {
+                    text: "text".to_string(),
+                    source_info: si(),
+                })]),
+            ],
+        )];
+        assert!(!stretch_classes(blocks, true).contains(&"r-stretch".to_string()));
+    }
+
+    #[test]
+    fn inline_image_among_text_skipped() {
+        let blocks = vec![section(
+            &[],
+            vec![
+                header(),
+                para(vec![
+                    Inline::Str(Str {
+                        text: "Here".to_string(),
+                        source_info: si(),
+                    }),
+                    image(&[], &[]),
+                ]),
+            ],
+        )];
+        assert!(!stretch_classes(blocks, true).contains(&"r-stretch".to_string()));
+    }
+
+    #[test]
+    fn sized_image_skipped() {
+        let width = vec![section(
+            &[],
+            vec![para(vec![image(&[], &[("width", "300")])])],
+        )];
+        assert!(!stretch_classes(width, true).contains(&"r-stretch".to_string()));
+        let height = vec![section(
+            &[],
+            vec![para(vec![image(&[], &[("height", "200")])])],
+        )];
+        assert!(!stretch_classes(height, true).contains(&"r-stretch".to_string()));
+        let styled = vec![section(
+            &[],
+            vec![para(vec![image(&[], &[("style", "height: 4em;")])])],
+        )];
+        assert!(!stretch_classes(styled, true).contains(&"r-stretch".to_string()));
+    }
+
+    #[test]
+    fn slide_nostretch_opts_out() {
+        let blocks = vec![section(
+            &["nostretch"],
+            vec![header(), para(vec![image(&[], &[])])],
+        )];
+        assert!(!stretch_classes(blocks, true).contains(&"r-stretch".to_string()));
+    }
+
+    #[test]
+    fn image_nostretch_opts_out_and_class_removed() {
+        let blocks = vec![section(
+            &[],
+            vec![header(), para(vec![image(&["nostretch"], &[])])],
+        )];
+        let classes = stretch_classes(blocks, true);
+        assert!(!classes.contains(&"r-stretch".to_string()));
+        assert!(
+            !classes.contains(&"nostretch".to_string()),
+            "nostretch should be consumed"
+        );
+    }
+
+    #[test]
+    fn image_absolute_skipped() {
+        let blocks = vec![section(&[], vec![para(vec![image(&["absolute"], &[])])])];
+        assert!(!stretch_classes(blocks, true).contains(&"r-stretch".to_string()));
+    }
+
+    #[test]
+    fn already_stretched_is_idempotent() {
+        let blocks = vec![section(&[], vec![para(vec![image(&["r-stretch"], &[])])])];
+        let classes = stretch_classes(blocks, true);
+        assert_eq!(
+            classes.iter().filter(|c| *c == "r-stretch").count(),
+            1,
+            "no duplicate r-stretch on re-run"
+        );
+    }
+}

--- a/crates/quarto-core/src/revealjs/auto_stretch.rs
+++ b/crates/quarto-core/src/revealjs/auto_stretch.rs
@@ -17,13 +17,19 @@
 //! therefore a pure AST transform: it adds the class to the image and lets
 //! reveal's own layout size it.
 //!
-//! Scope (conservative, matching this stage's plan; **narrower than Q1**):
-//! a slide qualifies only when its content — *ignoring the slide heading* — is
-//! exactly **one** block that is a `Paragraph` wrapping a single `Image`, or a
-//! `Figure` wrapping a single `Image`. Q1 is more aggressive (it stretches a
-//! lone image even on a slide that also has text); we stretch only
-//! single-image slides, where overflow is the real problem and there is no text
-//! for the stretch to collide with.
+//! Scope (matches Quarto 1's `applyStretch`): a slide qualifies when it holds
+//! exactly **one** image (peripheral `.notes`/`.aside` content aside), carries
+//! no `.aside`, and that image sits in a *standalone* top-level block — a
+//! `Paragraph` whose only inline is the image, or a `Figure`. Sibling blocks (a
+//! heading, an explanatory paragraph) are allowed: reveal sizes the image to
+//! the space they leave, so the common "heading + a sentence + a diagram" slide
+//! stretches. An image nested in a `.column`/layout/fragment div, an image
+//! among inline text, or a multi-image slide is left untouched.
+//!
+//! We still **don't** do Q1's DOM hoisting (moving the `<img>` to be a direct
+//! child of `<section>` and re-inserting the figure caption); Chrome E2E
+//! confirmed reveal sizes the nested `<p><img class=r-stretch>` / figure image
+//! correctly without it.
 //!
 //! Opt-outs (ported from Q1 `applyStretch`):
 //! - `auto-stretch: false` in metadata — disables the whole transform.
@@ -101,54 +107,86 @@ fn is_section(div: &Div) -> bool {
     div.attr.1.iter().any(|c| c == "section")
 }
 
-/// Add `.r-stretch` to the lone image of a single-image leaf slide, honoring
-/// the opt-outs. No-op for stacks, multi-block slides, sized/opted-out images.
+/// Add `.r-stretch` to the lone image of a slide, honoring the opt-outs.
+///
+/// A slide qualifies when it holds exactly **one** image (counting everything
+/// but speaker `.notes`), carries no peripheral `.aside`, and that image lives
+/// in a *standalone* top-level block — a `Paragraph` whose only inline is the
+/// image, or a `Figure`. Other blocks (a heading, explanatory paragraphs) may
+/// coexist: reveal sizes the image to the space they leave. This matches Quarto
+/// 1's `applyStretch`; an image nested in a `.column`/layout/fragment div, an
+/// image among inline text, or a multi-image slide is left untouched.
 fn maybe_stretch_section(div: &mut Div, auto_stretch: bool) {
-    // Per-slide opt-out.
+    // Per-slide opt-out, peripheral aside, and exactly-one-image gates.
     if div.attr.1.iter().any(|c| c == "nostretch") {
         return;
     }
+    if contains_aside(&div.content) {
+        return;
+    }
+    if count_images(&div.content) != 1 {
+        return;
+    }
 
-    // The slide body is everything but the heading(s). Exactly one body block
-    // qualifies a single-image slide.
-    let body: Vec<usize> = div
-        .content
+    // The image must sit in a standalone top-level block (Paragraph[Image] or
+    // Figure). If the single image is nested in a custom/layout div, no
+    // top-level block is eligible and we leave it alone.
+    for block in &mut div.content {
+        let Some(image) = body_image_mut(block) else {
+            continue;
+        };
+
+        // Per-image opt-outs. `.nostretch` is consumed (removed) per Q1.
+        if let Some(pos) = image.attr.1.iter().position(|c| c == "nostretch") {
+            image.attr.1.remove(pos);
+            return;
+        }
+        if image.attr.1.iter().any(|c| c == "absolute") {
+            return;
+        }
+        if image
+            .attr
+            .1
+            .iter()
+            .any(|c| c == STRETCH_CLASS || c == "stretch")
+        {
+            return; // already stretched (explicit or idempotent re-run)
+        }
+        if has_explicit_size(image) {
+            return;
+        }
+        if auto_stretch {
+            image.attr.1.push(STRETCH_CLASS.to_string());
+        }
+        return;
+    }
+}
+
+/// Whether the block tree contains a peripheral `.aside` div (a coalesced
+/// footnote block or an author `.aside`). Speaker `.notes` do not count.
+fn contains_aside(blocks: &[Block]) -> bool {
+    blocks.iter().any(|b| match b {
+        Block::Div(d) if d.attr.1.iter().any(|c| c == "aside") => true,
+        Block::Div(d) => contains_aside(&d.content),
+        Block::Figure(f) => contains_aside(&f.content),
+        _ => false,
+    })
+}
+
+/// Count `Image` inlines across the slide, skipping `.notes`/`.aside` divs
+/// (their images are peripheral and should not gate auto-stretch).
+fn count_images(blocks: &[Block]) -> usize {
+    blocks
         .iter()
-        .enumerate()
-        .filter(|(_, b)| !matches!(b, Block::Header(_)))
-        .map(|(i, _)| i)
-        .collect();
-    if body.len() != 1 {
-        return;
-    }
-
-    let Some(image) = body_image_mut(&mut div.content[body[0]]) else {
-        return;
-    };
-
-    // Per-image opt-outs. `.nostretch` is consumed (removed) per Q1.
-    if let Some(pos) = image.attr.1.iter().position(|c| c == "nostretch") {
-        image.attr.1.remove(pos);
-        return;
-    }
-    if image.attr.1.iter().any(|c| c == "absolute") {
-        return;
-    }
-    if image
-        .attr
-        .1
-        .iter()
-        .any(|c| c == STRETCH_CLASS || c == "stretch")
-    {
-        return; // already stretched (explicit or idempotent re-run)
-    }
-    if has_explicit_size(image) {
-        return;
-    }
-
-    if auto_stretch {
-        image.attr.1.push(STRETCH_CLASS.to_string());
-    }
+        .map(|b| match b {
+            Block::Paragraph(p) => image_count(&p.content),
+            Block::Plain(p) => image_count(&p.content),
+            Block::Figure(f) => count_images(&f.content),
+            Block::Div(d) if d.attr.1.iter().any(|c| c == "notes" || c == "aside") => 0,
+            Block::Div(d) => count_images(&d.content),
+            _ => 0,
+        })
+        .sum()
 }
 
 /// A mutable reference to the slide's lone image, when the body block is a
@@ -365,19 +403,75 @@ mod tests {
     }
 
     #[test]
-    fn multi_block_slide_skipped() {
-        // heading + image + a second paragraph → not single-image.
+    fn lone_image_with_sibling_text_stretches() {
+        // heading + explanatory paragraph + a standalone image → the lone image
+        // still stretches (matches Q1: one image, in its own block, amid text).
+        let blocks = vec![section(
+            &[],
+            vec![
+                header(),
+                para(vec![Inline::Str(Str {
+                    text: "Here is our architecture:".to_string(),
+                    source_info: si(),
+                })]),
+                para(vec![image(&[], &[])]),
+            ],
+        )];
+        assert!(stretch_classes(blocks, true).contains(&"r-stretch".to_string()));
+    }
+
+    #[test]
+    fn two_images_skipped() {
         let blocks = vec![section(
             &[],
             vec![
                 header(),
                 para(vec![image(&[], &[])]),
-                para(vec![Inline::Str(Str {
-                    text: "text".to_string(),
-                    source_info: si(),
-                })]),
+                para(vec![image(&[], &[])]),
             ],
         )];
+        assert!(!stretch_classes(blocks, true).contains(&"r-stretch".to_string()));
+    }
+
+    #[test]
+    fn slide_with_aside_skipped() {
+        // A peripheral aside (e.g. a coalesced footnote) suppresses auto-stretch,
+        // matching Q1 (`aside:not(.notes)`).
+        let aside = Block::Div(Div {
+            attr: (
+                String::new(),
+                vec!["aside".to_string()],
+                LinkedHashMap::new(),
+            ),
+            content: vec![para(vec![Inline::Str(Str {
+                text: "note".to_string(),
+                source_info: si(),
+            })])],
+            source_info: si(),
+            attr_source: AttrSourceInfo::empty(),
+        });
+        let blocks = vec![section(
+            &[],
+            vec![header(), para(vec![image(&[], &[])]), aside],
+        )];
+        assert!(!stretch_classes(blocks, true).contains(&"r-stretch".to_string()));
+    }
+
+    #[test]
+    fn image_nested_in_column_div_skipped() {
+        // A single image inside a `.column` is not a top-level standalone block,
+        // so it is left alone (Q1 screens out layout/column/fragment parents).
+        let column = Block::Div(Div {
+            attr: (
+                String::new(),
+                vec!["column".to_string()],
+                LinkedHashMap::new(),
+            ),
+            content: vec![para(vec![image(&[], &[])])],
+            source_info: si(),
+            attr_source: AttrSourceInfo::empty(),
+        });
+        let blocks = vec![section(&[], vec![header(), column])];
         assert!(!stretch_classes(blocks, true).contains(&"r-stretch".to_string()));
     }
 

--- a/crates/quarto-core/src/revealjs/footer_logo.rs
+++ b/crates/quarto-core/src/revealjs/footer_logo.rs
@@ -1,0 +1,417 @@
+/*
+ * revealjs/footer_logo.rs
+ * Copyright (c) 2026 Posit, PBC
+ *
+ * Reveal deck-level footer + logo: config alias + format-specific render.
+ */
+
+//! Reveal deck-level footer + logo (Stage D3).
+//!
+//! Two transforms implement the footer/logo, splitting **format-agnostic
+//! generation** from **format-specific rendering** (the same split the
+//! `format: html` chrome uses — navbar/sidebar/TOC/footer):
+//!
+//! 1. [`RevealFooterAliasTransform`] — a reveal-scoped config alias. Quarto 1
+//!    reveal decks configure the footer with `footer:`; the format-agnostic
+//!    [`FooterGenerateTransform`](crate::transforms::FooterGenerateTransform)
+//!    reads `page-footer:`. This transform copies `footer:` → `page-footer:`
+//!    (when `page-footer:` is absent) *before* generate, so a bare Q1 `footer:`
+//!    string flows through the shared generate (string → `center` region) with
+//!    no reveal-specific knowledge leaking into the generate step. Runs in the
+//!    reveal branch *before* `FooterGenerateTransform`.
+//!
+//! 2. [`RevealFooterLogoTransform`] — the reveal-specific *render*. Reads the
+//!    structured `navigation.footer` (produced by the shared generate) and emits
+//!    reveal markup into `rendered.reveal.footer`; reads `logo:` (which has no
+//!    format-agnostic generate — it is reveal-specific) and emits
+//!    `rendered.reveal.logo`. Each render is skipped when its slot is already
+//!    populated, so a user filter (or config) can pre-populate the slot to
+//!    override. The reveal scaffold ([`super::assemble::render_revealjs_document`])
+//!    reads these slots and places the markup as **direct children of `.reveal`,
+//!    outside `.slides`** — where `position: fixed` survives reveal's per-slide
+//!    CSS transforms (it would not if nested inside `.slides`).
+//!
+//! Why a transform + meta-slot rather than reading `footer:`/`logo:` in the
+//! scaffold directly: it puts footer/logo on the same filter-manipulation
+//! surface as the other chrome elements. The pipeline runs user filters around
+//! the AST transforms (`UserFiltersStage::pre` → `AstTransformsStage` →
+//! `…::post`), so a `pre` filter editing `footer`/`page-footer` flows through
+//! generate + render, and a filter can pre-populate `rendered.reveal.*` to
+//! override the rendered HTML outright.
+//!
+//! Scope (Stage D3): the `center` footer region only (Q1's reveal footer is a
+//! single centered element; left/right are carried in the structured entry for
+//! a future enhancement). `.qmd` hrefs inside a Text-region footer pass through
+//! unrewritten, matching html's `FooterRenderTransform` (which defers
+//! Text-region rewriting). WASM-safe (pure AST/metadata manipulation).
+
+use quarto_pandoc_types::pandoc::Pandoc;
+use quarto_pandoc_types::{ConfigValue, ConfigValueKind};
+use quarto_source_map::{By, SourceInfo};
+
+use crate::Result;
+use crate::render::RenderContext;
+use crate::transform::AstTransform;
+
+// --- config alias: footer: → page-footer: -----------------------------------
+
+/// Reveal-scoped alias mapping `footer:` → `page-footer:` so Q1 decks flow
+/// through the format-agnostic footer generate. Must run before
+/// [`FooterGenerateTransform`](crate::transforms::FooterGenerateTransform).
+pub struct RevealFooterAliasTransform;
+
+impl RevealFooterAliasTransform {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for RevealFooterAliasTransform {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait::async_trait(?Send)]
+impl AstTransform for RevealFooterAliasTransform {
+    fn name(&self) -> &str {
+        "reveal-footer-alias"
+    }
+
+    async fn transform(&self, ast: &mut Pandoc, _ctx: &mut RenderContext) -> Result<()> {
+        // `page-footer:` wins if the user set both (it's the canonical key).
+        if ast.meta.contains_path(&["page-footer"]) {
+            return Ok(());
+        }
+        let Some(footer) = ast.meta.get("footer").cloned() else {
+            return Ok(());
+        };
+        ast.meta.insert_path(&["page-footer"], footer);
+        Ok(())
+    }
+}
+
+// --- reveal-specific render: navigation.footer + logo → rendered.reveal.* ----
+
+/// Renders the reveal deck-level footer (from the format-agnostic
+/// `navigation.footer`) and logo (from `logo:`) into `rendered.reveal.footer` /
+/// `rendered.reveal.logo`. Skips a slot that is already populated (override).
+pub struct RevealFooterLogoTransform;
+
+impl RevealFooterLogoTransform {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for RevealFooterLogoTransform {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait::async_trait(?Send)]
+impl AstTransform for RevealFooterLogoTransform {
+    fn name(&self) -> &str {
+        "reveal-footer-logo"
+    }
+
+    async fn transform(&self, ast: &mut Pandoc, _ctx: &mut RenderContext) -> Result<()> {
+        if !ast.meta.contains_path(&["rendered", "reveal", "footer"])
+            && let Some(html) = footer_slot_html(&ast.meta)
+        {
+            ast.meta.insert_path(
+                &["rendered", "reveal", "footer"],
+                ConfigValue::new_string(&html, SourceInfo::generated(By::revealjs())),
+            );
+        }
+
+        if !ast.meta.contains_path(&["rendered", "reveal", "logo"])
+            && let Some(html) = logo_slot_html(&ast.meta)
+        {
+            ast.meta.insert_path(
+                &["rendered", "reveal", "logo"],
+                ConfigValue::new_string(&html, SourceInfo::generated(By::revealjs())),
+            );
+        }
+
+        Ok(())
+    }
+}
+
+/// Build the reveal footer markup from `navigation.footer`'s `center` region,
+/// or `None` when there is no center content. The `.footer-default` class
+/// matches Quarto 1 (and our SCSS in `quarto-revealjs.scss`).
+fn footer_slot_html(meta: &ConfigValue) -> Option<String> {
+    let center = meta
+        .get_path(&["navigation", "footer"])
+        .and_then(|f| f.get("center"))?;
+    let inner = config_field_to_html(center);
+    let inner = inner.trim();
+    if inner.is_empty() {
+        return None;
+    }
+    Some(format!(
+        r#"<div class="footer footer-default">{inner}</div>"#
+    ))
+}
+
+/// Build the reveal logo `<img>` from `logo:`, or `None` when unset/blank.
+fn logo_slot_html(meta: &ConfigValue) -> Option<String> {
+    let path = meta
+        .get("logo")
+        .and_then(|v| v.as_plain_text())
+        .filter(|s| !s.trim().is_empty())?;
+    Some(format!(
+        r#"<img class="slide-logo" src="{}">"#,
+        attr_escape(path.trim())
+    ))
+}
+
+/// Render a metadata field's inline/block Pandoc content to HTML (preserving
+/// links/emphasis); a bare scalar is HTML-escaped. Mirrors
+/// `template::titleblock_field_to_html` and the navigation footer's Text-region
+/// handling.
+fn config_field_to_html(value: &ConfigValue) -> String {
+    match &value.value {
+        ConfigValueKind::PandocInlines(inlines) => {
+            let mut out: Vec<u8> = Vec::new();
+            if pampa::writers::html::write_inlines_to(inlines, &mut out).is_ok() {
+                return String::from_utf8_lossy(&out).into_owned();
+            }
+            String::new()
+        }
+        ConfigValueKind::PandocBlocks(blocks) => {
+            let mut out: Vec<u8> = Vec::new();
+            if pampa::writers::html::write_blocks_to(blocks, &mut out).is_ok() {
+                return String::from_utf8_lossy(&out).into_owned();
+            }
+            String::new()
+        }
+        _ => escape_html(&value.as_plain_text().unwrap_or_default()),
+    }
+}
+
+/// Minimal HTML-text escape (text content).
+fn escape_html(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
+/// Escape for a double-quoted HTML attribute value.
+fn attr_escape(s: &str) -> String {
+    escape_html(s).replace('"', "&quot;")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hashlink::LinkedHashMap;
+    use quarto_pandoc_types::ConfigMapEntry;
+    use quarto_pandoc_types::inline::{Inline, Link, Str};
+
+    fn si() -> SourceInfo {
+        SourceInfo::generated(By::revealjs())
+    }
+
+    fn map(entries: Vec<(&str, ConfigValue)>) -> ConfigValue {
+        ConfigValue::new_map(
+            entries
+                .into_iter()
+                .map(|(k, v)| ConfigMapEntry {
+                    key: k.to_string(),
+                    key_source: si(),
+                    value: v,
+                })
+                .collect(),
+            si(),
+        )
+    }
+
+    fn s(v: &str) -> ConfigValue {
+        ConfigValue::new_string(v, si())
+    }
+
+    fn inlines(content: Vec<Inline>) -> ConfigValue {
+        ConfigValue {
+            value: ConfigValueKind::PandocInlines(content),
+            source_info: si(),
+            merge_op: Default::default(),
+        }
+    }
+
+    fn str_inline(text: &str) -> Inline {
+        Inline::Str(Str {
+            text: text.to_string(),
+            source_info: si(),
+        })
+    }
+
+    /// A footer whose `center` is the given ConfigValue, shaped like the output
+    /// of `FooterGenerateTransform` (which stores `navigation.footer.center`).
+    fn meta_with_footer_center(center: ConfigValue) -> ConfigValue {
+        map(vec![(
+            "navigation",
+            map(vec![("footer", map(vec![("center", center)]))]),
+        )])
+    }
+
+    #[test]
+    fn footer_slot_from_center_string() {
+        let m = meta_with_footer_center(s("© 2026 Me"));
+        let html = footer_slot_html(&m).expect("footer slot");
+        assert_eq!(
+            html,
+            r#"<div class="footer footer-default">© 2026 Me</div>"#
+        );
+    }
+
+    #[test]
+    fn footer_slot_renders_inline_links() {
+        let link = Inline::Link(Link {
+            attr: (String::new(), vec![], LinkedHashMap::new()),
+            content: vec![str_inline("Quarto")],
+            target: ("https://quarto.org".to_string(), String::new()),
+            source_info: si(),
+            attr_source: quarto_pandoc_types::attr::AttrSourceInfo::empty(),
+            target_source: quarto_pandoc_types::attr::TargetSourceInfo::empty(),
+        });
+        let m = meta_with_footer_center(inlines(vec![str_inline("© "), link]));
+        let html = footer_slot_html(&m).expect("footer slot");
+        assert!(
+            html.contains(r#"<a href="https://quarto.org">Quarto</a>"#),
+            "footer link should render as an anchor; got: {html}"
+        );
+    }
+
+    #[test]
+    fn footer_slot_escapes_scalar_text() {
+        let m = meta_with_footer_center(s("a < b & c"));
+        let html = footer_slot_html(&m).unwrap();
+        assert!(html.contains("a &lt; b &amp; c"), "got: {html}");
+    }
+
+    #[test]
+    fn footer_slot_none_when_no_footer() {
+        assert!(footer_slot_html(&map(vec![("title", s("T"))])).is_none());
+    }
+
+    #[test]
+    fn footer_slot_none_when_center_empty() {
+        let m = meta_with_footer_center(s("   "));
+        assert!(footer_slot_html(&m).is_none(), "blank center → no footer");
+    }
+
+    #[test]
+    fn logo_slot_builds_img() {
+        let m = map(vec![("logo", s("logo.png"))]);
+        assert_eq!(
+            logo_slot_html(&m).unwrap(),
+            r#"<img class="slide-logo" src="logo.png">"#
+        );
+    }
+
+    #[test]
+    fn logo_slot_escapes_path_attr() {
+        let m = map(vec![("logo", s(r#"a"b.png"#))]);
+        assert_eq!(
+            logo_slot_html(&m).unwrap(),
+            r#"<img class="slide-logo" src="a&quot;b.png">"#
+        );
+    }
+
+    #[test]
+    fn logo_slot_none_when_absent_or_blank() {
+        assert!(logo_slot_html(&map(vec![("title", s("T"))])).is_none());
+        assert!(logo_slot_html(&map(vec![("logo", s("  "))])).is_none());
+    }
+
+    // --- transform-level: slot writing + override hook + alias ---------------
+
+    async fn run<T: AstTransform>(t: T, meta: ConfigValue) -> ConfigValue {
+        use crate::format::Format;
+        use crate::project::{DocumentInfo, ProjectConfig, ProjectContext};
+        use crate::render::BinaryDependencies;
+        use std::path::PathBuf;
+
+        let mut ast = Pandoc {
+            meta,
+            blocks: vec![],
+        };
+        let project = ProjectContext {
+            dir: PathBuf::from("/project"),
+            config: ProjectConfig::default(),
+            is_single_file: true,
+            files: vec![DocumentInfo::from_path("/project/doc.qmd")],
+            output_dir: PathBuf::from("/project"),
+        };
+        let doc = DocumentInfo::from_path("/project/doc.qmd");
+        let format = Format::html();
+        let binaries = BinaryDependencies::new();
+        let mut ctx = RenderContext::new(&project, &doc, &format, &binaries);
+        t.transform(&mut ast, &mut ctx).await.unwrap();
+        ast.meta
+    }
+
+    #[tokio::test]
+    async fn render_writes_both_slots() {
+        let meta = {
+            let mut m = meta_with_footer_center(s("Footy"));
+            m.insert_path(&["logo"], s("l.png"));
+            m
+        };
+        let out = run(RevealFooterLogoTransform::new(), meta).await;
+        assert!(
+            out.get_path(&["rendered", "reveal", "footer"])
+                .and_then(|v| v.as_plain_text())
+                .unwrap()
+                .contains("Footy")
+        );
+        assert!(
+            out.get_path(&["rendered", "reveal", "logo"])
+                .and_then(|v| v.as_plain_text())
+                .unwrap()
+                .contains("slide-logo")
+        );
+    }
+
+    #[tokio::test]
+    async fn render_respects_pre_populated_footer_slot() {
+        let mut meta = meta_with_footer_center(s("Generated"));
+        meta.insert_path(&["rendered", "reveal", "footer"], s("OVERRIDE"));
+        let out = run(RevealFooterLogoTransform::new(), meta).await;
+        assert_eq!(
+            out.get_path(&["rendered", "reveal", "footer"])
+                .and_then(|v| v.as_plain_text())
+                .as_deref(),
+            Some("OVERRIDE"),
+            "pre-populated slot must win (filter/config override hook)"
+        );
+    }
+
+    #[tokio::test]
+    async fn alias_copies_footer_to_page_footer() {
+        let meta = map(vec![("footer", s("Hi"))]);
+        let out = run(RevealFooterAliasTransform::new(), meta).await;
+        assert_eq!(
+            out.get("page-footer")
+                .and_then(|v| v.as_plain_text())
+                .as_deref(),
+            Some("Hi")
+        );
+    }
+
+    #[tokio::test]
+    async fn alias_does_not_override_existing_page_footer() {
+        let meta = map(vec![("footer", s("Hi")), ("page-footer", s("Keep"))]);
+        let out = run(RevealFooterAliasTransform::new(), meta).await;
+        assert_eq!(
+            out.get("page-footer")
+                .and_then(|v| v.as_plain_text())
+                .as_deref(),
+            Some("Keep"),
+            "explicit page-footer wins over the footer alias"
+        );
+    }
+}

--- a/crates/quarto-core/src/revealjs/mod.rs
+++ b/crates/quarto-core/src/revealjs/mod.rs
@@ -18,6 +18,7 @@
 //! See `claude-notes/plans/2026-06-08-revealjs-presentations.md` (Phase 1).
 
 mod assemble;
+mod auto_stretch;
 mod columns;
 mod footer_logo;
 mod footnotes;
@@ -26,6 +27,7 @@ mod theme;
 mod transform;
 
 pub use assemble::{DEFAULT_THEME, register_reveal_assets, render_revealjs_document};
+pub use auto_stretch::RevealAutoStretchTransform;
 pub use columns::RevealColumnsTransform;
 pub use footer_logo::{RevealFooterAliasTransform, RevealFooterLogoTransform};
 pub use footnotes::RevealFootnotesTransform;

--- a/crates/quarto-core/src/revealjs/mod.rs
+++ b/crates/quarto-core/src/revealjs/mod.rs
@@ -19,6 +19,7 @@
 
 mod assemble;
 mod columns;
+mod footer_logo;
 mod footnotes;
 mod slides;
 mod theme;
@@ -26,6 +27,7 @@ mod transform;
 
 pub use assemble::{DEFAULT_THEME, register_reveal_assets, render_revealjs_document};
 pub use columns::RevealColumnsTransform;
+pub use footer_logo::{RevealFooterAliasTransform, RevealFooterLogoTransform};
 pub use footnotes::RevealFootnotesTransform;
 pub use slides::{DEFAULT_SLIDE_LEVEL, build_reveal_slides};
 pub use theme::{RevealThemeResolution, resolve_reveal_theme};

--- a/crates/quarto-core/src/revealjs/mod.rs
+++ b/crates/quarto-core/src/revealjs/mod.rs
@@ -21,10 +21,12 @@ mod assemble;
 mod columns;
 mod footnotes;
 mod slides;
+mod theme;
 mod transform;
 
 pub use assemble::{DEFAULT_THEME, register_reveal_assets, render_revealjs_document};
 pub use columns::RevealColumnsTransform;
 pub use footnotes::RevealFootnotesTransform;
 pub use slides::{DEFAULT_SLIDE_LEVEL, build_reveal_slides};
+pub use theme::{RevealThemeResolution, resolve_reveal_theme};
 pub use transform::RevealSlidesTransform;

--- a/crates/quarto-core/src/revealjs/theme.rs
+++ b/crates/quarto-core/src/revealjs/theme.rs
@@ -1,0 +1,166 @@
+/*
+ * revealjs/theme.rs
+ * Copyright (c) 2026 Posit, PBC
+ *
+ * Resolve a revealjs `theme:` configuration into SCSS layers for compilation.
+ */
+
+//! Resolve the `theme:` front-matter for a reveal deck into the SCSS theme
+//! layers (and load paths) that `quarto_sass::compile_reveal_theme_css`
+//! consumes.
+//!
+//! `theme:` may be:
+//! - absent / null → the `default` (white-equivalent) theme,
+//! - a string → one built-in name (`dracula`, `dark`, …; `white`/`black`
+//!   alias to `default`/`dark`) or a path to a user `.scss` file,
+//! - an array → several entries layered left→right (e.g. `[dark, custom.scss]`),
+//!   where later entries win (their `!default`s and rules override earlier ones).
+//!
+//! Built-in names resolve to the embedded reveal themes
+//! (`quarto_sass::load_reveal_theme_layer`); anything else is treated as a user
+//! `.scss` file resolved against the document directory
+//! (`quarto_sass::load_custom_theme`). This mirrors Quarto 1's resolution while
+//! keeping the reveal-specific name set (Bootstrap's `ThemeConfig` would reject
+//! reveal theme names).
+
+use std::path::{Path, PathBuf};
+
+use quarto_pandoc_types::ConfigValue;
+use quarto_sass::{SassError, SassLayer, ThemeContext};
+use quarto_system_runtime::SystemRuntime;
+
+/// The resolved reveal theme: ordered SCSS layers plus any extra load paths
+/// (directories of user `.scss` themes, for `@use`/`@import` resolution).
+#[derive(Debug, Default)]
+pub struct RevealThemeResolution {
+    pub layers: Vec<SassLayer>,
+    pub load_paths: Vec<PathBuf>,
+}
+
+/// Read the `theme:` entries from merged metadata as a list of names/paths.
+///
+/// Returns `["default"]` when `theme:` is absent, null, empty, or an
+/// unexpected shape (so a deck always gets the white-equivalent default).
+fn theme_entries(meta: &ConfigValue) -> Vec<String> {
+    match meta.get("theme") {
+        None => vec!["default".to_string()],
+        Some(value) if value.is_null() => vec!["default".to_string()],
+        Some(value) => {
+            if let Some(items) = value.as_array() {
+                let names: Vec<String> = items.iter().filter_map(|i| i.as_plain_text()).collect();
+                if names.is_empty() {
+                    vec!["default".to_string()]
+                } else {
+                    names
+                }
+            } else if let Some(s) = value.as_plain_text() {
+                vec![s]
+            } else {
+                vec!["default".to_string()]
+            }
+        }
+    }
+}
+
+/// Resolve a deck's `theme:` into SCSS theme layers + load paths.
+///
+/// `document_dir` is the directory of the input `.qmd` (user `.scss` themes
+/// resolve against it); `runtime` provides cross-platform file access.
+pub fn resolve_reveal_theme(
+    meta: &ConfigValue,
+    document_dir: &Path,
+    runtime: &dyn SystemRuntime,
+) -> Result<RevealThemeResolution, SassError> {
+    let context = ThemeContext::new(document_dir.to_path_buf(), runtime);
+    let mut resolution = RevealThemeResolution::default();
+
+    for entry in theme_entries(meta) {
+        if quarto_sass::resolve_reveal_theme_name(&entry).is_some() {
+            // A built-in reveal theme (or `white`/`black` alias).
+            resolution
+                .layers
+                .push(quarto_sass::load_reveal_theme_layer(&entry)?);
+        } else {
+            // Otherwise treat the entry as a path to a user `.scss` theme,
+            // resolved against the document directory.
+            let (layer, dir) = quarto_sass::load_custom_theme(Path::new(&entry), &context)?;
+            resolution.layers.push(layer);
+            resolution.load_paths.push(dir);
+        }
+    }
+
+    Ok(resolution)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use quarto_source_map::SourceInfo;
+    use quarto_system_runtime::NativeRuntime;
+
+    fn s(v: &str) -> ConfigValue {
+        ConfigValue::new_string(v, SourceInfo::for_test())
+    }
+    fn meta_with_theme(value: ConfigValue) -> ConfigValue {
+        let mut m = ConfigValue::new_map(vec![], SourceInfo::for_test());
+        m.insert_path(&["theme"], value);
+        m
+    }
+
+    #[test]
+    fn entries_default_when_absent_or_null() {
+        let empty = ConfigValue::new_map(vec![], SourceInfo::for_test());
+        assert_eq!(theme_entries(&empty), vec!["default".to_string()]);
+    }
+
+    #[test]
+    fn entries_string_and_array() {
+        assert_eq!(
+            theme_entries(&meta_with_theme(s("dracula"))),
+            vec!["dracula".to_string()]
+        );
+        let arr = ConfigValue::new_array(vec![s("dark"), s("custom.scss")], SourceInfo::for_test());
+        assert_eq!(
+            theme_entries(&meta_with_theme(arr)),
+            vec!["dark".to_string(), "custom.scss".to_string()]
+        );
+    }
+
+    #[test]
+    fn resolve_builtin_single_no_load_path() {
+        let rt = NativeRuntime::new();
+        let r = resolve_reveal_theme(&meta_with_theme(s("dracula")), Path::new("."), &rt).unwrap();
+        assert_eq!(r.layers.len(), 1);
+        assert!(r.load_paths.is_empty(), "built-in themes need no load path");
+    }
+
+    #[test]
+    fn resolve_array_with_aliases() {
+        let rt = NativeRuntime::new();
+        // white→default, black→dark — both resolve to built-in layers.
+        let arr = ConfigValue::new_array(vec![s("white"), s("black")], SourceInfo::for_test());
+        let r = resolve_reveal_theme(&meta_with_theme(arr), Path::new("."), &rt).unwrap();
+        assert_eq!(r.layers.len(), 2);
+    }
+
+    #[test]
+    fn resolve_default_when_absent() {
+        let rt = NativeRuntime::new();
+        let empty = ConfigValue::new_map(vec![], SourceInfo::for_test());
+        let r = resolve_reveal_theme(&empty, Path::new("."), &rt).unwrap();
+        assert_eq!(r.layers.len(), 1, "absent theme → the default layer");
+    }
+
+    #[test]
+    fn resolve_unknown_name_errors() {
+        let rt = NativeRuntime::new();
+        // Not a built-in and not an existing file → error (treated as a
+        // missing user `.scss`).
+        let r = resolve_reveal_theme(
+            &meta_with_theme(s("no-such-theme")),
+            Path::new("/nonexistent-dir-xyz"),
+            &rt,
+        );
+        assert!(r.is_err());
+    }
+}

--- a/crates/quarto-core/src/revealjs/transform.rs
+++ b/crates/quarto-core/src/revealjs/transform.rs
@@ -149,7 +149,16 @@ fn build_title_slide(meta: &quarto_pandoc_types::ConfigValue) -> Option<Block> {
     Some(Block::Div(Div {
         attr: (
             "title-slide".to_string(),
-            vec!["section".to_string(), "title-slide".to_string()],
+            // `center` keeps the title slide vertically centered even though
+            // the deck defaults to `center: false` (top-aligned body slides).
+            // reveal honors the per-slide `.center` class when the global
+            // `center` config is off — this mirrors Quarto 1's approach
+            // (format-reveal.ts: add `.center` to the title slide).
+            vec![
+                "section".to_string(),
+                "title-slide".to_string(),
+                "center".to_string(),
+            ],
             LinkedHashMap::new(),
         ),
         content,

--- a/crates/quarto-core/src/stage/stages/compile_theme_css.rs
+++ b/crates/quarto-core/src/stage/stages/compile_theme_css.rs
@@ -265,34 +265,40 @@ impl PipelineStage for CompileThemeCssStage {
         // one copy across decks via `site_libs` (bd-jij5gge2), then skip the
         // Bootstrap compilation.
         if ctx.format.identifier == crate::format::FormatIdentifier::Revealjs {
-            let theme = doc
-                .ast
-                .meta
-                .get("theme")
-                .and_then(|v| v.as_plain_text())
-                .unwrap_or_else(|| crate::revealjs::DEFAULT_THEME.to_string());
+            // Resolve `theme:` into SCSS theme layers (built-in reveal themes
+            // and/or user `.scss` files). An unresolvable theme (unknown name /
+            // missing file) is a user configuration error — fail loudly rather
+            // than silently render the wrong theme.
+            let document_dir = ctx.document.input.parent().map_or_else(
+                || std::path::PathBuf::from("."),
+                std::path::Path::to_path_buf,
+            );
+            let resolution = crate::revealjs::resolve_reveal_theme(
+                &doc.ast.meta,
+                &document_dir,
+                ctx.runtime.as_ref(),
+            )
+            .map_err(|e| PipelineError::stage_error(self.name(), e.to_string()))?;
 
             // Compile Quarto's reveal theme (single unified SCSS pass, D1) and
-            // register it as the theme-slot artifact. On a compile failure we
-            // fall back to the vendored stock theme CSS so the deck still
-            // renders (mirrors the Bootstrap path's graceful fallback).
-            let compiled = match compile_reveal(ctx, true).await {
-                Ok(css) => Some(css),
-                Err(e) => {
-                    trace_event!(
-                        ctx,
-                        EventLevel::Warn,
-                        "reveal theme compilation failed: {}, using vendored stock theme",
-                        e
-                    );
-                    None
-                }
-            };
-            crate::revealjs::register_reveal_assets(
-                &mut ctx.artifacts,
-                &theme,
-                compiled.as_deref(),
-            );
+            // register it as the theme-slot artifact (keyed by content
+            // fingerprint). On a *compile* failure we fall back to the vendored
+            // stock theme CSS so the deck still renders (mirrors the Bootstrap
+            // path's graceful fallback).
+            let compiled =
+                match compile_reveal(ctx, true, &resolution.layers, &resolution.load_paths).await {
+                    Ok(css) => Some(css),
+                    Err(e) => {
+                        trace_event!(
+                            ctx,
+                            EventLevel::Warn,
+                            "reveal theme compilation failed: {}, using vendored stock theme",
+                            e
+                        );
+                        None
+                    }
+                };
+            crate::revealjs::register_reveal_assets(&mut ctx.artifacts, compiled.as_deref());
             return Ok(PipelineData::DocumentAst(doc));
         }
 
@@ -607,13 +613,24 @@ async fn compile_default(ctx: &StageContext, minified: bool) -> Result<String, S
 /// WASM uses the dart-sass JS bridge (async). This wrapper gives the reveal
 /// branch one call site. See `quarto_sass::compile_reveal_theme_css`.
 #[cfg(not(target_arch = "wasm32"))]
-async fn compile_reveal(ctx: &StageContext, minified: bool) -> Result<String, String> {
-    quarto_sass::compile_reveal_theme_css(ctx.runtime.as_ref(), minified).map_err(|e| e.to_string())
+async fn compile_reveal(
+    ctx: &StageContext,
+    minified: bool,
+    theme_layers: &[SassLayer],
+    load_paths: &[PathBuf],
+) -> Result<String, String> {
+    quarto_sass::compile_reveal_theme_css(ctx.runtime.as_ref(), minified, theme_layers, load_paths)
+        .map_err(|e| e.to_string())
 }
 
 #[cfg(target_arch = "wasm32")]
-async fn compile_reveal(ctx: &StageContext, minified: bool) -> Result<String, String> {
-    quarto_sass::compile_reveal_theme_css(ctx.runtime.as_ref(), minified)
+async fn compile_reveal(
+    ctx: &StageContext,
+    minified: bool,
+    theme_layers: &[SassLayer],
+    load_paths: &[PathBuf],
+) -> Result<String, String> {
+    quarto_sass::compile_reveal_theme_css(ctx.runtime.as_ref(), minified, theme_layers, load_paths)
         .await
         .map_err(|e| e.to_string())
 }

--- a/crates/quarto-core/src/stage/stages/compile_theme_css.rs
+++ b/crates/quarto-core/src/stage/stages/compile_theme_css.rs
@@ -271,7 +271,28 @@ impl PipelineStage for CompileThemeCssStage {
                 .get("theme")
                 .and_then(|v| v.as_plain_text())
                 .unwrap_or_else(|| crate::revealjs::DEFAULT_THEME.to_string());
-            crate::revealjs::register_reveal_assets(&mut ctx.artifacts, &theme);
+
+            // Compile Quarto's reveal theme (single unified SCSS pass, D1) and
+            // register it as the theme-slot artifact. On a compile failure we
+            // fall back to the vendored stock theme CSS so the deck still
+            // renders (mirrors the Bootstrap path's graceful fallback).
+            let compiled = match compile_reveal(ctx, true).await {
+                Ok(css) => Some(css),
+                Err(e) => {
+                    trace_event!(
+                        ctx,
+                        EventLevel::Warn,
+                        "reveal theme compilation failed: {}, using vendored stock theme",
+                        e
+                    );
+                    None
+                }
+            };
+            crate::revealjs::register_reveal_assets(
+                &mut ctx.artifacts,
+                &theme,
+                compiled.as_deref(),
+            );
             return Ok(PipelineData::DocumentAst(doc));
         }
 
@@ -578,6 +599,21 @@ async fn compile_default(ctx: &StageContext, minified: bool) -> Result<String, S
 #[cfg(target_arch = "wasm32")]
 async fn compile_default(ctx: &StageContext, minified: bool) -> Result<String, String> {
     compile_default_css(ctx.runtime.as_ref(), minified)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+/// Compile Quarto's reveal.js theme CSS. Native uses `grass` in-process (sync);
+/// WASM uses the dart-sass JS bridge (async). This wrapper gives the reveal
+/// branch one call site. See `quarto_sass::compile_reveal_theme_css`.
+#[cfg(not(target_arch = "wasm32"))]
+async fn compile_reveal(ctx: &StageContext, minified: bool) -> Result<String, String> {
+    quarto_sass::compile_reveal_theme_css(ctx.runtime.as_ref(), minified).map_err(|e| e.to_string())
+}
+
+#[cfg(target_arch = "wasm32")]
+async fn compile_reveal(ctx: &StageContext, minified: bool) -> Result<String, String> {
+    quarto_sass::compile_reveal_theme_css(ctx.runtime.as_ref(), minified)
         .await
         .map_err(|e| e.to_string())
 }

--- a/crates/quarto-core/src/stage/stages/compile_theme_css.rs
+++ b/crates/quarto-core/src/stage/stages/compile_theme_css.rs
@@ -273,12 +273,29 @@ impl PipelineStage for CompileThemeCssStage {
                 || std::path::PathBuf::from("."),
                 std::path::Path::to_path_buf,
             );
-            let resolution = crate::revealjs::resolve_reveal_theme(
+            let mut resolution = crate::revealjs::resolve_reveal_theme(
                 &doc.ast.meta,
                 &document_dir,
                 ctx.runtime.as_ref(),
             )
             .map_err(|e| PipelineError::stage_error(self.name(), e.to_string()))?;
+
+            // `_brand.yml` integration: resolve the brand into SCSS layers and
+            // append them LAST (highest priority) so brand colors/typography
+            // override the built-in theme. Relative `brand:` paths resolve
+            // against the project dir, mirroring the HTML path. Reveal resolves
+            // brand on its own because the Bootstrap `ThemeConfig` theme path
+            // rejects reveal theme names.
+            let brand_layers = quarto_sass::resolve_brand_layers(
+                &doc.ast.meta,
+                ctx.runtime.as_ref(),
+                &ctx.project.dir,
+                std::path::Path::new(""),
+            )
+            .map_err(|e| {
+                PipelineError::stage_error(self.name(), format!("brand resolution: {e}"))
+            })?;
+            resolution.layers.extend(brand_layers);
 
             // Compile Quarto's reveal theme (single unified SCSS pass, D1) and
             // register it as the theme-slot artifact (keyed by content

--- a/crates/quarto-core/tests/integration/artifact_scoping_pipeline.rs
+++ b/crates/quarto-core/tests/integration/artifact_scoping_pipeline.rs
@@ -408,19 +408,34 @@ fn website_with_two_decks_shares_one_revealjs_lib() {
 
     // Vendored assets written ONCE under the shared lib dir.
     let shared = site.join("site_libs").join("revealjs");
-    for f in [
-        "reset.css",
-        "reveal.css",
-        "theme-white.css",
-        "quarto-reveal.css",
-        "reveal.js",
-    ] {
+    for f in ["reset.css", "reveal.css", "quarto-reveal.css", "reveal.js"] {
         assert!(
             shared.join(f).is_file(),
             "expected shared asset {}",
             shared.join(f).display()
         );
     }
+    // Both decks use the default theme, so the fingerprinted theme CSS dedups
+    // to EXACTLY ONE shared `theme-<hash>.css` file (per-deck themes would
+    // produce distinct fingerprints; same theme → same fingerprint → one file).
+    let theme_files: Vec<_> = std::fs::read_dir(&shared)
+        .unwrap()
+        .filter_map(Result::ok)
+        .filter(|e| {
+            e.file_name()
+                .to_str()
+                .is_some_and(|n| n.starts_with("theme-") && n.ends_with(".css"))
+        })
+        .collect();
+    assert_eq!(
+        theme_files.len(),
+        1,
+        "two decks on the same (default) theme must share one theme-<hash>.css; found {:?}",
+        theme_files
+            .iter()
+            .map(|e| e.file_name())
+            .collect::<Vec<_>>()
+    );
 
     // NOT duplicated per-deck.
     assert!(

--- a/crates/quarto-core/tests/integration/revealjs_format.rs
+++ b/crates/quarto-core/tests/integration/revealjs_format.rs
@@ -248,6 +248,16 @@ fn revealjs_auto_stretch_single_image_slides() {
         "lone-image slide should stretch; got:\n{html}"
     );
 
+    // A standalone image amid explanatory text still stretches (matches Q1:
+    // one image, in its own block, with sibling prose).
+    let amid_text = render(
+        "---\ntitle: T\nformat: revealjs\n---\n\n## Slide\n\nHere is the diagram:\n\n![](pic.png)\n",
+    );
+    assert!(
+        amid_text.contains("r-stretch"),
+        "a standalone image beside text should stretch; got:\n{amid_text}"
+    );
+
     // Sized image → no stretch.
     let sized =
         render("---\ntitle: T\nformat: revealjs\n---\n\n## Slide\n\n![](pic.png){width=\"300\"}\n");

--- a/crates/quarto-core/tests/integration/revealjs_format.rs
+++ b/crates/quarto-core/tests/integration/revealjs_format.rs
@@ -151,6 +151,13 @@ fn revealjs_render_emits_title_slide() {
         html.contains("My Talk"),
         "title slide must carry the metadata title"
     );
+    // The deck defaults to center:false (top-aligned body slides), so the
+    // title slide must carry a per-slide `.center` class to stay vertically
+    // centered — matching Quarto 1.
+    assert!(
+        html.contains("title-slide center"),
+        "title slide section must carry the `center` class; got:\n{html}"
+    );
 }
 
 #[test]

--- a/crates/quarto-core/tests/integration/revealjs_format.rs
+++ b/crates/quarto-core/tests/integration/revealjs_format.rs
@@ -177,11 +177,12 @@ fn revealjs_initialize_carries_options() {
     let c = compact(&html);
     assert!(
         c.contains("\"transition\":\"fade\""),
-        "Reveal.initialize must carry transition: fade"
+        "Reveal.initialize must carry the front-matter transition: fade"
     );
+    // slide-number: true → Quarto's "c/t" format (linear navigation default).
     assert!(
-        c.contains("\"slideNumber\":true"),
-        "slide-number: true must map to reveal `slideNumber: true`"
+        c.contains("\"slideNumber\":\"c/t\""),
+        "slide-number: true must map to reveal `slideNumber: \"c/t\"`"
     );
 }
 

--- a/crates/quarto-core/tests/integration/revealjs_format.rs
+++ b/crates/quarto-core/tests/integration/revealjs_format.rs
@@ -185,6 +185,31 @@ fn revealjs_initialize_carries_options() {
     );
 }
 
+/// Extract the fingerprinted theme href (`…/revealjs/theme-<hash>.css`) from a
+/// rendered deck. The theme filename is content-fingerprinted (like
+/// `format: html`'s theme), so tests can't hardcode it.
+fn theme_href(html: &str) -> String {
+    let marker = "revealjs/theme-";
+    let start = html.find(marker).expect("theme css link present in deck");
+    let rest = &html[start..];
+    let end = rest.find(".css").expect("theme css href ends in .css") + ".css".len();
+    rest[..end].to_string()
+}
+
+/// Find the flushed `theme-<hash>.css` file in a revealjs lib dir.
+fn find_theme_css(libs: &Path) -> std::path::PathBuf {
+    std::fs::read_dir(libs)
+        .unwrap()
+        .filter_map(Result::ok)
+        .map(|e| e.path())
+        .find(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.starts_with("theme-") && n.ends_with(".css"))
+        })
+        .expect("a theme-<hash>.css file should be flushed")
+}
+
 #[test]
 fn revealjs_links_assets_instead_of_inlining() {
     // bd-jij5gge2: vendored reveal assets are LINKED (shared lib dir), not
@@ -192,12 +217,14 @@ fn revealjs_links_assets_instead_of_inlining() {
     // order, and assert the ~700KB core does NOT appear inline.
     let html = render_revealjs(FLAT_DECK);
 
-    for href in [
-        "talk_files/revealjs/reset.css",
-        "talk_files/revealjs/reveal.css",
-        "talk_files/revealjs/theme-white.css",
-        "talk_files/revealjs/quarto-reveal.css",
-    ] {
+    let theme = theme_href(&html);
+    let mut hrefs = vec![
+        "talk_files/revealjs/reset.css".to_string(),
+        "talk_files/revealjs/reveal.css".to_string(),
+        "talk_files/revealjs/quarto-reveal.css".to_string(),
+    ];
+    hrefs.push(format!("talk_files/{theme}"));
+    for href in &hrefs {
         assert!(
             html.contains(&format!(r#"<link rel="stylesheet" href="{href}">"#)),
             "expected a <link> to {href}; head was:\n{}",
@@ -212,8 +239,8 @@ fn revealjs_links_assets_instead_of_inlining() {
     // Cascade order: reset → reveal → theme → quarto overrides.
     let at = |s: &str| html.find(s).unwrap_or_else(|| panic!("missing {s}"));
     assert!(at("reset.css") < at("revealjs/reveal.css"));
-    assert!(at("revealjs/reveal.css") < at("theme-white.css"));
-    assert!(at("theme-white.css") < at("quarto-reveal.css"));
+    assert!(at("revealjs/reveal.css") < at(&theme));
+    assert!(at(&theme) < at("quarto-reveal.css"));
     // reveal.js loads before the per-doc initialize().
     assert!(at("revealjs/reveal.js") < at("Reveal.initialize"));
 
@@ -250,14 +277,14 @@ fn revealjs_flushes_linked_assets_to_disk() {
 
     let out_dir = result.output_path.parent().unwrap();
     let libs = out_dir.join("talk_files").join("revealjs");
-    for f in [
-        "reset.css",
-        "reveal.css",
-        "theme-white.css",
-        "quarto-reveal.css",
-        "reveal.js",
-    ] {
-        let p = libs.join(f);
+    // The fixed-name assets, plus the fingerprinted theme file.
+    let mut paths: Vec<std::path::PathBuf> =
+        ["reset.css", "reveal.css", "quarto-reveal.css", "reveal.js"]
+            .iter()
+            .map(|f| libs.join(f))
+            .collect();
+    paths.push(find_theme_css(&libs));
+    for p in paths {
         assert!(p.is_file(), "expected flushed asset {}", p.display());
         assert!(
             std::fs::metadata(&p).unwrap().len() > 0,
@@ -302,12 +329,8 @@ fn revealjs_theme_slot_is_compiled_quarto_theme() {
         .expect("revealjs render failed");
 
     let out_dir = result.output_path.parent().unwrap();
-    let theme_css = read(
-        &out_dir
-            .join("talk_files")
-            .join("revealjs")
-            .join("theme-white.css"),
-    );
+    let libs = out_dir.join("talk_files").join("revealjs");
+    let theme_css = read(&find_theme_css(&libs));
     // The shipped theme is minified, so match whitespace-insensitively.
     let css = compact(&theme_css);
 
@@ -329,5 +352,47 @@ fn revealjs_theme_slot_is_compiled_quarto_theme() {
     assert!(
         !css.contains("uppercase"),
         "compiled Quarto theme must not uppercase headings"
+    );
+}
+
+/// bd-r9mkybwl Stage B: selecting a built-in theme (`theme: dark`) compiles
+/// THAT theme into the deck — end-to-end through `render_to_file`. Guards the
+/// theme-resolution + per-theme-compile path beyond the white default.
+#[test]
+fn revealjs_named_theme_is_compiled_and_selected() {
+    let deck = "\
+---
+title: \"Dark Talk\"
+format:
+  revealjs:
+    theme: dark
+---
+
+## A slide
+
+- one
+";
+    let temp = tempfile::TempDir::new().unwrap();
+    let qmd_path = temp.path().join("talk.qmd");
+    write_file(&qmd_path, deck);
+    let options = RenderToFileOptions {
+        quiet: true,
+        ..Default::default()
+    };
+    let result = render_to_file(&qmd_path, "revealjs", &options, runtime_arc())
+        .expect("revealjs render failed");
+
+    let out_dir = result.output_path.parent().unwrap();
+    let libs = out_dir.join("talk_files").join("revealjs");
+    let css = compact(&read(&find_theme_css(&libs)));
+
+    // The `dark` theme's dark background + light text flowed into --r-*.
+    assert!(
+        css.contains("--r-background-color:#191919"),
+        "theme: dark should compile the dark background\n{css}"
+    );
+    assert!(
+        css.contains("--r-main-color:#fff"),
+        "theme: dark should use light text"
     );
 }

--- a/crates/quarto-core/tests/integration/revealjs_format.rs
+++ b/crates/quarto-core/tests/integration/revealjs_format.rs
@@ -214,6 +214,67 @@ format: revealjs
     );
 }
 
+/// End-to-end: a single-image slide gets reveal's `.r-stretch` (default-on);
+/// a sized image, an inline-among-text image, and `auto-stretch: false` do not.
+#[test]
+fn revealjs_auto_stretch_single_image_slides() {
+    // 1x1 transparent PNG so the resource collector's copy succeeds.
+    const PNG: &[u8] = &[
+        0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44,
+        0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1f,
+        0x15, 0xc4, 0x89, 0x00, 0x00, 0x00, 0x0a, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9c, 0x63, 0x00,
+        0x01, 0x00, 0x00, 0x05, 0x00, 0x01, 0x0d, 0x0a, 0x2d, 0xb4, 0x00, 0x00, 0x00, 0x00, 0x49,
+        0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
+    ];
+
+    let render = |deck: &str| -> String {
+        let temp = tempfile::TempDir::new().unwrap();
+        std::fs::write(temp.path().join("pic.png"), PNG).unwrap();
+        let qmd_path = temp.path().join("talk.qmd");
+        write_file(&qmd_path, deck);
+        let options = RenderToFileOptions {
+            quiet: true,
+            ..Default::default()
+        };
+        let result = render_to_file(&qmd_path, "revealjs", &options, runtime_arc())
+            .expect("revealjs render failed");
+        read(&result.output_path)
+    };
+
+    // Lone image slide → image gains r-stretch.
+    let html = render("---\ntitle: T\nformat: revealjs\n---\n\n## Slide\n\n![](pic.png)\n");
+    assert!(
+        html.contains("r-stretch"),
+        "lone-image slide should stretch; got:\n{html}"
+    );
+
+    // Sized image → no stretch.
+    let sized =
+        render("---\ntitle: T\nformat: revealjs\n---\n\n## Slide\n\n![](pic.png){width=\"300\"}\n");
+    assert!(
+        !sized.contains("r-stretch"),
+        "sized image must not stretch; got:\n{sized}"
+    );
+
+    // Inline image among text → no stretch.
+    let inline = render(
+        "---\ntitle: T\nformat: revealjs\n---\n\n## Slide\n\nHere is ![](pic.png) inline.\n",
+    );
+    assert!(
+        !inline.contains("r-stretch"),
+        "inline image among text must not stretch; got:\n{inline}"
+    );
+
+    // auto-stretch: false → opt-out.
+    let off = render(
+        "---\ntitle: T\nformat:\n  revealjs:\n    auto-stretch: false\n---\n\n## Slide\n\n![](pic.png)\n",
+    );
+    assert!(
+        !off.contains("r-stretch"),
+        "auto-stretch: false must disable stretching; got:\n{off}"
+    );
+}
+
 #[test]
 fn revealjs_render_emits_title_slide() {
     let html = render_revealjs(FLAT_DECK);

--- a/crates/quarto-core/tests/integration/revealjs_format.rs
+++ b/crates/quarto-core/tests/integration/revealjs_format.rs
@@ -140,6 +140,80 @@ fn revealjs_render_produces_reveal_scaffold() {
     );
 }
 
+/// End-to-end: `footer:`/`logo:` metadata produce a single deck-level footer +
+/// logo placed OUTSIDE `.slides` (a direct child of `.reveal`). They must live
+/// outside `.slides` because reveal applies CSS transforms to `.slides`/section
+/// under which `position: fixed` breaks; see `revealjs::assemble`.
+#[test]
+fn revealjs_footer_and_logo_render_outside_slides() {
+    let deck = "\
+---
+title: \"Footed Talk\"
+logo: logo.png
+footer: \"© 2026 [Quarto](https://quarto.org)\"
+format: revealjs
+---
+
+## A slide
+
+- one
+";
+    let html = render_revealjs(deck);
+
+    // Logo image + footer container both present.
+    assert!(
+        html.contains(r#"<img class="slide-logo" src="logo.png">"#),
+        "expected a .slide-logo img; got:\n{html}"
+    );
+    assert!(
+        html.contains(r#"<div class="footer footer-default">"#),
+        "expected a deck-level .footer; got:\n{html}"
+    );
+    // Footer inline markdown renders (link preserved, not flattened).
+    assert!(
+        html.contains(r#"<a href="https://quarto.org">Quarto</a>"#),
+        "footer link should render as an anchor"
+    );
+    // `.reveal` carries `has-logo`.
+    assert!(
+        html.contains(r#"class="reveal has-logo""#),
+        "reveal element should carry `has-logo`"
+    );
+    // Placement: footer/logo come AFTER the `.slides` container closes, so they
+    // are direct children of `.reveal`, not nested inside transformed slides.
+    let slides_open = html.find(r#"<div class="slides">"#).unwrap();
+    let slides_close = slides_open + html[slides_open..].find("</div>").unwrap();
+    assert!(
+        html.find(r#"class="slide-logo""#).unwrap() > slides_close
+            && html.find(r#"class="footer footer-default""#).unwrap() > slides_close,
+        "footer/logo must be placed after `.slides` closes (outside it)"
+    );
+}
+
+/// The canonical `page-footer:` key (shared with `format: html`) also drives the
+/// reveal footer — the reveal render reuses the format-agnostic
+/// `FooterGenerateTransform`, so no reveal-specific `footer:` alias is required.
+#[test]
+fn revealjs_page_footer_key_drives_footer() {
+    let deck = "\
+---
+title: \"Canonical Footer\"
+page-footer: \"Shared footer key\"
+format: revealjs
+---
+
+## A slide
+
+- one
+";
+    let html = render_revealjs(deck);
+    assert!(
+        html.contains(r#"<div class="footer footer-default">"#)
+            && html.contains("Shared footer key"),
+        "page-footer: should drive the reveal footer; got:\n{html}"
+    );
+}
+
 #[test]
 fn revealjs_render_emits_title_slide() {
     let html = render_revealjs(FLAT_DECK);

--- a/crates/quarto-core/tests/integration/revealjs_format.rs
+++ b/crates/quarto-core/tests/integration/revealjs_format.rs
@@ -276,3 +276,51 @@ fn revealjs_rich_deck_has_scaffold_and_section_divider() {
         "level-3 subslide content must appear in the deck"
     );
 }
+
+/// bd-r9mkybwl Stage A: the theme slot now carries a *compiled* Quarto reveal
+/// theme (not the stock reveal `white.css`). End-to-end through `render_to_file`,
+/// the flushed `theme-white.css` must contain Quarto's look-fixing output:
+/// left-aligned slides, non-uppercase headings, Quarto title-slide layout, and
+/// the `--r-*` custom properties carrying Quarto's values.
+#[test]
+fn revealjs_theme_slot_is_compiled_quarto_theme() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let qmd_path = temp.path().join("talk.qmd");
+    write_file(&qmd_path, FLAT_DECK);
+    let options = RenderToFileOptions {
+        quiet: true,
+        ..Default::default()
+    };
+    let result = render_to_file(&qmd_path, "revealjs", &options, runtime_arc())
+        .expect("revealjs render failed");
+
+    let out_dir = result.output_path.parent().unwrap();
+    let theme_css = read(
+        &out_dir
+            .join("talk_files")
+            .join("revealjs")
+            .join("theme-white.css"),
+    );
+    // The shipped theme is minified, so match whitespace-insensitively.
+    let css = compact(&theme_css);
+
+    // Quarto values flowed into the reveal custom properties.
+    assert!(
+        css.contains("--r-main-color:#222"),
+        "compiled theme should set --r-main-color to Quarto's body color"
+    );
+    // Quarto's look-fixing rules are present.
+    assert!(
+        css.contains("text-align:left"),
+        "compiled theme should left-align slides"
+    );
+    assert!(
+        css.contains("#title-slide"),
+        "compiled theme should style the Quarto title slide"
+    );
+    // reveal's default uppercase headings are turned off.
+    assert!(
+        !css.contains("uppercase"),
+        "compiled Quarto theme must not uppercase headings"
+    );
+}

--- a/crates/quarto-core/tests/integration/revealjs_format.rs
+++ b/crates/quarto-core/tests/integration/revealjs_format.rs
@@ -356,6 +356,47 @@ fn revealjs_theme_slot_is_compiled_quarto_theme() {
     );
 }
 
+/// bd-j8qoyc0s Stage D2: a `_brand.yml` flows into the compiled reveal theme —
+/// brand colors and typography reach the `--r-*` custom properties.
+#[test]
+fn revealjs_brand_yml_flows_into_theme() {
+    let temp = tempfile::TempDir::new().unwrap();
+    write_file(
+        &temp.path().join("_brand.yml"),
+        "color:\n  palette:\n    brandred: \"#cc0000\"\n  primary: brandred\ntypography:\n  base:\n    family: Georgia\n",
+    );
+    let qmd_path = temp.path().join("talk.qmd");
+    write_file(
+        &qmd_path,
+        "---\ntitle: Branded\nbrand: _brand.yml\nformat: revealjs\n---\n\n## A slide\n\n- x\n",
+    );
+    let options = RenderToFileOptions {
+        quiet: true,
+        ..Default::default()
+    };
+    let result = render_to_file(&qmd_path, "revealjs", &options, runtime_arc())
+        .expect("revealjs render failed");
+
+    let libs = result
+        .output_path
+        .parent()
+        .unwrap()
+        .join("talk_files")
+        .join("revealjs");
+    let css = compact(&read(&find_theme_css(&libs)));
+
+    // Brand primary → $link-color → --r-link-color (#cc0000 minifies to #c00).
+    assert!(
+        css.contains("--r-link-color:#c00") || css.contains("--r-link-color:#cc0000"),
+        "brand primary should drive --r-link-color\n{css}"
+    );
+    // Brand base font → --r-main-font.
+    assert!(
+        css.contains("--r-main-font:Georgia"),
+        "brand base font should drive --r-main-font"
+    );
+}
+
 /// bd-r9mkybwl Stage B: selecting a built-in theme (`theme: dark`) compiles
 /// THAT theme into the deck — end-to-end through `render_to_file`. Guards the
 /// theme-resolution + per-theme-compile path beyond the white default.

--- a/crates/quarto-sass/src/brand_layer.rs
+++ b/crates/quarto-sass/src/brand_layer.rs
@@ -398,8 +398,10 @@ fn variable_translations_for_kind(kind: &str) -> &'static [(&'static str, &'stat
             ("size", "font-size-base"),
             ("line-height", "line-height-base"),
             ("weight", "font-weight-base"),
-            // revealjs
-            ("family", "mainFont"),
+            // revealjs (reveal.js 6 uses kebab-case Sass vars; the Quarto reveal
+            // layer maps $font-family-sans-serif → $main-font, and reads
+            // $main-font directly, so target the reveal-6 name)
+            ("family", "main-font"),
             ("size", "presentation-font-size-root"),
             ("line-height", "presentation-line-height"),
             // mermaid

--- a/crates/quarto-sass/src/bundle.rs
+++ b/crates/quarto-sass/src/bundle.rs
@@ -316,20 +316,80 @@ pub fn load_quarto_reveal_layer() -> Result<SassLayer, SassError> {
     parse_layer(content, Some("quarto-revealjs.scss"))
 }
 
+/// Canonical built-in reveal theme names — the file stems under
+/// `resources/scss/revealjs/themes/`. `white`/`black` are accepted as aliases
+/// for `default`/`dark` (see [`resolve_reveal_theme_name`]) and are not listed.
+pub const REVEAL_BUILTIN_THEMES: &[&str] = &[
+    "beige",
+    "blood",
+    "dark",
+    "default",
+    "dracula",
+    "league",
+    "moon",
+    "night",
+    "serif",
+    "simple",
+    "sky",
+    "solarized",
+];
+
+/// Resolve a requested reveal theme name to its canonical file stem, applying
+/// the Quarto-1 aliases `white`→`default` and `black`→`dark`. Returns `None`
+/// for an unknown name (the caller turns that into a user-facing error).
+pub fn resolve_reveal_theme_name(name: &str) -> Option<&'static str> {
+    match name {
+        "white" | "default" => Some("default"),
+        "black" | "dark" => Some("dark"),
+        other => REVEAL_BUILTIN_THEMES.iter().copied().find(|t| *t == other),
+    }
+}
+
+/// Load a built-in reveal theme as a [`SassLayer`].
+///
+/// `name` may be a canonical stem ([`REVEAL_BUILTIN_THEMES`]) or an alias
+/// (`white`/`black`). Returns [`SassError::ThemeNotFound`] for unknown names.
+/// The theme layer's `defaults` set the Quarto vocabulary (`$body-bg`,
+/// `$link-color`, `$presentation-*`, …); since theme layers are assembled ahead
+/// of the Quarto reveal layer, those `!default` assignments win.
+pub fn load_reveal_theme_layer(name: &str) -> Result<SassLayer, SassError> {
+    use crate::resources::REVEALJS_RESOURCES;
+
+    let resolved = resolve_reveal_theme_name(name)
+        .ok_or_else(|| SassError::ThemeNotFound(name.to_string()))?;
+    let rel = format!("themes/{resolved}.scss");
+    let content = REVEALJS_RESOURCES
+        .read_str(Path::new(&rel))
+        .ok_or_else(|| SassError::CompilationFailed {
+            message: format!("reveal theme SCSS not found: {rel}"),
+        })?;
+    parse_layer(content, Some(&rel))
+}
+
 /// Assemble a complete SCSS string for a reveal.js deck.
 ///
 /// The reveal analogue of [`assemble_with_theme`] / [`assemble_bootstrap`]: it
-/// loads the reveal framework + Quarto reveal layers and assembles them (with an
-/// optional theme layer) using the shared [`assemble_scss`] ordering. The result
-/// is a single SCSS string compiled in **one** pass (decision D1 — unified
-/// compilation), producing a self-contained reveal theme stylesheet.
+/// loads the reveal framework + Quarto reveal layers and assembles them (with
+/// zero or more theme layers) using the shared [`assemble_scss`] ordering. The
+/// result is a single SCSS string compiled in **one** pass (decision D1 —
+/// unified compilation), producing a self-contained reveal theme stylesheet.
 ///
-/// `theme` is `None` in Stage A (the Quarto defaults are the white-equivalent);
-/// built-in/user themes arrive in Stage B as additional `defaults` layers.
-pub fn assemble_reveal_scss(theme: Option<&SassLayer>) -> Result<String, SassError> {
+/// `theme_layers` are the resolved built-in/user theme layers in declaration
+/// order (e.g. `[dracula, custom.scss]`). They are merged via [`merge_layers`]
+/// (which reverses `defaults` so a later layer's `!default` wins) and slotted in
+/// as the single high-priority theme layer. An empty slice yields the
+/// white-equivalent default (Quarto defaults only).
+pub fn assemble_reveal_scss(theme_layers: &[SassLayer]) -> Result<String, SassError> {
+    use crate::layer::merge_layers;
+
     let framework = load_reveal_framework()?;
     let quarto = load_quarto_reveal_layer()?;
-    Ok(assemble_scss(&framework, &quarto, theme))
+    let merged = if theme_layers.is_empty() {
+        None
+    } else {
+        Some(merge_layers(theme_layers))
+    };
+    Ok(assemble_scss(&framework, &quarto, merged.as_ref()))
 }
 
 /// Assemble a complete SCSS string for compilation.

--- a/crates/quarto-sass/src/bundle.rs
+++ b/crates/quarto-sass/src/bundle.rs
@@ -252,6 +252,86 @@ pub fn load_embed_example_layer() -> Result<SassLayer, SassError> {
     parse_layer(content, Some("embed-example.scss"))
 }
 
+/// Load the reveal.js framework layer.
+///
+/// This is the reveal analogue of [`load_bootstrap_framework`]: it provides the
+/// low-priority framework layer for a reveal deck's theme compilation. It is
+/// assembled from the vendored reveal.js 6 theme template
+/// (`resources/scss/revealjs/reveal-template/`):
+///
+/// - `uses`     — `@use 'sass:color'` / `@use 'sass:meta'` (needed by the
+///   `color.scale(...)` calls in the settings declarations).
+/// - `defaults` — `_settings-vars.scss`: reveal's `$kebab: … !default;`
+///   declarations (the reveal-native fallbacks). Quarto's reveal layer
+///   overrides these via its own higher-priority `!default` assignments.
+/// - `mixins`   — `_mixins.scss`: `light/dark-bg-text-color`.
+/// - `rules`    — `_expose.scss` (the `:root { --r-*: … }` emitter, which must
+///   run *after* defaults collapse) followed by `_theme.scss` (the `var(--r-*)`
+///   rule set). Quarto's reveal rules are assembled after these and override them.
+///
+/// See `resources/scss/revealjs/README.md` for why settings is split this way
+/// (the `@use ... with (...)` authoring API fights the layered-`!default` model).
+pub fn load_reveal_framework() -> Result<SassLayer, SassError> {
+    use crate::resources::REVEALJS_RESOURCES;
+
+    let read = |rel: &str| -> Result<&'static str, SassError> {
+        REVEALJS_RESOURCES
+            .read_str(Path::new(rel))
+            .ok_or_else(|| SassError::CompilationFailed {
+                message: format!("reveal template SCSS not found: {rel}"),
+            })
+    };
+
+    let settings_vars = read("reveal-template/_settings-vars.scss")?;
+    let expose = read("reveal-template/_expose.scss")?;
+    let theme = read("reveal-template/_theme.scss")?;
+    let mixins = read("reveal-template/_mixins.scss")?;
+
+    Ok(SassLayer {
+        uses: "@use 'sass:color';\n@use 'sass:meta';\n".to_string(),
+        functions: String::new(),
+        defaults: settings_vars.to_string(),
+        mixins: mixins.to_string(),
+        // `_expose.scss` first so the `--r-*` custom properties are defined
+        // before `_theme.scss` consumes them via `var(--r-*)`.
+        rules: format!("{expose}\n\n{theme}"),
+    })
+}
+
+/// Load Quarto's reveal layer (`quarto-revealjs.scss`).
+///
+/// The reveal analogue of [`load_quarto_layer`]: the Quarto-owned layer that
+/// defines the `$presentation-*` / `$body-*` vocabulary, maps it onto reveal-6's
+/// kebab variables, and adds the rule overrides that make a deck feel native to
+/// Quarto (left-aligned slides, non-uppercase headings, Quarto title slide).
+pub fn load_quarto_reveal_layer() -> Result<SassLayer, SassError> {
+    use crate::resources::REVEALJS_RESOURCES;
+
+    let content = REVEALJS_RESOURCES
+        .read_str(Path::new("quarto-revealjs.scss"))
+        .ok_or_else(|| SassError::CompilationFailed {
+            message: "quarto-revealjs.scss not found in revealjs resources".to_string(),
+        })?;
+
+    parse_layer(content, Some("quarto-revealjs.scss"))
+}
+
+/// Assemble a complete SCSS string for a reveal.js deck.
+///
+/// The reveal analogue of [`assemble_with_theme`] / [`assemble_bootstrap`]: it
+/// loads the reveal framework + Quarto reveal layers and assembles them (with an
+/// optional theme layer) using the shared [`assemble_scss`] ordering. The result
+/// is a single SCSS string compiled in **one** pass (decision D1 — unified
+/// compilation), producing a self-contained reveal theme stylesheet.
+///
+/// `theme` is `None` in Stage A (the Quarto defaults are the white-equivalent);
+/// built-in/user themes arrive in Stage B as additional `defaults` layers.
+pub fn assemble_reveal_scss(theme: Option<&SassLayer>) -> Result<String, SassError> {
+    let framework = load_reveal_framework()?;
+    let quarto = load_quarto_reveal_layer()?;
+    Ok(assemble_scss(&framework, &quarto, theme))
+}
+
 /// Assemble a complete SCSS string for compilation.
 ///
 /// This function implements the correct assembly order from TypeScript Quarto:

--- a/crates/quarto-sass/src/compile.rs
+++ b/crates/quarto-sass/src/compile.rs
@@ -365,21 +365,22 @@ pub fn compile_default_css(
 /// `--r-*` custom properties carrying Quarto's overridden values, plus Quarto's
 /// look-fixing rule overrides.
 ///
-/// Stage A compiles the white-equivalent default (no theme layer); built-in /
-/// user themes (Stage B) will extend this with an additional theme layer.
-///
-/// Unlike Bootstrap compilation this needs no embedded-resource load paths — the
-/// reveal SCSS only `@use`s the built-in `sass:color` / `sass:meta` modules and
-/// is otherwise self-contained.
+/// `theme_layers` are the resolved built-in/user theme layers (empty = the
+/// white-equivalent default). `load_paths` are extra directories for resolving
+/// `@use`/`@import` inside *user* theme files (built-in reveal SCSS needs none —
+/// it only uses the built-in `sass:color` / `sass:meta` modules and is otherwise
+/// self-contained).
 #[cfg(not(target_arch = "wasm32"))]
 pub fn compile_reveal_theme_css(
     runtime: &dyn SystemRuntime,
     minified: bool,
+    theme_layers: &[crate::SassLayer],
+    load_paths: &[PathBuf],
 ) -> Result<String, SassError> {
     use quarto_system_runtime::sass_native::compile_scss;
 
-    let scss = crate::bundle::assemble_reveal_scss(None)?;
-    compile_scss(runtime, &scss, &[], minified).map_err(|e| SassError::CompilationFailed {
+    let scss = crate::bundle::assemble_reveal_scss(theme_layers)?;
+    compile_scss(runtime, &scss, load_paths, minified).map_err(|e| SassError::CompilationFailed {
         message: e.to_string(),
     })
 }
@@ -569,16 +570,18 @@ pub async fn compile_default_css(
 /// Compile Quarto's reveal.js theme CSS (WASM mirror of the native entry).
 ///
 /// See the native [`compile_reveal_theme_css`] for the architecture. Compiles
-/// via the dart-sass JS bridge. No embedded-resource load paths are needed (the
-/// reveal SCSS only uses built-in Sass modules).
+/// via the dart-sass JS bridge. `load_paths` resolve `@use`/`@import` inside
+/// user theme files; built-in reveal SCSS needs none.
 #[cfg(target_arch = "wasm32")]
 pub async fn compile_reveal_theme_css(
     runtime: &dyn SystemRuntime,
     minified: bool,
+    theme_layers: &[crate::SassLayer],
+    load_paths: &[PathBuf],
 ) -> Result<String, SassError> {
-    let scss = crate::bundle::assemble_reveal_scss(None)?;
+    let scss = crate::bundle::assemble_reveal_scss(theme_layers)?;
     runtime
-        .compile_sass(&scss, &[], minified)
+        .compile_sass(&scss, load_paths, minified)
         .await
         .map_err(|e| SassError::CompilationFailed {
             message: e.to_string(),

--- a/crates/quarto-sass/src/compile.rs
+++ b/crates/quarto-sass/src/compile.rs
@@ -356,6 +356,34 @@ pub fn compile_default_css(
     Ok(css)
 }
 
+/// Compile Quarto's reveal.js theme CSS (native).
+///
+/// Assembles the reveal framework + Quarto reveal layers (see
+/// [`crate::assemble_reveal_scss`]) into a single SCSS bundle and compiles it in
+/// one `grass` pass (decision D1 — unified compilation). The result is a
+/// self-contained reveal theme stylesheet: reveal's base rules driven by
+/// `--r-*` custom properties carrying Quarto's overridden values, plus Quarto's
+/// look-fixing rule overrides.
+///
+/// Stage A compiles the white-equivalent default (no theme layer); built-in /
+/// user themes (Stage B) will extend this with an additional theme layer.
+///
+/// Unlike Bootstrap compilation this needs no embedded-resource load paths — the
+/// reveal SCSS only `@use`s the built-in `sass:color` / `sass:meta` modules and
+/// is otherwise self-contained.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn compile_reveal_theme_css(
+    runtime: &dyn SystemRuntime,
+    minified: bool,
+) -> Result<String, SassError> {
+    use quarto_system_runtime::sass_native::compile_scss;
+
+    let scss = crate::bundle::assemble_reveal_scss(None)?;
+    compile_scss(runtime, &scss, &[], minified).map_err(|e| SassError::CompilationFailed {
+        message: e.to_string(),
+    })
+}
+
 /// Clear the default CSS cache.
 ///
 /// This is primarily useful for testing. In production, the cache persists
@@ -536,6 +564,25 @@ pub async fn compile_default_css(
     }
 
     Ok(css)
+}
+
+/// Compile Quarto's reveal.js theme CSS (WASM mirror of the native entry).
+///
+/// See the native [`compile_reveal_theme_css`] for the architecture. Compiles
+/// via the dart-sass JS bridge. No embedded-resource load paths are needed (the
+/// reveal SCSS only uses built-in Sass modules).
+#[cfg(target_arch = "wasm32")]
+pub async fn compile_reveal_theme_css(
+    runtime: &dyn SystemRuntime,
+    minified: bool,
+) -> Result<String, SassError> {
+    let scss = crate::bundle::assemble_reveal_scss(None)?;
+    runtime
+        .compile_sass(&scss, &[], minified)
+        .await
+        .map_err(|e| SassError::CompilationFailed {
+            message: e.to_string(),
+        })
 }
 
 #[cfg(test)]

--- a/crates/quarto-sass/src/config.rs
+++ b/crates/quarto-sass/src/config.rs
@@ -289,6 +289,44 @@ impl ThemeConfig {
     }
 }
 
+/// Resolve a `_brand.yml` (from the `brand:` key) into SCSS layers, independent
+/// of the Bootstrap `theme:` parsing.
+///
+/// `format: html` resolves brand through [`ThemeConfig::from_config_value`] +
+/// the `brand` position marker in `process_theme_specs`, but that path also
+/// parses `theme:` against the Bootswatch theme set — which rejects reveal theme
+/// names. RevealJS therefore resolves brand on its own via this helper: extract
+/// the `brand:` reference, read/parse it into a [`Brand`], and convert it to
+/// SCSS layers with [`crate::brand_to_layers`]. Returns an empty vector when no
+/// brand is configured.
+///
+/// `base_dir` resolves a relative `brand:` path (typically the project root);
+/// `font_path_prefix` is the directory prefix for `@font-face` URLs (pass an
+/// empty path to reference brand-bundled fonts by bare name).
+pub fn resolve_brand_layers(
+    config: &ConfigValue,
+    runtime: &dyn SystemRuntime,
+    base_dir: &Path,
+    font_path_prefix: &Path,
+) -> Result<Vec<crate::SassLayer>, SassError> {
+    let Some(brand_ref) = extract_brand_ref(config.get("brand"))? else {
+        return Ok(Vec::new());
+    };
+    // Reuse ThemeConfig's brand resolution (path/inline → typed Brand).
+    let resolved = ThemeConfig {
+        themes: Vec::new(),
+        minified: true,
+        suppress_bootstrap: false,
+        brand_ref: Some(brand_ref),
+    }
+    .resolve(runtime, base_dir)?;
+
+    match resolved.brand {
+        Some(brand) => crate::brand_layer::brand_to_layers(&brand, font_path_prefix),
+        None => Ok(Vec::new()),
+    }
+}
+
 /// Extract the text content from a ConfigValue, handling both Scalar strings
 /// and PandocInlines (which occur when document frontmatter values are parsed
 /// as markdown by pampa).

--- a/crates/quarto-sass/src/lib.rs
+++ b/crates/quarto-sass/src/lib.rs
@@ -64,7 +64,7 @@ pub use compile::{
     assemble_theme_scss, compile_css_from_config, compile_default_css, compile_reveal_theme_css,
     compile_theme_css, compile_with_doc_vars,
 };
-pub use config::{ResolvedThemeConfig, ThemeConfig};
+pub use config::{ResolvedThemeConfig, ThemeConfig, resolve_brand_layers};
 pub use error::SassError;
 pub use layer::{merge_layers, parse_layer, parse_layer_from_parts};
 pub use resources::{

--- a/crates/quarto-sass/src/lib.rs
+++ b/crates/quarto-sass/src/lib.rs
@@ -55,13 +55,13 @@ pub const CSS_BUILD_ID: &str = include_str!(concat!(env!("OUT_DIR"), "/css_build
 
 pub use brand_layer::brand_to_layers;
 pub use bundle::{
-    assemble_bootstrap, assemble_scss, assemble_themes, assemble_with_theme,
-    assemble_with_user_layers, load_bootstrap_framework, load_quarto_layer, load_theme,
-    load_title_block_layer,
+    assemble_bootstrap, assemble_reveal_scss, assemble_scss, assemble_themes, assemble_with_theme,
+    assemble_with_user_layers, load_bootstrap_framework, load_quarto_layer,
+    load_quarto_reveal_layer, load_reveal_framework, load_theme, load_title_block_layer,
 };
 pub use compile::{
-    assemble_theme_scss, compile_css_from_config, compile_default_css, compile_theme_css,
-    compile_with_doc_vars,
+    assemble_theme_scss, compile_css_from_config, compile_default_css, compile_reveal_theme_css,
+    compile_theme_css, compile_with_doc_vars,
 };
 pub use config::{ResolvedThemeConfig, ThemeConfig};
 pub use error::SassError;

--- a/crates/quarto-sass/src/lib.rs
+++ b/crates/quarto-sass/src/lib.rs
@@ -55,9 +55,10 @@ pub const CSS_BUILD_ID: &str = include_str!(concat!(env!("OUT_DIR"), "/css_build
 
 pub use brand_layer::brand_to_layers;
 pub use bundle::{
-    assemble_bootstrap, assemble_reveal_scss, assemble_scss, assemble_themes, assemble_with_theme,
-    assemble_with_user_layers, load_bootstrap_framework, load_quarto_layer,
-    load_quarto_reveal_layer, load_reveal_framework, load_theme, load_title_block_layer,
+    REVEAL_BUILTIN_THEMES, assemble_bootstrap, assemble_reveal_scss, assemble_scss,
+    assemble_themes, assemble_with_theme, assemble_with_user_layers, load_bootstrap_framework,
+    load_quarto_layer, load_quarto_reveal_layer, load_reveal_framework, load_reveal_theme_layer,
+    load_theme, load_title_block_layer, resolve_reveal_theme_name,
 };
 pub use compile::{
     assemble_theme_scss, compile_css_from_config, compile_default_css, compile_reveal_theme_css,

--- a/crates/quarto-sass/src/resources.rs
+++ b/crates/quarto-sass/src/resources.rs
@@ -59,6 +59,14 @@ static QUARTO_BOOTSTRAP_DIR: Dir<'static> =
 static TEMPLATES_DIR: Dir<'static> =
     include_dir!("$CARGO_MANIFEST_DIR/../../resources/scss/html/templates");
 
+/// RevealJS SCSS directory embedded at compile time.
+///
+/// Contains the vendored reveal.js 6 theme template (`reveal-template/`) and
+/// Quarto's reveal layer (`quarto-revealjs.scss`). See
+/// `resources/scss/revealjs/README.md` for provenance.
+static REVEALJS_DIR: Dir<'static> =
+    include_dir!("$CARGO_MANIFEST_DIR/../../resources/scss/revealjs");
+
 /// Virtual path prefix for embedded resources.
 ///
 /// Files embedded via `EmbeddedResources` are accessible under this prefix.
@@ -280,6 +288,15 @@ pub static QUARTO_BOOTSTRAP_RESOURCES: EmbeddedResources =
 /// - `title-block.scss` - Styling for document title block, metadata, abstract
 pub static TEMPLATES_RESOURCES: EmbeddedResources =
     EmbeddedResources::new(&TEMPLATES_DIR, "html/templates");
+
+/// RevealJS SCSS resources.
+///
+/// Contains the vendored reveal.js 6 theme template under `reveal-template/`
+/// (`_settings-vars.scss`, `_expose.scss`, `_theme.scss`, `_mixins.scss`) and
+/// Quarto's reveal layer `quarto-revealjs.scss`. Consumed by
+/// `bundle::load_reveal_framework` / `bundle::load_quarto_reveal_layer`.
+pub static REVEALJS_RESOURCES: EmbeddedResources =
+    EmbeddedResources::new(&REVEALJS_DIR, "revealjs");
 
 /// Get the default load paths for SASS compilation.
 ///

--- a/crates/quarto-sass/tests/integration/main.rs
+++ b/crates/quarto-sass/tests/integration/main.rs
@@ -8,5 +8,6 @@ pub mod compile_all_themes_test;
 pub mod custom_theme_test;
 pub mod embedded_compile_test;
 pub mod parity_test;
+pub mod reveal_theme_test;
 
 fn main() {}

--- a/crates/quarto-sass/tests/integration/reveal_theme_test.rs
+++ b/crates/quarto-sass/tests/integration/reveal_theme_test.rs
@@ -252,6 +252,39 @@ fn quick_wins_compile_and_emit() {
 }
 
 #[test]
+fn footer_and_logo_compile_and_emit() {
+    let css = compile(&assemble_reveal_scss(&[]).unwrap());
+
+    // The deck-level footer/logo elements are direct children of `.reveal`, so
+    // CSS positions them fixed (see assemble.rs `footer_logo_html`).
+    assert!(css.contains(".reveal .footer"), "footer color/layout rule");
+    assert!(
+        css.contains(".reveal .slide-logo"),
+        "slide-logo positioning rule"
+    );
+    // Both are fixed-positioned (the whole point of placing them outside .slides).
+    assert!(
+        css.contains("position: fixed"),
+        "footer/logo fixed positioning"
+    );
+    // Footer recolors on contrasting backgrounds, matching quarto.scss:570-592.
+    assert!(
+        css.contains(".reveal .footer.has-dark-background")
+            || css.contains(".footer.has-dark-background"),
+        "footer has-dark-background variant\n{css}"
+    );
+    assert!(
+        css.contains(".footer.has-light-background"),
+        "footer has-light-background variant"
+    );
+    // has-logo repositions the slide number (Q1 plugin footer.css).
+    assert!(
+        css.contains(".reveal.has-logo .slide-number"),
+        "has-logo slide-number reposition"
+    );
+}
+
+#[test]
 fn callouts_compile_and_emit_per_type() {
     let css = compile(&assemble_reveal_scss(&[]).unwrap());
     assert!(css.contains(".reveal div.callout"), "callout base rules");

--- a/crates/quarto-sass/tests/integration/reveal_theme_test.rs
+++ b/crates/quarto-sass/tests/integration/reveal_theme_test.rs
@@ -7,7 +7,10 @@
 //! - includes the look-fixing rules that distinguish a Quarto deck from a stock
 //!   reveal deck (left-aligned slides, non-uppercase headings, Quarto title slide).
 
-use quarto_sass::bundle::{assemble_reveal_scss, load_quarto_reveal_layer, load_reveal_framework};
+use quarto_sass::bundle::{
+    REVEAL_BUILTIN_THEMES, assemble_reveal_scss, load_quarto_reveal_layer, load_reveal_framework,
+    load_reveal_theme_layer, resolve_reveal_theme_name,
+};
 
 /// Compile assembled reveal SCSS through grass (expanded output for assertions).
 fn compile(scss: &str) -> String {
@@ -52,7 +55,7 @@ fn quarto_reveal_layer_parses() {
 
 #[test]
 fn reveal_theme_compiles() {
-    let scss = assemble_reveal_scss(None).unwrap();
+    let scss = assemble_reveal_scss(&[]).unwrap();
     let css = compile(&scss);
     assert!(!css.is_empty(), "compiled reveal CSS is non-empty");
     // sanity: the reveal base rule set made it through
@@ -64,7 +67,7 @@ fn reveal_theme_compiles() {
 
 #[test]
 fn quarto_values_flow_into_custom_properties() {
-    let css = compile(&assemble_reveal_scss(None).unwrap());
+    let css = compile(&assemble_reveal_scss(&[]).unwrap());
 
     // Quarto's body color (#222) must win over reveal's default (#eee).
     assert!(
@@ -85,7 +88,7 @@ fn quarto_values_flow_into_custom_properties() {
 
 #[test]
 fn headings_are_not_uppercased() {
-    let css = compile(&assemble_reveal_scss(None).unwrap());
+    let css = compile(&assemble_reveal_scss(&[]).unwrap());
     // Quarto turns OFF reveal's default uppercase headings.
     assert!(
         css.contains("--r-heading-text-transform: none"),
@@ -99,7 +102,7 @@ fn headings_are_not_uppercased() {
 
 #[test]
 fn slides_are_left_aligned() {
-    let css = compile(&assemble_reveal_scss(None).unwrap());
+    let css = compile(&assemble_reveal_scss(&[]).unwrap());
     // The Quarto rule `.reveal .slides { text-align: left }` must be present.
     assert!(
         css.contains("text-align: left"),
@@ -109,10 +112,102 @@ fn slides_are_left_aligned() {
 
 #[test]
 fn title_slide_is_centered_and_resized() {
-    let css = compile(&assemble_reveal_scss(None).unwrap());
+    let css = compile(&assemble_reveal_scss(&[]).unwrap());
     assert!(css.contains("#title-slide"), "title-slide rules present");
     assert!(
         css.contains("text-align: center"),
         "title slide centered\n{css}"
     );
+}
+
+// ── Stage B: built-in theme set + aliases ────────────────────────────────
+
+#[test]
+fn theme_name_aliases_resolve() {
+    assert_eq!(resolve_reveal_theme_name("white"), Some("default"));
+    assert_eq!(resolve_reveal_theme_name("black"), Some("dark"));
+    assert_eq!(resolve_reveal_theme_name("default"), Some("default"));
+    assert_eq!(resolve_reveal_theme_name("dark"), Some("dark"));
+    assert_eq!(resolve_reveal_theme_name("dracula"), Some("dracula"));
+    assert_eq!(resolve_reveal_theme_name("nope"), None);
+}
+
+#[test]
+fn all_builtin_themes_compile() {
+    // Every shipped theme must assemble + compile through grass.
+    for name in REVEAL_BUILTIN_THEMES {
+        let layer =
+            load_reveal_theme_layer(name).unwrap_or_else(|e| panic!("load theme {name}: {e}"));
+        let css = compile(&assemble_reveal_scss(&[layer]).unwrap());
+        assert!(
+            css.contains(".reveal-viewport"),
+            "theme {name} should produce reveal base rules"
+        );
+        // No theme should leak reveal's uppercase default unless it opted in
+        // (beige/league/moon/solarized/blood/sky set uppercase deliberately).
+        let opts_in_uppercase = matches!(
+            *name,
+            "beige" | "league" | "moon" | "solarized" | "blood" | "sky"
+        );
+        if !opts_in_uppercase {
+            assert!(
+                !css.contains("uppercase"),
+                "theme {name} should not uppercase headings"
+            );
+        }
+    }
+}
+
+#[test]
+fn dark_theme_sets_dark_background() {
+    let layer = load_reveal_theme_layer("dark").unwrap();
+    let css = compile(&assemble_reveal_scss(&[layer]).unwrap());
+    assert!(
+        css.contains("--r-background-color: #191919"),
+        "dark theme should set the dark background\n{css}"
+    );
+    assert!(
+        css.contains("--r-main-color: #fff"),
+        "dark theme should use light text"
+    );
+    // `black` is an alias for `dark` — same output.
+    let black =
+        compile(&assemble_reveal_scss(&[load_reveal_theme_layer("black").unwrap()]).unwrap());
+    assert!(black.contains("--r-background-color: #191919"));
+}
+
+#[test]
+fn dracula_theme_distinctive_colors() {
+    let layer = load_reveal_theme_layer("dracula").unwrap();
+    let css = compile(&assemble_reveal_scss(&[layer]).unwrap());
+    // Dracula background + purple headings + its custom-property effects.
+    assert!(
+        css.contains("--r-background-color: #282a36"),
+        "dracula background\n{css}"
+    );
+    assert!(
+        css.contains("--r-heading-color: #bd93f9"),
+        "dracula purple headings"
+    );
+    assert!(
+        css.contains("--r-bold-color: #ffb86c"),
+        "dracula bold-color effect from its rules"
+    );
+}
+
+#[test]
+fn beige_theme_has_radial_background() {
+    // The bodyBackground()/radial-gradient mixin was ported to a $background
+    // gradient (reveal 6 dropped the mixin).
+    let layer = load_reveal_theme_layer("beige").unwrap();
+    let css = compile(&assemble_reveal_scss(&[layer]).unwrap());
+    assert!(
+        css.contains("--r-background: radial-gradient"),
+        "beige should set a radial-gradient background\n{css}"
+    );
+}
+
+#[test]
+fn unknown_theme_errors() {
+    assert!(load_reveal_theme_layer("no-such-theme").is_err());
 }

--- a/crates/quarto-sass/tests/integration/reveal_theme_test.rs
+++ b/crates/quarto-sass/tests/integration/reveal_theme_test.rs
@@ -252,6 +252,28 @@ fn quick_wins_compile_and_emit() {
 }
 
 #[test]
+fn callouts_compile_and_emit_per_type() {
+    let css = compile(&assemble_reveal_scss(&[]).unwrap());
+    assert!(css.contains(".reveal div.callout"), "callout base rules");
+    assert!(
+        css.contains(".callout-note") && css.contains(".callout-warning"),
+        "per-type callout rules"
+    );
+    // Per-type icon as an inlined, URL-encoded SVG with the accent color.
+    assert!(
+        css.contains("background-image: url('data:image/svg+xml,"),
+        "callout icon SVG data URI\n{}",
+        &css[css.len().saturating_sub(600)..]
+    );
+    // The icon fill is recolored per type and URL-encoded (# → %23).
+    assert!(css.contains("%23"), "callout icon color URL-encoded");
+    assert!(css.contains("fill:"), "callout icon fill set");
+    // callout-style-simple / -default specific rules present
+    assert!(css.contains(".callout-style-simple"));
+    assert!(css.contains(".callout-style-default"));
+}
+
+#[test]
 fn shift_to_dark_picks_dark_value_on_dark_theme() {
     // kbd uses `shift_to_dark`, which depends on the slide background's
     // blackness. On the `dark` theme (bg #191919) the dark branch is chosen

--- a/crates/quarto-sass/tests/integration/reveal_theme_test.rs
+++ b/crates/quarto-sass/tests/integration/reveal_theme_test.rs
@@ -211,3 +211,67 @@ fn beige_theme_has_radial_background() {
 fn unknown_theme_errors() {
     assert!(load_reveal_theme_layer("no-such-theme").is_err());
 }
+
+// ── Stage C quick-wins (the ported quarto.scss systems) ──────────────────────
+
+#[test]
+fn quick_wins_compile_and_emit() {
+    let css = compile(&assemble_reveal_scss(&[]).unwrap());
+
+    // per-background text recoloring
+    assert!(
+        css.contains("section.has-dark-background"),
+        "has-dark-background rule present"
+    );
+    assert!(
+        css.contains("section.has-light-background"),
+        "has-light-background rule present"
+    );
+    // code blocks: bordered + scrollable
+    assert!(css.contains("div.sourceCode"), "sourceCode border rule");
+    assert!(
+        css.contains("max-height: 500px"),
+        "code block scroll max-height\n{css}"
+    );
+    // blockquote restyle (left accent border, not italic-centered)
+    assert!(
+        css.contains("border-left: 0.25rem"),
+        "blockquote accent border"
+    );
+    // .smaller system
+    assert!(css.contains(".reveal.smaller"), "global .smaller rule");
+    // kbd
+    assert!(css.contains("kbd {") || css.contains("kbd{"), "kbd rule");
+    // task lists
+    assert!(css.contains("task-list"), "task-list rule");
+    // code-font custom properties
+    assert!(
+        css.contains("--r-inline-code-font:"),
+        "inline code font custom property"
+    );
+}
+
+#[test]
+fn shift_to_dark_picks_dark_value_on_dark_theme() {
+    // kbd uses `shift_to_dark`, which depends on the slide background's
+    // blackness. On the `dark` theme (bg #191919) the dark branch is chosen
+    // (a shifted background), proving the helper + blackness threshold work.
+    let dark = compile(&assemble_reveal_scss(&[load_reveal_theme_layer("dark").unwrap()]).unwrap());
+    let light = compile(&assemble_reveal_scss(&[]).unwrap());
+    // The kbd background-color differs between dark and light themes.
+    let kbd_bg = |css: &str| {
+        let i = css
+            .find("kbd {")
+            .or_else(|| css.find("kbd{"))
+            .expect("kbd rule");
+        let seg = &css[i..(i + 200).min(css.len())];
+        seg.find("background-color:")
+            .map(|j| seg[j..].split(';').next().unwrap_or("").to_string())
+            .expect("kbd background-color")
+    };
+    assert_ne!(
+        kbd_bg(&dark),
+        kbd_bg(&light),
+        "shift_to_dark should yield different kbd backgrounds on dark vs light themes"
+    );
+}

--- a/crates/quarto-sass/tests/integration/reveal_theme_test.rs
+++ b/crates/quarto-sass/tests/integration/reveal_theme_test.rs
@@ -1,0 +1,118 @@
+//! RevealJS theme assembly + compilation tests (Stage A of bd-r9mkybwl).
+//!
+//! Verifies that `assemble_reveal_scss` produces a SCSS bundle that:
+//! - compiles cleanly through `grass` (our native SCSS compiler),
+//! - emits the reveal `--r-*` custom properties carrying Quarto's overridden
+//!   values (not reveal's defaults), and
+//! - includes the look-fixing rules that distinguish a Quarto deck from a stock
+//!   reveal deck (left-aligned slides, non-uppercase headings, Quarto title slide).
+
+use quarto_sass::bundle::{assemble_reveal_scss, load_quarto_reveal_layer, load_reveal_framework};
+
+/// Compile assembled reveal SCSS through grass (expanded output for assertions).
+fn compile(scss: &str) -> String {
+    let options = grass::Options::default();
+    grass::from_string(scss, &options).unwrap_or_else(|e| panic!("reveal SCSS should compile: {e}"))
+}
+
+#[test]
+fn reveal_framework_layer_loads() {
+    let fw = load_reveal_framework().unwrap();
+    assert!(fw.uses.contains("sass:color"), "framework uses sass:color");
+    assert!(
+        fw.defaults.contains("$heading-text-transform"),
+        "framework defaults declare reveal vars"
+    );
+    assert!(
+        fw.rules.contains("--r-main-color"),
+        "framework rules include the :root --r-* emitter"
+    );
+    assert!(
+        fw.rules.contains("var(--r-main-color)"),
+        "framework rules include the theme rule set"
+    );
+    assert!(
+        fw.mixins.contains("dark-bg-text-color"),
+        "framework mixins include reveal mixins"
+    );
+}
+
+#[test]
+fn quarto_reveal_layer_parses() {
+    let q = load_quarto_reveal_layer().unwrap();
+    assert!(
+        q.defaults.contains("$presentation-slide-text-align"),
+        "quarto layer declares the presentation vocabulary"
+    );
+    assert!(
+        q.rules.contains("#title-slide"),
+        "quarto layer rules include title-slide layout"
+    );
+}
+
+#[test]
+fn reveal_theme_compiles() {
+    let scss = assemble_reveal_scss(None).unwrap();
+    let css = compile(&scss);
+    assert!(!css.is_empty(), "compiled reveal CSS is non-empty");
+    // sanity: the reveal base rule set made it through
+    assert!(
+        css.contains(".reveal-viewport"),
+        "includes reveal base rules"
+    );
+}
+
+#[test]
+fn quarto_values_flow_into_custom_properties() {
+    let css = compile(&assemble_reveal_scss(None).unwrap());
+
+    // Quarto's body color (#222) must win over reveal's default (#eee).
+    assert!(
+        css.contains("--r-main-color: #222"),
+        "Quarto body color should drive --r-main-color\n{css}"
+    );
+    // Quarto's background (white) must win over reveal's default (#2b2b2b / #bbb).
+    assert!(
+        css.contains("--r-background-color: #fff"),
+        "Quarto body-bg should drive --r-background-color"
+    );
+    // Collision case: reveal's own $link-color is set from Quarto's $primary.
+    assert!(
+        css.contains("--r-link-color: #2a76dd"),
+        "Quarto primary should drive --r-link-color"
+    );
+}
+
+#[test]
+fn headings_are_not_uppercased() {
+    let css = compile(&assemble_reveal_scss(None).unwrap());
+    // Quarto turns OFF reveal's default uppercase headings.
+    assert!(
+        css.contains("--r-heading-text-transform: none"),
+        "heading text-transform should be none"
+    );
+    assert!(
+        !css.contains("uppercase"),
+        "no uppercase anywhere in the compiled Quarto reveal theme\n{css}"
+    );
+}
+
+#[test]
+fn slides_are_left_aligned() {
+    let css = compile(&assemble_reveal_scss(None).unwrap());
+    // The Quarto rule `.reveal .slides { text-align: left }` must be present.
+    assert!(
+        css.contains("text-align: left"),
+        "slides should be left aligned\n{css}"
+    );
+}
+
+#[test]
+fn title_slide_is_centered_and_resized() {
+    let css = compile(&assemble_reveal_scss(None).unwrap());
+    assert!(css.contains("#title-slide"), "title-slide rules present");
+    assert!(
+        css.contains("text-align: center"),
+        "title slide centered\n{css}"
+    );
+}

--- a/crates/wasm-quarto-hub-client/Cargo.lock
+++ b/crates/wasm-quarto-hub-client/Cargo.lock
@@ -377,7 +377,7 @@ dependencies = [
 
 [[package]]
 name = "comrak-to-pandoc"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "comrak",
  "hashlink",
@@ -2072,7 +2072,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-analysis"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "quarto-error-reporting",
  "quarto-pandoc-types",
@@ -2094,7 +2094,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-brand"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "serde",
  "serde_yaml",
@@ -2103,7 +2103,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-citeproc"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "glob",
  "hashlink",
@@ -2134,7 +2134,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2184,7 +2184,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-csl"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "quarto-error-reporting",
  "quarto-source-map",
@@ -2220,7 +2220,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-error-reporting"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ariadne",
  "once_cell",
@@ -2234,7 +2234,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-highlight"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "once_cell",
  "quarto-highlight-encoding",
@@ -2260,7 +2260,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-highlight-encoding"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2268,7 +2268,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-lsp-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "pampa",
  "pollster",
@@ -2286,7 +2286,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-navigation"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "quarto-config",
  "quarto-pandoc-types",
@@ -2321,7 +2321,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-project-create"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "quarto-doctemplate",
  "serde",
@@ -2330,7 +2330,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-sass"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "include_dir",
  "once_cell",
@@ -2348,7 +2348,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-source-map"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2357,7 +2357,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-system-runtime"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -2374,7 +2374,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-trace"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "flate2",
  "serde",
@@ -2392,7 +2392,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-util"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -2400,7 +2400,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-xml"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "quarto-error-reporting",
  "quarto-source-map",
@@ -2410,7 +2410,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-yaml"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "quarto-source-map",
  "serde",
@@ -3997,7 +3997,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-printf-fmt"
-version = "0.1.0"
+version = "0.2.0"
 
 [[package]]
 name = "wasm-quarto-hub-client"

--- a/crates/xtask/src/stage_doc_examples.rs
+++ b/crates/xtask/src/stage_doc_examples.rs
@@ -137,9 +137,16 @@ fn render_project(root: &Path, project: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Image extensions staged alongside the rendered HTML. A deck that references
+/// an image (`logo:`, a slide `![](pic.svg)`, …) keeps it as a **top-level**
+/// asset beside `slides.html` (a `type: default` project renders in place), so
+/// the embedded iframe needs it copied too — `*_files/` alone is not enough.
+const STAGED_IMAGE_EXTENSIONS: &[&str] = &["png", "jpg", "jpeg", "gif", "svg", "webp", "avif"];
+
 /// Copy the static render output from `src_project` into `dest`: every
-/// top-level `*.html` file and every top-level `*_files/` directory. Source
-/// files (`*.qmd`, `_quarto.yml`, `README.md`), caches (`.quarto/`), and
+/// top-level `*.html` file, every top-level image asset (see
+/// [`STAGED_IMAGE_EXTENSIONS`]), and every top-level `*_files/` directory.
+/// Source files (`*.qmd`, `_quarto.yml`, `README.md`), caches (`.quarto/`), and
 /// dotfiles are skipped — only published artifacts are staged. Returns the
 /// number of top-level items copied.
 fn copy_static_output(src_project: &Path, dest: &Path) -> Result<usize> {
@@ -156,13 +163,20 @@ fn copy_static_output(src_project: &Path, dest: &Path) -> Result<usize> {
         if file_type.is_dir() && name.ends_with("_files") {
             copy_dir_recursive(&path, &dest.join(name.as_ref()))?;
             copied += 1;
-        } else if file_type.is_file() && name.ends_with(".html") {
+        } else if file_type.is_file() && (name.ends_with(".html") || is_staged_image(&name)) {
             fs::copy(&path, dest.join(name.as_ref()))
                 .with_context(|| format!("copying {}", path.display()))?;
             copied += 1;
         }
     }
     Ok(copied)
+}
+
+/// Whether a top-level file is an image asset that should be staged.
+fn is_staged_image(name: &str) -> bool {
+    name.rsplit_once('.').is_some_and(|(_, ext)| {
+        STAGED_IMAGE_EXTENSIONS.contains(&ext.to_ascii_lowercase().as_str())
+    })
 }
 
 /// Recursively copy a directory tree.
@@ -179,4 +193,29 @@ fn copy_dir_recursive(src: &Path, dest: &Path) -> Result<()> {
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_staged_image;
+
+    #[test]
+    fn recognizes_image_assets_case_insensitively() {
+        for name in ["logo.svg", "pic.png", "photo.JPG", "anim.gif", "img.WEBP"] {
+            assert!(is_staged_image(name), "{name} should be staged");
+        }
+    }
+
+    #[test]
+    fn rejects_non_images_and_extensionless() {
+        for name in [
+            "slides.html",
+            "slides.qmd",
+            "_quarto.yml",
+            "README.md",
+            "noext",
+        ] {
+            assert!(!is_staged_image(name), "{name} should not be staged");
+        }
+    }
 }

--- a/docs/presentations/revealjs/index.qmd
+++ b/docs/presentations/revealjs/index.qmd
@@ -17,10 +17,9 @@ title slide. The rest of this page walks through the slide-authoring
 features Quarto 2 supports today.
 
 ::: {.callout-note}
-Quarto 2's reveal.js support is still growing. This page documents only
-what is implemented now; features such as slide backgrounds, code-line
-highlighting, transitions, themes, and the speaker-view UI are not yet
-available.
+Quarto 2's reveal.js support is still growing. This page documents only what is
+implemented now; features such as code-line highlighting, the speaker-view UI,
+and the reveal.js plugins (menu, search, chalkboard) are not yet available.
 :::
 
 ## Creating slides
@@ -260,3 +259,72 @@ format:
     reference-location: document
 ---
 ```
+
+## Themes
+
+Every deck starts from the `default` theme — a left-aligned, white theme tuned
+to feel like Quarto. To restyle the whole deck, set `theme:` to one of the
+built-in reveal.js themes (`dark`, `league`, `dracula`, `solarized`, and the
+rest):
+
+:::: {#demo-themes .embed-example-iframe file="/examples/presentations/09-themes/slides.html"}
+```markdown
+---
+format:
+  revealjs:
+    theme: dark
+---
+
+## A dark slide
+
+Content on a dark background.
+```
+
+The `theme:` option restyles the deck's background, text, and links at once;
+this deck uses the built-in `dark` theme. `white` aliases to `default` and
+`black` aliases to `dark`. [View source](https://github.com/quarto-dev/q2/tree/main/examples/presentations/09-themes)
+::::
+
+## Footer and logo
+
+To repeat a line of text along the bottom of every slide, set `footer:`. To pin
+an image to the corner of every slide, set `logo:`. Both live in the front
+matter and apply to the whole deck.
+
+:::: {#demo-footer-logo .embed-example-iframe file="/examples/presentations/10-footer-logo/slides.html"}
+```markdown
+---
+format: revealjs
+footer: "© 2026 Example Corp — [example.com](https://example.com)"
+logo: logo.svg
+---
+
+## A slide
+
+The footer and logo appear here, and on every other slide.
+```
+
+The footer sits centered and muted at the bottom of each slide and accepts
+Markdown, so a link in it renders as a link; the logo sits in the corner. [View source](https://github.com/quarto-dev/q2/tree/main/examples/presentations/10-footer-logo)
+::::
+
+## Stretching images
+
+When a slide's only image stands in a block of its own, Quarto sizes it to fill
+the space the slide's other content leaves — reveal.js calls this `.r-stretch`,
+and Quarto adds it automatically so a large image never overflows. A heading and
+a line of explanation can sit alongside the image.
+
+:::: {#demo-auto-stretch .embed-example-iframe file="/examples/presentations/11-auto-stretch/slides.html"}
+```markdown
+## A single image fills the slide
+
+Here is our architecture:
+
+![](diagram.svg)
+```
+
+A lone slide image stretches to fill the available space. To keep an image at
+its natural size, set `auto-stretch: false`, give the image an explicit
+`width`/`height`, or mark it `.nostretch`. [View source](https://github.com/quarto-dev/q2/tree/main/examples/presentations/11-auto-stretch)
+::::

--- a/examples/manifest.yml
+++ b/examples/manifest.yml
@@ -28,3 +28,6 @@ projects:
   - presentations/06-speaker-notes
   - presentations/07-asides
   - presentations/08-footnotes
+  - presentations/09-themes
+  - presentations/10-footer-logo
+  - presentations/11-auto-stretch

--- a/examples/presentations/09-themes/README.md
+++ b/examples/presentations/09-themes/README.md
@@ -1,0 +1,22 @@
+# 09-themes — Built-in themes
+
+Restyling a deck with the `theme:` option.
+
+## What this demonstrates
+
+- **Theme selection.** Setting `theme: dark` in the `revealjs` front matter
+  swaps the whole deck onto the built-in dark theme.
+- **Built-in themes and aliases.** Quarto ships the reveal.js theme set;
+  `white` aliases to the `default` theme and `black` aliases to `dark`.
+
+## How to run
+
+```bash
+cargo run --bin q2 -- render examples/presentations/09-themes
+```
+
+## What to look for
+
+- The deck renders with a dark background and light text rather than the white
+  default — the theme drives the colors, fonts, and link styling.
+- Omitting `theme:` would render the `default` theme instead.

--- a/examples/presentations/09-themes/_quarto.yml
+++ b/examples/presentations/09-themes/_quarto.yml
@@ -1,0 +1,2 @@
+project:
+  type: default

--- a/examples/presentations/09-themes/slides.qmd
+++ b/examples/presentations/09-themes/slides.qmd
@@ -1,0 +1,23 @@
+---
+title: "Themes"
+format:
+  revealjs:
+    theme: dark
+---
+
+## A themed deck
+
+The `theme:` option restyles the whole deck. This deck sets `theme: dark`, so
+its background, text, and links all come from the built-in dark theme.
+
+- The background is dark
+- The text is light
+- Links pick up the theme accent
+
+## Choosing a theme
+
+Quarto ships the reveal.js themes — `dark`, `league`, `dracula`, `solarized`,
+and the rest. The default theme (when you omit `theme:`) is `default`, a
+left-aligned white theme tuned to feel like Quarto.
+
+`white` is an alias for `default`, and `black` is an alias for `dark`.

--- a/examples/presentations/10-footer-logo/README.md
+++ b/examples/presentations/10-footer-logo/README.md
@@ -1,0 +1,26 @@
+# 10-footer-logo — Footer and logo
+
+Adding deck-level chrome: a footer line and a corner logo.
+
+## What this demonstrates
+
+- **Footer.** A `footer:` entry repeats one line at the bottom of every slide.
+  Its content is Markdown, so links and emphasis render.
+- **Logo.** A `logo:` entry pins an image to the corner of every slide.
+- **Deck-level placement.** Both are set once in the front matter and apply to
+  the whole deck.
+
+## How to run
+
+```bash
+cargo run --bin q2 -- render examples/presentations/10-footer-logo
+```
+
+## What to look for
+
+- The footer sits centered at the bottom of each slide, muted, with its link
+  rendered as an anchor.
+- The logo (`logo.svg`) sits in the bottom-right corner of each slide.
+- Both are emitted once, outside the slide container, so reveal.js shows them
+  fixed over every slide — Quarto 2 ships no reveal plugin, so there is no
+  per-slide footer override yet.

--- a/examples/presentations/10-footer-logo/_quarto.yml
+++ b/examples/presentations/10-footer-logo/_quarto.yml
@@ -1,0 +1,2 @@
+project:
+  type: default

--- a/examples/presentations/10-footer-logo/logo.svg
+++ b/examples/presentations/10-footer-logo/logo.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="44" viewBox="0 0 120 44" role="img" aria-label="Example Corp logo">
+  <rect width="120" height="44" rx="8" fill="#2a76dd"/>
+  <circle cx="24" cy="22" r="11" fill="#ffffff"/>
+  <text x="44" y="28" font-family="Helvetica, Arial, sans-serif" font-size="16" font-weight="700" fill="#ffffff">EXMPL</text>
+</svg>

--- a/examples/presentations/10-footer-logo/slides.qmd
+++ b/examples/presentations/10-footer-logo/slides.qmd
@@ -1,0 +1,18 @@
+---
+title: "Footer and logo"
+format: revealjs
+footer: "© 2026 Example Corp — [example.com](https://example.com)"
+logo: logo.svg
+---
+
+## Deck chrome
+
+A `footer:` repeats one line along the bottom of every slide, and a `logo:`
+pins an image to the corner. Both stay fixed as you move through the deck.
+
+The footer accepts Markdown, so a link in it renders as a link.
+
+## They persist across slides
+
+This second slide carries the same footer and logo — you set them once in the
+front matter and they apply to the whole deck.

--- a/examples/presentations/11-auto-stretch/README.md
+++ b/examples/presentations/11-auto-stretch/README.md
@@ -1,0 +1,26 @@
+# 11-auto-stretch — Auto-stretch single-image slides
+
+Sizing a lone slide image to fill the available space.
+
+## What this demonstrates
+
+- **Auto-stretch.** A slide whose only content is one image gets reveal's
+  `.r-stretch` class automatically, so the image fills the slide instead of
+  overflowing. This is on by default.
+- **Opting out.** `auto-stretch: false` (deck-wide), an explicit
+  `width`/`height` on the image, or a `.nostretch` class each leave the image
+  at its natural size.
+
+## How to run
+
+```bash
+cargo run --bin q2 -- render examples/presentations/11-auto-stretch
+```
+
+## What to look for
+
+- On the first slide, the lone image carries `class="r-stretch"` and reveal
+  sizes it to fill the slide.
+- On the second slide, the `.nostretch` image keeps its natural size.
+- A slide that mixes an image with other content, or holds more than one image,
+  is left untouched.

--- a/examples/presentations/11-auto-stretch/_quarto.yml
+++ b/examples/presentations/11-auto-stretch/_quarto.yml
@@ -1,0 +1,2 @@
+project:
+  type: default

--- a/examples/presentations/11-auto-stretch/diagram.svg
+++ b/examples/presentations/11-auto-stretch/diagram.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="400" viewBox="0 0 640 400" role="img" aria-label="Example diagram">
+  <rect width="640" height="400" fill="#eef3fb"/>
+  <rect x="40" y="40" width="200" height="120" rx="10" fill="#2a76dd"/>
+  <rect x="400" y="240" width="200" height="120" rx="10" fill="#21908c"/>
+  <line x1="240" y1="100" x2="400" y2="300" stroke="#444" stroke-width="4"/>
+  <circle cx="320" cy="200" r="34" fill="#f6c344"/>
+</svg>

--- a/examples/presentations/11-auto-stretch/slides.qmd
+++ b/examples/presentations/11-auto-stretch/slides.qmd
@@ -1,0 +1,18 @@
+---
+title: "Auto-stretch"
+format: revealjs
+---
+
+## A single image fills the slide
+
+When a slide holds just one image, Quarto sizes it to fill the available space
+so it never overflows. This happens by default.
+
+![](diagram.svg)
+
+## Keeping an image at its natural size
+
+To opt out, set `auto-stretch: false` in the front matter (deck-wide), or give
+the image an explicit `width`/`height`, or mark it `.nostretch`:
+
+![](diagram.svg){.nostretch}

--- a/examples/presentations/README.md
+++ b/examples/presentations/README.md
@@ -34,3 +34,6 @@ cargo run --bin q2 -- render examples/presentations/03-fragments
 | [`06-speaker-notes`](06-speaker-notes/) | `.notes` speaker notes |
 | [`07-asides`](07-asides/) | `.aside` peripheral commentary |
 | [`08-footnotes`](08-footnotes/) | per-slide footnote coalescing |
+| [`09-themes`](09-themes/) | `theme:` selection and built-in theme aliases |
+| [`10-footer-logo`](10-footer-logo/) | deck-level `footer:` and `logo:` |
+| [`11-auto-stretch`](11-auto-stretch/) | auto-stretch single-image slides |

--- a/hub-client/changelog.md
+++ b/hub-client/changelog.md
@@ -15,6 +15,10 @@ be in reverse chronological order (latest first).
 
 -->
 
+### 2026-06-16
+
+- [`37061765`](https://github.com/quarto-dev/q2/commits/37061765): RevealJS preview now matches the render path's Quarto-1 defaults — slides top-align (no vertical centering), slide transitions are off by default, and the deck uses a 0.1 margin with linear navigation and edge controls.
+
 ### 2026-06-12
 
 - [`3a35de43`](https://github.com/quarto-dev/q2/commits/3a35de43): Project-creation scaffolds (`create_project`) now render their templates in pure Rust (quarto-doctemplate) instead of EJS via the JS bridge; titles containing quotes, backslashes, or `&` now produce correct YAML in `_quarto.yml` and `index.qmd`.

--- a/hub-client/src/components/render/RevealjsReactAstSlideRenderer.tsx
+++ b/hub-client/src/components/render/RevealjsReactAstSlideRenderer.tsx
@@ -123,17 +123,23 @@ export function RevealjsSlideAst({ astJson, currentFilePath, onNavigateToDocumen
       <Deck
         deckRef={deckRef}
         config={{
+          // Match the render path's Quarto-1 opinionated defaults (see
+          // reveal_config_json in quarto-core): top-aligned slides, no
+          // transition, 0.1 margin, linear nav, edge controls.
           width: 1050,
           height: 700,
-          margin: 0.04,
+          margin: 0.1,
           minScale: 0.2,
           maxScale: 2.0,
           controls: true,
           progress: true,
-          center: true,
+          center: false,
+          navigationMode: 'linear',
+          controlsLayout: 'edges',
+          controlsTutorial: false,
           hash: false,
-          transition: 'slide',
-          backgroundTransition: 'fade',
+          transition: 'none',
+          backgroundTransition: 'none',
           // probably need to re-enable this on-focus or something
           // but it was making it so I can't type!
           keyboard: false,

--- a/resources/scss/revealjs/README.md
+++ b/resources/scss/revealjs/README.md
@@ -1,0 +1,52 @@
+# RevealJS SCSS resources
+
+Local SCSS sources for Quarto 2's reveal.js theming, embedded into the
+`quarto-sass` crate at compile time (`include_dir!`) and compiled per-deck
+through the same layered-SCSS subsystem (`grass` natively, dart-sass on WASM)
+that drives `format: html`.
+
+This directory exists because of the **External Sources Policy** (see root
+`CLAUDE.md`): nothing compiled or embedded may reference `external-sources/`.
+The reveal-template files below are therefore vendored copies.
+
+## Layout
+
+- `reveal-template/` — the reveal.js 6 base theme machinery, vendored from
+  reveal.js `css/theme/template/`:
+  - `_settings-vars.scss` — the `$kebab: … !default;` variable declarations from
+    upstream `settings.scss`. The reveal-native fallbacks (`#bbb`, `uppercase`,
+    `Lato`, …).
+  - `_expose.scss` — the trailing `:root { --r-*: … }` block from upstream
+    `settings.scss`, split out so it can run in the SCSS `rules` layer (after all
+    `!default`s collapse) and thus carry Quarto's overridden values.
+  - `_theme.scss` — upstream `theme.scss` verbatim (the `var(--r-*)` rule set).
+  - `_mixins.scss` — upstream `mixins.scss` verbatim (`light/dark-bg-text-color`).
+- `quarto-revealjs.scss` — **Quarto's** reveal layer (the analogue of Quarto 1's
+  `quarto.scss`): the `$presentation-*` / `$body-*` user-facing vocabulary, the
+  mapping from that vocabulary to reveal-6 kebab variables, and the rule
+  overrides that make a deck "feel at home" for Quarto users (left-aligned
+  slides, non-uppercase headings, Quarto title-slide layout, …).
+
+## Why the split
+
+reveal.js 6 themes are authored with `@use 'template/settings' with (...)`, which
+needs configuration values at the `@use` call site — that fights Quarto's
+layered-`!default` merge model (where a higher-priority layer wins by being
+emitted first). So instead of `@use`-ing reveal's `settings.scss`, we split its
+two responsibilities (declare vars / emit `:root`) across the `defaults` and
+`rules` layers and let Quarto's layer override the vars by ordinary `!default`
+precedence. See `crates/quarto-sass/src/bundle.rs` (`load_reveal_framework`).
+
+## Provenance / update procedure
+
+`reveal-template/` is copied from **reveal.js 6.0.x** (`css/theme/template/`).
+The vendored reveal.js runtime assets (`reset.css`, `reveal.css`, `reveal.js`,
+`theme/white.css`) live separately under `resources/revealjs/` and are version-
+pinned there; see that directory's README. When bumping reveal.js:
+
+1. Re-copy `settings.scss` → split into `_settings-vars.scss` (declarations) and
+   `_expose.scss` (the `:root` block); re-copy `theme.scss` → `_theme.scss` and
+   `mixins.scss` → `_mixins.scss`.
+2. Diff the variable set; if reveal renamed/added/removed a `--r-*` or a
+   `$kebab` variable, update the mapping in `quarto-revealjs.scss` accordingly.
+3. Run `cargo nextest run -p quarto-sass` and re-verify a rendered deck.

--- a/resources/scss/revealjs/quarto-revealjs.scss
+++ b/resources/scss/revealjs/quarto-revealjs.scss
@@ -5,6 +5,7 @@
 // coexist fine — different namespaces.
 @use "sass:color" as quarto-color;
 @use "sass:math" as quarto-math;
+@use "sass:map" as quarto-map;
 
 /*-- scss:defaults --*/
 
@@ -130,6 +131,19 @@ $link-weight: $font-weight-base !default;
 $link-color-bg: transparent !default;
 $link-decoration: inherit !default;
 
+// --- tables / callouts -------------------------------------------------------
+$table-border-color: $code-block-border-color !default;
+$callout-border-width: 0.3rem !default;
+$callout-border-scale: 0% !default;
+$callout-icon-scale: 10% !default;
+$callout-margin-top: 1rem !default;
+$callout-margin-bottom: 1rem !default;
+$callout-color-note: #0d6efd !default;
+$callout-color-tip: #198754 !default;
+$callout-color-important: #dc3545 !default;
+$callout-color-caution: #fd7e14 !default;
+$callout-color-warning: #ffc107 !default;
+
 // --- derive reveal-tuned versions of presentation variables ------------------
 // (a second indirection so a user can override the reveal-specific value
 // without disturbing the shared, cross-format `$presentation-*` name.)
@@ -202,6 +216,22 @@ $selection-background-color: $selection-bg !default;
     shade-color($color, $weight),
     tint-color($color, -$weight)
   );
+}
+
+// Recursively replace all `$search` with `$replace` in `$string`. Quarto 1 gets
+// this from Bootstrap's functions; the reveal layer has no Bootstrap, so define
+// it here (used to URL-encode the callout icon SVGs).
+@function str-replace($string, $search, $replace: "") {
+  $index: str-index($string, $search);
+  @if $index {
+    @return str-slice($string, 1, $index - 1) + $replace +
+      str-replace(
+        str-slice($string, $index + str-length($search)),
+        $search,
+        $replace
+      );
+  }
+  @return $string;
 }
 
 /*-- scss:mixins --*/
@@ -529,4 +559,234 @@ kbd {
   font-weight: $link-weight;
   background-color: $link-color-bg;
   text-decoration: $link-decoration;
+}
+
+// =============================================================================
+// Callouts — ported from Quarto 1 quarto.scss:873-1116 (bd-j8qoyc0s / D1).
+// Q2 emits the same `.callout callout-{type} callout-style-{simple,default}`
+// markup for reveal as for HTML (CalloutTransform + CalloutResolveTransform run
+// before the reveal branch), so this is a pure-SCSS port.
+// =============================================================================
+
+.reveal div.callout {
+  margin-top: $callout-margin-top;
+  margin-bottom: $callout-margin-bottom;
+  border-radius: $border-radius;
+  overflow-wrap: break-word;
+
+  // Rules for both styles
+  &.callout-style-simple,
+  &.callout-style-default {
+    border-left: $callout-border-width solid #acacac;
+    border-right: solid 1px $table-border-color;
+    border-top: solid 1px $table-border-color;
+    border-bottom: solid 1px $table-border-color;
+
+    div {
+      &.callout-body,
+      &.callout-title {
+        // Font size is inherited from the parent div.callout, which is scaled
+        // down like .smaller.
+        font-size: inherit;
+        border-bottom: none;
+        font-weight: 600;
+      }
+
+      &.callout-title {
+        display: flex;
+        align-items: center;
+
+        p {
+          margin-top: 0.5em;
+          margin-bottom: 0.5em;
+          color: var(--r-main-color);
+        }
+      }
+    }
+
+    .callout-icon::before {
+      height: 1.25em;
+      width: 1.25em;
+      background-size: 1.25em 1.25em;
+    }
+
+    &.callout-titled {
+      .callout-body {
+        > .callout-content {
+          > :last-child {
+            margin-bottom: var(--r-block-margin);
+          }
+          > :last-child:not(div.sourceCode) {
+            padding-bottom: 0.5rem;
+            margin-bottom: 0;
+          }
+        }
+      }
+      .callout-icon::before {
+        margin-top: 0.25em;
+        padding-right: 0.25em;
+      }
+    }
+
+    &.no-icon::before {
+      display: none !important;
+    }
+  }
+
+  // Simple style: title-or-not, icon-or-not.
+  &.callout-style-simple {
+    padding: 0em 0.5em;
+    display: flex;
+
+    &.callout-titled {
+      .callout-body {
+        margin-top: 0.2em;
+      }
+      &:not(.no-icon) {
+        .callout-content {
+          padding-left: 1.6em;
+        }
+      }
+      .callout-content {
+        p {
+          margin-top: 0;
+        }
+      }
+    }
+
+    &:not(.callout-titled) {
+      .callout-body {
+        display: flex;
+      }
+      .callout-icon::before {
+        margin-top: var(--r-block-margin);
+        padding-right: 0.5em;
+      }
+      .callout-body {
+        > .callout-content {
+          // Margin when last child is div.sourceCode (else code-cell border
+          // mixes with the callout border).
+          > div.sourceCode:last-child {
+            margin-bottom: 1rem;
+          }
+          > :first-child {
+            margin-top: var(--r-block-margin);
+          }
+        }
+      }
+    }
+
+    .callout-icon::before {
+      display: inline-block;
+      content: "";
+      background-repeat: no-repeat;
+    }
+
+    div {
+      &.callout-title {
+        opacity: 75%;
+      }
+      &.callout-body {
+        font-weight: 400;
+      }
+    }
+  }
+
+  // Default style: always titled, icon-or-not.
+  &.callout-style-default {
+    &.callout-titled {
+      .callout-content {
+        p {
+          margin-top: 0.7em;
+        }
+      }
+    }
+
+    .callout-icon::before {
+      display: inline-block;
+      content: "";
+      background-repeat: no-repeat;
+    }
+
+    div {
+      &.callout-body {
+        font-weight: 400;
+      }
+      &.callout-title {
+        opacity: 85%;
+        padding-left: 0.5em;
+        padding-right: 0.5em;
+      }
+      &.callout-content {
+        padding-left: 0.5em;
+        padding-right: 0.5em;
+      }
+    }
+  }
+
+  .callout-body-container {
+    flex-grow: 1;
+  }
+}
+
+// Per-type callout colors + icons. The icon SVGs are inlined (URL-encoded) with
+// a per-type accent color; `shift_to_dark` adapts the default-style title
+// background to light/dark slide backgrounds.
+$callouts: (
+  "note": (
+    "color": $callout-color-note,
+    "icon":
+      '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-info-circle" viewBox="0 0 16 16"><path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"/><path d="m8.93 6.588-2.29.287-.082.38.45.083c.294.07.352.176.288.469l-.738 3.468c-.194.897.105 1.319.808 1.319.545 0 1.178-.252 1.465-.598l.088-.416c-.2.176-.492.246-.686.246-.275 0-.375-.193-.304-.533L8.93 6.588zM9 4.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0z"/></svg>',
+  ),
+  "tip": (
+    "color": $callout-color-tip,
+    "icon":
+      '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-lightbulb" viewBox="0 0 16 16"><path d="M2 6a6 6 0 1 1 10.174 4.31c-.203.196-.359.4-.453.619l-.762 1.769A.5.5 0 0 1 10.5 13a.5.5 0 0 1 0 1 .5.5 0 0 1 0 1l-.224.447a1 1 0 0 1-.894.553H6.618a1 1 0 0 1-.894-.553L5.5 15a.5.5 0 0 1 0-1 .5.5 0 0 1 0-1 .5.5 0 0 1-.46-.302l-.761-1.77a1.964 1.964 0 0 0-.453-.618A5.984 5.984 0 0 1 2 6zm6-5a5 5 0 0 0-3.479 8.592c.263.254.514.564.676.941L5.83 12h4.342l.632-1.467c.162-.377.413-.687.676-.941A5 5 0 0 0 8 1z"/></svg>',
+  ),
+  "warning": (
+    "color": $callout-color-warning,
+    "icon":
+      '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-exclamation-triangle" viewBox="0 0 16 16"><path d="M7.938 2.016A.13.13 0 0 1 8.002 2a.13.13 0 0 1 .063.016.146.146 0 0 1 .054.057l6.857 11.667c.036.06.035.124.002.183a.163.163 0 0 1-.054.06.116.116 0 0 1-.066.017H1.146a.115.115 0 0 1-.066-.017.163.163 0 0 1-.054-.06.176.176 0 0 1 .002-.183L7.884 2.073a.147.147 0 0 1 .054-.057zm1.044-.45a1.13 1.13 0 0 0-1.96 0L.165 13.233c-.457.778.091 1.767.98 1.767h13.713c.889 0 1.438-.99.98-1.767L8.982 1.566z"/><path d="M7.002 12a1 1 0 1 1 2 0 1 1 0 0 1-2 0zM7.1 5.995a.905.905 0 1 1 1.8 0l-.35 3.507a.552.552 0 0 1-1.1 0L7.1 5.995z"/></svg>',
+  ),
+  "caution": (
+    "color": $callout-color-caution,
+    "icon":
+      '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-cone-striped" viewBox="0 0 16 16"><path d="M9.97 4.88l.953 3.811C10.158 8.878 9.14 9 8 9c-1.14 0-2.159-.122-2.923-.309L6.03 4.88C6.635 4.957 7.3 5 8 5s1.365-.043 1.97-.12zm-.245-.978L8.97.88C8.718-.13 7.282-.13 7.03.88L6.274 3.9C6.8 3.965 7.382 4 8 4c.618 0 1.2-.036 1.725-.098zm4.396 8.613a.5.5 0 0 1 .037.96l-6 2a.5.5 0 0 1-.316 0l-6-2a.5.5 0 0 1 .037-.96l2.391-.598.565-2.257c.862.212 1.964.339 3.165.339s2.303-.127 3.165-.339l.565 2.257 2.391.598z"/></svg>',
+  ),
+  "important": (
+    "color": $callout-color-important,
+    "icon":
+      '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-exclamation-circle" viewBox="0 0 16 16"><path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"/><path d="M7.002 11a1 1 0 1 1 2 0 1 1 0 0 1-2 0zM7.1 4.995a.905.905 0 1 1 1.8 0l-.35 3.507a.552.552 0 0 1-1.1 0L7.1 4.995z"/></svg>',
+  ),
+);
+
+@each $name, $info in $callouts {
+  $shifted-color: #{shift-color(quarto-map.get($info, "color"), $callout-icon-scale)};
+  $shifted-color-svg: str-replace($shifted-color, "#", "%23");
+
+  .reveal div.callout {
+    &.callout-#{$name} {
+      border-left-color: shift-color(
+        quarto-map.get($info, "color"),
+        $callout-border-scale
+      );
+      &.callout-style-default {
+        .callout-title {
+          @include shift_to_dark(
+            "background-color",
+            shift-color(quarto-map.get($info, "color"), 70%),
+            shift-color(quarto-map.get($info, "color"), -90%)
+          );
+        }
+      }
+      .callout-icon::before {
+        background-image: #{"url('data:image/svg+xml," +
+          str-replace(
+            quarto-map.get($info, "icon"),
+            'fill="currentColor"',
+            'style="fill: #{$shifted-color-svg}"'
+          ) + "');"};
+      }
+    }
+  }
 }

--- a/resources/scss/revealjs/quarto-revealjs.scss
+++ b/resources/scss/revealjs/quarto-revealjs.scss
@@ -1,0 +1,167 @@
+/*-- scss:defaults --*/
+
+// =============================================================================
+// Quarto's reveal.js layer (the Quarto-2 analogue of Quarto 1's quarto.scss).
+//
+// Ported from external-sources/quarto-cli .../formats/revealjs/quarto.scss,
+// adapted to reveal.js 6 (kebab-case Sass variables + the stable --r-* runtime
+// contract). This is the layer that makes a deck "feel at home" for Quarto
+// users; without it a deck inherits reveal's centered slides + uppercase
+// headings (see claude-notes/plans/2026-06-16-revealjs-themes-q1-to-q2.md).
+//
+// User-facing vocabulary is the Quarto `$presentation-*` / `$body-*` /
+// `$font-*` names (decision D2 — shared with HTML/Bootstrap theming so
+// _brand.yml and cross-format themes "just work"). This layer maps that
+// vocabulary onto reveal-6's own kebab variables, which reveal's _expose.scss
+// then publishes as `--r-*` custom properties.
+//
+// Stage A subset: fonts, colors, headings, spacing, slide/title alignment,
+// lists, and basic code blocks. Callouts, panels, tabsets, kbd, the `.smaller`
+// system, and per-background (light/dark) recoloring are Stage C.
+// =============================================================================
+
+// --- fonts -------------------------------------------------------------------
+$font-family-sans-serif: "Source Sans Pro", Helvetica, sans-serif !default;
+$font-family-monospace: SFMono-Regular, Menlo, Monaco, Consolas,
+  "Liberation Mono", "Courier New", monospace !default;
+$presentation-font-size-root: 40px !default;
+$presentation-font-smaller: 0.7 !default;
+$presentation-line-height: 1.3 !default;
+$font-weight-base: 400 !default;
+$code-font-size: 1em !default;
+
+// --- main colors -------------------------------------------------------------
+$body-bg: #fff !default;
+$body-color: #222 !default;
+
+// --- link colors -------------------------------------------------------------
+// NOTE: in reveal 6 `$link-color` / `$link-color-hover` are *also* reveal's own
+// variable names, so setting the Quarto default here directly feeds reveal's
+// :root emitter — no separate mapping line is needed (see mapping section).
+$primary: #2a76dd !default;
+$link-color: $primary !default;
+$link-color-hover: lighten($link-color, 10%) !default;
+
+// --- selection colors --------------------------------------------------------
+// `$selection-color` likewise coincides with reveal's own variable name.
+$selection-bg: lighten($link-color, 25%) !default;
+$selection-color: $body-bg !default;
+
+// --- headings ----------------------------------------------------------------
+$presentation-heading-font: $font-family-sans-serif !default;
+$presentation-heading-color: $body-color !default;
+$presentation-heading-line-height: 1.2 !default;
+$presentation-heading-letter-spacing: normal !default;
+$presentation-heading-text-transform: none !default; // reveal defaults to uppercase
+$presentation-heading-text-shadow: none !default;
+$presentation-h1-text-shadow: none !default;
+$presentation-heading-font-weight: 600 !default;
+$presentation-h1-font-size: 2.5em !default;
+$presentation-h2-font-size: 1.6em !default;
+$presentation-h3-font-size: 1.3em !default;
+$presentation-h4-font-size: 1em !default;
+
+// --- margins -----------------------------------------------------------------
+$presentation-block-margin: 12px !default;
+
+// --- text alignment ----------------------------------------------------------
+$presentation-slide-text-align: left !default; // reveal centers by default
+$presentation-title-slide-text-align: center !default;
+$reveal-slide-text-align: $presentation-slide-text-align !default;
+$reveal-title-slide-text-align: $presentation-title-slide-text-align !default;
+
+// --- lists -------------------------------------------------------------------
+$presentation-list-bullet-color: $body-color !default;
+
+// --- code blocks -------------------------------------------------------------
+$code-block-bg: $body-bg !default;
+$code-block-border-color: lighten($body-color, 60%) !default;
+$code-block-font-size: $code-font-size * 0.55 !default;
+$code-block-color: $body-color !default;
+
+// --- inline code -------------------------------------------------------------
+$code-inline-font-size: $code-font-size * 0.875 !default;
+$code-bg: transparent !default;
+
+// --- derive reveal-tuned versions of presentation variables ------------------
+// (a second indirection so a user can override the reveal-specific value
+// without disturbing the shared, cross-format `$presentation-*` name.)
+$revealjs-font-size-root: $presentation-font-size-root !default;
+$revealjs-h1-font-size: $presentation-h1-font-size !default;
+$revealjs-h2-font-size: $presentation-h2-font-size !default;
+$revealjs-h3-font-size: $presentation-h3-font-size !default;
+$revealjs-h4-font-size: $presentation-h4-font-size !default;
+$revealjs-heading-font: $presentation-heading-font !default;
+$revealjs-heading-color: $presentation-heading-color !default;
+$revealjs-heading-line-height: $presentation-heading-line-height !default;
+$revealjs-heading-letter-spacing: $presentation-heading-letter-spacing !default;
+$revealjs-heading-text-transform: $presentation-heading-text-transform !default;
+$revealjs-heading-text-shadow: $presentation-heading-text-shadow !default;
+$revealjs-h1-text-shadow: $presentation-h1-text-shadow !default;
+$revealjs-heading-font-weight: $presentation-heading-font-weight !default;
+$revealjs-block-margin: $presentation-block-margin !default;
+$revealjs-line-height: $presentation-line-height !default;
+$revealjs-list-bullet-color: $presentation-list-bullet-color !default;
+
+// --- map Quarto vocabulary onto reveal-6 kebab variables ---------------------
+// These reveal variables have names distinct from the Quarto vocabulary, so an
+// explicit mapping is required. reveal's `_expose.scss` reads these to emit the
+// `--r-*` custom properties that `_theme.scss` consumes at runtime.
+$background: $body-bg !default;
+$background-color: $body-bg !default;
+$main-font: $font-family-sans-serif !default;
+$main-font-size: $revealjs-font-size-root !default;
+$main-color: $body-color !default;
+$block-margin: $revealjs-block-margin !default;
+$heading-margin: 0 0 $revealjs-block-margin 0 !default;
+$heading-font: $revealjs-heading-font !default;
+$heading-color: $revealjs-heading-color !default;
+$heading-line-height: $revealjs-heading-line-height !default;
+$heading-letter-spacing: $revealjs-heading-letter-spacing !default;
+$heading-text-transform: $revealjs-heading-text-transform !default;
+$heading-text-shadow: $revealjs-heading-text-shadow !default;
+$heading1-text-shadow: $revealjs-h1-text-shadow !default;
+$heading-font-weight: $revealjs-heading-font-weight !default;
+$heading1-size: $revealjs-h1-font-size !default;
+$heading2-size: $revealjs-h2-font-size !default;
+$heading3-size: $revealjs-h3-font-size !default;
+$heading4-size: $revealjs-h4-font-size !default;
+$code-font: $font-family-monospace !default;
+$selection-background-color: $selection-bg !default;
+
+/*-- scss:rules --*/
+
+// Quarto aligns slide body content to the left; reveal centers it by default.
+.reveal .slides {
+  text-align: $reveal-slide-text-align;
+}
+
+// The title slide is centered (overriding the left body alignment), and its
+// title is sized like an h2 rather than a full-size h1 — the Quarto 1 look.
+#title-slide,
+div.reveal div.slides section.title-slide {
+  text-align: $reveal-title-slide-text-align;
+
+  .subtitle {
+    margin-bottom: 2.5rem;
+  }
+}
+
+.reveal #title-slide h1,
+.reveal .title-slide h1.title {
+  font-size: $revealjs-h2-font-size;
+}
+
+// In linear navigation mode (no vertical stacks) the title returns to h1 size.
+.reveal[data-navigation-mode="linear"] #title-slide h1,
+.reveal[data-navigation-mode="linear"] .title-slide h1.title {
+  font-size: $revealjs-h1-font-size;
+}
+
+// Bullet/marker color follows the configured list bullet color.
+.reveal ul,
+.reveal ol {
+  li::marker {
+    color: $revealjs-list-bullet-color;
+  }
+}

--- a/resources/scss/revealjs/quarto-revealjs.scss
+++ b/resources/scss/revealjs/quarto-revealjs.scss
@@ -475,6 +475,89 @@ section.has-dark-background {
   }
 }
 
+// --- deck-level footer + logo ------------------------------------------------
+// Quarto 1 places footer/logo on every slide via its quarto-support reveal
+// *plugin*, which relocates the markup to be a direct child of `.reveal` at
+// runtime. Quarto 2 ships no plugins, so the assembler emits a single
+// deck-level `.footer .footer-default` + `<img class="slide-logo">` as direct
+// children of `.reveal`, OUTSIDE `.slides` (see assemble.rs `footer_logo_html`).
+// They must live outside `.slides` because reveal applies CSS transforms to
+// `.slides`/`<section>`, under which `position: fixed` resolves against the
+// transformed ancestor rather than the viewport. Colors port quarto.scss:
+// 570-592; positioning ports plugins/support/footer.css.
+.reveal .slide-logo {
+  display: block;
+  position: fixed;
+  bottom: 0;
+  right: 12px;
+  max-height: 2.2rem;
+  height: 100%;
+  width: auto;
+  z-index: 2;
+}
+
+.reveal .footer {
+  display: block;
+  position: fixed;
+  bottom: 18px;
+  width: 100%;
+  margin: 0 auto;
+  text-align: center;
+  font-size: 18px;
+  z-index: 2;
+  color: $text-muted;
+
+  a {
+    color: $link-color;
+  }
+
+  &.has-dark-background {
+    color: quarto-color.scale($dark-bg-text-color, $whiteness: 30%);
+
+    a {
+      color: quarto-color.scale($dark-bg-link-color, $whiteness: 30%);
+    }
+  }
+
+  &.has-light-background {
+    color: quarto-color.scale($light-bg-text-color, $whiteness: 30%);
+
+    a {
+      color: quarto-color.scale($light-bg-link-color, $whiteness: 30%);
+    }
+  }
+}
+
+.reveal .footer > * {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+// Defensive: an in-slide `::: {.footer}` would be mis-positioned by reveal's
+// slide transforms; hide it so only the deck-level footer shows (matches Q1).
+.reveal .slide .footer {
+  display: none;
+}
+
+// When a logo sits bottom-right, move the slide number out of its way (Q1).
+.reveal.has-logo .slide-number {
+  bottom: initial;
+  top: 8px;
+  right: 8px;
+}
+
+@media screen and (max-width: 800px) {
+  .reveal .slide-logo {
+    max-height: 1.1rem;
+    bottom: -2px;
+    right: 10px;
+  }
+  .reveal .footer {
+    font-size: 14px;
+    bottom: 12px;
+  }
+}
+
 // --- figure captions ---------------------------------------------------------
 .reveal .slide {
   figure > figcaption,

--- a/resources/scss/revealjs/quarto-revealjs.scss
+++ b/resources/scss/revealjs/quarto-revealjs.scss
@@ -1,3 +1,11 @@
+/*-- scss:uses --*/
+
+// Namespaced Sass modules for the helper functions/mixins below. Two `@use`s of
+// `sass:color` (here as quarto-color, and the framework's unprefixed `color`)
+// coexist fine — different namespaces.
+@use "sass:color" as quarto-color;
+@use "sass:math" as quarto-math;
+
 /*-- scss:defaults --*/
 
 // =============================================================================
@@ -78,10 +86,49 @@ $code-block-bg: $body-bg !default;
 $code-block-border-color: lighten($body-color, 60%) !default;
 $code-block-font-size: $code-font-size * 0.55 !default;
 $code-block-color: $body-color !default;
+$code-block-height: 500px !default;
+// Blackness threshold (0–100%) above which a slide background counts as "dark"
+// for `shift_to_dark` (e.g. picking dark vs light code styling).
+$code-block-theme-dark-threshhold: 40% !default;
 
 // --- inline code -------------------------------------------------------------
 $code-inline-font-size: $code-font-size * 0.875 !default;
 $code-bg: transparent !default;
+// Inline code color: the syntax-highlight function color when present (Quarto's
+// CodeHighlightStage emits `--quarto-hl-*`), else the body color.
+$code-color: var(--quarto-hl-fu-color, #{$body-color}) !default;
+
+// --- monospace font split (shared with HTML/brand vocabulary) ----------------
+$font-weight-base: 400 !default;
+$font-family-monospace-block: $font-family-monospace !default;
+$font-family-monospace-inline: $font-family-monospace !default;
+
+// --- borders -----------------------------------------------------------------
+$text-muted: lighten($body-color, 30%) !default;
+$border-color: lighten($body-color, 30%) !default;
+$border-width: 1px !default;
+$border-radius: 4px !default;
+$gray-100: #f8f9fa !default;
+
+// --- per-background (light/dark slide) text colors ---------------------------
+$light-bg-text-color: #222 !default;
+$dark-bg-text-color: #fff !default;
+$light-bg-link-color: #2a76dd !default;
+$dark-bg-link-color: #42affa !default;
+$light-bg-code-color: #4758ab !default;
+$dark-bg-code-color: #ffa07a !default;
+
+// --- kbd ---------------------------------------------------------------------
+$kbd-padding-y: 0.4rem !default;
+$kbd-padding-x: 0.4rem !default;
+$kbd-font-size: $presentation-font-size-root !default;
+$kbd-color: $body-color !default;
+$kbd-bg: $gray-100 !default;
+
+// --- link / brand ------------------------------------------------------------
+$link-weight: $font-weight-base !default;
+$link-color-bg: transparent !default;
+$link-decoration: inherit !default;
 
 // --- derive reveal-tuned versions of presentation variables ------------------
 // (a second indirection so a user can override the reveal-specific value
@@ -102,6 +149,9 @@ $revealjs-heading-font-weight: $presentation-heading-font-weight !default;
 $revealjs-block-margin: $presentation-block-margin !default;
 $revealjs-line-height: $presentation-line-height !default;
 $revealjs-list-bullet-color: $presentation-list-bullet-color !default;
+$revealjs-code-block-font-size: $code-block-font-size !default;
+$revealjs-code-inline-font-size: $code-inline-font-size !default;
+$code-block-line-height: $presentation-line-height !default;
 
 // --- map Quarto vocabulary onto reveal-6 kebab variables ---------------------
 // These reveal variables have names distinct from the Quarto vocabulary, so an
@@ -128,6 +178,59 @@ $heading3-size: $revealjs-h3-font-size !default;
 $heading4-size: $revealjs-h4-font-size !default;
 $code-font: $font-family-monospace !default;
 $selection-background-color: $selection-bg !default;
+
+/*-- scss:functions --*/
+
+// Color helpers ported from Quarto 1 quarto.scss (used by callouts, kbd, code
+// styling, …). `tint`/`shade`/`shift` mirror Bootstrap's color math.
+@function colorToRGB($color) {
+  @return "rgb(" + red($color) + ", " + green($color) + ", " + blue($color) +
+    ")";
+}
+
+@function tint-color($color, $weight) {
+  @return mix(white, $color, $weight);
+}
+
+@function shade-color($color, $weight) {
+  @return mix(black, $color, $weight);
+}
+
+@function shift-color($color, $weight) {
+  @return if(
+    $weight > 0,
+    shade-color($color, $weight),
+    tint-color($color, -$weight)
+  );
+}
+
+/*-- scss:mixins --*/
+
+// Choose a value depending on whether the *slide background* is dark or light
+// (ported from Quarto 1). reveal 6's background var is kebab `$background-color`.
+@mixin shift_to_dark($property, $colorDark, $colorLight) {
+  @if (
+    quarto-color.blackness($background-color) > $code-block-theme-dark-threshhold
+  ) {
+    #{$property}: $colorDark;
+  } @else {
+    #{$property}: $colorLight;
+  }
+}
+
+// Scale a px font-size down by the `.smaller` factor `$times` times. Useful for
+// px sizes nested inside an em-based smaller context (they wouldn't otherwise
+// shrink). Ported from Quarto 1.
+@mixin make-smaller-font-size($element, $times: 1) {
+  font-size: calc(
+    #{$element} * #{quarto-math.pow($presentation-font-smaller, $times)}
+  );
+}
+
+// Undo the `.smaller` scaling for an em size that should not shrink.
+@mixin undo-smaller-font-size($element) {
+  font-size: calc(#{$element} / #{$presentation-font-smaller});
+}
 
 /*-- scss:rules --*/
 
@@ -164,4 +267,266 @@ div.reveal div.slides section.title-slide {
   li::marker {
     color: $revealjs-list-bullet-color;
   }
+}
+
+// =============================================================================
+// Stage C quick-wins — ported from Quarto 1 quarto.scss (bd-jxyqjf15).
+// =============================================================================
+
+// --- per-background (light/dark slide) text recoloring -----------------------
+// Keeps text/links/code legible when a slide overrides its background.
+section.has-light-background {
+  &,
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    color: $light-bg-text-color;
+  }
+  a,
+  a:hover {
+    color: $light-bg-link-color;
+  }
+  code {
+    color: $light-bg-code-color;
+  }
+}
+
+section.has-dark-background {
+  &,
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    color: $dark-bg-text-color;
+  }
+  a,
+  a:hover {
+    color: $dark-bg-link-color;
+  }
+  code {
+    color: $dark-bg-code-color;
+  }
+}
+
+// --- code blocks: bordered, full-width, scrollable ---------------------------
+.reveal div.sourceCode {
+  border: $border-width solid $code-block-border-color;
+  border-radius: $border-radius;
+}
+
+.reveal pre {
+  width: 100%;
+  box-shadow: none;
+  background-color: $code-block-bg;
+  border: none;
+  margin: 0;
+  font-size: $revealjs-code-block-font-size;
+  line-height: $code-block-line-height;
+  font-family: $font-family-monospace-block;
+
+  code {
+    background-color: $body-bg; // distinguish output vs code cells
+    font-size: inherit;
+    color: $code-block-color;
+    font-family: inherit;
+  }
+
+  &.sourceCode code {
+    color: $code-block-color;
+    font-size: inherit;
+    background-color: inherit;
+    white-space: pre;
+    font-family: inherit;
+    padding: 6px 9px;
+    max-height: $code-block-height;
+  }
+}
+
+// The code-with-filename header uses its own background (not the pre's).
+.reveal .code-with-filename .code-with-filename-file pre {
+  background-color: unset;
+}
+
+.reveal code {
+  color: $code-color;
+  font-size: $revealjs-code-inline-font-size;
+  background-color: $code-bg;
+  white-space: pre-wrap;
+  font-family: $font-family-monospace-inline;
+}
+
+// --- blockquote: left accent border, muted, not italic-centered --------------
+.reveal blockquote {
+  display: block;
+  position: relative;
+  color: $border-color;
+  width: unset;
+  margin: var(--r-block-margin) auto;
+  padding: 0.625rem 1.75rem;
+  border-left: 0.25rem solid $text-muted;
+  font-style: normal;
+  background: none;
+  box-shadow: none;
+}
+.reveal blockquote p:first-child,
+.reveal blockquote p:last-child {
+  display: block;
+}
+
+// --- line height -------------------------------------------------------------
+.reveal p,
+.reveal .slides section,
+.reveal .slides section > section {
+  line-height: $revealjs-line-height;
+}
+
+// --- `.smaller` font-scaling (global + per-slide), headers keep their size ---
+.reveal {
+  &.smaller .slides section {
+    font-size: #{$presentation-font-smaller}em;
+    // avoid doubling the reduction on nested (vertical) sections
+    section {
+      font-size: inherit;
+    }
+  }
+
+  &.smaller .slides h1 {
+    @include undo-smaller-font-size($revealjs-h1-font-size);
+  }
+  &.smaller .slides h2 {
+    @include undo-smaller-font-size($revealjs-h2-font-size);
+  }
+  &.smaller .slides h3 {
+    @include undo-smaller-font-size($revealjs-h3-font-size);
+  }
+
+  .slides section.smaller {
+    font-size: #{$presentation-font-smaller}em;
+    h1 {
+      @include undo-smaller-font-size($revealjs-h1-font-size);
+    }
+    h2 {
+      @include undo-smaller-font-size($revealjs-h2-font-size);
+    }
+    h3 {
+      @include undo-smaller-font-size($revealjs-h3-font-size);
+    }
+  }
+}
+
+// --- multi-column gutters ----------------------------------------------------
+.reveal .columns > .column > :not(ul, ol) {
+  margin-left: 0.25rem;
+  margin-right: 0.25rem;
+}
+.reveal .columns > .column:first-child > :not(ul, ol) {
+  margin-right: 0.5rem;
+  margin-left: 0;
+}
+.reveal .columns > .column:last-child > :not(ul, ol) {
+  margin-right: 0;
+  margin-left: 0.5rem;
+}
+
+// --- slide number (muted, background-aware) ----------------------------------
+.reveal .slide-number {
+  color: $text-muted;
+
+  &.has-dark-background {
+    color: quarto-color.scale($dark-bg-text-color, $whiteness: 30%);
+  }
+  &.has-light-background {
+    color: quarto-color.scale($light-bg-text-color, $whiteness: 30%);
+  }
+}
+
+// --- figure captions ---------------------------------------------------------
+.reveal .slide {
+  figure > figcaption,
+  img.stretch + p.caption,
+  img.r-stretch + p.caption {
+    font-size: #{$presentation-font-smaller}em;
+  }
+}
+
+// --- edge navigation-control spacing (we default controlsLayout: edges) ------
+@media screen and (min-width: 500px) {
+  $arrow-spacing: 0.2em;
+  $control-arrow-spacing: 1.4em;
+
+  .reveal .controls[data-controls-layout="edges"] .navigate-left {
+    left: $arrow-spacing;
+  }
+  .reveal .controls[data-controls-layout="edges"] .navigate-right {
+    right: $arrow-spacing;
+  }
+  .reveal .controls[data-controls-layout="edges"] .navigate-up {
+    top: $arrow-spacing * 2;
+  }
+  .reveal .controls[data-controls-layout="edges"] .navigate-down {
+    bottom: $arrow-spacing - $control-arrow-spacing + 3.5em;
+  }
+}
+
+// --- ordered-list `type=` + task-list checkboxes -----------------------------
+// Both case-sensitive and case-oblivious selectors (Chrome/Safari workaround,
+// quarto-cli#1902).
+.reveal ol[type="a"],
+.reveal ol[type="a" s] {
+  list-style-type: lower-alpha;
+}
+.reveal ol[type="A" s] {
+  list-style-type: upper-alpha;
+}
+.reveal ol[type="i"],
+.reveal ol[type="i" s] {
+  list-style-type: lower-roman;
+}
+.reveal ol[type="I" s] {
+  list-style-type: upper-roman;
+}
+.reveal ol[type="1"] {
+  list-style-type: decimal;
+}
+
+.reveal ul.task-list {
+  list-style: none;
+}
+.reveal ul.task-list li input[type="checkbox"] {
+  width: 2em;
+  height: 2em;
+  margin: 0 1em 0.5em -1.6em;
+  vertical-align: middle;
+}
+
+// --- kbd ---------------------------------------------------------------------
+kbd {
+  font-family: $font-family-monospace;
+  font-size: $kbd-font-size;
+  color: $kbd-color;
+  @include shift_to_dark("background-color", shift-color($kbd-bg, 70%), $kbd-bg);
+  border: 1px solid;
+  border-color: $code-block-border-color;
+  border-radius: 5px;
+  padding: $kbd-padding-y $kbd-padding-x;
+}
+
+// --- expose code fonts as reveal-style custom properties ---------------------
+:root {
+  --r-inline-code-font: #{$font-family-monospace-inline};
+  --r-block-code-font: #{$font-family-monospace-block};
+  --r-inline-code-font-size: #{$revealjs-code-inline-font-size};
+  --r-block-code-font-size: #{$revealjs-code-block-font-size};
+}
+
+// --- link styling (cross-format / brand vocabulary) -------------------------
+.reveal a {
+  font-weight: $link-weight;
+  background-color: $link-color-bg;
+  text-decoration: $link-decoration;
 }

--- a/resources/scss/revealjs/reveal-template/_expose.scss
+++ b/resources/scss/revealjs/reveal-template/_expose.scss
@@ -1,0 +1,57 @@
+// reveal.js 6 theme settings — CSS CUSTOM-PROPERTY EMITTER.
+//
+// Vendored from reveal.js 6.0.x `css/theme/template/settings.scss` (the trailing
+// `:root { … }` block). Split out of the variable declarations so it can run in
+// the SCSS `rules` layer, AFTER every `!default` has collapsed — that way the
+// emitted `--r-*` custom properties carry the *final* (Quarto-overridden) values.
+//
+// reveal's `theme.scss` styles everything via `var(--r-*)`, so this block is the
+// bridge between the compile-time Sass variables and the runtime appearance.
+// See resources/scss/revealjs/README.md for provenance.
+
+// Expose all SCSS variables as CSS custom properties
+:root {
+	// Background of the presentation
+	--r-background: #{$background};
+	--r-background-color: #{$background-color};
+
+	// Primary/body text
+	--r-main-font: #{$main-font};
+	--r-main-font-size: #{$main-font-size};
+	--r-main-color: #{$main-color};
+
+	// Vertical spacing between blocks of text
+	--r-block-margin: #{$block-margin};
+
+	// Headings
+	--r-heading-margin: #{$heading-margin};
+	--r-heading-font: #{$heading-font};
+	--r-heading-color: #{$heading-color};
+	--r-heading-line-height: #{$heading-line-height};
+	--r-heading-letter-spacing: #{$heading-letter-spacing};
+	--r-heading-text-transform: #{$heading-text-transform};
+	--r-heading-text-shadow: #{$heading-text-shadow};
+	--r-heading-font-weight: #{$heading-font-weight};
+	--r-heading1-text-shadow: #{$heading1-text-shadow};
+
+	--r-heading1-size: #{$heading1-size};
+	--r-heading2-size: #{$heading2-size};
+	--r-heading3-size: #{$heading3-size};
+	--r-heading4-size: #{$heading4-size};
+
+	--r-code-font: #{$code-font};
+
+	// Links and actions
+	--r-link-color: #{$link-color};
+	--r-link-color-dark: #{$link-color-dark};
+	--r-link-color-hover: #{$link-color-hover};
+
+	// Text selection
+	--r-selection-background-color: #{$selection-background-color};
+	--r-selection-color: #{$selection-color};
+
+	// Colors used for UI elements that are overlaid on top of
+	// the presentation
+	--r-overlay-element-bg-color: #{$overlay-element-bg-color};
+	--r-overlay-element-fg-color: #{$overlay-element-fg-color};
+}

--- a/resources/scss/revealjs/reveal-template/_mixins.scss
+++ b/resources/scss/revealjs/reveal-template/_mixins.scss
@@ -1,0 +1,33 @@
+// reveal.js 6 theme mixins.
+//
+// Vendored verbatim from reveal.js 6.0.x `css/theme/template/mixins.scss`
+// (External Sources Policy: kept local). Used by themes that recolor text on
+// light/dark slide backgrounds. See resources/scss/revealjs/README.md.
+
+@mixin light-bg-text-color($color) {
+	section.has-light-background {
+		&,
+		h1,
+		h2,
+		h3,
+		h4,
+		h5,
+		h6 {
+			color: $color;
+		}
+	}
+}
+
+@mixin dark-bg-text-color($color) {
+	section.has-dark-background {
+		&,
+		h1,
+		h2,
+		h3,
+		h4,
+		h5,
+		h6 {
+			color: $color;
+		}
+	}
+}

--- a/resources/scss/revealjs/reveal-template/_settings-vars.scss
+++ b/resources/scss/revealjs/reveal-template/_settings-vars.scss
@@ -1,0 +1,62 @@
+// reveal.js 6 theme settings — VARIABLE DECLARATIONS ONLY.
+//
+// Vendored from reveal.js 6.0.x `css/theme/template/settings.scss`
+// (External Sources Policy: kept local, never referenced from external-sources/).
+// See resources/scss/revealjs/README.md for provenance + update procedure.
+//
+// This file holds ONLY the `$kebab: … !default;` declarations. The companion
+// `_expose.scss` holds the `:root { --r-*: … }` emitter that the upstream
+// settings.scss appended after these declarations — we split it out so the
+// emitter can live in the SCSS `rules` layer (running *after* all `!default`
+// values collapse) while these declarations live in the `defaults` layer.
+//
+// These are the reveal-native fallbacks (#bbb, uppercase, Lato, …). Quarto's
+// reveal layer overrides them via its own `!default` assignments in a
+// higher-priority layer (see quarto-revealjs.scss).
+//
+// Requires `@use 'sass:color'` in scope (assembled into the framework `uses`
+// layer) for the `color.scale(...)` calls below.
+
+// Background of the presentation
+$background: #2b2b2b !default;
+$background-color: #bbb !default;
+
+// Primary/body text
+$main-font: 'Lato', sans-serif !default;
+$main-font-size: 40px !default;
+$main-color: #eee !default;
+
+// Vertical spacing between blocks of text
+$block-margin: 20px !default;
+
+// Headings
+$heading-margin: 0 0 20px 0 !default;
+$heading-font: 'League Gothic', Impact, sans-serif !default;
+$heading-color: #eee !default;
+$heading-line-height: 1.2 !default;
+$heading-letter-spacing: normal !default;
+$heading-text-transform: uppercase !default;
+$heading-text-shadow: none !default;
+$heading-font-weight: normal !default;
+$heading1-text-shadow: none !default;
+
+$heading1-size: 3.77em !default;
+$heading2-size: 2.11em !default;
+$heading3-size: 1.55em !default;
+$heading4-size: 1em !default;
+
+$code-font: monospace !default;
+
+// Links and actions
+$link-color: #13daec !default;
+$link-color-dark: color.scale($link-color, $lightness: -15%) !default;
+$link-color-hover: color.scale($link-color, $lightness: 20%) !default;
+
+// Text selection
+$selection-background-color: #0fadbb !default;
+$selection-color: #fff !default;
+
+// Colors used for UI elements that are overlaid on top of
+// the presentation
+$overlay-element-bg-color: 240, 240, 240 !default;
+$overlay-element-fg-color: 0, 0, 0 !default;

--- a/resources/scss/revealjs/reveal-template/_theme.scss
+++ b/resources/scss/revealjs/reveal-template/_theme.scss
@@ -1,0 +1,337 @@
+// reveal.js 6 base theme template (RULES).
+//
+// Vendored verbatim from reveal.js 6.0.x `css/theme/template/theme.scss`
+// (External Sources Policy: kept local). Styles everything via `var(--r-*)`,
+// which `_expose.scss` emits into `:root`. Quarto's reveal layer rules are
+// assembled AFTER this file, so they override these base rules.
+// See resources/scss/revealjs/README.md for provenance.
+
+/*********************************************
+ * GLOBAL STYLES
+ *********************************************/
+
+.reveal-viewport {
+	background: var(--r-background);
+	background-color: var(--r-background-color);
+}
+
+.reveal {
+	font-family: var(--r-main-font);
+	font-size: var(--r-main-font-size);
+	font-weight: normal;
+	color: var(--r-main-color);
+}
+
+.reveal ::selection {
+	color: var(--r-selection-color);
+	background: var(--r-selection-background-color);
+	text-shadow: none;
+}
+
+.reveal ::-moz-selection {
+	color: var(--r-selection-color);
+	background: var(--r-selection-background-color);
+	text-shadow: none;
+}
+
+.reveal .slides section,
+.reveal .slides section > section {
+	line-height: 1.3;
+	font-weight: inherit;
+}
+
+/*********************************************
+ * HEADERS
+ *********************************************/
+
+.reveal h1,
+.reveal h2,
+.reveal h3,
+.reveal h4,
+.reveal h5,
+.reveal h6 {
+	margin: var(--r-heading-margin);
+	color: var(--r-heading-color);
+
+	font-family: var(--r-heading-font);
+	font-weight: var(--r-heading-font-weight);
+	line-height: var(--r-heading-line-height);
+	letter-spacing: var(--r-heading-letter-spacing);
+
+	text-transform: var(--r-heading-text-transform);
+	text-shadow: var(--r-heading-text-shadow);
+
+	word-wrap: break-word;
+}
+
+.reveal h1 {
+	font-size: var(--r-heading1-size);
+}
+.reveal h2 {
+	font-size: var(--r-heading2-size);
+}
+.reveal h3 {
+	font-size: var(--r-heading3-size);
+}
+.reveal h4 {
+	font-size: var(--r-heading4-size);
+}
+
+.reveal h1 {
+	text-shadow: var(--r-heading1-text-shadow);
+}
+
+/*********************************************
+ * OTHER
+ *********************************************/
+
+.reveal p {
+	margin: var(--r-block-margin) 0;
+	line-height: 1.3;
+}
+
+/* Remove trailing margins after titles */
+.reveal h1:last-child,
+.reveal h2:last-child,
+.reveal h3:last-child,
+.reveal h4:last-child,
+.reveal h5:last-child,
+.reveal h6:last-child {
+	margin-bottom: 0;
+}
+
+/* Ensure certain elements are never larger than the slide itself */
+.reveal img,
+.reveal video,
+.reveal iframe {
+	max-width: 95%;
+	max-height: 95%;
+}
+.reveal strong,
+.reveal b {
+	font-weight: bold;
+}
+
+.reveal em {
+	font-style: italic;
+}
+
+.reveal ol,
+.reveal dl,
+.reveal ul {
+	display: inline-block;
+
+	text-align: left;
+	margin: 0 0 0 1em;
+}
+
+.reveal ol {
+	list-style-type: decimal;
+}
+
+.reveal ul {
+	list-style-type: disc;
+}
+
+.reveal ul ul {
+	list-style-type: square;
+}
+
+.reveal ul ul ul {
+	list-style-type: circle;
+}
+
+.reveal ul ul,
+.reveal ul ol,
+.reveal ol ol,
+.reveal ol ul {
+	display: block;
+	margin-left: 40px;
+}
+
+.reveal dt {
+	font-weight: bold;
+}
+
+.reveal dd {
+	margin-left: 40px;
+}
+
+.reveal blockquote {
+	display: block;
+	position: relative;
+	width: 70%;
+	margin: var(--r-block-margin) auto;
+	padding: 5px;
+
+	font-style: italic;
+	background: rgba(255, 255, 255, 0.05);
+	box-shadow: 0px 0px 2px rgba(0, 0, 0, 0.2);
+}
+.reveal blockquote p:first-child,
+.reveal blockquote p:last-child {
+	display: inline-block;
+}
+
+.reveal q {
+	font-style: italic;
+}
+
+.reveal pre {
+	display: block;
+	position: relative;
+	width: 90%;
+	margin: var(--r-block-margin) auto;
+
+	text-align: left;
+	font-size: 0.55em;
+	font-family: var(--r-code-font);
+	line-height: 1.2em;
+
+	word-wrap: break-word;
+
+	box-shadow: 0px 5px 15px rgba(0, 0, 0, 0.15);
+}
+
+.reveal code {
+	font-family: var(--r-code-font);
+	text-transform: none;
+	tab-size: 2;
+}
+
+.reveal pre code {
+	display: block;
+	padding: 5px;
+	overflow: auto;
+	max-height: 400px;
+	word-wrap: normal;
+}
+
+.reveal .code-wrapper {
+	white-space: normal;
+}
+
+.reveal .code-wrapper code {
+	white-space: pre;
+}
+
+.reveal table {
+	margin: auto;
+	border-collapse: collapse;
+	border-spacing: 0;
+}
+
+.reveal table th {
+	font-weight: bold;
+}
+
+.reveal table th,
+.reveal table td {
+	text-align: left;
+	padding: 0.2em 0.5em 0.2em 0.5em;
+	border-bottom: 1px solid;
+}
+
+.reveal table th[align='center'],
+.reveal table td[align='center'] {
+	text-align: center;
+}
+
+.reveal table th[align='right'],
+.reveal table td[align='right'] {
+	text-align: right;
+}
+
+.reveal table tbody tr:last-child th,
+.reveal table tbody tr:last-child td {
+	border-bottom: none;
+}
+
+.reveal sup {
+	vertical-align: super;
+	font-size: smaller;
+}
+.reveal sub {
+	vertical-align: sub;
+	font-size: smaller;
+}
+
+.reveal small {
+	display: inline-block;
+	font-size: 0.6em;
+	line-height: 1.2em;
+	vertical-align: top;
+}
+
+.reveal small * {
+	vertical-align: top;
+}
+
+.reveal img {
+	margin: var(--r-block-margin) 0;
+}
+
+/*********************************************
+ * LINKS
+ *********************************************/
+
+.reveal a {
+	color: var(--r-link-color);
+	text-decoration: none;
+	transition: color 0.15s ease;
+}
+.reveal a:hover {
+	color: var(--r-link-color-hover);
+	text-shadow: none;
+	border: none;
+}
+
+.reveal .roll span:after {
+	color: #fff;
+	// background: darken( var(--r-link-color), 15% );
+	background: var(--r-link-color-dark);
+}
+
+/*********************************************
+ * Frame helper
+ *********************************************/
+
+.reveal .r-frame {
+	border: 4px solid var(--r-main-color);
+	box-shadow: 0 0 10px rgba(0, 0, 0, 0.15);
+}
+
+.reveal a .r-frame {
+	transition: all 0.15s linear;
+}
+
+.reveal a:hover .r-frame {
+	border-color: var(--r-link-color);
+	box-shadow: 0 0 20px rgba(0, 0, 0, 0.55);
+}
+
+/*********************************************
+ * NAVIGATION CONTROLS
+ *********************************************/
+
+.reveal .controls {
+	color: var(--r-link-color);
+}
+
+/*********************************************
+ * PROGRESS BAR
+ *********************************************/
+
+.reveal .progress {
+	background: rgba(0, 0, 0, 0.2);
+	color: var(--r-link-color);
+}
+
+/*********************************************
+ * PRINT BACKGROUND
+ *********************************************/
+@media print {
+	.backgrounds {
+		background-color: var(--r-background-color);
+	}
+}

--- a/resources/scss/revealjs/themes/beige.scss
+++ b/resources/scss/revealjs/themes/beige.scss
@@ -1,0 +1,42 @@
+/**
+ * Beige theme for reveal.js — adapted from Quarto 1 themes/beige.scss to
+ * reveal.js 6 (kebab-case reveal vars; bodyBackground() mixin -> $background
+ * gradient, dropped in reveal 6; local league-gothic font -> Google Fonts CDN).
+ * Original (C) 2011-2012 Hakim El Hattab; Quarto adaptation (C) Posit, PBC.
+ */
+
+/*-- scss:defaults --*/
+
+// Theme-specific fonts (Google Fonts CDN — see B7 font decision in the plan).
+@import url(https://fonts.googleapis.com/css?family=League+Gothic);
+@import url(https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic);
+
+$font-family-sans-serif: Lato, sans-serif !default;
+
+$body-color: #333 !default;
+$body-bg: #f7f3de !default;
+$link-color: #8b743d !default;
+$selection-bg: rgba(79, 64, 28, 0.99) !default;
+
+$presentation-heading-font: "League Gothic", sans-serif !default;
+$presentation-heading-text-transform: uppercase !default;
+$presentation-h1-font-size: 3.77em !default;
+$presentation-h1-text-shadow: 0 1px 0 #ccc, 0 2px 0 #c9c9c9, 0 3px 0 #bbb,
+  0 4px 0 #b9b9b9, 0 5px 0 #aaa, 0 6px 1px rgba(0, 0, 0, 0.1),
+  0 0 5px rgba(0, 0, 0, 0.1), 0 1px 3px rgba(0, 0, 0, 0.3),
+  0 3px 5px rgba(0, 0, 0, 0.2), 0 5px 10px rgba(0, 0, 0, 0.25),
+  0 20px 20px rgba(0, 0, 0, 0.15) !default;
+
+$overlay-element-bg-color: 0, 0, 0 !default;
+$overlay-element-fg-color: 240, 240, 240 !default;
+
+$code-block-bg: transparent !default;
+
+// reveal 6 dropped the bodyBackground()/radial-gradient mixin; express the
+// radial background directly via $background (the `radial-gradient($outer,
+// $inner)` mixin emitted inner→outer center-to-edge).
+$background: radial-gradient(
+  circle at center,
+  rgba(255, 255, 255, 1) 0%,
+  rgba(247, 242, 211, 1) 100%
+) !default;

--- a/resources/scss/revealjs/themes/blood.scss
+++ b/resources/scss/revealjs/themes/blood.scss
@@ -1,0 +1,68 @@
+/**
+ * Blood theme for reveal.js — adapted from Quarto 1 themes/blood.scss to
+ * reveal.js 6. Designed to pair with a dark code-highlight theme.
+ * Original (C) Walther; Quarto adaptation (C) Posit, PBC.
+ */
+
+/*-- scss:defaults --*/
+
+@import url(https://fonts.googleapis.com/css?family=Ubuntu:300,700,300italic,700italic);
+
+// Colors used in the theme
+$blood: #a23;
+$coal: #222;
+$code-bg: #23241f !default;
+
+$body-bg: $coal !default;
+
+// Main text
+$font-family-sans-serif: Ubuntu, "sans-serif" !default;
+$body-color: #eee !default;
+
+// Headings
+$presentation-heading-font: Ubuntu, "sans-serif" !default;
+$presentation-heading-text-shadow: 2px 2px 2px $body-bg !default;
+$presentation-heading-font-weight: 700 !default;
+$presentation-h1-font-size: 3.77em !default;
+$presentation-h1-text-shadow: 0 1px 0 #ccc, 0 2px 0 #c9c9c9, 0 3px 0 #bbb,
+  0 4px 0 #b9b9b9, 0 5px 0 #aaa, 0 6px 1px rgba(0, 0, 0, 0.1),
+  0 0 5px rgba(0, 0, 0, 0.1), 0 1px 3px rgba(0, 0, 0, 0.3),
+  0 3px 5px rgba(0, 0, 0, 0.2), 0 5px 10px rgba(0, 0, 0, 0.25),
+  0 20px 20px rgba(0, 0, 0, 0.15) !default;
+$presentation-heading-text-transform: uppercase !default;
+
+// Links
+$link-color: $blood !default;
+
+// Text selection
+$selection-bg: $link-color !default;
+$selection-color: #fff !default;
+
+$input-panel-bg: rgba(233, 236, 239, 0.2) !default;
+
+/*-- scss:rules --*/
+
+.reveal p {
+  font-weight: 300;
+  text-shadow: 1px 1px $body-bg;
+}
+
+section.has-light-background {
+  p,
+  h1,
+  h2,
+  h3,
+  h4 {
+    text-shadow: none;
+  }
+}
+
+.reveal p code {
+  background-color: $code-bg;
+  display: inline-block;
+  border-radius: 7px;
+}
+
+.reveal small code {
+  vertical-align: baseline;
+}

--- a/resources/scss/revealjs/themes/dark.scss
+++ b/resources/scss/revealjs/themes/dark.scss
@@ -1,0 +1,8 @@
+/*-- scss:defaults --*/
+
+// The "dark" Quarto reveal theme (Quarto 1 themes/dark.scss). `black` aliases
+// to this theme.
+$body-bg: #191919 !default;
+$body-color: #fff !default;
+$link-color: #42affa !default;
+$input-panel-bg: rgba(233, 236, 239, 0.2) !default;

--- a/resources/scss/revealjs/themes/default.scss
+++ b/resources/scss/revealjs/themes/default.scss
@@ -1,0 +1,6 @@
+/*-- scss:defaults --*/
+
+// The default ("white") Quarto reveal theme inherits everything from the Quarto
+// reveal layer (quarto-revealjs.scss) — light background, dark text, Quarto's
+// fonts/spacing/headings. `white` aliases to this theme. Ported from Quarto 1
+// themes/default.scss (also a no-op defaults block).

--- a/resources/scss/revealjs/themes/dracula.scss
+++ b/resources/scss/revealjs/themes/dracula.scss
@@ -1,0 +1,86 @@
+/**
+ * Dracula Dark theme for reveal.js — adapted from Quarto 1 themes/dracula.scss
+ * to reveal.js 6. NOTE: Q1's local palette var `$background` is renamed here to
+ * `$drac-background` because in reveal 6 `$background` is reveal's own viewport
+ * background variable (kebab migration) — the rename avoids the implicit
+ * collision; reveal's `$background` is still driven from `$body-bg` by the
+ * Quarto reveal layer.
+ * Dracula palette (C) Zeno Rocha; Quarto adaptation (C) Posit, PBC.
+ */
+
+/*-- scss:defaults --*/
+
+$systemFontsSansSerif: -apple-system, BlinkMacSystemFont, avenir next, avenir,
+  segoe ui, helvetica neue, helvetica, Cantarell, Ubuntu, roboto, noto, arial,
+  sans-serif;
+$systemFontsMono: Menlo, Consolas, Monaco, Liberation Mono, Lucida Console,
+  monospace;
+
+$drac-background: #282a36;
+$foreground: #f8f8f2;
+$selection: #44475a;
+$comment: #6272a4;
+$red: #ff5555;
+$orange: #ffb86c;
+$yellow: #f1fa8c;
+$green: #50fa7b;
+$purple: #bd93f9;
+$cyan: #8be9fd;
+$pink: #ff79c6;
+
+// Override theme settings
+$body-color: $foreground !default;
+$presentation-heading-color: $purple !default;
+$presentation-heading-text-shadow: none !default;
+$presentation-heading-text-transform: none !default;
+$body-bg: $drac-background !default;
+$link-color: $pink !default;
+$link-color-hover: $cyan !default;
+$selection-bg: $selection !default;
+$code-color: $green !default;
+$presentation-list-bullet-color: $cyan !default;
+
+$font-family-sans-serif: $systemFontsSansSerif !default;
+$font-family-monospace: "Fira Code", $systemFontsMono !default;
+
+// Change text colors against light slide backgrounds
+$light-bg-text-color: $body-bg !default;
+
+/*-- scss:rules --*/
+
+// Additional color effects from the Dracula spec (https://spec.draculatheme.com/)
+:root {
+  --r-bold-color: #{$orange};
+  --r-italic-color: #{$yellow};
+  --r-inline-code-color: #{$code-color};
+  --r-list-bullet-color: #{$presentation-list-bullet-color};
+}
+
+.reveal {
+  strong,
+  b {
+    &:not(.callout-title strong, .callout-tile b) {
+      color: var(--r-bold-color);
+    }
+  }
+  em,
+  i,
+  blockquote {
+    color: var(--r-italic-color);
+  }
+  code {
+    color: var(--r-inline-code-color);
+  }
+  // Dracula colored list bullets and numbers
+  ul,
+  ol {
+    li::marker {
+      color: var(--r-list-bullet-color);
+    }
+  }
+}
+
+html * {
+  color-profile: sRGB;
+  rendering-intent: auto;
+}

--- a/resources/scss/revealjs/themes/league.scss
+++ b/resources/scss/revealjs/themes/league.scss
@@ -1,0 +1,40 @@
+/**
+ * League theme for reveal.js (the pre-3.0 default) — adapted from Quarto 1
+ * themes/league.scss to reveal.js 6 (bodyBackground() -> $background gradient;
+ * local league-gothic font -> Google Fonts CDN).
+ * Original (C) 2011-2012 Hakim El Hattab; Quarto adaptation (C) Posit, PBC.
+ */
+
+/*-- scss:defaults --*/
+
+@import url(https://fonts.googleapis.com/css?family=League+Gothic);
+@import url(https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic);
+
+$font-family-sans-serif: Lato, sans-serif !default;
+$presentation-heading-font: "League Gothic", sans-serif !default;
+
+$body-bg: #2b2b2b !default;
+$body-color: #eee !default;
+$link-color: #13daec !default;
+$selection-bg: #ff5e99 !default;
+
+$presentation-heading-text-shadow: 0px 0px 6px rgba(0, 0, 0, 0.2) !default;
+$presentation-h1-text-shadow: 0 1px 0 #ccc, 0 2px 0 #c9c9c9, 0 3px 0 #bbb,
+  0 4px 0 #b9b9b9, 0 5px 0 #aaa, 0 6px 1px rgba(0, 0, 0, 0.1),
+  0 0 5px rgba(0, 0, 0, 0.1), 0 1px 3px rgba(0, 0, 0, 0.3),
+  0 3px 5px rgba(0, 0, 0, 0.2), 0 5px 10px rgba(0, 0, 0, 0.25),
+  0 20px 20px rgba(0, 0, 0, 0.15) !default;
+$presentation-h1-font-size: 3.77em !default;
+$presentation-heading-text-transform: uppercase !default;
+
+// Change text colors against light slide backgrounds
+$light-bg-text-color: #222 !default;
+
+$input-panel-bg: rgba(233, 236, 239, 0.2) !default;
+$code-block-bg: transparent !default;
+
+$background: radial-gradient(
+  circle at center,
+  rgba(85, 90, 95, 1) 0%,
+  rgba(28, 30, 32, 1) 100%
+) !default;

--- a/resources/scss/revealjs/themes/moon.scss
+++ b/resources/scss/revealjs/themes/moon.scss
@@ -1,0 +1,45 @@
+/**
+ * Solarized Dark ("moon") theme for reveal.js — adapted from Quarto 1
+ * themes/moon.scss to reveal.js 6 (local league-gothic font -> Google Fonts CDN).
+ * Solarized palette (C) Ethan Schoonover; Quarto adaptation (C) Posit, PBC.
+ */
+
+/*-- scss:defaults --*/
+
+@import url(https://fonts.googleapis.com/css?family=League+Gothic);
+@import url(https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic);
+
+$font-family-sans-serif: Lato, sans-serif !default;
+
+// Solarized colors by Ethan Schoonover
+$base03: #002b36;
+$base02: #073642;
+$base01: #586e75;
+$base00: #657b83;
+$base0: #839496;
+$base1: #93a1a1;
+$base2: #eee8d5;
+$base3: #fdf6e3;
+$yellow: #b58900;
+$orange: #cb4b16;
+$red: #dc322f;
+$magenta: #d33682;
+$violet: #6c71c4;
+$blue: #268bd2;
+$cyan: #2aa198;
+$green: #859900;
+
+$body-color: $base1 !default;
+$presentation-heading-color: $base2 !default;
+$presentation-heading-text-shadow: none !default;
+$body-bg: $base03 !default;
+$link-color: $blue !default;
+$selection-bg: $magenta !default;
+
+$presentation-heading-text-transform: uppercase !default;
+$presentation-heading-font: "League Gothic", sans-serif !default;
+
+// Change text colors against light slide backgrounds
+$light-bg-text-color: #222 !default;
+
+$input-panel-bg: rgba(233, 236, 239, 0.2) !default;

--- a/resources/scss/revealjs/themes/night.scss
+++ b/resources/scss/revealjs/themes/night.scss
@@ -1,0 +1,27 @@
+/**
+ * Night theme for reveal.js — adapted from Quarto 1 themes/night.scss to
+ * reveal.js 6 (kebab-case reveal vars).
+ * Original (C) 2011-2012 Hakim El Hattab; Quarto adaptation (C) Posit, PBC.
+ */
+
+/*-- scss:defaults --*/
+
+@import url(https://fonts.googleapis.com/css?family=Montserrat:700);
+@import url(https://fonts.googleapis.com/css?family=Open+Sans:400,700,400italic,700italic);
+
+$body-bg: #111 !default;
+$body-color: #eee !default;
+
+$font-family-sans-serif: "Open Sans", sans-serif !default;
+$link-color: #e7ad52 !default;
+$presentation-heading-font: "Montserrat", sans-serif !default;
+$presentation-heading-text-shadow: none !default;
+$presentation-heading-letter-spacing: -0.03em !default;
+$presentation-heading-text-transform: none !default;
+$selection-bg: #e7ad52 !default;
+
+// Change text colors against light slide backgrounds
+$light-bg-text-color: #222 !default;
+
+$input-panel-bg: rgba(233, 236, 239, 0.2) !default;
+$code-block-bg: transparent !default;

--- a/resources/scss/revealjs/themes/serif.scss
+++ b/resources/scss/revealjs/themes/serif.scss
@@ -1,0 +1,30 @@
+/**
+ * Serif theme for reveal.js (brown accent) — adapted from Quarto 1
+ * themes/serif.scss to reveal.js 6 (kebab-case reveal vars).
+ * Original (C) 2012-2013 Owen Versteeg (MIT); Quarto adaptation (C) Posit, PBC.
+ */
+
+/*-- scss:defaults --*/
+
+$font-family-sans-serif: "Palatino Linotype", "Book Antiqua", Palatino,
+  FreeSerif, serif !default;
+$body-color: #000 !default;
+$presentation-heading-font: $font-family-sans-serif !default;
+$presentation-heading-color: #383d3d !default;
+$presentation-heading-text-shadow: none !default;
+$presentation-heading-text-transform: none !default;
+$body-bg: #f0f1eb !default;
+$link-color: #51483d !default;
+$selection-bg: #26351c !default;
+
+$overlay-element-bg-color: 0, 0, 0 !default;
+$overlay-element-fg-color: 240, 240, 240 !default;
+
+// Change text colors against dark slide backgrounds
+$dark-bg-text-color: #fff !default;
+
+/*-- scss:rules --*/
+
+.reveal a {
+  line-height: 1.3em;
+}

--- a/resources/scss/revealjs/themes/simple.scss
+++ b/resources/scss/revealjs/themes/simple.scss
@@ -1,0 +1,26 @@
+/**
+ * Simple theme for reveal.js (darkblue accent) — adapted from Quarto 1
+ * themes/simple.scss to reveal.js 6 (kebab-case reveal vars).
+ * Original (C) 2012 Owen Versteeg (MIT); Quarto adaptation (C) Posit, PBC.
+ */
+
+/*-- scss:defaults --*/
+
+@import url(https://fonts.googleapis.com/css?family=News+Cycle:400,700);
+@import url(https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic);
+
+$font-family-sans-serif: "Lato", sans-serif !default;
+$body-color: #000 !default;
+$presentation-heading-font: "News Cycle", sans-serif !default;
+$presentation-heading-color: $body-color !default;
+$presentation-heading-text-shadow: none !default;
+$presentation-heading-text-transform: none !default;
+$body-bg: #fff !default;
+$link-color: #00008b !default;
+$selection-bg: rgba(0, 0, 0, 0.99) !default;
+
+$overlay-element-bg-color: 0, 0, 0 !default;
+$overlay-element-fg-color: 240, 240, 240 !default;
+
+// Change text colors against dark slide backgrounds
+$dark-bg-text-color: #fff !default;

--- a/resources/scss/revealjs/themes/sky.scss
+++ b/resources/scss/revealjs/themes/sky.scss
@@ -1,0 +1,41 @@
+/**
+ * Sky theme for reveal.js — adapted from Quarto 1 themes/sky.scss to reveal.js 6
+ * (kebab-case reveal vars; bodyBackground() -> $background gradient).
+ * Original (C) 2011-2012 Hakim El Hattab; Quarto adaptation (C) Posit, PBC.
+ */
+
+/*-- scss:defaults --*/
+
+@import url(https://fonts.googleapis.com/css?family=Quicksand:400,700,400italic,700italic);
+@import url(https://fonts.googleapis.com/css?family=Open+Sans:400italic,700italic,400,700);
+
+$font-family-sans-serif: "Open Sans", sans-serif !default;
+$body-color: #333 !default;
+$presentation-heading-font: "Quicksand", sans-serif !default;
+$presentation-heading-color: $body-color !default;
+$presentation-heading-letter-spacing: -0.08em !default;
+$presentation-heading-text-shadow: none !default;
+$body-bg: #f7fbfc !default;
+$link-color: #3b759e !default;
+$selection-bg: #134674 !default;
+
+$presentation-heading-text-transform: uppercase !default;
+$presentation-heading-font-weight: normal !default;
+
+$overlay-element-bg-color: 0, 0, 0 !default;
+$overlay-element-fg-color: 240, 240, 240 !default;
+
+// Change text colors against dark slide backgrounds
+$dark-bg-text-color: #fff !default;
+
+$code-block-border-color: lighten($link-color, 30%) !default;
+$code-block-bg: transparent !default;
+
+$background: radial-gradient(circle at center, #f7fbfc 0%, #add9e4 100%) !default;
+
+/*-- scss:rules --*/
+
+// Fix links so they are not cut off
+.reveal a {
+  line-height: 1.3em;
+}

--- a/resources/scss/revealjs/themes/solarized.scss
+++ b/resources/scss/revealjs/themes/solarized.scss
@@ -1,0 +1,53 @@
+/**
+ * Solarized Light theme for reveal.js — adapted from Quarto 1
+ * themes/solarized.scss to reveal.js 6 (local league-gothic font -> Google
+ * Fonts CDN).
+ * Solarized palette (C) Ethan Schoonover; Quarto adaptation (C) Posit, PBC.
+ */
+
+/*-- scss:defaults --*/
+
+@import url(https://fonts.googleapis.com/css?family=League+Gothic);
+@import url(https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic);
+
+$font-family-sans-serif: Lato, sans-serif !default;
+
+// Solarized colors by Ethan Schoonover
+$base03: #002b36;
+$base02: #073642;
+$base01: #586e75;
+$base00: #657b83;
+$base0: #839496;
+$base1: #93a1a1;
+$base2: #eee8d5;
+$base3: #fdf6e3;
+$yellow: #b58900;
+$orange: #cb4b16;
+$red: #dc322f;
+$magenta: #d33682;
+$violet: #6c71c4;
+$blue: #268bd2;
+$cyan: #2aa198;
+$green: #859900;
+
+$body-color: $base00 !default;
+$presentation-heading-font: "League Gothic", sans-serif !default;
+$presentation-heading-color: $base01 !default;
+$presentation-heading-text-transform: uppercase !default;
+$presentation-heading-text-shadow: none !default;
+$presentation-heading-font-weight: normal !default;
+$body-bg: $base3 !default;
+$link-color: $blue !default;
+$selection-bg: $magenta !default;
+
+$overlay-element-bg-color: 0, 0, 0 !default;
+$overlay-element-fg-color: 240, 240, 240 !default;
+
+$code-block-border-color: #93a1a1 !default;
+
+/*-- scss:rules --*/
+
+html * {
+  color-profile: sRGB;
+  rendering-intent: auto;
+}

--- a/ts-packages/preview-renderer/src/q2-preview/RevealDeck.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/RevealDeck.tsx
@@ -156,18 +156,26 @@ export function RevealDeck(props: RevealDeckProps) {
             <IncrementalContext.Provider value={{ enabled: true, incremental: globalIncremental }}>
                 <Deck
                     config={{
+                        // Match the render path's Quarto-1 opinionated defaults
+                        // (see reveal_config_json in quarto-core) so preview and
+                        // render look the same: top-aligned slides, no
+                        // transition, 0.1 margin, linear nav, edge controls.
                         width: 1050,
                         height: 700,
-                        margin: 0.04,
+                        margin: 0.1,
                         minScale: 0.2,
                         maxScale: 2.0,
                         controls: true,
                         progress: true,
-                        center: true,
+                        center: false,
+                        navigationMode: 'linear',
+                        controlsLayout: 'edges',
+                        controlsTutorial: false,
+                        backgroundTransition: 'none',
                         // Preview re-renders on every edit; URL-hash navigation
                         // would fight that. Keep nav purely in-deck.
                         hash: false,
-                        transition: 'slide',
+                        transition: 'none',
                     }}
                 >
                     {slides}


### PR DESCRIPTION
Epic integration branch (`feature/revealjs-q1-themes`) bringing Quarto 1's
reveal.js theming and authoring defaults forward to Quarto 2 / reveal.js 6, so a
deck feels "at home" for Q1 users. Opened to see CI; this is the accumulated
Stage A–D work (strand bd-yown2ts4).

Plan & design rationale: `claude-notes/plans/2026-06-16-revealjs-themes-q1-to-q2.md`.

## Stages (each landed as a `--no-ff` merge)

- **A — Quarto reveal SCSS layer.** Compile a Quarto reveal theme through the
  `quarto-sass` subsystem (reveal-6 kebab vars), fixing the "feels wrong"
  defaults: left-aligned slides, non-uppercase headings, centered/h2-sized
  title slide, top-aligned body slides.
- **B — theme set + selection.** The 12 reveal themes adapted to reveal-6;
  real `theme:` resolution (built-ins, `white→default`/`black→dark` aliases,
  user `theme: [name, custom.scss]`), keyed by content fingerprint.
- **C — config defaults + Sass helpers + SCSS quick-wins.** Q1's opinionated
  `Reveal.initialize` block (transition:none, center:false, 1050×700, linear
  nav, …); Sass helper foundation; `.has-light/dark-background`, code-block
  borders/scroll, `.smaller`, blockquote/kbd/slide-number/figure restyles.
- **D — brand + callouts + footer/logo + auto-stretch + docs.**
  - D1 callouts (pure SCSS port).
  - D2 `_brand.yml` integration (brand layers appended highest-priority).
  - D3 `footer:`/`logo:` — reuses the format-agnostic `FooterGenerateTransform`,
    adds a reveal-specific render writing `rendered.reveal.*` slots (so the
    entries sit on the same user-filter surface as html chrome), placed outside
    `.slides` in the scaffold (fixed positioning survives reveal's transforms).
  - D4 auto-stretch single-image slides (`.r-stretch`, default-on,
    `auto-stretch: false`), matching Q1's `applyStretch`.
  - D5 feature docs: themes / footer-logo / auto-stretch on the reveal docs
    page, each with a runnable `examples/presentations/*` project embedded via
    `.embed-example-iframe`.

## Verification

- TDD throughout; `cargo xtask verify` (incl. the WASM leg) green locally.
- E2E through `q2 render` + Chrome DevTools for the user-visible features
  (theme colors, footer/logo fixed positioning, image stretch sizing).

## Deferred (own strands, not in this PR)

- Deep theming-variables guide + Q1→Q2 migration how-to — **bd-fw3872al**.
- End-to-end user Lua filters in revealjs — **bd-ocxnva1f**.
- light/dark integration, code-annotation, reveal plugins, fancy title slide,
  panels/tabsets — pre-existing separate strands.
- Preview-parity: SCSS-only theming renders via `q2 render` but not the
  `q2-slides` preview SPA (documented; tracked as a parity follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)