### PR TITLE
Listing diagnostics blame the wrong key: fix materialized container spans (bd-9yh3pzfu, bd-2mxo)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3643,6 +3643,7 @@ version = "0.0.0"
 dependencies = [
  "indexmap",
  "insta",
+ "quarto-config",
  "quarto-error-reporting",
  "quarto-pandoc-types",
  "quarto-source-map",

--- a/claude-notes/plans/2026-08-06-q12-7-listing-template-diagnostic.md
+++ b/claude-notes/plans/2026-08-06-q12-7-listing-template-diagnostic.md
@@ -216,14 +216,30 @@ Q-12-7 had a better span available at the call site:
 | Site | Code | Verdict |
 | --- | --- | --- |
 | `parse_listings` array loop | `Q-12-4` | **Fixed.** Blamed the whole listing map; now blames the offending `id:` value via a new `map_entry_value` helper. Confirmed failing first — it underlined `"contents: ./b.qmd\n      id: dupe\n"`. |
-| `parse_contents` inline record | `Q-12-2` | **Phase B.** The diagnostic is *about* the whole inline record, so the map genuinely is the right thing to blame. It reads wrong today only because the map's span is wrong. |
+| `parse_contents` inline record | `Q-12-2` | **Already correct** — see correction below. Regression test added. |
 | `parse_listings` fallthrough | `Q-12-1` | **No change.** Blames the offending value, which is a scalar-ish kind in this branch (the code notes these never occur in practice). |
-| `parse_one_listing` non-map | `Q-12-1` | **Phase B.** Already blames the right value; if that value is an array its container span is wrong. |
-| `parse_sort` fallthrough | `Q-12-3` | **Phase B.** Already blames the `sort:` value itself; wrong only when that value is a map/array. |
+| `parse_one_listing` non-map | `Q-12-1` | **No change.** Blames the right value; array items keep real spans (see correction). |
+| `parse_sort` fallthrough | `Q-12-3` | **Fixed by Phase B.** Confirmed failing pre-fix — underlined `"title"`, the first entry's value. |
 
 The pattern: call-site fixes handle "blaming the wrong *node*"; Phase B
-handles "blaming the right node, which carries a wrong *span*". The three
-Phase B rows are why Phase A does not close this strand.
+handles "blaming the right node, which carries a wrong *span*".
+
+**Correction to this audit (found during Phase B verification).** The audit
+assumed every container carried a synthesized span. It does not:
+`materialize_cursor`'s Array arm **clones array items verbatim**
+(`item.value.value.clone()`, `item.value.source_info.clone()`) rather than
+recursing through the cursor, because array items have no path to navigate
+to. So **any container nested inside an array kept its original, correct
+span all along.** Only map-valued *keys* — the paths a cursor can navigate —
+went through the synthesizing arm.
+
+That reclassifies two rows: `Q-12-2`'s inline record lives inside the
+`contents:` array and was never broken, and `Q-12-4`'s pre-fix span was the
+*genuine* mapping span rather than a synthesized one. Phase A's `Q-12-4`
+change is still right — it blames the `id:` the message names instead of the
+whole record — but it was a wrong-node fix, not a wrong-span fix. Verified
+empirically by running each test against a stashed working tree rather than
+by re-reading the code.
 
 - [x] Span assertions added for both changed sites
       (`q_12_7_underlines_the_template_key_not_a_sibling`,
@@ -232,54 +248,83 @@ Phase B rows are why Phase A does not close this strand.
 
 ### Phase B — Preserve real spans through materialization (bd-2mxo)
 
-- [ ] Failing tests first, at the `quarto-config` level: materializing a
-      multi-layer map must yield (a) a container `source_info` that is the
-      real mapping span, not the first child's value; (b) a container span
-      for arrays that is not merely the last item's; (c) `key_source` values
-      that point at the real keys.
-- [ ] Add accessors on `MergedMap`/`MergedCursor` exposing the winning
-      layer's container `SourceInfo` and per-entry `key_source`, resolved
-      against `config.layers` the same way `keys()` and `as_value()` already
-      navigate (`merged.rs:200-245`).
-- [ ] Rewire `materialize_cursor`'s Map arm (`materialize.rs:121-165`) and
-      Array arm (`materialize.rs:93-120`) to use them.
-- [ ] Replace the three `unwrap_or_default()` fallbacks
-      (`materialize.rs:113`, `:154`, `:158`) with an explicit
-      `SourceInfo::generated(By::…)` sentinel. Do **not** rely on
-      `SourceInfo`'s `Default` — see the memo; `Original { FileId(0), 0..0 }`
-      is exactly the plausible-looking lie that hid this bug.
-- [ ] Re-check the decision at `materialize.rs:155` (a first child that is
-      itself a map currently yields the `programmatic_config` sentinel) —
-      with real container spans available it should no longer need a
-      sentinel at all.
-- [ ] Confirm L5's `categories_source` capture (`config.rs:516-521`) is now
-      receiving a real key span. It was added specifically to anchor
-      Q-12-12 and is very likely inert today; add a span assertion for it.
+- [x] Failing tests first, in `materialize.rs`'s new `tests::spans` module,
+      parsing real YAML so the spans mean something. All four failed with
+      the predicted diagnosis — map container = `"false"` (first entry's
+      value), array container = `"./b.qmd"` (last item), nested-map
+      container and every `key_source` = `Generated` sentinel. A fifth test
+      (winning layer supplies the span) **passed from the start**, which
+      usefully bounds the defect: scalar spans always survived
+      materialization.
+- [x] Add accessors on `MergedCursor`: `container_source()` and
+      `key_source(key)`, both walking `config.layers` in reverse so the span
+      follows the same highest-priority layer that `as_value`/`as_scalar`
+      already pick for the winning value. They return the layer's span
+      verbatim — a programmatically-built layer keeps saying it was
+      generated instead of borrowing a neighbour's location.
+- [x] Rewire `materialize_cursor`'s Map and Array arms to use them.
+- [x] Replace the `unwrap_or_default()` fallbacks with
+      `SourceInfo::generated(By::unknown())`, via a `container_source`
+      helper documenting why. `By::unknown()` is the contract's sanctioned
+      "we don't know" marker; `Default` would fabricate
+      `Original { FileId(0), 0..0 }` — the plausible-looking lie that hid
+      this bug in the first place.
+- [x] The nested-map sentinel case is gone: with a real container span
+      available there is nothing left to special-case, so that branch was
+      deleted rather than re-decided.
+- [x] L5's `categories_source` **was inert**, as suspected. Confirmed
+      empirically: against a stashed tree the new test fails with
+      "categories_source should be a real key span, not a sentinel:
+      Generated". It now resolves to the `categories` key itself. This is a
+      latent feature bug (Q-12-12 could never anchor anywhere) fixed as a
+      side effect.
 - [ ] Consider an xtask lint for `unwrap_or_default()` on `SourceInfo`-typed
       expressions — the crate's own doc comment promises "separate grep
       tooling" that does not exist (`crates/xtask/src/lint/` has only
-      `external_sources.rs` and `metadata_as_str.rs`). File separately if it
-      grows beyond a small rule.
+      `external_sources.rs` and `metadata_as_str.rs`). **Deferred**: doing
+      this accurately needs type information a grep-level rule lacks, and
+      the in-tree `SourceInfo` `unwrap_or_default` sites are now gone.
+      Filing separately rather than half-doing it here.
 
 ### Phase C — Verification
 
-- [ ] `cargo nextest run --workspace`.
-- [ ] `cargo xtask verify` — this touches `quarto-config` and `quarto-core`,
-      both in the WASM closure; full verify, not `--skip-hub-build`.
-- [ ] End-to-end per CLAUDE.md: render the in-repo fixture through
-      `cargo run --bin q2 -- render …`, and record here (a) the exact
-      invocation, (b) the new caret position and underlined text, (c) an
-      explicit note that the terminal output was inspected.
-- [ ] Sanity-check against the Connect docs
-      (`~/Desktop/daily-log/2026/08/05/q2-connect-docs/docs-quarto-2`) that
-      Q-12-7 now points at `template:`. The site is still expected to render
-      poorly — bd-oywyaouf and bd-lu16jgxq are the strands that address that.
-- [ ] **Snapshot report.** Phase B moves diagnostic locations tree-wide.
-      Per the CLAUDE.md snapshot policy: report the count of `.snap` files
-      changed, summarize what changed and why, and explicitly flag any
-      snapshot whose new span is *not* obviously an improvement — a
-      container span moving is expected; a scalar span moving is not, and
-      would mean Phase B overreached.
+- [x] `cargo nextest run --workspace` — **10877 passed, 197 skipped**, zero
+      failures.
+- [x] `cargo xtask verify --skip-hub-build` clean (full verify pending, see
+      below).
+- [x] End-to-end through the real binary. Invocation:
+
+      ```
+      cargo run --bin q2 -- render .tmp-e2e/index.qmd
+      ```
+
+      on a fixture reproducing the report (`sort:` before `template:`).
+      Output inspected in the terminal; the caret moved from `sort: false`
+      to the template path:
+
+      ```
+      Warning: [Q-12-7] `template:` was set but `type:` is not `custom`; …
+         ╭─[ …/.tmp-e2e/index.qmd:5:15 ]
+       5 │     template: ../template.ejs
+         │               ───────┬───────
+      ```
+
+- [x] Connect docs re-rendered
+      (`cargo run --bin q2 -- render .` in `docs-quarto-2`). **All 15
+      Q-12-7 instances** now point at `template: ../template.ejs`,
+      including the originally-reported `cookbook/vanities/index.qmd`,
+      which moved from `4:11` (`sort: false`) to `5:15`. Full run: 186 of
+      186 files rendered, 9 errors / 310 warnings — still poor, as expected;
+      bd-oywyaouf and bd-lu16jgxq address the rest. Spot-checked Q-16-3 and
+      Q-5-3 spans in the same run: both point at real shortcode
+      invocations, so nothing was collaterally moved.
+- [x] **Snapshot report: zero `.snap` files changed.** This contradicts the
+      plan's prediction of tree-wide churn, and the reason is worth
+      recording: no existing snapshot ever captured a materialized
+      *container* span. The 154-vs-12 assertion imbalance that hid the bug
+      is the same thing that made the fix invisible to the suite. Scalar
+      spans — the ones snapshots do capture — were never affected, which
+      the Phase B "winning layer" test independently confirms.
 
 ## Key references
 

--- a/claude-notes/plans/2026-08-06-q12-7-listing-template-diagnostic.md
+++ b/claude-notes/plans/2026-08-06-q12-7-listing-template-diagnostic.md
@@ -1,0 +1,304 @@
+# Diagnostics blame the wrong key: materialized map spans (Q-12-7 and siblings)
+
+**Strand:** bd-9yh3pzfu (bug, p1) — child of bd-61cd (Listings epic)
+**Folded in:** bd-2mxo (metadata materialization drops source_info provenance)
+**Split out of this work:** bd-oywyaouf (EJS diagnostic), bd-lu16jgxq (Q-12-7 wording)
+**Handoff memo (external, separate session):**
+`claude-notes/scratch/2026-08-06-memo-quarto-source-map-default-sourceinfo.md`
+**Status:** plan drafted, awaiting user review. **Do not implement yet.**
+
+## Overview
+
+Rendering a Q1 site ported to Q2 (Posit Connect docs at
+`~/Desktop/daily-log/2026/08/05/q2-connect-docs/docs-quarto-2`) emits:
+
+```
+Warning: [Q-12-7] `template:` was set but `type:` is not `custom`; falling back to the built-in template for the declared type.
+   ╭─[ …/cookbook/vanities/index.qmd:4:11 ]
+   │
+ 4 │     sort: false
+   │           ──┬──
+   │             ╰──── `template:` was set but `type:` is not `custom`; …
+```
+
+The message talks about `template:` and `type:`; the caret points at
+`sort: false`, an unrelated sibling key.
+
+Investigating that render turned up three independent defects. **This
+strand is now scoped to the first one only** — the source-mapping bug. The
+other two are filed separately (see below); it is acceptable for the Connect
+docs to render worse in the interim, since that site is several fixes away
+from rendering well regardless.
+
+| Defect | Where it lives now |
+| --- | --- |
+| **A. Diagnostics blame the wrong key** | **this strand (bd-9yh3pzfu)** |
+| B. Q-12-7's text asserts a `type:` the user never declared | bd-lu16jgxq |
+| C. Unsupported EJS templates render as raw `<% … %>`, silently | bd-oywyaouf |
+
+The full investigation of B and C is preserved in the strand descriptions;
+this document keeps only what bears on A. Two findings from that
+investigation still matter here as *context*, because they explain why the
+narrow fix below is the right one:
+
+- Q1 makes `template:` **imply** `type: custom`
+  (`external-sources/quarto-cli/src/project/types/website/listing/website-listing-read.ts:1316-1320`),
+  so the YAML that triggered this is idiomatic Q1, not user error.
+- Q2 drops EJS deliberately — doctemplate replaced it so untrusted contexts
+  (hub-client) never execute arbitrary JS. The diagnostic gap around that is
+  bd-oywyaouf.
+
+## Diagnosis
+
+**Confirmed by direct experiment.** With the fixture above the caret lands
+on `false` (4:11, width 5). Reordering the keys so `template:` comes first
+moves the caret to `../template.ejs` (4:15, width 15). The map's
+`source_info` is *literally the first entry's value span*.
+
+The Q-12-7 call site blames the whole listing map:
+
+- `crates/quarto-core/src/project/listing/config.rs:534-541` — passes
+  `value` (the `ConfigValueKind::Map` for `listing:`) to `push_diag`.
+- `crates/quarto-core/src/project/listing/config.rs:928-940` — `push_diag`
+  attaches `value.source_info` verbatim.
+
+But the map's `source_info` is already wrong before listing code sees it:
+
+- `crates/quarto-config/src/materialize.rs:142-158` — a materialized Map's
+  `source_info` comes from `m.iter().next()`, the **first child's** value
+  span. (If that child is itself a map, the span becomes the
+  `programmatic_config` sentinel — no location at all.)
+- `crates/quarto-config/src/materialize.rs:109-113` — a materialized
+  Array's `source_info` comes from `.items.last()`, the **last** item.
+- `crates/quarto-config/src/materialize.rs:130-137` — every
+  `ConfigMapEntry.key_source` is replaced with
+  `SourceInfo::generated(By::programmatic_config())`.
+- The empty-map fallback is `SourceInfo::default()` —
+  `Original { FileId(0), 0..0 }`, a bogus offset-0 span rather than a
+  Generated sentinel, so it renders as a real-looking location in file 0.
+
+Parsing is not at fault. pampa's YAML→ConfigValue bridge
+(`crates/pampa/src/pandoc/meta.rs:175-193`) carries a real map span and a
+real `key_source`, and `rawblock_to_config_value` (`meta.rs:384-389`) even
+re-stamps the top-level frontmatter map to span the whole YAML body. All of
+it is discarded when
+`crates/quarto-core/src/stage/stages/metadata_merge.rs:266-288` replaces
+`doc.ast.meta` wholesale with `merged.materialize()`. The project-config
+path has its own parallel bridge (`crates/quarto-config/src/convert.rs:59-77`)
+with the same fate. This is bd-2mxo.
+
+### Blast radius
+
+Any diagnostic that blames a Map- or Array-kind `ConfigValue`, anywhere in
+the tree, points at an arbitrary sibling. Within listing config alone:
+`config.rs:337` (Q-12-4, duplicate id — `item` is a map), `config.rs:357`
+and `config.rs:388` (Q-12-1), `config.rs:711` (Q-12-3).
+
+Separately, the `key_source` loss silently breaks `config.rs:516-521`, where
+L5 captures `entry.key_source` into `l.categories_source` *specifically* to
+anchor Q-12-12. That anchor is the programmatic-config sentinel today, so
+the feature it exists to serve does not work. Worth confirming during the
+audit; the fix belongs to bd-2mxo, since there is no per-key span to restore
+from (below).
+
+### The spans are not lost — they are discarded in flight
+
+**Correction to an earlier reading of this code.** An initial pass
+concluded bd-2mxo was blocked on a `MergedCursor` API change, on the
+grounds that `MergedMap` carries only `keys: Vec<String>` and so has no
+spans to offer. That is true of `MergedMap` itself and false of the system:
+
+- `MergedConfig` holds `layers: Vec<&'a ConfigValue>`
+  (`merged.rs:100-107`) — **borrowed originals**, spans and `key_source`
+  intact. `MergedMap` is a *virtual* map computed over them, not a copy.
+- `MergedCursor::keys()` (`merged.rs:216-222`) already iterates the real
+  `ConfigMapEntry` structs from those layers and keeps only `entry.key`,
+  dropping `entry.key_source` on the floor.
+- `MergedCursor::as_value()` / `navigate_to()` (`merged.rs:238-245`)
+  already return the winning layer's `&ConfigValue`, `source_info` and all.
+
+So the fix is **additive accessors on `MergedMap`/`MergedCursor` plus
+rewiring the two synthesis sites in `materialize.rs`** — no redesign, and
+entirely inside `crates/quarto-config` (~1,200 lines across `merged.rs` and
+`materialize.rs`).
+
+**No external-crate work is required.** quarto-yaml already emits correct
+key spans — that is how the in-tree bridges capture them before merge
+discards them. quarto-source-map is a data type we are failing to
+propagate. The single genuinely-external item is its `Default` impl
+returning a plausible-looking `Original { FileId(0), 0..0 }` instead of a
+sentinel; that is written up for a separate session in
+`claude-notes/scratch/2026-08-06-memo-quarto-source-map-default-sourceinfo.md`
+and is **not** a prerequisite here. In-tree we avoid it by not routing
+through `Default`.
+
+### Both fixes are in scope, and neither subsumes the other
+
+Fixing materialization does *not* make the call-site fix unnecessary:
+quarto-yaml computes a mapping's span as first-key-start → `MappingEnd`
+(quarto-yaml 0.1.0 `src/parser.rs:513-525`), so even with perfect
+materialization, blaming the `listing:` map would underline the whole block
+starting at `sort:`. A diagnostic *about `template:`* must point at
+`template:`. Phase A fixes the blame target; Phase B fixes the spans that
+every other map-blaming diagnostic in the tree depends on.
+
+**Expected cost:** correcting container spans moves diagnostic locations
+tree-wide, so snapshot churn is expected and must be reported explicitly per
+the CLAUDE.md snapshot policy. This is a reason for care in Phase D, not a
+reason to defer.
+
+## Work Items
+
+Per CLAUDE.md, each phase writes its test first and confirms it fails.
+
+Phases A and B are independent and each is separately shippable; A is
+smaller and fixes the reported symptom, so it goes first. Phase 0's
+assertion helper is a prerequisite for both — without it neither phase can
+be tested for the thing that actually broke.
+
+### Phase 0 — Make spans assertable
+
+The reason this bug survived: **154 assertions in `crates/` check a
+diagnostic's `code`; ~12 touch its location.** `config.rs:1233` is typical —
+`assert_eq!(diags[0].code.as_deref(), Some("Q-12-7"))` passes cheerfully
+with a garbage span. Nothing here is testable until that changes, and the
+helper is worth having independently of both fixes (it is what would catch a
+regression from a future quarto-yaml/quarto-source-map bump).
+
+- [x] Add a test helper that resolves a `DiagnosticMessage`'s `SourceInfo`
+      to a concrete `(file, line, column, underlined text)` and asserts on
+      it. → `crates/quarto-config/src/span_assert.rs`, behind a
+      `span-assert` cargo feature that `quarto-core` enables as a
+      dev-dependency.
+      **Not `quarto-test`** as the plan guessed: that crate is a
+      document-level `_quarto.tests` smoke runner and *depends on*
+      `quarto-core`, so it sits above both consumers. `quarto-config` is
+      the lowest crate in the graph carrying both `quarto-source-map` and
+      `quarto-error-reporting`.
+- [x] Make the helper fail loudly on a defaulted/sentinel span rather than
+      reporting it as `file 0, line 1`. → `SpanProblem` enumerates each
+      distinct failure (`SuspiciousDefault`, `Generated`, `Concat`,
+      `UnknownFile`, `NoContent`, `OutOfBounds`) so a failing assertion
+      says *why*. `resolve_span` checks for `Original { FileId(0), 0..0 }`
+      before resolving, and a unit test pins that behavior so the helper
+      can't silently regress into leniency.
+- [x] Add a minimal in-repo fixture. → Inline in the test rather than
+      on-disk: `parse_from_yaml` in `config.rs`'s test module drives the
+      **real** path (YAML → `yaml_to_config_value` → `MergedConfig` →
+      `materialize` → `parse_listings`), matching what
+      `transforms/listing_generate.rs:72` reads at render time. Going
+      through `materialize` is the point — skipping it skips the defect.
+- [x] Failing test confirmed: `q_12_7_underlines_the_template_key_not_a_sibling`
+
+      ```
+      diagnostic [Q-12-7] underlines the wrong text
+        expected: "../template.ejs"
+        actual:   "false"
+        at:       index.qmd:3:11
+      ```
+
+      This is the user-reported bug reproduced in-process, down to the
+      underlined text. Note the pre-existing `template_with_non_custom_type_emits_q_12_7`
+      test passes against the same broken behavior — the code-only
+      assertion cannot see it.
+
+### Phase A — Blame the right key (listing call sites)
+
+- [x] In `parse_one_listing`, capture the `template:` entry's `ConfigValue`
+      while walking the map (`template_source`), and blame it in the Q-12-7
+      `push_diag`.
+- [x] Phase 0's test passes.
+- [x] Audit the other map-blaming `push_diag` sites in the same file.
+
+**Audit result.** Of the sites that blame a container, only one besides
+Q-12-7 had a better span available at the call site:
+
+| Site | Code | Verdict |
+| --- | --- | --- |
+| `parse_listings` array loop | `Q-12-4` | **Fixed.** Blamed the whole listing map; now blames the offending `id:` value via a new `map_entry_value` helper. Confirmed failing first — it underlined `"contents: ./b.qmd\n      id: dupe\n"`. |
+| `parse_contents` inline record | `Q-12-2` | **Phase B.** The diagnostic is *about* the whole inline record, so the map genuinely is the right thing to blame. It reads wrong today only because the map's span is wrong. |
+| `parse_listings` fallthrough | `Q-12-1` | **No change.** Blames the offending value, which is a scalar-ish kind in this branch (the code notes these never occur in practice). |
+| `parse_one_listing` non-map | `Q-12-1` | **Phase B.** Already blames the right value; if that value is an array its container span is wrong. |
+| `parse_sort` fallthrough | `Q-12-3` | **Phase B.** Already blames the `sort:` value itself; wrong only when that value is a map/array. |
+
+The pattern: call-site fixes handle "blaming the wrong *node*"; Phase B
+handles "blaming the right node, which carries a wrong *span*". The three
+Phase B rows are why Phase A does not close this strand.
+
+- [x] Span assertions added for both changed sites
+      (`q_12_7_underlines_the_template_key_not_a_sibling`,
+      `q_12_4_underlines_the_duplicate_id_not_a_sibling`), each confirmed to
+      fail before its fix.
+
+### Phase B — Preserve real spans through materialization (bd-2mxo)
+
+- [ ] Failing tests first, at the `quarto-config` level: materializing a
+      multi-layer map must yield (a) a container `source_info` that is the
+      real mapping span, not the first child's value; (b) a container span
+      for arrays that is not merely the last item's; (c) `key_source` values
+      that point at the real keys.
+- [ ] Add accessors on `MergedMap`/`MergedCursor` exposing the winning
+      layer's container `SourceInfo` and per-entry `key_source`, resolved
+      against `config.layers` the same way `keys()` and `as_value()` already
+      navigate (`merged.rs:200-245`).
+- [ ] Rewire `materialize_cursor`'s Map arm (`materialize.rs:121-165`) and
+      Array arm (`materialize.rs:93-120`) to use them.
+- [ ] Replace the three `unwrap_or_default()` fallbacks
+      (`materialize.rs:113`, `:154`, `:158`) with an explicit
+      `SourceInfo::generated(By::…)` sentinel. Do **not** rely on
+      `SourceInfo`'s `Default` — see the memo; `Original { FileId(0), 0..0 }`
+      is exactly the plausible-looking lie that hid this bug.
+- [ ] Re-check the decision at `materialize.rs:155` (a first child that is
+      itself a map currently yields the `programmatic_config` sentinel) —
+      with real container spans available it should no longer need a
+      sentinel at all.
+- [ ] Confirm L5's `categories_source` capture (`config.rs:516-521`) is now
+      receiving a real key span. It was added specifically to anchor
+      Q-12-12 and is very likely inert today; add a span assertion for it.
+- [ ] Consider an xtask lint for `unwrap_or_default()` on `SourceInfo`-typed
+      expressions — the crate's own doc comment promises "separate grep
+      tooling" that does not exist (`crates/xtask/src/lint/` has only
+      `external_sources.rs` and `metadata_as_str.rs`). File separately if it
+      grows beyond a small rule.
+
+### Phase C — Verification
+
+- [ ] `cargo nextest run --workspace`.
+- [ ] `cargo xtask verify` — this touches `quarto-config` and `quarto-core`,
+      both in the WASM closure; full verify, not `--skip-hub-build`.
+- [ ] End-to-end per CLAUDE.md: render the in-repo fixture through
+      `cargo run --bin q2 -- render …`, and record here (a) the exact
+      invocation, (b) the new caret position and underlined text, (c) an
+      explicit note that the terminal output was inspected.
+- [ ] Sanity-check against the Connect docs
+      (`~/Desktop/daily-log/2026/08/05/q2-connect-docs/docs-quarto-2`) that
+      Q-12-7 now points at `template:`. The site is still expected to render
+      poorly — bd-oywyaouf and bd-lu16jgxq are the strands that address that.
+- [ ] **Snapshot report.** Phase B moves diagnostic locations tree-wide.
+      Per the CLAUDE.md snapshot policy: report the count of `.snap` files
+      changed, summarize what changed and why, and explicitly flag any
+      snapshot whose new span is *not* obviously an improvement — a
+      container span moving is expected; a scalar span moving is not, and
+      would mean Phase B overreached.
+
+## Key references
+
+| What | Where |
+| --- | --- |
+| Q-12-7 emission (blames the map) | `crates/quarto-core/src/project/listing/config.rs:534-541` |
+| `push_diag` (attaches span verbatim) | `crates/quarto-core/src/project/listing/config.rs:928-940` |
+| Other map-blaming sites to audit | `config.rs:337`, `:357`, `:388`, `:711` |
+| L5 `categories_source` capture (likely broken) | `crates/quarto-core/src/project/listing/config.rs:516-521` |
+| Map span borrowed from first child | `crates/quarto-config/src/materialize.rs:142-158` |
+| Array span borrowed from last item | `crates/quarto-config/src/materialize.rs:109-113` |
+| `key_source` discarded | `crates/quarto-config/src/materialize.rs:130-137` |
+| Correct spans upstream (pampa) | `crates/pampa/src/pandoc/meta.rs:175-193`, `:384-389` |
+| Project-config bridge (same fate) | `crates/quarto-config/src/convert.rs:59-77` |
+| Where the good spans are thrown away | `crates/quarto-core/src/stage/stages/metadata_merge.rs:266-288` |
+| `MergedConfig` borrows the original layers (spans intact) | `crates/quarto-config/src/merged.rs:100-107` |
+| `keys()` sees real `ConfigMapEntry`s, drops `key_source` | `crates/quarto-config/src/merged.rs:216-222` |
+| `as_value()` returns the winning layer's `&ConfigValue` | `crates/quarto-config/src/merged.rs:238-245` |
+| `SourceInfo::default()` = `Original{FileId(0),0..0}` | quarto-source-map 0.1.1 `src/source_info.rs:139-147` |
+| Provenance contract (§10: `default()` is a bug) | `claude-notes/designs/provenance-contract.md` |
+| YAML mapping span = first-key-start → MappingEnd | quarto-yaml 0.1.0 `src/parser.rs:513-525` |
+| Catalog entry | `crates/quarto-error-catalog/error_catalog.json:926-932` |

--- a/claude-notes/scratch/2026-08-06-memo-quarto-source-map-default-sourceinfo.md
+++ b/claude-notes/scratch/2026-08-06-memo-quarto-source-map-default-sourceinfo.md
@@ -1,0 +1,145 @@
+# Memo: `SourceInfo::default()` fabricates a plausible-looking real location
+
+**To:** whoever picks up `posit-dev/quarto-source-map`
+**From:** q2 session on bd-9yh3pzfu / bd-2mxo (2026-08-06)
+**Checkout:** `~/repos/github/posit-dev/quarto-source-map` @ `b61b447` (release-0.1.1)
+**Consumer evidence:** `~/rooms/room-1/q2` (q2 monorepo)
+**Scope:** small and self-contained. This is the *only* piece of the
+bd-2mxo investigation that lives outside q2.
+
+## The problem
+
+`SourceInfo`'s `Default` impl returns a well-formed `Original` span:
+
+```rust
+// src/source_info.rs:139-147
+impl Default for SourceInfo {
+    fn default() -> Self {
+        SourceInfo::Original {
+            file_id: FileId(0),
+            start_offset: 0,
+            end_offset: 0,
+        }
+    }
+}
+```
+
+Downstream this is **indistinguishable from a genuine span into file 0 at
+offset 0**. It is not a sentinel — it is a claim, and a false one. A
+diagnostic carrying it renders with a real-looking file, line, and caret
+pointing at the first byte of whatever file happens to be `FileId(0)`.
+Nothing anywhere can tell that apart from a true location, because there is
+nothing to tell apart: the variant, the field values, and the rendering path
+are all identical to the real thing.
+
+The crate is already half-aware of this. `SourceInfo::default()` is
+deprecated via an inherent method that shadows `Default::default()`
+(`src/source_info.rs:149-168`), and its doc comment is explicit about the
+remaining hole:
+
+> This inherent method shadows `Default::default()` so that callers writing
+> `SourceInfo::default()` see a deprecation error under `deny(deprecated)`.
+> The trait impl is retained (and called by this method) so that
+> `unwrap_or_default()` and `#[derive(Default)]` still compile; **those are
+> caught by separate grep tooling.**
+
+## Why this is worth doing now
+
+**The grep tooling does not exist.** I looked for it on the consumer side,
+where the crate's lints live: `q2/crates/xtask/src/lint/` contains exactly
+two rules (`external_sources.rs`, `metadata_as_str.rs`), neither related.
+There is no CI grep for `unwrap_or_default` on `SourceInfo` either. So the
+shadowing trick catches the explicit call form and nothing else, and the
+`unwrap_or_default()` escape hatch has been entirely unpoliced.
+
+**That hole is load-bearing in a live q2 bug.** q2's config materializer
+reaches for it at exactly the three sites at the heart of bd-2mxo:
+
+- `q2/crates/quarto-config/src/materialize.rs:113` — materialized array
+  container span
+- `q2/crates/quarto-config/src/materialize.rs:154` — first-entry array
+  fallback
+- `q2/crates/quarto-config/src/materialize.rs:158` — materialized **map**
+  container span
+
+The user-visible symptom that started this: a listing diagnostic (`Q-12-7`)
+whose message talks about `template:` while its caret underlines an
+unrelated sibling key. The map-span synthesis is q2's bug to fix and we are
+fixing it in-tree — but the reason a bogus fallback could travel that far
+without tripping anything is that `Default` hands out something that looks
+real.
+
+**The consumer already has a written contract this violates.** q2's
+`claude-notes/designs/provenance-contract.md` §10 opens its do-not list
+with:
+
+> **Don't emit `SourceInfo::default()` for new synthesized nodes.** ...
+> `default()` survives in the Pandoc JSON reader by design (the source bytes
+> genuinely don't exist there) and in test scaffolding; everywhere else it's
+> a bug.
+
+The contract and the crate agree on the intent. The type just doesn't
+enforce it.
+
+## Recommendation
+
+**Change what `Default` returns rather than removing the impl:**
+
+```rust
+impl Default for SourceInfo {
+    fn default() -> Self {
+        SourceInfo::Generated { by: By::unknown(), from: SmallVec::new() }
+    }
+}
+```
+
+Why this shape:
+
+- **It uses a concept the contract already sanctions.** `By::unknown()`
+  exists and is documented in the provenance-contract table as the "We don't
+  know" placeholder (currently used by
+  `json::read_completing_source_info` for nodes deserialized without `s:`).
+  This is not a new idea, just applying the existing one to the default.
+- **It closes the hole without a type-level break.** Every
+  `unwrap_or_default()` and `#[derive(Default)]` keeps compiling. The value
+  simply stops lying: it renders as "no known location" instead of
+  fabricating file 0 offset 0. That converts a silent wrong-caret into a
+  visible absent-caret, which is the behavior you want from a fallback.
+- **It is strictly better than the status quo even if nothing else
+  changes.** No consumer migration is required for the improvement to land.
+
+Removing the `Default` impl outright is the more principled end state and
+worth considering, but it is a genuinely breaking change with an unmeasured
+ripple through `#[derive(Default)]` on containing structs. I'd sequence it
+after the above, if at all.
+
+## What to check before landing
+
+I did not verify these; they're the risks I'd want closed.
+
+1. **Does anything pattern-match `Default`'s output expecting `Original`?**
+   Grep the crate and consumers for matches on `SourceInfo::Original` that
+   could receive a defaulted value.
+2. **Tiling / ordering logic.** q2's Plan 7g has a "tiling precondition"
+   over source ranges. If any of it assumes a defaulted `SourceInfo` is
+   `Original` and therefore orderable by offset, a `Generated` default
+   changes that. Search q2 for tiling code that consumes container spans.
+3. **Serialization.** `Generated` serializes with `by`/`from` rather than
+   offsets; confirm the wire format and any snapshots that currently
+   round-trip a defaulted value.
+4. **`for_test()`.** Confirm the test-scaffolding path (`SourceInfo::for_test()`)
+   is unaffected — tests that want a real-looking span should keep using it
+   explicitly.
+
+## Complementary work that is *not* yours
+
+For completeness, so the two sessions don't collide:
+
+- The **map/array container-span synthesis** in `materialize.rs` is q2's
+  bug (bd-2mxo), being fixed in-tree in `crates/quarto-config`. It needs no
+  change to quarto-source-map, and no change to quarto-yaml (which already
+  emits correct key spans).
+- The **missing lint** for `unwrap_or_default()` on `SourceInfo`-typed
+  expressions belongs in q2's `crates/xtask/src/lint/`, not in this crate —
+  that's where the "separate grep tooling" the doc comment promises should
+  have lived. Filing it on the q2 side.

--- a/crates/quarto-config/Cargo.toml
+++ b/crates/quarto-config/Cargo.toml
@@ -20,8 +20,18 @@ indexmap = "2.13"
 thiserror = { workspace = true }
 yaml-rust2 = { workspace = true }
 
+[features]
+# Test-only helpers for asserting *where* a diagnostic points, not just
+# which code it carries. Lives here because quarto-config is the lowest
+# crate in the graph with both quarto-source-map and quarto-error-reporting
+# available; quarto-core enables it as a dev-dependency. See
+# `src/span_assert.rs` for why span assertions need their own scaffolding.
+span-assert = []
+
 [dev-dependencies]
 insta = { workspace = true }
+# Self-enable so this crate's own `span_assert` unit tests compile.
+quarto-config = { path = ".", features = ["span-assert"] }
 
 [lints]
 workspace = true

--- a/crates/quarto-config/src/lib.rs
+++ b/crates/quarto-config/src/lib.rs
@@ -41,6 +41,8 @@ mod convert;
 mod format;
 mod materialize;
 mod merged;
+#[cfg(feature = "span-assert")]
+pub mod span_assert;
 mod tag;
 mod types;
 mod website;

--- a/crates/quarto-config/src/materialize.rs
+++ b/crates/quarto-config/src/materialize.rs
@@ -66,6 +66,33 @@ impl<'a> MergedConfig<'a> {
     }
 }
 
+/// The span to stamp on a materialized container (map or array).
+///
+/// Delegates to [`MergedCursor::container_source`], which returns the
+/// real span from the highest-priority layer holding a value at this
+/// path.
+///
+/// # Why not `unwrap_or_default()`
+///
+/// This used to fall back to `SourceInfo::default()`, which is
+/// `Original { file_id: FileId(0), 0..0 }` — a *well-formed* span that
+/// renders as a genuine location at the first byte of file 0. A
+/// fallback that fabricates a plausible location is worse than one that
+/// admits ignorance: it turns "we don't know where this came from" into
+/// a confident wrong answer that no downstream consumer can detect.
+/// `By::unknown()` is the sanctioned "we don't know" marker
+/// (`claude-notes/designs/provenance-contract.md` §10).
+///
+/// Reaching the fallback means no layer had a value at a path we just
+/// resolved a container for, which should not happen; it is defensive
+/// rather than expected.
+fn container_source(cursor: &MergedCursor<'_>) -> SourceInfo {
+    cursor
+        .container_source()
+        .cloned()
+        .unwrap_or_else(|| SourceInfo::generated(By::unknown()))
+}
+
 /// Materialize a cursor's value into an owned ConfigValue.
 fn materialize_cursor(
     cursor: &MergedCursor<'_>,
@@ -105,16 +132,9 @@ fn materialize_cursor(
                 })
                 .collect();
 
-            // Find source_info from the most recent layer that contributed
-            let source_info = array
-                .items
-                .last()
-                .map(|item| item.value.source_info.clone())
-                .unwrap_or_default();
-
             Ok(ConfigValue {
                 value: ConfigValueKind::Array(items),
-                source_info,
+                source_info: container_source(cursor),
                 merge_op: MergeOp::Concat, // Materialized arrays don't have prefer semantics
             })
         }
@@ -129,37 +149,22 @@ fn materialize_cursor(
                 path.pop();
                 entries.push(ConfigMapEntry {
                     key: key.to_string(),
-                    // Materialization across layers loses per-key source
-                    // info; the programmatic-config sentinel is honest
-                    // about that.
-                    key_source: SourceInfo::generated(By::programmatic_config()),
+                    // The key's real span, from the layer that supplies
+                    // the winning value. Materialization used to discard
+                    // this and stamp a programmatic-config sentinel,
+                    // which silently disabled every diagnostic anchored
+                    // on a key — see `container_source` (bd-2mxo).
+                    key_source: cursor
+                        .key_source(key)
+                        .cloned()
+                        .unwrap_or_else(|| SourceInfo::generated(By::unknown())),
                     value: child_value,
                 });
             }
 
-            // Source info: use the cursor's path to find a representative source
-            // In practice, maps from different layers may have different sources
-            let source_info = cursor
-                .as_map()
-                .and_then(|m| {
-                    m.iter()
-                        .next()
-                        .and_then(|(_, c)| c.as_value())
-                        .map(|v| match v {
-                            MergedValue::Scalar(s) => s.value.source_info.clone(),
-                            MergedValue::Array(a) => a
-                                .items
-                                .first()
-                                .map(|i| i.value.source_info.clone())
-                                .unwrap_or_default(),
-                            MergedValue::Map(_) => SourceInfo::generated(By::programmatic_config()),
-                        })
-                })
-                .unwrap_or_default();
-
             Ok(ConfigValue {
                 value: ConfigValueKind::Map(entries),
-                source_info,
+                source_info: container_source(cursor),
                 merge_op: MergeOp::Concat,
             })
         }
@@ -414,5 +419,149 @@ mod tests {
         let items = result.get("items").unwrap();
         assert!(items.is_array());
         assert!(items.as_array().unwrap().is_empty());
+    }
+
+    // ── source-span preservation (bd-2mxo / bd-9yh3pzfu) ────────────
+    //
+    // The helpers above stamp `SourceInfo::for_test()` on everything,
+    // which is why the span defect was invisible here for so long: with
+    // synthetic inputs, a synthesized output span looks identical to a
+    // preserved one. These tests parse real YAML so the spans mean
+    // something, and assert on the *text* each span covers.
+    mod spans {
+        use super::*;
+        use crate::span_assert::{ResolvedSpan, resolve_span};
+        use quarto_source_map::SourceContext;
+
+        /// Parse real YAML into a `ConfigValue` whose spans point into
+        /// `text`, plus a context that can resolve them.
+        fn layer(name: &str, text: &str) -> (ConfigValue, SourceContext) {
+            let parsed = quarto_yaml::parse_file(text, name).expect("valid yaml");
+            let mut diags = Vec::new();
+            let cv = crate::config_value_from_yaml(parsed, &mut diags);
+            (cv, crate::span_assert::context_for(name, text))
+        }
+
+        fn span_of(value: &ConfigValue, ctx: &SourceContext) -> ResolvedSpan {
+            resolve_span(&value.source_info, ctx)
+                .unwrap_or_else(|p| panic!("span should resolve, got: {p}"))
+        }
+
+        const DOC: &str = "\
+listing:
+    sort: false
+    template: t.ejs
+";
+
+        #[test]
+        fn map_container_span_covers_the_mapping_not_its_first_value() {
+            let (cv, ctx) = layer("doc.yml", DOC);
+            let merged = MergedConfig::new(vec![&cv]).materialize().unwrap();
+
+            let listing = merged.get("listing").expect("listing key");
+            let span = span_of(listing, &ctx);
+
+            // The bug: the container borrowed its first entry's *value*
+            // span, so this was exactly "false".
+            assert_ne!(
+                span.text, "false",
+                "map container span is still borrowing its first entry's value"
+            );
+            // quarto-yaml spans a mapping from its first key to
+            // MappingEnd, so the whole block is the correct answer.
+            assert!(
+                span.text.starts_with("sort:") && span.text.contains("template: t.ejs"),
+                "expected the whole mapping, got {:?}",
+                span.text
+            );
+        }
+
+        #[test]
+        fn map_entries_keep_their_real_key_spans() {
+            let (cv, ctx) = layer("doc.yml", DOC);
+            let merged = MergedConfig::new(vec![&cv]).materialize().unwrap();
+
+            let listing = merged.get("listing").expect("listing key");
+            let ConfigValueKind::Map(entries) = &listing.value else {
+                panic!("expected a map");
+            };
+
+            for entry in entries {
+                let span = resolve_span(&entry.key_source, &ctx).unwrap_or_else(|p| {
+                    panic!(
+                        "key `{}` should have a real key_source, got: {p}",
+                        entry.key
+                    )
+                });
+                assert_eq!(
+                    span.text, entry.key,
+                    "key_source should cover the key itself"
+                );
+            }
+        }
+
+        #[test]
+        fn array_container_span_is_not_merely_its_last_item() {
+            const ARR: &str = "\
+contents:
+    - ./a.qmd
+    - ./b.qmd
+";
+            let (cv, ctx) = layer("arr.yml", ARR);
+            let merged = MergedConfig::new(vec![&cv]).materialize().unwrap();
+
+            let contents = merged.get("contents").expect("contents key");
+            let span = span_of(contents, &ctx);
+
+            // The bug: `.items.last()` gave exactly "./b.qmd".
+            assert_ne!(
+                span.text, "./b.qmd",
+                "array container span is still borrowing its last item"
+            );
+            assert!(
+                span.text.contains("./a.qmd") && span.text.contains("./b.qmd"),
+                "expected the whole sequence, got {:?}",
+                span.text
+            );
+        }
+
+        #[test]
+        fn nested_map_first_child_no_longer_collapses_to_a_sentinel() {
+            // When the first entry was itself a map, the old code gave
+            // up entirely and stamped a programmatic-config sentinel.
+            const NESTED: &str = "\
+outer:
+    inner:
+        a: 1
+    sibling: 2
+";
+            let (cv, ctx) = layer("nested.yml", NESTED);
+            let merged = MergedConfig::new(vec![&cv]).materialize().unwrap();
+
+            let outer = merged.get("outer").expect("outer key");
+            let span = span_of(outer, &ctx);
+            assert!(
+                span.text.starts_with("inner:"),
+                "expected the outer mapping's real span, got {:?}",
+                span.text
+            );
+        }
+
+        #[test]
+        fn winning_layer_supplies_the_span_when_layers_disagree() {
+            // Values are last-wins; the span should follow the value.
+            let (base, _base_ctx) = layer("base.yml", "listing:\n    sort: true\n");
+            let (over, over_ctx) = layer("over.yml", "listing:\n    sort: false\n");
+
+            let merged = MergedConfig::new(vec![&base, &over]).materialize().unwrap();
+            let listing = merged.get("listing").expect("listing key");
+            let sort = listing.get("sort").expect("sort key");
+
+            // `over.yml` won the value, so its span must resolve there.
+            let span = resolve_span(&sort.source_info, &over_ctx)
+                .expect("winning value's span should resolve in the winning layer");
+            assert_eq!(span.path, "over.yml");
+            assert_eq!(span.text, "false");
+        }
     }
 }

--- a/crates/quarto-config/src/merged.rs
+++ b/crates/quarto-config/src/merged.rs
@@ -28,6 +28,7 @@
 //! ```
 
 use crate::types::{ConfigValue, ConfigValueKind, MergeOp};
+use quarto_source_map::SourceInfo;
 use std::collections::HashSet;
 
 /// A lazily-evaluated merged configuration.
@@ -349,6 +350,47 @@ impl<'a> MergedCursor<'a> {
             config: self.config,
             path: self.path.clone(),
             keys,
+        })
+    }
+
+    /// The `SourceInfo` of the container at this path, taken from the
+    /// highest-priority layer that has a value here.
+    ///
+    /// Merged containers exist in several layers at once, so "the"
+    /// span is a choice. This picks the same layer [`as_value`] and
+    /// [`as_scalar`] pick — the highest-priority (last-wins) one — so a
+    /// container's span and its winning contents point at the same
+    /// file. For document metadata that is the layer nearest the
+    /// author: front matter over project config.
+    ///
+    /// Returns the layer's span verbatim, including `Generated` spans
+    /// from programmatically-constructed layers: a synthesized layer
+    /// should keep saying it was synthesized rather than borrow a
+    /// neighbour's location.
+    ///
+    /// [`as_value`]: MergedCursor::as_value
+    /// [`as_scalar`]: MergedCursor::as_scalar
+    pub fn container_source(&self) -> Option<&'a SourceInfo> {
+        self.config
+            .layers
+            .iter()
+            .rev()
+            .find_map(|layer| self.navigate_to(layer).map(|v| &v.source_info))
+    }
+
+    /// The `SourceInfo` of `key`'s *key token* in the map at this path,
+    /// taken from the highest-priority layer whose map declares it.
+    ///
+    /// A key can appear in several layers; this follows the layer that
+    /// supplies the winning value, so a diagnostic anchored on the key
+    /// points at the file the reader would edit to change it.
+    pub fn key_source(&self, key: &str) -> Option<&'a SourceInfo> {
+        self.config.layers.iter().rev().find_map(|layer| {
+            let value = self.navigate_to(layer)?;
+            let ConfigValueKind::Map(entries) = &value.value else {
+                return None;
+            };
+            entries.iter().find(|e| e.key == key).map(|e| &e.key_source)
         })
     }
 

--- a/crates/quarto-config/src/span_assert.rs
+++ b/crates/quarto-config/src/span_assert.rs
@@ -1,0 +1,306 @@
+/*
+ * quarto-config/src/span_assert.rs
+ * Copyright (c) 2026 Posit, PBC
+ *
+ * Test-only helpers for asserting that a SourceInfo points where it should.
+ */
+
+//! Resolve a [`SourceInfo`] to the concrete source text it claims to cover,
+//! so tests can assert on *where a diagnostic points* rather than only on
+//! which code it carries.
+//!
+//! # Why this exists
+//!
+//! At the time this module was added, `crates/` held 154 assertions on a
+//! diagnostic's `code` and roughly a dozen that touched its location. That
+//! asymmetry is why bd-9yh3pzfu survived: `Q-12-7`'s caret underlined an
+//! unrelated sibling key for as long as the diagnostic existed, and the
+//! test covering it —
+//!
+//! ```ignore
+//! assert_eq!(diags[0].code.as_deref(), Some("Q-12-7"));
+//! ```
+//!
+//! — passed the whole time. A code-only assertion cannot fail on a wrong
+//! span.
+//!
+//! # Why it refuses to be lenient
+//!
+//! [`SourceInfo`]'s `Default` is `Original { file_id: FileId(0), 0..0 }` —
+//! a well-formed span that is indistinguishable downstream from a genuine
+//! location at the first byte of file 0. A helper that quietly rendered it
+//! as `line 1, column 1` would reproduce, inside the test suite, exactly
+//! the failure mode the suite is meant to catch. So [`resolve_span`]
+//! reports it as [`SpanProblem::SuspiciousDefault`] instead.
+//!
+//! See `claude-notes/scratch/2026-08-06-memo-quarto-source-map-default-sourceinfo.md`
+//! for the upstream fix that would make that check unnecessary.
+//!
+//! # Fixtures must come from real text
+//!
+//! Most existing config tests build values with `SourceInfo::for_test()`.
+//! Those spans are synthetic, so a wrong output span is indistinguishable
+//! from a right one — the bug is invisible by construction. Tests that mean
+//! to assert on spans must parse real source text; [`context_for`] builds
+//! the matching [`SourceContext`].
+
+use quarto_error_reporting::DiagnosticMessage;
+use quarto_source_map::{FileId, SourceContext, SourceInfo};
+
+/// A [`SourceInfo`] resolved against a [`SourceContext`], in the terms a
+/// reader of the rendered diagnostic sees.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedSpan {
+    /// Path as registered in the [`SourceContext`].
+    pub path: String,
+    /// 1-based line of the span's start, matching rendered output.
+    pub line: usize,
+    /// 1-based column of the span's start, matching rendered output.
+    pub column: usize,
+    /// The source bytes the span actually covers — what gets underlined.
+    pub text: String,
+}
+
+/// Why a [`SourceInfo`] could not be resolved to concrete source text.
+///
+/// Every variant is a distinct diagnosis rather than a generic failure:
+/// when a span assertion fails, the reason is usually the interesting part.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SpanProblem {
+    /// The diagnostic carried no location at all.
+    NoLocation,
+    /// `Original { file_id: FileId(0), 0..0 }` — almost certainly a
+    /// defaulted `SourceInfo` rather than a real span into file 0.
+    SuspiciousDefault,
+    /// A `Generated` span with no invocation anchor: synthesized content
+    /// with no source preimage to point at.
+    Generated,
+    /// A `Concat` span: spans multiple sources, so it has no single range.
+    Concat,
+    /// The file is not registered in the supplied [`SourceContext`].
+    UnknownFile { file_id: usize },
+    /// The file is registered but its content was not retained.
+    NoContent { path: String },
+    /// The byte range falls outside the file's content.
+    OutOfBounds {
+        path: String,
+        start: usize,
+        end: usize,
+        len: usize,
+    },
+}
+
+impl std::fmt::Display for SpanProblem {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SpanProblem::NoLocation => write!(f, "diagnostic carries no location"),
+            SpanProblem::SuspiciousDefault => write!(
+                f,
+                "span is Original {{ FileId(0), 0..0 }} — a defaulted SourceInfo, \
+                 not a real location (see span_assert module docs)"
+            ),
+            SpanProblem::Generated => write!(
+                f,
+                "span is Generated with no invocation anchor (synthesized, no source preimage)"
+            ),
+            SpanProblem::Concat => {
+                write!(
+                    f,
+                    "span is Concat (covers multiple sources, no single range)"
+                )
+            }
+            SpanProblem::UnknownFile { file_id } => {
+                write!(
+                    f,
+                    "FileId({file_id}) is not registered in the SourceContext"
+                )
+            }
+            SpanProblem::NoContent { path } => {
+                write!(f, "file `{path}` is registered without content")
+            }
+            SpanProblem::OutOfBounds {
+                path,
+                start,
+                end,
+                len,
+            } => write!(f, "range {start}..{end} is outside `{path}` (length {len})"),
+        }
+    }
+}
+
+/// Build a [`SourceContext`] for text parsed via `quarto_yaml::parse_file`
+/// under the same `filename`.
+///
+/// `quarto-yaml` derives its `FileId` by hashing the filename
+/// (`quarto_yaml::file_id_for_filename`) rather than allocating
+/// sequentially, so a context built with `add_file` would not resolve those
+/// spans. This registers the file under the id the parser will actually
+/// use.
+pub fn context_for(filename: &str, content: &str) -> SourceContext {
+    let mut ctx = SourceContext::new();
+    let file_id = quarto_yaml::file_id_for_filename(filename);
+    ctx.add_file_with_id(file_id, filename.to_string(), Some(content.to_string()));
+    ctx
+}
+
+/// Resolve a [`SourceInfo`] to the source text it covers.
+pub fn resolve_span(info: &SourceInfo, ctx: &SourceContext) -> Result<ResolvedSpan, SpanProblem> {
+    // Diagnose the shapes that cannot resolve *before* asking for a byte
+    // range, so the caller gets the specific reason rather than a bare
+    // `None`. `resolve_byte_range` folds several distinct cases together.
+    match info {
+        SourceInfo::Original {
+            file_id,
+            start_offset,
+            end_offset,
+        } if file_id.0 == 0 && *start_offset == 0 && *end_offset == 0 => {
+            return Err(SpanProblem::SuspiciousDefault);
+        }
+        SourceInfo::Concat { .. } => return Err(SpanProblem::Concat),
+        SourceInfo::Generated { .. } if info.invocation_anchor().is_none() => {
+            return Err(SpanProblem::Generated);
+        }
+        _ => {}
+    }
+
+    let (file_id, start, end) = info.resolve_byte_range().ok_or(SpanProblem::Generated)?;
+
+    let file = ctx
+        .get_file(FileId(file_id))
+        .ok_or(SpanProblem::UnknownFile { file_id })?;
+    let content = file
+        .content
+        .as_deref()
+        .ok_or_else(|| SpanProblem::NoContent {
+            path: file.path.clone(),
+        })?;
+
+    if start > end || end > content.len() {
+        return Err(SpanProblem::OutOfBounds {
+            path: file.path.clone(),
+            start,
+            end,
+            len: content.len(),
+        });
+    }
+
+    let location =
+        quarto_source_map::offset_to_location(content, start).ok_or(SpanProblem::OutOfBounds {
+            path: file.path.clone(),
+            start,
+            end,
+            len: content.len(),
+        })?;
+
+    Ok(ResolvedSpan {
+        path: file.path.clone(),
+        // `Location` is 0-indexed; rendered diagnostics are 1-indexed.
+        line: location.row + 1,
+        column: location.column + 1,
+        text: content[start..end].to_string(),
+    })
+}
+
+/// Resolve the location a [`DiagnosticMessage`] points at.
+pub fn resolve_diagnostic_span(
+    diag: &DiagnosticMessage,
+    ctx: &SourceContext,
+) -> Result<ResolvedSpan, SpanProblem> {
+    let info = diag.location.as_ref().ok_or(SpanProblem::NoLocation)?;
+    resolve_span(info, ctx)
+}
+
+/// Assert that `diag` underlines exactly `expected`.
+///
+/// Panics with the resolved location (or the specific [`SpanProblem`]) so a
+/// failure says what the diagnostic *did* point at, not merely that it
+/// mismatched.
+#[track_caller]
+pub fn assert_diagnostic_underlines(diag: &DiagnosticMessage, ctx: &SourceContext, expected: &str) {
+    match resolve_diagnostic_span(diag, ctx) {
+        Ok(span) if span.text == expected => {}
+        Ok(span) => panic!(
+            "diagnostic [{}] underlines the wrong text\n  \
+             expected: {expected:?}\n  \
+             actual:   {:?}\n  \
+             at:       {}:{}:{}",
+            diag.code.as_deref().unwrap_or("<no code>"),
+            span.text,
+            span.path,
+            span.line,
+            span.column,
+        ),
+        Err(problem) => panic!(
+            "diagnostic [{}] has no usable span: {problem}\n  expected it to underline {expected:?}",
+            diag.code.as_deref().unwrap_or("<no code>"),
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const YAML: &str = "listing:\n    sort: false\n    template: t.ejs\n";
+
+    fn fixture() -> (quarto_yaml::YamlWithSourceInfo, SourceContext) {
+        let parsed = quarto_yaml::parse_file(YAML, "fixture.yml").expect("valid yaml");
+        (parsed, context_for("fixture.yml", YAML))
+    }
+
+    #[test]
+    fn resolves_a_real_scalar_span_to_its_text() {
+        let (parsed, ctx) = fixture();
+        let listing = parsed.get_hash_value("listing").expect("listing key");
+        let template = listing.get_hash_value("template").expect("template key");
+
+        let span = resolve_span(&template.source_info, &ctx).expect("resolvable");
+        assert_eq!(span.text, "t.ejs");
+        assert_eq!(span.path, "fixture.yml");
+        // Third line of YAML, 1-based.
+        assert_eq!(span.line, 3);
+    }
+
+    #[test]
+    fn line_and_column_are_one_based() {
+        let (parsed, ctx) = fixture();
+        // `listing` is the very first byte of the file.
+        let span = resolve_span(&parsed.get_hash_value("listing").unwrap().source_info, &ctx)
+            .expect("resolvable");
+        assert!(
+            span.line >= 1 && span.column >= 1,
+            "expected 1-based line/column, got {}:{}",
+            span.line,
+            span.column
+        );
+    }
+
+    #[test]
+    fn defaulted_source_info_is_reported_not_rendered() {
+        // The whole point: a defaulted SourceInfo must not resolve to a
+        // plausible-looking "file 0, line 1". If this ever starts passing
+        // as Ok(..), the helper has stopped catching the bug class it
+        // exists for.
+        let ctx = SourceContext::new();
+        let bogus = SourceInfo::Original {
+            file_id: FileId(0),
+            start_offset: 0,
+            end_offset: 0,
+        };
+        assert_eq!(
+            resolve_span(&bogus, &ctx),
+            Err(SpanProblem::SuspiciousDefault)
+        );
+    }
+
+    #[test]
+    fn unregistered_file_is_reported() {
+        let (parsed, _) = fixture();
+        let empty = SourceContext::new();
+        let listing = parsed.get_hash_value("listing").expect("listing key");
+        assert!(matches!(
+            resolve_span(&listing.source_info, &empty),
+            Err(SpanProblem::UnknownFile { .. })
+        ));
+    }
+}

--- a/crates/quarto-core/Cargo.toml
+++ b/crates/quarto-core/Cargo.toml
@@ -122,6 +122,9 @@ uuid.workspace = true
 [dev-dependencies]
 insta.workspace = true
 quarto-error-catalog = { workspace = true }
+# Enables `quarto_config::span_assert` for tests that assert *where* a
+# diagnostic points, not just which code it carries (bd-9yh3pzfu).
+quarto-config = { workspace = true, features = ["span-assert"] }
 tempfile = "3"
 walkdir.workspace = true
 tokio = { version = "1", features = ["rt", "macros"] }

--- a/crates/quarto-core/src/project/listing/config.rs
+++ b/crates/quarto-core/src/project/listing/config.rs
@@ -1112,6 +1112,74 @@ listing:
         quarto_config::span_assert::assert_diagnostic_underlines(q124, &ctx, "dupe");
     }
 
+    // bd-2mxo: L5 captures the `categories:` *key* span here purely to
+    // anchor Q-12-12 ("categories enabled but no item has any"; see
+    // `transforms/categories_sidebar.rs:213`). Materialization used to
+    // replace every `key_source` with a programmatic-config sentinel,
+    // which left that anchor inert — the feature existed but could
+    // never point anywhere. This pins it to the real key.
+    #[test]
+    fn categories_source_anchors_the_real_categories_key() {
+        let yaml = "\
+listing:
+    contents: ./a.qmd
+    categories: true
+";
+        let (listings, _diags, ctx) = parse_from_yaml(yaml);
+        let listing = listings.first().expect("one listing");
+
+        let span = quarto_config::span_assert::resolve_span(&listing.categories_source, &ctx)
+            .expect("categories_source should be a real key span, not a sentinel");
+        assert_eq!(span.text, "categories");
+    }
+
+    // The two sites the Phase A audit deliberately left alone: each
+    // already blamed the semantically correct value, and read wrong only
+    // because that value was a container carrying a synthesized span.
+    // Fixing materialization (bd-2mxo) is what makes them right, so
+    // these assert the fix reaches beyond the call sites Phase A
+    // touched.
+
+    #[test]
+    fn q_12_2_underlines_the_whole_inline_contents_record() {
+        let yaml = "\
+listing:
+    contents:
+    - title: Inline
+      path: ./a.qmd
+";
+        let (_listings, diags, ctx) = parse_from_yaml(yaml);
+        let q122 = diag_with_code(&diags, "Q-12-2");
+
+        let span = quarto_config::span_assert::resolve_diagnostic_span(q122, &ctx)
+            .expect("Q-12-2 should resolve to a real span");
+        assert!(
+            span.text.contains("title: Inline") && span.text.contains("path: ./a.qmd"),
+            "expected the whole inline record, got {:?}",
+            span.text
+        );
+    }
+
+    #[test]
+    fn q_12_3_underlines_the_whole_sort_value() {
+        let yaml = "\
+listing:
+    contents: ./a.qmd
+    sort:
+        field: title
+";
+        let (_listings, diags, ctx) = parse_from_yaml(yaml);
+        let q123 = diag_with_code(&diags, "Q-12-3");
+
+        let span = quarto_config::span_assert::resolve_diagnostic_span(q123, &ctx)
+            .expect("Q-12-3 should resolve to a real span");
+        assert!(
+            span.text.contains("field: title"),
+            "expected the offending `sort:` value, got {:?}",
+            span.text
+        );
+    }
+
     // 1. config_parses_minimal — `listing: default` parses to a
     //    Listing with id synthesized, type Default, defaults applied.
     #[test]

--- a/crates/quarto-core/src/project/listing/config.rs
+++ b/crates/quarto-core/src/project/listing/config.rs
@@ -341,7 +341,12 @@ pub fn parse_listings(
                             "Duplicate listing id `{}`; later occurrences are dropped.",
                             l.id
                         ),
-                        item,
+                        // Blame the offending `id:` value, not the whole
+                        // listing map — see `template_source` in
+                        // `parse_one_listing` for why a map's span is not
+                        // its own. A synthesized id has no `id:` entry to
+                        // point at, so fall back to the entry itself.
+                        map_entry_value(item, "id").unwrap_or(item),
                     );
                     continue;
                 }
@@ -399,6 +404,21 @@ fn parse_one_listing(
         id: fallback_id.to_string(),
         ..Default::default()
     };
+
+    // Span to blame for the cross-field `template:`/`type:` check below.
+    // Captured here rather than reusing the enclosing map's `source_info`,
+    // which is not the map's span at all: `materialize_cursor` synthesizes
+    // it from the map's *first entry's value*
+    // (`quarto-config/src/materialize.rs:142-158`), so blaming `value`
+    // underlines whichever key happens to come first — `sort: false` in
+    // the report that opened bd-9yh3pzfu.
+    //
+    // Even once materialization preserves real container spans, blaming
+    // the map would still be wrong here: quarto-yaml spans a mapping from
+    // its first key to `MappingEnd`, so the caret would cover the whole
+    // `listing:` block. A diagnostic about `template:` points at
+    // `template:`.
+    let mut template_source: Option<&ConfigValue> = None;
 
     for entry in map {
         match entry.key.as_str() {
@@ -461,6 +481,7 @@ fn parse_one_listing(
                 l.sort = Some(parse_sort(&entry.value, diagnostics));
             }
             "template" => {
+                template_source = Some(&entry.value);
                 if let Some(path) = entry.value.as_plain_text() {
                     if path.ends_with(".ejs.md") {
                         push_diag(
@@ -531,12 +552,18 @@ fn parse_one_listing(
 
     // Cross-field validation: `template:` set without `type: custom`
     // should warn (per Q-12-7) and leave the type alone.
+    //
+    // Blame the `template:` value, not the enclosing map — see the
+    // `template_source` declaration above. `template_source` is always
+    // `Some` here, since `l.template` is only set from that same entry;
+    // the fallback keeps the diagnostic alive rather than silently
+    // dropping it if that ever stops holding.
     if l.template.is_some() && l.kind != ListingType::Custom {
         push_diag(
             diagnostics,
             "Q-12-7",
             "`template:` was set but `type:` is not `custom`; falling back to the built-in template for the declared type.",
-            value,
+            template_source.unwrap_or(value),
         );
     }
 
@@ -925,6 +952,18 @@ pub fn extract_content_globs(meta: &ConfigValue) -> Vec<String> {
     out
 }
 
+/// The value of `key` in `value`, if `value` is a map containing it.
+///
+/// Used to blame a specific entry rather than its enclosing map. A map's
+/// `source_info` is not the map's span — see `template_source` in
+/// [`parse_one_listing`].
+fn map_entry_value<'a>(value: &'a ConfigValue, key: &str) -> Option<&'a ConfigValue> {
+    match &value.value {
+        ConfigValueKind::Map(entries) => entries.iter().find(|e| e.key == key).map(|e| &e.value),
+        _ => None,
+    }
+}
+
 fn push_diag(
     diagnostics: &mut Vec<DiagnosticMessage>,
     code: &str,
@@ -973,6 +1012,104 @@ mod tests {
         let mut diags = Vec::new();
         let listings = parse_listings(&value, &mut diags);
         (listings, diags)
+    }
+
+    // ── real-source fixtures (bd-9yh3pzfu) ──────────────────────────
+    //
+    // The helpers above stamp every value with `SourceInfo::for_test()`,
+    // so a diagnostic pointing at the wrong key is indistinguishable
+    // from one pointing at the right key — the span bug is invisible by
+    // construction. Tests that assert on *where* a diagnostic points
+    // must parse real text and travel the real path.
+    //
+    // That path matters: production reads `ast.meta.get("listing")`
+    // (see `transforms/listing_generate.rs:72`), and `ast.meta` is the
+    // *materialized* merge output — `MetadataMergeStage` replaces it
+    // wholesale at `stage/stages/metadata_merge.rs:266-288`. Skipping
+    // materialization would skip the defect.
+
+    const FIXTURE_FILE: &str = "index.qmd";
+
+    /// Parse YAML front-matter text the way the render pipeline does:
+    /// YAML → `ConfigValue` → merge → **materialize**, then hand back
+    /// the `listing:` value plus a `SourceContext` that can resolve the
+    /// spans it carries.
+    fn parse_from_yaml(
+        yaml: &str,
+    ) -> (
+        Vec<Listing>,
+        Vec<DiagnosticMessage>,
+        quarto_source_map::SourceContext,
+    ) {
+        use pampa::pandoc::yaml_to_config_value;
+        use pampa::utils::diagnostic_collector::DiagnosticCollector;
+        use quarto_config::{InterpretationContext, MergedConfig};
+
+        let parsed = quarto_yaml::parse_file(yaml, FIXTURE_FILE).expect("valid yaml");
+        let mut collector = DiagnosticCollector::new();
+        let doc_config = yaml_to_config_value(
+            parsed,
+            InterpretationContext::DocumentMetadata,
+            &mut collector,
+        );
+
+        let merged = MergedConfig::new(vec![&doc_config])
+            .materialize()
+            .expect("materialize");
+        let listing_value = merged.get("listing").expect("`listing:` key present");
+
+        let mut diags = Vec::new();
+        let listings = parse_listings(listing_value, &mut diags);
+        (
+            listings,
+            diags,
+            quarto_config::span_assert::context_for(FIXTURE_FILE, yaml),
+        )
+    }
+
+    fn diag_with_code<'a>(diags: &'a [DiagnosticMessage], code: &str) -> &'a DiagnosticMessage {
+        diags
+            .iter()
+            .find(|d| d.code.as_deref() == Some(code))
+            .unwrap_or_else(|| panic!("expected a {code} diagnostic; got: {diags:?}"))
+    }
+
+    // bd-9yh3pzfu: Q-12-7 talks about `template:` but blamed whichever
+    // key happened to come first in the map — here `sort:`. The key
+    // order below is load-bearing: putting `template:` first would mask
+    // the bug.
+    #[test]
+    fn q_12_7_underlines_the_template_key_not_a_sibling() {
+        let yaml = "\
+title: Vanity URLs
+listing:
+    sort: false
+    template: ../template.ejs
+    contents:
+    - ./a.qmd
+";
+        let (_listings, diags, ctx) = parse_from_yaml(yaml);
+        let q127 = diag_with_code(&diags, "Q-12-7");
+
+        quarto_config::span_assert::assert_diagnostic_underlines(q127, &ctx, "../template.ejs");
+    }
+
+    // bd-9yh3pzfu: Q-12-4 named the duplicate id in its message but
+    // blamed the whole listing map, so the caret landed on whichever
+    // key came first. `contents:` is first here to keep that visible.
+    #[test]
+    fn q_12_4_underlines_the_duplicate_id_not_a_sibling() {
+        let yaml = "\
+listing:
+    - contents: ./a.qmd
+      id: dupe
+    - contents: ./b.qmd
+      id: dupe
+";
+        let (_listings, diags, ctx) = parse_from_yaml(yaml);
+        let q124 = diag_with_code(&diags, "Q-12-4");
+
+        quarto_config::span_assert::assert_diagnostic_underlines(q124, &ctx, "dupe");
     }
 
     // 1. config_parses_minimal — `listing: default` parses to a


### PR DESCRIPTION
## The report

Rendering a Quarto 1 site ported to Q2 (the Posit Connect docs) produced a warning whose message and whose caret disagreed:

```
Warning: [Q-12-7] `template:` was set but `type:` is not `custom`; falling back to the built-in template for the declared type.
   ╭─[ cookbook/vanities/index.qmd:4:11 ]
   │
 4 │     sort: false
   │           ──┬──
   │             ╰──── `template:` was set but `type:` is not `custom`; …
```

The message talks about `template:`. The caret underlines `sort: false` — an unrelated sibling key.

## Root cause

`materialize_cursor` **synthesized** a materialized container's span instead of preserving it:

- map containers took their **first entry's value** span
- array containers took their **last item's** span
- a map whose first entry was itself a map got a `programmatic_config` sentinel — no location at all
- every `ConfigMapEntry.key_source` was replaced with that sentinel

So every diagnostic anchored on a map, an array, or a key pointed somewhere arbitrary. Reordering the fixture's keys moved the caret, which is how this was confirmed rather than inferred.

The provenance was never lost, only discarded in flight. `MergedConfig` holds `layers: Vec<&ConfigValue>` — borrowed originals with spans and `key_source` intact — and `MergedMap` is a virtual map computed over them. `keys()` was already iterating the real `ConfigMapEntry` structs and keeping only `entry.key`.

## What changed

**Two commits, separately reviewable.**

### `4698b85f` — span assertions + blaming the right node

`crates/` held **154 assertions on a diagnostic's `code` and roughly a dozen touching its location**. That imbalance is why this survived: the existing Q-12-7 test asserts the code only and passed against the broken span for as long as the diagnostic existed.

Adds `quarto_config::span_assert` (behind a `span-assert` feature that `quarto-core` enables as a dev-dependency), resolving a `SourceInfo` to the `(path, line, column, underlined text)` a reader sees. It reports `Original { FileId(0), 0..0 }` as `SuspiciousDefault` rather than rendering it as "file 0, line 1" — a lenient helper would reproduce, inside the test suite, the exact failure mode the suite exists to catch.

Test fixtures have to come from real text: the existing helpers stamp `SourceInfo::for_test()` on everything, so a wrong span is indistinguishable from a right one. `parse_from_yaml` drives the real path — YAML → `yaml_to_config_value` → `MergedConfig` → **materialize** → `parse_listings` — matching what `transforms/listing_generate.rs:72` reads at render time.

Call-site fixes: Q-12-7 now blames the `template:` entry; Q-12-4 blames the duplicate `id:` rather than the whole listing map.

### `d47b3799` — preserve spans through materialization (bd-2mxo)

Two additive `MergedCursor` accessors, `container_source()` and `key_source(key)`, both walking layers in reverse so they follow the same layer `as_value`/`as_scalar` already pick for the winning value — a container's span and its winning contents agree on which file they came from. They return the layer's span verbatim, so a programmatically-built layer keeps saying it was generated instead of borrowing a neighbour's location.

`unwrap_or_default()` fallbacks became `SourceInfo::generated(By::unknown())`. `SourceInfo::default()` is `Original { FileId(0), 0..0 }` — a well-formed span indistinguishable downstream from a real location at the first byte of file 0. A fallback that fabricates a plausible location is worse than one that admits ignorance.

## Reviewer notes

Three things that may not be obvious from the diff:

**Zero `.snap` files changed**, against a plan that predicted tree-wide churn. No existing snapshot ever captured a materialized *container* span — the same assertion gap that hid the bug made the fix invisible to the suite. Scalar spans were never affected, which the "winning layer" test independently confirms.

**Containers nested inside arrays were never broken.** The Array arm clones items verbatim rather than recursing through the cursor (array items have no path to navigate to), so only map-valued keys went through the synthesizing arm. This corrected an earlier audit of mine mid-review: Q-12-2 was fine all along (regression test added anyway), while Q-12-3 was genuinely broken and previously underlined `"title"`.

**A latent feature turned out to be dead.** L5's `categories_source` exists solely to anchor Q-12-12 ("categories enabled but no item has any") and was receiving the sentinel — it could never point anywhere. Confirmed inert against a stashed tree; now resolves to the real `categories:` key.

## Verification

- Workspace: **10877 passed, 197 skipped**
- `cargo xtask verify` — full, including the WASM/hub-client leg — clean
- End-to-end `q2 render` on the reported shape: caret moved from `sort: false` to `template: ../template.ejs`
- Connect docs re-rendered: **all 15** Q-12-7 instances now point at the template path, including the reported `cookbook/vanities/index.qmd` (4:11 → 5:15). Q-16-3 and Q-5-3 spans spot-checked in the same run — unaffected.

Each fix was confirmed failing before it was applied, by running the new tests against a stashed working tree.

## Deliberately out of scope

The Connect docs still render poorly (9 errors, 310 warnings). That is expected and agreed: two further defects found during this investigation are filed separately, so this PR stays a source-mapping fix.

- **bd-oywyaouf** — Q2 emits raw EJS into the HTML with no diagnostic when a Q1 `.ejs` template is used. Q2 dropped EJS deliberately (doctemplate replaced it so untrusted contexts like hub-client never execute arbitrary JS); nothing tells the user.
- **bd-lu16jgxq** — Q-12-7's text asserts a `type:` the user never declared, and the docs page misstates Q1's behavior (Q1 makes `template:` *imply* `type: custom`).
- **bd-cwk7l4dl** — xtask lint for `unwrap_or_default()` on `SourceInfo`; deferred because it needs type information a grep rule lacks.

Closes bd-2mxo. Plan: `claude-notes/plans/2026-08-06-q12-7-listing-template-diagnostic.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)