### PR TITLE
fix(render): exit non-zero on error diagnostics from successful renders

### DIFF
--- a/crates/quarto/src/commands/render.rs
+++ b/crates/quarto/src/commands/render.rs
@@ -839,38 +839,30 @@ fn execute_project(
 /// stays policy-free — partial-progress leniency lives in the
 /// `quarto preview` / hub-client consumer, not here.
 ///
-/// Project-level diagnostics with [`DiagnosticKind::Error`] severity
-/// (e.g. `Q-PROJECT-EMPTY` when the render set is empty — bd-h736)
-/// also force a non-zero exit; the user almost certainly wanted the
-/// previous behavior of "render the named file" rather than a silent
-/// zero-byte success. Warning / Info severity diagnostics are
-/// printed but do not affect the exit code.
+/// Beyond failures, the gate reads
+/// [`ProjectRenderSummary::diagnostic_counts`], which aggregates
+/// every diagnostic source: project-level diagnostics (e.g.
+/// `Q-PROJECT-EMPTY` — bd-h736), failure diagnostics, and
+/// per-document diagnostics on *successful* outputs (bd-zcjtaz78 —
+/// e.g. a duplicate crossref id, `Q-15-1`, where the render
+/// completes but the user was shown `Error:`). Any error-severity
+/// diagnostic anywhere forces a non-zero exit; the render output is
+/// still written, only the exit code reflects the reported error.
 ///
 /// Under `--strict` (bd-yjs54ptg), warnings have already been
-/// promoted to errors on the summary, and the gate additionally
-/// fails on *any* error diagnostic anywhere in the summary —
-/// including per-document diagnostics on successful outputs, which
-/// the non-strict gate does not consider. (Whether the non-strict
-/// gate *should* consider them is bd-zcjtaz78.)
-fn should_exit_nonzero(
-    summary: &quarto_core::project::orchestrator::ProjectRenderSummary,
+/// promoted to errors on the summary, so they trip the same error
+/// check; the explicit warnings arm merely keeps the gate correct if
+/// a caller forgets to promote. `Info` / `Note` never affect the
+/// exit code.
+fn should_exit_nonzero<O: quarto_core::project::orchestrator::OutputDiagnostics>(
+    summary: &quarto_core::project::orchestrator::ProjectRenderSummary<O>,
     strict: bool,
 ) -> bool {
-    if !summary.pass1_failures.is_empty() || !summary.pass2_failures.is_empty() {
+    if summary.has_failures() {
         return true;
     }
-    if strict {
-        let counts = summary.diagnostic_counts();
-        // Post-promotion `warnings` is always 0; checking it anyway
-        // keeps the gate correct even if a caller forgets to promote.
-        if counts.errors > 0 || counts.warnings > 0 {
-            return true;
-        }
-    }
-    summary
-        .project_diagnostics
-        .iter()
-        .any(|d| d.kind == quarto_error_reporting::DiagnosticKind::Error)
+    let counts = summary.diagnostic_counts();
+    counts.errors > 0 || (strict && counts.warnings > 0)
 }
 
 fn print_render_diagnostics(
@@ -2022,6 +2014,65 @@ mod tests {
     #[test]
     fn exit_gate_info_only_passes_under_strict() {
         let summary = summary_with(vec![DiagnosticMessage::info("i")]);
+        assert!(!should_exit_nonzero(&summary, true));
+    }
+
+    // === bd-zcjtaz78: per-output error diagnostics gate the exit ===
+
+    use quarto_core::project::orchestrator::OutputDiagnostics;
+
+    /// Output stub carrying only diagnostics, so the gate can be
+    /// tested against per-document diagnostics on successful renders
+    /// without building a full `RenderToFileResult`.
+    struct StubOutput {
+        diagnostics: Vec<DiagnosticMessage>,
+    }
+
+    impl OutputDiagnostics for StubOutput {
+        fn diagnostics(&self) -> &[DiagnosticMessage] {
+            &self.diagnostics
+        }
+
+        fn diagnostics_mut(&mut self) -> &mut [DiagnosticMessage] {
+            &mut self.diagnostics
+        }
+    }
+
+    fn summary_with_output(
+        diagnostics: Vec<DiagnosticMessage>,
+    ) -> ProjectRenderSummary<StubOutput> {
+        ProjectRenderSummary {
+            outputs: vec![StubOutput { diagnostics }],
+            pass1_failures: Vec::new(),
+            pass2_failures: Vec::new(),
+            project_diagnostics: Vec::new(),
+            stopped_early: false,
+        }
+    }
+
+    /// The bd-zcjtaz78 fix: an error diagnostic on a *successful*
+    /// output fails the gate even without `--strict`.
+    #[test]
+    fn exit_gate_output_error_fails_without_strict() {
+        let summary = summary_with_output(vec![DiagnosticMessage::error("e")]);
+        assert!(should_exit_nonzero(&summary, false));
+        assert!(should_exit_nonzero(&summary, true));
+    }
+
+    /// Per-output warnings keep the pre-fix behavior: exit 0 unless
+    /// `--strict`.
+    #[test]
+    fn exit_gate_output_warning_gates_only_under_strict() {
+        let summary = summary_with_output(vec![DiagnosticMessage::warning("w")]);
+        assert!(!should_exit_nonzero(&summary, false));
+        assert!(should_exit_nonzero(&summary, true));
+    }
+
+    /// Per-output info/note never gate.
+    #[test]
+    fn exit_gate_output_info_never_gates() {
+        let summary = summary_with_output(vec![DiagnosticMessage::info("i")]);
+        assert!(!should_exit_nonzero(&summary, false));
         assert!(!should_exit_nonzero(&summary, true));
     }
 }

--- a/crates/quarto/tests/integration/main.rs
+++ b/crates/quarto/tests/integration/main.rs
@@ -7,6 +7,7 @@ pub mod get_config_cli;
 pub mod json_errors;
 pub mod preview_cli;
 pub mod render_cli_e2e;
+pub mod render_exit_codes;
 pub mod render_integration;
 pub mod revealjs_cli;
 pub mod smoke_all;

--- a/crates/quarto/tests/integration/render_exit_codes.rs
+++ b/crates/quarto/tests/integration/render_exit_codes.rs
@@ -1,0 +1,130 @@
+//! End-to-end CLI tests for `q2 render` exit codes on per-document
+//! error diagnostics (bd-zcjtaz78).
+//!
+//! A render can complete successfully (output file written, no
+//! Pass-1/Pass-2 failure) while carrying a `DiagnosticKind::Error`
+//! diagnostic — e.g. a duplicate crossref identifier (`Q-15-1`),
+//! where the crossref indexer reports the error, skips the
+//! duplicate, and continues. Before bd-zcjtaz78 such a render
+//! printed `Error: ...` yet exited 0, so CI would report success on
+//! output the user was told is broken.
+//!
+//! Contract under verification: any error-severity diagnostic,
+//! wherever it lives in the summary, forces a non-zero exit — with
+//! or without `--strict`. The render still completes (the output
+//! file is written); only the exit code changes.
+//!
+//! TDD note: these tests are written *before* the fix and must fail
+//! (observed exit 0) before the gate change lands.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use tempfile::TempDir;
+
+const Q2_BIN: &str = env!("CARGO_BIN_EXE_q2");
+
+/// Two tables sharing one crossref id: renders successfully with
+/// exactly one error diagnostic (`Q-15-1`) and no warnings.
+const DUPLICATE_ID_DOC: &str = "---\ntitle: Duplicate ids\n---\n\n\
+| a | b |\n|---|---|\n| 1 | 2 |\n\n: First {#tbl-dup}\n\n\
+| c | d |\n|---|---|\n| 3 | 4 |\n\n: Second {#tbl-dup}\n";
+
+fn write_file(path: &Path, contents: &str) {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(path, contents).unwrap();
+}
+
+fn canonical(p: &Path) -> PathBuf {
+    p.canonicalize().unwrap_or_else(|_| p.to_path_buf())
+}
+
+fn run_q2_render(cwd: &Path, args: &[&str]) -> std::process::Output {
+    let mut cmd = Command::new(Q2_BIN);
+    cmd.current_dir(cwd);
+    cmd.arg("render");
+    for a in args {
+        cmd.arg(a);
+    }
+    cmd.output().expect("spawn q2 binary")
+}
+
+/// The core bd-zcjtaz78 contract: an error diagnostic on an
+/// otherwise-successful single-document render exits non-zero even
+/// without `--strict`, while the output file is still written.
+#[test]
+fn error_diagnostic_on_successful_render_exits_nonzero() {
+    let temp = TempDir::new().unwrap();
+    let dir = canonical(temp.path());
+    write_file(&dir.join("dup.qmd"), DUPLICATE_ID_DOC);
+
+    let out_path = dir.join("dup.html");
+    let output = run_q2_render(&dir, &["-o", out_path.to_str().unwrap(), "dup.qmd"]);
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Q-15-1"),
+        "expected the duplicate-id error diagnostic on stderr; got:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("1 error"),
+        "expected the counts clause to report one error; got:\n{stderr}"
+    );
+    assert!(
+        out_path.exists(),
+        "the render itself completes; only the exit code changes"
+    );
+    assert!(
+        !output.status.success(),
+        "an error diagnostic must force a non-zero exit even without --strict; stderr:\n{stderr}"
+    );
+}
+
+/// Project-render variant: one page with an error diagnostic in an
+/// otherwise-clean project exits non-zero.
+#[test]
+fn error_diagnostic_in_project_render_exits_nonzero() {
+    let temp = TempDir::new().unwrap();
+    let dir = canonical(temp.path());
+    write_file(
+        &dir.join("_quarto.yml"),
+        "project:\n  type: website\n  output-dir: _site\n",
+    );
+    write_file(
+        &dir.join("index.qmd"),
+        "---\ntitle: Home\n---\n\nAll good here.\n",
+    );
+    write_file(&dir.join("dup.qmd"), DUPLICATE_ID_DOC);
+
+    let output = run_q2_render(&dir, &[]);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Q-15-1"),
+        "expected the duplicate-id error diagnostic on stderr; got:\n{stderr}"
+    );
+    assert!(
+        !output.status.success(),
+        "a per-page error diagnostic must force a non-zero project exit; stderr:\n{stderr}"
+    );
+}
+
+/// Regression guard: a completely clean render still exits 0.
+#[test]
+fn clean_render_still_exits_zero() {
+    let temp = TempDir::new().unwrap();
+    let dir = canonical(temp.path());
+    write_file(
+        &dir.join("clean.qmd"),
+        "---\ntitle: Clean\n---\n\nNothing to report.\n",
+    );
+
+    let out_path = dir.join("clean.html");
+    let output = run_q2_render(&dir, &["-o", out_path.to_str().unwrap(), "clean.qmd"]);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "clean renders must keep exiting 0; stderr:\n{stderr}"
+    );
+}


### PR DESCRIPTION
Braid strand: bd-zcjtaz78 (discovered during #362 / bd-yjs54ptg).

## Problem

A render can complete successfully — output file written, no Pass-1/Pass-2 failure — while carrying a `DiagnosticKind::Error` diagnostic. Examples: a duplicate crossref identifier (`Q-15-1`, reported and skipped by the indexer), an include-file parse error (`Q-5-3`), or a Lua filter calling `quarto.error()`. Such a render printed `Error: ...` and tallied `1 error` in the summary line, yet exited 0 — so CI reported success on output the user was explicitly told is broken.

## Fix

`should_exit_nonzero` now reads `ProjectRenderSummary::diagnostic_counts()`, which aggregates every diagnostic source — pass-1/pass-2 failure diagnostics, project-level diagnostics, and per-document diagnostics on successful outputs (the previously-ignored source). Any error-severity diagnostic forces exit 1, with or without `--strict`. Warnings keep their existing semantics (exit 0 unless `--strict`); `Info`/`Note` never gate. The render still completes and writes its output; only the exit code changes.

The gate is now generic over `OutputDiagnostics`, which makes the per-output case directly unit-testable. Only `crates/quarto` is touched.

**Behavior change for non-strict users, by design:** CI pipelines that currently pass despite `Error:` output will start failing — the exit code now agrees with what the diagnostics already said.

## Testing

- TDD: 3 CLI integration tests (`crates/quarto/tests/integration/render_exit_codes.rs`) spawning the real `q2` binary against a duplicate-table-id fixture; confirmed failing first (observed `1 error` with exit 0).
- 3 new unit tests for the gate's per-output arm (error / warning / info).
- `cargo nextest run --workspace`: 9895 passed — no existing test relied on the old exit-0 behavior. `cargo xtask verify --skip-hub-build` and clippy green.
- End-to-end, output inspected:

  ```
  $ q2 render duptbl.qmd     # two tables share {#tbl-dup}
  Error: [Q-15-1] Duplicate crossref identifier
  1 error
  # exit 1; duptbl.html still written
  ```

  Also verified a Lua filter's `quarto.error()` now yields exit 1, and a warnings-only document still exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)