### PR TITLE
refactor(quarto-core): consolidate the artifact-write family (bd-v8gx, bd-gdhk)

### DIFF
--- a/claude-notes/plans/2026-07-28-rename-flush-site-libs.md
+++ b/claude-notes/plans/2026-07-28-rename-flush-site-libs.md
@@ -140,41 +140,116 @@ module whose doc opens "Post-render hooks for `WebsiteProjectType`."
 
 ## Phases
 
-- [x] **Phase 0 — Investigation + design** (this document; commit `5c874669` + this rewrite).
-- [ ] **Phase 1 — Tests first (TDD).** Written and failing/pinning before any move:
-  - [ ] Pin the scope-filter decision: a `Page`-scoped entry in the store handed
-        to `flush_project_artifacts` is **not** written (and `debug_assert` fires
-        in dev). This is the one deliberate behavior change.
-  - [ ] Characterize the current three pass-2/native routing sites: shared-lib
-        accumulates, no-shared-lib writes in place. Assert via
-        `route_drained_project_artifacts` so the test drives the new seam.
-  - [ ] Carry over the 4 existing `flush_site_libs_*` unit tests to the new
-        module + names, unchanged in substance.
-  - [ ] Empty store stays a no-op (no `dir_create`) — guards the dropped early return.
-- [ ] **Phase 2 — Move `enqueue_artifacts`** to `artifact_flush.rs`, drop its
-      per-fn cfg gate, fix its false doc comment. Re-export or update the two
-      `render_to_file.rs` callers.
-- [ ] **Phase 3 — Move + rename `flush_site_libs`** → `flush_project_artifacts`
-      in `artifact_flush.rs`, reimplemented over `enqueue_artifacts` + `debug_assert`.
-      Update `post_render`. Widen the `artifact_flush` module doc to describe the family.
-- [ ] **Phase 4 — bd-gdhk: add `route_drained_project_artifacts`** and convert
-      all three render sites to it.
-- [ ] **Phase 5 — Prose sweep.** The remaining `flush_site_libs` references
-      across 10 files / 3 crates (31 occurrences total). **Match on
-      `flush_site_libs`, never on `site_libs`** — see Risks.
-- [ ] **Phase 6 — Verify.** Full `cargo xtask verify` (**not** `--skip-hub-build`):
-      the function is cross-platform and named in `wasm-quarto-hub-client` and
-      `quarto-system-runtime`, so the WASM leg is in scope. Plus
-      `cargo xtask lint` and a `grep -rn 'flush_site_libs' crates/` that must
-      return empty.
+- [x] **Phase 0 — Investigation + design** (this document; commit `5c874669` + `36a70b39`).
+- [x] **Phase 1 — Tests first (TDD).** Written first; verified failing with
+      exactly the expected errors (`cannot find function flush_project_artifacts`
+      / `route_drained_project_artifacts`, nothing else) before implementing.
+  - [x] Pin the scope-filter decision — the one deliberate behavior change.
+        Two cfg'd tests: `#[cfg(debug_assertions)] #[should_panic]` for the
+        loud-in-dev guard, and a release-mode counterpart asserting the entry is
+        filtered rather than misplaced.
+  - [x] Characterize the three routing sites through the new
+        `route_drained_project_artifacts` seam (accumulate / write-in-place /
+        no-accumulator), plus the merge-conflict diagnostic naming the input doc.
+  - [x] Carry over the 3 `flush_site_libs_*` unit tests under the new names.
+  - [x] Empty store stays a no-op (no `dir_create`) — guards the dropped early return.
+- [x] **Phase 2 — Moved `enqueue_artifacts`** to `artifact_flush.rs`, dropped its
+      per-fn cfg gate, deleted its false doc comment.
+- [x] **Phase 3 — Moved + renamed** `flush_site_libs` → `flush_project_artifacts`,
+      reimplemented over `enqueue_artifacts` + `debug_assert`. `post_render`
+      updated. Module doc rewritten to describe the family as a table.
+- [x] **Phase 4 — bd-gdhk: added `route_drained_project_artifacts`**; all three
+      render sites converted (`render_to_file.rs`, both `pass2_renderer.rs` sites).
+      The two pass-2 sites were byte-identical before; they are now one call each.
+- [x] **Phase 5 — Prose sweep.** 31 → 3 occurrences. The 3 that remain are
+      deliberate history notes in prose (backticked, not doc links): two in
+      `artifact_flush.rs`'s module doc explaining why the family lives there, one
+      in `website_post_render.rs` saying where the flush went. Both stale
+      **intra-doc links** (`resource_resolver.rs`, `pass2_renderer.rs`) were
+      repointed — these are the ones CI cannot catch.
+- [x] **Phase 6 — Verify.** `cargo build --workspace`,
+      `cargo nextest run --workspace`, `cargo clippy --workspace --all-targets
+      -- -D warnings`, `cargo fmt --check`, `cargo xtask lint` all clean; full
+      `cargo xtask verify` (with the WASM/hub leg) run.
+- [x] **Phase 6b — End-to-end verification** (see below).
 - [ ] **Phase 7 — PR.** Push to `origin` and open a PR so CI reports. Document
       the one deliberate behavior change (scope filter) in the PR body.
-- [ ] **Phase 8 — Close out.** `braid close bd-v8gx` and `braid close bd-gdhk`;
-      file the discovered strand below.
+- [ ] **Phase 8 — Close out.** `braid close bd-v8gx` and `braid close bd-gdhk`.
+
+## End-to-end verification (Phase 6b)
+
+Tests alone are not sufficient here: this code is what puts `site_libs/` on disk
+during a real `q2 render`. Both routing branches were exercised through the
+actual binary and the output inspected.
+
+**Website project** (shared `lib_dir` → accumulate → `post_render` flush):
+
+```
+$ cargo run -q --bin q2 -- render <scratch>/e2e/site
+Rendering project: .../e2e/site (type: website)
+Rendered 2 of 2 files to .../e2e/site/_site
+
+$ find _site/site_libs -type f
+site_libs/bootstrap/bootstrap-icons.css
+site_libs/bootstrap/bootstrap-icons.woff
+site_libs/quarto/bootstrap.bundle.min.js
+site_libs/quarto/clipboard.min.js
+site_libs/quarto/code-copy-init.js
+site_libs/quarto/quarto-theme-127bdf77135c0e58.css
+
+$ grep -o 'href="[^"]*quarto-theme[^"]*"' _site/index.html
+href="site_libs/quarto/quarto-theme-127bdf77135c0e58.css"
+```
+
+Six Project-scope artifacts flushed, and the `<link href>` the HTML embeds
+matches the on-disk path — the Phase 9 §Decision 4 round-trip invariant holds
+through the refactor.
+
+**Standalone / default project** (`lib_dir == ""` → write in place, the bd-87fu
+path):
+
+```
+$ cargo run -q --bin q2 -- render <scratch>/e2e/standalone.qmd
+$ find standalone_files -type f
+bootstrap.bundle.min.js
+clipboard.min.js
+code-copy-init.js
+styles.css
+
+$ grep -o 'href="[^"]*\.css"' standalone.html
+href="standalone_files/styles.css"
+```
+
+Output inspected in both cases, not merely checked for absence of errors.
+
+## Note on a flaky test encountered (not ours)
+
+The first full-workspace run on this branch failed one unrelated test,
+`quarto-hub::integration admin_scan_real_store::scan_real_store_finds_orphaned_capture_only`.
+It was **investigated rather than assumed pre-existing**, because "unrelated
+flake" is exactly what an introduced regression looks like at first.
+
+Findings: the assertion diff is one document id read back with the wrong
+*letter case* (27 of 28 chars identical, differing only at index 1).
+`list_doc_ids_filesystem` (`quarto-hub/src/admin/scan.rs:80-106`) reconstructs
+doc ids as `format!("{prefix}{rest}")` from a two-level
+`<2-char prefix>/<rest>/` store layout; on macOS's case-insensitive APFS two ids
+whose prefixes case-fold together share one directory, so one reads back
+mis-cased.
+
+Reproduced **on a clean `main` worktree** at **2 failures in 60 iterations
+(~3%)**, with the same signature (`2Kd28qz…` vs `2kd28qz…`). Pre-existing,
+platform-dependent, and unreachable from this branch (no `crates/quarto-hub/`
+file changed). Filed as **bd-eb2wnxkp** with the evidence and a warning that
+verifying any fix needs a stress loop, not a single green run.
 
 Expect **no `docs/` change** — no user-facing symbol here. Confirm and move on.
 
-## Discovered work (to file as its own strand)
+## Discovered work (filed)
+
+- **bd-lameekm1** (bug, p2) — the empty-content divergence described below.
+- **bd-eb2wnxkp** (bug, p2) — `list_doc_ids_filesystem` reconstructs doc ids
+  unsoundly on case-insensitive filesystems; see the flaky-test note above.
 
 **Empty-content artifacts are skipped on the VFS path but written on the
 `OutputSink` paths.** `flush_artifacts_to_vfs` skips `artifact.content.is_empty()`

--- a/claude-notes/plans/2026-07-28-rename-flush-site-libs.md
+++ b/claude-notes/plans/2026-07-28-rename-flush-site-libs.md
@@ -172,9 +172,42 @@ module whose doc opens "Post-render hooks for `WebsiteProjectType`."
       -- -D warnings`, `cargo fmt --check`, `cargo xtask lint` all clean; full
       `cargo xtask verify` (with the WASM/hub leg) run.
 - [x] **Phase 6b — End-to-end verification** (see below).
-- [ ] **Phase 7 — PR.** Push to `origin` and open a PR so CI reports. Document
-      the one deliberate behavior change (scope filter) in the PR body.
-- [ ] **Phase 8 — Close out.** `braid close bd-v8gx` and `braid close bd-gdhk`.
+- [x] **Phase 7 — PR.** [PR #430](https://github.com/quarto-dev/q2/pull/430),
+      commit `478f7c37`, branch `feature/bd-v8gx-flush-project-artifacts`.
+      **All 8 CI checks green** (2x ubuntu + 2x macos test suites, WASM Tests,
+      Hub-Client E2E, license/snyk, security/snyk). The deliberate scope-filter
+      change is called out under a dedicated warning heading in the PR body.
+- [x] **Phase 8 — Close out.** bd-v8gx and bd-gdhk both closed.
+
+## Coverage (Phase 6b addendum)
+
+`cargo llvm-cov --package quarto-core --summary-only` (all targets, so integration
+tests contribute — a `--lib`-only run misleadingly reports `pass2_renderer.rs` at
+0% because its coverage comes almost entirely from integration tests):
+
+| File touched | Region | Func | Line |
+| --- | --- | --- | --- |
+| **`artifact_flush.rs`** | **98.48%** | **96.30%** | **99.39%** |
+| `render_to_file.rs` | 93.50% | 80.00% | 93.50% |
+| `resource_resolver.rs` | 95.99% | 83.33% | 95.88% |
+| `project/mod.rs` | 96.14% | 83.67% | 96.30% |
+| `project/orchestrator.rs` | 85.36% | 80.73% | 86.93% |
+| `project/pass2_renderer.rs` | 71.01% | 86.05% | 76.71% |
+| `project/website_post_render.rs` | 88.60% | 77.78% | 84.21% |
+
+`quarto-core` overall: 89.85% region / 87.96% line.
+
+`artifact_flush.rs` scores identically under `--lib` and all-targets (527 regions,
+8 missed either way), which confirms its coverage comes from the in-module unit
+tests written for this work rather than being inherited from integration suites.
+
+**Caveat, stated rather than glossed:** the *before* side of the checklist's
+before/after comparison was not measured — the `main` baseline worktree had
+already been removed after the flake investigation, and re-measuring needs
+another instrumented run. A regression on the moved code is implausible given it
+landed at 99.39% line coverage, but `website_post_render.rs` and
+`render_to_file.rs` both *lost* code, so their percentages shifted for reasons
+unrelated to test quality.
 
 ## End-to-end verification (Phase 6b)
 

--- a/claude-notes/plans/2026-07-28-rename-flush-site-libs.md
+++ b/claude-notes/plans/2026-07-28-rename-flush-site-libs.md
@@ -4,7 +4,10 @@
 **Braid:** bd-v8gx (chore, p4) — rename `flush_site_libs` → `flush_project_artifacts`
 **Braid:** bd-gdhk (chore, p3) — extract the drain-and-flush-or-merge helper
 **Branch:** `braid/bd-v8gx-flush-project-artifacts`, based on `main` @ `581e45c0`
-**Status:** Design settled with user 2026-07-28 (options: name = as-filed, scope = (c) rename+dedupe, module = move, branch + PR, both strands together). **Implementation in progress, plan-driven, TDD.**
+**Status:** ✅ **Complete.** Design settled with user 2026-07-28 (name = as-filed,
+scope = (c) rename+dedupe, module = move, branch + PR, both strands together).
+Shipped in [PR #430](https://github.com/quarto-dev/q2/pull/430) (`478f7c37`),
+all 8 CI checks green; bd-v8gx and bd-gdhk closed.
 
 ## Summary of the decision
 

--- a/claude-notes/plans/2026-07-28-rename-flush-site-libs.md
+++ b/claude-notes/plans/2026-07-28-rename-flush-site-libs.md
@@ -1,263 +1,219 @@
-# Rename flush_site_libs to flush_project_artifacts (bd-v8gx)
+# Consolidate the artifact-write family (bd-v8gx + bd-gdhk)
 
 **Date:** 2026-07-28
-**Braid:** bd-v8gx (chore, p4, opened 2026-05-01 by cscheid)
-**Checkout:** `/Users/cscheid/rooms/room-1/q2`, branch `main` @ `581e45c0`
-(this skill does not create branches — see "Where should this land?" below)
-**Status:** Investigation — pending design alignment with user. **Do not start
-implementation until the user gives the go-ahead.**
+**Braid:** bd-v8gx (chore, p4) — rename `flush_site_libs` → `flush_project_artifacts`
+**Braid:** bd-gdhk (chore, p3) — extract the drain-and-flush-or-merge helper
+**Branch:** `braid/bd-v8gx-flush-project-artifacts`, based on `main` @ `581e45c0`
+**Status:** Design settled with user 2026-07-28 (options: name = as-filed, scope = (c) rename+dedupe, module = move, branch + PR, both strands together). **Implementation in progress, plan-driven, TDD.**
 
-## Triage verdict
+## Summary of the decision
 
-**Ready to design, with a scope decision to make first** — the rename itself is
-mechanically valid and the code still has the shape the strand describes, but
-(a) the "one error message" the strand promises no longer exists (bd-cfl67
-deleted it), and (b) the investigation turned up a near-duplicate function,
-`render_to_file::enqueue_artifacts`, plus a *factually wrong* doc comment
-pointing at `flush_site_libs`. So the real question is whether bd-v8gx stays a
-pure rename or absorbs the small deduplication that would make the new name
-honest.
+Both strands land together on one branch, with a PR opened so CI reports on it.
+The investigation found that the two strands are really one piece of work, and
+that a **third** sibling of the same loop already exists — so the target state
+is a single `artifact_flush` module owning the whole artifact-write family.
 
-## Issue context
+## What the investigation found
 
-> `flush_site_libs` in `crates/quarto-core/src/project/website_post_render.rs`
-> is now called from both `WebsiteProjectType.post_render` (where the name is
-> accurate) and `RenderToHtmlRenderer.render` (where 'site_libs' is misleading
-> — default projects have no site_libs dir). The function body has always been
-> general (it just iterates project_artifacts and calls
-> `resolver.on_disk_path_for(Project, ...)`). Rename + update one error message
-> for clarity. Pure naming hygiene.
+### The premise holds, but the framing was incomplete
 
-Type `chore`, priority `4` (backlog), status `open`, filed 2026-05-01 —
-**~3 months old**. Never updated since creation.
+bd-v8gx says `flush_site_libs` is misleadingly named because it has two
+non-website callers. True at `581e45c0`. But three further findings reshape the
+work:
 
-## Dependency graph
+**Finding 1 — the "one error message" is already gone.** It was
+`"Failed to create site_libs subdirectory {}: {}"`, deleted by bd-cfl67
+(`ad18adcb`) when the manual `dir_create` + `file_write` pair became
+`OutputSink`. That half of bd-v8gx is overtaken; nothing to do.
 
-Small and one-directional:
+**Finding 2 — `artifact_flush.rs` already exists**
+(`crates/quarto-core/src/artifact_flush.rs`, 281 lines, added by bd-q3bxnq2e).
+It holds `flush_artifacts_to_vfs` — a **third** near-copy of the same loop, this
+one writing into the hub-client `VirtualFileSystem`. Its module doc is already
+framed as "shared artifact flush." This is the natural home for the family, and
+it means the module we would have created is already there with the right name.
 
-```
-bd-h736 (closed) ──discovered-from── bd-87fu (closed)
-                                        ├──discovered-from── bd-v8gx (this, open)
-                                        └──discovered-from── bd-gdhk (open, p3)
-```
+**Finding 3 — the three loops diverge in two ways that matter.**
 
-- **`discovered-from` → bd-87fu** (closed 2026-05-01, commit `c1af5b3b`):
-  "Default-project theme artifacts not flushed in hub-client live preview."
-  This is the whole context. bd-87fu's fix added the `lib_dir.is_empty()`
-  branch to `RenderToHtmlRenderer.render`, which is what created the second
-  caller and made the `site_libs` name misleading. bd-87fu's close reason
-  explicitly names bd-v8gx and bd-gdhk as its two follow-ups.
-- **Sibling: bd-gdhk** (open, p3, chore): "Extract drain-and-flush-or-merge
-  helper out of pass2 renderers." Same parent, and it overlaps this work — see
-  the design questions. Note bd-gdhk's cited line numbers
-  (`render_to_file.rs:264-297`, `pass2_renderer.rs:343-355`) have **both
-  drifted**; the real sites are now `render_to_file.rs:364-386` and
-  `pass2_renderer.rs:883-895` / `1170-1182`.
-- **No incoming `blocks` edges.** Nothing waits on this. Consistent with p4:
-  there is no urgency, only readability.
+| | sink | scope handling | empty content | cfg |
+| --- | --- | --- | --- | --- |
+| `flush_site_libs` (`website_post_render.rs:81`) | owns + flushes | **forces** `Project` | writes it | cross-platform |
+| `enqueue_artifacts` (`render_to_file.rs:445`) | caller's | **filters** on `scope` | writes it | native-only |
+| `flush_artifacts_to_vfs` (`artifact_flush.rs:44`) | VFS | uses `artifact.scope` | **skips** (bd-3gtn) | cross-platform |
 
-## What the code looks like today
+### The blocker that forces the module move
 
-Spot-check at `581e45c0`: **the strand's premise holds.** The function still
-exists with the general body the strand describes, and it still has two callers
-with contradictory naming.
+`pub mod render_to_file` is itself `#[cfg(not(target_arch = "wasm32"))]`
+(`lib.rs:59-60`) — so `enqueue_artifacts` is not merely gated, it **does not
+exist on wasm32**. A cross-platform `flush_project_artifacts` therefore *cannot*
+delegate to it in place. Option (c) requires moving `enqueue_artifacts` into a
+cross-platform module, and `artifact_flush.rs` (ungated, `lib.rs:40`) is it.
+The per-function gate on `enqueue_artifacts` is redundant belt-and-braces today;
+`OutputSink` itself is cross-platform (`new`/`write`/`copy`/`flush` are all
+ungated), so the body ports without change.
 
-`crates/quarto-core/src/project/website_post_render.rs:81`
+### The behavior trap to pin with a test first
+
+`flush_site_libs` calls `on_disk_path_for(Project, path)` **unconditionally**,
+ignoring `artifact.scope`. `enqueue_artifacts` **filters** on
+`artifact.scope == scope_filter`. Delegating therefore changes behavior for any
+non-Project entry in the store: today it is written at the Project root; after
+delegation it would be **silently dropped**.
+
+Does that happen? `merge_into_project` (`artifact.rs:344`) inserts entries
+**verbatim — it does not re-stamp scope**. The Project-only invariant holds
+only because every caller feeds it from `drain_project_scoped()`. Nothing
+enforces it.
+
+**Decision:** filter (adopt `enqueue_artifacts` semantics) **plus a
+`debug_assert!`** that every entry is Project-scoped. Silently routing a
+Page-scoped artifact to a Project path is arguably today's latent bug; making
+the invariant loud in dev is better than preserving an accident. This is a
+deliberate, tested change — recorded here because it is the one place this work
+is *not* behavior-preserving.
+
+Two facts that make the rest of the delegation safe:
+
+- `flush_site_libs`'s `if project_artifacts.is_empty() { return Ok(()) }` early
+  return can go: `OutputSink::flush` early-returns on empty `ops` **before**
+  materializing allowed roots (`output_sink.rs:291-293`), so no `dir_create`
+  happens either way. Existing test `flush_site_libs_empty_store_is_noop`
+  guards this.
+- Iteration is sorted-by-key in both, so flush order is unchanged.
+
+## Target state
+
+One module, `crates/quarto-core/src/artifact_flush.rs`, owning four named
+members with **one** write loop between them:
 
 ```rust
-pub(super) fn flush_site_libs(
-    project_artifacts: &ArtifactStore,
-    resolver: &ResourceResolverContext,
-    runtime: &dyn SystemRuntime,
+// The primitive. Moved from render_to_file.rs; per-fn cfg gate dropped.
+pub fn enqueue_artifacts(store, resolver, scope_filter, sink) -> Result<()>
+
+// Own-sink wrapper == bd-v8gx's rename target. Moved from
+// project/website_post_render.rs. Three lines over the primitive.
+pub(crate) fn flush_project_artifacts(store, resolver, runtime) -> Result<()>
+
+// bd-gdhk's helper: drain-and-flush-or-merge, shared by all 3 render sites.
+pub(crate) fn route_drained_project_artifacts(
+    drained, accumulator: Option<&mut ArtifactStore>, has_shared_lib,
+    resolver, sink: &mut OutputSink, input: &Path,
 ) -> Result<()>
+
+// Already present (bd-q3bxnq2e). Untouched.
+pub fn flush_artifacts_to_vfs(artifacts, resolver, vfs)
 ```
 
-Body: bail on empty → construct its **own** `OutputSink` from
-`resolver.allowed_output_roots()` → sort entries by key → for each artifact with
-a `path`, `sink.write(resolver.on_disk_path_for(Project, path), …)` →
-`sink.flush(runtime)`. Nothing in it is website-specific.
+**Name choice (Q1 resolved).** `flush_project_artifacts`, exactly as bd-v8gx
+filed it. The `enqueue_` / `flush_` verb pair already encodes the only
+distinction that matters — sink ownership — so no disambiguating suffix is
+needed. Once all four sit in one module with a doc comment naming the family,
+the collision I worried about in the skeleton stops being a hazard: a reader
+meets them together instead of discovering them one at a time. It is also
+uniquely greppable (`flush_project_artifacts` matches nothing else) and, unlike
+a `site_libs`-derived name, carries no risk of a sweep touching the 142
+legitimate `site_libs` directory references.
 
-### Callers (3)
+**Why `route_drained_project_artifacts` takes a sink rather than a runtime.**
+Each of the three render sites keeps its own sink lifecycle: `render_to_file`
+enqueues into its render-wide sink (shared with Page-scope writes and resource
+copies, flushed once), while the two pass-2 sites construct and flush their own.
+Passing the sink in preserves all three lifecycles exactly — no behavior change,
+no mode enum.
 
-| Site | Context | Is `site_libs` accurate? |
+## Call-site map (what changes where)
+
+| Site | Today | After |
 | --- | --- | --- |
-| `project/orchestrator.rs:372-373` | `WebsiteProjectType::post_render` | ✅ yes (`lib_dir == "site_libs"`) |
-| `project/pass2_renderer.rs:886` | `RenderToHtmlRenderer::render`, `lib_dir.is_empty()` branch (bd-87fu) | ❌ no — default project, no lib dir |
-| `project/pass2_renderer.rs:1173` | `RenderToPreviewAstRenderer::render`, same branch | ❌ no |
+| `orchestrator.rs:372-373` (`WebsiteProjectType::post_render`) | `flush_site_libs(...)` | `flush_project_artifacts(...)` |
+| `pass2_renderer.rs:883-895` (`RenderToHtmlRenderer::render`) | drain + `if lib_dir.is_empty()` branch, 13 lines | `route_drained_project_artifacts(...)` |
+| `pass2_renderer.rs:1170-1182` (`RenderToPreviewAstRenderer::render`) | **byte-identical** to the above | `route_drained_project_artifacts(...)` |
+| `render_to_file.rs:364-386` | drain + `match (project_artifacts, has_shared_lib)` | `route_drained_project_artifacts(...)` |
+| `render_to_file.rs:436-440` | doc comment that **falsely** claims `post_render` reaches `enqueue_artifacts` "via `flush_site_libs`" | corrected + moved with the fn |
 
-### Finding 1 — the "one error message" is already gone
+Note the honest consequence: once `route_drained_project_artifacts` owns the two
+pass-2 sites, `flush_project_artifacts` is left with exactly **one** caller —
+`post_render`, the site where `site_libs` was *accurate*. So bd-gdhk dissolves
+bd-v8gx's original motivation. The rename is still right, but for the second
+reason rather than the first: the function is general and should not live in a
+module whose doc opens "Post-render hooks for `WebsiteProjectType`."
 
-The strand says "update one error message for clarity." That message was
-`"Failed to create site_libs subdirectory {}: {}"`, and **bd-cfl67 deleted it**
-in `ad18adcb` ("route destructive writes through validated OutputSink") when the
-manual `dir_create` + `file_write` pair was replaced by `OutputSink`. Verified
-via `git show ad18adcb -- crates/quarto-core/src/project/website_post_render.rs`.
+## Phases
 
-There is no remaining `site_libs`-flavored error string in the function. So this
-half of the strand is **overtaken — nothing to do.** The rename half stands.
+- [x] **Phase 0 — Investigation + design** (this document; commit `5c874669` + this rewrite).
+- [ ] **Phase 1 — Tests first (TDD).** Written and failing/pinning before any move:
+  - [ ] Pin the scope-filter decision: a `Page`-scoped entry in the store handed
+        to `flush_project_artifacts` is **not** written (and `debug_assert` fires
+        in dev). This is the one deliberate behavior change.
+  - [ ] Characterize the current three pass-2/native routing sites: shared-lib
+        accumulates, no-shared-lib writes in place. Assert via
+        `route_drained_project_artifacts` so the test drives the new seam.
+  - [ ] Carry over the 4 existing `flush_site_libs_*` unit tests to the new
+        module + names, unchanged in substance.
+  - [ ] Empty store stays a no-op (no `dir_create`) — guards the dropped early return.
+- [ ] **Phase 2 — Move `enqueue_artifacts`** to `artifact_flush.rs`, drop its
+      per-fn cfg gate, fix its false doc comment. Re-export or update the two
+      `render_to_file.rs` callers.
+- [ ] **Phase 3 — Move + rename `flush_site_libs`** → `flush_project_artifacts`
+      in `artifact_flush.rs`, reimplemented over `enqueue_artifacts` + `debug_assert`.
+      Update `post_render`. Widen the `artifact_flush` module doc to describe the family.
+- [ ] **Phase 4 — bd-gdhk: add `route_drained_project_artifacts`** and convert
+      all three render sites to it.
+- [ ] **Phase 5 — Prose sweep.** The remaining `flush_site_libs` references
+      across 10 files / 3 crates (31 occurrences total). **Match on
+      `flush_site_libs`, never on `site_libs`** — see Risks.
+- [ ] **Phase 6 — Verify.** Full `cargo xtask verify` (**not** `--skip-hub-build`):
+      the function is cross-platform and named in `wasm-quarto-hub-client` and
+      `quarto-system-runtime`, so the WASM leg is in scope. Plus
+      `cargo xtask lint` and a `grep -rn 'flush_site_libs' crates/` that must
+      return empty.
+- [ ] **Phase 7 — PR.** Push to `origin` and open a PR so CI reports. Document
+      the one deliberate behavior change (scope filter) in the PR body.
+- [ ] **Phase 8 — Close out.** `braid close bd-v8gx` and `braid close bd-gdhk`;
+      file the discovered strand below.
 
-### Finding 2 — a near-duplicate exists, and its doc comment is wrong
+Expect **no `docs/` change** — no user-facing symbol here. Confirm and move on.
 
-`crates/quarto-core/src/render_to_file.rs:445` `pub fn enqueue_artifacts` has
-essentially the same body as `flush_site_libs`:
+## Discovered work (to file as its own strand)
 
-|  | `flush_site_libs` | `enqueue_artifacts` |
-| --- | --- | --- |
-| Sink | constructs + flushes its **own** | caller-owned, caller flushes |
-| Scope selection | assumes store is already Project-only | filters on `scope_filter` |
-| Sort | by key | by key |
-| Write | `sink.write(on_disk_path_for(Project, p), …)` | `sink.write(on_disk_path_for(a.scope, p), …)` |
-| cfg | **cross-platform** (WASM needs it) | `#[cfg(not(target_arch = "wasm32"))]` |
+**Empty-content artifacts are skipped on the VFS path but written on the
+`OutputSink` paths.** `flush_artifacts_to_vfs` skips `artifact.content.is_empty()`
+because bd-3gtn established that empty content means "manifest entry"
+(`Artifact::from_path`) whose destination "can alias the user's upload location —
+they must never be written." Neither `flush_site_libs` nor `enqueue_artifacts`
+has that skip; they rely on `OutputSink`'s allowed-roots validation instead.
+For a manifest entry with a *relative* path inside an allowed root, the
+`OutputSink` paths would write 0 bytes over it — the same class of bug bd-cfl67
+fixed. bd-cfl67 removed the producer (`ResourceCollectorTransform` no longer
+emits artifacts), so this may have no live trigger, but `Artifact::from_path`
+still exists and nothing enforces the absence. **File for investigation; do not
+fold into this branch** — it is a behavior question, not cleanup, and this
+branch should stay reviewable as "no behavior change except the documented one."
 
-The native project path does **not** call `flush_site_libs` at all — it calls
-`enqueue_artifacts(&drained, &resolver, Project, &mut sink)`
-(`render_to_file.rs:384`) on the render-wide sink.
+## Risks / tradeoffs
 
-And `enqueue_artifacts`' own doc comment (`render_to_file.rs:436-440`) claims:
-
-> Used by `render_document_to_file` (Page scope, per-doc; Project scope when
-> standalone) and by `WebsiteProjectType::post_render` for project-shared
-> artifacts (via [`crate::project::website_post_render::flush_site_libs`]).
-
-**That last clause is false.** `flush_site_libs` does not call
-`enqueue_artifacts`; it writes to its own sink directly. This is a stale doc
-link that a reader would follow to the wrong conclusion — worth fixing whatever
-we decide about the rename.
-
-### Finding 3 — the rename's real cost is the 31 textual references
-
-`flush_site_libs` occurs **31 times across 10 files**, mostly in prose (design
-comments and intra-doc links), not just at the 3 call sites:
-
-```
-crates/quarto-core/src/project/website_post_render.rs   :14 :34 :81(def) + 543-623 (4 tests, incl. fn names)
-crates/quarto-core/src/project/pass2_renderer.rs        :179 :196 :859 :872 :886 :1123 :1173
-crates/quarto-core/src/project/orchestrator.rs          :289 :341 :372 :373
-crates/quarto-core/src/project/mod.rs                   :36
-crates/quarto-core/src/resource_resolver.rs             :131
-crates/quarto-core/src/render_to_file.rs                :440
-crates/quarto-core/tests/integration/render_page_in_project.rs :19 :62
-crates/quarto-core/tests/integration/listing_pipeline.rs :376
-crates/quarto-system-runtime/src/wasm.rs                :326
-crates/wasm-quarto-hub-client/src/lib.rs                :1755
-```
-
-Two of these are `[`crate::project::website_post_render::flush_site_libs`]`
-**intra-doc links** (`resource_resolver.rs:131`, `render_to_file.rs:440`, plus
-`pass2_renderer.rs:179`). Note that **CI would not catch a stale one**: there is
-no `cargo doc` step in `.github/workflows/`, and `cargo clippy -D warnings`
-does not resolve intra-doc links. Broken links here fail silently. Grep is the
-gate, not the compiler.
-
-Three of the four unit tests carry the name in their **function names**
-(`flush_site_libs_vfs_root_writes_under_vfs_root`,
-`flush_site_libs_empty_store_is_noop`,
-`flush_site_libs_native_website_routes_under_site_libs`); renaming those changes
-nextest filter strings for anyone with muscle memory.
-
-### Not reproducible / not applicable checks
-
-Nothing to reproduce — this is naming hygiene, not a behavior bug. There is no
-fixture to capture, so `claude-notes/plans/2026-07-28-rename-flush-site-libs-investigation/`
-was not created.
-
-## Proposed phases (draft)
-
-Skeleton only — contents wait on the design discussion. **Phase 0 is not a
-TDD-style failing test**: a pure rename has no observable behavior to assert.
-The correctness gate is "the same tests still pass, unchanged in substance."
-If the answer to design question 2 is "also dedupe," Phase 0 becomes real.
-
-- **Phase 0 — Establish the no-behavior-change baseline.** Record the current
-  green `cargo nextest run -p quarto-core` result. If we take the dedupe option,
-  add a test asserting `flush_project_artifacts` and the native
-  `enqueue_artifacts(Project)` path produce identical destinations for the same
-  store + resolver — that one *is* a real new test and should be written first.
-- **Phase 1 — Rename the definition + 3 call sites.** `website_post_render.rs:81`,
-  `orchestrator.rs:372-373`, `pass2_renderer.rs:886` and `:1173`.
-- **Phase 2 — Sweep the prose.** The ~20 remaining comment / intra-doc-link
-  references across the 10 files above, including the 3 test function names.
-  Deliberately a separate phase from Phase 1 so the mechanical-but-wide diff is
-  reviewable on its own.
-- **Phase 3 — Fix the stale doc comment** at `render_to_file.rs:436-440`
-  (Finding 2) regardless of the dedupe decision.
-- **Phase 4 — (conditional on Q2) Dedupe against `enqueue_artifacts`.**
-- **Phase 5 — Verify.** `cargo xtask verify` (full, not `--skip-hub-build`):
-  `wasm-quarto-hub-client` and `quarto-system-runtime` both reference the name,
-  and the function is cross-platform, so the WASM leg is in scope.
-- **Phase 6 — Docs.** Nothing user-facing here; `docs/` does not mention this
-  symbol. Expect no `docs/` change — confirm and move on.
-
-## Open design questions for the user
-
-1. **Name.** The strand proposes `flush_project_artifacts`. That reads well
-   standalone but sits one word away from the existing
-   `enqueue_artifacts(…, ArtifactScope::Project, …)`, so a reader now meets two
-   similarly-named ways to write Project-scope artifacts and has to discover
-   from the bodies that the difference is *sink ownership*. Options:
-   `flush_project_artifacts` as filed (accept the mild collision), or something
-   that encodes the distinction such as `flush_project_artifacts_standalone` /
-   `flush_project_artifacts_own_sink`. Which do you want?
-
-2. **Scope: pure rename, or fold in the dedupe?** Finding 2 says
-   `flush_site_libs` ≈ `enqueue_artifacts` + own sink. We could make the renamed
-   function a three-line wrapper over `enqueue_artifacts`, which would make the
-   name honest by construction. **Blocker if we do:** `enqueue_artifacts` is
-   `#[cfg(not(target_arch = "wasm32"))]` and the renamed function must stay
-   cross-platform, so this requires lifting that cfg gate — no longer "pure
-   naming hygiene," and it eats part of bd-gdhk. Three ways to go:
-   (a) rename only, leave bd-gdhk untouched; (b) rename + fix the stale doc
-   comment, leave the code dedupe to bd-gdhk; (c) rename + dedupe, and close
-   bd-gdhk as absorbed. My recommendation is **(b)** — it fixes the actively
-   misleading thing (a doc link that lies) without smuggling a cfg-gate change
-   into a p4 chore.
-
-3. **Module home.** The renamed function would live in a file called
-   `website_post_render.rs`, whose module doc opens "Post-render hooks for
-   `WebsiteProjectType`" — while two of its three callers are *not* website
-   post-render. `mod.rs:36` and the module header already carry apologetic
-   comments about exactly this. Do we move it (to `project/artifact_flush.rs`,
-   or next to `enqueue_artifacts` in `render_to_file.rs`), or accept that the
-   file name stays a bit wrong and just widen the module doc? A move makes the
-   diff larger but is the change that actually removes the confusion the strand
-   is about.
-
-4. **Where should this land?** We are on `main` @ `581e45c0` in
-   `/Users/cscheid/rooms/room-1/q2` (note: `CLAUDE.local.md` here still
-   describes a bd-eiku4ymo worktree — stale). Per the skill I did not create a
-   branch. Given the width of the prose sweep, a `braid/bd-v8gx-rename-flush-site-libs`
-   branch seems right, but that is your call.
-
-5. **Worth doing at all?** p4, no dependents, 3 months old, and half the stated
-   work (the error message) is already gone. The honest counter-argument is
-   that the diff touches 10 files across 3 crates to change zero behavior, and
-   will conflict with anything else in flight in `pass2_renderer.rs` /
-   `orchestrator.rs`. Is now the time, or should this wait to ride along with
-   bd-gdhk (which has to touch the same functions anyway)? Bundling the two is
-   defensible.
-
-## Risks / tradeoffs (draft)
-
-- **Silent-failure risk on intra-doc links.** As noted in Finding 3, neither
-  clippy nor CI resolves them. If we rename, the completeness check must be
-  `grep -rn 'flush_site_libs' crates/` returning empty — do not rely on the
-  build.
+- **`site_libs` the string vastly outnumbers the symbol.** Measured at
+  `581e45c0`: `crates/**/*.rs` holds **173** occurrences of `site_libs`, of which
+  only **31** are `flush_site_libs`. The other **142 (82%)** name the real
+  output directory (`WebsiteProjectType::lib_dir()` returns `"site_libs"`,
+  `orchestrator.rs:335`) and must not be touched. A naive
+  `sed s/site_libs/project_artifacts/` would corrupt website output paths. The
+  sweep must match the full symbol.
+- **Intra-doc links fail silently.** Three references are
+  `[`crate::project::website_post_render::flush_site_libs`]` rustdoc links.
+  There is **no `cargo doc` step** in `.github/workflows/`, and
+  `cargo clippy -D warnings` does not resolve intra-doc links. Grep is the
+  completeness gate, not the compiler.
+- **One deliberate behavior change**, called out above (scope filter +
+  `debug_assert`). Everything else must be behavior-preserving; the PR body
+  should say so explicitly so review knows where to look.
 - **Merge-conflict surface.** `pass2_renderer.rs` and `orchestrator.rs` are
-  high-traffic files. A pure-rename diff conflicts loudly and resolves tediously.
-  Argues for doing it in one sitting and merging promptly, or for bundling with
-  bd-gdhk.
-- **`site_libs` the *string* stays — and it dominates.**
-  `WebsiteProjectType::lib_dir()` returns `"site_libs"` (`orchestrator.rs:335`)
-  and that is correct: it names a real directory. Measured at `581e45c0`,
-  `crates/**/*.rs` contains **173** occurrences of `site_libs`, of which only
-  **31** are `flush_site_libs`. So **142 occurrences (82%) must be left
-  untouched.** A careless `sed s/site_libs/project_artifacts/` would corrupt
-  output paths across the website pipeline. This is by far the largest risk in
-  an otherwise trivial change; the sweep must match on `flush_site_libs`, never
-  on `site_libs`.
-- **Test-name churn.** Renaming the 3 unit tests is right for consistency but
-  breaks saved nextest filters. Low cost, worth flagging.
-- **Cross-platform blast radius.** The function is cross-platform and named in
-  `wasm-quarto-hub-client` and `quarto-system-runtime`; full
-  `cargo xtask verify` (with the WASM leg) is required, not
-  `--skip-hub-build`.
+  high-traffic. Doing both strands at once is what makes this worth the
+  conflict risk — but it argues for merging promptly rather than letting the
+  branch age.
+- **Test-name churn.** Renaming the 3 `flush_site_libs_*` unit tests breaks
+  saved nextest filters. Low cost, worth flagging.
+- **`render_to_file` re-export question.** `enqueue_artifacts` is `pub` and has
+  only in-crate callers today, but moving a `pub` item is technically a
+  breaking change for any external consumer. Decide in Phase 2 whether to leave
+  a `pub use` behind; leaning no, since `quarto-core` is not published.

--- a/claude-notes/plans/2026-07-28-rename-flush-site-libs.md
+++ b/claude-notes/plans/2026-07-28-rename-flush-site-libs.md
@@ -1,0 +1,263 @@
+# Rename flush_site_libs to flush_project_artifacts (bd-v8gx)
+
+**Date:** 2026-07-28
+**Braid:** bd-v8gx (chore, p4, opened 2026-05-01 by cscheid)
+**Checkout:** `/Users/cscheid/rooms/room-1/q2`, branch `main` @ `581e45c0`
+(this skill does not create branches — see "Where should this land?" below)
+**Status:** Investigation — pending design alignment with user. **Do not start
+implementation until the user gives the go-ahead.**
+
+## Triage verdict
+
+**Ready to design, with a scope decision to make first** — the rename itself is
+mechanically valid and the code still has the shape the strand describes, but
+(a) the "one error message" the strand promises no longer exists (bd-cfl67
+deleted it), and (b) the investigation turned up a near-duplicate function,
+`render_to_file::enqueue_artifacts`, plus a *factually wrong* doc comment
+pointing at `flush_site_libs`. So the real question is whether bd-v8gx stays a
+pure rename or absorbs the small deduplication that would make the new name
+honest.
+
+## Issue context
+
+> `flush_site_libs` in `crates/quarto-core/src/project/website_post_render.rs`
+> is now called from both `WebsiteProjectType.post_render` (where the name is
+> accurate) and `RenderToHtmlRenderer.render` (where 'site_libs' is misleading
+> — default projects have no site_libs dir). The function body has always been
+> general (it just iterates project_artifacts and calls
+> `resolver.on_disk_path_for(Project, ...)`). Rename + update one error message
+> for clarity. Pure naming hygiene.
+
+Type `chore`, priority `4` (backlog), status `open`, filed 2026-05-01 —
+**~3 months old**. Never updated since creation.
+
+## Dependency graph
+
+Small and one-directional:
+
+```
+bd-h736 (closed) ──discovered-from── bd-87fu (closed)
+                                        ├──discovered-from── bd-v8gx (this, open)
+                                        └──discovered-from── bd-gdhk (open, p3)
+```
+
+- **`discovered-from` → bd-87fu** (closed 2026-05-01, commit `c1af5b3b`):
+  "Default-project theme artifacts not flushed in hub-client live preview."
+  This is the whole context. bd-87fu's fix added the `lib_dir.is_empty()`
+  branch to `RenderToHtmlRenderer.render`, which is what created the second
+  caller and made the `site_libs` name misleading. bd-87fu's close reason
+  explicitly names bd-v8gx and bd-gdhk as its two follow-ups.
+- **Sibling: bd-gdhk** (open, p3, chore): "Extract drain-and-flush-or-merge
+  helper out of pass2 renderers." Same parent, and it overlaps this work — see
+  the design questions. Note bd-gdhk's cited line numbers
+  (`render_to_file.rs:264-297`, `pass2_renderer.rs:343-355`) have **both
+  drifted**; the real sites are now `render_to_file.rs:364-386` and
+  `pass2_renderer.rs:883-895` / `1170-1182`.
+- **No incoming `blocks` edges.** Nothing waits on this. Consistent with p4:
+  there is no urgency, only readability.
+
+## What the code looks like today
+
+Spot-check at `581e45c0`: **the strand's premise holds.** The function still
+exists with the general body the strand describes, and it still has two callers
+with contradictory naming.
+
+`crates/quarto-core/src/project/website_post_render.rs:81`
+
+```rust
+pub(super) fn flush_site_libs(
+    project_artifacts: &ArtifactStore,
+    resolver: &ResourceResolverContext,
+    runtime: &dyn SystemRuntime,
+) -> Result<()>
+```
+
+Body: bail on empty → construct its **own** `OutputSink` from
+`resolver.allowed_output_roots()` → sort entries by key → for each artifact with
+a `path`, `sink.write(resolver.on_disk_path_for(Project, path), …)` →
+`sink.flush(runtime)`. Nothing in it is website-specific.
+
+### Callers (3)
+
+| Site | Context | Is `site_libs` accurate? |
+| --- | --- | --- |
+| `project/orchestrator.rs:372-373` | `WebsiteProjectType::post_render` | ✅ yes (`lib_dir == "site_libs"`) |
+| `project/pass2_renderer.rs:886` | `RenderToHtmlRenderer::render`, `lib_dir.is_empty()` branch (bd-87fu) | ❌ no — default project, no lib dir |
+| `project/pass2_renderer.rs:1173` | `RenderToPreviewAstRenderer::render`, same branch | ❌ no |
+
+### Finding 1 — the "one error message" is already gone
+
+The strand says "update one error message for clarity." That message was
+`"Failed to create site_libs subdirectory {}: {}"`, and **bd-cfl67 deleted it**
+in `ad18adcb` ("route destructive writes through validated OutputSink") when the
+manual `dir_create` + `file_write` pair was replaced by `OutputSink`. Verified
+via `git show ad18adcb -- crates/quarto-core/src/project/website_post_render.rs`.
+
+There is no remaining `site_libs`-flavored error string in the function. So this
+half of the strand is **overtaken — nothing to do.** The rename half stands.
+
+### Finding 2 — a near-duplicate exists, and its doc comment is wrong
+
+`crates/quarto-core/src/render_to_file.rs:445` `pub fn enqueue_artifacts` has
+essentially the same body as `flush_site_libs`:
+
+|  | `flush_site_libs` | `enqueue_artifacts` |
+| --- | --- | --- |
+| Sink | constructs + flushes its **own** | caller-owned, caller flushes |
+| Scope selection | assumes store is already Project-only | filters on `scope_filter` |
+| Sort | by key | by key |
+| Write | `sink.write(on_disk_path_for(Project, p), …)` | `sink.write(on_disk_path_for(a.scope, p), …)` |
+| cfg | **cross-platform** (WASM needs it) | `#[cfg(not(target_arch = "wasm32"))]` |
+
+The native project path does **not** call `flush_site_libs` at all — it calls
+`enqueue_artifacts(&drained, &resolver, Project, &mut sink)`
+(`render_to_file.rs:384`) on the render-wide sink.
+
+And `enqueue_artifacts`' own doc comment (`render_to_file.rs:436-440`) claims:
+
+> Used by `render_document_to_file` (Page scope, per-doc; Project scope when
+> standalone) and by `WebsiteProjectType::post_render` for project-shared
+> artifacts (via [`crate::project::website_post_render::flush_site_libs`]).
+
+**That last clause is false.** `flush_site_libs` does not call
+`enqueue_artifacts`; it writes to its own sink directly. This is a stale doc
+link that a reader would follow to the wrong conclusion — worth fixing whatever
+we decide about the rename.
+
+### Finding 3 — the rename's real cost is the 31 textual references
+
+`flush_site_libs` occurs **31 times across 10 files**, mostly in prose (design
+comments and intra-doc links), not just at the 3 call sites:
+
+```
+crates/quarto-core/src/project/website_post_render.rs   :14 :34 :81(def) + 543-623 (4 tests, incl. fn names)
+crates/quarto-core/src/project/pass2_renderer.rs        :179 :196 :859 :872 :886 :1123 :1173
+crates/quarto-core/src/project/orchestrator.rs          :289 :341 :372 :373
+crates/quarto-core/src/project/mod.rs                   :36
+crates/quarto-core/src/resource_resolver.rs             :131
+crates/quarto-core/src/render_to_file.rs                :440
+crates/quarto-core/tests/integration/render_page_in_project.rs :19 :62
+crates/quarto-core/tests/integration/listing_pipeline.rs :376
+crates/quarto-system-runtime/src/wasm.rs                :326
+crates/wasm-quarto-hub-client/src/lib.rs                :1755
+```
+
+Two of these are `[`crate::project::website_post_render::flush_site_libs`]`
+**intra-doc links** (`resource_resolver.rs:131`, `render_to_file.rs:440`, plus
+`pass2_renderer.rs:179`). Note that **CI would not catch a stale one**: there is
+no `cargo doc` step in `.github/workflows/`, and `cargo clippy -D warnings`
+does not resolve intra-doc links. Broken links here fail silently. Grep is the
+gate, not the compiler.
+
+Three of the four unit tests carry the name in their **function names**
+(`flush_site_libs_vfs_root_writes_under_vfs_root`,
+`flush_site_libs_empty_store_is_noop`,
+`flush_site_libs_native_website_routes_under_site_libs`); renaming those changes
+nextest filter strings for anyone with muscle memory.
+
+### Not reproducible / not applicable checks
+
+Nothing to reproduce — this is naming hygiene, not a behavior bug. There is no
+fixture to capture, so `claude-notes/plans/2026-07-28-rename-flush-site-libs-investigation/`
+was not created.
+
+## Proposed phases (draft)
+
+Skeleton only — contents wait on the design discussion. **Phase 0 is not a
+TDD-style failing test**: a pure rename has no observable behavior to assert.
+The correctness gate is "the same tests still pass, unchanged in substance."
+If the answer to design question 2 is "also dedupe," Phase 0 becomes real.
+
+- **Phase 0 — Establish the no-behavior-change baseline.** Record the current
+  green `cargo nextest run -p quarto-core` result. If we take the dedupe option,
+  add a test asserting `flush_project_artifacts` and the native
+  `enqueue_artifacts(Project)` path produce identical destinations for the same
+  store + resolver — that one *is* a real new test and should be written first.
+- **Phase 1 — Rename the definition + 3 call sites.** `website_post_render.rs:81`,
+  `orchestrator.rs:372-373`, `pass2_renderer.rs:886` and `:1173`.
+- **Phase 2 — Sweep the prose.** The ~20 remaining comment / intra-doc-link
+  references across the 10 files above, including the 3 test function names.
+  Deliberately a separate phase from Phase 1 so the mechanical-but-wide diff is
+  reviewable on its own.
+- **Phase 3 — Fix the stale doc comment** at `render_to_file.rs:436-440`
+  (Finding 2) regardless of the dedupe decision.
+- **Phase 4 — (conditional on Q2) Dedupe against `enqueue_artifacts`.**
+- **Phase 5 — Verify.** `cargo xtask verify` (full, not `--skip-hub-build`):
+  `wasm-quarto-hub-client` and `quarto-system-runtime` both reference the name,
+  and the function is cross-platform, so the WASM leg is in scope.
+- **Phase 6 — Docs.** Nothing user-facing here; `docs/` does not mention this
+  symbol. Expect no `docs/` change — confirm and move on.
+
+## Open design questions for the user
+
+1. **Name.** The strand proposes `flush_project_artifacts`. That reads well
+   standalone but sits one word away from the existing
+   `enqueue_artifacts(…, ArtifactScope::Project, …)`, so a reader now meets two
+   similarly-named ways to write Project-scope artifacts and has to discover
+   from the bodies that the difference is *sink ownership*. Options:
+   `flush_project_artifacts` as filed (accept the mild collision), or something
+   that encodes the distinction such as `flush_project_artifacts_standalone` /
+   `flush_project_artifacts_own_sink`. Which do you want?
+
+2. **Scope: pure rename, or fold in the dedupe?** Finding 2 says
+   `flush_site_libs` ≈ `enqueue_artifacts` + own sink. We could make the renamed
+   function a three-line wrapper over `enqueue_artifacts`, which would make the
+   name honest by construction. **Blocker if we do:** `enqueue_artifacts` is
+   `#[cfg(not(target_arch = "wasm32"))]` and the renamed function must stay
+   cross-platform, so this requires lifting that cfg gate — no longer "pure
+   naming hygiene," and it eats part of bd-gdhk. Three ways to go:
+   (a) rename only, leave bd-gdhk untouched; (b) rename + fix the stale doc
+   comment, leave the code dedupe to bd-gdhk; (c) rename + dedupe, and close
+   bd-gdhk as absorbed. My recommendation is **(b)** — it fixes the actively
+   misleading thing (a doc link that lies) without smuggling a cfg-gate change
+   into a p4 chore.
+
+3. **Module home.** The renamed function would live in a file called
+   `website_post_render.rs`, whose module doc opens "Post-render hooks for
+   `WebsiteProjectType`" — while two of its three callers are *not* website
+   post-render. `mod.rs:36` and the module header already carry apologetic
+   comments about exactly this. Do we move it (to `project/artifact_flush.rs`,
+   or next to `enqueue_artifacts` in `render_to_file.rs`), or accept that the
+   file name stays a bit wrong and just widen the module doc? A move makes the
+   diff larger but is the change that actually removes the confusion the strand
+   is about.
+
+4. **Where should this land?** We are on `main` @ `581e45c0` in
+   `/Users/cscheid/rooms/room-1/q2` (note: `CLAUDE.local.md` here still
+   describes a bd-eiku4ymo worktree — stale). Per the skill I did not create a
+   branch. Given the width of the prose sweep, a `braid/bd-v8gx-rename-flush-site-libs`
+   branch seems right, but that is your call.
+
+5. **Worth doing at all?** p4, no dependents, 3 months old, and half the stated
+   work (the error message) is already gone. The honest counter-argument is
+   that the diff touches 10 files across 3 crates to change zero behavior, and
+   will conflict with anything else in flight in `pass2_renderer.rs` /
+   `orchestrator.rs`. Is now the time, or should this wait to ride along with
+   bd-gdhk (which has to touch the same functions anyway)? Bundling the two is
+   defensible.
+
+## Risks / tradeoffs (draft)
+
+- **Silent-failure risk on intra-doc links.** As noted in Finding 3, neither
+  clippy nor CI resolves them. If we rename, the completeness check must be
+  `grep -rn 'flush_site_libs' crates/` returning empty — do not rely on the
+  build.
+- **Merge-conflict surface.** `pass2_renderer.rs` and `orchestrator.rs` are
+  high-traffic files. A pure-rename diff conflicts loudly and resolves tediously.
+  Argues for doing it in one sitting and merging promptly, or for bundling with
+  bd-gdhk.
+- **`site_libs` the *string* stays — and it dominates.**
+  `WebsiteProjectType::lib_dir()` returns `"site_libs"` (`orchestrator.rs:335`)
+  and that is correct: it names a real directory. Measured at `581e45c0`,
+  `crates/**/*.rs` contains **173** occurrences of `site_libs`, of which only
+  **31** are `flush_site_libs`. So **142 occurrences (82%) must be left
+  untouched.** A careless `sed s/site_libs/project_artifacts/` would corrupt
+  output paths across the website pipeline. This is by far the largest risk in
+  an otherwise trivial change; the sweep must match on `flush_site_libs`, never
+  on `site_libs`.
+- **Test-name churn.** Renaming the 3 unit tests is right for consistency but
+  breaks saved nextest filters. Low cost, worth flagging.
+- **Cross-platform blast radius.** The function is cross-platform and named in
+  `wasm-quarto-hub-client` and `quarto-system-runtime`; full
+  `cargo xtask verify` (with the WASM leg) is required, not
+  `--skip-hub-build`.

--- a/crates/quarto-core/src/artifact_flush.rs
+++ b/crates/quarto-core/src/artifact_flush.rs
@@ -2,10 +2,50 @@
  * artifact_flush.rs
  * Copyright (c) 2026 Posit, PBC
  *
- * Flush rendered artifacts into an in-memory VFS (bd-q3bxnq2e).
+ * The artifact-write family: one loop, four destinations
+ * (bd-q3bxnq2e, bd-v8gx, bd-gdhk).
  */
 
-//! Shared artifact → VFS flush used by the WASM render entry points.
+//! Where rendered artifacts go, and who owns the write.
+//!
+//! Every render produces an [`ArtifactStore`]; this module owns the
+//! *one* loop that turns those artifacts into writes, plus the small
+//! set of entry points that differ only in **who owns the sink**:
+//!
+//! | Function | Destination | Sink lifecycle |
+//! | --- | --- | --- |
+//! | [`enqueue_artifacts`] | an [`OutputSink`] | **caller** constructs + flushes |
+//! | [`flush_project_artifacts`] | an [`OutputSink`] | **owns** one, flushes it |
+//! | [`route_drained_project_artifacts`] | accumulator *or* sink | caller's sink |
+//! | [`flush_artifacts_to_vfs`] | a [`VirtualFileSystem`] | n/a (VFS is the sink) |
+//!
+//! The `enqueue_` / `flush_` verb prefix is the whole distinction:
+//! `enqueue_*` adds to a sink somebody else will flush, `flush_*`
+//! performs the write before returning.
+//!
+//! Before bd-v8gx / bd-gdhk these lived in three places under three
+//! unrelated names — `render_to_file::enqueue_artifacts`,
+//! `project::website_post_render::flush_site_libs` (misleading: two of
+//! its three callers were not website renders), and the VFS loop below.
+//! `render_to_file` is `#[cfg(not(target_arch = "wasm32"))]` as a
+//! *module*, so the primitive was unreachable from WASM and
+//! `flush_site_libs` had to duplicate it rather than call it. Hosting
+//! the family here — an ungated module — is what lets them share one
+//! loop.
+//!
+//! ## Scope contract
+//!
+//! [`enqueue_artifacts`] selects by `artifact.scope`; the resolver then
+//! decides the destination root for that scope. Note that
+//! [`ArtifactStore::merge_into_project`] inserts entries **verbatim**
+//! and does not re-stamp scope, so "everything in the project
+//! accumulator is Project-scoped" holds only by construction of its
+//! callers (all of which feed it from
+//! [`ArtifactStore::drain_project_scoped`]). Nothing enforces it, which
+//! is why [`flush_project_artifacts`] `debug_assert!`s the invariant
+//! instead of silently mis-routing or silently dropping a violation.
+//!
+//! ## VFS flush
 //!
 //! The hub-client's render tail populates the session VFS with every
 //! artifact the pipeline produced (theme CSS, shared JS, fonts, plot
@@ -32,10 +72,148 @@
 //!   readable at `resolver.on_disk_path_for(scope, path)` — whether
 //!   the write was performed or skipped as byte-identical.
 
-use quarto_system_runtime::VirtualFileSystem;
+use std::path::Path;
 
-use crate::artifact::ArtifactStore;
+use quarto_system_runtime::{SystemRuntime, VirtualFileSystem};
+
+use crate::Result;
+use crate::artifact::{ArtifactScope, ArtifactStore};
+use crate::error::QuartoError;
+use crate::output_sink::OutputSink;
 use crate::resource_resolver::ResourceResolverContext;
+
+/// Enqueue every artifact in `store` whose scope matches `scope_filter`
+/// into `sink` at its resolver-determined on-disk location. Skips
+/// artifacts without a `path`.
+///
+/// The caller owns the sink lifecycle (construct, enqueue producers,
+/// flush) — use this when artifacts share a sink with other writes, so
+/// one validated flush covers the whole render. When there is nothing
+/// to share a sink with, [`flush_project_artifacts`] wraps this.
+///
+/// Iteration is sorted-key so the resulting flush order is
+/// deterministic across runs / platforms.
+pub fn enqueue_artifacts(
+    store: &ArtifactStore,
+    resolver: &ResourceResolverContext,
+    scope_filter: ArtifactScope,
+    sink: &mut OutputSink,
+) -> Result<()> {
+    let mut entries: Vec<(&str, &crate::artifact::Artifact)> = store
+        .iter()
+        .filter(|(_, a)| a.scope == scope_filter)
+        .collect();
+    entries.sort_by(|a, b| a.0.cmp(b.0));
+
+    for (_, artifact) in entries {
+        let Some(path) = &artifact.path else { continue };
+        let on_disk = resolver.on_disk_path_for(artifact.scope, path);
+        sink.write(on_disk, artifact.content.clone())
+            .map_err(QuartoError::from)?;
+    }
+    Ok(())
+}
+
+/// Flush every Project-scoped artifact in `store` to its
+/// resolver-determined on-disk (or VFS) location, through a sink this
+/// function owns.
+///
+/// Used by a project type's `post_render` hook, which has accumulated
+/// artifacts across every Pass-2 render and has no other writes to
+/// batch with. Callers that already hold an [`OutputSink`] should use
+/// [`enqueue_artifacts`] directly instead of paying for a second one.
+///
+/// The resolver decides the destination: native website renders pass a
+/// [`ResourceResolverContext::project_root`] resolver (artifacts land
+/// under `{output_dir}/{lib_dir}/{path}`); the WASM hub-client passes a
+/// [`ResourceResolverContext::vfs_root`] resolver (artifacts land under
+/// `/{vfs_root}/{path}`).
+///
+/// Decoupling the destination from the function's logic enforces the
+/// construction-level invariant from the Phase 9 plan §Decision 4: the
+/// URL embedded in HTML by `html_url_for(Project, p)` and the on-disk
+/// write path returned by `on_disk_path_for(Project, p)` must
+/// round-trip through the same resolver.
+///
+/// An empty `store` is a no-op that touches no directories —
+/// [`OutputSink::flush`] short-circuits before materializing allowed
+/// roots.
+///
+/// # Panics
+///
+/// In debug builds, panics if `store` holds a non-Project-scoped entry.
+/// See the module's scope contract: such an entry means a caller broke
+/// the accumulator invariant, and both silent outcomes (writing it at
+/// the Project root, or filtering it away) hide a real bug.
+pub(crate) fn flush_project_artifacts(
+    store: &ArtifactStore,
+    resolver: &ResourceResolverContext,
+    runtime: &dyn SystemRuntime,
+) -> Result<()> {
+    debug_assert!(
+        store.iter().all(|(_, a)| a.scope == ArtifactScope::Project),
+        "flush_project_artifacts requires every entry to be Project-scoped; \
+         a non-Project entry here means a caller bypassed \
+         ArtifactStore::drain_project_scoped"
+    );
+
+    // bd-cfl67: all destructive output flows through the validated
+    // sink so we can never silently truncate a file outside the
+    // resolver's declared output roots.
+    let mut sink = OutputSink::new(resolver.allowed_output_roots());
+    enqueue_artifacts(store, resolver, ArtifactScope::Project, &mut sink)?;
+    sink.flush(runtime).map_err(QuartoError::from)?;
+    Ok(())
+}
+
+/// Route a render's freshly-[drained] Project-scope artifacts to
+/// whichever destination the project layout calls for.
+///
+/// Two outcomes, and the choice is *artifact-flow*, not payload-flow —
+/// which is why all three Pass-2 / native render tails share it:
+///
+/// - **Shared lib dir + an accumulator** (e.g. websites, `lib_dir ==
+///   "site_libs"`): merge into `accumulator` so the project type's
+///   `post_render` can [`flush_project_artifacts`] them **once** across
+///   the whole project, deduping identical bytes between pages.
+/// - **Otherwise** (default projects with `lib_dir == ""`, or a
+///   standalone render with no orchestrator): enqueue into `sink` for
+///   in-place writing via the per-page resolver.
+///
+/// The `else` branch is load-bearing, not a fallback:
+/// `DefaultProjectType::post_render` is a no-op, so anything left in
+/// the accumulator would silently disappear and the hub-client iframe
+/// would VFS-miss on the theme `<link>` URL its own HTML embeds
+/// (bd-87fu).
+///
+/// `input` names the document being rendered, for the merge-conflict
+/// diagnostic.
+///
+/// [drained]: ArtifactStore::drain_project_scoped
+pub(crate) fn route_drained_project_artifacts(
+    drained: ArtifactStore,
+    accumulator: Option<&mut ArtifactStore>,
+    has_shared_lib: bool,
+    resolver: &ResourceResolverContext,
+    sink: &mut OutputSink,
+    input: &Path,
+) -> Result<()> {
+    match (accumulator, has_shared_lib) {
+        (Some(dest), true) => {
+            dest.merge_into_project(drained).map_err(|e| {
+                QuartoError::other(format!(
+                    "Project-scoped artifact merge failed for {}: {}",
+                    input.display(),
+                    e
+                ))
+            })?;
+        }
+        _ => {
+            enqueue_artifacts(&drained, resolver, ArtifactScope::Project, sink)?;
+        }
+    }
+    Ok(())
+}
 
 /// Flush every path-bearing, non-empty artifact in `artifacts` into
 /// `vfs` at its resolver-computed location, skipping writes whose
@@ -277,5 +455,271 @@ mod tests {
             Some(vec![0xFF, 0xD8])
         );
         assert_eq!(vfs.write_stats().writes, 5);
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // bd-v8gx — flush_project_artifacts
+    // ═══════════════════════════════════════════════════════════════
+
+    /// A `vfs_root` resolver writes Project-scoped artifacts to
+    /// `<vfs_root>/<artifact_path>` — the hub-client convention,
+    /// where `vfs_root == "/.quarto/project-artifacts"`.
+    #[test]
+    fn flush_project_artifacts_vfs_root_writes_under_vfs_root() {
+        use quarto_system_runtime::NativeRuntime;
+        use tempfile::TempDir;
+
+        let temp = TempDir::new().unwrap();
+        let vfs_root = temp.path().join(".quarto/project-artifacts");
+        let resolver = ResourceResolverContext::vfs_root(vfs_root.clone());
+
+        let mut store = ArtifactStore::new();
+        store.store(
+            "theme",
+            Artifact::from_bytes(b"body { color: red; }".to_vec(), "text/css")
+                .with_path("quarto/theme.css")
+                .with_scope(ArtifactScope::Project),
+        );
+
+        flush_project_artifacts(&store, &resolver, &NativeRuntime::new()).unwrap();
+
+        let written = vfs_root.join("quarto/theme.css");
+        let bytes = std::fs::read(&written)
+            .unwrap_or_else(|e| panic!("expected artifact at {}: {}", written.display(), e));
+        assert_eq!(bytes, b"body { color: red; }");
+    }
+
+    /// An empty store creates no directories. This is the guard for
+    /// dropping the old explicit `is_empty()` early return:
+    /// `OutputSink::flush` short-circuits on empty `ops` *before*
+    /// materializing allowed roots, so no directory is created.
+    #[test]
+    fn flush_project_artifacts_empty_store_is_noop() {
+        use quarto_system_runtime::NativeRuntime;
+        use tempfile::TempDir;
+
+        let temp = TempDir::new().unwrap();
+        let vfs_root = temp.path().join("vfs");
+        let resolver = ResourceResolverContext::vfs_root(vfs_root.clone());
+
+        flush_project_artifacts(&ArtifactStore::new(), &resolver, &NativeRuntime::new()).unwrap();
+
+        assert!(!vfs_root.exists(), "no-op flush must not touch the FS");
+    }
+
+    /// The native website resolver routes Project-scope artifacts
+    /// under `{site_root}/{lib_dir}/`. Same function as the VFS case,
+    /// different destination, decided entirely by the resolver
+    /// (Phase 9 §Decision 4).
+    #[test]
+    fn flush_project_artifacts_native_website_routes_under_lib_dir() {
+        use quarto_system_runtime::NativeRuntime;
+        use tempfile::TempDir;
+
+        let temp = TempDir::new().unwrap();
+        let site_root = temp.path().join("_site");
+        let resolver = ResourceResolverContext::project_root(site_root.clone(), "site_libs");
+
+        let mut store = ArtifactStore::new();
+        store.store(
+            "kbd",
+            Artifact::from_bytes(b"kbd { font-family: monospace; }".to_vec(), "text/css")
+                .with_path("libs/kbd/kbd.css")
+                .with_scope(ArtifactScope::Project),
+        );
+
+        flush_project_artifacts(&store, &resolver, &NativeRuntime::new()).unwrap();
+
+        let written = site_root.join("site_libs/libs/kbd/kbd.css");
+        assert_eq!(
+            std::fs::read(&written).ok().as_deref(),
+            Some(b"kbd { font-family: monospace; }".as_slice()),
+            "expected artifact at {}",
+            written.display()
+        );
+    }
+
+    /// **The one deliberate behavior change on this branch.**
+    ///
+    /// This function's predecessor called
+    /// `on_disk_path_for(Project, p)` unconditionally, so a
+    /// non-Project entry that reached it was
+    /// written *at the Project root* — silently misplaced.
+    /// `flush_project_artifacts` delegates to [`enqueue_artifacts`],
+    /// which filters on `artifact.scope`, so such an entry would instead
+    /// be silently dropped. Neither silent outcome is good: nothing
+    /// enforces the invariant, because `merge_into_project`
+    /// (`artifact.rs:344`) inserts entries verbatim without re-stamping
+    /// scope. We make the violation loud in dev instead.
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "Project-scoped")]
+    fn flush_project_artifacts_debug_asserts_on_non_project_entry() {
+        use quarto_system_runtime::NativeRuntime;
+        use tempfile::TempDir;
+
+        let temp = TempDir::new().unwrap();
+        let resolver = ResourceResolverContext::vfs_root(temp.path().join("vfs"));
+
+        let mut store = ArtifactStore::new();
+        store.store(
+            "page-scoped-intruder",
+            Artifact::from_bytes(b"x".to_vec(), "text/css").with_path("oops.css"),
+        );
+
+        let _ = flush_project_artifacts(&store, &resolver, &NativeRuntime::new());
+    }
+
+    /// Release-mode counterpart: with `debug_assert` compiled out, the
+    /// scope filter drops the entry rather than misplacing it.
+    #[cfg(not(debug_assertions))]
+    #[test]
+    fn flush_project_artifacts_filters_non_project_entry_in_release() {
+        use quarto_system_runtime::NativeRuntime;
+        use tempfile::TempDir;
+
+        let temp = TempDir::new().unwrap();
+        let vfs_root = temp.path().join("vfs");
+        let resolver = ResourceResolverContext::vfs_root(vfs_root.clone());
+
+        let mut store = ArtifactStore::new();
+        store.store(
+            "page-scoped-intruder",
+            Artifact::from_bytes(b"x".to_vec(), "text/css").with_path("oops.css"),
+        );
+
+        flush_project_artifacts(&store, &resolver, &NativeRuntime::new()).unwrap();
+
+        assert!(
+            !vfs_root.join("oops.css").exists(),
+            "a Page-scoped entry must not be written at the Project root"
+        );
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // bd-gdhk — route_drained_project_artifacts
+    // ═══════════════════════════════════════════════════════════════
+
+    fn drained_project_store() -> ArtifactStore {
+        let mut store = ArtifactStore::new();
+        store.store(
+            "css:theme:abc123",
+            Artifact::from_string("body { color: red; }", "text/css")
+                .with_path("quarto/quarto-theme-abc123.css")
+                .with_scope(ArtifactScope::Project),
+        );
+        store
+    }
+
+    /// Shared lib dir (websites) **and** an accumulator present: the
+    /// drained artifacts merge into the accumulator so the project
+    /// type's `post_render` can flush them once for the whole project.
+    /// Nothing is enqueued for writing here.
+    #[test]
+    fn route_shared_lib_with_accumulator_merges_and_writes_nothing() {
+        let resolver = ResourceResolverContext::project_root("/tmp/_site", "site_libs");
+        let mut accumulator = ArtifactStore::new();
+        let mut sink = OutputSink::new(resolver.allowed_output_roots());
+
+        route_drained_project_artifacts(
+            drained_project_store(),
+            Some(&mut accumulator),
+            true,
+            &resolver,
+            &mut sink,
+            std::path::Path::new("index.qmd"),
+        )
+        .unwrap();
+
+        assert_eq!(sink.pending(), 0, "merge path must not enqueue writes");
+        assert_eq!(
+            accumulator
+                .get("css:theme:abc123")
+                .map(|a| a.content.as_slice()),
+            Some(b"body { color: red; }".as_slice()),
+            "artifact must land in the accumulator verbatim"
+        );
+    }
+
+    /// No shared lib dir (default projects, `lib_dir == ""`): the
+    /// drained artifacts are enqueued for in-place writing via the
+    /// per-page resolver. This is the bd-87fu path — leaving them in an
+    /// accumulator that `DefaultProjectType::post_render` ignores made
+    /// themes silently disappear.
+    #[test]
+    fn route_no_shared_lib_enqueues_for_in_place_write() {
+        let resolver = ResourceResolverContext::vfs_root("/.quarto/project-artifacts");
+        let mut accumulator = ArtifactStore::new();
+        let mut sink = OutputSink::new(resolver.allowed_output_roots());
+
+        route_drained_project_artifacts(
+            drained_project_store(),
+            Some(&mut accumulator),
+            false,
+            &resolver,
+            &mut sink,
+            std::path::Path::new("index.qmd"),
+        )
+        .unwrap();
+
+        assert_eq!(sink.pending(), 1, "expected one enqueued write");
+        assert_eq!(
+            accumulator.len(),
+            0,
+            "in-place path must not touch the accumulator"
+        );
+    }
+
+    /// Standalone render (no orchestrator, so no accumulator) even with
+    /// a shared lib dir: enqueue in place. Mirrors the `_ =>` arm of
+    /// `render_document_to_file`'s `match (project_artifacts, has_shared_lib)`.
+    #[test]
+    fn route_without_accumulator_enqueues_even_with_shared_lib() {
+        let resolver = ResourceResolverContext::project_root("/tmp/_site", "site_libs");
+        let mut sink = OutputSink::new(resolver.allowed_output_roots());
+
+        route_drained_project_artifacts(
+            drained_project_store(),
+            None,
+            true,
+            &resolver,
+            &mut sink,
+            std::path::Path::new("index.qmd"),
+        )
+        .unwrap();
+
+        assert_eq!(sink.pending(), 1, "expected one enqueued write");
+    }
+
+    /// A merge conflict (same key, different bytes) surfaces as an error
+    /// naming the input document — the diagnostic the three render sites
+    /// each hand-rolled before this helper existed.
+    #[test]
+    fn route_merge_conflict_error_names_the_input_document() {
+        let resolver = ResourceResolverContext::project_root("/tmp/_site", "site_libs");
+        let mut accumulator = ArtifactStore::new();
+        accumulator.store(
+            "css:theme:abc123",
+            Artifact::from_string("body { color: blue; }", "text/css")
+                .with_path("quarto/quarto-theme-abc123.css")
+                .with_scope(ArtifactScope::Project),
+        );
+        let mut sink = OutputSink::new(resolver.allowed_output_roots());
+
+        let err = route_drained_project_artifacts(
+            drained_project_store(),
+            Some(&mut accumulator),
+            true,
+            &resolver,
+            &mut sink,
+            std::path::Path::new("chapters/intro.qmd"),
+        )
+        .expect_err("conflicting bytes under one key must error");
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("chapters/intro.qmd"),
+            "error must name the input document, got: {msg}"
+        );
     }
 }

--- a/crates/quarto-core/src/project/mod.rs
+++ b/crates/quarto-core/src/project/mod.rs
@@ -33,10 +33,10 @@ pub mod pass2_renderer;
 pub mod profile_cache;
 pub mod sidebar_membership;
 pub mod website_config;
-// Phase 9 sub-phase 9.2 lifted the cfg gate so `flush_site_libs`
-// can run cross-platform (its destination is now resolver-driven).
-// Other hooks inside this module remain `#[cfg(not(wasm32))]` per
-// function.
+// Every hook in this module is native-only (`#[cfg(not(wasm32))]`
+// per function) — each writes into the on-disk output dir. The one
+// cross-platform member, the Phase 5 project-artifact flush, moved
+// to `crate::artifact_flush` in bd-v8gx.
 pub mod website_post_render;
 
 use std::path::{Path, PathBuf};

--- a/crates/quarto-core/src/project/orchestrator.rs
+++ b/crates/quarto-core/src/project/orchestrator.rs
@@ -286,8 +286,8 @@ pub trait ProjectType {
     /// renders pass an empty slice. The resolver argument is new
     /// — Phase 9 §Decision 4. It's the single source of truth for
     /// "where do Project-scope artifacts live on disk / VFS", so
-    /// hooks like `flush_site_libs` no longer reconstruct the path
-    /// math themselves.
+    /// hooks like the project-artifact flush no longer reconstruct
+    /// the path math themselves.
     async fn post_render(
         &self,
         _project: &ProjectContext,
@@ -338,11 +338,13 @@ impl ProjectType for WebsiteProjectType {
     /// Run the website post-render hooks.
     ///
     /// **Cross-platform** (Phase 9 sub-phase 9.2):
-    /// 1. **`flush_site_libs`** (Phase 5; resolver-driven) — drain
-    ///    Project-scoped artifacts to whatever destination the
-    ///    resolver decides — `<output_dir>/site_libs/...` natively
-    ///    or `/.quarto/project-artifacts/...` in the hub-client
-    ///    VFS.
+    /// 1. **[`flush_project_artifacts`]** (Phase 5; resolver-driven) —
+    ///    write the Project-scoped artifacts accumulated across every
+    ///    Pass-2 render to whatever destination the resolver decides:
+    ///    `<output_dir>/site_libs/...` natively, or
+    ///    `/.quarto/project-artifacts/...` in the hub-client VFS.
+    ///
+    /// [`flush_project_artifacts`]: crate::artifact_flush::flush_project_artifacts
     ///
     /// **Native-only** (the rest write into the on-disk
     /// `<output_dir>` which doesn't exist in the in-browser
@@ -358,7 +360,7 @@ impl ProjectType for WebsiteProjectType {
     ///
     /// Each hook short-circuits cleanly when its triggering config
     /// is absent, so a website project that opts in to none of
-    /// these features just runs the site_libs flush.
+    /// these features just runs the project-artifact flush.
     async fn post_render(
         &self,
         project: &ProjectContext,
@@ -369,8 +371,7 @@ impl ProjectType for WebsiteProjectType {
         runtime: &dyn quarto_system_runtime::SystemRuntime,
         diagnostics: &mut Vec<DiagnosticMessage>,
     ) -> Result<()> {
-        use super::website_post_render::flush_site_libs;
-        flush_site_libs(project_artifacts, resolver, runtime)?;
+        crate::artifact_flush::flush_project_artifacts(project_artifacts, resolver, runtime)?;
         // The remaining hooks write to the on-disk output dir,
         // which only exists natively. WASM hub-client renders skip
         // them — see Phase 9 plan §Decision 4.

--- a/crates/quarto-core/src/project/pass2_renderer.rs
+++ b/crates/quarto-core/src/project/pass2_renderer.rs
@@ -176,7 +176,7 @@ pub trait Pass2Renderer {
 
     /// Build a resolver suitable for project-level post-render
     /// hooks like
-    /// [`crate::project::website_post_render::flush_site_libs`].
+    /// [`crate::artifact_flush::flush_project_artifacts`].
     ///
     /// - Native ([`RenderToFileRenderer`]): produces a
     ///   [`ResourceResolverContext::project_root`] resolver from
@@ -193,7 +193,7 @@ pub trait Pass2Renderer {
     /// applies: the URL embedded in HTML by `html_url_for(Project,
     /// p)` and the on-disk write path returned by
     /// `on_disk_path_for(Project, p)` must round-trip through this
-    /// resolver. Otherwise `flush_site_libs` writes artifacts to a
+    /// resolver. Otherwise the project-artifact flush writes to a
     /// place the rendered HTML never references.
     fn build_project_resolver(
         &self,
@@ -850,29 +850,20 @@ impl Pass2Renderer for RenderToHtmlRenderer {
         )
         .await?;
 
-        // Drain Project-scoped artifacts. Where they go next mirrors
-        // the native `render_document_to_file` lib_dir branch
-        // (`render_to_file.rs:264-297`):
-        //
-        // - **Shared lib dir** (e.g. websites, `lib_dir == "site_libs"`):
-        //   merge into the orchestrator's accumulator so
-        //   `WebsiteProjectType::post_render` can `flush_site_libs`
-        //   them once across the whole project.
-        // - **No shared lib dir** (default projects, `lib_dir == ""`):
-        //   flush in-place via the per-page (vfs_root) resolver.
-        //   `DefaultProjectType::post_render` is a no-op, so anything
-        //   we leave in the accumulator would silently disappear and
-        //   the iframe would VFS-miss on the theme `<link>` URL the
-        //   HTML embeds (bd-87fu).
+        // Drain Project-scoped artifacts. Where they go next is decided
+        // by `route_drained_project_artifacts`, shared with the other
+        // Pass-2 renderer and with native `render_document_to_file`
+        // (bd-gdhk) — accumulate for a once-per-project flush when
+        // there is a shared lib dir, write in place otherwise.
         //
         // Page-scoped artifacts on `ctx.artifacts` travel back to JS
         // alongside the HTML regardless of which branch fires.
         //
         // Plan 2A item 11: capture the theme fingerprint **before**
-        // the drain. After drain + flush_site_libs (default-project
-        // path), the artifact is gone — neither `ctx.artifacts` nor
-        // `project_artifacts` retain it. Stashing on the output
-        // makes the value visible to both project types.
+        // the drain. After the drain the artifact is gone on the
+        // default-project (write-in-place) path — neither
+        // `ctx.artifacts` nor `project_artifacts` retain it. Stashing
+        // on the output makes the value visible to both project types.
         let theme_fingerprint = ctx
             .artifacts
             .get_by_prefix("css:theme:")
@@ -882,17 +873,19 @@ impl Pass2Renderer for RenderToHtmlRenderer {
 
         let drained = ctx.artifacts.drain_project_scoped();
         let lib_dir = super::orchestrator::project_type_for(project).lib_dir();
-        if lib_dir.is_empty() {
-            super::website_post_render::flush_site_libs(&drained, &resolver, runtime.as_ref())?;
-        } else {
-            project_artifacts.merge_into_project(drained).map_err(|e| {
-                crate::error::QuartoError::other(format!(
-                    "Project-scoped artifact merge failed for {}: {}",
-                    doc_info.input.display(),
-                    e
-                ))
-            })?;
-        }
+        let mut sink = crate::output_sink::OutputSink::new(resolver.allowed_output_roots());
+        crate::artifact_flush::route_drained_project_artifacts(
+            drained,
+            Some(project_artifacts),
+            !lib_dir.is_empty(),
+            &resolver,
+            &mut sink,
+            &doc_info.input,
+        )?;
+        // A no-op when the accumulate branch fired: `OutputSink::flush`
+        // short-circuits on empty ops before touching the filesystem.
+        sink.flush(runtime.as_ref())
+            .map_err(crate::error::QuartoError::from)?;
 
         // bd-cfl67: drain user-resource copy intents (images etc.
         // collected by `ResourceCollectorTransform`) into the
@@ -1118,12 +1111,12 @@ impl Pass2Renderer for RenderToPreviewAstRenderer {
         )
         .await?;
 
-        // Drain Project-scoped artifacts. Identical branching to
-        // `RenderToHtmlRenderer` — shared lib dir merges into the
-        // accumulator (websites use `flush_site_libs` in
-        // `post_render`), no-lib-dir flushes in-place. The choice
-        // is artifact-flow, not payload-flow, so HTML and q2-preview
-        // share it verbatim.
+        // Drain Project-scoped artifacts. Same routing as
+        // `RenderToHtmlRenderer`, via the shared
+        // `route_drained_project_artifacts` (bd-gdhk): shared lib dir
+        // merges into the accumulator for `post_render` to flush,
+        // no-lib-dir writes in place. The choice is artifact-flow, not
+        // payload-flow, so HTML and q2-preview share it verbatim.
         //
         // Plan 2A item 11: capture the theme fingerprint **before**
         // the drain (see `RenderToHtmlRenderer::render` for the
@@ -1169,17 +1162,19 @@ impl Pass2Renderer for RenderToPreviewAstRenderer {
 
         let drained = ctx.artifacts.drain_project_scoped();
         let lib_dir = super::orchestrator::project_type_for(project).lib_dir();
-        if lib_dir.is_empty() {
-            super::website_post_render::flush_site_libs(&drained, &resolver, runtime.as_ref())?;
-        } else {
-            project_artifacts.merge_into_project(drained).map_err(|e| {
-                crate::error::QuartoError::other(format!(
-                    "Project-scoped artifact merge failed for {}: {}",
-                    doc_info.input.display(),
-                    e
-                ))
-            })?;
-        }
+        let mut sink = crate::output_sink::OutputSink::new(resolver.allowed_output_roots());
+        crate::artifact_flush::route_drained_project_artifacts(
+            drained,
+            Some(project_artifacts),
+            !lib_dir.is_empty(),
+            &resolver,
+            &mut sink,
+            &doc_info.input,
+        )?;
+        // A no-op when the accumulate branch fired: `OutputSink::flush`
+        // short-circuits on empty ops before touching the filesystem.
+        sink.flush(runtime.as_ref())
+            .map_err(crate::error::QuartoError::from)?;
 
         // bd-cfl67: see the matching comment in the HTML renderer.
         let copy_warnings = flush_resource_copies(

--- a/crates/quarto-core/src/project/website_post_render.rs
+++ b/crates/quarto-core/src/project/website_post_render.rs
@@ -2,23 +2,31 @@
  * project/website_post_render.rs
  * Copyright (c) 2026 Posit, PBC
  *
- * WebsiteProjectType post-render hooks: site_libs flush, favicon
- * copy, sitemap.xml, robots.txt.
+ * WebsiteProjectType post-render hooks: favicon copy, sitemap.xml,
+ * robots.txt.
  */
 
 //! Post-render hooks for [`WebsiteProjectType`].
 //!
 //! Each function below runs once per project, after Pass 2 has
-//! finished rendering every file. The four hooks are:
+//! finished rendering every file. The three hooks are:
 //!
-//! - [`flush_site_libs`] (Phase 5): drain the orchestrator's
-//!   project-wide artifact accumulator into `_site/site_libs/...`.
 //! - [`copy_favicon`] (Phase 7): copy `<project>/favicon-path` to
 //!   `<output_dir>/favicon-path`.
 //! - [`write_sitemap`] (Phase 7): emit `_site/sitemap.xml` when
 //!   `website.site-url` is set.
 //! - [`write_robots_txt`] (Phase 7): emit `_site/robots.txt`
 //!   pointing at the sitemap, unless the user provided one.
+//!
+//! The Phase 5 project-artifact flush used to live here too, as
+//! `flush_site_libs`. bd-v8gx moved it to
+//! [`crate::artifact_flush::flush_project_artifacts`]: two of its three
+//! callers were not website renders, and the write loop is shared with
+//! the rest of the artifact-write family.
+//!
+//! Every hook that remains here is native-only — each writes into the
+//! project's on-disk output directory, which does not exist in the
+//! in-browser preview.
 //!
 //! Each hook short-circuits cleanly when its triggering config is
 //! absent. Failures bubble up as
@@ -30,14 +38,6 @@
 //!
 //! [`WebsiteProjectType`]: super::orchestrator::WebsiteProjectType
 
-// Phase 9 sub-phase 9.2 lifted the module-level
-// `#![cfg(not(target_arch = "wasm32"))]` so `flush_site_libs` can run
-// in WASM (the hub-client preview's "deduplicate theme CSS into a
-// shared lib dir" pass). The remaining hooks (`copy_favicon`,
-// `write_sitemap`, `write_robots_txt`) stay native-only — they
-// write into the project's on-disk output directory which doesn't
-// exist in the in-browser preview.
-
 #[cfg(not(target_arch = "wasm32"))]
 use std::path::Path;
 #[cfg(not(target_arch = "wasm32"))]
@@ -45,10 +45,12 @@ use std::time::SystemTime;
 
 #[cfg(not(target_arch = "wasm32"))]
 use quarto_error_reporting::DiagnosticMessage;
+#[cfg(not(target_arch = "wasm32"))]
 use quarto_system_runtime::SystemRuntime;
 
+#[cfg(not(target_arch = "wasm32"))]
 use crate::Result;
-use crate::artifact::ArtifactStore;
+#[cfg(not(target_arch = "wasm32"))]
 use crate::error::QuartoError;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::project::ProjectContext;
@@ -56,57 +58,6 @@ use crate::project::ProjectContext;
 use crate::project::index::ProjectIndex;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::project::website_config::{resolved_website_favicon, website_site_url};
-use crate::resource_resolver::ResourceResolverContext;
-
-// ═══════════════════════════════════════════════════════════════════
-// Site libs (Phase 5; resolver-driven since Phase 9 sub-phase 9.2)
-// ═══════════════════════════════════════════════════════════════════
-
-/// Flush every Project-scoped artifact accumulated across Pass-2
-/// renders to its resolver-determined on-disk (or VFS) location.
-///
-/// The resolver decides the destination: native website renders
-/// pass a [`ResourceResolverContext::project_root`] resolver
-/// (artifacts land under `{output_dir}/{lib_dir}/{path}`); the
-/// WASM hub-client passes a [`ResourceResolverContext::vfs_root`]
-/// resolver (artifacts land under `/{vfs_root}/{path}`).
-///
-/// Decoupling the destination from the function's logic enforces
-/// the construction-level invariant from the Phase 9 plan
-/// §Decision 4: the URL embedded in HTML by `html_url_for(Project,
-/// p)` and the on-disk write path returned by
-/// `on_disk_path_for(Project, p)` must round-trip through the same
-/// resolver. Iteration is in sorted-key order so the write order
-/// is deterministic across runs.
-pub(super) fn flush_site_libs(
-    project_artifacts: &ArtifactStore,
-    resolver: &ResourceResolverContext,
-    runtime: &dyn SystemRuntime,
-) -> Result<()> {
-    if project_artifacts.is_empty() {
-        return Ok(());
-    }
-
-    // bd-cfl67: all destructive output flows through the validated
-    // sink so we can never silently truncate a file outside the
-    // resolver's declared output roots.
-    let mut sink = crate::output_sink::OutputSink::new(resolver.allowed_output_roots());
-
-    let mut entries: Vec<(&str, &crate::artifact::Artifact)> = project_artifacts.iter().collect();
-    entries.sort_by(|a, b| a.0.cmp(b.0));
-
-    for (_, artifact) in entries {
-        let Some(path) = &artifact.path else {
-            continue;
-        };
-        let on_disk = resolver.on_disk_path_for(crate::artifact::ArtifactScope::Project, path);
-        sink.write(on_disk, artifact.content.clone())
-            .map_err(QuartoError::from)?;
-    }
-
-    sink.flush(runtime).map_err(QuartoError::from)?;
-    Ok(())
-}
 
 // ═══════════════════════════════════════════════════════════════════
 // Favicon (Phase 7) — native-only
@@ -539,96 +490,6 @@ mod tests {
     use super::*;
     #[cfg(not(target_arch = "wasm32"))]
     use std::time::Duration;
-
-    // === Phase 9 sub-phase 9.2 — resolver-driven flush_site_libs ===
-
-    /// Plan test 5 (refraled): `flush_site_libs` with a `vfs_root`
-    /// resolver writes Project-scoped artifacts to
-    /// `<vfs_root>/<artifact_path>`. The hub-client convention is
-    /// `vfs_root == "/.quarto/project-artifacts"`.
-    #[test]
-    fn flush_site_libs_vfs_root_writes_under_vfs_root() {
-        use crate::artifact::{Artifact, ArtifactScope, ArtifactStore};
-        use crate::resource_resolver::ResourceResolverContext;
-        use quarto_system_runtime::NativeRuntime;
-        use tempfile::TempDir;
-
-        let temp = TempDir::new().unwrap();
-        let vfs_root = temp.path().join(".quarto/project-artifacts");
-        let resolver = ResourceResolverContext::vfs_root(vfs_root.clone());
-
-        let mut store = ArtifactStore::new();
-        let artifact = Artifact::from_bytes(b"body { color: red; }".to_vec(), "text/css")
-            .with_path("quarto/theme.css")
-            .with_scope(ArtifactScope::Project);
-        store.store("theme", artifact);
-
-        let runtime = NativeRuntime::new();
-        flush_site_libs(&store, &resolver, &runtime).unwrap();
-
-        // The artifact landed at <vfs_root>/quarto/theme.css.
-        let written = vfs_root.join("quarto/theme.css");
-        let bytes = std::fs::read(&written).unwrap_or_else(|e| {
-            panic!("expected artifact at {}: {}", written.display(), e);
-        });
-        assert_eq!(bytes, b"body { color: red; }");
-    }
-
-    /// Plan test 6: empty artifact store → no-op (no spurious
-    /// directories created).
-    #[test]
-    fn flush_site_libs_empty_store_is_noop() {
-        use crate::artifact::ArtifactStore;
-        use crate::resource_resolver::ResourceResolverContext;
-        use quarto_system_runtime::NativeRuntime;
-        use tempfile::TempDir;
-
-        let temp = TempDir::new().unwrap();
-        let vfs_root = temp.path().join("vfs");
-        let resolver = ResourceResolverContext::vfs_root(vfs_root.clone());
-
-        let store = ArtifactStore::new();
-        let runtime = NativeRuntime::new();
-        flush_site_libs(&store, &resolver, &runtime).unwrap();
-
-        // The vfs root directory was never created.
-        assert!(!vfs_root.exists(), "no-op flush should not touch FS");
-    }
-
-    /// Plan test 7 (refraled): native website resolver routes
-    /// project-scope artifacts under `{site_root}/{lib_dir}/`.
-    /// Confirms native and WASM use the same `flush_site_libs`
-    /// function but produce different on-disk targets via the
-    /// resolver — Phase 9 §Decision 4 invariant.
-    #[cfg(not(target_arch = "wasm32"))]
-    #[test]
-    fn flush_site_libs_native_website_routes_under_site_libs() {
-        use crate::artifact::{Artifact, ArtifactScope, ArtifactStore};
-        use crate::resource_resolver::ResourceResolverContext;
-        use quarto_system_runtime::NativeRuntime;
-        use tempfile::TempDir;
-
-        let temp = TempDir::new().unwrap();
-        let site_root = temp.path().join("_site");
-        let resolver = ResourceResolverContext::project_root(site_root.clone(), "site_libs");
-
-        let mut store = ArtifactStore::new();
-        let artifact =
-            Artifact::from_bytes(b"kbd { font-family: monospace; }".to_vec(), "text/css")
-                .with_path("libs/kbd/kbd.css")
-                .with_scope(ArtifactScope::Project);
-        store.store("kbd", artifact);
-
-        let runtime = NativeRuntime::new();
-        flush_site_libs(&store, &resolver, &runtime).unwrap();
-
-        let written = site_root.join("site_libs/libs/kbd/kbd.css");
-        assert!(
-            written.exists(),
-            "expected artifact at {}",
-            written.display()
-        );
-    }
 
     /// Phase 9 §Decision 4 invariant: for every artifact, the URL
     /// embedded in HTML by `html_url_for(Project, p)` and the

--- a/crates/quarto-core/src/render_to_file.rs
+++ b/crates/quarto-core/src/render_to_file.rs
@@ -68,6 +68,7 @@ use quarto_system_runtime::SystemRuntime;
 
 use crate::Result;
 use crate::artifact::{ArtifactScope, ArtifactStore};
+use crate::artifact_flush::{enqueue_artifacts, route_drained_project_artifacts};
 use crate::error::QuartoError;
 use crate::format::Format;
 use crate::output_sink::{OutputSink, OutputSinkError};
@@ -363,27 +364,20 @@ pub fn render_document_to_file(
     enqueue_artifacts(&ctx.artifacts, &resolver, ArtifactScope::Page, &mut sink)?;
     let drained = ctx.artifacts.drain_project_scoped();
 
+    // Shared with both Pass-2 renderers (bd-gdhk). Project-scope
+    // artifacts either accumulate for a once-per-project flush, or —
+    // for `lib_dir == ""` / standalone calls — enqueue into this
+    // render's sink, where the resolver routes them under
+    // `{stem}_files/` (pre-Phase-5 layout).
     let has_shared_lib = !project_type.lib_dir().is_empty();
-    match (project_artifacts, has_shared_lib) {
-        (Some(dest), true) => {
-            // Real multi-doc project (e.g. website): drain into
-            // the orchestrator's accumulator; post_render flushes.
-            dest.merge_into_project(drained).map_err(|e| {
-                QuartoError::other(format!(
-                    "Project-scoped artifact merge failed for {}: {}",
-                    input_path.display(),
-                    e
-                ))
-            })?;
-        }
-        _ => {
-            // Default project or standalone call: enqueue Project-
-            // scoped artifacts via the resolver. For lib_dir == ""
-            // the resolver routes them under `{stem}_files/`,
-            // preserving pre-Phase-5 layout.
-            enqueue_artifacts(&drained, &resolver, ArtifactScope::Project, &mut sink)?;
-        }
-    }
+    route_drained_project_artifacts(
+        drained,
+        project_artifacts,
+        has_shared_lib,
+        &resolver,
+        &mut sink,
+        input_path,
+    )?;
 
     // Drain user-resource copy intents (images etc. collected by
     // `ResourceCollectorTransform`) into the sink. The sink will
@@ -427,40 +421,6 @@ pub fn render_document_to_file(
         render_output,
         resource_report,
     })
-}
-
-/// Enqueue every artifact in `store` whose scope matches `scope_filter`
-/// into `sink` at its resolver-determined on-disk location. Skips
-/// artifacts without a `path`.
-///
-/// The caller owns the sink lifecycle (construct, enqueue producers,
-/// flush). Used by `render_document_to_file` (Page scope, per-doc;
-/// Project scope when standalone) and by
-/// `WebsiteProjectType::post_render` for project-shared artifacts
-/// (via [`crate::project::website_post_render::flush_site_libs`]).
-///
-/// Iteration is sorted-key so the resulting flush order is
-/// deterministic across runs / platforms.
-#[cfg(not(target_arch = "wasm32"))]
-pub fn enqueue_artifacts(
-    store: &ArtifactStore,
-    resolver: &ResourceResolverContext,
-    scope_filter: ArtifactScope,
-    sink: &mut OutputSink,
-) -> Result<()> {
-    let mut entries: Vec<(&str, &crate::artifact::Artifact)> = store
-        .iter()
-        .filter(|(_, a)| a.scope == scope_filter)
-        .collect();
-    entries.sort_by(|a, b| a.0.cmp(b.0));
-
-    for (_, artifact) in entries {
-        let Some(path) = &artifact.path else { continue };
-        let on_disk = resolver.on_disk_path_for(artifact.scope, path);
-        sink.write(on_disk, artifact.content.clone())
-            .map_err(QuartoError::from)?;
-    }
-    Ok(())
 }
 
 /// When `options` has no explicit `output_path` / `output_dir`, fall

--- a/crates/quarto-core/src/resource_resolver.rs
+++ b/crates/quarto-core/src/resource_resolver.rs
@@ -128,7 +128,7 @@ impl ResourceResolverContext {
 
     /// Construct a resolver suitable for *project-level* hooks that
     /// only consult `Project`-scope queries (e.g.
-    /// [`crate::project::website_post_render::flush_site_libs`]).
+    /// [`crate::artifact_flush::flush_project_artifacts`]).
     ///
     /// Page-specific fields (page output, `{stem}_files/`) are
     /// stubbed out — calling [`Self::html_url_for`] with

--- a/crates/quarto-core/tests/integration/listing_pipeline.rs
+++ b/crates/quarto-core/tests/integration/listing_pipeline.rs
@@ -373,7 +373,8 @@ fn vendored_js_artifacts_emit_script_tags_and_land_under_site_libs() {
     // Project-scoped artifacts when at least one listing is
     // rendered, picked up by `<script>` auto-emission via the
     // `js:` artifact-key prefix, and flushed to
-    // `_site/site_libs/listing/<file>.js` by `flush_site_libs`.
+    // `_site/site_libs/listing/<file>.js` by
+    // `flush_project_artifacts`.
     let (project_dir, outputs) = render_project(|p| {
         write(
             &p.join("_quarto.yml"),

--- a/crates/quarto-core/tests/integration/render_page_in_project.rs
+++ b/crates/quarto-core/tests/integration/render_page_in_project.rs
@@ -16,7 +16,7 @@
 //! returning [`WasmPassTwoOutput`] in-memory rather than writing to
 //! disk. The HTML is inspected for sidebar entries, cross-document
 //! link rewriting, page-scope artifacts, and project-scope artifact
-//! flush via `flush_site_libs`.
+//! flush via `flush_project_artifacts`.
 //!
 //! Pinning native coverage on this code path means a regression in
 //! the project-rendering machinery surfaces in `cargo nextest run`
@@ -59,8 +59,8 @@ fn canonical(path: &Path) -> PathBuf {
 /// the artifact root. In WASM that's an absolute path under the
 /// in-memory VFS (`/.quarto/project-artifacts`). On native
 /// `NativeRuntime`, we point it at a real subdirectory of the
-/// temp test fixture so `flush_site_libs` can actually write
-/// without bumping into read-only system paths.
+/// temp test fixture so the project-artifact flush can actually
+/// write without bumping into read-only system paths.
 fn render_active_page(project_dir: &Path, active: &Path) -> WasmPassTwoOutput {
     let runtime: Arc<dyn SystemRuntime> = Arc::new(NativeRuntime::new());
     // Discover from the active file first — that locates the

--- a/crates/quarto-system-runtime/src/wasm.rs
+++ b/crates/quarto-system-runtime/src/wasm.rs
@@ -323,7 +323,7 @@ impl SystemRuntime for WasmRuntime {
     fn file_write(&self, path: &Path, contents: &[u8]) -> RuntimeResult<()> {
         // Change-detection in the in-memory VFS layer (bd-q3bxnq2e
         // decision 3): byte-identical re-writes are skipped — this is
-        // what makes `flush_site_libs`'s per-render re-flush of
+        // what makes `flush_project_artifacts`'s per-render re-flush of
         // unchanged project artifacts (theme CSS, fonts, shared JS)
         // cheap. Native disk writes are intentionally not change-aware
         // (a compare there would cost a disk read per artifact).

--- a/crates/wasm-quarto-hub-client/src/lib.rs
+++ b/crates/wasm-quarto-hub-client/src/lib.rs
@@ -1752,8 +1752,8 @@ async fn render_project_active_page_to_response(
 
     // Populate VFS with the active page's Page-scoped artifacts.
     // (Project-scoped artifacts were already flushed to VFS by
-    // `WebsiteProjectType::post_render` → `flush_site_libs` via
-    // the WASM renderer's vfs_root resolver.)
+    // `WebsiteProjectType::post_render` → `flush_project_artifacts`
+    // via the WASM renderer's vfs_root resolver.)
     //
     // The shared flush carries the bd-3gtn empty-content skip and the
     // bd-q3bxnq2e byte-identical-skip; see


### PR DESCRIPTION
Closes bd-v8gx and bd-gdhk together, because the investigation showed they are one piece of work.

## What this does

Three near-copies of "iterate an artifact store, resolve each path, write it" lived in three modules under three unrelated names. This collapses them onto **one loop** in `quarto-core::artifact_flush` — a module that already existed (bd-q3bxnq2e) and already held the third copy.

| Entry point | Destination | Sink lifecycle |
| --- | --- | --- |
| `enqueue_artifacts` | `OutputSink` | **caller** constructs + flushes |
| `flush_project_artifacts` | `OutputSink` | **owns** one, flushes it |
| `route_drained_project_artifacts` | accumulator *or* sink | caller's sink |
| `flush_artifacts_to_vfs` | `VirtualFileSystem` | n/a (pre-existing) |

The `enqueue_` / `flush_` verb prefix is the whole distinction — that is why `flush_project_artifacts` needs no disambiguating suffix despite sitting next to `enqueue_artifacts(…, ArtifactScope::Project, …)`.

- **bd-v8gx** — `flush_site_libs` → `flush_project_artifacts`, moved out of `project/website_post_render.rs`, whose module doc opens *"Post-render hooks for WebsiteProjectType"* while two of the function's three callers were not website renders.
- **bd-gdhk** — new `route_drained_project_artifacts` for the drain-and-flush-or-merge logic that `render_document_to_file` and both Pass-2 renderers each hand-rolled. The two Pass-2 copies were byte-identical.

### Why the move was forced, not merely tidy

`pub mod render_to_file` is itself `#[cfg(not(target_arch = "wasm32"))]`, so `enqueue_artifacts` did not just carry a redundant per-function gate — **it did not exist on wasm32**. The cross-platform `flush_site_libs` therefore could not call it and had to duplicate it. Hosting the family in an ungated module is what lets them share one loop. `OutputSink` is already cross-platform, so the body ported unchanged.

## ⚠️ One deliberate behavior change — please review this specifically

`flush_site_libs` called `on_disk_path_for(Project, p)` **unconditionally**. `enqueue_artifacts` **filters** on `artifact.scope`. So a non-Project entry reaching the old function was written *at the Project root* (silently misplaced); after delegation it would be *silently dropped* instead.

Does that happen? `merge_into_project` (`artifact.rs:344`) inserts entries **verbatim and does not re-stamp scope** — the "accumulator is all Project-scoped" invariant holds only by construction of its callers, and nothing enforces it.

Rather than preserve either silent outcome, `flush_project_artifacts` now `debug_assert!`s the invariant: **loud in dev, filtered in release**. Pinned by two `cfg`'d tests (`#[should_panic]` under `debug_assertions`, filter-behavior otherwise).

**Everything else is behavior-preserving.** Two supporting facts:
- `OutputSink::flush` short-circuits on empty `ops` *before* materializing allowed roots, so dropping the old explicit `is_empty()` early return creates no directories (guarded by a test).
- Iteration stays sorted-by-key, so flush order is unchanged.

Also fixes a doc comment that **lied**: `enqueue_artifacts` claimed `WebsiteProjectType::post_render` reached it "via `flush_site_libs`", which it never did.

## Tests (TDD)

14 tests in `artifact_flush` (was 5). Written **first** and confirmed failing with exactly the two expected `cannot find function` errors before any implementation: 3 carried over from the old `flush_site_libs_*` tests, 4 new for the routing seam (accumulate / write-in-place / no-accumulator / merge-conflict diagnostic), 2 `cfg`'d for the scope-filter decision.

## Prose sweep — note for reviewers

31 `flush_site_libs` references across 10 files in 3 crates → **3** deliberate history notes. Two stale **intra-doc links** were repointed.

Worth knowing: **neither `cargo clippy -D warnings` nor CI resolves intra-doc links** — there is no `cargo doc` step in `.github/workflows/`. A stale one fails silently, so grep is the gate here, not the compiler.

The sweep matched the full symbol, never `site_libs`: of **173** `site_libs` occurrences in `crates/**/*.rs`, only **31** were the function name; the other **142** name the real output directory (`WebsiteProjectType::lib_dir()` returns `"site_libs"`). A naive `sed` would have corrupted website output paths.

## Verification

`cargo build --workspace`, `cargo nextest run --workspace` (10598 passed), `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --check`, `cargo xtask lint`, and full `cargo xtask verify` (all 14 steps, including the WASM + hub-client legs) — all clean. No snapshot files changed.

### End-to-end through the real binary, both routing branches, output inspected

**Website** (shared `lib_dir` → accumulate → `post_render` flush):

```
$ cargo run -q --bin q2 -- render <fixture>/site
Rendered 2 of 2 files to .../site/_site

$ find _site/site_libs -type f
site_libs/bootstrap/bootstrap-icons.css
site_libs/bootstrap/bootstrap-icons.woff
site_libs/quarto/bootstrap.bundle.min.js
site_libs/quarto/clipboard.min.js
site_libs/quarto/code-copy-init.js
site_libs/quarto/quarto-theme-127bdf77135c0e58.css

$ grep -o 'href="[^"]*quarto-theme[^"]*"' _site/index.html
href="site_libs/quarto/quarto-theme-127bdf77135c0e58.css"
```

The `<link href>` matches the on-disk path — the Phase 9 §Decision 4 round-trip invariant survives the refactor.

**Standalone default project** (`lib_dir == ""` → write in place, the bd-87fu path):

```
$ find standalone_files -type f
bootstrap.bundle.min.js
clipboard.min.js
code-copy-init.js
styles.css

$ grep -o 'href="[^"]*\.css"' standalone.html
href="standalone_files/styles.css"
```

## Discovered work — filed, deliberately not folded in here

- **bd-lameekm1** — empty-content artifacts are skipped on the VFS path (bd-3gtn: "manifest entries … must never be written") but written on **both** `OutputSink` paths. bd-cfl67 removed the known producer, so there may be no live trigger, but nothing enforces that. Behavior question, deserves its own tests.
- **bd-eb2wnxkp** — `list_doc_ids_filesystem` (`quarto-hub/src/admin/scan.rs:80`) rebuilds automerge doc ids as `format!("{prefix}{rest}")` from a two-level `<2-char>/<rest>/` layout; on case-insensitive APFS/NTFS two ids whose prefixes case-fold together share one directory, so one reads back **mis-cased**.

  Surfaced as a failing `quarto-hub` test on this branch. I did not write it off as unrelated — that is what a real regression looks like at first. The assertion diff was one id differing *from itself* only in letter case at index 1 (27 of 28 chars identical). **Reproduced on a clean `main` worktree at 2 failures in 60 iterations (~3%)** with the same signature, so it is pre-existing and unreachable from this branch (no `crates/quarto-hub/` file changed here). Verifying any fix will need a stress loop — a single green run means nothing at 3%.

Plan: `claude-notes/plans/2026-07-28-rename-flush-site-libs.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
