### PR TITLE
chore(release): bump workspace version to 0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "comrak-to-pandoc"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "comrak",
  "hashlink",
@@ -3536,7 +3536,7 @@ dependencies = [
 
 [[package]]
 name = "quarto"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3582,7 +3582,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-analysis"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "insta",
  "quarto-error-reporting",
@@ -3608,7 +3608,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-brand"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "pathdiff",
  "quarto-util",
@@ -3620,7 +3620,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-citeproc"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "glob",
  "hashlink",
@@ -3654,7 +3654,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-core"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3710,7 +3710,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-csl"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "insta",
  "quarto-error-reporting",
@@ -3738,7 +3738,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-error-catalog"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "once_cell",
  "quarto-error-reporting",
@@ -3774,7 +3774,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-highlight"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "hashlink",
  "insta",
@@ -3803,7 +3803,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-highlight-encoding"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3811,7 +3811,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-hub"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "automerge",
@@ -3855,7 +3855,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-hub-provider"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "automerge",
  "ciborium",
@@ -3881,7 +3881,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-lsp"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "insta",
@@ -3897,7 +3897,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-lsp-core"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "insta",
  "pampa",
@@ -3920,7 +3920,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-mcp-launcher"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -3936,7 +3936,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-navigation"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "quarto-config",
  "quarto-pandoc-types",
@@ -3971,7 +3971,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-preview"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "automerge",
@@ -4003,7 +4003,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-project-create"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "quarto-doctemplate",
  "serde",
@@ -4014,7 +4014,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-publish"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4039,7 +4039,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-sass"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "grass",
  "include_dir",
@@ -4062,7 +4062,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-source-fetch"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "flate2",
  "tar",
@@ -4085,7 +4085,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-system-runtime"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4103,7 +4103,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-test"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "quarto-core",
@@ -4120,7 +4120,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-trace"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "flate2",
  "serde",
@@ -4131,7 +4131,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-trace-server"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4158,7 +4158,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-util"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -4166,7 +4166,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-xml"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "insta",
  "quarto-error-reporting",
@@ -4386,7 +4386,7 @@ dependencies = [
 
 [[package]]
 name = "reconcile-viewer"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "clap",
  "hashlink",
@@ -6425,7 +6425,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-printf-fmt"
-version = "0.11.0"
+version = "0.12.0"
 
 [[package]]
 name = "wasmparser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Posit Software, PBC"]
 homepage = "https://github.com/posit-dev/quarto-markdown-syntax"
 keywords = ["parser"]


### PR DESCRIPTION
Prepares the **v0.12.0** release (bd-ak4cnm44), per
`claude-notes/instructions/release-runbook.md` step 2.

The release workflow's preflight job fails unless the git tag exactly
equals `[workspace.package].version`, so the manifest is bumped before
`v0.12.0` is tagged.

## What's in the release

Scope is `main` as-is — no open PRs pulled in. Commits since `v0.11.0`:

- `0087da18` One glob semantics for q2: migrate every consumer onto the shared API (#461)
- `acf7ecac` ci(release): assert linux binaries run with no glibc (bd-3b47pxmm) (#458)
- `f12baae7` Listing contents: globs resolve against their declaring file's directory (#460)
- `d3f3a60e` Add minimal AGENTS.md
- `4d91cafe` fix(preview): ephemeral hub secrets; no spurious persist warning (bd-tp1l6a0w) (#462)
- `c9f6177f` Listing diagnostics blame the wrong key: fix materialized container spans (bd-9yh3pzfu, bd-2mxo) (#459)

## Changes here

`Cargo.toml` `[workspace.package].version` 0.11.0 → 0.12.0, plus the
`cargo update --workspace` lockfile rewrite. Diffing `Cargo.lock` for
version lines that are neither `0.11.0` nor `0.12.0` returns nothing, so
no external dependency moved — only workspace members.

## Verification

- `cargo build --bin q2 --locked` succeeds and prints `q2 (quarto 2) 0.12.0`.
  The `--locked` build is the real gate: CI builds `--locked`, so the
  lockfile had to already be in sync.
- `cargo xtask verify --skip-hub-build`: custom lints, clippy (`-D warnings`),
  and rustfmt all clean.
- `cargo nextest run --workspace --no-fail-fast`: **10997 passed, 0 failed,
  197 skipped.**

One caveat worth recording: the first verify run hit a single failure in
`quarto-hub::integration admin_collect_lifecycle::collect_reverification_skips_rereferenced_candidate`,
asserting `3qAsj6GjtESfaUtgqp4UoUVG9GJN` vs `3QAsj6GjtESfaUtgqp4UoUVG9GJN`.
That is the known macOS-APFS case-insensitivity flake tracked in
**bd-eb2wnxkp** (doc ids that differ only in case collide in the 2-level
store layout) — not a version-bump regression. It passed on re-run and the
full no-fail-fast suite above is green. CI's Linux runners have
case-sensitive filesystems and do not hit it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)