### PR TITLE
.md render support: explicit render-list opt-in, engines ignored with warning (bd-6d2wj4zp)

### DIFF
--- a/claude-notes/plans/2026-08-07-md-render-support.md
+++ b/claude-notes/plans/2026-08-07-md-render-support.md
@@ -411,14 +411,23 @@ render path (the Connect-docs `q2 render` use case) lands before preview.
 - [ ] `Q-7-6`/`Q-7-7` wording: extension-aware hint for `.md`-not-in-render-list
   (`render.rs:1358-1378`)
 
-### Phase 2 — Engine-ignored warning
+### Phase 2 — Engine-ignored warning — **DONE 2026-08-07**
 
-- [ ] Failing test: `.md` with `engine: jupyter` (and with top-level `jupyter:`)
-  renders with warning Q-2-40, no execution; `.md` without engine metadata
-  renders warning-free; `.qmd` with `engine:` unaffected
-- [ ] Catalog entry + presence test + `docs/errors/markdown/Q-2-40.qmd`
-- [ ] Emission in `EngineExecutionStage::run` via `SourceType::from_path`
-- [ ] Run `scripts/audit-error-codes.py`
+- [x] Stage-level tests (engine_execution.rs): `engine: jupyter` and top-level
+  `jupyter:` on `.md` → exactly one Q-2-40, AST passthrough; no engine
+  metadata → silent; explicit `engine: markdown` → silent (harmless no-op,
+  warning would be noise); unknown engine on `.md` → Q-2-40 only, no
+  availability-fallback warning (skip happens before engine resolution)
+- [x] E2e test (`md_with_engine_spec_renders_with_q_2_40_warning`): opted-in
+  `.md` with `engine: jupyter` renders successfully through the real binary,
+  Q-2-40 on stderr, content in output HTML
+- [x] Catalog entry (after Q-2-39) + presence test + docs page
+  `docs/errors/markdown/Q-2-40.qmd` (status: stub)
+- [x] Emission in `EngineExecutionStage::run` gated on
+  `SourceType::from_path(&ctx.document.input)` — the dormant `SourceType`
+  seam is now live; diagnostic anchored at the `engine:` (or engine-name)
+  metadata key via `ConfigMapEntry::key_source`
+- [x] `scripts/audit-error-codes.py`: 171/171 consistent
 
 ### Phase 3 — Single-file path + output guard
 

--- a/claude-notes/plans/2026-08-07-md-render-support.md
+++ b/claude-notes/plans/2026-08-07-md-render-support.md
@@ -502,17 +502,48 @@ per D8; noted for the listing follow-up strand.
   `iframePostProcessor.ts:252`, `iframeLinkHandlers.ts:114`)
 - [ ] Full WASM/SPA rebuild chain + `cargo xtask verify` (not `--skip-hub-build`)
 
-### Phase 6 — End-to-end verification + docs
+### Phase 6 — End-to-end verification + docs — **DONE 2026-08-07** (verify run below)
 
-- [ ] `cargo run --bin q2 -- render` the Connect docs project (or a trimmed
-  fixture derived from it); inspect emitted HTML for a `.md` page: shortcode
-  expansion, nav links pointing at `.html`, correct sidebar; record invocation +
-  output snippet per the end-to-end policy in CLAUDE.md
-- [ ] Fixture project under the repo's test corpus with mixed `.md`/`.qmd`,
-  engine-spec `.md`, excluded `.md`
-- [ ] User-facing docs on the docs/ website (rendered with q2): `.md` inputs are
-  render-list opt-in; engines ignored with warning
-- [ ] `cargo xtask verify`, snapshot-change report, close-out on bd-6d2wj4zp
+- [x] **End-to-end with real Connect-docs sources** (per the CLAUDE.md e2e
+  policy). Invocation: copied `admin/index.md` + `user/index.md` verbatim
+  from the Connect port into a scratch project with
+  `render: ["**/*.md", "**/*.qmd"]`, a sidebar `file: admin/index.md`, and a
+  body link `[Admin Guide](admin/index.md)`, then
+  `CONNECT_VERSION=2026.08 cargo run --bin q2 -- render <dir>` →
+  "Rendered 3 of 3 files". Output inspected:
+  - `_site/admin/index.html` exists; sidebar hrefs are page-relative and
+    correct from both root (`admin/index.html`) and the admin page itself
+    (`index.html` / `../index.html`)
+  - body link rewrote to `href="admin/index.html"`
+  - inline `{{< env CONNECT_VERSION >}}` expanded to `2026.08` in both `.md`
+    and `.qmd` (verified in a paired fixture)
+  - **discovered (not `.md`-related):** shortcodes in *metadata fields*
+    (`title:`/`subtitle:`) expand empty — identically for `.qmd` and `.md`.
+    Filed as bd-wpoiv8pq (discovered-from bd-6d2wj4zp). The two render
+    warnings in the slice were the unimplemented `include` shortcode, also
+    orthogonal.
+- [x] Mixed-fixture coverage lives in the inline e2e fixtures
+  (`md_pages_get_nav_and_body_links_rewritten`,
+  `md_with_engine_spec_renders_with_q_2_40_warning`,
+  `empty_project_with_md_files_hints_at_render_list_optin`, discovery unit
+  fixtures) — no separate corpus directory needed; smoke-all gains nothing
+  the e2e tests don't already assert
+- [x] User docs: new page `docs/guides/projects/render-list.qmd` (render-list
+  semantics, the default ≡ `**/*.qmd` invariant, `.md` opt-in, never-render
+  list, Q-2-40 pointer), added to the docs sidebar; `cargo run --bin q2 --
+  render docs/` → 184 of 184 files, no warnings from the new page, its
+  `.qmd` cross-links rewrote to `.html`
+- [ ] `cargo xtask verify` (full, WASM leg included) — running at session
+  end; no snapshot files changed anywhere in this strand
+- [ ] Close-out on bd-6d2wj4zp after Phase 5 decision (preview split to its
+  own session per D9)
+
+### Phase 5 status
+
+Deferred to a dedicated follow-up session per D9's escape hatch — it touches
+`quarto-hub` Rust, `ts-packages/preview-renderer` TS, and the WASM/SPA
+rebuild chain, and the render-path work (Phases 1–4, 6) stands on its own.
+The strand stays open until preview lands or is split into its own strand.
 
 ## References
 

--- a/claude-notes/plans/2026-08-07-md-render-support.md
+++ b/claude-notes/plans/2026-08-07-md-render-support.md
@@ -1,0 +1,473 @@
+# `.md` render support (bd-6d2wj4zp)
+
+**Status:** design questions D1–D9 resolved with Carlos 2026-08-07 (see "Design
+decisions"). One follow-up refinement adopted: the default render list is expressed
+*literally* as `render: ["**/*.qmd"]` (see S2′). Implementation not yet started —
+awaiting explicit go-ahead.
+
+**Strand:** bd-6d2wj4zp — "Render .md files as inputs (explicit render-list opt-in;
+ignore engine specs with warning)". Related: bd-xxul (the original "non-.qmd input
+extensions" deferral from websites Phase 1 — this plan settles its `.md` half;
+`.ipynb` rides separately with bd-19nc56ao).
+
+## Overview
+
+Support plain `.md` files as render inputs. Desired semantics (from the 2026-08-07
+session):
+
+1. `.md` files participate in a **project** render only when matched by explicit
+   `project.render` globs — never via default input discovery.
+2. Once included, a `.md` file behaves **exactly like a `.qmd`** file (same parser,
+   shortcodes, includes, transforms, formats).
+3. Engine specifications in a `.md` file are **ignored with a warning diagnostic**
+   (not honored, not a hard error).
+
+Motivating example: the Posit Connect docs port at
+`~/Desktop/daily-log/2026/08/05/q2-connect-docs/docs-quarto-2` — 176 `.md` + 205
+`.qmd` files, rendered via:
+
+```yaml
+project:
+  render:
+    - "**/*.md"
+    - "**/*.qmd"
+    - "!licenses/dashboard.licenses.md"
+    - "!licenses/go.licenses.md"
+    - "!news/NEWS.md"
+    ...
+```
+
+Its navbar/sidebar reference `.md` files directly (`file: admin/index.md`), and its
+`.md` sources use shortcodes (`{{< env … >}}`), raw HTML blocks, and `format:`
+front matter — but **zero** `engine:` keys and zero executable cells. So the
+"identical to `.qmd`, engines ignored" policy covers the real corpus exactly.
+
+## What Quarto 1 actually does (research summary)
+
+Research pass over `external-sources/quarto-cli` (HEAD `2e66958`, v1.10). Key
+findings, with the surprises flagged:
+
+- **Q1 includes `.md` in the render list *by default*** — this is the big
+  divergence from what we want. Input discovery has no extension allow-list; a
+  file is an input iff some engine claims it (`src/project/project-context.ts:932`),
+  and the markdown engine claims `.md`/`.markdown`
+  (`src/execute/markdown.ts:39-42`). With no `project.render`, a full directory
+  walk picks up every `.md`. So our "explicit opt-in only" rule is a **deliberate
+  departure from Q1**, not a match. (In practice most Q1 sites either have no stray
+  `.md` or, like the Connect docs, use explicit globs anyway.)
+  - Exception: **book** projects overwrite `project.render` with the chapter list
+    (`src/project/types/book/book-config.ts:265`), so books effectively already
+    have opt-in semantics.
+- **Engine selection never sees a `.md` file's front matter.** The markdown engine
+  claims `.md` by extension *before* YAML is read (`src/execute/engine.ts:320-330`),
+  so `engine: jupyter` in a `.md` is **silently ignored** and overwritten to
+  `markdown` (`src/command/render/render-contexts.ts:336`). Our warning is an
+  improvement over Q1's silence.
+- **Executable cells in `.md` are a hard error at execute time**:
+  "You must use the .qmd extension for documents with executable code"
+  (`src/execute/markdown.ts:78-98`). Notes: the check is `=== ".md"` so
+  `.markdown` files escape it; and the regex counts *any* brace-fenced cell
+  (`{ojs}`, `{mermaid}`, `{dot}` included), not just computational ones.
+- **Otherwise `.md` is pipeline-identical to `.qmd`**: the qmd Lua reader is
+  installed unconditionally for every Pandoc invocation
+  (`src/command/render/pandoc.ts:1021`), so shortcodes, fenced-div handling, and
+  the filter chain all apply. Includes too (`src/project/project-shared.ts:463`).
+- **Freeze is disabled** for `.md` (`canFreeze: false`, `src/execute/markdown.ts:46`);
+  `.md` inputs never touch `_freeze/`.
+- **Default ignore globs** exclude `README.?([Rrq])md`, `CLAUDE.md`,
+  `CLAUDE.local.md`, `AGENTS.md`, `AGENTS.local.md`, `*.llms.md`, `_*`, `.*`, plus
+  `.gitignore` entries (`src/project/project-context.ts:878-886`), and `keep-md`
+  intermediates (`<stem>.<format>.md`) are subtracted from the input set.
+- **`.md` → `.md` output collision** is special-cased: `format: gfm` on `foo.md`
+  outputs `foo-gfm.md` instead of clobbering the source
+  (`src/command/render/output.ts:188-193`).
+
+## Current q2 state (code map)
+
+- **There is exactly one hard `.qmd` gate in the render path**:
+  `has_qmd_extension` in `crates/quarto-core/src/project/discovery.rs:132`, used by
+  the walker (`walk_qmd`, `:369`) and the candidate filter (`is_renderable_qmd`,
+  `:94`). The module doc (`:9-13`) explicitly defers `.md`/`.ipynb` to a follow-up
+  (that's bd-xxul). Exclusion rules (underscore/dot components, `node_modules`,
+  case-insensitive `README` stem, output-dir) live in `is_renderable_qmd` and apply
+  to **both** the default-walk and render-pattern paths — `.md` inherits them for
+  free. Note `expand_patterns` (`:165`) matches patterns against the
+  already-filtered walked set, so the walk itself must learn about `.md`, not just
+  the filter.
+- **Glob machinery is ready.** The shared glob API from #460/#461
+  (`crates/quarto-core/src/glob/`) deliberately keeps extension policy out of the
+  matcher — `claude-notes/designs/glob-semantics.md` §"What does *not* belong in
+  `GlobOptions`" says discovery policy is the enumerator's job. `RENDER` consumer
+  options have `default_positive: None`. The pinned consumer-options test at
+  `glob/mod.rs:148-181` must be updated if any defaults change.
+- **Single-file `q2 render foo.md` already almost works.** `classify_inputs`
+  (`crates/quarto/src/commands/render.rs:209`) never checks the extension outside a
+  project (the `:279` comment says "must be a `.qmd` file" but the code only
+  rejects directories), and `ProjectContext::discover` wraps a single input with no
+  extension check (`project/mod.rs:541`). Known gap: `detect_single_input_format`
+  (`render.rs:1165-1171`) is `.qmd`-gated, so a `.md` file's front-matter `format:`
+  is silently ignored and falls back to `"html"`.
+  Inside a project, `q2 render foo.md` fails with Q-7-6 ("Input Excluded From
+  Render List") whose hint — check `project.render` and underscore conventions —
+  is misleading for the extension case.
+- **q2's engine machinery makes "no execution for `.md`" nearly free.** Engine
+  detection is metadata-only (`crates/quarto-core/src/engine/detection.rs` —
+  explicit `engine:` key, engine map, or engine-specific top-level key like
+  `jupyter:`; **no** code-cell sniffing), defaulting to the no-op `markdown`
+  engine. `EngineExecutionStage` (`stage/stages/engine_execution.rs:193`) skips
+  `markdown` and passes the AST through. So a `.md` with no engine metadata
+  already does exactly the right thing; the only new behavior is *detecting and
+  warning about* a non-trivial engine spec on a `.md` input. The stage can see the
+  input path via `ctx.document.input`.
+- **Pre-built seam:** `SourceType { Qmd, Markdown, Ipynb, Rmd }` at
+  `crates/quarto-core/src/stage/data.rs:170-201` exists and is currently dead code
+  — it's the intended dispatch point from bd-xxul.
+- **pampa has no literal-markdown reader** — `"markdown"` normalizes to `"qmd"`
+  (`crates/pampa/src/options.rs:257-263`). So "`.md` behaves precisely like
+  `.qmd`" is not just easy, it's the *only* available semantics without new work.
+  (Happily it's also what Q1 does and what we want.)
+- **Other `.qmd`-shaped gates that affect the motivating example:**
+  - Nav/body link classification: `transforms/navigation_href.rs:186/:243/:333`
+    (`ends_with(".qmd")`) — non-`.qmd` hrefs are treated as static resources, so
+    `file: admin/index.md` in a sidebar and `[x](other.md)` in a body would not be
+    rewritten to `.html`. The dep graph's body-link edges derive from the same
+    resolver (`project/dependency_graph.rs:147`).
+  - Preview: `crates/quarto-hub/src/discovery.rs:122-131` (only `.qmd` enters the
+    VFS), `crates/quarto-hub/src/watch.rs:244-247` (`is_qmd_file` watch filter),
+    and TS side `ts-packages/preview-renderer/src/types/project.ts:45` plus iframe
+    link handling (`iframePostProcessor.ts:252`, `iframeLinkHandlers.ts:114`).
+  - Listing default: `glob/mod.rs:107` `default_positive: Some("*.qmd")`;
+    `sidebar.auto` index detection hard-codes `index.qmd`
+    (`transforms/sidebar_auto.rs:321`).
+  - Diagnostics prose that says `.qmd`: Q-5-13 problem text (`discovery.rs:317`),
+    Q-7-7 ("No renderable `.qmd` files matched", `render.rs:1372`), Q-7-6 hint,
+    `Q-PROJECT-EMPTY` hint (`orchestrator.rs:1048`).
+- **Output-path hazard:** `Format::output_path` just swaps the extension
+  (`format.rs:463`), and `gfm`/`commonmark` map to `"md"` (`format.rs:286-287`) —
+  so `foo.md` with `format: gfm` would produce `output == input` and **overwrite
+  the source**. Q1 guards this; q2 currently doesn't.
+
+## Proposed semantics (spec)
+
+- **S1 — Renderable extensions.** A *renderable source* is `.qmd` (always) or
+  `.md` (conditionally, per S2/S3). `.markdown` is not supported (D1).
+- **S2 — Project discovery.** With no `project.render` key, discovery renders
+  `.qmd` only — unchanged; `.md` files are invisible (deliberate divergence from
+  Q1's default-inclusion). With `project.render` present, the walk collects both
+  extensions and a candidate is included iff it matches a positive pattern and no
+  negative one — for `.qmd` and `.md` alike. "Explicit" means *matched by an
+  explicitly written render pattern*, not "the pattern syntactically mentions
+  `.md`" (D2, option (a)). All existing exclusions (underscore/dot components,
+  `node_modules`, README stem, output-dir) apply to `.md` unchanged.
+- **S2′ — The default is a literal render list (adopted in review).** The
+  invariant users can be told, verbatim: **omitting `project.render` is exactly
+  equivalent to writing `render: ["**/*.qmd"]`.** There is no hidden ".md off by
+  default" extension policy — the default *pattern* is `.qmd`-shaped, and writing
+  your own render list replaces it, at which point globs mean what they say.
+  This is achievable **by construction**, not just documentation:
+  - The matcher's `**` matches zero segments (`**/*.qmd` matches root-level
+    `about.qmd` — pinned test `glob/matcher.rs:243-244`), and a single-pattern
+    match preserves walk order, so the match set *and order* of
+    `render: ["**/*.qmd"]` equal the default walk's.
+  - Implementation (refined during Phase 1): the default lives in the
+    **enumerator**, not in `GlobOptions::RENDER.default_positive` —
+    `discovery::effective_render_patterns` prepends
+    `DEFAULT_RENDER_PATTERN` (`**/*.qmd`) whenever the author wrote no
+    positive pattern (no `render:` key, or negations only), and everything
+    flows through one walk-then-match path. Two reasons over the
+    `default_positive` route: (1) the glob-layer injection only fires for
+    negation-only lists, so the empty case would have needed enumerator
+    logic anyway; (2) with raw-level detection, a *broken* positive pattern
+    (`Q-5-14`/`Q-5-15`) yields an empty set plus its diagnostic instead of
+    silently falling back to rendering everything. This also matches
+    `glob-semantics.md` ("the walk is the enumerator's job") and leaves the
+    pinned consumer-options table untouched.
+  - Pleasant consequence: a **negation-only** render list
+    (`render: ["!drafts/**"]`) now means "all `.qmd` minus these" — which is
+    exactly the intent documented at `glob/mod.rs:137-139` ("a render list of
+    only exclusions means walk the project, minus these") but which the current
+    code does *not* implement (`expand_patterns` iterates positive globs only →
+    empty set → `Q-PROJECT-EMPTY`). The injection fixes that latent bug, and
+    keeps `.md` out of negation-only lists, consistently with the invariant.
+  - The `consumer_options_are_as_documented` pinned test (`glob/mod.rs:148-181`)
+    and the RENDER doc-comment must be updated.
+  Note the built-in exclusions (README, underscore/dot, `node_modules`, D4 list,
+  output-dir) are **not** part of the pattern default — they are enumerator-level
+  filters applied in both modes, so the invariant holds without writing them as
+  negations. See D4′ for their interaction with explicit positive patterns.
+- **S3 — Single-file render.** `q2 render foo.md` works outside a project
+  (front-matter `format:` honored — fixes the `detect_single_input_format` gap).
+  Inside a project, the file must be in the render list, same as `.qmd`; the
+  not-in-render-list diagnostic gains extension-aware wording.
+- **S4 — Parse/pipeline semantics.** Identical to `.qmd`: same pampa parse, same
+  metadata handling, shortcodes, includes, transforms, themes, formats. No
+  literal-markdown mode (none exists; Q1 also applies qmd semantics to `.md`).
+- **S5 — Engines.** A `.md` input never executes engines. If engine detection on
+  a `.md` yields anything non-trivial — an explicit `engine:` key (string, array,
+  or map) or an engine-specific top-level key (`jupyter:`, `knitr:`) — emit a new
+  warning diagnostic (Q-code, see below) anchored at the offending metadata key,
+  and skip all engine execution for that document. Executable cells without engine
+  metadata pass through unexecuted — exactly like a `.qmd` without an `engine:`
+  key in q2 today (deliberate divergence from Q1's hard error; see D3).
+- **S6 — Output paths.** `foo.md` → `foo.html` via the existing mechanism. New
+  guard: if a format's `output_path(input) == input`, refuse with an error
+  diagnostic rather than overwriting the source (the `foo.md` + `format: gfm`
+  case). See D7 for whether we adopt Q1's `foo-gfm.md` rename instead.
+- **S7 — Links and navigation.** A project-relative link or nav `file:`/`href:`
+  entry pointing at a **render-list member** is a source-document link and gets
+  rewritten to its output href (`admin/index.md` → `admin/index.html`), for `.md`
+  exactly as for `.qmd`. A link to a `.md` file *not* in the render list stays a
+  static-resource link (see D6). Required for the Connect docs navbar/sidebar.
+- **S8 — Listings / sidebar-auto.** Defaults stay `.qmd`-flavored (listing
+  `default_positive: "*.qmd"`, sidebar-auto `index.qmd`). Explicit listing
+  `contents:` globs matching render-list `.md` files should work, but this is a
+  stretch goal (see D8).
+- **S9 — Preview.** `q2 preview` treats `.md` render-list members like `.qmd`:
+  synced into the VFS, watched for changes, links intercepted. Scoped as the final
+  implementation phase (see D9).
+
+### Q1 ↔ Q2 divergence table (all deliberate)
+
+| Behavior | Q1 | Proposed Q2 |
+|---|---|---|
+| `.md` in default (glob-less) discovery | included | **excluded** |
+| `engine: jupyter` in `.md` | silently ignored | ignored **with warning** |
+| ```` ```{python} ```` cell in `.md` | hard error at execute | passes through unexecuted (same as engine-less `.qmd`), per D3 |
+| `.md` + `format: gfm` | renamed output `foo-gfm.md` | **error** (D7) |
+| `.markdown` extension | supported (with buggy cell check) | **not supported** (D1) |
+| Explicit render entry naming an ignored file (e.g. `AGENTS.md`) | rendered (hidden ignores apply to walk only) | still excluded; `Q-5-13` explains (D4′) |
+| Negation-only `project.render` | all inputs minus exclusions | same, `.qmd`-only via injected `**/*.qmd` (S2′ — currently a latent empty-set bug in q2) |
+| Freeze for `.md` | n/a (`canFreeze: false`) | n/a — q2 has no freeze yet; `.md` never executes so nothing to freeze |
+
+## New diagnostic: engine spec ignored on `.md`
+
+- **Proposed code:** `Q-2-40` (markdown subsystem; next free after Q-2-39). The
+  condition is document-level (fires for single-file renders too), so the
+  `project` subsystem (`Q-5-*`) is wrong; there is no engine subsystem and this
+  doesn't seem to justify allocating one. Alternative if reviewers prefer: keep a
+  `Q-5-*`/`Q-7-*` code. (See D5.)
+- **Shape** (builder pattern per `example_embed.rs:551`):
+  - title: "Engine Specification Ignored for Markdown Input"
+  - problem: "`.md` documents never execute engines; the `engine:` specification
+    has no effect."
+  - detail: names the requested engine(s).
+  - hint: "Rename the file to `.qmd` if you need executable code."
+  - location: the `engine:` (or `jupyter:`/`knitr:`) key's `SourceInfo` from the
+    metadata `ConfigValue` map.
+- **Emission site:** `EngineExecutionStage::run`, gated on
+  `SourceType::from_path(&ctx.document.input) == Some(SourceType::Markdown)` —
+  bringing the dead `SourceType` seam to life as bd-xxul intended.
+- **Process:** catalog entry in `crates/quarto-error-catalog/error_catalog.json`
+  (`since_version: "99.9.9"`), presence test in `lib.rs`, docs page
+  `docs/errors/markdown/Q-2-40.qmd` (`status: stub` acceptable), then run
+  `scripts/audit-error-codes.py` manually (not part of `xtask verify`).
+
+## Design decisions (resolved with Carlos, 2026-08-07)
+
+- **D1 — `.markdown` extension: NO, `.md` only.** `.markdown` is a one-line
+  follow-up if ever requested. (Q1 supports it but its cell check misses it,
+  suggesting no real usage.)
+- **D2 — "Explicit inclusion" = matched by any positive render pattern** (option
+  (a)): `render: ["chapters/*"]` picks up `chapters/notes.md`. Accepted
+  conditional on the default render list being articulable as an actual render
+  list a user could have written — which S2′ makes literally true
+  (`render: ["**/*.qmd"]`). The opt-in moment is writing a `project.render` key
+  at all. Carlos also asked for an SSG-landscape sanity check on keeping `.md`
+  out of the default at all; the survey (session 2026-08-07) supported the
+  opt-in stance: SSGs that render `.md` by default (Hugo, Eleventy, MkDocs,
+  Docusaurus, Astro) all do so from a *dedicated content directory*, which is
+  itself the opt-in boundary; Quarto renders general project trees where `.md`
+  is heavily non-content (README/CHANGELOG/NEWS/licenses/agent files — Q1's
+  reactively-grown ignore list and the Connect project's own negations are the
+  evidence). Sphinx's "must be referenced in a toctree" is the closest analogue
+  to our choice. Jekyll's front-matter-sniffing middle ground was considered
+  and rejected as implicit magic. The strictness argument seals it: qmd is a
+  strict dialect, and diagnostics about files the user never meant to publish
+  are the worst kind of error.
+- **D3 — Executable cells in `.md`: silent passthrough** (identical to
+  engine-less `.qmd`). Revisit when/if q2 adds cell-language engine inference.
+- **D4 — Adopt Q1's ignore list as built-in exclusions**: `CLAUDE.md`,
+  `CLAUDE.local.md`, `AGENTS.md`, `AGENTS.local.md`, `*.llms.md`, in both
+  discovery paths.
+  - **D4′ (minor, open):** built-in exclusions are hard filters — an explicit
+    positive pattern (even a literal `render: [AGENTS.md]`) does not override
+    them; the user sees `Q-5-13` ("matched nothing"), whose prose should grow a
+    mention of built-in exclusions. Q1, for comparison, applies its hidden
+    ignore globs only to the walk, not to an explicit render list. Revisit only
+    if a real need to render such a file appears.
+- **D5 — Q-code: `Q-2-40`** (markdown subsystem). Carlos's additional argument:
+  the warning fires for `q2 render foo.md` with no `_quarto.yml`, and users
+  don't think of that as a "project", so `Q-5-*` would mislabel it.
+- **D6 — Links to non-render-list `.md`: static-resource classification, no new
+  warning** for now.
+- **D7 — `output == input` collision: hard error** with an actionable hint
+  (mention `output-file:`), not Q1's silent rename. Principle worth recording
+  (Carlos): Q1 was structurally unable to emit good errors (no source tracking,
+  Pandoc interop) and so veered toward "guess what the user meant"; Q2 leans
+  "be more strict, but ensure good, actionable diagnostics follow".
+- **D8 — Listings/sidebar-auto over `.md`: out of scope.** Follow-up strand if
+  the Connect port hits it. `LISTING.default_positive` stays `*.qmd`.
+- **D9 — Preview: in scope as final phase**, split into its own
+  session/strand if it turns out heavy. It will definitely be wanted (the
+  porting workflow is preview-driven).
+
+## Appendix: how other SSGs treat `.md` inputs (survey, 2026-08-07)
+
+Recorded because "why doesn't Quarto render my `.md` by default?" will recur in
+user discussions. The question underneath is: *what is the opt-in boundary that
+separates content from non-content markdown?*
+
+| Tool | Renders `.md` by default? | Opt-in boundary |
+|---|---|---|
+| Hugo | yes | dedicated `content/` directory |
+| MkDocs | yes | dedicated `docs/` directory |
+| Docusaurus | yes | dedicated `docs/` + `blog/` directories |
+| Astro | yes | dedicated `src/pages/` directory |
+| Pelican / Zola | yes | dedicated `content/` directory |
+| Eleventy | yes | **none** — input dir defaults to project root; compensates with built-in `node_modules` ignore + `.eleventyignore` + gitignore integration |
+| Jekyll | conditionally | **front-matter gate** — `.md` with YAML front matter renders; without it, the file is copied as a static asset |
+| Sphinx (MyST) | no | **explicit reference** — documents must appear in a `toctree`; orphans produce warnings |
+| Quarto 1 | yes | **none** — walks the project tree; compensates with a reactively-grown ignore list (README, then `CLAUDE.md`, then `AGENTS.md`, then `*.llms.md`, …) |
+| Quarto 2 (this plan) | **no** | **explicit render list** — default ≡ `render: ["**/*.qmd"]`; write your own list to include `.md` |
+
+Observations:
+
+1. **Every "renders `.md` by default" tool except Eleventy has a dedicated
+   content directory.** The directory *is* the explicit opt-in: putting a file
+   in `content/` is the same deliberate act as adding a glob to
+   `project.render`. Those tools aren't evidence against opt-in — they're
+   evidence that everyone needs *some* boundary.
+2. **Tools that treat the project root as the source tree all develop
+   compensating machinery**, because real project roots are full of
+   non-content markdown (README, CHANGELOG, NEWS, CONTRIBUTING, LICENSE.md,
+   vendored licenses, agent-instruction files). Eleventy grew ignore-file
+   integration; Q1 grew its hidden ignore-glob list one embarrassment at a
+   time; the Connect docs project *still* needs `!news/NEWS.md` and
+   `!licenses/*.licenses.md` on top of Q1's defaults. Default-inclusion in a
+   general project tree is structurally a whack-a-mole.
+3. **Jekyll's front-matter sniffing** is the interesting middle ground (content
+   self-identifies), but it's implicit magic — rendering behavior changes
+   because of file *contents*, and a stray `---` block in a README flips it.
+   Rejected for Q2.
+4. **Sphinx is the closest relative** — a documentation tool whose sources live
+   among other files, requiring explicit reference into the document tree, with
+   diagnostics for orphans. That is essentially the Q2 position.
+5. **The Q2-specific argument on top of the landscape:** qmd is a *strict*
+   dialect. Arbitrary `.md` files not written for Quarto will produce parse
+   diagnostics — and errors about files the user never asked to publish are
+   the worst kind of error. Opt-in means every `.md` in the render list is
+   there because someone asserted it is qmd-dialect content.
+6. **Discoverability mitigation** so the opt-in default doesn't read as "Quarto
+   ignored my files" silence: `Q-PROJECT-EMPTY` hints at present-but-unmatched
+   `.md` files (Phase 1).
+
+## Implementation plan
+
+TDD throughout: each phase starts with failing tests. Phases are ordered so the
+render path (the Connect-docs `q2 render` use case) lands before preview.
+
+### Phase 1 — Discovery (project render list) — **DONE 2026-08-07**
+
+- [x] Tests (in `discovery.rs` unit tests + orchestrator integration tests):
+  - `.md` NOT discovered when `render_patterns` is empty
+    (`md_is_not_discovered_without_render_patterns`)
+  - **S2′ equivalence**: no-`render:`-key discovery ≡ `render: ["**/*.qmd"]`,
+    same files *and order* (`default_discovery_equals_explicit_qmd_globstar`)
+  - `.md` matched by explicit pattern IS included — extension glob, literal
+    path, directory-shaped pattern per D2(a)
+    (`md_is_included_when_matched_by_render_patterns`,
+    `md_only_pattern_does_not_include_qmd`)
+  - negation globs exclude `.md` (`negation_excludes_md_matches`)
+  - negation-only render list = all `.qmd` minus exclusions, no `.md`
+    (`negation_only_render_list_subtracts_from_the_default` — fixed the
+    latent empty-set behavior)
+  - underscore/dot/README/output-dir exclusions apply to `.md`
+    (`md_respects_builtin_exclusions`)
+  - D4 ignore list excluded even when matched
+    (`agent_instruction_md_files_never_render`); literal positive naming one
+    still excluded + Q-5-13 (`literal_pattern_naming_an_excluded_file_is_diagnosed`)
+  - `.qmd`-only behavior unchanged (all 20 pre-existing discovery tests green
+    without modification)
+  - `unmatched_md_files` behavior (`unmatched_md_reports_optin_candidates`,
+    `unmatched_md_skips_builtin_exclusions`, `unmatched_md_shrinks_as_patterns_match`)
+  - CLI e2e: `empty_project_with_md_files_hints_at_render_list_optin`,
+    `rendering_md_not_in_render_list_hints_at_optin` (render_cli_e2e.rs)
+- [x] Default supplied by the enumerator: `effective_render_patterns` +
+  `DEFAULT_RENDER_PATTERN` in discovery.rs (see S2′ mechanism note);
+  `GlobOptions::RENDER` doc-comment updated, `default_positive` stays `None`,
+  pinned consumer-options test untouched
+- [x] Discovery generalized: single `walk_sources` (`.qmd` + `.md`) +
+  `select_from_walk` replaces the walk/expand split; `is_renderable_source`
+  with D4 `is_agent_instruction_md`; module docs rewritten
+- [x] Q-5-13 prose → "renderable source file", mentions built-in exclusions
+- [x] `Q-PROJECT-EMPTY` extra hint counts unmatched `.md` files and shows
+  `"**/*.md"` (via new pure helper `discovery::unmatched_md_files`, called
+  only in the empty-set path so `ProjectContext`/`discover_project_files`
+  signatures stay unchanged)
+- [x] Q-7-6 hint is extension-aware (`render_list_exclusion_hint`); Q-7-7
+  prose → "renderable source files"
+- [x] Full workspace suite green: 11011 passed / 197 skipped (one unrelated
+  `quarto-hub` admin-collect flake passed in isolation and on re-run)
+- [ ] `Q-7-6`/`Q-7-7` wording: extension-aware hint for `.md`-not-in-render-list
+  (`render.rs:1358-1378`)
+
+### Phase 2 — Engine-ignored warning
+
+- [ ] Failing test: `.md` with `engine: jupyter` (and with top-level `jupyter:`)
+  renders with warning Q-2-40, no execution; `.md` without engine metadata
+  renders warning-free; `.qmd` with `engine:` unaffected
+- [ ] Catalog entry + presence test + `docs/errors/markdown/Q-2-40.qmd`
+- [ ] Emission in `EngineExecutionStage::run` via `SourceType::from_path`
+- [ ] Run `scripts/audit-error-codes.py`
+
+### Phase 3 — Single-file path + output guard
+
+- [ ] Tests: `q2 render foo.md` outside a project honors front-matter `format:`;
+  `foo.md` + `format: gfm` errors with the collision diagnostic (D7)
+- [ ] `detect_single_input_format` accepts `.md` (`render.rs:1165`)
+- [ ] `output == input` guard (new check near `RenderContext::output_path`,
+  `render.rs:484` / `stage/context.rs:352`), with its own Q-code if reviewers
+  want one (default: reuse a generic render error)
+- [ ] Fix stale comment at `render.rs:279`
+
+### Phase 4 — Links, navigation, dependency graph
+
+- [ ] Tests: sidebar/navbar `file: admin/index.md` resolves to `admin/index.html`;
+  body link `[x](other.md)` rewritten when `other.md` is in the render list, left
+  alone when excluded (D6); dep-graph edges exist for `.md` body links
+- [ ] `navigation_href.rs:186/:243/:333`: classify by render-list membership (or
+  renderable-extension + membership) instead of `ends_with(".qmd")`
+- [ ] Verify `host_relative_qmd` (`listing/binding.rs:392`) and
+  `dependency_graph.rs:147` behave; rename `.qmd`-flavored identifiers touched
+  along the way
+
+### Phase 5 — Preview (scope per D9)
+
+- [ ] Rust: `quarto-hub/src/discovery.rs:122` VFS sync + `watch.rs:244` filter
+  accept `.md`
+- [ ] TS: `preview-renderer` source-file checks (`types/project.ts:45`,
+  `iframePostProcessor.ts:252`, `iframeLinkHandlers.ts:114`)
+- [ ] Full WASM/SPA rebuild chain + `cargo xtask verify` (not `--skip-hub-build`)
+
+### Phase 6 — End-to-end verification + docs
+
+- [ ] `cargo run --bin q2 -- render` the Connect docs project (or a trimmed
+  fixture derived from it); inspect emitted HTML for a `.md` page: shortcode
+  expansion, nav links pointing at `.html`, correct sidebar; record invocation +
+  output snippet per the end-to-end policy in CLAUDE.md
+- [ ] Fixture project under the repo's test corpus with mixed `.md`/`.qmd`,
+  engine-spec `.md`, excluded `.md`
+- [ ] User-facing docs on the docs/ website (rendered with q2): `.md` inputs are
+  render-list opt-in; engines ignored with warning
+- [ ] `cargo xtask verify`, snapshot-change report, close-out on bd-6d2wj4zp
+
+## References
+
+- Q1 research (this session, agent report): `src/project/project-context.ts:888-1009`,
+  `src/execute/engine.ts:310-330`, `src/execute/markdown.ts:23-107`,
+  `src/command/render/output.ts:188-193`, `src/command/render/render-contexts.ts:336`
+- q2 code map (this session, agent report): see file:line citations inline above
+- `claude-notes/plans/2026-04-23-websites-phase-1.md` §"File-list expansion" (the
+  original deferral), `claude-notes/designs/glob-semantics.md` (enumerator-owns-
+  extension-policy), `claude-notes/plans/2026-07-20-ipynb-surface-syntax-design.md`
+  (the `.ipynb` sibling)

--- a/claude-notes/plans/2026-08-07-md-render-support.md
+++ b/claude-notes/plans/2026-08-07-md-render-support.md
@@ -429,15 +429,36 @@ render path (the Connect-docs `q2 render` use case) lands before preview.
   metadata key via `ConfigMapEntry::key_source`
 - [x] `scripts/audit-error-codes.py`: 171/171 consistent
 
-### Phase 3 — Single-file path + output guard
+### Phase 3 — Single-file path + output guard — **DONE 2026-08-07**
 
-- [ ] Tests: `q2 render foo.md` outside a project honors front-matter `format:`;
-  `foo.md` + `format: gfm` errors with the collision diagnostic (D7)
-- [ ] `detect_single_input_format` accepts `.md` (`render.rs:1165`)
-- [ ] `output == input` guard (new check near `RenderContext::output_path`,
-  `render.rs:484` / `stage/context.rs:352`), with its own Q-code if reviewers
-  want one (default: reuse a generic render error)
-- [ ] Fix stale comment at `render.rs:279`
+Findings that adjusted the plan (research-report conclusions were stale):
+
+- Front-matter `format:` on a standalone `.md` was **already honored for
+  native formats** — per-document format resolution in the pipeline reads
+  front matter regardless of extension (`md_front_matter_format_revealjs_yields_reveal_deck`
+  passed before any fix; kept as a pin). The `.qmd` gate in
+  `detect_single_input_format` mattered for the **non-native bail-out**: a
+  `.md` with `format: pdf` slipped past the early "not yet supported"
+  refusal and rendered HTML bytes into `doc.pdf`. Fixed + pinned
+  (`md_with_non_native_format_gets_early_refusal_like_qmd`).
+- The D7 collision is **not** reachable via `format: gfm` today (non-native
+  formats bail; `determine_output_paths` maps unknown formats to `.html`) —
+  but `q2 render doc.qmd --output <abs path of doc.qmd>` **silently
+  destroyed the source file** (verified live). The guard lives in
+  `determine_output_paths` (`render_to_file.rs`) — the single chokepoint all
+  native single-file *and* project pass-2 renders funnel through — and
+  refuses `output == input` with an actionable error. Covers today's
+  `--output` data-loss bug and the future md-output-format default. Generic
+  render error, no dedicated Q-code (as decided).
+
+- [x] Tests: unit (`output_equal_to_input_is_refused`), e2e overwrite refusal
+  preserving the source byte-for-byte
+  (`output_equal_to_input_refuses_and_preserves_source`), `.md` revealjs pin,
+  `.md` non-native early refusal
+- [x] `detect_single_input_format` accepts `.md`
+- [x] `output == input` guard in `determine_output_paths`
+- [x] Stale "must be a `.qmd` file" comment at the SingleDoc fallthrough fixed
+- [x] Full workspace suite green (11022 passed)
 
 ### Phase 4 — Links, navigation, dependency graph
 

--- a/claude-notes/plans/2026-08-07-md-render-support.md
+++ b/claude-notes/plans/2026-08-07-md-render-support.md
@@ -1,9 +1,9 @@
 # `.md` render support (bd-6d2wj4zp)
 
-**Status:** design questions D1–D9 resolved with Carlos 2026-08-07 (see "Design
-decisions"). One follow-up refinement adopted: the default render list is expressed
-*literally* as `render: ["**/*.qmd"]` (see S2′). Implementation not yet started —
-awaiting explicit go-ahead.
+**Status:** COMPLETE (2026-08-07). All phases landed on
+`braid/bd-6d2wj4zp-md-render-support`: render path (Phases 1–4, 6) in session 1,
+preview + hub + hub-client (Phase 5, decisions D10/D11) in session 2
+(`279d7e5e`). Design questions D1–D11 resolved with Carlos. Branch not pushed.
 
 **Strand:** bd-6d2wj4zp — "Render .md files as inputs (explicit render-list opt-in;
 ignore engine specs with warning)". Related: bd-xxul (the original "non-.qmd input
@@ -607,7 +607,9 @@ Work items (all landed 2026-08-07, session 2):
   `.qmd` cross-links rewrote to `.html`
 - [x] `cargo xtask verify` (full, all 14 steps, WASM + hub-client legs) —
   passed clean on bb54fb7b; no snapshot files changed anywhere in this strand
-- [ ] Close-out on bd-6d2wj4zp after Phase 5 (preview) lands
+- [x] Close-out on bd-6d2wj4zp after Phase 5 (preview) lands — Phase 5
+  landed 2026-08-07 (session 2) as `279d7e5e` + changelog `0e2b1645`;
+  strand closed. Branch not pushed pending Carlos's approval.
 
 ### Phase 5 status + hand-off (for the next session)
 

--- a/claude-notes/plans/2026-08-07-md-render-support.md
+++ b/claude-notes/plans/2026-08-07-md-render-support.md
@@ -533,17 +533,67 @@ per D8; noted for the listing follow-up strand.
   list, Q-2-40 pointer), added to the docs sidebar; `cargo run --bin q2 --
   render docs/` → 184 of 184 files, no warnings from the new page, its
   `.qmd` cross-links rewrote to `.html`
-- [ ] `cargo xtask verify` (full, WASM leg included) — running at session
-  end; no snapshot files changed anywhere in this strand
-- [ ] Close-out on bd-6d2wj4zp after Phase 5 decision (preview split to its
-  own session per D9)
+- [x] `cargo xtask verify` (full, all 14 steps, WASM + hub-client legs) —
+  passed clean on bb54fb7b; no snapshot files changed anywhere in this strand
+- [ ] Close-out on bd-6d2wj4zp after Phase 5 (preview) lands
 
-### Phase 5 status
+### Phase 5 status + hand-off (for the next session)
 
 Deferred to a dedicated follow-up session per D9's escape hatch — it touches
 `quarto-hub` Rust, `ts-packages/preview-renderer` TS, and the WASM/SPA
 rebuild chain, and the render-path work (Phases 1–4, 6) stands on its own.
-The strand stays open until preview lands or is split into its own strand.
+
+**How to resume:** branch `braid/bd-6d2wj4zp-md-render-support` (6 commits
+ahead of main at `9249c43d`, NOT pushed as of 2026-08-07 — ask Carlos before
+pushing). `braid show bd-6d2wj4zp` for the comment trail. Note: the main
+checkout's `CLAUDE.local.md` worktree block still references the unrelated
+bd-09aja9gl — ignore it; this plan is the context.
+
+**Scope** — make `q2 preview` treat `.md` render-list members like `.qmd`:
+synced into the preview VFS, watched for changes, links intercepted, live
+re-render on edit.
+
+**Code sites** (line numbers from the 2026-08-07 survey — re-grep, they
+drift):
+
+- `crates/quarto-hub/src/discovery.rs` (~:122-131): VFS sync — only
+  `ext == Some("qmd")` lands in `qmd_files`; single-file mode at ~:177.
+- `crates/quarto-hub/src/watch.rs` (~:244-247): `is_qmd_file`, used by
+  `WatchFilter::QmdOnly` (~:56) and `is_preview_relevant` (~:256).
+  **Existing tests pin the old behavior** — `test_watcher_ignores_non_qmd_files`
+  and siblings in `watch.rs` will need their semantics revisited, not just
+  made green.
+- TS: `ts-packages/preview-renderer/src/types/project.ts:45`
+  (`endsWith('.qmd')`), `src/utils/iframePostProcessor.ts:252`,
+  `src/utils/iframeLinkHandlers.ts:114`.
+
+**Design decision to make explicitly at session start:** the hub layer syncs
+and watches *all* `.qmd` today regardless of render-list membership — the
+render pipeline decides membership later. The symmetric (recommended) choice
+for `.md` is the same: extension-based sync/watch, membership decided by
+discovery at render time. A render-list-aware sync layer would couple the
+hub to `_quarto.yml` parsing for no user-visible gain. But note the noise
+trade-off: watching all `.md` means edits to *non-rendered* `.md` (README,
+notes) trigger preview-relevant events — check what `is_preview_relevant`
+consumers do on a file that then renders nothing.
+
+**Traps** (see CLAUDE.md "Verifying Rust changes in `q2 preview`"): a plain
+`cargo build --bin q2` does NOT rebuild the embedded WASM/SPA. Full chain:
+`cd hub-client && npm run build:wasm` → `cargo xtask build-q2-preview-spa` →
+`cargo build --bin q2`. Run `npm install` from the repo root at session
+start. hub-client changes additionally require `npm run build:all` to pass
+(stricter than typecheck+vitest).
+
+**E2e bar** (per CLAUDE.md): a real `q2 preview` browser session on a
+project with `.md` render-list members — edit a `.md`, see the preview
+update; click a nav link into a `.md` page. Unit/vitest alone is not
+sufficient; if no browser is available, say so explicitly. The
+`/preview-parity` skill exists for preview-vs-render DOM divergence.
+
+**Related work discovered during Phases 1–6** (tracked under epic
+bd-wch2dotq "Make q2 render the posit-connect docs"): bd-wpoiv8pq
+(metadata-field shortcodes expand empty), bd-rmimy728 (project-absolute
+`{{< include /path >}}` unsupported, misleading diagnostic).
 
 ## References
 

--- a/claude-notes/plans/2026-08-07-md-render-support.md
+++ b/claude-notes/plans/2026-08-07-md-render-support.md
@@ -494,13 +494,85 @@ re-rendering when a linked `.md` changes) is exercised only at the unit
 level — an e2e needs always-render listing pages, which are out of scope
 per D8; noted for the listing follow-up strand.
 
-### Phase 5 — Preview (scope per D9)
+### Phase 5 — Preview (scope per D9) — decisions resolved 2026-08-07 (session 2)
 
-- [ ] Rust: `quarto-hub/src/discovery.rs:122` VFS sync + `watch.rs:244` filter
-  accept `.md`
-- [ ] TS: `preview-renderer` source-file checks (`types/project.ts:45`,
-  `iframePostProcessor.ts:252`, `iframeLinkHandlers.ts:114`)
-- [ ] Full WASM/SPA rebuild chain + `cargo xtask verify` (not `--skip-hub-build`)
+Two scope decisions made with Carlos at Phase-5 session start:
+
+- **D10 — Sync scope: hub-wide.** Extension-based sync/watch (the hand-off's
+  recommended option), applied symmetrically for `q2 preview` *and* the
+  long-lived `quarto hub` server: `.md` is a source/text file everywhere,
+  like `.qmd`. `WatchFilter::QmdOnly` becomes "source files" (`.qmd` +
+  `.md`). Membership stays a render-time (discovery) decision. No
+  render-list-aware sync layer.
+- **D11 — hub-client editor surfaces: in scope.** `PreviewRouter`,
+  `useIntelligence` / `intelligenceService`, and `FileSidebar` treat `.md`
+  as a source file (live preview, diagnostics, outline, folding), not a
+  follow-up strand.
+- **Noise check result** (the hand-off's open question): the consumer that
+  mattered is `shouldRerenderForTextChange` (`q2-preview-spa/src/PreviewApp.tsx`)
+  — today non-`.qmd` text edits *always* re-render the active page, so
+  synced `.md` edits (README etc.) would be noisy. Fix: treat `.md` like
+  `.qmd` there (dep-set-gated). With that, extension-based sync has no
+  user-visible noise cost found.
+- **New gate found beyond the hand-off list:** `quarto-preview`'s
+  `capture_driver.rs` walks `ProjectFiles::qmd_files` for **engine
+  captures** — `.md` must be skipped there or S5 (".md never executes")
+  breaks in preview.
+
+Work items (all landed 2026-08-07, session 2):
+
+- [x] Rust `quarto-hub` (tests first): `discovery.rs` walk accepts `.md`
+  into `qmd_files` (field name kept, docs note both extensions);
+  `watch.rs` `is_qmd_file` → `is_source_file`, `WatchFilter::QmdOnly`
+  renamed **`SourcesOnly`** (semantic rename, per hand-off warning) —
+  pinned tests revised: `.md` accepted by both filters, `README.md`
+  moved to the PreviewBroad *accepts* side, `.txt`/`_quarto.yml`
+  rejection semantics preserved. New tests:
+  `test_discover_md_files_as_sources`, `test_filters_accept_md_as_source`
+- [x] Rust `quarto-preview`: **no capture-driver code change needed** — the
+  S5 guard already lives at the single chokepoint (`EngineExecutionStage`'s
+  `SourceType::Markdown` skip from Phase 2), which the capture sub-pipeline
+  (`preview_record.rs`, truncated at engine execution) runs through. Pinned
+  by `md_doc_with_engine_spec_records_no_capture`, which also asserts
+  non-vacuity (the `.md` IS in the synced source set). `commands/preview.rs`
+  dir-mode initial page falls back `index.qmd` → `index.md` (2 new tests)
+- [x] TS `preview-renderer`: `isSourceFile` predicate beside `isQmdFile`
+  (`types/project.ts`); `RENDERABLE_EXTS` = `['.qmd', '.md']`
+  (`iframePostProcessor.ts` — reverse-map machinery was already
+  multi-extension-ready); `iframeLinkHandlers.ts` direct-link gate accepts
+  `.md`, `parseArtifactHref` now consults `projectFilePaths` to pick the
+  source extension (`.qmd` wins ties; `.qmd` fallback for the missing-page
+  overlay UX preserved); `PreviewStaticInfoViews` prose mentions `.md`
+- [x] TS `q2-preview-spa`: `shouldRerenderForTextChange` dep-filters `.md`
+  like `.qmd` (exported + 7-case unit test file; the deps fetch already
+  seeds the set with the active page, so self-edits re-render);
+  `pickInitialPage` falls back `.qmd`-first then `.md`
+- [x] hub-client (D11): `PreviewRouter`, `useIntelligence`,
+  `intelligenceService` (7 gates), `monacoProviders` (3 gates, with null
+  narrowing), `FileSidebar` (drag + icon) all use the source-file
+  predicate; `Editor.tsx` maps `.md` → Monaco language **`qmd`** (wires up
+  Monarch highlighting + the qmd-registered symbol/folding/semantic-token
+  providers) and `selectDefaultFile` falls back to `index.md`/any-`.md`
+  before first-file; `ReactAstSlideRenderer` link nav accepts `.md`.
+  `templateService` deliberately stays `.qmd`-only (curated built-ins)
+- [x] Full WASM/SPA rebuild chain (`build:wasm` → `build-q2-preview-spa` →
+  `cargo build --bin q2`), `npm run build:all` green, hub-client `test:ci`
+  green (unit + integration + wasm legs)
+- [x] Browser e2e (real `q2 preview` session on a fixture with
+  `render: ["**/*.qmd", "**/*.md"]`, sidebar `file: admin/index.md`, body
+  link, plus a never-rendered `README.md`): home renders with `.md`
+  sidebar entry; body link and sidebar link both navigate into the `.md`
+  page (`?page=admin/index.md`, content rendered); disk edit to the `.md`
+  live-updated the preview (`EDIT-SENTINEL-42` appeared without reload);
+  single-file `q2 preview standalone.md` boots and renders. The
+  README-noise assertion (no re-render on unrelated `.md` edit) is pinned
+  at the unit level only — the SPA emits no observable render log to
+  assert against in-browser. hub-client (quarto-hub.com editor) surfaces
+  were NOT browser-tested — covered by unit/integration tests +
+  `build:all` only.
+- [x] `cargo xtask verify` (full, all 14 steps, WASM + hub-client legs) —
+  passed clean on the Phase-5 tree (2026-08-07, session 2). No snapshot
+  files changed in this phase.
 
 ### Phase 6 — End-to-end verification + docs — **DONE 2026-08-07** (verify run below)
 

--- a/claude-notes/plans/2026-08-07-md-render-support.md
+++ b/claude-notes/plans/2026-08-07-md-render-support.md
@@ -460,16 +460,39 @@ Findings that adjusted the plan (research-report conclusions were stale):
 - [x] Stale "must be a `.qmd` file" comment at the SingleDoc fallthrough fixed
 - [x] Full workspace suite green (11022 passed)
 
-### Phase 4 — Links, navigation, dependency graph
+### Phase 4 — Links, navigation, dependency graph — **DONE 2026-08-07**
 
-- [ ] Tests: sidebar/navbar `file: admin/index.md` resolves to `admin/index.html`;
-  body link `[x](other.md)` rewritten when `other.md` is in the render list, left
-  alone when excluded (D6); dep-graph edges exist for `.md` body links
-- [ ] `navigation_href.rs:186/:243/:333`: classify by render-list membership (or
-  renderable-extension + membership) instead of `ends_with(".qmd")`
-- [ ] Verify `host_relative_qmd` (`listing/binding.rs:392`) and
-  `dependency_graph.rs:147` behave; rename `.qmd`-flavored identifiers touched
-  along the way
+Finding that shrank the phase: the href → output **rewriting was already
+membership-based** — both nav and body resolution go through
+`ProjectIndex::lookup_by_source`, which is keyed by source path and contains
+whatever discovery selected. Once Phase 1 put `.md` files in the render list,
+sidebar `file: notes.md` and body `[x](notes.md)` resolved to `notes.html`
+with no further change (pinned by e2e before any Phase-4 edit). The
+`.ends_with(".qmd")` gates control only two things:
+
+1. **Miss diagnostics** (Q-13-1..4/7): kept `.qmd`-only **deliberately** per
+   D6 — a `.md` miss may legitimately be a static resource; comments at both
+   gate sites now say so.
+2. **Pass-1 body-link target extraction** (`resolve_doc_relative_target`),
+   which feeds `DocumentProfile.body_link_targets` → dependency-graph edges:
+   extended to `.md`. Non-render-list `.md` targets are dropped by the graph
+   builder's index lookup, as designed.
+
+- [x] E2e (`md_pages_get_nav_and_body_links_rewritten`): website project with
+  sidebar `file: notes.md`, `.qmd`→`.md` and `.md`→`.qmd` body links, all
+  rewritten to `.html`; plus a subset-render (Mode B) leg pinning that links
+  into `.md` pages still rewrite when only the linking page renders
+- [x] Unit (`target_md_resolves_like_qmd`): `.md` targets extract like
+  `.qmd`, including `..` normalization and `.md`-source → `.qmd`-target
+- [x] D6 comments at both miss-diagnostic sites
+- [x] `host_relative_qmd` / `dependency_graph.rs` verified path-generic — no
+  change needed (graph filters by index, listing binding is extension-blind)
+- [x] Full workspace suite green (11024 passed)
+
+Note: the graph edges' pass-2 *augmentation* effect (always-render pages
+re-rendering when a linked `.md` changes) is exercised only at the unit
+level — an e2e needs always-render listing pages, which are out of scope
+per D8; noted for the listing follow-up strand.
 
 ### Phase 5 — Preview (scope per D9)
 

--- a/crates/quarto-core/src/glob/mod.rs
+++ b/crates/quarto-core/src/glob/mod.rs
@@ -134,10 +134,13 @@ impl GlobOptions {
 
     /// `project.render` in `_quarto.yml`.
     ///
-    /// `default_positive` stays `None` — a render list of only
-    /// exclusions means "walk the project, minus these", which is
-    /// what an empty `render:` already does, and the walk is the
-    /// enumerator's job rather than a pattern default.
+    /// `default_positive` stays `None` — the default render pattern
+    /// (`**/*.qmd`) is supplied by the enumerator instead
+    /// (`project::discovery::DEFAULT_RENDER_PATTERN`), for empty and
+    /// negation-only lists alike. Keeping it out of the glob layer
+    /// means a *broken* positive pattern (`Q-5-14`/`Q-5-15`) never
+    /// silently falls back to rendering everything, and the walk
+    /// stays the enumerator's job.
     pub const RENDER: Self = Self {
         directory_rule: true,
         default_positive: None,

--- a/crates/quarto-core/src/project/discovery.rs
+++ b/crates/quarto-core/src/project/discovery.rs
@@ -7,18 +7,25 @@
 
 //! Expand the set of source files a project renders.
 //!
-//! Phase-1 scope: `.qmd` only. Support for `.md`, `.ipynb`, and other
-//! renderable extensions is deferred to a follow-up — see
-//! `claude-notes/plans/2026-04-23-websites-phase-1.md` §"File-list
-//! expansion".
+//! Renderable extensions are `.qmd` (always) and `.md` (opt-in, see
+//! below). `.ipynb` / `.Rmd` remain deferred — see bd-xxul and
+//! `claude-notes/plans/2026-07-20-ipynb-surface-syntax-design.md`.
 //!
-//! Discovery rules:
+//! Discovery rules (plan:
+//! `claude-notes/plans/2026-08-07-md-render-support.md`):
 //!
-//! 1. If `render_patterns` is non-empty, treat each entry as a glob
-//!    relative to the project directory. Keep only matches with a
-//!    `.qmd` extension.
-//! 2. Otherwise, recursively walk the project directory for `.qmd`
-//!    files.
+//! 1. Every candidate comes from one recursive walk of the project
+//!    directory collecting `.qmd` and `.md` files.
+//! 2. Candidates are selected by matching them against the
+//!    `project.render` patterns. When the author wrote no *positive*
+//!    pattern — no `render:` key at all, or only `!` negations —
+//!    discovery supplies the default positive [`DEFAULT_RENDER_PATTERN`]
+//!    (`**/*.qmd`). The invariant users can be told verbatim:
+//!    **omitting `project.render` is exactly equivalent to writing
+//!    `render: ["**/*.qmd"]`**, and a negation-only list subtracts
+//!    from that same default. `.md` files therefore render only when
+//!    an explicitly written pattern matches them (a deliberate
+//!    divergence from Quarto 1, which walks `.md` in by default).
 //! 3. Exclude in either mode:
 //!    - the output directory (e.g. `_site/`)
 //!    - `.quarto/`, `.git/`, `node_modules/`
@@ -26,13 +33,18 @@
 //!      `_metadata.yml` / `_quarto*.yml`)
 //!    - any path whose component starts with `.` (hidden)
 //!    - any file whose stem is `README` (case-insensitive)
+//!    - agent-instruction markdown (`CLAUDE.md`, `CLAUDE.local.md`,
+//!      `AGENTS.md`, `AGENTS.local.md`, `*.llms.md`; case-insensitive)
 //!
-//! The project config file itself (`_quarto.yml` / `.yaml`) is
-//! naturally excluded because of the `_` prefix rule.
+//! These exclusions are hard filters: an explicit pattern naming an
+//! excluded file does not override them (the author gets `Q-5-13`
+//! instead). The project config file itself (`_quarto.yml` / `.yaml`)
+//! is naturally excluded because of the `_` prefix rule.
 
 use std::path::{Component, Path, PathBuf};
 
 use quarto_error_reporting::{DiagnosticMessage, DiagnosticMessageBuilder};
+use quarto_source_map::{By, SourceInfo};
 use quarto_system_runtime::SystemRuntime;
 
 use crate::error::{QuartoError, Result};
@@ -55,44 +67,113 @@ pub struct DiscoveryConfig<'a> {
     pub output_dir: &'a Path,
     /// `project.render` globs from `_quarto.yml`, each with the
     /// provenance of the YAML scalar it came from so diagnostics can
-    /// point at it. Empty = walk the whole project directory.
+    /// point at it. When no positive pattern is present (empty, or
+    /// negations only), discovery matches against
+    /// [`DEFAULT_RENDER_PATTERN`] instead.
     pub render_patterns: &'a [RawGlob],
 }
 
-/// Discover the list of `.qmd` files for a project.
+/// The positive pattern discovery supplies when the author wrote
+/// none: no `render:` key, or a list of only `!` negations. This is
+/// what makes the S2′ invariant literal — omitting `project.render`
+/// ≡ `render: ["**/*.qmd"]`.
+pub const DEFAULT_RENDER_PATTERN: &str = "**/*.qmd";
+
+/// Discover the render list for a project.
 ///
 /// Returned paths are **absolute** (joined with `project_dir`) and
-/// de-duplicated. Order is stable: render-patterns preserve their
-/// listed order (within a single pattern: lexicographic by path);
-/// the walk path uses directory-first lexicographic order.
+/// de-duplicated. Order is stable: patterns preserve their listed
+/// order (within a single pattern: lexicographic by path); the
+/// default pattern therefore yields lexicographic order.
 pub fn discover_project_files(
     config: &DiscoveryConfig<'_>,
     runtime: &dyn SystemRuntime,
 ) -> Result<Vec<PathBuf>> {
-    let mut files = Vec::new();
-    let mut seen = std::collections::HashSet::new();
-
-    let candidates: Vec<PathBuf> = if config.render_patterns.is_empty() {
-        walk_qmd(config.project_dir, runtime)?
-    } else {
-        expand_patterns(config.project_dir, config.render_patterns, runtime)?
-    };
-
-    for candidate in candidates {
-        if !is_renderable_qmd(&candidate, config) {
-            continue;
-        }
-        if seen.insert(candidate.clone()) {
-            files.push(candidate);
-        }
-    }
-
-    Ok(files)
+    let walked = walk_sources(config.project_dir, runtime)?;
+    Ok(select_from_walk(&walked, config))
 }
 
-/// True if a candidate path should be rendered under Phase-1 rules.
-fn is_renderable_qmd(candidate: &Path, config: &DiscoveryConfig<'_>) -> bool {
-    if !has_qmd_extension(candidate) {
+/// `.md` files an author may have expected to render: they survive
+/// every built-in exclusion but no render pattern selected them
+/// (with no `render:` key, that is all renderable `.md`). Pure apart
+/// from the walk; the orchestrator calls this only when explaining
+/// an empty render set (`Q-PROJECT-EMPTY`), so discovery's own
+/// signature stays lean.
+pub fn unmatched_md_files(
+    config: &DiscoveryConfig<'_>,
+    runtime: &dyn SystemRuntime,
+) -> Result<Vec<PathBuf>> {
+    let walked = walk_sources(config.project_dir, runtime)?;
+    let selected: std::collections::HashSet<PathBuf> =
+        select_from_walk(&walked, config).into_iter().collect();
+    Ok(walked
+        .into_iter()
+        .filter(|p| has_md_extension(p) && is_renderable_source(p, config))
+        .filter(|p| !selected.contains(p))
+        .collect())
+}
+
+/// The render patterns discovery actually matches against: the
+/// author's, plus [`DEFAULT_RENDER_PATTERN`] prepended when no
+/// positive pattern is present. Policy lives here in the enumerator
+/// (not in `GlobOptions::RENDER.default_positive`) per
+/// `claude-notes/designs/glob-semantics.md` — which files exist to be
+/// matched is discovery's business, and this way a broken positive
+/// pattern (`Q-5-14`/`Q-5-15`) never silently falls back to
+/// rendering everything.
+fn effective_render_patterns(user: &[RawGlob]) -> Vec<RawGlob> {
+    if user.iter().any(|r| !r.raw.starts_with('!')) {
+        return user.to_vec();
+    }
+    let mut patterns = vec![RawGlob::new(
+        DEFAULT_RENDER_PATTERN,
+        SourceInfo::generated(By::programmatic_config()),
+    )];
+    patterns.extend(user.iter().cloned());
+    patterns
+}
+
+/// Match walked candidates against the effective render patterns,
+/// applying the built-in exclusions. Iterates the *positive* patterns
+/// in their listed order so the documented render order survives
+/// (within one pattern: walk order). Exclusions are global: a `!`
+/// entry subtracts from every positive pattern regardless of where
+/// the author wrote it.
+fn select_from_walk(walked: &[PathBuf], config: &DiscoveryConfig<'_>) -> Vec<PathBuf> {
+    let patterns = effective_render_patterns(config.render_patterns);
+    let resolution = resolve_render_patterns(config.project_dir, &patterns);
+    let Ok(compiled) = resolution.compile(&RENDER_GLOB_OPTIONS) else {
+        // Unreachable: resolution only emits patterns it compiled.
+        return Vec::new();
+    };
+
+    let mut files = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    for glob in resolution.globs.iter().filter(|g| !g.negated) {
+        let Ok(single) = PatternSet::compile(std::slice::from_ref(glob), &RENDER_GLOB_OPTIONS)
+        else {
+            continue;
+        };
+        for candidate in walked {
+            let Ok(relative) = candidate.strip_prefix(config.project_dir) else {
+                continue;
+            };
+            if single.matches_path(relative)
+                && !compiled.excluded_path(relative)
+                && is_renderable_source(candidate, config)
+                && seen.insert(candidate.clone())
+            {
+                files.push(candidate.clone());
+            }
+        }
+    }
+    files
+}
+
+/// True if a candidate path may appear in a render list at all:
+/// renderable extension, and none of the built-in exclusions apply.
+fn is_renderable_source(candidate: &Path, config: &DiscoveryConfig<'_>) -> bool {
+    if !has_renderable_extension(candidate) {
         return false;
     }
     let Ok(relative) = candidate.strip_prefix(config.project_dir) else {
@@ -126,11 +207,38 @@ fn is_renderable_qmd(candidate: &Path, config: &DiscoveryConfig<'_>) -> bool {
     {
         return false;
     }
+    // Agent-instruction markdown never renders (D4) — under
+    // `render: ["**/*.md"]` these would otherwise publish agent
+    // instructions into the site. Case-insensitive, like README.
+    if let Some(name) = candidate.file_name().and_then(|s| s.to_str())
+        && is_agent_instruction_md(name)
+    {
+        return false;
+    }
     true
 }
 
-fn has_qmd_extension(path: &Path) -> bool {
-    path.extension().and_then(|e| e.to_str()) == Some("qmd")
+/// File names on the agent-instruction ignore list (matched
+/// case-insensitively): `CLAUDE.md`, `CLAUDE.local.md`, `AGENTS.md`,
+/// `AGENTS.local.md`, and any `*.llms.md` companion file. Mirrors
+/// Quarto 1's `projectHiddenIgnoreGlob`.
+fn is_agent_instruction_md(file_name: &str) -> bool {
+    let lower = file_name.to_ascii_lowercase();
+    matches!(
+        lower.as_str(),
+        "claude.md" | "claude.local.md" | "agents.md" | "agents.local.md"
+    ) || lower.ends_with(".llms.md")
+}
+
+fn has_renderable_extension(path: &Path) -> bool {
+    matches!(
+        path.extension().and_then(|e| e.to_str()),
+        Some("qmd" | "md")
+    )
+}
+
+fn has_md_extension(path: &Path) -> bool {
+    path.extension().and_then(|e| e.to_str()) == Some("md")
 }
 
 fn is_excluded_component(name: &str) -> bool {
@@ -155,54 +263,15 @@ fn starts_with(path: &Path, prefix: &Path) -> bool {
     true
 }
 
-/// Expand `project.render` glob patterns relative to `project_dir`.
-///
-/// Patterns are project-root-anchored (`project.render` can only be
-/// written in `_quarto.yml`, whose directory *is* the project root)
-/// and matched against the walked `.qmd` set with the shared matcher
-/// in [`crate::glob`] — the same one listings use, so a pattern means
-/// the same thing in both places.
-fn expand_patterns(
-    project_dir: &Path,
-    patterns: &[RawGlob],
-    runtime: &dyn SystemRuntime,
-) -> Result<Vec<PathBuf>> {
-    let walked = walk_qmd(project_dir, runtime)?;
-    let resolution = resolve_render_patterns(project_dir, patterns);
-    let Ok(compiled) = resolution.compile(&RENDER_GLOB_OPTIONS) else {
-        // Unreachable: resolution only emits patterns it compiled.
-        return Ok(Vec::new());
-    };
-
-    // Iterate the *positive* patterns in their listed order so the
-    // documented render order survives (within one pattern, walk
-    // order is lexicographic). Exclusions are global: a `!` entry
-    // subtracts from every positive pattern regardless of where the
-    // author wrote it.
-    let mut matches = Vec::new();
-    for glob in resolution.globs.iter().filter(|g| !g.negated) {
-        let Ok(single) = PatternSet::compile(std::slice::from_ref(glob), &RENDER_GLOB_OPTIONS)
-        else {
-            continue;
-        };
-        for candidate in &walked {
-            let Ok(relative) = candidate.strip_prefix(project_dir) else {
-                continue;
-            };
-            if single.matches_path(relative) && !compiled.excluded_path(relative) {
-                matches.push(candidate.clone());
-            }
-        }
-    }
-    Ok(matches)
-}
-
 /// Resolve `project.render` entries against the project root.
 ///
-/// Shared by [`expand_patterns`] and
+/// Shared by [`select_from_walk`] and
 /// [`render_pattern_diagnostics`] so the two agree by construction:
 /// what the diagnostic reports about a pattern is what discovery
-/// actually did with it.
+/// actually did with it. (The diagnostics side resolves the *user's*
+/// patterns, not the effective ones — the synthesized
+/// [`DEFAULT_RENDER_PATTERN`] has no YAML behind it and is never
+/// reported.)
 fn resolve_render_patterns(project_dir: &Path, patterns: &[RawGlob]) -> GlobResolution {
     resolve_patterns(
         patterns.iter().cloned(),
@@ -315,13 +384,15 @@ pub fn render_pattern_diagnostics(
                 .with_code("Q-5-13")
                 .with_location(raw.source.clone())
                 .problem(
-                    "No `.qmd` file in the project matches this pattern, so it \
-                     contributes nothing to the render list.",
+                    "No renderable source file (`.qmd` or `.md`) in the project \
+                     matches this pattern, so it contributes nothing to the render \
+                     list.",
                 )
                 .add_info(
                     "In Quarto 2, `*` matches within one directory level — write \
                      `**/` to search subdirectories (`posts/**/*.qmd`). Files whose \
-                     name or directory starts with `_` or `.`, and `README` files, \
+                     name or directory starts with `_` or `.`, `README` files, and \
+                     agent-instruction files (`CLAUDE.md`, `AGENTS.md`, `*.llms.md`) \
                      are never rendered.",
                 )
                 .build(),
@@ -332,10 +403,10 @@ pub fn render_pattern_diagnostics(
     out
 }
 
-/// Recursively walk `project_dir` collecting `.qmd` files, already
-/// filtered against the cheap excludes (hidden, underscore, output
-/// dir). Paths are absolute.
-fn walk_qmd(project_dir: &Path, runtime: &dyn SystemRuntime) -> Result<Vec<PathBuf>> {
+/// Recursively walk `project_dir` collecting candidate source files
+/// (`.qmd` and `.md`), already filtered against the cheap excludes
+/// (hidden, underscore components). Paths are absolute and sorted.
+fn walk_sources(project_dir: &Path, runtime: &dyn SystemRuntime) -> Result<Vec<PathBuf>> {
     let mut out = Vec::new();
     walk_rec(project_dir, project_dir, runtime, &mut out)?;
     out.sort();
@@ -366,7 +437,7 @@ fn walk_rec(
             }
             continue;
         }
-        if has_qmd_extension(&entry) {
+        if has_renderable_extension(&entry) {
             out.push(entry);
         }
     }
@@ -726,6 +797,262 @@ mod tests {
             .collect();
         assert!(names.contains(&"cómo estás.qmd".to_string()));
         assert!(names.contains(&"with spaces.qmd".to_string()));
+    }
+
+    // ── .md render support (bd-6d2wj4zp) ─────────────────────────
+    //
+    // Semantics under test (plan: 2026-08-07-md-render-support.md):
+    // `.md` files render only when matched by an explicitly written
+    // `project.render` pattern. Omitting `project.render` is exactly
+    // equivalent to writing `render: ["**/*.qmd"]` (S2′), so `.md` is
+    // invisible to default discovery; once matched, built-in
+    // exclusions still apply, including the agent-file ignore list
+    // (D4).
+
+    /// Fixture with a representative mix of `.qmd`, opt-in `.md`, and
+    /// `.md` files that must never render (D4 + built-in exclusions).
+    fn md_fixture() -> (TempDir, PathBuf) {
+        let temp = TempDir::new().unwrap();
+        let dir = canonical(temp.path());
+        write_file(&dir.join("index.qmd"), "# i\n");
+        write_file(&dir.join("posts/a.qmd"), "# a\n");
+        write_file(&dir.join("notes.md"), "# n\n");
+        write_file(&dir.join("posts/note.md"), "# pn\n");
+        write_file(&dir.join("news/NEWS.md"), "# news\n");
+        (temp, dir)
+    }
+
+    /// `.md` files are invisible when `project.render` is absent.
+    /// (Deliberate divergence from Quarto 1, which walks them in.)
+    #[test]
+    fn md_is_not_discovered_without_render_patterns() {
+        let (_t, dir) = md_fixture();
+        let (rels, _) = discover_with(&dir, &[]);
+        assert_eq!(
+            rels,
+            vec!["index.qmd".to_string(), "posts/a.qmd".to_string()]
+        );
+    }
+
+    /// S2′: omitting `project.render` ≡ `render: ["**/*.qmd"]` —
+    /// same files, same order, including root-level files (`**`
+    /// matches zero segments).
+    #[test]
+    fn default_discovery_equals_explicit_qmd_globstar() {
+        let (_t, dir) = md_fixture();
+        let ordered = |patterns: &[&str]| -> Vec<PathBuf> {
+            let patterns: Vec<RawGlob> = patterns
+                .iter()
+                .map(|p| RawGlob::new(*p, SourceInfo::generated(By::programmatic_config())))
+                .collect();
+            let output_dir = dir.join("_site");
+            let config = DiscoveryConfig {
+                project_dir: &dir,
+                output_dir: &output_dir,
+                render_patterns: &patterns,
+            };
+            discover_project_files(&config, &native()).unwrap()
+        };
+        let by_default = ordered(&[]);
+        let by_pattern = ordered(&["**/*.qmd"]);
+        assert!(!by_default.is_empty());
+        assert_eq!(by_default, by_pattern, "same files in the same order");
+    }
+
+    /// D2(a): any positive pattern match opts a `.md` file in — the
+    /// pattern does not need to name the extension.
+    #[test]
+    fn md_is_included_when_matched_by_render_patterns() {
+        let (_t, dir) = md_fixture();
+
+        // Extension glob, the Connect-docs shape.
+        let (rels, diags) = discover_with(&dir, &["**/*.qmd", "**/*.md"]);
+        assert_eq!(
+            rels,
+            vec![
+                "index.qmd".to_string(),
+                "news/NEWS.md".to_string(),
+                "notes.md".to_string(),
+                "posts/a.qmd".to_string(),
+                "posts/note.md".to_string(),
+            ]
+        );
+        assert!(diags.is_empty(), "{diags:?}");
+
+        // Literal path.
+        let (rels, _) = discover_with(&dir, &["notes.md"]);
+        assert_eq!(rels, vec!["notes.md".to_string()]);
+
+        // Bare directory: everything renderable beneath it, `.md`
+        // included (the pattern is the explicit opt-in, not the
+        // extension it happens to spell).
+        let (rels, _) = discover_with(&dir, &["posts"]);
+        assert_eq!(
+            rels,
+            vec!["posts/a.qmd".to_string(), "posts/note.md".to_string()]
+        );
+    }
+
+    /// Render patterns replace the default entirely: an `.md`-only
+    /// list renders no `.qmd`.
+    #[test]
+    fn md_only_pattern_does_not_include_qmd() {
+        let (_t, dir) = md_fixture();
+        let (rels, _) = discover_with(&dir, &["**/*.md"]);
+        assert_eq!(
+            rels,
+            vec![
+                "news/NEWS.md".to_string(),
+                "notes.md".to_string(),
+                "posts/note.md".to_string(),
+            ]
+        );
+    }
+
+    /// Negations subtract `.md` matches like any other (the
+    /// Connect-docs `!news/NEWS.md` shape).
+    #[test]
+    fn negation_excludes_md_matches() {
+        let (_t, dir) = md_fixture();
+        let (rels, diags) = discover_with(&dir, &["**/*.md", "!news/NEWS.md"]);
+        assert_eq!(
+            rels,
+            vec!["notes.md".to_string(), "posts/note.md".to_string()]
+        );
+        assert!(diags.is_empty(), "{diags:?}");
+    }
+
+    /// S2′: a negation-only render list means "the default
+    /// `**/*.qmd`, minus these" — the documented semantics, which
+    /// previously produced an empty render set.
+    #[test]
+    fn negation_only_render_list_subtracts_from_the_default() {
+        let (_t, dir) = md_fixture();
+        let (rels, diags) = discover_with(&dir, &["!posts/a.qmd"]);
+        assert_eq!(
+            rels,
+            vec!["index.qmd".to_string()],
+            "all default-discovered `.qmd` minus the negation, no `.md`"
+        );
+        assert!(diags.is_empty(), "{diags:?}");
+    }
+
+    /// Built-in exclusions (underscore/dot components, README,
+    /// output dir) apply to `.md` exactly as to `.qmd`, even under a
+    /// pattern that matches them.
+    #[test]
+    fn md_respects_builtin_exclusions() {
+        let temp = TempDir::new().unwrap();
+        let dir = canonical(temp.path());
+        write_file(&dir.join("docs/guide.md"), "# g\n");
+        write_file(&dir.join("_partials/frag.md"), "# f\n");
+        write_file(&dir.join("_draft.md"), "# d\n");
+        write_file(&dir.join(".hidden.md"), "# h\n");
+        write_file(&dir.join("README.md"), "# r\n");
+        write_file(&dir.join("readme.md"), "# r2\n");
+        write_file(&dir.join("_site/stale.md"), "# s\n");
+        let (rels, _) = discover_with(&dir, &["**/*.md"]);
+        assert_eq!(rels, vec!["docs/guide.md".to_string()]);
+    }
+
+    /// D4: agent-instruction files never render, even when a pattern
+    /// matches them. Case-insensitive, like the README rule.
+    #[test]
+    fn agent_instruction_md_files_never_render() {
+        let temp = TempDir::new().unwrap();
+        let dir = canonical(temp.path());
+        write_file(&dir.join("notes.md"), "# n\n");
+        write_file(&dir.join("CLAUDE.md"), "# c\n");
+        write_file(&dir.join("CLAUDE.local.md"), "# cl\n");
+        write_file(&dir.join("AGENTS.md"), "# a\n");
+        write_file(&dir.join("agents.local.md"), "# al\n");
+        write_file(&dir.join("docs/AGENTS.md"), "# da\n");
+        write_file(&dir.join("api.llms.md"), "# llms\n");
+        let (rels, _) = discover_with(&dir, &["**/*.md"]);
+        assert_eq!(rels, vec!["notes.md".to_string()]);
+    }
+
+    /// D4′: built-in exclusions are hard filters — a literal render
+    /// entry naming an excluded file does not override them, and the
+    /// author is told the pattern contributed nothing (Q-5-13).
+    #[test]
+    fn literal_pattern_naming_an_excluded_file_is_diagnosed() {
+        let temp = TempDir::new().unwrap();
+        let dir = canonical(temp.path());
+        write_file(&dir.join("CLAUDE.md"), "# c\n");
+        write_file(&dir.join("index.qmd"), "# i\n");
+        let (rels, diags) = discover_with(&dir, &["index.qmd", "CLAUDE.md"]);
+        assert_eq!(rels, vec!["index.qmd".to_string()]);
+        assert_eq!(diags.len(), 1, "{diags:?}");
+        assert_eq!(diags[0].code.as_deref(), Some("Q-5-13"));
+    }
+
+    /// Helper: project-relative `unmatched_md_files` results, sorted.
+    fn unmatched_with(project_dir: &Path, patterns: &[&str]) -> Vec<String> {
+        let patterns: Vec<RawGlob> = patterns
+            .iter()
+            .map(|p| RawGlob::new(*p, SourceInfo::generated(By::programmatic_config())))
+            .collect();
+        let output_dir = project_dir.join("_site");
+        let config = DiscoveryConfig {
+            project_dir,
+            output_dir: &output_dir,
+            render_patterns: &patterns,
+        };
+        let mut rels: Vec<String> = unmatched_md_files(&config, &native())
+            .unwrap()
+            .iter()
+            .map(|p| {
+                p.strip_prefix(project_dir)
+                    .unwrap()
+                    .to_string_lossy()
+                    .replace(std::path::MAIN_SEPARATOR, "/")
+            })
+            .collect();
+        rels.sort();
+        rels
+    }
+
+    /// With no `render:` key, every renderable `.md` is an opt-in
+    /// candidate the author may be missing — but files the built-in
+    /// exclusions reject are not (they could never render anyway).
+    #[test]
+    fn unmatched_md_reports_optin_candidates() {
+        let (_t, dir) = md_fixture();
+        assert_eq!(
+            unmatched_with(&dir, &[]),
+            vec![
+                "news/NEWS.md".to_string(),
+                "notes.md".to_string(),
+                "posts/note.md".to_string(),
+            ]
+        );
+    }
+
+    /// Excluded `.md` (README, agent files, underscore) never counts
+    /// as unmatched: suggesting the user opt in a file that cannot
+    /// render would be a lie.
+    #[test]
+    fn unmatched_md_skips_builtin_exclusions() {
+        let temp = TempDir::new().unwrap();
+        let dir = canonical(temp.path());
+        write_file(&dir.join("guide.md"), "# g\n");
+        write_file(&dir.join("README.md"), "# r\n");
+        write_file(&dir.join("CLAUDE.md"), "# c\n");
+        write_file(&dir.join("_frag.md"), "# f\n");
+        assert_eq!(unmatched_with(&dir, &[]), vec!["guide.md".to_string()]);
+    }
+
+    /// Once patterns select the `.md` files, nothing is unmatched;
+    /// partially-selecting patterns leave the remainder.
+    #[test]
+    fn unmatched_md_shrinks_as_patterns_match() {
+        let (_t, dir) = md_fixture();
+        assert!(unmatched_with(&dir, &["**/*.qmd", "**/*.md"]).is_empty());
+        assert_eq!(
+            unmatched_with(&dir, &["posts/*.md"]),
+            vec!["news/NEWS.md".to_string(), "notes.md".to_string()]
+        );
     }
 
     #[test]

--- a/crates/quarto-core/src/project/orchestrator.rs
+++ b/crates/quarto-core/src/project/orchestrator.rs
@@ -1045,13 +1045,35 @@ impl<'a, R: Pass2Renderer> ProjectPipeline<'a, R> {
         )));
         let has_render_patterns = !self.project.config.render_patterns.is_empty();
         let hint = if has_render_patterns {
-            "Check `project.render` in `_quarto.yml` — its globs matched no `.qmd` files."
+            "Check `project.render` in `_quarto.yml` — its globs matched no renderable files."
         } else {
             "Add a `.qmd` file to the project, or remove `_quarto.yml` to render a single \
              standalone document."
         };
         diag.hints
             .push(quarto_error_reporting::MessageContent::from(hint));
+        // `.md` files are render-list opt-in (bd-6d2wj4zp). When the
+        // project has renderable `.md` files that no pattern matched,
+        // the empty set is likely that policy at work — say so, or
+        // the default reads as Quarto silently ignoring the files.
+        let discovery_cfg = crate::project::discovery::DiscoveryConfig {
+            project_dir: &self.project.dir,
+            output_dir: &self.project.output_dir,
+            render_patterns: &self.project.config.render_patterns,
+        };
+        if let Ok(md) =
+            crate::project::discovery::unmatched_md_files(&discovery_cfg, self.runtime.as_ref())
+            && !md.is_empty()
+        {
+            let n = md.len();
+            let plural = if n == 1 { "" } else { "s" };
+            diag.hints
+                .push(quarto_error_reporting::MessageContent::from(format!(
+                    "The project contains {n} `.md` file{plural}; `.md` files render \
+                     only when matched by a `project.render` pattern such as \
+                     `\"**/*.md\"`."
+                )));
+        }
         vec![diag]
     }
 

--- a/crates/quarto-core/src/render_to_file.rs
+++ b/crates/quarto-core/src/render_to_file.rs
@@ -496,6 +496,25 @@ fn determine_output_paths(
         base_dir.join(format!("{}.{}", stem, extension))
     };
 
+    // Refuse an output that lands on the input itself — rendering
+    // would silently replace the source with its own output
+    // (bd-6d2wj4zp D7). Reachable via `--output <input>` today, and
+    // the guard also covers any future md-output format whose
+    // default `foo.md` → `foo.md` collides. Lexical comparison is
+    // the right level here: both paths are derived from the same
+    // (already-canonicalized) input in the default branch, and an
+    // explicit output aiming at the input through a different
+    // spelling still gets caught the moment the spellings agree —
+    // this is a safety net, not an ACL.
+    if output_path == input_path {
+        return Err(QuartoError::other(format!(
+            "Refusing to render {}: the output path would overwrite the input \
+             file itself. Pass a different `--output` / `output-file`, or let \
+             the output extension differ from the source's.",
+            input_path.display()
+        )));
+    }
+
     // Determine output directory
     let output_dir = output_path
         .parent()
@@ -533,6 +552,26 @@ mod tests {
         assert_eq!(output, PathBuf::from("/project/doc.html"));
         assert_eq!(dir, PathBuf::from("/project"));
         assert_eq!(stem, "doc");
+    }
+
+    /// bd-6d2wj4zp D7: a computed output that lands on the input
+    /// itself must refuse, not silently destroy the source. Reachable
+    /// today via `--output <input>`; will also guard the future
+    /// `foo.md` + `format: gfm` default (`foo.md` → `foo.md`).
+    #[test]
+    fn output_equal_to_input_is_refused() {
+        let input = Path::new("/project/notes.md");
+        let options = RenderToFileOptions {
+            output_path: Some(PathBuf::from("/project/notes.md")),
+            ..Default::default()
+        };
+        let err = determine_output_paths(input, "html", &options)
+            .expect_err("output == input must be an error");
+        let text = format!("{err}");
+        assert!(
+            text.contains("overwrite"),
+            "error should say it would overwrite the input: {text}"
+        );
     }
 
     #[test]

--- a/crates/quarto-core/src/stage/stages/engine_execution.rs
+++ b/crates/quarto-core/src/stage/stages/engine_execution.rs
@@ -28,12 +28,12 @@ use async_trait::async_trait;
 use std::collections::HashSet;
 use std::sync::Arc;
 
-use quarto_error_reporting::DiagnosticMessage;
+use quarto_error_reporting::{DiagnosticMessage, DiagnosticMessageBuilder};
 
 use crate::engine::{EngineRegistry, ExecutionContext, ExecutionEngine, detect_engine_sequence};
 use crate::stage::{
     DocumentAst, EventLevel, PipelineData, PipelineDataKind, PipelineError, PipelineStage,
-    StageContext,
+    SourceType, StageContext,
 };
 use crate::trace_event;
 
@@ -176,6 +176,42 @@ impl Default for EngineExecutionStage {
     }
 }
 
+/// `Q-2-40`: a `.md` document asked for an engine it will never get.
+fn md_engine_ignored_diagnostic(
+    ignored: &[&str],
+    meta: &quarto_pandoc_types::ConfigValue,
+) -> DiagnosticMessage {
+    let plural = if ignored.len() == 1 { "" } else { "s" };
+    let mut builder =
+        DiagnosticMessageBuilder::warning("Engine Specification Ignored for Markdown Input")
+            .with_code("Q-2-40")
+            .problem(
+                "`.md` documents never execute engines; the engine specification \
+                 has no effect.",
+            )
+            .add_detail(format!("Requested engine{plural}: {}.", ignored.join(", ")))
+            .add_hint("Rename the file to `.qmd` if you need executable code.");
+    if let Some(source) = engine_spec_source(meta, ignored) {
+        builder = builder.with_location(source);
+    }
+    builder.build()
+}
+
+/// The metadata key to anchor `Q-2-40` at: the explicit `engine:`
+/// key if present, else the first engine-specific top-level key
+/// (`jupyter:` / `knitr:`) that put an engine in the sequence.
+fn engine_spec_source(
+    meta: &quarto_pandoc_types::ConfigValue,
+    ignored: &[&str],
+) -> Option<quarto_source_map::SourceInfo> {
+    let entries = meta.as_map_entries()?;
+    entries
+        .iter()
+        .find(|e| e.key == "engine")
+        .or_else(|| entries.iter().find(|e| ignored.contains(&e.key.as_str())))
+        .map(|e| e.key_source.clone())
+}
+
 #[async_trait(?Send)]
 impl PipelineStage for EngineExecutionStage {
     fn name(&self) -> &str {
@@ -229,6 +265,30 @@ impl PipelineStage for EngineExecutionStage {
                 .collect::<Vec<_>>()
                 .join(", ")
         );
+
+        // `.md` inputs never execute engines (bd-6d2wj4zp S5): the qmd
+        // dialect is fully supported in `.md`, but execution requires
+        // the `.qmd` extension. Any non-trivial engine spec — anything
+        // in the detected sequence other than the no-op `markdown` —
+        // is ignored with `Q-2-40`. The skip happens before engine
+        // resolution so availability-fallback warnings don't pile on.
+        if SourceType::from_path(&ctx.document.input) == Some(SourceType::Markdown) {
+            let ignored: Vec<&str> = sequence
+                .engines
+                .iter()
+                .filter(|e| !e.is_markdown())
+                .map(|e| e.name.as_str())
+                .collect();
+            if !ignored.is_empty() {
+                ctx.add_diagnostic(md_engine_ignored_diagnostic(&ignored, &doc_ast.ast.meta));
+            }
+            trace_event!(
+                ctx,
+                EventLevel::Debug,
+                "`.md` input — engine execution skipped"
+            );
+            return Ok(PipelineData::DocumentAst(doc_ast));
+        }
 
         // Step 2: Resolve each detected engine to an implementation (with
         // fallback), dropping markdown — it's a no-op, so a markdown
@@ -696,7 +756,7 @@ mod tests {
         }
     }
 
-    fn make_test_context() -> StageContext {
+    fn make_test_context_for(input: &str) -> StageContext {
         use crate::format::Format;
         use crate::project::{DocumentInfo, ProjectContext};
         use std::sync::Arc;
@@ -709,10 +769,14 @@ mod tests {
             files: vec![],
             output_dir: PathBuf::from("/project"),
         };
-        let doc = DocumentInfo::from_path("/project/test.qmd");
+        let doc = DocumentInfo::from_path(input);
         let format = Format::html();
 
         StageContext::new(runtime, format, project, doc).unwrap()
+    }
+
+    fn make_test_context() -> StageContext {
+        make_test_context_for("/project/test.qmd")
     }
 
     fn parse_qmd_to_ast(content: &[u8], path: &str) -> DocumentAst {
@@ -802,6 +866,97 @@ mod tests {
         assert!(!result.ast.blocks.is_empty());
         assert!(!ctx.diagnostics.is_empty());
         assert!(ctx.diagnostics[0].title.contains("not available"));
+    }
+
+    // ── `.md` inputs never execute engines (bd-6d2wj4zp S5) ──────
+    //
+    // An engine specification on a `.md` document is ignored with
+    // warning `Q-2-40`; execution is skipped entirely (no fallback
+    // warnings, no engine runs). A `.md` without engine metadata —
+    // or with the explicit no-op `engine: markdown` — stays silent.
+
+    #[tokio::test]
+    async fn md_with_engine_key_warns_and_skips_execution() {
+        let stage = EngineExecutionStage::new();
+        let mut ctx = make_test_context_for("/project/notes.md");
+
+        let content = b"---\ntitle: Test\nengine: jupyter\n---\n\n# Hello\n\nWorld";
+        let doc_ast = parse_qmd_to_ast(content, "/project/notes.md");
+        let original_block_count = doc_ast.ast.blocks.len();
+
+        let input = PipelineData::DocumentAst(doc_ast);
+        let output = stage.run(input, &mut ctx).await.unwrap();
+        let result = output.into_document_ast().expect("Should be DocumentAst");
+
+        assert_eq!(
+            result.ast.blocks.len(),
+            original_block_count,
+            "AST passes through unexecuted"
+        );
+        assert_eq!(ctx.diagnostics.len(), 1, "{:?}", ctx.diagnostics);
+        assert_eq!(ctx.diagnostics[0].code.as_deref(), Some("Q-2-40"));
+        let text = format!("{:?}", ctx.diagnostics[0]);
+        assert!(text.contains("jupyter"), "names the ignored engine: {text}");
+    }
+
+    #[tokio::test]
+    async fn md_with_engine_toplevel_key_warns() {
+        let stage = EngineExecutionStage::new();
+        let mut ctx = make_test_context_for("/project/notes.md");
+
+        let content = b"---\ntitle: Test\njupyter:\n  kernel: python3\n---\n\n# Hello";
+        let doc_ast = parse_qmd_to_ast(content, "/project/notes.md");
+
+        let input = PipelineData::DocumentAst(doc_ast);
+        stage.run(input, &mut ctx).await.unwrap();
+
+        assert_eq!(ctx.diagnostics.len(), 1, "{:?}", ctx.diagnostics);
+        assert_eq!(ctx.diagnostics[0].code.as_deref(), Some("Q-2-40"));
+    }
+
+    #[tokio::test]
+    async fn md_without_engine_metadata_is_silent() {
+        let stage = EngineExecutionStage::new();
+        let mut ctx = make_test_context_for("/project/notes.md");
+
+        let content = b"---\ntitle: Test\n---\n\n# Hello\n\nWorld";
+        let doc_ast = parse_qmd_to_ast(content, "/project/notes.md");
+
+        let input = PipelineData::DocumentAst(doc_ast);
+        stage.run(input, &mut ctx).await.unwrap();
+        assert!(ctx.diagnostics.is_empty(), "{:?}", ctx.diagnostics);
+    }
+
+    #[tokio::test]
+    async fn md_with_explicit_markdown_engine_is_silent() {
+        // `engine: markdown` asks for exactly what `.md` does anyway;
+        // warning would be noise.
+        let stage = EngineExecutionStage::new();
+        let mut ctx = make_test_context_for("/project/notes.md");
+
+        let content = b"---\ntitle: Test\nengine: markdown\n---\n\n# Hello";
+        let doc_ast = parse_qmd_to_ast(content, "/project/notes.md");
+
+        let input = PipelineData::DocumentAst(doc_ast);
+        stage.run(input, &mut ctx).await.unwrap();
+        assert!(ctx.diagnostics.is_empty(), "{:?}", ctx.diagnostics);
+    }
+
+    #[tokio::test]
+    async fn md_with_unknown_engine_gets_q_2_40_not_fallback_warning() {
+        // The `.md` skip happens before engine resolution, so the
+        // "not available in this build" fallback warning must not
+        // also fire.
+        let stage = EngineExecutionStage::new();
+        let mut ctx = make_test_context_for("/project/notes.md");
+
+        let content = b"---\ntitle: Test\nengine: unknown-engine\n---\n\n# Hello";
+        let doc_ast = parse_qmd_to_ast(content, "/project/notes.md");
+
+        let input = PipelineData::DocumentAst(doc_ast);
+        stage.run(input, &mut ctx).await.unwrap();
+        assert_eq!(ctx.diagnostics.len(), 1, "{:?}", ctx.diagnostics);
+        assert_eq!(ctx.diagnostics[0].code.as_deref(), Some("Q-2-40"));
     }
 
     #[tokio::test]

--- a/crates/quarto-core/src/transforms/navigation_href.rs
+++ b/crates/quarto-core/src/transforms/navigation_href.rs
@@ -182,7 +182,10 @@ pub fn resolve_href_for_html(
         }
         // An index is present but the path didn't resolve — the user
         // has a project context and this looks like an intended
-        // internal link, so surface it.
+        // internal link, so surface it. Deliberately `.qmd`-only
+        // (bd-6d2wj4zp D6): a `.md` miss may legitimately be a
+        // static resource (`.md` renders only when opted into the
+        // render list), so it passes through silently.
         if path_part.ends_with(".qmd") {
             diagnostics.push(missing_document_warning(&surface, path_part, location));
         }
@@ -212,10 +215,11 @@ pub fn is_external(href: &str) -> bool {
 /// Pass-1 / static counterpart to [`resolve_doc_relative_href`].
 ///
 /// Returns the project-relative source path that an internal
-/// `.qmd` reference resolves to (after `..` / `.` / leading-`/`
-/// normalization), regardless of whether the target actually
-/// exists in the project. Returns `None` for external URLs,
-/// fragment-only anchors, and non-`.qmd` targets.
+/// renderable-source reference (`.qmd` or `.md` — bd-6d2wj4zp)
+/// resolves to (after `..` / `.` / leading-`/` normalization),
+/// regardless of whether the target actually exists in the project.
+/// Returns `None` for external URLs, fragment-only anchors, and
+/// non-source targets.
 ///
 /// **Why no index parameter?** Pass-1 (Phase 8 sub-phase 8.0d's
 /// `LinkResolutionStage`) runs *before* the project's
@@ -240,9 +244,10 @@ pub fn resolve_doc_relative_target(raw: &str, source_relative: &str) -> Option<P
         Some(i) => &raw[..i],
         None => raw,
     };
-    if !path_part.ends_with(".qmd") {
-        // Non-.qmd hrefs are static resources, not project documents.
-        // Match the diagnostic gating in resolve_doc_relative_href.
+    if !(path_part.ends_with(".qmd") || path_part.ends_with(".md")) {
+        // Other hrefs are static resources, not project documents.
+        // (`.md` targets that turn out not to be in the render list
+        // are dropped by the graph builder's index lookup.)
         return None;
     }
     let project_relative = resolve_to_project_root(source_relative, path_part);
@@ -328,8 +333,9 @@ pub fn resolve_doc_relative_href(
 
     // Miss. Surface a warning iff the target *looks like* a
     // renderable document (matches the `.qmd`-only convention from
-    // `resolve_href_for_html`). Non-qmd misses pass through silent
-    // since they may legitimately be static resources.
+    // `resolve_href_for_html`). Non-qmd misses — including `.md`,
+    // deliberately (bd-6d2wj4zp D6) — pass through silent since
+    // they may legitimately be static resources.
     if path_part.ends_with(".qmd") {
         diagnostics.push(missing_document_warning(
             &NavSurface::BodyLink,
@@ -1272,6 +1278,28 @@ mod tests {
     fn target_simple_qmd_resolves() {
         assert_eq!(
             resolve_doc_relative_target("about.qmd", "index.qmd"),
+            Some(PathBuf::from("about.qmd"))
+        );
+    }
+
+    /// bd-6d2wj4zp S7: `.md` targets are renderable sources too —
+    /// they must produce dependency-graph edges like `.qmd`. The
+    /// graph builder filters against the actual index, so a `.md`
+    /// that isn't in the render list becomes a no-op edge.
+    #[test]
+    fn target_md_resolves_like_qmd() {
+        assert_eq!(
+            resolve_doc_relative_target("notes.md", "index.qmd"),
+            Some(PathBuf::from("notes.md"))
+        );
+        assert_eq!(
+            resolve_doc_relative_target("../guide.md", "docs/api.qmd"),
+            Some(PathBuf::from("guide.md"))
+        );
+        // A `.md` source document linking to a `.qmd` (and vice
+        // versa) both extract.
+        assert_eq!(
+            resolve_doc_relative_target("about.qmd", "notes.md"),
             Some(PathBuf::from("about.qmd"))
         );
     }

--- a/crates/quarto-error-catalog/error_catalog.json
+++ b/crates/quarto-error-catalog/error_catalog.json
@@ -419,6 +419,13 @@
     "docs_url": "https://quarto.org/docs/errors/markdown/Q-2-39",
     "since_version": "99.9.9"
   },
+  "Q-2-40": {
+    "subsystem": "markdown",
+    "title": "Engine Specification Ignored for Markdown Input",
+    "message_template": "`.md` documents never execute engines; the engine specification has no effect.",
+    "docs_url": "https://quarto.org/docs/errors/markdown/Q-2-40",
+    "since_version": "99.9.9"
+  },
   "Q-3-1": {
     "subsystem": "writer",
     "title": "IO Error During Write",

--- a/crates/quarto-error-catalog/src/lib.rs
+++ b/crates/quarto-error-catalog/src/lib.rs
@@ -89,6 +89,24 @@ mod tests {
         assert!(ERROR_CATALOG.get("Q-999-999").is_none()); // quarto-error-code-audit-ignore
     }
 
+    // bd-6d2wj4zp: Q-2-40 catalog presence (`.md` engine-ignored warning).
+    #[test]
+    fn error_catalog_has_q_2_40() {
+        let info = ERROR_CATALOG
+            .get("Q-2-40")
+            .expect("Q-2-40 must be in the catalog");
+        assert_eq!(info.subsystem, "markdown");
+        assert_eq!(
+            info.title,
+            "Engine Specification Ignored for Markdown Input"
+        );
+        assert!(
+            info.message_template.contains("never execute engines"),
+            "Q-2-40 message must state the policy; got: {}",
+            info.message_template
+        );
+    }
+
     // L8 / bd-rqgx: Q-12-14 catalog presence.
     #[test]
     fn error_catalog_has_q_12_14() {

--- a/crates/quarto-hub/src/context.rs
+++ b/crates/quarto-hub/src/context.rs
@@ -57,7 +57,7 @@ pub struct HubConfig {
     pub watch_debounce_ms: u64,
 
     /// Which files surface as watch events. See [`WatchFilter`].
-    /// Default: `WatchFilter::QmdOnly` (legacy hub behaviour).
+    /// Default: `WatchFilter::SourcesOnly` (hub behaviour: `.qmd` + `.md`).
     /// `quarto-preview` overrides this to `WatchFilter::PreviewBroad`
     /// so config + asset edits trigger re-render.
     pub watch_filter: WatchFilter,

--- a/crates/quarto-hub/src/discovery.rs
+++ b/crates/quarto-hub/src/discovery.rs
@@ -1,6 +1,13 @@
 //! Project file discovery
 //!
-//! Walks the project directory to find `.qmd` files, config files, and binary resources.
+//! Walks the project directory to find source files (`.qmd`, `.md`), config
+//! files, and binary resources.
+//!
+//! `.md` is a source file at this layer (bd-6d2wj4zp, D10): sync and watch
+//! are extension-based, symmetric with `.qmd`. Whether a given `.md` is
+//! actually *rendered* is decided later by quarto-core's project discovery
+//! (render-list opt-in) — the hub layer deliberately does not parse
+//! `_quarto.yml` to find out.
 
 use std::path::{Path, PathBuf};
 
@@ -12,7 +19,9 @@ use crate::resource::is_binary_extension;
 /// Discovered files in a Quarto project.
 #[derive(Debug, Default)]
 pub struct ProjectFiles {
-    /// All discovered `.qmd` files (paths relative to project root)
+    /// All discovered source files — `.qmd` and `.md` (paths relative to
+    /// project root). The historical name predates `.md` support; both
+    /// extensions ride this list identically.
     pub qmd_files: Vec<PathBuf>,
 
     /// Config files (e.g., `_quarto.yml`, paths relative to project root)
@@ -121,10 +130,10 @@ impl ProjectFiles {
                 // Get file extension for further checks
                 let ext = path.extension().and_then(|e| e.to_str());
 
-                // Check for .qmd files
-                if ext == Some("qmd") {
+                // Check for source files (.qmd, .md — see module docs re D10)
+                if ext == Some("qmd") || ext == Some("md") {
                     if let Ok(relative) = path.strip_prefix(project_root) {
-                        debug!(?relative, "Discovered .qmd file");
+                        debug!(?relative, "Discovered source file");
                         files.qmd_files.push(relative.to_path_buf());
                     }
                     continue;
@@ -341,6 +350,37 @@ mod tests {
                 .qmd_files
                 .contains(&PathBuf::from("chapters/intro.qmd"))
         );
+    }
+
+    /// bd-6d2wj4zp Phase 5 (D10): `.md` is a source file hub-wide, synced
+    /// into the VFS exactly like `.qmd`. The sync layer is extension-based;
+    /// render-list membership stays a render-time (quarto-core discovery)
+    /// decision — so even never-rendered `.md` (a README) syncs as text.
+    #[test]
+    fn test_discover_md_files_as_sources() {
+        let temp = TempDir::new().unwrap();
+
+        fs::write(temp.path().join("index.qmd"), "# Hello").unwrap();
+        fs::write(temp.path().join("notes.md"), "# Notes").unwrap();
+        fs::write(temp.path().join("README.md"), "# Readme").unwrap();
+        fs::create_dir(temp.path().join("chapters")).unwrap();
+        fs::write(temp.path().join("chapters/guide.md"), "# Guide").unwrap();
+
+        let files = ProjectFiles::discover(temp.path());
+
+        assert_eq!(files.qmd_files.len(), 4);
+        assert!(files.qmd_files.contains(&PathBuf::from("notes.md")));
+        assert!(files.qmd_files.contains(&PathBuf::from("README.md")));
+        assert!(
+            files
+                .qmd_files
+                .contains(&PathBuf::from("chapters/guide.md"))
+        );
+        assert!(files.qmd_files.contains(&PathBuf::from("index.qmd")));
+
+        // .md rides the text sync path (automerge Text doc, vfsReadFile).
+        let text: Vec<_> = files.text_files().collect();
+        assert!(text.contains(&&PathBuf::from("notes.md")));
     }
 
     #[test]

--- a/crates/quarto-hub/src/watch.rs
+++ b/crates/quarto-hub/src/watch.rs
@@ -1,8 +1,8 @@
 //! Filesystem watching for continuous sync
 //!
-//! This module provides filesystem watching capabilities to detect when .qmd files
-//! are modified on disk, enabling real-time synchronization between the filesystem
-//! and automerge documents.
+//! This module provides filesystem watching capabilities to detect when source
+//! files (`.qmd`, `.md`) are modified on disk, enabling real-time
+//! synchronization between the filesystem and automerge documents.
 
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -30,16 +30,19 @@ pub enum WatchEvent {
 /// Which kinds of files the watcher should surface events for.
 ///
 /// The two modes correspond to the two consumers of the hub today:
-/// `quarto hub` (a long-lived sync server, which historically only
-/// observed `.qmd` content) and `q2 preview` (which needs config,
-/// metadata, custom-component, and asset edits to trigger re-render).
+/// `quarto hub` (a long-lived sync server, which only observes source
+/// content) and `q2 preview` (which needs config, metadata,
+/// custom-component, and asset edits to trigger re-render).
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum WatchFilter {
-    /// Legacy hub behaviour: only `.qmd` files surface events.
+    /// Hub default: only source files (`.qmd`, `.md`) surface events.
+    /// (`.md` joined `.qmd` with bd-6d2wj4zp D10 — sync and watch are
+    /// extension-based; render-list membership is decided at render
+    /// time, not here.)
     #[default]
-    QmdOnly,
+    SourcesOnly,
     /// Broadened filter for `q2 preview`. Accepts, in addition to
-    /// `.qmd`:
+    /// source files:
     ///   - `_quarto.yml` / `_quarto.yaml` (project config)
     ///   - `_metadata.yml` / `_metadata.yaml` (section config)
     ///   - `.png`, `.jpg`, `.jpeg`, `.gif`, `.svg`, `.webp` (media)
@@ -53,7 +56,7 @@ impl WatchFilter {
     /// Returns true if `path` should surface as a [`WatchEvent::Modified`].
     pub fn accepts(self, path: &Path) -> bool {
         match self {
-            Self::QmdOnly => is_qmd_file(path),
+            Self::SourcesOnly => is_source_file(path),
             Self::PreviewBroad => is_preview_relevant(path),
         }
     }
@@ -240,10 +243,10 @@ impl FileWatcher {
     }
 }
 
-/// Check if a path is a .qmd file.
-fn is_qmd_file(path: &Path) -> bool {
+/// Check if a path is a source file (`.qmd` or `.md`).
+fn is_source_file(path: &Path) -> bool {
     path.extension()
-        .is_some_and(|ext| ext.eq_ignore_ascii_case("qmd"))
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("qmd") || ext.eq_ignore_ascii_case("md"))
 }
 
 /// Check if a path matches the [`WatchFilter::PreviewBroad`] allow-list.
@@ -253,7 +256,7 @@ fn is_qmd_file(path: &Path) -> bool {
 /// and makes it tolerant of nested project layouts (e.g. a sub-section
 /// `posts/_metadata.yml`).
 fn is_preview_relevant(path: &Path) -> bool {
-    if is_qmd_file(path) {
+    if is_source_file(path) {
         return true;
     }
 
@@ -292,24 +295,39 @@ mod tests {
     use tempfile::TempDir;
 
     #[test]
-    fn test_is_qmd_file() {
-        assert!(is_qmd_file(Path::new("test.qmd")));
-        assert!(is_qmd_file(Path::new("test.QMD")));
-        assert!(is_qmd_file(Path::new("/path/to/file.qmd")));
-        assert!(!is_qmd_file(Path::new("test.md")));
-        assert!(!is_qmd_file(Path::new("test.txt")));
-        assert!(!is_qmd_file(Path::new("test")));
+    fn test_is_source_file() {
+        assert!(is_source_file(Path::new("test.qmd")));
+        assert!(is_source_file(Path::new("test.QMD")));
+        assert!(is_source_file(Path::new("/path/to/file.qmd")));
+        // bd-6d2wj4zp Phase 5 (D10): .md is a source file.
+        assert!(is_source_file(Path::new("test.md")));
+        assert!(is_source_file(Path::new("test.MD")));
+        assert!(!is_source_file(Path::new("test.txt")));
+        assert!(!is_source_file(Path::new("test")));
+    }
+
+    /// bd-6d2wj4zp Phase 5 (D10): `.md` is a source file for watching,
+    /// symmetric with the sync layer — both filters must surface `.md`
+    /// edits so a rendered `.md` page live-updates in the preview and
+    /// stays in sync on the hub. (Whether a given `.md` triggers a
+    /// re-render is dep-filtered downstream in the SPA, not here.)
+    #[test]
+    fn test_filters_accept_md_as_source() {
+        assert!(WatchFilter::SourcesOnly.accepts(Path::new("doc.md")));
+        assert!(WatchFilter::SourcesOnly.accepts(Path::new("doc.MD")));
+        assert!(WatchFilter::PreviewBroad.accepts(Path::new("doc.md")));
+        assert!(WatchFilter::PreviewBroad.accepts(Path::new("posts/README.md")));
     }
 
     #[test]
-    fn test_watch_filter_qmd_only() {
-        let f = WatchFilter::QmdOnly;
+    fn test_watch_filter_sources_only() {
+        let f = WatchFilter::SourcesOnly;
         assert!(f.accepts(Path::new("doc.qmd")));
         assert!(f.accepts(Path::new("doc.QMD")));
+        assert!(f.accepts(Path::new("doc.md")));
         assert!(!f.accepts(Path::new("_quarto.yml")));
         assert!(!f.accepts(Path::new("image.png")));
         assert!(!f.accepts(Path::new("Component.tsx")));
-        assert!(!f.accepts(Path::new("doc.md")));
     }
 
     #[test]
@@ -352,8 +370,8 @@ mod tests {
     fn test_watch_filter_preview_broad_rejects() {
         let f = WatchFilter::PreviewBroad;
 
-        // Random non-matching files.
-        assert!(!f.accepts(Path::new("README.md")));
+        // Random non-matching files. (README.md moved to the accepts
+        // side with bd-6d2wj4zp D10 — .md is a source file now.)
         assert!(!f.accepts(Path::new("notes.txt")));
         assert!(!f.accepts(Path::new("data.csv")));
 
@@ -399,7 +417,7 @@ mod tests {
             &temp_path,
             WatchConfig {
                 debounce_ms: 100,
-                filter: WatchFilter::QmdOnly,
+                filter: WatchFilter::SourcesOnly,
                 single_file: None,
                 single_file_deps: Vec::new(),
             },
@@ -422,7 +440,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_watcher_ignores_non_qmd_files() {
+    async fn test_watcher_ignores_non_source_files() {
         let temp = TempDir::new().unwrap();
         // Canonicalize to handle macOS /var -> /private/var symlinks
         let temp_path = temp.path().canonicalize().unwrap();
@@ -439,7 +457,7 @@ mod tests {
             &temp_path,
             WatchConfig {
                 debounce_ms: 100,
-                filter: WatchFilter::QmdOnly,
+                filter: WatchFilter::SourcesOnly,
                 single_file: None,
                 single_file_deps: Vec::new(),
             },
@@ -499,11 +517,11 @@ mod tests {
         }
     }
 
-    /// QmdOnly watcher must *not* surface a `_quarto.yml` edit. This
+    /// SourcesOnly watcher must *not* surface a `_quarto.yml` edit. This
     /// guards against an accidental future broadening of the default
     /// filter that would change hub semantics.
     #[tokio::test]
-    async fn test_watcher_qmd_only_ignores_quarto_yml() {
+    async fn test_watcher_sources_only_ignores_quarto_yml() {
         let temp = TempDir::new().unwrap();
         let temp_path = temp.path().canonicalize().unwrap();
         let yml_path = temp_path.join("_quarto.yml");
@@ -517,7 +535,7 @@ mod tests {
             &temp_path,
             WatchConfig {
                 debounce_ms: 100,
-                filter: WatchFilter::QmdOnly,
+                filter: WatchFilter::SourcesOnly,
                 single_file: None,
                 single_file_deps: Vec::new(),
             },

--- a/crates/quarto-preview/src/capture_driver.rs
+++ b/crates/quarto-preview/src/capture_driver.rs
@@ -629,6 +629,42 @@ mod tests {
         assert_eq!(entry.staleness, Some(false));
     }
 
+    /// bd-6d2wj4zp Phase 5 (S5): `.md` inputs never execute engines —
+    /// even with an explicit engine spec and code cells. Now that the
+    /// hub syncs `.md` into `ProjectFiles::qmd_files` (D10), the eager
+    /// capture walk must skip them, or preview would execute engines
+    /// the render path refuses to run (Q-2-40 warns and skips there).
+    #[tokio::test]
+    async fn md_doc_with_engine_spec_records_no_capture() {
+        let (_tmp, ctx, runtime) = build_ctx_with_files(&[(
+            "notes.md",
+            "---\nengine: test-passthrough\n---\n\n```{test-passthrough}\n42\n```\n",
+        )])
+        .await;
+
+        // Non-vacuity: the .md must actually be in the synced source set
+        // (D10) — otherwise this test would pass for the wrong reason.
+        assert!(
+            ctx.project_files()
+                .expect("project mode")
+                .qmd_files
+                .contains(&std::path::PathBuf::from("notes.md")),
+            "notes.md should be discovered into the hub source set"
+        );
+
+        let count = record_eager_captures(
+            ctx.clone(),
+            runtime,
+            Some(make_registry()),
+            EnginePolicy::Manual,
+            &cache_dir_for_test(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(count, 0, ".md must be skipped by the capture walk (S5)");
+        assert!(!ctx.index().has_capture("notes.md"));
+    }
+
     #[tokio::test]
     async fn capture_binary_doc_round_trips_through_samod() {
         let (_tmp, ctx, runtime) = build_ctx_with_files(&[(

--- a/crates/quarto/src/commands/preview.rs
+++ b/crates/quarto/src/commands/preview.rs
@@ -366,12 +366,13 @@ pub(crate) fn resolve_project_and_initial_page(canonical: &Path) -> Result<Resol
         .with_context(|| format!("reading metadata of {}", canonical.display()))?;
 
     if metadata.is_dir() {
-        let index = canonical.join("index.qmd");
-        let initial = if index.is_file() {
-            Some("index.qmd".to_string())
-        } else {
-            None
-        };
+        // Prefer `index.qmd`; fall back to `index.md` (bd-6d2wj4zp Phase 5 —
+        // a render-list `.md` can be the landing page). No index file →
+        // None, and the SPA falls through to its own selection.
+        let initial = ["index.qmd", "index.md"]
+            .into_iter()
+            .find(|name| canonical.join(name).is_file())
+            .map(str::to_string);
         return Ok(ResolvedProject {
             root: canonical.to_path_buf(),
             initial_page: initial,
@@ -535,6 +536,31 @@ mod tests {
         assert_eq!(resolved.root, canonical);
         assert_eq!(resolved.initial_page.as_deref(), Some("index.qmd"));
         assert!(resolved.single_file.is_none());
+    }
+
+    /// bd-6d2wj4zp Phase 5: a project whose landing page is a
+    /// render-list `.md` (e.g. the Connect docs port) should boot the
+    /// preview on `index.md` when there is no `index.qmd`.
+    #[test]
+    fn resolve_dir_with_only_index_md_returns_index_md() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("index.md"), "# index").unwrap();
+        std::fs::write(tmp.path().join("about.qmd"), "# about").unwrap();
+        let canonical = tmp.path().canonicalize().unwrap();
+        let resolved = resolve_project_and_initial_page(&canonical).unwrap();
+        assert_eq!(resolved.initial_page.as_deref(), Some("index.md"));
+    }
+
+    /// `index.qmd` wins over `index.md` when both exist — `.qmd` is
+    /// the canonical source; also keeps the pre-`.md` behavior stable.
+    #[test]
+    fn resolve_dir_prefers_index_qmd_over_index_md() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("index.qmd"), "# q").unwrap();
+        std::fs::write(tmp.path().join("index.md"), "# m").unwrap();
+        let canonical = tmp.path().canonicalize().unwrap();
+        let resolved = resolve_project_and_initial_page(&canonical).unwrap();
+        assert_eq!(resolved.initial_page.as_deref(), Some("index.qmd"));
     }
 
     #[test]

--- a/crates/quarto/src/commands/render.rs
+++ b/crates/quarto/src/commands/render.rs
@@ -291,9 +291,12 @@ pub fn classify_inputs(
         if resolved.len() > 1 {
             return Err(DispatchError::MultiArgNonProject);
         }
-        // Single arg outside any project: must be a `.qmd` file
-        // (single-doc fallthrough). Directories outside any project
-        // are not a meaningful render target — we error.
+        // Single arg outside any project: a renderable source file
+        // (`.qmd` or `.md` — bd-6d2wj4zp) as the single-doc
+        // fallthrough. Directories outside any project are not a
+        // meaningful render target — we error. Note the extension is
+        // not checked here: any file becomes a SingleDoc, and
+        // non-source files fail downstream at parse.
         let only = &resolved[0];
         let is_dir = runtime
             .is_dir(only)
@@ -1182,7 +1185,15 @@ fn detect_single_input_format(inputs: &[String]) -> Option<String> {
         return None;
     }
     let path = std::path::Path::new(&inputs[0]);
-    if path.extension().and_then(|e| e.to_str()) != Some("qmd") || !path.is_file() {
+    // `.md` inputs read front matter exactly like `.qmd`
+    // (bd-6d2wj4zp S3/S4) — without this, a `.md` declaring a
+    // non-native format slips past the early "not yet supported"
+    // refusal below and renders HTML into a mismatched output file.
+    if !matches!(
+        path.extension().and_then(|e| e.to_str()),
+        Some("qmd" | "md")
+    ) || !path.is_file()
+    {
         return None;
     }
     let content = std::fs::read_to_string(path).ok()?;

--- a/crates/quarto/src/commands/render.rs
+++ b/crates/quarto/src/commands/render.rs
@@ -181,14 +181,13 @@ impl std::fmt::Display for DispatchError {
             ),
             DispatchError::NotInRenderList { path, project_dir } => write!(
                 f,
-                "{} is excluded from the render list of project {} \
-                 (check `project.render` in `_quarto.yml` and the \
-                 underscore/hidden file conventions).",
+                "{} is excluded from the render list of project {} ({}).",
                 path.display(),
-                project_dir.display()
+                project_dir.display(),
+                render_list_exclusion_hint(path),
             ),
             DispatchError::NoRenderableMatches { path } => {
-                write!(f, "No renderable `.qmd` files matched: {}", path.display())
+                write!(f, "No renderable source files matched: {}", path.display())
             }
             DispatchError::Discover(msg) => write!(f, "Project discovery failed: {msg}"),
         }
@@ -196,6 +195,22 @@ impl std::fmt::Display for DispatchError {
 }
 
 impl std::error::Error for DispatchError {}
+
+/// Why is this input outside the render list, and what should the
+/// user do about it? For `.md` inputs the overwhelmingly likely
+/// cause is the opt-in policy (bd-6d2wj4zp) — `.md` renders only
+/// when a `project.render` pattern matches it — so the generic
+/// underscore/hidden advice would mislead. Shared by the
+/// [`DispatchError`] `Display` impl and the `Q-7-6` diagnostic.
+fn render_list_exclusion_hint(path: &std::path::Path) -> &'static str {
+    if path.extension().and_then(|e| e.to_str()) == Some("md") {
+        "`.md` files render only when matched by a `project.render` pattern \
+         such as `\"**/*.md\"` in `_quarto.yml`"
+    } else {
+        "check `project.render` in `_quarto.yml` and the underscore/hidden \
+         file conventions"
+    }
+}
 
 /// Classify CLI input strings into a [`RenderTarget`].
 ///
@@ -1355,24 +1370,22 @@ fn dispatch_error_to_diagnostic(e: &DispatchError) -> DiagnosticMessage {
                 ))
                 .build()
         }
-        DispatchError::NotInRenderList { path, project_dir } => DiagnosticMessageBuilder::error(
-            "Input Excluded From Render List",
-        )
-        .with_code("Q-7-6")
-        .problem(format!(
-            "{} is excluded from the render list of project {}.",
-            path.display(),
-            project_dir.display()
-        ))
-        .add_hint(
-            "Check `project.render` in `_quarto.yml` and the underscore/hidden file conventions.",
-        )
-        .build(),
+        DispatchError::NotInRenderList { path, project_dir } => {
+            DiagnosticMessageBuilder::error("Input Excluded From Render List")
+                .with_code("Q-7-6")
+                .problem(format!(
+                    "{} is excluded from the render list of project {}.",
+                    path.display(),
+                    project_dir.display()
+                ))
+                .add_hint(format!("{}.", render_list_exclusion_hint(path)))
+                .build()
+        }
         DispatchError::NoRenderableMatches { path } => {
             DiagnosticMessageBuilder::error("No Renderable Files Matched")
                 .with_code("Q-7-7")
                 .problem(format!(
-                    "No renderable `.qmd` files matched: {}",
+                    "No renderable source files matched: {}",
                     path.display()
                 ))
                 .build()

--- a/crates/quarto/tests/integration/render_cli_e2e.rs
+++ b/crates/quarto/tests/integration/render_cli_e2e.rs
@@ -617,6 +617,39 @@ fn rendering_md_not_in_render_list_hints_at_optin() {
     );
 }
 
+/// bd-6d2wj4zp S5: an opted-in `.md` with an `engine:` spec renders
+/// successfully (passthrough, no execution) and warns with Q-2-40
+/// through the real diagnostic path.
+#[test]
+fn md_with_engine_spec_renders_with_q_2_40_warning() {
+    let temp = TempDir::new().unwrap();
+    let project = canonical(temp.path());
+    write_file(
+        &project.join("_quarto.yml"),
+        "project:\n  type: default\n  render:\n    - \"*.md\"\n",
+    );
+    write_file(
+        &project.join("notes.md"),
+        "---\ntitle: Notes\nengine: jupyter\n---\n\n# Hello\n\nplain text\n",
+    );
+
+    let out = run_q2(&project, &[]);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "the render itself must succeed; stderr: {stderr}",
+    );
+    assert!(
+        stderr.contains("Q-2-40"),
+        "expected the engine-ignored warning; got stderr: {stderr}",
+    );
+    let html = std::fs::read_to_string(project.join("notes.html")).expect("notes.html exists");
+    assert!(
+        html.contains("plain text"),
+        "content renders as plain markdown"
+    );
+}
+
 /// Regression guard for bd-87fu: native default-project renders
 /// must continue to write theme CSS to `{stem}_files/quarto/...`
 /// and embed a matching `<link>` in the HTML. The WASM-side fix

--- a/crates/quarto/tests/integration/render_cli_e2e.rs
+++ b/crates/quarto/tests/integration/render_cli_e2e.rs
@@ -650,6 +650,62 @@ fn md_with_engine_spec_renders_with_q_2_40_warning() {
     );
 }
 
+/// bd-6d2wj4zp D7: an output path equal to the input must refuse
+/// rather than silently replace the source with rendered HTML.
+/// (Before the guard, `--output <abs input path>` destroyed the
+/// source file.)
+#[test]
+fn output_equal_to_input_refuses_and_preserves_source() {
+    let temp = TempDir::new().unwrap();
+    let dir = canonical(temp.path());
+    let source = "---\ntitle: T\n---\n\nhello\n";
+    write_file(&dir.join("doc.qmd"), source);
+    let abs = dir.join("doc.qmd");
+
+    let out = run_q2(&dir, &["doc.qmd", "--output", abs.to_str().unwrap()]);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !out.status.success(),
+        "expected refusal when output == input; stderr: {stderr}",
+    );
+    assert!(
+        stderr.contains("overwrite"),
+        "error should explain the overwrite refusal; got stderr: {stderr}",
+    );
+    let after = std::fs::read_to_string(&abs).expect("source still exists");
+    assert_eq!(after, source, "source file must be untouched");
+}
+
+/// bd-6d2wj4zp S3: single-file format detection reads `.md` front
+/// matter exactly like `.qmd`. Pinned via the non-native bail-out:
+/// a `.md` declaring `format: pdf` must get the same early "not yet
+/// supported" refusal a `.qmd` gets — before the fix it rendered
+/// HTML bytes into a `p.pdf` file.
+#[test]
+fn md_with_non_native_format_gets_early_refusal_like_qmd() {
+    let temp = TempDir::new().unwrap();
+    let dir = canonical(temp.path());
+    write_file(
+        &dir.join("doc.md"),
+        "---\ntitle: T\nformat: pdf\n---\n\nhi\n",
+    );
+
+    let out = run_q2(&dir, &["doc.md"]);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !out.status.success(),
+        "expected refusal for non-native format; stderr: {stderr}",
+    );
+    assert!(
+        stderr.contains("not yet supported"),
+        "expected the same early bail-out a .qmd gets; got stderr: {stderr}",
+    );
+    assert!(
+        !dir.join("doc.pdf").exists(),
+        "must not write a fake .pdf output"
+    );
+}
+
 /// Regression guard for bd-87fu: native default-project renders
 /// must continue to write theme CSS to `{stem}_files/quarto/...`
 /// and embed a matching `<link>` in the HTML. The WASM-side fix

--- a/crates/quarto/tests/integration/render_cli_e2e.rs
+++ b/crates/quarto/tests/integration/render_cli_e2e.rs
@@ -706,6 +706,70 @@ fn md_with_non_native_format_gets_early_refusal_like_qmd() {
     );
 }
 
+/// bd-6d2wj4zp S7: render-list `.md` pages participate in navigation
+/// and body-link rewriting exactly like `.qmd` — the Connect-docs
+/// shape (`file: admin/index.md` in the sidebar, `[x](other.md)` in
+/// body text).
+#[test]
+fn md_pages_get_nav_and_body_links_rewritten() {
+    let temp = TempDir::new().unwrap();
+    let project = canonical(temp.path());
+    write_file(
+        &project.join("_quarto.yml"),
+        "project:\n  type: website\n  output-dir: _site\n  render:\n    - \"*.qmd\"\n    - \"*.md\"\n\
+         website:\n  title: T\n  sidebar:\n    contents:\n      - index.qmd\n      - text: Notes\n        file: notes.md\n",
+    );
+    write_file(
+        &project.join("index.qmd"),
+        "---\ntitle: Home\n---\n\nSee [the notes](notes.md).\n",
+    );
+    write_file(
+        &project.join("notes.md"),
+        "---\ntitle: Notes\n---\n\nBack [home](index.qmd).\n",
+    );
+
+    let out = run_q2(&project, &[]);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(out.status.success(), "render failed; stderr: {stderr}");
+
+    let index_html = std::fs::read_to_string(project.join("_site/index.html")).expect("index.html");
+    assert!(
+        index_html.contains("href=\"notes.html\""),
+        "body link [the notes](notes.md) must rewrite to notes.html; got:\n{}",
+        &index_html[..index_html.len().min(4000)]
+    );
+
+    let notes_html = std::fs::read_to_string(project.join("_site/notes.html")).expect("notes.html");
+    assert!(
+        notes_html.contains("href=\"index.html\""),
+        "body link [home](index.qmd) from a .md page must rewrite to index.html"
+    );
+    // The sidebar entry `file: notes.md` must resolve on both pages.
+    assert!(
+        notes_html.contains("notes.html") && index_html.contains("notes.html"),
+        "sidebar entry for notes.md must resolve to notes.html on every page"
+    );
+
+    // Subset render (Mode B): Pass 1 profiles every project file
+    // regardless of mode, so links into a `.md` page must still
+    // rewrite when only the linking page is re-rendered. (The `.md`
+    // dependency-graph *edges* are pinned at the unit level in
+    // navigation_href.rs — their pass-2 augmentation effect only
+    // shows with always-render pages, which are listing territory.)
+    std::fs::remove_file(project.join("_site/index.html")).unwrap();
+    let out = run_q2(&project, &["index.qmd"]);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "subset render failed; stderr: {stderr}"
+    );
+    let index_html = std::fs::read_to_string(project.join("_site/index.html")).expect("index.html");
+    assert!(
+        index_html.contains("href=\"notes.html\""),
+        "subset render must still rewrite the body link into the .md page"
+    );
+}
+
 /// Regression guard for bd-87fu: native default-project renders
 /// must continue to write theme CSS to `{stem}_files/quarto/...`
 /// and embed a matching `<link>` in the HTML. The WASM-side fix

--- a/crates/quarto/tests/integration/render_cli_e2e.rs
+++ b/crates/quarto/tests/integration/render_cli_e2e.rs
@@ -559,6 +559,64 @@ fn empty_default_project_with_no_qmd_emits_diagnostic() {
     );
 }
 
+/// bd-6d2wj4zp: `.md` files render only when opted in via
+/// `project.render`. When that opt-in is the *reason* the render set
+/// came up empty, `Q-PROJECT-EMPTY` must say so — otherwise the
+/// default reads as "Quarto silently ignored my files".
+#[test]
+fn empty_project_with_md_files_hints_at_render_list_optin() {
+    let temp = TempDir::new().unwrap();
+    let project = canonical(temp.path());
+    write_file(&project.join("_quarto.yml"), "project:\n  type: default\n");
+    write_file(&project.join("notes.md"), "# notes\n");
+    write_file(&project.join("docs/guide.md"), "# guide\n");
+    // Excluded `.md` must not inflate the count.
+    write_file(&project.join("README.md"), "# readme\n");
+
+    let out = run_q2(&project, &[]);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !out.status.success(),
+        "expected non-zero exit on empty render set; stderr: {stderr}",
+    );
+    assert!(
+        stderr.contains("2 `.md` file"),
+        "hint should count the opt-in candidates; got stderr: {stderr}",
+    );
+    assert!(
+        stderr.contains("**/*.md"),
+        "hint should show the opt-in pattern; got stderr: {stderr}",
+    );
+}
+
+/// bd-6d2wj4zp: `q2 render notes.md` inside a project whose render
+/// list doesn't include it fails with Q-7-6 — and because the real
+/// cause is the `.md` opt-in policy (not underscore/hidden rules),
+/// the hint must say how to opt the file in.
+#[test]
+fn rendering_md_not_in_render_list_hints_at_optin() {
+    let temp = TempDir::new().unwrap();
+    let project = canonical(temp.path());
+    write_file(&project.join("_quarto.yml"), "project:\n  type: default\n");
+    write_file(&project.join("index.qmd"), "---\ntitle: T\n---\n\nhi\n");
+    write_file(&project.join("notes.md"), "# notes\n");
+
+    let out = run_q2(&project, &["notes.md"]);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !out.status.success(),
+        "expected non-zero exit for an un-opted-in .md; stderr: {stderr}",
+    );
+    assert!(
+        stderr.contains("Q-7-6") || stderr.contains("excluded from the render list"),
+        "expected the render-list exclusion diagnostic; got stderr: {stderr}",
+    );
+    assert!(
+        stderr.contains("**/*.md"),
+        "hint should explain the `.md` opt-in; got stderr: {stderr}",
+    );
+}
+
 /// Regression guard for bd-87fu: native default-project renders
 /// must continue to write theme CSS to `{stem}_files/quarto/...`
 /// and embed a matching `<link>` in the HTML. The WASM-side fix

--- a/crates/quarto/tests/integration/revealjs_cli.rs
+++ b/crates/quarto/tests/integration/revealjs_cli.rs
@@ -90,6 +90,32 @@ fn front_matter_format_revealjs_yields_reveal_deck() {
     );
 }
 
+/// bd-6d2wj4zp S3: a standalone `.md` input honors front-matter
+/// `format:` exactly like a `.qmd` — before, the detection was
+/// `.qmd`-gated and `.md` decks silently fell back to plain HTML.
+#[test]
+fn md_front_matter_format_revealjs_yields_reveal_deck() {
+    let temp = TempDir::new().unwrap();
+    let dir = temp.path();
+    write_file(&dir.join("talk.md"), DECK);
+
+    let out = run_q2_render(dir, &["talk.md"]);
+    assert!(
+        out.status.success(),
+        "q2 render talk.md failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let html = read(&dir.join("talk.html"));
+    assert!(
+        html.contains("class=\"reveal\""),
+        "front-matter `format: revealjs` in a .md (no --to) must render a \
+         reveal deck, not plain HTML; got {} bytes",
+        html.len()
+    );
+}
+
 /// Explicit `--to revealjs` also works.
 #[test]
 fn explicit_to_revealjs_yields_reveal_deck() {

--- a/crates/wasm-quarto-hub-client/Cargo.lock
+++ b/crates/wasm-quarto-hub-client/Cargo.lock
@@ -377,7 +377,7 @@ dependencies = [
 
 [[package]]
 name = "comrak-to-pandoc"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "comrak",
  "hashlink",
@@ -2074,7 +2074,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-analysis"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "quarto-error-reporting",
  "quarto-pandoc-types",
@@ -2096,7 +2096,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-brand"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "pathdiff",
  "quarto-util",
@@ -2107,7 +2107,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-citeproc"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "glob",
  "hashlink",
@@ -2138,7 +2138,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-core"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2190,7 +2190,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-csl"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "quarto-error-reporting",
  "quarto-source-map",
@@ -2241,7 +2241,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-highlight"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "once_cell",
  "quarto-highlight-encoding",
@@ -2267,7 +2267,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-highlight-encoding"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2275,7 +2275,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-lsp-core"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "pampa",
  "pollster",
@@ -2296,7 +2296,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-navigation"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "quarto-config",
  "quarto-pandoc-types",
@@ -2331,7 +2331,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-project-create"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "quarto-doctemplate",
  "serde",
@@ -2341,7 +2341,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-sass"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "include_dir",
  "once_cell",
@@ -2371,7 +2371,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-system-runtime"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -2388,7 +2388,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-trace"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "flate2",
  "serde",
@@ -2406,7 +2406,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-util"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -2414,7 +2414,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-xml"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "quarto-error-reporting",
  "quarto-source-map",
@@ -4021,7 +4021,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-printf-fmt"
-version = "0.11.0"
+version = "0.12.0"
 
 [[package]]
 name = "wasm-quarto-hub-client"

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -28,6 +28,7 @@ website:
           contents:
             - guides/authoring/index.qmd
             - guides/projects/create.qmd
+            - guides/projects/render-list.qmd
             - guides/projects/scripts.qmd
             - guides/publishing/index.qmd
     - id: Authoring

--- a/docs/errors/markdown/Q-2-40.qmd
+++ b/docs/errors/markdown/Q-2-40.qmd
@@ -1,0 +1,48 @@
+---
+title: "Engine Specification Ignored for Markdown Input"
+description: "A .md document declared an execution engine; .md files never execute code, so the specification has no effect."
+code: Q-2-40
+subsystem: markdown
+status: stub
+since: "99.9.9"
+categories:
+  - markdown
+---
+
+# `Q-2-40` — Engine Specification Ignored for Markdown Input
+
+> `.md` documents never execute engines; the engine specification has
+> no effect.
+
+## What this means
+
+A `.md` file's front matter declared an execution engine — either
+explicitly:
+
+```yaml
+---
+title: My notes
+engine: jupyter
+---
+```
+
+or implicitly, via an engine-specific top-level key:
+
+```yaml
+---
+title: My notes
+jupyter:
+  kernel: python3
+---
+```
+
+In Quarto 2, plain `.md` files support the full Quarto markdown
+dialect (shortcodes, divs, cross-references, …) but never execute
+code. The engine specification is ignored: the document still renders,
+code cells pass through as ordinary code blocks, and nothing runs.
+
+## How to fix it
+
+- If the document needs executable code, rename it to `.qmd`.
+- If it doesn't, delete the `engine:` (or `jupyter:` / `knitr:`) key
+  from its front matter.

--- a/docs/guides/projects/render-list.qmd
+++ b/docs/guides/projects/render-list.qmd
@@ -1,0 +1,88 @@
+---
+title: "The render list: choosing which files render"
+---
+
+## Overview
+
+When you run `q2 render` on a project, Quarto builds a **render
+list**: the set of source files that become pages of your site. You
+control it with the `project.render` key in `_quarto.yml`:
+
+```yaml
+project:
+  type: website
+  render:
+    - "**/*.qmd"
+    - "!drafts/**"
+```
+
+Each entry is a glob, matched against paths relative to the project
+root. Entries starting with `!` are exclusions; an exclusion applies
+to the whole list, wherever it appears. A bare directory name means
+everything renderable beneath it.
+
+## The default
+
+Omitting `project.render` is exactly equivalent to writing:
+
+```yaml
+project:
+  render:
+    - "**/*.qmd"
+```
+
+That is: every `.qmd` file in the project, wherever it lives. A render
+list containing only exclusions subtracts from that same default —
+`render: ["!drafts/**"]` means "all `.qmd` files except those under
+`drafts/`".
+
+## Rendering `.md` files
+
+Plain Markdown files can be full members of a Quarto project — they
+support the complete Quarto markdown dialect (shortcodes, divs,
+cross-references, navigation, themes) and render exactly like `.qmd`
+files, with one difference: **`.md` files never execute code**.
+
+`.md` files are opt-in: they render only when a `project.render`
+pattern you wrote matches them. Add them alongside your `.qmd` globs:
+
+```yaml
+project:
+  render:
+    - "**/*.qmd"
+    - "**/*.md"
+    - "!news/NEWS.md"
+```
+
+Any pattern you write can opt them in — `chapters/*`, a literal
+`notes.md`, or an extension glob all work. What never opts them in is
+the default: a project without a `render:` key renders `.qmd` only.
+
+Because `.md` files never execute code, an `engine:` specification in
+a `.md` file's front matter has no effect. Quarto warns about it
+([`Q-2-40`](/errors/markdown/Q-2-40.qmd)) and renders the document
+without execution; rename the file to `.qmd` if you need executable
+code.
+
+## Files that never render
+
+Some files are excluded from the render list even when a pattern
+matches them:
+
+- files and directories whose name starts with `_` (partials,
+  metadata) or `.` (hidden);
+- anything under `node_modules/` or the output directory;
+- `README` files (any extension, any capitalization);
+- agent-instruction Markdown: `CLAUDE.md`, `CLAUDE.local.md`,
+  `AGENTS.md`, `AGENTS.local.md`, and `*.llms.md` companions.
+
+A render entry that names one of these — or that matches nothing at
+all — produces a warning
+([`Q-5-13`](/errors/project/Q-5-13.qmd)) so a silent gap in your site
+doesn't go unnoticed.
+
+## Order
+
+Positive patterns contribute files in the order you list them
+(alphabetically within a single pattern). This is also the order pages
+render in.

--- a/hub-client/changelog.md
+++ b/hub-client/changelog.md
@@ -23,6 +23,10 @@ WASM rebuild is needed for a changelog-only edit.
 
 -->
 
+### 2026-08-07
+
+- [`279d7e5e`](https://github.com/quarto-dev/q2/commits/279d7e5e): `.md` files are now first-class source files: they sync into hub projects, get live preview, outline, folding, diagnostics, and qmd highlighting in the editor, and cross-document links into `.md` pages navigate like `.qmd` ones.
+
 ### 2026-08-03
 
 - [`bd8f5206`](https://github.com/quarto-dev/q2/commits/bd8f5206): The session-expiry re-check now schedules only from the server-reported expiry; `/auth/me` gained a `credential` field distinguishing sliding sessions from fixed-expiry Bearer tokens, and the obsolete 1-hour fallback lifetime was removed.

--- a/hub-client/src/components/Editor.tsx
+++ b/hub-client/src/components/Editor.tsx
@@ -101,9 +101,12 @@ function getLanguageForFile(filePath: string): string {
     case 'yml':
       return 'yaml';
     case 'qmd':
-      return 'qmd';
     case 'md':
-      return 'markdown';
+      // .md is a renderable source file parsed with the qmd grammar
+      // (bd-6d2wj4zp Phase 5, D11) — giving it the qmd language wires
+      // up the same Monarch highlighting and the qmd-registered
+      // symbol/folding/semantic-token providers as .qmd.
+      return 'qmd';
     default:
       return 'markdown';
   }
@@ -137,7 +140,10 @@ const editorOptions = {
   'semanticHighlighting.enabled': true as const,
 };
 
-// Select the best default file: prefer index.qmd, then first .qmd, then first file
+// Select the best default file: prefer index.qmd, then first .qmd, then
+// index.md / first .md (bd-6d2wj4zp Phase 5 — .md is a source file, but
+// only a fallback: a synced .md may be a never-rendered README while a
+// .qmd is always deliberate content), then first file.
 function selectDefaultFile(files: FileEntry[]): FileEntry | null {
   if (files.length === 0) return null;
 
@@ -148,6 +154,12 @@ function selectDefaultFile(files: FileEntry[]): FileEntry | null {
   // Then any .qmd file
   const anyQmd = files.find(f => f.path.endsWith('.qmd'));
   if (anyQmd) return anyQmd;
+
+  // Then index.md at root, then any .md
+  const indexMd = files.find(f => f.path === 'index.md');
+  if (indexMd) return indexMd;
+  const anyMd = files.find(f => f.path.endsWith('.md'));
+  if (anyMd) return anyMd;
 
   // Fall back to first file
   return files[0];

--- a/hub-client/src/components/FileSidebar.tsx
+++ b/hub-client/src/components/FileSidebar.tsx
@@ -73,10 +73,10 @@ function isImageFile(path: string): boolean {
   return IMAGE_EXTENSIONS.includes(ext);
 }
 
-/** Check if a file path is a qmd file */
-function isQmdFile(path: string): boolean {
+/** Check if a file path is a renderable source file (.qmd or .md) */
+function isSourceFile(path: string): boolean {
   const ext = path.split('.').pop()?.toLowerCase() || '';
-  return ext === 'qmd';
+  return ext === 'qmd' || ext === 'md';
 }
 
 /** Get file icon based on extension */
@@ -360,7 +360,7 @@ export default function FileSidebar({
     let fileType: 'image' | 'qmd' | 'other' = 'other';
     if (isImageFile(file.path)) {
       fileType = 'image';
-    } else if (isQmdFile(file.path)) {
+    } else if (isSourceFile(file.path)) {
       fileType = 'qmd';
     }
 
@@ -380,7 +380,7 @@ export default function FileSidebar({
     const isRenaming = renamingFile?.path === file.path;
     // Only make images and qmd files draggable (for editor insertion)
     const isDraggable =
-      !isRenaming && (isImageFile(file.path) || isQmdFile(file.path));
+      !isRenaming && (isImageFile(file.path) || isSourceFile(file.path));
     // Parent folder of this file, used by resolveDefaultDestination when a
     // drop lands on a file row (the drop target is the file, but the
     // destination for an upload is the enclosing folder).

--- a/hub-client/src/components/render/PreviewRouter.tsx
+++ b/hub-client/src/components/render/PreviewRouter.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
 import type * as Monaco from 'monaco-editor';
 import type { FileEntry } from '@quarto/preview-renderer/types/project';
-import { isQmdFile } from '@quarto/preview-renderer/types/project';
+import { isSourceFile } from '@quarto/preview-renderer/types/project';
 import type { Diagnostic } from '@quarto/preview-renderer/types/diagnostic';
 import type { ActorIdentity, CaptureRef } from '@quarto/preview-runtime';
 import { parseQmdToAst, isWasmReady, initWasm } from '@quarto/preview-runtime';
@@ -143,8 +143,8 @@ export default function PreviewRouter(props: PreviewRouterProps) {
     );
   }
 
-  // Non-QMD files: show placeholder
-  if (!isQmdFile(props.currentFile?.path)) {
+  // Non-source files (not .qmd/.md): show placeholder
+  if (!isSourceFile(props.currentFile?.path)) {
     return <NonQmdPlaceholderView filename={props.currentFile?.path ?? 'no currentFile path'} />;
   }
 

--- a/hub-client/src/components/render/ReactAstSlideRenderer.tsx
+++ b/hub-client/src/components/render/ReactAstSlideRenderer.tsx
@@ -726,8 +726,8 @@ function renderInline(
       const [[id, classes, attrs], inlines, [url, title]] = linkInline.c;
       const props = attributesToProps(id, classes, attrs);
 
-      // Handle .qmd links
-      if (url.endsWith('.qmd') && onNavigateToDocument) {
+      // Handle source-file links (.qmd, and .md since bd-6d2wj4zp Phase 5)
+      if ((url.endsWith('.qmd') || url.endsWith('.md')) && onNavigateToDocument) {
         const [path, anchor] = url.split('#');
         return (
           <a

--- a/hub-client/src/hooks/useIntelligence.ts
+++ b/hub-client/src/hooks/useIntelligence.ts
@@ -14,7 +14,7 @@ import {
   type FoldingRange,
   type DocumentAnalysis,
 } from '../services/intelligenceService';
-import { isQmdFile } from '@quarto/preview-renderer/types/project';
+import { isSourceFile } from '@quarto/preview-renderer/types/project';
 
 /**
  * Options for the useIntelligence hook.
@@ -106,8 +106,8 @@ export function useIntelligence(
       return;
     }
 
-    // Only analyze QMD files - other file types don't have symbols/diagnostics/folding
-    if (!isQmdFile(path)) {
+    // Only analyze source files (.qmd, .md) - other file types don't have symbols/diagnostics/folding
+    if (!isSourceFile(path)) {
       setSymbols([]);
       setDiagnostics([]);
       setFoldingRanges([]);

--- a/hub-client/src/services/intelligenceService.test.ts
+++ b/hub-client/src/services/intelligenceService.test.ts
@@ -36,6 +36,16 @@ describe('getSemanticTokens', () => {
     expect(result).toEqual(tokens);
   });
 
+  it('treats .md as a source file and calls WASM (bd-6d2wj4zp Phase 5)', async () => {
+    // D11: .md render inputs get the same intelligence treatment as
+    // .qmd — the source-file gate must not short-circuit them.
+    const tokens = [{ line: 0, character: 0, length: 1, tokenType: 0, modifiers: 0 }];
+    lspGetSemanticTokensMock.mockReturnValue(JSON.stringify({ success: true, tokens }));
+    const result = await getSemanticTokens('notes.md');
+    expect(result).toEqual(tokens);
+    expect(lspGetSemanticTokensMock).toHaveBeenCalled();
+  });
+
   it('returns [] for a failure envelope', async () => {
     lspGetSemanticTokensMock.mockReturnValue(JSON.stringify({ success: false, error: 'boom' }));
     const result = await getSemanticTokens('doc.qmd');

--- a/hub-client/src/services/intelligenceService.ts
+++ b/hub-client/src/services/intelligenceService.ts
@@ -22,7 +22,7 @@ import type {
   LspSemanticTokensResponse,
 } from '@quarto/preview-renderer/types/intelligence';
 import { initWasm, vfsAddFile } from '@quarto/preview-runtime';
-import { isQmdFile } from '@quarto/preview-renderer/types/project';
+import { isSourceFile } from '@quarto/preview-renderer/types/project';
 
 // Re-export types for convenience
 export type { Symbol, Diagnostic, FoldingRange, DocumentAnalysis, SemanticToken } from '@quarto/preview-renderer/types/intelligence';
@@ -118,8 +118,8 @@ async function getWasm(): Promise<typeof import('wasm-quarto-hub-client')> {
  * @returns Complete analysis (symbols, folding ranges, diagnostics)
  */
 export async function analyzeDocument(path: string): Promise<DocumentAnalysis> {
-  // Only QMD files have intelligence data
-  if (!isQmdFile(path)) {
+  // Only source files (.qmd, .md) have intelligence data
+  if (!isSourceFile(path)) {
     return { symbols: [], foldingRanges: [], diagnostics: [] };
   }
 
@@ -148,8 +148,8 @@ export async function analyzeDocument(path: string): Promise<DocumentAnalysis> {
  * @returns Hierarchical symbols for document outline
  */
 export async function getSymbols(path: string): Promise<Symbol[]> {
-  // Only QMD files have symbols
-  if (!isQmdFile(path)) {
+  // Only source files (.qmd, .md) have symbols
+  if (!isSourceFile(path)) {
     return [];
   }
 
@@ -176,8 +176,8 @@ export async function getSymbols(path: string): Promise<Symbol[]> {
  * @returns Folding ranges for code folding
  */
 export async function getFoldingRanges(path: string): Promise<FoldingRange[]> {
-  // Only QMD files have folding ranges
-  if (!isQmdFile(path)) {
+  // Only source files (.qmd, .md) have folding ranges
+  if (!isSourceFile(path)) {
     return [];
   }
 
@@ -202,8 +202,8 @@ export async function getFoldingRanges(path: string): Promise<FoldingRange[]> {
  * @returns Rich diagnostics array
  */
 export async function getDiagnostics(path: string): Promise<Diagnostic[]> {
-  // Only QMD files have diagnostics
-  if (!isQmdFile(path)) {
+  // Only source files (.qmd, .md) have diagnostics
+  if (!isSourceFile(path)) {
     return [];
   }
 
@@ -222,7 +222,7 @@ export async function getDiagnostics(path: string): Promise<Diagnostic[]> {
  * Get semantic tokens for a file — drives Monaco syntax highlighting for
  * `.qmd` (qmd structure + frontmatter YAML + code-cell interiors).
  *
- * Graceful by design: a non-qmd path, a `{ success: false }` envelope, or a
+ * Graceful by design: a non-source path, a `{ success: false }` envelope, or a
  * JSON-decode failure all resolve to `[]` (never a rejection), so the provider
  * needs no try/catch on the normal path and treats "no tokens" uniformly as
  * "fall back to the Monarch base layer".
@@ -231,7 +231,7 @@ export async function getDiagnostics(path: string): Promise<Diagnostic[]> {
  * @returns Semantic tokens, sorted and non-overlapping
  */
 export async function getSemanticTokens(path: string): Promise<SemanticToken[]> {
-  if (!isQmdFile(path)) {
+  if (!isSourceFile(path)) {
     return [];
   }
 
@@ -264,7 +264,7 @@ export async function getSemanticTokensForContent(
   path: string,
   content: string
 ): Promise<SemanticToken[]> {
-  if (!isQmdFile(path)) {
+  if (!isSourceFile(path)) {
     return [];
   }
 

--- a/hub-client/src/services/monacoProviders.ts
+++ b/hub-client/src/services/monacoProviders.ts
@@ -20,6 +20,7 @@ import {
   type Symbol,
   type FoldingRange,
 } from './intelligenceService';
+import { isSourceFile } from '@quarto/preview-renderer/types/project';
 import type {
   SymbolKind,
   FoldingRangeKind,
@@ -225,8 +226,8 @@ export function registerIntelligenceProviders(
       ): Promise<Monaco.languages.DocumentSymbol[]> => {
         const path = getCurrentFilePath();
 
-        // Only provide symbols for .qmd files
-        if (!path?.endsWith('.qmd')) {
+        // Only provide symbols for source files (.qmd, .md)
+        if (!path || !isSourceFile(path)) {
           return [];
         }
 
@@ -252,8 +253,8 @@ export function registerIntelligenceProviders(
       ): Promise<Monaco.languages.FoldingRange[]> => {
         const path = getCurrentFilePath();
 
-        // Only provide folding ranges for .qmd files
-        if (!path?.endsWith('.qmd')) {
+        // Only provide folding ranges for source files (.qmd, .md)
+        if (!path || !isSourceFile(path)) {
           return [];
         }
 
@@ -291,7 +292,7 @@ export function registerIntelligenceProviders(
         token
       ): Promise<Monaco.languages.SemanticTokens | null> => {
         const path = getCurrentFilePath();
-        if (!path?.endsWith('.qmd')) {
+        if (!path || !isSourceFile(path)) {
           return null;
         }
 

--- a/q2-preview-spa/src/PreviewApp.tsx
+++ b/q2-preview-spa/src/PreviewApp.tsx
@@ -389,25 +389,32 @@ function buildInitialState(): PreviewAppState {
  * `changedPath` should trigger a re-render of the page named by
  * `activeFile`, given the cached dep set `deps`.
  *
- * The filter is intentionally narrow: it ONLY filters `.qmd` edits.
- * Non-qmd files (CSS, _quarto.yml, _metadata.yml, .tsx custom
- * components, …) are project-wide signals that affect rendering
- * regardless of the active page's include-shortcode set, so they
- * always pass.
+ * The filter is intentionally narrow: it ONLY filters *source-file*
+ * edits (`.qmd`, and `.md` since bd-6d2wj4zp Phase 5 — with hub-wide
+ * extension-based sync, never-rendered `.md` like a README also watch,
+ * and must not re-render the active page). Non-source files (CSS,
+ * _quarto.yml, _metadata.yml, .tsx custom components, …) are
+ * project-wide signals that affect rendering regardless of the active
+ * page's include-shortcode set, so they always pass.
  *
  * Returns true (fail-open) when `deps` is null — the server response
  * hasn't landed yet, and we'd rather over-render than miss a change.
+ * (The deps fetch seeds the set with the active page itself, so "edit
+ * my own page" needs no special case here.)
+ *
+ * Exported for unit testing.
  */
-function shouldRerenderForTextChange(
+export function shouldRerenderForTextChange(
   changedPath: string,
   activeFile: string | null,
   deps: Set<string> | null,
 ): boolean {
   if (!activeFile) return true;
-  // Non-qmd edits always pass: they're either config (_quarto.yml,
+  // Non-source edits always pass: they're either config (_quarto.yml,
   // _metadata.yml) or project-wide assets (CSS, custom components)
   // that the include-shortcode dep extractor doesn't track.
-  if (!changedPath.toLowerCase().endsWith('.qmd')) return true;
+  const lower = changedPath.toLowerCase();
+  if (!lower.endsWith('.qmd') && !lower.endsWith('.md')) return true;
   if (deps === null) return true;
   return deps.has(changedPath);
 }

--- a/q2-preview-spa/src/pickInitialPage.test.ts
+++ b/q2-preview-spa/src/pickInitialPage.test.ts
@@ -57,4 +57,25 @@ describe('pickInitialPage', () => {
     expect(pickInitialPage('?page=', files)).toBe('posts/intro.qmd');
     expect(pickInitialPage('?page=   ', files)).toBe('posts/intro.qmd');
   });
+
+  // ─── bd-6d2wj4zp Phase 5: .md pages ───────────────────────────────
+
+  it('honors a ?page= hint naming a .md file', () => {
+    const mdFiles: FileLike[] = [{ path: 'index.qmd' }, { path: 'admin/index.md' }];
+    expect(pickInitialPage('?page=admin/index.md', mdFiles)).toBe('admin/index.md');
+  });
+
+  it('falls back to the first .md only when no .qmd exists', () => {
+    // .qmd stays the preferred fallback: with extension-based sync,
+    // the index may contain never-rendered .md (a README) — a .qmd,
+    // if present, is always deliberate content.
+    const mixed: FileLike[] = [
+      { path: 'README.md' },
+      { path: 'about.qmd' },
+    ];
+    expect(pickInitialPage('', mixed)).toBe('about.qmd');
+
+    const mdOnly: FileLike[] = [{ path: '_quarto.yml' }, { path: 'guide.md' }];
+    expect(pickInitialPage('', mdOnly)).toBe('guide.md');
+  });
 });

--- a/q2-preview-spa/src/pickInitialPage.ts
+++ b/q2-preview-spa/src/pickInitialPage.ts
@@ -29,9 +29,14 @@ export function pickInitialPage(
   }
   // Fall-through: first .qmd in the discovered index, as the SPA
   // has done since Phase A. This is also the path taken when the
-  // CLI didn't pass a `?page=` hint at all.
+  // CLI didn't pass a `?page=` hint at all. `.md` is only a
+  // last-resort fallback (bd-6d2wj4zp Phase 5): with extension-based
+  // sync the index may contain never-rendered `.md` (a README), while
+  // a `.qmd` is always deliberate content.
   const firstQmd = files.find((f) => f.path.endsWith('.qmd'));
-  return firstQmd ? firstQmd.path : null;
+  if (firstQmd) return firstQmd.path;
+  const firstMd = files.find((f) => f.path.endsWith('.md'));
+  return firstMd ? firstMd.path : null;
 }
 
 function parsePageQuery(search: string): string | null {

--- a/q2-preview-spa/src/shouldRerenderForTextChange.test.ts
+++ b/q2-preview-spa/src/shouldRerenderForTextChange.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Unit tests for `shouldRerenderForTextChange` (Phase D.6, bd-kw93.12;
+ * `.md` dep-filtering added in bd-6d2wj4zp Phase 5).
+ *
+ * With hub-wide extension-based sync (D10), *every* `.md` in the project
+ * syncs and watches — including never-rendered ones (README, notes). The
+ * dep filter is what keeps those edits from re-rendering the active page:
+ * source files (`.qmd` AND `.md`) only trigger a re-render when they are
+ * in the active page's dep set; non-source files (config, CSS, .tsx)
+ * remain project-wide signals that always pass.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { shouldRerenderForTextChange } from './PreviewApp';
+
+describe('shouldRerenderForTextChange', () => {
+  const deps = new Set(['included.qmd', 'snippets/part.md']);
+
+  it('always re-renders when there is no active file', () => {
+    expect(shouldRerenderForTextChange('anything.md', null, deps)).toBe(true);
+  });
+
+  it('fails open when the dep set has not arrived yet', () => {
+    expect(shouldRerenderForTextChange('other.qmd', 'index.qmd', null)).toBe(true);
+    expect(shouldRerenderForTextChange('other.md', 'index.qmd', null)).toBe(true);
+  });
+
+  it('passes non-source project-wide signals through', () => {
+    expect(shouldRerenderForTextChange('_quarto.yml', 'index.qmd', deps)).toBe(true);
+    expect(shouldRerenderForTextChange('styles.css', 'index.qmd', deps)).toBe(true);
+    expect(shouldRerenderForTextChange('Widget.tsx', 'index.qmd', deps)).toBe(true);
+  });
+
+  it('filters .qmd edits by the dep set (pre-existing behavior)', () => {
+    expect(shouldRerenderForTextChange('included.qmd', 'index.qmd', deps)).toBe(true);
+    expect(shouldRerenderForTextChange('unrelated.qmd', 'index.qmd', deps)).toBe(false);
+  });
+
+  it('filters .md edits by the dep set (bd-6d2wj4zp Phase 5)', () => {
+    // An unrelated .md (README, notes) must NOT re-render the active page…
+    expect(shouldRerenderForTextChange('README.md', 'index.qmd', deps)).toBe(false);
+    // …but a .md the active page includes must.
+    expect(shouldRerenderForTextChange('snippets/part.md', 'index.qmd', deps)).toBe(true);
+  });
+
+  it('re-renders when the active .md page itself is edited', () => {
+    // The deps fetch always seeds the set with the active page itself
+    // (PreviewApp's "edit my own page" convention) — mirror that shape.
+    const mdDeps = new Set(['admin/index.md', 'snippets/part.md']);
+    expect(
+      shouldRerenderForTextChange('admin/index.md', 'admin/index.md', mdDeps),
+    ).toBe(true);
+  });
+
+  it('is case-insensitive on the extension', () => {
+    expect(shouldRerenderForTextChange('NOTES.MD', 'index.qmd', deps)).toBe(false);
+    expect(shouldRerenderForTextChange('OTHER.QMD', 'index.qmd', deps)).toBe(false);
+  });
+});

--- a/ts-packages/preview-renderer/src/overlays/PreviewStaticInfoViews.tsx
+++ b/ts-packages/preview-renderer/src/overlays/PreviewStaticInfoViews.tsx
@@ -53,7 +53,7 @@ export function NonQmdPlaceholderView({ filename }: { filename: string }) {
           &#128196;
         </div>
         <div style={{ fontSize: '14px', lineHeight: '1.6' }}>
-          Preview is available for <span style={{ fontFamily: "'SF Mono', Monaco, monospace" }}>.qmd</span> files
+          Preview is available for <span style={{ fontFamily: "'SF Mono', Monaco, monospace" }}>.qmd</span> and <span style={{ fontFamily: "'SF Mono', Monaco, monospace" }}>.md</span> files
         </div>
         <div style={{ fontSize: '14px', lineHeight: '1.6', marginTop: '8px' }}>
           This <span style={{ fontFamily: "'SF Mono', Monaco, monospace" }}>.{extension}</span> file can be edited in the editor

--- a/ts-packages/preview-renderer/src/types/project.test.ts
+++ b/ts-packages/preview-renderer/src/types/project.test.ts
@@ -3,7 +3,38 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { isQmdFile } from './project';
+import { isQmdFile, isSourceFile } from './project';
+
+// bd-6d2wj4zp Phase 5 (D10/D11): `.md` is a renderable source file
+// alongside `.qmd`. `isSourceFile` is the predicate preview/intelligence
+// surfaces should use; `isQmdFile` stays for genuinely .qmd-only checks.
+describe('isSourceFile', () => {
+  it('accepts .qmd files', () => {
+    expect(isSourceFile('index.qmd')).toBe(true);
+    expect(isSourceFile('docs/intro.qmd')).toBe(true);
+    expect(isSourceFile('README.QMD')).toBe(true);
+  });
+
+  it('accepts .md files', () => {
+    expect(isSourceFile('notes.md')).toBe(true);
+    expect(isSourceFile('admin/index.md')).toBe(true);
+    expect(isSourceFile('README.MD')).toBe(true);
+  });
+
+  it('rejects non-source files', () => {
+    expect(isSourceFile('styles.css')).toBe(false);
+    expect(isSourceFile('_quarto.yml')).toBe(false);
+    expect(isSourceFile('Component.tsx')).toBe(false);
+    expect(isSourceFile('archive.mds')).toBe(false);
+    expect(isSourceFile('Makefile')).toBe(false);
+  });
+
+  it('handles null/undefined/empty', () => {
+    expect(isSourceFile(null)).toBe(false);
+    expect(isSourceFile(undefined)).toBe(false);
+    expect(isSourceFile('')).toBe(false);
+  });
+});
 
 describe('isQmdFile', () => {
   describe('returns true for QMD files', () => {

--- a/ts-packages/preview-renderer/src/types/project.ts
+++ b/ts-packages/preview-renderer/src/types/project.ts
@@ -45,6 +45,24 @@ export function isQmdFile(path: string | null | undefined): boolean {
   return path?.toLowerCase().endsWith('.qmd') ?? false;
 }
 
+/**
+ * Check if a file path is a renderable source file (`.qmd` or `.md`).
+ *
+ * bd-6d2wj4zp Phase 5 (D10/D11): `.md` files are render inputs (opted in
+ * via the project render list) and get the same live preview, outline,
+ * folding, and diagnostics treatment as `.qmd`. Surfaces gating those
+ * features should use this predicate; `isQmdFile` remains for genuinely
+ * `.qmd`-only checks.
+ *
+ * @param path - File path to check (can be null/undefined)
+ * @returns true if the path ends with .qmd or .md (case-insensitive)
+ */
+export function isSourceFile(path: string | null | undefined): boolean {
+  const lower = path?.toLowerCase();
+  if (!lower) return false;
+  return lower.endsWith('.qmd') || lower.endsWith('.md');
+}
+
 // ============================================================================
 // Application-Specific Types
 // ============================================================================

--- a/ts-packages/preview-renderer/src/utils/iframeLinkHandlers.integration.test.ts
+++ b/ts-packages/preview-renderer/src/utils/iframeLinkHandlers.integration.test.ts
@@ -329,6 +329,76 @@ describe('installLinkHandlers', () => {
         });
     });
 
+    // ─── bd-6d2wj4zp Phase 5: .md pages in the preview ──────────────
+
+    test('.md link is intercepted like .qmd and resolved relative to current file', () => {
+        installLinkHandlers(doc, {
+            currentFilePath: '/foo/bar.qmd',
+            onQmdLinkClick,
+        });
+
+        const a = appendAnchor('other.md#sec');
+        const continued = clickFromBody(a);
+
+        expect(onQmdLinkClick).toHaveBeenCalledWith({
+            path: '/foo/other.md',
+            anchor: 'sec',
+        });
+        expect(continued).toBe(false);
+    });
+
+    test('artifact-rooted .html link maps back to its .md via projectFilePaths', () => {
+        installLinkHandlers(doc, {
+            currentFilePath: 'index.qmd',
+            projectFilePaths: ['index.qmd', 'admin/index.md'],
+            onQmdLinkClick,
+        });
+
+        const a = appendAnchor('/.quarto/project-artifacts/admin/index.html');
+        const continued = clickFromBody(a);
+
+        expect(onQmdLinkClick).toHaveBeenCalledWith({
+            path: 'admin/index.md',
+            anchor: null,
+        });
+        expect(continued).toBe(false);
+    });
+
+    test('artifact-rooted missing page still falls back to the .qmd candidate', () => {
+        // The always-intercept policy is unchanged: with neither a
+        // .qmd nor .md source in projectFilePaths, the handler keeps
+        // the .qmd candidate so the missing-page overlay UX works.
+        installLinkHandlers(doc, {
+            currentFilePath: 'index.qmd',
+            projectFilePaths: ['index.qmd', 'admin/index.md'],
+            onQmdLinkClick,
+        });
+
+        const a = appendAnchor('/.quarto/project-artifacts/missing.html');
+        clickFromBody(a);
+
+        expect(onQmdLinkClick).toHaveBeenCalledWith({
+            path: 'missing.qmd',
+            anchor: null,
+        });
+    });
+
+    test('bare artifact-root maps to index.md when only index.md exists', () => {
+        installLinkHandlers(doc, {
+            currentFilePath: 'about.qmd',
+            projectFilePaths: ['index.md', 'about.qmd'],
+            onQmdLinkClick,
+        });
+
+        const a = appendAnchor('/.quarto/project-artifacts/');
+        clickFromBody(a);
+
+        expect(onQmdLinkClick).toHaveBeenCalledWith({
+            path: 'index.md',
+            anchor: null,
+        });
+    });
+
     test('non-artifact-rooted absolute path is left alone', () => {
         // A user-authored absolute href that isn't artifact-rooted
         // (e.g. someone hand-wrote `<a href="/about.html">`) should

--- a/ts-packages/preview-renderer/src/utils/iframeLinkHandlers.ts
+++ b/ts-packages/preview-renderer/src/utils/iframeLinkHandlers.ts
@@ -51,12 +51,13 @@ export interface InstallLinkHandlersOptions {
     currentFilePath: string;
     /**
      * Phase F.1 (bd-kw93.14): project file paths used to reverse-map
-     * artifact-rooted `.html` clicks back to their source `.qmd`.
-     * Optional and currently unused except for type-shape consistency
-     * with `iframePostProcessor.ts` — the q2-preview link handler
-     * intercepts every artifact-rooted href regardless of whether the
-     * mapped `.qmd` is in this list, so the field is a documentation
-     * hook for the future (e.g. a "did you mean ..." overlay).
+     * artifact-rooted `.html` clicks back to their source file. Since
+     * bd-6d2wj4zp Phase 5 the list picks the source *extension*: a
+     * clicked `foo.html` maps to `foo.qmd` or `foo.md`, whichever the
+     * project actually contains (`.qmd` wins a tie). The handler still
+     * intercepts every artifact-rooted href — when neither source
+     * exists it falls back to the `.qmd` candidate so a missing-page
+     * click surfaces the render-error overlay.
      */
     projectFilePaths?: readonly string[];
     /**
@@ -103,15 +104,19 @@ export function installLinkHandlers(
         // LinkRewriteTransform runs. Always intercept; route the
         // .qmd candidate through onQmdLinkClick (PreviewApp's render
         // attempt is what surfaces a missing-page error).
-        const artifact = parseArtifactHref(href);
+        const artifact = parseArtifactHref(href, opts.projectFilePaths);
         if (artifact && opts.onQmdLinkClick) {
             ev.preventDefault();
-            opts.onQmdLinkClick({ path: artifact.qmdCandidate, anchor: artifact.anchor });
+            opts.onQmdLinkClick({ path: artifact.sourceCandidate, anchor: artifact.anchor });
             return;
         }
 
         const parsed = parseLink(href);
-        if (parsed.path && parsed.path.endsWith('.qmd') && opts.onQmdLinkClick) {
+        if (
+            parsed.path &&
+            (parsed.path.endsWith('.qmd') || parsed.path.endsWith('.md')) &&
+            opts.onQmdLinkClick
+        ) {
             ev.preventDefault();
             const resolved = resolveRelativePath(opts.currentFilePath, parsed.path);
             opts.onQmdLinkClick({ path: resolved, anchor: parsed.anchor });
@@ -142,16 +147,25 @@ function parseLink(href: string): ParsedLink {
 }
 
 /**
- * Parse an artifact-rooted href into its `.qmd` source-path candidate +
+ * Source extensions the website renderer rewrites to `.html`, in
+ * tie-break order (`.qmd` wins when both stems exist — that pair is a
+ * render-time output collision anyway). Mirrors
+ * `iframePostProcessor.ts::RENDERABLE_EXTS`; bd-msp0 tracks hoisting
+ * the duplicated constants once service-worker resource resolution
+ * lands. (`.md` joined with bd-6d2wj4zp Phase 5.)
+ */
+const RENDERABLE_EXTS: readonly string[] = ['.qmd', '.md'];
+
+/**
+ * Parse an artifact-rooted href into its source-path candidate +
  * optional anchor. Returns null for hrefs that don't start with the
  * artifact root, or whose stem is neither empty nor ending in `.html`.
  *
- * Examples:
- *   /.quarto/project-artifacts/about.html       → { qmdCandidate: 'about.qmd', anchor: null }
- *   /.quarto/project-artifacts/about.html#sec   → { qmdCandidate: 'about.qmd', anchor: 'sec' }
- *   /.quarto/project-artifacts/posts/x.html     → { qmdCandidate: 'posts/x.qmd', anchor: null }
- *   /.quarto/project-artifacts/                 → { qmdCandidate: 'index.qmd', anchor: null }
- *   /.quarto/project-artifacts/#intro           → { qmdCandidate: 'index.qmd', anchor: 'intro' }
+ * Examples (with `projectFilePaths = ['index.qmd', 'admin/index.md']`):
+ *   /.quarto/project-artifacts/admin/index.html → { sourceCandidate: 'admin/index.md', anchor: null }
+ *   /.quarto/project-artifacts/about.html#sec   → { sourceCandidate: 'about.qmd', anchor: 'sec' }  (missing → .qmd fallback)
+ *   /.quarto/project-artifacts/                 → { sourceCandidate: 'index.qmd', anchor: null }
+ *   /.quarto/project-artifacts/#intro           → { sourceCandidate: 'index.qmd', anchor: 'intro' }
  *   /.quarto/project-artifacts/styles.css       → null  (not .html)
  *   ./about.qmd                                 → null  (not artifact-rooted)
  *
@@ -163,24 +177,41 @@ function parseLink(href: string): ParsedLink {
  * the SPA and the iframe navigates to a URL the preview server does
  * not serve.
  *
- * Unlike `iframePostProcessor.ts::reverseMapArtifactHref`, this helper
- * does not consult `projectFilePaths` — see the docstring on
- * `installLinkHandlers` for the rationale (missing-page UX).
+ * `projectFilePaths` picks the source *extension* (bd-6d2wj4zp Phase 5):
+ * the first `RENDERABLE_EXTS` candidate present in the list wins. The
+ * always-intercept policy is preserved — no match (or no list) falls
+ * back to the `.qmd` candidate so a missing-page click surfaces the
+ * render-error overlay instead of navigating the iframe to a 404.
  */
-function parseArtifactHref(href: string): { qmdCandidate: string; anchor: string | null } | null {
+function parseArtifactHref(
+    href: string,
+    projectFilePaths?: readonly string[],
+): { sourceCandidate: string; anchor: string | null } | null {
     if (!href.startsWith(ARTIFACT_ROOT)) return null;
     const stripped = href.slice(ARTIFACT_ROOT.length);
     const hashIdx = stripped.indexOf('#');
     const stem = hashIdx === -1 ? stripped : stripped.slice(0, hashIdx);
     const anchor = hashIdx === -1 ? null : stripped.slice(hashIdx + 1) || null;
     if (stem === '') {
-        return { qmdCandidate: 'index.qmd', anchor };
+        return { sourceCandidate: pickSourceCandidate('index', projectFilePaths), anchor };
     }
     if (!stem.endsWith('.html')) return null;
+    const base = stem.slice(0, -'.html'.length);
     return {
-        qmdCandidate: stem.slice(0, -'.html'.length) + '.qmd',
+        sourceCandidate: pickSourceCandidate(base, projectFilePaths),
         anchor,
     };
+}
+
+/** First `RENDERABLE_EXTS` candidate present in the project, else `<base>.qmd`. */
+function pickSourceCandidate(base: string, projectFilePaths?: readonly string[]): string {
+    if (projectFilePaths) {
+        for (const ext of RENDERABLE_EXTS) {
+            const candidate = base + ext;
+            if (projectFilePaths.includes(candidate)) return candidate;
+        }
+    }
+    return base + '.qmd';
 }
 
 function findAnchorAncestor(start: Element | null): HTMLAnchorElement | null {

--- a/ts-packages/preview-renderer/src/utils/iframePostProcessor.test.ts
+++ b/ts-packages/preview-renderer/src/utils/iframePostProcessor.test.ts
@@ -19,6 +19,36 @@ const FILES: readonly string[] = [
 ];
 
 describe('reverseMapArtifactHref', () => {
+  // ─── bd-6d2wj4zp Phase 5: .md is a renderable source ────────────
+  it('reverse-maps to a source .md when no .qmd sibling exists', () => {
+    const files = ['index.qmd', 'admin/index.md', 'notes.md'];
+    expect(
+      reverseMapArtifactHref('/.quarto/project-artifacts/notes.html', files),
+    ).toEqual({ path: 'notes.md', anchor: null });
+    expect(
+      reverseMapArtifactHref(
+        '/.quarto/project-artifacts/admin/index.html#setup',
+        files,
+      ),
+    ).toEqual({ path: 'admin/index.md', anchor: 'setup' });
+  });
+
+  it('prefers .qmd over .md when both stems exist', () => {
+    // Both rendering to the same .html is a render-time collision
+    // anyway; the reverse map just needs a deterministic order.
+    const files = ['about.qmd', 'about.md'];
+    expect(
+      reverseMapArtifactHref('/.quarto/project-artifacts/about.html', files),
+    ).toEqual({ path: 'about.qmd', anchor: null });
+  });
+
+  it('maps bare artifact root to index.md when only index.md exists', () => {
+    const files = ['index.md', 'about.qmd'];
+    expect(
+      reverseMapArtifactHref('/.quarto/project-artifacts/', files),
+    ).toEqual({ path: 'index.md', anchor: null });
+  });
+
   it('reverse-maps a top-level artifact-rooted .html URL to its source .qmd', () => {
     expect(
       reverseMapArtifactHref('/.quarto/project-artifacts/about.html', FILES),

--- a/ts-packages/preview-renderer/src/utils/iframePostProcessor.ts
+++ b/ts-packages/preview-renderer/src/utils/iframePostProcessor.ts
@@ -35,10 +35,12 @@ const ARTIFACT_ROOT = '/.quarto/project-artifacts/';
  * in order and intercept iff the resulting project path matches
  * a real `FileEntry`.
  *
- * Today only `.qmd` is renderable; `.md` / `.ipynb` are reserved
- * for when Q2 supports them.
+ * `.qmd` first: when both `about.qmd` and `about.md` exist (a
+ * render-time output collision anyway), the reverse map stays
+ * deterministic. `.ipynb` is reserved for when Q2 supports it
+ * (bd-19nc56ao). `.md` joined with bd-6d2wj4zp Phase 5.
  */
-const RENDERABLE_EXTS: readonly string[] = ['.qmd'];
+const RENDERABLE_EXTS: readonly string[] = ['.qmd', '.md'];
 
 export interface PostProcessOptions {
   /** Current file path for resolving relative links */


### PR DESCRIPTION
Support plain `.md` files as render inputs, matching Quarto 1's practical usage while diverging deliberately where strictness pays off. Motivating case: the Posit Connect docs port (~176 `.md` files rendered alongside `.qmd`).

## Semantics

- `.md` participates in a **project** render only when matched by explicit `project.render` globs — never via default discovery. The invariant is literal: omitting `project.render` ≡ `render: ["**/*.qmd"]`, by construction (default supplied by the enumerator).
- Once opted in, `.md` behaves exactly like `.qmd` (same parser, shortcodes, includes, transforms, formats).
- Engine specs in a `.md` are ignored with a new **Q-2-40** warning instead of Q1's silence; `.md` never executes engines.
- Single-file `q2 render foo.md` works (front-matter `format:` honored, non-native bail-out parity).
- New `output == input` guard in `determine_output_paths` — also fixes a live data-loss bug where `--output <input>` silently destroyed the source.
- Nav/body links and dependency-graph edges rewrite `.md` render-list members to `.html` like `.qmd`.
- Preview + hub (Phase 5): `.md` syncs and watches hub-wide (extension-based, symmetric with `.qmd`; membership stays a render-time decision); `q2 preview` renders `.md` pages, live-updates on edit, intercepts links; hub-client gives `.md` the full editor treatment (preview, diagnostics, outline, folding, qmd highlighting).
- Fixed a latent bug: negation-only render lists (`render: ["!drafts/**"]`) now mean "all `.qmd` minus these" instead of producing an empty render set.

## Deliberate divergences from Q1

| Behavior | Q1 | Q2 |
|---|---|---|
| `.md` in default (glob-less) discovery | included | excluded |
| `engine:` in `.md` | silently ignored | ignored with Q-2-40 |
| Executable cell in `.md` | hard error | passes through unexecuted |
| `.md` + `format: gfm` collision | renamed output | error with hint |
| `.markdown` extension | supported | not supported |

Full design rationale, D1–D11 decision log, and SSG-landscape survey: `claude-notes/plans/2026-08-07-md-render-support.md`.

## Verification

- Full `cargo xtask verify` (all 14 steps, WASM + hub-client legs) green.
- E2e with real Connect-docs sources (`admin/index.md`, `user/index.md`) — render, sidebar/body link rewriting, shortcode expansion inspected.
- Browser e2e on a live `q2 preview` session: navigation into a `.md` page, live re-render on disk edit, single-file `.md` preview.
- New user docs page: `docs/guides/projects/render-list.qmd`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)