### PR TITLE
Auth failures now say what went wrong (not "you are not authorized")

### DIFF
--- a/claude-notes/plans/2026-07-30-auth-error-reasons-and-audit-coverage.md
+++ b/claude-notes/plans/2026-07-30-auth-error-reasons-and-audit-coverage.md
@@ -1,0 +1,495 @@
+# Auth failure: distinguishable reasons and audit coverage
+
+**Status:** implemented 2026-07-30 on `braid/bd-htis60s7-auth-error-reasons`.
+**Date:** 2026-07-30.
+**Follows:** `claude-notes/plans/2026-07-27-auth-current-flow-hardening.md`
+(item H2, shipped in `807fd96c`, PR #427) and
+`claude-notes/plans/2026-07-06-hub-server-minted-sliding-sessions.md` (C0–C7).
+**Ops doc to keep in sync:** `dev-docs/quarto-hub/session-auth-operations.md`.
+
+## Overview
+
+Every way `POST /auth/callback` can fail lands the user on the same screen
+with the same sentence:
+
+> Sign-in failed. Your account is not authorized to access this hub.
+
+Eleven distinct causes collapse into that one message, and only two of them
+(a banned user, and an email matching no allowlist) are actually about
+authorization. The others — an expired sign-in, a stale browser tab, a lost
+cookie, a CSRF mismatch, a server-side mint failure — are misreported as a
+permissions problem, sending the user to an administrator instead of to the
+reload button that would fix it.
+
+Two audit gaps sit underneath:
+
+- The CSRF check (`server.rs:1049`) calls `auth_error()` without emitting an
+  audit event, so a deployment failing there is invisible in
+  `journalctl -u hub`.
+- `check_login_nonce` returns `login_state_missing` for a cookie-absent
+  callback without inspecting the token, conflating "this browser is running
+  an old bundle" with "the cookie did not survive Google's cross-site POST".
+  Those want opposite remedies. The same return also emits **doubled** —
+  it returns `"login_state_missing"` (`server.rs:997`) and the emit site
+  wraps it in `format!("login_state_{detail}")` (`server.rs:1071`), so the
+  log shows `detail=login_state_login_state_missing` while the ops doc
+  (line 77) documents `login_state_missing`. No test pins any of the six
+  detail strings.
+
+| Item | What | Size |
+|------|------|------|
+| E0 | `login_state_missing` conflates stale-client with cookie-loss, and is emitted double-prefixed | S |
+| E1 | `auth_error()` collapses 11 causes into "not authorized", discarding the 403/401 status that separates the two real denials from the rest | M |
+| E2 | CSRF failures are audit-silent | S |
+| E3 | Auto-generated secrets are silent (multi-instance hazard) | S |
+
+E0 lands before E1 — it is what makes E1's `stale_client` reason
+expressible. E1 is the highest-leverage item: it turns the next auth failure
+into a legible error instead of a debugging session.
+
+## Design constraints
+
+1. **User-facing reasons stay coarse** — `stale_client`, `restart`, `denied`,
+   `server`. They land in a URL the user can see and an attacker can
+   enumerate, so fine distinctions (tampered / kid mismatch / expired /
+   nonce mismatch) live **only** in the audit log. The mapping is
+   deliberately many-to-one.
+
+2. **The audit log is where precision goes.** Every failure path carries a
+   `detail` discriminator. Where a path already has one, pin it in a test
+   rather than adding a coarser one on top.
+
+3. **`auth_error()` holds one invariant** — every exit path from the callback
+   clears the sealed login-state cookie, so a single pre-flight can complete
+   at most one login (`server.rs:1034-1042`). Parameterizing the closure must
+   not break that; each new reason path gets a test asserting the
+   clear-cookie is present.
+
+4. **`denied` means an identity was established and then refused.** Exactly
+   two causes qualify: a ban, and an allowlist miss. `authenticate_claims`
+   already separates the latter from credential failures by status — 403 for
+   "good credentials, wrong user", 401 for everything else
+   (`auth.rs:358-360`) — so the callback reads that status rather than
+   discarding it.
+
+## Work items
+
+### Phase 1 — E0: make `login_state_missing` self-disambiguating
+
+Tests first, in `crates/quarto-hub/tests/integration/login_nonce.rs`
+(harness already present: `secure_google_setup`, `fetch_nonce`,
+`post_callback`, `assert_auth_error`, `snapshot_events`):
+
+- [x] A callback with **no cookie and a nonce-less token** asserts, via
+  `snapshot_events`, the **exact** emitted detail `login_state_stale_client`.
+- [x] A callback with **no cookie but a nonce-bearing token** asserts the
+  **exact** emitted detail `login_state_missing`. Exactness is the point —
+  today the log emits `login_state_login_state_missing`.
+
+Then implement:
+
+- [x] Split the early return in `check_login_nonce` (`server.rs:996-997`),
+  which currently fires before `claims.nonce` is ever examined. Return the
+  **bare class** from both branches; the emit site (`server.rs:1071`) adds
+  the `login_state_` prefix:
+  - cookie absent **and** `claims.nonce.is_none()` ⇒ return `"stale_client"`
+    (emitted as `login_state_stale_client`).
+  - cookie absent but `claims.nonce.is_some()` ⇒ return `"missing"`
+    (emitted as `login_state_missing`, aligning code with the ops doc).
+
+  The check runs after `authenticate_claims`, so `claims` is already
+  signature-validated — reading `claims.nonce` here is safe.
+- [x] Add both discriminators to the ops doc's audit quick reference
+  (`dev-docs/quarto-hub/session-auth-operations.md:163`).
+- [x] Rewrite the `login_state_missing` description (ops doc line 77) to
+  carry **both readings**: a nonce-bearing token with no cookie is either
+  benign cookie loss (`SameSite=None` / `Path=/auth` / the reverse proxy —
+  the fix is configuration) **or the replay shape the doc records today** (a
+  captured token replayed from a browser that never did the pre-flight). The
+  two are indistinguishable per event; telling them apart needs correlation
+  (volume, distinct `sub`s, source IPs). Do not erase the attack signature
+  the current text documents.
+- [x] Document `stale_client` in the ops doc as "old bundle **or** a login
+  attempt made outside the app" — not "definitely an old bundle". A current
+  client cannot submit a nonce-less token (`GoogleAuthProvider` renders
+  nothing until the nonce is in hand,
+  `hub-client/src/auth/GoogleAuthProvider.tsx:70-77`), but the hub's Google
+  client ID ships in the SPA, so anyone driving GIS directly can mint a
+  signature-valid nonce-less token for our `aud`. Enforcement is unaffected;
+  the heuristic is about honest clients, not a guarantee of benignity.
+- [x] Note in the ops doc that tooling exact-matching the old doubled string
+  must be updated. Substring greps for `login_state_missing` matched both
+  forms and keep working.
+
+### Phase 2 — E2: audit-log the CSRF failure path
+
+CSRF is the only genuinely silent path. Every `Err` return from
+`authenticate_claims_for_kind` (`context.rs:571-661`) already emits an
+`auth_fail` event with a discriminator strictly *finer* than a blanket
+`credential_invalid` would be: `jwt_decode:<err>`, `azp_or_iat_rejected`,
+`email_not_verified`, `user_not_allowlisted`. **Do not add a blanket emit at
+`server.rs:1055-1057`** — it would fire a second, less specific WARN
+alongside each of those, burying the detail an operator needs.
+
+Tests first:
+
+- [x] Assert via `snapshot_events` that a bad CSRF pair emits `auth_fail`
+  with `detail = "callback_csrf"`.
+- [x] **Pin the existing credential-path details.** Assert that a
+  non-allowlisted (but otherwise valid) credential emits
+  `detail = "user_not_allowlisted"`, and that an undecodable credential emits
+  a `jwt_decode:`-prefixed detail. Nothing asserts these from the callback
+  path today. The first doubles as the fixture Phase 3 needs for the `denied`
+  mapping.
+
+Then implement:
+
+- [x] Emit the existing `auth_fail` audit shape (the one at
+  `server.rs:1063-1071` — `target: "quarto_hub::audit"`, `Level::WARN`,
+  `action`, `outcome`, `credential_kind`, `detail`) at the CSRF rejection
+  (`server.rs:1049`) **only**.
+  - **`sub` is not available** — the CSRF check runs before the token is
+    parsed. Omit the field rather than inventing a placeholder, and do not
+    restructure the handler to make a `sub` available; an unvalidated `sub`
+    in the audit log is worse than an absent one.
+- [x] Add `callback_csrf` to the ops doc's audit quick reference, with one
+  caveat sentence: it is emittable by unauthenticated callers (garbage POSTs
+  to `/auth/callback`), so WARN volume there is attacker-influenceable —
+  already true of the nonce path, not a new exposure. `user_not_allowlisted`
+  is already documented (line 170); no change.
+
+### Phase 3 — E1: split `auth_error()` into distinguishable reasons
+
+Tests first:
+
+- [x] Extend `login_nonce.rs` so each failure class asserts its own redirect
+  target. Generalize `assert_auth_error` (`login_nonce.rs:101`) to take an
+  expected reason; the existing call sites become the per-reason assertions.
+  There are **seven**: `:231`, `:249`, `:264`, `:287`, `:315`, `:340`
+  (`callback_with_a_blob_sealed_under_a_foreign_secret_is_rejected`) and
+  `:388` (`a_session_token_is_not_a_login_state_cookie`) — the last two
+  assert `restart`.
+- [x] **Two dedicated tests for the 403/401 split** — the one mapping whose
+  failure mode is silent and user-visible:
+  - a signature-valid credential whose email matches no configured allowlist
+    ⇒ redirect reason `denied`;
+  - an undecodable or wrong-`aud` credential ⇒ redirect reason `restart`.
+- [x] Assert the clear-login-state cookie is present on **every** new reason
+  path (design constraint 3).
+- [x] Add a `LoginScreen` case per user-facing message, in
+  `hub-client/src/components/auth/LoginScreen.test.tsx` shape.
+- [x] Client-side reason parsing has **three presence states**, each with a
+  test:
+  - parameter absent (`.get()` → `null`) ⇒ no error; normal sign-in prompt.
+  - parameter present with an **empty value** (`/?auth_error`, what a pre-E1
+    server or a cached redirect emits; `.get()` → `''`) ⇒ the `restart` copy,
+    **not** nothing. A naive `if (reason)` truthiness check regresses this.
+  - parameter present with an **unknown value** ⇒ the `restart` copy.
+
+Then implement, server side:
+
+- [x] Give the `auth_error` closure (`server.rs:1037`) a reason parameter and
+  redirect to `/?auth_error=<reason>` instead of the bare `/?auth_error` it
+  emits today. Collapse the **twelve post-E0 causes** into the four coarse
+  reasons. Every cause must appear in this table, and a reasonless
+  `auth_error()` call must not compile.
+
+  | Reason | Causes | Exact user-facing copy |
+  |--------|--------|------------------------|
+  | `stale_client` | the E0 discriminator: no cookie **and** a nonce-less token | This version of the app is out of date. Please reload the page and try again. |
+  | `restart` | `login_state_missing` (nonce-bearing token), `nonce_mismatch`, `expired`, `tampered`, `kid_mismatch`, `token_nonce_missing`, `callback_csrf`, and the **401 family** from `authenticate_claims` (`jwt_decode:*`, `azp_or_iat_rejected`, `email_not_verified`) | Sign-in didn't complete. Please try again. |
+  | `denied` | banned user; **`user_not_allowlisted`** (the 403 from `authenticate_claims`) | Sign-in failed. Your account is not authorized to access this hub. |
+  | `server` | session mint failure | Something went wrong on the hub. Please try again shortly. |
+
+  (Counted at *handler* granularity — branches `auth_callback` can actually
+  distinguish. The 401 family is one cause because the handler sees a single
+  `StatusCode`; its audit details are listed for orientation, not as rows to
+  map.)
+
+- [x] **Read the status; do not discard it.** `server.rs:1057` is
+  `Err(_status) => return auth_error()` today, which is what makes the
+  allowlist denial invisible to this mapping. It becomes:
+
+  ```rust
+  Err(status) => return auth_error(if status == StatusCode::FORBIDDEN {
+      Reason::Denied      // allowlist miss: identity established, refused
+  } else {
+      Reason::Restart     // 401 family: no identity was established
+  }),
+  ```
+
+  No new plumbing: `check_allowlists_for` already draws this line and
+  documents it (`auth.rs:358-360` — "403, not 401: the user authenticated
+  successfully but is not permitted").
+
+  - **The 403 is `denied`.** Signature, `aud`, `azp` and `iat` all passed and
+    the email is verified: an identity was established and then refused on
+    policy. `--allowed-emails`/`--allowed-domains` is the standard admission
+    gate (`session-auth-operations.md:141`), so this is the likelier of the
+    two denials; mapping it to `restart` would put a permanently-refused user
+    in a retry loop.
+  - **The 401 family is `restart`, never `denied`.** No identity was
+    established, so "not authorized" would be false. On client-ID drift
+    (hub's configured `aud` diverging from the SPA's) every user in the
+    deployment fails at this line at once; `denied` would tell all of them
+    their account is not authorized, indistinguishable from a mass
+    de-allowlisting.
+  - **Known coarse mapping:** `email_not_verified` is a 401 where `restart`
+    is also wrong (retrying will not verify an email), but `denied` is no
+    better — no administrator can fix it either. Accepted deliberately;
+    revisit only if it appears in production logs.
+  - The reason strings are server-controlled constants; nothing
+    user-supplied is ever reflected into the redirect.
+
+Then implement, client side:
+
+- [x] `hub-client/src/App.tsx:180` currently does
+  `new URLSearchParams(window.location.search).has('auth_error')` — a
+  boolean. Keep `.has('auth_error')` for **presence** and add
+  `.get('auth_error')` for the **value**: on the bare `/?auth_error` a pre-E1
+  server emits, `.get()` returns `''` (falsy), so presence and value must be
+  read separately or the error message silently disappears.
+- [x] `hub-client/src/components/auth/LoginScreen.tsx:17` takes
+  `error?: boolean` and hardcodes the "not authorized" sentence at `:27`.
+  Change the prop to carry the reason and map it to the copy above. The
+  reason value is only ever a lookup key into the four fixed strings —
+  **never render it**.
+- [x] **Treat an unknown or empty reason as `restart`,** not as `denied`. An
+  unrecognized reason means client/server skew, and the retry copy is the
+  safer default: a false "try again" costs one retry, a false "not
+  authorized" sends users to administrators. The parameter is also a
+  craftable URL, so a `denied` fallback would let any `/?auth_error=anything`
+  link render the alarming sentence. A real ban is never hidden — `denied` is
+  in the client's vocabulary from day one, so skew only affects reasons added
+  later.
+
+### Phase 4 — E3: warn when secrets are auto-generated
+
+Two hub instances each generating their own secret reject each other's
+cookies and sealed blobs, surfacing as intermittent, self-healing sign-in
+failure. The ops doc documents `QUARTO_HUB_SESSION_SECRET` as the
+multi-instance mechanism, but nothing surfaces it at the moment it matters.
+
+Tests first:
+
+- [x] Assert the warning fires on the auto-generate branch.
+- [x] Assert it stays silent for the env-var and existing-config branches.
+
+Then implement:
+
+- [x] `tracing::warn!` in `resolve_session_secret`'s generate-and-persist
+  branch (`crates/quarto-hub/src/storage.rs:247-253`; fn at `:236`), stating
+  that the secret is now pinned to this data directory and that
+  **multi-instance deployments must set `QUARTO_HUB_SESSION_SECRET`**. The
+  warning names the env var and the data directory — **never the secret value
+  itself** ("token contents are never logged" applies here too).
+- [x] The same for `resolve_server_secret` (branch at `storage.rs:217-223`;
+  fn at `:206`).
+
+**Priority note.** If production logs ever show `login_state_kid_mismatch`
+dominating, this item is the fix for that incident and rises to `-p 0` ahead
+of everything else here: `kid_mismatch` is the signature of two instances
+with divergent auto-generated secrets.
+
+### Phase 5 — verification
+
+- [x] `cargo nextest run --workspace` — **10801 passed, 0 failed**, 197
+  skipped.
+- [x] `cargo xtask verify --skip-rust-tests` (the workspace run above covers
+  that leg) — all 14 steps passed, including `hub-client` `build:all` and
+  `test:ci`.
+- [x] `cd hub-client && npm run test:ci` — **130 passed** across 21 files
+  (18 of them the new/changed auth tests).
+- [x] End-to-end, **partially**. See "End-to-end record" below for what ran,
+  what was observed, and — importantly — the two legs that **cannot** run.
+- [x] `hub-client/changelog.md` — two-commit workflow, hash from the first
+  commit (CLAUDE.md).
+
+## End-to-end record
+
+### What ran, and what was observed
+
+**Server, through the real `hub` binary.** New script
+`scripts/hub-auth-error-reasons-e2e.mjs`, 13/13 checks passing:
+
+```
+cargo build --bin hub
+node scripts/hub-auth-error-reasons-e2e.mjs
+```
+
+```
+PASS  POST /auth/callback is routed for a Google issuer — status=303
+PASS  CSRF pair mismatch -> /?auth_error=restart — location=/?auth_error=restart
+PASS  CSRF field absent entirely -> /?auth_error=restart — location=/?auth_error=restart
+PASS  undecodable credential -> /?auth_error=restart — location=/?auth_error=restart
+PASS  csrf: no session cookie minted / login-state cookie cleared
+PASS  jwt:  no session cookie minted / login-state cookie cleared
+PASS  callback_csrf is in the audit log (was silent before E2)
+        WARN quarto_hub::audit: action="auth_fail" outcome="deny"
+             credential_kind="cookie" detail="callback_csrf"
+PASS  the jwt_decode detail survives, unburied by a blanket emit
+        INFO quarto_hub::audit: action="auth_fail" outcome="deny"
+             credential_kind="unknown" detail=jwt_decode:JWT error: InvalidToken
+PASS  startup warns that it generated a session secret
+PASS  startup warns that it generated a server secret
+```
+
+**E3, through the real binary,** on a fresh data dir — first start emits both
+warnings, second start on the same dir is byte-for-byte silent, and neither
+log contains the secret value:
+
+```
+first start  — 'generated a new' lines: 2
+second start — 'generated a new' lines: 0
+second start log size:        0 bytes
+session secret appears in logs: 0
+```
+
+Observed text (ANSI stripped):
+
+```
+WARN quarto_hub::storage: generated a new session secret and persisted it to
+  hub.json — it is now pinned to this data directory. Multi-instance
+  deployments must set QUARTO_HUB_SESSION_SECRET to the same value on every
+  instance; otherwise instances reject each other's session cookies.
+  hub_dir=/tmp/hub-e3-Ci6s
+```
+
+**Client copy, through the real production bundle.** All four sentences are
+present in an auth-enabled `vite build`, matching the E1 table verbatim
+(`1` = number of bundle files containing the string):
+
+```
+VITE_GOOGLE_CLIENT_ID=verify.apps.googleusercontent.com npx vite build --outDir <tmp>
+1    This version of the app is out of date. Please reload the page and try again.
+1    Sign-in didn't complete. Please try again.
+1    Sign-in failed. Your account is not authorized to access this hub.
+1    Something went wrong on the hub. Please try again shortly.
+```
+
+Note the default `npm run build` **omits** these strings entirely, and that
+is correct: `AUTH_ENABLED = !!import.meta.env.VITE_GOOGLE_CLIENT_ID`, so
+without that variable vite statically eliminates the whole `LoginScreen`
+branch as dead code. Grepping plain `dist/` for the copy is therefore not a
+valid check.
+
+### What could NOT be run, and why
+
+Two legs the plan asked for are **not reachable**, and no amount of scripting
+fixes it:
+
+1. **`stale_client` and `denied` against the real binary.** Both require
+   first *passing* `authenticate_claims`, i.e. presenting a credential
+   Google actually signed for our audience. Forging one is precisely what
+   the hub exists to prevent. They are covered instead by
+   `login_nonce.rs`, which drives the real router over real HTTP against a
+   mock provider whose JWKS the hub genuinely fetches — bypassing only CLI
+   parsing and OIDC discovery, both of which the new script covers.
+
+2. **Extending `scripts/hub-sliding-sessions-e2e.mjs` as written.** That
+   script mocks the IdP on localhost, which yields a **Generic** provider,
+   and `POST /auth/callback` is registered only for a **Google** provider
+   (`AuthConfig::uses_form_post_callback`, with the provider derived from
+   the issuer being exactly `https://accounts.google.com`). Verified
+   empirically, not inferred — a mock-IdP hub answers the callback with
+   **404**. Hence the separate script, which uses Google's real public
+   discovery/JWKS to make the route exist and needs outbound network.
+   Forcing the provider via a new CLI flag would mean adding production
+   surface for test convenience; not done.
+
+3. **No browser leg.** The four sentences were verified in the production
+   bundle and in jsdom (`LoginScreen.test.tsx`), **not** in a real browser —
+   browser tooling was unavailable this session. The untested surface is
+   narrow (React rendering a string chosen by a pure lookup), but it is
+   untested, and this is a hub-client change, so CLAUDE.md's rule applies:
+   stating it rather than inferring success.
+
+## Sequencing
+
+E0 (Phase 1) before E1 (Phase 3): the `stale_client` reason is not
+expressible until the discriminator exists. E2 is independent, but it is
+small and sits in the same handler, so landing it before E1's larger refactor
+keeps the diffs legible.
+
+## Not in scope
+
+- Any change to *when* the callback fails. This plan changes only what the
+  server reports and what the user is told; the failure conditions are
+  untouched.
+- A client build-id / `/version` skew endpoint (the SPA sending the `gitInfo`
+  commit hash from `hub-client/vite.config.ts:12` for the server to flag a
+  mismatch). Redundant: nginx serves the SPA in production, so the hub does
+  not know which client build is canonical, and `stale_client` already
+  carries the "you are out of date" signal at the moment it matters.
+
+## Current state (verified against `e86a9275`)
+
+Server, `crates/quarto-hub/src/server.rs`:
+
+- `auth_error` redirects to a bare `/?auth_error` (`:1037-1042`).
+- The CSRF path (`:1049`) emits no audit event. `validate_callback_csrf`
+  (`:891-919`) returns a bare `bool` and emits nothing on any of its three
+  false-returning branches.
+- The `login_state_missing` early return (`:996-997`) precedes any read of
+  `claims.nonce`, and its return string double-prefixes the emit at `:1071`.
+- The nonce-failure audit event (`:1063-1071`) is the shape the CSRF path
+  should copy.
+- `Err(_status) => return auth_error()` at `:1057` discards the
+  `authenticate_claims` status.
+- The `/auth/callback` route is registered only when `auth_config` is `Some`
+  (`:1661-1665`), so `auth_disabled` and `missing_credential` are unreachable
+  from the callback.
+
+Auth and audit:
+
+- The email allowlist is enforced inside `authenticate_claims` →
+  `check_allowlists` (`auth.rs:317`, `check_allowlists_for` at `:324-362`):
+  **403** for a verified email matching no list, **401** for an unverified
+  email.
+- `authenticate_claims_for_kind` (`context.rs:571-661`) has no silent `Err`
+  path — all five returns emit an `auth_fail` event first: `auth_disabled`
+  (`:571-581`), `missing_credential` (`:583-593`), `jwt_decode:<err>`
+  (`:603-615`), `azp_or_iat_rejected` (`:620-638`), and
+  `user_not_allowlisted` / `email_not_verified` (`:640-660`).
+- No test asserts any of the six login-state detail strings.
+- `assert_auth_error` has seven call sites (`:231`, `:249`, `:264`, `:287`,
+  `:315`, `:340`, `:388`). `snapshot_events` lives in
+  `tests/integration/support.rs:89` and is already imported by
+  `login_nonce.rs:26`.
+
+Client:
+
+- `hub-client/src/App.tsx:180` uses `.has('auth_error')`.
+- `LoginScreen.tsx:17` takes `error?: boolean` and hardcodes the "not
+  authorized" sentence at `:27`.
+  `hub-client/src/components/auth/LoginScreen.test.tsx` exists.
+- The adjacent pre-flight failure ("Could not start sign-in. Please reload
+  the page.", `GoogleAuthProvider.tsx:64-66`) is a different, pre-callback
+  path, untouched by this plan.
+
+Ops doc, `dev-docs/quarto-hub/session-auth-operations.md`: audit quick
+reference starts at line 163; `login_state_missing` described at line 77;
+`user_not_allowlisted` at line 170; allowlist removal semantics at line 141.
+
+Cause inventory, exhaustively: `callback_csrf`, the `authenticate_claims`
+failures (401 family + the 403 `user_not_allowlisted`),
+`login_state_missing`, `kid_mismatch`, `tampered`, `expired`,
+`token_nonce_missing`, `nonce_mismatch`, `user_banned`, mint failure —
+**eleven**. E0 splits `login_state_missing` in two, giving the **twelve**
+E1's table maps. (`NonceCheck::Skipped` is insecure-mode-only and not a
+failure path.)
+
+## Braid strands
+
+Filed 2026-07-30, all `discovered-from` the H2 strand `bd-uqjiac5a`:
+
+- `bd-htis60s7` — E0+E1, `-p 1` (feature). Together they make every future
+  auth failure diagnosable.
+- `bd-sxnfoefn` — E2, `-p 2` (task).
+- `bd-sx7k3vid` — E3, `-p 2` (task); rises to `-p 0` on any production
+  `kid_mismatch`.
+
+Implemented together on branch `braid/bd-htis60s7-auth-error-reasons` — one
+branch rather than three, because the three items touch the same handler and
+the same ops doc, and splitting them would have made the diffs harder to read
+rather than easier.

--- a/claude-notes/plans/2026-07-30-auth-error-reasons-and-audit-coverage.md
+++ b/claude-notes/plans/2026-07-30-auth-error-reasons-and-audit-coverage.md
@@ -196,7 +196,7 @@ Then implement, server side:
 
   | Reason | Causes | Exact user-facing copy |
   |--------|--------|------------------------|
-  | `stale_client` | the E0 discriminator: no cookie **and** a nonce-less token | This version of the app is out of date. Please reload the page and try again. |
+  | `stale_client` | the E0 discriminator: no cookie **and** a nonce-less token | This app is out of date and updating. Please try again in a few minutes. |
   | `restart` | `login_state_missing` (nonce-bearing token), `nonce_mismatch`, `expired`, `tampered`, `kid_mismatch`, `token_nonce_missing`, `callback_csrf`, and the **401 family** from `authenticate_claims` (`jwt_decode:*`, `azp_or_iat_rejected`, `email_not_verified`) | Sign-in didn't complete. Please try again. |
   | `denied` | banned user; **`user_not_allowlisted`** (the 403 from `authenticate_claims`) | Sign-in failed. Your account is not authorized to access this hub. |
   | `server` | session mint failure | Something went wrong on the hub. Please try again shortly. |
@@ -361,11 +361,19 @@ present in an auth-enabled `vite build`, matching the E1 table verbatim
 
 ```
 VITE_GOOGLE_CLIENT_ID=verify.apps.googleusercontent.com npx vite build --outDir <tmp>
-1    This version of the app is out of date. Please reload the page and try again.
+1    This app is out of date and updating. Please try again in a few minutes.
 1    Sign-in didn't complete. Please try again.
 1    Sign-in failed. Your account is not authorized to access this hub.
 1    Something went wrong on the hub. Please try again shortly.
+0    (superseded) This version of the app is out of date. Please reload the page and try again.
 ```
+
+**Re-run 2026-07-30** after the `stale_client` copy was shortened; the first
+record of this leg showed the superseded sentence, so it was re-measured
+rather than edited. The `0` line is an added check — the old copy is absent,
+so no bundle carries both. The build's PWA leg reported **166 precache
+entries, 67138 KiB**, against the 63 MB recorded in
+`2026-07-30-hub-client-sw-precache-and-update.md`'s Measurements block.
 
 Note the default `npm run build` **omits** these strings entirely, and that
 is correct: `AUTH_ENABLED = !!import.meta.env.VITE_GOOGLE_CLIENT_ID`, so
@@ -418,9 +426,11 @@ keeps the diffs legible.
   untouched.
 - A client build-id / `/version` skew endpoint (the SPA sending the `gitInfo`
   commit hash from `hub-client/vite.config.ts:12` for the server to flag a
-  mismatch). Redundant: nginx serves the SPA in production, so the hub does
-  not know which client build is canonical, and `stale_client` already
-  carries the "you are out of date" signal at the moment it matters.
+  mismatch). Still rejected, but not for the reason first given: nginx serves
+  the SPA in production, so the hub does not know which client build is
+  canonical — and a skew endpoint carries the *same* one-generation lag as
+  `stale_client`, since acting on the server's answer needs client code the
+  stale client does not have. No better positioned, rather than redundant.
 
 ## Current state (verified against `e86a9275`)
 

--- a/crates/quarto-hub/src/server.rs
+++ b/crates/quarto-hub/src/server.rs
@@ -960,11 +960,18 @@ async fn auth_nonce(State(ctx): State<SharedContext>) -> impl IntoResponse {
     response
 }
 
+/// Login-state failure class for a callback that presented no cookie
+/// **and** a nonce-less token. Named because the user-facing reason
+/// mapping keys off it; every other class maps to `restart`.
+const LOGIN_STATE_STALE_CLIENT: &str = "stale_client";
+
 /// Outcome of the callback's nonce check.
 enum NonceCheck {
     Ok,
     /// Enforcement was skipped — insecure mode only.
     Skipped,
+    /// The **bare** failure class, e.g. `expired`. The emit site adds
+    /// the `login_state_` prefix, so carrying one here would double it.
     Failed(&'static str),
 }
 
@@ -994,7 +1001,22 @@ fn check_login_nonce(
     }
 
     let Some(blob) = login_state_cookie(headers, true) else {
-        return NonceCheck::Failed("login_state_missing");
+        // Two readings, opposite remedies — and the token's own `nonce`
+        // claim separates them. Reading it here is safe: the callback
+        // has already signature-validated these claims.
+        //
+        // No nonce means no current client produced this (the SPA
+        // renders no button until it holds one), so the fix is a reload
+        // — or nothing, if something is driving GIS outside the app.
+        // A nonce with no cookie means the pre-flight *did* happen and
+        // the cookie was lost in transit (fix the configuration), or a
+        // captured token is being replayed from a browser that never
+        // ran one. Per-event those two are indistinguishable.
+        return NonceCheck::Failed(if claims.nonce.is_none() {
+            LOGIN_STATE_STALE_CLIENT
+        } else {
+            "missing"
+        });
     };
     let sealed = match crate::login_state::open_login_state(
         ctx.session_keys(),
@@ -1015,6 +1037,45 @@ fn check_login_nonce(
     NonceCheck::Ok
 }
 
+/// Why `POST /auth/callback` failed, as told to the *user*.
+///
+/// Deliberately coarse. These values land in a URL the user can read and
+/// anyone can craft, so the fine distinctions — tampered blob, `kid`
+/// mismatch, nonce mismatch, which JWT claim was wrong — stay in the
+/// audit log, where they cost an attacker nothing to learn and an
+/// operator everything to lose. The mapping from cause to reason is
+/// many-to-one by design; a dozen causes collapse into these four.
+///
+/// The distinction that matters most is `Denied` vs `Restart`: `Denied`
+/// sends the user to an administrator, so it is reserved for the two
+/// causes where an identity really was established and then refused (a
+/// ban, and an allowlist miss). Everything else is a retry.
+#[derive(Clone, Copy)]
+enum AuthErrorReason {
+    /// No login-state cookie **and** a nonce-less token: an out-of-date
+    /// bundle, or a login driven outside the app.
+    StaleClient,
+    /// The attempt broke down without establishing an identity.
+    Restart,
+    /// An identity was established, then refused on policy.
+    Denied,
+    /// The hub itself failed.
+    Server,
+}
+
+impl AuthErrorReason {
+    /// The query-parameter value. Server-controlled constants only —
+    /// nothing user-supplied is ever reflected into the redirect.
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::StaleClient => "stale_client",
+            Self::Restart => "restart",
+            Self::Denied => "denied",
+            Self::Server => "server",
+        }
+    }
+}
+
 /// Handle `POST /auth/callback` — credential delivery via form POST.
 ///
 /// Registered for providers where [`AuthConfig::uses_form_post_callback()`]
@@ -1033,9 +1094,11 @@ async fn auth_callback(
     // The sealed login-state blob is single-use: every exit path from
     // here clears it, so one pre-flight can complete at most one login.
     // Building the failure response through a closure is what keeps that
-    // true as paths are added.
-    let auth_error = || {
-        let mut response = Redirect::to("/?auth_error").into_response();
+    // true as paths are added. The reason is a required parameter for the
+    // same reason — a new path cannot silently inherit someone else's.
+    let auth_error = |reason: AuthErrorReason| {
+        let mut response =
+            Redirect::to(&format!("/?auth_error={}", reason.as_str())).into_response();
         attach_cookies(&mut response, &[build_clear_login_state_cookie(secure)]);
         response
     };
@@ -1047,14 +1110,44 @@ async fn auth_callback(
         });
 
     if !validate_callback_csrf(&mode, &form, &headers) {
-        return auth_error();
+        // No `sub`: this runs before the token is parsed, so no subject
+        // has been validated — and an unvalidated one in the audit log
+        // would be worse than an absent one. Emittable by
+        // unauthenticated callers, so WARN volume here is
+        // attacker-influenceable (as it already is on the nonce path).
+        tracing::event!(
+            target: "quarto_hub::audit",
+            tracing::Level::WARN,
+            action = "auth_fail",
+            outcome = "deny",
+            credential_kind = "cookie",
+            detail = "callback_csrf",
+        );
+        return auth_error(AuthErrorReason::Restart);
     }
 
     // Validate the Google ID token once, then mint the hub session
     // cookie (§1) — the Google token itself is never cookie'd.
     let claims = match ctx.authenticate_claims(Some(&form.credential)).await {
         Ok(claims) => claims,
-        Err(_status) => return auth_error(),
+        // The status is the whole point here: `check_allowlists_for`
+        // answers 403 for "good credentials, wrong user" and 401 for
+        // everything else, which is exactly the denied/restart line.
+        // Discarding it is what made an allowlist denial indistinguish-
+        // able from a broken login.
+        Err(status) => {
+            return auth_error(if status == StatusCode::FORBIDDEN {
+                // An identity was established, then refused on policy;
+                // retrying will never help.
+                AuthErrorReason::Denied
+            } else {
+                // No identity was established, so "not authorized" would
+                // be false. On client-ID drift this fires for every user
+                // at once — telling them all their accounts were refused
+                // would be indistinguishable from a mass de-allowlisting.
+                AuthErrorReason::Restart
+            });
+        }
     };
 
     // Bind the token to this login attempt (H2). Runs after signature
@@ -1070,7 +1163,14 @@ async fn auth_callback(
             sub = %claims.sub,
             detail = %format!("login_state_{detail}"),
         );
-        return auth_error();
+        // Only the nonce-less-token-without-a-cookie class is worth a
+        // distinct user-facing reason — it is the one a reload fixes.
+        // Every other class (and any added later) is a plain retry.
+        return auth_error(if detail == LOGIN_STATE_STALE_CLIENT {
+            AuthErrorReason::StaleClient
+        } else {
+            AuthErrorReason::Restart
+        });
     }
 
     // Bans gate mint too (§3) — otherwise a banned user just
@@ -1085,14 +1185,16 @@ async fn auth_callback(
             sub = %claims.sub,
             detail = "user_banned",
         );
-        return auth_error();
+        // The other genuine denial: this identity is refused until an
+        // operator says otherwise.
+        return auth_error(AuthErrorReason::Denied);
     }
 
     let cookies = match mint_session_cookie(&ctx, &claims, LoginEndpoint::Callback).await {
         Ok(cookies) => cookies,
         Err(err) => {
             tracing::error!(error = %err, "failed to mint session token");
-            return auth_error();
+            return auth_error(AuthErrorReason::Server);
         }
     };
     let mut response = Redirect::to("/").into_response();

--- a/crates/quarto-hub/src/server.rs
+++ b/crates/quarto-hub/src/server.rs
@@ -1052,8 +1052,10 @@ fn check_login_nonce(
 /// ban, and an allowlist miss). Everything else is a retry.
 #[derive(Clone, Copy)]
 enum AuthErrorReason {
-    /// No login-state cookie **and** a nonce-less token: an out-of-date
-    /// bundle, or a login driven outside the app.
+    /// The client predates a protocol step the hub now requires — the
+    /// general slot for "your bundle is old". Map a future callback-time
+    /// break here, not to `Restart`: a client cannot render a reason
+    /// invented after it shipped.
     StaleClient,
     /// The attempt broke down without establishing an identity.
     Restart,

--- a/crates/quarto-hub/src/storage.rs
+++ b/crates/quarto-hub/src/storage.rs
@@ -220,6 +220,17 @@ pub fn resolve_server_secret(config: &mut HubStorageConfig, hub_dir: &Path) -> R
     rand::rng().fill_bytes(&mut bytes);
     config.server_secret = Some(hex::encode(bytes));
     config.save(hub_dir)?;
+    // Loud because it is now pinned to *this* data directory: a second
+    // instance with its own generated secret derives a different actor ID
+    // for the same user in the same project. The value itself is never
+    // logged.
+    warn!(
+        hub_dir = %hub_dir.display(),
+        "generated a new server secret and persisted it to hub.json. \
+         Multi-instance deployments must set QUARTO_HUB_SERVER_SECRET to \
+         the same value on every instance; otherwise each derives its own \
+         actor IDs."
+    );
     Ok(bytes)
 }
 
@@ -250,6 +261,19 @@ pub fn resolve_session_secret(config: &mut HubStorageConfig, hub_dir: &Path) -> 
     rand::rng().fill_bytes(&mut bytes);
     config.session_secret = Some(hex::encode(bytes));
     config.save(hub_dir)?;
+    // The multi-instance hazard this warns about is genuinely hard to
+    // diagnose from symptoms: two hubs with divergent generated secrets
+    // reject each other's session cookies and sealed login blobs, so
+    // sign-in fails intermittently and heals itself on retry. Its audit
+    // signature is a run of `*_kid_mismatch`. The value itself is never
+    // logged.
+    warn!(
+        hub_dir = %hub_dir.display(),
+        "generated a new session secret and persisted it to hub.json — it is \
+         now pinned to this data directory. Multi-instance deployments must \
+         set QUARTO_HUB_SESSION_SECRET to the same value on every instance; \
+         otherwise instances reject each other's session cookies."
+    );
     Ok(bytes)
 }
 
@@ -1041,5 +1065,159 @@ mod tests {
         // Should have generated a new secret
         assert_eq!(secret.len(), 32);
         assert!(config.server_secret.is_some());
+    }
+
+    // ── auto-generation is loud (E3, bd-sx7k3vid) ─────────────────
+
+    /// Run `f` under a scoped subscriber that captures formatted output,
+    /// so we can assert on what an operator would actually see.
+    fn capture_logs(f: impl FnOnce()) -> String {
+        use std::sync::{Arc, Mutex};
+
+        #[derive(Clone)]
+        struct BufWriter(Arc<Mutex<Vec<u8>>>);
+        impl Write for BufWriter {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                self.0.lock().unwrap().extend_from_slice(buf);
+                Ok(buf.len())
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+        impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for BufWriter {
+            type Writer = BufWriter;
+            fn make_writer(&'a self) -> Self::Writer {
+                self.clone()
+            }
+        }
+
+        let buf = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(BufWriter(buf.clone()))
+            .with_ansi(false)
+            .with_max_level(tracing::Level::TRACE)
+            .finish();
+        tracing::subscriber::with_default(subscriber, f);
+        String::from_utf8(buf.lock().unwrap().clone()).unwrap()
+    }
+
+    fn fresh_hub_dir() -> (TempDir, PathBuf) {
+        let temp = TempDir::new().unwrap();
+        let hub_dir = temp.path().join("hub");
+        fs::create_dir_all(&hub_dir).unwrap();
+        (temp, hub_dir)
+    }
+
+    /// Two hubs that each auto-generate their own session secret reject
+    /// each other's cookies and sealed login blobs — an intermittent,
+    /// self-healing sign-in failure whose audit signature
+    /// (`login_state_kid_mismatch`) gives no hint about the cause. The
+    /// warning is the only thing that surfaces it at the moment the
+    /// secret gets pinned to one data directory.
+    #[test]
+    fn resolve_session_secret_warns_when_it_generates_one() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        unsafe { std::env::remove_var("QUARTO_HUB_SESSION_SECRET") };
+
+        let (_temp, hub_dir) = fresh_hub_dir();
+        let mut config = HubStorageConfig::new();
+        let logs = capture_logs(|| {
+            resolve_session_secret(&mut config, &hub_dir).unwrap();
+        });
+
+        assert!(logs.contains("WARN"), "must be a warning: {logs}");
+        assert!(
+            logs.contains("QUARTO_HUB_SESSION_SECRET"),
+            "must name the way out: {logs}"
+        );
+        assert!(
+            logs.contains(&hub_dir.display().to_string()),
+            "must name the directory the secret is now pinned to: {logs}"
+        );
+
+        // Token contents are never logged, and neither is this.
+        let generated = config.session_secret.as_deref().unwrap();
+        assert!(
+            !logs.contains(generated),
+            "the secret value must never reach the log"
+        );
+    }
+
+    #[test]
+    fn resolve_session_secret_is_silent_when_a_secret_is_configured() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let (_temp, hub_dir) = fresh_hub_dir();
+
+        // Source 1: the env var — the multi-instance mechanism itself.
+        unsafe { std::env::set_var("QUARTO_HUB_SESSION_SECRET", hex::encode([3u8; 32])) };
+        let mut config = HubStorageConfig::new();
+        let env_logs = capture_logs(|| {
+            resolve_session_secret(&mut config, &hub_dir).unwrap();
+        });
+        unsafe { std::env::remove_var("QUARTO_HUB_SESSION_SECRET") };
+
+        // Source 2: an existing hub.json value — already pinned, nothing
+        // new to warn about.
+        let mut config = HubStorageConfig::new();
+        config.session_secret = Some(hex::encode([5u8; 32]));
+        let config_logs = capture_logs(|| {
+            resolve_session_secret(&mut config, &hub_dir).unwrap();
+        });
+
+        assert!(!env_logs.contains("WARN"), "env branch: {env_logs}");
+        assert!(
+            !config_logs.contains("WARN"),
+            "config branch: {config_logs}"
+        );
+    }
+
+    #[test]
+    fn resolve_server_secret_warns_when_it_generates_one() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        unsafe { std::env::remove_var("QUARTO_HUB_SERVER_SECRET") };
+
+        let (_temp, hub_dir) = fresh_hub_dir();
+        let mut config = HubStorageConfig::new();
+        let logs = capture_logs(|| {
+            resolve_server_secret(&mut config, &hub_dir).unwrap();
+        });
+
+        assert!(logs.contains("WARN"), "must be a warning: {logs}");
+        assert!(
+            logs.contains("QUARTO_HUB_SERVER_SECRET"),
+            "must name the way out: {logs}"
+        );
+
+        let generated = config.server_secret.as_deref().unwrap();
+        assert!(
+            !logs.contains(generated),
+            "the secret value must never reach the log"
+        );
+    }
+
+    #[test]
+    fn resolve_server_secret_is_silent_when_a_secret_is_configured() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let (_temp, hub_dir) = fresh_hub_dir();
+
+        unsafe { std::env::set_var("QUARTO_HUB_SERVER_SECRET", hex::encode([4u8; 32])) };
+        let mut config = HubStorageConfig::new();
+        let env_logs = capture_logs(|| {
+            resolve_server_secret(&mut config, &hub_dir).unwrap();
+        });
+        unsafe { std::env::remove_var("QUARTO_HUB_SERVER_SECRET") };
+
+        let mut config = HubStorageConfig::new();
+        config.server_secret = Some(hex::encode([6u8; 32]));
+        let config_logs = capture_logs(|| {
+            resolve_server_secret(&mut config, &hub_dir).unwrap();
+        });
+
+        assert!(!env_logs.contains("WARN"), "env branch: {env_logs}");
+        assert!(
+            !config_logs.contains("WARN"),
+            "config branch: {config_logs}"
+        );
     }
 }

--- a/crates/quarto-hub/tests/integration/login_nonce.rs
+++ b/crates/quarto-hub/tests/integration/login_nonce.rs
@@ -48,6 +48,28 @@ async fn secure_google_setup() -> &'static (MockOidcProvider, TestHub) {
         .await
 }
 
+/// As [`secure_google_setup`], plus a domain allowlist — the standard
+/// admission gate, and the only shape that can produce the 403 from
+/// `authenticate_claims`.
+async fn allowlisted_google_setup() -> &'static (MockOidcProvider, TestHub) {
+    static SETUP: tokio::sync::OnceCell<(MockOidcProvider, TestHub)> =
+        tokio::sync::OnceCell::const_new();
+    SETUP
+        .get_or_init(|| async {
+            install_tracing_once();
+            let provider = MockOidcProvider::start().await;
+            let hub = TestHubBuilder::new()
+                .secure()
+                .google_provider()
+                .allowed_domains(&["posit.co"])
+                .session_secret(TEST_SESSION_SECRET)
+                .start(&provider)
+                .await;
+            (provider, hub)
+        })
+        .await
+}
+
 fn test_keys() -> SessionKeys {
     SessionKeys::new(TEST_SESSION_SECRET)
 }
@@ -98,21 +120,74 @@ async fn post_callback(
         .unwrap()
 }
 
-fn assert_auth_error(resp: &reqwest::Response) {
+/// Assert a failed callback: a redirect to `/?auth_error=<reason>`, no
+/// session minted, and the sealed login-state cookie cleared.
+///
+/// `reason` is the coarse, user-facing class — deliberately many-to-one
+/// over the dozen causes, because it lands in a URL the user sees. The
+/// precise cause is asserted separately, against the audit log.
+fn assert_auth_error(resp: &reqwest::Response, reason: &str) {
     assert!(
         resp.status().is_redirection(),
         "expected a redirect, got {}",
         resp.status()
     );
+    let location = resp
+        .headers()
+        .get("location")
+        .and_then(|v| v.to_str().ok())
+        .expect("a Location header");
     assert_eq!(
-        resp.headers().get("location").unwrap(),
-        "/?auth_error",
-        "failed nonce verification must land on the auth-error route"
+        location,
+        format!("/?auth_error={reason}"),
+        "the redirect must name which kind of failure this was"
     );
     assert!(
         TestHub::find_set_cookie(resp, AUTH_COOKIE_NAME_SECURE).is_none(),
         "no session may be minted"
     );
+    // Single use, on **every** exit path — one pre-flight can complete
+    // at most one login, and adding reasons must not open a hole in that.
+    let (value, attrs) = TestHub::find_set_cookie(resp, LOGIN_STATE_COOKIE_SECURE)
+        .expect("the login-state cookie must be cleared on every failure path");
+    assert_eq!(value, "", "cleared, not rewritten: {attrs}");
+    assert!(attrs.contains("Max-Age=0"), "{attrs}");
+}
+
+/// The `detail` of the sole `auth_fail` audit event carrying `sub`.
+///
+/// Asserted **exactly**, not by substring: the whole point of the
+/// discriminator is that an operator can tell one failure class from
+/// another, and a substring match would accept a doubled prefix.
+fn auth_fail_detail_for(sub: &str) -> String {
+    let details: Vec<String> = snapshot_events()
+        .iter()
+        .filter(|e| {
+            e.fields.get("action").map(String::as_str) == Some("auth_fail")
+                && e.fields.get("sub").map(String::as_str) == Some(sub)
+        })
+        .filter_map(|e| e.fields.get("detail").cloned())
+        .collect();
+    assert_eq!(
+        details.len(),
+        1,
+        "expected exactly one auth_fail for sub={sub}, got {details:?}"
+    );
+    details.into_iter().next().unwrap()
+}
+
+/// `detail`s of every `auth_fail` audit event carrying **no** `sub` —
+/// the pre-identity failures, where there is no validated subject to
+/// report.
+fn subless_auth_fail_details() -> Vec<String> {
+    snapshot_events()
+        .iter()
+        .filter(|e| {
+            e.fields.get("action").map(String::as_str) == Some("auth_fail")
+                && !e.fields.contains_key("sub")
+        })
+        .filter_map(|e| e.fields.get("detail").cloned())
+        .collect()
 }
 
 // ── the pre-flight endpoint ───────────────────────────────────────
@@ -228,7 +303,7 @@ async fn callback_without_a_login_cookie_is_rejected() {
     );
 
     let resp = post_callback(hub, &google, None).await;
-    assert_auth_error(&resp);
+    assert_auth_error(&resp, "restart");
 }
 
 #[tokio::test]
@@ -246,7 +321,7 @@ async fn callback_with_a_nonce_from_another_login_is_rejected() {
             .to_value(),
     );
     let resp = post_callback(hub, &google, Some((LOGIN_STATE_COOKIE_SECURE, &blob_b))).await;
-    assert_auth_error(&resp);
+    assert_auth_error(&resp, "restart");
 }
 
 #[tokio::test]
@@ -261,7 +336,7 @@ async fn callback_with_a_token_carrying_no_nonce_is_rejected() {
     );
 
     let resp = post_callback(hub, &google, Some((LOGIN_STATE_COOKIE_SECURE, &blob))).await;
-    assert_auth_error(&resp);
+    assert_auth_error(&resp, "restart");
 }
 
 #[tokio::test]
@@ -284,7 +359,7 @@ async fn callback_with_an_expired_login_blob_is_rejected() {
             .to_value(),
     );
     let resp = post_callback(hub, &google, Some((LOGIN_STATE_COOKIE_SECURE, &stale))).await;
-    assert_auth_error(&resp);
+    assert_auth_error(&resp, "restart");
 }
 
 #[tokio::test]
@@ -312,7 +387,7 @@ async fn callback_with_a_tampered_login_blob_is_rejected() {
         Some((LOGIN_STATE_COOKIE_SECURE, &parts.join("."))),
     )
     .await;
-    assert_auth_error(&resp);
+    assert_auth_error(&resp, "restart");
 }
 
 /// A forged blob claiming an attacker-chosen nonce, signed with the
@@ -337,7 +412,206 @@ async fn callback_with_a_blob_sealed_under_a_foreign_secret_is_rejected() {
             .to_value(),
     );
     let resp = post_callback(hub, &google, Some((LOGIN_STATE_COOKIE_SECURE, &forged))).await;
-    assert_auth_error(&resp);
+    assert_auth_error(&resp, "restart");
+}
+
+// ── which cookie-absent reading? (E0) ─────────────────────────────
+
+/// A cookie-absent callback has two readings, and they want opposite
+/// remedies — reload the app, or fix cookie delivery. The token's own
+/// `nonce` claim is what tells them apart, so the check must look at it
+/// rather than returning a single blanket class.
+///
+/// Nonce-less: no current client can produce this. `GoogleAuthProvider`
+/// renders nothing until it holds a nonce, so the token came from a
+/// stale bundle or from something driving GIS outside the app.
+#[tokio::test]
+async fn a_nonceless_token_without_a_cookie_audits_as_stale_client() {
+    let (provider, hub) = secure_google_setup().await;
+    let google = provider.sign(
+        &ClaimsBuilder::from_provider(provider)
+            .sub("nonce-stale-client-sub")
+            .to_value(),
+    );
+
+    let resp = post_callback(hub, &google, None).await;
+    assert_auth_error(&resp, "stale_client");
+    assert_eq!(
+        auth_fail_detail_for("nonce-stale-client-sub"),
+        "login_state_stale_client"
+    );
+}
+
+/// Nonce-bearing: a login attempt that really did do the pre-flight but
+/// arrived without its cookie (`SameSite` / `Path` / proxy — fix the
+/// configuration), *or* a captured token replayed from a browser that
+/// never did one. Indistinguishable per event; correlation tells them
+/// apart.
+#[tokio::test]
+async fn a_nonce_bearing_token_without_a_cookie_audits_as_login_state_missing() {
+    let (provider, hub) = secure_google_setup().await;
+    let (nonce, _blob) = fetch_nonce(hub, LOGIN_STATE_COOKIE_SECURE).await;
+    let google = provider.sign(
+        &ClaimsBuilder::from_provider(provider)
+            .sub("nonce-cookie-lost-sub")
+            .nonce(&nonce)
+            .to_value(),
+    );
+
+    let resp = post_callback(hub, &google, None).await;
+    assert_auth_error(&resp, "restart");
+    // Exactly this, undoubled: the emit site adds the `login_state_`
+    // prefix, so the returned class must not carry one of its own.
+    assert_eq!(
+        auth_fail_detail_for("nonce-cookie-lost-sub"),
+        "login_state_missing"
+    );
+}
+
+// ── the callback's other failure paths, in the log (E2) ───────────
+
+/// CSRF was the callback's one genuinely silent rejection: a deployment
+/// whose reverse proxy drops the `g_csrf_token` cookie failed every
+/// login with nothing whatsoever in `journalctl -u hub`.
+#[tokio::test]
+async fn a_bad_csrf_pair_is_audited_as_callback_csrf() {
+    let (provider, hub) = secure_google_setup().await;
+    let google = provider.sign(
+        &ClaimsBuilder::from_provider(provider)
+            .sub("nonce-csrf-sub")
+            .to_value(),
+    );
+
+    // The double-submit pair disagrees — cookie says one thing, form
+    // field another.
+    let resp = no_redirect_client()
+        .post(hub.url("/auth/callback"))
+        .header("cookie", "g_csrf_token=from-the-cookie")
+        .header("content-type", "application/x-www-form-urlencoded")
+        .body(format!("credential={google}&g_csrf_token=from-the-form"))
+        .send()
+        .await
+        .unwrap();
+    assert_auth_error(&resp, "restart");
+
+    let events = snapshot_events();
+    let mut matching = events
+        .iter()
+        .filter(|e| e.fields.get("detail").map(String::as_str) == Some("callback_csrf"));
+    let event = matching.next().expect("a callback_csrf audit event");
+    assert!(matching.next().is_none(), "exactly one callback_csrf event");
+
+    assert_eq!(event.target, "quarto_hub::audit");
+    assert_eq!(
+        event.fields.get("action").map(String::as_str),
+        Some("auth_fail")
+    );
+    assert_eq!(
+        event.fields.get("outcome").map(String::as_str),
+        Some("deny")
+    );
+    assert_eq!(
+        event.fields.get("credential_kind").map(String::as_str),
+        Some("cookie")
+    );
+    // The check runs before the token is parsed, so no `sub` has been
+    // validated. An unvalidated one in the audit log is worse than none.
+    assert!(
+        !event.fields.contains_key("sub"),
+        "no sub is available here: {:?}",
+        event.fields
+    );
+}
+
+/// The credential paths already carry details finer than a blanket
+/// `credential_invalid`, but nothing pinned them **from the callback**.
+/// These two tests are what stops a later blanket emit from burying the
+/// specific discriminator an operator needs.
+#[tokio::test]
+async fn a_non_allowlisted_credential_is_audited_as_user_not_allowlisted() {
+    let (provider, hub) = allowlisted_google_setup().await;
+    let google = provider.sign(
+        &ClaimsBuilder::from_provider(provider)
+            .sub("nonce-allowlist-sub")
+            .email("outsider@example.com")
+            .to_value(),
+    );
+
+    // `authenticate_claims` runs before the nonce check, so this never
+    // reaches the login-state cookie — hence no `login_state_` prefix.
+    let resp = post_callback(hub, &google, None).await;
+    assert_auth_error(&resp, "denied");
+    assert_eq!(
+        auth_fail_detail_for("nonce-allowlist-sub"),
+        "user_not_allowlisted"
+    );
+}
+
+#[tokio::test]
+async fn an_undecodable_credential_is_audited_as_a_jwt_decode_failure() {
+    let (_provider, hub) = secure_google_setup().await;
+
+    let resp = post_callback(hub, "not-a-jwt", None).await;
+    assert_auth_error(&resp, "restart");
+
+    let details = subless_auth_fail_details();
+    assert_eq!(
+        details.len(),
+        1,
+        "one event, not a specific one plus a blanket one: {details:?}"
+    );
+    assert!(
+        details[0].starts_with("jwt_decode:"),
+        "expected a jwt_decode: detail, got {details:?}"
+    );
+}
+
+// ── the 403/401 split (E1) ────────────────────────────────────────
+
+/// `denied` means an identity was established and then refused, and the
+/// allowlist miss is one of exactly two causes that qualify: signature,
+/// `aud`, `azp` and `iat` all passed and the email is verified, so this
+/// user was refused on policy and will be refused again. Mapping it to
+/// `restart` would put a permanently-refused user in a retry loop.
+///
+/// This is the mapping whose failure mode is both silent and
+/// user-visible, which is why it gets a test of its own: the callback
+/// used to discard the status that draws the line.
+#[tokio::test]
+async fn an_allowlist_miss_redirects_with_reason_denied() {
+    let (provider, hub) = allowlisted_google_setup().await;
+    let google = provider.sign(
+        &ClaimsBuilder::from_provider(provider)
+            .sub("reason-denied-sub")
+            .email("stranger@example.com")
+            .to_value(),
+    );
+
+    let resp = post_callback(hub, &google, None).await;
+    assert_auth_error(&resp, "denied");
+}
+
+/// The 401 family is `restart`, never `denied` — no identity was
+/// established, so "your account is not authorized" would simply be
+/// false. A wrong `aud` is the case that matters most: on client-ID
+/// drift (the hub's configured audience diverging from the SPA's) every
+/// user in the deployment fails here at once, and `denied` would tell
+/// all of them their account was refused — indistinguishable from a mass
+/// de-allowlisting.
+#[tokio::test]
+async fn a_wrong_audience_credential_redirects_with_reason_restart() {
+    let (provider, hub) = secure_google_setup().await;
+    let google = provider.sign(
+        &ClaimsBuilder::from_provider(provider)
+            .sub("reason-restart-sub")
+            .aud(serde_json::json!(
+                "some-other-client.apps.googleusercontent.com"
+            ))
+            .to_value(),
+    );
+
+    let resp = post_callback(hub, &google, None).await;
+    assert_auth_error(&resp, "restart");
 }
 
 // ── domain separation across the HTTP surface ─────────────────────
@@ -385,7 +659,7 @@ async fn a_session_token_is_not_a_login_state_cookie() {
             .to_value(),
     );
     let resp = post_callback(hub, &google, Some((LOGIN_STATE_COOKIE_SECURE, &session))).await;
-    assert_auth_error(&resp);
+    assert_auth_error(&resp, "restart");
 }
 
 // ── insecure mode ─────────────────────────────────────────────────

--- a/crates/quarto-hub/tests/integration/login_nonce.rs
+++ b/crates/quarto-hub/tests/integration/login_nonce.rs
@@ -70,6 +70,27 @@ async fn allowlisted_google_setup() -> &'static (MockOidcProvider, TestHub) {
         .await
 }
 
+/// As [`secure_google_setup`], with one `sub` banned — the other cause
+/// that qualifies as a genuine denial.
+async fn banned_google_setup() -> &'static (MockOidcProvider, TestHub) {
+    static SETUP: tokio::sync::OnceCell<(MockOidcProvider, TestHub)> =
+        tokio::sync::OnceCell::const_new();
+    SETUP
+        .get_or_init(|| async {
+            install_tracing_once();
+            let provider = MockOidcProvider::start().await;
+            let hub = TestHubBuilder::new()
+                .secure()
+                .google_provider()
+                .banned_subs(&["reason-banned-sub"])
+                .session_secret(TEST_SESSION_SECRET)
+                .start(&provider)
+                .await;
+            (provider, hub)
+        })
+        .await
+}
+
 fn test_keys() -> SessionKeys {
     SessionKeys::new(TEST_SESSION_SECRET)
 }
@@ -612,6 +633,30 @@ async fn a_wrong_audience_credential_redirects_with_reason_restart() {
 
     let resp = post_callback(hub, &google, None).await;
     assert_auth_error(&resp, "restart");
+}
+
+/// The other cause that qualifies as `denied`. It is gated *after* the
+/// nonce check, so reaching it takes an otherwise flawless nonce-bound
+/// login — which is the point of testing it: a ban must refuse a login
+/// that is perfect in every other respect.
+///
+/// The pre-existing ban coverage (`session_auth.rs::ban_gates_verify_and_mint`)
+/// goes through `/auth/session`, which answers 403 rather than
+/// redirecting, so it says nothing about the reason a browser is shown.
+#[tokio::test]
+async fn a_banned_user_redirects_with_reason_denied() {
+    let (provider, hub) = banned_google_setup().await;
+    let (nonce, blob) = fetch_nonce(hub, LOGIN_STATE_COOKIE_SECURE).await;
+    let google = provider.sign(
+        &ClaimsBuilder::from_provider(provider)
+            .sub("reason-banned-sub")
+            .nonce(&nonce)
+            .to_value(),
+    );
+
+    let resp = post_callback(hub, &google, Some((LOGIN_STATE_COOKIE_SECURE, &blob))).await;
+    assert_auth_error(&resp, "denied");
+    assert_eq!(auth_fail_detail_for("reason-banned-sub"), "user_banned");
 }
 
 // ── domain separation across the HTTP surface ─────────────────────

--- a/crates/quarto-hub/tests/integration/session_auth.rs
+++ b/crates/quarto-hub/tests/integration/session_auth.rs
@@ -213,7 +213,9 @@ async fn ws_upgrade_rejects_legacy_google_cookie() {
 }
 
 /// The failure path of the cutover is a clean logged-out flow: one
-/// redirect to `/?auth_error`, no cookie set, no loop.
+/// redirect to `/?auth_error=<reason>`, no cookie set, no loop.
+/// An undecodable credential is a 401 — no identity was established, so
+/// the reason is `restart` rather than `denied`.
 #[tokio::test]
 async fn callback_failure_redirects_once_without_cookie() {
     let (_provider, hub) = google_session_setup().await;
@@ -231,7 +233,10 @@ async fn callback_failure_redirects_once_without_cookie() {
         .await
         .unwrap();
     assert!(resp.status().is_redirection());
-    assert_eq!(resp.headers().get("location").unwrap(), "/?auth_error");
+    assert_eq!(
+        resp.headers().get("location").unwrap(),
+        "/?auth_error=restart"
+    );
     assert!(
         TestHub::set_auth_cookie(&resp).is_none(),
         "no cookie may be set on a failed login"

--- a/dev-docs/quarto-hub/session-auth-operations.md
+++ b/dev-docs/quarto-hub/session-auth-operations.md
@@ -102,10 +102,15 @@ Operational notes:
   covered both readings above. Anything exact-matching that string needs
   updating; substring greps for `login_state_missing` matched both forms
   and keep working.
-- **Rollout:** a user holding a stale SPA bundle fails login once to
-  `/?auth_error=stale_client` — which the client renders as "this version
-  of the app is out of date, please reload" — and recovers on reload. Hub
-  and client deploy together.
+- **Rollout:** a user holding a stale SPA bundle fails login to
+  `/?auth_error=stale_client` but **cannot render that reason** — a bundle
+  predating 2026-07-30 shows "your account is not authorized" for every
+  reason, the opposite of the advice it needs. A manual reload does not
+  help either: the service worker's `NavigationRoute` serves `index.html`
+  from its ~63 MB precache, bypassing nginx's `no-cache` on `/`. What
+  recovers is retrying once the new worker has installed and claimed the
+  tab — the sign-in click is itself a navigation, so it fetches the new
+  bundle. Hub and client deploy together.
 - **Scope:** the Google callback only. `/auth/session` (the Generic
   provider's JSON mint) is not nonce-bound and remains replay-able
   within the submitted token's validity.
@@ -292,7 +297,7 @@ anyone can craft, so the precise cause stays in the audit log.
 
 | `reason` | What the user is told | Audit `detail` to look for |
 |---|---|---|
-| `stale_client` | This version of the app is out of date. Please reload the page and try again. | `login_state_stale_client` |
+| `stale_client` | This app is out of date and updating. Please try again in a few minutes. | `login_state_stale_client` |
 | `restart` | Sign-in didn't complete. Please try again. | `login_state_missing`, `login_state_nonce_mismatch`, `login_state_expired`, `login_state_tampered`, `login_state_kid_mismatch`, `login_state_token_nonce_missing`, `callback_csrf`, `jwt_decode:*`, `azp_or_iat_rejected`, `email_not_verified` |
 | `denied` | Sign-in failed. Your account is not authorized to access this hub. | `user_banned`, `user_not_allowlisted` |
 | `server` | Something went wrong on the hub. Please try again shortly. | (no audit event — a mint failure logs at ERROR, not `auth_fail`) |
@@ -301,8 +306,10 @@ Two properties worth knowing when reading reports:
 
 - **`denied` is exactly the two real denials** — a ban and an allowlist
   miss, the cases where an identity *was* established and then refused.
-  Everything else is a retry, so a user reporting "not authorized" really
-  does need an administrator, not a reload.
+  Everything else is a retry. **But do not infer the reason from the
+  sentence the user saw:** a bundle predating 2026-07-30 renders "not
+  authorized" for all four reasons, so match the report against the audit
+  `detail` instead. Once clients are current, the sentence is reliable.
 - **Unknown and empty reasons render as `restart`.** A pre-2026-07-30 hub
   emits a bare `/?auth_error`, and the parameter is craftable, so the
   client falls back to the retry copy rather than the alarming one. If a

--- a/dev-docs/quarto-hub/session-auth-operations.md
+++ b/dev-docs/quarto-hub/session-auth-operations.md
@@ -73,17 +73,72 @@ Operational notes:
   The skip logs at WARN on every login — if you see
   `nonce verification skipped` in a deployment that is meant to be
   production, the hub is running with the dev flag.
-- **Rejections** appear as `auth_fail` with
-  `detail=login_state_<class>`: `login_state_missing` (no cookie —
-  the replay shape), `nonce_mismatch`, `token_nonce_missing` (client too
-  old to send one), `expired`, `tampered`, `kid_mismatch`.
+- **Rejections** appear as `auth_fail` with `detail=login_state_<class>`,
+  where `<class>` is one of `stale_client`, `missing`, `nonce_mismatch`,
+  `token_nonce_missing` (cookie present, client too old to send a
+  nonce), `expired`, `tampered`, `kid_mismatch`. The last four all mean
+  a cookie arrived and failed on its merits. The two **cookie-absent**
+  classes are the ones to read carefully, because they want opposite
+  remedies:
+  - `login_state_stale_client` — no cookie **and** no `nonce` claim.
+    A current SPA cannot produce this (`GoogleAuthProvider` renders no
+    button until it holds a nonce), so it is an out-of-date bundle **or**
+    a login attempt made outside the app: the hub's Google client ID
+    ships in the SPA, so anyone driving GIS directly can mint a
+    signature-valid nonce-less token for our `aud`. Enforcement is
+    unaffected either way — the heuristic describes honest clients, it
+    does not certify benignity.
+  - `login_state_missing` — no cookie, but the token *does* carry a
+    nonce, so a pre-flight really ran. Either the cookie did not survive
+    delivery (`SameSite=None`, `Path=/auth`, or the reverse proxy — the
+    fix is configuration), **or** it is the replay shape: a captured
+    token presented from a browser that never did a pre-flight. A single
+    event cannot tell those apart; correlation can — volume, distinct
+    `sub`s, and source IPs look very different for a misconfiguration
+    than for a replay campaign.
+
+  **Log-tooling note.** Until 2026-07-30 the cookie-absent class was
+  emitted double-prefixed, as `login_state_login_state_missing`, and it
+  covered both readings above. Anything exact-matching that string needs
+  updating; substring greps for `login_state_missing` matched both forms
+  and keep working.
 - **Rollout:** a user holding a stale SPA bundle fails login once to
-  `/?auth_error` and recovers on reload. Hub and client deploy together.
+  `/?auth_error=stale_client` — which the client renders as "this version
+  of the app is out of date, please reload" — and recovers on reload. Hub
+  and client deploy together.
 - **Scope:** the Google callback only. `/auth/session` (the Generic
   provider's JSON mint) is not nonce-bound and remains replay-able
   within the submitted token's validity.
 - Sealed blobs verify against the **previous** secret during a graceful
   rotation overlap, so a login started just before a rotation completes.
+
+## Auto-generated secrets and the multi-instance hazard
+
+With neither `QUARTO_HUB_SESSION_SECRET` nor a `session_secret` in
+`hub.json`, the hub generates one on startup, persists it, and **warns**:
+
+```
+WARN generated a new session secret and persisted it to hub.json — it is
+     now pinned to this data directory. Multi-instance deployments must set
+     QUARTO_HUB_SESSION_SECRET to the same value on every instance;
+     otherwise instances reject each other's session cookies. hub_dir=…
+```
+
+Expect this exactly once per data directory, on first start. Seeing it on
+**every** restart means the hub cannot persist `hub.json` (check
+permissions on the data dir) — and a hub that regenerates its secret on
+each restart logs every user out on each restart.
+
+If two instances each generate their own, each rejects the other's
+session cookies and sealed login blobs. The symptom is maddening:
+sign-in fails intermittently and appears to heal itself on retry,
+depending on which instance the load balancer picked. The signature in
+the log is a run of `session_kid_mismatch` (and
+`login_state_kid_mismatch` on the login path) with no rotation to explain
+it. The fix is to set `QUARTO_HUB_SESSION_SECRET` to the same value on
+every instance. `QUARTO_HUB_SERVER_SECRET` warns the same way; divergence
+there means each instance derives different actor IDs for the same user.
+The secret **values** are never logged.
 
 ## Rotating the session secret
 
@@ -160,15 +215,58 @@ cargo build --bin hub
 node scripts/hub-sliding-sessions-e2e.mjs
 ```
 
+`scripts/hub-auth-error-reasons-e2e.mjs` covers the callback's *failure*
+side — the `/?auth_error=<reason>` codes and the `callback_csrf` audit
+event — against the real binary:
+
+```
+cargo build --bin hub
+node scripts/hub-auth-error-reasons-e2e.mjs
+```
+
+It needs **outbound network**, and that is not incidental: the
+`POST /auth/callback` route is registered only for a Google provider, and
+the provider is derived from the issuer being exactly
+`https://accounts.google.com`. A mock IdP on localhost yields a Generic
+provider and the route 404s, so the sliding-sessions script above
+structurally cannot reach any callback failure path. Using Google's real
+public discovery + JWKS is what makes the route exist. The trade-off:
+only the pre-credential rejections (CSRF, undecodable token) are
+reachable, because everything past them needs a credential Google
+actually signed for our audience. `stale_client`, `denied` and `server`
+are covered by `crates/quarto-hub/tests/integration/login_nonce.rs`
+instead.
+
 ## Audit log quick reference
 
 Auth events on target `quarto_hub::audit` carry
 `credential_kind=cookie|bearer` and a `detail` discriminator:
-`session_kid_mismatch` (different secret: rotated away, config drift,
-or a legacy Google-JWT cookie), `session_expired`,
+`session_kid_mismatch` (different secret: rotated away, config drift, a
+legacy Google-JWT cookie, or **two instances that each auto-generated
+their own secret** — see below), `session_expired`,
 `session_absolute_cap`, `session_tampered`, `session_revoked`,
-`user_banned`, `user_not_allowlisted`, `conflicting_credentials`.
-Token contents are never logged.
+`user_banned`, `user_not_allowlisted`, `conflicting_credentials`,
+`login_state_stale_client` and `login_state_missing` (the two
+cookie-absent login classes — see "Login nonce" above for their opposite
+remedies), `callback_csrf`. Token contents are never logged.
+
+**Mind the level.** The login-state classes and `callback_csrf` are
+**WARN**, so they appear at the hub's default verbosity. The
+credential-path details — `jwt_decode:*`, `azp_or_iat_rejected`,
+`email_not_verified`, `user_not_allowlisted` — are **INFO**, and are
+invisible unless the hub runs with `-v` or `RUST_LOG=info`. Chasing "why
+is this user refused?" without one of those set will show you nothing.
+
+`callback_csrf` means the Google double-submit pair on
+`POST /auth/callback` did not match: the form's `g_csrf_token` and the
+cookie GIS set on the hub origin disagreed, or one was missing. A
+*deployment-wide* run of these usually means the reverse proxy is
+dropping that cookie. It carries no `sub` — the check runs before the
+token is parsed, and an unvalidated subject in the audit log would be
+worse than an absent one. It is also emittable by unauthenticated
+callers (any garbage POST to `/auth/callback`), so WARN volume here is
+attacker-influenceable; that is already true of the login-nonce classes
+and is not a new exposure.
 
 Actions, by what they mean:
 
@@ -183,3 +281,33 @@ across sliding re-issues, so it identifies a login for as long as that
 session lives. **Sliding re-issue is deliberately silent** — it extends
 a session rather than opening one, so a keep-alive never looks like a
 fresh login.
+
+## What the user saw: `/?auth_error=<reason>`
+
+A failed `POST /auth/callback` redirects to `/?auth_error=<reason>`, and
+the SPA turns that into one of four sentences. Use this table to go from
+a user's report back to the `detail` worth grepping for. The mapping is
+**many-to-one on purpose** — the reason is in a URL the user can read and
+anyone can craft, so the precise cause stays in the audit log.
+
+| `reason` | What the user is told | Audit `detail` to look for |
+|---|---|---|
+| `stale_client` | This version of the app is out of date. Please reload the page and try again. | `login_state_stale_client` |
+| `restart` | Sign-in didn't complete. Please try again. | `login_state_missing`, `login_state_nonce_mismatch`, `login_state_expired`, `login_state_tampered`, `login_state_kid_mismatch`, `login_state_token_nonce_missing`, `callback_csrf`, `jwt_decode:*`, `azp_or_iat_rejected`, `email_not_verified` |
+| `denied` | Sign-in failed. Your account is not authorized to access this hub. | `user_banned`, `user_not_allowlisted` |
+| `server` | Something went wrong on the hub. Please try again shortly. | (no audit event — a mint failure logs at ERROR, not `auth_fail`) |
+
+Two properties worth knowing when reading reports:
+
+- **`denied` is exactly the two real denials** — a ban and an allowlist
+  miss, the cases where an identity *was* established and then refused.
+  Everything else is a retry, so a user reporting "not authorized" really
+  does need an administrator, not a reload.
+- **Unknown and empty reasons render as `restart`.** A pre-2026-07-30 hub
+  emits a bare `/?auth_error`, and the parameter is craftable, so the
+  client falls back to the retry copy rather than the alarming one. If a
+  user reports the retry sentence and you find no matching `auth_fail`,
+  suspect a stale or cached redirect.
+- `email_not_verified` is a known-coarse mapping: it lands in `restart`
+  even though retrying will not verify an email. `denied` is no better —
+  no administrator can fix it either. Revisit if it shows up in practice.

--- a/hub-client/changelog.md
+++ b/hub-client/changelog.md
@@ -23,6 +23,11 @@ WASM rebuild is needed for a changelog-only edit.
 
 -->
 
+### 2026-07-30
+
+- [`047903c3`](https://github.com/quarto-dev/q2/commits/047903c3): The out-of-date sign-in message no longer asks you to reload the page, which the app's cached bundle would have ignored; it now tells you the app is updating and to try again in a few minutes.
+- [`d2582ed9`](https://github.com/quarto-dev/q2/commits/d2582ed9): A failed sign-in now says what actually went wrong — an interrupted sign-in asks you to try again, an out-of-date app says it is out of date, and only a genuinely refused account is told it is not authorized.
+
 ### 2026-07-29
 
 - [`d866c6ae`](https://github.com/quarto-dev/q2/commits/d866c6ae): New projects can now be created from a Blog template — a listing home page, two starter posts with images, an about page, and an RSS-ready configuration.

--- a/hub-client/src/App.tsx
+++ b/hub-client/src/App.tsx
@@ -20,6 +20,7 @@ import { ErrorBoundary } from './components/ErrorBoundary';
 import Toast from './components/Toast';
 import { ViewModeProvider } from './components/ViewModeContext';
 import { LoginScreen } from './components/auth/LoginScreen';
+import { readAuthErrorReason } from './auth/authError';
 import {
   connect,
   disconnect,
@@ -175,11 +176,16 @@ function App() {
     [expireSession, localActorId],
   );
 
-  // Capture auth error from redirect query param (once, before URL is cleaned).
-  const [authError] = useState(() => {
-    const has = new URLSearchParams(window.location.search).has('auth_error');
-    if (has) window.history.replaceState(null, '', window.location.pathname + window.location.hash);
-    return has;
+  // Capture the auth error reason from the redirect query param (once,
+  // before the URL is cleaned). `undefined` means no error; `''` means a
+  // bare `/?auth_error` from a hub predating the reason codes, which is
+  // still an error — see readAuthErrorReason.
+  const [authErrorReason] = useState(() => {
+    const reason = readAuthErrorReason(window.location.search);
+    if (reason !== undefined) {
+      window.history.replaceState(null, '', window.location.pathname + window.location.hash);
+    }
+    return reason;
   });
 
   // Load screen name from IndexedDB (for identity mapping in Automerge docs).
@@ -693,7 +699,7 @@ function App() {
   if (AUTH_ENABLED && !auth) {
     return (
       <LoginScreen
-        error={authError}
+        errorReason={authErrorReason}
         message={sessionExpired ? 'Your session expired — please sign in again.' : undefined}
       />
     );

--- a/hub-client/src/auth/authError.test.ts
+++ b/hub-client/src/auth/authError.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Tests for the `auth_error` redirect parameter: reading it, and mapping
+ * it to user-facing copy.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { authErrorMessage, readAuthErrorReason } from './authError';
+
+describe('readAuthErrorReason', () => {
+  it('returns undefined when the parameter is absent', () => {
+    expect(readAuthErrorReason('')).toBeUndefined();
+    expect(readAuthErrorReason('?project=abc')).toBeUndefined();
+  });
+
+  it("returns '' for a bare ?auth_error — present, but with no value", () => {
+    // What a pre-E1 hub, or a cached redirect, emits. `''` is falsy, so
+    // presence has to be read separately from the value; a truthiness
+    // check here makes the error message silently disappear.
+    expect(readAuthErrorReason('?auth_error')).toBe('');
+    expect(readAuthErrorReason('?auth_error=')).toBe('');
+  });
+
+  it('returns the reason when the parameter carries one', () => {
+    expect(readAuthErrorReason('?auth_error=denied')).toBe('denied');
+    expect(readAuthErrorReason('?project=abc&auth_error=stale_client')).toBe('stale_client');
+  });
+});
+
+describe('authErrorMessage', () => {
+  it('gives each hub reason its own copy', () => {
+    expect(authErrorMessage('stale_client')).toMatch(/out of date/i);
+    expect(authErrorMessage('restart')).toMatch(/didn't complete/i);
+    expect(authErrorMessage('denied')).toMatch(/not authorized/i);
+    expect(authErrorMessage('server')).toMatch(/went wrong on the hub/i);
+  });
+
+  it('falls back to the retry copy for an empty or unknown reason', () => {
+    // Client/server skew, or a crafted URL. A false "try again" costs one
+    // retry; a false "not authorized" sends the user to an administrator.
+    expect(authErrorMessage('')).toBe(authErrorMessage('restart'));
+    expect(authErrorMessage('nonsense')).toBe(authErrorMessage('restart'));
+  });
+
+  it('falls back for prototype keys too, and never echoes the reason', () => {
+    // The reason is only ever a lookup key. An object-literal lookup of
+    // `__proto__` would return something truthy that is not copy at all.
+    expect(authErrorMessage('__proto__')).toBe(authErrorMessage('restart'));
+    expect(authErrorMessage('constructor')).toBe(authErrorMessage('restart'));
+    expect(authErrorMessage('<script>alert(1)</script>')).toBe(authErrorMessage('restart'));
+  });
+});

--- a/hub-client/src/auth/authError.ts
+++ b/hub-client/src/auth/authError.ts
@@ -19,7 +19,7 @@ const RESTART_COPY = "Sign-in didn't complete. Please try again.";
  * so an object lookup would slip past the fallback below.
  */
 const COPY = new Map<string, string>([
-  ['stale_client', 'This version of the app is out of date. Please reload the page and try again.'],
+  ['stale_client', 'This app is out of date and updating. Please try again in a few minutes.'],
   ['restart', RESTART_COPY],
   ['denied', 'Sign-in failed. Your account is not authorized to access this hub.'],
   ['server', 'Something went wrong on the hub. Please try again shortly.'],

--- a/hub-client/src/auth/authError.ts
+++ b/hub-client/src/auth/authError.ts
@@ -1,0 +1,55 @@
+/**
+ * The `auth_error` redirect parameter: reading it, and turning it into
+ * something worth showing a user.
+ *
+ * `POST /auth/callback` can fail about a dozen ways. The hub collapses
+ * them into four coarse reasons, because the reason lands in a URL the
+ * user can read and anyone can craft — the fine distinctions (tampered
+ * blob, `kid` mismatch, nonce mismatch, which claim was wrong) stay in
+ * the hub's audit log. The reason is only ever a lookup key here; it is
+ * never rendered.
+ */
+
+/** Copy for a reason the hub did not send, or one we do not recognize. */
+const RESTART_COPY = "Sign-in didn't complete. Please try again.";
+
+/**
+ * A `Map`, not an object literal, precisely because the key comes from a
+ * craftable URL: `({})['__proto__']` is truthy and is not copy at all,
+ * so an object lookup would slip past the fallback below.
+ */
+const COPY = new Map<string, string>([
+  ['stale_client', 'This version of the app is out of date. Please reload the page and try again.'],
+  ['restart', RESTART_COPY],
+  ['denied', 'Sign-in failed. Your account is not authorized to access this hub.'],
+  ['server', 'Something went wrong on the hub. Please try again shortly.'],
+]);
+
+/**
+ * Read the `auth_error` parameter out of a query string.
+ *
+ * Presence and value are separate questions. A hub predating the reason
+ * codes — or a cached redirect — emits a bare `/?auth_error`, for which
+ * `.get()` returns `''`; a truthiness check on the value would drop the
+ * error entirely and show the normal sign-in prompt. `undefined` is
+ * returned only when the parameter is genuinely absent.
+ */
+export function readAuthErrorReason(search: string): string | undefined {
+  const params = new URLSearchParams(search);
+  if (!params.has('auth_error')) return undefined;
+  return params.get('auth_error') ?? '';
+}
+
+/**
+ * Copy for a reason, falling back to the retry sentence.
+ *
+ * Unknown or empty means client/server skew, and retry is the safer
+ * default: a false "try again" costs one retry, whereas a false "not
+ * authorized" sends a user to an administrator over nothing — and would
+ * let any `/?auth_error=anything` link render that sentence. A real
+ * refusal is never hidden by this: `denied` is in the vocabulary from day
+ * one, so skew can only affect reasons added later.
+ */
+export function authErrorMessage(reason: string): string {
+  return COPY.get(reason) ?? RESTART_COPY;
+}

--- a/hub-client/src/components/auth/LoginScreen.test.tsx
+++ b/hub-client/src/components/auth/LoginScreen.test.tsx
@@ -48,16 +48,58 @@ describe('LoginScreen', () => {
     expect(mock.lastLoginUri).toBe(window.location.origin + '/subpath/auth/callback');
   });
 
-  it('renders the default copy when error is false/absent', () => {
+  it('renders the default copy when no error reason is present', () => {
     render(withProvider(<LoginScreen />));
     expect(screen.getByText(/Sign in with Google to continue/i)).toBeTruthy();
-    expect(screen.queryByText(/Sign-in failed/i)).toBeNull();
+    expect(screen.queryByText(/not authorized/i)).toBeNull();
+    expect(screen.queryByText(/didn't complete/i)).toBeNull();
   });
 
-  it('renders the error copy when error={true}', () => {
-    render(withProvider(<LoginScreen error />));
-    expect(screen.getByText(/Sign-in failed/i)).toBeTruthy();
+  // One case per user-facing message. Eleven distinct causes used to
+  // collapse into the "not authorized" sentence, sending users who needed
+  // a reload to an administrator instead.
+  it('tells a stale client to reload', () => {
+    render(withProvider(<LoginScreen errorReason="stale_client" />));
+    expect(screen.getByText(/out of date.*reload the page/i)).toBeTruthy();
+    expect(screen.queryByText(/not authorized/i)).toBeNull();
+  });
+
+  it('tells a broken-down sign-in to try again', () => {
+    render(withProvider(<LoginScreen errorReason="restart" />));
+    expect(screen.getByText(/didn't complete.*try again/i)).toBeTruthy();
+    expect(screen.queryByText(/not authorized/i)).toBeNull();
+  });
+
+  it('tells a refused identity it is not authorized', () => {
+    render(withProvider(<LoginScreen errorReason="denied" />));
+    expect(screen.getByText(/not authorized to access this hub/i)).toBeTruthy();
+  });
+
+  it('reports a hub-side failure as a hub-side failure', () => {
+    render(withProvider(<LoginScreen errorReason="server" />));
+    expect(screen.getByText(/went wrong on the hub/i)).toBeTruthy();
+    expect(screen.queryByText(/not authorized/i)).toBeNull();
+  });
+
+  // A bare `/?auth_error` from a pre-E1 hub parses to `''`, which is
+  // falsy — the error must still show, and as the retry copy rather than
+  // the alarming one.
+  it('renders the retry copy for an empty reason, not nothing', () => {
+    render(withProvider(<LoginScreen errorReason="" />));
+    expect(screen.getByText(/didn't complete.*try again/i)).toBeTruthy();
     expect(screen.queryByText(/Sign in with Google to continue/i)).toBeNull();
+  });
+
+  it('renders the retry copy for an unknown reason, never "not authorized"', () => {
+    render(withProvider(<LoginScreen errorReason="something-we-do-not-know" />));
+    expect(screen.getByText(/didn't complete.*try again/i)).toBeTruthy();
+    expect(screen.queryByText(/not authorized/i)).toBeNull();
+  });
+
+  it('never renders the reason string itself', () => {
+    render(withProvider(<LoginScreen errorReason="<img src=x onerror=1>" />));
+    expect(screen.queryByText(/onerror/i)).toBeNull();
+    expect(screen.getByText(/didn't complete.*try again/i)).toBeTruthy();
   });
 
   it('renders a custom message (session expiry) instead of the default copy', () => {
@@ -67,8 +109,8 @@ describe('LoginScreen', () => {
   });
 
   it('error copy wins over a custom message', () => {
-    render(withProvider(<LoginScreen error message="Your session expired — please sign in again." />));
-    expect(screen.getByText(/Sign-in failed/i)).toBeTruthy();
+    render(withProvider(<LoginScreen errorReason="denied" message="Your session expired — please sign in again." />));
+    expect(screen.getByText(/not authorized/i)).toBeTruthy();
     expect(screen.queryByText(/session expired/i)).toBeNull();
   });
 });

--- a/hub-client/src/components/auth/LoginScreen.test.tsx
+++ b/hub-client/src/components/auth/LoginScreen.test.tsx
@@ -58,9 +58,9 @@ describe('LoginScreen', () => {
   // One case per user-facing message. Eleven distinct causes used to
   // collapse into the "not authorized" sentence, sending users who needed
   // a reload to an administrator instead.
-  it('tells a stale client to reload', () => {
+  it('tells a stale client its bundle is out of date', () => {
     render(withProvider(<LoginScreen errorReason="stale_client" />));
-    expect(screen.getByText(/out of date.*reload the page/i)).toBeTruthy();
+    expect(screen.getByText(/out of date.*try again/i)).toBeTruthy();
     expect(screen.queryByText(/not authorized/i)).toBeNull();
   });
 

--- a/hub-client/src/components/auth/LoginScreen.tsx
+++ b/hub-client/src/components/auth/LoginScreen.tsx
@@ -12,9 +12,15 @@
  */
 
 import { useAuthProvider } from '../../auth/AuthProvider';
+import { authErrorMessage } from '../../auth/authError';
 import { hubPath } from '../../utils/routing';
 
-export function LoginScreen({ error, message }: { error?: boolean; message?: string }) {
+/**
+ * `errorReason` is the hub's coarse `auth_error` reason, not a flag —
+ * `''` (a bare `/?auth_error`) is a *present* error, so presence is
+ * tested with `!== undefined` rather than truthiness.
+ */
+export function LoginScreen({ errorReason, message }: { errorReason?: string; message?: string }) {
   const provider = useAuthProvider();
 
   return (
@@ -22,9 +28,9 @@ export function LoginScreen({ error, message }: { error?: boolean; message?: str
       <div className="modal" style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', textAlign: 'center', padding: '48px 32px' }}>
         <img src="/quarto-icon.svg" alt="Quarto" style={{ width: '48px', height: '48px', marginBottom: '8px' }} />
         <h1 style={{ margin: 0 }}>Quarto Hub</h1>
-        {error ? (
+        {errorReason !== undefined ? (
           <p style={{ color: 'var(--posit-red)', fontSize: '14px', margin: '0 0 16px' }}>
-            Sign-in failed. Your account is not authorized to access this hub.
+            {authErrorMessage(errorReason)}
           </p>
         ) : message ? (
           <p style={{ color: 'var(--text-secondary)', fontSize: '14px', margin: '0 0 16px' }}>

--- a/scripts/hub-auth-error-reasons-e2e.mjs
+++ b/scripts/hub-auth-error-reasons-e2e.mjs
@@ -1,0 +1,141 @@
+// End-to-end verification of the `/?auth_error=<reason>` redirect codes
+// (E1/E2, bd-htis60s7 + bd-sxnfoefn). Drives the REAL `hub` binary over
+// HTTP. Node built-ins only.
+//
+//   cargo build --bin hub
+//   node scripts/hub-auth-error-reasons-e2e.mjs
+//
+// WHY THIS SCRIPT DOES NOT MOCK THE IdP
+// ------------------------------------
+// `POST /auth/callback` is registered only when the provider is Google,
+// and the provider is derived from the issuer being exactly
+// `https://accounts.google.com` (`AuthConfig::new`). Point the hub at a
+// mock IdP on localhost and the route 404s, so the sibling script
+// `hub-sliding-sessions-e2e.mjs` — which mocks the IdP — structurally
+// cannot reach any of these paths. This script therefore uses Google's
+// real (public) discovery + JWKS endpoints, and needs outbound network.
+//
+// WHAT THAT BUYS, AND WHAT IT COSTS
+// ---------------------------------
+// Reachable: every rejection that happens *before* the credential is
+// validated — the CSRF pair, and an undecodable credential. Both map to
+// `restart`.
+//
+// Not reachable: `stale_client`, `denied` and `server` all require first
+// *passing* `authenticate_claims`, i.e. a credential signed by Google for
+// our audience. Forging one is the thing the hub exists to prevent. Those
+// three are covered by the integration tests in
+// `crates/quarto-hub/tests/integration/login_nonce.rs`, which drive the
+// real router over real HTTP against a mock provider whose JWKS the hub
+// actually fetches — bypassing only CLI parsing and OIDC discovery, both
+// of which *this* script covers.
+import { spawn } from 'node:child_process';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const CLIENT_ID = 'e2e-reasons.apps.googleusercontent.com';
+const HUB_PORT = 3992;
+const HUB = `http://127.0.0.1:${HUB_PORT}`;
+
+const dataDir = mkdtempSync(join(tmpdir(), 'hub-reasons-e2e-'));
+const hubArgs = [
+  '--data-dir', dataDir, '--port', String(HUB_PORT),
+  '--oidc-client-id', CLIENT_ID,
+  '--oidc-issuer', 'https://accounts.google.com',
+  '--allow-insecure-auth',
+];
+console.log(`[hub] target/debug/hub ${hubArgs.join(' ')}`);
+// RUST_LOG=info because the credential-path audit details (`jwt_decode:*`,
+// `user_not_allowlisted`) are emitted at INFO, while the login-state and
+// CSRF ones are WARN. At the hub's default verbosity only the WARNs show,
+// so an operator chasing a credential failure needs `-v` / RUST_LOG.
+const hub = spawn('target/debug/hub', hubArgs, {
+  stdio: ['ignore', 'pipe', 'pipe'],
+  env: { ...process.env, RUST_LOG: 'info' },
+});
+// The fmt layer writes ANSI escapes when it thinks a terminal is present,
+// which lands *between* a field name and its `=`. Strip them before matching.
+const ANSI = /\[[0-9;]*m/g;
+let hubLog = '';
+const collect = (d) => { hubLog += d.toString().replace(ANSI, ''); };
+hub.stderr.on('data', collect);
+hub.stdout.on('data', collect);
+process.on('exit', () => hub.kill());
+
+for (let i = 0; ; i++) {
+  try { await fetch(`${HUB}/auth/me`); break; }
+  catch {
+    if (i > 75) throw new Error('hub did not start (OIDC discovery needs network)');
+    await new Promise((r) => setTimeout(r, 200));
+  }
+}
+console.log('[hub] up (Google discovery + JWKS fetched)');
+
+let failures = 0;
+const check = (label, cond, detail) => {
+  console.log(`${cond ? 'PASS' : 'FAIL'}  ${label}${detail ? ` — ${detail}` : ''}`);
+  if (!cond) failures++;
+};
+
+const postCallback = (body, cookie) =>
+  fetch(`${HUB}/auth/callback`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded', ...(cookie ? { cookie } : {}) },
+    body,
+    redirect: 'manual',
+  });
+
+// ── the route exists at all (what a mock issuer cannot give us) ──────
+const routed = await postCallback('credential=x&g_csrf_token=x', 'g_csrf_token=x');
+check('POST /auth/callback is routed for a Google issuer', routed.status !== 404,
+  `status=${routed.status}`);
+
+// ── CSRF mismatch -> restart (E2's newly-audited path) ──────────────
+const mismatch = await postCallback(
+  'credential=irrelevant&g_csrf_token=from-the-form', 'g_csrf_token=from-the-cookie');
+check('CSRF pair mismatch -> /?auth_error=restart',
+  mismatch.headers.get('location') === '/?auth_error=restart',
+  `location=${mismatch.headers.get('location')}`);
+
+const missingCsrf = await postCallback('credential=irrelevant', undefined);
+check('CSRF field absent entirely -> /?auth_error=restart',
+  missingCsrf.headers.get('location') === '/?auth_error=restart',
+  `location=${missingCsrf.headers.get('location')}`);
+
+// ── undecodable credential -> restart (the 401 family) ──────────────
+const badJwt = await postCallback('credential=not-a-jwt&g_csrf_token=m', 'g_csrf_token=m');
+check('undecodable credential -> /?auth_error=restart',
+  badJwt.headers.get('location') === '/?auth_error=restart',
+  `location=${badJwt.headers.get('location')}`);
+
+// No path may mint a session on the way out, and every one clears the
+// sealed login-state blob.
+for (const [label, res] of [['csrf', mismatch], ['jwt', badJwt]]) {
+  const cookies = res.headers.getSetCookie();
+  check(`${label}: no session cookie minted`,
+    !cookies.some((c) => c.startsWith('quarto_hub_token=') && !c.includes('Max-Age=0')),
+    cookies.join(' | ') || '(none)');
+  check(`${label}: login-state cookie cleared`,
+    cookies.some((c) => c.startsWith('quarto_hub_login=') && c.includes('Max-Age=0')),
+    cookies.join(' | ') || '(none)');
+}
+
+// ── the audit trail an operator would grep (E2) ──────────────────────
+await new Promise((r) => setTimeout(r, 300));
+check('callback_csrf is in the audit log (was silent before E2)',
+  /detail="?callback_csrf/.test(hubLog),
+  hubLog.split('\n').find((l) => l.includes('callback_csrf')) ?? '(absent)');
+check('the jwt_decode detail survives, unburied by a blanket emit',
+  /detail="?jwt_decode:/.test(hubLog),
+  hubLog.split('\n').find((l) => l.includes('jwt_decode:')) ?? '(absent)');
+
+// ── E3: auto-generated secrets are loud, exactly once ────────────────
+check('startup warns that it generated a session secret',
+  /generated a new session secret/.test(hubLog) && /QUARTO_HUB_SESSION_SECRET/.test(hubLog));
+check('startup warns that it generated a server secret',
+  /generated a new server secret/.test(hubLog) && /QUARTO_HUB_SERVER_SECRET/.test(hubLog));
+
+console.log(failures === 0 ? '\nALL CHECKS PASSED' : `\n${failures} CHECK(S) FAILED`);
+hub.kill();
+process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
## Why

Every way `POST /auth/callback` can fail redirected to the same bare `/?auth_error`, which the client turned into one sentence:

> Sign-in failed. Your account is not authorized to access this hub.

A dozen causes collapsed into that message, and only two of them were actually about authorization. Someone with an expired sign-in, a stale browser tab, a lost cookie or a CSRF mismatch was told their account was refused — sending them to an administrator instead of to the retry that would have fixed it.

This PR gives the failure a name. The hub now redirects to `/?auth_error=<reason>`, and the client shows copy that matches what actually happened.

## The four messages

| `reason` | What the user is told | When |
|---|---|---|
| `stale_client` | This app is out of date and updating. Please try again in a few minutes. | No login-state cookie **and** a token with no nonce — an out-of-date bundle, or a login driven outside the app |
| `restart` | Sign-in didn't complete. Please try again. | The attempt broke down without establishing an identity: expired/tampered/mismatched login state, CSRF mismatch, undecodable or wrong-audience credential |
| `denied` | Sign-in failed. Your account is not authorized to access this hub. | An identity **was** established and then refused — exactly two causes: a ban, and an email matching no allowlist |
| `server` | Something went wrong on the hub. Please try again shortly. | The hub failed to mint the session |

The mapping is many-to-one on purpose. The key change is that the callback now *reads* the status `authenticate_claims` already returns — 403 for "good credentials, wrong user", 401 for everything else — instead of discarding it. That one line is what made an allowlist denial indistinguishable from a broken login.

Two smaller fixes ride along:

- **The CSRF rejection was audit-silent.** A deployment whose reverse proxy dropped the `g_csrf_token` cookie failed every login with nothing in `journalctl -u hub`. It now emits `detail=callback_csrf`.
- **`login_state_missing` was self-conflating and double-prefixed.** It covered both "old bundle" and "cookie lost in transit" — opposite remedies — and the emitted detail was literally `login_state_login_state_missing`. Split, and un-doubled.
- **Auto-generated secrets are now loud.** Two hub instances that each generate their own reject each other's cookies, which shows up as intermittent, self-healing sign-in failure. The warning names the env var to set.

## What this does not fix

The copy is rendered by the client, so **a browser already running an out-of-date bundle cannot show it.** That client falls into `stale_client` on the server, receives `/?auth_error=stale_client`, and then renders the *old* hardcoded sentence — "your account is not authorized" — because it is the only one it has. It also strips the parameter from the URL on first render, so nothing is left for the user to report.

A reload does not rescue it either: the service worker binds a `NavigationRoute` to a precached `index.html`, so navigations never consult nginx's `no-cache` on `/`. What recovers is retrying once the new worker has installed (166 precache entries, about 65 MB) and claimed the tab — the sign-in click is itself a navigation, so it fetches the new bundle. That is why the `stale_client` copy says the app is updating instead of telling you to reload.

So the four sentences reach clients on this bundle or newer, and `stale_client`'s real payoff is the *next* breaking client/server change: a reason absent from the client's vocabulary today cannot be used later without the same one-generation lag. `AuthErrorReason::StaleClient` is documented as the general "your bundle is old" slot for exactly that reason, so a future callback-time break maps there rather than to `restart`.

The operational consequence is recorded in `dev-docs/quarto-hub/session-auth-operations.md`: **during a rollout, do not infer the reason from the sentence a user reports** — match it against the audit `detail` instead.

## Security and safety considerations

**The reason is coarse on purpose.** It lands in a URL the user can read and anyone can enumerate, so it says `restart` rather than which check failed. Tampered blob, `kid` mismatch, nonce mismatch, expired login state, which JWT claim was wrong — all of that stays in the audit log, where an operator can see it and an attacker cannot. This PR *increases* audit precision while keeping the user-facing surface vague.

**Nothing user-supplied is reflected.** The reasons are four server-controlled constants. On the client the reason is only ever a lookup key into four fixed strings — it is never rendered. A crafted `/?auth_error=<script>…` renders ordinary retry copy.

**Unknown and empty reasons fall back to `restart`, never `denied`.** Because the parameter is craftable, a `denied` fallback would let any `/?auth_error=anything` link render the alarming sentence. And a false "try again" costs one retry, whereas a false "not authorized" costs a support ticket. A real refusal is never hidden by this: `denied` is in the client's vocabulary from day one, so skew can only affect reasons added later. (Presence and value are read separately, so a bare `/?auth_error` from an older hub still shows an error rather than silently vanishing.)

**The 401 family is never `denied`.** No identity was established, so "your account is not authorized" would simply be false. This matters at scale: if the hub's configured audience ever drifts from the SPA's, every user in the deployment fails at that line at once — telling all of them their accounts were refused would be indistinguishable from a mass de-allowlisting.

**No failure condition changed.** This PR changes only what the server *reports* and what the user is *told*. Every check still runs, in the same order, with the same outcome.

**Two invariants held.** The sealed login-state blob is still cleared on every exit path — a single pre-flight can complete at most one login — and `assert_auth_error` now asserts that on all 13 failure paths, so a new reason cannot open a hole in it. And the CSRF audit event carries no `sub`: the check runs before the token is parsed, and an unvalidated subject in the audit log would be worse than an absent one.

**No secret is ever logged.** The new warnings name the env var and the data directory, never the value; a test asserts the generated secret does not appear in the log.

## Verification

- `cargo xtask verify` fully green — 10802 Rust tests, hub-client build + 130 tests. `cargo xtask lint` clean. (Run before the copy revision below.)
- 9 new integration tests; all 13 callback failure paths now assert their own reason **and** the clear-login-state cookie. 12 new client tests.
- New `scripts/hub-auth-error-reasons-e2e.mjs` drives the reason codes through the **real `hub` binary** (13/13). E3 verified the same way: fresh data dir warns twice, restart is byte-for-byte silent, secret absent from both logs.
- The copy revision (`047903c3`) was verified separately: `cargo build --workspace`, `cargo nextest run -p quarto-hub` (442), hub-client `tsc -b && vite build`, the full hub-client suite (130), and an auth-enabled production build confirming all four sentences are present in the bundle and the superseded one is absent. **`cargo xtask verify` has not been re-run since that commit** — it changes one string, one doc comment and three documents.

Strands: `bd-htis60s7` (E0+E1), `bd-sxnfoefn` (E2), `bd-sx7k3vid` (E3). Plan: `claude-notes/plans/2026-07-30-auth-error-reasons-and-audit-coverage.md`
