### PR TITLE
Fix command tests failing on Windows without Unix coreutils

### DIFF
--- a/claude-notes/plans/2026-06-25-fix-windows-lua-command-tests.md
+++ b/claude-notes/plans/2026-06-25-fix-windows-lua-command-tests.md
@@ -55,30 +55,86 @@ The `command` binding wiring, not the programs themselves:
 Any platform-appropriate program that produces the same observable behavior
 satisfies these contracts.
 
-## Draft phases (skeleton — design not finalized)
+## Scope: 8 tests, not 3 (confirmed)
 
-- [ ] Phase 1: make the three tests hermetic / platform-aware
-  - [ ] `test_command_success`: Windows uses `cmd` + `["/C", "echo", "hello"]`; Unix keeps `echo`.
-  - [ ] `test_command_failure`: Windows uses `cmd` + `["/C", "exit", "1"]`; Unix keeps `false`.
-  - [ ] `test_command_with_input`: stdin echo. Windows candidate `cmd /C more` or `sort` (reads stdin, writes it back); Unix keeps `cat`. Needs a verified choice — see design questions.
+The same disease lives in a second crate. All confirmed failing from PowerShell
+(coreutils-free PATH) with `program not found`:
+
+`crates/pampa/src/lua/system.rs` (Lua binding layer):
+- `test_command_success` — `echo` — assert `contains("hello")` *(tolerant)*
+- `test_command_failure` — `false` — assert integer exit *(tolerant)*
+- `test_command_with_input` — `cat` — assert `contains(...)` *(tolerant)*
+
+`crates/quarto-system-runtime/src/native.rs` (runtime layer):
+- `test_exec_command_success` — `echo` — `contains` *(tolerant)*
+- `test_exec_command_failure` — `false` — `!success()` *(tolerant)*
+- `test_exec_pipe_failure` — `false` — expects `ProcessFailed` *(tolerant)*
+- `test_exec_command_with_stdin` — `cat` — **`assert_eq!(stdout, "input data")`** *(strict)*
+- `test_exec_pipe_success` — `cat` — **`assert_eq!(output, b"pipe input")`** *(strict)*
+
+The two **strict** stdin tests are the design wrinkle: no stock Windows program
+echoes stdin **verbatim** — `findstr`/`sort`/`more` all append `\r\n`. The
+runtime *does* pass bytes through unchanged (`exec_command` is byte-clean); the
+trailing CRLF is an artifact of the chosen Windows echo program, not the
+runtime. So the strict assertions must compare `trim_end()` (or `contains`) on
+Windows, otherwise the program's CRLF breaks an otherwise-correct round-trip.
+
+## Verified program choices (Windows)
+
+Tested from a coreutils-free shell — all exit 0, all round-trip the input:
+
+| Concept | Unix | Windows |
+|---|---|---|
+| print arg, exit 0 | `echo hello` | `cmd /C echo hello` |
+| nonzero exit | `false` | `cmd /C exit 1` |
+| echo stdin | `cat` | `findstr "^"` (matches every line, preserves order) |
+
+`cmd.exe`, `findstr.exe`, `sort.exe` are all in `C:\Windows\System32` — present
+on every Windows install. Chose `findstr "^"` over `sort` (sort reorders
+multi-line input; findstr preserves it — safer if a fixture grows).
+
+## Design (option A — cross-platform, keep Windows coverage)
+
+Per-crate, test-only `#[cfg]` helpers (the two crates can't share a helper
+without a new test-util dependency; duplication is two tiny functions):
+
+```rust
+// returns the program + args for "print hello, exit 0"
+#[cfg(not(windows))]
+fn echo_cmd() -> (&'static str, &'static [&'static str]) { ("echo", &["hello"]) }
+#[cfg(windows)]
+fn echo_cmd() -> (&'static str, &'static [&'static str]) { ("cmd", &["/C", "echo", "hello"]) }
+```
+
+(pampa's tests build a Lua string, so its helpers return the `command(...)`
+snippet instead; same cfg shape.)
+
+For the two **strict** stdin tests, swap the program via the helper AND relax
+the assertion to line-ending-tolerant:
+
+```rust
+assert_eq!(output.stdout_string().trim_end(), "input data");
+```
+
+A one-line doc comment on each helper explains why (Pandoc-compatible
+`exec_command` spawns directly with no shell; Unix coreutils are absent on a
+stock Windows box; the strict tests trim because the Windows echo program adds
+CRLF).
+
+## Phases
+
+- [ ] Phase 1 (TDD): confirm red, then fix
+  - [ ] Confirm the 8 tests fail from PowerShell (done — evidence above).
+  - [ ] pampa: cfg-helpers for the 3 `command` tests.
+  - [ ] native: cfg-helpers for the 5 exec tests; trim-compare the 2 strict ones.
 - [ ] Phase 2: verify
-  - [ ] Run the three tests from **PowerShell** (coreutils-free PATH) — must pass.
-  - [ ] Run from Git Bash — must still pass.
+  - [ ] All 8 pass from **PowerShell** (coreutils-free).
+  - [ ] All 8 still pass from **Git Bash**.
   - [ ] `cargo xtask verify --skip-hub-build`.
 
-## Design questions for Chris
+## Open question for Chris
 
-1. **Shape of the fix.** Platform-gate the command strings with
-   `cfg!(windows)` inside each test (smallest change), or factor a single
-   `#[cfg(windows)]` / `#[cfg(unix)]` helper returning `(cmd, args, input)`
-   tuples for the three cases (DRYer, one place to maintain)? Leaning toward
-   the helper since all three share the same pattern.
-2. **stdin-echo program on Windows.** `cmd /C more` mangles short input and
-   adds a trailing form-feed in some shells; `sort` with no args reads stdin and
-   echoes lines but reorders multi-line input (fine for the single-line test
-   fixture). Which do you want — `sort`, `more`, `findstr "^"`, or a different
-   approach? I'll verify the chosen one actually round-trips before committing.
-3. **Scope.** This strand is the three `command` tests only. While running the
-   full suite from PowerShell I can catch any *other* coreutils-dependent tests
-   in the same pass — want me to file those as separate strands (the Windows
-   test-fix campaign), or keep this one narrow?
+**Scope confirmation.** Fix all 8 here (one mechanical change, one root cause),
+or keep this strand to pampa's 3 and file the 5 `native.rs` ones as a linked
+sibling strand? I lean fix-all-8 — splitting leaves the workspace red on Windows
+for no benefit, and the fix is identical in shape.

--- a/claude-notes/plans/2026-06-25-fix-windows-lua-command-tests.md
+++ b/claude-notes/plans/2026-06-25-fix-windows-lua-command-tests.md
@@ -1,0 +1,84 @@
+# Fix Windows test failures: lua system command tests use Unix-only programs
+
+Strand: bd-c5bdf948
+Date: 2026-06-25
+
+## Verdict
+
+**Tests problem, not tools problem.** The `exec_command` runtime is correct and
+Pandoc-compatible; the three tests are non-hermetic and assume Unix coreutils on
+`PATH`.
+
+## Overview
+
+Three tests in `crates/pampa/src/lua/system.rs` call programs that are not
+standalone executables on a stock Windows install:
+
+- `test_command_success` → `echo` (a `cmd`/PowerShell builtin, not a binary)
+- `test_command_failure` → `false` (Unix utility)
+- `test_command_with_input` → `cat` (Unix utility)
+
+All three fail with `RuntimeError("I/O error: program not found")`.
+
+## Investigation findings (evidence)
+
+The failure is **PATH-dependent**, which is why it looked intermittent:
+
+| Run environment | `echo`/`false`/`cat` on PATH? | Result |
+|---|---|---|
+| Bash tool (Git Bash) | Yes — `C:\Program Files\Git\usr\bin\{echo,false,cat}.exe` | **PASS** (8/8) |
+| PowerShell tool (no Git usr/bin) | No | **FAIL** (3/3 command tests) |
+
+`where.exe echo` → `C:\Program Files\Git\usr\bin\echo.exe`; the same for `false`
+and `cat`. Git Bash puts `usr/bin` (MSYS2 coreutils) on PATH, so any process
+spawned from a Git Bash shell inherits real `echo.exe`/`cat.exe`/`false.exe`.
+PowerShell, `cmd`, and a clean CI runner do **not** — so `Command::new("echo")`
+returns "program not found". That is the environment the strand was filed from.
+
+### Why this is NOT a tools bug
+
+`SystemRuntime::exec_command` (`crates/quarto-system-runtime/src/native.rs:216`)
+is a direct `Command::new(command).args(args).spawn()` — no shell. This matches
+Pandoc's `pandoc.system.command`, which also spawns the program directly with no
+shell. On a stock Windows box a Lua filter author calling
+`pandoc.system.command('echo', …)` would hit the same "program not found" — that
+is correct, Pandoc-compatible behavior. Making the *tool* paper over missing
+Unix programs would diverge from Pandoc and is the wrong fix.
+
+### What the tests actually exercise
+
+The `command` binding wiring, not the programs themselves:
+- `test_command_success` — exit-code-0 maps to `Value::Boolean(false)`, stdout captured.
+- `test_command_failure` — non-zero exit maps to `Value::Integer(code)`.
+- `test_command_with_input` — stdin piping + stdout capture round-trips.
+
+Any platform-appropriate program that produces the same observable behavior
+satisfies these contracts.
+
+## Draft phases (skeleton — design not finalized)
+
+- [ ] Phase 1: make the three tests hermetic / platform-aware
+  - [ ] `test_command_success`: Windows uses `cmd` + `["/C", "echo", "hello"]`; Unix keeps `echo`.
+  - [ ] `test_command_failure`: Windows uses `cmd` + `["/C", "exit", "1"]`; Unix keeps `false`.
+  - [ ] `test_command_with_input`: stdin echo. Windows candidate `cmd /C more` or `sort` (reads stdin, writes it back); Unix keeps `cat`. Needs a verified choice — see design questions.
+- [ ] Phase 2: verify
+  - [ ] Run the three tests from **PowerShell** (coreutils-free PATH) — must pass.
+  - [ ] Run from Git Bash — must still pass.
+  - [ ] `cargo xtask verify --skip-hub-build`.
+
+## Design questions for Chris
+
+1. **Shape of the fix.** Platform-gate the command strings with
+   `cfg!(windows)` inside each test (smallest change), or factor a single
+   `#[cfg(windows)]` / `#[cfg(unix)]` helper returning `(cmd, args, input)`
+   tuples for the three cases (DRYer, one place to maintain)? Leaning toward
+   the helper since all three share the same pattern.
+2. **stdin-echo program on Windows.** `cmd /C more` mangles short input and
+   adds a trailing form-feed in some shells; `sort` with no args reads stdin and
+   echoes lines but reorders multi-line input (fine for the single-line test
+   fixture). Which do you want — `sort`, `more`, `findstr "^"`, or a different
+   approach? I'll verify the chosen one actually round-trips before committing.
+3. **Scope.** This strand is the three `command` tests only. While running the
+   full suite from PowerShell I can catch any *other* coreutils-dependent tests
+   in the same pass — want me to file those as separate strands (the Windows
+   test-fix campaign), or keep this one narrow?

--- a/crates/pampa/src/lua/system.rs
+++ b/crates/pampa/src/lua/system.rs
@@ -505,6 +505,26 @@ mod tests {
         (lua, runtime)
     }
 
+    // pandoc.system.command spawns the program directly with no shell (matching
+    // Pandoc), so these tests must name a program that exists on the platform.
+    // Unix coreutils (echo/false/cat) are not standalone executables on a stock
+    // Windows box, so Windows routes through cmd.exe / findstr.exe (both always
+    // present in System32).
+    #[cfg(not(windows))]
+    const ECHO_COMMAND: &str = "pandoc.system.command('echo', {'hello'})";
+    #[cfg(windows)]
+    const ECHO_COMMAND: &str = "pandoc.system.command('cmd', {'/C', 'echo', 'hello'})";
+
+    #[cfg(not(windows))]
+    const FALSE_COMMAND: &str = "pandoc.system.command('false', {})";
+    #[cfg(windows)]
+    const FALSE_COMMAND: &str = "pandoc.system.command('cmd', {'/C', 'exit', '1'})";
+
+    #[cfg(not(windows))]
+    const CAT_STDIN_COMMAND: &str = "pandoc.system.command('cat', {}, 'hello from stdin')";
+    #[cfg(windows)]
+    const CAT_STDIN_COMMAND: &str = "pandoc.system.command('findstr', {'^'}, 'hello from stdin')";
+
     #[test]
     fn test_os_and_arch() {
         let (lua, _) = create_test_lua();
@@ -686,10 +706,7 @@ mod tests {
     fn test_command_success() {
         let (lua, _) = create_test_lua();
 
-        let result: (Value, String, String) = lua
-            .load("pandoc.system.command('echo', {'hello'})")
-            .eval()
-            .unwrap();
+        let result: (Value, String, String) = lua.load(ECHO_COMMAND).eval().unwrap();
 
         // On success, first value should be false
         assert_eq!(result.0, Value::Boolean(false));
@@ -700,10 +717,7 @@ mod tests {
     fn test_command_failure() {
         let (lua, _) = create_test_lua();
 
-        let result: (Value, String, String) = lua
-            .load("pandoc.system.command('false', {})")
-            .eval()
-            .unwrap();
+        let result: (Value, String, String) = lua.load(FALSE_COMMAND).eval().unwrap();
 
         // On failure, first value should be the exit code
         match result.0 {
@@ -871,11 +885,8 @@ mod tests {
     fn test_command_with_input() {
         let (lua, _) = create_test_lua();
 
-        // Test command with stdin input (cat echoes back input)
-        let result: (Value, String, String) = lua
-            .load("pandoc.system.command('cat', {}, 'hello from stdin')")
-            .eval()
-            .unwrap();
+        // Test command with stdin input (the program echoes back stdin)
+        let result: (Value, String, String) = lua.load(CAT_STDIN_COMMAND).eval().unwrap();
 
         assert_eq!(result.0, Value::Boolean(false));
         assert!(result.1.contains("hello from stdin"));

--- a/crates/quarto-system-runtime/src/native.rs
+++ b/crates/quarto-system-runtime/src/native.rs
@@ -519,6 +519,39 @@ mod tests {
         NativeRuntime::new()
     }
 
+    // exec_command/exec_pipe spawn the program directly with no shell, so these
+    // tests must name a program that exists on the platform. Unix coreutils
+    // (echo/false/cat) are not standalone executables on a stock Windows box, so
+    // Windows routes through cmd.exe / findstr.exe (both always present in
+    // System32). The runtime is byte-clean; the Windows echo program appends
+    // CRLF, which is why the stdin round-trip assertions trim trailing newlines.
+    #[cfg(not(windows))]
+    fn echo_cmd() -> (&'static str, &'static [&'static str]) {
+        ("echo", &["hello"])
+    }
+    #[cfg(windows)]
+    fn echo_cmd() -> (&'static str, &'static [&'static str]) {
+        ("cmd", &["/C", "echo", "hello"])
+    }
+
+    #[cfg(not(windows))]
+    fn false_cmd() -> (&'static str, &'static [&'static str]) {
+        ("false", &[])
+    }
+    #[cfg(windows)]
+    fn false_cmd() -> (&'static str, &'static [&'static str]) {
+        ("cmd", &["/C", "exit", "1"])
+    }
+
+    #[cfg(not(windows))]
+    fn cat_cmd() -> (&'static str, &'static [&'static str]) {
+        ("cat", &[])
+    }
+    #[cfg(windows)]
+    fn cat_cmd() -> (&'static str, &'static [&'static str]) {
+        ("findstr", &["^"])
+    }
+
     #[test]
     fn test_file_read_write() {
         let temp = TempFileTempDir::new().unwrap();
@@ -722,7 +755,8 @@ mod tests {
     fn test_exec_command_success() {
         let rt = runtime();
 
-        let output = rt.exec_command("echo", &["hello"], None).unwrap();
+        let (cmd, args) = echo_cmd();
+        let output = rt.exec_command(cmd, args, None).unwrap();
 
         assert!(output.success());
         assert!(output.stdout_string().contains("hello"));
@@ -732,7 +766,8 @@ mod tests {
     fn test_exec_command_failure() {
         let rt = runtime();
 
-        let output = rt.exec_command("false", &[], None).unwrap();
+        let (cmd, args) = false_cmd();
+        let output = rt.exec_command(cmd, args, None).unwrap();
 
         assert!(!output.success());
     }
@@ -741,26 +776,33 @@ mod tests {
     fn test_exec_command_with_stdin() {
         let rt = runtime();
 
-        let output = rt.exec_command("cat", &[], Some(b"input data")).unwrap();
+        let (cmd, args) = cat_cmd();
+        let output = rt.exec_command(cmd, args, Some(b"input data")).unwrap();
 
         assert!(output.success());
-        assert_eq!(output.stdout_string(), "input data");
+        // trim_end: the Windows echo program (findstr) appends CRLF; the runtime
+        // itself passes stdin through unchanged.
+        assert_eq!(output.stdout_string().trim_end(), "input data");
     }
 
     #[test]
     fn test_exec_pipe_success() {
         let rt = runtime();
 
-        let output = rt.exec_pipe("cat", &[], b"pipe input").unwrap();
+        let (cmd, args) = cat_cmd();
+        let output = rt.exec_pipe(cmd, args, b"pipe input").unwrap();
 
-        assert_eq!(output, b"pipe input");
+        // trim_end: the Windows echo program (findstr) appends CRLF; the runtime
+        // itself passes stdin through unchanged.
+        assert_eq!(String::from_utf8_lossy(&output).trim_end(), "pipe input");
     }
 
     #[test]
     fn test_exec_pipe_failure() {
         let rt = runtime();
 
-        let result = rt.exec_pipe("false", &[], b"");
+        let (cmd, args) = false_cmd();
+        let result = rt.exec_pipe(cmd, args, b"");
 
         assert!(matches!(result, Err(RuntimeError::ProcessFailed { .. })));
     }


### PR DESCRIPTION
On Windows, eight tests in `pampa` and `quarto-system-runtime` panic with `RuntimeError("I/O error: program not found")`. They run `echo`, `false`, and `cat` through the no-shell command runner, and none of those exist as standalone executables on a stock Windows install.

The failure is PATH-dependent, which is why it surfaces inconsistently: a dev machine with Git Bash on PATH has MSYS2's `echo.exe`/`false.exe`/`cat.exe` in `usr/bin`, so the tests pass there. Bare PowerShell and CI have no such binaries, so the spawn fails.

This is a test problem, not a runtime bug. `exec_command` spawns the program directly with no shell, matching Pandoc's `pandoc.system.command` — a filter author calling `pandoc.system.command('echo', …)` on stock Windows would hit the same error. The runtime is correct and left unchanged.

## Fix

Route the Windows cases through programs that always exist in `System32` — `cmd /C echo`, `cmd /C exit 1`, and `findstr "^"` for stdin echo — via cfg-gated test helpers. Unix keeps `echo`/`false`/`cat`. The two byte-exact stdin round-trip assertions trim trailing newlines, since `findstr` appends CRLF while the runtime passes stdin through unchanged.

Verified locally: the eight tests pass from both PowerShell (coreutils-free PATH) and Git Bash (coreutils present).

## Test Plan

- [ ] Eight target tests pass from PowerShell (no coreutils on PATH)
- [ ] Same tests still pass from Git Bash (coreutils present)
- [ ] macOS/Linux unaffected (Unix arm unchanged)
