### PR TITLE
Fix Windows path-separator leak in brand logo path resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3555,6 +3555,7 @@ dependencies = [
 name = "quarto-brand"
 version = "0.7.0"
 dependencies = [
+ "quarto-util",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/crates/quarto-brand/Cargo.toml
+++ b/crates/quarto-brand/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 description = "Parse and resolve `_brand.yml` brand configuration for Quarto"
 
 [dependencies]
+quarto-util = { workspace = true }
 serde = { workspace = true }
 serde_yaml = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/quarto-brand/src/types.rs
+++ b/crates/quarto-brand/src/types.rs
@@ -535,10 +535,10 @@ impl BrandLogoResource {
     /// paths and `http(s)://` URLs are left unchanged.
     pub fn with_path_relative_to(&self, base: &Path) -> Self {
         let raw = self.path();
-        let resolved = if is_external_url(raw) || Path::new(raw).is_absolute() {
+        let resolved = if is_external_url(raw) || quarto_util::is_rooted(Path::new(raw)) {
             raw.to_string()
         } else {
-            base.join(raw).to_string_lossy().into_owned()
+            quarto_util::to_forward_slashes(&base.join(raw))
         };
         match self {
             BrandLogoResource::Path(_) => BrandLogoResource::Path(resolved),


### PR DESCRIPTION
On Windows, BrandLogoResource::with_path_relative_to joined the base
directory with Path::join and converted via to_string_lossy, which
yields native backslash separators. Downstream consumers (and the
crate's own tests) expect forward-slash paths.

Same root-cause family as #340 (pampa's quarto_api path resolution):
also swaps Path::is_absolute() for quarto_util::is_rooted(), which is
has_root()-based and correct on wasm32 targets where is_absolute()
misfires.