### PR TITLE
fix(doctemplate): preserve line-ending convention in multiline directives

### DIFF
--- a/claude-notes/plans/2026-06-23-doctemplate-crlf-line-ending-preservation.md
+++ b/claude-notes/plans/2026-06-23-doctemplate-crlf-line-ending-preservation.md
@@ -1,0 +1,75 @@
+# doctemplate CRLF line-ending preservation (bd-1d3e / #157)
+
+## Policy decision
+
+**Preserve the input line-ending convention end-to-end.** CRLF input renders
+CRLF output; LF input renders LF output. No ingress normalization, no silent
+byte rewriting. (Chris, 2026-06-23. Matches Pandoc's parser-aware doctemplates;
+`--eol` writer override is a separate, future concern.)
+
+This sets precedent for pampa output, the JSON/native writers, and future
+tree-sitter grammars: line-ending conventions are preserved, not normalized.
+
+## Root cause
+
+`normalize_multiline_directives` (`crates/quarto-doctemplate/src/parser.rs`)
+detects a "directive on its own line" and swallows the surrounding newlines, to
+match Pandoc. Its three helper functions hardcode `'\n'`:
+
+- `first_node_is_newline_literal` / `is_first_child_newline_literal` — detection
+  via `lit.text.starts_with('\n')` (parser.rs:1093-1098).
+- `strip_leading_newline_from_node` — `starts_with('\n')` then `text[1..]`
+  strips a single byte (parser.rs:1115-1120).
+
+For CRLF input the body Literal starts with `\r\n`, so detection returns false,
+`is_multiline` stays false, and the newline-consumption branch never runs →
+doubled blank lines around every multiline `$if$` / `$for$` / `$else$`.
+
+The bug is in the engine and reproduces with in-memory `Template::compile` —
+**not** a file-read concern. (An earlier ingress-normalize attempt was reverted:
+it was the approach #157 explicitly rules out, and it masked this engine bug.)
+
+## Fix
+
+Make the three helpers treat `\r\n`, `\r`, and `\n` each as one leading
+line-ending unit:
+
+- detection: body's first Literal starts with any of `\n` / `\r\n` / `\r`.
+- strip: remove the full leading sequence (2 bytes for `\r\n`, else 1).
+
+Single chokepoint — all detection/stripping routes through these helpers — so
+both `$if$` and `$for$` (and nested/else) are fixed at once. CRLF bytes in the
+surrounding literals are preserved, so output keeps the input convention.
+
+## tree-sitter-doctemplate audit
+
+The buggy output already contained `\r\n` inside the body Literal, so the
+grammar tokenizes CRLF into literal text fine; the Rust pass alone should
+suffice. Confirm no grammar change is needed (no `\r`-specific tokenization gap).
+
+## Test fixtures
+
+`tests/pandoc-equiv/*.template` and `test-fixtures/*.template` are checked out
+CRLF on Windows (`core.autocrlf=true`). Their tests assert LF output. Pin these
+fixtures to LF via a scoped `.gitattributes` (`*.template eol=lf`) + renormalize,
+so they are LF on every platform and the existing LF assertions verify
+LF-preservation. The CRLF path is covered by new in-process tests.
+
+## Work items
+
+- [x] TDD: in-process CRLF regression tests — `Template::compile(crlf_source)`
+      for `$if$`, `$for$`, nested, `$else$`; assert CRLF-preserved output (no
+      doubled lines). Confirmed they FAILED on current engine (doubled `\r\n`).
+      Added `crlf_preservation` module in `src/parser.rs` (+ `lf_behavior_unchanged`).
+- [x] Fix the three helpers to be line-ending-agnostic via new
+      `leading_line_ending_len` (`\r\n`→2, `\r`/`\n`→1).
+- [x] New CRLF tests pass; `lf_behavior_unchanged` confirms LF path unchanged.
+- [x] Pin `.template` fixtures to LF via `crates/quarto-doctemplate/.gitattributes`
+      + renormalize (delete + checkout to apply `eol=lf`).
+- [x] The 8 originally-failing fixture tests pass; full crate suite 200/200.
+- [x] Audited `tree-sitter-doctemplate`: `text: /[^$]+/` captures CRLF verbatim,
+      so Rust-only fix is enough. No grammar change. (Only `\n`-specific rule is
+      `comment`, which chomps CRLF comment lines correctly; lone-CR comment
+      terminator is a no-consumer edge.)
+- [ ] Full workspace verification (Chris runs): `cargo nextest run --workspace`
+      + `cargo xtask verify --skip-hub-build`.

--- a/crates/quarto-doctemplate/.gitattributes
+++ b/crates/quarto-doctemplate/.gitattributes
@@ -1,0 +1,6 @@
+# Template test fixtures must stay LF on every platform so the line-ending
+# tests are deterministic regardless of core.autocrlf. The engine preserves
+# whatever convention the input uses (#157); the CRLF path is exercised by
+# in-process tests in src/parser.rs (crlf_preservation), not by these files.
+tests/pandoc-equiv/*.template text eol=lf
+test-fixtures/*.template text eol=lf

--- a/crates/quarto-doctemplate/src/parser.rs
+++ b/crates/quarto-doctemplate/src/parser.rs
@@ -1087,16 +1087,32 @@ fn is_first_child_newline_literal(branches: &[(VariableRef, Vec<TemplateNode>)])
     }
 }
 
-/// Check if the first node in a list is a Literal starting with '\n'.
+/// Length in bytes of the line ending a string begins with, if any.
+///
+/// Recognizes all three conventions (`\r\n`, `\n`, `\r`) like Pandoc's
+/// parser-aware doctemplates, so multiline-directive handling preserves the
+/// input convention instead of assuming LF. `\r\n` is checked first so the
+/// full two-byte sequence is consumed as a unit (#157).
+fn leading_line_ending_len(text: &str) -> Option<usize> {
+    if text.starts_with("\r\n") {
+        Some(2)
+    } else if text.starts_with(['\n', '\r']) {
+        Some(1)
+    } else {
+        None
+    }
+}
+
+/// Check if the first node in a list is a Literal starting with a line ending.
 fn first_node_is_newline_literal(nodes: &[TemplateNode]) -> bool {
     if let Some(TemplateNode::Literal(lit)) = nodes.first() {
-        lit.text.starts_with('\n')
+        leading_line_ending_len(&lit.text).is_some()
     } else {
         false
     }
 }
 
-/// Strip a leading '\n' from the first Literal node if present.
+/// Strip a leading line ending from the first Literal node if present.
 fn strip_leading_newline_from_nodes(nodes: &mut Vec<TemplateNode>) {
     if let Some(first) = nodes.first_mut() {
         strip_leading_newline_from_node(first);
@@ -1109,18 +1125,89 @@ fn strip_leading_newline_from_nodes(nodes: &mut Vec<TemplateNode>) {
     }
 }
 
-/// Strip a leading '\n' from a node if it's a Literal starting with '\n'.
+/// Strip a leading line ending (`\r\n`, `\n`, or `\r`) from a node if it's a
+/// Literal that starts with one. The full line-ending sequence is removed, so
+/// CRLF input keeps CRLF in the surrounding content.
 fn strip_leading_newline_from_node(node: &mut TemplateNode) {
     if let TemplateNode::Literal(lit) = node
-        && lit.text.starts_with('\n')
+        && let Some(len) = leading_line_ending_len(&lit.text)
     {
-        lit.text = lit.text[1..].to_string();
+        lit.text = lit.text[len..].to_string();
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// CRLF input must render with CRLF preserved and NO doubled blank lines
+    /// around multiline directives — matching how Pandoc's parser-aware
+    /// doctemplates preserves the input line-ending convention (#157, bd-1d3e).
+    /// These build the input in-process so the engine bug is caught on every
+    /// platform, not just on a Windows CRLF checkout.
+    mod crlf_preservation {
+        use super::*;
+        use crate::{TemplateContext, TemplateValue};
+
+        fn ctx() -> TemplateContext {
+            let mut ctx = TemplateContext::new();
+            ctx.insert("show", TemplateValue::Bool(true));
+            ctx.insert(
+                "items",
+                TemplateValue::List(vec![
+                    TemplateValue::String("one".to_string()),
+                    TemplateValue::String("two".to_string()),
+                    TemplateValue::String("three".to_string()),
+                ]),
+            );
+            ctx
+        }
+
+        #[test]
+        fn multiline_if_preserves_crlf() {
+            let src = "before\r\n$if(show)$\r\ncontent\r\n$endif$\r\nafter\r\n";
+            let template = Template::compile(src).unwrap();
+            assert_eq!(
+                template.render(&ctx()).unwrap(),
+                "before\r\ncontent\r\nafter\r\n"
+            );
+        }
+
+        #[test]
+        fn multiline_for_preserves_crlf() {
+            let src = "before\r\n$for(items)$\r\n- $it$\r\n$endfor$\r\nafter\r\n";
+            let template = Template::compile(src).unwrap();
+            assert_eq!(
+                template.render(&ctx()).unwrap(),
+                "before\r\n- one\r\n- two\r\n- three\r\nafter\r\n"
+            );
+        }
+
+        #[test]
+        fn nested_if_for_preserves_crlf() {
+            let src = "$if(items)$\r\nList:\r\n$for(items)$\r\n  - $it$\r\n$endfor$\r\n$endif$\r\n";
+            let template = Template::compile(src).unwrap();
+            assert_eq!(
+                template.render(&ctx()).unwrap(),
+                "List:\r\n  - one\r\n  - two\r\n  - three\r\n"
+            );
+        }
+
+        #[test]
+        fn else_branch_preserves_crlf() {
+            let src = "$if(show)$\r\nshown\r\n$else$\r\nhidden\r\n$endif$\r\n";
+            let template = Template::compile(src).unwrap();
+            assert_eq!(template.render(&ctx()).unwrap(), "shown\r\n");
+        }
+
+        #[test]
+        fn lf_behavior_unchanged() {
+            // The LF path must keep producing LF output (no regression).
+            let src = "before\n$if(show)$\ncontent\n$endif$\nafter\n";
+            let template = Template::compile(src).unwrap();
+            assert_eq!(template.render(&ctx()).unwrap(), "before\ncontent\nafter\n");
+        }
+    }
 
     #[test]
     fn test_parse_literal() {


### PR DESCRIPTION
On Windows with `core.autocrlf=true`, doctemplate templates with CRLF line
endings render an extra blank line around every multiline `$if$` / `$for$` /
`$else$` directive. It surfaced as 8 failing tests in `quarto-doctemplate`, but
the engine bug means any Windows author of a Quarto template gets visibly wrong
output in every format the doctemplate engine drives. There is no Windows CI
yet, so it never showed up in `cargo nextest run` for the rest of the team.

## Root Cause

`normalize_multiline_directives` reproduces Pandoc's behavior of swallowing the
newlines around a directive that sits on its own line. Its detection and
stripping helpers hardcoded `'\n'` (`first_node_is_newline_literal`,
`strip_leading_newline_from_node`). With CRLF input the directive's body literal
starts with `\r\n`, so `starts_with('\n')` returns false, the directive is never
treated as multiline, and the newline-consumption branch never runs — leaving
the doubled blank line.

The bug is in the engine and reproduces with in-memory `Template::compile`; it
is not a file-read concern. An earlier attempt that normalized CRLF→LF at file
ingestion was discarded: it papered over this engine bug and is the approach
#157 explicitly rules out.

## Decision: preserve the input convention

CRLF input now renders CRLF output, LF renders LF — the input line-ending
convention is preserved end-to-end, matching Pandoc's parser-aware
`doctemplates`, whose endline parser accepts all three conventions.

Two alternatives were rejected:

- Ingress-normalize CRLF→LF before parsing — silently rewrites bytes and shifts
  every source offset by one per preceding `\r`, which drifts diagnostics.
- Always emit LF — diverges from the rest of a Windows author's file, and still
  needs the engine fix anyway since the bug fires in-memory.

This sets the precedent for the other writers (pampa output, JSON/native) and
future grammars: conventions are preserved, not normalized. A writer-side
`--eol` override, like Pandoc's, stays a separate future concern.

## Fix

Detection and stripping now recognize `\r\n`, `\r`, and `\n` each as one
line-ending unit (new `leading_line_ending_len`), so the full sequence is
consumed and the surrounding CRLF content is left intact. Source bytes and
offsets are untouched.

The `.template` test fixtures are pinned to LF via `.gitattributes` so the
LF-asserting fixture tests stay deterministic regardless of `core.autocrlf`; the
CRLF path is covered by new in-process tests that build the input in source, so
Linux CI catches future regressions (same pattern as #139 for tree-sitter-qmd
pipe tables).

The `tree-sitter-doctemplate` grammar needs no change: its `text` token
(`/[^$]+/`) already captures CRLF verbatim, so `\r\n` reaches the Rust
normalization pass intact.

## Test Plan

- [ ] `cargo nextest run -p quarto-doctemplate` — 200/200, including new `crlf_preservation` tests
- [ ] CRLF template renders CRLF output with no doubled blank lines
- [ ] LF template output unchanged
- [ ] `cargo xtask verify --skip-hub-build`

Fixes #157
