### PR TITLE
source-map: map the exclusive end of a Concat range

### DIFF
--- a/crates/quarto-source-map/src/mapping.rs
+++ b/crates/quarto-source-map/src/mapping.rs
@@ -63,6 +63,13 @@ impl SourceInfo {
                         return piece.source_info.map_offset(offset_in_piece, ctx);
                     }
                 }
+                // Exclusive end: `offset == total` matches no piece above; map it to
+                // the end of the last piece (like Original/Substring's map_offset(length)).
+                if let Some(last) = pieces.last()
+                    && offset == last.offset_in_concat + last.length
+                {
+                    return last.source_info.map_offset(last.length, ctx);
+                }
                 None // Offset not found in any piece
             }
             SourceInfo::Generated { .. } => {
@@ -212,6 +219,18 @@ mod tests {
         let mapped = concat.map_offset(4, &ctx).unwrap();
         assert_eq!(mapped.file_id, file_id2);
         assert_eq!(mapped.location.offset, 1);
+
+        // Exclusive end (offset 6 == total): maps to end of last piece
+        let mapped = concat.map_offset(6, &ctx).unwrap();
+        assert_eq!(mapped.file_id, file_id2);
+        assert_eq!(mapped.location.offset, 3);
+
+        // map_range over the whole concat: exclusive end must resolve
+        let (start, end) = concat.map_range(0, 6, &ctx).unwrap();
+        assert_eq!(start.file_id, file_id1);
+        assert_eq!(start.location.offset, 0);
+        assert_eq!(end.file_id, file_id2);
+        assert_eq!(end.location.offset, 3);
     }
 
     #[test]


### PR DESCRIPTION
Selecting certain inlines in the source editor failed to highlight the corresponding range in the preview. The clearest repro is a bare URL in prose — selecting `https://www.automerge.org` highlights nothing in the preview, while the words around it select fine.

**Root cause.** `SourceInfo::map_offset` on a `Concat` located the offset with a half-open per-piece test (`offset >= piece_start && offset < piece_end`). The *exclusive* end of the whole concat — `offset == total length` — satisfies no piece (the last piece's `piece_end` equals the total), so it returned `None`. Because `map_range(start, end)` returns `None` if *either* endpoint is unmapped, `map_range(0, length)` over a `Concat`-backed node failed entirely, leaving the preview with no range to highlight.

A `Concat` lands on an inline when tree-sitter splits one text run into multiple tokens that are then coalesced back — typically a token containing markup-adjacent punctuation (`:` `/` `.` `_` `+`). A bare URL is the canonical case: `https://www.automerge.org` becomes one `Str` with a length-25 `Concat`, and selecting it requests `map_range(0, 25)` → `map_offset(25)` hit the miss. Neighbouring plain words are single `Original` ranges, which is why the bug looked intermittent.

**How to trigger.** In `html`, with a document containing:

```qmd
See https://www.automerge.org for details.
```

select the URL in the source pane → before this change nothing highlights in the preview; after, the URL's range highlights as expected.

**Fix.** Map `offset == total` to the end of the last piece (`last.map_offset(last.length)`), mirroring `Original`/`Substring`, where `map_offset(length)` has always been a valid exclusive end. Callers that carried `.or_else(|| map_offset(length - 1))` workarounds stop firing on this path and now get an exact end; they're **kept** — they still guard over-running ranges, so this isn't a cleanup of them. The callers with *no* fallback — `map_range` and `quarto-yaml-validation`'s `extract_source_range` — previously failed outright and are the real beneficiaries.
