### PR TITLE
feat(preview): single-file deck transitive include + image closure (bd-9cyza5vy)

### DIFF
--- a/claude-notes/plans/2026-06-16-single-file-preview-transitive-deps.md
+++ b/claude-notes/plans/2026-06-16-single-file-preview-transitive-deps.md
@@ -1,0 +1,304 @@
+# Single-file `q2 preview`: transitive sibling-dependency resolution
+
+**Strand:** bd-9cyza5vy · **Follows:** bd-kpuweafo (direct images), bd-ggvq1j68
+(`_brand.yml`), bd-tnm3k (no-walk single-file mode)
+**Design doc this refines:** `2026-06-16-single-file-preview-vfs-bootstrapping.md`
+**Status:** plan for review — *not yet approved for implementation.*
+
+## Goal
+
+Make single-file `q2 preview deck.qmd` (no `_quarto.yml`) populate the preview
+VFS with the deck's **full transitive static dependency closure** —
+`{{< include >}}`d `.qmd` files (recursively) plus every image those files
+reference — so includes expand and their images display, matching `q2 render`
+and project-mode preview. Re-resolve on deck edits so refs added mid-session
+appear without a reload.
+
+## What we verified in the code (the levers)
+
+- **`extract_include_path(block) -> Option<String>`** (`stage/stages/include_expansion.rs:299`)
+  — the *shared* "is this an include?" recognizer. `deps.rs` already reuses it
+  for the single-hop `/api/preview/deps` endpoint. **Reusing this is the
+  no-drift anchor for the include channel.**
+- **`IncludeExpansionStage`** resolves an include relative to the *including
+  file's* dir (`base_dir = current_file.parent(); base_dir.join(path)`,
+  `include_expansion.rs:90`), with cycle detection on the canonicalized path.
+- **`collect_referenced_asset_urls(blocks) -> Vec<String>`**
+  (`transforms/resource_collector.rs:440`) — the *shared* image-URL extractor,
+  reused by `resolve_single_file_assets` today. Returns raw relative URLs
+  (external/absolute dropped, deduped, nested images found).
+- **Render's image resolution is deck-dir-anchored — by design.**
+  `ResourceCollectorTransform` uses `input_dir = ctx.document.input.parent()`
+  (the *main* deck) over the *fully-expanded* AST, and `expand_includes_in_blocks`
+  never rewrites URLs. ⇒ q2 render resolves an image written inside
+  `sub/part.qmd` relative to the deck dir, not `sub/`. This is the **intended
+  "no path retargeting" design** of Quarto include shortcodes (confirmed against
+  Quarto 1 + the docs — see `claude-notes/research/2026-06-16-include-shortcode-path-resolution.md`).
+- **…but nested *include* paths are wrongly retargeted (latent bug bd-udrn0q47).**
+  Verified E2E: a nested `{{< include other.qmd >}}` inside `sub/part.qmd`
+  resolves to `sub/other.qmd` (the including file's dir), not the original deck
+  dir. The design says no-retargeting for includes too; q2's AST-level recursion
+  (`include_expansion.rs:248`) anchors at the including file. **This asymmetry is
+  exactly why the preview resolver must inherit render's behavior rather than
+  re-derive it** (see mechanism choice below).
+- **`DocumentProfile.includes: Vec<IncludeEntry>`** (`document_profile.rs:328`)
+  carries the transitive include set — but it's produced by the *project*
+  pass-1 orchestrator and does not include the image closure. Useful as a
+  cross-check, not as the single-file mechanism (too heavy for one bare deck).
+- **Current single-file wiring:** `build_hub_config` (`quarto-preview/src/lib.rs:321`)
+  calls `config::resolve_single_file_assets` once at session start → fills
+  `HubConfig.single_file_assets` (binaries only) → `ProjectFiles::single_file()
+  .with_config_siblings().with_binary_files()` (`context.rs:229`) →
+  `reconcile_files_with_index` syncs them. The watcher watches **only the deck
+  file** (`server.rs:1244`); `sync_file` only re-syncs files already in the index.
+
+## The bootstrapping paradox — and why it dissolves natively
+
+The design doc frames a circularity: populating the VFS needs parsing; parsing
+(in WASM) needs the VFS populated. **That circularity only exists in WASM.**
+`quarto-preview` runs natively and reads the *real* filesystem. So we resolve
+the closure natively by parsing real files directly — no VFS, no fixpoint loop,
+no async on-miss fetch. This is the cheap, correct core of the fix.
+
+## Chosen mechanism: reuse the renderer's *actual* include expansion (C-strict)
+
+**Decision (revised after the bd-udrn0q47 finding):** run `quarto-core`'s real
+`IncludeExpansionStage` natively against the real filesystem to produce the
+expanded AST + the recorded include set, then collect images off the **expanded**
+AST with `collect_referenced_asset_urls`. The single-file resolver thereby
+**inherits render's exact path-resolution semantics** — the un-retargeted image
+anchor *and* the (currently buggy) nested-include anchor — and will automatically
+track whatever bd-udrn0q47 lands on, with **zero parallel re-implementation** of
+include resolution to keep in sync.
+
+Why not the lighter "worklist reusing `extract_include_path`" approach (design-doc
+option A): it would force us to hard-code one side of the contested include-path
+anchor (including-file vs original-file). Either choice would make preview diverge
+from render — now (if we pick original-file while render still retargets) or after
+the fix (if we pick including-file). The user explicitly flagged this subtlety;
+reusing the real stage is the only option that can't drift. The cost (construct a
+`StageContext`, stop before `EngineExecutionStage`) is modest for one deck.
+
+New function in `quarto-preview` (it has `quarto-core` + the qmd parser):
+
+```rust
+/// Transitive static dependency closure of a single-file deck.
+pub struct SingleFileDeps {
+    /// Included `.qmd` files, project-root-relative (text → VFS).
+    pub qmd_files: Vec<PathBuf>,
+    /// Referenced image assets, project-root-relative (binary → VFS).
+    pub binary_files: Vec<PathBuf>,
+}
+
+pub fn resolve_single_file_deps(
+    project_root: &Path,      // deck's parent dir in single-file mode
+    single_file_rel: &Path,   // deck, relative to project_root
+    runtime: &dyn SystemRuntime,
+) -> SingleFileDeps;
+```
+
+Algorithm:
+
+1. Build a minimal native head pipeline for the deck up to **and including**
+   `IncludeExpansionStage` — and **stopping before** `EngineExecutionStage` (no
+   R/Python execution; engines never run in WASM preview anyway). Reuse the
+   orchestrator's pass-1 plumbing if it can be invoked for a single file cheaply;
+   otherwise assemble the minimal stage list. *Implementation spike needed — see
+   open question 1.*
+2. **Include channel:** read the expanded `DocumentAst.recorded_includes` (the
+   `IncludeEntry.path`s the stage actually spliced, transitively). Map each to a
+   project-root-relative path; apply the under-root canonicalization guard
+   (reuse today's logic) → `qmd_files`.
+3. **Image channel:** `collect_referenced_asset_urls(&expanded.ast.blocks)` over
+   the fully-expanded AST; resolve each relative to the **deck dir** (the same
+   anchor `ResourceCollectorTransform` uses — render parity for free). Keep
+   binary-extension, existing, in-tree files → `binary_files`.
+4. Dedup + sort both vecs. Any read/parse failure degrades to a partial closure
+   (renders broken for the missing piece, exactly as render does).
+
+Notes / subtleties to encode as tests:
+- **Image-in-include is deck-dir-anchored** (by design): `sub/part.qmd` with
+  `![](img.png)` ⇒ we sync root `img.png`, matching render. Pin with a test +
+  comment pointing at the research doc.
+- **Nested-include anchor matches render today** (bd-udrn0q47 behavior): a test
+  should assert the resolver returns whatever the live stage spliced, so when
+  bd-udrn0q47 changes the anchor, this resolver and its test move in lock-step
+  with render automatically (no separate update needed).
+- `resolve_single_file_assets` (deck-direct images only) is **superseded** — the
+  new closure is a superset; delete the old function + its single-channel field.
+
+## Wiring the text channel into the VFS
+
+Included `.qmd` must ride the **text** sync path (synced to the VFS as an
+automerge Text doc readable by `vfsReadFile`) but stay **out of `qmd_files`** so
+they are invisible VFS-only dependencies — **decided with the user** (the
+single-file preview SPA has no file list today, and we don't want included files
+surfaced as nav entries). This is exactly the `resource_files` precedent
+(bd-kjrpya2d): a separate vec that flows through `text_files()`/`all_files()`
+but not `qmd_files`.
+
+- `HubConfig`: add `single_file_text_deps: Vec<PathBuf>` (parallel to
+  `single_file_assets`).
+- `ProjectFiles`: add a `text_dep_files: Vec<PathBuf>` field + `with_text_deps()`
+  builder (sorted/deduped), included in `text_files()` and `all_files()` and the
+  `text_file_count()`/`total_count()` totals — mirroring `resource_files`
+  exactly, but **not** in `qmd_files` (so no nav surfacing).
+- `context.rs` single-file branch: `.with_text_deps(config.single_file_text_deps.clone())`.
+- `build_hub_config`: call `resolve_single_file_deps`, fill both
+  `single_file_assets` (binaries) and `single_file_text_deps` (included `.qmd`).
+- `reconcile_files_with_index` already syncs everything in `text_files()` as a
+  Text doc, so no reconcile change is needed.
+
+## Watching the discovered closure (mid-edit changes)
+
+**Decision (from the user):** watch every file in the *initial* resolved closure
+for content changes so edits to an included `.qmd` or a referenced image
+re-render the preview. Do **not** re-traverse includes mid-session to chase
+*newly-added* references back into the filesystem — that is explicitly out of
+scope for now (a later, informative error message is the likely treatment).
+
+- **Watch set:** today the single-file watcher watches only the deck
+  (`server.rs:1244`, `watch.rs` `single_file` filter). Extend it to the resolved
+  closure (deck + included `.qmd` + referenced images). Mechanism options:
+  (a) widen the single-file watch filter to an explicit allow-list of the
+  resolved absolute paths, or (b) watch the deck's directory but filter events to
+  the closure set. Lean **(a)** — it preserves the bd-tnm3k "don't react to
+  arbitrary siblings" property (we only watch files we deliberately synced).
+- Each watched file is already in the index (we synced it at startup), so the
+  existing `sync_file` path handles its edits → re-render. No new
+  reconcile/discovery logic is needed for the in-scope case.
+- **Out of scope (documented):** a `{{< include >}}`/`![]()` *added* to the deck
+  mid-session points at a file not in the closure → it won't sync until restart.
+  Acceptable for v1; consider a surfaced diagnostic later.
+
+## TDD work items
+
+### Phase 0 — spike: invoke real include expansion natively for one deck
+- [x] **DONE.** Chosen entry point: run the two public stages directly (NOT the
+      orchestrator pass-1 — it yields a `DocumentProfile`, not the expanded AST we
+      need for image collection). Sequence in `quarto-preview`:
+      - `runtime = Arc::new(NativeRuntime::new())`
+      - `project = ProjectContext::single_file(abs_deck, &*runtime)?` (canonicalizes,
+        sets `is_single_file` so `StageContext::new`'s extension discovery passes
+        `None` for the project dir — cheap)
+      - `document = DocumentInfo::from_path(abs_deck)`
+      - `ctx = StageContext::new(runtime, Format::html(), project, document)?`
+      - `ParseDocumentStage.run(PipelineData::LoadedSource(LoadedSource::new(abs_deck, bytes)), &mut ctx)`
+        → `PipelineData::DocumentAst`
+      - `IncludeExpansionStage::new().run(that, &mut ctx)` → expanded `DocumentAst`
+      - drive both with `pollster::block_on` (the `run` futures are `?Send`; the
+        file already uses this pattern). Resolver stays sync like
+        `resolve_single_file_assets`.
+      - **Text deps** = `doc.recorded_includes[].path` (canonical ABSOLUTE paths of
+        spliced files); strip `project_root` via the under-root guard.
+      - **Binary deps** = `collect_referenced_asset_urls(&doc.ast.blocks)` over the
+        EXPANDED AST; resolve each relative to the deck dir; same guard as today.
+      - Only successfully-spliced includes are recorded (missing ones get a
+        diagnostic and are skipped) — matches render.
+
+### Phase 1 — resolver (quarto-preview) ✅ DONE
+- [x] Test: include + image-in-include resolved (`qmd_files=[part.qmd]`,
+      `binary_files=[inc.png]`).
+- [x] Test: transitive (`main → a.qmd → b.qmd`, image in `b`) returns all.
+- [x] Test: **image-in-subdir-include resolves deck-dir-relative** (no
+      retargeting, matches render + design) — `img.png` present at both root and
+      `sub/`; closure picks root.
+- [x] Test: self-include cycle terminates, recorded once (the stage's own cycle
+      detection).
+- [x] Test: guard — `../escape.qmd` / `../secret.png` dropped; external images
+      dropped; missing files dropped.
+- [x] Test: deck's own direct image still collected (superset of the old path).
+- [x] Implement `resolve_single_file_deps` (+ `SingleFileDeps`) in
+      `quarto-preview/src/config.rs`, running the real `ParseDocumentStage` +
+      `IncludeExpansionStage` via `pollster::block_on`. All 6 new tests pass; full
+      `quarto-preview` suite green (85 passed).
+- [ ] `resolve_single_file_assets` deletion deferred to **Phase 2** — it stays
+      live until `build_hub_config` is rewired to call `resolve_single_file_deps`
+      (avoids a half-switched caller). Tracked there.
+
+### Phase 2 — VFS plumbing (quarto-hub + quarto-preview) ✅ DONE
+- [x] Test (`discovery.rs`): `with_text_deps` populates `text_dep_files`, flows
+      through `text_files()`/`all_files()`, dedup/sort, and is **absent from
+      `qmd_files`** (invisible-dependency invariant). Plus a dedup/sort test.
+- [x] Test (`context.rs`): single-file branch syncs text deps into the index
+      (`test_single_file_mode_syncs_text_deps_invisibly`).
+- [x] Add `HubConfig.single_file_text_deps`, `ProjectFiles.text_dep_files` +
+      `with_text_deps` (mirrors `resource_files`: in `text_files()`/`all_files()`/
+      counts, NOT `qmd_files`), wire `context.rs` single-file branch + the
+      `info!` discovery log.
+- [x] Rewire `build_hub_config` to call `resolve_single_file_deps` once → fills
+      both `single_file_assets` (binary) and `single_file_text_deps` (text).
+- [x] Delete `resolve_single_file_assets` + its 2 tests (superseded). Updated the
+      4 other explicit `HubConfig { … }` literals (main.rs, hub.rs, 3× auth_bearer).
+- [x] `cargo build -p quarto-preview -p quarto-hub -p quarto` clean; full
+      `quarto-preview` + `quarto-hub` suites green (357 passed).
+
+### Phase 3 — watch the discovered closure ✅ DONE
+- [x] Test (`watch.rs`): editing an included `.qmd` in the closure surfaces a
+      watch event, while an *unrelated* sibling does **not**
+      (`test_watcher_single_file_watches_closure_dep`) — one test pins both the
+      new behavior and the preserved bd-tnm3k safety. Existing
+      `test_watcher_single_file_ignores_sibling_qmd` still green.
+- [x] `WatchConfig.single_file_deps: Vec<PathBuf>` (the deck's closure, absolute).
+      `FileWatcher::new`: build an allow-`HashSet` (deck + deps); accept events
+      only for set members; subscribe to the deck (required) + each dep
+      (best-effort, NonRecursive — so subdir deps are seen without widening to
+      the whole directory). Images-only watch covered by the same path (media
+      passes `PreviewBroad`).
+- [x] `server.rs`: in single-file mode, compute `single_file_deps` from
+      `ctx.project_files().all_files()` (everything synced *except* the deck) →
+      `project_root.join(rel)`. No new discovery — watches exactly what discovery
+      synced. Full `quarto-hub` suite green (275 passed); `q2` builds.
+
+### Phase 4 — E2E (the strand's fixture; CLAUDE.md mandate) ✅ DONE
+- [x] Fixture: `/tmp/q2-e2e-incl/main.qmd` → `{{< include part.qmd >}}`;
+      `part.qmd` has `![logo](inc-image.png)` (a real 1×1 PNG); **no `_quarto.yml`**
+      → single-file mode.
+- [x] Invocation: `cargo run --bin q2 -- preview /tmp/q2-e2e-incl/main.qmd --port 7799`
+      → served `http://127.0.0.1:7799/?page=main.qmd`.
+- [x] Inspected the rendered preview iframe in a real browser (chrome-devtools
+      MCP, `evaluate_script` into `iframe.contentDocument`). Observed:
+      - `hasIncluded: true` — "Included Section" renders (include **expanded**).
+      - `literalShortcode: false` — no leftover `?include` placeholder (the
+        reported bug is gone).
+      - image inside the include: `src` = `blob:http://127.0.0.1:7799/798c24c0…`,
+        `naturalWidth: 1` (the 1×1 PNG loaded — `>0` ⇒ resolved, not broken).
+      - body text: "Single-file include E2E Top Included Section Text from the
+        included file. logo".
+- [x] Note on the WASM chain: the fix is **native-only** (the q2-preview server
+      populates the VFS; the WASM include-expansion + asset path is unchanged
+      `quarto-core`). `cargo xtask verify` rebuilt the SPA/WASM; `cargo build --bin q2`
+      re-embedded the dist before the run. Include-expansion in WASM is
+      pre-existing (works in project mode); the gap was purely VFS population,
+      which this strand fixes.
+- Closure-watch re-render (editing an included file refreshes) is covered by the
+  `watch.rs` unit test rather than a browser session.
+
+## Out of scope (document, don't fix)
+
+- **Dynamically generated refs** (a code cell that writes `![](plot.png)` at
+  runtime) — not statically discoverable; engines don't run in WASM preview
+  anyway. Documented caveat.
+- **Long-tail channels** beyond include + image: `bibliography:`/`csl:`,
+  `{{< embed >}}`, `resources:` globs, raw `<img>/<video>/<link>/<script>`/CSS
+  `url(...)`. Each is a future per-channel extension of the resolver; the
+  worklist structure accommodates them. Note in the strand as follow-ups.
+- **Included-file content-edit re-render** (Phase 2 watcher extension above).
+
+## Resolved decisions
+
+- **Resolver mechanism:** reuse the real `IncludeExpansionStage` natively
+  (C-strict), so preview inherits render's path resolution and tracks bd-udrn0q47.
+- **Image-in-include:** deck-dir-anchored (no retargeting) — by design, matches
+  render; not a "bug-for-bug" concession.
+- **Nested include retargeting:** a real render-side bug, filed as **bd-udrn0q47**
+  and fixed there; this strand just inherits whatever render does.
+- **Watching:** watch the initial closure for content edits; do NOT re-traverse
+  for newly-added refs (out of scope; maybe a diagnostic later).
+- **Included `.qmd` visibility:** invisible VFS-only deps via a dedicated
+  `text_dep_files` vec (the `resource_files` pattern) — **not** `qmd_files`. The
+  single-file preview SPA has no file list, and we don't want included files
+  surfaced.
+
+All design questions resolved — plan is ready for implementation on your
+go-ahead.

--- a/claude-notes/research/2026-06-16-include-shortcode-path-resolution.md
+++ b/claude-notes/research/2026-06-16-include-shortcode-path-resolution.md
@@ -1,0 +1,115 @@
+# `{{< include >}}` shortcode path resolution: the "no retargeting" design
+
+**Captured:** 2026-06-16 (while planning bd-9cyza5vy, single-file preview deps).
+**Why this exists in the repo, not in a personal memory:** this is a project-wide
+design fact + a latent code/intent discrepancy that any contributor touching
+include expansion, resource collection, or preview VFS population needs to know.
+
+## The intended design (authoritative, from Carlos)
+
+Quarto include shortcodes do **no path retargeting**. Every path a document
+references — image/resource URLs **and** nested `{{< include >}}` arguments —
+is meant to be resolved relative to the **original (top-level) file**, not the
+file the path textually appears in.
+
+History: Quarto 1's first include implementation *did* retarget paths (resolve
+them relative to the included file). That was abandoned because users could not
+reason about the boundary between:
+
+- image paths parsed as markdown (retargetable in principle),
+- raw-HTML image `src`s authored by the user (retargetable in principle),
+- raw-HTML image `src`s emitted by an **executed code cell** (produced *after*
+  shortcode resolution — *cannot* be retargeted even in principle).
+
+The simpler, teachable rule won: **no retargeting at all.** The recommended
+authoring pattern in projects is **project-root-relative notation with a
+leading slash** — `{{< include /path/with/leading/slash.qmd >}}` and
+`![](/assets/img.png)` — because then the anchor is irrelevant and the
+ambiguity disappears.
+
+Docs: <https://quarto.org/docs/authoring/includes.html> (Carlos authored this
+feature).
+
+**Confirmed against the Quarto 1 implementation.**
+`external-sources/quarto-cli/src/core/handlers/include-standalone.ts`
+(`standaloneInclude`) resolves every include via the *same fixed*
+`handlerContext.resolvePath(filename)`; the nested call
+`retrieveInclude(params[0])` reuses the *same* `handlerContext`, whose anchor is
+the original document's `target.source`. So all include paths — top-level and
+nested — resolve against the **original** document. No retargeting. Q1 also
+splices raw **text** (`mappedConcat(textFragments)`) and parses the whole
+concatenation **once**, so image/resource paths are likewise un-retargeted by
+construction. q2 instead splices at the **AST** level
+(`expand_includes_in_blocks`), parsing each included file separately — which is
+exactly where the nested-include asymmetry crept in (images stayed correct
+because `ResourceCollectorTransform` re-anchors at the original deck dir).
+
+## What q2 actually does today (empirically verified)
+
+Fixture (`main.qmd` at root includes `sub/part.qmd`; `sub/part.qmd` contains
+both an image and a nested include; `other.qmd`/`img.png` exist at BOTH root
+and `sub/`):
+
+```
+main.qmd            {{< include sub/part.qmd >}}
+sub/part.qmd        ![](img.png)   +   {{< include other.qmd >}}
+other.qmd           ROOT-OTHER       sub/other.qmd   SUB-OTHER
+img.png             ROOTPNG          sub/img.png     SUBPNG
+```
+
+`q2 render main.qmd --to html` produced:
+
+- `<img src="img.png">` in `main.html` (at root) → resolves to **root `img.png`
+  (ROOTPNG)**. **No retargeting** — matches the intended design. ✓
+- Included text was **`SUB-OTHER`** → the nested `{{< include other.qmd >}}`
+  resolved relative to **the including file (`sub/`)**, i.e. it **WAS
+  retargeted**. ✗ contradicts the intended design.
+
+### So there is an asymmetry / latent bug
+
+- **Images / resources:** resolved by `ResourceCollectorTransform` over the
+  *fully expanded* AST using `input_dir = ctx.document.input.parent()` — the
+  *original* deck dir — and `expand_includes_in_blocks` never rewrites URL
+  strings. ⇒ correctly **un-retargeted**.
+  (`crates/quarto-core/src/transforms/resource_collector.rs:79`,
+  `:440` `collect_referenced_asset_urls`.)
+- **Nested includes:** `expand_includes_in_blocks` recurses with
+  `current_file = &resolved` (the just-included file), so the next level's
+  `base_dir = current_file.parent()` is the *including* file's dir — a
+  retarget. ⇒ **violates** the no-retargeting design for nested includes in
+  subdirectories.
+  (`crates/quarto-core/src/stage/stages/include_expansion.rs:90` and the
+  recursive call at `:248`.)
+
+A single-level include from the deck root is unaffected (the anchor is the deck
+dir either way); the discrepancy only bites a nested include whose *including*
+file lives in a subdirectory and whose argument is a relative path.
+
+### Leading-slash caveat (separate, also worth a look)
+
+`base_dir.join("/foo.qmd")` on Unix yields `/foo.qmd` (filesystem root), not
+project-root. So the recommended `{{< include /... >}}` notation does **not**
+resolve to the project root through this code path as-is — there must be
+(or must be added) explicit project-root handling upstream of the bare
+`join`. Verify before relying on leading-slash includes; not exercised by the
+fixture above.
+
+## Consequence for preview ↔ render parity (bd-9cyza5vy)
+
+`q2 preview` must match `q2 render` **bug-for-bug**, including this asymmetry,
+until render itself is changed. The safest way for the single-file preview
+dependency resolver to stay in lock-step is to **reuse the renderer's actual
+`IncludeExpansionStage`** (run it natively against the real filesystem) rather
+than re-deriving include path resolution in a parallel walker — otherwise the
+resolver would have to hard-code one side of a contested rule and could drift
+from render now or after a future fix. See
+`claude-notes/plans/2026-06-16-single-file-preview-transitive-deps.md`.
+
+## Follow-up (filed)
+
+**bd-udrn0q47** (bug, render-side): align nested-include resolution with the
+documented no-retargeting design (anchor the recursion at the original
+top-level document dir, not the including file), and fix/confirm leading-slash
+project-root includes. That is a **render** behaviour change, distinct from the
+preview parity work (bd-9cyza5vy), and should land on the render side so preview
+inherits it.

--- a/crates/quarto-hub/src/context.rs
+++ b/crates/quarto-hub/src/context.rs
@@ -95,6 +95,18 @@ pub struct HubConfig {
     /// project mode (the dir walk finds binaries) and the `quarto hub` server.
     pub single_file_assets: Vec<PathBuf>,
 
+    /// Single-file mode (bd-9cyza5vy): included `.qmd` files the deck pulls in
+    /// via `{{< include >}}` (transitively), project-root-relative.
+    ///
+    /// Single-file mode does not walk the directory, so the bare `single_file`
+    /// discovery never finds these. `q2 preview` resolves the deck's transitive
+    /// include closure upstream in `quarto-preview` (which has the qmd parser)
+    /// via `config::resolve_single_file_deps` and injects them here so they reach
+    /// [`ProjectFiles::with_text_deps`] — synced into the VFS as text (readable
+    /// by the WASM include-expansion stage) but kept out of `qmd_files` (invisible
+    /// dependencies). Empty for project mode and the `quarto hub` server.
+    pub single_file_text_deps: Vec<PathBuf>,
+
     /// OAuth2 auth configuration. None = auth disabled.
     pub auth_config: Option<AuthConfig>,
 
@@ -134,6 +146,7 @@ impl Default for HubConfig {
             single_file: None,
             resource_files: Vec::new(),
             single_file_assets: Vec::new(),
+            single_file_text_deps: Vec::new(),
             auth_config: None,
             allow_insecure_auth: false,
             register_root_ws: true,
@@ -231,7 +244,11 @@ impl HubContext {
                     // bd-kpuweafo: sync the sibling images the deck references
                     // (resolved upstream by quarto-preview) so they reach the
                     // VFS like project mode, without walking the directory.
-                    .with_binary_files(config.single_file_assets.clone()),
+                    .with_binary_files(config.single_file_assets.clone())
+                    // bd-9cyza5vy: sync the deck's transitive `{{< include >}}`
+                    // closure as invisible text deps (also resolved upstream)
+                    // so includes expand in the WASM pipeline.
+                    .with_text_deps(config.single_file_text_deps.clone()),
                 // bd-kjrpya2d: the bare walk can't see resources-scoped
                 // `.html` (it falls through every category), so the
                 // caller-resolved set is injected here to ride the text
@@ -246,6 +263,7 @@ impl HubContext {
                 extension_count = files.extension_files.len(),
                 source_count = files.source_files.len(),
                 resource_count = files.resource_files.len(),
+                text_dep_count = files.text_dep_files.len(),
                 "Discovered project files"
             );
             Some(files)
@@ -786,6 +804,41 @@ mod tests {
         // File should be in the index
         let files = ctx.index().get_all_files();
         assert_eq!(files.len(), 1);
+    }
+
+    /// bd-9cyza5vy: in single-file mode, included `.qmd` injected via
+    /// `single_file_text_deps` must be synced into the index as invisible text
+    /// deps — present in the VFS (so includes expand) but NOT in `qmd_files`.
+    #[tokio::test]
+    async fn test_single_file_mode_syncs_text_deps_invisibly() {
+        let temp = TempDir::new().unwrap();
+        std::fs::write(temp.path().join("main.qmd"), "{{< include part.qmd >}}\n").unwrap();
+        std::fs::write(temp.path().join("part.qmd"), "## Included\n").unwrap();
+
+        let storage = StorageManager::new(temp.path()).unwrap();
+        let config = HubConfig {
+            single_file: Some(PathBuf::from("main.qmd")),
+            single_file_text_deps: vec![PathBuf::from("part.qmd")],
+            ..HubConfig::default()
+        };
+
+        let ctx = HubContext::new(storage, config).await.unwrap();
+
+        let pf = ctx.project_files().unwrap();
+        // The deck is the only nav qmd; the include is an invisible text dep.
+        assert_eq!(pf.qmd_files, vec![PathBuf::from("main.qmd")]);
+        assert_eq!(pf.text_dep_files, vec![PathBuf::from("part.qmd")]);
+
+        // Both reach the index (so both are in the VFS for include expansion).
+        let files = ctx.index().get_all_files();
+        assert!(
+            files.iter().any(|(f, _)| f.as_str() == "main.qmd"),
+            "deck missing from index: {files:?}"
+        );
+        assert!(
+            files.iter().any(|(f, _)| f.as_str() == "part.qmd"),
+            "included text dep missing from index: {files:?}"
+        );
     }
 
     /// Build an automerge text document with the given content.

--- a/crates/quarto-hub/src/discovery.rs
+++ b/crates/quarto-hub/src/discovery.rs
@@ -41,6 +41,21 @@ pub struct ProjectFiles {
     /// post-processor can read them via `vfsReadFile` and inline them
     /// as `srcdoc` — see `iframePostProcessor.ts`'s `readArtifactOrSource`.
     pub resource_files: Vec<PathBuf>,
+
+    /// Single-file mode (bd-9cyza5vy): included `.qmd` files the deck pulls in
+    /// via `{{< include >}}` (transitively), project-root-relative.
+    ///
+    /// These must be in the VFS for the WASM include-expansion stage to read
+    /// them, but they are **deliberately kept out of [`qmd_files`](Self::qmd_files)**
+    /// so they stay *invisible* VFS-only dependencies — single-file preview does
+    /// not surface included files as their own entries. Like
+    /// [`resource_files`](Self::resource_files), they ride the **text** sync path
+    /// ([`text_files`](Self::text_files)) into an automerge Text doc readable by
+    /// `vfsReadFile`. Resolved upstream in `quarto-preview` (which has the qmd
+    /// parser) via `config::resolve_single_file_deps` and injected through
+    /// [`with_text_deps`](Self::with_text_deps). Empty for project mode (the dir
+    /// walk finds them) and the `quarto hub` server.
+    pub text_dep_files: Vec<PathBuf>,
 }
 
 impl ProjectFiles {
@@ -211,6 +226,18 @@ impl ProjectFiles {
         self
     }
 
+    /// Attach included `.qmd` files (resolved by the caller from the deck's
+    /// transitive `{{< include >}}` closure) to be synced into the VFS as
+    /// **text**, without surfacing them in [`qmd_files`](Self::qmd_files).
+    /// Deduplicates and sorts for deterministic ordering. See
+    /// [`ProjectFiles::text_dep_files`]. (bd-9cyza5vy)
+    pub fn with_text_deps(mut self, mut text_dep_files: Vec<PathBuf>) -> Self {
+        text_dep_files.sort();
+        text_dep_files.dedup();
+        self.text_dep_files = text_dep_files;
+        self
+    }
+
     /// Returns the total number of discovered files.
     pub fn total_count(&self) -> usize {
         self.qmd_files.len()
@@ -219,16 +246,18 @@ impl ProjectFiles {
             + self.extension_files.len()
             + self.source_files.len()
             + self.resource_files.len()
+            + self.text_dep_files.len()
     }
 
     /// Returns the count of text files (config + qmd + extension text +
-    /// source files + resources-scoped `.html`).
+    /// source files + resources-scoped `.html` + single-file text deps).
     pub fn text_file_count(&self) -> usize {
         self.qmd_files.len()
             + self.config_files.len()
             + self.extension_files.len()
             + self.source_files.len()
             + self.resource_files.len()
+            + self.text_dep_files.len()
     }
 
     /// Returns an iterator over all discovered file paths.
@@ -239,13 +268,15 @@ impl ProjectFiles {
             .chain(self.extension_files.iter())
             .chain(self.source_files.iter())
             .chain(self.resource_files.iter())
+            .chain(self.text_dep_files.iter())
             .chain(self.binary_files.iter())
     }
 
     /// Returns an iterator over text files only (config + qmd +
-    /// extension text + source files + resources-scoped `.html`).
-    /// Resources-scoped `.html` is text so the reconcile loop stores it
-    /// as an automerge Text doc readable by the SPA's `vfsReadFile`.
+    /// extension text + source files + resources-scoped `.html` +
+    /// single-file text deps). All ride the text sync path so the
+    /// reconcile loop stores each as an automerge Text doc readable by
+    /// the SPA's `vfsReadFile`.
     pub fn text_files(&self) -> impl Iterator<Item = &PathBuf> {
         self.config_files
             .iter()
@@ -253,6 +284,7 @@ impl ProjectFiles {
             .chain(self.extension_files.iter())
             .chain(self.source_files.iter())
             .chain(self.resource_files.iter())
+            .chain(self.text_dep_files.iter())
     }
 }
 
@@ -701,6 +733,46 @@ mod tests {
         // Counted in both totals.
         assert_eq!(files.total_count(), 2); // index.qmd + slides.html
         assert_eq!(files.text_file_count(), 2);
+    }
+
+    #[test]
+    fn test_with_text_deps_syncs_as_text_but_not_in_qmd_files() {
+        // bd-9cyza5vy: included `.qmd` must reach the VFS via the TEXT sync path
+        // (so the WASM include-expansion stage can read them) but must NOT appear
+        // in `qmd_files` — they are invisible VFS-only dependencies.
+        let files = ProjectFiles::single_file(PathBuf::from("main.qmd")).with_text_deps(vec![
+            PathBuf::from("part.qmd"),
+            PathBuf::from("sub/inc.qmd"),
+        ]);
+
+        // Deck stays the only nav qmd; included files are NOT surfaced there.
+        assert_eq!(files.qmd_files, vec![PathBuf::from("main.qmd")]);
+        assert!(!files.qmd_files.contains(&PathBuf::from("part.qmd")));
+
+        // ...but they DO flow through the text sync path.
+        let text: Vec<_> = files.text_files().collect();
+        assert!(text.contains(&&PathBuf::from("part.qmd")));
+        assert!(text.contains(&&PathBuf::from("sub/inc.qmd")));
+        let all: Vec<_> = files.all_files().collect();
+        assert!(all.contains(&&PathBuf::from("part.qmd")));
+        assert!(all.contains(&&PathBuf::from("sub/inc.qmd")));
+
+        // Counted in both totals (1 deck qmd + 2 text deps).
+        assert_eq!(files.text_file_count(), 3);
+        assert_eq!(files.total_count(), 3);
+    }
+
+    #[test]
+    fn test_with_text_deps_dedups_and_sorts() {
+        let files = ProjectFiles::default().with_text_deps(vec![
+            PathBuf::from("b/two.qmd"),
+            PathBuf::from("a/one.qmd"),
+            PathBuf::from("b/two.qmd"), // duplicate (diamond include)
+        ]);
+        assert_eq!(
+            files.text_dep_files,
+            vec![PathBuf::from("a/one.qmd"), PathBuf::from("b/two.qmd")]
+        );
     }
 
     #[test]

--- a/crates/quarto-hub/src/main.rs
+++ b/crates/quarto-hub/src/main.rs
@@ -224,6 +224,7 @@ async fn main() -> anyhow::Result<()> {
         resource_files: Vec::new(),
         // Single-file asset sync is a preview-only concern (bd-kpuweafo).
         single_file_assets: Vec::new(),
+        single_file_text_deps: Vec::new(),
         auth_config,
         allow_insecure_auth: args.allow_insecure_auth,
         register_root_ws: true,

--- a/crates/quarto-hub/src/server.rs
+++ b/crates/quarto-hub/src/server.rs
@@ -1242,10 +1242,31 @@ where
         // an absolute target path. The project_root is the file's
         // parent directory, so `project_root.join(rel)` is the file.
         let single_file_abs = watch_single_file.as_ref().map(|rel| project_root.join(rel));
+        // bd-9cyza5vy: also watch the deck's resolved dependency closure
+        // (included `.qmd`, referenced images, sibling `_brand.yml`) so editing
+        // any of them re-renders — matching project mode. The closure is
+        // exactly what discovery synced; take every synced file except the deck
+        // itself (which `single_file_abs` already covers) and absolutize it the
+        // same way. Only the closure is watched — unrelated siblings are not,
+        // preserving the bd-tnm3k safety property.
+        let single_file_deps: Vec<std::path::PathBuf> = if single_file_abs.is_some() {
+            ctx_for_watch
+                .project_files()
+                .map(|pf| {
+                    pf.all_files()
+                        .filter(|rel| Some(rel.as_path()) != watch_single_file.as_deref())
+                        .map(|rel| project_root.join(rel))
+                        .collect()
+                })
+                .unwrap_or_default()
+        } else {
+            Vec::new()
+        };
         let watch_config = WatchConfig {
             debounce_ms: watch_debounce_ms,
             filter: watch_filter,
             single_file: single_file_abs,
+            single_file_deps,
         };
         match FileWatcher::new(&project_root, watch_config) {
             Ok(watcher) => {

--- a/crates/quarto-hub/src/watch.rs
+++ b/crates/quarto-hub/src/watch.rs
@@ -73,6 +73,22 @@ pub struct WatchConfig {
     /// observing or surfacing sibling-file edits. The path must be
     /// absolute / canonicalized to match the events `notify` produces.
     pub single_file: Option<PathBuf>,
+
+    /// Single-file mode (bd-9cyza5vy): the deck's *other* synced
+    /// dependency files — included `.qmd`, referenced images, a sibling
+    /// `_brand.yml` — as absolute paths. Only meaningful when
+    /// [`single_file`](Self::single_file) is `Some`.
+    ///
+    /// The watcher subscribes to each of these (in addition to the deck)
+    /// and accepts their events, so editing an included file or a
+    /// referenced image re-renders the preview — matching project mode's
+    /// dir-watch for the deck's closure. Crucially it does **not** widen
+    /// the watch to the whole directory: only the resolved closure is
+    /// watched, so an unrelated sibling (the `bd-tnm3k` concern) still
+    /// never surfaces. Built the same way as `single_file`
+    /// (`project_root.join(rel)`) so paths match the events `notify`
+    /// echoes back.
+    pub single_file_deps: Vec<PathBuf>,
 }
 
 impl Default for WatchConfig {
@@ -81,6 +97,7 @@ impl Default for WatchConfig {
             debounce_ms: DEFAULT_DEBOUNCE_MS,
             filter: WatchFilter::default(),
             single_file: None,
+            single_file_deps: Vec::new(),
         }
     }
 }
@@ -92,6 +109,7 @@ impl WatchConfig {
             debounce_ms: DEFAULT_DEBOUNCE_MS,
             filter,
             single_file: None,
+            single_file_deps: Vec::new(),
         }
     }
 }
@@ -117,11 +135,21 @@ impl FileWatcher {
         let project_root = project_root.to_path_buf();
         let filter = config.filter;
         let single_file = config.single_file.clone();
+        let single_file_deps = config.single_file_deps.clone();
 
-        // Pre-compute the closure's matcher so we don't capture
-        // `single_file` twice (once for the subscribe call below and
-        // once in the event-acceptance test).
-        let event_single_file = single_file.clone();
+        // In single-file mode, the watcher's allow-list is the deck plus its
+        // resolved dependency closure (bd-tnm3k + bd-9cyza5vy). An event
+        // surfaces only if its path is in this set, so `notify` directory-level
+        // events and unrelated siblings are both dropped. `None` ⇒ project mode
+        // (recursive walk, no allow-list).
+        let allowed: Option<std::collections::HashSet<PathBuf>> =
+            single_file.as_ref().map(|deck| {
+                let mut set = std::collections::HashSet::with_capacity(1 + single_file_deps.len());
+                set.insert(deck.clone());
+                set.extend(single_file_deps.iter().cloned());
+                set
+            });
+        let event_allowed = allowed.clone();
 
         // Create a debounced watcher
         let mut debouncer = new_debouncer(
@@ -130,13 +158,13 @@ impl FileWatcher {
                 match res {
                     Ok(events) => {
                         for event in events {
-                            // bd-tnm3k: in single-file mode, drop any
-                            // event whose path isn't the target file.
-                            // `notify` may report directory-level
-                            // events on some platforms even when only
-                            // a single file is watched.
-                            if let Some(ref target) = event_single_file
-                                && event.path != *target
+                            // bd-tnm3k / bd-9cyza5vy: in single-file mode, drop
+                            // any event whose path isn't in the deck's closure
+                            // allow-list. `notify` may report directory-level
+                            // events on some platforms even when only specific
+                            // files are watched.
+                            if let Some(ref allow) = event_allowed
+                                && !allow.contains(&event.path)
                             {
                                 continue;
                             }
@@ -158,23 +186,43 @@ impl FileWatcher {
         )
         .map_err(|e| Error::Sync(format!("failed to create filesystem watcher: {}", e)))?;
 
-        // bd-tnm3k: single-file mode subscribes to the file itself in
-        // NonRecursive mode. Project mode keeps the recursive walk of
-        // `project_root`.
-        let (subscribe_path, mode) = match single_file.as_deref() {
-            Some(file) => (file, RecursiveMode::NonRecursive),
-            None => (project_root.as_path(), RecursiveMode::Recursive),
-        };
-        debouncer
-            .watcher()
-            .watch(subscribe_path, mode)
-            .map_err(|e| Error::Sync(format!("failed to watch project root: {}", e)))?;
+        // bd-tnm3k / bd-9cyza5vy: single-file mode subscribes to the deck and
+        // each closure dependency individually (NonRecursive) — so a dep in a
+        // subdirectory is seen without widening the watch to the whole
+        // directory. Project mode keeps the recursive walk of `project_root`.
+        match single_file.as_deref() {
+            Some(deck) => {
+                // The deck is required: a failure here is fatal.
+                debouncer
+                    .watcher()
+                    .watch(deck, RecursiveMode::NonRecursive)
+                    .map_err(|e| Error::Sync(format!("failed to watch single file: {}", e)))?;
+                // Dependencies are best-effort: a missing/edge-case dep must not
+                // tank the whole watcher (the deck still re-renders on edit).
+                for dep in &single_file_deps {
+                    if let Err(e) = debouncer.watcher().watch(dep, RecursiveMode::NonRecursive) {
+                        warn!(
+                            path = %dep.display(),
+                            error = %e,
+                            "failed to watch single-file dependency; edits to it won't refresh the preview"
+                        );
+                    }
+                }
+            }
+            None => {
+                debouncer
+                    .watcher()
+                    .watch(project_root.as_path(), RecursiveMode::Recursive)
+                    .map_err(|e| Error::Sync(format!("failed to watch project root: {}", e)))?;
+            }
+        }
 
         info!(
             path = %project_root.display(),
             debounce_ms = config.debounce_ms,
             filter = ?filter,
             single_file = ?single_file,
+            single_file_dep_count = single_file_deps.len(),
             "Started filesystem watcher"
         );
 
@@ -353,6 +401,7 @@ mod tests {
                 debounce_ms: 100,
                 filter: WatchFilter::QmdOnly,
                 single_file: None,
+                single_file_deps: Vec::new(),
             },
         )
         .unwrap();
@@ -392,6 +441,7 @@ mod tests {
                 debounce_ms: 100,
                 filter: WatchFilter::QmdOnly,
                 single_file: None,
+                single_file_deps: Vec::new(),
             },
         )
         .unwrap();
@@ -434,6 +484,7 @@ mod tests {
                 debounce_ms: 100,
                 filter: WatchFilter::PreviewBroad,
                 single_file: None,
+                single_file_deps: Vec::new(),
             },
         )
         .unwrap();
@@ -468,6 +519,7 @@ mod tests {
                 debounce_ms: 100,
                 filter: WatchFilter::QmdOnly,
                 single_file: None,
+                single_file_deps: Vec::new(),
             },
         )
         .unwrap();
@@ -507,6 +559,7 @@ mod tests {
                 debounce_ms: 100,
                 filter: WatchFilter::PreviewBroad,
                 single_file: Some(target.clone()),
+                single_file_deps: Vec::new(),
             },
         )
         .unwrap();
@@ -521,6 +574,50 @@ mod tests {
             Ok(Some(WatchEvent::Modified(path))) => assert_eq!(path, target),
             Ok(None) => panic!("Watcher stopped unexpectedly"),
             Err(_) => panic!("Timeout waiting for target.qmd change event"),
+        }
+    }
+
+    /// bd-9cyza5vy: an edit to a file in the deck's resolved closure (here an
+    /// included `.qmd`) must surface so the preview re-renders — while an
+    /// unrelated sibling still must NOT (the bd-tnm3k safety property is
+    /// preserved: only the closure is watched, not the whole directory).
+    #[tokio::test]
+    async fn test_watcher_single_file_watches_closure_dep() {
+        let temp = TempDir::new().unwrap();
+        let temp_path = temp.path().canonicalize().unwrap();
+        let deck = temp_path.join("main.qmd");
+        let dep = temp_path.join("part.qmd");
+        let unrelated = temp_path.join("unrelated.qmd");
+
+        std::fs::write(&deck, "{{< include part.qmd >}}\n").unwrap();
+        std::fs::write(&dep, "initial").unwrap();
+        std::fs::write(&unrelated, "initial").unwrap();
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let mut watcher = FileWatcher::new(
+            &temp_path,
+            WatchConfig {
+                debounce_ms: 100,
+                filter: WatchFilter::PreviewBroad,
+                single_file: Some(deck.clone()),
+                single_file_deps: vec![dep.clone()],
+            },
+        )
+        .unwrap();
+
+        // Edit the unrelated sibling first (must be filtered out)...
+        std::fs::write(&unrelated, "edited unrelated").unwrap();
+        // ...then the included dep (must surface).
+        std::fs::write(&dep, "edited dep").unwrap();
+
+        let event = tokio::time::timeout(Duration::from_secs(2), watcher.recv()).await;
+        match event {
+            Ok(Some(WatchEvent::Modified(path))) => assert_eq!(
+                path, dep,
+                "expected the included dep edit to surface, got {path:?}"
+            ),
+            Ok(None) => panic!("Watcher stopped unexpectedly"),
+            Err(_) => panic!("Timeout waiting for included-dep change event"),
         }
     }
 }

--- a/crates/quarto-hub/tests/auth_bearer.rs
+++ b/crates/quarto-hub/tests/auth_bearer.rs
@@ -362,6 +362,7 @@ impl TestHub {
             single_file: None,
             resource_files: Vec::new(),
             single_file_assets: Vec::new(),
+            single_file_text_deps: Vec::new(),
             auth_config: Some(auth_config),
             allow_insecure_auth: true,
             register_root_ws: false,
@@ -483,6 +484,7 @@ async fn allowlist_setup() -> &'static (MockOidcProvider, TestHub) {
                 single_file: None,
                 resource_files: Vec::new(),
                 single_file_assets: Vec::new(),
+                single_file_text_deps: Vec::new(),
                 auth_config: Some(auth_config),
                 allow_insecure_auth: true,
                 register_root_ws: false,
@@ -948,6 +950,7 @@ async fn secure_setup() -> &'static (MockOidcProvider, TestHub) {
                 single_file: None,
                 resource_files: Vec::new(),
                 single_file_assets: Vec::new(),
+                single_file_text_deps: Vec::new(),
                 auth_config: Some(auth_config),
                 allow_insecure_auth: false, // <-- the key difference
                 register_root_ws: false,

--- a/crates/quarto-preview/src/config.rs
+++ b/crates/quarto-preview/src/config.rs
@@ -214,56 +214,135 @@ pub fn resolve_project_resource_files(
         .collect()
 }
 
-/// Resolve the on-disk sibling **assets** a single-file deck references, so
-/// `q2 preview deck.qmd` (no `_quarto.yml` ancestor) can sync exactly those
-/// into the preview VFS — without walking the deck's directory, which the
-/// `bd-tnm3k` safety property forbids (bd-kpuweafo).
+/// The transitive static dependency closure of a single-file deck — the
+/// sibling files `q2 preview deck.qmd` must sync into the preview VFS so the
+/// deck renders like `q2 render` / project-mode preview, without walking the
+/// deck's directory (the `bd-tnm3k` safety property). Supersedes the earlier
+/// direct-image-only resolution (bd-kpuweafo): the closure now also includes
+/// `{{< include >}}`d `.qmd` files (transitively) and the images referenced
+/// *inside* them.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct SingleFileDeps {
+    /// Included `.qmd` files (project-root-relative). Synced as **text**, kept
+    /// out of `qmd_files` so they are invisible VFS-only dependencies.
+    pub qmd_files: Vec<std::path::PathBuf>,
+    /// Referenced image assets (project-root-relative). Synced as **binary**.
+    pub binary_files: Vec<std::path::PathBuf>,
+}
+
+/// Resolve a single-file deck's full transitive static dependency closure
+/// (bd-9cyza5vy) by running the renderer's **own** `ParseDocumentStage` +
+/// `IncludeExpansionStage` natively against the real filesystem, then reading
+/// back the files the renderer actually consumed.
 ///
-/// Parses the deck, collects the relative `Image` URLs it references
-/// (`quarto_core::transforms::collect_referenced_asset_urls`), and keeps the
-/// ones that (a) are binary assets (`is_binary_extension`), (b) resolve to an
-/// existing file, and (c) stay **under** `project_root` once canonicalized (no
-/// `../` escape). Returns project-root-relative paths matching the form
-/// `ProjectFiles::discover` produces in project mode, so the same reconcile +
-/// VFS sync + asset-manifest path applies and the image resolves identically.
+/// Reusing the real stages (rather than re-deriving include resolution in a
+/// parallel walker) keeps the preview's path-resolution semantics in exact
+/// lock-step with render — including the un-retargeted image anchor *and* the
+/// nested-include anchor (a latent render bug, bd-udrn0q47, which this resolver
+/// will track automatically once it is fixed). See
+/// `claude-notes/research/2026-06-16-include-shortcode-path-resolution.md`.
+///
+/// - **Includes** come from `DocumentAst::recorded_includes` — the exact set of
+///   files the stage spliced, transitively, with the stage's own cycle
+///   detection. Each is canonical-absolute; we re-express it project-root-
+///   relative and drop anything that escapes the deck dir.
+/// - **Images** come from `collect_referenced_asset_urls` over the *expanded*
+///   AST, resolved relative to the **deck dir** (the same anchor
+///   `ResourceCollectorTransform` uses — render parity for free).
 ///
 /// `single_file_rel` is the deck path relative to `project_root` (its parent
 /// directory in single-file mode). On any parse / IO error this returns an
-/// empty vec — a missing asset just renders broken, exactly as before.
-pub fn resolve_single_file_assets(
+/// empty closure — a missing dependency just renders broken, exactly as before.
+pub fn resolve_single_file_deps(
     project_root: &std::path::Path,
     single_file_rel: &std::path::Path,
-    runtime: &dyn SystemRuntime,
-) -> Vec<std::path::PathBuf> {
+    runtime: std::sync::Arc<dyn SystemRuntime>,
+) -> SingleFileDeps {
     use std::path::{Path, PathBuf};
+
+    use quarto_core::project::{DocumentInfo, ProjectContext};
+    use quarto_core::stage::{
+        IncludeExpansionStage, LoadedSource, ParseDocumentStage, PipelineData, PipelineStage,
+        StageContext,
+    };
 
     let abs_deck = project_root.join(single_file_rel);
     let Ok(source) = runtime.file_read(&abs_deck) else {
-        return Vec::new();
+        return SingleFileDeps::default();
     };
 
-    // Parse for asset references only; commentary + source spans are unneeded
-    // (mirrors `deps::extract_include_deps`).
-    let mut sink = std::io::sink();
-    let Ok((pandoc, _ctx, _warnings)) = pampa::readers::qmd::read(
-        &source,
-        false, // loose
-        &single_file_rel.to_string_lossy(),
-        &mut sink,
-        false, // track_source_locations
-        None,  // parent SourceInfo
+    // Build a single-file render context and run the renderer's OWN parse +
+    // include-expansion stages natively. Reusing the real stages keeps path
+    // resolution identical to `q2 render` (see the module + research notes).
+    let Ok(project) = ProjectContext::single_file(&abs_deck, runtime.as_ref()) else {
+        return SingleFileDeps::default();
+    };
+    let document = DocumentInfo::from_path(&abs_deck);
+    let Ok(mut ctx) = StageContext::new(
+        runtime.clone(),
+        quarto_core::Format::html(),
+        project,
+        document,
     ) else {
-        return Vec::new();
+        return SingleFileDeps::default();
     };
 
-    let deck_dir = single_file_rel.parent().unwrap_or_else(|| Path::new(""));
+    // The stage `run` futures are `?Send`; drive them on this thread without a
+    // tokio runtime (the same pattern `quarto-preview` uses elsewhere). Include
+    // expansion reads included files through `ctx.runtime` (the native FS).
+    let parse = ParseDocumentStage;
+    let expand = IncludeExpansionStage::new();
+    let expanded = pollster::block_on(async {
+        let parsed = parse
+            .run(
+                PipelineData::LoadedSource(LoadedSource::new(abs_deck.clone(), source)),
+                &mut ctx,
+            )
+            .await?;
+        expand.run(parsed, &mut ctx).await
+    });
+    let Ok(PipelineData::DocumentAst(doc)) = expanded else {
+        return SingleFileDeps::default();
+    };
+
     let canonical_root = project_root
         .canonicalize()
         .unwrap_or_else(|_| project_root.to_path_buf());
 
-    let mut out: Vec<PathBuf> = Vec::new();
-    let mut seen = std::collections::HashSet::new();
-    for url in quarto_core::transforms::collect_referenced_asset_urls(&pandoc.blocks) {
+    // Re-express a canonical absolute path as project-root-relative, keeping
+    // only existing files that stay under the deck dir (no `../` escape).
+    let to_in_tree_rel = |canon: PathBuf| -> Option<PathBuf> {
+        if !canon.is_file() || !canon.starts_with(&canonical_root) {
+            return None;
+        }
+        canon
+            .strip_prefix(&canonical_root)
+            .ok()
+            .map(Path::to_path_buf)
+    };
+
+    // Text deps: the `.qmd` files the stage actually spliced (transitive,
+    // cycle-truncated). `IncludeEntry::path` is canonical-absolute.
+    let mut qmd_files: Vec<PathBuf> = Vec::new();
+    let mut seen_qmd = std::collections::HashSet::new();
+    for entry in &doc.recorded_includes {
+        let Ok(canon) = entry.path.canonicalize() else {
+            continue;
+        };
+        if let Some(rel) = to_in_tree_rel(canon)
+            && seen_qmd.insert(rel.clone())
+        {
+            qmd_files.push(rel);
+        }
+    }
+
+    // Binary deps: images referenced by the EXPANDED AST, resolved relative to
+    // the deck dir (matches `ResourceCollectorTransform`'s anchor — render
+    // parity, including images that came from included files).
+    let deck_dir = single_file_rel.parent().unwrap_or_else(|| Path::new(""));
+    let mut binary_files: Vec<PathBuf> = Vec::new();
+    let mut seen_bin = std::collections::HashSet::new();
+    for url in quarto_core::transforms::collect_referenced_asset_urls(&doc.ast.blocks) {
         let ext = Path::new(&url)
             .extension()
             .and_then(|e| e.to_str())
@@ -271,24 +350,22 @@ pub fn resolve_single_file_assets(
         if !quarto_hub::resource::is_binary_extension(ext) {
             continue;
         }
-        let abs = project_root.join(deck_dir).join(&url);
-        let Ok(canon) = abs.canonicalize() else {
-            continue; // missing file → nothing to sync (renders broken, as before)
+        let Ok(canon) = project_root.join(deck_dir).join(&url).canonicalize() else {
+            continue;
         };
-        if !canon.is_file() || !canon.starts_with(&canonical_root) {
-            continue; // directories and `../` escapes are out of scope
-        }
-        // Re-express as a project-root-relative path (normalizes `./`), matching
-        // the form `ProjectFiles::discover` yields in project mode.
-        let rel = match canon.strip_prefix(&canonical_root) {
-            Ok(r) => r.to_path_buf(),
-            Err(_) => continue,
-        };
-        if seen.insert(rel.clone()) {
-            out.push(rel);
+        if let Some(rel) = to_in_tree_rel(canon)
+            && seen_bin.insert(rel.clone())
+        {
+            binary_files.push(rel);
         }
     }
-    out
+
+    qmd_files.sort();
+    binary_files.sort();
+    SingleFileDeps {
+        qmd_files,
+        binary_files,
+    }
 }
 
 #[cfg(test)]
@@ -303,60 +380,159 @@ mod tests {
         ConfigValue::from_path(&["preview", "engine"], value)
     }
 
+    // ── resolve_single_file_deps (bd-9cyza5vy) ──────────────────────
+
+    use std::sync::Arc;
+
+    fn native_arc() -> Arc<dyn SystemRuntime> {
+        Arc::new(NativeRuntime::new())
+    }
+
+    /// An image referenced *inside* an included file is part of the closure —
+    /// the include `.qmd` is a text dep, the image is a binary dep. (This is
+    /// the exact gap the strand reported: in single-file preview, includes and
+    /// their images both used to be missing.)
     #[test]
-    fn single_file_assets_resolves_referenced_image_siblings_only() {
-        // bd-kpuweafo: a single-file deck referencing `./sibling.png` should
-        // resolve that one sibling — not a missing one, not an external URL,
-        // and (safety) nothing outside the deck's directory.
+    fn single_file_deps_include_and_image_inside_include() {
         let temp = TempDir::new().unwrap();
         let root = temp.path();
-        std::fs::write(root.join("sibling.png"), b"\x89PNG\r\n").unwrap();
-        std::fs::write(root.join("unused.png"), b"\x89PNG\r\n").unwrap();
-        std::fs::create_dir(root.join("sub")).unwrap();
-        std::fs::write(root.join("sub/nested.svg"), b"<svg/>").unwrap();
+        std::fs::write(root.join("inc.png"), b"\x89PNG\r\n").unwrap();
         std::fs::write(
-            root.join("deck.qmd"),
-            "---\ntitle: T\n---\n\n\
-             ![ok](./sibling.png)\n\n\
-             - ![nested](sub/nested.svg)\n\n\
-             ![missing](./missing.png)\n\n\
-             ![remote](https://example.com/r.png)\n",
+            root.join("part.qmd"),
+            "## Included Section\n\n![](inc.png)\n",
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("main.qmd"),
+            "---\ntitle: T\n---\n\n{{< include part.qmd >}}\n",
         )
         .unwrap();
 
-        let runtime = NativeRuntime::new();
-        let mut assets =
-            resolve_single_file_assets(root, std::path::Path::new("deck.qmd"), &runtime);
-        assets.sort();
+        let deps = resolve_single_file_deps(root, std::path::Path::new("main.qmd"), native_arc());
         assert_eq!(
-            assets,
-            vec![
-                std::path::PathBuf::from("sibling.png"),
-                std::path::PathBuf::from("sub/nested.svg"),
-            ],
-            "only existing, relative, in-tree image siblings; missing + external dropped; \
-             `unused.png` (not referenced) not synced"
+            deps,
+            SingleFileDeps {
+                qmd_files: vec![std::path::PathBuf::from("part.qmd")],
+                binary_files: vec![std::path::PathBuf::from("inc.png")],
+            }
         );
     }
 
+    /// Includes are followed transitively: `main → a → b`, and an image in `b`
+    /// is collected. All three deps (a.qmd, b.qmd, the image) appear.
     #[test]
-    fn single_file_assets_rejects_parent_escape() {
-        // `![](../secret.png)` must NOT be synced even if the file exists —
-        // it's outside the deck's directory (canonicalized-under-root guard).
+    fn single_file_deps_transitive_includes_and_images() {
         let temp = TempDir::new().unwrap();
         let root = temp.path();
+        std::fs::write(root.join("c.png"), b"\x89PNG\r\n").unwrap();
+        std::fs::write(root.join("b.qmd"), "From B\n\n![](c.png)\n").unwrap();
+        std::fs::write(root.join("a.qmd"), "From A\n\n{{< include b.qmd >}}\n").unwrap();
+        std::fs::write(root.join("main.qmd"), "{{< include a.qmd >}}\n").unwrap();
+
+        let mut deps =
+            resolve_single_file_deps(root, std::path::Path::new("main.qmd"), native_arc());
+        deps.qmd_files.sort();
+        assert_eq!(
+            deps,
+            SingleFileDeps {
+                qmd_files: vec![
+                    std::path::PathBuf::from("a.qmd"),
+                    std::path::PathBuf::from("b.qmd"),
+                ],
+                binary_files: vec![std::path::PathBuf::from("c.png")],
+            }
+        );
+    }
+
+    /// Render parity: an image written inside a *subdirectory* include resolves
+    /// relative to the **deck dir**, not the include's dir (the "no
+    /// retargeting" design — see the research note). Here `img.png` exists at
+    /// BOTH the deck root and `sub/`; the closure must pick the **root** one.
+    #[test]
+    fn single_file_deps_image_in_subdir_include_anchored_at_deck_dir() {
+        let temp = TempDir::new().unwrap();
+        let root = temp.path();
+        std::fs::create_dir(root.join("sub")).unwrap();
+        std::fs::write(root.join("img.png"), b"ROOT").unwrap();
+        std::fs::write(root.join("sub/img.png"), b"SUB").unwrap();
+        std::fs::write(root.join("sub/part.qmd"), "Part\n\n![](img.png)\n").unwrap();
+        std::fs::write(root.join("main.qmd"), "{{< include sub/part.qmd >}}\n").unwrap();
+
+        let deps = resolve_single_file_deps(root, std::path::Path::new("main.qmd"), native_arc());
+        assert_eq!(
+            deps.binary_files,
+            vec![std::path::PathBuf::from("img.png")],
+            "image inside a subdir include must resolve to the DECK dir (img.png), \
+             not the include's dir (sub/img.png) — render parity / no retargeting"
+        );
+        assert_eq!(
+            deps.qmd_files,
+            vec![std::path::PathBuf::from("sub/part.qmd")]
+        );
+    }
+
+    /// A self-referential include terminates (the stage's own cycle detection)
+    /// and records the included file exactly once.
+    #[test]
+    fn single_file_deps_cycle_terminates() {
+        let temp = TempDir::new().unwrap();
+        let root = temp.path();
+        // a.qmd includes itself.
+        std::fs::write(root.join("a.qmd"), "From A\n\n{{< include a.qmd >}}\n").unwrap();
+        std::fs::write(root.join("main.qmd"), "{{< include a.qmd >}}\n").unwrap();
+
+        let deps = resolve_single_file_deps(root, std::path::Path::new("main.qmd"), native_arc());
+        assert_eq!(deps.qmd_files, vec![std::path::PathBuf::from("a.qmd")]);
+        assert!(deps.binary_files.is_empty());
+    }
+
+    /// The under-deck-dir guard drops `../` escapes (both include and image),
+    /// missing files, and external URLs — nothing outside the deck dir is
+    /// synced even if it exists.
+    #[test]
+    fn single_file_deps_guard_drops_escapes_missing_and_external() {
+        let temp = TempDir::new().unwrap();
+        let root = temp.path();
+        // Real files OUTSIDE the deck dir that must NOT be pulled in.
         std::fs::write(root.join("secret.png"), b"\x89PNG\r\n").unwrap();
+        std::fs::write(root.join("escape.qmd"), "secret include\n").unwrap();
         let deck_dir = root.join("deck");
         std::fs::create_dir(&deck_dir).unwrap();
-        std::fs::write(deck_dir.join("deck.qmd"), "![x](../secret.png)\n").unwrap();
+        std::fs::write(
+            deck_dir.join("main.qmd"),
+            "{{< include ../escape.qmd >}}\n\n\
+             ![a](../secret.png)\n\n\
+             ![b](./missing.png)\n\n\
+             ![c](https://example.com/r.png)\n",
+        )
+        .unwrap();
 
-        let runtime = NativeRuntime::new();
-        // project_root is the deck's dir in single-file mode.
-        let assets =
-            resolve_single_file_assets(&deck_dir, std::path::Path::new("deck.qmd"), &runtime);
-        assert!(
-            assets.is_empty(),
-            "a `../` reference escaping the deck directory must not be synced; got {assets:?}"
+        // project_root is the deck's own dir in single-file mode.
+        let deps =
+            resolve_single_file_deps(&deck_dir, std::path::Path::new("main.qmd"), native_arc());
+        assert_eq!(
+            deps,
+            SingleFileDeps::default(),
+            "escapes, missing, and external refs are all dropped; got {deps:?}"
+        );
+    }
+
+    /// The deck's own direct image (no include involved) is still collected —
+    /// `resolve_single_file_deps` is a superset of the old direct-image path.
+    #[test]
+    fn single_file_deps_collects_deck_own_direct_image() {
+        let temp = TempDir::new().unwrap();
+        let root = temp.path();
+        std::fs::write(root.join("logo.png"), b"\x89PNG\r\n").unwrap();
+        std::fs::write(root.join("deck.qmd"), "![ok](logo.png)\n").unwrap();
+
+        let deps = resolve_single_file_deps(root, std::path::Path::new("deck.qmd"), native_arc());
+        assert_eq!(
+            deps,
+            SingleFileDeps {
+                qmd_files: vec![],
+                binary_files: vec![std::path::PathBuf::from("logo.png")],
+            }
         );
     }
 

--- a/crates/quarto-preview/src/lib.rs
+++ b/crates/quarto-preview/src/lib.rs
@@ -295,6 +295,22 @@ fn build_storage(config: &PreviewConfig) -> Result<StorageManager> {
 }
 
 fn build_hub_config(config: &PreviewConfig) -> HubConfig {
+    // bd-9cyza5vy: in single-file mode (no `_quarto.yml`), the deck's
+    // transitive dependencies aren't found by a dir walk. Resolve the full
+    // closure once — included `.qmd` (text) + referenced images (binary) — by
+    // running the renderer's own include-expansion natively (quarto-preview has
+    // the qmd parser + quarto-core). Supersedes the old direct-image-only
+    // `resolve_single_file_assets`.
+    let single_file_deps = match (
+        config.project_root.as_deref(),
+        config.single_file.as_deref(),
+    ) {
+        (Some(root), Some(rel)) => {
+            config::resolve_single_file_deps(root, rel, std::sync::Arc::new(NativeRuntime::new()))
+        }
+        _ => config::SingleFileDeps::default(),
+    };
+
     HubConfig {
         port: config.port,
         host: config.host.clone(),
@@ -314,19 +330,13 @@ fn build_hub_config(config: &PreviewConfig) -> HubConfig {
         // resolved at session start, carried into the VFS as text so the
         // preview iframe post-processor can inline them via `srcdoc`.
         resource_files: config.resource_html_files.clone(),
-        // bd-kpuweafo: in single-file mode (no `_quarto.yml`), the deck's
-        // sibling images aren't discovered by the dir walk. Parse the deck and
-        // resolve exactly the assets it references so they sync into the VFS
-        // like project mode (resolved here — quarto-preview has the qmd parser).
-        single_file_assets: match (
-            config.project_root.as_deref(),
-            config.single_file.as_deref(),
-        ) {
-            (Some(root), Some(rel)) => {
-                config::resolve_single_file_assets(root, rel, &NativeRuntime::new())
-            }
-            _ => Vec::new(),
-        },
+        // bd-kpuweafo / bd-9cyza5vy: sibling images the deck references —
+        // including images inside `{{< include >}}`d files — sync into the VFS
+        // like project mode (resolved above via the real expansion pass).
+        single_file_assets: single_file_deps.binary_files,
+        // bd-9cyza5vy: the deck's transitive `{{< include >}}` closure, synced
+        // as invisible text deps so includes expand in the WASM pipeline.
+        single_file_text_deps: single_file_deps.qmd_files,
         // Light periodic sync — the user can Ctrl-C any time, and
         // shutdown does a final sync anyway. 5 seconds is a reasonable
         // crash-resilience window for a *preview* invocation.

--- a/crates/quarto-yaml-validation/src/validator.rs
+++ b/crates/quarto-yaml-validation/src/validator.rs
@@ -612,9 +612,10 @@ fn validate_object(
             // message the user would have seen had it been present with a bad
             // value: enum values for an enum subschema, otherwise the type(s).
             let (allowed, expected_type) = match schema.properties.get(required) {
-                Some(Schema::Enum(e)) if !e.values.is_empty() => {
-                    (Some(e.values.iter().map(|v| format!("{}", v)).collect()), None)
-                }
+                Some(Schema::Enum(e)) if !e.values.is_empty() => (
+                    Some(e.values.iter().map(|v| format!("{}", v)).collect()),
+                    None,
+                ),
                 Some(prop) => (None, expected_type_description(prop)),
                 None => (None, None),
             };
@@ -730,11 +731,7 @@ fn expected_type_description(schema: &Schema) -> Option<String> {
                 Some(names.join(" or "))
             }
         }
-        Schema::Enum(_)
-        | Schema::AllOf(_)
-        | Schema::Any(_)
-        | Schema::True
-        | Schema::Ref(_) => None,
+        Schema::Enum(_) | Schema::AllOf(_) | Schema::Any(_) | Schema::True | Schema::Ref(_) => None,
     }
 }
 
@@ -903,7 +900,9 @@ mod tests {
             })
         };
 
-        for text in [".inf", "+.inf", "-.inf", ".Inf", ".INF", ".nan", ".NaN", ".NAN"] {
+        for text in [
+            ".inf", "+.inf", "-.inf", ".Inf", ".INF", ".nan", ".NaN", ".NAN",
+        ] {
             let yaml = quarto_yaml::parse(text).unwrap();
             assert!(
                 validate(&yaml, &number_schema(), &registry, &source_ctx).is_ok(),
@@ -1510,15 +1509,16 @@ mod tests {
                 assert_eq!(property, "version");
                 // Enum values render via `format!("{}", json)`, so strings keep
                 // their quotes — matching the `InvalidEnumValue` rendering.
-                assert_eq!(allowed.as_deref(), Some(["\"0.1.0\"".to_string()].as_slice()));
+                assert_eq!(
+                    allowed.as_deref(),
+                    Some(["\"0.1.0\"".to_string()].as_slice())
+                );
                 assert_eq!(*expected_type, None);
             }
             other => panic!("expected MissingRequiredProperty, got {:?}", other),
         }
         assert!(
-            err.kind
-                .message()
-                .contains("must be one of: \"0.1.0\""),
+            err.kind.message().contains("must be one of: \"0.1.0\""),
             "message was: {}",
             err.kind.message()
         );

--- a/crates/quarto/src/commands/hub.rs
+++ b/crates/quarto/src/commands/hub.rs
@@ -145,6 +145,7 @@ async fn run_hub(args: HubArgs) -> Result<()> {
         resource_files: Vec::new(),
         // Single-file asset sync is a preview-only concern (bd-kpuweafo).
         single_file_assets: Vec::new(),
+        single_file_text_deps: Vec::new(),
         auth_config,
         allow_insecure_auth: args.allow_insecure_auth,
         // `quarto hub` keeps the sync.automerge.org-style `/` ws path


### PR DESCRIPTION
## What

Single-file `q2 preview deck.qmd` (no `_quarto.yml`) previously synced only the deck, a sibling `_brand.yml`, and the deck's *direct* images into the preview VFS. So `{{< include part.qmd >}}` rendered as a literal `?include` placeholder, and any image referenced *inside* an included file was missing — single-file preview diverged from both `q2 render` and project-mode preview.

This resolves the deck's **full transitive static dependency closure** natively — without walking the directory (preserving the bd-tnm3k safety property) — by running the renderer's **own** `ParseDocumentStage` + `IncludeExpansionStage` against the real filesystem and reading back what it consumed:

- includes from `DocumentAst::recorded_includes` (transitive, cycle-truncated)
- images from `collect_referenced_asset_urls` over the *expanded* AST, deck-dir-anchored — matching render's "no path retargeting" design

Reusing the real stages (rather than a parallel walker) keeps preview path resolution in exact lock-step with render, including a latent nested-include retargeting bug (filed separately as **bd-udrn0q47**), which preview now inherits automatically instead of hard-coding one side of a contested rule.

## Changes

- **quarto-preview** `config.rs`: `resolve_single_file_deps -> SingleFileDeps` (supersedes + deletes `resolve_single_file_assets`); `build_hub_config` makes one resolver call filling both channels.
- **quarto-hub** `discovery.rs` + `context.rs`: included `.qmd` ride a new **invisible** text path — `HubConfig.single_file_text_deps` → `ProjectFiles.text_dep_files` + `with_text_deps` (in `text_files()`/`all_files()`/counts, **not** `qmd_files`, mirroring `resource_files`). The single-file preview SPA has no file list, so included files stay VFS-only dependencies.
- **quarto-hub** `watch.rs` + `server.rs`: extend the single-file watch set to the resolved closure (`WatchConfig.single_file_deps`) so editing an included file or referenced image re-renders, while unrelated siblings still never surface (bd-tnm3k preserved).

## Tests

TDD throughout:
- 6 resolver tests: include + image-in-include, transitive, **deck-dir anchoring (render parity)**, cycle termination, under-root guard, deck-own direct image.
- discovery + context: invisible-text-dep invariants (synced as text, absent from `qmd_files`, in the index).
- watcher: closure dep surfaces while an unrelated sibling is ignored.
- `cargo xtask verify --skip-hub-build` passes (clippy `-D warnings` + full-workspace nextest). The fix is native-only; WASM/quarto-core unchanged.

## E2E

Browser inspection of `q2 preview main.qmd` (no `_quarto.yml`) where `main.qmd` includes `part.qmd` which references `inc-image.png`: the include **expands** ("Included Section" renders, no literal `?include`), and the image *inside the include* displays via a `blob:` URL (`naturalWidth 1`, the 1×1 PNG loaded).

## Notes

- Render-side bug **bd-udrn0q47** (nested-include path retargeting vs the documented "no retargeting" design) is filed but intentionally **not** addressed here — it's a separate render change this resolver will inherit.
- Design + research: `claude-notes/research/2026-06-16-include-shortcode-path-resolution.md`, `claude-notes/plans/2026-06-16-single-file-preview-transitive-deps.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)