### PR TITLE
Auth hardening: nonce-bound GIS login, __Host- session cookie, narrower mint surface

### DIFF
--- a/claude-notes/plans/2026-07-27-auth-current-flow-hardening.md
+++ b/claude-notes/plans/2026-07-27-auth-current-flow-hardening.md
@@ -209,6 +209,42 @@ Note: `GoogleOAuthProvider`'s own `nonce` prop is unrelated — it sets the
 CSP nonce on the injected `<script>` tag. Do not pass the login nonce
 there.
 
+#### Why a dedicated `GET /auth/nonce` and not something cheaper
+
+Asked and settled 2026-07-28. Three alternatives were considered:
+
+- **Embed it in the SPA document.** Impossible: the SPA HTML is served by
+  nginx / the static proxy, and the hub never sees that request.
+- **Let the client generate the nonce and have the hub seal it.** Breaks
+  the scheme outright. An attacker holding a captured ID token can read
+  its `nonce` claim (plaintext JWT payload), ask the hub to seal that
+  value, and replay. The nonce **must** be server-generated and
+  uninfluenced by the caller — which forces a round trip before the IdP
+  hop.
+- **Fold it into `GET /auth/me`,** the one pre-login request the SPA
+  already makes. Rejected: `/auth/me` doubles as the sliding-session
+  keep-alive probe (`useSessionKeepAlive`), so it would re-mint the
+  login-state cookie repeatedly — clobbering a second tab's in-flight
+  login, since the cookie is a single named slot — and it is
+  Bearer-reachable from hub-mcp, where browser login state is
+  meaningless. Two different lifetimes on one endpoint.
+
+Also rejected: carrying the sealed blob in GIS's `state` parameter
+(`GsiButtonConfiguration.state` does return with the ID token) instead of
+a cookie. Tempting, because it needs no endpoint *and* would work under
+`--allow-insecure-auth`. But `state` comes back as a **form field in the
+same POST as the credential**, making both halves of the pair
+attacker-suppliable, with no single-use clear. The cookie is not
+attacker-chosen, is HttpOnly, and is cleared after one use.
+
+The residual cost is one same-origin GET, serialized after `/auth/me`
+because `LoginScreen` renders only once auth state resolves. Not
+optimised: the GIS script must load from `accounts.google.com` before the
+button can render at all, so a local GET is very unlikely to be on the
+critical path. If it ever measures as such, the fix is a module-level
+promise cache in `GoogleAuthProvider` (no interface change), not moving
+the endpoint.
+
 ### Divergences found in passing (filed, not fixed here)
 
 - `scripts/hub-sliding-sessions-e2e.mjs` still logs in via the removed

--- a/claude-notes/plans/2026-07-27-auth-current-flow-hardening.md
+++ b/claude-notes/plans/2026-07-27-auth-current-flow-hardening.md
@@ -165,7 +165,13 @@ client ID whose authorized origin includes the local-prod host, which
 this session does not have, and no browser-automation tooling was
 available. H2's nonce round-trip is therefore covered only by the
 integration and client tests, not by a browser. This gap should close
-with a TLS-fronted staging login before sign-off.
+with a TLS-fronted staging login before sign-off, tracked as
+`bd-fcv3q5kl` — an **open child of the epic**, so `bd-uv8xynxk` cannot
+be closed until that verification happens.
+
+Full `cargo xtask verify` (all 14 steps, including the WASM rebuild and
+the hub-client build + tests) passes at the branch tip, and the working
+tree is clean afterwards — the WASM rebuild produced no tracked diffs.
 
 ### H2 — implementation notes
 

--- a/claude-notes/plans/2026-07-27-auth-current-flow-hardening.md
+++ b/claude-notes/plans/2026-07-27-auth-current-flow-hardening.md
@@ -1,0 +1,188 @@
+# Auth hardening — current-flow easy wins (pre-pattern-(ii))
+
+**Status:** proposed — intended to land **before** Epic 2's B1 (the pattern-(ii)
+redirect login), as independent hardening of the flow that exists today.
+**Epic:** `bd-uv8xynxk` (open; discovered-from `bd-qxgoti2b`). **Date:** 2026-07-27.
+**Part of:** the auth-reshape path — umbrella index
+`claude-notes/plans/2026-07-06-connection-gated-auth-and-auth-unification.md`.
+
+## Overview
+
+The 2026-07-27 security audit that re-scoped Epic 2 to pattern (ii) (hub-side
+code exchange — see `2026-07-06-hub-client-auth-unification-pkce.md`
+§Decision record) also identified improvements to the **current** GIS →
+`/auth/callback` flow that do **not** require the hub to become an OAuth
+client. This plan collects them as easy wins to ship first. Every item stands
+on its own: if pattern (ii) is later rejected, nothing here is wasted; if it
+proceeds, H2's sealed-cookie machinery is a direct stepping stone to its
+`OidcState` callback and the rest simply persists.
+
+The four items, by payoff-per-effort:
+
+| Item | What | Size | Closes |
+|------|------|------|--------|
+| H1 | Deregister `POST /auth/session` for Google deployments | S | Second token-replay mint sink (zero callers today) |
+| H2 | Server-verified `nonce` in the GIS login | M | The ~1 h ID-token replay-to-mint window — the audit's main in-place gap |
+| H3 | `__Host-` prefix on the session cookie | S | Subdomain cookie-tossing / session fixation |
+| H5 | Distinct login-mint audit event | S | Forensics gap: mints indistinguishable from per-request auth |
+
+## Work items
+
+### Phase 1 — independent quick wins (H1, H3, H5; any order, TDD each)
+
+- [ ] **H1 — register `/auth/session` only for Generic OIDC providers.**
+  Tests first: with a Google-shaped `AuthConfig`, `POST /auth/session` → 404;
+  with a Generic config it still mints; with auth disabled it is absent.
+  Then: change the unconditional `.route("/auth/session", post(auth_session))`
+  (`server.rs:1316`) to mirror the `uses_form_post_callback()` conditional used
+  for `/auth/callback` (`server.rs:1332`) — inverted: register only when auth is
+  enabled **and** the provider is Generic (it is documented as the Generic
+  provider's only mint endpoint; Google deployments log in via the form-post
+  callback and nothing else calls it — grep of `hub-client/src` +
+  `ts-packages/` verified empty, 2026-07-27). Migrate any existing integration
+  tests that exercise `/auth/session` under a Google-shaped config to a Generic
+  config.
+- [ ] **H3 — `__Host-` prefix on the session cookie.**
+  Tests first: secure-mode mint sets `__Host-quarto_hub_token` with
+  `Secure; Path=/; HttpOnly` and no `Domain`; `extract_credential` accepts the
+  prefixed name; the legacy name is ignored as a credential and cleared on
+  login; insecure-auth mode keeps the unprefixed name (the `__Host-` prefix
+  *requires* `Secure`, which requires TLS).
+  Then: replace the `AUTH_COOKIE_NAME` constant (`server.rs:130`; 4 use sites,
+  all in `server.rs` — the client never reads the name, the cookie is HttpOnly)
+  with a mode-aware name helper used by mint, extract, clear, and the
+  `session_reissue_layer`. On login, additionally emit a clear-cookie for the
+  legacy name for one release so stale cookies don't linger. Existing sessions
+  are invalidated once at rollout (users re-log-in); call this out in the PR.
+- [ ] **H5 — distinct login-mint audit event.**
+  Tests first (follow the existing audit-event test pattern if one exists;
+  otherwise assert at the mint-helper level). Emit
+  `target: "quarto_hub::audit", action = "login_mint"` with `sub`, the new
+  session's `sid`, and `endpoint = "callback" | "session"` on successful mint in
+  `auth_callback` and `auth_session` — `mint_session_cookie` (`server.rs:316`)
+  currently returns only the `Set-Cookie` string, so it must be widened to
+  surface the `sid`. Note the `sid` is generated one layer deeper, in
+  `session::mint_session_at`, so it has to be threaded out of there (or
+  generated in `mint_session_cookie` and passed in) — not simply read off the
+  returned cookie. The `session_reissue_layer` stays silent by design
+  (documented at `server.rs:1067` — don't change it).
+  Vocabulary should sit beside the existing `auth_fail` /
+  `revoke_all_sessions` actions.
+
+### Phase 2 — the substantive win (H2)
+
+- [ ] **H2 — server-verified `nonce` in the GIS login.**
+  Today the hub validates signature/`iss`/`aud`/`exp` but cannot bind an ID
+  token to a login attempt: **any captured Google ID token can be replayed to a
+  mint endpoint for its ~1 h validity.** GIS supports a `nonce` at
+  `google.accounts.id.initialize`; a hub pre-flight makes it verifiable
+  server-side with no OAuth-client role.
+  *Design:*
+  - `GET /auth/nonce` (new, unauthenticated): generate a 32-byte random nonce;
+    return `{ "nonce": … }`; set a **sealed** (HMAC-signed) cookie carrying
+    `{nonce, exp}` with `Max-Age` ≈ 600 s. Sign with the existing session keys
+    but with **domain separation** (a distinct `typ`/purpose so a sealed
+    login blob can never verify as a session token, and vice versa).
+  - Cookie attributes: `__Secure-` prefixed name, `HttpOnly; Secure;
+    SameSite=None; Path=/auth`. `SameSite=None` is load-bearing: Google's
+    credential delivery is a **cross-site form POST**, and `Lax` cookies are
+    not attached to those (the `g_csrf` cookie only survives via Chrome's
+    2-minute Lax-by-default grace). `__Secure-` rather than `__Host-` because
+    we want `Path=/auth`; the HMAC covers the cookie-tossing risk `__Host-`
+    would otherwise address.
+  - SPA: the nonce must reach `<GoogleLogin nonce={…}>`, but `LoginScreen`
+    does **not** render `GoogleLogin` directly — it renders
+    `<provider.SignInButton>` (`LoginScreen.tsx:38`) and the Google provider
+    renders `GoogleLogin` behind the `SignInButtonProps` boundary
+    (`GoogleAuthProvider.tsx:16-27`), an abstraction introduced deliberately
+    (see `2026-05-20-auth-provider-interface.md`). Do **not** widen the generic
+    `SignInButtonProps` with a Google-specific `nonce`; instead **fetch
+    `/auth/nonce` inside `GoogleAuthProvider`** (the nonce is a GIS concern and
+    belongs with the GIS provider) and pass it to `<GoogleLogin>` there. Verify
+    the `@react-oauth/google` wrapper forwards `nonce` to `initialize` in
+    `ux_mode="redirect"` — current versions accept the prop; confirm at
+    implementation.
+  - Callback: add an optional `nonce` field to `OidcClaims`; verify the sealed
+    cookie (signature, expiry) and require `claims.nonce` to match; any
+    missing/mismatch/expired/tampered case → `/?auth_error`; clear the sealed
+    cookie on both success and failure.
+  - **Enforcement is unconditional in secure mode.** Under
+    `--allow-insecure-auth` (no TLS), `SameSite=None; Secure` cookies cannot
+    function over plain http — the callback logs a warning and skips the check
+    there, consistent with that flag's existing "never in production" contract.
+  - **Scope: Google/callback flow only.** H2 binds the nonce for the GIS →
+    `/auth/callback` path (the audit's target — the ~1 h GIS ID-token replay
+    window). It deliberately does **not** touch `/auth/session` (the Generic
+    provider's JSON mint), which stays replay-able within the submitted token's
+    validity. That is an accepted scope boundary — the audit targeted the GIS
+    flow — but note the asymmetry so it is not mistaken for full coverage.
+    (H1 still narrows `/auth/session` to Generic deployments only.)
+  - *Rollout note:* a user holding a stale SPA bundle (no nonce) fails login to
+    `/?auth_error` and recovers on reload. Accept this — login is a full-page
+    flow and hub + client deploy together. No compatibility flag unless it
+    bites in practice.
+  *Tests first:* mock-JWKS helper gains a nonce-claim knob; happy-path round
+  trip; missing cookie; nonce mismatch; expired blob; tampered signature;
+  sealed blob presented as a session cookie is rejected (domain separation);
+  insecure-mode skip logs the warning; cookie cleared after use. Client test:
+  `LoginScreen` passes the fetched nonce. **E2E:** real browser login via
+  `local-prod:nginx`… noting that insecure mode skips enforcement, the full
+  enforcement path is exercised by the integration tests + a TLS-fronted
+  staging login before sign-off.
+  *Pattern-(ii) synergy:* the sealed short-lived signed-state helper (mint /
+  verify / expiry / domain separation) is exactly what the `OidcState`
+  callback needs — build it as a reusable unit in `session.rs` or a sibling
+  module, not inline in the handler.
+
+## Sequencing & scope
+
+- Proposed order: Phase 1 as one or more small PRs (items are independent),
+  then H2. All four before Epic 2's B1 kicks off.
+- Out of scope, deliberately: anything giving the hub an OAuth-client role
+  (that is B1, `bd-qxgoti2b`, with its own decision record);
+  `SameSite=Strict` on the session cookie (negligible gain over Lax + the
+  `X-Requested-With` gate); rate-limiting mint endpoints (signature forgery is
+  not brute-forceable).
+- What this plan **cannot** deliver (only pattern (ii) can): removing the GIS
+  third-party script, and a single-use PKCE-bound login exchange — though H2
+  captures most of the latter's replay protection.
+
+## Verification
+
+- Per item: TDD (test fails → fix → passes), then
+  `cargo nextest run --workspace`; `cargo xtask verify --skip-hub-build` for
+  the Rust-only items (H1, H3, H5).
+- H2 touches hub-client: `cd hub-client && npm run build:all` +
+  `npm run test:ci`.
+- End-to-end (per CLAUDE.md policy — tests alone are insufficient): a real
+  browser GIS login through `npm run local-prod:nginx` after H2 (login
+  succeeds; then a doctored replay attempt with a mismatched nonce fails to
+  `/?auth_error`). Record invocations + observed output in this plan or the
+  closing strand comments.
+
+## Braid
+
+- **Epic `bd-uv8xynxk`** (open) — this plan. Child strands (H1, H2, H3, H5) filed at
+  kickoff, one per item; H2 depends on nothing but is Phase 2 by size, not by
+  blocking.
+- **Related:** `bd-qxgoti2b` (Epic 2 — this epic was discovered from its
+  2026-07-27 security-audit re-scope; H2's sealed-cookie helper is reusable by
+  its B1), `bd-ey6jg70f` (closed — sliding sessions; H3/H5 touch its mint and
+  audit surfaces).
+
+## References
+
+- `claude-notes/plans/2026-07-06-hub-client-auth-unification-pkce.md` — the
+  pattern-(ii) re-scope + §Decision record; §References carries the audit
+  sources (Google's secret-required token endpoint; Browser-Based Apps BCP).
+- `claude-notes/plans/2026-07-06-hub-server-minted-sliding-sessions.md` —
+  session mint/verify + revocation this plan hardens around.
+- Key files: `crates/quarto-hub/src/server.rs` (`build_csp` 108,
+  `AUTH_COOKIE_NAME` 130, `mint_session_cookie` 316, `auth_callback` 728,
+  `auth_session` 999, routes ~1316), `crates/quarto-hub/src/auth.rs`
+  (`OidcClaims` ~190, `CallbackCsrfMode` ~656), `crates/quarto-hub/src/session.rs`
+  (mint/verify — home for the sealed-state helper),
+  `config/local-nginx.conf` (:8080 `server {}` :28, SPA `location /` :86),
+  `scripts/local-prod.sh` (+ its
+  Node proxy), `hub-client/src/components/auth/LoginScreen.tsx`,
+  `hub-client/src/auth/GoogleAuthProvider.tsx`. *(Line numbers approximate.)*

--- a/claude-notes/plans/2026-07-27-auth-current-flow-hardening.md
+++ b/claude-notes/plans/2026-07-27-auth-current-flow-hardening.md
@@ -71,7 +71,7 @@ The four items, by payoff-per-effort:
 
 ### Phase 2 — the substantive win (H2)
 
-- [ ] **H2 — server-verified `nonce` in the GIS login.**
+- [x] **H2 — server-verified `nonce` in the GIS login.**
   Today the hub validates signature/`iss`/`aud`/`exp` but cannot bind an ID
   token to a login attempt: **any captured Google ID token can be replayed to a
   mint endpoint for its ~1 h validity.** GIS supports a `nonce` at
@@ -146,6 +146,80 @@ The four items, by payoff-per-effort:
 - What this plan **cannot** deliver (only pattern (ii) can): removing the GIS
   third-party script, and a single-use PKCE-bound login exchange — though H2
   captures most of the latter's replay protection.
+
+## Verification record (as implemented)
+
+Branch `feature/auth-hardening-current-flow`. Strands filed at kickoff:
+H1 `bd-zbep24xd`, H2 `bd-uqjiac5a`, H3 `bd-gt2hhrcg`, H5 `bd-k2xvvh9f`
+(all children of `bd-uv8xynxk`).
+
+### E2E actually performed (and what could not be)
+
+`npm run local-prod` (Node-proxy mode) against a freshly built
+`target/debug/hub`: H1 confirmed **through the real binary** — with auth
+disabled, `POST /auth/session` → 404 and `POST /auth/callback` → 404
+while `GET /health` → 200.
+
+**Not done, explicitly:** no real GIS browser login. It needs a Google
+client ID whose authorized origin includes the local-prod host, which
+this session does not have, and no browser-automation tooling was
+available. H2's nonce round-trip is therefore covered only by the
+integration and client tests, not by a browser. This gap should close
+with a TLS-fronted staging login before sign-off.
+
+### H2 — implementation notes
+
+The sealed-state helper landed as its **own module**,
+`crates/quarto-hub/src/login_state.rs`, rather than inside `session.rs`
+(already 1100+ lines) — the plan allowed either, and a sibling module
+makes the pattern-(ii) reuse obvious. It needed two crate-private
+accessors on `SessionKeys` (`current_secret`, `secret_for_kid`), since
+the raw secrets are otherwise private to `session.rs`.
+
+**Domain separation is doubled, not single.** The plan called for a
+distinct `typ`; the implementation also uses a distinct `iss`
+(`quarto-hub-login` vs `quarto-hub`), because both verifiers pin their
+issuer via `set_issuer`. Either barrier alone suffices; both are asserted,
+**in both directions**, at the unit level (a session token must not open
+as login state, and a login blob must not verify as a session) and again
+across the HTTP surface (`a_sealed_login_blob_is_not_a_session_cookie`,
+`a_session_token_is_not_a_login_state_cookie`).
+
+Two deviations from the plan's letter, both deliberate:
+
+- **`GET /auth/nonce` is registered whenever auth is enabled**, not only
+  for form-post providers. The SPA then has one unconditional way to get
+  a nonce and never branches on the deployment's provider. *Enforcement*
+  stays exactly as scoped — only `/auth/callback` checks it.
+- **The `login_mint` audit event lives in `mint_session_cookie`**, not
+  duplicated in the two handlers as the plan described. Same events, but
+  a future third mint call site cannot forget to log.
+
+`@react-oauth/google@0.13.4` was verified to forward `nonce` to
+`google.accounts.id.initialize` — it is part of `IdConfiguration`, which
+`GoogleLoginProps` spreads through. **But its effect's dependency array
+does not include `nonce`**, so a nonce arriving after the first render
+would never reach GIS and every login would fail the server check.
+`SignInButton` therefore renders nothing until the fetch resolves, and
+renders an error rather than a nonce-less button if it fails. A test pins
+that ordering explicitly (`does not render GIS before the nonce arrives`)
+because it would otherwise look like a removable loading state.
+
+Note: `GoogleOAuthProvider`'s own `nonce` prop is unrelated — it sets the
+CSP nonce on the injected `<script>` tag. Do not pass the login nonce
+there.
+
+### Divergences found in passing (filed, not fixed here)
+
+- `scripts/hub-sliding-sessions-e2e.mjs` still logs in via the removed
+  `POST /auth/refresh` route, so the session-auth E2E script the
+  operator guide points at is already broken (`bd-gppva1ee`).
+- The local-prod Node proxy only forwards `/auth` and `/ws`, so
+  `/health` and `/api` are served as the SPA fallback instead of being
+  proxied to the hub — nginx forwards `^/(auth|api|health)`. Pre-existing
+  parity gap (`bd-r28nr1fc`).
+- `scripts/local-prod-port.test.mjs` is not wired into any test runner
+  (`bd-h2jdelwm`).
 
 ## Verification
 

--- a/crates/quarto-hub/src/auth.rs
+++ b/crates/quarto-hub/src/auth.rs
@@ -215,6 +215,17 @@ pub struct OidcClaims {
     /// refresh from the real expiry (bd-3o8zmz46).
     #[serde(default)]
     pub exp: i64,
+
+    /// OIDC `nonce` (Core §3.1.3.7 step 11): the value the RP supplied
+    /// at authorization time, echoed back by the IdP. It is what binds a
+    /// token to *one* login attempt — signature/`iss`/`aud`/`exp` cannot.
+    ///
+    /// `Option` because not every flow supplies one: the Bearer/MCP path
+    /// and the Generic `/auth/session` mint do not. The Google callback
+    /// **requires** it in secure mode (H2) — see
+    /// [`crate::login_state`].
+    #[serde(default)]
+    pub nonce: Option<String>,
 }
 
 /// Accept either a single-string `aud` or a `["a", "b"]` array.
@@ -762,6 +773,7 @@ mod tests {
             azp: None,
             iat: None,
             exp: 0,
+            nonce: None,
         }
     }
 
@@ -1002,6 +1014,7 @@ mod tests {
             azp: None,
             iat: None,
             exp: 0,
+            nonce: None,
         };
         let allowed = allowed_list();
         assert!(validate_azp_and_iat(&claims, allowed.iter(), 1_000_000, 60).is_ok());
@@ -1019,6 +1032,7 @@ mod tests {
             azp: None,
             iat: None,
             exp: 0,
+            nonce: None,
         };
         let allowed = allowed_list();
         assert_eq!(
@@ -1039,6 +1053,7 @@ mod tests {
             azp: Some("attacker-client".into()),
             iat: None,
             exp: 0,
+            nonce: None,
         };
         let allowed = allowed_list();
         assert_eq!(
@@ -1059,6 +1074,7 @@ mod tests {
             azp: Some("spa-client".into()),
             iat: None,
             exp: 0,
+            nonce: None,
         };
         let allowed = allowed_list();
         assert!(validate_azp_and_iat(&claims, allowed.iter(), 1_000_000, 60).is_ok());
@@ -1076,6 +1092,7 @@ mod tests {
             azp: None,
             iat: Some(1_000_000 + 3600),
             exp: 0,
+            nonce: None,
         };
         let allowed = allowed_list();
         assert_eq!(
@@ -1096,6 +1113,7 @@ mod tests {
             azp: None,
             iat: Some(1_000_000 + 30),
             exp: 0,
+            nonce: None,
         };
         let allowed = allowed_list();
         assert!(validate_azp_and_iat(&claims, allowed.iter(), 1_000_000, 60).is_ok());

--- a/crates/quarto-hub/src/lib.rs
+++ b/crates/quarto-hub/src/lib.rs
@@ -13,6 +13,7 @@ pub mod context;
 pub mod discovery;
 pub mod error;
 pub mod index;
+pub mod login_state;
 pub mod peer;
 pub mod resource;
 pub mod revocation;

--- a/crates/quarto-hub/src/login_state.rs
+++ b/crates/quarto-hub/src/login_state.rs
@@ -1,0 +1,313 @@
+//! Sealed, short-lived login state (H2, `bd-uqjiac5a`).
+//!
+//! A **sealed login-state blob** is an HMAC-signed, expiring token the
+//! hub hands to a browser in a cookie before sending it to the IdP, and
+//! verifies when the IdP's response comes back. It lets the hub bind an
+//! ID token to *the login attempt it started* without holding server-side
+//! state.
+//!
+//! Today it carries a `nonce` for the GIS flow: without it, any captured
+//! Google ID token can be replayed to a mint endpoint for its full (~1 h)
+//! validity, because signature/`iss`/`aud`/`exp` all still check out.
+//!
+//! # Domain separation
+//!
+//! The blob is signed with the **same keys** as session tokens
+//! ([`crate::session::SessionKeys`]), so it must be impossible to
+//! confuse the two — a sealed login blob accepted as a session cookie
+//! would be an authentication bypass. Two independent barriers:
+//!
+//! 1. **Distinct `iss`.** [`LOGIN_STATE_ISSUER`] vs
+//!    [`crate::session::SESSION_ISSUER`], and both verifiers pin theirs.
+//! 2. **Required `typ`.** [`LOGIN_STATE_TYP`] must be present and exact;
+//!    session tokens have no `typ` claim at all.
+//!
+//! Beyond those, the claim sets are disjoint: `SessionClaims` requires
+//! `sub`/`email`/`sid`/`auth_time`, which a login blob does not carry, so
+//! deserialization alone already fails. Tests assert both directions.
+//!
+//! # Reuse
+//!
+//! Pattern (ii)'s `OidcState` callback (Epic 2's B1, `bd-qxgoti2b`) needs
+//! exactly this shape — mint / verify / expiry / domain separation — for
+//! its PKCE `state`. Add a variant here rather than re-deriving it
+//! inline; see `claude-notes/plans/2026-07-27-auth-current-flow-hardening.md`.
+
+use serde::{Deserialize, Serialize};
+
+use crate::session::SessionKeys;
+
+/// `iss` on every sealed login-state blob.
+///
+/// Deliberately **not** [`crate::session::SESSION_ISSUER`]: the session
+/// verifier pins that value, so a login blob can never pass as a session
+/// token even if the claim sets ever converged.
+pub const LOGIN_STATE_ISSUER: &str = "quarto-hub-login";
+
+/// Required `typ` on every sealed login-state blob. Versioned so a
+/// future payload change can be rejected explicitly rather than
+/// silently misread.
+pub const LOGIN_STATE_TYP: &str = "login-nonce-v1";
+
+/// How long a sealed login-state blob stays valid.
+///
+/// Bounds how long a captured blob is useful, and is the practical
+/// ceiling on how long a user may sit on the IdP's consent screen before
+/// their login must be restarted.
+pub const LOGIN_STATE_TTL_SECS: i64 = 600;
+
+/// Clock-skew leeway on the blob's `exp`, matching
+/// [`crate::session::SESSION_LEEWAY_SECS`].
+pub const LOGIN_STATE_LEEWAY_SECS: i64 = 60;
+
+/// Claims payload of a sealed login-state blob.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LoginStateClaims {
+    /// Always [`LOGIN_STATE_ISSUER`].
+    pub iss: String,
+    /// Always [`LOGIN_STATE_TYP`].
+    pub typ: String,
+    /// The nonce the IdP must echo back in the ID token.
+    pub nonce: String,
+    pub iat: i64,
+    pub exp: i64,
+}
+
+/// Why a sealed login-state blob failed to open. Variants map 1:1 to the
+/// distinguishable audit classes; none carries blob contents.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LoginStateError {
+    /// JOSE header `kid` missing or not in the key map — signed under a
+    /// different secret, or not a hub blob at all.
+    UnknownKid,
+    /// Signature, structure, `iss`, or `typ` invalid. Also the class a
+    /// **session token** presented as a login blob lands in.
+    Tampered,
+    /// `exp` in the past, beyond leeway.
+    Expired,
+}
+
+impl LoginStateError {
+    /// Stable audit-log discriminator (`detail = "login_state_<class>"`).
+    pub fn audit_class(&self) -> &'static str {
+        match self {
+            LoginStateError::UnknownKid => "kid_mismatch",
+            LoginStateError::Tampered => "tampered",
+            LoginStateError::Expired => "expired",
+        }
+    }
+}
+
+/// Generate a fresh login nonce: 32 random bytes, hex-encoded.
+///
+/// 256 bits because this value is what binds an ID token to one login
+/// attempt — it must not be guessable by a party who can observe other
+/// logins.
+pub fn generate_login_nonce() -> String {
+    use rand::RngCore;
+    let mut bytes = [0u8; 32];
+    rand::rng().fill_bytes(&mut bytes);
+    hex::encode(bytes)
+}
+
+/// Seal a nonce into a signed, expiring blob valid from `now`.
+pub fn seal_login_state(
+    keys: &SessionKeys,
+    nonce: &str,
+    now: i64,
+    ttl_secs: i64,
+) -> Result<String, jsonwebtoken::errors::Error> {
+    let claims = LoginStateClaims {
+        iss: LOGIN_STATE_ISSUER.to_string(),
+        typ: LOGIN_STATE_TYP.to_string(),
+        nonce: nonce.to_string(),
+        iat: now,
+        exp: now + ttl_secs,
+    };
+    let mut header = jsonwebtoken::Header::new(jsonwebtoken::Algorithm::HS256);
+    header.kid = Some(keys.current().kid().to_string());
+    jsonwebtoken::encode(
+        &header,
+        &claims,
+        &jsonwebtoken::EncodingKey::from_secret(keys.current_secret()),
+    )
+}
+
+/// Open a sealed login-state blob at time `now`.
+///
+/// Order: resolve `kid` (fail closed) → HS256 signature + structure +
+/// `iss` under the resolved key → `typ` → `exp`. Verification accepts the
+/// previous key during a rotation overlap, so a login started just before
+/// a graceful rotation still completes.
+pub fn open_login_state(
+    keys: &SessionKeys,
+    blob: &str,
+    now: i64,
+) -> Result<LoginStateClaims, LoginStateError> {
+    let header = jsonwebtoken::decode_header(blob).map_err(|_| LoginStateError::Tampered)?;
+    let kid = header.kid.as_deref().ok_or(LoginStateError::UnknownKid)?;
+    let secret = keys
+        .secret_for_kid(kid)
+        .ok_or(LoginStateError::UnknownKid)?;
+
+    // `exp` is checked below against the caller-supplied clock, so the
+    // library's implicit system-clock check is disabled. The algorithm
+    // set is pinned to HS256 — the header can never select another.
+    let mut validation = jsonwebtoken::Validation::new(jsonwebtoken::Algorithm::HS256);
+    validation.validate_exp = false;
+    validation.validate_aud = false;
+    validation.set_issuer(&[LOGIN_STATE_ISSUER]);
+    validation.set_required_spec_claims(&["iss"]);
+
+    let claims = jsonwebtoken::decode::<LoginStateClaims>(
+        blob,
+        &jsonwebtoken::DecodingKey::from_secret(secret),
+        &validation,
+    )
+    .map_err(|_| LoginStateError::Tampered)?
+    .claims;
+
+    // Second domain barrier (see module docs). A session token cannot
+    // reach here — it has no `typ` — but an explicit check keeps the
+    // guarantee local rather than emergent.
+    if claims.typ != LOGIN_STATE_TYP {
+        return Err(LoginStateError::Tampered);
+    }
+
+    // A blob stamped from the future was never sealed by this hub.
+    if claims.iat > now + LOGIN_STATE_LEEWAY_SECS {
+        return Err(LoginStateError::Tampered);
+    }
+
+    if now > claims.exp + LOGIN_STATE_LEEWAY_SECS {
+        return Err(LoginStateError::Expired);
+    }
+
+    Ok(claims)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session::{SESSION_ISSUER, SessionIdentity, SessionLifetimes, mint_session};
+
+    const SECRET_A: [u8; 32] = [0xA1; 32];
+    const SECRET_B: [u8; 32] = [0xB2; 32];
+
+    fn keys() -> SessionKeys {
+        SessionKeys::new(SECRET_A)
+    }
+
+    fn now() -> i64 {
+        1_800_000_000
+    }
+
+    #[test]
+    fn seal_open_roundtrip() {
+        let t = now();
+        let blob = seal_login_state(&keys(), "abc123", t, LOGIN_STATE_TTL_SECS).unwrap();
+        let opened = open_login_state(&keys(), &blob, t).unwrap();
+        assert_eq!(opened.nonce, "abc123");
+        assert_eq!(opened.iss, LOGIN_STATE_ISSUER);
+        assert_eq!(opened.typ, LOGIN_STATE_TYP);
+        assert_eq!(opened.iat, t);
+        assert_eq!(opened.exp, t + LOGIN_STATE_TTL_SECS);
+    }
+
+    #[test]
+    fn open_rejects_expired_blob() {
+        let t = now();
+        let blob = seal_login_state(&keys(), "abc123", t, LOGIN_STATE_TTL_SECS).unwrap();
+        // Just inside the leeway still opens; past it does not.
+        let edge = t + LOGIN_STATE_TTL_SECS + LOGIN_STATE_LEEWAY_SECS;
+        assert!(open_login_state(&keys(), &blob, edge).is_ok());
+        assert_eq!(
+            open_login_state(&keys(), &blob, edge + 1),
+            Err(LoginStateError::Expired)
+        );
+    }
+
+    #[test]
+    fn open_rejects_tampered_payload() {
+        let t = now();
+        let blob = seal_login_state(&keys(), "abc123", t, LOGIN_STATE_TTL_SECS).unwrap();
+        let mut parts: Vec<String> = blob.split('.').map(String::from).collect();
+        let mut payload = parts[1].clone().into_bytes();
+        let i = payload.len() / 2;
+        payload[i] = if payload[i] == b'A' { b'B' } else { b'A' };
+        parts[1] = String::from_utf8(payload).unwrap();
+        assert_eq!(
+            open_login_state(&keys(), &parts.join("."), t),
+            Err(LoginStateError::Tampered)
+        );
+    }
+
+    #[test]
+    fn open_rejects_blob_sealed_under_another_secret() {
+        let t = now();
+        let blob = seal_login_state(&SessionKeys::new(SECRET_B), "abc", t, 600).unwrap();
+        // Different secret → different derived kid → fails closed at kid
+        // resolution rather than as a signature error.
+        assert_eq!(
+            open_login_state(&keys(), &blob, t),
+            Err(LoginStateError::UnknownKid)
+        );
+    }
+
+    #[test]
+    fn open_accepts_blob_sealed_under_the_previous_key() {
+        // Graceful rotation: a login started just before the rotation
+        // must still be completable.
+        let t = now();
+        let blob = seal_login_state(&SessionKeys::new(SECRET_B), "abc", t, 600).unwrap();
+        let rotated = SessionKeys::with_previous(SECRET_A, SECRET_B);
+        assert_eq!(open_login_state(&rotated, &blob, t).unwrap().nonce, "abc");
+    }
+
+    // ── domain separation (both directions) ───────────────────────
+
+    #[test]
+    fn a_session_token_is_not_a_valid_login_blob() {
+        let t = now();
+        let identity = SessionIdentity {
+            sub: "sub-1".into(),
+            email: "user@posit.co".into(),
+            email_verified: true,
+            name: None,
+            picture: None,
+        };
+        let session = mint_session(&keys(), SessionLifetimes::default(), &identity, t).unwrap();
+        assert_eq!(
+            open_login_state(&keys(), &session, t),
+            Err(LoginStateError::Tampered),
+            "a session token must never open as login state"
+        );
+    }
+
+    #[test]
+    fn a_login_blob_is_not_a_valid_session_token() {
+        // The mirror image, asserted here so both halves of the
+        // separation live in one place. `verify_session` pins
+        // `SESSION_ISSUER` and requires claims the blob lacks.
+        let t = now();
+        let blob = seal_login_state(&keys(), "abc", t, 600).unwrap();
+        let err = crate::session::verify_session(&keys(), SessionLifetimes::default(), &blob, t)
+            .expect_err("a login blob must never verify as a session");
+        assert_eq!(err, crate::session::SessionVerifyError::Tampered);
+    }
+
+    #[test]
+    fn issuers_are_distinct() {
+        // The invariant the two tests above rest on.
+        assert_ne!(LOGIN_STATE_ISSUER, SESSION_ISSUER);
+    }
+
+    #[test]
+    fn generated_nonces_are_256_bit_and_unique() {
+        let a = generate_login_nonce();
+        let b = generate_login_nonce();
+        assert_eq!(a.len(), 64, "32 bytes hex-encoded");
+        assert!(a.chars().all(|c| c.is_ascii_hexdigit()));
+        assert_ne!(a, b);
+    }
+}

--- a/crates/quarto-hub/src/server.rs
+++ b/crates/quarto-hub/src/server.rs
@@ -153,6 +153,84 @@ fn auth_cookie_name(secure: bool) -> &'static str {
     }
 }
 
+/// Cookie carrying the sealed login-state blob in secure mode (H2).
+///
+/// `__Secure-` rather than `__Host-`: the cookie is scoped to
+/// `Path=/auth`, which `__Host-` forbids. The cookie-tossing risk that
+/// `__Host-` would cover is already covered here by the HMAC — a tossed
+/// blob cannot be forged, and a *replayed* one is bounded by its `exp`.
+const LOGIN_STATE_COOKIE_SECURE: &str = "__Secure-quarto_hub_login";
+
+/// Login-state cookie name under `--allow-insecure-auth`, where neither
+/// `__Secure-` nor `SameSite=None` can work (both require TLS).
+const LOGIN_STATE_COOKIE_LEGACY: &str = "quarto_hub_login";
+
+/// The login-state cookie name for the current TLS mode.
+fn login_state_cookie_name(secure: bool) -> &'static str {
+    if secure {
+        LOGIN_STATE_COOKIE_SECURE
+    } else {
+        LOGIN_STATE_COOKIE_LEGACY
+    }
+}
+
+/// Build the `Set-Cookie` carrying a sealed login-state blob.
+///
+/// `SameSite=None` in secure mode is **load-bearing, not laxity**:
+/// Google delivers the credential by cross-site form POST to
+/// `/auth/callback`, and a `Lax` cookie is not attached to that. (The
+/// `g_csrf` cookie only survives it via Chrome's 2-minute
+/// Lax-by-default grace period — not something to depend on.) Since
+/// `SameSite=None` requires `Secure`, insecure mode falls back to `Lax`;
+/// the callback skips enforcement there anyway.
+///
+/// `Path=/auth` scopes it to the two routes that use it: this cookie is
+/// attached to a cross-site POST, so it should not ride along on
+/// anything else.
+fn build_login_state_cookie(blob: &str, secure: bool) -> String {
+    let mut builder = cookie::Cookie::build((login_state_cookie_name(secure), blob))
+        .http_only(true)
+        .path("/auth")
+        .max_age(time::Duration::seconds(
+            crate::login_state::LOGIN_STATE_TTL_SECS,
+        ));
+    builder = if secure {
+        builder.secure(true).same_site(SameSite::None)
+    } else {
+        builder.same_site(SameSite::Lax)
+    };
+    builder.build().to_string()
+}
+
+/// Build a `Set-Cookie` that clears the login-state cookie.
+///
+/// The blob is single-use: the callback clears it on **every** exit path,
+/// so one pre-flight can complete at most one login.
+fn build_clear_login_state_cookie(secure: bool) -> String {
+    let mut builder = cookie::Cookie::build((login_state_cookie_name(secure), ""))
+        .http_only(true)
+        .path("/auth")
+        .max_age(time::Duration::ZERO);
+    builder = if secure {
+        builder.secure(true).same_site(SameSite::None)
+    } else {
+        builder.same_site(SameSite::Lax)
+    };
+    builder.build().to_string()
+}
+
+/// Read the sealed login-state blob from the `Cookie` header.
+fn login_state_cookie(headers: &HeaderMap, secure: bool) -> Option<String> {
+    let name = login_state_cookie_name(secure);
+    let cookies = headers.get("cookie")?.to_str().ok()?;
+    cookies
+        .split(';')
+        .filter_map(|s| cookie::Cookie::parse(s.trim()).ok())
+        .find(|c| c.name() == name)
+        .map(|c| c.value().to_owned())
+        .filter(|v| !v.is_empty())
+}
+
 /// JSON error body for auth failures, so clients can distinguish
 /// 401 auth errors from other HTTP errors programmatically.
 fn unauthorized() -> (StatusCode, Json<serde_json::Value>) {
@@ -840,6 +918,103 @@ fn validate_callback_csrf(
     }
 }
 
+/// Response for `GET /auth/nonce`.
+#[derive(Serialize)]
+struct AuthNonceResponse {
+    nonce: String,
+}
+
+/// Handle `GET /auth/nonce` — the login pre-flight (H2).
+///
+/// Mints a random nonce, returns it to the SPA (which passes it to the
+/// IdP), and seals a copy into an HttpOnly cookie so the callback can
+/// verify the IdP echoed *this* login attempt's value back. No
+/// server-side state: the cookie is the state, and the HMAC is what
+/// makes trusting it safe.
+///
+/// Unauthenticated by necessity — it runs before there is a session. It
+/// is a GET, so no CSRF gate applies; it reveals nothing and its only
+/// side effect is a cookie on the caller's own jar.
+async fn auth_nonce(State(ctx): State<SharedContext>) -> impl IntoResponse {
+    let secure = !ctx.allow_insecure_auth();
+    let nonce = crate::login_state::generate_login_nonce();
+    let blob = match crate::login_state::seal_login_state(
+        ctx.session_keys(),
+        &nonce,
+        crate::session::unix_now(),
+        crate::login_state::LOGIN_STATE_TTL_SECS,
+    ) {
+        Ok(blob) => blob,
+        Err(err) => {
+            tracing::error!(error = %err, "failed to seal login state");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": "login_state_seal_failed"})),
+            )
+                .into_response();
+        }
+    };
+
+    let mut response = Json(AuthNonceResponse { nonce }).into_response();
+    attach_cookies(&mut response, &[build_login_state_cookie(&blob, secure)]);
+    response
+}
+
+/// Outcome of the callback's nonce check.
+enum NonceCheck {
+    Ok,
+    /// Enforcement was skipped — insecure mode only.
+    Skipped,
+    Failed(&'static str),
+}
+
+/// Verify that the ID token's `nonce` matches the sealed login-state
+/// cookie (H2).
+///
+/// This is what makes a captured ID token useless: without it, the hub
+/// validates signature, `iss`, `aud`, and `exp` — all of which still hold
+/// for a stolen token — and has no way to ask "did *this* browser start
+/// *this* login?".
+///
+/// Returns [`NonceCheck::Skipped`] under `--allow-insecure-auth`: the
+/// flow needs a `SameSite=None; Secure` cookie, which cannot function
+/// over plain HTTP. That is consistent with the flag's existing "never in
+/// production" contract, and the skip is logged at WARN.
+fn check_login_nonce(
+    ctx: &HubContext,
+    claims: &auth::OidcClaims,
+    headers: &HeaderMap,
+) -> NonceCheck {
+    if ctx.allow_insecure_auth() {
+        tracing::warn!(
+            "nonce verification skipped: --allow-insecure-auth cannot carry the \
+             SameSite=None; Secure login-state cookie. Never use this in production."
+        );
+        return NonceCheck::Skipped;
+    }
+
+    let Some(blob) = login_state_cookie(headers, true) else {
+        return NonceCheck::Failed("login_state_missing");
+    };
+    let sealed = match crate::login_state::open_login_state(
+        ctx.session_keys(),
+        &blob,
+        crate::session::unix_now(),
+    ) {
+        Ok(sealed) => sealed,
+        Err(err) => return NonceCheck::Failed(err.audit_class()),
+    };
+    let Some(presented) = claims.nonce.as_deref() else {
+        return NonceCheck::Failed("token_nonce_missing");
+    };
+    // Both values are hub-generated hex of fixed length, so a plain
+    // comparison leaks nothing useful about timing.
+    if presented != sealed.nonce {
+        return NonceCheck::Failed("nonce_mismatch");
+    }
+    NonceCheck::Ok
+}
+
 /// Handle `POST /auth/callback` — credential delivery via form POST.
 ///
 /// Registered for providers where [`AuthConfig::uses_form_post_callback()`]
@@ -854,6 +1029,17 @@ async fn auth_callback(
     headers: HeaderMap,
     Form(form): Form<AuthCallbackForm>,
 ) -> impl IntoResponse {
+    let secure = !ctx.allow_insecure_auth();
+    // The sealed login-state blob is single-use: every exit path from
+    // here clears it, so one pre-flight can complete at most one login.
+    // Building the failure response through a closure is what keeps that
+    // true as paths are added.
+    let auth_error = || {
+        let mut response = Redirect::to("/?auth_error").into_response();
+        attach_cookies(&mut response, &[build_clear_login_state_cookie(secure)]);
+        response
+    };
+
     let mode = ctx
         .auth_config()
         .map_or(auth::CallbackCsrfMode::GoogleDoubleSubmit, |c| {
@@ -861,15 +1047,31 @@ async fn auth_callback(
         });
 
     if !validate_callback_csrf(&mode, &form, &headers) {
-        return Redirect::to("/?auth_error").into_response();
+        return auth_error();
     }
 
     // Validate the Google ID token once, then mint the hub session
     // cookie (§1) — the Google token itself is never cookie'd.
     let claims = match ctx.authenticate_claims(Some(&form.credential)).await {
         Ok(claims) => claims,
-        Err(_status) => return Redirect::to("/?auth_error").into_response(),
+        Err(_status) => return auth_error(),
     };
+
+    // Bind the token to this login attempt (H2). Runs after signature
+    // validation — there is no point comparing claims from a token we
+    // have not authenticated — but before the ban check and the mint.
+    if let NonceCheck::Failed(detail) = check_login_nonce(&ctx, &claims, &headers) {
+        tracing::event!(
+            target: "quarto_hub::audit",
+            tracing::Level::WARN,
+            action = "auth_fail",
+            outcome = "deny",
+            credential_kind = "cookie",
+            sub = %claims.sub,
+            detail = %format!("login_state_{detail}"),
+        );
+        return auth_error();
+    }
 
     // Bans gate mint too (§3) — otherwise a banned user just
     // re-logs-in via Google.
@@ -883,18 +1085,19 @@ async fn auth_callback(
             sub = %claims.sub,
             detail = "user_banned",
         );
-        return Redirect::to("/?auth_error").into_response();
+        return auth_error();
     }
 
     let cookies = match mint_session_cookie(&ctx, &claims, LoginEndpoint::Callback).await {
         Ok(cookies) => cookies,
         Err(err) => {
             tracing::error!(error = %err, "failed to mint session token");
-            return Redirect::to("/?auth_error").into_response();
+            return auth_error();
         }
     };
     let mut response = Redirect::to("/").into_response();
     attach_cookies(&mut response, &cookies);
+    attach_cookies(&mut response, &[build_clear_login_state_cookie(secure)]);
     response
 }
 
@@ -1460,6 +1663,15 @@ pub async fn build_router_with_state(ctx: SharedContext) -> Result<Router<Shared
         .is_some_and(|c| c.uses_form_post_callback())
     {
         router = router.route("/auth/callback", post(auth_callback));
+    }
+
+    // Login pre-flight (H2). Registered whenever auth is enabled — not
+    // just for form-post providers — so the SPA has one unconditional
+    // way to obtain a nonce and never has to branch on the deployment's
+    // provider. *Enforcement* is narrower: only `/auth/callback` checks
+    // it (see `check_login_nonce`).
+    if ctx.auth_config().is_some() {
+        router = router.route("/auth/nonce", get(auth_nonce));
     }
 
     // `/auth/session` is the JSON mint endpoint, and the *only* login

--- a/crates/quarto-hub/src/server.rs
+++ b/crates/quarto-hub/src/server.rs
@@ -126,8 +126,32 @@ fn build_csp(config: &auth::AuthConfig) -> String {
     )
 }
 
-/// Cookie name for the hub authentication token.
-const AUTH_COOKIE_NAME: &str = "quarto_hub_token";
+/// Cookie name for the hub authentication token in secure (TLS) mode.
+///
+/// The `__Host-` prefix is a browser-enforced binding: a cookie with
+/// this name is only accepted if it carries `Secure`, `Path=/`, and
+/// **no** `Domain`. That makes it un-tossable — a sibling subdomain
+/// (`evil.example.com` setting `Domain=example.com`) cannot plant one,
+/// which is the session-fixation vector the bare name leaves open (H3).
+const AUTH_COOKIE_NAME_SECURE: &str = "__Host-quarto_hub_token";
+
+/// Cookie name under `--allow-insecure-auth`, and the pre-H3 name
+/// everywhere. `__Host-` *requires* `Secure`, which requires TLS, so
+/// plain-HTTP dev mode cannot use the prefixed form.
+const AUTH_COOKIE_NAME_LEGACY: &str = "quarto_hub_token";
+
+/// The session-cookie name for the current TLS mode.
+///
+/// Mint, extract, clear, and the sliding-re-issue layer all resolve the
+/// name through here, so the two modes can never disagree about which
+/// cookie is the credential.
+fn auth_cookie_name(secure: bool) -> &'static str {
+    if secure {
+        AUTH_COOKIE_NAME_SECURE
+    } else {
+        AUTH_COOKIE_NAME_LEGACY
+    }
+}
 
 /// JSON error body for auth failures, so clients can distinguish
 /// 401 auth errors from other HTTP errors programmatically.
@@ -206,10 +230,14 @@ pub enum CredentialError {
 /// checks: a request that smuggles a stolen Bearer with a same-origin
 /// cookie must not be silently routed through one credential path or
 /// the other.
+///
+/// `secure` selects which cookie name counts as the credential — see
+/// [`auth_cookie_name`]. Callers pass `!ctx.allow_insecure_auth()`.
 pub fn extract_credential(
     headers: &HeaderMap,
+    secure: bool,
 ) -> std::result::Result<Option<Credential>, CredentialError> {
-    let cookie = cookie_token(headers);
+    let cookie = cookie_token(headers, secure);
     let auth_header = headers.get(http::header::AUTHORIZATION);
 
     let bearer = match auth_header {
@@ -266,12 +294,20 @@ fn conflicting_credentials() -> (StatusCode, Json<serde_json::Value>) {
 /// Uses the `cookie` crate parser for RFC 6265 compliance (handles
 /// quoted values and other edge cases). Returns `None` if the cookie
 /// is absent, the header is not valid UTF-8, or the value is empty.
-fn cookie_token(headers: &HeaderMap) -> Option<String> {
+///
+/// Only the name for the current mode is honoured. In secure mode a
+/// token presented under the legacy (unprefixed) name is **not** a
+/// credential: accepting both would forfeit the `__Host-` guarantee,
+/// since a subdomain-tossed unprefixed cookie would still authenticate.
+/// Sessions minted before the H3 rollout therefore die once, and the
+/// user re-logs-in.
+fn cookie_token(headers: &HeaderMap, secure: bool) -> Option<String> {
+    let name = auth_cookie_name(secure);
     let cookies = headers.get("cookie")?.to_str().ok()?;
     cookies
         .split(';')
         .filter_map(|s| cookie::Cookie::parse(s.trim()).ok())
-        .find(|c| c.name() == AUTH_COOKIE_NAME)
+        .find(|c| c.name() == name)
         .map(|c| c.value().to_owned())
         .filter(|v| !v.is_empty())
 }
@@ -296,7 +332,7 @@ fn build_auth_cookie(token: &str, secure: bool, max_age_secs: i64) -> String {
              (4096 byte limit including cookie metadata)"
         );
     }
-    let mut builder = cookie::Cookie::build((AUTH_COOKIE_NAME, token))
+    let mut builder = cookie::Cookie::build((auth_cookie_name(secure), token))
         .http_only(true)
         .same_site(SameSite::Lax)
         .path("/")
@@ -312,11 +348,16 @@ fn build_auth_cookie(token: &str, secure: bool, max_age_secs: i64) -> String {
 /// claims, `auth_time = now` — bumped to the revocation ledger's
 /// re-login floor when one exists, so a login in the same second as a
 /// logout-everywhere doesn't die with the revoked family (clocks are
-/// second-granular). Returns the full `Set-Cookie` value.
+/// second-granular).
+///
+/// Returns every `Set-Cookie` value the login response must carry: the
+/// session cookie, plus — in secure mode — a clear for the pre-H3
+/// unprefixed name. Callers **append** these (a login sets more than
+/// one cookie).
 async fn mint_session_cookie(
     ctx: &HubContext,
     claims: &auth::OidcClaims,
-) -> std::result::Result<String, jsonwebtoken::errors::Error> {
+) -> std::result::Result<Vec<String>, jsonwebtoken::errors::Error> {
     let now = crate::session::unix_now();
     let lifetimes = ctx.session_lifetimes();
     let identity = crate::session::SessionIdentity::from_oidc(claims);
@@ -328,16 +369,61 @@ async fn mint_session_cookie(
     let token =
         crate::session::mint_session_at(ctx.session_keys(), lifetimes, &identity, now, auth_time)?;
     let max_age = lifetimes.expiry(now, auth_time) - now;
-    Ok(build_auth_cookie(
-        &token,
-        !ctx.allow_insecure_auth(),
-        max_age,
-    ))
+    let secure = !ctx.allow_insecure_auth();
+
+    let mut cookies = vec![build_auth_cookie(&token, secure, max_age)];
+    if secure {
+        cookies.push(build_clear_legacy_cookie());
+    }
+    Ok(cookies)
+}
+
+/// Attach `Set-Cookie` values to a response, appending so multiple
+/// cookies survive (`insert` would keep only the last).
+fn attach_cookies(response: &mut axum::response::Response, cookies: &[String]) {
+    for cookie in cookies {
+        match cookie.parse() {
+            Ok(value) => {
+                response
+                    .headers_mut()
+                    .append(http::header::SET_COOKIE, value);
+            }
+            Err(err) => {
+                // Cookie values are built by the `cookie` crate from
+                // hub-minted tokens, so this is unreachable short of a
+                // bug — log rather than drop silently.
+                tracing::error!(error = %err, "failed to encode Set-Cookie header");
+            }
+        }
+    }
 }
 
 /// Build a `Set-Cookie` header value that clears the auth cookie.
-fn build_clear_cookie() -> String {
-    cookie::Cookie::build((AUTH_COOKIE_NAME, ""))
+///
+/// Clearing a `__Host-` cookie requires re-stating the attributes the
+/// prefix demands, or the browser rejects the clear and the cookie
+/// survives — hence `Secure`/`Path=/` in secure mode.
+fn build_clear_cookie(secure: bool) -> String {
+    let mut builder = cookie::Cookie::build((auth_cookie_name(secure), ""))
+        .http_only(true)
+        .same_site(SameSite::Lax)
+        .path("/")
+        .max_age(time::Duration::ZERO);
+    if secure {
+        builder = builder.secure(true);
+    }
+    builder.build().to_string()
+}
+
+/// Build a `Set-Cookie` that clears the *pre-H3* unprefixed cookie.
+///
+/// Emitted alongside a secure-mode login mint so a session predating
+/// the `__Host-` rollout doesn't linger in the jar — it is no longer a
+/// credential (see [`cookie_token`]), just dead weight the user can't
+/// remove themselves. Never emitted in insecure mode, where this *is*
+/// the live cookie name.
+fn build_clear_legacy_cookie() -> String {
+    cookie::Cookie::build((AUTH_COOKIE_NAME_LEGACY, ""))
         .http_only(true)
         .same_site(SameSite::Lax)
         .path("/")
@@ -439,7 +525,7 @@ where
         state: &S,
     ) -> std::result::Result<Self, Self::Rejection> {
         let ctx = SharedContext::from_ref(state);
-        let credential = match extract_credential(&parts.headers) {
+        let credential = match extract_credential(&parts.headers, !ctx.allow_insecure_auth()) {
             Ok(c) => c,
             Err(CredentialError::Conflicting) => {
                 return Err(conflicting_credentials());
@@ -762,17 +848,15 @@ async fn auth_callback(
         return Redirect::to("/?auth_error").into_response();
     }
 
-    let cookie = match mint_session_cookie(&ctx, &claims).await {
-        Ok(cookie) => cookie,
+    let cookies = match mint_session_cookie(&ctx, &claims).await {
+        Ok(cookies) => cookies,
         Err(err) => {
             tracing::error!(error = %err, "failed to mint session token");
             return Redirect::to("/?auth_error").into_response();
         }
     };
     let mut response = Redirect::to("/").into_response();
-    response
-        .headers_mut()
-        .insert(http::header::SET_COOKIE, cookie.parse().unwrap());
+    attach_cookies(&mut response, &cookies);
     response
 }
 
@@ -813,7 +897,7 @@ async fn authenticate_request(
     ctx: &HubContext,
     headers: &HeaderMap,
 ) -> std::result::Result<crate::context::AuthenticatedUser, (StatusCode, Json<serde_json::Value>)> {
-    let credential = match extract_credential(headers) {
+    let credential = match extract_credential(headers, !ctx.allow_insecure_auth()) {
         Ok(Some(c)) => c,
         Ok(None) => return Err(unauthorized()),
         Err(CredentialError::Conflicting) => return Err(conflicting_credentials()),
@@ -893,6 +977,7 @@ async fn auth_actor(
 /// them, kept symmetric for tooling.
 async fn auth_logout(
     auth: Authenticated,
+    State(ctx): State<SharedContext>,
     headers: HeaderMap,
 ) -> std::result::Result<impl IntoResponse, (StatusCode, Json<serde_json::Value>)> {
     if auth.credential_kind == CredentialKind::Cookie {
@@ -900,7 +985,7 @@ async fn auth_logout(
             .map_err(|s| (s, Json(serde_json::json!({"error": "csrf check failed"}))))?;
     }
 
-    let cookie = build_clear_cookie();
+    let cookie = build_clear_cookie(!ctx.allow_insecure_auth());
     let mut response = Json(serde_json::json!({"status": "ok"})).into_response();
     response
         .headers_mut()
@@ -923,7 +1008,7 @@ async fn auth_logout_everywhere(
     headers: HeaderMap,
     State(ctx): State<SharedContext>,
 ) -> std::result::Result<impl IntoResponse, (StatusCode, Json<serde_json::Value>)> {
-    let credential = match extract_credential(&headers) {
+    let credential = match extract_credential(&headers, !ctx.allow_insecure_auth()) {
         Ok(Some(c)) => c,
         Ok(None) => return Err(unauthorized()),
         Err(CredentialError::Conflicting) => return Err(conflicting_credentials()),
@@ -974,7 +1059,7 @@ async fn auth_logout_everywhere(
         sub = %verified.claims.sub,
     );
 
-    let cookie = build_clear_cookie();
+    let cookie = build_clear_cookie(!ctx.allow_insecure_auth());
     let mut response = Json(serde_json::json!({"status": "ok"})).into_response();
     response
         .headers_mut()
@@ -1009,7 +1094,7 @@ async fn auth_session(
     // `Authenticated` extractor. Without this, a request carrying both
     // a cookie and a Bearer would bypass the conflicting-credentials
     // rule on this endpoint (the cookie path runs without `Authenticated`).
-    let bearer_present = match extract_credential(&headers) {
+    let bearer_present = match extract_credential(&headers, !ctx.allow_insecure_auth()) {
         Ok(Some(c)) => matches!(c.kind(), CredentialKind::Bearer),
         Ok(None) => false,
         Err(CredentialError::Conflicting) => return Err(conflicting_credentials()),
@@ -1049,7 +1134,7 @@ async fn auth_session(
         ));
     }
 
-    let cookie = mint_session_cookie(&ctx, &claims).await.map_err(|err| {
+    let cookies = mint_session_cookie(&ctx, &claims).await.map_err(|err| {
         tracing::error!(error = %err, "failed to mint session token");
         (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -1057,9 +1142,7 @@ async fn auth_session(
         )
     })?;
     let mut response = Json(serde_json::json!({"status": "ok"})).into_response();
-    response
-        .headers_mut()
-        .insert(http::header::SET_COOKIE, cookie.parse().unwrap());
+    attach_cookies(&mut response, &cookies);
     Ok(response)
 }
 
@@ -1088,7 +1171,7 @@ async fn session_reissue_layer(
     // attached (a Bearer/MCP or dual-credential request must never
     // slide the window).
     let token = if request.headers().get(http::header::AUTHORIZATION).is_none() {
-        cookie_token(request.headers())
+        cookie_token(request.headers(), !ctx.allow_insecure_auth())
     } else {
         None
     };
@@ -1166,7 +1249,7 @@ async fn ws_handler(
     ws: WebSocketUpgrade,
 ) -> axum::response::Response {
     let email = if ctx.auth_config().is_some() {
-        let credential = match extract_credential(&headers) {
+        let credential = match extract_credential(&headers, !ctx.allow_insecure_auth()) {
             Ok(c) => c,
             Err(CredentialError::Conflicting) => {
                 return conflicting_credentials().into_response();
@@ -1760,7 +1843,7 @@ mod tests {
     #[test]
     fn cookie_token_extracts_value() {
         let h = headers_with(&[("cookie", "quarto_hub_token=abc123")]);
-        assert_eq!(cookie_token(&h).as_deref(), Some("abc123"));
+        assert_eq!(cookie_token(&h, false).as_deref(), Some("abc123"));
     }
 
     #[test]
@@ -1769,32 +1852,66 @@ mod tests {
             "cookie",
             "other=x; quarto_hub_token=jwt.value.here; third=y",
         )]);
-        assert_eq!(cookie_token(&h).as_deref(), Some("jwt.value.here"));
+        assert_eq!(cookie_token(&h, false).as_deref(), Some("jwt.value.here"));
     }
 
     #[test]
     fn cookie_token_missing() {
         let h = headers_with(&[("cookie", "other=x; another=y")]);
-        assert_eq!(cookie_token(&h), None);
+        assert_eq!(cookie_token(&h, false), None);
     }
 
     #[test]
     fn cookie_token_no_cookie_header() {
         let h = HeaderMap::new();
-        assert_eq!(cookie_token(&h), None);
+        assert_eq!(cookie_token(&h, false), None);
     }
 
     #[test]
     fn cookie_token_empty_value() {
         let h = headers_with(&[("cookie", "quarto_hub_token=")]);
-        assert_eq!(cookie_token(&h), None);
+        assert_eq!(cookie_token(&h, false), None);
     }
 
     #[test]
     fn cookie_token_prefix_mismatch() {
         // "quarto_hub_token_v2" should NOT match "quarto_hub_token"
         let h = headers_with(&[("cookie", "quarto_hub_token_v2=abc")]);
-        assert_eq!(cookie_token(&h), None);
+        assert_eq!(cookie_token(&h, false), None);
+    }
+
+    // ── H3: mode-aware cookie name ────────────────────────────────
+
+    #[test]
+    fn cookie_token_secure_mode_reads_host_prefixed_name() {
+        let h = headers_with(&[("cookie", "__Host-quarto_hub_token=abc123")]);
+        assert_eq!(cookie_token(&h, true).as_deref(), Some("abc123"));
+    }
+
+    #[test]
+    fn cookie_token_secure_mode_ignores_legacy_name() {
+        // Accepting the unprefixed name in secure mode would forfeit the
+        // whole point of `__Host-`: a subdomain-tossed cookie would
+        // still authenticate.
+        let h = headers_with(&[("cookie", "quarto_hub_token=abc123")]);
+        assert_eq!(cookie_token(&h, true), None);
+    }
+
+    #[test]
+    fn cookie_token_insecure_mode_ignores_host_prefixed_name() {
+        let h = headers_with(&[("cookie", "__Host-quarto_hub_token=abc123")]);
+        assert_eq!(cookie_token(&h, false), None);
+    }
+
+    #[test]
+    fn cookie_token_secure_mode_picks_prefixed_among_both() {
+        // Transitional jar: a stale legacy cookie sitting next to the
+        // live prefixed one must not shadow it.
+        let h = headers_with(&[(
+            "cookie",
+            "quarto_hub_token=stale; __Host-quarto_hub_token=live",
+        )]);
+        assert_eq!(cookie_token(&h, true).as_deref(), Some("live"));
     }
 
     // ── build_auth_cookie ─────────────────────────────────────────
@@ -1802,12 +1919,14 @@ mod tests {
     #[test]
     fn build_auth_cookie_secure() {
         let cookie = build_auth_cookie("mytoken", true, 3600);
-        assert!(cookie.starts_with("quarto_hub_token=mytoken;"));
+        assert!(cookie.starts_with("__Host-quarto_hub_token=mytoken;"));
         assert!(cookie.contains("HttpOnly"));
         assert!(cookie.contains("Secure"));
         assert!(cookie.contains("SameSite=Lax"));
         assert!(cookie.contains("Path=/"));
         assert!(cookie.contains("Max-Age=3600"));
+        // `__Host-` is only honoured without a Domain attribute.
+        assert!(!cookie.contains("Domain"));
     }
 
     #[test]
@@ -1830,10 +1949,29 @@ mod tests {
 
     #[test]
     fn build_clear_cookie_has_zero_max_age() {
-        let cookie = build_clear_cookie();
+        let cookie = build_clear_cookie(false);
         assert!(cookie.contains("Max-Age=0"));
         assert!(cookie.contains("HttpOnly"));
         assert!(cookie.starts_with("quarto_hub_token=;"));
+    }
+
+    #[test]
+    fn build_clear_cookie_secure_restates_host_prefix_attributes() {
+        // A clear for a `__Host-` cookie is itself subject to the
+        // prefix rules — drop `Secure`/`Path=/` and the browser
+        // rejects the clear, leaving the cookie in place.
+        let cookie = build_clear_cookie(true);
+        assert!(cookie.starts_with("__Host-quarto_hub_token=;"));
+        assert!(cookie.contains("Max-Age=0"));
+        assert!(cookie.contains("Secure"));
+        assert!(cookie.contains("Path=/"));
+    }
+
+    #[test]
+    fn build_clear_legacy_cookie_targets_unprefixed_name() {
+        let cookie = build_clear_legacy_cookie();
+        assert!(cookie.starts_with("quarto_hub_token=;"));
+        assert!(cookie.contains("Max-Age=0"));
     }
 
     // ── check_csrf ────────────────────────────────────────────────

--- a/crates/quarto-hub/src/server.rs
+++ b/crates/quarto-hub/src/server.rs
@@ -991,6 +991,10 @@ async fn auth_logout_everywhere(
 /// OIDC deployment has — `/auth/callback` is registered only for providers
 /// whose `AuthConfig::uses_form_post_callback()` is true (Google alone).
 ///
+/// **Registered only for Generic providers** (H1): a form-post
+/// deployment has no caller for it, so exposing it there would be a
+/// second ID-token replay sink for nothing.
+///
 /// The submitted JWT goes through the full `authenticate_claims()` path
 /// (signature, audience, issuer, email allowlist) before a session is minted;
 /// because this is a fresh login, `auth_time = now` and a new `sid` are correct.
@@ -1313,7 +1317,6 @@ pub async fn build_router_with_state(ctx: SharedContext) -> Result<Router<Shared
         .route("/auth/actor", get(auth_actor))
         .route("/auth/logout", post(auth_logout))
         .route("/auth/logout-everywhere", post(auth_logout_everywhere))
-        .route("/auth/session", post(auth_session))
         // WebSocket endpoint for automerge sync at `/ws` (hub-client +
         // q2-preview SPA's canonical path).
         .route("/ws", get(ws_handler))
@@ -1334,6 +1337,19 @@ pub async fn build_router_with_state(ctx: SharedContext) -> Result<Router<Shared
         .is_some_and(|c| c.uses_form_post_callback())
     {
         router = router.route("/auth/callback", post(auth_callback));
+    }
+
+    // `/auth/session` is the JSON mint endpoint, and the *only* login
+    // path a Generic OIDC deployment has. Form-post providers (Google)
+    // log in through `/auth/callback` and nothing calls this — leaving
+    // it registered there would publish a second ID-token replay sink
+    // for no benefit, so it is the exact inverse of the condition above
+    // (H1, bd-zbep24xd).
+    if ctx
+        .auth_config()
+        .is_some_and(|c| !c.uses_form_post_callback())
+    {
+        router = router.route("/auth/session", post(auth_session));
     }
 
     // Add Content-Security-Policy header when auth is enabled.

--- a/crates/quarto-hub/src/server.rs
+++ b/crates/quarto-hub/src/server.rs
@@ -343,6 +343,25 @@ fn build_auth_cookie(token: &str, secure: bool, max_age_secs: i64) -> String {
     builder.build().to_string()
 }
 
+/// Which login endpoint minted a session — the `endpoint` field of the
+/// `login_mint` audit event (H5).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LoginEndpoint {
+    /// Form-post `/auth/callback` (Google).
+    Callback,
+    /// JSON `/auth/session` (Generic providers).
+    Session,
+}
+
+impl LoginEndpoint {
+    fn label(self) -> &'static str {
+        match self {
+            LoginEndpoint::Callback => "callback",
+            LoginEndpoint::Session => "session",
+        }
+    }
+}
+
 /// Mint a fresh hub session cookie (§1) for Google-validated claims:
 /// fresh random `sid`, identity stamped from the validated Google
 /// claims, `auth_time = now` — bumped to the revocation ledger's
@@ -354,9 +373,14 @@ fn build_auth_cookie(token: &str, secure: bool, max_age_secs: i64) -> String {
 /// session cookie, plus — in secure mode — a clear for the pre-H3
 /// unprefixed name. Callers **append** these (a login sets more than
 /// one cookie).
+///
+/// Emits the `login_mint` audit event (H5) on success. It lives here
+/// rather than in the two handlers so a future third mint call site
+/// cannot forget it; `endpoint` is what distinguishes them in the log.
 async fn mint_session_cookie(
     ctx: &HubContext,
     claims: &auth::OidcClaims,
+    endpoint: LoginEndpoint,
 ) -> std::result::Result<Vec<String>, jsonwebtoken::errors::Error> {
     let now = crate::session::unix_now();
     let lifetimes = ctx.session_lifetimes();
@@ -366,12 +390,26 @@ async fn mint_session_cookie(
         .min_auth_time(&claims.sub)
         .await
         .map_or(now, |floor| floor.max(now));
-    let token =
+    let minted =
         crate::session::mint_session_at(ctx.session_keys(), lifetimes, &identity, now, auth_time)?;
     let max_age = lifetimes.expiry(now, auth_time) - now;
     let secure = !ctx.allow_insecure_auth();
 
-    let mut cookies = vec![build_auth_cookie(&token, secure, max_age)];
+    // A mint is the birth of a session family, not just another
+    // authenticated request — logged distinctly so "where did this
+    // session come from?" is answerable from the audit trail alone.
+    tracing::event!(
+        target: "quarto_hub::audit",
+        tracing::Level::INFO,
+        action = "login_mint",
+        outcome = "allow",
+        credential_kind = "cookie",
+        sub = %claims.sub,
+        sid = %minted.sid,
+        endpoint = endpoint.label(),
+    );
+
+    let mut cookies = vec![build_auth_cookie(&minted.token, secure, max_age)];
     if secure {
         cookies.push(build_clear_legacy_cookie());
     }
@@ -848,7 +886,7 @@ async fn auth_callback(
         return Redirect::to("/?auth_error").into_response();
     }
 
-    let cookies = match mint_session_cookie(&ctx, &claims).await {
+    let cookies = match mint_session_cookie(&ctx, &claims, LoginEndpoint::Callback).await {
         Ok(cookies) => cookies,
         Err(err) => {
             tracing::error!(error = %err, "failed to mint session token");
@@ -1134,13 +1172,15 @@ async fn auth_session(
         ));
     }
 
-    let cookies = mint_session_cookie(&ctx, &claims).await.map_err(|err| {
-        tracing::error!(error = %err, "failed to mint session token");
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({"error": "session_mint_failed"})),
-        )
-    })?;
+    let cookies = mint_session_cookie(&ctx, &claims, LoginEndpoint::Session)
+        .await
+        .map_err(|err| {
+            tracing::error!(error = %err, "failed to mint session token");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": "session_mint_failed"})),
+            )
+        })?;
     let mut response = Json(serde_json::json!({"status": "ok"})).into_response();
     attach_cookies(&mut response, &cookies);
     Ok(response)

--- a/crates/quarto-hub/src/session.rs
+++ b/crates/quarto-hub/src/session.rs
@@ -316,6 +316,22 @@ impl SessionKeys {
         }
         self.previous.as_ref().filter(|p| p.kid == kid)
     }
+
+    /// Raw current secret, for signing the *other* payload type that
+    /// shares this keyring: sealed login state
+    /// ([`crate::login_state`]). Crate-private — the secret must not
+    /// leak past the two modules that sign with it, and sharing the
+    /// keyring is only safe because those payloads are domain-separated
+    /// (see that module's docs).
+    pub(crate) fn current_secret(&self) -> &[u8; 32] {
+        &self.current.secret
+    }
+
+    /// Exact-match `kid` → raw secret, the verification counterpart to
+    /// [`Self::current_secret`]. Fails closed on unknown kids.
+    pub(crate) fn secret_for_kid(&self, kid: &str) -> Option<&[u8; 32]> {
+        self.key_for_kid(kid).map(|k| &k.secret)
+    }
 }
 
 /// Why a session token failed verification. The variants map 1:1 to the
@@ -1029,6 +1045,7 @@ mod tests {
             azp: None,
             iat: None,
             exp: 0,
+            nonce: None,
         };
         let id = SessionIdentity::from_oidc(&claims);
         assert_eq!(id.name.as_ref().unwrap().chars().count(), 200);

--- a/crates/quarto-hub/src/session.rs
+++ b/crates/quarto-hub/src/session.rs
@@ -388,15 +388,30 @@ pub fn derive_session_kid(secret: &[u8; 32]) -> String {
     hex::encode(&digest[..4])
 }
 
+/// A freshly minted session: the signed token and the `sid` of the
+/// session family it opens.
+///
+/// The `sid` is returned alongside rather than left inside the token so
+/// the login path can name the new session in the audit log without
+/// re-decoding what it just signed (H5).
+#[derive(Debug, Clone)]
+pub struct MintedSession {
+    pub token: String,
+    pub sid: String,
+}
+
 /// Mint a fresh session token at login: `auth_time = now`, fresh
 /// random `sid`, identity stamped from the validated Google claims.
+///
+/// Returns the token only. The login path uses [`mint_session_at`],
+/// which also surfaces the `sid`.
 pub fn mint_session(
     keys: &SessionKeys,
     lifetimes: SessionLifetimes,
     identity: &SessionIdentity,
     now: i64,
 ) -> Result<String, jsonwebtoken::errors::Error> {
-    mint_session_at(keys, lifetimes, identity, now, now)
+    Ok(mint_session_at(keys, lifetimes, identity, now, now)?.token)
 }
 
 /// [`mint_session`] with an explicit `auth_time` anchor.
@@ -413,7 +428,8 @@ pub fn mint_session_at(
     identity: &SessionIdentity,
     now: i64,
     auth_time: i64,
-) -> Result<String, jsonwebtoken::errors::Error> {
+) -> Result<MintedSession, jsonwebtoken::errors::Error> {
+    let sid = generate_sid();
     let claims = SessionClaims {
         iss: SESSION_ISSUER.to_string(),
         sub: identity.sub.clone(),
@@ -424,9 +440,12 @@ pub fn mint_session_at(
         iat: now,
         auth_time,
         exp: lifetimes.expiry(now, auth_time),
-        sid: generate_sid(),
+        sid: sid.clone(),
     };
-    sign_claims(keys, &claims)
+    Ok(MintedSession {
+        token: sign_claims(keys, &claims)?,
+        sid,
+    })
 }
 
 /// Re-issue a session token on authenticated activity: `iat = now`,
@@ -712,6 +731,18 @@ mod tests {
         assert_eq!(v.claims.auth_time, t, "fresh mint anchors auth_time = now");
         assert_eq!(v.claims.exp, t + DEFAULT_SESSION_IDLE_SECS);
         assert!(v.signed_with_current_key);
+    }
+
+    #[test]
+    fn mint_session_at_returns_the_sid_inside_the_token() {
+        // H5 logs the returned `sid` as the identity of the new session
+        // family. If it ever drifted from the token's claim, the audit
+        // trail would name a session that does not exist.
+        let t = now();
+        let lt = SessionLifetimes::default();
+        let minted = mint_session_at(&keys(), lt, &identity(), t, t).unwrap();
+        let v = verify_session(&keys(), lt, &minted.token, t).unwrap();
+        assert_eq!(minted.sid, v.claims.sid);
     }
 
     #[test]

--- a/crates/quarto-hub/tests/integration/auth_bearer.rs
+++ b/crates/quarto-hub/tests/integration/auth_bearer.rs
@@ -23,8 +23,8 @@ use rsa::{RsaPrivateKey, pkcs1::EncodeRsaPrivateKey, pkcs8::LineEnding};
 use serde_json::json;
 
 use crate::support::{
-    ClaimsBuilder, MCP_CLIENT_ID, MockOidcProvider, SPA_CLIENT_ID, TestHub, TestHubBuilder,
-    install_tracing_once, snapshot_events,
+    AUTH_COOKIE_NAME_SECURE, ClaimsBuilder, MCP_CLIENT_ID, MockOidcProvider, SPA_CLIENT_ID,
+    TestHub, TestHubBuilder, install_tracing_once, snapshot_events,
 };
 
 // ── shared test fixtures ──────────────────────────────────────────
@@ -437,7 +437,8 @@ async fn ws_upgrade_with_bearer_skips_origin_check() {
 #[tokio::test]
 async fn ws_upgrade_with_cookie_still_requires_origin() {
     // Hubs started with allow_insecure_auth=true skip the Origin check,
-    // so this regression needs the secure fixture.
+    // so this regression needs the secure fixture — which is also why
+    // the cookie carries the `__Host-` prefixed name (H3).
     let (provider, hub) = secure_setup().await;
     let token = provider.sign(
         &ClaimsBuilder::from_provider(provider)
@@ -447,7 +448,7 @@ async fn ws_upgrade_with_cookie_still_requires_origin() {
     let resp = hub
         .ws_upgrade()
         .header("origin", "https://attacker.example.com")
-        .header("cookie", format!("quarto_hub_token={token}"))
+        .header("cookie", format!("{AUTH_COOKIE_NAME_SECURE}={token}"))
         .send()
         .await
         .unwrap();

--- a/crates/quarto-hub/tests/integration/login_nonce.rs
+++ b/crates/quarto-hub/tests/integration/login_nonce.rs
@@ -1,0 +1,441 @@
+//! Server-verified `nonce` in the GIS login (H2, `bd-uqjiac5a`).
+//!
+//! Without a nonce the hub validates an ID token's signature, `iss`,
+//! `aud`, and `exp` — but has no way to tell whether *this* token belongs
+//! to *this* login attempt. Any captured Google ID token could therefore
+//! be replayed to a mint endpoint for its full (~1 h) validity. These
+//! tests pin the binding: `GET /auth/nonce` seals a nonce into a cookie,
+//! and `POST /auth/callback` requires the ID token to echo it.
+//!
+//! **Scope.** Enforcement covers the Google form-post callback only —
+//! `/auth/session` (the Generic provider's JSON mint) stays replay-able
+//! within the submitted token's validity. That is an accepted boundary,
+//! not an oversight; see the plan.
+//!
+//! Every enforcement test runs on a **secure** hub:
+//! `--allow-insecure-auth` deliberately skips the check, because the
+//! `SameSite=None; Secure` cookie the flow needs cannot work over plain
+//! HTTP. `insecure_mode_skips_enforcement_with_a_warning` covers that.
+
+use quarto_hub::login_state::{LOGIN_STATE_TTL_SECS, seal_login_state};
+use quarto_hub::session::{SessionIdentity, SessionKeys, SessionLifetimes, mint_session};
+
+use crate::support::{
+    AUTH_COOKIE_NAME_SECURE, ClaimsBuilder, LOGIN_STATE_COOKIE_LEGACY, LOGIN_STATE_COOKIE_SECURE,
+    MockOidcProvider, TEST_SESSION_SECRET, TestHub, TestHubBuilder, install_tracing_once,
+    snapshot_events,
+};
+
+// ── fixtures ──────────────────────────────────────────────────────
+
+/// Secure Google-provider hub with the known session secret — the shape
+/// that enforces the nonce.
+async fn secure_google_setup() -> &'static (MockOidcProvider, TestHub) {
+    static SETUP: tokio::sync::OnceCell<(MockOidcProvider, TestHub)> =
+        tokio::sync::OnceCell::const_new();
+    SETUP
+        .get_or_init(|| async {
+            install_tracing_once();
+            let provider = MockOidcProvider::start().await;
+            let hub = TestHubBuilder::new()
+                .secure()
+                .google_provider()
+                .session_secret(TEST_SESSION_SECRET)
+                .start(&provider)
+                .await;
+            (provider, hub)
+        })
+        .await
+}
+
+fn test_keys() -> SessionKeys {
+    SessionKeys::new(TEST_SESSION_SECRET)
+}
+
+fn epoch_now() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64
+}
+
+fn no_redirect_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap()
+}
+
+/// Fetch `/auth/nonce`, returning `(nonce, sealed_blob)`.
+async fn fetch_nonce(hub: &TestHub, cookie_name: &str) -> (String, String) {
+    let resp = hub.client.get(hub.url("/auth/nonce")).send().await.unwrap();
+    assert_eq!(resp.status(), 200, "nonce pre-flight must succeed");
+    let (blob, _) =
+        TestHub::find_set_cookie(&resp, cookie_name).expect("sealed login-state cookie set");
+    let body: serde_json::Value = resp.json().await.unwrap();
+    let nonce = body["nonce"].as_str().expect("nonce in body").to_string();
+    (nonce, blob)
+}
+
+/// Drive `POST /auth/callback` with the Google double-submit CSRF pair,
+/// optionally attaching a sealed login-state cookie.
+async fn post_callback(
+    hub: &TestHub,
+    credential: &str,
+    login_cookie: Option<(&str, &str)>,
+) -> reqwest::Response {
+    let mut cookies = vec!["g_csrf_token=csrf-h2".to_string()];
+    if let Some((name, value)) = login_cookie {
+        cookies.push(format!("{name}={value}"));
+    }
+    no_redirect_client()
+        .post(hub.url("/auth/callback"))
+        .header("cookie", cookies.join("; "))
+        .header("content-type", "application/x-www-form-urlencoded")
+        .body(format!("credential={credential}&g_csrf_token=csrf-h2"))
+        .send()
+        .await
+        .unwrap()
+}
+
+fn assert_auth_error(resp: &reqwest::Response) {
+    assert!(
+        resp.status().is_redirection(),
+        "expected a redirect, got {}",
+        resp.status()
+    );
+    assert_eq!(
+        resp.headers().get("location").unwrap(),
+        "/?auth_error",
+        "failed nonce verification must land on the auth-error route"
+    );
+    assert!(
+        TestHub::find_set_cookie(resp, AUTH_COOKIE_NAME_SECURE).is_none(),
+        "no session may be minted"
+    );
+}
+
+// ── the pre-flight endpoint ───────────────────────────────────────
+
+#[tokio::test]
+async fn nonce_endpoint_returns_a_nonce_and_a_sealed_cookie() {
+    let (_provider, hub) = secure_google_setup().await;
+    let resp = hub.client.get(hub.url("/auth/nonce")).send().await.unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let (blob, attrs) = TestHub::find_set_cookie(&resp, LOGIN_STATE_COOKIE_SECURE)
+        .expect("__Secure- prefixed login-state cookie");
+
+    // `SameSite=None` is load-bearing, not laxity: Google delivers the
+    // credential by *cross-site* form POST, and a Lax cookie is not
+    // attached to that.
+    assert!(attrs.contains("SameSite=None"), "{attrs}");
+    assert!(attrs.contains("Secure"), "__Secure- requires it: {attrs}");
+    assert!(attrs.contains("HttpOnly"), "{attrs}");
+    // Scoped to the only two routes that use it, hence `__Secure-`
+    // rather than `__Host-` (which would force Path=/).
+    assert!(attrs.contains("Path=/auth"), "{attrs}");
+    assert!(
+        attrs.contains(&format!("Max-Age={LOGIN_STATE_TTL_SECS}")),
+        "{attrs}"
+    );
+
+    let body: serde_json::Value = resp.json().await.unwrap();
+    let nonce = body["nonce"].as_str().expect("nonce in body");
+    assert_eq!(nonce.len(), 64, "256 bits, hex-encoded");
+
+    // The cookie must seal the nonce that was handed to the client —
+    // otherwise the callback could never match them.
+    let opened =
+        quarto_hub::login_state::open_login_state(&test_keys(), &blob, epoch_now()).unwrap();
+    assert_eq!(opened.nonce, nonce);
+}
+
+#[tokio::test]
+async fn nonce_endpoint_issues_a_distinct_nonce_per_call() {
+    let (_provider, hub) = secure_google_setup().await;
+    let (a, blob_a) = fetch_nonce(hub, LOGIN_STATE_COOKIE_SECURE).await;
+    let (b, blob_b) = fetch_nonce(hub, LOGIN_STATE_COOKIE_SECURE).await;
+    assert_ne!(a, b, "a reused nonce would not bind a single attempt");
+    assert_ne!(blob_a, blob_b);
+}
+
+// ── happy path ────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn callback_with_matching_nonce_mints_a_session() {
+    let (provider, hub) = secure_google_setup().await;
+    let (nonce, blob) = fetch_nonce(hub, LOGIN_STATE_COOKIE_SECURE).await;
+
+    let google = provider.sign(
+        &ClaimsBuilder::from_provider(provider)
+            .sub("nonce-happy-sub")
+            .email("nonce@posit.co")
+            .nonce(&nonce)
+            .to_value(),
+    );
+    let resp = post_callback(hub, &google, Some((LOGIN_STATE_COOKIE_SECURE, &blob))).await;
+
+    assert!(resp.status().is_redirection());
+    assert_eq!(resp.headers().get("location").unwrap(), "/");
+    let (token, _) = TestHub::find_set_cookie(&resp, AUTH_COOKIE_NAME_SECURE)
+        .expect("session cookie minted on a nonce-bound login");
+    let verified = quarto_hub::session::verify_session(
+        &test_keys(),
+        SessionLifetimes::default(),
+        &token,
+        epoch_now(),
+    )
+    .unwrap();
+    assert_eq!(verified.claims.sub, "nonce-happy-sub");
+}
+
+#[tokio::test]
+async fn callback_clears_the_login_cookie_after_use() {
+    let (provider, hub) = secure_google_setup().await;
+    let (nonce, blob) = fetch_nonce(hub, LOGIN_STATE_COOKIE_SECURE).await;
+    let google = provider.sign(
+        &ClaimsBuilder::from_provider(provider)
+            .sub("nonce-singleuse-sub")
+            .nonce(&nonce)
+            .to_value(),
+    );
+
+    let resp = post_callback(hub, &google, Some((LOGIN_STATE_COOKIE_SECURE, &blob))).await;
+    assert!(resp.status().is_redirection());
+
+    // Single use: the blob is cleared so the same login attempt cannot
+    // be completed twice from the same jar.
+    let (value, attrs) = TestHub::find_set_cookie(&resp, LOGIN_STATE_COOKIE_SECURE)
+        .expect("login-state cookie cleared on success");
+    assert_eq!(value, "");
+    assert!(attrs.contains("Max-Age=0"), "{attrs}");
+}
+
+// ── the replay window this closes ─────────────────────────────────
+
+#[tokio::test]
+async fn callback_without_a_login_cookie_is_rejected() {
+    // This is the captured-token replay case: a valid, unexpired Google
+    // ID token, correct CSRF pair, no login attempt behind it.
+    let (provider, hub) = secure_google_setup().await;
+    let (nonce, _blob) = fetch_nonce(hub, LOGIN_STATE_COOKIE_SECURE).await;
+    let google = provider.sign(
+        &ClaimsBuilder::from_provider(provider)
+            .sub("nonce-nocookie-sub")
+            .nonce(&nonce)
+            .to_value(),
+    );
+
+    let resp = post_callback(hub, &google, None).await;
+    assert_auth_error(&resp);
+}
+
+#[tokio::test]
+async fn callback_with_a_nonce_from_another_login_is_rejected() {
+    // Two concurrent pre-flights; the token from one presented with the
+    // cookie from the other.
+    let (provider, hub) = secure_google_setup().await;
+    let (nonce_a, _blob_a) = fetch_nonce(hub, LOGIN_STATE_COOKIE_SECURE).await;
+    let (_nonce_b, blob_b) = fetch_nonce(hub, LOGIN_STATE_COOKIE_SECURE).await;
+
+    let google = provider.sign(
+        &ClaimsBuilder::from_provider(provider)
+            .sub("nonce-crossed-sub")
+            .nonce(&nonce_a)
+            .to_value(),
+    );
+    let resp = post_callback(hub, &google, Some((LOGIN_STATE_COOKIE_SECURE, &blob_b))).await;
+    assert_auth_error(&resp);
+}
+
+#[tokio::test]
+async fn callback_with_a_token_carrying_no_nonce_is_rejected() {
+    // A pre-H2 client, or a token minted for some other relying party.
+    let (provider, hub) = secure_google_setup().await;
+    let (_nonce, blob) = fetch_nonce(hub, LOGIN_STATE_COOKIE_SECURE).await;
+    let google = provider.sign(
+        &ClaimsBuilder::from_provider(provider)
+            .sub("nonce-missing-claim-sub")
+            .to_value(),
+    );
+
+    let resp = post_callback(hub, &google, Some((LOGIN_STATE_COOKIE_SECURE, &blob))).await;
+    assert_auth_error(&resp);
+}
+
+#[tokio::test]
+async fn callback_with_an_expired_login_blob_is_rejected() {
+    let (provider, hub) = secure_google_setup().await;
+    let nonce = "a".repeat(64);
+    // Sealed far enough in the past that even the leeway is exhausted.
+    let stale = seal_login_state(
+        &test_keys(),
+        &nonce,
+        epoch_now() - LOGIN_STATE_TTL_SECS - 3600,
+        LOGIN_STATE_TTL_SECS,
+    )
+    .unwrap();
+
+    let google = provider.sign(
+        &ClaimsBuilder::from_provider(provider)
+            .sub("nonce-expired-sub")
+            .nonce(&nonce)
+            .to_value(),
+    );
+    let resp = post_callback(hub, &google, Some((LOGIN_STATE_COOKIE_SECURE, &stale))).await;
+    assert_auth_error(&resp);
+}
+
+#[tokio::test]
+async fn callback_with_a_tampered_login_blob_is_rejected() {
+    let (provider, hub) = secure_google_setup().await;
+    let (nonce, blob) = fetch_nonce(hub, LOGIN_STATE_COOKIE_SECURE).await;
+
+    // Flip a byte in the signature: the payload still says the right
+    // nonce, so only the HMAC stands between this and acceptance.
+    let mut parts: Vec<String> = blob.split('.').map(String::from).collect();
+    let mut sig = parts[2].clone().into_bytes();
+    let i = sig.len() / 2;
+    sig[i] = if sig[i] == b'A' { b'B' } else { b'A' };
+    parts[2] = String::from_utf8(sig).unwrap();
+
+    let google = provider.sign(
+        &ClaimsBuilder::from_provider(provider)
+            .sub("nonce-tampered-sub")
+            .nonce(&nonce)
+            .to_value(),
+    );
+    let resp = post_callback(
+        hub,
+        &google,
+        Some((LOGIN_STATE_COOKIE_SECURE, &parts.join("."))),
+    )
+    .await;
+    assert_auth_error(&resp);
+}
+
+/// A forged blob claiming an attacker-chosen nonce, signed with the
+/// wrong secret — the case that would break the whole scheme if the
+/// signature were not checked.
+#[tokio::test]
+async fn callback_with_a_blob_sealed_under_a_foreign_secret_is_rejected() {
+    let (provider, hub) = secure_google_setup().await;
+    let nonce = "b".repeat(64);
+    let forged = seal_login_state(
+        &SessionKeys::new([0x99; 32]),
+        &nonce,
+        epoch_now(),
+        LOGIN_STATE_TTL_SECS,
+    )
+    .unwrap();
+
+    let google = provider.sign(
+        &ClaimsBuilder::from_provider(provider)
+            .sub("nonce-forged-sub")
+            .nonce(&nonce)
+            .to_value(),
+    );
+    let resp = post_callback(hub, &google, Some((LOGIN_STATE_COOKIE_SECURE, &forged))).await;
+    assert_auth_error(&resp);
+}
+
+// ── domain separation across the HTTP surface ─────────────────────
+
+/// The unit tests prove the two token types cannot open as each other;
+/// this proves the *wiring* honours that — a sealed login blob handed to
+/// the hub as a session cookie must not authenticate.
+#[tokio::test]
+async fn a_sealed_login_blob_is_not_a_session_cookie() {
+    let (_provider, hub) = secure_google_setup().await;
+    let (_nonce, blob) = fetch_nonce(hub, LOGIN_STATE_COOKIE_SECURE).await;
+
+    let resp = hub
+        .get_health()
+        .header("cookie", format!("{AUTH_COOKIE_NAME_SECURE}={blob}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 401, "a login blob must not authenticate");
+}
+
+/// And the reverse: a real session token presented as the login-state
+/// cookie must not satisfy the nonce check.
+#[tokio::test]
+async fn a_session_token_is_not_a_login_state_cookie() {
+    let (provider, hub) = secure_google_setup().await;
+    let session = mint_session(
+        &test_keys(),
+        SessionLifetimes::default(),
+        &SessionIdentity {
+            sub: "nonce-crosstype-sub".into(),
+            email: "user@posit.co".into(),
+            email_verified: true,
+            name: None,
+            picture: None,
+        },
+        epoch_now(),
+    )
+    .unwrap();
+
+    let google = provider.sign(
+        &ClaimsBuilder::from_provider(provider)
+            .sub("nonce-crosstype-sub")
+            .nonce("whatever")
+            .to_value(),
+    );
+    let resp = post_callback(hub, &google, Some((LOGIN_STATE_COOKIE_SECURE, &session))).await;
+    assert_auth_error(&resp);
+}
+
+// ── insecure mode ─────────────────────────────────────────────────
+
+/// `--allow-insecure-auth` has no TLS, and the flow's
+/// `SameSite=None; Secure` cookie cannot function over plain HTTP. The
+/// callback therefore skips the check and says so — consistent with that
+/// flag's existing "never in production" contract.
+#[tokio::test]
+async fn insecure_mode_skips_enforcement_with_a_warning() {
+    static SETUP: tokio::sync::OnceCell<(MockOidcProvider, TestHub)> =
+        tokio::sync::OnceCell::const_new();
+    let (provider, hub) = SETUP
+        .get_or_init(|| async {
+            install_tracing_once();
+            let provider = MockOidcProvider::start().await;
+            let hub = TestHubBuilder::new()
+                .google_provider()
+                .session_secret(TEST_SESSION_SECRET)
+                .start(&provider)
+                .await;
+            (provider, hub)
+        })
+        .await;
+
+    // No nonce claim, no login cookie — would be rejected in secure mode.
+    let google = provider.sign(
+        &ClaimsBuilder::from_provider(provider)
+            .sub("nonce-insecure-sub")
+            .to_value(),
+    );
+    let resp = post_callback(hub, &google, None).await;
+    assert!(resp.status().is_redirection());
+    assert_eq!(
+        resp.headers().get("location").unwrap(),
+        "/",
+        "insecure mode still logs in"
+    );
+
+    let events = snapshot_events();
+    assert!(
+        events.iter().any(|e| {
+            e.fields
+                .get("message")
+                .is_some_and(|m| m.contains("nonce verification skipped"))
+        }),
+        "the skip must be loud in the log"
+    );
+
+    // The pre-flight still works there, using the unprefixed cookie name
+    // (`__Secure-` requires TLS), so the client flow is identical.
+    let (_nonce, _blob) = fetch_nonce(hub, LOGIN_STATE_COOKIE_LEGACY).await;
+}

--- a/crates/quarto-hub/tests/integration/main.rs
+++ b/crates/quarto-hub/tests/integration/main.rs
@@ -9,5 +9,6 @@
 pub mod admin_collect_lifecycle;
 pub mod admin_scan_real_store;
 pub mod auth_bearer;
+pub mod login_nonce;
 pub mod session_auth;
 pub mod support;

--- a/crates/quarto-hub/tests/integration/session_auth.rs
+++ b/crates/quarto-hub/tests/integration/session_auth.rs
@@ -558,6 +558,138 @@ async fn auth_session_mints_session_cookie() {
     assert!(attrs.contains(&format!("Max-Age={}", lt.idle_secs)));
 }
 
+// ── H5: distinct login-mint audit event ────────────────────────────
+
+/// A login mint must be distinguishable in the audit log from ordinary
+/// per-request authentication. Without it, "when did this session come
+/// into existence, and through which endpoint?" is unanswerable — every
+/// mint looked exactly like an `auth_ok` (bd-k2xvvh9f).
+#[tokio::test]
+async fn login_mint_logs_audit_event_with_sid_and_endpoint() {
+    let (provider, hub) = session_setup().await;
+    let sub = "audit-login-mint-session";
+    let google = provider.sign(
+        &ClaimsBuilder::from_provider(provider)
+            .sub(sub)
+            .email("mintaudit@posit.co")
+            .to_value(),
+    );
+
+    let resp = hub
+        .client
+        .post(hub.url("/auth/session"))
+        .header("x-requested-with", "XMLHttpRequest")
+        .json(&serde_json::json!({ "credential": google }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let (token, _) = TestHub::set_auth_cookie(&resp).expect("session cookie set");
+    let minted_sid = verify_session(
+        &test_keys(),
+        SessionLifetimes::default(),
+        &token,
+        epoch_now(),
+    )
+    .unwrap()
+    .claims
+    .sid;
+
+    let events = snapshot_events();
+    let hit = events
+        .iter()
+        .find(|e| {
+            e.fields.get("action").map(|s| s.as_str()) == Some("login_mint")
+                && e.fields.get("sub").map(|s| s.as_str()) == Some(sub)
+        })
+        .expect("expected a login_mint audit event for the minted session");
+
+    assert_eq!(hit.fields.get("outcome").map(|s| s.as_str()), Some("allow"));
+    assert_eq!(
+        hit.fields.get("endpoint").map(|s| s.as_str()),
+        Some("session"),
+        "the JSON mint endpoint identifies itself"
+    );
+    // The logged sid must name the session actually handed out, so an
+    // audit trail can be joined to a live cookie.
+    assert_eq!(
+        hit.fields.get("sid").map(|s| s.as_str()),
+        Some(minted_sid.as_str())
+    );
+}
+
+/// The form-post callback is a *different* login endpoint and says so.
+#[tokio::test]
+async fn login_mint_audit_event_names_the_callback_endpoint() {
+    let (provider, hub) = google_session_setup().await;
+    let sub = "audit-login-mint-callback";
+    let google = provider.sign(&ClaimsBuilder::from_provider(provider).sub(sub).to_value());
+
+    let client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let resp = client
+        .post(hub.url("/auth/callback"))
+        .header("cookie", "g_csrf_token=csrfmint")
+        .header("content-type", "application/x-www-form-urlencoded")
+        .body(format!("credential={google}&g_csrf_token=csrfmint"))
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.status().is_redirection());
+
+    let events = snapshot_events();
+    let hit = events
+        .iter()
+        .find(|e| {
+            e.fields.get("action").map(|s| s.as_str()) == Some("login_mint")
+                && e.fields.get("sub").map(|s| s.as_str()) == Some(sub)
+        })
+        .expect("expected a login_mint audit event from the callback");
+    assert_eq!(
+        hit.fields.get("endpoint").map(|s| s.as_str()),
+        Some("callback")
+    );
+    assert!(hit.fields.contains_key("sid"), "sid must be recorded");
+}
+
+/// The sliding re-issue layer stays silent by design (`server.rs`
+/// documents why): it extends an existing session rather than opening
+/// one, and the request's authoritative auth decision was already
+/// logged by the handler. A `login_mint` there would misreport a
+/// keep-alive as a fresh login.
+#[tokio::test]
+async fn session_reissue_emits_no_login_mint_event() {
+    let (_provider, hub) = session_setup().await;
+    let sub = "audit-reissue-no-mint";
+    let token = mint_session(
+        &test_keys(),
+        SessionLifetimes::default(),
+        &identity(sub, "user@posit.co"),
+        epoch_now() - 2 * 3600,
+    )
+    .unwrap();
+
+    let resp = hub
+        .get_health()
+        .header("cookie", cookie_header(&token))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    TestHub::set_auth_cookie(&resp).expect("re-issue fired (precondition)");
+
+    let events = snapshot_events();
+    assert!(
+        !events.iter().any(|e| {
+            e.fields.get("action").map(|s| s.as_str()) == Some("login_mint")
+                && e.fields.get("sub").map(|s| s.as_str()) == Some(sub)
+        }),
+        "a sliding re-issue is not a login"
+    );
+}
+
 // ── H3: `__Host-` prefix on the session cookie ─────────────────────
 
 /// Secure-mode mint uses the `__Host-`-prefixed name with the exact

--- a/crates/quarto-hub/tests/integration/session_auth.rs
+++ b/crates/quarto-hub/tests/integration/session_auth.rs
@@ -533,6 +533,93 @@ async fn auth_session_mints_session_cookie() {
     assert!(attrs.contains(&format!("Max-Age={}", lt.idle_secs)));
 }
 
+// ── H1: /auth/session is the Generic provider's endpoint only ─────
+
+/// `/auth/session` is the *Generic* provider's only mint endpoint.
+/// Google deployments log in through the form-post `/auth/callback`, so
+/// leaving the JSON mint registered there just publishes a second
+/// ID-token replay sink with no caller (bd-zbep24xd).
+#[tokio::test]
+async fn auth_session_not_registered_on_google_provider_hub() {
+    let (provider, hub) = google_session_setup().await;
+    let google = provider.sign(
+        &ClaimsBuilder::from_provider(provider)
+            .sub("google-hub-session-sub")
+            .to_value(),
+    );
+
+    let resp = hub
+        .client
+        .post(hub.url("/auth/session"))
+        .header("x-requested-with", "XMLHttpRequest")
+        .json(&serde_json::json!({ "credential": google }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        404,
+        "Google deployments must not expose the JSON mint endpoint"
+    );
+    assert!(TestHub::set_auth_cookie(&resp).is_none());
+
+    // The form-post callback is still the Google login path.
+    let client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let resp = client
+        .post(hub.url("/auth/callback"))
+        .header("cookie", "g_csrf_token=tok")
+        .header("content-type", "application/x-www-form-urlencoded")
+        .body(format!("credential={google}&g_csrf_token=tok"))
+        .send()
+        .await
+        .unwrap();
+    assert!(
+        resp.status().is_redirection(),
+        "form-post callback still registered, got {}",
+        resp.status()
+    );
+    assert!(TestHub::set_auth_cookie(&resp).is_some());
+}
+
+/// With auth disabled there is nothing to mint a session *from*, so
+/// neither login endpoint is registered.
+#[tokio::test]
+async fn login_endpoints_absent_when_auth_disabled() {
+    static SETUP: tokio::sync::OnceCell<(MockOidcProvider, TestHub)> =
+        tokio::sync::OnceCell::const_new();
+    let (_provider, hub) = SETUP
+        .get_or_init(|| async {
+            install_tracing_once();
+            let provider = MockOidcProvider::start().await;
+            let hub = TestHubBuilder::new().auth_disabled().start(&provider).await;
+            (provider, hub)
+        })
+        .await;
+
+    let resp = hub
+        .client
+        .post(hub.url("/auth/session"))
+        .header("x-requested-with", "XMLHttpRequest")
+        .json(&serde_json::json!({ "credential": "irrelevant" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 404);
+
+    let resp = hub
+        .client
+        .post(hub.url("/auth/callback"))
+        .header("content-type", "application/x-www-form-urlencoded")
+        .body("credential=irrelevant")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 404);
+}
+
 /// The One-Tap renewal endpoint was renamed `/auth/refresh` → `/auth/session`
 /// (bd-s042qcxj); the old path must no longer be registered.
 #[tokio::test]

--- a/crates/quarto-hub/tests/integration/session_auth.rs
+++ b/crates/quarto-hub/tests/integration/session_auth.rs
@@ -20,8 +20,8 @@ use quarto_hub::session::{
 };
 
 use crate::support::{
-    ClaimsBuilder, MockOidcProvider, TEST_SESSION_SECRET, TestHub, TestHubBuilder,
-    install_tracing_once, snapshot_events,
+    AUTH_COOKIE_NAME_LEGACY, AUTH_COOKIE_NAME_SECURE, ClaimsBuilder, MockOidcProvider,
+    TEST_SESSION_SECRET, TestHub, TestHubBuilder, install_tracing_once, snapshot_events,
 };
 
 // ── fixtures ──────────────────────────────────────────────────────
@@ -95,7 +95,32 @@ fn mint_test_session(sub: &str, email: &str) -> String {
 }
 
 fn cookie_header(token: &str) -> String {
-    format!("quarto_hub_token={token}")
+    format!("{AUTH_COOKIE_NAME_LEGACY}={token}")
+}
+
+/// Cookie header a browser would send to a **secure-mode** hub, where
+/// the session cookie carries the `__Host-` prefix (H3).
+fn secure_cookie_header(token: &str) -> String {
+    format!("{AUTH_COOKIE_NAME_SECURE}={token}")
+}
+
+/// Secure-mode Generic hub with the known session secret. Secure mode
+/// is what puts the `__Host-` prefix on the session cookie.
+async fn secure_session_setup() -> &'static (MockOidcProvider, TestHub) {
+    static SETUP: tokio::sync::OnceCell<(MockOidcProvider, TestHub)> =
+        tokio::sync::OnceCell::const_new();
+    SETUP
+        .get_or_init(|| async {
+            install_tracing_once();
+            let provider = MockOidcProvider::start().await;
+            let hub = TestHubBuilder::new()
+                .secure()
+                .session_secret(TEST_SESSION_SECRET)
+                .start(&provider)
+                .await;
+            (provider, hub)
+        })
+        .await
 }
 
 // ── C2: session cookie accepted on the central path ───────────────
@@ -531,6 +556,139 @@ async fn auth_session_mints_session_cookie() {
     assert!(attrs.contains("SameSite=Lax"));
     assert!(attrs.contains("Path=/"));
     assert!(attrs.contains(&format!("Max-Age={}", lt.idle_secs)));
+}
+
+// ── H3: `__Host-` prefix on the session cookie ─────────────────────
+
+/// Secure-mode mint uses the `__Host-`-prefixed name with the exact
+/// attributes the prefix requires: `Secure`, `Path=/`, and **no**
+/// `Domain`. The prefix is what makes a sibling subdomain unable to
+/// toss a cookie into this host's jar (bd-gt2hhrcg).
+#[tokio::test]
+async fn secure_mint_sets_host_prefixed_cookie() {
+    let (provider, hub) = secure_session_setup().await;
+    let google = provider.sign(
+        &ClaimsBuilder::from_provider(provider)
+            .sub("host-prefix-sub")
+            .email("hostpfx@posit.co")
+            .to_value(),
+    );
+
+    let resp = hub
+        .client
+        .post(hub.url("/auth/session"))
+        .header("x-requested-with", "XMLHttpRequest")
+        .json(&serde_json::json!({ "credential": google }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let (value, attrs) = TestHub::find_set_cookie(&resp, AUTH_COOKIE_NAME_SECURE)
+        .expect("__Host- prefixed session cookie set");
+    // A real hub session token, not the submitted Google JWT.
+    verify_session(
+        &test_keys(),
+        SessionLifetimes::default(),
+        &value,
+        epoch_now(),
+    )
+    .unwrap();
+
+    assert!(attrs.contains("Secure"), "__Host- requires Secure: {attrs}");
+    assert!(attrs.contains("Path=/"), "__Host- requires Path=/: {attrs}");
+    assert!(attrs.contains("HttpOnly"));
+    assert!(!attrs.contains("Domain"), "__Host- forbids Domain: {attrs}");
+}
+
+/// In secure mode the prefixed name is the credential and the legacy
+/// name is not. Accepting both would defeat the prefix: an attacker who
+/// can set cookies on a sibling subdomain could still pin a victim to a
+/// session of their choosing.
+#[tokio::test]
+async fn secure_hub_accepts_prefixed_name_and_ignores_legacy() {
+    let (_provider, hub) = secure_session_setup().await;
+    let token = mint_test_session("host-accept-sub", "user@posit.co");
+
+    let resp = hub
+        .get_health()
+        .header("cookie", secure_cookie_header(&token))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200, "__Host- name authenticates");
+
+    // Byte-identical token under the pre-H3 name: not a credential.
+    let resp = hub
+        .get_health()
+        .header("cookie", cookie_header(&token))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        401,
+        "legacy cookie name must not authenticate in secure mode"
+    );
+}
+
+/// Rollout hygiene: a secure-mode login clears any lingering
+/// legacy-name cookie so it cannot sit in the jar unused.
+#[tokio::test]
+async fn secure_mint_clears_legacy_cookie_name() {
+    let (provider, hub) = secure_session_setup().await;
+    let google = provider.sign(
+        &ClaimsBuilder::from_provider(provider)
+            .sub("legacy-clear-sub")
+            .to_value(),
+    );
+
+    let resp = hub
+        .client
+        .post(hub.url("/auth/session"))
+        .header("x-requested-with", "XMLHttpRequest")
+        .json(&serde_json::json!({ "credential": google }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let (value, attrs) = TestHub::find_set_cookie(&resp, AUTH_COOKIE_NAME_LEGACY)
+        .expect("legacy-name clear emitted on login");
+    assert_eq!(value, "", "legacy cookie is cleared, not set");
+    assert!(attrs.contains("Max-Age=0"), "{attrs}");
+}
+
+/// `--allow-insecure-auth` has no TLS, and `__Host-` *requires*
+/// `Secure` — so insecure mode keeps the bare name and must not emit a
+/// clear for it (that would delete the live session).
+#[tokio::test]
+async fn insecure_hub_keeps_unprefixed_cookie_name() {
+    let (provider, hub) = session_setup().await;
+    let google = provider.sign(
+        &ClaimsBuilder::from_provider(provider)
+            .sub("insecure-name-sub")
+            .to_value(),
+    );
+
+    let resp = hub
+        .client
+        .post(hub.url("/auth/session"))
+        .header("x-requested-with", "XMLHttpRequest")
+        .json(&serde_json::json!({ "credential": google }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    assert!(
+        TestHub::find_set_cookie(&resp, AUTH_COOKIE_NAME_SECURE).is_none(),
+        "insecure mode cannot use __Host- (it requires Secure)"
+    );
+    let (value, attrs) = TestHub::find_set_cookie(&resp, AUTH_COOKIE_NAME_LEGACY)
+        .expect("bare-name session cookie set");
+    assert!(!value.is_empty(), "must be the session token, not a clear");
+    assert!(!attrs.contains("Secure"));
 }
 
 // ── H1: /auth/session is the Generic provider's endpoint only ─────
@@ -1012,20 +1170,7 @@ async fn non_allowlisted_old_session_not_reissued() {
 
 #[tokio::test]
 async fn reissue_preserves_secure_flag_on_secure_hub() {
-    static SETUP: tokio::sync::OnceCell<(MockOidcProvider, TestHub)> =
-        tokio::sync::OnceCell::const_new();
-    let (_provider, hub) = SETUP
-        .get_or_init(|| async {
-            install_tracing_once();
-            let provider = MockOidcProvider::start().await;
-            let hub = TestHubBuilder::new()
-                .secure()
-                .session_secret(TEST_SESSION_SECRET)
-                .start(&provider)
-                .await;
-            (provider, hub)
-        })
-        .await;
+    let (_provider, hub) = secure_session_setup().await;
 
     let lt = SessionLifetimes::default();
     let token = mint_session(
@@ -1038,13 +1183,16 @@ async fn reissue_preserves_secure_flag_on_secure_hub() {
 
     let resp = hub
         .get_health()
-        .header("cookie", cookie_header(&token))
+        .header("cookie", secure_cookie_header(&token))
         .send()
         .await
         .unwrap();
     assert_eq!(resp.status(), 200);
     let (_, attrs) = TestHub::set_auth_cookie(&resp).expect("re-issued cookie");
     assert!(attrs.contains("Secure"), "Secure preserved on re-issue");
+    // Re-issue routes through the same name helper as mint, so the
+    // sliding cookie keeps the `__Host-` prefix (H3).
+    assert!(attrs.starts_with(&format!("{AUTH_COOKIE_NAME_SECURE}=")));
 }
 
 #[tokio::test]

--- a/crates/quarto-hub/tests/integration/support.rs
+++ b/crates/quarto-hub/tests/integration/support.rs
@@ -223,6 +223,10 @@ pub struct ClaimsBuilder {
     iat: Option<i64>,
     nbf: Option<i64>,
     exp: i64,
+    /// OIDC `nonce`, echoed by the IdP from the authorization request.
+    /// Omitted from the payload when `None`, which is what a pre-H2
+    /// client (or a replayed token from another login) looks like.
+    nonce: Option<String>,
 }
 
 impl ClaimsBuilder {
@@ -240,6 +244,7 @@ impl ClaimsBuilder {
             iat: Some(now - 5),
             nbf: None,
             exp: now + 600,
+            nonce: None,
         }
     }
 
@@ -281,6 +286,12 @@ impl ClaimsBuilder {
         self.exp = exp;
         self
     }
+    /// Set the OIDC `nonce` claim (H2). Leave unset to model a token
+    /// that carries none.
+    pub fn nonce(mut self, nonce: impl Into<String>) -> Self {
+        self.nonce = Some(nonce.into());
+        self
+    }
     pub fn to_value(&self) -> JsonValue {
         let mut v = json!({
             "iss": self.iss,
@@ -306,6 +317,9 @@ impl ClaimsBuilder {
         if let Some(nbf) = self.nbf {
             m.insert("nbf".into(), JsonValue::Number(nbf.into()));
         }
+        if let Some(nonce) = &self.nonce {
+            m.insert("nonce".into(), JsonValue::String(nonce.clone()));
+        }
         v
     }
 }
@@ -324,6 +338,14 @@ pub const AUTH_COOKIE_NAME_SECURE: &str = "__Host-quarto_hub_token";
 /// pre-H3 name everywhere. `__Host-` requires `Secure`, which requires
 /// TLS, so insecure mode cannot use the prefixed form.
 pub const AUTH_COOKIE_NAME_LEGACY: &str = "quarto_hub_token";
+
+/// Sealed login-state cookie name in secure mode (H2). `__Secure-`
+/// rather than `__Host-` because the cookie is scoped to `Path=/auth`,
+/// which `__Host-` forbids.
+pub const LOGIN_STATE_COOKIE_SECURE: &str = "__Secure-quarto_hub_login";
+
+/// Sealed login-state cookie name under `--allow-insecure-auth`.
+pub const LOGIN_STATE_COOKIE_LEGACY: &str = "quarto_hub_login";
 
 pub struct TestHub {
     pub base_url: String,

--- a/crates/quarto-hub/tests/integration/support.rs
+++ b/crates/quarto-hub/tests/integration/support.rs
@@ -317,6 +317,14 @@ impl ClaimsBuilder {
 /// hub accept them.
 pub const TEST_SESSION_SECRET: [u8; 32] = [0x42; 32];
 
+/// Session-cookie name in secure (TLS) mode — `__Host-` prefixed (H3).
+pub const AUTH_COOKIE_NAME_SECURE: &str = "__Host-quarto_hub_token";
+
+/// Session-cookie name under `--allow-insecure-auth`, and the
+/// pre-H3 name everywhere. `__Host-` requires `Secure`, which requires
+/// TLS, so insecure mode cannot use the prefixed form.
+pub const AUTH_COOKIE_NAME_LEGACY: &str = "quarto_hub_token";
+
 pub struct TestHub {
     pub base_url: String,
     pub client: reqwest::Client,
@@ -547,18 +555,31 @@ impl TestHub {
         self.client.post(self.url("/auth/logout"))
     }
 
-    /// Extract the `quarto_hub_token` value from a response's
-    /// `Set-Cookie` headers, plus the full attribute string.
-    /// Returns `None` when no auth cookie was set.
+    /// Extract the session-cookie value from a response's `Set-Cookie`
+    /// headers, plus the full attribute string. Returns `None` when no
+    /// auth cookie was set.
+    ///
+    /// The hub's cookie name is mode-dependent (H3): `__Host-`-prefixed
+    /// under TLS, bare under `--allow-insecure-auth`. The prefixed name
+    /// is checked **first** so a secure-mode mint — which also emits a
+    /// legacy-name *clear* — yields the real token, not the clear.
     pub fn set_auth_cookie(resp: &reqwest::Response) -> Option<(String, String)> {
+        Self::find_set_cookie(resp, AUTH_COOKIE_NAME_SECURE)
+            .or_else(|| Self::find_set_cookie(resp, AUTH_COOKIE_NAME_LEGACY))
+    }
+
+    /// Extract a specific `Set-Cookie` by cookie name, as
+    /// `(value, full_attribute_string)`.
+    pub fn find_set_cookie(resp: &reqwest::Response, name: &str) -> Option<(String, String)> {
+        let prefix = format!("{name}=");
         resp.headers()
             .get_all(http::header::SET_COOKIE)
             .iter()
             .filter_map(|v| v.to_str().ok())
-            .find(|v| v.starts_with("quarto_hub_token="))
+            .find(|v| v.starts_with(&prefix))
             .map(|v| {
                 let value = v
-                    .strip_prefix("quarto_hub_token=")
+                    .strip_prefix(&prefix)
                     .unwrap()
                     .split(';')
                     .next()

--- a/crates/quarto-hub/tests/integration/support.rs
+++ b/crates/quarto-hub/tests/integration/support.rs
@@ -335,6 +335,7 @@ pub struct TestHubBuilder {
     session_secret: Option<[u8; 32]>,
     previous_session_secret: Option<[u8; 32]>,
     google_provider: bool,
+    auth_disabled: bool,
     banned_subs: Vec<String>,
 }
 
@@ -352,8 +353,17 @@ impl TestHubBuilder {
             session_secret: None,
             previous_session_secret: None,
             google_provider: false,
+            auth_disabled: false,
             banned_subs: Vec::new(),
         }
+    }
+
+    /// Start the hub with `auth_config: None` — the no-auth deployment
+    /// shape. Auth-conditional routes (`/auth/session`,
+    /// `/auth/callback`) must not be registered.
+    pub fn auth_disabled(mut self) -> Self {
+        self.auth_disabled = true;
+        self
     }
 
     pub fn allowed_domains(mut self, domains: &[&str]) -> Self {
@@ -470,7 +480,7 @@ impl TestHubBuilder {
             host: "127.0.0.1".to_string(),
             sync_interval_secs: None,
             watch_enabled: false,
-            auth_config: Some(auth_config),
+            auth_config: (!self.auth_disabled).then_some(auth_config),
             allow_insecure_auth: self.allow_insecure_auth,
             register_root_ws: false,
             ..HubConfig::default()
@@ -480,17 +490,20 @@ impl TestHubBuilder {
         let ctx: SharedContext = Arc::new(ctx);
 
         // Inject the auth state ourselves, bypassing OIDC discovery so the
-        // mock provider's http:// URLs are usable in tests.
-        let audiences = vec![SPA_CLIENT_ID.to_string(), MCP_CLIENT_ID.to_string()];
-        let auth_state = auth::build_auth_state_from_parts(
-            provider.jwks_url.clone(),
-            vec![Algorithm::RS256],
-            audiences,
-            provider.issuer.clone(),
-        )
-        .await
-        .expect("build auth state");
-        ctx.set_auth_state(auth_state).expect("set auth state");
+        // mock provider's http:// URLs are usable in tests. Skipped for a
+        // no-auth hub, which has no JWKS decoder to install.
+        if !self.auth_disabled {
+            let audiences = vec![SPA_CLIENT_ID.to_string(), MCP_CLIENT_ID.to_string()];
+            let auth_state = auth::build_auth_state_from_parts(
+                provider.jwks_url.clone(),
+                vec![Algorithm::RS256],
+                audiences,
+                provider.issuer.clone(),
+            )
+            .await
+            .expect("build auth state");
+            ctx.set_auth_state(auth_state).expect("set auth state");
+        }
 
         let router = build_router_with_state(ctx.clone()).await.unwrap();
         let router = router.with_state(ctx);

--- a/dev-docs/quarto-hub/session-auth-operations.md
+++ b/dev-docs/quarto-hub/session-auth-operations.md
@@ -7,8 +7,9 @@ Operational reference for the hub's server-minted sliding sessions
 ## The session model in one paragraph
 
 The hub validates a user's Google ID token **once** at login, then
-mints its own compact HS256 session token into the `quarto_hub_token`
-HttpOnly cookie (~400 bytes). The session **slides**: authenticated
+mints its own compact HS256 session token into an HttpOnly session
+cookie (~400 bytes) — named `__Host-quarto_hub_token` under TLS, or
+`quarto_hub_token` in insecure dev mode. The session **slides**: authenticated
 HTTP activity re-issues the cookie (at most ~1/hour), up to an **idle
 timeout** (default 7 days) and an **absolute lifetime cap** (default
 30 days, anchored at login — re-issue can never extend past it). The
@@ -37,9 +38,15 @@ Notes:
 - **Multi-instance:** hubs sharing `QUARTO_HUB_SESSION_SECRET` via env
   accept each other's session cookies. Per-hub auto-generated secrets
   give per-instance isolation.
-- Serve the hub from an origin with **no untrusted sibling
-  subdomains** (cookie-planting residual until a `__Host-` cookie-name
-  upgrade; see plan §6).
+- **Cookie name is TLS-mode dependent** (H3, `bd-gt2hhrcg`): secure
+  deployments use `__Host-quarto_hub_token`; only
+  `--allow-insecure-auth` uses the bare `quarto_hub_token` (the
+  `__Host-` prefix requires `Secure`, which requires TLS). The prefix
+  is browser-enforced — a sibling subdomain cannot plant one — which
+  closes the cookie-planting residual previously called out here. In
+  secure mode the bare name is **not** accepted as a credential, so the
+  H3 rollout invalidates outstanding sessions once (users re-log-in);
+  a login also emits a clear for the bare name so it doesn't linger.
 
 ## Rotating the session secret
 

--- a/dev-docs/quarto-hub/session-auth-operations.md
+++ b/dev-docs/quarto-hub/session-auth-operations.md
@@ -132,3 +132,17 @@ or a legacy Google-JWT cookie), `session_expired`,
 `session_absolute_cap`, `session_tampered`, `session_revoked`,
 `user_banned`, `user_not_allowlisted`, `conflicting_credentials`.
 Token contents are never logged.
+
+Actions, by what they mean:
+
+| `action` | Meaning |
+|---|---|
+| `auth_ok` / `auth_fail` | Per-request authentication decision. |
+| `login_mint` | A **new session family** was created. Carries `sub`, the new `sid`, and `endpoint=callback\|session` (which login path). |
+| `revoke_all_sessions` | Logout-everywhere: every prior session for `sub` is dead. |
+
+`login_mint` is the one to join sessions against: `sid` is immutable
+across sliding re-issues, so it identifies a login for as long as that
+session lives. **Sliding re-issue is deliberately silent** — it extends
+a session rather than opening one, so a keep-alive never looks like a
+fresh login.

--- a/dev-docs/quarto-hub/session-auth-operations.md
+++ b/dev-docs/quarto-hub/session-auth-operations.md
@@ -48,6 +48,43 @@ Notes:
   H3 rollout invalidates outstanding sessions once (users re-log-in);
   a login also emits a clear for the bare name so it doesn't linger.
 
+## Login nonce (Google flow)
+
+The Google login is a two-request flow. `GET /auth/nonce` mints a random
+nonce, returns it to the SPA (which hands it to Google Identity
+Services), and seals a copy into a short-lived HMAC-signed cookie —
+`__Secure-quarto_hub_login`, `SameSite=None; HttpOnly; Path=/auth`, 10
+minute lifetime. `POST /auth/callback` then requires the ID token's
+`nonce` claim to match that cookie.
+
+This is what stops a **captured ID token from being replayed** to mint a
+session: signature, `iss`, `aud`, and `exp` all still validate for a
+stolen token, so before the nonce the hub had no way to tell whether a
+token belonged to a login *it* started. The blob is single-use — the
+callback clears the cookie on every exit path.
+
+Operational notes:
+
+- **`SameSite=None` is required, not lax.** Google delivers the
+  credential by cross-site form POST; a `Lax` cookie is not attached to
+  it. That in turn requires `Secure`, hence TLS.
+- **Enforcement is unconditional in secure mode**, and **skipped under
+  `--allow-insecure-auth`** (that cookie cannot work over plain HTTP).
+  The skip logs at WARN on every login — if you see
+  `nonce verification skipped` in a deployment that is meant to be
+  production, the hub is running with the dev flag.
+- **Rejections** appear as `auth_fail` with
+  `detail=login_state_<class>`: `login_state_missing` (no cookie —
+  the replay shape), `nonce_mismatch`, `token_nonce_missing` (client too
+  old to send one), `expired`, `tampered`, `kid_mismatch`.
+- **Rollout:** a user holding a stale SPA bundle fails login once to
+  `/?auth_error` and recovers on reload. Hub and client deploy together.
+- **Scope:** the Google callback only. `/auth/session` (the Generic
+  provider's JSON mint) is not nonce-bound and remains replay-able
+  within the submitted token's validity.
+- Sealed blobs verify against the **previous** secret during a graceful
+  rotation overlap, so a login started just before a rotation completes.
+
 ## Rotating the session secret
 
 Two modes. **The distinction is security-critical.**

--- a/hub-client/changelog.md
+++ b/hub-client/changelog.md
@@ -25,7 +25,7 @@ WASM rebuild is needed for a changelog-only edit.
 
 ### 2026-07-28
 
-- [`807fd96c`](https://github.com/quarto-dev/q2/commits/807fd96c): Signing in with Google is now tied to the specific sign-in you started, so a copied Google token can no longer be used to open a session on your behalf. The sign-in button appears a moment after the screen loads while that handshake is set up.
+- [`807fd96c`](https://github.com/quarto-dev/q2/commits/807fd96c): Signing in with Google is now tied to the specific sign-in you started, so a copied Google token can no longer be used to open a session on your behalf.
 - [`9a673bbc`](https://github.com/quarto-dev/q2/commits/9a673bbc): Sign-in sessions are now stored in a host-locked browser cookie (`__Host-`), which a neighbouring subdomain cannot plant or overwrite. You will be asked to sign in once more after this update.
 
 ### 2026-07-27

--- a/hub-client/changelog.md
+++ b/hub-client/changelog.md
@@ -23,6 +23,10 @@ WASM rebuild is needed for a changelog-only edit.
 
 -->
 
+### 2026-07-28
+
+- [`9a673bbc`](https://github.com/quarto-dev/q2/commits/9a673bbc): Sign-in sessions are now stored in a host-locked browser cookie (`__Host-`), which a neighbouring subdomain cannot plant or overwrite. You will be asked to sign in once more after this update.
+
 ### 2026-07-27
 
 - [`d419d32`](https://github.com/quarto-dev/q2/commits/d419d32): Opening a document now connects to the live document straight away, so the connection indicator no longer briefly shows "Offline" before switching to "Online" on a normal connection.

--- a/hub-client/changelog.md
+++ b/hub-client/changelog.md
@@ -25,6 +25,7 @@ WASM rebuild is needed for a changelog-only edit.
 
 ### 2026-07-28
 
+- [`807fd96c`](https://github.com/quarto-dev/q2/commits/807fd96c): Signing in with Google is now tied to the specific sign-in you started, so a copied Google token can no longer be used to open a session on your behalf. The sign-in button appears a moment after the screen loads while that handshake is set up.
 - [`9a673bbc`](https://github.com/quarto-dev/q2/commits/9a673bbc): Sign-in sessions are now stored in a host-locked browser cookie (`__Host-`), which a neighbouring subdomain cannot plant or overwrite. You will be asked to sign in once more after this update.
 
 ### 2026-07-27

--- a/hub-client/src/auth/GoogleAuthProvider.test.tsx
+++ b/hub-client/src/auth/GoogleAuthProvider.test.tsx
@@ -6,40 +6,111 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, cleanup } from '@testing-library/react';
+import { render, cleanup, screen, waitFor } from '@testing-library/react';
 
 // Capture mock state at module scope so each test can inspect / drive it.
 let lastGoogleLoginProps: {
   ux_mode?: string;
   login_uri?: string;
+  nonce?: string;
 } | null = null;
+
+let googleLoginRenderCount = 0;
 
 const mockGoogleLogout = vi.fn();
 
 vi.mock('@react-oauth/google', () => ({
   GoogleLogin: (props: typeof lastGoogleLoginProps) => {
     lastGoogleLoginProps = props;
-    return null;
+    googleLoginRenderCount += 1;
+    return <div data-testid="gis-button" />;
   },
   googleLogout: () => mockGoogleLogout(),
 }));
 
 import { googleAuthProvider } from './GoogleAuthProvider';
 
+/** Stub `fetch` with a successful `/auth/nonce` response. */
+function stubNonce(nonce: string) {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ nonce }),
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
 beforeEach(() => {
   lastGoogleLoginProps = null;
+  googleLoginRenderCount = 0;
   mockGoogleLogout.mockClear();
 });
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
 
 describe('GoogleAuthProvider.SignInButton', () => {
-  it('renders GoogleLogin in redirect mode with the given loginUri', () => {
+  it('renders GoogleLogin in redirect mode with the given loginUri', async () => {
+    stubNonce('nonce-abc');
     render(<googleAuthProvider.SignInButton loginUri="/auth/callback" />);
 
-    expect(lastGoogleLoginProps).not.toBeNull();
+    await waitFor(() => expect(lastGoogleLoginProps).not.toBeNull());
     expect(lastGoogleLoginProps?.ux_mode).toBe('redirect');
     expect(lastGoogleLoginProps?.login_uri).toBe('/auth/callback');
+  });
+
+  it('fetches a nonce from the hub and passes it to GIS', async () => {
+    // Server-verified nonce (H2): GIS puts this in the ID token, and the
+    // hub's /auth/callback requires it to match the sealed cookie the
+    // same pre-flight set.
+    const fetchMock = stubNonce('nonce-xyz');
+    render(<googleAuthProvider.SignInButton loginUri="/auth/callback" />);
+
+    await waitFor(() => expect(lastGoogleLoginProps?.nonce).toBe('nonce-xyz'));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe('/auth/nonce');
+  });
+
+  it('does not render GIS before the nonce arrives', async () => {
+    // Load-bearing: @react-oauth/google forwards `nonce` into
+    // `google.accounts.id.initialize` from an effect whose dependency
+    // list does NOT include it. A nonce that arrives after the first
+    // render would therefore never reach GIS, and every login would fail
+    // the server check. Gating the render is what makes the prop stick.
+    let resolveFetch: (value: unknown) => void = () => {};
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockReturnValue(new Promise((resolve) => {
+        resolveFetch = resolve;
+      })),
+    );
+
+    render(<googleAuthProvider.SignInButton loginUri="/auth/callback" />);
+    expect(googleLoginRenderCount).toBe(0);
+    expect(lastGoogleLoginProps).toBeNull();
+
+    resolveFetch({ ok: true, json: async () => ({ nonce: 'late' }) });
+    await waitFor(() => expect(lastGoogleLoginProps?.nonce).toBe('late'));
+  });
+
+  it('shows an error instead of a nonce-less button when the pre-flight fails', async () => {
+    // Rendering GIS without a nonce would produce a login that always
+    // fails at the callback — worse than saying so up front.
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')));
+    render(<googleAuthProvider.SignInButton loginUri="/auth/callback" />);
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeDefined());
+    expect(googleLoginRenderCount).toBe(0);
+  });
+
+  it('treats a non-OK pre-flight response as a failure', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 500 }));
+    render(<googleAuthProvider.SignInButton loginUri="/auth/callback" />);
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeDefined());
+    expect(googleLoginRenderCount).toBe(0);
   });
 });
 

--- a/hub-client/src/auth/GoogleAuthProvider.tsx
+++ b/hub-client/src/auth/GoogleAuthProvider.tsx
@@ -7,17 +7,81 @@
  * wrap stays in `main.tsx` (see Phase 3 of
  * `claude-notes/plans/2026-05-20-auth-provider-interface.md`); this
  * module does not produce its own provider scope.
+ *
+ * The login nonce (H2) is fetched here rather than passed down through
+ * `SignInButtonProps`: a nonce is a GIS concern, and widening the
+ * provider-agnostic interface with a Google-specific field would leak
+ * this provider's mechanics into every other one.
  */
 
+import { useEffect, useState } from 'react';
 import { GoogleLogin, googleLogout } from '@react-oauth/google';
 
+import { hubPath } from '../utils/routing';
 import type { AuthProvider, SignInButtonProps } from './AuthProvider';
 
+/**
+ * Fetch a login nonce from the hub's pre-flight endpoint.
+ *
+ * The response body carries the nonce for GIS; the hub simultaneously
+ * sets a sealed HttpOnly cookie holding the same value, which it
+ * verifies when Google POSTs the credential back. Returns `null` on any
+ * failure — the caller must not fall back to a nonce-less login, which
+ * the hub would reject.
+ */
+async function fetchLoginNonce(): Promise<string | null> {
+  try {
+    const response = await fetch(hubPath('/auth/nonce'), {
+      // The pre-flight's whole purpose is the cookie it sets.
+      credentials: 'include',
+    });
+    if (!response.ok) return null;
+    const body = await response.json();
+    return typeof body?.nonce === 'string' && body.nonce.length > 0 ? body.nonce : null;
+  } catch {
+    return null;
+  }
+}
+
 function SignInButton({ loginUri }: SignInButtonProps) {
+  const [nonce, setNonce] = useState<string | null>(null);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchLoginNonce().then((value) => {
+      if (cancelled) return;
+      if (value) setNonce(value);
+      else setFailed(true);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (failed) {
+    return (
+      <p role="alert" style={{ color: 'var(--posit-red)', fontSize: '14px', margin: 0 }}>
+        Could not start sign-in. Please reload the page.
+      </p>
+    );
+  }
+
+  // Deliberately render nothing until the nonce is in hand.
+  // `@react-oauth/google` forwards `nonce` into
+  // `google.accounts.id.initialize` from an effect whose dependency list
+  // does not include it, so a nonce arriving after the first render
+  // would never reach GIS — and every login would then fail the hub's
+  // check. Gating the mount is what guarantees the prop is applied.
+  if (!nonce) {
+    return null;
+  }
+
   return (
     <GoogleLogin
       ux_mode="redirect"
       login_uri={loginUri}
+      nonce={nonce}
       onSuccess={() => {
         // Not called in redirect mode — credential arrives via HttpOnly
         // cookie set by the server-side redirect callback.


### PR DESCRIPTION
Four independent hardenings of the login flow that exists **today** — none of them require the hub to become an OAuth client, so nothing here is wasted if Epic 2's pattern (ii) lands (and H2's sealed-cookie helper is a direct stepping stone to its `OidcState`). Plan: `claude-notes/plans/2026-07-27-auth-current-flow-hardening.md`, epic `bd-uv8xynxk`.

| Item | What | Closes |
|---|---|---|
| H1 | `POST /auth/session` registered only for Generic OIDC deployments | a second ID-token replay sink, with zero callers on Google hubs |
| **H2** | **server-verified `nonce` in the GIS login** | **the audit's main gap: any captured Google ID token could be replayed to a mint endpoint for its full ~1 h validity** |
| H3 | `__Host-` prefix on the session cookie | subdomain cookie-planting / session fixation |
| H5 | distinct `login_mint` audit event | mints were indistinguishable from per-request auth in the log |

**H2, the substantive one.** `GET /auth/nonce` mints a 256-bit nonce, returns it to the SPA (which hands it to GIS), and seals a copy into a short-lived HMAC-signed cookie; `/auth/callback` then requires the ID token's `nonce` claim to match. No server-side state — the cookie *is* the state, and the HMAC is what makes trusting it safe. The blob is single-use: every exit path from the callback clears it, enforced by routing failures through one closure. Because sealed blobs share the session keyring, domain separation is doubled (distinct `iss` *and* a required `typ`) and asserted in both directions, at the unit level and again over HTTP.

Under `--allow-insecure-auth` the `SameSite=None;` Secure cookie cannot function, so enforcement is skipped and logged at WARN on every login — a loud signal if the dev flag ever reaches production.

**Rollout:** H3 invalidates existing sessions once, so everyone signs in again after deploy. A user on a stale SPA bundle (no nonce) fails to `/?auth_error` and recovers on reload; hub and client deploy together.

**Tests.** Full \`cargo xtask verify\` green (all 14 steps, incl. the WASM rebuild and hub-client build/tests); 10631 workspace tests pass. H2 adds 9 unit tests on the sealed primitive, 13 integration, and 4 client tests.

**Not verified, explicitly:** no real GIS browser login — it needs a Google client ID whose authorized origin covers the test host, which this environment does not have. H2's nonce round-trip is covered by integration and client tests only. Tracked as \`bd-fcv3q5kl\`, an open child of the epic, so it gates sign-off.