### PR TITLE
fix(highlight): capture brace in qmd cell tokenizer rule (bd-yrl8vqbg)

### DIFF
--- a/hub-client/changelog.md
+++ b/hub-client/changelog.md
@@ -17,6 +17,7 @@ be in reverse chronological order (latest first).
 
 ### 2026-06-17
 
+- [`0e2bb57d`](https://github.com/quarto-dev/q2/commits/0e2bb57d): Fixed a crash that blanked the editor when opening a `.qmd` file containing an executable code cell (e.g. ```` ```{r} ````).
 - [`744c6ed1`](https://github.com/quarto-dev/q2/commits/744c6ed1): Editor `.qmd` syntax highlighting now appears immediately on file open, instead of after a brief debounce.
 - [`13c5b98b`](https://github.com/quarto-dev/q2/commits/13c5b98b): The Monaco editor now syntax-highlights `.qmd` files via tree-sitter — qmd structure, frontmatter YAML, and code-cell interiors (comments and link/image brackets included) — driven by the same highlighter as the render path.
 

--- a/hub-client/src/components/quartoTheme.test.ts
+++ b/hub-client/src/components/quartoTheme.test.ts
@@ -28,6 +28,36 @@ describe('quartoThemeRules namespace invariant', () => {
   });
 });
 
+describe('qmd Monarch base — group reconstruction invariant', () => {
+  // Regression (GH#10): Monaco's MonarchTokenizer throws "with groups, all
+  // characters should be matched in consecutive groups" when an array-action
+  // rule's regex consumes characters outside its capture groups (e.g. via a
+  // non-capturing `(?:…)` group). It crashes the editor mid-tokenise, but only
+  // on lines that actually match — so it slips past mount and fires when a
+  // ```{r} executable cell appears. Encode the invariant statically.
+  const samples: Array<{ line: string; desc: string }> = [
+    { line: '```{r}', desc: 'executable cell, brace syntax' },
+    { line: '```{python echo=false}', desc: 'executable cell with options' },
+    { line: '```python', desc: 'plain fenced cell' },
+    { line: '```', desc: 'bare fence' },
+  ];
+  const contentRules = qmdMonarch.tokenizer.content as Array<[RegExp, unknown]>;
+  for (const { line, desc } of samples) {
+    it(`array-action rules matching "${line}" (${desc}) capture every char`, () => {
+      for (const [re, action] of contentRules) {
+        if (!Array.isArray(action)) continue;
+        const m = line.match(re);
+        if (!m) continue;
+        const groupLen = m.slice(1).reduce((n, g) => n + (g?.length ?? 0), 0);
+        expect(
+          groupLen,
+          `rule ${re} leaves ${m[0].length - groupLen} char(s) uncaptured — Monaco will throw mid-tokenise`,
+        ).toBe(m[0].length);
+      }
+    });
+  }
+});
+
 describe('qmd Monarch base — bracket symmetry', () => {
   // Regression: a base `content` rule coloured the opening `[` (as `string`)
   // but nothing coloured the closing `]`, so wherever the base shows through

--- a/hub-client/src/components/quartoTheme.ts
+++ b/hub-client/src/components/quartoTheme.ts
@@ -123,7 +123,7 @@ export const qmdMonarch: Monaco.languages.IMonarchLanguage = {
       // Quarto executable cell: ```{r}, ```{python}, ... — route by the inner
       // language name (capture group 2).
       [
-        /^(\s*`{3,})(?:\{)([\w-]+)([^}]*\}.*)$/,
+        /^(\s*`{3,}\{)([\w-]+)([^}]*\}.*)$/,
         ['string', { token: 'attribute.name', nextEmbedded: '$2', next: '@codeblock' }, 'attribute.value'],
       ],
       // Plain fenced cell: ```python, ```sql, ...


### PR DESCRIPTION
## What

Opening a `.qmd` file containing an executable cell (e.g. ` ```{r} `) crashed the editor to a blank page.

## Cause

The qmd Monarch tokenizer's executable-cell rule used a **non-capturing** group for the opening brace:

```js
/^(\s*`{3,})(?:\{)([\w-]+)([^}]*\}.*)$/
```

Monaco requires array-action rules to capture **every** matched character in consecutive groups. The `(?:\{)` consumed the `{` without a capture, so the moment a `{r}`/`{python}` line matched, Monaco threw *"with groups, all characters should be matched in consecutive groups"* and tokenization died.

## Fix

Fold the `{` into capture group 1 — group 2 (the language name used by `nextEmbedded: '$2'`) is unchanged:

```js
/^(\s*`{3,}\{)([\w-]+)([^}]*\}.*)$/
```

A static invariant test guards every array-action rule against future non-capturing groups.