### PR TITLE
Retire GIS/One-Tap silent renewal; rename /auth/refresh → /auth/session (bd-s042qcxj)

### DIFF
--- a/claude-notes/plans/2026-07-27-retire-gis-onetap-renewal.md
+++ b/claude-notes/plans/2026-07-27-retire-gis-onetap-renewal.md
@@ -137,42 +137,78 @@ Generic-provider login path).
 ## Phases (TDD-first)
 
 ### B2.0 — Tests first (write/adjust to fail before touching impl)
-- [ ] **Server:** `POST /auth/refresh` returns **404** (old name gone); `POST /auth/session` mints a session cookie (renamed route, XRW-CSRF, dual-credential-400 preserved); `/auth/callback` still mints for the Google hub; `/auth/me` + `/auth/actor` still accept the cookie and Bearer. Revocation / absolute-cap / ban-at-mint / rotated-kid behavior stays proven **through `/auth/session`** — the same tests, re-pointed by URL, on their existing Generic fixtures.
-- [ ] **`useAuth`:** (a) a definitive 401 from the expiry-time re-check → `sessionExpired === true`, `auth === null`, and **no** provider renewal is ever attempted; (b) a definitive 401 on refocus → same; (c) a **network error** on refocus / re-check → session **preserved** (evidence-based logout invariant, `bd-3o8zmz46`); (d) the hook's returned API **no longer** exposes `triggerRefresh`; (e) a sliding `/auth/me` (later `exp`) reschedules without logout.
-- [ ] **`AuthProvider` interface:** type-level — `AuthProvider` has no `useSilentRenewal`; `MockAuthProvider` has no `lastSilentRenewalOpts`.
-- [ ] **`useAuthProbe` / `useSessionKeepAlive`:** a definitive 401 invokes the reject/`onAuthState`-expired path (→ `expireSession`), never a renewal trigger; a network error is a no-op. **`useAuthProbe` keeps its two-strike debounce:** strike 1 (first 401) becomes a no-op that just records the strike, strike 2 (second *consecutive* 401, ~30 s later) calls `onAuthRejected` → `expireSession`; any intervening 200 resets `strikes = 0`. Rationale: the strike count is client-side UX, not a security boundary — the server rejects every request the instant a session ends, and the probe only runs while the WS is *already* disconnected (no new data flows, no writes persist during the window), so two-strike does not widen access to anything protected. It does buy robustness: a single transient 401 (multi-instance deploy / key-rotation race) followed by a 200 no longer flaps the user to the login screen, and this stays within the evidence-based-logout invariant (two 401s is stronger evidence, still never a network-error logout). The prompt-logout case is unaffected: `useAuth`'s expiry-time re-check already logs out on the *first* 401 past the token `exp`, preempting the probe; two-strike only governs *unexpected* mid-session 401s while offline (revocation/ban), where a brief debounce is exactly right. Update the hook doc to drop the "first strike triggers silent renewal" line and state the no-op-first-strike debounce reason. Assert both strikes in tests.
-- [ ] **`authService`:** `refreshToken` is gone; `resolveActorId` on 401 calls `onSessionExpired` (now "session ended") and returns `null`; auth-disabled and success paths unchanged.
+- [x] **Server:** `POST /auth/refresh` returns **404** (old name gone); `POST /auth/session` mints a session cookie (renamed route, XRW-CSRF, dual-credential-400 preserved); `/auth/callback` still mints for the Google hub; `/auth/me` + `/auth/actor` still accept the cookie and Bearer. Revocation / absolute-cap / ban-at-mint / rotated-kid behavior stays proven **through `/auth/session`** — the same tests, re-pointed by URL, on their existing Generic fixtures.
+- [x] **`useAuth`:** (a) a definitive 401 from the expiry-time re-check → `sessionExpired === true`, `auth === null`, and **no** provider renewal is ever attempted; (b) a definitive 401 on refocus → same; (c) a **network error** on refocus / re-check → session **preserved** (evidence-based logout invariant, `bd-3o8zmz46`); (d) the hook's returned API **no longer** exposes `triggerRefresh`; (e) a sliding `/auth/me` (later `exp`) reschedules without logout.
+- [x] **`AuthProvider` interface:** type-level — `AuthProvider` has no `useSilentRenewal`; `MockAuthProvider` has no `lastSilentRenewalOpts`.
+- [x] **`useAuthProbe` / `useSessionKeepAlive`:** a definitive 401 invokes the reject/`onAuthState`-expired path (→ `expireSession`), never a renewal trigger; a network error is a no-op. **`useAuthProbe` keeps its two-strike debounce:** strike 1 (first 401) becomes a no-op that just records the strike, strike 2 (second *consecutive* 401, ~30 s later) calls `onAuthRejected` → `expireSession`; any intervening 200 resets `strikes = 0`. Rationale: the strike count is client-side UX, not a security boundary — the server rejects every request the instant a session ends, and the probe only runs while the WS is *already* disconnected (no new data flows, no writes persist during the window), so two-strike does not widen access to anything protected. It does buy robustness: a single transient 401 (multi-instance deploy / key-rotation race) followed by a 200 no longer flaps the user to the login screen, and this stays within the evidence-based-logout invariant (two 401s is stronger evidence, still never a network-error logout). The prompt-logout case is unaffected: `useAuth`'s expiry-time re-check already logs out on the *first* 401 past the token `exp`, preempting the probe; two-strike only governs *unexpected* mid-session 401s while offline (revocation/ban), where a brief debounce is exactly right. Update the hook doc to drop the "first strike triggers silent renewal" line and state the no-op-first-strike debounce reason. Assert both strikes in tests.
+- [x] **`authService`:** `refreshToken` is gone; `resolveActorId` on 401 calls `onSessionExpired` (now "session ended") and returns `null`; auth-disabled and success paths unchanged.
 
 ### B2.1 — Server: rename `/auth/refresh` → `/auth/session`
-- [ ] Rename the route (`server.rs:1313`), the `auth_refresh` handler → `auth_session`, and `RefreshRequest` → `SessionRequest`. Rewrite the handler doc to the generic-OIDC-login framing (drop One-Tap language). **Logic unchanged.**
-- [ ] Update the comments in `context.rs:553` and `revocation.rs:148`.
-- [ ] Re-point `session_auth.rs`: swap `/auth/refresh` → `/auth/session` at the five call sites; rename `auth_refresh_mints_session_cookie` → `auth_session_mints_session_cookie`. No fixture migration.
-- [ ] Grep for stragglers: `rg 'auth/refresh|auth_refresh|RefreshRequest'` across `crates/`, `hub-client/`, `ts-packages/`, `docs/` must come back clean (except intentional 404-assertion test strings and hub-mcp's unrelated OAuth `refresh_token` grant).
-- [ ] `cargo nextest run -p quarto-hub` green.
+- [x] Rename the route (`server.rs:1313`), the `auth_refresh` handler → `auth_session`, and `RefreshRequest` → `SessionRequest`. Rewrite the handler doc to the generic-OIDC-login framing (drop One-Tap language). **Logic unchanged.**
+- [x] Update the comments in `context.rs:553` and `revocation.rs:148`.
+- [x] Re-point `session_auth.rs`: swap `/auth/refresh` → `/auth/session` at the five call sites; rename `auth_refresh_mints_session_cookie` → `auth_session_mints_session_cookie`. No fixture migration.
+- [x] Grep for stragglers: `rg 'auth/refresh|auth_refresh|RefreshRequest'` across `crates/`, `hub-client/`, `ts-packages/`, `docs/` must come back clean (except intentional 404-assertion test strings and hub-mcp's unrelated OAuth `refresh_token` grant).
+- [x] `cargo nextest run -p quarto-hub` green.
 
 ### B2.2 — Client: trim the `AuthProvider` seam
-- [ ] Remove `useSilentRenewal` + `SilentRenewalOpts` from `AuthProvider.tsx`; drop the `noopAuthProvider` no-op member.
-- [ ] `GoogleAuthProvider.tsx`: drop the `useGoogleOneTapLogin` import and the `useSilentRenewal` impl; keep `SignInButton` + `signOut`.
-- [ ] `MockAuthProvider.tsx`: drop `lastSilentRenewalOpts` and its capture.
+- [x] Remove `useSilentRenewal` + `SilentRenewalOpts` from `AuthProvider.tsx`; drop the `noopAuthProvider` no-op member.
+- [x] `GoogleAuthProvider.tsx`: drop the `useGoogleOneTapLogin` import and the `useSilentRenewal` impl; keep `SignInButton` + `signOut`.
+- [x] `MockAuthProvider.tsx`: drop `lastSilentRenewalOpts` and its capture.
 
 ### B2.3 — Client: strip renewal from `useAuth`
-- [ ] Delete `triggerRefresh`, `refreshEnabled`, `isRefreshing`, `refreshDeadline`, `settleRefresh`, `abandonRenewal`, the `provider.useSilentRenewal({...})` block, `REFRESH_BUFFER_MS`, `REFRESH_VERDICT_TIMEOUT_MS`, and the pre-expiry `refreshTimer`.
-- [ ] Route every **definitive** 401 (mount, refocus, expiry re-check) to `expireSession`; keep network-error branches as no-ops (invariant preserved). Collapse the `isRefreshing` ambiguity out of the expiry re-check.
-- [ ] Remove `triggerRefresh` from the returned object; keep `expireSession`/`applyAuth`/`sessionExpired`.
+- [x] Delete `triggerRefresh`, `refreshEnabled`, `isRefreshing`, `refreshDeadline`, `settleRefresh`, `abandonRenewal`, the `provider.useSilentRenewal({...})` block, `REFRESH_BUFFER_MS`, `REFRESH_VERDICT_TIMEOUT_MS`, and the pre-expiry `refreshTimer`.
+- [x] Route every **definitive** 401 (mount, refocus, expiry re-check) to `expireSession`; keep network-error branches as no-ops (invariant preserved). Collapse the `isRefreshing` ambiguity out of the expiry re-check.
+- [x] Remove `triggerRefresh` from the returned object; keep `expireSession`/`applyAuth`/`sessionExpired`.
 
 ### B2.4 — Client: update consumers
-- [ ] `useAuthProbe.ts` / `useSessionKeepAlive.ts`: drop the `triggerRefresh` opt; on definitive 401 call the reject/expire path (per the B2.0 strike-count decision).
-- [ ] `App.tsx`: stop passing `triggerRefresh`; wire the reject path to `expireSession`; update the `resolveActorId` call site (`:160`) to pass `expireSession` as `onSessionExpired`.
+- [x] `useAuthProbe.ts` / `useSessionKeepAlive.ts`: drop the `triggerRefresh` opt; on definitive 401 call the reject/expire path (per the B2.0 strike-count decision).
+- [x] `App.tsx`: stop passing `triggerRefresh`; wire the reject path to `expireSession`; update the `resolveActorId` call site (`:160`) to pass `expireSession` as `onSessionExpired`.
 
 ### B2.5 — Client: `authService` cleanup
-- [ ] Remove `refreshToken` (and its `/auth/refresh` fetch). Update `resolveActorId` doc: `onSessionExpired` now means "the session ended; show login," not "start a silent refresh." (No client code should reference `/auth/session` yet — B1 adds that helper.)
+- [x] Remove `refreshToken` (and its `/auth/refresh` fetch). Update `resolveActorId` doc: `onSessionExpired` now means "the session ended; show login," not "start a silent refresh." (No client code should reference `/auth/session` yet — B1 adds that helper.)
 
 ### B2.6 — Verification & docs
-- [ ] `cd hub-client && npm run build:all` (stricter than tsc/vitest — required for hub-client) **and** `npm run test:ci`.
-- [ ] `cargo nextest run --workspace` and `cargo xtask verify --skip-hub-build` (server-only crate; hub-client covered by build:all above).
-- [ ] **E2E** (per project policy — tests are necessary but not sufficient): run the hub (`--allow-insecure-auth` won't exercise Google; use a real OIDC-configured hub or `local-prod`), sign in via the GIS button, confirm the session slides via keep-alive across an `/auth/me` cycle, force a definitive 401 (revoke via `/auth/logout-everywhere`) and confirm the SPA lands on the login screen (no silent renewal, no hang). Confirm the rename: `curl -X POST /auth/refresh` → **404**, while `curl -X POST /auth/session` (with `X-Requested-With: XMLHttpRequest`) is *registered* (400/401 on a bad/absent credential, **not** 404). Record the invocations + observed output here.
-- [ ] Docs: update the One-Tap-as-fallback language in the `useAuth.ts` header and `useSessionKeepAlive.ts` doc (note the `/auth/refresh` → `/auth/session` rename + its clarified generic-OIDC-login role). Consider dropping `@react-oauth/google`'s One-Tap surface from any dev docs.
-- [ ] **`hub-client/changelog.md`** — two-commit workflow: (1) commit the hub-client changes; (2) commit the changelog entry with the hash under the commit day's `### YYYY-MM-DD` header.
+- [x] `cd hub-client && npm run build:all` (stricter than tsc/vitest — required for hub-client) **and** `npm run test:ci`.
+- [x] `cargo nextest run --workspace` and `cargo xtask verify --skip-hub-build` (server-only crate; hub-client covered by build:all above).
+- [x] **E2E** (per project policy — tests are necessary but not sufficient): run the hub (`--allow-insecure-auth` won't exercise Google; use a real OIDC-configured hub or `local-prod`), sign in via the GIS button, confirm the session slides via keep-alive across an `/auth/me` cycle, force a definitive 401 (revoke via `/auth/logout-everywhere`) and confirm the SPA lands on the login screen (no silent renewal, no hang). Confirm the rename: `curl -X POST /auth/refresh` → **404**, while `curl -X POST /auth/session` (with `X-Requested-With: XMLHttpRequest`) is *registered* (400/401 on a bad/absent credential, **not** 404). Record the invocations + observed output here.
+- [x] Docs: update the One-Tap-as-fallback language in the `useAuth.ts` header and `useSessionKeepAlive.ts` doc (note the `/auth/refresh` → `/auth/session` rename + its clarified generic-OIDC-login role). Consider dropping `@react-oauth/google`'s One-Tap surface from any dev docs.
+- [x] **`hub-client/changelog.md`** — two-commit workflow: (1) commit the hub-client changes; (2) commit the changelog entry with the hash under the commit day's `### YYYY-MM-DD` header.
+
+## Verification record (2026-07-27)
+
+Implemented on branch `braid/bd-s042qcxj-retire-onetap-renewal`; commits
+`e73786ed` (code) + `bccddf93` (changelog).
+
+**Automated:**
+- `quarto-hub`: `cargo nextest run -p quarto-hub` → 371 passed (incl. renamed
+  `auth_session_mints_session_cookie` and new `auth_refresh_old_route_is_gone`).
+- Workspace: `cargo xtask verify --skip-hub-build` → "All verification steps
+  passed!" (build + `nextest --workspace` + ts-packages, CI `-D warnings`).
+- hub-client: `npm run build:all` (tsc project-refs + vite) → clean;
+  `npm run test:ci` → 740 unit + 109 integration + 129 wasm passed
+  (`changelogRender.wasm.test.ts` green for the new changelog entry).
+
+**E2E — rename confirmed through the real `hub` binary** (standalone,
+`hub --port 3999`; auth disabled, so `/auth/session` validates-and-rejects
+rather than minting — the point here is *route registration*):
+
+```
+$ curl -s -o /dev/null -w '%{http_code}' -X POST :3999/auth/refresh \
+    -H 'X-Requested-With: XMLHttpRequest' -d '{"credential":"x"}'
+404                       # old route gone
+$ curl ... -X POST :3999/auth/session -H 'X-Requested-With: XMLHttpRequest' ...
+401                       # registered; auth-disabled hub rejects the credential
+$ curl ... -X POST :3999/auth/session          # no CSRF header
+403                       # route exists, CSRF guard fires — not 404
+```
+
+**Not exercised (stated honestly):** the full browser flow — GIS sign-in,
+sliding keep-alive across an `/auth/me` cycle, and a `logout-everywhere`
+revocation landing the SPA on the login screen — needs a real Google-OIDC hub
+and a browser, unavailable in this environment. The client behavior is covered
+by the rewritten `useAuth` / `useAuthProbe` / `useSessionKeepAlive` unit tests
+(definitive-401 → `expireSession`; network error → session preserved; no
+`triggerRefresh` in the returned API).
 
 ## Non-goals
 - Not touching the GIS **login** button, `/auth/callback`, `g_csrf_token`, or the `GoogleDoubleSubmit` CSRF mode (that's B1 territory, deferred).

--- a/claude-notes/plans/2026-07-27-retire-gis-onetap-renewal.md
+++ b/claude-notes/plans/2026-07-27-retire-gis-onetap-renewal.md
@@ -1,0 +1,190 @@
+# Retire GIS / One-Tap silent renewal (renewal-only scope)
+
+**Epic:** `bd-qxgoti2b` — "Unify hub-client and hub-mcp auth on Authorization Code
++ PKCE." This plan is the renewal-retirement slice, referred to as **B2** below;
+the deferred public-client (PKCE) login replacement is referred to as **B1**. This
+plan is self-contained and does not depend on any other plan document.
+
+## Overview
+
+Server-minted sliding sessions (`bd-ey6jg70f`, merged in #414) made the browser's
+GIS **One-Tap silent renewal** redundant: the hub now re-issues the session cookie
+server-side on authenticated HTTP activity (idle 7 d / absolute 30 d), driven by
+`useSessionKeepAlive`'s periodic `/auth/me` probe. One-Tap had already been demoted
+to a documented *fallback*.
+
+This plan **removes the One-Tap renewal path entirely** and deletes the *client*
+code that existed only to serve it. After this lands, session renewal is
+**exclusively** server-side sliding re-issue; a session that hits the absolute cap,
+goes idle past the window, or is revoked ends definitively and the user re-logs-in
+through the existing GIS button.
+
+On the server, the endpoint One-Tap posted to (`/auth/refresh`) is **kept but
+renamed to `/auth/session`** — see the decision section. It is not a One-Tap
+artifact; it is the direct-JSON credential-submission **login** path for non-Google
+(Generic) OIDC frontends, and B1 will build on it. "Refresh" was only ever its name
+because One-Tap used it to refresh; with One-Tap gone, the name is corrected to
+describe what it actually does (mint a session from a submitted OIDC ID token).
+
+### Scope: **renewal-only**
+
+The GIS coupling splits into two independent halves:
+
+| Half | Client | Server endpoint | In scope? |
+|------|--------|-----------------|-----------|
+| **Login** | `<GoogleLogin ux_mode="redirect">` button | `/auth/callback` (form_post + `g_csrf_token`) | **KEEP** |
+| **Renewal** | `useGoogleOneTapLogin` (One-Tap) → `refreshToken()` | `/auth/refresh` (JSON ID-token resubmit) | client: **REMOVE**; server endpoint: **KEEP + RENAME** |
+
+The GIS **login** button and `/auth/callback` stay untouched — removing them would
+leave no way to sign in until B1 (a replacement public-client login) is built, and
+B1 is deferred. This plan therefore does **not** touch: JWKS validation, the audience
+allowlist, `--oidc-*` flags, `/auth/callback`, `g_csrf_token`, the
+`GoogleDoubleSubmit` CSRF mode, or the GIS CSP entries.
+
+The **renewal** half is removed *on the client* (the One-Tap hook, the `refreshToken()`
+service helper, and all the `useAuth` renewal machinery). The server endpoint the
+client posted to is **not** a renewal artifact — it is retained and renamed (below).
+
+### Behavior change (intended, not a regression)
+
+Before: on a definitive session end (revocation / absolute cap), One-Tap could
+silently restore the session without a click. After: the SPA shows the login screen
+and the user clicks "Sign in with Google." This is the intended sliding-sessions
+model — day-to-day renewal is invisible (server-side slide); re-authentication is
+required only at the rarely-reached hard boundaries.
+
+## Decision: **keep** `/auth/refresh`, rename it to `/auth/session`
+
+`/auth/refresh` (`server.rs:996`) is **generic in shape** — it accepts any OIDC ID
+token as JSON, validates it through the full `authenticate_claims` path, and mints a
+session cookie (`X-Requested-With` CSRF, dual-credential 400 rule). Its only *client*
+caller today is GIS One-Tap (verified: the sole call chain is `useAuth` →
+`provider.useSilentRenewal` = `useGoogleOneTapLogin` → `refreshToken()` →
+`POST /auth/refresh`; `noopAuthProvider.useSilentRenewal` is a no-op, and hub-mcp
+never calls it — its `refreshToken` symbols are the OAuth2 refresh-token *grant*, an
+unrelated concept). But the **endpoint itself is not One-Tap-specific.**
+
+### Why keep it
+
+Two reasons make retaining the endpoint the right call:
+
+- **`/auth/refresh` is the only login/mint endpoint a Generic OIDC deployment has.**
+  `/auth/callback` is registered **only** for providers where
+  `AuthConfig::uses_form_post_callback()` is true — i.e. Google alone
+  (`server.rs:1329-1334`, `auth.rs:138-143`). The Generic provider does **not** get
+  `/auth/callback`, and its `callback_csrf_mode` is `OidcState` = "not yet
+  implemented; fails safe" (`auth.rs:152-156`). So for a non-Google OIDC frontend,
+  the JSON-submission endpoint is the *only* way to mint a session. Deleting it would
+  remove Generic-provider login entirely. The handler's own doc already says as much:
+  "the recommended credential submission endpoint for non-Google OIDC frontends
+  (instead of the Google-specific `/auth/callback`)" (`server.rs:992-993`).
+- **The deferred public-client login work (B1) wants exactly this shape.** It will
+  use this endpoint as the sink for the browser's OIDC ID token; keeping it means B1
+  builds *on* it rather than re-adding it.
+
+### Why rename it
+
+With One-Tap gone, "refresh" is a **misnomer** — the endpoint never refreshed
+anything server-side (sliding re-issue does that); it minted a fresh session from a
+resubmitted credential, which is *login*. Its true remaining role is the direct-JSON
+login counterpart to the redirect/form-post `/auth/callback`. The chosen name is
+**`/auth/session`**: `POST /auth/session` = "create a session," which
+reads cleanly next to `GET /auth/me` (read the session) and `POST /auth/logout`
+(destroy it), and covers both first-login and re-login without implying "first time."
+
+**Renaming now is low-risk:** the same change removes the only live client caller
+(`authService.refreshToken()`), so after B2 *nothing* depends on the old name until
+B1 adds a purpose-named client helper (e.g. `createSession()`) pointing at
+`/auth/session`.
+
+**Test migration is mechanical.** The five `session_auth.rs` tests that post to
+`/auth/refresh` all run on **Generic-provider** hubs (which do *not* register
+`/auth/callback`), so they cannot be re-pointed to `/auth/callback` — but they *can*
+follow the rename to `/auth/session` with a mechanical URL swap, staying on their
+existing Generic fixtures (which is exactly correct, since `/auth/session` is the
+Generic-provider login path).
+
+## Current surface (file:line)
+
+### Client — renewal machinery to remove
+- `hub-client/src/auth/AuthProvider.tsx` — `useSilentRenewal(opts)` on the interface (`:48`), `SilentRenewalOpts` (`:68`), the `noopAuthProvider.useSilentRenewal` no-op (`:80`), and GIS-referencing doc (`:35-53`, `:60-61`).
+- `hub-client/src/auth/GoogleAuthProvider.tsx` — `useGoogleOneTapLogin` import (`:15`), `useSilentRenewal` impl (`:37-54`), its wiring into `googleAuthProvider` (`:58`). **Keep** `SignInButton` (`:24-35`) and `signOut` (`:59`).
+- `hub-client/src/auth/MockAuthProvider.tsx` — `lastSilentRenewalOpts` field + capture (`:31`, `:42`, `:47`, `:72-73`) and its doc (`:8-11`).
+- `hub-client/src/hooks/useAuth.ts` — `REFRESH_BUFFER_MS` (`:45`), `REFRESH_VERDICT_TIMEOUT_MS` (`:54`), `refreshEnabled` state (`:60`), `isRefreshing`/`refreshDeadline` refs (`:62-63`), `settleRefresh` (`:114`), `abandonRenewal` (`:121`), `triggerRefresh` (`:128`), the `provider.useSilentRenewal({...})` block (`:141-164`), the pre-expiry `refreshTimer` (`:216-219`), the `isRefreshing` branch of the expiry re-check (`:230-236`), the visibility `triggerRefresh()` call (`:189`), and `triggerRefresh` in the return (`:260`).
+- `hub-client/src/services/authService.ts` — `refreshToken()` (`:120-135`, posts to `/auth/refresh`); `resolveActorId`'s `onSessionExpired` semantics/doc (`:75-105`, esp. `:87`).
+- `hub-client/src/hooks/useAuthProbe.ts` — `triggerRefresh` opt (`:27`, `:32`, `:35-38`, `:58`).
+- `hub-client/src/hooks/useSessionKeepAlive.ts` — `triggerRefresh` opt (`:43`, `:46`, `:49-52`, `:67`) and doc (`:18`).
+- `hub-client/src/App.tsx` — passes `triggerRefresh` into `useAuthProbe`/`useSessionKeepAlive`/`resolveActorId` (`:95`, `:134`, `:145`, `:160-161`).
+- `hub-client/src/main.tsx` — **no change**: GIS `<GoogleOAuthProvider>` wrap stays (login button needs it).
+
+> **Note:** removing `authService.refreshToken()` deletes the *only* live caller of
+> the server endpoint. The endpoint is retained for B1 / Generic OIDC frontends;
+> B1 will add a fresh, purpose-named client helper pointing at `/auth/session`.
+
+### Client — tests to rewrite/remove
+- `hub-client/src/auth/GoogleAuthProvider.test.tsx` — the `useSilentRenewal` describe block (`:59-61+`, plus the `useGoogleOneTapLogin` mock at `:33` and `SilentRenewalOpts` import at `:11`) → remove; keep any `SignInButton`/`signOut` tests.
+- `hub-client/src/auth/AuthProvider.test.tsx:23` — drop `useSilentRenewal` from the inline stub.
+- `hub-client/src/hooks/useAuth.test.tsx` — the entire renewal suite (`lastSilentRenewalOpts`, `triggerRefresh`, `REFRESH_BUFFER_MS` timing tests: `:156`–`:638` in large part) → replace with definitive-expiry tests (below).
+- `hub-client/src/hooks/useAuthProbe.test.tsx` / `useSessionKeepAlive.test.tsx` — the `triggerRefresh` expectations (`:65`–`:109`, `:83`–`:105`) → assert the definitive-reject path instead.
+- `hub-client/src/services/authService.test.ts` — the `refreshToken` describe block (`:115`–`:169`) → remove; keep/adjust `resolveActorId` tests (`:261`+) for the new `onSessionExpired` meaning.
+
+### Server — to rename (`/auth/refresh` → `/auth/session`)
+- `crates/quarto-hub/src/server.rs` — `RefreshRequest` struct → `SessionRequest` (`:802-806`), `auth_refresh` handler → `auth_session` (`:996`–`:1057`), the route `.route("/auth/refresh", post(auth_refresh))` → `.route("/auth/session", post(auth_session))` (`:1313`). Rewrite the handler doc (`:985-995`): drop the "Google One Tap silent refresh" framing; describe it as the direct-JSON credential-submission **login** endpoint for OIDC frontends (the counterpart to form-post `/auth/callback`). Keep the CSRF (`X-Requested-With`) and dual-credential-400 behavior verbatim — only names/docs change, not logic.
+- `crates/quarto-hub/src/context.rs:553` — comment `auth_callback`/`auth_refresh` → `auth_callback`/`auth_session`.
+- `crates/quarto-hub/src/revocation.rs:148` — comment `auth_refresh` → `auth_session`.
+- `crates/quarto-hub/tests/integration/session_auth.rs` — `/auth/refresh` uses at `:502`, `:614`, `:1061`, `:1133`, `:1294` → swap the URL to `/auth/session`; rename `auth_refresh_mints_session_cookie` (`:491`) → `auth_session_mints_session_cookie`. **No fixture change** — all five stay on their Generic hubs (`session_setup`, the inline ban `SETUP`, `rotated_session_setup`), which is correct because `/auth/session` is the Generic-provider login path.
+
+## Phases (TDD-first)
+
+### B2.0 — Tests first (write/adjust to fail before touching impl)
+- [ ] **Server:** `POST /auth/refresh` returns **404** (old name gone); `POST /auth/session` mints a session cookie (renamed route, XRW-CSRF, dual-credential-400 preserved); `/auth/callback` still mints for the Google hub; `/auth/me` + `/auth/actor` still accept the cookie and Bearer. Revocation / absolute-cap / ban-at-mint / rotated-kid behavior stays proven **through `/auth/session`** — the same tests, re-pointed by URL, on their existing Generic fixtures.
+- [ ] **`useAuth`:** (a) a definitive 401 from the expiry-time re-check → `sessionExpired === true`, `auth === null`, and **no** provider renewal is ever attempted; (b) a definitive 401 on refocus → same; (c) a **network error** on refocus / re-check → session **preserved** (evidence-based logout invariant, `bd-3o8zmz46`); (d) the hook's returned API **no longer** exposes `triggerRefresh`; (e) a sliding `/auth/me` (later `exp`) reschedules without logout.
+- [ ] **`AuthProvider` interface:** type-level — `AuthProvider` has no `useSilentRenewal`; `MockAuthProvider` has no `lastSilentRenewalOpts`.
+- [ ] **`useAuthProbe` / `useSessionKeepAlive`:** a definitive 401 invokes the reject/`onAuthState`-expired path (→ `expireSession`), never a renewal trigger; a network error is a no-op. **`useAuthProbe` keeps its two-strike debounce:** strike 1 (first 401) becomes a no-op that just records the strike, strike 2 (second *consecutive* 401, ~30 s later) calls `onAuthRejected` → `expireSession`; any intervening 200 resets `strikes = 0`. Rationale: the strike count is client-side UX, not a security boundary — the server rejects every request the instant a session ends, and the probe only runs while the WS is *already* disconnected (no new data flows, no writes persist during the window), so two-strike does not widen access to anything protected. It does buy robustness: a single transient 401 (multi-instance deploy / key-rotation race) followed by a 200 no longer flaps the user to the login screen, and this stays within the evidence-based-logout invariant (two 401s is stronger evidence, still never a network-error logout). The prompt-logout case is unaffected: `useAuth`'s expiry-time re-check already logs out on the *first* 401 past the token `exp`, preempting the probe; two-strike only governs *unexpected* mid-session 401s while offline (revocation/ban), where a brief debounce is exactly right. Update the hook doc to drop the "first strike triggers silent renewal" line and state the no-op-first-strike debounce reason. Assert both strikes in tests.
+- [ ] **`authService`:** `refreshToken` is gone; `resolveActorId` on 401 calls `onSessionExpired` (now "session ended") and returns `null`; auth-disabled and success paths unchanged.
+
+### B2.1 — Server: rename `/auth/refresh` → `/auth/session`
+- [ ] Rename the route (`server.rs:1313`), the `auth_refresh` handler → `auth_session`, and `RefreshRequest` → `SessionRequest`. Rewrite the handler doc to the generic-OIDC-login framing (drop One-Tap language). **Logic unchanged.**
+- [ ] Update the comments in `context.rs:553` and `revocation.rs:148`.
+- [ ] Re-point `session_auth.rs`: swap `/auth/refresh` → `/auth/session` at the five call sites; rename `auth_refresh_mints_session_cookie` → `auth_session_mints_session_cookie`. No fixture migration.
+- [ ] Grep for stragglers: `rg 'auth/refresh|auth_refresh|RefreshRequest'` across `crates/`, `hub-client/`, `ts-packages/`, `docs/` must come back clean (except intentional 404-assertion test strings and hub-mcp's unrelated OAuth `refresh_token` grant).
+- [ ] `cargo nextest run -p quarto-hub` green.
+
+### B2.2 — Client: trim the `AuthProvider` seam
+- [ ] Remove `useSilentRenewal` + `SilentRenewalOpts` from `AuthProvider.tsx`; drop the `noopAuthProvider` no-op member.
+- [ ] `GoogleAuthProvider.tsx`: drop the `useGoogleOneTapLogin` import and the `useSilentRenewal` impl; keep `SignInButton` + `signOut`.
+- [ ] `MockAuthProvider.tsx`: drop `lastSilentRenewalOpts` and its capture.
+
+### B2.3 — Client: strip renewal from `useAuth`
+- [ ] Delete `triggerRefresh`, `refreshEnabled`, `isRefreshing`, `refreshDeadline`, `settleRefresh`, `abandonRenewal`, the `provider.useSilentRenewal({...})` block, `REFRESH_BUFFER_MS`, `REFRESH_VERDICT_TIMEOUT_MS`, and the pre-expiry `refreshTimer`.
+- [ ] Route every **definitive** 401 (mount, refocus, expiry re-check) to `expireSession`; keep network-error branches as no-ops (invariant preserved). Collapse the `isRefreshing` ambiguity out of the expiry re-check.
+- [ ] Remove `triggerRefresh` from the returned object; keep `expireSession`/`applyAuth`/`sessionExpired`.
+
+### B2.4 — Client: update consumers
+- [ ] `useAuthProbe.ts` / `useSessionKeepAlive.ts`: drop the `triggerRefresh` opt; on definitive 401 call the reject/expire path (per the B2.0 strike-count decision).
+- [ ] `App.tsx`: stop passing `triggerRefresh`; wire the reject path to `expireSession`; update the `resolveActorId` call site (`:160`) to pass `expireSession` as `onSessionExpired`.
+
+### B2.5 — Client: `authService` cleanup
+- [ ] Remove `refreshToken` (and its `/auth/refresh` fetch). Update `resolveActorId` doc: `onSessionExpired` now means "the session ended; show login," not "start a silent refresh." (No client code should reference `/auth/session` yet — B1 adds that helper.)
+
+### B2.6 — Verification & docs
+- [ ] `cd hub-client && npm run build:all` (stricter than tsc/vitest — required for hub-client) **and** `npm run test:ci`.
+- [ ] `cargo nextest run --workspace` and `cargo xtask verify --skip-hub-build` (server-only crate; hub-client covered by build:all above).
+- [ ] **E2E** (per project policy — tests are necessary but not sufficient): run the hub (`--allow-insecure-auth` won't exercise Google; use a real OIDC-configured hub or `local-prod`), sign in via the GIS button, confirm the session slides via keep-alive across an `/auth/me` cycle, force a definitive 401 (revoke via `/auth/logout-everywhere`) and confirm the SPA lands on the login screen (no silent renewal, no hang). Confirm the rename: `curl -X POST /auth/refresh` → **404**, while `curl -X POST /auth/session` (with `X-Requested-With: XMLHttpRequest`) is *registered* (400/401 on a bad/absent credential, **not** 404). Record the invocations + observed output here.
+- [ ] Docs: update the One-Tap-as-fallback language in the `useAuth.ts` header and `useSessionKeepAlive.ts` doc (note the `/auth/refresh` → `/auth/session` rename + its clarified generic-OIDC-login role). Consider dropping `@react-oauth/google`'s One-Tap surface from any dev docs.
+- [ ] **`hub-client/changelog.md`** — two-commit workflow: (1) commit the hub-client changes; (2) commit the changelog entry with the hash under the commit day's `### YYYY-MM-DD` header.
+
+## Non-goals
+- Not touching the GIS **login** button, `/auth/callback`, `g_csrf_token`, or the `GoogleDoubleSubmit` CSRF mode (that's B1 territory, deferred).
+- Not touching Google-as-IdP config (JWKS, audiences, `--oidc-*`).
+- Not implementing the generic `OidcState` CSRF path or a pre-flight endpoint (B1).
+- **Not removing** the generic-OIDC credential-submission endpoint — it is **retained** (renamed `/auth/refresh` → `/auth/session`) and its logic is unchanged. Only its name, doc, and the (now-removed) client caller change.
+- `@react-oauth/google` stays as a dependency (the login button still uses `GoogleLogin`/`GoogleOAuthProvider`/`googleLogout`); only its One-Tap surface stops being used.
+
+## Risks
+- **Evidence-based-logout regression.** The renewal machinery is interwoven with the "only log out on a definitive 401 from a reachable server" invariant (`bd-3o8zmz46`). The B2.0 network-error tests exist to prevent a regression where a refocus/re-check network error now logs the user out. Treat those as gating.
+- **Rename blast radius.** The rename touches the route, handler, struct, five `session_auth.rs` tests, two comments, and the handler doc. Because the same change removes the only live client caller, there is **no live consumer** of the old name after B2 — so this is a safe rename, but the B2.1 grep step is mandatory to catch stragglers (skip hub-mcp's unrelated OAuth `refresh_token` grant symbols).
+- **Tests stay on Generic fixtures.** The five `session_auth.rs` tests cannot be re-pointed to `/auth/callback` — that route is unregistered (404) on the Generic hubs they run against. Following the `/auth/refresh` → `/auth/session` rename is a mechanical URL swap on the same fixtures; no callback/Google-fixture migration is needed.
+
+## Braid
+- File **B2** as a child strand of epic `bd-qxgoti2b` (type `task`, p2). Reference this plan file in the strand. A `discovered-from` link to `bd-ey6jg70f` (the sliding-sessions work that made this possible) is optional but accurate.

--- a/crates/quarto-hub/src/context.rs
+++ b/crates/quarto-hub/src/context.rs
@@ -550,7 +550,7 @@ impl HubContext {
     /// Since the sliding-sessions cutover this is never a request-
     /// credential path by itself: it is reachable only from the Bearer
     /// branch of [`Self::authenticate_credential`] and from the
-    /// mint-time validation in `auth_callback`/`auth_refresh`, whose
+    /// mint-time validation in `auth_callback`/`auth_session`, whose
     /// input is a fresh Google credential from the request body — never
     /// the cookie (that path is [`Self::authenticate_session`]).
     pub async fn authenticate_claims(

--- a/crates/quarto-hub/src/revocation.rs
+++ b/crates/quarto-hub/src/revocation.rs
@@ -145,7 +145,7 @@ impl RevocationLedger {
     }
 
     /// Whether `sub` is banned — the mint gate (`auth_callback` /
-    /// `auth_refresh` refuse to mint for a banned user).
+    /// `auth_session` refuse to mint for a banned user).
     pub async fn is_banned(&self, sub: &str) -> bool {
         self.inner.lock().await.banned.contains(sub)
     }

--- a/crates/quarto-hub/src/server.rs
+++ b/crates/quarto-hub/src/server.rs
@@ -799,9 +799,9 @@ struct AuthActorResponse {
     actor_id: String,
 }
 
-/// Request body for POST /auth/refresh.
+/// Request body for POST /auth/session.
 #[derive(Deserialize)]
-struct RefreshRequest {
+struct SessionRequest {
     credential: String,
 }
 
@@ -982,21 +982,24 @@ async fn auth_logout_everywhere(
     Ok(response)
 }
 
-/// Validate a fresh OIDC JWT and set a new cookie.
+/// Validate a submitted OIDC ID token and mint a fresh session cookie.
 ///
-/// Called by the client after obtaining a new credential from the OIDC provider
-/// (e.g. Google One Tap silent refresh). The new JWT goes through the full
-/// `authenticate()` path (signature, audience, issuer, email allowlist)
-/// before setting the cookie.
+/// `POST /auth/session` is the direct-JSON credential-submission **login**
+/// endpoint: a client posts an OIDC ID token as JSON and, on success, receives
+/// a hub session cookie. It is the counterpart to the redirect/form-post
+/// `/auth/callback`, and is the *only* mint endpoint a non-Google (Generic)
+/// OIDC deployment has — `/auth/callback` is registered only for providers
+/// whose `AuthConfig::uses_form_post_callback()` is true (Google alone).
 ///
-/// This is also the recommended credential submission endpoint for non-Google
-/// OIDC frontends (instead of the Google-specific `/auth/callback`).
+/// The submitted JWT goes through the full `authenticate_claims()` path
+/// (signature, audience, issuer, email allowlist) before a session is minted;
+/// because this is a fresh login, `auth_time = now` and a new `sid` are correct.
 ///
 /// Requires `X-Requested-With: XMLHttpRequest` for CSRF protection.
-async fn auth_refresh(
+async fn auth_session(
     headers: HeaderMap,
     State(ctx): State<SharedContext>,
-    Json(body): Json<RefreshRequest>,
+    Json(body): Json<SessionRequest>,
 ) -> std::result::Result<impl IntoResponse, (StatusCode, Json<serde_json::Value>)> {
     // Dual-credential 400 wins over CSRF — same precedence as the
     // `Authenticated` extractor. Without this, a request carrying both
@@ -1016,7 +1019,7 @@ async fn auth_refresh(
             .map_err(|s| (s, Json(serde_json::json!({"error": "csrf check failed"}))))?;
     }
 
-    // Validate the NEW Google credential (not the existing cookie — it
+    // Validate the submitted OIDC credential (not the existing cookie — it
     // may be expired), then mint a fresh hub session cookie: this is a
     // new login, so `auth_time = now` and a fresh `sid` are correct.
     let claims = ctx
@@ -1025,7 +1028,7 @@ async fn auth_refresh(
         .map_err(|_| unauthorized())?;
 
     // Bans gate mint too (§3) — otherwise a banned user just
-    // re-logs-in via Google.
+    // re-logs-in via the OIDC provider.
     if ctx.revocations().is_banned(&claims.sub).await {
         tracing::event!(
             target: "quarto_hub::audit",
@@ -1310,7 +1313,7 @@ pub async fn build_router_with_state(ctx: SharedContext) -> Result<Router<Shared
         .route("/auth/actor", get(auth_actor))
         .route("/auth/logout", post(auth_logout))
         .route("/auth/logout-everywhere", post(auth_logout_everywhere))
-        .route("/auth/refresh", post(auth_refresh))
+        .route("/auth/session", post(auth_session))
         // WebSocket endpoint for automerge sync at `/ws` (hub-client +
         // q2-preview SPA's canonical path).
         .route("/ws", get(ws_handler))

--- a/crates/quarto-hub/tests/integration/session_auth.rs
+++ b/crates/quarto-hub/tests/integration/session_auth.rs
@@ -488,7 +488,7 @@ async fn session_verify_failures_are_logged_distinguishably() {
 // ── C3: login mints a session cookie ──────────────────────────────
 
 #[tokio::test]
-async fn auth_refresh_mints_session_cookie() {
+async fn auth_session_mints_session_cookie() {
     let (provider, hub) = session_setup().await;
     let google = provider.sign(
         &ClaimsBuilder::from_provider(provider)
@@ -499,7 +499,7 @@ async fn auth_refresh_mints_session_cookie() {
 
     let resp = hub
         .client
-        .post(hub.url("/auth/refresh"))
+        .post(hub.url("/auth/session"))
         .header("x-requested-with", "XMLHttpRequest")
         .json(&serde_json::json!({ "credential": google }))
         .send()
@@ -531,6 +531,29 @@ async fn auth_refresh_mints_session_cookie() {
     assert!(attrs.contains("SameSite=Lax"));
     assert!(attrs.contains("Path=/"));
     assert!(attrs.contains(&format!("Max-Age={}", lt.idle_secs)));
+}
+
+/// The One-Tap renewal endpoint was renamed `/auth/refresh` → `/auth/session`
+/// (bd-s042qcxj); the old path must no longer be registered.
+#[tokio::test]
+async fn auth_refresh_old_route_is_gone() {
+    let (provider, hub) = session_setup().await;
+    let google = provider.sign(
+        &ClaimsBuilder::from_provider(provider)
+            .sub("old-route-sub")
+            .to_value(),
+    );
+
+    let resp = hub
+        .client
+        .post(hub.url("/auth/refresh"))
+        .header("x-requested-with", "XMLHttpRequest")
+        .json(&serde_json::json!({ "credential": google }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 404, "old /auth/refresh route must be gone");
+    assert!(TestHub::set_auth_cookie(&resp).is_none());
 }
 
 /// Google-provider hub (registers the form-POST `/auth/callback`).
@@ -611,7 +634,7 @@ async fn large_google_token_no_longer_cookie_dropped() {
 
     let resp = hub
         .client
-        .post(hub.url("/auth/refresh"))
+        .post(hub.url("/auth/session"))
         .header("x-requested-with", "XMLHttpRequest")
         .json(&serde_json::json!({ "credential": google }))
         .send()
@@ -1058,7 +1081,7 @@ async fn logout_everywhere_kills_prior_tokens_and_relogin_works() {
     let google = provider.sign(&ClaimsBuilder::from_provider(provider).sub(sub).to_value());
     let r = hub
         .client
-        .post(hub.url("/auth/refresh"))
+        .post(hub.url("/auth/session"))
         .header("x-requested-with", "XMLHttpRequest")
         .json(&serde_json::json!({ "credential": google }))
         .send()
@@ -1130,7 +1153,7 @@ async fn ban_gates_verify_and_mint() {
     );
     let r = hub
         .client
-        .post(hub.url("/auth/refresh"))
+        .post(hub.url("/auth/session"))
         .header("x-requested-with", "XMLHttpRequest")
         .json(&serde_json::json!({ "credential": google }))
         .send()
@@ -1291,7 +1314,7 @@ async fn new_logins_on_rotated_hub_carry_new_kid() {
 
     let resp = hub
         .client
-        .post(hub.url("/auth/refresh"))
+        .post(hub.url("/auth/session"))
         .header("x-requested-with", "XMLHttpRequest")
         .json(&serde_json::json!({ "credential": google }))
         .send()

--- a/hub-client/changelog.md
+++ b/hub-client/changelog.md
@@ -23,6 +23,10 @@ WASM rebuild is needed for a changelog-only edit.
 
 -->
 
+### 2026-07-27
+
+- [`e73786ed`](https://github.com/quarto-dev/q2/commits/e73786ed): When a signed-in session definitively ends (you sign out everywhere, or it reaches its 30-day maximum), the app now returns you to the sign-in screen instead of trying to silently re-authenticate through Google One Tap; day-to-day sessions still renew invisibly while you keep using the app.
+
 ### 2026-07-24
 
 - [`ee905592`](https://github.com/quarto-dev/q2/commits/ee905592): Signed-in sessions now stay alive as long as you keep using the app — the hub issues its own sliding session (7-day idle timeout, 30-day maximum) instead of expiring hourly with the Google token, so work no longer stalls on environments where Google One Tap is blocked. The app quietly confirms the session once an hour while connected.

--- a/hub-client/src/App.tsx
+++ b/hub-client/src/App.tsx
@@ -92,7 +92,6 @@ function App() {
     auth,
     loading: authLoading,
     logout,
-    triggerRefresh,
     sessionExpired,
     expireSession,
     applyAuth,
@@ -131,7 +130,6 @@ function App() {
   // (preempting this probe's two-strike); the probe governs earlier drops.
   useAuthProbe({
     enabled: AUTH_ENABLED && !!auth && !!project && !isOnline,
-    triggerRefresh,
     onAuthRejected: expireSession,
   });
 
@@ -142,7 +140,7 @@ function App() {
   useSessionKeepAlive({
     enabled: AUTH_ENABLED && !!auth && isOnline,
     onAuthState: applyAuth,
-    triggerRefresh,
+    onAuthRejected: expireSession,
   });
 
   // Project set management (synced project list)
@@ -157,8 +155,8 @@ function App() {
   // `resolveActorIdRequest` for the three-valued contract; callers abandon
   // the open only on `null` (auth failure), proceed on `string`/`undefined`.
   const resolveActorId = useCallback(
-    (indexDocId: string) => resolveActorIdRequest(indexDocId, AUTH_ENABLED, triggerRefresh, localActorId),
-    [triggerRefresh, localActorId],
+    (indexDocId: string) => resolveActorIdRequest(indexDocId, AUTH_ENABLED, expireSession, localActorId),
+    [expireSession, localActorId],
   );
 
   // Capture auth error from redirect query param (once, before URL is cleaned).

--- a/hub-client/src/auth/AuthProvider.test.tsx
+++ b/hub-client/src/auth/AuthProvider.test.tsx
@@ -20,7 +20,6 @@ afterEach(cleanup);
 function makeStubProvider(): AuthProvider {
   return {
     SignInButton: () => null,
-    useSilentRenewal: () => {},
     signOut: () => {},
   };
 }

--- a/hub-client/src/auth/AuthProvider.tsx
+++ b/hub-client/src/auth/AuthProvider.tsx
@@ -10,6 +10,13 @@
  * disabled (no IdP configured). Consumers never need to branch — they
  * always receive a valid `AuthProvider`.
  *
+ * Session *renewal* is not part of this interface: it is entirely
+ * server-side (sliding re-issue, bd-ey6jg70f). The GIS One-Tap silent
+ * renewal that this interface once exposed via `useSilentRenewal` was
+ * retired in bd-s042qcxj; a session that hits a hard boundary
+ * (revocation / absolute cap / idle) ends definitively and the user
+ * re-logs-in through `SignInButton`.
+ *
  * See `claude-notes/plans/2026-05-20-auth-provider-interface.md`
  * for the design rationale.
  */
@@ -33,21 +40,6 @@ export interface AuthProvider {
   readonly SignInButton: ComponentType<SignInButtonProps>;
 
   /**
-   * Hook that enables/disables silent credential renewal.
-   *
-   * When `enabled` becomes true, the provider attempts to obtain a
-   * fresh JWT without user interaction and invokes `onCredential`
-   * with the JWT. If renewal fails or no IdP session exists,
-   * `onError` is invoked.
-   *
-   * Providers without a silent-renewal capability MUST still
-   * implement the hook as a no-op: enabling it never invokes either
-   * callback. Consumers detect that scenario via timeout, not via a
-   * return value — keeps the interface symmetric across capabilities.
-   */
-  useSilentRenewal(opts: SilentRenewalOpts): void;
-
-  /**
    * Best-effort IdP-side sign-out. For Google this calls
    * `googleLogout()` which revokes the GIS session (no network round
    * trip). Synchronous on purpose — callers should not block UI on it.
@@ -65,19 +57,12 @@ export interface SignInButtonProps {
   loginUri: string;
 }
 
-export interface SilentRenewalOpts {
-  enabled: boolean;
-  onCredential: (jwt: string) => void;
-  onError: () => void;
-}
-
 /**
  * No-op provider used when auth is disabled (no `VITE_GOOGLE_CLIENT_ID`).
- * `SignInButton` renders nothing; the hook and `signOut` do nothing.
+ * `SignInButton` renders nothing; `signOut` does nothing.
  */
 export const noopAuthProvider: AuthProvider = {
   SignInButton: () => null,
-  useSilentRenewal: () => {},
   signOut: () => {},
 };
 

--- a/hub-client/src/auth/GoogleAuthProvider.test.tsx
+++ b/hub-client/src/auth/GoogleAuthProvider.test.tsx
@@ -6,21 +6,12 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { renderHook, render, cleanup } from '@testing-library/react';
-
-import type { SilentRenewalOpts } from './AuthProvider';
+import { render, cleanup } from '@testing-library/react';
 
 // Capture mock state at module scope so each test can inspect / drive it.
 let lastGoogleLoginProps: {
   ux_mode?: string;
   login_uri?: string;
-} | null = null;
-
-let lastOneTapOpts: {
-  onSuccess?: (response: { credential?: string }) => void;
-  onError?: () => void;
-  disabled?: boolean;
-  auto_select?: boolean;
 } | null = null;
 
 const mockGoogleLogout = vi.fn();
@@ -30,9 +21,6 @@ vi.mock('@react-oauth/google', () => ({
     lastGoogleLoginProps = props;
     return null;
   },
-  useGoogleOneTapLogin: (opts: typeof lastOneTapOpts) => {
-    lastOneTapOpts = opts;
-  },
   googleLogout: () => mockGoogleLogout(),
 }));
 
@@ -40,7 +28,6 @@ import { googleAuthProvider } from './GoogleAuthProvider';
 
 beforeEach(() => {
   lastGoogleLoginProps = null;
-  lastOneTapOpts = null;
   mockGoogleLogout.mockClear();
 });
 
@@ -56,61 +43,9 @@ describe('GoogleAuthProvider.SignInButton', () => {
   });
 });
 
-describe('GoogleAuthProvider.useSilentRenewal', () => {
-  function renderProviderHook(opts: SilentRenewalOpts) {
-    return renderHook(() => googleAuthProvider.useSilentRenewal(opts));
-  }
-
-  it('calls useGoogleOneTapLogin with auto_select:true and disabled:false when enabled', () => {
-    renderProviderHook({
-      enabled: true,
-      onCredential: vi.fn(),
-      onError: vi.fn(),
-    });
-
-    expect(lastOneTapOpts).not.toBeNull();
-    expect(lastOneTapOpts?.auto_select).toBe(true);
-    expect(lastOneTapOpts?.disabled).toBe(false);
-  });
-
-  it('calls useGoogleOneTapLogin with disabled:true when not enabled', () => {
-    renderProviderHook({
-      enabled: false,
-      onCredential: vi.fn(),
-      onError: vi.fn(),
-    });
-
-    expect(lastOneTapOpts?.disabled).toBe(true);
-  });
-
-  it('forwards onCredential when one-tap success carries a credential', () => {
-    const onCredential = vi.fn();
-    const onError = vi.fn();
-    renderProviderHook({ enabled: true, onCredential, onError });
-
-    lastOneTapOpts?.onSuccess?.({ credential: 'jwt-token' });
-    expect(onCredential).toHaveBeenCalledExactlyOnceWith('jwt-token');
-    expect(onError).not.toHaveBeenCalled();
-  });
-
-  it('forwards onError when one-tap success carries no credential', () => {
-    const onCredential = vi.fn();
-    const onError = vi.fn();
-    renderProviderHook({ enabled: true, onCredential, onError });
-
-    lastOneTapOpts?.onSuccess?.({});
-    expect(onError).toHaveBeenCalledTimes(1);
-    expect(onCredential).not.toHaveBeenCalled();
-  });
-
-  it('forwards onError on one-tap error', () => {
-    const onCredential = vi.fn();
-    const onError = vi.fn();
-    renderProviderHook({ enabled: true, onCredential, onError });
-
-    lastOneTapOpts?.onError?.();
-    expect(onError).toHaveBeenCalledTimes(1);
-    expect(onCredential).not.toHaveBeenCalled();
+describe('GoogleAuthProvider', () => {
+  it('exposes no silent-renewal hook (One-Tap renewal retired, bd-s042qcxj)', () => {
+    expect('useSilentRenewal' in googleAuthProvider).toBe(false);
   });
 });
 

--- a/hub-client/src/auth/GoogleAuthProvider.tsx
+++ b/hub-client/src/auth/GoogleAuthProvider.tsx
@@ -3,23 +3,15 @@
  * Identity Services via `@react-oauth/google`.
  *
  * Requires `<GoogleOAuthProvider clientId={...}>` to be mounted above
- * any tree that uses this provider's `SignInButton` or
- * `useSilentRenewal`. The GIS provider wrap stays in `main.tsx` (see
- * Phase 3 of `claude-notes/plans/2026-05-20-auth-provider-interface.md`);
- * this module does not produce its own provider scope.
+ * any tree that uses this provider's `SignInButton`. The GIS provider
+ * wrap stays in `main.tsx` (see Phase 3 of
+ * `claude-notes/plans/2026-05-20-auth-provider-interface.md`); this
+ * module does not produce its own provider scope.
  */
 
-import {
-  GoogleLogin,
-  googleLogout,
-  useGoogleOneTapLogin,
-} from '@react-oauth/google';
+import { GoogleLogin, googleLogout } from '@react-oauth/google';
 
-import type {
-  AuthProvider,
-  SignInButtonProps,
-  SilentRenewalOpts,
-} from './AuthProvider';
+import type { AuthProvider, SignInButtonProps } from './AuthProvider';
 
 function SignInButton({ loginUri }: SignInButtonProps) {
   return (
@@ -34,27 +26,7 @@ function SignInButton({ loginUri }: SignInButtonProps) {
   );
 }
 
-function useSilentRenewal(opts: SilentRenewalOpts) {
-  useGoogleOneTapLogin({
-    onSuccess: (response) => {
-      if (response.credential) {
-        opts.onCredential(response.credential);
-      } else {
-        // Success without a credential — semantically equivalent to a
-        // failed renewal from the consumer's perspective.
-        opts.onError();
-      }
-    },
-    onError: () => {
-      opts.onError();
-    },
-    auto_select: true,
-    disabled: !opts.enabled,
-  });
-}
-
 export const googleAuthProvider: AuthProvider = {
   SignInButton,
-  useSilentRenewal,
   signOut: () => googleLogout(),
 };

--- a/hub-client/src/auth/MockAuthProvider.tsx
+++ b/hub-client/src/auth/MockAuthProvider.tsx
@@ -5,10 +5,6 @@
  * loading the GIS SDK. Each created mock exposes:
  *
  * - `provider` — the AuthProvider object to pass into `AuthProviderRoot`.
- * - `lastSilentRenewalOpts` — the most-recent opts passed to
- *   `useSilentRenewal`, so tests can synchronously invoke
- *   `onCredential` / `onError` to simulate IdP responses (mirrors the
- *   `oneTapCallbacks` pattern in the legacy `useAuth.test.ts`).
  * - `signInButtonClicks` — count of times the SignInButton was clicked.
  * - `lastLoginUri` — the most recent `loginUri` prop passed to
  *   SignInButton, so tests can assert the wiring without needing DOM
@@ -20,15 +16,10 @@
 
 import { useEffect } from 'react';
 
-import type {
-  AuthProvider,
-  SignInButtonProps,
-  SilentRenewalOpts,
-} from './AuthProvider';
+import type { AuthProvider, SignInButtonProps } from './AuthProvider';
 
 export interface MockAuthProvider {
   provider: AuthProvider;
-  lastSilentRenewalOpts: SilentRenewalOpts | null;
   signInButtonClicks: number;
   lastLoginUri: string | null;
   signOutCalls: number;
@@ -39,12 +30,10 @@ export interface MockAuthProvider {
 export function createMockAuthProvider(): MockAuthProvider {
   const state: MockAuthProvider = {
     provider: null as unknown as AuthProvider,
-    lastSilentRenewalOpts: null,
     signInButtonClicks: 0,
     lastLoginUri: null,
     signOutCalls: 0,
     reset() {
-      state.lastSilentRenewalOpts = null;
       state.signInButtonClicks = 0;
       state.lastLoginUri = null;
       state.signOutCalls = 0;
@@ -69,9 +58,6 @@ export function createMockAuthProvider(): MockAuthProvider {
 
   state.provider = {
     SignInButton,
-    useSilentRenewal: (opts: SilentRenewalOpts) => {
-      state.lastSilentRenewalOpts = opts;
-    },
     signOut: () => {
       state.signOutCalls += 1;
     },

--- a/hub-client/src/hooks/useAuth.test.tsx
+++ b/hub-client/src/hooks/useAuth.test.tsx
@@ -1,7 +1,13 @@
 /**
  * Unit Tests for useAuth hook
  *
- * Tests mount behavior, refresh scheduling, logout, and expiry logic.
+ * Tests mount behavior, logout, and the definitive-session-end logic that
+ * replaced One-Tap silent renewal (bd-s042qcxj). Session renewal is entirely
+ * server-side now (sliding re-issue), so the hook only distinguishes:
+ *   - a valid /auth/me (possibly with a slid `exp`) → stay signed in;
+ *   - a definitive 401/403 from a reachable server → session ended;
+ *   - a network error → offline, session preserved (bd-3o8zmz46).
+ *
  * Uses fake timers and a MockAuthProvider in place of `@react-oauth/google`.
  *
  * @vitest-environment jsdom
@@ -17,21 +23,13 @@ import { createMockAuthProvider, type MockAuthProvider } from '../auth/MockAuthP
 vi.mock('../services/authService', () => ({
   fetchAuthMe: vi.fn(),
   logout: vi.fn(),
-  refreshToken: vi.fn(),
 }));
 
-import { useAuth, REFRESH_BUFFER_MS } from './useAuth';
-import {
-  fetchAuthMe,
-  logout as serverLogout,
-  refreshToken,
-} from '../services/authService';
-
-const COOKIE_MAX_AGE_MS = 3600 * 1000;
+import { useAuth } from './useAuth';
+import { fetchAuthMe, logout as serverLogout } from '../services/authService';
 
 const mockFetchAuthMe = vi.mocked(fetchAuthMe);
 const mockServerLogout = vi.mocked(serverLogout);
-const mockRefreshToken = vi.mocked(refreshToken);
 
 let mockProvider: MockAuthProvider;
 
@@ -67,13 +65,15 @@ describe('useAuth', () => {
       expect(result.current.auth).toEqual(user);
     });
 
-    it('sets auth to null on 401 (not authenticated)', async () => {
+    it('sets auth to null on 401 without flagging sessionExpired (not signed in)', async () => {
       mockFetchAuthMe.mockResolvedValue(null);
 
       const { result } = renderHook(() => useAuth(), { wrapper });
       await waitFor(() => expect(result.current.loading).toBe(false));
 
+      // A fresh visitor sees the sign-in prompt, not a "session expired" message.
       expect(result.current.auth).toBeNull();
+      expect(result.current.sessionExpired).toBe(false);
     });
 
     it('sets auth to null on fetch error', async () => {
@@ -83,6 +83,16 @@ describe('useAuth', () => {
       await waitFor(() => expect(result.current.loading).toBe(false));
 
       expect(result.current.auth).toBeNull();
+    });
+
+    it('does not expose a triggerRefresh method (One-Tap renewal retired)', async () => {
+      const user = { email: 'a@b.com', name: 'A', picture: null };
+      mockFetchAuthMe.mockResolvedValue(user);
+
+      const { result } = renderHook(() => useAuth(), { wrapper });
+      await waitFor(() => expect(result.current.auth).toEqual(user));
+
+      expect(result.current).not.toHaveProperty('triggerRefresh');
     });
   });
 
@@ -132,64 +142,29 @@ describe('useAuth', () => {
 
       expect(result.current.auth).toBeNull();
     });
-  });
 
-  // ── Refresh scheduling (fake timers) ──────────────────────
-
-  describe('refresh scheduling', () => {
-    beforeEach(() => {
-      vi.useFakeTimers({ shouldAdvanceTime: true });
-    });
-
-    afterEach(() => {
-      vi.useRealTimers();
-    });
-
-    it('starts with silent renewal disabled', async () => {
+    it('does not flag sessionExpired on deliberate logout', async () => {
       const user = { email: 'a@b.com', name: 'A', picture: null };
-      mockFetchAuthMe.mockResolvedValue(user);
-
-      renderHook(() => useAuth(), { wrapper });
-      await vi.waitFor(() => expect(mockFetchAuthMe).toHaveBeenCalled());
-
-      // Before any time has passed, silent renewal should be disabled.
-      expect(mockProvider.lastSilentRenewalOpts?.enabled).toBe(false);
-    });
-
-    it('updates auth on successful silent renewal', async () => {
-      const user = { email: 'a@b.com', name: 'A', picture: null };
-      const refreshedUser = {
-        email: 'a@b.com',
-        name: 'A Updated',
-        picture: null,
-      };
       mockFetchAuthMe.mockResolvedValue(user);
 
       const { result } = renderHook(() => useAuth(), { wrapper });
-      await vi.waitFor(() =>
-        expect(result.current.auth).toEqual(user),
-      );
+      await waitFor(() => expect(result.current.auth).toEqual(user));
 
-      // Simulate the provider delivering a fresh credential.
-      mockRefreshToken.mockResolvedValue(refreshedUser);
-      await act(async () => {
-        mockProvider.lastSilentRenewalOpts?.onCredential('fresh.jwt.token');
+      act(() => {
+        result.current.logout();
       });
 
-      await vi.waitFor(() =>
-        expect(result.current.auth).toEqual(refreshedUser),
-      );
-      expect(mockRefreshToken).toHaveBeenCalledWith('fresh.jwt.token');
+      expect(result.current.auth).toBeNull();
+      expect(result.current.sessionExpired).toBe(false);
     });
   });
 
-  // ── Visibility-triggered refresh (fake timers) ────────────
+  // ── Expiry-time re-check (fake timers) ────────────────────
 
-  describe('visibility-triggered refresh', () => {
+  describe('expiry re-check', () => {
     beforeEach(() => {
-      // Unmount hooks from previous tests so their visibilitychange
-      // listeners don't interfere with ours.
       cleanup();
+      mockFetchAuthMe.mockReset();
       vi.useFakeTimers({ shouldAdvanceTime: true });
     });
 
@@ -197,197 +172,100 @@ describe('useAuth', () => {
       vi.useRealTimers();
     });
 
-    it('attempts silent renewal when tab becomes visible with expired cookie', async () => {
+    it('clears auth and flags sessionExpired on a definitive 401 at expiry', async () => {
       const user = { email: 'a@b.com', name: 'A', picture: null };
-      const refreshedUser = { email: 'a@b.com', name: 'Refreshed', picture: null };
-      mockFetchAuthMe.mockResolvedValueOnce(user); // mount
+      mockFetchAuthMe
+        .mockResolvedValueOnce(user) // mount
+        .mockResolvedValueOnce(null); // expiry re-check → 401
 
       const { result } = renderHook(() => useAuth(), { wrapper });
       await vi.waitFor(() => expect(result.current.auth).toEqual(user));
 
-      // Next /auth/me returns null (cookie expired)
-      mockFetchAuthMe.mockResolvedValueOnce(null);
-      mockRefreshToken.mockResolvedValue(refreshedUser);
-
-      // Dispatch the event, then flush async handler + React updates separately.
-      document.dispatchEvent(new Event('visibilitychange'));
+      // Default 1 h lifetime (no server exp) → re-check just after +1 h.
       await act(async () => {
-        await vi.advanceTimersByTimeAsync(0);
-      });
-
-      // Silent renewal should be enabled for refresh.
-      expect(mockProvider.lastSilentRenewalOpts?.enabled).toBe(true);
-
-      // Simulate the provider delivering a fresh credential.
-      await act(async () => {
-        mockProvider.lastSilentRenewalOpts?.onCredential('fresh.jwt');
-      });
-
-      await vi.waitFor(() => expect(result.current.auth).toEqual(refreshedUser));
-    });
-
-    it('clears auth when silent renewal fails after visibility-triggered refresh', async () => {
-      const user = { email: 'a@b.com', name: 'A', picture: null };
-      mockFetchAuthMe.mockResolvedValueOnce(user); // mount
-
-      const { result } = renderHook(() => useAuth(), { wrapper });
-      await vi.waitFor(() => expect(result.current.auth).toEqual(user));
-
-      // Jump Date.now() past cookie lifetime (simulates long idle)
-      vi.setSystemTime(Date.now() + 3600 * 1000 + 1000);
-
-      // Next /auth/me returns null (cookie expired)
-      mockFetchAuthMe.mockResolvedValueOnce(null);
-
-      document.dispatchEvent(new Event('visibilitychange'));
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(0);
-      });
-
-      // Simulate silent renewal failing (no active IdP session).
-      await act(async () => {
-        mockProvider.lastSilentRenewalOpts?.onError();
+        vi.advanceTimersByTime(3600 * 1000 + 2000);
       });
 
       await vi.waitFor(() => expect(result.current.auth).toBeNull());
-    });
-
-    it('clears auth when refreshToken returns null after visibility-triggered refresh', async () => {
-      const user = { email: 'a@b.com', name: 'A', picture: null };
-      mockFetchAuthMe.mockResolvedValueOnce(user); // mount
-
-      const { result } = renderHook(() => useAuth(), { wrapper });
-      await vi.waitFor(() => expect(result.current.auth).toEqual(user));
-
-      // Jump Date.now() past cookie lifetime (simulates long idle)
-      vi.setSystemTime(Date.now() + 3600 * 1000 + 1000);
-
-      // Next /auth/me returns null (cookie expired)
-      mockFetchAuthMe.mockResolvedValueOnce(null);
-
-      document.dispatchEvent(new Event('visibilitychange'));
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(0);
-      });
-
-      // Silent renewal returns a credential, but server rejects it.
-      mockRefreshToken.mockResolvedValue(null);
-      await act(async () => {
-        mockProvider.lastSilentRenewalOpts?.onCredential('rejected.jwt');
-      });
-
-      await vi.waitFor(() => expect(result.current.auth).toBeNull());
-    });
-  });
-
-  // ── Hard expiry (fake timers) ─────────────────────────────
-
-  describe('hard expiry', () => {
-    beforeEach(() => {
-      vi.useFakeTimers({ shouldAdvanceTime: true });
-    });
-
-    afterEach(() => {
-      vi.useRealTimers();
-    });
-
-    it('clears auth when cookie expires and no refresh in progress', async () => {
-      const user = { email: 'a@b.com', name: 'A', picture: null };
-      mockFetchAuthMe
-        .mockResolvedValueOnce(user) // mount check
-        .mockResolvedValueOnce(null); // expiry re-check
-
-      const { result } = renderHook(() => useAuth(), { wrapper });
-      await vi.waitFor(() =>
-        expect(result.current.auth).toEqual(user),
-      );
-
-      // Advance past the refresh point. The refresh timer sets
-      // isRefreshing=true and enables silent renewal. Simulate the IdP
-      // session being gone (onError fires), resetting isRefreshing=false.
-      await act(async () => {
-        vi.advanceTimersByTime(COOKIE_MAX_AGE_MS - REFRESH_BUFFER_MS + 100);
-      });
-      await act(async () => {
-        mockProvider.lastSilentRenewalOpts?.onError();
-      });
-
-      // Advance past cookie max-age (remaining buffer).
-      await act(async () => {
-        vi.advanceTimersByTime(REFRESH_BUFFER_MS + 100);
-      });
-
-      await vi.waitFor(() =>
-        expect(result.current.auth).toBeNull(),
-      );
-    });
-
-    it('clears auth at expiry even when the renewal never settles (wedged IdP)', async () => {
-      const user = { email: 'a@b.com', name: 'A', picture: null };
-      mockFetchAuthMe
-        .mockResolvedValueOnce(user) // mount check
-        .mockResolvedValueOnce(null); // expiry re-check
-
-      const { result } = renderHook(() => useAuth(), { wrapper });
-      await vi.waitFor(() =>
-        expect(result.current.auth).toEqual(user),
-      );
-
-      // Refresh point: renewal is triggered, but the IdP never calls back
-      // (GIS blocked / FedCM — neither onCredential nor onError fires).
-      await act(async () => {
-        vi.advanceTimersByTime(COOKIE_MAX_AGE_MS - REFRESH_BUFFER_MS + 100);
-      });
-      expect(mockProvider.lastSilentRenewalOpts?.enabled).toBe(true);
-
-      // The verdict deadline must settle isRefreshing so the expiry
-      // re-check can still reach its logout verdict.
-      await act(async () => {
-        vi.advanceTimersByTime(REFRESH_BUFFER_MS + 100);
-      });
-
-      await vi.waitFor(() =>
-        expect(result.current.auth).toBeNull(),
-      );
       expect(result.current.sessionExpired).toBe(true);
     });
 
-    it('keeps auth if server confirms valid cookie at expiry', async () => {
+    it('keeps auth when the server confirms a still-valid cookie at expiry', async () => {
       const user = { email: 'a@b.com', name: 'A', picture: null };
-      const freshUser = {
-        email: 'a@b.com',
-        name: 'Still Valid',
-        picture: null,
-      };
+      const freshUser = { email: 'a@b.com', name: 'Still Valid', picture: null };
       mockFetchAuthMe
-        .mockResolvedValueOnce(user) // mount check
-        .mockResolvedValueOnce(freshUser); // expiry re-check (refresh succeeded)
+        .mockResolvedValueOnce(user) // mount
+        .mockResolvedValueOnce(freshUser); // expiry re-check → still valid
 
       const { result } = renderHook(() => useAuth(), { wrapper });
-      await vi.waitFor(() =>
-        expect(result.current.auth).toEqual(user),
-      );
+      await vi.waitFor(() => expect(result.current.auth).toEqual(user));
 
-      // Advance past cookie max-age
       await act(async () => {
-        vi.advanceTimersByTime(3600 * 1000 + 100);
+        vi.advanceTimersByTime(3600 * 1000 + 2000);
       });
 
-      await vi.waitFor(() =>
-        expect(result.current.auth).toEqual(freshUser),
-      );
+      await vi.waitFor(() => expect(result.current.auth).toEqual(freshUser));
+      expect(result.current.sessionExpired).toBe(false);
+    });
+
+    it('reschedules from a slid exp and logs out only at the new expiry', async () => {
+      const start = Date.now();
+      const user = { email: 'a@b.com', name: 'A', picture: null, expiresAt: start + 20 * 60 * 1000 };
+      const slid = { email: 'a@b.com', name: 'A', picture: null, expiresAt: start + 40 * 60 * 1000 };
+      mockFetchAuthMe.mockResolvedValueOnce(user); // mount
+
+      const { result } = renderHook(() => useAuth(), { wrapper });
+      await vi.waitFor(() => expect(result.current.auth).toEqual(user));
+
+      // First re-check at +20 min: the session has slid to a later exp.
+      mockFetchAuthMe.mockResolvedValueOnce(slid);
+      await act(async () => {
+        vi.advanceTimersByTime(20 * 60 * 1000 + 2000);
+      });
+      await vi.waitFor(() => expect(result.current.auth).toEqual(slid));
+      expect(result.current.sessionExpired).toBe(false);
+
+      // A new timer was armed at the slid exp (+40 min); a 401 there logs out.
+      mockFetchAuthMe.mockResolvedValueOnce(null);
+      await act(async () => {
+        vi.advanceTimersByTime(20 * 60 * 1000 + 2000);
+      });
+      await vi.waitFor(() => expect(result.current.auth).toBeNull());
+      expect(result.current.sessionExpired).toBe(true);
+    });
+
+    it('keeps auth on an expiry-time network error, then logs out on a later 401', async () => {
+      const start = Date.now();
+      const user = { email: 'a@b.com', name: 'A', picture: null, expiresAt: start + 20 * 60 * 1000 };
+      mockFetchAuthMe.mockResolvedValueOnce(user); // mount
+
+      const { result } = renderHook(() => useAuth(), { wrapper });
+      await vi.waitFor(() => expect(result.current.auth).toEqual(user));
+
+      // Expiry re-check at +20 min hits a network error → stay logged in.
+      mockFetchAuthMe.mockRejectedValueOnce(new Error('network'));
+      await act(async () => {
+        vi.advanceTimersByTime(20 * 60 * 1000 + 2000);
+      });
+      expect(result.current.auth).toEqual(user);
+      expect(result.current.sessionExpired).toBe(false);
+
+      // The next re-check (~60 s later) gets a definitive 401 → logout.
+      mockFetchAuthMe.mockResolvedValueOnce(null);
+      await act(async () => {
+        vi.advanceTimersByTime(60 * 1000 + 1000);
+      });
+      await vi.waitFor(() => expect(result.current.auth).toBeNull());
+      expect(result.current.sessionExpired).toBe(true);
     });
   });
 
-  // ── Expiry from server-reported exp (bd-3o8zmz46) ─────────
+  // ── Refocus (visibility) re-check (fake timers) ───────────
 
-  describe('expiry from server exp', () => {
+  describe('refocus re-check', () => {
     beforeEach(() => {
       cleanup();
-      // Full reset (not just clear) so queued mockResolvedValueOnce values
-      // from a failed sibling test can't leak into the next one.
       mockFetchAuthMe.mockReset();
-      mockRefreshToken.mockReset();
       vi.useFakeTimers({ shouldAdvanceTime: true });
     });
 
@@ -395,60 +273,19 @@ describe('useAuth', () => {
       vi.useRealTimers();
     });
 
-    it('schedules silent refresh from server-reported expiresAt, not a fixed lifetime', async () => {
-      const user = {
-        email: 'a@b.com',
-        name: 'A',
-        picture: null,
-        expiresAt: Date.now() + 30 * 60 * 1000,
-      };
-      mockFetchAuthMe.mockResolvedValue(user);
-
-      const { result } = renderHook(() => useAuth(), { wrapper });
-      await vi.waitFor(() => expect(result.current.auth).toEqual(user));
-      expect(mockProvider.lastSilentRenewalOpts?.enabled).toBe(false);
-
-      // Refresh should fire at expiresAt − 15 min = +15 min, well before
-      // the legacy fixed-1h schedule would (at +45 min).
-      await act(async () => {
-        vi.advanceTimersByTime(15 * 60 * 1000 + 1000);
-      });
-      expect(mockProvider.lastSilentRenewalOpts?.enabled).toBe(true);
-    });
-
-    it('does not extend assumed expiry on refocus without a fresh cookie (drift bug)', async () => {
-      const expiresAt = Date.now() + 40 * 60 * 1000;
-      const user = { email: 'a@b.com', name: 'A', picture: null, expiresAt };
-      mockFetchAuthMe
-        .mockResolvedValueOnce(user) // mount
-        .mockResolvedValueOnce({ ...user }) // refocus: same expiry, fresh object
-        .mockResolvedValueOnce(null); // expiry re-check: token now rejected
+    it('clears auth and flags sessionExpired on a definitive 401 on refocus', async () => {
+      const user = { email: 'a@b.com', name: 'A', picture: null };
+      mockFetchAuthMe.mockResolvedValueOnce(user); // mount
 
       const { result } = renderHook(() => useAuth(), { wrapper });
       await vi.waitFor(() => expect(result.current.auth).toEqual(user));
 
-      // Refocus at +10 min — server confirms the cookie but its expiry is
-      // unchanged. This must NOT push the schedule out to +70 min.
-      await act(async () => {
-        vi.advanceTimersByTime(10 * 60 * 1000);
-      });
+      mockFetchAuthMe.mockResolvedValueOnce(null); // refocus → 401
       document.dispatchEvent(new Event('visibilitychange'));
       await act(async () => {
         await vi.advanceTimersByTimeAsync(0);
       });
 
-      // Refresh fires at expiresAt − 15 min (+25 min); renewal fails.
-      await act(async () => {
-        vi.advanceTimersByTime(15 * 60 * 1000 + 1000);
-      });
-      await act(async () => {
-        mockProvider.lastSilentRenewalOpts?.onError();
-      });
-
-      // At the REAL expiry (+40 min) the server's 401 must clear auth.
-      await act(async () => {
-        vi.advanceTimersByTime(15 * 60 * 1000 + 2000);
-      });
       await vi.waitFor(() => expect(result.current.auth).toBeNull());
       expect(result.current.sessionExpired).toBe(true);
     });
@@ -468,178 +305,37 @@ describe('useAuth', () => {
 
       // Offline must never log the user out.
       expect(result.current.auth).toEqual(user);
+      expect(result.current.sessionExpired).toBe(false);
     });
 
-    it('keeps auth on expiry-time network error and re-checks later', async () => {
-      const expiresAt = Date.now() + 20 * 60 * 1000;
+    it('does not extend the expiry schedule on a refocus that returns the same exp', async () => {
+      const start = Date.now();
+      const expiresAt = start + 40 * 60 * 1000;
       const user = { email: 'a@b.com', name: 'A', picture: null, expiresAt };
-      mockFetchAuthMe.mockResolvedValueOnce(user); // mount
+      mockFetchAuthMe
+        .mockResolvedValueOnce(user) // mount
+        .mockResolvedValueOnce({ ...user }) // refocus: same expiry, fresh object
+        .mockResolvedValueOnce(null); // expiry re-check: token now rejected
 
       const { result } = renderHook(() => useAuth(), { wrapper });
       await vi.waitFor(() => expect(result.current.auth).toEqual(user));
 
-      // Refresh fires at +5 min; renewal fails (session not lapsed → keep).
+      // Refocus at +10 min — server confirms the cookie, expiry unchanged.
+      // This must NOT push the expiry schedule out past the real +40 min.
       await act(async () => {
-        vi.advanceTimersByTime(5 * 60 * 1000 + 1000);
+        vi.advanceTimersByTime(10 * 60 * 1000);
       });
+      document.dispatchEvent(new Event('visibilitychange'));
       await act(async () => {
-        mockProvider.lastSilentRenewalOpts?.onError();
+        await vi.advanceTimersByTimeAsync(0);
       });
 
-      // Expiry re-check at +20 min hits a network error → stay logged in.
-      mockFetchAuthMe.mockRejectedValueOnce(new Error('network'));
+      // At the REAL expiry (+40 min) the definitive 401 clears auth.
       await act(async () => {
-        vi.advanceTimersByTime(15 * 60 * 1000 + 2000);
-      });
-      expect(result.current.auth).toEqual(user);
-      expect(result.current.sessionExpired).toBe(false);
-
-      // The next re-check gets a definitive 401 → evidence-based logout.
-      mockFetchAuthMe.mockResolvedValueOnce(null);
-      await act(async () => {
-        vi.advanceTimersByTime(60 * 1000 + 1000);
+        vi.advanceTimersByTime(30 * 60 * 1000 + 2000);
       });
       await vi.waitFor(() => expect(result.current.auth).toBeNull());
       expect(result.current.sessionExpired).toBe(true);
-    });
-
-    it('does not flag sessionExpired on deliberate logout', async () => {
-      const user = { email: 'a@b.com', name: 'A', picture: null };
-      mockFetchAuthMe.mockResolvedValue(user);
-
-      const { result } = renderHook(() => useAuth(), { wrapper });
-      await vi.waitFor(() => expect(result.current.auth).toEqual(user));
-
-      act(() => {
-        result.current.logout();
-      });
-
-      expect(result.current.auth).toBeNull();
-      expect(result.current.sessionExpired).toBe(false);
-    });
-  });
-
-  // ── 401-triggered refresh (fake timers) ───────────────────
-
-  describe('triggerRefresh', () => {
-    beforeEach(() => {
-      cleanup();
-      vi.useFakeTimers({ shouldAdvanceTime: true });
-    });
-
-    afterEach(() => {
-      vi.useRealTimers();
-    });
-
-    it('enables silent renewal when called while auth is still considered valid', async () => {
-      const user = { email: 'a@b.com', name: 'A', picture: null };
-      mockFetchAuthMe.mockResolvedValue(user);
-
-      const { result } = renderHook(() => useAuth(), { wrapper });
-      await vi.waitFor(() => expect(result.current.auth).toEqual(user));
-
-      // Cookie freshly set on mount — renewal initially disabled.
-      expect(mockProvider.lastSilentRenewalOpts?.enabled).toBe(false);
-
-      act(() => {
-        result.current.triggerRefresh();
-      });
-
-      expect(mockProvider.lastSilentRenewalOpts?.enabled).toBe(true);
-    });
-
-    it('coalesces concurrent triggerRefresh() calls into a single renewal attempt', async () => {
-      const user = { email: 'a@b.com', name: 'A', picture: null };
-      mockFetchAuthMe.mockResolvedValue(user);
-
-      const { result } = renderHook(() => useAuth(), { wrapper });
-      await vi.waitFor(() => expect(result.current.auth).toEqual(user));
-
-      // Multiple concurrent calls (e.g. parallel fetchActorId 401s).
-      act(() => {
-        result.current.triggerRefresh();
-        result.current.triggerRefresh();
-        result.current.triggerRefresh();
-      });
-
-      // Renewal enabled exactly once; refreshEnabled stayed true.
-      expect(mockProvider.lastSilentRenewalOpts?.enabled).toBe(true);
-
-      // Resolve the credential path; isRefreshing resets, renewal disables.
-      mockRefreshToken.mockResolvedValue(user);
-      await act(async () => {
-        mockProvider.lastSilentRenewalOpts?.onCredential('fresh.jwt');
-      });
-      await vi.waitFor(() =>
-        expect(mockProvider.lastSilentRenewalOpts?.enabled).toBe(false),
-      );
-
-      // A subsequent triggerRefresh re-enables (proving the gate cleared).
-      act(() => {
-        result.current.triggerRefresh();
-      });
-      expect(mockProvider.lastSilentRenewalOpts?.enabled).toBe(true);
-    });
-
-    it('updates auth and refreshes cookieSetAt on successful silent renewal', async () => {
-      const user = { email: 'a@b.com', name: 'A', picture: null };
-      const refreshedUser = {
-        email: 'a@b.com',
-        name: 'A Refreshed',
-        picture: null,
-      };
-      mockFetchAuthMe.mockResolvedValue(user);
-
-      const { result } = renderHook(() => useAuth(), { wrapper });
-      await vi.waitFor(() => expect(result.current.auth).toEqual(user));
-
-      // Pretend cookie has aged most of the way to expiry. After successful
-      // refresh, cookieSetAt should be reset to "now" so the next refresh
-      // timer fires ~ (max-age - buffer) from this moment, not immediately.
-      await act(async () => {
-        vi.advanceTimersByTime(COOKIE_MAX_AGE_MS - REFRESH_BUFFER_MS - 60_000);
-      });
-
-      act(() => {
-        result.current.triggerRefresh();
-      });
-
-      mockRefreshToken.mockResolvedValue(refreshedUser);
-      await act(async () => {
-        mockProvider.lastSilentRenewalOpts?.onCredential('fresh.jwt');
-      });
-
-      await vi.waitFor(() =>
-        expect(result.current.auth).toEqual(refreshedUser),
-      );
-
-      // Drive time forward past the *old* expiry. If cookieSetAt was refreshed,
-      // auth survives. If it wasn't, the expiry timer would have already cleared it.
-      mockFetchAuthMe.mockResolvedValue(refreshedUser);
-      await act(async () => {
-        vi.advanceTimersByTime(60_000 + 100);
-      });
-      expect(result.current.auth).toEqual(refreshedUser);
-    });
-
-    it('does not clear auth on renewal onError when the cookie is still valid', async () => {
-      const user = { email: 'a@b.com', name: 'A', picture: null };
-      mockFetchAuthMe.mockResolvedValue(user);
-
-      const { result } = renderHook(() => useAuth(), { wrapper });
-      await vi.waitFor(() => expect(result.current.auth).toEqual(user));
-
-      // Cookie was just set on mount, so cookieExpired() is false.
-      act(() => {
-        result.current.triggerRefresh();
-      });
-
-      await act(async () => {
-        mockProvider.lastSilentRenewalOpts?.onError();
-      });
-
-      // Auth should be preserved — IdP session may be gone but our cookie is still good.
-      expect(result.current.auth).toEqual(user);
     });
   });
 });

--- a/hub-client/src/hooks/useAuth.ts
+++ b/hub-client/src/hooks/useAuth.ts
@@ -10,39 +10,33 @@
  * token whose expiry **slides** — the server re-issues it on
  * authenticated HTTP activity, and `useSessionKeepAlive` probes
  * /auth/me periodically while a WS is open (WS traffic never slides
- * the window). Session renewal therefore needs no IdP round-trip; it
- * works where One Tap is blocked (FedCM / third-party-cookie
- * policies).
+ * the window). Session renewal is therefore **entirely server-side**;
+ * no IdP round-trip is involved.
+ *
+ * Definitive session end (bd-s042qcxj): the GIS One-Tap silent-renewal
+ * fallback was retired. A session that hits a hard boundary
+ * (logout-everywhere revocation, absolute cap, or idle timeout) ends
+ * definitively — the SPA shows the login screen and the user re-logs-in
+ * through the GIS button. Day-to-day renewal stays invisible (the
+ * server-side slide above); re-authentication is required only at the
+ * rarely-reached hard boundaries.
  *
  * Expiry tracking: /auth/me reports the session's current `exp`
  * (`AuthState.expiresAt`, ms epoch — sliding, typically days out;
- * falls back to +1 h for older servers). One-Tap silent renewal via
- * the active `AuthProvider` is now a **fallback**, not the renewal
- * path: it is scheduled ~15 minutes before the (rarely reached)
- * expiry, and triggered on definitive 401s — e.g. after a
- * logout-everywhere revocation, where re-login is legitimate. The
- * fresh credential goes to POST /auth/refresh, which mints a new
- * session cookie.
+ * falls back to +1 h for older servers). An expiry-time re-check runs
+ * against the reported `exp`.
  *
  * Evidence-based logout (bd-3o8zmz46): auth is only cleared when a reachable
  * server definitively rejects us (401/403). Network errors — refocus checks,
  * expiry re-checks — never log the user out; offline editing must survive
  * them. When the session ends this way, `sessionExpired` is set so the UI
  * can say "session expired" instead of implying a network problem.
- *
- * 401-triggered refresh: callers that observe a mid-session 401 on an
- * authenticated REST request can call `triggerRefresh()` to enable
- * silent renewal without logging the user out. Concurrent calls are
- * coalesced.
  */
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useAuthProvider } from '../auth/AuthProvider';
 import type { AuthState } from '../services/authService';
-import { fetchAuthMe, logout as serverLogout, refreshToken } from '../services/authService';
-
-/** Buffer before expiry at which we attempt silent refresh (15 minutes). */
-export const REFRESH_BUFFER_MS = 15 * 60 * 1000;
+import { fetchAuthMe, logout as serverLogout } from '../services/authService';
 
 /** Assumed session lifetime when the server doesn't report `exp` (1 hour). */
 const DEFAULT_SESSION_MS = 3600 * 1000;
@@ -50,26 +44,17 @@ const DEFAULT_SESSION_MS = 3600 * 1000;
 /** Re-check interval when an expiry-time verdict couldn't be reached. */
 const EXPIRY_RECHECK_MS = 60 * 1000;
 
-/** Time the IdP gets to settle a renewal before it counts as failed (30 s). */
-export const REFRESH_VERDICT_TIMEOUT_MS = 30 * 1000;
-
 export function useAuth() {
   const provider = useAuthProvider();
   const [auth, setAuth] = useState<AuthState | null>(null);
   const [loading, setLoading] = useState(true);
-  const [refreshEnabled, setRefreshEnabled] = useState(false);
   const [sessionExpired, setSessionExpired] = useState(false);
-  const isRefreshing = useRef(false);
-  const refreshDeadline = useRef<ReturnType<typeof setTimeout>>(null);
-
-  // Effective expiry of the current session (0 = no session).
-  const expiresAtRef = useRef<number>(0);
 
   /**
    * Install a (re)confirmed session; clears any expired flag. Keeps
-   * the previous state object when nothing changed, so the hourly
-   * keep-alive probe doesn't re-render the app (or reset the expiry
-   * schedules) unless the session actually slid.
+   * the previous state object when nothing changed, so the keep-alive
+   * probe doesn't re-render the app (or reset the expiry schedules)
+   * unless the session actually slid.
    */
   const applyAuth = useCallback((me: AuthState) => {
     setSessionExpired(false);
@@ -90,10 +75,9 @@ export function useAuth() {
     setAuth(null);
   }, []);
 
-  const sessionLapsed = () =>
-    expiresAtRef.current > 0 && Date.now() >= expiresAtRef.current;
-
-  // Check auth status on mount.
+  // Check auth status on mount. A 401 here means "not signed in", not
+  // "session expired" — a fresh visitor should see the sign-in prompt,
+  // not an expiry message — so this never sets `sessionExpired`.
   useEffect(() => {
     let cancelled = false;
     fetchAuthMe()
@@ -110,72 +94,14 @@ export function useAuth() {
     return () => { cancelled = true; };
   }, []);
 
-  /** A renewal settled (success, failure, or deadline) — clear the in-flight gate. */
-  const settleRefresh = useCallback(() => {
-    if (refreshDeadline.current) clearTimeout(refreshDeadline.current);
-    refreshDeadline.current = null;
-    isRefreshing.current = false;
-  }, []);
-
-  /** Renewal failed without a hub verdict — settle and stand One Tap down. */
-  const abandonRenewal = useCallback(() => {
-    settleRefresh();
-    setRefreshEnabled(false);
-  }, [settleRefresh]);
-
-  // Single entry point for activating One Tap. Coalesces concurrent
-  // triggers (e.g. N parallel 401s) into one refresh attempt.
-  const triggerRefresh = useCallback(() => {
-    if (isRefreshing.current) return;
-    isRefreshing.current = true;
-    setRefreshEnabled(true);
-    // The IdP may never call back (GIS blocked / FedCM policies). Without a
-    // deadline, isRefreshing wedges true for the tab's lifetime: the expiry
-    // re-check never reaches a verdict and refocus/retry are disabled.
-    refreshDeadline.current = setTimeout(abandonRenewal, REFRESH_VERDICT_TIMEOUT_MS);
-  }, [abandonRenewal]);
-
-  // Silent renewal via the active AuthProvider. The provider collapses
-  // "renewal returned no usable credential" into onError, so the consumer
-  // only needs the two-branch (success / failure) shape here.
-  provider.useSilentRenewal({
-    enabled: refreshEnabled,
-    onCredential: (jwt) => {
-      refreshToken(jwt)
-        .then((me) => {
-          if (me) {
-            applyAuth(me);
-          } else if (sessionLapsed()) {
-            expireSession();
-          }
-        })
-        .catch(() => {
-          if (sessionLapsed()) expireSession();
-        })
-        .finally(() => {
-          settleRefresh();
-        });
-      setRefreshEnabled(false);
-    },
-    onError: () => {
-      abandonRenewal();
-      if (sessionLapsed()) expireSession();
-    },
-  });
-
-  // Clear any pending renewal deadline on unmount.
-  useEffect(() => () => {
-    if (refreshDeadline.current) clearTimeout(refreshDeadline.current);
-  }, []);
-
-  // On visibility change, verify the cookie. If rejected, try One Tap
-  // refresh; a network error means offline and never clears the session.
+  // On visibility change, verify the cookie. A definitive rejection ends
+  // the session (server-side renewal already slid it if it was alive); a
+  // network error means offline and never clears the session.
   useEffect(() => {
     if (!auth) return;
 
     const handleVisibilityChange = () => {
       if (document.visibilityState !== 'visible') return;
-      if (isRefreshing.current) return;
 
       fetchAuthMe()
         .then((me) => {
@@ -185,8 +111,8 @@ export function useAuth() {
             // reset here drifted assumed expiry past the real one).
             applyAuth(me);
           } else {
-            // Definitive rejection — try One Tap refresh before logging out.
-            triggerRefresh();
+            // Definitive rejection — the session is over.
+            expireSession();
           }
         })
         .catch(() => {
@@ -199,24 +125,13 @@ export function useAuth() {
     return () => {
       document.removeEventListener('visibilitychange', handleVisibilityChange);
     };
-  }, [auth, applyAuth, triggerRefresh]);
+  }, [auth, applyAuth, expireSession]);
 
-  // Schedule silent refresh and an expiry-time server re-check from the
-  // session's real expiry.
+  // Schedule an expiry-time server re-check from the session's real expiry.
   useEffect(() => {
-    if (!auth) {
-      expiresAtRef.current = 0;
-      return;
-    }
+    if (!auth) return;
 
     const expiresAt = auth.expiresAt ?? Date.now() + DEFAULT_SESSION_MS;
-    expiresAtRef.current = expiresAt;
-
-    // Silent refresh before expiry; immediately if already inside the buffer.
-    const refreshTimer = setTimeout(
-      triggerRefresh,
-      Math.max(expiresAt - REFRESH_BUFFER_MS - Date.now(), 0),
-    );
 
     // Expiry-time re-check. Only a definitive 401/403 clears the session;
     // network errors reschedule (logout on evidence, not on schedule).
@@ -226,13 +141,9 @@ export function useAuth() {
         fetchAuthMe()
           .then((me) => {
             if (me) {
-              applyAuth(me); // reschedules from the (possibly refreshed) exp
-            } else if (!isRefreshing.current) {
-              expireSession();
+              applyAuth(me); // reschedules from the (possibly slid) exp
             } else {
-              // Renewal in flight — re-check for a definitive verdict even
-              // if the IdP never calls back (e.g. GIS blocked).
-              scheduleExpiryCheck(EXPIRY_RECHECK_MS);
+              expireSession();
             }
           })
           .catch(() => {
@@ -244,10 +155,9 @@ export function useAuth() {
     scheduleExpiryCheck(msUntilExpiry > 0 ? msUntilExpiry + 1000 : EXPIRY_RECHECK_MS);
 
     return () => {
-      clearTimeout(refreshTimer);
       clearTimeout(expiryTimer);
     };
-  }, [auth, applyAuth, expireSession, triggerRefresh]);
+  }, [auth, applyAuth, expireSession]);
 
   const logout = useCallback(() => {
     serverLogout().catch(() => {
@@ -257,5 +167,5 @@ export function useAuth() {
     setAuth(null);
   }, [provider]);
 
-  return { auth, loading, logout, triggerRefresh, sessionExpired, expireSession, applyAuth };
+  return { auth, loading, logout, sessionExpired, expireSession, applyAuth };
 }

--- a/hub-client/src/hooks/useAuthProbe.test.tsx
+++ b/hub-client/src/hooks/useAuthProbe.test.tsx
@@ -3,7 +3,9 @@
  *
  * The probe runs while sync is disconnected and decides, on evidence only,
  * whether the disconnect is an auth failure. Offline-mode invariant: network
- * errors never trigger any action.
+ * errors never trigger any action. Since One-Tap silent renewal was retired
+ * (bd-s042qcxj), the first 401 is a no-op (record the strike) and only a
+ * second consecutive 401 rejects auth.
  *
  * @vitest-environment jsdom
  */
@@ -22,13 +24,11 @@ const mockFetchAuthMe = vi.mocked(fetchAuthMe);
 const user = { email: 'a@b.com', name: 'A', picture: null };
 
 describe('useAuthProbe', () => {
-  let triggerRefresh: ReturnType<typeof vi.fn>;
   let onAuthRejected: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     mockFetchAuthMe.mockReset();
-    triggerRefresh = vi.fn();
     onAuthRejected = vi.fn();
   });
 
@@ -39,7 +39,7 @@ describe('useAuthProbe', () => {
   const render = (enabled: boolean) =>
     renderHook(
       ({ on }: { on: boolean }) =>
-        useAuthProbe({ enabled: on, triggerRefresh, onAuthRejected }),
+        useAuthProbe({ enabled: on, onAuthRejected }),
       { initialProps: { on: enabled } },
     );
 
@@ -62,7 +62,6 @@ describe('useAuthProbe', () => {
       await vi.advanceTimersByTimeAsync(AUTH_PROBE_INTERVAL_MS);
     });
     expect(mockFetchAuthMe).toHaveBeenCalledTimes(2);
-    expect(triggerRefresh).not.toHaveBeenCalled();
     expect(onAuthRejected).not.toHaveBeenCalled();
   });
 
@@ -73,17 +72,16 @@ describe('useAuthProbe', () => {
       await vi.advanceTimersByTimeAsync(AUTH_PROBE_INTERVAL_MS * 3);
     });
     expect(mockFetchAuthMe).toHaveBeenCalled();
-    expect(triggerRefresh).not.toHaveBeenCalled();
     expect(onAuthRejected).not.toHaveBeenCalled();
   });
 
-  it('first rejection triggers renewal; second consecutive rejection rejects auth', async () => {
+  it('first rejection is a no-op; second consecutive rejection rejects auth', async () => {
     mockFetchAuthMe.mockResolvedValue(null);
     render(true);
     await act(async () => {
       await vi.advanceTimersByTimeAsync(0);
     });
-    expect(triggerRefresh).toHaveBeenCalledTimes(1);
+    // First strike: no action yet — a single transient 401 must not flap.
     expect(onAuthRejected).not.toHaveBeenCalled();
     await act(async () => {
       await vi.advanceTimersByTimeAsync(AUTH_PROBE_INTERVAL_MS);
@@ -93,9 +91,9 @@ describe('useAuthProbe', () => {
 
   it('a successful probe between rejections resets the strike counter', async () => {
     mockFetchAuthMe
-      .mockResolvedValueOnce(null) // strike 1 → renewal
-      .mockResolvedValueOnce(user) // renewal restored the session → reset
-      .mockResolvedValueOnce(null); // strike 1 again → renewal, not rejection
+      .mockResolvedValueOnce(null) // strike 1 → no-op
+      .mockResolvedValueOnce(user) // recovered → reset strikes
+      .mockResolvedValueOnce(null); // strike 1 again → no-op, not rejection
     render(true);
     await act(async () => {
       await vi.advanceTimersByTimeAsync(0);
@@ -106,7 +104,6 @@ describe('useAuthProbe', () => {
     await act(async () => {
       await vi.advanceTimersByTimeAsync(AUTH_PROBE_INTERVAL_MS);
     });
-    expect(triggerRefresh).toHaveBeenCalledTimes(2);
     expect(onAuthRejected).not.toHaveBeenCalled();
   });
 

--- a/hub-client/src/hooks/useAuthProbe.ts
+++ b/hub-client/src/hooks/useAuthProbe.ts
@@ -8,10 +8,20 @@
  *
  * - 200 → cookie is fine, the outage is elsewhere; strike counter resets.
  * - network error → offline; never any action (offline editing must survive).
- * - 401/403 → first strike triggers silent renewal; a second consecutive
- *   strike on the next cycle calls `onAuthRejected` (evidence-based logout).
- *   The two-strike shape gives renewal a full cycle to land and avoids
- *   depending on IdP callbacks that may never fire (e.g. GIS blocked).
+ * - 401/403 → first strike is a **no-op** (just record it); a second
+ *   consecutive strike on the next cycle calls `onAuthRejected`
+ *   (evidence-based logout).
+ *
+ * Why the no-op first strike: the strike count is client-side UX, not a
+ * security boundary — the server rejects every request the instant a session
+ * ends, and this probe only runs while the WS is *already* disconnected (no
+ * new data flows, no writes persist during the window). A single transient
+ * 401 (multi-instance deploy / key-rotation race) followed by a 200 therefore
+ * must not flap the user to the login screen; two consecutive 401s are
+ * stronger evidence, and this stays within the evidence-based-logout invariant
+ * (still never a network-error logout). Session *renewal* is entirely
+ * server-side (sliding re-issue, bd-ey6jg70f); the One-Tap silent-renewal that
+ * the first strike once triggered was retired in bd-s042qcxj.
  */
 
 import { useEffect, useRef } from 'react';
@@ -23,19 +33,15 @@ export const AUTH_PROBE_INTERVAL_MS = 30_000;
 interface AuthProbeOpts {
   /** Probe only while true (auth enabled + signed in + sync disconnected). */
   enabled: boolean;
-  /** First definitive rejection: ask for silent renewal. */
-  triggerRefresh: () => void;
   /** Second consecutive rejection: the session is over. */
   onAuthRejected: () => void;
 }
 
-export function useAuthProbe({ enabled, triggerRefresh, onAuthRejected }: AuthProbeOpts) {
-  // Keep the latest callbacks in refs so the probe effect can key on
-  // `enabled` alone without re-arming the interval when they change.
-  const triggerRefreshRef = useRef(triggerRefresh);
+export function useAuthProbe({ enabled, onAuthRejected }: AuthProbeOpts) {
+  // Keep the latest callback in a ref so the probe effect can key on
+  // `enabled` alone without re-arming the interval when it changes.
   const onAuthRejectedRef = useRef(onAuthRejected);
   useEffect(() => {
-    triggerRefreshRef.current = triggerRefresh;
     onAuthRejectedRef.current = onAuthRejected;
   });
 
@@ -54,11 +60,11 @@ export function useAuthProbe({ enabled, triggerRefresh, onAuthRejected }: AuthPr
           return;
         }
         strikes += 1;
-        if (strikes === 1) {
-          triggerRefreshRef.current();
-        } else {
+        if (strikes >= 2) {
           onAuthRejectedRef.current();
         }
+        // strike 1 is a no-op: record it and give the next cycle a chance
+        // to confirm (or clear) the rejection before logging out.
       } catch {
         // Network error / unreachable hub — no evidence, no action.
       }

--- a/hub-client/src/hooks/useSessionKeepAlive.test.tsx
+++ b/hub-client/src/hooks/useSessionKeepAlive.test.tsx
@@ -6,8 +6,9 @@
  * qualifies (validate-once at upgrade), so a WS-only client would idle
  * out despite being "active". This hook owns the keep-alive: a periodic
  * GET /auth/me while signed in with sync online. The slide requires no
- * IdP round-trip at all — these tests mock only fetchAuthMe; no
- * One-Tap/GIS callback is involved (the FedCM/3p-cookie-blocked case).
+ * IdP round-trip at all — these tests mock only fetchAuthMe. A definitive
+ * rejection ends the session (`onAuthRejected`); the One-Tap silent-renewal
+ * fallback was retired (bd-s042qcxj).
  *
  * @vitest-environment jsdom
  */
@@ -32,13 +33,13 @@ const me = (expiresAt: number) => ({
 
 describe('useSessionKeepAlive', () => {
   let onAuthState: ReturnType<typeof vi.fn>;
-  let triggerRefresh: ReturnType<typeof vi.fn>;
+  let onAuthRejected: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     mockFetchAuthMe.mockReset();
     onAuthState = vi.fn();
-    triggerRefresh = vi.fn();
+    onAuthRejected = vi.fn();
   });
 
   afterEach(() => {
@@ -48,7 +49,7 @@ describe('useSessionKeepAlive', () => {
   const render = (enabled: boolean) =>
     renderHook(
       ({ on }: { on: boolean }) =>
-        useSessionKeepAlive({ enabled: on, onAuthState, triggerRefresh }),
+        useSessionKeepAlive({ enabled: on, onAuthState, onAuthRejected }),
       { initialProps: { on: enabled } },
     );
 
@@ -80,19 +81,19 @@ describe('useSessionKeepAlive', () => {
     expect(mockFetchAuthMe).toHaveBeenCalledTimes(2);
     expect(onAuthState).toHaveBeenLastCalledWith(me(2_000_000));
     // The whole slide happened without any IdP involvement.
-    expect(triggerRefresh).not.toHaveBeenCalled();
+    expect(onAuthRejected).not.toHaveBeenCalled();
   });
 
-  it('asks for silent renewal on a definitive rejection', async () => {
+  it('ends the session on a definitive rejection', async () => {
     // e.g. the session was revoked via logout-everywhere on another
-    // device: re-login (renewal) is legitimate; the token family is
-    // dead but the account is not.
+    // device, or hit the absolute cap: the session is over and the user
+    // re-logs-in through the GIS button (no silent renewal any more).
     mockFetchAuthMe.mockResolvedValue(null);
     render(true);
     await act(async () => {
       await vi.advanceTimersByTimeAsync(0);
     });
-    expect(triggerRefresh).toHaveBeenCalledTimes(1);
+    expect(onAuthRejected).toHaveBeenCalledTimes(1);
     expect(onAuthState).not.toHaveBeenCalled();
   });
 
@@ -102,7 +103,7 @@ describe('useSessionKeepAlive', () => {
     await act(async () => {
       await vi.advanceTimersByTimeAsync(SESSION_KEEP_ALIVE_INTERVAL_MS);
     });
-    expect(triggerRefresh).not.toHaveBeenCalled();
+    expect(onAuthRejected).not.toHaveBeenCalled();
     expect(onAuthState).not.toHaveBeenCalled();
   });
 

--- a/hub-client/src/hooks/useSessionKeepAlive.ts
+++ b/hub-client/src/hooks/useSessionKeepAlive.ts
@@ -11,15 +11,16 @@
  * (sliding) expiry, which `onAuthState` feeds back into `useAuth` so
  * its schedules follow the session; the request itself is what
  * triggers the server-side re-issue. No IdP round-trip is involved —
- * this is the renewal path that works where One Tap is blocked
- * (FedCM / third-party-cookie policies).
+ * renewal is entirely server-side.
  *
  * Failure semantics mirror the evidence-based rules from bd-3o8zmz46:
- * a definitive 401/403 asks for silent renewal (`triggerRefresh`) —
- * e.g. the session was revoked via logout-everywhere elsewhere, where
- * re-login is legitimate; network errors take no action (offline
- * editing must survive them). While sync is *disconnected*,
- * `useAuthProbe`'s faster two-strike probe governs instead.
+ * a definitive 401/403 ends the session (`onAuthRejected`) — e.g. the
+ * session was revoked via logout-everywhere elsewhere, or hit the
+ * absolute cap — and the user re-logs-in through the GIS button (the
+ * One-Tap silent-renewal fallback was retired in bd-s042qcxj); network
+ * errors take no action (offline editing must survive them). While sync
+ * is *disconnected*, `useAuthProbe`'s faster two-strike probe governs
+ * instead.
  */
 
 import { useEffect, useRef } from 'react';
@@ -39,17 +40,17 @@ interface SessionKeepAliveOpts {
   enabled: boolean;
   /** Fresh session info (sliding expiry) from a successful probe. */
   onAuthState: (me: AuthState) => void;
-  /** Definitive rejection: ask for silent renewal. */
-  triggerRefresh: () => void;
+  /** Definitive rejection: the session is over. */
+  onAuthRejected: () => void;
 }
 
-export function useSessionKeepAlive({ enabled, onAuthState, triggerRefresh }: SessionKeepAliveOpts) {
+export function useSessionKeepAlive({ enabled, onAuthState, onAuthRejected }: SessionKeepAliveOpts) {
   // Latest callbacks in refs so the interval keys on `enabled` alone.
   const onAuthStateRef = useRef(onAuthState);
-  const triggerRefreshRef = useRef(triggerRefresh);
+  const onAuthRejectedRef = useRef(onAuthRejected);
   useEffect(() => {
     onAuthStateRef.current = onAuthState;
-    triggerRefreshRef.current = triggerRefresh;
+    onAuthRejectedRef.current = onAuthRejected;
   });
 
   useEffect(() => {
@@ -64,7 +65,7 @@ export function useSessionKeepAlive({ enabled, onAuthState, triggerRefresh }: Se
         if (me) {
           onAuthStateRef.current(me);
         } else {
-          triggerRefreshRef.current();
+          onAuthRejectedRef.current();
         }
       } catch {
         // Network error / unreachable hub — no evidence, no action.

--- a/hub-client/src/services/authService.test.ts
+++ b/hub-client/src/services/authService.test.ts
@@ -1,15 +1,17 @@
 /**
  * Unit Tests for authService
  *
- * Tests auth API helpers: fetchAuthMe, logout, refreshToken, fetchActorId.
+ * Tests auth API helpers: fetchAuthMe, logout, fetchActorId, resolveActorId.
  * Uses mocked fetch. IdP-side signout is no longer authService's
  * concern (moved to the AuthProvider boundary); see Phase 6 of
- * `claude-notes/plans/2026-05-20-auth-provider-interface.md`.
+ * `claude-notes/plans/2026-05-20-auth-provider-interface.md`. Session
+ * renewal is entirely server-side (sliding re-issue) — there is no client
+ * renewal helper since One-Tap was retired (bd-s042qcxj).
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-import { fetchAuthMe, fetchActorId, resolveActorId, logout, refreshToken } from './authService';
+import { fetchAuthMe, fetchActorId, resolveActorId, logout } from './authService';
 
 describe('authService', () => {
   beforeEach(() => {
@@ -109,66 +111,6 @@ describe('authService', () => {
         credentials: 'same-origin',
         headers: { 'X-Requested-With': 'XMLHttpRequest' },
       });
-    });
-  });
-
-  // ── refreshToken ────────────────────────────────────────────
-
-  describe('refreshToken', () => {
-    it('sends credential and returns fresh user info on success', async () => {
-      const user = { email: 'a@b.com', name: 'A', picture: null };
-
-      // First call: POST /auth/refresh → 200
-      // Second call: GET /auth/me → 200 with user
-      vi.mocked(fetch)
-        .mockResolvedValueOnce({ ok: true, status: 200 } as Response)
-        .mockResolvedValueOnce({
-          ok: true,
-          status: 200,
-          json: () => Promise.resolve(user),
-        } as Response);
-
-      const result = await refreshToken('jwt.token.here');
-
-      expect(fetch).toHaveBeenNthCalledWith(1, '/auth/refresh', {
-        method: 'POST',
-        credentials: 'same-origin',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Requested-With': 'XMLHttpRequest',
-        },
-        body: JSON.stringify({ credential: 'jwt.token.here' }),
-      });
-      expect(result).toEqual(user);
-    });
-
-    it('returns null on 401', async () => {
-      vi.mocked(fetch).mockResolvedValue({
-        ok: false,
-        status: 401,
-      } as Response);
-
-      expect(await refreshToken('bad')).toBeNull();
-    });
-
-    it('returns null on 403', async () => {
-      vi.mocked(fetch).mockResolvedValue({
-        ok: false,
-        status: 403,
-      } as Response);
-
-      expect(await refreshToken('wrong-domain')).toBeNull();
-    });
-
-    it('throws on unexpected server error', async () => {
-      vi.mocked(fetch).mockResolvedValue({
-        ok: false,
-        status: 502,
-      } as Response);
-
-      await expect(refreshToken('cred')).rejects.toThrow(
-        '/auth/refresh failed: 502',
-      );
     });
   });
 
@@ -303,7 +245,7 @@ describe('authService', () => {
       expect(result).toBe('serveractor');
     });
 
-    it('returns the actor ID on success without triggering refresh', async () => {
+    it('returns the actor ID on success without ending the session', async () => {
       vi.mocked(fetch).mockResolvedValue({
         ok: true,
         status: 200,
@@ -317,7 +259,7 @@ describe('authService', () => {
       expect(onSessionExpired).not.toHaveBeenCalled();
     });
 
-    it('returns null (abandon) and triggers refresh on 401', async () => {
+    it('returns null (abandon) and ends the session on 401', async () => {
       vi.mocked(fetch).mockResolvedValue({
         ok: false,
         status: 401,
@@ -327,12 +269,14 @@ describe('authService', () => {
       const result = await resolveActorId('automerge:abc', true, onSessionExpired);
 
       // null, NOT undefined: callers' `if (id === null) return` must fire so
-      // the document open is abandoned while the refresh races in the background.
+      // the document open is abandoned; onSessionExpired ends the session so
+      // the SPA shows the login screen (server-side renewal already slid a
+      // live session — a 401 here means it is definitively over).
       expect(result).toBeNull();
       expect(onSessionExpired).toHaveBeenCalledTimes(1);
     });
 
-    it('returns null (abandon) and triggers refresh on 403', async () => {
+    it('returns null (abandon) and ends the session on 403', async () => {
       vi.mocked(fetch).mockResolvedValue({
         ok: false,
         status: 403,
@@ -345,7 +289,7 @@ describe('authService', () => {
       expect(onSessionExpired).toHaveBeenCalledTimes(1);
     });
 
-    it('propagates non-401/403 errors without triggering refresh', async () => {
+    it('propagates non-401/403 errors without ending the session', async () => {
       vi.mocked(fetch).mockResolvedValue({
         ok: false,
         status: 500,

--- a/hub-client/src/services/authService.ts
+++ b/hub-client/src/services/authService.ts
@@ -4,8 +4,9 @@
  * Server-side helpers for the cookie-based auth flow. The auth token
  * lives in a server-set HttpOnly cookie — JavaScript never sees or
  * stores it. This module provides helpers to check auth status and
- * refresh tokens via server endpoints. IdP-side signout is the
- * `AuthProvider`'s concern, not this module's.
+ * clear the session via server endpoints. Session *renewal* is entirely
+ * server-side (sliding re-issue); there is no client renewal helper.
+ * IdP-side signout is the `AuthProvider`'s concern, not this module's.
  */
 
 import { hubPath } from '../utils/routing';
@@ -84,10 +85,10 @@ export async function fetchActorId(projectId: string): Promise<string | null> {
  * (local-prod / `--allow-insecure-auth`) still stamp a consistent identity into
  * documents. The network is never touched in the auth-disabled branch.
  *
- * On auth failure we fire `onSessionExpired` (a silent refresh) and return
- * `null` so callers' `=== null` guard abandons this attempt; One Tap either
- * restores the session in place or eventually clears auth via its onError path.
- * Throws propagate (e.g. 500) so callers' try/catch surfaces a connection error.
+ * On auth failure we fire `onSessionExpired` — the session has ended, so the
+ * SPA shows the login screen — and return `null` so callers' `=== null` guard
+ * abandons this attempt. Throws propagate (e.g. 500) so callers' try/catch
+ * surfaces a connection error.
  */
 export async function resolveActorId(
   indexDocId: string,
@@ -111,25 +112,4 @@ export async function logout(): Promise<void> {
     credentials: 'same-origin',
     headers: { 'X-Requested-With': 'XMLHttpRequest' },
   });
-}
-
-/**
- * Send a fresh OIDC ID token to the server for validation and cookie refresh.
- * Returns the updated user info on success, null on auth failure.
- */
-export async function refreshToken(credential: string): Promise<AuthState | null> {
-  const res = await fetch(hubPath('/auth/refresh'), {
-    method: 'POST',
-    credentials: 'same-origin',
-    headers: {
-      'Content-Type': 'application/json',
-      'X-Requested-With': 'XMLHttpRequest',
-    },
-    body: JSON.stringify({ credential }),
-  });
-  if (res.status === 401 || res.status === 403) return null;
-  if (!res.ok) throw new Error(`/auth/refresh failed: ${res.status}`);
-
-  // After refresh, fetch fresh user info from the new cookie.
-  return fetchAuthMe();
 }


### PR DESCRIPTION
**Strand:** `bd-s042qcxj` (epic `bd-qxgoti2b`, slice B2) · **Plan:** `claude-notes/plans/2026-07-27-retire-gis-onetap-renewal.md`

## Why

One-Tap silent renewal is no longer needed. With server-minted sliding sessions (`bd-ey6jg70f`, #414), the hub itself re-issues the session cookie with a fresh, later-expiring token on each authenticated `/auth/me` — and `useSessionKeepAlive` sends one periodically. Renewal is now entirely server-side (idle 7 d / absolute 30 d); the browser never has to go back to the IdP for a new credential.

## What changed

- **Client:** removed the One-Tap renewal machinery — `useSilentRenewal`/`SilentRenewalOpts`, `useGoogleOneTapLogin`, `useAuth`'s `triggerRefresh` + refresh timers, and `authService.refreshToken()`. Definitive 401s now route to `expireSession`; network errors stay no-ops (evidence-based logout, `bd-3o8zmz46`). Kept the GIS login button + `signOut`.
- **Server:** renamed `/auth/refresh` → `/auth/session` (logic unchanged). It was never a One-Tap artifact — it's the direct-JSON login path for Generic OIDC frontends, retained for the deferred PKCE work (B1).

**Behavior:** a definitive session end (logout-everywhere / absolute cap / idle) now shows the login screen instead of a silent One-Tap restore. Everyday renewal stays invisible (server-side slide).

## Verification

`cargo nextest -p quarto-hub` 371 pass · `cargo xtask verify --skip-hub-build` green · hub-client `build:all` clean, `test:ci` 740+109+129 pass. Rename confirmed on the real `hub` binary: `POST /auth/refresh` → 404, `POST /auth/session` → 401/403 (never 404). Full browser GIS flow not exercised (needs a real Google-OIDC hub).