### PR TITLE
Revert #307 qmd cell brace fix; add <Editor> error boundary

### DIFF
--- a/hub-client/changelog.md
+++ b/hub-client/changelog.md
@@ -17,7 +17,6 @@ be in reverse chronological order (latest first).
 
 ### 2026-06-17
 
-- [`0e2bb57d`](https://github.com/quarto-dev/q2/commits/0e2bb57d): Fixed a crash that blanked the editor when opening a `.qmd` file containing an executable code cell (e.g. ```` ```{r} ````).
 - [`744c6ed1`](https://github.com/quarto-dev/q2/commits/744c6ed1): Editor `.qmd` syntax highlighting now appears immediately on file open, instead of after a brief debounce.
 - [`13c5b98b`](https://github.com/quarto-dev/q2/commits/13c5b98b): The Monaco editor now syntax-highlights `.qmd` files via tree-sitter — qmd structure, frontmatter YAML, and code-cell interiors (comments and link/image brackets included) — driven by the same highlighter as the render path.
 

--- a/hub-client/src/App.tsx
+++ b/hub-client/src/App.tsx
@@ -14,6 +14,7 @@ function DevHarnessLazy({ page }: { page: string }) {
   );
 }
 import Editor from './components/Editor';
+import { ErrorBoundary } from './components/ErrorBoundary';
 import Toast from './components/Toast';
 import { ViewModeProvider } from './components/ViewModeContext';
 import { LoginScreen } from './components/auth/LoginScreen';
@@ -652,19 +653,21 @@ function App() {
         />
       ) : (
         <ViewModeProvider>
-          <Editor
-            project={project}
-            files={files}
-            fileContents={fileContents}
-            onDisconnect={handleDisconnect}
-            onContentOperations={handleContentOperations}
-            route={route}
-            onNavigateToFile={(filePath, options) => {
-              navigateToFile(project.id, filePath, options);
-            }}
-            identities={identities}
-            isOnline={isOnline}
-          />
+          <ErrorBoundary>
+            <Editor
+              project={project}
+              files={files}
+              fileContents={fileContents}
+              onDisconnect={handleDisconnect}
+              onContentOperations={handleContentOperations}
+              route={route}
+              onNavigateToFile={(filePath, options) => {
+                navigateToFile(project.id, filePath, options);
+              }}
+              identities={identities}
+              isOnline={isOnline}
+            />
+          </ErrorBoundary>
         </ViewModeProvider>
       )}
       <Toast

--- a/hub-client/src/components/ErrorBoundary.test.tsx
+++ b/hub-client/src/components/ErrorBoundary.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * Tests for the reusable ErrorBoundary.
+ *
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { useState } from 'react';
+import { ErrorBoundary } from './ErrorBoundary';
+
+afterEach(cleanup);
+
+// A child that throws on render — React surfaces it to the nearest boundary.
+function Boom({ when = true }: { when?: boolean }) {
+  if (when) throw new Error('kaboom');
+  return <div>child ok</div>;
+}
+
+// React logs caught boundary errors to console.error; silence it per test.
+function withSilencedConsole(fn: () => void) {
+  const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  try {
+    fn();
+  } finally {
+    spy.mockRestore();
+  }
+}
+
+describe('ErrorBoundary', () => {
+  it('renders children unchanged when nothing throws', () => {
+    render(
+      <ErrorBoundary>
+        <div>safe child</div>
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText('safe child')).toBeTruthy();
+  });
+
+  it('renders an actionable fallback (not a blank tree) when a child throws', () => {
+    withSilencedConsole(() => {
+      render(
+        <ErrorBoundary>
+          <Boom />
+        </ErrorBoundary>,
+      );
+    });
+    // The whole subtree must not vanish: the fallback surfaces the error and a
+    // recovery affordance instead of blanking the session.
+    expect(screen.getByText(/something went wrong/i)).toBeTruthy();
+    expect(screen.getByText('kaboom')).toBeTruthy();
+    expect(screen.getByRole('button', { name: /reload/i })).toBeTruthy();
+  });
+
+  it('renders a custom fallback node when provided', () => {
+    withSilencedConsole(() => {
+      render(
+        <ErrorBoundary fallback={<div>editor unavailable</div>}>
+          <Boom />
+        </ErrorBoundary>,
+      );
+    });
+    expect(screen.getByText('editor unavailable')).toBeTruthy();
+  });
+
+  it('passes the error + reset() to a function fallback, and reset() recovers', () => {
+    function Harness() {
+      const [explode, setExplode] = useState(true);
+      return (
+        <ErrorBoundary
+          fallback={(error, reset) => (
+            <button
+              onClick={() => {
+                setExplode(false);
+                reset();
+              }}
+            >
+              retry: {error.message}
+            </button>
+          )}
+        >
+          <Boom when={explode} />
+        </ErrorBoundary>
+      );
+    }
+    withSilencedConsole(() => {
+      render(<Harness />);
+      fireEvent.click(screen.getByText('retry: kaboom'));
+    });
+    expect(screen.getByText('child ok')).toBeTruthy();
+  });
+
+  it('invokes onError with the caught error', () => {
+    const onError = vi.fn();
+    withSilencedConsole(() => {
+      render(
+        <ErrorBoundary onError={onError}>
+          <Boom />
+        </ErrorBoundary>,
+      );
+    });
+    expect(onError).toHaveBeenCalledOnce();
+    expect(onError.mock.calls[0][0]).toBeInstanceOf(Error);
+  });
+});

--- a/hub-client/src/components/ErrorBoundary.tsx
+++ b/hub-client/src/components/ErrorBoundary.tsx
@@ -1,0 +1,77 @@
+/**
+ * Reusable React error boundary.
+ *
+ * A throw in a descendant's render/lifecycle unmounts only this subtree and
+ * shows a fallback, instead of propagating up and blanking the whole app. Wrap
+ * isolatable regions (e.g. the Monaco `<Editor>`) so a bug in one pane can't
+ * take down the session.
+ *
+ * Note: like all React error boundaries, this catches errors thrown during
+ * render/lifecycle — NOT async callbacks or event handlers. Monaco's own
+ * background tokenizer throws are already absorbed by its `safeTokenize`.
+ */
+
+import { Component } from 'react';
+import type { ErrorInfo, ReactNode } from 'react';
+
+interface Props {
+  children: ReactNode;
+  /** Custom fallback. A function receives the error + a reset() to retry. */
+  fallback?: ReactNode | ((error: Error, reset: () => void) => ReactNode);
+  /** Side-effect hook for the caught error (logging/telemetry). */
+  onError?: (error: Error, info: ErrorInfo) => void;
+}
+
+interface State {
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    console.error('[ErrorBoundary] Caught error:', error, info);
+    this.props.onError?.(error, info);
+  }
+
+  private reset = (): void => this.setState({ error: null });
+
+  render(): ReactNode {
+    const { error } = this.state;
+    if (!error) return this.props.children;
+
+    const { fallback } = this.props;
+    if (typeof fallback === 'function') return fallback(error, this.reset);
+    if (fallback !== undefined) return fallback;
+    return <DefaultFallback error={error} onReset={this.reset} />;
+  }
+}
+
+function DefaultFallback({ error, onReset }: { error: Error; onReset: () => void }) {
+  return (
+    <div
+      role="alert"
+      style={{
+        padding: '24px',
+        margin: '16px',
+        backgroundColor: '#fee',
+        border: '1px solid #fcc',
+        borderRadius: '6px',
+        fontFamily: 'system-ui, sans-serif',
+        fontSize: '14px',
+        color: '#900',
+      }}
+    >
+      <h3 style={{ margin: '0 0 8px 0' }}>Something went wrong</h3>
+      <p style={{ margin: '0 0 12px 0' }}>{error.message}</p>
+      <div style={{ display: 'flex', gap: '8px' }}>
+        <button onClick={onReset}>Try again</button>
+        <button onClick={() => window.location.reload()}>Reload</button>
+      </div>
+    </div>
+  );
+}

--- a/hub-client/src/components/quartoTheme.test.ts
+++ b/hub-client/src/components/quartoTheme.test.ts
@@ -28,36 +28,6 @@ describe('quartoThemeRules namespace invariant', () => {
   });
 });
 
-describe('qmd Monarch base — group reconstruction invariant', () => {
-  // Regression (GH#10): Monaco's MonarchTokenizer throws "with groups, all
-  // characters should be matched in consecutive groups" when an array-action
-  // rule's regex consumes characters outside its capture groups (e.g. via a
-  // non-capturing `(?:…)` group). It crashes the editor mid-tokenise, but only
-  // on lines that actually match — so it slips past mount and fires when a
-  // ```{r} executable cell appears. Encode the invariant statically.
-  const samples: Array<{ line: string; desc: string }> = [
-    { line: '```{r}', desc: 'executable cell, brace syntax' },
-    { line: '```{python echo=false}', desc: 'executable cell with options' },
-    { line: '```python', desc: 'plain fenced cell' },
-    { line: '```', desc: 'bare fence' },
-  ];
-  const contentRules = qmdMonarch.tokenizer.content as Array<[RegExp, unknown]>;
-  for (const { line, desc } of samples) {
-    it(`array-action rules matching "${line}" (${desc}) capture every char`, () => {
-      for (const [re, action] of contentRules) {
-        if (!Array.isArray(action)) continue;
-        const m = line.match(re);
-        if (!m) continue;
-        const groupLen = m.slice(1).reduce((n, g) => n + (g?.length ?? 0), 0);
-        expect(
-          groupLen,
-          `rule ${re} leaves ${m[0].length - groupLen} char(s) uncaptured — Monaco will throw mid-tokenise`,
-        ).toBe(m[0].length);
-      }
-    });
-  }
-});
-
 describe('qmd Monarch base — bracket symmetry', () => {
   // Regression: a base `content` rule coloured the opening `[` (as `string`)
   // but nothing coloured the closing `]`, so wherever the base shows through

--- a/hub-client/src/components/quartoTheme.ts
+++ b/hub-client/src/components/quartoTheme.ts
@@ -123,7 +123,7 @@ export const qmdMonarch: Monaco.languages.IMonarchLanguage = {
       // Quarto executable cell: ```{r}, ```{python}, ... — route by the inner
       // language name (capture group 2).
       [
-        /^(\s*`{3,}\{)([\w-]+)([^}]*\}.*)$/,
+        /^(\s*`{3,})(?:\{)([\w-]+)([^}]*\}.*)$/,
         ['string', { token: 'attribute.name', nextEmbedded: '$2', next: '@codeblock' }, 'attribute.value'],
       ],
       // Plain fenced cell: ```python, ```sql, ...


### PR DESCRIPTION
Reverts #307 and adds an editor error boundary instead.

### Why revert #307
Its fix folded the opening `{` into the `string` token, which made the closing `}` render as a **mismatched** bracket. A follow-up that made both braces real brackets then painted them **bright red** via bracket-pair colorization. Neither was acceptable.

### What this does
- **Revert #307** — restores the pre-#307 baseline (`bd-rxy7iexi`). The `(?:\{)` rule can still throw, but Monaco's `safeTokenize` already absorbs it (logs + plain-token fallback), so the only effect is console noise and one unhighlighted fence line. A proper rule fix is deferred.
- **Add a React error boundary** around `<Editor>` (`bd-c5j0ocgl`) so any throw in the editor subtree shows a fallback instead of blanking the session.
