### PR TITLE
revealjs preview↔render parity: footer/logo, section attrs, resources: VFS sync

### DIFF
--- a/claude-notes/plans/2026-06-17-revealjs-preview-render-parity-audit.md
+++ b/claude-notes/plans/2026-06-17-revealjs-preview-render-parity-audit.md
@@ -1,0 +1,211 @@
+# revealjs `q2 preview` ↔ `q2 render` parity audit
+
+**Created:** 2026-06-17
+**Epic:** bd-67yja58s (format: revealjs) · GA gate: bd-v053sk3s (Phase 1P)
+**Related strands:** bd-vv8jft5n (section-id + config parity), bd-qn8yi1su
+(automated golden parity test), bd-ocxnva1f (user Lua filters footer/logo)
+**Audit strand:** bd-zaa4m4bd
+**Footer/logo strand:** bd-n2w0sxgd (F3)
+
+## Overview
+
+`q2 preview`'s React `RevealDeck` (`ts-packages/preview-renderer/src/q2-preview/
+RevealDeck.tsx`) is supposed to produce the same DOM as `q2 render`'s native
+reveal scaffold (`crates/quarto-core/src/revealjs/assemble.rs`) for the same
+deck. This audit compares the two pipelines across `examples/presentations/*`
+and records every divergence so we can close them before the revealjs epic
+lands (the GA gate is bd-v053sk3s, "q2 preview shows an in-parity Tier-1
+slideshow").
+
+The investigation that seeded this plan compared `10-footer-logo` and
+`02-sections` empirically in Chrome (render served via `python -m http.server`
+over `slides.html`; preview via `q2 preview … --no-browser`), and cataloged the
+render-side `<section>` signatures for all 11 examples. Two divergence classes
+are **systemic** (every deck); one is **deck-chrome-specific** (only
+`10-footer-logo` today, but applies to any deck with `footer:`/`logo:`).
+
+## Findings
+
+### F1 — Section `id` dropped in preview (SYSTEMIC, partly tracked: bd-vv8jft5n)
+
+Render emits an `id` on every `<section>` (derived from heading text, or absent
+for `---`-only slides). Preview emits bare `<section>` with no `id`.
+
+| | render | preview |
+|---|---|---|
+| title slide | `<section id="title-slide" …>` | `<section …>` (no id) |
+| `## First topic` | `<section id="first-topic" …>` | `<section …>` (no id) |
+| `# Part One` stack | `<section id="part-one" class="section stack">` | `<section class="stack">` |
+
+**Impact:** breaks in-deck `#/id` deep links, cross-document anchors
+(`other.html#first-topic`), and any cross-reference whose target is a slide.
+bd-vv8jft5n already names this ("pass section ids onto `<Slide>`") but frames it
+as "minor" because hash-nav is off in preview — cross-doc anchors make it not
+minor.
+
+### F2 — Section semantic classes dropped in preview (SYSTEMIC, tracked: bd-vv8jft5n)
+
+Render puts `section` on every `<section>`, and `section title-slide center` on
+the title slide. Preview emits only the classes reveal.js itself adds at runtime
+(`present` / `future` / `stack`). The Quarto-authored classes are gone.
+
+| logical slide | render `class` | preview `class` |
+|---|---|---|
+| title slide | `section title-slide center present` | `present` |
+| content slide | `section future` | `future` |
+| section divider stack | `section stack present` | `stack present` |
+
+**Impact:**
+- `center` drives reveal's vertical centering of the **title slide** — its
+  absence visibly shifts the title-slide layout.
+- `title-slide` is a theme-CSS hook (Quarto reveal theme keys off it).
+- `section` is the generic slide-content hook.
+- Any author-supplied per-slide class (`## Slide {.smaller}`,
+  `{background-color="…"}`, etc.) rides the same `Attr` and is **also** dropped
+  — so F2 is broader than the three built-in classes; it is "the section `Attr`
+  is never forwarded onto `<Slide>`/`<Stack>` at all."
+
+F1 and F2 share one root cause and should be fixed together (likely folded into
+bd-vv8jft5n with its scope widened from "section-id" to "section `Attr`").
+
+### F3 — Deck-level footer / logo absent in preview (`10-footer-logo`, tracked: bd-n2w0sxgd)
+
+Render (`assemble.rs::render_revealjs_document`) places, as **direct children of
+`.reveal` outside `.slides`**:
+
+```html
+<div class="reveal has-logo">
+  <div class="slides"> … </div>
+  <img class="slide-logo" src="logo.svg">
+  <div class="footer footer-default">© 2026 … <a href="…">example.com</a></div>
+</div>
+```
+
+Preview emits none of these: no `.footer`, no `.slide-logo`, and `.reveal` lacks
+the `has-logo` class.
+
+**The data is already available to preview.** The reveal footer/logo render
+stage (`RevealFooterLogoTransform`, name `reveal-footer-logo`, selected by
+`pipeline.rs::footer_render_stage(is_revealjs=true)`) runs in the q2-preview
+pipeline — it is **not** in `Q2_PREVIEW_TRANSFORM_EXCLUDED` — so the preview's
+`ast.meta` carries `rendered.reveal.footer` and `rendered.reveal.logo`.
+`RevealDeck` simply never reads those slots, and the `<Deck>` wrapper never adds
+`has-logo` to `.reveal`. The fix is purely in `RevealDeck.tsx`: read the two
+meta slots and inject the markup outside `<Deck>`'s slides + add `has-logo`.
+
+**Impact:** decks with `footer:`/`logo:` show no footer and no logo in preview —
+a complete feature miss, not a style nudge. Tracked by **bd-n2w0sxgd**;
+`bd-ocxnva1f` covers *Lua filters* manipulating footer/logo, a different
+concern from this baseline "preview doesn't render them at all" gap.
+
+**Status (2026-06-17): DOM fixed.** `RevealDeck` now emits the chrome.
+`RevealChrome` reads `rendered.reveal.{footer,logo}` and injects the markup into
+the `.reveal` element (outside `.slides`) via `useReveal()` →
+`getRevealElement()`, plus `has-logo`. Verified in Chrome on `10-footer-logo`:
+`.reveal.has-logo`, `img.slide-logo` + `.footer.footer-default` are direct
+children of `.reveal`, not in `.slides`, footer link preserved. Tests:
+`RevealDeck.integration.test.tsx` (7 cases). **Caveat → F4.**
+
+### F4 — Preview reveal theme omits the Quarto chrome CSS layer (discovered via F3, tracked: bd-d0f9xoa6)
+
+With F3's DOM in place, the footer/logo render **unstyled** (`position: static`)
+because the preview's runtime-delivered theme (`<link data-q2-theme>` blob, 1784
+rules) does **not** contain `.reveal .footer` / `.reveal .slide-logo`. Render
+positions them `fixed` via rules in the per-doc `theme-<fp>.css` (compiled from
+`resources/scss/revealjs/quarto-revealjs.scss`); the preview theme is missing
+that chrome layer. This is a theme-**content** parity gap (sibling of the
+theme-delivery work bd-y259zb57), independent of the DOM fix — fixing it likely
+means either compiling the same SCSS partials into the preview theme or moving
+the theme-independent chrome rules into the statically-imported
+`resources/revealjs/quarto-reveal.css`.
+
+## Root cause (F1 + F2)
+
+`RevealDeck.tsx` maps each section `Div` onto `@revealjs/react`'s
+`<Slide>` / `<Stack>` but passes only the Div's **children** (`div.c[1]`). The
+Div's `Attr` (`div.c[0]` = `[id, classes, kvs]`) is read **only** to flip the
+incremental scope (`SlideBody` inspects `sectionClasses` for
+`incremental`/`nonincremental`); it is never emitted onto the `<section>`.
+`@revealjs/react`'s `<Slide>`/`<Stack>` accept `id`/`className` props (they pass
+through to the rendered `<section>`), so the fix is to forward them. The native
+contract is `assemble.rs` (and the `RevealSlidesTransform` that produced the
+`Div(.section)` tree shared by both paths).
+
+## Render-side catalog (all 11 examples)
+
+Every example renders `id` + `section` class on every `<section>`; title slides
+get `section title-slide center`. Only `10` carries deck chrome. Feature markup
+present per example (candidates for feature-specific preview divergence still to
+verify):
+
+| example | special markup to verify in preview |
+|---|---|
+| 01-creating-slides | title slide (`center`) |
+| 02-sections | vertical `stack`s ✅ compared |
+| 03-fragments | `.fragment` spans + `fragment-index` |
+| 04-incremental-lists | incremental lists → `.fragment` |
+| 05-columns | `.columns`/`.column` flex layout |
+| 06-speaker-notes | `.notes` (does preview load the Notes plugin?) |
+| 07-asides | `.aside` |
+| 08-footnotes | per-slide footnote coalescing + `.aside` |
+| 09-themes | `theme:` selection (theme parity in_progress: bd-y259zb57) |
+| 10-footer-logo | footer + logo + `has-logo` ✅ compared (F3) |
+| 11-auto-stretch | `.r-stretch` auto-stretch |
+
+## Work items
+
+### Phase A — fix the two systemic + one chrome divergence (TDD per /preview-parity)
+
+- [ ] **F1+F2: forward section `Attr` onto `<Slide>`/`<Stack>`** (extend
+  bd-vv8jft5n; widen scope from "section-id" to "section `Attr`: id + classes +
+  kvs"). Failing test first in
+  `ts-packages/preview-renderer/src/q2-preview/q2-preview.integration.test.tsx`:
+  mount a deck AST, assert `<section id="…" class="section …">`. Mirror
+  `assemble.rs`. Verify in Chrome on `01`/`02`/`10`.
+- [x] **F3: render deck footer/logo + `has-logo` in `RevealDeck`** (bd-n2w0sxgd).
+  DONE 2026-06-17 — `RevealChrome` + `revealChromeFromMeta` in `RevealDeck.tsx`,
+  7-case `RevealDeck.integration.test.tsx`, verified in Chrome. DOM-only;
+  styling blocked on F4.
+- [ ] **F4: include the Quarto reveal chrome CSS layer in the preview theme**
+  (bd-d0f9xoa6). Footer/logo emit but render `position: static` — the preview
+  theme lacks `.reveal .footer` / `.slide-logo`. Decide under theme-parity
+  (bd-y259zb57): compile `quarto-revealjs.scss` into the preview theme, or move
+  the theme-independent chrome rules into the static `quarto-reveal.css`.
+
+### Phase B — full per-example audit (the "other examples" sweep)
+
+For each example NOT yet compared (01, 03, 04, 05, 06, 07, 08, 09, 11): render →
+serve → `q2 preview` → Chrome DOM diff (the workflow in this plan's Overview).
+Record any new divergence class as a finding here and file a focused strand.
+Known suspects: `06-speaker-notes` (Notes plugin), `05-columns` (flex styles),
+`09-themes` (theme delivery — already in_progress under bd-y259zb57).
+
+### Phase C — lock it down
+
+- [ ] Land **bd-qn8yi1su**: automated render↔preview golden parity test (the
+  slides analogue of `/preview-render-parity`) covering the Tier-1 set, so Phase
+  2 authoring features extend it per feature instead of re-auditing by hand.
+
+## Verification recipe (used for this audit)
+
+```bash
+cargo build --bin q2 --release
+./target/release/q2 render examples/presentations/<ex>/slides.qmd
+(cd examples/presentations/<ex> && python3 -m http.server 8765 &)   # render
+./target/release/q2 preview examples/presentations/<ex>/slides.qmd --port 8766 --no-browser &
+# Chrome: compare http://127.0.0.1:8765/slides.html  vs  http://127.0.0.1:8766/?page=slides.qmd
+# preview DOM is inside an <iframe> — query iframe.contentDocument.
+```
+
+## References
+
+- Native reveal scaffold: `crates/quarto-core/src/revealjs/assemble.rs`
+  (`render_revealjs_document`, `footer_logo_html`, `has-logo`).
+- Footer/logo render stage: `crates/quarto-core/src/revealjs/footer_logo.rs`
+  (`RevealFooterLogoTransform` → `rendered.reveal.{footer,logo}`).
+- Preview deck: `ts-packages/preview-renderer/src/q2-preview/RevealDeck.tsx`.
+- Pipeline seam: `crates/quarto-core/src/pipeline.rs`
+  (`footer_render_stage`, `Q2_PREVIEW_TRANSFORM_EXCLUDED`,
+  `build_q2_preview_pipeline_stages`).
+- Epic plan: `claude-notes/plans/2026-06-08-revealjs-presentations.md` (Phase 1P).
+- Skill: `/preview-render-parity`.

--- a/claude-notes/plans/2026-06-17-revealjs-preview-render-parity-audit.md
+++ b/claude-notes/plans/2026-06-17-revealjs-preview-render-parity-audit.md
@@ -98,26 +98,58 @@ a complete feature miss, not a style nudge. Tracked by **bd-n2w0sxgd**;
 `bd-ocxnva1f` covers *Lua filters* manipulating footer/logo, a different
 concern from this baseline "preview doesn't render them at all" gap.
 
-**Status (2026-06-17): DOM fixed.** `RevealDeck` now emits the chrome.
-`RevealChrome` reads `rendered.reveal.{footer,logo}` and injects the markup into
-the `.reveal` element (outside `.slides`) via `useReveal()` →
+**Status (2026-06-17): DOM fixed and styled.** `RevealDeck` now emits the
+chrome. `RevealChrome` reads `rendered.reveal.{footer,logo}` and injects the
+markup into the `.reveal` element (outside `.slides`) via `useReveal()` →
 `getRevealElement()`, plus `has-logo`. Verified in Chrome on `10-footer-logo`:
 `.reveal.has-logo`, `img.slide-logo` + `.footer.footer-default` are direct
-children of `.reveal`, not in `.slides`, footer link preserved. Tests:
-`RevealDeck.integration.test.tsx` (7 cases). **Caveat → F4.**
+children of `.reveal`, not in `.slides`, footer link preserved, footer
+`position: fixed; bottom: 18px` and logo `position: fixed; bottom: 0; right:
+12px` (theme styling applies — see F4). Tests: `RevealDeck.integration.test.tsx`.
+**Caveat:** the logo *image* still 404s — see F5.
 
-### F4 — Preview reveal theme omits the Quarto chrome CSS layer (discovered via F3, tracked: bd-d0f9xoa6)
+### F4 — (RETRACTED) "Preview reveal theme omits the chrome CSS layer" — was a stale-WASM artifact (bd-d0f9xoa6, closed)
 
-With F3's DOM in place, the footer/logo render **unstyled** (`position: static`)
-because the preview's runtime-delivered theme (`<link data-q2-theme>` blob, 1784
-rules) does **not** contain `.reveal .footer` / `.reveal .slide-logo`. Render
-positions them `fixed` via rules in the per-doc `theme-<fp>.css` (compiled from
-`resources/scss/revealjs/quarto-revealjs.scss`); the preview theme is missing
-that chrome layer. This is a theme-**content** parity gap (sibling of the
-theme-delivery work bd-y259zb57), independent of the DOM fix — fixing it likely
-means either compiling the same SCSS partials into the preview theme or moving
-the theme-independent chrome rules into the statically-imported
-`resources/revealjs/quarto-reveal.css`.
+Initially filed when the footer/logo measured `position: static` and the theme
+blob lacked `.reveal .footer`. **Not reproducible on a clean build.** That
+reading came from a binary whose embedded WASM theme artifact was stale (built
+via `cargo xtask build-q2-preview-spa` *without* a WASM rebuild — the
+stale-WASM-in-`q2 preview` trap in CLAUDE.md). After `cargo xtask verify`
+rebuilt the WASM, the runtime-delivered theme **does** contain the chrome rules
+and footer/logo are correctly `position: fixed`, stable across reloads and
+500 ms–5 s time samples. Lesson: always rebuild WASM (`npm run build:wasm` /
+`cargo xtask verify`) before judging a preview *styling* gap.
+
+### F5 — Logo image 404s in preview: asset walker misses meta-driven raw-HTML images (tracked: bd-k5rxujiy)
+
+_(Moved up from below — kept here with the other F-numbered findings.)_ See the
+detailed entry under "Findings" above.
+
+### F5 — Logo image 404s in preview: asset walker misses meta-driven raw-HTML images (tracked: bd-k5rxujiy)
+
+With F3's DOM in place, the logo `<img class="slide-logo" src="logo.svg">` fails
+to load in preview (`naturalWidth: 0`). Network: `GET /logo.svg` → **200
+`text/html`** (the SPA shell) — `logo.svg` is not in the preview's served VFS
+asset set, so the catch-all returns `index.html`.
+
+**Root cause (confirmed):** the parent-side asset walker
+(`ts-packages/preview-renderer/src/q2-preview/assetWalker.ts::collectImagePaths`)
+collects **only AST `Image` nodes** (`obj.t === 'Image'`). The logo comes from
+metadata (`logo: logo.svg`), rendered by `RevealFooterLogoTransform` into
+`rendered.reveal.logo` as a **raw HTML `<img>` string** that `RevealChrome`
+injects via `dangerouslySetInnerHTML`. It is never an `Image` node, so (1) no
+blob URL is minted for it, and (2) the raw `<img>` bypasses the `<Image>` React
+component that rewrites `src` against the manifest. `ResourceCollectorTransform`
+is likewise a no-op in `vfs_root` mode (`resource_collector.rs:96`) by design —
+the walker is the producer in preview. Native render works only because
+`logo.svg` sits next to `slides.html` on disk.
+
+**Fix options** (need a design call): (A) walker also collects `meta.logo` and
+`RevealChrome` rewrites the injected `src` via `AssetManifestContext` — targeted;
+(B) generalize the walker to scan `rendered.{reveal,navigation}.*` HTML strings
+for `src=`/`href=` asset refs and have the injecting slots rewrite — general
+(covers footer images, navbar logos); (C) represent the logo as a real `Image`
+AST node. Recommend (B) long-term, (A) as a quick win.
 
 ## Root cause (F1 + F2)
 
@@ -156,12 +188,24 @@ verify):
 
 ### Phase A — fix the two systemic + one chrome divergence (TDD per /preview-parity)
 
-- [ ] **F1+F2: forward section `Attr` onto `<Slide>`/`<Stack>`** (extend
-  bd-vv8jft5n; widen scope from "section-id" to "section `Attr`: id + classes +
-  kvs"). Failing test first in
-  `ts-packages/preview-renderer/src/q2-preview/q2-preview.integration.test.tsx`:
-  mount a deck AST, assert `<section id="…" class="section …">`. Mirror
-  `assemble.rs`. Verify in Chrome on `01`/`02`/`10`.
+- [x] **F1+F2: forward section `Attr` onto `<Slide>`/`<Stack>`** (bd-vv8jft5n).
+  DONE 2026-06-17 — `sectionAttrProps(div)` forwards `id` + joined classes;
+  `renderTopSection` spreads it onto each leaf/inner `<Slide>` and the `<Stack>`.
+  Verified in Chrome on `10-footer-logo`: title slide now
+  `id="title-slide" class="section title-slide center present"` and reveal
+  vertically centers it (`section top: 288.5px`, h1 `text-align: center`); other
+  sections gain ids + `section`. Tests in `RevealDeck.integration.test.tsx`.
+  **Known gap:** `@revealjs/react`'s `<Stack>` only accepts `className` (drops
+  `id`), so a `# Section`-divider stack's own `id` can't round-trip through the
+  component yet (inner vertical slides still get theirs). `kvs` (e.g.
+  `data-background-color`) not yet forwarded — defer to authoring features
+  (bd-bea550b0). Both noted on bd-vv8jft5n.
+- [x] ~~**F4: include the Quarto reveal chrome CSS layer in the preview
+  theme**~~ — RETRACTED (bd-d0f9xoa6 closed); was a stale-WASM artifact, the
+  theme is fine on a clean build.
+- [ ] **F5: collect meta-driven / raw-HTML images into the preview VFS**
+  (bd-k5rxujiy). Logo `<img src="logo.svg">` 404s because the asset walker only
+  sees AST `Image` nodes. Needs a design call (see F5 fix options).
 - [x] **F3: render deck footer/logo + `has-logo` in `RevealDeck`** (bd-n2w0sxgd).
   DONE 2026-06-17 — `RevealChrome` + `revealChromeFromMeta` in `RevealDeck.tsx`,
   7-case `RevealDeck.integration.test.tsx`, verified in Chrome. DOM-only;

--- a/claude-notes/plans/2026-06-17-revealjs-preview-render-parity-audit.md
+++ b/claude-notes/plans/2026-06-17-revealjs-preview-render-parity-audit.md
@@ -122,11 +122,6 @@ and footer/logo are correctly `position: fixed`, stable across reloads and
 
 ### F5 — Logo image 404s in preview: asset walker misses meta-driven raw-HTML images (tracked: bd-k5rxujiy)
 
-_(Moved up from below — kept here with the other F-numbered findings.)_ See the
-detailed entry under "Findings" above.
-
-### F5 — Logo image 404s in preview: asset walker misses meta-driven raw-HTML images (tracked: bd-k5rxujiy)
-
 With F3's DOM in place, the logo `<img class="slide-logo" src="logo.svg">` fails
 to load in preview (`naturalWidth: 0`). Network: `GET /logo.svg` → **200
 `text/html`** (the SPA shell) — `logo.svg` is not in the preview's served VFS
@@ -144,12 +139,62 @@ is likewise a no-op in `vfs_root` mode (`resource_collector.rs:96`) by design �
 the walker is the producer in preview. Native render works only because
 `logo.svg` sits next to `slides.html` on disk.
 
-**Fix options** (need a design call): (A) walker also collects `meta.logo` and
-`RevealChrome` rewrites the injected `src` via `AssetManifestContext` — targeted;
-(B) generalize the walker to scan `rendered.{reveal,navigation}.*` HTML strings
-for `src=`/`href=` asset refs and have the injecting slots rewrite — general
-(covers footer images, navbar logos); (C) represent the logo as a real `Image`
-AST node. Recommend (B) long-term, (A) as a quick win.
+#### The fix is two independent layers
+
+The problem decomposes into "are the bytes available?" and "does the element
+that wants them actually get them?". These are separable and must *both* hold.
+
+**Layer 1 — get the declared bytes into the preview VFS.** Honor a document's
+front-matter `resources:` in single-file preview, the same declaration used for
+publishing. `crates/quarto-preview/src/config.rs::resolve_single_file_deps`
+(bd-9cyza5vy) already runs the real parse + include stages and collects image
+deps via `collect_referenced_asset_urls(blocks)`; document `resources:` plugs in
+right beside that, reusing the existing publish machinery —
+`project_resources::extract_resource_patterns(&doc.ast.meta, ["resources"])` +
+`expand_patterns(canonical_root, deck_dir_anchor, …, DocumentMetadata, Page)`
+(the same `expand_patterns` already used in that file for *project* `resources:`)
+— folding the resolved files into `SingleFileDeps.binary_files`. Properties:
+reuses publish semantics (declare once → publish + preview), handles globs, is
+format-agnostic (helps any single-file doc referencing assets the AST walker
+can't see: `logo:`, raw HTML, shortcodes, CSS `url()`), and is on-policy
+(`config.rs:122` already treats `resources:` as the sync upload trust boundary).
+**This is the cheap, clearly-worthwhile piece and is implemented under
+bd-k5rxujiy.** Bytes-in-VFS is *necessary but not sufficient.*
+
+**Layer 2 — serve those bytes to the raw `<img>`.** The logo is a raw
+`<img src="logo.svg">` injected by `RevealChrome`; it fetches `/logo.svg`, hits
+the SPA catch-all, and never passes through the `<Image>` component that swaps in
+blob URLs. Two ways to close it:
+
+- **(a) per-asset rewrite (targeted, no infra changes).** Two small steps, both
+  in `preview-renderer` TS:
+  1. *Walker collects the non-Image paths.* `assetWalker.ts` already builds
+     `manifest: { origPath → blobUrl }` by reading VFS bytes via
+     `vfsReadBinaryFile` and minting blob URLs. Extend `collectImagePaths` (or
+     add a sibling collector) to also gather `meta.logo` and/or `meta.resources`
+     path strings, so the manifest gains `{ "logo.svg": "blob:…" }`. (Keyed by
+     the **same** string that appears in the injected HTML — both come from the
+     `logo:` value the Rust transform emits verbatim, so they match; a test
+     should pin that.)
+  2. *Injecting slot rewrites against the manifest.* `RevealChrome` builds a
+     detached `<div>` from the raw HTML before appending. Add a pass:
+     `wrapper.querySelectorAll('[src],[href]')`, and for each, look the current
+     attr value up in the manifest (via `AssetManifestContext`, the same source
+     the `<Image>` component already uses) and rewrite to the blob URL when
+     matched; external/`data:`/`blob:` pass through. Best factored as a reusable
+     `rewriteAssetRefs(root, lookupAssetUrl)` so footer images / navbar logos get
+     it too. **Stays entirely inside `preview-renderer` — no hub-client, sync
+     server, or quarto-hub.com involvement.**
+- **(b) service-worker VFS-by-path server (general, future-proof).** Serve
+  `/logo.svg` straight from the VFS so *any* path reference resolves with no
+  rewriting (`resources:` becomes the allow-list that gates it). This is the
+  bd-msp0 epic — it **touches hub-client and the quarto-hub.com deployment**, so
+  it is deferred until we're ready for that surface.
+
+**Decision:** Layer 1 lands now (bd-k5rxujiy). For Layer 2 we go with **(a)** —
+the per-asset rewrite, contained to `preview-renderer` — *or* defer Layer 2
+entirely, because **(b)** the service worker pulls in hub-client + the
+quarto-hub.com deployment, which we are not ready to take on yet.
 
 ## Root cause (F1 + F2)
 
@@ -203,9 +248,17 @@ verify):
 - [x] ~~**F4: include the Quarto reveal chrome CSS layer in the preview
   theme**~~ — RETRACTED (bd-d0f9xoa6 closed); was a stale-WASM artifact, the
   theme is fine on a clean build.
-- [ ] **F5: collect meta-driven / raw-HTML images into the preview VFS**
-  (bd-k5rxujiy). Logo `<img src="logo.svg">` 404s because the asset walker only
-  sees AST `Image` nodes. Needs a design call (see F5 fix options).
+- [x] **F5 Layer 1: honor document `resources:` in single-file preview VFS**
+  (bd-k5rxujiy). DONE 2026-06-17 — `resolve_single_file_deps` expands
+  `meta.resources` into `binary_files` (reuses `extract_resource_patterns` +
+  `expand_patterns`; globs supported). Tests `single_file_deps_includes_declared_resources`
+  + `_glob`; E2E A/B via real `q2 preview` (`binary_count` 1 vs 0). Bytes-in-VFS
+  only — the logo still 404s until Layer 2.
+- [ ] **F5 Layer 2: serve the bytes to the raw `<img>`** — option (a) per-asset
+  rewrite in `preview-renderer` (walker collects `meta.logo`/`meta.resources`;
+  `RevealChrome` rewrites `src`/`href` via `AssetManifestContext`), OR defer
+  until the (b) service-worker path-server (bd-msp0, touches hub-client +
+  quarto-hub.com) is on the table.
 - [x] **F3: render deck footer/logo + `has-logo` in `RevealDeck`** (bd-n2w0sxgd).
   DONE 2026-06-17 — `RevealChrome` + `revealChromeFromMeta` in `RevealDeck.tsx`,
   7-case `RevealDeck.integration.test.tsx`, verified in Chrome. DOM-only;

--- a/crates/quarto-preview/src/config.rs
+++ b/crates/quarto-preview/src/config.rs
@@ -360,6 +360,50 @@ pub fn resolve_single_file_deps(
         }
     }
 
+    // Document-declared `resources:` (bd-k5rxujiy Layer 1). The AST image walk
+    // above can only see `Image` nodes; assets referenced through metadata or
+    // raw HTML — `logo:`, footer images, shortcode/CSS `url()` refs — are
+    // invisible to it. `resources:` is the author's explicit declaration of
+    // exactly those files (the same one `q2 render` / publish uses, and the
+    // sync upload trust boundary — see `resources_scoped_html_files` above), so
+    // we honor it here too: expand the patterns (globs included) against the
+    // deck dir, the same anchor as the image walk, and fold the matches into
+    // the binary closure so they sync into the preview VFS.
+    //
+    // Note: this gets the bytes into the VFS (Layer 1). A raw `<img src=…>`
+    // still needs its `src` rewritten to the minted blob URL to actually load
+    // (Layer 2 — `preview-renderer` asset manifest); see the plan.
+    {
+        use quarto_core::project_resources::{
+            ResourceOrigin, ResourceScope, expand_patterns, extract_resource_patterns,
+        };
+        let patterns = extract_resource_patterns(&doc.ast.meta, &["resources"]);
+        if !patterns.is_empty() {
+            // Anchor relative patterns at the deck dir (render parity with the
+            // image walk); contain + relativize against the canonical root, so
+            // the resulting keys match the VFS source keys produced above.
+            let anchor = canonical_root.join(deck_dir);
+            if let Ok(resolved) = expand_patterns(
+                &canonical_root,
+                &anchor,
+                &patterns,
+                || ResourceOrigin::DocumentMetadata {
+                    source: abs_deck.clone(),
+                },
+                ResourceScope::Page {
+                    source: abs_deck.clone(),
+                },
+            ) {
+                for r in resolved {
+                    let rel = PathBuf::from(&r.output_relative);
+                    if seen_bin.insert(rel.clone()) {
+                        binary_files.push(rel);
+                    }
+                }
+            }
+        }
+    }
+
     qmd_files.sort();
     binary_files.sort();
     SingleFileDeps {
@@ -415,6 +459,56 @@ mod tests {
                 qmd_files: vec![std::path::PathBuf::from("part.qmd")],
                 binary_files: vec![std::path::PathBuf::from("inc.png")],
             }
+        );
+    }
+
+    /// A document `resources:` declaration is honored in single-file preview
+    /// (bd-k5rxujiy Layer 1): declared files land in `binary_files` even when
+    /// nothing in the AST references them — the `logo:` / raw-HTML / shortcode
+    /// case the AST image walker can't see.
+    #[test]
+    fn single_file_deps_includes_declared_resources() {
+        let temp = TempDir::new().unwrap();
+        let root = temp.path();
+        std::fs::write(root.join("logo.svg"), b"<svg/>").unwrap();
+        std::fs::write(
+            root.join("main.qmd"),
+            "---\ntitle: T\nlogo: logo.svg\nresources:\n  - logo.svg\n---\n\n# Hi\n",
+        )
+        .unwrap();
+
+        let deps = resolve_single_file_deps(root, std::path::Path::new("main.qmd"), native_arc());
+        assert!(
+            deps.binary_files
+                .contains(&std::path::PathBuf::from("logo.svg")),
+            "declared resource logo.svg should sync into the VFS; got {:?}",
+            deps.binary_files,
+        );
+    }
+
+    /// `resources:` accepts globs — reuses the publish-path `expand_patterns`,
+    /// so a `*.svg` pattern pulls every matching sibling into the closure.
+    #[test]
+    fn single_file_deps_resources_glob() {
+        let temp = TempDir::new().unwrap();
+        let root = temp.path();
+        std::fs::write(root.join("a.svg"), b"<svg/>").unwrap();
+        std::fs::write(root.join("b.svg"), b"<svg/>").unwrap();
+        std::fs::write(
+            root.join("main.qmd"),
+            "---\ntitle: T\nresources:\n  - \"*.svg\"\n---\n\n# Hi\n",
+        )
+        .unwrap();
+
+        let mut deps =
+            resolve_single_file_deps(root, std::path::Path::new("main.qmd"), native_arc());
+        deps.binary_files.sort();
+        assert_eq!(
+            deps.binary_files,
+            vec![
+                std::path::PathBuf::from("a.svg"),
+                std::path::PathBuf::from("b.svg"),
+            ],
         );
     }
 

--- a/ts-packages/preview-renderer/src/q2-preview/RevealDeck.integration.test.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/RevealDeck.integration.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * RevealDeck deck-chrome parity (bd-n2w0sxgd, F3 of the
+ * 2026-06-17 preview↔render parity audit).
+ *
+ * `q2 render` places the deck-level footer + logo as DIRECT children of
+ * `.reveal`, OUTSIDE `.slides`, and adds `has-logo` to `.reveal`
+ * (crates/quarto-core/src/revealjs/assemble.rs::render_revealjs_document +
+ * footer_logo_html). `q2 preview`'s `RevealDeck` must mirror that. The markup
+ * is pre-rendered by the `reveal-footer-logo` transform into the
+ * `rendered.reveal.{footer,logo}` meta slots (which run in the q2-preview
+ * pipeline), so the React side only reads + places it.
+ *
+ * `<Deck>` from `@revealjs/react` renders children only inside `.slides`, so the
+ * chrome is injected into the `.reveal` element imperatively via `useReveal()` →
+ * `getRevealElement()` (the `RevealChrome` component). These tests drive that
+ * component directly with a fake `RevealContext`, so they assert the exact DOM
+ * mutation without booting reveal.js.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { RevealContext } from '@revealjs/react';
+import { RevealChrome, revealChromeFromMeta } from './RevealDeck';
+
+const metaString = (c: string) => ({ t: 'MetaString', c });
+const metaMap = (entries: Record<string, unknown>) => ({
+    t: 'MetaMap',
+    c: Object.entries(entries).map(([key, value]) => ({ key, value })),
+});
+
+/** Top-level meta carrying `rendered.reveal.{footer,logo}` slots. */
+function metaWithReveal(slots: { footer?: string; logo?: string }) {
+    const reveal: Record<string, unknown> = {};
+    if (slots.footer !== undefined) reveal.footer = metaString(slots.footer);
+    if (slots.logo !== undefined) reveal.logo = metaString(slots.logo);
+    return { rendered: metaMap({ reveal: metaMap(reveal) }) };
+}
+
+const FOOTER_HTML =
+    '<div class="footer footer-default">© 2026 Example Corp — <a href="https://example.com">example.com</a></div>';
+const LOGO_HTML = '<img class="slide-logo" src="logo.svg">';
+
+/** Render `RevealChrome` against a real `.reveal`/`.slides` element via a fake
+ *  reveal API, returning that `.reveal` element for assertions. */
+function renderChrome(props: { footerHtml?: string; logoHtml?: string }) {
+    const reveal = document.createElement('div');
+    reveal.className = 'reveal';
+    const slides = document.createElement('div');
+    slides.className = 'slides';
+    reveal.appendChild(slides);
+    document.body.appendChild(reveal);
+    const fakeApi = { getRevealElement: () => reveal } as never;
+    const utils = render(
+        <RevealContext.Provider value={fakeApi}>
+            <RevealChrome {...props} />
+        </RevealContext.Provider>,
+    );
+    return { reveal, slides, ...utils };
+}
+
+describe('revealChromeFromMeta — reads rendered.reveal.{footer,logo}', () => {
+    it('extracts both slots', () => {
+        const chrome = revealChromeFromMeta(
+            metaWithReveal({ footer: FOOTER_HTML, logo: LOGO_HTML }) as never,
+        );
+        expect(chrome.footerHtml).toBe(FOOTER_HTML);
+        expect(chrome.logoHtml).toBe(LOGO_HTML);
+    });
+
+    it('returns undefined slots when absent', () => {
+        const chrome = revealChromeFromMeta({} as never);
+        expect(chrome.footerHtml).toBeUndefined();
+        expect(chrome.logoHtml).toBeUndefined();
+    });
+});
+
+describe('RevealChrome — places footer/logo outside .slides, adds has-logo', () => {
+    it('injects logo + footer as direct children of .reveal (outside .slides)', () => {
+        const { reveal, slides } = renderChrome({
+            footerHtml: FOOTER_HTML,
+            logoHtml: LOGO_HTML,
+        });
+
+        const logo = reveal.querySelector('img.slide-logo');
+        const footer = reveal.querySelector('div.footer.footer-default');
+        expect(logo).not.toBeNull();
+        expect(footer).not.toBeNull();
+        // Direct children of `.reveal`, NOT nested in `.slides`.
+        expect(logo!.parentElement).toBe(reveal);
+        expect(footer!.parentElement).toBe(reveal);
+        expect(slides.contains(logo!)).toBe(false);
+        expect(slides.contains(footer!)).toBe(false);
+        // Footer preserves inline markup (link survives).
+        expect(footer!.querySelector('a')?.getAttribute('href')).toBe(
+            'https://example.com',
+        );
+    });
+
+    it('orders logo before footer (matches assemble.rs footer_logo_html)', () => {
+        const { reveal } = renderChrome({ footerHtml: FOOTER_HTML, logoHtml: LOGO_HTML });
+        const logo = reveal.querySelector('img.slide-logo')!;
+        const footer = reveal.querySelector('div.footer')!;
+        // logo precedes footer in document order
+        expect(
+            logo.compareDocumentPosition(footer) &
+                Node.DOCUMENT_POSITION_FOLLOWING,
+        ).toBeTruthy();
+    });
+
+    it('adds has-logo to .reveal only when a logo is present', () => {
+        const withLogo = renderChrome({ footerHtml: FOOTER_HTML, logoHtml: LOGO_HTML });
+        expect(withLogo.reveal.classList.contains('has-logo')).toBe(true);
+
+        const footerOnly = renderChrome({ footerHtml: FOOTER_HTML });
+        expect(footerOnly.reveal.classList.contains('has-logo')).toBe(false);
+        expect(footerOnly.reveal.querySelector('div.footer')).not.toBeNull();
+        expect(footerOnly.reveal.querySelector('img.slide-logo')).toBeNull();
+    });
+
+    it('injects nothing when both slots are absent', () => {
+        const { reveal, slides } = renderChrome({});
+        expect(reveal.children.length).toBe(1); // only `.slides`
+        expect(reveal.firstElementChild).toBe(slides);
+        expect(reveal.classList.contains('has-logo')).toBe(false);
+    });
+
+    it('removes injected chrome + has-logo on unmount', () => {
+        const { reveal, unmount } = renderChrome({
+            footerHtml: FOOTER_HTML,
+            logoHtml: LOGO_HTML,
+        });
+        expect(reveal.querySelector('.slide-logo')).not.toBeNull();
+        unmount();
+        expect(reveal.querySelector('.slide-logo')).toBeNull();
+        expect(reveal.querySelector('.footer')).toBeNull();
+        expect(reveal.classList.contains('has-logo')).toBe(false);
+    });
+});

--- a/ts-packages/preview-renderer/src/q2-preview/RevealDeck.integration.test.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/RevealDeck.integration.test.tsx
@@ -18,9 +18,15 @@
  */
 
 import { describe, it, expect } from 'vitest';
+import { isValidElement } from 'react';
 import { render } from '@testing-library/react';
-import { RevealContext } from '@revealjs/react';
-import { RevealChrome, revealChromeFromMeta } from './RevealDeck';
+import { RevealContext, Slide, Stack } from '@revealjs/react';
+import {
+    RevealChrome,
+    revealChromeFromMeta,
+    renderTopSection,
+    sectionAttrProps,
+} from './RevealDeck';
 
 const metaString = (c: string) => ({ t: 'MetaString', c });
 const metaMap = (entries: Record<string, unknown>) => ({
@@ -57,6 +63,60 @@ function renderChrome(props: { footerHtml?: string; logoHtml?: string }) {
     );
     return { reveal, slides, ...utils };
 }
+
+/** A `Div(.section)` block as `RevealSlidesTransform` emits it: Attr =
+ *  [id, classes, kvs], then the child blocks. */
+const sectionDiv = (
+    id: string,
+    classes: string[],
+    blocks: unknown[] = [],
+): never =>
+    ({ t: 'Div', c: [[id, classes, []], blocks] }) as never;
+
+const H1_TITLE = { t: 'Header', c: [1, ['', ['title'], []], [{ t: 'Str', c: 'T' }]] };
+
+describe('sectionAttrProps — forwards the section Div Attr (F1+F2, bd-vv8jft5n)', () => {
+    it('joins classes and keeps the id', () => {
+        const props = sectionAttrProps(
+            sectionDiv('title-slide', ['section', 'title-slide', 'center']),
+        );
+        expect(props.id).toBe('title-slide');
+        expect(props.className).toBe('section title-slide center');
+    });
+
+    it('omits an empty id and empty className (untitled / class-less slide)', () => {
+        const props = sectionAttrProps(sectionDiv('', []));
+        expect(props.id).toBeUndefined();
+        expect(props.className).toBeUndefined();
+    });
+});
+
+describe('renderTopSection — title slide keeps `center` so reveal centers it', () => {
+    it('leaf <Slide> carries the section id + classes (title-slide center)', () => {
+        const div = sectionDiv('title-slide', ['section', 'title-slide', 'center'], [
+            H1_TITLE,
+        ]);
+        const el = renderTopSection(div, 0);
+        expect(isValidElement(el)).toBe(true);
+        const node = el as React.ReactElement<Record<string, unknown>>;
+        expect(node.type).toBe(Slide);
+        expect(node.props.id).toBe('title-slide');
+        expect(node.props.className).toBe('section title-slide center');
+    });
+
+    it('<Stack> divider carries `section` class; inner <Slide>s carry their id+classes', () => {
+        const inner1 = sectionDiv('part-one', ['section']); // divider heading slide
+        const inner2 = sectionDiv('first-topic', ['section']);
+        const div = sectionDiv('part-one', ['section'], [inner1, inner2]);
+        const el = renderTopSection(div, 0) as React.ReactElement<Record<string, unknown>>;
+        expect(el.type).toBe(Stack);
+        expect(el.props.className).toContain('section');
+        const slides = el.props.children as React.ReactElement<Record<string, unknown>>[];
+        expect(slides[0].props.id).toBe('part-one');
+        expect(slides[1].props.id).toBe('first-topic');
+        expect(slides[1].props.className).toBe('section');
+    });
+});
 
 describe('revealChromeFromMeta — reads rendered.reveal.{footer,logo}', () => {
     it('extracts both slots', () => {

--- a/ts-packages/preview-renderer/src/q2-preview/RevealDeck.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/RevealDeck.tsx
@@ -102,12 +102,39 @@ function SlideBody(props: {
 }
 
 /**
+ * Forward a section `Div`'s `Attr` (`[id, classes, kvs]`) onto the reveal
+ * `<section>` as `id` + `className`, mirroring the native writer — the same
+ * `id`/`class` `q2 render` puts on every `<section>`
+ * (`crates/quarto-core/src/revealjs/assemble.rs`). Without this, preview
+ * `<section>`s carry only reveal's runtime `present`/`future` classes: the
+ * title slide loses `center` (reveal's vertical centering) and `title-slide`
+ * (a theme-CSS hook), in-deck `#id` anchors break, and author per-slide classes
+ * (`## Slide {.smaller}`) are dropped. F1+F2 of bd-vv8jft5n.
+ *
+ * Empty id / empty class list collapse to `undefined` so we don't emit
+ * `id=""` / `class=""`.
+ */
+export function sectionAttrProps(div: DivBlock): { id?: string; className?: string } {
+    const [id, classes] = div.c[0];
+    return {
+        id: id || undefined,
+        className: classes.length > 0 ? classes.join(' ') : undefined,
+    };
+}
+
+/**
  * Map one top-level section Div to a `<Slide>` (leaf) or `<Stack>` of
  * vertical `<Slide>`s (a section divider whose children are themselves
  * section Divs — the shape `RevealSlidesTransform` emits for `# Section`
  * dividers and their `## ` sub-slides).
+ *
+ * Each `<section>` carries its Div's `id` + classes via [`sectionAttrProps`].
+ * Caveat: `@revealjs/react`'s `<Stack>` only accepts `className` (it drops
+ * `id`), so a section-divider stack's own `id` cannot round-trip through the
+ * component today — the inner vertical `<Slide>`s still get theirs. Tracked
+ * under bd-vv8jft5n.
  */
-function renderTopSection(
+export function renderTopSection(
     div: DivBlock,
     key: number,
     onNavigateToDocument?: (path: string, anchor: string | null) => void,
@@ -117,9 +144,9 @@ function renderTopSection(
 
     if (verticalSlides.length > 0) {
         return (
-            <Stack key={key}>
+            <Stack key={key} {...sectionAttrProps(div)}>
                 {verticalSlides.map((slide, j) => (
-                    <Slide key={j}>
+                    <Slide key={j} {...sectionAttrProps(slide as DivBlock)}>
                         <SlideBody
                             blocks={(slide as DivBlock).c[1]}
                             sectionClasses={(slide as DivBlock).c[0][1]}
@@ -132,7 +159,7 @@ function renderTopSection(
     }
 
     return (
-        <Slide key={key}>
+        <Slide key={key} {...sectionAttrProps(div)}>
             <SlideBody
                 blocks={children}
                 sectionClasses={div.c[0][1]}

--- a/ts-packages/preview-renderer/src/q2-preview/RevealDeck.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/RevealDeck.tsx
@@ -17,8 +17,8 @@
  * See claude-notes/plans/2026-06-08-revealjs-presentations.md (Phase 1P).
  */
 
-import React, { useContext } from 'react';
-import { Deck, Slide, Stack } from '@revealjs/react';
+import React, { useContext, useEffect } from 'react';
+import { Deck, Slide, Stack, useReveal } from '@revealjs/react';
 // Reveal CSS from the SAME vendored copy `q2 render` links — `resources/
 // revealjs/` — in the SAME cascade order, so render and preview cannot disagree
 // on reveal styling (bd-ibqkf9ry). The `vendored_reveal_assets_match_npm_package`
@@ -41,7 +41,7 @@ import '../../../../resources/revealjs/reset.css';
 import '../../../../resources/revealjs/reveal.css';
 import '../../../../resources/revealjs/quarto-reveal.css';
 
-import { extractMetaBool, Node, RegistryContext } from '../framework';
+import { extractMetaBool, extractMetaString, getMetaPath, Node, RegistryContext } from '../framework';
 import type { BlockNode, DivBlock, FormatRegistry, PandocAST } from '../framework';
 import { IncrementalContext } from './IncrementalContext';
 
@@ -142,7 +142,79 @@ function renderTopSection(
     );
 }
 
+/**
+ * Read the pre-rendered deck-level footer/logo markup from the
+ * `rendered.reveal.{footer,logo}` meta slots (populated by the
+ * `reveal-footer-logo` transform — `crates/quarto-core/src/revealjs/
+ * footer_logo.rs` — which runs in the q2-preview pipeline, so the markup
+ * is already present in the AST handed to preview). Each slot is a raw
+ * HTML string, byte-identical to what `q2 render` links.
+ */
+export function revealChromeFromMeta(meta: PandocAST['meta'] | undefined): {
+    footerHtml?: string;
+    logoHtml?: string;
+} {
+    return {
+        logoHtml: extractMetaString(getMetaPath(meta, ['rendered', 'reveal', 'logo'])),
+        footerHtml: extractMetaString(getMetaPath(meta, ['rendered', 'reveal', 'footer'])),
+    };
+}
+
+/**
+ * Place the deck-level footer/logo as **direct children of `.reveal`, OUTSIDE
+ * `.slides`**, and add `has-logo` to `.reveal` — mirroring the native scaffold
+ * (`crates/quarto-core/src/revealjs/assemble.rs::render_revealjs_document` +
+ * `footer_logo_html`). `position: fixed` only resolves against the viewport
+ * outside `.slides` (reveal applies a CSS `transform` to `.slides`/`<section>`).
+ *
+ * `@revealjs/react`'s `<Deck>` renders its children only *inside* `.slides`, so
+ * we cannot place this chrome declaratively. Instead we reach the `.reveal`
+ * element via `useReveal()` → `getRevealElement()` and inject the markup
+ * imperatively — the same escape hatch `HeaderIncludesEffect` uses for
+ * `document.head`. `RevealChrome` itself renders nothing in the React tree;
+ * mount it as a child of `<Deck>` so `useReveal()` sees the deck context.
+ *
+ * Order (logo then footer) matches `footer_logo_html`. Cleanup on unmount keeps
+ * test re-mounts and edit re-renders from accumulating nodes / the class.
+ */
+export function RevealChrome(props: { footerHtml?: string; logoHtml?: string }) {
+    const reveal = useReveal();
+    const { footerHtml, logoHtml } = props;
+    useEffect(() => {
+        if (!reveal) return;
+        // `useReveal()`'s `RevealApi` resolves loosely (the package's
+        // `../../dist/reveal` type import widens to `any`), so annotate the DOM
+        // node explicitly — otherwise `Array.from(wrapper.children)` below
+        // infers `unknown[]` under the SPA's stricter `tsc -b`.
+        const el = reveal.getRevealElement?.() as HTMLElement | null;
+        if (!el) return;
+
+        const inserted: Element[] = [];
+        const parts = [logoHtml, footerHtml].filter((s): s is string => !!s);
+        if (parts.length > 0) {
+            const wrapper = el.ownerDocument.createElement('div');
+            wrapper.innerHTML = parts.join('\n');
+            for (const node of Array.from(wrapper.children)) {
+                node.setAttribute('data-q2-reveal-chrome', '1');
+                el.appendChild(node);
+                inserted.push(node);
+            }
+        }
+        // `.reveal.has-logo` repositions the slide number (quarto-revealjs.scss);
+        // the native scaffold sets it iff the logo slot is present.
+        if (logoHtml) el.classList.add('has-logo');
+
+        return () => {
+            for (const node of inserted) node.remove();
+            if (logoHtml) el.classList.remove('has-logo');
+        };
+    }, [reveal, footerHtml, logoHtml]);
+
+    return null;
+}
+
 export function RevealDeck(props: RevealDeckProps) {
+    const chrome = revealChromeFromMeta(props.ast.meta);
     const slides = props.ast.blocks.map((block, i) => {
         if (isSectionDiv(block)) {
             return renderTopSection(block as DivBlock, i, props.onNavigateToDocument);
@@ -188,6 +260,9 @@ export function RevealDeck(props: RevealDeckProps) {
                     }}
                 >
                     {slides}
+                    {/* Deck-level footer/logo: injected into `.reveal` outside
+                        `.slides` (renders null in-tree). Mirrors assemble.rs. */}
+                    <RevealChrome footerHtml={chrome.footerHtml} logoHtml={chrome.logoHtml} />
                 </Deck>
             </IncrementalContext.Provider>
         </RegistryContext.Provider>


### PR DESCRIPTION
## What

Closes three `q2 preview` ↔ `q2 render` parity gaps for `format: revealjs` decks, surfaced by an audit of `examples/presentations/*` (plan: `claude-notes/plans/2026-06-17-revealjs-preview-render-parity-audit.md`). Each commit is one focused fix.

| commit | fix | strand |
|---|---|---|
| footer/logo DOM | preview now emits the deck-level footer, logo, and `has-logo` outside `.slides`, mirroring `assemble.rs` | bd-n2w0sxgd ✅ |
| section `Attr` | forward each section's `id` + classes onto `<Slide>`/`<Stack>` — fixes the title slide rendering uncentered (it lost `center`); every section regains its `id` + `section` class | bd-vv8jft5n |
| `resources:` → VFS | single-file preview honors a document's front-matter `resources:` so declared assets (e.g. `logo:`) sync into the preview VFS | bd-k5rxujiy (Layer 1) |

### 1. Deck footer/logo (bd-n2w0sxgd)
`RevealDeck` never read `rendered.reveal.{footer,logo}` (already populated in the preview AST by the `reveal-footer-logo` stage). New `RevealChrome` injects the markup into the `.reveal` element via `useReveal()` → `getRevealElement()` (the `HeaderIncludesEffect` escape-hatch pattern, since `@revealjs/react`'s `<Deck>` only renders children inside `.slides`) and toggles `has-logo`.

### 2. Section attributes (bd-vv8jft5n)
`sectionAttrProps(div)` derives `{id, className}` from the section Div's Attr; `renderTopSection` spreads it onto each `<Slide>`/`<Stack>`. The title slide now gets `id="title-slide" class="section title-slide center"` and reveal vertically + horizontally centers it.
- *Known follow-ups (left on the strand):* `@revealjs/react`'s `<Stack>` accepts only `className` (drops `id`), so a `# Section`-divider stack's own id can't round-trip yet; `kvs` (`data-background-*`) not forwarded; config-option parity (Deck config from `format.revealjs.*`) still pending.

### 3. `resources:` VFS sync (bd-k5rxujiy, Layer 1)
`resolve_single_file_deps` expands `meta.resources` (reusing the publish-path `extract_resource_patterns` + `expand_patterns`, globs included) into `binary_files`, riding the existing `single_file_assets → with_binary_files` VFS sync.
- This is **Layer 1 only** (bytes into the VFS). A raw `<img src="logo.svg">` still 404s until **Layer 2** serves the bytes to it — either a per-asset rewrite in `preview-renderer`, or the bd-msp0 service-worker path-server. Decision deferred; see the plan.

## Testing
- New `RevealDeck.integration.test.tsx` (section-attr + chrome injection); `single_file_deps_includes_declared_resources` + `_glob`.
- preview-renderer: 219 unit + 228 integration green. `cargo xtask verify` green (full for the TS legs; `--skip-hub-build` for the Rust-only `resources:` change — `quarto-preview` is native-only, not in the WASM path).
- **E2E** (real `q2 preview`, Chrome, on `examples/presentations/10-footer-logo`): footer/logo are direct children of `.reveal` outside `.slides`, footer `position: fixed`, title slide centered. `resources:` Layer 1 verified via `binary_count` A/B (1 with `resources:`, 0 without).

## Not included
- The unrelated `wasm-quarto-hub-client/Cargo.lock` workspace version-sync (regenerated by the WASM build) is intentionally left out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)