### PR TITLE
q2 preview: hierarchical block navigator + fix breadcrumb/toolbar overlap (bd-9x3zbuj8)

### DIFF
--- a/claude-notes/plans/2026-06-25-q2-preview-hierarchy-nav-and-overlap.md
+++ b/claude-notes/plans/2026-06-25-q2-preview-hierarchy-nav-and-overlap.md
@@ -1,0 +1,354 @@
+# q2 preview: hierarchical block navigator + breadcrumb/toolbar overlap
+
+**Strand:** bd-9x3zbuj8
+**Date:** 2026-06-25
+**Status:** DRAFT — awaiting user review before implementation
+
+## Overview
+
+Two independent changes to the `q2 preview` live block editor (the tiptap
+rich-text editor, bd-sjb4pzx8 lineage):
+
+1. **Task 1 — Bring the hierarchical block navigator to `q2 preview --allow-edit`.**
+   The `BreadcrumbChip` (`◀ Dv ¶ ▶` ancestor-path navigator) ships in
+   hub-client / quarto-hub.com but is invisible in `q2 preview`. It is gated
+   solely on `PreviewContext.unlockNestingCursor`, which the SPA defaults OFF.
+2. **Task 2 — Fix the breadcrumb / rich-text-toolbar overlap.** When a nested
+   rich-text block is open, `BreadcrumbChip` and `RichTextToolbar` collide at
+   the block's top-left. Move the breadcrumb to the **right** of the
+   fixed-position rich-text controls so they sit side by side.
+
+Both features live in the **shared** `@quarto/preview-renderer` package
+(`ts-packages/preview-renderer/src/q2-preview/`), consumed by both hub-client
+and the q2-preview SPA. The mount points are shared; only the gating flag and
+the layout geometry differ.
+
+## Background / architecture (verified 2026-06-25)
+
+### How the breadcrumb is gated
+
+- `BreadcrumbChip.tsx:189` — `const active = !!ctx?.unlockNestingCursor && !!et;`
+  (`et = ctx.editTarget`). Returns `null` when `!active` (line 259). So the chip
+  appears **only** when `unlockNestingCursor` is on **and** a block is being
+  edited.
+- Mounted once, for both environments, in `PreviewDocument.tsx:298`
+  (`<BreadcrumbChip />`, a child of `#quarto-content`).
+- `unlockNestingCursor` flows: host → `PreviewRoot` prop → `PreviewContext`.
+  - **hub-client:** `ReactPreview.tsx:446` reads `usePreference('unlockNestingCursor')`;
+    `schema.ts:25,49` defaults the preference **`true`**. → chip visible.
+  - **q2-preview SPA:** `PreviewApp.tsx:370-372` sets
+    `nestingCursor: parseNestingCursorParam(window.location.search)`;
+    `parseNestingCursorParam` (PreviewApp.tsx:282-289) returns `true` **only**
+    for `?nestingCursor=1`, else `false`. → chip hidden by default.
+
+Because the chip self-gates on `editTarget`, it can never appear in read-only
+`q2 preview` (no `--allow-edit` ⇒ `editingDisabled` ⇒ no edit target). So
+defaulting the flag ON is safe: it only takes visible effect once the user is
+actually editing under `--allow-edit`.
+
+### The overlap (Task 2)
+
+Both elements float above the top-left of the open edit box:
+
+- **`RichTextToolbar`** (`styles.ts:63-80`, `.q2-rt-toolbar`): abs-positioned
+  inside `.q2-richtext-editor` at `left:-2px; bottom:100%; margin-bottom:4px;
+  z-index:20`. Fixed at the block's left edge; rendered by
+  `RichTextEditor.tsx:232`. Rich-text blocks only (paragraphs/headings).
+- **`BreadcrumbChip`** (`BreadcrumbChip.tsx`): abs-positioned inside
+  `#quarto-content`, `z-index:50`. Geometry (`computeChipGeometry`) pins the
+  crumb **band's right edge at `surfaceLeft`** (the edit surface's left edge =
+  the block's left edge) and spills the band LEFT into the indent gutter/margin.
+  Crucially, the `▶` in-arrow **and a future-crumb placeholder are rendered
+  AFTER the band** (BreadcrumbChip.tsx:450-459), i.e. they extend to the RIGHT
+  of `surfaceLeft`, over the content — directly on top of the toolbar's left
+  buttons. The chip's higher `z-index` (50 > 20) paints it over the toolbar.
+
+So the collision is structural: the breadcrumb's right tail and the toolbar's
+left buttons both occupy the strip immediately right of the block's left edge.
+
+## Task 1 — Bring the navigator to `q2 preview --allow-edit`
+
+### Approach (recommended)
+
+Mirror the `richText` default-on / opt-out contract exactly. The richText
+precedent: `parseRichTextParam` (PreviewApp.tsx:297-303) returns `true` unless
+`?richText=0`.
+
+Change `parseNestingCursorParam` to default **ON**, opt out via
+`?nestingCursor=0`:
+
+```ts
+export function parseNestingCursorParam(search: string): boolean {
+  try {
+    return new URLSearchParams(search).get('nestingCursor') !== '0';
+  } catch {
+    return true;
+  }
+}
+```
+
+(Also export it, matching `parseRichTextParam`, so it can be unit-tested
+directly.)
+
+No other wiring is needed — the flag already flows SPA → `Q2PreviewIframe` →
+`entry.tsx` → `PreviewRoot` → `PreviewContext`, and the chip mounts in the
+shared `PreviewDocument`.
+
+### Open question for Task 1
+
+- **Default-on globally, or only under `--allow-edit`?** Recommendation:
+  default-on globally (simplest, matches `richText`). The chip self-gates on
+  `editTarget`, so read-only previews never show it — there is no user-visible
+  downside, and it keeps the SPA's flag handling uniform. If we'd rather be
+  explicit, we could AND it with the fetched `allowEdit` state, but that adds a
+  dependency for no observable behavior change. **Proposed: default-on globally.**
+
+### TDD for Task 1
+
+1. **Unit (RED first):** add `parseNestingCursorParam.test.ts` (clone of
+   `parseRichTextParam.test.ts`): defaults ON for `''`, `?page=…`,
+   `?nestingCursor=1`, any other value; OFF only for `?nestingCursor=0`. Fails
+   against the current `=== '1'` implementation.
+2. **Integration:** `p3-2-nesting-cursor-spa.integration.test.tsx` already
+   exercises SPA nesting-cursor plumbing — update/extend it to assert the chip
+   is present by default (no `?nestingCursor=1`) and absent with
+   `?nestingCursor=0`.
+3. **e2e (Playwright):** the geometry specs currently force
+   `unlockNestingCursor: true` explicitly. Add/adjust one spec asserting the
+   default boot (no param) shows the chip when editing under allow-edit. Audit
+   `q2-preview-block-nav-p2-5b.spec.ts` and `q2-preview-locked-hover.spec.ts`,
+   which deliberately set `unlockNestingCursor: false` — they pass the flag
+   explicitly so they are unaffected by the default flip, but confirm.
+
+## Task 2 — Side-by-side layout (breadcrumb right of toolbar)
+
+The user's constraint: the rich-text controls must keep a **fixed** position
+(at the block's left edge); the **variable-width** breadcrumb goes to their
+right. This rules out putting the breadcrumb on the left (which would make the
+toolbar's x-position depend on breadcrumb width).
+
+**Decision (user, 2026-06-25): Option B — render the breadcrumb inline in the
+toolbar's flex row for rich-text blocks; keep the standalone chip (unchanged
+left-spill geometry) for plain blocks.**
+
+### Chosen design — inline in the toolbar row
+
+For a rich-text block, the floating chrome above the block becomes a single flex
+row:
+
+```
+[ B  I  S  x₂  x²  🔗  │  ◀ Dv ¶ ▶ ]
+  └──── toolbar (fixed) ────┘ └ breadcrumb ┘
+```
+
+For a plain block (code, list, div, table, raw, or a Para/Header the user
+toggled to "plain" mode), there is no toolbar, so the **standalone**
+`BreadcrumbChip` renders exactly as today (current left-spill geometry — no
+overlap, nothing to change).
+
+This means the breadcrumb has **two render paths**, but each is simple and only
+the rich path needed fixing. No measurement, no `ResizeObserver`, no timing race
+— flexbox lays the two groups side by side, and the toolbar's left edge stays
+pinned at the block's left edge regardless of breadcrumb width.
+
+### Implementation outline
+
+1. **Extract a presentational crumb component.** Factor the crumb UI out of
+   `BreadcrumbChip` into a reusable, **position-agnostic** `BreadcrumbCrumbs`
+   (the `◀` / band / crumb buttons / `▶`, with the click handlers wired to
+   `ctx.requestNestingMove` / `ctx.requestNestingSelect`, and
+   `buildAncestorPath(ctx.sourceIndex, et.anchorR0, et.anchorR1)`). It carries
+   NO absolute positioning / geometry — that stays in `BreadcrumbChip` for the
+   standalone path.
+   - The standalone `BreadcrumbChip` keeps its `computeChipGeometry` /
+     left-spill model and renders `<BreadcrumbCrumbs>` inside the positioned
+     pill. **No geometry change** → the big geometry test suite is preserved.
+   - Note: in the inline row, the crumb band should size to its **natural**
+     content width (it is not pinned to a gutter), so `BreadcrumbCrumbs` must
+     accept a "natural width / no fixed band" mode. Keep the flex-fill band
+     mode for the standalone chip.
+
+2. **Render the inline breadcrumb in `RichTextEditor`.** In
+   `RichTextEditor.tsx:230-235`, wrap the toolbar + inline breadcrumb in a flex
+   row (or append `<BreadcrumbCrumbs>` inside `.q2-rt-toolbar` after the
+   buttons, separated by a `.q2-rt-tb-sep`). Gate on
+   `ctx.unlockNestingCursor && ctx.editTarget` (same condition as the chip).
+
+3. **Suppress the standalone chip when the rich editor is active for the active
+   target.** The rich editor is chosen by
+   `richTextAvailable(ctx, nodeType) && (ctx.editorMode ?? 'rich') !== 'plain'`
+   (`dispatchers.tsx:515-529`; `RICHTEXT_SUPPORTED_TYPES = {Para, Header}`).
+   `BreadcrumbChip` must return `null` in exactly that case to avoid a double
+   breadcrumb. The wrinkle: `editTarget` does **not** carry the node type
+   (`PreviewContext.tsx:62-83`), so the chip can't compute the predicate
+   synchronously today. Two clean options to settle during build:
+   - **(preferred) Stamp the hint on `editTarget` at activation.** The
+     activation path resolves the node anyway, so add a
+     `richSupported: boolean` field to the `editTarget` object; the chip
+     suppresses when `editTarget.richSupported && editorMode !== 'plain'`.
+     Synchronous, flash-free, single source of truth.
+   - **(fallback) A context flag toggled by `RichTextEditor` mount/unmount**
+     (e.g. `ctx.richEditorActive` state). Simpler to wire but risks a
+     one-frame flash of the standalone chip before the flag lands.
+
+4. **Styling.** The inline breadcrumb sits in `.q2-rt-toolbar`'s solid pill, so
+   the standalone chip's opaque-pill / shadow / `z-index` styling is not needed
+   inline — just spacing (a separator + small gap). Keep the crumb category
+   colors (`.q2-crumb-cat-*`).
+
+### Test impact (Task 2)
+
+Because the standalone geometry is **unchanged**, the large geometry suite is
+largely preserved — a major advantage of Option B:
+
+- **Preserved (verify still green):** `BreadcrumbChip.geometry.test.ts`,
+  `q2-preview-breadcrumb-geometry.spec.ts` (standalone path still exercised via
+  plain blocks / code blocks), `q2-preview-breadcrumb-isolation.spec.ts`
+  (pointer isolation — re-verify for the inline path too).
+- **New tests:** assert the inline breadcrumb renders inside the toolbar row for
+  a rich-text block (Para/Header) and that the **standalone** chip is suppressed
+  for that same block (no double breadcrumb). Assert the toolbar's left edge is
+  unchanged regardless of breadcrumb width.
+- **Re-check:** `p3-4-breadcrumb.integration.test.tsx`,
+  `g5-carry-expansion.integration.test.tsx`,
+  `p3-3-unlocked-subclauses.integration.test.tsx` — any that open a Para/Header
+  edit target now find the breadcrumb inline rather than standalone; update
+  selectors accordingly.
+
+### TDD for Task 2
+
+1. **RED:** test that opening a Para/Header edit target renders crumbs **inside**
+   the toolbar row and that `data-testid="q2-breadcrumb-chip"` (standalone) is
+   **absent** for that target. Fails today (standalone chip renders, overlapping).
+2. Extract `BreadcrumbCrumbs`; render it inline in `RichTextEditor`; add the
+   suppression hint to `editTarget`.
+3. Re-check the integration specs above; confirm the standalone geometry suite
+   still passes (plain/code blocks).
+4. Verify no overlap and a stable toolbar position in a real browser
+   (navigate in/out to vary breadcrumb width).
+
+## End-to-end verification (required before declaring done)
+
+Per CLAUDE.md, tests are necessary but not sufficient. For both tasks:
+
+1. Rebuild the SPA chain so `q2 preview` picks up the change:
+   `cd hub-client && npm run build:wasm` (only if Rust changed — it isn't here),
+   then build the SPA bundle and re-embed. For TS-only SPA changes, the relevant
+   chain is the q2-preview-spa build + `cargo xtask build-q2-preview-spa` +
+   `cargo build --bin q2`. (Confirm exact commands; no Rust change here, so WASM
+   rebuild is likely unnecessary.)
+2. `cargo run --bin q2 -- preview <fixture-dir> --allow-edit`, open a doc with a
+   **nested** rich-text block (e.g. a paragraph inside a div inside a list),
+   click to edit, and confirm:
+   - Task 1: the `◀ … ▶` navigator appears.
+   - Task 2: navigator and toolbar are side by side with no overlap; toolbar
+     position is stable as the breadcrumb width changes (navigate in/out).
+3. Capture a screenshot and note it in this plan + the strand.
+
+## hub-client changelog
+
+Both changes are under `hub-client` scope's influence (shared package consumed
+by hub-client). Per CLAUDE.md, add `hub-client/changelog.md` entries (two-commit
+workflow: code commit first, then changelog entry with the hash). Note: Task 1
+changes default behavior **only in the SPA**; hub-client already defaults the
+preference on, so describe accordingly. Task 2 affects both environments
+(shared geometry) — call that out.
+
+## Work items
+
+### Task 1 — navigator in q2 preview ✅ (pending real-binary e2e verification)
+- [x] Add failing `parseNestingCursorParam.test.ts` (default-on / `=0` opt-out) — RED confirmed (4/6 failed), now GREEN
+- [x] Flip `parseNestingCursorParam` to default-on; export it
+- [x] Update `p3-2-nesting-cursor-spa.integration.test.tsx` for default-on (8/8 pass)
+- [x] Add/adjust e2e spec for default-boot chip visibility under allow-edit
+      (`q2-preview-spa/e2e/nesting-cursor.spec.ts`: default-boot → unlocked +
+      chip visible; `?nestingCursor=0` → locked). NOTE: requires SPA/WASM
+      rebuild + binary build to run; deferred to combined e2e verification.
+- [x] Confirm `unlockNestingCursor:false` specs unaffected — the hub-client
+      e2e specs (`q2-preview-block-nav-p2-5b`, `q2-preview-locked-hover`) set
+      the preference via localStorage, a separate path from the SPA URL-param
+      default; the only SPA e2e depending on the old default was
+      `nesting-cursor.spec.ts` (updated above).
+
+### Task 2 — side-by-side layout (Option B — inline in toolbar row) ✅ (pending real-binary e2e)
+- [x] Settle the design fork → **Option B** (user, 2026-06-25)
+- [x] Failing test: rich-block edit renders crumbs inline in the toolbar row;
+      standalone `q2-breadcrumb-chip` absent for that target
+      (`p3-4-inline-breadcrumb.integration.test.tsx`, 2 tests, GREEN)
+- [x] Extract position-agnostic `BreadcrumbCrumbs` from `BreadcrumbChip`
+      (`BreadcrumbCrumbs.tsx`; `layout: 'standalone' | 'inline'`; shared
+      `ensureBreadcrumbStyles()`; inline = natural width, standalone = flex band)
+- [x] Render `BreadcrumbCrumbs` inline in `RichTextEditor` toolbar row
+      (new `trailing` slot on `RichTextToolbar`, after a separator)
+- [x] Suppress standalone `BreadcrumbChip` when rich editor is active for the
+      target. NOTE: chose a cleaner mechanism than stamping `editTarget` — a
+      shared leaf module `richTextSupport.ts` (`RICHTEXT_SUPPORTED_TYPES`,
+      `richTextAvailable`, `richEditorActiveForType`) + `currentSourceNodeType`
+      (resolves the active node's type from `sourceIndex`). Fully synchronous &
+      reactive (tracks `editorMode`/`richText`), no activation-path changes, no
+      flash, no context flag. `dispatchers.tsx` now imports from the leaf module.
+- [x] Confirm standalone geometry suite still green (plain/code blocks) —
+      `BreadcrumbChip.geometry.test.ts` + the breadcrumb integration suite pass
+      unchanged (they don't enable `richText`, so they exercise the standalone path)
+- [x] Re-check breadcrumb integration specs — all green (unit 500, integration 515)
+
+### Cross-cutting
+- [x] preview-renderer suites green (unit 500, integration 515)
+- [x] q2-preview-spa suites green (unit 37, integration 75) + production build
+- [x] hub-client production build green; unit 662 + integration 76 green
+- [x] e2e verification in a real `q2 preview --allow-edit` session + screenshot
+      (see below). Full q2-preview-spa e2e suite green (37 tests).
+- [ ] `hub-client/changelog.md` entry (two-commit workflow) — pending commit
+- [ ] `cargo xtask verify --skip-hub-build` before push (Rust untouched; binary
+      builds clean — `cargo build --bin q2` succeeded)
+
+## End-to-end verification record (2026-06-25)
+
+Built the chain (TS-only change → no WASM rebuild needed): `cargo xtask
+build-q2-preview-spa` → `cargo build --bin q2`. Ran
+`q2 preview <fixture> --allow-edit` and drove it in Chrome.
+
+Clicking a paragraph nested in a callout div (the user's exact scenario) opened
+the rich editor and produced this toolbar DOM (`.q2-rt-toolbar` textContent):
+
+```
+BISx₂x²🔗◀Dv¶▶
+```
+
+i.e. `B I S x₂ x² 🔗` (formatting, fixed at the block's left edge) followed by
+`◀ Dv ¶ ▶` (the nesting navigator, inline to the right). Inspected:
+`toolbarPresent: true, prosemirrorPresent: true, standaloneChipPresent: false,
+inlineCrumbs: ["Dv","¶"]`. Screenshot confirmed the side-by-side layout with no
+overlap. Both tasks verified through the real binary.
+
+Real-binary e2e (`q2-preview-spa/e2e/nesting-cursor.spec.ts`, 3 tests, all green):
+default boot → rich editor + inline navigator + standalone chip suppressed;
+`?richText=0` → clean textarea buffer (no `>`); `?nestingCursor=0` → locked
+whole-quote with `>`.
+
+## Discovered work (filed, out of scope)
+
+- **bd-n4v4phe4** (fixed + closed): `edit-cell-sizing.spec.ts` (q2-preview-spa
+  e2e) no-reflow tests waited for a `textarea` but rich-text default-on opens the
+  rich editor. Pinned `?richText=0` (the bd-038tnyqy baseline pattern). Fixed
+  here because it shares the e2e suite I ran to verify these tasks.
+- **bd-fpys25b0** (filed, NOT fixed here): the entire hub-client block-editing
+  e2e suite (12 `q2-preview-*.spec.ts` that wait for `textarea`) has been red
+  since bd-j1nto6eq (rich-text default-on) — none pin `richText`. Pre-existing,
+  systemic, not in default `cargo xtask verify` (`test:e2e` is opt-in). The 3
+  breadcrumb specs there test the STANDALONE chip; with `richText=0` pinned they
+  stay valid and are unaffected by Task 2's suppression. Left for a dedicated
+  hub-client-e2e session.
+
+## Key files
+
+| Concern | File |
+| --- | --- |
+| Breadcrumb component + geometry | `ts-packages/preview-renderer/src/q2-preview/BreadcrumbChip.tsx` |
+| Breadcrumb mount | `ts-packages/preview-renderer/src/q2-preview/PreviewDocument.tsx:298` |
+| Rich-text toolbar | `ts-packages/preview-renderer/src/q2-preview/richtext/RichTextToolbar.tsx` |
+| Toolbar + editor styles | `ts-packages/preview-renderer/src/q2-preview/richtext/styles.ts` |
+| Editor wrapper | `ts-packages/preview-renderer/src/q2-preview/richtext/RichTextEditor.tsx:230-235` |
+| SPA flag defaulting | `q2-preview-spa/src/PreviewApp.tsx:282-303, 370-375` |
+| hub-client preference | `hub-client/src/services/preferences/schema.ts:25,49`; `hub-client/src/components/render/ReactPreview.tsx:446` |
+| Flag plumbing | `entry.tsx`, `iframe/Q2PreviewIframe.tsx`, `PreviewRoot.tsx`, `PreviewContext.tsx` |

--- a/claude-notes/plans/2026-06-25-q2-preview-hierarchy-nav-and-overlap.md
+++ b/claude-notes/plans/2026-06-25-q2-preview-hierarchy-nav-and-overlap.md
@@ -298,9 +298,17 @@ preference on, so describe accordingly. Task 2 affects both environments
 - [x] hub-client production build green; unit 662 + integration 76 green
 - [x] e2e verification in a real `q2 preview --allow-edit` session + screenshot
       (see below). Full q2-preview-spa e2e suite green (37 tests).
-- [ ] `hub-client/changelog.md` entry (two-commit workflow) — pending commit
+- [x] `hub-client/changelog.md` entry (commit df3287bf, referencing 15b9287c)
 - [ ] `cargo xtask verify --skip-hub-build` before push (Rust untouched; binary
       builds clean — `cargo build --bin q2` succeeded)
+
+## Commits (branch `braid/bd-9x3zbuj8-preview-hierarchy-nav-overlap`)
+
+- `15b9287c` feat(preview-renderer): inline nesting breadcrumb in the toolbar (Task 2)
+- `d73079be` feat(q2-preview): default the hierarchical block navigator ON (Task 1)
+- `ad18bf91` test(q2-preview e2e): pin richText=0 in edit-cell-sizing (bd-n4v4phe4)
+- `553ded66` docs(plan)
+- `df3287bf` docs(hub-client): changelog
 
 ## End-to-end verification record (2026-06-25)
 

--- a/hub-client/changelog.md
+++ b/hub-client/changelog.md
@@ -15,6 +15,10 @@ be in reverse chronological order (latest first).
 
 -->
 
+### 2026-06-25
+
+- [`15b9287c`](https://github.com/quarto-dev/q2/commits/15b9287c): The block-hierarchy navigator (◀ Dv ¶ ▶) now sits inline to the right of the rich-text formatting buttons instead of overlapping them, and `q2 preview --allow-edit` shows the navigator by default (matching the hub editor).
+
 ### 2026-06-24
 
 - [`0ccf989a`](https://github.com/quarto-dev/q2/commits/0ccf989a): The editor no longer auto-inserts a second backtick — typing `` ` `` at the end of a word to close inline code now adds just one backtick instead of two (selecting a word and typing `` ` `` still wraps it).

--- a/q2-preview-spa/e2e/edit-cell-sizing.spec.ts
+++ b/q2-preview-spa/e2e/edit-cell-sizing.spec.ts
@@ -68,7 +68,12 @@ test.afterEach(async () => {
 });
 
 test('paragraph: active region height and following heading top unchanged on activation', async ({ page }) => {
-    await page.goto(server.url);
+    // Pin richText=0: these no-reflow tests use the textarea as the activation
+    // baseline (assertNoReflowOnActivation waits for a <textarea>). Since rich-text
+    // is the q2-preview default (bd-j1nto6eq), Para/Header would otherwise open in
+    // the rich editor and no textarea would mount. Same baseline pin as the
+    // hub-client e2e (bd-038tnyqy). Tracked: bd-n4v4phe4.
+    await page.goto(`${server.url}${server.url.includes('?') ? '&' : '?'}richText=0`);
     await waitForEditableBlocks(page);
     const iframe = page.frameLocator('iframe');
     await assertNoReflowOnActivation(
@@ -80,7 +85,12 @@ test('paragraph: active region height and following heading top unchanged on act
 });
 
 test('heading: active region height and following list top unchanged on activation', async ({ page }) => {
-    await page.goto(server.url);
+    // Pin richText=0: these no-reflow tests use the textarea as the activation
+    // baseline (assertNoReflowOnActivation waits for a <textarea>). Since rich-text
+    // is the q2-preview default (bd-j1nto6eq), Para/Header would otherwise open in
+    // the rich editor and no textarea would mount. Same baseline pin as the
+    // hub-client e2e (bd-038tnyqy). Tracked: bd-n4v4phe4.
+    await page.goto(`${server.url}${server.url.includes('?') ? '&' : '?'}richText=0`);
     await waitForEditableBlocks(page);
     const iframe = page.frameLocator('iframe');
     await assertNoReflowOnActivation(
@@ -92,7 +102,12 @@ test('heading: active region height and following list top unchanged on activati
 });
 
 test('paragraph above list: active region height and list top unchanged on activation', async ({ page }) => {
-    await page.goto(server.url);
+    // Pin richText=0: these no-reflow tests use the textarea as the activation
+    // baseline (assertNoReflowOnActivation waits for a <textarea>). Since rich-text
+    // is the q2-preview default (bd-j1nto6eq), Para/Header would otherwise open in
+    // the rich editor and no textarea would mount. Same baseline pin as the
+    // hub-client e2e (bd-038tnyqy). Tracked: bd-n4v4phe4.
+    await page.goto(`${server.url}${server.url.includes('?') ? '&' : '?'}richText=0`);
     await waitForEditableBlocks(page);
     const iframe = page.frameLocator('iframe');
     await assertNoReflowOnActivation(

--- a/q2-preview-spa/e2e/nesting-cursor.spec.ts
+++ b/q2-preview-spa/e2e/nesting-cursor.spec.ts
@@ -5,12 +5,15 @@
  * embeds the SPA + WASM through `include_dir!`. Asserts the §3a/§3b nesting-cursor
  * RESOLUTION that no existing q2-preview-spa spec covers:
  *
- *   - WITH `?nestingCursor=1` (+ `--allow-edit`): a leaf-click on a blockquote
+ *   - DEFAULT boot (no param, + `--allow-edit`, bd-9x3zbuj8): the nesting cursor
+ *     is now ON by default (matching hub-client). A leaf-click on a blockquote
  *     child opens THAT child with a CLEAN, AST-regenerated buffer (no `>`
- *     markers) — proving leaf resolution + nested-buffer regeneration end to
- *     end through the binary's embedded SPA + WASM.
- *   - WITHOUT the param: clicking the blockquote opens the WHOLE quote WITH `>`
- *     markers (Phase-2 locked, prefixing-atomic) — proving the unlock is gated.
+ *     markers), and the breadcrumb navigator chip is visible — proving leaf
+ *     resolution + nested-buffer regeneration end to end through the binary's
+ *     embedded SPA + WASM, with no query param required.
+ *   - WITH the explicit `?nestingCursor=0` opt-out: clicking the blockquote
+ *     opens the WHOLE quote WITH `>` markers (Phase-2 locked, prefixing-atomic)
+ *     — proving the unlock can still be turned off.
  *
  * The boot path is covered at jsdom in
  * `q2-preview-spa/src/p3-2-nesting-cursor-spa.integration.test.tsx`; the
@@ -76,25 +79,70 @@ test.describe('P3.5 — SPA nesting-cursor resolution (real q2 preview binary)',
         );
     }
 
-    test('with ?nestingCursor=1: leaf-click opens the blockquote child with a clean buffer (no `>`)', async ({ page }) => {
-        // server.url already carries the CLI's `?page=index.qmd` query (previewServer
-        // waitForUrl captures it), so append nestingCursor with the correct separator —
-        // `${server.url}?nestingCursor=1` would produce the malformed `?page=index.qmd?nestingCursor=1`
-        // (nestingCursor parses to null → the unlock silently never engages).
-        const sep = server.url.includes('?') ? '&' : '?';
-        await page.goto(`${server.url}${sep}nestingCursor=1`);
+    test('default boot (no param): leaf-click opens the blockquote child in the RICH editor with the navigator INLINE in the toolbar (no overlap)', async ({ page }) => {
+        // bd-9x3zbuj8: the nesting cursor is now ON by default — no query param.
+        // Combined with rich-text being the SPA default, leaf-clicking a paragraph
+        // opens the rich editor (ProseMirror), and the hierarchy navigator renders
+        // INLINE in the toolbar row (Task 2) instead of as a floating chip.
+        await page.goto(server.url);
         await waitForBlockquote(page);
 
         const iframe = page.frameLocator('iframe');
 
-        // Leaf-click the blockquote CHILD (the inner paragraph). In unlocked
-        // mode this resolves to the child, not the whole quote.
+        // Leaf-click the blockquote CHILD (the inner paragraph). In unlocked mode
+        // this resolves to the child Para, which opens in the rich editor.
+        await iframe.locator('blockquote p[data-block-pool-id]').first().click();
+
+        // The rich editor (ProseMirror) — NOT a textarea — must open, showing the
+        // rendered quote text with no `>` source markers.
+        const pm = iframe.locator('.q2-richtext-editor .ProseMirror').first();
+        await pm.waitFor({ timeout: 10_000 });
+        await expect
+            .poll(async () => pm.textContent(), {
+                timeout: 8000,
+                message: 'rich editor should show the blockquote-child text',
+            })
+            .toContain('Quote line one.');
+        const text = (await pm.textContent()) ?? '';
+        expect(text, 'rich editor shows both lines').toContain('Quote line two.');
+        expect(text, 'rich editor renders text without `>` markers').not.toContain('>');
+        expect(text, 'leaf edit must not include the Intro paragraph').not.toContain('Intro paragraph.');
+
+        // Task 2: the navigator renders INLINE inside the toolbar row (to the right
+        // of the formatting buttons), and the standalone floating chip is suppressed
+        // — so the two never overlap.
+        const toolbar = iframe.locator('.q2-rt-toolbar').first();
+        await expect(toolbar, 'rich-text toolbar must be present').toBeVisible({ timeout: 5000 });
+        await expect(
+            toolbar.locator('.q2-breadcrumb-out'),
+            'navigator ◀ must be inside the toolbar row (inline breadcrumb)',
+        ).toBeVisible();
+        await expect(
+            toolbar.locator('.q2-crumb').last(),
+            'current crumb (¶) must be inside the toolbar row',
+        ).toHaveText('¶');
+        await expect(
+            iframe.locator('[data-testid="q2-breadcrumb-chip"]'),
+            'standalone floating chip must be suppressed when the inline breadcrumb shows',
+        ).toHaveCount(0);
+
+        await pm.press('Escape');
+    });
+
+    test('default nesting cursor with ?richText=0: leaf-click opens the blockquote child as a clean textarea buffer (no `>`)', async ({ page }) => {
+        // With rich text opted OUT, the nested leaf opens in the textarea — this is
+        // where the clean-buffer REGENERATION (markers stripped) is observable. Also
+        // proves the nesting-cursor default-on is independent of the rich-text flag.
+        const sep = server.url.includes('?') ? '&' : '?';
+        await page.goto(`${server.url}${sep}richText=0`);
+        await waitForBlockquote(page);
+
+        const iframe = page.frameLocator('iframe');
+
         await iframe.locator('blockquote p[data-block-pool-id]').first().click();
         const ta = iframe.locator('textarea').first();
         await ta.waitFor({ timeout: 10_000 });
 
-        // The textarea must carry the CLEAN regenerated buffer: both quote lines,
-        // and crucially NO `>` markers (regeneration stripped them).
         await expect
             .poll(async () => ta.inputValue(), {
                 timeout: 8000,
@@ -108,20 +156,29 @@ test.describe('P3.5 — SPA nesting-cursor resolution (real q2 preview binary)',
             value,
             'clean nested buffer must NOT contain `>` markers (leaf resolution + regeneration)',
         ).not.toContain('>');
-        // And it must not have pulled in the surrounding paragraphs.
         expect(value, 'leaf edit must not include the Intro paragraph').not.toContain('Intro paragraph.');
+
+        // The standalone navigator chip is the breadcrumb home in plain/textarea mode.
+        const chip = iframe.locator('[data-testid="q2-breadcrumb-chip"]');
+        await expect(chip, 'breadcrumb navigator chip must be visible by default').toBeVisible({ timeout: 5000 });
 
         await ta.press('Escape');
     });
 
-    test('without the param: clicking the blockquote opens the whole quote with `>` (locked)', async ({ page }) => {
-        await page.goto(server.url);
+    test('with ?nestingCursor=0 (opt-out): clicking the blockquote opens the whole quote with `>` (locked)', async ({ page }) => {
+        // server.url already carries the CLI's `?page=index.qmd` query (previewServer
+        // waitForUrl captures it), so append nestingCursor with the correct separator —
+        // `${server.url}?nestingCursor=0` would produce the malformed `?page=index.qmd?nestingCursor=0`
+        // (nestingCursor parses to null → defaults back ON, defeating the opt-out).
+        const sep = server.url.includes('?') ? '&' : '?';
+        await page.goto(`${server.url}${sep}nestingCursor=0`);
         await waitForBlockquote(page);
 
         const iframe = page.frameLocator('iframe');
 
-        // Click inside the blockquote. In locked mode (default), prefixing-atomic
-        // resolution opens the WHOLE quote as one buffer, markers included.
+        // Click inside the blockquote. In locked mode (explicit opt-out),
+        // prefixing-atomic resolution opens the WHOLE quote as one buffer,
+        // markers included.
         await iframe.locator('blockquote p[data-block-pool-id]').first().click();
         const ta = iframe.locator('textarea').first();
         await ta.waitFor({ timeout: 10_000 });

--- a/q2-preview-spa/src/PreviewApp.tsx
+++ b/q2-preview-spa/src/PreviewApp.tsx
@@ -275,16 +275,21 @@ const CONNECTION_BANNER_STYLE: React.CSSProperties = {
 };
 
 /**
- * P3.2: parse `?nestingCursor=1` from the boot URL search string.
- * Returns true only when the param is exactly `"1"`. Read-at-load;
- * the SPA does not react to URL changes after mount.
+ * Parse `?nestingCursor` from the boot URL (P3.2; default flipped in
+ * bd-9x3zbuj8). The hierarchical block navigator (BreadcrumbChip) is now the
+ * DEFAULT in q2 preview, matching hub-client (which defaults the
+ * `unlockNestingCursor` preference on): only an explicit `?nestingCursor=0`
+ * opts OUT; an absent param, `?nestingCursor=1`, or any other value keeps it
+ * on. Read-at-load; the SPA does not react to URL changes after mount.
+ *
+ * Safe to default on globally: the navigator self-gates on an active edit
+ * target, so a read-only preview (no `--allow-edit`) never shows it.
  */
-function parseNestingCursorParam(search: string): boolean {
-  if (!search) return false;
+export function parseNestingCursorParam(search: string): boolean {
   try {
-    return new URLSearchParams(search).get('nestingCursor') === '1';
+    return new URLSearchParams(search).get('nestingCursor') !== '0';
   } catch {
-    return false;
+    return true;
   }
 }
 

--- a/q2-preview-spa/src/p3-2-nesting-cursor-spa.integration.test.tsx
+++ b/q2-preview-spa/src/p3-2-nesting-cursor-spa.integration.test.tsx
@@ -193,7 +193,7 @@ describe('P3.2 SPA query param: ?nestingCursor=1 → iframe receives unlockNesti
     expect(mockRegenerateNestedBuffers).toHaveBeenCalledWith(CONTENT, AST);
   });
 
-  it('passes unlockNestingCursor: false (or absent) when no ?nestingCursor param', async () => {
+  it('passes unlockNestingCursor: true by default when no ?nestingCursor param (bd-9x3zbuj8)', async () => {
     Object.defineProperty(window, 'location', {
       value: {
         ...window.location,
@@ -214,8 +214,13 @@ describe('P3.2 SPA query param: ?nestingCursor=1 → iframe receives unlockNesti
     );
 
     const props = capturedIframeProps[capturedIframeProps.length - 1];
-    // No param → nestingCursor defaults to false → unlockNestingCursor should be false/absent.
-    expect(props?.unlockNestingCursor).toBeFalsy();
+    // The navigator is now default-ON (matching hub-client): no param ⇒
+    // unlockNestingCursor: true. It still self-gates on an edit target, so a
+    // read-only preview shows nothing.
+    expect(props?.unlockNestingCursor).toBe(true);
+    // On-path: with nestingCursor on AND non-empty content + AST, the nested
+    // buffer regen runs (same assertion as the ?nestingCursor=1 case).
+    expect(mockRegenerateNestedBuffers).toHaveBeenCalledWith(CONTENT, AST);
   });
 
   it('passes unlockNestingCursor: false when ?nestingCursor=0', async () => {

--- a/q2-preview-spa/src/parseNestingCursorParam.test.ts
+++ b/q2-preview-spa/src/parseNestingCursorParam.test.ts
@@ -1,0 +1,40 @@
+/**
+ * The hierarchical block navigator (BreadcrumbChip) is now the DEFAULT in
+ * q2 preview, matching hub-client (which defaults the `unlockNestingCursor`
+ * preference on). Only an explicit `?nestingCursor=0` opts out (bd-9x3zbuj8).
+ * These assert that default-on / opt-out contract.
+ *
+ * Note: the navigator self-gates on an active edit target, so it only becomes
+ * visible when actually editing — i.e. under `q2 preview --allow-edit`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseNestingCursorParam } from './PreviewApp';
+
+describe('parseNestingCursorParam — the nesting navigator is the default', () => {
+  it('defaults ON when no query string is present', () => {
+    expect(parseNestingCursorParam('')).toBe(true);
+  });
+
+  it('defaults ON when the nestingCursor param is absent', () => {
+    expect(parseNestingCursorParam('?page=index.qmd')).toBe(true);
+  });
+
+  it('stays ON for ?nestingCursor=1', () => {
+    expect(parseNestingCursorParam('?nestingCursor=1')).toBe(true);
+  });
+
+  it('turns OFF only for the explicit ?nestingCursor=0 opt-out', () => {
+    expect(parseNestingCursorParam('?nestingCursor=0')).toBe(false);
+  });
+
+  it('keeps ON for any other value (only "0" disables)', () => {
+    expect(parseNestingCursorParam('?nestingCursor=true')).toBe(true);
+    expect(parseNestingCursorParam('?nestingCursor=')).toBe(true);
+  });
+
+  it('works mixed with other params', () => {
+    expect(parseNestingCursorParam('?page=a.qmd&nestingCursor=0&richText=1')).toBe(false);
+    expect(parseNestingCursorParam('?page=a.qmd&richText=0')).toBe(true);
+  });
+});

--- a/ts-packages/preview-renderer/src/q2-preview/BreadcrumbChip.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/BreadcrumbChip.tsx
@@ -53,8 +53,10 @@
 
 import React, { useContext, useLayoutEffect, useRef, useState } from 'react';
 import { PreviewContext } from './PreviewContext';
-import { buildAncestorPath, detectPlatform } from './nestingNav';
+import { buildAncestorPath, currentSourceNodeType } from './nestingNav';
 import type { AncestorCrumb } from './nestingNav';
+import { BreadcrumbCrumbs, type CrumbDisplayItem } from './BreadcrumbCrumbs';
+import { richEditorActiveForType } from './richTextSupport';
 
 // ── Constants ──────────────────────────────────────────────────────────────────
 
@@ -81,16 +83,12 @@ export const MIN_GLYPH_W = 16;
  */
 export const CRUMB_W = 22;
 
-// ── Display item types ─────────────────────────────────────────────────────────
-
-// The crumb row fills a fixed band [◀.right, surfaceLeft] via flexbox, so items
-// carry no explicit width — they share the band equally (expand when few, shrink
-// when many; the middle ellipsizes once they no longer fit at MIN_GLYPH_W).
-type CrumbDisplayItem =
-    | { kind: 'crumb'; crumb: AncestorCrumb }
-    | { kind: 'ellipsis' };
-
 // ── Chip geometry (computed once per editTarget change) ────────────────────────
+//
+// The crumb row fills a fixed band [◀.right, surfaceLeft] via flexbox; the crumb
+// UI itself (◀ · band · ▶ · future) is rendered by the shared `BreadcrumbCrumbs`
+// component (also used inline in the rich-text toolbar — bd-9x3zbuj8 Task 2). This
+// file owns only the standalone POSITIONING geometry.
 
 interface ChipGeometry {
     /** chip top (px, relative to #quarto-content). */
@@ -186,7 +184,15 @@ export function BreadcrumbChip(): React.ReactElement | null {
     const [geom, setGeom] = useState<ChipGeometry | null>(null);
 
     const et = ctx?.editTarget;
-    const active = !!ctx?.unlockNestingCursor && !!et;
+    // Suppress the standalone floating chip when the rich-text editor is showing
+    // for this target — there the breadcrumb renders INLINE in the toolbar row
+    // instead (bd-9x3zbuj8 Task 2), so a standalone chip would double it up.
+    // currentSourceNodeType resolves the active node's type from the source index;
+    // richEditorActiveForType applies the same predicate the dispatcher uses to
+    // pick the rich surface (so this stays in lock-step with editorMode/richText).
+    const nodeType = et ? currentSourceNodeType(ctx?.sourceIndex, et.anchorR0, et.anchorR1) : null;
+    const richInlineActive = !!ctx && nodeType != null && richEditorActiveForType(ctx, nodeType);
+    const active = !!ctx?.unlockNestingCursor && !!et && !richInlineActive;
 
     // ── Geometry effect (Phase 3: content-plane anchor, no scroll listener) ───
     //
@@ -259,15 +265,14 @@ export function BreadcrumbChip(): React.ReactElement | null {
     if (!active || !et) return null;
 
     const crumbs = buildAncestorPath(ctx?.sourceIndex, et.anchorR0, et.anchorR1);
-    const platform = detectPlatform();
-    const outTip = platform === 'mac' ? 'Out (⌘⌃←)' : 'Out (Alt+Shift+←)';
-    const inTip = platform === 'mac' ? 'In (⌘⌃→)' : 'In (Alt+Shift+→)';
 
     // stopPropagation: the host (#quarto-content) carries delegated pointer
-    // handlers (useBlockEditHover); the chip must fully intercept its own pointer
-    // events so a chip click is never read as a leaf-reset/click-switch.
-    // preventDefault on pointerdown keeps the textarea focused (no blur-commit on
-    // a button press). [Real focus/blur + pointer-ordering: verified in P3.5.]
+    // handlers (useBlockEditHover); the standalone chip floats OUTSIDE the edit
+    // region, so it must fully intercept its own pointer events — a chip click
+    // must never be read as a leaf-reset/click-switch, and pointerdown must not
+    // blur-commit the textarea. (The inline rendering sits INSIDE the edit region,
+    // where the host's active-region guard already ignores it.)
+    // [Real focus/blur + pointer-ordering: verified in P3.5.]
     const eat = (e: React.PointerEvent) => { e.stopPropagation(); e.preventDefault(); };
 
     // Determine display items for the crumb row.
@@ -278,186 +283,43 @@ export function BreadcrumbChip(): React.ReactElement | null {
         ? geom.displayItems
         : crumbs.map((crumb) => ({ kind: 'crumb' as const, crumb }));
 
+    // The crumb styles (incl. `#quarto-content { position: relative }` that the
+    // geometry effect's offset-parent lookup relies on) are injected by
+    // BreadcrumbCrumbs via ensureBreadcrumbStyles(), rendered as our child below.
     return (
-        <>
-            <style>{`
-                /* Phase 3: make #quarto-content the chip's offset-parent.
-                   This creates a stacking context on the page-columns grid
-                   container (spans screen-start → screen-end). Risk is LOW:
-                   no position:fixed children inside #quarto-content; the
-                   attribution overlay renders outside it; sidebar/TOC/overlays
-                   have their own stacking contexts at the page-grid level.
-                   The chip's z-index:50 paints above sidebar(z≈1)/main(z=0). */
-                #quarto-content { position: relative; }
-
-                .q2-breadcrumb-chip {
-                    display: flex;
-                    align-items: center;
-                    gap: 0;
-                    pointer-events: auto;
-                    /* No horizontal padding: chipLeft + ◀ width + band width must sum
-                       exactly to surfaceLeft so the crumb row's right edge meets the
-                       pivot (computeChipGeometry pins it there). Vertical breathing
-                       only. The opaque fill (set below) gives the glyphs legibility
-                       over occluded content. */
-                    padding: 1px 0;
-                    /* G13: opaque pill — a very faint cool blue-grey (B highest,
-                       G a touch over R). The previous translucent white +
-                       backdrop-filter read as murky over occluded content; an opaque
-                       fill fully covers what's behind, so the filter is redundant. */
-                    background: rgb(243, 247, 250);
-                    border-radius: 4px;
-                    box-shadow: 0 1px 3px rgba(0,0,0,0.12);
-                }
-                /* Fixed-width crumb band: [◀.right, surfaceLeft]. Crumbs flex to fill
-                   it (expand when few, shrink when many); width is set inline. */
-                .q2-breadcrumb-crumbs {
-                    display: flex;
-                    align-items: center;
-                    gap: 0;
-                    overflow: hidden;
-                }
-                .q2-crumb {
-                    border: none;
-                    background: transparent;
-                    font-size: 12px;
-                    padding: 1px 3px;
-                    cursor: pointer;
-                    color: inherit;
-                    line-height: 1.4;
-                    overflow: hidden;
-                    white-space: nowrap;
-                    text-overflow: ellipsis;
-                    text-align: center;
-                    /* Share the band equally; shrink below content width if needed. */
-                    flex: 1 1 0;
-                    min-width: 0;
-                }
-                .q2-crumb-current {
-                    font-weight: bold;
-                    text-decoration: underline;
-                }
-                .q2-crumb:not(.q2-crumb-current):hover {
-                    text-decoration: underline;
-                }
-                .q2-breadcrumb-out,
-                .q2-breadcrumb-in {
-                    border: none;
-                    background: transparent;
-                    font-size: 11px;
-                    padding: 1px 4px;
-                    cursor: pointer;
-                    color: #555;
-                    line-height: 1.4;
-                    border-radius: 3px;
-                    flex-shrink: 0;
-                }
-                .q2-breadcrumb-out:hover,
-                .q2-breadcrumb-in:hover {
-                    background: rgba(0,0,0,0.08);
-                }
-                .q2-crumb-cat-container { color: #4f46e5; }
-                .q2-crumb-cat-list      { color: #15803d; }
-                .q2-crumb-cat-quote     { color: #b45309; }
-                .q2-crumb-cat-leaf-text { color: #0284c7; }
-                .q2-crumb-cat-embed     { color: #0f766e; }
-                .q2-breadcrumb-future   { opacity: 0.4; }
-                .q2-crumb-ellipsis {
-                    font-size: 12px;
-                    padding: 1px 3px;
-                    color: #888;
-                    line-height: 1.4;
-                    flex: 0 0 auto;
-                    user-select: none;
-                }
-            `}</style>
-            {/* Phase 3d: position:absolute — never reflows; paints into outer margin
-                (no overflow:hidden on #quarto-content or page-columns ancestors). */}
-            <div
-                ref={chipRef}
-                className="q2-breadcrumb-chip"
-                data-testid="q2-breadcrumb-chip"
-                role="toolbar"
-                aria-label="Nesting breadcrumb"
-                onPointerDown={eat}
-                onPointerUp={(e) => e.stopPropagation()}
-                style={{
-                    position: 'absolute',
-                    // #quarto-content is a CSS grid (.page-columns). An abspos child
-                    // of a grid is contained by its GRID AREA, not the grid box — so
-                    // without this it auto-places into the body content column and
-                    // `left:0` resolves to the column edge (colLeft), unable to reach
-                    // the outer page margin. Spanning screen-start→screen-end makes the
-                    // grid area the full page width, so computed left/top (measured vs
-                    // #quarto-content) resolve against the full box and margin-spill works.
-                    gridColumn: 'screen-start / screen-end',
-                    gridRow: '1 / -1',
-                    top: geom ? `${geom.top}px` : undefined,
-                    // Left edge from computeChipGeometry (pivot-pinned left-spill):
-                    // surfaceLeft − ◀ − band, clamped to ≥ 0 at the page edge.
-                    left: geom ? `${geom.chipLeft}px` : undefined,
-                    zIndex: 50,
-                }}
-            >
-                {/* ◀ out-arrow — fixed width, sits in the left page margin. */}
-                <button
-                    type="button"
-                    className="q2-breadcrumb-out"
-                    title={outTip}
-                    aria-label={outTip}
-                    style={{ minWidth: `${MIN_GLYPH_W}px`, maxWidth: `${MIN_GLYPH_W}px`, flex: '0 0 auto' }}
-                    onPointerDown={(e) => e.preventDefault()}
-                    onClick={(e) => { e.stopPropagation(); ctx?.requestNestingMove?.('out'); }}
-                >◀</button>
-                {/* Crumb band — fixed width [◀.right, surfaceLeft]; crumbs flex to fill,
-                    so their right edge meets the surface left (the pivot). */}
-                <div
-                    className="q2-breadcrumb-crumbs"
-                    style={geom ? { width: `${geom.bandWidth}px`, flex: '0 0 auto' } : undefined}
-                >
-                    {displayItems.map((item, idx) => {
-                        if (item.kind === 'ellipsis') {
-                            return (
-                                <span
-                                    key={`ellipsis-${idx}`}
-                                    className="q2-crumb-ellipsis"
-                                    aria-hidden="true"
-                                >…</span>
-                            );
-                        }
-                        const c = item.crumb;
-                        return (
-                            <button
-                                key={`${c.r0}-${c.r1}`}
-                                type="button"
-                                className={[
-                                    'q2-crumb',
-                                    `q2-crumb-cat-${c.category}`,
-                                    c.isCurrent ? 'q2-crumb-current' : '',
-                                ].filter(Boolean).join(' ')}
-                                title={c.label}
-                                aria-label={c.label}
-                                aria-current={c.isCurrent ? 'true' : undefined}
-                                onPointerDown={(e) => e.preventDefault()}
-                                onClick={(e) => { e.stopPropagation(); ctx?.requestNestingSelect?.(c.r0, c.r1); }}
-                            >{c.abbrev}</button>
-                        );
-                    })}
-                </div>
-                {/* ▶ in-arrow + future-crumb placeholder — just right of the pivot
-                    (over the content). The placeholder reserves the successor plan's
-                    forward-crumb slot. */}
-                <button
-                    type="button"
-                    className="q2-breadcrumb-in"
-                    title={inTip}
-                    aria-label={inTip}
-                    style={{ flex: '0 0 auto' }}
-                    onPointerDown={(e) => e.preventDefault()}
-                    onClick={(e) => { e.stopPropagation(); ctx?.requestNestingMove?.('in'); }}
-                >▶</button>
-                <span className="q2-breadcrumb-future" />
-            </div>
-        </>
+        // Phase 3d: position:absolute — never reflows; paints into outer margin
+        // (no overflow:hidden on #quarto-content or page-columns ancestors).
+        <div
+            ref={chipRef}
+            className="q2-breadcrumb-chip"
+            data-testid="q2-breadcrumb-chip"
+            role="toolbar"
+            aria-label="Nesting breadcrumb"
+            onPointerDown={eat}
+            onPointerUp={(e) => e.stopPropagation()}
+            style={{
+                position: 'absolute',
+                // #quarto-content is a CSS grid (.page-columns). An abspos child
+                // of a grid is contained by its GRID AREA, not the grid box — so
+                // without this it auto-places into the body content column and
+                // `left:0` resolves to the column edge (colLeft), unable to reach
+                // the outer page margin. Spanning screen-start→screen-end makes the
+                // grid area the full page width, so computed left/top (measured vs
+                // #quarto-content) resolve against the full box and margin-spill works.
+                gridColumn: 'screen-start / screen-end',
+                gridRow: '1 / -1',
+                top: geom ? `${geom.top}px` : undefined,
+                // Left edge from computeChipGeometry (pivot-pinned left-spill):
+                // surfaceLeft − ◀ − band, clamped to ≥ 0 at the page edge.
+                left: geom ? `${geom.chipLeft}px` : undefined,
+                zIndex: 50,
+            }}
+        >
+            <BreadcrumbCrumbs
+                layout="standalone"
+                displayItems={displayItems}
+                bandWidth={geom?.bandWidth}
+            />
+        </div>
     );
 }

--- a/ts-packages/preview-renderer/src/q2-preview/BreadcrumbCrumbs.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/BreadcrumbCrumbs.tsx
@@ -1,0 +1,240 @@
+/**
+ * BreadcrumbCrumbs.tsx — the position-agnostic crumb UI shared by the two
+ * breadcrumb renderings (bd-9x3zbuj8 Task 2):
+ *
+ *   - STANDALONE: rendered inside the floating, absolutely-positioned
+ *     `BreadcrumbChip` pill (for plain-text blocks: lists, code, divs, …, or a
+ *     Para/Header the user toggled to plain mode). Uses the pivot-pinned
+ *     left-spill geometry — the band is a fixed `bandWidth` the crumbs flex to
+ *     fill, and the middle may ellipsize.
+ *   - INLINE: rendered in the rich-text toolbar's flex row, to the RIGHT of the
+ *     formatting buttons (for Para/Header in rich mode). No geometry: the crumbs
+ *     size to their natural content width and flow after the toolbar buttons, so
+ *     the toolbar's left edge stays fixed regardless of breadcrumb width.
+ *
+ * This component renders ONLY the inner trio (◀ · crumb band · ▶ · future
+ * placeholder) as a fragment, so each caller supplies its own wrapper (the
+ * positioned pill for standalone; the toolbar row for inline). It reads the
+ * nesting handlers off `PreviewContext` and injects the shared stylesheet once.
+ */
+
+import React, { useContext } from 'react';
+import { PreviewContext } from './PreviewContext';
+import { detectPlatform } from './nestingNav';
+import type { AncestorCrumb } from './nestingNav';
+
+// ── Display item types ─────────────────────────────────────────────────────────
+
+// A crumb to render, or an ellipsis standing in for the elided middle of a path
+// too long to show at a legible width (standalone band only).
+export type CrumbDisplayItem =
+    | { kind: 'crumb'; crumb: AncestorCrumb }
+    | { kind: 'ellipsis' };
+
+// ── Shared stylesheet (inject-once) ─────────────────────────────────────────────
+
+let stylesInjected = false;
+
+/**
+ * Inject the shared breadcrumb stylesheet once. Holds both the crumb-button
+ * styling (shared by standalone + inline) and the standalone-only positioning
+ * rules (`#quarto-content` offset-parent, `.q2-breadcrumb-chip` pill). The
+ * positioning rules are class-scoped and harmless when only the inline crumbs
+ * are present.
+ */
+export function ensureBreadcrumbStyles(): void {
+    if (stylesInjected || typeof document === 'undefined') return;
+    stylesInjected = true;
+    const style = document.createElement('style');
+    style.setAttribute('data-q2-breadcrumb', '1');
+    style.textContent = CSS;
+    document.head.appendChild(style);
+}
+
+const CSS = `
+/* Phase 3: make #quarto-content the standalone chip's offset-parent. This
+   creates a stacking context on the page-columns grid container. Risk is LOW:
+   no position:fixed children inside #quarto-content; sidebar/TOC/overlays have
+   their own stacking contexts. The chip's z-index:50 paints above
+   sidebar(z≈1)/main(z=0). Only relevant to the standalone chip. */
+#quarto-content { position: relative; }
+
+.q2-breadcrumb-chip {
+    display: flex;
+    align-items: center;
+    gap: 0;
+    pointer-events: auto;
+    /* No horizontal padding: chipLeft + ◀ width + band width must sum exactly to
+       surfaceLeft so the crumb row's right edge meets the pivot
+       (computeChipGeometry pins it there). Vertical breathing only. */
+    padding: 1px 0;
+    /* G13: opaque pill — a very faint cool blue-grey. */
+    background: rgb(243, 247, 250);
+    border-radius: 4px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.12);
+}
+/* Fixed-width crumb band (standalone): [◀.right, surfaceLeft]. Crumbs flex to
+   fill it; width is set inline. */
+.q2-breadcrumb-crumbs {
+    display: flex;
+    align-items: center;
+    gap: 0;
+    overflow: hidden;
+}
+/* Inline band (in the rich-text toolbar): natural-width, no flex-fill, no
+   ellipsize — the crumbs size to content and flow after the toolbar buttons. */
+.q2-breadcrumb-crumbs.q2-bc-inline {
+    overflow: visible;
+    width: auto;
+}
+.q2-crumb {
+    border: none;
+    background: transparent;
+    font-size: 12px;
+    padding: 1px 3px;
+    cursor: pointer;
+    color: inherit;
+    line-height: 1.4;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    text-align: center;
+    /* Share the band equally; shrink below content width if needed (standalone). */
+    flex: 1 1 0;
+    min-width: 0;
+}
+/* Inline crumbs size to content rather than sharing a fixed band. */
+.q2-bc-inline .q2-crumb {
+    flex: 0 0 auto;
+}
+.q2-crumb-current {
+    font-weight: bold;
+    text-decoration: underline;
+}
+.q2-crumb:not(.q2-crumb-current):hover {
+    text-decoration: underline;
+}
+.q2-breadcrumb-out,
+.q2-breadcrumb-in {
+    border: none;
+    background: transparent;
+    font-size: 11px;
+    padding: 1px 4px;
+    cursor: pointer;
+    color: #555;
+    line-height: 1.4;
+    border-radius: 3px;
+    flex-shrink: 0;
+}
+.q2-breadcrumb-out:hover,
+.q2-breadcrumb-in:hover {
+    background: rgba(0,0,0,0.08);
+}
+.q2-crumb-cat-container { color: #4f46e5; }
+.q2-crumb-cat-list      { color: #15803d; }
+.q2-crumb-cat-quote     { color: #b45309; }
+.q2-crumb-cat-leaf-text { color: #0284c7; }
+.q2-crumb-cat-embed     { color: #0f766e; }
+.q2-breadcrumb-future   { opacity: 0.4; }
+.q2-crumb-ellipsis {
+    font-size: 12px;
+    padding: 1px 3px;
+    color: #888;
+    line-height: 1.4;
+    flex: 0 0 auto;
+    user-select: none;
+}
+`;
+
+// MIN_GLYPH_W is re-exported by BreadcrumbChip (geometry owner); the ◀/▶ buttons
+// only need it for their fixed-width inline style in the standalone band.
+const MIN_GLYPH_W = 16;
+
+// ── Component ──────────────────────────────────────────────────────────────────
+
+export interface BreadcrumbCrumbsProps {
+    /** Items to render in the crumb band (already ellipsized for standalone; the
+     *  full path for inline). */
+    displayItems: CrumbDisplayItem[];
+    /** 'standalone' (floating pill, fixed band) | 'inline' (toolbar row, natural). */
+    layout: 'standalone' | 'inline';
+    /** Standalone only: the fixed band width (px) the crumbs flex to fill. */
+    bandWidth?: number;
+}
+
+/**
+ * The crumb trio (◀ · band · ▶ · future placeholder), as a fragment. Reads the
+ * nesting handlers off PreviewContext; injects the shared stylesheet.
+ */
+export function BreadcrumbCrumbs({
+    displayItems,
+    layout,
+    bandWidth,
+}: BreadcrumbCrumbsProps): React.ReactElement {
+    ensureBreadcrumbStyles();
+    const ctx = useContext(PreviewContext);
+    const platform = detectPlatform();
+    const outTip = platform === 'mac' ? 'Out (⌘⌃←)' : 'Out (Alt+Shift+←)';
+    const inTip = platform === 'mac' ? 'In (⌘⌃→)' : 'In (Alt+Shift+→)';
+    const inline = layout === 'inline';
+
+    return (
+        <>
+            {/* ◀ out-arrow */}
+            <button
+                type="button"
+                className="q2-breadcrumb-out"
+                title={outTip}
+                aria-label={outTip}
+                style={inline ? undefined : { minWidth: `${MIN_GLYPH_W}px`, maxWidth: `${MIN_GLYPH_W}px`, flex: '0 0 auto' }}
+                onPointerDown={(e) => e.preventDefault()}
+                onClick={(e) => { e.stopPropagation(); ctx?.requestNestingMove?.('out'); }}
+            >◀</button>
+            {/* Crumb band */}
+            <div
+                className={`q2-breadcrumb-crumbs${inline ? ' q2-bc-inline' : ''}`}
+                style={!inline && bandWidth != null ? { width: `${bandWidth}px`, flex: '0 0 auto' } : undefined}
+            >
+                {displayItems.map((item, idx) => {
+                    if (item.kind === 'ellipsis') {
+                        return (
+                            <span
+                                key={`ellipsis-${idx}`}
+                                className="q2-crumb-ellipsis"
+                                aria-hidden="true"
+                            >…</span>
+                        );
+                    }
+                    const c = item.crumb;
+                    return (
+                        <button
+                            key={`${c.r0}-${c.r1}`}
+                            type="button"
+                            className={[
+                                'q2-crumb',
+                                `q2-crumb-cat-${c.category}`,
+                                c.isCurrent ? 'q2-crumb-current' : '',
+                            ].filter(Boolean).join(' ')}
+                            title={c.label}
+                            aria-label={c.label}
+                            aria-current={c.isCurrent ? 'true' : undefined}
+                            onPointerDown={(e) => e.preventDefault()}
+                            onClick={(e) => { e.stopPropagation(); ctx?.requestNestingSelect?.(c.r0, c.r1); }}
+                        >{c.abbrev}</button>
+                    );
+                })}
+            </div>
+            {/* ▶ in-arrow + future-crumb placeholder */}
+            <button
+                type="button"
+                className="q2-breadcrumb-in"
+                title={inTip}
+                aria-label={inTip}
+                style={{ flex: '0 0 auto' }}
+                onPointerDown={(e) => e.preventDefault()}
+                onClick={(e) => { e.stopPropagation(); ctx?.requestNestingMove?.('in'); }}
+            >▶</button>
+            <span className="q2-breadcrumb-future" />
+        </>
+    );
+}

--- a/ts-packages/preview-renderer/src/q2-preview/dispatchers.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/dispatchers.tsx
@@ -15,6 +15,7 @@ import { buildNestingCommitDestination, classifyNestingKey, detectPlatform } fro
 import { editBaseline } from './outerBlocks';
 import { RichTextEditor } from './richtext/RichTextEditor';
 import { EditAffordance } from './richtext/EditAffordance';
+import { richTextAvailable } from './richTextSupport';
 
 // P3.3 §3b: detect platform once at module load so classifyNestingKey can
 // distinguish mac (Cmd+Ctrl) from other (Alt+Shift) nesting chords.
@@ -505,16 +506,8 @@ function renderBlockTextarea(
     return <EditTextarea ctx={ctx} resolved={resolved} />;
 }
 
-/**
- * Block types the rich-text editor can handle. Everything else falls back to the
- * textarea even when `richText` is on. 1a: Para. 1b: + Header. (1c: lists/quotes.)
- */
-const RICHTEXT_SUPPORTED_TYPES = new Set<string>(['Para', 'Header']);
-
-/** True when the rich editor is available for this block (flag on + supported type). */
-function richTextAvailable(ctx: PreviewContextValue, sourceNodeType: string): boolean {
-    return !!ctx.richText && RICHTEXT_SUPPORTED_TYPES.has(sourceNodeType);
-}
+// `RICHTEXT_SUPPORTED_TYPES` / `richTextAvailable` live in the leaf module
+// `richTextSupport.ts` (shared with the breadcrumb, no import cycle).
 
 /**
  * Which edit surface to render for the active block: the tiptap editor when rich

--- a/ts-packages/preview-renderer/src/q2-preview/nestingNav.ts
+++ b/ts-packages/preview-renderer/src/q2-preview/nestingNav.ts
@@ -743,6 +743,36 @@ export function buildAncestorPath(
   }));
 }
 
+// ── currentSourceNodeType ───────────────────────────────────────────────────────
+
+/**
+ * The Pandoc node type (`t`) of the non-Opaque source-index entry whose range
+ * exactly matches `[r0, r1]` — i.e. the node currently being edited. Returns
+ * null when no entry matches or the match has no string `t`.
+ *
+ * Used by the breadcrumb to decide whether the active edit target is a
+ * rich-text-supported block: when it is (and the rich editor is showing), the
+ * standalone floating chip defers to the breadcrumb rendered INLINE in the
+ * rich-text toolbar row (bd-9x3zbuj8 Task 2). Pure (no DOM).
+ */
+export function currentSourceNodeType(
+  sourceIndex: Map<string, SourceIndexEntry> | null | undefined,
+  r0: number,
+  r1: number,
+): string | null {
+  if (!sourceIndex) return null;
+  for (const [key, entry] of sourceIndex) {
+    if (entry.reachabilityClass === 'Opaque') continue;
+    const parsed = parseSiKey(key);
+    if (!parsed) continue;
+    if (parsed.r0 === r0 && parsed.r1 === r1) {
+      const t = (entry.sourceNode as { t?: unknown }).t;
+      return typeof t === 'string' ? t : null;
+    }
+  }
+  return null;
+}
+
 // ── buildNestingCommitDestination ───────────────────────────────────────────────
 
 /**

--- a/ts-packages/preview-renderer/src/q2-preview/p3-4-inline-breadcrumb.integration.test.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/p3-4-inline-breadcrumb.integration.test.tsx
@@ -1,0 +1,187 @@
+/**
+ * bd-9x3zbuj8 Task 2 — inline nesting breadcrumb in the rich-text toolbar.
+ *
+ * When the rich-text editor is showing for the active target (a Para/Header in
+ * rich mode), the nesting breadcrumb must render INLINE in the toolbar row
+ * (`.q2-rt-toolbar .q2-crumb`), to the right of the formatting buttons — NOT as
+ * the separate floating chip (`[data-testid="q2-breadcrumb-chip"]`), which would
+ * overlap the toolbar. The standalone chip must SUPPRESS itself for that target.
+ *
+ * Conversely, for a NON-rich block (e.g. a CodeBlock) the standalone floating
+ * chip is still used (there is no toolbar to host an inline breadcrumb).
+ *
+ * Drives the REAL PreviewRoot so the dispatcher picks the rich surface and the
+ * real RichTextEditor/RichTextToolbar mount (tiptap runs in jsdom).
+ *
+ * Structural-overlap note: asserting the crumbs live INSIDE `.q2-rt-toolbar`
+ * proves they flow after the toolbar buttons in the same flex row, so the
+ * toolbar's left edge is independent of the breadcrumb's width — the no-overlap
+ * invariant. Pixel geometry (toolbar-left stable as crumb width changes) is
+ * jsdom-untestable (all rects are 0) and is covered by Playwright.
+ */
+
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup, act, fireEvent } from '@testing-library/react';
+import { PreviewRoot } from './PreviewRoot';
+import type { PreviewRootProps } from './PreviewRoot';
+
+afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+});
+
+/* ─── PointerEvent helper (verbatim from p3-4-breadcrumb) ───────────────────── */
+function ptrEvent(
+    type: string,
+    opts: PointerEventInit & { clientX?: number; clientY?: number } = {},
+): Event {
+    const PE = (window as any).PointerEvent ?? Event;
+    const evt = new PE(type, { bubbles: true, cancelable: true, ...opts });
+    for (const [key, val] of Object.entries({
+        ...(opts.pointerType !== undefined ? { pointerType: opts.pointerType } : {}),
+    } as Record<string, unknown>)) {
+        Object.defineProperty(evt, key, { value: val, configurable: true });
+    }
+    return evt;
+}
+
+/* ─── Fixture: a Para nested in a Div (so the path has > 1 crumb) ───────────── */
+// content bytes (length 25): :::␠d\nAAA\n\nBBB\n:::\npara2\n
+const CONTENT = '::: d\nAAA\n\nBBB\n:::\npara2\n';
+const POOL = [
+    { t: 0, r: [0, 18], d: 0 },    // pool[0] Div        siKey 0:0-18:0
+    { t: 0, r: [6, 9], d: 0 },     // pool[1] ParaA      siKey 0:6-9:0
+    { t: 0, r: [11, 14], d: 0 },   // pool[2] ParaB      siKey 0:11-14:0
+    { t: 0, r: [19, 24], d: 0 },   // pool[3] para2      siKey 0:19-24:0
+];
+
+function makeAstJson(): string {
+    return JSON.stringify({
+        'pandoc-api-version': [1, 23, 0],
+        meta: {},
+        blocks: [
+            {
+                t: 'Div',
+                c: [
+                    ['', ['d'], []],
+                    [
+                        { t: 'Para', c: [{ t: 'Str', c: 'AAA' }], s: 1 },
+                        { t: 'Para', c: [{ t: 'Str', c: 'BBB' }], s: 2 },
+                    ],
+                ],
+                s: 0,
+            },
+            { t: 'Para', c: [{ t: 'Str', c: 'para2' }], s: 3 },
+        ],
+        astContext: { p: POOL },
+    });
+}
+
+function mountFixture(opts: { richText?: boolean } = {}) {
+    const astJson = makeAstJson();
+    const props: PreviewRootProps = {
+        astJson,
+        untransformedAstJson: astJson,
+        renderedContent: CONTENT,
+        currentFilePath: '/test.qmd',
+        assetManifest: {},
+        setAst: vi.fn(),
+        unlockNestingCursor: true,
+        richText: opts.richText,
+        onNavigateToDocument: () => {},
+    };
+    return render(<PreviewRoot {...props} />);
+}
+
+function mockTileRects(container: HTMLElement) {
+    container.querySelectorAll<HTMLElement>('[data-block-pool-id]').forEach((tile) => {
+        const pid = Number(tile.getAttribute('data-block-pool-id'));
+        vi.spyOn(tile, 'getBoundingClientRect').mockReturnValue({
+            left: 0, top: pid * 80, right: 300, bottom: pid * 80 + 60,
+            width: 300, height: 60, x: 0, y: pid * 80, toJSON: () => ({}),
+        } as DOMRect);
+    });
+}
+
+async function openEditor(container: HTMLElement, poolId: string) {
+    const el = container.querySelector<HTMLElement>(`[data-block-pool-id="${poolId}"]`)!;
+    await act(async () => {
+        fireEvent(el, ptrEvent('pointerdown', { pointerType: 'mouse' }));
+        fireEvent(el, ptrEvent('pointerup', { pointerType: 'mouse' }));
+    });
+}
+
+const standaloneChip = (c: HTMLElement) =>
+    c.querySelector<HTMLElement>('[data-testid="q2-breadcrumb-chip"]');
+const toolbar = (c: HTMLElement) => c.querySelector<HTMLElement>('.q2-rt-toolbar');
+
+describe('bd-9x3zbuj8 Task 2 — inline breadcrumb in the rich-text toolbar', () => {
+    it('renders the breadcrumb INSIDE the toolbar row and suppresses the standalone chip (rich Para)', async () => {
+        const { container } = mountFixture({ richText: true });
+        await act(async () => {});
+        mockTileRects(container);
+
+        // Open ParaB (pool-id=2) — a rich-text-supported Para nested in a Div.
+        await openEditor(container, '2');
+
+        // The rich-text toolbar must be present (rich editor is the active surface).
+        const tb = toolbar(container);
+        expect(tb, 'rich-text toolbar must render for a Para in rich mode').not.toBeNull();
+
+        // The crumbs must live INSIDE the toolbar row — proving side-by-side layout
+        // with the formatting buttons (no separate floating chip to overlap).
+        const inlineCrumbs = Array.from(tb!.querySelectorAll<HTMLElement>('.q2-crumb'));
+        expect(inlineCrumbs.map((c) => c.textContent)).toEqual(['Dv', '¶']);
+        // The in/out nav arrows are inline too.
+        expect(tb!.querySelector('.q2-breadcrumb-out')).not.toBeNull();
+        expect(tb!.querySelector('.q2-breadcrumb-in')).not.toBeNull();
+
+        // The standalone floating chip must NOT render for this target (no double).
+        expect(
+            standaloneChip(container),
+            'standalone chip must be suppressed when the inline breadcrumb is showing',
+        ).toBeNull();
+    });
+
+    it('still uses the standalone floating chip for a non-rich block (CodeBlock)', async () => {
+        // A CodeBlock is not rich-text-supported, so the textarea (not the rich
+        // editor) opens and the breadcrumb falls back to the standalone chip.
+        const codeContent = '``` python\nx = 1\n```\n';
+        const codePool = [{ t: 0, r: [0, 20], d: 0 }]; // pool[0] CodeBlock
+        const codeAst = JSON.stringify({
+            'pandoc-api-version': [1, 23, 0],
+            meta: {},
+            blocks: [
+                { t: 'CodeBlock', c: [['', ['python'], []], 'x = 1'], s: 0 },
+            ],
+            astContext: { p: codePool },
+        });
+        const props: PreviewRootProps = {
+            astJson: codeAst,
+            untransformedAstJson: codeAst,
+            renderedContent: codeContent,
+            currentFilePath: '/code.qmd',
+            assetManifest: {},
+            setAst: vi.fn(),
+            unlockNestingCursor: true,
+            richText: true, // on, but a CodeBlock is unsupported → textarea + standalone chip
+            onNavigateToDocument: () => {},
+        };
+        const { container } = render(<PreviewRoot {...props} />);
+        await act(async () => {});
+        mockTileRects(container);
+
+        await openEditor(container, '0'); // the CodeBlock
+
+        // No rich toolbar for a code block.
+        expect(toolbar(container), 'no rich toolbar for a CodeBlock').toBeNull();
+        // The standalone floating chip carries the breadcrumb here.
+        expect(
+            standaloneChip(container),
+            'standalone chip must render for a non-rich block',
+        ).not.toBeNull();
+    });
+});

--- a/ts-packages/preview-renderer/src/q2-preview/richTextSupport.ts
+++ b/ts-packages/preview-renderer/src/q2-preview/richTextSupport.ts
@@ -1,0 +1,33 @@
+/**
+ * richTextSupport.ts — the single source of truth for "which blocks the
+ * rich-text editor handles" and "is the rich editor actually showing".
+ *
+ * Kept in a tiny leaf module (no React, no component imports) so both the
+ * dispatcher (which chooses the edit surface) and the breadcrumb (which chooses
+ * between its inline and standalone renderings) can share the predicate without
+ * an import cycle. bd-9x3zbuj8 Task 2.
+ */
+
+import type { PreviewContextValue } from './PreviewContext';
+
+/**
+ * Block types the rich-text editor can handle. Everything else falls back to the
+ * textarea even when `richText` is on. 1a: Para. 1b: + Header. (1c: lists/quotes.)
+ */
+export const RICHTEXT_SUPPORTED_TYPES = new Set<string>(['Para', 'Header']);
+
+/** True when the rich editor is available for this block (flag on + supported type). */
+export function richTextAvailable(ctx: PreviewContextValue, sourceNodeType: string): boolean {
+    return !!ctx.richText && RICHTEXT_SUPPORTED_TYPES.has(sourceNodeType);
+}
+
+/**
+ * True when the rich-text editor surface is actually showing for a block of this
+ * node type — the rich editor is available AND the session mode is not 'plain'.
+ * This is the exact condition `renderBlockEditSurface` uses to choose
+ * `<RichTextEditor>` over the textarea. The breadcrumb uses it to decide between
+ * the inline (in-toolbar) and standalone (floating) renderings.
+ */
+export function richEditorActiveForType(ctx: PreviewContextValue, sourceNodeType: string): boolean {
+    return richTextAvailable(ctx, sourceNodeType) && (ctx.editorMode ?? 'rich') !== 'plain';
+}

--- a/ts-packages/preview-renderer/src/q2-preview/richtext/RichTextEditor.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/richtext/RichTextEditor.tsx
@@ -20,7 +20,8 @@ import Superscript from '@tiptap/extension-superscript';
 import type { Editor } from '@tiptap/core';
 import type { Node as PMNode } from '@tiptap/pm/model';
 import type { PreviewContextValue, ResolvedSource } from './../PreviewContext';
-import { buildNestingCommitDestination } from './../nestingNav';
+import { buildNestingCommitDestination, buildAncestorPath } from './../nestingNav';
+import { BreadcrumbCrumbs } from './../BreadcrumbCrumbs';
 import { astToDoc } from './astToProseMirror';
 import { docToMarkdown } from './serializer';
 import { Chip } from './chipExtension';
@@ -224,12 +225,33 @@ export function RichTextEditor({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [editor]);
 
+  // Inline nesting breadcrumb (bd-9x3zbuj8 Task 2): when the nesting cursor is
+  // on, the hierarchy navigator renders to the RIGHT of the formatting buttons in
+  // the SAME toolbar row, instead of as a separate floating chip that would
+  // overlap the toolbar. The standalone BreadcrumbChip self-suppresses for this
+  // exact case (rich editor active for the target). Built here from the live edit
+  // target so it tracks nesting in/out moves.
+  const et = ctx.editTarget;
+  const inlineBreadcrumb =
+    ctx.unlockNestingCursor && et
+      ? (() => {
+          const crumbs = buildAncestorPath(ctx.sourceIndex, et.anchorR0, et.anchorR1);
+          if (crumbs.length === 0) return null;
+          return (
+            <BreadcrumbCrumbs
+              layout="inline"
+              displayItems={crumbs.map((crumb) => ({ kind: 'crumb' as const, crumb }))}
+            />
+          );
+        })()
+      : null;
+
   // The left-margin affordance (Editing… + rich/plain toggle) is rendered by
   // renderMeasuredEdit so it is shared with the plain-text surface. The
   // formatting toolbar is rich-only and lives here (it needs the editor).
   return (
     <div className="q2-richtext-editor" ref={rootRef}>
-      {editor && <RichTextToolbar editor={editor} />}
+      {editor && <RichTextToolbar editor={editor} trailing={inlineBreadcrumb} />}
       {editor && <EditorContent editor={editor} />}
     </div>
   );

--- a/ts-packages/preview-renderer/src/q2-preview/richtext/RichTextToolbar.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/richtext/RichTextToolbar.tsx
@@ -13,7 +13,7 @@
 // input DOES take focus; the editor's commit is scoped to "focus left the whole
 // edit box" (see RichTextEditor), so focusing the input keeps the session open.
 
-import { useEffect, useRef, useState, type MouseEvent } from 'react';
+import { useEffect, useRef, useState, type MouseEvent, type ReactNode } from 'react';
 import type { Editor } from '@tiptap/core';
 
 interface MarkSpec {
@@ -30,7 +30,15 @@ const MARKS: MarkSpec[] = [
   { name: 'superscript', label: 'x²', title: 'Superscript' },
 ];
 
-export function RichTextToolbar({ editor }: { editor: Editor }) {
+export function RichTextToolbar({
+  editor,
+  trailing,
+}: {
+  editor: Editor;
+  /** Optional content rendered at the END of the toolbar row, after a separator
+   *  (bd-9x3zbuj8 Task 2: the inline nesting breadcrumb). */
+  trailing?: ReactNode;
+}) {
   // Re-render on selection/content changes so isActive() highlights stay current.
   const [, force] = useState(0);
   useEffect(() => {
@@ -145,6 +153,12 @@ export function RichTextToolbar({ editor }: { editor: Editor }) {
             <button type="button" className="q2-rt-tb-btn" title="Remove link" onMouseDown={(e) => { e.preventDefault(); removeLink(); }}>✕</button>
           )}
         </div>
+      )}
+      {trailing != null && (
+        <>
+          <span className="q2-rt-tb-sep" />
+          {trailing}
+        </>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary

Two changes to the `q2 preview` live block editor (tiptap rich text), strand **bd-9x3zbuj8**:

1. **Task 1 — bring the hierarchical block navigator to `q2 preview --allow-edit`.** The nesting-cursor breadcrumb (◀ Dv ¶ ▶) shipped in hub-client/quarto-hub.com but was off by default in the `q2 preview` SPA. `parseNestingCursorParam` now defaults **on** (`?nestingCursor=0` opts out), mirroring the existing `richText` default-on / `?richText=0` contract. It self-gates on an active edit target, so read-only previews never show it.

2. **Task 2 — fix the breadcrumb / rich-text-toolbar overlap.** When a rich-text block is open, the navigator now renders **inline in the toolbar row**, to the right of the formatting buttons, instead of as a floating chip that overlapped them. Implemented via the user-chosen **Option B** (inline in the toolbar; standalone chip retained for plain/non-rich blocks).

Before (reported): `◀ Dv ¶ ▶` floating chip overlapping `B I S x₂ x² 🔗`.
After: single toolbar row `B I S x₂ x² 🔗 │ ◀ Dv ¶ ▶` — formatting fixed on the left, navigator inline to the right, no overlap. Fixes the overlap in both hub-client and `q2 preview` (shared `@quarto/preview-renderer`).

## Implementation

- Extracted a position-agnostic `BreadcrumbCrumbs` from `BreadcrumbChip` (`layout: 'standalone' | 'inline'`, shared `ensureBreadcrumbStyles()`). Standalone keeps its pivot-pinned left-spill geometry **unchanged**; inline sizes to natural width and flows after the toolbar buttons, so the toolbar's left edge is independent of breadcrumb width.
- `RichTextToolbar` gains a `trailing` slot; `RichTextEditor` builds the inline breadcrumb from the live edit target.
- The standalone `BreadcrumbChip` self-suppresses for a target whose rich editor is active, via a new leaf module `richTextSupport.ts` (`RICHTEXT_SUPPORTED_TYPES`, `richTextAvailable`, `richEditorActiveForType`) + `currentSourceNodeType`. Synchronous and reactive (tracks `editorMode`/`richText`); no changes to the activation path.

## Verification

- **End-to-end through the real `q2` binary** + Chrome: clicking a paragraph nested in a callout div produced toolbar DOM `B I S x₂ x² 🔗 ◀ Dv ¶ ▶` with the standalone chip absent and no overlap (screenshot inspected).
- Tests: preview-renderer 500 unit + 515 integration; q2-preview-spa 37 unit + 75 integration + **37 real-binary Playwright e2e**; hub-client 662 unit + 76 integration. `cargo xtask verify --skip-hub-build` green (Rust untouched); hub-client + q2-preview-spa production builds green.
- New tests: `parseNestingCursorParam.test.ts`, `p3-4-inline-breadcrumb.integration.test.tsx`; restructured `nesting-cursor.spec.ts` for the new defaults.

## Discovered work (filed)

- **bd-fpys25b0** (filed, *not* in this PR): the entire hub-client block-editing e2e suite (12 specs) has been red since rich-text went default-on (bd-j1nto6eq) — none pin `richText`, so they wait for a `textarea` the rich editor replaces. Not in default `cargo xtask verify` (`test:e2e` is opt-in). Left for a dedicated session.
- **bd-n4v4phe4** (fixed here): the equivalent `edit-cell-sizing.spec.ts` (q2-preview-spa e2e) — pinned `?richText=0` (the bd-038tnyqy baseline pattern).

Plan: `claude-notes/plans/2026-06-25-q2-preview-hierarchy-nav-and-overlap.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)