### PR TITLE
Bump workspace version to 0.11.0 for release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "comrak-to-pandoc"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "comrak",
  "hashlink",
@@ -3536,7 +3536,7 @@ dependencies = [
 
 [[package]]
 name = "quarto"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3582,7 +3582,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-analysis"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "insta",
  "quarto-error-reporting",
@@ -3608,7 +3608,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-brand"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "pathdiff",
  "quarto-util",
@@ -3620,7 +3620,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-citeproc"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "glob",
  "hashlink",
@@ -3653,7 +3653,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-core"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3709,7 +3709,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-csl"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "insta",
  "quarto-error-reporting",
@@ -3737,7 +3737,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-error-catalog"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "once_cell",
  "quarto-error-reporting",
@@ -3773,7 +3773,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-highlight"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "hashlink",
  "insta",
@@ -3802,7 +3802,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-highlight-encoding"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3810,7 +3810,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-hub"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "automerge",
@@ -3854,7 +3854,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-hub-provider"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "automerge",
  "ciborium",
@@ -3880,7 +3880,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-lsp"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "insta",
@@ -3896,7 +3896,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-lsp-core"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "insta",
  "pampa",
@@ -3919,7 +3919,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-mcp-launcher"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -3935,7 +3935,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-navigation"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "quarto-config",
  "quarto-pandoc-types",
@@ -3970,7 +3970,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-preview"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "automerge",
@@ -4002,7 +4002,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-project-create"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "quarto-doctemplate",
  "serde",
@@ -4013,7 +4013,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-publish"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4038,7 +4038,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-sass"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "grass",
  "include_dir",
@@ -4061,7 +4061,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-source-fetch"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "flate2",
  "tar",
@@ -4084,7 +4084,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-system-runtime"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4102,7 +4102,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-test"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "quarto-core",
@@ -4119,7 +4119,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-trace"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "flate2",
  "serde",
@@ -4130,7 +4130,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-trace-server"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4157,7 +4157,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-util"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -4165,7 +4165,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-xml"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "insta",
  "quarto-error-reporting",
@@ -4385,7 +4385,7 @@ dependencies = [
 
 [[package]]
 name = "reconcile-viewer"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "clap",
  "hashlink",
@@ -6424,7 +6424,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-printf-fmt"
-version = "0.10.0"
+version = "0.11.0"
 
 [[package]]
 name = "wasmparser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Posit Software, PBC"]
 homepage = "https://github.com/posit-dev/quarto-markdown-syntax"
 keywords = ["parser"]

--- a/crates/wasm-quarto-hub-client/Cargo.lock
+++ b/crates/wasm-quarto-hub-client/Cargo.lock
@@ -377,7 +377,7 @@ dependencies = [
 
 [[package]]
 name = "comrak-to-pandoc"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "comrak",
  "hashlink",
@@ -2074,7 +2074,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-analysis"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "quarto-error-reporting",
  "quarto-pandoc-types",
@@ -2096,7 +2096,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-brand"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "pathdiff",
  "quarto-util",
@@ -2107,7 +2107,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-citeproc"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "glob",
  "hashlink",
@@ -2138,7 +2138,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-core"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2190,7 +2190,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-csl"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "quarto-error-reporting",
  "quarto-source-map",
@@ -2241,7 +2241,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-highlight"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "once_cell",
  "quarto-highlight-encoding",
@@ -2267,7 +2267,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-highlight-encoding"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2275,7 +2275,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-lsp-core"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "pampa",
  "pollster",
@@ -2296,7 +2296,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-navigation"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "quarto-config",
  "quarto-pandoc-types",
@@ -2331,7 +2331,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-project-create"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "quarto-doctemplate",
  "serde",
@@ -2341,7 +2341,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-sass"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "include_dir",
  "once_cell",
@@ -2371,7 +2371,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-system-runtime"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -2388,7 +2388,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-trace"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "flate2",
  "serde",
@@ -2406,7 +2406,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-util"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -2414,7 +2414,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-xml"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "quarto-error-reporting",
  "quarto-source-map",
@@ -4021,7 +4021,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-printf-fmt"
-version = "0.10.0"
+version = "0.11.0"
 
 [[package]]
 name = "wasm-quarto-hub-client"


### PR DESCRIPTION
Version bump ahead of the `v0.11.0` binary release.

The release workflow's preflight job fails unless the git tag exactly equals
`[workspace.package].version` in the root `Cargo.toml`, so this lands first.

## Changes

- `Cargo.toml`: `[workspace.package] version` `0.10.0` → `0.11.0`
- `Cargo.lock` + `crates/wasm-quarto-hub-client/Cargo.lock`: regenerated via
  `cargo update --workspace` (workspace-member versions only; no external
  dependency drift)

## Verification

- `cargo build --bin q2 --locked` → `q2 (quarto 2) 0.11.0`
- `cargo xtask verify` (full, all 14 steps including the WASM + hub-client
  build and tests) → all passed
- Lockfile diff inspected: every changed `version =` line is a workspace member

## Scope

Releases what is on `main` as of c6ab84c2 — 100 commits since v0.10.0. Open PRs
(#453, #452, #426, #416, #235) are not included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)