### PR TITLE
Comments v1

### DIFF
--- a/hub-client/q2-preview.html
+++ b/hub-client/q2-preview.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -12,11 +13,6 @@
       margin: 0;
       padding: 0;
     }
-    #root {
-      width: 100%;
-      height: 100vh;
-      overflow: auto;
-    }
   </style>
   <script>
     // Stub out React Fast Refresh runtime for iframe context
@@ -25,8 +21,10 @@
     window.$RefreshSig$ = function () { return function (type) { return type; }; };
   </script>
 </head>
+
 <body>
   <div id="root">Loading q2-preview renderer...</div>
   <script type="module" src="/src/components/render/q2-preview/entry.tsx"></script>
 </body>
+
 </html>

--- a/hub-client/src/components/Editor.tsx
+++ b/hub-client/src/components/Editor.tsx
@@ -256,6 +256,10 @@ export default function Editor({ project, files, fileContents, onDisconnect, onC
   // than a setting: resets on reload so a previously-curious view
   // doesn't bleed into the next session.
   const [attributionOn, setAttributionOn] = useState(false);
+  // Comment-bubble display mode (session-only, like attribution):
+  // three-way toggle in the replay bar, threaded into the q2-preview
+  // iframe where CommentBlock consumes it.
+  const [commentsMode, setCommentsMode] = useState<'expand' | 'show' | 'hide'>('show');
   // `useAttribution` (inside ReactPreview) reports whether it's
   // mid-build via `onAttributionGeneratingChange`; the flag drives
   // the rotating-gradient border on the Attribution pill so a slow
@@ -1137,6 +1141,7 @@ export default function Editor({ project, files, fileContents, onDisconnect, onC
             identities={identities}
             captures={captures}
             attributionOn={attributionOn}
+            commentsMode={commentsMode}
             onAttributionGeneratingChange={setAttributionGenerating}
           />
         </div>
@@ -1151,6 +1156,8 @@ export default function Editor({ project, files, fileContents, onDisconnect, onC
           identities={identities}
           attributionOn={attributionOn}
           onAttributionChange={setAttributionOn}
+          commentsMode={commentsMode}
+          onCommentsModeChange={setCommentsMode}
           attributionGenerating={attributionGenerating}
           attributionDisabled={
             currentFormat !== 'q2-debug' && currentFormat !== 'q2-preview'

--- a/hub-client/src/components/ReplayDrawer.tsx
+++ b/hub-client/src/components/ReplayDrawer.tsx
@@ -4,6 +4,7 @@ import { actorColor } from '../utils/palette';
 import type { ActorIdentity } from '@quarto/preview-runtime';
 import { getActorId } from '@quarto/preview-runtime';
 import './ReplayDrawer.css';
+import './ViewToggleControl.css';
 
 interface Props {
   state: ReplayState;
@@ -39,6 +40,86 @@ interface Props {
    * to a supported format restores the user's previous preference.
    */
   attributionDisabled?: boolean;
+  /**
+   * Comment-bubble display mode (three-way toggle rendered beside the
+   * Authors pill): 'expand' pins every comment popup open, 'show' is
+   * the default hover/click chrome, 'hide' removes the bubbles. Both
+   * props must be supplied to render the toggle. Session-only, like
+   * the attribution toggle.
+   */
+  commentsMode?: CommentsMode;
+  onCommentsModeChange?: (next: CommentsMode) => void;
+}
+
+type CommentsMode = 'expand' | 'show' | 'hide';
+
+/**
+ * Three small square buttons in the `view-toggle-btn` style (same CSS
+ * as the header's layout toggle): expand all comments / show bubbles /
+ * hide bubbles.
+ */
+function CommentsModeToggle({
+  mode,
+  onChange,
+}: {
+  mode: CommentsMode;
+  onChange: (next: CommentsMode) => void;
+}) {
+  // Speech-bubble outline shared by the show/hide icons; the expand
+  // icon is the same bubble with a taller body.
+  const bubblePath =
+    'M1 0 h10 a1 1 0 0 1 1 1 v5 a1 1 0 0 1 -1 1 H5 L2 10 V7 H1 a1 1 0 0 1 -1 -1 V1 a1 1 0 0 1 1 -1 Z';
+  const tallBubblePath =
+    'M1 0 h10 a1 1 0 0 1 1 1 v6 a1 1 0 0 1 -1 1 H5 L2 10 V8 H1 a1 1 0 0 1 -1 -1 V1 a1 1 0 0 1 1 -1 Z';
+  return (
+    <div
+      className="view-toggle-control"
+      role="group"
+      aria-label="Comment display mode"
+      style={{ marginLeft: '6px' }}
+    >
+      <button
+        className={`view-toggle-btn${mode === 'expand' ? ' active' : ''}`}
+        onClick={(e) => {
+          e.stopPropagation();
+          onChange('expand');
+        }}
+        title="Expand all comments"
+        aria-label="Expand comments"
+      >
+        <svg width="12" height="10" viewBox="0 0 12 10">
+          <path d={tallBubblePath} fill="currentColor" />
+        </svg>
+      </button>
+      <button
+        className={`view-toggle-btn${mode === 'show' ? ' active' : ''}`}
+        onClick={(e) => {
+          e.stopPropagation();
+          onChange('show');
+        }}
+        title="Show comment bubbles"
+        aria-label="Show comments"
+      >
+        <svg width="12" height="10" viewBox="0 0 12 10">
+          <path d={bubblePath} fill="currentColor" />
+        </svg>
+      </button>
+      <button
+        className={`view-toggle-btn${mode === 'hide' ? ' active' : ''}`}
+        onClick={(e) => {
+          e.stopPropagation();
+          onChange('hide');
+        }}
+        title="Hide comment bubbles"
+        aria-label="Hide comments"
+      >
+        <svg width="12" height="10" viewBox="0 0 12 10">
+          <path d={bubblePath} fill="currentColor" opacity="0.25" />
+          <line x1="1" y1="9" x2="11" y2="1" stroke="currentColor" strokeWidth="1.5" />
+        </svg>
+      </button>
+    </div>
+  );
 }
 
 interface AttributionToggleProps {
@@ -120,9 +201,13 @@ export default function ReplayDrawer({
   onAttributionChange,
   attributionGenerating,
   attributionDisabled,
+  commentsMode,
+  onCommentsModeChange,
 }: Props) {
   const showAttributionToggle =
     attributionOn !== undefined && onAttributionChange !== undefined;
+  const showCommentsToggle =
+    commentsMode !== undefined && onCommentsModeChange !== undefined;
   const currentActorId = getActorId();
   const drawerRef = useRef<HTMLDivElement>(null);
 
@@ -234,6 +319,9 @@ export default function ReplayDrawer({
             disabled={!!attributionDisabled}
           />
         )}
+        {showCommentsToggle && (
+          <CommentsModeToggle mode={commentsMode!} onChange={onCommentsModeChange!} />
+        )}
       </div>
     );
   }
@@ -296,6 +384,9 @@ export default function ReplayDrawer({
             generating={!!attributionGenerating}
             disabled={!!attributionDisabled}
           />
+        )}
+        {showCommentsToggle && (
+          <CommentsModeToggle mode={commentsMode!} onChange={onCommentsModeChange!} />
         )}
       </div>
 

--- a/hub-client/src/components/render/PreviewRouter.tsx
+++ b/hub-client/src/components/render/PreviewRouter.tsx
@@ -52,6 +52,12 @@ interface PreviewRouterProps {
    */
   attributionOn: boolean;
   /**
+   * Comment-bubble display mode (expand / show / hide). Session-only —
+   * owned by `Editor.tsx`, threaded into `ReactPreview` (the non-React
+   * `Preview` branch has no comment chrome).
+   */
+  commentsMode?: 'expand' | 'show' | 'hide';
+  /**
    * Reports `useAttribution`'s in-flight state up to `Editor.tsx` so
    * the Attribution pill can animate its border while attribution
    * data is being generated. Only fires from the ReactPreview branch;
@@ -145,7 +151,7 @@ export default function PreviewRouter(props: PreviewRouterProps) {
   // Render the appropriate preview component with shared WASM error banner.
   // `identities` and `attributionOn` are for ReactPreview only — Preview
   // doesn't know about either.
-  const { onRegisterScrollToLine, onRegisterSetScrollRatio, onRegisterReplayScroll, onFormatChange, onContentRewrite, fileContents, identities, captures, attributionOn, onAttributionGeneratingChange, ...commonProps } = props;
+  const { onRegisterScrollToLine, onRegisterSetScrollRatio, onRegisterReplayScroll, onFormatChange, onContentRewrite, fileContents, identities, captures, attributionOn, commentsMode, onAttributionGeneratingChange, ...commonProps } = props;
 
   return (
     <div style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
@@ -155,7 +161,7 @@ export default function PreviewRouter(props: PreviewRouterProps) {
       )}
       <div style={{ flex: 1, overflow: 'hidden' }}>
         {reactFormat ? (
-          <ReactPreview {...commonProps} onContentRewrite={onContentRewrite} fileContents={fileContents} format={reactFormat} identities={identities} captures={captures} attributionOn={attributionOn} onAttributionGeneratingChange={onAttributionGeneratingChange} onRegisterReplayScroll={onRegisterReplayScroll} />
+          <ReactPreview {...commonProps} onContentRewrite={onContentRewrite} fileContents={fileContents} format={reactFormat} identities={identities} captures={captures} attributionOn={attributionOn} commentsMode={commentsMode} onAttributionGeneratingChange={onAttributionGeneratingChange} onRegisterReplayScroll={onRegisterReplayScroll} />
         ) : (
           // Phase 9 Decision 6: pass `fileContents` so any sibling
           // edit (including `_quarto.yml`) triggers a re-render via

--- a/hub-client/src/components/render/ReactPreview.tsx
+++ b/hub-client/src/components/render/ReactPreview.tsx
@@ -169,6 +169,22 @@ type RenderResult = {
   diagnostics: Diagnostic[];
 }
 
+/**
+ * True when a format renders AND edits through the q2-preview
+ * pipeline. `format: revealjs` converged onto the shared q2-preview
+ * iframe (bd-vwp4y5ku) but is not in `pipelineKindForFormat`'s
+ * Rust-mirrored table — it reaches the preview pipeline via the
+ * `revealjs → q2-slides` pseudo-format substitution instead. Both the
+ * render dispatch (doRender) and the edit-back dispatch (handleSetAst)
+ * must use THIS predicate: gating only the render side left deck
+ * commits falling into the whole-AST `incrementalWriteQmd` branch,
+ * which rejects PreviewNodeEditPayloads ("Missing required field:
+ * meta").
+ */
+function usesPreviewPipeline(format: string): boolean {
+  return format === 'revealjs' || pipelineKindForFormat(format) === 'preview';
+}
+
 // Render QMD content to AST JSON for the iframe-based preview.
 //
 // Dispatches on `pipelineKindForFormat(format)`:
@@ -227,7 +243,7 @@ async function doRender(
   // reveal's stock `white.css` (uppercase headings, centered content).
   const isSlidesPreview = options.format === 'revealjs';
 
-  if (isSlidesPreview || pipelineKindForFormat(options.format) === 'preview') {
+  if (usesPreviewPipeline(options.format)) {
     if (!options.documentPath) {
       return {
         success: false,
@@ -766,7 +782,7 @@ export default function ReactPreview({
   // and calls incrementalWriteQmd as before.
   const handleSetAst = useCallback(
     (newAst: any) => {
-      if (pipelineKindForFormat(format) === 'preview') {
+      if (usesPreviewPipeline(format)) {
         const edit = newAst as PreviewNodeEditPayload;
         if (!edit.__isPreviewNodeEdit) {
           console.warn(

--- a/hub-client/src/components/render/ReactPreview.tsx
+++ b/hub-client/src/components/render/ReactPreview.tsx
@@ -127,6 +127,12 @@ interface PreviewProps {
    */
   attributionOn: boolean;
   /**
+   * Comment-bubble display mode (three-way toggle in the replay bar:
+   * expand / show / hide). Forwarded into the q2-preview iframe.
+   * Absent ⇒ 'show'.
+   */
+  commentsMode?: 'expand' | 'show' | 'hide';
+  /**
    * Reports whether `useAttribution` is mid-build. The Attribution
    * pill animates its border while true so a long run-list build on
    * a large document gives visible feedback that work is happening.
@@ -446,6 +452,7 @@ export default function ReactPreview({
   identities,
   captures,
   attributionOn,
+  commentsMode,
   onAttributionGeneratingChange,
 }: PreviewProps) {
   // Preview state machine for error handling
@@ -843,6 +850,7 @@ export default function ReactPreview({
             renderedContent={rendered.renderedContent}
             untransformedAstJson={rendered.untransformedAstJson}
             currentActor={getActorId()}
+            commentsMode={commentsMode}
             unlockNestingCursor={unlockNestingCursor}
             richText={richText}
             nestedEditBuffers={nestedEditBuffers}

--- a/hub-client/src/components/render/ReactRenderer.tsx
+++ b/hub-client/src/components/render/ReactRenderer.tsx
@@ -107,6 +107,11 @@ interface ReactRendererProps {
    */
   currentActor?: string | null;
   /**
+   * Comment-bubble display mode (expand / show / hide), forwarded to
+   * `Q2PreviewIframe` only.
+   */
+  commentsMode?: 'expand' | 'show' | 'hide';
+  /**
    * P3.2: nesting-cursor mode for nested blocks. Forwarded to
    * `Q2PreviewIframe` only (q2-debug/slides don't support it).
    */
@@ -154,6 +159,7 @@ function ReactRenderer({
   renderedContent,
   untransformedAstJson,
   currentActor,
+  commentsMode,
   unlockNestingCursor,
   richText,
   nestedEditBuffers,
@@ -320,6 +326,7 @@ function ReactRenderer({
             renderedContent={renderedContent}
             untransformedAstJson={untransformedAstJson}
             currentActor={currentActor}
+            commentsMode={commentsMode}
             unlockNestingCursor={unlockNestingCursor}
             richText={richText}
             nestedEditBuffers={nestedEditBuffers}

--- a/ts-packages/preview-renderer/src/iframe/Q2PreviewIframe.tsx
+++ b/ts-packages/preview-renderer/src/iframe/Q2PreviewIframe.tsx
@@ -94,6 +94,11 @@ interface Q2PreviewIframeProps {
    */
   editingDisabled?: boolean;
   /**
+   * Comment-bubble display mode (host three-way toggle: expand / show /
+   * hide). Forwarded unchanged in the UPDATE_AST payload. Absent ⇒ 'show'.
+   */
+  commentsMode?: 'expand' | 'show' | 'hide';
+  /**
    * P3.2: nesting-cursor mode for nested blocks. When true, the iframe's
    * PreviewContext exposes nesting-cursor behaviour. Default-off
    * (undefined/false). Forwarded unchanged in the UPDATE_AST payload.
@@ -173,6 +178,7 @@ export function Q2PreviewIframe({
   untransformedAstJson,
   currentActor,
   editingDisabled,
+  commentsMode,
   unlockNestingCursor,
   richText,
   nestedEditBuffers,
@@ -369,6 +375,8 @@ export function Q2PreviewIframe({
           currentActor,
           // bd-ov4gqk3m: read-only hosts disable the edit surface.
           editingDisabled,
+          // Comment-bubble mode (expand / show / hide).
+          commentsMode,
           // P3.2: nesting-cursor mode + per-key nested buffers.
           unlockNestingCursor,
           // Phase 1a (bd-sjb4pzx8): opt-in rich-text editor.
@@ -390,6 +398,7 @@ export function Q2PreviewIframe({
     untransformedAstJson,
     currentActor,
     editingDisabled,
+    commentsMode,
     unlockNestingCursor,
     richText,
     nestedEditBuffers,

--- a/ts-packages/preview-renderer/src/q2-preview/PreviewContext.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/PreviewContext.tsx
@@ -28,6 +28,9 @@ import type { PendingOpenSelection } from './dragSelectionCapture';
 
 export type { ReachabilityClass, SourceIndexEntry, ResolvedSource };
 
+/** Comment-bubble display mode (host three-way toggle). */
+export type CommentsMode = 'expand' | 'show' | 'hide';
+
 export interface PreviewContextValue {
     currentFilePath: string;
     /** Source-info pool from the rendered AST — `astContext.p` array. */
@@ -174,6 +177,13 @@ export interface PreviewContextValue {
      * `q2 preview` without `--allow-edit`. Absent/false ⇒ editable.
      */
     editingDisabled?: boolean;
+    /**
+     * Comment-bubble display mode (three-way toggle in the host UI):
+     * 'expand' pins every commented block's popup open, 'show' is the
+     * default hover/click chrome, 'hide' renders no comment chrome at
+     * all. Absent ⇒ 'show'.
+     */
+    commentsMode?: CommentsMode;
     /**
      * P3.2: nesting-cursor mode for nested blocks. When true, nested
      * list/quote blocks are each separately editable (nesting cursor).

--- a/ts-packages/preview-renderer/src/q2-preview/PreviewRoot.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/PreviewRoot.tsx
@@ -1497,9 +1497,13 @@ export function PreviewRoot(props: PreviewRootProps) {
     };
 
     // commitSubtreeEdit: send a subtree-channel PreviewNodeEditPayload (Plan 2b).
+    // The replacer strips every pool-index-carrying key: `s` (node
+    // SourceInfo), `a` (AttrSourceInfo), and `targetS` (Link/Image
+    // URL+title source refs — missing it caused InvalidSourceInfoRef
+    // on any subtree containing a link).
     const commitSubtreeEdit = (destinationSourceInfoJson: string, modifiedBlock: BlockNode) => {
         const stripped = JSON.parse(JSON.stringify(modifiedBlock, (key, value) =>
-            key === 's' || key === 'a' ? undefined : value,
+            key === 's' || key === 'a' || key === 'targetS' ? undefined : value,
         )) as BlockNode;
         const wrappedDoc = {
             'pandoc-api-version': [1, 23, 0],

--- a/ts-packages/preview-renderer/src/q2-preview/PreviewRoot.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/PreviewRoot.tsx
@@ -19,6 +19,7 @@ import type { FormatRegistry, NoteInline, PandocAST } from '../framework';
 import type { BlockNode } from '../framework/types';
 import type { PreviewNodeEditPayload } from '../types/diagnostic';
 import { previewRegistry, PreviewContext } from '.';
+import type { CommentsMode } from './PreviewContext';
 import { buildSourceIndex, serializeSourceEntry } from './sourceIndex';
 import type { ResolvedSource } from './sourceIndex';
 import { outerBlockForAnchorR0, refocusTargetForAnchorR0, findReanchorCandidate, enumerateOuterBlocks, captureEditTarget, measureBlockBox, seedForRange, snapshotOuterBlockGeometry, isDirty } from './outerBlocks';
@@ -155,6 +156,8 @@ export interface PreviewRootProps {
     untransformedAstJson?: string | null;
     /** Globally disable the edit surface (bd-ov4gqk3m). */
     editingDisabled?: boolean;
+    /** Comment-bubble display mode ('expand' | 'show' | 'hide'). */
+    commentsMode?: CommentsMode;
     /**
      * P3.2: nesting-cursor mode for nested blocks. When true, the context
      * exposes nesting-cursor behaviour. Default-off (undefined/false).
@@ -1538,6 +1541,7 @@ export function PreviewRoot(props: PreviewRootProps) {
                 sourceIndex,
                 resolveSource,
                 editingDisabled: props.editingDisabled,
+                commentsMode: props.commentsMode,
                 unlockNestingCursor: props.unlockNestingCursor,
                 unlockNestingCursorRef,
                 richText: props.richText,

--- a/ts-packages/preview-renderer/src/q2-preview/RevealDeck.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/RevealDeck.tsx
@@ -17,7 +17,7 @@
  * See claude-notes/plans/2026-06-08-revealjs-presentations.md (Phase 1P).
  */
 
-import React, { useContext, useEffect } from 'react';
+import React, { useContext, useEffect, useLayoutEffect } from 'react';
 import { Deck, Slide, Stack, useReveal } from '@revealjs/react';
 // Reveal CSS from the SAME vendored copy `q2 render` links — `resources/
 // revealjs/` — in the SAME cascade order, so render and preview cannot disagree
@@ -311,7 +311,70 @@ export function RevealNavSync(props: {
     return null;
 }
 
+/**
+ * Broadcasts reveal's slide scale to interested chrome (the comment
+ * bubbles counter-scale themselves with it). Published as a window
+ * CustomEvent to avoid coupling; fires once the deck is ready and on
+ * every reveal re-layout (viewport resize), and resets to 1 when the
+ * deck unmounts. Renders null; must sit inside `<Deck>` so
+ * `useReveal()` resolves.
+ */
+function RevealScaleSync() {
+    const reveal = useReveal();
+    useEffect(() => {
+        if (!reveal) return;
+        const api = reveal as unknown as {
+            getScale?: () => number;
+            on?: (type: string, cb: () => void) => void;
+            off?: (type: string, cb: () => void) => void;
+        };
+        const publish = () => {
+            window.dispatchEvent(
+                new CustomEvent('q2-reveal-scale', { detail: api.getScale?.() ?? 1 }),
+            );
+        };
+        publish();
+        api.on?.('ready', publish);
+        api.on?.('resize', publish);
+        // Slide changes re-publish too: hidden sections never
+        // mount/unmount bubbles, so this is what tells the bubble
+        // layout to re-solve for the newly visible slide.
+        api.on?.('slidechanged', publish);
+        // Reveal also moves content at times we can't hook exhaustively
+        // (fragments, async embeds, late layout settling) — while a
+        // deck is live, republish on a slow tick so bubbles are
+        // continuously re-positioned. Each publish triggers a bubble
+        // reset-solve, which is a no-op (no re-renders) once settled.
+        const tick = window.setInterval(publish, 250);
+        return () => {
+            window.clearInterval(tick);
+            api.off?.('ready', publish);
+            api.off?.('resize', publish);
+            api.off?.('slidechanged', publish);
+            window.dispatchEvent(new CustomEvent('q2-reveal-scale', { detail: 1 }));
+        };
+    }, [reveal]);
+    return null;
+}
+
 export function RevealDeck(props: RevealDeckProps) {
+    // Reveal sizes the deck from its container, so #root needs an
+    // explicit height while a deck is mounted. The iframe HTML doesn't
+    // style #root (a fixed 100vh there broke normal HTML pages), so
+    // apply it here, scoped to the deck's lifetime.
+    useLayoutEffect(() => {
+        const root = document.getElementById('root');
+        if (!root) return;
+        root.style.width = '100%';
+        root.style.height = '100vh';
+        root.style.overflow = 'auto';
+        return () => {
+            root.style.width = '';
+            root.style.height = '';
+            root.style.overflow = '';
+        };
+    }, []);
+
     const chrome = revealChromeFromMeta(props.ast.meta);
     const slides = props.ast.blocks.map((block, i) => {
         if (isSectionDiv(block)) {
@@ -367,6 +430,8 @@ export function RevealDeck(props: RevealDeckProps) {
                         registerSlideNavigator={props.registerSlideNavigator}
                         onSlideChange={props.onSlideChange}
                     />
+                    {/* Publishes the slide scale for the comment bubbles. */}
+                    <RevealScaleSync />
                 </Deck>
             </IncrementalContext.Provider>
         </RegistryContext.Provider>

--- a/ts-packages/preview-renderer/src/q2-preview/custom/CommentBlock.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/custom/CommentBlock.tsx
@@ -1,0 +1,782 @@
+/**
+ * Default comment chrome for q2-preview blocks. Promoted from the
+ * render-components-comment playwright fixture
+ * (`crates/quarto/tests/playwright-fixtures/q2-preview/render-components-comment/comment.tsx`)
+ * so every preview gets it without a user render-components file.
+ *
+ * Extracts `quarto-edit-comment` spans out of a Para/Header's inlines
+ * before rendering and shows them as corner chrome: a comment-count
+ * button opening a list with per-comment "Resolve" (delete) and an
+ * add-comment input. The chrome only appears while hovering the block,
+ * unless the block already has comments. Adds/resolves round-trip
+ * through `usePreviewEdit().commitSubtreeEdit`, which is a no-op where
+ * `PreviewContext` is absent.
+ *
+ * Registered as the `Block` entry in `registry.ts`. Delegates actual
+ * block rendering to the `dispatchers.tsx` `Block` dispatcher, so edit
+ * substitution and attribution wrapping are untouched. A user
+ * render-components override of `Block` still wins via
+ * `mergedPreviewRegistry` (and receives the raw dispatcher as
+ * `__Q2_PREVIEW_RENDERER__.Block`, exactly as before).
+ */
+import React from 'react';
+import { AttributionLookupContext } from '../../framework';
+import type {
+    BlockNode,
+    DivBlock,
+    HeaderBlock,
+    InlineNode,
+    NodeArgs,
+    ParaBlock,
+    PlainBlock,
+    SpanInline,
+    StrInline,
+} from '../../framework';
+import { Block as B } from '../dispatchers';
+import { usePreviewEdit } from '../usePreviewEdit';
+
+function isComment(inline: InlineNode): boolean {
+    if (inline.t === 'Span' && 'c' in inline) {
+        const attrs = (inline as SpanInline).c[0];
+        const classes = attrs[1];
+        return classes.includes('quarto-edit-comment');
+    }
+    return false;
+}
+
+// A block that can't hold an inline comment span (a code block) gets
+// wrapped in a Div with this class; the comment lives as a `[>> ...]`
+// paragraph inside the Div. The Div owns the one bubble for the whole
+// thread; its children render chrome-free (InsideCommentContainer).
+const CONTAINER_CLASS = 'quarto-edit-comment-container';
+
+function isCommentContainer(block: BlockNode): boolean {
+    return (
+        block.t === 'Div' &&
+        ((block as DivBlock).c[0][1] ?? []).includes(CONTAINER_CLASS)
+    );
+}
+
+const InsideCommentContainer = React.createContext(false);
+
+/**
+ * True when the rendered block and its resolved source node are the
+ * same simple kind we know how to modify + serialize safely. A
+ * mismatch means the rendered block is a transform product — a figure
+ * caption resolving to the whole `Figure`, a definition-list item
+ * resolving to the `DefinitionList` — whose source form the qmd writer
+ * would rewrite lossily (bd: figures became `::: {#fig-..}` divs,
+ * `::: {.definition-list}` sugar became bare `term\n:   def` syntax).
+ * Refuse to touch those.
+ */
+function sameCommentableKind(rendered: BlockNode, source: BlockNode): boolean {
+    const paraish = (t: string) => t === 'Para' || t === 'Plain';
+    if (paraish(rendered.t) && paraish(source.t)) {
+        // An implicit figure is a paragraph holding just an image —
+        // appending an inline span next to the image de-figures it.
+        const inlines = (source as ParaBlock | PlainBlock).c;
+        const solid = inlines.filter((n) => n.t !== 'Space' && n.t !== 'SoftBreak');
+        return !(solid.length === 1 && solid[0].t === 'Image');
+    }
+    if (rendered.t === 'Header' && source.t === 'Header') return true;
+    if (rendered.t === 'CodeBlock' && source.t === 'CodeBlock') return true;
+    if (isCommentContainer(rendered) && isCommentContainer(source)) return true;
+    return false;
+}
+
+function commentSpanText(span: InlineNode): string {
+    return (span as SpanInline).c[1]
+        .map((o: InlineNode) => {
+            if (o.t === 'Str') return (o as StrInline).c;
+            if (o.t === 'Space') return ' ';
+            return '';
+        })
+        .join('');
+}
+
+export const CommentBlock = (args: NodeArgs<BlockNode>) => {
+    const edit = usePreviewEdit();
+    const insideContainer = React.useContext(InsideCommentContainer);
+    const { node: block, onNavigateToDocument, setLocalAst } = args;
+
+    // Children of a comment container defer to the container's bubble.
+    if (insideContainer) {
+        return <B node={block} onNavigateToDocument={onNavigateToDocument} setLocalAst={setLocalAst} />;
+    }
+
+    let comments: InlineNode[] = [];
+    let newBlock = block;
+    // Casts: the BlockNode union includes `UnknownBlock { t: string }`,
+    // which defeats discriminant narrowing on `block.t`.
+    if (block.t === 'Para' || block.t === 'Plain') {
+        const b = block as ParaBlock | PlainBlock;
+        comments = b.c.filter(isComment);
+        const clone = structuredClone(b);
+        clone.c = b.c.filter((n) => !isComment(n));
+        newBlock = clone;
+    } else if (block.t === 'Header') {
+        const b = block as HeaderBlock;
+        comments = b.c[2].filter(isComment);
+        const clone = structuredClone(b);
+        clone.c[2] = b.c[2].filter((n) => !isComment(n));
+        newBlock = clone;
+    } else if (isCommentContainer(block)) {
+        // Collect comment spans from the container's paragraphs and
+        // strip them (dropping paragraphs that were nothing but
+        // comments) so only the wrapped content renders.
+        const clone = structuredClone(block) as DivBlock;
+        const kept: BlockNode[] = [];
+        for (const child of clone.c[1]) {
+            if (child.t === 'Para' || child.t === 'Plain') {
+                const p = child as ParaBlock | PlainBlock;
+                comments.push(...p.c.filter(isComment));
+                p.c = p.c.filter((n) => !isComment(n));
+                if (p.c.length === 0) continue;
+            }
+            kept.push(child);
+        }
+        clone.c[1] = kept;
+        newBlock = clone;
+    }
+
+    // The chrome applies to every block type that can store a comment:
+    // Para, Plain (list items), and Header hold an inline comment span;
+    // commenting on a CodeBlock (incl. mermaid) wraps it in a comment
+    // container Div, which then owns the thread's single bubble. That
+    // covers essentially everything hoverable/editable; other block
+    // types (lists as a whole, tables, ...) render plain.
+    const canHoldComment =
+        block.t === 'Para' || block.t === 'Plain' || block.t === 'Header' ||
+        block.t === 'CodeBlock' || isCommentContainer(block);
+    if (!canHoldComment) {
+        return <B node={block} onNavigateToDocument={onNavigateToDocument} setLocalAst={setLocalAst} />;
+    }
+
+    // Commenting on figures, definition lists, and table cells is
+    // BUSTED right now. Writing Figures cause broken syntax, 
+    // writing definition lists cause broke syntax, table cells just dont write.
+    if (comments.length === 0) {
+        const resolved = edit.resolveSource(block);
+        if (
+            !resolved ||
+            resolved.reachabilityClass === 'Opaque' ||
+            !sameCommentableKind(block, resolved.sourceNode)
+        ) {
+            return <B node={block} onNavigateToDocument={onNavigateToDocument} setLocalAst={setLocalAst} />;
+        }
+    }
+
+    const inner = (
+        <B node={newBlock} onNavigateToDocument={onNavigateToDocument} setLocalAst={setLocalAst} />
+    );
+    return (
+        <CommentWrapper comments={comments} block={block} edit={edit}>
+            {isCommentContainer(block) ? (
+                <InsideCommentContainer.Provider value={true}>
+                    {inner}
+                </InsideCommentContainer.Provider>
+            ) : (
+                inner
+            )}
+        </CommentWrapper>
+    );
+};
+
+type EditHandle = ReturnType<typeof usePreviewEdit>;
+
+// Only one comments popup may be open at a time. Whichever popup opens
+// closes the previously open one via this module-level latch.
+let closeOpenPopup: (() => void) | null = null;
+
+// ---------------------------------------------------------------------
+// Tiny force layout: visible bubbles register here; after any of them
+// mounts/unmounts, a rAF pass sorts them by natural position and nudges
+// later ones down (translateY) just enough to clear earlier ones.
+const BUBBLE_GAP = 4;
+type BubbleEntry = {
+    el: HTMLElement | null;
+    nudge: number;
+    /** Block currently hovered — its bubble is pinned at its natural spot. */
+    hovered: boolean;
+    setNudge: (y: number) => void;
+};
+const bubbleEntries = new Set<BubbleEntry>();
+let bubbleRelayoutScheduled = false;
+
+/** The translateY currently painted on the element. During a transform
+ *  transition this is the in-flight value, not the target nudge — the
+ *  relayout pass subtracts it to recover the natural position. */
+function appliedTranslateY(el: HTMLElement, fallback: number): number {
+    try {
+        const t = getComputedStyle(el).transform;
+        if (!t || t === 'none') return 0;
+        const m = t.match(/matrix\(([^)]+)\)/);
+        if (!m) return fallback;
+        return parseFloat(m[1].split(',')[5]) || 0;
+    } catch {
+        return fallback;
+    }
+}
+
+function scheduleBubbleRelayout() {
+    if (bubbleRelayoutScheduled) return;
+    bubbleRelayoutScheduled = true;
+    requestAnimationFrame(() => {
+        bubbleRelayoutScheduled = false;
+        const items = [...bubbleEntries]
+            .filter((e) => e.el)
+            .map((e) => {
+                const rect = e.el!.getBoundingClientRect();
+                // Subtract the currently painted translation to get the
+                // bubble's natural (untranslated) position.
+                const top = rect.top - appliedTranslateY(e.el!, e.nudge);
+                const height = rect.height;
+                // HOVER PIN: while its block is hovered, the bubble is
+                // pinned at its exact natural position (always the same
+                // spot, overlapping its block, ready to click); the
+                // relaxation pushes every other bubble around it. Idle
+                // bubbles float freely to resolve overlaps.
+                const clamp = e.hovered ? () => top : (y: number) => y;
+                return { e, top, height, left: rect.left, right: rect.right, cur: top, clamp };
+            })
+            .sort((a, b) => a.top - b.top);
+        // Iterative relaxation: each overlapping pair splits the push —
+        // the earlier bubble moves up, the later one down — clamped to
+        // each bubble's own-block range. When one side hits its clamp,
+        // later rounds shift the remaining overlap onto the other side,
+        // so the earlier bubble keeps moving up as far as it's allowed.
+        for (let iter = 0; iter < 20; iter++) {
+            let moved = false;
+            for (let i = 0; i < items.length; i++) {
+                for (let j = i + 1; j < items.length; j++) {
+                    const a = items[i];
+                    const b = items[j];
+                    const overlapsH = a.left < b.right && b.left < a.right;
+                    if (!overlapsH) continue;
+                    const overlap = a.cur + a.height + BUBBLE_GAP - b.cur;
+                    if (overlap > 0) {
+                        const aBefore = a.cur;
+                        const bBefore = b.cur;
+                        a.cur = a.clamp(a.cur - overlap / 2);
+                        b.cur = b.clamp(b.cur + overlap / 2);
+                        // Whatever the clamps refused, try shoving onto
+                        // either side (up first, then down).
+                        let remaining = a.cur + a.height + BUBBLE_GAP - b.cur;
+                        if (remaining > 0) {
+                            a.cur = a.clamp(a.cur - remaining);
+                            remaining = a.cur + a.height + BUBBLE_GAP - b.cur;
+                            if (remaining > 0) b.cur = b.clamp(b.cur + remaining);
+                        }
+                        if (a.cur !== aBefore || b.cur !== bBefore) moved = true;
+                    }
+                }
+            }
+            if (!moved) break;
+        }
+        for (const it of items) {
+            const nudge = Math.round(it.cur - it.top);
+            if (nudge !== it.e.nudge) {
+                it.e.nudge = nudge;
+                it.e.setNudge(nudge);
+            }
+        }
+    });
+}
+
+const CommentWrapper = ({
+    children,
+    comments,
+    block,
+    edit,
+}: {
+    children: React.ReactNode;
+    comments: InlineNode[];
+    block: BlockNode;
+    edit: EditHandle;
+}) => {
+    const [commentText, setCommentText] = React.useState('');
+    const [showCommentsList, setShowCommentsList] = React.useState(false);
+    const [isHovered, setIsHovered] = React.useState(false);
+    // Force-layout nudge (translateY) keeping this bubble clear of its
+    // neighbors; nudgeRef mirrors it for the module-level relayout pass.
+    const [nudge, setNudge] = React.useState(0);
+    const nudgeRef = React.useRef(0);
+    const chromeRef = React.useRef<HTMLDivElement>(null);
+    // Mirror of isHovered for the registry (re-registrations read it),
+    // plus the live entry so hover changes can update it in place.
+    const isHoveredRef = React.useRef(false);
+    const entryRef = React.useRef<BubbleEntry | null>(null);
+
+    // Per-comment authorship, resolved from the comment span's source
+    // pool id (`s`). The lookup is only populated when the host provides
+    // attribution (Authors overlay on); otherwise rows render without
+    // an author line.
+    const attributionLookup = React.useContext(AttributionLookupContext);
+    const commentAuthor = (span: InlineNode) => {
+        if (!attributionLookup) return null;
+        const s = (span as { s?: number }).s;
+        if (s == null) return null;
+        return attributionLookup.get(s) ?? null;
+    };
+    const commentsListRef = React.useRef<HTMLDivElement>(null);
+    const commentInputRef = React.useRef<HTMLTextAreaElement>(null);
+    const popupRef = React.useRef<HTMLDivElement>(null);
+    const [popupShift, setPopupShift] = React.useState(0);
+
+    // Keep the popup inside the visible viewport: measure it when it
+    // opens or grows (and on scroll/resize while open) and translate it
+    // up/down as needed. If the anchor block itself scrolls fully out
+    // of view, close the popup instead. React bails out when the
+    // computed shift equals the current one, so including popupShift in
+    // the deps doesn't loop.
+    React.useLayoutEffect(() => {
+        if (!showCommentsList) {
+            setPopupShift(0);
+            return;
+        }
+        const clampOrClose = () => {
+            const anchor = commentsListRef.current;
+            const el = popupRef.current;
+            if (!anchor || !el) return;
+            // Close only once the block is a comfortable 50px past the
+            // viewport edge, not the instant it leaves.
+            const CLOSE_SLACK = 50;
+            const anchorRect = anchor.getBoundingClientRect();
+            if (
+                anchorRect.bottom < -CLOSE_SLACK ||
+                anchorRect.top > window.innerHeight + CLOSE_SLACK
+            ) {
+                setShowCommentsList(false);
+                return;
+            }
+            const rect = el.getBoundingClientRect();
+            const margin = 8;
+            // rect includes the currently applied shift; work from the
+            // unshifted position.
+            const top = rect.top - popupShift;
+            const bottom = rect.bottom - popupShift;
+            let shift = 0;
+            if (bottom > window.innerHeight - margin) shift = window.innerHeight - margin - bottom;
+            if (top + shift < margin) shift = margin - top;
+            setPopupShift(shift);
+        };
+        clampOrClose();
+        window.addEventListener('scroll', clampOrClose, true);
+        window.addEventListener('resize', clampOrClose);
+        return () => {
+            window.removeEventListener('scroll', clampOrClose, true);
+            window.removeEventListener('resize', clampOrClose);
+        };
+    }, [showCommentsList, comments.length, commentText, popupShift]);
+
+    // Auto-grow the input with its content (also shrinks back after
+    // submit clears it).
+    React.useEffect(() => {
+        const ta = commentInputRef.current;
+        if (!ta) return;
+        ta.style.height = 'auto';
+        ta.style.height = `${ta.scrollHeight}px`;
+    }, [commentText, showCommentsList]);
+
+    // Close any other open popup when this one opens; deregister on
+    // close (only if still the registered one — a newer popup may have
+    // taken over the latch).
+    React.useEffect(() => {
+        if (!showCommentsList) return;
+        closeOpenPopup?.();
+        const close = () => setShowCommentsList(false);
+        closeOpenPopup = close;
+        return () => {
+            if (closeOpenPopup === close) closeOpenPopup = null;
+        };
+    }, [showCommentsList]);
+
+    React.useEffect(() => {
+        if (!showCommentsList) return;
+        const handleClickOutside = (event: MouseEvent) => {
+            if (commentsListRef.current && !commentsListRef.current.contains(event.target as Node)) {
+                setShowCommentsList(false);
+            }
+        };
+        document.addEventListener('mousedown', handleClickOutside);
+        return () => { document.removeEventListener('mousedown', handleClickOutside); };
+    }, [showCommentsList]);
+
+    // Focus the input when the modal opens, with the cursor at the end
+    // of any drafted text. (The block editors see `data-q2-owns-focus`
+    // on their blur relatedTarget and skip their focus-restore, so
+    // nothing steals focus back.)
+    React.useEffect(() => {
+        const ta = commentInputRef.current;
+        if (showCommentsList && ta) {
+            ta.focus();
+            const end = ta.value.length;
+            ta.setSelectionRange(end, end);
+        }
+    }, [showCommentsList]);
+
+    // Remove the index-th comment span (counting comment spans only,
+    // in order) from the source node and commit.
+    const resolveCommentAtIndex = (index: number): void => {
+        const resolved = edit.resolveSource(block);
+        if (!resolved) return;
+        // Same safety gates as addComment: no structurally unreachable
+        // targets (table cells), no transform products the writer
+        // would re-serialize lossily (figures, definition lists).
+        if (resolved.reachabilityClass === 'Opaque') return;
+        if (!sameCommentableKind(block, resolved.sourceNode)) return;
+        const modified = structuredClone(resolved.sourceNode);
+        const removeNth = (arr: InlineNode[]) => {
+            let seen = -1;
+            for (let i = 0; i < arr.length; i++) {
+                if (isComment(arr[i])) {
+                    seen++;
+                    if (seen === index) {
+                        arr.splice(i, 1);
+                        return;
+                    }
+                }
+            }
+        };
+        if (modified.t === 'Para' || modified.t === 'Plain') {
+            removeNth((modified as ParaBlock | PlainBlock).c);
+        } else if (modified.t === 'Header') {
+            removeNth((modified as HeaderBlock).c[2]);
+        } else if (isCommentContainer(modified)) {
+            // Comments live across the container's paragraphs; count
+            // them in order, remove the index-th, and drop a paragraph
+            // that was left empty by the removal.
+            const children = (modified as DivBlock).c[1];
+            let seen = -1;
+            outer:
+            for (let ci = 0; ci < children.length; ci++) {
+                const ch = children[ci];
+                if (ch.t !== 'Para' && ch.t !== 'Plain') continue;
+                const arr = (ch as ParaBlock | PlainBlock).c;
+                for (let i = 0; i < arr.length; i++) {
+                    if (isComment(arr[i])) {
+                        seen++;
+                        if (seen === index) {
+                            arr.splice(i, 1);
+                            if (arr.length === 0) children.splice(ci, 1);
+                            break outer;
+                        }
+                    }
+                }
+            }
+            // Last comment resolved with a single wrapped block left →
+            // unwrap: commit the bare block in place of the container.
+            const anyLeft = children.some(
+                (ch) =>
+                    (ch.t === 'Para' || ch.t === 'Plain') &&
+                    (ch as ParaBlock | PlainBlock).c.some(isComment),
+            );
+            if (!anyLeft && children.length === 1) {
+                edit.commitSubtreeEdit(JSON.stringify(resolved.sourceEntry), children[0]);
+                return;
+            }
+        }
+        edit.commitSubtreeEdit(JSON.stringify(resolved.sourceEntry), modified);
+    };
+
+    // Append a comment span to the source node and commit.
+    const addComment = () => {
+        const resolved = edit.resolveSource(block);
+        if (!resolved) return;
+        // Safety gates: table cells resolve as Opaque (the edit system
+        // can't commit there — same reason they aren't click-editable),
+        // and transform products (figure captions → Figure, def-list
+        // items → DefinitionList) would round-trip lossily. Bail
+        // silently rather than corrupt the source.
+        if (resolved.reachabilityClass === 'Opaque') return;
+        if (!sameCommentableKind(block, resolved.sourceNode)) return;
+        const modified = structuredClone(resolved.sourceNode);
+        const newComment: SpanInline = {
+            t: 'Span',
+            c: [['', ['quarto-edit-comment'], []], [{ t: 'Str', c: commentText }]],
+        };
+        if (modified.t === 'Para' || modified.t === 'Plain') {
+            (modified as ParaBlock | PlainBlock).c.push(newComment);
+        } else if (modified.t === 'Header') {
+            (modified as HeaderBlock).c[2].push(newComment);
+        } else if (modified.t === 'CodeBlock') {
+            // A code block can't hold an inline span: wrap it in a
+            // comment container Div with the comment as a `[>> ...]`
+            // paragraph inside. Further comments append to that Div.
+            const wrapper: DivBlock = {
+                t: 'Div',
+                c: [
+                    ['', [CONTAINER_CLASS], []],
+                    [modified, { t: 'Para', c: [newComment] } as ParaBlock],
+                ],
+            };
+            edit.commitSubtreeEdit(JSON.stringify(resolved.sourceEntry), wrapper as BlockNode);
+            setCommentText('');
+            return;
+        } else if (isCommentContainer(modified)) {
+            // Append to the container's last comment paragraph, or add
+            // a fresh one at the end.
+            const children = (modified as DivBlock).c[1];
+            const lastCommentPara = [...children].reverse().find(
+                (ch) =>
+                    (ch.t === 'Para' || ch.t === 'Plain') &&
+                    (ch as ParaBlock | PlainBlock).c.some(isComment),
+            );
+            if (lastCommentPara) {
+                (lastCommentPara as ParaBlock | PlainBlock).c.push(newComment);
+            } else {
+                children.push({ t: 'Para', c: [newComment] } as ParaBlock);
+            }
+        }
+        edit.commitSubtreeEdit(JSON.stringify(resolved.sourceEntry), modified);
+        setCommentText('');
+    };
+
+    const hasContent = comments.length > 0;
+    const chromeVisible = hasContent || isHovered || showCommentsList;
+
+    // Register this bubble with the force layout while visible; any
+    // mount/unmount (including hover chrome) reflows all bubbles.
+    React.useLayoutEffect(() => {
+        if (!chromeVisible) return;
+        const entry: BubbleEntry = {
+            el: chromeRef.current,
+            nudge: nudgeRef.current,
+            hovered: isHoveredRef.current,
+            setNudge: (y) => {
+                nudgeRef.current = y;
+                setNudge(y);
+            },
+        };
+        entryRef.current = entry;
+        bubbleEntries.add(entry);
+        scheduleBubbleRelayout();
+        return () => {
+            entryRef.current = null;
+            bubbleEntries.delete(entry);
+            scheduleBubbleRelayout();
+        };
+    }, [chromeVisible, comments.length]);
+
+    // Sync hover into the registry entry — the own-block clamp only
+    // applies while the block is hovered, and hover changes reflow.
+    React.useEffect(() => {
+        isHoveredRef.current = isHovered;
+        if (entryRef.current && entryRef.current.hovered !== isHovered) {
+            entryRef.current.hovered = isHovered;
+            scheduleBubbleRelayout();
+        }
+    }, [isHovered]);
+
+    return (
+        <div
+            style={{ position: 'relative' }}
+            onMouseEnter={() => setIsHovered(true)}
+            onMouseLeave={() => setIsHovered(false)}
+        >
+            {/* Chrome renders BEFORE the content: mounting it as a
+                LAST sibling on hover would stop the content matching
+                theme `:last-child` rules (e.g. the last paragraph in a
+                blockquote loses margin-bottom: 0 and the quote grows —
+                a hover reflow). It's absolutely positioned, so DOM
+                order doesn't change where it paints. */}
+            {chromeVisible && (
+                <div
+                    ref={chromeRef}
+                    style={{
+                        position: 'absolute',
+                        bottom: '-11px',
+                        right: '-10px',
+                        transform: `translateY(${nudge}px)`,
+                        // Animate nudge changes; the relayout pass reads
+                        // the in-flight translation, so mid-animation
+                        // reflows stay correct.
+                        transition: 'transform 0.15s ease-out',
+                        display: 'flex',
+                        flexDirection: 'row',
+                        gap: '4px',
+                        alignItems: 'center',
+                        // The bubble hangs below the block's box, into
+                        // the next (positioned) sibling wrapper — lift
+                        // it above so it wins hit-testing there. While
+                        // OUR popup is open, lift the whole container
+                        // further so no other block's bubble (all peers
+                        // at 100) can paint above the popup.
+                        zIndex: showCommentsList ? 1000 : 100,
+                    }}
+                    // Keep chrome interactions away from the delegated
+                    // click-to-edit handler on the document root —
+                    // otherwise clicking the bubble/input activates the
+                    // enclosing block's editor.
+                    // Marks this chrome as owning its focus: the block
+                    // editors see it on blur relatedTarget and skip
+                    // their focus-restore (which would steal focus back
+                    // from the comment input).
+                    data-q2-owns-focus=""
+                    onPointerDown={(e) => e.stopPropagation()}
+                    onPointerUp={(e) => e.stopPropagation()}
+                    onMouseDown={(e) => {
+                        e.stopPropagation();
+                        // Clicking non-interactive chrome (the bubble)
+                        // must not blur an open block editor — the
+                        // modal takes focus itself once open.
+                        if (!(e.target as HTMLElement).closest('input, textarea, button')) {
+                            e.preventDefault();
+                        }
+                    }}
+                    onClick={(e) => e.stopPropagation()}
+                    onKeyDown={(e) => e.stopPropagation()}
+                >
+                    <div ref={commentsListRef} style={{ position: 'relative' }}>
+                        <div
+                            style={{
+                                // Hovering anywhere on the block tints
+                                // its bubble, tying the two together.
+                                backgroundColor: showCommentsList || isHovered ? '#e0f0ff' : '#b3d9ff',
+                                color: '#4a7ba7',
+                                padding: '4px 8px',
+                                borderRadius: '12px',
+                                border: '1px solid #4a7ba7',
+                                fontSize: '0.7rem',
+                                cursor: 'pointer',
+                                boxShadow: '0 2px 4px rgba(0,0,0,0.2)',
+                                userSelect: 'none',
+                            }}
+                            onClick={() => setShowCommentsList(!showCommentsList)}
+                            title={`${comments.length} comment${comments.length !== 1 ? 's' : ''}`}
+                        >
+                            <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+                                <span>💬</span>
+                                {comments.length > 0 && (
+                                    <span style={{
+                                        maxWidth: '140px',
+                                        overflow: 'hidden',
+                                        whiteSpace: 'nowrap',
+                                        textOverflow: 'ellipsis',
+                                    }}>
+                                        {commentSpanText(comments[0])}
+                                    </span>
+                                )}
+                            </div>
+                            {comments.length > 1 && (
+                                <div style={{ color: '#6699cc', textAlign: 'right' }}>
+                                    +{comments.length - 1} more
+                                </div>
+                            )}
+                        </div>
+                        {showCommentsList && (
+                            <div ref={popupRef} style={{
+                                position: 'absolute',
+                                top: '30px',
+                                right: '7px',
+                                transform: `translateY(${popupShift}px)`,
+                                backgroundColor: 'white',
+                                border: '1px solid #ccc',
+                                borderRadius: '8px',
+                                padding: '8px',
+                                boxShadow: '0 4px 8px rgba(0,0,0,0.2)',
+                                width: '300px',
+                                maxWidth: '80vw',
+                                minHeight: '220px',
+                                maxHeight: '50vh',
+                                display: 'flex',
+                                flexDirection: 'column',
+                                zIndex: '9999',
+                            }}>
+                                <div style={{ flex: 1, overflowY: 'auto' }}>
+                                    {comments.map((comment, i) => {
+                                        const author = commentAuthor(comment);
+                                        return (
+                                            <div key={i} style={{
+                                                display: 'flex',
+                                                alignItems: 'flex-start',
+                                                gap: '8px',
+                                                padding: '8px',
+                                                borderBottom: i < comments.length - 1 ? '1px solid #eee' : 'none',
+                                                fontSize: '0.75rem',
+                                                color: '#333',
+                                            }}>
+                                                <div style={{ flex: 1, minWidth: 0 }}>
+                                                    {author && (
+                                                        <div style={{ display: 'flex', alignItems: 'center', gap: '4px', marginBottom: '2px' }}>
+                                                            <span style={{
+                                                                width: '8px',
+                                                                height: '8px',
+                                                                borderRadius: '50%',
+                                                                backgroundColor: author.color,
+                                                                display: 'inline-block',
+                                                                flexShrink: 0,
+                                                            }} />
+                                                            <span style={{ fontWeight: 600, fontSize: '0.7rem', color: '#555' }}>
+                                                                {author.name}
+                                                            </span>
+                                                        </div>
+                                                    )}
+                                                    <span style={{ wordWrap: 'break-word' }}>
+                                                        {commentSpanText(comment)}
+                                                    </span>
+                                                </div>
+                                                <button
+                                                    onClick={() => resolveCommentAtIndex(i)}
+                                                    title="Resolve comment"
+                                                    style={{
+                                                        padding: '2px 6px',
+                                                        backgroundColor: '#f0f0f0',
+                                                        color: '#4a7ba7',
+                                                        border: '1px solid #ccc',
+                                                        borderRadius: '4px',
+                                                        fontSize: '0.7rem',
+                                                        cursor: 'pointer',
+                                                        whiteSpace: 'nowrap',
+                                                    }}
+                                                >
+                                                    ✓
+                                                </button>
+                                            </div>
+                                        );
+                                    })}
+                                </div>
+                                <div style={{ marginTop: '8px', display: 'flex', flexDirection: 'column', gap: '4px' }}>
+                                    <textarea
+                                        ref={commentInputRef}
+                                        rows={1}
+                                        value={commentText}
+                                        onChange={(e) => setCommentText(e.target.value)}
+                                        onKeyDown={(e) => {
+                                            if (e.key === 'Enter') {
+                                                e.preventDefault();
+                                                if (commentText) addComment();
+                                            }
+                                        }}
+                                        placeholder="type comment here"
+                                        style={{ padding: '7px 11px', fontFamily: 'inherit', fontSize: '0.75rem', backgroundColor: '#f0f0f0', color: '#333', border: '1px solid #ccc', borderRadius: '12px', resize: 'none', overflow: 'hidden', boxSizing: 'border-box' }}
+                                    />
+                                    <button
+                                        onClick={addComment}
+                                        disabled={!commentText}
+                                        style={{
+                                            padding: '4px 8px',
+                                            backgroundColor: '#b3d9ff',
+                                            color: '#4a7ba7',
+                                            border: '1px solid #4a7ba7',
+                                            borderRadius: '12px',
+                                            fontSize: '0.7rem',
+                                            cursor: commentText ? 'pointer' : 'default',
+                                            opacity: commentText ? 1 : 0.5,
+                                            whiteSpace: 'nowrap',
+                                            alignSelf: 'flex-end',
+                                        }}
+                                    >
+                                        add comment
+                                    </button>
+                                </div>
+                            </div>
+                        )}
+                    </div>
+                </div>
+            )}
+
+            {children}
+        </div>
+    );
+};

--- a/ts-packages/preview-renderer/src/q2-preview/custom/CommentBlock.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/custom/CommentBlock.tsx
@@ -33,6 +33,8 @@ import type {
     StrInline,
 } from '../../framework';
 import { Block as B } from '../dispatchers';
+import { PreviewContext } from '../PreviewContext';
+import type { CommentsMode } from '../PreviewContext';
 import { usePreviewEdit } from '../usePreviewEdit';
 
 function isComment(inline: InlineNode): boolean {
@@ -58,6 +60,19 @@ function isCommentContainer(block: BlockNode): boolean {
 }
 
 const InsideCommentContainer = React.createContext(false);
+
+// Light blue placeholder tint for the comment inputs — ::placeholder
+// isn't reachable from inline styles, so inject one tiny rule per
+// document (idempotent).
+(() => {
+    if (typeof document === 'undefined') return;
+    if (document.head.querySelector('style[data-q2-comment-styles]')) return;
+    const tag = document.createElement('style');
+    tag.setAttribute('data-q2-comment-styles', '1');
+    tag.textContent =
+        '.q2-comment-input::placeholder { color: #a9c7e8; opacity: 1; }';
+    document.head.appendChild(tag);
+})();
 
 /**
  * True when the rendered block and its resolved source node are the
@@ -97,6 +112,8 @@ function commentSpanText(span: InlineNode): string {
 export const CommentBlock = (args: NodeArgs<BlockNode>) => {
     const edit = usePreviewEdit();
     const insideContainer = React.useContext(InsideCommentContainer);
+    const mode: CommentsMode =
+        React.useContext(PreviewContext)?.commentsMode ?? 'show';
     const { node: block, onNavigateToDocument, setLocalAst } = args;
 
     // Children of a comment container defer to the container's bubble.
@@ -169,15 +186,21 @@ export const CommentBlock = (args: NodeArgs<BlockNode>) => {
     const inner = (
         <B node={newBlock} onNavigateToDocument={onNavigateToDocument} setLocalAst={setLocalAst} />
     );
+    const maybeProvided = isCommentContainer(block) ? (
+        <InsideCommentContainer.Provider value={true}>
+            {inner}
+        </InsideCommentContainer.Provider>
+    ) : (
+        inner
+    );
+    // 'hide' mode: comments stay stripped from the text, but no chrome
+    // (and no wrapper div) renders at all.
+    if (mode === 'hide') {
+        return maybeProvided;
+    }
     return (
-        <CommentWrapper comments={comments} block={block} edit={edit}>
-            {isCommentContainer(block) ? (
-                <InsideCommentContainer.Provider value={true}>
-                    {inner}
-                </InsideCommentContainer.Provider>
-            ) : (
-                inner
-            )}
+        <CommentWrapper comments={comments} block={block} edit={edit} mode={mode}>
+            {maybeProvided}
         </CommentWrapper>
     );
 };
@@ -235,8 +258,15 @@ function scheduleBubbleRelayout() {
                 // pinned at its exact natural position (always the same
                 // spot, overlapping its block, ready to click); the
                 // relaxation pushes every other bubble around it. Idle
-                // bubbles float freely to resolve overlaps.
-                const clamp = e.hovered ? () => top : (y: number) => y;
+                // bubbles float freely to resolve overlaps, EXCEPT they
+                // may never be pushed above the viewport top (a bubble
+                // whose natural spot is already above it stays put —
+                // the floor only limits upward nudging).
+                const TOP_MARGIN = 8;
+                const floor = Math.min(top, TOP_MARGIN);
+                const clamp = e.hovered
+                    ? () => top
+                    : (y: number) => Math.max(y, floor);
                 return { e, top, height, left: rect.left, right: rect.right, cur: top, clamp };
             })
             .sort((a, b) => a.top - b.top);
@@ -288,15 +318,24 @@ const CommentWrapper = ({
     comments,
     block,
     edit,
+    mode,
 }: {
     children: React.ReactNode;
     comments: InlineNode[];
     block: BlockNode;
     edit: EditHandle;
+    mode: CommentsMode;
 }) => {
     const [commentText, setCommentText] = React.useState('');
-    const [showCommentsList, setShowCommentsList] = React.useState(false);
+    // No modal: clicking a compact bubble expands it in place (with the
+    // inline add-comment input open at its bottom).
+    const [selfExpanded, setSelfExpanded] = React.useState(false);
+    const [showInlineInput, setShowInlineInput] = React.useState(false);
+    const inlineInputRef = React.useRef<HTMLTextAreaElement>(null);
     const [isHovered, setIsHovered] = React.useState(false);
+    // Global 'expand' mode expands every commented bubble; a click
+    // self-expands one bubble in any mode.
+    const expanded = (mode === 'expand' && comments.length > 0) || selfExpanded;
     // Force-layout nudge (translateY) keeping this bubble clear of its
     // neighbors; nudgeRef mirrors it for the module-level relayout pass.
     const [nudge, setNudge] = React.useState(0);
@@ -307,10 +346,12 @@ const CommentWrapper = ({
     const isHoveredRef = React.useRef(false);
     const entryRef = React.useRef<BubbleEntry | null>(null);
 
+    const commentsListRef = React.useRef<HTMLDivElement>(null);
+
     // Per-comment authorship, resolved from the comment span's source
     // pool id (`s`). The lookup is only populated when the host provides
     // attribution (Authors overlay on); otherwise rows render without
-    // an author line.
+    // an author dot.
     const attributionLookup = React.useContext(AttributionLookupContext);
     const commentAuthor = (span: InlineNode) => {
         if (!attributionLookup) return null;
@@ -318,102 +359,68 @@ const CommentWrapper = ({
         if (s == null) return null;
         return attributionLookup.get(s) ?? null;
     };
-    const commentsListRef = React.useRef<HTMLDivElement>(null);
-    const commentInputRef = React.useRef<HTMLTextAreaElement>(null);
-    const popupRef = React.useRef<HTMLDivElement>(null);
-    const [popupShift, setPopupShift] = React.useState(0);
 
-    // Keep the popup inside the visible viewport: measure it when it
-    // opens or grows (and on scroll/resize while open) and translate it
-    // up/down as needed. If the anchor block itself scrolls fully out
-    // of view, close the popup instead. React bails out when the
-    // computed shift equals the current one, so including popupShift in
-    // the deps doesn't loop.
-    React.useLayoutEffect(() => {
-        if (!showCommentsList) {
-            setPopupShift(0);
-            return;
-        }
-        const clampOrClose = () => {
-            const anchor = commentsListRef.current;
-            const el = popupRef.current;
-            if (!anchor || !el) return;
-            // Close only once the block is a comfortable 50px past the
-            // viewport edge, not the instant it leaves.
-            const CLOSE_SLACK = 50;
-            const anchorRect = anchor.getBoundingClientRect();
-            if (
-                anchorRect.bottom < -CLOSE_SLACK ||
-                anchorRect.top > window.innerHeight + CLOSE_SLACK
-            ) {
-                setShowCommentsList(false);
-                return;
-            }
-            const rect = el.getBoundingClientRect();
-            const margin = 8;
-            // rect includes the currently applied shift; work from the
-            // unshifted position.
-            const top = rect.top - popupShift;
-            const bottom = rect.bottom - popupShift;
-            let shift = 0;
-            if (bottom > window.innerHeight - margin) shift = window.innerHeight - margin - bottom;
-            if (top + shift < margin) shift = margin - top;
-            setPopupShift(shift);
-        };
-        clampOrClose();
-        window.addEventListener('scroll', clampOrClose, true);
-        window.addEventListener('resize', clampOrClose);
-        return () => {
-            window.removeEventListener('scroll', clampOrClose, true);
-            window.removeEventListener('resize', clampOrClose);
-        };
-    }, [showCommentsList, comments.length, commentText, popupShift]);
-
-    // Auto-grow the input with its content (also shrinks back after
-    // submit clears it).
+    // Auto-grow the inline input with its content (also shrinks back
+    // after submit clears it).
     React.useEffect(() => {
-        const ta = commentInputRef.current;
+        const ta = inlineInputRef.current;
         if (!ta) return;
         ta.style.height = 'auto';
         ta.style.height = `${ta.scrollHeight}px`;
-    }, [commentText, showCommentsList]);
+    }, [commentText, showInlineInput]);
 
-    // Close any other open popup when this one opens; deregister on
-    // close (only if still the registered one — a newer popup may have
-    // taken over the latch).
+    // Close the inline input only once the submitted comment actually
+    // lands in the list (the commit round-trip re-renders this block
+    // with the new comment), not the moment Enter is pressed.
+    const [closeAtCount, setCloseAtCount] = React.useState<number | null>(null);
     React.useEffect(() => {
-        if (!showCommentsList) return;
-        closeOpenPopup?.();
-        const close = () => setShowCommentsList(false);
-        closeOpenPopup = close;
-        return () => {
-            if (closeOpenPopup === close) closeOpenPopup = null;
-        };
-    }, [showCommentsList]);
+        if (closeAtCount !== null && comments.length > closeAtCount) {
+            setShowInlineInput(false);
+            setCloseAtCount(null);
+        }
+    }, [comments.length, closeAtCount]);
 
+    // Focus the inline input when it opens, cursor at the end. (The
+    // block editors see `data-q2-owns-focus` on their blur
+    // relatedTarget and skip their focus-restore, so nothing steals
+    // focus back.)
     React.useEffect(() => {
-        if (!showCommentsList) return;
-        const handleClickOutside = (event: MouseEvent) => {
-            if (commentsListRef.current && !commentsListRef.current.contains(event.target as Node)) {
-                setShowCommentsList(false);
-            }
-        };
-        document.addEventListener('mousedown', handleClickOutside);
-        return () => { document.removeEventListener('mousedown', handleClickOutside); };
-    }, [showCommentsList]);
-
-    // Focus the input when the modal opens, with the cursor at the end
-    // of any drafted text. (The block editors see `data-q2-owns-focus`
-    // on their blur relatedTarget and skip their focus-restore, so
-    // nothing steals focus back.)
-    React.useEffect(() => {
-        const ta = commentInputRef.current;
-        if (showCommentsList && ta) {
+        const ta = inlineInputRef.current;
+        if (showInlineInput && ta) {
             ta.focus();
             const end = ta.value.length;
             ta.setSelectionRange(end, end);
         }
-    }, [showCommentsList]);
+    }, [showInlineInput]);
+
+    // Clicking outside the bubble collapses a self-expanded bubble and
+    // closes the inline input.
+    React.useEffect(() => {
+        if (!showInlineInput && !selfExpanded) return;
+        const handleClickOutside = (event: MouseEvent) => {
+            if (commentsListRef.current && !commentsListRef.current.contains(event.target as Node)) {
+                setShowInlineInput(false);
+                setSelfExpanded(false);
+            }
+        };
+        document.addEventListener('mousedown', handleClickOutside);
+        return () => { document.removeEventListener('mousedown', handleClickOutside); };
+    }, [showInlineInput, selfExpanded]);
+
+    // Only one self-expanded bubble at a time: expanding one collapses
+    // the previously expanded one via the module-level latch.
+    React.useEffect(() => {
+        if (!selfExpanded) return;
+        closeOpenPopup?.();
+        const close = () => {
+            setSelfExpanded(false);
+            setShowInlineInput(false);
+        };
+        closeOpenPopup = close;
+        return () => {
+            if (closeOpenPopup === close) closeOpenPopup = null;
+        };
+    }, [selfExpanded]);
 
     // Remove the index-th comment span (counting comment spans only,
     // in order) from the source node and commit.
@@ -533,7 +540,7 @@ const CommentWrapper = ({
     };
 
     const hasContent = comments.length > 0;
-    const chromeVisible = hasContent || isHovered || showCommentsList;
+    const chromeVisible = hasContent || isHovered || selfExpanded;
 
     // Register this bubble with the force layout while visible; any
     // mount/unmount (including hover chrome) reflows all bubbles.
@@ -556,7 +563,9 @@ const CommentWrapper = ({
             bubbleEntries.delete(entry);
             scheduleBubbleRelayout();
         };
-    }, [chromeVisible, comments.length]);
+        // expanded/showInlineInput change the bubble's size — re-register
+        // so the force layout re-measures.
+    }, [chromeVisible, comments.length, expanded, showInlineInput]);
 
     // Sync hover into the registry entry — the own-block clamp only
     // applies while the block is hovered, and hover changes reflow.
@@ -598,11 +607,10 @@ const CommentWrapper = ({
                         alignItems: 'center',
                         // The bubble hangs below the block's box, into
                         // the next (positioned) sibling wrapper — lift
-                        // it above so it wins hit-testing there. While
-                        // OUR popup is open, lift the whole container
-                        // further so no other block's bubble (all peers
-                        // at 100) can paint above the popup.
-                        zIndex: showCommentsList ? 1000 : 100,
+                        // it above so it wins hit-testing there. A
+                        // self-expanded bubble lifts further so no peer
+                        // bubble (all at 100) can paint above it.
+                        zIndex: selfExpanded ? 1000 : 100,
                     }}
                     // Keep chrome interactions away from the delegated
                     // click-to-edit handler on the document root —
@@ -630,148 +638,171 @@ const CommentWrapper = ({
                     <div ref={commentsListRef} style={{ position: 'relative' }}>
                         <div
                             style={{
-                                // Hovering anywhere on the block tints
-                                // its bubble, tying the two together.
-                                backgroundColor: showCommentsList || isHovered ? '#e0f0ff' : '#b3d9ff',
+                                // Near-white with just a hint of blue.
+                                backgroundColor: '#f7faff',
                                 color: '#4a7ba7',
-                                padding: '4px 8px',
-                                borderRadius: '12px',
+                                padding: '2px 6px',
+                                borderRadius: '5px',
                                 border: '1px solid #4a7ba7',
                                 fontSize: '0.7rem',
                                 cursor: 'pointer',
-                                boxShadow: '0 2px 4px rgba(0,0,0,0.2)',
+                                // Block hover puts an offset-free light
+                                // blue glow on the bubble.
+                                boxShadow: isHovered
+                                    ? '0 0 8px 2px rgba(140, 190, 240, 0.6)'
+                                    : '0 2px 4px rgba(0,0,0,0.2)',
+                                transition: 'box-shadow 0.15s',
                                 userSelect: 'none',
                             }}
-                            onClick={() => setShowCommentsList(!showCommentsList)}
+                            onClick={() => {
+                                // Clicking a compact bubble expands it
+                                // in place; any click opens the inline
+                                // add-comment input.
+                                if (!expanded) setSelfExpanded(true);
+                                setShowInlineInput(true);
+                            }}
                             title={`${comments.length} comment${comments.length !== 1 ? 's' : ''}`}
                         >
-                            <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
-                                <span>💬</span>
-                                {comments.length > 0 && (
-                                    <span style={{
+                            {/* An expanded bubble (global 'expand' mode or
+                                clicked-open) lists every comment as its own
+                                row with dividers, plus the inline input; a
+                                compact bubble previews the first comment
+                                and sums the rest as "+n more". A
+                                comment-less compact bubble is just the "+"
+                                add affordance. */}
+                            {comments.length === 0 && !expanded ? (
+                                <div>+</div>
+                            ) : expanded ? (
+                                <>
+                                {comments.map((c, i) => {
+                                    const author = commentAuthor(c);
+                                    return (
+                                    <div key={i} style={{
+                                        display: 'flex',
+                                        alignItems: 'center',
+                                        gap: '6px',
+                                        padding: '3px 2px',
+                                        borderBottom: i < comments.length - 1
+                                            ? '1px solid rgba(74, 123, 167, 0.3)'
+                                            : 'none',
+                                    }}>
+                                        {author && (
+                                            <span
+                                                title={author.name}
+                                                style={{
+                                                    width: '8px',
+                                                    height: '8px',
+                                                    borderRadius: '50%',
+                                                    backgroundColor: author.color,
+                                                    display: 'inline-block',
+                                                    flexShrink: 0,
+                                                }}
+                                            />
+                                        )}
+                                        <span style={{
+                                            flex: 1,
+                                            minWidth: 0,
+                                            maxWidth: '160px',
+                                            overflow: 'hidden',
+                                            whiteSpace: 'nowrap',
+                                            textOverflow: 'ellipsis',
+                                        }}>
+                                            {commentSpanText(c)}
+                                        </span>
+                                        <button
+                                            onClick={(ev) => {
+                                                // Resolve without toggling
+                                                // the modal (bubble onClick).
+                                                ev.stopPropagation();
+                                                resolveCommentAtIndex(i);
+                                            }}
+                                            title="Resolve comment"
+                                            style={{
+                                                padding: '0 4px',
+                                                backgroundColor: 'transparent',
+                                                color: '#4a7ba7',
+                                                border: '1px solid #b3d9ff',
+                                                borderRadius: '4px',
+                                                fontSize: '0.65rem',
+                                                cursor: 'pointer',
+                                                flexShrink: 0,
+                                                transition: 'background-color 0.15s',
+                                            }}
+                                            onMouseEnter={(ev) => ev.currentTarget.style.backgroundColor = '#d4e8ff'}
+                                            onMouseLeave={(ev) => ev.currentTarget.style.backgroundColor = 'transparent'}
+                                        >
+                                            ✓
+                                        </button>
+                                    </div>
+                                    );
+                                })}
+                                {showInlineInput && (
+                                    <div style={{
+                                        borderTop: '1px solid rgba(74, 123, 167, 0.3)',
+                                        marginTop: '2px',
+                                        paddingTop: '5px',
+                                        paddingBottom: '2px',
+                                    }}>
+                                        <textarea
+                                            ref={inlineInputRef}
+                                            className="q2-comment-input"
+                                            rows={1}
+                                            value={commentText}
+                                            onChange={(e) => setCommentText(e.target.value)}
+                                            onKeyDown={(e) => {
+                                                if (e.key === 'Enter') {
+                                                    e.preventDefault();
+                                                    if (commentText) {
+                                                        addComment();
+                                                        // Close once the comment
+                                                        // shows up in the list.
+                                                        setCloseAtCount(comments.length);
+                                                    }
+                                                } else if (e.key === 'Escape') {
+                                                    setShowInlineInput(false);
+                                                    setSelfExpanded(false);
+                                                }
+                                            }}
+                                            placeholder="type comment here"
+                                            style={{
+                                                display: 'block',
+                                                width: '100%',
+                                                padding: '3px 2px',
+                                                fontFamily: 'inherit',
+                                                fontSize: 'inherit',
+                                                // Blend into the bubble like
+                                                // the comment rows do.
+                                                backgroundColor: 'transparent',
+                                                color: 'inherit',
+                                                border: '1px solid rgba(74, 123, 167, 0.3)',
+                                                borderRadius: '4px',
+                                                outline: 'none',
+                                                resize: 'none',
+                                                overflow: 'hidden',
+                                                boxSizing: 'border-box',
+                                            }}
+                                        />
+                                    </div>
+                                )}
+                                </>
+                            ) : (
+                                <>
+                                    <div style={{
                                         maxWidth: '140px',
                                         overflow: 'hidden',
                                         whiteSpace: 'nowrap',
                                         textOverflow: 'ellipsis',
                                     }}>
                                         {commentSpanText(comments[0])}
-                                    </span>
-                                )}
-                            </div>
-                            {comments.length > 1 && (
-                                <div style={{ color: '#6699cc', textAlign: 'right' }}>
-                                    +{comments.length - 1} more
-                                </div>
+                                    </div>
+                                    {comments.length > 1 && (
+                                        <div style={{ color: '#6699cc', textAlign: 'right' }}>
+                                            +{comments.length - 1} more
+                                        </div>
+                                    )}
+                                </>
                             )}
                         </div>
-                        {showCommentsList && (
-                            <div ref={popupRef} style={{
-                                position: 'absolute',
-                                top: '30px',
-                                right: '7px',
-                                transform: `translateY(${popupShift}px)`,
-                                backgroundColor: 'white',
-                                border: '1px solid #ccc',
-                                borderRadius: '8px',
-                                padding: '8px',
-                                boxShadow: '0 4px 8px rgba(0,0,0,0.2)',
-                                width: '300px',
-                                maxWidth: '80vw',
-                                minHeight: '220px',
-                                maxHeight: '50vh',
-                                display: 'flex',
-                                flexDirection: 'column',
-                                zIndex: '9999',
-                            }}>
-                                <div style={{ flex: 1, overflowY: 'auto' }}>
-                                    {comments.map((comment, i) => {
-                                        const author = commentAuthor(comment);
-                                        return (
-                                            <div key={i} style={{
-                                                display: 'flex',
-                                                alignItems: 'flex-start',
-                                                gap: '8px',
-                                                padding: '8px',
-                                                borderBottom: i < comments.length - 1 ? '1px solid #eee' : 'none',
-                                                fontSize: '0.75rem',
-                                                color: '#333',
-                                            }}>
-                                                <div style={{ flex: 1, minWidth: 0 }}>
-                                                    {author && (
-                                                        <div style={{ display: 'flex', alignItems: 'center', gap: '4px', marginBottom: '2px' }}>
-                                                            <span style={{
-                                                                width: '8px',
-                                                                height: '8px',
-                                                                borderRadius: '50%',
-                                                                backgroundColor: author.color,
-                                                                display: 'inline-block',
-                                                                flexShrink: 0,
-                                                            }} />
-                                                            <span style={{ fontWeight: 600, fontSize: '0.7rem', color: '#555' }}>
-                                                                {author.name}
-                                                            </span>
-                                                        </div>
-                                                    )}
-                                                    <span style={{ wordWrap: 'break-word' }}>
-                                                        {commentSpanText(comment)}
-                                                    </span>
-                                                </div>
-                                                <button
-                                                    onClick={() => resolveCommentAtIndex(i)}
-                                                    title="Resolve comment"
-                                                    style={{
-                                                        padding: '2px 6px',
-                                                        backgroundColor: '#f0f0f0',
-                                                        color: '#4a7ba7',
-                                                        border: '1px solid #ccc',
-                                                        borderRadius: '4px',
-                                                        fontSize: '0.7rem',
-                                                        cursor: 'pointer',
-                                                        whiteSpace: 'nowrap',
-                                                    }}
-                                                >
-                                                    ✓
-                                                </button>
-                                            </div>
-                                        );
-                                    })}
-                                </div>
-                                <div style={{ marginTop: '8px', display: 'flex', flexDirection: 'column', gap: '4px' }}>
-                                    <textarea
-                                        ref={commentInputRef}
-                                        rows={1}
-                                        value={commentText}
-                                        onChange={(e) => setCommentText(e.target.value)}
-                                        onKeyDown={(e) => {
-                                            if (e.key === 'Enter') {
-                                                e.preventDefault();
-                                                if (commentText) addComment();
-                                            }
-                                        }}
-                                        placeholder="type comment here"
-                                        style={{ padding: '7px 11px', fontFamily: 'inherit', fontSize: '0.75rem', backgroundColor: '#f0f0f0', color: '#333', border: '1px solid #ccc', borderRadius: '12px', resize: 'none', overflow: 'hidden', boxSizing: 'border-box' }}
-                                    />
-                                    <button
-                                        onClick={addComment}
-                                        disabled={!commentText}
-                                        style={{
-                                            padding: '4px 8px',
-                                            backgroundColor: '#b3d9ff',
-                                            color: '#4a7ba7',
-                                            border: '1px solid #4a7ba7',
-                                            borderRadius: '12px',
-                                            fontSize: '0.7rem',
-                                            cursor: commentText ? 'pointer' : 'default',
-                                            opacity: commentText ? 1 : 0.5,
-                                            whiteSpace: 'nowrap',
-                                            alignSelf: 'flex-end',
-                                        }}
-                                    >
-                                        add comment
-                                    </button>
-                                </div>
-                            </div>
-                        )}
                     </div>
                 </div>
             )}

--- a/ts-packages/preview-renderer/src/q2-preview/custom/CommentBlock.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/custom/CommentBlock.tsx
@@ -253,32 +253,51 @@ let collapseExpandedBubble: (() => void) | null = null;
 const BUBBLE_GAP = 4;
 type BubbleEntry = {
     el: HTMLElement | null;
+    /** Nudge in VIEWPORT px (applied as `nudge / scale` local px). */
     nudge: number;
     /** Block currently hovered — its bubble is pinned at its natural spot. */
     hovered: boolean;
+    /**
+     * Real accumulated ancestor scale, measured from the DOM in the
+     * relayout pass (reveal's getScale() proved unreliable — extra
+     * scaling exists between `.slides` and the blocks, and a wrong
+     * factor makes nudge round-trips drift). 1 outside decks.
+     */
+    scale: number;
     setNudge: (y: number) => void;
+    setScale: (s: number) => void;
 };
+
+// ---------------------------------------------------------------------
+// Deck scale. Reveal scales slides with a CSS transform, which would
+// shrink the bubbles to unreadable; `RevealScaleSync` (RevealDeck.tsx)
+// broadcasts reveal's actual scale — once the deck is ready and on
+// every reveal re-layout (viewport resize) — and the chrome
+// counter-scales by 1/scale. Stays 1 outside decks. Local translations
+// inside the scaled deck move `scale×` as far in viewport terms; the
+// relayout math converts accordingly.
+// MAGIC NUMBER: even with the deck's transform countered, bubbles on
+// slides come out visibly smaller than in regular previews (some
+// sizing channel we haven't pinned down — likely the deck theme's
+// root font size). Rather than chasing it, bump deck bubbles up by
+// this factor. Tune to taste; only applies inside decks (scale ≠ 1).
+const DECK_BUBBLE_FUDGE = 1.2;
+if (typeof window !== 'undefined') {
+    // Deck lifecycle signal (ready / resize / slidechanged + a slow
+    // tick while a deck is live): geometry may have changed wholesale
+    // — hidden sections never unmount, so slide switches don't
+    // re-register anything. Always reset-solve; the actual scale is
+    // measured per-bubble inside the pass.
+    window.addEventListener('q2-reveal-scale', () => {
+        scheduleBubbleRelayout(true);
+    });
+}
 const bubbleEntries = new Set<BubbleEntry>();
 let bubbleRelayoutScheduled = false;
 // When set, the next pass solves from NATURAL positions (full reset)
 // instead of from current nudges (push-only). OR-ed across schedule
 // calls in the same frame.
 let bubbleRelayoutReset = false;
-
-/** The translateY currently painted on the element. During a transform
- *  transition this is the in-flight value, not the target nudge — the
- *  relayout pass subtracts it to recover the natural position. */
-function appliedTranslateY(el: HTMLElement, fallback: number): number {
-    try {
-        const t = getComputedStyle(el).transform;
-        if (!t || t === 'none') return 0;
-        const m = t.match(/matrix\(([^)]+)\)/);
-        if (!m) return fallback;
-        return parseFloat(m[1].split(',')[5]) || 0;
-    } catch {
-        return fallback;
-    }
-}
 
 function scheduleBubbleRelayout(reset = false) {
     if (reset) bubbleRelayoutReset = true;
@@ -288,50 +307,101 @@ function scheduleBubbleRelayout(reset = false) {
         bubbleRelayoutScheduled = false;
         const resetPass = bubbleRelayoutReset;
         bubbleRelayoutReset = false;
-        const items = [...bubbleEntries]
-            .filter((e) => e.el)
-            .map((e) => {
-                const rect = e.el!.getBoundingClientRect();
-                // Subtract the currently painted translation to get the
-                // bubble's natural (untranslated) position.
-                const top = rect.top - appliedTranslateY(e.el!, e.nudge);
-                // HOVER PIN: the hovered bubble sits at its natural
-                // position (same spot every time, overlapping its
-                // block, ready to click) — except it may never sit
-                // above the top of the PAGE (a tall expanded bubble on
-                // the first block would otherwise be unreachable); its
-                // pin shifts down just enough. Going above the viewport
-                // top when scrolled is fine. Idle bubbles float freely.
-                const TOP_MARGIN = 8;
-                // Page-top expressed in viewport coords (rects are
-                // viewport-relative).
-                const pageTop = TOP_MARGIN - window.scrollY;
-                const pinnedTop = Math.max(top, pageTop);
-                const clamp = e.hovered ? () => pinnedTop : (y: number) => y;
-                // Idle bubbles START from their current (already-nudged)
-                // position — a relayout only ever PUSHES them further,
-                // never pulls them back (the settle phase below handles
-                // drifting home). A reset pass starts from naturals.
-                return {
-                    e,
-                    top,
-                    height: rect.height,
-                    left: rect.left,
-                    right: rect.right,
-                    cur: e.hovered ? pinnedTop : resetPass ? top : top + e.nudge,
-                    clamp,
-                    pinned: e.hovered,
-                };
-            })
-            // DOCUMENT order, not visual order: pushes are directional
-            // relative to it (earlier-in-document bubbles may only be
-            // pushed UP, later ones only DOWN), so document order can
-            // never be visually inverted by the layout.
-            .sort((a, b) =>
-                a.e.el!.compareDocumentPosition(b.e.el!) & Node.DOCUMENT_POSITION_FOLLOWING
-                    ? -1
-                    : 1,
-            );
+        // Measure every bubble's REAL accumulated ancestor scale from
+        // its (untransformed) wrapper: rect width is viewport px,
+        // offsetWidth is layout px. Synced to the component so the
+        // counter-scale transform uses the same factor the solve math
+        // does. Skipped inside display:none slides (offsetWidth 0).
+        for (const e of bubbleEntries) {
+            if (!e.el) continue;
+            const parent = e.el.parentElement;
+            if (parent && parent.offsetWidth > 0) {
+                let s = parent.getBoundingClientRect().width / parent.offsetWidth;
+                if (Math.abs(s - 1) < 0.02) s = 1;
+                if (s !== e.scale) {
+                    e.scale = s;
+                    e.setScale(s);
+                }
+            }
+        }
+
+        // Collect the solvable bubbles. Everything below runs in
+        // viewport px, for documents and decks alike.
+        type Item = {
+            e: BubbleEntry;
+            top: number;
+            height: number;
+            left: number;
+            right: number;
+            cur: number;
+            clamp: (y: number) => number;
+            pinned: boolean;
+        };
+        const items: Item[] = [];
+        for (const e of bubbleEntries) {
+            const el = e.el;
+            if (!el) continue;
+            // SLIDES: only bubbles contained in the CURRENT slide
+            // participate. Zero-size / visibility checks are NOT
+            // enough — reveal keeps nearby slides mounted for
+            // preloading (viewDistance) in states that still measure
+            // real rects, and their ghost bubbles shove the visible
+            // slide's bubbles around. `.present` is reveal's own
+            // marker for the active slide (and the active child of a
+            // vertical stack). Scoped to `.reveal` so document
+            // <section>s are unaffected.
+            const section = el.closest('.reveal section');
+            if (section && !section.classList.contains('present')) continue;
+            // Generic visibility gate (e.g. undisclosed fragments).
+            const cv = (el as { checkVisibility?: (o?: object) => boolean }).checkVisibility;
+            if (cv && !cv.call(el, { checkVisibilityCSS: true, visibilityProperty: true })) {
+                continue;
+            }
+            const parentRect = el.parentElement?.getBoundingClientRect();
+            if (!parentRect || parentRect.width === 0) continue;
+            const rect = el.getBoundingClientRect();
+            if (rect.width === 0) continue;
+            // Natural anchor derived from the UNTRANSFORMED wrapper —
+            // the chrome anchors at `top: -11px` local px above the
+            // wrapper top (keep in sync with the chrome's `top`
+            // style), × scale for viewport. Never read back from our
+            // own transform: that round-trip proved fragile.
+            const top = parentRect.top - 11 * e.scale;
+            // HOVER PIN: the hovered bubble sits at its natural
+            // position (same spot every time, overlapping its block,
+            // ready to click) — except it may never sit above the top
+            // of the PAGE (a tall expanded bubble on the first block
+            // would otherwise be unreachable); its pin shifts down
+            // just enough. Going above the viewport top when scrolled
+            // is fine. Idle bubbles float freely.
+            const TOP_MARGIN = 8;
+            const pageTop = TOP_MARGIN - window.scrollY;
+            const pinnedTop = Math.max(top, pageTop);
+            const clamp = e.hovered ? () => pinnedTop : (y: number) => y;
+            // Idle bubbles START from their current (already-nudged)
+            // position — a relayout only ever PUSHES them further,
+            // never pulls them back (the settle phase below handles
+            // drifting home). A reset pass starts from naturals.
+            items.push({
+                e,
+                top,
+                height: rect.height,
+                left: rect.left,
+                right: rect.right,
+                cur: e.hovered ? pinnedTop : resetPass ? top : top + e.nudge,
+                clamp,
+                pinned: e.hovered,
+            });
+        }
+        // DOCUMENT order, not visual order: pushes are directional
+        // relative to it (earlier-in-document bubbles may only be
+        // pushed UP, later ones only DOWN), so document order can
+        // never be visually inverted by the layout.
+        items.sort((a, b) =>
+            a.e.el!.compareDocumentPosition(b.e.el!) & Node.DOCUMENT_POSITION_FOLLOWING
+                ? -1
+                : 1,
+        );
         const overlapsH = (
             a: { left: number; right: number },
             b: { left: number; right: number },
@@ -450,6 +520,11 @@ const CommentWrapper = ({
     // neighbors; nudgeRef mirrors it for the module-level relayout pass.
     const [nudge, setNudge] = React.useState(0);
     const nudgeRef = React.useRef(0);
+    // Real ancestor scale, measured by the relayout pass (1 outside
+    // reveal decks); the chrome counter-scales by 1/scale so bubbles
+    // stay normal-sized on scaled slides.
+    const [scale, setScale] = React.useState(1);
+    const scaleRef = React.useRef(1);
     const chromeRef = React.useRef<HTMLDivElement>(null);
     // Mirror of isHovered for the registry (re-registrations read it),
     // plus the live entry so hover changes can update it in place.
@@ -654,9 +729,14 @@ const CommentWrapper = ({
             el: chromeRef.current,
             nudge: nudgeRef.current,
             hovered: isHoveredRef.current,
+            scale: scaleRef.current,
             setNudge: (y) => {
                 nudgeRef.current = y;
                 setNudge(y);
+            },
+            setScale: (s) => {
+                scaleRef.current = s;
+                setScale(s);
             },
         };
         entryRef.current = entry;
@@ -723,7 +803,12 @@ const CommentWrapper = ({
                         position: 'absolute',
                         top: '-11px',
                         right: '-10px',
-                        transform: `translateY(${nudge}px)`,
+                        // Nudge is viewport px → local px via /scale;
+                        // the counter-scale keeps the bubble at normal
+                        // size inside scaled reveal slides (plus the
+                        // fudge factor — see DECK_BUBBLE_FUDGE).
+                        transform: `translateY(${nudge / scale}px) scale(${scale === 1 ? 1 : DECK_BUBBLE_FUDGE / scale})`,
+                        transformOrigin: 'top right',
                         // Animate nudge changes; the relayout pass reads
                         // the in-flight translation, so mid-animation
                         // reflows stay correct.

--- a/ts-packages/preview-renderer/src/q2-preview/custom/CommentBlock.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/custom/CommentBlock.tsx
@@ -1,16 +1,29 @@
 /**
- * Default comment chrome for q2-preview blocks. Promoted from the
- * render-components-comment playwright fixture
- * (`crates/quarto/tests/playwright-fixtures/q2-preview/render-components-comment/comment.tsx`)
- * so every preview gets it without a user render-components file.
+ * Default comment chrome for q2-preview blocks.
  *
- * Extracts `quarto-edit-comment` spans out of a Para/Header's inlines
- * before rendering and shows them as corner chrome: a comment-count
- * button opening a list with per-comment "Resolve" (delete) and an
- * add-comment input. The chrome only appears while hovering the block,
- * unless the block already has comments. Adds/resolves round-trip
- * through `usePreviewEdit().commitSubtreeEdit`, which is a no-op where
- * `PreviewContext` is absent.
+ * Comments are `[>> ...]` editorial-mark spans (class
+ * `quarto-edit-comment`) stored inline in the block's own source. This
+ * component extracts them before rendering and shows them as a small
+ * "bubble" anchored to the block's bottom-right corner:
+ *
+ *  - Compact bubble ('show' mode): first comment preview + "+n more";
+ *    a comment-less block shows a "+" add affordance on hover.
+ *  - Expanded bubble (global 'expand' mode, or any bubble clicked
+ *    open): every comment as its own row with author dot (when the
+ *    Authors overlay provides attribution), a ✓ resolve button, and an
+ *    inline add-comment input at the bottom.
+ *  - 'hide' mode strips comments from the text but renders no chrome.
+ *
+ * The three-way mode arrives via `PreviewContext.commentsMode` from the
+ * host toolbar. Adds/resolves round-trip through
+ * `usePreviewEdit().commitSubtreeEdit` (no-ops where `PreviewContext`
+ * is absent). Blocks without an inline slot (code blocks, incl.
+ * mermaid) get wrapped in a `CONTAINER_CLASS` Div holding the comment
+ * paragraphs; the Div owns the thread's single bubble and its children
+ * render chrome-free.
+ *
+ * Overlapping bubbles are kept apart by a tiny force layout (see the
+ * "force layout" section below).
  *
  * Registered as the `Block` entry in `registry.ts`. Delegates actual
  * block rendering to the `dispatchers.tsx` `Block` dispatcher, so edit
@@ -37,10 +50,14 @@ import { PreviewContext } from '../PreviewContext';
 import type { CommentsMode } from '../PreviewContext';
 import { usePreviewEdit } from '../usePreviewEdit';
 
+// Shared palette bits.
+const CHROME_BLUE = '#4a7ba7';
+const DIVIDER = '1px solid rgba(74, 123, 167, 0.3)';
+const GLOW = '0 0 8px 2px rgba(140, 190, 240, 0.6)';
+
 function isComment(inline: InlineNode): boolean {
     if (inline.t === 'Span' && 'c' in inline) {
-        const attrs = (inline as SpanInline).c[0];
-        const classes = attrs[1];
+        const classes = (inline as SpanInline).c[0][1];
         return classes.includes('quarto-edit-comment');
     }
     return false;
@@ -61,7 +78,21 @@ function isCommentContainer(block: BlockNode): boolean {
 
 const InsideCommentContainer = React.createContext(false);
 
-// Light blue placeholder tint for the comment inputs — ::placeholder
+/**
+ * The mutable inline array where a block's comment spans live, or null
+ * when the block type has no inline slot. (Casts because the BlockNode
+ * union includes `UnknownBlock { t: string }`, which defeats
+ * discriminant narrowing.)
+ */
+function inlineSlot(block: BlockNode): InlineNode[] | null {
+    if (block.t === 'Para' || block.t === 'Plain') {
+        return (block as ParaBlock | PlainBlock).c;
+    }
+    if (block.t === 'Header') return (block as HeaderBlock).c[2];
+    return null;
+}
+
+// Light blue placeholder tint for the comment input — ::placeholder
 // isn't reachable from inline styles, so inject one tiny rule per
 // document (idempotent).
 (() => {
@@ -80,7 +111,7 @@ const InsideCommentContainer = React.createContext(false);
  * mismatch means the rendered block is a transform product — a figure
  * caption resolving to the whole `Figure`, a definition-list item
  * resolving to the `DefinitionList` — whose source form the qmd writer
- * would rewrite lossily (bd: figures became `::: {#fig-..}` divs,
+ * would rewrite lossily (figures became `::: {#fig-..}` divs,
  * `::: {.definition-list}` sugar became bare `term\n:   def` syntax).
  * Refuse to touch those.
  */
@@ -116,27 +147,26 @@ export const CommentBlock = (args: NodeArgs<BlockNode>) => {
         React.useContext(PreviewContext)?.commentsMode ?? 'show';
     const { node: block, onNavigateToDocument, setLocalAst } = args;
 
-    // Children of a comment container defer to the container's bubble.
-    if (insideContainer) {
-        return <B node={block} onNavigateToDocument={onNavigateToDocument} setLocalAst={setLocalAst} />;
-    }
+    const passthrough = (
+        <B node={block} onNavigateToDocument={onNavigateToDocument} setLocalAst={setLocalAst} />
+    );
 
+    // Children of a comment container defer to the container's bubble.
+    if (insideContainer) return passthrough;
+
+    // Extract this block's comment spans and build a stripped copy for
+    // rendering. Blocks without comments render as-is (no clone).
     let comments: InlineNode[] = [];
     let newBlock = block;
-    // Casts: the BlockNode union includes `UnknownBlock { t: string }`,
-    // which defeats discriminant narrowing on `block.t`.
-    if (block.t === 'Para' || block.t === 'Plain') {
-        const b = block as ParaBlock | PlainBlock;
-        comments = b.c.filter(isComment);
-        const clone = structuredClone(b);
-        clone.c = b.c.filter((n) => !isComment(n));
-        newBlock = clone;
-    } else if (block.t === 'Header') {
-        const b = block as HeaderBlock;
-        comments = b.c[2].filter(isComment);
-        const clone = structuredClone(b);
-        clone.c[2] = b.c[2].filter((n) => !isComment(n));
-        newBlock = clone;
+    const slot = inlineSlot(block);
+    if (slot) {
+        comments = slot.filter(isComment);
+        if (comments.length > 0) {
+            const clone = structuredClone(block);
+            const cloneSlot = inlineSlot(clone)!;
+            cloneSlot.splice(0, cloneSlot.length, ...slot.filter((n) => !isComment(n)));
+            newBlock = clone;
+        }
     } else if (isCommentContainer(block)) {
         // Collect comment spans from the container's paragraphs and
         // strip them (dropping paragraphs that were nothing but
@@ -144,11 +174,11 @@ export const CommentBlock = (args: NodeArgs<BlockNode>) => {
         const clone = structuredClone(block) as DivBlock;
         const kept: BlockNode[] = [];
         for (const child of clone.c[1]) {
-            if (child.t === 'Para' || child.t === 'Plain') {
-                const p = child as ParaBlock | PlainBlock;
-                comments.push(...p.c.filter(isComment));
-                p.c = p.c.filter((n) => !isComment(n));
-                if (p.c.length === 0) continue;
+            const childSlot = inlineSlot(child);
+            if (childSlot) {
+                comments.push(...childSlot.filter(isComment));
+                childSlot.splice(0, childSlot.length, ...childSlot.filter((n) => !isComment(n)));
+                if (childSlot.length === 0) continue;
             }
             kept.push(child);
         }
@@ -163,15 +193,16 @@ export const CommentBlock = (args: NodeArgs<BlockNode>) => {
     // covers essentially everything hoverable/editable; other block
     // types (lists as a whole, tables, ...) render plain.
     const canHoldComment =
-        block.t === 'Para' || block.t === 'Plain' || block.t === 'Header' ||
-        block.t === 'CodeBlock' || isCommentContainer(block);
-    if (!canHoldComment) {
-        return <B node={block} onNavigateToDocument={onNavigateToDocument} setLocalAst={setLocalAst} />;
-    }
+        slot !== null || block.t === 'CodeBlock' || isCommentContainer(block);
+    if (!canHoldComment) return passthrough;
 
     // Commenting on figures, definition lists, and table cells is
-    // BUSTED right now. Writing Figures cause broken syntax, 
-    // writing definition lists cause broke syntax, table cells just dont write.
+    // BUSTED right now: committing a Figure or DefinitionList source
+    // node re-serializes it lossily (broken syntax), and table cells
+    // are Opaque (writes never land). Hide the bubble there entirely —
+    // addComment/resolveCommentAtIndex refuse the same cases as a
+    // backstop. Blocks that already carry comments keep their bubble
+    // for read-only display.
     if (comments.length === 0) {
         const resolved = edit.resolveSource(block);
         if (
@@ -179,14 +210,14 @@ export const CommentBlock = (args: NodeArgs<BlockNode>) => {
             resolved.reachabilityClass === 'Opaque' ||
             !sameCommentableKind(block, resolved.sourceNode)
         ) {
-            return <B node={block} onNavigateToDocument={onNavigateToDocument} setLocalAst={setLocalAst} />;
+            return passthrough;
         }
     }
 
     const inner = (
         <B node={newBlock} onNavigateToDocument={onNavigateToDocument} setLocalAst={setLocalAst} />
     );
-    const maybeProvided = isCommentContainer(block) ? (
+    const content = isCommentContainer(block) ? (
         <InsideCommentContainer.Provider value={true}>
             {inner}
         </InsideCommentContainer.Provider>
@@ -195,26 +226,30 @@ export const CommentBlock = (args: NodeArgs<BlockNode>) => {
     );
     // 'hide' mode: comments stay stripped from the text, but no chrome
     // (and no wrapper div) renders at all.
-    if (mode === 'hide') {
-        return maybeProvided;
-    }
+    if (mode === 'hide') return content;
     return (
         <CommentWrapper comments={comments} block={block} edit={edit} mode={mode}>
-            {maybeProvided}
+            {content}
         </CommentWrapper>
     );
 };
 
 type EditHandle = ReturnType<typeof usePreviewEdit>;
 
-// Only one comments popup may be open at a time. Whichever popup opens
-// closes the previously open one via this module-level latch.
-let closeOpenPopup: (() => void) | null = null;
+// Only one self-expanded bubble at a time: expanding one collapses the
+// previously expanded one via this module-level latch.
+let collapseExpandedBubble: (() => void) | null = null;
 
 // ---------------------------------------------------------------------
-// Tiny force layout: visible bubbles register here; after any of them
-// mounts/unmounts, a rAF pass sorts them by natural position and nudges
-// later ones down (translateY) just enough to clear earlier ones.
+// Tiny force layout. Visible bubbles register here; a batched rAF pass
+// keeps them from overlapping, under these rules:
+//  - the hovered bubble is pinned at its natural spot (nudged below the
+//    viewport top if needed) and everything else moves around it;
+//  - pushes are directional in DOCUMENT order (earlier bubbles only get
+//    pushed up, later ones only down), so bubbles never reorder;
+//  - idle bubbles keep their displacement between passes (push-only),
+//    but drift back toward natural whenever free space allows;
+//  - a comments-mode switch does a full reset solve from naturals.
 const BUBBLE_GAP = 4;
 type BubbleEntry = {
     el: HTMLElement | null;
@@ -225,6 +260,10 @@ type BubbleEntry = {
 };
 const bubbleEntries = new Set<BubbleEntry>();
 let bubbleRelayoutScheduled = false;
+// When set, the next pass solves from NATURAL positions (full reset)
+// instead of from current nudges (push-only). OR-ed across schedule
+// calls in the same frame.
+let bubbleRelayoutReset = false;
 
 /** The translateY currently painted on the element. During a transform
  *  transition this is the in-flight value, not the target nudge — the
@@ -241,11 +280,14 @@ function appliedTranslateY(el: HTMLElement, fallback: number): number {
     }
 }
 
-function scheduleBubbleRelayout() {
+function scheduleBubbleRelayout(reset = false) {
+    if (reset) bubbleRelayoutReset = true;
     if (bubbleRelayoutScheduled) return;
     bubbleRelayoutScheduled = true;
     requestAnimationFrame(() => {
         bubbleRelayoutScheduled = false;
+        const resetPass = bubbleRelayoutReset;
+        bubbleRelayoutReset = false;
         const items = [...bubbleEntries]
             .filter((e) => e.el)
             .map((e) => {
@@ -253,36 +295,58 @@ function scheduleBubbleRelayout() {
                 // Subtract the currently painted translation to get the
                 // bubble's natural (untranslated) position.
                 const top = rect.top - appliedTranslateY(e.el!, e.nudge);
-                const height = rect.height;
-                // HOVER PIN: while its block is hovered, the bubble is
-                // pinned at its exact natural position (always the same
-                // spot, overlapping its block, ready to click); the
-                // relaxation pushes every other bubble around it. Idle
-                // bubbles float freely to resolve overlaps, EXCEPT they
-                // may never be pushed above the viewport top (a bubble
-                // whose natural spot is already above it stays put —
-                // the floor only limits upward nudging).
+                // HOVER PIN: the hovered bubble sits at its natural
+                // position (same spot every time, overlapping its
+                // block, ready to click) — except it may never sit
+                // above the top of the PAGE (a tall expanded bubble on
+                // the first block would otherwise be unreachable); its
+                // pin shifts down just enough. Going above the viewport
+                // top when scrolled is fine. Idle bubbles float freely.
                 const TOP_MARGIN = 8;
-                const floor = Math.min(top, TOP_MARGIN);
-                const clamp = e.hovered
-                    ? () => top
-                    : (y: number) => Math.max(y, floor);
-                return { e, top, height, left: rect.left, right: rect.right, cur: top, clamp };
+                // Page-top expressed in viewport coords (rects are
+                // viewport-relative).
+                const pageTop = TOP_MARGIN - window.scrollY;
+                const pinnedTop = Math.max(top, pageTop);
+                const clamp = e.hovered ? () => pinnedTop : (y: number) => y;
+                // Idle bubbles START from their current (already-nudged)
+                // position — a relayout only ever PUSHES them further,
+                // never pulls them back (the settle phase below handles
+                // drifting home). A reset pass starts from naturals.
+                return {
+                    e,
+                    top,
+                    height: rect.height,
+                    left: rect.left,
+                    right: rect.right,
+                    cur: e.hovered ? pinnedTop : resetPass ? top : top + e.nudge,
+                    clamp,
+                    pinned: e.hovered,
+                };
             })
-            .sort((a, b) => a.top - b.top);
+            // DOCUMENT order, not visual order: pushes are directional
+            // relative to it (earlier-in-document bubbles may only be
+            // pushed UP, later ones only DOWN), so document order can
+            // never be visually inverted by the layout.
+            .sort((a, b) =>
+                a.e.el!.compareDocumentPosition(b.e.el!) & Node.DOCUMENT_POSITION_FOLLOWING
+                    ? -1
+                    : 1,
+            );
+        const overlapsH = (
+            a: { left: number; right: number },
+            b: { left: number; right: number },
+        ) => a.left < b.right && b.left < a.right;
         // Iterative relaxation: each overlapping pair splits the push —
-        // the earlier bubble moves up, the later one down — clamped to
-        // each bubble's own-block range. When one side hits its clamp,
-        // later rounds shift the remaining overlap onto the other side,
-        // so the earlier bubble keeps moving up as far as it's allowed.
-        for (let iter = 0; iter < 20; iter++) {
+        // the earlier-in-document bubble moves up, the later one down —
+        // clamped to the hover pin. When one side hits its clamp, later
+        // rounds shift the remaining overlap onto the other side.
+        for (let iter = 0; iter < 40; iter++) {
             let moved = false;
             for (let i = 0; i < items.length; i++) {
                 for (let j = i + 1; j < items.length; j++) {
                     const a = items[i];
                     const b = items[j];
-                    const overlapsH = a.left < b.right && b.left < a.right;
-                    if (!overlapsH) continue;
+                    if (!overlapsH(a, b)) continue;
                     const overlap = a.cur + a.height + BUBBLE_GAP - b.cur;
                     if (overlap > 0) {
                         const aBefore = a.cur;
@@ -302,6 +366,49 @@ function scheduleBubbleRelayout() {
                 }
             }
             if (!moved) break;
+        }
+        // Settle: bubbles with free space drift back toward their
+        // natural position — as far as they can WITHOUT pushing
+        // anything (each move only respects neighbors where they
+        // currently are; document order is preserved by keeping
+        // earlier-in-document neighbors above / later ones below).
+        for (let iter = 0; iter < 10; iter++) {
+            let moved = false;
+            for (let i = 0; i < items.length; i++) {
+                const x = items[i];
+                if (x.pinned) continue;
+                let lo = -Infinity;
+                let hi = Infinity;
+                for (let j = 0; j < items.length; j++) {
+                    if (j === i) continue;
+                    const o = items[j];
+                    if (!overlapsH(x, o)) continue;
+                    if (j < i) lo = Math.max(lo, o.cur + o.height + BUBBLE_GAP);
+                    else hi = Math.min(hi, o.cur - x.height - BUBBLE_GAP);
+                }
+                if (lo > hi) continue; // boxed in — stay put
+                const desired = Math.min(Math.max(x.top, lo), hi);
+                if (Math.abs(desired - x.cur) > 0.5) {
+                    x.cur = desired;
+                    moved = true;
+                }
+            }
+            if (!moved) break;
+        }
+        // Hard no-reorder guarantee: if clamp interactions left any
+        // h-overlapping pair visually inverted (later-in-document
+        // bubble above an earlier one), push the later bubble DOWN to
+        // clear it — the one direction the rule always allows. Skips
+        // pinned bubbles (they never move).
+        for (let i = 0; i < items.length; i++) {
+            for (let j = i + 1; j < items.length; j++) {
+                const a = items[i];
+                const b = items[j];
+                if (!overlapsH(a, b) || b.pinned) continue;
+                if (b.cur < a.cur) {
+                    b.cur = a.cur + a.height + BUBBLE_GAP;
+                }
+            }
         }
         for (const it of items) {
             const nudge = Math.round(it.cur - it.top);
@@ -327,12 +434,15 @@ const CommentWrapper = ({
     mode: CommentsMode;
 }) => {
     const [commentText, setCommentText] = React.useState('');
-    // No modal: clicking a compact bubble expands it in place (with the
-    // inline add-comment input open at its bottom).
+    // Clicking a compact bubble expands it in place (with the inline
+    // add-comment input open at its bottom).
     const [selfExpanded, setSelfExpanded] = React.useState(false);
     const [showInlineInput, setShowInlineInput] = React.useState(false);
     const inlineInputRef = React.useRef<HTMLTextAreaElement>(null);
     const [isHovered, setIsHovered] = React.useState(false);
+    // Hovering the bubble itself glows the block (mirror of the
+    // block-hover → bubble-glow effect).
+    const [bubbleHovered, setBubbleHovered] = React.useState(false);
     // Global 'expand' mode expands every commented bubble; a click
     // self-expands one bubble in any mode.
     const expanded = (mode === 'expand' && comments.length > 0) || selfExpanded;
@@ -345,8 +455,7 @@ const CommentWrapper = ({
     // plus the live entry so hover changes can update it in place.
     const isHoveredRef = React.useRef(false);
     const entryRef = React.useRef<BubbleEntry | null>(null);
-
-    const commentsListRef = React.useRef<HTMLDivElement>(null);
+    const bubbleRef = React.useRef<HTMLDivElement>(null);
 
     // Per-comment authorship, resolved from the comment span's source
     // pool id (`s`). The lookup is only populated when the host provides
@@ -398,7 +507,7 @@ const CommentWrapper = ({
     React.useEffect(() => {
         if (!showInlineInput && !selfExpanded) return;
         const handleClickOutside = (event: MouseEvent) => {
-            if (commentsListRef.current && !commentsListRef.current.contains(event.target as Node)) {
+            if (bubbleRef.current && !bubbleRef.current.contains(event.target as Node)) {
                 setShowInlineInput(false);
                 setSelfExpanded(false);
             }
@@ -407,31 +516,40 @@ const CommentWrapper = ({
         return () => { document.removeEventListener('mousedown', handleClickOutside); };
     }, [showInlineInput, selfExpanded]);
 
-    // Only one self-expanded bubble at a time: expanding one collapses
-    // the previously expanded one via the module-level latch.
+    // Only one self-expanded bubble at a time (module-level latch).
     React.useEffect(() => {
         if (!selfExpanded) return;
-        closeOpenPopup?.();
-        const close = () => {
+        collapseExpandedBubble?.();
+        const collapse = () => {
             setSelfExpanded(false);
             setShowInlineInput(false);
         };
-        closeOpenPopup = close;
+        collapseExpandedBubble = collapse;
         return () => {
-            if (closeOpenPopup === close) closeOpenPopup = null;
+            if (collapseExpandedBubble === collapse) collapseExpandedBubble = null;
         };
     }, [selfExpanded]);
+
+    /**
+     * Resolve the block to a committable source node. Null when
+     * commenting here would corrupt the source: table cells resolve as
+     * Opaque (the edit system can't commit there — same reason they
+     * aren't click-editable), and transform products (figure captions →
+     * Figure, def-list items → DefinitionList) round-trip lossily.
+     */
+    const resolveCommittable = () => {
+        const resolved = edit.resolveSource(block);
+        if (!resolved) return null;
+        if (resolved.reachabilityClass === 'Opaque') return null;
+        if (!sameCommentableKind(block, resolved.sourceNode)) return null;
+        return resolved;
+    };
 
     // Remove the index-th comment span (counting comment spans only,
     // in order) from the source node and commit.
     const resolveCommentAtIndex = (index: number): void => {
-        const resolved = edit.resolveSource(block);
+        const resolved = resolveCommittable();
         if (!resolved) return;
-        // Same safety gates as addComment: no structurally unreachable
-        // targets (table cells), no transform products the writer
-        // would re-serialize lossily (figures, definition lists).
-        if (resolved.reachabilityClass === 'Opaque') return;
-        if (!sameCommentableKind(block, resolved.sourceNode)) return;
         const modified = structuredClone(resolved.sourceNode);
         const removeNth = (arr: InlineNode[]) => {
             let seen = -1;
@@ -445,10 +563,9 @@ const CommentWrapper = ({
                 }
             }
         };
-        if (modified.t === 'Para' || modified.t === 'Plain') {
-            removeNth((modified as ParaBlock | PlainBlock).c);
-        } else if (modified.t === 'Header') {
-            removeNth((modified as HeaderBlock).c[2]);
+        const slot = inlineSlot(modified);
+        if (slot) {
+            removeNth(slot);
         } else if (isCommentContainer(modified)) {
             // Comments live across the container's paragraphs; count
             // them in order, remove the index-th, and drop a paragraph
@@ -457,9 +574,8 @@ const CommentWrapper = ({
             let seen = -1;
             outer:
             for (let ci = 0; ci < children.length; ci++) {
-                const ch = children[ci];
-                if (ch.t !== 'Para' && ch.t !== 'Plain') continue;
-                const arr = (ch as ParaBlock | PlainBlock).c;
+                const arr = inlineSlot(children[ci]);
+                if (!arr) continue;
                 for (let i = 0; i < arr.length; i++) {
                     if (isComment(arr[i])) {
                         seen++;
@@ -473,10 +589,8 @@ const CommentWrapper = ({
             }
             // Last comment resolved with a single wrapped block left →
             // unwrap: commit the bare block in place of the container.
-            const anyLeft = children.some(
-                (ch) =>
-                    (ch.t === 'Para' || ch.t === 'Plain') &&
-                    (ch as ParaBlock | PlainBlock).c.some(isComment),
+            const anyLeft = children.some((ch) =>
+                (inlineSlot(ch) ?? []).some(isComment),
             );
             if (!anyLeft && children.length === 1) {
                 edit.commitSubtreeEdit(JSON.stringify(resolved.sourceEntry), children[0]);
@@ -488,24 +602,16 @@ const CommentWrapper = ({
 
     // Append a comment span to the source node and commit.
     const addComment = () => {
-        const resolved = edit.resolveSource(block);
+        const resolved = resolveCommittable();
         if (!resolved) return;
-        // Safety gates: table cells resolve as Opaque (the edit system
-        // can't commit there — same reason they aren't click-editable),
-        // and transform products (figure captions → Figure, def-list
-        // items → DefinitionList) would round-trip lossily. Bail
-        // silently rather than corrupt the source.
-        if (resolved.reachabilityClass === 'Opaque') return;
-        if (!sameCommentableKind(block, resolved.sourceNode)) return;
         const modified = structuredClone(resolved.sourceNode);
         const newComment: SpanInline = {
             t: 'Span',
             c: [['', ['quarto-edit-comment'], []], [{ t: 'Str', c: commentText }]],
         };
-        if (modified.t === 'Para' || modified.t === 'Plain') {
-            (modified as ParaBlock | PlainBlock).c.push(newComment);
-        } else if (modified.t === 'Header') {
-            (modified as HeaderBlock).c[2].push(newComment);
+        const slot = inlineSlot(modified);
+        if (slot) {
+            slot.push(newComment);
         } else if (modified.t === 'CodeBlock') {
             // A code block can't hold an inline span: wrap it in a
             // comment container Div with the comment as a `[>> ...]`
@@ -524,13 +630,11 @@ const CommentWrapper = ({
             // Append to the container's last comment paragraph, or add
             // a fresh one at the end.
             const children = (modified as DivBlock).c[1];
-            const lastCommentPara = [...children].reverse().find(
-                (ch) =>
-                    (ch.t === 'Para' || ch.t === 'Plain') &&
-                    (ch as ParaBlock | PlainBlock).c.some(isComment),
+            const lastCommentPara = [...children].reverse().find((ch) =>
+                (inlineSlot(ch) ?? []).some(isComment),
             );
             if (lastCommentPara) {
-                (lastCommentPara as ParaBlock | PlainBlock).c.push(newComment);
+                inlineSlot(lastCommentPara)!.push(newComment);
             } else {
                 children.push({ t: 'Para', c: [newComment] } as ParaBlock);
             }
@@ -539,11 +643,11 @@ const CommentWrapper = ({
         setCommentText('');
     };
 
-    const hasContent = comments.length > 0;
-    const chromeVisible = hasContent || isHovered || selfExpanded;
+    const chromeVisible = comments.length > 0 || isHovered || selfExpanded;
 
-    // Register this bubble with the force layout while visible; any
-    // mount/unmount (including hover chrome) reflows all bubbles.
+    // Register this bubble with the force layout while visible. Mounts
+    // (and size changes via the deps) reflow; unmounts deliberately
+    // don't — a disappearing bubble leaves the arrangement as-is.
     React.useLayoutEffect(() => {
         if (!chromeVisible) return;
         const entry: BubbleEntry = {
@@ -561,26 +665,49 @@ const CommentWrapper = ({
         return () => {
             entryRef.current = null;
             bubbleEntries.delete(entry);
-            scheduleBubbleRelayout();
         };
         // expanded/showInlineInput change the bubble's size — re-register
         // so the force layout re-measures.
     }, [chromeVisible, comments.length, expanded, showInlineInput]);
 
-    // Sync hover into the registry entry — the own-block clamp only
-    // applies while the block is hovered, and hover changes reflow.
+    // Sync hover into the registry entry. Re-layout on hover START
+    // only: un-hovering keeps the arrangement as-is (it persists until
+    // the next hover or a new bubble mounts).
     React.useEffect(() => {
         isHoveredRef.current = isHovered;
         if (entryRef.current && entryRef.current.hovered !== isHovered) {
             entryRef.current.hovered = isHovered;
-            scheduleBubbleRelayout();
+            if (isHovered) scheduleBubbleRelayout();
         }
     }, [isHovered]);
 
+    // Switching comments mode (e.g. back to un-expanded view) does a
+    // full reset solve: bubbles return to their proper positions
+    // instead of keeping accumulated push-only displacement.
+    const prevModeRef = React.useRef(mode);
+    React.useEffect(() => {
+        if (prevModeRef.current !== mode) {
+            prevModeRef.current = mode;
+            scheduleBubbleRelayout(true);
+        }
+    }, [mode]);
+
     return (
         <div
-            style={{ position: 'relative' }}
-            onMouseEnter={() => setIsHovered(true)}
+            style={{
+                position: 'relative',
+                // Bubble hover glows the block, tying the two together.
+                boxShadow: bubbleHovered ? GLOW : 'none',
+                transition: 'box-shadow 0.15s',
+            }}
+            // Only the RIGHT half of the block counts as hover (the
+            // bubble lives at the right edge) — mousing across the left
+            // half while reading doesn't reveal chrome or reshuffle the
+            // bubble layout.
+            onMouseMove={(e) => {
+                const rect = e.currentTarget.getBoundingClientRect();
+                setIsHovered(e.clientX >= rect.left + rect.width / 2);
+            }}
             onMouseLeave={() => setIsHovered(false)}
         >
             {/* Chrome renders BEFORE the content: mounting it as a
@@ -601,10 +728,6 @@ const CommentWrapper = ({
                         // the in-flight translation, so mid-animation
                         // reflows stay correct.
                         transition: 'transform 0.15s ease-out',
-                        display: 'flex',
-                        flexDirection: 'row',
-                        gap: '4px',
-                        alignItems: 'center',
                         // The bubble hangs below the block's box, into
                         // the next (positioned) sibling wrapper — lift
                         // it above so it wins hit-testing there. A
@@ -615,11 +738,11 @@ const CommentWrapper = ({
                     // Keep chrome interactions away from the delegated
                     // click-to-edit handler on the document root —
                     // otherwise clicking the bubble/input activates the
-                    // enclosing block's editor.
-                    // Marks this chrome as owning its focus: the block
-                    // editors see it on blur relatedTarget and skip
-                    // their focus-restore (which would steal focus back
-                    // from the comment input).
+                    // enclosing block's editor. `data-q2-owns-focus`
+                    // additionally marks this chrome as owning its
+                    // focus: the block editors see it on blur
+                    // relatedTarget and skip the focus-restore that
+                    // would steal focus back from the comment input.
                     data-q2-owns-focus=""
                     onPointerDown={(e) => e.stopPropagation()}
                     onPointerUp={(e) => e.stopPropagation()}
@@ -627,7 +750,7 @@ const CommentWrapper = ({
                         e.stopPropagation();
                         // Clicking non-interactive chrome (the bubble)
                         // must not blur an open block editor — the
-                        // modal takes focus itself once open.
+                        // bubble's input takes focus itself once open.
                         if (!(e.target as HTMLElement).closest('input, textarea, button')) {
                             e.preventDefault();
                         }
@@ -635,110 +758,101 @@ const CommentWrapper = ({
                     onClick={(e) => e.stopPropagation()}
                     onKeyDown={(e) => e.stopPropagation()}
                 >
-                    <div ref={commentsListRef} style={{ position: 'relative' }}>
-                        <div
-                            style={{
-                                // Near-white with just a hint of blue.
-                                backgroundColor: '#f7faff',
-                                color: '#4a7ba7',
-                                padding: '2px 6px',
-                                borderRadius: '5px',
-                                border: '1px solid #4a7ba7',
-                                fontSize: '0.7rem',
-                                cursor: 'pointer',
-                                // Block hover puts an offset-free light
-                                // blue glow on the bubble.
-                                boxShadow: isHovered
-                                    ? '0 0 8px 2px rgba(140, 190, 240, 0.6)'
-                                    : '0 2px 4px rgba(0,0,0,0.2)',
-                                transition: 'box-shadow 0.15s',
-                                userSelect: 'none',
-                            }}
-                            onClick={() => {
-                                // Clicking a compact bubble expands it
-                                // in place; any click opens the inline
-                                // add-comment input.
-                                if (!expanded) setSelfExpanded(true);
-                                setShowInlineInput(true);
-                            }}
-                            title={`${comments.length} comment${comments.length !== 1 ? 's' : ''}`}
-                        >
-                            {/* An expanded bubble (global 'expand' mode or
-                                clicked-open) lists every comment as its own
-                                row with dividers, plus the inline input; a
-                                compact bubble previews the first comment
-                                and sums the rest as "+n more". A
-                                comment-less compact bubble is just the "+"
-                                add affordance. */}
-                            {comments.length === 0 && !expanded ? (
-                                <div>+</div>
-                            ) : expanded ? (
-                                <>
+                    <div
+                        ref={bubbleRef}
+                        style={{
+                            // Near-white with just a hint of blue.
+                            backgroundColor: '#f7faff',
+                            color: CHROME_BLUE,
+                            padding: '2px 6px',
+                            borderRadius: '5px',
+                            border: `1px solid ${CHROME_BLUE}`,
+                            fontSize: '0.7rem',
+                            cursor: 'pointer',
+                            // Block hover puts an offset-free light
+                            // blue glow on the bubble.
+                            boxShadow: isHovered ? GLOW : '0 2px 4px rgba(0,0,0,0.2)',
+                            transition: 'box-shadow 0.15s',
+                            userSelect: 'none',
+                        }}
+                        onClick={() => {
+                            // Clicking a compact bubble expands it in
+                            // place; any click opens the inline input.
+                            if (!expanded) setSelfExpanded(true);
+                            setShowInlineInput(true);
+                        }}
+                        onMouseEnter={() => setBubbleHovered(true)}
+                        onMouseLeave={() => setBubbleHovered(false)}
+                        title={`${comments.length} comment${comments.length !== 1 ? 's' : ''}`}
+                    >
+                        {comments.length === 0 && !expanded ? (
+                            <div>+</div>
+                        ) : expanded ? (
+                            <>
                                 {comments.map((c, i) => {
                                     const author = commentAuthor(c);
                                     return (
-                                    <div key={i} style={{
-                                        display: 'flex',
-                                        alignItems: 'center',
-                                        gap: '6px',
-                                        padding: '3px 2px',
-                                        borderBottom: i < comments.length - 1
-                                            ? '1px solid rgba(74, 123, 167, 0.3)'
-                                            : 'none',
-                                    }}>
-                                        {author && (
-                                            <span
-                                                title={author.name}
-                                                style={{
-                                                    width: '8px',
-                                                    height: '8px',
-                                                    borderRadius: '50%',
-                                                    backgroundColor: author.color,
-                                                    display: 'inline-block',
-                                                    flexShrink: 0,
-                                                }}
-                                            />
-                                        )}
-                                        <span style={{
-                                            flex: 1,
-                                            minWidth: 0,
-                                            maxWidth: '160px',
-                                            overflow: 'hidden',
-                                            whiteSpace: 'nowrap',
-                                            textOverflow: 'ellipsis',
+                                        <div key={i} style={{
+                                            display: 'flex',
+                                            alignItems: 'flex-start',
+                                            gap: '6px',
+                                            padding: '3px 2px',
+                                            borderBottom: i < comments.length - 1 ? DIVIDER : 'none',
                                         }}>
-                                            {commentSpanText(c)}
-                                        </span>
-                                        <button
-                                            onClick={(ev) => {
-                                                // Resolve without toggling
-                                                // the modal (bubble onClick).
-                                                ev.stopPropagation();
-                                                resolveCommentAtIndex(i);
-                                            }}
-                                            title="Resolve comment"
-                                            style={{
-                                                padding: '0 4px',
-                                                backgroundColor: 'transparent',
-                                                color: '#4a7ba7',
-                                                border: '1px solid #b3d9ff',
-                                                borderRadius: '4px',
-                                                fontSize: '0.65rem',
-                                                cursor: 'pointer',
-                                                flexShrink: 0,
-                                                transition: 'background-color 0.15s',
-                                            }}
-                                            onMouseEnter={(ev) => ev.currentTarget.style.backgroundColor = '#d4e8ff'}
-                                            onMouseLeave={(ev) => ev.currentTarget.style.backgroundColor = 'transparent'}
-                                        >
-                                            ✓
-                                        </button>
-                                    </div>
+                                            {author && (
+                                                <span
+                                                    title={author.name}
+                                                    style={{
+                                                        width: '8px',
+                                                        height: '8px',
+                                                        borderRadius: '50%',
+                                                        backgroundColor: author.color,
+                                                        display: 'inline-block',
+                                                        flexShrink: 0,
+                                                        // Align with the first text line.
+                                                        marginTop: '3px',
+                                                    }}
+                                                />
+                                            )}
+                                            <span style={{
+                                                flex: 1,
+                                                minWidth: 0,
+                                                maxWidth: '160px',
+                                                overflowWrap: 'break-word',
+                                            }}>
+                                                {commentSpanText(c)}
+                                            </span>
+                                            <button
+                                                onClick={(ev) => {
+                                                    // Resolve without also
+                                                    // triggering the bubble's
+                                                    // own click handler.
+                                                    ev.stopPropagation();
+                                                    resolveCommentAtIndex(i);
+                                                }}
+                                                title="Resolve comment"
+                                                style={{
+                                                    padding: '0 4px',
+                                                    backgroundColor: 'transparent',
+                                                    color: CHROME_BLUE,
+                                                    border: '1px solid #b3d9ff',
+                                                    borderRadius: '4px',
+                                                    fontSize: '0.65rem',
+                                                    cursor: 'pointer',
+                                                    flexShrink: 0,
+                                                    transition: 'background-color 0.15s',
+                                                }}
+                                                onMouseEnter={(ev) => ev.currentTarget.style.backgroundColor = '#d4e8ff'}
+                                                onMouseLeave={(ev) => ev.currentTarget.style.backgroundColor = 'transparent'}
+                                            >
+                                                ✓
+                                            </button>
+                                        </div>
                                     );
                                 })}
                                 {showInlineInput && (
                                     <div style={{
-                                        borderTop: '1px solid rgba(74, 123, 167, 0.3)',
+                                        borderTop: comments.length > 0 ? DIVIDER : 'none',
                                         marginTop: '2px',
                                         paddingTop: '5px',
                                         paddingBottom: '2px',
@@ -774,7 +888,7 @@ const CommentWrapper = ({
                                                 // the comment rows do.
                                                 backgroundColor: 'transparent',
                                                 color: 'inherit',
-                                                border: '1px solid rgba(74, 123, 167, 0.3)',
+                                                border: DIVIDER,
                                                 borderRadius: '4px',
                                                 outline: 'none',
                                                 resize: 'none',
@@ -784,25 +898,24 @@ const CommentWrapper = ({
                                         />
                                     </div>
                                 )}
-                                </>
-                            ) : (
-                                <>
-                                    <div style={{
-                                        maxWidth: '140px',
-                                        overflow: 'hidden',
-                                        whiteSpace: 'nowrap',
-                                        textOverflow: 'ellipsis',
-                                    }}>
-                                        {commentSpanText(comments[0])}
+                            </>
+                        ) : (
+                            <>
+                                <div style={{
+                                    maxWidth: '140px',
+                                    overflow: 'hidden',
+                                    whiteSpace: 'nowrap',
+                                    textOverflow: 'ellipsis',
+                                }}>
+                                    {commentSpanText(comments[0])}
+                                </div>
+                                {comments.length > 1 && (
+                                    <div style={{ color: '#6699cc', textAlign: 'right' }}>
+                                        +{comments.length - 1} more
                                     </div>
-                                    {comments.length > 1 && (
-                                        <div style={{ color: '#6699cc', textAlign: 'right' }}>
-                                            +{comments.length - 1} more
-                                        </div>
-                                    )}
-                                </>
-                            )}
-                        </div>
+                                )}
+                            </>
+                        )}
                     </div>
                 </div>
             )}

--- a/ts-packages/preview-renderer/src/q2-preview/custom/CommentBlock.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/custom/CommentBlock.tsx
@@ -721,16 +721,16 @@ const CommentWrapper = ({
                     ref={chromeRef}
                     style={{
                         position: 'absolute',
-                        bottom: '-11px',
+                        top: '-11px',
                         right: '-10px',
                         transform: `translateY(${nudge}px)`,
                         // Animate nudge changes; the relayout pass reads
                         // the in-flight translation, so mid-animation
                         // reflows stay correct.
                         transition: 'transform 0.15s ease-out',
-                        // The bubble hangs below the block's box, into
-                        // the next (positioned) sibling wrapper — lift
-                        // it above so it wins hit-testing there. A
+                        // The bubble pokes above the block's box, into
+                        // the previous (positioned) sibling wrapper —
+                        // lift it above so it wins hit-testing there. A
                         // self-expanded bubble lifts further so no peer
                         // bubble (all at 100) can paint above it.
                         zIndex: selfExpanded ? 1000 : 100,

--- a/ts-packages/preview-renderer/src/q2-preview/dispatchers.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/dispatchers.tsx
@@ -376,7 +376,7 @@ function EditTextarea({
             }}
             onCompositionStart={() => { isComposingRef.current = true; }}
             onCompositionEnd={() => { isComposingRef.current = false; }}
-            onBlur={() => {
+            onBlur={(e) => {
                 // Do not commit mid-IME-composition (e.g. mobile dismiss before compositionend).
                 if (isComposingRef.current) return;
                 // A rich/plain surface swap is not a commit (Phase 1a) — the swap
@@ -387,6 +387,14 @@ function EditTextarea({
                 // the editor — all in one shot. Returns true when consumed (skip normal path).
                 if (ctx.handleClickSwitchBlur?.(draft)) {
                     return; // dirty click-switch handled — do NOT also focus-restore or commitIfDirty
+                }
+                // Focus moved into UI that owns its focus (e.g. the
+                // comment popup, marked [data-q2-owns-focus]) — commit,
+                // but do NOT arm the focus-restore timer that would
+                // steal focus back from it.
+                if ((e.relatedTarget as Element | null)?.closest?.('[data-q2-owns-focus]')) {
+                    commitIfDirty(draft);
+                    return;
                 }
                 // P2.4c: stash focus restore BEFORE commitIfDirty closes the editor.
                 // requestFocusRestore only stashes the landing + arms the timer;

--- a/ts-packages/preview-renderer/src/q2-preview/entry.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/entry.tsx
@@ -193,6 +193,11 @@ interface UpdateAstPayload {
      */
     editingDisabled?: boolean;
     /**
+     * Comment-bubble display mode (host three-way toggle). Forwarded
+     * into `PreviewContext.commentsMode`. Absent ⇒ 'show'.
+     */
+    commentsMode?: 'expand' | 'show' | 'hide';
+    /**
      * P3.2: nesting-cursor mode for nested blocks. Forwarded into
      * `PreviewContext.unlockNestingCursor`. Default-off (undefined/false).
      */
@@ -339,6 +344,7 @@ function updateAst(payload: UpdateAstPayload) {
         untransformedAstJson,
         currentActor,
         editingDisabled,
+        commentsMode,
         unlockNestingCursor,
         richText,
         nestedEditBuffers,
@@ -365,6 +371,7 @@ function updateAst(payload: UpdateAstPayload) {
                 untransformedAstJson={untransformedAstJson}
                 currentActor={currentActor ?? null}
                 editingDisabled={editingDisabled}
+                commentsMode={commentsMode}
                 unlockNestingCursor={unlockNestingCursor}
                 richText={richText}
                 nestedEditBuffers={nestedEditBuffers}

--- a/ts-packages/preview-renderer/src/q2-preview/registry.ts
+++ b/ts-packages/preview-renderer/src/q2-preview/registry.ts
@@ -2,7 +2,8 @@ import type { FormatRegistry } from '../framework';
 import * as Blocks from './blocks';
 import * as Inlines from './inlines';
 import * as Custom from './custom';
-import { Block, Inline, CustomBlock, CustomInline } from './dispatchers';
+import { Inline, CustomBlock, CustomInline } from './dispatchers';
+import { CommentBlock } from './custom/CommentBlock';
 import { MermaidCodeBlock } from './blocks/MermaidCodeBlock';
 import { PreviewDocument } from './PreviewDocument';
 
@@ -47,7 +48,12 @@ export const previewRegistry: FormatRegistry = {
     CodeBlock: MermaidCodeBlock,
     __fallback__: Custom.Fallback,
     __title_block__: Custom.PreviewTitleBlock,
-    Block,
+    // Default comment/reaction chrome (custom/CommentBlock.tsx): wraps
+    // the dispatchers.tsx Block dispatcher, extracting
+    // `quarto-edit-comment` spans into corner chrome. A user
+    // render-components override of `Block` still wins via
+    // mergedPreviewRegistry.
+    Block: CommentBlock,
     Inline,
     CustomBlock,
     CustomInline,

--- a/ts-packages/preview-renderer/src/q2-preview/richtext/RichTextEditor.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/richtext/RichTextEditor.tsx
@@ -251,6 +251,13 @@ export function RichTextEditor({
       const next = e.relatedTarget as Node | null;
       // Focus stayed within the edit box (toolbar button / link input) — not a commit.
       if (next && root && root.contains(next)) return;
+      // Focus moved into UI that owns its focus (e.g. the comment
+      // popup, marked [data-q2-owns-focus]) — commit, but don't arm a
+      // focus restore that would steal focus back from it.
+      if (next && (next as Element).closest?.('[data-q2-owns-focus]')) {
+        commit(editor);
+        return;
+      }
       ctx.requestFocusRestore?.(resolved.sourceEntry.r[0]);
       commit(editor);
     };


### PR DESCRIPTION
This PR adds a default block render component for q2-preview and revealjs formats that 
- shows comment threads and allows you to add comments and resolve them.
- adds a toggle to the bottom bar that expands, collapses, and hides comment threads.

https://github.com/user-attachments/assets/62a318df-6709-431e-971a-7c2af087592c

## Notes
- I didn't try to get commenting on list table entries working, disabled that
- *commenting doesn't work on figures for some reason (it writes, but it causes broken syntax) so I've disabled commenting on figures.*
- comment bubbles try to position themselves at the top right of their associated block, but, especially when in expanded mode, bubbles can get large and its impossible for them to stay in that position without overlapping with other bubbles. To address this problem I've added force layout that ensures bubbles don't overlap. When you hover over the right half of a block, it highlights the associated comment bubble and moves the bubble to the top right of the block, pushing other bubbles around to make that happen.
- If you hover over the left half of a block, it doesn't cause any comment bubble interactions. I added this so people have an easy place to put their mouse while scrolling without causing bubbles to move around a bunch.