### PR TITLE
feat(hub-client): full-text search — Phase 1 (open-project, client-side)

### DIFF
--- a/claude-notes/plans/2026-06-23-hub-client-full-text-search.md
+++ b/claude-notes/plans/2026-06-23-hub-client-full-text-search.md
@@ -1,6 +1,7 @@
 # Hub-client full-text search
 
-**Status:** design / assessment — not yet started
+**Status:** Phase 1 complete (open-project client-side search shipped on
+`epic/hub-client-full-text-search`); Phase B + Phase 2 not started.
 **Date:** 2026-06-23
 **Scope decision (from user):** open-project search first; then cross-project
 ("all my projects"), which should ride on the upcoming server-side

--- a/claude-notes/plans/2026-06-23-hub-client-full-text-search.md
+++ b/claude-notes/plans/2026-06-23-hub-client-full-text-search.md
@@ -266,9 +266,15 @@ under vitest, and the production build must pass
       `buildSnippet(content, terms)` helper rendering `<mark>` segments;
       kept out of the provider (which need not store full text).
       `snippet.{ts,test.ts}` (8 tests).
-- [ ] 1.7 End-to-end check in a real browser session against a running hub
-      (per CLAUDE.md end-to-end-verification rule); record the invocation +
-      observed result here.
+- [x] 1.7 End-to-end check in a real browser session against a running hub.
+      → `hub-client/e2e/search.spec.ts`, run via
+      `VITE_E2E=1 npm run build && npx playwright test search.spec.ts`. Drives
+      the **full Automerge sync pipeline**: a 4-file project created on the real
+      Rust hub (`cargo run --bin hub`), synced into the browser, then the
+      sidebar search box exercised. Observed (1 passed, 16.2s): query
+      `regression` → exactly one result `methods.qmd`; snippet `<mark>`
+      highlighted "regression"; clicking the result opened the file (preview
+      rendered "logistic regression"); clearing restored all 4 files.
 - [ ] 1.8 `hub-client/changelog.md` entry (two-commit workflow per CLAUDE.md).
 
 ### Phase B — relevance enrichment (after measuring parse cost)

--- a/claude-notes/plans/2026-06-23-hub-client-full-text-search.md
+++ b/claude-notes/plans/2026-06-23-hub-client-full-text-search.md
@@ -251,11 +251,21 @@ under vitest, and the production build must pass
       MiniSearch over `text` + `path` fields; incremental
       add/replace/discard/removeAll; prefix + fuzzy(0.2) + path boost. All 18
       green; typecheck clean.
-- [ ] 1.4 Wire indexing into `setSyncHandlers` (`App.tsx:435-465`): bulk index
-      on project open, `addOrUpdate`/`remove`/`clear` on change.
-- [ ] 1.5 Search UI in `FileSidebar.tsx`: query box, result list, select →
-      `onSelectFile`.
-- [ ] 1.6 Snippet/highlight rendering for matches (raw-text offsets).
+- [x] 1.4 Wire indexing into the project. **Refinement:** instead of hooking
+      raw `setSyncHandlers` callbacks, the index is maintained by a
+      `useProjectSearch(files, fileContents)` hook (in `Editor.tsx`) that
+      reconciles the index against React state — a file is indexed iff it is in
+      both `files` (authoritative membership) and `fileContents` (text). This
+      reflects adds/edits/deletes/project-switches for free with no risk of
+      drift from what the user sees. `useProjectSearch.{ts,test.tsx}` (6 tests).
+- [x] 1.5 Search UI in `FileSidebar.tsx`: debounced query box (120ms), ranked
+      result list, clear button, select → `onSelectFile`. `searchFiles` +
+      `fileContents` props threaded from `Editor`. `FileSidebar.search.test.tsx`
+      (5 tests).
+- [x] 1.6 Snippet/highlight rendering for matches (raw-text offsets) via a pure
+      `buildSnippet(content, terms)` helper rendering `<mark>` segments;
+      kept out of the provider (which need not store full text).
+      `snippet.{ts,test.ts}` (8 tests).
 - [ ] 1.7 End-to-end check in a real browser session against a running hub
       (per CLAUDE.md end-to-end-verification rule); record the invocation +
       observed result here.

--- a/claude-notes/plans/2026-06-23-hub-client-full-text-search.md
+++ b/claude-notes/plans/2026-06-23-hub-client-full-text-search.md
@@ -1,0 +1,275 @@
+# Hub-client full-text search
+
+**Status:** design / assessment — not yet started
+**Date:** 2026-06-23
+**Scope decision (from user):** open-project search first; then cross-project
+("all my projects"), which should ride on the upcoming server-side
+"project sets" work (logged-in-user → automerge-document-of-project-sets).
+
+## Overview
+
+Add full-text search to the Quarto Hub web client (and therefore
+quarto-hub.com). The goal is to let a user find content across the files of
+the project they have open, and — later — across the set of projects they own.
+
+This plan records the full design space (four approaches), then commits to a
+phased design that:
+
+1. works against the **currently open project**, entirely client-side, with no
+   server changes;
+2. is structured behind a `SearchProvider` interface so it can later iterate
+   against **a set of projects**, where the project set is itself an Automerge
+   document reached through a single indirection from the logged-in user;
+3. lets the eventual cross-project backend be a **swap of the provider
+   implementation**, not a UI rewrite.
+
+## Background: what the current architecture gives us
+
+(Findings from three exploration passes on 2026-06-23 — data model, hub server,
+WASM parsing.)
+
+### The client already holds all the text
+On project open, `connectAndLoadContents` (`hub-client/src/App.tsx:47`) walks
+the index document and loads every file's content into an in-memory
+`Map<path, string>` held in React state (`fileContents`,
+`hub-client/src/App.tsx:98`). The map is kept live by sync handlers registered
+via `setSyncHandlers(...)` (`hub-client/src/App.tsx:435-465`):
+
+- `onFileContent(path, content, _patches)` fires on **every CRDT change** and
+  updates the map (`App.tsx:443-450`).
+- `onFilesChange(newFiles)` fires on add/remove (`App.tsx:437-439`).
+- Project switch / disconnect resets the map to empty
+  (`App.tsx:231, 404, 496`).
+
+So a client-side index has its corpus **already loaded** and an **incremental
+update stream already wired**. The same handler seam is where indexing hooks in.
+
+The underlying callbacks live in `ts-packages/preview-runtime/src/automergeSync.ts`
+(passthrough) and `ts-packages/quarto-sync-client/src/client.ts`
+(`onFileAdded` / `onFileChanged` / `onFileUnavailable` / `onFilesChange`,
+plus `getFileContent(path)` at `client.ts:1069`).
+
+### Data model: three tiers of Automerge documents
+(`ts-packages/quarto-automerge-schema/src/index.ts`)
+
+- **ProjectSetDocument** (per user) — `projects: Record<indexDocId, ProjectSetEntry>`,
+  synced per-browser today; cached in IndexedDB. *This is the indirection the
+  user referenced* — logged-in user → an Automerge doc listing their projects.
+- **IndexDocument** (per project) — `files: Record<path, docId>` plus
+  `identities`, `captures`. One per project.
+- **File documents** (per file) — `TextDocumentContent { text }` or
+  `BinaryDocumentContent { content, mimeType, hash }`.
+
+### The server is a deliberately dumb sync relay
+(`crates/quarto-hub/`, via the `samod` fork)
+
+- Pure CRDT sync relay; **never decodes document text** in standalone mode
+  (the mode quarto-hub.com runs).
+- No database, no query layer, no inverted index.
+- Only metadata: the `path → docId` index document.
+- Access policy is `AuditAccessPolicy::should_allow → always true` — logs but
+  does not gate per document. There is **no per-document access-control model
+  to build on** today.
+- *Project mode* (local `quarto hub --project`) does materialize text to disk
+  in `sync.rs`, but quarto-hub.com is *standalone* mode and does not.
+
+Implication: any server-side search is a **new architectural surface**, not an
+extension of something present.
+
+### Rich text/structure extraction exists — in Rust/WASM, not JS
+(`crates/wasm-quarto-hub-client/`, `crates/quarto-core/`, `crates/pampa/`)
+
+- `DocumentProfile` (`crates/quarto-core/src/document_profile.rs`): title,
+  subtitle, description, authors, keywords, categories, **outline/headings**
+  (`Vec<TocEntry>`). Already computed for the sidebar.
+- Plaintext writer (`crates/pampa/src/writers/plaintext.rs`) and
+  `as_plain_text()` (`crates/quarto-pandoc-types/src/config_value.rs`).
+- `lsp_get_symbols()` WASM export → structured outline.
+- The WASM module is already called per-keystroke for the active document.
+
+But: **no JS-side search library or tokenizer/stemmer anywhere** (verified
+absent from `hub-client/package.json`). And batch-parsing *every* file (vs.
+just the active one) is currently **unmeasured**.
+
+## The four approaches
+
+### A. Client-side in-memory index — *the Phase 1 foundation*
+Build an inverted index in the browser over the already-loaded `fileContents`,
+using a small library (MiniSearch / FlexSearch / Orama). Update incrementally
+from `onFileContent` / `onFilesChange`.
+
+- **Pros:** zero server changes; offline-first (matches existing design);
+  inherits the auth boundary for free (you can only index what you can already
+  sync); incremental updates nearly free; ships in `hub-client` (+ maybe
+  `quarto-sync-client`).
+- **Cons:** bounded by browser memory; each client rebuilds its own index;
+  cold build on project open (but content is loaded then anyway); no
+  cross-project search.
+
+### B. Client-side, WASM-enriched (A + relevance)
+Same index, but index **plaintext** (markdown/code stripped via the WASM
+plaintext writer) and **boost on `DocumentProfile` fields** — title, headings,
+keywords. Searching prose-not-syntax and weighting headings is the difference
+between "find" and "find the right thing."
+
+- **Cons:** must parse every file, not just the active one; parse cost at
+  project scale is **unmeasured**. Mitigate: index raw text immediately, enrich
+  lazily / during idle time.
+
+### C. Server-side index (tantivy / Meilisearch) — *the Phase 2 backend*
+Server materializes text and maintains an index; client queries `/search`.
+Required for cross-project/global search or projects too big for the browser.
+
+- **Cost:** standalone server must decode CRDT content (it doesn't today),
+  gain persistence, **and gain a real per-user / per-project access model**.
+- **Key insight:** those last two costs are exactly what the upcoming
+  server-side **project-sets** work has to pay anyway. Cross-project search
+  should ride along with that work, not justify the infrastructure on its own.
+
+### D. Published-site search (Pagefind / Quarto-1-style static index)
+A *different* feature: search on rendered/published sites for end readers,
+emitted as a build-time static index by the render pipeline. Out of scope for
+this plan (it is not a feature of the editing client). Recorded here only to
+disambiguate "search on quarto-hub.com."
+
+## Chosen design
+
+**Phase 1 = Approach A, structured so B and C slot in without UI changes.**
+
+The hinge is a single abstraction:
+
+```ts
+interface SearchProvider {
+  // Lifecycle / corpus maintenance
+  addOrUpdate(path: string, text: string): void;
+  remove(path: string): void;
+  clear(): void;                       // project switch / disconnect
+  // Query
+  search(query: string, opts?: SearchOptions): Promise<SearchResult[]>;
+}
+
+interface SearchResult {
+  path: string;
+  score: number;
+  // optional, populated when available:
+  title?: string;        // from DocumentProfile (Phase B)
+  snippets?: Snippet[];  // match context with offsets for highlighting
+  // Phase 2 forward-compat:
+  projectId?: string;    // indexDocId; undefined ⇒ current project
+}
+```
+
+- **Phase 1** implements `SearchProvider` in-memory, fed by the existing sync
+  handlers. The corpus is the open project; `projectId` is left undefined.
+- **Phase 2** swaps in a provider that queries a server `/search` endpoint and
+  returns results spanning multiple `projectId`s. The corpus source is no
+  longer "everything in browser memory."
+- The **UI never assumes the corpus is fully in browser memory** — that single
+  rule is what makes Phase 2 a backend swap.
+
+### Where it plugs in
+- Indexing hook: the `setSyncHandlers({ onFileContent, onFilesChange })` block
+  at `hub-client/src/App.tsx:435-465`. `onFileContent` → `addOrUpdate`;
+  removals (derived from `onFilesChange` diffs) → `remove`; project switch →
+  `clear`.
+- Search UI: `hub-client/src/components/FileSidebar.tsx` (already builds its
+  tree from the same `FileEntry[]`; `FileSidebarProps` at line 22). A search box
+  filters/sorts results; selecting a result calls the existing
+  `onSelectFile`.
+- Initial bulk index: after `connectAndLoadContents` resolves, feed every
+  entry of the returned `contents` map into the provider.
+
+### Phase 2 forward-compatibility (cross-project)
+The user's stated direction: iterate against a **set of projects**, where some
+project sets become **server-managed via a single indirection**
+(logged-in-user → Automerge-document-of-project-sets). Today's
+`ProjectSetDocument` is exactly that document, but per-browser-synced.
+
+Design notes for the eventual Phase 2 (NOT built now):
+- Do **not** scale Phase 1 by loading every file of every project into the
+  browser — that does not scale and the per-browser project-set doc is not an
+  authoritative ownership record.
+- When the server gains an authoritative project-set (the logged-in-user →
+  project-set-doc indirection), that is the natural and only sensible home for
+  a cross-project index: it can materialize text per project and index it,
+  gated by the **same ownership model project-sets must already define**.
+- Cross-project search therefore becomes a strand **blocked on / discovered
+  from** the server-side project-sets epic, implemented as a `SearchProvider`
+  that calls `/search`.
+
+## Open questions / risks
+
+- **Batch-parse cost (Phase B):** parsing every file via WASM is unmeasured.
+  Measure on a realistic multi-file project before committing to enrichment.
+  Per-doc parse is keystroke-fast; N-file batch is the unknown.
+- **Index library choice:** MiniSearch (small, simple, good fuzzy/prefix) vs.
+  FlexSearch (fastest, larger API) vs. Orama (typed, plugin tokenizers).
+  Decide in Phase 1.1 with a bundle-size + relevance spike.
+- **Snippet/highlighting:** raw-text offsets are easy; mapping back to rendered
+  preview positions is harder and may be deferred.
+- **Binary files:** excluded from the text index (only `TextDocumentContent`).
+- **Dangling/unavailable files** (`onFileUnavailable`): simply absent from the
+  index until their content arrives; `addOrUpdate` on later sync covers it.
+
+## Test plan (TDD — write first, per CLAUDE.md)
+
+Phase 1 is JS/TS in `hub-client` + possibly `quarto-sync-client`; tests run
+under vitest, and the production build must pass
+(`cd hub-client && npm run build:all`).
+
+1. **Provider unit tests** (`SearchProvider` in-memory impl):
+   - `addOrUpdate` then `search` returns the doc; ranking by term frequency.
+   - `remove` drops a doc from results.
+   - `clear` empties the index.
+   - Re-`addOrUpdate` of an existing path replaces, not duplicates.
+   - Prefix / partial-term match behavior (lib-dependent — pin expectations).
+   - Empty query / whitespace query returns empty (or all, by decision).
+2. **Sync-handler integration test:** simulate `onFileContent` /
+   `onFilesChange` sequences; assert the index reflects the live corpus.
+3. **UI test** (FileSidebar search box): typing filters results; selecting a
+   result fires `onSelectFile` with the right `FileEntry`.
+4. **Forward-compat test:** results carry `projectId === undefined` in Phase 1;
+   the result-rendering code does not assume a single project (so Phase 2's
+   multi-project results render without change).
+
+## Work items
+
+### Phase 1 — open-project, client-side
+- [ ] 1.1 Spike: pick search library (MiniSearch / FlexSearch / Orama) —
+      bundle size + relevance + fuzzy/prefix support. Record decision here.
+- [ ] 1.2 Write provider unit tests (failing) for the `SearchProvider`
+      interface.
+- [ ] 1.3 Implement in-memory `SearchProvider` (raw text) to green the tests.
+- [ ] 1.4 Wire indexing into `setSyncHandlers` (`App.tsx:435-465`): bulk index
+      on project open, `addOrUpdate`/`remove`/`clear` on change.
+- [ ] 1.5 Search UI in `FileSidebar.tsx`: query box, result list, select →
+      `onSelectFile`.
+- [ ] 1.6 Snippet/highlight rendering for matches (raw-text offsets).
+- [ ] 1.7 End-to-end check in a real browser session against a running hub
+      (per CLAUDE.md end-to-end-verification rule); record the invocation +
+      observed result here.
+- [ ] 1.8 `hub-client/changelog.md` entry (two-commit workflow per CLAUDE.md).
+
+### Phase B — relevance enrichment (after measuring parse cost)
+- [ ] B.1 Measure batch WASM-parse cost on a realistic N-file project.
+- [ ] B.2 If acceptable: index plaintext (WASM plaintext writer) instead of /
+      alongside raw text; lazy/idle enrichment.
+- [ ] B.3 Boost `DocumentProfile` fields (title, headings, keywords) in
+      ranking; surface title in `SearchResult`.
+
+### Phase 2 — cross-project (rides on server-side project sets)
+- [ ] 2.1 (blocked on the server-side project-sets epic) Design `/search`
+      endpoint + server index (tantivy/Meilisearch), gated by the project-set
+      ownership model.
+- [ ] 2.2 Implement a server-backed `SearchProvider`; results span
+      `projectId`s. No UI rewrite.
+
+## References
+- Data model: `ts-packages/quarto-automerge-schema/src/index.ts`
+- Sync client: `ts-packages/quarto-sync-client/src/client.ts`
+- Runtime bridge: `ts-packages/preview-runtime/src/automergeSync.ts`
+- Indexing seam: `hub-client/src/App.tsx:435-465` (sync handlers)
+- UI seam: `hub-client/src/components/FileSidebar.tsx`
+- Hub server: `crates/quarto-hub/src/{server,sync,index,access_policy}.rs`
+- Extraction: `crates/quarto-core/src/document_profile.rs`,
+  `crates/pampa/src/writers/plaintext.rs`

--- a/claude-notes/plans/2026-06-23-hub-client-full-text-search.md
+++ b/claude-notes/plans/2026-06-23-hub-client-full-text-search.md
@@ -202,9 +202,14 @@ Design notes for the eventual Phase 2 (NOT built now):
 - **Batch-parse cost (Phase B):** parsing every file via WASM is unmeasured.
   Measure on a realistic multi-file project before committing to enrichment.
   Per-doc parse is keystroke-fast; N-file batch is the unknown.
-- **Index library choice:** MiniSearch (small, simple, good fuzzy/prefix) vs.
-  FlexSearch (fastest, larger API) vs. Orama (typed, plugin tokenizers).
-  Decide in Phase 1.1 with a bundle-size + relevance spike.
+- **Index library choice:** RESOLVED 2026-06-23 → **MiniSearch** (v7, MIT).
+  Rationale: first-class incremental `add`/`replace`/`discard`/`vacuum` maps
+  directly onto our `onFileContent`/`onFilesChange` event stream; per-field
+  `boost` + `boostDocument` covers Phase B title/heading weighting; prefix +
+  fuzzy built in; ~7KB gzip; excellent TS types. FlexSearch's raw-throughput
+  edge buys nothing at one-project corpus scale while costing removal/TS
+  ergonomics; Orama is heavier than Phase 1 needs (its stemming is replicable
+  via MiniSearch `processTerm` in Phase B).
 - **Snippet/highlighting:** raw-text offsets are easy; mapping back to rendered
   preview positions is harder and may be deferred.
 - **Binary files:** excluded from the text index (only `TextDocumentContent`).
@@ -235,8 +240,9 @@ under vitest, and the production build must pass
 ## Work items
 
 ### Phase 1 — open-project, client-side
-- [ ] 1.1 Spike: pick search library (MiniSearch / FlexSearch / Orama) —
-      bundle size + relevance + fuzzy/prefix support. Record decision here.
+- [x] 1.1 Spike: pick search library (MiniSearch / FlexSearch / Orama) —
+      bundle size + relevance + fuzzy/prefix support. **Decision: MiniSearch
+      v7** (see Open questions for rationale).
 - [ ] 1.2 Write provider unit tests (failing) for the `SearchProvider`
       interface.
 - [ ] 1.3 Implement in-memory `SearchProvider` (raw text) to green the tests.

--- a/claude-notes/plans/2026-06-23-hub-client-full-text-search.md
+++ b/claude-notes/plans/2026-06-23-hub-client-full-text-search.md
@@ -243,9 +243,14 @@ under vitest, and the production build must pass
 - [x] 1.1 Spike: pick search library (MiniSearch / FlexSearch / Orama) —
       bundle size + relevance + fuzzy/prefix support. **Decision: MiniSearch
       v7** (see Open questions for rationale).
-- [ ] 1.2 Write provider unit tests (failing) for the `SearchProvider`
-      interface.
-- [ ] 1.3 Implement in-memory `SearchProvider` (raw text) to green the tests.
+- [x] 1.2 Write provider unit tests (failing) for the `SearchProvider`
+      interface. → `hub-client/src/services/search/inMemorySearchProvider.test.ts`
+      (18 tests; verified failing before impl).
+- [x] 1.3 Implement in-memory `SearchProvider` (raw text) to green the tests.
+      → `hub-client/src/services/search/{types,inMemorySearchProvider,index}.ts`.
+      MiniSearch over `text` + `path` fields; incremental
+      add/replace/discard/removeAll; prefix + fuzzy(0.2) + path boost. All 18
+      green; typecheck clean.
 - [ ] 1.4 Wire indexing into `setSyncHandlers` (`App.tsx:435-465`): bulk index
       on project open, `addOrUpdate`/`remove`/`clear` on change.
 - [ ] 1.5 Search UI in `FileSidebar.tsx`: query box, result list, select →

--- a/claude-notes/plans/2026-06-23-hub-client-full-text-search.md
+++ b/claude-notes/plans/2026-06-23-hub-client-full-text-search.md
@@ -275,7 +275,7 @@ under vitest, and the production build must pass
       `regression` → exactly one result `methods.qmd`; snippet `<mark>`
       highlighted "regression"; clicking the result opened the file (preview
       rendered "logistic regression"); clearing restored all 4 files.
-- [ ] 1.8 `hub-client/changelog.md` entry (two-commit workflow per CLAUDE.md).
+- [x] 1.8 `hub-client/changelog.md` entry (two-commit workflow per CLAUDE.md). → 2026-06-23 entry referencing 9a48dd86.
 
 ### Phase B — relevance enrichment (after measuring parse cost)
 - [ ] B.1 Measure batch WASM-parse cost on a realistic N-file project.

--- a/hub-client/changelog.md
+++ b/hub-client/changelog.md
@@ -15,6 +15,10 @@ be in reverse chronological order (latest first).
 
 -->
 
+### 2026-06-23
+
+- [`9a48dd86`](https://github.com/quarto-dev/q2/commits/9a48dd86): Added full-text search to the file sidebar — type in the search box to find files in the open project by content (with highlighted match snippets) and click a result to open it.
+
 ### 2026-06-22
 
 - [`f4e2c25e`](https://github.com/quarto-dev/q2/commits/f4e2c25e): Slide and AST previews now restyle live when a sibling config file changes — editing `_brand.yml` (or `_quarto.yml`) in another window recompiles the deck's theme without a page reload, matching the HTML preview.

--- a/hub-client/e2e/search.spec.ts
+++ b/hub-client/e2e/search.spec.ts
@@ -1,0 +1,80 @@
+/**
+ * End-to-end test for Phase 1 full-text search: a project with several files
+ * is loaded through the real Automerge sync pipeline, then the FileSidebar
+ * search box is exercised in the browser.
+ */
+
+import { test, expect } from '@playwright/test';
+import {
+  bootstrapProjectSet,
+  createProjectOnServer,
+  seedProjectInBrowser,
+  getServerUrl,
+} from './helpers/projectFactory';
+
+test.describe('Full-text search', () => {
+  test('finds files by content and opens the selected result', async ({ page }) => {
+    const serverUrl = getServerUrl();
+
+    const indexDocId = await createProjectOnServer(serverUrl, [
+      {
+        path: '_quarto.yml',
+        content: 'project:\n  type: default\n',
+        contentType: 'text',
+      },
+      {
+        path: 'index.qmd',
+        content: ['---', 'title: Home', '---', '', 'Welcome to the project homepage.'].join('\n'),
+        contentType: 'text',
+      },
+      {
+        path: 'methods.qmd',
+        content: [
+          '---',
+          'title: Methods',
+          '---',
+          '',
+          'We fit a logistic regression model to the survey data.',
+        ].join('\n'),
+        contentType: 'text',
+      },
+      {
+        path: 'notes.qmd',
+        content: ['---', 'title: Notes', '---', '', 'Buy groceries and water the plants.'].join('\n'),
+        contentType: 'text',
+      },
+    ]);
+
+    await bootstrapProjectSet(page, serverUrl);
+    const localId = await seedProjectInBrowser(page, indexDocId, serverUrl);
+    await page.goto(`/#/p/${localId}/file/index.qmd`);
+
+    // Wait for the project to load (preview renders the home page).
+    const previewFrame = page.frameLocator('iframe.preview-active');
+    await expect(previewFrame.locator('body')).toContainText('homepage', { timeout: 30000 });
+
+    const searchBox = page.getByLabel('Search files');
+    await expect(searchBox).toBeVisible();
+
+    // Query a term unique to methods.qmd.
+    await searchBox.fill('regression');
+
+    // The matching file appears; non-matching files do not.
+    const results = page.locator('.search-result');
+    await expect(results).toHaveCount(1);
+    await expect(page.locator('.search-result-name')).toHaveText('methods.qmd');
+    // The snippet highlights the matched term.
+    await expect(page.locator('.search-result-snippet mark')).toContainText('regression');
+
+    // Selecting the result opens that file in the preview.
+    await page.locator('.search-result').click();
+    await expect(previewFrame.locator('body')).toContainText('logistic regression', {
+      timeout: 30000,
+    });
+
+    // Clearing the search restores the file tree (all files listed).
+    await page.getByLabel('Clear search').click();
+    await expect(searchBox).toHaveValue('');
+    await expect(page.locator('.file-item')).toHaveCount(4);
+  });
+});

--- a/hub-client/package.json
+++ b/hub-client/package.json
@@ -43,6 +43,7 @@
     "@revealjs/react": "0.2.0",
     "fast-diff": "^1.3.0",
     "idb": "^8.0.3",
+    "minisearch": "^7.2.0",
     "morphdom": "^2.7.8",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/hub-client/src/components/Editor.tsx
+++ b/hub-client/src/components/Editor.tsx
@@ -18,6 +18,7 @@ import type { Diagnostic } from '@quarto/preview-renderer/types/diagnostic';
 import { useIntelligenceProviders } from '../hooks/useIntelligenceProviders';
 import { registerQmdLanguage } from './quartoTheme';
 import { processFileForUpload } from '../services/resourceService';
+import { useProjectSearch } from '../services/search';
 import { usePresence } from '../hooks/usePresence';
 import { usePreference } from '../hooks/usePreference';
 import { useTheme } from './ThemeContext';
@@ -139,6 +140,9 @@ export default function Editor({ project, files, fileContents, onDisconnect, onC
   // View mode for pane sizing
   const { viewMode } = useViewMode();
   const { effectiveTheme } = useTheme();
+
+  // Full-text search index over the open project (Phase 1: client-side).
+  const searchFiles = useProjectSearch(files, fileContents);
 
   // Select initial file based on URL route or default
   const getInitialFile = useCallback((): FileEntry | null => {
@@ -972,6 +976,8 @@ export default function Editor({ project, files, fileContents, onDisconnect, onC
                       onRenameFile={handleRenameFile}
                       onOpenInNewTab={handleOpenInNewTab}
                       onCopyLink={handleCopyLink}
+                      searchFiles={searchFiles}
+                      fileContents={fileContents}
                     />
                   );
                 case 'outline':

--- a/hub-client/src/components/FileSidebar.css
+++ b/hub-client/src/components/FileSidebar.css
@@ -223,3 +223,104 @@
 .context-menu button.danger:hover {
   background: var(--context-menu-danger-bg);
 }
+
+/* ── Full-text search ─────────────────────────────────────────────── */
+
+.sidebar-search {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 12px;
+  border-bottom: 1px solid var(--sidebar-border);
+}
+
+.sidebar-search-input {
+  flex: 1;
+  min-width: 0;
+  padding: 4px 8px;
+  background: var(--editor-accent-bg);
+  border: 1px solid var(--editor-accent-border);
+  border-radius: 4px;
+  color: var(--editor-text);
+  font-size: 12px;
+}
+
+.sidebar-search-input::placeholder {
+  color: var(--editor-text-muted);
+}
+
+.sidebar-search-input:focus {
+  outline: none;
+  border-color: var(--sidebar-active-accent);
+}
+
+.sidebar-search-clear {
+  flex: none;
+  padding: 2px 6px;
+  background: none;
+  border: none;
+  color: var(--editor-text-muted);
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.sidebar-search-clear:hover {
+  color: var(--editor-text);
+}
+
+.search-result {
+  padding: 6px 12px;
+  cursor: pointer;
+  transition: background 0.15s;
+  border-left: 2px solid transparent;
+}
+
+.search-result:hover {
+  background: var(--sidebar-border);
+}
+
+.search-result.active {
+  background: var(--editor-accent-bg);
+  border-left-color: var(--sidebar-active-accent);
+}
+
+.search-result-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.search-result-name {
+  color: var(--editor-text);
+  font-size: 13px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.search-result-path {
+  color: var(--editor-text-muted);
+  font-size: 11px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.search-result-snippet {
+  margin-top: 2px;
+  padding-left: 22px;
+  color: var(--editor-text-muted);
+  font-size: 11px;
+  line-height: 1.4;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.search-result-snippet mark {
+  background: var(--editor-accent-border);
+  color: var(--editor-text);
+  border-radius: 2px;
+  padding: 0 1px;
+}

--- a/hub-client/src/components/FileSidebar.search.test.tsx
+++ b/hub-client/src/components/FileSidebar.search.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import type { FileEntry } from '@quarto/preview-renderer/types/project';
+import FileSidebar from './FileSidebar';
+import type { SearchResult } from '../services/search';
+
+afterEach(cleanup);
+
+function entry(path: string): FileEntry {
+  return { path, docId: `doc-${path}` } as FileEntry;
+}
+
+const baseProps = {
+  currentFile: null,
+  onNewFile: () => {},
+  onUploadFiles: () => {},
+};
+
+describe('FileSidebar full-text search', () => {
+  it('does not render a search box when searchFiles is not provided', () => {
+    render(
+      <FileSidebar files={[entry('a.qmd')]} onSelectFile={() => {}} {...baseProps} />
+    );
+    expect(screen.queryByLabelText('Search files')).toBeNull();
+  });
+
+  it('runs a query and renders ranked results with snippets', async () => {
+    const searchFiles = vi.fn(
+      async (): Promise<SearchResult[]> => [
+        { path: 'intro.qmd', score: 2, terms: ['search'] },
+      ]
+    );
+    const fileContents = new Map([['intro.qmd', 'a document about search engines']]);
+
+    render(
+      <FileSidebar
+        files={[entry('intro.qmd'), entry('other.qmd')]}
+        onSelectFile={() => {}}
+        searchFiles={searchFiles}
+        fileContents={fileContents}
+        {...baseProps}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText('Search files'), {
+      target: { value: 'search' },
+    });
+
+    await waitFor(() => expect(searchFiles).toHaveBeenCalledWith('search', expect.anything()));
+    expect(await screen.findByText('intro.qmd')).toBeTruthy();
+    // Snippet highlights the matched term in a <mark>.
+    const mark = document.querySelector('.search-result-snippet mark');
+    expect(mark?.textContent).toBe('search');
+  });
+
+  it('selects the right file when a result is clicked', async () => {
+    const onSelectFile = vi.fn();
+    const searchFiles = vi.fn(
+      async (): Promise<SearchResult[]> => [{ path: 'intro.qmd', score: 1, terms: ['intro'] }]
+    );
+
+    render(
+      <FileSidebar
+        files={[entry('intro.qmd')]}
+        onSelectFile={onSelectFile}
+        searchFiles={searchFiles}
+        {...baseProps}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText('Search files'), {
+      target: { value: 'intro' },
+    });
+
+    const result = await screen.findByText('intro.qmd');
+    fireEvent.click(result);
+    expect(onSelectFile).toHaveBeenCalledWith(expect.objectContaining({ path: 'intro.qmd' }));
+  });
+
+  it('shows a no-matches state when the query returns nothing', async () => {
+    const searchFiles = vi.fn(async (): Promise<SearchResult[]> => []);
+    render(
+      <FileSidebar
+        files={[entry('a.qmd')]}
+        onSelectFile={() => {}}
+        searchFiles={searchFiles}
+        {...baseProps}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText('Search files'), {
+      target: { value: 'zzz' },
+    });
+
+    expect(await screen.findByText('No matches')).toBeTruthy();
+  });
+
+  it('clears the query with the clear button, restoring the file tree', async () => {
+    const searchFiles = vi.fn(async (): Promise<SearchResult[]> => []);
+    render(
+      <FileSidebar
+        files={[entry('tree-file.qmd')]}
+        onSelectFile={() => {}}
+        searchFiles={searchFiles}
+        {...baseProps}
+      />
+    );
+
+    const input = screen.getByLabelText('Search files') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'zzz' } });
+    await screen.findByText('No matches');
+
+    fireEvent.click(screen.getByLabelText('Clear search'));
+    expect(input.value).toBe('');
+    // Tree is back: the file name is shown again.
+    expect(screen.getByText('tree-file.qmd')).toBeTruthy();
+  });
+});

--- a/hub-client/src/components/FileSidebar.tsx
+++ b/hub-client/src/components/FileSidebar.tsx
@@ -17,6 +17,7 @@ import {
   type FileTreeNode,
 } from '../utils/fileTree';
 import { resolveDefaultDestination } from './fileUpload';
+import { buildSnippet, type SearchFiles, type SearchResult } from '../services/search';
 import './FileSidebar.css';
 
 export interface FileSidebarProps {
@@ -36,6 +37,17 @@ export interface FileSidebarProps {
   onOpenInNewTab?: (file: FileEntry) => void;
   /** Copy a link to a file to clipboard */
   onCopyLink?: (file: FileEntry) => void;
+  /**
+   * Full-text search over the open project. When provided, a search box is
+   * shown and a query replaces the file tree with ranked results. Absent
+   * means search is disabled (the tree renders as before).
+   */
+  searchFiles?: SearchFiles;
+  /**
+   * Live text content per path, used only to render match snippets in search
+   * results. Optional; without it results show the path alone.
+   */
+  fileContents?: Map<string, string>;
 }
 
 interface ContextMenuState {
@@ -91,8 +103,12 @@ export default function FileSidebar({
   onRenameFile,
   onOpenInNewTab,
   onCopyLink,
+  searchFiles,
+  fileContents,
 }: FileSidebarProps) {
   const [isDragOver, setIsDragOver] = useState(false);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
   const [contextMenu, setContextMenu] = useState<ContextMenuState>({
     visible: false,
     x: 0,
@@ -109,6 +125,39 @@ export default function FileSidebar({
 
   // Build file tree from flat file list
   const fileTree = useMemo(() => buildFileTree(files), [files]);
+
+  // Resolve a search result's path back to its FileEntry.
+  const filesByPath = useMemo(() => {
+    const m = new Map<string, FileEntry>();
+    for (const f of files) m.set(f.path, f);
+    return m;
+  }, [files]);
+
+  const isSearching = searchQuery.trim() !== '';
+
+  // Debounced full-text search; ignore stale async resolutions. All state
+  // updates happen inside the timer callback (never synchronously in the
+  // effect body) to avoid cascading renders.
+  useEffect(() => {
+    if (!searchFiles) return;
+    let cancelled = false;
+    const handle = setTimeout(
+      () => {
+        if (!isSearching) {
+          if (!cancelled) setSearchResults([]);
+          return;
+        }
+        void searchFiles(searchQuery, { limit: 50 }).then((results) => {
+          if (!cancelled) setSearchResults(results);
+        });
+      },
+      isSearching ? 120 : 0
+    );
+    return () => {
+      cancelled = true;
+      clearTimeout(handle);
+    };
+  }, [searchFiles, searchQuery, isSearching]);
 
   // Toggle a folder's expanded state
   const toggleFolder = useCallback((path: string) => {
@@ -375,6 +424,51 @@ export default function FileSidebar({
     );
   };
 
+  // Render the ranked search results (replaces the tree while searching).
+  const renderSearchResults = (): React.ReactNode => {
+    if (searchResults.length === 0) {
+      return (
+        <div className="empty-state">
+          <p>No matches</p>
+        </div>
+      );
+    }
+    return searchResults.map((result) => {
+      const file = filesByPath.get(result.path);
+      if (!file) return null; // result for a file no longer listed
+      const fileName = result.path.split('/').pop() || result.path;
+      const dir = result.path.slice(0, result.path.length - fileName.length);
+      const content = fileContents?.get(result.path);
+      const snippet = content ? buildSnippet(content, result.terms) : [];
+      const isActive = currentFile?.path === result.path;
+      return (
+        <div
+          key={result.path}
+          className={`search-result ${isActive ? 'active' : ''}`}
+          onClick={() => onSelectFile(file)}
+          title={result.path}
+        >
+          <div className="search-result-header">
+            <span className="file-icon">{getFileIcon(result.path)}</span>
+            <span className="search-result-name">{fileName}</span>
+            {dir && <span className="search-result-path">{dir}</span>}
+          </div>
+          {snippet.length > 0 && (
+            <div className="search-result-snippet">
+              {snippet.map((seg, i) =>
+                seg.match ? (
+                  <mark key={i}>{seg.text}</mark>
+                ) : (
+                  <span key={i}>{seg.text}</span>
+                )
+              )}
+            </div>
+          )}
+        </div>
+      );
+    });
+  };
+
   return (
     <div
       ref={sidebarRef}
@@ -397,8 +491,33 @@ export default function FileSidebar({
         </button>
       </div>
 
+      {searchFiles && (
+        <div className="sidebar-search">
+          <input
+            type="search"
+            className="sidebar-search-input"
+            placeholder="Search files…"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            aria-label="Search files"
+          />
+          {isSearching && (
+            <button
+              className="sidebar-search-clear"
+              onClick={() => setSearchQuery('')}
+              title="Clear search"
+              aria-label="Clear search"
+            >
+              ✕
+            </button>
+          )}
+        </div>
+      )}
+
       <div className="file-list">
-        {files.length === 0 ? (
+        {isSearching ? (
+          renderSearchResults()
+        ) : files.length === 0 ? (
           <div className="empty-state">
             <p>No files yet</p>
             <p className="hint">Drop files here or click + to create</p>

--- a/hub-client/src/services/search/inMemorySearchProvider.test.ts
+++ b/hub-client/src/services/search/inMemorySearchProvider.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { InMemorySearchProvider } from './inMemorySearchProvider';
+
+describe('InMemorySearchProvider', () => {
+  let provider: InMemorySearchProvider;
+
+  beforeEach(() => {
+    provider = new InMemorySearchProvider();
+  });
+
+  describe('addOrUpdate + search', () => {
+    it('returns a document whose content matches the query', async () => {
+      provider.addOrUpdate('intro.qmd', 'The quick brown fox jumps');
+      const results = await provider.search('fox');
+      expect(results.map((r) => r.path)).toEqual(['intro.qmd']);
+    });
+
+    it('returns multiple matching documents', async () => {
+      provider.addOrUpdate('a.qmd', 'apples and oranges');
+      provider.addOrUpdate('b.qmd', 'oranges and lemons');
+      provider.addOrUpdate('c.qmd', 'completely unrelated');
+      const paths = (await provider.search('oranges')).map((r) => r.path).sort();
+      expect(paths).toEqual(['a.qmd', 'b.qmd']);
+    });
+
+    it('ranks a document with more occurrences of the term higher', async () => {
+      provider.addOrUpdate('dense.qmd', 'search search search search results');
+      provider.addOrUpdate('sparse.qmd', 'a single search term among many other words here');
+      const results = await provider.search('search');
+      expect(results[0].path).toBe('dense.qmd');
+    });
+
+    it('matches on the file path as well as content', async () => {
+      provider.addOrUpdate('chapters/methodology.qmd', 'body text without the term');
+      const results = await provider.search('methodology');
+      expect(results.map((r) => r.path)).toContain('chapters/methodology.qmd');
+    });
+
+    it('populates matched terms for highlighting', async () => {
+      provider.addOrUpdate('intro.qmd', 'collaborative editing is collaborative');
+      const results = await provider.search('collaborative');
+      expect(results[0].terms).toContain('collaborative');
+    });
+
+    it('returns scores in non-increasing order', async () => {
+      provider.addOrUpdate('a.qmd', 'token token token');
+      provider.addOrUpdate('b.qmd', 'token once');
+      const scores = (await provider.search('token')).map((r) => r.score);
+      const sorted = [...scores].sort((x, y) => y - x);
+      expect(scores).toEqual(sorted);
+    });
+  });
+
+  describe('prefix and fuzzy matching', () => {
+    it('matches on a term prefix', async () => {
+      provider.addOrUpdate('doc.qmd', 'documentation generator');
+      const results = await provider.search('docum');
+      expect(results.map((r) => r.path)).toContain('doc.qmd');
+    });
+
+    it('tolerates a small typo (fuzzy)', async () => {
+      provider.addOrUpdate('doc.qmd', 'collaborative editing');
+      const results = await provider.search('colaborative');
+      expect(results.map((r) => r.path)).toContain('doc.qmd');
+    });
+  });
+
+  describe('update semantics', () => {
+    it('replaces content on re-add without duplicating the document', async () => {
+      provider.addOrUpdate('f.qmd', 'original content alpha');
+      provider.addOrUpdate('f.qmd', 'revised content beta');
+
+      // Old term no longer matches.
+      expect(await provider.search('alpha')).toEqual([]);
+      // New term matches, exactly once.
+      const beta = await provider.search('beta');
+      expect(beta.map((r) => r.path)).toEqual(['f.qmd']);
+    });
+  });
+
+  describe('remove', () => {
+    it('drops a document from results', async () => {
+      provider.addOrUpdate('f.qmd', 'removable content');
+      provider.remove('f.qmd');
+      expect(await provider.search('removable')).toEqual([]);
+    });
+
+    it('is a no-op for an unknown path', async () => {
+      provider.addOrUpdate('keep.qmd', 'keep this content');
+      expect(() => provider.remove('never-added.qmd')).not.toThrow();
+      expect((await provider.search('keep')).map((r) => r.path)).toEqual(['keep.qmd']);
+    });
+  });
+
+  describe('clear', () => {
+    it('empties the corpus', async () => {
+      provider.addOrUpdate('a.qmd', 'alpha');
+      provider.addOrUpdate('b.qmd', 'beta');
+      provider.clear();
+      expect(await provider.search('alpha')).toEqual([]);
+      expect(await provider.search('beta')).toEqual([]);
+    });
+
+    it('allows re-indexing after clear', async () => {
+      provider.addOrUpdate('a.qmd', 'alpha');
+      provider.clear();
+      provider.addOrUpdate('a.qmd', 'alpha again');
+      expect((await provider.search('alpha')).map((r) => r.path)).toEqual(['a.qmd']);
+    });
+  });
+
+  describe('empty queries', () => {
+    it('returns nothing for an empty query', async () => {
+      provider.addOrUpdate('a.qmd', 'some content');
+      expect(await provider.search('')).toEqual([]);
+    });
+
+    it('returns nothing for a whitespace-only query', async () => {
+      provider.addOrUpdate('a.qmd', 'some content');
+      expect(await provider.search('   \t  ')).toEqual([]);
+    });
+  });
+
+  describe('limit option', () => {
+    it('caps the number of results', async () => {
+      for (let i = 0; i < 10; i++) {
+        provider.addOrUpdate(`f${i}.qmd`, 'shared term here');
+      }
+      const results = await provider.search('shared', { limit: 3 });
+      expect(results).toHaveLength(3);
+    });
+  });
+
+  describe('Phase 2 forward-compatibility', () => {
+    it('leaves projectId undefined for the single-project (Phase 1) case', async () => {
+      provider.addOrUpdate('a.qmd', 'content');
+      const [result] = await provider.search('content');
+      expect(result.projectId).toBeUndefined();
+    });
+
+    it('leaves title undefined for the raw-text (Phase 1) index', async () => {
+      provider.addOrUpdate('a.qmd', 'content');
+      const [result] = await provider.search('content');
+      expect(result.title).toBeUndefined();
+    });
+  });
+});

--- a/hub-client/src/services/search/inMemorySearchProvider.ts
+++ b/hub-client/src/services/search/inMemorySearchProvider.ts
@@ -1,0 +1,81 @@
+import MiniSearch from 'minisearch';
+import type { SearchOptions, SearchProvider, SearchResult } from './types';
+
+/**
+ * Internal shape of an indexed document. `id` is the file path, which is also
+ * indexed as a field so filename terms are searchable.
+ */
+interface IndexedDoc {
+  id: string;
+  path: string;
+  text: string;
+}
+
+/**
+ * Phase 1 {@link SearchProvider}: a MiniSearch-backed inverted index held
+ * entirely in browser memory over the currently-open project's files.
+ *
+ * The corpus is maintained incrementally so it can be driven straight from the
+ * hub's sync callbacks: {@link addOrUpdate} on `onFileContent`, {@link remove}
+ * on a file deletion, {@link clear} on project switch.
+ */
+export class InMemorySearchProvider implements SearchProvider {
+  private index: MiniSearch<IndexedDoc>;
+
+  constructor() {
+    this.index = InMemorySearchProvider.createIndex();
+  }
+
+  private static createIndex(): MiniSearch<IndexedDoc> {
+    return new MiniSearch<IndexedDoc>({
+      fields: ['text', 'path'],
+      storeFields: ['path'],
+      // Default tokenizer splits on whitespace and punctuation, so a path like
+      // "chapters/methodology.qmd" yields ["chapters", "methodology", "qmd"].
+    });
+  }
+
+  addOrUpdate(path: string, text: string): void {
+    const doc: IndexedDoc = { id: path, path, text };
+    if (this.index.has(path)) {
+      this.index.replace(doc);
+    } else {
+      this.index.add(doc);
+    }
+  }
+
+  remove(path: string): void {
+    // discard() removes by id without needing the original document, and is a
+    // no-op-safe only when the id exists — guard to keep remove() idempotent.
+    if (this.index.has(path)) {
+      this.index.discard(path);
+    }
+  }
+
+  clear(): void {
+    this.index.removeAll();
+  }
+
+  async search(query: string, opts?: SearchOptions): Promise<SearchResult[]> {
+    if (query.trim() === '') {
+      return [];
+    }
+
+    const raw = this.index.search(query, {
+      prefix: true,
+      fuzzy: 0.2,
+      // Filename hits are a strong relevance signal.
+      boost: { path: 2 },
+    });
+
+    const limited = opts?.limit != null ? raw.slice(0, opts.limit) : raw;
+
+    return limited.map((r) => ({
+      path: r.id as string,
+      score: r.score,
+      terms: r.terms,
+      // title / projectId intentionally absent in Phase 1 (raw-text,
+      // single-project index). Populated by later phases.
+    }));
+  }
+}

--- a/hub-client/src/services/search/index.ts
+++ b/hub-client/src/services/search/index.ts
@@ -1,2 +1,6 @@
 export type { SearchProvider, SearchResult, SearchOptions } from './types';
 export { InMemorySearchProvider } from './inMemorySearchProvider';
+export { useProjectSearch } from './useProjectSearch';
+export type { SearchFiles } from './useProjectSearch';
+export { buildSnippet } from './snippet';
+export type { SnippetSegment, SnippetOptions } from './snippet';

--- a/hub-client/src/services/search/index.ts
+++ b/hub-client/src/services/search/index.ts
@@ -1,0 +1,2 @@
+export type { SearchProvider, SearchResult, SearchOptions } from './types';
+export { InMemorySearchProvider } from './inMemorySearchProvider';

--- a/hub-client/src/services/search/snippet.test.ts
+++ b/hub-client/src/services/search/snippet.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { buildSnippet } from './snippet';
+
+/** Concatenate segment texts back into the rendered string. */
+function rendered(segs: ReturnType<typeof buildSnippet>): string {
+  return segs.map((s) => s.text).join('');
+}
+/** The substrings that would be wrapped in <mark>. */
+function marks(segs: ReturnType<typeof buildSnippet>): string[] {
+  return segs.filter((s) => s.match).map((s) => s.text);
+}
+
+describe('buildSnippet', () => {
+  it('marks the matched term', () => {
+    const segs = buildSnippet('the collaborative editor', ['collaborative']);
+    expect(marks(segs)).toEqual(['collaborative']);
+  });
+
+  it('includes surrounding context around the match', () => {
+    const content = 'lorem ipsum dolor sit amet target consectetur adipiscing elit done';
+    const segs = buildSnippet(content, ['target'], { context: 15 });
+    const out = rendered(segs);
+    expect(out).toContain('target');
+    expect(out).toContain('amet');         // preceding context
+    expect(out).toContain('consectetur');  // following context
+    expect(out.length).toBeLessThan(content.length);
+  });
+
+  it('matches case-insensitively but preserves original casing in output', () => {
+    const segs = buildSnippet('The QUICK brown fox', ['quick']);
+    expect(marks(segs)).toEqual(['QUICK']);
+  });
+
+  it('highlights multiple terms within the window', () => {
+    const segs = buildSnippet('alpha beta gamma', ['alpha', 'gamma']);
+    expect(marks(segs)).toEqual(['alpha', 'gamma']);
+  });
+
+  it('prepends an ellipsis when the window starts mid-content', () => {
+    const content = 'a b c d e f g h i j target k l m';
+    const segs = buildSnippet(content, ['target'], { context: 6 });
+    expect(rendered(segs).startsWith('…')).toBe(true);
+  });
+
+  it('returns a leading slice (no marks) when no term matches', () => {
+    const content = 'this content has none of the searched words at all here';
+    const segs = buildSnippet(content, ['absent'], { maxLength: 20 });
+    expect(marks(segs)).toEqual([]);
+    expect(rendered(segs).length).toBeLessThanOrEqual(21); // +1 for possible ellipsis
+  });
+
+  it('returns an empty array for empty content', () => {
+    expect(buildSnippet('', ['x'])).toEqual([]);
+  });
+
+  it('does not mark anything when terms is empty', () => {
+    const segs = buildSnippet('some content here', []);
+    expect(marks(segs)).toEqual([]);
+  });
+});

--- a/hub-client/src/services/search/snippet.ts
+++ b/hub-client/src/services/search/snippet.ts
@@ -1,0 +1,128 @@
+/**
+ * Snippet extraction for search results.
+ *
+ * Given a file's raw text and the query terms that matched it (as returned in
+ * {@link SearchResult.terms}), produce a short, highlightable excerpt centered
+ * on the first match. Pure and presentation-agnostic: the caller renders
+ * {@link SnippetSegment}s with `match: true` as `<mark>` (or similar).
+ *
+ * Kept out of the {@link SearchProvider} on purpose — the provider need not
+ * store full document text, and snippet shaping is a presentation concern.
+ */
+
+/** One run of snippet text; `match` segments are the highlighted terms. */
+export interface SnippetSegment {
+  text: string;
+  match: boolean;
+}
+
+export interface SnippetOptions {
+  /** Characters of context to keep on each side of the match. Default 40. */
+  context?: number;
+  /** Max length of the leading slice used when no term matches. Default 80. */
+  maxLength?: number;
+}
+
+const ELLIPSIS = '…';
+
+/** Lowercased, de-duplicated, non-empty terms, longest first (greedy match). */
+function normalizeTerms(terms: string[]): string[] {
+  const seen = new Set<string>();
+  for (const t of terms) {
+    const lt = t.toLowerCase();
+    if (lt) seen.add(lt);
+  }
+  return [...seen].sort((a, b) => b.length - a.length);
+}
+
+/** Find the earliest occurrence of any term; returns null if none match. */
+function firstMatch(
+  haystack: string,
+  terms: string[]
+): { index: number; length: number } | null {
+  let best: { index: number; length: number } | null = null;
+  for (const term of terms) {
+    const idx = haystack.indexOf(term);
+    if (idx !== -1 && (best === null || idx < best.index)) {
+      best = { index: idx, length: term.length };
+    }
+  }
+  return best;
+}
+
+export function buildSnippet(
+  content: string,
+  terms: string[],
+  opts: SnippetOptions = {}
+): SnippetSegment[] {
+  if (content === '') return [];
+
+  const context = opts.context ?? 40;
+  const maxLength = opts.maxLength ?? 80;
+  const normTerms = normalizeTerms(terms);
+  const lower = content.toLowerCase();
+
+  const hit = normTerms.length > 0 ? firstMatch(lower, normTerms) : null;
+
+  // No match: return a leading slice as a single, unmarked segment.
+  if (hit === null) {
+    const slice = content.slice(0, maxLength);
+    const text = slice.length < content.length ? slice + ELLIPSIS : slice;
+    return text === '' ? [] : [{ text, match: false }];
+  }
+
+  // Window around the first match.
+  const start = Math.max(0, hit.index - context);
+  const end = Math.min(content.length, hit.index + hit.length + context);
+  const window = content.slice(start, end);
+  const windowLower = lower.slice(start, end);
+
+  // Walk the window, emitting alternating unmatched / matched segments by
+  // scanning for any term at each position (greedy, longest term first).
+  const segments: SnippetSegment[] = [];
+  let plainStart = 0;
+  let i = 0;
+  const pushPlain = (upto: number) => {
+    if (upto > plainStart) {
+      segments.push({ text: window.slice(plainStart, upto), match: false });
+    }
+  };
+  while (i < window.length) {
+    let matchedLen = 0;
+    for (const term of normTerms) {
+      if (windowLower.startsWith(term, i)) {
+        matchedLen = term.length;
+        break;
+      }
+    }
+    if (matchedLen > 0) {
+      pushPlain(i);
+      segments.push({ text: window.slice(i, i + matchedLen), match: true });
+      i += matchedLen;
+      plainStart = i;
+    } else {
+      i++;
+    }
+  }
+  pushPlain(window.length);
+
+  // Add ellipses where the window was clipped, by prefixing/suffixing the
+  // adjacent plain segment (or inserting one).
+  if (start > 0) {
+    if (segments[0]?.match === false) {
+      segments[0] = { text: ELLIPSIS + segments[0].text, match: false };
+    } else {
+      segments.unshift({ text: ELLIPSIS, match: false });
+    }
+  }
+  if (end < content.length) {
+    const last = segments[segments.length - 1];
+    if (last?.match === false) {
+      segments[segments.length - 1] = { text: last.text + ELLIPSIS, match: false };
+    } else {
+      segments.push({ text: ELLIPSIS, match: false });
+    }
+  }
+
+  return segments;
+}

--- a/hub-client/src/services/search/types.ts
+++ b/hub-client/src/services/search/types.ts
@@ -1,0 +1,74 @@
+/**
+ * Full-text search abstraction for the Quarto Hub client.
+ *
+ * The {@link SearchProvider} interface is the single seam that lets Phase 1
+ * (an in-memory index over the currently-open project) evolve into Phase 2
+ * (a server-backed index spanning a *set* of projects) without changing the
+ * UI. The UI must never assume the corpus lives entirely in browser memory:
+ * {@link SearchProvider.search} is therefore async, and {@link SearchResult}
+ * already carries an optional {@link SearchResult.projectId} so cross-project
+ * results render unchanged.
+ *
+ * See claude-notes/plans/2026-06-23-hub-client-full-text-search.md.
+ */
+
+/** Options refining a search query. */
+export interface SearchOptions {
+  /** Cap on the number of results returned (best-scoring first). */
+  limit?: number;
+}
+
+/** A single match returned from {@link SearchProvider.search}. */
+export interface SearchResult {
+  /** File path within its project, e.g. "docs/intro.qmd". */
+  path: string;
+  /** Relevance score; higher is better. Comparable only within one result set. */
+  score: number;
+  /**
+   * Query terms that actually matched this document (after prefix/fuzzy
+   * expansion). Lets the UI highlight matches / build snippets without
+   * re-running the matcher.
+   */
+  terms: string[];
+  /**
+   * Document title, when known (populated in Phase B from DocumentProfile).
+   * Absent in Phase 1's raw-text index.
+   */
+  title?: string;
+  /**
+   * Identifies the owning project (the project's index-doc id). `undefined`
+   * means "the single currently-open project" — the Phase 1 case. Phase 2's
+   * cross-project provider populates this so results from different projects
+   * are distinguishable.
+   */
+  projectId?: string;
+}
+
+/**
+ * A full-text search index over a corpus of text files.
+ *
+ * Implementations maintain the corpus incrementally via
+ * {@link addOrUpdate}/{@link remove}/{@link clear}, which are designed to be
+ * driven directly from the hub's sync callbacks (`onFileContent`,
+ * `onFilesChange`).
+ */
+export interface SearchProvider {
+  /**
+   * Insert a file, or replace it if a file with the same `path` is already
+   * indexed. Idempotent for unchanged content.
+   */
+  addOrUpdate(path: string, text: string): void;
+
+  /** Remove a file from the index. No-op if the path is not indexed. */
+  remove(path: string): void;
+
+  /** Drop the entire corpus (e.g. on project switch or disconnect). */
+  clear(): void;
+
+  /**
+   * Search the corpus. Returns best-scoring results first. An empty or
+   * whitespace-only query returns no results. Async to keep the interface
+   * stable across the eventual server-backed (Phase 2) implementation.
+   */
+  search(query: string, opts?: SearchOptions): Promise<SearchResult[]>;
+}

--- a/hub-client/src/services/search/useProjectSearch.test.tsx
+++ b/hub-client/src/services/search/useProjectSearch.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import type { FileEntry } from '@quarto/preview-renderer/types/project';
+import { useProjectSearch } from './useProjectSearch';
+
+function entry(path: string): FileEntry {
+  return { path, docId: `doc-${path}` } as FileEntry;
+}
+
+function filesOf(...paths: string[]): FileEntry[] {
+  return paths.map(entry);
+}
+
+describe('useProjectSearch', () => {
+  it('indexes files present in both the file list and the contents map', async () => {
+    const files = filesOf('a.qmd', 'b.qmd');
+    const contents = new Map([
+      ['a.qmd', 'alpha content'],
+      ['b.qmd', 'beta content'],
+    ]);
+    const { result } = renderHook(() => useProjectSearch(files, contents));
+
+    expect((await result.current('alpha')).map((r) => r.path)).toEqual(['a.qmd']);
+    expect((await result.current('beta')).map((r) => r.path)).toEqual(['b.qmd']);
+  });
+
+  it('does not index content for a path absent from the file list (stale/binary guard)', async () => {
+    const files = filesOf('a.qmd'); // b.qmd is NOT a listed file
+    const contents = new Map([
+      ['a.qmd', 'alpha content'],
+      ['b.qmd', 'beta content'],
+    ]);
+    const { result } = renderHook(() => useProjectSearch(files, contents));
+
+    expect(await result.current('beta')).toEqual([]);
+    expect((await result.current('alpha')).map((r) => r.path)).toEqual(['a.qmd']);
+  });
+
+  it('re-indexes when a file’s content changes', async () => {
+    const files = filesOf('a.qmd');
+    const { result, rerender } = renderHook(
+      ({ contents }: { contents: Map<string, string> }) => useProjectSearch(files, contents),
+      { initialProps: { contents: new Map([['a.qmd', 'original alpha']]) } }
+    );
+
+    expect((await result.current('alpha')).map((r) => r.path)).toEqual(['a.qmd']);
+
+    rerender({ contents: new Map([['a.qmd', 'revised omega']]) });
+
+    expect(await result.current('alpha')).toEqual([]);
+    expect((await result.current('omega')).map((r) => r.path)).toEqual(['a.qmd']);
+  });
+
+  it('removes a file from the index when it leaves the file list', async () => {
+    const { result, rerender } = renderHook(
+      ({ files }: { files: FileEntry[] }) =>
+        useProjectSearch(
+          files,
+          new Map([
+            ['a.qmd', 'alpha content'],
+            ['b.qmd', 'beta content'],
+          ])
+        ),
+      { initialProps: { files: filesOf('a.qmd', 'b.qmd') } }
+    );
+
+    expect((await result.current('beta')).map((r) => r.path)).toEqual(['b.qmd']);
+
+    rerender({ files: filesOf('a.qmd') }); // b.qmd deleted
+
+    expect(await result.current('beta')).toEqual([]);
+    expect((await result.current('alpha')).map((r) => r.path)).toEqual(['a.qmd']);
+  });
+
+  it('clears the index when the project is switched (inputs reset to empty)', async () => {
+    const { result, rerender } = renderHook(
+      ({ files, contents }: { files: FileEntry[]; contents: Map<string, string> }) =>
+        useProjectSearch(files, contents),
+      {
+        initialProps: {
+          files: filesOf('a.qmd'),
+          contents: new Map([['a.qmd', 'alpha content']]),
+        },
+      }
+    );
+
+    expect((await result.current('alpha')).map((r) => r.path)).toEqual(['a.qmd']);
+
+    rerender({ files: [], contents: new Map() });
+
+    expect(await result.current('alpha')).toEqual([]);
+  });
+
+  it('returns a stable search function across re-renders', () => {
+    const files = filesOf('a.qmd');
+    const { result, rerender } = renderHook(
+      ({ contents }: { contents: Map<string, string> }) => useProjectSearch(files, contents),
+      { initialProps: { contents: new Map([['a.qmd', 'alpha']]) } }
+    );
+    const first = result.current;
+    rerender({ contents: new Map([['a.qmd', 'alpha revised']]) });
+    expect(result.current).toBe(first);
+  });
+});

--- a/hub-client/src/services/search/useProjectSearch.ts
+++ b/hub-client/src/services/search/useProjectSearch.ts
@@ -1,0 +1,77 @@
+import { useCallback, useEffect, useRef } from 'react';
+import type { FileEntry } from '@quarto/preview-renderer/types/project';
+import { InMemorySearchProvider } from './inMemorySearchProvider';
+import type { SearchOptions, SearchResult } from './types';
+
+/** Async search function handed to the UI. */
+export type SearchFiles = (query: string, opts?: SearchOptions) => Promise<SearchResult[]>;
+
+/**
+ * Owns a Phase 1 in-memory {@link InMemorySearchProvider} and keeps it
+ * reconciled with the currently-open project.
+ *
+ * The index is maintained as a pure function of two pieces of React state the
+ * hub already tracks:
+ *
+ * - `files` — the authoritative file list (membership; controls deletions and
+ *   project switches), and
+ * - `fileContents` — the live text of each file (only text files appear here;
+ *   binaries are excluded upstream).
+ *
+ * A file is indexed iff it is in **both** (so a path lingering in
+ * `fileContents` after deletion, or a binary with no text, is never indexed).
+ * Driving from state — rather than from raw sync callbacks — means project
+ * switches (both inputs reset to empty) and deletions are reflected for free,
+ * with no risk of the index drifting from what the user sees.
+ *
+ * Returns a stable async `search` function. Swapping this hook for a
+ * server-backed one is how Phase 2 (cross-project search) lands without
+ * touching the UI.
+ */
+export function useProjectSearch(
+  files: FileEntry[],
+  fileContents: Map<string, string>
+): SearchFiles {
+  const providerRef = useRef<InMemorySearchProvider | null>(null);
+  if (providerRef.current === null) {
+    providerRef.current = new InMemorySearchProvider();
+  }
+  // Shadow of what is currently indexed (path -> indexed content), so we only
+  // touch the index on real deltas.
+  const indexedRef = useRef<Map<string, string>>(new Map());
+
+  useEffect(() => {
+    const provider = providerRef.current!;
+    const indexed = indexedRef.current;
+    const listed = new Set(files.map((f) => f.path));
+
+    // Desired corpus: text content for paths that are also listed files.
+    const desired = new Map<string, string>();
+    for (const [path, content] of fileContents) {
+      if (listed.has(path)) {
+        desired.set(path, content);
+      }
+    }
+
+    // Adds and updates.
+    for (const [path, content] of desired) {
+      if (indexed.get(path) !== content) {
+        provider.addOrUpdate(path, content);
+        indexed.set(path, content);
+      }
+    }
+
+    // Removals (files deleted, unlisted, or whose content disappeared).
+    for (const path of [...indexed.keys()]) {
+      if (!desired.has(path)) {
+        provider.remove(path);
+        indexed.delete(path);
+      }
+    }
+  }, [files, fileContents]);
+
+  return useCallback<SearchFiles>(
+    (query, opts) => providerRef.current!.search(query, opts),
+    []
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "@revealjs/react": "0.2.0",
         "fast-diff": "^1.3.0",
         "idb": "^8.0.3",
+        "minisearch": "^7.2.0",
         "morphdom": "^2.7.8",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -2058,7 +2059,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2076,7 +2076,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2094,7 +2093,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2112,7 +2110,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2130,7 +2127,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2148,7 +2144,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2166,7 +2161,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2184,7 +2178,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2202,7 +2195,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2220,7 +2212,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2238,7 +2229,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2256,7 +2246,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2274,7 +2263,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2292,7 +2280,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2310,7 +2297,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2328,7 +2314,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2346,7 +2331,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2364,7 +2348,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2382,7 +2365,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2400,7 +2382,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2418,7 +2399,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2436,7 +2416,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2454,7 +2433,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2472,7 +2450,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2490,7 +2467,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2508,7 +2484,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8341,6 +8316,12 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/minisearch": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-7.2.0.tgz",
+      "integrity": "sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==",
+      "license": "MIT"
     },
     "node_modules/monaco-editor": {
       "version": "0.55.1",


### PR DESCRIPTION
## Summary

Phase 1 of full-text search for the Quarto Hub client (epic **bd-mdet0yoy**): an **open-project, client-side** search index behind a `SearchProvider` abstraction designed so later phases (relevance enrichment, then cross-project search) slot in without a UI rewrite.

Design doc: `claude-notes/plans/2026-06-23-hub-client-full-text-search.md` (full four-approach assessment + phased plan).

## What's here

- **`hub-client/src/services/search/`**
  - `SearchProvider` interface — `addOrUpdate` / `remove` / `clear` / async `search`. `SearchResult.projectId` exists but is `undefined` in Phase 1 (the Phase 2 forward-compat hinge).
  - `InMemorySearchProvider` — MiniSearch v7 over `text` + `path`; incremental add/replace/discard; prefix + fuzzy; filename boosting.
  - `useProjectSearch(files, fileContents)` — owns the index and reconciles it against React state (a file is indexed iff it's in **both** the file list and the contents map), so deletes/edits/project-switches are reflected with no drift.
  - `buildSnippet(content, terms)` — pure `<mark>` snippet highlighter, kept out of the provider.
- **UI** — debounced search box + ranked results with highlighted snippets in `FileSidebar`, wired via `Editor`. Feature-gated on the optional `searchFiles` prop.
- MiniSearch v7.2.0 dependency (spike-chosen over FlexSearch/Orama).
- Changelog entry.

## Verification

- Unit: **651** hub-client tests pass (38 new: provider/hook/snippet/sidebar, all TDD).
- Integration: **75** pass. WASM: **121** pass (after a local WASM rebuild).
- Production build (`tsc -b && vite build`) clean; no new lint errors.
- **End-to-end** (`hub-client/e2e/search.spec.ts`, passes against the real Rust hub): a 4-file project synced into the browser; query `regression` → only `methods.qmd`; snippet highlighted the term; clicking opened the file; clearing restored all 4 files.

## Not in this PR

- **Phase B** (bd-b5ub29xd): WASM-plaintext + `DocumentProfile` title/heading boosting — gated on measuring batch-parse cost.
- **Phase 2** (bd-ghao01p6): cross-project search, riding on the server-side project-sets epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)