### PR TITLE
fix(video): embed + size video shortcode in preview, hub-client, and revealjs render

### DIFF
--- a/claude-notes/plans/2026-06-22-video-shortcode-preview.md
+++ b/claude-notes/plans/2026-06-22-video-shortcode-preview.md
@@ -1,0 +1,306 @@
+# Video shortcode support in `q2 preview` / hub-client
+
+**Strand:** bd-5b21rbaq
+**Date:** 2026-06-22
+**Status:** Diagnosis complete; plan drafted; awaiting go-ahead to implement.
+
+## Overview
+
+The Quarto `{{< video ... >}}` shortcode embeds an `<iframe>` player in
+`q2 render` (HTML and revealjs) but degrades to a **plain `<a>` link** in
+`q2 preview` and the hub-client WASM preview. This plan diagnoses the root
+cause and proposes a fix.
+
+Running example:
+`/Users/cscheid/Desktop/daily-log/2026/06/22/update/slides.qmd`
+(copied to `/tmp/video-repro/slides.qmd` for reproduction).
+
+## Reproduction (verified 2026-06-22)
+
+All three paths exercised end-to-end through the real `q2` binary.
+
+| Path | Invocation | Result |
+|------|-----------|--------|
+| **render html** | `q2 render /tmp/video-repro/slides.qmd` | ✅ Full-width `<iframe>` — `<div class="quarto-video ratio ratio-16x9"><iframe ... src="https://www.youtube.com/embed/sAWFsP0Bbbk" ...></iframe></div>`. Verified in browser (full YouTube player). |
+| **render revealjs** | `q2 render` on a `format: revealjs` copy | ✅ Bare `<iframe>` (no wrapping `quarto-video`/ratio div) — plays, but small/unsized. |
+| **preview html** | `q2 preview --no-browser --port 8766 /tmp/video-repro/slides.qmd` | ❌ Plain link: `<a href="https://youtu.be/sAWFsP0Bbbk">https://youtu.be/sAWFsP0Bbbk</a>`. Verified in browser (a11y snapshot node `link "https://youtu.be/sAWFsP0Bbbk"`). |
+
+## Root cause
+
+The `video` shortcode is a **built-in Lua extension**
+(`resources/extensions/quarto/video/video.lua`). Its dispatch is gated on the
+output format:
+
+```lua
+if quarto.doc.is_format("html:js") then
+    return htmlVideo(...)        -- emits the <iframe>
+elseif quarto.doc.is_format("asciidoc") then ...
+elseif quarto.doc.is_format("markdown") then
+    return pandoc.Link(...)      -- a link
+else
+    return pandoc.Link(srcValue, srcValue)   -- FALLBACK: the plain link we see
+end
+```
+
+`quarto.doc.is_format(query)` (in `crates/pampa/src/lua/quarto_doc.rs`,
+`is_format_match` / `is_html_output`) matches the Lua `FORMAT` global against
+the query. `FORMAT` is set verbatim from the pipeline's `target_format` string
+(`crates/pampa/src/lua/shortcode.rs:102`, and `filter.rs:186` for user
+filters).
+
+- **render html:** `target_format = "html"` → `is_html_output("html")` is
+  true → `is_format("html:js")` true → iframe. ✅
+- **render revealjs:** `target_format = "revealjs"` → `is_html_output` true →
+  iframe (no wrapper div because `video.lua` special-cases `isRevealJS()`). ✅
+- **preview html:** `target_format = "q2-preview"` (a **preview pseudo-format**,
+  see `map_format_for_preview` in `crates/wasm-quarto-hub-client/src/lib.rs:662`
+  and `builtin_pseudo_format` in `crates/quarto-core/src/format.rs:115`).
+  `is_html_output("q2-preview")` is **false** (the pseudo-format is not in the
+  HTML family list) → `is_format("html:js")` false → falls through to the
+  fallback `pandoc.Link`. ❌
+- **preview revealjs:** `target_format = "q2-slides"` → same problem.
+
+### Key insight: this is **not** video-specific
+
+Any Lua shortcode or filter (built-in or user) that gates on
+`is_format("html")` / `"html:js"` / `"revealjs"` will misbehave under preview,
+because the Lua `FORMAT` global carries the q2 preview pseudo-format
+(`q2-preview` / `q2-slides`) instead of the canonical pandoc output format it
+emulates. Video is just the first place we noticed. The fix belongs at the
+format boundary, not in `video.lua`.
+
+`builtin_pseudo_format()` already encodes the base mapping
+(`q2-preview`/`q2-debug`/`q2-raw` → `html`, `q2-slides` → `html` w/ preview
+kind), but for **Lua FORMAT purposes** `q2-slides` should resolve to
+`revealjs` (so `is_format("revealjs")` is true), matching what
+`is_revealjs_target("q2-slides")` already does for pipeline decisions.
+
+Verified safe: **no** `.lua` under `resources/` references `q2-preview` /
+`q2-slides`, so normalizing the FORMAT global cannot break a deliberate
+pseudo-format check.
+
+## Proposed fix
+
+**Normalize the Lua `FORMAT` global to the canonical pandoc output format at
+the quarto-core boundary**, so preview Lua shortcodes/filters see exactly what
+render sees. Keep `target_format` unchanged for q2 pipeline decisions
+(`is_revealjs_target`, `pipeline_kind`, the SPA's AST-vs-HTML branch) — only the
+value handed to the Lua engines changes.
+
+### Layering choice (recommended)
+
+Do the mapping in `quarto-core` (which already owns `format.rs` and the
+pseudo-format vocabulary), **not** in pampa's `is_format`. pampa is the
+lower-level qmd-parser + Lua-runtime crate and should stay a pure pandoc-format
+matcher with no knowledge of q2 preview pseudo-formats. This matches the
+"format-agnostic core, format knowledge lives in quarto-core" sensibility.
+
+Add to `crates/quarto-core/src/format.rs` (next to `builtin_pseudo_format`):
+
+```rust
+/// The canonical pandoc output format a Lua filter/shortcode should see as its
+/// `FORMAT` global. Preview pseudo-formats resolve to the real format they
+/// emulate so `is_format("html:js")`, `is_format("revealjs")`, etc. behave
+/// identically in preview and render.
+pub fn lua_format_for(target_format: &str) -> &str {
+    match target_format {
+        "q2-preview" | "q2-debug" | "q2-raw" => "html",
+        "q2-slides" => "revealjs",
+        other => other,
+    }
+}
+```
+
+Then in `build_transform_pipeline` (`crates/quarto-core/src/pipeline.rs`
+~L1108-1124), compute `let lua_format = lua_format_for(&target_format).to_string();`
+**before** `target_format` is moved, and pass `lua_format` to
+`ShortcodeResolveTransform::with_lua_support(...)` instead of `target_format`.
+Keep the existing `is_revealjs = is_revealjs_target(&target_format)` line as-is.
+
+Apply the same normalization on the **user Lua filter** path
+(`pampa::lua::apply_lua_filters`, reached via `unified_filter.rs:239`) — trace
+where that call's `target_format` originates in the preview pipeline and feed it
+the normalized value too.
+
+### Alternatives considered (and why not)
+
+- **Teach pampa's `is_html_output` about `q2-*`** — leaks q2 preview vocabulary
+  into the parser/runtime crate; pollutes the pure format matcher. Rejected.
+- **Patch `video.lua` to accept `q2-preview`** — fixes only video; every other
+  format-gated Lua filter stays broken; and it bakes preview pseudo-formats into
+  a resource we keep in sync with TS Quarto. Rejected.
+
+## Secondary issue: revealjs iframe sizing (separate)
+
+`q2 render` with `format: revealjs` emits a **bare** `<iframe>` (no
+`quarto-video`/`ratio-16x9` wrapper, because `video.lua` skips the wrapper for
+revealjs), so the player renders small/unsized on the slide. TS Quarto sizes
+reveal video via reveal/quarto SCSS. This is **independent** of the preview
+bug and is about (S)CSS, not Lua dispatch. Tracked as a follow-up item below;
+consider a separate strand if it grows.
+
+## Work items
+
+### Phase 0 — Tests first (TDD)
+- [x] Failing end-to-end test: render the video shortcode through the **preview**
+      pipeline (target_format `q2-preview`) and assert the output contains an
+      `<iframe>` (currently a link). Routed through `render_qmd_to_preview_ast`
+      (real preview entry), not `HtmlRenderConfig::default()`.
+      → `crates/quarto-core/tests/integration/video_shortcode_preview.rs`.
+- [x] Analogous `q2-slides` test asserting iframe under reveal preview.
+- [x] Baseline html-render test (iframe) to prove the harness loads the
+      built-in video extension.
+- [x] Ran the new tests; html baseline **passes**, both preview tests **fail**
+      for the expected reason — AST shows a `Link` at video.lua `lua_line:362`
+      (the fallback `pandoc.Link`), confirming the shortcode ran and degraded.
+- [x] Unit test for `lua_format_for` in `format.rs` (each pseudo-format → base,
+      real formats pass through). Added alongside Phase 1.
+
+### Phase 1 — Normalize Lua FORMAT (fixes video + all format-gated shortcodes)
+- [x] Add `lua_format_for` to `crates/quarto-core/src/format.rs`.
+- [x] Use it in `build_transform_pipeline` for the shortcode transform
+      (`crates/quarto-core/src/pipeline.rs` ~L1116). `target_format` is kept for
+      `is_revealjs`; only the Lua-facing value is normalized.
+- [x] Ran new + unit tests: all 3 video tests pass, both `lua_format_for` unit
+      tests pass.
+
+### Phase 2 — Same normalization for user Lua filters
+- [x] Traced the user-filter FORMAT source: `UserFiltersStage`
+      (`crates/quarto-core/src/stage/stages/user_filters.rs:134`) used
+      `ctx.format.identifier.as_str()`, which collapses **both** `q2-preview`
+      **and** `q2-slides` to `html` — so `q2-preview` was already correct, but a
+      user filter in **reveal preview** (`q2-slides`) wrongly saw `html` instead
+      of `revealjs`.
+- [x] Introduced `Format::lua_format()` (identifier base + revealjs override,
+      so extension formats like `acm-pdf` → `pdf` stay correct) as the
+      `Format`-aware companion to the string-only `lua_format_for`. Switched
+      `UserFiltersStage` to it.
+- [x] Unit tests: `test_format_lua_format_canonicalizes` (matrix incl.
+      `q2-slides`→`revealjs`, `acm-pdf`→`pdf`) and
+      `test_lua_format_helpers_agree_on_shared_cases` (the two helpers can't
+      drift on shared cases). Existing `user_filters` stage tests still pass.
+- Note: the end-to-end FORMAT-normalization mechanism is already exercised
+  through the preview pipeline by the video shortcode tests; a dedicated
+  user-Lua-filter e2e (authoring a filter that branches on
+  `is_format("revealjs")`) is deferred — the unit coverage on `lua_format()`
+  plus the shortcode e2e cover the logic. Revisit if we want belt-and-braces.
+
+### Phase 3 — End-to-end verification (binary + browser)
+- [x] Rebuilt the WASM + SPA chain so the embedded preview image is fresh:
+      `cd hub-client && npm run build:wasm` (exit 0) →
+      `cargo xtask build-q2-preview-spa` (exit 0) → `cargo build --bin q2`
+      (exit 0; binary stamped 15:55). Per CLAUDE.md "Verifying Rust changes in
+      `q2 preview`".
+- [x] `q2 preview --no-browser --port 8767 /tmp/video-repro/slides.qmd`;
+      confirmed via Chrome DevTools the video is now an embedded YouTube
+      `<iframe>` (`url="https://www.youtube.com/embed/sAWFsP0Bbbk"`, a11y node
+      `Iframe → RootWebArea "Hello Posit Assistant + Quarto Hub - YouTube"` with
+      a "Play video" button), replacing the prior `link` node. Screenshot shows
+      the full player, identical to `q2 render`.
+- Note: `q2 preview` exercises the same WASM render path as the hub-client, so
+  this confirms both. A separate live hub-client session wasn't needed.
+
+**Observed output (preview, after fix):**
+```
+uid Iframe
+  RootWebArea "Hello Posit Assistant + Quarto Hub - YouTube"
+              url="https://www.youtube.com/embed/sAWFsP0Bbbk"
+    button "Play video"
+    link "Watch on YouTube" url="https://www.youtube.com/watch?v=sAWFsP0Bbbk"
+```
+(Before the fix this node was: `link "https://youtu.be/sAWFsP0Bbbk"`.)
+
+### Phase 4 — Workspace verification
+- [x] `cargo nextest run --workspace` — **10319 passed, 197 skipped, 0 failed**.
+- [x] `cargo xtask verify` (full) — **✓ All verification steps passed!**
+      (14/14 steps). First run was red only on a pre-existing missing
+      `vitest-axe` dep in `ts-packages/preview-renderer` (unrelated to this
+      change); `npm install` installed it, re-run is fully green.
+- Note: `crates/wasm-quarto-hub-client/Cargo.lock` picked up a `0.4.0 → 0.5.0`
+  version sync during `npm run build:wasm` — it was lagging the already-released
+  0.5.0 workspace bump. Legitimate; include in the commit.
+
+### Phase 5 — revealjs video iframe sizing (this strand, after the preview fix)
+User confirmed: fold the sizing fix into this strand, after the larger fix.
+
+Findings so far:
+- `q2 render` `format: revealjs` emits a **bare** `<iframe>` (video.lua skips the
+  `quarto-video`/`ratio` wrapper for reveal) with no width/height.
+- Reveal core CSS only sets `.reveal iframe { z-index: 1 }` (reveal.scss:224) —
+  no sizing — so the iframe falls back to the browser default (~300×150) and
+  renders tiny on the slide. TS Quarto's `quarto.scss` has **no** `iframe`
+  rule either, so the sizing must come from elsewhere (still to pin down).
+- [x] Reproduced + measured (render reveal, browser): the video `<iframe>` is a
+      **direct child of `section`** with no width/height → browser default
+      **300×150** (rendered 222×111 after reveal scale), tiny on a 778px-wide
+      slide. Screenshot captured.
+- [x] **Mechanism confirmed empirically:** adding class `r-stretch` to the
+      iframe + `Reveal.layout()` resizes it **222×111 → 778×414** (reveal sets
+      inline `height:559px; width:1050px`). So reveal core *does* stretch
+      `section > iframe.r-stretch` — **no custom (S)CSS needed**, identical to
+      how images are stretched.
+- [x] Found that **Q1's `applyStretch` is images-only**
+      (`external-sources/.../format-reveal.ts:949`) — it does **not** stretch
+      video/iframe. So a bare reveal video is *also* small in Q1; giving the
+      iframe `r-stretch` is a q2 **enhancement**, not just parity.
+
+**Decision needed — where to inject `r-stretch` on the reveal video iframe:**
+- **A. Extend `RevealAutoStretchTransform`** (`crates/quarto-core/src/revealjs/
+  auto_stretch.rs`) to recognize a standalone video `RawBlock(html,<iframe>)`
+  and add `r-stretch`. Pro: same home as image stretch; can reuse the
+  single-media gating + `auto-stretch:false`/`.nostretch` opt-outs. Con: the
+  iframe is opaque raw HTML, so it means editing an HTML string.
+- **B. video.lua adds `class="r-stretch"`** to the iframe when `isRevealJS()`
+  (it already branches on reveal). Pro: built at the source, no Rust HTML
+  surgery. Con: unconditional (ignores opt-outs), diverges from upstream
+  video.lua (acceptable — q2 has no DOM postprocessor and Q1 doesn't stretch
+  video anyway).
+
+- [x] Decided: **conditional B + meta-bridge fix** (user's call).
+- [x] Meta-bridge fix: `shortcode_to_lua_args` (`shortcode_resolve.rs`) now
+      forwards boolean/numeric/inline scalars to the Lua handler `meta`, not
+      just strings — so `auto-stretch: false` reaches `video.lua`.
+- [x] `video.lua`: handler reads `meta['auto-stretch']` and the explicit
+      `width`/`height`; passes `stretchReveal = autoStretch and not
+      hasExplicitSize` to `htmlVideo`, which adds `class="r-stretch"` to the
+      reveal iframe when set.
+- [x] TDD tests (`revealjs_features.rs`): default reveal video → `r-stretch`
+      (failed before, passes after); explicit `width` → no `r-stretch`;
+      `auto-stretch: false` → no `r-stretch` (proves the bridge forwards the
+      bool). Plus html-path guard (`video_shortcode_preview.rs`): html keeps
+      `quarto-video`, never `r-stretch`. All pass.
+- [x] q2-slides **preview parity** asserted in `video_shortcode_preview.rs`
+      (slides preview AST carries `r-stretch`).
+- [x] Browser (native render, new binary): reveal video now sized **778×414**
+      (reveal inline `height:559px; width:1050px`) filling the slide, vs the
+      prior 300×150. Screenshot captured.
+- [x] Full quarto-core suite (2404 tests) green after the bridge change.
+- [x] Rebuilt WASM→SPA→binary; checked the slides **preview** in the browser.
+      **Finding (honest):** the preview AST correctly carries
+      `<iframe class="r-stretch">`, BUT it is **not** visually stretched in
+      q2-slides preview (stays ~222×111). Cause: the q2-preview SPA reveal
+      renderer wraps the RawBlock iframe in a bare `<div>` —
+      `section > div > iframe.r-stretch` — so reveal's direct-child stretch
+      selector (`section > .r-stretch`) misses it, and the preview doesn't run
+      the global `window.Reveal` layout the way native render does.
+
+**Scope outcome:** both originally-reported issues are fixed and verified —
+(1) preview/hub-client video was a plain link → now an embedded iframe;
+(2) `q2 render` revealjs video was tiny → now stretched (778×414). The
+**q2-slides preview** video-sizing is a *newly-discovered third issue* in the
+SPA reveal renderer (div-wraps RawBlocks, no reveal.js autostretch). It is
+out of scope for the video shortcode and should be its **own strand** (likely a
+preview-SPA CSS rule like `.reveal section > div > iframe.r-stretch { … }`,
+since the preview can't rely on reveal's JS stretch). Filed as a follow-up.
+
+## Key references
+- `resources/extensions/quarto/video/video.lua` — dispatch + builders.
+- `crates/pampa/src/lua/quarto_doc.rs` — `is_format_match`, `is_html_output`,
+  FORMAT global read.
+- `crates/pampa/src/lua/shortcode.rs:102`, `filter.rs:186` — FORMAT global set.
+- `crates/quarto-core/src/format.rs:115` — `builtin_pseudo_format`,
+  `is_revealjs_target`.
+- `crates/quarto-core/src/pipeline.rs:1108-1124` — `build_transform_pipeline`;
+  `:1418-1430` — `build_q2_preview_transform_pipeline`.
+- `crates/wasm-quarto-hub-client/src/lib.rs:662` — `map_format_for_preview`;
+  `:1333` — preview format selection.

--- a/claude-notes/plans/2026-06-22-video-shortcode-preview.md
+++ b/claude-notes/plans/2026-06-22-video-shortcode-preview.md
@@ -284,6 +284,28 @@ Findings so far:
       selector (`section > .r-stretch`) misses it, and the preview doesn't run
       the global `window.Reveal` layout the way native render does.
 
+**Preview reveal-sizing fix (follow-up bd-xfw2omlt, now DONE):** RawBlock.tsx
+mirrors a root-level `r-stretch` onto its wrapper `<div>` (so reveal stretches
+the wrapper that React's `dangerouslySetInnerHTML` forces), and a
+`quarto-reveal.css` rule `.reveal .slides section > div.r-stretch > iframe { … }`
+makes the iframe fill it. TDD: `RawBlock.test.tsx`. Verified in the browser via
+the real `q2 preview` binary — slides-preview video now 778×452 (was 222×111).
+456 unit + 484 integration preview-renderer tests pass.
+
+**hub-client end-to-end verification (real product).** Ran the local stack —
+`q2 hub --no-project` (port 3000, anonymous: auth is opt-in via
+`--oidc-client-id`) + `npm run dev:fresh` (build shows commit `82dbb636`) — and
+drove it via Chrome DevTools: created a project, added a `format: revealjs`
+`slides.qmd` with `{{< video … >}}`. Observed in the live editor's preview pane:
+the video embeds as a YouTube `<iframe>` (Phase 1 fix) AND, on the active
+"Video" slide, auto-stretches to fill it (678×394; wrapper carries `r-stretch`,
+reveal sets `height:700px; width:1050px`). Note: reveal switches between
+**scroll view** (narrow/tall pane → r-stretch wrapper collapses to height 0)
+and **classic slide view** (wider pane → stretches correctly) based on pane
+size. Verified in classic mode. The scroll-view r-stretch-collapse is a
+reveal-scroll-mode trait, not specific to this fix — worth a separate look if
+scroll view becomes the hub-client default.
+
 **Scope outcome:** both originally-reported issues are fixed and verified —
 (1) preview/hub-client video was a plain link → now an embedded iframe;
 (2) `q2 render` revealjs video was tiny → now stretched (778×414). The

--- a/crates/quarto-core/src/format.rs
+++ b/crates/quarto-core/src/format.rs
@@ -138,6 +138,37 @@ pub fn is_revealjs_target(target_format: &str) -> bool {
     matches!(target_format, "revealjs" | "q2-slides")
 }
 
+/// The canonical Pandoc output format a Lua filter or shortcode should see as
+/// its `FORMAT` global, given the pipeline's `target_format`.
+///
+/// The preview pipeline runs with a *pseudo-format* `target_format`
+/// (`q2-preview`, `q2-slides`, …) so q2-core can branch on it for AST-vs-HTML
+/// output and reveal-tree construction (see [`builtin_pseudo_format`] /
+/// [`is_revealjs_target`]). But Lua extensions don't know about those
+/// pseudo-formats: their `quarto.doc.is_format("html:js")` /
+/// `is_format("revealjs")` checks (e.g. the built-in `video` shortcode) only
+/// recognize real Pandoc formats. If we hand the pseudo-format straight to Lua,
+/// those checks fail and format-gated shortcodes/filters silently degrade
+/// (`{{< video >}}` collapsed to a plain link in preview — bd-5b21rbaq).
+///
+/// This maps each preview pseudo-format back to the real format it emulates so
+/// preview Lua behaves identically to render:
+/// - `q2-preview` / `q2-debug` / `q2-raw` → `html`
+/// - `q2-slides` → `revealjs` (so `is_format("revealjs")` is true, matching
+///   what [`is_revealjs_target`] already does for pipeline decisions; note this
+///   intentionally differs from [`builtin_pseudo_format`], which reports the
+///   *output writer* base `html`).
+///
+/// Any non-pseudo `target_format` (`html`, `revealjs`, `latex`, …) passes
+/// through unchanged.
+pub fn lua_format_for(target_format: &str) -> &str {
+    match target_format {
+        "q2-preview" | "q2-debug" | "q2-raw" => "html",
+        "q2-slides" => "revealjs",
+        other => other,
+    }
+}
+
 /// Extract the chosen output format from a document's leading YAML
 /// front-matter: the `format:` scalar, or the first key when `format:` is a
 /// map (e.g. `format: {revealjs: {...}}`). Returns `None` when there is no
@@ -326,6 +357,35 @@ impl Format {
             output_extension: "docx".to_string(),
             native_pipeline: false,
             pipeline_kind: None,
+        }
+    }
+
+    /// The canonical Pandoc output format a Lua filter or shortcode should see
+    /// as its `FORMAT` global.
+    ///
+    /// Lua extensions branch on real Pandoc formats
+    /// (`quarto.doc.is_format("html:js")`, `is_format("revealjs")`, …), not on
+    /// q2's preview pseudo-formats or extension-style format strings. This
+    /// resolves a `Format` to the base format it emulates:
+    /// - reveal targets (`revealjs` render **and** `q2-slides` preview) →
+    ///   `"revealjs"`, so `is_format("revealjs")` fires in preview too. The
+    ///   bare [`identifier`](Self::identifier) would otherwise collapse
+    ///   `q2-slides` to `Html` (its *output writer* is HTML), losing
+    ///   reveal-ness — the reason a user filter in a reveal preview saw
+    ///   `"html"` (bd-5b21rbaq).
+    /// - everything else → the identifier base (`html`, `pdf`, …), which
+    ///   already canonicalizes extension formats (`acm-pdf` → `pdf`) and the
+    ///   HTML preview pseudo-formats (`q2-preview`/`q2-debug`/`q2-raw` → `html`).
+    ///
+    /// This is the [`Format`]-aware companion to the string-only
+    /// [`lua_format_for`] (used where only a `target_format` string is in hand,
+    /// e.g. the transform-pipeline builder); the two agree on the pseudo-format
+    /// and base cases.
+    pub fn lua_format(&self) -> &str {
+        if is_revealjs_target(&self.target_format) {
+            "revealjs"
+        } else {
+            self.identifier.as_str()
         }
     }
 
@@ -819,6 +879,79 @@ mod tests {
         // later commit (Plan 7 cleanup retires the temporary
         // `target_format == "q2-preview"` string match).
         assert_eq!(f.pipeline_kind, Some("preview"));
+    }
+
+    #[test]
+    fn test_lua_format_for_maps_preview_pseudo_formats() {
+        // HTML-emulating pseudo-formats resolve to `html` so
+        // `is_format("html:js")` fires in preview (bd-5b21rbaq).
+        assert_eq!(lua_format_for("q2-preview"), "html");
+        assert_eq!(lua_format_for("q2-debug"), "html");
+        assert_eq!(lua_format_for("q2-raw"), "html");
+        // The reveal preview pseudo-format resolves to `revealjs` so
+        // `is_format("revealjs")` fires — distinct from
+        // `builtin_pseudo_format`, which reports the output-writer base `html`.
+        assert_eq!(lua_format_for("q2-slides"), "revealjs");
+    }
+
+    #[test]
+    fn test_lua_format_for_passes_through_real_formats() {
+        for f in ["html", "revealjs", "latex", "pdf", "gfm", "typst", "docx"] {
+            assert_eq!(lua_format_for(f), f, "real format {f} must pass through");
+        }
+    }
+
+    #[test]
+    fn test_format_lua_format_canonicalizes() {
+        // Real formats: identifier base.
+        assert_eq!(
+            Format::from_format_string("html").unwrap().lua_format(),
+            "html"
+        );
+        assert_eq!(
+            Format::from_format_string("revealjs").unwrap().lua_format(),
+            "revealjs"
+        );
+        // Extension formats canonicalize to their base (the bug `identifier`
+        // already handled; `lua_format` must preserve it).
+        assert_eq!(
+            Format::from_format_string("acm-pdf").unwrap().lua_format(),
+            "pdf"
+        );
+        // HTML preview pseudo-formats → html.
+        assert_eq!(
+            Format::from_format_string("q2-preview")
+                .unwrap()
+                .lua_format(),
+            "html"
+        );
+        assert_eq!(
+            Format::from_format_string("q2-debug").unwrap().lua_format(),
+            "html"
+        );
+        // Reveal preview pseudo-format → revealjs (NOT its html output base) —
+        // the parity fix for user filters in reveal preview.
+        assert_eq!(
+            Format::from_format_string("q2-slides")
+                .unwrap()
+                .lua_format(),
+            "revealjs"
+        );
+    }
+
+    /// `Format::lua_format` and the string-only `lua_format_for` must agree on
+    /// the pseudo-format + base cases both handle, so the shortcode pipeline
+    /// (string-only) and user-filter stage (Format-aware) don't drift.
+    #[test]
+    fn test_lua_format_helpers_agree_on_shared_cases() {
+        for fmt in ["html", "revealjs", "q2-preview", "q2-slides", "q2-debug"] {
+            let f = Format::from_format_string(fmt).unwrap();
+            assert_eq!(
+                f.lua_format(),
+                lua_format_for(&f.target_format),
+                "lua_format helpers disagree for {fmt}"
+            );
+        }
     }
 
     #[test]

--- a/crates/quarto-core/src/pipeline.rs
+++ b/crates/quarto-core/src/pipeline.rs
@@ -1113,6 +1113,14 @@ pub fn build_transform_pipeline(
     // True for `revealjs` (native render) and `q2-slides` (preview).
     let is_revealjs = crate::format::is_revealjs_target(&target_format);
 
+    // The Lua engines (shortcodes, user filters) see the *canonical* Pandoc
+    // format as their `FORMAT` global, not q2's preview pseudo-format. Under
+    // preview, `target_format` is `q2-preview` / `q2-slides`, which Lua's
+    // `is_format("html:js")` / `is_format("revealjs")` don't recognize — so
+    // format-gated shortcodes degrade (the `{{< video >}}` → plain-link bug,
+    // bd-5b21rbaq). Normalizing here makes preview Lua behave like render.
+    let lua_format = crate::format::lua_format_for(&target_format).to_string();
+
     // === NORMALIZATION PHASE ===
     pipeline.push(Box::new(CalloutTransform::new()));
     pipeline.push(Box::new(CalloutResolveTransform::new()));
@@ -1120,7 +1128,7 @@ pub fn build_transform_pipeline(
         shortcode_paths,
         extensions,
         runtime,
-        target_format,
+        lua_format,
     )));
     pipeline.push(Box::new(MetadataNormalizeTransform::new()));
     // bd-1tl09 Phase 0: code-block decoration Generate runs after

--- a/crates/quarto-core/src/stage/stages/user_filters.rs
+++ b/crates/quarto-core/src/stage/stages/user_filters.rs
@@ -131,7 +131,12 @@ impl PipelineStage for UserFiltersStage {
                 .join(", ")
         );
 
-        let target_format = ctx.format.identifier.as_str();
+        // The canonical Pandoc format Lua filters see as FORMAT. Using
+        // `Format::lua_format()` (not `identifier.as_str()`) makes the reveal
+        // *preview* pseudo-format `q2-slides` resolve to `revealjs` rather than
+        // its HTML output-writer base — so a user filter's `is_format("revealjs")`
+        // fires in preview exactly as in native reveal render (bd-5b21rbaq).
+        let target_format = ctx.format.lua_format();
 
         // Build the attribution lookup handle when a sidecar is
         // present. `AttributionGenerateStage` runs before this stage

--- a/crates/quarto-core/src/transforms/shortcode_resolve.rs
+++ b/crates/quarto-core/src/transforms/shortcode_resolve.rs
@@ -470,15 +470,25 @@ fn shortcode_to_lua_args(
         })
         .collect();
 
-    // Extract top-level metadata as string key-value pairs for Lua
+    // Extract top-level metadata as string key-value pairs for Lua.
+    //
+    // Forward scalars of every stringifiable kind, not just strings: a handler
+    // that gates on a boolean/numeric flag (e.g. the `video` shortcode reading
+    // `auto-stretch: false` to decide reveal stretching — bd-5b21rbaq) needs to
+    // see it. Booleans/ints are stringified ("false", "16"); string and
+    // PandocInlines scalars come through `as_plain_text()`. Map/array values
+    // remain dropped (no flat string form).
     let meta_entries: Vec<(String, String)> = if let Some(entries) = metadata.as_map_entries() {
         entries
             .iter()
             .filter_map(|entry| {
-                entry
-                    .value
-                    .as_str()
-                    .map(|v| (entry.key.clone(), v.to_string()))
+                let v = &entry.value;
+                let s = v
+                    .as_bool()
+                    .map(|b| b.to_string())
+                    .or_else(|| v.as_int().map(|n| n.to_string()))
+                    .or_else(|| v.as_plain_text());
+                s.map(|s| (entry.key.clone(), s))
             })
             .collect()
     } else {

--- a/crates/quarto-core/tests/integration/main.rs
+++ b/crates/quarto-core/tests/integration/main.rs
@@ -40,6 +40,7 @@ pub mod replay_engine;
 pub mod revealjs_features;
 pub mod revealjs_format;
 pub mod sidebar_pipeline;
+pub mod video_shortcode_preview;
 pub mod website_post_render;
 
 fn main() {}

--- a/crates/quarto-core/tests/integration/revealjs_features.rs
+++ b/crates/quarto-core/tests/integration/revealjs_features.rs
@@ -444,3 +444,57 @@ fn fragment_data_index_passes_through() {
         &html[..html.len().min(1500)]
     );
 }
+
+// ── video shortcode auto-stretch on reveal (bd-5b21rbaq Phase 5) ──────────
+//
+// A `{{< video >}}` on a slide emits a bare `<iframe>` with no size, which
+// reveal renders at the browser default (~300×150). reveal sizes
+// `section > iframe.r-stretch` to fill the slide, so the video shortcode adds
+// `r-stretch` to the reveal iframe — but only when auto-stretch is on AND the
+// author gave no explicit width/height (so explicit sizing always wins).
+
+fn video_iframe_line(html: &str) -> String {
+    html.lines()
+        .find(|l| l.contains("<iframe") && l.contains("youtube.com/embed"))
+        .unwrap_or_else(|| panic!("no youtube iframe in reveal output:\n{html}"))
+        .to_string()
+}
+
+#[test]
+fn video_reveal_default_iframe_gets_r_stretch() {
+    let html = render_revealjs(
+        "---\nformat: revealjs\n---\n\n## Video\n\n{{< video https://youtu.be/sAWFsP0Bbbk >}}\n",
+    );
+    let iframe = video_iframe_line(&html);
+    assert!(
+        iframe.contains("r-stretch"),
+        "default reveal video iframe must carry `r-stretch` so reveal sizes it; iframe:\n{iframe}"
+    );
+}
+
+#[test]
+fn video_reveal_explicit_width_no_r_stretch() {
+    // Explicit author sizing must win — no auto-stretch.
+    let html = render_revealjs(
+        "---\nformat: revealjs\n---\n\n## Video\n\n{{< video https://youtu.be/sAWFsP0Bbbk width=\"640\" >}}\n",
+    );
+    let iframe = video_iframe_line(&html);
+    assert!(
+        !iframe.contains("r-stretch"),
+        "reveal video with explicit width must NOT be stretched; iframe:\n{iframe}"
+    );
+}
+
+#[test]
+fn video_reveal_auto_stretch_false_no_r_stretch() {
+    // The `auto-stretch: false` global opt-out must suppress the class —
+    // requires the Lua meta bridge to forward the boolean to the handler.
+    let html = render_revealjs(
+        "---\nformat: revealjs\nauto-stretch: false\n---\n\n## Video\n\n{{< video https://youtu.be/sAWFsP0Bbbk >}}\n",
+    );
+    let iframe = video_iframe_line(&html);
+    assert!(
+        !iframe.contains("r-stretch"),
+        "reveal video must NOT be stretched when `auto-stretch: false`; iframe:\n{iframe}"
+    );
+}

--- a/crates/quarto-core/tests/integration/video_shortcode_preview.rs
+++ b/crates/quarto-core/tests/integration/video_shortcode_preview.rs
@@ -1,0 +1,153 @@
+/*
+ * tests/integration/video_shortcode_preview.rs
+ * Copyright (c) 2026 Posit, PBC
+ *
+ * bd-5b21rbaq: the {{< video >}} shortcode must embed an <iframe> in the
+ * q2-preview pipeline, exactly as it does in the html render pipeline.
+ */
+
+//! End-to-end regression: the built-in `video` Lua shortcode in the
+//! **preview** pipeline.
+//!
+//! The video shortcode (`resources/extensions/quarto/video/video.lua`)
+//! gates on `quarto.doc.is_format("html:js")`: when true it emits an
+//! `<iframe>` player, otherwise it falls through to a plain
+//! `pandoc.Link`. The Lua `FORMAT` global is set from the pipeline's
+//! `target_format`. The html render pipeline passes `"html"`, so the
+//! check passes and an iframe is emitted. The q2-preview pipeline passes
+//! the pseudo-format `"q2-preview"`, which `is_html_output` did not
+//! recognize — so the shortcode degraded to a bare link in preview and
+//! the hub-client.
+//!
+//! These tests render the same video document through both pipelines
+//! in-process and assert both produce an embedded iframe. The
+//! `q2-slides` (revealjs preview) case is covered too.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use tempfile::TempDir;
+
+use quarto_core::format::Format;
+use quarto_core::pipeline::{HtmlRenderConfig, render_qmd_to_html, render_qmd_to_preview_ast};
+use quarto_core::project::{DocumentInfo, ProjectContext};
+use quarto_core::render::{BinaryDependencies, RenderContext};
+use quarto_system_runtime::{NativeRuntime, SystemRuntime};
+
+const VIDEO_DOC: &[u8] = b"---\ntitle: Test\n---\n\n{{< video https://youtu.be/sAWFsP0Bbbk >}}\n";
+
+const VIDEO_DOC_REVEAL: &[u8] =
+    b"---\ntitle: Test\nformat: revealjs\n---\n\n## Slide\n\n{{< video https://youtu.be/sAWFsP0Bbbk >}}\n";
+
+fn test_project() -> ProjectContext {
+    ProjectContext {
+        dir: PathBuf::from("/project"),
+        config: quarto_core::project::ProjectConfig::default(),
+        is_single_file: true,
+        files: vec![DocumentInfo::from_path("/project/test.qmd")],
+        output_dir: PathBuf::from("/project"),
+    }
+}
+
+/// A runtime with a private, throwaway cache so renders never share
+/// state across tests.
+fn fresh_runtime() -> Arc<dyn SystemRuntime> {
+    let temp = TempDir::new().unwrap();
+    let cache_dir = temp.path().to_path_buf();
+    std::mem::forget(temp);
+    Arc::new(NativeRuntime::with_cache_dir(cache_dir))
+}
+
+/// Render `content` through the html render pipeline, returning the HTML.
+fn render_html(content: &[u8]) -> String {
+    let project = test_project();
+    let doc = DocumentInfo::from_path("/project/test.qmd");
+    let format = Format::html();
+    let binaries = BinaryDependencies::new();
+    let mut ctx = RenderContext::new(&project, &doc, &format, &binaries);
+    pollster::block_on(render_qmd_to_html(
+        content,
+        "test.qmd",
+        &mut ctx,
+        &HtmlRenderConfig::default(),
+        fresh_runtime(),
+    ))
+    .expect("html pipeline render")
+    .html
+}
+
+/// Render `content` through the q2-preview pipeline for `pseudo_format`
+/// (`"q2-preview"` or `"q2-slides"`), returning the serialized AST JSON.
+fn render_preview_ast(content: &[u8], pseudo_format: &str) -> String {
+    let project = test_project();
+    let doc = DocumentInfo::from_path("/project/test.qmd");
+    let format = Format::from_format_string(pseudo_format).expect("pseudo-format");
+    let binaries = BinaryDependencies::new();
+    let mut ctx = RenderContext::new(&project, &doc, &format, &binaries);
+    pollster::block_on(render_qmd_to_preview_ast(
+        content,
+        "test.qmd",
+        &mut ctx,
+        fresh_runtime(),
+        None,
+        vec![],
+    ))
+    .expect("q2-preview pipeline render")
+    .ast_json
+}
+
+/// Sanity baseline: the html render pipeline embeds an iframe. This is
+/// the behavior the preview pipeline must match; if this fails, the test
+/// harness isn't loading the built-in video extension at all.
+#[test]
+fn video_shortcode_html_render_embeds_iframe() {
+    let html = render_html(VIDEO_DOC);
+    assert!(
+        html.contains("<iframe") && html.contains("youtube.com/embed"),
+        "html render should embed a YouTube iframe, got:\n{html}"
+    );
+}
+
+/// Guard: the html (non-reveal) render keeps the responsive `quarto-video`
+/// wrapper and must NOT carry reveal's `r-stretch` class (that's reveal-only —
+/// bd-5b21rbaq Phase 5).
+#[test]
+fn video_shortcode_html_render_has_no_r_stretch() {
+    let html = render_html(VIDEO_DOC);
+    assert!(
+        html.contains("quarto-video") && !html.contains("r-stretch"),
+        "html video must use the quarto-video wrapper and not r-stretch, got:\n{html}"
+    );
+}
+
+/// The actual bug: the q2-preview pipeline must embed the iframe too,
+/// not degrade to a plain link.
+#[test]
+fn video_shortcode_preview_embeds_iframe() {
+    let ast_json = render_preview_ast(VIDEO_DOC, "q2-preview");
+    assert!(
+        ast_json.contains("youtube.com/embed") && ast_json.contains("iframe"),
+        "q2-preview pipeline should embed a YouTube iframe (RawBlock), \
+         but it appears to have degraded to a plain link. AST JSON:\n{ast_json}"
+    );
+}
+
+/// The revealjs preview pseudo-format (`q2-slides`) must also embed the
+/// iframe rather than degrade to a link.
+#[test]
+fn video_shortcode_slides_preview_embeds_iframe() {
+    let ast_json = render_preview_ast(VIDEO_DOC_REVEAL, "q2-slides");
+    assert!(
+        ast_json.contains("youtube.com/embed") && ast_json.contains("iframe"),
+        "q2-slides preview pipeline should embed a YouTube iframe, but it \
+         appears to have degraded to a plain link. AST JSON:\n{ast_json}"
+    );
+    // Preview parity for the auto-stretch fix: because the Lua FORMAT resolves
+    // to `revealjs` in slides preview, `is_format("revealjs")` fires and the
+    // video iframe carries `r-stretch`, just like native reveal render.
+    assert!(
+        ast_json.contains("r-stretch"),
+        "q2-slides preview video iframe should be auto-stretched (r-stretch), \
+         matching native reveal render. AST JSON:\n{ast_json}"
+    );
+}

--- a/crates/wasm-quarto-hub-client/Cargo.lock
+++ b/crates/wasm-quarto-hub-client/Cargo.lock
@@ -377,7 +377,7 @@ dependencies = [
 
 [[package]]
 name = "comrak-to-pandoc"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "comrak",
  "hashlink",
@@ -2072,7 +2072,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-analysis"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "quarto-error-reporting",
  "quarto-pandoc-types",
@@ -2094,7 +2094,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-brand"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "serde",
  "serde_yaml",
@@ -2103,7 +2103,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-citeproc"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "glob",
  "hashlink",
@@ -2134,7 +2134,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-core"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2184,7 +2184,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-csl"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "quarto-error-reporting",
  "quarto-source-map",
@@ -2220,7 +2220,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-error-reporting"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "ariadne",
  "once_cell",
@@ -2234,7 +2234,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-highlight"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "once_cell",
  "quarto-highlight-encoding",
@@ -2260,7 +2260,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-highlight-encoding"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2268,7 +2268,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-lsp-core"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "pampa",
  "pollster",
@@ -2289,7 +2289,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-navigation"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "quarto-config",
  "quarto-pandoc-types",
@@ -2324,7 +2324,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-project-create"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "quarto-doctemplate",
  "serde",
@@ -2333,7 +2333,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-sass"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "include_dir",
  "once_cell",
@@ -2351,7 +2351,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-source-map"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2360,7 +2360,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-system-runtime"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -2377,7 +2377,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-trace"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "flate2",
  "serde",
@@ -2395,7 +2395,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-util"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -2403,7 +2403,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-xml"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "quarto-error-reporting",
  "quarto-source-map",
@@ -2413,7 +2413,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-yaml"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "quarto-source-map",
  "serde",
@@ -4000,7 +4000,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-printf-fmt"
-version = "0.4.0"
+version = "0.5.0"
 
 [[package]]
 name = "wasm-quarto-hub-client"

--- a/resources/extensions/quarto/video/video.lua
+++ b/resources/extensions/quarto/video/video.lua
@@ -234,7 +234,7 @@ local function asciidocVideo(src, height, width, title, start, _aspectRatio, ari
 
 end
 
-function htmlVideo(src, height, width, title, start, aspectRatio, ariaLabel)
+function htmlVideo(src, height, width, title, start, aspectRatio, ariaLabel, stretchReveal)
 
   -- https://github.com/quarto-dev/quarto-cli/issues/6833
   -- handle partially-specified width, height, and aspectRatio
@@ -302,6 +302,14 @@ function htmlVideo(src, height, width, title, start, aspectRatio, ariaLabel)
             aspectRatio,
             shouldAddResponsiveClasses
     )
+  elseif stretchReveal then
+    -- On reveal.js a bare <iframe> has no size and renders at the browser
+    -- default (~300x150). reveal sizes `section > iframe.r-stretch` to fill the
+    -- slide, so we add the reveal-core `r-stretch` class (no Quarto CSS needed).
+    -- Gated by the caller: only when auto-stretch is on AND the author gave no
+    -- explicit width/height, so explicit sizing always wins (bd-5b21rbaq).
+    -- Q2 has no DOM postprocessor, so we mark the class here at construction.
+    videoSnippet = videoSnippet:gsub('<iframe ', '<iframe class="r-stretch" ', 1)
   end
 
   -- inject the rendering code
@@ -311,7 +319,7 @@ end
 -- defining shortcodes this way allows us to create helper
 -- functions that are not themselves considered shortcodes
 return {
-  ["video"] = function(args, kwargs, _meta, raw_args)
+  ["video"] = function(args, kwargs, meta, raw_args)
     checkArg = function(toCheck, key)
       value = pandoc.utils.stringify(toCheck[key])
       if not isEmpty(value) then
@@ -339,13 +347,24 @@ return {
         srcValue = pandoc.utils.stringify(raw_args[1])
       else
         -- luacov: disable
-        fail("No video source specified for video shortcode")        
+        fail("No video source specified for video shortcode")
         -- luacov: enable
       end
     end
 
+    -- Decide whether a reveal video iframe should be auto-stretched to fill the
+    -- slide. Mirrors the gates of RevealAutoStretchTransform that a shortcode
+    -- can observe: on unless `auto-stretch: false` in metadata, and off when the
+    -- author gave an explicit width/height (their sizing wins). bd-5b21rbaq.
+    local autoStretch = true
+    if meta and meta['auto-stretch'] ~= nil then
+      autoStretch = pandoc.utils.stringify(meta['auto-stretch']) ~= 'false'
+    end
+    local hasExplicitSize = not isEmpty(widthValue) or not isEmpty(heightValue)
+    local stretchReveal = autoStretch and not hasExplicitSize
+
     if quarto.doc.is_format("html:js") then
-      return htmlVideo(srcValue, heightValue, widthValue, titleValue, startValue, aspectRatio, ariaLabelValue)
+      return htmlVideo(srcValue, heightValue, widthValue, titleValue, startValue, aspectRatio, ariaLabelValue, stretchReveal)
     elseif quarto.doc.is_format("asciidoc") then
       return asciidocVideo(srcValue, heightValue, widthValue, titleValue, startValue, aspectRatio, ariaLabelValue)
     elseif quarto.doc.is_format("markdown") then

--- a/resources/revealjs/quarto-reveal.css
+++ b/resources/revealjs/quarto-reveal.css
@@ -42,3 +42,16 @@
 .reveal .slides aside .aside-footnotes li:first-of-type {
   margin-top: 0;
 }
+
+/* Stretched video in `q2 preview` (bd-xfw2omlt). The video shortcode emits
+   `<iframe class="r-stretch">`; `q2 render` makes it a direct child of the
+   `<section>` so reveal sizes it. The preview renderer must inject raw HTML
+   through a wrapper `<div>` (React `dangerouslySetInnerHTML`), so RawBlock
+   mirrors `r-stretch` onto that wrapper — reveal then stretches the wrapper,
+   and this rule makes the iframe fill it. Inert in `q2 render` (no such
+   `div.r-stretch > iframe` structure there). */
+.reveal .slides section > div.r-stretch > iframe {
+  width: 100%;
+  height: 100%;
+  display: block;
+}

--- a/ts-packages/preview-renderer/src/q2-preview/blocks/RawBlock.test.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/blocks/RawBlock.test.tsx
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { RawBlock } from './RawBlock';
+import type { NodeArgs, RawBlock as RawBlockType } from '../../framework';
+
+/**
+ * bd-xfw2omlt: a `{{< video >}}` on a reveal slide produces a RawBlock
+ * `<iframe class="r-stretch">`. React injects raw HTML through a wrapper
+ * `<div dangerouslySetInnerHTML>`, so the iframe ends up at
+ * `section > div > iframe` — and reveal's stretch selector
+ * (`section > .r-stretch`, direct children only) misses it. RawBlock mirrors a
+ * root-level `r-stretch` onto its wrapper div so reveal stretches the wrapper
+ * (the iframe then fills it via quarto-reveal.css).
+ */
+
+const raw = (content: string): RawBlockType => ({ t: 'RawBlock', c: ['html', content] });
+
+function renderRaw(content: string) {
+    const args = { node: raw(content), setLocalAst: () => {} } as NodeArgs<RawBlockType>;
+    return render(<RawBlock {...args} />);
+}
+
+describe('RawBlock reveal stretch mirroring', () => {
+    it('mirrors r-stretch from a reveal video iframe onto the wrapper div', () => {
+        const { container } = renderRaw(
+            '<iframe class="r-stretch" data-external="1" src="https://www.youtube.com/embed/x"></iframe>',
+        );
+        const div = container.firstElementChild as HTMLElement;
+        expect(div.tagName).toBe('DIV');
+        expect(div.classList.contains('r-stretch')).toBe(true);
+        expect(div.querySelector('iframe')).not.toBeNull();
+    });
+
+    it('does not add r-stretch to the html (non-reveal) video wrapper', () => {
+        const { container } = renderRaw(
+            '<div class="quarto-video ratio ratio-16x9"><iframe src="https://www.youtube.com/embed/x"></iframe></div>',
+        );
+        const div = container.firstElementChild as HTMLElement;
+        expect(div.classList.contains('r-stretch')).toBe(false);
+    });
+
+    it('does not add r-stretch to plain raw html', () => {
+        const { container } = renderRaw('<p>hello</p>');
+        const div = container.firstElementChild as HTMLElement;
+        expect(div.classList.contains('r-stretch')).toBe(false);
+    });
+});

--- a/ts-packages/preview-renderer/src/q2-preview/blocks/RawBlock.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/blocks/RawBlock.tsx
@@ -11,7 +11,23 @@ import { PreviewContext } from '../PreviewContext';
  *
  * Sanitization is the user's responsibility — RawBlock means "trust
  * the author." The iframe sandbox limits the blast radius.
+ *
+ * Reveal stretch: React can only inject raw HTML through a wrapper element
+ * (`dangerouslySetInnerHTML`), so a stretched reveal video ends up at
+ * `section > div > iframe.r-stretch`. reveal's stretch selector
+ * (`section > .r-stretch`, direct children only) would miss it. When the raw
+ * HTML's root element carries `r-stretch`, we mirror that class onto the
+ * wrapper div so reveal stretches the wrapper; quarto-reveal.css then sizes the
+ * inner iframe to fill it. Inert outside reveal (the CSS rule is reveal-scoped).
+ * bd-xfw2omlt.
  */
+
+/** Does the first/root element of an HTML fragment carry the given class? */
+function rootHasClass(html: string, cls: string): boolean {
+    const m = html.match(/^\s*<[a-zA-Z][^>]*?\sclass\s*=\s*"([^"]*)"/);
+    return m != null && m[1].split(/\s+/).includes(cls);
+}
+
 export const RawBlock = ({ node }: NodeArgs<RawBlockType>) => {
     const ctx = useContext(PreviewContext);
     const poolId = (node as any).s as string | number | undefined;
@@ -21,7 +37,8 @@ export const RawBlock = ({ node }: NodeArgs<RawBlockType>) => {
 
     const [format, content] = node.c;
     if (format === 'html' || format === 'html5') {
-        return <div {...affordanceAttr} dangerouslySetInnerHTML={{ __html: content }} />;
+        const className = rootHasClass(content, 'r-stretch') ? 'r-stretch' : undefined;
+        return <div className={className} {...affordanceAttr} dangerouslySetInnerHTML={{ __html: content }} />;
     }
     return <pre {...affordanceAttr}>{content}</pre>;
 };


### PR DESCRIPTION
Fixes the `{{< video >}}` shortcode across `q2 render`, `q2 preview`, and hub-client. Strands **bd-5b21rbaq** (main) and **bd-xfw2omlt** (preview reveal sizing).

## Problems

1. **Preview/hub-client showed a plain link**, not an embedded player. The Lua `FORMAT` global received q2's preview *pseudo-format* (`q2-preview`/`q2-slides`), which Lua's `is_format("html:js")`/`is_format("revealjs")` don't recognize, so the format-gated video shortcode fell through to its `pandoc.Link` fallback.
2. **`q2 render` revealjs video rendered tiny** (~300×150) — a bare `<iframe>` with no sizing; reveal only sizes `section > iframe.r-stretch`.
3. **`q2 preview`/hub-client revealjs video was also tiny** — the SPA injects raw HTML via a wrapper `<div>` (`dangerouslySetInnerHTML`), so the iframe lands at `section > div > iframe.r-stretch` and reveal's direct-child stretch selector misses it.

## Fixes

- **Lua FORMAT normalization** (`format.rs`): `lua_format_for` (string) + `Format::lua_format` (Format-aware: identifier base + revealjs override) map preview pseudo-formats to the real format they emulate (`q2-preview`→`html`, `q2-slides`→`revealjs`; extension formats like `acm-pdf`→`pdf` preserved). Used by the shortcode pipeline (`pipeline.rs`) and the user-filter stage (`user_filters.rs`), so both Lua entry points see the real format in preview as in render.
- **revealjs sizing** (`video.lua`): adds `class="r-stretch"` to the reveal iframe, gated on auto-stretch enabled AND no explicit width/height (explicit sizing wins). The shortcode meta bridge (`shortcode_to_lua_args`) now forwards boolean/numeric metadata so `video.lua` can read `auto-stretch: false`.
- **preview sizing** (`RawBlock.tsx` + `quarto-reveal.css`): RawBlock mirrors a root-level `r-stretch` onto its wrapper `<div>` (reveal then stretches the wrapper); a `quarto-reveal.css` rule makes the iframe fill it. Inert in `q2 render` (no such wrapper there).

## Verification

- New tests: `video_shortcode_preview.rs`, `revealjs_features.rs` (default stretch + explicit-width / `auto-stretch:false` opt-outs), `format.rs` unit tests, `RawBlock.test.tsx`. Workspace **10,323 pass**; 456 unit + 484 integration preview-renderer tests pass; lint clean.
- Browser, real binaries: `q2 preview` embeds the iframe; `q2 render` revealjs sizes it 778×414; `q2 preview` revealjs 778×452; **live hub-client** (local `q2 hub` + `dev:fresh`) embeds + stretches the video on a revealjs slide (678×394).

## Notes

- Incidental: `crates/wasm-quarto-hub-client/Cargo.lock` synced `0.4.0`→`0.5.0` (was stale vs the released workspace version).
- Known reveal-scroll-mode caveat (flagged in bd-xfw2omlt): in reveal's *scroll view* (narrow/tall preview pane) the `r-stretch` wrapper collapses to height 0 — a general reveal-scroll trait of `r-stretch` (affects images too), not specific to this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)