### PR TITLE
chore(hub-e2e): restore parallel smoke-all workers (3)

### DIFF
--- a/.github/workflows/hub-client-e2e.yml
+++ b/.github/workflows/hub-client-e2e.yml
@@ -26,6 +26,10 @@ on:
         description: 'Also run smoke-all E2E tests (slow, ~80 extra tests, opt-in only)'
         type: boolean
         default: false
+      smoke-all-workers:
+        description: 'Playwright worker count for smoke-all (override; nightly default is 3)'
+        type: string
+        default: '3'
   schedule:
     - cron: '0 7 * * *'  # 2am EST / 3am EDT, runs on main
   push:
@@ -171,6 +175,11 @@ jobs:
       # changes to the WASM pipeline or theme resolution.
       - name: Run smoke-all E2E tests (nightly + opt-in)
         if: inputs.run-smoke-all == true || github.event_name == 'schedule'
+        env:
+          # Worker count override. Scheduled nightlies leave inputs unset, so
+          # this is empty → the config uses its default (3). A workflow_dispatch
+          # can raise it (e.g. 4) to re-stress the samod-0.12 sync fix.
+          SMOKE_ALL_WORKERS: ${{ inputs.smoke-all-workers }}
         run: |
           cd hub-client
           npx playwright test --config playwright.smoke-all.config.ts

--- a/hub-client/playwright.smoke-all.config.ts
+++ b/hub-client/playwright.smoke-all.config.ts
@@ -27,9 +27,19 @@ export default defineConfig({
   // match so only the smoke-all spec runs under this config.
   testIgnore: undefined,
   testMatch: '**/smoke-all.spec.ts',
-  // Run smoke-all serially. The base config uses 2 workers on CI, but the
-  // WASM render pipeline stalls under contention on a 2-core runner, which is
-  // the dominant source of the 75s-timeout flakiness in this suite. A single
-  // worker trades wall-clock for stability — acceptable for a nightly run.
-  workers: 1,
+  // Parallel workers for smoke-all. This suite historically ran at `workers: 1`
+  // because the 75s-timeout flakiness was blamed on the WASM render pipeline
+  // stalling under CPU contention. That diagnosis was wrong: the public-repo
+  // `ubuntu-latest` runner has 4 vCPUs (not 2), and the real cause was
+  // server-side sync contention, fixed by the samod-0.12 hub upgrade (PR #355,
+  // 2026-07-03). Since that landed the nightly has been clean, and dispatch
+  // stress runs confirmed 78/78 with zero flaky at both 3 and 4 workers
+  // (~3.4m vs the serial ~4.8m). We restore parallelism at 3, which reserves
+  // one core for the co-resident hub + vite-preview + node processes.
+  //
+  // `SMOKE_ALL_WORKERS` overrides the count for a workflow_dispatch run (e.g.
+  // to re-stress at 4 if flakiness ever returns).
+  workers: process.env.SMOKE_ALL_WORKERS
+    ? parseInt(process.env.SMOKE_ALL_WORKERS, 10)
+    : 3,
 });


### PR DESCRIPTION
## What

Restore parallelism in the nightly `smoke-all` E2E suite: default workers
`1` → `3`, with a `SMOKE_ALL_WORKERS` env / `smoke-all-workers` dispatch-input
override retained as a knob.

## Why

The suite ran serially on the theory that the 75s-timeout flakiness came from
the WASM render pipeline stalling under CPU contention on a "2-core" runner.
**That diagnosis was wrong on both counts:**

- the public-repo `ubuntu-latest` runner has **4 vCPUs**, not 2 (confirmed via
  `nproc` in the stress runs);
- the real cause was **server-side sync contention**, fixed by the samod-0.12
  hub upgrade (**PR #355**, 2026-07-03).

Since #355 the nightly has been clean at `workers: 1` for several consecutive
nights. Dispatch stress runs on this branch then confirmed the fix holds under
concurrent load:

| run | workers | nproc | result |
|-----|---------|-------|--------|
| 28840734138 | 4 | 4 | **78 passed, 0 flaky** (3.4m) |
| 28871855320 | 3 | 4 | **78 passed, 0 flaky** (3.4m) |

vs the pre-#355 regime: 7–17 flaky per night, 14–30 min.

## Choice of 3

Both 3 and 4 were clean and equally fast (~3.4m — the suite is I/O-bound at
this point, not core-starved). Landing on **3** reserves one core for the
co-resident hub + `vite preview` + node processes, keeping a robustness margin
over the 4-vCPU ceiling. Re-stress at 4 any time via
`workflow_dispatch` with `smoke-all-workers=4`.

## Verification

- Config resolves correctly: unset → 3, override `4` → 4.
- Workflow YAML validated; `smoke-all-workers` input default `3`.
- The two CI runs above are the end-to-end evidence (real dispatch runs, not
  in-process tests).

Context: `claude-notes/research/2026-07-03-e2e-reliability-experiment-log.md`
(lead 2, samod-0.12).