### PR TITLE
fix(hub-client): stop Monaco auto-closing inline-code backticks (bd-w1s38lbe)

### DIFF
--- a/claude-notes/plans/2026-06-24-monaco-backtick-autoclose.md
+++ b/claude-notes/plans/2026-06-24-monaco-backtick-autoclose.md
@@ -1,0 +1,117 @@
+# Fix: Monaco editor auto-closes backtick, inserting a doubled `` ` ``
+
+**Strand:** bd-w1s38lbe
+
+## Overview
+
+A quarto-hub.com user reports an annoyance in the **Monaco** editor view
+(not the tiptap rich-text editor) of hub-client:
+
+> If I have existing text with a word that I want to wrap in inline backticks,
+> I'll go to the front of the word and add a backtick, then when I go to the
+> end of the word and add a backtick, it adds two of them, and I have to
+> delete one.
+
+### Root cause
+
+`hub-client/src/components/quartoTheme.ts` registers the `qmd` language with a
+`LanguageConfiguration` whose `autoClosingPairs` includes the backtick pair
+(`quartoTheme.ts:171`):
+
+```ts
+const qmdLanguageConfiguration: Monaco.languages.LanguageConfiguration = {
+  // ...
+  autoClosingPairs: [
+    { open: '[', close: ']' },
+    { open: '(', close: ')' },
+    { open: '{', close: '}' },
+    { open: '`', close: '`' },   // <-- this is the problem
+    { open: '"', close: '"' },
+    { open: '$', close: '$' },
+  ],
+  surroundingPairs: [
+    { open: '[', close: ']' },
+    { open: '(', close: ')' },
+    { open: '`', close: '`' },   // <-- keep this one
+    { open: '*', close: '*' },
+    { open: '_', close: '_' },
+  ],
+};
+```
+
+This config is applied in `registerQmdLanguage()`
+(`quartoTheme.ts:201`, via `monaco.languages.setLanguageConfiguration`),
+which is called from `Editor.tsx`'s `beforeMount` handler
+(`Editor.tsx:19`, `Editor.tsx:546-551`).
+
+### Why the exact symptom appears
+
+Monaco only fires an auto-close when the character *after* the cursor is
+whitespace, end-of-line, or a closing bracket — never when it is a word
+character. So the user's two keystrokes behave differently:
+
+- **Front of word** — cursor at `|word`. The next char is `w` (a word char),
+  so Monaco does **not** auto-close. One backtick is inserted: `` `word``.
+- **End of word** — cursor at `` `word|`` (EOL after). The next char is the
+  line end, so Monaco **does** auto-close, inserting the pair: `` `word``|``.
+  Two backticks appear; the user deletes one.
+
+Removing the backtick from `autoClosingPairs` makes the end-of-word keystroke
+insert a single backtick, matching the user's expectation. Keeping it in
+`surroundingPairs` preserves the genuinely-useful behavior of wrapping a
+*selection* by typing `` ` `` (Monaco distinguishes the two lists).
+
+### Scope decision
+
+- Remove **only** the backtick entry from `autoClosingPairs`. Leave `[`, `(`,
+  `{`, `"`, `$` auto-closing as they are (no report against them, and `$` /
+  brackets are far less likely to be typed singly in prose-with-math).
+- Leave the backtick in `surroundingPairs` untouched.
+- This is the minimal, targeted fix. Do **not** rework the broader
+  auto-closing strategy in this strand.
+
+## Work Items (TDD order)
+
+### Phase 1 — Test first
+- [x] Export `qmdLanguageConfiguration` from `quartoTheme.ts` (currently a
+      module-private const) so it can be asserted against. (It is the
+      configuration object, not behavior — exporting it is the mechanical seam.)
+- [x] Add a test to `hub-client/src/components/quartoTheme.test.ts`:
+  - [x] `autoClosingPairs` does **not** contain a `` { open: '`', … } `` entry
+        (regression guard for this bug).
+  - [x] `surroundingPairs` **still** contains the backtick entry (so the fix
+        doesn't over-correct and lose wrap-selection).
+- [x] Run the test, confirm the first assertion **fails** against current code
+      (backtick still in `autoClosingPairs`). ✅ Confirmed red.
+
+### Phase 2 — Fix
+- [x] Remove `{ open: '`', close: '`' }` from `autoClosingPairs` in
+      `quartoTheme.ts` (line ~171). Add a short comment explaining why backtick
+      is intentionally absent from auto-closing but present in surrounding.
+- [x] Run the test, confirm it now passes. ✅ 5/5 green.
+
+### Phase 3 — Verify
+- [x] `cd hub-client && npm run test:ci` — full hub-client test suite green.
+      ✅ 18 files / 121 tests pass.
+- [x] `cd hub-client && npm run build:all` — production build succeeds (stricter
+      than `tsc --noEmit`; required for hub-client changes per CLAUDE.md). ✅
+- [ ] **End-to-end, in a browser**: open a `.qmd` in the Monaco view, place the
+      cursor at the end of a word, type `` ` ``, and confirm only **one**
+      backtick is inserted. Also confirm: selecting a word and typing `` ` ``
+      still wraps it (surroundingPairs intact). Record the steps + observation.
+      ⏳ To be done together against a local hub-client.
+- [ ] Update `hub-client/changelog.md` per the two-commit workflow in CLAUDE.md
+      (hub-client changes require a changelog entry referencing the commit hash).
+
+## Notes / caveats
+
+- The config-level test is a **mechanical regression guard**, not proof of the
+  runtime behavior. Monaco's auto-close logic runs inside the Monaco runtime;
+  the test only asserts the configuration we feed it. The browser check in
+  Phase 3 is what actually verifies the user-visible behavior — do not skip it.
+- Files involved:
+  - `hub-client/src/components/quartoTheme.ts` (config + `registerQmdLanguage`)
+  - `hub-client/src/components/quartoTheme.test.ts` (tests)
+  - `hub-client/src/components/Editor.tsx` (calls `registerQmdLanguage`; no
+    change expected here)
+  - `hub-client/changelog.md` (entry)

--- a/claude-notes/plans/2026-06-24-monaco-backtick-autoclose.md
+++ b/claude-notes/plans/2026-06-24-monaco-backtick-autoclose.md
@@ -95,11 +95,11 @@ insert a single backtick, matching the user's expectation. Keeping it in
       ✅ 18 files / 121 tests pass.
 - [x] `cd hub-client && npm run build:all` — production build succeeds (stricter
       than `tsc --noEmit`; required for hub-client changes per CLAUDE.md). ✅
-- [ ] **End-to-end, in a browser**: open a `.qmd` in the Monaco view, place the
+- [x] **End-to-end, in a browser**: open a `.qmd` in the Monaco view, place the
       cursor at the end of a word, type `` ` ``, and confirm only **one**
       backtick is inserted. Also confirm: selecting a word and typing `` ` ``
-      still wraps it (surroundingPairs intact). Record the steps + observation.
-      ⏳ To be done together against a local hub-client.
+      still wraps it (surroundingPairs intact). ✅ User tested against a local
+      hub-client and confirmed the bug is fixed (2026-06-24).
 - [ ] Update `hub-client/changelog.md` per the two-commit workflow in CLAUDE.md
       (hub-client changes require a changelog entry referencing the commit hash).
 

--- a/hub-client/changelog.md
+++ b/hub-client/changelog.md
@@ -17,6 +17,7 @@ be in reverse chronological order (latest first).
 
 ### 2026-06-24
 
+- [`0ccf989a`](https://github.com/quarto-dev/q2/commits/0ccf989a): The editor no longer auto-inserts a second backtick — typing `` ` `` at the end of a word to close inline code now adds just one backtick instead of two (selecting a word and typing `` ` `` still wraps it).
 - [`a6f16a1e`](https://github.com/quarto-dev/q2/commits/a6f16a1e): The live preview now opens paragraphs and headings in a rich-text (WYSIWYG) editor by default — click to edit formatted text instead of raw markdown. Toggle it off under Settings → "Rich-text editor"; other block types continue to use the plain text editor.
 - [`79ea2831`](https://github.com/quarto-dev/q2/commits/79ea2831): Fixed italic/emphasis text rendering upright in the preview — reveal.js's global CSS reset was leaking onto every document and zeroing `font-style` on `<em>`/`<i>`/`<cite>`; it is now scoped to slide decks only.
 - [`160c6607`](https://github.com/quarto-dev/q2/commits/160c6607): The AST preview (q2-preview) now keeps editor↔preview scroll in sync — moving the cursor scrolls the preview to that block, and scrolling the preview tracks back to the editor.

--- a/hub-client/src/components/quartoTheme.test.ts
+++ b/hub-client/src/components/quartoTheme.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { quartoThemeRules, qmdMonarch } from './quartoTheme';
+import { quartoThemeRules, qmdMonarch, qmdLanguageConfiguration } from './quartoTheme';
 
 describe('quartoThemeRules namespace invariant', () => {
   it('every theme rule token carries the qmd. sentinel prefix', () => {
@@ -43,5 +43,31 @@ describe('qmd Monarch base — bracket symmetry', () => {
         `rule ${re} treats "[" and "]" asymmetrically — link brackets would mismatch`,
       ).toBe(re.test(']'));
     }
+  });
+});
+
+describe('qmd language configuration — backtick auto-close (bd-w1s38lbe)', () => {
+  // Regression: a backtick in `autoClosingPairs` made Monaco auto-close `` ` ``
+  // whenever the next char was whitespace/EOL. Wrapping an existing word in
+  // inline code (type `` ` `` before the word, then `` ` `` after it) inserted
+  // TWO trailing backticks because the end-of-word keystroke triggered the
+  // auto-close. Backticks must NOT auto-close.
+  it('does not auto-close backticks', () => {
+    const pairs = qmdLanguageConfiguration.autoClosingPairs ?? [];
+    expect(
+      pairs.some((p) => p.open === '`' || p.close === '`'),
+      'backtick must not be in autoClosingPairs — it doubles when wrapping a word',
+    ).toBe(false);
+  });
+
+  // The fix must not over-correct: typing `` ` `` over a *selection* should
+  // still wrap it, which is the `surroundingPairs` list (independent of
+  // `autoClosingPairs` in Monaco).
+  it('still surrounds a selection with backticks', () => {
+    const pairs = qmdLanguageConfiguration.surroundingPairs ?? [];
+    expect(
+      pairs.some((p) => p.open === '`' && p.close === '`'),
+      'backtick must remain in surroundingPairs so wrap-selection still works',
+    ).toBe(true);
   });
 });

--- a/hub-client/src/components/quartoTheme.ts
+++ b/hub-client/src/components/quartoTheme.ts
@@ -157,7 +157,7 @@ export const qmdMonarch: Monaco.languages.IMonarchLanguage = {
   },
 };
 
-const qmdLanguageConfiguration: Monaco.languages.LanguageConfiguration = {
+export const qmdLanguageConfiguration: Monaco.languages.LanguageConfiguration = {
   comments: { blockComment: ['<!--', '-->'] },
   brackets: [
     ['[', ']'],
@@ -168,7 +168,11 @@ const qmdLanguageConfiguration: Monaco.languages.LanguageConfiguration = {
     { open: '[', close: ']' },
     { open: '(', close: ')' },
     { open: '{', close: '}' },
-    { open: '`', close: '`' },
+    // NOTE: backtick is intentionally NOT auto-closed (bd-w1s38lbe). Monaco
+    // auto-closes only when the next char is whitespace/EOL, so wrapping an
+    // existing word — `` ` `` before it, then `` ` `` after it — doubled the
+    // trailing backtick. It stays in `surroundingPairs` below so typing `` ` ``
+    // over a selection still wraps it.
     { open: '"', close: '"' },
     { open: '$', close: '$' },
   ],


### PR DESCRIPTION
## Problem

A quarto-hub.com user reported that wrapping an existing word in inline code is awkward in the **Monaco** editor:

> If I have existing text with a word that I want to wrap in inline backticks, I'll go to the front of the word and add a backtick, then when I go to the end of the word and add a backtick, it adds two of them, and I have to delete one.

## Root cause

The `qmd` Monaco language configuration (`hub-client/src/components/quartoTheme.ts`) listed the backtick in `autoClosingPairs`. Monaco only auto-closes when the next character is whitespace/EOL — never a word character — which produces the exact asymmetry reported:

- **Front of word** (`` `|word``): next char is `w`, so no auto-close → one backtick.
- **End of word** (`` `word|``): next char is EOL, so Monaco auto-closes → the pair is inserted → two backticks, one of which must be deleted.

## Fix

Remove the backtick from `autoClosingPairs`. It stays in `surroundingPairs`, so typing `` ` `` over a *selection* still wraps it (Monaco treats the two lists independently). This is the minimal, targeted change — other auto-closing pairs (`[`, `(`, `{`, `"`, `$`) are untouched.

## Tests

- Added a regression test in `quartoTheme.test.ts` (exporting `qmdLanguageConfiguration`): backtick must be **absent** from `autoClosingPairs` and **present** in `surroundingPairs`. Confirmed it failed before the fix and passes after.
- `npm run test:ci` → 18 files / 121 tests pass.
- `npm run build:all` → clean production build.
- **End-to-end**: verified in a browser against a local hub-client — typing `` ` `` at the end of a word now inserts a single backtick, and wrap-selection still works.

Plan: `claude-notes/plans/2026-06-24-monaco-backtick-autoclose.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)