### PR TITLE
Hard-error on unknown project.type; route discovery parse diagnostics structurally (bd-sekn481x, bd-y56u1gl7)

### DIFF
--- a/claude-notes/plans/2026-08-08-discovery-error-structured-diagnostics.md
+++ b/claude-notes/plans/2026-08-08-discovery-error-structured-diagnostics.md
@@ -1,0 +1,134 @@
+# Route structured diagnostics through discovery errors (bd-y56u1gl7)
+
+**Strand:** bd-y56u1gl7 (discovered-from bd-sekn481x)
+**Status:** done — all gates green (2026-08-08; workspace suite
+11075 passed, `cargo xtask verify --skip-hub-build` passed)
+
+## Situation
+
+All project-discovery failures in `q2 render` are flattened to a
+string at nine `.map_err(|e| DispatchError::Discover(e.to_string()))`
+call sites in `crates/quarto/src/commands/render.rs` (lines 240–428).
+For a structured `QuartoError::Parse` — the new Q-5-17
+unknown-project-type error, or any `_quarto.yml` parse failure —
+`to_string()` is the fully *rendered* diagnostic (ANSI colors,
+Ariadne snippet and all), which then gets re-wrapped:
+
+- **Text path** (`execute`, line ~668): `Err(anyhow!("{}", e))` →
+  anyhow's top level prints `Error: ` + `Display for
+  DispatchError::Discover` prints `Project discovery failed: ` + the
+  embedded rendering starts with its own `Error: [Q-5-17]`. Net:
+  `Error: Project discovery failed: Error: [Q-5-17] …` — double
+  prefix plus a wrapper that adds nothing.
+- **`--json-errors` path** (`emit_dispatch_error_json` →
+  `dispatch_error_to_diagnostic`, line ~1404): everything becomes a
+  generic **Q-7-8 "Project Discovery Failed"** diagnostic whose
+  `problem` field contains the ANSI-escape-soaked rendered text.
+  The real code (Q-5-17), the span, and the file are all buried in
+  an opaque string — machine consumers can't discriminate. This is
+  worse than cosmetic.
+
+The right pattern already exists 60 lines away: for *pipeline-stage*
+parse errors, `execute_single_doc` (line ~740) matches
+`Err(QuartoError::Parse(parse_error))` and either
+`eprintln!("{parse_error}")` + exit 1 (bare rendered diagnostic, no
+wrapper) or `emit_parse_error_json(&parse_error, …)` (one JSON line
+per contained diagnostic, real codes, real source context). Discovery
+errors just never reach it.
+
+## Proposed fix
+
+Carry the `ParseError` structurally through `DispatchError` and route
+it into the existing printers.
+
+1. **New variant** `DispatchError::DiscoverParse(quarto_core::ParseError)`
+   (`ParseError` is `Clone + Debug`; no payload-type gymnastics).
+   Keep `Discover(String)` for the non-structured cases (runtime I/O
+   errors from `path_exists`, etc.).
+2. **One helper** `fn discover_error(e: QuartoError) -> DispatchError`
+   used at the `ProjectContext::discover`-shaped call sites:
+   `QuartoError::Parse(pe) => DiscoverParse(pe)`, everything else →
+   `Discover(e.to_string())`. The `path_exists` sites keep the plain
+   string mapping (their errors aren't `QuartoError`).
+3. **Text path**: in `execute`'s classify error arm, mirror
+   `execute_single_doc`: on `DiscoverParse(pe)`, `eprintln!("{pe}")`
+   and `std::process::exit(1)` instead of bubbling through anyhow.
+   Output becomes exactly the bare rendered diagnostic — single
+   `Error: [Q-5-17]` header, snippet, info — nothing else.
+4. **JSON path**: in `emit_dispatch_error_json`, on `DiscoverParse(pe)`
+   call `emit_parse_error_json(&pe, None)` — real per-diagnostic
+   codes and locations. Q-7-8 remains for genuinely unstructured
+   discovery failures.
+5. `Display for DiscoverParse` renders the `ParseError` bare (the
+   diagnostic is self-describing); `dispatch_error_to_diagnostic`
+   gets an arm returning the first contained diagnostic (fallback to
+   a Q-7-8-shaped message if the vec is somehow empty).
+
+Non-goals: the redundant re-`discover()` calls inside
+`execute_single_doc`/`execute_project` (their parse failures are
+caught by classification first); any change to the other Q-7-N
+dispatch diagnostics.
+
+## Test plan (TDD)
+
+Tests live in the existing files for their layer.
+
+1. **Unit (render.rs tests)**: `classify_inputs` on a project whose
+   `_quarto.yml` has `type: posit-docs` yields
+   `DispatchError::DiscoverParse(pe)` with `pe.diagnostics[0].code ==
+   Some("Q-5-17")` (variant pin, per the module's convention).
+2. **E2e text** (extend `tests/integration/unknown_project_type.rs`):
+   stderr contains exactly one `Error:` occurrence and no
+   `Project discovery failed`; still contains `Q-5-17` and the
+   snippet filename.
+3. **E2e json** (extend `tests/integration/json_errors.rs`): render
+   the same fixture with `--json-errors`; the emitted line parses as
+   JSON, has `code == "Q-5-17"` (not Q-7-8), and carries a location;
+   no ANSI escapes in the payload.
+4. Existing suites stay green (`cargo nextest run --workspace`);
+   `--json-errors` shape for unstructured discovery errors (Q-7-8)
+   unchanged.
+
+## Work items
+
+- [x] Phase 0: failing tests. Text e2e
+      (`unknown_project_type_diagnostic_is_not_double_wrapped`) and
+      json e2e (`discovery_parse_error_json_carries_real_code`)
+      observed failing at runtime pre-fix (json failure captured the
+      Q-7-8 envelope with ANSI-soaked `problem` verbatim); unit
+      variant pin (`classify_project_with_unknown_type_yields_structured_parse_error`)
+      red as a compile failure until the variant landed.
+- [x] Phase 1: `DiscoverParse(ParseError)` variant +
+      `discover_error` helper; the three `ProjectContext::discover`
+      call sites converted (the six runtime-I/O sites keep
+      `Discover(String)`).
+- [x] Phase 2: `execute` prints `DiscoverParse` bare + exit 1
+      (mirrors `execute_single_doc`); `emit_dispatch_error_json`
+      routes it to `emit_parse_error_json`;
+      `dispatch_error_to_diagnostic` kept total (first diagnostic,
+      Q-7-8 fallback on empty).
+- [x] Phase 3: 23/23 targeted tests green; `cargo xtask lint` clean;
+      full workspace suite green.
+- [x] Phase 4: manual e2e (below); `cargo xtask verify
+      --skip-hub-build` — change confined to `crates/quarto` (git
+      status confirms), not in the WASM closure.
+
+## End-to-end verification record (2026-08-08)
+
+Text mode (`q2 render <repro-dir>`, exit 1) — single header, no
+wrapper:
+
+```
+Error: [Q-5-17] Unknown project type `posit-docs`
+   ╭─[ <repro-dir>/_quarto.yml:2:9 ]
+   ...snippet + info as before, nothing else...
+```
+
+JSON mode (`q2 render <repro-dir> --json-errors`, exit 1) — one
+NDJSON line, real code + location, no ANSI:
+
+```
+{"code":"Q-5-17","kind":"error","title":"Unknown project type `posit-docs`","start_line":2,"start_column":9}
+```
+
+Output inspected directly on the standalone repro from bd-sekn481x.

--- a/claude-notes/plans/2026-08-08-unknown-project-type-error.md
+++ b/claude-notes/plans/2026-08-08-unknown-project-type-error.md
@@ -1,0 +1,272 @@
+# Unknown `project.type` should be a hard error (bd-sekn481x)
+
+**Strand:** bd-sekn481x
+**Status:** done — implemented, all gates green (2026-08-08)
+
+**Review decisions (Carlos, 2026-08-08):** hard error (custom project
+type extensions likely tackled next anyway); no `_extensions/`-aware
+smart hint for now; hard error on the WASM/hub path is fine.
+
+## Symptom (as reported)
+
+`q2 render` on the posit-connect docs port
+(`~/repos/github/cscheid/q2-connect-docs/docs-quarto-2`) leaves shared
+JS/CSS strewn about the *source tree*: 351 `<stem>_files/` directories,
+each holding private copies of `quarto/bootstrap.bundle.min.js`,
+`quarto/clipboard.min.js`, `quarto/code-copy-init.js`, and
+`quarto/quarto-theme-*.css` (plus extension assets like
+`libs/quarto-tiers/quarto-tiers.css`). These were accidentally committed
+to the docs repo.
+
+The initial hypothesis was an `.md`-specific bug in shared-dependency
+determination. That is **not** the cause — `.qmd` documents in the same
+project get identical stray `_files/` dirs (e.g.
+`cookbook/index_files/`, from `cookbook/index.qmd`).
+
+## Root cause
+
+The connect docs project declares:
+
+```yaml
+project:
+  type: posit-docs
+```
+
+`posit-docs` is a Quarto 1 **extension project type**
+(`_extensions/posit-dev/posit-docs/_extension.yml`, which contributes
+`project.type: website` plus navbar/theme config). Q2 has no extension
+project-type support, and — the actual bug — it **silently discards the
+unknown type**:
+
+```rust
+// crates/quarto-core/src/project/mod.rs:651-656 (parse_config)
+let project_kind = metadata
+    .get("project")
+    .and_then(|p| p.get("type"))
+    .and_then(|t| t.as_str())
+    .and_then(|s| ProjectKind::try_from(s).ok())   // <-- Err swallowed
+    .unwrap_or_default();                           // <-- becomes Default
+```
+
+`ProjectKind::try_from` already returns
+`Err("Unknown project type: posit-docs")`; the `.ok()` throws that away
+and `unwrap_or_default()` yields `ProjectKind::Default`.
+
+A default-type project then behaves exactly as designed — and that
+design produces the symptom:
+
+- `DefaultProjectType::lib_dir()` returns `""` (orchestrator.rs:334),
+  so there is no shared `site_libs/`; every document's HTML dependencies
+  are flushed to a per-document `<stem>_files/` dir.
+- No `output-dir` default, so output lands **next to the sources**.
+
+So each of the ~350 documents got its own copy of the bootstrap bundle,
+in-tree. `.md` vs `.qmd` is irrelevant.
+
+### Verification (standalone repro)
+
+Minimal project (3 files) — recreate with:
+
+```bash
+mkdir -p /tmp/md-libs-repro/sub && cd /tmp/md-libs-repro
+cat > _quarto.yml <<'EOF'
+project:
+  type: posit-docs        # any unknown type
+  render: ["**/*.md", "**/*.qmd"]
+website:
+  title: "repro"
+EOF
+printf -- '---\ntitle: Home\n---\n\nSome `code`.\n' > index.qmd
+printf -- '---\ntitle: About\n---\n\nSome `code`.\n' > about.md
+printf -- '---\ntitle: Sub\n---\n\nMore.\n' > sub/page.md
+cargo run --bin q2 -- render /tmp/md-libs-repro
+```
+
+Observed (2026-08-08, workspace @ 5c714919):
+
+- `q2 render` prints `Rendering project: … (type: default)` — no
+  warning, no error — and exits 0.
+- Source tree afterwards contains `index_files/quarto/{bootstrap.bundle.min.js,
+  clipboard.min.js,code-copy-init.js,quarto-theme-*.css}`, plus identical
+  copies under `about_files/` and `sub/page_files/`.
+- Control: change `type: posit-docs` → `type: website`, wipe outputs,
+  re-render → everything lands in `_site/`, shared libs deduplicated in
+  `_site/site_libs/`, source tree untouched. Both `.md` and `.qmd`
+  inputs behave identically in both runs.
+
+### Quarto 1 comparison
+
+Q1 hard-errors (`quarto-cli/src/project/types/project-types.ts:47`):
+
+```
+ERROR: Unsupported project type no-such-type
+```
+
+(Verified against the local quarto-cli dev build. `posit-docs` works in
+Q1 only because the extension resolves it to `website`.)
+
+## Proposed fix
+
+Make an unknown `project.type` a **hard error** in
+`ProjectConfig::parse_config`, matching Q1. Silently rendering hundreds
+of junk files into a user's source tree is strictly worse than
+stopping; a warning-and-continue would still strew the files.
+
+Semantics:
+
+- `project.type` **absent** → `ProjectKind::Default` (unchanged — this
+  is the documented default and must keep working).
+- `project.type` present and recognized (`default` / `website` / `book`
+  / `manuscript`, case-insensitive) → unchanged.
+- `project.type` present but **unrecognized** → render fails before any
+  document is processed, with a source-located diagnostic.
+- `project.type` present but **not a string** (e.g. a map) → currently
+  also silently `Default` via the `as_str()` step; fold into the same
+  error path ("expected a string").
+
+### Diagnostic shape
+
+Use the existing `QuartoError::Parse(ParseError)` vehicle (error.rs:12)
+— `parse_config` has the file content in hand and can build the
+`SourceContext`; the `ConfigValue` for the `type` scalar carries
+`source_info` for the span. Modeled on `theme_diagnostic.rs` errors and
+the Q-5-11 unknown-key warning in `render_scripts.rs`:
+
+```
+error[Q-5-17]: Unknown project type `posit-docs`
+  --> _quarto.yml:7:9
+   |
+ 7 |   type: posit-docs
+   |         ^^^^^^^^^^
+   = problem: `project.type` must be one of `default`, `website`, `book`, or `manuscript`.
+   = info: Quarto 1 extension project types (from `_extensions/`) are not yet
+           supported in Quarto 2. If `posit-docs` comes from an extension, set
+           `project.type` to the base type the extension extends (for
+           `posit-docs`: `website`).
+```
+
+- Allocate **Q-5-17** in `crates/quarto-error-catalog/error_catalog.json`
+  (Q-5-1 … Q-5-16 are taken; Q-5-x is the project-config family).
+- The "extension" hint is generic wording; we should not special-case
+  `posit-docs` in code. (Open question 2 below considers whether to
+  detect `_extensions/<…>/<type>/` and tailor the hint.)
+
+### Non-goals
+
+- **No change to default-type projects' per-document `_files/` layout.**
+  That layout is intentional for `type: default` (and matches Q1);
+  the bug is only the misclassification.
+- **No extension project-type support.** That's a large feature; if we
+  want it, it deserves its own strand/epic. This fix's error message is
+  the honest interim behavior.
+
+## Test plan (TDD — written and failing before the fix)
+
+Where: `crates/quarto-core` unit tests next to the code they cover
+(project/mod.rs already has a `TryFrom` test block), plus the
+integration-test binary per `.claude/rules/integration-tests.md` if a
+render-level test is warranted.
+
+1. **Unit: unknown type errors.** `ProjectConfig::parse_config` (via a
+   `_quarto.yml` fixture string with `type: posit-docs`) returns
+   `Err(QuartoError::Parse(_))`; diagnostic carries code `Q-5-17`, names
+   `posit-docs`, and lists the four valid types. Verify the span points
+   at the `posit-docs` scalar (line/col from `source_info`).
+2. **Unit: absent type still defaults.** `_quarto.yml` without
+   `project.type` parses to `ProjectKind::Default` (regression guard for
+   the common case).
+3. **Unit: valid types unchanged.** `website`/`book`/`manuscript`/
+   `default`, plus case-insensitivity (`WEBSITE`) — mostly covered by
+   existing tests at mod.rs:736-768; extend if the parse path changes.
+4. **Unit: non-string type errors.** `type: {a: b}` produces the
+   "expected a string" flavor of Q-5-17 rather than silent Default.
+5. **Catalog test.** Q-5-17 registered, docs_url ends with the code —
+   mirror `theme_diagnostic_code_is_registered_in_catalog`
+   (theme_diagnostic.rs:271) and the Q-5-6/Q-5-7 checks in
+   quarto-error-catalog/src/lib.rs.
+6. **End-to-end (per CLAUDE.md verification policy).** Drive the real
+   binary: `cargo run --bin q2 -- render <repro-dir>` with the repro
+   above; assert non-zero exit, stderr contains `Q-5-17` and
+   `posit-docs`, and — critically — **no `*_files/` dirs and no `.html`
+   outputs are created** in the source tree. Then flip the fixture to
+   `type: website` and assert success. (Exact harness location TBD:
+   follow the existing pattern for render-CLI integration tests in
+   `crates/quarto/tests/integration/` if one exists, else
+   quarto-core's `render_document_to_file`-style e2e helper.)
+
+## Work items
+
+- [x] Phase 0: repro fixture + failing tests. Unit tests in
+      `project/mod.rs` (`project_type_config_tests`: unknown type,
+      non-string type, absent-type default, valid types, catalog
+      registration); e2e tests in
+      `crates/quarto/tests/integration/unknown_project_type.rs`
+      (registered in `main.rs`). Verified failing pre-fix: 3 unit
+      failures + e2e observed exit 0 with `(type: default)` and 3
+      documents rendered.
+- [x] Phase 1: Q-5-17 added to
+      `crates/quarto-error-catalog/error_catalog.json` (subsystem
+      `project`).
+- [x] Phase 2: `parse_config` now matches explicitly on
+      present/absent/unknown/non-string `project.type`; helper
+      `unknown_project_type_error` builds the `QuartoError::Parse`
+      with the config file registered under the scalar's FileId
+      (same technique as `resource_error_to_parse_error`).
+- [x] Phase 3: all 5 unit + 2 e2e tests pass. `cargo xtask lint`
+      clean. Full `cargo nextest run --workspace`: 11072 passed.
+- [x] Phase 4: e2e verification (see below).
+- [x] Phase 5: full `cargo xtask verify` — all steps passed
+      (2026-08-08).
+- [x] Cleanup check: `q2 render` on the real connect-docs port now
+      exits 1 up front with Q-5-17 pointing at `_quarto.yml:7:9`
+      (`type: posit-docs`) — nothing written. Remaining advisory for
+      that repo: switch it to `type: website` and delete the
+      committed `*_files/` dirs.
+
+## End-to-end verification record (2026-08-08)
+
+Invocation (real binary, repro project from § Verification above,
+with `type: posit-docs`):
+
+```
+$ cargo run --bin q2 -- render <repro-dir>   # exit code 1
+Error: Project discovery failed: Error: [Q-5-17] Unknown project type `posit-docs`
+   ╭─[ <repro-dir>/_quarto.yml:2:9 ]
+   │
+ 2 │   type: posit-docs
+   │         ─────┬────
+   │              ╰────── `project.type` must be one of `default`, `website`, `book`, or `manuscript`.
+───╯
+ℹ Quarto 1 extension project types (from `_extensions/`) are not yet supported in Quarto 2.
+  If `posit-docs` comes from an extension, set `project.type` to the base type that
+  extension extends (often `website`).
+```
+
+Output inspected: exit code 1; `find` over the project tree shows
+only the four source files — **no** `.html`, no `*_files/` dirs.
+Control run with `type: website` renders to `_site/` with shared
+`_site/site_libs/` and a clean source tree (covered continuously by
+the `website_type_control_renders_shared_libs` e2e test).
+
+Known cosmetic wart (pre-existing, out of scope): every discovery
+error — including YAML syntax errors — is stringified through
+`DispatchError::Discover(String)` (`crates/quarto/src/commands/render.rs`),
+so the rendered diagnostic arrives wrapped in
+`Error: Project discovery failed: …` and the Q-7-8 JSON-errors
+envelope. Making structured diagnostics flow through discovery
+dispatch would be a separate strand.
+
+## Open questions (for review)
+
+1. **Error vs. warn-and-default.** Plan says hard error (Q1 parity, and
+   the failure mode of continuing is nasty). Confirm you don't want a
+   softer landing for not-yet-ported extension types.
+2. **Smarter extension hint.** We could check
+   `_extensions/*/<type>/_extension.yml` (and its `contributes.project`)
+   to say "found extension `posit-dev/posit-docs`, which is
+   website-based — use `type: website`". Nice UX, but it wires extension
+   awareness into config parsing before we've designed extension
+   support. Default: generic hint only; tell me if you want the smart one.
+3. **WASM/hub context.** `parse_config` also runs under the WASM
+   runtime. A hard error there surfaces as a render failure in hub —
+   presumably fine, but flagging it.

--- a/crates/quarto-core/src/project/mod.rs
+++ b/crates/quarto-core/src/project/mod.rs
@@ -647,13 +647,29 @@ impl ProjectContext {
         let metadata =
             yaml_to_config_value(yaml, InterpretationContext::ProjectConfig, &mut diagnostics);
 
-        // Extract project-specific settings from metadata
-        let project_kind = metadata
-            .get("project")
-            .and_then(|p| p.get("type"))
-            .and_then(|t| t.as_str())
-            .and_then(|s| ProjectKind::try_from(s).ok())
-            .unwrap_or_default();
+        // Extract project-specific settings from metadata.
+        //
+        // An unrecognized (or non-string) `project.type` is a hard
+        // error (bd-sekn481x). Q2 has no extension project types, so
+        // a Quarto 1 extension type like `posit-docs` used to fall
+        // back silently to `default` — which renders in place and
+        // strews per-document copies of the shared JS/CSS through
+        // the source tree of what the user meant as a website.
+        // Quarto 1 also errors here ("Unsupported project type").
+        let project_kind = match metadata.get("project").and_then(|p| p.get("type")) {
+            None => ProjectKind::default(),
+            Some(type_value) => {
+                let type_str = type_value.as_str();
+                match type_str.map(ProjectKind::try_from) {
+                    Some(Ok(kind)) => kind,
+                    Some(Err(_)) | None => {
+                        return Err(unknown_project_type_error(
+                            type_str, type_value, path, &content,
+                        ));
+                    }
+                }
+            }
+        };
 
         let output_dir = metadata
             .get("project")
@@ -722,6 +738,57 @@ impl ProjectContext {
                 ProjectKind::Website | ProjectKind::Book | ProjectKind::Manuscript
             )
     }
+}
+
+/// Build the Q-5-17 hard error for an unrecognized or non-string
+/// `project.type` (bd-sekn481x).
+///
+/// `type_str` is `Some` when the value was a string but not a known
+/// kind, `None` when it wasn't a string at all. The `ConfigValue`'s
+/// `source_info` carries the FileId `quarto_yaml::parse_file`
+/// computed for the config file; registering `content` under that
+/// exact id lets the diagnostic render an Ariadne snippet pointing
+/// at the offending scalar (same technique as
+/// `resource_error_to_parse_error`).
+fn unknown_project_type_error(
+    type_str: Option<&str>,
+    type_value: &ConfigValue,
+    config_path: &Path,
+    content: &str,
+) -> QuartoError {
+    use quarto_error_reporting::DiagnosticMessageBuilder;
+    use quarto_source_map::{FileId, SourceContext};
+
+    let mut source_context = SourceContext::new();
+    if let Some((fid_usize, _, _)) = type_value.source_info.resolve_byte_range() {
+        source_context.add_file_with_id(
+            FileId(fid_usize),
+            config_path.to_string_lossy().into_owned(),
+            Some(content.to_string()),
+        );
+    }
+
+    let builder = match type_str {
+        Some(s) => DiagnosticMessageBuilder::error(format!("Unknown project type `{s}`"))
+            .problem("`project.type` must be one of `default`, `website`, `book`, or `manuscript`.")
+            .add_info(format!(
+                "Quarto 1 extension project types (from `_extensions/`) are not yet \
+                 supported in Quarto 2. If `{s}` comes from an extension, set \
+                 `project.type` to the base type that extension extends (often `website`)."
+            )),
+        None => DiagnosticMessageBuilder::error("Invalid `project.type`").problem(
+            "`project.type` must be a string — one of `default`, `website`, `book`, or \
+             `manuscript`.",
+        ),
+    };
+    let diagnostic = builder
+        .with_code("Q-5-17")
+        .with_location(type_value.source_info.clone())
+        .build();
+    QuartoError::Parse(crate::error::ParseError::new(
+        vec![diagnostic],
+        source_context,
+    ))
 }
 
 #[cfg(test)]
@@ -1060,6 +1127,124 @@ mod tests {
             // Config should be default with no metadata
             assert_eq!(ctx.config.project_kind, ProjectKind::Default);
             assert!(ctx.config.metadata.is_none());
+        }
+    }
+
+    // === project.type config parsing tests (bd-sekn481x) ===
+
+    mod project_type_config_tests {
+        use super::*;
+        use quarto_system_runtime::NativeRuntime;
+        use std::fs;
+        use tempfile::TempDir;
+
+        fn discover_with_config(config: &str) -> Result<ProjectContext> {
+            let temp = TempDir::new().unwrap();
+            fs::write(temp.path().join("_quarto.yml"), config).unwrap();
+            fs::write(temp.path().join("index.qmd"), "---\ntitle: x\n---\n\nhi\n").unwrap();
+            let runtime = NativeRuntime::new();
+            ProjectContext::discover(temp.path(), &runtime)
+        }
+
+        /// An unrecognized `project.type` (e.g. a Quarto 1 extension
+        /// project type) must be a hard error, not a silent fallback
+        /// to `default` — the fallback strews per-document lib copies
+        /// into the source tree of what the user meant to be a
+        /// website (bd-sekn481x).
+        #[test]
+        fn unknown_project_type_is_hard_error() {
+            let err = discover_with_config("project:\n  type: posit-docs\n")
+                .expect_err("unknown project.type must fail discovery");
+            let QuartoError::Parse(parse_err) = err else {
+                panic!("expected QuartoError::Parse, got: {err:?}");
+            };
+            assert_eq!(parse_err.diagnostics.len(), 1);
+            let d = &parse_err.diagnostics[0];
+            assert_eq!(d.code.as_deref(), Some("Q-5-17"));
+            assert!(
+                d.location.is_some(),
+                "diagnostic must point at the `type:` scalar in _quarto.yml"
+            );
+            let rendered = parse_err.render();
+            assert!(
+                rendered.contains("posit-docs"),
+                "diagnostic must name the offending type; got:\n{rendered}"
+            );
+            for valid in ["default", "website", "book", "manuscript"] {
+                assert!(
+                    rendered.contains(valid),
+                    "diagnostic must list valid type `{valid}`; got:\n{rendered}"
+                );
+            }
+            assert!(
+                rendered.contains("_quarto.yml"),
+                "diagnostic must render a source snippet naming the file; got:\n{rendered}"
+            );
+        }
+
+        /// A non-string `project.type` gets the same hard error
+        /// rather than silently becoming `default` via `as_str() ->
+        /// None`.
+        #[test]
+        fn non_string_project_type_is_hard_error() {
+            let err = discover_with_config("project:\n  type:\n    nested: map\n")
+                .expect_err("non-string project.type must fail discovery");
+            let QuartoError::Parse(parse_err) = err else {
+                panic!("expected QuartoError::Parse, got: {err:?}");
+            };
+            assert_eq!(parse_err.diagnostics.len(), 1);
+            let d = &parse_err.diagnostics[0];
+            assert_eq!(d.code.as_deref(), Some("Q-5-17"));
+            let rendered = parse_err.render();
+            assert!(
+                rendered.contains("string"),
+                "diagnostic must say the value should be a string; got:\n{rendered}"
+            );
+        }
+
+        /// Absent `project.type` keeps defaulting to `default` — the
+        /// documented behavior for bare projects.
+        #[test]
+        fn absent_project_type_still_defaults() {
+            let ctx = discover_with_config("project:\n  render:\n    - \"*.qmd\"\n").unwrap();
+            assert_eq!(ctx.config.project_kind, ProjectKind::Default);
+        }
+
+        /// Recognized types (including case-insensitive spellings)
+        /// keep parsing.
+        #[test]
+        fn valid_project_types_still_parse() {
+            for (spelling, kind) in [
+                ("default", ProjectKind::Default),
+                ("website", ProjectKind::Website),
+                ("book", ProjectKind::Book),
+                ("manuscript", ProjectKind::Manuscript),
+                ("WEBSITE", ProjectKind::Website),
+            ] {
+                let ctx = discover_with_config(&format!("project:\n  type: {spelling}\n")).unwrap();
+                assert_eq!(ctx.config.project_kind, kind, "spelling: {spelling}");
+            }
+        }
+
+        /// Belt-and-braces: the code this module emits must exist in
+        /// the shared catalog, under the 'project' subsystem (mirrors
+        /// `theme_diagnostic_code_is_registered_in_catalog`).
+        #[test]
+        fn unknown_project_type_code_is_registered_in_catalog() {
+            let info = quarto_error_catalog::ERROR_CATALOG.get("Q-5-17");
+            assert!(
+                info.is_some(),
+                "Q-5-17 is not registered in error_catalog.json"
+            );
+            let info = info.unwrap();
+            assert_eq!(info.subsystem, "project");
+            assert!(
+                info.docs_url
+                    .as_deref()
+                    .is_some_and(|u| u.ends_with("Q-5-17")),
+                "Q-5-17 docs_url must end with the code; got: {:?}",
+                info.docs_url
+            );
         }
     }
 

--- a/crates/quarto-error-catalog/error_catalog.json
+++ b/crates/quarto-error-catalog/error_catalog.json
@@ -1154,6 +1154,13 @@
     "docs_url": "https://quarto.org/docs/errors/project/Q-5-15",
     "since_version": "99.9.9"
   },
+  "Q-5-17": {
+    "subsystem": "project",
+    "title": "Unknown Project Type",
+    "message_template": "`project.type` in `_quarto.yml` is not one of the supported types (`default`, `website`, `book`, `manuscript`), or is not a string. Quarto 1 extension project types (contributed from `_extensions/`) are not yet supported in Quarto 2; set `project.type` to the base type the extension extends (often `website`). The render stops before any document is processed — continuing under the wrong project type would scatter per-document copies of shared JS/CSS next to every source file.",
+    "docs_url": "https://quarto.org/docs/errors/project/Q-5-17",
+    "since_version": "99.9.9"
+  },
   "Q-16-1": {
     "subsystem": "extension",
     "title": "Extension Not Loaded",

--- a/crates/quarto/src/commands/render.rs
+++ b/crates/quarto/src/commands/render.rs
@@ -151,9 +151,29 @@ pub enum DispatchError {
     /// A directory or glob argument expanded to zero renderable files
     /// after the project's render list is applied.
     NoRenderableMatches { path: PathBuf },
-    /// Project discovery failed for unrelated reasons (parse error in
-    /// `_quarto.yml`, I/O error, etc.).
+    /// Project discovery failed with a structured parse diagnostic
+    /// (e.g. an invalid `_quarto.yml`, or Q-5-17 unknown
+    /// `project.type`). Kept structured (bd-y56u1gl7) so the text
+    /// path can print the rendered diagnostic bare and the
+    /// `--json-errors` path can emit the real per-diagnostic codes
+    /// and locations instead of a stringified Q-7-8 envelope.
+    DiscoverParse(quarto_core::ParseError),
+    /// Project discovery failed for unrelated, unstructured reasons
+    /// (I/O error, etc.).
     Discover(String),
+}
+
+/// Convert a discovery-stage [`QuartoError`] into a
+/// [`DispatchError`], preserving structured diagnostics
+/// (bd-y56u1gl7). Used at the `ProjectContext::discover` call
+/// sites; runtime-level errors (`path_exists`, `canonicalize`,
+/// `is_dir`) are not `QuartoError`s and keep the plain
+/// `Discover(String)` mapping.
+fn discover_error(e: QuartoError) -> DispatchError {
+    match e {
+        QuartoError::Parse(pe) => DispatchError::DiscoverParse(pe),
+        other => DispatchError::Discover(other.to_string()),
+    }
 }
 
 impl std::fmt::Display for DispatchError {
@@ -189,6 +209,9 @@ impl std::fmt::Display for DispatchError {
             DispatchError::NoRenderableMatches { path } => {
                 write!(f, "No renderable source files matched: {}", path.display())
             }
+            // The rendered ParseError is self-describing (it opens
+            // with its own `Error: [Q-N-M]` header) — no prefix.
+            DispatchError::DiscoverParse(pe) => write!(f, "{pe}"),
             DispatchError::Discover(msg) => write!(f, "Project discovery failed: {msg}"),
         }
     }
@@ -254,8 +277,7 @@ pub fn classify_inputs(
     let mut shared_project: Option<PathBuf> = None;
     let mut any_outside_project = false;
     for r in &resolved {
-        let ctx = ProjectContext::discover(r, runtime)
-            .map_err(|e| DispatchError::Discover(e.to_string()))?;
+        let ctx = ProjectContext::discover(r, runtime).map_err(discover_error)?;
         // `is_single_file` only fires for *file* inputs with no
         // surrounding `_quarto.yml`. A *directory* input never trips
         // it, even when no config exists — so we re-check the
@@ -313,8 +335,7 @@ pub fn classify_inputs(
     // Re-discover from the project root to get the full
     // render-list-filtered file list. (Per-input `discover` only fills
     // `files` with that one input.)
-    let project = ProjectContext::discover(&project_dir, runtime)
-        .map_err(|e| DispatchError::Discover(e.to_string()))?;
+    let project = ProjectContext::discover(&project_dir, runtime).map_err(discover_error)?;
     let project_files: Vec<PathBuf> = project.files.iter().map(|f| f.input.clone()).collect();
 
     // Step 3: expand each input into the set of project files it
@@ -399,8 +420,7 @@ fn classify_no_inputs(
         return Err(DispatchError::NoInputAndNoProject(cwd_canon));
     };
 
-    let project = ProjectContext::discover(&project_root, runtime)
-        .map_err(|e| DispatchError::Discover(e.to_string()))?;
+    let project = ProjectContext::discover(&project_root, runtime).map_err(discover_error)?;
     Ok(RenderTarget::FullProject {
         project_dir: project.dir,
     })
@@ -663,6 +683,15 @@ pub fn execute(args: RenderArgs) -> Result<()> {
         Err(e) => {
             if args.json_errors {
                 emit_dispatch_error_json(&e);
+                std::process::exit(1);
+            }
+            // A structured parse diagnostic prints bare — it carries
+            // its own `Error: [Q-N-M]` header and source snippet.
+            // Routing it through anyhow would stack a second
+            // `Error:` prefix on top (bd-y56u1gl7). Mirrors the
+            // `QuartoError::Parse` arm in `execute_single_doc`.
+            if let DispatchError::DiscoverParse(pe) = &e {
+                eprintln!("{pe}");
                 std::process::exit(1);
             }
             return Err(anyhow::anyhow!("{}", e));
@@ -1337,6 +1366,13 @@ fn emit_parse_error_json(parse_error: &quarto_core::ParseError, input: Option<&P
 /// `crates/quarto-error-catalog/error_catalog.json` — keep them
 /// in sync.
 fn emit_dispatch_error_json(e: &DispatchError) {
+    // Structured parse diagnostics emit their real per-diagnostic
+    // codes and source locations (bd-y56u1gl7); everything else gets
+    // its Q-7-N classification.
+    if let DispatchError::DiscoverParse(pe) = e {
+        emit_parse_error_json(pe, None);
+        return;
+    }
     emit_json_line(&diagnostic_to_json(
         &dispatch_error_to_diagnostic(e),
         &SourceContext::new(),
@@ -1401,6 +1437,17 @@ fn dispatch_error_to_diagnostic(e: &DispatchError) -> DiagnosticMessage {
                 ))
                 .build()
         }
+        // Normally unreachable through `emit_dispatch_error_json`
+        // (which routes DiscoverParse to `emit_parse_error_json` for
+        // multi-diagnostic + source-context fidelity); kept total so
+        // direct callers still get the leading real diagnostic
+        // rather than a stringified wrapper.
+        DispatchError::DiscoverParse(pe) => pe.diagnostics.first().cloned().unwrap_or_else(|| {
+            DiagnosticMessageBuilder::error("Project Discovery Failed")
+                .with_code("Q-7-8")
+                .problem(format!("Project discovery failed: {pe}"))
+                .build()
+        }),
         DispatchError::Discover(msg) => DiagnosticMessageBuilder::error("Project Discovery Failed")
             .with_code("Q-7-8")
             .problem(format!("Project discovery failed: {msg}"))
@@ -1665,6 +1712,25 @@ mod tests {
                 project_dir: project.clone()
             }
         );
+    }
+
+    /// bd-y56u1gl7: a structured parse error from project discovery
+    /// (here: Q-5-17 unknown `project.type`) must survive
+    /// classification as a `ParseError`, not be flattened into the
+    /// `Discover(String)` variant.
+    #[test]
+    fn classify_project_with_unknown_type_yields_structured_parse_error() {
+        let temp = TempDir::new().unwrap();
+        let dir = canonical(temp.path());
+        write_file(&dir.join("_quarto.yml"), "project:\n  type: posit-docs\n");
+        write_file(&dir.join("index.qmd"), "---\ntitle: x\n---\n");
+        let runtime = NativeRuntime::new();
+        let err = classify_inputs(&[], &dir, &runtime).unwrap_err();
+        let DispatchError::DiscoverParse(pe) = err else {
+            panic!("expected DiscoverParse, got {err:?}");
+        };
+        assert_eq!(pe.diagnostics.len(), 1);
+        assert_eq!(pe.diagnostics[0].code.as_deref(), Some("Q-5-17"));
     }
 
     #[test]

--- a/crates/quarto/tests/integration/json_errors.rs
+++ b/crates/quarto/tests/integration/json_errors.rs
@@ -329,3 +329,60 @@ fn text_mode_unchanged_regression() {
         "text mode must not emit JsonPass1Failure; stderr:\n{stderr}"
     );
 }
+
+/// bd-y56u1gl7: a structured parse error from *project discovery*
+/// (here: Q-5-17 unknown `project.type`) must surface its real code
+/// and location under `--json-errors` — not the generic Q-7-8
+/// "Project Discovery Failed" envelope with the ANSI-rendered text
+/// buried in `problem`.
+#[test]
+fn discovery_parse_error_json_carries_real_code() {
+    let temp = TempDir::new().unwrap();
+    let dir = canonical(temp.path());
+    write_file(&dir.join("_quarto.yml"), "project:\n  type: posit-docs\n");
+    write_file(&dir.join("index.qmd"), "---\ntitle: x\n---\n\nhi\n");
+
+    let output = run_q2_render(&dir, &["--json-errors"]);
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit on unknown project.type"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let lines = parse_ndjson_lines(&stderr);
+    assert!(
+        !lines.is_empty(),
+        "expected at least one JSON diagnostic on stderr; stderr was:\n{stderr}"
+    );
+
+    let codes: Vec<&str> = lines
+        .iter()
+        .filter_map(|l| l.get("code").and_then(|c| c.as_str()))
+        .collect();
+    assert!(
+        codes.contains(&"Q-5-17"),
+        "expected the real Q-5-17 code in the stream, got {codes:?}; stderr:\n{stderr}"
+    );
+    assert!(
+        !codes.contains(&"Q-7-8"),
+        "the generic Q-7-8 envelope must not wrap a structured parse error; got {codes:?}"
+    );
+
+    let diag = lines
+        .iter()
+        .find(|l| l.get("code").and_then(|c| c.as_str()) == Some("Q-5-17"))
+        .unwrap();
+    assert!(
+        is_diagnostic_shape(diag),
+        "Q-5-17 line must claim the JsonDiagnostic schema; got:\n{diag:#?}"
+    );
+    assert_eq!(diag.get("kind").and_then(|k| k.as_str()), Some("error"));
+    assert!(
+        diag.get("start_line").is_some(),
+        "the diagnostic must carry its source location; got:\n{diag:#?}"
+    );
+    assert!(
+        !stderr.contains('\u{1b}'),
+        "no ANSI escapes may leak into --json-errors output; got:\n{stderr}"
+    );
+}

--- a/crates/quarto/tests/integration/main.rs
+++ b/crates/quarto/tests/integration/main.rs
@@ -16,6 +16,7 @@ pub mod revealjs_cli;
 pub mod smoke_all;
 pub mod strict_mode;
 pub mod trace_cli;
+pub mod unknown_project_type;
 pub mod use_brand;
 pub mod version_cli;
 

--- a/crates/quarto/tests/integration/unknown_project_type.rs
+++ b/crates/quarto/tests/integration/unknown_project_type.rs
@@ -114,6 +114,36 @@ fn unknown_project_type_fails_before_rendering() {
     );
 }
 
+/// bd-y56u1gl7: the structured Q-5-17 diagnostic must arrive bare —
+/// exactly one `Error:` header, no `Project discovery failed:`
+/// wrapper. Before the fix, classify_inputs flattened the rendered
+/// diagnostic into `DispatchError::Discover(String)` and anyhow
+/// re-prefixed it: `Error: Project discovery failed: Error: [Q-5-17] …`.
+#[test]
+fn unknown_project_type_diagnostic_is_not_double_wrapped() {
+    let temp = TempDir::new().unwrap();
+    let dir = canonical(temp.path());
+    write_project(&dir, "posit-docs");
+
+    let output = run_q2_render(&dir);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(!output.status.success());
+    assert!(
+        !stderr.contains("Project discovery failed"),
+        "the generic discovery wrapper must not swallow a structured diagnostic; got:\n{stderr}"
+    );
+    let error_headers = stderr.matches("Error:").count();
+    assert_eq!(
+        error_headers, 1,
+        "expected exactly one `Error:` header, got {error_headers}; stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("Q-5-17"),
+        "the real diagnostic must still print; got:\n{stderr}"
+    );
+}
+
 /// Control: the identical project with `type: website` renders
 /// cleanly — shared libs deduplicated in `_site/site_libs/`, source
 /// tree untouched.

--- a/crates/quarto/tests/integration/unknown_project_type.rs
+++ b/crates/quarto/tests/integration/unknown_project_type.rs
@@ -1,0 +1,146 @@
+//! End-to-end CLI tests for the unknown-`project.type` hard error
+//! (bd-sekn481x).
+//!
+//! Before the fix, `project.type: posit-docs` (a Quarto 1 extension
+//! project type q2 doesn't support) was silently coerced to
+//! `default`, so `q2 render` rendered in place and strewed a private
+//! `<stem>_files/quarto/` copy of the shared JS/CSS next to every
+//! document — `.md` and `.qmd` alike. The contract under test:
+//! render fails up front with Q-5-17, and *nothing* is written.
+//!
+//! TDD note: written before the fix; the failure mode observed on
+//! the unfixed tree is exit 0 with stray `*_files/` dirs.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use tempfile::TempDir;
+
+const Q2_BIN: &str = env!("CARGO_BIN_EXE_q2");
+
+fn write_file(path: &Path, contents: &str) {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(path, contents).unwrap();
+}
+
+fn canonical(p: &Path) -> PathBuf {
+    p.canonicalize().unwrap_or_else(|_| p.to_path_buf())
+}
+
+fn run_q2_render(cwd: &Path) -> std::process::Output {
+    let mut cmd = Command::new(Q2_BIN);
+    cmd.current_dir(cwd);
+    cmd.arg("render");
+    cmd.output().expect("spawn q2 binary")
+}
+
+/// Mixed .md/.qmd project — the shape of the posit-connect docs port
+/// where the bug was reported.
+fn write_project(dir: &Path, project_type: &str) {
+    write_file(
+        &dir.join("_quarto.yml"),
+        &format!(
+            "project:\n  type: {project_type}\n  render:\n    - \"**/*.md\"\n    - \"**/*.qmd\"\n\nwebsite:\n  title: repro\n"
+        ),
+    );
+    write_file(
+        &dir.join("index.qmd"),
+        "---\ntitle: Home\n---\n\nSome `code`.\n",
+    );
+    write_file(
+        &dir.join("about.md"),
+        "---\ntitle: About\n---\n\nSome `code`.\n",
+    );
+    write_file(&dir.join("sub/page.md"), "---\ntitle: Sub\n---\n\nMore.\n");
+}
+
+/// Every path under `dir` (files and directories) whose name matches
+/// `pred`, for asserting on render side effects.
+fn find_matching(dir: &Path, pred: &dyn Fn(&str) -> bool) -> Vec<PathBuf> {
+    let mut hits = Vec::new();
+    let mut stack = vec![dir.to_path_buf()];
+    while let Some(d) = stack.pop() {
+        for entry in std::fs::read_dir(&d).unwrap() {
+            let entry = entry.unwrap();
+            let path = entry.path();
+            let name = entry.file_name().to_string_lossy().into_owned();
+            if pred(&name) {
+                hits.push(path.clone());
+            }
+            if path.is_dir() {
+                stack.push(path);
+            }
+        }
+    }
+    hits
+}
+
+/// The core contract: an unknown `project.type` fails the render up
+/// front — no HTML outputs, no `<stem>_files/` lib copies strewn
+/// into the source tree.
+#[test]
+fn unknown_project_type_fails_before_rendering() {
+    let temp = TempDir::new().unwrap();
+    let dir = canonical(temp.path());
+    write_project(&dir, "posit-docs");
+
+    let output = run_q2_render(&dir);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !output.status.success(),
+        "unknown project.type must exit non-zero; stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("Q-5-17"),
+        "expected the Q-5-17 diagnostic on stderr; got:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("posit-docs"),
+        "diagnostic must name the offending type; got:\n{stderr}"
+    );
+
+    let stray_files_dirs = find_matching(&dir, &|name| name.ends_with("_files"));
+    assert!(
+        stray_files_dirs.is_empty(),
+        "no per-document lib dirs may be written; found: {stray_files_dirs:?}"
+    );
+    let html_outputs = find_matching(&dir, &|name| name.ends_with(".html"));
+    assert!(
+        html_outputs.is_empty(),
+        "no document may render before the config error; found: {html_outputs:?}"
+    );
+}
+
+/// Control: the identical project with `type: website` renders
+/// cleanly — shared libs deduplicated in `_site/site_libs/`, source
+/// tree untouched.
+#[test]
+fn website_type_control_renders_shared_libs() {
+    let temp = TempDir::new().unwrap();
+    let dir = canonical(temp.path());
+    write_project(&dir, "website");
+
+    let output = run_q2_render(&dir);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "website render must succeed; stderr:\n{stderr}"
+    );
+    assert!(
+        dir.join("_site/site_libs").is_dir(),
+        "shared libs must land in _site/site_libs"
+    );
+
+    // No `<stem>_files/` lib copies outside the output dir.
+    let source_tree_files_dirs: Vec<_> = find_matching(&dir, &|name| name.ends_with("_files"))
+        .into_iter()
+        .filter(|p| !p.starts_with(dir.join("_site")))
+        .collect();
+    assert!(
+        source_tree_files_dirs.is_empty(),
+        "source tree must stay clean; found: {source_tree_files_dirs:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Two related fixes, one per commit:

**1. Unknown `project.type` is now a hard error (Q-5-17) — bd-sekn481x.**
An unrecognized `project.type` in `_quarto.yml` (e.g. `posit-docs`, a Quarto 1 extension project type Q2 doesn't support yet) was silently coerced to `default` via `.ok().unwrap_or_default()` in `ProjectConfig::parse_config`. A default-type project renders in place with no shared lib dir, so every document — `.md` and `.qmd` alike — got a private `<stem>_files/quarto/` copy of bootstrap/clipboard/theme assets strewn through the source tree (351 stray dirs in the posit-connect docs port). Now the render fails before any document is processed, with an Ariadne snippet pointing at the offending scalar, the list of valid types, and a hint that Q1 extension project types aren't supported yet. Matches Quarto 1's "Unsupported project type" error. Absent `project.type` still defaults to `default`.

**2. Discovery errors carry structured diagnostics — bd-y56u1gl7.**
`classify_inputs` flattened every discovery failure to `DispatchError::Discover(e.to_string())`, so structured parse errors printed as `Error: Project discovery failed: Error: [Q-5-17] …` (double prefix) and `--json-errors` buried the real code/span inside a generic Q-7-8 envelope containing ANSI-soaked text. New `DiscoverParse(ParseError)` variant routes them through the existing bare-print / `emit_parse_error_json` paths: text mode prints one clean header + snippet; JSON mode emits `{"code":"Q-5-17",…,"start_line":2,"start_column":9}`. Q-7-8 remains for genuinely unstructured failures.

## Test plan

- TDD throughout: every test below was written first and observed failing.
- Unit: `project_type_config_tests` in `quarto-core` (unknown / non-string / absent / valid types, catalog registration for Q-5-17); `classify_inputs` variant pin in the CLI crate.
- E2e (real binary): `tests/integration/unknown_project_type.rs` — unknown type exits non-zero with **no** HTML or `*_files/` written; `type: website` control renders shared libs to `_site/site_libs/`; exactly one `Error:` header, no `Project discovery failed` wrapper. `tests/integration/json_errors.rs` — `--json-errors` emits Q-5-17 (not Q-7-8) with a location and no ANSI escapes.
- Full workspace suite green (11075 tests), `cargo xtask lint` clean, `cargo xtask verify` (full, incl. WASM/hub leg) passed for commit 1; `--skip-hub-build` for commit 2 (CLI-crate-only change).
- Manually verified both output modes on a standalone repro and on the real posit-connect docs port (errors up front at `_quarto.yml:7:9`, nothing written).

Plans: `claude-notes/plans/2026-08-08-unknown-project-type-error.md`, `claude-notes/plans/2026-08-08-discovery-error-structured-diagnostics.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)