### PR TITLE
fix(quarto-core): normalize intermediate filename to forward slashes on Windows

### DIFF
--- a/crates/quarto-core/src/stage/stages/engine_execution.rs
+++ b/crates/quarto-core/src/stage/stages/engine_execution.rs
@@ -494,10 +494,8 @@ fn intermediate_filename(source_path: &std::path::Path, engine_name: &str) -> St
         .file_stem()
         .map(|s| s.to_string_lossy().into_owned())
         .unwrap_or_default();
-    source_path
-        .with_file_name(format!("{stem}.{engine_name}.rmarkdown"))
-        .display()
-        .to_string()
+    let joined = source_path.with_file_name(format!("{stem}.{engine_name}.rmarkdown"));
+    quarto_util::to_forward_slashes(&joined)
 }
 
 /// Serialize a Pandoc AST to QMD text.


### PR DESCRIPTION
On Windows, `intermediate_filename()` produced mixed-separator paths like `/project\test.knitr.rmarkdown` instead of `/project/test.knitr.rmarkdown`. `Path::with_file_name().display()` renders the joined filename component with the native separator, while the VFS-style root stays forward-slash.

Wrap the result in `quarto_util::to_forward_slashes`, matching how other VFS-style paths are normalized elsewhere in the codebase.