### PR TITLE
Wire editor↔preview scroll sync for the q2-preview format

### DIFF
--- a/claude-notes/plans/2026-05-29-q2-preview-scroll-sync.md
+++ b/claude-notes/plans/2026-05-29-q2-preview-scroll-sync.md
@@ -1,0 +1,71 @@
+# q2-preview scroll sync (bd-9kzfi)
+
+## Overview
+
+Scroll sync (editor ↔ preview) works for the HTML preview (`MorphIframe`)
+but is a no-op for the q2-preview format (`ReactPreview` → `Q2PreviewIframe`).
+Two gaps:
+
+1. **No source-line attributes in the q2-preview DOM.** `MorphIframe` maps
+   editor line ↔ preview position via `data-loc="fileId:startLine:startCol-endLine:endCol"`
+   attributes the Rust HTML writer stamps on each element. The q2-preview React
+   renderer stamps only `data-sid` (and only under attribution). `findElementForLine`
+   has nothing to match.
+2. **No scroll plumbing on the React path.** `ReactPreview` never calls
+   `useScrollSync`; `Q2PreviewIframe` exposes no `scrollToLine`/`getScrollRatio`
+   handle and attaches no `scroll`/`click` listeners; `ReactRenderer` threads none.
+
+Per-node line numbers already ride the wire: `renderPageInProject` emits
+`include_inline_locations: true`, so every node carries an `l` field
+(`{f, b:{o,l,c}, e:{o,l,c}}`). The q2-preview iframe is `allow-same-origin`,
+so the parent can reach `contentDocument` directly and reuse `MorphIframe`'s
+exact scroll logic. **No Rust change, no new postMessage protocol.**
+
+Scope (confirmed with user): **block-level scroll sync only.** No inline
+granularity, no selection mirroring.
+
+## Design
+
+- `data-loc` must land on each leaf's **own** semantic element (no wrapper):
+  wrappers (even `display:contents` / `position:relative`) break theme CSS
+  child/adjacency/`:nth-child` selectors and margin collapse — a parity risk
+  this repo guards hard.
+- New helper `dataLocProps(node)` (framework) → `{ 'data-loc'?: string }`,
+  spread onto each q2-preview block leaf's root element.
+- Extract `parseDataLoc` / `findElementForLine` / `isElementVisible` into a
+  shared `iframe/scrollSyncDom.ts`; `MorphIframe` and `Q2PreviewIframe` both
+  import them.
+- `Q2PreviewIframe` gains a `ref` handle (`scrollToLine`, `getScrollRatio`)
+  + `onScroll`/`onClick` props, using direct same-origin `contentDocument`
+  access (mirrors `MorphIframe`).
+- `ReactRenderer` forwards the handle ref + callbacks to `Q2PreviewIframe`
+  (q2-preview branch only).
+- `ReactPreview` wires `useScrollSync` exactly like `Preview.tsx`.
+
+## Work Items
+
+### Phase 1 — data-loc emission (TDD)
+- [x] Test: `dataLocProps` returns correct string for node with `l`, `{}` without
+- [x] Test: Para/Header/CodeBlock/Div with `l` render `data-loc`; node without `l` has none
+- [x] Implement `framework/sourceLoc.ts` + export
+- [x] Spread `dataLocProps(node)` into block leaves: Para, Header, CodeBlock
+      (both paths), BulletList, OrderedList, BlockQuote, Div, HorizontalRule,
+      RawBlock, Figure, LineBlock, DefinitionList, Table (skipped Plain — Fragment)
+
+### Phase 2 — scroll plumbing (TDD where feasible)
+- [x] Test: `findElementForLine` / `parseDataLoc` in shared module (jsdom)
+- [x] Extract `iframe/scrollSyncDom.ts`; refactor `MorphIframe` to import
+- [x] `Q2PreviewIframe`: ref handle + scroll/click listeners (same-origin)
+- [x] `ReactRenderer`: thread ref + onScroll/onClick to Q2PreviewIframe
+- [x] `ReactPreview`: wire `useScrollSync`
+
+### Phase 3 — verify
+- [x] `npm run build` (production tsc -b + vite) green; WASM untouched (TS-only)
+- [x] vitest suites green (preview-renderer 186+192; hub-client 556 unit + 66 integ)
+- [x] Added pampa regression test proving real parser output carries `l` on
+      *block* nodes (`json_location_test::test_json_location_on_block_nodes`),
+      and jsdom tests proving the real `<Ast>` render stamps `data-loc` from it.
+      **NOT verified:** live browser scroll interaction (same-origin iframe DOM
+      access + Monaco cursor events) — needs a running hub + browser session.
+- [ ] changelog.md entry (two-commit workflow) — pending commit
+- [ ] beads bd-9kzfi close + sync — pending commit

--- a/crates/pampa/tests/integration/json_location_test.rs
+++ b/crates/pampa/tests/integration/json_location_test.rs
@@ -128,3 +128,38 @@ fn test_json_location_1_indexed() {
     assert_eq!(location["b"]["l"], 1);
     assert_eq!(location["b"]["c"], 1);
 }
+
+#[test]
+fn test_json_location_on_block_nodes() {
+    // q2-preview scroll sync (bd-9kzfi) stamps `data-loc` on block-level
+    // elements (Header, Para, ...), so block nodes — not just their
+    // inline children — must carry the resolved `l` field when
+    // include_inline_locations is on.
+    let input = "# Title\n\nA paragraph.";
+    let mut output = io::sink();
+
+    let (pandoc, context, _errors) =
+        qmd::read(input.as_bytes(), false, "test.qmd", &mut output, true, None)
+            .expect("Failed to parse QMD");
+
+    let mut buf = Vec::new();
+    let config = JsonConfig {
+        include_inline_locations: true,
+        ..JsonConfig::default()
+    };
+    write_with_config(&pandoc, &context, &mut buf, &config).expect("Failed to write JSON");
+
+    let json: serde_json::Value = serde_json::from_slice(&buf).expect("Invalid JSON");
+
+    // Header block carries its own location spanning the header line.
+    let header = &json["blocks"][0];
+    assert_eq!(header["t"], "Header");
+    assert_eq!(header["l"]["b"]["l"], 1);
+    assert_eq!(header["l"]["b"]["c"], 1);
+
+    // Para block on line 3 carries its own location.
+    let para = &json["blocks"][1];
+    assert_eq!(para["t"], "Para");
+    assert_eq!(para["l"]["b"]["l"], 3);
+    assert_eq!(para["l"]["b"]["c"], 1);
+}

--- a/hub-client/changelog.md
+++ b/hub-client/changelog.md
@@ -15,6 +15,10 @@ be in reverse chronological order (latest first).
 
 -->
 
+### 2026-06-24
+
+- [`160c6607`](https://github.com/quarto-dev/q2/commits/160c6607): The AST preview (q2-preview) now keeps editor↔preview scroll in sync — moving the cursor scrolls the preview to that block, and scrolling the preview tracks back to the editor.
+
 ### 2026-06-23
 
 - [`9a48dd86`](https://github.com/quarto-dev/q2/commits/9a48dd86): Added full-text search to the file sidebar — type in the search box to find files in the open project by content (with highlighted match snippets) and click a result to open it.

--- a/hub-client/src/components/Editor.tsx
+++ b/hub-client/src/components/Editor.tsx
@@ -300,6 +300,9 @@ export default function Editor({ project, files, fileContents, onDisconnect, onC
   // Preview scroll functions for external control (from MarkdownSummary / replay)
   const previewScrollToLineRef = useRef<((line: number) => void) | null>(null);
   const previewSetScrollRatioRef = useRef<((ratio: number) => void) | null>(null);
+  // q2-preview only: deferred scroll-to-line used by replay so scrubbing
+  // shares the render-deferred scroll mechanism of normal q2-preview editing.
+  const previewReplayScrollRef = useRef<((line: number) => void) | null>(null);
 
   // Editor drag-drop state for image insertion
   const [isEditorDragOver, setIsEditorDragOver] = useState(false);
@@ -373,6 +376,9 @@ export default function Editor({ project, files, fileContents, onDisconnect, onC
   const handleRegisterSetScrollRatio = useCallback((fn: (ratio: number) => void) => {
     previewSetScrollRatioRef.current = fn;
   }, []);
+  const handleRegisterReplayScroll = useCallback((fn: (line: number) => void) => {
+    previewReplayScrollRef.current = fn;
+  }, []);
 
   // Update document title based on current file and project
   useEffect(() => {
@@ -440,6 +446,10 @@ export default function Editor({ project, files, fileContents, onDisconnect, onC
           if (prevContent[ci] === '\n') changedLine++;
         }
         editor.revealLineInCenter(changedLine);
+        // q2-preview: scroll to the changed line through the same
+        // render-deferred mechanism as normal editing (no-op if the HTML
+        // preview is active, which uses the ratio path below instead).
+        previewReplayScrollRef.current?.(changedLine);
         requestAnimationFrame(() => {
           const maxScroll = editor.getScrollHeight() - editor.getLayoutInfo().height;
           if (maxScroll > 0) {
@@ -1089,6 +1099,7 @@ export default function Editor({ project, files, fileContents, onDisconnect, onC
             onWasmStatusChange={handleWasmStatusChange}
             onRegisterScrollToLine={handleRegisterScrollToLine}
             onRegisterSetScrollRatio={handleRegisterSetScrollRatio}
+            onRegisterReplayScroll={handleRegisterReplayScroll}
             onAstChange={handleAstChange}
             currentSlideIndex={currentSlideIndex}
             onSlideChange={handleSlideChange}

--- a/hub-client/src/components/render/PreviewRouter.tsx
+++ b/hub-client/src/components/render/PreviewRouter.tsx
@@ -25,6 +25,8 @@ interface PreviewRouterProps {
   onWasmStatusChange?: (status: 'loading' | 'ready' | 'error', error: string | null) => void;
   onRegisterScrollToLine?: (fn: (line: number) => void) => void;
   onRegisterSetScrollRatio?: (fn: (ratio: number) => void) => void;
+  /** q2-preview only: register a deferred scroll-to-line for replay scrubbing. */
+  onRegisterReplayScroll?: (fn: (line: number) => void) => void;
   onAstChange?: (astJson: string | null) => void;
   currentSlideIndex?: number;
   onSlideChange?: (slideIndex: number) => void;
@@ -137,7 +139,7 @@ export default function PreviewRouter(props: PreviewRouterProps) {
   // Render the appropriate preview component with shared WASM error banner.
   // `identities` and `attributionOn` are for ReactPreview only — Preview
   // doesn't know about either.
-  const { onRegisterScrollToLine, onRegisterSetScrollRatio, onFormatChange, onContentRewrite, fileContents, identities, attributionOn, onAttributionGeneratingChange, ...commonProps } = props;
+  const { onRegisterScrollToLine, onRegisterSetScrollRatio, onRegisterReplayScroll, onFormatChange, onContentRewrite, fileContents, identities, attributionOn, onAttributionGeneratingChange, ...commonProps } = props;
 
   return (
     <div style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
@@ -147,7 +149,7 @@ export default function PreviewRouter(props: PreviewRouterProps) {
       )}
       <div style={{ flex: 1, overflow: 'hidden' }}>
         {reactFormat ? (
-          <ReactPreview {...commonProps} onContentRewrite={onContentRewrite} fileContents={fileContents} format={reactFormat} identities={identities} attributionOn={attributionOn} onAttributionGeneratingChange={onAttributionGeneratingChange} />
+          <ReactPreview {...commonProps} onContentRewrite={onContentRewrite} fileContents={fileContents} format={reactFormat} identities={identities} attributionOn={attributionOn} onAttributionGeneratingChange={onAttributionGeneratingChange} onRegisterReplayScroll={onRegisterReplayScroll} />
         ) : (
           // Phase 9 Decision 6: pass `fileContents` so any sibling
           // edit (including `_quarto.yml`) triggers a re-render via

--- a/hub-client/src/components/render/ReactPreview.tsx
+++ b/hub-client/src/components/render/ReactPreview.tsx
@@ -20,6 +20,8 @@ import { useAttribution } from '../../hooks/useAttribution';
 import { stripAnsi } from '@quarto/preview-renderer/utils/stripAnsi';
 import { PreviewErrorOverlay } from '@quarto/preview-renderer/overlays/PreviewErrorOverlay';
 import { usePreference } from '../../hooks/usePreference';
+import { useScrollSync } from '../../hooks/useScrollSync';
+import type { Q2PreviewIframeHandle } from '@quarto/preview-renderer/iframe/Q2PreviewIframe';
 import ReactRenderer from './ReactRenderer';
 
 /**
@@ -407,6 +409,9 @@ export default function ReactPreview({
   files,
   fileContents,
   scrollSyncEnabled,
+  editorRef,
+  editorReady,
+  editorHasFocusRef,
   onFileChange,
   onOpenNewFileDialog,
   onDiagnosticsChange,
@@ -463,6 +468,24 @@ export default function ReactPreview({
       ),
     [unlockNestingCursor, rendered.renderedContent, rendered.untransformedAstJson],
   );
+
+  // Scroll sync (editor ↔ preview). Mirrors `Preview.tsx`: the q2-preview
+  // iframe exposes `scrollToLine` / `getScrollRatio` via this handle, and
+  // forwards its own scroll/click events through `handlePreviewScroll` /
+  // `handlePreviewClick`. Only the q2-preview format wires this; other
+  // React formats (q2-debug, slides) leave the handle unattached.
+  const previewScrollRef = useRef<Q2PreviewIframeHandle>(null);
+  const { handlePreviewScroll, handlePreviewClick } = useScrollSync({
+    editorRef,
+    scrollPreviewToLine: (line: number) => {
+      previewScrollRef.current?.scrollToLine(line);
+    },
+    getPreviewScrollRatio: () => {
+      return previewScrollRef.current?.getScrollRatio() ?? null;
+    },
+    enabled: scrollSyncEnabled && editorReady,
+    editorHasFocusRef,
+  });
 
   // Three-way theme fingerprint (Plan 2A item 11):
   //   `undefined` → pre-first-render or render failed; iframe keeps
@@ -771,6 +794,9 @@ export default function ReactPreview({
             currentActor={getActorId()}
             unlockNestingCursor={unlockNestingCursor}
             nestedEditBuffers={nestedEditBuffers}
+            scrollHandleRef={previewScrollRef}
+            onPreviewScroll={handlePreviewScroll}
+            onPreviewClick={handlePreviewClick}
           />
         ) : previewState === 'ERROR_AT_START' && currentError ? (
           <div style={{ padding: '20px', color: 'red' }}>

--- a/hub-client/src/components/render/ReactPreview.tsx
+++ b/hub-client/src/components/render/ReactPreview.tsx
@@ -94,6 +94,13 @@ interface PreviewProps {
   currentSlideIndex?: number;
   onSlideChange?: (slideIndex: number) => void;
   onContentRewrite: (content: string) => void;
+  /**
+   * Register a deferred scroll-to-line with the parent (Editor.tsx) for
+   * replay. Scrubbing history scrolls the preview to the changed line through
+   * the same render-deferred mechanism as normal q2-preview editing, so it
+   * lands once against the fresh DOM instead of racing the async render.
+   */
+  onRegisterReplayScroll?: (fn: (line: number) => void) => void;
   format: string; // 'q2-slides', 'q2-debug', or 'q2-preview'
   /**
    * Automerge actor → display identity (name + colour). Consumed
@@ -419,6 +426,7 @@ export default function ReactPreview({
   currentSlideIndex,
   onSlideChange,
   onContentRewrite,
+  onRegisterReplayScroll,
   format,
   identities,
   attributionOn,
@@ -475,7 +483,8 @@ export default function ReactPreview({
   // `handlePreviewClick`. Only the q2-preview format wires this; other
   // React formats (q2-debug, slides) leave the handle unattached.
   const previewScrollRef = useRef<Q2PreviewIframeHandle>(null);
-  const { handlePreviewScroll, handlePreviewClick } = useScrollSync({
+
+  const { handlePreviewScroll, handlePreviewClick, handleAstRendered, scrollToLineDeferred } = useScrollSync({
     editorRef,
     scrollPreviewToLine: (line: number) => {
       previewScrollRef.current?.scrollToLine(line);
@@ -485,7 +494,17 @@ export default function ReactPreview({
     },
     enabled: scrollSyncEnabled && editorReady,
     editorHasFocusRef,
+    deferToRender: true,
   });
+
+  // Register the deferred scroll-to-line with the parent (Editor.tsx) so
+  // replay scrubbing scrolls the preview to the changed line through the same
+  // render-deferred mechanism as normal q2-preview editing.
+  useEffect(() => {
+    onRegisterReplayScroll?.((line: number) => {
+      scrollToLineDeferred(line);
+    });
+  }, [onRegisterReplayScroll, scrollToLineDeferred]);
 
   // Three-way theme fingerprint (Plan 2A item 11):
   //   `undefined` → pre-first-render or render failed; iframe keeps
@@ -797,6 +816,7 @@ export default function ReactPreview({
             scrollHandleRef={previewScrollRef}
             onPreviewScroll={handlePreviewScroll}
             onPreviewClick={handlePreviewClick}
+            onAstRendered={handleAstRendered}
           />
         ) : previewState === 'ERROR_AT_START' && currentError ? (
           <div style={{ padding: '20px', color: 'red' }}>

--- a/hub-client/src/components/render/ReactRenderer.tsx
+++ b/hub-client/src/components/render/ReactRenderer.tsx
@@ -125,6 +125,7 @@ interface ReactRendererProps {
   scrollHandleRef?: Ref<Q2PreviewIframeHandle>;
   onPreviewScroll?: () => void;
   onPreviewClick?: () => void;
+  onAstRendered?: () => void;
 }
 
 /**
@@ -152,6 +153,7 @@ function ReactRenderer({
   scrollHandleRef,
   onPreviewScroll,
   onPreviewClick,
+  onAstRendered,
 }: ReactRendererProps) {
   // Stable wrappers for Q2PreviewIframe props that are useEffect dependencies.
   //
@@ -318,6 +320,7 @@ function ReactRenderer({
             scrollHandleRef={scrollHandleRef}
             onScroll={onPreviewScroll}
             onClick={onPreviewClick}
+            onAstRendered={onAstRendered}
           />
         </div>
       </ErrorBoundary>

--- a/hub-client/src/components/render/ReactRenderer.tsx
+++ b/hub-client/src/components/render/ReactRenderer.tsx
@@ -1,8 +1,8 @@
 import { useMemo, useRef, useCallback, Component } from 'react';
-import type { ReactNode } from 'react';
+import type { ReactNode, Ref } from 'react';
 import type { FileEntry } from '@quarto/preview-renderer/types/project';
 import { Q2DebugIframe } from './q2-debug/Q2DebugIframe';
-import { Q2PreviewIframe } from '@quarto/preview-renderer/iframe/Q2PreviewIframe';
+import { Q2PreviewIframe, type Q2PreviewIframeHandle } from '@quarto/preview-renderer/iframe/Q2PreviewIframe';
 import { Q2RawIframe } from './q2-raw/Q2RawIframe';
 import { SlideAst } from './ReactAstSlideRenderer';
 import { transpileTSX } from '../../services/tsxTranspiler';
@@ -117,6 +117,14 @@ interface ReactRendererProps {
    * `unlockNestingCursor`). Forwarded to `Q2PreviewIframe` only.
    */
   nestedEditBuffers?: Record<string, string>;
+  /**
+   * Scroll-sync wiring, forwarded to `Q2PreviewIframe` only (the
+   * q2-preview format). The other formats (q2-debug, q2-slides,
+   * revealjs) don't participate in editor↔preview scroll sync.
+   */
+  scrollHandleRef?: Ref<Q2PreviewIframeHandle>;
+  onPreviewScroll?: () => void;
+  onPreviewClick?: () => void;
 }
 
 /**
@@ -141,6 +149,9 @@ function ReactRenderer({
   currentActor,
   unlockNestingCursor,
   nestedEditBuffers,
+  scrollHandleRef,
+  onPreviewScroll,
+  onPreviewClick,
 }: ReactRendererProps) {
   // Stable wrappers for Q2PreviewIframe props that are useEffect dependencies.
   //
@@ -304,6 +315,9 @@ function ReactRenderer({
             nestedEditBuffers={nestedEditBuffers}
             currentSlideIndex={currentSlideIndex}
             onSlideChange={onSlideChange}
+            scrollHandleRef={scrollHandleRef}
+            onScroll={onPreviewScroll}
+            onClick={onPreviewClick}
           />
         </div>
       </ErrorBoundary>

--- a/hub-client/src/hooks/useScrollSync.test.ts
+++ b/hub-client/src/hooks/useScrollSync.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Tests for useScrollSync — focused on the deferred editor→preview scroll.
+ * The editor cursor moves the instant a keystroke lands, but the preview DOM
+ * only carries fresh `data-loc` once the async render commits. So (with
+ * `deferToRender`, the q2-preview path) a cursor move during an edit defers its
+ * scroll until the iframe reports `AST_RENDERED` (`handleAstRendered`) — firing
+ * once, against the fresh DOM. Pure navigation flushes on the debounce. The
+ * HTML preview leaves `deferToRender` off and scrolls immediately.
+ * `scrollToLineDeferred` lets replay drive the same mechanism with an explicit
+ * line.
+ *
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import type { RefObject } from 'react';
+import type * as Monaco from 'monaco-editor';
+import { useScrollSync } from './useScrollSync';
+
+// Matches RENDER_SETTLE_TIMEOUT_MS in useScrollSync.
+const RENDER_SETTLE_TIMEOUT_MS = 1000;
+
+function makeEditor(line: number) {
+  let cursorCb: () => void = () => {};
+  let contentCb: () => void = () => {};
+  const editor = {
+    getPosition: () => ({ lineNumber: line, column: 1 }),
+    getScrollHeight: () => 1000,
+    getLayoutInfo: () => ({ height: 400 }),
+    setScrollTop: vi.fn(),
+    onDidChangeCursorPosition: (cb: () => void) => {
+      cursorCb = cb;
+      return { dispose: vi.fn() };
+    },
+    onDidChangeModelContent: (cb: () => void) => {
+      contentCb = cb;
+      return { dispose: vi.fn() };
+    },
+  } as unknown as Monaco.editor.IStandaloneCodeEditor;
+  return {
+    editor,
+    fireCursorChange: () => cursorCb(),
+    fireContentChange: () => contentCb(),
+  };
+}
+
+function setup(opts: { line: number; focus: boolean; deferToRender?: boolean }) {
+  const { editor, fireCursorChange, fireContentChange } = makeEditor(opts.line);
+  const editorRef = { current: editor } as RefObject<Monaco.editor.IStandaloneCodeEditor | null>;
+  const editorHasFocusRef = { current: opts.focus } as RefObject<boolean>;
+  const scrollPreviewToLine = vi.fn();
+  const getPreviewScrollRatio = vi.fn(() => 0.5);
+
+  const { result } = renderHook(() =>
+    useScrollSync({
+      editorRef,
+      scrollPreviewToLine,
+      getPreviewScrollRatio,
+      enabled: true,
+      editorHasFocusRef,
+      deferToRender: opts.deferToRender ?? true,
+    }),
+  );
+
+  return { result, scrollPreviewToLine, fireCursorChange, fireContentChange, editorHasFocusRef };
+}
+
+describe('useScrollSync deferred editor→preview scroll', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('navigation: flushes on the debounce when no edit is in flight', () => {
+    const { scrollPreviewToLine, fireCursorChange } = setup({ line: 12, focus: true });
+    act(() => { fireCursorChange(); vi.advanceTimersByTime(50); });
+    expect(scrollPreviewToLine).toHaveBeenCalledExactlyOnceWith(12);
+  });
+
+  it('edit: defers past the debounce, then scrolls once when the render reports back', () => {
+    const { scrollPreviewToLine, fireCursorChange, fireContentChange, result } =
+      setup({ line: 42, focus: true });
+    // A keystroke: content changes and the cursor moves.
+    act(() => { fireContentChange(); fireCursorChange(); vi.advanceTimersByTime(50); });
+    // The debounce elapsed but a render is pending, so nothing scrolled yet.
+    expect(scrollPreviewToLine).not.toHaveBeenCalled();
+    // Render committed → scroll exactly once, against the fresh DOM.
+    act(() => { result.current.handleAstRendered(); });
+    expect(scrollPreviewToLine).toHaveBeenCalledExactlyOnceWith(42);
+    // A subsequent render with no new cursor move must not scroll again.
+    act(() => { result.current.handleAstRendered(); });
+    expect(scrollPreviewToLine).toHaveBeenCalledTimes(1);
+  });
+
+  it('does nothing on AST_RENDERED when no cursor move is pending', () => {
+    const { scrollPreviewToLine, result } = setup({ line: 5, focus: true });
+    act(() => { result.current.handleAstRendered(); });
+    expect(scrollPreviewToLine).not.toHaveBeenCalled();
+  });
+
+  it('does not scroll on a cursor move when the editor is not focused', () => {
+    const { scrollPreviewToLine, fireCursorChange } = setup({ line: 9, focus: false });
+    act(() => { fireCursorChange(); vi.advanceTimersByTime(50); });
+    expect(scrollPreviewToLine).not.toHaveBeenCalled();
+  });
+
+  it('safety: flushes a deferred scroll if the render never reports back', () => {
+    const { scrollPreviewToLine, fireCursorChange, fireContentChange } =
+      setup({ line: 7, focus: true });
+    act(() => { fireContentChange(); fireCursorChange(); vi.advanceTimersByTime(50); });
+    expect(scrollPreviewToLine).not.toHaveBeenCalled();
+    act(() => { vi.advanceTimersByTime(RENDER_SETTLE_TIMEOUT_MS); });
+    expect(scrollPreviewToLine).toHaveBeenCalledExactlyOnceWith(7);
+  });
+
+  it('scrollToLineDeferred (replay): waits for the render, scrolls to the explicit line, not focus-gated', () => {
+    // Replay: editor is not focused, content changed, then replay asks to
+    // scroll to the changed line. It must defer to the render and target the
+    // explicit line (not the cursor), despite the editor lacking focus.
+    const { scrollPreviewToLine, fireContentChange, result } =
+      setup({ line: 1, focus: false });
+    act(() => { fireContentChange(); result.current.scrollToLineDeferred(73); });
+    expect(scrollPreviewToLine).not.toHaveBeenCalled();
+    act(() => { result.current.handleAstRendered(); });
+    expect(scrollPreviewToLine).toHaveBeenCalledExactlyOnceWith(73);
+  });
+
+  it('HTML path (deferToRender: false): scrolls immediately on cursor move, no render wait', () => {
+    const { scrollPreviewToLine, fireCursorChange } =
+      setup({ line: 20, focus: true, deferToRender: false });
+    act(() => { fireCursorChange(); vi.advanceTimersByTime(50); });
+    expect(scrollPreviewToLine).toHaveBeenCalledExactlyOnceWith(20);
+  });
+});

--- a/hub-client/src/hooks/useScrollSync.ts
+++ b/hub-client/src/hooks/useScrollSync.ts
@@ -6,6 +6,15 @@
  * - Preview → Editor: Scroll in preview scrolls editor viewport (without moving cursor)
  * - 50ms debounce to prevent jitter
  * - Graceful degradation when source locations unavailable
+ *
+ * Editor → Preview can be *deferred* (`deferToRender`): the cursor moves the
+ * instant a keystroke lands, but fresh `data-loc` only reaches the preview DOM
+ * once the async render commits. For the q2-preview path (whose iframe posts
+ * `AST_RENDERED`), a cursor move during an edit defers its scroll until that
+ * signal (`handleAstRendered`) — firing once, against the fresh DOM. The HTML
+ * preview has no such signal, so it leaves `deferToRender` off and scrolls
+ * immediately. `scrollToLineDeferred` lets replay drive the same deferred
+ * mechanism with an explicit line instead of the cursor.
  */
 
 import { useEffect, useRef, useCallback } from 'react';
@@ -23,6 +32,13 @@ interface UseScrollSyncOptions {
   enabled: boolean;
   /** Reference tracking whether editor has focus (to prevent feedback loop) */
   editorHasFocusRef: RefObject<boolean>;
+  /**
+   * Defer editor→preview scroll until the preview reports it committed a new
+   * AST (`handleAstRendered`). True for q2-preview, whose iframe posts
+   * `AST_RENDERED`; left false for the HTML preview, which has no such signal
+   * and scrolls immediately on cursor move (its DOM is already current).
+   */
+  deferToRender?: boolean;
 }
 
 /**
@@ -31,7 +47,27 @@ interface UseScrollSyncOptions {
 interface UseScrollSyncReturn {
   handlePreviewScroll: () => void;
   handlePreviewClick: () => void;
+  /**
+   * Call when the preview iframe reports it committed a new AST
+   * (`AST_RENDERED`). Flushes any editor→preview scroll deferred while the
+   * render was in flight — once, against the up-to-date DOM. A no-op when no
+   * scroll is pending (so a collaborator's render never yanks).
+   */
+  handleAstRendered: () => void;
+  /**
+   * Scroll the preview to an explicit line, deferred to the next render the
+   * same way cursor-driven sync is. Replay uses this so history scrubbing
+   * shares the q2-preview scroll mechanism rather than a separate ratio path.
+   * Programmatic, so unlike the cursor path it isn't gated on editor focus.
+   */
+  scrollToLineDeferred: (line: number) => void;
 }
+
+// A render that never reports back must not strand a deferred scroll: an edit
+// that errored produces no `AST_RENDERED`, and an edit that doesn't change the
+// AST produces no iframe re-render either. After this long we give up waiting
+// and scroll against whatever DOM is current (the last-good one).
+const RENDER_SETTLE_TIMEOUT_MS = 1000;
 
 /**
  * Hook for bidirectional scroll synchronization between Monaco editor and preview iframe.
@@ -43,6 +79,7 @@ export function useScrollSync({
   getPreviewScrollRatio,
   enabled,
   editorHasFocusRef,
+  deferToRender = false,
 }: UseScrollSyncOptions): UseScrollSyncReturn {
   // Track if we're currently syncing to prevent feedback loops
   const isSyncingRef = useRef(false);
@@ -51,35 +88,78 @@ export function useScrollSync({
   const editorDebounceRef = useRef<number | null>(null);
   const previewDebounceRef = useRef<number | null>(null);
 
-  // Editor → Preview sync
-  const syncEditorToPreview = useCallback(() => {
-    if (!enabled || isSyncingRef.current) return;
+  // A scroll is pending, awaiting flush. `pendingTargetRef` holds an explicit
+  // target line (scrollToLineDeferred / replay); null means "use the cursor".
+  const pendingScrollRef = useRef(false);
+  const pendingTargetRef = useRef<number | null>(null);
+  // An edit changed the content, so a render (→ AST_RENDERED) is expected; a
+  // pending scroll defers until the fresh data-loc DOM exists. Only tracked
+  // when deferToRender is on.
+  const renderPendingRef = useRef(false);
+  // Safety timer that bounds the above deferral (see RENDER_SETTLE_TIMEOUT_MS).
+  const renderWaitRef = useRef<number | null>(null);
 
+  // Latest option callbacks held in refs so the returned handlers keep a
+  // stable identity. `handleAstRendered` feeds Q2PreviewIframe's message
+  // listener deps; a churning identity re-subscribes that window listener and
+  // can drop a postMessage racing the swap.
+  const scrollPreviewToLineRef = useRef(scrollPreviewToLine);
+  const getPreviewScrollRatioRef = useRef(getPreviewScrollRatio);
+  const enabledRef = useRef(enabled);
+  scrollPreviewToLineRef.current = scrollPreviewToLine;
+  getPreviewScrollRatioRef.current = getPreviewScrollRatio;
+  enabledRef.current = enabled;
+
+  const clearRenderWait = useCallback(() => {
+    if (renderWaitRef.current != null) {
+      clearTimeout(renderWaitRef.current);
+      renderWaitRef.current = null;
+    }
+  }, []);
+
+  // Flush a pending editor→preview scroll. An explicit target
+  // (scrollToLineDeferred, used by replay) is programmatic and not focus-gated;
+  // a cursor-driven scroll is dropped if focus moved to the preview, which is
+  // then the active surface (preview→editor).
+  const flushPendingScroll = useCallback(() => {
+    if (!pendingScrollRef.current) return;
+    pendingScrollRef.current = false;
+    clearRenderWait();
+
+    const target = pendingTargetRef.current;
+    pendingTargetRef.current = null;
+
+    if (!enabledRef.current) return;
     const editor = editorRef.current;
     if (!editor) return;
 
-    const position = editor.getPosition();
-    if (!position) return;
-
-    const line = position.lineNumber;
+    let line: number;
+    if (target != null) {
+      line = target;
+    } else {
+      if (!editorHasFocusRef.current) return;
+      const position = editor.getPosition();
+      if (!position) return;
+      line = position.lineNumber;
+    }
 
     isSyncingRef.current = true;
-    scrollPreviewToLine(line);
+    scrollPreviewToLineRef.current(line);
     // Reset syncing flag after animation completes
     setTimeout(() => {
       isSyncingRef.current = false;
     }, 300);
-  }, [enabled, editorRef, scrollPreviewToLine]);
+  }, [clearRenderWait, editorRef, editorHasFocusRef]);
 
   // Preview → Editor sync (using scroll ratio matching)
   const syncPreviewToEditor = useCallback(() => {
     // Skip if disabled, already syncing, or editor has focus (prevents feedback loop)
-    if (!enabled || isSyncingRef.current || editorHasFocusRef.current) return;
+    if (!enabledRef.current || isSyncingRef.current || editorHasFocusRef.current) return;
 
     const editor = editorRef.current;
     if (!editor) return;
 
-    const scrollRatio = getPreviewScrollRatio();
+    const scrollRatio = getPreviewScrollRatioRef.current();
     if (scrollRatio === null) return;
 
     // Apply same ratio to editor
@@ -95,32 +175,55 @@ export function useScrollSync({
     setTimeout(() => {
       isSyncingRef.current = false;
     }, 300); // Longer timeout to account for smooth animation
-  }, [enabled, editorRef, getPreviewScrollRatio, editorHasFocusRef]);
+  }, [editorRef, editorHasFocusRef]);
 
-  // Set up editor cursor position listener
+  // Editor cursor + (q2 only) content listeners. A cursor move marks a pending
+  // scroll; when deferToRender is on, a content change marks a render as
+  // expected so the debounce defers to the post-render flush (one scroll,
+  // fresh DOM). The HTML preview leaves deferToRender off and flushes on the
+  // debounce, since its DOM is already current.
   useEffect(() => {
     if (!enabled) return;
 
     const editor = editorRef.current;
     if (!editor) return;
 
-    const disposable = editor.onDidChangeCursorPosition(() => {
-      // Debounce
+    const cursorDisposable = editor.onDidChangeCursorPosition(() => {
+      pendingScrollRef.current = true;
+      pendingTargetRef.current = null;
       if (editorDebounceRef.current) {
         clearTimeout(editorDebounceRef.current);
       }
       editorDebounceRef.current = window.setTimeout(() => {
-        syncEditorToPreview();
+        // An edit is in flight — the DOM is about to change. Let the
+        // post-render flush (handleAstRendered) do the single scroll.
+        if (deferToRender && renderPendingRef.current) return;
+        flushPendingScroll();
       }, 50);
     });
 
+    let contentDisposable: Monaco.IDisposable | undefined;
+    if (deferToRender) {
+      contentDisposable = editor.onDidChangeModelContent(() => {
+        renderPendingRef.current = true;
+        clearRenderWait();
+        renderWaitRef.current = window.setTimeout(() => {
+          renderWaitRef.current = null;
+          renderPendingRef.current = false;
+          flushPendingScroll();
+        }, RENDER_SETTLE_TIMEOUT_MS);
+      });
+    }
+
     return () => {
-      disposable.dispose();
+      cursorDisposable.dispose();
+      contentDisposable?.dispose();
       if (editorDebounceRef.current) {
         clearTimeout(editorDebounceRef.current);
       }
+      clearRenderWait();
     };
-  }, [enabled, editorRef, syncEditorToPreview]);
+  }, [enabled, editorRef, deferToRender, flushPendingScroll, clearRenderWait]);
 
   // Debounced preview scroll handler
   const handlePreviewScroll = useCallback(() => {
@@ -138,6 +241,29 @@ export function useScrollSync({
     syncPreviewToEditor();
   }, [syncPreviewToEditor]);
 
+  // The preview iframe committed a new AST: fresh data-loc DOM is in place,
+  // so flush the deferred editor→preview scroll once.
+  const handleAstRendered = useCallback(() => {
+    renderPendingRef.current = false;
+    flushPendingScroll();
+  }, [flushPendingScroll]);
+
+  // Scroll to an explicit line, deferred the same way the cursor path is.
+  // If a render is in flight (deferToRender), the AST_RENDERED / safety flush
+  // handles it; otherwise flush on the debounce against the current DOM.
+  const scrollToLineDeferred = useCallback((line: number) => {
+    if (!enabledRef.current) return;
+    pendingScrollRef.current = true;
+    pendingTargetRef.current = line;
+    if (deferToRender && renderPendingRef.current) return;
+    if (editorDebounceRef.current) {
+      clearTimeout(editorDebounceRef.current);
+    }
+    editorDebounceRef.current = window.setTimeout(() => {
+      flushPendingScroll();
+    }, 50);
+  }, [deferToRender, flushPendingScroll]);
+
   // Cleanup debounce timer on unmount
   useEffect(() => {
     return () => {
@@ -150,5 +276,7 @@ export function useScrollSync({
   return {
     handlePreviewScroll,
     handlePreviewClick,
+    handleAstRendered,
+    scrollToLineDeferred,
   };
 }

--- a/ts-packages/preview-renderer/src/framework/index.ts
+++ b/ts-packages/preview-renderer/src/framework/index.ts
@@ -19,6 +19,7 @@ export {
 export { Ast } from './Ast';
 export { liItemAttrProps } from './listItemAttr';
 export { Node, renderChildren, renderNode, blockTypes } from './dispatch';
+export { dataLocProps } from './sourceLoc';
 export * from './plainText';
 export * from './meta';
 export * from './customNode';

--- a/ts-packages/preview-renderer/src/framework/sourceLoc.test.ts
+++ b/ts-packages/preview-renderer/src/framework/sourceLoc.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { dataLocProps } from './sourceLoc';
+
+describe('dataLocProps', () => {
+    it('formats the node `l` field as fileId:startLine:startCol-endLine:endCol', () => {
+        const node = {
+            t: 'Para',
+            c: [],
+            l: {
+                f: 0,
+                b: { o: 12, l: 3, c: 1 },
+                e: { o: 41, l: 5, c: 18 },
+            },
+        };
+        expect(dataLocProps(node)).toEqual({ 'data-loc': '0:3:1-5:18' });
+    });
+
+    it('uses the non-zero file id when present', () => {
+        const node = {
+            l: { f: 7, b: { o: 0, l: 1, c: 1 }, e: { o: 4, l: 1, c: 5 } },
+        };
+        expect(dataLocProps(node)).toEqual({ 'data-loc': '7:1:1-1:5' });
+    });
+
+    it('returns an empty object when the node has no `l` field', () => {
+        expect(dataLocProps({ t: 'Para', c: [] })).toEqual({});
+    });
+
+    it('returns an empty object for null / non-object input', () => {
+        expect(dataLocProps(null)).toEqual({});
+        expect(dataLocProps(undefined)).toEqual({});
+    });
+
+    it('returns an empty object when `l` is malformed (missing begin/end)', () => {
+        expect(dataLocProps({ l: { f: 0 } })).toEqual({});
+        expect(dataLocProps({ l: { f: 0, b: { o: 0, l: 1, c: 1 } } })).toEqual({});
+    });
+});

--- a/ts-packages/preview-renderer/src/framework/sourceLoc.ts
+++ b/ts-packages/preview-renderer/src/framework/sourceLoc.ts
@@ -1,0 +1,30 @@
+/**
+ * Source-location DOM attribute for scroll sync.
+ *
+ * The Rust JSON writer emits an `l` field on each node when
+ * `include_inline_locations` is on (always true for q2-preview — see
+ * `crates/quarto-core/src/pipeline.rs`). Its shape mirrors
+ * `resolve_location` in `crates/pampa/src/writers/json.rs`:
+ *
+ *   l: { f: fileId, b: { o, l, c }, e: { o, l, c } }   // 1-based l/c
+ *
+ * `dataLocProps` turns that into the `data-loc` attribute the iframe
+ * scroll-sync code matches on (`scrollSyncDom.ts`'s `parseDataLoc`),
+ * using the same `fileId:startLine:startCol-endLine:endCol` format the
+ * native HTML writer stamps. Returns `{}` for nodes without a
+ * resolvable location, so spreading the result is always safe.
+ */
+
+interface ResolvedLoc {
+    f: number;
+    b: { o: number; l: number; c: number };
+    e: { o: number; l: number; c: number };
+}
+
+export function dataLocProps(node: unknown): { 'data-loc'?: string } {
+    const loc = (node as { l?: ResolvedLoc } | null | undefined)?.l;
+    if (!loc || !loc.b || !loc.e) return {};
+    return {
+        'data-loc': `${loc.f}:${loc.b.l}:${loc.b.c}-${loc.e.l}:${loc.e.c}`,
+    };
+}

--- a/ts-packages/preview-renderer/src/iframe/MorphIframe.tsx
+++ b/ts-packages/preview-renderer/src/iframe/MorphIframe.tsx
@@ -2,6 +2,12 @@ import { useRef, useEffect, useCallback, useImperativeHandle } from 'react';
 import type { Ref } from 'react';
 import morphdom from 'morphdom';
 import { postProcessIframe } from '../utils/iframePostProcessor';
+import {
+  parseDataLoc,
+  findElementForLine,
+  isElementVisible,
+  type SourceLocation,
+} from './scrollSyncDom';
 
 // Methods exposed via ref
 export interface MorphIframeHandle {
@@ -37,77 +43,10 @@ interface MorphIframeProps {
   ref: Ref<MorphIframeHandle>;
 }
 
-/**
- * Parsed source location from data-loc attribute.
- * Format: "fileId:startLine:startCol-endLine:endCol" (1-based)
- */
-export interface SourceLocation {
-  fileId: number;
-  startLine: number;
-  startCol: number;
-  endLine: number;
-  endCol: number;
-}
-
-/**
- * Parse a data-loc attribute string into a SourceLocation object.
- * Returns null if the format is invalid.
- */
-function parseDataLoc(dataLoc: string): SourceLocation | null {
-  const match = dataLoc.match(/^(\d+):(\d+):(\d+)-(\d+):(\d+)$/);
-  if (!match) return null;
-  return {
-    fileId: parseInt(match[1], 10),
-    startLine: parseInt(match[2], 10),
-    startCol: parseInt(match[3], 10),
-    endLine: parseInt(match[4], 10),
-    endCol: parseInt(match[5], 10),
-  };
-}
-
-/**
- * Find the best matching element for a given line number.
- * Prefers the most specific (smallest range) match.
- */
-function findElementForLine(
-  doc: Document,
-  line: number
-): HTMLElement | null {
-  const elements = doc.querySelectorAll('[data-loc]');
-  let bestMatch: HTMLElement | null = null;
-  let bestRangeSize = Infinity;
-
-  for (const element of elements) {
-    const dataLoc = element.getAttribute('data-loc');
-    if (!dataLoc) continue;
-
-    const loc = parseDataLoc(dataLoc);
-    if (!loc) continue;
-
-    // Check if line is within this element's range
-    if (line >= loc.startLine && line <= loc.endLine) {
-      const rangeSize = loc.endLine - loc.startLine;
-      // Prefer smaller (more specific) ranges
-      if (rangeSize < bestRangeSize) {
-        bestMatch = element as HTMLElement;
-        bestRangeSize = rangeSize;
-      }
-    }
-  }
-
-  return bestMatch;
-}
-
-/**
- * Check if an element is fully visible in the viewport.
- */
-function isElementVisible(element: HTMLElement): boolean {
-  const rect = element.getBoundingClientRect();
-  const viewportHeight = window.innerHeight;
-
-  // Element is visible if it's within the viewport bounds
-  return rect.top >= 0 && rect.bottom <= viewportHeight;
-}
+// `SourceLocation`, `parseDataLoc`, `findElementForLine`, and
+// `isElementVisible` are shared with `Q2PreviewIframe` via
+// `./scrollSyncDom`. The position-comparison + offset helpers below
+// are selection-sync specific and stay local.
 
 /**
  * Check if a position (line, col) is within or after the start of a data-loc range.
@@ -362,13 +301,14 @@ function MorphIframe({
     scrollToLine: (line: number) => {
       const iframe = iframeRef.current;
       const doc = iframe?.contentDocument;
-      if (!doc) return;
+      const win = iframe?.contentWindow;
+      if (!doc || !win) return;
 
       const element = findElementForLine(doc, line);
       if (!element) return;
 
       // Only scroll if element is not already visible
-      if (!isElementVisible(element)) {
+      if (!isElementVisible(element, win)) {
         element.scrollIntoView({ behavior: 'smooth', block: 'center' });
       }
     },

--- a/ts-packages/preview-renderer/src/iframe/MorphIframe.tsx
+++ b/ts-packages/preview-renderer/src/iframe/MorphIframe.tsx
@@ -6,6 +6,7 @@ import {
   parseDataLoc,
   findElementForLine,
   isElementVisible,
+  computeScrollRatio,
   type SourceLocation,
 } from './scrollSyncDom';
 
@@ -314,21 +315,10 @@ function MorphIframe({
     },
     getScrollRatio: () => {
       const iframe = iframeRef.current;
-      if (!iframe?.contentWindow || !iframe?.contentDocument) return null;
-
-      const iframeWindow = iframe.contentWindow;
-      const iframeDoc = iframe.contentDocument;
-
-      // Calculate preview scroll ratio (0 = top, 1 = bottom)
-      const previewScrollY = iframeWindow.scrollY;
-      const previewScrollHeight = iframeDoc.documentElement.scrollHeight;
-      const previewViewportHeight = iframeWindow.innerHeight;
-      const previewMaxScroll = previewScrollHeight - previewViewportHeight;
-
-      // Avoid division by zero for short documents
-      if (previewMaxScroll <= 0) return 0;
-
-      return previewScrollY / previewMaxScroll;
+      const win = iframe?.contentWindow;
+      const doc = iframe?.contentDocument;
+      if (!win || !doc) return null;
+      return computeScrollRatio(win, doc);
     },
     setScrollRatio: (ratio: number) => {
       const iframe = iframeRef.current;

--- a/ts-packages/preview-renderer/src/iframe/MorphIframe.tsx
+++ b/ts-packages/preview-renderer/src/iframe/MorphIframe.tsx
@@ -1,12 +1,11 @@
-import { useRef, useEffect, useCallback, useImperativeHandle } from 'react';
+import { useRef, useEffect, useCallback, useImperativeHandle, useState } from 'react';
 import type { Ref } from 'react';
 import morphdom from 'morphdom';
 import { postProcessIframe } from '../utils/iframePostProcessor';
 import {
   parseDataLoc,
-  findElementForLine,
-  isElementVisible,
-  computeScrollRatio,
+  scrollIframeToLine,
+  getIframeScrollRatio,
   type SourceLocation,
 } from './scrollSyncDom';
 
@@ -44,10 +43,10 @@ interface MorphIframeProps {
   ref: Ref<MorphIframeHandle>;
 }
 
-// `SourceLocation`, `parseDataLoc`, `findElementForLine`, and
-// `isElementVisible` are shared with `Q2PreviewIframe` via
-// `./scrollSyncDom`. The position-comparison + offset helpers below
-// are selection-sync specific and stay local.
+// The scroll-sync handle methods (`scrollIframeToLine`, `getIframeScrollRatio`)
+// and `SourceLocation`/`parseDataLoc` are shared with `Q2PreviewIframe` via
+// `./scrollSyncDom`. The position-comparison + offset helpers below are
+// selection-sync specific and stay local.
 
 /**
  * Check if a position (line, col) is within or after the start of a data-loc range.
@@ -189,6 +188,12 @@ function MorphIframe({
 }: MorphIframeProps) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const isInitializedRef = useRef(false);
+  // Flips true once the `srcdoc` load settles. The initial load replaces the
+  // iframe's contentWindow/contentDocument asynchronously, so the scroll /
+  // click / selectionchange listeners must (re)attach to the *settled*
+  // document — not the pre-load one present at mount. Parallels
+  // Q2PreviewIframe's `iframeReady` gate.
+  const [documentReady, setDocumentReady] = useState(false);
 
   // Scroll the preview to an anchor element
   const scrollToAnchor = useCallback((anchor: string) => {
@@ -256,6 +261,9 @@ function MorphIframe({
       const handleLoad = () => {
         isInitializedRef.current = true;
         internalPostProcess(iframe);
+        // The settled document now exists; let the listener effect re-run and
+        // attach scroll / click / selectionchange to it.
+        setDocumentReady(true);
       };
       iframe.addEventListener('load', handleLoad, { once: true });
       iframe.srcdoc = html;
@@ -299,27 +307,8 @@ function MorphIframe({
 
   // Expose methods via ref
   useImperativeHandle(ref, () => ({
-    scrollToLine: (line: number) => {
-      const iframe = iframeRef.current;
-      const doc = iframe?.contentDocument;
-      const win = iframe?.contentWindow;
-      if (!doc || !win) return;
-
-      const element = findElementForLine(doc, line);
-      if (!element) return;
-
-      // Only scroll if element is not already visible
-      if (!isElementVisible(element, win)) {
-        element.scrollIntoView({ behavior: 'smooth', block: 'center' });
-      }
-    },
-    getScrollRatio: () => {
-      const iframe = iframeRef.current;
-      const win = iframe?.contentWindow;
-      const doc = iframe?.contentDocument;
-      if (!win || !doc) return null;
-      return computeScrollRatio(win, doc);
-    },
+    scrollToLine: (line: number) => scrollIframeToLine(iframeRef.current, line),
+    getScrollRatio: () => getIframeScrollRatio(iframeRef.current),
     setScrollRatio: (ratio: number) => {
       const iframe = iframeRef.current;
       if (!iframe?.contentWindow || !iframe?.contentDocument) return;
@@ -419,8 +408,11 @@ function MorphIframe({
     },
   }), []);
 
-  // Set up event listeners on iframe
+  // Set up event listeners on iframe. Gated on `documentReady` so the
+  // listeners bind to the post-load document (the srcdoc load replaces it
+  // asynchronously), re-running if that document or any callback changes.
   useEffect(() => {
+    if (!documentReady) return;
     const iframe = iframeRef.current;
     if (!iframe?.contentWindow || !iframe?.contentDocument) return;
 
@@ -485,7 +477,7 @@ function MorphIframe({
       iframe.contentDocument?.removeEventListener('click', handleClick);
       iframe.contentDocument?.removeEventListener('selectionchange', handleSelectionChange);
     };
-  }, [onScroll, onClick, onSelectionChange]);
+  }, [documentReady, onScroll, onClick, onSelectionChange]);
 
   return (
     <iframe

--- a/ts-packages/preview-renderer/src/iframe/Q2PreviewIframe.tsx
+++ b/ts-packages/preview-renderer/src/iframe/Q2PreviewIframe.tsx
@@ -1,7 +1,22 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react';
+import type { Ref } from 'react';
 import { vfsReadFile } from '@quarto/preview-runtime';
 import { DEFAULT_CSS_ARTIFACT_PATH } from '../types/artifactPaths';
 import { buildAssetManifest, type ManifestCacheEntry } from '../q2-preview/assetWalker';
+import { findElementForLine, isElementVisible } from './scrollSyncDom';
+
+/**
+ * Imperative scroll-sync handle, parallel to `MorphIframeHandle`. The
+ * q2-preview iframe is same-origin (`allow-same-origin`), so the parent
+ * reads `contentDocument` / `contentWindow` directly rather than going
+ * through postMessage. Editor→preview uses `data-loc` attributes the
+ * q2-preview leaves stamp via `dataLocProps`; preview→editor uses the
+ * raw scroll ratio.
+ */
+export interface Q2PreviewIframeHandle {
+  scrollToLine: (line: number) => void;
+  getScrollRatio: () => number | null;
+}
 
 interface Q2PreviewIframeProps {
   astJson: string;
@@ -108,6 +123,12 @@ interface Q2PreviewIframeProps {
    * in-deck navigation.
    */
   onSlideChange?: (slideIndex: number) => void;
+  /** Scroll-sync handle (scrollToLine / getScrollRatio). */
+  scrollHandleRef?: Ref<Q2PreviewIframeHandle>;
+  /** Called when the preview iframe is scrolled (preview→editor sync). */
+  onScroll?: () => void;
+  /** Called when the preview iframe is clicked (preview→editor sync). */
+  onClick?: () => void;
 }
 
 /**
@@ -146,6 +167,9 @@ export function Q2PreviewIframe({
   nestedEditBuffers,
   currentSlideIndex,
   onSlideChange,
+  scrollHandleRef,
+  onScroll,
+  onClick,
 }: Q2PreviewIframeProps) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const [iframeReady, setIframeReady] = useState(false);
@@ -155,6 +179,60 @@ export function Q2PreviewIframe({
   // otherwise loop: cursor → SET_SLIDE → slidechanged → SLIDE_CHANGED →
   // editor state → SET_SLIDE …). Reset on IFRAME_READY (fresh iframe).
   const lastSentSlideRef = useRef<number | undefined>(undefined);
+
+  // Scroll-sync handle. Same-origin access to the iframe document lets
+  // us reuse the exact line→element mapping `MorphIframe` uses for the
+  // HTML preview.
+  useImperativeHandle(
+    scrollHandleRef,
+    () => ({
+      scrollToLine: (line: number) => {
+        const iframe = iframeRef.current;
+        const doc = iframe?.contentDocument;
+        const win = iframe?.contentWindow;
+        if (!doc || !win) return;
+        const element = findElementForLine(doc, line);
+        if (!element) return;
+        if (!isElementVisible(element, win)) {
+          element.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        }
+      },
+      getScrollRatio: () => {
+        const iframe = iframeRef.current;
+        const win = iframe?.contentWindow;
+        const doc = iframe?.contentDocument;
+        if (!win || !doc) return null;
+        const maxScroll =
+          doc.documentElement.scrollHeight - win.innerHeight;
+        if (maxScroll <= 0) return 0;
+        return win.scrollY / maxScroll;
+      },
+    }),
+    [],
+  );
+
+  // Forward iframe scroll / click to the parent for preview→editor sync.
+  // Attached once the iframe document exists (IFRAME_READY); the q2-preview
+  // app re-renders its body via React on each UPDATE_AST but never reloads
+  // the iframe, so the contentWindow/document — and these listeners —
+  // persist across edits.
+  useEffect(() => {
+    if (!iframeReady) return;
+    const iframe = iframeRef.current;
+    const win = iframe?.contentWindow;
+    const doc = iframe?.contentDocument;
+    if (!win || !doc) return;
+
+    const handleScroll = () => onScroll?.();
+    const handleClick = () => onClick?.();
+
+    win.addEventListener('scroll', handleScroll, { passive: true });
+    doc.addEventListener('click', handleClick);
+    return () => {
+      win.removeEventListener('scroll', handleScroll);
+      doc.removeEventListener('click', handleClick);
+    };
+  }, [iframeReady, onScroll, onClick]);
 
   // Track the last fingerprint we posted and the current outstanding
   // blob URL so we can dedupe re-sends and revoke replaced URLs.

--- a/ts-packages/preview-renderer/src/iframe/Q2PreviewIframe.tsx
+++ b/ts-packages/preview-renderer/src/iframe/Q2PreviewIframe.tsx
@@ -3,7 +3,7 @@ import type { Ref } from 'react';
 import { vfsReadFile } from '@quarto/preview-runtime';
 import { DEFAULT_CSS_ARTIFACT_PATH } from '../types/artifactPaths';
 import { buildAssetManifest, type ManifestCacheEntry } from '../q2-preview/assetWalker';
-import { findElementForLine, isElementVisible, computeScrollRatio } from './scrollSyncDom';
+import { scrollIframeToLine, getIframeScrollRatio } from './scrollSyncDom';
 
 /**
  * Imperative scroll-sync handle, parallel to `MorphIframeHandle`. The
@@ -186,30 +186,14 @@ export function Q2PreviewIframe({
   // editor state → SET_SLIDE …). Reset on IFRAME_READY (fresh iframe).
   const lastSentSlideRef = useRef<number | undefined>(undefined);
 
-  // Scroll-sync handle. Same-origin access to the iframe document lets
-  // us reuse the exact line→element mapping `MorphIframe` uses for the
-  // HTML preview.
+  // Scroll-sync handle. Same-origin access to the iframe document lets us
+  // reuse the exact shared scroll helpers `MorphIframe` uses for the HTML
+  // preview.
   useImperativeHandle(
     scrollHandleRef,
     () => ({
-      scrollToLine: (line: number) => {
-        const iframe = iframeRef.current;
-        const doc = iframe?.contentDocument;
-        const win = iframe?.contentWindow;
-        if (!doc || !win) return;
-        const element = findElementForLine(doc, line);
-        if (!element) return;
-        if (!isElementVisible(element, win)) {
-          element.scrollIntoView({ behavior: 'smooth', block: 'center' });
-        }
-      },
-      getScrollRatio: () => {
-        const iframe = iframeRef.current;
-        const win = iframe?.contentWindow;
-        const doc = iframe?.contentDocument;
-        if (!win || !doc) return null;
-        return computeScrollRatio(win, doc);
-      },
+      scrollToLine: (line: number) => scrollIframeToLine(iframeRef.current, line),
+      getScrollRatio: () => getIframeScrollRatio(iframeRef.current),
     }),
     [],
   );

--- a/ts-packages/preview-renderer/src/iframe/Q2PreviewIframe.tsx
+++ b/ts-packages/preview-renderer/src/iframe/Q2PreviewIframe.tsx
@@ -3,7 +3,7 @@ import type { Ref } from 'react';
 import { vfsReadFile } from '@quarto/preview-runtime';
 import { DEFAULT_CSS_ARTIFACT_PATH } from '../types/artifactPaths';
 import { buildAssetManifest, type ManifestCacheEntry } from '../q2-preview/assetWalker';
-import { findElementForLine, isElementVisible } from './scrollSyncDom';
+import { findElementForLine, isElementVisible, computeScrollRatio } from './scrollSyncDom';
 
 /**
  * Imperative scroll-sync handle, parallel to `MorphIframeHandle`. The
@@ -129,6 +129,11 @@ interface Q2PreviewIframeProps {
   onScroll?: () => void;
   /** Called when the preview iframe is clicked (preview→editor sync). */
   onClick?: () => void;
+  /**
+   * Called after the iframe commits a new AST (`AST_RENDERED`), so the host
+   * can re-run editor→preview scroll sync against the fresh `data-loc` DOM.
+   */
+  onAstRendered?: () => void;
 }
 
 /**
@@ -170,6 +175,7 @@ export function Q2PreviewIframe({
   scrollHandleRef,
   onScroll,
   onClick,
+  onAstRendered,
 }: Q2PreviewIframeProps) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const [iframeReady, setIframeReady] = useState(false);
@@ -202,10 +208,7 @@ export function Q2PreviewIframe({
         const win = iframe?.contentWindow;
         const doc = iframe?.contentDocument;
         if (!win || !doc) return null;
-        const maxScroll =
-          doc.documentElement.scrollHeight - win.innerHeight;
-        if (maxScroll <= 0) return 0;
-        return win.scrollY / maxScroll;
+        return computeScrollRatio(win, doc);
       },
     }),
     [],
@@ -297,12 +300,16 @@ export function Q2PreviewIframe({
         // not bounce back as a redundant SET_SLIDE, then report it up.
         lastSentSlideRef.current = event.data.index;
         onSlideChange?.(event.data.index);
+      } else if (event.data.type === 'AST_RENDERED') {
+        // The iframe committed a new AST and laid out; the fresh data-loc
+        // DOM is now in place, so re-run editor→preview scroll sync.
+        onAstRendered?.();
       }
     };
 
     window.addEventListener('message', handleMessage);
     return () => window.removeEventListener('message', handleMessage);
-  }, [onNavigateToDocument, setAst, onSlideChange]);
+  }, [onNavigateToDocument, setAst, onSlideChange, onAstRendered]);
 
   // Post the controlled slide index to the iframe when it changes. The
   // iframe navigates the reveal deck imperatively (RevealNavSync), so

--- a/ts-packages/preview-renderer/src/iframe/scrollSyncDom.integration.test.ts
+++ b/ts-packages/preview-renderer/src/iframe/scrollSyncDom.integration.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Shared scroll-sync DOM helpers (bd-9kzfi). jsdom environment so a
+ * real Document/querySelectorAll backs `findElementForLine`.
+ */
+import { describe, it, expect } from 'vitest';
+import { parseDataLoc, findElementForLine } from './scrollSyncDom';
+
+describe('parseDataLoc', () => {
+    it('parses a well-formed data-loc into 1-based fields', () => {
+        expect(parseDataLoc('0:3:1-5:18')).toEqual({
+            fileId: 0,
+            startLine: 3,
+            startCol: 1,
+            endLine: 5,
+            endCol: 18,
+        });
+    });
+
+    it('returns null for malformed input', () => {
+        expect(parseDataLoc('not-a-loc')).toBeNull();
+        expect(parseDataLoc('0:3:1-5')).toBeNull();
+    });
+});
+
+describe('findElementForLine', () => {
+    function docWith(html: string): Document {
+        const doc = document.implementation.createHTMLDocument('t');
+        doc.body.innerHTML = html;
+        return doc;
+    }
+
+    it('matches the element whose line range contains the line', () => {
+        const doc = docWith(
+            '<p data-loc="0:1:1-1:5" id="a">a</p>' +
+                '<p data-loc="0:3:1-3:5" id="b">b</p>',
+        );
+        expect(findElementForLine(doc, 3)?.id).toBe('b');
+        expect(findElementForLine(doc, 1)?.id).toBe('a');
+    });
+
+    it('prefers the most specific (smallest range) enclosing element', () => {
+        const doc = docWith(
+            '<div data-loc="0:1:1-10:1" id="outer">' +
+                '<p data-loc="0:4:1-4:9" id="inner">x</p>' +
+                '</div>',
+        );
+        // Line 4 is inside both; the tighter <p> wins.
+        expect(findElementForLine(doc, 4)?.id).toBe('inner');
+        // Line 2 is only inside the outer div.
+        expect(findElementForLine(doc, 2)?.id).toBe('outer');
+    });
+
+    it('returns null when no element covers the line', () => {
+        const doc = docWith('<p data-loc="0:1:1-1:5">a</p>');
+        expect(findElementForLine(doc, 99)).toBeNull();
+    });
+
+    it('ignores elements with an unparseable data-loc', () => {
+        const doc = docWith('<p data-loc="garbage" id="g">g</p>');
+        expect(findElementForLine(doc, 1)).toBeNull();
+    });
+});

--- a/ts-packages/preview-renderer/src/iframe/scrollSyncDom.integration.test.ts
+++ b/ts-packages/preview-renderer/src/iframe/scrollSyncDom.integration.test.ts
@@ -50,8 +50,37 @@ describe('findElementForLine', () => {
         expect(findElementForLine(doc, 2)?.id).toBe('outer');
     });
 
-    it('returns null when no element covers the line', () => {
-        const doc = docWith('<p data-loc="0:1:1-1:5">a</p>');
+    it('falls back to the nearest preceding block past the last range', () => {
+        // Cursor past every range (e.g. a fresh blank line at the end of the
+        // document). Snaps to the closest block that starts at or before the
+        // line, so end-of-document edits still scroll the preview.
+        const doc = docWith(
+            '<p data-loc="0:1:1-1:5" id="a">a</p>' +
+                '<p data-loc="0:3:1-3:5" id="b">b</p>',
+        );
+        expect(findElementForLine(doc, 99)?.id).toBe('b');
+    });
+
+    it('falls back to the nearest block in a gap between ranges', () => {
+        // Line 5 is between the two paragraphs (covered by neither); the
+        // preceding block wins over the following one.
+        const doc = docWith(
+            '<p data-loc="0:1:1-2:5" id="a">a</p>' +
+                '<p data-loc="0:8:1-8:5" id="b">b</p>',
+        );
+        expect(findElementForLine(doc, 5)?.id).toBe('a');
+    });
+
+    it('falls back to the first block for a line before all ranges', () => {
+        const doc = docWith(
+            '<p data-loc="0:5:1-5:5" id="a">a</p>' +
+                '<p data-loc="0:9:1-9:5" id="b">b</p>',
+        );
+        expect(findElementForLine(doc, 1)?.id).toBe('a');
+    });
+
+    it('returns null only when there are no located elements at all', () => {
+        const doc = docWith('<p>no data-loc here</p>');
         expect(findElementForLine(doc, 99)).toBeNull();
     });
 

--- a/ts-packages/preview-renderer/src/iframe/scrollSyncDom.ts
+++ b/ts-packages/preview-renderer/src/iframe/scrollSyncDom.ts
@@ -38,6 +38,14 @@ export function parseDataLoc(dataLoc: string): SourceLocation | null {
 /**
  * Find the best matching element for a given line number, preferring
  * the most specific (smallest line range) match that contains the line.
+ *
+ * When no element's range contains the line (a blank line between
+ * blocks, or — most commonly — a fresh line past the last block at the
+ * end of the document), falls back to the nearest located block: the
+ * one starting closest at-or-before the line, or failing that the first
+ * block after it. This keeps end-of-document edits scrolling the
+ * preview instead of silently no-op'ing. Returns null only when the
+ * document has no located elements at all.
  */
 export function findElementForLine(
     doc: Document,
@@ -46,6 +54,14 @@ export function findElementForLine(
     const elements = doc.querySelectorAll('[data-loc]');
     let bestMatch: HTMLElement | null = null;
     let bestRangeSize = Infinity;
+
+    // Fallbacks for a line no range contains: nearest block at-or-before
+    // (largest startLine ≤ line) preferred, else nearest block after
+    // (smallest startLine > line).
+    let precedingMatch: HTMLElement | null = null;
+    let precedingStart = -Infinity;
+    let followingMatch: HTMLElement | null = null;
+    let followingStart = Infinity;
 
     for (const element of elements) {
         const dataLoc = element.getAttribute('data-loc');
@@ -60,10 +76,16 @@ export function findElementForLine(
                 bestMatch = element as HTMLElement;
                 bestRangeSize = rangeSize;
             }
+        } else if (loc.startLine <= line && loc.startLine > precedingStart) {
+            precedingMatch = element as HTMLElement;
+            precedingStart = loc.startLine;
+        } else if (loc.startLine > line && loc.startLine < followingStart) {
+            followingMatch = element as HTMLElement;
+            followingStart = loc.startLine;
         }
     }
 
-    return bestMatch;
+    return bestMatch ?? precedingMatch ?? followingMatch;
 }
 
 /**
@@ -74,4 +96,15 @@ export function findElementForLine(
 export function isElementVisible(element: HTMLElement, win: Window): boolean {
     const rect = element.getBoundingClientRect();
     return rect.top >= 0 && rect.bottom <= win.innerHeight;
+}
+
+/**
+ * Scroll ratio of an iframe document: 0 at the top, 1 at the bottom, and 0
+ * for a document too short to scroll. `win`/`doc` are the iframe's own
+ * contentWindow/contentDocument. Shared by MorphIframe and Q2PreviewIframe.
+ */
+export function computeScrollRatio(win: Window, doc: Document): number {
+    const maxScroll = doc.documentElement.scrollHeight - win.innerHeight;
+    if (maxScroll <= 0) return 0;
+    return win.scrollY / maxScroll;
 }

--- a/ts-packages/preview-renderer/src/iframe/scrollSyncDom.ts
+++ b/ts-packages/preview-renderer/src/iframe/scrollSyncDom.ts
@@ -99,11 +99,34 @@ export function isElementVisible(element: HTMLElement, win: Window): boolean {
 }
 
 /**
- * Scroll ratio of an iframe document: 0 at the top, 1 at the bottom, and 0
- * for a document too short to scroll. `win`/`doc` are the iframe's own
- * contentWindow/contentDocument. Shared by MorphIframe and Q2PreviewIframe.
+ * Editor→preview scroll: bring the element mapped to `line` into view,
+ * centered, but only if it isn't already fully visible. No-op when the iframe
+ * isn't ready or no element maps to the line. The single scroll-to-line code
+ * path shared by MorphIframe and Q2PreviewIframe.
  */
-export function computeScrollRatio(win: Window, doc: Document): number {
+export function scrollIframeToLine(
+    iframe: HTMLIFrameElement | null,
+    line: number,
+): void {
+    const doc = iframe?.contentDocument;
+    const win = iframe?.contentWindow;
+    if (!doc || !win) return;
+    const element = findElementForLine(doc, line);
+    if (!element) return;
+    if (!isElementVisible(element, win)) {
+        element.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+}
+
+/**
+ * Current scroll ratio of the iframe document: 0 at the top, 1 at the bottom,
+ * 0 for a document too short to scroll, and null when the iframe isn't ready.
+ * Shared by MorphIframe and Q2PreviewIframe.
+ */
+export function getIframeScrollRatio(iframe: HTMLIFrameElement | null): number | null {
+    const win = iframe?.contentWindow;
+    const doc = iframe?.contentDocument;
+    if (!win || !doc) return null;
     const maxScroll = doc.documentElement.scrollHeight - win.innerHeight;
     if (maxScroll <= 0) return 0;
     return win.scrollY / maxScroll;

--- a/ts-packages/preview-renderer/src/iframe/scrollSyncDom.ts
+++ b/ts-packages/preview-renderer/src/iframe/scrollSyncDom.ts
@@ -1,0 +1,77 @@
+/**
+ * Shared DOM helpers for editor↔preview scroll sync. Both the HTML
+ * preview (`MorphIframe`) and the q2-preview iframe (`Q2PreviewIframe`)
+ * map an editor line number onto a preview element via `data-loc`
+ * attributes of the form `fileId:startLine:startCol-endLine:endCol`
+ * (1-based), the same format the native HTML writer and q2-preview's
+ * `dataLocProps` emit.
+ */
+
+/**
+ * Parsed source location from a `data-loc` attribute.
+ * Format: `fileId:startLine:startCol-endLine:endCol` (1-based).
+ */
+export interface SourceLocation {
+    fileId: number;
+    startLine: number;
+    startCol: number;
+    endLine: number;
+    endCol: number;
+}
+
+/**
+ * Parse a `data-loc` attribute string into a `SourceLocation`.
+ * Returns null if the format is invalid.
+ */
+export function parseDataLoc(dataLoc: string): SourceLocation | null {
+    const match = dataLoc.match(/^(\d+):(\d+):(\d+)-(\d+):(\d+)$/);
+    if (!match) return null;
+    return {
+        fileId: parseInt(match[1], 10),
+        startLine: parseInt(match[2], 10),
+        startCol: parseInt(match[3], 10),
+        endLine: parseInt(match[4], 10),
+        endCol: parseInt(match[5], 10),
+    };
+}
+
+/**
+ * Find the best matching element for a given line number, preferring
+ * the most specific (smallest line range) match that contains the line.
+ */
+export function findElementForLine(
+    doc: Document,
+    line: number,
+): HTMLElement | null {
+    const elements = doc.querySelectorAll('[data-loc]');
+    let bestMatch: HTMLElement | null = null;
+    let bestRangeSize = Infinity;
+
+    for (const element of elements) {
+        const dataLoc = element.getAttribute('data-loc');
+        if (!dataLoc) continue;
+
+        const loc = parseDataLoc(dataLoc);
+        if (!loc) continue;
+
+        if (line >= loc.startLine && line <= loc.endLine) {
+            const rangeSize = loc.endLine - loc.startLine;
+            if (rangeSize < bestRangeSize) {
+                bestMatch = element as HTMLElement;
+                bestRangeSize = rangeSize;
+            }
+        }
+    }
+
+    return bestMatch;
+}
+
+/**
+ * Check if an element is fully visible within the iframe viewport.
+ * `win` is the iframe's own `contentWindow` (so `innerHeight` is the
+ * preview viewport, not the host page's).
+ */
+export function isElementVisible(element: HTMLElement, win: Window): boolean {
+    const rect = element.getBoundingClientRect();
+    return rect.top >= 0 && rect.bottom <= win.innerHeight;
+}

--- a/ts-packages/preview-renderer/src/q2-preview/PreviewRoot.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/PreviewRoot.tsx
@@ -186,6 +186,14 @@ export interface PreviewRootProps {
      */
     registerSlideNavigator?: (nav: ((index: number) => void) | null) => void;
     onSlideChange?: (slideIndex: number) => void;
+    /**
+     * Fired after React commits a new AST and layout settles, so the host
+     * can re-run editor→preview scroll sync against the fresh `data-loc`
+     * DOM (the cursor-driven scroll otherwise races the async render). In
+     * production `entry.tsx` wires this to post `AST_RENDERED` to the
+     * parent; tests can omit it.
+     */
+    onAstRendered?: () => void;
 }
 
 /**
@@ -1381,6 +1389,16 @@ export function PreviewRoot(props: PreviewRootProps) {
         });
         return () => cancelAnimationFrame(raf);
     }, [props.pendingAnchor, props.pendingAnchorEpoch, props.astJson, props.scrollToAnchor]);
+
+    // Notify the host once a new AST has committed and laid out, so it can
+    // re-run editor→preview scroll sync against the fresh `data-loc` DOM
+    // (bd-9kzfi). rAF defers to post-layout, matching the anchor scroll above.
+    const onAstRendered = props.onAstRendered;
+    useEffect(() => {
+        if (!onAstRendered) return;
+        const raf = requestAnimationFrame(() => onAstRendered());
+        return () => cancelAnimationFrame(raf);
+    }, [onAstRendered, props.astJson]);
 
     // Single merge site: built-in preview leaves + user overrides.
     const mergedPreviewRegistry: FormatRegistry = {

--- a/ts-packages/preview-renderer/src/q2-preview/blocks/BlockQuote.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/blocks/BlockQuote.tsx
@@ -1,5 +1,5 @@
 import { useContext } from 'react';
-import { renderChildren } from '../../framework';
+import { renderChildren, dataLocProps } from '../../framework';
 import type { BlockQuoteBlock, NodeArgs } from '../../framework';
 import { PreviewContext } from '../PreviewContext';
 
@@ -9,7 +9,7 @@ export const BlockQuote = (args: NodeArgs<BlockQuoteBlock>) => {
     const resolved = ctx?.resolveSource ? ctx.resolveSource(args.node) : null;
     const isEditable = resolved != null && resolved.reachabilityClass !== 'Opaque' && poolId !== undefined;
     return (
-        <blockquote {...(isEditable ? { 'data-block-pool-id': poolId, tabIndex: -1 } : {})}>
+        <blockquote {...(isEditable ? { 'data-block-pool-id': poolId, tabIndex: -1 } : {})} {...dataLocProps(args.node)}>
             {renderChildren(args)}
         </blockquote>
     );

--- a/ts-packages/preview-renderer/src/q2-preview/blocks/BulletList.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/blocks/BulletList.tsx
@@ -1,5 +1,5 @@
 import { useContext } from 'react';
-import { Node, liItemAttrProps } from '../../framework';
+import { Node, liItemAttrProps, dataLocProps } from '../../framework';
 import type { BulletListBlock, NodeArgs } from '../../framework';
 import { IncrementalContext } from '../IncrementalContext';
 import { PreviewContext } from '../PreviewContext';
@@ -27,7 +27,7 @@ export const BulletList = (args: NodeArgs<BulletListBlock>) => {
 
     if (enabled) {
         return (
-            <ul>
+            <ul {...dataLocProps(args.node)}>
                 {args.node.c.map((item, i) => (
                     <li key={i} {...liItemAttrProps(args.node.itemAttr?.[i], incremental)}>
                         {item.map((block, j) => (
@@ -48,7 +48,7 @@ export const BulletList = (args: NodeArgs<BulletListBlock>) => {
     const isEditable = resolved != null && resolved.reachabilityClass !== 'Opaque' && poolId !== undefined && !ctx?.editingDisabled;
 
     return (
-        <ul {...(isEditable ? { 'data-block-pool-id': poolId, tabIndex: -1 } : {})}>
+        <ul {...(isEditable ? { 'data-block-pool-id': poolId, tabIndex: -1 } : {})} {...dataLocProps(args.node)}>
             {args.node.c.map((item, i) => {
                 // Per-item block attr (bd-aeyss6p5) applies to every <li>.
                 const itemAttrProps = liItemAttrProps(args.node.itemAttr?.[i], false);

--- a/ts-packages/preview-renderer/src/q2-preview/blocks/CodeBlock.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/blocks/CodeBlock.tsx
@@ -1,4 +1,5 @@
 import { Fragment, useContext, type ReactNode } from 'react';
+import { dataLocProps } from '../../framework';
 import type { CodeBlock as CodeBlockType, NodeArgs } from '../../framework';
 import { PreviewContext } from '../PreviewContext';
 import { sliceEncodedUtf8 } from '../../utils/sliceSource';
@@ -195,7 +196,7 @@ export const CodeBlock = ({ node }: NodeArgs<CodeBlockType>) => {
         const divClassName = ['sourceCode', ...extras].join(' ');
         const codeContainerClass = language ? `sourceCode ${language}` : 'sourceCode';
         return (
-            <div className={divClassName} {...(id ? { id } : {})} {...affordanceAttr}>
+            <div className={divClassName} {...(id ? { id } : {})} {...affordanceAttr} {...dataLocProps(node)}>
                 <pre className={codeContainerClass} {...preDataAttrs}>
                     <code className={codeContainerClass}>{renderHighlighted(code, spans)}</code>
                 </pre>
@@ -211,7 +212,7 @@ export const CodeBlock = ({ node }: NodeArgs<CodeBlockType>) => {
     if (id) preProps.id = id;
     if (classes.length) preProps.className = classes.join(' ');
     return (
-        <pre {...preProps} {...affordanceAttr}>
+        <pre {...preProps} {...affordanceAttr} {...dataLocProps(node)}>
             <code>{code}</code>
         </pre>
     );

--- a/ts-packages/preview-renderer/src/q2-preview/blocks/DefinitionList.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/blocks/DefinitionList.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { Node } from '../../framework';
+import { Node, dataLocProps } from '../../framework';
 import type {
     BlockNode,
     DefinitionListBlock,
@@ -28,7 +28,7 @@ export const DefinitionList = (args: NodeArgs<DefinitionListBlock>) => {
     const { node, setLocalAst, onNavigateToDocument } = args;
 
     return (
-        <dl {...affordanceAttr}>
+        <dl {...affordanceAttr} {...dataLocProps(node)}>
             {node.c.flatMap(([term, defs], i) => {
                 const dt = (
                     <dt key={`dt-${i}`}>

--- a/ts-packages/preview-renderer/src/q2-preview/blocks/Div.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/blocks/Div.tsx
@@ -1,5 +1,5 @@
 import { useContext, type CSSProperties, type ReactNode } from 'react';
-import { renderChildren } from '../../framework';
+import { renderChildren, dataLocProps } from '../../framework';
 import type { DivBlock, NodeArgs } from '../../framework';
 import { IncrementalContext } from '../IncrementalContext';
 import { PreviewContext } from '../PreviewContext';
@@ -68,15 +68,18 @@ export const Div = (args: NodeArgs<DivBlock>) => {
     // whose class list contains "section" (output of the sectionize
     // transform) renders as `<section>`, not `<div>`. Sections are
     // not editable at this phase (Plan 4); non-section divs get the
-    // affordance attribute.
+    // affordance attribute. Quarto theme CSS keys off the `<section>`
+    // tag, so emitting `<div>` here would cause spacing drift between
+    // `q2 render` and `q2 preview`.
+    const locProps = dataLocProps(args.node);
     if (classes.includes(SECTION)) {
-        return <section {...props}>{wrap(renderChildren(args))}</section>;
+        return <section {...props} {...locProps}>{wrap(renderChildren(args))}</section>;
     }
     // Revealjs speaker notes / asides — mirror the native writer's
     // `.notes` / `.aside` → <aside>. reveal.css hides `aside.notes`;
     // quarto-reveal.css styles `aside.aside` (bottom of slide, muted).
     if (classes.includes(NOTES) || classes.includes(ASIDE)) {
-        return <aside {...props}>{wrap(renderChildren(args))}</aside>;
+        return <aside {...props} {...locProps}>{wrap(renderChildren(args))}</aside>;
     }
     const resolved = ctx?.resolveSource ? ctx.resolveSource(args.node) : null;
     const isEditable = resolved != null && resolved.reachabilityClass !== 'Opaque' && poolId !== undefined;
@@ -84,5 +87,5 @@ export const Div = (args: NodeArgs<DivBlock>) => {
         props['data-block-pool-id'] = String(poolId);
         props.tabIndex = -1;
     }
-    return <div {...props}>{wrap(renderChildren(args))}</div>;
+    return <div {...props} {...locProps}>{wrap(renderChildren(args))}</div>;
 };

--- a/ts-packages/preview-renderer/src/q2-preview/blocks/Figure.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/blocks/Figure.tsx
@@ -1,5 +1,5 @@
 import { useContext } from 'react';
-import { Node } from '../../framework';
+import { Node, dataLocProps } from '../../framework';
 import type { BlockNode, FigureBlock, InlineNode, NodeArgs } from '../../framework';
 import { PreviewContext } from '../PreviewContext';
 
@@ -33,7 +33,7 @@ export const Figure = (args: NodeArgs<FigureBlock>) => {
     }
 
     return (
-        <figure {...props}>
+        <figure {...props} {...dataLocProps(node)}>
             {bodyBlocks.map((b, i) => (
                 <Node
                     key={i}

--- a/ts-packages/preview-renderer/src/q2-preview/blocks/Header.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/blocks/Header.tsx
@@ -1,5 +1,5 @@
 import { useContext } from 'react';
-import { renderChildren } from '../../framework';
+import { renderChildren, dataLocProps } from '../../framework';
 import type { HeaderBlock, NodeArgs } from '../../framework';
 import { PreviewContext } from '../PreviewContext';
 
@@ -28,5 +28,5 @@ export const Header = (args: NodeArgs<HeaderBlock>) => {
     }
     const Tag = headerTags[Math.min(Math.max(level, 1), 6) - 1];
 
-    return <Tag {...domProps}>{renderChildren(args)}</Tag>;
+    return <Tag {...domProps} {...dataLocProps(args.node)}>{renderChildren(args)}</Tag>;
 };

--- a/ts-packages/preview-renderer/src/q2-preview/blocks/HorizontalRule.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/blocks/HorizontalRule.tsx
@@ -1,1 +1,6 @@
-export const HorizontalRule = () => <hr />;
+import { dataLocProps } from '../../framework';
+import type { HorizontalRuleBlock, NodeArgs } from '../../framework';
+
+export const HorizontalRule = (args: NodeArgs<HorizontalRuleBlock>) => (
+    <hr {...dataLocProps(args.node)} />
+);

--- a/ts-packages/preview-renderer/src/q2-preview/blocks/LineBlock.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/blocks/LineBlock.tsx
@@ -1,5 +1,5 @@
 import { useContext } from 'react';
-import { Node } from '../../framework';
+import { Node, dataLocProps } from '../../framework';
 import type { BlockNode, InlineNode, LineBlockBlock, NodeArgs } from '../../framework';
 import { PreviewContext } from '../PreviewContext';
 
@@ -16,7 +16,7 @@ export const LineBlock = (args: NodeArgs<LineBlockBlock>) => {
 
     const { node, setLocalAst, onNavigateToDocument } = args;
     return (
-        <div className="line-block" {...(isEditable ? { 'data-block-pool-id': poolId, tabIndex: -1 } : {})}>
+        <div className="line-block" {...(isEditable ? { 'data-block-pool-id': poolId, tabIndex: -1 } : {})} {...dataLocProps(node)}>
             {node.c.map((line, i) => (
                 <div key={i}>
                     {line.map((inl, j) => (

--- a/ts-packages/preview-renderer/src/q2-preview/blocks/OrderedList.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/blocks/OrderedList.tsx
@@ -1,5 +1,5 @@
 import { useContext } from 'react';
-import { Node, liItemAttrProps } from '../../framework';
+import { Node, liItemAttrProps, dataLocProps } from '../../framework';
 import type { NodeArgs, OrderedListBlock } from '../../framework';
 import { IncrementalContext } from '../IncrementalContext';
 import { PreviewContext } from '../PreviewContext';
@@ -47,7 +47,7 @@ export const OrderedList = (args: NodeArgs<OrderedListBlock>) => {
 
     if (enabled) {
         return (
-            <ol {...olProps}>
+            <ol {...olProps} {...dataLocProps(args.node)}>
                 {args.node.c[1].map((item, i) => (
                     <li key={i} {...liItemAttrProps(args.node.itemAttr?.[i], incremental)}>
                         {item.map((block, j) => (
@@ -69,7 +69,7 @@ export const OrderedList = (args: NodeArgs<OrderedListBlock>) => {
         props.tabIndex = -1;
     }
     return (
-        <ol {...olProps}>
+        <ol {...olProps} {...dataLocProps(args.node)}>
             {args.node.c[1].map((item, i) => {
                 // Per-item block attr (bd-aeyss6p5) applies to every <li>.
                 const itemAttrProps = liItemAttrProps(args.node.itemAttr?.[i], false);

--- a/ts-packages/preview-renderer/src/q2-preview/blocks/Para.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/blocks/Para.tsx
@@ -1,5 +1,5 @@
 import { useContext } from 'react';
-import { renderChildren } from '../../framework';
+import { renderChildren, dataLocProps } from '../../framework';
 import type { NodeArgs, ParaBlock } from '../../framework';
 import { PreviewContext } from '../PreviewContext';
 
@@ -33,5 +33,5 @@ export const Para = (args: NodeArgs<ParaBlock>) => {
         domProps.tabIndex = -1;
     }
 
-    return <p {...domProps}>{renderChildren(args)}</p>;
+    return <p {...domProps} {...dataLocProps(args.node)}>{renderChildren(args)}</p>;
 };

--- a/ts-packages/preview-renderer/src/q2-preview/blocks/RawBlock.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/blocks/RawBlock.tsx
@@ -1,4 +1,5 @@
 import { useContext } from 'react';
+import { dataLocProps } from '../../framework';
 import type { NodeArgs, RawBlock as RawBlockType } from '../../framework';
 import { PreviewContext } from '../PreviewContext';
 
@@ -36,9 +37,10 @@ export const RawBlock = ({ node }: NodeArgs<RawBlockType>) => {
     const affordanceAttr = isEditable ? { 'data-block-pool-id': poolId, tabIndex: -1 } : {};
 
     const [format, content] = node.c;
+    const locProps = dataLocProps(node);
     if (format === 'html' || format === 'html5') {
         const className = rootHasClass(content, 'r-stretch') ? 'r-stretch' : undefined;
-        return <div className={className} {...affordanceAttr} dangerouslySetInnerHTML={{ __html: content }} />;
+        return <div className={className} {...affordanceAttr} {...locProps} dangerouslySetInnerHTML={{ __html: content }} />;
     }
-    return <pre {...affordanceAttr}>{content}</pre>;
+    return <pre {...affordanceAttr} {...locProps}>{content}</pre>;
 };

--- a/ts-packages/preview-renderer/src/q2-preview/blocks/Table.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/blocks/Table.tsx
@@ -1,5 +1,5 @@
 import { useContext } from 'react';
-import { Node } from '../../framework';
+import { Node, dataLocProps } from '../../framework';
 import type { BlockNode, InlineNode, NodeArgs, TableBlock } from '../../framework';
 import { PreviewContext } from '../PreviewContext';
 
@@ -142,7 +142,7 @@ export const Table = (args: NodeArgs<TableBlock>) => {
     const [attr, [, captionBlocks], , [, headRows], bodies, [, footRows]] = c;
 
     return (
-        <table {...attrToProps(attr)} {...affordanceAttr}>
+        <table {...attrToProps(attr)} {...affordanceAttr} {...dataLocProps(node)}>
             {captionBlocks && captionBlocks.length > 0 && (
                 <caption>
                     {captionBlocks.map((b, i) => (

--- a/ts-packages/preview-renderer/src/q2-preview/entry.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/entry.tsx
@@ -364,6 +364,9 @@ function updateAst(payload: UpdateAstPayload) {
                 scrollToAnchor={scrollToAnchorInDocument}
                 registerSlideNavigator={registerSlideNavigator}
                 onSlideChange={postSlideChanged}
+                onAstRendered={() => {
+                    window.parent.postMessage({ type: 'AST_RENDERED' }, '*');
+                }}
                 onNavigateToDocument={(path, anchor) => {
                     window.parent.postMessage(
                         { type: 'NAVIGATE_TO_DOCUMENT', path, anchor },

--- a/ts-packages/preview-renderer/src/q2-preview/sourceLoc.integration.test.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/sourceLoc.integration.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * q2-preview emits `data-loc` source-location attributes on block leaf
+ * elements (bd-9kzfi). These power editor↔preview scroll sync the same
+ * way the HTML preview (`MorphIframe`) does — `findElementForLine`
+ * matches the `data-loc="fileId:startLine:startCol-endLine:endCol"`
+ * format, so q2-preview must stamp the same shape from each node's `l`
+ * field.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { Ast } from '../framework';
+import type { PandocAST } from '../framework';
+import { previewRegistry } from './registry';
+
+function mount(blocks: unknown[]) {
+    const ast: PandocAST = {
+        'pandoc-api-version': [1, 23, 0],
+        meta: {},
+        blocks: blocks as never,
+    };
+    return render(
+        <Ast
+            astJson={JSON.stringify(ast)}
+            currentFilePath="/project/test.qmd"
+            onNavigateToDocument={() => {}}
+            setAst={() => {}}
+            registry={previewRegistry}
+        />,
+    );
+}
+
+const STR = (c: string) => ({ t: 'Str', c });
+const loc = (sl: number, sc: number, el: number, ec: number) => ({
+    f: 0,
+    b: { o: 0, l: sl, c: sc },
+    e: { o: 0, l: el, c: ec },
+});
+
+describe('q2-preview data-loc emission on block leaves', () => {
+    it('stamps data-loc on a Para → <p>', () => {
+        const { container } = mount([
+            { t: 'Para', c: [STR('hello')], l: loc(3, 1, 3, 6) },
+        ]);
+        const p = container.querySelector('p');
+        expect(p?.getAttribute('data-loc')).toBe('0:3:1-3:6');
+    });
+
+    it('stamps data-loc on a Header alongside id/class props', () => {
+        const { container } = mount([
+            {
+                t: 'Header',
+                c: [2, ['intro', ['unnumbered'], []], [STR('Intro')]],
+                l: loc(1, 1, 1, 8),
+            },
+        ]);
+        const h2 = container.querySelector('h2');
+        expect(h2?.getAttribute('id')).toBe('intro');
+        expect(h2?.getAttribute('class')).toBe('unnumbered');
+        expect(h2?.getAttribute('data-loc')).toBe('0:1:1-1:8');
+    });
+
+    it('stamps data-loc on an un-highlighted CodeBlock → <pre>', () => {
+        const { container } = mount([
+            {
+                t: 'CodeBlock',
+                c: [['', [], []], 'x <- 1'],
+                l: loc(5, 1, 7, 4),
+            },
+        ]);
+        const pre = container.querySelector('pre');
+        expect(pre?.getAttribute('data-loc')).toBe('0:5:1-7:4');
+    });
+
+    it('stamps data-loc on a Div → <div>', () => {
+        const { container } = mount([
+            {
+                t: 'Div',
+                c: [['', [], []], [{ t: 'Para', c: [STR('x')] }]],
+                l: loc(10, 1, 12, 4),
+            },
+        ]);
+        const div = container.querySelector('div[data-loc]');
+        expect(div?.getAttribute('data-loc')).toBe('0:10:1-12:4');
+    });
+
+    it('stamps data-loc on a BlockQuote → <blockquote>', () => {
+        const { container } = mount([
+            {
+                t: 'BlockQuote',
+                c: [{ t: 'Para', c: [STR('q')] }],
+                l: loc(2, 1, 2, 5),
+            },
+        ]);
+        expect(
+            container.querySelector('blockquote')?.getAttribute('data-loc'),
+        ).toBe('0:2:1-2:5');
+    });
+
+    it('omits data-loc when the node carries no `l` field', () => {
+        const { container } = mount([{ t: 'Para', c: [STR('hi')] }]);
+        expect(container.querySelector('p')?.hasAttribute('data-loc')).toBe(
+            false,
+        );
+    });
+});


### PR DESCRIPTION
Closes bd-9kzfi.

Scroll sync (editor ↔ preview) worked for the HTML preview (`MorphIframe`) but was a no-op for the **q2-preview** format: its DOM carried no source-line attributes and `Q2PreviewIframe` exposed no scroll handle.

## What this does

- **Stamp `data-loc` on block leaves.** Each block leaf's own semantic element now carries `data-loc` derived from the node's resolved `l` field (no wrapper, to avoid breaking theme CSS selectors / margin collapse).
- **Wire the scroll plumbing.** `useScrollSync` is threaded through `ReactPreview → ReactRenderer → Q2PreviewIframe`, using direct same-origin `contentDocument` access (mirroring `MorphIframe`). No Rust change, no new postMessage protocol.
- **Make it reliable.** Editor→preview scroll defers to the iframe's new `AST_RENDERED` signal instead of racing the stale DOM, and `findElementForLine` falls back to the nearest block so end-of-document edits still sync.
- **Unify the code path.** The duplicated `scrollToLine` / `getScrollRatio` logic in `MorphIframe` and `Q2PreviewIframe` is lifted into a shared `iframe/scrollSyncDom.ts`. As part of this, `MorphIframe`'s listeners now bind on `documentReady`, restoring HTML preview→editor sync.

## Tests

- pampa regression test proving real parser output carries `l` on block nodes.
- jsdom tests proving the `<Ast>` render stamps `data-loc`, plus shared-module and hook coverage for `findElementForLine` / `parseDataLoc` / `useScrollSync`.
