### PR TITLE
fix(hub): accept nonce-less old SPA logins

### DIFF
--- a/claude-notes/plans/2026-07-31-temporarily-disable-hub-login-nonce-check.md
+++ b/claude-notes/plans/2026-07-31-temporarily-disable-hub-login-nonce-check.md
@@ -1,0 +1,31 @@
+# Temporarily disable hub login nonce verification
+
+## Overview
+
+Permit an already deployed SPA, which does not return the newer login nonce,
+to authenticate with the current hub server. A callback that presents a nonce
+continues to require an exact match against the sealed login-state cookie.
+Universal nonce enforcement must be restored after the old SPA is no longer in
+use.
+
+**Tracking strand:** `bd-mc00s2ws`
+
+## Checklist
+
+- [x] Write a regression test proving a nonce-less old SPA callback mints a session.
+- [x] Observe the regression test fail while nonce enforcement is enabled.
+- [x] Temporarily bypass nonce verification with a TODO linked to `bd-mc00s2ws`.
+- [x] Restore nonce-bearing rejection tests.
+- [x] Verify nonce-bearing rejection tests fail under the broad bypass.
+- [x] Restrict the bypass to nonce-less tokens.
+- [x] Retain the `stale_client` callback reason for future compatibility branches.
+- [x] Re-run the focused authentication test to verify old SPA compatibility.
+- [x] Run the complete hub test suite (`442 passed`).
+- [ ] Run workspace regression and strict verification. Skipped before this
+  commit at the user's request; focused and complete hub verification passed.
+
+## Details
+
+The bypass is intentionally restricted to `check_login_nonce` in
+`crates/quarto-hub/src/server.rs`; signature, issuer, audience, expiry, CSRF,
+allowlist, ban, and session-mint validation remain unchanged.

--- a/crates/quarto-hub/src/server.rs
+++ b/crates/quarto-hub/src/server.rs
@@ -960,9 +960,9 @@ async fn auth_nonce(State(ctx): State<SharedContext>) -> impl IntoResponse {
     response
 }
 
-/// Login-state failure class for a callback that presented no cookie
-/// **and** a nonce-less token. Named because the user-facing reason
-/// mapping keys off it; every other class maps to `restart`.
+/// Login-state failure class for a callback that presented no cookie and a
+/// nonce-less token. Retained for future callback-time compatibility branches;
+/// every other login-state failure maps to `restart`.
 const LOGIN_STATE_STALE_CLIENT: &str = "stale_client";
 
 /// Outcome of the callback's nonce check.
@@ -983,10 +983,9 @@ enum NonceCheck {
 /// for a stolen token — and has no way to ask "did *this* browser start
 /// *this* login?".
 ///
-/// Returns [`NonceCheck::Skipped`] under `--allow-insecure-auth`: the
-/// flow needs a `SameSite=None; Secure` cookie, which cannot function
-/// over plain HTTP. That is consistent with the flag's existing "never in
-/// production" contract, and the skip is logged at WARN.
+/// Returns [`NonceCheck::Skipped`] for a nonce-less token while old SPA
+/// compatibility is required. Tokens that present a nonce still require an
+/// exact match against the sealed login-state cookie.
 fn check_login_nonce(
     ctx: &HubContext,
     claims: &auth::OidcClaims,
@@ -1000,23 +999,25 @@ fn check_login_nonce(
         return NonceCheck::Skipped;
     }
 
+    // TODO(bd-mc00s2ws): Reject nonce-less tokens after old SPA versions no
+    // longer need to authenticate against current hub servers.
+    if claims.nonce.is_none() {
+        tracing::warn!(
+            "nonce verification skipped for a nonce-less token to support an old SPA; \
+             restore universal nonce enforcement before removing the old SPA"
+        );
+        return NonceCheck::Skipped;
+    }
+
     let Some(blob) = login_state_cookie(headers, true) else {
         // Two readings, opposite remedies — and the token's own `nonce`
         // claim separates them. Reading it here is safe: the callback
         // has already signature-validated these claims.
         //
-        // No nonce means no current client produced this (the SPA
-        // renders no button until it holds one), so the fix is a reload
-        // — or nothing, if something is driving GIS outside the app.
-        // A nonce with no cookie means the pre-flight *did* happen and
-        // the cookie was lost in transit (fix the configuration), or a
-        // captured token is being replayed from a browser that never
-        // ran one. Per-event those two are indistinguishable.
-        return NonceCheck::Failed(if claims.nonce.is_none() {
-            LOGIN_STATE_STALE_CLIENT
-        } else {
-            "missing"
-        });
+        // A nonce with no cookie means the pre-flight did happen and the
+        // cookie was lost in transit (fix the configuration), or a captured
+        // token is being replayed from a browser that never ran one.
+        return NonceCheck::Failed("missing");
     };
     let sealed = match crate::login_state::open_login_state(
         ctx.session_keys(),
@@ -1165,9 +1166,6 @@ async fn auth_callback(
             sub = %claims.sub,
             detail = %format!("login_state_{detail}"),
         );
-        // Only the nonce-less-token-without-a-cookie class is worth a
-        // distinct user-facing reason — it is the one a reload fixes.
-        // Every other class (and any added later) is a plain retry.
         return auth_error(if detail == LOGIN_STATE_STALE_CLIENT {
             AuthErrorReason::StaleClient
         } else {

--- a/crates/quarto-hub/tests/integration/login_nonce.rs
+++ b/crates/quarto-hub/tests/integration/login_nonce.rs
@@ -12,7 +12,10 @@
 //! within the submitted token's validity. That is an accepted boundary,
 //! not an oversight; see the plan.
 //!
-//! Every enforcement test runs on a **secure** hub:
+//! A nonce-less token is temporarily accepted for old SPA compatibility;
+//! `bd-mc00s2ws` tracks restoring universal nonce enforcement.
+//!
+//! Every secure-hub test uses a **secure** hub:
 //! `--allow-insecure-auth` deliberately skips the check, because the
 //! `SameSite=None; Secure` cookie the flow needs cannot work over plain
 //! HTTP. `insecure_mode_skips_enforcement_with_a_warning` covers that.
@@ -346,8 +349,9 @@ async fn callback_with_a_nonce_from_another_login_is_rejected() {
 }
 
 #[tokio::test]
-async fn callback_with_a_token_carrying_no_nonce_is_rejected() {
-    // A pre-H2 client, or a token minted for some other relying party.
+async fn a_nonceless_token_is_accepted_even_with_a_login_cookie() {
+    // A pre-H2 client can carry a leftover login-state cookie from a prior
+    // attempt. Its missing token nonce is still the compatibility signal.
     let (provider, hub) = secure_google_setup().await;
     let (_nonce, blob) = fetch_nonce(hub, LOGIN_STATE_COOKIE_SECURE).await;
     let google = provider.sign(
@@ -357,7 +361,12 @@ async fn callback_with_a_token_carrying_no_nonce_is_rejected() {
     );
 
     let resp = post_callback(hub, &google, Some((LOGIN_STATE_COOKIE_SECURE, &blob))).await;
-    assert_auth_error(&resp, "restart");
+    assert!(resp.status().is_redirection());
+    assert_eq!(resp.headers().get("location").unwrap(), "/");
+    assert!(
+        TestHub::find_set_cookie(&resp, AUTH_COOKIE_NAME_SECURE).is_some(),
+        "session cookie minted for old SPA login"
+    );
 }
 
 #[tokio::test]
@@ -438,16 +447,11 @@ async fn callback_with_a_blob_sealed_under_a_foreign_secret_is_rejected() {
 
 // ── which cookie-absent reading? (E0) ─────────────────────────────
 
-/// A cookie-absent callback has two readings, and they want opposite
-/// remedies — reload the app, or fix cookie delivery. The token's own
-/// `nonce` claim is what tells them apart, so the check must look at it
-/// rather than returning a single blanket class.
-///
-/// Nonce-less: no current client can produce this. `GoogleAuthProvider`
-/// renders nothing until it holds a nonce, so the token came from a
-/// stale bundle or from something driving GIS outside the app.
+/// A deployed pre-nonce SPA does not fetch `/auth/nonce` or return an ID-token
+/// nonce. It must remain able to complete login until every deployed SPA has
+/// moved to the nonce-aware flow.
 #[tokio::test]
-async fn a_nonceless_token_without_a_cookie_audits_as_stale_client() {
+async fn a_nonceless_token_without_a_cookie_mints_a_session_for_an_old_spa() {
     let (provider, hub) = secure_google_setup().await;
     let google = provider.sign(
         &ClaimsBuilder::from_provider(provider)
@@ -456,11 +460,18 @@ async fn a_nonceless_token_without_a_cookie_audits_as_stale_client() {
     );
 
     let resp = post_callback(hub, &google, None).await;
-    assert_auth_error(&resp, "stale_client");
-    assert_eq!(
-        auth_fail_detail_for("nonce-stale-client-sub"),
-        "login_state_stale_client"
-    );
+    assert!(resp.status().is_redirection());
+    assert_eq!(resp.headers().get("location").unwrap(), "/");
+    let (token, _) = TestHub::find_set_cookie(&resp, AUTH_COOKIE_NAME_SECURE)
+        .expect("session cookie minted for old SPA login");
+    let verified = quarto_hub::session::verify_session(
+        &test_keys(),
+        SessionLifetimes::default(),
+        &token,
+        epoch_now(),
+    )
+    .unwrap();
+    assert_eq!(verified.claims.sub, "nonce-stale-client-sub");
 }
 
 /// Nonce-bearing: a login attempt that really did do the pre-flight but


### PR DESCRIPTION
## Summary
- temporarily accept validated, nonce-less ID tokens from deployed old SPAs
- retain strict sealed-cookie nonce validation for tokens that present a nonce
- retain `stale_client` callback reason for future compatibility branches; restoration is tracked in `bd-mc00s2ws`

## Verification
- `cargo build -p quarto-hub`
- `cargo nextest run -p quarto-hub` (442 passed)
- Previously completed: `cargo build --workspace` and `cargo nextest run --workspace`
- Skipped a repeated workspace rerun and `cargo xtask verify` at requester direction. The earlier `cargo xtask verify --skip-hub-build` attempt failed in unrelated existing WASM project-create tests expecting the absent `blog` template.