### PR TITLE
diag(sync-client,hub-e2e): expose stranded-doc DocHandle state in smoke-diag

### DIFF
--- a/hub-client/e2e/helpers/previewExtraction.ts
+++ b/hub-client/e2e/helpers/previewExtraction.ts
@@ -207,6 +207,30 @@ export interface PreviewStageDiagnostics {
    * render error is shown.
    */
   renderError: string;
+  /**
+   * Sync-layer view of the stall (from the sync client's
+   * `getSyncDiagnostics()` test hook): for every index-referenced file that
+   * never loaded, the underlying automerge-repo DocHandle state
+   * (`loading` / `requesting` / `unavailable` / `nohandle`) and whether the
+   * client's own unavailable marker was set, plus connected-peer count and
+   * the unavailable-retry poll's tick counter / timer state. This is the
+   * field that distinguishes the remaining stall *mechanisms* behind the
+   * uniform "Path not found: <target>" symptom — a request lost in flight
+   * (`requesting`), automerge-repo's terminal cached verdict
+   * (`unavailable`), or a storage load that never finished (`loading`).
+   * Null when the hook is unavailable (older bundle) or capture threw.
+   */
+  sync: {
+    connectedPeers: number;
+    unavailableRetryTicks: number;
+    retryTimerActive: boolean;
+    stranded: Array<{
+      path: string;
+      docId: string;
+      handleState: string | null;
+      unavailableMarker: boolean;
+    }>;
+  } | null;
   /** Single-line, key=value, grep-friendly form for the failure message. */
   line: string;
 }
@@ -259,6 +283,29 @@ export async function capturePreviewDiagnostics(
       renderError = msg.replace(/\s+/g, ' ').slice(0, 300);
     }
 
+    // Sync-layer stall mechanism (see the `sync` field doc on
+    // PreviewStageDiagnostics). Optional-called so a bundle predating the
+    // hook degrades to null instead of throwing inside the diag capture.
+    let sync: {
+      connectedPeers: number;
+      unavailableRetryTicks: number;
+      retryTimerActive: boolean;
+      stranded: Array<{
+        path: string;
+        docId: string;
+        handleState: string | null;
+        unavailableMarker: boolean;
+      }>;
+    } | null = null;
+    try {
+      const renderer = window.__quartoTest?.wasmRenderer as
+        | { getSyncDiagnostics?: () => NonNullable<typeof sync> }
+        | undefined;
+      sync = renderer?.getSyncDiagnostics?.() ?? null;
+    } catch {
+      /* not connected yet, or hook absent */
+    }
+
     return {
       wasmReady,
       vfsCount,
@@ -270,6 +317,7 @@ export async function capturePreviewDiagnostics(
       iframePresent: !!iframe,
       bodyLen,
       renderError,
+      sync,
     };
   }, iframeSelector);
 
@@ -284,6 +332,28 @@ export async function capturePreviewDiagnostics(
   else if (!raw.wasmReady) stage = 'WASM_NOT_READY';
   else stage = 'UNKNOWN';
 
+  // Compact sync-mechanism suffix, e.g.
+  //   syncPeers=1 syncRetryTicks=12 stranded="test.qmd=requesting+marker"
+  // `stranded` lists each never-loaded file as <path>=<handleState>, with
+  // `+marker` when the sync client's unavailable marker is set and
+  // `nohandle` when the repo holds no cached handle. Only emitted when the
+  // hook returned data; kept after renderError so existing parsers are
+  // unaffected.
+  let syncSuffix = '';
+  if (raw.sync) {
+    const stranded = raw.sync.stranded
+      .map(
+        (s) =>
+          `${s.path}=${s.handleState ?? 'nohandle'}${s.unavailableMarker ? '+marker' : ''}`,
+      )
+      .join(',');
+    syncSuffix =
+      ` syncPeers=${raw.sync.connectedPeers}` +
+      ` syncRetryTicks=${raw.sync.unavailableRetryTicks}` +
+      ` syncRetryTimer=${raw.sync.retryTimerActive ? 1 : 0}` +
+      (stranded ? ` stranded="${stranded}"` : '');
+  }
+
   const line =
     `[smoke-diag] stage=${stage} wasmReady=${raw.wasmReady} vfs=${raw.vfsCount} ` +
     `projectSelector=${raw.projectSelector ? 1 : 0} connecting=${raw.connecting ? 1 : 0} ` +
@@ -291,8 +361,10 @@ export async function capturePreviewDiagnostics(
     `loadingPreview=${raw.loadingPreview ? 1 : 0} iframe=${raw.iframePresent ? 1 : 0} ` +
     `bodyLen=${raw.bodyLen}` +
     // The real failure reason, when the preview is showing a render error.
-    // Appended last so the analyzer's `stage=` parse is unaffected.
-    (raw.renderError ? ` renderError="${raw.renderError}"` : '');
+    // Appended after the fixed fields so the analyzer's `stage=` parse is
+    // unaffected.
+    (raw.renderError ? ` renderError="${raw.renderError}"` : '') +
+    syncSuffix;
 
   return { stage, ...raw, line };
 }

--- a/ts-packages/preview-runtime/src/automergeSync.ts
+++ b/ts-packages/preview-runtime/src/automergeSync.ts
@@ -21,6 +21,7 @@ import {
   type CreateProjectOptions,
   type CreateProjectResult,
   type FilePayload,
+  type SyncDiagnostics,
 } from '@quarto/quarto-sync-client';
 
 import { vfsAddFile, vfsAddBinaryFile, vfsRemoveFile, vfsClear, initWasm, type ProjectFile } from './wasmRenderer';
@@ -285,6 +286,16 @@ export async function createNewProject(
  */
 export function getActorId(): string | null {
   return client?.getActorId() ?? null;
+}
+
+/**
+ * Diagnostic snapshot of sync health: stranded (index-referenced but
+ * never-loaded) files with their automerge-repo DocHandle states, plus
+ * peer/retry-poll state. Consumed by the e2e smoke-diag classifier via the
+ * test hooks; reads only in-memory state.
+ */
+export function getSyncDiagnostics(): SyncDiagnostics {
+  return ensureClient().getSyncDiagnostics();
 }
 
 /**

--- a/ts-packages/quarto-sync-client/src/client.ts
+++ b/ts-packages/quarto-sync-client/src/client.ts
@@ -210,6 +210,38 @@ interface SyncClientState {
    * connected" loop, or null when idle. Cleared on disconnect.
    */
   unavailableRetryTimer: ReturnType<typeof setTimeout> | null;
+  /**
+   * Cumulative count of unavailable-retry poll ticks fired on this
+   * connection. Diagnostic only (see {@link getSyncDiagnostics}) — lets a
+   * failure snapshot show whether the poll actually ran, and how often,
+   * for a file that never recovered. Reset on disconnect.
+   */
+  unavailableRetryTicks: number;
+}
+
+/**
+ * One index-referenced file that has NOT loaded, as reported by
+ * `getSyncDiagnostics()`. `handleState` is the raw automerge-repo DocHandle
+ * state (`'loading'` / `'requesting'` / `'unavailable'` / …), or null when
+ * the repo holds no cached handle for the doc at all. `unavailableMarker`
+ * is this client's own dangling-entry marker (`markFileUnavailable`).
+ * The two disagree exactly when a stall mechanism is hiding: e.g. a handle
+ * stuck `requesting` with no marker means a find is still in flight (or
+ * hung), while marker-set + `unavailable` is the settled verdict.
+ */
+export interface StrandedFileDiagnostic {
+  path: string;
+  docId: string;
+  handleState: string | null;
+  unavailableMarker: boolean;
+}
+
+/** Snapshot returned by `getSyncDiagnostics()`. */
+export interface SyncDiagnostics {
+  connectedPeers: number;
+  unavailableRetryTicks: number;
+  retryTimerActive: boolean;
+  stranded: StrandedFileDiagnostic[];
 }
 
 const DEFAULT_FIND_DOC_RETRY: Required<FindDocRetryOptions> = {
@@ -279,6 +311,7 @@ export function createSyncClient(callbacks: SyncClientCallbacks, astOptions?: AS
     findDocRetry: DEFAULT_FIND_DOC_RETRY,
     initialLoadComplete: false,
     unavailableRetryTimer: null,
+    unavailableRetryTicks: 0,
   };
 
   // AST cache: last successful parse per file (for round-tripping)
@@ -681,6 +714,7 @@ export function createSyncClient(callbacks: SyncClientCallbacks, astOptions?: AS
     const deadline = Date.now() + UNAVAILABLE_RETRY_WINDOW_MS;
     const tick = async (): Promise<void> => {
       state.unavailableRetryTimer = null;
+      state.unavailableRetryTicks += 1;
       if (state.unavailableFiles.size === 0) return;
       if (state.connectedPeers.size > 0) {
         await retryUnavailableFilesOnce();
@@ -1049,6 +1083,7 @@ export function createSyncClient(callbacks: SyncClientCallbacks, astOptions?: AS
     state.connectedPeers = new Set();
     state.peerStorageIds = new Map();
     state.findDocRetry = DEFAULT_FIND_DOC_RETRY;
+    state.unavailableRetryTicks = 0;
     lastIdentities = {};
     lastCaptures = {};
 
@@ -1358,6 +1393,50 @@ export function createSyncClient(callbacks: SyncClientCallbacks, astOptions?: AS
   }
 
   /**
+   * Diagnostic snapshot of sync health for files the index references but
+   * that have NOT loaded (no entry in `fileHandles`). Built for the e2e
+   * smoke-diag classifier: the nightly suite's dominant failure is a render
+   * target that never lands in the VFS, and the *mechanism* differs by the
+   * stranded doc's automerge-repo DocHandle state — `requesting` (request
+   * frame lost in flight), `unavailable` (automerge-repo's terminal
+   * verdict), `loading` (storage load never finished), or null (no handle
+   * was ever created). Those are indistinguishable in the timeout symptom;
+   * this makes them observable. Reads only in-memory state — no network,
+   * no storage; safe to call at any time, including mid-connect (returns
+   * empty `stranded` before the index doc loads).
+   */
+  function getSyncDiagnostics(): SyncDiagnostics {
+    const repo = state.repo;
+    const indexDoc = state.indexHandle?.doc() as
+      | { files?: Record<string, string> }
+      | undefined;
+    const entries = indexDoc?.files ? Object.entries(indexDoc.files) : [];
+    const stranded: StrandedFileDiagnostic[] = entries
+      .filter(([path]) => !state.fileHandles.has(path))
+      .map(([path, docId]) => {
+        const raw = String(docId);
+        // `repo.handles` is keyed by the bare document id; index entries may
+        // carry the `automerge:`-prefixed URL form.
+        const bareId = raw.startsWith('automerge:')
+          ? raw.slice('automerge:'.length)
+          : raw;
+        const cached = repo?.handles?.[bareId as DocumentId];
+        return {
+          path,
+          docId: raw,
+          handleState: cached?.state ?? null,
+          unavailableMarker: state.unavailableFiles.has(path),
+        };
+      });
+    return {
+      connectedPeers: state.connectedPeers.size,
+      unavailableRetryTicks: state.unavailableRetryTicks,
+      retryTimerActive: state.unavailableRetryTimer !== null,
+      stranded,
+    };
+  }
+
+  /**
    * Create a new project with the given files.
    */
   async function createNewProject(
@@ -1592,6 +1671,7 @@ export function createSyncClient(callbacks: SyncClientCallbacks, astOptions?: AS
     getFileHandle,
     getFilePaths,
     getUnavailableFiles,
+    getSyncDiagnostics,
     createNewProject,
     getActorId,
   };

--- a/ts-packages/quarto-sync-client/src/index.ts
+++ b/ts-packages/quarto-sync-client/src/index.ts
@@ -58,7 +58,7 @@ export {
   fileUnavailableMessage,
   indexUnavailableMessage,
 } from './client.js';
-export type { SyncClient } from './client.js';
+export type { SyncClient, SyncDiagnostics, StrandedFileDiagnostic } from './client.js';
 
 // Injectable diagnostic-log sink (bd-sl4o01y0): stdio hosts (hub-mcp)
 // must route library diagnostics to stderr; browsers keep console.log.

--- a/ts-packages/quarto-sync-client/src/sync-diagnostics.test.ts
+++ b/ts-packages/quarto-sync-client/src/sync-diagnostics.test.ts
@@ -1,0 +1,143 @@
+/**
+ * getSyncDiagnostics() — introspection used by the e2e smoke-diag
+ * classifier (claude-notes/research/2026-07-03-e2e-reliability-experiment-log.md,
+ * lead 2).
+ *
+ * Contract: for every file the index references that has NOT loaded
+ * (no ready handle), report the underlying automerge-repo DocHandle
+ * state (`loading` / `requesting` / `unavailable` / null when no handle
+ * was ever cached) plus whether the sync client's own unavailable
+ * marker is set, alongside connected-peer count and the retry-poll's
+ * tick counter / timer state. This is what lets a nightly failure log
+ * distinguish "request lost in flight" from "terminal unavailable
+ * verdict" from "storage load never finished" — mechanisms that are
+ * indistinguishable in the render-timeout symptom.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  generateAutomergeUrl,
+  parseAutomergeUrl,
+  type DocumentId,
+} from '@automerge/automerge-repo';
+
+import { createSyncClient, type SyncClient } from './client.js';
+import { startTestHub, type TestHub } from './test-hub.js';
+
+let hub: TestHub;
+const liveClients: SyncClient[] = [];
+
+beforeEach(async () => {
+  hub = await startTestHub();
+});
+
+afterEach(async () => {
+  for (const c of liveClients.splice(0)) {
+    await c.disconnect();
+  }
+  await hub.stop();
+});
+
+function client(): SyncClient {
+  const c = createSyncClient({
+    onFileAdded: () => {},
+    onFileChanged: () => {},
+    onFileRemoved: () => {},
+  });
+  liveClients.push(c);
+  return c;
+}
+
+async function createProjectOnHub(
+  files: Array<{ path: string; content: string }>,
+): Promise<string> {
+  const creator = client();
+  const result = await creator.createNewProject({
+    syncServer: hub.url,
+    files: files.map((f) => ({ ...f, contentType: 'text' as const })),
+    storage: 'memory',
+    peerTimeoutMs: 10000,
+    requireOnline: true,
+  });
+  // Wait for the hub to actually hold every doc before the creator
+  // disconnects — creation syncs in the background (same discipline as
+  // dangling-entries.test.ts).
+  expect(await hub.hubHasDoc(result.indexDocId, 8000)).toBe(true);
+  for (const f of result.files) {
+    expect(await hub.hubHasDoc(f.docId, 8000)).toBe(true);
+  }
+  await creator.disconnect();
+  return result.indexDocId;
+}
+
+/** Mint an index entry pointing at a doc no repo holds. */
+async function mintGhostEntry(indexDocId: string, path: string): Promise<string> {
+  const ghostId = parseAutomergeUrl(generateAutomergeUrl()).documentId;
+  const handle = await hub.repo.find<{ files: Record<string, string> }>(
+    indexDocId as DocumentId,
+  );
+  handle.change((d) => {
+    d.files[path] = ghostId;
+  });
+  return ghostId;
+}
+
+const FAST_RETRY = { attempts: 1, baseDelayMs: 10 };
+
+describe('getSyncDiagnostics', () => {
+  it('reports a stranded file with its DocHandle state and unavailable marker', async () => {
+    const indexDocId = await createProjectOnHub([
+      { path: 'main.qmd', content: 'loads fine\n' },
+    ]);
+    const ghostId = await mintGhostEntry(indexDocId, 'ghost.qmd');
+
+    const reader = client();
+    await reader.connect(hub.url, indexDocId, undefined, undefined, undefined, {
+      storage: 'memory',
+      peerTimeoutMs: 10000,
+      requireOnline: true,
+      findDocRetry: FAST_RETRY,
+    });
+
+    const diag = reader.getSyncDiagnostics();
+
+    // Healthy state around the stranded file.
+    expect(diag.connectedPeers).toBeGreaterThanOrEqual(1);
+    // The loaded file is NOT reported — only stranded entries are.
+    expect(diag.stranded.map((s) => s.path)).toEqual(['ghost.qmd']);
+
+    const ghost = diag.stranded[0];
+    expect(ghost.docId).toContain(ghostId);
+    // The sync client marked it unavailable at connect...
+    expect(ghost.unavailableMarker).toBe(true);
+    // ...and the repo-level handle verdict is visible. For a doc the hub
+    // explicitly reports missing this is 'unavailable'; the field's job is
+    // to expose whatever state the handle is actually in.
+    expect(ghost.handleState).toBe('unavailable');
+
+    // The bounded retry poll is scheduled (unavailable entries exist and a
+    // peer is connected).
+    expect(diag.retryTimerActive).toBe(true);
+    expect(diag.unavailableRetryTicks).toBeGreaterThanOrEqual(0);
+  }, 30000);
+
+  it('reports no stranded files for a fully-loaded project', async () => {
+    const indexDocId = await createProjectOnHub([
+      { path: 'a.qmd', content: 'a\n' },
+      { path: 'b.qmd', content: 'b\n' },
+    ]);
+
+    const reader = client();
+    await reader.connect(hub.url, indexDocId, undefined, undefined, undefined, {
+      storage: 'memory',
+      peerTimeoutMs: 10000,
+      requireOnline: true,
+      findDocRetry: FAST_RETRY,
+    });
+
+    const diag = reader.getSyncDiagnostics();
+    expect(diag.stranded).toEqual([]);
+    expect(diag.retryTimerActive).toBe(false);
+    expect(diag.connectedPeers).toBeGreaterThanOrEqual(1);
+  }, 30000);
+});


### PR DESCRIPTION
## What

Implements **lead 2** of the e2e reliability experiment log (`claude-notes/research/2026-07-03-e2e-reliability-experiment-log.md`, on branch `research/e2e-reliability-log`): the nightly smoke-all suite's dominant failure has been a render target that never syncs into the VFS, and the remaining candidate *mechanisms* — request frame lost in flight (`requesting`), automerge-repo's terminal cached verdict (`unavailable`), a storage load that never finished (`loading`), or no handle ever created — are indistinguishable in the timeout symptom. This makes the mechanism observable in every future failure log:

```
[smoke-diag] stage=EDITOR_NO_PREVIEW ... renderError="..." syncPeers=1 syncRetryTicks=12 syncRetryTimer=1 stranded="test.qmd=requesting+marker"
```

- **quarto-sync-client**: new `getSyncDiagnostics()` — for every index-referenced file with no loaded handle, the raw DocHandle state + the client's own unavailable marker, plus connected-peer count and the unavailable-retry poll's cumulative tick count / timer state. In-memory reads only; no behavior change.
- **preview-runtime**: re-exported via `automergeSync`, so the existing `wasmRenderer` test-hook namespace picks it up. No hub-client production-source change; hooks remain `VITE_E2E`-gated and tree-shaken from production bundles.
- **e2e previewExtraction**: `capturePreviewDiagnostics` appends the `syncPeers/syncRetryTicks/syncRetryTimer/stranded` suffix after `renderError`, so existing log parsers are unaffected; degrades to nothing on bundles without the hook.

## Verification

- `quarto-sync-client` vitest **187/187** (includes new `sync-diagnostics.test.ts`: dangling entry → `unavailable`+marker with retry timer active; healthy project → empty).
- `tsc` green for both packages; hub-client `VITE_E2E=1` production build green.
- End-to-end via a scratch Playwright spec against the real hub: observed `syncPeers=1 syncRetryTicks=0 syncRetryTimer=0` in the emitted line (scratch spec deleted, not committed).
- Dispatch smoke-all run on this branch: [28654650334](https://github.com/quarto-dev/q2/actions/runs/28654650334) — **78/78 passed, 0 flaky, 5.0m**, so no failure line was emitted in CI; emission is validated by the unit tests + local e2e run above. (The clean run itself is further evidence for the samod-0.12 lead tracked in the research log.)

## Why merge

The nightly runs against `main`; the field only starts appearing in nightly failure logs once merged. If the samod-0.12 era keeps the suite clean, this costs nothing; if flakes return, the first failing night identifies the mechanism instead of starting another guessing round.