### PR TITLE
feat(hub-mcp): accept a quarto-hub.com share URL wherever a project id is expected

### DIFF
--- a/ts-packages/quarto-hub-mcp/src/connection-manager.ts
+++ b/ts-packages/quarto-hub-mcp/src/connection-manager.ts
@@ -214,6 +214,11 @@ export class ConnectionManager {
     this.probePath = opts.probePath ?? '/health';
   }
 
+  /** The hub server URL this manager connects to (from `--server` / `QUARTO_HUB_SERVER` / default). */
+  get configuredServerUrl(): string {
+    return this.serverUrl;
+  }
+
   /** Phase 7 hook — observed auth-mode of the last connect attempt. */
   lastObservedAuthMode(): ObservedAuthMode {
     return this.observedAuthMode;

--- a/ts-packages/quarto-hub-mcp/src/hub-mcp.test.ts
+++ b/ts-packages/quarto-hub-mcp/src/hub-mcp.test.ts
@@ -79,6 +79,21 @@ describe('MCP protocol', () => {
       required: ['project', 'path'],
     });
   });
+
+  // A share URL whose server= names a hub other than this server's configured
+  // one (--server wss://dummy.example.com) must error *before* connecting, so no
+  // network is needed here. (bd-m4slev7a)
+  it('should reject a share URL pointing at a different hub', async () => {
+    const result = await client.callTool('connect_project', {
+      project:
+        'https://quarto-hub.com/#/share/abc123?server=wss%3A%2F%2Fother.example.com%2Fws',
+    });
+    expect(result.isError).toBe(true);
+    const msg = result.content[0]!.text;
+    expect(msg).toContain('other.example.com');
+    expect(msg).toContain('dummy.example.com');
+    expect(msg).toContain('--server');
+  });
 });
 
 describe('MCP protocol (read-only mode)', () => {

--- a/ts-packages/quarto-hub-mcp/src/hub-mcp.test.ts
+++ b/ts-packages/quarto-hub-mcp/src/hub-mcp.test.ts
@@ -202,6 +202,41 @@ describe('live: connect and read', () => {
     expect(result.isError).toBe(true);
     expect(result.content[0]!.text).toContain('File not found');
   }, 15000);
+
+  // End-to-end share-URL handling: the `project` argument is a full
+  // quarto-hub.com share link rather than a bare id. The server must extract
+  // the id from the `#/share/<id>` fragment, and `file=` must supply a default
+  // `path` so read_file works with no explicit path. (bd-m4slev7a)
+  const SHARE_URL =
+    `https://quarto-hub.com/#/share/${HELLO_WORLD_DOC}` +
+    `?server=wss%3A%2F%2Fsync.automerge.org&file=index.qmd&name=Hello+World`;
+
+  it('should connect using a share URL in place of an id', async () => {
+    const result = await client.callTool('connect_project', { project: SHARE_URL });
+    expect(result.isError).toBeUndefined();
+    const data = JSON.parse(result.content[0]!.text);
+    expect(data.project).toBe(HELLO_WORLD_DOC);
+    const paths = data.files.map((f: { path: string }) => f.path);
+    expect(paths).toContain('index.qmd');
+  }, 15000);
+
+  it('should read the share URL file= with no explicit path', async () => {
+    const result = await client.callTool('read_file', { project: SHARE_URL });
+    expect(result.isError).toBeUndefined();
+    const content = result.content[0]!.text;
+    // index.qmd (named by file= in the share URL) has YAML frontmatter.
+    expect(content).toContain('---');
+    expect(content).toContain('title:');
+  }, 15000);
+
+  it('should let an explicit path override the share URL file=', async () => {
+    const result = await client.callTool('read_file', {
+      project: SHARE_URL,
+      path: '_quarto.yml',
+    });
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0]!.text.length).toBeGreaterThan(0);
+  }, 15000);
 });
 
 describe('live: create project and mutate files', () => {

--- a/ts-packages/quarto-hub-mcp/src/index.ts
+++ b/ts-packages/quarto-hub-mcp/src/index.ts
@@ -236,6 +236,13 @@ async function main(): Promise<void> {
       capabilities: {
         tools: {},
       },
+      instructions:
+        'Tools operate on a project identified by its automerge index document ID. ' +
+        'You may pass that id directly, OR paste a quarto-hub.com share URL ' +
+        '(`https://quarto-hub.com/#/share/<id>?file=…&name=…`) — the link users share ' +
+        'to grant access — anywhere a `project` is expected. The server extracts the ' +
+        'id from the `#/share/<id>` fragment, and if the URL carries a `file=` ' +
+        'parameter it becomes the default `path` for file tools.',
     },
   );
 

--- a/ts-packages/quarto-hub-mcp/src/index.ts
+++ b/ts-packages/quarto-hub-mcp/src/index.ts
@@ -242,7 +242,9 @@ async function main(): Promise<void> {
         '(`https://quarto-hub.com/#/share/<id>?file=…&name=…`) — the link users share ' +
         'to grant access — anywhere a `project` is expected. The server extracts the ' +
         'id from the `#/share/<id>` fragment, and if the URL carries a `file=` ' +
-        'parameter it becomes the default `path` for file tools.',
+        'parameter it becomes the default `path` for file tools. If a share URL ' +
+        "names a different hub in its `server=` than this server is connected to, " +
+        'the call is rejected (rather than silently hitting the wrong hub).',
     },
   );
 

--- a/ts-packages/quarto-hub-mcp/src/share-url.test.ts
+++ b/ts-packages/quarto-hub-mcp/src/share-url.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { parseProjectRef } from './share-url.js';
+
+// The canonical share link quarto-hub.com hands users. Note that file/server/
+// name live inside the URL *fragment* (after `#`), which `new URL().searchParams`
+// does not see — the whole point of parsing it by hand.
+const SHARE_URL =
+  'https://quarto-hub.com/#/share/3fA4nXRpYK1JPkeyef3KXFMEs4aN' +
+  '?server=wss%3A%2F%2Fquarto-hub.com%2Fws&file=_brand.yml&name=A+%60quarto-hub%60+update';
+
+describe('parseProjectRef', () => {
+  it('returns a bare index doc id unchanged', () => {
+    expect(parseProjectRef('3fA4nXRpYK1JPkeyef3KXFMEs4aN')).toEqual({
+      project: '3fA4nXRpYK1JPkeyef3KXFMEs4aN',
+    });
+  });
+
+  it('trims surrounding whitespace from a bare id', () => {
+    expect(parseProjectRef('  3fA4nXRpYK1JPkeyef3KXFMEs4aN \n')).toEqual({
+      project: '3fA4nXRpYK1JPkeyef3KXFMEs4aN',
+    });
+  });
+
+  it('extracts project, file, server, and name from a full share URL', () => {
+    expect(parseProjectRef(SHARE_URL)).toEqual({
+      project: '3fA4nXRpYK1JPkeyef3KXFMEs4aN',
+      file: '_brand.yml',
+      server: 'wss://quarto-hub.com/ws',
+      name: 'A `quarto-hub` update',
+    });
+  });
+
+  it('decodes percent-encoding and + in the name', () => {
+    // %60 -> backtick, + -> space
+    expect(parseProjectRef(SHARE_URL).name).toBe('A `quarto-hub` update');
+  });
+
+  it('handles a share URL with no query params', () => {
+    expect(
+      parseProjectRef('https://quarto-hub.com/#/share/3fA4nXRpYK1JPkeyef3KXFMEs4aN'),
+    ).toEqual({ project: '3fA4nXRpYK1JPkeyef3KXFMEs4aN' });
+  });
+
+  it('handles a bare fragment without the scheme/host', () => {
+    expect(
+      parseProjectRef('/share/3fA4nXRpYK1JPkeyef3KXFMEs4aN?file=slides.qmd'),
+    ).toEqual({ project: '3fA4nXRpYK1JPkeyef3KXFMEs4aN', file: 'slides.qmd' });
+  });
+
+  it('omits file/server/name keys when those params are absent', () => {
+    const ref = parseProjectRef(
+      'https://quarto-hub.com/#/share/3fA4nXRpYK1JPkeyef3KXFMEs4aN?name=Untitled',
+    );
+    expect(ref).toEqual({ project: '3fA4nXRpYK1JPkeyef3KXFMEs4aN', name: 'Untitled' });
+    expect('file' in ref).toBe(false);
+    expect('server' in ref).toBe(false);
+  });
+});

--- a/ts-packages/quarto-hub-mcp/src/share-url.test.ts
+++ b/ts-packages/quarto-hub-mcp/src/share-url.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseProjectRef } from './share-url.js';
+import { parseProjectRef, serversMatch } from './share-url.js';
 
 // The canonical share link quarto-hub.com hands users. Note that file/server/
 // name live inside the URL *fragment* (after `#`), which `new URL().searchParams`
@@ -54,5 +54,40 @@ describe('parseProjectRef', () => {
     expect(ref).toEqual({ project: '3fA4nXRpYK1JPkeyef3KXFMEs4aN', name: 'Untitled' });
     expect('file' in ref).toBe(false);
     expect('server' in ref).toBe(false);
+  });
+});
+
+describe('serversMatch', () => {
+  it('matches identical URLs', () => {
+    expect(serversMatch('wss://quarto-hub.com/ws', 'wss://quarto-hub.com/ws')).toBe(true);
+  });
+
+  it('ignores a trailing slash difference', () => {
+    expect(serversMatch('wss://quarto-hub.com/ws', 'wss://quarto-hub.com/ws/')).toBe(true);
+  });
+
+  it('ignores host case', () => {
+    expect(serversMatch('wss://Quarto-Hub.com/ws', 'wss://quarto-hub.com/ws')).toBe(true);
+  });
+
+  it('ignores surrounding whitespace', () => {
+    expect(serversMatch('  wss://quarto-hub.com/ws ', 'wss://quarto-hub.com/ws')).toBe(true);
+  });
+
+  it('treats ws and wss as different (scheme matters)', () => {
+    expect(serversMatch('ws://quarto-hub.com/ws', 'wss://quarto-hub.com/ws')).toBe(false);
+  });
+
+  it('treats different hosts as different', () => {
+    expect(serversMatch('wss://sync.automerge.org', 'wss://quarto-hub.com/ws')).toBe(false);
+  });
+
+  it('treats different paths as different', () => {
+    expect(serversMatch('wss://quarto-hub.com/ws', 'wss://quarto-hub.com/other')).toBe(false);
+  });
+
+  it('falls back to a trimmed string compare for unparseable input', () => {
+    expect(serversMatch('not a url', 'not a url')).toBe(true);
+    expect(serversMatch('not a url', 'other')).toBe(false);
   });
 });

--- a/ts-packages/quarto-hub-mcp/src/share-url.ts
+++ b/ts-packages/quarto-hub-mcp/src/share-url.ts
@@ -59,3 +59,31 @@ export function parseProjectRef(input: string): ProjectRef {
   if (name) ref.name = name;
   return ref;
 }
+
+/**
+ * Whether two hub server URLs refer to the same endpoint. Tolerant of trailing
+ * slashes, host case, and surrounding whitespace, but **scheme-sensitive**
+ * (`ws://` ≠ `wss://`) and path-sensitive. Used to reject a share URL whose
+ * `server=` names a different hub than the MCP is configured to talk to —
+ * connecting to the wrong hub would read/write the wrong documents.
+ *
+ * Falls back to a trimmed exact-string compare when either value is not a
+ * parseable URL, so a bad input never silently "matches".
+ */
+export function serversMatch(a: string, b: string): boolean {
+  const normalize = (s: string): string | null => {
+    try {
+      const u = new URL(s.trim());
+      const path = u.pathname.replace(/\/+$/, '');
+      return `${u.protocol}//${u.host.toLowerCase()}${path}`;
+    } catch {
+      return null;
+    }
+  };
+  const na = normalize(a);
+  const nb = normalize(b);
+  if (na === null || nb === null) {
+    return a.trim() === b.trim();
+  }
+  return na === nb;
+}

--- a/ts-packages/quarto-hub-mcp/src/share-url.ts
+++ b/ts-packages/quarto-hub-mcp/src/share-url.ts
@@ -1,0 +1,61 @@
+/**
+ * Parse a "project reference" — the value a caller supplies wherever a
+ * Quarto Hub project is named.
+ *
+ * Historically this was always a bare automerge index document ID. It may now
+ * also be a full quarto-hub.com **share URL** — the link users hand each other
+ * to grant project access, e.g.
+ *
+ *   https://quarto-hub.com/#/share/<id>?server=wss://…&file=_brand.yml&name=…
+ *
+ * The catch: everything after `#` is the URL *fragment*, so `<id>`, `file`,
+ * `server`, and `name` all live there — and `new URL(u).searchParams` (which
+ * only sees the real query string, which is empty here) returns none of them.
+ * So we split the fragment by hand. Parsing this once, in TypeScript, is far
+ * more reliable than asking a model to decode `%60`→backtick and `+`→space and
+ * split the fragment correctly on every call.
+ */
+export interface ProjectRef {
+  /** The automerge index document ID of the project. */
+  project: string;
+  /** The file named by `?file=` in a share URL, if any. */
+  file?: string;
+  /** The hub websocket endpoint named by `?server=` in a share URL, if any. */
+  server?: string;
+  /** The human-readable project name from `?name=` in a share URL, if any. */
+  name?: string;
+}
+
+/**
+ * Normalize a project reference. Accepts either a bare index doc id or a
+ * quarto-hub.com share URL; always returns at least `{ project }`.
+ */
+export function parseProjectRef(input: string): ProjectRef {
+  const raw = input.trim();
+
+  // Not a share link — treat the whole string as a bare index doc id.
+  if (!raw.includes('/share/')) {
+    return { project: raw };
+  }
+
+  // The share link's data is in the fragment; isolate it, then split off its
+  // (fragment-local) query string.
+  const fragment = raw.includes('#') ? raw.slice(raw.indexOf('#') + 1) : raw;
+  const queryStart = fragment.indexOf('?');
+  const pathPart = queryStart === -1 ? fragment : fragment.slice(0, queryStart);
+  const queryPart = queryStart === -1 ? '' : fragment.slice(queryStart + 1);
+
+  const idMatch = pathPart.match(/\/share\/([^/?#]+)/);
+  const project = idMatch ? decodeURIComponent(idMatch[1]) : raw;
+
+  // URLSearchParams handles percent-decoding and `+`→space for us.
+  const params = new URLSearchParams(queryPart);
+  const ref: ProjectRef = { project };
+  const file = params.get('file');
+  const server = params.get('server');
+  const name = params.get('name');
+  if (file) ref.file = file;
+  if (server) ref.server = server;
+  if (name) ref.name = name;
+  return ref;
+}

--- a/ts-packages/quarto-hub-mcp/src/tools.ts
+++ b/ts-packages/quarto-hub-mcp/src/tools.ts
@@ -23,6 +23,7 @@ import {
   type AuthToolName,
 } from './auth/auth-tools.js';
 import { redactTokens } from './auth/redact.js';
+import { parseProjectRef } from './share-url.js';
 
 function text(msg: string): CallToolResult {
   return { content: [{ type: 'text', text: msg }] };
@@ -31,6 +32,17 @@ function text(msg: string): CallToolResult {
 function error(msg: string): CallToolResult {
   return { content: [{ type: 'text', text: msg }], isError: true };
 }
+
+/**
+ * Shared description for every `project` parameter. Tells the model that a
+ * quarto-hub.com share URL is accepted in place of a bare id — the server
+ * extracts the id (and a default `path`) from it. See {@link parseProjectRef}.
+ */
+const PROJECT_PARAM_DESC =
+  "The project's automerge index document ID, OR a full quarto-hub.com share URL " +
+  'such as `https://quarto-hub.com/#/share/<id>?file=…&name=…` (the link users share ' +
+  'to grant access). Given a share URL, the `<id>` after `#/share/` is used as the ' +
+  'project and the `file=` query parameter, if present, supplies a default `path`.';
 
 // ============================================================================
 // Tool definitions
@@ -41,7 +53,9 @@ function getReadTools(): Tool[] {
     {
       name: 'connect_project',
       description:
-        'Connect to a Quarto Hub project by its automerge index document ID. ' +
+        'Connect to a Quarto Hub project by its automerge index document ID — ' +
+        'or by a quarto-hub.com share URL (`https://quarto-hub.com/#/share/<id>?…`), ' +
+        'from which the id is extracted automatically. ' +
         'Returns the list of files in the project. ' +
         'If the hub requires authentication and no valid credentials are cached, ' +
         'this throws an `AuthRequiredError` / `ReauthRequired` — call ' +
@@ -49,7 +63,7 @@ function getReadTools(): Tool[] {
       inputSchema: {
         type: 'object',
         properties: {
-          project: { type: 'string', description: 'The automerge index document ID of the project' },
+          project: { type: 'string', description: PROJECT_PARAM_DESC },
         },
         required: ['project'],
       },
@@ -61,7 +75,7 @@ function getReadTools(): Tool[] {
       inputSchema: {
         type: 'object',
         properties: {
-          project: { type: 'string', description: 'The automerge index document ID of the project' },
+          project: { type: 'string', description: PROJECT_PARAM_DESC },
         },
         required: ['project'],
       },
@@ -73,7 +87,7 @@ function getReadTools(): Tool[] {
       inputSchema: {
         type: 'object',
         properties: {
-          project: { type: 'string', description: 'The automerge index document ID of the project' },
+          project: { type: 'string', description: PROJECT_PARAM_DESC },
           path: { type: 'string', description: 'The file path within the project' },
         },
         required: ['project', 'path'],
@@ -91,7 +105,7 @@ function getReadTools(): Tool[] {
       inputSchema: {
         type: 'object',
         properties: {
-          project: { type: 'string', description: 'The automerge index document ID of the project' },
+          project: { type: 'string', description: PROJECT_PARAM_DESC },
           path: { type: 'string', description: 'The file path within the project to watch' },
           timeout_seconds: {
             type: 'number',
@@ -120,7 +134,7 @@ function getWriteTools(): Tool[] {
       inputSchema: {
         type: 'object',
         properties: {
-          project: { type: 'string', description: 'The automerge index document ID of the project' },
+          project: { type: 'string', description: PROJECT_PARAM_DESC },
           path: { type: 'string', description: 'The file path within the project' },
           content: { type: 'string', description: 'The new file content' },
         },
@@ -134,7 +148,7 @@ function getWriteTools(): Tool[] {
       inputSchema: {
         type: 'object',
         properties: {
-          project: { type: 'string', description: 'The automerge index document ID of the project' },
+          project: { type: 'string', description: PROJECT_PARAM_DESC },
           path: { type: 'string', description: 'The file path within the project' },
           old_string: { type: 'string', description: 'The exact string to find and replace' },
           new_string: { type: 'string', description: 'The replacement string' },
@@ -149,7 +163,7 @@ function getWriteTools(): Tool[] {
       inputSchema: {
         type: 'object',
         properties: {
-          project: { type: 'string', description: 'The automerge index document ID of the project' },
+          project: { type: 'string', description: PROJECT_PARAM_DESC },
           path: { type: 'string', description: 'The file path within the project' },
           content: { type: 'string', description: 'Initial file content (defaults to empty)', default: '' },
         },
@@ -163,7 +177,7 @@ function getWriteTools(): Tool[] {
       inputSchema: {
         type: 'object',
         properties: {
-          project: { type: 'string', description: 'The automerge index document ID of the project' },
+          project: { type: 'string', description: PROJECT_PARAM_DESC },
           path: { type: 'string', description: 'The file path to delete' },
         },
         required: ['project', 'path'],
@@ -176,7 +190,7 @@ function getWriteTools(): Tool[] {
       inputSchema: {
         type: 'object',
         properties: {
-          project: { type: 'string', description: 'The automerge index document ID of the project' },
+          project: { type: 'string', description: PROJECT_PARAM_DESC },
           old_path: { type: 'string', description: 'The current file path' },
           new_path: { type: 'string', description: 'The new file path' },
         },
@@ -215,6 +229,24 @@ function getWriteTools(): Tool[] {
 // ============================================================================
 
 type ToolArgs = Record<string, unknown>;
+
+/**
+ * Normalize tool arguments before dispatch. If `project` is a quarto-hub.com
+ * share URL, replace it with the bare index doc id; and when the share URL
+ * named a `file=` and the caller gave no explicit `path`, default `path` to it.
+ * A bare id passes through unchanged, so existing callers are unaffected.
+ */
+function normalizeArgs(args: ToolArgs): ToolArgs {
+  if (typeof args.project !== 'string') {
+    return args;
+  }
+  const ref = parseProjectRef(args.project);
+  const next: ToolArgs = { ...args, project: ref.project };
+  if (ref.file && (next.path === undefined || next.path === '')) {
+    next.path = ref.file;
+  }
+  return next;
+}
 
 /**
  * One listed file. `type` is present for loaded files; dangling index
@@ -259,9 +291,10 @@ function unavailableFileError(path: string, docId: string): CallToolResult {
 
 async function handleTool(
   name: string,
-  args: ToolArgs,
+  rawArgs: ToolArgs,
   manager: ConnectionManager
 ): Promise<CallToolResult> {
+  const args = normalizeArgs(rawArgs);
   switch (name) {
     case 'connect_project':
       return handleConnectProject(args, manager);

--- a/ts-packages/quarto-hub-mcp/src/tools.ts
+++ b/ts-packages/quarto-hub-mcp/src/tools.ts
@@ -23,7 +23,7 @@ import {
   type AuthToolName,
 } from './auth/auth-tools.js';
 import { redactTokens } from './auth/redact.js';
-import { parseProjectRef } from './share-url.js';
+import { parseProjectRef, serversMatch } from './share-url.js';
 
 function text(msg: string): CallToolResult {
   return { content: [{ type: 'text', text: msg }] };
@@ -235,17 +235,34 @@ type ToolArgs = Record<string, unknown>;
  * share URL, replace it with the bare index doc id; and when the share URL
  * named a `file=` and the caller gave no explicit `path`, default `path` to it.
  * A bare id passes through unchanged, so existing callers are unaffected.
+ *
+ * If the share URL's `server=` names a hub different from the one this MCP is
+ * configured to use, returns an `error` instead: silently connecting to the
+ * configured hub would read/write the wrong documents. `configuredServer` is
+ * the manager's {@link ConnectionManager.configuredServerUrl}.
  */
-function normalizeArgs(args: ToolArgs): ToolArgs {
+function normalizeArgs(
+  args: ToolArgs,
+  configuredServer: string,
+): { args: ToolArgs } | { error: string } {
   if (typeof args.project !== 'string') {
-    return args;
+    return { args };
   }
   const ref = parseProjectRef(args.project);
+  if (ref.server && !serversMatch(ref.server, configuredServer)) {
+    return {
+      error:
+        `Error: this share URL targets Quarto Hub server ${ref.server}, but this MCP ` +
+        `server is connected to ${configuredServer}. Reading or writing would hit the ` +
+        `wrong hub. Restart quarto-hub-mcp with \`--server ${ref.server}\` (or set ` +
+        `QUARTO_HUB_SERVER=${ref.server}) to use the project this link points to.`,
+    };
+  }
   const next: ToolArgs = { ...args, project: ref.project };
   if (ref.file && (next.path === undefined || next.path === '')) {
     next.path = ref.file;
   }
-  return next;
+  return { args: next };
 }
 
 /**
@@ -294,7 +311,11 @@ async function handleTool(
   rawArgs: ToolArgs,
   manager: ConnectionManager
 ): Promise<CallToolResult> {
-  const args = normalizeArgs(rawArgs);
+  const normalized = normalizeArgs(rawArgs, manager.configuredServerUrl);
+  if ('error' in normalized) {
+    return error(normalized.error);
+  }
+  const args = normalized.args;
   switch (name) {
     case 'connect_project':
       return handleConnectProject(args, manager);


### PR DESCRIPTION
## Summary

Lets a caller (a user, or a model acting for them) pass a **quarto-hub.com share URL** — the link users share to grant project access — anywhere a `project` id is expected, instead of having to hand over the bare automerge index doc id plus a separate file path.

Example link:
```
https://quarto-hub.com/#/share/3fA4nXRpYK1JPkeyef3KXFMEs4aN?server=wss%3A%2F%2Fquarto-hub.com%2Fws&file=_brand.yml&name=A+%60quarto-hub%60+update
```

The id, `file`, `server`, and `name` all live in the URL **fragment** (after `#`), so `new URL().searchParams` misses them — parsing it correctly, once, in TypeScript is far more reliable than asking a model to decode `%60`→backtick / `+`→space and split the fragment on every call.

## What changed

**Share-URL support (`98d161c7`)**
- `parseProjectRef()` (`src/share-url.ts`): accepts a bare id **or** a share URL → `{ project, file?, server?, name? }`, parsing the fragment by hand.
- `normalizeArgs()` at the tool dispatch boundary (`src/tools.ts`): a `project` that is a share URL is replaced with the bare id; if the URL named a `file=` and no explicit `path` was given, `path` defaults to it. **A bare id passes through unchanged — fully backward compatible.**
- Discoverability: every `project` param description, the `connect_project` description, and a new server-level `instructions` block explain the affordance.

**Wrong-hub guard (`60008d9c`)**
- A share URL carries the hub it belongs to in `server=`. The MCP talks to a single hub fixed at startup. If a link points at a *different* hub, the call is now **rejected** with an actionable error (`restart with --server <hub>`) rather than silently reading/writing the wrong hub.
- `serversMatch()` (`src/share-url.ts`): scheme/host/path comparison tolerant of trailing slash, host case, whitespace; scheme-sensitive (`ws://` ≠ `wss://`); falls back to a trimmed string compare for unparseable input.
- `ConnectionManager.configuredServerUrl` getter exposes the configured hub.

## Deliberately out of scope
- `server=` does **not** re-point the connection (the `ConnectionManager` is built with one `serverUrl`); a mismatch errors instead. Auto-switching is a possible follow-up.
- No dedicated `resolve_share_url` tool (Layer 3) — the param-level support already makes "use this share link" work.

## Testing
- `share-url.test.ts`: 15 unit cases — parsing (incl. percent/`+` decoding, bare-fragment, no-query) and `serversMatch`.
- `hub-mcp.test.ts`: **end-to-end** tests driving the spawned MCP server over JSON-RPC:
  - 3 live tests (sync.automerge.org): connect via share URL, `file=`-defaulted read, explicit-path override.
  - 1 protocol test (no network): a share URL for a different hub is rejected with both hosts + the `--server` hint.
- Full package suite: **226 passed / 4 skipped**. `tsc` clean. `cargo xtask build-hub-mcp-bundle` clean.

**Verification scope:** TypeScript-only change (6 files, all under `ts-packages/quarto-hub-mcp/src/`); no Rust files touched, so the full Rust workspace `cargo xtask verify` was not run. Not yet re-embedded into the `q2` binary (`cargo build --bin q2`) — that's a release-time step.

braid: bd-m4slev7a

🤖 Generated with [Claude Code](https://claude.com/claude-code)