### PR TITLE
hub-client: don't flash Offline before Online on open

### DIFF
--- a/claude-notes/plans/2026-07-27-connection-indicator-hide-until-resolved.md
+++ b/claude-notes/plans/2026-07-27-connection-indicator-hide-until-resolved.md
@@ -1,0 +1,66 @@
+# Connection indicator: no Offline flash on open (bd-53501yf7)
+
+## Overview
+
+When opening a document in hub-client, the header connection indicator
+**always showed "Offline" first, then flipped to "Online"** a moment later.
+
+### Root cause
+
+- `App.tsx` holds a boolean `isOnline`, initialized to `false`.
+- The indicator lives in `MinimalHeader`, which is inside `Editor` — and
+  `Editor` only mounts **after** `project` is set, i.e. **after**
+  `connect()` has already resolved. So the indicator's *first paint* is
+  whatever `connect()` decided; it never renders during the connecting
+  window, and the initial `false` is never seen.
+- Production passed `peerTimeoutMs = undefined` → coerced to **1 ms**
+  (`client.ts:814`). The WebSocket almost never completes its handshake in
+  1 ms, so `connect()` resolved offline-first and fired
+  `onConnectionChange(false)` (`client.ts:946`). The header mounted showing
+  **Offline**. The later `peer` network event flipped it to **Online**.
+
+So the *connecting* window was displayed as *offline*, and — because of the
+1 ms budget — the initial content was also the (possibly stale) local cache
+rather than the live document.
+
+### Fix: widen the initial peer wait (only)
+
+Widen the production peer wait from 1 ms to **400 ms**
+(`PRODUCTION_PEER_TIMEOUT_MS` in `App.tsx`). Because `waitForPeer` resolves
+the *instant* the peer connects:
+
+- **Common (fast) case:** `connect()` resolves as **Online**, so the header
+  mounts already Online, showing the **live** document — adding only the
+  real connect latency. No flash.
+- **Slow/offline case:** `connect()` resolves offline; the header mounts
+  Offline and flips to Online when the peer lands. This is the rare tail —
+  and still strictly better than today's *always*-Offline-first, so we
+  accept it (no extra machinery).
+
+The E2E path is unchanged at 15000 ms (it starts from empty storage and must
+sync every doc; opening before the socket connects makes `loadFileDocuments`
+race it and the render-target doc can lose under CI contention).
+
+### Approaches considered and dropped
+
+We first built a three-state `connecting`/`online`/`offline` indicator that
+stayed **hidden** during the connecting window and used a grace timer to
+concede "Offline" only after a first connect that never landed a peer. That
+deterministically hid the slow/offline flash tail but added a pure module, a
+grace-timer constant, a `hasEverConnected` ref, and a `beginConnect()` reset
+at every connect site. Per the user (2026-07-27), we dropped it: the 400 ms
+widen alone fixes the common case, and showing Offline on a genuinely slow
+connect is acceptable. Simpler wins.
+
+## Work Items
+
+- [x] Widen production `peerTimeoutMs` 1 ms → 400 ms
+      (`PRODUCTION_PEER_TIMEOUT_MS`); update the comment; E2E unchanged.
+- [x] `MinimalHeader.test.tsx` (jsdom) — indicator shows Online when
+      `isOnline`, Offline otherwise (previously untested).
+- [x] `npm run test:ci` (hub-client) green.
+- [x] `tsc -b` clean and `npm run build:all` succeeds (WASM + vite).
+- [ ] End-to-end: `npm run local-prod` (or a real hub) — open a doc,
+      confirm the indicator opens Online (fast connect) rather than
+      flashing Offline→Online. **(not yet run — see status note)**
+- [x] Update `hub-client/changelog.md` (two-commit workflow).

--- a/hub-client/changelog.md
+++ b/hub-client/changelog.md
@@ -25,6 +25,7 @@ WASM rebuild is needed for a changelog-only edit.
 
 ### 2026-07-27
 
+- [`d419d32`](https://github.com/quarto-dev/q2/commits/d419d32): Opening a document now connects to the live document straight away, so the connection indicator no longer briefly shows "Offline" before switching to "Online" on a normal connection.
 - [`2b6091d8`](https://github.com/quarto-dev/q2/commits/2b6091d8): The project selector avatar now shows your profile picture when signed in, instead of a plain initials circle.
 - [`e73786ed`](https://github.com/quarto-dev/q2/commits/e73786ed): When a signed-in session definitively ends (you sign out everywhere, or it reaches its 30-day maximum), the app now returns you to the sign-in screen instead of trying to silently re-authenticate through Google One Tap; day-to-day sessions still renew invisibly while you keep using the app.
 

--- a/hub-client/src/App.tsx
+++ b/hub-client/src/App.tsx
@@ -47,6 +47,20 @@ import { resolveSyncServerUrl, DEFAULT_SYNC_SERVER } from './utils/routing';
 import './App.css';
 
 /**
+ * Production budget for the initial peer connect. `waitForPeer` resolves the
+ * *instant* the peer connects, so in the common (online) case this adds only
+ * the real connect latency and lets `connect()` resolve as Online — the header
+ * (which mounts only after connect() resolves) then shows Online right away
+ * with the *live* document, instead of the 1 ms probe that always resolved
+ * offline-first and made the indicator flash Offline → Online. If the connect
+ * is slower than this budget the header mounts Offline and flips to Online when
+ * the peer lands — the rare tail, and still an improvement on always-first
+ * Offline. A genuinely-offline user waits at most this long before cached
+ * content appears (bounded regression of offline-first).
+ */
+const PRODUCTION_PEER_TIMEOUT_MS = 400;
+
+/**
  * Connect to a sync server and load all file contents into a Map.
  * Shared by every code path that opens a project.
  */
@@ -62,18 +76,20 @@ async function connectAndLoadContents(
   if (import.meta.env.VITE_E2E === '1') {
     actorId = (window as any).__QUARTO_TEST_ACTOR_ID__ as string | undefined ?? actorId;
   }
-  // Production opens offline-first (the sync client's 1 ms default peer wait):
-  // a returning user sees cached content instantly while the peer connects in
-  // the background. But the smoke-all E2E env always starts with EMPTY storage
-  // and must sync every doc from the (local) server, so opening offline-first
-  // there means loadFileDocuments races the still-connecting websocket — and
-  // under CI contention the render-target doc loses that race, is marked
-  // unavailable, and the preview fails "Path not found" (stage
-  // EDITOR_NO_PREVIEW; sometimes the index loses it too → CONNECT_STALL).
-  // waitForPeer resolves the instant the peer connects, so this only adds wall
-  // time when the connection is genuinely slow — exactly the CI case we want to
-  // wait out. Tree-shaken in production, so no offline-first UX change there.
-  const peerTimeoutMs = import.meta.env.VITE_E2E === '1' ? 15000 : undefined;
+  // Production gives the peer a modest budget (PRODUCTION_PEER_TIMEOUT_MS) so
+  // the common (online) open resolves as Online with the live document, rather
+  // than the 1 ms offline-first probe that made the indicator always flash
+  // Offline → Online. waitForPeer resolves the instant the peer connects, so a
+  // fast connection pays only its real latency; a genuinely-offline user waits
+  // at most the budget before cached content appears.
+  //
+  // The smoke-all E2E env always starts with EMPTY storage and must sync every
+  // doc from the (local) server, so it needs a much longer wait: opening before
+  // the socket connects means loadFileDocuments races it — under CI contention
+  // the render-target doc loses, is marked unavailable, and the preview fails
+  // "Path not found" (stage EDITOR_NO_PREVIEW; sometimes the index loses it too
+  // → CONNECT_STALL).
+  const peerTimeoutMs = import.meta.env.VITE_E2E === '1' ? 15000 : PRODUCTION_PEER_TIMEOUT_MS;
   const files = await connect(resolveSyncServerUrl(syncServer), indexDocId, actorId, screenName, color, peerTimeoutMs);
   const contents = new Map<string, string>();
   for (const file of files) {

--- a/hub-client/src/components/MinimalHeader.test.tsx
+++ b/hub-client/src/components/MinimalHeader.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * Tests for the MinimalHeader connection indicator.
+ *
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import MinimalHeader from './MinimalHeader';
+import { ViewModeProvider } from './ViewModeContext';
+
+afterEach(cleanup);
+
+const baseProps = {
+  currentFilePath: 'index.qmd',
+  projectName: 'My Project',
+  onChooseNewProject: () => {},
+};
+
+// MinimalHeader renders <ViewToggleControl/>, which reads ViewModeContext.
+function renderHeader(isOnline: boolean) {
+  return render(
+    <ViewModeProvider>
+      <MinimalHeader {...baseProps} isOnline={isOnline} />
+    </ViewModeProvider>,
+  );
+}
+
+describe('MinimalHeader connection indicator', () => {
+  it('shows Online when connected', () => {
+    renderHeader(true);
+    const indicator = document.querySelector('.connection-indicator')!;
+    expect(indicator.className).toContain('online');
+    expect(indicator.className).not.toContain('offline');
+    expect(screen.getByText('Online')).toBeDefined();
+  });
+
+  it('shows Offline when disconnected', () => {
+    renderHeader(false);
+    const indicator = document.querySelector('.connection-indicator')!;
+    expect(indicator.className).toContain('offline');
+    expect(screen.getByText('Offline')).toBeDefined();
+  });
+});


### PR DESCRIPTION
Closes #421.

Opening a document briefly showed the connection indicator as **Offline** before flipping to **Online**.

**Cause:** the indicator (`MinimalHeader`) mounts only after `connect()` resolves, so its first paint is whatever `connect()` decided. Production waited just **1 ms** for a peer, so `connect()` essentially always resolved offline-first — the header mounted Offline, and only the later `peer` event flipped it to Online.

**Fix:** widen the production peer wait 1 ms → **400 ms** (`PRODUCTION_PEER_TIMEOUT_MS`). `waitForPeer` resolves the instant the peer connects, so the common (fast) open now resolves as Online — the header mounts Online right away with the *live* document — adding only the real connect latency. A slower connect still mounts Offline and flips when the peer lands (rare tail, accepted — still better than always-first Offline). E2E path unchanged at 15000 ms.

Adds `MinimalHeader.test.tsx` covering the Online/Offline indicator (previously untested).

**Verified:** `tsc -b` clean, full hub-client suite 129 pass (incl. changelog qmd gate), `npm run build:all` green. Not verified in a live browser session.