### PR TITLE
Sidecar-strip hardening (#442) + fix s0 suite crash from Comments v1 (bd-ddaqjb91)

### DIFF
--- a/claude-notes/plans/2026-07-30-commentblock-defensive-resolvesource.md
+++ b/claude-notes/plans/2026-07-30-commentblock-defensive-resolvesource.md
@@ -1,0 +1,145 @@
+# Fix bd-ddaqjb91 — s0-list-item-surfaces crash: defensive `CommentBlock` + honest test stub
+
+**Strand:** bd-ddaqjb91 (bug, P1)
+**Discovered:** 2026-07-30, while landing the #442 sidecar-stripping fix (`c33c40bd`).
+**Broken since:** `a6fc44b8` (Comments v1, PR #441) on `main`.
+
+## Overview
+
+`ts-packages/preview-renderer`'s integration suite fails on main:
+`s0-list-item-surfaces.integration.test.tsx` has 18/23 tests failing. All 18
+share a single crash:
+
+```
+TypeError: Cannot read properties of undefined (reading 't')
+  at sameCommentableKind (src/q2-preview/custom/CommentBlock.tsx:120)
+  at CommentBlock (src/q2-preview/custom/CommentBlock.tsx:211)
+```
+
+### Root-cause chain (diagnosed, experiment-validated)
+
+1. **PR #441 put `CommentBlock` on every block render path.** The registry now
+   maps `Block: CommentBlock` (`registry.ts:56`), and the framework `Node`
+   dispatcher routes *every* block — top-level and nested — through
+   `registry['Block']` (`framework/dispatch.tsx:402`). For any commentable-
+   looking block with no comments, `CommentBlock` calls
+   `edit.resolveSource(block)` and passes `resolved.sourceNode` to
+   `sameCommentableKind()` **without checking that `sourceNode` exists**
+   (`CommentBlock.tsx:205-216`).
+
+2. **The s0 test harness's `resolveSource` stub predates `ResolvedSource`'s
+   current shape** (`s0-list-item-surfaces.integration.test.tsx:80-89`). It
+   returns `{ reachabilityClass: 'Reachable', sourceEntry, sourceIndex: null }`:
+   - missing `sourceNode` (required by the interface, crashes CommentBlock);
+   - `'Reachable'` is not a member of `ReachabilityClass`
+     (`'TopLevel' | 'Descendable' | 'Opaque'`, `sourceIndex.ts:17`);
+   - `sourceIndex` is not a property of `ResolvedSource` at all.
+   Before #441 nothing on this render path consumed the resolved value's
+   `sourceNode`, so the stale stub passed.
+
+3. **No gate type-checks test files**, so the drift was invisible:
+   `tsconfig.json` excludes `*.test.ts(x)` from `tsc`, and vitest transforms
+   with esbuild (no type checking). `npm run build` passes with a stub that
+   violates the interface three ways.
+
+4. **Process note:** `cargo xtask verify` step 11 *does* run these suites
+   (`verify.rs:391-403`); the merge evidently went in without a full verify.
+   No tooling change needed for this — the gate exists.
+
+### What is NOT broken (verified)
+
+Production is likely unaffected: the real `resolveSource`
+(`PreviewRoot.tsx:1473-1489`) always includes `sourceNode` when it returns
+non-null. The crash needs a malformed `ResolvedSource`, which only the test
+stub produces today. (The defensive guard is still worth having:
+`PreviewContextValue.resolveSource` is a pluggable, optional context member.)
+
+Also verified: the comment chrome's wrapper `<div>` inside `<li>` does **not**
+violate s0's assertions — they check `textContent` and *pool-id-carrying*
+inner elements, not arbitrary wrappers, and the geometry tests mock rects on
+the `<li>`/`<ul>` directly. Comments on list items are an intended #441
+feature; no policy change needed.
+
+**Experiment (2026-07-30, reverted):** patching the stub to return
+`sourceNode: node` flips the suite from 18-failed to **23/23 passing**. No
+assertion changes needed. This bounds the fix to the two defects below.
+
+## Work Items
+
+### Phase 1 — defensive guard in CommentBlock (TDD)
+
+- [ ] Write a unit test (new file, e.g.
+      `src/q2-preview/custom/CommentBlock.defensive.integration.test.tsx`):
+      mount a Para through `previewRegistry` with a `PreviewContext` whose
+      `resolveSource` returns a malformed entry (no `sourceNode`); assert the
+      block renders as passthrough (text present, no crash). A second case:
+      `resolveSource` throws → also worth deciding (see Open Questions).
+- [ ] Run it; verify it fails with the exact `TypeError` above.
+- [ ] Fix: in `CommentBlock.tsx` (`comments.length === 0` gate), treat a
+      resolved entry without a `sourceNode` like an unresolvable block:
+      `if (!resolved || !resolved.sourceNode || resolved.reachabilityClass === 'Opaque' || !sameCommentableKind(block, resolved.sourceNode)) return passthrough;`
+      Audit the other `resolved.sourceNode` consumers in the same file
+      (`resolveCommittable`, `addComment`, `resolveCommentAtIndex`) for the
+      same dereference and guard them consistently.
+- [ ] Run the test; verify it passes.
+
+### Phase 2 — honest s0 stub
+
+- [ ] Fix `makeResolveSource` in `s0-list-item-surfaces.integration.test.tsx`
+      to satisfy `ResolvedSource` for real: `sourceNode: node`,
+      `reachabilityClass: 'Descendable'` (a real union member — these are
+      nested list blocks), `sourceEntry: entry`; drop the bogus `sourceIndex`
+      property and the `as any`. Type the return without casts so future
+      drift is a compile error *once Phase 3 lands*.
+- [ ] Run the s0 suite; verify 23/23 pass.
+
+### Phase 3 — close the type-check gap (the systemic fix)
+
+- [ ] Make test files type-check somewhere: either a
+      `tsconfig.tests.json` (extends the base, includes `src/**/*`, no
+      `exclude` of tests, `noEmit`) wired as a `typecheck` npm script and
+      called from `verify.rs` step 11, or vitest's built-in
+      `test.typecheck`. Decide based on runtime cost (see Open Questions).
+- [ ] Prove it catches the original defect: temporarily reintroduce the
+      stale stub shape, confirm the typecheck fails, revert.
+- [ ] Do the same for `preview-runtime` if the chosen mechanism is cheap to
+      extend (same step-11 leg).
+
+### Phase 4 — verification + landing
+
+- [ ] `npm run test` and `npm run test:integration` in
+      `ts-packages/preview-renderer` — full suites green.
+- [ ] `cd hub-client && npm run build:all` (strict production build).
+- [ ] `cargo xtask verify --skip-rust-tests` (exercises step 11 exactly as CI
+      would; Rust untouched, so skipping the Rust test leg is fine).
+- [ ] Commit; comment on bd-ddaqjb91 with the commit hash; close the strand
+      with `--reason`.
+
+## Open Questions
+
+1. **Should `CommentBlock` also tolerate a *throwing* `resolveSource`?**
+   Recommendation: no try/catch for now — swallowing exceptions hides real
+   bugs; the guard should only normalize *shape*, not *behavior*. Revisit if
+   user render-components can inject `resolveSource`.
+2. **Typecheck mechanism** (Phase 3): a separate `tsc -p tsconfig.tests.json`
+   is predictable and CI-friendly; vitest `typecheck` runs per-test-run and
+   may be slower in watch mode. Default to the separate tsconfig unless
+   something surfaces.
+3. **Tighten `ResolvedSource` consumers?** `sourceNode: BlockNode` could stay
+   required in the type while consumers guard at runtime (types don't survive
+   pluggable-context boundaries). Do not weaken the type to
+   `sourceNode?: BlockNode` — that would force needless guards on the many
+   sound call sites in `PreviewRoot.tsx`.
+
+## Details / references
+
+- Crash gate: `CommentBlock.tsx:205-216` (`comments.length === 0` branch).
+- Kind check: `sameCommentableKind`, `CommentBlock.tsx:118-131`.
+- Registry wiring: `registry.ts:51-56` (`Block: CommentBlock`).
+- Dispatcher: `framework/dispatch.tsx:402+` (all blocks route via
+  `registry['Block']`).
+- Real resolver: `PreviewRoot.tsx:1473-1489`; index builder + types:
+  `sourceIndex.ts`.
+- Stale stub: `s0-list-item-surfaces.integration.test.tsx:80-89`.
+- Related work landed just before: sidecar stripping for subtree commits
+  (`c33c40bd`, GH #442, follow-up strand bd-d01m11aw).

--- a/claude-notes/plans/2026-07-30-commentblock-defensive-resolvesource.md
+++ b/claude-notes/plans/2026-07-30-commentblock-defensive-resolvesource.md
@@ -68,52 +68,52 @@ assertion changes needed. This bounds the fix to the two defects below.
 
 ### Phase 1 — defensive guard in CommentBlock (TDD)
 
-- [ ] Write a unit test (new file, e.g.
+- [x] Write a unit test (new file,
       `src/q2-preview/custom/CommentBlock.defensive.integration.test.tsx`):
       mount a Para through `previewRegistry` with a `PreviewContext` whose
       `resolveSource` returns a malformed entry (no `sourceNode`); assert the
-      block renders as passthrough (text present, no crash). A second case:
-      `resolveSource` throws → also worth deciding (see Open Questions).
-- [ ] Run it; verify it fails with the exact `TypeError` above.
-- [ ] Fix: in `CommentBlock.tsx` (`comments.length === 0` gate), treat a
-      resolved entry without a `sourceNode` like an unresolvable block:
-      `if (!resolved || !resolved.sourceNode || resolved.reachabilityClass === 'Opaque' || !sameCommentableKind(block, resolved.sourceNode)) return passthrough;`
-      Audit the other `resolved.sourceNode` consumers in the same file
-      (`resolveCommittable`, `addComment`, `resolveCommentAtIndex`) for the
-      same dereference and guard them consistently.
-- [ ] Run the test; verify it passes.
+      block renders as passthrough (text present, no crash). Plus a guard-not-
+      over-broad case: well-formed entry still gets comment chrome.
+- [x] Run it; verified it fails with the exact `TypeError` above.
+- [x] Fix: added `!resolved.sourceNode` to the render gate and to
+      `resolveCommittable` (which `addComment`/`resolveCommentAtIndex` both
+      funnel through — no other `sourceNode` consumers in the file).
+- [x] Run the test; passes (2/2).
 
 ### Phase 2 — honest s0 stub
 
-- [ ] Fix `makeResolveSource` in `s0-list-item-surfaces.integration.test.tsx`
-      to satisfy `ResolvedSource` for real: `sourceNode: node`,
-      `reachabilityClass: 'Descendable'` (a real union member — these are
-      nested list blocks), `sourceEntry: entry`; drop the bogus `sourceIndex`
-      property and the `as any`. Type the return without casts so future
-      drift is a compile error *once Phase 3 lands*.
-- [ ] Run the s0 suite; verify 23/23 pass.
+- [x] Fixed `makeResolveSource`: `sourceNode: node`,
+      `reachabilityClass: 'Descendable'`, typed `sourceEntry`; dropped the
+      bogus `sourceIndex` property and the `as any`.
+- [x] s0 suite: 23/23 pass.
 
 ### Phase 3 — close the type-check gap (the systemic fix)
 
-- [ ] Make test files type-check somewhere: either a
-      `tsconfig.tests.json` (extends the base, includes `src/**/*`, no
-      `exclude` of tests, `noEmit`) wired as a `typecheck` npm script and
-      called from `verify.rs` step 11, or vitest's built-in
-      `test.typecheck`. Decide based on runtime cost (see Open Questions).
-- [ ] Prove it catches the original defect: temporarily reintroduce the
-      stale stub shape, confirm the typecheck fails, revert.
-- [ ] Do the same for `preview-runtime` if the chosen mechanism is cheap to
-      extend (same step-11 leg).
+- [x] Chose the separate-tsconfig route: `tsconfig.tests.json` in
+      preview-renderer (extends base; `noEmit`; `noUnusedLocals`/
+      `noUnusedParameters` off — lint-grade noise, not drift detection),
+      exposed as `npm run typecheck:tests`, and wired into `verify.rs`
+      step 11 ahead of the test runs. Fixed the pre-existing type errors
+      it surfaced in 6 preview-renderer test files (typed `vi.fn`
+      generics, a `Mock` import, missing `setLocalAst` props, a
+      `useContext` typo'd type, tuple-typed pool fixtures, two narrow
+      casts documented in place).
+- [x] Proved it catches the original defect: reintroducing the stale stub
+      fails with `TS2322: '"Reachable"' is not assignable to
+      'ReachabilityClass'` (plus the pool-tuple errors); reverted.
+- [x] Extended to `preview-runtime` (same tsconfig + script + verify leg).
+      Surfaced real drift there too: `MockSyncClient`'s interface was
+      missing `applyEditorOperations` (impl had it), and the handler mocks
+      were untyped. Fixed; 74/74 tests still pass.
 
 ### Phase 4 — verification + landing
 
-- [ ] `npm run test` and `npm run test:integration` in
-      `ts-packages/preview-renderer` — full suites green.
-- [ ] `cd hub-client && npm run build:all` (strict production build).
-- [ ] `cargo xtask verify --skip-rust-tests` (exercises step 11 exactly as CI
-      would; Rust untouched, so skipping the Rust test leg is fine).
+- [x] `npm run test` (542 passed / 36 skipped) and `npm run test:integration`
+      (572 passed / 1 skipped) in `ts-packages/preview-renderer`.
+- [x] `cargo xtask verify --skip-rust-tests` — includes the hub-client
+      `build:all` leg and the new step-11 typecheck legs.
 - [ ] Commit; comment on bd-ddaqjb91 with the commit hash; close the strand
-      with `--reason`.
+      with `--reason`. Open PR.
 
 ## Open Questions
 

--- a/crates/xtask/src/verify.rs
+++ b/crates/xtask/src/verify.rs
@@ -402,6 +402,25 @@ pub fn run(config: &VerifyConfig) -> Result<()> {
             "\n━━━ Step 11/{}: Running shared preview-* package tests ━━━\n",
             TOTAL_STEPS
         );
+        // Type-check the test files first (tsconfig.tests.json): the
+        // package build excludes *.test.* from tsc and vitest only
+        // transforms with esbuild, so without this leg a test harness
+        // can silently drift from the interfaces it stubs — that's how
+        // the s0 suite broke on main (bd-ddaqjb91).
+        run_command(
+            "npm",
+            &["run", "typecheck:tests"],
+            &preview_renderer_dir,
+            None,
+            "preview-renderer test typecheck failed",
+        )?;
+        run_command(
+            "npm",
+            &["run", "typecheck:tests"],
+            &preview_runtime_dir,
+            None,
+            "preview-runtime test typecheck failed",
+        )?;
         run_command(
             "npm",
             &["test"],

--- a/ts-packages/preview-renderer/package.json
+++ b/ts-packages/preview-renderer/package.json
@@ -58,6 +58,7 @@
   "scripts": {
     "build": "tsc",
     "typecheck": "tsc --noEmit",
+    "typecheck:tests": "tsc -p tsconfig.tests.json",
     "clean": "rm -rf dist",
     "test": "vitest run",
     "test:integration": "vitest run --config vitest.integration.config.ts",

--- a/ts-packages/preview-renderer/src/q2-preview/PreviewRoot.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/PreviewRoot.tsx
@@ -21,6 +21,7 @@ import type { PreviewNodeEditPayload } from '../types/diagnostic';
 import { previewRegistry, PreviewContext } from '.';
 import type { CommentsMode } from './PreviewContext';
 import { buildSourceIndex, serializeSourceEntry } from './sourceIndex';
+import { stripSourceInfoFields } from './stripSourceInfoFields';
 import type { ResolvedSource } from './sourceIndex';
 import { outerBlockForAnchorR0, refocusTargetForAnchorR0, findReanchorCandidate, enumerateOuterBlocks, captureEditTarget, measureBlockBox, seedForRange, snapshotOuterBlockGeometry, isDirty } from './outerBlocks';
 import { buildByteLineMap } from '../utils/byteLineMap';
@@ -1500,14 +1501,11 @@ export function PreviewRoot(props: PreviewRootProps) {
     };
 
     // commitSubtreeEdit: send a subtree-channel PreviewNodeEditPayload (Plan 2b).
-    // The replacer strips every pool-index-carrying key: `s` (node
-    // SourceInfo), `a` (AttrSourceInfo), and `targetS` (Link/Image
-    // URL+title source refs — missing it caused InvalidSourceInfoRef
-    // on any subtree containing a link).
+    // stripSourceInfoFields removes every pool-index-carrying sidecar key
+    // (`s`, `a`, `targetS`, …) — a surviving index caused
+    // InvalidSourceInfoRef on any subtree containing a link.
     const commitSubtreeEdit = (destinationSourceInfoJson: string, modifiedBlock: BlockNode) => {
-        const stripped = JSON.parse(JSON.stringify(modifiedBlock, (key, value) =>
-            key === 's' || key === 'a' || key === 'targetS' ? undefined : value,
-        )) as BlockNode;
+        const stripped = stripSourceInfoFields(modifiedBlock);
         const wrappedDoc = {
             'pandoc-api-version': [1, 23, 0],
             meta: {},

--- a/ts-packages/preview-renderer/src/q2-preview/custom-components.integration.test.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/custom-components.integration.test.tsx
@@ -487,7 +487,9 @@ describe('Callout', () => {
             title: [STR('Custom Title')],
             id: 'tip-foo',
         });
-        ast.plain_data = {
+        // Crossref fields (ref_type/kind/identifier) aren't part of the
+        // callout plain_data type; widen for this fixture.
+        (ast as { plain_data: unknown }).plain_data = {
             ...ast.plain_data,
             ref_type: 'tip',
             kind: 'Tip',

--- a/ts-packages/preview-renderer/src/q2-preview/custom/CommentBlock.defensive.integration.test.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/custom/CommentBlock.defensive.integration.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * bd-ddaqjb91 — CommentBlock must be defensive about ResolvedSource.
+ *
+ * `PreviewContextValue.resolveSource` is a pluggable, optional context
+ * member (test harnesses and hosts can supply their own). CommentBlock
+ * consumes `resolved.sourceNode` on every comment-less block render to
+ * decide whether to show comment chrome; a malformed entry with no
+ * `sourceNode` must degrade to a plain passthrough render, not crash
+ * the whole preview with
+ *   TypeError: Cannot read properties of undefined (reading 't')
+ * (the failure that broke the s0-list-item-surfaces suite on main).
+ *
+ * Plan: claude-notes/plans/2026-07-30-commentblock-defensive-resolvesource.md
+ */
+
+// @vitest-environment jsdom
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import React from 'react';
+import { Ast } from '../../framework';
+import { previewRegistry } from '../registry';
+import { PreviewContext } from '../PreviewContext';
+import type { PreviewContextValue } from '../PreviewContext';
+import type { ResolvedSource } from '../sourceIndex';
+
+afterEach(() => {
+    cleanup();
+    document.body.innerHTML = '';
+});
+
+const POOL = [{ t: 0, r: [0, 11], d: 0 }];
+
+const BLOCKS = [
+    { t: 'Para', s: 0, c: [{ t: 'Str', c: 'hello' }, { t: 'Space' }, { t: 'Str', c: 'world' }] },
+];
+
+function astJson(): string {
+    return JSON.stringify({
+        'pandoc-api-version': [1, 23, 0],
+        meta: {},
+        blocks: BLOCKS,
+        astContext: { p: POOL },
+    });
+}
+
+function mountWithResolveSource(resolveSource: PreviewContextValue['resolveSource']) {
+    const ctx: PreviewContextValue = {
+        currentFilePath: '/project/test.qmd',
+        pool: POOL,
+        content: '',
+        resolveSource,
+    };
+    return render(
+        <PreviewContext.Provider value={ctx}>
+            <Ast
+                astJson={astJson()}
+                currentFilePath="/project/test.qmd"
+                onNavigateToDocument={() => {}}
+                setAst={() => {}}
+                registry={previewRegistry}
+            />
+        </PreviewContext.Provider>,
+    );
+}
+
+describe('CommentBlock defensiveness against malformed ResolvedSource', () => {
+    it('renders passthrough (no crash) when resolveSource omits sourceNode', () => {
+        // The exact stale shape that broke s0: an entry with no sourceNode.
+        const malformed = (node: any): ResolvedSource | null => {
+            if (node?.s === undefined) return null;
+            return {
+                reachabilityClass: 'Descendable',
+                sourceEntry: POOL[Number(node.s)],
+            } as unknown as ResolvedSource;
+        };
+        const { container } = mountWithResolveSource(malformed);
+        expect(container.textContent).toContain('hello world');
+    });
+
+    it('well-formed ResolvedSource still gets comment chrome (guard is not over-broad)', () => {
+        const wellFormed = (node: any): ResolvedSource | null => {
+            if (node?.s === undefined) return null;
+            return {
+                sourceNode: node,
+                reachabilityClass: 'TopLevel',
+                sourceEntry: POOL[Number(node.s)] as { t: 0; r: [number, number]; d: number },
+            };
+        };
+        const { container } = mountWithResolveSource(wellFormed);
+        expect(container.textContent).toContain('hello world');
+        // Chrome marker: the CommentWrapper's relative-positioned host div
+        // wraps the paragraph when the block is commentable.
+        const para = container.querySelector('p');
+        expect(para).not.toBeNull();
+        const host = para!.parentElement as HTMLElement;
+        expect(host.style.position).toBe('relative');
+    });
+});

--- a/ts-packages/preview-renderer/src/q2-preview/custom/CommentBlock.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/custom/CommentBlock.tsx
@@ -204,9 +204,13 @@ export const CommentBlock = (args: NodeArgs<BlockNode>) => {
     // backstop. Blocks that already carry comments keep their bubble
     // for read-only display.
     if (comments.length === 0) {
+        // `resolveSource` is a pluggable context member — treat a
+        // malformed entry (no sourceNode) like an unresolvable block
+        // rather than crashing the render (bd-ddaqjb91).
         const resolved = edit.resolveSource(block);
         if (
             !resolved ||
+            !resolved.sourceNode ||
             resolved.reachabilityClass === 'Opaque' ||
             !sameCommentableKind(block, resolved.sourceNode)
         ) {
@@ -614,7 +618,7 @@ const CommentWrapper = ({
      */
     const resolveCommittable = () => {
         const resolved = edit.resolveSource(block);
-        if (!resolved) return null;
+        if (!resolved || !resolved.sourceNode) return null;
         if (resolved.reachabilityClass === 'Opaque') return null;
         if (!sameCommentableKind(block, resolved.sourceNode)) return null;
         return resolved;

--- a/ts-packages/preview-renderer/src/q2-preview/p2-4b.integration.test.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/p2-4b.integration.test.tsx
@@ -40,6 +40,7 @@
 // @vitest-environment jsdom
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
+import type { Mock } from 'vitest';
 import {
     render,
     cleanup,
@@ -246,7 +247,7 @@ interface KeydownHarnessProps {
     pool: unknown[];
     content: string;
     editTarget: EditTarget;
-    requestMove: vi.Mock;
+    requestMove: Mock;
     cancelPendingLand?: () => void;
 }
 
@@ -285,7 +286,7 @@ function EditTextareaKeydownHarness({
     return (
         <PreviewContext.Provider value={ctx}>
             <RegistryContext.Provider value={{ registry: {} }}>
-                <Block node={makeParaNode(0) as any} />
+                <Block node={makeParaNode(0) as any} setLocalAst={() => {}} />
             </RegistryContext.Provider>
         </PreviewContext.Provider>
     );
@@ -507,7 +508,7 @@ function CaretArrivalHarness({
     return (
         <PreviewContext.Provider value={ctx}>
             <RegistryContext.Provider value={{ registry: {} }}>
-                <Block node={makeParaNode(0) as any} />
+                <Block node={makeParaNode(0) as any} setLocalAst={() => {}} />
             </RegistryContext.Provider>
         </PreviewContext.Provider>
     );

--- a/ts-packages/preview-renderer/src/q2-preview/p3-2-nesting-cursor-context.integration.test.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/p3-2-nesting-cursor-context.integration.test.tsx
@@ -14,6 +14,7 @@ import { describe, it, expect } from 'vitest';
 import { render } from '@testing-library/react';
 import React, { useContext } from 'react';
 import { PreviewContext } from './PreviewContext';
+import type { PreviewContextValue } from './PreviewContext';
 import { PreviewRoot } from './PreviewRoot';
 
 // An AST with one Para so the customRegistry Para entry fires, giving us
@@ -36,7 +37,7 @@ const SAMPLE_NESTED_BUFFERS: Record<string, string> = {
  * value during render. Returns `capturedCtx` synchronously after `render()`.
  */
 function mountAndCapture(props: Partial<React.ComponentProps<typeof PreviewRoot>> = {}) {
-    let capturedCtx: ReturnType<typeof useContext<typeof PreviewContext>> = null;
+    let capturedCtx: PreviewContextValue | null = null;
 
     function ContextCapture() {
         capturedCtx = useContext(PreviewContext);

--- a/ts-packages/preview-renderer/src/q2-preview/s0-list-item-surfaces.integration.test.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/s0-list-item-surfaces.integration.test.tsx
@@ -77,14 +77,18 @@ const PARA = (...inlines: any[]) => ({ t: 'Para', c: inlines });
 const noopNav = () => {};
 const noopSet = () => {};
 
-/** Minimal resolveSource that returns non-Opaque for any node that has .s */
+/** Minimal resolveSource that returns non-Opaque for any node that has .s.
+ * Must satisfy the real ResolvedSource shape — CommentBlock (the registry's
+ * Block wrapper since Comments v1) consumes `sourceNode` on every block
+ * render, so a stale stub crashes the whole suite (bd-ddaqjb91). These
+ * fixtures are their own source, so the node doubles as its sourceNode. */
 function makeResolveSource(pool: any[]) {
     return (node: any): ResolvedSource | null => {
         const s = node?.s;
         if (s === undefined || s === null) return null;
-        const entry = pool[s];
+        const entry = pool[s] as { t: 0; r: [number, number]; d: number } | undefined;
         if (!entry) return null;
-        return { reachabilityClass: 'Reachable', sourceEntry: entry, sourceIndex: null as any };
+        return { sourceNode: node, reachabilityClass: 'Descendable', sourceEntry: entry };
     };
 }
 
@@ -269,7 +273,7 @@ describe('0.a — measureLeadingBlockBox: Range-aware leading-block measure', ()
  * ─────────────────────────────────────────────────────────────────────────── */
 
 describe('0.b — tight single-block BulletList: <li> borrows leading Plain pool-id', () => {
-    const POOL_0B = [
+    const POOL_0B: Array<{ t: number; r: [number, number]; d: number }> = [
         { t: 0, r: [2, 7],   d: 0 },  // pool[0] Plain "apple"
         { t: 0, r: [10, 16], d: 0 }, // pool[1] Plain "banana"
         { t: 0, r: [0, 18],  d: 0 }, // pool[2] BulletList
@@ -358,7 +362,7 @@ describe('0.b — tight single-block BulletList: <li> borrows leading Plain pool
  * ─────────────────────────────────────────────────────────────────────────── */
 
 describe('0.c — text-with-sublist item: Range measure excludes sublist height', () => {
-    const POOL_0C = [
+    const POOL_0C: Array<{ t: number; r: [number, number]; d: number }> = [
         { t: 0, r: [2, 7],   d: 0 },  // pool[0] Plain "intro"
         { t: 0, r: [8, 20],  d: 0 },  // pool[1] inner BulletList
         { t: 0, r: [0, 22],  d: 0 },  // pool[2] outer BulletList

--- a/ts-packages/preview-renderer/src/q2-preview/s4-dirty-caret-col.integration.test.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/s4-dirty-caret-col.integration.test.tsx
@@ -81,7 +81,9 @@ const BQ_ANCHOR_SLICE = '> line one\n> line two';
 const BUFFERS: Record<string, string> = { [CHILD_SI_KEY]: CLEAN_BUFFER };
 
 function makeAstJson(): string {
-    const ast: PandocAST = {
+    // The `s` pool-index fields on blocks are a runtime extension the
+    // framework types don't declare (readers cast per-site); cast once here.
+    const ast = {
         'pandoc-api-version': [1, 23, 0],
         meta: {},
         blocks: [
@@ -102,7 +104,7 @@ function makeAstJson(): string {
             },
         ],
         astContext: { p: POOL },
-    };
+    } as unknown as PandocAST;
     return JSON.stringify(ast);
 }
 

--- a/ts-packages/preview-renderer/src/q2-preview/stripSourceInfoFields.test.ts
+++ b/ts-packages/preview-renderer/src/q2-preview/stripSourceInfoFields.test.ts
@@ -1,26 +1,21 @@
 /**
- * Unit tests for the `s`-field stripping assumption used by
- * `commitSubtreeEdit` in entry.tsx.
+ * Unit tests for the sidecar-key stripping used by `commitSubtreeEdit`
+ * in PreviewRoot.tsx.
  *
  * `apply_node_edit` (Rust) throws `InvalidSourceInfoRef` when the
- * replacement subtree JSON contains `s` pool-index fields, because the
- * replacement doc carries no pool.  `commitSubtreeEdit` strips them with
- * a JSON.stringify replacer before sending.  These tests verify that the
- * replacer actually removes `s` at every nesting depth.
+ * replacement subtree JSON contains pool-index sidecar fields, because
+ * the replacement doc carries no pool.  `commitSubtreeEdit` strips them
+ * with `stripSourceInfoFields` before sending.  These tests verify that
+ * the shared replacer (the real one — not a copy) removes every
+ * pool-index-carrying key at every nesting depth.
+ *
+ * The authoritative key inventory lives in
+ * `crates/pampa/src/writers/json.rs`; see also `normalize_nodes` in
+ * `crates/pampa/tests/integration/lua_differential.rs`.
  */
 
 import { describe, test, expect } from 'vitest';
-
-/**
- * The exact replacer used in commitSubtreeEdit (entry.tsx).
- * Strips both `s` (block/inline SourceInfo pool-index) and `a` (AttrSourceInfo
- * object whose `id`/`classes`/`kvs` values are also pool indices).
- */
-function stripSourceInfoFields<T>(block: T): T {
-    return JSON.parse(JSON.stringify(block, (key, value) =>
-        key === 's' || key === 'a' ? undefined : value,
-    )) as T;
-}
+import { stripSourceInfoFields } from './stripSourceInfoFields';
 
 describe('s-field stripping for commitSubtreeEdit', () => {
     test('strips s from a flat block', () => {
@@ -123,5 +118,95 @@ describe('s-field stripping for commitSubtreeEdit', () => {
         const json = JSON.stringify(wrappedDoc);
         expect(json).not.toMatch(/"s":/);
         expect(json).not.toMatch(/"a":/);
+    });
+});
+
+describe('sidecar keys beyond s/a (bare pool indices on specific nodes)', () => {
+    test('strips targetS from Link — the "cannot edit anything with a link" bug (#441)', () => {
+        // targetS is [urlRef, titleRef]: pool indices for the Link/Image
+        // URL and title source spans.
+        const block = {
+            t: 'Para',
+            s: 1,
+            c: [{
+                t: 'Link',
+                s: 2,
+                a: { id: null, classes: [], kvs: [] },
+                targetS: [3, 4],
+                c: [['', [], []], [{ t: 'Str', c: 'click' }], ['https://example.com', '']],
+            }],
+        };
+        const result = stripSourceInfoFields(block);
+        const json = JSON.stringify(result);
+        expect(json).not.toMatch(/"targetS":/);
+        // The structural target (URL + title) must survive.
+        expect((result as any).c[0].c[2]).toEqual(['https://example.com', '']);
+    });
+
+    test('strips targetS from Image', () => {
+        const block = {
+            t: 'Para',
+            s: 1,
+            c: [{
+                t: 'Image',
+                s: 2,
+                targetS: [3, null],
+                c: [['', [], []], [], ['fig.png', '']],
+            }],
+        };
+        const json = JSON.stringify(stripSourceInfoFields(block));
+        expect(json).not.toMatch(/"targetS":/);
+        expect(json).toMatch(/fig\.png/);
+    });
+
+    test('strips captionS from Figure (issue #442) — a bare pool index', () => {
+        // Unlike targetS, captionS is a bare index (readers/json.rs
+        // read_caption passes it straight to resolve_source_info).
+        const block = {
+            t: 'Figure',
+            s: 1,
+            a: { id: null, classes: [], kvs: [] },
+            captionS: 7,
+            c: [
+                ['fig-1', [], []],
+                [null, [{ t: 'Plain', s: 8, c: [{ t: 'Str', c: 'A caption' }] }]],
+                [{ t: 'Plain', s: 9, c: [{ t: 'Image', s: 10, targetS: [11, null], c: [['', [], []], [], ['fig.png', '']] }] }],
+            ],
+        };
+        const result = stripSourceInfoFields(block);
+        const json = JSON.stringify(result);
+        expect(json).not.toMatch(/"captionS":/);
+        // Caption content itself must survive.
+        expect(json).toMatch(/A caption/);
+    });
+
+    test('strips citationIdS from Cite citation objects (issue #442)', () => {
+        // Citation objects carry no `t` tag; citationIdS sits next to
+        // citationId and is a bare pool index read via read_opt_source_ref.
+        const block = {
+            t: 'Para',
+            s: 1,
+            c: [{
+                t: 'Cite',
+                s: 2,
+                c: [
+                    [{
+                        citationId: 'knuth1984',
+                        citationIdS: 12,
+                        citationPrefix: [],
+                        citationSuffix: [],
+                        citationMode: { t: 'NormalCitation' },
+                        citationNoteNum: 0,
+                        citationHash: 0,
+                    }],
+                    [{ t: 'Str', c: '[@knuth1984]' }],
+                ],
+            }],
+        };
+        const result = stripSourceInfoFields(block);
+        const json = JSON.stringify(result);
+        expect(json).not.toMatch(/"citationIdS":/);
+        // The citation id itself must survive.
+        expect((result as any).c[0].c[0][0].citationId).toBe('knuth1984');
     });
 });

--- a/ts-packages/preview-renderer/src/q2-preview/stripSourceInfoFields.ts
+++ b/ts-packages/preview-renderer/src/q2-preview/stripSourceInfoFields.ts
@@ -1,0 +1,34 @@
+/**
+ * Strip q2's source-map "sidecar" keys from an AST subtree before it is
+ * sent over the subtree edit channel (`commitSubtreeEdit` in
+ * PreviewRoot.tsx).
+ *
+ * Sidecar values are indices into the emitting document's SourceInfo
+ * pool (`astContext`). A subtree cloned out of the untransformed AST
+ * still carries them, but the wrapped replacement doc we send to Rust's
+ * `apply_node_edit` has no pool — any surviving index makes the reader
+ * throw `InvalidSourceInfoRef` and the whole edit fails.
+ *
+ * Keys stripped (see `crates/pampa/src/writers/json.rs` and the
+ * normalization rule in `crates/pampa/tests/integration/lua_differential.rs`):
+ * - `s`           — node SourceInfo (every node)
+ * - `a`           — AttrSourceInfo (attr-bearing nodes; `id`/`classes`/`kvs`
+ *                   values are pool indices)
+ * - `targetS`     — Link/Image `[urlRef, titleRef]`
+ * - `captionS`    — Table/Figure caption ref (a bare pool index)
+ * - `citationIdS` — citation id ref on Cite citation objects (bare index)
+ *
+ * Table-internal sidecars (`headS`, `footS`, `bodiesS`, `rowsS`,
+ * `cellsS`, `bodyS`) are nested objects whose only pool-carrying leaves
+ * are `s`/`a` keys, which the recursive replacer already removes; the
+ * leftover skeletons read back as empty. Dropping them wholesale is
+ * deferred until table editing is actually supported.
+ */
+
+const STRIPPED_KEYS = new Set(['s', 'a', 'targetS', 'captionS', 'citationIdS']);
+
+export function stripSourceInfoFields<T>(block: T): T {
+    return JSON.parse(JSON.stringify(block, (key, value) =>
+        STRIPPED_KEYS.has(key) ? undefined : value,
+    )) as T;
+}

--- a/ts-packages/preview-renderer/src/utils/iframeLinkHandlers.integration.test.ts
+++ b/ts-packages/preview-renderer/src/utils/iframeLinkHandlers.integration.test.ts
@@ -14,8 +14,10 @@
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
 import { installLinkHandlers } from './iframeLinkHandlers';
 
+type QmdLinkClickArg = { path: string; anchor: string | null } | { anchor: string };
+
 let doc: Document;
-let onQmdLinkClick: ReturnType<typeof vi.fn>;
+let onQmdLinkClick: ReturnType<typeof vi.fn<(arg: QmdLinkClickArg) => void>>;
 let postMessageSpy: ReturnType<typeof vi.spyOn>;
 let openSpy: ReturnType<typeof vi.spyOn>;
 
@@ -25,7 +27,7 @@ beforeEach(() => {
     // returns an unattached XML doc with `body === null` under jsdom.
     doc = document.implementation.createHTMLDocument();
 
-    onQmdLinkClick = vi.fn();
+    onQmdLinkClick = vi.fn<(arg: QmdLinkClickArg) => void>();
     postMessageSpy = vi.spyOn(window.parent, 'postMessage');
     openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
 });

--- a/ts-packages/preview-renderer/tsconfig.tests.json
+++ b/ts-packages/preview-renderer/tsconfig.tests.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "declaration": false,
+    "declarationMap": false,
+    "sourceMap": false,
+    "types": ["vitest/globals", "node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/ts-packages/preview-runtime/package.json
+++ b/ts-packages/preview-runtime/package.json
@@ -33,6 +33,7 @@
   "scripts": {
     "build": "tsc",
     "typecheck": "tsc --noEmit",
+    "typecheck:tests": "tsc -p tsconfig.tests.json",
     "clean": "rm -rf dist",
     "test": "vitest run",
     "test:integration": "vitest run --config vitest.integration.config.ts",

--- a/ts-packages/preview-runtime/src/automergeSync.test.ts
+++ b/ts-packages/preview-runtime/src/automergeSync.test.ts
@@ -8,7 +8,7 @@
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { zipSync, strToU8 } from 'fflate';
-import type { FileEntry, Patch } from '@quarto/quarto-sync-client';
+import type { FileEntry, Patch, SyncClient } from '@quarto/quarto-sync-client';
 import {
   setSyncHandlers,
   isConnected,
@@ -34,22 +34,24 @@ vi.mock('./wasmRenderer', () => ({
 
 describe('automergeSync', () => {
   let mockClient: MockSyncClient;
-  let onFilesChange: ReturnType<typeof vi.fn>;
-  let onFileContent: ReturnType<typeof vi.fn>;
-  let onBinaryContent: ReturnType<typeof vi.fn>;
-  let onConnectionChange: ReturnType<typeof vi.fn>;
-  let onError: ReturnType<typeof vi.fn>;
+  // Mirror automergeSync's (module-private) handler signatures so the
+  // mocks satisfy setSyncHandlers under the tests typecheck.
+  let onFilesChange: ReturnType<typeof vi.fn<(files: FileEntry[]) => void>>;
+  let onFileContent: ReturnType<typeof vi.fn<(path: string, content: string, patches: Patch[]) => void>>;
+  let onBinaryContent: ReturnType<typeof vi.fn<(path: string, content: Uint8Array, mimeType: string) => void>>;
+  let onConnectionChange: ReturnType<typeof vi.fn<(connected: boolean) => void>>;
+  let onError: ReturnType<typeof vi.fn<(error: Error) => void>>;
 
   beforeEach(() => {
     // Reset the module state
     _resetForTesting();
 
     // Create mock handlers
-    onFilesChange = vi.fn();
-    onFileContent = vi.fn();
-    onBinaryContent = vi.fn();
-    onConnectionChange = vi.fn();
-    onError = vi.fn();
+    onFilesChange = vi.fn<(files: FileEntry[]) => void>();
+    onFileContent = vi.fn<(path: string, content: string, patches: Patch[]) => void>();
+    onBinaryContent = vi.fn<(path: string, content: Uint8Array, mimeType: string) => void>();
+    onConnectionChange = vi.fn<(connected: boolean) => void>();
+    onError = vi.fn<(error: Error) => void>();
 
     // Set up handlers
     setSyncHandlers({
@@ -91,7 +93,9 @@ describe('automergeSync', () => {
       );
 
       // Inject the mock client
-      _setClientForTesting(mockClient);
+      // MockSyncClient implements the subset of SyncClient these tests
+      // exercise; the seam is test-only, so widen at the boundary.
+      _setClientForTesting(mockClient as unknown as SyncClient);
     });
 
     it('should report connected state', async () => {
@@ -133,7 +137,9 @@ describe('automergeSync', () => {
         },
         { initialFiles: new Map() },
       );
-      _setClientForTesting(mockClient);
+      // MockSyncClient implements the subset of SyncClient these tests
+      // exercise; the seam is test-only, so widen at the boundary.
+      _setClientForTesting(mockClient as unknown as SyncClient);
       await mockClient.connect('ws://test', 'automerge:test');
     });
 
@@ -176,7 +182,9 @@ describe('automergeSync', () => {
         },
         { initialFiles: new Map() },
       );
-      _setClientForTesting(mockClient);
+      // MockSyncClient implements the subset of SyncClient these tests
+      // exercise; the seam is test-only, so widen at the boundary.
+      _setClientForTesting(mockClient as unknown as SyncClient);
       await mockClient.connect('ws://test', 'automerge:test');
     });
 
@@ -211,7 +219,9 @@ describe('automergeSync', () => {
         },
         { failConnection: true, connectionError: 'Server unavailable' },
       );
-      _setClientForTesting(mockClient);
+      // MockSyncClient implements the subset of SyncClient these tests
+      // exercise; the seam is test-only, so widen at the boundary.
+      _setClientForTesting(mockClient as unknown as SyncClient);
 
       await expect(mockClient.connect('ws://test', 'automerge:test')).rejects.toThrow(
         'Server unavailable',
@@ -230,7 +240,9 @@ describe('automergeSync', () => {
         },
         { initialFiles: new Map() },
       );
-      _setClientForTesting(mockClient);
+      // MockSyncClient implements the subset of SyncClient these tests
+      // exercise; the seam is test-only, so widen at the boundary.
+      _setClientForTesting(mockClient as unknown as SyncClient);
       await mockClient.connect('ws://test', 'automerge:test');
       await mockClient.createFile('test.qmd', 'hello world');
     });
@@ -275,7 +287,9 @@ describe('automergeSync', () => {
         _getCallbacksForTesting(),
         { initialFiles: new Map() },
       );
-      _setClientForTesting(mockClient);
+      // MockSyncClient implements the subset of SyncClient these tests
+      // exercise; the seam is test-only, so widen at the boundary.
+      _setClientForTesting(mockClient as unknown as SyncClient);
       await mockClient.connect('ws://test', 'automerge:test');
     });
 
@@ -384,7 +398,9 @@ describe('automergeSync', () => {
         _getCallbacksForTesting(),
         { initialFiles: new Map() },
       );
-      _setClientForTesting(mockClient);
+      // MockSyncClient implements the subset of SyncClient these tests
+      // exercise; the seam is test-only, so widen at the boundary.
+      _setClientForTesting(mockClient as unknown as SyncClient);
       await mockClient.connect('ws://test', 'automerge:test');
     });
 
@@ -503,7 +519,9 @@ describe('automergeSync', () => {
         },
         { initialFiles: new Map() },
       );
-      _setClientForTesting(mockClient);
+      // MockSyncClient implements the subset of SyncClient these tests
+      // exercise; the seam is test-only, so widen at the boundary.
+      _setClientForTesting(mockClient as unknown as SyncClient);
 
       // The callback should have been cleared by _resetForTesting
       expect(callback).not.toHaveBeenCalled();

--- a/ts-packages/preview-runtime/src/test-utils/mockSyncClient.ts
+++ b/ts-packages/preview-runtime/src/test-utils/mockSyncClient.ts
@@ -48,6 +48,7 @@ export interface MockSyncClient {
   getFileContent(path: string): string | null;
   getBinaryFileContent(path: string): { content: Uint8Array; mimeType: string } | null;
   updateFileContent(path: string, content: string): void;
+  applyEditorOperations(path: string, changes: EditorContentChange[]): void;
   createFile(path: string, content?: string): Promise<void>;
   createBinaryFile(path: string, content: Uint8Array, mimeType: string): Promise<CreateBinaryFileResult>;
   deleteFile(path: string): void;

--- a/ts-packages/preview-runtime/tsconfig.tests.json
+++ b/ts-packages/preview-runtime/tsconfig.tests.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "declaration": false,
+    "declarationMap": false,
+    "sourceMap": false,
+    "types": ["vitest/globals", "node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
Two related pieces of post-Comments-v1 hardening.

## 1. Strip `captionS` / `citationIdS` in `commitSubtreeEdit` (closes #442's immediate ask)

`commitSubtreeEdit` sends subtrees cloned from the untransformed AST to Rust's `apply_node_edit`, whose replacement doc carries no SourceInfo pool — any surviving pool-index sidecar fails the edit with `InvalidSourceInfoRef` (the bug #441 fixed for `targetS` on links). Two bare-index sidecars were still unstripped:

- `captionS` (Table/Figure captions)
- `citationIdS` (Cite citation objects)

The replacer is now a shared `stripSourceInfoFields` util that the test file imports (it previously tested a hand-copied duplicate), with new coverage for `targetS`, `captionS`, and `citationIdS`. Table-internal sidecars (`headS`/`rowsS`/…) are deferred with table editing — tracked in bd-d01m11aw, along with the systemic Rust-side option (tolerant completing-mode reader) and the sidecar schema doc #442 asks for.

## 2. Fix the s0-list-item-surfaces crash on main (bd-ddaqjb91)

`ts-packages/preview-renderer`'s integration suite was failing 18/23 in `s0-list-item-surfaces` since the Comments v1 merge: CommentBlock became the registry's `Block` wrapper and dereferences `resolved.sourceNode` on every block render, and the s0 harness's `resolveSource` stub predated the current `ResolvedSource` shape (no `sourceNode`, invalid `'Reachable'` class). Production was likely unaffected — the real `resolveSource` always supplies `sourceNode`.

- **Defensive guard** (TDD'd): CommentBlock treats a malformed resolved entry as unresolvable → passthrough render, in both the chrome gate and `resolveCommittable`. New test proves the passthrough and that the guard isn't over-broad.
- **Honest stub**: the s0 harness now satisfies `ResolvedSource` for real. 23/23 pass.
- **Systemic fix**: test files are now type-checked (`tsconfig.tests.json` + `npm run typecheck:tests` in preview-renderer and preview-runtime, wired into `cargo xtask verify` step 11). The gate provably catches the original defect, and already surfaced real drift in preview-runtime (`MockSyncClient` missing `applyEditorOperations` from its interface) plus type errors in 6 other test files, all fixed here.

Plan/diagnosis: `claude-notes/plans/2026-07-30-commentblock-defensive-resolvesource.md`

## Verification

- preview-renderer: unit 542 passed / 36 skipped; integration 572 passed / 1 skipped (incl. s0 23/23)
- preview-runtime: 74/74; both `typecheck:tests` clean
- `cd hub-client && npm run build:all` ✓
- `cargo xtask verify --skip-rust-tests` ✓ (14/14 steps, including the new typecheck legs)
- Not verified in a live browser session: citation/figure comment edits (unit-level only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)