### PR TITLE
Suppress Q-5-12 render-scripts warning in q2 preview (bd-pq72bplh)

### DIFF
--- a/claude-notes/plans/2026-08-08-q5-12-suppress-in-q2-preview.md
+++ b/claude-notes/plans/2026-08-08-q5-12-suppress-in-q2-preview.md
@@ -1,0 +1,232 @@
+# Suppress the Q-5-12 render-scripts warning in `q2 preview`
+
+**Strand:** bd-pq72bplh (caused-by bd-w348iu63)
+**Status:** in progress — Option A + full suppression approved by Carlos 2026-08-08.
+
+## Overview
+
+`q2 preview` of a project that configures `project.pre-render` /
+`project.post-render` scripts shows the "Render Warning" overlay:
+
+> [Q-5-12] Project render scripts do not run in the hub preview — This
+> project configures `project.pre-render` / `project.post-render` scripts,
+> which cannot run in the browser. The preview renders without them; use
+> `q2 render` on a machine with the interpreters installed to run the
+> scripts.
+
+That message is correct for the **hub-client** preview (browser-only, no
+subprocesses) but false for **`q2 preview`**, whose native host *does* run
+pre-render scripts once at server boot (design decision D7 of
+`claude-notes/plans/2026-07-29-pre-post-render-scripts.md`). Goal: stop
+showing Q-5-12 in `q2 preview` while keeping it in the hub preview.
+
+## Reproduction (2026-08-08, verified end-to-end)
+
+Scratch project: `_quarto.yml` with `project.type: website` +
+`project.pre-render: pre.sh`; `pre.sh` writes `pre-ran.txt`; one
+`index.qmd`.
+
+```
+cargo run --bin q2 -- preview <scratch-dir> --port 7799 --no-browser
+```
+
+Observed (output inspected directly):
+
+- Terminal prints `Running pre-render script: pre.sh` and `pre-ran.txt`
+  appears on disk — **the script ran**.
+- Chrome at `http://127.0.0.1:7799/?page=index.qmd` shows the ⚠ Warning
+  pill; expanding it shows exactly the Q-5-12 text quoted above
+  (inspected via devtools a11y snapshot of the `PreviewDiagnosticsOverlay`).
+
+## Root cause
+
+One shared WASM function serves two hosts with different script semantics:
+
+- **Warning emitter:** `render_project_active_page_to_response`
+  (`crates/wasm-quarto-hub-client/src/lib.rs:1598`) unconditionally appends
+  `render_scripts_unsupported_diagnostic(&project.config)`
+  (`src/lib.rs:1776` / builder at `:1858`) whenever the project config has
+  any pre/post-render scripts. Once-per-session gating via a static
+  `AtomicBool`.
+- **Hub-client** reaches it through `render_page_in_project` /
+  `render_page_in_project_with_attribution` (`src/lib.rs:1121`, `:1184`).
+  Here the warning is *correct*: the browser cannot run the scripts.
+- **`q2 preview`** reaches it through `render_page_for_preview`
+  (`src/lib.rs:1290`) — the entry point the q2-preview SPA calls
+  exclusively (`q2-preview-spa/src/PreviewApp.tsx:1062`). Here the warning
+  is *wrong*: the native server already ran pre-render scripts at boot
+  (`run_boot_pre_render_scripts`, `crates/quarto-preview/src/lib.rs:301`,
+  invoked from the on-ready hook at `:223`), and their outputs are on disk
+  and synced into the preview VFS before any page render.
+
+Script-semantics truth table (per D7, all deliberate):
+
+| Host | pre-render | post-render |
+|---|---|---|
+| `q2 render` | every invocation | every invocation |
+| `q2 preview` | once at boot (restart to re-run) | never (no materialized output dir in the preview loop) |
+| hub preview | never | never |
+
+So in `q2 preview` the only true statement is "post-render scripts don't
+run" — and post-render has no observable effect in the preview loop
+anyway, since nothing consumes an output dir.
+
+The existing `prefer_preview_format: bool` parameter happens to correlate
+with the caller today (`true` only from `render_page_for_preview`), but it
+means "apply the q2-preview format-default substitution", not "the host
+runs render scripts" — and a hub document could in principle reach the
+`pipeline_kind == "preview"` branch via an explicit format. Overloading it
+would conflate two meanings; we should thread explicit host information
+instead.
+
+## Design options
+
+### Option A (recommended): thread host context, suppress for `q2 preview`
+
+Add an explicit host parameter to the shared path and gate the warning on
+it. Sketch:
+
+1. In `crates/wasm-quarto-hub-client/src/lib.rs`, add a small enum:
+
+   ```rust
+   /// Which application is driving this WASM render. Decides
+   /// host-dependent diagnostics (Q-5-12: the q2-preview native host
+   /// runs pre-render scripts at boot; the hub browser cannot).
+   #[derive(Clone, Copy, PartialEq, Eq)]
+   enum RenderHost {
+       HubClient,
+       NativePreview,
+   }
+   ```
+
+2. `render_project_active_page_to_response` takes `host: RenderHost`;
+   `render_page_in_project_with_attribution` passes `HubClient`,
+   `render_page_for_preview` passes `NativePreview`. (The single-doc path
+   needs no parameter — single-file projects have no `_quarto.yml`, hence
+   no scripts, and the warning is only emitted on the project path.)
+
+3. The warning push becomes:
+
+   ```rust
+   if host == RenderHost::HubClient {
+       if let Some(diag) = render_scripts_unsupported_diagnostic(&project.config) { ... }
+   }
+   ```
+
+4. For testability, split the existing function: a **pure** builder
+   `fn render_scripts_unsupported_diagnostic_pure(config) -> Option<DiagnosticMessage>`
+   (no static), wrapped by the existing once-per-session AtomicBool gate.
+   Unit tests target the pure part plus a host-gating helper
+   (`fn should_warn_render_scripts(host, config) -> bool`), avoiding
+   cross-test interference from the static.
+
+No message text, catalog entry, or hub behavior changes. The `q2 preview`
+user story is covered natively: the terminal prints
+`Running pre-render script: …` at boot, failures print with a
+"restart to re-run" note, and the deviations are documented per D7.
+
+### Option B (alternative): preview-specific milder note
+
+Instead of full suppression, `NativePreview` gets a different, accurate
+info-level note — e.g. only when `post_render_scripts` is non-empty:
+"post-render scripts do not run in `q2 preview`; they run in `q2 render`"
+(new catalog code Q-5-13). Rejected as the default because post-render has
+no observable effect in the preview loop (nothing consumes the output
+dir), so the note is noise; and pre-render staleness ("edited `pre.sh`,
+preview didn't re-run it") is better handled someday by the native side,
+which actually knows when the scripts last ran. Noted here so we can
+revisit if users get confused by boot-only cadence.
+
+### Option C (rejected): filter Q-5-12 in the q2-preview SPA
+
+Have `PreviewApp.tsx` / `PreviewDiagnosticsOverlay` drop warnings with
+code Q-5-12. Wrong layer: the engine knows which host it serves; the SPA
+would be string-matching a code to undo an upstream mistake, and the
+incorrect warning would still sit in the `RenderResponse` for any other
+consumer.
+
+## Work items (Option A, TDD)
+
+### Phase 1 — tests first
+
+- [x] Unit tests for the host-gating decision. **Placement change from
+      the original sketch:** `crates/wasm-quarto-hub-client` is
+      `exclude`d from the workspace (root `Cargo.toml:12`), so tests
+      there would never run under `cargo nextest run --workspace`.
+      The pure decision fn + `RenderHost` enum therefore live in
+      `quarto-core::project::render_scripts` (alongside the other
+      Q-5-x diagnostics), tests in its `unsupported_diagnostic` test
+      module: hub+pre → warn; hub+post-only → warn; native-preview +
+      any combination → silent; no scripts → silent for both hosts.
+      Verified red first (E0432 on the not-yet-existing API), then
+      green after implementation (4/4 pass).
+- [x] WASM-level regression test
+      `hub-client/src/services/renderScriptsWarning.wasm.test.ts`
+      (vitest, real WASM): `render_page_for_preview` → no Q-5-12;
+      then `render_page_in_project` → exactly one Q-5-12 (proving the
+      suppressed path doesn't consume the once-gate); then again → none
+      (once-per-session). Added after the Rust red/green cycle, so its
+      red state was not observed against the pre-fix WASM; the Rust
+      unit test carried the TDD burden.
+
+### Phase 2 — implementation
+
+- [x] `RenderHost { HubClient, NativePreview }` + pure
+      `render_scripts_unsupported_diagnostic(host, config)` in
+      `quarto-core::project::render_scripts` (message text unchanged).
+      WASM crate keeps only the once-per-session AtomicBool wrapper
+      (`render_scripts_unsupported_once`) and threads
+      `host: RenderHost` through
+      `render_project_active_page_to_response`
+      (`render_page_in_project_with_attribution` → `HubClient`,
+      `render_page_for_preview` → `NativePreview`).
+- [x] `cargo build --workspace` clean; targeted nextest green;
+      `cd hub-client && npm run build:wasm` clean (direct
+      `cargo check --target wasm32-unknown-unknown` fails in cc on
+      tree-sitter C parsers — the npm script is the sanctioned build).
+- [ ] `cargo nextest run --workspace` (full run; scheduled with the
+      Phase 3 verification).
+
+### Phase 3 — end-to-end verification (both hosts)
+
+- [x] Rebuilt the preview chain: `cd hub-client && npm run build:wasm`,
+      `cargo xtask build-q2-preview-spa`, `cargo build --bin q2`
+      (dist WASM timestamp confirmed fresh before the binary rebuild).
+- [x] Re-ran the reproduction end-to-end (2026-08-08):
+      `cargo run --bin q2 -- preview <scratch-dir> --port 7799
+      --no-browser` on the same scratch project. Observed and
+      inspected directly: terminal printed
+      `Running pre-render script: pre.sh`; `pre-ran.txt` recreated on
+      disk; page rendered in Chrome; devtools a11y snapshot shows
+      **no** "⚠ Warning" button (previously present at the same spot),
+      a `wait_for("Warning")` probe timed out, and a screenshot shows
+      a clean page.
+- [x] Hub path: Q-5-12 still fires — verified by executing the real
+      WASM through the hub entry point (`render_page_in_project`) in
+      `renderScriptsWarning.wasm.test.ts`: exactly one Q-5-12 warning
+      on first render, none on second (once-gate). **Not** verified in
+      a live hub browser session (a local-prod + Automerge project
+      setup was judged not worth the cost given the WASM-level test
+      hits the identical code path).
+- [x] `cargo nextest run --workspace`: 11069 passed, 0 failed.
+- [x] Full `cargo xtask verify` (no skips): all steps passed
+      (2026-08-08). `cargo clippy -p quarto-core` clean.
+
+### Phase 4 — wrap-up
+
+- [x] Record the end-to-end invocation + observed output in this plan
+      (see Phase 3 items and the Reproduction section).
+- [ ] Commit (staged; awaiting Carlos's approval per
+      `claude-notes/instructions/review.md`).
+- [ ] `braid close bd-pq72bplh`.
+
+## Open questions for review
+
+1. **Suppress entirely vs Option B's post-render note** — recommendation:
+   suppress entirely (Option A); revisit B only on user confusion.
+2. **Enum vs bool** — recommendation: the two-variant `RenderHost` enum
+   (self-documenting at call sites, room for future host-dependent
+   diagnostics); a `host_runs_render_scripts: bool` would also do.
+3. Should the Q-5-12 catalog `message_template` stay as-is? It already
+   says "the browser-based hub preview", which remains accurate for the
+   only host that will still emit it. Recommendation: leave untouched.

--- a/claude-notes/plans/2026-08-08-q5-12-suppress-in-q2-preview.md
+++ b/claude-notes/plans/2026-08-08-q5-12-suppress-in-q2-preview.md
@@ -216,9 +216,14 @@ consumer.
 
 - [x] Record the end-to-end invocation + observed output in this plan
       (see Phase 3 items and the Reproduction section).
-- [ ] Commit (staged; awaiting Carlos's approval per
-      `claude-notes/instructions/review.md`).
-- [ ] `braid close bd-pq72bplh`.
+- [x] Committed as `87393d27` on
+      `bugfix/bd-pq72bplh-q5-12-preview-warning`; PR
+      https://github.com/quarto-dev/q2/pull/472 (changelog entry
+      skipped per Carlos — test-only hub-client change).
+- [x] CI green on the PR: all 8 checks pass (test suites on
+      ubuntu/macos across both workflows, WASM Tests, Hub-Client E2E,
+      Snyk license/security), 2026-08-08.
+- [ ] `braid close bd-pq72bplh` (after merge).
 
 ## Open questions for review
 

--- a/crates/quarto-core/src/project/render_scripts.rs
+++ b/crates/quarto-core/src/project/render_scripts.rs
@@ -148,6 +148,58 @@ pub fn underscore_typo_diagnostics(config: &ProjectConfig) -> Vec<DiagnosticMess
         .collect()
 }
 
+/// Which application is hosting a WASM render (bd-pq72bplh).
+///
+/// The two hosts have different render-script semantics (D7 in
+/// `claude-notes/plans/2026-07-29-pre-post-render-scripts.md`): the
+/// hub preview runs entirely in the browser and can never execute
+/// scripts, while `q2 preview`'s native server runs
+/// `project.pre-render` scripts once at boot, before any page render
+/// (post-render scripts don't run in the preview loop — a documented
+/// deviation, as nothing consumes a materialized output dir there).
+/// Host-dependent diagnostics dispatch on this.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RenderHost {
+    /// The hub-client web app: browser-only, no subprocesses.
+    HubClient,
+    /// The `q2 preview` SPA embedded in the `q2` binary, backed by a
+    /// native server that ran pre-render scripts at boot.
+    NativePreview,
+}
+
+/// Q-5-12: warn that configured `project.pre-render` /
+/// `project.post-render` scripts will not run — but only for the host
+/// where that is actually true ([`RenderHost::HubClient`]).
+/// [`RenderHost::NativePreview`] returns `None`: its native side
+/// already ran the pre-render scripts at boot, so the warning would
+/// be false (bd-pq72bplh).
+///
+/// Pure decision + message builder: no once-per-session gating here.
+/// The WASM caller (`wasm-quarto-hub-client`) layers an AtomicBool
+/// once-gate on top so the warning shows at most once per session.
+pub fn render_scripts_unsupported_diagnostic(
+    host: RenderHost,
+    config: &ProjectConfig,
+) -> Option<DiagnosticMessage> {
+    if host != RenderHost::HubClient {
+        return None;
+    }
+    if config.pre_render_scripts.is_empty() && config.post_render_scripts.is_empty() {
+        return None;
+    }
+    Some(
+        DiagnosticMessageBuilder::warning("Project render scripts do not run in the hub preview")
+            .with_code("Q-5-12")
+            .problem(
+                "This project configures `project.pre-render` / `project.post-render` \
+                 scripts, which cannot run in the browser. The preview renders without \
+                 them; use `q2 render` on a machine with the interpreters installed to \
+                 run the scripts.",
+            )
+            .build(),
+    )
+}
+
 #[cfg(not(target_arch = "wasm32"))]
 mod exec {
     use std::path::{Path, PathBuf};
@@ -744,6 +796,74 @@ mod tests {
                 ),
             )];
             assert!(check_forbidden_mutations(&before, &after).is_ok());
+        }
+    }
+
+    // ── host-dependent Q-5-12 diagnostic (bd-pq72bplh) ──────────────
+
+    mod unsupported_diagnostic {
+        use super::super::{RenderHost, RenderScript, render_scripts_unsupported_diagnostic};
+        use crate::project::ProjectConfig;
+
+        fn script(cmd: &str) -> RenderScript {
+            RenderScript {
+                command: cmd.to_string(),
+                source_info: quarto_source_map::SourceInfo::generated(
+                    quarto_source_map::By::programmatic_config(),
+                ),
+            }
+        }
+
+        fn config_with_scripts(pre: &[&str], post: &[&str]) -> ProjectConfig {
+            ProjectConfig {
+                pre_render_scripts: pre.iter().map(|c| script(c)).collect(),
+                post_render_scripts: post.iter().map(|c| script(c)).collect(),
+                ..Default::default()
+            }
+        }
+
+        #[test]
+        fn hub_client_with_pre_render_scripts_warns() {
+            let config = config_with_scripts(&["prepare.py"], &[]);
+            let diag = render_scripts_unsupported_diagnostic(RenderHost::HubClient, &config)
+                .expect("hub preview must warn: the browser cannot run the scripts");
+            let text = diag.to_text(None);
+            assert!(text.contains("[Q-5-12]"), "got: {text}");
+            assert!(text.contains("hub preview"), "got: {text}");
+        }
+
+        #[test]
+        fn hub_client_with_post_render_scripts_only_warns() {
+            let config = config_with_scripts(&[], &["cleanup.R"]);
+            assert!(
+                render_scripts_unsupported_diagnostic(RenderHost::HubClient, &config).is_some(),
+                "post-render-only projects must still warn in the hub preview"
+            );
+        }
+
+        #[test]
+        fn native_preview_with_scripts_is_silent() {
+            // `q2 preview`'s native host runs pre-render scripts at
+            // boot (D7, 2026-07-29 plan) — the warning would be false.
+            for config in [
+                config_with_scripts(&["prepare.py"], &[]),
+                config_with_scripts(&[], &["cleanup.R"]),
+                config_with_scripts(&["prepare.py"], &["cleanup.R"]),
+            ] {
+                assert!(
+                    render_scripts_unsupported_diagnostic(RenderHost::NativePreview, &config)
+                        .is_none(),
+                    "q2 preview must not warn: its native host runs the scripts"
+                );
+            }
+        }
+
+        #[test]
+        fn no_scripts_is_silent_for_both_hosts() {
+            let config = config_with_scripts(&[], &[]);
+            for host in [RenderHost::HubClient, RenderHost::NativePreview] {
+                assert!(render_scripts_unsupported_diagnostic(host, &config).is_none());
+            }
         }
     }
 

--- a/crates/wasm-quarto-hub-client/src/lib.rs
+++ b/crates/wasm-quarto-hub-client/src/lib.rs
@@ -19,14 +19,14 @@ use std::path::Path;
 use std::rc::Rc;
 use std::sync::{Arc, OnceLock};
 
+use quarto_core::project::render_scripts::RenderHost;
 use quarto_core::{
     BinaryDependencies, DocumentInfo, Format, HtmlRenderConfig, ProjectConfig, ProjectContext,
     QuartoError, RenderContext, RenderOptions, ResourceResolverContext, render_qmd_to_html,
     render_qmd_to_preview_ast,
 };
 use quarto_error_reporting::{
-    DiagnosticMessage, DiagnosticMessageBuilder, JsonDiagnostic, JsonPass1Failure,
-    diagnostic_to_json, with_source_file,
+    DiagnosticMessage, JsonDiagnostic, JsonPass1Failure, diagnostic_to_json, with_source_file,
 };
 use quarto_pandoc_types::ConfigValue;
 use quarto_sass::{
@@ -1261,6 +1261,7 @@ pub async fn render_page_in_project_with_attribution(
         project,
         user_grammars,
         false,
+        RenderHost::HubClient,
         captures,
         attribution_json,
     )
@@ -1349,6 +1350,7 @@ pub async fn render_page_for_preview(
         project,
         user_grammars,
         true,
+        RenderHost::NativePreview,
         captures,
         None,
     )
@@ -1601,6 +1603,11 @@ async fn render_project_active_page_to_response(
     mut project: ProjectContext,
     user_grammars: Option<JsUserGrammars>,
     prefer_preview_format: bool,
+    // bd-pq72bplh: which application is driving this render. Decides
+    // host-dependent diagnostics (Q-5-12) — deliberately separate from
+    // `prefer_preview_format`, which is about format substitution and
+    // only happens to correlate with the caller today.
+    host: RenderHost,
     // bd-lucp / bd-5yff4: recorded engine capture sequence attached to
     // the q2-preview pass-2 renderer (one per engine, in order).
     // `RenderToPreviewAstRenderer::with_captures` threads them into every
@@ -1773,7 +1780,9 @@ async fn render_project_active_page_to_response(
     all_diags.extend(summary.project_diagnostics);
     // bd-w348iu63: project render scripts can't run in the browser —
     // surface a one-time warning instead of silently ignoring them.
-    if let Some(diag) = render_scripts_unsupported_diagnostic(&project.config) {
+    // bd-pq72bplh: host-dependent — `q2 preview`'s native server runs
+    // pre-render scripts at boot, so only the hub host warns.
+    if let Some(diag) = render_scripts_unsupported_once(host, &project.config) {
         all_diags.push(diag);
     }
     let warnings = diagnostics_to_json(&all_diags, &active_output.source_context);
@@ -1849,32 +1858,29 @@ async fn render_project_active_page_to_response(
     .unwrap()
 }
 
-/// bd-w348iu63: once-per-session warning when the project declares
-/// `project.pre-render` / `project.post-render` scripts, which the
-/// browser preview cannot run (no subprocesses in WASM). Returns
-/// `None` when no scripts are configured or the warning already
-/// fired. WASM is single-threaded, but `AtomicBool` keeps the static
-/// safe by construction.
-fn render_scripts_unsupported_diagnostic(config: &ProjectConfig) -> Option<DiagnosticMessage> {
+/// bd-w348iu63 / bd-pq72bplh: once-per-session Q-5-12 warning when the
+/// project declares `project.pre-render` / `project.post-render`
+/// scripts the current host cannot run. The host-dependent decision
+/// and message live in
+/// [`quarto_core::project::render_scripts::render_scripts_unsupported_diagnostic`]
+/// (pure: [`RenderHost::NativePreview`] never warns, because `q2
+/// preview`'s native server ran the pre-render scripts at boot); this
+/// wrapper adds the once-per-session gate. Returns `None` when the
+/// host/config combination doesn't warrant a warning or the warning
+/// already fired. WASM is single-threaded, but `AtomicBool` keeps the
+/// static safe by construction.
+fn render_scripts_unsupported_once(
+    host: RenderHost,
+    config: &ProjectConfig,
+) -> Option<DiagnosticMessage> {
     use std::sync::atomic::{AtomicBool, Ordering};
     static WARNED: AtomicBool = AtomicBool::new(false);
-    if config.pre_render_scripts.is_empty() && config.post_render_scripts.is_empty() {
-        return None;
-    }
+    let diag =
+        quarto_core::project::render_scripts::render_scripts_unsupported_diagnostic(host, config)?;
     if WARNED.swap(true, Ordering::Relaxed) {
         return None;
     }
-    Some(
-        DiagnosticMessageBuilder::warning("Project render scripts do not run in the hub preview")
-            .with_code("Q-5-12")
-            .problem(
-                "This project configures `project.pre-render` / `project.post-render` \
-                 scripts, which cannot run in the browser. The preview renders without \
-                 them; use `q2 render` on a machine with the interpreters installed to \
-                 run the scripts.",
-            )
-            .build(),
-    )
+    Some(diag)
 }
 
 /// Build a `success: false` response with no diagnostics.

--- a/hub-client/src/services/renderScriptsWarning.wasm.test.ts
+++ b/hub-client/src/services/renderScriptsWarning.wasm.test.ts
@@ -1,0 +1,107 @@
+/**
+ * WASM safety net for the host-dependent Q-5-12 render-scripts
+ * warning (bd-pq72bplh).
+ *
+ * A project that configures `project.pre-render` / `project.post-render`
+ * scripts must warn in the hub preview (the browser cannot run the
+ * scripts) but NOT in `q2 preview` (its native server runs pre-render
+ * scripts once at boot — see D7 in
+ * `claude-notes/plans/2026-07-29-pre-post-render-scripts.md`). The two
+ * hosts enter the WASM through different entry points:
+ * `render_page_in_project` (hub-client) vs `render_page_for_preview`
+ * (q2-preview SPA).
+ *
+ * Call order inside the single test matters: the warning is
+ * once-per-session (AtomicBool in the WASM module, one instance per
+ * test file). Rendering through the preview entry point FIRST also
+ * proves the suppressed path does not consume the once-gate.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import { readFile } from 'fs/promises';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+import { initWasm, vfsAddFile, vfsClear } from '@quarto/preview-runtime';
+
+interface JsonDiagnosticLike {
+    kind: string;
+    code?: string;
+}
+
+interface RenderResponse {
+    success: boolean;
+    error?: string;
+    warnings?: JsonDiagnosticLike[];
+}
+
+let renderInProject: (path: string) => Promise<string>;
+let renderForPreview: (path: string) => Promise<string>;
+
+beforeAll(async () => {
+    // Pre-load the WASM module with explicit bytes — node has no
+    // `fetch`, so an argless `wasm.default()` would fail.
+    const __dirname = dirname(fileURLToPath(import.meta.url));
+    const wasmDir = join(__dirname, '../../wasm-quarto-hub-client');
+    const wasmPath = join(wasmDir, 'wasm_quarto_hub_client_bg.wasm');
+    const wasmBytes = await readFile(wasmPath);
+    const wasm = (await import('wasm-quarto-hub-client')) as unknown as {
+        default: (input?: BufferSource) => Promise<unknown>;
+        render_page_in_project: (path: string) => Promise<string>;
+        render_page_for_preview: (path: string) => Promise<string>;
+    };
+    await wasm.default(wasmBytes);
+
+    // Initialize the wasmRenderer singleton so the VFS helpers
+    // (`vfsAddFile`, `vfsClear`) talk to the already-loaded module.
+    // wasm-bindgen's `__wbg_init` is idempotent.
+    await initWasm();
+
+    renderInProject = wasm.render_page_in_project.bind(wasm);
+    renderForPreview = wasm.render_page_for_preview.bind(wasm);
+});
+
+beforeEach(() => {
+    vfsClear();
+});
+
+function q512Warnings(response: RenderResponse): JsonDiagnosticLike[] {
+    return (response.warnings ?? []).filter((w) => w.code === 'Q-5-12');
+}
+
+describe('host-dependent Q-5-12 render-scripts warning (bd-pq72bplh)', () => {
+    it('warns in the hub entry point but not the q2-preview entry point', async () => {
+        vfsAddFile(
+            '_quarto.yml',
+            'project:\n  type: default\n  pre-render: pre.sh\n',
+        );
+        vfsAddFile('index.qmd', '---\ntitle: Repro\n---\n\nHello.\n');
+
+        // 1. q2-preview host: no warning — the native server already
+        //    ran the pre-render scripts at boot.
+        const preview = JSON.parse(
+            await renderForPreview('/project/index.qmd'),
+        ) as RenderResponse;
+        expect(preview.success, `preview render failed: ${preview.error}`).toBe(
+            true,
+        );
+        expect(q512Warnings(preview)).toEqual([]);
+
+        // 2. Hub host: the warning fires — and the suppressed preview
+        //    render above must not have consumed the once-per-session
+        //    gate.
+        const hub = JSON.parse(
+            await renderInProject('/project/index.qmd'),
+        ) as RenderResponse;
+        expect(hub.success, `hub render failed: ${hub.error}`).toBe(true);
+        const warnings = q512Warnings(hub);
+        expect(warnings).toHaveLength(1);
+        expect(warnings[0].kind).toBe('warning');
+
+        // 3. Hub host again: once-per-session — no repeat.
+        const hubAgain = JSON.parse(
+            await renderInProject('/project/index.qmd'),
+        ) as RenderResponse;
+        expect(hubAgain.success).toBe(true);
+        expect(q512Warnings(hubAgain)).toEqual([]);
+    });
+});


### PR DESCRIPTION
## Summary

`q2 preview` of a project with `project.pre-render` / `project.post-render` scripts showed the Q-5-12 "Render Warning" overlay claiming the scripts do not run — which is true for the hub preview but false for `q2 preview`, whose native server runs pre-render scripts once at boot (D7 of the bd-w348iu63 plan).

- Add `RenderHost { HubClient, NativePreview }` and a pure `render_scripts_unsupported_diagnostic(host, config)` in `quarto-core::project::render_scripts`; the warning is emitted only for the hub host.
- The WASM crate keeps just the once-per-session gate and threads the host from its two entry points (`render_page_in_project*` → `HubClient`, `render_page_for_preview` → `NativePreview`).
- Hub behavior and message text unchanged; `q2 preview` no longer warns.

Plan + investigation record: `claude-notes/plans/2026-08-08-q5-12-suppress-in-q2-preview.md` (strand bd-pq72bplh, caused-by bd-w348iu63).

## Test plan

- quarto-core unit tests for the host gating (TDD: verified red first).
- New `hub-client/src/services/renderScriptsWarning.wasm.test.ts` runs the real WASM through both entry points: preview silent, hub warns exactly once, suppressed path doesn't consume the once-gate.
- Verified end-to-end: full WASM→SPA→`q2` rebuild, `q2 preview` on a scratch project with a bash pre-render script — script runs, warning pill gone (devtools-inspected).
- `cargo nextest run --workspace` (11,069 passed) and full `cargo xtask verify` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)