### PR TITLE
Bring forward samod to 0.12.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4813,8 +4813,8 @@ dependencies = [
 
 [[package]]
 name = "samod"
-version = "0.12.1"
-source = "git+https://github.com/quarto-dev/samod.git?branch=access-policy#c5a06c397e69554b65441da39da6deb788a75d26"
+version = "0.12.3"
+source = "git+https://github.com/quarto-dev/samod.git?branch=access-policy#56c83568bb7a35d2cbdf322f67ccc5fb2fdc25e9"
 dependencies = [
  "async-channel",
  "automerge",
@@ -4836,8 +4836,8 @@ dependencies = [
 
 [[package]]
 name = "samod-core"
-version = "0.12.0"
-source = "git+https://github.com/quarto-dev/samod.git?branch=access-policy#c5a06c397e69554b65441da39da6deb788a75d26"
+version = "0.12.3"
+source = "git+https://github.com/quarto-dev/samod.git?branch=access-policy#56c83568bb7a35d2cbdf322f67ccc5fb2fdc25e9"
 dependencies = [
  "automerge",
  "base64 0.21.7",

--- a/crates/quarto-hub-provider/Cargo.toml
+++ b/crates/quarto-hub-provider/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/lib.rs"
 # Automerge sync via the same samod fork the hub uses. Must match quarto-hub's
 # version/branch exactly, else samod (and its automerge) resolve to a second copy
 # and DocHandle types no longer unify across the crate boundary.
-samod = { version = "0.12.1", git = "https://github.com/quarto-dev/samod.git", branch = "access-policy", features = ["tokio", "tungstenite"] }
+samod = { version = "0.12.3", git = "https://github.com/quarto-dev/samod.git", branch = "access-policy", features = ["tokio", "tungstenite"] }
 # Reused index-document model (file list, capture sidecar) for the join+list path.
 quarto-hub = { path = "../quarto-hub" }
 # Read file documents out of the VFS during materialization (must match the

--- a/crates/quarto-hub/Cargo.toml
+++ b/crates/quarto-hub/Cargo.toml
@@ -47,7 +47,7 @@ time = "0.3"
 # non-BMP characters (emoji etc.) — each emoji is 1 code point but 2 UTF-16 code units.
 automerge = { version = "0.10.0", features = ["utf16-indexing"] }
 # Vendored samod fork carrying the synchronous AccessPolicy trait (long-term home).
-samod = { version = "0.12.1", git = "https://github.com/quarto-dev/samod.git", branch = "access-policy", features = ["tokio", "axum", "tungstenite"] }
+samod = { version = "0.12.3", git = "https://github.com/quarto-dev/samod.git", branch = "access-policy", features = ["tokio", "axum", "tungstenite"] }
 
 # Async streams (for samod event handling)
 futures = "0.3"

--- a/crates/quarto-preview/Cargo.toml
+++ b/crates/quarto-preview/Cargo.toml
@@ -23,7 +23,7 @@ thiserror.workspace = true
 # can talk to samod directly (it reads back the binary doc Phase C.1
 # writes; Phase C.4 reuses the same wire format in the WASM/SPA layer).
 automerge = { version = "0.10.0", features = ["utf16-indexing"] }
-samod = { version = "0.12.1", git = "https://github.com/quarto-dev/samod.git", branch = "access-policy", features = ["tokio"] }
+samod = { version = "0.12.3", git = "https://github.com/quarto-dev/samod.git", branch = "access-policy", features = ["tokio"] }
 
 quarto-core.workspace = true
 quarto-error-reporting = { workspace = true, features = ["json"] }


### PR DESCRIPTION
Pull in our patched version of `samod` (rebased on 0.12.3) at `quarto-dev/samod@access-policy`.