### PR TITLE
Title-block bottom-margin parity: port base #title-block-header rule (bd-btjkyylx)

### DIFF
--- a/claude-notes/plans/2026-07-21-quarto-rules-scss-parity-epic.md
+++ b/claude-notes/plans/2026-07-21-quarto-rules-scss-parity-epic.md
@@ -1,0 +1,124 @@
+# Epic: Port TS Quarto `_quarto-rules.scss` to Q2 for HTML DOM parity
+
+**Epic:** bd-4doe9lvt
+**Audit task:** bd-eias3e39
+**Discovered from:** bd-btjkyylx (title-block bottom-margin, PR #406)
+**Date:** 2026-07-21
+
+## Overview
+
+TS Quarto's `src/resources/formats/html/_quarto-rules.scss` (774 lines,
+~80 top-level selectors) is the HTML format's base rule layer. **Q2 has no
+single counterpart layer.** Its rules were ported into Q2 piecemeal — into
+`resources/scss/bootstrap/_bootstrap-rules.scss` and
+`resources/scss/html/templates/title-block.scss` (and a few dedicated layers
+like `copy-code.scss`, `highlight.scss`, `embed-example.scss`) — and the port
+is **incomplete**. The title-block bottom-margin bug (bd-btjkyylx) was one
+missing slice; that it slipped through is the signal that motivates this epic:
+a rule-by-rule port leaves gaps, and we should systematically close them.
+
+**Goal:** bring over the rest of `_quarto-rules.scss` to the extent Q2's
+emitted DOM matches, and adapt the rules that make sense, without shipping dead
+CSS for DOM Q2 doesn't produce.
+
+## Guiding principle
+
+A rule is only worth porting if Q2 emits the DOM it targets. The missing rules
+split into two very different buckets:
+
+- **Port-now** — Q2 already emits the DOM; the rule is a real, visible parity
+  gap (like the title-block margin). Port it.
+- **Blocked-on-emitter** — Q2 does not yet emit the DOM (e.g. Jupyter widget
+  output, knitr SQL tables, layout panels). Porting the CSS now is dead code;
+  the work is really a *feature* strand for the emitter, and the CSS follows.
+
+So the epic's first deliverable is **not** a big CSS commit — it's a
+**categorized inventory** (the audit). The audit promotes port-now rows to
+themed child strands and files blocked rows with `blocks` deps on their emitter
+features.
+
+## Phase 1 — Audit (bd-eias3e39)
+
+For each of the ~80 top-level selectors in `_quarto-rules.scss`:
+
+- [ ] Is the rule **already present** in Q2's SCSS? (grep
+      `_bootstrap-rules.scss`, `title-block.scss`, `copy-code.scss`,
+      `highlight.scss`, `embed-example.scss`, page-footer layer.)
+- [ ] Does Q2's HTML writer / transforms **emit the DOM** the selector targets?
+      (grep `crates/pampa/src/writers/`, `crates/quarto-core/src/transforms/`;
+      render a fixture exercising the feature and inspect the HTML.)
+- [ ] **Categorize:** `PORT-NOW` / `BLOCKED-ON-EMITTER` (name the emitter) /
+      `ALREADY-PRESENT` / `INTENTIONALLY-DROPPED` (with reason).
+- [ ] Write the inventory table to
+      `claude-notes/research/2026-07-DD-quarto-rules-scss-inventory.md`.
+- [ ] File child strands under bd-4doe9lvt from the inventory (see Phase 2).
+
+### Initial coverage scan (from the bd-btjkyylx session — NOT authoritative)
+
+A quick token grep of `resources/scss/` for selector families. **Every row must
+be re-verified by the audit** — "present" only means the token appears
+somewhere, not that the rule matches TS Quarto, and "missing" doesn't say
+whether the DOM is emitted.
+
+| Selector family                | scss token present? |
+| ------------------------------ | ------------------- |
+| `quarto-layout-cell`           | present             |
+| `quarto-float-caption`         | present             |
+| `title-block-header` (base)    | **now complete** (bd-btjkyylx) |
+| `code-copy-outer-scaffold`     | present             |
+| `task-list`                    | present             |
+| `tippy`                        | present             |
+| `panel-input`                  | present             |
+| `quarto-embedded-source-code`  | present             |
+| `quarto-layout-panel`          | missing             |
+| `quarto-figure`                | missing             |
+| `code-overflow-wrap` / `-scroll` | missing           |
+| `footnote-back`                | missing             |
+| `quarto-cover-image`           | missing             |
+| `quarto-unresolved-ref`        | missing             |
+| `widget-subarea`               | missing             |
+| `knitsql-table`                | missing             |
+| `abstract-title`               | missing             |
+| `quarto-float-tbl`             | missing             |
+
+The MISSING set mixes port-now (Q2 emits the DOM) and blocked (Q2 doesn't yet)
+— separating them is the whole point of the audit.
+
+## Phase 2 — Themed port-now strands (created by the audit)
+
+Candidate groupings to become child strands of bd-4doe9lvt (final shape decided
+by the audit):
+
+- [ ] Figures / floats — `quarto-figure`, `quarto-figure > figure`,
+      `quarto-float-caption-*`, `quarto-float-tbl`, `figure > figcaption`.
+- [ ] Code overflow — `pre.code-overflow-wrap`, `pre.code-overflow-scroll`,
+      `pre > code.sourceCode` line-anchor rules.
+- [ ] Footnotes — `.footnote-back`, `.tippy-content .footnote-back`,
+      tippy footnote-popup rules.
+- [ ] Layout panels — `.quarto-layout-panel`, `.quarto-layout-row`,
+      `.quarto-layout-valign-*` (likely blocked on the layout-panel emitter).
+- [ ] Misc — `.quarto-cover-image`, `.quarto-unresolved-ref`,
+      `details`/`summary`, `.visually-hidden`/`.hidden`/`.top-right` utilities.
+
+Each port-now strand follows the bd-btjkyylx template: TDD (compile-output
+assertion) → port the rule into the right existing layer → re-capture the
+`phase5-single-doc-baseline` hash if `styles.css` shifts → end-to-end render
+check.
+
+## Phase 3 — Blocked-on-emitter strands (created by the audit)
+
+For each selector whose DOM Q2 doesn't emit yet, file a strand describing the
+emitter feature and add a `blocks` dep so the CSS work isn't picked up as ready
+prematurely. Known likely-blocked: `widget-subarea` (Jupyter widgets),
+`knitsql-table` (knitr SQL), possibly the layout-panel family.
+
+## Notes
+
+- The byte-identity baseline
+  `crates/quarto-core/tests/fixtures/phase5-single-doc-baseline/expected_hashes.txt`
+  has a strong convention of a `# Re-captured <date> (<strand>): …` comment per
+  intentional CSS change — follow it for every port that shifts `styles.css`.
+- Both `q2 render` and `q2 preview` consume the same `quarto-sass` bundle, so
+  every port fixes both surfaces — but the preview needs a WASM rebuild +
+  server restart to reflect the change (see bd-btjkyylx / CLAUDE.md
+  "Verifying Rust changes in `q2 preview`").

--- a/claude-notes/plans/2026-07-21-title-block-bottom-margin-parity.md
+++ b/claude-notes/plans/2026-07-21-title-block-bottom-margin-parity.md
@@ -1,0 +1,143 @@
+# Title-block bottom-margin parity (Q1 ↔ Q2)
+
+**Strand:** bd-btjkyylx
+**Date:** 2026-07-21
+
+## Overview
+
+In Q2 HTML output, the document title block sits **flush** against the first
+article section — there is no vertical gap. In Q1 the same document renders with
+a comfortable gap below the title block. The goal is to make Q2 match Q1's
+spacing for both `q2 render` and `q2 preview`.
+
+## Findings (measured)
+
+Reproduction (`~/Desktop/daily-log/2026/07/21/test-title-block.qmd`) rendered
+side by side:
+
+- Q1: <http://localhost:3744/>
+- Q2 preview: <http://127.0.0.1:55049/?page=test-title-block.qmd>
+
+Measured with Chrome DevTools (computed styles + bounding rects):
+
+| Element                                | Q1                | Q2               |
+| -------------------------------------- | ----------------- | ---------------- |
+| `#title-block-header` `margin-bottom`  | **17px** (`1rem`) | **0px**          |
+| gap: title-block bottom → first `<section>` top | **17px** | **0px**          |
+| `#title-block-header .abstract` top    | 177 (matches)     | 178 (matches)    |
+| `main.content` `margin-top`            | 17px (matches)    | 17px (matches)   |
+
+The DOM structure is otherwise identical: `main#quarto-document-content.content`
+→ `header#title-block-header.quarto-title-block.default` → `section.level2`.
+Both carry `body.fullcontent.quarto-light`. The **only** relevant difference is
+the missing bottom margin on the header.
+
+### Root cause
+
+TS Quarto defines the base rule in
+`src/resources/formats/html/_quarto-rules.scss` (lines 180–182):
+
+```scss
+#title-block-header {
+  margin-block-end: 1rem;
+  position: relative;
+  margin-top: -1px; // Chrome draws 1px white line between navbar and title block
+}
+```
+
+**Q2 has no `_quarto-rules.scss` layer at all.** Its SCSS bundle
+(`crates/quarto-sass/src/bundle.rs`) assembles only:
+
+- the Bootstrap layer — `resources/scss/bootstrap/_bootstrap-rules.scss`
+- the title-block layer — `resources/scss/html/templates/title-block.scss`
+- theme + syntax-highlight layers
+
+Q2 ported *most* of `_quarto-rules.scss`'s title-block styling into
+`title-block.scss` (under the `#title-block-header.quarto-title-block.default`
+selector — abstract, meta grid, etc.), but the **unconditional** base rule on
+`#title-block-header` (which applies regardless of the `.default` variant class)
+was never carried over. The only `#title-block-header { margin-block-end … }`
+rule present in Q2's `_bootstrap-rules.scss` is the responsive override inside
+`body.nav-sidebar { @include media-breakpoint-down(lg) { … margin-block-end: 0 } }`
+— i.e. Q2 has the "collapse the margin on small screens" rule but not the base
+"give it a margin" rule it's meant to collapse.
+
+### Fix verified end-to-end
+
+Injecting the missing rule into the live Q2 preview iframe changed the measured
+gap **0px → 17px**, exactly matching Q1:
+
+```js
+style.textContent =
+  '#title-block-header { margin-block-end: 1rem; position: relative; margin-top: -1px; }';
+// gap_before: 0, gap_after: 17, header margin-bottom: 17px
+```
+
+Because both `q2 render` and `q2 preview` consume the same compiled bundle from
+`quarto-sass`, a single SCSS change fixes both surfaces.
+
+## Plan
+
+### Phase 1 — Test first (TDD)
+
+- [x] Add a compile-output assertion in `crates/quarto-sass`
+      (`test_compile_default_css` in `src/compile.rs`) that the compiled
+      default-theme CSS contains `#title-block-header{margin-block-end:1rem` —
+      the `1rem` value uniquely distinguishes the base rule from the
+      `body.nav-sidebar` responsive override (`…margin-block-end:0`). Confirmed
+      it **failed** against current `main` for the right reason (panic at the
+      new assertion).
+
+### Phase 2 — Implement
+
+- [x] Added the base rule to the `/*-- scss:rules --*/` section of
+      `resources/scss/html/templates/title-block.scss`, immediately before the
+      `#title-block-header.quarto-title-block.default` block:
+      ```scss
+      #title-block-header {
+        margin-block-end: 1rem;
+        position: relative;
+        margin-top: -1px;
+      }
+      ```
+      Unconditional (not nested under `.quarto-title-block.default`), mirroring
+      TS Quarto's `_quarto-rules.scss` ordering (base rule → variant styling).
+- [x] Phase 1 test now passes; all 207 `quarto-sass` tests pass.
+- [x] Updated the byte-identity baseline
+      `crates/quarto-core/tests/fixtures/phase5-single-doc-baseline/expected_hashes.txt`:
+      the `doc_files/styles.css` hash shifted (the compiled CSS gained the
+      rule). `doc.html` hash is unchanged — the change is CSS-only and the
+      fixture's `#title-block-header` element already existed. Added a
+      `# Re-captured 2026-07-21 (bd-btjkyylx …)` comment per the file's
+      convention. This was the only test in the full workspace run affected by
+      the CSS change.
+
+### Phase 3 — Verify
+
+- [x] `cargo nextest run -p quarto-sass` — 207/207 pass.
+- [ ] Full workspace: `cargo nextest run --workspace`.
+- [x] End-to-end (render path): `cargo run --bin q2 -- render <fixture>.qmd`.
+      The emitted `test_files/styles.css` contains the exact rule
+      `#title-block-header{margin-block-end:1rem;position:relative;margin-top:-1px}`
+      — grep-verified from real binary output, byte-for-byte matching Q1's
+      compiled rule. Combined with (a) the rendered DOM being structurally
+      identical to Q1 and (b) the same rule injected into the identical live
+      DOM producing a 0→17px gap earlier this session, this confirms the render
+      output now matches Q1's spacing.
+      *Note: a fresh in-browser screenshot of the served render was blocked by
+      the Chrome extension disconnecting mid-session; the emitted-CSS grep plus
+      the earlier injection measurement are conclusive without it.*
+- [ ] `q2 preview` check: the running preview embeds a separately-built WASM
+      image, so it won't reflect this SCSS change until the WASM chain is
+      rebuilt. `cargo xtask verify` (full, not `--skip-hub-build`) rebuilds it;
+      re-measure the preview gap afterward.
+- [ ] `cargo xtask verify` (full) before requesting push.
+
+## Open questions / notes
+
+- The `.abstract` top-margin already matches (Q2 handles it under `.default`),
+  so no change needed there. Scope this strand strictly to the missing base
+  `#title-block-header` rule.
+- Worth a follow-up audit: what *else* from TS Quarto's `_quarto-rules.scss`
+  never got ported into Q2's layers? This bug suggests the port was
+  rule-by-rule and may have other gaps. File as discovered-from if found.

--- a/claude-notes/plans/2026-07-21-title-block-bottom-margin-parity.md
+++ b/claude-notes/plans/2026-07-21-title-block-bottom-margin-parity.md
@@ -127,11 +127,31 @@ Because both `q2 render` and `q2 preview` consume the same compiled bundle from
       *Note: a fresh in-browser screenshot of the served render was blocked by
       the Chrome extension disconnecting mid-session; the emitted-CSS grep plus
       the earlier injection measurement are conclusive without it.*
-- [ ] `q2 preview` check: the running preview embeds a separately-built WASM
+- [x] `q2 preview` check: the running preview embeds a separately-built WASM
       image, so it won't reflect this SCSS change until the WASM chain is
-      rebuilt. `cargo xtask verify` (full, not `--skip-hub-build`) rebuilds it;
-      re-measure the preview gap afterward.
-- [ ] `cargo xtask verify` (full) before requesting push.
+      rebuilt + the preview server is restarted (documented stale-WASM
+      behavior). Confirmed the WASM CSS path is identical to render
+      (`compile_default_bootstrap_css` → `compile_theme_css` →
+      `compile_default_css` → `load_title_block_layer`), and that
+      `load_title_block_layer` embeds this exact file via a target-agnostic
+      `include_dir!(".../resources/scss/html/templates")`. After rebuilding
+      (`npm run build:wasm` → `cargo xtask build-q2-preview-spa` →
+      `cargo build --bin q2`), verified by `strings` that the ported rule is
+      literally embedded in both the freshly-built WASM and the SPA-bundled
+      WASM the `q2` binary carries. **Not** visually re-measured in a browser —
+      the Chrome extension disconnected mid-session; the embed check +
+      native-compile test are the substitute evidence.
+- [x] `cargo xtask verify` (full): Rust build ✓, workspace tests ✓ (10346),
+      WASM build ✓, SPA dist ✓, hub-mcp non-live tests ✓. The 20 `live:`
+      hub-mcp failures are environmental (no `wss://sync.automerge.org`
+      connectivity in this sandbox — `braid` reported the same) and unrelated
+      to this CSS change.
+
+## Status
+
+- Committed `f0de2005`; **PR #406** opened against `main`
+  (branch `feature/bd-btjkyylx-title-block-margin`). Awaiting review/merge.
+- Strand `bd-btjkyylx` remains open until merge.
 
 ## Open questions / notes
 

--- a/crates/quarto-core/tests/fixtures/phase5-single-doc-baseline/expected_hashes.txt
+++ b/crates/quarto-core/tests/fixtures/phase5-single-doc-baseline/expected_hashes.txt
@@ -178,5 +178,16 @@
 # glyph). doc.html hash unchanged: the fixture has no authors, so
 # neither the new selectors nor the title-block markup changes touch
 # its body/head.
+# Re-captured 2026-07-21 (bd-btjkyylx, title-block bottom-margin parity):
+# doc_files/styles.css hash updated because the base
+# `#title-block-header { margin-block-end: 1rem; position: relative;
+# margin-top: -1px }` rule from TS Quarto's `_quarto-rules.scss` was
+# ported into `resources/scss/html/templates/title-block.scss`. Q2 had
+# only the `body.nav-sidebar` responsive override (`…margin-block-end: 0`)
+# and no base rule, so the title block sat flush against the first article
+# section (Q1 renders a 1rem/17px gap). doc.html hash unchanged: the change
+# is CSS-only and the fixture's `#title-block-header` element already
+# existed — only the compiled CSS gained the rule, so the `styles.css`
+# hash shifts.
 doc.html c85d97d01136c864f9bd54ce0c5a15dd649c029a8f44aa3608819282199e3e57
-doc_files/styles.css d4ca5cf8b3763de4308eefa220028fbe989b6aec6bc5be54127788a940a0e235
+doc_files/styles.css 6eafe1bf027fd735d0c41ecf49cd390f4c627fada4c36cbe5403e2fe877e599a

--- a/crates/quarto-sass/src/compile.rs
+++ b/crates/quarto-sass/src/compile.rs
@@ -664,6 +664,19 @@ mod tests {
             "Should contain .quarto-title-meta class from title-block.scss"
         );
 
+        // Should have the base #title-block-header rule ported from TS Quarto's
+        // _quarto-rules.scss: the unconditional bottom margin that separates the
+        // title block from the first article section. Without it the title block
+        // sits flush against the content (bd-btjkyylx). This is distinct from the
+        // responsive `body.nav-sidebar #title-block-header{margin-block-end:0}`
+        // override, which collapses this margin on small screens — the `1rem`
+        // value uniquely identifies the base rule.
+        assert!(
+            css.contains("#title-block-header{margin-block-end:1rem"),
+            "Should contain the base #title-block-header{{margin-block-end:1rem}} \
+             rule ported from _quarto-rules.scss (bd-btjkyylx)"
+        );
+
         // Should have default syntax-highlight rules for `.hl-*` classes
         // emitted by the HTML writer for tree-sitter captures.
         assert!(

--- a/resources/scss/html/templates/title-block.scss
+++ b/resources/scss/html/templates/title-block.scss
@@ -142,6 +142,19 @@ main.quarto-banner-title-block > section:first-child > h4 {
   margin-right: 0.3em;
 }
 
+/* Base title block: unconditional spacing that applies to every title-block
+   variant. Ported from TS Quarto's _quarto-rules.scss (bd-btjkyylx). The
+   bottom margin separates the title block from the first article section;
+   the responsive `body.nav-sidebar` rule in _bootstrap-rules.scss collapses
+   it to 0 on small screens. `position: relative` establishes a positioning
+   context (e.g. for anchor links); `margin-top: -1px` hides the 1px white
+   line Chrome draws between the navbar and the title block. */
+#title-block-header {
+  margin-block-end: 1rem;
+  position: relative;
+  margin-top: -1px;
+}
+
 /* Title Default */
 #title-block-header.quarto-title-block.default {
   .quarto-title-meta {


### PR DESCRIPTION
## Summary

Q2 HTML rendered the document title block **flush against** the first article section (0px gap) where Q1 renders a `1rem` (~17px) gap. This ports the missing base rule so `q2 render` and `q2 preview` match Q1's spacing.

## Root cause

TS Quarto defines the base rule in `_quarto-rules.scss`:

```scss
#title-block-header {
  margin-block-end: 1rem;
  position: relative;
  margin-top: -1px;
}
```

Q2 has **no `_quarto-rules.scss` layer**. Title-block styling was ported piecemeal into `title-block.scss` (scoped under `.quarto-title-block.default`) and `_bootstrap-rules.scss`, but this *unconditional* base rule was never carried over. Q2 shipped only the responsive `body.nav-sidebar #title-block-header{margin-block-end:0}` override — the rule that collapses this margin on small screens — with no base margin for it to collapse.

## Fix

Add the base rule to the `scss:rules` section of `resources/scss/html/templates/title-block.scss`, unconditional and ahead of the `.default` block (mirroring TS Quarto's ordering). Both `q2 render` and `q2 preview` consume the same compiled `quarto-sass` bundle (the preview via the WASM `compile_default_bootstrap_css` → `compile_theme_css` → `load_title_block_layer` path, which embeds this same file), so one change fixes both surfaces.

## Verification

- **TDD**: added a `test_compile_default_css` assertion for the base rule; confirmed it failed on the pre-fix tree and passes now. The `1rem` value uniquely distinguishes the base rule from the `margin-block-end:0` responsive override.
- **`q2 render` end-to-end**: emitted `styles.css` now contains `#title-block-header{margin-block-end:1rem;position:relative;margin-top:-1px}`, byte-for-byte matching Q1; measured gap **0px → 17px** on the identical DOM.
- **`q2 preview`**: confirmed the ported SCSS is embedded in the freshly-built WASM (and the SPA-bundled WASM the `q2` binary carries); the preview compiles CSS through the same `quarto-sass` path. A running preview server must be **restarted** to pick up the rebuilt WASM (documented stale-WASM behavior).
- **Full workspace**: 10346/10346 tests pass.

## Snapshot / baseline note

The byte-identity baseline `crates/quarto-core/tests/fixtures/phase5-single-doc-baseline/expected_hashes.txt` has its `doc_files/styles.css` hash updated (the compiled CSS gained the rule). `doc.html` hash is **unchanged** (CSS-only change; the `#title-block-header` element already existed). A `# Re-captured 2026-07-21` note documents it per the file's convention. This was the only test in the workspace affected by the change.

## Follow-up

This is the first item from a broader audit (bd-btjkyylx): TS Quarto's `_quarto-rules.scss` (774 lines, ~80 selectors) was ported to Q2 rule-by-rule and has other gaps. A dedicated audit epic will inventory port-now vs. blocked-on-emitter selectors.

Plan: `claude-notes/plans/2026-07-21-title-block-bottom-margin-parity.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)