### PR TITLE
Don't lex '< text' (whitespace after '<') as html_element (bd-ly83qewg)

### DIFF
--- a/claude-notes/plans/2026-08-07-angle-bracket-inner-whitespace.md
+++ b/claude-notes/plans/2026-08-07-angle-bracket-inner-whitespace.md
@@ -1,0 +1,192 @@
+# Angle brackets with inner whitespace should not lex as `html_element` (bd-ly83qewg)
+
+**Status: approved 2026-08-07 — in progress.**
+
+## Overview
+
+### Symptom
+
+```text
+*a < b this text is interpreted as an HTML element.* a > b
+```
+
+fails to parse with `[Q-2-12] Unclosed Star Emphasis`. Unintuitively,
+deleting the trailing `>` makes the document parse fine (both `<` and
+`>` become literal `Str`s).
+
+Original repro: `~/Desktop/daily-log/2026/08/07/test-qmd-parse-issue.qmd`
+(the on-disk copy is the `>`-deleted, passing variant).
+
+### Diagnosis
+
+`parse_open_angle_brace` in
+`crates/tree-sitter-qmd/tree-sitter-markdown/src/scanner.c` (~line 1821)
+handles every inline `<`. After consuming `<` it scans forward looking
+for a closing delimiter:
+
+- `}` → `RAW_SPECIFIER` (qmd raw-reader extension, `` `x`{<pandoc} ``)
+- `>` with URL-ish content and no whitespace → `AUTOLINK`
+- **any other `>` → `HTML_ELEMENT`** — a best-effort token that exists
+  "simply for good error reporting" (we recognize HTML elements but warn
+  against them)
+- EOF with no delimiter → `LT_STR_LITERAL` (the bd-j9cf fallback: only
+  the `<` is consumed, and it becomes a plain `Str`)
+
+In the repro, the scanner starts at the `<`, walks 54 bytes to the `>`
+after the emphasis has already closed, and emits one `HTML_ELEMENT`
+token spanning `< b this … element.* a >` — **swallowing the closing
+`*`**. The paragraph then has an opening emphasis delimiter with no
+closer → Q-2-12. Verified with `pampa -v`:
+
+```text
+lexed_lookahead sym:html_element, size:54
+```
+
+Deleting the `>` removes the only closing delimiter, so the scan
+reaches EOF and the bd-j9cf `LT_STR_LITERAL` fallback kicks in — which
+is why the error "unintuitively" vanishes.
+
+`AUTOLINK` is already immune: the scan sets `could_be_autolink = false`
+on the first whitespace character. Only the `HTML_ELEMENT` arm lacks a
+whitespace guard.
+
+### Pandoc behavior (target)
+
+`pandoc -f markdown -t native` on the repro yields
+`Emph [Str "a", Space, Str "<", …]` with `Str ">"` outside — both
+brackets are literal text and the emphasis closes. That matches the
+CommonMark/HTML rule this plan adopts: an open tag's name must
+*immediately* follow `<` (letter, or `/` `!` `?` for the other
+constructs); `<` followed by whitespace can never begin any HTML
+construct or autolink.
+
+### Proposed rule
+
+**Whitespace (space, tab, CR, LF) or EOF immediately after `<`
+disqualifies `HTML_ELEMENT`** (autolink is already disqualified by the
+existing `could_be_autolink` logic; HTML comments are dispatched earlier
+on `<!`).
+
+Notes on scope:
+
+- The user-suggested rule was "inner whitespace on *both* sides"
+  (`< text >`). Whitespace-after-`<` alone is strictly stronger (the
+  both-sides rule is a subset), is the spec-aligned condition, and also
+  fixes cases like `*a < b* c>d` where the eventual `>` is *not*
+  preceded by whitespace. We deliberately do **not** add a
+  whitespace-before-`>` condition: `<div >` is a valid HTML open tag
+  (trailing whitespace before `>` is allowed by the spec), so that
+  side must not disqualify. **Open question for review**: confirm we
+  prefer the after-`<` rule over the literal both-sides rule.
+- `< text >` sequences where the whitespace is only *interior*
+  (e.g. `<not a tag>`) still lex as `html_element` and warn. As noted
+  in the report, this class of ambiguity can't be fully eliminated;
+  this plan only removes the spec-unambiguous case.
+- The `RAW_SPECIFIER` path is left byte-for-byte unchanged: when
+  `RAW_SPECIFIER` is a valid symbol we still scan ahead for `}` exactly
+  as today (so `` `x`{<pandoc} `` — and even a hypothetical
+  `{< pandoc}` — keep their current behavior); we only suppress the
+  `HTML_ELEMENT` emission on `>`.
+
+### Sketch of the scanner change
+
+In `parse_open_angle_brace`, after consuming `<` and the bd-j9cf
+`mark_end`:
+
+1. Compute `bool html_possible = !(lookahead is ' ' / '\t' / '\r' /
+   '\n' or EOF)`.
+2. **Fast path**: if `!html_possible && !valid_symbols[RAW_SPECIFIER]`,
+   nothing downstream can match (autolink needs no-whitespace, comment
+   already dispatched), so immediately `EMIT_TOKEN(LT_STR_LITERAL)` when
+   `lt_str_valid`, else `return false`. This also avoids an O(n) scan to
+   EOF for every `< ` in a document.
+3. In the scan loop, guard the `HTML_ELEMENT` arm with
+   `html_possible`. A skipped `>` is just an ordinary character: the
+   scan continues (a later `}` can still make a `RAW_SPECIFIER`) and
+   otherwise falls through to the existing EOF → `LT_STR_LITERAL`
+   fallback.
+
+`scanner.c` is handwritten (not generated), so the change is
+scanner-only; no `grammar.js` edit is expected. Rebuild with
+`tree-sitter generate; tree-sitter build` in
+`crates/tree-sitter-qmd/tree-sitter-markdown` per CLAUDE.md, then
+`cargo` picks up the new `scanner.c` for the Rust crate.
+
+## Work Items
+
+### Phase 1 — tests first (TDD) — DONE 2026-08-07
+
+- [x] Add failing corpus tests to
+      `crates/tree-sitter-qmd/tree-sitter-markdown/test/corpus/lt-as-str.txt`
+      (this is the bd-j9cf file; the new cases are its natural
+      extension):
+  - [x] repro: `*a < b text.* a > b` → emphasis closes; `<` and `>` are
+        `pandoc_str`s
+  - [x] plain `a < b > c` → all `pandoc_str`s (today: `html_element`)
+  - [x] `<` at end of line with a `>` on a later line (newline counts
+        as inner whitespace) — confirmed today's behavior is an
+        `html_element` *spanning the soft break*
+- [x] Add regression corpus cases pinning current behavior (some may
+      already exist in `lt-as-str.txt` — verify rather than duplicate):
+  - [x] `<b>` → `html_element` (already present, bd-j9cf)
+  - [x] `<div >` → `html_element` (whitespace before `>` only — must
+        NOT be disqualified) — added
+  - [x] `<not a tag>` → `html_element` (interior-only whitespace —
+        out of scope, stays) — added
+  - [x] `<https://example.com>` → `autolink` (already present)
+  - [x] `<!-- c -->` → `comment` (already present)
+  - [x] `` `a span`{<pandoc} `` → `raw_specifier` (present in
+        `inline-markdown.txt` case 3; runs with the suite)
+  - [x] bd-j9cf cases still pass (`1 < 2`, `foo <`, `a <foo`)
+- [x] Run `tree-sitter test` and verify the new cases fail as expected —
+      `tree-sitter test -i lt-as-str`: 3 failed (the three bd-ly83qewg
+      cases, each showing `html_element` where `pandoc_str`s are
+      asserted), 9 passed
+- [x] Add pampa-level regression tests in
+      `crates/pampa/tests/integration/test_bare_lt_str.rs` (3 new
+      behavior tests + 2 new RawInline regression guards); verified
+      failing: emphasis case dies with Q-2-12, the other two mismatch
+      (12 passed, 3 failed)
+
+### Phase 2 — scanner fix — DONE 2026-08-07
+
+- [x] Implement the `html_possible` guard + fast path in
+      `parse_open_angle_brace` (sketch above)
+- [x] `tree-sitter generate && tree-sitter build && tree-sitter test`
+      — all 545 corpus tests green
+- [x] `cargo nextest run -p pampa` bare-lt suite — all 15 green
+
+### Phase 3 — verification — DONE 2026-08-07
+
+- [x] Full `cargo xtask verify` (all 14 steps green, exit 0) — this
+      includes `cargo build --workspace`, `cargo nextest run
+      --workspace`, the WASM build, and hub-client build + tests
+- [x] End-to-end per CLAUDE.md: ran the `pampa` binary on the failing
+      variant (`*a < b this text is interpreted as an HTML element.* a > b`):
+
+      ```
+      $ target/debug/pampa repro.qmd
+      [ Para [Emph [Str "a", Space, Str "<", Space, Str "b", …,
+        Str "element."], Space, Str "a", Space, Str ">", Space, Str "b"] ]
+      ```
+
+      Output inspected; byte-identical in structure to
+      `pandoc -f markdown -t native` on the same input.
+- [x] Snapshot churn: none — no `.snap` files changed
+
+### Phase 4 — bookkeeping
+
+- [x] `braid comment bd-ly83qewg` with the outcome + e2e evidence
+- [x] `braid close bd-ly83qewg` once all tests pass
+
+## Open questions — resolved 2026-08-07 (user review)
+
+1. **Rule shape**: after-`<`-only rule **approved** (subsumes the
+   both-sides rule; `<div >` must stay a valid open tag).
+2. `HTML_ELEMENT` scan stopping at newlines: **no** — by the same
+   spec argument, `<div\n  class="foo">` is a valid open tag, so the
+   scan must keep crossing newlines. (Note the after-`<` rule still
+   treats a newline *immediately* after `<` as disqualifying, which is
+   spec-consistent: a tag name must immediately follow `<`.)
+3. `qmd-syntax-helper` angle: **no** — nothing to rewrite once the
+   construct parses correctly.

--- a/crates/pampa/tests/integration/test_bare_lt_str.rs
+++ b/crates/pampa/tests/integration/test_bare_lt_str.rs
@@ -96,6 +96,114 @@ fn unclosed_tag_parses_as_str_lt_plus_text() {
 }
 
 #[test]
+fn lt_gt_with_inner_whitespace_does_not_swallow_emphasis_closer() {
+    // bd-ly83qewg: `< b text.* a >` used to lex as one html_element token,
+    // swallowing the closing `*` and failing with Q-2-12 Unclosed Star
+    // Emphasis. Whitespace immediately after `<` disqualifies the HTML
+    // construct, so both brackets are literal Strs (pandoc-compatible).
+    let pandoc = parse_qmd("*a < b text.* a > b\n");
+    let inlines = first_paragraph_inlines(&pandoc);
+    match &inlines[0] {
+        Inline::Emph(e) => assert_str_texts(
+            &e.content,
+            &[
+                r#"Str("a")"#,
+                "Space",
+                r#"Str("<")"#,
+                "Space",
+                r#"Str("b")"#,
+                "Space",
+                r#"Str("text.")"#,
+            ],
+        ),
+        other => panic!("expected Emph, got {:?}", other),
+    }
+    assert_str_texts(
+        &inlines[1..],
+        &[
+            "Space",
+            r#"Str("a")"#,
+            "Space",
+            r#"Str(">")"#,
+            "Space",
+            r#"Str("b")"#,
+        ],
+    );
+}
+
+#[test]
+fn lt_gt_with_inner_whitespace_in_plain_text_parses_as_strs() {
+    // bd-ly83qewg: `a < b > c` used to lex `< b >` as html_element.
+    let pandoc = parse_qmd("a < b > c\n");
+    let inlines = first_paragraph_inlines(&pandoc);
+    assert_str_texts(
+        inlines,
+        &[
+            r#"Str("a")"#,
+            "Space",
+            r#"Str("<")"#,
+            "Space",
+            r#"Str("b")"#,
+            "Space",
+            r#"Str(">")"#,
+            "Space",
+            r#"Str("c")"#,
+        ],
+    );
+}
+
+#[test]
+fn lt_at_end_of_line_with_gt_on_next_line_parses_as_str() {
+    // bd-ly83qewg: the html_element scan crosses newlines, so a `>` on a
+    // later line used to produce an html_element spanning the soft break.
+    // A newline immediately after `<` disqualifies it like any whitespace.
+    let pandoc = parse_qmd("foo <\nbar > baz\n");
+    let inlines = first_paragraph_inlines(&pandoc);
+    assert_str_texts(
+        inlines,
+        &[
+            r#"Str("foo")"#,
+            "Space",
+            r#"Str("<")"#,
+            "SoftBreak",
+            r#"Str("bar")"#,
+            "Space",
+            r#"Str(">")"#,
+            "Space",
+            r#"Str("baz")"#,
+        ],
+    );
+}
+
+#[test]
+fn html_element_with_whitespace_before_gt_still_parses_as_raw_html() {
+    // Regression guard for bd-ly83qewg: `<div >` is a valid open tag
+    // (whitespace before `>` is allowed by the HTML spec); only whitespace
+    // immediately after `<` disqualifies.
+    let pandoc = parse_qmd("<div >\n");
+    let inlines = first_paragraph_inlines(&pandoc);
+    assert!(
+        matches!(inlines[0], Inline::RawInline(_)),
+        "expected RawInline, got: {:?}",
+        inlines
+    );
+}
+
+#[test]
+fn html_element_with_interior_whitespace_still_parses_as_raw_html() {
+    // Regression guard for bd-ly83qewg: interior-only whitespace
+    // (`<not a tag>`) keeps the best-effort html_element lexing; this class
+    // of ambiguity is out of scope.
+    let pandoc = parse_qmd("<not a tag>\n");
+    let inlines = first_paragraph_inlines(&pandoc);
+    assert!(
+        matches!(inlines[0], Inline::RawInline(_)),
+        "expected RawInline, got: {:?}",
+        inlines
+    );
+}
+
+#[test]
 fn html_element_still_parses_as_raw_html() {
     // Regression: `<b>` is still recognized as an HTML element (raw HTML),
     // not split into `<`, `b`, `>` strings. The existing Q-2-9 warning path

--- a/crates/tree-sitter-qmd/tree-sitter-markdown/src/scanner.c
+++ b/crates/tree-sitter-qmd/tree-sitter-markdown/src/scanner.c
@@ -1849,9 +1849,26 @@ static bool parse_open_angle_brace(TSLexer *lexer, const bool *valid_symbols) {
         return false;
     }
 
+    // bd-ly83qewg: whitespace (or EOF) immediately after '<' disqualifies
+    // every angle-bracket HTML construct — per HTML/CommonMark, a tag name
+    // (or '/', '!', '?') must immediately follow '<' — and autolinks, which
+    // admit no whitespace at all. Only a raw specifier ('{<reader}') scans
+    // past this point, so when that isn't a valid symbol either, bail out
+    // right away instead of walking to the next '>'/EOF.
+    bool html_possible = !(lexer->lookahead == ' ' || lexer->lookahead == '\t' ||
+                           lexer->lookahead == '\r' || lexer->lookahead == '\n' ||
+                           lexer->eof(lexer));
+    if (!html_possible && !valid_symbols[RAW_SPECIFIER]) {
+        if (lt_str_valid) {
+            EMIT_TOKEN(LT_STR_LITERAL);
+        }
+        return false;
+    }
+
     // consume all characters until one of:
     // - '}': that was a raw specifier
-    // - '>': that was an autolink or html_element
+    // - '>': that was an autolink or html_element (unless disqualified by
+    //   whitespace right after '<', see above)
     // - EOF: no HTML construct matched; emit LT_STR_LITERAL (bd-j9cf) so the
     //   bare '<' becomes a plain Str instead of a parse error.
 
@@ -1869,7 +1886,7 @@ static bool parse_open_angle_brace(TSLexer *lexer, const bool *valid_symbols) {
             lexer->advance(lexer, false); // we want to consume '>' for autolinks
             lexer->mark_end(lexer);
             EMIT_TOKEN(AUTOLINK);
-        } else if (lexer->lookahead == '>') {
+        } else if (html_possible && lexer->lookahead == '>') {
             // this token is never valid, but we emit it for error messages
             lexer->advance(lexer, false);
             lexer->mark_end(lexer);

--- a/crates/tree-sitter-qmd/tree-sitter-markdown/test/corpus/lt-as-str.txt
+++ b/crates/tree-sitter-qmd/tree-sitter-markdown/test/corpus/lt-as-str.txt
@@ -71,3 +71,77 @@ a <foo
           (pandoc_str)
           (pandoc_str)
           (pandoc_str))))
+================================================================================
+lt-as-str — `< text >` does not swallow an emphasis closer (bd-ly83qewg)
+================================================================================
+*a < b text.* a > b
+--------------------------------------------------------------------------------
+    (document
+      (section
+        (pandoc_paragraph
+          (pandoc_emph
+            (emphasis_delimiter)
+            (pandoc_str)
+            (pandoc_str)
+            (pandoc_space)
+            (pandoc_str)
+            (pandoc_space)
+            (pandoc_str)
+            (emphasis_delimiter))
+          (pandoc_space)
+          (pandoc_str)
+          (pandoc_space)
+          (pandoc_str)
+          (pandoc_space)
+          (pandoc_str))))
+================================================================================
+lt-as-str — `a < b > c` is all Strs, not html_element (bd-ly83qewg)
+================================================================================
+a < b > c
+--------------------------------------------------------------------------------
+    (document
+      (section
+        (pandoc_paragraph
+          (pandoc_str)
+          (pandoc_str)
+          (pandoc_space)
+          (pandoc_str)
+          (pandoc_space)
+          (pandoc_str)
+          (pandoc_space)
+          (pandoc_str))))
+================================================================================
+lt-as-str — `<` at end of line with `>` on next line is a Str (bd-ly83qewg)
+================================================================================
+foo <
+bar > baz
+--------------------------------------------------------------------------------
+    (document
+      (section
+        (pandoc_paragraph
+          (pandoc_str)
+          (pandoc_str)
+          (pandoc_soft_break)
+          (pandoc_str)
+          (pandoc_space)
+          (pandoc_str)
+          (pandoc_space)
+          (pandoc_str))))
+================================================================================
+lt-as-str — `<div >` (whitespace before `>` only) stays html_element (regression)
+================================================================================
+<div >
+--------------------------------------------------------------------------------
+    (document
+      (section
+        (pandoc_paragraph
+          (html_element))))
+================================================================================
+lt-as-str — `<not a tag>` (interior-only whitespace) stays html_element (regression)
+================================================================================
+<not a tag>
+--------------------------------------------------------------------------------
+    (document
+      (section
+        (pandoc_paragraph
+          (html_element))))


### PR DESCRIPTION
## Summary

The external scanner's `parse_open_angle_brace` walked from any inline `<` to the next `>` and emitted a best-effort `HTML_ELEMENT` token, even when whitespace immediately followed the `<`. A construct like

```
*a < b this text is interpreted as an HTML element.* a > b
```

lexed `< b text.* a >` as one `html_element`, swallowing the emphasis closer and failing with **Q-2-12 Unclosed Star Emphasis** — while deleting the `>` made the error vanish (the bd-j9cf EOF fallback then emitted `LT_STR_LITERAL` instead).

## Fix

Per HTML/CommonMark, a tag name (or `/` `!` `?`) must *immediately* follow `<`, and autolinks admit no whitespace, so whitespace or EOF right after `<` disqualifies every angle-bracket construct except the raw specifier (`{<reader}`):

- guard the `HTML_ELEMENT` arm with `html_possible` (no whitespace/EOF immediately after `<`);
- fast path: when HTML is impossible and `RAW_SPECIFIER` isn't a valid symbol, emit `LT_STR_LITERAL` immediately instead of scanning to the next `>`/EOF (avoids an O(n) walk per `< ` occurrence);
- `RAW_SPECIFIER` scan path byte-for-byte unchanged.

Deliberate non-changes: whitespace before `>` does **not** disqualify (`<div >` is a valid open tag), and the scan still crosses newlines (`<div\n class="foo">` is valid); interior-only whitespace (`<not a tag>`) still lexes as `html_element` — that ambiguity is out of scope.

Output now matches `pandoc -t native` for the repro (emphasis closes; `<` and `>` are literal `Str`s).

## Tests

Written first and verified failing (repro died with Q-2-12):

- 3 new corpus cases + 2 regression pins in `test/corpus/lt-as-str.txt`
- 3 behavior tests + 2 `RawInline` regression guards in pampa's `test_bare_lt_str.rs`

Verification: tree-sitter corpus 545/545; full `cargo xtask verify` green (workspace build + tests, WASM leg, hub-client build + tests); no `.snap` changes.

Plan: `claude-notes/plans/2026-08-07-angle-bracket-inner-whitespace.md` (bd-ly83qewg)

🤖 Generated with [Claude Code](https://claude.com/claude-code)