### PR TITLE
Gate native-pampa round-trip tests behind opt-in env var (bd-d8nol0xn)

### DIFF
--- a/ts-packages/preview-renderer/src/q2-preview/richtext/roundtrip.test.ts
+++ b/ts-packages/preview-renderer/src/q2-preview/richtext/roundtrip.test.ts
@@ -4,8 +4,12 @@
 //
 //   qmd -> pampa AST -> astToDoc -> docToMarkdown -> pampa AST -> compare
 //
-// Skips when native pampa can't be built (Rust-less CI). Run locally:
-//   cd ts-packages/preview-renderer && npx vitest run src/q2-preview/richtext/
+// DISABLED BY DEFAULT (bd-d8nol0xn): shells out to the native `pampa` binary via
+// the test-utils oracle (slow, and intermittently flaky under the parallel load of
+// a full `vitest run` / `cargo xtask verify`). This is a fidelity oracle, not a
+// routine gate. Opt in (and only runs when native pampa is buildable):
+//   QUARTO_RUN_PAMPA_ROUNDTRIP=1 npx vitest run src/q2-preview/richtext/roundtrip.test.ts
+// (from ts-packages/preview-renderer).
 
 import { describe, it, expect } from 'vitest';
 import { astToDoc } from './astToProseMirror';
@@ -34,7 +38,7 @@ const FIXTURES: { name: string; qmd: string }[] = [
 // nodes. Byte-exact round-tripping is a nice-to-have, not required (cosmetic
 // reformatting like `***x***` -> `**_x_**`, or `-` -> `*` bullets, is acceptable);
 // we log it for visibility but do not fail on it.
-describe.skipIf(!pampaAvailable())('rich-text bridge round-trip', () => {
+describe.skipIf(!process.env.QUARTO_RUN_PAMPA_ROUNDTRIP || !pampaAvailable())('rich-text bridge round-trip', () => {
   for (const fx of FIXTURES) {
     it(`preserves semantics: ${fx.name}`, () => {
       const astIn = parseUntransformed(fx.qmd);

--- a/ts-packages/preview-renderer/src/q2-preview/tiptap-roundtrip-spike/roundtrip.test.ts
+++ b/ts-packages/preview-renderer/src/q2-preview/tiptap-roundtrip-spike/roundtrip.test.ts
@@ -3,7 +3,11 @@
 // Bucket each fixture: exact / equivalent (reformatted) / broken. Prints a findings
 // table. See claude-notes/plans/2026-06-23-tiptap-rich-text-block-editor.md.
 //
-// Run: npx vitest run src/q2-preview/tiptap-roundtrip-spike/roundtrip.test.ts
+// DISABLED BY DEFAULT (bd-d8nol0xn): this is a measurement spike, not a routine
+// gate, and it shells out to the native `pampa` binary (build + per-fixture
+// subprocess over temp files) — slow, and intermittently flaky under the parallel
+// load of a full `vitest run` / `cargo xtask verify`. Opt in to run it:
+//   QUARTO_RUN_PAMPA_ROUNDTRIP=1 npx vitest run src/q2-preview/tiptap-roundtrip-spike/roundtrip.test.ts
 // (from ts-packages/preview-renderer). Requires a buildable native `pampa`.
 
 import { writeFileSync } from 'node:fs';
@@ -43,7 +47,7 @@ function roundtrip(qmd: string): { row: Omit<Row, 'name'>; } {
   return { row: { verdict, chips: chips.length, unknown, mdOut } };
 }
 
-describe('tiptap markdown round-trip spike', () => {
+describe.skipIf(!process.env.QUARTO_RUN_PAMPA_ROUNDTRIP)('tiptap markdown round-trip spike', () => {
   const rows: Row[] = [];
 
   for (const fx of FIXTURES) {


### PR DESCRIPTION
## Summary

The two bd-sjb4pzx8 round-trip tests shell out to the native `pampa` binary (build + per-fixture subprocess over temp files) and are slow + **intermittently flaky** under the parallel load of a full `vitest run` / `cargo xtask verify` — a transient process/IO race around concurrent `cargo build --bin pampa` and temp dirs — while passing in isolation and on re-run. They are measurement/fidelity oracles, not routine gates:

- `tiptap-roundtrip-spike/roundtrip.test.ts` — the throwaway feasibility spike.
- `richtext/roundtrip.test.ts` — the production round-trip fidelity guard (via `test-utils/pampaOracle`).

## Change

Gate both with `describe.skipIf(!process.env.QUARTO_RUN_PAMPA_ROUNDTRIP)` so they're **skipped in routine runs** and **runnable on demand**:

```
QUARTO_RUN_PAMPA_ROUNDTRIP=1 npx vitest run src/q2-preview/richtext/roundtrip.test.ts
```

(The richtext guard keeps its existing `pampaAvailable()` skip too.) Each file's header documents the opt-in.

## Scope / what's kept

Only the two native-pampa **oracle** tests are gated. The fast jsdom rich-text unit tests of shipping behavior — `caretFromClick.test.ts`, `RichTextEditor.caret.integration.test.tsx` — are untouched and still run every time.

## Verification

- Default `vitest run` (preview-renderer): **468 passed | 32 skipped**, ~0.7s, **no pampa subprocesses** → can no longer flake (was 500 with the oracle running, ~6–23s + noisy oracle output).
- Opt-in: `QUARTO_RUN_PAMPA_ROUNDTRIP=1 … richtext/roundtrip.test.ts` → 15 passed (shells out to pampa as before).
- `cargo xtask verify --skip-hub-build` green.

Strand: bd-d8nol0xn (discovered via the flake hit in bd-pvcnea83 / PR #346).

🤖 Generated with [Claude Code](https://claude.com/claude-code)