### PR TITLE
Fix pandoc-oracle tests hard-failing on newer local pandoc

### DIFF
--- a/.claude/rules/xtask.md
+++ b/.claude/rules/xtask.md
@@ -23,6 +23,7 @@ paths:
 | `cargo xtask lint` | — | Run custom lint checks |
 | `cargo xtask create-worktree` | `cargo create-worktree` | Create git worktree + CLAUDE.local.md context stub (braid needs no redirect) |
 | `cargo xtask braid-snapshot` | — | Write backup-only `braid export` to `.braid/snapshot.jsonl` (one-directional; never re-import) |
+| `cargo xtask pandoc-check` | — | Check local pandoc against pampa's 4 version-gated oracle tests; print-only, reports the ceiling to bump on green |
 | `cargo xtask verify` | — | Full project verification (build + tests for Rust and hub-client) |
 
 ## Dev tool version pinning

--- a/claude-notes/plans/2026-07-02-pandoc-oracle-version-gate.md
+++ b/claude-notes/plans/2026-07-02-pandoc-oracle-version-gate.md
@@ -55,38 +55,59 @@ The two version-check sites **disagree on philosophy**: dev_setup wants a *floor
 2. **`pandoc-check` is print-only.** It does **not** auto-edit `test.rs` (avoids fighting the `cargo fmt` post-edit hook and needing a stable source anchor). On green it prints the exact ceiling to bump to; the human makes the one-line edit — matching the "manual verification ledger" spirit.
 3. **Closed range, not an explicit set.** Calibrated window is a closed range `(3,6)..=(3,9)`; bumping = raise the ceiling.
 4. **`pandoc-check` scope is narrow.** Runs just the 4 oracle tests against local pandoc + reports calibration. It does **not** also drive the dev-setup floor warning.
+5. **Gate bypass is an env var.** `has_good_pandoc_version()` returns `true` when `PAMPA_PANDOC_ORACLE_BYPASS_VERSION_GATE=1` is set (checked before parsing). This is the single seam `pandoc-check` uses to run the 4 tests against an off-range pandoc without weakening the assertion or duplicating test bodies. Normal local/CI runs never set it, so the hard-fail ledger signal is untouched. (Added from design review — this seam was previously implicit.)
+
+### Out of scope
+
+- **No-pandoc behavior is unchanged.** `has_good_pandoc_version()` currently `Command::new("pandoc")…expect(...)` → panics when pandoc is absent. That is pre-existing and not addressed here; this strand is about the version *range* gate, not pandoc discovery.
 
 ## Phases
 
 ### Phase 0 — Test plan (TDD, RED first)
 
-Unit-test `parse_pandoc_version` + the range check. Cases:
+Two pure functions to test (both spawn nothing → runnable via `cargo nextest run -p pampa`, unblocked by bd-nj9nnkn1):
+
+**a. `parse_pandoc_version(&str) -> (u32, u32)` + range check.** Cases:
 - `pandoc 3.10` → `(3,10)`, **out of range** (this is the bug: substring `contains` false-rejects; numeric `(3,10) > (3,9)` correctly out-of-range, not falsely-in).
 - `3.6` / `3.9` boundaries → in range; `3.5` → below floor; `4.0` → above ceiling.
 - Malformed / empty → `(0,0)`, out of range.
-- Mirror the same cases in xtask's existing `test_pandoc_version_at_least` module so both parsers share one contract.
 
-Run via `cargo nextest run -p pampa` (does not require clippy → unblocked by bd-nj9nnkn1). Confirm RED before implementing.
+**b. Diagnostic formatter** — a pure `fn format_gate_failure(raw_version: &str, range: …) -> String` that the `assert!` message uses. Assert it contains the raw detected version line, the calibrated range, and the `cargo xtask pandoc-check` command. This guards the *user-visible* improvement (M3 from design review) without depending on assertion-message brittleness.
 
-### Phase 1 — Replace the substring gate
+**Shared case table (M5).** Define the parse test vectors as one named `const` slice reused by both `test.rs` and xtask's `test_pandoc_version_at_least` module, with a comment on each requiring lockstep updates. Both parser copies are validated against the same table.
 
-In `test.rs`: replace `has_good_pandoc_version()`'s `contains("3.x")` chain with `parse_pandoc_version()` + closed-range check `(3,6)..=(3,9)`. Keep the hard-`assert!` at the 4 test call sites (ledger signal preserved); leave the 3 internal helpers' skip behavior unchanged.
+Confirm RED before implementing.
+
+### Phase 1 — Replace the gate + bypass seam
+
+In `test.rs`, rewrite `has_good_pandoc_version()`:
+1. First, if `PAMPA_PANDOC_ORACLE_BYPASS_VERSION_GATE=1`, return `true` (decision 5 — the calibration seam).
+2. Otherwise replace the `contains("3.x")` chain with `parse_pandoc_version()` + closed-range check `(3,6)..=(3,9)`.
+
+Keep the hard-`assert!` at the 4 test call sites (ledger signal preserved); leave the 3 internal helpers' skip behavior unchanged. The bypass lands **here**, not in Phase 3, so the xtask command layers cleanly on a finished seam (H4 — avoids Phase 3 rewriting Phase 2's assertions).
 
 ### Phase 2 — Actionable failure message
 
-On out-of-range, the `assert!` message prints: detected version, the calibrated range, and the exact command to verify+bump (`cargo xtask pandoc-check`).
+Wire the Phase 0b `format_gate_failure` into the 4 `assert!` sites so on out-of-range they print: the raw detected version line, the calibrated range, and `cargo xtask pandoc-check`.
 
 ### Phase 3 — `cargo xtask pandoc-check`
 
-New xtask subcommand (steps in `.claude/rules/xtask.md`). Runs the 4 oracle tests against local pandoc **bypassing the version gate**, narrow scope. On green: print the new ceiling to set in `test.rs`. On failure: report which test broke. Print-only — no source edit.
+New xtask subcommand (steps in `.claude/rules/xtask.md`). Sets `PAMPA_PANDOC_ORACLE_BYPASS_VERSION_GATE=1` and runs the 4 oracle tests against local pandoc, narrow scope. Print-only — no source edit. **Contract:**
+- **Exit 0** iff all 4 oracle tests pass under bypass; **nonzero** otherwise.
+- **Output** always: detected pandoc version, current calibrated range, and — on green with detected > ceiling — the proposed new ceiling plus the exact constant/line in `test.rs` to edit.
+- **On failure:** report which of the 4 tests broke (so an incompatible pandoc is diagnosable, not just "red").
 
 ### Phase 4 — Docs
 
 Ledger comment next to the range constant in `test.rs` describing the bump workflow; add `pandoc-check` to the xtask command list in `.claude/rules/xtask.md`.
 
+### Phase 5 — Final verification
+
+After **bd-nj9nnkn1** is green, run `cargo xtask verify --skip-hub-build` and confirm the full Rust leg passes (this is the step the pre-flight couldn't reach). Rust-only change → `--skip-hub-build` is sufficient.
+
 ## Prerequisite
 
-- **bd-nj9nnkn1** — `highest_version_node` Windows dead-code clippy failure blocks `cargo xtask verify` locally on Windows. One-line `#[cfg(not(windows))]` gate. Must be green for the final verify step; does not block Phase 0–3 iteration via `cargo nextest run -p pampa`.
+- **bd-nj9nnkn1** — `highest_version_node` Windows dead-code clippy failure blocks `cargo xtask verify` locally on Windows. One-line `#[cfg(not(windows))]` gate. Must be green for Phase 5; does not block Phase 0–4 iteration via `cargo nextest run -p pampa`.
 
 ## Risks / tradeoffs
 

--- a/claude-notes/plans/2026-07-02-pandoc-oracle-version-gate.md
+++ b/claude-notes/plans/2026-07-02-pandoc-oracle-version-gate.md
@@ -1,0 +1,76 @@
+# Pampa pandoc-oracle tests hard-fail on local pandoc newer than allowlist (bd-i9i5ad2t)
+
+**Date:** 2026-07-02
+**Braid:** bd-i9i5ad2t
+**Worktree:** `.worktrees/bd-i9i5ad2t-pampa-pandoc-oracle-tests` (branch `braid/bd-i9i5ad2t-pampa-pandoc-oracle-tests`, based on `main` @ `51cf3707`)
+**Status:** Investigation — pending design alignment with user. **Do not start implementation until the user gives the go-ahead.**
+
+## Triage verdict
+
+**Ready to design.** Root cause confirmed at HEAD, repro trivial, and Chris's strand already carries a detailed design ledger. Three real design decisions remain (cross-crate parser sharing, auto-edit-vs-print for the bump command, range-vs-allowlist representation) before the skeleton becomes a finished plan.
+
+## Issue context
+
+Substring version gate in `crates/pampa/tests/integration/test.rs`:
+
+```rust
+fn has_good_pandoc_version() -> bool {
+    // ...
+    version_str.contains("3.6")
+        || version_str.contains("3.7")
+        || version_str.contains("3.8")
+        || version_str.contains("3.9")
+}
+```
+
+Two failure axes:
+1. **Fragile matching.** `contains("3.6")` matches anywhere in the string — brittle. `pandoc 3.10` matches none of the four literals → returns `false`.
+2. **Inconsistent handling at call sites.** Internal helpers (`matches_pandoc_*_reader`) treat `false` as *skip* (`return true`). But four `#[test]` functions (`test_html_writer`, `test_json_writer`, `unit_test_corpus_matches_pandoc_markdown`, `unit_test_corpus_matches_pandoc_commonmark`) `assert!(has_good_pandoc_version(), ...)` → **hard-fail** with unhelpful `"Pandoc version is not suitable for testing"`.
+
+CI unaffected — `.github/workflows/test-suite.yml` pins `PANDOC_VERSION=3.8.3` exactly. Only local dev with off-allowlist pandoc bites. Priority 3, bug, filed + `in_progress` by cderv 2026-07-02.
+
+**Design intent (from strand):** keep the hard-FAIL. The allowlist is a *manual verification ledger* — each minor version was added by a human confirming the 4 oracle tests still pass against it (commit `12bca3b5`). A graceful skip would rot silently (nextest shows early-return tests as PASS, not SKIP). So the goal is not "stop failing" — it's "fail with an actionable message, and make the ledger bump a one-command chore."
+
+## Dependency graph
+
+**Empty.** `braid dep list` returns no edges — no `discovered-from`, no `blocks`, no `related`. No incoming urgency, no upstream context beyond the strand's own (rich) description. The design ledger substitutes for what a dep graph would normally supply.
+
+## What the code looks like today
+
+Both paths in the strand still exist with the described shape:
+
+- `crates/pampa/tests/integration/test.rs:91-101` — `has_good_pandoc_version()` substring allowlist (confirmed).
+- `crates/pampa/tests/integration/test.rs` call sites — 3 skip-style (`:126, :141, :171`), 4 hard-fail `assert!` (`:227, :257, :438, :528`) (confirmed).
+- `crates/xtask/src/dev_setup.rs:239` — `pandoc_version_at_least(version_output, min_major, min_minor)`. Floor check only (`>= (min_major, min_minor)`), no upper bound. Already has unit tests (`:253-263`) covering `3.6`, `3.10`-style… actually only tests up to `4.0`; parses `major.minor` off the first line after `"pandoc "`. Used once, for a dev-setup warning.
+
+**Repro at HEAD:** local `pandoc 3.10` installed. `contains("3.6".."3.9")` all `false` → the 4 oracle tests `assert!`-fail. This is exactly the reported symptom. (No fixture needed; the repro is "run the 4 tests with pandoc 3.10 on PATH.") Repro is confirmed *logically* — see the pre-flight note below; a harness-level run of the 4 tests was blocked by an unrelated clippy error before nextest ran.
+
+**Pre-flight verify did NOT reach the pampa tests.** `cargo xtask verify --skip-hub-build` at HEAD (`51cf3707`) fails at the clippy stage on a **pre-existing, Windows-only, unrelated** dead-code error: `highest_version_node` in `crates/quarto-mcp-launcher/src/node.rs:231` is called only from the non-Windows branch of `node_search_paths` (lines 207-213); the `#[cfg(windows)]` branch doesn't call it and the fn itself is not cfg-gated, so on Windows it is dead code → `-D warnings`. CI (Linux/Mac) uses the fn, so it's green there; only Windows dev (Chris) hits it. Filed as a discovered strand linked to this one. It blocks running the pampa test leg locally until fixed or `#[allow]`/`#[cfg]`-gated.
+
+The two version-check sites **disagree on philosophy**: dev_setup wants a *floor* (`>=3.6`, forward-open), test.rs wants a *calibrated set* (3.6–3.9, closed). A shared parser can serve both, but the *policy* differs — see design questions.
+
+## Proposed phases (draft)
+
+Skeleton only — contents wait on the design discussion.
+
+- **Phase 0 — Test plan (TDD).** Unit-test the new parser/gate for: `3.10` (numeric > 3.9, must be out-of-range not falsely-in), `3.6`/`3.9` boundaries, `4.0`, malformed/empty. Test lives where the shared parser lands (see Q1). RED first.
+- **Phase 1 — Shared parser.** Replace substring matching with `major.minor` parsing; unify with `dev_setup.rs`'s `pandoc_version_at_least`. Represent the calibrated range (see Q3).
+- **Phase 2 — Actionable failure message.** On out-of-range: print detected version, calibrated range, and the exact command to verify+bump.
+- **Phase 3 — `cargo xtask pandoc-check`.** Run the 4 oracle tests against local pandoc bypassing the gate; on green, self-heal the allowlist (or print the line to add) — see Q2.
+- **Phase 4 — Docs.** Note the bump workflow (dev-docs or the ledger comment near the allowlist).
+
+## Open design questions for the user
+
+1. **Where does the shared parser live?** `dev_setup.rs` is in the `xtask` crate; `test.rs` is pampa's integration-test binary. xtask is not (and shouldn't become) a dependency of pampa's tests. Options: (a) a tiny shared crate / `quarto-util` helper both depend on; (b) accept a small duplicated `parse_pandoc_version()` in each place with a shared unit-test contract; (c) something else. The strand says "reuse/share logic" — but a cross-crate share may cost more than the ~8-line parser is worth. **Recommendation: (b) duplicate the parser, share the contract via matching unit tests** unless you want a util home for it.
+
+2. **`pandoc-check`: auto-edit source, or print-only?** The ledger says "edits the allowlist in test.rs … (or at minimum prints the exact line to add)." Auto-editing a source file from an xtask is a codegen-touches-tracked-source pattern (needs a stable anchor in test.rs, risks fighting rustfmt/the fmt hook). Print-only is simpler and keeps the human in the ledger loop (matches the "manual verification ledger" spirit). **Recommendation: print-only for v1**, add auto-edit later if the chore is still annoying.
+
+3. **How is the calibrated range represented?** Once parsing is numeric, is it (a) a floor+ceiling `(3,6)..=(3,9)`, or (b) an explicit set of known-good minors `{6,7,8,9}`? A closed range is one bump-the-ceiling edit; an explicit set matches "each version individually verified" but is more to maintain. Note the ledger semantics: a *gap* (e.g. 3.7 verified, 3.8 skipped, 3.9 verified) is only expressible with a set. Has any minor ever been skipped, or is it always contiguous? **Recommendation: closed range** unless gaps are real.
+
+4. **Scope of `pandoc-check` vs. the gate.** Should `pandoc-check` also drive the dev-setup floor warning (one command reporting both), or stay narrowly "run the 4 oracle tests + report calibration"? Keeps blast radius small if narrow.
+
+## Risks / tradeoffs (draft)
+
+- **Auto-editing test.rs** (Q2 option) is the highest-risk piece: fmt hook runs `cargo fmt` on any edited Rust file, so the xtask's edit and the hook could race/conflict; a print-only design sidesteps this entirely.
+- **Cross-crate sharing** (Q1) could pull a new dependency edge into pampa's test build for an 8-line function — likely not worth it.
+- Low blast radius overall: changes are test-harness + xtask only, no product code, CI already pinned and unaffected.

--- a/claude-notes/plans/2026-07-02-pandoc-oracle-version-gate.md
+++ b/claude-notes/plans/2026-07-02-pandoc-oracle-version-gate.md
@@ -3,11 +3,11 @@
 **Date:** 2026-07-02
 **Braid:** bd-i9i5ad2t
 **Worktree:** `.worktrees/bd-i9i5ad2t-pampa-pandoc-oracle-tests` (branch `braid/bd-i9i5ad2t-pampa-pandoc-oracle-tests`, based on `main` @ `51cf3707`)
-**Status:** Investigation — pending design alignment with user. **Do not start implementation until the user gives the go-ahead.**
+**Status:** Design aligned 2026-07-02 — ready to implement (TDD). One prerequisite: bd-nj9nnkn1 (Windows clippy blocker) must be green for the final `cargo xtask verify`.
 
 ## Triage verdict
 
-**Ready to design.** Root cause confirmed at HEAD, repro trivial, and Chris's strand already carries a detailed design ledger. Three real design decisions remain (cross-crate parser sharing, auto-edit-vs-print for the bump command, range-vs-allowlist representation) before the skeleton becomes a finished plan.
+**Ready to implement.** Root cause confirmed at HEAD, repro trivial. Four design decisions resolved with the user (below). Skeleton is now a real plan.
 
 ## Issue context
 
@@ -47,30 +47,48 @@ Both paths in the strand still exist with the described shape:
 
 **Pre-flight verify did NOT reach the pampa tests.** `cargo xtask verify --skip-hub-build` at HEAD (`51cf3707`) fails at the clippy stage on a **pre-existing, Windows-only, unrelated** dead-code error: `highest_version_node` in `crates/quarto-mcp-launcher/src/node.rs:231` is called only from the non-Windows branch of `node_search_paths` (lines 207-213); the `#[cfg(windows)]` branch doesn't call it and the fn itself is not cfg-gated, so on Windows it is dead code → `-D warnings`. CI (Linux/Mac) uses the fn, so it's green there; only Windows dev (Chris) hits it. Filed as a discovered strand linked to this one. It blocks running the pampa test leg locally until fixed or `#[allow]`/`#[cfg]`-gated.
 
-The two version-check sites **disagree on philosophy**: dev_setup wants a *floor* (`>=3.6`, forward-open), test.rs wants a *calibrated set* (3.6–3.9, closed). A shared parser can serve both, but the *policy* differs — see design questions.
+The two version-check sites **disagree on philosophy**: dev_setup wants a *floor* (`>=3.6`, forward-open), test.rs wants a *calibrated set* (3.6–3.9, closed). A shared parser body serves both, but each site keeps its own *policy* (floor in dev_setup, closed range in test.rs) — see decisions 1 and 3.
 
-## Proposed phases (draft)
+## Resolved design decisions (2026-07-02)
 
-Skeleton only — contents wait on the design discussion.
+1. **Parser home — duplicate, don't cross-crate-share.** xtask is bin-only (no `[lib]`, "not part of the library API"), so pampa's test binary can't import from it without converting xtask to lib+bin and pulling `syn`/`clap`/`walkdir`/`serde_yaml` into pampa's test build. Instead: keep a small `parse_pandoc_version(&str) -> (u32, u32)` in **both** `crates/pampa/tests/integration/test.rs` and `crates/xtask/src/dev_setup.rs`, pinned to identical behavior by matching unit tests. No `Cargo.toml` dep changes, no cycle.
+2. **`pandoc-check` is print-only.** It does **not** auto-edit `test.rs` (avoids fighting the `cargo fmt` post-edit hook and needing a stable source anchor). On green it prints the exact ceiling to bump to; the human makes the one-line edit — matching the "manual verification ledger" spirit.
+3. **Closed range, not an explicit set.** Calibrated window is a closed range `(3,6)..=(3,9)`; bumping = raise the ceiling.
+4. **`pandoc-check` scope is narrow.** Runs just the 4 oracle tests against local pandoc + reports calibration. It does **not** also drive the dev-setup floor warning.
 
-- **Phase 0 — Test plan (TDD).** Unit-test the new parser/gate for: `3.10` (numeric > 3.9, must be out-of-range not falsely-in), `3.6`/`3.9` boundaries, `4.0`, malformed/empty. Test lives where the shared parser lands (see Q1). RED first.
-- **Phase 1 — Shared parser.** Replace substring matching with `major.minor` parsing; unify with `dev_setup.rs`'s `pandoc_version_at_least`. Represent the calibrated range (see Q3).
-- **Phase 2 — Actionable failure message.** On out-of-range: print detected version, calibrated range, and the exact command to verify+bump.
-- **Phase 3 — `cargo xtask pandoc-check`.** Run the 4 oracle tests against local pandoc bypassing the gate; on green, self-heal the allowlist (or print the line to add) — see Q2.
-- **Phase 4 — Docs.** Note the bump workflow (dev-docs or the ledger comment near the allowlist).
+## Phases
 
-## Open design questions for the user
+### Phase 0 — Test plan (TDD, RED first)
 
-1. **Where does the shared parser live?** `dev_setup.rs` is in the `xtask` crate; `test.rs` is pampa's integration-test binary. xtask is not (and shouldn't become) a dependency of pampa's tests. Options: (a) a tiny shared crate / `quarto-util` helper both depend on; (b) accept a small duplicated `parse_pandoc_version()` in each place with a shared unit-test contract; (c) something else. The strand says "reuse/share logic" — but a cross-crate share may cost more than the ~8-line parser is worth. **Recommendation: (b) duplicate the parser, share the contract via matching unit tests** unless you want a util home for it.
+Unit-test `parse_pandoc_version` + the range check. Cases:
+- `pandoc 3.10` → `(3,10)`, **out of range** (this is the bug: substring `contains` false-rejects; numeric `(3,10) > (3,9)` correctly out-of-range, not falsely-in).
+- `3.6` / `3.9` boundaries → in range; `3.5` → below floor; `4.0` → above ceiling.
+- Malformed / empty → `(0,0)`, out of range.
+- Mirror the same cases in xtask's existing `test_pandoc_version_at_least` module so both parsers share one contract.
 
-2. **`pandoc-check`: auto-edit source, or print-only?** The ledger says "edits the allowlist in test.rs … (or at minimum prints the exact line to add)." Auto-editing a source file from an xtask is a codegen-touches-tracked-source pattern (needs a stable anchor in test.rs, risks fighting rustfmt/the fmt hook). Print-only is simpler and keeps the human in the ledger loop (matches the "manual verification ledger" spirit). **Recommendation: print-only for v1**, add auto-edit later if the chore is still annoying.
+Run via `cargo nextest run -p pampa` (does not require clippy → unblocked by bd-nj9nnkn1). Confirm RED before implementing.
 
-3. **How is the calibrated range represented?** Once parsing is numeric, is it (a) a floor+ceiling `(3,6)..=(3,9)`, or (b) an explicit set of known-good minors `{6,7,8,9}`? A closed range is one bump-the-ceiling edit; an explicit set matches "each version individually verified" but is more to maintain. Note the ledger semantics: a *gap* (e.g. 3.7 verified, 3.8 skipped, 3.9 verified) is only expressible with a set. Has any minor ever been skipped, or is it always contiguous? **Recommendation: closed range** unless gaps are real.
+### Phase 1 — Replace the substring gate
 
-4. **Scope of `pandoc-check` vs. the gate.** Should `pandoc-check` also drive the dev-setup floor warning (one command reporting both), or stay narrowly "run the 4 oracle tests + report calibration"? Keeps blast radius small if narrow.
+In `test.rs`: replace `has_good_pandoc_version()`'s `contains("3.x")` chain with `parse_pandoc_version()` + closed-range check `(3,6)..=(3,9)`. Keep the hard-`assert!` at the 4 test call sites (ledger signal preserved); leave the 3 internal helpers' skip behavior unchanged.
 
-## Risks / tradeoffs (draft)
+### Phase 2 — Actionable failure message
 
-- **Auto-editing test.rs** (Q2 option) is the highest-risk piece: fmt hook runs `cargo fmt` on any edited Rust file, so the xtask's edit and the hook could race/conflict; a print-only design sidesteps this entirely.
-- **Cross-crate sharing** (Q1) could pull a new dependency edge into pampa's test build for an 8-line function — likely not worth it.
-- Low blast radius overall: changes are test-harness + xtask only, no product code, CI already pinned and unaffected.
+On out-of-range, the `assert!` message prints: detected version, the calibrated range, and the exact command to verify+bump (`cargo xtask pandoc-check`).
+
+### Phase 3 — `cargo xtask pandoc-check`
+
+New xtask subcommand (steps in `.claude/rules/xtask.md`). Runs the 4 oracle tests against local pandoc **bypassing the version gate**, narrow scope. On green: print the new ceiling to set in `test.rs`. On failure: report which test broke. Print-only — no source edit.
+
+### Phase 4 — Docs
+
+Ledger comment next to the range constant in `test.rs` describing the bump workflow; add `pandoc-check` to the xtask command list in `.claude/rules/xtask.md`.
+
+## Prerequisite
+
+- **bd-nj9nnkn1** — `highest_version_node` Windows dead-code clippy failure blocks `cargo xtask verify` locally on Windows. One-line `#[cfg(not(windows))]` gate. Must be green for the final verify step; does not block Phase 0–3 iteration via `cargo nextest run -p pampa`.
+
+## Risks / tradeoffs
+
+- **Two parser copies** (decision 1): drift risk, mitigated by the shared unit-test contract in Phase 0.
+- Low blast radius: test-harness + xtask only, no product code. CI pins `PANDOC_VERSION=3.8.3` and is unaffected either way.

--- a/claude-notes/plans/2026-07-02-pandoc-oracle-version-gate.md
+++ b/claude-notes/plans/2026-07-02-pandoc-oracle-version-gate.md
@@ -55,7 +55,7 @@ The two version-check sites **disagree on philosophy**: dev_setup wants a *floor
 2. **`pandoc-check` is print-only.** It does **not** auto-edit `test.rs` (avoids fighting the `cargo fmt` post-edit hook and needing a stable source anchor). On green it prints the exact ceiling to bump to; the human makes the one-line edit — matching the "manual verification ledger" spirit.
 3. **Closed range, not an explicit set.** Calibrated window is a closed range `(3,6)..=(3,9)`; bumping = raise the ceiling.
 4. **`pandoc-check` scope is narrow.** Runs just the 4 oracle tests against local pandoc + reports calibration. It does **not** also drive the dev-setup floor warning.
-5. **Gate bypass is an env var.** `has_good_pandoc_version()` returns `true` when `PAMPA_PANDOC_ORACLE_BYPASS_VERSION_GATE=1` is set (checked before parsing). This is the single seam `pandoc-check` uses to run the 4 tests against an off-range pandoc without weakening the assertion or duplicating test bodies. Normal local/CI runs never set it, so the hard-fail ledger signal is untouched. (Added from design review — this seam was previously implicit.)
+5. **Gate bypass is an env var.** `has_good_pandoc_version()` returns `true` when `PAMPA_PANDOC_ORACLE_BYPASS_VERSION_GATE` is set to **exactly `1`** (checked before parsing); any other value, or unset, leaves the gate active. This is the single seam `pandoc-check` uses to run the 4 tests against an off-range pandoc without weakening the assertion or duplicating test bodies. Normal local/CI runs never set it, so the hard-fail ledger signal is untouched. (Added from design review — this seam was previously implicit.)
 
 ### Out of scope
 
@@ -65,7 +65,7 @@ The two version-check sites **disagree on philosophy**: dev_setup wants a *floor
 
 ### Phase 0 — Test plan (TDD, RED first)
 
-Two pure functions to test (both spawn nothing → runnable via `cargo nextest run -p pampa`, unblocked by bd-nj9nnkn1):
+Two pure functions to test (both spawn nothing → unblocked by bd-nj9nnkn1). The pampa copies run via `cargo nextest run -p pampa`; the mirrored xtask parser tests run via `cargo nextest run -p xtask` — run **both** to complete the RED/GREEN loop across the two copies.
 
 **a. `parse_pandoc_version(&str) -> (u32, u32)` + range check.** Cases:
 - `pandoc 3.10` → `(3,10)`, **out of range** (this is the bug: substring `contains` false-rejects; numeric `(3,10) > (3,9)` correctly out-of-range, not falsely-in).
@@ -74,7 +74,7 @@ Two pure functions to test (both spawn nothing → runnable via `cargo nextest r
 
 **b. Diagnostic formatter** — a pure `fn format_gate_failure(raw_version: &str, range: …) -> String` that the `assert!` message uses. Assert it contains the raw detected version line, the calibrated range, and the `cargo xtask pandoc-check` command. This guards the *user-visible* improvement (M3 from design review) without depending on assertion-message brittleness.
 
-**Shared case table (M5).** Define the parse test vectors as one named `const` slice reused by both `test.rs` and xtask's `test_pandoc_version_at_least` module, with a comment on each requiring lockstep updates. Both parser copies are validated against the same table.
+**Duplicated case table (M5).** Consistent with decision 1 (duplicate, don't cross-crate-share): put an **identical** named `const` slice of parse test vectors in *each* location — `test.rs` and xtask's `test_pandoc_version_at_least` module — not a single shared slice (no new crate dep). Each copy carries a comment requiring lockstep updates. Both parser copies are validated against their (identical) table.
 
 Confirm RED before implementing.
 

--- a/crates/pampa/tests/integration/test.rs
+++ b/crates/pampa/tests/integration/test.rs
@@ -89,15 +89,189 @@ fn test_unnumbered_section_specifier() {
 }
 
 fn has_good_pandoc_version() -> bool {
+    if pandoc_oracle_bypass_active() {
+        return true;
+    }
     let output = Command::new("pandoc")
         .arg("--version")
         .output()
         .expect("Failed to execute pandoc command");
     let version_str = String::from_utf8_lossy(&output.stdout);
-    version_str.contains("3.6")
-        || version_str.contains("3.7")
-        || version_str.contains("3.8")
-        || version_str.contains("3.9")
+    is_pandoc_version_in_oracle_range(parse_pandoc_version(&version_str))
+}
+
+/// Ledger: calibrated pandoc oracle window. Each minor version in this
+/// closed range was manually verified against the 4 oracle tests
+/// (`test_html_writer`, `test_json_writer`,
+/// `unit_test_corpus_matches_pandoc_markdown`,
+/// `unit_test_corpus_matches_pandoc_commonmark`) before being added. A local
+/// pandoc outside this range hard-fails those 4 tests by design — it is not
+/// a bug, it means the range hasn't been calibrated against that version
+/// yet. To bump the ceiling: run `cargo xtask pandoc-check`, and if it
+/// reports green, edit `PANDOC_ORACLE_MAX_VERSION` to the value it prints.
+///
+/// Adding a 5th test that calls [`assert_good_pandoc_version`]? Also add its
+/// name to `ORACLE_TEST_NAMES` in `crates/xtask/src/pandoc_check.rs` — that
+/// list is hand-maintained, not derived from this file, so a new gated test
+/// silently isn't covered by `cargo xtask pandoc-check` until you do.
+const PANDOC_ORACLE_MIN_VERSION: (u32, u32) = (3, 6);
+const PANDOC_ORACLE_MAX_VERSION: (u32, u32) = (3, 9);
+
+/// Parse the first line of `pandoc --version` output into `(major, minor)`.
+/// Expects format like "pandoc 3.6.1" or "pandoc 3.6". Malformed or empty
+/// input parses as `(0, 0)`.
+///
+/// Duplicated (byte-for-byte identical behavior, pinned by
+/// [`PANDOC_VERSION_PARSE_CASES`]) in `crates/xtask/src/dev_setup.rs` —
+/// xtask is bin-only, so this test binary can't import it directly without
+/// pulling xtask's deps into the test build. See bd-i9i5ad2t.
+fn parse_pandoc_version(version_output: &str) -> (u32, u32) {
+    let first_line = version_output.lines().next().unwrap_or("");
+    let version_part = first_line.strip_prefix("pandoc ").unwrap_or(first_line);
+    let mut parts = version_part.split('.');
+    let major: u32 = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0);
+    let minor: u32 = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0);
+    (major, minor)
+}
+
+fn is_pandoc_version_in_oracle_range(version: (u32, u32)) -> bool {
+    (PANDOC_ORACLE_MIN_VERSION..=PANDOC_ORACLE_MAX_VERSION).contains(&version)
+}
+
+/// Pure form of the bypass check, taking the raw env value directly so it's
+/// unit-testable without mutating the real environment.
+fn bypass_active_for(raw: Option<&str>) -> bool {
+    raw == Some("1")
+}
+
+/// Calibration seam for `cargo xtask pandoc-check`: when this env var is set
+/// to exactly `"1"`, the oracle version gate is bypassed. Any other value,
+/// or unset, leaves the gate active.
+fn pandoc_oracle_bypass_active() -> bool {
+    bypass_active_for(
+        std::env::var("PAMPA_PANDOC_ORACLE_BYPASS_VERSION_GATE")
+            .ok()
+            .as_deref(),
+    )
+}
+
+/// Hard-fail assertion for the 4 oracle tests: unlike `has_good_pandoc_version`
+/// (which the internal helpers treat as skip-if-false), this panics with an
+/// actionable message when the local pandoc isn't in the calibrated range.
+fn assert_good_pandoc_version() {
+    if pandoc_oracle_bypass_active() {
+        return;
+    }
+    let output = Command::new("pandoc")
+        .arg("--version")
+        .output()
+        .expect("Failed to execute pandoc command");
+    let raw_version = String::from_utf8_lossy(&output.stdout).to_string();
+    assert!(
+        is_pandoc_version_in_oracle_range(parse_pandoc_version(&raw_version)),
+        "{}",
+        format_gate_failure(
+            &raw_version,
+            PANDOC_ORACLE_MIN_VERSION,
+            PANDOC_ORACLE_MAX_VERSION
+        )
+    );
+}
+
+/// Actionable failure message for a hard-fail oracle test, containing the
+/// raw detected pandoc version line, the calibrated range, and the command
+/// to run to check a newer pandoc against the oracle tests.
+fn format_gate_failure(raw_version: &str, min: (u32, u32), max: (u32, u32)) -> String {
+    let first_line = raw_version.lines().next().unwrap_or("<no pandoc output>");
+    format!(
+        "Pandoc version not calibrated for oracle tests.\n  \
+         Detected: {first_line}\n  \
+         Calibrated range: {}.{}\u{2013}{}.{}\n  \
+         Run `cargo xtask pandoc-check` to check a newer pandoc against the oracle tests.",
+        min.0, min.1, max.0, max.1
+    )
+}
+
+/// Shared parse test vectors, duplicated identically in
+/// `crates/xtask/src/dev_setup.rs`. Keep both copies in lockstep.
+const PANDOC_VERSION_PARSE_CASES: &[(&str, (u32, u32))] = &[
+    ("pandoc 3.6\n...", (3, 6)),
+    ("pandoc 3.6.1\n...", (3, 6)),
+    ("pandoc 3.9\n...", (3, 9)),
+    ("pandoc 3.10\n...", (3, 10)),
+    ("pandoc 4.0\n...", (4, 0)),
+    ("pandoc 3.1.3\n...", (3, 1)),
+    ("pandoc 2.19\n...", (2, 19)),
+    ("garbage\n...", (0, 0)),
+    ("", (0, 0)),
+];
+
+const PANDOC_ORACLE_RANGE_CASES: &[((u32, u32), bool)] = &[
+    ((3, 5), false),
+    ((3, 6), true),
+    ((3, 7), true),
+    ((3, 9), true),
+    ((3, 10), false),
+    ((4, 0), false),
+    ((0, 0), false),
+];
+
+#[cfg(test)]
+mod pandoc_oracle_gate_tests {
+    use super::*;
+
+    #[test]
+    fn unit_test_parse_pandoc_version_cases() {
+        for (input, expected) in PANDOC_VERSION_PARSE_CASES {
+            assert_eq!(parse_pandoc_version(input), *expected, "parsing {input:?}");
+        }
+    }
+
+    #[test]
+    fn unit_test_pandoc_oracle_range_cases() {
+        for (version, expected) in PANDOC_ORACLE_RANGE_CASES {
+            assert_eq!(
+                is_pandoc_version_in_oracle_range(*version),
+                *expected,
+                "checking {version:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn unit_test_format_gate_failure_contains_required_info() {
+        let message = format_gate_failure(
+            "pandoc 3.10\nCompiled with pandoc-types 1.23.1",
+            PANDOC_ORACLE_MIN_VERSION,
+            PANDOC_ORACLE_MAX_VERSION,
+        );
+        assert!(
+            message.contains("pandoc 3.10"),
+            "message should contain the raw detected version line, got: {message}"
+        );
+        assert!(
+            message.contains("3.6") && message.contains("3.9"),
+            "message should contain the calibrated range, got: {message}"
+        );
+        assert!(
+            message.contains("cargo xtask pandoc-check"),
+            "message should point at the calibration command, got: {message}"
+        );
+    }
+
+    #[test]
+    fn unit_test_bypass_active_for_cases() {
+        let cases: &[(Option<&str>, bool)] = &[
+            (Some("1"), true),
+            (Some("0"), false),
+            (Some("true"), false),
+            (Some(""), false),
+            (None, false),
+        ];
+        for (raw, expected) in cases {
+            assert_eq!(bypass_active_for(*raw), *expected, "raw env value {raw:?}");
+        }
+    }
 }
 
 fn canonicalize_pandoc_ast(ast: &str, from: &str, to: &str) -> String {
@@ -223,10 +397,7 @@ fn matches_pandoc_commonmark_reader(input: &str) -> bool {
 
 #[test]
 fn unit_test_corpus_matches_pandoc_markdown() {
-    assert!(
-        has_good_pandoc_version(),
-        "Pandoc version is not suitable for testing"
-    );
+    assert_good_pandoc_version();
     let mut file_count = 0;
     for entry in
         glob("tests/pandoc-match-corpus/markdown/*.qmd").expect("Failed to read glob pattern")
@@ -253,10 +424,7 @@ fn unit_test_corpus_matches_pandoc_markdown() {
 
 #[test]
 fn unit_test_corpus_matches_pandoc_commonmark() {
-    assert!(
-        has_good_pandoc_version(),
-        "Pandoc version is not suitable for testing"
-    );
+    assert_good_pandoc_version();
     let mut file_count = 0;
     for entry in
         glob("tests/pandoc-match-corpus/commonmark/*.qmd").expect("Failed to read glob pattern")
@@ -434,10 +602,7 @@ fn remove_location_fields(json: &mut serde_json::Value) {
 
 #[test]
 fn test_json_writer() {
-    assert!(
-        has_good_pandoc_version(),
-        "Pandoc version is not suitable for testing"
-    );
+    assert_good_pandoc_version();
     let mut file_count = 0;
     for entry in glob("tests/writers/json/*.md").expect("Failed to read glob pattern") {
         match entry {
@@ -524,10 +689,7 @@ fn normalize_html(html: &str) -> String {
 
 #[test]
 fn test_html_writer() {
-    assert!(
-        has_good_pandoc_version(),
-        "Pandoc version is not suitable for testing"
-    );
+    assert_good_pandoc_version();
     let mut file_count = 0;
     for entry in glob("tests/writers/html/*.md").expect("Failed to read glob pattern") {
         match entry {

--- a/crates/xtask/src/dev_setup.rs
+++ b/crates/xtask/src/dev_setup.rs
@@ -234,21 +234,54 @@ fn check_pandoc() {
     }
 }
 
-/// Parse the first line of `pandoc --version` output and check if the version
-/// is at least `major.minor`. Expects format like "pandoc 3.6.1" or "pandoc 3.6".
-fn pandoc_version_at_least(version_output: &str, min_major: u32, min_minor: u32) -> bool {
+/// Parse the first line of `pandoc --version` output into `(major, minor)`.
+/// Expects format like "pandoc 3.6.1" or "pandoc 3.6". Malformed or empty
+/// input parses as `(0, 0)`.
+///
+/// Duplicated (byte-for-byte identical behavior, pinned by
+/// [`PANDOC_VERSION_PARSE_CASES`]) in
+/// `crates/pampa/tests/integration/test.rs` — xtask is bin-only, so pampa's
+/// test binary can't import this directly without pulling xtask's deps into
+/// the test build. See bd-i9i5ad2t.
+pub(crate) fn parse_pandoc_version(version_output: &str) -> (u32, u32) {
     let first_line = version_output.lines().next().unwrap_or("");
-    // Extract version string after "pandoc "
     let version_part = first_line.strip_prefix("pandoc ").unwrap_or(first_line);
     let mut parts = version_part.split('.');
     let major: u32 = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0);
     let minor: u32 = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0);
-    (major, minor) >= (min_major, min_minor)
+    (major, minor)
 }
+
+/// Check if a parsed pandoc `--version` output is at least `major.minor`.
+fn pandoc_version_at_least(version_output: &str, min_major: u32, min_minor: u32) -> bool {
+    parse_pandoc_version(version_output) >= (min_major, min_minor)
+}
+
+/// Shared parse test vectors, duplicated identically in
+/// `crates/pampa/tests/integration/test.rs`. Keep both copies in lockstep.
+#[cfg(test)]
+const PANDOC_VERSION_PARSE_CASES: &[(&str, (u32, u32))] = &[
+    ("pandoc 3.6\n...", (3, 6)),
+    ("pandoc 3.6.1\n...", (3, 6)),
+    ("pandoc 3.9\n...", (3, 9)),
+    ("pandoc 3.10\n...", (3, 10)),
+    ("pandoc 4.0\n...", (4, 0)),
+    ("pandoc 3.1.3\n...", (3, 1)),
+    ("pandoc 2.19\n...", (2, 19)),
+    ("garbage\n...", (0, 0)),
+    ("", (0, 0)),
+];
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_parse_pandoc_version_cases() {
+        for (input, expected) in PANDOC_VERSION_PARSE_CASES {
+            assert_eq!(parse_pandoc_version(input), *expected, "parsing {input:?}");
+        }
+    }
 
     #[test]
     fn test_pandoc_version_at_least() {

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -10,6 +10,7 @@
 //! - `lint`: Run custom lint checks on the codebase
 //! - `create-worktree`: Create git worktree with CLAUDE.local.md context stub
 //! - `braid-snapshot`: Write a backup-only `braid export` to `.braid/snapshot.jsonl`
+//! - `pandoc-check`: Check local pandoc against the pampa oracle tests
 //! - `test`: Run workspace tests with platform-appropriate crate exclusions
 //! - `verify`: Run full project verification (build + tests for Rust and hub-client)
 //! - `build-all`: Fresh-clone build orchestration (npm install + hub-client + Rust workspace)
@@ -25,6 +26,7 @@ mod build_trace_viewer;
 mod create_worktree;
 mod dev_setup;
 mod lint;
+mod pandoc_check;
 mod stage_doc_examples;
 mod switch_task;
 mod test;
@@ -204,6 +206,17 @@ enum Command {
         no_deny_warnings: bool,
     },
 
+    /// Check the local `pandoc` against the pampa oracle tests.
+    ///
+    /// Print-only calibration tool for bd-i9i5ad2t's version-gated oracle
+    /// tests (`test_html_writer`, `test_json_writer`,
+    /// `unit_test_corpus_matches_pandoc_markdown`,
+    /// `unit_test_corpus_matches_pandoc_commonmark`). Runs those 4 tests
+    /// against the local pandoc under a bypass of the calibrated version
+    /// gate, then reports pass/fail and — on a green run past the current
+    /// ceiling — the exact line in `test.rs` to bump. Never edits the file.
+    PandocCheck {},
+
     /// Stage doc-example projects into the docs site for `.embed-example-iframe`.
     ///
     /// Renders each project listed in `examples/manifest.yml` with `q2` and
@@ -349,6 +362,7 @@ fn main() -> Result<()> {
             };
             verify::run(&config)
         }
+        Command::PandocCheck {} => pandoc_check::run(),
         Command::StageDocExamples {} => stage_doc_examples::run(),
         Command::BuildTraceViewer {} => build_trace_viewer::run(),
         Command::BuildQ2PreviewSpa {} => build_q2_preview_spa::run(),

--- a/crates/xtask/src/pandoc_check.rs
+++ b/crates/xtask/src/pandoc_check.rs
@@ -1,0 +1,207 @@
+//! `cargo xtask pandoc-check` — check the local `pandoc` binary against the
+//! pampa oracle tests without touching the calibrated version gate.
+//!
+//! Print-only (decision 2 in bd-i9i5ad2t): on a green run past the current
+//! ceiling, this prints the proposed new ceiling and where to bump it — it
+//! never edits `crates/pampa/tests/integration/test.rs` itself. See the
+//! ledger comment next to `PANDOC_ORACLE_MAX_VERSION` there.
+
+use anyhow::{Context, Result, bail};
+use std::process::Command;
+
+use crate::dev_setup::parse_pandoc_version;
+use crate::switch_task::current_worktree_root;
+use crate::util::nested_command;
+
+/// The oracle tests hard-gated on the calibrated pandoc range (each one
+/// calls `assert_good_pandoc_version()` in `test.rs`). Hand-maintained, not
+/// derived from that file — adding a new gated test there means adding its
+/// name here too, or this tool will silently skip checking it.
+const ORACLE_TEST_NAMES: &[&str] = &[
+    "unit_test_corpus_matches_pandoc_markdown",
+    "unit_test_corpus_matches_pandoc_commonmark",
+    "test_json_writer",
+    "test_html_writer",
+];
+
+const TEST_RS_RELATIVE_PATH: &str = "crates/pampa/tests/integration/test.rs";
+
+/// Build the nextest filterset for exactly the oracle tests. `test(<name>)`
+/// alone is a substring match against every binary in the crate — e.g.
+/// `test(test_html_writer)` also matches the unrelated
+/// `writers::html::tests::test_html_writer_context_*` unit tests in pampa's
+/// lib and bin targets, silently inflating "4 oracle tests" into 8. Scoping
+/// to `binary(integration)` (the single binary all pampa integration tests
+/// compile into, per `.claude/rules/integration-tests.md`) excludes those.
+fn oracle_test_filter() -> String {
+    let names = ORACLE_TEST_NAMES
+        .iter()
+        .map(|name| format!("test({name})"))
+        .collect::<Vec<_>>()
+        .join(" + ");
+    format!("binary(integration) & ({names})")
+}
+
+pub fn run() -> Result<()> {
+    let root = current_worktree_root()?;
+
+    let version_output = Command::new("pandoc")
+        .arg("--version")
+        .output()
+        .context("running `pandoc --version` \u{2014} is pandoc installed?")?;
+    let raw_version = String::from_utf8_lossy(&version_output.stdout).to_string();
+    let detected = parse_pandoc_version(&raw_version);
+    let first_line = raw_version.lines().next().unwrap_or("<no output>");
+
+    let test_rs_path = root.join(TEST_RS_RELATIVE_PATH);
+    let test_rs_source = std::fs::read_to_string(&test_rs_path)
+        .with_context(|| format!("reading {}", test_rs_path.display()))?;
+    let (min, _min_line) = find_version_const(&test_rs_source, "PANDOC_ORACLE_MIN_VERSION")?;
+    let (max, max_line) = find_version_const(&test_rs_source, "PANDOC_ORACLE_MAX_VERSION")?;
+
+    println!("Detected: {first_line}");
+    println!(
+        "Calibrated range: {}.{}\u{2013}{}.{}",
+        min.0, min.1, max.0, max.1
+    );
+
+    let filter = oracle_test_filter();
+
+    let mut cmd = nested_command("cargo");
+    cmd.args(["nextest", "run", "-p", "pampa", "-E", &filter])
+        .env("PAMPA_PANDOC_ORACLE_BYPASS_VERSION_GATE", "1")
+        .current_dir(&root);
+    let test_output = cmd
+        .output()
+        .context("running cargo nextest for the oracle tests")?;
+
+    let combined = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&test_output.stdout),
+        String::from_utf8_lossy(&test_output.stderr)
+    );
+    print!("{combined}");
+
+    if test_output.status.success() {
+        println!(
+            "\nAll {} oracle tests pass against {first_line}.",
+            ORACLE_TEST_NAMES.len()
+        );
+        if detected > max {
+            println!(
+                "Detected version is past the calibrated ceiling \u{2014} bump it:\n  \
+                 {}:{max_line}\n  const PANDOC_ORACLE_MAX_VERSION: (u32, u32) = ({}, {});",
+                test_rs_path.display(),
+                detected.0,
+                detected.1
+            );
+        }
+        Ok(())
+    } else {
+        let broken = failed_test_names(&combined);
+        if broken.is_empty() {
+            bail!("oracle tests failed against {first_line} (see output above)");
+        }
+        bail!(
+            "oracle tests failed against {first_line}: {}",
+            broken.join(", ")
+        );
+    }
+}
+
+/// Find `const {name}: (u32, u32) = (MAJOR, MINOR);` in `source` and return
+/// its parsed value plus its 1-based line number.
+fn find_version_const(source: &str, name: &str) -> Result<((u32, u32), usize)> {
+    let needle = format!("const {name}: (u32, u32) = (");
+    for (idx, line) in source.lines().enumerate() {
+        let Some(pos) = line.find(&needle) else {
+            continue;
+        };
+        let rest = &line[pos + needle.len()..];
+        let end = rest
+            .find(')')
+            .with_context(|| format!("malformed `{name}` line: {line}"))?;
+        let mut parts = rest[..end].split(',').map(str::trim);
+        let major: u32 = parts
+            .next()
+            .and_then(|s| s.parse().ok())
+            .with_context(|| format!("bad major version in `{name}` line: {line}"))?;
+        let minor: u32 = parts
+            .next()
+            .and_then(|s| s.parse().ok())
+            .with_context(|| format!("bad minor version in `{name}` line: {line}"))?;
+        return Ok(((major, minor), idx + 1));
+    }
+    bail!("could not find `const {name}: (u32, u32) = (...)` in {TEST_RS_RELATIVE_PATH}")
+}
+
+/// Parse nextest's human-readable output for `FAIL ... <test-name>` lines,
+/// returning the trailing test names of the tests that broke.
+fn failed_test_names(nextest_output: &str) -> Vec<String> {
+    nextest_output
+        .lines()
+        .filter_map(|line| {
+            let trimmed = line.trim_start();
+            trimmed
+                .strip_prefix("FAIL ")
+                .and_then(|rest| rest.rsplit(' ').next())
+                .map(|name| name.to_string())
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE_SOURCE: &str = "const PANDOC_ORACLE_MIN_VERSION: (u32, u32) = (3, 6);\nconst PANDOC_ORACLE_MAX_VERSION: (u32, u32) = (3, 9);\n";
+
+    #[test]
+    fn find_version_const_locates_min_and_max() {
+        let (min, min_line) =
+            find_version_const(SAMPLE_SOURCE, "PANDOC_ORACLE_MIN_VERSION").unwrap();
+        assert_eq!(min, (3, 6));
+        assert_eq!(min_line, 1);
+
+        let (max, max_line) =
+            find_version_const(SAMPLE_SOURCE, "PANDOC_ORACLE_MAX_VERSION").unwrap();
+        assert_eq!(max, (3, 9));
+        assert_eq!(max_line, 2);
+    }
+
+    #[test]
+    fn oracle_test_filter_scopes_to_integration_binary_and_all_oracle_names() {
+        let filter = oracle_test_filter();
+        assert!(
+            filter.starts_with("binary(integration) & ("),
+            "filter must scope to the integration binary to avoid matching \
+             unrelated lib/bin tests with the same substring: {filter}"
+        );
+        for name in ORACLE_TEST_NAMES {
+            assert!(
+                filter.contains(&format!("test({name})")),
+                "filter missing {name}: {filter}"
+            );
+        }
+    }
+
+    #[test]
+    fn find_version_const_missing_name_errors() {
+        assert!(find_version_const(SAMPLE_SOURCE, "NOT_THERE").is_err());
+    }
+
+    #[test]
+    fn failed_test_names_extracts_names_from_nextest_output() {
+        let output = "        FAIL [   0.211s] (1/1) pampa::integration test::unit_test_corpus_matches_pandoc_markdown\n        PASS [   0.100s] (2/2) pampa::integration test::test_json_writer\n";
+        assert_eq!(
+            failed_test_names(output),
+            vec!["test::unit_test_corpus_matches_pandoc_markdown".to_string()]
+        );
+    }
+
+    #[test]
+    fn failed_test_names_empty_when_all_pass() {
+        let output = "        PASS [   0.100s] (1/1) pampa::integration test::test_json_writer\n";
+        assert!(failed_test_names(output).is_empty());
+    }
+}

--- a/crates/xtask/src/switch_task.rs
+++ b/crates/xtask/src/switch_task.rs
@@ -44,7 +44,7 @@ use crate::create_worktree::{
 /// declaration is shared across all worktrees). The CLAUDE.local.md
 /// we want to rewrite is per-worktree, so we need the worktree's own
 /// toplevel.
-fn current_worktree_root() -> Result<PathBuf> {
+pub(crate) fn current_worktree_root() -> Result<PathBuf> {
     let output = Command::new("git")
         .args(["rev-parse", "--show-toplevel"])
         .output()


### PR DESCRIPTION
When the local `pandoc` on a contributor's machine is newer than the oldest allowlisted minor version (e.g. `pandoc 3.10`), the 4 pandoc-comparison oracle tests hard-fail with an unhelpful message, even though nothing about the setup is actually broken.

## Root Cause

The version gate compared `pandoc --version` output with `contains("3.6"|"3.7"|"3.8"|"3.9")` substring checks. `pandoc 3.10` doesn't contain any of those substrings, so a newer, perfectly capable pandoc gets rejected the same way an untested one would. The hard-fail itself is intentional -- this is a manually-calibrated ledger, not automatic detection -- but the trigger was a string-matching false negative, not the intended "outside the calibrated range" case.

## Fix

Replace the substring check with a real `(major, minor)` range comparison against a calibrated ledger (`PANDOC_ORACLE_MIN_VERSION`..=`PANDOC_ORACLE_MAX_VERSION`), and make the failure message name the detected version, the calibrated range, and how to move the ceiling.

Add `cargo xtask pandoc-check`, a print-only calibration tool: it runs the 4 oracle tests against the local pandoc under a bypass of the gate, and on a green run past the current ceiling prints the exact line to edit:

```
Detected: pandoc 3.10
Calibrated range: 3.6-3.9
Starting 4 tests across 1 binary (1039 tests and 4 binaries skipped)
...
All 4 oracle tests pass against pandoc 3.10.
Detected version is past the calibrated ceiling -- bump it:
  crates/pampa/tests/integration/test.rs:118
  const PANDOC_ORACLE_MAX_VERSION: (u32, u32) = (3, 10);
```

Bumping the ceiling is then a one-line edit:

```rust
const PANDOC_ORACLE_MIN_VERSION: (u32, u32) = (3, 6);
const PANDOC_ORACLE_MAX_VERSION: (u32, u32) = (3, 10);
```