### PR TITLE
feat: block-level attributes on Paragraph via safe extra `attr` JSON key (bd-itqcfxc3)

### DIFF
--- a/claude-notes/plans/2026-06-17-block-level-attrs-inline-attr.md
+++ b/claude-notes/plans/2026-06-17-block-level-attrs-inline-attr.md
@@ -30,21 +30,52 @@
     accumulate (dedup), kv last-wins. Easy to revisit — it's localized to the
     helper.
 
+- **2026-06-17 — `Paragraph` across all three renderers (done).**
+  - **html.rs** `Paragraph` writer collects via `split_trailing_block_attr`,
+    emits `write_attr` on the `<p>`, renders the retained content. The inline
+    writers (`write_inlines` / `find_attribution_run_end` / `write_inlines_as_text`)
+    were widened from `&Inlines` to `&[Inline]` so a content *prefix* can be
+    rendered. Test `paragraph_trailing_attr_becomes_p_class`.
+  - **React** `Para.tsx` reads the optional `attr` key (added to `ParaBlock` in
+    `framework/types.ts`) and applies id/classes/`data-*`/`role` to the `<p>`,
+    mirroring `Header.tsx`. Test in `q2-preview.integration.test.tsx`. Full
+    preview-renderer suite green (219 unit + 229 integration); `tsc` build clean.
+  - **End-to-end through the binary** (✅ inspected). The parser *already* emits a
+    trailing `Inline::Attr` for plain qmd `paragraph text {.caption}`, so the
+    capability is reachable by plain authoring — no consumer filter needed:
+    - `pampa -t html -i cap.qmd` → `<p class="caption">This is a caption.</p>`
+    - `pampa -t json -i cap.qmd | pandoc -f json -t html` → `<p>This is a caption.</p>`
+      (Pandoc ignores the `attr` key — graceful, no error)
+    - This was previously a `Q-3-32` *error* in JSON; it now works.
+  - **Behavior change worth noting:** plain qmd `paragraph {.class}` now yields
+    `<p class="class">` in html/json/preview (it errored/was dropped before).
+    Consistent with `## Heading {.class}`; arguably the intended qmd semantics.
+    Full `pampa` suite stayed green (3967), so no existing test relied on the old
+    drop/error.
+
+### `Plain` is out of scope (decided)
+
+A `Plain` emits **no wrapping element** — bare inlines in HTML, a bare fragment
+in React — so a block attr on a `Plain` has nowhere to land. The figure-caption
+that wants `<p class="caption">` must be a **`Paragraph`**. `Plain` is therefore
+intentionally *not* a block-attr carrier; the `json.rs`/`native.rs` `Plain`
+arms are left as-is.
+
 ### Remaining (next increments)
 
-- [ ] `Plain` streaming writer: same treatment (reveal caption may be a `Plain`).
-- [ ] **html.rs** `Paragraph`/`Plain` writers: call `split_trailing_block_attr`,
-      `write_attr` on the `<p>`, write the retained content. (`q2 render` path.)
-- [ ] **React** `Para.tsx`/`Plain.tsx` (`ts-packages/preview-renderer`): read the
-      `attr` key and apply to the wrapper. Dumb read — no merge logic in TS.
+- [ ] **`native.rs`** still errors `Q-3-32` on a `Para` trailing attr (pre-existing;
+      now reachable via plain qmd `paragraph {.attr}`). Decide its contract:
+      faithfully print the resolved attr, drop silently, or keep erroring as a
+      debug-only format. Deferred — needs a call on native's faithfulness intent.
 - [ ] JSON **reader** fold-back (optional): teach `readers/json.rs` to restore a
       trailing `Inline::Attr` from the `attr` key, so a json→AST→json round-trip
       doesn't silently drop the block attr. Not needed for preview (no read-back).
-- [ ] End-to-end parity test: reveal figure-caption fixture renders
-      `<p class="caption">` in both `q2 render` and `q2 preview` (q2-slides).
-- [ ] List items (`<li class>`) — distinct hoist mechanism; later sub-task.
-- [ ] Decide `native.rs` behavior (still errors `Q-3-32`): faithfully print the
-      resolved attr, or keep erroring as a debug-only format.
+- [ ] List items (`<li class>`) — distinct hoist mechanism (attr rides on the
+      item's child block; the `<li>` writer must hoist it, composing with the
+      incremental `fragment` class). Later sub-task.
+- [ ] Wire the actual consumer: bd-38ioql41 reveal figure caption emits a
+      `Paragraph[..caption.., Attr{.caption}]`; add the q2-slides preview parity
+      check there.
 
 
 

--- a/claude-notes/plans/2026-06-17-block-level-attrs-inline-attr.md
+++ b/claude-notes/plans/2026-06-17-block-level-attrs-inline-attr.md
@@ -2,7 +2,51 @@
 
 **Strand:** bd-itqcfxc3 (discovered-from bd-38ioql41)
 **Date:** 2026-06-17
-**Status:** design sketch — separate implementation session, not started
+**Status:** in progress — JSON-writer keystone landed (see Progress below)
+
+## Progress
+
+- **2026-06-17 — JSON transport keystone (done).** The conceptual blocker was
+  that the `q2 preview` path is `json.rs` → React, and `json.rs` *errored*
+  (`Q-3-32`) on a stray `Inline::Attr`, so a block attr could never reach the
+  preview. **Resolved via the "safe extra key" channel** (the same trick the
+  `s`/`l` source-info keys use): a `Para` with a trailing `Inline::Attr` now
+  serializes to a Pandoc-valid `Para` node carrying an extra `attr` object key
+  (`{"attr":[id,classes,kvs], "c":[…stripped inlines…], …}`). **Verified
+  empirically** that Pandoc 3.9 ignores the extra key (`pandoc -f json` on the
+  writer's literal bytes yields `Para [Str …]` → `<p>…</p>`) — so the wire form
+  degrades gracefully for external Pandoc while our React renderer can read it.
+  - New shared helper `crates/pampa/src/writers/block_attr.rs`
+    `split_trailing_block_attr(&[Inline]) -> (&[Inline], Attr)` — collects the
+    trailing `Inline::Attr` run (+ interleaved/preceding whitespace), merges
+    (id last-wins, classes accumulate+dedup, kv last-wins), returns the retained
+    prefix. Block-agnostic; html.rs and the list-item case will reuse it.
+  - Wired into the **streaming** `Para` writer (`json.rs` `stream_write_block`;
+    note `write_with_config` uses the streaming path, not the tree `write_block`).
+  - Tests: `block_attr` unit tests (semantics) + `test_paragraph_trailing_attr_emits_attr_key`
+    (wire format). Full `pampa` suite green (3965), inert for existing docs (no
+    paragraph carries a trailing `Inline::Attr` today).
+  - **Merge semantics chosen:** trailing-run-only, id last-wins, classes
+    accumulate (dedup), kv last-wins. Easy to revisit — it's localized to the
+    helper.
+
+### Remaining (next increments)
+
+- [ ] `Plain` streaming writer: same treatment (reveal caption may be a `Plain`).
+- [ ] **html.rs** `Paragraph`/`Plain` writers: call `split_trailing_block_attr`,
+      `write_attr` on the `<p>`, write the retained content. (`q2 render` path.)
+- [ ] **React** `Para.tsx`/`Plain.tsx` (`ts-packages/preview-renderer`): read the
+      `attr` key and apply to the wrapper. Dumb read — no merge logic in TS.
+- [ ] JSON **reader** fold-back (optional): teach `readers/json.rs` to restore a
+      trailing `Inline::Attr` from the `attr` key, so a json→AST→json round-trip
+      doesn't silently drop the block attr. Not needed for preview (no read-back).
+- [ ] End-to-end parity test: reveal figure-caption fixture renders
+      `<p class="caption">` in both `q2 render` and `q2 preview` (q2-slides).
+- [ ] List items (`<li class>`) — distinct hoist mechanism; later sub-task.
+- [ ] Decide `native.rs` behavior (still errors `Q-3-32`): faithfully print the
+      resolved attr, or keep erroring as a debug-only format.
+
+
 
 ## Motivation
 
@@ -43,24 +87,81 @@ Paragraph[ Str("This is a caption."), Attr({"", ["caption"], {}}) ]
   ⇒  <p class="caption">This is a caption.</p>
 ```
 
+## Architecture (confirmed 2026-06-17 — this reframes the risk)
+
+The render and preview paths are **two different renderers**, and the primary
+consumer (reveal figure caption) flows through the *non-HTML* one:
+
+- **`q2 render` (to disk)** → `crates/pampa/src/writers/html.rs`. Today it
+  **drops** a stray `Inline::Attr` (`html.rs:1058`). It consumes the in-memory
+  AST directly and can emit raw `<p class="…">` trivially.
+- **`q2 preview` (live iframe)** → `crates/pampa/src/writers/json.rs` produces a
+  **Pandoc-shaped JSON tree + an `astContext` sidecar**, which is rendered by a
+  **separate React renderer**, `ts-packages/preview-renderer/` — *not* by
+  `html.rs`. For `format: revealjs` the preview pseudo-format is `q2-slides`
+  (`wasm-quarto-hub-client/src/lib.rs` `map_format_for_preview`): same JSON
+  pipeline, React builds the reveal shell. **The figure-caption consumer
+  (bd-38ioql41) is a reveal feature, so its preview is rendered by React, not
+  by `html.rs`.**
+  - Today `json.rs` **errors** (`Q-3-32`) on a stray `Inline::Attr` and emits an
+    empty `Str` placeholder, so the node never reaches the JSON.
+  - The React side has **no `Attr` inline** at all — an unregistered inline
+    renders a "(not yet implemented)" placeholder
+    (`ts-packages/preview-renderer/src/q2-preview/dispatchers.tsx`).
+  - React block leaves read the Pandoc attr triple directly: `Header.tsx` reads
+    `node.c[1] = [id, classes, kvs]`; `Div.tsx` reads `node.c[0]`. `Para.tsx`
+    emits `<p>{children}</p>` with **no** attr; `Plain.tsx` a bare fragment;
+    `BulletList.tsx`/`OrderedList.tsx` wrap each item's blocks in a bare `<li>`.
+
+**Q2's JSON extension model:** node shapes stay Pandoc-valid; Quarto-only data
+is either desugared to a valid Pandoc node (e.g. `Custom`→marker `Span`,
+`Shortcode`→`Span`) **or** carried out-of-band in the `astContext` sidecar
+(source info, attribution are already threaded this way and read by the React
+renderer via `resolveSource`). A block-level attr on a paragraph is **not
+expressible as a standard Pandoc node** (`Para` is `["Para",[inlines]]`), so
+*any* approach that makes the preview render `<p class>` must use one of these
+two extension channels and the React renderer must gain explicit handling.
+
 ## Design questions to resolve (the session's real work)
 
-### 1. Where does collection happen — writers vs a normalization transform?
+### 1. Where does collection happen? (the decisive decision)
 
-- **(A) Writer-side collection (user's proposal).** Each block writer scans its
-  inlines for `Inline::Attr`, folds them onto the element, and skips them when
-  writing content. AST stays plain `Para + trailing Attr` (round-trips, simple).
-  **Cost:** *every* renderer must implement the same rule — HTML writer,
-  `native`/`json` writers (already special-case `Inline::Attr`), **and the
-  hub-client React leaves** — or `q2 render` and `q2 preview` diverge. This is
-  the same preview-parity trap the reveal work hit; it is the dominant risk.
-- **(B) Normalization transform.** A late AST pass folds a trailing
-  `Inline::Attr` into a carrier the writers already attribute — but `Para` has
-  no `Attr` field, so the carrier would be a `Div`/`Span`/custom node, changing
-  the DOM (`<div class="caption"><p>…</p></div>`), which is *not* what we want.
-- **Leaning (A)** for fidelity, but the parity cost must be paid deliberately:
-  enumerate every writer/renderer and cover them in one change, with a shared
-  helper so the rule lives in one place.
+Plan option (A) below ("writer-side scan") was the original lean, but the
+two-renderer finding above reframes its cost: a writer-side scan means the
+**merge rule is implemented twice — once in Rust (`html.rs`) and once in
+TypeScript (React leaves)** — with `json.rs` emitting the raw node. That cross-
+language duplication *is* the preview-parity divergence the project fears.
+
+- **(A) Per-renderer scan.** `html.rs` scans its inlines, merges, applies,
+  skips them; `json.rs` emits the `Inline::Attr` faithfully (desugared to a
+  marker `Span` to stay Pandoc-valid); React `Para`/`Plain`/`li` scan children,
+  merge, and apply. AST node types unchanged. **Merge logic duplicated
+  Rust+TS.** Lowest type churn, highest divergence risk.
+- **(B) Resolve once in Rust (recommended).** A shared late AST transform folds
+  the trailing `Inline::Attr` run into a single resolved `Attr` and stores it on
+  the block, so **both** writers read a resolved attr and neither re-merges.
+  Merge semantics live in exactly one place (Rust). Two carrier sub-options:
+  - **(B1) `astContext` sidecar keyed by the block's pool-id** (mirrors how
+    attribution/source-info already reach React). Node tree stays valid Pandoc;
+    `html.rs` reads the resolved attr; React looks up pool-id → applies, no TS
+    merge logic. Most consistent with the existing extension model; most
+    plumbing.
+  - **(B2) Add an `attr: Attr` field to `Paragraph`/`Plain`** (our types — we
+    already extend Pandoc heavily). Cleanest semantics: one transform fills it;
+    `html.rs` and React read it like `Header`/`Div`. Cost: touches every
+    `Paragraph`/`Plain` construction site (mechanical, via `Default`), and the
+    `Para` *JSON node shape* would diverge from Pandoc unless we still sidecar
+    it for `-t json` — i.e. a strict-vs-preview JSON emit split.
+- **(C) Normalization into a different block (rejected).** Folding into a
+  `Div`/`Span` changes the DOM (`<div class><p>…`), which is not the `<p class>`
+  we want.
+
+**Recommendation: (B).** Resolve in Rust so the merge rule is single-sourced;
+lean **(B1 sidecar)** to keep JSON Pandoc-valid and reuse the React renderer's
+existing `astContext` lookup, falling back to a `para.attr` field (B2) only if a
+first-class attributed paragraph is judged worth the wider change. A hybrid is
+also possible: a `para.attr` field internally (clean for `html.rs`) that
+`json.rs` emits into the `astContext` sidecar (Pandoc-valid wire form).
 
 ### 2. Collection semantics
 
@@ -75,9 +176,20 @@ Paragraph[ Str("This is a caption."), Attr({"", ["caption"], {}}) ]
 
 ### 3. Which blocks, in what order
 
-- `Paragraph` first (unblocks the figure caption).
-- `Plain` and **list items** next (the `<li>` styling case).
-- Consider `BlockQuote` and others later; keep the helper block-agnostic.
+- `Paragraph` first (unblocks the figure caption) — the attr rides *in* the
+  paragraph's own inlines, so collection/application is local to the `<p>`.
+- `Plain` next (same shape; the reveal caption may be a `Plain`, not `Para`).
+- **List items** are a *different mechanism* and probably a later sub-task. A
+  Pandoc list item is `[[Block]]` with no per-item attr; the injected
+  `Inline::Attr` would live inside the item's first/last child block (a
+  `Plain`/`Para`). Producing `<li class>` therefore means the list writer must
+  **hoist** the resolved attr from the item's child block up to the `<li>`
+  element — extra plumbing beyond the `<p>` case. (Note the existing
+  `list_item_open` at `html.rs:1272` already special-cases `class="fragment"`
+  for incremental reveal lists; an item attr must compose with that.) Keep the
+  collection helper block-agnostic (returns `(content, Attr)`); the *hoist* is
+  list-writer-specific.
+- Consider `BlockQuote` and others later.
 
 ### 4. Source mapping & round-trip
 
@@ -86,26 +198,58 @@ Paragraph[ Str("This is a caption."), Attr({"", ["caption"], {}}) ]
   `qmd` writer already round-trips `Inline::Attr` (`qmd.rs:2393`). Verify the
   collected-and-applied path keeps source info coherent for the source map.
 
-## Affected code (survey)
+## Affected code (survey, verified 2026-06-17)
 
-- `crates/quarto-pandoc-types/src/inline.rs` — `Inline::Attr` / `InlineAttr`.
-- `crates/pampa/src/writers/html.rs:1058` — currently drops `Inline::Attr`;
-  block writers for `Paragraph`/`Plain` at `:1282`/`:1286`.
-- `crates/pampa/src/writers/{native,json,plaintext,ansi,incremental}.rs` —
-  each already has an `Inline::Attr` arm; align behavior.
-- `crates/pampa/src/pandoc/treesitter_utils/postprocess.rs:924-969` — the
-  existing Header fold precedent (mirror its semantics).
-- **hub-client** React leaves that render `Paragraph`/list items — must honor
-  the same collection rule for preview parity (locate during the session).
+Rust:
+- `crates/quarto-pandoc-types/src/inline.rs:332` — `InlineAttr { attr,
+  attr_source, source_info }`; `inline.rs:41` the `Inline::Attr` variant.
+  (B2 only) `Paragraph`/`Plain` in `block.rs` would gain an `attr` field.
+- `crates/pampa/src/writers/html.rs` — `Inline::Attr` dropped at `:1058`; the
+  attr emitter is `write_attr` (`:504`, used by `Header`/`Div`); `Paragraph`
+  writer `:1286`, `Plain` `:1282`, `list_item_open` `:1272`.
+- `crates/pampa/src/writers/json.rs:922` (and `:2846`) — currently **errors**
+  `Q-3-32` on `Inline::Attr`. This is the preview transport; must change.
+- `crates/pampa/src/writers/native.rs:384` — also errors `Q-3-32`; decide
+  whether native faithfully prints the resolved attr or stays an error.
+- `crates/pampa/src/writers/{qmd,incremental}.rs` — already **round-trip**
+  `Inline::Attr` back to `{…}`; must stay correct (don't double-emit if the
+  transform also strips/relocates the node).
+- `crates/pampa/src/writers/{plaintext,ansi}.rs` — no-op on `Inline::Attr`; fine.
+- `crates/pampa/src/pandoc/treesitter_utils/postprocess.rs:924-969` — the Header
+  fold precedent to mirror (trailing-only pop + `trim_inlines`).
+- A new shared collection helper / transform — location TBD by Decision 1
+  (writer-local helper for (A); an `AstTransform` in `quarto-core` for (B)).
+
+TypeScript (preview-renderer, `q2 preview` / `q2-slides`):
+- `ts-packages/preview-renderer/src/q2-preview/blocks/{Para,Plain,BulletList,OrderedList}.tsx`
+  — apply the resolved/collected attr to the `<p>`/`<li>` wrapper.
+- `ts-packages/preview-renderer/src/framework/types.ts` — (A only) add an
+  `Attr` inline type; (B1) the sidecar lookup reuses existing `astContext`.
+- `ts-packages/preview-renderer/src/q2-preview/dispatchers.tsx` — (A only)
+  register an `Attr` inline so it isn't a "(not yet implemented)" placeholder.
 
 ## Test plan (TDD)
 
-- Writer unit tests: `Paragraph` with a trailing `Inline::Attr{.caption}` →
-  `<p class="caption">…</p>`; multiple attrs merge; empty attr is a no-op;
-  preceding space stripped; list item gets `<li class>`.
-- Parity test: the same AST through the q2-preview path yields the same element
-  attributes (guards the multi-renderer risk).
-- Round-trip: `Inline::Attr` still survives qmd round-trip unaffected.
+Rust:
+- `html.rs` unit tests (mirror `mod tests` there): `Paragraph` with a trailing
+  `Inline::Attr{.caption}` → `<p class="caption">…</p>`; id + kvs applied;
+  multiple attrs merge per rule; empty attr is a no-op; the `Space` before the
+  attr is stripped (no trailing space in `<p>` text); `Plain` and a list item
+  variant per scope.
+- `json.rs` test: the same `Paragraph` serializes so the preview carries the
+  resolved attr (node tree stays Pandoc-valid; attr in `astContext` for B1, or
+  marker form for A) — guards the cross-renderer contract at the boundary.
+- Round-trip: a parser-emitted `Inline::Attr` (heading/table path) still
+  round-trips through `qmd`/`incremental` unaffected.
+- **End-to-end** (per CLAUDE.md): drive a fixture through `render_document_to_file`
+  for `q2 render` and assert `<p class="caption">` in the HTML; do not rely on
+  `render_qmd_to_html` defaults.
+
+TypeScript:
+- preview-renderer test: AST with an attributed `Para`/`li` renders the wrapper
+  with the class (vitest), so `q2 preview` matches `q2 render`.
+- Real-render parity: render the reveal figure-caption fixture and confirm both
+  `q2 render` HTML and the `q2 preview` (q2-slides) DOM show `<p class="caption">`.
 
 ## Relationship to other work
 

--- a/claude-notes/plans/2026-06-17-block-level-attrs-inline-attr.md
+++ b/claude-notes/plans/2026-06-17-block-level-attrs-inline-attr.md
@@ -67,9 +67,15 @@ arms are left as-is.
       now reachable via plain qmd `paragraph {.attr}`). Decide its contract:
       faithfully print the resolved attr, drop silently, or keep erroring as a
       debug-only format. Deferred — needs a call on native's faithfulness intent.
-- [ ] JSON **reader** fold-back (optional): teach `readers/json.rs` to restore a
-      trailing `Inline::Attr` from the `attr` key, so a json→AST→json round-trip
-      doesn't silently drop the block attr. Not needed for preview (no read-back).
+- **2026-06-17 — JSON reader fold-back (done).** `readers/json.rs` `Para` arm
+      now restores a trailing `Inline::Attr` from the `attr` key, so AST→JSON→AST
+      round-trips preserve the block attr. Verified end-to-end through the binary:
+      `pampa -t json cap.qmd | pampa -f json -t html` → `<p class="caption">…</p>`.
+      Test `test_paragraph_trailing_attr_roundtrips`.
+  - **Q-3-32 still live (no docs change).** The Para writer no longer errors, but
+      `native.rs` and `json.rs`' non-Para `Inline::Attr` paths (stray attr in a
+      `Plain`, mid-content, etc.) still emit `Q-3-32`, so the error code stays
+      emitted — the docs/ page needs no "no longer emitted" note.
 - [ ] List items (`<li class>`) — distinct hoist mechanism (attr rides on the
       item's child block; the `<li>` writer must hoist it, composing with the
       incremental `fragment` class). Later sub-task.

--- a/crates/pampa/src/readers/json.rs
+++ b/crates/pampa/src/readers/json.rs
@@ -24,11 +24,11 @@ use crate::pandoc::location::{Location, Range};
 use crate::pandoc::{
     Alignment, Attr, AttrSourceInfo, Block, BlockQuote, BulletList, Caption, Cell, Citation,
     CitationMode, Cite, Code, CodeBlock, ColSpec, ColWidth, CustomNode, DefinitionList, Div, Emph,
-    Figure, Header, HorizontalRule, Image, Inline, Inlines, LineBlock, Link, ListAttributes,
-    ListNumberDelim, ListNumberStyle, Math, MathType, MetaBlock, Note, OrderedList, Pandoc,
-    Paragraph, Plain, QuoteType, Quoted, RawBlock, RawInline, Row, Slot, SmallCaps, SoftBreak,
-    Space, Span, Str, Strikeout, Strong, Subscript, Superscript, Table, TableBody, TableFoot,
-    TableHead, Underline,
+    Figure, Header, HorizontalRule, Image, Inline, InlineAttr, Inlines, LineBlock, Link,
+    ListAttributes, ListNumberDelim, ListNumberStyle, Math, MathType, MetaBlock, Note, OrderedList,
+    Pandoc, Paragraph, Plain, QuoteType, Quoted, RawBlock, RawInline, Row, Slot, SmallCaps,
+    SoftBreak, Space, Span, Str, Strikeout, Strong, Subscript, Superscript, Table, TableBody,
+    TableFoot, TableHead, Underline,
 };
 use hashlink::LinkedHashMap;
 use quarto_pandoc_types::{ConfigMapEntry, ConfigValue, ConfigValueKind};
@@ -1821,7 +1821,21 @@ fn read_block(value: &Value, deserializer: &SourceInfoDeserializer) -> Result<Bl
             let c = obj
                 .get("c")
                 .ok_or_else(|| JsonReadError::MissingField("c".to_string()))?;
-            let content = read_inlines(c, deserializer)?;
+            let mut content = read_inlines(c, deserializer)?;
+            // Fold a block-level `attr` key (Quarto extension; see bd-itqcfxc3)
+            // back into a trailing `Inline::Attr`, the canonical AST shape the
+            // writer collected it from. This keeps AST -> JSON -> AST round-trips
+            // from silently dropping the paragraph's block attribute.
+            if let Some(attr_val) = obj.get("attr") {
+                let attr = read_attr(attr_val)?;
+                if !crate::pandoc::attr::is_empty_attr(&attr) {
+                    content.push(Inline::Attr(InlineAttr::new(
+                        attr,
+                        AttrSourceInfo::empty(),
+                        source_info.clone(),
+                    )));
+                }
+            }
             Ok(Block::Paragraph(Paragraph {
                 content,
                 source_info,

--- a/crates/pampa/src/writers/block_attr.rs
+++ b/crates/pampa/src/writers/block_attr.rs
@@ -1,0 +1,187 @@
+/*
+ * block_attr.rs
+ * Copyright (c) 2026 Posit, PBC
+ *
+ * Shared collection of trailing standalone `Inline::Attr` nodes into a single
+ * block-level `Attr`, so writers can attach attributes to Pandoc blocks that
+ * have no native `Attr` field (`Paragraph`, `Plain`, list items). See
+ * bd-itqcfxc3 and claude-notes/plans/2026-06-17-block-level-attrs-inline-attr.md.
+ */
+
+use hashlink::LinkedHashMap;
+use quarto_pandoc_types::attr::{Attr, empty_attr};
+use quarto_pandoc_types::inline::Inline;
+
+/// Split a block's inline content into `(retained_content, merged_attr)` by
+/// collecting the **trailing run** of standalone [`Inline::Attr`] nodes — plus
+/// any whitespace (`Space`/`SoftBreak`) interleaved with, or immediately
+/// preceding, that run — and merging the attrs into one [`Attr`].
+///
+/// The retained content is always a prefix of `inlines` (the trailing run sits
+/// at the end), so the return is a borrowed slice — no clone.
+///
+/// If the block carries no trailing `Inline::Attr`, `inlines` is returned
+/// unchanged with an empty attr (and no whitespace is stripped). Callers should
+/// treat an empty attr (`is_empty_attr`) as "no block attribute".
+///
+/// Merge rule (mirrors the `Header` fold in `postprocess.rs`): processing the
+/// collected attrs in document order, `id` = last non-empty wins, `classes`
+/// accumulate in order (deduplicated), key-values = last wins. Empty attrs in
+/// the run contribute nothing.
+///
+/// Only a *trailing* run is collected (matching the heading/table precedent); a
+/// standalone `Inline::Attr` in the middle of content is left in place for the
+/// caller to handle (the inline writers already drop it from output).
+pub(crate) fn split_trailing_block_attr(inlines: &[Inline]) -> (&[Inline], Attr) {
+    // Walk back from the end over a maximal run of (Attr | whitespace),
+    // remembering where the run starts and whether it contains any Attr.
+    let mut run_start = inlines.len();
+    let mut saw_attr = false;
+    for (idx, inline) in inlines.iter().enumerate().rev() {
+        match inline {
+            Inline::Attr(_) => {
+                saw_attr = true;
+                run_start = idx;
+            }
+            Inline::Space(_) | Inline::SoftBreak(_) => {
+                run_start = idx;
+            }
+            _ => break,
+        }
+    }
+
+    if !saw_attr {
+        // No trailing attr — leave content (and any trailing whitespace) intact.
+        return (inlines, empty_attr());
+    }
+
+    let mut id = String::new();
+    let mut classes: Vec<String> = Vec::new();
+    let mut kvs: LinkedHashMap<String, String> = LinkedHashMap::new();
+    for inline in &inlines[run_start..] {
+        if let Inline::Attr(a) = inline {
+            let (a_id, a_classes, a_kvs) = &a.attr;
+            if !a_id.is_empty() {
+                id = a_id.clone();
+            }
+            for c in a_classes {
+                if !classes.contains(c) {
+                    classes.push(c.clone());
+                }
+            }
+            for (k, v) in a_kvs {
+                kvs.insert(k.clone(), v.clone());
+            }
+        }
+    }
+
+    (&inlines[..run_start], (id, classes, kvs))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use quarto_pandoc_types::attr::{AttrSourceInfo, is_empty_attr};
+    use quarto_pandoc_types::inline::{InlineAttr, Space, Str};
+    use quarto_source_map::SourceInfo;
+
+    fn si() -> SourceInfo {
+        SourceInfo::for_test()
+    }
+
+    fn str_(text: &str) -> Inline {
+        Inline::Str(Str {
+            text: text.to_string(),
+            source_info: si(),
+        })
+    }
+
+    fn space() -> Inline {
+        Inline::Space(Space { source_info: si() })
+    }
+
+    fn attr_node(id: &str, classes: &[&str], kvs: &[(&str, &str)]) -> Inline {
+        let mut m = LinkedHashMap::new();
+        for (k, v) in kvs {
+            m.insert(k.to_string(), v.to_string());
+        }
+        let attr: Attr = (
+            id.to_string(),
+            classes.iter().map(|s| s.to_string()).collect(),
+            m,
+        );
+        Inline::Attr(InlineAttr::new(attr, AttrSourceInfo::empty(), si()))
+    }
+
+    fn texts(inlines: &[Inline]) -> Vec<String> {
+        inlines
+            .iter()
+            .map(|i| match i {
+                Inline::Str(s) => format!("Str({})", s.text),
+                Inline::Space(_) => "Space".to_string(),
+                Inline::Attr(_) => "Attr".to_string(),
+                _ => "?".to_string(),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn no_trailing_attr_is_unchanged() {
+        let inlines = vec![str_("hello"), space()];
+        let (content, attr) = split_trailing_block_attr(&inlines);
+        assert_eq!(texts(content), vec!["Str(hello)", "Space"]);
+        assert!(is_empty_attr(&attr));
+    }
+
+    #[test]
+    fn trailing_attr_with_preceding_space_is_stripped() {
+        let inlines = vec![str_("caption"), space(), attr_node("", &["caption"], &[])];
+        let (content, attr) = split_trailing_block_attr(&inlines);
+        assert_eq!(texts(content), vec!["Str(caption)"]);
+        assert_eq!(attr.1, vec!["caption".to_string()]);
+        assert!(attr.0.is_empty());
+    }
+
+    #[test]
+    fn trailing_whitespace_after_attr_is_stripped() {
+        let inlines = vec![str_("x"), space(), attr_node("", &["c"], &[]), space()];
+        let (content, _) = split_trailing_block_attr(&inlines);
+        assert_eq!(texts(content), vec!["Str(x)"]);
+    }
+
+    #[test]
+    fn multiple_attrs_merge_in_document_order() {
+        // id: last non-empty wins; classes accumulate (dedup); kv: last wins.
+        let inlines = vec![
+            str_("x"),
+            attr_node("first", &["a", "b"], &[("k", "1")]),
+            attr_node("second", &["b", "c"], &[("k", "2")]),
+        ];
+        let (content, attr) = split_trailing_block_attr(&inlines);
+        assert_eq!(texts(content), vec!["Str(x)"]);
+        assert_eq!(attr.0, "second");
+        assert_eq!(
+            attr.1,
+            vec!["a".to_string(), "b".to_string(), "c".to_string()]
+        );
+        assert_eq!(attr.2.get("k"), Some(&"2".to_string()));
+    }
+
+    #[test]
+    fn empty_attr_node_collects_to_nothing() {
+        let inlines = vec![str_("x"), attr_node("", &[], &[])];
+        let (content, attr) = split_trailing_block_attr(&inlines);
+        // The (empty) attr node is still stripped from content...
+        assert_eq!(texts(content), vec!["Str(x)"]);
+        // ...but contributes no id/classes/kvs.
+        assert!(is_empty_attr(&attr));
+    }
+
+    #[test]
+    fn mid_content_attr_is_left_in_place() {
+        let inlines = vec![attr_node("", &["mid"], &[]), str_("x")];
+        let (content, attr) = split_trailing_block_attr(&inlines);
+        assert_eq!(texts(content), vec!["Attr", "Str(x)"]);
+        assert!(is_empty_attr(&attr));
+    }
+}

--- a/crates/pampa/src/writers/html.rs
+++ b/crates/pampa/src/writers/html.rs
@@ -3,6 +3,7 @@
  * Copyright (c) 2025 Posit, PBC
  */
 
+use crate::pandoc::attr::is_empty_attr;
 use crate::pandoc::{ASTContext, Attr, Block, CitationMode, Inline, Inlines, Pandoc};
 use crate::writers::html_source::build_source_map;
 use crate::writers::json::{self, JsonConfig};
@@ -1095,7 +1096,7 @@ fn write_inline<W: Write>(
 
 /// Write a sequence of inlines
 fn write_inlines<W: Write>(
-    inlines: &Inlines,
+    inlines: &[Inline],
     ctx: &mut HtmlWriterContext<'_, W>,
 ) -> std::io::Result<()> {
     // Prose coalescing (Phase 4b): when contiguous prose inlines
@@ -1129,7 +1130,7 @@ fn write_inlines<W: Write>(
 /// the end of the run is trimmed so it isn't pulled into a wrapper
 /// that wouldn't otherwise extend that far.
 fn find_attribution_run_end<W: Write>(
-    inlines: &Inlines,
+    inlines: &[Inline],
     start: usize,
     ctx: &HtmlWriterContext<'_, W>,
 ) -> usize {
@@ -1239,7 +1240,7 @@ fn write_inline_locations_only_attrs<W: Write>(
 
 /// Write inlines as plain text (for alt attributes, etc.)
 fn write_inlines_as_text<W: Write>(
-    inlines: &Inlines,
+    inlines: &[Inline],
     ctx: &mut HtmlWriterContext<'_, W>,
 ) -> std::io::Result<()> {
     for inline in inlines {
@@ -1284,10 +1285,19 @@ fn write_block<W: Write>(block: &Block, ctx: &mut HtmlWriterContext<'_, W>) -> s
             writeln!(ctx)?;
         }
         Block::Paragraph(para) => {
+            // A filter may inject a trailing standalone `Inline::Attr` to give
+            // the paragraph block-level attributes Pandoc's `Para` can't carry
+            // (e.g. `<p class="caption">`). Collect that trailing run, apply the
+            // merged attr to the `<p>`, and render only the retained content.
+            // See bd-itqcfxc3.
+            let (content, attr) = super::block_attr::split_trailing_block_attr(&para.content);
             write!(ctx, "<p")?;
+            if !is_empty_attr(&attr) {
+                write_attr(&attr, ctx)?;
+            }
             write_block_source_attrs(block, ctx)?;
             write!(ctx, ">")?;
-            write_inlines(&para.content, ctx)?;
+            write_inlines(content, ctx)?;
             writeln!(ctx, "</p>")?;
         }
         Block::LineBlock(lineblock) => {
@@ -2337,6 +2347,45 @@ mod tests {
         }));
         assert!(html.contains("<span class=\"hl-keyword\">def</span>"));
         assert!(!html.contains("data-hl-spans="));
+    }
+
+    #[test]
+    fn paragraph_trailing_attr_becomes_p_class() {
+        // A `Paragraph` ending in a trailing standalone `Inline::Attr` (as a
+        // filter injects for a hoisted figure caption) renders as
+        // `<p class="caption">…</p>`, with the attr node and the preceding
+        // `Space` stripped from the text. See bd-itqcfxc3.
+        use crate::pandoc::block::Paragraph;
+        use crate::pandoc::inline::{InlineAttr, Space, Str};
+        use hashlink::LinkedHashMap;
+
+        let attr = (
+            String::new(),
+            vec!["caption".to_string()],
+            LinkedHashMap::new(),
+        );
+        let para = Block::Paragraph(Paragraph {
+            content: vec![
+                Inline::Str(Str {
+                    text: "This is a caption.".to_string(),
+                    source_info: dummy_source_info(),
+                }),
+                Inline::Space(Space {
+                    source_info: dummy_source_info(),
+                }),
+                Inline::Attr(InlineAttr::new(
+                    attr,
+                    AttrSourceInfo::empty(),
+                    dummy_source_info(),
+                )),
+            ],
+            source_info: dummy_source_info(),
+        });
+        let html = render_block_to_html(para);
+        assert!(
+            html.contains("<p class=\"caption\">This is a caption.</p>"),
+            "expected `<p class=\"caption\">This is a caption.</p>`, got:\n{html}",
+        );
     }
 
     #[test]

--- a/crates/pampa/src/writers/json.rs
+++ b/crates/pampa/src/writers/json.rs
@@ -4554,6 +4554,64 @@ mod tests {
         assert_eq!(c[0]["c"], "This is a caption.");
     }
 
+    #[test]
+    fn test_paragraph_trailing_attr_roundtrips() {
+        // AST -> JSON -> AST must preserve a Para's block attr: the writer emits
+        // it as the `attr` key (stripping the trailing `Inline::Attr` from `c`),
+        // and the reader must fold it back into a trailing `Inline::Attr` so a
+        // re-serialization re-emits the same `attr` key. See bd-itqcfxc3.
+        use crate::pandoc::inline::InlineAttr;
+        use crate::pandoc::{Block, Inline, Paragraph, Space, Str};
+        use crate::readers::json as json_reader;
+
+        let attr: Attr = (
+            "cap1".to_string(),
+            vec!["caption".to_string()],
+            LinkedHashMap::new(),
+        );
+        let para = Paragraph {
+            content: vec![
+                Inline::Str(Str {
+                    text: "Cap".to_string(),
+                    source_info: SourceInfo::for_test(),
+                }),
+                Inline::Space(Space {
+                    source_info: SourceInfo::for_test(),
+                }),
+                Inline::Attr(InlineAttr::new(
+                    attr,
+                    AttrSourceInfo::empty(),
+                    SourceInfo::for_test(),
+                )),
+            ],
+            source_info: SourceInfo::for_test(),
+        };
+        let pandoc = crate::pandoc::Pandoc {
+            meta: quarto_pandoc_types::ConfigValue::default(),
+            blocks: vec![Block::Paragraph(para)],
+        };
+
+        let context = make_test_context();
+        let config = make_test_config();
+        let mut output = Vec::new();
+        write_with_config(&pandoc, &context, &mut output, &config).unwrap();
+
+        let (read_pandoc, _) = json_reader::read(&mut output.as_slice()).unwrap();
+        match &read_pandoc.blocks[0] {
+            Block::Paragraph(p) => {
+                // The trailing Inline::Attr is restored from the `attr` key.
+                match p.content.last() {
+                    Some(Inline::Attr(a)) => {
+                        assert_eq!(a.attr.0, "cap1");
+                        assert_eq!(a.attr.1, vec!["caption".to_string()]);
+                    }
+                    other => panic!("expected trailing Inline::Attr, got {:?}", other),
+                }
+            }
+            other => panic!("expected Paragraph, got {:?}", other),
+        }
+    }
+
     // ----------------------------------------------------------------
     // Plan 5 Phase 3+4 — writer-side Generated emission
     // ----------------------------------------------------------------

--- a/crates/pampa/src/writers/json.rs
+++ b/crates/pampa/src/writers/json.rs
@@ -3,7 +3,7 @@
  * Copyright (c) 2025 Posit, PBC
  */
 
-use crate::pandoc::attr::{AttrSourceInfo, TargetSourceInfo};
+use crate::pandoc::attr::{AttrSourceInfo, TargetSourceInfo, is_empty_attr};
 use crate::pandoc::shortcode::shortcode_to_span;
 use crate::pandoc::{
     ASTContext, Attr, Block, Caption, CitationMode, Inline, Inlines, ListAttributes, Pandoc,
@@ -3152,15 +3152,50 @@ fn stream_write_block<W: io::Write>(
                 Ok(())
             },
         ),
-        Block::Paragraph(p) => stream_write_simple_node(
-            w,
-            "Para",
-            &p.source_info,
-            ctx,
-            |w: &mut JsonStreamWriter<W>, ctx: &mut JsonWriterContext| {
-                stream_write_inlines(w, &p.content, ctx)
-            },
-        ),
+        Block::Paragraph(p) => {
+            // A `Paragraph` may carry a trailing standalone `Inline::Attr`
+            // injected by a filter (e.g. `<p class="caption">`). Pandoc's `Para`
+            // has no `Attr` field, so we collect that trailing run into a single
+            // block attr and emit it as an extra `attr` object key — the same
+            // "safe extra key" channel as `s`/`l`, which Pandoc ignores while
+            // our React preview renderer reads it. See bd-itqcfxc3.
+            let (content, attr) = super::block_attr::split_trailing_block_attr(&p.content);
+            if is_empty_attr(&attr) {
+                stream_write_simple_node(
+                    w,
+                    "Para",
+                    &p.source_info,
+                    ctx,
+                    |w: &mut JsonStreamWriter<W>, ctx: &mut JsonWriterContext| {
+                        stream_write_inlines(w, &p.content, ctx)
+                    },
+                )
+            } else {
+                // Inlined so we can emit the extra `attr` key in alphabetical
+                // wire order (attr, c, l?, s, t).
+                let s_id = ctx.serializer.intern(&p.source_info);
+                ctx.maybe_record_attribution_for(&p.source_info, s_id);
+                w.begin_object()?;
+                w.key("attr")?;
+                stream_write_attr(w, &attr)?;
+                w.key("c")?;
+                w.begin_array()?;
+                for inline in content {
+                    stream_write_inline(w, inline, ctx)?;
+                }
+                w.end_array()?;
+                if ctx.serializer.config.include_inline_locations {
+                    let ast_context = ctx.serializer.context;
+                    stream_write_location_key_if_mapped(w, "l", &p.source_info, ast_context)?;
+                }
+                w.key("s")?;
+                w.u64_value(s_id as u64)?;
+                w.key("t")?;
+                w.str_value("Para")?;
+                w.end_object()?;
+                Ok(())
+            }
+        }
         Block::Header(h) => stream_write_attrs_node(
             w,
             "Header",
@@ -4462,6 +4497,61 @@ mod tests {
             }
             _ => panic!("Expected Custom block"),
         }
+    }
+
+    #[test]
+    fn test_paragraph_trailing_attr_emits_attr_key() {
+        // A `Paragraph` ending in a trailing standalone `Inline::Attr` (as a
+        // filter would inject for `<p class="caption">`) must serialize to a
+        // Pandoc-valid `Para` node carrying an extra `attr` object key — the
+        // same "safe extra key" channel the `s`/`l` source-info keys use, which
+        // Pandoc ignores. The trailing `Inline::Attr` (and the `Space` before
+        // it) are stripped from `c`. See bd-itqcfxc3.
+        use crate::pandoc::inline::InlineAttr;
+        use crate::pandoc::{Block, Inline, Paragraph, Space, Str};
+
+        let attr: Attr = (
+            String::new(),
+            vec!["caption".to_string()],
+            LinkedHashMap::new(),
+        );
+        let para = Paragraph {
+            content: vec![
+                Inline::Str(Str {
+                    text: "This is a caption.".to_string(),
+                    source_info: SourceInfo::for_test(),
+                }),
+                Inline::Space(Space {
+                    source_info: SourceInfo::for_test(),
+                }),
+                Inline::Attr(InlineAttr::new(
+                    attr,
+                    AttrSourceInfo::empty(),
+                    SourceInfo::for_test(),
+                )),
+            ],
+            source_info: SourceInfo::for_test(),
+        };
+        let pandoc = crate::pandoc::Pandoc {
+            meta: quarto_pandoc_types::ConfigValue::default(),
+            blocks: vec![Block::Paragraph(para)],
+        };
+
+        let context = make_test_context();
+        let config = make_test_config();
+        let mut output = Vec::new();
+        write_with_config(&pandoc, &context, &mut output, &config).unwrap();
+
+        let v: serde_json::Value = serde_json::from_slice(&output).unwrap();
+        let para_node = &v["blocks"][0];
+        assert_eq!(para_node["t"], "Para");
+        // The collected block attr rides as an extra `attr` key: [id, classes, kvs].
+        assert_eq!(para_node["attr"], json!(["", ["caption"], []]));
+        // The trailing `Inline::Attr` and its preceding `Space` are gone from `c`.
+        let c = para_node["c"].as_array().expect("c is an array");
+        assert_eq!(c.len(), 1, "expected only the Str to remain, got {:?}", c);
+        assert_eq!(c[0]["t"], "Str");
+        assert_eq!(c[0]["c"], "This is a caption.");
     }
 
     // ----------------------------------------------------------------

--- a/crates/pampa/src/writers/mod.rs
+++ b/crates/pampa/src/writers/mod.rs
@@ -5,6 +5,7 @@
 
 #[cfg(feature = "terminal-support")]
 pub mod ansi;
+pub(crate) mod block_attr;
 pub mod html;
 pub(crate) mod html_source;
 pub mod incremental;

--- a/ts-packages/preview-renderer/src/framework/types.ts
+++ b/ts-packages/preview-renderer/src/framework/types.ts
@@ -16,7 +16,10 @@ export interface PandocAST {
  */
 export type Attr = [string, string[], [string, string][]];
 
-export type ParaBlock = { t: 'Para'; c: InlineNode[] };
+// `attr` is an optional Quarto extension: a block-level Pandoc attribute
+// carried on the Para node as an extra key the Rust JSON writer emits and
+// Pandoc ignores. Used for e.g. `<p class="caption">`. See bd-itqcfxc3.
+export type ParaBlock = { t: 'Para'; c: InlineNode[]; attr?: Attr };
 export type PlainBlock = { t: 'Plain'; c: InlineNode[] };
 export type HeaderBlock = { t: 'Header'; c: [number, [string, string[], [string, string][]], InlineNode[]] };
 export type CodeBlock = { t: 'CodeBlock'; c: [[string, string[], [string, string][]], string] };

--- a/ts-packages/preview-renderer/src/q2-preview/blocks/Para.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/blocks/Para.tsx
@@ -13,9 +13,22 @@ export const Para = (args: NodeArgs<ParaBlock>) => {
         && poolId !== undefined
         && !ctx?.editingDisabled;
 
-    return (
-        <p {...(isEditable ? { 'data-block-pool-id': poolId } : {})}>
-            {renderChildren(args)}
-        </p>
-    );
+    // A block-level attribute (id/classes/key-values) may ride on the Para node
+    // via the optional `attr` key the Rust JSON writer emits (Pandoc ignores
+    // it). Apply it to the <p> like Header/Div do, so the preview matches
+    // `q2 render` (e.g. `<p class="caption">`). See bd-itqcfxc3.
+    const domProps: Record<string, string | number> = {};
+    if (args.node.attr) {
+        const [id, classes, kvs] = args.node.attr;
+        if (id) domProps.id = id;
+        if (classes.length) domProps.className = classes.join(' ');
+        for (const [k, v] of kvs) {
+            if (k.startsWith('data-') || k === 'role') domProps[k] = v;
+        }
+    }
+    if (isEditable && poolId !== undefined) {
+        domProps['data-block-pool-id'] = poolId;
+    }
+
+    return <p {...domProps}>{renderChildren(args)}</p>;
 };

--- a/ts-packages/preview-renderer/src/q2-preview/q2-preview.integration.test.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/q2-preview.integration.test.tsx
@@ -100,6 +100,21 @@ describe('q2-preview registry — Pandoc base types render as real HTML', () => 
         expect(p!.textContent).toBe('hello');
     });
 
+    it('applies a Para `attr` key to the <p> (block-level attributes, bd-itqcfxc3)', () => {
+        // The Rust JSON writer carries a block-level attribute on a Para via an
+        // extra `attr` key (Pandoc ignores it; we read it). The preview must
+        // apply id/classes/kvs to the <p> so it matches `q2 render`.
+        const { container } = mount([
+            { t: 'Para', c: [STR('This is a caption.')], attr: ['cap1', ['caption'], [['data-foo', 'bar']]] },
+        ]);
+        const p = container.querySelector('p');
+        expect(p).not.toBeNull();
+        expect(p!.classList.contains('caption')).toBe(true);
+        expect(p!.id).toBe('cap1');
+        expect(p!.getAttribute('data-foo')).toBe('bar');
+        expect(p!.textContent).toBe('This is a caption.');
+    });
+
     it('renders Str inlines as text content (no placeholder)', () => {
         const { container } = mount([PARA(STR('hello'))]);
         // Use querySelector('p') to avoid picking up CSS text from useBlockEditHover's


### PR DESCRIPTION
## What & why

Pandoc's `Para` has no `Attr` field, so a filter that injects a trailing standalone `Inline::Attr` (e.g. to produce `<p class="caption">`) had nowhere to land. Worse, the `q2 preview` path renders through `json.rs` → a separate React renderer (not `html.rs`), and `json.rs` **errored** (`Q-3-32`) on a stray `Inline::Attr` — so a block attribute could never reach the live preview.

This PR gives Attr-less Pandoc blocks (starting with `Paragraph`) a way to carry block-level attributes, consistently across **all three renderers**, without changing Pandoc's block types. Strand: **bd-itqcfxc3** (unblocks the reveal figure-caption work, bd-38ioql41).

## How

The key realization: our JSON nodes are objects, and source info already rides as **extra object keys** Pandoc ignores (`s`, `l`). So a `Para` with a trailing `Inline::Attr` now serializes to a Pandoc-valid node carrying an extra `attr` key:

```json
{"t":"Para","attr":["",["caption"],[]],"c":[ …inlines without the attr… ], "s":…}
```

Verified empirically that **Pandoc 3.9 ignores the extra key** (`pandoc -f json` on the writer's literal bytes → `Para [Str …]` → `<p>…</p>`), so the wire form degrades gracefully for external Pandoc while our renderers read it. This avoids any `astContext` sidecar or strict-vs-preview JSON split — the merge logic lives once, in Rust.

- **Shared helper** `writers/block_attr.rs::split_trailing_block_attr` — collects the trailing `Inline::Attr` run (+ interleaved/preceding whitespace), merges (id last-wins, classes accumulate+dedup, kv last-wins), returns the retained content prefix. Block-agnostic so `html.rs` and the future `<li>` case reuse it.
- **`json.rs`** (preview transport): streaming `Para` writer emits the `attr` key.
- **`html.rs`** (`q2 render`): `Para` writer applies the merged attr to the `<p>`.
- **React** (`ts-packages/preview-renderer`): `ParaBlock` gains an optional `attr` key; `Para.tsx` reads it and applies id/classes/`data-*`/`role`, mirroring `Header.tsx` — a dumb read, no merge logic in TS.
- **`readers/json.rs`**: folds the `attr` key back into a trailing `Inline::Attr` so `AST → JSON → AST` round-trips preserve the block attr.

## End-to-end verification

The parser already emits a trailing `Inline::Attr` for plain qmd `paragraph text {.caption}`, so this is reachable through plain authoring:

```
pampa -t html cap.qmd                          → <p class="caption">This is a caption.</p>
pampa -t json cap.qmd | pandoc -f json -t html → <p>This is a caption.</p>   (key ignored)
pampa -t json cap.qmd | pampa -f json -t html  → <p class="caption">…</p>     (round-trip)
```

These inputs previously **errored** (`Q-3-32`) in JSON.

## Notes / scope

- **Behavior change:** plain qmd `paragraph {.class}` now yields `<p class="class">` everywhere (was dropped in HTML / errored in JSON). Consistent with `## Heading {.class}`; no existing test relied on the old behavior.
- **`Plain` is intentionally excluded** — it emits no wrapping element, so a block attr has nowhere to land. The figure caption must be a `Paragraph`.
- **`Q-3-32` stays live** — `native.rs` and `json.rs`'s non-`Para` `Inline::Attr` paths still emit it, so its docs page needs no change. `native.rs` keeps erroring (deferred decision on its faithfulness contract).
- **Not in this PR:** list items (`<li class>`, a distinct hoist mechanism) and wiring the bd-38ioql41 figure-caption consumer.

## Tests

- `block_attr` unit tests (merge/strip semantics); `json` wire-format + round-trip tests; `html` `paragraph_trailing_attr_becomes_p_class`; React integration test.
- Full `pampa` suite green (3969); preview-renderer green (219 + 229); `tsc` + workspace builds clean.

Design notes: `claude-notes/plans/2026-06-17-block-level-attrs-inline-attr.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
