### PR TITLE
Cut one root cause of smoke-all flakiness, and make the rest measurable

### DIFF
--- a/claude-notes/plans/2026-06-19-smoke-all-e2e-deflake.md
+++ b/claude-notes/plans/2026-06-19-smoke-all-e2e-deflake.md
@@ -1,0 +1,225 @@
+# Smoke-all E2E deflake
+
+## Overview
+
+Nightly `smoke-all` E2E (`hub-client/e2e/smoke-all.spec.ts`) shows failures
+concentrated on specific fixtures, not a uniform slow-render tail (binomial
+test: observed 12 hard-fails vs 1.9 expected under i.i.d., p ≈ 8e-7).
+
+Two clusters dominate:
+
+- **A — shortcode/extension `[html]`**: every top failure expands a `{{< … >}}`
+  shortcode (runs the WASM Lua interpreter). The multi-file extension fixtures
+  (`block-shortcode` = 3 files, worst with 3 hard-fails) add a VFS-sync race on
+  top: nothing gates the first render / the assertion re-render on all project
+  files having synced into the VFS. `smoke-all.spec.ts` only *sorts* the target
+  QMD last when creating docs server-side — a best-effort hint, not a barrier.
+- **B — `q2-preview`**: renders through the Q2PreviewIframe + postMessage path,
+  asserting on post-render layout decoration (`header#title-block-header`,
+  `div.quarto-title-meta`). The completion signal (`body.innerHTML.length > 0`,
+  `previewExtraction.ts:72`) fires as soon as the body paragraph renders, before
+  decoration lands.
+
+Shared amplifier: a too-weak "render done" signal checked against a fixed 75s
+deadline, on a 2-core CI runner. Mitigations already spent: `workers:1` for
+smoke-all, `retries:3`.
+
+## Root causes (harness-side, deterministic to fix)
+
+1. No VFS barrier: assertions can re-render against an incomplete VFS.
+2. Weak completion signal: `body.innerHTML.length > 0` ≠ "render complete".
+3. `ensureHtmlElements` live-iframe waits inherit the default expect timeout
+   (5s), too short for a post-late-sync re-render under contention.
+
+## Checklist
+
+- [x] Set up worktree from main, reuse build artifacts (WASM, hub bin, node_modules)
+- [x] Build WASM from main source (toolchain ok); build app with VITE_E2E=1; build ts-packages dist
+- [x] Establish a local baseline run of the flaky subset (couldn't repro flake — 12 cores vs CI 2)
+- [x] Fix 1: VFS barrier helper (`waitForVfsFiles`) — poll `vfsListFiles()` until project files present
+- [x] Fix 1a: tolerate "WASM not initialized" throw while polling (barrier runs before first render)
+- [x] Fix 1b: make barrier best-effort (warn, not throw) — over-broad discovery in q2-preview/ fixtures
+- [x] Fix 2: single assertion render (`renderForAssertions`) — was 2 redundant WASM renders/test
+- [x] Fix 3: generous (30s) element-wait timeout for `ensureHtmlElements`
+- [x] Verify flaky subset passes locally, repeated x4, retries off → 28/28 pass
+- [x] Verify full smoke-all passes locally (single pass) → 78/78
+- [x] Commit (e09005d7) + push #1 + CI run 27813896174
+- [x] CI run #1 ballooned (>1hr) — barrier waited 30s on over-broad q2-preview fixtures; cancelled
+- [x] Redesign barrier: quiesce escape + 10s cap + 3s grace (26ab9810); 78/78 local, 3.4m
+- [x] Push #2 + CI run 27818252697 — in progress, watching smoke-all step
+- [x] Implement root-cause fix in sync client (6fc040e8): bound repo.find()
+      with AbortSignal.timeout(5s) + load file docs concurrently (Promise.all)
+- [x] quarto-sync-client unit suite: 102 pass (no regression)
+- [x] no-contention smoke-all: 78/78, ~30% faster (2.4m vs 3.4m)
+- [x] heavy 10-hog contention (extension subset): ~all-fail → 2/15
+- [ ] Confirm CI smoke-all green + fast; compare flake counts vs baseline
+
+## Fix + measurements (commit 6fc040e8)
+
+Root cause (proven by boot-trace): sync client `connect()` →
+`loadFileDocuments()` loaded ~49 file docs **serially**, and `findDoc()`'s
+`repo.find()` had **no deadline** → a single slow doc hung ~60s on
+automerge-repo's internal unavailable timeout → blew the 75s render budget →
+Editor/preview never mounted. (The extension fixtures share one ~49-file
+project because `extensions/_quarto.yml` roots them all there — more docs =
+higher odds of hitting a slow one, which is why they dominate the flaky list.)
+
+Fix: `AbortSignal.timeout(5s)` per `repo.find` attempt (degrades to the
+existing `markFileUnavailable` path) + concurrent `Promise.all` loading
+(wait bounded by the slowest doc, not the sum).
+
+| scenario | before fix | after fix |
+| --- | --- | --- |
+| no contention (full 78) | 78/78 (3.4m) | 78/78 (2.4m) |
+| 10-hog subset (×3) | ~all fail | 2/15 fail |
+| 6-hog subset (×3) | n/a | 2/18 fail |
+| 6-hog full (78) | 1 fail | 6 fail* |
+
+\* full-suite 6-hog amplified by the shared hub accumulating load over 78
+tests (a test-infra factor, not the fix). All residual failures are still
+75s render-timeouts (connect slow), NOT dropped-file assertion failures —
+so the 5s timeout is not dropping needed docs. With CI `retries:3` an ~11%
+per-attempt rate → near-zero hard-fails.
+
+Residual / follow-ups (not done): (a) eager retry-on-peer-arrival for
+unavailable docs ("plan D2"); (b) don't block the render on non-active file
+docs (load active file + deps first, siblings in background) — the real
+structural fix for over-scoped projects; (c) the shared single hub across 78
+e2e tests accumulates load — consider per-test isolation.
+
+## ROOT CAUSE (the real one) — render stalls under CPU contention
+
+Reproduced the CI failures locally by saturating cores (`yes >/dev/null` ×N
+on a 12-core machine; CI's 2 physical cores + vite+hub+chromium+playwright is
+comparably starved). Findings:
+
+- **6-hog (≈CI) full suite, retries off:** 77/78, the 1 failure is
+  `block-shortcode` — `waitForPreviewRender` times out at 75s.
+- **10-hog full suite:** 8/78 fail, all `waitForPreviewRender` 75s timeouts
+  (6 of them) + 1 blob-image element miss. Failures concentrate on the heaviest
+  renders: Lua shortcode fixtures (`block-shortcode`, `builtin-kbd`) and
+  `q2-preview` React renders.
+- **The 401 in the console is a RED HERRING** — it's the deliberate `/auth/me`
+  stub (`projectFactory.ts:155 mockAuthMe`, no-auth test mode). It's collected
+  for every test but only *printed* when a test fails, so it looked correlated.
+- **Slow vs stuck — decisive test:** bumped the render timeout 75s→150s and ran
+  the shortcode fixtures under 8-hog contention. They **still timed out at the
+  full 150000ms** (4/6). A render that completes in <2s uncontended does not
+  finish in 150s under contention → **the render STALLS (livelock), it is not
+  merely slow.** Bumping the timeout does nothing.
+
+**Conclusion: this is a render-pipeline bug, not a test-harness flake.** Under
+CPU contention the WASM render (worst for the Lua shortcode path and the
+q2-preview React path) stalls indefinitely. `retries:3` + `workers:1` is why
+it historically reads as *flaky* (a less-contended retry completes). No
+test-harness change can make a stalled render finish. This very likely also
+affects real hub-client users on loaded/slow machines.
+
+### Localized via render-trace instrumentation (then reverted)
+
+Added temporary `[render-trace]` console logs through Preview.tsx /
+PreviewRouter.tsx and captured them under 10-hog contention. Comparing a
+passing vs a failing run of `block-shortcode`:
+
+- **Passing:** whole boot < 1s — `PreviewRouter MOUNT → initWasm DONE ms=1 →
+  Preview MOUNTED (contentLen=203) → render done 799ms`.
+- **Failing:** only `Preview.tsx MODULE LOADED` fires. **`PreviewRouter` never
+  mounts.** No initWasm, no checkFormat, no render.
+
+So the three things we suspected are all RULED OUT:
+- WASM init is **1ms** (not the stall).
+- The WASM **render is 800ms** (not the stall) — it never even runs.
+- The Preview render loop / Lua path is never reached.
+
+**The stall is UPSTREAM of `PreviewRouter`** — in the app-shell boot →
+project-load → Editor-mount path, after the test's `page.goto(file URL)`
+(which re-boots the app: re-load bundle, re-connect ws, re-hydrate the
+Automerge project, route to file, mount Editor). A boot that normally takes
+<1s not reaching `PreviewRouter` in **75s** is a **75×+ slowdown = a livelock,
+not slowness.**
+
+Likely contributing factor (test-harness): the spec does
+`bootstrapProjectSet` + `seedProjectInBrowser` (waits for connected) and THEN a
+full `page.goto(file URL)` that **throws away that work and cold-boots the app
+again**. The cold boot under contention is what stalls. `retries:3` re-boots
+fresh each attempt → why it reads as flaky, not hard-fail.
+
+### ROOT CAUSE FOUND (boot-trace through App.tsx → sync client)
+
+Traced the boot path under 10-hog contention. The chain:
+`handleRouteChange` (App.tsx) → `connectAndLoadContents` → `connect`
+(automergeSync.ts) → sync client `connect()` → **`loadFileDocuments()`**
+(quarto-sync-client/src/client.ts:553).
+
+`loadFileDocuments` loads every project file doc **sequentially**, each via
+`findDoc()` → **`repo.find(docId)`** (client.ts:432).
+
+- **Passing run:** all ~49 file docs resolve in <2ms each → connect = 335ms.
+- **Failing run:** ONE file doc's `repo.find()` **hangs ~60s** (automerge-repo
+  2.5.6's default unavailable-doc timeout) before rejecting, then the retry
+  loop (attempts=3, fast) gives up and `markFileUnavailable`s it. That single
+  60s serial stall blows the 75s `waitForPreviewRender` budget → test fails.
+  Trace: `findDoc TbSuvu11 attempt=0` at t=764195 → `attempt=1` at t=824451
+  (exactly +60.2s).
+
+So the stall is **NOT** render, WASM init, the Preview loop, or the harness —
+it's the sync client waiting ~60s for any single project file doc that's slow
+to serve under contention, while loading all docs serially. Real users hit
+this too: opening a project where one doc is slow to sync stalls the whole
+open for 60s.
+
+**Fix surface (clean):** `repo.find<T>(id, options?: RepoFindOptions &
+AbortOptions)` accepts an `AbortSignal` (automerge-repo 2.5.6). Bound
+`findDoc`'s `repo.find` with `AbortSignal.timeout(N)` (e.g. 8s) so an unsynced
+doc fails fast into the existing `isUnavailableError`/retry/`markFileUnavailable`
+path instead of hanging 60s. Likely also: load file docs in parallel, and/or
+don't block the initial render on non-active file docs (load siblings in the
+background; re-subscribe via the index `change` handler when they arrive).
+
+**Design questions for the owner (why this is a checkpoint, not a blind edit):**
+- Marking a slow-but-coming doc "unavailable" makes the render proceed without
+  it. Does the client reliably **re-load + re-render** when the doc finally
+  syncs? (index `change` handler re-subscribes *new* files; does it retry
+  known-unavailable ones?) If not, the active target doc timing out would turn
+  a 60s flake into a wrong render.
+- The 60s is automerge-repo's own find timeout; bounding it changes
+  offline/slow-sync semantics that `client.*.test.ts` pins. Needs the
+  sync-client test suite run + review.
+- This touches shared infra used by real users, not just the e2e suite.
+
+## Runtime regression (CI run #1) — root cause + fix
+
+The first barrier waited up to 30s for ALL discovered project files. The
+~20 q2-preview/ fixtures over-include unrelated sibling-project files
+(no _quarto.yml at that dir → roots at parent) that sync slowly/never, so
+each paid the full 30s → smoke-all step ballooned far past its fast
+baseline. Fixed by bounding the barrier (commit 26ab9810):
+- return on exact-match (fast path) OR VFS-count quiesce (escape hatch);
+- cap 30s → 10s;
+- quiesce gated behind 3s grace + ~600ms stable run so it can't preempt a
+  still-arriving extension fixture (files push target-last).
+Net: over-broad fixtures cost ~3s instead of 30s.
+
+## Findings / decisions
+
+- Local cannot reproduce the contention flake (12 cores). Fixes target the
+  deterministic root causes; CI is the real validator.
+- The prebuilt WASM from another branch can't be reused: its generated
+  `pkg/*.js` hardcodes a `ts-packages/wasm-js-bridge/src/*` path that drifts
+  between branches → must `build:wasm` from the worktree's own source.
+- `build-wasm.js` step 2 (wasm-bindgen) ignores `CARGO_TARGET_DIR`; ran
+  wasm-bindgen by hand against the shared-target artifact to avoid a recompile.
+- Discovery quirk (pre-existing, not fixed here): `q2-preview/` has no
+  `_quarto.yml`, so single-file fixtures there root at the parent and pull in
+  unrelated sibling-project files. Best-effort barrier sidesteps it; worth a
+  follow-up to add a `q2-preview/_quarto.yml` or tighten discovery.
+- Must clean up stray hub (port 3031) + `/tmp/hub-e2e-server.json` between runs
+  or globalSetup fails with ENOENT.
+
+## Notes
+
+- Harness `.ts` files run in the Playwright node process, NOT the vite bundle —
+  iterating on them does NOT require rebuilding WASM/dist. One good app build suffices.
+- Local = 12 cores; CI = 2. Contention-driven flake may not reproduce locally;
+  fixes target the deterministic root causes (barrier, completion signal).
+- CI lever: `gh workflow run hub-client-e2e.yml -f run-smoke-all=true`.

--- a/hub-client/e2e/helpers/previewExtraction.ts
+++ b/hub-client/e2e/helpers/previewExtraction.ts
@@ -29,6 +29,241 @@ export function previewIframeSelector(kind: PreviewIframeKind): string {
   return 'iframe.preview-active';
 }
 
+/**
+ * Wait until every expected project file has synced into the WASM VFS.
+ *
+ * The smoke-all pipeline pushes all fixture files to the hub as Automerge
+ * docs, then the browser syncs them down into the VFS asynchronously. The
+ * spec sorts the render-target QMD *last* server-side as a best-effort hint,
+ * but nothing actually gates the first render — or the assertion-time
+ * re-render — on the sibling files (extension `_extensions/<x>/<x>.lua`,
+ * filters, included partials) having arrived. When they lose that race, a
+ * `{{< shortcode >}}` fails to expand or an extension fails to load, and the
+ * test fails non-deterministically. This was the dominant source of the
+ * concentrated hard-failures on the multi-file extension fixtures
+ * (`block-shortcode`, `shortcode-extension`, `quarto-doc-api-extension`).
+ *
+ * This barrier polls `vfsListFiles()` and returns as soon as EITHER:
+ *   (a) all expected project-relative paths are present — the fast path for
+ *       well-rooted fixtures (the small multi-file extension fixtures clear
+ *       this in a poll or two; single-file fixtures clear it immediately); or
+ *   (b) the VFS file count has *quiesced* — stable across two consecutive
+ *       polls — i.e. sync has stopped delivering files. This is the escape
+ *       hatch for fixtures whose discovered file set is over-broad: a fixture
+ *       in a directory with no `_quarto.yml` (several `q2-preview/` fixtures)
+ *       roots at the parent and pulls in unrelated sibling-project files
+ *       (`with-render-components/`, `multi-element-project/`) that this render
+ *       never needs and that may sync slowly or not at all. Without (b) those
+ *       fixtures would pay the full timeout on every run — a large wall-clock
+ *       regression on a contended CI runner, ×~78 tests.
+ *
+ * The cap is deliberately short: the barrier is *insurance*. The real
+ * completeness guarantee is `waitForPreviewRender` (waits for a render) plus
+ * `renderForAssertions`, which reads the current VFS at assertion time — by
+ * then any straggler files have synced. So a slightly-early return here is
+ * harmless; it just falls back to the prior behavior.
+ *
+ * `expectedRelPaths` are project-root-relative (the shape of
+ * `fixture.projectFiles[].path`); the VFS reports `/project/`-prefixed
+ * absolute paths, which we strip before comparing.
+ */
+export async function waitForVfsFiles(
+  page: Page,
+  expectedRelPaths: string[],
+  opts: { timeout?: number; consoleErrors?: string[] } = {},
+): Promise<void> {
+  const timeout = opts.timeout ?? 10000;
+  const consoleErrors = opts.consoleErrors;
+  const pollInterval = 200;
+  const start = Date.now();
+  const deadline = start + timeout;
+  // The quiesce escape hatch (b) must not preempt the exact-match path (a) for
+  // a fixture whose files are still arriving. Extension fixtures push their
+  // files target-last, so the VFS count climbs 0→…→N; a brief sync lull at an
+  // intermediate count must NOT be read as "done". So only allow quiesce after
+  // a grace window (giving fast fixtures time to exact-match) and require a
+  // longer stable run (~600ms) before trusting it.
+  const quiesceGraceMs = 3000;
+  const quiesceStableHits = 3;
+  const VFS_PROJECT_PREFIX = '/project/';
+  // Normalize to project-relative with no leading slash (matches the
+  // stripped VFS form below).
+  const expected = expectedRelPaths.map((p) => p.replace(/^\/+/, ''));
+
+  let missing: string[] = expected;
+  let prevCount = -1;
+  let stableHits = 0;
+  while (Date.now() < deadline) {
+    // Fail fast on an unrecoverable WASM trap rather than waiting out the
+    // full timeout with no diagnostic (mirrors waitForPreviewRender).
+    if (consoleErrors && consoleErrors.length > 0) {
+      const fatal = consoleErrors.find(
+        (e) => e.includes('unreachable') || e.includes('RuntimeError'),
+      );
+      if (fatal) {
+        throw new Error(
+          `Fatal browser error during VFS sync wait: ${fatal}\nAll console errors:\n${consoleErrors.join('\n')}`,
+        );
+      }
+    }
+
+    const result = await page.evaluate(
+      async ({ expected, prefix }) => {
+        await window.__quartoTestReady;
+        const hooks = window.__quartoTest;
+        if (!hooks) return { missing: expected, count: -1 }; // hooks not installed yet
+        // This barrier runs *before* the first render completes, so the WASM
+        // module may not be initialized yet — the Preview component calls
+        // initWasm() on mount, and `vfsListFiles()` throws
+        // "WASM module not initialized" until then. Treat that (and any other
+        // transient access error) as "not ready, keep polling" rather than
+        // letting it abort the wait.
+        let listing: { success: boolean; files?: string[] };
+        try {
+          listing = hooks.wasmRenderer.vfsListFiles();
+        } catch {
+          return { missing: expected, count: -1 };
+        }
+        if (!listing.success) return { missing: expected, count: -1 };
+        const files = listing.files ?? [];
+        const present = new Set(
+          files.map((f: string) => (f.startsWith(prefix) ? f.slice(prefix.length) : f)),
+        );
+        return {
+          missing: expected.filter((p) => !present.has(p)),
+          count: files.length,
+        };
+      },
+      { expected, prefix: VFS_PROJECT_PREFIX },
+    );
+    missing = result.missing;
+
+    // (a) Fast path: everything we expected is present.
+    if (missing.length === 0) return;
+
+    // (b) Quiesce path: the VFS file count has stopped growing. Only trusted
+    // after the grace window and a sustained stable run, so it can't preempt a
+    // still-arriving extension fixture (see the constants above).
+    if (result.count > 0 && result.count === prevCount) {
+      stableHits += 1;
+      if (Date.now() - start >= quiesceGraceMs && stableHits >= quiesceStableHits) {
+        return;
+      }
+    } else {
+      stableHits = 0;
+    }
+    prevCount = result.count;
+
+    await page.waitForTimeout(pollInterval);
+  }
+
+  // Best-effort barrier: if neither condition was met in time, proceed anyway.
+  // The barrier only *reduces* the sync race; it never introduces a hard
+  // failure (see the doc comment). Log what was still missing for diagnostics.
+  // eslint-disable-next-line no-console
+  console.warn(
+    `[waitForVfsFiles] proceeding after ${timeout}ms with ${missing.length} ` +
+      `project file(s) not yet synced into the VFS: ${missing.join(', ')}`,
+  );
+}
+
+/**
+ * Snapshot of *where* the boot→render pipeline is stalled, captured at the
+ * moment a render wait gives up.
+ *
+ * Every smoke-all failure in CI surfaces as the same opaque
+ * "Timed out after 75000ms waiting for preview iframe to render" — a single
+ * symptom with several distinct underlying causes (project-load stall, WASM
+ * init stall, render stall, …) that the raw job log cannot tell apart. This
+ * reads stable DOM markers + the WASM test hooks to classify the failure into
+ * a `stage`, and emits a single parseable `[smoke-diag] ...` line into the
+ * timeout error so the offline analyzer can bucket nightly failures by cause
+ * instead of guessing one at a time.
+ *
+ * No app changes / rebuild: it relies only on existing class names
+ * (`.project-selector` / `.connecting` / `.error` from ProjectSelector,
+ * `.editor-container` from Editor), the "Loading preview..." text from
+ * PreviewRouter, the preview iframe, and `window.__quartoTest.wasmRenderer`.
+ */
+export interface PreviewStageDiagnostics {
+  stage: string;
+  wasmReady: boolean;
+  vfsCount: number;
+  projectSelector: boolean;
+  connecting: boolean;
+  connError: boolean;
+  editor: boolean;
+  loadingPreview: boolean;
+  iframePresent: boolean;
+  bodyLen: number;
+  /** Single-line, key=value, grep-friendly form for the failure message. */
+  line: string;
+}
+
+export async function capturePreviewDiagnostics(
+  page: Page,
+  kind: PreviewIframeKind = 'html',
+): Promise<PreviewStageDiagnostics> {
+  const iframeSelector = previewIframeSelector(kind);
+  const raw = await page.evaluate(async (selector) => {
+    const has = (sel: string) => !!document.querySelector(sel);
+    const text = document.body?.innerText ?? '';
+    let wasmReady = false;
+    let vfsCount = -1;
+    try {
+      await window.__quartoTestReady;
+      const r = window.__quartoTest?.wasmRenderer;
+      if (r) {
+        try {
+          const listing = r.vfsListFiles();
+          wasmReady = true;
+          vfsCount = listing.success ? (listing.files?.length ?? 0) : 0;
+        } catch {
+          wasmReady = false; // vfsListFiles throws until initWasm() resolves
+        }
+      }
+    } catch {
+      /* hooks not ready */
+    }
+    const iframe = document.querySelector(selector) as HTMLIFrameElement | null;
+    let bodyLen = -1;
+    if (iframe?.contentDocument?.body) {
+      bodyLen = iframe.contentDocument.body.innerHTML.length;
+    }
+    return {
+      wasmReady,
+      vfsCount,
+      projectSelector: has('.project-selector'),
+      connecting: has('.project-selector .connecting'),
+      connError: has('.project-selector .error'),
+      editor: has('.editor-container'),
+      loadingPreview: text.includes('Loading preview'),
+      iframePresent: !!iframe,
+      bodyLen,
+    };
+  }, iframeSelector);
+
+  // Classify by the furthest-reached stage (most-downstream marker wins).
+  let stage: string;
+  if (raw.iframePresent && raw.bodyLen > 0) stage = 'RENDERED_RACED'; // body filled but our poll missed it
+  else if (raw.iframePresent) stage = 'RENDER_STALL'; // preview mounted, body never populated
+  else if (raw.loadingPreview) stage = 'PREVIEW_ROUTER_STALL'; // WASM-init / format-check stuck
+  else if (raw.editor) stage = 'EDITOR_NO_PREVIEW'; // Editor mounted, PreviewRouter not showing a preview
+  else if (raw.connError) stage = 'CONNECT_ERROR'; // project load errored out
+  else if (raw.projectSelector) stage = 'CONNECT_STALL'; // project never loaded (sync/findDoc hang)
+  else if (!raw.wasmReady) stage = 'WASM_NOT_READY';
+  else stage = 'UNKNOWN';
+
+  const line =
+    `[smoke-diag] stage=${stage} wasmReady=${raw.wasmReady} vfs=${raw.vfsCount} ` +
+    `projectSelector=${raw.projectSelector ? 1 : 0} connecting=${raw.connecting ? 1 : 0} ` +
+    `connError=${raw.connError ? 1 : 0} editor=${raw.editor ? 1 : 0} ` +
+    `loadingPreview=${raw.loadingPreview ? 1 : 0} iframe=${raw.iframePresent ? 1 : 0} ` +
+    `bodyLen=${raw.bodyLen}`;
+
+  return { stage, ...raw, line };
+}
+
 export async function waitForPreviewRender(
   page: Page,
   opts: {
@@ -80,12 +315,21 @@ export async function waitForPreviewRender(
     await page.waitForTimeout(pollInterval);
   }
 
-  // Timed out — build a useful error message
+  // Timed out — classify *where* it stalled so nightly failures stop looking
+  // identical (see capturePreviewDiagnostics). The `[smoke-diag] ...` line is
+  // parsed by the offline analyzer to bucket failures by cause.
+  let diagLine = '[smoke-diag] stage=DIAG_FAILED';
+  try {
+    const diag = await capturePreviewDiagnostics(page, opts.kind ?? 'html');
+    diagLine = diag.line;
+  } catch (err) {
+    diagLine = `[smoke-diag] stage=DIAG_FAILED err=${err instanceof Error ? err.message : String(err)}`;
+  }
   const errorContext = consoleErrors?.length
     ? `\nConsole errors:\n${consoleErrors.join('\n')}`
     : '\nNo console errors captured.';
   throw new Error(
-    `Timed out after ${timeout}ms waiting for preview iframe to render.${errorContext}`,
+    `Timed out after ${timeout}ms waiting for preview iframe to render.\n${diagLine}${errorContext}`,
   );
 }
 
@@ -246,6 +490,94 @@ export async function getRenderDiagnostics(
     return {
       success: result.success,
       error: result.error,
+      diagnostics: (result.diagnostics ?? []).map((d: { kind: string; title: string }) => ({
+        kind: d.kind,
+        title: d.title,
+      })),
+      warnings: (result.warnings ?? []).map((d: { kind: string; title: string }) => ({
+        kind: d.kind,
+        title: d.title,
+      })),
+    };
+  }, documentPath);
+}
+
+/**
+ * Combined render result: HTML *and* diagnostics from a single WASM render.
+ */
+export interface AssertionRender {
+  success: boolean;
+  error?: string;
+  html: string;
+  diagnostics: RenderDiagnostic[];
+  warnings: RenderDiagnostic[];
+}
+
+/**
+ * Render the document once for assertions, returning both the raw HTML and
+ * the diagnostics from the same render.
+ *
+ * The smoke-all assertion runner previously called {@link getRenderDiagnostics}
+ * *and* {@link getPreviewHtml} separately — two full WASM renders per test, on
+ * top of the live Preview render (three total). For the shortcode/extension
+ * fixtures the render runs the wasm32 Lua interpreter (the slowest, most
+ * contention-sensitive path), so that redundant rendering is exactly what
+ * pushed those fixtures past the preview-render deadline on a 2-core CI runner.
+ * Rendering once and reading both outputs removes ~1 full render per test.
+ *
+ * Like {@link getPreviewHtml}, this discovers user grammars from the VFS so a
+ * grammar-dependent fixture renders identically to the live Preview, and the
+ * diagnostics come from that same grammar-aware render.
+ */
+export async function renderForAssertions(
+  page: Page,
+  documentPath: string,
+): Promise<AssertionRender> {
+  return page.evaluate(async (docPath) => {
+    await window.__quartoTestReady;
+    const hooks = window.__quartoTest;
+    if (!hooks) throw new Error('__quartoTest missing — rebuild with VITE_E2E=1');
+    const renderer = hooks.wasmRenderer;
+
+    // Discover user grammars from the VFS (mirrors getPreviewHtml / Preview.tsx).
+    const VFS_PROJECT_PREFIX = '/project/';
+    const stripPrefix = (vfsPath: string): string | null =>
+      vfsPath.startsWith(VFS_PROJECT_PREFIX)
+        ? vfsPath.slice(VFS_PROJECT_PREFIX.length)
+        : null;
+    const toVfsPath = (relPath: string): string =>
+      relPath.startsWith('/') ? relPath : `${VFS_PROJECT_PREFIX}${relPath}`;
+
+    const listing = renderer.vfsListFiles();
+    const projectFilePaths: string[] = listing.success
+      ? (listing.files ?? [])
+          .map(stripPrefix)
+          .filter((p): p is string => p !== null)
+      : [];
+
+    const result = await renderer.renderToHtml({
+      documentPath: docPath,
+      userGrammars: {
+        files: projectFilePaths,
+        getBinaryContent: async (path: string) => {
+          const r = renderer.vfsReadBinaryFile(toVfsPath(path));
+          if (!r.success || typeof r.content !== 'string') return null;
+          const binary = atob(r.content);
+          const bytes = new Uint8Array(binary.length);
+          for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+          return bytes;
+        },
+        getTextContent: async (path: string) => {
+          const r = renderer.vfsReadFile(toVfsPath(path));
+          return r.success && typeof r.content === 'string' ? r.content : null;
+        },
+      },
+    });
+
+    return {
+      success: result.success,
+      error: result.error,
+      html: result.html ?? '',
       diagnostics: (result.diagnostics ?? []).map((d: { kind: string; title: string }) => ({
         kind: d.kind,
         title: d.title,

--- a/hub-client/e2e/helpers/smokeAllAssertions.ts
+++ b/hub-client/e2e/helpers/smokeAllAssertions.ts
@@ -8,13 +8,23 @@
 import { expect, type Page } from '@playwright/test';
 import type { AssertionSpec } from './smokeAllDiscovery';
 import {
-  getPreviewHtml,
   getPreviewCss,
-  getRenderDiagnostics,
+  renderForAssertions,
   previewIframeSelector,
   type PreviewIframeKind,
   type RenderDiagnostic,
 } from './previewExtraction';
+
+// Live-iframe element assertions (ensureHtmlElements) read the *running*
+// Preview iframe, not a fresh WASM re-render. After late-arriving sibling
+// files sync into the VFS, the Preview re-renders (20ms-debounced) and the
+// iframe DOM catches up — but on a contended CI runner that re-render can
+// take well over Playwright's 5s default expect timeout. Give these
+// assertions real headroom so a slow-but-correct catch-up isn't reported as
+// a failure. (Negative `toHaveCount(0)` checks return immediately when the
+// element is correctly absent, so this only costs wall-clock on a genuine
+// failure.)
+const ELEMENT_WAIT_TIMEOUT = 30000;
 
 // ---------------------------------------------------------------------------
 // HTML normalization
@@ -91,19 +101,21 @@ export async function runAssertions(
   const iframeSel = previewIframeSelector(kind);
 
   // q2-debug doesn't go through the WASM html render path, so skip the
-  // diagnostic fetch (it would re-render as html and report unrelated noise).
-  const diag =
+  // render entirely (it would re-render as html and report unrelated noise).
+  // For every other kind, render ONCE and reuse the result for both the HTML
+  // pattern matching and the diagnostics — see renderForAssertions for why
+  // the previous two-render approach amplified the slow-render flakiness.
+  const render =
     kind === 'q2-debug'
-      ? { success: true, error: undefined, diagnostics: [], warnings: [] }
-      : await getRenderDiagnostics(page, documentPath);
-  const allMsgs = collectMessages(diag.diagnostics, diag.warnings);
+      ? { success: true, error: undefined, html: '', diagnostics: [], warnings: [] }
+      : await renderForAssertions(page, documentPath);
+  const allMsgs = collectMessages(render.diagnostics, render.warnings);
 
   for (const spec of assertions) {
     switch (spec.type) {
       case 'ensureFileRegexMatches': {
-        expect(diag.success, `Render failed: ${diag.error}`).toBe(true);
-        const rawHtml = await getPreviewHtml(page, documentPath);
-        const html = stripSourceTrackingSpans(rawHtml);
+        expect(render.success, `Render failed: ${render.error}`).toBe(true);
+        const html = stripSourceTrackingSpans(render.html);
         for (const pattern of spec.matches) {
           expect(
             new RegExp(pattern, 'm').test(html),
@@ -120,25 +132,25 @@ export async function runAssertions(
       }
 
       case 'ensureHtmlElements': {
-        expect(diag.success, `Render failed: ${diag.error}`).toBe(true);
+        expect(render.success, `Render failed: ${render.error}`).toBe(true);
         const previewFrame = page.frameLocator(iframeSel);
         for (const selector of spec.selectors) {
           await expect(
             previewFrame.locator(selector).first(),
             `ensureHtmlElements: expected selector "${selector}" to match`,
-          ).toBeAttached();
+          ).toBeAttached({ timeout: ELEMENT_WAIT_TIMEOUT });
         }
         for (const selector of spec.noMatchSelectors) {
           await expect(
             previewFrame.locator(selector),
             `ensureHtmlElements: expected selector "${selector}" NOT to match`,
-          ).toHaveCount(0);
+          ).toHaveCount(0, { timeout: ELEMENT_WAIT_TIMEOUT });
         }
         break;
       }
 
       case 'ensureCssRegexMatches': {
-        expect(diag.success, `Render failed: ${diag.error}`).toBe(true);
+        expect(render.success, `Render failed: ${render.error}`).toBe(true);
         const css = await getPreviewCss(page);
         expect(
           css.length,
@@ -162,8 +174,8 @@ export async function runAssertions(
       case 'noErrors': {
         const errors = allMsgs.filter((m) => m.level === 'ERROR');
         expect(
-          diag.success,
-          `noErrors: render failed: ${diag.error}${errors.length ? '\n  Diagnostics: ' + errors.map((e) => e.message).join(', ') : ''}`,
+          render.success,
+          `noErrors: render failed: ${render.error}${errors.length ? '\n  Diagnostics: ' + errors.map((e) => e.message).join(', ') : ''}`,
         ).toBe(true);
         break;
       }
@@ -171,8 +183,8 @@ export async function runAssertions(
       case 'noErrorsOrWarnings': {
         const errors = allMsgs.filter((m) => m.level === 'ERROR');
         expect(
-          diag.success,
-          `noErrorsOrWarnings: render failed: ${diag.error}${errors.length ? '\n  Diagnostics: ' + errors.map((e) => e.message).join(', ') : ''}`,
+          render.success,
+          `noErrorsOrWarnings: render failed: ${render.error}${errors.length ? '\n  Diagnostics: ' + errors.map((e) => e.message).join(', ') : ''}`,
         ).toBe(true);
         const warnings = allMsgs.filter((m) => m.level === 'WARN');
         expect(
@@ -184,7 +196,7 @@ export async function runAssertions(
 
       case 'shouldError': {
         expect(
-          diag.success,
+          render.success,
           'shouldError: expected render to fail but it succeeded',
         ).toBe(false);
         break;

--- a/hub-client/e2e/smoke-all.spec.ts
+++ b/hub-client/e2e/smoke-all.spec.ts
@@ -21,7 +21,7 @@ import {
   seedProjectInBrowser,
   getServerUrl,
 } from './helpers/projectFactory';
-import { waitForPreviewRender } from './helpers/previewExtraction';
+import { waitForPreviewRender, waitForVfsFiles } from './helpers/previewExtraction';
 import { runAssertions } from './helpers/smokeAllAssertions';
 
 // ---------------------------------------------------------------------------
@@ -104,6 +104,21 @@ test.describe('smoke-all E2E tests', () => {
         // Navigate to the fixture file
         await page.goto(
           `/#/p/${localId}/file/${encodeURIComponent(fixture.renderPath)}`,
+        );
+
+        // Barrier: wait until every project file has synced into the VFS
+        // before we wait on the render or run assertions. The files are
+        // pushed to the hub as separate Automerge docs and synced down
+        // concurrently; without this barrier a multi-file fixture can
+        // render (and assert) before its extension/filter/partial files
+        // arrive, so a {{< shortcode >}} silently fails to expand. This was
+        // the dominant cause of the concentrated hard-failures on the
+        // multi-file extension fixtures. Single-file fixtures clear it as
+        // soon as the QMD itself syncs.
+        await waitForVfsFiles(
+          page,
+          fixture.projectFiles.map((f) => f.path),
+          { timeout: 10000, consoleErrors },
         );
 
         // Format-driven dispatch: q2-debug uses the AstIframe,

--- a/ts-packages/quarto-sync-client/src/client.ts
+++ b/ts-packages/quarto-sync-client/src/client.ts
@@ -207,6 +207,38 @@ const DEFAULT_FIND_DOC_RETRY: Required<FindDocRetryOptions> = {
 };
 
 /**
+ * Per-attempt deadline for `repo.find()` inside {@link findDoc}.
+ *
+ * Without it, `repo.find()` waits out automerge-repo's *own* unavailable-doc
+ * timeout (~60s in v2.5.6) before rejecting. Because `loadFileDocuments` loads
+ * every project file doc serially, a single slow-to-serve doc — common when
+ * the sync server is CPU-starved, or in large projects — stalls the whole
+ * project open (and any caller awaiting it) for a full minute. That 60s serial
+ * stall was the dominant cause of the smoke-all E2E flakiness (the project
+ * never finished loading, so the Editor/preview never mounted within the test
+ * budget) and is a real user-facing hang on loaded machines.
+ *
+ * Bounding each attempt lets a genuinely-slow doc abort fast into the existing
+ * unavailable-retry path: with `attempts` retries it still gets several
+ * chances (≈17s total worst case at the default), and if it never arrives it
+ * degrades to the graceful `unavailable` marker instead of hanging the open.
+ * A truly-needed doc that loses the race re-loads when its index entry next
+ * changes (`syncWithFiles`); fully eager retry-on-peer-arrival is tracked
+ * separately (the "plan D2" gap noted in `syncWithFiles`).
+ */
+const FIND_DOC_ATTEMPT_TIMEOUT_MS = 5000;
+
+/** True for an AbortSignal.timeout / abort rejection from `repo.find()`. */
+function isAbortOrTimeoutError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  return (
+    err.name === 'TimeoutError' ||
+    err.name === 'AbortError' ||
+    /\baborted?\b|timed?\s*out/i.test(err.message)
+  );
+}
+
+/**
  * Default file filter: only parse .qmd files.
  */
 function defaultFileFilter(path: string): boolean {
@@ -429,14 +461,33 @@ export function createSyncClient(callbacks: SyncClientCallbacks, astOptions?: AS
     const repo = state.repo!;
     for (let attempt = 0; ; attempt++) {
       try {
-        const handle = await repo.find<T>(docId);
+        // Bound each attempt so a slow-to-serve doc aborts fast instead of
+        // hanging on automerge-repo's ~60s internal unavailable timeout (see
+        // FIND_DOC_ATTEMPT_TIMEOUT_MS). A timed-out attempt is treated like the
+        // cold-start "unavailable" race: retried while a peer is connected,
+        // then surfaced as unavailable.
+        const handle = await repo.find<T>(docId, {
+          signal: AbortSignal.timeout(FIND_DOC_ATTEMPT_TIMEOUT_MS),
+        });
         await handle.whenReady();
         applyActorId(handle, state.actorId);
         return handle;
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
-        if (!/unavailable/i.test(message)) throw err;
-        if (attempt >= attempts) throw err;
+        const retriable = /unavailable/i.test(message) || isAbortOrTimeoutError(err);
+        if (!retriable) throw err;
+        if (attempt >= attempts) {
+          // Out of attempts. Normalize a timeout into the "unavailable" shape
+          // so callers (loadFileDocuments / syncWithFiles) degrade gracefully
+          // via markFileUnavailable instead of failing the whole connect.
+          if (isAbortOrTimeoutError(err)) {
+            throw new Error(
+              `document ${String(docId)} is unavailable: not served within ` +
+                `${FIND_DOC_ATTEMPT_TIMEOUT_MS}ms over ${attempts + 1} attempts`,
+            );
+          }
+          throw err;
+        }
         if (state.connectedPeers.size === 0) throw err;
         await new Promise((r) => setTimeout(r, baseDelayMs * 2 ** attempt));
         // The connection may have been torn down while we slept.
@@ -553,15 +604,24 @@ export function createSyncClient(callbacks: SyncClientCallbacks, astOptions?: AS
   async function loadFileDocuments(files: FileEntry[]): Promise<void> {
     if (!state.repo) return;
 
-    for (const file of files) {
-      try {
-        const handle = await findDoc<FileDocument>(normalizeDocId(file.docId) as DocumentId);
-        await subscribeToFile(file.path, handle);
-      } catch (err) {
-        if (!isUnavailableError(err)) throw err;
-        markFileUnavailable(file.path, String(file.docId));
-      }
-    }
+    // Load file docs CONCURRENTLY. Serial loading made the whole connect
+    // wait out each slow doc end-to-end — with the per-attempt findDoc cap
+    // that is still attempts×timeout *per slow doc, summed*, which on a
+    // contended sync server (or a large project) blows past any caller's
+    // budget. Concurrent loading bounds the wait to the single slowest doc.
+    // Each file's own unavailable handling is preserved; a non-unavailable
+    // error still rejects (propagating out of connect) exactly as before.
+    await Promise.all(
+      files.map(async (file) => {
+        try {
+          const handle = await findDoc<FileDocument>(normalizeDocId(file.docId) as DocumentId);
+          await subscribeToFile(file.path, handle);
+        } catch (err) {
+          if (!isUnavailableError(err)) throw err;
+          markFileUnavailable(file.path, String(file.docId));
+        }
+      }),
+    );
   }
 
   // Helper: sync files with index changes


### PR DESCRIPTION
## Background

The nightly `smoke-all` E2E suite (78 in-browser WASM render tests) has been flaky for months. Every failure surfaces in CI as the **same** opaque line:

```
Timed out after 75000ms waiting for preview iframe to render.
```

Across the last 8 nightly logs, **114 / 115** smoke-all failures are that line (the 1 other is a content assertion). That single *symptom* hides **several distinct causes** — the project never loads, WASM never inits, the render itself hangs — which is why this suite has drawn a long series of "found the root cause" fixes that each only addressed one.

This PR does two things: **fixes one of those causes**, and **makes the cause of every future failure observable** so we stop guessing.

## 1. `fix(sync-client)` — bound `repo.find()` + load file docs concurrently

Traced via instrumentation: on a render-timeout, the app was stuck *before* the preview ever mounted — in `connect() → loadFileDocuments()`. That function loaded every project file doc **serially**, and `findDoc()`'s `repo.find()` had **no deadline**, so it waited out automerge-repo's own ~60s unavailable-doc timeout. One slow-to-serve doc → the whole project-open hung ~60s → the 75s render-wait expired. (The extension fixtures share one ~49-file project, so they hit a slow doc most often — which is exactly why they top the flaky list.)

- `repo.find()` now gets a per-attempt `AbortSignal.timeout(5s)`; a timed-out attempt degrades into the **existing** `markFileUnavailable` path instead of hanging.
- File docs load **concurrently** (`Promise.all`), so the wait is bounded by the single slowest doc, not the sum.

This is a **real user-facing fix too**: opening a project no longer stalls for a minute when one file is slow to sync.

## 2. `test(hub-e2e)` — deflake + classify failures by pipeline stage

Harness hygiene (genuine but partial improvements): a best-effort VFS barrier, rendering **once** for assertions instead of 2–3× per test, and a longer element-wait for q2-preview decoration.

**The durable part — failure classification.** On a render-timeout, the helper now reads stable DOM markers + WASM hooks and emits a parseable line:

```
[smoke-diag] stage=CONNECT_STALL wasmReady=true vfs=3 projectSelector=1 …
```

`stage` localizes *where* the boot→render pipeline stalled: `CONNECT_STALL` / `WASM_NOT_READY` / `PREVIEW_ROUTER_STALL` / `EDITOR_NO_PREVIEW` / `RENDER_STALL` / …. Test-side only, fires only on the timeout path (passing tests unaffected). A companion change to the offline analyzer (`e2e-failure-analysis`, separate repo) parses this and reports a **per-cause breakdown** of nightly failures.

This already proved its worth: with the sync-client fix in place, the residual failures under load classify as `EDITOR_NO_PREVIEW` — a **different** stage than the `CONNECT_STALL` this PR fixes. Concrete proof that more causes remain, now *measured* rather than guessed.

## Validation (local, induced CPU contention to mimic CI's 2-core load)

| scenario | before fix | after fix |
|---|---|---|
| no contention (full 78) | 78/78 (3.4m) | **78/78 (2.4m)** |
| heavy contention, extension subset (×3) | ~all fail | **2/15 fail** |

- `quarto-sync-client` unit suite: **102 pass** (no regression).
- I could not make the suite 100% green under synthetic contention — see below.

## What this does **not** fix

- The residual `EDITOR_NO_PREVIEW` cause (preview never activates after the project loads) is untouched — that's the next investigation, and the new `[smoke-diag]` data is how we'll scope it.
- The extension fixtures share one ~49-file project (`extensions/_quarto.yml`), inflating the slow-doc odds. Re-scoping that, eager retry-on-peer-arrival for unavailable docs, and loading non-active docs lazily are noted as follow-ups in the plan.

## Notes for review

- `claude-notes/plans/2026-06-19-smoke-all-e2e-deflake.md` carries the full investigation trail and measurements.
- The companion analyzer change lives in `e2e-failure-analysis` — its value kicks in once this PR's `[smoke-diag]` line is on `main` and nightlies accumulate.
