### PR TITLE
Mermaid diagrams as a regular rendering feature (bd-5m4ga0s1)

### DIFF
--- a/claude-notes/plans/2026-07-20-mermaid-regular-rendering.md
+++ b/claude-notes/plans/2026-07-20-mermaid-regular-rendering.md
@@ -372,11 +372,25 @@ were the freshly rebuilt `target/debug/q2` (SPA re-embedded).
 
 ### Phase 5 — docs + close-out
 
-- [ ] User-facing docs page under `docs/` (syntax, both formats,
-      CDN note); render with `cargo run --bin q2 -- render docs/`
-      (Q2, not Q1). Relates to existing docs strand bd-5ijtt —
-      re-scope or re-parent it rather than duplicating.
-- [ ] Full `cargo xtask verify`; commit; ask before push
+- [ ] User-facing docs page under `docs/` — deliberately left to the
+      dedicated docs strand **bd-5ijtt** (child of + blocked by
+      bd-5m4ga0s1); do it in a follow-up session rather than
+      duplicating here.
+- [x] Full `cargo xtask verify` run 2026-07-20. **Steps 1–11 green**
+      (clippy/-D warnings, fmt, workspace build, tree-sitter, 10222
+      Rust tests, ts-packages builds, hub-client WASM build,
+      test:ci 129, trace-viewer, preview-* suites). Step 13's SPA
+      build ran green earlier in-session; step 14 is `--e2e`-gated.
+      **Step 12 (hub-MCP live tests) failed environmentally**: 20/26
+      failures, all in `live:` describe blocks that connect to a
+      hard-coded remote hub project; `sync.automerge.org` was
+      unreachable from this machine for the whole session (braid
+      offline warnings + direct curl timeout confirm). The 6
+      offline-capable protocol tests passed. `quarto-hub-mcp` has no
+      dependency on any code changed by this strand. Re-run step 12
+      when connectivity returns before merging.
+- [x] Commits on `braid/bd-5m4ga0s1-mermaid-diagrams-regular-rendering`;
+      push awaits user approval per repo policy.
 
 ## Resolved decisions (ratified by user 2026-07-20)
 

--- a/claude-notes/plans/2026-07-20-mermaid-regular-rendering.md
+++ b/claude-notes/plans/2026-07-20-mermaid-regular-rendering.md
@@ -372,10 +372,16 @@ were the freshly rebuilt `target/debug/q2` (SPA re-embedded).
 
 ### Phase 5 — docs + close-out
 
-- [ ] User-facing docs page under `docs/` — deliberately left to the
-      dedicated docs strand **bd-5ijtt** (child of + blocked by
-      bd-5m4ga0s1); do it in a follow-up session rather than
-      duplicating here.
+- [x] User-facing docs page (bd-5ijtt, commit `e44f184f`):
+      `docs/guides/authoring/diagrams.qmd` filled in (was a TBD stub
+      already wired into the sidebar), with two runnable examples in a
+      new `examples/diagrams/` category embedded via
+      `.embed-example-iframe` (the revealjs-docs pattern). Scoped to
+      `q2 render`/`q2 preview` per user direction (hub-client
+      differences belong in future ancillary docs). Verified:
+      `stage-doc-examples` renders both examples; `q2 render docs/`
+      clean for this page; browser check confirmed both iframes draw
+      live diagrams and `@demo-…` crossrefs resolve.
 - [x] Full `cargo xtask verify` run 2026-07-20. **Steps 1–11 green**
       (clippy/-D warnings, fmt, workspace build, tree-sitter, 10222
       Rust tests, ts-packages builds, hub-client WASM build,

--- a/claude-notes/plans/2026-07-20-mermaid-regular-rendering.md
+++ b/claude-notes/plans/2026-07-20-mermaid-regular-rendering.md
@@ -1,0 +1,379 @@
+---
+date: 2026-07-20
+branch: TBD (plan phase — no implementation yet)
+status: >
+  v1.1 — ratified by user 2026-07-20 (all five open questions
+  resolved; see § Resolved decisions). Awaiting explicit go-ahead
+  to begin implementation.
+braid: bd-5m4ga0s1 (supersedes + related → epic bd-je48v)
+---
+
+# Mermaid diagrams as a "regular" rendering feature (non-engine)
+
+## Overview
+
+Pivot mermaid support away from the engine model (bd-je48v /
+`feature/mermaid-engine`, never merged to `main`) and implement it as:
+
+1. **`q2 render`** (`format: html`, `format: revealjs`): a
+   format-gated **AST transform** that turns ` ```mermaid ` fenced
+   code blocks (`CodeBlock` with class `mermaid`) into
+   `RawBlock(HTML, "<pre class=\"mermaid\">…</pre>")`, plus a
+   once-per-doc CDN `<script>` injected through the canonical
+   `rendered.includes.*` mechanism.
+2. **`q2 preview` / hub-client** (`format: q2-preview`,
+   `format: revealjs`): a **built-in React component** in
+   `ts-packages/preview-renderer` that overrides the `CodeBlock`
+   registry entry, renders `class="mermaid"` blocks via mermaid.js
+   loaded dynamically from CDN, and delegates everything else to the
+   existing built-in. This productionizes the prototype at
+   `~/Desktop/daily-log/2026/07/20/mermaid-react/mermaid.tsx`.
+
+### Why the pivot (user rationale, 2026-07-20)
+
+- Engine execution is not ergonomic on hub-client /
+  quarto-hub.com: engine outputs must be contributed via explicit
+  code execution + upload to the automerge project sidecar, which
+  breaks "codeless previews".
+- Diagram rendering as a regular feature integrates with the new
+  preview mode: the React-component prototype works today.
+- Cost: the ergonomic syntax becomes ` ```mermaid ` (GFM-style)
+  rather than Q1's ` ```{mermaid} `. This is arguably a net positive
+  — it matches GitHub/GitLab markdown rendering conventions.
+
+### What this supersedes
+
+The engine implementation on `feature/mermaid-engine`
+(`crates/quarto-core/src/engine/mermaid.rs`, registry/detection
+edits, `RawBlock.tsx` script-execution fix, `mermaid_pipeline.rs`
+integration tests) is **not merged and will not be merged**. The
+branch stays as reference; the design history lives in
+`claude-notes/plans/2026-05-28-mermaidjs-engine-design.md`. Note that
+the engine approach's C1 hack (script inlined into
+`ExecuteResult.markdown` to survive capture-splice) is unnecessary
+here: with no engine there is no capture, so we can use the clean
+`rendered.includes.*` path that the old plan reserved for
+"after bd-cp3em".
+
+## Syntax decision
+
+**First cut supports only the plain fenced form:**
+
+````
+```mermaid
+flowchart LR
+  a --> b
+```
+````
+
+pampa parses this as `CodeBlock(("", ["mermaid"], []), source)` — no
+engine, no cell options, works identically in native parse and WASM
+parse, and renders as a code block (not broken output) on surfaces
+that don't know about mermaid.
+
+**Explicitly out of scope for the first cut** (tracked as open
+questions / follow-ups, not silently dropped):
+
+- ` ```{mermaid} ` executable-cell syntax (Q1 compat). Note the
+  interaction hazard: knitr's `handledLanguages` already claims
+  `mermaid`, so `{mermaid}` cells in a knitr doc get engine-routed
+  today. Recognizing `{mermaid}` in the transform would create
+  ambiguity about ownership. Recommendation: don't; if Q1-compat
+  matters later, `qmd-syntax-helper` can rewrite the fences.
+- `%%|` cell options, `fig-cap` / `label` / crossrefs-as-figures,
+  `fig-width`/`fig-height`, `echo`.
+- `mermaid-format: png|svg` (Q1 pre-renders via headless Chrome for
+  PDF/docx — no non-HTML formats in Q2 yet).
+- Theming (Q1's `--mermaid-*` CSS variables derived from Bootstrap
+  SCSS, and `mermaid: theme:` metadata). See Open Questions.
+
+## Architecture — `q2 render` path
+
+### The transform
+
+New file `crates/quarto-core/src/transforms/mermaid.rs`:
+`MermaidRenderTransform`, an `AstTransform` with
+`phase() == TransformPhase::Finalization`.
+
+- Walk blocks; for each `CodeBlock` whose classes include `mermaid`,
+  replace with `RawBlock(Format("html"), "<pre class=\"mermaid\">\n{escaped}\n</pre>")`,
+  HTML-escaping `&`, `<`, `>` (same escaping the engine version used).
+  Nested-in-Div cases are covered by the normal transform walk.
+- If ≥1 block matched, append the CDN script to
+  `ast.meta.rendered.includes.after-body` (the
+  `website_favicon.rs` / `feed/link_inject.rs` precedent, consumed by
+  `IncludeResolveStage`'s `write_rendered_lists` output and
+  `ApplyTemplateStage`):
+
+  ```html
+  <script type="module">
+  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11.12.0/dist/mermaid.esm.min.mjs';
+  mermaid.initialize({ startOnLoad: false });
+  mermaid.run({ querySelector: 'pre.mermaid' });
+  </script>
+  ```
+
+  Version pinned exactly (`11.12.0`, matching Q1's bundled copy) as a
+  single Rust const; the TS component pins the same version as a TS
+  const. Ratified 2026-07-20.
+
+  Explicit `mermaid.run()` rather than `startOnLoad: true`, matching
+  the engine version's reasoning (robust regardless of when the
+  script executes relative to DOMContentLoaded).
+
+  **Verify at impl time**: a Finalization-phase transform runs after
+  `IncludeResolveStage` has already written `rendered.includes.*` —
+  confirm the favicon/feed-link transforms' exact append target and
+  timing, and do the same. If late appends to
+  `rendered.includes.after-body` are NOT picked up by
+  `ApplyTemplateStage`, fall back to appending a trailing
+  `RawBlock(HTML, script)` to the body (the engine version's shape,
+  equally correct for render output).
+
+### Pipeline placement
+
+- In `build_transform_pipeline` (`crates/quarto-core/src/pipeline.rs`),
+  Finalization phase, **immediately before `CodeBlockRenderTransform`**
+  so mermaid blocks are consumed before code-block chrome
+  (copy-button, highlight classes) is applied. Because the transform
+  runs inside `AstTransformsStage`, `CodeHighlightStage` (a later
+  stage) never sees the mermaid `CodeBlock` either.
+- Gate: HTML-based targets only (`ctx.format.is_html_based()`-style
+  self-gate or pipeline-level gate). It runs for **both** `html` and
+  `revealjs` — it is html-family-specific, not reveal-specific, so it
+  does NOT go in `reveal_finalization_transforms`.
+- **Excluded from `build_q2_preview_transform_pipeline`** (the
+  `Q2_PREVIEW_TRANSFORM_EXCLUDED` list): in preview the `CodeBlock`
+  must survive to the React layer, which owns rendering. This
+  exclusion is what makes `format: revealjs` work in both worlds —
+  native render gets the RawBlock, hub-client's q2-slides preview
+  gets the raw CodeBlock.
+- The phase-ordering invariant test
+  (`test_build_transform_pipeline_phase_ordering`) must stay green.
+
+### revealjs specifics (native render)
+
+Same transform, same script. Reveal slides render `pre.mermaid`
+inside `<section>` elements; mermaid.run at load time processes all
+of them. Known risks to check during E2E (not blockers, but must be
+looked at in a browser, per Q1's special-casing):
+
+- Diagrams on non-visible slides: mermaid measures DOM at render
+  time; hidden sections can produce mis-sized SVGs. Q1 handles
+  alignment/sizing in `mermaid-init.js` postProcess with
+  `reveal: true`. First cut: observe behavior with mermaid@11 and
+  file a follow-up strand if sizing is broken.
+- Oversized diagrams overflowing slides (no `r-stretch`
+  integration in the first cut).
+
+## Architecture — preview path (React)
+
+New built-in component in
+`ts-packages/preview-renderer/src/q2-preview/blocks/MermaidCodeBlock.tsx`
+(name TBD), registered in `registry.ts` **as the `CodeBlock` entry**,
+wrapping the existing plain `CodeBlock.tsx`:
+
+- If `classes.includes('mermaid')` → render `<MermaidDiagram code>`;
+  else delegate to the plain built-in component (direct import, not
+  via `window.__Q2_PREVIEW_RENDERER__` — that surface is for user
+  TSX).
+- `MermaidDiagram` is the prototype's shape: load-once cached dynamic
+  `import()` of the jsdelivr ESM bundle, `mermaid.initialize({ startOnLoad: false })`,
+  per-instance `mermaid.render(uniqueId, code)` → inject SVG via
+  ref; error state renders the message + source instead of throwing.
+  CDN lazy-load (not an npm dependency bundled like katex) is
+  deliberate for the first cut, per user direction; it also keeps the
+  SPA bundle small. Follow-up may vendor it.
+- Because `registry.ts` is the merge base and user
+  `render-components` layer on top, a user-supplied `CodeBlock`
+  override still wins — the prototype workflow keeps working, and
+  users can replace our mermaid handling wholesale.
+- Since `format: q2-preview` and `format: revealjs` (q2-slides) both
+  render through `mergedPreviewRegistry` (including inside
+  `RevealDeck` slides), one component covers both — but the reveal
+  path needs its own browser verification (slide visibility timing,
+  see Test matrix).
+
+Testability: structure the component so the mermaid loader is
+injectable (module-level `setMermaidLoaderForTests` or similar), so
+vitest can exercise dispatch + error paths without network.
+
+### Rebuild chain (both artifacts embed this code)
+
+- hub-client: its own Vite build bundles `preview-renderer` from
+  source. Requires `npm run build:all` verification + changelog
+  entries per CLAUDE.md's two-commit rule.
+- `q2 preview` binary: `cargo xtask build-q2-preview-spa` then
+  `cargo build --bin q2` (re-embed `q2-preview-spa/dist/`). The Rust
+  transform also touches `quarto-core` → WASM leg affected → full
+  `cargo xtask verify` before push.
+
+## Work items
+
+### Phase 0 — plan ratification + bookkeeping
+
+- [x] Exploration: existing engine branch, Q1 implementation, preview
+      renderer architecture (this session, 2026-07-20)
+- [x] Plan written
+- [x] User ratified plan 2026-07-20 (all five open questions resolved)
+- [x] Create braid strand bd-5m4ga0s1; linked `supersedes` + `related`
+      to bd-je48v; recorded in this header
+- [x] Epic bd-je48v closed as superseded; `feature/mermaid-engine`
+      branch kept unmerged as reference; docs strand bd-5ijtt
+      re-parented to (and blocked by) bd-5m4ga0s1
+- [x] Theming follow-up filed: bd-nj25kgbu (discovered-from
+      bd-5m4ga0s1)
+
+### Phase 1 — tests first (native render)
+
+Per CLAUDE.md TDD: all of these must exist and fail before the
+transform is written.
+
+- [x] Unit tests for `MermaidRenderTransform` (in
+      `transforms/mermaid.rs`, 9 tests): single block, multiple blocks
+      (script appended once), rerun idempotency (sentinel), no mermaid
+      block → no script + AST untouched, `{mermaid}` brace form
+      untouched, HTML escaping, nested-in-Div, extra classes,
+      non-HTML format no-op. **Verified failing** against the no-op
+      skeleton (2026-07-20).
+- [x] Integration tests via smoke-all fixtures (better vehicle than a
+      bespoke integration file — three runners share them):
+      `crates/quarto/tests/smoke-all/mermaid/{basic,no-mermaid,revealjs}.qmd`
+      with `ensureFileRegexMatches` for the `<pre>`, escaped `--&gt;`,
+      pinned CDN URL, `mermaid.run`. **Verified failing** (basic +
+      revealjs fail, no-mermaid passes as expected). Note learned: a
+      raw CodeBlock already renders a `<pre>` carrying class
+      `mermaid`, so `ensureHtmlElements` alone is weak — the regex
+      assertions carry the test.
+- [x] Reveal scaffold include tests (in `revealjs/assemble.rs`, 4
+      tests): header/after-body/both/absent. **Verified failing** —
+      the scaffold currently drops `rendered.includes.*` entirely.
+- [x] Pipeline wiring tests (in `pipeline.rs`):
+      `mermaid_render_present_before_code_block_render` (html +
+      revealjs) and `q2_preview_pipeline_excludes_mermaid_render`
+      (q2-preview + q2-slides). **Verified failing.**
+
+### Phase 2 — implement native render support
+
+- [x] `MermaidRenderTransform` in
+      `crates/quarto-core/src/transforms/mermaid.rs` with
+      `phase() == Finalization`; `MERMAID_VERSION = "11.12.0"` const;
+      5-char HTML escape; container-descending walker mirroring
+      `CodeBlockRenderTransform`
+- [x] Wire into `build_transform_pipeline` before
+      `CodeBlockRenderTransform`; `"mermaid-render"` added to
+      `Q2_PREVIEW_TRANSFORM_EXCLUDED`; phase-ordering test green
+- [x] Script injection via `rendered.includes.after-body`. The
+      sentinel-dedup appender was promoted from
+      `attribution_viewer.rs` to a shared
+      `transforms::append_with_sentinel` (single definition, both
+      transforms use it)
+- [x] **Discovered + fixed a general gap**: the reveal scaffold
+      (`render_revealjs_document`) consumed NO includes at all —
+      `rendered.includes.{header,after-body}` are now wired into the
+      reveal `<head>` / before-`</body>` (`includes_block` helper).
+      This is what carries `include-in-header` / `include-after-body`
+      authored keys into reveal decks generally, not just mermaid.
+      (`before-body` deferred — no natural anchor inside `.reveal`,
+      no consumer yet.)
+- [x] `cargo nextest run --workspace`: 10222 passed. clippy clean on
+      quarto-core; `cargo fmt --check` clean.
+
+#### Phase 2 end-to-end evidence (2026-07-20, per CLAUDE.md)
+
+Invocation: `cargo run --bin q2 -- render <scratch>/demo.qmd` (html)
+and `<scratch>/slides.qmd` (`format: revealjs`). Inspected output:
+
+- `demo.html:30-32` — `<pre class="mermaid">` / `flowchart LR` /
+  `a --&gt; b` (escaped); `demo.html:44-48` — single
+  `<script type="module">` importing
+  `https://cdn.jsdelivr.net/npm/mermaid@11.12.0/dist/mermaid.esm.min.mjs`,
+  `initialize({ startOnLoad: false })`, `run({ querySelector: 'pre.mermaid' })`
+  just before `</body>`; the ordinary python block still renders as
+  `sourceCode python`.
+- `slides.html` — `pre.mermaid` at line 24 inside the slide
+  `<section>`, `Reveal.initialize` at 36, mermaid script at 57-59,
+  `</body>` at 61 — after-body include correctly placed after deck
+  init.
+
+Browser-visual verification (diagram actually drawn) is Phase 4.
+
+### Phase 3 — preview React component
+
+- [ ] vitest tests first (in `ts-packages/preview-renderer`):
+      registry dispatch (mermaid class → diagram component, other
+      code → plain CodeBlock), error rendering path, loader mocked
+- [ ] `MermaidCodeBlock` + `MermaidDiagram` components; registry
+      entry swap in `registry.ts`
+- [ ] `npm run build:all` from hub-client (strict production build)
+- [ ] `cargo xtask build-q2-preview-spa` + `cargo build --bin q2`
+- [ ] hub-client changelog entries (two-commit workflow)
+
+### Phase 4 — end-to-end verification (per CLAUDE.md, record evidence here)
+
+- [ ] `cargo run --bin q2 -- render fixture.qmd` (`format: html`) —
+      inspect output HTML; open in browser; diagram renders
+- [ ] `cargo run --bin q2 -- render fixture.qmd --to revealjs` —
+      open in browser; diagram renders on its slide; note any
+      sizing/visibility issues on later slides
+- [ ] `q2 preview` (rebuilt binary): `format: q2-preview` doc with a
+      mermaid block renders the diagram live; editing the block
+      re-renders
+- [ ] `q2 preview` / hub-client with `format: revealjs`: diagram
+      renders inside `RevealDeck` slides — **explicitly called out by
+      the user as needing particular testing** (slide mount/visibility
+      timing differs from the flat q2-preview flow); check a diagram
+      on slide 1 and on a later slide
+- [ ] Prototype-compat check: the
+      `~/Desktop/daily-log/2026/07/20/mermaid-react` doc (user
+      `render-components` override) still works — user override
+      shadows the new built-in without breaage
+- [ ] Record invocations + output snippets in this file
+
+### Phase 5 — docs + close-out
+
+- [ ] User-facing docs page under `docs/` (syntax, both formats,
+      CDN note); render with `cargo run --bin q2 -- render docs/`
+      (Q2, not Q1). Relates to existing docs strand bd-5ijtt —
+      re-scope or re-parent it rather than duplicating.
+- [ ] Full `cargo xtask verify`; commit; ask before push
+
+## Resolved decisions (ratified by user 2026-07-20)
+
+1. **CDN version pinning: exact `11.12.0`** (matches Q1's bundled
+   copy). Single shared constant per side — Rust const in the
+   transform, TS const in the React component.
+2. **bd-je48v closed as superseded**; `feature/mermaid-engine` stays
+   unmerged as reference. bd-5ijtt (docs) re-parented to and blocked
+   by bd-5m4ga0s1. Engine-gap follow-ups (bd-14rer, bd-s8llm,
+   bd-mqk49, bd-cp3em) unaffected.
+3. **Script placement: `after-body`** include (Q1 precedent).
+4. **Theming deferred** — first cut renders mermaid's default theme.
+   Follow-up strand filed: **bd-nj25kgbu** ("Mermaid theming:
+   `--mermaid-*` CSS variables + mermaid theme metadata",
+   discovered-from bd-5m4ga0s1) covering Q1's CSS-variable system
+   wired into our SCSS pipeline, the `mermaid: theme:` metadata
+   pass-through, and preview/render parity.
+5. **`{mermaid}` cells not recognized** in the first cut; plain
+   ` ```mermaid ` only.
+
+## References
+
+- Prototype: `~/Desktop/daily-log/2026/07/20/mermaid-react/{mermaid-react.qmd,mermaid.tsx}`
+- Engine-era design (superseded): `claude-notes/plans/2026-05-28-mermaidjs-engine-design.md`
+- Engine-era code (unmerged): branch `feature/mermaid-engine` —
+  `crates/quarto-core/src/engine/mermaid.rs`, `tests/mermaid_pipeline.rs`
+- Transform pipeline contract: `claude-notes/designs/transform-pipeline-phases.md`;
+  `build_transform_pipeline` at `crates/quarto-core/src/pipeline.rs:1173`,
+  Finalization seams ~1373-1400, `Q2_PREVIEW_TRANSFORM_EXCLUDED` ~1461
+- Includes mechanism precedents:
+  `crates/quarto-core/src/transforms/website_favicon.rs`,
+  `crates/quarto-core/src/project/listing/feed/link_inject.rs:38`,
+  `crates/quarto-core/src/stage/stages/include_resolve.rs`
+- Preview registry: `ts-packages/preview-renderer/src/q2-preview/registry.ts:37-48`;
+  built-in CodeBlock `.../blocks/CodeBlock.tsx`; iframe entry
+  `.../q2-preview/entry.tsx`; merge site `PreviewRoot.tsx:1423-1426`;
+  reveal path `RevealDeck.tsx`
+- Quarto 1 reference: `external-sources/quarto-cli/src/core/handlers/mermaid.ts`,
+  `src/resources/formats/html/mermaid/` (mermaid-init.js etc.),
+  docs `external-sources/quarto-web/docs/authoring/diagrams.qmd`

--- a/claude-notes/plans/2026-07-20-mermaid-regular-rendering.md
+++ b/claude-notes/plans/2026-07-20-mermaid-regular-rendering.md
@@ -317,31 +317,58 @@ Browser-visual verification (diagram actually drawn) is Phase 4.
       affordance + data-loc attrs so click-to-edit / scroll-sync
       keep working on diagram blocks.
 - [x] Full preview-renderer suite: 537 passed.
-- [ ] `npm run build:all` from hub-client (strict production build)
-- [ ] hub-client `npm run test:ci`
-- [ ] `cargo xtask build-q2-preview-spa` + `cargo build --bin q2`
-- [ ] hub-client changelog entries (two-commit workflow)
+- [x] `npm run build:all` from hub-client (strict production build) —
+      green
+- [x] hub-client `npm run test:ci` — 129 passed (incl. WASM smoke-all
+      with the mermaid fixtures)
+- [x] `cargo xtask build-q2-preview-spa` + `cargo build --bin q2` —
+      SPA re-embedded, used for Phase 4 browser checks
+- [x] hub-client changelog entry (`cd7f61fd`, two-commit workflow)
+- [x] Post-Phase-4 addition: vitest lock that a user render-components
+      `CodeBlock` shadows the built-in via the merge expression
+      (8 tests total in MermaidCodeBlock.test.tsx)
 
 ### Phase 4 — end-to-end verification (per CLAUDE.md, record evidence here)
 
-- [ ] `cargo run --bin q2 -- render fixture.qmd` (`format: html`) —
-      inspect output HTML; open in browser; diagram renders
-- [ ] `cargo run --bin q2 -- render fixture.qmd --to revealjs` —
-      open in browser; diagram renders on its slide; note any
-      sizing/visibility issues on later slides
-- [ ] `q2 preview` (rebuilt binary): `format: q2-preview` doc with a
-      mermaid block renders the diagram live; editing the block
-      re-renders
-- [ ] `q2 preview` / hub-client with `format: revealjs`: diagram
-      renders inside `RevealDeck` slides — **explicitly called out by
-      the user as needing particular testing** (slide mount/visibility
-      timing differs from the flat q2-preview flow); check a diagram
-      on slide 1 and on a later slide
-- [ ] Prototype-compat check: the
-      `~/Desktop/daily-log/2026/07/20/mermaid-react` doc (user
-      `render-components` override) still works — user override
-      shadows the new built-in without breaage
-- [ ] Record invocations + output snippets in this file
+All browser checks done 2026-07-20 via chrome-devtools MCP; servers
+were the freshly rebuilt `target/debug/q2` (SPA re-embedded).
+
+- [x] `q2 render` (`format: html`) → opened `demo.html` in Chrome:
+      mermaid drew the a→b→c flowchart from the CDN module
+      (`pre.mermaid` gained `data-processed="true"`, SVG with 3
+      `.node`s); the python block still renders as highlighted
+      sourceCode.
+- [x] `q2 render --to revealjs` → opened `slides.html`: diagram SVG
+      rendered on the (initially hidden) later slide; navigated to it
+      via `Reveal.slide(2)` — visible 250×86 SVG on the `.present`
+      section, screenshot inspected.
+- [x] `q2 preview doc.qmd` (`format: q2-preview`): diagram rendered
+      live in the sandboxed iframe (`[data-mermaid-diagram] svg`,
+      `quarto-mermaid-1`, 3 nodes / 2 edges); screenshot inspected.
+      **Live edit**: changed the fenced block on disk 3→5 nodes and
+      back — preview re-rendered each time without reload.
+- [x] `q2 preview slides.qmd` (`format: revealjs` → q2-slides
+      RevealDeck): diagram rendered inside the slide `<section>`
+      **while the slide was not active** with a correct non-zero
+      layout; navigating to the slide shows it correctly (screenshot
+      inspected). This was the user-flagged risk area — no
+      mount/visibility sizing issue observed with mermaid@11.12.0.
+      (hub-client uses the identical shared
+      Q2PreviewIframe→PreviewRoot→RevealDeck path; hub-client
+      integration itself is covered by test:ci + Playwright, no
+      separate manual hub session was run.)
+- [x] Prototype-compat: covered three ways — (1) new vitest lock:
+      a user `CodeBlock` in the merge expression shadows
+      `MermaidCodeBlock`; (2) the full hub-client Playwright
+      `render-components` suite (8 specs) passes against the changed
+      registry (real browser + hub + automerge); (3) **discovered**:
+      the CLI preview SPA never loads `render-components` at all
+      (parent-side plumbing absent in `PreviewApp.tsx`) —
+      pre-existing, now tracked as **bd-ue80chl0**. Consequence: in
+      CLI preview the prototype doc renders via the new built-in
+      (an improvement — previously the override silently didn't load
+      AND there was no built-in, leaving a dead code block).
+- [x] Evidence recorded (this section + Phase 2 section).
 
 ### Phase 5 — docs + close-out
 

--- a/claude-notes/plans/2026-07-20-mermaid-regular-rendering.md
+++ b/claude-notes/plans/2026-07-20-mermaid-regular-rendering.md
@@ -300,12 +300,25 @@ Browser-visual verification (diagram actually drawn) is Phase 4.
 
 ### Phase 3 — preview React component
 
-- [ ] vitest tests first (in `ts-packages/preview-renderer`):
-      registry dispatch (mermaid class → diagram component, other
-      code → plain CodeBlock), error rendering path, loader mocked
-- [ ] `MermaidCodeBlock` + `MermaidDiagram` components; registry
-      entry swap in `registry.ts`
+- [x] vitest tests first
+      (`src/q2-preview/blocks/MermaidCodeBlock.test.tsx`, 7 tests):
+      diagram render + SVG injection, delegation to plain CodeBlock,
+      `{mermaid}` brace form ignored, load-once across diagrams,
+      error box (message + source), registry entry identity, version
+      parity with the Rust const. **Verified failing** (module absent)
+      before implementation.
+- [x] `MermaidCodeBlock` + `MermaidDiagram` in
+      `blocks/MermaidCodeBlock.tsx`; registered as the `CodeBlock`
+      entry in `registry.ts` (delegates non-mermaid to
+      `Blocks.CodeBlock`; user overrides still win via
+      mergedPreviewRegistry). CDN dynamic import with
+      `/* @vite-ignore */`, load-once promise cache, injectable
+      loader test seam. Diagram container preserves the edit
+      affordance + data-loc attrs so click-to-edit / scroll-sync
+      keep working on diagram blocks.
+- [x] Full preview-renderer suite: 537 passed.
 - [ ] `npm run build:all` from hub-client (strict production build)
+- [ ] hub-client `npm run test:ci`
 - [ ] `cargo xtask build-q2-preview-spa` + `cargo build --bin q2`
 - [ ] hub-client changelog entries (two-commit workflow)
 

--- a/crates/quarto-core/src/pipeline.rs
+++ b/crates/quarto-core/src/pipeline.rs
@@ -75,13 +75,13 @@ use crate::transforms::{
     DateNormalizeTransform, EquationLabelTransform, ExampleEmbedRenderTransform,
     ExampleEmbedTransform, FloatRefTargetSugarTransform, FooterGenerateTransform,
     FooterRenderTransform, FootnotesTransform, LinkRewriteTransform, ListingGenerateTransform,
-    ListingRenderTransform, MetadataNormalizeTransform, NavbarGenerateTransform,
-    NavbarRenderTransform, PageNavGenerateTransform, PageNavRenderTransform, ProofSugarTransform,
-    ResourceCollectorTransform, SectionizeTransform, ShortcodeResolveTransform,
-    SidebarGenerateTransform, SidebarRenderTransform, TableBootstrapClassTransform,
-    TheoremSugarTransform, TitleBannerTransform, TitleBlockTransform, TocGenerateTransform,
-    TocRenderTransform, WebsiteBootstrapIconsTransform, WebsiteCanonicalUrlTransform,
-    WebsiteFaviconTransform, WebsiteTitlePrefixTransform,
+    ListingRenderTransform, MermaidRenderTransform, MetadataNormalizeTransform,
+    NavbarGenerateTransform, NavbarRenderTransform, PageNavGenerateTransform,
+    PageNavRenderTransform, ProofSugarTransform, ResourceCollectorTransform, SectionizeTransform,
+    ShortcodeResolveTransform, SidebarGenerateTransform, SidebarRenderTransform,
+    TableBootstrapClassTransform, TheoremSugarTransform, TitleBannerTransform, TitleBlockTransform,
+    TocGenerateTransform, TocRenderTransform, WebsiteBootstrapIconsTransform,
+    WebsiteCanonicalUrlTransform, WebsiteFaviconTransform, WebsiteTitlePrefixTransform,
 };
 
 /// Well-known path for the default CSS artifact in WASM context.
@@ -1397,6 +1397,14 @@ pub fn build_transform_pipeline(
     // hoisted `<img>` is still visible to resource collection). See
     // `reveal_finalization_transforms` and bd-w0c6d38k.
     pipeline.extend(reveal_finalization_transforms(is_revealjs));
+    // bd-5m4ga0s1: replace ```mermaid code blocks with
+    // `<pre class="mermaid">` RawBlocks + the after-body CDN script.
+    // HTML-family self-gated (html + revealjs). Must precede
+    // `code-block-render` so diagram blocks never grow copy-button /
+    // filename chrome. Excluded from q2-preview via
+    // `Q2_PREVIEW_TRANSFORM_EXCLUDED` — the React built-in mermaid
+    // component consumes the raw CodeBlock there.
+    pipeline.push(Box::new(MermaidRenderTransform::new()));
     // bd-1tl09 Phase 0: code-block decoration Render. Consumes the
     // typed payload produced by `code-block-generate` in the
     // Normalization Phase and emits the outer wrapping markup
@@ -1504,6 +1512,12 @@ const Q2_PREVIEW_TRANSFORM_EXCLUDED: &[&str] = &[
     //     replacing the HTML-injection approach with React
     //     components.
     "crossref-render",
+    // `mermaid-render` replaces the diagram CodeBlock with a RawBlock
+    // + after-body CDN script for `q2 render`. In preview the raw
+    // CodeBlock must survive to the React layer, where the built-in
+    // mermaid component (ts-packages/preview-renderer) renders the
+    // diagram live for both q2-preview and q2-slides (bd-5m4ga0s1).
+    "mermaid-render",
 ];
 
 /// Build the q2-preview transform pipeline (Plan 1).
@@ -3216,6 +3230,51 @@ mod tests {
                 names.contains(&required),
                 "{required} must be present in the q2-preview pipeline so preview's React \
                  renderer sees the same decorated code blocks as `q2 render`; got: {names:?}",
+            );
+        }
+    }
+
+    /// bd-5m4ga0s1: `mermaid-render` must run for both HTML-family
+    /// render formats, and must precede `code-block-render` so a
+    /// diagram block is already a `RawBlock` before code-block chrome
+    /// (copy button, filename header) would attach to it.
+    #[test]
+    fn mermaid_render_present_before_code_block_render() {
+        for format in ["html", "revealjs"] {
+            let runtime = make_test_runtime();
+            let pipeline = build_transform_pipeline(vec![], vec![], runtime, format.to_string());
+            let names: Vec<&str> = pipeline.iter().map(|t| t.name()).collect();
+
+            let mermaid_pos = names.iter().position(|&n| n == "mermaid-render");
+            let cbr_pos = names.iter().position(|&n| n == "code-block-render");
+            assert!(
+                mermaid_pos.is_some(),
+                "[{format}] mermaid-render must be in build_transform_pipeline; got: {names:?}",
+            );
+            assert!(
+                mermaid_pos.unwrap() < cbr_pos.expect("code-block-render anchor missing"),
+                "[{format}] mermaid-render must precede code-block-render; got positions \
+                 mermaid={mermaid_pos:?}, code-block-render={cbr_pos:?} in {names:?}",
+            );
+        }
+    }
+
+    /// bd-5m4ga0s1: in `q2 preview` / hub-client the raw `CodeBlock`
+    /// with class `mermaid` must survive to the React layer (the
+    /// built-in mermaid component in ts-packages/preview-renderer owns
+    /// rendering there, for both `q2-preview` and `q2-slides`). The
+    /// transform is therefore on `Q2_PREVIEW_TRANSFORM_EXCLUDED`.
+    #[test]
+    fn q2_preview_pipeline_excludes_mermaid_render() {
+        for format in ["q2-preview", "q2-slides"] {
+            let runtime = make_test_runtime();
+            let pipeline =
+                build_q2_preview_transform_pipeline(vec![], vec![], runtime, format.to_string());
+            let names: Vec<&str> = pipeline.iter().map(|t| t.name()).collect();
+            assert!(
+                !names.contains(&"mermaid-render"),
+                "[{format}] mermaid-render must NOT run in the preview pipeline — the React \
+                 mermaid component consumes the raw CodeBlock; got: {names:?}",
             );
         }
     }

--- a/crates/quarto-core/src/revealjs/assemble.rs
+++ b/crates/quarto-core/src/revealjs/assemble.rs
@@ -412,6 +412,19 @@ pub fn render_revealjs_document(
         .collect::<Vec<_>>()
         .join("\n");
 
+    // Canonical include slots (bd-5m4ga0s1). The Bootstrap HTML
+    // template consumes `rendered.includes.{header,after-body}` via
+    // `$header-includes$` / `$include-after$`; the reveal scaffold
+    // bypasses doctemplate, so wire the same two slots in here. This
+    // is what carries `include-in-header` / `include-after-body`
+    // authored keys and Finalization-transform injections (mermaid
+    // CDN loader, attribution viewer) into reveal decks.
+    // (`before-body` has no natural anchor in the deck scaffold —
+    // reveal.js owns everything inside `.reveal` — and is deferred
+    // until a concrete consumer appears.)
+    let header_includes_block = includes_block(meta, "header");
+    let after_body_block = includes_block(meta, "after-body");
+
     format!(
         r#"<!DOCTYPE html>
 <html lang="{lang}">
@@ -419,7 +432,7 @@ pub fn render_revealjs_document(
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 <title>{title}</title>
-{links}
+{links}{header_includes_block}
 </head>
 <body>
 <div class="{reveal_class}">
@@ -430,18 +443,37 @@ pub fn render_revealjs_document(
 {scripts}
 <script>
 Reveal.initialize({config});
-</script>
+</script>{after_body_block}
 </body>
 </html>
 "#,
         title = escape_html(&title),
         reveal_class = reveal_class,
         links = links,
+        header_includes_block = header_includes_block,
         body = body,
         footer_logo_block = footer_logo_block,
         scripts = scripts,
         config = config,
+        after_body_block = after_body_block,
     )
+}
+
+/// Join the `rendered.includes.<slot>` string entries into a block
+/// ready for interpolation: empty string when the slot is absent or
+/// empty, otherwise `\n`-prefixed so it lands on its own line without
+/// leaving a blank one when unused (same shape as `footer_logo_block`).
+fn includes_block(meta: &ConfigValue, slot: &str) -> String {
+    let entries: Vec<&str> = meta
+        .get_path(&["rendered", "includes", slot])
+        .and_then(|v| v.as_array())
+        .map(|items| items.iter().filter_map(|v| v.as_str()).collect())
+        .unwrap_or_default();
+    if entries.is_empty() {
+        String::new()
+    } else {
+        format!("\n{}", entries.join("\n"))
+    }
 }
 
 /// Escape a string for use inside a double-quoted HTML attribute value.
@@ -555,6 +587,97 @@ mod tests {
     }
     fn sample_js() -> Vec<String> {
         vec!["site_libs/revealjs/reveal.js".to_string()]
+    }
+
+    /// Build a meta map carrying `rendered.includes.{header,after-body}`
+    /// lists, the canonical include slots populated by
+    /// `IncludeResolveStage` and appended to by Finalization transforms
+    /// (mermaid-render, attribution-viewer, …).
+    fn meta_with_includes(header: Vec<&str>, after_body: Vec<&str>) -> ConfigValue {
+        let arr = |items: Vec<&str>| {
+            ConfigValue::new_array(
+                items.into_iter().map(s).collect(),
+                SourceInfo::generated(By::revealjs()),
+            )
+        };
+        meta(vec![
+            ("title", s("T")),
+            (
+                "rendered",
+                meta(vec![(
+                    "includes",
+                    meta(vec![
+                        ("header", arr(header)),
+                        ("after-body", arr(after_body)),
+                    ]),
+                )]),
+            ),
+        ])
+    }
+
+    /// `rendered.includes.header` entries land inside `<head>`,
+    /// mirroring the Bootstrap HTML template's `$header-includes$`
+    /// slot. Reveal decks previously dropped all includes (the
+    /// scaffold bypasses the doctemplate path) — bd-5m4ga0s1 wires the
+    /// two slots in.
+    #[test]
+    fn includes_header_lands_in_head() {
+        let m = meta_with_includes(vec![r#"<meta name="probe" content="x">"#], vec![]);
+        let html = render_revealjs_document("<section></section>", &m, &sample_css(), &sample_js());
+        let head_end = html.find("</head>").expect("scaffold has </head>");
+        let pos = html
+            .find(r#"<meta name="probe" content="x">"#)
+            .expect("header include must be emitted");
+        assert!(
+            pos < head_end,
+            "header include must appear inside <head>; found at {pos}, </head> at {head_end}"
+        );
+    }
+
+    /// `rendered.includes.after-body` entries land after the
+    /// `Reveal.initialize` script and before `</body>`, mirroring the
+    /// HTML template's `$include-after$` slot. Order matters: an
+    /// after-body script (e.g. the mermaid CDN loader) must not run
+    /// before the deck scaffold exists.
+    #[test]
+    fn includes_after_body_lands_before_body_close() {
+        let m = meta_with_includes(vec![], vec!["<script>window.__probe = 1;</script>"]);
+        let html = render_revealjs_document("<section></section>", &m, &sample_css(), &sample_js());
+        let pos = html
+            .find("<script>window.__probe = 1;</script>")
+            .expect("after-body include must be emitted");
+        let init_pos = html
+            .find("Reveal.initialize")
+            .expect("scaffold has Reveal.initialize");
+        let body_end = html.find("</body>").expect("scaffold has </body>");
+        assert!(
+            init_pos < pos && pos < body_end,
+            "after-body include must sit between Reveal.initialize ({init_pos}) and </body> ({body_end}); found at {pos}"
+        );
+    }
+
+    /// Both slots at once: header and after-body each reach their own
+    /// side of the document.
+    #[test]
+    fn includes_both_slots_render() {
+        let m = meta_with_includes(
+            vec![r#"<link rel="probe" href="p.css">"#],
+            vec!["<script>1</script>"],
+        );
+        let html = render_revealjs_document("<section></section>", &m, &sample_css(), &sample_js());
+        let head_end = html.find("</head>").unwrap();
+        assert!(html.find(r#"<link rel="probe" href="p.css">"#).unwrap() < head_end);
+        assert!(html.find("<script>1</script>").unwrap() > head_end);
+    }
+
+    /// No `rendered.includes` in meta: scaffold renders as before,
+    /// with no stray blank sections.
+    #[test]
+    fn includes_absent_is_clean() {
+        let m = meta(vec![("title", s("T"))]);
+        let html = render_revealjs_document("<section></section>", &m, &sample_css(), &sample_js());
+        assert!(html.contains("<title>T</title>"));
+        assert!(!html.contains("\n\n\n"), "no triple blank lines expected");
     }
 
     /// bd-ibqkf9ry: `q2 render` embeds the **vendored** `resources/revealjs/`

--- a/crates/quarto-core/src/transforms/attribution_viewer.rs
+++ b/crates/quarto-core/src/transforms/attribution_viewer.rs
@@ -43,14 +43,13 @@
 
 use std::fmt::Write as _;
 
-use quarto_pandoc_types::ConfigValue;
-use quarto_pandoc_types::config_value::ConfigValueKind;
 use quarto_pandoc_types::pandoc::Pandoc;
 
 use crate::Result;
 use crate::attribution::{IdentityMap, VIEWER_CSS, VIEWER_JS};
 use crate::render::RenderContext;
 use crate::transform::{AstTransform, TransformPhase};
+use crate::transforms::append_with_sentinel;
 
 /// HTML-comment sentinel embedded in the injected `<style>` block.
 /// Used by the dedup scan so a transform re-run is idempotent.
@@ -220,36 +219,4 @@ mod tests {
         // Newlines and quotes get escaped. Backslash too.
         assert_eq!(escape_css_string("a\"b\\c\nd"), "a\\\"b\\\\c\\A d");
     }
-}
-
-/// Append `payload` to `meta.rendered.includes.<slot>`, skipping if
-/// any existing string in that slot already contains `sentinel`. The
-/// dedup keeps the transform idempotent under accidental double
-/// invocation (e.g. tests that rerun the same transform).
-fn append_with_sentinel(meta: &mut ConfigValue, slot: &str, sentinel: &str, payload: String) {
-    if !matches!(&meta.value, ConfigValueKind::Map(_)) {
-        return;
-    }
-    let source_info = meta.source_info.clone();
-
-    if !meta.contains_path(&["rendered", "includes", slot]) {
-        meta.insert_path(
-            &["rendered", "includes", slot],
-            ConfigValue::new_array(vec![], source_info.clone()),
-        );
-    }
-
-    let Some(target) = meta.get_path_mut(&["rendered", "includes", slot]) else {
-        return;
-    };
-    let ConfigValueKind::Array(items) = &mut target.value else {
-        return;
-    };
-    if items
-        .iter()
-        .any(|item| item.as_str().is_some_and(|s| s.contains(sentinel)))
-    {
-        return;
-    }
-    items.push(ConfigValue::new_string(payload, source_info));
 }

--- a/crates/quarto-core/src/transforms/mermaid.rs
+++ b/crates/quarto-core/src/transforms/mermaid.rs
@@ -1,0 +1,467 @@
+/*
+ * transforms/mermaid.rs
+ * Copyright (c) 2026 Posit, PBC
+ */
+
+//! Render ` ```mermaid ` fenced code blocks as browser-rendered
+//! diagrams for HTML-family output (`format: html`, `format: revealjs`).
+//!
+//! A plain fenced block with the `mermaid` class — pampa parses
+//! ` ```mermaid ` to `CodeBlock(("", ["mermaid"], []), source)` — is
+//! replaced with `RawBlock("html", "<pre class=\"mermaid\">…</pre>")`
+//! (source HTML-escaped). When at least one diagram was found, a
+//! once-per-document `<script type="module">` that loads mermaid.js
+//! from the jsdelivr CDN and calls `mermaid.run()` is appended to the
+//! canonical `rendered.includes.after-body` list (the
+//! [`WebsiteFaviconTransform`](super::WebsiteFaviconTransform) /
+//! [`AttributionViewerTransform`](super::AttributionViewerTransform)
+//! channel); both the Bootstrap HTML template (`$include-after$`) and
+//! the reveal scaffold ([`render_revealjs_document`]) wire that slot
+//! in before `</body>`.
+//!
+//! Design notes (bd-5m4ga0s1, plan
+//! `claude-notes/plans/2026-07-20-mermaid-regular-rendering.md`):
+//!
+//! - **Not an engine.** This supersedes the unmerged
+//!   `feature/mermaid-engine` approach (bd-je48v): no `engine:`
+//!   declaration, no capture/replay involvement — the block is plain
+//!   markdown that any surface can fall back to rendering as code.
+//! - **Presentation transform**: [`TransformPhase::Finalization`],
+//!   ordered before [`CodeBlockRenderTransform`](super::CodeBlockRenderTransform)
+//!   so diagram blocks never grow copy-button/filename chrome, and
+//!   (being inside `AstTransformsStage`) before `CodeHighlightStage`
+//!   ever sees them.
+//! - **Excluded from the q2-preview pipeline**
+//!   (`Q2_PREVIEW_TRANSFORM_EXCLUDED`): in `q2 preview` / hub-client
+//!   the raw `CodeBlock` must survive to the React layer, where the
+//!   built-in mermaid component (ts-packages/preview-renderer) owns
+//!   rendering for both `q2-preview` and `q2-slides`.
+//! - **`{mermaid}` executable cells are deliberately NOT recognized**
+//!   (first-cut decision, ratified 2026-07-20): knitr's
+//!   `handledLanguages` already claims `mermaid`, so brace-form cells
+//!   remain engine territory.
+//! - Explicit `mermaid.run()` rather than `startOnLoad: true` so the
+//!   diagrams render regardless of when the module executes relative
+//!   to `DOMContentLoaded`.
+//!
+//! [`render_revealjs_document`]: crate::revealjs::render_revealjs_document
+
+use quarto_pandoc_types::block::{Block, Blocks, RawBlock};
+use quarto_pandoc_types::pandoc::Pandoc;
+
+use crate::Result;
+use crate::render::RenderContext;
+use crate::transform::{AstTransform, TransformPhase};
+use crate::transforms::append_with_sentinel;
+
+/// Exact-pinned mermaid.js version (decision 1, plan §Resolved
+/// decisions — matches the copy Quarto 1 bundles). The TS preview
+/// component pins the same version in
+/// `ts-packages/preview-renderer/src/q2-preview/blocks/MermaidCodeBlock.tsx`;
+/// bump both together.
+pub const MERMAID_VERSION: &str = "11.12.0";
+
+/// HTML-comment sentinel embedded in the injected `<script>` block so
+/// a transform re-run is idempotent (same contract as the
+/// attribution-viewer includes).
+const MERMAID_JS_SENTINEL: &str = "<!-- quarto-mermaid-js -->";
+
+/// See module docs.
+pub struct MermaidRenderTransform;
+
+impl MermaidRenderTransform {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for MermaidRenderTransform {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait::async_trait(?Send)]
+impl AstTransform for MermaidRenderTransform {
+    fn name(&self) -> &str {
+        "mermaid-render"
+    }
+
+    fn phase(&self) -> TransformPhase {
+        TransformPhase::Finalization
+    }
+
+    async fn transform(&self, ast: &mut Pandoc, ctx: &mut RenderContext) -> Result<()> {
+        // Self-gate: mermaid.js is a browser runtime; only HTML-family
+        // output (html, revealjs) can host it. A future PDF/docx story
+        // needs pre-rendering (Q1 uses headless Chrome) — out of scope
+        // for the first cut, see the plan's §Syntax decision.
+        if !ctx.format.identifier.is_html_based() {
+            return Ok(());
+        }
+
+        let mut found = false;
+        convert_mermaid_blocks(&mut ast.blocks, &mut found);
+        if found {
+            append_with_sentinel(
+                &mut ast.meta,
+                "after-body",
+                MERMAID_JS_SENTINEL,
+                mermaid_script_block(),
+            );
+        }
+        Ok(())
+    }
+}
+
+/// Walk `blocks`, replacing each `CodeBlock` carrying the `mermaid`
+/// class with the `<pre class="mermaid">` RawBlock. Descends into the
+/// same container variants as
+/// [`CodeBlockRenderTransform`](super::CodeBlockRenderTransform)'s
+/// walker so nested diagrams (columns, slide sections, list items)
+/// convert too.
+fn convert_mermaid_blocks(blocks: &mut Blocks, found: &mut bool) {
+    for block in blocks.iter_mut() {
+        match block {
+            Block::CodeBlock(cb) if cb.attr.1.iter().any(|c| c == "mermaid") => {
+                *found = true;
+                let text = format!("<pre class=\"mermaid\">\n{}\n</pre>", html_escape(&cb.text));
+                let source_info = cb.source_info.clone();
+                *block = Block::RawBlock(RawBlock {
+                    format: "html".to_string(),
+                    text,
+                    source_info,
+                });
+            }
+            Block::BlockQuote(bq) => convert_mermaid_blocks(&mut bq.content, found),
+            Block::Div(div) => convert_mermaid_blocks(&mut div.content, found),
+            Block::Figure(fig) => convert_mermaid_blocks(&mut fig.content, found),
+            Block::OrderedList(list) => {
+                for item in list.content.iter_mut() {
+                    convert_mermaid_blocks(item, found);
+                }
+            }
+            Block::BulletList(list) => {
+                for item in list.content.iter_mut() {
+                    convert_mermaid_blocks(item, found);
+                }
+            }
+            Block::DefinitionList(dl) => {
+                for (_term, defs) in dl.content.iter_mut() {
+                    for def in defs.iter_mut() {
+                        convert_mermaid_blocks(def, found);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+/// The once-per-document CDN loader. `mermaid.run()` is called
+/// explicitly (not `startOnLoad: true`) so diagrams render regardless
+/// of when the module executes relative to `DOMContentLoaded` — the
+/// script sits in the after-body slot, and in embedded contexts
+/// (iframes, late injection) load-event timing is not guaranteed.
+fn mermaid_script_block() -> String {
+    format!(
+        "{MERMAID_JS_SENTINEL}\n\
+         <script type=\"module\">\n\
+         import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@{MERMAID_VERSION}/dist/mermaid.esm.min.mjs';\n\
+         mermaid.initialize({{ startOnLoad: false }});\n\
+         mermaid.run({{ querySelector: 'pre.mermaid' }});\n\
+         </script>"
+    )
+}
+
+/// HTML-escape diagram source for embedding as `<pre>` text content.
+/// Same five-character escape as
+/// [`CodeBlockRenderTransform`](super::CodeBlockRenderTransform)'s
+/// filename escaping: mermaid source is user-controlled and flows
+/// into a RawBlock the writer emits verbatim.
+fn html_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&#x27;"),
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::format::Format;
+    use crate::project::{DocumentInfo, ProjectConfig, ProjectContext};
+    use crate::render::BinaryDependencies;
+    use quarto_pandoc_types::ConfigValue;
+    use quarto_pandoc_types::attr::AttrSourceInfo;
+    use quarto_pandoc_types::block::{Block, CodeBlock, Div};
+    use quarto_source_map::SourceInfo;
+
+    fn make_codeblock(classes: &[&str], text: &str) -> Block {
+        Block::CodeBlock(CodeBlock {
+            attr: (
+                String::new(),
+                classes.iter().map(|c| c.to_string()).collect(),
+                hashlink::LinkedHashMap::new(),
+            ),
+            text: text.to_string(),
+            source_info: SourceInfo::for_test(),
+            attr_source: AttrSourceInfo::empty(),
+        })
+    }
+
+    fn make_test_project() -> ProjectContext {
+        ProjectContext {
+            dir: std::path::PathBuf::from("/project"),
+            config: ProjectConfig::default(),
+            is_single_file: true,
+            files: vec![DocumentInfo::from_path("/project/doc.qmd")],
+            output_dir: std::path::PathBuf::from("/project"),
+        }
+    }
+
+    async fn run_transform(ast: &mut Pandoc, format: Format) {
+        let project = make_test_project();
+        let doc = DocumentInfo::from_path("/project/doc.qmd");
+        let binaries = BinaryDependencies::new();
+        let mut ctx = RenderContext::new(&project, &doc, &format, &binaries);
+        MermaidRenderTransform::new()
+            .transform(ast, &mut ctx)
+            .await
+            .unwrap();
+    }
+
+    /// Read `rendered.includes.after-body` as plain strings.
+    fn after_body_includes(meta: &ConfigValue) -> Vec<String> {
+        meta.get_path(&["rendered", "includes", "after-body"])
+            .and_then(|v| v.as_array())
+            .map(|items| {
+                items
+                    .iter()
+                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    fn default_meta() -> ConfigValue {
+        // A Map, as real documents always have (front matter). The
+        // includes helper no-ops on non-map meta.
+        ConfigValue::new_map(vec![], SourceInfo::for_test())
+    }
+
+    /// A `CodeBlock` with class `mermaid` becomes a
+    /// `RawBlock("html", <pre class="mermaid">…</pre>)`, and the CDN
+    /// script lands in `rendered.includes.after-body`.
+    #[tokio::test]
+    async fn mermaid_codeblock_becomes_pre_rawblock() {
+        let mut ast = Pandoc {
+            meta: default_meta(),
+            blocks: vec![make_codeblock(&["mermaid"], "flowchart LR\n  a --> b")],
+        };
+        run_transform(&mut ast, Format::html()).await;
+
+        assert_eq!(ast.blocks.len(), 1);
+        let Block::RawBlock(raw) = &ast.blocks[0] else {
+            panic!("expected RawBlock; got {:?}", ast.blocks[0]);
+        };
+        assert_eq!(raw.format, "html");
+        assert_eq!(
+            raw.text,
+            "<pre class=\"mermaid\">\nflowchart LR\n  a --&gt; b\n</pre>"
+        );
+
+        let includes = after_body_includes(&ast.meta);
+        assert_eq!(includes.len(), 1);
+        let script = &includes[0];
+        assert!(
+            script
+                .contains("https://cdn.jsdelivr.net/npm/mermaid@11.12.0/dist/mermaid.esm.min.mjs"),
+            "script must import the exact-pinned CDN build; got:\n{script}"
+        );
+        assert!(
+            script.contains("mermaid.initialize({ startOnLoad: false })"),
+            "script must initialize with startOnLoad false; got:\n{script}"
+        );
+        assert!(
+            script.contains("mermaid.run({ querySelector: 'pre.mermaid' })"),
+            "script must run explicitly on pre.mermaid; got:\n{script}"
+        );
+    }
+
+    /// Two diagrams → two `<pre>` blocks, but the script is appended
+    /// exactly once.
+    #[tokio::test]
+    async fn script_appended_once_for_multiple_diagrams() {
+        let mut ast = Pandoc {
+            meta: default_meta(),
+            blocks: vec![
+                make_codeblock(&["mermaid"], "flowchart LR\n  a --> b"),
+                make_codeblock(&["mermaid"], "sequenceDiagram\n  A->>B: hi"),
+            ],
+        };
+        run_transform(&mut ast, Format::html()).await;
+
+        assert!(
+            matches!(&ast.blocks[0], Block::RawBlock(r) if r.text.contains("pre class=\"mermaid\""))
+        );
+        assert!(
+            matches!(&ast.blocks[1], Block::RawBlock(r) if r.text.contains("pre class=\"mermaid\""))
+        );
+        assert_eq!(after_body_includes(&ast.meta).len(), 1);
+    }
+
+    /// Re-running the transform on already-transformed output must not
+    /// duplicate the script (sentinel dedup, mirroring the
+    /// attribution-viewer contract).
+    #[tokio::test]
+    async fn rerun_does_not_duplicate_script() {
+        let mut ast = Pandoc {
+            meta: default_meta(),
+            blocks: vec![make_codeblock(&["mermaid"], "flowchart LR\n  a --> b")],
+        };
+        run_transform(&mut ast, Format::html()).await;
+        // Second run: the block is now a RawBlock (no CodeBlock to
+        // match), but even a doc that still contains a mermaid block
+        // must not gain a second script.
+        ast.blocks
+            .push(make_codeblock(&["mermaid"], "flowchart TD\n  x --> y"));
+        run_transform(&mut ast, Format::html()).await;
+        assert_eq!(after_body_includes(&ast.meta).len(), 1);
+    }
+
+    /// Documents without mermaid blocks: AST untouched, no script.
+    #[tokio::test]
+    async fn no_mermaid_no_script_no_change() {
+        let mut ast = Pandoc {
+            meta: default_meta(),
+            blocks: vec![make_codeblock(&["python"], "print('hi')")],
+        };
+        run_transform(&mut ast, Format::html()).await;
+
+        assert!(
+            matches!(&ast.blocks[0], Block::CodeBlock(cb) if cb.text == "print('hi')"),
+            "non-mermaid code block must pass through; got {:?}",
+            ast.blocks[0]
+        );
+        assert!(after_body_includes(&ast.meta).is_empty());
+    }
+
+    /// The brace form `{mermaid}` is engine territory (knitr claims
+    /// it) and must NOT be matched. pampa parses ` ```{mermaid} ` to a
+    /// class list containing `{mermaid}`, not `mermaid`.
+    #[tokio::test]
+    async fn brace_form_mermaid_cell_untouched() {
+        let mut ast = Pandoc {
+            meta: default_meta(),
+            blocks: vec![make_codeblock(&["{mermaid}"], "flowchart LR\n  a --> b")],
+        };
+        run_transform(&mut ast, Format::html()).await;
+
+        assert!(
+            matches!(&ast.blocks[0], Block::CodeBlock(_)),
+            "brace-form cell must pass through; got {:?}",
+            ast.blocks[0]
+        );
+        assert!(after_body_includes(&ast.meta).is_empty());
+    }
+
+    /// Diagram source is HTML-escaped: `&`, `<`, `>`.
+    #[tokio::test]
+    async fn diagram_source_is_html_escaped() {
+        let mut ast = Pandoc {
+            meta: default_meta(),
+            blocks: vec![make_codeblock(
+                &["mermaid"],
+                "flowchart LR\n  a[\"<b> & </b>\"] --> b",
+            )],
+        };
+        run_transform(&mut ast, Format::html()).await;
+
+        let Block::RawBlock(raw) = &ast.blocks[0] else {
+            panic!("expected RawBlock");
+        };
+        assert!(
+            raw.text
+                .contains("a[&quot;&lt;b&gt; &amp; &lt;/b&gt;&quot;] --&gt; b"),
+            "source must be escaped; got:\n{}",
+            raw.text
+        );
+        assert!(
+            !raw.text.contains("<b>"),
+            "raw <b> must not survive; got:\n{}",
+            raw.text
+        );
+    }
+
+    /// A mermaid block nested inside a Div (e.g. a `::: {.column}`
+    /// container or a reveal slide section) is converted too.
+    #[tokio::test]
+    async fn nested_mermaid_block_is_converted() {
+        let inner = make_codeblock(&["mermaid"], "flowchart LR\n  a --> b");
+        let mut ast = Pandoc {
+            meta: default_meta(),
+            blocks: vec![Block::Div(Div {
+                attr: (
+                    String::new(),
+                    vec!["section".to_string()],
+                    hashlink::LinkedHashMap::new(),
+                ),
+                content: vec![inner],
+                source_info: SourceInfo::for_test(),
+                attr_source: AttrSourceInfo::empty(),
+            })],
+        };
+        run_transform(&mut ast, Format::html()).await;
+
+        let Block::Div(div) = &ast.blocks[0] else {
+            panic!("expected Div wrapper to survive");
+        };
+        assert!(
+            matches!(&div.content[0], Block::RawBlock(r) if r.text.contains("pre class=\"mermaid\"")),
+            "nested mermaid block must be converted; got {:?}",
+            div.content[0]
+        );
+        assert_eq!(after_body_includes(&ast.meta).len(), 1);
+    }
+
+    /// A code block whose class list includes `mermaid` among others
+    /// (e.g. ` ```{.mermaid .extra} `) is still converted.
+    #[tokio::test]
+    async fn mermaid_with_extra_classes_is_converted() {
+        let mut ast = Pandoc {
+            meta: default_meta(),
+            blocks: vec![make_codeblock(
+                &["mermaid", "extra"],
+                "flowchart LR\n  a --> b",
+            )],
+        };
+        run_transform(&mut ast, Format::html()).await;
+        assert!(matches!(&ast.blocks[0], Block::RawBlock(_)));
+    }
+
+    /// Non-HTML-family formats: transform is a no-op (self-gated).
+    #[tokio::test]
+    async fn non_html_format_is_untouched() {
+        let mut ast = Pandoc {
+            meta: default_meta(),
+            blocks: vec![make_codeblock(&["mermaid"], "flowchart LR\n  a --> b")],
+        };
+        run_transform(&mut ast, Format::pdf()).await;
+
+        assert!(
+            matches!(&ast.blocks[0], Block::CodeBlock(_)),
+            "non-html format must leave the block alone; got {:?}",
+            ast.blocks[0]
+        );
+        assert!(after_body_includes(&ast.meta).is_empty());
+    }
+}

--- a/crates/quarto-core/src/transforms/mod.rs
+++ b/crates/quarto-core/src/transforms/mod.rs
@@ -52,6 +52,7 @@ mod footnotes;
 mod link_rewrite;
 mod listing_generate;
 mod listing_render;
+mod mermaid;
 mod metadata_normalize;
 mod navbar_generate;
 mod navbar_render;
@@ -107,6 +108,7 @@ pub use footnotes::FootnotesTransform;
 pub use link_rewrite::LinkRewriteTransform;
 pub use listing_generate::ListingGenerateTransform;
 pub use listing_render::ListingRenderTransform;
+pub use mermaid::{MERMAID_VERSION, MermaidRenderTransform};
 pub use metadata_normalize::MetadataNormalizeTransform;
 pub(crate) use metadata_normalize::inlines_to_plain_text;
 pub use navbar_generate::NavbarGenerateTransform;
@@ -129,3 +131,51 @@ pub use website_bootstrap_icons::WebsiteBootstrapIconsTransform;
 pub use website_canonical_url::WebsiteCanonicalUrlTransform;
 pub use website_favicon::WebsiteFaviconTransform;
 pub use website_title_prefix::WebsiteTitlePrefixTransform;
+
+/// Append an HTML literal to the canonical `rendered.includes.<slot>`
+/// list (`slot` is `"header"`, `"before-body"`, or `"after-body"`) —
+/// the location populated by
+/// [`IncludeResolveStage`](crate::stage::IncludeResolveStage) and read
+/// by the HTML template (`$header-includes$` / `$include-after$`) and
+/// the reveal scaffold
+/// ([`render_revealjs_document`](crate::revealjs::render_revealjs_document)).
+///
+/// `sentinel` must be a substring embedded in `payload` (typically an
+/// HTML comment); if any existing entry already contains it, the
+/// append is skipped, making transform re-runs idempotent. Shared by
+/// [`AttributionViewerTransform`] and [`MermaidRenderTransform`].
+pub(crate) fn append_with_sentinel(
+    meta: &mut quarto_pandoc_types::ConfigValue,
+    slot: &str,
+    sentinel: &str,
+    payload: String,
+) {
+    use quarto_pandoc_types::ConfigValue;
+    use quarto_pandoc_types::config_value::ConfigValueKind;
+
+    if !matches!(&meta.value, ConfigValueKind::Map(_)) {
+        return;
+    }
+    let source_info = meta.source_info.clone();
+
+    if !meta.contains_path(&["rendered", "includes", slot]) {
+        meta.insert_path(
+            &["rendered", "includes", slot],
+            ConfigValue::new_array(vec![], source_info.clone()),
+        );
+    }
+
+    let Some(target) = meta.get_path_mut(&["rendered", "includes", slot]) else {
+        return;
+    };
+    let ConfigValueKind::Array(items) = &mut target.value else {
+        return;
+    };
+    if items
+        .iter()
+        .any(|item| item.as_str().is_some_and(|s| s.contains(sentinel)))
+    {
+        return;
+    }
+    items.push(ConfigValue::new_string(payload, source_info));
+}

--- a/crates/quarto/tests/smoke-all/mermaid/_quarto.yml
+++ b/crates/quarto/tests/smoke-all/mermaid/_quarto.yml
@@ -1,0 +1,2 @@
+project:
+  title: Mermaid Tests

--- a/crates/quarto/tests/smoke-all/mermaid/basic.qmd
+++ b/crates/quarto/tests/smoke-all/mermaid/basic.qmd
@@ -1,0 +1,34 @@
+---
+title: "Mermaid Basic"
+# bd-5m4ga0s1: a plain ```mermaid fenced block renders as
+# <pre class="mermaid"> with the escaped diagram source, plus a single
+# after-body <script type="module"> loading the exact-pinned CDN build
+# and calling mermaid.run(). The `-->` arrow doubles as the
+# HTML-escaping probe (must appear as --&gt;).
+_quarto:
+  tests:
+    html:
+      noErrors: true
+      ensureHtmlElements:
+        - ["pre.mermaid"]
+        - []
+      ensureFileRegexMatches:
+        - [
+            "<pre class=\"mermaid\">",
+            "flowchart LR",
+            "a --&gt; b",
+            "cdn\\.jsdelivr\\.net/npm/mermaid@11\\.12\\.0/dist/mermaid\\.esm\\.min\\.mjs",
+            "mermaid\\.initialize\\(\\{ startOnLoad: false \\}\\)",
+            "mermaid\\.run\\(\\{ querySelector: 'pre\\.mermaid' \\}\\)",
+          ]
+        - ["a --> b"]
+---
+
+Before the diagram.
+
+```mermaid
+flowchart LR
+  a --> b
+```
+
+After the diagram.

--- a/crates/quarto/tests/smoke-all/mermaid/no-mermaid.qmd
+++ b/crates/quarto/tests/smoke-all/mermaid/no-mermaid.qmd
@@ -1,0 +1,20 @@
+---
+title: "No Mermaid, No Script"
+# bd-5m4ga0s1: the CDN script is injected only when a mermaid block
+# exists. A doc with only ordinary code blocks must not reference the
+# mermaid CDN, and the ordinary block must keep its normal rendering.
+_quarto:
+  tests:
+    html:
+      noErrors: true
+      ensureHtmlElements:
+        - []
+        - ["pre.mermaid"]
+      ensureFileRegexMatches:
+        - []
+        - ["cdn\\.jsdelivr\\.net/npm/mermaid"]
+---
+
+```python
+print("hello")
+```

--- a/crates/quarto/tests/smoke-all/mermaid/revealjs.qmd
+++ b/crates/quarto/tests/smoke-all/mermaid/revealjs.qmd
@@ -1,0 +1,34 @@
+---
+title: "Mermaid Revealjs"
+format: revealjs
+# bd-5m4ga0s1: same transform output inside a reveal deck — the
+# diagram <pre> sits inside a slide <section>, and the CDN script
+# reaches the deck through the rendered.includes.after-body slot newly
+# wired into the reveal scaffold (render_revealjs_document).
+_quarto:
+  tests:
+    revealjs:
+      noErrors: true
+      ensureHtmlElements:
+        - ["section pre.mermaid"]
+        - []
+      ensureFileRegexMatches:
+        - [
+            "<pre class=\"mermaid\">",
+            "cdn\\.jsdelivr\\.net/npm/mermaid@11\\.12\\.0/dist/mermaid\\.esm\\.min\\.mjs",
+            "mermaid\\.run\\(\\{ querySelector: 'pre\\.mermaid' \\}\\)",
+          ]
+        - []
+---
+
+## A slide
+
+Some text.
+
+## Diagram slide
+
+```mermaid
+flowchart LR
+  a --> b
+  b --> c
+```

--- a/crates/wasm-quarto-hub-client/Cargo.lock
+++ b/crates/wasm-quarto-hub-client/Cargo.lock
@@ -377,7 +377,7 @@ dependencies = [
 
 [[package]]
 name = "comrak-to-pandoc"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "comrak",
  "hashlink",
@@ -2074,7 +2074,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-analysis"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "quarto-error-reporting",
  "quarto-pandoc-types",
@@ -2096,7 +2096,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-brand"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "quarto-util",
  "serde",
@@ -2106,7 +2106,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-citeproc"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "glob",
  "hashlink",
@@ -2137,7 +2137,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-core"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2187,7 +2187,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-csl"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "quarto-error-reporting",
  "quarto-source-map",
@@ -2238,7 +2238,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-highlight"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "once_cell",
  "quarto-highlight-encoding",
@@ -2264,7 +2264,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-highlight-encoding"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2272,7 +2272,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-lsp-core"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "pampa",
  "pollster",
@@ -2293,7 +2293,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-navigation"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "quarto-config",
  "quarto-pandoc-types",
@@ -2328,7 +2328,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-project-create"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "quarto-doctemplate",
  "serde",
@@ -2337,7 +2337,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-sass"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "include_dir",
  "once_cell",
@@ -2367,7 +2367,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-system-runtime"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -2384,7 +2384,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-trace"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "flate2",
  "serde",
@@ -2402,7 +2402,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-util"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -2410,7 +2410,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-xml"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "quarto-error-reporting",
  "quarto-source-map",
@@ -4016,7 +4016,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-printf-fmt"
-version = "0.8.0"
+version = "0.9.0"
 
 [[package]]
 name = "wasm-quarto-hub-client"

--- a/docs/guides/authoring/diagrams.qmd
+++ b/docs/guides/authoring/diagrams.qmd
@@ -1,5 +1,132 @@
 ---
-title: Diagrams
+title: "Diagrams"
 ---
 
-TBD.
+## Overview
+
+Quarto renders [Mermaid](https://mermaid.js.org/) diagrams — flowcharts,
+sequence diagrams, state machines, and the other chart types Mermaid
+supports — from a plain-text description inside your document. To create
+a diagram, write a fenced code block whose language is `mermaid`:
+
+````markdown
+```mermaid
+flowchart LR
+  A[Idea] --> B(Draft)
+  B --> C{Review}
+  C --> D[Publish]
+  C --> B
+```
+````
+
+This is the same syntax GitHub and GitLab render in their markdown
+previews, so a diagram you wrote for a README works in a Quarto document
+unchanged. Diagram blocks render in the `html` and `revealjs` formats,
+and `q2 preview` draws them live as you edit.
+
+@demo-mermaid-basic shows a complete document with two diagram types
+alongside an ordinary code block:
+
+:::: {#demo-mermaid-basic .embed-example-iframe file="/examples/diagrams/01-mermaid-basic/document.html"}
+````markdown
+---
+title: "Mermaid diagrams"
+---
+
+A fenced code block marked `mermaid` renders as a diagram. A flowchart:
+
+```mermaid
+flowchart LR
+  A[Idea] --> B(Draft)
+  B --> C{Review}
+  C --> D[Publish]
+  C --> B
+```
+
+The same syntax draws every diagram type Mermaid supports. A sequence
+diagram:
+
+```mermaid
+sequenceDiagram
+  participant Author
+  participant Editor
+  Author->>Editor: Submit draft
+  Editor-->>Author: Request changes
+```
+````
+
+A flowchart and a sequence diagram, drawn from fenced `mermaid` blocks;
+code blocks in other languages render as code. [View source](https://github.com/quarto-dev/q2/tree/main/examples/diagrams/01-mermaid-basic)
+::::
+
+To learn the diagram syntax itself — node shapes, arrow styles, and the
+full catalog of diagram types — see the [Mermaid
+documentation](https://mermaid.js.org/intro/).
+
+## Diagrams in presentations
+
+Slides accept the same fenced blocks: a `mermaid` block is ordinary
+slide content, so any slide in a `format: revealjs` deck can carry a
+diagram. @demo-mermaid-revealjs puts diagrams on two slides of a small
+deck:
+
+:::: {#demo-mermaid-revealjs .embed-example-iframe file="/examples/diagrams/02-mermaid-revealjs/slides.html"}
+````markdown
+---
+title: "Diagrams in slides"
+format: revealjs
+---
+
+## A release pipeline
+
+```mermaid
+flowchart LR
+  commit --> build
+  build --> test
+  test --> deploy
+```
+
+## A state machine
+
+```mermaid
+stateDiagram-v2
+  [*] --> Draft
+  Draft --> Review
+  Review --> Published
+```
+````
+
+Diagrams render on their slides at natural size — including slides that
+are not visible when the deck first loads. [View source](https://github.com/quarto-dev/q2/tree/main/examples/diagrams/02-mermaid-revealjs)
+::::
+
+## How diagrams render
+
+Quarto draws diagrams in the browser: the rendered page keeps your
+diagram source and includes one script that loads the Mermaid library
+from the [jsdelivr CDN](https://www.jsdelivr.com/) and converts every
+diagram on the page to an SVG drawing. Two consequences are worth
+knowing:
+
+- **Viewing a page with diagrams requires network access.** Offline,
+  the diagram source appears as preformatted text instead of a drawing.
+- **Documents without diagrams are unaffected.** The library loads only
+  on pages that contain at least one `mermaid` block.
+
+If Mermaid cannot parse a diagram, the browser console reports the
+error; `q2 preview` goes further and shows the error message, together
+with the diagram source, in place of the drawing.
+
+## Differences from Quarto 1
+
+Quarto 1 embeds diagrams through executable cells — ```` ```{mermaid} ````
+with `%%|` cell options — and Quarto 2 does not yet recognize that
+form: only the plain ```` ```mermaid ```` fence renders. The following
+Quarto 1 diagram features are also not yet available:
+
+- Graphviz (`{dot}`) diagrams
+- Figure captions, labels, and cross-references on diagrams
+- Sizing options (`fig-width`, `fig-height`, `fig-responsive`)
+- Pre-rendered PNG/SVG output for print formats (`mermaid-format`)
+- Theming (Mermaid currently renders with its default theme regardless
+  of the document theme)

--- a/examples/diagrams/.gitignore
+++ b/examples/diagrams/.gitignore
@@ -1,0 +1,7 @@
+# Quarto 2 project outputs and caches
+_site/
+.quarto/
+*_files/
+# type: default projects render the output in place beside the source
+document.html
+slides.html

--- a/examples/diagrams/01-mermaid-basic/README.md
+++ b/examples/diagrams/01-mermaid-basic/README.md
@@ -1,0 +1,35 @@
+# 01-mermaid-basic — Mermaid diagrams in an HTML document
+
+A `format: html` document with two Mermaid diagrams — a flowchart and a
+sequence diagram — plus an ordinary code block for contrast.
+
+## What this demonstrates
+
+- **` ```mermaid ` fenced blocks.** A plain fenced code block whose
+  language is `mermaid` renders as a diagram; no front-matter opt-in is
+  needed. This is the same syntax GitHub renders in its markdown preview.
+- **Browser-side rendering.** The rendered page carries the diagram
+  source in a `<pre class="mermaid">` element plus one script that loads
+  mermaid.js from the jsdelivr CDN and draws every diagram at page load.
+- **Ordinary code blocks are untouched.** The `python` block renders as
+  highlighted code, with none of the diagram machinery attached.
+
+## How to run
+
+From the repository root:
+
+```bash
+cargo run --bin q2 -- render examples/diagrams/01-mermaid-basic
+```
+
+The page is written next to the source as `document.html`.
+
+## What to look for
+
+- Two `<pre class="mermaid">` elements holding the escaped diagram
+  source, replaced by SVG drawings when the page loads in a browser.
+- Exactly one `<script type="module">` near `</body>` importing
+  `mermaid@…` from `cdn.jsdelivr.net` — the script appears once no
+  matter how many diagrams the page has.
+- Viewing the page needs network access (the diagram library comes from
+  the CDN); without it the diagram source is shown as preformatted text.

--- a/examples/diagrams/01-mermaid-basic/_quarto.yml
+++ b/examples/diagrams/01-mermaid-basic/_quarto.yml
@@ -1,0 +1,2 @@
+project:
+  type: default

--- a/examples/diagrams/01-mermaid-basic/document.qmd
+++ b/examples/diagrams/01-mermaid-basic/document.qmd
@@ -1,0 +1,32 @@
+---
+title: "Mermaid diagrams"
+---
+
+A fenced code block marked `mermaid` renders as a diagram. A flowchart:
+
+```mermaid
+flowchart LR
+  A[Idea] --> B(Draft)
+  B --> C{Review}
+  C --> D[Publish]
+  C --> B
+```
+
+The same syntax draws every diagram type Mermaid supports. A sequence
+diagram:
+
+```mermaid
+sequenceDiagram
+  participant Author
+  participant Editor
+  Author->>Editor: Submit draft
+  Editor-->>Author: Request changes
+  Author->>Editor: Submit revision
+  Editor->>Author: Accept
+```
+
+Ordinary code blocks are unaffected:
+
+```python
+print("hello")
+```

--- a/examples/diagrams/02-mermaid-revealjs/README.md
+++ b/examples/diagrams/02-mermaid-revealjs/README.md
@@ -1,0 +1,32 @@
+# 02-mermaid-revealjs — Mermaid diagrams on reveal.js slides
+
+A `format: revealjs` deck where two of the three content slides carry a
+Mermaid diagram.
+
+## What this demonstrates
+
+- **The same ` ```mermaid ` syntax works on slides.** A fenced diagram
+  block is ordinary slide content; nothing changes between `format:
+  html` and `format: revealjs`.
+- **Diagrams on any slide.** Diagrams draw correctly even on slides
+  that are not visible when the deck loads — advance to the last slide
+  to see the state machine.
+
+## How to run
+
+From the repository root:
+
+```bash
+cargo run --bin q2 -- render examples/diagrams/02-mermaid-revealjs
+```
+
+The deck is written next to the source as `slides.html`.
+
+## What to look for
+
+- A `<pre class="mermaid">` element inside each diagram slide's
+  `<section>`.
+- The mermaid loader script sits after the `Reveal.initialize` call,
+  delivered through the deck's after-body include slot.
+- In the browser, the flowchart is drawn on slide 2 and the state
+  machine on slide 4, both at their natural size.

--- a/examples/diagrams/02-mermaid-revealjs/_quarto.yml
+++ b/examples/diagrams/02-mermaid-revealjs/_quarto.yml
@@ -1,0 +1,2 @@
+project:
+  type: default

--- a/examples/diagrams/02-mermaid-revealjs/slides.qmd
+++ b/examples/diagrams/02-mermaid-revealjs/slides.qmd
@@ -1,0 +1,30 @@
+---
+title: "Diagrams in slides"
+author: "Jane Doe"
+format: revealjs
+---
+
+## A release pipeline
+
+```mermaid
+flowchart LR
+  commit --> build
+  build --> test
+  test --> deploy
+```
+
+## Why it works
+
+- The diagram block is ordinary slide content
+- Each slide can carry its own diagram
+
+## A state machine
+
+```mermaid
+stateDiagram-v2
+  [*] --> Draft
+  Draft --> Review
+  Review --> Draft: changes requested
+  Review --> Published
+  Published --> [*]
+```

--- a/examples/manifest.yml
+++ b/examples/manifest.yml
@@ -31,3 +31,5 @@ projects:
   - presentations/09-themes
   - presentations/10-footer-logo
   - presentations/11-auto-stretch
+  - diagrams/01-mermaid-basic
+  - diagrams/02-mermaid-revealjs

--- a/hub-client/changelog.md
+++ b/hub-client/changelog.md
@@ -23,6 +23,10 @@ WASM rebuild is needed for a changelog-only edit.
 
 -->
 
+### 2026-07-20
+
+- [`4202d342`](https://github.com/quarto-dev/q2/commits/4202d342): Mermaid diagrams: a fenced code block marked `mermaid` now renders as a live diagram in the preview (both regular documents and revealjs slides), with a readable error box when the diagram source fails to parse. The diagram library loads on demand from the jsdelivr CDN, so diagram-free documents load no extra code.
+
 ### 2026-07-17
 
 - [`4aabfdaa`](https://github.com/quarto-dev/q2/commits/4aabfdaa): Dates in the preview title block are now formatted like the rendered site: `date` and `date-modified` render in a readable long form (e.g. "July 1, 2026") by default, honor the `date-format` option (named styles like `medium` or format strings like `MMM D, YYYY`), and support the `today`, `now`, and `last-modified` keywords.

--- a/ts-packages/preview-renderer/src/q2-preview/blocks/MermaidCodeBlock.test.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/blocks/MermaidCodeBlock.test.tsx
@@ -121,4 +121,15 @@ describe('MermaidCodeBlock', () => {
         // crates/quarto-core/src/transforms/mermaid.rs.
         expect(MERMAID_VERSION).toBe('11.12.0');
     });
+
+    it('is shadowed by a user render-components CodeBlock override', () => {
+        // Prototype-compat lock (bd-5m4ga0s1): the daily-log mermaid
+        // prototype ships its own CodeBlock via render-components.
+        // PreviewRoot merges `{ ...previewRegistry, ...customRegistry }`,
+        // so a user CodeBlock must win over the mermaid-aware built-in.
+        const UserCodeBlock = () => null;
+        const merged = { ...previewRegistry, ...{ CodeBlock: UserCodeBlock } };
+        expect(merged.CodeBlock).toBe(UserCodeBlock);
+        expect(previewRegistry.CodeBlock).toBe(MermaidCodeBlock);
+    });
 });

--- a/ts-packages/preview-renderer/src/q2-preview/blocks/MermaidCodeBlock.test.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/blocks/MermaidCodeBlock.test.tsx
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import {
+    MermaidCodeBlock,
+    MERMAID_VERSION,
+    setMermaidLoaderForTests,
+} from './MermaidCodeBlock';
+import { previewRegistry } from '../registry';
+import type { NodeArgs, CodeBlock as CodeBlockType } from '../../framework';
+
+/**
+ * bd-5m4ga0s1: built-in mermaid rendering for q2-preview / q2-slides.
+ * A ```mermaid fenced block reaches the React layer as a raw
+ * CodeBlock (the Rust `mermaid-render` transform is excluded from the
+ * preview pipeline); the registry's `CodeBlock` entry is the
+ * mermaid-aware wrapper, which renders diagrams via mermaid.js and
+ * delegates everything else to the plain built-in.
+ *
+ * The mermaid loader is injected in tests (`setMermaidLoaderForTests`)
+ * so no network / CDN access happens here; the default loader's
+ * dynamic-import path is exercised in browser e2e (Phase 4).
+ */
+
+const codeBlock = (classes: string[], code: string): CodeBlockType =>
+    ({ t: 'CodeBlock', c: [['', classes, []], code] }) as CodeBlockType;
+
+function renderNode(node: CodeBlockType, Component = MermaidCodeBlock) {
+    const args = { node, setLocalAst: () => {} } as NodeArgs<CodeBlockType>;
+    return render(<Component {...args} />);
+}
+
+describe('MermaidCodeBlock', () => {
+    let renderCalls: string[];
+
+    beforeEach(() => {
+        renderCalls = [];
+    });
+
+    afterEach(() => {
+        setMermaidLoaderForTests(null);
+    });
+
+    /** Install a fake mermaid API; returns the loader spy. */
+    function installFakeMermaid() {
+        const loader = vi.fn(async () => ({
+            render: async (_id: string, code: string) => {
+                renderCalls.push(code);
+                return { svg: '<svg data-fake-mermaid="1"></svg>' };
+            },
+        }));
+        setMermaidLoaderForTests(loader);
+        return loader;
+    }
+
+    it('renders a diagram container and injects the rendered SVG', async () => {
+        installFakeMermaid();
+        const { container } = renderNode(codeBlock(['mermaid'], 'flowchart LR\n  a --> b'));
+
+        const wrapper = container.querySelector('[data-mermaid-diagram]');
+        expect(wrapper).not.toBeNull();
+        await waitFor(() => {
+            expect(container.querySelector('svg[data-fake-mermaid]')).not.toBeNull();
+        });
+        expect(renderCalls).toEqual(['flowchart LR\n  a --> b']);
+        // The raw source must not be shown as code once rendered.
+        expect(container.querySelector('pre')).toBeNull();
+    });
+
+    it('delegates non-mermaid code blocks to the plain CodeBlock', () => {
+        const loader = installFakeMermaid();
+        const { container } = renderNode(codeBlock(['python'], "print('hi')"));
+
+        const pre = container.querySelector('pre');
+        expect(pre).not.toBeNull();
+        expect(pre!.className).toBe('python');
+        expect(pre!.textContent).toBe("print('hi')");
+        expect(container.querySelector('[data-mermaid-diagram]')).toBeNull();
+        expect(loader).not.toHaveBeenCalled();
+    });
+
+    it('does not treat the brace form {mermaid} as a diagram', () => {
+        const loader = installFakeMermaid();
+        const { container } = renderNode(codeBlock(['{mermaid}'], 'flowchart LR\n  a --> b'));
+        expect(container.querySelector('[data-mermaid-diagram]')).toBeNull();
+        expect(loader).not.toHaveBeenCalled();
+    });
+
+    it('loads mermaid once across multiple diagrams', async () => {
+        const loader = installFakeMermaid();
+        const a = renderNode(codeBlock(['mermaid'], 'flowchart LR\n  a --> b'));
+        const b = renderNode(codeBlock(['mermaid'], 'flowchart TD\n  x --> y'));
+        await waitFor(() => {
+            expect(a.container.querySelector('svg[data-fake-mermaid]')).not.toBeNull();
+            expect(b.container.querySelector('svg[data-fake-mermaid]')).not.toBeNull();
+        });
+        expect(loader).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders an error box (message + source) when mermaid rejects', async () => {
+        setMermaidLoaderForTests(async () => ({
+            render: async () => {
+                throw new Error('Parse error on line 1');
+            },
+        }));
+        const { container } = renderNode(codeBlock(['mermaid'], 'not a diagram'));
+        await waitFor(() => {
+            expect(container.querySelector('[data-mermaid-error]')).not.toBeNull();
+        });
+        const box = container.querySelector('[data-mermaid-error]')!;
+        expect(box.textContent).toContain('Parse error on line 1');
+        expect(box.textContent).toContain('not a diagram');
+    });
+
+    it('is registered as the previewRegistry CodeBlock entry', () => {
+        expect(previewRegistry.CodeBlock).toBe(MermaidCodeBlock);
+    });
+
+    it('pins the same mermaid version as the Rust transform', () => {
+        // Keep in sync with MERMAID_VERSION in
+        // crates/quarto-core/src/transforms/mermaid.rs.
+        expect(MERMAID_VERSION).toBe('11.12.0');
+    });
+});

--- a/ts-packages/preview-renderer/src/q2-preview/blocks/MermaidCodeBlock.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/blocks/MermaidCodeBlock.tsx
@@ -1,0 +1,144 @@
+import { useContext, useEffect, useRef, useState } from 'react';
+import { dataLocProps } from '../../framework';
+import type { CodeBlock as CodeBlockType, NodeArgs } from '../../framework';
+import { PreviewContext } from '../PreviewContext';
+import { CodeBlock } from './CodeBlock';
+
+/**
+ * bd-5m4ga0s1: built-in mermaid diagram rendering.
+ *
+ * A ```mermaid fenced block parses to a Pandoc CodeBlock whose class
+ * list contains `mermaid`. In `q2 render` the Rust `mermaid-render`
+ * transform (crates/quarto-core/src/transforms/mermaid.rs) turns it
+ * into `<pre class="mermaid">` + a CDN loader script; that transform
+ * is excluded from the preview pipeline, so here the raw CodeBlock
+ * reaches the React layer and this component owns rendering — for
+ * both `q2-preview` documents and `q2-slides` decks (RevealDeck
+ * renders slide content through the same registry).
+ *
+ * Registered as the `CodeBlock` entry in `registry.ts`; anything
+ * without the `mermaid` class delegates to the plain built-in. User
+ * `render-components` overrides of `CodeBlock` still win over this
+ * component via the `mergedPreviewRegistry` layering.
+ *
+ * mermaid.js is loaded on demand from the CDN (dynamic import, cached
+ * promise) rather than bundled — same first-cut CDN decision as the
+ * Rust side, and diagram-free documents never pay for it. The brace
+ * form `{mermaid}` is deliberately NOT matched (engine territory;
+ * first-cut decision ratified 2026-07-20).
+ */
+
+/**
+ * Exact-pinned mermaid version. Keep in sync with `MERMAID_VERSION`
+ * in `crates/quarto-core/src/transforms/mermaid.rs` — the version
+ * parity is locked by a test on each side.
+ */
+export const MERMAID_VERSION = '11.12.0';
+
+const MERMAID_CDN_URL = `https://cdn.jsdelivr.net/npm/mermaid@${MERMAID_VERSION}/dist/mermaid.esm.min.mjs`;
+
+/** The slice of mermaid's API this component consumes. */
+interface MermaidApi {
+    render(id: string, code: string): Promise<{ svg: string }>;
+}
+
+type MermaidLoader = () => Promise<MermaidApi>;
+
+/**
+ * Default loader: dynamic-import the ESM bundle from the CDN and
+ * initialize it once. `@vite-ignore` keeps Vite from trying to
+ * resolve/bundle the remote URL at build time — this import is meant
+ * to happen in the browser at runtime.
+ */
+const defaultLoader: MermaidLoader = async () => {
+    const mod = await import(/* @vite-ignore */ MERMAID_CDN_URL);
+    const mermaid = mod.default;
+    mermaid.initialize({ startOnLoad: false });
+    return mermaid as MermaidApi;
+};
+
+let activeLoader: MermaidLoader = defaultLoader;
+let mermaidPromise: Promise<MermaidApi> | null = null;
+
+/** Load-once cache shared by every diagram on the page. */
+function getMermaid(): Promise<MermaidApi> {
+    if (!mermaidPromise) {
+        mermaidPromise = activeLoader();
+    }
+    return mermaidPromise;
+}
+
+/**
+ * Test seam: replace (or, with `null`, restore) the mermaid loader.
+ * Resets the load-once cache either way so tests are independent.
+ */
+export function setMermaidLoaderForTests(loader: MermaidLoader | null): void {
+    activeLoader = loader ?? defaultLoader;
+    mermaidPromise = null;
+}
+
+/**
+ * Monotonic id source — `mermaid.render()` requires a document-unique
+ * element id for its transient render container.
+ */
+let renderSeq = 0;
+
+const MermaidDiagram = ({ code }: { code: string }) => {
+    const ref = useRef<HTMLDivElement | null>(null);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        let cancelled = false;
+        setError(null);
+        const id = `quarto-mermaid-${++renderSeq}`;
+        getMermaid()
+            .then((mermaid) => mermaid.render(id, code))
+            .then(({ svg }) => {
+                if (cancelled || !ref.current) return;
+                ref.current.innerHTML = svg;
+            })
+            .catch((err: unknown) => {
+                if (cancelled) return;
+                setError(err instanceof Error ? err.message : String(err));
+            });
+        return () => {
+            cancelled = true;
+        };
+    }, [code]);
+
+    if (error) {
+        return (
+            <div className="mermaid-diagram-error" data-mermaid-error="">
+                <strong>Mermaid error:</strong> {error}
+                <pre>{code}</pre>
+            </div>
+        );
+    }
+
+    return <div ref={ref} className="mermaid-diagram" data-mermaid-diagram="" />;
+};
+
+export const MermaidCodeBlock = (args: NodeArgs<CodeBlockType>) => {
+    const { node } = args;
+    const ctx = useContext(PreviewContext);
+    const [[, classes], code] = node.c;
+
+    if (!classes.includes('mermaid')) {
+        return <CodeBlock {...args} />;
+    }
+
+    // Preserve the edit affordance + source-loc attributes the plain
+    // CodeBlock carries, so click-to-edit and scroll-sync still work
+    // on diagram blocks (the diagram is a *view* of the code cell).
+    const poolId = (node as any).s as string | number | undefined;
+    const resolved = ctx?.resolveSource ? ctx.resolveSource(node) : null;
+    const isEditable =
+        resolved != null && resolved.reachabilityClass !== 'Opaque' && poolId !== undefined;
+    const affordanceAttr = isEditable ? { 'data-block-pool-id': poolId, tabIndex: -1 } : {};
+
+    return (
+        <div className="mermaid-diagram-container" {...affordanceAttr} {...dataLocProps(node)}>
+            <MermaidDiagram code={code} />
+        </div>
+    );
+};

--- a/ts-packages/preview-renderer/src/q2-preview/registry.ts
+++ b/ts-packages/preview-renderer/src/q2-preview/registry.ts
@@ -3,6 +3,7 @@ import * as Blocks from './blocks';
 import * as Inlines from './inlines';
 import * as Custom from './custom';
 import { Block, Inline, CustomBlock, CustomInline } from './dispatchers';
+import { MermaidCodeBlock } from './blocks/MermaidCodeBlock';
 import { PreviewDocument } from './PreviewDocument';
 
 /**
@@ -38,6 +39,12 @@ export const previewRegistry: FormatRegistry = {
     ...Blocks,
     ...Inlines,
     ...Custom, // Callout, Theorem, Proof, FloatRefTarget, Equation, CrossrefResolvedRef, Fallback, PreviewTitleBlock
+    // bd-5m4ga0s1: mermaid-aware CodeBlock wrapper — renders
+    // ```mermaid blocks as diagrams (CDN mermaid.js), delegates
+    // everything else to Blocks.CodeBlock. Overrides the plain entry
+    // from the `...Blocks` spread; user render-components overrides
+    // of `CodeBlock` still layer on top via mergedPreviewRegistry.
+    CodeBlock: MermaidCodeBlock,
     __fallback__: Custom.Fallback,
     __title_block__: Custom.PreviewTitleBlock,
     Block,


### PR DESCRIPTION
## Summary

Implements mermaid diagram support as a **regular rendering feature** (plain ```` ```mermaid ```` fenced blocks), superseding the unmerged engine approach from bd-je48v / `feature/mermaid-engine`. Rationale: engine execution is not ergonomic on hub-client codeless previews, and the React-component path integrates with the new preview architecture. Plan + design record: `claude-notes/plans/2026-07-20-mermaid-regular-rendering.md`.

Two legs sharing one syntax and one pinned version (mermaid **11.12.0**, jsdelivr CDN, version-parity locked by tests on both sides):

- **`q2 render` (html + revealjs)**: `MermaidRenderTransform` (Finalization phase, before `code-block-render`, excluded from the preview pipeline) converts `CodeBlock.mermaid` → `<pre class="mermaid">` RawBlock (HTML-escaped) + a once-per-doc after-body CDN loader via `rendered.includes.after-body`.
- **`q2 preview` / hub-client (q2-preview + q2-slides)**: built-in `MermaidCodeBlock` registered as the `CodeBlock` entry in `previewRegistry` — renders diagrams via CDN-loaded mermaid.js (load-once cache, error box on parse failure), delegates non-mermaid blocks to the plain built-in; user `render-components` overrides still win.

Also fixes a general gap found on the way: **the reveal scaffold dropped all `rendered.includes.*`** — `render_revealjs_document` now wires `header` and `after-body` slots in (include-in-header / include-after-body parity for reveal decks).

Deliberately out of scope (tracked): `{mermaid}` executable cells (knitr owns that namespace), theming (bd-nj25kgbu), captions/crossrefs, PNG/SVG pre-render for non-HTML formats. Discovered + filed: bd-ue80chl0 (CLI preview SPA doesn't load render-components; pre-existing).

## Testing

TDD throughout (all tests verified failing before implementation):

- 9 transform unit tests, 4 reveal-includes tests, 2 pipeline wiring tests (phase-ordering invariant stays green)
- 3 smoke-all fixtures (`mermaid/{basic,revealjs,no-mermaid}.qmd`) exercised by the native, WASM-vitest, and Playwright runners
- 8 vitest component tests incl. Rust↔TS version-parity lock and user-override layering lock
- Full workspace suite: 10222 passed; hub-client `build:all` + `test:ci` green; hub-client Playwright `render-components` suite (8 specs) green
- Browser E2E (recorded in the plan): rendered html + reveal decks draw diagrams from the CDN; `q2 preview` renders live and re-renders on edit; RevealDeck renders correctly on inactive slides
- `cargo xtask verify`: steps 1–11 green locally; step 12 (hub-MCP **live** tests) could not run — the dev machine had no route to sync.automerge.org all session (unrelated package, no dependency on this change). CI should report the authoritative result.

No snapshot files changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)