### PR TITLE
Bump workspace version to 0.10.0 for release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -698,7 +698,7 @@ dependencies = [
 
 [[package]]
 name = "comrak-to-pandoc"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "comrak",
  "hashlink",
@@ -3488,7 +3488,7 @@ dependencies = [
 
 [[package]]
 name = "quarto"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3528,7 +3528,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-analysis"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "insta",
  "quarto-error-reporting",
@@ -3554,7 +3554,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-brand"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "quarto-util",
  "serde",
@@ -3565,7 +3565,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-citeproc"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "glob",
  "hashlink",
@@ -3598,7 +3598,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-core"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3653,7 +3653,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-csl"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "insta",
  "quarto-error-reporting",
@@ -3681,7 +3681,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-error-catalog"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "once_cell",
  "quarto-error-reporting",
@@ -3717,7 +3717,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-highlight"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "hashlink",
  "insta",
@@ -3746,7 +3746,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-highlight-encoding"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3754,7 +3754,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-hub"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "automerge",
@@ -3798,7 +3798,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-hub-provider"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "automerge",
  "ciborium",
@@ -3824,7 +3824,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-lsp"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "insta",
@@ -3840,7 +3840,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-lsp-core"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "insta",
  "pampa",
@@ -3863,7 +3863,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-mcp-launcher"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -3879,7 +3879,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-navigation"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "quarto-config",
  "quarto-pandoc-types",
@@ -3914,7 +3914,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-preview"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "automerge",
@@ -3946,7 +3946,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-project-create"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "quarto-doctemplate",
  "serde",
@@ -3955,7 +3955,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-publish"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3980,7 +3980,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-sass"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "grass",
  "include_dir",
@@ -4014,7 +4014,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-system-runtime"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4032,7 +4032,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-test"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "quarto-core",
@@ -4049,7 +4049,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-trace"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "flate2",
  "serde",
@@ -4060,7 +4060,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-trace-server"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4087,7 +4087,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-util"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -4095,7 +4095,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-xml"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "insta",
  "quarto-error-reporting",
@@ -4315,7 +4315,7 @@ dependencies = [
 
 [[package]]
 name = "reconcile-viewer"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "clap",
  "hashlink",
@@ -6342,7 +6342,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-printf-fmt"
-version = "0.9.0"
+version = "0.10.0"
 
 [[package]]
 name = "wasmparser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Posit Software, PBC"]
 homepage = "https://github.com/posit-dev/quarto-markdown-syntax"
 keywords = ["parser"]


### PR DESCRIPTION
Version bump for the v0.10.0 release, per `claude-notes/instructions/release-runbook.md`.

Ships since v0.9.0:
- Mermaid diagrams as a regular rendering feature (bd-5m4ga0s1, #401)
- pampa raw-json: lossless pampa-native JSON reader/writer (bd-en2hvrwn, #400)

Checks done locally:
- `cargo update --workspace` — only the 28 workspace members bumped, no external dep changes
- `cargo build --bin q2 --locked` → `q2 (quarto 2) 0.10.0`
- `cargo nextest run --workspace` → 10243 passed, 197 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)