### PR TITLE
Custom project types: extension-contributed project types (bd-ad7i1pc6)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4177,9 +4177,9 @@ dependencies = [
 
 [[package]]
 name = "quarto-yaml"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c32ab7b39ffa5c43c8aa6abf7eff392678acee63bad5d21680fe295e69b7c2e0"
+checksum = "fc3a45a71cc89e7f171552a98b786ae0b9b2bd84e8608d708539a869e0bc4d21"
 dependencies = [
  "quarto-source-map",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,7 +112,7 @@ path = "./crates/quarto-core"
 path = "./crates/quarto-util"
 
 [workspace.dependencies.quarto-yaml]
-version = "0.1.0"
+version = "0.1.2"
 
 [workspace.dependencies.quarto-error-reporting]
 version = "0.2.1"

--- a/claude-notes/plans/2026-08-08-custom-project-types.md
+++ b/claude-notes/plans/2026-08-08-custom-project-types.md
@@ -1,0 +1,474 @@
+# Custom project types: extension-contributed project types (website base)
+
+- **Strand:** bd-ad7i1pc6 (discovered-from bd-wch2dotq "Make q2 render the posit-connect docs"; related: bd-mqk49; **absorbs bd-zb2tod5f** — see Phase 5)
+- **Date:** 2026-08-08
+- **Status:** DESIGN APPROVED 2026-08-08 (decisions recorded below) — awaiting go-ahead to execute
+
+## Overview
+
+Q2 currently **silently falls back to the default project type** when
+`_quarto.yml` declares a `project: type:` it doesn't recognize. The
+Posit Connect docs testbed (`~/repos/github/cscheid/q2-connect-docs/docs-quarto-2`)
+declares `project: type: posit-docs`, supplied by the
+`_extensions/posit-dev/posit-docs` extension via `contributes: project:` —
+so today Q2 renders it as a bare default project: no website navigation,
+no extension theme, wrong output-dir default.
+
+This plan adds Q1-compatible **extension-contributed custom project
+types**: common resolution/merge infrastructure for all custom project
+kinds, with the website base type fully supported. Custom types whose
+base is `book`/`manuscript` get a clear "not yet supported" error
+(there are no book projects in Q2 yet); a future session picks those up
+when the base types exist.
+
+## What Quarto 1 does (findings)
+
+Full details from the Q1 source study (paths relative to
+`external-sources/quarto-cli/src`):
+
+**A custom project type is not code — it is a named config bundle.**
+Q1 has exactly four registered `ProjectType` implementations
+(`project/types/register.ts:16-19`: book, default, website, manuscript)
+and **no API for extensions to register a new one**. An extension
+project type is a `_quarto.yml` *fragment* under `contributes.project`
+that (a) names a base built-in type and (b) supplies default config.
+
+Resolution flow (`project/project-context.ts`):
+
+1. `projectContext()` reads `_quarto.yml`; if `project.type` is not a
+   built-in name (line 199), it calls `resolveProjectExtension()`
+   (lines 678-737).
+2. That finds the extension by name (exact `org/name` match wins, else
+   name-only with org-less first; ambiguity → warning, first match
+   used), takes `contributes.project` as a config fragment, and:
+   - **strips `project.detect`** (bootstrap-only auto-detection);
+   - **deletes the extension's `project.render` wholesale** if the
+     user's `_quarto.yml` sets `project.render` (all-or-nothing, no
+     array union — the one exception to the general merge rule);
+   - **rewrites `project.type` to the extension's base type**
+     (`contributes.project.project.type`, defaulting to `"default"`);
+   - merges extension-fragment-first, user-config-second →
+     **user `_quarto.yml` wins** on scalar/object conflicts; arrays
+     union-concat with dedup.
+3. Path-looking strings in the fragment are rewritten to be relative to
+   the project dir (so the extension's `theme.scss` becomes
+   `_extensions/posit-dev/posit-docs/theme.scss`).
+4. After the merge, the config is an ordinary `_quarto.yml` for a
+   built-in type; `projectType(base)` dispatches as usual and the base
+   type's config hook runs on the merged config.
+
+Failure behavior: extension not found → the config is returned
+untouched and `projectType()` **throws `Unsupported project type foo`**
+(`project/types/project-types.ts:47`). Q1 never falls back silently.
+
+Also relevant but **distinct**: `contributes.metadata.project` is a
+separate, later merge with **reversed precedence** (extension wins over
+user, `project-context.ts:113-137`). That's bd-zb2tod5f's territory;
+we do not implement it here, but the two share the "discover extensions
+at project-config time" substrate (see Phase 2). We should *not*
+replicate Q1's reversed precedence without deciding to on purpose.
+
+Q1 quirks we deliberately do not copy:
+- `extensionProjectType()` (`extension/extension.ts:437-447`) reads the
+  wrong nesting level (`contributes.project.type` instead of
+  `contributes.project.project.type`) so path fixup always uses the
+  default type's resource-ignore fields — a latent Q1 bug.
+- `contributes: project: {}` (empty) passes the "contributes something"
+  check and then crashes. We validate the fragment shape instead.
+
+## What Q2 has today (findings)
+
+- **The silent fallback**: `crates/quarto-core/src/project/mod.rs:651-656`
+  — `ProjectKind::try_from(s).ok().unwrap_or_default()`. The error
+  string is discarded; no diagnostic, no log. This is the single parse
+  site (native CLI, WASM, and LSP all reach it via
+  `ProjectContext::discover`).
+- **`ProjectKind`** (`project/mod.rs:279-289`) is a closed `Copy` enum
+  {Default, Website, Book, Manuscript}; a doc comment says it is a pure
+  dispatch tag. `project_type_for` (`project/orchestrator.rs:418-431`)
+  maps it to `DefaultProjectType`/`WebsiteProjectType` (book/manuscript
+  currently also map to default, silently).
+- **`contributes.project` is already parsed and never consumed**:
+  `extension/read.rs:158` → `Contributes::project: Option<ConfigValue>`
+  (`extension/types.rs:90`). The reading side exists end-to-end.
+- **Extension discovery today is per-document and too late**: it runs in
+  `StageContext::new` (`stage/context.rs:233-243`), after
+  `ProjectContext::parse_config` has already frozen `project_kind`,
+  `output_dir`, `render_patterns`, `resources`, `brand`, and
+  pre/post-render scripts. To let an extension supply project config we
+  must run a **project-scoped discovery pass inside
+  `ProjectContext::discover`**, between reading raw `_quarto.yml`
+  metadata and the field extraction at `mod.rs:651-697`. This is the
+  same prerequisite bd-zb2tod5f identifies for
+  `contributes.metadata.project.pre-render`.
+- **Website behavior is mostly config-gated, not kind-gated**: navbar/
+  sidebar/footer/listing transforms fire on config-key presence
+  (`resolve_website_value`), not on `ProjectKind::Website`. Only a
+  handful of sites dispatch on the kind (output-dir default, lib_dir,
+  post_render sitemap/robots/favicon, bootstrap-icons transform,
+  page-nav default, favicon brand fallback, is_multi_document). So once
+  the merged config is in place and the kind resolves to `Website`,
+  essentially everything downstream just works.
+- **Config merge machinery is ready**: `ConfigValue` carries
+  `SourceInfo` provenance, `MergeOp` (default Concat for arrays,
+  `!prefer` for replace), and `quarto-config`'s layered `MergedConfig`.
+  The per-document metadata merge (`stage/stages/metadata_merge.rs`)
+  already rebases extension-relative `Path`-kind values.
+
+## The testbed: what posit-docs actually exercises
+
+`_extensions/posit-dev/posit-docs/_extension.yml` contributes:
+
+```yaml
+contributes:
+  project:
+    project:
+      type: website          # base-type rewrite
+    website:
+      favicon: "assets/images/favicon.svg"     # ext-relative path
+      bread-crumbs: true
+      navbar: { pinned, logo (ext-relative), logo-alt, right: [Help menu] }
+      search: { copy-button, show-item-context }
+    format:
+      html:
+        theme: { light: [theme.scss], dark: [theme-dark.scss] }  # ext-relative, imports _posit-colors.scss
+        highlight-style: { light: github, dark: arrow }
+        link-external-icon / link-external-newwindow / code-copy: true
+        toc: true / toc-expand: true
+        include-in-header: ["assets/_analytics.html"]            # ext-relative
+```
+
+The user's `_quarto.yml` collides on purpose in several places —
+`website.favicon`, `navbar.logo`, `format.html.include-in-header`
+(three `!path` entries) — so the testbed exercises user-wins scalar
+precedence *and* array concat semantics in one project. It also chains
+`type: posit-docs → website`, giving us the full resolution path.
+
+(The same project also needs `contributes.metadata` from quarto-openapi
+[bd-zb2tod5f], `.ts` pre-render script execution, `_environment`, `!path`
+includes, profiles, `llms-txt` — all tracked separately under
+bd-wch2dotq. This strand only makes `type: posit-docs` work.)
+
+## Design
+
+### D1. Representation: resolve to base kind, remember the name
+
+`ProjectKind` **stays a closed `Copy` enum**, matching Q1's semantics:
+a custom type always resolves to a built-in base kind before anything
+dispatches on it. We add to `ProjectConfig` (project/mod.rs:321):
+
+```rust
+/// Present when project.type named an extension-contributed type.
+pub custom_project_type: Option<CustomProjectType>,
+
+pub struct CustomProjectType {
+    pub name: String,            // "posit-docs" as written by the user
+    pub extension_id: String,    // "posit-dev/posit-docs"
+    pub extension_dir: PathBuf,  // for diagnostics / path provenance
+}
+```
+
+Rationale: `ProjectKind::Custom(String)` would break `Copy` and
+propagate through ~7 dispatch sites for no benefit — nothing downstream
+ever needs to behave differently for `posit-docs` vs `website` once the
+config is merged. The record exists for diagnostics ("type: posit-docs
+(website, from extension posit-dev/posit-docs)") and future features.
+
+### D2. Resolution point and discovery
+
+Inside `ProjectContext::parse_config`, after raw `_quarto.yml` metadata
+is available and **before** the field extraction at mod.rs:651-697:
+
+1. Read `project.type` as a string. If it is a built-in name → done
+   (unchanged fast path).
+2. Otherwise run **project-scoped extension discovery**: project root
+   `_extensions/` plus the embedded built-in extensions (same loader as
+   `extension/discover.rs`, restricted to the project root — Q1's
+   project resolution effectively does the same since input = project
+   dir). Build this as a reusable function so bd-zb2tod5f can call it
+   for `contributes.metadata.project` later.
+3. Name resolution, Q1-compatible: `org/name` exact match wins; else
+   name-only match with org-less first; 2+ matches → warning diagnostic,
+   first match used. Only extensions with a non-empty
+   `contributes.project` participate.
+4. Not found → **error diagnostic, abort render** (new Q-code; see D5).
+   No silent fallback.
+
+Chaining is not supported (Q1 parity): the extension's declared base
+type must be a built-in name, else error.
+
+### D3. Merge semantics (Q1-compatible)
+
+Given the extension fragment `F` (a `ConfigValue` map) and user config
+`U`:
+
+1. Clone `F`; strip `F.project.detect` (unsupported for now; see
+   out-of-scope) — if present, note it in verbose output.
+2. ~~If `U.project.render` exists, delete `F.project.render` entirely
+   (all-or-nothing, Q1 parity).~~ **Dropped (Carlos, 2026-08-08):** no
+   Q1-parity special cases in the merge. Q2's standard semantics apply
+   uniformly: arrays concat by default; a project that wants to fully
+   replace an extension-contributed list (render globs, includes, css)
+   annotates its own value with `!prefer`. Custom project types should
+   feel like "just additional configuration options" under Q2's
+   existing merge model; the Connect docs `_quarto.yml` may be adjusted
+   with `!prefer`/`!concat` where Q1 and Q2 semantics differ.
+3. Read `F.project.type` → base kind. Missing → `default` (Q1 parity,
+   but with a warning diagnostic since it's almost certainly an
+   authoring mistake). `book`/`manuscript` → error "custom project
+   types with base 'book' are not yet supported in Quarto 2".
+4. Rebase path-valued entries of `F` from extension-dir-relative to
+   project-root-relative (D4).
+5. Merge: `merged = layer(F) then layer(U)` using the existing
+   `quarto-config` machinery — **user wins** on scalars/maps, arrays
+   concat (extension entries first). Set `merged.project.type` to the
+   base type name.
+6. Continue `parse_config` field extraction against `merged` — so
+   `output_dir`, `render_patterns`, `resources`, `brand`, pre/post
+   render scripts, and the per-document layer-1 project metadata all
+   see the merged config with zero further changes. The per-document
+   extension layer (layer 2, `contributes.formats`) is unaffected — no
+   double-counting, since `contributes.project.format.html` flows in
+   via layer 1.
+
+Known divergence from Q1: Q1 dedups array unions by JSON equality; Q2's
+Concat does not dedup. Accepted for now (documented), revisit if the
+testbed shows duplicate includes/css.
+
+### D4. Path rebasing (the fiddly part)
+
+Q1 rewrites *every path-looking string* in the fragment via
+`toInputRelativePaths` with a per-key ignore list. Q2 is explicit
+instead: `ConfigValueKind::Path` values get rebased during merge.
+
+Approach: at extension read time (or at resolution time in D2), mark
+path-valued keys in the `contributes.project` fragment as
+`ConfigValueKind::Path`, using a **named key list** (extending the
+existing `PATH_VALUED_KEYS` mechanism in `extension/read.rs`), then
+rewrite them ext-dir → project-root before the merge. Initial key list,
+driven by what posit-docs + the Q1 built-ins (confluence, hugo,
+docusaurus) actually use:
+
+- `format.*.theme` (scalar, list, and light/dark map forms), `css`,
+  `include-in-header` / `include-before-body` / `include-after-body`,
+  `format-resources`, `template`, `template-partials`
+- `website.favicon`, `website.navbar.logo`, `website.sidebar.*.logo`,
+  `website.page-footer.*` image entries
+- `project.pre-render` / `project.post-render` (script paths),
+  `project.resources`
+
+Each key gets a test. **Verification item:** check how layer 2 handles
+`contributes.formats.html.theme` today — `theme` is not in
+`PATH_VALUED_KEYS` (only template/template-partials/shortcodes/filters),
+so format-extension themes may already be broken; if so, file a
+discovered-from strand and fix the shared list once.
+
+SCSS: the rebased theme path
+(`_extensions/posit-dev/posit-docs/theme.scss`) `@import`s
+`_posit-colors.scss` — verify the sass include-path setup resolves
+imports relative to the theme file's own directory (test in Phase 4).
+
+### D5. Diagnostics (no more silent anything)
+
+New error-catalog entries (Q-16 block is extension-related):
+
+- **Unknown project type** (error): `project: type: foo` is not a
+  built-in and no extension in `_extensions/` contributes project type
+  `foo`. Hint: list available project-contributing extensions found, and
+  the built-in names. Replaces the `.ok().unwrap_or_default()` at
+  mod.rs:651-656. (`ProjectKind::try_from`'s error stops being
+  discarded.)
+- **Unsupported base type** (error): extension resolves but declares
+  base `book`/`manuscript`.
+- **Ambiguous extension match** (warning): 2+ name-only matches;
+  names which one was chosen.
+- **Missing base type in contribution** (warning): fragment has no
+  `project.type`; defaulted to `default`.
+
+Also fix the adjacent silent hole: today a *built-in* `type: book` /
+`type: manuscript` silently renders as default via `project_type_for`
+(orchestrator.rs:429). Emit a warning ("book projects are not yet
+supported; rendering as default") — small, in scope, same code
+neighborhood. `q2 render` output line should show
+`type: posit-docs (website)` instead of `type: default`.
+
+### D6. `contributes.metadata` (bd-zb2tod5f, folded into this strand)
+
+Decision 2026-08-08: implement `contributes.metadata` here too, since
+it shares the Phase 2 substrate and the Connect docs testbed needs both
+(quarto-openapi contributes `metadata.project.pre-render`). Following
+bd-zb2tod5f's own proposal, in two parts:
+
+1. **Project-level**: merge each discovered extension's
+   `contributes.metadata.project` into the project config at
+   `parse_config` time, *before* field extraction (so `pre-render`/
+   `post-render`/`resources` contributions take effect). Precedence:
+   **user wins**, arrays concat — deliberately diverging from Q1,
+   whose `mergeExtensionMetadata` lets the extension override the user
+   (`project-context.ts:113-137`); that reversed precedence looks like
+   an accident of implementation order, not a design, and bd-zb2tod5f
+   already proposed user-wins. Paths in the fragment (notably script
+   paths like `pre-render`) rebase ext-dir → project-root via the D4
+   machinery.
+2. **Document-level**: non-`project` keys of `contributes.metadata`
+   join the per-document merge as part of the existing extension layer
+   (layer 2 in `metadata_merge.rs`), below directory/document/runtime
+   layers.
+
+Unlike `contributes.project` (opt-in by naming the type),
+`contributes.metadata` applies from **every discovered extension**
+unconditionally — same as Q1. Ordering among multiple extensions:
+discovery order (built-ins first, then project `_extensions`), which
+the tests pin down.
+
+### D7. What we explicitly do NOT build now
+
+- `contributes.project.project.detect` (project-less bootstrap
+  detection) — stripped with a verbose note; future strand.
+- `preview.serve` external-preview contributions (hugo/docusaurus
+  style) — future strand.
+- Custom **book**/**manuscript** base types — blocked on Q2 growing
+  those project types at all.
+- A pluggable `ProjectType`-trait registry / pipeline-stage
+  contribution (bd-mqk49) — nothing in Q1's model needs it; custom
+  types are config bundles.
+- `q2 add` / template install — extensions arrive in-tree for now.
+- Running quarto-openapi's `.ts` pre-render script (needs a Deno/Node
+  story) — that's script *execution*, tracked under bd-wch2dotq; here
+  we only make the contributed `pre-render` entry land in project
+  config.
+
+## Test plan (TDD — tests first in every phase)
+
+Fixture: `crates/quarto-core/tests/fixtures/custom-project-type/` (or
+alongside existing project fixtures): a minimal project with
+`_extensions/acme/fancysite/_extension.yml` contributing
+`project.type: website`, website config with ext-relative favicon/logo,
+`format.html.theme` + `include-in-header`, plus a user `_quarto.yml`
+that collides on favicon (user-wins check) and declares its own
+`render:` list (all-or-nothing check). A second org-less extension for
+name-resolution tests.
+
+Unit/integration tests (crates/quarto-core `tests/integration/`):
+
+1. Resolution: exact org match beats name-only; org-less first;
+   ambiguity warning; not-found → error diagnostic (assert Q-code).
+2. Type rewrite: `project_kind() == Website`,
+   `custom_project_type` populated.
+3. Merge: user scalar wins; extension fills gaps; arrays concat with
+   extension first; `render` all-or-nothing; `detect` stripped.
+4. Path rebasing: one assertion per key in the D4 list.
+5. Field extraction sees merged config: `output_dir` defaults to
+   `_site` (website base), pre/post-render scripts, resources.
+6. Diagnostics: built-in `book` warning; unknown-type error; missing
+   base-type warning.
+7. End-to-end (`render_document_to_file`-level, then real binary):
+   render the fixture project, assert navbar/theme/include-in-header
+   markup in output HTML.
+
+End-to-end verification (per CLAUDE.md policy): run
+`cargo run --bin q2 -- render` on the fixture **and** on
+`q2-connect-docs/docs-quarto-2`, inspect output HTML for the posit-docs
+theme/navbar contributions, and record invocation + output snippet in
+this plan before closing.
+
+## Work items
+
+### Phase 1 — kill the silent fallback (standalone value) ✅ 2026-08-08
+- [x] Tests: unknown `project: type:` → error diagnostic; built-in
+      `book`/`manuscript` → "not yet supported" warning
+      (`tests/integration/project_type_parsing.rs`, 8 tests, written
+      first and observed failing)
+- [x] Error-catalog entries — **Q-5-17** (Unknown Project Type, error)
+      and **Q-5-18** (Project Type Not Yet Implemented, warning); the
+      project subsystem is Q-5, not Q-16 as originally guessed. Wired
+      into `parse_config` via `extract_project_kind` /
+      `project_type_error`; Q-5-18 via `project_kind_diagnostics`,
+      printed next to the `underscore_typo_diagnostics` precedent in
+      `quarto/src/commands/render.rs` and `quarto-preview/src/lib.rs`.
+- [x] `q2 render` banner accuracy: banner still prints the parsed
+      kind; the Q-5-18 warning directly above it explains the
+      book→default behavior. Custom-name display (`posit-docs
+      (website)`) lands with Phase 3.
+
+Phase 1 end-to-end evidence (2026-08-08, output inspected):
+
+```
+$ cargo run --bin q2 -- render <tmp>/unknown   # _quarto.yml: type: posit-docs
+Error: Project discovery failed: Error: [Q-5-17] Unknown project type
+ 2 │  type: posit-docs
+   │        ─────┬────  ╰─ `posit-docs` is not a recognized project type.
+ℹ Built-in project types are `default`, `website`, `book`, and `manuscript`.
+(exit 1)
+
+$ cargo run --bin q2 -- render <tmp>/book      # _quarto.yml: type: book
+Warning [Q-5-18]: `book` projects are not yet implemented
+...renders with default-project behavior...
+Rendering project: ... (type: book)
+Rendered 1 of 1 files (exit 0)
+```
+
+Full workspace suite: 11,077 passed. `cargo xtask lint` clean; clippy
+clean on quarto-core/quarto/quarto-preview.
+
+### Phase 2 — project-scoped extension discovery (shared substrate)
+- [ ] Tests: discovery from project root `_extensions/` + embedded
+      built-ins at project-config time; org/name resolution rules
+- [ ] Reusable `discover_project_extensions(project_root)` consumed by
+      both Phase 3 (`contributes.project`) and Phase 5
+      (`contributes.metadata`); no change to per-document discovery
+
+### Phase 3 — resolution + merge (the core)
+- [ ] Tests: items 1-3, 5-6 of the test plan
+- [ ] `CustomProjectType` on `ProjectConfig`; resolution in
+      `parse_config` per D2/D3
+- [ ] Fragment validation (empty/missing `project.type` handling)
+
+### Phase 4 — path rebasing + real-world verification
+- [ ] Tests: item 4 (per-key rebasing), SCSS import resolution
+- [ ] Rebase implementation (D4); verify/fix layer-2 `theme` gap,
+      filing discovered-from strand if it's a pre-existing bug
+- [ ] End-to-end: fixture + q2-connect-docs render, evidence recorded
+      here
+- [ ] Full workspace verify (`cargo xtask verify` — quarto-core touched,
+      so full WASM leg)
+
+### Phase 5 — `contributes.metadata` (absorbed bd-zb2tod5f)
+- [ ] Tests: project-level `contributes.metadata.project` merge
+      (user-wins, pre-render path rebased, multiple-extension
+      ordering); document-level layer for non-project keys
+- [ ] Project-level merge in `parse_config` (D6.1)
+- [ ] Document-level layer extension in `metadata_merge.rs` (D6.2)
+- [ ] End-to-end: quarto-openapi's contributed
+      `project.pre-render` entry appears in resolved project config for
+      q2-connect-docs (execution of the .ts script itself is out of
+      scope — bd-wch2dotq)
+- [ ] Close bd-zb2tod5f pointing here
+
+### Phase 6 — docs + follow-ups
+- [ ] `docs/guides/authoring/extensions.qmd`: replace `TBD.` with at
+      least the `contributes.project` + `contributes.metadata` sections
+      (user-facing usage, not internals); render docs/ with q2 to
+      verify
+- [ ] File follow-up strands: `detect` bootstrap, `preview.serve`,
+      custom book/manuscript (blocked on base types), array-dedup
+      parity decision if the testbed surfaces duplicates
+
+## Design decisions (resolved 2026-08-08 with Carlos)
+
+1. **Unknown project type → hard error** (new Q-16 code, hint lists
+   built-ins + discovered project-contributing extensions). No silent
+   or warned fallback.
+2. **Representation**: closed `ProjectKind` + `CustomProjectType`
+   record on `ProjectConfig` (D1). No `ProjectKind::Custom` variant.
+3. **Extension base `book`/`manuscript` → hard error** ("not yet
+   supported in Quarto 2"). Built-in `type: book`/`manuscript` keep
+   rendering as default but gain a visible warning.
+4. **bd-zb2tod5f folded in**: this strand implements both
+   `contributes.project` and `contributes.metadata` on the shared
+   project-scoped discovery substrate (D6, Phase 5).
+
+Still open (minor, decide during implementation, flag in review):
+array concat without dedup (divergence from Q1); ambiguity = warning +
+first match (Q1 parity); built-in embedded extensions participate in
+project-type resolution.

--- a/claude-notes/plans/2026-08-08-custom-project-types.md
+++ b/claude-notes/plans/2026-08-08-custom-project-types.md
@@ -511,17 +511,29 @@ https://github.com/posit-dev/quarto-yaml/issues/14 (bd-43lc07w1).
 
 Full workspace suite: 11,099 passed.
 
-### Phase 5 — `contributes.metadata` (absorbed bd-zb2tod5f)
-- [ ] Tests: project-level `contributes.metadata.project` merge
-      (user-wins, pre-render path rebased, multiple-extension
-      ordering); document-level layer for non-project keys
-- [ ] Project-level merge in `parse_config` (D6.1)
-- [ ] Document-level layer extension in `metadata_merge.rs` (D6.2)
-- [ ] End-to-end: quarto-openapi's contributed
-      `project.pre-render` entry appears in resolved project config for
-      q2-connect-docs (execution of the .ts script itself is out of
-      scope — bd-wch2dotq)
-- [ ] Close bd-zb2tod5f pointing here
+### Phase 5 — `contributes.metadata` (absorbed bd-zb2tod5f) ✅ 2026-08-08
+- [x] Tests: 6 project-level integration tests
+      (`extension_metadata.rs`) + 4 doc-level unit tests in
+      `metadata_merge.rs` (written first, observed failing)
+- [x] Project-level merge (D6.1):
+      `apply_metadata_project_contributions` in `parse_config` —
+      applies from **all** discovered extensions (discovery now runs
+      once in `parse_config`, shared with type resolution), user wins,
+      bundled paths rebase via the Phase-4 machinery
+- [x] Document-level layer (D6.2):
+      `build_metadata_contribution_layers` — non-`project` keys of
+      `contributes.metadata`, one layer per extension, format-
+      flattened, Path-kind values rebased ext→doc dir, inserted at
+      the **bottom** of the merge stack (below project config)
+- [x] End-to-end: real Connect docs copy with scripts enabled prints
+      `Running pre-render script:
+      _extensions/posit-dev/quarto-openapi/openapi-to-markdown.ts` —
+      the contribution lands in project config and drives execution;
+      the script then fails on Deno-style imports under Node, which is
+      the separate `.ts`-runtime gap (bd-wch2dotq)
+- [x] Close bd-zb2tod5f pointing here
+
+Full workspace suite: 11,109 passed.
 
 ### Phase 6 — docs + follow-ups
 - [ ] `docs/guides/authoring/extensions.qmd`: replace `TBD.` with at

--- a/claude-notes/plans/2026-08-08-custom-project-types.md
+++ b/claude-notes/plans/2026-08-08-custom-project-types.md
@@ -460,14 +460,56 @@ $ grep -o '<title>[^<]*</title>' <tmp>/_site/index.html
 
 Full workspace suite: 11,094 passed (1 ignored pending bd-43lc07w1).
 
-### Phase 4 — path rebasing + real-world verification
-- [ ] Tests: item 4 (per-key rebasing), SCSS import resolution
-- [ ] Rebase implementation (D4); verify/fix layer-2 `theme` gap,
-      filing discovered-from strand if it's a pre-existing bug
-- [ ] End-to-end: fixture + q2-connect-docs render, evidence recorded
-      here
-- [ ] Full workspace verify (`cargo xtask verify` — quarto-core touched,
-      so full WASM leg)
+### Phase 4 — path rebasing + real-world verification ✅ 2026-08-08
+- [x] Tests: 5 new rebasing tests in `custom_project_type.rs` (written
+      first, observed failing) — favicon/logo, theme map form with
+      builtin-name passthrough, css exists/missing/URL, user entries
+      untouched, pre-render script paths vs command lines
+- [x] Rebase implementation: `FRAGMENT_PATH_PATTERNS` +
+      `rebase_fragment_paths` in `project/mod.rs`. Key-path table
+      narrows *where*; an existence check under the extension dir
+      decides *whether* (builtin theme names, command lines, and
+      project-relative refs pass through). Rebased values become
+      `Path` kind so per-document merging keeps adjusting them.
+      Layer-2 gap confirmed real and pre-existing: format-extension
+      `contributes.formats.html.theme` silently drops bundled SCSS →
+      **bd-of20unsb** (P2, discovered-from).
+- [x] End-to-end (evidence below): fixture render with SCSS `@import`;
+      **real q2-connect-docs render** on a scratch copy
+- [ ] Full `cargo xtask verify` (WASM leg) — deferred to end of
+      session, before push
+
+Phase 4 end-to-end evidence (2026-08-08, output inspected):
+
+Fixture (`type: fancy-docs`, theme.scss with `@import "colors"`):
+banner `type: fancy-docs (website)`; compiled site CSS contains
+`.fancy-e2e-marker{color:#ab34cd}` (import resolved relative to the
+extension theme); `<meta name="fancy-e2e" content="from-extension">`
+inlined from the extension's include-in-header; favicon rebased to
+`_extensions/acme/fancy-docs/assets/favicon.svg`, referenced in HTML
+and copied into `_site`.
+
+Real Connect docs (`~/repos/github/cscheid/q2-connect-docs`,
+`--no-render-scripts`):
+- Direct render: `type: posit-docs (website)` resolves; all 351 files
+  then fail on **Q-14-1** because the extension uses the light/dark
+  **map** theme form (`theme: {light: […], dark: […]}`), which Q2's
+  theme stage doesn't support → filed **bd-o76p01wb** (P1,
+  discovered-from). Same gap class for `highlight-style` maps.
+- Scratch copy with the extension's theme flattened to a plain list:
+  **`Rendered 351 of 351 files`** (378 warnings, mostly Q-12-7
+  cookbook EJS `template:` — separate testbed concern). Verified in
+  output: extension navbar Help menu ("Posit Support") present;
+  extension theme compiled (`posit-footer-logo{margin-right:-10px}`
+  from `theme.scss` + `_posit-colors.scss` import); Google Tag
+  Manager `_analytics.html` inlined; user's `images/favicon.ico`
+  **wins** the favicon collision with the extension (user-wins
+  precedence on real data).
+
+Upstream: quarto-yaml tag bug filed as
+https://github.com/posit-dev/quarto-yaml/issues/14 (bd-43lc07w1).
+
+Full workspace suite: 11,099 passed.
 
 ### Phase 5 — `contributes.metadata` (absorbed bd-zb2tod5f)
 - [ ] Tests: project-level `contributes.metadata.project` merge

--- a/claude-notes/plans/2026-08-08-custom-project-types.md
+++ b/claude-notes/plans/2026-08-08-custom-project-types.md
@@ -440,11 +440,13 @@ clean on quarto-core/quarto/quarto-preview.
 **Discovered (bd-43lc07w1, P1):** `quarto-yaml` 0.1.1 only captures
 YAML tags on *scalars* — `Event::SequenceStart`/`MappingStart` discard
 theirs — so `!prefer`/`!concat` written on an array or map in any YAML
-file never reaches the merge machinery. This blocks the sanctioned
-"replace an extension-contributed list with `!prefer`" pattern. Fix is
-upstream (posit-dev/quarto-yaml) + a version bump here. The pinning
-test `user_prefer_replaces_extension_array` is `#[ignore]`d with the
-strand id until the fix ships.
+file never reaches the merge machinery. This blocked the sanctioned
+"replace an extension-contributed list with `!prefer`" pattern.
+**Resolved 2026-08-08**: fix merged upstream
+(posit-dev/quarto-yaml#14), quarto-yaml bumped 0.1.0 → 0.1.2, the
+pinning test un-ignored and passing, and `!prefer` verified end-to-end
+through `q2 render` (user's tagged include-in-header replaces the
+extension's entry in the output HTML). bd-43lc07w1 closed.
 
 Phase 3 end-to-end evidence (2026-08-08, output inspected):
 

--- a/claude-notes/plans/2026-08-08-custom-project-types.md
+++ b/claude-notes/plans/2026-08-08-custom-project-types.md
@@ -411,18 +411,54 @@ Rendered 1 of 1 files (exit 0)
 Full workspace suite: 11,077 passed. `cargo xtask lint` clean; clippy
 clean on quarto-core/quarto/quarto-preview.
 
-### Phase 2 — project-scoped extension discovery (shared substrate)
-- [ ] Tests: discovery from project root `_extensions/` + embedded
-      built-ins at project-config time; org/name resolution rules
-- [ ] Reusable `discover_project_extensions(project_root)` consumed by
-      both Phase 3 (`contributes.project`) and Phase 5
-      (`contributes.metadata`); no change to per-document discovery
+### Phase 2 — project-scoped extension discovery (shared substrate) ✅ 2026-08-08
+- [x] Tests: discovery from project root `_extensions/` + embedded
+      built-ins at project-config time (4 unit tests in
+      `extension::discover`; subdirectory `_extensions/` deliberately
+      excluded at project scope)
+- [x] Reusable `discover_project_extensions(project_dir, builtin_dir,
+      runtime)`; `builtin_extensions_path` hoisted from
+      `stage/context.rs` to `extension::`; no change to per-document
+      discovery (commit e15f173c)
 
-### Phase 3 — resolution + merge (the core)
-- [ ] Tests: items 1-3, 5-6 of the test plan
-- [ ] `CustomProjectType` on `ProjectConfig`; resolution in
-      `parse_config` per D2/D3
-- [ ] Fragment validation (empty/missing `project.type` handling)
+### Phase 3 — resolution + merge (the core) ✅ 2026-08-08
+- [x] Tests: `tests/integration/custom_project_type.rs` (14 tests,
+      written first, observed failing) — resolution, user-wins /
+      concat merge, `!prefer`, render-glob concat, `detect` stripping,
+      Q-5-17 candidate listing, Q-16-7 base-type errors, Q-16-8
+      ambiguity, Q-16-9 missing base
+- [x] `CustomProjectType` + `config_diagnostics` on `ProjectConfig`;
+      `resolve_project_type` / `resolve_custom_project_type` in
+      `parse_config`; `project_type_label()` drives the render banner
+      (`type: fancy-docs (website)`); config diagnostics printed at
+      the render + preview sites; catalog entries Q-16-7/8/9 and
+      updated Q-5-17
+- [x] Fragment validation: non-map fragment and non-string/chained/
+      book/manuscript base → Q-16-7 error; missing base → Q-16-9
+      warning + `default`
+
+**Discovered (bd-43lc07w1, P1):** `quarto-yaml` 0.1.1 only captures
+YAML tags on *scalars* — `Event::SequenceStart`/`MappingStart` discard
+theirs — so `!prefer`/`!concat` written on an array or map in any YAML
+file never reaches the merge machinery. This blocks the sanctioned
+"replace an extension-contributed list with `!prefer`" pattern. Fix is
+upstream (posit-dev/quarto-yaml) + a version bump here. The pinning
+test `user_prefer_replaces_extension_array` is `#[ignore]`d with the
+strand id until the fix ships.
+
+Phase 3 end-to-end evidence (2026-08-08, output inspected):
+
+```
+$ cargo run --bin q2 -- render <tmp>   # type: fancy-docs; navbar only in extension
+Rendering project: <tmp> (type: fancy-docs (website))
+Rendered 2 of 2 files to <tmp>/_site
+$ grep -o '<nav[^>]*>' <tmp>/_site/index.html
+<nav class="navbar navbar-expand-lg">      # extension-contributed navbar rendered
+$ grep -o '<title>[^<]*</title>' <tmp>/_site/index.html
+<title>E2E Site</title>                    # user's website.title wins
+```
+
+Full workspace suite: 11,094 passed (1 ignored pending bd-43lc07w1).
 
 ### Phase 4 — path rebasing + real-world verification
 - [ ] Tests: item 4 (per-key rebasing), SCSS import resolution

--- a/claude-notes/plans/2026-08-08-custom-project-types.md
+++ b/claude-notes/plans/2026-08-08-custom-project-types.md
@@ -476,8 +476,8 @@ Full workspace suite: 11,094 passed (1 ignored pending bd-43lc07w1).
       **bd-of20unsb** (P2, discovered-from).
 - [x] End-to-end (evidence below): fixture render with SCSS `@import`;
       **real q2-connect-docs render** on a scratch copy
-- [ ] Full `cargo xtask verify` (WASM leg) — deferred to end of
-      session, before push
+- [ ] Full `cargo xtask verify` (WASM leg) — running at end of
+      session; result recorded below when complete
 
 Phase 4 end-to-end evidence (2026-08-08, output inspected):
 
@@ -535,14 +535,18 @@ Full workspace suite: 11,099 passed.
 
 Full workspace suite: 11,109 passed.
 
-### Phase 6 — docs + follow-ups
-- [ ] `docs/guides/authoring/extensions.qmd`: replace `TBD.` with at
-      least the `contributes.project` + `contributes.metadata` sections
-      (user-facing usage, not internals); render docs/ with q2 to
-      verify
-- [ ] File follow-up strands: `detect` bootstrap, `preview.serve`,
-      custom book/manuscript (blocked on base types), array-dedup
-      parity decision if the testbed surfaces duplicates
+### Phase 6 — docs + follow-ups ✅ 2026-08-08
+- [x] `docs/guides/authoring/extensions.qmd`: replaced `TBD.` with
+      user-facing sections on custom project types (usage, merge
+      rules incl. `!prefer`, bundled files, Q-5-17/Q-16-7 errors) and
+      metadata contributions. Verified: `q2 render docs/` — 188/188
+      files, no warnings attributed to the page.
+- [x] Follow-up strands filed: **bd-0dtv2nhe** (`detect` bootstrap,
+      P4), **bd-nmawh9vj** (`preview.serve`, P4), **bd-m1fzvpov**
+      (book/manuscript bases, P4, conceptually blocked on those base
+      types existing). Array-dedup parity: not filed — the Connect
+      docs testbed surfaced no duplicate-entry problems; revisit only
+      if one appears.
 
 ## Design decisions (resolved 2026-08-08 with Carlos)
 

--- a/claude-notes/plans/2026-08-08-custom-project-types.md
+++ b/claude-notes/plans/2026-08-08-custom-project-types.md
@@ -476,8 +476,9 @@ Full workspace suite: 11,094 passed (1 ignored pending bd-43lc07w1).
       **bd-of20unsb** (P2, discovered-from).
 - [x] End-to-end (evidence below): fixture render with SCSS `@import`;
       **real q2-connect-docs render** on a scratch copy
-- [ ] Full `cargo xtask verify` (WASM leg) — running at end of
-      session; result recorded below when complete
+- [x] Full `cargo xtask verify` (WASM leg) — passed 2026-08-08
+      (all 14 steps incl. hub-client/WASM build + tests; one strict-
+      clippy fix in a test: `sort` → `sort_unstable`)
 
 Phase 4 end-to-end evidence (2026-08-08, output inspected):
 

--- a/crates/quarto-core/src/extension/discover.rs
+++ b/crates/quarto-core/src/extension/discover.rs
@@ -79,6 +79,51 @@ pub fn discover_extensions(
     (extensions, diagnostics)
 }
 
+/// Discover extensions visible at **project-config** time (bd-ad7i1pc6).
+///
+/// Project-scoped counterpart to [`discover_extensions`]: scans the
+/// embedded built-in extensions (lowest priority, when provided) and
+/// the **project root's** `_extensions/` only. Per-directory
+/// `_extensions/` in subdirectories are deliberately not consulted —
+/// this discovery feeds project-level concerns (resolving a custom
+/// `project.type` via `contributes.project`, and merging
+/// `contributes.metadata.project`), which must not vary per document.
+///
+/// Runs during `ProjectContext::parse_config`, i.e. *before* the
+/// per-document discovery in `StageContext::new`; the two are
+/// independent (per-document discovery re-scans and additionally sees
+/// subdirectory extensions).
+///
+/// Same ordering contract as [`discover_extensions`]: built-ins first,
+/// user extensions later, so [`find_extension`]'s last-match-wins gives
+/// user extensions priority.
+pub fn discover_project_extensions(
+    project_dir: &Path,
+    builtin_extensions_dir: Option<&Path>,
+    runtime: &dyn SystemRuntime,
+) -> (Vec<Extension>, Vec<DiagnosticMessage>) {
+    let mut extensions = Vec::new();
+    let mut diagnostics = Vec::new();
+
+    if let Some(builtin_dir) = builtin_extensions_dir
+        && runtime
+            .path_exists(builtin_dir, Some(PathKind::Directory))
+            .unwrap_or(false)
+    {
+        scan_extensions_dir(builtin_dir, runtime, &mut extensions, &mut diagnostics);
+    }
+
+    let ext_dir = project_dir.join("_extensions");
+    if runtime
+        .path_exists(&ext_dir, Some(PathKind::Directory))
+        .unwrap_or(false)
+    {
+        scan_extensions_dir(&ext_dir, runtime, &mut extensions, &mut diagnostics);
+    }
+
+    (extensions, diagnostics)
+}
+
 /// Scan all entries in an extensions directory.
 fn scan_extensions_dir(
     ext_dir: &Path,
@@ -393,6 +438,108 @@ contributes:
         let rendered = format!("{:?}", diags[0]);
         assert!(rendered.contains("Q-16-1"), "diagnostic: {rendered}");
         assert!(rendered.contains("bad-ext"), "diagnostic: {rendered}");
+    }
+
+    // === discover_project_extensions tests (bd-ad7i1pc6 Phase 2) ===
+
+    #[test]
+    fn project_discovery_finds_root_extensions_org_and_orgless() {
+        let tmp = TempDir::new().unwrap();
+        write_extension(
+            &tmp.path().join("_extensions/plain-ext"),
+            "contributes:\n  shortcodes:\n    - hello.lua\n",
+        );
+        write_extension(
+            &tmp.path().join("_extensions/acme/fancy"),
+            "contributes:\n  project:\n    project:\n      type: website\n",
+        );
+
+        let runtime = make_runtime();
+        let (extensions, diags) = discover_project_extensions(tmp.path(), None, &runtime);
+
+        assert_eq!(diags.len(), 0, "diags: {diags:?}");
+        assert_eq!(extensions.len(), 2);
+        let mut ids: Vec<(Option<&str>, &str)> = extensions
+            .iter()
+            .map(|e| (e.id.organization.as_deref(), e.id.name.as_str()))
+            .collect();
+        ids.sort();
+        assert_eq!(ids, vec![(None, "plain-ext"), (Some("acme"), "fancy")]);
+    }
+
+    #[test]
+    fn project_discovery_ignores_subdirectory_extensions() {
+        // Project-scoped discovery feeds project-level concerns
+        // (`contributes.project` / `contributes.metadata.project`),
+        // which must not vary per document — so `_extensions/` dirs in
+        // subdirectories are deliberately not consulted, unlike the
+        // per-document walk in `discover_extensions`.
+        let tmp = TempDir::new().unwrap();
+        write_extension(
+            &tmp.path().join("_extensions/root-ext"),
+            "contributes:\n  shortcodes:\n    - a.lua\n",
+        );
+        write_extension(
+            &tmp.path().join("subdir/_extensions/sub-ext"),
+            "contributes:\n  shortcodes:\n    - b.lua\n",
+        );
+
+        let runtime = make_runtime();
+        let (extensions, _diags) = discover_project_extensions(tmp.path(), None, &runtime);
+
+        assert_eq!(extensions.len(), 1);
+        assert_eq!(extensions[0].id.name, "root-ext");
+    }
+
+    #[test]
+    fn project_discovery_scans_builtins_first() {
+        // Built-ins come first in the vec (lowest priority), so a user
+        // extension with the same name wins under last-match-wins.
+        let builtin_tmp = TempDir::new().unwrap();
+        write_extension(
+            &builtin_tmp.path().join("quarto/lipsum"),
+            "contributes:\n  shortcodes:\n    - lipsum.lua\n",
+        );
+        let tmp = TempDir::new().unwrap();
+        write_extension(
+            &tmp.path().join("_extensions/lipsum"),
+            "contributes:\n  shortcodes:\n    - lipsum.lua\n",
+        );
+
+        let runtime = make_runtime();
+        let (extensions, _diags) =
+            discover_project_extensions(tmp.path(), Some(builtin_tmp.path()), &runtime);
+
+        assert_eq!(extensions.len(), 2);
+        assert_eq!(extensions[0].id.organization.as_deref(), Some("quarto"));
+        assert_eq!(extensions[0].id.name, "lipsum");
+        assert_eq!(extensions[1].id.organization, None);
+        assert_eq!(extensions[1].id.name, "lipsum");
+        assert_eq!(
+            find_extension("lipsum", &extensions)
+                .unwrap()
+                .id
+                .organization,
+            None,
+            "user extension must win over the built-in"
+        );
+    }
+
+    #[test]
+    fn project_discovery_reports_broken_manifests() {
+        let tmp = TempDir::new().unwrap();
+        write_extension(
+            &tmp.path().join("_extensions/bad-ext"),
+            "contributes: [unclosed\n  nonsense: {{{{",
+        );
+
+        let runtime = make_runtime();
+        let (extensions, diags) = discover_project_extensions(tmp.path(), None, &runtime);
+
+        assert!(extensions.is_empty());
+        assert_eq!(diags.len(), 1);
+        let rendered = format!("{:?}", diags[0]);
+        assert!(rendered.contains("Q-16-1"), "diagnostic: {rendered}");
     }
 
     // === find_extension tests ===

--- a/crates/quarto-core/src/extension/mod.rs
+++ b/crates/quarto-core/src/extension/mod.rs
@@ -19,9 +19,41 @@ pub mod discover;
 pub mod read;
 pub mod types;
 
-pub use discover::{discover_extensions, find_extension};
+pub use discover::{discover_extensions, discover_project_extensions, find_extension};
 pub use read::read_extension;
 pub use types::{Contributes, Extension, ExtensionFilter, ExtensionId};
+
+/// Locate the built-in extensions directory for the current platform.
+///
+/// - **Native**: the embedded `resources/extensions/` bundle, lazily
+///   extracted to a temp directory on first access.
+/// - **WASM**: the `/__quarto_resources__/extensions` VFS path, when the
+///   host has populated it.
+///
+/// Returns `None` when built-ins are unavailable (extraction failed, or
+/// the VFS path is absent); discovery then proceeds with user
+/// extensions only.
+pub fn builtin_extensions_path(
+    _runtime: &dyn quarto_system_runtime::SystemRuntime,
+) -> Option<std::path::PathBuf> {
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        BUILTIN_EXTENSIONS.path().ok().map(|p| p.to_path_buf())
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    {
+        let vfs_path = std::path::PathBuf::from("/__quarto_resources__/extensions");
+        if _runtime
+            .path_exists(&vfs_path, Some(quarto_system_runtime::PathKind::Directory))
+            .unwrap_or(false)
+        {
+            Some(vfs_path)
+        } else {
+            None
+        }
+    }
+}
 
 #[cfg(not(target_arch = "wasm32"))]
 mod builtin {

--- a/crates/quarto-core/src/project/mod.rs
+++ b/crates/quarto-core/src/project/mod.rs
@@ -353,57 +353,388 @@ pub fn project_kind_diagnostics(
     ]
 }
 
-/// Extract and validate `project.type` from parsed `_quarto.yml`
-/// metadata (bd-ad7i1pc6).
+/// Result of resolving `project.type` (bd-ad7i1pc6).
+struct ResolvedProjectType {
+    kind: ProjectKind,
+    custom: Option<CustomProjectType>,
+    /// Non-fatal resolution diagnostics (Q-16-8 ambiguity, Q-16-9
+    /// missing base type), destined for
+    /// [`ProjectConfig::config_diagnostics`].
+    diagnostics: Vec<quarto_error_reporting::DiagnosticMessage>,
+}
+
+impl ResolvedProjectType {
+    fn builtin(kind: ProjectKind) -> Self {
+        Self {
+            kind,
+            custom: None,
+            diagnostics: Vec::new(),
+        }
+    }
+}
+
+/// Resolve `project.type` from parsed `_quarto.yml` metadata
+/// (bd-ad7i1pc6).
+///
+/// Built-in names parse directly. A custom name resolves against
+/// extensions discovered at project scope
+/// ([`crate::extension::discover_project_extensions`]): the selected
+/// extension's `contributes.project` fragment is merged **under** the
+/// user's config — mutating `metadata` in place, before
+/// `parse_config` extracts any field from it — and `project.type` is
+/// rewritten to the extension's built-in base type, so every
+/// downstream consumer sees an ordinary built-in project.
 ///
 /// An unknown or non-string `project.type` is a hard **Q-5-17** error:
 /// the previous `.ok().unwrap_or_default()` fallback silently rendered
 /// e.g. a `type: posit-docs` website as a bare default project.
-/// Extension-contributed custom project types will be resolved here,
-/// before this error fires (bd-ad7i1pc6 Phase 3).
 ///
 /// `content` is the already-read text of `config_path`, registered
-/// into the error's `SourceContext` so the diagnostic renders a
-/// snippet pointing at the offending `type:` scalar.
-fn extract_project_kind(
-    metadata: &ConfigValue,
+/// into the error's `SourceContext` so diagnostics render a snippet
+/// pointing at the offending `type:` scalar.
+fn resolve_project_type(
+    metadata: &mut ConfigValue,
     config_path: &Path,
     content: &str,
-) -> Result<ProjectKind> {
+    runtime: &dyn SystemRuntime,
+) -> Result<ResolvedProjectType> {
     let Some(type_value) = metadata.get("project").and_then(|p| p.get("type")) else {
-        return Ok(ProjectKind::Default);
+        return Ok(ResolvedProjectType::builtin(ProjectKind::Default));
+    };
+    let type_source = type_value.source_info.clone();
+
+    let Some(type_str) = type_value.as_str().map(str::to_owned) else {
+        return Err(project_type_error(
+            "`project.type` must be a string.".to_string(),
+            &type_source,
+            config_path,
+            content,
+            Vec::new(),
+            Vec::new(),
+        ));
     };
 
-    let problem = match type_value.as_str() {
-        Some(s) => match ProjectKind::try_from(s) {
-            Ok(kind) => return Ok(kind),
-            Err(_) => format!("`{s}` is not a recognized project type."),
-        },
-        None => "`project.type` must be a string.".to_string(),
-    };
+    if let Ok(kind) = ProjectKind::try_from(type_str.as_str()) {
+        return Ok(ResolvedProjectType::builtin(kind));
+    }
 
-    Err(project_type_error(
-        problem,
-        type_value,
+    resolve_custom_project_type(
+        metadata,
+        &type_str,
+        &type_source,
         config_path,
         content,
+        runtime,
+    )
+}
+
+/// Resolve a non-built-in `project.type` against project-scoped
+/// extensions and merge the winner's `contributes.project` fragment
+/// under the user's config.
+///
+/// Merge semantics are Quarto 2's standard rules, uniformly — no
+/// Q1-style special cases: user wins scalar conflicts, arrays concat
+/// (extension entries first), and a user value tagged `!prefer`
+/// replaces the extension's outright. The only fragment surgery is
+/// stripping `project.detect` (bootstrap-only, unsupported — future
+/// strand) before the merge.
+fn resolve_custom_project_type(
+    metadata: &mut ConfigValue,
+    type_str: &str,
+    type_source: &quarto_source_map::SourceInfo,
+    config_path: &Path,
+    content: &str,
+    runtime: &dyn SystemRuntime,
+) -> Result<ResolvedProjectType> {
+    use quarto_config::MergedConfig;
+
+    let project_dir = config_path.parent().unwrap_or(Path::new("."));
+    let builtin_dir = crate::extension::builtin_extensions_path(runtime);
+    let (extensions, load_diagnostics) =
+        crate::extension::discover_project_extensions(project_dir, builtin_dir.as_deref(), runtime);
+
+    let candidates: Vec<&crate::extension::Extension> = extensions
+        .iter()
+        .filter(|e| e.contributes.project.is_some())
+        .collect();
+
+    let (selected, mut diagnostics) =
+        select_project_type_extension(type_str, &candidates, config_path);
+    let Some(ext) = selected else {
+        let mut hints = Vec::new();
+        if candidates.is_empty() {
+            hints.push(
+                "No extension under `_extensions/` contributes a project type \
+                 (`contributes: project:` in `_extension.yml`)."
+                    .to_string(),
+            );
+        } else {
+            let available: Vec<String> = candidates.iter().map(|e| format!("`{}`", e.id)).collect();
+            hints.push(format!(
+                "Extensions contributing project types found: {}.",
+                available.join(", ")
+            ));
+        }
+        // A broken manifest (Q-16-1) may be exactly why the type failed
+        // to resolve — attach those diagnostics so the cause is visible.
+        return Err(project_type_error(
+            format!("`{type_str}` is not a recognized project type."),
+            type_source,
+            config_path,
+            content,
+            hints,
+            load_diagnostics,
+        ));
+    };
+
+    // `select_project_type_extension` only returns candidates, and
+    // candidates are filtered on `contributes.project.is_some()`.
+    let fragment_src = ext
+        .contributes
+        .project
+        .as_ref()
+        .expect("selected extension must contribute a project fragment");
+    if !fragment_src.is_map() {
+        return Err(project_contribution_error(
+            ext,
+            format!(
+                "The `contributes.project` entry in `{}` must be a mapping \
+                 (a `_quarto.yml` fragment).",
+                ext.path.join("_extension.yml").display()
+            ),
+        ));
+    }
+
+    // Base kind: the built-in type this custom type renders as.
+    let base_kind = match fragment_src
+        .get("project")
+        .and_then(|p| p.get("type"))
+        .map(|t| t.as_str().map(str::to_owned))
+    {
+        None => {
+            diagnostics.push(missing_base_type_warning(ext));
+            ProjectKind::Default
+        }
+        Some(None) => {
+            return Err(project_contribution_error(
+                ext,
+                "The `project.type` inside `contributes.project` must be a string.".to_string(),
+            ));
+        }
+        Some(Some(base)) => match ProjectKind::try_from(base.as_str()) {
+            Ok(kind @ (ProjectKind::Book | ProjectKind::Manuscript)) => {
+                return Err(project_contribution_error(
+                    ext,
+                    format!(
+                        "Extension `{}` declares base project type `{}`, which \
+                         Quarto 2 does not implement yet. Custom project types \
+                         with a `{}` base are not yet supported.",
+                        ext.id,
+                        kind.as_str(),
+                        kind.as_str()
+                    ),
+                ));
+            }
+            Ok(kind) => kind,
+            Err(_) => {
+                return Err(project_contribution_error(
+                    ext,
+                    format!(
+                        "Extension `{}` declares base project type `{base}`, which \
+                         is not a built-in project type. A custom project type must \
+                         name a built-in base (`default` or `website`); chaining \
+                         custom types is not supported.",
+                        ext.id
+                    ),
+                ));
+            }
+        },
+    };
+
+    // Strip `project.detect` (bootstrap-only) from a working copy of
+    // the fragment before merging.
+    let mut fragment = fragment_src.clone();
+    if let Some(project_entry) = fragment.get_mut("project")
+        && let ConfigValueKind::Map(entries) = &mut project_entry.value
+    {
+        entries.retain(|e| e.key != "detect");
+    }
+
+    // Merge: extension fragment is the lower-priority layer; the
+    // user's `_quarto.yml` wins conflicts under standard Q2 semantics.
+    let merged = MergedConfig::new(vec![&fragment, metadata])
+        .materialize()
+        .map_err(|e| {
+            QuartoError::Other(format!(
+                "Failed to merge project config contributed by extension `{}`: {}",
+                ext.id, e
+            ))
+        })?;
+    *metadata = merged;
+
+    // Rewrite `project.type` to the base type so downstream consumers
+    // see an ordinary built-in project. The value keeps the provenance
+    // of the user's original `type:` scalar.
+    metadata.insert_path(
+        &["project", "type"],
+        ConfigValue::new_string(base_kind.as_str(), type_source.clone()),
+    );
+
+    Ok(ResolvedProjectType {
+        kind: base_kind,
+        custom: Some(CustomProjectType {
+            name: type_str.to_string(),
+            extension_id: ext.id.to_string(),
+            extension_dir: ext.path.clone(),
+        }),
+        diagnostics,
+    })
+}
+
+/// Select the extension backing a custom project type name.
+///
+/// Rules (Q1-compatible, made deterministic):
+/// - An extension with the same full id appearing more than once
+///   (built-in shadowed by a user copy) collapses to the **last**
+///   occurrence — user extensions are discovered after built-ins.
+/// - `org/name` form: exact id match only.
+/// - bare `name`: all candidates with that name; if several distinct
+///   ids match, the org-less one wins, then the lexicographically
+///   first organization — with a **Q-16-8** warning naming the choice
+///   and the shadowed candidates.
+fn select_project_type_extension<'a>(
+    name: &str,
+    candidates: &[&'a crate::extension::Extension],
+    config_path: &Path,
+) -> (
+    Option<&'a crate::extension::Extension>,
+    Vec<quarto_error_reporting::DiagnosticMessage>,
+) {
+    use hashlink::LinkedHashMap;
+
+    // Dedup by full id, keeping the last occurrence (user shadows
+    // built-in). LinkedHashMap keeps discovery order for determinism.
+    let mut by_id: LinkedHashMap<String, &crate::extension::Extension> = LinkedHashMap::new();
+    for ext in candidates {
+        by_id.replace(ext.id.to_string(), ext);
+    }
+
+    if let Some((org, ext_name)) = name.split_once('/') {
+        let found = by_id
+            .values()
+            .find(|e| e.id.name == ext_name && e.id.organization.as_deref() == Some(org))
+            .copied();
+        return (found, Vec::new());
+    }
+
+    let mut matches: Vec<&crate::extension::Extension> = by_id
+        .values()
+        .filter(|e| e.id.name == name)
+        .copied()
+        .collect();
+    match matches.len() {
+        0 => (None, Vec::new()),
+        1 => (Some(matches[0]), Vec::new()),
+        _ => {
+            // Deterministic preference: org-less first, then by org.
+            matches.sort_by_key(|e| e.id.organization.clone());
+            let chosen = matches
+                .iter()
+                .find(|e| e.id.organization.is_none())
+                .copied()
+                .unwrap_or(matches[0]);
+            let others: Vec<String> = matches
+                .iter()
+                .filter(|e| e.id != chosen.id)
+                .map(|e| format!("`{}`", e.id))
+                .collect();
+            let config_name = config_path.display();
+            let warning = quarto_error_reporting::DiagnosticMessageBuilder::warning(
+                "Ambiguous project type extension",
+            )
+            .with_code("Q-16-8")
+            .problem(format!(
+                "`project.type: {name}` in {config_name} matches more than one \
+                 extension; `{}` was chosen over {}.",
+                chosen.id,
+                others.join(", ")
+            ))
+            .add_hint(format!(
+                "Use the full `organization/name` form (e.g. `type: {}`) to \
+                 disambiguate.",
+                chosen.id
+            ))
+            .build();
+            (Some(chosen), vec![warning])
+        }
+    }
+}
+
+/// Build the **Q-16-9** warning for a `contributes.project` fragment
+/// with no `project.type`: the base defaults to `default`, which is
+/// almost certainly an authoring mistake in the extension.
+fn missing_base_type_warning(
+    ext: &crate::extension::Extension,
+) -> quarto_error_reporting::DiagnosticMessage {
+    quarto_error_reporting::DiagnosticMessageBuilder::warning(
+        "Project type contribution has no base type",
+    )
+    .with_code("Q-16-9")
+    .problem(format!(
+        "Extension `{}` contributes a project type but its \
+         `contributes.project` fragment does not declare `project.type`. \
+         The project renders with the `default` base type.",
+        ext.id
+    ))
+    .add_hint(format!(
+        "Add `project: type: website` (or `default`) to `{}`.",
+        ext.path.join("_extension.yml").display()
+    ))
+    .build()
+}
+
+/// Build the structured **Q-16-7** error for an invalid
+/// `contributes.project` fragment (non-mapping, bad or unsupported
+/// base type). Span-less: the fault is in the extension manifest, not
+/// the user's `_quarto.yml`; the problem text names the extension.
+fn project_contribution_error(ext: &crate::extension::Extension, problem: String) -> QuartoError {
+    use quarto_error_reporting::DiagnosticMessageBuilder;
+    use quarto_source_map::SourceContext;
+
+    let diagnostic = DiagnosticMessageBuilder::error("Invalid project type contribution")
+        .with_code("Q-16-7")
+        .problem(problem)
+        .add_info(format!(
+            "The extension's manifest is `{}`.",
+            ext.path.join("_extension.yml").display()
+        ))
+        .build();
+
+    QuartoError::Parse(crate::error::ParseError::new(
+        vec![diagnostic],
+        SourceContext::new(),
     ))
 }
 
 /// Build the structured **Q-5-17** error for a `project.type` that
 /// could not be resolved, anchored at the `type:` value's span in the
-/// project config file.
+/// project config file. `extra_hints` (e.g. the list of available
+/// project-contributing extensions) follow the built-ins hint;
+/// `extra_diagnostics` (e.g. Q-16-1 manifest-load failures that may be
+/// the root cause) are attached after the main diagnostic.
 fn project_type_error(
     problem: String,
-    type_value: &ConfigValue,
+    type_source: &quarto_source_map::SourceInfo,
     config_path: &Path,
     content: &str,
+    extra_hints: Vec<String>,
+    extra_diagnostics: Vec<quarto_error_reporting::DiagnosticMessage>,
 ) -> QuartoError {
     use quarto_error_reporting::DiagnosticMessageBuilder;
     use quarto_source_map::{FileId, SourceContext};
 
     let mut source_context = SourceContext::new();
-    if let Some((fid_usize, _, _)) = type_value.source_info.resolve_byte_range() {
+    if let Some((fid_usize, _, _)) = type_source.resolve_byte_range() {
         source_context.add_file_with_id(
             FileId(fid_usize),
             config_path.to_string_lossy().into_owned(),
@@ -411,24 +742,62 @@ fn project_type_error(
         );
     }
 
-    let diagnostic = DiagnosticMessageBuilder::error("Unknown project type")
+    let mut builder = DiagnosticMessageBuilder::error("Unknown project type")
         .with_code("Q-5-17")
-        .with_location(type_value.source_info.clone())
+        .with_location(type_source.clone())
         .problem(problem)
-        .add_hint("Built-in project types are `default`, `website`, `book`, and `manuscript`.")
-        .build();
+        .add_hint("Built-in project types are `default`, `website`, `book`, and `manuscript`.");
+    for hint in extra_hints {
+        builder = builder.add_hint(hint);
+    }
 
-    QuartoError::Parse(crate::error::ParseError::new(
-        vec![diagnostic],
-        source_context,
-    ))
+    let mut diagnostics = vec![builder.build()];
+    diagnostics.extend(extra_diagnostics);
+
+    QuartoError::Parse(crate::error::ParseError::new(diagnostics, source_context))
+}
+
+/// Record of an extension-contributed custom project type
+/// (bd-ad7i1pc6).
+///
+/// Present on [`ProjectConfig`] when `project.type` named a custom
+/// type that an extension's `contributes.project` resolved. The custom
+/// type always resolves to a built-in **base** kind before anything
+/// dispatches on it — [`ProjectConfig::project_kind`] holds that base
+/// kind, and nothing downstream behaves differently for a custom type;
+/// this record exists for diagnostics (`q2 render`'s
+/// `type: posit-docs (website)` banner) and provenance.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CustomProjectType {
+    /// The type name as written in `_quarto.yml` (e.g. `posit-docs`).
+    pub name: String,
+    /// Resolved extension id (`org/name` or bare `name`).
+    pub extension_id: String,
+    /// Absolute path of the extension's directory (holds
+    /// `_extension.yml`); the base for rebasing contributed paths.
+    pub extension_dir: PathBuf,
 }
 
 /// Parsed project configuration from `_quarto.yml`
 #[derive(Debug, Clone, Default)]
 pub struct ProjectConfig {
     /// Project kind (the tag selected by `project.type:`).
+    ///
+    /// For extension-contributed custom types this is the resolved
+    /// **base** kind; see [`Self::custom_project_type`].
     pub project_kind: ProjectKind,
+
+    /// Set when `project.type` named an extension-contributed custom
+    /// type (bd-ad7i1pc6); `None` for built-in types.
+    pub custom_project_type: Option<CustomProjectType>,
+
+    /// Non-fatal diagnostics produced while parsing the project
+    /// config (e.g. Q-16-8 ambiguous project-type extension, Q-16-9
+    /// missing base type). CLI drivers print these once per run,
+    /// next to [`project_kind_diagnostics`] — they are *not* folded
+    /// into per-document render diagnostics, which would repeat them
+    /// for every file.
+    pub config_diagnostics: Vec<quarto_error_reporting::DiagnosticMessage>,
 
     /// Output directory (relative to project root)
     pub output_dir: Option<PathBuf>,
@@ -754,13 +1123,18 @@ impl ProjectContext {
         // Convert to ConfigValue with ProjectConfig interpretation context
         // (strings are kept literal, not parsed as markdown)
         let mut diagnostics = DiagnosticCollector::new();
-        let metadata =
+        let mut metadata =
             yaml_to_config_value(yaml, InterpretationContext::ProjectConfig, &mut diagnostics);
 
-        // Extract project-specific settings from metadata. An
-        // unrecognized `project.type` is a hard error (Q-5-17), not a
-        // silent fall-back to the default kind (bd-ad7i1pc6).
-        let project_kind = extract_project_kind(&metadata, path, &content)?;
+        // Resolve `project.type` (bd-ad7i1pc6). Built-in names parse
+        // directly; a custom name resolves against extensions
+        // discovered at project scope, whose `contributes.project`
+        // fragment is merged *under* the user's config (mutating
+        // `metadata`) before any field below is extracted. An
+        // unresolvable `project.type` is a hard error (Q-5-17), not a
+        // silent fall-back to the default kind.
+        let resolved = resolve_project_type(&mut metadata, path, &content, runtime)?;
+        let project_kind = resolved.kind;
 
         let output_dir = metadata
             .get("project")
@@ -805,6 +1179,8 @@ impl ProjectContext {
 
         Ok(ProjectConfig {
             project_kind,
+            custom_project_type: resolved.custom,
+            config_diagnostics: resolved.diagnostics,
             output_dir,
             render_patterns,
             resources,
@@ -819,6 +1195,18 @@ impl ProjectContext {
     /// Get the project kind.
     pub fn project_kind(&self) -> ProjectKind {
         self.config.project_kind
+    }
+
+    /// Human-readable project-type label for status output.
+    ///
+    /// Built-in types print their name (`website`); custom types print
+    /// the name the user wrote plus the resolved base kind:
+    /// `posit-docs (website)`.
+    pub fn project_type_label(&self) -> String {
+        match &self.config.custom_project_type {
+            Some(custom) => format!("{} ({})", custom.name, self.project_kind().as_str()),
+            None => self.project_kind().as_str().to_string(),
+        }
     }
 
     /// Check if this is a multi-document project

--- a/crates/quarto-core/src/project/mod.rs
+++ b/crates/quarto-core/src/project/mod.rs
@@ -314,6 +314,116 @@ impl TryFrom<&str> for ProjectKind {
     }
 }
 
+/// Advisory diagnostics about the parsed project kind (bd-ad7i1pc6).
+///
+/// `book` and `manuscript` parse successfully but currently render
+/// with default-project behavior (`project_type_for` maps them to
+/// `DefaultProjectType`). That surprise used to be silent; this
+/// returns the **Q-5-18** warning CLI drivers print next to the
+/// `underscore_typo_diagnostics` check. Span-less, mirroring Q-5-11:
+/// the config file is named in the problem text instead.
+pub fn project_kind_diagnostics(
+    config: &ProjectConfig,
+) -> Vec<quarto_error_reporting::DiagnosticMessage> {
+    use quarto_error_reporting::DiagnosticMessageBuilder;
+
+    let kind = config.project_kind;
+    if !matches!(kind, ProjectKind::Book | ProjectKind::Manuscript) {
+        return Vec::new();
+    }
+    let config_name = config
+        .config_path
+        .as_ref()
+        .map_or_else(|| "_quarto.yml".to_string(), |p| p.display().to_string());
+    vec![
+        DiagnosticMessageBuilder::warning(format!(
+            "`{}` projects are not yet implemented",
+            kind.as_str()
+        ))
+        .with_code("Q-5-18")
+        .problem(format!(
+            "{config_name} sets `project.type: {}`, but Quarto 2 does not implement \
+             {} projects yet. The project renders with default-project behavior: \
+             documents are rendered individually, without {}-specific structure.",
+            kind.as_str(),
+            kind.as_str(),
+            kind.as_str(),
+        ))
+        .build(),
+    ]
+}
+
+/// Extract and validate `project.type` from parsed `_quarto.yml`
+/// metadata (bd-ad7i1pc6).
+///
+/// An unknown or non-string `project.type` is a hard **Q-5-17** error:
+/// the previous `.ok().unwrap_or_default()` fallback silently rendered
+/// e.g. a `type: posit-docs` website as a bare default project.
+/// Extension-contributed custom project types will be resolved here,
+/// before this error fires (bd-ad7i1pc6 Phase 3).
+///
+/// `content` is the already-read text of `config_path`, registered
+/// into the error's `SourceContext` so the diagnostic renders a
+/// snippet pointing at the offending `type:` scalar.
+fn extract_project_kind(
+    metadata: &ConfigValue,
+    config_path: &Path,
+    content: &str,
+) -> Result<ProjectKind> {
+    let Some(type_value) = metadata.get("project").and_then(|p| p.get("type")) else {
+        return Ok(ProjectKind::Default);
+    };
+
+    let problem = match type_value.as_str() {
+        Some(s) => match ProjectKind::try_from(s) {
+            Ok(kind) => return Ok(kind),
+            Err(_) => format!("`{s}` is not a recognized project type."),
+        },
+        None => "`project.type` must be a string.".to_string(),
+    };
+
+    Err(project_type_error(
+        problem,
+        type_value,
+        config_path,
+        content,
+    ))
+}
+
+/// Build the structured **Q-5-17** error for a `project.type` that
+/// could not be resolved, anchored at the `type:` value's span in the
+/// project config file.
+fn project_type_error(
+    problem: String,
+    type_value: &ConfigValue,
+    config_path: &Path,
+    content: &str,
+) -> QuartoError {
+    use quarto_error_reporting::DiagnosticMessageBuilder;
+    use quarto_source_map::{FileId, SourceContext};
+
+    let mut source_context = SourceContext::new();
+    if let Some((fid_usize, _, _)) = type_value.source_info.resolve_byte_range() {
+        source_context.add_file_with_id(
+            FileId(fid_usize),
+            config_path.to_string_lossy().into_owned(),
+            Some(content.to_string()),
+        );
+    }
+
+    let diagnostic = DiagnosticMessageBuilder::error("Unknown project type")
+        .with_code("Q-5-17")
+        .with_location(type_value.source_info.clone())
+        .problem(problem)
+        .add_hint("Built-in project types are `default`, `website`, `book`, and `manuscript`.")
+        .build();
+
+    QuartoError::Parse(crate::error::ParseError::new(
+        vec![diagnostic],
+        source_context,
+    ))
+}
+
 /// Parsed project configuration from `_quarto.yml`
 #[derive(Debug, Clone, Default)]
 pub struct ProjectConfig {
@@ -647,13 +757,10 @@ impl ProjectContext {
         let metadata =
             yaml_to_config_value(yaml, InterpretationContext::ProjectConfig, &mut diagnostics);
 
-        // Extract project-specific settings from metadata
-        let project_kind = metadata
-            .get("project")
-            .and_then(|p| p.get("type"))
-            .and_then(|t| t.as_str())
-            .and_then(|s| ProjectKind::try_from(s).ok())
-            .unwrap_or_default();
+        // Extract project-specific settings from metadata. An
+        // unrecognized `project.type` is a hard error (Q-5-17), not a
+        // silent fall-back to the default kind (bd-ad7i1pc6).
+        let project_kind = extract_project_kind(&metadata, path, &content)?;
 
         let output_dir = metadata
             .get("project")

--- a/crates/quarto-core/src/project/mod.rs
+++ b/crates/quarto-core/src/project/mod.rs
@@ -396,6 +396,8 @@ fn resolve_project_type(
     metadata: &mut ConfigValue,
     config_path: &Path,
     content: &str,
+    extensions: &[crate::extension::Extension],
+    load_diagnostics: &[quarto_error_reporting::DiagnosticMessage],
     runtime: &dyn SystemRuntime,
 ) -> Result<ResolvedProjectType> {
     let Some(type_value) = metadata.get("project").and_then(|p| p.get("type")) else {
@@ -424,6 +426,8 @@ fn resolve_project_type(
         &type_source,
         config_path,
         content,
+        extensions,
+        load_diagnostics,
         runtime,
     )
 }
@@ -438,20 +442,20 @@ fn resolve_project_type(
 /// replaces the extension's outright. The only fragment surgery is
 /// stripping `project.detect` (bootstrap-only, unsupported — future
 /// strand) before the merge.
+#[allow(clippy::too_many_arguments)]
 fn resolve_custom_project_type(
     metadata: &mut ConfigValue,
     type_str: &str,
     type_source: &quarto_source_map::SourceInfo,
     config_path: &Path,
     content: &str,
+    extensions: &[crate::extension::Extension],
+    load_diagnostics: &[quarto_error_reporting::DiagnosticMessage],
     runtime: &dyn SystemRuntime,
 ) -> Result<ResolvedProjectType> {
     use quarto_config::MergedConfig;
 
     let project_dir = config_path.parent().unwrap_or(Path::new("."));
-    let builtin_dir = crate::extension::builtin_extensions_path(runtime);
-    let (extensions, load_diagnostics) =
-        crate::extension::discover_project_extensions(project_dir, builtin_dir.as_deref(), runtime);
 
     let candidates: Vec<&crate::extension::Extension> = extensions
         .iter()
@@ -483,7 +487,7 @@ fn resolve_custom_project_type(
             config_path,
             content,
             hints,
-            load_diagnostics,
+            load_diagnostics.to_vec(),
         ));
     };
 
@@ -595,6 +599,69 @@ fn resolve_custom_project_type(
         }),
         diagnostics,
     })
+}
+
+/// Merge every discovered extension's `contributes.metadata.project`
+/// into the project config (bd-ad7i1pc6 Phase 5, absorbing
+/// bd-zb2tod5f).
+///
+/// Unlike `contributes.project` (opt-in via `project.type`), this
+/// applies from **all** discovered extensions, unconditionally — the
+/// Q1 mechanism quarto-openapi uses to inject its `pre-render` script.
+/// Layering (low → high): extension contributions in discovery order,
+/// then the user's `_quarto.yml` (already fragment-merged for custom
+/// types) — so the **user wins**, deliberately diverging from Q1's
+/// `mergeExtensionMetadata`, which lets the extension override the
+/// user (an accident of implementation order, not a design).
+///
+/// Bundled file paths (scripts, resources) rebase ext-dir →
+/// project-root via the same existence-driven machinery as
+/// `contributes.project` fragments.
+///
+/// Non-`project` keys of `contributes.metadata` are a *document-level*
+/// concern, handled as a metadata layer in `MetadataMergeStage` — they
+/// must not merge into project config here.
+fn apply_metadata_project_contributions(
+    metadata: &mut ConfigValue,
+    extensions: &[crate::extension::Extension],
+    project_dir: &Path,
+    runtime: &dyn SystemRuntime,
+) {
+    use quarto_config::MergedConfig;
+    use quarto_pandoc_types::config_value::ConfigMapEntry;
+
+    let mut contribution_layers: Vec<ConfigValue> = Vec::new();
+    for ext in extensions {
+        let Some(meta) = ext.contributes.metadata.as_ref() else {
+            continue;
+        };
+        let Some(project_part) = meta.get("project") else {
+            continue;
+        };
+        // Wrap as `{project: …}` so the fragment merges at top level,
+        // then rebase bundled paths against this extension's dir.
+        let mut fragment = ConfigValue::new_map(
+            vec![ConfigMapEntry {
+                key: "project".to_string(),
+                key_source: project_part.source_info.clone(),
+                value: project_part.clone(),
+            }],
+            meta.source_info.clone(),
+        );
+        rebase_fragment_paths(&mut fragment, &ext.path, project_dir, runtime);
+        contribution_layers.push(fragment);
+    }
+    if contribution_layers.is_empty() {
+        return;
+    }
+
+    let mut layers: Vec<&ConfigValue> = contribution_layers.iter().collect();
+    layers.push(metadata);
+    // A materialize failure (pathological nesting) keeps the user's
+    // config untouched — same tolerant posture as `MetadataMergeStage`.
+    if let Ok(merged) = MergedConfig::new(layers).materialize() {
+        *metadata = merged;
+    }
 }
 
 /// Key paths within a `contributes.project` fragment whose string
@@ -1281,15 +1348,43 @@ impl ProjectContext {
         let mut metadata =
             yaml_to_config_value(yaml, InterpretationContext::ProjectConfig, &mut diagnostics);
 
+        // Discover project-scoped extensions once (bd-ad7i1pc6): both
+        // custom-type resolution and `contributes.metadata.project`
+        // merging consume the same list. Manifest-load failures
+        // (Q-16-1) are attached to the Q-5-17 error when type
+        // resolution fails; otherwise they are dropped here — the
+        // per-document discovery in `StageContext::new` re-reports
+        // them on every render.
+        let config_dir = path.parent().unwrap_or(Path::new("."));
+        let builtin_dir = crate::extension::builtin_extensions_path(runtime);
+        let (extensions, load_diagnostics) = crate::extension::discover_project_extensions(
+            config_dir,
+            builtin_dir.as_deref(),
+            runtime,
+        );
+
         // Resolve `project.type` (bd-ad7i1pc6). Built-in names parse
-        // directly; a custom name resolves against extensions
-        // discovered at project scope, whose `contributes.project`
-        // fragment is merged *under* the user's config (mutating
-        // `metadata`) before any field below is extracted. An
-        // unresolvable `project.type` is a hard error (Q-5-17), not a
-        // silent fall-back to the default kind.
-        let resolved = resolve_project_type(&mut metadata, path, &content, runtime)?;
+        // directly; a custom name resolves against the discovered
+        // extensions, whose `contributes.project` fragment is merged
+        // *under* the user's config (mutating `metadata`) before any
+        // field below is extracted. An unresolvable `project.type` is
+        // a hard error (Q-5-17), not a silent fall-back to the
+        // default kind.
+        let resolved = resolve_project_type(
+            &mut metadata,
+            path,
+            &content,
+            &extensions,
+            &load_diagnostics,
+            runtime,
+        )?;
         let project_kind = resolved.kind;
+
+        // Merge `contributes.metadata.project` from every discovered
+        // extension (user wins; bd-zb2tod5f semantics) — before the
+        // field extraction below, so contributed `pre-render` /
+        // `resources` / `output-dir` entries take effect.
+        apply_metadata_project_contributions(&mut metadata, &extensions, config_dir, runtime);
 
         let output_dir = metadata
             .get("project")

--- a/crates/quarto-core/src/project/mod.rs
+++ b/crates/quarto-core/src/project/mod.rs
@@ -560,6 +560,12 @@ fn resolve_custom_project_type(
         entries.retain(|e| e.key != "detect");
     }
 
+    // Rebase extension-bundled file references (theme SCSS, includes,
+    // favicon, …) from extension-dir-relative to project-root-relative
+    // so the merged config behaves as if the user had written the
+    // paths in `_quarto.yml`.
+    rebase_fragment_paths(&mut fragment, &ext.path, project_dir, runtime);
+
     // Merge: extension fragment is the lower-priority layer; the
     // user's `_quarto.yml` wins conflicts under standard Q2 semantics.
     let merged = MergedConfig::new(vec![&fragment, metadata])
@@ -589,6 +595,155 @@ fn resolve_custom_project_type(
         }),
         diagnostics,
     })
+}
+
+/// Key paths within a `contributes.project` fragment whose string
+/// values may name files bundled with the extension (bd-ad7i1pc6 D4).
+///
+/// `*` matches any map key; arrays are transparent (a pattern position
+/// applies to every item). When a pattern is exhausted at a node,
+/// every string leaf underneath is a rebase candidate — this is what
+/// makes the `theme: {light: […], dark: […]}` and plain-list forms
+/// work from one `["format", "*", "theme"]` entry.
+///
+/// The table narrows *where* rebasing may happen; the existence check
+/// in [`rebase_candidate`] decides *whether* an individual string is a
+/// bundled file (builtin theme names like `cosmo`, command lines, and
+/// project-relative references simply don't exist under the extension
+/// dir and pass through verbatim).
+const FRAGMENT_PATH_PATTERNS: &[&[&str]] = &[
+    &["format", "*", "theme"],
+    &["format", "*", "css"],
+    &["format", "*", "include-in-header"],
+    &["format", "*", "include-before-body"],
+    &["format", "*", "include-after-body"],
+    &["format", "*", "format-resources"],
+    &["format", "*", "template"],
+    &["format", "*", "template-partials"],
+    &["website", "favicon"],
+    &["website", "navbar", "logo"],
+    &["website", "sidebar", "logo"],
+    &["project", "pre-render"],
+    &["project", "post-render"],
+    &["project", "resources"],
+    &["brand"],
+];
+
+/// Rebase extension-bundled file references in a `contributes.project`
+/// fragment from extension-dir-relative to project-root-relative.
+///
+/// Rebased values become [`ConfigValueKind::Path`] so the per-document
+/// metadata merge keeps adjusting them (project root → document dir)
+/// for documents in subdirectories.
+fn rebase_fragment_paths(
+    fragment: &mut ConfigValue,
+    ext_dir: &Path,
+    project_dir: &Path,
+    runtime: &dyn SystemRuntime,
+) {
+    fn walk(
+        value: &mut ConfigValue,
+        active: &[&[&str]],
+        ext_dir: &Path,
+        project_dir: &Path,
+        runtime: &dyn SystemRuntime,
+    ) {
+        if active.iter().any(|p| p.is_empty()) {
+            rebase_leaves(value, ext_dir, project_dir, runtime);
+            return;
+        }
+        match &mut value.value {
+            ConfigValueKind::Map(entries) => {
+                for entry in entries {
+                    let next: Vec<&[&str]> = active
+                        .iter()
+                        .filter(|p| p[0] == "*" || p[0] == entry.key)
+                        .map(|p| &p[1..])
+                        .collect();
+                    if !next.is_empty() {
+                        walk(&mut entry.value, &next, ext_dir, project_dir, runtime);
+                    }
+                }
+            }
+            // Arrays are transparent: items share the pattern position.
+            ConfigValueKind::Array(items) => {
+                for item in items {
+                    walk(item, active, ext_dir, project_dir, runtime);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn rebase_leaves(
+        value: &mut ConfigValue,
+        ext_dir: &Path,
+        project_dir: &Path,
+        runtime: &dyn SystemRuntime,
+    ) {
+        match &mut value.value {
+            ConfigValueKind::Map(entries) => {
+                for entry in entries {
+                    rebase_leaves(&mut entry.value, ext_dir, project_dir, runtime);
+                }
+            }
+            ConfigValueKind::Array(items) => {
+                for item in items {
+                    rebase_leaves(item, ext_dir, project_dir, runtime);
+                }
+            }
+            ConfigValueKind::Scalar(yaml_rust2::Yaml::String(s)) | ConfigValueKind::Path(s) => {
+                if let Some(rebased) = rebase_candidate(s, ext_dir, project_dir, runtime) {
+                    value.value = ConfigValueKind::Path(rebased);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    walk(
+        fragment,
+        FRAGMENT_PATH_PATTERNS,
+        ext_dir,
+        project_dir,
+        runtime,
+    );
+}
+
+/// Decide whether `s` names a file bundled with the extension, and if
+/// so return its rebased (forward-slash) form.
+///
+/// Rooted paths and URLs pass through. Otherwise the string is a
+/// bundled file exactly when it exists under the extension dir; the
+/// rebased form is project-root-relative when the extension lives
+/// inside the project (`_extensions/…`), absolute otherwise (embedded
+/// built-in extensions extracted to a temp dir).
+fn rebase_candidate(
+    s: &str,
+    ext_dir: &Path,
+    project_dir: &Path,
+    runtime: &dyn SystemRuntime,
+) -> Option<String> {
+    if quarto_util::is_rooted(Path::new(s)) || s.starts_with("http://") || s.starts_with("https://")
+    {
+        return None;
+    }
+    let abs = ext_dir.join(s);
+    if !runtime.path_exists(&abs, None).unwrap_or(false) {
+        return None;
+    }
+    let rebased = match pathdiff::diff_paths(&abs, project_dir) {
+        Some(rel)
+            if !matches!(
+                rel.components().next(),
+                Some(std::path::Component::ParentDir)
+            ) =>
+        {
+            quarto_util::to_forward_slashes(&rel)
+        }
+        _ => quarto_util::to_forward_slashes(&abs),
+    };
+    Some(rebased)
 }
 
 /// Select the extension backing a custom project type name.

--- a/crates/quarto-core/src/stage/context.rs
+++ b/crates/quarto-core/src/stage/context.rs
@@ -794,27 +794,4 @@ fn load_project_variables(
     }
 }
 
-fn builtin_extensions_path(
-    _runtime: &dyn quarto_system_runtime::SystemRuntime,
-) -> Option<std::path::PathBuf> {
-    #[cfg(not(target_arch = "wasm32"))]
-    {
-        crate::extension::BUILTIN_EXTENSIONS
-            .path()
-            .ok()
-            .map(|p| p.to_path_buf())
-    }
-
-    #[cfg(target_arch = "wasm32")]
-    {
-        let vfs_path = std::path::PathBuf::from("/__quarto_resources__/extensions");
-        if _runtime
-            .path_exists(&vfs_path, Some(quarto_system_runtime::PathKind::Directory))
-            .unwrap_or(false)
-        {
-            Some(vfs_path)
-        } else {
-            None
-        }
-    }
-}
+use crate::extension::builtin_extensions_path;

--- a/crates/quarto-core/src/stage/stages/metadata_merge.rs
+++ b/crates/quarto-core/src/stage/stages/metadata_merge.rs
@@ -20,7 +20,7 @@
 //! format-flattened config. Downstream stages (AST transforms, rendering)
 //! can read metadata without knowing about the layering.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use async_trait::async_trait;
 use quarto_config::{MergedConfig, resolve_format_config};
@@ -115,6 +115,46 @@ fn build_extension_metadata_layer(
     };
 
     config.map(|cv| (cv, ext.path.clone()))
+}
+
+/// Build the per-document layers from extension `contributes.metadata`
+/// (bd-ad7i1pc6 Phase 5, absorbing bd-zb2tod5f).
+///
+/// One layer per extension declaring `contributes.metadata`, in
+/// discovery order. The `project` key is stripped — it is a
+/// project-config concern, merged into the project config by
+/// `ProjectContext::parse_config` — and the rest is format-flattened
+/// like every metadata layer, with `Path`-kind values rebased from the
+/// extension dir to the document dir.
+///
+/// These layers sit at the **bottom** of the merge stack (below the
+/// project config): extension metadata fills gaps, and everything the
+/// user writes — `_quarto.yml`, directory metadata, the document —
+/// wins over it.
+fn build_metadata_contribution_layers(
+    extensions: &[Extension],
+    base_format: &str,
+    document_dir: &Path,
+) -> Vec<ConfigValue> {
+    extensions
+        .iter()
+        .filter_map(|ext| {
+            let meta = ext.contributes.metadata.as_ref()?;
+            let entries: Vec<quarto_pandoc_types::config_value::ConfigMapEntry> = meta
+                .as_map_entries()?
+                .iter()
+                .filter(|e| e.key != "project")
+                .cloned()
+                .collect();
+            if entries.is_empty() {
+                return None;
+            }
+            let wrapped = ConfigValue::new_map(entries, meta.source_info.clone());
+            let mut flattened = resolve_format_config(&wrapped, base_format);
+            adjust_paths_to_document_dir(&mut flattened, &ext.path, document_dir);
+            Some(flattened)
+        })
+        .collect()
 }
 
 /// Merge project, directory, document, and runtime metadata.
@@ -217,6 +257,12 @@ impl PipelineStage for MetadataMergeStage {
             flattened
         });
 
+        // Layer 0 (lowest priority): extension `contributes.metadata`
+        // (non-`project` keys; bd-ad7i1pc6 Phase 5). Sits below the
+        // project config so everything user-written wins over it.
+        let metadata_contribution_layers =
+            build_metadata_contribution_layers(&ctx.extensions, base_format, &document_dir);
+
         // Layer 2: Extension metadata (uses full target_format for lookup)
         // Adjust !path values from extension dir to document dir
         let extension_layer = build_extension_metadata_layer(&ctx.extensions, target_format).map(
@@ -286,8 +332,12 @@ impl PipelineStage for MetadataMergeStage {
             .as_ref()
             .map(|json| resolve_format_config(&json_to_config_value(json), base_format));
 
-        // Build merge layers: project → extension → dir[0..] → document → runtime
+        // Build merge layers: metadata-contributions → project →
+        // extension-format → dir[0..] → document → runtime
         let mut layers: Vec<&ConfigValue> = Vec::new();
+        for contrib in &metadata_contribution_layers {
+            layers.push(contrib);
+        }
         if let Some(ref proj) = project_layer {
             layers.push(proj);
         }
@@ -443,7 +493,7 @@ mod tests {
     use quarto_pandoc_types::pandoc::Pandoc;
     use quarto_source_map::SourceContext;
     use quarto_system_runtime::TempDir;
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
     use std::sync::Arc;
 
     // Mock runtime for testing
@@ -1825,6 +1875,139 @@ mod tests {
         // Regression test: with no extensions, behavior is identical to before
         let layer = build_extension_metadata_layer(&[], "html");
         assert!(layer.is_none());
+    }
+
+    // === build_metadata_contribution_layers (bd-ad7i1pc6 Phase 5) ===
+
+    fn make_metadata_extension(name: &str, metadata: ConfigValue) -> Extension {
+        Extension {
+            id: ExtensionId::new(name),
+            title: Some(name.to_string()),
+            author: Some("Test".to_string()),
+            version: None,
+            quarto_required: None,
+            path: PathBuf::from("/extensions").join(name),
+            contributes: Contributes {
+                metadata: Some(metadata),
+                ..Default::default()
+            },
+        }
+    }
+
+    #[test]
+    fn metadata_contribution_layer_strips_project_and_flattens_format() {
+        let meta = config_map(vec![
+            (
+                "project",
+                config_map(vec![("pre-render", config_str("x.ts"))]),
+            ),
+            ("author-notice", config_str("from extension")),
+            (
+                "format",
+                config_map(vec![("html", config_map(vec![("toc", config_bool(true))]))]),
+            ),
+        ]);
+        let ext = make_metadata_extension("meta-ext", meta);
+
+        let layers = build_metadata_contribution_layers(&[ext], "html", Path::new("/project"));
+        assert_eq!(layers.len(), 1);
+        let layer = &layers[0];
+        assert!(
+            layer.get("project").is_none(),
+            "`project` is a project-config concern, merged in parse_config"
+        );
+        assert_eq!(
+            layer.get("author-notice").and_then(|v| v.as_str()),
+            Some("from extension")
+        );
+        // `format.html.*` flattens for the html render, like every
+        // other metadata layer.
+        assert_eq!(layer.get("toc").and_then(|v| v.as_bool()), Some(true));
+        assert!(layer.get("format").is_none());
+    }
+
+    #[test]
+    fn metadata_contribution_layer_rebases_path_values_to_document_dir() {
+        let css = ConfigValue {
+            value: ConfigValueKind::Path("assets/extra.css".to_string()),
+            source_info: SourceInfo::for_test(),
+            merge_op: Default::default(),
+        };
+        let meta = config_map(vec![("css", css)]);
+        let ext = make_metadata_extension("meta-ext", meta);
+
+        let layers = build_metadata_contribution_layers(&[ext], "html", Path::new("/project"));
+        assert_eq!(layers.len(), 1);
+        assert_eq!(
+            layers[0].get("css").and_then(|v| v.as_str()),
+            Some("../extensions/meta-ext/assets/extra.css"),
+            "Path-kind values rebase ext dir → document dir"
+        );
+    }
+
+    #[test]
+    fn metadata_contribution_layer_absent_when_only_project_key() {
+        let meta = config_map(vec![(
+            "project",
+            config_map(vec![("pre-render", config_str("x.ts"))]),
+        )]);
+        let ext = make_metadata_extension("meta-ext", meta);
+        let layers = build_metadata_contribution_layers(&[ext], "html", Path::new("/project"));
+        assert!(layers.is_empty());
+    }
+
+    #[tokio::test]
+    async fn metadata_contribution_reaches_merged_doc_meta_below_document() {
+        let runtime = Arc::new(MockRuntime);
+        let project = ProjectContext {
+            dir: PathBuf::from("/project"),
+            config: ProjectConfig::default(),
+            is_single_file: true,
+            files: vec![],
+            output_dir: PathBuf::from("/project"),
+        };
+        let doc = DocumentInfo::from_path("/project/test.qmd");
+        let mut ctx = StageContext::new(runtime, Format::html(), project, doc).unwrap();
+        ctx.extensions = vec![make_metadata_extension(
+            "meta-ext",
+            config_map(vec![
+                ("author-notice", config_str("from extension")),
+                ("subtitle", config_str("extension subtitle")),
+            ]),
+        )];
+
+        let mut doc_ast = DocumentAst {
+            path: PathBuf::from("/project/test.qmd"),
+            ast: Pandoc::default(),
+            ast_context: pampa::pandoc::ASTContext::default(),
+            source_context: SourceContext::new(),
+            warnings: vec![],
+            recorded_includes: Vec::new(),
+        };
+        // The document sets its own subtitle — it must win.
+        doc_ast.ast.meta = config_map(vec![("subtitle", config_str("doc subtitle"))]);
+
+        let stage = MetadataMergeStage::new();
+        let output = stage
+            .run(PipelineData::DocumentAst(doc_ast), &mut ctx)
+            .await
+            .unwrap();
+        let result = output.into_document_ast().unwrap();
+
+        assert_eq!(
+            result
+                .ast
+                .meta
+                .get("author-notice")
+                .and_then(|v| v.as_str()),
+            Some("from extension"),
+            "extension metadata fills gaps in document metadata"
+        );
+        assert_eq!(
+            result.ast.meta.get("subtitle").and_then(|v| v.as_str()),
+            Some("doc subtitle"),
+            "document metadata wins over extension metadata"
+        );
     }
 
     #[test]

--- a/crates/quarto-core/tests/integration/custom_project_type.rs
+++ b/crates/quarto-core/tests/integration/custom_project_type.rs
@@ -241,8 +241,6 @@ fn arrays_concat_extension_entries_first() {
 }
 
 #[test]
-#[ignore = "bd-43lc07w1: quarto-yaml drops !prefer tags on sequences/mappings, so the \
-            tag never reaches the merge; un-ignore when the upstream fix ships"]
 fn user_prefer_replaces_extension_array() {
     // No Q1-style special-casing: a project that wants to *replace* an
     // extension-contributed list uses Quarto 2's `!prefer`.

--- a/crates/quarto-core/tests/integration/custom_project_type.rs
+++ b/crates/quarto-core/tests/integration/custom_project_type.rs
@@ -409,3 +409,200 @@ contributes:
     assert_eq!(warnings.len(), 1, "must warn about the missing base type");
     assert_eq!(warnings[0].kind, DiagnosticKind::Warning);
 }
+
+// ── Path rebasing (Phase 4) ─────────────────────────────────────────
+
+/// Like `discover_with_extensions`, but also writes asset files
+/// (paths relative to the extension dir) so the existence-driven
+/// rebase has something to find.
+fn discover_with_extension_assets(
+    quarto_yml: &str,
+    ext_rel_dir: &str,
+    manifest: &str,
+    assets: &[&str],
+) -> (quarto_core::error::Result<ProjectContext>, TempDir) {
+    let tmp = TempDir::new().unwrap();
+    std::fs::write(tmp.path().join("_quarto.yml"), quarto_yml).unwrap();
+    std::fs::write(tmp.path().join("index.qmd"), "# Hello\n").unwrap();
+    let ext_dir = tmp.path().join("_extensions").join(ext_rel_dir);
+    std::fs::create_dir_all(&ext_dir).unwrap();
+    std::fs::write(ext_dir.join("_extension.yml"), manifest).unwrap();
+    for asset in assets {
+        let p = ext_dir.join(asset);
+        std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+        std::fs::write(&p, "/* asset */\n").unwrap();
+    }
+    let runtime: Arc<dyn SystemRuntime> = Arc::new(NativeRuntime::new());
+    let result = ProjectContext::discover(tmp.path(), runtime.as_ref());
+    (result, tmp)
+}
+
+const THEMED: &str = r#"
+contributes:
+  project:
+    project:
+      type: website
+      pre-render:
+        - scripts/generate.ts
+        - echo hello
+    website:
+      favicon: assets/favicon.svg
+      navbar:
+        logo: assets/logo.svg
+    format:
+      html:
+        theme:
+          light: [cosmo, theme.scss]
+          dark: [theme-dark.scss]
+        css:
+          - style.css
+          - ghost.css
+          - https://example.com/remote.css
+        include-in-header:
+          - assets/header.html
+"#;
+
+const THEMED_ASSETS: &[&str] = &[
+    "assets/favicon.svg",
+    "assets/logo.svg",
+    "theme.scss",
+    "theme-dark.scss",
+    "style.css",
+    "assets/header.html",
+    "scripts/generate.ts",
+];
+
+fn themed_project() -> (ProjectContext, TempDir) {
+    let (result, tmp) = discover_with_extension_assets(
+        "project:\n  type: fancysite\nformat:\n  html:\n    include-in-header:\n      - user-header.html\n",
+        "acme/fancysite",
+        THEMED,
+        THEMED_ASSETS,
+    );
+    (result.expect("themed custom type must resolve"), tmp)
+}
+
+fn meta_at<'a>(
+    project: &'a ProjectContext,
+    path: &[&str],
+) -> Option<&'a quarto_pandoc_types::ConfigValue> {
+    let mut current = project.config.metadata.as_ref()?;
+    for key in path {
+        current = current.get(key)?;
+    }
+    Some(current)
+}
+
+#[test]
+fn extension_favicon_and_logo_rebased_to_project_root() {
+    let (project, _tmp) = themed_project();
+    assert_eq!(
+        meta_at(&project, &["website", "favicon"]).and_then(|v| v.as_str()),
+        Some("_extensions/acme/fancysite/assets/favicon.svg")
+    );
+    assert_eq!(
+        meta_at(&project, &["website", "navbar", "logo"]).and_then(|v| v.as_str()),
+        Some("_extensions/acme/fancysite/assets/logo.svg")
+    );
+    // Rebased values carry Path kind so downstream document-dir
+    // rebasing (metadata_merge layer 1) keeps adjusting them.
+    assert!(matches!(
+        meta_at(&project, &["website", "favicon"]).unwrap().value,
+        quarto_pandoc_types::config_value::ConfigValueKind::Path(_)
+    ));
+}
+
+#[test]
+fn theme_entries_rebase_files_but_not_builtin_names() {
+    let (project, _tmp) = themed_project();
+    let light: Vec<String> = meta_at(&project, &["format", "html", "theme", "light"])
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|i| i.as_str().map(str::to_owned))
+                .collect()
+        })
+        .unwrap_or_default();
+    assert_eq!(
+        light,
+        vec![
+            "cosmo".to_string(),
+            "_extensions/acme/fancysite/theme.scss".to_string()
+        ],
+        "builtin theme names stay; bundled files rebase"
+    );
+    let dark: Vec<String> = meta_at(&project, &["format", "html", "theme", "dark"])
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|i| i.as_str().map(str::to_owned))
+                .collect()
+        })
+        .unwrap_or_default();
+    assert_eq!(
+        dark,
+        vec!["_extensions/acme/fancysite/theme-dark.scss".to_string()]
+    );
+}
+
+#[test]
+fn css_rebases_existing_files_leaves_missing_and_urls() {
+    let (project, _tmp) = themed_project();
+    let css: Vec<String> = meta_at(&project, &["format", "html", "css"])
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|i| i.as_str().map(str::to_owned))
+                .collect()
+        })
+        .unwrap_or_default();
+    assert_eq!(
+        css,
+        vec![
+            "_extensions/acme/fancysite/style.css".to_string(),
+            "ghost.css".to_string(),
+            "https://example.com/remote.css".to_string(),
+        ],
+        "existing bundled files rebase; missing files and URLs stay verbatim"
+    );
+}
+
+#[test]
+fn include_in_header_rebases_extension_entry_not_users() {
+    let (project, _tmp) = themed_project();
+    let items: Vec<String> = meta_at(&project, &["format", "html", "include-in-header"])
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|i| i.as_str().map(str::to_owned))
+                .collect()
+        })
+        .unwrap_or_default();
+    assert_eq!(
+        items,
+        vec![
+            "_extensions/acme/fancysite/assets/header.html".to_string(),
+            "user-header.html".to_string(),
+        ],
+        "extension entry rebases; the user's own entry is untouched"
+    );
+}
+
+#[test]
+fn pre_render_script_paths_rebase_commands_do_not() {
+    let (project, _tmp) = themed_project();
+    let scripts: Vec<&str> = project
+        .config
+        .pre_render_scripts
+        .iter()
+        .map(|s| s.command.as_str())
+        .collect();
+    assert_eq!(
+        scripts,
+        vec![
+            "_extensions/acme/fancysite/scripts/generate.ts",
+            "echo hello"
+        ],
+        "bundled script paths rebase; command lines stay verbatim"
+    );
+}

--- a/crates/quarto-core/tests/integration/custom_project_type.rs
+++ b/crates/quarto-core/tests/integration/custom_project_type.rs
@@ -1,0 +1,411 @@
+/*
+ * tests/integration/custom_project_type.rs
+ * Copyright (c) 2026 Posit, PBC
+ *
+ * Extension-contributed custom project types (bd-ad7i1pc6, Phase 3).
+ */
+
+//! Custom project types resolved from `contributes.project`.
+//!
+//! A `_quarto.yml` `project.type` that is not a built-in name resolves
+//! against extensions discovered at project-config time
+//! (`discover_project_extensions`). The matching extension's
+//! `contributes.project` is a `_quarto.yml` *fragment*: its
+//! `project.type` names the built-in base type the project actually
+//! renders as, and the rest merges **under** the user's config —
+//! user wins scalar conflicts, arrays concat (extension entries
+//! first), and a user value tagged `!prefer` replaces the extension's
+//! outright. No Q1-style special cases: Quarto 2's standard merge
+//! semantics apply uniformly.
+
+use std::sync::Arc;
+
+use tempfile::TempDir;
+
+use quarto_core::error::QuartoError;
+use quarto_core::project::{ProjectContext, ProjectKind};
+use quarto_error_reporting::DiagnosticKind;
+use quarto_system_runtime::{NativeRuntime, SystemRuntime};
+
+/// Build a project in a tempdir: `_quarto.yml` plus
+/// `(extension-dir-relative-to-_extensions, _extension.yml content)`
+/// pairs, then discover it.
+fn discover_with_extensions(
+    quarto_yml: &str,
+    extensions: &[(&str, &str)],
+) -> (quarto_core::error::Result<ProjectContext>, TempDir) {
+    let tmp = TempDir::new().unwrap();
+    std::fs::write(tmp.path().join("_quarto.yml"), quarto_yml).unwrap();
+    std::fs::write(tmp.path().join("index.qmd"), "# Hello\n").unwrap();
+    for (rel_dir, manifest) in extensions {
+        let dir = tmp.path().join("_extensions").join(rel_dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("_extension.yml"), manifest).unwrap();
+    }
+    let runtime: Arc<dyn SystemRuntime> = Arc::new(NativeRuntime::new());
+    let result = ProjectContext::discover(tmp.path(), runtime.as_ref());
+    (result, tmp)
+}
+
+const FANCYSITE: &str = r#"
+title: Fancy Site
+contributes:
+  project:
+    project:
+      type: website
+    website:
+      title: "From The Extension"
+      bread-crumbs: true
+    format:
+      html:
+        include-in-header:
+          - ext-header.html
+"#;
+
+fn parse_error(result: quarto_core::error::Result<ProjectContext>) -> quarto_core::ParseError {
+    match result {
+        Err(QuartoError::Parse(pe)) => pe,
+        Err(other) => panic!("expected QuartoError::Parse, got: {other:?}"),
+        Ok(_) => panic!("expected discovery to fail"),
+    }
+}
+
+/// String value at a metadata path, for merge assertions.
+fn meta_str(project: &ProjectContext, path: &[&str]) -> Option<String> {
+    let mut current = project.config.metadata.as_ref()?;
+    for key in path {
+        current = current.get(key)?;
+    }
+    current.as_str().map(|s| s.to_string())
+}
+
+// ── Resolution ──────────────────────────────────────────────────────
+
+#[test]
+fn custom_type_resolves_to_website_base() {
+    let (result, _tmp) = discover_with_extensions(
+        "project:\n  type: fancysite\n",
+        &[("acme/fancysite", FANCYSITE)],
+    );
+    let project = result.expect("custom type backed by an extension must resolve");
+
+    assert_eq!(project.project_kind(), ProjectKind::Website);
+    let custom = project
+        .config
+        .custom_project_type
+        .as_ref()
+        .expect("custom_project_type must be recorded");
+    assert_eq!(custom.name, "fancysite");
+    assert_eq!(custom.extension_id, "acme/fancysite");
+    assert!(custom.extension_dir.ends_with("_extensions/acme/fancysite"));
+
+    // Website base drives downstream defaults: output-dir is `_site`.
+    assert!(
+        project.output_dir.ends_with("_site"),
+        "website base must give the _site output-dir default; got {}",
+        project.output_dir.display()
+    );
+    // The merged metadata carries the *base* type so every downstream
+    // consumer sees an ordinary website project.
+    assert_eq!(
+        meta_str(&project, &["project", "type"]).as_deref(),
+        Some("website")
+    );
+}
+
+#[test]
+fn custom_type_label_names_extension_and_base() {
+    let (result, _tmp) = discover_with_extensions(
+        "project:\n  type: fancysite\n",
+        &[("acme/fancysite", FANCYSITE)],
+    );
+    let project = result.unwrap();
+    assert_eq!(project.project_type_label(), "fancysite (website)");
+
+    let (result, _tmp) = discover_with_extensions("project:\n  type: website\n", &[]);
+    assert_eq!(result.unwrap().project_type_label(), "website");
+}
+
+#[test]
+fn exact_org_match_beats_name_only() {
+    let other = r#"
+contributes:
+  project:
+    project:
+      type: default
+"#;
+    let (result, _tmp) = discover_with_extensions(
+        "project:\n  type: acme/fancysite\n",
+        &[("acme/fancysite", FANCYSITE), ("other/fancysite", other)],
+    );
+    let project = result.expect("org-qualified type must resolve");
+    assert_eq!(project.project_kind(), ProjectKind::Website);
+    assert_eq!(
+        project
+            .config
+            .custom_project_type
+            .as_ref()
+            .unwrap()
+            .extension_id,
+        "acme/fancysite"
+    );
+    assert!(project.config.config_diagnostics.is_empty());
+}
+
+#[test]
+fn ambiguous_name_only_match_warns_and_prefers_orgless() {
+    let orgless = r#"
+contributes:
+  project:
+    project:
+      type: default
+"#;
+    let (result, _tmp) = discover_with_extensions(
+        "project:\n  type: fancysite\n",
+        &[("fancysite", orgless), ("acme/fancysite", FANCYSITE)],
+    );
+    let project = result.expect("ambiguous name must still resolve");
+    // Org-less extension wins (Q1 parity), so base is `default`.
+    assert_eq!(project.project_kind(), ProjectKind::Default);
+    assert_eq!(
+        project
+            .config
+            .custom_project_type
+            .as_ref()
+            .unwrap()
+            .extension_id,
+        "fancysite"
+    );
+    let warnings: Vec<_> = project
+        .config
+        .config_diagnostics
+        .iter()
+        .filter(|d| d.code.as_deref() == Some("Q-16-8"))
+        .collect();
+    assert_eq!(warnings.len(), 1, "must warn about the ambiguity");
+    assert_eq!(warnings[0].kind, DiagnosticKind::Warning);
+    let text = warnings[0].to_text(None);
+    assert!(
+        text.contains("fancysite") && text.contains("acme/fancysite"),
+        "warning must name the chosen and the shadowed extension; got: {text}"
+    );
+}
+
+// ── Merge semantics ─────────────────────────────────────────────────
+
+#[test]
+fn user_scalar_wins_extension_fills_gaps() {
+    let (result, _tmp) = discover_with_extensions(
+        "project:\n  type: fancysite\nwebsite:\n  title: \"Mine\"\n",
+        &[("acme/fancysite", FANCYSITE)],
+    );
+    let project = result.unwrap();
+    // Collision: user wins.
+    assert_eq!(
+        meta_str(&project, &["website", "title"]).as_deref(),
+        Some("Mine")
+    );
+    // Gap: extension fills.
+    let breadcrumbs = project
+        .config
+        .metadata
+        .as_ref()
+        .and_then(|m| m.get("website"))
+        .and_then(|w| w.get("bread-crumbs"))
+        .and_then(|b| b.as_bool());
+    assert_eq!(breadcrumbs, Some(true));
+}
+
+#[test]
+fn arrays_concat_extension_entries_first() {
+    let (result, _tmp) = discover_with_extensions(
+        "project:\n  type: fancysite\nformat:\n  html:\n    include-in-header:\n      - user-header.html\n",
+        &[("acme/fancysite", FANCYSITE)],
+    );
+    let project = result.unwrap();
+    let items: Vec<String> = project
+        .config
+        .metadata
+        .as_ref()
+        .and_then(|m| m.get("format"))
+        .and_then(|f| f.get("html"))
+        .and_then(|h| h.get("include-in-header"))
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|i| i.as_str().map(|s| s.to_string()))
+                .collect()
+        })
+        .unwrap_or_default();
+    assert_eq!(items, vec!["ext-header.html", "user-header.html"]);
+}
+
+#[test]
+#[ignore = "bd-43lc07w1: quarto-yaml drops !prefer tags on sequences/mappings, so the \
+            tag never reaches the merge; un-ignore when the upstream fix ships"]
+fn user_prefer_replaces_extension_array() {
+    // No Q1-style special-casing: a project that wants to *replace* an
+    // extension-contributed list uses Quarto 2's `!prefer`.
+    let (result, _tmp) = discover_with_extensions(
+        "project:\n  type: fancysite\nformat:\n  html:\n    include-in-header: !prefer\n      - user-header.html\n",
+        &[("acme/fancysite", FANCYSITE)],
+    );
+    let project = result.unwrap();
+    let items: Vec<String> = project
+        .config
+        .metadata
+        .as_ref()
+        .and_then(|m| m.get("format"))
+        .and_then(|f| f.get("html"))
+        .and_then(|h| h.get("include-in-header"))
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|i| i.as_str().map(|s| s.to_string()))
+                .collect()
+        })
+        .unwrap_or_default();
+    assert_eq!(items, vec!["user-header.html"]);
+}
+
+#[test]
+fn extension_render_globs_concat_with_users() {
+    let ext = r#"
+contributes:
+  project:
+    project:
+      type: website
+      render:
+        - "**/*.qmd"
+"#;
+    let (result, _tmp) = discover_with_extensions(
+        "project:\n  type: fancysite\n  render:\n    - index.qmd\n",
+        &[("acme/fancysite", ext)],
+    );
+    let project = result.unwrap();
+    let patterns: Vec<&str> = project
+        .config
+        .render_patterns
+        .iter()
+        .map(|g| g.raw.as_str())
+        .collect();
+    assert_eq!(patterns, vec!["**/*.qmd", "index.qmd"]);
+}
+
+#[test]
+fn detect_is_stripped_from_merged_config() {
+    let ext = r#"
+contributes:
+  project:
+    project:
+      type: website
+      detect:
+        - ["fancy.config.json"]
+"#;
+    let (result, _tmp) =
+        discover_with_extensions("project:\n  type: fancysite\n", &[("acme/fancysite", ext)]);
+    let project = result.unwrap();
+    assert!(
+        project
+            .config
+            .metadata
+            .as_ref()
+            .and_then(|m| m.get("project"))
+            .and_then(|p| p.get("detect"))
+            .is_none(),
+        "`project.detect` is bootstrap-only and must not leak into the merged config"
+    );
+}
+
+// ── Failure modes ───────────────────────────────────────────────────
+
+#[test]
+fn unknown_type_with_no_matching_extension_lists_candidates() {
+    let (result, _tmp) = discover_with_extensions(
+        "project:\n  type: nonexistent\n",
+        &[("acme/fancysite", FANCYSITE)],
+    );
+    let pe = parse_error(result);
+    assert_eq!(pe.diagnostics[0].code.as_deref(), Some("Q-5-17"));
+    let text = pe.render();
+    assert!(
+        text.contains("acme/fancysite"),
+        "error must list project-contributing extensions that were found; got: {text}"
+    );
+}
+
+#[test]
+fn extension_without_project_contribution_does_not_match() {
+    let shortcode_only = r#"
+contributes:
+  shortcodes:
+    - hello.lua
+"#;
+    let (result, _tmp) = discover_with_extensions(
+        "project:\n  type: fancysite\n",
+        &[("acme/fancysite", shortcode_only)],
+    );
+    let pe = parse_error(result);
+    assert_eq!(pe.diagnostics[0].code.as_deref(), Some("Q-5-17"));
+}
+
+#[test]
+fn base_type_book_is_a_q_16_7_error() {
+    let ext = r#"
+contributes:
+  project:
+    project:
+      type: book
+"#;
+    let (result, _tmp) =
+        discover_with_extensions("project:\n  type: fancybook\n", &[("acme/fancybook", ext)]);
+    let pe = parse_error(result);
+    assert_eq!(pe.diagnostics[0].code.as_deref(), Some("Q-16-7"));
+    assert_eq!(pe.diagnostics[0].kind, DiagnosticKind::Error);
+    let text = pe.render();
+    assert!(
+        text.contains("book") && text.contains("not yet"),
+        "error must say book base types are not yet supported; got: {text}"
+    );
+}
+
+#[test]
+fn chained_custom_base_is_a_q_16_7_error() {
+    let ext = r#"
+contributes:
+  project:
+    project:
+      type: other-custom-type
+"#;
+    let (result, _tmp) =
+        discover_with_extensions("project:\n  type: fancysite\n", &[("acme/fancysite", ext)]);
+    let pe = parse_error(result);
+    assert_eq!(pe.diagnostics[0].code.as_deref(), Some("Q-16-7"));
+    let text = pe.render();
+    assert!(
+        text.contains("other-custom-type"),
+        "error must name the invalid base type; got: {text}"
+    );
+}
+
+#[test]
+fn missing_base_type_defaults_with_q_16_9_warning() {
+    let ext = r#"
+contributes:
+  project:
+    website:
+      bread-crumbs: true
+"#;
+    let (result, _tmp) =
+        discover_with_extensions("project:\n  type: fancysite\n", &[("acme/fancysite", ext)]);
+    let project = result.expect("missing base type defaults to `default` (Q1 parity)");
+    assert_eq!(project.project_kind(), ProjectKind::Default);
+    let warnings: Vec<_> = project
+        .config
+        .config_diagnostics
+        .iter()
+        .filter(|d| d.code.as_deref() == Some("Q-16-9"))
+        .collect();
+    assert_eq!(warnings.len(), 1, "must warn about the missing base type");
+    assert_eq!(warnings[0].kind, DiagnosticKind::Warning);
+}

--- a/crates/quarto-core/tests/integration/extension_metadata.rs
+++ b/crates/quarto-core/tests/integration/extension_metadata.rs
@@ -1,0 +1,231 @@
+/*
+ * tests/integration/extension_metadata.rs
+ * Copyright (c) 2026 Posit, PBC
+ *
+ * `contributes.metadata` project-level merging (bd-ad7i1pc6 Phase 5,
+ * absorbing bd-zb2tod5f).
+ */
+
+//! Extension `contributes.metadata.project` → project config.
+//!
+//! Unlike `contributes.project` (opt-in by naming the extension in
+//! `project.type`), `contributes.metadata.project` applies from
+//! **every** discovered extension, unconditionally — the Q1 mechanism
+//! quarto-openapi uses to inject its `pre-render` script. Precedence
+//! deliberately diverges from Q1 (whose `mergeExtensionMetadata` lets
+//! the extension override the user): here the **user wins**, arrays
+//! concat (extension entries first), and bundled file paths rebase
+//! ext-dir → project-root exactly like `contributes.project` fragments.
+
+use std::sync::Arc;
+
+use tempfile::TempDir;
+
+use quarto_core::project::{ProjectContext, ProjectKind};
+use quarto_system_runtime::{NativeRuntime, SystemRuntime};
+
+/// Build a project: `_quarto.yml`, plus extensions given as
+/// `(rel_dir, manifest, assets)` where assets are files created
+/// relative to the extension dir.
+fn discover(
+    quarto_yml: &str,
+    extensions: &[(&str, &str, &[&str])],
+) -> (quarto_core::error::Result<ProjectContext>, TempDir) {
+    let tmp = TempDir::new().unwrap();
+    std::fs::write(tmp.path().join("_quarto.yml"), quarto_yml).unwrap();
+    std::fs::write(tmp.path().join("index.qmd"), "# Hello\n").unwrap();
+    for (rel_dir, manifest, assets) in extensions {
+        let dir = tmp.path().join("_extensions").join(rel_dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("_extension.yml"), manifest).unwrap();
+        for asset in *assets {
+            let p = dir.join(asset);
+            std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+            std::fs::write(&p, "// asset\n").unwrap();
+        }
+    }
+    let runtime: Arc<dyn SystemRuntime> = Arc::new(NativeRuntime::new());
+    let result = ProjectContext::discover(tmp.path(), runtime.as_ref());
+    (result, tmp)
+}
+
+/// The quarto-openapi shape: a pre-render script injected via
+/// `contributes.metadata.project`.
+const OPENAPI_LIKE: &str = r#"
+contributes:
+  metadata:
+    project:
+      pre-render:
+        - openapi-to-markdown.ts
+  format:
+    html:
+      css:
+        - openapi-styles.css
+"#;
+
+#[test]
+fn metadata_project_pre_render_lands_in_project_config() {
+    let (result, _tmp) = discover(
+        "project:\n  type: website\n",
+        &[(
+            "posit-dev/quarto-openapi",
+            OPENAPI_LIKE,
+            &["openapi-to-markdown.ts"],
+        )],
+    );
+    let project = result.expect("builtin type with metadata contribution must parse");
+    assert_eq!(project.project_kind(), ProjectKind::Website);
+    let scripts: Vec<&str> = project
+        .config
+        .pre_render_scripts
+        .iter()
+        .map(|s| s.command.as_str())
+        .collect();
+    assert_eq!(
+        scripts,
+        vec!["_extensions/posit-dev/quarto-openapi/openapi-to-markdown.ts"],
+        "bundled script path must rebase to project root"
+    );
+}
+
+#[test]
+fn metadata_project_concats_with_user_scripts_extension_first() {
+    let (result, _tmp) = discover(
+        "project:\n  type: website\n  pre-render:\n    - ./user-script.sh\n",
+        &[(
+            "posit-dev/quarto-openapi",
+            OPENAPI_LIKE,
+            &["openapi-to-markdown.ts"],
+        )],
+    );
+    let project = result.unwrap();
+    let scripts: Vec<&str> = project
+        .config
+        .pre_render_scripts
+        .iter()
+        .map(|s| s.command.as_str())
+        .collect();
+    assert_eq!(
+        scripts,
+        vec![
+            "_extensions/posit-dev/quarto-openapi/openapi-to-markdown.ts",
+            "./user-script.sh",
+        ]
+    );
+}
+
+#[test]
+fn user_scalar_wins_over_metadata_contribution() {
+    let ext = r#"
+contributes:
+  metadata:
+    project:
+      output-dir: ext-out
+"#;
+    let (result, _tmp) = discover(
+        "project:\n  type: website\n  output-dir: mine\n",
+        &[("meta-ext", ext, &[])],
+    );
+    let project = result.unwrap();
+    assert!(project.output_dir.ends_with("mine"));
+
+    // Gap-fill: without a user value the extension's applies.
+    let (result, _tmp) = discover("project:\n  type: website\n", &[("meta-ext", ext, &[])]);
+    let project = result.unwrap();
+    assert!(
+        project.output_dir.ends_with("ext-out"),
+        "extension output-dir must fill the gap; got {}",
+        project.output_dir.display()
+    );
+}
+
+#[test]
+fn metadata_project_applies_from_multiple_extensions() {
+    let ext_a = r#"
+contributes:
+  metadata:
+    project:
+      resources:
+        - a-resource.json
+"#;
+    let ext_b = r#"
+contributes:
+  metadata:
+    project:
+      resources:
+        - b-resource.json
+"#;
+    let (result, _tmp) = discover(
+        "project:\n  type: website\n",
+        &[("aext", ext_a, &[]), ("bext", ext_b, &[])],
+    );
+    let project = result.unwrap();
+    let mut patterns: Vec<&str> = project
+        .config
+        .resources
+        .iter()
+        .map(|r| r.pattern.as_str())
+        .collect();
+    patterns.sort();
+    assert_eq!(patterns, vec!["a-resource.json", "b-resource.json"]);
+}
+
+#[test]
+fn metadata_contribution_composes_with_custom_project_type() {
+    let type_ext = r#"
+contributes:
+  project:
+    project:
+      type: website
+"#;
+    let (result, _tmp) = discover(
+        "project:\n  type: fancysite\n",
+        &[
+            ("acme/fancysite", type_ext, &[]),
+            (
+                "posit-dev/quarto-openapi",
+                OPENAPI_LIKE,
+                &["openapi-to-markdown.ts"],
+            ),
+        ],
+    );
+    let project = result.expect("custom type + metadata contribution must compose");
+    assert_eq!(project.project_kind(), ProjectKind::Website);
+    assert_eq!(
+        project.config.custom_project_type.as_ref().unwrap().name,
+        "fancysite"
+    );
+    let scripts: Vec<&str> = project
+        .config
+        .pre_render_scripts
+        .iter()
+        .map(|s| s.command.as_str())
+        .collect();
+    assert_eq!(
+        scripts,
+        vec!["_extensions/posit-dev/quarto-openapi/openapi-to-markdown.ts"]
+    );
+}
+
+#[test]
+fn metadata_without_project_key_leaves_project_config_alone() {
+    let ext = r#"
+contributes:
+  metadata:
+    author-notice: "from extension"
+"#;
+    let (result, _tmp) = discover("project:\n  type: website\n", &[("meta-ext", ext, &[])]);
+    let project = result.unwrap();
+    // Non-`project` metadata keys are a *document-level* concern; the
+    // project config must not absorb them at parse time.
+    assert!(
+        project
+            .config
+            .metadata
+            .as_ref()
+            .and_then(|m| m.get("author-notice"))
+            .is_none(),
+        "non-project metadata keys must not merge into project config"
+    );
+    assert!(project.config.pre_render_scripts.is_empty());
+}

--- a/crates/quarto-core/tests/integration/extension_metadata.rs
+++ b/crates/quarto-core/tests/integration/extension_metadata.rs
@@ -166,7 +166,7 @@ contributes:
         .iter()
         .map(|r| r.pattern.as_str())
         .collect();
-    patterns.sort();
+    patterns.sort_unstable();
     assert_eq!(patterns, vec!["a-resource.json", "b-resource.json"]);
 }
 

--- a/crates/quarto-core/tests/integration/main.rs
+++ b/crates/quarto-core/tests/integration/main.rs
@@ -44,6 +44,7 @@ pub mod preview_render_css_parity;
 pub mod printable_render;
 pub mod project_pipeline;
 pub mod project_resources;
+pub mod project_type_parsing;
 pub mod render_page_in_project;
 pub mod render_preserves_source_files;
 pub mod render_to_html_captures;

--- a/crates/quarto-core/tests/integration/main.rs
+++ b/crates/quarto-core/tests/integration/main.rs
@@ -20,6 +20,7 @@ pub mod document_profile_pipeline;
 pub mod engine_error_policy;
 pub mod engine_merge;
 pub mod engine_output_parity;
+pub mod extension_metadata;
 pub mod fail_fast;
 pub mod get_config_merge;
 pub mod idempotence;

--- a/crates/quarto-core/tests/integration/main.rs
+++ b/crates/quarto-core/tests/integration/main.rs
@@ -15,6 +15,7 @@ pub mod bootstrap_js_pipeline;
 pub mod brand_render;
 pub mod capture_splice_engines;
 pub mod crossref_fixtures;
+pub mod custom_project_type;
 pub mod document_profile_pipeline;
 pub mod engine_error_policy;
 pub mod engine_merge;

--- a/crates/quarto-core/tests/integration/project_type_parsing.rs
+++ b/crates/quarto-core/tests/integration/project_type_parsing.rs
@@ -1,0 +1,171 @@
+/*
+ * tests/integration/project_type_parsing.rs
+ * Copyright (c) 2026 Posit, PBC
+ *
+ * `project.type` parsing diagnostics (bd-ad7i1pc6, Phase 1).
+ */
+
+//! `_quarto.yml` `project.type` parsing contract.
+//!
+//! Before bd-ad7i1pc6, an unrecognized `project.type` silently fell
+//! back to the default project kind (`.ok().unwrap_or_default()` in
+//! `ProjectContext::parse_config`) — a `type: posit-docs` website
+//! rendered as a bare default project with no indication anything was
+//! wrong. These tests pin the replacement contract:
+//!
+//! - Unknown `project.type` → hard **Q-5-17** error naming the type,
+//!   with a source snippet anchored in `_quarto.yml`.
+//! - Non-string `project.type` → same Q-5-17 error.
+//! - Built-in names (any case) parse as before; absent type = default.
+//! - `book` / `manuscript` parse but render with default-project
+//!   behavior today — that gets a visible **Q-5-18** warning instead
+//!   of silence.
+
+use std::sync::Arc;
+
+use tempfile::TempDir;
+
+use quarto_core::error::QuartoError;
+use quarto_core::project::{ProjectContext, ProjectKind};
+use quarto_error_reporting::DiagnosticKind;
+use quarto_system_runtime::{NativeRuntime, SystemRuntime};
+
+/// Discover a project whose `_quarto.yml` is `yaml`, keeping the
+/// backing tempdir alive alongside the result.
+fn discover(yaml: &str) -> (quarto_core::error::Result<ProjectContext>, TempDir) {
+    let tmp = TempDir::new().unwrap();
+    std::fs::write(tmp.path().join("_quarto.yml"), yaml).unwrap();
+    std::fs::write(tmp.path().join("index.qmd"), "# Hello\n").unwrap();
+    let runtime: Arc<dyn SystemRuntime> = Arc::new(NativeRuntime::new());
+    let result = ProjectContext::discover(tmp.path(), runtime.as_ref());
+    (result, tmp)
+}
+
+/// Unwrap the structured parse error from a failed discover.
+fn parse_error(result: quarto_core::error::Result<ProjectContext>) -> quarto_core::ParseError {
+    match result {
+        Err(QuartoError::Parse(pe)) => pe,
+        Err(other) => panic!("expected QuartoError::Parse, got: {other:?}"),
+        Ok(_) => panic!("expected discovery to fail"),
+    }
+}
+
+// ── Q-5-17: unknown / malformed `project.type` ──────────────────────
+
+#[test]
+fn unknown_project_type_is_a_q_5_17_error() {
+    let (result, _tmp) = discover("project:\n  type: posit-docs\n");
+    let pe = parse_error(result);
+
+    assert_eq!(pe.diagnostics.len(), 1);
+    let d = &pe.diagnostics[0];
+    assert_eq!(d.kind, DiagnosticKind::Error);
+    assert_eq!(d.code.as_deref(), Some("Q-5-17"));
+
+    let text = pe.render();
+    assert!(
+        text.contains("posit-docs"),
+        "error must name the unknown type; got: {text}"
+    );
+    // The hint lists the built-in type names so the user can spot typos.
+    assert!(
+        text.contains("website") && text.contains("manuscript"),
+        "error must list built-in project types; got: {text}"
+    );
+    // The diagnostic is anchored at the `type:` scalar in _quarto.yml:
+    // the source context must render a snippet naming the config file.
+    assert!(
+        text.contains("_quarto.yml"),
+        "error must carry a source snippet from _quarto.yml; got: {text}"
+    );
+}
+
+#[test]
+fn non_string_project_type_is_a_q_5_17_error() {
+    let (result, _tmp) = discover("project:\n  type: [website]\n");
+    let pe = parse_error(result);
+
+    assert_eq!(pe.diagnostics.len(), 1);
+    assert_eq!(pe.diagnostics[0].code.as_deref(), Some("Q-5-17"));
+    assert_eq!(pe.diagnostics[0].kind, DiagnosticKind::Error);
+    let text = pe.render();
+    assert!(
+        text.contains("string"),
+        "error must say the type must be a string; got: {text}"
+    );
+}
+
+// ── Built-in names keep parsing ─────────────────────────────────────
+
+#[test]
+fn builtin_project_types_parse() {
+    for (yaml, expected) in [
+        ("project:\n  type: default\n", ProjectKind::Default),
+        ("project:\n  type: website\n", ProjectKind::Website),
+        ("project:\n  type: book\n", ProjectKind::Book),
+        ("project:\n  type: manuscript\n", ProjectKind::Manuscript),
+    ] {
+        let (result, _tmp) = discover(yaml);
+        let project = result.expect("built-in project type must parse");
+        assert_eq!(project.project_kind(), expected, "yaml: {yaml}");
+    }
+}
+
+#[test]
+fn project_type_is_case_insensitive() {
+    let (result, _tmp) = discover("project:\n  type: Website\n");
+    let project = result.expect("case-insensitive type must parse");
+    assert_eq!(project.project_kind(), ProjectKind::Website);
+}
+
+#[test]
+fn absent_project_type_defaults_without_diagnostics() {
+    let (result, _tmp) = discover("title: no project block\n");
+    let project = result.expect("absent project.type must default");
+    assert_eq!(project.project_kind(), ProjectKind::Default);
+    assert!(
+        quarto_core::project::project_kind_diagnostics(&project.config).is_empty(),
+        "a default project must not warn"
+    );
+}
+
+// ── Q-5-18: book / manuscript parse but warn ────────────────────────
+
+#[test]
+fn book_project_type_warns_q_5_18() {
+    let (result, _tmp) = discover("project:\n  type: book\n");
+    let project = result.expect("book must parse");
+    assert_eq!(project.project_kind(), ProjectKind::Book);
+
+    let diags = quarto_core::project::project_kind_diagnostics(&project.config);
+    assert_eq!(diags.len(), 1);
+    assert_eq!(diags[0].code.as_deref(), Some("Q-5-18"));
+    assert_eq!(diags[0].kind, DiagnosticKind::Warning);
+    let text = diags[0].to_text(None);
+    assert!(
+        text.contains("book") && text.contains("default"),
+        "warning must say book renders with default behavior; got: {text}"
+    );
+}
+
+#[test]
+fn manuscript_project_type_warns_q_5_18() {
+    let (result, _tmp) = discover("project:\n  type: manuscript\n");
+    let project = result.expect("manuscript must parse");
+    assert_eq!(project.project_kind(), ProjectKind::Manuscript);
+
+    let diags = quarto_core::project::project_kind_diagnostics(&project.config);
+    assert_eq!(diags.len(), 1);
+    assert_eq!(diags[0].code.as_deref(), Some("Q-5-18"));
+    assert!(diags[0].to_text(None).contains("manuscript"));
+}
+
+#[test]
+fn website_project_type_does_not_warn() {
+    let (result, _tmp) = discover("project:\n  type: website\n");
+    let project = result.expect("website must parse");
+    assert!(
+        quarto_core::project::project_kind_diagnostics(&project.config).is_empty(),
+        "website is fully implemented — no Q-5-18 warning"
+    );
+}

--- a/crates/quarto-error-catalog/error_catalog.json
+++ b/crates/quarto-error-catalog/error_catalog.json
@@ -1136,7 +1136,7 @@
   "Q-5-17": {
     "subsystem": "project",
     "title": "Unknown Project Type",
-    "message_template": "`_quarto.yml` sets a `project.type` that is neither a built-in project type (`default`, `website`, `book`, `manuscript`) nor a string, so the project cannot be rendered. Earlier Quarto 2 versions silently rendered such projects with default-project behavior; that fallback was removed because it hides a broken site build. Check the type name for typos. (Extension-contributed custom project types are planned; once implemented, a matching extension under `_extensions/` resolves the type before this error fires.)",
+    "message_template": "`_quarto.yml` sets a `project.type` that is not a string, is not a built-in project type (`default`, `website`, `book`, `manuscript`), and does not match any extension contributing a project type (`contributes: project:` in an `_extensions/` manifest), so the project cannot be rendered. Earlier Quarto 2 versions silently rendered such projects with default-project behavior; that fallback was removed because it hides a broken site build. Check the type name for typos; the hints list the project-contributing extensions that were found, and any manifest that failed to load is reported alongside as Q-16-1 (a broken manifest is a common root cause).",
     "docs_url": "https://quarto.org/docs/errors/project/Q-5-17",
     "since_version": "99.9.9"
   },
@@ -1208,6 +1208,27 @@
     "title": "Block Shortcode In Inline Position",
     "message_template": "A shortcode used inline (inside a sentence or other inline content) produced block-level output (for example a raw HTML block from the `video` shortcode), and none of it could be carried into the inline position — the output was dropped. Put the shortcode in its own paragraph, surrounded by blank lines.",
     "docs_url": "https://quarto.org/docs/errors/extension/Q-16-6",
+    "since_version": "99.9.9"
+  },
+  "Q-16-7": {
+    "subsystem": "extension",
+    "title": "Invalid Project Type Contribution",
+    "message_template": "An extension resolved a custom `project.type`, but its `contributes.project` fragment is unusable: it is not a mapping, its `project.type` is not a string, it names a base type that is not built-in (chaining custom types is not supported), or it names `book`/`manuscript`, which Quarto 2 does not implement yet. The project cannot be rendered until the extension manifest is fixed (or the type is changed). The message names the extension and its `_extension.yml`.",
+    "docs_url": "https://quarto.org/docs/errors/extension/Q-16-7",
+    "since_version": "99.9.9"
+  },
+  "Q-16-8": {
+    "subsystem": "extension",
+    "title": "Ambiguous Project Type Extension",
+    "message_template": "A bare `project.type` name matched more than one extension contributing a project type. The org-less extension wins, then the lexicographically first organization; the message names the chosen extension and the shadowed candidates. Use the full `organization/name` form in `project.type` to disambiguate.",
+    "docs_url": "https://quarto.org/docs/errors/extension/Q-16-8",
+    "since_version": "99.9.9"
+  },
+  "Q-16-9": {
+    "subsystem": "extension",
+    "title": "Project Type Contribution Missing Base Type",
+    "message_template": "An extension's `contributes.project` fragment does not declare `project.type`, so the custom project type falls back to the `default` base type. This is almost always an authoring mistake in the extension — a website-styled project type without `project: type: website` silently loses all website behavior. Declare the base type in the extension's `_extension.yml`.",
+    "docs_url": "https://quarto.org/docs/errors/extension/Q-16-9",
     "since_version": "99.9.9"
   },
   "Q-17-1": {

--- a/crates/quarto-error-catalog/error_catalog.json
+++ b/crates/quarto-error-catalog/error_catalog.json
@@ -1133,6 +1133,20 @@
     "docs_url": "https://quarto.org/docs/errors/project/Q-5-16",
     "since_version": "99.9.9"
   },
+  "Q-5-17": {
+    "subsystem": "project",
+    "title": "Unknown Project Type",
+    "message_template": "`_quarto.yml` sets a `project.type` that is neither a built-in project type (`default`, `website`, `book`, `manuscript`) nor a string, so the project cannot be rendered. Earlier Quarto 2 versions silently rendered such projects with default-project behavior; that fallback was removed because it hides a broken site build. Check the type name for typos. (Extension-contributed custom project types are planned; once implemented, a matching extension under `_extensions/` resolves the type before this error fires.)",
+    "docs_url": "https://quarto.org/docs/errors/project/Q-5-17",
+    "since_version": "99.9.9"
+  },
+  "Q-5-18": {
+    "subsystem": "project",
+    "title": "Project Type Not Yet Implemented",
+    "message_template": "`_quarto.yml` sets `project.type: book` or `project.type: manuscript`, which Quarto 2 does not implement yet. The type name is accepted (for forward compatibility with Quarto 1 projects) but the project renders with default-project behavior: documents render individually, with no book/manuscript structure, navigation, or combined output.",
+    "docs_url": "https://quarto.org/docs/errors/project/Q-5-18",
+    "since_version": "99.9.9"
+  },
   "Q-5-13": {
     "subsystem": "project",
     "title": "`project.render` Pattern Matched No Files",

--- a/crates/quarto-preview/src/lib.rs
+++ b/crates/quarto-preview/src/lib.rs
@@ -310,7 +310,12 @@ fn run_boot_pre_render_scripts(project_root: &std::path::Path) {
             return;
         }
     };
-    for diagnostic in render_scripts::underscore_typo_diagnostics(&project.config) {
+    for diagnostic in render_scripts::underscore_typo_diagnostics(&project.config)
+        .into_iter()
+        .chain(quarto_core::project::project_kind_diagnostics(
+            &project.config,
+        ))
+    {
         eprintln!("{}", diagnostic.to_text(None));
     }
     if project.config.pre_render_scripts.is_empty() {

--- a/crates/quarto-preview/src/lib.rs
+++ b/crates/quarto-preview/src/lib.rs
@@ -315,6 +315,7 @@ fn run_boot_pre_render_scripts(project_root: &std::path::Path) {
         .chain(quarto_core::project::project_kind_diagnostics(
             &project.config,
         ))
+        .chain(project.config.config_diagnostics.iter().cloned())
     {
         eprintln!("{}", diagnostic.to_text(None));
     }

--- a/crates/quarto/src/commands/render.rs
+++ b/crates/quarto/src/commands/render.rs
@@ -796,8 +796,14 @@ fn execute_project(
 
     // bd-w348iu63: warn about the likely `pre_render` / `post_render`
     // misspellings (Q2 has no schema layer; unknown keys are
-    // otherwise silently ignored).
-    for diagnostic in render_scripts::underscore_typo_diagnostics(&project.config) {
+    // otherwise silently ignored). bd-ad7i1pc6: also warn when the
+    // project kind (book/manuscript) renders with default behavior.
+    for diagnostic in render_scripts::underscore_typo_diagnostics(&project.config)
+        .into_iter()
+        .chain(quarto_core::project::project_kind_diagnostics(
+            &project.config,
+        ))
+    {
         eprintln!("{}", diagnostic.to_text(None));
     }
 

--- a/crates/quarto/src/commands/render.rs
+++ b/crates/quarto/src/commands/render.rs
@@ -797,12 +797,15 @@ fn execute_project(
     // bd-w348iu63: warn about the likely `pre_render` / `post_render`
     // misspellings (Q2 has no schema layer; unknown keys are
     // otherwise silently ignored). bd-ad7i1pc6: also warn when the
-    // project kind (book/manuscript) renders with default behavior.
+    // project kind (book/manuscript) renders with default behavior,
+    // and surface config-parse diagnostics (ambiguous / incomplete
+    // project-type extensions) once per run.
     for diagnostic in render_scripts::underscore_typo_diagnostics(&project.config)
         .into_iter()
         .chain(quarto_core::project::project_kind_diagnostics(
             &project.config,
         ))
+        .chain(project.config.config_diagnostics.iter().cloned())
     {
         eprintln!("{}", diagnostic.to_text(None));
     }
@@ -849,7 +852,7 @@ fn execute_project(
         args.quiet,
         "Rendering project: {} (type: {})",
         project.dir.display(),
-        project.project_kind().as_str()
+        project.project_type_label()
     );
 
     let project_type = project_type_for(&project);

--- a/crates/wasm-quarto-hub-client/Cargo.lock
+++ b/crates/wasm-quarto-hub-client/Cargo.lock
@@ -2424,9 +2424,9 @@ dependencies = [
 
 [[package]]
 name = "quarto-yaml"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c32ab7b39ffa5c43c8aa6abf7eff392678acee63bad5d21680fe295e69b7c2e0"
+checksum = "fc3a45a71cc89e7f171552a98b786ae0b9b2bd84e8608d708539a869e0bc4d21"
 dependencies = [
  "quarto-source-map",
  "serde",

--- a/docs/guides/authoring/extensions.qmd
+++ b/docs/guides/authoring/extensions.qmd
@@ -2,4 +2,116 @@
 title: Using Quarto extensions
 ---
 
-TBD.
+## Overview
+
+Extensions add capabilities to Quarto projects and documents. An extension lives in a directory under `_extensions/` at your project root, described by an `_extension.yml` manifest:
+
+``` {.default}
+my-project/
+  _quarto.yml
+  _extensions/
+    acme/                  # optional organization directory
+      fancy-docs/
+        _extension.yml     # the extension manifest
+        theme.scss         # files bundled with the extension
+        assets/...
+```
+
+The manifest declares what the extension contributes:
+
+``` {.yaml filename="_extension.yml"}
+title: Fancy Docs
+author: Acme
+version: 1.0.0
+contributes:
+  # one or more of:
+  shortcodes: [...]
+  filters: [...]
+  formats: {...}
+  project: {...}
+  metadata: {...}
+```
+
+This page covers project types and metadata contributions. Shortcodes and filters have their own pages ([Shortcodes](shortcodes.qmd), [Lua filters](lua-filters.qmd)).
+
+## Custom project types
+
+An extension can define a **custom project type**: a named bundle of configuration that projects opt into by setting `project.type`. This is how a team ships a house style — theme, navigation defaults, analytics — as one reusable package.
+
+In your project:
+
+``` {.yaml filename="_quarto.yml"}
+project:
+  type: fancy-docs
+website:
+  title: "My Site"
+```
+
+In the extension:
+
+``` {.yaml filename="_extensions/acme/fancy-docs/_extension.yml"}
+title: Fancy Docs
+contributes:
+  project:
+    project:
+      type: website        # the built-in base type
+    website:
+      bread-crumbs: true
+      navbar:
+        logo: assets/logo.svg
+    format:
+      html:
+        theme: [cosmo, theme.scss]
+        include-in-header:
+          - assets/analytics.html
+```
+
+Everything under `contributes: project:` is an ordinary `_quarto.yml` fragment. When Quarto sees `type: fancy-docs`, it:
+
+1. finds the extension by name (use the full `acme/fancy-docs` form in `type:` if two extensions share a name);
+2. reads the **base type** from the fragment's `project.type` — the built-in type the project actually renders as (`website` or `default`);
+3. merges the fragment *underneath* your `_quarto.yml`.
+
+The project then behaves exactly as if you had written the combined configuration yourself.
+
+### Merge rules
+
+Quarto's standard configuration merging applies, uniformly:
+
+- **Your value wins** wherever both you and the extension set the same option.
+- **Lists combine**: the extension's entries come first, then yours. In the example above, a project-level `include-in-header` is appended after the extension's analytics include.
+- To **replace** an extension-provided list instead of appending, tag your value with `!prefer`:
+
+  ``` {.yaml filename="_quarto.yml"}
+  format:
+    html:
+      include-in-header: !prefer
+        - only-mine.html
+  ```
+
+### Bundled files
+
+Files the extension ships next to its manifest — SCSS themes, CSS, header includes, favicons, logos, scripts — are referenced with paths relative to the extension directory, as in the example above. Quarto resolves them automatically; your project does not need to spell out `_extensions/acme/fancy-docs/theme.scss`.
+
+### Errors you might see
+
+- **Unknown project type (Q-5-17)**: `project.type` is neither built-in nor provided by any extension in `_extensions/`. The message lists the project-type extensions that were found — check for typos, and check whether the extension failed to load.
+- **Invalid project type contribution (Q-16-7)**: the extension declares a base type that is not available. Custom types must use a built-in base (`website` or `default`); `book` and `manuscript` bases are not supported yet, and custom types cannot chain to other custom types.
+
+## Metadata contributions
+
+An extension can also contribute configuration *unconditionally* — applied whenever the extension is installed, without being named in `project.type`. This is `contributes: metadata:`:
+
+``` {.yaml filename="_extensions/posit-dev/quarto-openapi/_extension.yml"}
+title: quarto-openapi
+contributes:
+  metadata:
+    project:
+      pre-render:
+        - openapi-to-markdown.ts
+```
+
+- Keys under `metadata.project` merge into your project configuration — the example adds a pre-render script that runs before every project render.
+- Other keys under `metadata` merge into every document's metadata.
+
+The same merge rules apply: your own configuration always wins over extension contributions, and lists combine with the extension's entries first.


### PR DESCRIPTION
## Summary

Implements Q1-style **extension-contributed custom project types** (`contributes: project:` in `_extension.yml`) plus **`contributes: metadata:`** support, driven by the Posit Connect docs testbed (`project: type: posit-docs`). Plan with design decisions and per-phase evidence: `claude-notes/plans/2026-08-08-custom-project-types.md`. Strand: bd-ad7i1pc6 (absorbs bd-zb2tod5f, closed).

A custom `project.type` now resolves against extensions discovered at project-config time: the selected extension's `contributes.project` fragment (an ordinary `_quarto.yml` fragment) merges **under** the user's config inside `ProjectContext::parse_config`, and `project.type` is rewritten to the fragment's built-in base type — downstream code sees an ordinary website/default project. `ProjectConfig` records the resolution and the render banner prints `type: posit-docs (website)`.

Merge semantics are Quarto 2's standard rules, uniformly — no Q1 special cases: user wins scalars, arrays concat (extension entries first), and a user value tagged `!prefer` replaces the extension's list outright.

## Commits / phases

1. **3ac0d892** — kill the silent fallback: unknown `project.type` is a hard **Q-5-17** error (ariadne snippet at the `type:` scalar); built-in `book`/`manuscript` warn visibly (**Q-5-18**) that they render with default behavior.
2. **e15f173c** — project-scoped extension discovery (`discover_project_extensions`): project-root `_extensions/` + embedded built-ins, at parse-config time.
3. **c97ce8bb** — resolution + merge: deterministic Q1-compatible selection (exact `org/name`; bare names prefer org-less, **Q-16-8** ambiguity warning), fragment validation (**Q-16-7** for non-map / chained / book / manuscript bases, **Q-16-9** for missing base), `detect` stripped.
4. **545b3981** — path rebasing: key-path pattern table + existence check under the extension dir rebases bundled files (theme SCSS, includes, favicon, logos, scripts) to project-root-relative `Path` values; builtin theme names, command lines, URLs pass through.
5. **20f937f3** — `contributes.metadata`: `metadata.project` merges into project config from **all** discovered extensions (user wins — deliberate divergence from Q1's extension-wins `mergeExtensionMetadata`); non-`project` keys join the per-document merge as bottom layers.
6. **8dabfe3f** — user-facing docs (`docs/guides/authoring/extensions.qmd`, was `TBD.`), verified with `q2 render docs/`.
7. **c727fb02** — strict-clippy fix in a test.
8. **0ca1b881** — bump quarto-yaml 0.1.0 → 0.1.2 (posit-dev/quarto-yaml#14, found during this work): `!prefer`/`!concat` on YAML sequences/mappings now reach the merge; previously-ignored pinning test un-ignored.

## Real-world verification

On the Connect docs testbed, `type: posit-docs` resolves and — with the extension's light/dark theme map flattened to a plain list — **351/351 files render**, with the extension's navbar Help menu, compiled SCSS theme (imports resolved), and analytics include in the output; the user's favicon wins its collision per the designed precedence. The light/dark theme map form is the remaining testbed blocker, filed as **bd-o76p01wb** (Q-14-1 today). quarto-openapi's contributed `pre-render` is discovered and launched (its Deno-style `.ts` imports failing under Node is the separate runtime gap under bd-wch2dotq).

Discovered and filed along the way: **bd-o76p01wb** (light/dark theme maps, P1), **bd-of20unsb** (format-extension bundled theme SCSS silently dropped — pre-existing, P2), **bd-43lc07w1** (quarto-yaml tag drop — fixed upstream + bumped here, closed), plus P4 parity follow-ups (`detect` bootstrap bd-0dtv2nhe, `preview.serve` bd-nmawh9vj, book/manuscript bases bd-m1fzvpov).

## Test plan

- 42 new tests across `project_type_parsing.rs`, `custom_project_type.rs`, `extension_metadata.rs`, `extension::discover`, and `metadata_merge.rs` — all written first and observed failing (TDD).
- Full workspace suite: **11,110 passed**.
- Full `cargo xtask verify` (including hub-client/WASM leg): green.
- End-to-end through the real binary at every phase (invocations + output snippets recorded in the plan doc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)