### PR TITLE
feat(jupyter,quarto-core): cell-options facility + error policy (bd-ohvl879u)

### DIFF
--- a/claude-notes/plans/2026-07-02-bd-ohvl879u-cell-options-error-policy.md
+++ b/claude-notes/plans/2026-07-02-bd-ohvl879u-cell-options-error-policy.md
@@ -1,0 +1,478 @@
+# bd-ohvl879u: cell-options facility + jupyter error policy
+
+**Strand:** bd-ohvl879u (bug, P2, discovered-from bd-gthycd33, blocked-by bd-gthycd33)
+**Branch:** `braid/bd-ohvl879u-jupyter-engine-ignores-error` (based on
+`braid/bd-gthycd33-jupyter-engine-output-not`, i.e. PR #360 — merge that first)
+**Status:** decisions 1–7 locked with Carlos (2026-07-02) — awaiting
+explicit go-ahead before execution. Note decision 3 upgraded the design:
+cell options resolve through a ConfigValue merge against the document's
+already-merged metadata (scoped resolution), not a direct YAML read.
+
+## Overview
+
+Two deliverables, one mechanism:
+
+1. **A shared cell-options facility** in `quarto-core`: identify and extract
+   the `#|`-style YAML options block at the head of an executable code cell,
+   language-aware (each language writes options in its own comment syntax:
+   `#|` for python/R, `--|` for lua/sql, `//|` for js/rust, `%|` for matlab,
+   block-comment forms like `/*| … */` for C), parsed with `quarto-yaml`,
+   **with source locations that map back through `quarto-source-map` to the
+   enclosing text**.
+2. **The jupyter engine consumes it** to fix the error-policy divergence:
+   today q2's jupyter unconditionally embeds a failing cell's error as
+   `.cell-output-error` output and reports success, while knitr fails the
+   whole render (Q1's default `execute.error: false` policy). After this
+   strand: an un-annotated cell error fails the render for jupyter too;
+   `#| error: true` opts a cell into embedded error output.
+
+## What the source study found
+
+### Quarto 1 (external-sources/quarto-cli) — the reference
+
+- **Canonical implementation:** `src/core/lib/partition-cell-options.ts`.
+  - `kLangCommentChars: Record<string, string | [string, string]>` — the
+    registry (~50 languages). Value is a line-comment prefix (`"#"`, `"//"`,
+    `"--"`, `"%"`, `"!"`, `"⍝"`, …) or a `[prefix, suffix]` pair for
+    block-comment-only languages (`c`/`css`: `["/*","*/"]`, `ocaml`:
+    `["(*","*)"]`, `sas`: `["*",";"]`). Unknown language ⇒ `"#"`.
+  - Option-line pattern: `^<escaped prefix>\s*\| ?` — comment chars,
+    optional whitespace, a literal `|`, one optional space. With a suffix,
+    the line must also end with the suffix (stripped along with trailing
+    whitespace).
+  - Partition: scan **only the leading run** of matching lines; the first
+    non-matching line ends the options block. Everything below is the code.
+  - `partitionCellOptionsText` keeps per-line ranges so the reassembled
+    YAML is a `MappedString` into the original source — parse errors point
+    at real file positions. (This MappedString machinery is exactly what we
+    replicate with `quarto-source-map`.)
+  - `addLanguageComment` — registration hook used by language handlers
+    (relevant someday for user-extensible engines; not v1).
+  - `guessChunkOptionsFormat` (guess-chunk-options-format.ts): for `r`
+    cells only, sniffs knitr's `key=value, key2=value` comma syntax vs YAML
+    and skips YAML parsing for the former.
+- Q1 has **several other copies** of this logic (jupyter.ts, percent.ts,
+  the Python-side `nb_cell_yaml_options` in resources/jupyter/notebook.py,
+  filters/modules/constants.lua) — precisely the duplication we should not
+  reproduce. q2 gets **one** implementation.
+- **Error semantics** (resources/jupyter/notebook.py `cell_execute`,
+  ~L550): per-cell options are read before execution; `error: true` adds
+  the `raises-exception` tag (execution continues, error is embedded);
+  otherwise a raising cell aborts the run. Global default comes from
+  document `execute.error` (default false). Q1 also **strips the option
+  lines from the source sent to the kernel** (`nb_strip_yaml_options`) so
+  cell magics work, and the echoed source excludes them (`sourceStartLine`).
+
+### q2 today — four ad-hoc `#|` sites, no shared facility
+
+(Full survey in session transcript, 2026-07-02.)
+
+- `quarto-core/src/crossref/codeblock_shorthand.rs` — the only site that
+  *extracts* values: hardcoded `"#|"`, naive `split_once(':')` (no real
+  YAML), `HashMap<String,String>`, no per-option source spans. Consumed by
+  the `pre-engine-sugaring` stage.
+- `quarto-lsp-core/src/tokens.rs` (`leading_directive_byte_len`,
+  `directive_tokens`) — the **best technical precedent**: detects the
+  leading `#|` run, strips markers, reassembles one YAML document, and
+  keeps a `DirectiveLine { virt_start, doc_start, len }` table mapping
+  reassembled-YAML offsets back to document offsets. But it's
+  highlight-only (tree-sitter YAML highlighter, no structural parse) and
+  hardcodes `"#|"`.
+- `engine/jupyter/text_execute.rs` — sends and echoes `#|` lines verbatim;
+  no parsing (this strand's consumer).
+- `engine/knitr` — delegates `#|` handling to knitr itself (stays that
+  way).
+- The tree-sitter qmd grammar has **no** node type for option lines; all
+  `#|` structure is imposed post-parse. (No grammar changes in this plan.)
+- `quarto-lsp-core` already depends on `quarto-core`, so a quarto-core
+  facility is reusable by the LSP later.
+
+### quarto-yaml + quarto-source-map — the APIs we compose
+
+- `quarto_yaml::parse_with_parent(content, parent: SourceInfo)` parses a
+  fragment; every node gets `SourceInfo::substring(parent, start, end)`
+  with fragment-relative offsets — positions compose through the parent
+  chain. Values are `YamlWithSourceInfo` (`yaml: yaml_rust2::Yaml` +
+  per-node `source_info`, `YamlHashEntry` with key/value/entry spans;
+  `get_hash_value("error")`, `yaml.as_bool()` for reads).
+- `SourceInfo::concat(pieces)` expresses "this string is a concatenation
+  of regions of another source" — the `SourceInfo`-native form of the
+  LSP's `DirectiveLine` table, and the right representation for the
+  reassembled YAML (option lines are non-contiguous: the `#| ` markers and
+  the joining structure are elided). `map_offset` walks Concat → Substring
+  → Original automatically. Precedent for the substring pattern:
+  `pampa/src/pandoc/meta.rs:334-390` (frontmatter extraction).
+- Caveat to design around: synthetic join positions (offsets falling on a
+  seam between Concat pieces) don't map; real YAML node spans land inside
+  pieces, so this is fine in practice — the seams are the newlines we
+  insert. (One per-line subtlety: include each source line's own `\n` as
+  part of its piece when possible, so seams are minimized.)
+- **Engine-input caveat (important):** the jupyter engine is text-in/
+  text-out; its input is the *serialized post-include* QMD (`input_qmd`),
+  not the user's original file, and no `SourceInfo` accompanies it through
+  `ExecutionEngine::execute`. See decision D4 for what error locations
+  mean in v1.
+- (Recorded for the future, not this strand: `CodeBlock.source_info` spans
+  the whole fenced block *including fences*, and there is no body-only
+  `SourceInfo`, so AST-side consumers like the crossref shorthand can't
+  yet map `cb.text` offsets faithfully. Follow-up strand, see Phase 6.)
+
+## Design
+
+### New module: `crates/quarto-core/src/cell_options/`
+
+```rust
+/// Comment syntax for a language's cell-option lines.
+pub struct CommentSyntax {
+    pub prefix: &'static str,          // "#", "//", "--", "%", "!", "⍝", "/*", …
+    pub suffix: Option<&'static str>,  // Some("*/") for c/css, Some("*)") ocaml, Some(";") sas
+}
+
+/// Q1's kLangCommentChars, ported verbatim. Unknown language ⇒ "#".
+pub fn comment_syntax_for(language: &str) -> CommentSyntax;
+
+/// One extracted option line (marker stripped), with its provenance.
+struct OptionLine { /* content byte-range within the cell body, … */ }
+
+/// Result of partitioning a cell body.
+pub struct PartitionedCell {
+    /// Parsed options; None when the cell has no option lines.
+    pub options: Option<YamlWithSourceInfo>,
+    /// The cell body with the option lines removed (what runs / echoes).
+    pub code: String,
+    /// SourceInfo for `code` (Concat of the retained regions of `body_source`).
+    pub code_source: SourceInfo,
+    /// Byte length of the option block within the original body (0 if none).
+    pub options_len: usize,
+}
+
+/// Identify the leading option-line run of `body` (per `language`'s
+/// comment syntax), reassemble the YAML with a `SourceInfo::concat` of
+/// per-line substrings of `body_source`, parse via
+/// `quarto_yaml::parse_with_parent`, and partition body into
+/// options/code. Returns Err (with the quarto-yaml diagnostic, which
+/// carries a mapped location) when the option lines are not valid YAML.
+pub fn partition_cell_options(
+    language: &str,
+    body: &str,
+    body_source: SourceInfo,
+) -> Result<PartitionedCell, CellOptionsError>;
+```
+
+Notes:
+- The option-line matcher mirrors Q1: `^<prefix>\s*\| ?`, leading-run
+  only, suffix-checked for block-comment languages. Indentation before the
+  prefix is *not* allowed (Q1 anchors at `^`) — pinned by a test.
+- The caller supplies `body_source`; the facility never guesses
+  provenance. Callers with no better anchor pass
+  `SourceInfo::original(ephemeral_file_id, 0, body.len())` over a
+  registered in-memory file (what text_execute will do, D4).
+- `YamlWithSourceInfo` is the return type — consumers read
+  `options.get_hash_value("error").and_then(|v| v.yaml.as_bool())`, and
+  every node span maps back through the Concat automatically.
+- **Not in v1:** `guessChunkOptionsFormat` (knitr comma-syntax sniffing) —
+  the knitr engine keeps handling its own options, and q2 already rejects
+  old-style options at parse time (Q-2-36); if/when a shared consumer
+  needs r-cell tolerance we port the guesser (Phase 6 note). Also not in
+  v1: an `addLanguageComment`-style runtime registration hook (no
+  user-extensible engines yet); the registry is a static table with a
+  documented extension point.
+
+### Jupyter engine changes (`engine/jupyter/text_execute.rs`)
+
+In `execute_blocks_inner`, per cell:
+
+1. Register the engine input string once as an ephemeral file in a local
+   `SourceContext` (name like `<doc-stem>.engine-input.qmd`); build
+   `body_source = SourceInfo::original(file_id, block.code_start, block.code_end)`
+   (the regex already yields the byte offsets; we extend `CodeBlock` —
+   the module-private struct — with the *body* range, which the existing
+   capture groups give us).
+2. `partition_cell_options(&block.language, &block.code, body_source)`.
+   - Malformed options YAML ⇒ `ExecutionError` with the located
+     diagnostic (D6).
+3. Read `error: true` (absent/false ⇒ errors disallowed — Q1 default).
+4. Send **only `partitioned.code`** to the kernel (Q1 strips option lines
+   so cell magics work — D5).
+5. Echo **only `partitioned.code`** in the `.cell-code` fence (knitr
+   parity — verify knitr's echoed fence for a `#| error: true` cell
+   during Phase 1 and pin it in the parity suite if content-checkable).
+6. On `CellOutput::Error` / `ExecuteStatus::Error`:
+   - `error: true` ⇒ current behavior (embed `.cell-output-error` div,
+     continue to next cell).
+   - otherwise ⇒ **abort**: return `ExecutionError::execution_failed`
+     with a diagnostic naming the cell (language, index, first code line)
+     + the kernel's `ename: evalue`, and the D4-scoped location. No
+     further cells run (matches knitr/Q1: the render fails).
+
+Downstream effects (already in place from bd-gthycd33's work): a failing
+`record_capture` marks the hub sidecar `CaptureState::Error` via the
+provider, and `q2 render`/`q2 preview` surface pipeline errors — so no
+provider/hub-client changes are expected in this strand.
+
+## Decisions (locked 2026-07-02 with Carlos)
+
+1. **Facility home:** `crates/quarto-core/src/cell_options/` (module,
+   sibling of `crossref/`); engine consumes now, crossref-shorthand and
+   quarto-lsp-core in follow-ups. No new crate for v1.
+2. **Scope: `error` only.** `eval` is a follow-up (the facility makes it
+   small).
+3. **Document-level default via ConfigValue merge — yes, and it's the
+   point.** Rather than reading `error` straight off the
+   `YamlWithSourceInfo`, convert the cell options to `ConfigValue` and
+   interpret **the result of merging against the document's metadata** —
+   which at engine time already includes `_quarto.yml` / `_metadata.yml` /
+   front-matter merging from Q2's ConfigValue management. Cell-level
+   options then naturally respect document-level options
+   (`execute: error: true` becomes the default; per-cell `error:` wins).
+   Worth the setup cost even so: this starts the infrastructure for
+   **scoped resolution of document metadata in cell options**, a
+   longstanding Q1 limitation. See "Scoped option resolution" below.
+4. **Error-location fidelity: accepted for v1**, with the framing
+   corrected — see "Note: how source locations work here" below. Not a
+   problem to be fixed, just a mechanism to document.
+5. **Strip option lines from kernel input and echo:** yes to both.
+6. **Malformed option YAML:** hard error with mapped location.
+7. **Crossref-shorthand migration:** follow-up strand.
+
+## Scoped option resolution via ConfigValue (decision 3 design)
+
+The pieces all exist:
+
+- `pampa::pandoc::meta::yaml_to_config_value(YamlWithSourceInfo,
+  InterpretationContext, &mut DiagnosticCollector) -> ConfigValue`
+  (meta.rs:139) — the unified, source-info-preserving YAML→ConfigValue
+  converter (quarto-core already depends on pampa).
+- `quarto_config::materialize::merge_with_diagnostics` — the merge
+  machinery the rest of Q2's config management uses.
+- The engine input's front matter **is the merged document metadata**:
+  `MetadataMergeStage` runs before `EngineExecutionStage`, and the
+  serialized `input_qmd` front matter carries the result (observed
+  empirically during bd-gthycd33: the captured input contained merged
+  `title`/`format`/`listing-item`/… keys).
+
+Resolution flow in the engine (text path, self-contained — no engine-API
+change):
+
+1. Extract the input's `---` front-matter block (same
+   `extract_between_delimiters` pattern as `pampa/src/pandoc/meta.rs`'s
+   `rawblock_to_config_value`), parse with
+   `quarto_yaml::parse_with_parent`, convert via `yaml_to_config_value`.
+   Read the `execute` map from it.
+2. Partition each cell; convert its options `YamlWithSourceInfo` to
+   `ConfigValue` the same way.
+3. **Merge**: cell options over the document's `execute` scope
+   (`merge_with_diagnostics`), then read `error` from the merged value.
+   Per-cell `error:` overrides document `execute: error:`; absent both ⇒
+   `false` (Q1 default).
+
+Implementation questions to settle in Phase 1 (small, not blocking the
+plan): which `InterpretationContext` for cell options (recommend
+`DocumentMetadata`, matching front matter — cell options include
+markdown-bearing values like `fig-cap`); the exact boolean read on the
+merged `ConfigValue` (mind the `metadata-as-str` lint — use the proper
+bool accessor); and whether the doc-level `execute` extraction should be
+memoized once per document rather than per cell (yes, trivially).
+
+The facility itself stays config-agnostic (returns `YamlWithSourceInfo`);
+a thin `cell_options_config()` helper (or engine-local code, whichever
+reads better) does the ConfigValue conversion + merge. That keeps the
+partition mechanism reusable by consumers that don't want config
+semantics (LSP highlighting).
+
+## Note: how source locations work here (decision 4)
+
+The engine input is the serialized post-include QMD. Its cell-body spans
+are registered as an ephemeral source file so diagnostics render
+row/col against exactly the text the engine executed. This is consistent
+with how the rest of the pipeline already treats that serialized text:
+downstream, the same serialized QMD (as `capture.input_qmd`) is re-parsed
+and **reconciled at the AST level against the live pipeline AST**
+(`quarto-ast-reconcile`; the capture splice from bd-gthycd33 is one such
+consumer), and portions of the AST that don't change retain their
+original source locations through that reconciliation. So locating
+engine-side errors in the serialized text is not a divergence from the
+architecture — it's the same coordinate system the pipeline already
+manages, and the existing multi-file error infrastructure
+(`SourceContext` with ephemeral files) renders it correctly. v1 proceeds
+on this basis; if we later want engine diagnostics re-expressed in
+original-file coordinates, that's a reconciliation/mapping pass over an
+unchanged mechanism, not a redesign.
+
+## Work items
+
+### Phase 1 — investigation + tests first (TDD)
+
+- [x] Decision-3 implementation questions settled (2026-07-02, probes in
+      the bd-gthycd33 worktree, deleted after):
+      * `_quarto.yml` `execute: error: true` **does** appear in the
+        capture's `input_qmd` front matter (observed directly) — the
+        engine sees fully merged metadata.
+      * `InterpretationContext::DocumentMetadata` for cell options
+        (booleans stay `Yaml::Boolean` in any context; markdown-bearing
+        string values match front-matter semantics).
+      * Bool read: `merged.get("error").and_then(|v| v.as_bool())` —
+        `ConfigValue::as_bool` (config_value.rs:652) matches
+        `Scalar(Yaml::Boolean)` only, which is what quarto-yaml produces
+        for `true`/`false`; not metadata-as-str-lint territory.
+      * Merge: follow the in-tree precedent
+        (`build_extension_metadata_layer`, metadata_merge.rs:109) —
+        `MergedConfig::new(vec![&lower, &higher])` + `.materialize()`;
+        **later layer wins**. (`merge_with_diagnostics` is a validating
+        wrapper around the same; use it for the diagnostics.)
+- [x] knitr's echoed `.cell-code` for a `#| error: true` cell contains
+      **only** `stop("boom")` — the directive line is stripped, and the
+      output is an embedded `::: {.cell-output .cell-output-error}` div
+      (observed directly). Jupyter must strip too; no discrepancy-log
+      entry needed.
+- [x] Unit tests, registry (4 tests in `cell_options/mod.rs`): line-comment
+      languages incl. `⍝`, block-comment suffix languages, unknown → `#`,
+      case-insensitive lookup.
+- [x] Unit tests, partition (12 tests): leading-run detection; no-options;
+      options-only; blank `#|` run ⇒ no options but still consumed;
+      marker spacing variants; indented marker rejected; block-scalar
+      reassembly; lua `--|` / js `//|` / c `/*|…*/` markers; wrong-language
+      marker rejected; suffix-less block-comment line rejected; malformed
+      YAML ⇒ `CellOptionsError::InvalidYaml`.
+- [x] Unit tests, source mapping (3 tests): `true` node maps to the byte of
+      `t` in the body (via `SourceContext` + `map_offset`, following
+      attribution_chain_resolution.rs); second-line option value maps;
+      `code_source` maps to the first code byte.
+- [x] Engine decision logic is covered by the scoped-resolution unit tests
+      (the allow/deny ladder IS the merge) + the kernel-gated integration
+      assertions (kernel input / echo stripping observable only through a
+      real run — see below).
+- [x] Unit tests, scoped resolution (6 tests): the 4-case matrix + both
+      override directions + non-`error` keys don't grant + scope keys
+      survive the merge. **All 6 pass immediately** — `options_to_config`
+      (pampa `yaml_to_config_value`) and `merge_cell_over_scope`
+      (`MergedConfig::new` + `materialize`, later-layer-wins) are thin
+      compositions of existing infrastructure, which validates the
+      decision-3 design end to end before any engine code exists.
+- [x] Kernel-gated integration tests: `engine_error_policy.rs` (7 tests:
+      plain-error-fails, error-true-embeds-and-strips, doc-level allow,
+      cell-false-overrides-doc-true, failing-cell-stops-subsequent-cells,
+      malformed-options-fail, healthy-cells-unaffected) +
+      `parity_error_policy_behavior` in engine_output_parity.rs (both
+      engines must fail for un-annotated error). Also updated the stale
+      `parity_error_output` doc comment.
+- [x] Run everything; reds confirmed 2026-07-02: 15 registry/partition
+      unit tests fail on `todo!()` stubs; 6 scoped tests pass (see above);
+      7 integration tests fail for the expected reasons; 2 pass as
+      expected (`parity_error_output` shape — unchanged behavior — and
+      `document_execute_error_true_allows…`, vacuously green today since
+      jupyter never aborts; it becomes the over-aborting guard once the
+      policy lands).
+
+### Phase 2 — implement the facility
+
+- [x] `crates/quarto-core/src/cell_options/mod.rs`: registry (Q1 table
+      ported, provenance comment, case-insensitive, unknown → `#`),
+      `option_content_ranges` matcher (prefix + ws + `|` + one optional
+      space, column-0 anchored; suffix languages require + elide the
+      terminator, their newline carried as its own piece),
+      `partition_cell_options` with `SourceInfo::concat` of per-line
+      substrings feeding `quarto_yaml::parse_with_parent`, plus
+      `options_to_config` / `merge_cell_over_scope` (decision-3 helpers)
+      and `CellOptionsError::location()`. Design win over the plan: for
+      prefix-only languages the content ranges run *through each line's
+      newline*, so every byte of the reassembled YAML is a real source
+      byte — no synthetic seams at all.
+- [x] Module docs: contract + provenance + scoped-resolution rationale.
+- [x] All 28 unit tests green after implementation (registry 4,
+      partition 12, mapping 3, scoped 6, + error-path 3). ✅ 2026-07-02.
+
+### Phase 3 — wire the jupyter engine
+
+- [x] text_execute.rs rewired: per-cell `partition_cell_options`; kernel
+      input and echoed `.cell-code` fence use the **partitioned** code
+      (`render_cell`/`echoed_source_fence` now take `(language, code)`);
+      `document_execute_scope` extracts the front matter's `execute` map
+      once per document (parsed with a `Substring` parent over
+      `ctx.source_info`); `resolve_allow_errors` = decision-3 merge;
+      abort-on-disallowed-error via new `JupyterError::CellExecutionFailed`
+      (halts before any later cell runs); malformed options via new
+      `JupyterError::InvalidCellOptions`. **Location fidelity came out
+      better than planned**: `ExecutionContext` already carries
+      `source_info` (a `Concat` from `write_with_source_info` mapping
+      engine-input offsets back to the ORIGINAL files, through includes)
+      plus a shared `SourceContext` — so diagnostics render
+      `path:line:col` in original-file coordinates via `describe_location`,
+      and the plan's ephemeral-file fallback was never needed. (This
+      confirms the decision-4 note's framing: the infrastructure was
+      already there.)
+- [x] All Phase 1 tests green with real kernels ✅ 2026-07-02: 48 lib
+      tests (cell_options + text_execute), 15/15 engine integration tests
+      (7 error-policy + behavior-parity + all pre-existing fences —
+      splice pair, 5 shape-parity cases — unchanged).
+
+### Phase 4 — regression sweep
+
+- [x] `cargo nextest run --workspace` ✅ **10217/10217 passed** (run twice:
+      before and after the clippy shape fixes; identical results,
+      2026-07-02). `cargo clippy -p quarto-core --all-targets` 0 warnings;
+      `cargo xtask lint` clean; `cargo fmt --check` clean.
+- [x] `cargo xtask verify` (full, WASM leg) ✅ "All verification steps
+      passed!" (2026-07-02, fresh-worktree npm install + cold WASM build).
+- [x] Existing parity suite + splice pair still green (all 8 bd-gthycd33
+      fences pass unchanged; non-error-cell emission byte-identical).
+
+### Phase 5 — end-to-end (per CLAUDE.md)
+
+- [x] CLI e2e through the real binary ✅ 2026-07-02 (worktree-built
+      `./target/debug/q2`, scratch fixtures; all outputs inspected):
+      * `q2 render fail.qmd` (plain `raise Exception("boom-e2e")`) ⇒
+        **exit 1** with:
+        `Error: Execution failed in jupyter: code cell at
+        …/fail.qmd:9:2 raised Exception: boom-e2e` + the
+        `Use `#| error: true` …` hint. Line 9 is exactly the `raise`
+        line **in the user's original file** — the `ExecutionContext`
+        source-map chain resolves through the serialized engine input
+        as designed (decision-4 note vindicated).
+      * `q2 render allowed.qmd` (`#| error: true`) ⇒ renders;
+        `allowed.html` contains `class="cell-output cell-output-error"`
+        and **zero** `#|` occurrences (directive stripped from echo).
+      * `q2 render doc-allowed.qmd` (front-matter `execute: error: true`,
+        un-annotated failing cell) ⇒ renders;
+        `<div class="cell-output cell-output-error">…<code>Exception:
+        boom-doc-allowed` present (decision-3 path end to end).
+- [x] `q2 preview` spot-check ✅ (2026-07-02, after
+      `cargo xtask build-q2-preview-spa` + `cargo build --bin q2`):
+      healthy jupyter doc with a `#| echo: true` directive, inspected the
+      preview iframe DOM in a real Chrome tab — 1 `div.cell`, echoed
+      `.cell-code` text is exactly `2 + 3` (directive stripped through
+      the capture path too), output `5` spliced, no `#|` anywhere in the
+      rendered body.
+
+### Phase 6 — close out
+
+- [ ] Update this plan with evidence; `braid close bd-ohvl879u`.
+- [x] Follow-up strands filed (all `discovered-from: bd-ohvl879u`):
+      **bd-eizgnxlx** crossref-shorthand migration (D7);
+      **bd-1gty7f7o** LSP `directive_tokens` reuse;
+      **bd-2xkpy5ra** body-only `SourceInfo` on `CodeBlock`;
+      **bd-moef1ec4** `eval` option (D2);
+      **bd-2lc8qu6e** port `guessChunkOptionsFormat` when a shared
+      consumer handles r cells.
+      The planned "re-express engine diagnostics in original-file
+      coordinates" follow-up was NOT filed — it turned out to already
+      work: `ExecutionContext.source_info` maps engine-input offsets to
+      original files, and the e2e diagnostic pointed at `fail.qmd:9:2`
+      out of the box.
+
+## References
+
+- Strand: bd-ohvl879u; parent context bd-gthycd33 (+ its plan,
+  `claude-notes/plans/2026-07-01-bd-gthycd33-jupyter-cell-wrapper.md`).
+- Q1 canonical partition: `external-sources/quarto-cli/src/core/lib/partition-cell-options.ts`
+  (registry at L310; `optionCommentPattern` L294); error semantics:
+  `external-sources/quarto-cli/src/resources/jupyter/notebook.py`
+  (`cell_execute`, ~L550); knitr-format sniffing:
+  `src/core/lib/guess-chunk-options-format.ts`.
+- q2 precedents: `crates/quarto-lsp-core/src/tokens.rs` (run detection +
+  offset table), `crates/pampa/src/pandoc/meta.rs:334-390`
+  (`parse_with_parent` + `SourceInfo::substring` pattern),
+  `crates/quarto-core/tests/integration/attribution_chain_resolution.rs`
+  (mapping assertions).
+- API surveys (quarto-yaml entry points, SourceInfo variants/builders,
+  survey of all `#|` sites): session transcript 2026-07-02.

--- a/crates/quarto-core/src/cell_options/mod.rs
+++ b/crates/quarto-core/src/cell_options/mod.rs
@@ -1,0 +1,689 @@
+/*
+ * cell_options/mod.rs
+ * Copyright (c) 2026 Posit, PBC
+ *
+ * Shared cell-options facility: identify and extract the YAML options
+ * block at the head of an executable code cell (bd-ohvl879u).
+ */
+
+//! Cell-option partitioning for executable code cells.
+//!
+//! Quarto cells carry per-cell options as YAML written in the cell
+//! language's own comment syntax, one option-marker per line at the
+//! top of the cell: `#|` for python/R, `--|` for lua/sql, `//|` for
+//! js/rust, `%|` for matlab, and block-comment forms like
+//! `/*| … */` for C. This module is q2's **single** implementation of
+//! detecting that block, splitting a cell body into options + code,
+//! and parsing the options with real source attribution — Quarto 1
+//! grew several divergent copies of this logic (partition-cell-options.ts,
+//! jupyter.ts, notebook.py, constants.lua), and q2 itself had two
+//! partial ad-hoc ones before this module (the crossref code-block
+//! shorthand's string matcher and the LSP's highlight-only
+//! `directive_tokens`); consumers should migrate here.
+//!
+//! ## Shape of the options block
+//!
+//! Mirroring Q1's `partition-cell-options.ts`:
+//! - An option line is `<prefix><spaces/tabs>|<one optional space><content>`,
+//!   anchored at column 0 (indented markers are *not* option lines).
+//! - For block-comment languages the line must also end with the
+//!   suffix (after trailing whitespace), which is stripped.
+//! - Only the **leading run** of option lines counts; the first
+//!   non-matching line starts the code.
+//!
+//! ## Source attribution
+//!
+//! The option lines' YAML content is non-contiguous in the cell body
+//! (markers elided), so the reassembled YAML document's provenance is
+//! a [`SourceInfo::concat`] of per-line substrings of the caller's
+//! `body_source` — for prefix-only languages every byte of the
+//! reassembled string (including the newlines) is a real source byte,
+//! so `map_offset` on any parsed node resolves exactly. The YAML is
+//! parsed with [`quarto_yaml::parse_with_parent`], so every node's
+//! span composes back through the concat automatically.
+//!
+//! The facility is config-agnostic: it returns [`YamlWithSourceInfo`].
+//! Consumers that want document-scoped semantics convert via
+//! [`options_to_config`] and merge with [`merge_cell_over_scope`]
+//! (cell options over a document-level scope, cell wins) — the
+//! beginning of scoped resolution of document metadata in cell
+//! options, which Q1 never had.
+
+use quarto_config::MergedConfig;
+use quarto_pandoc_types::config_value::{ConfigValue, InterpretationContext};
+use quarto_source_map::SourceInfo;
+use quarto_yaml::YamlWithSourceInfo;
+
+/// Comment syntax for a language's cell-option lines.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CommentSyntax {
+    /// Line-comment (or block-comment opener) characters, e.g. `#`,
+    /// `//`, `--`, `/*`.
+    pub prefix: &'static str,
+    /// Block-comment closer for languages with no line comments,
+    /// e.g. `*/` for C/CSS, `*)` for OCaml, `;` for SAS.
+    pub suffix: Option<&'static str>,
+}
+
+/// Look up the comment syntax for `language` (case-insensitive).
+/// Unknown languages default to `#`, matching Q1.
+///
+/// Ported from Q1's `kLangCommentChars`
+/// (`quarto-cli/src/core/lib/partition-cell-options.ts`). When q2
+/// grows user-extensible engines this becomes a registration surface
+/// (Q1's `addLanguageComment`); today it is a static table.
+pub fn comment_syntax_for(language: &str) -> CommentSyntax {
+    let lang = language.to_lowercase();
+    let (prefix, suffix): (&'static str, Option<&'static str>) = match lang.as_str() {
+        // Q1 table order preserved for diffability against
+        // kLangCommentChars; the default arm covers r/python/julia/
+        // powershell/bash/stan/octave/awk/gawk/sed/perl/prql/ruby/
+        // coffee and every unknown language.
+        "scala" | "csharp" | "fsharp" | "cpp" | "cc" | "java" | "groovy" | "kotlin" | "js"
+        | "d3" | "node" | "sass" | "scss" | "go" | "asy" | "dot" | "ojs" | "rust" => ("//", None),
+        "matlab" | "tikz" => ("%", None),
+        "c" | "css" => ("/*", Some("*/")),
+        "sas" => ("*", Some(";")),
+        "sql" | "mysql" | "psql" | "lua" | "haskell" => ("--", None),
+        "fortran" | "fortran95" => ("!", None),
+        "stata" => ("*", None),
+        "apl" => ("⍝", None),
+        "ocaml" => ("(*", Some("*)")),
+        "q" => ("/", None),
+        _ => ("#", None),
+    };
+    CommentSyntax { prefix, suffix }
+}
+
+/// Result of partitioning a cell body into options + code.
+#[derive(Debug)]
+pub struct PartitionedCell {
+    /// Parsed options. `None` when the cell has no option lines (or
+    /// the option lines are blank).
+    pub options: Option<YamlWithSourceInfo>,
+    /// The cell body with the option lines removed — what should be
+    /// executed and echoed.
+    pub code: String,
+    /// Provenance of `code`: a substring of the caller's `body_source`.
+    pub code_source: SourceInfo,
+    /// Byte length of the option-line run at the head of the body
+    /// (0 when there are no option lines).
+    pub options_len: usize,
+}
+
+/// Failure to interpret a cell's option lines.
+#[derive(Debug)]
+pub enum CellOptionsError {
+    /// The option lines were detected but are not valid YAML. The
+    /// wrapped error's location (when present) maps into the caller's
+    /// `body_source` via the concat parent.
+    InvalidYaml(quarto_yaml::Error),
+}
+
+impl std::fmt::Display for CellOptionsError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CellOptionsError::InvalidYaml(e) => {
+                write!(f, "cell options are not valid YAML: {}", e)
+            }
+        }
+    }
+}
+
+impl std::error::Error for CellOptionsError {}
+
+impl CellOptionsError {
+    /// The most specific source location the failure carries (maps
+    /// into the caller's `body_source` via the concat parent).
+    pub fn location(&self) -> Option<&SourceInfo> {
+        match self {
+            CellOptionsError::InvalidYaml(e) => match e {
+                quarto_yaml::Error::ParseError { location, .. }
+                | quarto_yaml::Error::UnexpectedEof { location }
+                | quarto_yaml::Error::InvalidStructure { location, .. } => location.as_ref(),
+            },
+        }
+    }
+}
+
+/// Partition `body` (a code cell's text) into its leading option
+/// lines and the remaining code, per `language`'s comment syntax.
+///
+/// `body_source` is the provenance of `body`; the parsed options'
+/// node spans and `code_source` are derived from it. Callers with no
+/// better anchor can register `body` as an ephemeral file in a
+/// [`quarto_source_map::SourceContext`] and pass an `Original` span.
+pub fn partition_cell_options(
+    language: &str,
+    body: &str,
+    body_source: SourceInfo,
+) -> Result<PartitionedCell, CellOptionsError> {
+    let syntax = comment_syntax_for(language);
+
+    // Scan the leading run of option lines, collecting the byte
+    // ranges (within `body`) of each line's YAML content. For
+    // prefix-only languages a range runs to the end of the line
+    // *including* its newline, so the reassembled YAML document is a
+    // pure concatenation of real source bytes. For suffix languages
+    // the suffix is elided, so the line's newline becomes its own
+    // piece (still a real source byte).
+    let mut pieces: Vec<(usize, usize)> = Vec::new();
+    let mut run_end = 0usize;
+    let mut offset = 0usize;
+    while offset < body.len() {
+        let line_end = body[offset..]
+            .find('\n')
+            .map_or(body.len(), |i| offset + i + 1);
+        let line = &body[offset..line_end];
+        let Some(ranges) = option_content_ranges(line, &syntax) else {
+            break;
+        };
+        for r in ranges {
+            pieces.push((offset + r.start, offset + r.end));
+        }
+        run_end = line_end;
+        offset = line_end;
+    }
+
+    let code = body[run_end..].to_string();
+    let code_source = SourceInfo::substring(body_source.clone(), run_end, body.len());
+
+    if pieces.is_empty() {
+        return Ok(PartitionedCell {
+            options: None,
+            code,
+            code_source,
+            options_len: 0,
+        });
+    }
+
+    let mut yaml_text = String::new();
+    let mut concat_pieces: Vec<(SourceInfo, usize)> = Vec::new();
+    for (start, end) in &pieces {
+        yaml_text.push_str(&body[*start..*end]);
+        concat_pieces.push((
+            SourceInfo::substring(body_source.clone(), *start, *end),
+            end - start,
+        ));
+    }
+
+    // A run of blank option lines (`#|` with no content) is not an
+    // options document.
+    if yaml_text.trim().is_empty() {
+        return Ok(PartitionedCell {
+            options: None,
+            code,
+            code_source,
+            options_len: run_end,
+        });
+    }
+
+    let yaml_parent = SourceInfo::concat(concat_pieces);
+    let options = quarto_yaml::parse_with_parent(&yaml_text, yaml_parent)
+        .map_err(CellOptionsError::InvalidYaml)?;
+
+    Ok(PartitionedCell {
+        options: Some(options),
+        code,
+        code_source,
+        options_len: run_end,
+    })
+}
+
+/// Match one line against the option-line shape
+/// `<prefix><spaces/tabs>|<one optional space><content>` (anchored at
+/// column 0), returning the line-relative byte ranges of the YAML
+/// content — one range for prefix-only languages (content through the
+/// line's newline), or content + newline ranges for suffix languages
+/// (whose suffix must terminate the line and is elided). `None` means
+/// the line is not an option line.
+fn option_content_ranges(
+    line: &str,
+    syntax: &CommentSyntax,
+) -> Option<Vec<std::ops::Range<usize>>> {
+    let rest = line.strip_prefix(syntax.prefix)?;
+    let after_ws = rest.trim_start_matches([' ', '\t']);
+    let ws_len = rest.len() - after_ws.len();
+    let after_pipe = after_ws.strip_prefix('|')?;
+    let content_start = syntax.prefix.len() + ws_len + 1 + usize::from(after_pipe.starts_with(' '));
+
+    let mut ranges = Vec::with_capacity(2);
+    match syntax.suffix {
+        None => {
+            ranges.push(content_start..line.len());
+            Some(ranges)
+        }
+        Some(suffix) => {
+            // The line (sans newline and trailing whitespace) must end
+            // with the suffix; content is what precedes it, trimmed.
+            let no_newline = line.trim_end_matches(['\n', '\r']);
+            let before_suffix = no_newline.trim_end().strip_suffix(suffix)?;
+            let content_end = before_suffix.trim_end().len().max(content_start);
+
+            ranges.push(content_start..content_end);
+            // The elided suffix means the line's newline is not
+            // adjacent to the content — carry it as its own piece so
+            // option lines stay separate YAML lines and every
+            // reassembled byte remains a real source byte.
+            let newline_len = line.len() - no_newline.len();
+            if newline_len > 0 {
+                ranges.push(no_newline.len()..line.len());
+            }
+            Some(ranges)
+        }
+    }
+}
+
+/// Convert parsed cell options to a [`ConfigValue`] using
+/// document-metadata interpretation (markdown-bearing strings become
+/// `PandocInlines`, exactly like front matter). Conversion
+/// diagnostics (e.g. unknown tags) are returned alongside.
+pub fn options_to_config(
+    options: YamlWithSourceInfo,
+) -> (ConfigValue, Vec<quarto_error_reporting::DiagnosticMessage>) {
+    let mut collector = pampa::utils::diagnostic_collector::DiagnosticCollector::new();
+    let config = pampa::pandoc::meta::yaml_to_config_value(
+        options,
+        InterpretationContext::DocumentMetadata,
+        &mut collector,
+    );
+    (config, collector.into_diagnostics())
+}
+
+/// Merge cell-level options over a document-level scope: the scope
+/// (e.g. the document's merged `execute` map) is the lower layer,
+/// the cell options the higher — per-cell values win, scope values
+/// fill the gaps. Returns `None` when both inputs are `None`.
+pub fn merge_cell_over_scope(
+    scope: Option<&ConfigValue>,
+    cell: Option<&ConfigValue>,
+) -> Option<ConfigValue> {
+    match (scope, cell) {
+        (None, None) => None,
+        (Some(s), None) => Some(s.clone()),
+        (None, Some(c)) => Some(c.clone()),
+        (Some(s), Some(c)) => {
+            // In-tree precedent (metadata_merge.rs): later layer wins.
+            let merged = MergedConfig::new(vec![s, c]);
+            Some(merged.materialize().unwrap_or_else(|_| c.clone()))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use quarto_source_map::{FileId, SourceContext};
+
+    // ── Registry ────────────────────────────────────────────────────
+
+    #[test]
+    fn registry_line_comment_languages() {
+        for (lang, prefix) in [
+            ("python", "#"),
+            ("r", "#"),
+            ("julia", "#"),
+            ("bash", "#"),
+            ("lua", "--"),
+            ("sql", "--"),
+            ("haskell", "--"),
+            ("js", "//"),
+            ("rust", "//"),
+            ("cpp", "//"),
+            ("java", "//"),
+            ("matlab", "%"),
+            ("tikz", "%"),
+            ("fortran", "!"),
+            ("apl", "⍝"),
+            ("stata", "*"),
+        ] {
+            let syn = comment_syntax_for(lang);
+            assert_eq!(syn.prefix, prefix, "prefix for {lang}");
+            assert_eq!(syn.suffix, None, "suffix for {lang}");
+        }
+    }
+
+    #[test]
+    fn registry_block_comment_languages() {
+        assert_eq!(
+            comment_syntax_for("c"),
+            CommentSyntax {
+                prefix: "/*",
+                suffix: Some("*/")
+            }
+        );
+        assert_eq!(
+            comment_syntax_for("css"),
+            CommentSyntax {
+                prefix: "/*",
+                suffix: Some("*/")
+            }
+        );
+        assert_eq!(
+            comment_syntax_for("ocaml"),
+            CommentSyntax {
+                prefix: "(*",
+                suffix: Some("*)")
+            }
+        );
+        assert_eq!(
+            comment_syntax_for("sas"),
+            CommentSyntax {
+                prefix: "*",
+                suffix: Some(";")
+            }
+        );
+    }
+
+    #[test]
+    fn registry_unknown_language_defaults_to_hash() {
+        assert_eq!(
+            comment_syntax_for("some-new-kernel"),
+            CommentSyntax {
+                prefix: "#",
+                suffix: None
+            }
+        );
+    }
+
+    #[test]
+    fn registry_lookup_is_case_insensitive() {
+        assert_eq!(comment_syntax_for("Python").prefix, "#");
+        assert_eq!(comment_syntax_for("LUA").prefix, "--");
+    }
+
+    // ── Partition: test scaffolding ─────────────────────────────────
+
+    /// Register `body` as an ephemeral file and return a matching
+    /// `Original` SourceInfo plus the context for mapping assertions.
+    fn body_fixture(body: &str) -> (SourceInfo, SourceContext, FileId) {
+        let mut ctx = SourceContext::new();
+        let file_id = ctx.add_file("cell-body.txt".to_string(), Some(body.to_string()));
+        let info = SourceInfo::original(file_id, 0, body.len());
+        (info, ctx, file_id)
+    }
+
+    fn partition(language: &str, body: &str) -> PartitionedCell {
+        let (info, _ctx, _) = body_fixture(body);
+        partition_cell_options(language, body, info).expect("partition should succeed")
+    }
+
+    // ── Partition: structure ────────────────────────────────────────
+
+    #[test]
+    fn partition_no_option_lines_returns_body_unchanged() {
+        let body = "x = 1\nprint(x)\n";
+        let cell = partition("python", body);
+        assert!(cell.options.is_none());
+        assert_eq!(cell.code, body);
+        assert_eq!(cell.options_len, 0);
+    }
+
+    #[test]
+    fn partition_extracts_leading_options_and_strips_them_from_code() {
+        let body = "#| error: true\n#| echo: false\nx = 1\n";
+        let cell = partition("python", body);
+        let options = cell.options.expect("options parsed");
+        assert!(options.is_hash());
+        assert_eq!(
+            options
+                .get_hash_value("error")
+                .and_then(|v| v.yaml.as_bool()),
+            Some(true)
+        );
+        assert_eq!(
+            options
+                .get_hash_value("echo")
+                .and_then(|v| v.yaml.as_bool()),
+            Some(false)
+        );
+        assert_eq!(cell.code, "x = 1\n");
+        assert_eq!(cell.options_len, "#| error: true\n#| echo: false\n".len());
+    }
+
+    #[test]
+    fn partition_stops_at_first_non_option_line() {
+        // The `#|` after a code line is NOT an option (leading run only).
+        let body = "#| error: true\nx = 1\n#| echo: false\n";
+        let cell = partition("python", body);
+        let options = cell.options.expect("options parsed");
+        assert!(options.get_hash_value("error").is_some());
+        assert!(options.get_hash_value("echo").is_none());
+        assert_eq!(cell.code, "x = 1\n#| echo: false\n");
+    }
+
+    #[test]
+    fn partition_indented_marker_is_not_an_option_line() {
+        // Q1 anchors the option pattern at column 0.
+        let body = "  #| error: true\nx = 1\n";
+        let cell = partition("python", body);
+        assert!(cell.options.is_none());
+        assert_eq!(cell.code, body);
+    }
+
+    #[test]
+    fn partition_marker_allows_space_before_pipe_and_one_after() {
+        // `# | error: true` (spaces between prefix and pipe) and
+        // exactly one space consumed after the pipe.
+        let body = "#  | error: true\nx = 1\n";
+        let cell = partition("python", body);
+        let options = cell.options.expect("options parsed");
+        assert_eq!(
+            options
+                .get_hash_value("error")
+                .and_then(|v| v.yaml.as_bool()),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn partition_options_only_cell_has_empty_code() {
+        let body = "#| error: true\n";
+        let cell = partition("python", body);
+        assert!(cell.options.is_some());
+        assert_eq!(cell.code, "");
+        assert_eq!(cell.options_len, body.len());
+    }
+
+    #[test]
+    fn partition_blank_option_lines_yield_no_options() {
+        // A bare `#|` run with no content is not an options map.
+        let body = "#|\nx = 1\n";
+        let cell = partition("python", body);
+        assert!(cell.options.is_none());
+        assert_eq!(cell.code, "x = 1\n");
+        // The blank option line is still consumed from the code.
+        assert_eq!(cell.options_len, "#|\n".len());
+    }
+
+    #[test]
+    fn partition_multiline_yaml_value_reassembles() {
+        // Block-scalar option value spanning several option lines.
+        let body = "#| fig-cap: |\n#|   A caption\n#|   over two lines\nplot()\n";
+        let cell = partition("python", body);
+        let options = cell.options.expect("options parsed");
+        let cap = options
+            .get_hash_value("fig-cap")
+            .and_then(|v| v.yaml.as_str().map(str::to_string))
+            .expect("fig-cap parsed");
+        assert_eq!(cap, "A caption\nover two lines\n");
+        assert_eq!(cell.code, "plot()\n");
+    }
+
+    #[test]
+    fn partition_lua_style_marker() {
+        let body = "--| error: true\nprint(1)\n";
+        let cell = partition("lua", body);
+        let options = cell.options.expect("options parsed");
+        assert_eq!(
+            options
+                .get_hash_value("error")
+                .and_then(|v| v.yaml.as_bool()),
+            Some(true)
+        );
+        assert_eq!(cell.code, "print(1)\n");
+    }
+
+    #[test]
+    fn partition_js_style_marker() {
+        let body = "//| error: true\nconsole.log(1)\n";
+        let cell = partition("js", body);
+        assert!(cell.options.is_some());
+        assert_eq!(cell.code, "console.log(1)\n");
+    }
+
+    #[test]
+    fn partition_block_comment_language_requires_and_strips_suffix() {
+        let body = "/*| error: true */\nint x;\n";
+        let cell = partition("c", body);
+        let options = cell.options.expect("options parsed");
+        assert_eq!(
+            options
+                .get_hash_value("error")
+                .and_then(|v| v.yaml.as_bool()),
+            Some(true)
+        );
+        assert_eq!(cell.code, "int x;\n");
+    }
+
+    #[test]
+    fn partition_block_comment_line_without_suffix_is_not_an_option() {
+        let body = "/*| error: true\nint x;\n";
+        let cell = partition("c", body);
+        assert!(cell.options.is_none());
+        assert_eq!(cell.code, body);
+    }
+
+    #[test]
+    fn partition_hash_marker_does_not_match_other_languages() {
+        // A `#|` line in a js cell is not an option line (js is `//|`).
+        let body = "#| error: true\nconsole.log(1)\n";
+        let cell = partition("js", body);
+        assert!(cell.options.is_none());
+        assert_eq!(cell.code, body);
+    }
+
+    #[test]
+    fn partition_malformed_yaml_is_an_error() {
+        let body = "#| error: [unclosed\nx = 1\n";
+        let (info, _ctx, _) = body_fixture(body);
+        let result = partition_cell_options("python", body, info);
+        assert!(
+            matches!(result, Err(CellOptionsError::InvalidYaml(_))),
+            "expected InvalidYaml, got {result:?}"
+        );
+    }
+
+    // ── Partition: source attribution ───────────────────────────────
+
+    #[test]
+    fn partition_option_value_maps_back_to_body_offset() {
+        let body = "#| error: true\nx = 1\n";
+        let (info, ctx, file_id) = body_fixture(body);
+        let cell = partition_cell_options("python", body, info).expect("partition");
+        let options = cell.options.expect("options parsed");
+        let value = options.get_hash_value("error").expect("error key");
+        let mapped = value
+            .source_info
+            .map_offset(0, &ctx)
+            .expect("value offset maps through the concat");
+        assert_eq!(mapped.file_id, file_id);
+        // `true` starts at byte 10 of the body ("#| error: " is 10 bytes).
+        assert_eq!(mapped.location.offset, body.find("true").unwrap());
+    }
+
+    #[test]
+    fn partition_second_line_option_maps_back_to_body_offset() {
+        let body = "#| error: true\n#| echo: false\nx = 1\n";
+        let (info, ctx, file_id) = body_fixture(body);
+        let cell = partition_cell_options("python", body, info).expect("partition");
+        let options = cell.options.expect("options parsed");
+        let value = options.get_hash_value("echo").expect("echo key");
+        let mapped = value
+            .source_info
+            .map_offset(0, &ctx)
+            .expect("second-line value maps");
+        assert_eq!(mapped.file_id, file_id);
+        assert_eq!(mapped.location.offset, body.find("false").unwrap());
+    }
+
+    #[test]
+    fn partition_code_source_is_substring_after_options() {
+        let body = "#| error: true\nx = 1\n";
+        let (info, ctx, file_id) = body_fixture(body);
+        let cell = partition_cell_options("python", body, info).expect("partition");
+        let mapped = cell
+            .code_source
+            .map_offset(0, &ctx)
+            .expect("code start maps");
+        assert_eq!(mapped.file_id, file_id);
+        assert_eq!(mapped.location.offset, body.find("x = 1").unwrap());
+    }
+
+    // ── Scoped resolution (decision 3) ──────────────────────────────
+
+    /// Parse a YAML string into a ConfigValue for scope-merge tests.
+    fn config_of(yaml: &str) -> ConfigValue {
+        let parsed = quarto_yaml::parse(yaml).expect("test yaml parses");
+        let (config, diags) = options_to_config(parsed);
+        assert!(diags.is_empty(), "unexpected diagnostics: {diags:?}");
+        config
+    }
+
+    fn allow_errors(merged: Option<&ConfigValue>) -> bool {
+        merged
+            .and_then(|c| c.get("error"))
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false)
+    }
+
+    #[test]
+    fn scoped_cell_error_true_alone_allows() {
+        let cell = config_of("error: true");
+        let merged = merge_cell_over_scope(None, Some(&cell));
+        assert!(allow_errors(merged.as_ref()));
+    }
+
+    #[test]
+    fn scoped_doc_execute_error_true_alone_allows() {
+        let scope = config_of("error: true");
+        let merged = merge_cell_over_scope(Some(&scope), None);
+        assert!(allow_errors(merged.as_ref()));
+    }
+
+    #[test]
+    fn scoped_cell_false_overrides_doc_true() {
+        let scope = config_of("error: true");
+        let cell = config_of("error: false");
+        let merged = merge_cell_over_scope(Some(&scope), Some(&cell));
+        assert!(!allow_errors(merged.as_ref()));
+    }
+
+    #[test]
+    fn scoped_cell_true_overrides_doc_false() {
+        let scope = config_of("error: false");
+        let cell = config_of("error: true");
+        let merged = merge_cell_over_scope(Some(&scope), Some(&cell));
+        assert!(allow_errors(merged.as_ref()));
+    }
+
+    #[test]
+    fn scoped_absent_everywhere_disallows() {
+        assert!(!allow_errors(merge_cell_over_scope(None, None).as_ref()));
+        // Unrelated keys on both sides don't grant permission.
+        let scope = config_of("echo: true");
+        let cell = config_of("warning: false");
+        let merged = merge_cell_over_scope(Some(&scope), Some(&cell));
+        assert!(!allow_errors(merged.as_ref()));
+    }
+
+    #[test]
+    fn scoped_merge_preserves_scope_keys_cell_does_not_set() {
+        let scope = config_of("error: true\ntimeout: 30");
+        let cell = config_of("echo: false");
+        let merged = merge_cell_over_scope(Some(&scope), Some(&cell)).expect("merged");
+        assert_eq!(merged.get("timeout").and_then(|v| v.as_int()), Some(30));
+        assert!(allow_errors(Some(&merged)));
+        assert_eq!(merged.get("echo").and_then(|v| v.as_bool()), Some(false));
+    }
+}

--- a/crates/quarto-core/src/engine/jupyter/error.rs
+++ b/crates/quarto-core/src/engine/jupyter/error.rs
@@ -64,6 +64,16 @@ pub enum JupyterError {
         traceback: Vec<String>,
     },
 
+    /// A code cell raised an error and error output is not allowed —
+    /// no `#| error: true` on the cell and no `execute: error: true`
+    /// on the document (bd-ohvl879u, matching knitr/Q1 policy).
+    #[error("{message}")]
+    CellExecutionFailed { message: String },
+
+    /// A cell's `#|` option lines are not valid YAML (bd-ohvl879u).
+    #[error("{message}")]
+    InvalidCellOptions { message: String },
+
     /// Error receiving message from kernel.
     #[error("failed to receive message: {0}")]
     ReceiveError(String),

--- a/crates/quarto-core/src/engine/jupyter/text_execute.rs
+++ b/crates/quarto-core/src/engine/jupyter/text_execute.rs
@@ -11,14 +11,16 @@
 //! It parses QMD input, executes code blocks via the Jupyter daemon, and returns
 //! markdown with outputs inserted.
 
-use std::path::PathBuf;
-
 use regex::Regex;
+
+use quarto_pandoc_types::config_value::{ConfigValue, InterpretationContext};
+use quarto_source_map::SourceInfo;
 
 use super::daemon::daemon;
 use super::error::JupyterError;
 use super::execute::{CellOutput, ExecuteResult as KernelExecuteResult, ExecuteStatus};
 use super::session::SessionKey;
+use crate::cell_options::{merge_cell_over_scope, options_to_config, partition_cell_options};
 use crate::engine::context::{ExecuteResult, ExecutionContext};
 use crate::engine::error::ExecutionError;
 
@@ -31,6 +33,9 @@ struct CodeBlock {
     start: usize,
     /// End byte offset in the input (exclusive).
     end: usize,
+    /// Start byte offset of the code content (the capture between the
+    /// fences) in the input — anchors per-cell source attribution.
+    code_start: usize,
     /// The language/engine specifier (e.g., "python", "julia").
     language: String,
     /// The code content.
@@ -56,7 +61,7 @@ pub fn execute_qmd(
     let kernel_name = map_language_to_kernel(&blocks[0].language);
 
     // Execute via async runtime
-    let result = execute_blocks_async(input, &blocks, &kernel_name, &ctx.cwd);
+    let result = execute_blocks_async(input, &blocks, &kernel_name, ctx);
 
     result.map_err(|e| ExecutionError::execution_failed("jupyter", e.to_string()))
 }
@@ -95,13 +100,15 @@ fn parse_code_blocks(input: &str) -> Vec<CodeBlock> {
     for cap in re.captures_iter(input) {
         let full_match = cap.get(0).unwrap();
         let language = cap.get(1).unwrap().as_str().to_string();
-        let code = cap.get(2).unwrap().as_str().to_string();
+        let code_match = cap.get(2).unwrap();
+        let code = code_match.as_str().to_string();
 
         // Only include executable languages (not plain code blocks)
         if is_executable_language(&language) {
             blocks.push(CodeBlock {
                 start: full_match.start(),
                 end: full_match.end(),
+                code_start: code_match.start(),
                 language,
                 code,
             });
@@ -137,7 +144,7 @@ fn execute_blocks_async(
     input: &str,
     blocks: &[CodeBlock],
     kernel_name: &str,
-    working_dir: &PathBuf,
+    ctx: &ExecutionContext,
 ) -> JupyterResult<ExecuteResult> {
     // Use tokio runtime to execute async code
     let rt = tokio::runtime::Builder::new_current_thread()
@@ -145,12 +152,7 @@ fn execute_blocks_async(
         .build()
         .map_err(|e| JupyterError::RuntimeLibError(e.to_string()))?;
 
-    rt.block_on(execute_blocks_inner(
-        input,
-        blocks,
-        kernel_name,
-        working_dir,
-    ))
+    rt.block_on(execute_blocks_inner(input, blocks, kernel_name, ctx))
 }
 
 /// Inner async function that does the actual execution.
@@ -158,14 +160,18 @@ async fn execute_blocks_inner(
     input: &str,
     blocks: &[CodeBlock],
     kernel_name: &str,
-    working_dir: &PathBuf,
+    ctx: &ExecutionContext,
 ) -> JupyterResult<ExecuteResult> {
     let daemon = daemon();
 
     // Start or get existing kernel session
-    let key: SessionKey = daemon
-        .get_or_start_session(kernel_name, working_dir)
-        .await?;
+    let key: SessionKey = daemon.get_or_start_session(kernel_name, &ctx.cwd).await?;
+
+    // Document-level defaults for cell options (bd-ohvl879u): the
+    // input's front matter is the pipeline's fully merged metadata
+    // (MetadataMergeStage runs before engine execution), so its
+    // `execute` map is the scope cell options merge over.
+    let doc_scope = document_execute_scope(input, ctx);
 
     // Build output by processing blocks in order
     let mut output = String::new();
@@ -182,15 +188,55 @@ async fn execute_blocks_inner(
             output.push('\n');
         }
 
-        // Execute the code
+        // Partition the cell into `#|` options + code (bd-ohvl879u).
+        // `ctx.source_info` maps input offsets back to the original
+        // files, so option spans and diagnostics resolve to real
+        // source positions.
+        let body_source = SourceInfo::substring(
+            ctx.source_info.clone(),
+            block.code_start,
+            block.code_start + block.code.len(),
+        );
+        let cell = partition_cell_options(&block.language, &block.code, body_source.clone())
+            .map_err(|e| {
+                let at = e
+                    .location()
+                    .and_then(|loc| describe_location(loc, 0, ctx))
+                    .or_else(|| describe_location(&body_source, 0, ctx))
+                    .map(|l| format!(" at {l}"))
+                    .unwrap_or_default();
+                JupyterError::InvalidCellOptions {
+                    message: format!("cell options are not valid YAML{at}: {e}"),
+                }
+            })?;
+        let allow_errors = resolve_allow_errors(doc_scope.as_ref(), cell.options);
+
+        // Execute the code — the partitioned code only, without the
+        // option lines (Q1 strips them too, so cell magics work).
         let exec_result = daemon
-            .execute_in_session(&key, &block.code)
+            .execute_in_session(&key, &cell.code)
             .await
             .ok_or(JupyterError::NotConnected)??;
 
-        // Emit the whole cell — echoed source plus outputs — in the
-        // Quarto-canonical `::: {.cell}` shape.
-        output.push_str(&render_cell(block, &exec_result));
+        // Error policy (bd-ohvl879u, knitr/Q1 parity): a raising cell
+        // aborts the render unless the cell or the document allows
+        // errors in output.
+        if !allow_errors && let Some((ename, evalue)) = first_cell_error(&exec_result) {
+            let at = describe_location(&body_source, 0, ctx)
+                .map(|l| format!(" at {l}"))
+                .unwrap_or_default();
+            return Err(JupyterError::CellExecutionFailed {
+                message: format!(
+                    "code cell{at} raised {ename}: {evalue}\n\
+                     Use `#| error: true` on the cell (or `execute: error: true` in the \
+                     document metadata) to show the error in the output instead."
+                ),
+            });
+        }
+
+        // Emit the whole cell — echoed (option-stripped) source plus
+        // outputs — in the Quarto-canonical `::: {.cell}` shape.
+        output.push_str(&render_cell(&block.language, &cell.code, &exec_result));
 
         last_end = block.end;
     }
@@ -199,6 +245,102 @@ async fn execute_blocks_inner(
     output.push_str(&input[last_end..]);
 
     Ok(ExecuteResult::new(output))
+}
+
+/// The `execute` scope of the document's (already merged) metadata,
+/// read from the engine input's front matter. `None` when the input
+/// has no front matter or no `execute` map.
+fn document_execute_scope(input: &str, ctx: &ExecutionContext) -> Option<ConfigValue> {
+    let (start, end) = front_matter_range(input)?;
+    let parent = SourceInfo::substring(ctx.source_info.clone(), start, end);
+    let parsed = match quarto_yaml::parse_with_parent(&input[start..end], parent) {
+        Ok(parsed) => parsed,
+        Err(e) => {
+            // The front matter was serialized by our own pipeline; a
+            // parse failure here is an internal inconsistency, not a
+            // user error — don't take the render down over defaults.
+            tracing::warn!("engine input front matter did not re-parse: {e}");
+            return None;
+        }
+    };
+    let mut collector = pampa::utils::diagnostic_collector::DiagnosticCollector::new();
+    let config = pampa::pandoc::meta::yaml_to_config_value(
+        parsed,
+        InterpretationContext::DocumentMetadata,
+        &mut collector,
+    );
+    config.get("execute").cloned()
+}
+
+/// Byte range of the YAML between the input's leading `---` fence and
+/// its closing `---` line (exclusive of both delimiter lines).
+fn front_matter_range(input: &str) -> Option<(usize, usize)> {
+    let rest = input.strip_prefix("---")?;
+    let rest = rest
+        .strip_prefix("\r\n")
+        .or_else(|| rest.strip_prefix('\n'))?;
+    let fm_start = input.len() - rest.len();
+    let mut search = 0;
+    while let Some(pos) = rest[search..].find("\n---") {
+        let abs = search + pos;
+        let after = &rest[abs + 4..];
+        if after.is_empty() || after.starts_with('\n') || after.starts_with('\r') {
+            // Include the newline that ends the last YAML line.
+            return Some((fm_start, fm_start + abs + 1));
+        }
+        search = abs + 4;
+    }
+    None
+}
+
+/// Resolve the effective `error:` option for one cell: cell options
+/// merged over the document's `execute` scope (cell wins), absent
+/// everywhere = false (Q1's default `execute: error: false`).
+fn resolve_allow_errors(
+    doc_scope: Option<&ConfigValue>,
+    options: Option<quarto_yaml::YamlWithSourceInfo>,
+) -> bool {
+    let cell_config = options.map(|o| {
+        let (config, diagnostics) = options_to_config(o);
+        for d in diagnostics {
+            tracing::warn!("cell option conversion diagnostic: {d:?}");
+        }
+        config
+    });
+    merge_cell_over_scope(doc_scope, cell_config.as_ref())
+        .as_ref()
+        .and_then(|merged| merged.get("error"))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+}
+
+/// The first error a cell produced, from its outputs or its status.
+fn first_cell_error(result: &KernelExecuteResult) -> Option<(String, String)> {
+    for output in &result.outputs {
+        if let CellOutput::Error { ename, evalue, .. } = output {
+            return Some((ename.clone(), evalue.clone()));
+        }
+    }
+    if let ExecuteStatus::Error { ename, evalue, .. } = &result.status {
+        return Some((ename.clone(), evalue.clone()));
+    }
+    None
+}
+
+/// Render `info` + `offset` as `path:line:column` (1-based) through
+/// the execution context's source map, when it resolves.
+fn describe_location(info: &SourceInfo, offset: usize, ctx: &ExecutionContext) -> Option<String> {
+    let mapped = info.map_offset(offset, &ctx.source_context)?;
+    let path = ctx
+        .source_context
+        .get_file(mapped.file_id)
+        .map(|f| f.path.clone())?;
+    Some(format!(
+        "{}:{}:{}",
+        path,
+        mapped.location.row + 1,
+        mapped.location.column + 1
+    ))
 }
 
 /// Fence for `text`, sized so the fence can never collide with the
@@ -242,10 +384,10 @@ fn ticks_for_code(text: &str) -> String {
 /// engine cell with exactly one wrapper Div, and the Bootstrap CSS
 /// targets `.cell .cell-output-* pre code`. A cell with no outputs
 /// still gets the wrapper (knitr wraps output-less chunks too).
-fn render_cell(block: &CodeBlock, result: &KernelExecuteResult) -> String {
+fn render_cell(language: &str, code: &str, result: &KernelExecuteResult) -> String {
     format!(
         "::: {{.cell}}\n\n{}\n{}\n:::\n",
-        echoed_source_fence(block),
+        echoed_source_fence(language, code),
         format_outputs(result)
     )
 }
@@ -258,17 +400,14 @@ fn render_cell(block: &CodeBlock, result: &KernelExecuteResult) -> String {
 /// `{.python .cell-code}` — so the block is no longer scheduled for
 /// execution, the highlight stage resolves the language from the
 /// first class, and downstream consumers can target `.cell-code`
-/// (same classes knitr's hooks emit). Per-cell directives like
-/// `#| echo: false` travel inside `block.code` and are handled by
-/// whatever stage consumes them — this function only rewrites the
-/// fence.
-fn echoed_source_fence(block: &CodeBlock) -> String {
-    let code = block.code.trim_end_matches('\n');
+/// (same classes knitr's hooks emit). The caller passes the
+/// *partitioned* code — `#|` option lines are consumed by
+/// `crate::cell_options` before execution and are not echoed
+/// (knitr/Q1 parity).
+fn echoed_source_fence(language: &str, code: &str) -> String {
+    let code = code.trim_end_matches('\n');
     let ticks = ticks_for_code(code);
-    format!(
-        "{ticks}{{.{} .cell-code}}\n{}\n{ticks}",
-        block.language, code
-    )
+    format!("{ticks}{{.{language} .cell-code}}\n{code}\n{ticks}")
 }
 
 /// Wrap already-trimmed output text in a `::: {<classes>}` div around
@@ -526,15 +665,6 @@ print("hello")
     // purpose — this shape is a cross-engine contract (see the
     // engine_output_parity integration suite).
 
-    fn py_block(code: &str) -> CodeBlock {
-        CodeBlock {
-            start: 0,
-            end: 0,
-            language: "python".to_string(),
-            code: code.to_string(),
-        }
-    }
-
     fn ok_result(outputs: Vec<CellOutput>) -> KernelExecuteResult {
         KernelExecuteResult {
             status: ExecuteStatus::Ok,
@@ -555,9 +685,8 @@ print("hello")
         // source comes back as an attribute-form fence with the
         // language class first (the highlight stage resolves the
         // language from the first class) plus `.cell-code`.
-        let block = py_block("print(\"hi\")\n");
         assert_eq!(
-            echoed_source_fence(&block),
+            echoed_source_fence("python", "print(\"hi\")\n"),
             "```{.python .cell-code}\nprint(\"hi\")\n```"
         );
     }
@@ -567,8 +696,7 @@ print("hello")
         // Q1's ticksForCode rule: max(3, longest leading backtick
         // run + 1). Code containing a ``` line must get a 4-tick
         // fence or the emitted markdown is corrupt.
-        let block = py_block("s = \"\"\n```\n\"\"\n");
-        let fence = echoed_source_fence(&block);
+        let fence = echoed_source_fence("python", "s = \"\"\n```\n\"\"\n");
         assert!(
             fence.starts_with("````{.python .cell-code}\n"),
             "expected a 4-tick fence, got:\n{fence}"
@@ -658,14 +786,13 @@ print("hello")
 
     #[test]
     fn test_render_cell_wraps_source_and_outputs_in_cell_div() {
-        let block = py_block("2 + 3\n");
         let result = ok_result(vec![CellOutput::ExecuteResult {
             execution_count: 1,
             data: text_plain("5"),
             metadata: serde_json::json!({}),
         }]);
         assert_eq!(
-            render_cell(&block, &result),
+            render_cell("python", "2 + 3\n", &result),
             "::: {.cell}\n\n```{.python .cell-code}\n2 + 3\n```\n\n::: {.cell-output .cell-output-display}\n\n```\n5\n```\n\n:::\n\n:::\n"
         );
     }
@@ -732,10 +859,9 @@ print("hello")
         // gets the `.cell` wrapper — the splice must be able to
         // replace the live cell, and knitr wraps output-less chunks
         // too.
-        let block = py_block("x = 1\n");
         let result = ok_result(vec![]);
         assert_eq!(
-            render_cell(&block, &result),
+            render_cell("python", "x = 1\n", &result),
             "::: {.cell}\n\n```{.python .cell-code}\nx = 1\n```\n\n:::\n"
         );
     }

--- a/crates/quarto-core/src/lib.rs
+++ b/crates/quarto-core/src/lib.rs
@@ -39,6 +39,7 @@
 pub mod artifact;
 pub mod artifact_flush;
 pub mod attribution;
+pub mod cell_options;
 pub mod crossref;
 pub mod dependency;
 pub mod document_profile;

--- a/crates/quarto-core/tests/integration/engine_error_policy.rs
+++ b/crates/quarto-core/tests/integration/engine_error_policy.rs
@@ -1,0 +1,179 @@
+//! bd-ohvl879u: engine error policy — a failing cell aborts the render
+//! unless `error: true` allows it (per-cell `#| error: true` or the
+//! document's `execute: error: true`), matching knitr and Q1 semantics.
+//!
+//! Drives the real jupyter engine through `record_capture` (the same
+//! producer path `q2 render` / `q2 preview` / `q2 provide-hub` use).
+//! Tests skip when the engine isn't installed — same gating as
+//! capture_splice_engines.rs, and the same pollster calling convention
+//! (the jupyter engine builds its own tokio runtime internally).
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use quarto_core::engine::EngineRegistry;
+use quarto_core::engine::preview_record::record_capture;
+use quarto_core::project::ProjectContext;
+use quarto_system_runtime::{NativeRuntime, SystemRuntime};
+
+fn engine_available(name: &str) -> bool {
+    EngineRegistry::default()
+        .get(name)
+        .is_some_and(|e| e.is_available())
+}
+
+fn fixture(
+    content: &str,
+) -> (
+    tempfile::TempDir,
+    PathBuf,
+    ProjectContext,
+    Arc<dyn SystemRuntime>,
+) {
+    let dir = tempfile::tempdir().unwrap();
+    let qmd_path = dir.path().join("doc.qmd");
+    std::fs::write(&qmd_path, content).unwrap();
+    let runtime: Arc<dyn SystemRuntime> = Arc::new(NativeRuntime::new());
+    let project = ProjectContext::discover(&qmd_path, runtime.as_ref()).unwrap();
+    (dir, qmd_path, project, runtime)
+}
+
+fn run(content: &str) -> Result<Vec<quarto_trace::EngineCapture>, String> {
+    let (_tmp, path, project, runtime) = fixture(content);
+    pollster::block_on(record_capture(&path, &project, runtime, None)).map_err(|e| format!("{e:?}"))
+}
+
+fn result_markdown(captures: &[quarto_trace::EngineCapture]) -> String {
+    captures[0]
+        .result
+        .get("markdown")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string()
+}
+
+#[test]
+fn plain_cell_error_fails_the_render() {
+    if !engine_available("jupyter") {
+        eprintln!("Skipping test: jupyter not available");
+        return;
+    }
+    let result = run(
+        "---\ntitle: Error policy\nengine: jupyter\n---\n\nBefore.\n\n```{python}\nraise Exception(\"boom\")\n```\n",
+    );
+    let err = result.expect_err(
+        "bd-ohvl879u: an un-annotated cell error must fail the render (knitr/Q1 parity)",
+    );
+    assert!(
+        err.contains("Exception") && err.contains("boom"),
+        "diagnostic should carry the kernel error; got: {err}"
+    );
+}
+
+#[test]
+fn cell_error_true_embeds_error_output_and_strips_directive() {
+    if !engine_available("jupyter") {
+        eprintln!("Skipping test: jupyter not available");
+        return;
+    }
+    let captures = run(
+        "---\ntitle: Error policy\nengine: jupyter\n---\n\nBefore.\n\n```{python}\n#| error: true\nraise Exception(\"boom\")\n```\n",
+    )
+    .expect("error: true must allow the render to proceed");
+    let md = result_markdown(&captures);
+    assert!(
+        md.contains(".cell-output-error"),
+        "error output must be embedded; got:\n{md}"
+    );
+    assert!(
+        md.contains("boom"),
+        "error text must be embedded; got:\n{md}"
+    );
+    // Q1/knitr parity: the option line is stripped from the echoed
+    // source (and from what the kernel executed).
+    assert!(
+        !md.contains("#|"),
+        "option lines must not appear in the emitted markdown; got:\n{md}"
+    );
+}
+
+#[test]
+fn document_execute_error_true_allows_plain_cell_error() {
+    if !engine_available("jupyter") {
+        eprintln!("Skipping test: jupyter not available");
+        return;
+    }
+    let captures = run(
+        "---\ntitle: Error policy\nengine: jupyter\nexecute:\n  error: true\n---\n\nBefore.\n\n```{python}\nraise Exception(\"boom\")\n```\n",
+    )
+    .expect("document-level execute.error: true must allow the render to proceed");
+    let md = result_markdown(&captures);
+    assert!(
+        md.contains(".cell-output-error") && md.contains("boom"),
+        "error output must be embedded under doc-level allow; got:\n{md}"
+    );
+}
+
+#[test]
+fn cell_error_false_overrides_document_allow() {
+    if !engine_available("jupyter") {
+        eprintln!("Skipping test: jupyter not available");
+        return;
+    }
+    let result = run(
+        "---\ntitle: Error policy\nengine: jupyter\nexecute:\n  error: true\n---\n\nBefore.\n\n```{python}\n#| error: false\nraise Exception(\"boom\")\n```\n",
+    );
+    assert!(
+        result.is_err(),
+        "cell-level error: false must override the document allow (scoped resolution)"
+    );
+}
+
+#[test]
+fn failing_cell_stops_subsequent_cells() {
+    if !engine_available("jupyter") {
+        eprintln!("Skipping test: jupyter not available");
+        return;
+    }
+    // If the second cell ran, the engine would have kept executing
+    // past a disallowed error. The render must fail on cell 1.
+    let result = run(
+        "---\ntitle: Error policy\nengine: jupyter\n---\n\n```{python}\nraise Exception(\"first boom\")\n```\n\n```{python}\nprint(\"must not run\")\n```\n",
+    );
+    let err = result.expect_err("first cell's error must abort");
+    assert!(
+        err.contains("first boom"),
+        "diagnostic should reference the failing cell; got: {err}"
+    );
+}
+
+#[test]
+fn malformed_cell_options_fail_the_render() {
+    if !engine_available("jupyter") {
+        eprintln!("Skipping test: jupyter not available");
+        return;
+    }
+    let result = run(
+        "---\ntitle: Error policy\nengine: jupyter\n---\n\n```{python}\n#| error: [unclosed\nprint(1)\n```\n",
+    );
+    assert!(
+        result.is_err(),
+        "malformed cell-option YAML must be a hard error (decision 6)"
+    );
+}
+
+#[test]
+fn healthy_cells_are_unaffected() {
+    if !engine_available("jupyter") {
+        eprintln!("Skipping test: jupyter not available");
+        return;
+    }
+    let captures = run(
+        "---\ntitle: Error policy\nengine: jupyter\n---\n\n```{python}\n#| echo: true\n2 + 3\n```\n",
+    )
+    .expect("healthy cell renders");
+    let md = result_markdown(&captures);
+    assert!(md.contains("::: {.cell}"), "cell wrapper intact");
+    assert!(md.contains('5'), "output intact");
+    assert!(!md.contains("#|"), "directive stripped from echo");
+}

--- a/crates/quarto-core/tests/integration/engine_output_parity.rs
+++ b/crates/quarto-core/tests/integration/engine_output_parity.rs
@@ -190,19 +190,45 @@ fn parity_expression_value() {
 }
 
 /// Error *output shape* parity, under the sanctioned "show errors in
-/// the output" mode (`#| error: true`). Without it, knitr fails the
-/// whole pipeline on a cell error (Q1's default `error: false`
-/// policy) and produces no capture at all, so there is no shape to
-/// compare — while q2's jupyter currently embeds the error and
-/// succeeds regardless. That *policy* divergence is a separate bug
-/// (jupyter should fail the render on cell error unless
-/// `error: true`), tracked as a follow-up strand; see the plan.
+/// the output" mode (`#| error: true`). Without it, both engines fail
+/// the whole pipeline on a cell error (Q1's default `error: false`
+/// policy — see `parity_error_policy_behavior` below and
+/// engine_error_policy.rs, bd-ohvl879u) and produce no capture, so
+/// there would be no shape to compare.
 #[test]
 fn parity_error_output() {
     assert_engine_parity(
         "#| error: true\nstop(\"boom\")",
         "#| error: true\nraise Exception(\"boom\")",
     );
+}
+
+/// Error-policy *behavior* parity (bd-ohvl879u): an un-annotated cell
+/// error must fail `record_capture` for BOTH engines — no capture is
+/// produced. (Shape parity above covers the `error: true` mode;
+/// this pins the default-deny policy itself.)
+#[test]
+fn parity_error_policy_behavior() {
+    if !both_engines_available() {
+        eprintln!("Skipping test: parity suite needs both knitr and jupyter installed");
+        return;
+    }
+    let knitr = try_record(&knitr_doc("stop(\"boom\")"));
+    let jupyter = try_record(&jupyter_doc("raise Exception(\"boom\")"));
+    assert!(
+        knitr.is_err(),
+        "knitr must fail the render for an un-annotated cell error"
+    );
+    assert!(
+        jupyter.is_err(),
+        "jupyter must fail the render for an un-annotated cell error (bd-ohvl879u)"
+    );
+}
+
+/// `record_capture` without unwrapping — for behavior (not shape) cases.
+fn try_record(content: &str) -> Result<Vec<quarto_trace::EngineCapture>, String> {
+    let (_tmp, path, project, runtime) = fixture(content);
+    pollster::block_on(record_capture(&path, &project, runtime, None)).map_err(|e| format!("{e:?}"))
 }
 
 #[test]

--- a/crates/quarto-core/tests/integration/main.rs
+++ b/crates/quarto-core/tests/integration/main.rs
@@ -16,6 +16,7 @@ pub mod brand_render;
 pub mod capture_splice_engines;
 pub mod crossref_fixtures;
 pub mod document_profile_pipeline;
+pub mod engine_error_policy;
 pub mod engine_merge;
 pub mod engine_output_parity;
 pub mod fail_fast;


### PR DESCRIPTION
## Summary

Follow-up to #360 (bd-gthycd33). Fixes **bd-ohvl879u**: q2's jupyter engine unconditionally embedded a failing cell's error as `.cell-output-error` output and reported success, while knitr fails the whole render (Q1's default `execute: error: false` policy). The fix rides on a new shared **cell-options facility** — the design center of this PR.

### The facility: `quarto-core/src/cell_options/`

q2's *single* implementation of identifying and extracting the `#|`-style YAML options block at the head of an executable code cell (Q1 grew four divergent copies; q2 had two partial ad-hoc ones — the crossref shorthand's string matcher and the LSP's highlight-only `directive_tokens`):

- **Language-aware registry** ported from Q1's `kLangCommentChars`: `#|` for python/R, `--|` for lua/sql, `//|` for js/rust, `%|` matlab, block-comment forms (`/*| … */` for C, `(*| … *)` OCaml, `*| … ;` SAS); unknown → `#`.
- **Partition** mirrors Q1's `partition-cell-options.ts`: leading-run only, column-0 anchored, `prefix + ws + | + one optional space`, suffix required+elided for block-comment languages.
- **Exact source attribution**: the reassembled YAML's provenance is `SourceInfo::concat` of per-line substrings; for prefix-only languages the ranges run through each line's newline, so *every byte of the reassembled YAML is a real source byte* — `map_offset` on any parsed node resolves exactly. Parsed with `quarto_yaml::parse_with_parent`.
- **Scoped resolution** (new vs Q1): cell options convert to `ConfigValue` (`pampa::yaml_to_config_value`) and merge over the document's already-merged `execute` metadata (`MergedConfig`, cell wins) — the start of scoped document-metadata resolution in cell options, a longstanding Q1 limitation.

### The engine consumer

`text_execute.rs` now partitions each cell and:
- **strips option lines from kernel input and echoed `.cell-code`** (Q1/knitr parity — verified empirically that knitr strips them; cell magics would otherwise break);
- resolves `error:` via the scoped merge: per-cell `#| error: true` ⇒ embed error output; document `execute: error: true` ⇒ default-allow; cell `error: false` overrides a document allow; absent everywhere ⇒ **the render fails** (knitr/Q1 parity), halting before later cells run;
- malformed option YAML is a hard, located error.

Diagnostics resolve to **original-file coordinates** through `ExecutionContext.source_info` (no new plumbing needed), e.g.:

```
Error: Execution failed in jupyter: code cell at …/fail.qmd:9:2 raised Exception: boom-e2e
Use `#| error: true` on the cell (or `execute: error: true` in the document metadata) to show the error in the output instead.
```

### Tests

- 28 facility unit tests (registry / partition / source-mapping / scoped-resolution matrix), TDD reds confirmed before implementation.
- `engine_error_policy.rs`: 7 kernel-gated integration tests covering the full policy matrix.
- `engine_output_parity.rs` gains a **behavioral** parity case (both engines must fail identically on un-annotated errors); all bd-gthycd33 fences unchanged and green.
- Workspace suite 9924/9924 on the rebased tree; full `cargo xtask verify` passed; clippy/lint/fmt clean.
- E2E through the real binary: all three policy paths inspected (`q2 render`), plus a `q2 preview` browser spot-check (directive-bearing healthy cell: stripped echo, spliced output) after the full WASM chain rebuild.

**Follow-ups filed** (discovered-from bd-ohvl879u): bd-eizgnxlx (migrate crossref shorthand to the facility), bd-1gty7f7o (LSP reuse), bd-2xkpy5ra (body-only `CodeBlock` SourceInfo), bd-moef1ec4 (`eval` option), bd-2lc8qu6e (`guessChunkOptionsFormat`).

Plan with full evidence: `claude-notes/plans/2026-07-02-bd-ohvl879u-cell-options-error-policy.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)