### PR TITLE
hub-client: fix image drag-drop path when the .qmd is not at project root (bd-jzqswvh0)

### DIFF
--- a/claude-notes/plans/2026-07-15-image-drop-relative-path.md
+++ b/claude-notes/plans/2026-07-15-image-drop-relative-path.md
@@ -178,9 +178,12 @@ dialog behavior, unrelated to path handling.
 
 ### Phase 4 — bookkeeping
 
-- [ ] Commit (staged; awaiting user approval per pre-commit review policy).
-- [ ] hub-client changelog entry (two-commit workflow, needs commit 1's hash).
-- [ ] `braid close bd-jzqswvh0` with reason.
+- [x] Commit `64ba0e38` (fix + tests + this plan), approved by Carlos.
+- [x] hub-client changelog entry: commit `5f544f12` (two-commit workflow);
+      `npm run test:wasm` green (changelog render gate).
+- [x] Pushed as `bugfix/bd-jzqswvh0-image-drop-relative-path`; PR
+      https://github.com/quarto-dev/q2/pull/395 — awaiting CI.
+- [ ] `braid close bd-jzqswvh0` after PR merge.
 
 ## Resolved questions (Carlos, 2026-07-15)
 

--- a/claude-notes/plans/2026-07-15-image-drop-relative-path.md
+++ b/claude-notes/plans/2026-07-15-image-drop-relative-path.md
@@ -1,0 +1,194 @@
+# Editor image drag-drop: wrong relative path when .qmd is in a subdirectory
+
+**Strand:** bd-jzqswvh0
+**Status:** in progress (branch `braid/bd-jzqswvh0-image-drop-relative-path`)
+**Date:** 2026-07-15
+
+## Overview
+
+Dropping an image from the desktop onto the markdown editor while editing a
+`.qmd` that lives in a subdirectory produces a broken image reference:
+
+- The asset dialog opens with **destination = project root** (`''`), so the
+  image is uploaded to e.g. `photo.png` at the root.
+- The inserted markdown is `![](<result.path>)` — the *project-root-relative*
+  upload path used verbatim. Markdown image paths resolve relative to the
+  document's own directory, so from `posts/hello.qmd` the reference resolves
+  to `posts/photo.png`, which does not exist.
+
+The two paths only coincide when the `.qmd` is itself at the project root,
+which is why the bug hides in the common single-directory case.
+
+## Reproduction (performed 2026-07-15, hub-client dev + public sync server)
+
+1. `npm run dev` in `hub-client/` (defaults to `wss://sync.automerge.org`).
+2. Create a new project (`image-drop-path-repro`), create `posts/hello.qmd`,
+   open it.
+3. Drop a PNG (`photo.png`) from the desktop onto the editor pane.
+   (Automated via a synthetic `DragEvent` with a `DataTransfer` holding a
+   real `File`, dispatched on `.monaco-editor` — this drives the exact
+   `handleEditorDrop` listener a real drop hits.)
+4. The "Add asset to project" dialog opens with **Destination folder empty**.
+   Click Upload.
+
+**Observed:**
+- File sidebar: `photo.png` appears at project root (sibling of
+  `_quarto.yml`), not under `posts/`.
+- Editor (`posts/hello.qmd`) content: `![](photo.png)`.
+- Preview iframe: `<img src="photo.png">` with `naturalWidth: 0` — broken
+  image, nothing rendered.
+
+Screenshot: `claude-notes/scratch/image-drop-bug-repro.png`.
+
+## Root cause
+
+`hub-client/src/components/Editor.tsx`:
+
+- `handleEditorDrop` (external-file branch, ~line 854): opens the asset
+  dialog with `setAssetDestination('')` — always project root, ignoring the
+  current file's directory.
+- `handleUploadAsset` (~line 905): inserts
+  `` `![](${result.path})` `` where `result.path` is the final
+  project-root-relative upload path returned by `createBinaryFile`
+  (`CreateBinaryFileResult.path` — authoritative; it can differ from the
+  requested path via hash-suffix rename on name conflict). No relativization
+  against the current file's directory.
+- `handleEditorDrop` (internal sidebar-drag branch, ~line 814): same bug —
+  `` `![](${path})` `` / `` `[${fileName}](${path})` `` insert the sidebar's
+  project-root-relative path verbatim.
+
+## Design
+
+Two complementary changes:
+
+1. **Correctness (the fix): relativize the inserted path.** Compute the
+   inserted markdown path as the relative path from the current file's
+   directory to the final uploaded path (`result.path`). Examples, editing
+   `posts/hello.qmd`:
+   - upload to root `photo.png` → insert `![](../photo.png)`
+   - upload to `posts/photo.png` → insert `![](photo.png)`
+   - upload to `images/photo.png` → insert `![](../images/photo.png)`
+   This holds no matter what destination/filename the user chooses in the
+   dialog, and survives the hash-suffix rename (we relativize what was
+   *actually* created). This is the "markdown matches the user's chosen file
+   name" requirement.
+
+2. **UX default: destination = current file's directory.** For editor drops,
+   pre-fill the asset dialog destination with the current `.qmd`'s parent
+   directory instead of `''`. The image then lands next to the document and
+   the inserted path is the bare filename in the common case. (The sidebar
+   drop path already does selection-based defaulting via
+   `resolveDefaultDestination`; the editor drop path hardcodes `''`.)
+
+Choice made: use `../`-style relative paths, **not** project-absolute
+(`/photo.png`) paths. Rationale: qmd's supported link syntax here is the
+plain inline form; relative paths are what the preview's
+`resolveRelativePath` (ts-packages/preview-renderer/src/utils/vfsPaths.ts)
+resolves against the current file, and they keep documents portable if a
+folder is moved wholesale. (Project-absolute paths pass through
+`resolveRelativePath` unchanged and would need their own VFS-prefix
+handling — a larger change with no user-facing benefit here.)
+
+New helper needed: `relativePathBetween(fromFile, toPath)` — the inverse of
+the existing `resolveRelativePath`. Natural home: same module,
+`ts-packages/preview-renderer/src/utils/vfsPaths.ts` (hub-client already
+imports from `@quarto/preview-renderer/utils/vfsPaths`). It should:
+
+- accept POSIX-style project-root-relative inputs (`posts/hello.qmd`,
+  `photo.png`) — the shapes Editor.tsx traffics in;
+- walk up with `..` segments as needed;
+- be pure and unit-testable.
+
+Also extract the markdown-string construction into a pure, testable
+function (e.g. `buildDropMarkdown(currentFilePath, targetPath, kind)` in
+`hub-client/src/components/fileUpload/`), covering both the image and the
+qmd-link cases, so the Editor callbacks just call it.
+
+## Work items
+
+### Phase 1 — tests first (TDD)
+
+- [x] Unit tests for `relativePathBetween` in
+      `ts-packages/preview-renderer/src/utils/vfsPaths.test.ts`:
+      same-dir, parent-dir (`../`), sibling-dir, root-file → subdir-doc,
+      deep nesting, current file at root (identity), inputs with/without
+      leading slash normalization, segment-boundary (`post` vs `posts`).
+- [x] Unit tests for the markdown builder
+      (`hub-client/src/components/fileUpload/dropMarkdown.test.ts`):
+      image vs qmd link, current file at root vs subdirectory,
+      hash-suffixed upload path, null current file fallback.
+- [x] Unit test for the editor-drop default destination: documented in
+      `resolveDefaultDestination.test.ts` ("editor drop" describe block) —
+      the editor will pass the current file as `selection`; the mapping
+      `posts/hello.qmd → posts` is pure and covered there. The wiring
+      itself is Phase 3 E2E.
+- [x] Run the new tests; verified failures: 11 × `relativePathBetween is
+      not a function`; dropMarkdown suite fails with missing module.
+      resolveDefaultDestination additions pass (pure logic pre-exists;
+      the bug is the Editor not calling it).
+
+### Phase 2 — implementation
+
+- [x] Add `relativePathBetween` to
+      `ts-packages/preview-renderer/src/utils/vfsPaths.ts`.
+- [x] Add the markdown-builder helper
+      (`hub-client/src/components/fileUpload/dropMarkdown.ts`,
+      `buildDropMarkdown(kind, currentFilePath, targetPath)`) and use it
+      from `handleUploadAsset` (external drop → post-upload insertion).
+      `handleUploadAsset` deps now include `currentFile`.
+- [x] Fix the internal sidebar-drag insertion with the same helper
+      (images *and* qmd links).
+- [x] Default the editor-drop asset-dialog destination to the current
+      file's parent directory via
+      `resolveDefaultDestination({ selection: currentFile?.path })`.
+      Note: safe against stale closures because `MonacoEditor` uses
+      `key={currentFile?.path}` — every file switch remounts the editor
+      and re-attaches fresh drop handlers.
+- [x] All new/existing unit tests pass: hub-client `test:ci` 129/129;
+      preview-renderer 530 passed / 36 skipped.
+
+### Phase 3 — verification
+
+- [x] `cd hub-client && npm run build:all` succeeds (exit 0).
+- [x] End-to-end browser verification (2026-07-15, dev server, project
+      `image-drop-path-repro`, editing `posts/hello.qmd`), four cases:
+      1. **External drop, default destination**: dialog opened with
+         destination pre-filled `posts`; upload created `posts/photo.png`;
+         inserted `![](photo.png)`; preview `<img>` resolved to a data URI
+         with `naturalWidth: 1` (renders).
+      2. **External drop, destination overridden to root** (file renamed
+         `photo2.png` to dodge the exists-check): inserted
+         `![](../photo2.png)`; preview resolved and rendered it
+         (`naturalWidth: 1`).
+      3. **Internal sidebar drag, image at root**: synthetic
+         `application/x-hub-file` drop `{path: 'photo.png', type:
+         'image'}` inserted `![](../photo.png)`.
+      4. **Internal sidebar drag, qmd link**: `{path: 'guides/notes.qmd',
+         type: 'qmd'}` inserted `[notes.qmd](../guides/notes.qmd)`.
+- [x] E2E evidence recorded here; screenshots
+      `claude-notes/scratch/image-drop-bug-repro.png` (before) and
+      `claude-notes/scratch/image-drop-bug-fixed.png` (after).
+- [x] No Rust touched (hub-client + ts-packages only) — full
+      `cargo xtask verify` not required for this change.
+
+**Observed during E2E, out of scope:** re-dropping a file while the
+NewAssetDialog had been opened before showed the previous drop's preview
+entry still listed (dialog state persists across open/close). Pre-existing
+dialog behavior, unrelated to path handling.
+
+### Phase 4 — bookkeeping
+
+- [ ] Commit (staged; awaiting user approval per pre-commit review policy).
+- [ ] hub-client changelog entry (two-commit workflow, needs commit 1's hash).
+- [ ] `braid close bd-jzqswvh0` with reason.
+
+## Resolved questions (Carlos, 2026-07-15)
+
+1. **Default destination**: current file's directory — confirmed preferred.
+2. **Non-image editor drops**: same default applies — one consistent rule.
+
+## Repro artifacts
+
+- Browser project `image-drop-path-repro` (project set of this machine's
+  dev profile, public sync server) — reusable for Phase 3 verification.
+- Screenshot: `claude-notes/scratch/image-drop-bug-repro.png`

--- a/hub-client/changelog.md
+++ b/hub-client/changelog.md
@@ -23,6 +23,10 @@ WASM rebuild is needed for a changelog-only edit.
 
 -->
 
+### 2026-07-15
+
+- [`64ba0e38`](https://github.com/quarto-dev/q2/commits/64ba0e38): Dropping an image into the editor now defaults the upload to the current document's folder and inserts a correctly relativized path (e.g. `![](../photo.png)`), instead of uploading to the project root with a broken document-relative reference; sidebar drags into a subdirectory document are fixed the same way.
+
 ### 2026-07-13
 
 - [`3fc6e610`](https://github.com/quarto-dev/q2/commits/3fc6e610): Editing a block in the preview now uses one pop-up toolbar — the rich/plain switch is a Markdown-mark icon on it, the toolbar appears for every editable block (code chunks included), and the type/nesting breadcrumb folds into it, replacing the cut-off left-margin "Editing…" label and the separate floating breadcrumb.

--- a/hub-client/src/components/Editor.tsx
+++ b/hub-client/src/components/Editor.tsx
@@ -20,6 +20,7 @@ import type { Diagnostic } from '@quarto/preview-renderer/types/diagnostic';
 import { useIntelligenceProviders } from '../hooks/useIntelligenceProviders';
 import { registerQmdLanguage } from './quartoTheme';
 import { processFileForUpload } from '../services/resourceService';
+import { buildDropMarkdown, resolveDefaultDestination } from './fileUpload';
 import { useProjectSearch } from '../services/search';
 import { usePresence } from '../hooks/usePresence';
 import { usePreference } from '../hooks/usePreference';
@@ -808,15 +809,13 @@ export default function Editor({ project, files, fileContents, onDisconnect, onC
         const position = target?.position ?? editorRef.current.getPosition();
 
         if (position && (type === 'image' || type === 'qmd')) {
-          // Generate appropriate markdown
-          let markdown: string;
-          if (type === 'image') {
-            markdown = `![](${path})`;
-          } else {
-            // For qmd files, use the filename as link text
-            const fileName = path.split('/').pop() || path;
-            markdown = `[${fileName}](${path})`;
-          }
+          // Sidebar paths are project-root relative; the markdown target
+          // must be relative to the current file's directory.
+          const markdown = buildDropMarkdown(
+            type === 'image' ? 'image' : 'link',
+            currentFile?.path ?? null,
+            path
+          );
 
           // Insert markdown at drop position
           editorRef.current.executeEdits('file-drop', [{
@@ -852,7 +851,9 @@ export default function Editor({ project, files, fileContents, onDisconnect, onC
     }
 
     setAssetInitialFiles(files);
-    setAssetDestination('');
+    // Default the upload next to the document being edited, so the common
+    // case yields a same-directory reference.
+    setAssetDestination(resolveDefaultDestination({ selection: currentFile?.path ?? null }));
     setShowNewAssetDialog(true);
   }, [currentFile]);
 
@@ -902,7 +903,10 @@ export default function Editor({ project, files, fileContents, onDisconnect, onC
       // insert a markdown image reference at the drop point.
       if (file.type.startsWith('image/') && pendingDropPositionRef.current && editorRef.current) {
         const position = pendingDropPositionRef.current;
-        const markdown = `![](${result.path})`;
+        // result.path is the final project-root-relative path (it can be
+        // hash-suffix renamed on conflict); relativize it against the
+        // current file so the markdown reference resolves.
+        const markdown = buildDropMarkdown('image', currentFile?.path ?? null, result.path);
 
         editorRef.current.executeEdits('image-drop', [{
           range: {
@@ -921,7 +925,7 @@ export default function Editor({ project, files, fileContents, onDisconnect, onC
       console.error('Failed to upload file:', err);
       pendingDropPositionRef.current = null;
     }
-  }, [handleCreateTextFile]);
+  }, [handleCreateTextFile, currentFile]);
 
   // Handle deleting a file
   const handleDeleteFile = useCallback((file: FileEntry) => {

--- a/hub-client/src/components/fileUpload/dropMarkdown.test.ts
+++ b/hub-client/src/components/fileUpload/dropMarkdown.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Tests for buildDropMarkdown
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildDropMarkdown } from './dropMarkdown';
+
+describe('buildDropMarkdown', () => {
+  describe('image markdown', () => {
+    it('uses the bare filename when the target is next to the current file', () => {
+      expect(buildDropMarkdown('image', 'posts/hello.qmd', 'posts/photo.png')).toBe(
+        '![](photo.png)'
+      );
+    });
+
+    it('walks up when the target is at the project root and the file is not', () => {
+      expect(buildDropMarkdown('image', 'posts/hello.qmd', 'photo.png')).toBe(
+        '![](../photo.png)'
+      );
+    });
+
+    it('walks up and down for a sibling directory', () => {
+      expect(buildDropMarkdown('image', 'posts/hello.qmd', 'images/photo.png')).toBe(
+        '![](../images/photo.png)'
+      );
+    });
+
+    it('uses the bare filename when both are at the project root', () => {
+      expect(buildDropMarkdown('image', 'hello.qmd', 'photo.png')).toBe(
+        '![](photo.png)'
+      );
+    });
+
+    it('preserves a conflict-renamed (hash-suffixed) filename', () => {
+      expect(
+        buildDropMarkdown('image', 'posts/hello.qmd', 'posts/photo-1a2b3c4d.png')
+      ).toBe('![](photo-1a2b3c4d.png)');
+    });
+
+    it('falls back to the target path verbatim without a current file', () => {
+      expect(buildDropMarkdown('image', null, 'photo.png')).toBe('![](photo.png)');
+    });
+  });
+
+  describe('link markdown', () => {
+    it('uses the target filename as link text and a relative path as target', () => {
+      expect(buildDropMarkdown('link', 'posts/hello.qmd', 'notes.qmd')).toBe(
+        '[notes.qmd](../notes.qmd)'
+      );
+    });
+
+    it('links to a file in the same directory with a bare filename', () => {
+      expect(buildDropMarkdown('link', 'posts/hello.qmd', 'posts/notes.qmd')).toBe(
+        '[notes.qmd](notes.qmd)'
+      );
+    });
+
+    it('falls back to the target path verbatim without a current file', () => {
+      expect(buildDropMarkdown('link', null, 'guides/notes.qmd')).toBe(
+        '[notes.qmd](guides/notes.qmd)'
+      );
+    });
+  });
+});

--- a/hub-client/src/components/fileUpload/dropMarkdown.ts
+++ b/hub-client/src/components/fileUpload/dropMarkdown.ts
@@ -1,0 +1,31 @@
+/**
+ * Build the markdown inserted into the editor when a file is dropped on it
+ * (external image upload or internal sidebar drag).
+ *
+ * Markdown link/image targets resolve relative to the *containing
+ * document's* directory, while project file paths are project-root
+ * relative — so the target must be relativized against the current file
+ * (bd-jzqswvh0). `targetPath` should be the final created path (for
+ * uploads, `CreateBinaryFileResult.path`, which can be hash-suffix renamed
+ * on conflict), not the requested one.
+ */
+
+import { relativePathBetween } from '@quarto/preview-renderer/utils/vfsPaths';
+
+export type DropMarkdownKind = 'image' | 'link';
+
+export function buildDropMarkdown(
+  kind: DropMarkdownKind,
+  currentFilePath: string | null,
+  targetPath: string
+): string {
+  const href = currentFilePath
+    ? relativePathBetween(currentFilePath, targetPath)
+    : targetPath;
+
+  if (kind === 'image') {
+    return `![](${href})`;
+  }
+  const fileName = targetPath.split('/').pop() || targetPath;
+  return `[${fileName}](${href})`;
+}

--- a/hub-client/src/components/fileUpload/index.ts
+++ b/hub-client/src/components/fileUpload/index.ts
@@ -12,3 +12,4 @@ export {
   type ResolveDefaultDestinationOpts,
 } from './resolveDefaultDestination';
 export { processAssetFiles, type AssetFilePreview } from './processAssetFiles';
+export { buildDropMarkdown, type DropMarkdownKind } from './dropMarkdown';

--- a/hub-client/src/components/fileUpload/resolveDefaultDestination.test.ts
+++ b/hub-client/src/components/fileUpload/resolveDefaultDestination.test.ts
@@ -89,4 +89,18 @@ describe('resolveDefaultDestination', () => {
       expect(resolveDefaultDestination({})).toBe('');
     });
   });
+
+  describe('editor drop (selection = file open in the editor)', () => {
+    // The editor's external-file drop handler passes the current file as
+    // `selection` so dropped assets default to the document's own folder
+    // (bd-jzqswvh0). There is no dropTarget: the drop landed on the
+    // editor surface, not on a sidebar folder row.
+    it('defaults to the open file\'s directory for a subdirectory file', () => {
+      expect(resolveDefaultDestination({ selection: 'posts/hello.qmd' })).toBe('posts');
+    });
+
+    it('defaults to root when the open file is at the project root', () => {
+      expect(resolveDefaultDestination({ selection: 'hello.qmd' })).toBe('');
+    });
+  });
 });

--- a/ts-packages/preview-renderer/src/utils/vfsPaths.test.ts
+++ b/ts-packages/preview-renderer/src/utils/vfsPaths.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { resolveRelativePath, normalizePath, guessMimeType } from './vfsPaths';
+import {
+    resolveRelativePath,
+    relativePathBetween,
+    normalizePath,
+    guessMimeType,
+} from './vfsPaths';
 
 describe('resolveRelativePath', () => {
     it('returns absolute paths unchanged', () => {
@@ -28,6 +33,81 @@ describe('resolveRelativePath', () => {
 
     it('handles currentFile with no slashes', () => {
         expect(resolveRelativePath('index.qmd', 'hero.png')).toBe('/hero.png');
+    });
+});
+
+describe('relativePathBetween', () => {
+    it('returns the bare filename for a target in the same directory', () => {
+        expect(relativePathBetween('posts/hello.qmd', 'posts/photo.png')).toBe(
+            'photo.png',
+        );
+    });
+
+    it('walks up to reach a target in the parent directory', () => {
+        expect(relativePathBetween('posts/hello.qmd', 'photo.png')).toBe(
+            '../photo.png',
+        );
+    });
+
+    it('walks up and back down to reach a sibling directory', () => {
+        expect(
+            relativePathBetween('posts/hello.qmd', 'images/photo.png'),
+        ).toBe('../images/photo.png');
+    });
+
+    it('returns the bare filename when both are at the root', () => {
+        expect(relativePathBetween('hello.qmd', 'photo.png')).toBe(
+            'photo.png',
+        );
+    });
+
+    it('descends from a root file into a subdirectory', () => {
+        expect(relativePathBetween('hello.qmd', 'images/photo.png')).toBe(
+            'images/photo.png',
+        );
+    });
+
+    it('walks up multiple levels', () => {
+        expect(relativePathBetween('a/b/c/doc.qmd', 'a/x.png')).toBe(
+            '../../x.png',
+        );
+    });
+
+    it('descends below the current directory', () => {
+        expect(relativePathBetween('a/b/doc.qmd', 'a/b/c/d.png')).toBe(
+            'c/d.png',
+        );
+    });
+
+    it('does not treat a segment-name prefix as a shared directory', () => {
+        // 'post' and 'posts' share a string prefix but are different dirs
+        expect(relativePathBetween('post/doc.qmd', 'posts/photo.png')).toBe(
+            '../posts/photo.png',
+        );
+    });
+
+    it('tolerates leading slashes on either argument', () => {
+        expect(relativePathBetween('/posts/hello.qmd', '/photo.png')).toBe(
+            '../photo.png',
+        );
+        expect(relativePathBetween('posts/hello.qmd', '/photo.png')).toBe(
+            '../photo.png',
+        );
+        expect(relativePathBetween('/posts/hello.qmd', 'photo.png')).toBe(
+            '../photo.png',
+        );
+    });
+
+    it('normalizes `.` and `..` segments in the inputs', () => {
+        expect(
+            relativePathBetween('posts/./hello.qmd', 'posts/../photo.png'),
+        ).toBe('../photo.png');
+    });
+
+    it('handles conflict-renamed (hash-suffixed) upload paths', () => {
+        expect(
+            relativePathBetween('posts/hello.qmd', 'photo-1a2b3c4d.png'),
+        ).toBe('../photo-1a2b3c4d.png');
     });
 });
 

--- a/ts-packages/preview-renderer/src/utils/vfsPaths.ts
+++ b/ts-packages/preview-renderer/src/utils/vfsPaths.ts
@@ -40,6 +40,39 @@ export function resolveRelativePath(
 }
 
 /**
+ * Compute the relative path from the directory of `fromFile` to `toPath` —
+ * the inverse of {@link resolveRelativePath}. The result is suitable for a
+ * markdown link/image target inside `fromFile`.
+ *
+ * Both arguments are POSIX-style paths in the same convention (project-root
+ * relative, with or without a leading `/`); `.`/`..` segments are
+ * normalized before comparison.
+ *
+ *   relativePathBetween('posts/hello.qmd', 'posts/photo.png')  → 'photo.png'
+ *   relativePathBetween('posts/hello.qmd', 'photo.png')        → '../photo.png'
+ *   relativePathBetween('posts/hello.qmd', 'images/photo.png') → '../images/photo.png'
+ */
+export function relativePathBetween(fromFile: string, toPath: string): string {
+    // normalizePath yields a single-leading-slash canonical form for both,
+    // making segment comparison convention-independent.
+    const fromSegments = normalizePath(fromFile).split('/').filter(Boolean);
+    const toSegments = normalizePath(toPath).split('/').filter(Boolean);
+    fromSegments.pop(); // drop the filename: we relativize against its directory
+
+    let shared = 0;
+    while (
+        shared < fromSegments.length &&
+        shared < toSegments.length - 1 && // keep at least the target filename
+        fromSegments[shared] === toSegments[shared]
+    ) {
+        shared++;
+    }
+
+    const ups = fromSegments.length - shared;
+    return [...Array(ups).fill('..'), ...toSegments.slice(shared)].join('/');
+}
+
+/**
  * Collapse `.` and `..` segments and remove empty segments, ensuring
  * the result has a single leading `/`. Trailing `..` past the root is
  * silently swallowed (matches the prior private-copy behavior).


### PR DESCRIPTION
## Summary

Dropping an image from the desktop onto the markdown editor while editing a `.qmd` in a subdirectory (e.g. `posts/hello.qmd`) uploaded the file to the **project root** (the asset dialog destination defaulted to `''`) but inserted `![](photo.png)` — a *document-relative* reference that resolved to `posts/photo.png`, which doesn't exist. The preview showed a broken image. The two path conventions only coincide when the document is itself at the project root, which is why this hid in single-directory projects.

## Changes

- **New `relativePathBetween(fromFile, toPath)`** in `ts-packages/preview-renderer/src/utils/vfsPaths.ts` — the inverse of the existing `resolveRelativePath`.
- **New `buildDropMarkdown(kind, currentFilePath, targetPath)`** in `hub-client/src/components/fileUpload/dropMarkdown.ts` — pure builder for the inserted markdown, used by both editor insertion paths:
  - post-upload image insertion now relativizes the **final** created path (`CreateBinaryFileResult.path`, which can be hash-suffix renamed on conflict) against the current file's directory;
  - the internal sidebar-drag branch (images **and** qmd links) gets the same fix.
- **Editor drops now pre-fill the asset dialog destination with the current file's directory** (via the existing `resolveDefaultDestination` selection fallback) instead of always the project root, so the common case inserts a bare same-directory filename.

## Testing

- TDD: new unit tests written and verified failing first (11 `relativePathBetween` cases incl. the `post/` vs `posts/` segment-boundary trap; 9 `buildDropMarkdown` cases; editor-drop destination cases documented in `resolveDefaultDestination.test.ts`).
- hub-client `test:ci` 129/129 · preview-renderer 530 passed · `npm run typecheck` clean · `npm run build:all` exit 0 · `npm run test:wasm` green (changelog render gate).
- Verified end-to-end in a real browser session against the dev server (project on the public sync server): dialog defaults to `posts`; same-dir upload inserts `![](photo.png)` and the preview renders it; root-destination upload inserts `![](../photo2.png)`; sidebar drag of a root image inserts `![](../photo.png)`; qmd drag inserts `[notes.qmd](../guides/notes.qmd)`.

Plan: `claude-notes/plans/2026-07-15-image-drop-relative-path.md` (braid strand bd-jzqswvh0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)