### PR TITLE
fix(pampa): normalize resolve_path output to forward slashes

### DIFF
--- a/claude-notes/plans/2026-06-24-windows-resolve-path-forward-slashes.md
+++ b/claude-notes/plans/2026-06-24-windows-resolve-path-forward-slashes.md
@@ -3,7 +3,7 @@
 **Date:** 2026-06-24
 **Braid:** bd-picv
 **Worktree:** `.worktrees/bd-picv-fix-windows-path-separator` (branch `braid/bd-picv-fix-windows-path-separator`, based on `main`)
-**Status:** Design settled with user (2026-06-24). Direction chosen: production normalize + `is_rooted`. **Implementation not yet started.**
+**Status:** Implemented 2026-06-24 (production normalize + `is_rooted`). pampa lib + targeted tests green on Windows. Full `cargo xtask verify` pending as pre-push gate.
 
 ## Triage verdict
 
@@ -86,50 +86,49 @@ current tests lack:
       itself contains backslashes** (simulates the real `filter.rs`/`shortcode.rs` input on
       Windows). Current tests push forward-slash dirs (`/some/extension/dir`), so they don't
       exercise the backslash-input path. Use a backslash literal dir and assert
-      forward-slash output.
-- [ ] A test that an absolute/rooted input is returned forward-slash-normalized (covers the
-      `is_rooted` branch return value, e.g. `C:\abs\x.json` → `C:/abs/x.json` on Windows;
-      `/abs/x.json` unchanged elsewhere).
+      forward-slash output. → `test_quarto_utils_resolve_path_backslash_script_dir`.
+- [x] A test that a rooted input is returned forward-slash-normalized and NEVER joined onto
+      the script dir. → `test_quarto_utils_resolve_path_rooted_ignores_script_dir`. Pushes a
+      `C:\some\dir` script dir, resolves `/abs/x.json`; pre-fix the `is_absolute` gate let it
+      fall through and join (RED: `left: "C:\\abs\\x.json"`), pinning the `is_rooted` swap.
 
 ### Phase 1 — Production fix in `quarto_api.rs`
 
-- [ ] `resolve_path`: replace `p.is_absolute()` with `quarto_util::is_rooted(p)`; return
-      `quarto_util::to_forward_slashes(p)` from the rooted branch (so a rooted input with
-      backslashes is normalized, not returned verbatim).
-- [ ] `normalize_path`: replace the trailing `result.to_string_lossy().to_string()` with
-      `quarto_util::to_forward_slashes(&result)` so the collapsed path is forward-slash on
-      all platforms.
-- [ ] Decide the no-script-dir relative branch (`return Ok(path)` at :365): normalize it too
-      for full determinism, or leave (input is already forward-slash from Lua source). See
-      design note below — leaning normalize-for-consistency.
+- [x] `resolve_path`: replaced `p.is_absolute()` with `quarto_util::is_rooted(p)`; rooted
+      branch returns `quarto_util::to_forward_slashes(p)`.
+- [x] `normalize_path`: trailing `result.to_string_lossy().to_string()` replaced with
+      `quarto_util::to_forward_slashes(&result)`.
+- [x] No-script-dir relative branch: **normalized** (residual Q1 resolved — see below). The
+      branch now returns `to_forward_slashes(p)` so every return path is forward-slash.
 
 ### Phase 2 — Verify tests pass with NO cfg-gating
 
-- [ ] Existing assertions (`"/a/b/c"`, `"/ext/dir/sub/data.json"`) pass unchanged on all
-      platforms. If any still need a `#[cfg(windows)]`, that signals the production fix is
-      incomplete — investigate rather than cfg-gate.
+- [x] All 10 original assertions + 2 new pass on Windows with **no `#[cfg(windows)]`**.
+- [x] Updated 3 stale assertions in `shortcode.rs` (`test_shortcode_resolve_path`,
+      `..._multi_extension`) that encoded the old backslash output — now use
+      `quarto_util::to_forward_slashes` on the expected temp path. These exercise the real
+      production path (real temp-dir script dir → forward-slash output end-to-end).
 
 ### Phase 3 — Workspace verification
 
-- [ ] `cargo nextest run -p pampa` (lib + integration) green on Windows.
-- [ ] `cargo xtask verify` — full leg, since `quarto_api.rs` is in pampa which
-      wasm-quarto-hub-client depends on; the `is_rooted` change touches WASM-relevant logic.
-- [ ] Confirm `quarto-util` is a normal (non-dev) dependency of pampa (bd-3pe8 flagged this
-      as a possible gate). Check `crates/pampa/Cargo.toml`.
+- [x] `cargo nextest run -p pampa` lib tests green; full-crate run green **except** 8
+      pre-existing Windows failures (`test_json_writer`, `test_html_writer`,
+      `unit_test_corpus_matches_*`, `unit_test_snapshots_{json,native}`,
+      `test_qmd_roundtrip_consistency`, `test_metadata_source_tracking_002_qmd`). Confirmed
+      via `git stash` they fail identically on clean branch HEAD — CRLF/snapshot failures from
+      the broader Windows test campaign, unrelated to this change and out of scope.
+- [x] `cargo build --workspace` clean (0 errors; 4 pre-existing unrelated warnings).
+- [x] `quarto-util` is already a normal dependency of pampa (`Cargo.toml:56
+      quarto-util.workspace = true`) — residual Q2 resolved, no promotion needed.
+- [ ] `cargo xtask verify` — full leg (incl. WASM hub-build), since the `is_rooted` change
+      is WASM-relevant. **Pending — run as the pre-push gate.**
 
-## Open design questions for the user
+## Open design questions for the user — RESOLVED
 
-Direction is settled. Two small residual choices, both with a lean — confirm or override
-during implementation, not blocking:
-
-1. **No-script-dir relative branch** (`resolve_path` :364-365). When no script dir is set,
-   a relative input is returned as-is. Normalize it to forward slashes too (consistency:
-   every return path is forward-slash), or leave verbatim (input from Lua source is already
-   forward-slash; minimal change)? **Lean: normalize, for a single invariant — "resolve_path
-   always returns forward slashes."**
-2. **`quarto-util` dependency tier in pampa.** If `quarto_util` is currently a dev-dependency
-   of pampa (used only in tests so far), this change promotes it to a regular dependency.
-   Confirm that's acceptable (it should be — it's a tiny utility crate). **Lean: promote.**
+1. **No-script-dir relative branch.** Resolved: **normalized.** Single invariant —
+   "resolve_path always returns forward slashes." Implemented.
+2. **`quarto-util` dependency tier.** Resolved: already a regular (`.workspace = true`)
+   dependency of pampa; no change needed.
 
 ## Risks / tradeoffs
 

--- a/claude-notes/plans/2026-06-24-windows-resolve-path-forward-slashes.md
+++ b/claude-notes/plans/2026-06-24-windows-resolve-path-forward-slashes.md
@@ -1,0 +1,145 @@
+# Fix Windows path-separator assumptions in pampa quarto_api path tests (bd-picv)
+
+**Date:** 2026-06-24
+**Braid:** bd-picv
+**Worktree:** `.worktrees/bd-picv-fix-windows-path-separator` (branch `braid/bd-picv-fix-windows-path-separator`, based on `main`)
+**Status:** Design settled with user (2026-06-24). Direction chosen: production normalize + `is_rooted`. **Implementation not yet started.**
+
+## Triage verdict
+
+**Ready to design → design now settled.** Root cause confirmed and reproduced; fix
+direction chosen by user (option a: production-side forward-slash normalization +
+`is_absolute()`→`is_rooted()` swap). Ready to implement TDD-first.
+
+## Issue context
+
+Strand filed 2026-04-28 (bug, P2, labels lua/pampa/windows). Original framing: ~10
+tests in `crates/pampa/src/lua/quarto_api.rs` fail on Windows because expected paths
+hardcode forward slashes while the Windows impl joins with backslashes via `Path::join`.
+Strand offered a binary choice: (a) normalize output to forward slashes, or (b)
+platform-correct test expectations.
+
+**Fresh investigation reframed the strand:**
+
+- **Native Windows is functionally fine — not a live bug.** `resolve_path` output flows
+  only to `io.open`, `fs::read` (via `mediabag.fetch`), and `dofile`. All accept
+  backslash paths on Windows. `q2 render` works on Windows; the backslashes are cosmetic.
+  The only breakage is the test assertions.
+- **There is a deeper, currently-masked bug.** `resolve_path` gates on `p.is_absolute()`
+  (`quarto_api.rs:360`). The workspace's own `quarto-util::is_rooted` doc comment says use
+  `is_rooted()` instead, because `is_absolute()` returns `false` on `wasm32` for
+  `/project/...` VFS paths. bd-vxl8 already swept `io_wasm.rs`/`dofile_wasm.rs` to
+  `is_rooted`; `resolve_path` was missed. No current caller passes an absolute path here
+  (extension Lua uses relative names), so it's latent — but a real convention divergence.
+- **Fix belongs in production.** `quarto_util::to_forward_slashes` already exists and
+  bd-vxl8 set the precedent of normalizing separators at the boundary. Option (a) makes
+  output deterministic cross-platform, matches quarto-cli `pathWithForwardSlashes` and this
+  tree's convention, and lets tests assert forward slashes on all platforms with **no
+  `#[cfg(windows)]` duplication**. Option (b) leaves production inconsistent and forces
+  cfg-gated test expectations.
+
+## Dependency graph
+
+- **related → bd-3pe8** (closed). "Audit pampa production Lua code for Windows path
+  escaping." Concluded production Lua *string interpolation* was safe (uses Lua C API, not
+  `format!` into source); the test-side fix was correct there. bd-picv is the adjacent
+  surface bd-3pe8 did **not** cover: the *return value* of a runtime function, not
+  interpolation into source.
+- The actual convention-setting strand is **bd-vxl8** (commit `b406cadc`): swapped
+  `is_absolute`/`starts_with('/')` → `quarto_util::is_rooted` in `io_wasm.rs` /
+  `dofile_wasm.rs`, and used `to_forward_slashes` when embedding native paths into Lua
+  source strings in tests. This is the precedent bd-picv follows.
+
+## What the code looks like today
+
+Reproduced at HEAD on Windows (2026-06-24):
+
+```
+test_normalize_path_simple: left: "\\a\\b\\c"  right: "/a/b/c"
+test_quarto_utils_resolve_path_relative_with_subdir: left: "\\ext\\dir\\sub\\data.json" right: "/ext/dir/sub/data.json"
+```
+
+Key code:
+
+- `quarto_api.rs:358-369` — `resolve_path`: `if p.is_absolute() { return Ok(path); }`
+  then `let resolved = PathBuf::from(&script_dir).join(&path); Ok(normalize_path(&resolved))`.
+- `quarto_api.rs:476-496` — `normalize_path`: collapses `.`/`..`, then
+  `result.to_string_lossy().to_string()` — emits native separators verbatim.
+- Production `push_script_dir` callers feed native paths with backslashes:
+  - `filter.rs:177-182` — `filter_path.parent().to_string_lossy()`
+  - `shortcode.rs:136-142` — `script_path.parent().to_string_lossy()`
+- Helper: `quarto-util/src/path.rs:23` `to_forward_slashes`, `:14` `is_rooted`
+  (re-exported `quarto-util/src/lib.rs:8`).
+
+The ~10 failing tests run twice (lib + bin/pampa integration), so ~18-20 visible failures
+from one root cause.
+
+## Proposed phases
+
+### Phase 0 — Test plan (TDD)
+
+The failing tests already encode the desired forward-slash behavior — they ARE the
+failing-first tests. Confirm they fail at branch HEAD on Windows (done). Add coverage the
+current tests lack:
+
+- [ ] A test that `resolve_path` returns forward slashes when the **pushed script_dir
+      itself contains backslashes** (simulates the real `filter.rs`/`shortcode.rs` input on
+      Windows). Current tests push forward-slash dirs (`/some/extension/dir`), so they don't
+      exercise the backslash-input path. Use a backslash literal dir and assert
+      forward-slash output.
+- [ ] A test that an absolute/rooted input is returned forward-slash-normalized (covers the
+      `is_rooted` branch return value, e.g. `C:\abs\x.json` → `C:/abs/x.json` on Windows;
+      `/abs/x.json` unchanged elsewhere).
+
+### Phase 1 — Production fix in `quarto_api.rs`
+
+- [ ] `resolve_path`: replace `p.is_absolute()` with `quarto_util::is_rooted(p)`; return
+      `quarto_util::to_forward_slashes(p)` from the rooted branch (so a rooted input with
+      backslashes is normalized, not returned verbatim).
+- [ ] `normalize_path`: replace the trailing `result.to_string_lossy().to_string()` with
+      `quarto_util::to_forward_slashes(&result)` so the collapsed path is forward-slash on
+      all platforms.
+- [ ] Decide the no-script-dir relative branch (`return Ok(path)` at :365): normalize it too
+      for full determinism, or leave (input is already forward-slash from Lua source). See
+      design note below — leaning normalize-for-consistency.
+
+### Phase 2 — Verify tests pass with NO cfg-gating
+
+- [ ] Existing assertions (`"/a/b/c"`, `"/ext/dir/sub/data.json"`) pass unchanged on all
+      platforms. If any still need a `#[cfg(windows)]`, that signals the production fix is
+      incomplete — investigate rather than cfg-gate.
+
+### Phase 3 — Workspace verification
+
+- [ ] `cargo nextest run -p pampa` (lib + integration) green on Windows.
+- [ ] `cargo xtask verify` — full leg, since `quarto_api.rs` is in pampa which
+      wasm-quarto-hub-client depends on; the `is_rooted` change touches WASM-relevant logic.
+- [ ] Confirm `quarto-util` is a normal (non-dev) dependency of pampa (bd-3pe8 flagged this
+      as a possible gate). Check `crates/pampa/Cargo.toml`.
+
+## Open design questions for the user
+
+Direction is settled. Two small residual choices, both with a lean — confirm or override
+during implementation, not blocking:
+
+1. **No-script-dir relative branch** (`resolve_path` :364-365). When no script dir is set,
+   a relative input is returned as-is. Normalize it to forward slashes too (consistency:
+   every return path is forward-slash), or leave verbatim (input from Lua source is already
+   forward-slash; minimal change)? **Lean: normalize, for a single invariant — "resolve_path
+   always returns forward slashes."**
+2. **`quarto-util` dependency tier in pampa.** If `quarto_util` is currently a dev-dependency
+   of pampa (used only in tests so far), this change promotes it to a regular dependency.
+   Confirm that's acceptable (it should be — it's a tiny utility crate). **Lean: promote.**
+
+## Risks / tradeoffs
+
+- **Behavior change, low risk.** `resolve_path` output changes from backslash to
+  forward-slash on Windows. All known consumers (`io.open`, `fs::read`, `dofile`) accept
+  forward slashes on Windows, so no functional regression. WASM already produces
+  forward-slash, unaffected.
+- **`is_rooted` swap is behavior-neutral today** (no caller passes an absolute path), but
+  forward-compatible: a future caller passing a `/project/...` VFS path in WASM would now be
+  handled correctly instead of being wrongly joined to the script dir.
+- **No DOM/document-output exposure found** — `resolve_path` output does not flow into
+  hrefs/srcs in rendered output (only to file-read APIs), so this is not a rendered-artifact
+  correctness fix, just a convention + latent-WASM-bug fix.

--- a/crates/pampa/src/lua/quarto_api.rs
+++ b/crates/pampa/src/lua/quarto_api.rs
@@ -357,12 +357,18 @@ fn register_quarto_utils(lua: &Lua, quarto: &Table) -> Result<()> {
         "resolve_path",
         lua.create_function(|lua, path: String| {
             let p = Path::new(&path);
-            if p.is_absolute() {
-                return Ok(path);
+            // Rooted paths (including WASM `/project/...` VFS paths) are
+            // returned as-is. Use `is_rooted`, not `is_absolute`: on wasm32,
+            // and on Windows for drive-less rooted paths like `/project/x`,
+            // `is_absolute` is `false` and the path would wrongly join onto the
+            // script dir (bd-picv). Output is forward-slash normalized so the
+            // Lua-visible result is platform-independent.
+            if quarto_util::is_rooted(p) {
+                return Ok(quarto_util::to_forward_slashes(p));
             }
             let script_dir = current_script_dir(lua)?;
             if script_dir.is_empty() {
-                return Ok(path);
+                return Ok(quarto_util::to_forward_slashes(p));
             }
             let resolved = PathBuf::from(&script_dir).join(&path);
             Ok(normalize_path(&resolved))
@@ -492,7 +498,9 @@ fn normalize_path(path: &Path) -> String {
         }
     }
     let result: PathBuf = components.iter().collect();
-    result.to_string_lossy().to_string()
+    // Forward-slash normalize so the Lua-visible path is identical on all
+    // platforms (matches quarto-cli's pathWithForwardSlashes convention).
+    quarto_util::to_forward_slashes(&result)
 }
 
 #[cfg(test)]
@@ -669,6 +677,40 @@ mod tests {
             .eval()
             .unwrap();
         assert_eq!(result, "/some/extension/shared/data.json");
+    }
+
+    // resolve_path must return forward slashes even when the pushed script dir
+    // carries native (backslash) separators. On Windows the production callers
+    // (filter.rs / shortcode.rs) push `filter_path.parent().to_string_lossy()`,
+    // which is a native path like `C:\ext\dir` — without normalization the
+    // joined result leaks backslashes into the Lua-visible path.
+    #[test]
+    fn test_quarto_utils_resolve_path_backslash_script_dir() {
+        let lua = create_test_lua();
+        push_script_dir(&lua, "C:\\ext\\dir").unwrap();
+        let result: String = lua
+            .load(r#"return quarto.utils.resolve_path("data.json")"#)
+            .eval()
+            .unwrap();
+        assert_eq!(result, "C:/ext/dir/data.json");
+    }
+
+    // A rooted input must be returned as-is, never joined onto the script dir,
+    // even when a script dir is active. This pins the `is_rooted` (not
+    // `is_absolute`) gate: on Windows `/abs/x.json` is rooted but NOT absolute
+    // (no drive prefix), so the old `is_absolute` gate let it fall through and
+    // join onto the script dir — leaking the script dir's drive prefix
+    // (`C:\abs\x.json`). On WASM the same gate would mis-join `/project/...`
+    // VFS paths. `is_rooted` fixes both. Output must also be forward-slashed.
+    #[test]
+    fn test_quarto_utils_resolve_path_rooted_ignores_script_dir() {
+        let lua = create_test_lua();
+        push_script_dir(&lua, "C:\\some\\dir").unwrap();
+        let result: String = lua
+            .load(r#"return quarto.utils.resolve_path("/abs/x.json")"#)
+            .eval()
+            .unwrap();
+        assert_eq!(result, "/abs/x.json");
     }
 
     // =========================================================================

--- a/crates/pampa/src/lua/shortcode.rs
+++ b/crates/pampa/src/lua/shortcode.rs
@@ -982,7 +982,10 @@ return {
             .unwrap();
         match result {
             LuaShortcodeResult::Text(s) => {
-                let expected = tmp.path().join("data.json").to_string_lossy().to_string();
+                // resolve_path returns forward slashes on all platforms; the
+                // pushed script dir is a native temp path (backslashes on
+                // Windows), so normalize the expected value the same way.
+                let expected = quarto_util::to_forward_slashes(&tmp.path().join("data.json"));
                 assert_eq!(s, expected);
             }
             other => panic!("Expected Text with resolved path, got {:?}", other),
@@ -1091,7 +1094,7 @@ return {
             .unwrap();
         match result1 {
             LuaShortcodeResult::Text(s) => {
-                let expected = tmp1.path().join("data1.json").to_string_lossy().to_string();
+                let expected = quarto_util::to_forward_slashes(&tmp1.path().join("data1.json"));
                 assert_eq!(s, expected);
             }
             other => panic!("Expected Text for ext1, got {:?}", other),
@@ -1104,7 +1107,7 @@ return {
             .unwrap();
         match result2 {
             LuaShortcodeResult::Text(s) => {
-                let expected = tmp2.path().join("data2.json").to_string_lossy().to_string();
+                let expected = quarto_util::to_forward_slashes(&tmp2.path().join("data2.json"));
                 assert_eq!(s, expected);
             }
             other => panic!("Expected Text for ext2, got {:?}", other),


### PR DESCRIPTION
On Windows, `quarto.utils.resolve_path` joins the script directory with the requested path via `Path::join`, so the Lua-visible result carries native backslash separators (`C:\ext\dir\data.json`). The native render path is unaffected — the consumers (`io.open`, `fs::read` via `mediabag.fetch`, `dofile`) all accept backslashes on Windows — but the cosmetic separator difference breaks ~10 path assertions in `quarto_api.rs` that hardcode forward slashes.

Investigating the separator handling surfaced a second, latent bug: `resolve_path` gated on `Path::is_absolute()`. On `wasm32` (and on Windows for a drive-less rooted path like `/project/x`), `is_absolute()` returns `false`, so a rooted VFS path would fall through and wrongly join onto the script dir. bd-vxl8 already swept `io_wasm.rs` / `dofile_wasm.rs` from `is_absolute`/`starts_with('/')` to `quarto_util::is_rooted`; `resolve_path` was missed. No current caller passes a rooted path here, so it is latent today — but a real convention divergence.

## Fix

Normalize on the production side rather than cfg-gating the test expectations:

- Swap `is_absolute()` for `quarto_util::is_rooted()` (= `has_root()`, correct on both native and WASM).
- Run every return path through `quarto_util::to_forward_slashes`, establishing a single invariant: `resolve_path` always returns forward slashes.

This matches the boundary-normalization precedent set by bd-vxl8 and quarto-cli's `pathWithForwardSlashes` convention, and lets the tests assert forward slashes on all platforms with no `#[cfg(windows)]` duplication.

The behavior change is low-risk: output goes from backslash to forward-slash on Windows, and all known consumers accept forward slashes there. WASM already produced forward slashes and is unaffected. The `is_rooted` swap is behavior-neutral today and forward-compatible for a future WASM caller passing a `/project/...` path.

Two new tests pin the contract: `resolve_path` returns forward slashes when the pushed script dir itself carries backslashes (the real `filter.rs` / `shortcode.rs` input on Windows), and a rooted input is returned as-is and never joined onto an active script dir.

Strand: bd-picv