### PR TITLE
Listing contents: globs resolve against their declaring file's directory

### DIFF
--- a/claude-notes/plans/2026-08-06-listing-glob-provenance.md
+++ b/claude-notes/plans/2026-08-06-listing-glob-provenance.md
@@ -2,7 +2,7 @@
 
 **GitHub issue:** https://github.com/quarto-dev/q2/issues/456
 **Braid strand:** bd-v7ixzsp5 (bug, P1)
-**Status:** plan draft — awaiting review/iteration with Carlos before execution.
+**Status:** in execution on branch `braid/bd-v7ixzsp5-listing-contents-globs-resolve`.
 
 ## Overview
 
@@ -202,43 +202,81 @@ to the stage/render context. Keep the helper synchronous and pure.
       pinned by `projmeta` test: cross-directory items currently get
       non-relativized hrefs (`href="posts/a.qmd"` verbatim) — the fix must
       produce page-relative hrefs for items outside the host's directory.
-- [ ] Unit tests for the resolver (provenance → base dir, incl. fallback) and
+- [x] Unit tests for the resolver (provenance → base dir, incl. fallback) and
       the single-view matcher (incl. `..` normalization; escaping the project
-      root matches nothing AND emits the new diagnostic code).
-- [ ] Unit tests for negation partition semantics.
-- [ ] Dep-graph tests updated: edges under new semantics (existing tests #14–#22
-      in `dependency_graph.rs` will need review — some encode the dual-view
-      behavior being removed).
+      root matches nothing AND emits the new diagnostic code) — in
+      `glob_resolve.rs`.
+- [x] Unit tests for negation partition semantics (`glob_resolve.rs` +
+      dep-graph test #22b).
+- [x] Dep-graph tests updated: #15/#19 rewritten for resolved patterns, #22b
+      added for negation; the rest were root-host tests that survive
+      unchanged.
 
 ### Phase 2 — resolver + data model
-- [ ] Provenance-resolver helper (shared, pure) in `project/listing/` or
-      `project/mod.rs`.
-- [ ] `ListingContents::Glob { pattern, base_dir }`; `parse_listings` threads
-      the per-entry `ConfigValue` source info into it.
-- [ ] `DocumentProfile` field change + `profile_version` bump.
+- [x] Provenance-resolver helper: `project/listing/glob_resolve.rs`
+      (`resolve_content_globs`, `item_matches`; pure, WASM-safe).
+      `MetadataMergeStage` registers `_quarto.yml`/`_metadata.yml` in BOTH
+      document SourceContexts (hash FileIds; symmetric append preserves
+      `IncludeExpansionStage`'s FileId-parity invariant — a full-suite run
+      caught the one-context version).
+- [x] `ListingContents::Glob { pattern, source }` — carries `SourceInfo`
+      rather than a pre-resolved base dir (resolution happens at the two
+      consumption points, which own the context).
+- [x] `DocumentProfile` v7 → v8: `listing_content_globs:
+      Vec<ListingContentGlob>` (resolved pattern + negated), populated by
+      `DocumentProfileStage` (extract stays pure).
 
 ### Phase 3 — matcher swap
-- [ ] Shared single-view matcher; `ListingGenerateTransform` and
-      `ProjectDependencyGraph::build` both use it; delete the dual-view logic
-      and the now-unused `relative_to_dir` host-view path if nothing else uses it.
-- [ ] Negation applied in both sites.
+- [x] Shared single-view matcher in both consumers; dual-view logic and
+      `relative_to_dir` deleted. Bonus fix surfaced by the tests:
+      `host_relative_qmd` in `binding.rs` now emits `../`-style hrefs for
+      items outside the host's directory (page-relative links were broken
+      for cross-directory items).
+- [x] Negation applied in both sites (render + dep graph). `Q-12-17`
+      registered in the catalog + docs stub page; audit script clean.
 
 ### Phase 4 — verification
-- [ ] `cargo nextest run --workspace`.
-- [ ] End-to-end: `cargo run --bin q2 -- render` on each fixture; inspect HTML;
-      record invocation + output snippets here per the E2E policy.
-- [ ] Render `docs/` with q2 and diff listing pages against main.
+- [x] `cargo nextest run --workspace` — 10890 passed at 359ad0c2 (includes
+      the 8 new integration tests, all green).
+- [x] End-to-end: `./target/debug/q2 render <fixture>` on all six scratchpad
+      fixtures at 359ad0c2; HTML inspected. Observed listing items
+      (href/title extracted from the rendered pages):
+      - `p1-basic` sub/index.html → `p1.html P1` only; **zero Q-13-4** (was:
+        Home + About phantoms + 2 warnings). Q-1-20 still fires (Phase 5).
+      - `p2-dirmeta` blog/deep/index.html → `p1.html Deep P1` (was empty).
+      - `p3-projmeta` index.html → `sub/p1.html Sub P1`.
+      - `p4-root-host` index.html → posts a+b unchanged (no regression).
+      - `p5-parent-glob` sub/index.html → `../rootpost.html Root Post`
+        (was empty; href correctly page-relative).
+      - `p6-glob-corruption` → still empty, fixed by Phase 5.
+- [x] Render `docs/` with q2 and diff against main (clean caches, both
+      sides). The errors-reference listing (`docs/errors/index.qmd`, glob
+      `*/Q-*.qmd`) is **more correct on the branch**: main's render dropped
+      `crossref/Q-15-1`, `project/Q-5-6`, `project/Q-5-7` from the listing
+      data; the branch lists all 147 on-disk `Q-*.qmd` pages exactly
+      (verified by `comm` against the file tree; includes the new
+      `Q-12-17`). No entries were lost. The legacy drop mechanism wasn't
+      chased further — the code path that caused it is deleted.
 - [ ] `cargo xtask verify` (full — quarto-core changes affect the WASM leg).
 
 ### Phase 5 — `listing.contents` interpretation (defects #5 + #6)
-- [ ] Failing test first: `p6-glob-corruption` fixture — `p*osts*.qmd` must
-      match `pXosts_extra.qmd` (glob survives with asterisks intact).
-- [ ] Annotation-source table in the front-matter interpretation path
-      (`listing.contents[*]` → `Interpretation::Glob`), designed for later
-      replacement by schema-derived annotations.
-- [ ] Remove the `PandocInlines` recovery chain in `parse_listings`.
-- [ ] Regression test: clean renders of `p1-basic`/`p4-root-host` emit zero
-      `Q-1-20` warnings.
+- [x] Failing tests first (pampa unit tests, verified failing with the
+      emphasis-corrupted value visible in the assert output; +
+      `glob_with_markdown_parseable_asterisks_survives` integration test).
+- [x] Annotation-source table: `crates/pampa/src/pandoc/meta_annotations.rs`
+      (`listing.contents` + `format.*.listing.contents` → `Glob`;
+      exact-length matching, single-segment wildcard, arrays transparent,
+      maps extend the path; explicit tags always win; module doc marks it
+      delete-on-schema-arrival). `yaml_to_config_value` threads a key path
+      internally; public signature unchanged.
+- [x] `parse_listings` recovery chain: **kept as defensive fallback** rather
+      than removed — PandocInlines/string-shaped values can still arrive from
+      non-YAML sources (programmatic construction, runtime metadata), and the
+      fallback is harmless; comment updated to reflect the new primary path.
+- [x] Regression tests: zero `Q-1-20` asserted in the integration suite;
+      E2E: `p1-basic`, `p4-root-host`, `p6-glob-corruption` all render with
+      **zero warnings** at c7b475cb and p6's listing contains `Should Match`.
+      Full workspace suite: 10911 passed.
 
 ### Phase 6 — bookkeeping
 - [ ] `braid close bd-v7ixzsp5`; comment on GH #456 with the fix summary.

--- a/claude-notes/plans/2026-08-06-listing-glob-provenance.md
+++ b/claude-notes/plans/2026-08-06-listing-glob-provenance.md
@@ -257,7 +257,10 @@ to the stage/render context. Keep the helper synchronous and pure.
       (verified by `comm` against the file tree; includes the new
       `Q-12-17`). No entries were lost. The legacy drop mechanism wasn't
       chased further — the code path that caused it is deleted.
-- [ ] `cargo xtask verify` (full — quarto-core changes affect the WASM leg).
+- [x] `cargo xtask verify` (full, all 14 steps incl. hub-client WASM build +
+      tests) — passed at a4c5c1e2 (post-clippy-fix commit; two clippy lints from
+      the first run fixed: `same_item_push` in binding.rs,
+      `manual_string_new` in a glob_resolve test).
 
 ### Phase 5 — `listing.contents` interpretation (defects #5 + #6)
 - [x] Failing tests first (pampa unit tests, verified failing with the
@@ -279,9 +282,13 @@ to the stage/render context. Keep the helper synchronous and pure.
       Full workspace suite: 10911 passed.
 
 ### Phase 6 — bookkeeping
-- [ ] `braid close bd-v7ixzsp5`; comment on GH #456 with the fix summary.
-- [ ] docs/ website: document listing `contents` resolution semantics
-      (user-facing, no internals).
+- [ ] `braid close bd-v7ixzsp5`; comment on GH #456 with the fix summary
+      (after PR review/merge).
+- [x] docs/ website: **deferred to bd-2nb6i1qv** (discovered-from) — docs/
+      has no listings guide at all to host the semantics write-up; the
+      Q-12-17 error page documents the project-boundary rule meanwhile.
+- [x] Follow-up strand for migrating other glob consumers onto the
+      glob-resolve API: bd-mt7a6uc4 (discovered-from).
 
 ## Decisions (Carlos, 2026-08-06)
 

--- a/claude-notes/plans/2026-08-06-listing-glob-provenance.md
+++ b/claude-notes/plans/2026-08-06-listing-glob-provenance.md
@@ -191,11 +191,17 @@ to the stage/render context. Keep the helper synchronous and pure.
       removes them; no separate change needed.
 
 ### Phase 1 — tests first (TDD)
-- [ ] Commit the five fixture projects under the integration-test convention
-      (`tests/integration/` layout; follow `.claude/rules/integration-tests.md`).
-- [ ] Failing integration tests, one per fixture, asserting: exact listing item
-      set in rendered HTML, zero `Q-13-4` warnings, resolved `.html` hrefs
-      (no `.qmd` leakage).
+- [x] Fixture projects as **inline-written temp-dir fixtures** (the repo's
+      established convention in `listing_pipeline.rs` — no committed fixture
+      dirs needed): `tests/integration/listing_glob_resolution.rs`, registered
+      in `main.rs`.
+- [x] Failing integration tests (8, all verified failing for the right
+      semantic reasons at 59500cf1): host-dir resolution, dual-view removal,
+      `_metadata.yml` base dir, `_quarto.yml` base dir, `../` traversal,
+      root-escape `Q-12-17`, negation, negation-only default. Bonus finding
+      pinned by `projmeta` test: cross-directory items currently get
+      non-relativized hrefs (`href="posts/a.qmd"` verbatim) — the fix must
+      produce page-relative hrefs for items outside the host's directory.
 - [ ] Unit tests for the resolver (provenance → base dir, incl. fallback) and
       the single-view matcher (incl. `..` normalization; escaping the project
       root matches nothing AND emits the new diagnostic code).

--- a/claude-notes/plans/2026-08-06-listing-glob-provenance.md
+++ b/claude-notes/plans/2026-08-06-listing-glob-provenance.md
@@ -1,0 +1,257 @@
+# Listing `contents:` globs — provenance-based base-directory resolution
+
+**GitHub issue:** https://github.com/quarto-dev/q2/issues/456
+**Braid strand:** bd-v7ixzsp5 (bug, P1)
+**Status:** plan draft — awaiting review/iteration with Carlos before execution.
+
+## Overview
+
+A listing host in a subdirectory with `contents: ["*.qmd"]` picks up project-root
+documents. Root cause: `matches_any_glob` in
+`crates/quarto-core/src/transforms/listing_generate.rs` (and its mirror in
+`crates/quarto-core/src/project/dependency_graph.rs`) matches every candidate
+against **both** the host-relative and the project-relative path view, OR-ed
+together. The project-relative fallback lets `*.qmd` from `sub/index.qmd` match
+root-level `about.qmd` and `index.qmd`.
+
+Agreed direction (Carlos, session 2026-08-06): do **not** chase Q1-exact
+behavior. Instead, resolve each glob relative to the directory of the file where
+the `contents:` entry was **written**, using the `ConfigValue` provenance
+(`SourceInfo`) infrastructure. Front-matter globs resolve against the host's
+directory; `_metadata.yml` globs against that file's directory; `_quarto.yml`
+globs against the project root. This naturally extends to future metadata
+sources.
+
+## Observed defects (assessment matrix)
+
+Five fixture projects were built (currently in session scratchpad under
+`issue456/`; to be committed as test fixtures in Phase 1). Rendered with
+`cargo run --bin q2 -- render <dir>` at 3ce0c095:
+
+| Fixture | Mechanism | Declared glob(s) | Expected (new semantics) | Actual today |
+|---|---|---|---|---|
+| `p1-basic` | front matter, host `sub/index.qmd` | `*.qmd`, `!index.qmd` | only `sub/p1.qmd` | Home + About + P1 listed; 2× spurious `Q-13-4`; `href="about.qmd"` broken link; `href="index.html"` silently points at host's own page; negation ignored |
+| `p2-dirmeta` | `blog/_metadata.yml`, host `blog/deep/index.qmd` | `deep/*.qmd` | `blog/deep/p1.qmd` | **empty listing** (glob resolved against host dir and project root, never against `blog/`) |
+| `p3-projmeta` | `_quarto.yml` top-level `listing:` | `sub/*.qmd` | `sub/p1.qmd` on every host, project-root base | correct on root host (accidentally — host-relative == project-relative there) |
+| `p4-root-host` | front matter, host at root | `posts/*.qmd` | posts a, b | correct (must not regress) |
+| `p5-parent-glob` | front matter, host `sub/index.qmd` | `../rootpost.qmd` | `rootpost.qmd` | **empty listing** (`relative_to_dir` can't go up; project-relative literal `../…` never matches) |
+
+Distinct bugs:
+
+1. **Dual-view OR matching** (the reported bug). Wrong items, broken/wrong
+   links, spurious `Q-13-4` (emitted twice per phantom item — thumbnail link +
+   title link — via the dep-graph/link-resolution path).
+2. **No provenance base for `_metadata.yml` globs** — p2 renders an empty
+   listing. (Precedent: `adjust_paths_to_document_dir` in
+   `project/mod.rs` already rebases `!path` values per layer at merge time but
+   deliberately skips `Glob`.)
+3. **`../` traversal unsupported** — p5 renders an empty listing.
+4. **Negation globs (`!pattern`) silently ignored** — no negation support
+   anywhere in the listing matcher; `!index.qmd` is matched literally (`!` is
+   only special inside `[...]`), so it matches nothing and drops out.
+5. **Spurious `Q-1-20`** ("Failed to parse metadata value as markdown") on any
+   glob string containing `*` in front-matter `contents:` — DocumentMetadata
+   context tries to parse the string as markdown before the listing parser's
+   `as_plain_text` fallback recovers it.
+6. **Silent glob corruption when the markdown parse *succeeds*** (fixture
+   `p6-glob-corruption`, verified 2026-08-06): `contents: ["p*osts*.qmd"]`
+   parses as emphasis, `as_plain_text` reconstructs `posts.qmd` (asterisks
+   lost), the listing renders empty, and **no diagnostic fires at all**. Same
+   root cause as #5; strictly worse failure mode.
+
+## Design
+
+### Provenance → base directory
+
+At listing-parse time, each glob's `ConfigValue.source_info` is resolved to a
+**base directory** (project-relative, forward slashes):
+
+- `root_file_id()` on the value's `SourceInfo`:
+  - Front matter is `Substring` → resolves to pampa's primary `FileId(0)` →
+    base = host document's directory.
+  - `_metadata.yml` / `_quarto.yml` layers are parsed by
+    `quarto_yaml::parse_file`, whose FileIds are **hash-derived from the
+    filename** (`quarto_yaml::file_id_for_filename`) → build a candidate
+    inventory (document path, `_quarto.yml` path, each `_metadata.yml` on the
+    doc's directory chain) and match. Worked precedent:
+    `compile_theme_css.rs:379-384` does exactly this for theme diagnostics.
+  - Unresolvable (programmatic/runtime metadata, `Generated` sentinels) → fall
+    back to the host directory.
+- `ListingContents::Glob(String)` becomes a struct variant carrying
+  `pattern` + resolved `base_dir` (resolved eagerly at parse time so downstream
+  consumers never need the file table).
+
+### Single-view matching (seed of a shared glob-expansion API)
+
+Replace the dual-view OR with: join `base_dir` + pattern, lexically normalize
+(`..` segments collapse), then match the normalized project-relative pattern
+against each candidate's project-relative path with the existing
+`glob_match_path_or_dir` (bare-directory rule preserved). A pattern that
+normalizes **outside the project root** matches nothing and emits a **new
+diagnostic code** (register in `quarto-error-catalog`, next free code in the
+listing/`Q-12-*` or glob-appropriate subsystem), so warnings-as-errors mode
+fails loudly. One shared helper used by **both** `ListingGenerateTransform` and
+`ProjectDependencyGraph::build` so the two sites cannot drift.
+
+Decision (Carlos, 2026-08-06): design this helper as the seed of an **internal
+glob-expansion API** for all of q2 — base-dir-anchored resolution, negation,
+consistent defaults — with the intent that other glob consumers
+(`project.render`, resources, etc.) migrate onto it over time, squashing the
+Q1-inherited inconsistency where some globs default to `*.qmd` and others to
+`**/*.qmd`. Migration of other consumers is out of scope here; file a
+follow-up strand (`discovered-from:bd-v7ixzsp5`) when the API shape settles.
+
+Consequence (intentional behavior change, shipping **silently** — Carlos,
+2026-08-06: q2 is 0.*, no stability promises): a subdirectory host using a
+project-relative glob (`posts/*.qmd` meaning root-level `posts/` from
+`sub/index.qmd`) stops matching. This aligns with both Q1 and the new
+provenance semantics. No transition diagnostic.
+
+### DocumentProfile / dep graph
+
+`DocumentProfile.listing_content_globs: Vec<String>` must carry base dirs so
+graph edges agree with render-time resolution. Per the profile contract
+(profiles are read-only; producers move earlier, fields get added):
+
+- new field shape (e.g. `Vec<ListingContentGlob { pattern, base_dir }>`),
+- `profile_version` bump,
+- profile cache invalidates via the version bump (verify in
+  `project/profile_cache.rs`).
+
+Provenance resolution therefore happens **at profile-extraction time** (where
+the metadata + file inventory is in scope) and at `parse_listings` time in the
+render transform; both must use the same resolver helper.
+
+### Negation
+
+Partition a listing's `contents` into positive and negative (`!`-prefixed)
+patterns. An item is included iff it matches ≥1 positive pattern (after
+base-dir resolution) and 0 negative patterns (same base-dir resolution, minus
+the `!`). If `contents` has only negative patterns, the positive set defaults
+to `*.qmd` (mirroring the existing "absent contents" default — approved by
+Carlos 2026-08-06). Order within the list does not matter. (Q1 uses
+order-independent exclusion too; exact parity not required per issue
+direction. Q1's defaults are known-inconsistent — `*.qmd` vs `**/*.qmd`
+depending on code path — which is exactly what the shared glob API above is
+meant to eventually fix.)
+
+Dep-graph note: negative patterns only ever shrink the item set, so the graph
+builder must apply them as well — otherwise excluded items still force
+host re-renders.
+
+### Interpretation of `listing.contents` (fixes defects #5 and #6)
+
+The glob strings in `contents:` are semantically globs/paths, not markdown.
+The markdown round-trip both spams `Q-1-20` (parse failure) and silently
+corrupts globs whose asterisks parse as emphasis (parse success, defect #6).
+
+Design (settled with Carlos 2026-08-06, addressing his schema concern): teach
+`yaml_to_config_value` an **annotation source** — a small declarative table
+mapping key paths to `Interpretation` (here: `listing.contents[*]` →
+`Interpretation::Glob`) — NOT an inline `if key == …` special case. When full
+YAML validation lands, schemas become the annotation source and the
+hand-written table is deleted/generated; the consumption contract is
+unchanged. Rationale for why the scoped hint is safe despite user-schema
+shadowing concerns: q2 already owns `listing:` in document metadata
+(`parse_listings` consumes it and emits `Q-12-*` on shape mismatch), and the
+failure asymmetry favors the hint — a user who truly wanted markdown gets a
+diagnosable no-match warning, whereas today's defect #6 is silent corruption.
+This also removes the `PandocInlines` recovery chain in `parse_listings`.
+
+## WASM note
+
+`ListingGenerateTransform` runs in hub-client preview. The resolver must not
+touch the filesystem: the candidate inventory is built from paths already known
+to the stage/render context. Keep the helper synchronous and pure.
+
+## Work items
+
+### Phase 0 — investigation residue (small, before tests)
+- [x] Confirm how pampa assigns the document's own FileId (assumed `FileId(0)`)
+      and that `_quarto.yml`'s metadata layer retains `parse_file` provenance
+      through `resolve_format_config` + merging. **Confirmed 2026-08-06:**
+      front matter = `Substring` into the RawBlock's source (doc `FileId(0)`,
+      `pampa/src/pandoc/meta.rs:355-361`); `_quarto.yml` parsed via
+      `parse_file(<full path>)` → hash FileId, `config_path` retained
+      (`project/mod.rs:621-699`); `_metadata.yml` same scheme
+      (`directory_metadata_for_document`), chain re-derivable by walking
+      root→doc dir. Merge preserves leaf `source_info` (theme diagnostics
+      pointing into `_quarto.yml` post-merge are the existing proof;
+      `compile_theme_css.rs:368-388`).
+- [x] Check `docs/` site and existing test corpus. **Confirmed 2026-08-06:**
+      docs/ has one listing host (`errors/index.qmd`, glob `*/Q-*.qmd`) which
+      matches via the host-relative view — unaffected. All existing
+      project-relative tests (dep-graph #15/#15b, transform
+      `project_relative_glob_matches_files_in_subdir`) use hosts at the
+      project root, where host-relative == project-relative — they survive
+      unchanged (doc comments need updating).
+- [x] Confirm `Q-13-4` origin. **Confirmed 2026-08-06:** emitted by
+      `resolve_doc_relative_href` (`transforms/navigation_href.rs`) once per
+      phantom-item link (thumbnail + title = the observed pair). Fixing bug 1
+      removes them; no separate change needed.
+
+### Phase 1 — tests first (TDD)
+- [ ] Commit the five fixture projects under the integration-test convention
+      (`tests/integration/` layout; follow `.claude/rules/integration-tests.md`).
+- [ ] Failing integration tests, one per fixture, asserting: exact listing item
+      set in rendered HTML, zero `Q-13-4` warnings, resolved `.html` hrefs
+      (no `.qmd` leakage).
+- [ ] Unit tests for the resolver (provenance → base dir, incl. fallback) and
+      the single-view matcher (incl. `..` normalization; escaping the project
+      root matches nothing AND emits the new diagnostic code).
+- [ ] Unit tests for negation partition semantics.
+- [ ] Dep-graph tests updated: edges under new semantics (existing tests #14–#22
+      in `dependency_graph.rs` will need review — some encode the dual-view
+      behavior being removed).
+
+### Phase 2 — resolver + data model
+- [ ] Provenance-resolver helper (shared, pure) in `project/listing/` or
+      `project/mod.rs`.
+- [ ] `ListingContents::Glob { pattern, base_dir }`; `parse_listings` threads
+      the per-entry `ConfigValue` source info into it.
+- [ ] `DocumentProfile` field change + `profile_version` bump.
+
+### Phase 3 — matcher swap
+- [ ] Shared single-view matcher; `ListingGenerateTransform` and
+      `ProjectDependencyGraph::build` both use it; delete the dual-view logic
+      and the now-unused `relative_to_dir` host-view path if nothing else uses it.
+- [ ] Negation applied in both sites.
+
+### Phase 4 — verification
+- [ ] `cargo nextest run --workspace`.
+- [ ] End-to-end: `cargo run --bin q2 -- render` on each fixture; inspect HTML;
+      record invocation + output snippets here per the E2E policy.
+- [ ] Render `docs/` with q2 and diff listing pages against main.
+- [ ] `cargo xtask verify` (full — quarto-core changes affect the WASM leg).
+
+### Phase 5 — `listing.contents` interpretation (defects #5 + #6)
+- [ ] Failing test first: `p6-glob-corruption` fixture — `p*osts*.qmd` must
+      match `pXosts_extra.qmd` (glob survives with asterisks intact).
+- [ ] Annotation-source table in the front-matter interpretation path
+      (`listing.contents[*]` → `Interpretation::Glob`), designed for later
+      replacement by schema-derived annotations.
+- [ ] Remove the `PandocInlines` recovery chain in `parse_listings`.
+- [ ] Regression test: clean renders of `p1-basic`/`p4-root-host` emit zero
+      `Q-1-20` warnings.
+
+### Phase 6 — bookkeeping
+- [ ] `braid close bd-v7ixzsp5`; comment on GH #456 with the fix summary.
+- [ ] docs/ website: document listing `contents` resolution semantics
+      (user-facing, no internals).
+
+## Decisions (Carlos, 2026-08-06)
+
+1. **Behavior change ships silently.** q2 is 0.*; no stability promises. Fix
+   it properly, no transition diagnostic.
+2. **Escaping the project root warns** via a new diagnostic code registered in
+   `quarto-error-catalog`, so warnings-as-errors mode fails loudly.
+3. **Negation-only `contents` defaults the positive set to `*.qmd`.** Design
+   the matcher as the seed of an internal glob-expansion API to be adopted by
+   other q2 glob consumers over time (follow-up strand when the shape settles).
+4. **Q-1-20 / interpretation is in scope (Phase 5)**, implemented as a
+   schema-replaceable annotation-source table, not an inline key special-case.
+   Elevated in priority by the discovery of defect #6 (silent glob corruption
+   on successful emphasis parse) — doing nothing is not neutral. See
+   "Interpretation of `listing.contents`" section for the full rationale
+   against Carlos's user-schema-shadowing concern.
+5. **Single strand.** bd-v7ixzsp5 stays a single strand; no epic conversion.

--- a/crates/pampa/src/pandoc/meta.rs
+++ b/crates/pampa/src/pandoc/meta.rs
@@ -141,6 +141,22 @@ pub fn yaml_to_config_value(
     context: InterpretationContext,
     diagnostics: &mut crate::utils::diagnostic_collector::DiagnosticCollector,
 ) -> ConfigValue {
+    let mut path: Vec<String> = Vec::new();
+    yaml_to_config_value_at(yaml, context, diagnostics, &mut path)
+}
+
+/// Recursive worker for [`yaml_to_config_value`], threading the
+/// map-key path from the metadata root so untagged scalars can
+/// consult the key-path annotation table
+/// ([`super::meta_annotations`]; bd-v7ixzsp5). `path` is maintained
+/// by the map branch (push key / recurse / pop); arrays are
+/// transparent (items share the array's path).
+fn yaml_to_config_value_at(
+    yaml: quarto_yaml::YamlWithSourceInfo,
+    context: InterpretationContext,
+    diagnostics: &mut crate::utils::diagnostic_collector::DiagnosticCollector,
+    path: &mut Vec<String>,
+) -> ConfigValue {
     // Parse tags using quarto-config's tag parser
     let parsed_tag = if let Some((tag_str, tag_source)) = &yaml.tag {
         let mut tag_diags = Vec::new();
@@ -160,9 +176,11 @@ pub fn yaml_to_config_value(
     // Handle compound types first (arrays and maps)
     if yaml.is_array() {
         let (items, source_info) = yaml.into_array().unwrap();
+        // Arrays are transparent for the annotation path: items
+        // share the array's key path.
         let config_items: Vec<ConfigValue> = items
             .into_iter()
-            .map(|item| yaml_to_config_value(item, context, diagnostics))
+            .map(|item| yaml_to_config_value_at(item, context, diagnostics, path))
             .collect();
 
         return ConfigValue {
@@ -177,10 +195,15 @@ pub fn yaml_to_config_value(
         let config_entries: Vec<ConfigMapEntry> = entries
             .into_iter()
             .filter_map(|entry| {
-                entry.key.yaml.as_str().map(|key_str| ConfigMapEntry {
-                    key: key_str.to_string(),
-                    key_source: entry.key_span,
-                    value: yaml_to_config_value(entry.value, context, diagnostics),
+                entry.key.yaml.as_str().map(|key_str| {
+                    path.push(key_str.to_string());
+                    let value = yaml_to_config_value_at(entry.value, context, diagnostics, path);
+                    path.pop();
+                    ConfigMapEntry {
+                        key: key_str.to_string(),
+                        key_source: entry.key_span,
+                        value,
+                    }
                 })
             })
             .collect();
@@ -237,6 +260,31 @@ pub fn yaml_to_config_value(
                             attr_source: AttrSourceInfo::empty(),
                         };
                         ConfigValueKind::PandocInlines(vec![Inline::Span(span)])
+                    } else if let Some(annotated) =
+                        super::meta_annotations::annotated_interpretation(path)
+                    {
+                        // No tag, but the key path carries an
+                        // interpretation annotation (bd-v7ixzsp5;
+                        // e.g. `listing.contents` entries are globs,
+                        // never markdown). Explicit tags took the
+                        // branches above, so annotations only replace
+                        // the untagged default.
+                        match annotated {
+                            quarto_config::Interpretation::Path => ConfigValueKind::Path(s),
+                            quarto_config::Interpretation::Glob => ConfigValueKind::Glob(s),
+                            quarto_config::Interpretation::Expr => ConfigValueKind::Expr(s),
+                            quarto_config::Interpretation::PlainString => {
+                                ConfigValueKind::Scalar(Yaml::String(s))
+                            }
+                            quarto_config::Interpretation::Markdown => {
+                                parse_yaml_string_as_markdown_to_config(
+                                    &s,
+                                    &source_info,
+                                    true,
+                                    diagnostics,
+                                )
+                            }
+                        }
                     } else {
                         // No tag: Use context-dependent default
                         match context {
@@ -452,6 +500,136 @@ mod tests {
             result.value,
             ConfigValueKind::Scalar(Yaml::String(_))
         ));
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Key-path interpretation annotations (bd-v7ixzsp5, GH #456).
+    //
+    // `listing.contents` entries are globs, not markdown. Without
+    // the annotation, the DocumentMetadata markdown default either
+    // warns (Q-1-20, `*.qmd` fails to parse) or silently corrupts
+    // the pattern (`p*osts*.qmd` parses as emphasis and
+    // `as_plain_text` reconstructs `posts.qmd`).
+    // ─────────────────────────────────────────────────────────────
+
+    fn convert_doc_meta(
+        yaml_text: &str,
+    ) -> (ConfigValue, Vec<quarto_error_reporting::DiagnosticMessage>) {
+        let yaml = quarto_yaml::parse(yaml_text).expect("valid yaml");
+        let mut diagnostics = crate::utils::diagnostic_collector::DiagnosticCollector::new();
+        let result = yaml_to_config_value(
+            yaml,
+            InterpretationContext::DocumentMetadata,
+            &mut diagnostics,
+        );
+        (result, diagnostics.diagnostics().to_vec())
+    }
+
+    #[test]
+    fn listing_contents_array_items_are_globs_not_markdown() {
+        let (result, diags) =
+            convert_doc_meta("listing:\n  contents:\n    - \"p*osts*.qmd\"\n    - \"*.qmd\"\n");
+        let contents = result
+            .get("listing")
+            .and_then(|l| l.get("contents"))
+            .expect("listing.contents");
+        let ConfigValueKind::Array(items) = &contents.value else {
+            panic!("contents should be an array, got {:?}", contents.value);
+        };
+        assert!(
+            matches!(&items[0].value, ConfigValueKind::Glob(s) if s == "p*osts*.qmd"),
+            "asterisks must survive verbatim (no markdown emphasis parse); got {:?}",
+            items[0].value
+        );
+        assert!(
+            matches!(&items[1].value, ConfigValueKind::Glob(s) if s == "*.qmd"),
+            "got {:?}",
+            items[1].value
+        );
+        assert!(
+            diags.is_empty(),
+            "no Q-1-20 markdown-parse warning for glob strings; got {:?}",
+            diags
+        );
+    }
+
+    #[test]
+    fn listing_contents_string_shorthand_is_glob() {
+        let (result, diags) = convert_doc_meta("listing:\n  contents: \"*.qmd\"\n");
+        let contents = result
+            .get("listing")
+            .and_then(|l| l.get("contents"))
+            .expect("listing.contents");
+        assert!(
+            matches!(&contents.value, ConfigValueKind::Glob(s) if s == "*.qmd"),
+            "got {:?}",
+            contents.value
+        );
+        assert!(diags.is_empty(), "got {:?}", diags);
+    }
+
+    #[test]
+    fn listing_contents_annotation_leaves_sibling_keys_as_markdown() {
+        let (result, _) = convert_doc_meta("title: \"*bold*\"\nlisting:\n  contents: \"*.qmd\"\n");
+        let title = result.get("title").expect("title");
+        assert!(
+            matches!(&title.value, ConfigValueKind::PandocInlines(_)),
+            "title keeps the markdown default; got {:?}",
+            title.value
+        );
+    }
+
+    #[test]
+    fn listing_contents_inline_record_fields_keep_markdown() {
+        let (result, _) = convert_doc_meta(
+            "listing:\n  contents:\n    - title: \"*bold*\"\n      path: x.html\n",
+        );
+        let contents = result
+            .get("listing")
+            .and_then(|l| l.get("contents"))
+            .expect("listing.contents");
+        let ConfigValueKind::Array(items) = &contents.value else {
+            panic!("contents should be an array");
+        };
+        let title = items[0].get("title").expect("record title");
+        assert!(
+            matches!(&title.value, ConfigValueKind::PandocInlines(_)),
+            "map entries under contents extend the key path, so record \
+             fields keep the markdown default; got {:?}",
+            title.value
+        );
+    }
+
+    #[test]
+    fn listing_contents_explicit_tag_overrides_annotation() {
+        let (result, _) = convert_doc_meta("listing:\n  contents: !str \"*.qmd\"\n");
+        let contents = result
+            .get("listing")
+            .and_then(|l| l.get("contents"))
+            .expect("listing.contents");
+        assert!(
+            matches!(&contents.value, ConfigValueKind::Scalar(Yaml::String(s)) if s == "*.qmd"),
+            "explicit tags always win over the annotation; got {:?}",
+            contents.value
+        );
+    }
+
+    #[test]
+    fn listing_contents_under_format_key_is_glob() {
+        let (result, diags) =
+            convert_doc_meta("format:\n  html:\n    listing:\n      contents: \"*.qmd\"\n");
+        let contents = result
+            .get("format")
+            .and_then(|f| f.get("html"))
+            .and_then(|h| h.get("listing"))
+            .and_then(|l| l.get("contents"))
+            .expect("format.html.listing.contents");
+        assert!(
+            matches!(&contents.value, ConfigValueKind::Glob(s) if s == "*.qmd"),
+            "got {:?}",
+            contents.value
+        );
+        assert!(diags.is_empty(), "got {:?}", diags);
     }
 
     #[test]

--- a/crates/pampa/src/pandoc/meta_annotations.rs
+++ b/crates/pampa/src/pandoc/meta_annotations.rs
@@ -1,0 +1,128 @@
+/*
+ * pandoc/meta_annotations.rs
+ * Copyright (c) 2026 Posit, PBC
+ */
+
+//! **Temporary** key-path interpretation annotations for metadata
+//! conversion (bd-v7ixzsp5, GH #456).
+//!
+//! Some metadata keys hold values whose semantics are known a
+//! priori — `listing.contents` entries are glob patterns, never
+//! markdown. Interpreting them with the untagged-string default
+//! (markdown, in document-metadata context) either warns (`Q-1-20`
+//! when the glob fails to parse as markdown) or silently corrupts
+//! the pattern (`p*osts*.qmd` parses as emphasis and flattens back
+//! to `posts.qmd`).
+//!
+//! This module is the **annotation source** consulted by
+//! [`yaml_to_config_value`](super::meta::yaml_to_config_value) for
+//! untagged scalars: a declarative table mapping key paths to the
+//! [`Interpretation`] the value should get. Explicit tags (`!str`,
+//! `!md`, …) always win; the annotation only replaces the
+//! *untagged* default.
+//!
+//! ## Lifecycle: delete me when schemas land
+//!
+//! The long-term design is for YAML schemas to drive default
+//! interpretations once full schema validation is wired in. When
+//! that happens, this hand-written table is superseded: delete this
+//! module and the single `annotated_interpretation` consult in
+//! `meta.rs`, and derive the same information from the schema.
+//! Keep the table small and boring until then — one entry per key
+//! whose misinterpretation is an actual observed bug, not a
+//! speculative registry.
+//!
+//! ## Path semantics
+//!
+//! - A path is the chain of map keys from the metadata root to the
+//!   value, e.g. `listing.contents`.
+//! - **Arrays are transparent**: items of the array at
+//!   `listing.contents` have path `listing.contents`.
+//! - **Maps are not**: an inline record `{title: …}` inside
+//!   `contents` puts its fields at `listing.contents.title`, which
+//!   no entry matches — record fields keep the normal default
+//!   (markdown), so authors still get markdown diagnostics there.
+//! - `*` in a pattern matches exactly one segment
+//!   (`format.*.listing.contents` covers per-format nesting).
+//!   Matching is exact-length, never a suffix match, so a user's
+//!   unrelated `my.listing.contents` key is not captured.
+
+use quarto_config::Interpretation;
+
+/// The annotation table: key-path pattern → interpretation for
+/// untagged scalars at that path. See the module docs for the path
+/// semantics and for why this stays deliberately small.
+const ANNOTATIONS: &[(&[&str], Interpretation)] = &[
+    (&["listing", "contents"], Interpretation::Glob),
+    (
+        &["format", "*", "listing", "contents"],
+        Interpretation::Glob,
+    ),
+];
+
+/// Interpretation annotated for the value at `path`, if any.
+/// `path` is the map-key chain from the metadata root (arrays are
+/// transparent — see module docs).
+pub(crate) fn annotated_interpretation(path: &[String]) -> Option<Interpretation> {
+    ANNOTATIONS
+        .iter()
+        .find(|(pattern, _)| {
+            pattern.len() == path.len()
+                && pattern
+                    .iter()
+                    .zip(path.iter())
+                    .all(|(p, seg)| *p == "*" || *p == seg.as_str())
+        })
+        .map(|(_, interp)| *interp)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn path(segments: &[&str]) -> Vec<String> {
+        segments.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn listing_contents_matches() {
+        assert_eq!(
+            annotated_interpretation(&path(&["listing", "contents"])),
+            Some(Interpretation::Glob)
+        );
+    }
+
+    #[test]
+    fn format_nested_listing_contents_matches_any_format() {
+        assert_eq!(
+            annotated_interpretation(&path(&["format", "html", "listing", "contents"])),
+            Some(Interpretation::Glob)
+        );
+        assert_eq!(
+            annotated_interpretation(&path(&["format", "revealjs", "listing", "contents"])),
+            Some(Interpretation::Glob)
+        );
+    }
+
+    #[test]
+    fn exact_length_no_suffix_matching() {
+        // A user's unrelated nested key is NOT captured.
+        assert_eq!(
+            annotated_interpretation(&path(&["my", "listing", "contents"])),
+            None
+        );
+        // Fields of inline records under contents are NOT captured.
+        assert_eq!(
+            annotated_interpretation(&path(&["listing", "contents", "title"])),
+            None
+        );
+        // Prefixes are not captured either.
+        assert_eq!(annotated_interpretation(&path(&["listing"])), None);
+    }
+
+    #[test]
+    fn unrelated_paths_do_not_match() {
+        assert_eq!(annotated_interpretation(&path(&["title"])), None);
+        assert_eq!(annotated_interpretation(&path(&[])), None);
+    }
+}

--- a/crates/pampa/src/pandoc/mod.rs
+++ b/crates/pampa/src/pandoc/mod.rs
@@ -6,6 +6,7 @@
 pub mod ast_context;
 pub mod location;
 pub mod meta;
+mod meta_annotations;
 pub mod shortcode;
 pub mod treesitter;
 pub mod treesitter_utils;

--- a/crates/quarto-core/src/document_profile.rs
+++ b/crates/quarto-core/src/document_profile.rs
@@ -65,7 +65,16 @@ use thiserror::Error;
 ///   type and now derives its literals from the same normalization
 ///   (`metadata::authors::parse_authors_model`), so the two fields
 ///   always agree.
-pub const DOCUMENT_PROFILE_VERSION: u32 = 7;
+/// - `8`: `bd-v7ixzsp5` (GH #456). Changes `listing_content_globs`
+///   from `Vec<String>` (raw patterns, expanded dual-view at
+///   graph-build time) to `Vec<ListingContentGlob>` — patterns are
+///   now **resolved to project-relative form at profile-extraction
+///   time** against the directory of the file each glob was written
+///   in (front matter → host dir, `_metadata.yml` → its dir,
+///   `_quarto.yml` → project root), and carry a `negated` flag for
+///   `!`-prefixed exclusion patterns. Consumers match single-view
+///   via [`crate::project::listing::glob_resolve::item_matches`].
+pub const DOCUMENT_PROFILE_VERSION: u32 = 8;
 
 /// Depth used when extracting the heading outline at the profile
 /// checkpoint.
@@ -502,20 +511,29 @@ pub struct DocumentProfile {
 
     /// Glob patterns from the host's `listing.*.contents:` config,
     /// flattened across all listings declared on the page. Each
-    /// entry is a raw glob string (e.g. `"*.qmd"`,
-    /// `"posts/**/*.qmd"`) — *not* a resolved path.
+    /// entry is a **project-relative, base-resolved** pattern (e.g.
+    /// `"sub/*.qmd"`) plus a negation flag — resolved by
+    /// [`crate::project::listing::glob_resolve::resolve_content_globs`]
+    /// against the directory of the file the glob was written in
+    /// (front matter → host dir, `_metadata.yml` → its dir,
+    /// `_quarto.yml` → project root; GH #456, bd-v7ixzsp5).
+    /// Populated by `DocumentProfileStage` (the resolution needs the
+    /// document's `SourceContext`, which `extract` doesn't take);
+    /// [`DocumentProfile::extract`] leaves it empty. Patterns whose
+    /// normalization escapes the project root are dropped here (the
+    /// render transform owns the `Q-12-17` diagnostic).
     ///
-    /// Resolution is **not** cached on the profile because it
-    /// depends on the full project source set, which a per-doc
-    /// profile cannot represent safely (a new sibling `.qmd` added
-    /// to the project would not invalidate the host's profile
-    /// cache, leaving the resolution stale). Instead, the
-    /// dependency-graph builder
+    /// *Expansion* against the project's file set is still **not**
+    /// cached on the profile because it depends on the full project
+    /// source set, which a per-doc profile cannot represent safely
+    /// (a new sibling `.qmd` added to the project would not
+    /// invalidate the host's profile cache, leaving the expansion
+    /// stale). The dependency-graph builder
     /// ([`crate::project::dependency_graph::ProjectDependencyGraph::build`])
-    /// expands these globs at graph-build time against
-    /// [`crate::project::index::ProjectIndex::profiles`]
-    /// (host-relative first, project-relative fallback — same rule
-    /// the L3 generate transform uses at render time) and produces
+    /// matches these patterns at graph-build time against
+    /// [`crate::project::index::ProjectIndex::profiles`] (single
+    /// view, via `glob_resolve::item_matches` — the same rule the
+    /// L3 generate transform uses at render time) and produces
     /// forward edges from each host to each match. Listing hosts
     /// with non-empty entries are also added to
     /// [`crate::project::dependency_graph::ProjectDependencyGraph::force_render`]
@@ -523,9 +541,10 @@ pub struct DocumentProfile {
     /// in the user-named target set.
     ///
     /// Default empty; serializer omits empty lists.
-    /// Added v4 → v5 (`bd-xbnf`).
+    /// Added v4 → v5 (`bd-xbnf`); shape changed v7 → v8
+    /// (`bd-v7ixzsp5`).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub listing_content_globs: Vec<String>,
+    pub listing_content_globs: Vec<crate::project::listing::glob_resolve::ListingContentGlob>,
 }
 
 /// Helper for `#[serde(skip_serializing_if = ...)]` on plain bool
@@ -642,11 +661,13 @@ impl DocumentProfile {
             // the wiring, not the field declarations.
             categories_raw: extract_categories_raw(meta),
             listing_item: extract_listing_item(meta),
-            // L6 (`bd-xbnf`): pull glob strings out of meta.listing
-            // so the dep-graph builder can expand them later. The
-            // resolution itself happens at graph-build time, not
-            // here — see the field doc for the reason.
-            listing_content_globs: crate::project::listing::config::extract_content_globs(meta),
+            // L6 (`bd-xbnf`) / v8 (`bd-v7ixzsp5`): populated by
+            // `DocumentProfileStage`, which resolves each glob's
+            // base directory from its `SourceInfo` provenance — a
+            // lookup that needs the document's `SourceContext`,
+            // which this pure extractor doesn't take. See the field
+            // doc.
+            listing_content_globs: Vec::new(),
         }
     }
 
@@ -1578,8 +1599,8 @@ Body.
     }
 
     #[test]
-    fn document_profile_version_is_7() {
-        assert_eq!(DOCUMENT_PROFILE_VERSION, 7);
+    fn document_profile_version_is_8() {
+        assert_eq!(DOCUMENT_PROFILE_VERSION, 8);
     }
 
     /// A v3 profile (the pre-listings shape) must be rejected by
@@ -1696,11 +1717,15 @@ Body.
         assert!(p.listing_content_globs.is_empty());
     }
 
-    /// Test #10 — frontmatter with a listing populates the field.
-    /// Mirrors what `extract_content_globs` returns when called on
-    /// the document's `meta`.
+    /// Test #10 — `extract` leaves the field empty even when the
+    /// frontmatter declares a listing: since v8 (bd-v7ixzsp5) the
+    /// globs are resolved (base-directory + negation) by
+    /// `DocumentProfileStage`, which has the `SourceContext` the
+    /// pure extractor lacks. The stage-level population is covered
+    /// by `document_profile` stage tests and the
+    /// `listing_glob_resolution` integration suite.
     #[test]
-    fn profile_extract_populates_listing_content_globs_from_meta() {
+    fn profile_extract_leaves_listing_content_globs_to_the_stage() {
         let qmd = "\
 ---
 title: Host
@@ -1712,10 +1737,9 @@ Body.
 ";
         let ast = parse_qmd(qmd);
         let p = DocumentProfile::extract(&ast, Path::new("idx.qmd"), "idx.html", "html");
-        assert_eq!(
-            p.listing_content_globs,
-            vec!["posts/*.qmd".to_string()],
-            "extract should pull glob strings from meta.listing.contents"
+        assert!(
+            p.listing_content_globs.is_empty(),
+            "resolution happens in DocumentProfileStage, not extract"
         );
     }
 
@@ -1754,16 +1778,23 @@ Body.
     #[test]
     #[allow(clippy::field_reassign_with_default)] // default-then-set keeps the test readable
     fn profile_v5_listing_content_globs_round_trip() {
+        use crate::project::listing::glob_resolve::ListingContentGlob;
         let mut p = DocumentProfile::default();
         p.source_path = PathBuf::from("idx.qmd");
-        p.listing_content_globs = vec!["a/*.qmd".to_string(), "b/*.qmd".to_string()];
+        p.listing_content_globs = vec![
+            ListingContentGlob {
+                pattern: "a/*.qmd".to_string(),
+                negated: false,
+            },
+            ListingContentGlob {
+                pattern: "a/wip.qmd".to_string(),
+                negated: true,
+            },
+        ];
 
         let json = p.to_json().expect("serialize");
         let restored = DocumentProfile::from_json(&json).expect("deserialize");
-        assert_eq!(
-            restored.listing_content_globs,
-            vec!["a/*.qmd".to_string(), "b/*.qmd".to_string()]
-        );
+        assert_eq!(restored.listing_content_globs, p.listing_content_globs);
     }
 
     /// Test #13 — `to_json` of a default profile omits the empty

--- a/crates/quarto-core/src/project/dependency_graph.rs
+++ b/crates/quarto-core/src/project/dependency_graph.rs
@@ -51,7 +51,7 @@ use std::path::{Path, PathBuf};
 
 use quarto_pandoc_types::ConfigValue;
 
-use crate::project::discovery::{glob_match_path_or_dir, path_to_forward_slashes, relative_to_dir};
+use crate::project::discovery::path_to_forward_slashes;
 use crate::project::index::ProjectIndex;
 use crate::project::sidebar_membership::resolve_sidebar_membership;
 
@@ -169,15 +169,18 @@ impl ProjectDependencyGraph {
             // === Listing-content edges (L6, `bd-xbnf`) ===
             //
             // Each listing host advertises its `listing.*.contents:`
-            // globs on `profile.listing_content_globs`. We expand
-            // them against the project's source set and add a
-            // forward edge `host → content` for each match.
+            // globs on `profile.listing_content_globs` — already
+            // resolved to project-relative patterns (base directory
+            // = the file each glob was written in; bd-v7ixzsp5,
+            // GH #456). We match them against the project's source
+            // set and add a forward edge `host → content` for each
+            // match.
             //
-            // Match rule mirrors `ListingGenerateTransform` at
-            // render time (host-relative first, project-relative
-            // fallback) so graph edges line up with what the
-            // listing actually resolves. Self-edges are dropped by
-            // `add_edge`.
+            // Match rule is `glob_resolve::item_matches` — the same
+            // single-view matcher `ListingGenerateTransform` uses at
+            // render time, so graph edges line up with what the
+            // listing actually resolves (negation patterns shrink
+            // both alike). Self-edges are dropped by `add_edge`.
             //
             // Hosts with non-empty globs are added to
             // `force_render` so Mode B's
@@ -189,26 +192,16 @@ impl ProjectDependencyGraph {
             if !profile.listing_content_globs.is_empty() {
                 force_render.insert(from.clone());
 
-                let host_path_str = path_to_forward_slashes(from);
-                let host_dir_str = Path::new(&host_path_str)
-                    .parent()
-                    .map(path_to_forward_slashes)
-                    .unwrap_or_default();
-
-                for glob in &profile.listing_content_globs {
-                    for candidate in index.profiles() {
-                        if candidate.source_path == *from {
-                            continue;
-                        }
-                        let cand_str = path_to_forward_slashes(&candidate.source_path);
-                        let cand_host_relative = relative_to_dir(&cand_str, &host_dir_str);
-                        let host_match = cand_host_relative
-                            .as_deref()
-                            .is_some_and(|hr| glob_match_path_or_dir(glob, hr));
-                        let project_match = glob_match_path_or_dir(glob, &cand_str);
-                        if host_match || project_match {
-                            add_edge(from, &candidate.source_path);
-                        }
+                for candidate in index.profiles() {
+                    if candidate.source_path == *from {
+                        continue;
+                    }
+                    let cand_str = path_to_forward_slashes(&candidate.source_path);
+                    if crate::project::listing::glob_resolve::item_matches(
+                        &profile.listing_content_globs,
+                        &cand_str,
+                    ) {
+                        add_edge(from, &candidate.source_path);
                     }
                 }
             }
@@ -765,23 +758,40 @@ mod tests {
     // L6 (`bd-xbnf`): listing_content_globs become edges + force_render.
     //
     // The dep-graph builder reads each profile's
-    // `listing_content_globs` and expands them against the project's
-    // source set (host-relative first, project-relative fallback).
-    // Each match becomes a forward edge `host → content`. Hosts with
-    // non-empty entries are also added to `force_render` so Mode B's
+    // `listing_content_globs` — since v8 (bd-v7ixzsp5) these are
+    // already base-resolved, project-relative patterns — and matches
+    // them single-view against the project's source set. Each match
+    // becomes a forward edge `host → content`. Hosts with non-empty
+    // entries are also added to `force_render` so Mode B's
     // `augment_targets_with_always_render` pulls them in when any
     // matched content file is targeted.
     // ─────────────────────────────────────────────────────────────────
 
     /// A profile builder for L6 tests, with `listing_content_globs`
-    /// as its distinguishing input.
+    /// as its distinguishing input. `globs` entries are the
+    /// **resolved** project-relative patterns (a leading `!` here
+    /// marks a negated entry, mirroring what
+    /// `glob_resolve::resolve_content_globs` produces).
     fn listing_host(path: &str, globs: &[&str]) -> DocumentProfile {
+        use crate::project::listing::glob_resolve::ListingContentGlob;
         DocumentProfile {
             source_path: PathBuf::from(path),
             output_href: path.replace(".qmd", ".html"),
             format_id: "html".to_string(),
             title: Some(path.to_string()),
-            listing_content_globs: globs.iter().map(|g| g.to_string()).collect(),
+            listing_content_globs: globs
+                .iter()
+                .map(|g| match g.strip_prefix('!') {
+                    Some(rest) => ListingContentGlob {
+                        pattern: rest.to_string(),
+                        negated: true,
+                    },
+                    None => ListingContentGlob {
+                        pattern: g.to_string(),
+                        negated: false,
+                    },
+                })
+                .collect(),
             ..DocumentProfile::default()
         }
     }
@@ -823,8 +833,9 @@ mod tests {
         assert_eq!(deps.len(), 2);
     }
 
-    /// Test #15 — explicit `posts/**/*.qmd` glob matches via the
-    /// project-relative fallback. Sibling `outside.qmd` does not match.
+    /// Test #15 — explicit `posts/**/*.qmd` pattern (root host, so
+    /// the resolved form is unchanged) matches recursively; sibling
+    /// `outside.qmd` does not match.
     #[test]
     fn listing_globs_become_edges_project_relative() {
         let profiles = vec![
@@ -924,12 +935,13 @@ mod tests {
         assert!(g.force_render.is_empty());
     }
 
-    /// Test #19 — host inside a sub-directory uses host-relative
-    /// glob matching for default `"*.qmd"` and excludes itself.
+    /// Test #19 — host inside a sub-directory: the stage resolved
+    /// its default `"*.qmd"` to `posts/*.qmd`, which matches its
+    /// siblings, never itself, and never a sibling directory.
     #[test]
     fn listing_globs_dont_self_edge_in_subdir() {
         let profiles = vec![
-            listing_host("posts/index.qmd", &["*.qmd"]),
+            listing_host("posts/index.qmd", &["posts/*.qmd"]),
             plain_doc("posts/foo.qmd"),
             plain_doc("posts/bar.qmd"),
             plain_doc("other/baz.qmd"),
@@ -1011,6 +1023,30 @@ mod tests {
         assert!(deps.contains(Path::new("b/two.qmd")));
         assert!(!deps.contains(Path::new("c/three.qmd")));
         assert_eq!(deps.len(), 2);
+    }
+
+    /// Test #22b (bd-v7ixzsp5) — negated patterns shrink the edge
+    /// set exactly as they shrink the rendered listing, so excluded
+    /// items don't force host re-renders.
+    #[test]
+    fn listing_globs_negation_removes_edges() {
+        let profiles = vec![
+            listing_host("index.qmd", &["posts/*.qmd", "!posts/wip.qmd"]),
+            plain_doc("posts/foo.qmd"),
+            plain_doc("posts/wip.qmd"),
+        ];
+        let index = ProjectIndex::new(profiles);
+
+        let mut diags = Vec::new();
+        let g = ProjectDependencyGraph::build(&index, &ConfigValue::default(), &mut diags);
+
+        let deps = &g.edges[Path::new("index.qmd")];
+        assert!(deps.contains(Path::new("posts/foo.qmd")));
+        assert!(
+            !deps.contains(Path::new("posts/wip.qmd")),
+            "negated pattern must not contribute an edge"
+        );
+        assert_eq!(deps.len(), 1);
     }
 
     // ─────────────────────────────────────────────────────────────────

--- a/crates/quarto-core/src/project/discovery.rs
+++ b/crates/quarto-core/src/project/discovery.rs
@@ -225,31 +225,6 @@ pub fn path_to_forward_slashes(path: &Path) -> String {
     to_forward_slashes(path)
 }
 
-/// Compute `path` relative to `base_dir`, both expressed as
-/// forward-slash project-relative strings. Returns `None` when
-/// `path` is not under `base_dir`. Empty `base_dir` means the
-/// project root, in which case the project-relative form is the
-/// host-relative form.
-///
-/// Shared by:
-///
-/// - the L3 [`crate::transforms::listing_generate::ListingGenerateTransform`]
-///   when matching a candidate sibling against a listing's `contents:`
-///   glob at render time;
-/// - the L6 [`crate::project::dependency_graph::ProjectDependencyGraph::build`]
-///   when computing dep-graph edges from the same globs at graph-build
-///   time.
-///
-/// Both call sites use the same host-relative-first / project-
-/// relative-fallback rule, so they must agree on this primitive.
-pub(crate) fn relative_to_dir(path: &str, base_dir: &str) -> Option<String> {
-    if base_dir.is_empty() {
-        return Some(path.to_string());
-    }
-    let prefix = format!("{}/", base_dir);
-    path.strip_prefix(&prefix).map(|s| s.to_string())
-}
-
 /// Minimal glob matcher: supports literals, `*`, `?`, and `**`.
 ///
 /// This is narrow by design — we accept the glob vocabulary we want to

--- a/crates/quarto-core/src/project/listing/binding.rs
+++ b/crates/quarto-core/src/project/listing/binding.rs
@@ -401,11 +401,26 @@ fn host_relative_qmd(source_path: &std::path::Path, host_dir: &str) -> String {
     if host_dir.is_empty() {
         return project_relative;
     }
-    let prefix = format!("{}/", host_dir);
-    project_relative
-        .strip_prefix(&prefix)
-        .map(str::to_string)
-        .unwrap_or(project_relative)
+    // Walk off the shared directory prefix, then climb out of the
+    // remaining host segments with `..`. An item outside the host's
+    // directory (legal since bd-v7ixzsp5 — e.g. a `../rootpost.qmd`
+    // or `_quarto.yml`-declared glob) gets `../…` exactly as a
+    // hand-written body link from the host would, so
+    // `LinkRewriteTransform` resolves it to the right page-relative
+    // output URL.
+    let host_segments: Vec<&str> = host_dir.split('/').collect();
+    let path_segments: Vec<&str> = project_relative.split('/').collect();
+    let common = host_segments
+        .iter()
+        .zip(path_segments.iter())
+        .take_while(|(h, p)| h == p)
+        .count();
+    let mut out: Vec<&str> = Vec::new();
+    for _ in common..host_segments.len() {
+        out.push("..");
+    }
+    out.extend(&path_segments[common..]);
+    out.join("/")
 }
 
 fn build_project_map(meta: &ConfigValue) -> TemplateValue {

--- a/crates/quarto-core/src/project/listing/binding.rs
+++ b/crates/quarto-core/src/project/listing/binding.rs
@@ -416,9 +416,7 @@ fn host_relative_qmd(source_path: &std::path::Path, host_dir: &str) -> String {
         .take_while(|(h, p)| h == p)
         .count();
     let mut out: Vec<&str> = Vec::new();
-    for _ in common..host_segments.len() {
-        out.push("..");
-    }
+    out.extend(std::iter::repeat_n("..", host_segments.len() - common));
     out.extend(&path_segments[common..]);
     out.join("/")
 }

--- a/crates/quarto-core/src/project/listing/config.rs
+++ b/crates/quarto-core/src/project/listing/config.rs
@@ -591,15 +591,15 @@ fn parse_contents(
     value: &ConfigValue,
     diagnostics: &mut Vec<DiagnosticMessage>,
 ) -> Vec<ListingContents> {
-    // Quarto YAML routinely parses bare frontmatter strings as
-    // `PandocInlines` (e.g. when a glob like `posts/*.qmd` confuses
-    // the markdown sublexer and lands as a `Span` carrying the
-    // `yaml-markdown-syntax-error` class). Route through
-    // `as_plain_text` first so any string-shaped variant becomes a
-    // glob, mirroring `parse_listings`'s top-level shorthand
-    // handling. The bug that surfaced when L5's snapshot fixture
-    // used `contents: "posts/*.qmd"` and the broader audit of
-    // sibling parser branches is tracked under bd-nwyp.
+    // Since bd-v7ixzsp5, front-matter `contents:` strings arrive as
+    // `ConfigValueKind::Glob` — the key-path annotation table in
+    // pampa (`meta_annotations.rs`) types them at parse time, so
+    // they never take the markdown-parsing path (which used to warn
+    // Q-1-20 and could silently corrupt patterns whose asterisks
+    // parsed as emphasis). The `as_plain_text` route below is kept
+    // as a defensive fallback for string-shaped values from other
+    // sources (programmatic construction, runtime metadata, legacy
+    // `PandocInlines` values — the original bd-nwyp shape).
     if let Some(s) = value.as_plain_text() {
         return vec![ListingContents::Glob {
             pattern: s,

--- a/crates/quarto-core/src/project/listing/config.rs
+++ b/crates/quarto-core/src/project/listing/config.rs
@@ -129,12 +129,28 @@ pub enum ListingType {
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum ListingContents {
-    /// Glob pattern resolved against the project file set; see
-    /// L3 D10 (host-relative globs filtered through ProjectIndex).
-    Glob(String),
+    /// Glob pattern, kept as the user wrote it (a leading `!` marks
+    /// a negation). `source` is the provenance of the YAML scalar —
+    /// [`glob_resolve::resolve_content_globs`](super::glob_resolve::resolve_content_globs)
+    /// uses it to recover the declaring file's directory, which is
+    /// the base the pattern resolves against (GH #456,
+    /// bd-v7ixzsp5).
+    Glob { pattern: String, source: SourceInfo },
     /// Inline metadata record. Schema accepts; L3 emits `Q-12-2`
     /// and skips the entry until a follow-up bd issue lands.
     Inline(BTreeMap<String, ConfigValue>),
+}
+
+impl ListingContents {
+    /// Test/construction convenience: a glob entry with programmatic
+    /// (no-file) provenance, which resolves against the host
+    /// directory.
+    pub fn glob_no_source(pattern: impl Into<String>) -> Self {
+        ListingContents::Glob {
+            pattern: pattern.into(),
+            source: SourceInfo::generated(By::programmatic_config()),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -585,26 +601,42 @@ fn parse_contents(
     // used `contents: "posts/*.qmd"` and the broader audit of
     // sibling parser branches is tracked under bd-nwyp.
     if let Some(s) = value.as_plain_text() {
-        return vec![ListingContents::Glob(s)];
+        return vec![ListingContents::Glob {
+            pattern: s,
+            source: value.source_info.clone(),
+        }];
     }
     match &value.value {
         ConfigValueKind::Scalar(Yaml::String(s)) => {
-            vec![ListingContents::Glob(s.clone())]
+            vec![ListingContents::Glob {
+                pattern: s.clone(),
+                source: value.source_info.clone(),
+            }]
         }
         ConfigValueKind::Glob(pattern) => {
-            vec![ListingContents::Glob(pattern.clone())]
+            vec![ListingContents::Glob {
+                pattern: pattern.clone(),
+                source: value.source_info.clone(),
+            }]
         }
         ConfigValueKind::Array(items) => items
             .iter()
             .filter_map(|item| {
                 if let Some(s) = item.as_plain_text() {
-                    return Some(ListingContents::Glob(s));
+                    return Some(ListingContents::Glob {
+                        pattern: s,
+                        source: item.source_info.clone(),
+                    });
                 }
                 match &item.value {
-                    ConfigValueKind::Scalar(Yaml::String(s)) => {
-                        Some(ListingContents::Glob(s.clone()))
-                    }
-                    ConfigValueKind::Glob(pattern) => Some(ListingContents::Glob(pattern.clone())),
+                    ConfigValueKind::Scalar(Yaml::String(s)) => Some(ListingContents::Glob {
+                        pattern: s.clone(),
+                        source: item.source_info.clone(),
+                    }),
+                    ConfigValueKind::Glob(pattern) => Some(ListingContents::Glob {
+                        pattern: pattern.clone(),
+                        source: item.source_info.clone(),
+                    }),
                     ConfigValueKind::Map(entries) => {
                         push_diag(
                             diagnostics,
@@ -884,45 +916,31 @@ pub fn apply_type_defaults(l: &mut Listing) {
     // host page (Q1 default; the host file itself gets excluded
     // during item discovery, not here).
     if l.contents.is_empty() {
-        l.contents.push(ListingContents::Glob("*.qmd".to_string()));
+        l.contents.push(ListingContents::glob_no_source("*.qmd"));
     }
 }
 
-/// Extract just the content-glob strings from a host page's
-/// `meta.listing:` value, ignoring all other listing config.
+/// Flatten every `contents:` glob entry across all listings declared
+/// on a host page's `meta.listing:` value, ignoring all other listing
+/// config. Inline-record entries (`Q-12-2` at render time) contribute
+/// nothing.
 ///
-/// Used by [`crate::project::dependency_graph::ProjectDependencyGraph::build`]
-/// (Phase-8 / L6, `bd-xbnf`) to discover which sibling files this
-/// page's listings reference, so Mode B can re-render the host
-/// when any of those siblings is in the user-named target set.
-///
-/// Globs are flattened across all listings declared on the page —
-/// the dep graph cares about edges, not which listing produced
-/// them. Inline-record `contents:` entries (`Q-12-2` at render
-/// time) contribute nothing to the dep graph.
-///
-/// **Implementation note (`bd-bqf2`):** today this routes through
-/// [`parse_listings`] and discards the resulting diagnostics, so
-/// shape-handling stays in lockstep with the L3 generate transform
-/// without any duplicated walker logic. If profiling ever shows
-/// the redundant work as a hotspot, `bd-bqf2` tracks the refactor
-/// to a shared shape walker. For now: one source of truth, no
-/// drift risk.
-pub fn extract_content_globs(meta: &ConfigValue) -> Vec<String> {
+/// Consumers resolve the returned entries with
+/// [`super::glob_resolve::resolve_content_globs`] — see that module
+/// for the base-directory semantics. Routes through
+/// [`parse_listings`] (diagnostics discarded) so shape-handling
+/// stays in lockstep with the L3 generate transform (`bd-bqf2`).
+pub fn flatten_content_globs(meta: &ConfigValue) -> Vec<ListingContents> {
     let Some(listing_value) = meta.get("listing") else {
         return Vec::new();
     };
     let mut throwaway_diagnostics: Vec<DiagnosticMessage> = Vec::new();
     let listings = parse_listings(listing_value, &mut throwaway_diagnostics);
-    let mut out: Vec<String> = Vec::new();
-    for listing in listings {
-        for content in listing.contents {
-            if let ListingContents::Glob(g) = content {
-                out.push(g);
-            }
-        }
-    }
-    out
+    listings
+        .into_iter()
+        .flat_map(|l| l.contents)
+        .filter(|c| matches!(c, ListingContents::Glob { .. }))
+        .collect()
 }
 
 fn push_diag(
@@ -975,6 +993,18 @@ mod tests {
         (listings, diags)
     }
 
+    /// The glob pattern strings of a contents list, ignoring the
+    /// per-entry provenance (which tests can't reproduce exactly).
+    fn glob_patterns(contents: &[ListingContents]) -> Vec<String> {
+        contents
+            .iter()
+            .filter_map(|c| match c {
+                ListingContents::Glob { pattern, .. } => Some(pattern.clone()),
+                ListingContents::Inline(_) => None,
+            })
+            .collect()
+    }
+
     // 1. config_parses_minimal — `listing: default` parses to a
     //    Listing with id synthesized, type Default, defaults applied.
     #[test]
@@ -984,10 +1014,7 @@ mod tests {
         assert_eq!(listings[0].id, "listing-1");
         assert_eq!(listings[0].kind, ListingType::Default);
         // Default contents glob filled in.
-        assert_eq!(
-            listings[0].contents,
-            vec![ListingContents::Glob("*.qmd".to_string())]
-        );
+        assert_eq!(glob_patterns(&listings[0].contents), vec!["*.qmd"]);
         // Default fields set.
         assert!(listings[0].fields.contains(&"title".to_string()));
         assert!(listings[0].fields.contains(&"date".to_string()));
@@ -1067,10 +1094,7 @@ mod tests {
             ("type", s("default")),
             ("contents", arr(vec![s("posts/**/*.qmd")])),
         ]));
-        assert_eq!(
-            listings[0].contents,
-            vec![ListingContents::Glob("posts/**/*.qmd".to_string())]
-        );
+        assert_eq!(glob_patterns(&listings[0].contents), vec!["posts/**/*.qmd"]);
     }
 
     // 6b. Quarto YAML often parses globs like `posts/*.qmd` as
@@ -1095,8 +1119,8 @@ mod tests {
             ("contents", contents_val),
         ]));
         assert_eq!(
-            listings[0].contents,
-            vec![ListingContents::Glob("posts/*.qmd".to_string())],
+            glob_patterns(&listings[0].contents),
+            vec!["posts/*.qmd"],
             "expected `posts/*.qmd` glob; diags: {:?}",
             diags
         );
@@ -1121,11 +1145,8 @@ mod tests {
         );
         let (listings, _) = parse(map(vec![("type", s("default")), ("contents", arr_val)]));
         assert_eq!(
-            listings[0].contents,
-            vec![
-                ListingContents::Glob("posts/*.qmd".to_string()),
-                ListingContents::Glob("notes/*.qmd".to_string()),
-            ]
+            glob_patterns(&listings[0].contents),
+            vec!["posts/*.qmd", "notes/*.qmd"]
         );
     }
 
@@ -1286,11 +1307,12 @@ mod tests {
     }
 
     // ─────────────────────────────────────────────────────────────
-    // L6 (bd-xbnf): extract_content_globs
+    // L6 (bd-xbnf): flatten_content_globs
     //
-    // The dep-graph builder calls this to read just the glob strings
-    // out of `meta.listing`, ignoring all the other listing config.
-    // It must agree with `parse_listings` on every accepted shape so
+    // The profile stage calls this to read just the glob entries
+    // out of `meta.listing` (before resolving them via
+    // `glob_resolve`), ignoring all the other listing config. It
+    // must agree with `parse_listings` on every accepted shape so
     // graph edges line up with what the L3 generate transform
     // resolves at render time.
     // ─────────────────────────────────────────────────────────────
@@ -1303,7 +1325,7 @@ mod tests {
     #[test]
     fn extract_globs_from_single_listing_default_shorthand() {
         let meta = meta_with_listing(b(true));
-        assert_eq!(extract_content_globs(&meta), vec!["*.qmd".to_string()]);
+        assert_eq!(glob_patterns(&flatten_content_globs(&meta)), vec!["*.qmd"]);
     }
 
     /// Explicit `contents:` glob list.
@@ -1311,8 +1333,8 @@ mod tests {
     fn extract_globs_from_single_listing_with_explicit_contents() {
         let meta = meta_with_listing(map(vec![("contents", arr(vec![s("posts/*.qmd")]))]));
         assert_eq!(
-            extract_content_globs(&meta),
-            vec!["posts/*.qmd".to_string()]
+            glob_patterns(&flatten_content_globs(&meta)),
+            vec!["posts/*.qmd"]
         );
     }
 
@@ -1321,7 +1343,7 @@ mod tests {
     #[test]
     fn extract_globs_from_single_listing_no_contents_shorthand() {
         let meta = meta_with_listing(map(vec![("type", s("grid"))]));
-        assert_eq!(extract_content_globs(&meta), vec!["*.qmd".to_string()]);
+        assert_eq!(glob_patterns(&flatten_content_globs(&meta)), vec!["*.qmd"]);
     }
 
     /// Array of listings; globs flatten across listings.
@@ -1332,12 +1354,8 @@ mod tests {
             map(vec![("contents", arr(vec![s("b/*.qmd"), s("c/*.qmd")]))]),
         ]));
         assert_eq!(
-            extract_content_globs(&meta),
-            vec![
-                "a/*.qmd".to_string(),
-                "b/*.qmd".to_string(),
-                "c/*.qmd".to_string(),
-            ]
+            glob_patterns(&flatten_content_globs(&meta)),
+            vec!["a/*.qmd", "b/*.qmd", "c/*.qmd"]
         );
     }
 
@@ -1349,7 +1367,7 @@ mod tests {
             "contents",
             arr(vec![map(vec![("title", s("foo"))]), s("*.qmd")]),
         )]));
-        assert_eq!(extract_content_globs(&meta), vec!["*.qmd".to_string()]);
+        assert_eq!(glob_patterns(&flatten_content_globs(&meta)), vec!["*.qmd"]);
     }
 
     /// `listing: false` → no globs (parse_listings emits Q-12-6
@@ -1357,21 +1375,21 @@ mod tests {
     #[test]
     fn extract_globs_listing_false_is_empty() {
         let meta = meta_with_listing(b(false));
-        assert!(extract_content_globs(&meta).is_empty());
+        assert!(flatten_content_globs(&meta).is_empty());
     }
 
     /// Meta with no `listing:` key → empty globs.
     #[test]
     fn extract_globs_no_listing_key_is_empty() {
         let meta = map(vec![("title", s("Hello"))]);
-        assert!(extract_content_globs(&meta).is_empty());
+        assert!(flatten_content_globs(&meta).is_empty());
     }
 
     /// `contents:` as a single string (not an array) — `parse_contents`
-    /// accepts this shape; `extract_content_globs` must agree.
+    /// accepts this shape; `flatten_content_globs` must agree.
     #[test]
     fn extract_globs_handles_string_shorthand_contents() {
         let meta = meta_with_listing(map(vec![("contents", s("*.qmd"))]));
-        assert_eq!(extract_content_globs(&meta), vec!["*.qmd".to_string()]);
+        assert_eq!(glob_patterns(&flatten_content_globs(&meta)), vec!["*.qmd"]);
     }
 }

--- a/crates/quarto-core/src/project/listing/glob_resolve.rs
+++ b/crates/quarto-core/src/project/listing/glob_resolve.rs
@@ -308,7 +308,7 @@ mod tests {
         );
         assert_eq!(
             project_relative_dir_of("/proj/_quarto.yml", project),
-            Some("".into())
+            Some(String::new())
         );
     }
 

--- a/crates/quarto-core/src/project/listing/glob_resolve.rs
+++ b/crates/quarto-core/src/project/listing/glob_resolve.rs
@@ -1,0 +1,542 @@
+/*
+ * project/listing/glob_resolve.rs
+ * Copyright (c) 2026 Posit, PBC
+ */
+
+//! Base-directory resolution and matching for listing `contents:`
+//! globs (GH #456, bd-v7ixzsp5).
+//!
+//! A `contents:` glob resolves relative to the directory of the file
+//! where it was **written**:
+//!
+//! - document front matter → the host document's directory;
+//! - a directory `_metadata.yml` → that file's directory;
+//! - the project `_quarto.yml` → the project root.
+//!
+//! The declaring file is recovered from the glob's `ConfigValue`
+//! provenance: [`SourceInfo::root_file_id`] gives the `FileId` the
+//! value was parsed from, and the document's
+//! [`SourceContext`](quarto_source_map::SourceContext) maps it back
+//! to a path ([`MetadataMergeStage`](crate::stage::stages::MetadataMergeStage)
+//! registers the YAML metadata layers there for exactly this
+//! lookup). Values with no recoverable file — runtime `--metadata`,
+//! programmatic config, extension metadata — fall back to the host
+//! document's directory.
+//!
+//! Matching is **single-view**: the pattern is joined to its base
+//! directory, lexically normalized, and matched against each
+//! candidate's project-relative path. There is no project-relative
+//! fallback (the pre-#456 dual-view rule let `*.qmd` in `sub/`
+//! match project-root files). A pattern that normalizes outside the
+//! project root matches nothing and is reported to the caller so
+//! the render transform can emit `Q-12-17`.
+//!
+//! Negation: a `!`-prefixed pattern excludes matches. An item is
+//! included iff it matches at least one positive pattern and no
+//! negative pattern. When `contents:` holds only negative patterns,
+//! the positive set defaults to `*.qmd` in the host directory.
+//!
+//! This module is intended as the seed of a shared, base-directory-
+//! anchored glob-expansion API for q2 (plan decision 3); other glob
+//! consumers (`project.render`, resources) can migrate onto it once
+//! the shape settles.
+
+use std::path::Path;
+
+use quarto_source_map::{SourceContext, SourceInfo};
+use serde::{Deserialize, Serialize};
+
+use super::ListingContents;
+use crate::project::discovery::glob_match_path_or_dir;
+
+/// One resolved `contents:` glob: a normalized project-relative
+/// pattern plus its negation flag. This is the shape stored on
+/// [`DocumentProfile::listing_content_globs`](crate::document_profile::DocumentProfile)
+/// (resolution happens once, at profile-extraction / listing-parse
+/// time; consumers only match).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ListingContentGlob {
+    /// Normalized project-relative pattern (forward slashes, no
+    /// `.`/`..` segments), e.g. `"sub/*.qmd"`.
+    pub pattern: String,
+    /// True for `!`-prefixed patterns: matches are excluded.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub negated: bool,
+}
+
+/// A `contents:` glob whose normalized form escapes the project
+/// root (e.g. `../../*.qmd` written next to the root). It matches
+/// nothing; the render transform reports it as `Q-12-17`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct EscapedContentGlob {
+    /// The pattern as the user wrote it (including any `!`).
+    pub raw: String,
+    /// Provenance of the offending YAML scalar, for the diagnostic
+    /// span.
+    pub source: SourceInfo,
+}
+
+/// Result of resolving a listing's `contents:` entries.
+#[derive(Debug, Clone, Default)]
+pub struct GlobResolution {
+    /// Usable patterns (positive and negative), project-relative.
+    pub globs: Vec<ListingContentGlob>,
+    /// Patterns that escaped the project root (diagnose, match
+    /// nothing).
+    pub escaped: Vec<EscapedContentGlob>,
+}
+
+/// Resolve each glob entry of a listing's `contents:` to a
+/// project-relative pattern.
+///
+/// `host_dir` is the host document's project-relative directory
+/// (forward slashes, `""` for the project root) — the fallback base
+/// and the base for the negation-only default. `project_dir` is the
+/// absolute project root, used to relativize absolute paths found
+/// in the `SourceContext`. Inline-record entries contribute
+/// nothing (the parser already emitted `Q-12-2`).
+pub fn resolve_content_globs(
+    contents: &[ListingContents],
+    source_context: Option<&SourceContext>,
+    project_dir: &Path,
+    host_dir: &str,
+) -> GlobResolution {
+    let mut out = GlobResolution::default();
+
+    for entry in contents {
+        let ListingContents::Glob {
+            pattern: raw,
+            source,
+        } = entry
+        else {
+            continue;
+        };
+        let (negated, pattern) = match raw.strip_prefix('!') {
+            Some(rest) => (true, rest),
+            None => (false, raw.as_str()),
+        };
+        let base_dir = base_dir_for(source, source_context, project_dir, host_dir);
+        match join_and_normalize(&base_dir, pattern) {
+            Some(resolved) => out.globs.push(ListingContentGlob {
+                pattern: resolved,
+                negated,
+            }),
+            None => out.escaped.push(EscapedContentGlob {
+                raw: raw.clone(),
+                source: source.clone(),
+            }),
+        }
+    }
+
+    // Negation-only contents: the positive set defaults to the
+    // host-directory siblings (`*.qmd`), mirroring the
+    // absent-`contents:` default.
+    if !out.globs.is_empty() && out.globs.iter().all(|g| g.negated) {
+        // `join_and_normalize` cannot fail here: `host_dir` is
+        // already a normalized project-relative directory.
+        if let Some(default_pattern) = join_and_normalize(host_dir, "*.qmd") {
+            out.globs.insert(
+                0,
+                ListingContentGlob {
+                    pattern: default_pattern,
+                    negated: false,
+                },
+            );
+        }
+    }
+
+    out
+}
+
+/// True iff `candidate` (a project-relative forward-slash path)
+/// matches at least one positive pattern and no negative pattern.
+/// Bare-directory patterns match everything beneath them (the
+/// [`glob_match_path_or_dir`] rule).
+pub fn item_matches(globs: &[ListingContentGlob], candidate: &str) -> bool {
+    globs
+        .iter()
+        .any(|g| !g.negated && glob_match_path_or_dir(&g.pattern, candidate))
+        && !globs
+            .iter()
+            .any(|g| g.negated && glob_match_path_or_dir(&g.pattern, candidate))
+}
+
+/// Project-relative directory (forward slashes, `""` for the root)
+/// of the file a value was written in, per its `SourceInfo`
+/// provenance. Falls back to `host_dir` when the file cannot be
+/// recovered (generated/programmatic values, unregistered files,
+/// paths outside the project).
+fn base_dir_for(
+    source: &SourceInfo,
+    source_context: Option<&SourceContext>,
+    project_dir: &Path,
+    host_dir: &str,
+) -> String {
+    let resolved = source
+        .root_file_id()
+        .and_then(|id| source_context?.get_file(id))
+        .and_then(|f| project_relative_dir_of(&f.path, project_dir));
+    resolved.unwrap_or_else(|| host_dir.to_string())
+}
+
+/// Directory of `file_path` as a project-relative forward-slash
+/// string. Absolute paths are relativized against `project_dir`;
+/// already-relative paths are taken as project-relative. Returns
+/// `None` for placeholder names (`<unknown>`, empty) and for paths
+/// outside the project.
+fn project_relative_dir_of(file_path: &str, project_dir: &Path) -> Option<String> {
+    if file_path.is_empty() || file_path.starts_with('<') {
+        return None;
+    }
+    let path = Path::new(file_path);
+    let relative = if quarto_util::is_rooted(path) {
+        path.strip_prefix(project_dir).ok()?
+    } else {
+        path
+    };
+    let dir = relative.parent().unwrap_or(Path::new(""));
+    let mut segments: Vec<&str> = Vec::new();
+    for comp in dir.components() {
+        match comp {
+            std::path::Component::Normal(os) => segments.push(os.to_str()?),
+            std::path::Component::CurDir => {}
+            // `..` or a root inside a supposedly project-relative
+            // path — not resolvable to a project-relative dir.
+            _ => return None,
+        }
+    }
+    Some(segments.join("/"))
+}
+
+/// Join `pattern` onto `base_dir` and lexically normalize the
+/// result: `.` segments drop, `..` segments pop. Returns `None`
+/// when a `..` would climb above the project root. Both inputs use
+/// forward slashes (backslashes are normalized for safety, matching
+/// the matcher's tolerance).
+fn join_and_normalize(base_dir: &str, pattern: &str) -> Option<String> {
+    let pattern = pattern.replace('\\', "/");
+    let mut segments: Vec<&str> = Vec::new();
+    let joined = if base_dir.is_empty() {
+        pattern.clone()
+    } else {
+        format!("{base_dir}/{pattern}")
+    };
+    for seg in joined.split('/') {
+        match seg {
+            "" | "." => {}
+            ".." => {
+                segments.pop()?;
+            }
+            other => segments.push(other),
+        }
+    }
+    Some(segments.join("/"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use quarto_source_map::{By, FileId};
+
+    fn glob(pattern: &str, source: SourceInfo) -> ListingContents {
+        ListingContents::Glob {
+            pattern: pattern.to_string(),
+            source,
+        }
+    }
+
+    fn programmatic() -> SourceInfo {
+        SourceInfo::generated(By::programmatic_config())
+    }
+
+    // ── join_and_normalize ──────────────────────────────────────
+
+    #[test]
+    fn join_empty_base_is_identity() {
+        assert_eq!(join_and_normalize("", "*.qmd"), Some("*.qmd".into()));
+        assert_eq!(
+            join_and_normalize("", "posts/**/*.qmd"),
+            Some("posts/**/*.qmd".into())
+        );
+    }
+
+    #[test]
+    fn join_prefixes_base_dir() {
+        assert_eq!(join_and_normalize("sub", "*.qmd"), Some("sub/*.qmd".into()));
+        assert_eq!(
+            join_and_normalize("blog", "deep/*.qmd"),
+            Some("blog/deep/*.qmd".into())
+        );
+    }
+
+    #[test]
+    fn join_normalizes_dot_and_dotdot() {
+        assert_eq!(
+            join_and_normalize("sub", "../rootpost.qmd"),
+            Some("rootpost.qmd".into())
+        );
+        assert_eq!(
+            join_and_normalize("sub", "./*.qmd"),
+            Some("sub/*.qmd".into())
+        );
+        assert_eq!(
+            join_and_normalize("a/b", "../c/*.qmd"),
+            Some("a/c/*.qmd".into())
+        );
+        // `..` inside the pattern body normalizes too.
+        assert_eq!(
+            join_and_normalize("", "posts/../notes/*.qmd"),
+            Some("notes/*.qmd".into())
+        );
+    }
+
+    #[test]
+    fn join_escaping_project_root_is_none() {
+        assert_eq!(join_and_normalize("", "../*.qmd"), None);
+        assert_eq!(join_and_normalize("sub", "../../*.qmd"), None);
+        assert_eq!(join_and_normalize("a/b", "../../../x.qmd"), None);
+    }
+
+    // ── project_relative_dir_of ─────────────────────────────────
+
+    #[test]
+    fn dir_of_absolute_path_inside_project() {
+        let project = Path::new("/proj");
+        assert_eq!(
+            project_relative_dir_of("/proj/blog/_metadata.yml", project),
+            Some("blog".into())
+        );
+        assert_eq!(
+            project_relative_dir_of("/proj/_quarto.yml", project),
+            Some("".into())
+        );
+    }
+
+    #[test]
+    fn dir_of_relative_path_is_project_relative() {
+        let project = Path::new("/proj");
+        assert_eq!(
+            project_relative_dir_of("sub/index.qmd", project),
+            Some("sub".into())
+        );
+    }
+
+    #[test]
+    fn dir_of_placeholder_or_outside_is_none() {
+        let project = Path::new("/proj");
+        assert_eq!(project_relative_dir_of("<unknown>", project), None);
+        assert_eq!(project_relative_dir_of("", project), None);
+        assert_eq!(project_relative_dir_of("/elsewhere/doc.qmd", project), None);
+    }
+
+    // ── resolve_content_globs ───────────────────────────────────
+
+    /// A SourceContext with the host doc as FileId(0) plus a
+    /// hash-registered YAML layer, mirroring what the parse +
+    /// MetadataMergeStage leave behind.
+    fn context_with_layer(doc: &str, layer: &str) -> (SourceContext, FileId) {
+        let mut sc = SourceContext::new();
+        // Overwrite the FileId(0) slot convention: a fresh context
+        // in production is created via ASTContext::with_filename,
+        // which adds the doc as FileId(0). SourceContext::new()
+        // pre-adds nothing here, so add the doc first.
+        let doc_id = sc.add_file(doc.to_string(), None);
+        assert_eq!(doc_id, FileId(0));
+        let layer_id = quarto_yaml::file_id_for_filename(layer);
+        sc.add_file_with_id(layer_id, layer.to_string(), None);
+        (sc, layer_id)
+    }
+
+    #[test]
+    fn frontmatter_glob_resolves_against_doc_dir() {
+        let (sc, _) = context_with_layer("/proj/sub/index.qmd", "/proj/_quarto.yml");
+        // Front matter values are Substrings into FileId(0).
+        let source = SourceInfo::substring(SourceInfo::original(FileId(0), 0, 100), 10, 20);
+        let r = resolve_content_globs(
+            &[glob("*.qmd", source)],
+            Some(&sc),
+            Path::new("/proj"),
+            "sub",
+        );
+        assert_eq!(
+            r.globs,
+            vec![ListingContentGlob {
+                pattern: "sub/*.qmd".into(),
+                negated: false
+            }]
+        );
+        assert!(r.escaped.is_empty());
+    }
+
+    #[test]
+    fn metadata_layer_glob_resolves_against_layer_dir() {
+        let (sc, layer_id) =
+            context_with_layer("/proj/blog/deep/index.qmd", "/proj/blog/_metadata.yml");
+        let source = SourceInfo::original(layer_id, 0, 10);
+        let r = resolve_content_globs(
+            &[glob("deep/*.qmd", source)],
+            Some(&sc),
+            Path::new("/proj"),
+            "blog/deep",
+        );
+        assert_eq!(
+            r.globs,
+            vec![ListingContentGlob {
+                pattern: "blog/deep/*.qmd".into(),
+                negated: false
+            }]
+        );
+    }
+
+    #[test]
+    fn project_config_glob_resolves_against_root() {
+        let (sc, layer_id) = context_with_layer("/proj/sub/viewer.qmd", "/proj/_quarto.yml");
+        let source = SourceInfo::original(layer_id, 0, 10);
+        let r = resolve_content_globs(
+            &[glob("posts/*.qmd", source)],
+            Some(&sc),
+            Path::new("/proj"),
+            "sub",
+        );
+        assert_eq!(
+            r.globs,
+            vec![ListingContentGlob {
+                pattern: "posts/*.qmd".into(),
+                negated: false
+            }]
+        );
+    }
+
+    #[test]
+    fn unresolvable_provenance_falls_back_to_host_dir() {
+        let r = resolve_content_globs(
+            &[glob("*.qmd", programmatic())],
+            None,
+            Path::new("/proj"),
+            "sub",
+        );
+        assert_eq!(
+            r.globs,
+            vec![ListingContentGlob {
+                pattern: "sub/*.qmd".into(),
+                negated: false
+            }]
+        );
+    }
+
+    #[test]
+    fn escaping_glob_is_reported_not_matched() {
+        let r = resolve_content_globs(
+            &[glob("../../*.qmd", programmatic())],
+            None,
+            Path::new("/proj"),
+            "sub",
+        );
+        assert!(r.globs.is_empty());
+        assert_eq!(r.escaped.len(), 1);
+        assert_eq!(r.escaped[0].raw, "../../*.qmd");
+    }
+
+    #[test]
+    fn negation_strips_bang_and_sets_flag() {
+        let r = resolve_content_globs(
+            &[
+                glob("*.qmd", programmatic()),
+                glob("!p2.qmd", programmatic()),
+            ],
+            None,
+            Path::new("/proj"),
+            "sub",
+        );
+        assert_eq!(
+            r.globs,
+            vec![
+                ListingContentGlob {
+                    pattern: "sub/*.qmd".into(),
+                    negated: false
+                },
+                ListingContentGlob {
+                    pattern: "sub/p2.qmd".into(),
+                    negated: true
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn negation_only_injects_host_default_positive() {
+        let r = resolve_content_globs(
+            &[glob("!p2.qmd", programmatic())],
+            None,
+            Path::new("/proj"),
+            "sub",
+        );
+        assert_eq!(
+            r.globs,
+            vec![
+                ListingContentGlob {
+                    pattern: "sub/*.qmd".into(),
+                    negated: false
+                },
+                ListingContentGlob {
+                    pattern: "sub/p2.qmd".into(),
+                    negated: true
+                },
+            ]
+        );
+    }
+
+    // ── item_matches ────────────────────────────────────────────
+
+    fn pos(p: &str) -> ListingContentGlob {
+        ListingContentGlob {
+            pattern: p.into(),
+            negated: false,
+        }
+    }
+
+    fn neg(p: &str) -> ListingContentGlob {
+        ListingContentGlob {
+            pattern: p.into(),
+            negated: true,
+        }
+    }
+
+    #[test]
+    fn matches_positive_only() {
+        let globs = vec![pos("sub/*.qmd")];
+        assert!(item_matches(&globs, "sub/p1.qmd"));
+        assert!(!item_matches(&globs, "about.qmd"));
+        assert!(!item_matches(&globs, "sub/deep/p1.qmd"));
+    }
+
+    #[test]
+    fn negation_excludes() {
+        let globs = vec![pos("sub/*.qmd"), neg("sub/p2.qmd")];
+        assert!(item_matches(&globs, "sub/p1.qmd"));
+        assert!(!item_matches(&globs, "sub/p2.qmd"));
+    }
+
+    #[test]
+    fn bare_directory_positive_matches_beneath() {
+        let globs = vec![pos("posts")];
+        assert!(item_matches(&globs, "posts/welcome/index.qmd"));
+        assert!(!item_matches(&globs, "posts-archive/old.qmd"));
+    }
+
+    #[test]
+    fn bare_directory_negation_excludes_beneath() {
+        let globs = vec![pos("posts"), neg("posts/drafts")];
+        assert!(item_matches(&globs, "posts/welcome/index.qmd"));
+        assert!(!item_matches(&globs, "posts/drafts/wip.qmd"));
+    }
+
+    #[test]
+    fn no_positive_matches_nothing() {
+        assert!(!item_matches(&[], "sub/p1.qmd"));
+        let only_neg = vec![neg("sub/p2.qmd")];
+        // resolve_content_globs injects the default positive before
+        // matching; raw negation-only lists match nothing.
+        assert!(!item_matches(&only_neg, "sub/p1.qmd"));
+    }
+}

--- a/crates/quarto-core/src/project/listing/mod.rs
+++ b/crates/quarto-core/src/project/listing/mod.rs
@@ -57,10 +57,15 @@ pub mod post_render_upgrade;
 // §"Module gate granularity".
 pub mod feed;
 
+pub mod glob_resolve;
+
 pub use config::{
     ColumnType, FeedType, GridItemAlign, ImageAlign, Listing, ListingCategoriesMode,
     ListingContents, ListingFeedOptions, ListingFilter, ListingSort, ListingType, SortDirection,
     parse_listings,
+};
+pub use glob_resolve::{
+    EscapedContentGlob, GlobResolution, ListingContentGlob, item_matches, resolve_content_globs,
 };
 pub use item::{ListingItem, hydrate_item};
 

--- a/crates/quarto-core/src/project/mod.rs
+++ b/crates/quarto-core/src/project/mod.rs
@@ -111,12 +111,17 @@ fn default_output_dir(dir: &Path, config: Option<&ProjectConfig>) -> PathBuf {
 ///       chapter1.qmd       # Document being rendered
 /// ```
 ///
-/// Returns: [layer0, layer1] - deeper directories later in vec
+/// Returns: [layer0, layer1] - deeper directories later in vec.
+/// Each layer carries the path of the `_metadata.yml` it was parsed
+/// from — the exact `PathBuf` whose string form was hashed into the
+/// layer's `FileId`s by `quarto_yaml::parse_file`, so callers
+/// (`MetadataMergeStage`) can register the file in the document's
+/// `SourceContext` under the matching id.
 pub fn directory_metadata_for_document(
     project: &ProjectContext,
     document_path: &Path,
     runtime: &dyn SystemRuntime,
-) -> Result<Vec<ConfigValue>> {
+) -> Result<Vec<(PathBuf, ConfigValue)>> {
     use pampa::pandoc::yaml_to_config_value;
     use pampa::utils::diagnostic_collector::DiagnosticCollector;
     use quarto_config::InterpretationContext;
@@ -188,7 +193,7 @@ pub fn directory_metadata_for_document(
             // Adjust !path values to be relative to document directory
             adjust_paths_to_document_dir(&mut metadata, &current_dir, document_dir);
 
-            layers.push(metadata);
+            layers.push((path, metadata));
         }
     }
 
@@ -1113,7 +1118,7 @@ mod tests {
                 directory_metadata_for_document(&project, &doc_path, &native_runtime()).unwrap();
 
             assert_eq!(result.len(), 1);
-            assert_eq!(result[0].get("toc").unwrap().as_bool(), Some(true));
+            assert_eq!(result[0].1.get("toc").unwrap().as_bool(), Some(true));
         }
 
         #[test]
@@ -1164,8 +1169,8 @@ mod tests {
             //
             // So our test should expect 2 layers, not 3.
             assert_eq!(result.len(), 2);
-            assert_eq!(result[0].get("toc").unwrap().as_bool(), Some(true));
-            assert_eq!(result[1].get("toc-depth").unwrap().as_int(), Some(2));
+            assert_eq!(result[0].1.get("toc").unwrap().as_bool(), Some(true));
+            assert_eq!(result[1].1.get("toc-depth").unwrap().as_int(), Some(2));
         }
 
         #[test]
@@ -1203,7 +1208,7 @@ mod tests {
 
             // Only the deep/_metadata.yml should be found
             assert_eq!(result.len(), 1);
-            assert_eq!(result[0].get("toc").unwrap().as_bool(), Some(true));
+            assert_eq!(result[0].1.get("toc").unwrap().as_bool(), Some(true));
         }
 
         #[test]
@@ -1222,7 +1227,7 @@ mod tests {
                 directory_metadata_for_document(&project, &doc_path, &native_runtime()).unwrap();
 
             assert_eq!(result.len(), 1);
-            assert_eq!(result[0].get("toc").unwrap().as_bool(), Some(true));
+            assert_eq!(result[0].1.get("toc").unwrap().as_bool(), Some(true));
         }
 
         #[test]
@@ -1336,7 +1341,7 @@ mod tests {
                 directory_metadata_for_document(&project, &doc_path, &native_runtime()).unwrap();
 
             assert_eq!(result.len(), 1);
-            let css_value = result[0].get("css").expect("should have css key");
+            let css_value = result[0].1.get("css").expect("should have css key");
 
             // The path should be adjusted from ../shared/styles.css to ../../shared/styles.css
             // because we went one directory deeper (chapters/intro instead of chapters/)
@@ -1369,7 +1374,7 @@ mod tests {
                 directory_metadata_for_document(&project, &doc_path, &native_runtime()).unwrap();
 
             assert_eq!(result.len(), 1);
-            let css_value = result[0].get("css").expect("should have css key");
+            let css_value = result[0].1.get("css").expect("should have css key");
 
             // Path should remain equivalent (pathdiff may normalize ./local.css to local.css)
             let path_str = css_value.as_str().expect("should be a string path");
@@ -1406,7 +1411,7 @@ mod tests {
                 directory_metadata_for_document(&project, &doc_path, &native_runtime()).unwrap();
 
             assert_eq!(result.len(), 1);
-            let theme_value = result[0].get("theme").expect("should have theme key");
+            let theme_value = result[0].1.get("theme").expect("should have theme key");
 
             // Plain string should NOT be adjusted
             assert_eq!(
@@ -1441,7 +1446,7 @@ mod tests {
                 directory_metadata_for_document(&project, &doc_path, &native_runtime()).unwrap();
 
             assert_eq!(result.len(), 1);
-            let css_value = result[0].get("css").expect("should have css key");
+            let css_value = result[0].1.get("css").expect("should have css key");
 
             // Absolute path should be unchanged
             assert_eq!(
@@ -1479,6 +1484,7 @@ mod tests {
 
             assert_eq!(result.len(), 1);
             let css_array = result[0]
+                .1
                 .get("css")
                 .expect("should have css key")
                 .as_array()
@@ -1523,6 +1529,7 @@ mod tests {
 
             assert_eq!(result.len(), 1);
             let resources = result[0]
+                .1
                 .get("resources")
                 .expect("should have resources key");
 
@@ -1562,6 +1569,7 @@ mod tests {
 
             assert_eq!(result.len(), 1);
             let css_value = result[0]
+                .1
                 .get("format")
                 .and_then(|f| f.get("html"))
                 .and_then(|h| h.get("css"))

--- a/crates/quarto-core/src/stage/stages/document_profile.rs
+++ b/crates/quarto-core/src/stage/stages/document_profile.rs
@@ -89,6 +89,24 @@ impl PipelineStage for DocumentProfileStage {
         // (transitive) child file the parent depends on.
         profile.includes = std::mem::take(&mut doc.recorded_includes);
 
+        // Resolve the host's `listing.*.contents:` globs to
+        // project-relative form (bd-v7ixzsp5, GH #456). Needs the
+        // document's `SourceContext` (registered YAML metadata
+        // layers) to recover each glob's declaring file, so it
+        // lives here rather than in the pure `extract`. Escaping
+        // patterns are dropped silently — the render transform owns
+        // the `Q-12-17` diagnostic.
+        let host_dir = to_forward_slash(source_path.parent().unwrap_or(Path::new("")));
+        let contents = crate::project::listing::config::flatten_content_globs(&doc.ast.meta);
+        profile.listing_content_globs =
+            crate::project::listing::glob_resolve::resolve_content_globs(
+                &contents,
+                Some(&doc.ast_context.source_context),
+                &ctx.project.dir,
+                &host_dir,
+            )
+            .globs;
+
         Ok(PipelineData::AtProfile(DocumentAtProfile {
             profile,
             ast: doc,

--- a/crates/quarto-core/src/stage/stages/metadata_merge.rs
+++ b/crates/quarto-core/src/stage/stages/metadata_merge.rs
@@ -227,15 +227,56 @@ impl PipelineStage for MetadataMergeStage {
         );
 
         // Layer 3: Directory metadata layers (each flattened for base format)
-        let dir_layers: Vec<_> = if !ctx.project.is_single_file {
+        let dir_layer_entries: Vec<(PathBuf, ConfigValue)> = if !ctx.project.is_single_file {
             directory_metadata_for_document(&ctx.project, &ctx.document.input, ctx.runtime.as_ref())
                 .unwrap_or_default()
-                .into_iter()
-                .map(|m| resolve_format_config(&m, base_format))
-                .collect()
         } else {
             vec![]
         };
+
+        // Register the YAML metadata layer files (`_quarto.yml` +
+        // each `_metadata.yml`) in the document's SourceContexts
+        // under their hash-based FileIds
+        // (`quarto_yaml::file_id_for_filename`), so downstream
+        // provenance consumers can map a merged value's `SourceInfo`
+        // back to the file it was written in — listing contents-glob
+        // base-dir resolution (bd-v7ixzsp5) reads this, and ariadne
+        // diagnostics gain renderable spans into these files.
+        //
+        // Registration goes to BOTH `doc.ast_context.source_context`
+        // and `doc.source_context`, appending to each in the same
+        // order: `IncludeExpansionStage` keeps the two contexts'
+        // sequential FileIds in lockstep (it debug-asserts parity),
+        // and appending to only one would desynchronize the shared
+        // index space.
+        {
+            let mut register = |path: &std::path::Path| {
+                let path_str = path.to_string_lossy().to_string();
+                let id = quarto_yaml::file_id_for_filename(&path_str);
+                let content = ctx.runtime.file_read_string(path).ok();
+                for source_context in [&mut doc.ast_context.source_context, &mut doc.source_context]
+                {
+                    // Skip when already registered (pipeline
+                    // re-entry) or on the astronomically unlikely
+                    // hash collision with a sequential doc-file id —
+                    // `add_file_with_id` would panic on a duplicate.
+                    if source_context.get_file(id).is_none() {
+                        source_context.add_file_with_id(id, path_str.clone(), content.clone());
+                    }
+                }
+            };
+            if let Some(config_path) = ctx.project.config.config_path.as_deref() {
+                register(config_path);
+            }
+            for (path, _) in &dir_layer_entries {
+                register(path);
+            }
+        }
+
+        let dir_layers: Vec<_> = dir_layer_entries
+            .into_iter()
+            .map(|(_, m)| resolve_format_config(&m, base_format))
+            .collect();
 
         // Layer 4: Document metadata (flattened for base format)
         let doc_layer = resolve_format_config(&doc.ast.meta, base_format);

--- a/crates/quarto-core/src/transforms/listing_generate.rs
+++ b/crates/quarto-core/src/transforms/listing_generate.rs
@@ -14,12 +14,17 @@
 //! ListingRenderTransform) to consume.
 //!
 //! Item discovery (D10): no filesystem walk. Each listing's
-//! `contents:` glob is matched against
-//! [`crate::project::index::ProjectIndex::profiles`], trying both
-//! host-directory-relative and project-relative path views. This
-//! gives identical behavior on native and WASM, naturally excludes
-//! files outside the project's render set, and naturally excludes
-//! the host page itself.
+//! `contents:` glob is resolved to a project-relative pattern
+//! against the directory of the file it was written in
+//! ([`crate::project::listing::glob_resolve`]; GH #456,
+//! bd-v7ixzsp5) and matched single-view against
+//! [`crate::project::index::ProjectIndex::profiles`]. This gives
+//! identical behavior on native and WASM, naturally excludes files
+//! outside the project's render set, and naturally excludes the
+//! host page itself. Patterns whose normalization escapes the
+//! project root match nothing and emit `Q-12-17` here (this
+//! transform owns the diagnostic; the profile stage drops them
+//! silently).
 //!
 //! TODO(bd-0fd0): when a Lua filter slot lands between generate and
 //! render transforms, serialize the resolved listings into
@@ -28,13 +33,15 @@
 //! `RenderContext` is the only data path between this transform
 //! and `ListingRenderTransform`.
 
+use quarto_error_reporting::DiagnosticMessageBuilder;
 use quarto_pandoc_types::pandoc::Pandoc;
 
 use crate::Result;
-use crate::project::discovery::{glob_match_path_or_dir, path_to_forward_slashes, relative_to_dir};
+use crate::project::discovery::path_to_forward_slashes;
 use crate::project::listing::filter::apply_filters;
+use crate::project::listing::glob_resolve::{item_matches, resolve_content_globs};
 use crate::project::listing::sort::apply_sort;
-use crate::project::listing::{ListingContents, ResolvedListing, hydrate_item, parse_listings};
+use crate::project::listing::{ResolvedListing, hydrate_item, parse_listings};
 use crate::render::RenderContext;
 use crate::transform::{AstTransform, TransformPhase};
 use crate::transforms::is_feature_disabled;
@@ -102,6 +109,32 @@ impl AstTransform for ListingGenerateTransform {
         let mut resolved: Vec<ResolvedListing> = Vec::with_capacity(listings.len());
 
         for listing in listings {
+            // Resolve each glob against the directory of the file
+            // it was written in (provenance-based; GH #456).
+            let resolution = resolve_content_globs(
+                &listing.contents,
+                ctx.source_context,
+                &ctx.project.dir,
+                &host_dir_str,
+            );
+            for escaped in &resolution.escaped {
+                diags.push(
+                    DiagnosticMessageBuilder::warning(format!(
+                        "Listing `contents:` pattern `{}` points outside the project \
+                         directory and matches nothing.",
+                        escaped.raw
+                    ))
+                    .with_code("Q-12-17")
+                    .with_location(escaped.source.clone())
+                    .problem("The pattern's `..` segments climb above the project root.")
+                    .add_info(
+                        "Listing contents are limited to files inside the project. \
+                         Adjust the pattern so it stays within the project directory.",
+                    )
+                    .build(),
+                );
+            }
+
             let mut items = Vec::new();
             if let Some(index) = ctx.project_index.as_deref() {
                 for profile in index.profiles() {
@@ -109,13 +142,7 @@ impl AstTransform for ListingGenerateTransform {
                     if candidate_path_str == host_path_str {
                         continue;
                     }
-                    let host_relative_candidate =
-                        relative_to_dir(&candidate_path_str, &host_dir_str);
-                    if matches_any_glob(
-                        &listing.contents,
-                        &candidate_path_str,
-                        host_relative_candidate.as_deref(),
-                    ) {
+                    if item_matches(&resolution.globs, &candidate_path_str) {
                         items.push(hydrate_item(profile));
                     }
                 }
@@ -171,28 +198,6 @@ impl AstTransform for ListingGenerateTransform {
     }
 }
 
-/// True iff `candidate` (in either path view) matches *any* glob in
-/// `contents`. Inline-record entries are skipped (the parser already
-/// emitted `Q-12-2`).
-fn matches_any_glob(
-    contents: &[ListingContents],
-    project_relative: &str,
-    host_relative: Option<&str>,
-) -> bool {
-    contents.iter().any(|c| match c {
-        ListingContents::Glob(pattern) => {
-            // Try host-relative first (Q1 default `*.qmd` is host-
-            // relative). If that misses, try project-relative for
-            // explicit patterns like `posts/**/*.qmd`. The dir-aware
-            // variant lets a bare `contents: posts` match everything
-            // under the directory (Q1 parity, bd-9arwdicv).
-            host_relative.is_some_and(|hr| glob_match_path_or_dir(pattern, hr))
-                || glob_match_path_or_dir(pattern, project_relative)
-        }
-        ListingContents::Inline(_) => false,
-    })
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -229,33 +234,6 @@ mod tests {
             })
             .collect();
         ConfigValue::new_map(map_entries, SourceInfo::for_test())
-    }
-
-    /// A bare directory entry (`contents: posts`) matches everything
-    /// under the directory, in both path views; segment-exact, so a
-    /// sibling `posts-archive/` never matches. See bd-9arwdicv.
-    #[test]
-    fn matches_any_glob_bare_directory() {
-        let contents = vec![ListingContents::Glob("posts".to_string())];
-        assert!(matches_any_glob(
-            &contents,
-            "posts/welcome/index.qmd",
-            Some("posts/welcome/index.qmd"),
-        ));
-        // Project-relative fallback (host in a sub-directory).
-        assert!(matches_any_glob(&contents, "posts/welcome/index.qmd", None));
-        assert!(!matches_any_glob(
-            &contents,
-            "posts-archive/old.qmd",
-            Some("posts-archive/old.qmd"),
-        ));
-        // A literal file entry still matches itself exactly.
-        let file_entry = vec![ListingContents::Glob("posts/welcome/index.qmd".to_string())];
-        assert!(matches_any_glob(
-            &file_entry,
-            "posts/welcome/index.qmd",
-            None
-        ));
     }
 
     fn make_profile(source: &str, output_href: &str, title: &str) -> DocumentProfile {

--- a/crates/quarto-core/tests/integration/listing_glob_resolution.rs
+++ b/crates/quarto-core/tests/integration/listing_glob_resolution.rs
@@ -174,6 +174,49 @@ fn frontmatter_glob_resolves_against_host_dir_not_project_root() {
         "no unresolved .qmd href may leak into the listing"
     );
     assert_no_code(&outputs, "Q-13-4");
+    // Phase 5 (defect #5): glob strings in `contents:` are typed as
+    // globs by the key-path annotation — no markdown-parse warning.
+    assert_no_code(&outputs, "Q-1-20");
+}
+
+// ─────────────────────────────────────────────────────────────────
+// 6. Interpretation of `contents:` entries (defects #5/#6): glob
+//    strings never take the markdown-parsing path, which used to
+//    warn (Q-1-20) on parse failure and silently corrupt the
+//    pattern on parse *success* (`p*osts*.qmd` → emphasis →
+//    `posts.qmd`).
+// ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn glob_with_markdown_parseable_asterisks_survives() {
+    let (_dir, outputs) = render_project(|p| {
+        write(
+            &p.join("_quarto.yml"),
+            "project:\n  type: website\n  output-dir: _site\n",
+        );
+        write(
+            &p.join("index.qmd"),
+            "---\ntitle: Home\nlisting:\n  contents:\n    - \"p*osts*.qmd\"\n---\n",
+        );
+        write(
+            &p.join("pXosts_extra.qmd"),
+            "---\ntitle: Should Match\ndate: 2026-01-01\n---\n\nx.\n",
+        );
+        write(
+            &p.join("posts/ignore.qmd"),
+            "---\ntitle: In Subdir\n---\n\nx.\n",
+        );
+    });
+
+    let host = html_for(&outputs, "index.html");
+    assert_eq!(
+        listing_titles(&host),
+        vec!["Should Match"],
+        "the asterisks in `p*osts*.qmd` must survive the front-matter \
+         parse verbatim (previously the markdown emphasis parse \
+         silently flattened the pattern to `posts.qmd`)"
+    );
+    assert_no_code(&outputs, "Q-1-20");
 }
 
 #[test]

--- a/crates/quarto-core/tests/integration/listing_glob_resolution.rs
+++ b/crates/quarto-core/tests/integration/listing_glob_resolution.rs
@@ -1,0 +1,429 @@
+/*
+ * tests/integration/listing_glob_resolution.rs
+ * Copyright (c) 2026 Posit, PBC
+ *
+ * Integration tests for listing `contents:` glob base-directory
+ * resolution (GH #456, bd-v7ixzsp5). See
+ * `claude-notes/plans/2026-08-06-listing-glob-provenance.md`.
+ */
+
+//! End-to-end tests pinning the provenance-based glob semantics:
+//! a `contents:` glob resolves relative to the directory of the file
+//! where it was written — the host document's directory for
+//! front-matter globs, the `_metadata.yml`'s directory for directory
+//! metadata, and the project root for `_quarto.yml` metadata.
+//!
+//! Each test writes a fixture project to a temp dir, drives it
+//! through the full `ProjectPipeline`, then inspects the rendered
+//! HTML and the per-page diagnostics. Same shape as
+//! `listing_pipeline.rs`, but outputs are keyed by project-relative
+//! output path (fixtures here have several `index.qmd` files) and
+//! the full `RenderToFileResult` is kept so diagnostics can be
+//! asserted on.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use tempfile::TempDir;
+
+use quarto_core::format::Format;
+use quarto_core::project::ProjectContext;
+use quarto_core::project::orchestrator::{ProjectPipeline, project_type_for};
+use quarto_core::render_to_file::{RenderToFileOptions, RenderToFileResult};
+use quarto_system_runtime::{NativeRuntime, SystemRuntime};
+
+fn canonical(path: &std::path::Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn write(path: &std::path::Path, contents: &str) {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(path, contents).unwrap();
+}
+
+fn read(path: &std::path::Path) -> String {
+    std::fs::read_to_string(path).unwrap_or_else(|e| panic!("read {}: {}", path.display(), e))
+}
+
+/// Drive a fresh project through the full Pass-1/Pass-2 pipeline.
+/// Returns the project dir and the per-file results (kept whole so
+/// tests can inspect both the rendered HTML and the diagnostics).
+fn render_project(fixture: impl FnOnce(&std::path::Path)) -> (PathBuf, Vec<RenderToFileResult>) {
+    let temp = TempDir::new().unwrap();
+    let project_dir = canonical(temp.path());
+    fixture(&project_dir);
+
+    let runtime: Arc<dyn SystemRuntime> = Arc::new(NativeRuntime::new());
+    let mut project = ProjectContext::discover(&project_dir, runtime.as_ref()).unwrap();
+    assert!(
+        !project.is_single_file,
+        "test expected a multi-file project"
+    );
+
+    let options = RenderToFileOptions::default();
+    let project_type = project_type_for(&project);
+    let mut pipeline = ProjectPipeline::new(
+        &mut project,
+        project_type,
+        Format::html(),
+        "html",
+        &options,
+        runtime.clone(),
+    );
+    let summary = pollster::block_on(pipeline.run()).expect("pipeline");
+    assert!(
+        summary.pass1_failures.is_empty() && summary.pass2_failures.is_empty(),
+        "unexpected failures: pass1={:?} pass2={:?}",
+        summary.pass1_failures,
+        summary.pass2_failures,
+    );
+
+    std::mem::forget(temp);
+    (project_dir, summary.outputs)
+}
+
+/// Rendered HTML for the output whose path ends with
+/// `relative_output` (forward-slash, e.g. `"sub/index.html"`).
+fn html_for(outputs: &[RenderToFileResult], relative_output: &str) -> String {
+    let suffix: PathBuf = relative_output.split('/').collect();
+    let out = outputs
+        .iter()
+        .find(|o| o.output_path.ends_with(&suffix))
+        .unwrap_or_else(|| {
+            panic!(
+                "no output ending in `{}`; have: {:?}",
+                relative_output,
+                outputs.iter().map(|o| &o.output_path).collect::<Vec<_>>()
+            )
+        });
+    read(&out.output_path)
+}
+
+/// Titles of the listing items in a rendered page, in DOM order.
+fn listing_titles(html: &str) -> Vec<String> {
+    let mut titles = Vec::new();
+    let marker = "listing-title\">";
+    let mut rest = html;
+    while let Some(i) = rest.find(marker) {
+        rest = &rest[i + marker.len()..];
+        if let Some(end) = rest.find('<') {
+            titles.push(rest[..end].to_string());
+        }
+    }
+    titles
+}
+
+/// Every diagnostic code attached to any per-page output.
+fn all_diag_codes(outputs: &[RenderToFileResult]) -> Vec<String> {
+    outputs
+        .iter()
+        .flat_map(|o| o.render_output.diagnostics.iter())
+        .filter_map(|d| d.code.clone())
+        .collect()
+}
+
+fn assert_no_code(outputs: &[RenderToFileResult], code: &str) {
+    let codes = all_diag_codes(outputs);
+    assert!(
+        !codes.iter().any(|c| c == code),
+        "expected no {} diagnostics, got codes: {:?}",
+        code,
+        codes
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────
+// 1. The reported bug (GH #456): a front-matter glob in a subdir
+//    host must resolve against the host's directory only — never
+//    against the project root.
+// ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn frontmatter_glob_resolves_against_host_dir_not_project_root() {
+    let (_dir, outputs) = render_project(|p| {
+        write(
+            &p.join("_quarto.yml"),
+            "project:\n  type: website\n  output-dir: _site\n",
+        );
+        write(&p.join("index.qmd"), "---\ntitle: Home\n---\n\nHome.\n");
+        write(&p.join("about.qmd"), "---\ntitle: About\n---\n\nAbout.\n");
+        write(
+            &p.join("sub/index.qmd"),
+            "---\ntitle: Sub\nlisting:\n  contents:\n    - \"*.qmd\"\n---\n",
+        );
+        write(
+            &p.join("sub/p1.qmd"),
+            "---\ntitle: P1\ndate: 2026-01-01\n---\n\nPost one.\n",
+        );
+    });
+
+    let host = html_for(&outputs, "sub/index.html");
+    let titles = listing_titles(&host);
+    assert_eq!(
+        titles,
+        vec!["P1"],
+        "glob `*.qmd` from sub/ must match only sub/ siblings"
+    );
+
+    // The phantom items previously produced unresolved `.qmd` hrefs
+    // and Q-13-4 "missing document" warnings (one per phantom link).
+    assert!(
+        !host.contains("href=\"about.qmd\""),
+        "no unresolved .qmd href may leak into the listing"
+    );
+    assert_no_code(&outputs, "Q-13-4");
+}
+
+#[test]
+fn subdir_host_project_relative_glob_no_longer_matches() {
+    // Intentional behavior change (plan decision 1, ships silently):
+    // a subdir host writing `posts/*.qmd` no longer reaches the
+    // project-root `posts/` directory.
+    let (_dir, outputs) = render_project(|p| {
+        write(
+            &p.join("_quarto.yml"),
+            "project:\n  type: website\n  output-dir: _site\n",
+        );
+        write(&p.join("index.qmd"), "---\ntitle: Home\n---\n\nHome.\n");
+        write(
+            &p.join("posts/a.qmd"),
+            "---\ntitle: Post A\ndate: 2026-01-01\n---\n\nA.\n",
+        );
+        write(
+            &p.join("sub/index.qmd"),
+            "---\ntitle: Sub\nlisting:\n  contents:\n    - \"posts/*.qmd\"\n---\n",
+        );
+    });
+
+    let host = html_for(&outputs, "sub/index.html");
+    assert_eq!(
+        listing_titles(&host),
+        Vec::<String>::new(),
+        "sub/posts/*.qmd matches nothing; the project-relative fallback is gone"
+    );
+    assert_no_code(&outputs, "Q-13-4");
+    // Inside the project root — no escape warning either.
+    assert_no_code(&outputs, "Q-12-17");
+}
+
+// ─────────────────────────────────────────────────────────────────
+// 2. Globs declared in `_metadata.yml` resolve against the
+//    directory holding that `_metadata.yml`.
+// ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn dirmeta_glob_resolves_against_metadata_dir() {
+    let (_dir, outputs) = render_project(|p| {
+        write(
+            &p.join("_quarto.yml"),
+            "project:\n  type: website\n  output-dir: _site\n",
+        );
+        write(
+            &p.join("rootpost.qmd"),
+            "---\ntitle: Root Post\ndate: 2026-01-05\n---\n\nRoot.\n",
+        );
+        write(
+            &p.join("blog/_metadata.yml"),
+            "listing:\n  contents:\n    - \"deep/*.qmd\"\n",
+        );
+        write(
+            &p.join("blog/deep/index.qmd"),
+            "---\ntitle: Deep Index\n---\n",
+        );
+        write(
+            &p.join("blog/deep/p1.qmd"),
+            "---\ntitle: Deep P1\ndate: 2026-01-02\n---\n\nDeep post.\n",
+        );
+    });
+
+    let host = html_for(&outputs, "blog/deep/index.html");
+    let titles = listing_titles(&host);
+    assert!(
+        titles.contains(&"Deep P1".to_string()),
+        "`deep/*.qmd` written in blog/_metadata.yml must resolve against blog/ \
+         and match blog/deep/p1.qmd; got titles: {:?}",
+        titles
+    );
+    assert!(
+        !titles.contains(&"Root Post".to_string()),
+        "project-root files must not leak into the blog listing"
+    );
+    assert_no_code(&outputs, "Q-13-4");
+}
+
+// ─────────────────────────────────────────────────────────────────
+// 3. Globs declared in `_quarto.yml` (project metadata layer)
+//    resolve against the project root, regardless of the host's
+//    directory.
+// ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn projmeta_glob_resolves_against_project_root() {
+    let (_dir, outputs) = render_project(|p| {
+        write(
+            &p.join("_quarto.yml"),
+            "project:\n  type: website\n  output-dir: _site\nlisting:\n  contents:\n    - \"posts/*.qmd\"\n",
+        );
+        write(
+            &p.join("sub/viewer.qmd"),
+            "---\ntitle: Viewer\n---\n\nViewer.\n",
+        );
+        write(
+            &p.join("posts/a.qmd"),
+            "---\ntitle: Post A\ndate: 2026-01-01\n---\n\nA.\n",
+        );
+    });
+
+    // The listing config applies to every page; on the subdir host
+    // the glob must still resolve against the *project root* (where
+    // `_quarto.yml` lives), not against sub/.
+    let host = html_for(&outputs, "sub/viewer.html");
+    let titles = listing_titles(&host);
+    assert!(
+        titles.contains(&"Post A".to_string()),
+        "`posts/*.qmd` written in _quarto.yml must resolve against the \
+         project root even for a sub/ host; got titles: {:?}",
+        titles
+    );
+    assert!(
+        host.contains("href=\"../posts/a.html\""),
+        "item href must be page-relative from sub/"
+    );
+    assert_no_code(&outputs, "Q-13-4");
+}
+
+// ─────────────────────────────────────────────────────────────────
+// 4. `../` traversal inside the project works; escaping the
+//    project root warns (Q-12-17) and matches nothing.
+// ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn parent_traversal_glob_matches_root_file() {
+    let (_dir, outputs) = render_project(|p| {
+        write(
+            &p.join("_quarto.yml"),
+            "project:\n  type: website\n  output-dir: _site\n",
+        );
+        write(&p.join("index.qmd"), "---\ntitle: Home\n---\n\nHome.\n");
+        write(
+            &p.join("rootpost.qmd"),
+            "---\ntitle: Root Post\ndate: 2026-01-04\n---\n\nRoot.\n",
+        );
+        write(
+            &p.join("sub/index.qmd"),
+            "---\ntitle: Sub\nlisting:\n  contents:\n    - \"../rootpost.qmd\"\n---\n",
+        );
+    });
+
+    let host = html_for(&outputs, "sub/index.html");
+    assert_eq!(
+        listing_titles(&host),
+        vec!["Root Post"],
+        "`../rootpost.qmd` from sub/ must reach the project root"
+    );
+    assert!(
+        host.contains("href=\"../rootpost.html\""),
+        "item href must be page-relative from sub/"
+    );
+    assert_no_code(&outputs, "Q-13-4");
+    assert_no_code(&outputs, "Q-12-17");
+}
+
+#[test]
+fn glob_escaping_project_root_warns() {
+    let (_dir, outputs) = render_project(|p| {
+        write(
+            &p.join("_quarto.yml"),
+            "project:\n  type: website\n  output-dir: _site\n",
+        );
+        write(
+            &p.join("index.qmd"),
+            "---\ntitle: Home\nlisting:\n  contents:\n    - \"../../*.qmd\"\n---\n",
+        );
+        write(
+            &p.join("other.qmd"),
+            "---\ntitle: Other\ndate: 2026-01-01\n---\n\nOther.\n",
+        );
+    });
+
+    let host = html_for(&outputs, "index.html");
+    assert_eq!(
+        listing_titles(&host),
+        Vec::<String>::new(),
+        "a glob escaping the project root matches nothing"
+    );
+    let codes = all_diag_codes(&outputs);
+    assert_eq!(
+        codes.iter().filter(|c| c.as_str() == "Q-12-17").count(),
+        1,
+        "exactly one Q-12-17 for the escaping glob; got codes: {:?}",
+        codes
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────
+// 5. Negation patterns.
+// ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn negation_glob_excludes_matched_items() {
+    let (_dir, outputs) = render_project(|p| {
+        write(
+            &p.join("_quarto.yml"),
+            "project:\n  type: website\n  output-dir: _site\n",
+        );
+        write(&p.join("index.qmd"), "---\ntitle: Home\n---\n\nHome.\n");
+        write(
+            &p.join("sub/index.qmd"),
+            "---\ntitle: Sub\nlisting:\n  contents:\n    - \"*.qmd\"\n    - \"!p2.qmd\"\n---\n",
+        );
+        write(
+            &p.join("sub/p1.qmd"),
+            "---\ntitle: P1\ndate: 2026-01-01\n---\n\nOne.\n",
+        );
+        write(
+            &p.join("sub/p2.qmd"),
+            "---\ntitle: P2\ndate: 2026-01-02\n---\n\nTwo.\n",
+        );
+    });
+
+    let host = html_for(&outputs, "sub/index.html");
+    assert_eq!(
+        listing_titles(&host),
+        vec!["P1"],
+        "`!p2.qmd` must exclude p2 from the `*.qmd` matches"
+    );
+}
+
+#[test]
+fn negation_only_contents_defaults_to_sibling_qmd() {
+    let (_dir, outputs) = render_project(|p| {
+        write(
+            &p.join("_quarto.yml"),
+            "project:\n  type: website\n  output-dir: _site\n",
+        );
+        write(&p.join("about.qmd"), "---\ntitle: About\n---\n\nAbout.\n");
+        write(
+            &p.join("sub/index.qmd"),
+            "---\ntitle: Sub\nlisting:\n  contents:\n    - \"!p2.qmd\"\n---\n",
+        );
+        write(
+            &p.join("sub/p1.qmd"),
+            "---\ntitle: P1\ndate: 2026-01-01\n---\n\nOne.\n",
+        );
+        write(
+            &p.join("sub/p2.qmd"),
+            "---\ntitle: P2\ndate: 2026-01-02\n---\n\nTwo.\n",
+        );
+    });
+
+    let host = html_for(&outputs, "sub/index.html");
+    assert_eq!(
+        listing_titles(&host),
+        vec!["P1"],
+        "negation-only contents defaults the positive set to `*.qmd` \
+         (host-dir siblings), then excludes p2"
+    );
+}

--- a/crates/quarto-core/tests/integration/main.rs
+++ b/crates/quarto-core/tests/integration/main.rs
@@ -29,6 +29,7 @@ pub mod language_catalog;
 pub mod language_pipeline;
 pub mod language_resolve;
 pub mod link_rewriting_pipeline;
+pub mod listing_glob_resolution;
 pub mod listing_pipeline;
 pub mod math_mode_pipeline;
 pub mod metadata_path_resolution;

--- a/crates/quarto-error-catalog/error_catalog.json
+++ b/crates/quarto-error-catalog/error_catalog.json
@@ -993,6 +993,13 @@
     "docs_url": "https://quarto.org/docs/errors/listing/Q-12-16",
     "since_version": "99.9.9"
   },
+  "Q-12-17": {
+    "subsystem": "listing",
+    "title": "Listing Contents Pattern Outside Project",
+    "message_template": "A listing `contents:` pattern resolves outside the project directory and matches nothing. Patterns resolve relative to the directory of the file they are written in; `..` segments may not climb above the project root.",
+    "docs_url": "https://quarto.org/docs/errors/listing/Q-12-17",
+    "since_version": "99.9.9"
+  },
   "Q-13-1": {
     "subsystem": "navigation",
     "title": "Sidebar references missing document",

--- a/docs/errors/listing/Q-12-17.qmd
+++ b/docs/errors/listing/Q-12-17.qmd
@@ -1,0 +1,45 @@
+---
+title: "Listing Contents Pattern Outside Project"
+description: "A listing `contents:` pattern resolves outside the project directory; it matches nothing."
+code: Q-12-17
+subsystem: listing
+status: stub
+since: "99.9.9"
+categories:
+  - listing
+---
+
+# `Q-12-17` — Listing Contents Pattern Outside Project
+
+> A listing `contents:` pattern resolves outside the project
+> directory and matches nothing.
+
+## What this means
+
+Each pattern in a listing's `contents:` list resolves relative to
+the directory of the file it is written in — the listing page's
+own directory for front-matter patterns, the directory holding a
+`_metadata.yml`, or the project root for patterns in
+`_quarto.yml`. A pattern may climb toward the project root with
+`..` segments (for example `../posts/*.qmd`), but it may not
+climb *above* the project root. A pattern that does — say
+`../../*.qmd` written next to `_quarto.yml` — cannot refer to any
+project document, so it matches nothing and this warning fires.
+
+## Why this happens
+
+Usually one `..` too many: the pattern was written for a
+different directory layout, or moved along with its file into a
+shallower directory.
+
+## How to fix
+
+Count the `..` segments against the location of the file the
+pattern is written in, and adjust the pattern so it stays within
+the project directory. Files outside the project cannot appear in
+a listing; if the content you want to list lives outside the
+project, move it into the project's directory tree.
+
+## Related
+
+- `Q-12-2` — inline `contents:` records are not yet supported.


### PR DESCRIPTION
Fixes #456. Braid strand: bd-v7ixzsp5. Plan: `claude-notes/plans/2026-08-06-listing-glob-provenance.md`.

## What

A listing `contents:` glob now resolves relative to the directory of the file it was **written in** — front matter → the host document's directory, `_metadata.yml` → that file's directory, `_quarto.yml` → the project root — recovered from the value's `SourceInfo` provenance, then matched single-view against project-relative paths. The old rule matched every candidate against both the host-relative *and* project-relative views, OR-ed together, which let `*.qmd` in a subdirectory host match project-root documents.

## Defects fixed (investigation found six)

1. **Cross-directory false matches** (the reported bug): phantom listing items, broken `href="about.qmd"` links, silently-wrong links, and the spurious `Q-13-4` pair per phantom item.
2. **`_metadata.yml`-declared globs resolved against the wrong base** — such listings rendered empty.
3. **`../` traversal in `contents:` matched nothing** — now works within the project.
4. **Negation globs (`!pattern`) were silently ignored** — now supported in both the render transform and the dependency graph; negation-only `contents` defaults the positive set to `*.qmd`.
5. **Spurious `Q-1-20`** on every glob containing `*` (markdown-parse warning).
6. **Silent glob corruption**: a glob whose asterisks parsed as valid emphasis (`p*osts*.qmd`) was flattened to `posts.qmd` with no diagnostic. This was also silently truncating **q2's own docs error-reference listing** — main drops 3 pages from it; this branch lists all 147 exactly.

## How

- New module `quarto-core/src/project/listing/glob_resolve.rs`: provenance → base-dir resolution, lexical `../` normalization (project-root-clamped), negation, and a single-view matcher shared by `ListingGenerateTransform` and `ProjectDependencyGraph::build`. Designed as the seed of an internal glob-expansion API (follow-up: bd-mt7a6uc4).
- `MetadataMergeStage` registers `_quarto.yml`/`_metadata.yml` in the document's SourceContexts under their hash-based FileIds (symmetric append preserves `IncludeExpansionStage`'s FileId-parity invariant).
- `DocumentProfile` v7 → v8: `listing_content_globs` stores resolved patterns + negation flags, populated by the profile stage.
- New diagnostic **Q-12-17** (catalog + docs stub): a `contents:` pattern escaping the project root warns and matches nothing.
- Defects 5/6: a small, deliberately isolated **key-path annotation table** in pampa (`pandoc/meta_annotations.rs`) types untagged `listing.contents` entries as `Interpretation::Glob` (exact-length matching, `*` = one segment, arrays transparent, maps extend the path; explicit tags always win). The module is documented as delete-on-schema-arrival — when schema-driven validation lands, schemas become the annotation source.
- Cross-directory listing items now get correct `../`-style page-relative hrefs.

## Behavior change (intentional, ships silently)

A subdirectory host using a project-relative glob (`posts/*.qmd` meaning root-level `posts/` from `sub/index.qmd`) no longer matches — write `../posts/*.qmd` instead. q2 is 0.x; no stability promises.

## Verification

- 8 failing-first integration tests (`tests/integration/listing_glob_resolution.rs`) + unit tests for the resolver, matcher, negation, annotations, and dep-graph edges.
- Full workspace: 10 911 tests green; `cargo xtask verify` (incl. hub-client WASM leg) passes.
- End-to-end via `q2 render` on six fixture projects, output HTML inspected (details in the plan doc).
- `docs/` renders verified strictly better than main (3 silently-dropped listing entries recovered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)