### PR TITLE
fix(quarto-citeproc): stop false CSL lockfile mismatches

### DIFF
--- a/claude-notes/plans/2026-07-07-csl-lockfile-windows-rerun-if-changed.md
+++ b/claude-notes/plans/2026-07-07-csl-lockfile-windows-rerun-if-changed.md
@@ -1,0 +1,150 @@
+# CSL manifest lockfile false-positive on Windows incremental builds
+
+Strand: bd-2w80 ("Investigate CSL manifest test failure after rebase") — **closed**.
+
+## Resolution (final)
+
+Neither research agent's mechanism theory panned out. Empirical repro (add
+then remove a fixture file, no `cargo clean`) showed directory-level
+`rerun-if-changed` correctly triggers a rebuild both ways on cargo
+1.97.0-nightly — the "directory watch misses changes" theories (both the
+pre-1.50-citation one and the mtime-granularity one) were never confirmed as
+the actual cause. Bigger finding: the baked `expected` string only ever
+depended on file names/counts, never content — so the per-file
+`rerun-if-changed` fix originally planned below **would not have prevented
+this failure even if applied**, since it only helps with content-edit
+detection.
+
+Actual fix shipped: stopped baking the validation state at build time
+entirely. `csl_validate_manifest` is now a hand-written runtime test in
+`tests/integration/csl_conformance.rs` that reads `test-data/csl-suite/` +
+`tests/enabled_tests.txt` live at test-run time (via
+`env!("CARGO_MANIFEST_DIR")`, a compile-time *path* constant, not a baked
+*computed value*) and compares against `tests/csl_conformance.lock` in the
+same instant. No time-of-check/time-of-use gap, no dependency on
+build-script rerun timing for this check at all. `build.rs` now only handles
+per-fixture test codegen (unaffected — verified byte-identical by an
+independent review pass). Full crate suite green: 863 passed, 0 failed.
+
+The per-file `rerun-if-changed` hardening for `quarto-citeproc` +
+`quarto-sass` (checklist items below) was **not applied** — no reproducible
+defect was ever found for that angle, so it would have been unproven
+defensive code.
+
+---
+
+## Original investigation (kept for history)
+
+## Overview
+
+`quarto-citeproc::csl_conformance::csl_validate_manifest` failed on a Windows
+incremental build with "Lockfile mismatch: tests/csl_conformance.lock", even
+though `git status` showed `tests/enabled_tests.txt` and `test-data/csl-suite/`
+clean, and regenerating the lockfile (`UPDATE_CSL_LOCKFILE=1`) produced a
+byte-identical file. `cargo clean -p quarto-citeproc` + fresh build made the
+test pass with zero lockfile changes. Conclusion: `build.rs` served a stale
+baked `expected` value from an old `generated_csl_tests.rs`, not a real data
+divergence.
+
+Two research passes (Opus, repo-specific; Sonnet, ecosystem-wide) looked at
+*why* `build.rs`'s `cargo:rerun-if-changed=test-data/csl-suite` (a directory,
+not per-file) failed to trigger a rebuild, and disagree on mechanism:
+
+- **Opus**: cited [rust-lang/cargo#2599](https://github.com/rust-lang/cargo/issues/2599)
+  — directory `rerun-if-changed` only tracks the directory's own mtime, misses
+  in-place file edits.
+- **Sonnet**: found #2599 was *fixed* by
+  [rust-lang/cargo#8973](https://github.com/rust-lang/cargo/pull/8973), merged
+  2020-12-14, shipped in **Cargo 1.50**. Since then, directory
+  `rerun-if-changed` recursively scans and takes the max mtime of every file
+  inside. Current repo toolchain is `nightly-2026-04-28` → `cargo
+  1.97.0-nightly` — Opus's cited mechanism is stale for the cargo version we
+  actually run.
+
+So the "directory watch is shallow" story is **not confirmed** for our cargo
+version. Sonnet's alternate candidates: mtime-granularity/timestamp-truncation
+bugs Cargo has open elsewhere (e.g.
+[#13119](https://github.com/rust-lang/cargo/issues/13119), WSL/9p nanosecond
+truncation; [#9445](https://github.com/rust-lang/cargo/issues/9445), relative
+path normalization in dep-info) are more plausible, but neither is a confirmed
+match either — they're precedent for "Cargo's rerun-if-changed freshness check
+is fragile on Windows-adjacent filesystems in general," not a proven cause
+here.
+
+**Before writing any public rationale (tracker comment, commit message), we
+need to settle the actual mechanism empirically on this machine** — not ship a
+fix with a plausible-sounding but unverified "why."
+
+The concrete fix both agents converge on regardless of mechanism — enumerate
+every fixture file explicitly for `rerun-if-changed` instead of relying solely
+on the directory line — is correct either way: it's strictly more precise than
+Cargo's own directory scan, and matches an existing in-repo pattern
+(`watch_recursive()` in `quarto-trace-server`, `quarto-preview`,
+`quarto-mcp-launcher` build.rs files). `quarto-sass/build.rs` has the same
+directory-only gap (`resources/scss`, `src`) and has not yet manifested a
+failure — worth fixing in the same pass since it's the same category of bug.
+
+## Checklist
+
+- [ ] **Reproduce mechanism empirically.** With current `generated_csl_tests.rs`
+      freshly built (no dirty cache), touch *only the mtime and content* of one
+      existing file in `test-data/csl-suite/` (no add/remove), then run
+      `cargo nextest run -p quarto-citeproc csl_validate_manifest` without
+      `cargo clean` first. If build.rs re-runs and the test still passes (no
+      new fixture added, so `expected` shouldn't change anyway) — need a
+      variant that actually changes what's baked, e.g. add a fixture to
+      `test-data/csl-suite/` *and* to `enabled_tests.txt`, then only touch
+      mtime-adjacent files to see if a plain incremental build (no clean)
+      picks up the addition. Confirm whether Cargo actually re-invokes
+      build.rs (check via `cargo build -vv -p quarto-citeproc | grep
+      "Running.*build-script"` or by adding a temporary `eprintln!` in
+      build.rs) or serves stale output.
+- [ ] **Identify actual trigger** for the original failure if possible — was it
+      a `git rebase`/checkout that touched files at/before Cargo's cached
+      build-script timestamp? Check `git reflog` / recent branch history if
+      still reconstructable; otherwise document as "not reproduced from a
+      clean baseline, only observed once" and rely on the mechanism test above.
+- [ ] **Apply per-file `rerun-if-changed` fix** to `crates/quarto-citeproc/build.rs`:
+      after `test_files` is collected and sorted (existing code, ~line 36),
+      loop over it and emit `cargo:rerun-if-changed=<path>` per fixture. Keep
+      the existing directory line (still needed/harmless for catching
+      additions/removals). No new `walkdir` dependency needed — `csl-suite/`
+      is flat, and the file list is already collected.
+- [ ] **Apply the same fix to `crates/quarto-sass/build.rs`** (`resources/scss`
+      and `src` directory watches) — same latent gap, not yet triggered.
+      Confirm whether that build.rs already collects a file list to reuse, or
+      needs its own walk (check if `walkdir` is already a build-dependency
+      there for the sibling crates' pattern).
+- [ ] **Verify per project TDD/bug-fix rules**: this is build-script infra, not
+      app logic, so the "test" is the reproduction procedure itself (already
+      have one: `cargo clean -p quarto-citeproc` fixes it; need the
+      no-clean-incremental repro from step 1 to prove the *fix*, not just the
+      symptom, is addressed). Confirm fixed build.rs reruns correctly on a
+      fixture add without requiring `cargo clean`.
+- [ ] **Full workspace verify**: `cargo build --workspace`, `cargo nextest run
+      --workspace`, `cargo xtask verify --skip-hub-build` (Rust-only change).
+- [ ] **Correct the existing bd-2w80 comment.** The comment already posted
+      claims "cargo's directory-mtime dependency tracking is known to be
+      unreliable on Windows (NTFS mtime semantics differ from Linux ext4)" —
+      that framing is Opus's pre-1.50 citation, not confirmed against our
+      actual cargo version. Post a follow-up comment with the corrected
+      mechanism once step 1 settles it, before/alongside closing.
+- [ ] **Decide bd-2w80 disposition**: close with the confirmed root cause +
+      fix, or split the `quarto-sass` sibling fix into its own strand
+      (`discovered-from` link) if it's not bundled into the same PR.
+- [ ] **Commit.** Stage `crates/quarto-citeproc/build.rs`,
+      `crates/quarto-sass/build.rs` (if touched). Do not push without explicit
+      approval per project git policy.
+
+## Notes / open questions
+
+- Both research agents agree on the *fix* even while disagreeing on the
+  *mechanism* — low risk either way, but the tracker comment and commit
+  message should state only what we've actually verified on this cargo
+  version, not repeat either agent's unverified citation.
+- Dispatch-prompt gap noticed mid-investigation: non-fork subagents (Explore,
+  general-purpose) inherit zero context from `~/.claude/rules/*.md` or project
+  `CLAUDE.md` — the sonnet research agent used `curl` for GitHub source
+  reads instead of `gh repo read-file`/`read-dir` because the dispatch prompt
+  never mentioned that preference. Not fixed as part of this plan; noted for
+  future dispatch-prompt hygiene.

--- a/crates/quarto-citeproc/.gitattributes
+++ b/crates/quarto-citeproc/.gitattributes
@@ -1,0 +1,7 @@
+# The CSL conformance manifest lockfile is byte-compared against a
+# generated LF-only string in tests/integration/csl_conformance.rs
+# (build_lockfile()). Without this pin, core.autocrlf=true checks the
+# file out as CRLF on Windows, producing a false "Lockfile mismatch"
+# unrelated to any real enabled_tests.txt/fixture divergence.
+tests/csl_conformance.lock text eol=lf
+tests/enabled_tests.txt text eol=lf

--- a/crates/quarto-citeproc/build.rs
+++ b/crates/quarto-citeproc/build.rs
@@ -4,19 +4,18 @@
 //! test functions. Tests not listed in tests/enabled_tests.txt are
 //! generated with #[ignore].
 //!
-//! It also generates a validation test that checks:
-//! - No duplicate entries in enabled_tests.txt
-//! - All entries in enabled_tests.txt correspond to actual test files
-//! - The state matches the committed lockfile (tests/csl_conformance.lock)
+//! Manifest validation (enabled_tests.txt vs. tests/csl_conformance.lock)
+//! lives in tests/integration/csl_conformance.rs as a runtime test, not
+//! here, so it can't go stale relative to a build-cache baked value. See
+//! claude-notes/plans/2026-07-07-csl-lockfile-windows-rerun-if-changed.md.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::env;
 use std::fs;
 use std::path::Path;
 
 fn main() {
     println!("cargo:rerun-if-changed=tests/enabled_tests.txt");
-    println!("cargo:rerun-if-changed=tests/csl_conformance.lock");
     println!("cargo:rerun-if-changed=test-data/csl-suite");
 
     let out_dir = env::var("OUT_DIR").unwrap();
@@ -35,33 +34,9 @@ fn main() {
     // Sort for deterministic output
     test_files.sort_by_key(|e| e.path());
 
-    // Build set of valid test names (lowercase)
-    let valid_tests: HashSet<String> = test_files
-        .iter()
-        .map(|e| {
-            e.path()
-                .file_stem()
-                .unwrap()
-                .to_str()
-                .unwrap()
-                .to_lowercase()
-        })
-        .collect();
-
-    // Load enabled tests with validation
-    let (enabled_tests, duplicates, nonexistent) =
-        load_and_validate_enabled_tests(&enabled_file, &valid_tests);
-
-    // Emit warnings for issues (will show during compilation)
-    for dup in &duplicates {
-        println!("cargo:warning=Duplicate test in enabled_tests.txt: {}", dup);
-    }
-    for bad in &nonexistent {
-        println!(
-            "cargo:warning=Non-existent test in enabled_tests.txt: {}",
-            bad
-        );
-    }
+    // Existence-against-fixtures validation happens at test-run time in the
+    // hand-written csl_validate_manifest test, not here.
+    let enabled_tests = load_enabled_tests(&enabled_file);
 
     // Generate test functions
     let mut generated = String::new();
@@ -95,30 +70,6 @@ fn csl_{}() {{
         ));
     }
 
-    // Generate the validation test
-    let enabled_sorted: Vec<&String> = {
-        let mut v: Vec<_> = enabled_tests.iter().collect();
-        v.sort();
-        v
-    };
-    let duplicates_sorted: Vec<&String> = {
-        let mut v: Vec<_> = duplicates.iter().collect();
-        v.sort();
-        v
-    };
-    let nonexistent_sorted: Vec<&String> = {
-        let mut v: Vec<_> = nonexistent.iter().collect();
-        v.sort();
-        v
-    };
-
-    generated.push_str(&generate_validation_test(
-        test_files.len(),
-        &enabled_sorted,
-        &duplicates_sorted,
-        &nonexistent_sorted,
-    ));
-
     let out_path = Path::new(&out_dir).join("generated_csl_tests.rs");
     fs::write(&out_path, generated).expect("Failed to write generated tests");
 
@@ -132,207 +83,21 @@ fn csl_{}() {{
     fs::write(&count_path, count_info).expect("Failed to write test counts");
 }
 
-/// Load enabled test names from the manifest file with validation.
-/// Returns: (unique enabled tests, duplicates found, non-existent tests)
-fn load_and_validate_enabled_tests(
-    path: &Path,
-    valid_tests: &HashSet<String>,
-) -> (HashSet<String>, Vec<String>, Vec<String>) {
+/// Load enabled test names from the manifest file.
+/// Existence-against-fixtures validation happens at test-run time in the
+/// hand-written csl_validate_manifest test (tests/integration/csl_conformance.rs).
+fn load_enabled_tests(path: &Path) -> HashSet<String> {
     if !path.exists() {
-        return (HashSet::new(), Vec::new(), Vec::new());
+        return HashSet::new();
     }
 
-    let mut enabled = HashSet::new();
-    let mut duplicates = Vec::new();
-    let mut nonexistent = Vec::new();
-    let mut seen_counts: HashMap<String, usize> = HashMap::new();
-
-    for line in fs::read_to_string(path).unwrap_or_default().lines() {
-        let line = line.trim();
-        if line.is_empty() || line.starts_with('#') {
-            continue;
-        }
-
-        let name = line.to_lowercase();
-
-        // Track occurrences
-        let count = seen_counts.entry(name.clone()).or_insert(0);
-        *count += 1;
-
-        if *count == 2 {
-            // First duplicate occurrence
-            duplicates.push(name.clone());
-        }
-
-        // Check if test exists
-        if !valid_tests.contains(&name) && !nonexistent.contains(&name) {
-            nonexistent.push(name.clone());
-        }
-
-        enabled.insert(name);
-    }
-
-    (enabled, duplicates, nonexistent)
-}
-
-/// Generate the validation test function.
-fn generate_validation_test(
-    suite_total: usize,
-    enabled: &[&String],
-    duplicates: &[&String],
-    nonexistent: &[&String],
-) -> String {
-    let enabled_count = enabled.len();
-    let disabled_count = suite_total - enabled_count;
-
-    // Build the expected lockfile content
-    let mut expected_lockfile = String::new();
-    expected_lockfile.push_str("# CSL Conformance Test Lockfile\n");
-    expected_lockfile.push_str("# Auto-generated - do not edit manually\n");
-    expected_lockfile.push_str(
-        "# To update: UPDATE_CSL_LOCKFILE=1 cargo nextest run -p quarto-citeproc csl_validate_manifest\n",
-    );
-    expected_lockfile.push_str("#\n");
-    expected_lockfile.push_str(&format!("# Suite total: {}\n", suite_total));
-    expected_lockfile.push_str(&format!("# Enabled: {}\n", enabled_count));
-    expected_lockfile.push_str(&format!("# Disabled: {}\n", disabled_count));
-    expected_lockfile.push_str("#\n");
-    expected_lockfile.push_str("[enabled]\n");
-    for name in enabled {
-        expected_lockfile.push_str(name);
-        expected_lockfile.push('\n');
-    }
-
-    // Escape the lockfile content for embedding in Rust
-    let escaped_lockfile = expected_lockfile
-        .replace('\\', "\\\\")
-        .replace('"', "\\\"")
-        .replace('\n', "\\n");
-
-    // Build duplicates array
-    let duplicates_array = if duplicates.is_empty() {
-        "Vec::new()".to_string()
-    } else {
-        let items: Vec<String> = duplicates.iter().map(|s| format!("\"{}\"", s)).collect();
-        format!("vec![{}]", items.join(", "))
-    };
-
-    // Build nonexistent array
-    let nonexistent_array = if nonexistent.is_empty() {
-        "Vec::new()".to_string()
-    } else {
-        let items: Vec<String> = nonexistent.iter().map(|s| format!("\"{}\"", s)).collect();
-        format!("vec![{}]", items.join(", "))
-    };
-
-    format!(
-        r##"
-/// Validation test for CSL test manifest.
-/// This test ensures enabled_tests.txt is valid and matches the lockfile.
-#[test]
-fn csl_validate_manifest() {{
-    let duplicates: Vec<&str> = {duplicates};
-    let nonexistent: Vec<&str> = {nonexistent};
-
-    // Check for duplicates
-    if !duplicates.is_empty() {{
-        panic!(
-            "Duplicate entries in enabled_tests.txt:\n  {{}}\n\nRemove the duplicates and try again.",
-            duplicates.join("\n  ")
-        );
-    }}
-
-    // Check for non-existent tests
-    if !nonexistent.is_empty() {{
-        panic!(
-            "Non-existent tests in enabled_tests.txt:\n  {{}}\n\nThese test files do not exist in test-data/csl-suite/. Remove or fix them.",
-            nonexistent.join("\n  ")
-        );
-    }}
-
-    // Compare against lockfile
-    let expected = "{expected}";
-    let lockfile_path = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/csl_conformance.lock");
-
-    // Check if we should auto-update the lockfile
-    let auto_update = std::env::var("UPDATE_CSL_LOCKFILE").is_ok();
-
-    let actual = match std::fs::read_to_string(lockfile_path) {{
-        Ok(content) => content,
-        Err(_) if auto_update => {{
-            // Create the lockfile
-            std::fs::write(lockfile_path, expected).expect("Failed to write lockfile");
-            eprintln!("\nCreated lockfile: tests/csl_conformance.lock");
-            eprintln!("  Suite total: {suite_total}");
-            eprintln!("  Enabled: {enabled_count}");
-            eprintln!("  Disabled: {disabled_count}");
-            return;
-        }}
-        Err(_) => {{
-            eprintln!("\nLockfile not found: tests/csl_conformance.lock\n");
-            eprintln!("Run with UPDATE_CSL_LOCKFILE=1 to create it:");
-            eprintln!("  UPDATE_CSL_LOCKFILE=1 cargo nextest run -p quarto-citeproc csl_validate_manifest\n");
-            panic!("Lockfile not found");
-        }}
-    }};
-
-    if actual != expected {{
-        if auto_update {{
-            // Show what changed before updating
-            let actual_lines: Vec<&str> = actual.lines().collect();
-            let expected_lines: Vec<&str> = expected.lines().collect();
-
-            let actual_enabled = actual_lines.iter().find(|l| l.starts_with("# Enabled:"));
-            let expected_enabled = expected_lines.iter().find(|l| l.starts_with("# Enabled:"));
-
-            eprintln!("\nUpdating lockfile: tests/csl_conformance.lock");
-            if actual_enabled != expected_enabled {{
-                eprintln!("  Count changed:");
-                eprintln!("    Before: {{:?}}", actual_enabled.unwrap_or(&"(none)"));
-                eprintln!("    After:  {{:?}}", expected_enabled.unwrap_or(&"(none)"));
-            }}
-
-            std::fs::write(lockfile_path, expected).expect("Failed to write lockfile");
-            eprintln!("  Lockfile updated successfully.");
-            return;
-        }}
-
-        // Show a simple diff summary
-        let actual_lines: Vec<&str> = actual.lines().collect();
-        let expected_lines: Vec<&str> = expected.lines().collect();
-
-        // Find enabled count lines for quick comparison
-        let actual_enabled = actual_lines.iter().find(|l| l.starts_with("# Enabled:"));
-        let expected_enabled = expected_lines.iter().find(|l| l.starts_with("# Enabled:"));
-
-        eprintln!("\nLockfile mismatch: tests/csl_conformance.lock\n");
-        if actual_enabled != expected_enabled {{
-            eprintln!("Count changed:");
-            eprintln!("  Lockfile: {{:?}}", actual_enabled.unwrap_or(&"(none)"));
-            eprintln!("  Actual:   {{:?}}", expected_enabled.unwrap_or(&"(none)"));
-            eprintln!();
-        }}
-
-        eprintln!("Run with UPDATE_CSL_LOCKFILE=1 to update:");
-        eprintln!("  UPDATE_CSL_LOCKFILE=1 cargo nextest run -p quarto-citeproc csl_validate_manifest\n");
-
-        panic!("Lockfile mismatch - see above for update instructions");
-    }}
-
-    // All good!
-    eprintln!("\nCSL test manifest validated successfully!");
-    eprintln!("  Suite total: {suite_total}");
-    eprintln!("  Enabled: {enabled_count}");
-    eprintln!("  Disabled: {disabled_count}");
-}}
-"##,
-        duplicates = duplicates_array,
-        nonexistent = nonexistent_array,
-        expected = escaped_lockfile,
-        suite_total = suite_total,
-        enabled_count = enabled_count,
-        disabled_count = disabled_count,
-    )
+    fs::read_to_string(path)
+        .unwrap_or_default()
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        .map(str::to_lowercase)
+        .collect()
 }
 
 /// Sanitize a test name for use as a Rust identifier.

--- a/crates/quarto-citeproc/tests/integration/csl_conformance.rs
+++ b/crates/quarto-citeproc/tests/integration/csl_conformance.rs
@@ -550,6 +550,248 @@ fn simple_diff(expected: &str, actual: &str) -> String {
 }
 
 // ============================================================================
+// Manifest validation (hand-written; replaces the build.rs-generated test).
+//
+// This test recomputes the expected lockfile LIVE at test-run time from
+// test-data/csl-suite/ + tests/enabled_tests.txt, then compares against the
+// on-disk tests/csl_conformance.lock. Because both sides are computed in the
+// same instant, there is no build-cache time-of-check/time-of-use gap and no
+// dependency on Cargo's build-script rerun timing (see bd-2w80).
+// ============================================================================
+
+use std::collections::HashSet;
+use std::path::Path;
+
+/// Result of scanning enabled_tests.txt against the fixture set.
+struct ManifestScan {
+    enabled: HashSet<String>,
+    duplicates: Vec<String>,
+    nonexistent: Vec<String>,
+}
+
+/// Read the fixture directory. Returns (valid lowercased stems, suite_total).
+/// `suite_total` counts .txt files, matching build.rs's old `test_files.len()`.
+fn scan_fixture_dir(dir: &Path) -> (HashSet<String>, usize) {
+    let mut valid = HashSet::new();
+    let mut total = 0usize;
+    for entry in std::fs::read_dir(dir)
+        .expect("Failed to read test-data/csl-suite")
+        .filter_map(|entry| entry.ok())
+    {
+        let path = entry.path();
+        if path.extension().is_some_and(|ext| ext == "txt") {
+            total += 1;
+            valid.insert(path.file_stem().unwrap().to_str().unwrap().to_lowercase());
+        }
+    }
+    (valid, total)
+}
+
+/// Parse enabled_tests.txt content against valid stems.
+fn scan_enabled_tests(enabled_txt: &str, valid_tests: &HashSet<String>) -> ManifestScan {
+    let mut enabled = HashSet::new();
+    let mut duplicates = Vec::new();
+    let mut nonexistent = Vec::new();
+    let mut seen_counts: HashMap<String, usize> = HashMap::new();
+
+    for line in enabled_txt.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let name = line.to_lowercase();
+
+        let count = seen_counts.entry(name.clone()).or_insert(0);
+        *count += 1;
+        if *count == 2 {
+            duplicates.push(name.clone());
+        }
+        if !valid_tests.contains(&name) && !nonexistent.contains(&name) {
+            nonexistent.push(name.clone());
+        }
+        enabled.insert(name);
+    }
+
+    ManifestScan {
+        enabled,
+        duplicates,
+        nonexistent,
+    }
+}
+
+/// Build the canonical lockfile text.
+fn build_lockfile(suite_total: usize, enabled: &HashSet<String>) -> String {
+    let mut enabled_sorted: Vec<&String> = enabled.iter().collect();
+    enabled_sorted.sort();
+
+    let enabled_count = enabled.len();
+    let disabled_count = suite_total - enabled_count;
+
+    let mut s = String::new();
+    s.push_str("# CSL Conformance Test Lockfile\n");
+    s.push_str("# Auto-generated - do not edit manually\n");
+    s.push_str(
+        "# To update: UPDATE_CSL_LOCKFILE=1 cargo nextest run -p quarto-citeproc csl_validate_manifest\n",
+    );
+    s.push_str("#\n");
+    s.push_str(&format!("# Suite total: {}\n", suite_total));
+    s.push_str(&format!("# Enabled: {}\n", enabled_count));
+    s.push_str(&format!("# Disabled: {}\n", disabled_count));
+    s.push_str("#\n");
+    s.push_str("[enabled]\n");
+    for name in enabled_sorted {
+        s.push_str(name);
+        s.push('\n');
+    }
+    s
+}
+
+/// Validation test for the CSL test manifest.
+/// Ensures enabled_tests.txt is valid and matches tests/csl_conformance.lock.
+#[test]
+fn csl_validate_manifest() {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let fixture_dir = Path::new(manifest_dir).join("test-data/csl-suite");
+    let enabled_path = Path::new(manifest_dir).join("tests/enabled_tests.txt");
+    let lockfile_path = Path::new(manifest_dir).join("tests/csl_conformance.lock");
+
+    let (valid_tests, suite_total) = scan_fixture_dir(&fixture_dir);
+    let enabled_txt = std::fs::read_to_string(&enabled_path).unwrap_or_default();
+    let scan = scan_enabled_tests(&enabled_txt, &valid_tests);
+
+    if !scan.duplicates.is_empty() {
+        let mut dups = scan.duplicates.clone();
+        dups.sort();
+        panic!(
+            "Duplicate entries in enabled_tests.txt:\n  {}\n\nRemove the duplicates and try again.",
+            dups.join("\n  ")
+        );
+    }
+
+    if !scan.nonexistent.is_empty() {
+        let mut bad = scan.nonexistent.clone();
+        bad.sort();
+        panic!(
+            "Non-existent tests in enabled_tests.txt:\n  {}\n\nThese test files do not exist in test-data/csl-suite/. Remove or fix them.",
+            bad.join("\n  ")
+        );
+    }
+
+    let expected = build_lockfile(suite_total, &scan.enabled);
+    let enabled_count = scan.enabled.len();
+    let disabled_count = suite_total - enabled_count;
+
+    let auto_update = std::env::var("UPDATE_CSL_LOCKFILE").is_ok();
+
+    let actual = match std::fs::read_to_string(&lockfile_path) {
+        Ok(content) => content,
+        Err(_) if auto_update => {
+            std::fs::write(&lockfile_path, &expected).expect("Failed to write lockfile");
+            eprintln!("\nCreated lockfile: tests/csl_conformance.lock");
+            eprintln!("  Suite total: {suite_total}");
+            eprintln!("  Enabled: {enabled_count}");
+            eprintln!("  Disabled: {disabled_count}");
+            return;
+        }
+        Err(_) => {
+            eprintln!("\nLockfile not found: tests/csl_conformance.lock\n");
+            eprintln!("Run with UPDATE_CSL_LOCKFILE=1 to create it:");
+            eprintln!(
+                "  UPDATE_CSL_LOCKFILE=1 cargo nextest run -p quarto-citeproc csl_validate_manifest\n"
+            );
+            panic!("Lockfile not found");
+        }
+    };
+
+    if actual != expected {
+        if auto_update {
+            let actual_enabled = actual.lines().find(|l| l.starts_with("# Enabled:"));
+            let expected_enabled = expected.lines().find(|l| l.starts_with("# Enabled:"));
+            eprintln!("\nUpdating lockfile: tests/csl_conformance.lock");
+            if actual_enabled != expected_enabled {
+                eprintln!("  Count changed:");
+                eprintln!("    Before: {:?}", actual_enabled.unwrap_or("(none)"));
+                eprintln!("    After:  {:?}", expected_enabled.unwrap_or("(none)"));
+            }
+            std::fs::write(&lockfile_path, &expected).expect("Failed to write lockfile");
+            eprintln!("  Lockfile updated successfully.");
+            return;
+        }
+
+        let actual_enabled = actual.lines().find(|l| l.starts_with("# Enabled:"));
+        let expected_enabled = expected.lines().find(|l| l.starts_with("# Enabled:"));
+        eprintln!("\nLockfile mismatch: tests/csl_conformance.lock\n");
+        if actual_enabled != expected_enabled {
+            eprintln!("Count changed:");
+            eprintln!("  Lockfile: {:?}", actual_enabled.unwrap_or("(none)"));
+            eprintln!("  Actual:   {:?}", expected_enabled.unwrap_or("(none)"));
+            eprintln!();
+        }
+        eprintln!("Run with UPDATE_CSL_LOCKFILE=1 to update:");
+        eprintln!(
+            "  UPDATE_CSL_LOCKFILE=1 cargo nextest run -p quarto-citeproc csl_validate_manifest\n"
+        );
+        panic!("Lockfile mismatch - see above for update instructions");
+    }
+
+    eprintln!("\nCSL test manifest validated successfully!");
+    eprintln!("  Suite total: {suite_total}");
+    eprintln!("  Enabled: {enabled_count}");
+    eprintln!("  Disabled: {disabled_count}");
+}
+
+mod manifest_logic_tests {
+    use super::*;
+
+    fn stems(names: &[&str]) -> HashSet<String> {
+        names.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn build_lockfile_is_byte_exact() {
+        let enabled = stems(&["b_two", "a_one"]);
+        let expected = "\
+# CSL Conformance Test Lockfile
+# Auto-generated - do not edit manually
+# To update: UPDATE_CSL_LOCKFILE=1 cargo nextest run -p quarto-citeproc csl_validate_manifest
+#
+# Suite total: 5
+# Enabled: 2
+# Disabled: 3
+#
+[enabled]
+a_one
+b_two
+";
+        assert_eq!(build_lockfile(5, &enabled), expected);
+    }
+
+    #[test]
+    fn scan_detects_duplicates_case_insensitively() {
+        let valid = stems(&["a", "b"]);
+        let scan = scan_enabled_tests("a\nA\nb\n", &valid);
+        assert_eq!(scan.duplicates, vec!["a".to_string()]);
+        assert!(scan.nonexistent.is_empty());
+    }
+
+    #[test]
+    fn scan_detects_nonexistent_and_skips_comments_blanks() {
+        let valid = stems(&["a"]);
+        let scan = scan_enabled_tests("# header\n\na\nz\n", &valid);
+        assert!(scan.duplicates.is_empty());
+        assert_eq!(scan.nonexistent, vec!["z".to_string()]);
+        assert!(scan.enabled.contains("a"));
+    }
+
+    #[test]
+    fn divergent_manifest_is_detected() {
+        let fresh = build_lockfile(3, &stems(&["a", "b"]));
+        let stale = build_lockfile(3, &stems(&["a"]));
+        assert_ne!(fresh, stale);
+    }
+}
+
+// ============================================================================
 // Generated Tests
 // ============================================================================
 


### PR DESCRIPTION
When csl_validate_manifest ran after a rebase, it reported "Lockfile mismatch: tests/csl_conformance.lock" even though enabled_tests.txt and test-data/csl-suite/ were unchanged and regenerating the lockfile produced a byte-identical file.

## Root Cause

Two independent bugs, both making the check flaky rather than authoritative:

1. `csl_validate_manifest` was generated by `build.rs`, which baked an "expected" lockfile string into the compiled test binary at build-script run time and compared it against the live file at test-run time. If Cargo didn't rerun `build.rs` when it should have, the baked value went stale relative to disk - a time-of-check/time-of-use gap.
2. Separately, on Windows checkouts with the common `core.autocrlf=true` setting, `tests/csl_conformance.lock` gets checked out with CRLF line endings, while the generator that produces the "expected" string always emits LF-only. The raw byte compare then fails on line endings alone, with no real content divergence - `crates/quarto-citeproc` had no `.gitattributes` pinning the file, unlike `crates/pampa`, which already pins its fixtures the same way.

## Fix

`csl_validate_manifest` is now a hand-written runtime test in `tests/integration/csl_conformance.rs` that reads `test-data/csl-suite/` and `enabled_tests.txt` live at test-run time via `env!("CARGO_MANIFEST_DIR")` - a compile-time path constant, not a baked computed value - and compares against the lockfile in the same instant. `build.rs` keeps only per-fixture test codegen. Duplicate/nonexistent-entry detection moves from a soft `cargo:warning` to a hard test failure. `UPDATE_CSL_LOCKFILE=1` auto-update behavior is unchanged.

`crates/quarto-citeproc/.gitattributes` now pins `tests/csl_conformance.lock` and `tests/enabled_tests.txt` to `eol=lf`, matching the existing `crates/pampa/.gitattributes` convention. This overrides `core.autocrlf` for these two paths in both directions, so regenerating the lockfile from Windows stays safe too.