### PR TITLE
chore(deps): remove unused dependency declarations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -658,7 +658,6 @@ version = "0.3.0"
 dependencies = [
  "comrak",
  "hashlink",
- "insta",
  "pampa",
  "proptest",
  "quarto-pandoc-types",
@@ -1133,12 +1132,6 @@ dependencies = [
  "rustc_version",
  "syn",
 ]
-
-[[package]]
-name = "diff"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
@@ -2936,7 +2929,6 @@ dependencies = [
 name = "pampa"
 version = "0.0.0"
 dependencies = [
- "ariadne",
  "base64 0.22.1",
  "clap",
  "comrak",
@@ -2944,7 +2936,6 @@ dependencies = [
  "crossterm",
  "glob",
  "hashlink",
- "indexmap",
  "insta",
  "mlua",
  "once_cell",
@@ -3308,16 +3299,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
-name = "pretty_assertions"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
-dependencies = [
- "diff",
- "yansi",
-]
-
-[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3417,14 +3398,12 @@ dependencies = [
  "pampa",
  "pollster",
  "quarto-core",
- "quarto-doctemplate",
  "quarto-error-reporting",
  "quarto-hub",
  "quarto-lsp",
  "quarto-mcp-launcher",
  "quarto-preview",
  "quarto-publish",
- "quarto-sass",
  "quarto-source-map",
  "quarto-system-runtime",
  "quarto-test",
@@ -3433,7 +3412,6 @@ dependencies = [
  "quarto-util",
  "serde",
  "serde_json",
- "serde_yaml",
  "sha2 0.11.0",
  "tempfile",
  "tokio",
@@ -3446,7 +3424,6 @@ dependencies = [
 name = "quarto-analysis"
 version = "0.3.0"
 dependencies = [
- "insta",
  "quarto-error-reporting",
  "quarto-pandoc-types",
  "quarto-source-map",
@@ -3473,7 +3450,6 @@ name = "quarto-brand"
 version = "0.3.0"
 dependencies = [
  "serde",
- "serde_json",
  "serde_yaml",
  "thiserror 2.0.18",
 ]
@@ -3482,9 +3458,7 @@ dependencies = [
 name = "quarto-citeproc"
 version = "0.3.0"
 dependencies = [
- "glob",
  "hashlink",
- "insta",
  "quarto-csl",
  "quarto-error-reporting",
  "quarto-pandoc-types",
@@ -3494,15 +3468,12 @@ dependencies = [
  "serde",
  "serde_json",
  "similar 3.1.0",
- "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "quarto-config"
 version = "0.0.0"
 dependencies = [
- "indexmap",
- "insta",
  "quarto-error-reporting",
  "quarto-pandoc-types",
  "quarto-source-map",
@@ -3515,7 +3486,6 @@ dependencies = [
 name = "quarto-core"
 version = "0.3.0"
 dependencies = [
- "anyhow",
  "async-trait",
  "base64 0.22.1",
  "clap",
@@ -3542,7 +3512,6 @@ dependencies = [
  "quarto-source-map",
  "quarto-system-runtime",
  "quarto-trace",
- "quarto-util",
  "quarto-yaml",
  "rayon",
  "regex",
@@ -3569,24 +3538,18 @@ dependencies = [
 name = "quarto-csl"
 version = "0.3.0"
 dependencies = [
- "insta",
  "quarto-error-reporting",
  "quarto-source-map",
  "quarto-xml",
- "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "quarto-doctemplate"
 version = "0.1.0"
 dependencies = [
- "pretty_assertions",
  "quarto-error-reporting",
- "quarto-parse-errors",
  "quarto-source-map",
  "quarto-treesitter-ast",
- "serde",
- "serde_json",
  "tempfile",
  "thiserror 2.0.18",
  "tree-sitter",
@@ -3614,7 +3577,6 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
  "url",
 ]
 
@@ -3691,7 +3653,6 @@ dependencies = [
  "time",
  "tokio",
  "tokio-util",
- "tower 0.5.3",
  "tower-http",
  "tracing",
  "tracing-subscriber",
@@ -3703,16 +3664,10 @@ dependencies = [
 name = "quarto-lsp"
 version = "0.3.0"
 dependencies = [
- "anyhow",
- "insta",
  "quarto-lsp-core",
- "serde",
  "serde_json",
- "thiserror 2.0.18",
  "tokio",
  "tower-lsp",
- "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -3726,13 +3681,10 @@ dependencies = [
  "quarto-core",
  "quarto-error-reporting",
  "quarto-highlight",
- "quarto-pandoc-types",
  "quarto-source-map",
  "quarto-system-runtime",
- "quarto-yaml",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
  "tokio",
  "tree-sitter",
  "tree-sitter-qmd",
@@ -3747,7 +3699,6 @@ dependencies = [
  "fs2",
  "include_dir",
  "libc",
- "serde",
  "serde_json",
  "sha2 0.11.0",
  "tempfile",
@@ -3769,7 +3720,6 @@ name = "quarto-pandoc-types"
 version = "0.0.0"
 dependencies = [
  "hashlink",
- "indexmap",
  "quarto-source-map",
  "serde",
  "serde_json",
@@ -3784,7 +3734,6 @@ dependencies = [
  "quarto-error-message-macros",
  "quarto-error-reporting",
  "quarto-source-map",
- "serde",
  "serde_json",
  "tree-sitter",
 ]
@@ -3798,7 +3747,6 @@ dependencies = [
  "axum",
  "flate2",
  "http",
- "http-body-util",
  "include_dir",
  "pampa",
  "pollster",
@@ -3817,7 +3765,6 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
- "tower 0.5.3",
  "tracing",
 ]
 
@@ -3838,18 +3785,13 @@ dependencies = [
  "async-trait",
  "pollster",
  "quarto-config",
- "quarto-core",
- "quarto-error-reporting",
  "quarto-pandoc-types",
  "quarto-source-map",
- "quarto-system-runtime",
- "quarto-util",
  "serde",
  "serde_json",
  "serde_yaml",
  "tempfile",
  "thiserror 2.0.18",
- "tracing",
  "ureq",
  "url",
  "uuid",
@@ -3861,7 +3803,6 @@ version = "0.3.0"
 dependencies = [
  "grass",
  "include_dir",
- "insta",
  "once_cell",
  "quarto-brand",
  "quarto-pandoc-types",
@@ -3914,11 +3855,8 @@ dependencies = [
  "quarto-system-runtime",
  "regex",
  "scraper",
- "serde",
  "serde_yaml",
  "tempfile",
- "thiserror 2.0.18",
- "tracing",
 ]
 
 [[package]]
@@ -3942,14 +3880,9 @@ dependencies = [
  "http-body-util",
  "include_dir",
  "quarto-trace",
- "serde",
  "serde_json",
- "tempfile",
- "thiserror 2.0.18",
  "tokio",
  "tower 0.5.3",
- "tower-http",
- "tracing",
 ]
 
 [[package]]
@@ -3962,20 +3895,14 @@ dependencies = [
 [[package]]
 name = "quarto-util"
 version = "0.3.0"
-dependencies = [
- "serde",
- "thiserror 2.0.18",
-]
 
 [[package]]
 name = "quarto-xml"
 version = "0.3.0"
 dependencies = [
- "insta",
  "quarto-error-reporting",
  "quarto-source-map",
  "quick-xml",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3984,8 +3911,6 @@ version = "0.3.0"
 dependencies = [
  "quarto-source-map",
  "regex",
- "serde",
- "thiserror 2.0.18",
  "yaml-rust2",
 ]
 
@@ -3993,7 +3918,6 @@ dependencies = [
 name = "quarto-yaml-validation"
 version = "0.3.0"
 dependencies = [
- "anyhow",
  "insta",
  "quarto-error-reporting",
  "quarto-source-map",
@@ -5998,7 +5922,6 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",
- "quarto-error-reporting",
  "quarto-source-map",
  "quarto-yaml",
  "quarto-yaml-validation",

--- a/crates/comrak-to-pandoc/Cargo.toml
+++ b/crates/comrak-to-pandoc/Cargo.toml
@@ -15,7 +15,6 @@ hashlink = { version = "0.11.0", features = ["serde_impl"] }
 
 [dev-dependencies]
 pampa = { workspace = true }
-insta = { workspace = true }
 proptest = "1.10"
 
 [lints]

--- a/crates/pampa/Cargo.toml
+++ b/crates/pampa/Cargo.toml
@@ -63,9 +63,7 @@ paste = "1.0.15"
 once_cell = "1.21.3"
 yaml-rust2 = { workspace = true }
 hashlink = { version = "0.11.0", features = ["serde_impl"] }
-indexmap = "2.13"
 quarto-error-message-macros = { path = "../quarto-parse-errors/error-message-macros" }
-ariadne = "0.6"
 crossterm = { version = "0.29", optional = true }
 supports-hyperlinks = { version = "3.2", optional = true }
 mlua = { version = "0.11", features = ["lua54", "vendored", "serialize", "async"], optional = true }

--- a/crates/quarto-analysis/Cargo.toml
+++ b/crates/quarto-analysis/Cargo.toml
@@ -17,7 +17,6 @@ quarto-source-map.workspace = true
 quarto-error-reporting.workspace = true
 
 [dev-dependencies]
-insta.workspace = true
 yaml-rust2.workspace = true
 
 [lints]

--- a/crates/quarto-brand/Cargo.toml
+++ b/crates/quarto-brand/Cargo.toml
@@ -13,7 +13,6 @@ serde_yaml = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-serde_json = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/quarto-citeproc/Cargo.toml
+++ b/crates/quarto-citeproc/Cargo.toml
@@ -17,13 +17,10 @@ rust-embed = { version = "8", features = ["include-exclude"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 similar = "3"
-thiserror = { workspace = true }
 
 [dev-dependencies]
-insta = { workspace = true }
 
 [build-dependencies]
-glob = "0.3"
 
 [[bin]]
 name = "csl_conformance_report"

--- a/crates/quarto-config/Cargo.toml
+++ b/crates/quarto-config/Cargo.toml
@@ -16,12 +16,10 @@ quarto-source-map = { path = "../quarto-source-map" }
 quarto-yaml = { path = "../quarto-yaml" }
 quarto-pandoc-types = { path = "../quarto-pandoc-types" }
 quarto-error-reporting = { path = "../quarto-error-reporting" }
-indexmap = "2.13"
 thiserror = { workspace = true }
 yaml-rust2 = { workspace = true }
 
 [dev-dependencies]
-insta = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/quarto-core/Cargo.toml
+++ b/crates/quarto-core/Cargo.toml
@@ -8,7 +8,6 @@ repository.workspace = true
 description = "Core rendering infrastructure for Quarto"
 
 [dependencies]
-anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 serde.workspace = true
@@ -32,8 +31,6 @@ glob = "0.3"
 # RFC 3339 / RFC 2822 / ISO date-only inputs); `macros` enables the
 # compile-time `format_description!` macro. WASM-compatible.
 time = { version = "0.3", features = ["formatting", "parsing", "macros"] }
-
-quarto-util.workspace = true
 quarto-system-runtime.workspace = true
 quarto-pandoc-types.workspace = true
 quarto-source-map.workspace = true

--- a/crates/quarto-csl/Cargo.toml
+++ b/crates/quarto-csl/Cargo.toml
@@ -11,10 +11,8 @@ description = "CSL (Citation Style Language) parsing with source tracking for Qu
 quarto-error-reporting = { path = "../quarto-error-reporting" }
 quarto-source-map = { path = "../quarto-source-map" }
 quarto-xml = { path = "../quarto-xml" }
-thiserror = { workspace = true }
 
 [dev-dependencies]
-insta = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/quarto-doctemplate/Cargo.toml
+++ b/crates/quarto-doctemplate/Cargo.toml
@@ -18,21 +18,13 @@ tree-sitter = { workspace = true }
 
 # Generic tree-sitter traversal utilities
 quarto-treesitter-ast = { workspace = true }
-
-# Error reporting infrastructure
-quarto-parse-errors = { path = "../quarto-parse-errors" }
 quarto-error-reporting = { path = "../quarto-error-reporting" }
 quarto-source-map = { path = "../quarto-source-map" }
-
-# Serialization (for TemplateValue conversion from JSON)
-serde = { workspace = true, features = ["derive"] }
-serde_json = "1.0"
 
 # Error handling
 thiserror = "2.0"
 
 [dev-dependencies]
-pretty_assertions = "1.4"
 tempfile = "3"
 
 [lints]

--- a/crates/quarto-error-reporting/Cargo.toml
+++ b/crates/quarto-error-reporting/Cargo.toml
@@ -13,7 +13,6 @@ quarto-source-map = { path = "../quarto-source-map" }
 
 # Error reporting
 ariadne = { workspace = true }
-thiserror = { workspace = true }
 once_cell = { workspace = true }
 
 # Serialization

--- a/crates/quarto-hub/Cargo.toml
+++ b/crates/quarto-hub/Cargo.toml
@@ -22,7 +22,6 @@ tokio = { version = "1", features = ["full"] }
 
 # Web framework (version 0.8 to match samod)
 axum = { version = "0.8", features = ["ws"] }
-tower = "0.5"
 tower-http = { version = "0.6", features = ["trace", "cors", "set-header"] }
 http = "1"
 

--- a/crates/quarto-lsp-core/Cargo.toml
+++ b/crates/quarto-lsp-core/Cargo.toml
@@ -12,16 +12,11 @@ description = "Transport-agnostic language analysis for Quarto documents"
 serde.workspace = true
 serde_json.workspace = true
 
-# Error handling
-thiserror.workspace = true
-
 # Workspace dependencies (all WASM-compatible)
 pampa = { workspace = true }
 quarto-analysis = { workspace = true }
 quarto-core = { workspace = true }
-quarto-pandoc-types = { workspace = true }
 quarto-system-runtime = { workspace = true }
-quarto-yaml = { workspace = true }
 quarto-source-map = { workspace = true }
 quarto-error-reporting = { workspace = true }
 

--- a/crates/quarto-lsp/Cargo.toml
+++ b/crates/quarto-lsp/Cargo.toml
@@ -16,24 +16,12 @@ path = "src/lib.rs"
 # Note: We use the lsp-types re-exported by tower-lsp to avoid version conflicts
 tower-lsp.workspace = true
 tokio.workspace = true
-
-# Serialization
-serde.workspace = true
 serde_json.workspace = true
-
-# Error handling
-thiserror.workspace = true
-anyhow.workspace = true
-
-# Logging
-tracing.workspace = true
-tracing-subscriber.workspace = true
 
 # Local crates
 quarto-lsp-core = { workspace = true }
 
 [dev-dependencies]
-insta.workspace = true
 
 [lints]
 workspace = true

--- a/crates/quarto-mcp-launcher/Cargo.toml
+++ b/crates/quarto-mcp-launcher/Cargo.toml
@@ -11,7 +11,6 @@ anyhow.workspace = true
 dirs = "6"
 fs2 = "0.4"
 include_dir.workspace = true
-serde = { version = "1.0", features = ["derive"] }
 serde_json.workspace = true
 sha2 = "0.11"
 thiserror.workspace = true

--- a/crates/quarto-pandoc-types/Cargo.toml
+++ b/crates/quarto-pandoc-types/Cargo.toml
@@ -17,7 +17,6 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 hashlink = { version = "0.11.0", features = ["serde_impl"] }
 yaml-rust2 = { workspace = true }
-indexmap = "2.13"
 
 [lints]
 workspace = true

--- a/crates/quarto-parse-errors/Cargo.toml
+++ b/crates/quarto-parse-errors/Cargo.toml
@@ -14,7 +14,6 @@ repository.workspace = true
 quarto-error-reporting = { path = "../quarto-error-reporting" }
 quarto-source-map = { path = "../quarto-source-map" }
 tree-sitter = { workspace = true }
-serde = { workspace = true, features = ["derive"] }
 serde_json = "1.0"
 quarto-error-message-macros = { path = "./error-message-macros" }
 hashlink = "0.11"

--- a/crates/quarto-preview/Cargo.toml
+++ b/crates/quarto-preview/Cargo.toml
@@ -35,8 +35,6 @@ quarto-trace.workspace = true
 
 [dev-dependencies]
 tempfile = "3"
-tower = "0.5"
-http-body-util = "0.1"
 http = "1"
 reqwest = { version = "0.12", features = ["blocking", "json"] }
 

--- a/crates/quarto-publish/Cargo.toml
+++ b/crates/quarto-publish/Cargo.toml
@@ -19,18 +19,12 @@ serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true
 thiserror.workspace = true
-tracing.workspace = true
 url = "2.5"
 ureq = { version = "3", default-features = false, features = ["rustls"] }
 uuid.workspace = true
-
-quarto-core.workspace = true
-quarto-util.workspace = true
-quarto-system-runtime.workspace = true
 quarto-config.workspace = true
 quarto-pandoc-types.workspace = true
 quarto-source-map.workspace = true
-quarto-error-reporting.workspace = true
 
 [dev-dependencies]
 pollster.workspace = true

--- a/crates/quarto-sass/Cargo.toml
+++ b/crates/quarto-sass/Cargo.toml
@@ -28,7 +28,6 @@ quarto-brand.workspace = true
 sha2 = "0.11"
 
 [dev-dependencies]
-insta.workspace = true
 serde_json.workspace = true
 yaml-rust2.workspace = true
 tempfile = "3"

--- a/crates/quarto-test/Cargo.toml
+++ b/crates/quarto-test/Cargo.toml
@@ -9,9 +9,6 @@ description = "Testing infrastructure for Quarto documents with embedded asserti
 
 [dependencies]
 anyhow.workspace = true
-thiserror.workspace = true
-tracing.workspace = true
-serde.workspace = true
 serde_yaml.workspace = true
 regex.workspace = true
 scraper.workspace = true

--- a/crates/quarto-trace-server/Cargo.toml
+++ b/crates/quarto-trace-server/Cargo.toml
@@ -8,19 +8,14 @@ description = "Local HTTP server for the Quarto trace viewer SPA."
 
 [dependencies]
 anyhow.workspace = true
-tracing.workspace = true
-serde.workspace = true
 serde_json.workspace = true
-thiserror.workspace = true
 include_dir.workspace = true
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "signal", "fs"] }
 axum = "0.8"
-tower-http = { version = "0.6", features = ["cors"] }
 
 quarto-trace.workspace = true
 
 [dev-dependencies]
-tempfile = "3"
 tower = "0.5"
 http-body-util = "0.1"
 http = "1"

--- a/crates/quarto-util/Cargo.toml
+++ b/crates/quarto-util/Cargo.toml
@@ -8,8 +8,6 @@ repository.workspace = true
 description = "Shared utilities for Quarto"
 
 [dependencies]
-thiserror.workspace = true
-serde.workspace = true
 
 [lints]
 workspace = true

--- a/crates/quarto-xml/Cargo.toml
+++ b/crates/quarto-xml/Cargo.toml
@@ -11,10 +11,8 @@ description = "Source-tracked XML parsing for Quarto"
 quick-xml = { workspace = true }
 quarto-error-reporting = { path = "../quarto-error-reporting" }
 quarto-source-map = { path = "../quarto-source-map" }
-thiserror = { workspace = true }
 
 [dev-dependencies]
-insta = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/quarto-yaml-validation/Cargo.toml
+++ b/crates/quarto-yaml-validation/Cargo.toml
@@ -7,8 +7,6 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-# Error handling
-anyhow.workspace = true
 thiserror.workspace = true
 
 # Serialization (serde_json for enum values in schemas)

--- a/crates/quarto-yaml/Cargo.toml
+++ b/crates/quarto-yaml/Cargo.toml
@@ -8,8 +8,6 @@ repository.workspace = true
 
 [dependencies]
 yaml-rust2 = { workspace = true }
-serde = { workspace = true }
-thiserror = { workspace = true }
 quarto-source-map = { path = "../quarto-source-map" }
 
 [dev-dependencies]

--- a/crates/quarto/Cargo.toml
+++ b/crates/quarto/Cargo.toml
@@ -29,15 +29,12 @@ quarto-trace.workspace = true
 quarto-trace-server.workspace = true
 quarto-util.workspace = true
 quarto-system-runtime.workspace = true
-quarto-doctemplate.workspace = true
 quarto-lsp = { workspace = true }
 quarto-hub.workspace = true
 quarto-mcp-launcher = { path = "../quarto-mcp-launcher" }
 quarto-preview = { path = "../quarto-preview" }
 quarto-publish.workspace = true
-quarto-sass.workspace = true
 quarto-test.workspace = true
-serde_yaml.workspace = true
 tempfile = "3"
 # Phase D.1 (bd-kw93.8): auto-open browser tabs on `q2 preview`.
 # `open` shells out to the platform-native launcher (`open` on macOS,

--- a/crates/validate-yaml/Cargo.toml
+++ b/crates/validate-yaml/Cargo.toml
@@ -10,7 +10,6 @@ repository.workspace = true
 # Workspace crates
 quarto-yaml.workspace = true
 quarto-yaml-validation.workspace = true
-quarto-error-reporting.workspace = true
 quarto-source-map.workspace = true
 
 # Error handling

--- a/crates/wasm-quarto-hub-client/Cargo.lock
+++ b/crates/wasm-quarto-hub-client/Cargo.lock
@@ -1796,14 +1796,12 @@ dependencies = [
 name = "pampa"
 version = "0.0.0"
 dependencies = [
- "ariadne",
  "base64",
  "clap",
  "comrak",
  "comrak-to-pandoc",
  "glob",
  "hashlink",
- "indexmap",
  "mlua",
  "once_cell",
  "paste",
@@ -2105,7 +2103,6 @@ dependencies = [
 name = "quarto-citeproc"
 version = "0.3.0"
 dependencies = [
- "glob",
  "hashlink",
  "quarto-csl",
  "quarto-error-reporting",
@@ -2116,14 +2113,12 @@ dependencies = [
  "serde",
  "serde_json",
  "similar",
- "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "quarto-config"
 version = "0.0.0"
 dependencies = [
- "indexmap",
  "quarto-error-reporting",
  "quarto-pandoc-types",
  "quarto-source-map",
@@ -2136,7 +2131,6 @@ dependencies = [
 name = "quarto-core"
 version = "0.3.0"
 dependencies = [
- "anyhow",
  "async-trait",
  "base64",
  "glob",
@@ -2160,7 +2154,6 @@ dependencies = [
  "quarto-source-map",
  "quarto-system-runtime",
  "quarto-trace",
- "quarto-util",
  "quarto-yaml",
  "rayon",
  "regex",
@@ -2189,7 +2182,6 @@ dependencies = [
  "quarto-error-reporting",
  "quarto-source-map",
  "quarto-xml",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2197,11 +2189,8 @@ name = "quarto-doctemplate"
 version = "0.1.0"
 dependencies = [
  "quarto-error-reporting",
- "quarto-parse-errors",
  "quarto-source-map",
  "quarto-treesitter-ast",
- "serde",
- "serde_json",
  "thiserror 2.0.18",
  "tree-sitter",
  "tree-sitter-doctemplate",
@@ -2228,7 +2217,6 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
  "url",
 ]
 
@@ -2276,13 +2264,10 @@ dependencies = [
  "quarto-core",
  "quarto-error-reporting",
  "quarto-highlight",
- "quarto-pandoc-types",
  "quarto-source-map",
  "quarto-system-runtime",
- "quarto-yaml",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
  "tree-sitter",
  "tree-sitter-qmd",
 ]
@@ -2302,7 +2287,6 @@ name = "quarto-pandoc-types"
 version = "0.0.0"
 dependencies = [
  "hashlink",
- "indexmap",
  "quarto-source-map",
  "serde",
  "serde_json",
@@ -2317,7 +2301,6 @@ dependencies = [
  "quarto-error-message-macros",
  "quarto-error-reporting",
  "quarto-source-map",
- "serde",
  "serde_json",
  "tree-sitter",
 ]
@@ -2394,21 +2377,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "quarto-util"
-version = "0.3.0"
-dependencies = [
- "serde",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "quarto-xml"
 version = "0.3.0"
 dependencies = [
  "quarto-error-reporting",
  "quarto-source-map",
  "quick-xml",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2416,8 +2390,6 @@ name = "quarto-yaml"
 version = "0.3.0"
 dependencies = [
  "quarto-source-map",
- "serde",
- "thiserror 2.0.18",
  "yaml-rust2",
 ]
 


### PR DESCRIPTION
Removes **59 unused dependency declarations across 27 crates** — manifest hygiene, no source changes.

## What we used
[`cargo-machete`](https://github.com/bnjbvr/cargo-machete) (`--with-metadata`) to find unused deps, then Claude verified every hit "by hand" before removing it.

## Intentionally risk-averse
We removed only declarations with zero usage and left anything that *looks* unused but isn't. Kept on purpose:

- `openssl-sys` (`quarto`) — link-only, behind the `vendored-openssl` feature
- `quarto-error-message-macros` (`quarto-parse-errors`) — proc-macro; derive name ≠ crate name
- `tokio` (`quarto-lsp-core`) — macro-based usage
- `sha2` (`quarto-sass`) — used in `build.rs` (machete doesn't scan build scripts)
- `cc` + the wasm/fuzz/patch-crate deps — left untouched

## Impact
Only `pretty_assertions` (+ `diff`) drops from the build graph entirely; the rest were redundant declarations of crates still used elsewhere.

## How we tested
Full `cargo xtask verify` — all 14 steps green, covering `cargo build --workspace`, `cargo nextest run --workspace`, the WASM rebuild, and the hub-client build/tests. The all-targets build is itself the proof: any test relying on a removed dev-dep would have failed to compile.

Strand: bd-e3lv7eg3.