### PR TITLE
chore(release): bump workspace version to 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,7 +654,7 @@ dependencies = [
 
 [[package]]
 name = "comrak-to-pandoc"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "comrak",
  "hashlink",
@@ -3407,7 +3407,7 @@ dependencies = [
 
 [[package]]
 name = "quarto"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3444,7 +3444,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-analysis"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "insta",
  "quarto-error-reporting",
@@ -3470,7 +3470,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-brand"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3480,7 +3480,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-citeproc"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "glob",
  "hashlink",
@@ -3513,7 +3513,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-core"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3567,7 +3567,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-csl"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "insta",
  "quarto-error-reporting",
@@ -3606,7 +3606,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-error-reporting"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "ariadne",
  "once_cell",
@@ -3620,7 +3620,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-highlight"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "hashlink",
  "insta",
@@ -3649,7 +3649,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-highlight-encoding"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3657,7 +3657,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-hub"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "automerge",
@@ -3701,7 +3701,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-lsp"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "insta",
@@ -3717,7 +3717,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-lsp-core"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "insta",
  "pampa",
@@ -3740,7 +3740,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-mcp-launcher"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -3756,7 +3756,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-navigation"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "quarto-config",
  "quarto-pandoc-types",
@@ -3791,7 +3791,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-preview"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "automerge",
@@ -3823,7 +3823,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-project-create"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "quarto-doctemplate",
  "serde",
@@ -3832,7 +3832,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-publish"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3857,7 +3857,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-sass"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "grass",
  "include_dir",
@@ -3879,7 +3879,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-source-map"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3888,7 +3888,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-system-runtime"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3906,7 +3906,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-test"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "quarto-core",
@@ -3923,7 +3923,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-trace"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "flate2",
  "serde",
@@ -3934,7 +3934,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-trace-server"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3961,7 +3961,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-util"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -3969,7 +3969,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-xml"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "insta",
  "quarto-error-reporting",
@@ -3980,7 +3980,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-yaml"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "quarto-source-map",
  "regex",
@@ -3991,7 +3991,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-yaml-validation"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "insta",
@@ -4187,7 +4187,7 @@ dependencies = [
 
 [[package]]
 name = "reconcile-viewer"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "clap",
  "hashlink",
@@ -5994,7 +5994,7 @@ dependencies = [
 
 [[package]]
 name = "validate-yaml"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -6183,7 +6183,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-printf-fmt"
-version = "0.6.0"
+version = "0.7.0"
 
 [[package]]
 name = "wasmparser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Posit Software, PBC"]
 homepage = "https://github.com/posit-dev/quarto-markdown-syntax"
 keywords = ["parser"]


### PR DESCRIPTION
Bumps `[workspace.package].version` from `0.6.0` → `0.7.0` in preparation for the **v0.7.0** binary release.

- `cargo update --workspace` refreshed only the 31 workspace members in `Cargo.lock` (external deps untouched).
- `cargo build --bin q2 --locked` succeeds; `q2 --version` → `q2 (quarto 2) 0.7.0`.

Once merged, the `v0.7.0` tag is pushed against the merge commit to trigger the `Release` workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)