### PR TITLE
chore: bump workspace version to 0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -698,7 +698,7 @@ dependencies = [
 
 [[package]]
 name = "comrak-to-pandoc"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "comrak",
  "hashlink",
@@ -3487,7 +3487,7 @@ dependencies = [
 
 [[package]]
 name = "quarto"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3527,7 +3527,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-analysis"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "insta",
  "quarto-error-reporting",
@@ -3553,7 +3553,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-brand"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "quarto-util",
  "serde",
@@ -3564,7 +3564,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-citeproc"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "glob",
  "hashlink",
@@ -3597,7 +3597,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-core"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3652,7 +3652,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-csl"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "insta",
  "quarto-error-reporting",
@@ -3680,7 +3680,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-error-catalog"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "once_cell",
  "quarto-error-reporting",
@@ -3716,7 +3716,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-highlight"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "hashlink",
  "insta",
@@ -3745,7 +3745,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-highlight-encoding"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3753,7 +3753,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-hub"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "automerge",
@@ -3797,7 +3797,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-hub-provider"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "automerge",
  "ciborium",
@@ -3823,7 +3823,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-lsp"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "insta",
@@ -3839,7 +3839,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-lsp-core"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "insta",
  "pampa",
@@ -3862,7 +3862,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-mcp-launcher"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -3878,7 +3878,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-navigation"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "quarto-config",
  "quarto-pandoc-types",
@@ -3913,7 +3913,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-preview"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "automerge",
@@ -3945,7 +3945,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-project-create"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "quarto-doctemplate",
  "serde",
@@ -3954,7 +3954,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-publish"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3979,7 +3979,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-sass"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "grass",
  "include_dir",
@@ -4013,7 +4013,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-system-runtime"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4031,7 +4031,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-test"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "quarto-core",
@@ -4048,7 +4048,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-trace"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "flate2",
  "serde",
@@ -4059,7 +4059,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-trace-server"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4086,7 +4086,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-util"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -4094,7 +4094,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-xml"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "insta",
  "quarto-error-reporting",
@@ -4314,7 +4314,7 @@ dependencies = [
 
 [[package]]
 name = "reconcile-viewer"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "clap",
  "hashlink",
@@ -6341,7 +6341,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-printf-fmt"
-version = "0.7.0"
+version = "0.8.0"
 
 [[package]]
 name = "wasmparser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Posit Software, PBC"]
 homepage = "https://github.com/posit-dev/quarto-markdown-syntax"
 keywords = ["parser"]


### PR DESCRIPTION
Release version bump for **q2 v0.8.0**.

Follows `claude-notes/instructions/release-runbook.md` step 2 (bump on a branch → PR → merge, before tagging).

## Changes
- `[workspace.package].version`: `0.7.0` → `0.8.0`
- `cargo update --workspace` (workspace members only; no external deps moved)

## Verification
- `cargo build --bin q2 --locked` → `q2 (quarto 2) 0.8.0`
- `version_cli` contract tests pass (last token is bare version)
- Full `cargo xtask verify` passed (Rust build + tests, ts-packages, hub-client/WASM build + tests)

After merge: tag `origin/main` HEAD as `v0.8.0` and push to fire the Release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)