### PR TITLE
Vendor and integrate quarto-listing.scss into the theme bundle (bd-57y4)

### DIFF
--- a/claude-notes/plans/2026-07-29-listing-scss.md
+++ b/claude-notes/plans/2026-07-29-listing-scss.md
@@ -1,0 +1,139 @@
+# Vendor and integrate quarto-listing.scss (bd-57y4)
+
+**Strand:** bd-57y4 (P2; discovered from L3 phase 7, bd-ml8z — see D5 in
+`claude-notes/plans/2026-05-06-listings-L3-resolve-transform.md`)
+**Created:** 2026-07-29
+**Branch:** `braid/bd-57y4-listing-scss` (based on the blog-scaffold
+branch, PR #434 — independent code, but the blog scaffold is the natural
+e2e fixture)
+
+## Overview
+
+Q2 ships the listing JS pair (`list.min.js` + `quarto-listing.js`) as
+Project-scoped artifacts but never compiled Q1's `quarto-listing.scss`,
+so listing cards/tables/category chips render with default browser
+styling. This strand vendors the SCSS and composes it into the theme-CSS
+bundle as a `SassLayer`, restoring Q1 visual parity for listings and the
+categories sidebar (the L5 markup already exists and consumes these
+classes).
+
+## Design decisions
+
+1. **Unconditional layer (deviation from the strand sketch, matching
+   Q1).** The strand suggested adding the layer "when at least one
+   listing is rendered", but:
+   - Q1 attaches `listingSassBundle()` gated only on
+     `formatHasBootstrap(format)` — *not* on `pageHasListings`
+     (`website-listing.ts:284,424`); only the JS/postprocessor slots are
+     page-conditional. Q2 parity = unconditional.
+   - `CompileThemeCssStage` runs at stage 11, before the listing
+     transforms populate `ctx.resolved_listings` (stage 13) — the only
+     sound predicate would be raw `meta.listing`, which needs a new
+     `ThemeConfig` flag plus a cache-key discriminator
+     (`compile_theme_css.rs:234-238`), and would fork a website's theme
+     CSS into two fingerprints (listing vs non-listing pages), worse
+     for caching than one shared file.
+   - Cost of unconditional: a few KB of CSS on non-listing docs — the
+     same cost Q1 accepts.
+2. **Vendor verbatim** to `resources/scss/html/templates/
+   quarto-listing.scss` (auto-embedded via `TEMPLATES_DIR` include_dir,
+   auto-hashed by quarto-sass `build.rs`). The file's
+   `/*-- scss:variables --*/` marker is *invalid* (only
+   uses/functions/defaults/mixins/rules parse), so its `!default` block
+   lands in the functions band — the same known quirk as
+   `title-block.scss` (`bundle.rs:178-189`, quarto-cli#13960). Q1's
+   parser has the identical behavior; do NOT "fix" the marker.
+3. **HTML paths only** — the layer is pushed at every HTML assembly
+   site (`assemble_theme_scss`, native+wasm `compile_with_doc_vars`,
+   native+wasm `compile_default_css`); **not** `assemble_reveal_scss`
+   (no listings in slide decks).
+4. **`$theme-name` parity (small extra).** Q1 sets `$theme-name` so the
+   listing SCSS's per-theme override map (cyborg/darkly/slate/… chip
+   borders and form colors) activates. Q2 never defines it; the layer's
+   own `$theme-name: null !default` then makes every override fall back
+   to defaults — correct for custom themes, a visible gap for the dark
+   built-ins. Since Sass `!default` also fires on *null* values, a
+   later-band `$theme-name: "<name>" !default` emitted for built-in
+   themes activates the map. Implement if it stays a ~few-line change
+   in the theme defaults; otherwise file a follow-up strand and ship
+   without it.
+
+## Work Items
+
+### Phase 1: tests first (TDD)
+
+- [x] T1 `quarto-sass` unit tests (mirror the highlight/copy-code
+      regression pattern at `compile.rs:857-876`): compiled theme CSS
+      contains `.quarto-listing` and listing-category rules for (a) the
+      default-css path and (b) the themed/doc-vars path. One assertion
+      per assembly path touched.
+- [x] T2 e2e integration test (brand_render.rs shape, using
+      `listing_pipeline.rs`'s `render_project` harness): render a
+      website with a listing page → concatenated `.css` under the
+      output tree contains `.quarto-listing` / `listing-category`
+      selectors.
+- [x] T3 ($theme-name, if implemented) unit test: compiling theme
+      `darkly` yields the darkly category-chip override (border color
+      `$gray-600`) rather than the default.
+- [x] T4 run tests, record expected failures.
+
+### Phase 2: implementation
+
+- [x] I1 copy `external-sources/quarto-cli/src/resources/projects/
+      website/listing/quarto-listing.scss` →
+      `resources/scss/html/templates/quarto-listing.scss` (verbatim);
+      update `resources/scss/README.md`'s vendored list.
+- [x] I2 `load_listing_layer()` in `quarto-sass/src/bundle.rs` next to
+      `load_copy_code_layer`; push at the HTML assembly sites
+      (`compile.rs:88-98`, `:226-243`, `:359-370`, wasm `:498-515` and
+      wasm `compile_default_css`).
+- [x] I3 ($theme-name) emit `$theme-name: "<name>" !default;` into the
+      defaults band for built-in bootstrap themes.
+- [x] I4 make Phase-1 tests green; full `-p quarto-sass` +
+      `-p quarto-core` suites (preview/render CSS parity tests must
+      stay green — the layer is unconditional so fingerprints move
+      uniformly).
+
+### Phase 3: verification + handoff
+
+- [x] V1 `cargo build --workspace` + `cargo nextest run --workspace`.
+- [x] V2 full `cargo xtask verify` (quarto-sass feeds the WASM leg; the
+      hub preview compiles SCSS through the dart-sass JS bridge — the
+      layer must ride the assembled string, which SassLayer composition
+      guarantees).
+- [x] V3 e2e: `q2 create project blog myblog && q2 render myblog`,
+      inspect `_site/` theme CSS for `.quarto-listing` rules and load
+      the listing page to confirm card layout (image-right float,
+      category chips, pagination styling); check a dark theme (darkly)
+      if T3/I3 landed.
+- [x] V4 update this plan, close bd-57y4 (note the unconditional-layer
+      deviation in the close reason), report.
+
+## Implementation record (2026-07-29)
+
+- T4 recorded failures: 3 quarto-sass unit tests + the e2e test all
+  failed before wiring (missing `.quarto-listing` selectors).
+- I3 came **for free**: Q2's vendored bootstrap layer already defines
+  `$theme: "<name>" !default` per built-in theme and derives
+  `$theme-name` in `_bootstrap-variables.scss`, so the listing
+  override map fires with no new code. One subtlety, captured in the
+  darkly test: the override's `$gray-600` resolves to the
+  *bootstrap-default* value (#6c757d), not darkly's, because the
+  file's invalid `scss:variables` marker parks its `!default` block in
+  the functions band ahead of theme defaults — Q1's parser has the
+  identical band order, so this is parity, not a bug.
+- V3 e2e (real binary): `q2 render` of the bd-r1by4u2a blog scaffold →
+  `site_libs/quarto/quarto-theme-<fp>.css` contains the card layout
+  (`div.quarto-post .thumbnail{flex-basis:30%…}`,
+  `.quarto-listing-default…`, category-chip rules) and is linked from
+  the listing page; markup classes (`quarto-post image-right`,
+  `listing-categories`) match. Output inspected.
+- Tests: quarto-sass 210/210; e2e + both preview/render CSS-parity
+  guards green (the layer is unconditional, so fingerprints moved
+  uniformly in both pipelines).
+- V1/V2 (2026-07-29): workspace 10794/10794; full `cargo xtask verify`
+  "All verification steps passed!". One legitimate baseline update: the
+  phase5 single-doc byte-identity fixture's `styles.css` hash
+  re-captured per its documented procedure (listing rules now in every
+  HTML theme compile; `doc.html` hash unchanged — no listing selector
+  matches a single-doc body).

--- a/crates/quarto-core/tests/fixtures/phase5-single-doc-baseline/expected_hashes.txt
+++ b/crates/quarto-core/tests/fixtures/phase5-single-doc-baseline/expected_hashes.txt
@@ -262,5 +262,11 @@
 # the compiled CSS (this branch's title-block/tables/code/print/misc/13g rules +
 # #407's ul.task-list/checkbox rules), so styles.css is re-captured to reflect
 # BOTH rule sets. doc.html unchanged.
+# Re-captured 2026-07-29 (bd-57y4): styles.css hash updated because the
+# listing SCSS layer (Q1's quarto-listing.scss — cards, table layout,
+# category chips, pagination) is now composed into every HTML theme
+# compile, unconditionally like Q1. doc.html hash unchanged: no
+# `.quarto-listing*` selector matches anything in a single-doc body,
+# and `<head>` is unaffected.
 doc.html c85d97d01136c864f9bd54ce0c5a15dd649c029a8f44aa3608819282199e3e57
-doc_files/styles.css a54a2e6e2cf7beb3b74e1579ed08eb0af881ed9de390a582143a0d58ea34ca99
+doc_files/styles.css 701063255f83fe84581ee7b0a02bdd620bfa4365c276d8b6585396d401926200

--- a/crates/quarto-core/tests/integration/listing_pipeline.rs
+++ b/crates/quarto-core/tests/integration/listing_pipeline.rs
@@ -968,3 +968,44 @@ fn front_matter_image_rebase_nested_host() {
     );
     assert!(dir.join("_site/posts/cover.png").exists());
 }
+
+/// The listing SCSS layer must reach the *rendered site's* theme CSS
+/// (bd-57y4). quarto-sass unit tests can't see whether the pipeline
+/// wired the layer; this is the brand_render.rs-shaped guard. The
+/// layer is unconditional (Q1 parity), so any HTML render carries it —
+/// asserted here on a listing project where it visibly matters.
+#[test]
+fn listing_css_rules_land_in_rendered_theme_css() {
+    let (dir, _outputs) = render_project(|p| {
+        write(
+            &p.join("_quarto.yml"),
+            "project:\n  type: website\n  output-dir: _site\nwebsite:\n  title: \"Blog\"\nformat:\n  html:\n    theme: cosmo\n",
+        );
+        write(
+            &p.join("index.qmd"),
+            "---\ntitle: Blog\nlisting:\n  contents: posts\nformat: html\n---\n",
+        );
+        write(
+            &p.join("posts/first.qmd"),
+            "---\ntitle: First\ndate: 2026-01-15\ncategories: [news]\nformat: html\n---\n\nBody.\n",
+        );
+    });
+
+    let mut css = String::new();
+    for entry in walkdir::WalkDir::new(dir.join("_site"))
+        .into_iter()
+        .filter_map(Result::ok)
+    {
+        if entry.path().extension().and_then(|e| e.to_str()) == Some("css") {
+            css.push_str(&read(entry.path()));
+        }
+    }
+    assert!(
+        css.contains(".quarto-listing"),
+        "rendered theme CSS must contain .quarto-listing rules"
+    );
+    assert!(
+        css.contains(".listing-category"),
+        "rendered theme CSS must contain category-chip rules"
+    );
+}

--- a/crates/quarto-sass/src/bundle.rs
+++ b/crates/quarto-sass/src/bundle.rs
@@ -279,6 +279,37 @@ pub fn load_embed_example_layer() -> Result<SassLayer, SassError> {
     parse_layer(content, Some("embed-example.scss"))
 }
 
+/// Load the listing (cards / table / category chips / pagination) SCSS
+/// layer (bd-57y4).
+///
+/// Reads `quarto-listing.scss` — a verbatim vendor of Q1's
+/// `projects/website/listing/quarto-listing.scss`. Like Q1's
+/// `listingSassBundle()`, the layer is attached **unconditionally** to
+/// every HTML (bootstrap) compile, not gated on a page having listings:
+/// the theme-CSS stage runs before listing resolution, and keeping the
+/// layer unconditional keeps one shared theme CSS per site. Slide
+/// formats do not include it.
+///
+/// Known parity quirk carried over on purpose: the file's
+/// `/*-- scss:variables --*/` marker is not a recognized boundary (in
+/// Q1 or here), so its `!default` block rides along in the `functions`
+/// band — same as `title-block.scss` (quarto-cli#13960). Do not "fix"
+/// the marker without a deliberate parity decision.
+///
+/// The per-theme override map inside keys off `$theme-name`, emitted
+/// for built-in themes by [`crate::themes::process_theme_specs`].
+pub fn load_listing_layer() -> Result<SassLayer, SassError> {
+    use crate::resources::TEMPLATES_RESOURCES;
+
+    let content = TEMPLATES_RESOURCES
+        .read_str(Path::new("quarto-listing.scss"))
+        .ok_or_else(|| SassError::CompilationFailed {
+            message: "quarto-listing.scss not found in templates resources".to_string(),
+        })?;
+
+    parse_layer(content, Some("quarto-listing.scss"))
+}
+
 /// Load the reveal.js framework layer.
 ///
 /// This is the reveal analogue of [`load_bootstrap_framework`]: it provides the

--- a/crates/quarto-sass/src/compile.rs
+++ b/crates/quarto-sass/src/compile.rs
@@ -74,7 +74,7 @@ pub fn assemble_theme_scss(
     context: &ThemeContext<'_>,
 ) -> Result<(String, Vec<PathBuf>), SassError> {
     use crate::bundle::{
-        load_copy_code_layer, load_embed_example_layer, load_highlight_layer,
+        load_copy_code_layer, load_embed_example_layer, load_highlight_layer, load_listing_layer,
         load_title_block_layer,
     };
 
@@ -88,13 +88,19 @@ pub fn assemble_theme_scss(
     let highlight_layer = load_highlight_layer()?;
     let embed_example_layer = load_embed_example_layer()?;
     let copy_code_layer = load_copy_code_layer()?;
+    let listing_layer = load_listing_layer()?;
     let mut user_layers = Vec::new();
     // `title-block-style: plain|none` drops the title-block layer
     // (bd-gx9cic8z P6); all other built-in layers are unconditional.
     if config.title_block_layer {
         user_layers.push(load_title_block_layer()?);
     }
-    user_layers.extend([highlight_layer, embed_example_layer, copy_code_layer]);
+    user_layers.extend([
+        highlight_layer,
+        embed_example_layer,
+        copy_code_layer,
+        listing_layer,
+    ]);
     user_layers.extend(result.layers);
 
     // Assemble SCSS
@@ -197,7 +203,7 @@ pub fn compile_with_doc_vars(
     doc_vars: &crate::SassLayer,
 ) -> Result<String, SassError> {
     use crate::bundle::{
-        load_copy_code_layer, load_embed_example_layer, load_highlight_layer,
+        load_copy_code_layer, load_embed_example_layer, load_highlight_layer, load_listing_layer,
         load_title_block_layer,
     };
     use crate::themes::process_theme_specs;
@@ -226,11 +232,17 @@ pub fn compile_with_doc_vars(
     let highlight_layer = load_highlight_layer()?;
     let embed_example_layer = load_embed_example_layer()?;
     let copy_code_layer = load_copy_code_layer()?;
+    let listing_layer = load_listing_layer()?;
     let mut user_layers = Vec::new();
     if config.title_block_layer {
         user_layers.push(load_title_block_layer()?);
     }
-    user_layers.extend([highlight_layer, embed_example_layer, copy_code_layer]);
+    user_layers.extend([
+        highlight_layer,
+        embed_example_layer,
+        copy_code_layer,
+        listing_layer,
+    ]);
 
     let mut load_paths = default_load_paths();
     if config.has_themes() {
@@ -344,7 +356,7 @@ pub fn compile_default_css(
     minified: bool,
 ) -> Result<String, SassError> {
     use crate::bundle::{
-        load_copy_code_layer, load_embed_example_layer, load_highlight_layer,
+        load_copy_code_layer, load_embed_example_layer, load_highlight_layer, load_listing_layer,
         load_title_block_layer,
     };
     use quarto_system_runtime::sass_native::compile_scss_with_embedded;
@@ -360,13 +372,16 @@ pub fn compile_default_css(
     let highlight_layer = load_highlight_layer()?;
     let embed_example_layer = load_embed_example_layer()?;
     let copy_code_layer = load_copy_code_layer()?;
+    let listing_layer = load_listing_layer()?;
 
-    // Assemble SCSS: Bootstrap + Quarto + title block + highlight + embed-example defaults
+    // Assemble SCSS: Bootstrap + Quarto + title block + highlight +
+    // embed-example + copy-code + listing defaults
     let scss = assemble_with_user_layers(&[
         title_block_layer,
         highlight_layer,
         embed_example_layer,
         copy_code_layer,
+        listing_layer,
     ])?;
 
     // Get load paths and resources
@@ -478,7 +493,7 @@ pub async fn compile_with_doc_vars(
     doc_vars: &crate::SassLayer,
 ) -> Result<String, SassError> {
     use crate::bundle::{
-        load_copy_code_layer, load_embed_example_layer, load_highlight_layer,
+        load_copy_code_layer, load_embed_example_layer, load_highlight_layer, load_listing_layer,
         load_title_block_layer,
     };
     use crate::themes::process_theme_specs;
@@ -498,11 +513,17 @@ pub async fn compile_with_doc_vars(
     let highlight_layer = load_highlight_layer()?;
     let embed_example_layer = load_embed_example_layer()?;
     let copy_code_layer = load_copy_code_layer()?;
+    let listing_layer = load_listing_layer()?;
     let mut user_layers = Vec::new();
     if config.title_block_layer {
         user_layers.push(load_title_block_layer()?);
     }
-    user_layers.extend([highlight_layer, embed_example_layer, copy_code_layer]);
+    user_layers.extend([
+        highlight_layer,
+        embed_example_layer,
+        copy_code_layer,
+        listing_layer,
+    ]);
 
     let mut load_paths = default_load_paths();
     if config.has_themes() {
@@ -568,7 +589,7 @@ pub async fn compile_default_css(
     minified: bool,
 ) -> Result<String, SassError> {
     use crate::bundle::{
-        load_copy_code_layer, load_embed_example_layer, load_highlight_layer,
+        load_copy_code_layer, load_embed_example_layer, load_highlight_layer, load_listing_layer,
         load_title_block_layer,
     };
 
@@ -590,13 +611,16 @@ pub async fn compile_default_css(
     let highlight_layer = load_highlight_layer()?;
     let embed_example_layer = load_embed_example_layer()?;
     let copy_code_layer = load_copy_code_layer()?;
+    let listing_layer = load_listing_layer()?;
 
-    // Assemble SCSS: Bootstrap + Quarto + title block + highlight + embed-example defaults
+    // Assemble SCSS: Bootstrap + Quarto + title block + highlight +
+    // embed-example + copy-code + listing defaults
     let scss = assemble_with_user_layers(&[
         title_block_layer,
         highlight_layer,
         embed_example_layer,
         copy_code_layer,
+        listing_layer,
     ])?;
 
     // Get load paths (these point to VFS paths populated by wasm-quarto-hub-client)
@@ -990,6 +1014,81 @@ mod tests {
         // Should have Bootstrap classes
         assert!(css.contains(".btn"));
         assert!(css.contains(".container"));
+    }
+
+    /// Listing card/table/category styling ships as a built-in layer
+    /// (bd-57y4). Like Q1, the layer is unconditional for HTML — one
+    /// assertion per assembly path, matching the highlight/copy-code
+    /// regression pattern.
+    #[test]
+    fn test_compile_default_css_includes_listing_rules() {
+        let runtime = NativeRuntime::new();
+        let css = compile_default_css(&runtime, true).unwrap();
+        assert!(
+            css.contains(".quarto-listing"),
+            "default CSS must contain .quarto-listing rules from quarto-listing.scss"
+        );
+        assert!(
+            css.contains(".listing-category"),
+            "default CSS must contain category-chip rules"
+        );
+    }
+
+    #[test]
+    fn test_compile_theme_css_builtin_theme_includes_listing_rules() {
+        let runtime = NativeRuntime::new();
+        let themes = vec![ThemeSpec::parse("cosmo").unwrap()];
+        let config = ThemeConfig::new(themes, true);
+        let context = ThemeContext::new(PathBuf::from("/doc"), &runtime);
+
+        let css = compile_theme_css(&config, &context).unwrap();
+        assert!(
+            css.contains(".quarto-listing"),
+            "themed CSS must contain .quarto-listing rules from quarto-listing.scss"
+        );
+        assert!(
+            css.contains(".listing-pagination"),
+            "themed CSS must contain pagination rules"
+        );
+    }
+
+    /// Q1's listing SCSS carries a per-theme override map keyed on
+    /// `$theme-name` (chip borders / form colors for the dark
+    /// built-ins). `$theme-name` already flows from the vendored
+    /// bootstrap layer (`$theme: "darkly" !default` +
+    /// `_bootstrap-variables.scss`), so darkly's map entry fires and
+    /// chips get a border — which the default (border-free) path never
+    /// emits. The border color is the *bootstrap-default* gray-600
+    /// (#6c757d), not darkly's, because the listing file's
+    /// `scss:variables` block rides in the functions band ahead of the
+    /// theme's defaults — the same quirk Q1's identical parser has, so
+    /// this is parity, not a bug (see load_listing_layer docs).
+    #[test]
+    fn test_compile_theme_css_darkly_activates_listing_theme_overrides() {
+        let runtime = NativeRuntime::new();
+
+        let darkly_css = {
+            let themes = vec![ThemeSpec::parse("darkly").unwrap()];
+            let config = ThemeConfig::new(themes, false);
+            let context = ThemeContext::new(PathBuf::from("/doc"), &runtime);
+            compile_theme_css(&config, &context).unwrap()
+        };
+        assert!(
+            darkly_css.contains("border: solid #6c757d 1px"),
+            "darkly's $theme-name override must put a border on category chips"
+        );
+
+        // Control: cosmo has no map entry → no chip border emitted.
+        let cosmo_css = {
+            let themes = vec![ThemeSpec::parse("cosmo").unwrap()];
+            let config = ThemeConfig::new(themes, false);
+            let context = ThemeContext::new(PathBuf::from("/doc"), &runtime);
+            compile_theme_css(&config, &context).unwrap()
+        };
+        assert!(
+            !cosmo_css.contains("border: solid #6c757d 1px"),
+            "cosmo must not inherit darkly's chip border"
+        );
     }
 
     #[test]

--- a/resources/scss/README.md
+++ b/resources/scss/README.md
@@ -11,12 +11,14 @@ This directory contains SCSS resources used for Bootstrap/theme compilation in R
   - `_bootstrap-*.scss` - Quarto's Bootstrap customization files
 - `html/templates/` - HTML template SCSS files
   - `title-block.scss` - Title block styling
+  - `quarto-listing.scss` - Listing cards / table / category-chip styling (bd-57y4)
 
 ## Source
 
 These files are copied from:
 - `quarto-cli/src/resources/formats/html/bootstrap/` (Bootstrap and themes)
 - `quarto-cli/src/resources/formats/html/templates/` (title-block.scss)
+- `quarto-cli/src/resources/projects/website/listing/` (quarto-listing.scss)
 
 ## Updating
 
@@ -30,6 +32,7 @@ To update these files when quarto-cli updates Bootstrap or themes:
    cp -r external-sources/quarto-cli/src/resources/formats/html/bootstrap/themes resources/scss/bootstrap/
    cp external-sources/quarto-cli/src/resources/formats/html/bootstrap/_bootstrap-*.scss resources/scss/bootstrap/
    cp external-sources/quarto-cli/src/resources/formats/html/templates/title-block.scss resources/scss/html/templates/
+   cp external-sources/quarto-cli/src/resources/projects/website/listing/quarto-listing.scss resources/scss/html/templates/
    ```
 
 2. Regenerate the dart-sass fixtures:

--- a/resources/scss/html/templates/quarto-listing.scss
+++ b/resources/scss/html/templates/quarto-listing.scss
@@ -1,0 +1,642 @@
+/*-- scss:uses --*/
+@use "sass:map" as listing-map;
+
+/*-- scss:functions --*/
+@function listing-override-value($theme, $varname, $default) {
+  // These will be defined in bootstrap, but creating values here
+  // That will make this function accessible to callers prior to bootstrap variables
+  // being set
+  $black: rgb(0, 0, 0) !default;
+  $white: rgb(255, 255, 255) !default;
+  $gray-300: #dee2e6 !default;
+  $gray-500: #adb5bd !default;
+  $gray-600: #6c757d !default;
+  $blue: #0d6efd !default;
+
+  $theme-overrides: (
+    cyborg: (
+      category-border: solid $gray-500 1px,
+      category-color: $gray-500,
+      form-background-color: $body-bg,
+      form-color: $body-color,
+      input-group-border: solid $text-muted 1px,
+      input-group-border-radius: $border-radius,
+    ),
+    darkly: (
+      form-background-color: $body-bg,
+      form-color: $body-color,
+      category-border: solid $gray-600 1px,
+      category-color: $gray-600,
+    ),
+    materia: (
+      input-text-margin: 0 0.5em 0 0,
+    ),
+    quartz: (
+      category-color: $gray-300,
+      input-text-placeholder-color: $gray-500,
+    ),
+    slate: (
+      category-border: solid $gray-600 1px,
+      category-color: $gray-600,
+      form-background-color: $body-bg,
+      form-color: $body-color,
+      input-text-background-color: $body-bg,
+      input-text-color: $body-color,
+      input-group-border: solid $gray-600 1px,
+    ),
+    solar: (
+      input-group-border: solid $gray-600 1px,
+      category-color: $body-color,
+      category-border: solid $body-color 1px,
+    ),
+    superhero: (
+      input-text-background-color: $body-bg,
+      input-text-color: $body-color,
+      input-group-border: solid $gray-600 1px,
+      category-color: $gray-600,
+      category-border: solid $gray-600 1px,
+    ),
+    vapor: (
+      category-border: solid $text-muted 1px,
+      input-group-border: solid $text-muted 1px,
+    ),
+  );
+
+  $val: null;
+  @if ($theme != null) {
+    $theme-vals: listing-map.get($theme-overrides, $theme);
+    @if ($theme-vals != null) {
+      $val: listing-map.get($theme-vals, $varname);
+    }
+  }
+
+  @if ($val != null) {
+    @return $val;
+  } @else {
+    @return $default;
+  }
+}
+
+/*-- scss:variables --*/
+
+// Since we use these colors, we need to ensure that they
+// are defined (for example, if no theme is specified)
+$gray-300: #dee2e6 !default;
+$gray-500: #adb5bd !default;
+$gray-600: #6c757d !default;
+$gray-600: #6c757d !default;
+$gray-800: #343a40 !default;
+
+$card-cap-bg: rgba($gray-800, 0.25) !default;
+
+$border-color: $gray-300 !default;
+$border-radius: 0.25rem !default;
+$border-radius-sm: 0.2em !default;
+
+$text-muted: $gray-600 !default;
+
+$theme-name: null !default;
+
+/*-- scss:mixins --*/
+@mixin listing-category {
+  display: flex;
+  flex-wrap: wrap;
+  padding-bottom: 5px;
+
+  .listing-category {
+    color: listing-override-value($theme-name, "category-color", $text-muted);
+
+    $val: listing-override-value($theme-name, "category-border", null);
+    @if $val != null {
+      border: $val;
+    } @else {
+      border: solid 1px $border-color;
+    }
+
+    border-radius: $border-radius;
+    text-transform: uppercase;
+    font-size: 0.65em;
+    padding-left: 0.5em;
+    padding-right: 0.5em;
+    padding-top: 0.15em;
+    padding-bottom: 0.15em;
+    cursor: pointer;
+    margin-right: 4px;
+    margin-bottom: 4px;
+  }
+}
+
+// Provide theme level customization of the listing inputs
+@mixin input-group {
+}
+
+@mixin input-form-control {
+  $val: listing-override-value($theme-name, "form-background-color", null);
+  @if $val != null {
+    background-color: $val;
+  }
+  $val: listing-override-value($theme-name, "form-color", null);
+  @if $val != null {
+    color: $val;
+  }
+}
+
+@mixin input-group-text {
+  $val: listing-override-value($theme-name, "input-group-border-radius", null);
+  @if $val != null {
+    border-radius: $val;
+  }
+
+  $val: listing-override-value($theme-name, "input-group-border", null);
+  @if $val != null {
+    border: $val;
+  }
+
+  $val: listing-override-value($theme-name, "input-text-margin", null);
+  @if $val != null {
+    margin: $val;
+  }
+  $val: listing-override-value(
+    $theme-name,
+    "input-text-background-color",
+    null
+  );
+  @if $val != null {
+    background-color: $val;
+  }
+  $val: listing-override-value($theme-name, "input-text-color", null);
+  @if $val != null {
+    color: $val;
+  }
+}
+
+@mixin input-placeholder {
+  $val: listing-override-value(
+    $theme-name,
+    "input-text-placeholder-color",
+    null
+  );
+  @if $val != null {
+    ::placeholder {
+      color: $val;
+    }
+  }
+}
+
+/*-- scss:rules --*/
+
+.quarto-listing {
+  padding-bottom: 1em;
+}
+
+// General Pagination / Filter Control Styling
+.listing-pagination {
+  padding-top: 0.5em;
+}
+
+ul.pagination {
+  float: right;
+  padding-left: 8px;
+  padding-top: 0.5em;
+  li {
+    padding-right: 0.75em;
+  }
+  li.disabled,
+  li.active {
+    a {
+      color: $pagination-active-color;
+      text-decoration: none;
+    }
+  }
+  li:last-of-type {
+    padding-right: 0;
+  }
+}
+
+.listing-actions-group {
+  display: flex;
+  .form-select,
+  .form-control {
+    @include input-form-control();
+  }
+  .input-group {
+    @include input-group();
+    @include input-placeholder();
+  }
+}
+
+// Filtering and Sorting
+.quarto-listing-filter {
+  margin-bottom: 1em;
+  width: 200px;
+  margin-left: auto;
+}
+
+.quarto-listing-sort {
+  margin-bottom: 1em;
+  margin-right: auto;
+  .input-group-text {
+    font-size: 0.8em;
+  }
+  width: auto;
+}
+
+.input-group input,
+.input-group select {
+  @include input-group-text();
+}
+.input-group-text {
+  @include input-group-text();
+  border-right: none;
+}
+
+.quarto-listing-sort select.form-select {
+  font-size: 0.8em;
+}
+
+.listing-no-matching {
+  text-align: center;
+  padding-top: 2em;
+  padding-bottom: 3em;
+  font-size: 1em;
+}
+
+// Category styling
+#quarto-margin-sidebar {
+  .quarto-listing-category {
+    padding-top: 0;
+    font-size: 1rem;
+  }
+  .quarto-listing-category-title {
+    cursor: pointer;
+    font-weight: 600;
+    font-size: 1rem;
+  }
+}
+
+.quarto-listing-category {
+  .category {
+    cursor: pointer;
+  }
+  .category.active {
+    font-weight: 600;
+  }
+}
+
+.quarto-listing-category.category-cloud {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  .category {
+    padding-right: 5px;
+  }
+
+  @for $count from 1 through 10 {
+    .category-cloud-#{$count} {
+      font-size: 0.55em + ($count * 0.2em);
+    }
+  }
+}
+
+// Grid Listing Styling
+@for $colcount from 1 through 12 {
+  .quarto-listing-cols-#{$colcount} {
+    grid-template-columns: repeat($colcount, minmax(0, 1fr));
+    gap: 1.5em;
+  }
+
+  @include media-breakpoint-down(md) {
+    .quarto-listing-cols-#{$colcount} {
+      grid-template-columns: repeat(min(2, $colcount), minmax(0, 1fr));
+      gap: 1.5em;
+    }
+  }
+
+  @include media-breakpoint-down(sm) {
+    .quarto-listing-cols-#{$colcount} {
+      grid-template-columns: minmax(0, 1fr);
+      gap: 1.5em;
+    }
+  }
+}
+
+.quarto-listing-grid {
+  gap: 1.5em;
+}
+
+.quarto-grid-item.borderless {
+  border: none;
+  .listing-categories {
+    .listing-category:last-of-type,
+    .listing-category:first-of-type {
+      padding-left: 0;
+    }
+    .listing-category {
+      border: 0;
+    }
+  }
+}
+
+.quarto-grid-link {
+  text-decoration: none;
+  color: inherit;
+}
+
+.quarto-grid-link:hover {
+  text-decoration: none;
+  color: inherit;
+}
+
+.quarto-grid-item {
+  h5.title {
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+
+  .card-footer {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.8em;
+    p {
+      margin-bottom: 0;
+    }
+  }
+
+  p.card-img-top {
+    margin-bottom: 0;
+    > img {
+      object-fit: cover;
+    }
+  }
+
+  .card-other-values {
+    margin-top: 0.5em;
+    font-size: 0.8em;
+    tr {
+      margin-bottom: 0.5em;
+    }
+    tr > td:first-of-type {
+      font-weight: 600;
+      padding-right: 1em;
+      padding-left: 1em;
+      vertical-align: top;
+    }
+  }
+
+  div.post-contents {
+    display: flex;
+    flex-direction: column;
+    text-decoration: none;
+    height: 100%;
+  }
+
+  .listing-item-img-placeholder {
+    background-color: $card-cap-bg;
+    flex-shrink: 0;
+  }
+
+  .card-attribution {
+    padding-top: 1em;
+    display: flex;
+    gap: 1em;
+    text-transform: uppercase;
+    color: $text-muted;
+    font-weight: 500;
+    flex-grow: 10;
+    align-items: flex-end;
+  }
+
+  .description {
+    padding-bottom: 1em;
+  }
+
+  .card-attribution .date {
+    align-self: flex-end;
+  }
+
+  .card-attribution.justify {
+    justify-content: space-between;
+  }
+
+  .card-attribution.start {
+    justify-content: flex-start;
+  }
+
+  .card-attribution.end {
+    justify-content: flex-end;
+  }
+
+  .card-title {
+    margin-bottom: 0.1em;
+  }
+  .card-subtitle {
+    padding-top: 0.25em;
+  }
+
+  .card-text {
+    font-size: 0.9em;
+  }
+
+  .listing-reading-time {
+    padding-bottom: 0.25em;
+  }
+
+  .card-text-small {
+    font-size: 0.8em;
+  }
+
+  .card-subtitle.subtitle {
+    font-size: 0.9em;
+    font-weight: 600;
+    padding-bottom: 0.5em;
+  }
+
+  .listing-categories {
+    @include listing-category();
+  }
+}
+
+.quarto-grid-item.card-right {
+  text-align: right;
+  .listing-categories {
+    justify-content: flex-end;
+  }
+}
+
+.quarto-grid-item.card-left {
+  text-align: left;
+}
+
+.quarto-grid-item.card-center {
+  text-align: center;
+  .listing-description {
+    text-align: justify;
+  }
+  .listing-categories {
+    justify-content: center;
+  }
+}
+
+// Table Listing Styling
+table.quarto-listing-table {
+  td.image {
+    padding: 0px;
+    img {
+      width: 100%;
+      max-width: 50px;
+      object-fit: contain;
+    }
+  }
+
+  a {
+    text-decoration: none;
+    word-break: keep-all;
+  }
+
+  th a {
+    color: inherit;
+  }
+
+  th a.asc:after {
+    margin-bottom: -2px;
+    margin-left: 5px;
+    display: inline-block;
+    height: 1rem;
+    width: 1rem;
+    background-repeat: no-repeat;
+    background-size: 1rem 1rem;
+    background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-sort-up" viewBox="0 0 16 16"><path d="M3.5 12.5a.5.5 0 0 1-1 0V3.707L1.354 4.854a.5.5 0 1 1-.708-.708l2-1.999.007-.007a.498.498 0 0 1 .7.006l2 2a.5.5 0 1 1-.707.708L3.5 3.707V12.5zm3.5-9a.5.5 0 0 1 .5-.5h7a.5.5 0 0 1 0 1h-7a.5.5 0 0 1-.5-.5zM7.5 6a.5.5 0 0 0 0 1h5a.5.5 0 0 0 0-1h-5zm0 3a.5.5 0 0 0 0 1h3a.5.5 0 0 0 0-1h-3zm0 3a.5.5 0 0 0 0 1h1a.5.5 0 0 0 0-1h-1z"/></svg>');
+    content: "";
+  }
+
+  th a.desc:after {
+    margin-bottom: -2px;
+    margin-left: 5px;
+    display: inline-block;
+    height: 1rem;
+    width: 1rem;
+    background-repeat: no-repeat;
+    background-size: 1rem 1rem;
+    background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-sort-down" viewBox="0 0 16 16"><path d="M3.5 2.5a.5.5 0 0 0-1 0v8.793l-1.146-1.147a.5.5 0 0 0-.708.708l2 1.999.007.007a.497.497 0 0 0 .7-.006l2-2a.5.5 0 0 0-.707-.708L3.5 11.293V2.5zm3.5 1a.5.5 0 0 1 .5-.5h7a.5.5 0 0 1 0 1h-7a.5.5 0 0 1-.5-.5zM7.5 6a.5.5 0 0 0 0 1h5a.5.5 0 0 0 0-1h-5zm0 3a.5.5 0 0 0 0 1h3a.5.5 0 0 0 0-1h-3zm0 3a.5.5 0 0 0 0 1h1a.5.5 0 0 0 0-1h-1z"/></svg>');
+    content: "";
+  }
+}
+
+table.quarto-listing-table.table-hover td {
+  cursor: pointer;
+}
+
+.quarto-post.image-left {
+  flex-direction: row;
+}
+
+.quarto-post.image-right {
+  flex-direction: row-reverse;
+}
+
+@include media-breakpoint-down(md) {
+  .quarto-post.image-right,
+  .quarto-post.image-left {
+    gap: 0em;
+    flex-direction: column;
+  }
+
+  .quarto-post .metadata {
+    padding-bottom: 1em;
+    order: 2;
+  }
+
+  .quarto-post .body {
+    order: 1;
+  }
+
+  .quarto-post .thumbnail {
+    order: 3;
+  }
+}
+
+// Post (default) Styling
+.list.quarto-listing-default div:last-of-type {
+  border-bottom: none;
+}
+
+.quarto-listing-container-default {
+  @include media-breakpoint-up(lg) {
+    margin-right: 2em;
+  }
+}
+
+div.quarto-post {
+  display: flex;
+  gap: 2em;
+  margin-bottom: 1.5em;
+  @include media-breakpoint-down(md) {
+    padding-bottom: 1em;
+  }
+  border-bottom: 1px solid $border-color;
+
+  .metadata {
+    flex-basis: 20%;
+    flex-grow: 0;
+    margin-top: 0.2em;
+    flex-shrink: 10;
+  }
+
+  .thumbnail {
+    flex-basis: 30%;
+    flex-grow: 0;
+    flex-shrink: 0;
+    img {
+      margin-top: 0.4em;
+      width: 100%;
+      object-fit: cover;
+    }
+  }
+
+  .body {
+    flex-basis: 45%;
+    flex-grow: 1;
+    flex-shrink: 0;
+
+    h3.listing-title {
+      margin-top: 0px;
+      margin-bottom: 0px;
+      border-bottom: none;
+    }
+
+    .listing-subtitle {
+      font-size: 0.875em;
+      margin-bottom: 0.5em;
+      margin-top: 0.2em;
+    }
+
+    .description {
+      font-size: 0.9em;
+    }
+
+    pre code {
+      white-space: pre-wrap;
+    }
+  }
+
+  a {
+    color: $body-color;
+    text-decoration: none;
+  }
+
+  .metadata {
+    display: flex;
+    flex-direction: column;
+    font-size: 0.8em;
+    font-family: $font-family-base;
+    flex-basis: 33%;
+  }
+
+  .listing-categories {
+    @include listing-category();
+  }
+
+  .listing-description {
+    margin-bottom: 0.5em;
+  }
+}


### PR DESCRIPTION
Implements **bd-57y4**: Q2 shipped the listing JS pair (`list.min.js` + `quarto-listing.js`) but never compiled Q1's `quarto-listing.scss`, so listing cards, table listings, category chips, and the categories sidebar rendered with default browser styling. This vendors the file verbatim to `resources/scss/html/templates/quarto-listing.scss` and composes it as a built-in `SassLayer` (`load_listing_layer`) at every HTML assembly site — native and WASM, themed and default paths; not reveal.

Plan + rationale: `claude-notes/plans/2026-07-29-listing-scss.md`.

## Design notes

- **Unconditional, like Q1** (deviating from the strand's "when a listing is rendered" sketch): Q1's `listingSassBundle()` gates only on the format having Bootstrap, not on `pageHasListings`; on our side the theme-CSS stage runs before listing resolution, and a conditional layer would fork a website's theme CSS into two fingerprinted files. Cost is a few KB on non-listing pages — the same trade Q1 makes.
- **`$theme-name` overrides came for free** — the vendored bootstrap layer already defines `$theme`/`$theme-name`, so the per-dark-theme chip styling (darkly/slate/cyborg/…) activates with no new code; a darkly-vs-cosmo test pins it, including the Q1-parity band quirk (the file's invalid `scss:variables` marker rides in the functions band, identical in Q1's parser — kept verbatim on purpose).

## Tests

- 3 new `quarto-sass` unit tests (default path, themed path, darkly override + cosmo control), mirroring the highlight/copy-code regression pattern.
- `brand_render`-shaped e2e: rendered site's CSS contains the listing rules.
- Preview/render CSS-parity guards stay green (unconditional layer moves fingerprints uniformly in both pipelines).
- Phase-5 single-doc byte-identity baseline: `styles.css` hash re-captured per its documented procedure (`doc.html` unchanged — no listing selector matches a single-doc body).
- Workspace 10794/10794; full `cargo xtask verify` green (pre-rebase; rebase onto post-#434 main touched no overlapping files).

e2e verified against the #434 blog scaffold: `q2 create project blog` → `q2 render` → theme CSS carries the card layout (`div.quarto-post .thumbnail{flex-basis:30%…}`), linked from the listing page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)