### PR TITLE
Preview rich-text editor: open with drag-selection preserved (bd-abo9m23f)

### DIFF
--- a/claude-notes/plans/2026-07-07-preview-drag-selection-into-richtext.md
+++ b/claude-notes/plans/2026-07-07-preview-drag-selection-into-richtext.md
@@ -1,0 +1,269 @@
+# Preview rich-text editor: open with drag-selection preserved
+
+**Strand:** bd-abo9m23f
+**Builds on:** bd-q9lyghv2 (caret-at-click), whose design comments live in
+`ts-packages/preview-renderer/src/q2-preview/richtext/caretFromClick.ts` and
+`RichTextEditor.tsx`.
+
+## Overview
+
+In `q2 preview --allow-edit` (and `format: q2-preview` in hub-client), clicking
+a block opens the rich-text editor with the caret placed at the click point
+(bd-q9lyghv2). But when the user *drags* a selection inside a single block, the
+`pointerup` at the end of the drag activates the editor with only a **caret at
+the release point** — the selection the user just made is discarded. Since the
+rich-text toolbar (bold, italic, link, …) operates on the selection, this
+forces a re-select inside the freshly opened editor.
+
+**Goal:** when the DOM selection at activation time is non-collapsed and fully
+contained in the block being activated, open the rich-text editor with an
+equivalent editor selection (anchor and head mapped from the DOM selection,
+direction preserved).
+
+**Also in scope** (decided 2026-07-07, was open question 1): when the
+selection at a mouse activation is non-collapsed but NOT contained in the
+activated block (cross-block drag), **suppress activation entirely** — today
+the release block opens with a caret and the DOM swap destroys the user's
+selection, which breaks plain copy gestures. Mouse-open paths only; keyboard
+and touch activation are untouched. (The user has separate follow-ups planned
+around rich-text activation mechanisms; this stands on its own.)
+
+**Out of scope** (current behavior stays):
+- The plain-text `EditTextarea` surface → caret behavior as today (possible
+  follow-up: map to `selectionStart`/`selectionEnd`, but it needs a
+  coords→textarea-offset mapping that doesn't exist; not worth it now).
+- Keyboard/touch activation → end-of-block, as today.
+
+## Reproduction (2026-07-07)
+
+Fixture: a `.qmd` with a few paragraphs/lists (any multi-word paragraph works).
+
+```
+cargo run --bin q2 -- preview repro.qmd --allow-edit --no-browser
+# → http://127.0.0.1:61115/?page=repro.qmd
+```
+
+Scripted repro against the live preview (chrome-devtools MCP; CDP's `drag` is
+an HTML5-DnD gesture and never builds a text selection, so the drag end-state
+was synthesized — a real `Range` over "quick brown fox jumps over the lazy"
+set as the window selection, then a `pointerup` dispatched at the coordinates
+of the end of "lazy", exactly the state a completed mouse drag leaves):
+
+- **Before `pointerup`:** `getSelection().toString()` = `"quick brown fox
+  jumps over the lazy"`, fully inside the paragraph (`data-block-pool-id="5"`).
+- **After `pointerup`:** rich-text editor open and focused; selection is a
+  collapsed `Caret` with context `…fox jumps over the lazy‸ dog, and then…` —
+  i.e. caret at the release point, drag selection lost. (Screenshot inspected:
+  caret visible between "lazy" and "dog", no highlight.)
+
+Feasibility probes (same session):
+1. The native selection **is intact and readable at `pointerup` time** in the
+   capture phase (verified with capture-phase listeners).
+2. Collapsed clone-ranges at the selection endpoints give usable viewport
+   rects (`range.cloneRange(); collapse(); getClientRects()[0]`).
+3. **Geometric stability across the swap:** after the editor mounted, the
+   pre-swap endpoint coordinates resolved (via `caretRangeFromPoint`) to
+   exactly `|quick` and `lazy|` **inside the ProseMirror editor** — the same
+   invariant caret-at-click relies on (same text, same measured box, same
+   theme CSS).
+
+## Design
+
+Extend the existing coordinate bridge from one point to an anchor/head pair.
+Same architecture as bd-q9lyghv2 — no new mechanism, just a richer payload:
+
+```
+useBlockEditHover.activate()          RichTextEditor mount effect
+  capture selection endpoint coords →  pendingClickCoordsRef  →  posAtCoords ×2
+  (viewport space, direction-aware)      (read-once + clear)      TextSelection(anchor, head)
+```
+
+### 1. Payload type (PreviewContext.tsx, PreviewRoot.tsx)
+
+Rename/retype `pendingClickCoordsRef` payload from `{x, y} | null` to:
+
+```ts
+type PendingOpenSelection =
+  | { kind: 'caret'; head: { x: number; y: number } }
+  | { kind: 'range'; anchor: { x: number; y: number }; head: { x: number; y: number } }
+  | null;
+```
+
+Read-once-and-clear semantics unchanged (self-heal remounts still fall back to
+end-of-block; after a reflow *both* endpoints are stale, so the same reasoning
+applies a fortiori).
+
+### 2. Capture (useBlockEditHover.tsx, inside `activate()`)
+
+`activate()` is the single open chokepoint and already resolves `outerBlock`,
+so containment is checked there (not in `onPointerUp`, which doesn't know the
+resolved block). When `opts.clickCoords` is present (mouse open):
+
+1. `const sel = outerBlock.ownerDocument.defaultView.getSelection()` —
+   `ownerDocument`-relative, not bare `window`, since the preview runs inside
+   an iframe.
+2. If `sel` is non-collapsed, `rangeCount > 0`, and **both** the range's
+   `startContainer` and `endContainer` are inside `outerBlock` → compute
+   viewport coords of the **anchor** and **focus** points (selection API, not
+   range start/end — preserves drag direction for backward drags) via
+   collapsed clone-ranges + `getClientRects()[0]`, and stash
+   `{ kind: 'range', anchor, head }`.
+3. If `sel` is non-collapsed but NOT contained in `outerBlock` (cross-block
+   drag) → **abort the activation**: return from `activate()` before any side
+   effect (before `cancelPendingLand`/`captureGeometry`/draft seeding), leaving
+   the user's selection intact for copying. A plain click can't false-trigger
+   this: the browser collapses/clears the selection on `mousedown`, so by
+   `pointerup` a non-drag click always sees a collapsed selection.
+4. Otherwise (collapsed / no rects / `rangeCount === 0`) → stash
+   `{ kind: 'caret', head: opts.clickCoords }` — exactly today's behavior.
+
+Note the degenerate case: a drag contained in block A but *released* over
+block B classifies as cross-block relative to B (the activated block) →
+suppressed, selection preserved. Consistent with decision 2 below (we don't
+hunt for the selection's home block).
+
+The capture is a pure helper (own module, e.g. `dragSelectionCapture.ts`) so
+it unit-tests without a real layout — a three-way classification:
+`classifyOpenSelection(outerBlock, clickCoords): PendingOpenSelection |
+'suppress'` (where `'suppress'` makes `activate()` return early; only for
+mouse opens — keyboard/touch never reach this code since they carry no
+`clickCoords`).
+
+Containment against `outerBlock` means the check is automatically mode-aware
+(leaf in unlock-nesting mode, outer block in locked mode) — it tests the
+element actually being activated.
+
+### 3. Replay (caretFromClick.ts + RichTextEditor.tsx mount effect)
+
+New sibling to `placeCaretFromClick`:
+
+```ts
+placeSelectionFromDrag(editor, anchor, head): boolean
+  // posAtCoords both endpoints; if BOTH hit:
+  //   TextSelection.create(doc, anchorHit.pos, headHit.pos)  — direction preserved
+  //   dispatch + focus; return true
+  // else return false
+```
+
+Note: tiptap's `setTextSelection({from, to})` normalizes/clamps and does not
+document direction preservation — use ProseMirror directly
+(`view.dispatch(state.tr.setSelection(TextSelection.create(...)))` +
+`editor.commands.focus()`), matching the file's existing "single source of
+truth" stance.
+
+Mount-effect fallback chain (inside the existing rAF):
+
+1. `kind: 'range'` → `placeSelectionFromDrag`; on miss ↓
+2. head coords → `placeCaretFromClick` (caret at release point, today's
+   behavior); on miss ↓
+3. `editor.commands.focus('end')` (historical default).
+
+### 4. Edge cases
+
+| Case | Behavior |
+| --- | --- |
+| Backward drag (right→left) | anchor/focus coords keep direction; head = release point, so shift-arrow keeps extending naturally |
+| Multi-line drag within block | endpoints on different lines — two independent `posAtCoords`, fine |
+| Selection exactly = whole block (triple-click) | contained → range replay; if the browser range leaks outside the block element, containment fails → suppressed (selection preserved). Note triple-click on an *unopened* block never reaches this path anyway: click #1's `pointerup` already opened the editor, clicks #2/#3 hit the active-region guard and ProseMirror handles word/para select natively |
+| Cross-block drag (selection spans blocks) | activation suppressed, selection preserved for copying (decision 1, 2026-07-07) |
+| Drag contained in block A, released over block B | classifies cross-block relative to B → suppressed, selection preserved |
+| Drag across styled inlines (bold/em) | coords land on glyphs; `posAtCoords` doesn't care about inline structure |
+| Double-click word-select | first click's `pointerup` already opened the editor, so the second click hits the active-region guard and ProseMirror handles word-select natively — not this path |
+| Drag ends outside any block | `findEditTarget` returns null → no activation (unchanged) |
+| Click-switch (editor A open, drag in block B) | flows through the same `activate()` chokepoint → works |
+| Self-heal remount | ref already cleared → end-of-block (unchanged, per read-once) |
+| `richTextAvailable` false → textarea surface | textarea ignores the ref (today it already ignores coords); unchanged |
+
+### Decisions (2026-07-07, user)
+
+1. **Cross-block drags: suppress activation** (included in this work, § 2
+   above). Today the release block activates and the DOM swap destroys the
+   selection — bad for plain copy gestures. The user has separate follow-ups
+   planned around rich-text activation mechanisms; this improvement stands on
+   its own. *(Within-block copy-drags are incidentally fixed too: the
+   selection survives into the editor.)*
+2. **Drag releasing outside every block: leave as-is** (nothing activates).
+   The dominant use cases are short "drag, then bold / link" selections;
+   resolving the target from the selection's ancestor is corner-casey,
+   brittle, and too early in the feature's life.
+
+## Work items (TDD ordering)
+
+### Phase 0 — tests first
+
+- [x] Unit: `dragSelectionCapture.test.ts` — mocked selection/ranges:
+  contained → `{kind:'range'}` with direction-aware anchor/head; cross-block →
+  `'suppress'`; collapsed → caret; `rangeCount === 0` → caret; empty
+  `getClientRects()` → caret; invalid endpoint offset → caret.
+- [x] Unit: extend `caretFromClick.test.ts` — `placeSelectionFromDrag` against
+  a REAL EditorState (richTextSchema): both-hit → selection dispatched with
+  direction preserved + focus, `true`; either-miss → nothing moved, `false`;
+  degenerate same-pos → `false`.
+- [x] Integration: `RichTextEditor.caret.integration.test.tsx` — mount with a
+  `range` payload → `placeSelectionFromDrag` called with both coord pairs;
+  range-miss → caret fallback at head; ref read-and-cleared; `caret` payload
+  keeps existing path (regression).
+- [x] Integration: `useBlockEditHover.caret-coords.integration.test.tsx` —
+  mouse `pointerup` with stubbed contained selection stashes a `range`
+  payload; with cross-block selection `setEditTarget` is NOT called
+  (suppression); keyboard activation with a live selection still opens
+  (suppression is mouse-only); keyboard/touch stash nothing (regression).
+- [x] Run new tests, verify they fail (2026-07-07: 11 fail for missing
+  module/export + old ref name; pre-existing caret tests still pass).
+  Note: integration tests run via `npm run test:integration`
+  (`vitest.integration.config.ts`) — the default config excludes them.
+
+### Phase 1 — implementation
+
+- [x] `PreviewContext.tsx` / `PreviewRoot.tsx`: ref renamed
+  `pendingClickCoordsRef` → `pendingOpenSelectionRef`, union payload
+  (`PendingOpenSelection`), doc comments updated.
+- [x] New `dragSelectionCapture.ts` pure helper (`classifyOpenSelection` +
+  the `PendingOpenSelection` type; endpoint coords via collapsed clone-range
+  rects, `ownerDocument`-relative selection lookup for iframe safety).
+- [x] `useBlockEditHover.tsx` `activate()`: classify after the dedup guard and
+  before any side effect; `'suppress'` returns early; stash payload at the
+  single chokepoint.
+- [x] `caretFromClick.ts`: `placeSelectionFromDrag` via
+  `TextSelection.between(resolve(anchor), resolve(head))` (direction
+  preserved, endpoints nudged to valid text positions; empty ⇒ false so the
+  caret fallback owns collapsed cases).
+- [x] `RichTextEditor.tsx` mount effect: fallback chain range → caret → end.
+- [x] preview-renderer suites green (2026-07-07: 508 unit + 533 integration
+  passed, 0 failed).
+- [ ] `npm run test:ci` (hub-client) green.
+
+### Phase 2 — end-to-end verification
+
+- [x] Playwright e2e `q2-preview-spa/e2e/drag-selection-open.spec.ts` — real
+  trusted mouse drags via `mouse.down/move/up` against the real `q2` binary
+  (embedded SPA rebuilt first: `cargo xtask build-q2-preview-spa` +
+  `cargo build -p quarto --bin q2`). Three tests, all passed 2026-07-07:
+  forward drag (editor selection === selection recorded at `pointerup` in a
+  capture-phase listener), backward drag (direction preserved), cross-block
+  drag (no editor, selection intact). `npx playwright test
+  drag-selection-open` → `3 passed (2.4s)`.
+- [x] Manual (2026-07-07): `./target/debug/q2 preview repro.qmd --allow-edit`
+  (fresh binary), drove the preview at `http://127.0.0.1:62037/` via
+  chrome-devtools MCP. With the DOM selection "quick brown fox jumps over the
+  lazy" in the first paragraph, `pointerup` opened the rich-text editor with
+  `selectionType: "Range"`, `selectionText: "quick brown fox jumps over the
+  lazy"`, selection anchored inside `.ProseMirror` (screenshot inspected —
+  highlight visible in the open editor). Clicking the toolbar **B** on the
+  carried selection produced exactly
+  `<strong>quick brown fox jumps over the lazy</strong>` — the
+  selection-driven-toolbar fluidity this strand is for.
+- [ ] Full `cargo xtask verify` (covers Rust legs + ts-packages builds +
+  hub-client `build:all` + `test:ci`).
+
+## Notes
+
+- `posAtCoords` endpoint bias: the PoC resolved `|quick` / `lazy|` exactly at
+  word boundaries, so no bias correction is planned. If e2e shows a
+  one-position drift at line wraps, clamp/bias there — not speculatively.
+- Timing: selection is final by `pointerup` for drags (browsers build it
+  during `pointermove`; verified readable in capture phase). The e2e test
+  locks this in with trusted events.
+- jsdom can't do geometry (`posAtCoords`/`getClientRects` are null/empty) —
+  unit tests mock the view/ranges, geometry truth lives in the e2e test. Same
+  split bd-q9lyghv2 used.

--- a/claude-notes/plans/2026-07-07-preview-drag-selection-into-richtext.md
+++ b/claude-notes/plans/2026-07-07-preview-drag-selection-into-richtext.md
@@ -231,7 +231,12 @@ Mount-effect fallback chain (inside the existing rAF):
 - [x] `RichTextEditor.tsx` mount effect: fallback chain range → caret → end.
 - [x] preview-renderer suites green (2026-07-07: 508 unit + 533 integration
   passed, 0 failed).
-- [ ] `npm run test:ci` (hub-client) green.
+- [x] `npm run test:ci` (hub-client): unit + integration legs green; the
+  `test:wasm` leg fails on the PRE-EXISTING `changelog.md renders
+  successfully` test — the 2026-07-07 changelog entry's literal `~37MB`
+  parses as an unclosed subscript (Q-2-17). Broken on main (commit
+  `6cd4dd5a`), unrelated to this strand; an open PR already fixes it
+  (bd-5px05kui filed and closed as duplicate).
 
 ### Phase 2 — end-to-end verification
 
@@ -253,8 +258,17 @@ Mount-effect fallback chain (inside the existing rAF):
   carried selection produced exactly
   `<strong>quick brown fox jumps over the lazy</strong>` — the
   selection-driven-toolbar fluidity this strand is for.
-- [ ] Full `cargo xtask verify` (covers Rust legs + ts-packages builds +
-  hub-client `build:all` + `test:ci`).
+- [x] Full `cargo xtask verify` (2026-07-07): Rust build + tests, ts-packages
+  builds, hub-client `build:all` all green; hub-client tests green except the
+  pre-existing changelog.md Q-2-17 failure noted above (fix in flight in an
+  open PR, independent of this change).
+
+## Outcome
+
+Shipped as `4af08ef3` (feature) + `d116a917` (hub-client changelog entry) on
+branch `braid/bd-abo9m23f-drag-selection-richtext`, 2026-07-07, rebased onto
+main's `658026d0` (which fixed the pre-existing changelog Q-2-17 failure noted
+above). Strand bd-abo9m23f closed.
 
 ## Notes
 

--- a/hub-client/changelog.md
+++ b/hub-client/changelog.md
@@ -17,6 +17,7 @@ be in reverse chronological order (latest first).
 
 ### 2026-07-07
 
+- [`4af08ef3`](https://github.com/quarto-dev/q2/commits/4af08ef3): Dragging a text selection in the preview now opens the rich-text editor with that selection already active (so Bold/Italic/Link apply immediately); a selection dragged across multiple blocks no longer opens an editor, keeping the selection available for copying.
 - [`6cfc098f`](https://github.com/quarto-dev/q2/commits/6cfc098f): Raised the service-worker precache size limit so the (now about 37 MB) WASM module is cached again for offline use, and to stop continued WASM growth from breaking the production build.
 
 ### 2026-07-06

--- a/q2-preview-spa/e2e/drag-selection-open.spec.ts
+++ b/q2-preview-spa/e2e/drag-selection-open.spec.ts
@@ -1,0 +1,218 @@
+/**
+ * bd-abo9m23f — a mouse drag inside a single block must open the rich-text
+ * editor with the dragged selection recreated (not a bare caret at the
+ * release point), and a drag spanning blocks must not open an editor at all
+ * (it would destroy a selection the user may only want to copy).
+ *
+ * Real-binary e2e (drives target/debug/q2 via startPreviewServer) with REAL
+ * trusted mouse drags (`mouse.down/move/up`) — the only place the browser's
+ * own drag→selection→pointerup pipeline and posAtCoords geometry are
+ * exercised; unit tests mock both (jsdom has no layout). The invariant
+ * asserted is exactly the feature's contract: the editor's opening selection
+ * equals the native selection that existed at `pointerup`.
+ *
+ * Build chain prerequisite (the binary does NOT auto-rebuild the embedded SPA):
+ *   cargo xtask build-q2-preview-spa
+ *   cargo build -p quarto --bin q2
+ */
+
+import { test, expect, type Page } from '@playwright/test';
+import { startPreviewServer, type PreviewServerHandle } from './helpers/previewServer';
+
+let server: PreviewServerHandle;
+
+const FIXTURE = [
+    '---',
+    'title: Drag selection e2e',
+    '---',
+    '',
+    'The quick brown fox jumps over the lazy dog in the first paragraph.',
+    '',
+    'A second paragraph sits below with more words to select across.',
+    '',
+].join('\n');
+
+/** Page-viewport coordinates of a word edge inside a preview block (the
+ *  preview renders in an iframe, so the iframe offset is added). `inset`
+ *  nudges the point INTO the word so the drag press lands on a glyph, not on
+ *  the boundary between two characters. */
+async function wordPoint(
+    page: Page,
+    blockIndex: number,
+    word: string,
+    edge: 'start' | 'end',
+): Promise<{ x: number; y: number }> {
+    const iframeBox = await page.locator('iframe').boundingBox();
+    if (!iframeBox) throw new Error('preview iframe has no bounding box');
+    const rel = await page
+        .frameLocator('iframe')
+        .locator('p[data-block-pool-id]')
+        .nth(blockIndex)
+        .evaluate((el, args: { word: string; edge: 'start' | 'end' }) => {
+            const doc = el.ownerDocument;
+            const walker = doc.createTreeWalker(el, NodeFilter.SHOW_TEXT);
+            while (walker.nextNode()) {
+                const n = walker.currentNode as Text;
+                const idx = (n.textContent ?? '').indexOf(args.word);
+                if (idx < 0) continue;
+                const r = doc.createRange();
+                r.setStart(n, args.edge === 'start' ? idx : idx + args.word.length);
+                r.collapse(true);
+                const rect = r.getClientRects()[0];
+                if (!rect) throw new Error(`no caret rect for "${args.word}"`);
+                const inset = args.edge === 'start' ? 1 : -1;
+                return { x: rect.left + inset, y: rect.top + rect.height / 2 };
+            }
+            throw new Error(`word not found in block: "${args.word}"`);
+        }, { word, edge });
+    return { x: iframeBox.x + rel.x, y: iframeBox.y + rel.y };
+}
+
+/** Record, in the iframe, the native selection text as it stands when
+ *  `pointerup` fires (capture phase — before React's activation handler). */
+async function armPointerupSelectionRecorder(page: Page): Promise<void> {
+    await page.frameLocator('iframe').locator('body').evaluate((body) => {
+        const win = body.ownerDocument.defaultView as Window & {
+            __selAtPointerup?: string | null;
+        };
+        win.__selAtPointerup = null;
+        win.addEventListener(
+            'pointerup',
+            () => {
+                win.__selAtPointerup =
+                    win.getSelection()?.toString() ?? null;
+            },
+            true,
+        );
+    });
+}
+
+/** Snapshot the iframe's editor/selection state. */
+async function editorState(page: Page) {
+    return page.frameLocator('iframe').locator('body').evaluate((body) => {
+        const win = body.ownerDocument.defaultView as Window & {
+            __selAtPointerup?: string | null;
+        };
+        const sel = win.getSelection();
+        const pm = body.querySelector('.ProseMirror');
+        let backward = false;
+        if (sel && !sel.isCollapsed && sel.anchorNode && sel.focusNode) {
+            backward =
+                sel.anchorNode === sel.focusNode
+                    ? sel.focusOffset < sel.anchorOffset
+                    : !!(
+                          sel.anchorNode.compareDocumentPosition(sel.focusNode) &
+                          Node.DOCUMENT_POSITION_PRECEDING
+                      );
+        }
+        return {
+            recordedAtPointerup: win.__selAtPointerup ?? null,
+            editorOpen: pm != null,
+            textareaOpen: body.querySelector('textarea') != null,
+            selText: sel?.toString() ?? '',
+            collapsed: sel?.isCollapsed ?? true,
+            backward,
+            selInEditor:
+                pm != null && sel?.anchorNode != null
+                    ? pm.contains(sel.anchorNode)
+                    : false,
+        };
+    });
+}
+
+async function dragOpen(page: Page): Promise<void> {
+    server = await startPreviewServer({
+        allowEdit: true,
+        fixtureFiles: [{ path: 'index.qmd', content: FIXTURE }],
+    });
+    await page.goto(server.url);
+    await page.waitForFunction(() => {
+        const inner = document.querySelector('iframe')?.contentDocument;
+        return inner?.querySelector('p[data-block-pool-id]') != null;
+    }, null, { timeout: 30_000 });
+    await armPointerupSelectionRecorder(page);
+}
+
+async function drag(page: Page, from: { x: number; y: number }, to: { x: number; y: number }) {
+    await page.mouse.move(from.x, from.y);
+    await page.mouse.down();
+    await page.mouse.move(to.x, to.y, { steps: 12 });
+    await page.mouse.up();
+}
+
+test.describe('bd-abo9m23f — drag selection carries into the rich-text editor', () => {
+    test.setTimeout(120_000);
+
+    test.afterEach(async () => {
+        await server?.stop();
+    });
+
+    test('forward drag within one paragraph opens the editor with the dragged selection', async ({ page }) => {
+        await dragOpen(page);
+
+        const from = await wordPoint(page, 0, 'quick', 'start');
+        const to = await wordPoint(page, 0, 'lazy', 'end');
+        await drag(page, from, to);
+
+        await page.frameLocator('iframe').locator('.ProseMirror').waitFor({ timeout: 10_000 });
+        // Selection placement runs one rAF after mount — poll rather than race it.
+        await expect
+            .poll(async () => (await editorState(page)).collapsed, {
+                message: 'editor selection should become non-collapsed',
+                timeout: 5_000,
+            })
+            .toBe(false);
+
+        const state = await editorState(page);
+        expect(state.editorOpen).toBe(true);
+        // The contract: what the user had selected at pointerup is what the
+        // editor opens with.
+        expect(state.recordedAtPointerup).toBeTruthy();
+        expect(state.selText).toBe(state.recordedAtPointerup);
+        expect(state.selText).toContain('brown fox jumps');
+        expect(state.selInEditor).toBe(true);
+        expect(state.backward).toBe(false);
+    });
+
+    test('backward drag preserves selection direction (head at the release end)', async ({ page }) => {
+        await dragOpen(page);
+
+        // Drag right-to-left: press at the end of "lazy", release at "quick".
+        const from = await wordPoint(page, 0, 'lazy', 'end');
+        const to = await wordPoint(page, 0, 'quick', 'start');
+        await drag(page, from, to);
+
+        await page.frameLocator('iframe').locator('.ProseMirror').waitFor({ timeout: 10_000 });
+        await expect
+            .poll(async () => (await editorState(page)).collapsed, {
+                message: 'editor selection should become non-collapsed',
+                timeout: 5_000,
+            })
+            .toBe(false);
+
+        const state = await editorState(page);
+        expect(state.selText).toBe(state.recordedAtPointerup);
+        expect(state.selText).toContain('brown fox jumps');
+        expect(state.selInEditor).toBe(true);
+        expect(state.backward, 'a right-to-left drag must stay backward in the editor').toBe(true);
+    });
+
+    test('cross-block drag opens no editor and leaves the selection intact', async ({ page }) => {
+        await dragOpen(page);
+
+        const from = await wordPoint(page, 0, 'jumps', 'start');
+        const to = await wordPoint(page, 1, 'below', 'end');
+        await drag(page, from, to);
+
+        // Nothing should open; give the (absent) activation a beat to misfire.
+        await page.waitForTimeout(800);
+
+        const state = await editorState(page);
+        expect(state.editorOpen, 'cross-block drag must not open the rich-text editor').toBe(false);
+        expect(state.textareaOpen, 'cross-block drag must not open the plain editor').toBe(false);
+        // The user's selection survives (this is what enables copy).
+        expect(state.collapsed).toBe(false);
+        expect(state.selText).toContain('lazy dog in the first paragraph.');
+        expect(state.selText).toContain('A second paragraph');
+    });
+});

--- a/ts-packages/preview-renderer/src/q2-preview/PreviewContext.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/PreviewContext.tsx
@@ -4,6 +4,7 @@ import type { BlockNode } from '../framework/types';
 import type { ReachabilityClass, SourceIndexEntry, ResolvedSource } from './sourceIndex';
 import type { MutableRefObject } from 'react';
 import type { CaretHint } from './caretGeometry';
+import type { PendingOpenSelection } from './dragSelectionCapture';
 
 /**
  * q2-preview-specific context. Carries values that don't belong on the
@@ -100,21 +101,26 @@ export interface PreviewContextValue {
      */
     editDraftRef?: MutableRefObject<string | null>;
     /**
-     * Viewport coordinates of the mouse click that activated the current edit
-     * target, or null for keyboard / touch activation (bd-q9lyghv2). Written by
-     * `useBlockEditHover`'s mouse `onPointerUp` (the single activation site that
-     * opens a block — both fresh-open and click-switch flow through it) and read
-     * exactly ONCE by `RichTextEditor` at mount, which uses `posAtCoords` to land
-     * the caret where the user clicked instead of at end-of-block.
+     * The opening-selection payload of the mouse gesture that activated the
+     * current edit target, or null for keyboard / touch activation
+     * (bd-q9lyghv2, extended for drags by bd-abo9m23f):
+     *  - `{ kind: 'caret', head }` — plain click; place the caret at the
+     *    click's viewport coords.
+     *  - `{ kind: 'range', anchor, head }` — drag selection contained in the
+     *    activated block; recreate it (direction-aware) in the editor.
+     * Written by `useBlockEditHover`'s `activate()` (the single activation
+     * site that opens a block — both fresh-open and click-switch flow through
+     * it) and read exactly ONCE by `RichTextEditor` at mount, which replays
+     * the coords through `posAtCoords` instead of focusing end-of-block.
      *
-     * The reader CLEARS it after consuming so a self-heal re-anchor remount can't
-     * reuse a stale click (after a reflow the coordinates point at the wrong
-     * glyph) — that remount correctly falls back to end-of-block.
+     * The reader CLEARS it after consuming so a self-heal re-anchor remount
+     * can't reuse stale coordinates (after a reflow they point at the wrong
+     * glyphs) — that remount correctly falls back to end-of-block.
      *
      * A `MutableRefObject` is referentially stable, so exposing it here does NOT
      * cause extra re-renders.
      */
-    pendingClickCoordsRef?: MutableRefObject<{ x: number; y: number } | null>;
+    pendingOpenSelectionRef?: MutableRefObject<PendingOpenSelection | null>;
     /** SourceInfo-value index from the untransformed AST (Plan 2a). Built once per render. */
     sourceIndex?: Map<string, SourceIndexEntry> | null;
     /** Resolve a transformed block to its source counterpart + reachability class (Plan 2a). */

--- a/ts-packages/preview-renderer/src/q2-preview/PreviewRoot.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/PreviewRoot.tsx
@@ -33,6 +33,7 @@ import { buildNestingCommitDestination, buildNestingSurfaces, parentSurface, chi
 import type { NestingSurface } from './nestingNav';
 import type { CaretHint } from './caretGeometry';
 import { prefixWidth } from './caretGeometry';
+import type { PendingOpenSelection } from './dragSelectionCapture';
 
 /**
  * §2 Phase 0: a landing-resolution spec — what the reland (or the synchronous
@@ -270,11 +271,13 @@ export function PreviewRoot(props: PreviewRootProps) {
     // activation; reset to null on close. Referentially stable → no extra
     // re-renders from draft changes.
     const editDraftRef = useRef<string | null>(null);
-    // bd-q9lyghv2 caret-at-click: viewport coords of the mouse click that opened
-    // the current editor (null for keyboard/touch). Written by useBlockEditHover's
-    // onPointerUp; read+cleared once by RichTextEditor at mount to place the caret
-    // at the click via posAtCoords. Referentially stable → no extra re-renders.
-    const pendingClickCoordsRef = useRef<{ x: number; y: number } | null>(null);
+    // bd-q9lyghv2 caret-at-click / bd-abo9m23f drag-selection: opening-selection
+    // payload of the mouse gesture that opened the current editor — caret coords
+    // for a click, anchor+head coords for a contained drag selection (null for
+    // keyboard/touch). Written by useBlockEditHover's activate(); read+cleared
+    // once by RichTextEditor at mount, replayed via posAtCoords. Referentially
+    // stable → no extra re-renders.
+    const pendingOpenSelectionRef = useRef<PendingOpenSelection | null>(null);
     // §7 expand-on-edit: mirrors the expanded state of the current editor.
     // Written at EVERY open (activate / openEditTarget) so:
     //   - Remounts read the correct value (PRESERVED).
@@ -1524,7 +1527,7 @@ export function PreviewRoot(props: PreviewRootProps) {
                 editTarget,
                 setEditTarget,
                 editDraftRef,
-                pendingClickCoordsRef,
+                pendingOpenSelectionRef,
                 editExpandedRef,
                 activeEditRegionRef,
                 editTargetRef,

--- a/ts-packages/preview-renderer/src/q2-preview/dragSelectionCapture.test.ts
+++ b/ts-packages/preview-renderer/src/q2-preview/dragSelectionCapture.test.ts
@@ -1,0 +1,197 @@
+// @vitest-environment jsdom
+/**
+ * Unit tests for classifyOpenSelection (bd-abo9m23f).
+ *
+ * When a mouse click/drag activates a block, the opening DOM selection is
+ * classified into one of three outcomes:
+ *  - a non-collapsed selection fully inside the activated block → `range`
+ *    payload carrying direction-aware anchor/head viewport coords;
+ *  - a non-collapsed selection NOT contained in the block (cross-block drag)
+ *    → `'suppress'` (the activation is aborted, preserving the selection);
+ *  - anything else (collapsed, no ranges, unreadable endpoint geometry) →
+ *    `caret` payload with the click coords (the bd-q9lyghv2 behavior).
+ *
+ * jsdom has no layout, so endpoint rects (collapsed Range.getClientRects) are
+ * mocked: x = startOffset * 10, line top 100, height 20. Real geometry is
+ * covered by the Playwright e2e drag test.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { classifyOpenSelection } from './dragSelectionCapture';
+
+let block: HTMLParagraphElement;
+let otherBlock: HTMLParagraphElement;
+let blockText: Text;
+let otherText: Text;
+
+const CLICK = { x: 400, y: 110 };
+
+const caretRect = (offset: number): DOMRect =>
+    ({
+        left: offset * 10,
+        right: offset * 10,
+        top: 100,
+        bottom: 120,
+        height: 20,
+        width: 0,
+        x: offset * 10,
+        y: 100,
+        toJSON: () => ({}),
+    }) as DOMRect;
+
+// jsdom does not implement Range client-rect geometry (spyOn has nothing to
+// hook), so install the synthetic implementations with defineProperty and
+// restore the original descriptors afterwards. `rectsImpl` is swappable
+// per-test (the "no rects" case).
+let rectsImpl: (r: Range) => DOMRect[];
+const savedDescriptors: Array<[string, PropertyDescriptor | undefined]> = [];
+
+beforeEach(() => {
+    document.body.innerHTML = '';
+    block = document.createElement('p');
+    block.setAttribute('data-block-pool-id', '5');
+    blockText = document.createTextNode('the quick brown fox jumps');
+    block.appendChild(blockText);
+    otherBlock = document.createElement('p');
+    otherBlock.setAttribute('data-block-pool-id', '6');
+    otherText = document.createTextNode('another paragraph entirely');
+    otherBlock.appendChild(otherText);
+    document.body.append(block, otherBlock);
+
+    // Synthetic endpoint geometry: a collapsed range at offset N in a text
+    // node reports a caret rect at x = N * 10 on a line spanning y 100..120.
+    rectsImpl = (r) => [caretRect(r.startOffset)];
+    for (const name of ['getClientRects', 'getBoundingClientRect'] as const) {
+        savedDescriptors.push([
+            name,
+            Object.getOwnPropertyDescriptor(Range.prototype, name),
+        ]);
+        Object.defineProperty(Range.prototype, name, {
+            value: function (this: Range) {
+                const rects = rectsImpl(this);
+                return name === 'getClientRects'
+                    ? (rects as unknown as DOMRectList)
+                    : (rects[0] ??
+                          ({ left: 0, right: 0, top: 0, bottom: 0, height: 0,
+                             width: 0, x: 0, y: 0, toJSON: () => ({}) } as DOMRect));
+            },
+            configurable: true,
+            writable: true,
+        });
+    }
+});
+
+afterEach(() => {
+    for (const [name, desc] of savedDescriptors.splice(0)) {
+        if (desc) Object.defineProperty(Range.prototype, name, desc);
+        else delete (Range.prototype as any)[name];
+    }
+    vi.restoreAllMocks();
+});
+
+/** Install a fake window.getSelection reporting the given endpoints. The
+ *  normalized range (start = earlier endpoint) is derived for containment. */
+function setSelection(
+    anchorNode: Node,
+    anchorOffset: number,
+    focusNode: Node,
+    focusOffset: number,
+    opts: { collapsed?: boolean; rangeCount?: number } = {},
+) {
+    const backward =
+        anchorNode === focusNode
+            ? focusOffset < anchorOffset
+            : !!(
+                  anchorNode.compareDocumentPosition(focusNode) &
+                  Node.DOCUMENT_POSITION_PRECEDING
+              );
+    const [startContainer, endContainer] = backward
+        ? [focusNode, anchorNode]
+        : [anchorNode, focusNode];
+    const sel = {
+        isCollapsed: opts.collapsed ?? false,
+        rangeCount: opts.rangeCount ?? 1,
+        anchorNode,
+        anchorOffset,
+        focusNode,
+        focusOffset,
+        getRangeAt: () => ({ startContainer, endContainer }),
+    };
+    vi.spyOn(window, 'getSelection').mockReturnValue(sel as unknown as Selection);
+}
+
+describe('classifyOpenSelection', () => {
+    it('returns a caret payload with the click coords when there is no selection', () => {
+        vi.spyOn(window, 'getSelection').mockReturnValue(null);
+        expect(classifyOpenSelection(block, CLICK)).toEqual({
+            kind: 'caret',
+            head: CLICK,
+        });
+    });
+
+    it('returns a caret payload when the selection is collapsed (plain click)', () => {
+        setSelection(blockText, 4, blockText, 4, { collapsed: true });
+        expect(classifyOpenSelection(block, CLICK)).toEqual({
+            kind: 'caret',
+            head: CLICK,
+        });
+    });
+
+    it('returns a caret payload when the selection has no ranges', () => {
+        setSelection(blockText, 0, blockText, 5, { rangeCount: 0 });
+        expect(classifyOpenSelection(block, CLICK)).toEqual({
+            kind: 'caret',
+            head: CLICK,
+        });
+    });
+
+    it('maps a contained forward drag to a range payload (anchor before head)', () => {
+        // "quick" (offset 4) dragged to after "fox" (offset 19).
+        setSelection(blockText, 4, blockText, 19);
+        expect(classifyOpenSelection(block, CLICK)).toEqual({
+            kind: 'range',
+            anchor: { x: 40, y: 110 },
+            head: { x: 190, y: 110 },
+        });
+    });
+
+    it('preserves direction for a backward drag (anchor after head)', () => {
+        // Dragged right-to-left: anchor at 19, focus (release point) at 4.
+        setSelection(blockText, 19, blockText, 4);
+        expect(classifyOpenSelection(block, CLICK)).toEqual({
+            kind: 'range',
+            anchor: { x: 190, y: 110 },
+            head: { x: 40, y: 110 },
+        });
+    });
+
+    it("suppresses activation when the selection crosses out of the block", () => {
+        // Starts in the activated block, ends in the next one.
+        setSelection(blockText, 4, otherText, 7);
+        expect(classifyOpenSelection(block, CLICK)).toBe('suppress');
+    });
+
+    it('suppresses activation when the selection lives entirely in ANOTHER block', () => {
+        // Drag happened in block A; release (activation) landed on block B.
+        setSelection(otherText, 0, otherText, 7);
+        expect(classifyOpenSelection(block, CLICK)).toBe('suppress');
+    });
+
+    it('falls back to caret when endpoint geometry is unreadable (no rects)', () => {
+        setSelection(blockText, 4, blockText, 19);
+        rectsImpl = () => [];
+        expect(classifyOpenSelection(block, CLICK)).toEqual({
+            kind: 'caret',
+            head: CLICK,
+        });
+    });
+
+    it('falls back to caret when an endpoint offset is invalid for its node', () => {
+        // setStart throws (offset beyond node length) → unreadable geometry.
+        setSelection(blockText, 4, blockText, 9999);
+        expect(classifyOpenSelection(block, CLICK)).toEqual({
+            kind: 'caret',
+            head: CLICK,
+        });
+    });
+});

--- a/ts-packages/preview-renderer/src/q2-preview/dragSelectionCapture.ts
+++ b/ts-packages/preview-renderer/src/q2-preview/dragSelectionCapture.ts
@@ -1,0 +1,113 @@
+// dragSelectionCapture.ts (bd-abo9m23f) — classify the DOM selection at a
+// mouse activation into the editor's opening-selection payload.
+//
+// bd-q9lyghv2 bridged a mouse CLICK across the render→editor DOM swap by
+// stashing the click's viewport coordinates and replaying them through
+// posAtCoords at editor mount. This module extends that bridge to a mouse
+// DRAG: when the user releases a drag whose selection is fully contained in
+// the block being activated, we capture BOTH selection endpoints (viewport
+// coords, direction-aware) so the editor can open with the equivalent
+// selection instead of a bare caret — making the selection-driven toolbar
+// (bold, link, …) immediately usable.
+//
+// A selection that reaches OUTSIDE the activated block can't be represented
+// in the single-block editor. Worse, activating would swap the DOM under the
+// user's feet and destroy a selection they may have made just to copy text —
+// so cross-block drags suppress the activation entirely.
+//
+// Same geometric premise as caret-at-click: the editor renders the same
+// visual text in the same measured box (same theme CSS), so endpoint
+// coordinates captured before the swap land on the same glyphs after it.
+// jsdom can't do this geometry (getClientRects is empty) — unit tests mock
+// the rects; truth lives in the browser e2e test.
+
+/** A point in viewport (client) coordinate space. */
+export interface ViewportPoint {
+    x: number;
+    y: number;
+}
+
+/**
+ * The opening-selection payload stashed on `pendingOpenSelectionRef` by the
+ * activation site and consumed (read-once) by `RichTextEditor` at mount.
+ *
+ * - `caret`: place the caret at `head` (the click / release point) — the
+ *   bd-q9lyghv2 behavior.
+ * - `range`: recreate a drag selection from `anchor` to `head`. Direction is
+ *   preserved (`head` is the selection's focus — where the drag released) so
+ *   Shift-Arrow keeps extending from the right end.
+ */
+export type PendingOpenSelection =
+    | { kind: 'caret'; head: ViewportPoint }
+    | { kind: 'range'; anchor: ViewportPoint; head: ViewportPoint };
+
+/**
+ * Classify the live DOM selection for a mouse activation of `outerBlock`.
+ *
+ * @returns
+ * - `{ kind: 'range', anchor, head }` — non-collapsed selection fully inside
+ *   `outerBlock`, endpoints readable → open with the equivalent selection.
+ * - `'suppress'` — non-collapsed selection NOT contained in `outerBlock`
+ *   (cross-block drag) → caller must abort the activation, leaving the
+ *   user's selection intact.
+ * - `{ kind: 'caret', head: clickCoords }` — everything else (collapsed
+ *   selection i.e. plain click, no ranges, unreadable endpoint geometry) →
+ *   today's caret-at-click behavior.
+ *
+ * Mouse-only by construction: keyboard/touch activations carry no click
+ * coords and never reach this classification.
+ */
+export function classifyOpenSelection(
+    outerBlock: Element,
+    clickCoords: ViewportPoint,
+): PendingOpenSelection | 'suppress' {
+    const caret: PendingOpenSelection = { kind: 'caret', head: clickCoords };
+    const doc = outerBlock.ownerDocument;
+    // ownerDocument-relative, not the bare global: the preview runs inside an
+    // iframe and must read that iframe's selection.
+    const sel = doc.defaultView?.getSelection();
+    if (!sel || sel.isCollapsed || sel.rangeCount === 0) return caret;
+
+    const range = sel.getRangeAt(0);
+    const contained =
+        outerBlock.contains(range.startContainer) &&
+        outerBlock.contains(range.endContainer);
+    if (!contained) return 'suppress';
+
+    // Endpoint coords come from the SELECTION's anchor/focus (not the
+    // normalized range start/end) so a backward drag keeps its direction.
+    const anchor = endpointViewportPoint(doc, sel.anchorNode, sel.anchorOffset);
+    const head = endpointViewportPoint(doc, sel.focusNode, sel.focusOffset);
+    if (!anchor || !head) return caret;
+
+    return { kind: 'range', anchor, head };
+}
+
+/**
+ * Viewport coordinates of a selection endpoint, via a collapsed range's
+ * client rect. Vertically centered in the endpoint's line box so the replayed
+ * posAtCoords lands inside the line, not on its boundary.
+ *
+ * Returns null when the geometry is unreadable (invalid offset, or no rect —
+ * e.g. an endpoint between element boundaries); the caller falls back to the
+ * caret payload.
+ */
+function endpointViewportPoint(
+    doc: Document,
+    node: Node | null,
+    offset: number,
+): ViewportPoint | null {
+    if (!node) return null;
+    const r = doc.createRange();
+    try {
+        r.setStart(node, offset);
+    } catch {
+        return null;
+    }
+    r.collapse(true);
+    const rect = r.getClientRects()[0] ?? r.getBoundingClientRect();
+    if (!rect || (rect.width === 0 && rect.height === 0 && rect.left === 0 && rect.top === 0)) {
+        return null;
+    }
+    return { x: rect.left, y: rect.top + rect.height / 2 };
+}

--- a/ts-packages/preview-renderer/src/q2-preview/richtext/RichTextEditor.caret.integration.test.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/richtext/RichTextEditor.caret.integration.test.tsx
@@ -1,14 +1,16 @@
 /**
- * RichTextEditor caret-at-click consume wiring (bd-q9lyghv2).
+ * RichTextEditor opening-selection consume wiring (bd-q9lyghv2, bd-abo9m23f).
  *
- * At mount the editor must read-and-clear `pendingClickCoordsRef`. When coords
- * are present it places the caret via placeCaretFromClick (the helper, unit-
- * tested separately); when absent it leaves the autofocus:'end' default. Either
- * way the ref is consumed exactly once so a re-anchor remount cannot reuse a
- * stale click.
+ * At mount the editor must read-and-clear `pendingOpenSelectionRef`, then
+ * (one frame later) apply the payload with a fallback chain:
+ *   range payload → placeSelectionFromDrag; on miss ↓
+ *   head coords   → placeCaretFromClick (caret at the release point); on miss ↓
+ *   no payload    → end-of-block focus (historical default).
+ * Either way the ref is consumed exactly once so a re-anchor remount cannot
+ * replay stale coordinates.
  *
- * Real posAtCoords geometry is browser-verified — here we mock the helper to
- * observe the wiring (was it called? with what? is the ref cleared?).
+ * Real posAtCoords geometry is browser-verified — here we mock the helpers to
+ * observe the wiring (what was called, with what, and is the ref cleared?).
  */
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
@@ -17,17 +19,22 @@ import React, { useRef } from 'react';
 import { PreviewContext } from '../PreviewContext';
 import type { PreviewContextValue } from '../PreviewContext';
 import type { ResolvedSource } from '../sourceIndex';
+import type { PendingOpenSelection } from '../dragSelectionCapture';
 import { RichTextEditor } from './RichTextEditor';
 
-// Observe the caret-placement call without needing real layout/geometry.
+// Observe the placement calls without needing real layout/geometry.
 const placeCaretFromClick = vi.fn().mockReturnValue(true);
+const placeSelectionFromDrag = vi.fn().mockReturnValue(true);
 vi.mock('./caretFromClick', () => ({
     placeCaretFromClick: (...args: unknown[]) => placeCaretFromClick(...args),
+    placeSelectionFromDrag: (...args: unknown[]) => placeSelectionFromDrag(...args),
 }));
 
 afterEach(() => {
     cleanup();
     vi.clearAllMocks();
+    placeCaretFromClick.mockReturnValue(true);
+    placeSelectionFromDrag.mockReturnValue(true);
 });
 
 // A single "hello" paragraph: pool[0] spans the whole 5-byte source.
@@ -40,18 +47,18 @@ const RESOLVED: ResolvedSource = {
     sourceEntry: { t: 0, r: [0, 5], d: 0 },
 };
 
-/** Mount RichTextEditor with a pre-seeded coords ref; expose it to the test. */
-function mountEditor(initialCoords: { x: number; y: number } | null) {
-    let coordsRef!: React.MutableRefObject<{ x: number; y: number } | null>;
+/** Mount RichTextEditor with a pre-seeded payload ref; expose it to the test. */
+function mountEditor(initialPayload: PendingOpenSelection | null) {
+    let payloadRef!: React.MutableRefObject<PendingOpenSelection | null>;
     function Host() {
-        coordsRef = useRef<{ x: number; y: number } | null>(initialCoords);
+        payloadRef = useRef<PendingOpenSelection | null>(initialPayload);
         const editDraftRef = useRef<string | null>(CONTENT);
         const ctx: PreviewContextValue = {
             currentFilePath: '/project/test.qmd',
             pool: POOL as PreviewContextValue['pool'],
             content: CONTENT,
             editDraftRef,
-            pendingClickCoordsRef: coordsRef,
+            pendingOpenSelectionRef: payloadRef,
             setEditTarget: vi.fn(),
         };
         return (
@@ -61,7 +68,7 @@ function mountEditor(initialCoords: { x: number; y: number } | null) {
         );
     }
     const utils = render(<Host />);
-    return { ...utils, getCoords: () => coordsRef.current };
+    return { ...utils, getPayload: () => payloadRef.current };
 }
 
 /** Flush a requestAnimationFrame tick (placement is deferred one frame so the
@@ -69,27 +76,61 @@ function mountEditor(initialCoords: { x: number; y: number } | null) {
 const nextFrame = () =>
     new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
 
-describe('RichTextEditor — caret-at-click consume', () => {
-    it('consumes the coords ref at mount and places the caret (next frame) when coords are present', async () => {
-        const { getCoords } = mountEditor({ x: 42, y: 117 });
+describe('RichTextEditor — opening-selection consume', () => {
+    it('consumes a caret payload at mount and places the caret (next frame)', async () => {
+        const { getPayload } = mountEditor({ kind: 'caret', head: { x: 42, y: 117 } });
 
         // The ref is consumed synchronously at mount (so a remount can't reuse a
         // stale click); placement itself is deferred one frame.
-        expect(getCoords()).toBeNull();
+        expect(getPayload()).toBeNull();
         expect(placeCaretFromClick).not.toHaveBeenCalled();
 
         await nextFrame();
 
-        // Helper invoked with the editor + the captured coords after layout settles.
         expect(placeCaretFromClick).toHaveBeenCalledTimes(1);
         expect(placeCaretFromClick.mock.calls[0][1]).toEqual({ x: 42, y: 117 });
+        expect(placeSelectionFromDrag).not.toHaveBeenCalled();
     });
 
-    it('does not place the caret (and leaves end-of-block) when no coords present', async () => {
-        const { getCoords } = mountEditor(null);
+    it('consumes a range payload and replays both endpoints (next frame)', async () => {
+        const { getPayload } = mountEditor({
+            kind: 'range',
+            anchor: { x: 10, y: 100 },
+            head: { x: 80, y: 100 },
+        });
+
+        expect(getPayload()).toBeNull();
+        await nextFrame();
+
+        expect(placeSelectionFromDrag).toHaveBeenCalledTimes(1);
+        expect(placeSelectionFromDrag.mock.calls[0][1]).toEqual({ x: 10, y: 100 });
+        expect(placeSelectionFromDrag.mock.calls[0][2]).toEqual({ x: 80, y: 100 });
+        // Range replay succeeded → no caret fallback.
+        expect(placeCaretFromClick).not.toHaveBeenCalled();
+    });
+
+    it('falls back to a caret at the head when the range replay misses', async () => {
+        placeSelectionFromDrag.mockReturnValue(false);
+        mountEditor({
+            kind: 'range',
+            anchor: { x: 10, y: 100 },
+            head: { x: 80, y: 100 },
+        });
+
+        await nextFrame();
+
+        expect(placeSelectionFromDrag).toHaveBeenCalledTimes(1);
+        // Head = release point — the bd-q9lyghv2 caret behavior.
+        expect(placeCaretFromClick).toHaveBeenCalledTimes(1);
+        expect(placeCaretFromClick.mock.calls[0][1]).toEqual({ x: 80, y: 100 });
+    });
+
+    it('places nothing (end-of-block default) when no payload is present', async () => {
+        const { getPayload } = mountEditor(null);
         await nextFrame();
 
         expect(placeCaretFromClick).not.toHaveBeenCalled();
-        expect(getCoords()).toBeNull();
+        expect(placeSelectionFromDrag).not.toHaveBeenCalled();
+        expect(getPayload()).toBeNull();
     });
 });

--- a/ts-packages/preview-renderer/src/q2-preview/richtext/RichTextEditor.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/richtext/RichTextEditor.tsx
@@ -26,7 +26,7 @@ import { buildRichTextExtensions } from './editorConfig';
 import { RichTextToolbar } from './RichTextToolbar';
 import type { AstNode, PoolEntry } from './ast';
 import { ensureRichTextStyles } from './styles';
-import { placeCaretFromClick } from './caretFromClick';
+import { placeCaretFromClick, placeSelectionFromDrag } from './caretFromClick';
 
 function commitDestination(ctx: PreviewContextValue, resolved: ResolvedSource): string | null {
   if (ctx.editTargetRef !== undefined) {
@@ -201,28 +201,39 @@ export function RichTextEditor({
   // input keeps the session open.
   const rootRef = useRef<HTMLDivElement | null>(null);
 
-  // bd-q9lyghv2 caret-at-click: own the editor's opening caret. Consume the
-  // viewport coords of the mouse click that opened this editor (stashed by
-  // useBlockEditHover) and place the caret there via posAtCoords — so the FIRST
-  // click lands the cursor where the user clicked. With no coords (keyboard/touch
-  // open, or a posAtCoords miss) we focus at end-of-block — the historical
-  // default that `autofocus:'end'` used to provide before we disabled it.
+  // bd-q9lyghv2 caret-at-click / bd-abo9m23f drag-selection: own the editor's
+  // opening selection. Consume the opening-selection payload of the mouse
+  // gesture that opened this editor (stashed by useBlockEditHover) and replay
+  // it via posAtCoords — so the FIRST gesture lands: a click places the caret
+  // at the clicked glyph, a drag recreates the dragged selection (making the
+  // selection-driven toolbar immediately usable). Fallback chain:
+  //   range payload → placeSelectionFromDrag (both endpoints); on miss ↓
+  //   head coords   → placeCaretFromClick (caret at click/release point); on miss ↓
+  //   no payload    → focus('end') — the historical default that
+  //                   `autofocus:'end'` used to provide before we disabled it.
   //
-  // Read-and-CLEAR the coords exactly once: a self-heal re-anchor can remount this
-  // editor, but by then the document has reflowed and the captured coordinates are
-  // stale (the block moved on screen), so the remount falls back to end-of-block
-  // rather than re-replaying a now-wrong click. Nulling the ref here guarantees that.
+  // Read-and-CLEAR the payload exactly once: a self-heal re-anchor can remount
+  // this editor, but by then the document has reflowed and the captured
+  // coordinates are stale (the block moved on screen), so the remount falls back
+  // to end-of-block rather than re-replaying a now-wrong gesture. Nulling the
+  // ref here guarantees that.
   //
   // The placement runs in a requestAnimationFrame so the swapped-in editor box is
   // laid out before posAtCoords reads geometry, and (with autofocus disabled)
   // nothing competes to reset the selection afterward.
   useEffect(() => {
     if (!editor) return;
-    const coords = ctx.pendingClickCoordsRef?.current ?? null;
-    if (ctx.pendingClickCoordsRef) ctx.pendingClickCoordsRef.current = null;
+    const pending = ctx.pendingOpenSelectionRef?.current ?? null;
+    if (ctx.pendingOpenSelectionRef) ctx.pendingOpenSelectionRef.current = null;
     const raf = requestAnimationFrame(() => {
       if (editor.isDestroyed) return;
-      if (coords && placeCaretFromClick(editor, coords)) return;
+      if (
+        pending?.kind === 'range' &&
+        placeSelectionFromDrag(editor, pending.anchor, pending.head)
+      ) {
+        return;
+      }
+      if (pending && placeCaretFromClick(editor, pending.head)) return;
       editor.commands.focus('end');
     });
     return () => cancelAnimationFrame(raf);

--- a/ts-packages/preview-renderer/src/q2-preview/richtext/caretFromClick.test.ts
+++ b/ts-packages/preview-renderer/src/q2-preview/richtext/caretFromClick.test.ts
@@ -10,7 +10,9 @@
  */
 
 import { describe, it, expect, vi } from 'vitest';
-import { placeCaretFromClick } from './caretFromClick';
+import { EditorState } from '@tiptap/pm/state';
+import { placeCaretFromClick, placeSelectionFromDrag } from './caretFromClick';
+import { richTextSchema } from './schema';
 
 /** Build a fake tiptap editor recording the chained caret commands. */
 function fakeEditor(posAtCoordsReturn: { pos: number; inside: number } | null) {
@@ -49,5 +51,116 @@ describe('placeCaretFromClick', () => {
         expect(placed).toBe(false);
         expect(calls.setTextSelection).toEqual([]);
         expect(calls.run).toBe(0);
+    });
+});
+
+/**
+ * placeSelectionFromDrag (bd-abo9m23f) — replay a drag selection's two
+ * endpoints. Uses a REAL EditorState (richTextSchema, one paragraph) so the
+ * TextSelection the helper builds is validated against real resolve/between
+ * semantics; only the view's coordinate lookup and dispatch are faked.
+ */
+
+/** doc: <p>hello world drag me</p> — inline positions 1..19. */
+function fakeDragEditor(coordToPos: Map<string, number | null>) {
+    const doc = richTextSchema.node('doc', null, [
+        richTextSchema.node('paragraph', null, [
+            richTextSchema.text('hello world drag me'),
+        ]),
+    ]);
+    let state = EditorState.create({ doc });
+    const calls = { dispatch: 0, focus: 0 };
+    const view = {
+        get state() { return state; },
+        posAtCoords(pt: { left: number; top: number }) {
+            const pos = coordToPos.get(`${pt.left},${pt.top}`);
+            return pos == null ? null : { pos, inside: 0 };
+        },
+        dispatch(tr: any) { calls.dispatch++; state = state.apply(tr); },
+    };
+    const editor = {
+        view,
+        commands: { focus: () => { calls.focus++; return true; } },
+    };
+    return { editor, calls, getSelection: () => state.selection };
+}
+
+describe('placeSelectionFromDrag', () => {
+    it('maps both endpoints and sets a forward range selection (direction preserved)', () => {
+        const { editor, calls, getSelection } = fakeDragEditor(
+            new Map([['10,100', 3], ['80,100', 12]]),
+        );
+
+        const placed = placeSelectionFromDrag(
+            editor as any,
+            { x: 10, y: 100 },   // anchor
+            { x: 80, y: 100 },   // head
+        );
+
+        expect(placed).toBe(true);
+        expect(calls.dispatch).toBe(1);
+        expect(calls.focus).toBeGreaterThanOrEqual(1);
+        expect(getSelection().anchor).toBe(3);
+        expect(getSelection().head).toBe(12);
+    });
+
+    it('preserves a backward drag (anchor > head)', () => {
+        const { editor, getSelection } = fakeDragEditor(
+            new Map([['80,100', 12], ['10,100', 3]]),
+        );
+
+        const placed = placeSelectionFromDrag(
+            editor as any,
+            { x: 80, y: 100 },   // anchor (drag started here)
+            { x: 10, y: 100 },   // head (released here, to the left)
+        );
+
+        expect(placed).toBe(true);
+        expect(getSelection().anchor).toBe(12);
+        expect(getSelection().head).toBe(3);
+        expect(getSelection().empty).toBe(false);
+    });
+
+    it('returns false and moves nothing when the anchor misses', () => {
+        const { editor, calls } = fakeDragEditor(new Map([['80,100', 12]]));
+
+        const placed = placeSelectionFromDrag(
+            editor as any,
+            { x: 10, y: 100 },
+            { x: 80, y: 100 },
+        );
+
+        expect(placed).toBe(false);
+        expect(calls.dispatch).toBe(0);
+    });
+
+    it('returns false and moves nothing when the head misses', () => {
+        const { editor, calls } = fakeDragEditor(new Map([['10,100', 3]]));
+
+        const placed = placeSelectionFromDrag(
+            editor as any,
+            { x: 10, y: 100 },
+            { x: 80, y: 100 },
+        );
+
+        expect(placed).toBe(false);
+        expect(calls.dispatch).toBe(0);
+    });
+
+    it('returns false when both endpoints resolve to the same position (degenerate)', () => {
+        // Caller falls back to placeCaretFromClick — same visible outcome,
+        // one code path for the caret case.
+        const { editor, calls } = fakeDragEditor(
+            new Map([['10,100', 5], ['11,100', 5]]),
+        );
+
+        const placed = placeSelectionFromDrag(
+            editor as any,
+            { x: 10, y: 100 },
+            { x: 11, y: 100 },
+        );
+
+        expect(placed).toBe(false);
+        expect(calls.dispatch).toBe(0);
     });
 });

--- a/ts-packages/preview-renderer/src/q2-preview/richtext/caretFromClick.ts
+++ b/ts-packages/preview-renderer/src/q2-preview/richtext/caretFromClick.ts
@@ -15,6 +15,7 @@
 // editor.
 
 import type { Editor } from '@tiptap/core';
+import { TextSelection } from '@tiptap/pm/state';
 
 /**
  * Move the caret to the document position under the given viewport coordinates.
@@ -31,5 +32,45 @@ export function placeCaretFromClick(
     const hit = editor.view.posAtCoords({ left: coords.x, top: coords.y });
     if (!hit) return false;
     editor.chain().focus().setTextSelection(hit.pos).run();
+    return true;
+}
+
+/**
+ * Recreate a drag selection from the viewport coordinates of its two
+ * endpoints (bd-abo9m23f). `anchor` is where the drag started, `head` where
+ * it released — passed through in that order so a backward drag stays
+ * backward and Shift-Arrow keeps extending from the release end.
+ *
+ * Uses `TextSelection.between`, which nudges each endpoint to the nearest
+ * valid text position while preserving the anchor/head roles — the raw
+ * `posAtCoords` hits may sit on structural boundaries.
+ *
+ * @returns `true` if both endpoints resolved to a non-empty selection and it
+ *   was applied; `false` otherwise (either endpoint missed, or the endpoints
+ *   collapse to a single position) — the caller falls back to
+ *   `placeCaretFromClick` with `head`, i.e. the plain caret-at-release-point
+ *   behavior.
+ */
+export function placeSelectionFromDrag(
+    editor: Editor,
+    anchor: { x: number; y: number },
+    head: { x: number; y: number },
+): boolean {
+    const view = editor.view;
+    const anchorHit = view.posAtCoords({ left: anchor.x, top: anchor.y });
+    const headHit = view.posAtCoords({ left: head.x, top: head.y });
+    if (!anchorHit || !headHit) return false;
+
+    const { state } = view;
+    const selection = TextSelection.between(
+        state.doc.resolve(anchorHit.pos),
+        state.doc.resolve(headHit.pos),
+    );
+    // Degenerate (both endpoints at one position, or no text positions found):
+    // report a miss so the caller's caret fallback owns the collapsed case.
+    if (selection.empty) return false;
+
+    view.dispatch(state.tr.setSelection(selection));
+    editor.commands.focus();
     return true;
 }

--- a/ts-packages/preview-renderer/src/q2-preview/useBlockEditHover.caret-coords.integration.test.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/useBlockEditHover.caret-coords.integration.test.tsx
@@ -1,21 +1,28 @@
 /**
- * Caret-at-click capture wiring (bd-q9lyghv2).
+ * Caret-at-click / drag-selection capture wiring (bd-q9lyghv2, bd-abo9m23f).
  *
- * When a mouse click activates a block for rich-text editing, the activating
- * click's viewport coordinates must be stashed on `pendingClickCoordsRef` so the
- * editor can place the caret at the clicked position (instead of end-of-block) at
- * mount. Keyboard and touch activation must NOT set coords (they fall back to
- * end-of-block).
+ * When a mouse click activates a block for rich-text editing, the opening
+ * pointer state must be classified and stashed on `pendingOpenSelectionRef`:
+ *  - plain click → `{ kind: 'caret', head }` (viewport coords of the click);
+ *  - drag selection contained in the activated block → `{ kind: 'range',
+ *    anchor, head }` (direction-aware endpoint coords);
+ *  - drag selection NOT contained in the block → activation is SUPPRESSED
+ *    entirely (the user's selection survives for copying).
+ * Keyboard and touch activation must NOT set a payload (end-of-block), and
+ * are never suppressed by a live selection.
  *
  * jsdom note: PointerEvent does not honour pointerType/clientX/clientY from the
  * constructor init dict — force them via Object.defineProperty (see ptrEvent).
+ * jsdom has no layout: endpoint rects come from a mocked
+ * Range.prototype.getClientRects (x = startOffset * 10, line y 100..120).
  */
 
-import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, cleanup, fireEvent } from '@testing-library/react';
 import React, { useRef } from 'react';
 import { PreviewContext } from './PreviewContext';
 import type { PreviewContextValue } from './PreviewContext';
+import type { PendingOpenSelection } from './dragSelectionCapture';
 import { useBlockEditHover } from './useBlockEditHover';
 
 afterEach(() => {
@@ -41,9 +48,11 @@ function ptrEvent(
 }
 
 const POOL_ENTRY_5 = { t: 0, r: [100, 200] as [number, number], d: 0 };
-const POOL_WITH_5: unknown[] = [
+const POOL_ENTRY_6 = { t: 0, r: [210, 300] as [number, number], d: 0 };
+const POOL: unknown[] = [
     ...Array.from({ length: 5 }, () => null),
     POOL_ENTRY_5,
+    POOL_ENTRY_6,
 ];
 
 const MOCK_RECT: DOMRect = {
@@ -56,23 +65,24 @@ function Inner() {
     return (
         <div {...hostProps} data-testid="host">
             {stylesheet}
-            <p data-block-pool-id="5" tabIndex={-1} data-testid="block5">block 5</p>
+            <p data-block-pool-id="5" tabIndex={-1} data-testid="block5">the quick brown fox</p>
+            <p data-block-pool-id="6" tabIndex={-1} data-testid="block6">another paragraph here</p>
         </div>
     );
 }
 
-/** Mount the hover host, exposing the live pendingClickCoordsRef to the test. */
+/** Mount the hover host, exposing the live pendingOpenSelectionRef to the test. */
 function mountHost() {
     const setEditTarget = vi.fn();
-    let coordsRef!: React.MutableRefObject<{ x: number; y: number } | null>;
+    let openSelRef!: React.MutableRefObject<PendingOpenSelection | null>;
     function Host() {
-        coordsRef = useRef<{ x: number; y: number } | null>(null);
+        openSelRef = useRef<PendingOpenSelection | null>(null);
         const ctx: PreviewContextValue = {
             currentFilePath: '/project/test.qmd',
             setEditTarget,
-            pool: POOL_WITH_5,
+            pool: POOL,
             content: '',
-            pendingClickCoordsRef: coordsRef,
+            pendingOpenSelectionRef: openSelRef,
         };
         return (
             <PreviewContext.Provider value={ctx}>
@@ -81,26 +91,88 @@ function mountHost() {
         );
     }
     const utils = render(<Host />);
-    return { ...utils, setEditTarget, getCoords: () => coordsRef.current };
+    return { ...utils, setEditTarget, getPayload: () => openSelRef.current };
 }
 
-describe('useBlockEditHover — caret-at-click coord capture', () => {
-    it('stashes the click viewport coords on mouse pointerup activation', () => {
-        const { getByTestId, setEditTarget, getCoords } = mountHost();
+/** Install a fake window.getSelection over real DOM nodes, plus synthetic
+ *  endpoint rects (x = startOffset * 10, line y 100..120). */
+function stubSelection(
+    anchorNode: Node, anchorOffset: number,
+    focusNode: Node, focusOffset: number,
+) {
+    const backward =
+        anchorNode === focusNode
+            ? focusOffset < anchorOffset
+            : !!(anchorNode.compareDocumentPosition(focusNode) & Node.DOCUMENT_POSITION_PRECEDING);
+    const [startContainer, endContainer] = backward
+        ? [focusNode, anchorNode]
+        : [anchorNode, focusNode];
+    vi.spyOn(window, 'getSelection').mockReturnValue({
+        isCollapsed: false,
+        rangeCount: 1,
+        anchorNode, anchorOffset, focusNode, focusOffset,
+        getRangeAt: () => ({ startContainer, endContainer }),
+    } as unknown as Selection);
+    vi.spyOn(Range.prototype, 'getClientRects').mockImplementation(function (this: Range) {
+        const rect = {
+            left: this.startOffset * 10, right: this.startOffset * 10,
+            top: 100, bottom: 120, height: 20, width: 0,
+            x: this.startOffset * 10, y: 100, toJSON: () => ({}),
+        } as DOMRect;
+        return [rect] as unknown as DOMRectList;
+    });
+}
+
+describe('useBlockEditHover — opening-selection capture', () => {
+    it('stashes a caret payload with the click coords on plain mouse pointerup', () => {
+        const { getByTestId, setEditTarget, getPayload } = mountHost();
         const block = getByTestId('block5');
         vi.spyOn(block, 'getBoundingClientRect').mockReturnValue(MOCK_RECT);
 
         fireEvent(block, ptrEvent('pointerdown', { pointerType: 'mouse', clientX: 42, clientY: 117 }));
         fireEvent(block, ptrEvent('pointerup', { pointerType: 'mouse', clientX: 42, clientY: 117 }));
 
-        // Activation happened…
         expect(setEditTarget).toHaveBeenCalledOnce();
-        // …and the click coords were captured for the editor to consume.
-        expect(getCoords()).toEqual({ x: 42, y: 117 });
+        expect(getPayload()).toEqual({ kind: 'caret', head: { x: 42, y: 117 } });
     });
 
-    it('does NOT stash coords on keyboard (Enter) activation', () => {
-        const { getByTestId, setEditTarget, getCoords } = mountHost();
+    it('stashes a direction-aware range payload for a drag contained in the block', () => {
+        const { getByTestId, setEditTarget, getPayload } = mountHost();
+        const block = getByTestId('block5');
+        vi.spyOn(block, 'getBoundingClientRect').mockReturnValue(MOCK_RECT);
+        const text = block.firstChild as Text;
+        // Backward drag: anchor at offset 15, released (focus) at offset 4.
+        stubSelection(text, 15, text, 4);
+
+        fireEvent(block, ptrEvent('pointerdown', { pointerType: 'mouse', clientX: 150, clientY: 110 }));
+        fireEvent(block, ptrEvent('pointerup', { pointerType: 'mouse', clientX: 40, clientY: 110 }));
+
+        expect(setEditTarget).toHaveBeenCalledOnce();
+        expect(getPayload()).toEqual({
+            kind: 'range',
+            anchor: { x: 150, y: 110 },
+            head: { x: 40, y: 110 },
+        });
+    });
+
+    it('suppresses activation entirely for a cross-block drag (selection preserved)', () => {
+        const { getByTestId, setEditTarget, getPayload } = mountHost();
+        const block5 = getByTestId('block5');
+        const block6 = getByTestId('block6');
+        vi.spyOn(block5, 'getBoundingClientRect').mockReturnValue(MOCK_RECT);
+        // Drag started in block 5, released over block 6 → activation target is
+        // block 6, but the selection spans out of it.
+        stubSelection(block5.firstChild as Text, 2, block6.firstChild as Text, 7);
+
+        fireEvent(block6, ptrEvent('pointerdown', { pointerType: 'mouse', clientX: 70, clientY: 160 }));
+        fireEvent(block6, ptrEvent('pointerup', { pointerType: 'mouse', clientX: 70, clientY: 160 }));
+
+        expect(setEditTarget).not.toHaveBeenCalled();
+        expect(getPayload()).toBeNull();
+    });
+
+    it('does NOT stash a payload on keyboard (Enter) activation', () => {
+        const { getByTestId, setEditTarget, getPayload } = mountHost();
         const host = getByTestId('host');
         const block = getByTestId('block5');
         vi.spyOn(block, 'getBoundingClientRect').mockReturnValue(MOCK_RECT);
@@ -110,16 +182,32 @@ describe('useBlockEditHover — caret-at-click coord capture', () => {
         fireEvent.keyDown(host, { key: 'Enter' });
 
         expect(setEditTarget).toHaveBeenCalledOnce();
-        expect(getCoords()).toBeNull();
+        expect(getPayload()).toBeNull();
     });
 
-    it('does NOT stash coords on touch hold activation', () => {
+    it('keyboard activation is NOT suppressed by a live selection elsewhere', () => {
+        const { getByTestId, setEditTarget, getPayload } = mountHost();
+        const host = getByTestId('host');
+        const block5 = getByTestId('block5');
+        const block6 = getByTestId('block6');
+        vi.spyOn(block5, 'getBoundingClientRect').mockReturnValue(MOCK_RECT);
+        // A selection lives in block 6; keyboard-activating block 5 must still work.
+        stubSelection(block6.firstChild as Text, 0, block6.firstChild as Text, 7);
+
+        fireEvent(block5, ptrEvent('pointermove', { pointerType: 'mouse' }));
+        fireEvent.keyDown(host, { key: 'Enter' });
+
+        expect(setEditTarget).toHaveBeenCalledOnce();
+        expect(getPayload()).toBeNull();
+    });
+
+    it('does NOT stash a payload on touch hold activation', () => {
         vi.useFakeTimers();
         Object.defineProperty(HTMLElement.prototype, 'setPointerCapture', {
             value: vi.fn(), writable: true, configurable: true,
         });
         try {
-            const { getByTestId, setEditTarget, getCoords } = mountHost();
+            const { getByTestId, setEditTarget, getPayload } = mountHost();
             const block = getByTestId('block5');
             vi.spyOn(block, 'getBoundingClientRect').mockReturnValue(MOCK_RECT);
 
@@ -127,7 +215,7 @@ describe('useBlockEditHover — caret-at-click coord capture', () => {
             vi.advanceTimersByTime(500);
 
             expect(setEditTarget).toHaveBeenCalledOnce();
-            expect(getCoords()).toBeNull();
+            expect(getPayload()).toBeNull();
         } finally {
             delete (HTMLElement.prototype as any).setPointerCapture;
         }

--- a/ts-packages/preview-renderer/src/q2-preview/useBlockEditHover.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/useBlockEditHover.tsx
@@ -1,6 +1,8 @@
 import React, { useCallback, useContext, useRef } from 'react';
 import { PreviewContext } from './PreviewContext';
 import { resolveOuterBlock, enumerateOuterBlocks, enumerateNestingSurfaces, captureEditTarget, measureBlockBox, seedForRange } from './outerBlocks';
+import { classifyOpenSelection } from './dragSelectionCapture';
+import type { PendingOpenSelection } from './dragSelectionCapture';
 
 const HOLD_MS = 500;
 const MOVE_THRESHOLD_PX = 8;
@@ -81,6 +83,22 @@ export function useBlockEditHover(): {
         // Dedup: if this block is already the active edit target (same byte range), do nothing.
         if (ctx?.editTarget?.anchorR0 === anchorR0) return;
 
+        // bd-abo9m23f: classify the live DOM selection for mouse opens — BEFORE
+        // any side effect below, so a suppressed activation is a true no-op.
+        //  - caret payload: plain click (caret-at-click, bd-q9lyghv2);
+        //  - range payload: drag selection contained in this block — the editor
+        //    opens with the equivalent selection;
+        //  - suppress: drag selection reaching outside this block — activating
+        //    would swap the DOM and destroy a selection the user may only want
+        //    to copy, so we don't open at all.
+        // Keyboard/touch opens carry no clickCoords and skip classification.
+        let pendingOpen: PendingOpenSelection | null = null;
+        if (opts?.clickCoords) {
+            const classified = classifyOpenSelection(outerBlock, opts.clickCoords);
+            if (classified === 'suppress') return;
+            pendingOpen = classified;
+        }
+
         // G18 clear-on-open invariant: a fresh activation supersedes any pending landing.
         // The reland paths never reach activate, so a landing present here is orphaned.
         // Clearing it ensures pendingLandingRef is always null while an editor is open,
@@ -115,13 +133,13 @@ export function useBlockEditHover(): {
         // §7: write editExpandedRef at EVERY open so remounts read the correct value
         // and hops see false (reset) rather than stale true from a prior expand.
         if (ctx.editExpandedRef) ctx.editExpandedRef.current = expandOnOpen;
-        // bd-q9lyghv2 caret-at-click: stash (mouse) or clear (keyboard/touch) the
-        // opening click's viewport coords at the single open chokepoint — after the
+        // bd-q9lyghv2 / bd-abo9m23f: stash (mouse) or clear (keyboard/touch) the
+        // opening-selection payload at the single open chokepoint — after the
         // early-return guards above, so the ref always matches the editor that is
-        // about to mount and can never hold a stale click from an earlier session.
-        // RichTextEditor reads+clears it once at mount; a null ref means
+        // about to mount and can never hold a stale gesture from an earlier
+        // session. RichTextEditor reads+clears it once at mount; a null ref means
         // end-of-block (the keyboard/touch default).
-        if (ctx.pendingClickCoordsRef) ctx.pendingClickCoordsRef.current = opts?.clickCoords ?? null;
+        if (ctx.pendingOpenSelectionRef) ctx.pendingOpenSelectionRef.current = pendingOpen;
         ctx.setEditTarget({
             anchorR0,
             anchorR1,


### PR DESCRIPTION
## Summary

In `q2 preview --allow-edit` (and hub-client's `format: q2-preview`), a mouse **drag** inside a single block now opens the rich-text editor with the dragged selection recreated — direction-aware, so a right-to-left drag keeps its focus at the release end — instead of a bare caret at the mouse-release point. This makes the selection-driven toolbar (bold, italic, link, …) immediately usable after a drag: drag, click **B**, done.

A drag whose selection spans **multiple blocks** no longer activates an editor at all. Previously the release block opened with a caret and the DOM swap destroyed the user's selection — breaking plain copy gestures.

## Mechanism

Extends the bd-q9lyghv2 caret-at-click coordinate bridge from a single point to an anchor/head pair (same geometric premise: the editor renders the same visual text in the same measured box, so viewport coords captured before the DOM swap land on the same glyphs after it):

- **`dragSelectionCapture.ts`** (new): `classifyOpenSelection` classifies the DOM selection at the `activate()` chokepoint into `caret` / `range` / `suppress`, using direction-aware selection endpoints (anchor/focus, not the normalized range) and `ownerDocument`-relative lookups (iframe-safe).
- **`pendingClickCoordsRef` → `pendingOpenSelectionRef`** with a union payload; read-once-and-clear semantics at editor mount unchanged (self-heal remounts still fall back to end-of-block).
- **`placeSelectionFromDrag`**: replays both endpoints through `posAtCoords` and applies `TextSelection.between(resolve(anchor), resolve(head))` — direction preserved, endpoints nudged to valid text positions.
- **Mount fallback chain**: range → caret at head (release point) → `focus('end')`.

Keyboard and touch activation are untouched (no click coords → no classification).

## Tests

- 9 unit tests for the capture classification (contained/backward/cross-block/collapsed/no-rects/invalid-offset).
- 5 unit tests for the replay against a **real `EditorState`** (direction preserved; misses and degenerate same-pos return false).
- Hover + editor integration tests extended: range payload stash, suppression (mouse-only — keyboard with a live selection still opens), read-once consume, fallback chain.
- New Playwright e2e (`q2-preview-spa/e2e/drag-selection-open.spec.ts`) driving **real trusted mouse drags** against the real `q2` binary: forward drag (editor selection equals the selection recorded at `pointerup`), backward drag stays backward, cross-block drag opens nothing and preserves the selection. 3/3 passed.
- Manually verified end-to-end with `q2 preview --allow-edit`: drag-selecting "quick brown fox jumps over the lazy" opens the editor with that exact selection highlighted; toolbar Bold produces `<strong>` around exactly that range.
- `cargo xtask verify` green (the previously-failing changelog Q-2-17 WASM test passes after rebasing onto #381's fix).

Plan/design record: `claude-notes/plans/2026-07-07-preview-drag-selection-into-richtext.md` (strand bd-abo9m23f).

🤖 Generated with [Claude Code](https://claude.com/claude-code)