### PR TITLE
chore(release): bump workspace version to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,7 +654,7 @@ dependencies = [
 
 [[package]]
 name = "comrak-to-pandoc"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "comrak",
  "hashlink",
@@ -3407,7 +3407,7 @@ dependencies = [
 
 [[package]]
 name = "quarto"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3444,7 +3444,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-analysis"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "insta",
  "quarto-error-reporting",
@@ -3470,7 +3470,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-brand"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3480,7 +3480,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-citeproc"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "glob",
  "hashlink",
@@ -3513,7 +3513,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-core"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3567,7 +3567,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-csl"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "insta",
  "quarto-error-reporting",
@@ -3606,7 +3606,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-error-reporting"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "ariadne",
  "once_cell",
@@ -3620,7 +3620,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-highlight"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "hashlink",
  "insta",
@@ -3649,7 +3649,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-highlight-encoding"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3657,7 +3657,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-hub"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "automerge",
@@ -3701,7 +3701,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-lsp"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "insta",
@@ -3717,7 +3717,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-lsp-core"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "insta",
  "pampa",
@@ -3737,7 +3737,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-mcp-launcher"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -3753,7 +3753,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-navigation"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "quarto-config",
  "quarto-pandoc-types",
@@ -3788,7 +3788,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-preview"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "automerge",
@@ -3820,7 +3820,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-project-create"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "quarto-doctemplate",
  "serde",
@@ -3829,7 +3829,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-publish"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3854,7 +3854,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-sass"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "grass",
  "include_dir",
@@ -3876,7 +3876,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-source-map"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3885,7 +3885,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-system-runtime"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3903,7 +3903,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-test"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "quarto-core",
@@ -3920,7 +3920,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-trace"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "flate2",
  "serde",
@@ -3931,7 +3931,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-trace-server"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3958,7 +3958,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-util"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -3966,7 +3966,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-xml"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "insta",
  "quarto-error-reporting",
@@ -3977,7 +3977,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-yaml"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "quarto-source-map",
  "regex",
@@ -3988,7 +3988,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-yaml-validation"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "quarto-error-reporting",
@@ -4183,7 +4183,7 @@ dependencies = [
 
 [[package]]
 name = "reconcile-viewer"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "clap",
  "hashlink",
@@ -5990,7 +5990,7 @@ dependencies = [
 
 [[package]]
 name = "validate-yaml"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -6179,7 +6179,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-printf-fmt"
-version = "0.2.0"
+version = "0.3.0"
 
 [[package]]
 name = "wasmparser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Posit Software, PBC"]
 homepage = "https://github.com/posit-dev/quarto-markdown-syntax"
 keywords = ["parser"]


### PR DESCRIPTION
Bumps `[workspace.package].version` from `0.2.0` to `0.3.0` and refreshes the workspace entries in `Cargo.lock` via `cargo update --workspace`.

This is the version-bump step that must land on `main` before tagging `v0.3.0`: the Release workflow's preflight job fails unless the git tag exactly equals the manifest version (see `claude-notes/instructions/release-runbook.md`).

## Verification
- `cargo update --workspace` touched only workspace crate versions (0.2.0 → 0.3.0); no external deps moved.
- `cargo build --bin q2 --locked` succeeds.
- `./target/debug/q2 --version` prints `q2 (quarto 2) 0.3.0`.

Strand: bd-jbj5mtsr

🤖 Generated with [Claude Code](https://claude.com/claude-code)