### PR TITLE
Resolve leading-/ include paths against the project root (bd-w9koo1i2)

### DIFF
--- a/claude-notes/plans/2026-08-07-include-project-absolute-paths.md
+++ b/claude-notes/plans/2026-08-07-include-project-absolute-paths.md
@@ -1,7 +1,7 @@
 # Include shortcode: project-absolute (root-relative) path resolution
 
 **Strand:** bd-w9koo1i2
-**Status:** planned, not yet implemented
+**Status:** implemented; PR open — https://github.com/quarto-dev/q2/pull/468
 **Date:** 2026-08-07
 
 ## Overview

--- a/claude-notes/plans/2026-08-07-include-project-absolute-paths.md
+++ b/claude-notes/plans/2026-08-07-include-project-absolute-paths.md
@@ -1,0 +1,223 @@
+# Include shortcode: project-absolute (root-relative) path resolution
+
+**Strand:** bd-w9koo1i2
+**Status:** planned, not yet implemented
+**Date:** 2026-08-07
+
+## Overview
+
+`{{< include /admin/_includes/license-file.qmd >}}` fails with Q-17-2
+("Include file not found"), because the leading-`/` path is handed to the
+filesystem as an OS-absolute path. Per the Quarto path convention (Q1, and
+q2's own glob layer, decision D2), a leading `/` means
+**project-root-relative**: `/admin/_includes/license-file.qmd` =
+`<project>/admin/_includes/license-file.qmd`.
+
+Found while porting the posit-connect docs to Quarto 2
+(`~/Desktop/daily-log/2026/08/05/q2-connect-docs/docs-quarto-2`,
+`admin/licensing/index.md:146` and many more sites).
+
+### Minimal reproduction (verified 2026-08-07)
+
+```
+repro/
+  _quarto.yml            # project: {type: default}
+  sub/doc.qmd            # contains: {{< include /sub/_includes/snippet.qmd >}}
+  sub/_includes/snippet.qmd
+```
+
+`cargo run --bin q2 -- render repro/` warns:
+
+```
+Warning: [Q-17-2] Include file not found
+  Could not read included file '/sub/_includes/snippet.qmd':
+  I/O error: No such file or directory (os error 2)
+```
+
+## Diagnosis
+
+### Primary defect
+
+`crates/quarto-core/src/stage/stages/include_expansion.rs:150-152`
+(`IncludeExpander::expand_blocks`):
+
+```rust
+// Resolve relative to the including file's directory
+let base_dir = current_file.parent().unwrap_or(Path::new("."));
+let resolved = base_dir.join(&include_path);
+```
+
+`Path::join` with an absolute right-hand side **discards the base**, so a
+leading-`/` include path becomes a filesystem-absolute path and every
+downstream step (cycle detection, `file_read`, `recorded_includes`,
+diagnostics) operates on the wrong path.
+
+### Secondary site (preview dep-graph)
+
+`crates/quarto-preview/src/deps.rs:213` (`extract_include_deps`):
+
+```rust
+let joined = page_dir.join(&raw);
+normalize_forward_slash(&joined)
+```
+
+Same `join` trap. `normalize_forward_slash` then hits the
+`Component::RootDir` arm and returns the raw leading-`/` string, which never
+matches the SPA's forward-slash project-relative paths — so editing the
+included file does not trigger a re-render of the includer in `q2 preview`.
+
+### Reference semantics (Q1)
+
+`external-sources/quarto-cli/src/core/handlers/base.ts:224-236`:
+
+```ts
+resolvePath(path: string): string {
+  const sourceDir = dirname(options.context.target.source);
+  const rootDir = options.context.project.isSingleFile
+    ? sourceDir
+    : options.context.project.dir;
+  if (path.startsWith("/")) {
+    return resolve(rootDir, `.${path}`);   // root-relative
+  } else {
+    return resolve(sourceDir, path);       // relative
+  }
+}
+```
+
+Key points:
+
+- Leading `/` → resolve against **project root**; for single-file renders,
+  against the **source file's directory**.
+- q2's `ProjectContext.dir` already encodes exactly this anchor: it is the
+  `_quarto.yml` directory when a project exists, and the input file's
+  directory when `is_single_file` (`crates/quarto-core/src/project/mod.rs:505-587`).
+  So `ctx.project.dir` is the correct anchor in *all* modes, with no
+  `is_single_file` branch needed.
+- Nested includes: Q1 anchors leading-`/` at the same fixed root at every
+  nesting level. (q2 resolves *relative* nested includes against the
+  included file's own directory — bd-1fz3vh99, deliberate; unaffected here.)
+
+### Existing q2 precedent
+
+The convention is already implemented lexically for globs/resources:
+`quarto_core::glob::join_and_normalize`
+(`crates/quarto-core/src/glob/pattern.rs:88`) — "A pattern beginning with
+`/` is **project-root-relative** (decision D2, Quarto YAML convention)".
+It also normalizes backslashes and clamps `..` at the project root. It is
+`pub use`d from `quarto_core::glob`.
+
+### WASM note
+
+The same `IncludeExpansionStage` runs in the hub-client WASM build, where
+VFS paths live under `/project/`. Today a leading-`/` include resolves to
+`/sub/...` (outside the VFS root → always missing). Anchoring at
+`ctx.project.dir` (which is the VFS project root in that context) fixes
+WASM/live-preview too. Verify during implementation what
+`project.dir` actually is in the WASM render entry points.
+
+## Fix design
+
+1. **New helper** in `include_expansion.rs` (unit-testable, no fs access):
+
+   ```rust
+   /// Resolve a raw include-shortcode path. A leading `/` (or `\`) is
+   /// project-root-relative per the Quarto path convention (see
+   /// glob::join_and_normalize, decision D2); anything else resolves
+   /// against the including file's directory.
+   fn resolve_include_target(base_dir: &Path, project_dir: &Path, raw: &str) -> PathBuf
+   ```
+
+   Behavior:
+   - `raw` starts with `/` or `\` → `project_dir.join(raw trimmed of leading
+     slashes, backslashes normalized)`.
+   - otherwise → `base_dir.join(raw)` (unchanged behavior).
+   - Windows drive-absolute paths (`C:\...`) fall through the `join` as
+     today (Q1 has no defined semantics for them either; do not invent one).
+
+   Call it at `expand_blocks` (replacing lines 150-152), passing
+   `self.ctx.project.dir`. Cycle detection, `file_read`, diagnostics, and
+   `recorded_includes` all pick up the corrected path for free.
+
+2. **Preview dep-graph** (`quarto-preview/src/deps.rs`): in
+   `extract_include_deps`, treat a leading-`/` raw path as already
+   project-relative — bypass `page_dir.join` and normalize the stripped
+   path directly (or route both arms through
+   `quarto_core::glob::join_and_normalize(page_dir_str, raw)`, which
+   implements exactly this and additionally clamps `..`; preferred if the
+   `Option` (root-escape) case maps cleanly onto the existing fallback).
+
+3. **Out of scope** (documented, not changed):
+   - `include_resolve.rs` (metadata `include-in-header` etc.) is
+     document-relative by its own plan
+     (2026-05-04-includes-feature.md §Resolved questions #4, pending
+     `!path`); if it should also learn the leading-`/` convention, that is
+     a separate strand.
+   - Reference-doc update: `docs/` include documentation should mention
+     root-relative includes once implemented (check whether a page exists).
+
+## Work items (TDD order)
+
+### Phase 1 — tests first (must fail before the fix)
+
+- [x] Unit tests for `resolve_include_target` in `include_expansion.rs`:
+      relative path unchanged; leading `/` anchors at project dir; leading
+      `\` (Windows-authored) same; `//double` collapse. (Written alongside
+      the helper; the behavioral failing-first evidence came from the
+      integration + preview tests.)
+- [x] Integration test (new file
+      `crates/quarto-core/tests/integration/include_project_absolute.rs`,
+      registered alphabetically in `tests/integration/main.rs`). Harness
+      improves on the plan: it uses `ProjectContext::discover` on a real
+      temp-dir layout (with/without `_quarto.yml`) so the anchor comes from
+      the CLI's own discovery branch. Five tests: project mode, cross-tree
+      target, single-file parity, nested leading-`/`, relative regression
+      guard.
+- [x] Preview dep test in `quarto-preview` (alongside the existing
+      `extract_include_deps` unit tests): a page `sub/doc.qmd` with
+      `{{< include /sub/_includes/x.qmd >}}` yields dep
+      `sub/_includes/x.qmd`.
+- [x] Run the new tests, **verify they fail** for the expected reason.
+      Verified 2026-08-07: the four leading-`/` integration tests fail
+      with Q-17-2 ("Could not read included file '/other/_b.qmd'" etc.),
+      the relative-include guard passes; the preview test fails returning
+      the raw `/sub/_includes/x.qmd` (RootDir fallback), not the
+      project-relative form.
+
+### Phase 2 — implementation
+
+- [x] Add `resolve_include_target` and use it in `expand_blocks`
+      (module + method docs updated to state the two anchors).
+- [x] Fix `extract_include_deps` leading-`/` handling (local branch in
+      `deps.rs`, mirroring the stage's anchors; kept deps' existing
+      lenient `..` normalization untouched to avoid scope creep).
+- [x] All new tests pass (43 include-related quarto-core tests, full
+      quarto-preview suite 89/89).
+
+### Phase 3 — regression + end-to-end verification
+
+- [x] `cargo build --workspace` and `cargo nextest run --workspace` —
+      11060 passed, 197 skipped (2026-08-07).
+- [x] Full `cargo xtask verify` (quarto-core changed → WASM leg affected) —
+      all 14 steps passed (2026-08-07).
+- [x] End-to-end: `cargo run --bin q2 -- render
+      <scratch>/include-repro` — no warnings; rendered
+      `sub/doc.html:30` contains `<p>INCLUDED CONTENT MARKER</p>`
+      (file inspected).
+- [x] End-to-end: re-rendered the posit-connect docs project
+      (`q2 render ~/Desktop/daily-log/2026/08/05/q2-connect-docs/docs-quarto-2`);
+      Q-17-2 count went from many to **0**, and the license-file callout
+      content ("license file activation") appears 5× in the rendered
+      `admin/licensing/index.html` — one per former warning site.
+- [ ] Optional: verify in `q2 preview` that editing
+      `sub/_includes/snippet.qmd` re-renders `sub/doc.qmd` (dep-graph fix);
+      remember the preview WASM rebuild chain if exercising the SPA.
+- [ ] Close bd-w9koo1i2 with a summary; changelog entry if user wants one.
+
+## Notes
+
+- The Q-17-2 diagnostic prints the resolved path; after the fix it will
+  print the real `<project>/...` path, which is a strictly better message.
+  No diagnostic-text change needed.
+- `collect_include_paths` itself stays raw-string; both consumers
+  (expander, preview deps) apply the convention at their own resolution
+  points.

--- a/crates/quarto-core/src/stage/stages/include_expansion.rs
+++ b/crates/quarto-core/src/stage/stages/include_expansion.rs
@@ -16,6 +16,11 @@
 //! standalone and its blocks become children of the containing
 //! construct. Runs before engine execution so that included code cells
 //! are visible to the engine.
+//!
+//! Path resolution: relative paths anchor at the including file's
+//! directory (at every nesting level); a leading `/` is
+//! **project-root-relative** per the Quarto path convention
+//! (bd-w9koo1i2, see [`resolve_include_target`]).
 
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
@@ -123,8 +128,9 @@ struct IncludeExpander<'a> {
 
 impl IncludeExpander<'_> {
     /// Expand includes in one block list. `current_file` is the file
-    /// whose source produced these blocks — include paths resolve
-    /// against its directory.
+    /// whose source produced these blocks — relative include paths
+    /// resolve against its directory; leading-`/` paths resolve
+    /// against the project root (see [`resolve_include_target`]).
     ///
     /// An included file's blocks are recursively expanded *before*
     /// being spliced into `blocks`, so every nesting level sees the
@@ -147,9 +153,8 @@ impl IncludeExpander<'_> {
                 continue;
             };
 
-            // Resolve relative to the including file's directory
             let base_dir = current_file.parent().unwrap_or(Path::new("."));
-            let resolved = base_dir.join(&include_path);
+            let resolved = resolve_include_target(base_dir, &self.ctx.project.dir, &include_path);
 
             // Canonicalize for cycle detection
             let canonical = resolved.canonicalize().unwrap_or_else(|_| resolved.clone());
@@ -457,6 +462,35 @@ fn record_include(out: &mut Vec<IncludeEntry>, resolved: &Path, bytes: &[u8]) {
     out.push(IncludeEntry::new(resolved.to_path_buf(), bytes));
 }
 
+/// Resolve a raw include-shortcode path against its anchor.
+///
+/// A path beginning with `/` (or `\` — Windows-authored) is
+/// **project-root-relative**, per the Quarto path convention (glob
+/// decision D2; Q1's `resolvePath` in `core/handlers/base.ts`):
+/// `/a/b.qmd` means `<project>/a/b.qmd`, never the filesystem root.
+/// For single-file renders `project_dir` is the input file's own
+/// directory ([`crate::project::ProjectContext::discover`]), which
+/// matches Q1's `rootDir = sourceDir` fallback without a branch here.
+///
+/// Everything else resolves against `base_dir`, the including file's
+/// directory — so nested relative includes anchor at each included
+/// file (bd-1fz3vh99) while the leading-`/` anchor stays fixed at the
+/// project root at every nesting level.
+///
+/// Windows drive-absolute paths (`C:\…`) are not part of the
+/// convention (Q1 defines no semantics for them either); they fall
+/// through the relative arm, where `Path::join` keeps them absolute.
+fn resolve_include_target(base_dir: &Path, project_dir: &Path, raw: &str) -> PathBuf {
+    if raw.starts_with('/') || raw.starts_with('\\') {
+        // Normalize separators before anchoring so a Windows-authored
+        // `\a\b.qmd` behaves identically everywhere.
+        let normalized = raw.replace('\\', "/");
+        project_dir.join(normalized.trim_start_matches('/'))
+    } else {
+        base_dir.join(raw)
+    }
+}
+
 /// Check if a block is a paragraph (or plain block) containing only an
 /// include shortcode. Returns the include path if so, None otherwise.
 ///
@@ -517,6 +551,52 @@ mod tests {
             })],
             source_info: SourceInfo::original(FileId(0), 0, 30),
         })
+    }
+
+    // === resolve_include_target (bd-w9koo1i2) ===
+
+    #[test]
+    fn resolve_relative_against_base_dir() {
+        assert_eq!(
+            resolve_include_target(Path::new("/proj/sub"), Path::new("/proj"), "x.qmd"),
+            Path::new("/proj/sub/x.qmd")
+        );
+        assert_eq!(
+            resolve_include_target(Path::new("/proj/sub"), Path::new("/proj"), "../up.qmd"),
+            Path::new("/proj/sub/../up.qmd")
+        );
+    }
+
+    #[test]
+    fn resolve_leading_slash_against_project_dir() {
+        assert_eq!(
+            resolve_include_target(Path::new("/proj/sub"), Path::new("/proj"), "/a/b.qmd"),
+            Path::new("/proj/a/b.qmd")
+        );
+        // Already at the root: same anchor.
+        assert_eq!(
+            resolve_include_target(Path::new("/proj"), Path::new("/proj"), "/a.qmd"),
+            Path::new("/proj/a.qmd")
+        );
+    }
+
+    #[test]
+    fn resolve_leading_backslash_is_project_root_relative() {
+        // Windows-authored separators normalize before anchoring.
+        assert_eq!(
+            resolve_include_target(Path::new("/proj/sub"), Path::new("/proj"), "\\a\\b.qmd"),
+            Path::new("/proj/a/b.qmd")
+        );
+    }
+
+    #[test]
+    fn resolve_redundant_leading_slashes_collapse() {
+        // Path comparison is component-wise, so the interior `//`
+        // in the joined form is equivalent to `/`.
+        assert_eq!(
+            resolve_include_target(Path::new("/proj/sub"), Path::new("/proj"), "//a//b.qmd"),
+            Path::new("/proj/a/b.qmd")
+        );
     }
 
     #[test]

--- a/crates/quarto-core/tests/integration/include_project_absolute.rs
+++ b/crates/quarto-core/tests/integration/include_project_absolute.rs
@@ -1,0 +1,200 @@
+/*
+ * tests/integration/include_project_absolute.rs
+ * Copyright (c) 2026 Posit, PBC
+ *
+ * Project-absolute (leading-`/`) include paths (bd-w9koo1i2).
+ */
+
+//! `{{< include /path/from/root.qmd >}}` resolves against the
+//! **project root**, per the Quarto path convention (Q1
+//! `resolvePath`, q2 glob decision D2) — never against the
+//! filesystem root. For single-file renders the anchor is the
+//! document's own directory (Q1 parity: `rootDir = sourceDir`), which
+//! is exactly what `ProjectContext::discover` puts in `project.dir`.
+//!
+//! Fixtures here go through `ProjectContext::discover` on a real
+//! temp-dir layout (with or without `_quarto.yml`) so the
+//! project-vs-single-file anchor comes from the same discovery branch
+//! the CLI uses, not from a hand-built context.
+//!
+//! Plan: `claude-notes/plans/2026-08-07-include-project-absolute-paths.md`.
+
+use std::sync::Arc;
+
+use quarto_core::format::Format;
+use quarto_core::pipeline::{HtmlRenderConfig, RenderOutput, render_qmd_to_html};
+use quarto_core::project::{DocumentInfo, ProjectContext};
+use quarto_core::render::{BinaryDependencies, RenderContext};
+
+use crate::include_expansion_diagnostics::codes;
+
+const MARKER: &str = "PROJECT-ABSOLUTE-INCLUDE-MARKER";
+
+/// Write `files` (paths may contain subdirectories) into a temp dir,
+/// discover the project context from `main` (finding `_quarto.yml` if
+/// the fixture provides one), and render `main` through the real HTML
+/// pipeline.
+async fn render_discovered_fixture(files: &[(&str, &str)], main: &str) -> RenderOutput {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let project_dir = tmp.path().to_path_buf();
+
+    for (name, content) in files {
+        let path = project_dir.join(name);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(path, content).unwrap();
+    }
+
+    let main_path = project_dir.join(main);
+    let content = std::fs::read(&main_path).unwrap();
+
+    let runtime: Arc<dyn quarto_system_runtime::SystemRuntime> =
+        Arc::new(quarto_system_runtime::NativeRuntime::new());
+
+    let project =
+        ProjectContext::discover(&main_path, runtime.as_ref()).expect("fixture project discovers");
+    let doc = DocumentInfo::from_path(&main_path);
+    let format = Format::html();
+    let binaries = BinaryDependencies::new();
+    let mut ctx = RenderContext::new(&project, &doc, &format, &binaries);
+
+    render_qmd_to_html(
+        &content,
+        &main_path.to_string_lossy(),
+        &mut ctx,
+        &HtmlRenderConfig::default(),
+        runtime,
+    )
+    .await
+    .expect("render completes (include failures are diagnostics, not fatal)")
+}
+
+fn assert_include_resolved(output: &RenderOutput) {
+    let codes = codes(output);
+    assert!(
+        !codes.contains(&"Q-17-2"),
+        "project-absolute include must resolve, not report Q-17-2; diagnostics: {:?}",
+        output.diagnostics
+    );
+    assert!(
+        output.html.contains(MARKER),
+        "included content must reach the HTML:\n{}",
+        output.html
+    );
+}
+
+#[tokio::test]
+async fn project_absolute_include_resolves_from_project_root() {
+    let output = render_discovered_fixture(
+        &[
+            ("_quarto.yml", "project:\n  type: default\n"),
+            (
+                "sub/doc.qmd",
+                "---\ntitle: Root-relative include\n---\n\n\
+                 {{< include /sub/_includes/snippet.qmd >}}\n",
+            ),
+            (
+                "sub/_includes/snippet.qmd",
+                "PROJECT-ABSOLUTE-INCLUDE-MARKER\n",
+            ),
+        ],
+        "sub/doc.qmd",
+    )
+    .await;
+
+    assert_include_resolved(&output);
+}
+
+#[tokio::test]
+async fn project_absolute_include_reaches_across_directories() {
+    // The include target lives in a *different* subtree than the
+    // including document — the case a document-relative fallback
+    // cannot fake.
+    let output = render_discovered_fixture(
+        &[
+            ("_quarto.yml", "project:\n  type: default\n"),
+            (
+                "a/b/doc.qmd",
+                "---\ntitle: Cross-tree include\n---\n\n\
+                 {{< include /shared/_snippet.qmd >}}\n",
+            ),
+            ("shared/_snippet.qmd", "PROJECT-ABSOLUTE-INCLUDE-MARKER\n"),
+        ],
+        "a/b/doc.qmd",
+    )
+    .await;
+
+    assert_include_resolved(&output);
+}
+
+#[tokio::test]
+async fn single_file_project_absolute_include_anchors_at_document_dir() {
+    // No `_quarto.yml`: single-file render. Q1 parity — the
+    // leading-`/` anchor falls back to the source file's directory.
+    let output = render_discovered_fixture(
+        &[
+            (
+                "sub/doc.qmd",
+                "---\ntitle: Single-file root-relative include\n---\n\n\
+                 {{< include /deep/_snippet.qmd >}}\n",
+            ),
+            ("sub/deep/_snippet.qmd", "PROJECT-ABSOLUTE-INCLUDE-MARKER\n"),
+        ],
+        "sub/doc.qmd",
+    )
+    .await;
+
+    assert_include_resolved(&output);
+}
+
+#[tokio::test]
+async fn nested_project_absolute_include_anchors_at_project_root() {
+    // A relatively-included child that itself uses a leading-`/`
+    // include: the root anchor must stay fixed at the project root at
+    // every nesting level (it must NOT drift to the child's own
+    // directory, where `other/` does not exist).
+    let output = render_discovered_fixture(
+        &[
+            ("_quarto.yml", "project:\n  type: default\n"),
+            (
+                "doc.qmd",
+                "---\ntitle: Nested root-relative include\n---\n\n\
+                 {{< include sub/_a.qmd >}}\n",
+            ),
+            (
+                "sub/_a.qmd",
+                "outer child\n\n{{< include /other/_b.qmd >}}\n",
+            ),
+            ("other/_b.qmd", "PROJECT-ABSOLUTE-INCLUDE-MARKER\n"),
+        ],
+        "doc.qmd",
+    )
+    .await;
+
+    assert_include_resolved(&output);
+}
+
+#[tokio::test]
+async fn relative_include_still_resolves_against_document_dir() {
+    // Regression guard: the fix must not disturb plain relative
+    // resolution.
+    let output = render_discovered_fixture(
+        &[
+            ("_quarto.yml", "project:\n  type: default\n"),
+            (
+                "sub/doc.qmd",
+                "---\ntitle: Relative include\n---\n\n\
+                 {{< include _includes/snippet.qmd >}}\n",
+            ),
+            (
+                "sub/_includes/snippet.qmd",
+                "PROJECT-ABSOLUTE-INCLUDE-MARKER\n",
+            ),
+        ],
+        "sub/doc.qmd",
+    )
+    .await;
+
+    assert_include_resolved(&output);
+}

--- a/crates/quarto-core/tests/integration/main.rs
+++ b/crates/quarto-core/tests/integration/main.rs
@@ -24,6 +24,7 @@ pub mod get_config_merge;
 pub mod idempotence;
 pub mod include_expansion_diagnostics;
 pub mod include_nested_expansion;
+pub mod include_project_absolute;
 pub mod include_resolve_pipeline;
 pub mod incremental_rebuild;
 pub mod jupyter_integration;

--- a/crates/quarto-preview/src/deps.rs
+++ b/crates/quarto-preview/src/deps.rs
@@ -50,7 +50,7 @@
 //! that includes too many is just the pre-D.6 behaviour, so we'd
 //! rather over-broadcast than fail closed.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use axum::{
     Json,
@@ -205,12 +205,21 @@ pub fn extract_include_deps(source: &[u8], page_rel: &str) -> Vec<String> {
     let mut deps: Vec<String> = collect_include_paths(&mut pandoc.blocks)
         .into_iter()
         .map(|raw| {
-            // Resolve relative to the page's directory and emit a
-            // forward-slash project-relative path. We don't
-            // canonicalize against the filesystem — the SPA matches
-            // these strings against paths from `onFileContent`,
-            // which arrive in the same forward-slash form.
-            let joined = page_dir.join(&raw);
+            // Resolve to a forward-slash project-relative path,
+            // mirroring `IncludeExpansionStage`'s anchors
+            // (bd-w9koo1i2): a leading `/` (or `\`) is
+            // project-root-relative — dep strings are already
+            // project-relative, so the root anchor means dropping the
+            // slash, NOT prepending the page dir. Anything else is
+            // page-relative. We don't canonicalize against the
+            // filesystem — the SPA matches these strings against
+            // paths from `onFileContent`, which arrive in the same
+            // forward-slash form.
+            let joined = if raw.starts_with('/') || raw.starts_with('\\') {
+                PathBuf::from(raw.replace('\\', "/").trim_start_matches('/'))
+            } else {
+                page_dir.join(&raw)
+            };
             normalize_forward_slash(&joined)
         })
         .collect();
@@ -286,6 +295,20 @@ mod tests {
         // page = posts/post1.qmd; include = ../shared.qmd → shared.qmd
         let src = "# Post\n\n{{< include ../shared.qmd >}}\n";
         assert_eq!(deps_for(src, "posts/post1.qmd"), vec!["shared.qmd"]);
+    }
+
+    #[test]
+    fn project_absolute_include_is_project_relative_dep() {
+        // bd-w9koo1i2: a leading `/` is project-root-relative (Quarto
+        // path convention), and dep strings are project-relative
+        // forward-slash paths — so the leading slash strips and the
+        // page directory is NOT prepended.
+        let src = "# Post\n\n{{< include /sub/_includes/x.qmd >}}\n";
+        assert_eq!(
+            deps_for(src, "sub/doc.qmd"),
+            vec!["sub/_includes/x.qmd"],
+            "leading-/ include must anchor at the project root, not the page dir"
+        );
     }
 
     #[test]

--- a/docs/errors/include/Q-17-2.qmd
+++ b/docs/errors/include/Q-17-2.qmd
@@ -26,11 +26,14 @@ Common causes:
 
 - **A typo in the path**, or a file that was renamed or moved after
   the include was written.
-- **A path resolved from the wrong base.** Include paths are
-  resolved relative to the directory of the file *containing the
+- **A path resolved from the wrong base.** Relative include paths
+  are resolved from the directory of the file *containing the
   shortcode* — not the project root, and not the top-level document.
   A snippet that lives in a subdirectory resolves its own includes
-  from that subdirectory.
+  from that subdirectory. To resolve from the project root instead,
+  start the path with `/`: `{{{< include /snippets/note.qmd >}}}`
+  means `<project>/snippets/note.qmd` no matter which file contains
+  the shortcode.
 - **Case mismatch** on a case-sensitive filesystem (for example,
   deploying to Linux a project authored on macOS).
 - **A permissions problem** — the file exists but is not readable.
@@ -39,6 +42,7 @@ Common causes:
 ## How to fix
 
 Check the path in the message: it is the fully resolved path Quarto
-tried to read. Compare it against the actual file location, fix the
-relative path in the shortcode, and remember that it is relative to
-the file the shortcode appears in.
+tried to read. Compare it against the actual file location and fix
+the path in the shortcode — remembering that a relative path is
+relative to the file the shortcode appears in, while a path starting
+with `/` is relative to the project root.


### PR DESCRIPTION
## Summary

`{{< include /admin/_includes/license-file.qmd >}}` failed with Q-17-2: the leading-`/` path was handed to the filesystem as an OS-absolute path. Per the Quarto path convention (Q1's `resolvePath` in `core/handlers/base.ts`, q2's own glob decision D2), a leading `/` is **project-root-relative**. Found porting the posit-connect docs to Quarto 2.

The defect: `base_dir.join(&include_path)` — `Path::join` discards its base when the right-hand side is absolute.

## Changes

- **`include_expansion.rs`**: new `resolve_include_target()` anchors leading-`/` (or Windows-authored `\`) paths at `ctx.project.dir`; everything else resolves against the including file's directory, unchanged. `ProjectContext.dir` already matches Q1's anchor in both modes (project root, or the input file's directory for single-file renders), so no mode branch is needed. The root anchor stays fixed at every include-nesting level. Also fixes the same class of failure in the WASM/hub-client build, where a leading-`/` path escaped the `/project/` VFS root.
- **`quarto-preview/deps.rs`**: `extract_include_deps` mirrors the same anchors — previously a leading-`/` include never matched the SPA's project-relative dep strings, so editing the included file didn't re-render the includer in `q2 preview`.
- **`docs/errors/include/Q-17-2.qmd`**: documented the old behavior ("not the project root"); now describes both anchors.

## Tests (TDD)

- 5 integration tests (`include_project_absolute.rs`) driving the real HTML pipeline through `ProjectContext::discover` on temp-dir layouts: project mode, cross-tree target, single-file parity, nested leading-`/`, relative regression guard. The four leading-`/` tests failed with Q-17-2 before the fix.
- 4 unit tests for `resolve_include_target`; 1 preview deps unit test (failed pre-fix returning the raw absolute path).
- Full workspace: 11060 tests pass; full `cargo xtask verify` (including WASM + hub-client legs) green.

## End-to-end verification

- Minimal repro project: `q2 render` now emits no warnings and the rendered `sub/doc.html` contains the included marker (inspected).
- posit-connect docs port: Q-17-2 warnings went from many to **0**; the license-file callout content appears 5× in rendered `admin/licensing/index.html`, one per former warning site.

Plan: `claude-notes/plans/2026-08-07-include-project-absolute-paths.md`
Strand: bd-w9koo1i2 (docs follow-up filed as bd-ehp5ardt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)