### PR TITLE
Fix flaky preview-renderer run: unhandled elementFromPoint error (bd-cpyq99ps)

### DIFF
--- a/claude-notes/plans/2026-07-28-preview-renderer-elementfrompoint-flake.md
+++ b/claude-notes/plans/2026-07-28-preview-renderer-elementfrompoint-flake.md
@@ -1,0 +1,155 @@
+# Flaky preview-renderer run: unhandled `elementFromPoint` error (bd-cpyq99ps)
+
+**Date:** 2026-07-28
+**Braid:** bd-cpyq99ps (bug, P2) — `discovered-from: bd-dofxhzaj`
+**Branch:** `braid/bd-cpyq99ps-flaky-preview-renderer-integration` off `main` @ `7ff19ff8`
+
+## Symptom
+
+`cargo xtask verify` step 11 fails **with every test passing**:
+
+```
+ Test Files  48 passed (48)
+      Tests  565 passed | 1 skipped (566)
+     Errors  1 error
+```
+
+Vitest counts an *unhandled* error as a run failure, so a fully green suite
+reddens the whole verify. Observed once during bd-dofxhzaj's pre-push verify on
+a loaded machine; three immediate re-runs were clean.
+
+```
+TypeError: (intermediate value).elementFromPoint is not a function
+ ❯ posAtCoords          node_modules/prosemirror-view/dist/index.js:465:10
+ ❯ EditorView.posAtCoords  …:5724:16
+ ❯ placeCaretFromClick  src/q2-preview/richtext/caretFromClick.ts:32:29
+ ❯ src/q2-preview/richtext/RichTextEditor.tsx:235:22
+ ❯ runAnimationFrameCallbacks  node_modules/jsdom/lib/jsdom/browser/Window.js:662
+```
+
+## Root cause
+
+ProseMirror's `posAtCoords` does:
+
+```js
+let elt = (view.root.elementFromPoint ? view.root : doc)
+            .elementFromPoint(coords.left, coords.top);
+```
+
+The ternary guards `view.root` but **not** the `doc` fallback. jsdom implements
+`elementFromPoint` on neither, so the fallback branch throws.
+
+Two things turned that into a *flake* rather than an honest failure:
+
+1. **It runs in a `requestAnimationFrame`.** `RichTextEditor.tsx:227` schedules
+   the opening-click replay a frame after mount (deliberately — the editor box
+   must be laid out first). When the frame fires while its test is still
+   running, the throw is attributed to that test; when it fires after the test
+   finished, it escapes as an unhandled error belonging to no test. Which one
+   happens depends on machine load — hence intermittent, and hence why it
+   showed up during a verify competing with concurrent cargo builds.
+2. **Nothing ever tested the real code path.** `caretFromClick.test.ts` drives a
+   *fake* editor whose `posAtCoords` is a `vi.fn()`.
+   `RichTextEditor.caret.integration.test.tsx` `vi.mock`s the whole
+   `./caretFromClick` module. The file that actually tripped it,
+   `p3-4-inline-breadcrumb.integration.test.tsx`, mocks nothing at all and
+   mounts a real editor — it hit the real ProseMirror path by accident, not by
+   design.
+
+So `caretFromClick.ts`'s own comment — *"jsdom returns null from posAtCoords"* —
+was **false**, and had never been checked.
+
+## What was already fine (checked, not assumed)
+
+The strand's original guesses about the production code were wrong, and are
+recorded here so nobody re-litigates them:
+
+- The mount effect **already** cancels its frame on cleanup
+  (`return () => cancelAnimationFrame(raf)`) and **already** guards
+  `if (editor.isDestroyed) return`. There is no leaked-callback bug to fix.
+- `caretFromPoint` — the other coordinate helper on the same ProseMirror path —
+  *does* guard both `doc.caretPositionFromPoint` and `doc.caretRangeFromPoint`
+  with `if (doc.X)`. `elementFromPoint` is the single unguarded one.
+
+## Fix
+
+Stub `Document.prototype.elementFromPoint` to return `null` in
+`src/test-utils/setup.ts`.
+
+**Why the test environment and not the production code.** Every real browser
+implements `elementFromPoint`; a `typeof … === 'function'` guard in
+`caretFromClick.ts` would be dead code in production whose only purpose is to
+paper over a test-harness gap. The honest jsdom answer is that no element is
+under any point (there is no layout), and `null` says exactly that.
+`posAtCoords` then takes its "outside the editor" branch and returns `null` —
+which is the miss that `caretFromClick.ts` documents and its callers already
+handle by falling back to `focus('end')`. The fix makes the documented contract
+*true* rather than suppressing its violation.
+
+**This is a precedent, not a new pattern.** `setup.ts` already carries a
+structurally identical block: jsdom implements `getClientRects` on neither
+`Text` nor `Range`, so ProseMirror's `coordsAtPos` threw from tiptap's autofocus
+rAF, and it was fixed by stubbing zero-size rects. Same gap, same rAF, same
+remedy — the new block sits directly beneath it and says so.
+
+## Work items
+
+- [x] Reproduce deterministically — new `caretFromClick.integration.test.ts`
+      drives a **real** tiptap editor (real ProseMirror `EditorView`, nothing
+      mocked). 5/5 tests fail before the fix with the exact
+      `prosemirror-view:465` stack from the flake.
+- [x] Fix: stub `Document.prototype.elementFromPoint` in `setup.ts`, beneath the
+      existing `getClientRects` precedent, with a comment explaining the rAF
+      escape mechanism.
+- [x] 5/5 pass after.
+- [x] Correct `caretFromClick.ts`'s comment: its jsdom claim is now true, and it
+      points at *what makes it true* (the setup stub) and at the test that pins
+      it.
+- [x] Full preview-renderer integration suite: 4/4 clean runs, 49 files, 570
+      tests, **0 errors**.
+- [x] Unit suite unaffected: 40 passed / 2 skipped, 538 tests.
+- [x] `cargo xtask verify --skip-hub-build` green (exit 0, all steps) — step 11
+      is the one that flaked; it is the step this fixes
+- [ ] PR
+
+## Verification record
+
+**Before the fix** (stub reverted via `git stash`), full integration suite ×6 —
+the new test file fails every time, 5 `elementFromPoint` hits per run:
+
+```
+run 1: elementFromPoint-hits=5 | Test Files 1 failed | 48 passed (49)
+… identical through run 6
+```
+
+**After the fix**, full integration suite ×4:
+
+```
+run 1: elementFromPoint-hits=0 | Test Files 49 passed (49) | Tests 570 passed | 1 skipped (571)
+… identical through run 4
+```
+
+### Honest limit on what was reproduced
+
+I reproduced and fixed the **root cause** deterministically. I did **not**
+reproduce the original *intermittent manifestation* on demand: running
+`p3-4-inline-breadcrumb.integration.test.tsx` alone ×5 and the full suite ×6
+with the fix reverted never produced the unhandled-error form, because that
+requires the rAF to lose its race against test teardown — which needs the
+machine under load, as it was during the verify that first surfaced it.
+
+That gap does not weaken the fix: the throw is now impossible regardless of
+*when* the frame fires, since `posAtCoords` no longer has anything to throw
+from. Timing only ever decided whether the error was attributed to a test or
+escaped it.
+
+## Follow-up worth considering (not done here)
+
+`p3-4-inline-breadcrumb.integration.test.tsx` mounts a real `RichTextEditor`
+and mocks nothing. That is how this was found, and it is a *good* property — but
+it means any future unguarded browser API on the editor mount path will surface
+the same way: as an unhandled error in an unrelated-looking test file. Worth
+considering a vitest `onUnhandledError` that fails loudly with a pointer to
+`setup.ts`, so the next one reads as "a DOM API is missing from the harness"
+rather than "the breadcrumb test is flaky". Not filed as a strand — mentioning
+it in case it earns its keep the next time this class of bug appears.

--- a/ts-packages/preview-renderer/src/q2-preview/richtext/caretFromClick.integration.test.ts
+++ b/ts-packages/preview-renderer/src/q2-preview/richtext/caretFromClick.integration.test.ts
@@ -1,0 +1,102 @@
+/**
+ * caretFromClick against a REAL ProseMirror view in jsdom (bd-cpyq99ps).
+ *
+ * `caretFromClick.ts` documents its jsdom contract as "jsdom returns null from
+ * posAtCoords" — i.e. every coordinate lookup is a MISS, so the caller falls
+ * back to end-of-block focus. That claim was never tested: the unit tests
+ * (`caretFromClick.test.ts`) drive a *fake* editor whose `posAtCoords` is a
+ * `vi.fn()`, and `RichTextEditor.caret.integration.test.tsx` `vi.mock`s this
+ * whole module. Nothing exercised the real ProseMirror code path.
+ *
+ * It was false. ProseMirror's `posAtCoords` calls
+ * `(view.root.elementFromPoint ? view.root : doc).elementFromPoint(...)`, and
+ * jsdom implements `elementFromPoint` on neither — so the fallback `doc` branch
+ * threw `TypeError: ...elementFromPoint is not a function` rather than
+ * returning null.
+ *
+ * That surfaced as a FLAKE, not a failure: the only caller is a
+ * `requestAnimationFrame` in RichTextEditor's mount effect. When the frame
+ * happened to fire while its test was still running, the throw was attributed
+ * somewhere; when it fired after the test finished, it escaped as an unhandled
+ * error and vitest failed the whole run with every test passing (48 files, 565
+ * tests, "Errors 1 error").
+ *
+ * These tests pin the documented contract to the real implementation, so a
+ * future jsdom/ProseMirror change that reintroduces the throw fails here —
+ * deterministically, in one named test — instead of reappearing as an
+ * intermittent red run somewhere else in the suite.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { Editor } from '@tiptap/core';
+import StarterKit from '@tiptap/starter-kit';
+import { placeCaretFromClick, placeSelectionFromDrag } from './caretFromClick';
+
+let editor: Editor | null = null;
+
+afterEach(() => {
+    editor?.destroy();
+    editor = null;
+});
+
+/**
+ * A genuine tiptap editor with a genuine ProseMirror `EditorView` — the point
+ * of these tests is that `view.posAtCoords` is the real implementation, so
+ * nothing here may be mocked.
+ */
+function realEditor(): Editor {
+    const element = document.createElement('div');
+    document.body.appendChild(element);
+    return new Editor({
+        element,
+        extensions: [StarterKit],
+        content: '<p>hello</p>',
+        autofocus: false,
+    });
+}
+
+describe('placeCaretFromClick against a real ProseMirror view in jsdom', () => {
+    it('reports a miss instead of throwing', () => {
+        editor = realEditor();
+
+        // The regression itself: this threw TypeError before bd-cpyq99ps.
+        expect(() => placeCaretFromClick(editor!, { x: 12, y: 34 })).not.toThrow();
+    });
+
+    it('returns false so the caller keeps its end-of-block default', () => {
+        editor = realEditor();
+
+        // jsdom has no layout, so every point is outside every box: a miss.
+        // Returning `false` (rather than throwing, or claiming a bogus hit) is
+        // what lets RichTextEditor's fallback chain reach `focus('end')`.
+        expect(placeCaretFromClick(editor!, { x: 12, y: 34 })).toBe(false);
+    });
+
+    it('leaves the selection untouched on a miss', () => {
+        editor = realEditor();
+        const before = editor.state.selection.from;
+
+        placeCaretFromClick(editor, { x: 12, y: 34 });
+
+        expect(editor.state.selection.from).toBe(before);
+    });
+});
+
+describe('placeSelectionFromDrag against a real ProseMirror view in jsdom', () => {
+    it('reports a miss instead of throwing', () => {
+        editor = realEditor();
+
+        // Same posAtCoords path, called twice (drag anchor + head).
+        expect(() =>
+            placeSelectionFromDrag(editor!, { x: 5, y: 6 }, { x: 40, y: 6 }),
+        ).not.toThrow();
+    });
+
+    it('returns false so the caller falls back to the caret path', () => {
+        editor = realEditor();
+
+        expect(
+            placeSelectionFromDrag(editor, { x: 5, y: 6 }, { x: 40, y: 6 }),
+        ).toBe(false);
+    });
+});

--- a/ts-packages/preview-renderer/src/q2-preview/richtext/caretFromClick.ts
+++ b/ts-packages/preview-renderer/src/q2-preview/richtext/caretFromClick.ts
@@ -10,9 +10,17 @@
 //
 // This works because the editor renders the SAME visual text in the SAME measured
 // box as the rendered block (same theme CSS), so the click's viewport coordinates
-// land on the same glyph. Geometry correctness is browser-verified (jsdom returns
-// null from posAtCoords); the unit tests here cover the hit/miss logic with a fake
-// editor.
+// land on the same glyph. Geometry correctness is browser-verified; the unit tests
+// here cover the hit/miss logic with a fake editor.
+//
+// Under jsdom every lookup is a MISS (posAtCoords returns null), so callers take
+// their fallback path. That is only true because `src/test-utils/setup.ts` stubs
+// `Document.prototype.elementFromPoint` — jsdom does not implement it, and without
+// the stub ProseMirror's posAtCoords THROWS rather than returning null
+// (bd-cpyq99ps: it escaped a requestAnimationFrame as an unhandled error and
+// reddened the whole suite intermittently). `caretFromClick.integration.test.ts`
+// pins the miss contract against a real ProseMirror view so it cannot silently
+// become a throw again.
 
 import type { Editor } from '@tiptap/core';
 import { TextSelection } from '@tiptap/pm/state';

--- a/ts-packages/preview-renderer/src/test-utils/setup.ts
+++ b/ts-packages/preview-renderer/src/test-utils/setup.ts
@@ -48,3 +48,29 @@ if (!globalThis.IntersectionObserver) {
     if (proto && typeof proto.getBoundingClientRect !== 'function') proto.getBoundingClientRect = zeroRect;
   }
 }
+
+// Same shape as the block above, different missing API (bd-cpyq99ps). jsdom does
+// not implement elementFromPoint, and ProseMirror's posAtCoords calls
+//   (view.root.elementFromPoint ? view.root : doc).elementFromPoint(x, y)
+// — with neither implemented it takes the `doc` branch and throws
+// "elementFromPoint is not a function" whenever a mounted tiptap editor replays
+// an opening click (RichTextEditor's placement rAF, bd-q9lyghv2).
+//
+// That made it a FLAKE rather than a failure: because the call happens in a
+// requestAnimationFrame, the throw escaped as an *unhandled* error whenever the
+// frame fired after its test had finished, and vitest failed the entire run
+// with every test passing.
+//
+// null is the honest jsdom answer — there is no layout, so no element is under
+// any point. posAtCoords treats a null hit as "outside the editor" and returns
+// null, which is precisely the miss that caretFromClick.ts documents and that
+// its callers already handle by falling back to end-of-block focus. Pinned by
+// caretFromClick.integration.test.ts against a real ProseMirror view.
+{
+  const proto = globalThis.Document?.prototype as
+    | { elementFromPoint?: unknown }
+    | undefined;
+  if (proto && typeof proto.elementFromPoint !== 'function') {
+    proto.elementFromPoint = () => null;
+  }
+}


### PR DESCRIPTION
`cargo xtask verify` step 11 intermittently failed **with every test passing**:

```
 Test Files  48 passed (48)
      Tests  565 passed | 1 skipped (566)
     Errors  1 error
```

Vitest counts an *unhandled* error as a run failure, so a fully green suite reddened the whole verify. Found during bd-dofxhzaj's pre-push verify on a loaded machine; three immediate re-runs were clean.

## Root cause

One unguarded line in ProseMirror's `posAtCoords`:

```js
let elt = (view.root.elementFromPoint ? view.root : doc)
            .elementFromPoint(coords.left, coords.top);
```

The ternary guards `view.root` but **not** the `doc` fallback. jsdom implements `elementFromPoint` on neither, so the fallback throws.

Two things made it a *flake* rather than an honest failure:

1. **It runs in a `requestAnimationFrame`** — deliberately, so the editor box is laid out before geometry is read (`RichTextEditor.tsx:227`). Whether the throw lands inside its test or escapes as an unhandled error depends on machine load. Hence intermittent, and hence why it appeared during a verify competing with concurrent cargo builds.
2. **Nothing ever exercised the real path.** `caretFromClick.test.ts` drives a *fake* editor whose `posAtCoords` is a `vi.fn()`; `RichTextEditor.caret.integration.test.tsx` `vi.mock`s the whole module. The file that tripped it mocks nothing and reached real ProseMirror by accident. So `caretFromClick.ts`'s own comment — *"jsdom returns null from posAtCoords"* — was **false** and had never been checked.

## Fix

Stub `Document.prototype.elementFromPoint` → `null` in `src/test-utils/setup.ts`.

**In the harness, not production, deliberately.** Every real browser implements `elementFromPoint`, so a `typeof … === 'function'` guard in `caretFromClick.ts` would be dead code whose only purpose is papering over a jsdom gap. `null` is the honest jsdom answer — there is no layout, so no element is under any point — and it makes `posAtCoords` return the miss that `caretFromClick.ts` documents and its callers already handle by falling back to `focus('end')`. This makes the documented contract *true* rather than suppressing its violation.

**Not a new pattern.** `setup.ts` already carries a structurally identical block a few lines above: jsdom implements `getClientRects` on neither `Text` nor `Range`, so ProseMirror's `coordsAtPos` threw from tiptap's autofocus rAF, fixed by stubbing zero-size rects. Same gap, same rAF, same remedy — the new block sits directly beneath it and says so.

## Checked, not assumed — and deliberately not changed

The strand's original guesses about the production code were wrong:

- The mount effect **already** cancels its frame on cleanup (`return () => cancelAnimationFrame(raf)`) and **already** guards `if (editor.isDestroyed) return`. There is no leaked-callback bug.
- `caretFromPoint`, the sibling helper on the same ProseMirror path, **already** guards both `caretPositionFromPoint` and `caretRangeFromPoint`. `elementFromPoint` is the single unguarded one.

## The real defect was a coverage gap

`caretFromClick.integration.test.ts` (new) drives a **real** tiptap editor with a **real** ProseMirror `EditorView`, nothing mocked — closing the gap that let a false documented contract survive.

| | before fix | after fix |
|---|---|---|
| new test file | **5/5 fail**, exact `prosemirror-view:465` stack | 5/5 pass |
| full integration suite | ×6, fails every run | ×4 clean: 49 files, 570 tests, **0 errors** |
| unit suite | — | unaffected: 40 passed / 2 skipped, 538 tests |

`cargo xtask verify --skip-hub-build` green, exit 0 — including step 11, the step this fixes.

### Honest limit

I reproduced and fixed the **root cause** deterministically. I did **not** reproduce the original *intermittent manifestation* on demand — that needs the rAF to lose its race against test teardown, which needs the machine under load. It doesn't weaken the fix: timing only ever decided whether the error was attributed to a test or escaped it, and `posAtCoords` now has nothing to throw from regardless of when the frame fires.

Closes bd-cpyq99ps. Plan: `claude-notes/plans/2026-07-28-preview-renderer-elementfrompoint-flake.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
