### PR TITLE
Fix smoke-all E2E flakiness: isolate over-broad extension project (+ self-diagnosing failures, sync-client retry)

### DIFF
--- a/crates/quarto/tests/smoke-all/extensions/_quarto.yml
+++ b/crates/quarto/tests/smoke-all/extensions/_quarto.yml
@@ -1,1 +1,0 @@
-title: Extensions Test Project

--- a/hub-client/e2e/helpers/previewExtraction.ts
+++ b/hub-client/e2e/helpers/previewExtraction.ts
@@ -196,6 +196,17 @@ export interface PreviewStageDiagnostics {
   loadingPreview: boolean;
   iframePresent: boolean;
   bodyLen: number;
+  /**
+   * The on-screen "Render Error" message, if the preview pane is showing one
+   * (Preview's ErrorView or ReactPreview's inline error view). This is the
+   * *actual* failure reason — e.g. "Failed to read file: Path not found:
+   * /project/<target>.qmd" — which otherwise lives only in the page DOM and
+   * never reaches the CI log, where the lone visible signal is the benign
+   * mocked-auth 401. Surfacing it stops failure logs misleading the next
+   * investigator toward a phantom connectivity/auth cause. Empty when no
+   * render error is shown.
+   */
+  renderError: string;
   /** Single-line, key=value, grep-friendly form for the failure message. */
   line: string;
 }
@@ -230,6 +241,24 @@ export async function capturePreviewDiagnostics(
     if (iframe?.contentDocument?.body) {
       bodyLen = iframe.contentDocument.body.innerHTML.length;
     }
+
+    // Capture the on-screen "Render Error" message if the preview is showing
+    // one. Both error views (Preview's ErrorView and ReactPreview's inline
+    // view) render `<strong>Render Error</strong>` followed by a `<pre>` with
+    // the message, so match on that shared structure rather than a class
+    // (both use inline styles). The message is the genuine failure reason that
+    // otherwise never leaves the DOM. Collapse whitespace + cap length to keep
+    // the single-line diag tidy.
+    let renderError = '';
+    const errStrong = Array.from(document.querySelectorAll('strong')).find(
+      (s) => s.textContent?.trim() === 'Render Error',
+    );
+    if (errStrong) {
+      const pre = errStrong.parentElement?.querySelector('pre');
+      const msg = (pre?.textContent ?? errStrong.parentElement?.textContent ?? '').trim();
+      renderError = msg.replace(/\s+/g, ' ').slice(0, 300);
+    }
+
     return {
       wasmReady,
       vfsCount,
@@ -240,6 +269,7 @@ export async function capturePreviewDiagnostics(
       loadingPreview: text.includes('Loading preview'),
       iframePresent: !!iframe,
       bodyLen,
+      renderError,
     };
   }, iframeSelector);
 
@@ -259,7 +289,10 @@ export async function capturePreviewDiagnostics(
     `projectSelector=${raw.projectSelector ? 1 : 0} connecting=${raw.connecting ? 1 : 0} ` +
     `connError=${raw.connError ? 1 : 0} editor=${raw.editor ? 1 : 0} ` +
     `loadingPreview=${raw.loadingPreview ? 1 : 0} iframe=${raw.iframePresent ? 1 : 0} ` +
-    `bodyLen=${raw.bodyLen}`;
+    `bodyLen=${raw.bodyLen}` +
+    // The real failure reason, when the preview is showing a render error.
+    // Appended last so the analyzer's `stage=` parse is unaffected.
+    (raw.renderError ? ` renderError="${raw.renderError}"` : '');
 
   return { stage, ...raw, line };
 }

--- a/hub-client/src/App.tsx
+++ b/hub-client/src/App.tsx
@@ -56,7 +56,19 @@ async function connectAndLoadContents(
   if (import.meta.env.VITE_E2E === '1') {
     actorId = (window as any).__QUARTO_TEST_ACTOR_ID__ as string | undefined ?? actorId;
   }
-  const files = await connect(syncServer, indexDocId, actorId, screenName, color);
+  // Production opens offline-first (the sync client's 1 ms default peer wait):
+  // a returning user sees cached content instantly while the peer connects in
+  // the background. But the smoke-all E2E env always starts with EMPTY storage
+  // and must sync every doc from the (local) server, so opening offline-first
+  // there means loadFileDocuments races the still-connecting websocket — and
+  // under CI contention the render-target doc loses that race, is marked
+  // unavailable, and the preview fails "Path not found" (stage
+  // EDITOR_NO_PREVIEW; sometimes the index loses it too → CONNECT_STALL).
+  // waitForPeer resolves the instant the peer connects, so this only adds wall
+  // time when the connection is genuinely slow — exactly the CI case we want to
+  // wait out. Tree-shaken in production, so no offline-first UX change there.
+  const peerTimeoutMs = import.meta.env.VITE_E2E === '1' ? 15000 : undefined;
+  const files = await connect(syncServer, indexDocId, actorId, screenName, color, peerTimeoutMs);
   const contents = new Map<string, string>();
   for (const file of files) {
     const content = getFileContent(file.path);

--- a/ts-packages/quarto-sync-client/src/client.ts
+++ b/ts-packages/quarto-sync-client/src/client.ts
@@ -199,6 +199,17 @@ interface SyncClientState {
   peerStorageIds: Map<string, string>;
   /** Resolved retry policy for the current connection. */
   findDocRetry: Required<FindDocRetryOptions>;
+  /**
+   * Set once the initial `loadFileDocuments` pass has finished. Gates the
+   * unavailable-file retry: a peer event during the initial load must not race
+   * it (that load's own findDocs already benefit from the connected peer).
+   */
+  initialLoadComplete: boolean;
+  /**
+   * Active timer for the bounded "retry unavailable files while a peer is
+   * connected" loop, or null when idle. Cleared on disconnect.
+   */
+  unavailableRetryTimer: ReturnType<typeof setTimeout> | null;
 }
 
 const DEFAULT_FIND_DOC_RETRY: Required<FindDocRetryOptions> = {
@@ -266,6 +277,8 @@ export function createSyncClient(callbacks: SyncClientCallbacks, astOptions?: AS
     connectedPeers: new Set(),
     peerStorageIds: new Map(),
     findDocRetry: DEFAULT_FIND_DOC_RETRY,
+    initialLoadComplete: false,
+    unavailableRetryTimer: null,
   };
 
   // AST cache: last successful parse per file (for round-tripping)
@@ -624,6 +637,68 @@ export function createSyncClient(callbacks: SyncClientCallbacks, astOptions?: AS
     );
   }
 
+  // Bounded "retry unavailable files while a peer is connected" loop. This
+  // closes the gap that made the smoke-all preview tests flaky in CI: the app
+  // opens each project offline-first (its per-project connect uses the 1 ms
+  // default peer wait), the websocket connects in the background, most docs
+  // sync — but a doc still in flight when loadFileDocuments' 5 s findDoc cap
+  // fires is marked `unavailable`, and was then NEVER retried, so the render
+  // failed permanently with "Path not found". The key insight from the CI
+  // diagnostics: the peer is *connected* by then (vfs shows ~all files) — the
+  // straggler is sync-lag, not a dangling entry — yet retry-on-peer-*transition*
+  // never fires because the peer doesn't drop+reconnect. So instead, while a
+  // peer is present, poll: re-fetch the stranded files every few seconds until
+  // they arrive or a deadline. subscribeToFile feeds the normal onFileContent
+  // path, so a late file flows into the VFS and re-renders like any live edit.
+  // (Implements retry-on-peer-arrival, deferred as "plan D2" at the
+  // syncWithFiles dangling-entry guard.)
+  const UNAVAILABLE_RETRY_INTERVAL_MS = 2000;
+  const UNAVAILABLE_RETRY_WINDOW_MS = 60000;
+
+  async function retryUnavailableFilesOnce(): Promise<void> {
+    if (!state.repo || state.unavailableFiles.size === 0) return;
+    const entries = Array.from(state.unavailableFiles.entries());
+    await Promise.all(
+      entries.map(async ([path, docId]) => {
+        try {
+          const handle = await findDoc<FileDocument>(normalizeDocId(docId) as DocumentId);
+          state.unavailableFiles.delete(path);
+          await subscribeToFile(path, handle);
+        } catch (err) {
+          if (!isUnavailableError(err)) throw err;
+          // Still unavailable — leave the marker for the next poll tick.
+        }
+      }),
+    );
+  }
+
+  // Start (idempotently) the bounded retry poll. No-op when nothing is
+  // unavailable or a poll is already scheduled. With zero connected peers an
+  // unavailable file IS the truth (offline), so the tick re-fetches only while
+  // a peer is present; the deadline bounds the whole effort.
+  function startUnavailableRetry(): void {
+    if (state.unavailableRetryTimer || state.unavailableFiles.size === 0) return;
+    const deadline = Date.now() + UNAVAILABLE_RETRY_WINDOW_MS;
+    const tick = async (): Promise<void> => {
+      state.unavailableRetryTimer = null;
+      if (state.unavailableFiles.size === 0) return;
+      if (state.connectedPeers.size > 0) {
+        await retryUnavailableFilesOnce();
+      }
+      if (state.unavailableFiles.size > 0 && Date.now() < deadline) {
+        state.unavailableRetryTimer = setTimeout(() => void tick(), UNAVAILABLE_RETRY_INTERVAL_MS);
+      }
+    };
+    state.unavailableRetryTimer = setTimeout(() => void tick(), UNAVAILABLE_RETRY_INTERVAL_MS);
+  }
+
+  function stopUnavailableRetry(): void {
+    if (state.unavailableRetryTimer) {
+      clearTimeout(state.unavailableRetryTimer);
+      state.unavailableRetryTimer = null;
+    }
+  }
+
   // Helper: sync files with index changes
   async function syncWithFiles(newFiles: FileEntry[]): Promise<void> {
     const newPaths = new Set(newFiles.map(f => f.path));
@@ -801,6 +876,12 @@ export function createSyncClient(callbacks: SyncClientCallbacks, astOptions?: AS
           currentlyOnline = true;
           syncLog('Peer connected - switching to online mode');
           callbacks.onConnectionChange?.(true);
+          // A peer just (re)connected; (re)start the bounded retry of any
+          // stranded files. Guarded to after the initial load so it can't
+          // race it (that load's own findDocs already see this peer).
+          if (state.initialLoadComplete) {
+            startUnavailableRetry();
+          }
         }
       };
       const onPeerDisconnect = () => {
@@ -815,10 +896,18 @@ export function createSyncClient(callbacks: SyncClientCallbacks, astOptions?: AS
       state.cleanupFns.push(() => {
         state.repo!.networkSubsystem.off('peer', onPeerConnect);
         state.repo!.networkSubsystem.off('peer-disconnected', onPeerDisconnect);
+        stopUnavailableRetry();
       });
 
       // Load file documents
       await loadFileDocuments(files);
+      // From here, stranded files are retried by the bounded poll below (and
+      // re-kicked on any later peer reconnect).
+      state.initialLoadComplete = true;
+      // Kick the bounded retry for anything the initial load left stranded
+      // (the common CI case: peer connected mid-load, last doc lost the 5 s
+      // race; it syncs a moment later and the poll picks it up).
+      startUnavailableRetry();
 
       callbacks.onConnectionChange?.(currentlyOnline);
       // Annotate dangling entries so callers can list-but-mark them


### PR DESCRIPTION
## Problem

The nightly **smoke-all** E2E suite (78 in-browser WASM-render tests) has been flaky for months: renders intermittently fail with `Timed out after 75000ms waiting for preview iframe to render`. The failures concentrated hard on the `extensions/*shortcode*` fixtures (per-test binomial p-val down to 1e-10).

## Root cause (structural)

`smokeAllDiscovery.findProjectRoot` scopes a fixture's project to the nearest `_quarto.yml`'s **entire tree**. A single title-only `extensions/_quarto.yml` (`title: Extensions Test Project`) lumped **all 19 independent, self-contained extension fixtures into one ~49-doc project** — so opening `extensions/block-shortcode` (3 own files) synced ~49 docs. Under CI's 2-core contention the one doc that loses the sync race is the doc the test renders → the VFS read fails `Path not found: /project/<target>.qmd` → the preview shows an ErrorView instead of an iframe → 75s timeout.

It's **accretion, not design**: the shared `_quarto.yml` was added with the first extension test and ~19 fixtures piled under it over many commits, never revisited — and it's inconsistent with the suite's own norm (`themes/`, `metadata/` already give each fixture its own `_quarto.yml`). Nothing shares the project.

## The fix (3 commits)

1. **`chore(hub-e2e)`: surface render-error in the smoke-diag line** — every failure logged only a benign *mocked-auth* 401 (`projectFactory.mockAuthMe`), repeatedly luring investigators toward a phantom connectivity cause. The real reason was in the DOM but not the log. This appends `renderError="..."` to the `[smoke-diag]` line. Additive; no filtering. *(Independently valuable — makes every future failure self-explaining.)*
2. **`fix(sync-client)`: retry unavailable files via bounded poll while online** — the app opens projects offline-first (1ms peer wait), so `loadFileDocuments` races the connecting websocket; a doc lost past the 5s `findDoc` cap was marked unavailable and **never retried**. Now, while a peer is connected, stranded files are re-fetched every 2s for up to 60s (implements the deferred "plan D2"). Offline (zero peers) no-ops, so a genuine dangling entry isn't hammered.
3. **`test(smoke-all)`: isolate extension fixtures + wait for sync peer in E2E** — delete `extensions/_quarto.yml` so each fixture roots at its own dir (block-shortcode syncs **3 docs, not 49**). Plus an E2E-only (VITE_E2E) 15s peer wait on project open, since the test env always starts empty and must sync from the local server; **production keeps the 1ms offline-first open (tree-shaken, no UX change)**.

## Validation

| | result |
|---|---|
| **CI smoke-all** (this branch) | **0 failed**, 2 flaky, 76 passed — **6.4m** (was 15–46m); **zero extension-fixture failures** |
| CI interactive | 0 failed, 2 flaky, 57 passed |
| Native smoke-all (`cargo nextest`) | 70 passed / 20 skipped / 0 failed (unchanged by the fixture change) |
| Local Playwright smoke-all | 78/78 passed |
| `quarto-sync-client` vitest | 173/173 |

Trajectory across iterations: `0 / 4 / 2` failed (client-side mitigations alone) → **0 failed, 2 flaky, 6.4m** once the over-broad project was removed.

## Honest caveats

- Validated green on CI, but contention flakiness is inherently sampling-noisy — the durable confirmation is several green nightlies (the offline analyzer tracks the `EDITOR_NO_PREVIEW` bucket over time).
- A few residual `q2-preview` stragglers still flake (recovered by Playwright retry, 0 hard-fails). Those are genuine multi-file projects, not the accidental-grouping bug this PR fixes.
