### PR TITLE
fix(quarto-core): normalize CRLF in bootstrap-icons test assertion

### DIFF
--- a/crates/quarto-core/src/transforms/website_bootstrap_icons.rs
+++ b/crates/quarto-core/src/transforms/website_bootstrap_icons.rs
@@ -111,7 +111,13 @@ mod tests {
         assert_eq!(css.scope, ArtifactScope::Project);
         assert_eq!(css.path.as_deref(), Some(Path::new(CSS_REL_PATH)));
         assert_eq!(css.content_type, "text/css");
-        assert!(css.content.starts_with(b"/*!\n * Bootstrap Icons"));
+        // Line endings are normalized before the check: this served asset carries
+        // no SourceInfo/byte-offset and is never compared byte-for-byte with
+        // anything, so a Windows checkout (`core.autocrlf` rewriting the
+        // committed-LF vendored file to CRLF) must not false-positive on EOL.
+        let head_len = css.content.len().min(64);
+        let head = String::from_utf8_lossy(&css.content[..head_len]).replace("\r\n", "\n");
+        assert!(head.starts_with("/*!\n * Bootstrap Icons"));
 
         let woff = store
             .get("font:bootstrap-icons:bootstrap-icons.woff")


### PR DESCRIPTION
On a Windows checkout, the vendored `resources/bootstrap-icons/bootstrap-icons.css` checks out with CRLF line endings (`core.autocrlf` rewriting the committed LF file), so `store_artifacts_uses_project_scope_paths` fails its `starts_with(b"/*!\n * Bootstrap Icons")` assertion.

This artifact carries no source-map/byte-offset tracking and is never compared byte-for-byte against anything downstream — CRLF vs LF is invisible to a browser rendering the CSS. The test should tolerate the host's line-ending convention, not encode it.

Normalized the assertion to compare against `\r\n`-stripped content, mirroring the existing pattern in `crates/quarto-core/src/revealjs/assemble.rs` (`vendored_reveal_assets_match_npm_package`).