### PR TITLE
hub-client: show user picture in collections project selector avatar (bd-cq56h487)

### DIFF
--- a/hub-client/changelog.md
+++ b/hub-client/changelog.md
@@ -25,6 +25,7 @@ WASM rebuild is needed for a changelog-only edit.
 
 ### 2026-07-27
 
+- [`2b6091d8`](https://github.com/quarto-dev/q2/commits/2b6091d8): The project selector avatar now shows your profile picture when signed in, instead of a plain initials circle.
 - [`e73786ed`](https://github.com/quarto-dev/q2/commits/e73786ed): When a signed-in session definitively ends (you sign out everywhere, or it reaches its 30-day maximum), the app now returns you to the sign-in screen instead of trying to silently re-authenticate through Google One Tap; day-to-day sessions still renew invisibly while you keep using the app.
 
 ### 2026-07-24

--- a/hub-client/src/App.tsx
+++ b/hub-client/src/App.tsx
@@ -760,6 +760,7 @@ function App() {
             error={connectionError}
             onSignOut={AUTH_ENABLED ? logout : undefined}
             authEmail={auth?.email}
+            authPicture={auth?.picture}
             onScreenNameChange={setScreenName}
             onColorChange={setCursorColor}
             projectSetDocId={projectSetActions.getProjectSetDocId()}

--- a/hub-client/src/components/ProjectsHome.css
+++ b/hub-client/src/components/ProjectsHome.css
@@ -184,6 +184,8 @@
   align-items: center;
   justify-content: center;
   cursor: pointer;
+  padding: 0;
+  overflow: hidden;
 }
 
 .ph-avatar.big {
@@ -192,6 +194,13 @@
   font-size: 14px;
   cursor: default;
   flex-shrink: 0;
+}
+
+.ph-avatar-img {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  object-fit: cover;
 }
 
 /* ---- menus ---- */

--- a/hub-client/src/components/ProjectsHome.tsx
+++ b/hub-client/src/components/ProjectsHome.tsx
@@ -53,6 +53,7 @@ interface Props {
   onProjectCreated?: (files: ProjectFile[], title: string, projectType: string, syncServer: string) => void;
   onSignOut?: () => void;
   authEmail?: string;
+  authPicture?: string | null;
   onScreenNameChange?: (name: string) => void;
   onColorChange?: (color: string) => void;
   projectSetDocId?: string | null;
@@ -219,6 +220,7 @@ export default function ProjectsHome({
   onProjectCreated,
   onSignOut,
   authEmail,
+  authPicture,
   onScreenNameChange,
   onColorChange,
   projectSetDocId,
@@ -1554,17 +1556,25 @@ export default function ProjectsHome({
           <div className="qh-menu-anchor ph-avatar-anchor">
             <button
               className="ph-avatar"
-              style={{ backgroundColor: userSettings?.userColor ?? 'var(--posit-blue)' }}
+              style={authPicture ? undefined : { backgroundColor: userSettings?.userColor ?? 'var(--posit-blue)' }}
               onClick={() => setAvatarMenuOpen((v) => !v)}
               title={userSettings?.userName}
             >
-              {initialsFor(userSettings?.userName ?? '')}
+              {authPicture ? (
+                <img src={authPicture} alt="" className="ph-avatar-img" referrerPolicy="no-referrer" />
+              ) : (
+                initialsFor(userSettings?.userName ?? '')
+              )}
             </button>
             {avatarMenuOpen && userSettings && (
               <div className="ph-menu ph-menu-right ph-avatar-menu">
                 <div className="ph-avatar-menu-id">
-                  <span className="ph-avatar big" style={{ backgroundColor: userSettings.userColor }}>
-                    {initialsFor(userSettings.userName)}
+                  <span className="ph-avatar big" style={authPicture ? undefined : { backgroundColor: userSettings.userColor }}>
+                    {authPicture ? (
+                      <img src={authPicture} alt="" className="ph-avatar-img" referrerPolicy="no-referrer" />
+                    ) : (
+                      initialsFor(userSettings.userName)
+                    )}
                   </span>
                   <div className="ph-avatar-menu-who">
                     {editingName ? (


### PR DESCRIPTION
## Symptom

In the redesigned **collections** project-selector (`ProjectsHome`), the current-user avatar showed a plain colored circle with initials even when signed in. With auth enabled it should show the user's OIDC profile picture, as the classic `ProjectSelector` always did.

## Cause

The collections redesign (`f21e851e`, #394) only ever rendered an initials circle (`.ph-avatar`) and was never threaded `auth.picture`. `App.tsx` passed `authPicture={auth?.picture}` to the classic `ProjectSelector` but only `authEmail` to `ProjectsHome`, and `ProjectsHome` had no `authPicture` prop at all — so it couldn't render the picture even if it wanted to.

## Fix

- Add `authPicture?: string | null` to `ProjectsHome`'s props (matching `AuthState.picture`) and thread `auth?.picture` from `App.tsx`.
- Render an `<img class="ph-avatar-img" referrerPolicy="no-referrer">` when a picture is present, falling back to `initialsFor(...)` when absent (auth disabled or no picture). Applies to both the header avatar button and the dropdown "big" avatar, mirroring `ProjectSelector`.
- CSS: `.ph-avatar-img` fills the circle (`object-fit: cover`); `.ph-avatar` gains `padding: 0; overflow: hidden` so the image clips to the round shape. The background-color style is dropped when a picture is shown.

Because the picture only appears when `authPicture` is truthy, the auth-disabled case (local dev, no picture) keeps the existing initials circle unchanged.

## Tests

- `npm run build:all` ✅ (production `tsc -b && vite build`, stricter than tsc/vitest)
- `npm run test:ci` — 129/129 ✅
- `npm run test:wasm` (changelog render gate) — 129/129 ✅

**Not verified:** browser E2E of the picture path — needs an auth-enabled hub with a real OIDC session, which can't be stood up locally. The code path is identical to the previously-working classic `ProjectSelector`.

Strand: bd-cq56h487