### PR TITLE
fix(pampa): pin test fixtures and snapshots to LF

### DIFF
--- a/crates/pampa/.gitattributes
+++ b/crates/pampa/.gitattributes
@@ -1,0 +1,8 @@
+# Pampa test fixtures and snapshot baselines must stay LF on every platform
+# so the snapshot/roundtrip/corpus tests are deterministic regardless of
+# core.autocrlf. The engine's line-ending *preserve* policy is exercised by
+# in-source CRLF tests (see claude-notes/designs/line-ending-preserve.md),
+# never by these on-disk fixtures.
+tests/** text eol=lf
+snapshots/** text eol=lf
+test-fixtures/** text eol=lf


### PR DESCRIPTION
On Windows, core.autocrlf=true converts pampa's LF-committed qmd fixtures and .snap baselines to CRLF on checkout, producing snapshot, roundtrip, and corpus test failures unrelated to actual code behavior.

Mirrors the existing crates/quarto-doctemplate/.gitattributes precedent: pin fixture/snapshot/test-fixture paths to eol=lf for checkout determinism, independent of the engine's CRLF-preserve policy. That policy is exercised through in-source tests, never through file-based snapshots, so pinning these paths to LF does not weaken or bypass CRLF coverage.

## Test Plan

- [x] On a Windows checkout with core.autocrlf=true, confirm crates/pampa/tests, snapshots, and test-fixtures check out as LF (no CRLF)
- [x] `cargo nextest run -p pampa` passes unit_test_snapshots_native and test_qmd_roundtrip_consistency