### PR TITLE
fix(preview): ephemeral hub secrets; no spurious persist warning (bd-tp1l6a0w)

### DIFF
--- a/claude-notes/plans/2026-08-07-ephemeral-hub-secrets-for-preview.md
+++ b/claude-notes/plans/2026-08-07-ephemeral-hub-secrets-for-preview.md
@@ -1,0 +1,181 @@
+# Ephemeral hub secrets for `q2 preview`
+
+## Overview
+
+`q2 preview` boots an in-process hub whose `data_dir` is a fresh `TempDir`
+([preview.rs:93](../../crates/quarto/src/commands/preview.rs)). On every
+invocation, `StorageManager::init`
+([storage.rs:447](../../crates/quarto-hub/src/storage.rs)) finds no
+`hub.json` secrets, so `resolve_server_secret` / `resolve_session_secret`
+auto-generate, persist, and emit two `WARN` lines aimed at multi-instance
+deployments:
+
+```
+WARN quarto_hub::storage: generated a new server secret and persisted it to hub.json
+WARN quarto_hub::storage: generated a new session secret and persisted it to hub.json
+```
+
+The warning's premise ("now pinned to *this* data directory") never holds for
+preview: the directory is deleted on exit, the server binds loopback only, and
+`auth_config` is hardcoded `None`.
+
+**Approach:** make ephemeralness explicit in the `quarto-hub` storage API
+(new `*_ephemeral` constructors backed by a crate-private `SecretPolicy`),
+and switch `quarto-preview` to it. The real hub server path is untouched.
+
+## Work Items
+
+### Phase 1 — Tests first (TDD)
+
+Write the new tests against the not-yet-existing API and confirm they fail
+(expected failure mode: compile error — the constructors don't exist yet).
+
+- [x] Add tests in `crates/quarto-hub/src/storage.rs` test module (reuse
+  `capture_logs`, `fresh_hub_dir`, `ENV_MUTEX` helpers):
+  - `ephemeral_secrets_are_not_persisted_and_do_not_warn`: fresh dir →
+    `new_standalone_ephemeral` → no WARN in captured logs; `hub.json` on
+    disk has neither `server_secret` nor `session_secret`; both
+    `manager.server_secret()` and `session_secret()` return 32 bytes.
+  - `ephemeral_secrets_are_distinct`: server ≠ session (mirrors the
+    existing persistent-path distinctness test).
+  - `ephemeral_respects_env_override`: set `QUARTO_HUB_SERVER_SECRET` under
+    `ENV_MUTEX` (existing `unsafe` + SAFETY-comment pattern) → manager uses
+    it, no WARN, nothing persisted.
+  - `ephemeral_generates_fresh_secrets_each_boot`: two sequential managers
+    on the same dir (drop the first to release the lock) get different
+    secrets; `hub.json` still clean.
+- [x] `cargo nextest run -p quarto-hub storage` — confirm the new tests
+  fail to compile (expected TDD failure for a new API). Confirmed:
+  `error[E0599]: no associated function or constant named
+  new_standalone_ephemeral found for struct storage::StorageManager`.
+
+### Phase 2 — `quarto-hub` implementation (`crates/quarto-hub/src/storage.rs`)
+
+- [x] Add private `fn generate_secret() -> [u8; 32]` (dedupes the
+  `rand::rng().fill_bytes` boilerplate currently at ~lines 218-221 and
+  259-262).
+- [x] Add crate-private `enum SecretPolicy { Persist, Ephemeral }`.
+- [x] Add `fn resolve_ephemeral_secret(env_var: &str) -> Result<[u8; 32]>`:
+  env var via `decode_secret_hex` if set, else `generate_secret()`; emit a
+  value-free `debug!` noting non-persistence.
+- [x] Change `init` to take `secret_policy: SecretPolicy`; replace the two
+  resolve calls (~lines 481-484) with a `match`: `Persist` → existing
+  functions; `Ephemeral` → `resolve_ephemeral_secret(
+  "QUARTO_HUB_SERVER_SECRET")` / `("QUARTO_HUB_SESSION_SECRET")`.
+- [x] Existing constructors (`new`, `new_standalone`, `new_with_data_dir`)
+  pass `SecretPolicy::Persist` — signatures unchanged, no caller churn.
+- [x] Add public `new_standalone_ephemeral(data_dir)` and
+  `new_with_data_dir_ephemeral(project_root, data_dir)` with rustdoc:
+  secrets live only in memory, env vars still honored, intended for
+  short-lived embedded hubs (preview); contrast with the persistent
+  constructors' multi-instance warning.
+- [x] Refactor `resolve_server_secret` / `resolve_session_secret` branch 3
+  to call `generate_secret()` (no behavior change).
+- [x] `cargo nextest run -p quarto-hub` — new and existing tests pass.
+  (452 passed, including the 4 new ephemeral tests.)
+
+### Phase 3 — Preview switch (`crates/quarto-preview/src/lib.rs`)
+
+- [x] `build_storage` (lines 351-358): switch to
+  `new_with_data_dir_ephemeral` / `new_standalone_ephemeral`; update the
+  doc comment to note secrets are per-session and never persisted.
+- [x] `cargo nextest run -p quarto-preview` — the `boot.rs` integration
+  test exercises the switched path end to end. (86 passed, 1 pre-existing
+  skip.)
+
+### Phase 4 — Docs
+
+- [x] Short note in `dev-docs/quarto-hub/session-auth-operations.md`
+  (documents the multi-instance warning at ~line 146): embedded/short-lived
+  hubs use the `*_ephemeral` constructors; secrets are per-process, env
+  vars still honored, nothing persisted or warned.
+
+### Phase 5 — Verification
+
+- [x] `cargo build --workspace` — clean.
+- [x] `cargo nextest run --workspace` (monorepo rule — do not stop at the
+  modified crates) — **10881 passed, 0 failed**, 197 skipped.
+- [x] `cargo xtask verify --skip-hub-build` (Rust-only change;
+  `quarto-hub`/`quarto-preview` are not in the WASM/hub-client dependency
+  chain, so the hub-build leg is not required) — all 14 steps passed.
+- [x] End-to-end through the real binary (per CLAUDE.md, tests alone are
+  not sufficient) — evidence below. (Ran `target/debug/q2` directly
+  instead of via `cargo run`: the server must run in the background with
+  a direct PID for signal delivery, and `cargo run` wraps the child.)
+
+#### End-to-end evidence
+
+**1. Preview, default ephemeral tempdir:**
+
+```
+$ target/debug/q2 preview examples/websites/01-minimal --no-browser
+
+  q2 preview
+  → http://127.0.0.1:52724/?page=index.qmd
+```
+
+Full boot log inspected: `grep -c 'generated a new'` → **0**; no WARN
+lines at all.
+
+**2. Preview with a persistent `--data-dir`:**
+
+```
+$ target/debug/q2 preview examples/websites/01-minimal --no-browser \
+    --data-dir /tmp/q2-secret-check
+```
+
+WARN count **0**; `/tmp/q2-secret-check/hub.json` after shutdown
+(inspected) contains no secret fields:
+
+```json
+{
+  "version": 1,
+  "created_at": "1786099964",
+  "index_document_id": "3KAAwqQu4HBzML1RENRWboNCQ4Sf"
+}
+```
+
+**3. Real hub server (control case — warning must survive):**
+
+```
+$ target/debug/q2 hub --no-project --data-dir /tmp/q2-hub-check
+```
+
+Both warnings fire and both secrets persist — `hub.json` keys:
+`created_at, index_document_id, server_secret, session_secret, version`.
+The multi-instance warning remains intact for actual hub servers.
+
+## Details
+
+### Design decisions
+
+1. **Two new public constructors, existing ones unchanged.** All three
+   existing constructors keep their signatures and delegate with
+   `SecretPolicy::Persist`, so `hub.rs`, `main.rs`, and all hub tests are
+   untouched. The policy is crate-private; the public surface is just the
+   two constructors, which read clearly at call sites.
+2. **Ephemeral semantics:** honor the env var if set
+   (`QUARTO_HUB_SERVER_SECRET` / `QUARTO_HUB_SESSION_SECRET` — preserves
+   the "env is always highest priority" invariant, still no I/O, no warn);
+   otherwise generate fresh random 32 bytes. Never mutates
+   `HubStorageConfig`, never saves `hub.json`, never warns.
+3. **Preview always uses ephemeral** — no `PreviewConfig` field, no CLI
+   change. Preview has no auth, binds loopback, and its data dir is
+   per-session by default; even with `--data-dir`, pinned secrets buy
+   nothing (crash resilience is about the automerge store; actor IDs are
+   opaque to automerge).
+4. **The two resolve functions keep their signatures** — their ~10 test
+   call sites don't churn. The policy branch lives in `init`.
+
+### Explicitly out of scope
+
+- The `.gitignore` and `hub.lock` writes in `init` still happen in
+  ephemeral mode (harmless in a tempdir; the lock is needed for
+  `HubAlreadyRunning`).
+- `new_with_data_dir` (persistent variant) becomes unused by the workspace
+  after Phase 3 — kept as public API; removal is a separate decision.
+- The two test-only `new_standalone` calls in
+  `crates/quarto-preview/src/capture_driver.rs` (lines 519, 893) may
+  optionally switch to ephemeral to keep test logs clean; not required.
+- No changes to `q2 hub` / `main.rs` — real hub servers keep the current
+  persist-and-warn behavior.

--- a/crates/quarto-hub/src/storage.rs
+++ b/crates/quarto-hub/src/storage.rs
@@ -193,6 +193,43 @@ fn decode_secret_hex(hex: &str, source: &str) -> Result<[u8; 32]> {
     })
 }
 
+/// Generate a fresh random 32-byte secret.
+fn generate_secret() -> [u8; 32] {
+    use rand::RngCore;
+    let mut bytes = [0u8; 32];
+    rand::rng().fill_bytes(&mut bytes);
+    bytes
+}
+
+/// How a [`StorageManager`] treats the two signing secrets it resolves at
+/// startup (the server secret for actor-id derivation and the session
+/// secret for session-cookie signing).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SecretPolicy {
+    /// Resolve from env / `hub.json`, auto-generating **and persisting** on
+    /// first run with a loud warning: the secret is now pinned to the data
+    /// directory, so multi-instance deployments must keep it in sync. The
+    /// right policy for real hub servers.
+    Persist,
+    /// Resolve from env if set, else generate fresh per process. Never
+    /// persisted to `hub.json`, never warned about: the data directory is
+    /// per-session, so pinning is meaningless. The right policy for
+    /// short-lived embedded hubs (`q2 preview`).
+    Ephemeral,
+}
+
+/// Ephemeral secret resolution: the env var if set (same highest-priority
+/// override as the persistent path), else fresh random bytes. Never touches
+/// `hub.json`, never warns — see [`SecretPolicy::Ephemeral`].
+fn resolve_ephemeral_secret(env_var: &str) -> Result<[u8; 32]> {
+    if let Ok(hex) = std::env::var(env_var) {
+        return decode_secret_hex(&hex, env_var);
+    }
+    let bytes = generate_secret();
+    debug!(env_var, "generated ephemeral secret (not persisted)");
+    Ok(bytes)
+}
+
 /// Resolve the server secret for HMAC actor ID derivation.
 ///
 /// Resolution order (highest priority first):
@@ -215,9 +252,7 @@ pub fn resolve_server_secret(config: &mut HubStorageConfig, hub_dir: &Path) -> R
     }
 
     // 3. Auto-generate, persist, and return
-    use rand::RngCore;
-    let mut bytes = [0u8; 32];
-    rand::rng().fill_bytes(&mut bytes);
+    let bytes = generate_secret();
     config.server_secret = Some(hex::encode(bytes));
     config.save(hub_dir)?;
     // Loud because it is now pinned to *this* data directory: a second
@@ -256,9 +291,7 @@ pub fn resolve_session_secret(config: &mut HubStorageConfig, hub_dir: &Path) -> 
     }
 
     // 3. Auto-generate, persist, and return
-    use rand::RngCore;
-    let mut bytes = [0u8; 32];
-    rand::rng().fill_bytes(&mut bytes);
+    let bytes = generate_secret();
     config.session_secret = Some(hex::encode(bytes));
     config.save(hub_dir)?;
     // The multi-instance hazard this warns about is genuinely hard to
@@ -408,7 +441,7 @@ impl StorageManager {
 
         let hub_dir = project_root.join(".quarto").join("hub");
 
-        Self::init(Some(project_root), hub_dir)
+        Self::init(Some(project_root), hub_dir, SecretPolicy::Persist)
     }
 
     /// Create a StorageManager for standalone mode (no local project).
@@ -420,7 +453,7 @@ impl StorageManager {
     pub fn new_standalone(data_dir: impl AsRef<Path>) -> Result<Self> {
         let hub_dir = data_dir.as_ref().to_path_buf();
 
-        Self::init(None, hub_dir)
+        Self::init(None, hub_dir, SecretPolicy::Persist)
     }
 
     /// Create a StorageManager for project mode with an explicit data dir.
@@ -440,11 +473,48 @@ impl StorageManager {
             return Err(Error::ProjectNotFound(project_root));
         }
         let hub_dir = data_dir.as_ref().to_path_buf();
-        Self::init(Some(project_root), hub_dir)
+        Self::init(Some(project_root), hub_dir, SecretPolicy::Persist)
+    }
+
+    /// Create a StorageManager for standalone mode (no local project)
+    /// with **ephemeral secrets**: the server and session secrets are
+    /// resolved per process — from the `QUARTO_HUB_SERVER_SECRET` /
+    /// `QUARTO_HUB_SESSION_SECRET` env vars when set, otherwise freshly
+    /// generated — and are never persisted to `hub.json`.
+    ///
+    /// Use this for short-lived embedded hubs (e.g. `q2 preview`) whose
+    /// data directory is deleted on exit: a persisted secret would pin
+    /// nothing, so the multi-instance warning emitted by
+    /// [`new_standalone`](Self::new_standalone) would be noise.
+    pub fn new_standalone_ephemeral(data_dir: impl AsRef<Path>) -> Result<Self> {
+        let hub_dir = data_dir.as_ref().to_path_buf();
+
+        Self::init(None, hub_dir, SecretPolicy::Ephemeral)
+    }
+
+    /// Create a StorageManager for project mode with an explicit data dir
+    /// and **ephemeral secrets** — see
+    /// [`new_standalone_ephemeral`](Self::new_standalone_ephemeral) for the
+    /// secret semantics. Used by `q2 preview`, which watches the project
+    /// but keeps samod storage in a per-session `TempDir`.
+    pub fn new_with_data_dir_ephemeral(
+        project_root: impl AsRef<Path>,
+        data_dir: impl AsRef<Path>,
+    ) -> Result<Self> {
+        let project_root = project_root.as_ref().to_path_buf();
+        if !project_root.exists() {
+            return Err(Error::ProjectNotFound(project_root));
+        }
+        let hub_dir = data_dir.as_ref().to_path_buf();
+        Self::init(Some(project_root), hub_dir, SecretPolicy::Ephemeral)
     }
 
     /// Shared initialization logic for both project and standalone modes.
-    fn init(project_root: Option<PathBuf>, hub_dir: PathBuf) -> Result<Self> {
+    fn init(
+        project_root: Option<PathBuf>,
+        hub_dir: PathBuf,
+        secret_policy: SecretPolicy,
+    ) -> Result<Self> {
         fs::create_dir_all(&hub_dir).map_err(Error::CreateHubDir)?;
 
         // The hub dir holds signing secrets (`hub.json`). In project mode it
@@ -477,11 +547,20 @@ impl StorageManager {
         // Load or create hub config
         let mut config = HubStorageConfig::load_or_create(&hub_dir)?;
 
-        // Resolve and cache the server secret for HMAC actor ID derivation.
-        let server_secret = resolve_server_secret(&mut config, &hub_dir)?;
-
-        // Resolve and cache the session-token signing secret.
-        let session_secret = resolve_session_secret(&mut config, &hub_dir)?;
+        // Resolve and cache the server secret (HMAC actor ID derivation)
+        // and the session-token signing secret. Ephemeral hubs keep both
+        // in memory only: nothing is persisted to hub.json, and the
+        // multi-instance pinning warning does not apply.
+        let (server_secret, session_secret) = match secret_policy {
+            SecretPolicy::Persist => (
+                resolve_server_secret(&mut config, &hub_dir)?,
+                resolve_session_secret(&mut config, &hub_dir)?,
+            ),
+            SecretPolicy::Ephemeral => (
+                resolve_ephemeral_secret("QUARTO_HUB_SERVER_SECRET")?,
+                resolve_ephemeral_secret("QUARTO_HUB_SESSION_SECRET")?,
+            ),
+        };
 
         if let Some(ref project_root) = project_root {
             info!(
@@ -1219,5 +1298,103 @@ mod tests {
             !config_logs.contains("WARN"),
             "config branch: {config_logs}"
         );
+    }
+
+    // ── ephemeral secret policy (bd-tp1l6a0w) ─────────────────────
+    //
+    // Short-lived embedded hubs (`q2 preview`) resolve secrets per
+    // process: never persisted to `hub.json`, never warned about. The
+    // multi-instance warning only makes sense for secrets pinned to a
+    // data directory.
+
+    #[test]
+    fn ephemeral_secrets_are_not_persisted_and_do_not_warn() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        // SAFETY: test-only env mutation, serialized by ENV_MUTEX.
+        unsafe { std::env::remove_var("QUARTO_HUB_SERVER_SECRET") };
+        unsafe { std::env::remove_var("QUARTO_HUB_SESSION_SECRET") };
+
+        let (_temp, hub_dir) = fresh_hub_dir();
+        let logs = capture_logs(|| {
+            let manager = StorageManager::new_standalone_ephemeral(&hub_dir).unwrap();
+            assert_eq!(manager.server_secret().len(), 32);
+            assert_eq!(manager.session_secret().len(), 32);
+        });
+
+        assert!(
+            !logs.contains("WARN"),
+            "ephemeral mode must not warn: {logs}"
+        );
+
+        // hub.json exists (load_or_create writes it) but carries no secrets.
+        let content = fs::read_to_string(hub_dir.join("hub.json")).unwrap();
+        let on_disk: HubStorageConfig = serde_json::from_str(&content).unwrap();
+        assert!(on_disk.server_secret.is_none());
+        assert!(on_disk.session_secret.is_none());
+    }
+
+    #[test]
+    fn ephemeral_secrets_are_distinct() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        // SAFETY: test-only env mutation, serialized by ENV_MUTEX.
+        unsafe { std::env::remove_var("QUARTO_HUB_SERVER_SECRET") };
+        unsafe { std::env::remove_var("QUARTO_HUB_SESSION_SECRET") };
+
+        let (_temp, hub_dir) = fresh_hub_dir();
+        let manager = StorageManager::new_standalone_ephemeral(&hub_dir).unwrap();
+        assert_ne!(
+            manager.server_secret(),
+            manager.session_secret().as_slice(),
+            "session secret must never equal the actor-id server secret"
+        );
+    }
+
+    #[test]
+    fn ephemeral_respects_env_override() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+
+        let expected = [17u8; 32];
+        let hex = hex::encode(expected);
+        // SAFETY: test-only env mutation, serialized by ENV_MUTEX.
+        unsafe { std::env::set_var("QUARTO_HUB_SERVER_SECRET", &hex) };
+
+        let (_temp, hub_dir) = fresh_hub_dir();
+        let logs = capture_logs(|| {
+            let manager = StorageManager::new_standalone_ephemeral(&hub_dir).unwrap();
+            assert_eq!(manager.server_secret(), expected.as_slice());
+        });
+        unsafe { std::env::remove_var("QUARTO_HUB_SERVER_SECRET") };
+
+        assert!(!logs.contains("WARN"), "env override must not warn: {logs}");
+        let content = fs::read_to_string(hub_dir.join("hub.json")).unwrap();
+        let on_disk: HubStorageConfig = serde_json::from_str(&content).unwrap();
+        assert!(
+            on_disk.server_secret.is_none(),
+            "an env-provided secret must not be persisted"
+        );
+    }
+
+    #[test]
+    fn ephemeral_generates_fresh_secrets_each_boot() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        // SAFETY: test-only env mutation, serialized by ENV_MUTEX.
+        unsafe { std::env::remove_var("QUARTO_HUB_SERVER_SECRET") };
+        unsafe { std::env::remove_var("QUARTO_HUB_SESSION_SECRET") };
+
+        let (_temp, hub_dir) = fresh_hub_dir();
+
+        let (first_session, first_server) = {
+            let manager = StorageManager::new_standalone_ephemeral(&hub_dir).unwrap();
+            (*manager.session_secret(), manager.server_secret().to_vec())
+        }; // manager dropped → lock released
+
+        let manager = StorageManager::new_standalone_ephemeral(&hub_dir).unwrap();
+        assert_ne!(first_session, *manager.session_secret());
+        assert_ne!(first_server.as_slice(), manager.server_secret());
+
+        let content = fs::read_to_string(hub_dir.join("hub.json")).unwrap();
+        let on_disk: HubStorageConfig = serde_json::from_str(&content).unwrap();
+        assert!(on_disk.server_secret.is_none());
+        assert!(on_disk.session_secret.is_none());
     }
 }

--- a/crates/quarto-preview/src/lib.rs
+++ b/crates/quarto-preview/src/lib.rs
@@ -348,11 +348,17 @@ fn run_boot_pre_render_scripts(project_root: &std::path::Path) {
 
 /// Construct the StorageManager. `project_root` decides project vs
 /// standalone mode; either way, `config.data_dir` is the storage root.
+///
+/// Secrets are always ephemeral (bd-tp1l6a0w): the preview is a
+/// short-lived embedded hub — loopback only, no auth, per-session data
+/// dir by default — so the server/session secrets live in memory only.
+/// Nothing is persisted to `hub.json`, and the hub's multi-instance
+/// secret-pinning warning does not apply.
 fn build_storage(config: &PreviewConfig) -> Result<StorageManager> {
     match &config.project_root {
-        Some(root) => StorageManager::new_with_data_dir(root, &config.data_dir)
+        Some(root) => StorageManager::new_with_data_dir_ephemeral(root, &config.data_dir)
             .map_err(|e| anyhow::anyhow!("storage init failed: {e}")),
-        None => StorageManager::new_standalone(&config.data_dir)
+        None => StorageManager::new_standalone_ephemeral(&config.data_dir)
             .map_err(|e| anyhow::anyhow!("storage init failed: {e}")),
     }
 }

--- a/dev-docs/quarto-hub/session-auth-operations.md
+++ b/dev-docs/quarto-hub/session-auth-operations.md
@@ -147,6 +147,14 @@ every instance. `QUARTO_HUB_SERVER_SECRET` warns the same way; divergence
 there means each instance derives different actor IDs for the same user.
 The secret **values** are never logged.
 
+**Embedded hubs (`q2 preview`) are exempt.** Short-lived hubs built on
+`StorageManager::new_standalone_ephemeral` / `new_with_data_dir_ephemeral`
+resolve both secrets per process — the env vars still win when set — and
+never persist or warn: their data directory is deleted on exit, so there
+is nothing to pin. Expect a `hub.json` without secret fields from such
+hubs, and fresh actor IDs on every restart (harmless there: loopback
+only, no auth).
+
 ## Rotating the session secret
 
 Two modes. **The distinction is security-critical.**


### PR DESCRIPTION
## Summary

`q2 preview` boots its embedded hub with a fresh `TempDir` data dir, so every invocation auto-generated both hub signing secrets, persisted them to `hub.json`, and emitted two WARN lines about multi-instance secret drift:

```
WARN quarto_hub::storage: generated a new server secret and persisted it to hub.json
WARN quarto_hub::storage: generated a new session secret and persisted it to hub.json
```

The warning's premise — a secret now pinned to a data directory — never holds for an ephemeral, loopback-only, auth-less preview whose data dir is deleted on exit.

Instead of routing around the warning (env vars, log filtering), this makes ephemeralness explicit in the `quarto-hub` storage API:

- Crate-private `SecretPolicy::{Persist, Ephemeral}` threaded through `StorageManager::init`; the three existing constructors delegate with `Persist`, so `q2 hub` and all existing callers are unchanged.
- New public constructors `StorageManager::new_standalone_ephemeral` / `new_with_data_dir_ephemeral`: secrets resolve from `QUARTO_HUB_SERVER_SECRET` / `QUARTO_HUB_SESSION_SECRET` when set (env remains highest priority), otherwise fresh random per process — never persisted to `hub.json`, never warned.
- `build_storage` in `quarto-preview` switches to the ephemeral constructors; preview secrets are always per-session (no auth, loopback, per-session data dir by default).
- `generate_secret()` helper dedupes the generation boilerplate shared by both resolve functions.
- Ops doc note: embedded hubs are exempt from the multi-instance warning.

Plan (committed here): `claude-notes/plans/2026-08-07-ephemeral-hub-secrets-for-preview.md` — includes full end-to-end evidence. Strand: bd-tp1l6a0w.

## Test plan

- [x] Four new `storage::tests` written first (TDD red confirmed: E0599 on the not-yet-existing constructors): secrets not persisted + no WARN, server ≠ session, env override honored + not persisted, fresh secrets each boot.
- [x] `cargo nextest run -p quarto-hub` — 452 passed.
- [x] `cargo nextest run -p quarto-preview` — 86 passed (boot integration test exercises the switched path).
- [x] `cargo nextest run --workspace` — 10881 passed, 0 failed.
- [x] `cargo xtask verify --skip-hub-build` — all 14 steps (Rust-only change; neither crate is in the WASM/hub-client dependency chain).
- [x] E2E: `q2 preview examples/websites/01-minimal --no-browser` — zero `generated a new ... secret` lines in the boot log; with `--data-dir`, the resulting `hub.json` contains no `server_secret`/`session_secret` fields.
- [x] E2E control: `q2 hub --no-project --data-dir ...` still emits both warnings and persists both secrets — the multi-instance warning is intact for real hub servers.
