### PR TITLE
Accept theme: {light, dark} map form; honor light half, warn Q-14-3 (bd-o76p01wb)

### DIFF
--- a/claude-notes/plans/2026-08-08-theme-light-dark-interim.md
+++ b/claude-notes/plans/2026-08-08-theme-light-dark-interim.md
@@ -263,11 +263,12 @@ is already filed.
 - [x] Work committed as 29ed786d on
       `braid/bd-o76p01wb-light-dark-theme-map`; completion note on
       bd-o76p01wb (c-gfv7ojsc)
-- [ ] Open the PR (against `main` once #474 merges; branch currently
-      contains #474's commits — the PR diff must be only this strand's
-      commit), then close bd-o76p01wb (decided: close upon opening the PR).
-      **Blocked on #474 merging** (still OPEN as of 2026-08-08); pushing
-      needs user approval per repo policy.
+- [x] #474 merged; rebased onto `main` (single commit fc422255), re-ran
+      the full gates on the rebased tree (11,135 workspace tests + full
+      `cargo xtask verify`, both green), pushed as
+      `origin/feature/bd-o76p01wb-light-dark-theme-map`, opened
+      **PR #475** (https://github.com/quarto-dev/q2/pull/475), and closed
+      bd-o76p01wb.
 
 ## Resolved questions (review with Carlos, 2026-08-08)
 

--- a/claude-notes/plans/2026-08-08-theme-light-dark-interim.md
+++ b/claude-notes/plans/2026-08-08-theme-light-dark-interim.md
@@ -1,0 +1,281 @@
+# Interim support for `theme: {light: [...], dark: [...]}` — use light, warn on dark
+
+**Strand:** bd-o76p01wb (P1, feature) — discovered-from bd-ad7i1pc6 (custom project types, PR #474)
+**Full-support strand (out of scope here):** bd-0pic6 — "Support theme: {light, dark} dark-mode config (object form)"
+**Branch:** `braid/bd-o76p01wb-light-dark-theme-map`, based on `origin/feature/bd-ad7i1pc6-custom-project-types` (PR #474). The eventual PR waits for #474 to merge, then retargets/rebases onto `main`.
+
+## Overview
+
+Q1 supports a map form for `format.html.theme` (and `highlight-style`):
+
+```yaml
+format:
+  html:
+    theme:
+      light: [theme.scss]
+      dark: [theme-dark.scss]
+    highlight-style:
+      light: github
+      dark: arrow
+```
+
+Q2 rejects the theme map with **Q-14-1** ("theme must be a string or array of
+strings"). The posit-dev/posit-docs extension ships exactly this form, so after
+PR #474 resolves `project.type: posit-docs` on the Connect docs testbed
+(`~/repos/github/cscheid/q2-connect-docs/docs-quarto-2`), all 351 files fail on
+the theme map. With the map hand-flattened to a plain list, everything renders
+— the map form is the single remaining testbed blocker.
+
+**Scope decision (per Carlos):** full dual-theme support (compile both CSS
+variants + toggle wiring) is a separate task — it stays on bd-0pic6. This
+strand does the documented degradation: **accept the map, use only the `light`
+half, emit a user-visible warning that `dark` is ignored.**
+
+## Assessment (code reading, 2026-08-08)
+
+### Where the error comes from
+
+- `crates/quarto-sass/src/config.rs::extract_theme_specs` handles string and
+  array; anything else → `SassError::InvalidThemeConfig` ("theme must be a
+  string or array of strings"), carrying the value's `SourceInfo`.
+- `ThemeConfig::from_config_value` (same file) is the only entry point that
+  calls it; it also handles the `theme: none` sentinel and brand auto-inject.
+- `crates/quarto-core/src/theme_diagnostic.rs::sass_error_to_parse_error`
+  lifts `InvalidThemeConfig` into the structured **Q-14-1** ariadne diagnostic.
+
+### Consumers of `ThemeConfig::from_config_value`
+
+1. `crates/quarto-core/src/stage/stages/compile_theme_css.rs:368` — the main
+   consumer. On `Err`, the render of that document hard-fails with Q-14-1.
+2. `crates/quarto-core/src/stage/stages/bootstrap_js.rs:152` — on `Err` it
+   logs a trace warning and **silently suppresses Bootstrap JS** (treats the
+   parse failure as `suppress_bootstrap = true`). Today the map form both
+   fails the render *and* (in any path that tolerates the failure) drops
+   Bootstrap JS. Fixing the parse in quarto-sass repairs both consumers at
+   once — a point in favor of fixing at the parsing layer rather than
+   pre-normalizing metadata in one stage.
+
+### Prior art already in the same file
+
+`extract_brand_ref` (config.rs:415) already implements exactly this shape for
+`brand:`: a map whose keys are only `light`/`dark` is treated as a pair, the
+`light` half is used, the dark side is deferred ("TODO(brand light/dark): wire
+dark variant once Q2 has a light/dark seam"). Caveat: its doc comment promises
+a "soft warning" but **no warning is actually emitted** — quarto-sass has no
+diagnostics channel. The theme interim should do better (see D2) and is the
+occasion to define the pattern the brand path can later adopt.
+
+### Path rebasing (PR #474) already handles the map form
+
+`FRAGMENT_PATH_PATTERNS` in `crates/quarto-core/src/project/mod.rs:681` ends
+patterns at `["format", "*", "theme"]` and rebases **every string leaf
+underneath** — the doc comment explicitly says this is what makes
+`theme: {light: […], dark: […]}` work from one table entry. So
+`light: [theme.scss]` arrives at the theme stage already rebased to a
+project-relative `ConfigValueKind::Path` (e.g.
+`_extensions/posit-dev/posit-docs/theme.scss`). No rebasing work needed here;
+the existing array-item text extraction (`config_value_as_text`) already
+handles `Path` kinds (the flattened-list workaround renders today through the
+same code).
+
+### `highlight-style` needs no interim work
+
+Q2 currently has **no reader for `highlight-style` at all** — code
+highlighting is tree-sitter-based (`CodeHighlightStage`), and the only
+`highlight_style` mention in the workspace is an inert default in
+`crates/pampa/src/options.rs`. The map form therefore passes through silently
+today (confirmed by the testbed: with only the theme flattened, all 351 files
+render — highlight-style stayed in map form). Wiring `highlight-style` (both
+scalar and map forms) into the highlighter is part of the full-support work;
+noted on bd-0pic6 rather than handled here.
+
+### Warning plumbing and noise control
+
+- Stages emit user-visible warnings via `StageContext::add_diagnostic`
+  (`crates/quarto-core/src/stage/context.rs:339`); per-document diagnostics on
+  successful outputs are printed by `print_render_diagnostics_text`
+  (`crates/quarto/src/commands/render.rs`) through
+  `coalesce_by_source` — diagnostics sharing a source location collapse into
+  **one** report with an "Affected files:" tail. Our warning's `SourceInfo`
+  points at the theme map in the extension's `_extension.yml` (same location
+  for every document), so 351 renders produce one printed warning, not 351.
+- Warnings do not affect the exit code unless `--strict`
+  (`should_exit_nonzero`: `counts.errors > 0 || (strict && counts.warnings > 0)`).
+  So the testbed exits 0 by default with the degradation visible. Under
+  `--strict` it would exit non-zero — that is the designed meaning of
+  `--strict`, not a problem to engineer around.
+
+### Error catalog
+
+`Q-14-1` / `Q-14-2` live in `crates/quarto-error-catalog/error_catalog.json`
+under subsystem `theme`. Next free code: **Q-14-3** for the new warning.
+
+## Design
+
+**D1 — parse the map form in quarto-sass, not in a quarto-core pre-pass.**
+`ThemeConfig::from_config_value` gains a branch: when the theme value is a map
+whose keys ⊆ {`light`, `dark`} (at least one present), it is a light/dark
+pair. Rationale: single source of truth repairs both consumers
+(compile_theme_css + bootstrap_js), covers project config *and* document
+frontmatter overrides, and sits next to the brand precedent. Any map with
+other keys keeps the Q-14-1 error (message updated to mention the accepted
+`light:`/`dark:` form).
+
+**D2 — carry the degradation as data; emit the warning in the stage.**
+quarto-sass stays diagnostics-free: `ThemeConfig` gains a field, e.g.
+`pub dark_theme_ignored: Option<SourceInfo>` (location of the `dark:` entry,
+falling back to the map). `CompileThemeCssStage` converts it into a
+**Q-14-3 warning** via `ctx.add_diagnostic` after a successful parse.
+`BootstrapJsStage` deliberately does not emit (it would double-report every
+document); it only reads `suppress_bootstrap` as before.
+
+**D3 — semantics of the pair (interim):**
+- `light` present → its value goes through the existing string/array logic
+  (`light: cosmo` and `light: [cosmo, custom.scss]` both work, matching Q1's
+  accepted shapes). `dark` recorded for the warning, otherwise ignored.
+- `dark` only → default Bootstrap themes (empty spec list) + the same Q-14-3
+  warning. (Mirrors the brand precedent's "only dark → none", but with the
+  warning the brand path lacks.)
+- Nested maps inside `light:` (e.g. `light: {light: …}`) → Q-14-1, as today.
+  Implementation guard: the pair branch runs only at the top level; the
+  recursive extraction for the light half rejects maps.
+- `theme: {light: none}` → the `none` sentinel is honored for the light half
+  (suppress Bootstrap), same as `theme: none`. Implementation: factor the
+  existing `none`/string/array handling into a helper both the top level and
+  the light half call.
+- Empty map `theme: {}` → Q-14-1 (no light, no dark ⇒ not a pair).
+
+**D4 — Q-14-3 catalog entry.** Subsystem `theme`, title
+"Dark theme variant not yet supported", message: the `dark:` half of a
+`theme: light:/dark:` map is ignored in this release; the document is styled
+with the `light:` themes only. The user-facing message must **not** reference
+braid strands (they are not publicly readable); internal tracking of the full
+feature stays on bd-0pic6, mentioned only here and in code comments.
+
+**D6 — warning granularity (decided 2026-08-08).** Warn only when `dark:` is
+actually present. `theme: {light: [...]}` alone is a fully-honored (if
+redundant) spelling and is accepted silently — with explicit test coverage
+for both the scalar and list forms of a light-only map.
+
+**D5 — out of scope.** RevealJS light/dark (bd-904h9kmt), the brand
+light/dark seam (existing TODO in `extract_brand_ref` — can adopt the same
+`SourceInfo`-carrying pattern later), `highlight-style` wiring, and actual
+dual-CSS compilation + toggle (bd-0pic6). No new strands needed; everything
+is already filed.
+
+## Work items
+
+### Phase 1 — tests first (TDD) ✅ (red state confirmed 2026-08-08)
+
+- [x] quarto-sass unit tests (`crates/quarto-sass/src/config.rs` tests
+      module, next to the existing "theme set to a map" rejection test):
+  - [x] `{light: [a.scss, cosmo], dark: [b.scss]}` → specs = light list,
+        `dark_theme_ignored` is `Some` pointing at the `dark` entry
+  - [x] `{light: cosmo}` scalar form → single spec, no warning field
+        (per D6: no `dark:` present ⇒ nothing ignored ⇒ no warning)
+  - [x] `{light: [a.scss, cosmo]}` list form, no `dark:` → specs = light
+        list, no warning field (per D6)
+  - [x] `{dark: darkly}` only → empty specs (default Bootstrap),
+        `dark_theme_ignored` is `Some`
+  - [x] `{light: cosmo, dark: darkly, contrast: high}` → Q-14-1 (unchanged)
+  - [x] `{}` → Q-14-1 error (already covered by
+        `test_from_config_value_invalid_type` /
+        `test_invalid_theme_map_carries_location`, which stay untouched)
+  - [x] `{light: none}` → `suppress_bootstrap = true`
+  - [x] map form + `brand:` key → brand auto-inject still appends to the
+        light specs
+  - [x] (extra) `{light: {light: …}}` nested map → Q-14-1; unknown light
+        theme → Q-14-2; light half as PandocInlines (frontmatter path)
+- [x] quarto-core stage tests:
+  - [x] `compile_theme_css`: map-form metadata → stage succeeds, exactly one
+        Q-14-3 warning in `ctx.diagnostics`, compiled CSS reflects the light
+        theme
+  - [x] `bootstrap_js`: map-form metadata no longer suppresses Bootstrap JS
+- [x] catalog test: Q-14-3 registered under subsystem `theme`
+      (extended `theme_diagnostic_code_is_registered_in_catalog`)
+- [x] integration test through the real render path
+      (`crates/quarto-core/tests/integration/theme_light_dark.rs`, 3 tests:
+      project-config map, frontmatter map, light-only map): render succeeds,
+      CSS contains the light marker rule and not the dark one, exactly one
+      Q-14-3 warning (none for light-only)
+- [x] run new tests, verify they fail for the expected reason —
+      quarto-sass: 8 failed (Q-14-1 on map form) / 3 passed (error-shape
+      tests that stay valid); quarto-core: 6 failed (Q-14-1 render failures,
+      suppressed JS, Q-14-3 not in catalog). Scaffolding note: the
+      `dark_theme_ignored` field was added as an inert stub (always `None`)
+      so the red tests compile; all behavior is Phase 2.
+
+### Phase 2 — implementation ✅ (2026-08-08)
+
+- [x] `ThemeConfig`: `dark_theme_ignored: Option<SourceInfo>`; pair branch
+      (`light_dark_pair` + `LightDarkPair`) and the shared
+      `Self::from_theme_value` helper (null / `none` sentinel / string /
+      array) used by both the top level and the light half
+- [x] Q-14-1 fallback message now reads "theme must be a string or array of
+      strings, or a map with only `light:`/`dark:` keys"
+- [x] Q-14-3 added to `crates/quarto-error-catalog/error_catalog.json`
+      (no braid-strand references in the user-facing text, per review)
+- [x] `CompileThemeCssStage`: emits Q-14-3 warning via `ctx.add_diagnostic`,
+      located at the ignored `dark:` key, with a remove-or-keep hint;
+      emitted after parse and before the `suppress_bootstrap` early return
+      so `{light: none, dark: …}` still warns
+- [x] All Phase-1 tests green; full workspace suite: 11,125 passed
+
+### Phase 3 — verification
+
+- [x] `cargo nextest run --workspace` — 11,125 passed, 0 failed
+- [x] End-to-end minimal fixture (2026-08-08): project in scratchpad with
+      `format.html.theme: {light: [cosmo, light-marker.scss], dark: [darkly,
+      dark-marker.scss]}`. Invocation: `cargo run --bin q2 -- render
+      <fixture-dir>`. Observed: exit 0; stderr shows
+      `Warning: [Q-14-3] Dark theme variant not yet supported` with an
+      ariadne snippet pointing at `_quarto.yml:7:7` (the `dark:` key) and
+      the remove-or-keep hint; compiled `quarto-theme-*.css` contains
+      `.q-light-marker{color:#123456}` and zero occurrences of
+      `q-dark-marker`. Output inspected directly.
+- [x] Testbed (2026-08-08): rendered
+      `~/repos/github/cscheid/q2-connect-docs/docs-quarto-2` with the
+      posit-docs extension's theme map **unflattened** via
+      `target/debug/q2 render <testbed>`. Result: **`Rendered 351 of 351
+      files`, exit 0**; Q-14-3 printed **exactly once**, coalesced with
+      "Affected files: … (and 348 others)". Compiled site theme CSS contains
+      light-half markers (`Open Sans`, posit orange `ee6331`) and **not**
+      the dark-only body background `#181c25`. The `highlight-style`
+      light/dark map passed through inert as assessed (no reader in Q2).
+      Caveat A: the run required temporarily stripping quarto-openapi's
+      contributed `pre-render` (its Deno-style `.ts` fails under Node —
+      the separate bd-wch2dotq gap; file restored via git afterwards).
+      Caveat B: the Q-14-3 warning renders span-less on the testbed — its
+      location points into the extension's `_extension.yml`, which per-page
+      SourceContexts don't register (`attach_config_source` only repairs
+      `_quarto.yml`-anchored FileIds). Message + affected-files list are
+      still clear; snippet support for extension-fragment locations noted
+      as a possible follow-up.
+- [x] `cargo xtask verify` (full, including hub-client/WASM leg) — all 14
+      steps passed (2026-08-08)
+
+### Phase 4 — bookkeeping
+
+- [x] `braid dep add bd-o76p01wb bd-0pic6 --type related` (interim ↔ full)
+- [x] Comment on bd-0pic6 (c-9gw5c02b): interim degradation landed; full
+      work = dual-CSS compilation + toggle + `highlight-style` map + brand
+      light/dark seam; Q-14-3 warning to be removed/replaced when it lands
+- [x] Work committed as 29ed786d on
+      `braid/bd-o76p01wb-light-dark-theme-map`; completion note on
+      bd-o76p01wb (c-gfv7ojsc)
+- [ ] Open the PR (against `main` once #474 merges; branch currently
+      contains #474's commits — the PR diff must be only this strand's
+      commit), then close bd-o76p01wb (decided: close upon opening the PR).
+      **Blocked on #474 merging** (still OPEN as of 2026-08-08); pushing
+      needs user approval per repo policy.
+
+## Resolved questions (review with Carlos, 2026-08-08)
+
+1. **Warning granularity:** warn only when `dark:` is present; a light-only
+   map is honored silently. Both scalar and list light-only forms get
+   explicit tests. (→ D6)
+2. **Q-14-3 wording:** "Dark theme variant not yet supported" is the right
+   frame. The warning is expected to be short-lived, and user-facing text
+   must not reference braid strands (not publicly readable). (→ D4)
+3. **Close timing:** close bd-o76p01wb upon opening the PR; full support
+   stays on bd-0pic6.

--- a/crates/quarto-core/src/stage/stages/bootstrap_js.rs
+++ b/crates/quarto-core/src/stage/stages/bootstrap_js.rs
@@ -260,6 +260,34 @@ mod tests {
         }
     }
 
+    /// Metadata with the Q1 light/dark map form:
+    /// `theme: {light: <light>, dark: <dark>}` (bd-o76p01wb).
+    fn meta_with_light_dark_theme(light: &str, dark: &str) -> ConfigValue {
+        let scalar = |s: &str| ConfigValue {
+            value: ConfigValueKind::Scalar(Yaml::String(s.to_string())),
+            source_info: SourceInfo::for_test(),
+            merge_op: quarto_pandoc_types::MergeOp::Concat,
+        };
+        let entry = |key: &str, value: ConfigValue| ConfigMapEntry {
+            key: key.to_string(),
+            key_source: SourceInfo::for_test(),
+            value,
+        };
+        let theme_value = ConfigValue {
+            value: ConfigValueKind::Map(vec![
+                entry("light", scalar(light)),
+                entry("dark", scalar(dark)),
+            ]),
+            source_info: SourceInfo::for_test(),
+            merge_op: quarto_pandoc_types::MergeOp::Concat,
+        };
+        ConfigValue {
+            value: ConfigValueKind::Map(vec![entry("theme", theme_value)]),
+            source_info: SourceInfo::for_test(),
+            merge_op: quarto_pandoc_types::MergeOp::Concat,
+        }
+    }
+
     fn meta_with_minimal(value: bool) -> ConfigValue {
         let v = ConfigValue {
             value: ConfigValueKind::Scalar(Yaml::Boolean(value)),
@@ -483,6 +511,31 @@ mod tests {
             "theme: none must not register Bootstrap JS"
         );
         assert!(ctx.artifacts.get_by_prefix("js:").is_empty());
+    }
+
+    /// `theme: {light: cosmo, dark: darkly}` → Bootstrap (light half)
+    /// is in use, so JS must be registered. Guards against the
+    /// pre-bd-o76p01wb behavior where the map form failed theme
+    /// parsing and this stage silently treated the failure as
+    /// `suppress_bootstrap`, shipping themed CSS without its JS.
+    #[tokio::test]
+    async fn light_dark_theme_map_registers_bootstrap_js() {
+        let runtime = Arc::new(MockRuntime);
+        let mut ctx = make_stage_context(runtime, true);
+
+        let stage = BootstrapJsStage::new();
+        stage
+            .run(
+                make_doc_ast(meta_with_light_dark_theme("cosmo", "darkly")),
+                &mut ctx,
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            ctx.artifacts.contains("js:bootstrap"),
+            "light/dark map form must not suppress Bootstrap JS"
+        );
     }
 
     /// `theme: pandoc` → user wants raw Pandoc HTML; no Bootstrap JS.

--- a/crates/quarto-core/src/stage/stages/compile_theme_css.rs
+++ b/crates/quarto-core/src/stage/stages/compile_theme_css.rs
@@ -387,6 +387,34 @@ impl PipelineStage for CompileThemeCssStage {
             }
         };
 
+        // Interim light/dark degradation (bd-o76p01wb): the parser
+        // accepted a `theme: {light: …, dark: …}` map but only the
+        // light half is honored. Make the degradation loud — one
+        // Q-14-3 *warning* per document, anchored at the ignored
+        // `dark:` key. Emitted here (not in `BootstrapJsStage`, which
+        // parses the same config) so each document warns exactly once;
+        // the CLI's source-location coalescer collapses repeats across
+        // documents that share the offending config file.
+        if let Some(dark_loc) = &theme_config.dark_theme_ignored {
+            ctx.add_diagnostic(
+                quarto_error_reporting::DiagnosticMessageBuilder::warning(
+                    "Dark theme variant not yet supported",
+                )
+                .with_code("Q-14-3")
+                .problem(
+                    "`theme:` uses the `light:`/`dark:` map form; only the `light:` \
+                     themes are applied. The `dark:` entry is ignored and no \
+                     dark-mode toggle is emitted.",
+                )
+                .add_hint(
+                    "Remove the `dark:` entry to silence this warning, or keep it — \
+                     it will take effect when dual light/dark theme support lands.",
+                )
+                .with_location(dark_loc.clone())
+                .build(),
+            );
+        }
+
         // `theme: none` → ship the static lightweight DEFAULT_CSS without
         // compiling Bootstrap. This is the explicit opt-out path.
         if theme_config.suppress_bootstrap {
@@ -807,6 +835,38 @@ mod tests {
         }
     }
 
+    /// Metadata with the Q1 light/dark map form:
+    /// `theme: {light: [<light>], dark: [<dark>]}` (bd-o76p01wb).
+    fn meta_with_light_dark_theme(light: &str, dark: &str) -> ConfigValue {
+        let list = |name: &str| ConfigValue {
+            value: ConfigValueKind::Array(vec![ConfigValue {
+                value: ConfigValueKind::Scalar(Yaml::String(name.to_string())),
+                source_info: SourceInfo::for_test(),
+                merge_op: quarto_pandoc_types::MergeOp::Concat,
+            }]),
+            source_info: SourceInfo::for_test(),
+            merge_op: quarto_pandoc_types::MergeOp::Concat,
+        };
+        let entry = |key: &str, value: ConfigValue| ConfigMapEntry {
+            key: key.to_string(),
+            key_source: SourceInfo::for_test(),
+            value,
+        };
+        let theme_value = ConfigValue {
+            value: ConfigValueKind::Map(vec![
+                entry("light", list(light)),
+                entry("dark", list(dark)),
+            ]),
+            source_info: SourceInfo::for_test(),
+            merge_op: quarto_pandoc_types::MergeOp::Concat,
+        };
+        ConfigValue {
+            value: ConfigValueKind::Map(vec![entry("theme", theme_value)]),
+            source_info: SourceInfo::for_test(),
+            merge_op: quarto_pandoc_types::MergeOp::Concat,
+        }
+    }
+
     /// Locate the (single) `css:theme:*` artifact stored by
     /// [`CompileThemeCssStage`] and return its content as a string.
     /// Phase 5 retires the singleton `"css:default"` key in favor
@@ -1035,6 +1095,52 @@ mod tests {
         assert!(
             css.contains(".container"),
             "compiled CSS should contain .container"
+        );
+    }
+
+    #[tokio::test]
+    async fn light_dark_theme_map_compiles_light_and_warns_q_14_3() {
+        // bd-o76p01wb interim: the Q1 `theme: {light: […], dark: […]}`
+        // map form must not fail the render. The light half compiles;
+        // the ignored dark half surfaces as exactly one Q-14-3
+        // *warning* on the stage context.
+        let runtime: Arc<dyn quarto_system_runtime::SystemRuntime> =
+            Arc::new(quarto_system_runtime::NativeRuntime::new());
+        let mut ctx = make_stage_context(runtime);
+        let stage = CompileThemeCssStage::new();
+
+        let input = make_doc_ast(meta_with_light_dark_theme("cosmo", "darkly"));
+        let output = stage
+            .run(input, &mut ctx)
+            .await
+            .expect("light/dark map form must not fail the stage");
+        assert!(output.into_document_ast().is_some());
+
+        let css = get_css_artifact(&ctx);
+        assert_ne!(
+            css, DEFAULT_CSS,
+            "light half must be compiled, not fallback"
+        );
+        assert!(
+            css.contains(".btn"),
+            "light half must produce real Bootstrap CSS"
+        );
+
+        let q14_3: Vec<_> = ctx
+            .diagnostics
+            .iter()
+            .filter(|d| d.code.as_deref() == Some("Q-14-3"))
+            .collect();
+        assert_eq!(
+            q14_3.len(),
+            1,
+            "expected exactly one Q-14-3 warning, diagnostics: {:?}",
+            ctx.diagnostics
+        );
+        assert_eq!(
+            q14_3[0].kind,
+            quarto_error_reporting::DiagnosticKind::Warning,
+            "Q-14-3 must be warning severity, not error"
         );
     }
 
@@ -1488,6 +1594,7 @@ mod tests {
             suppress_bootstrap: false,
             title_block_layer: true,
             brand_ref: None,
+            dark_theme_ignored: None,
         }
     }
 
@@ -1498,6 +1605,7 @@ mod tests {
             suppress_bootstrap: false,
             title_block_layer: true,
             brand_ref: None,
+            dark_theme_ignored: None,
         }
     }
 

--- a/crates/quarto-core/src/theme_diagnostic.rs
+++ b/crates/quarto-core/src/theme_diagnostic.rs
@@ -274,7 +274,10 @@ mod tests {
         // catalog, under the 'theme' subsystem.
         // Query the catalog data directly (the codes live in
         // `quarto-error-catalog` now, not in `quarto-error-reporting`).
-        for code in ["Q-14-1", "Q-14-2"] {
+        // Q-14-3 (dark-theme-variant-ignored warning, bd-o76p01wb) is
+        // emitted by CompileThemeCssStage rather than this converter,
+        // but it lives in the same subsystem and must be registered.
+        for code in ["Q-14-1", "Q-14-2", "Q-14-3"] {
             let info = quarto_error_catalog::ERROR_CATALOG.get(code);
             assert!(
                 info.is_some(),

--- a/crates/quarto-core/tests/integration/main.rs
+++ b/crates/quarto-core/tests/integration/main.rs
@@ -55,6 +55,7 @@ pub mod replay_engine;
 pub mod revealjs_features;
 pub mod revealjs_format;
 pub mod sidebar_pipeline;
+pub mod theme_light_dark;
 pub mod title_block_pipeline;
 pub mod video_shortcode_preview;
 pub mod website_post_render;

--- a/crates/quarto-core/tests/integration/theme_light_dark.rs
+++ b/crates/quarto-core/tests/integration/theme_light_dark.rs
@@ -1,0 +1,186 @@
+//! End-to-end render tests for the Q1 light/dark theme map form
+//! (bd-o76p01wb interim behavior).
+//!
+//! `theme: {light: […], dark: […]}` must render using only the
+//! `light:` half and emit a single Q-14-3 warning that the `dark:`
+//! half is ignored. Full dual-theme support (compile both variants +
+//! toggle) is tracked separately (bd-0pic6).
+//!
+//! Drives the real `render_to_file` API (see CLAUDE.md "End-to-end
+//! verification") against tempdir-based projects, then inspects both
+//! the produced CSS and the render diagnostics.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::Path;
+use std::sync::Arc;
+
+use tempfile::TempDir;
+
+use quarto_core::render_to_file::{RenderToFileOptions, render_to_file};
+use quarto_error_reporting::DiagnosticKind;
+use quarto_system_runtime::{NativeRuntime, SystemRuntime};
+
+fn write(path: &Path, contents: &str) {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(path, contents).unwrap();
+}
+
+fn read_css(resources_dir: &Path) -> String {
+    let mut combined = String::new();
+    for entry in walkdir::WalkDir::new(resources_dir)
+        .follow_links(false)
+        .into_iter()
+        .filter_map(Result::ok)
+    {
+        let p = entry.path();
+        if p.extension().and_then(|e| e.to_str()) == Some("css") {
+            combined.push_str(&std::fs::read_to_string(p).unwrap());
+            combined.push('\n');
+        }
+    }
+    combined
+}
+
+const LIGHT_SCSS: &str = "/*-- scss:rules --*/\n.q-light-marker { color: #123456; }\n";
+const DARK_SCSS: &str = "/*-- scss:rules --*/\n.q-dark-marker { color: #654321; }\n";
+
+/// Project-config path: the map form in `_quarto.yml`
+/// (`format.html.theme`), the way the posit-docs extension ships it.
+#[test]
+fn project_theme_light_dark_map_renders_light_half_with_q_14_3_warning() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    write(
+        &root.join("_quarto.yml"),
+        "project:\n  type: default\nformat:\n  html:\n    theme:\n      light: [cosmo, light-marker.scss]\n      dark: [darkly, dark-marker.scss]\n",
+    );
+    write(&root.join("light-marker.scss"), LIGHT_SCSS);
+    write(&root.join("dark-marker.scss"), DARK_SCSS);
+    write(
+        &root.join("index.qmd"),
+        "---\ntitle: Light/Dark Map\n---\n\n# Hello\n",
+    );
+
+    let runtime: Arc<dyn SystemRuntime> = Arc::new(NativeRuntime::new());
+    let result = render_to_file(
+        &root.join("index.qmd"),
+        "html",
+        &RenderToFileOptions {
+            quiet: true,
+            ..Default::default()
+        },
+        runtime,
+    )
+    .expect("light/dark theme map must render, not fail with Q-14-1");
+
+    // Only the light half is compiled into the page CSS.
+    let css = read_css(&result.resources_dir);
+    assert!(
+        css.contains(".q-light-marker"),
+        "light half's custom SCSS must be in the compiled CSS"
+    );
+    assert!(
+        !css.contains(".q-dark-marker"),
+        "dark half must be ignored in the interim behavior"
+    );
+
+    // The degradation is loud: exactly one Q-14-3 warning.
+    let diagnostics = &result.render_output.diagnostics;
+    let q14_3: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.code.as_deref() == Some("Q-14-3"))
+        .collect();
+    assert_eq!(
+        q14_3.len(),
+        1,
+        "expected exactly one Q-14-3 warning, diagnostics: {:?}",
+        diagnostics
+    );
+    assert_eq!(q14_3[0].kind, DiagnosticKind::Warning);
+    assert!(
+        q14_3[0].location.is_some(),
+        "Q-14-3 should carry a source location pointing at the dark entry"
+    );
+}
+
+/// Document-frontmatter path: the map form in the document's own
+/// `format.html.theme` (single-file render, no `_quarto.yml`).
+#[test]
+fn frontmatter_theme_light_dark_map_renders_light_half_with_q_14_3_warning() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    write(&root.join("light-marker.scss"), LIGHT_SCSS);
+    write(&root.join("dark-marker.scss"), DARK_SCSS);
+    write(
+        &root.join("doc.qmd"),
+        "---\ntitle: Frontmatter Map\nformat:\n  html:\n    theme:\n      light: [cosmo, light-marker.scss]\n      dark: [dark-marker.scss]\n---\n\n# Hi\n",
+    );
+
+    let runtime: Arc<dyn SystemRuntime> = Arc::new(NativeRuntime::new());
+    let result = render_to_file(
+        &root.join("doc.qmd"),
+        "html",
+        &RenderToFileOptions {
+            quiet: true,
+            ..Default::default()
+        },
+        runtime,
+    )
+    .expect("frontmatter light/dark theme map must render");
+
+    let css = read_css(&result.resources_dir);
+    assert!(css.contains(".q-light-marker"));
+    assert!(!css.contains(".q-dark-marker"));
+
+    let q14_3: Vec<_> = result
+        .render_output
+        .diagnostics
+        .iter()
+        .filter(|d| d.code.as_deref() == Some("Q-14-3"))
+        .collect();
+    assert_eq!(q14_3.len(), 1, "expected exactly one Q-14-3 warning");
+}
+
+/// A light-only map is a fully-honored (if redundant) spelling — no
+/// warning (D6 in the plan).
+#[test]
+fn light_only_theme_map_renders_without_warning() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    write(
+        &root.join("_quarto.yml"),
+        "project:\n  type: default\nformat:\n  html:\n    theme:\n      light: [cosmo, light-marker.scss]\n",
+    );
+    write(&root.join("light-marker.scss"), LIGHT_SCSS);
+    write(
+        &root.join("index.qmd"),
+        "---\ntitle: Light Only\n---\n\n# Hello\n",
+    );
+
+    let runtime: Arc<dyn SystemRuntime> = Arc::new(NativeRuntime::new());
+    let result = render_to_file(
+        &root.join("index.qmd"),
+        "html",
+        &RenderToFileOptions {
+            quiet: true,
+            ..Default::default()
+        },
+        runtime,
+    )
+    .expect("light-only theme map must render");
+
+    let css = read_css(&result.resources_dir);
+    assert!(css.contains(".q-light-marker"));
+
+    assert!(
+        !result
+            .render_output
+            .diagnostics
+            .iter()
+            .any(|d| d.code.as_deref() == Some("Q-14-3")),
+        "light-only map ignores nothing, so it must not warn"
+    );
+}

--- a/crates/quarto-error-catalog/error_catalog.json
+++ b/crates/quarto-error-catalog/error_catalog.json
@@ -1084,6 +1084,13 @@
     "docs_url": "https://quarto.org/docs/errors/theme/Q-14-2",
     "since_version": "99.9.9"
   },
+  "Q-14-3": {
+    "subsystem": "theme",
+    "title": "Dark theme variant not yet supported",
+    "message_template": "The `theme:` configuration uses the `light:`/`dark:` map form. This release renders only the `light:` themes; the `dark:` entry is ignored and no dark-mode toggle is emitted. The document still renders, styled by the light themes. Remove the `dark:` entry to silence this warning, or keep it — it will take effect when dual light/dark theme support lands.",
+    "docs_url": "https://quarto.org/docs/errors/theme/Q-14-3",
+    "since_version": "99.9.9"
+  },
   "Q-15-1": {
     "subsystem": "crossref",
     "title": "Duplicate Crossref Identifier",

--- a/crates/quarto-sass/src/config.rs
+++ b/crates/quarto-sass/src/config.rs
@@ -30,6 +30,7 @@ use std::path::{Path, PathBuf};
 
 use quarto_brand::{Brand, BrandRef, ResolvedBrand};
 use quarto_pandoc_types::ConfigValue;
+use quarto_source_map::SourceInfo;
 use quarto_system_runtime::SystemRuntime;
 
 use crate::error::SassError;
@@ -88,6 +89,20 @@ pub struct ThemeConfig {
     /// Resolved into a typed [`quarto_brand::Brand`] via
     /// [`ThemeConfig::resolve`].
     pub brand_ref: Option<BrandRef>,
+
+    /// Set when the configuration used the `theme: {light: …, dark: …}`
+    /// map form **and** a `dark:` entry was present: the interim
+    /// behavior (bd-o76p01wb) honors only the `light:` half, and this
+    /// field carries the source location of the ignored `dark:` key so
+    /// the caller can emit a user-visible warning (Q-14-3) pointing at
+    /// it. `None` when the theme was not a map or the map had no
+    /// `dark:` entry (a light-only map is fully honored — nothing is
+    /// ignored, so nothing to warn about).
+    ///
+    /// quarto-sass itself stays diagnostics-free: this is data, not a
+    /// side channel. `CompileThemeCssStage` turns it into the actual
+    /// diagnostic.
+    pub dark_theme_ignored: Option<SourceInfo>,
 }
 
 /// Resolved form of [`ThemeConfig`] with the brand file loaded and
@@ -116,6 +131,7 @@ impl ThemeConfig {
             suppress_bootstrap: false,
             title_block_layer: true,
             brand_ref: None,
+            dark_theme_ignored: None,
         }
     }
 
@@ -130,6 +146,7 @@ impl ThemeConfig {
             suppress_bootstrap: false,
             title_block_layer: true,
             brand_ref: None,
+            dark_theme_ignored: None,
         }
     }
 
@@ -139,6 +156,12 @@ impl ThemeConfig {
     /// Supports:
     /// - String: single theme name or path (e.g., `"cosmo"`, `"custom.scss"`)
     /// - Array: multiple themes to layer (e.g., `["cosmo", "custom.scss"]`)
+    /// - Map with only `light:`/`dark:` keys (Q1's dual-theme form):
+    ///   the `light:` half is parsed like a top-level theme value; the
+    ///   `dark:` half is **ignored** for now, its location recorded on
+    ///   [`ThemeConfig::dark_theme_ignored`] so the caller can warn
+    ///   (Q-14-3). Interim behavior per bd-o76p01wb; full dual-theme
+    ///   support is bd-0pic6.
     /// - Null/absent: use default Bootstrap theme
     ///
     /// # Arguments
@@ -152,7 +175,8 @@ impl ThemeConfig {
     /// # Errors
     ///
     /// Returns `SassError::InvalidThemeConfig` if the theme configuration
-    /// has an unexpected structure (e.g., a map instead of string/array).
+    /// has an unexpected structure (e.g., a map with keys other than
+    /// `light`/`dark`).
     ///
     /// # Example
     ///
@@ -170,31 +194,24 @@ impl ThemeConfig {
 
         let mut result = match theme_value {
             None => Self::default_bootstrap(),
-            Some(value) => {
-                if value.is_null() {
-                    Self::default_bootstrap()
-                } else if let Some(s) = config_value_as_text(value)
-                    && s.eq_ignore_ascii_case("none")
-                {
-                    // `theme: none` sentinel: suppress Bootstrap entirely.
-                    Self {
-                        themes: Vec::new(),
-                        minified: true,
-                        suppress_bootstrap: true,
-                        title_block_layer: true,
-                        brand_ref: None,
-                    }
-                } else {
-                    let themes = extract_theme_specs(value)?;
-                    Self {
-                        themes,
-                        minified: true,
-                        suppress_bootstrap: false,
-                        title_block_layer: true,
-                        brand_ref: None,
-                    }
+            Some(value) => match light_dark_pair(value) {
+                Some(pair) => {
+                    // The pair form is top-level only: the light half
+                    // goes through the same value parsing as a plain
+                    // `theme:` (string / array / null / `none`
+                    // sentinel), where a nested map is invalid.
+                    let mut cfg = match pair.light {
+                        Some(light_value) => Self::from_theme_value(light_value)?,
+                        // Only `dark:` configured → default Bootstrap
+                        // for the rendered (light) page; the warning
+                        // still fires so the degradation is visible.
+                        None => Self::default_bootstrap(),
+                    };
+                    cfg.dark_theme_ignored = pair.dark_ignored;
+                    cfg
                 }
-            }
+                None => Self::from_theme_value(value)?,
+            },
         };
 
         // `title-block-style: plain | none | false` drops the
@@ -235,6 +252,39 @@ impl ThemeConfig {
         }
 
         Ok(result)
+    }
+
+    /// Parse a single theme *value* — the top-level `theme:` value, or
+    /// the `light:` half of a `light:`/`dark:` pair. Handles null, the
+    /// `none` sentinel, a string, and an array of strings; anything
+    /// else (including a map — the pair form is recognized one level
+    /// up, top-level only) is `SassError::InvalidThemeConfig`.
+    fn from_theme_value(value: &ConfigValue) -> Result<Self, SassError> {
+        if value.is_null() {
+            return Ok(Self::default_bootstrap());
+        }
+        if let Some(s) = config_value_as_text(value)
+            && s.eq_ignore_ascii_case("none")
+        {
+            // `theme: none` sentinel: suppress Bootstrap entirely.
+            return Ok(Self {
+                themes: Vec::new(),
+                minified: true,
+                suppress_bootstrap: true,
+                title_block_layer: true,
+                brand_ref: None,
+                dark_theme_ignored: None,
+            });
+        }
+        let themes = extract_theme_specs(value)?;
+        Ok(Self {
+            themes,
+            minified: true,
+            suppress_bootstrap: false,
+            title_block_layer: true,
+            brand_ref: None,
+            dark_theme_ignored: None,
+        })
     }
 
     /// Resolve any [`BrandRef`] in this config by reading the brand
@@ -340,6 +390,7 @@ pub fn resolve_brand(
         suppress_bootstrap: false,
         title_block_layer: true,
         brand_ref: Some(brand_ref),
+        dark_theme_ignored: None,
     }
     .resolve(runtime, base_dir)?;
 
@@ -541,6 +592,38 @@ fn brand_err(e: quarto_brand::BrandError) -> SassError {
     }
 }
 
+/// The recognized halves of a `theme: {light: …, dark: …}` map.
+///
+/// Produced by [`light_dark_pair`]; consumed by
+/// [`ThemeConfig::from_config_value`]'s pair branch.
+struct LightDarkPair<'a> {
+    /// The `light:` entry's value, if present.
+    light: Option<&'a ConfigValue>,
+    /// Location of the `dark:` key, if present — recorded on
+    /// [`ThemeConfig::dark_theme_ignored`] so the caller's Q-14-3
+    /// warning points at the ignored entry.
+    dark_ignored: Option<SourceInfo>,
+}
+
+/// Detect Q1's dual-theme pair form: a **non-empty** map whose keys
+/// are only `light`/`dark` (at least one present). Mirrors the shape
+/// check `extract_brand_ref` applies to `brand:` maps. Returns `None`
+/// for every other value — including an empty map or a map with extra
+/// keys, which stay invalid-config errors downstream.
+fn light_dark_pair(value: &ConfigValue) -> Option<LightDarkPair<'_>> {
+    let entries = value.as_map_entries()?;
+    if entries.is_empty() || entries.iter().any(|e| e.key != "light" && e.key != "dark") {
+        return None;
+    }
+    Some(LightDarkPair {
+        light: entries.iter().find(|e| e.key == "light").map(|e| &e.value),
+        dark_ignored: entries
+            .iter()
+            .find(|e| e.key == "dark")
+            .map(|e| e.key_source.clone()),
+    })
+}
+
 /// Extract theme specifications from a ConfigValue.
 ///
 /// Handles both string and array formats. Theme values from document
@@ -572,9 +655,14 @@ fn extract_theme_specs(value: &ConfigValue) -> Result<Vec<ThemeSpec>, SassError>
         return Ok(specs);
     }
 
-    // Neither string nor array - invalid
+    // Neither string nor array - invalid. (The `light:`/`dark:` map
+    // form is recognized before this function is reached; a map
+    // arriving here has extra keys, is empty, or is nested inside a
+    // pair's half.)
     Err(SassError::InvalidThemeConfig {
-        message: "theme must be a string or array of strings".to_string(),
+        message: "theme must be a string or array of strings, \
+                  or a map with only `light:`/`dark:` keys"
+            .to_string(),
         location: Some(value.source_info.clone()),
     })
 }
@@ -1216,5 +1304,223 @@ mod tests {
             }
             other => panic!("expected UnknownTheme error, got: {:?}", other),
         }
+    }
+
+    // === Light/dark theme map tests (bd-o76p01wb interim) ===
+    //
+    // Q1's `theme: {light: […], dark: […]}` map form. Interim
+    // behavior: the `light:` half is honored (string or array), the
+    // `dark:` half is ignored with its location recorded on
+    // `ThemeConfig::dark_theme_ignored` so the pipeline can warn
+    // (Q-14-3). Maps with keys other than `light`/`dark` stay
+    // Q-14-1 errors.
+
+    /// Compact scalar ConfigValue builder for map-form tests.
+    fn scalar_value(s: &str) -> ConfigValue {
+        ConfigValue {
+            value: ConfigValueKind::Scalar(Yaml::String(s.to_string())),
+            source_info: SourceInfo::for_test(),
+            merge_op: quarto_pandoc_types::MergeOp::Concat,
+        }
+    }
+
+    /// Compact string-array ConfigValue builder for map-form tests.
+    fn array_value(items: &[&str]) -> ConfigValue {
+        ConfigValue {
+            value: ConfigValueKind::Array(items.iter().map(|s| scalar_value(s)).collect()),
+            source_info: SourceInfo::for_test(),
+            merge_op: quarto_pandoc_types::MergeOp::Concat,
+        }
+    }
+
+    /// Map entry with a default (for_test) key source.
+    fn map_entry(key: &str, value: ConfigValue) -> ConfigMapEntry {
+        ConfigMapEntry {
+            key: key.to_string(),
+            key_source: SourceInfo::for_test(),
+            value,
+        }
+    }
+
+    /// A map-kind ConfigValue from entries.
+    fn map_value(entries: Vec<ConfigMapEntry>) -> ConfigValue {
+        ConfigValue {
+            value: ConfigValueKind::Map(entries),
+            source_info: SourceInfo::for_test(),
+            merge_op: quarto_pandoc_types::MergeOp::Concat,
+        }
+    }
+
+    /// Root config `{ theme: <value> }` (post-MetadataMergeStage shape).
+    fn config_with_theme_value(theme_value: ConfigValue) -> ConfigValue {
+        map_value(vec![map_entry("theme", theme_value)])
+    }
+
+    #[test]
+    fn test_theme_map_light_dark_uses_light_half() {
+        // The canonical posit-docs shape: both halves are lists. Only
+        // the light list becomes theme specs; the dark entry's key
+        // location is recorded for the warning.
+        let dark_key_source = SourceInfo::original(quarto_source_map::FileId(9), 40, 44);
+        let theme_value = map_value(vec![
+            map_entry("light", array_value(&["custom.scss", "cosmo"])),
+            ConfigMapEntry {
+                key: "dark".to_string(),
+                key_source: dark_key_source.clone(),
+                value: array_value(&["dark.scss"]),
+            },
+        ]);
+
+        let theme_config =
+            ThemeConfig::from_config_value(&config_with_theme_value(theme_value)).unwrap();
+
+        assert_eq!(theme_config.themes.len(), 2);
+        assert!(theme_config.themes[0].is_custom());
+        assert_eq!(
+            theme_config.themes[0].as_custom().and_then(|p| p.to_str()),
+            Some("custom.scss")
+        );
+        assert!(theme_config.themes[1].is_builtin());
+        assert!(!theme_config.suppress_bootstrap);
+        assert_eq!(
+            theme_config.dark_theme_ignored.as_ref(),
+            Some(&dark_key_source),
+            "dark_theme_ignored should carry the dark entry's key source",
+        );
+    }
+
+    #[test]
+    fn test_theme_map_light_scalar_only_no_warning() {
+        // D6: a light-only map is fully honored — nothing is ignored,
+        // so nothing to warn about. Scalar form.
+        let theme_value = map_value(vec![map_entry("light", scalar_value("cosmo"))]);
+        let theme_config =
+            ThemeConfig::from_config_value(&config_with_theme_value(theme_value)).unwrap();
+
+        assert_eq!(theme_config.themes.len(), 1);
+        assert!(theme_config.themes[0].is_builtin());
+        assert!(theme_config.dark_theme_ignored.is_none());
+    }
+
+    #[test]
+    fn test_theme_map_light_list_only_no_warning() {
+        // D6, list form.
+        let theme_value = map_value(vec![map_entry(
+            "light",
+            array_value(&["custom.scss", "cosmo"]),
+        )]);
+        let theme_config =
+            ThemeConfig::from_config_value(&config_with_theme_value(theme_value)).unwrap();
+
+        assert_eq!(theme_config.themes.len(), 2);
+        assert!(theme_config.themes[0].is_custom());
+        assert!(theme_config.themes[1].is_builtin());
+        assert!(theme_config.dark_theme_ignored.is_none());
+    }
+
+    #[test]
+    fn test_theme_map_dark_only_defaults_with_warning() {
+        // Only `dark:` configured → default Bootstrap for the (light)
+        // rendered page, plus the warning. Bootstrap is NOT
+        // suppressed — the page still gets default styling.
+        let theme_value = map_value(vec![map_entry("dark", scalar_value("darkly"))]);
+        let theme_config =
+            ThemeConfig::from_config_value(&config_with_theme_value(theme_value)).unwrap();
+
+        assert!(theme_config.themes.is_empty());
+        assert!(!theme_config.suppress_bootstrap);
+        assert!(theme_config.dark_theme_ignored.is_some());
+    }
+
+    #[test]
+    fn test_theme_map_extra_keys_still_errors() {
+        // A map with keys beyond light/dark is not the pair form —
+        // it stays a Q-14-1 invalid-config error.
+        let theme_value = map_value(vec![
+            map_entry("light", scalar_value("cosmo")),
+            map_entry("dark", scalar_value("darkly")),
+            map_entry("contrast", scalar_value("high")),
+        ]);
+        match ThemeConfig::from_config_value(&config_with_theme_value(theme_value)) {
+            Err(SassError::InvalidThemeConfig { message, .. }) => {
+                assert!(message.contains("string or array"), "message: {message}");
+            }
+            other => panic!("expected InvalidThemeConfig error, got: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_theme_map_nested_map_in_light_errors() {
+        // The pair form is top-level only; a nested map inside
+        // `light:` is invalid.
+        let inner = map_value(vec![map_entry("light", scalar_value("cosmo"))]);
+        let theme_value = map_value(vec![map_entry("light", inner)]);
+        match ThemeConfig::from_config_value(&config_with_theme_value(theme_value)) {
+            Err(SassError::InvalidThemeConfig { .. }) => {}
+            other => panic!("expected InvalidThemeConfig error, got: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_theme_map_light_none_suppresses_bootstrap() {
+        // The `none` sentinel is honored inside the light half, same
+        // as `theme: none` at top level.
+        let theme_value = map_value(vec![map_entry("light", scalar_value("none"))]);
+        let theme_config =
+            ThemeConfig::from_config_value(&config_with_theme_value(theme_value)).unwrap();
+
+        assert!(theme_config.suppress_bootstrap);
+        assert!(theme_config.themes.is_empty());
+    }
+
+    #[test]
+    fn test_theme_map_unknown_light_theme_errors() {
+        // The light half goes through the same spec parsing as a
+        // top-level theme value — unknown names still error.
+        let theme_value = map_value(vec![map_entry("light", scalar_value("nosuchtheme"))]);
+        match ThemeConfig::from_config_value(&config_with_theme_value(theme_value)) {
+            Err(SassError::UnknownTheme { name, .. }) => assert_eq!(name, "nosuchtheme"),
+            other => panic!("expected UnknownTheme error, got: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_theme_map_with_brand_auto_injects_into_light() {
+        // brand auto-inject composes with the map form: the Brand
+        // token is appended to the honored (light) spec list.
+        let theme_value = map_value(vec![
+            map_entry("light", array_value(&["cosmo"])),
+            map_entry("dark", array_value(&["darkly"])),
+        ]);
+        let config = map_value(vec![
+            map_entry("theme", theme_value),
+            map_entry("brand", scalar_value("_brand.yml")),
+        ]);
+
+        let theme_config = ThemeConfig::from_config_value(&config).unwrap();
+        assert_eq!(theme_config.themes.len(), 2);
+        assert!(theme_config.themes[0].is_builtin());
+        assert!(theme_config.themes[1].is_brand());
+        assert!(theme_config.brand_ref.is_some());
+        assert!(theme_config.dark_theme_ignored.is_some());
+    }
+
+    #[test]
+    fn test_theme_map_light_pandoc_inlines_scalar() {
+        // Frontmatter path: pampa parses `light: cosmo` as
+        // PandocInlines, not a YAML scalar. The light half must go
+        // through the same text extraction as top-level themes.
+        use quarto_pandoc_types::inline::{Inline, Str};
+        let str_node = Inline::Str(Str {
+            text: "cosmo".to_string(),
+            source_info: SourceInfo::for_test(),
+        });
+        let light_value = ConfigValue::new_inlines(vec![str_node], SourceInfo::for_test());
+        let theme_value = map_value(vec![map_entry("light", light_value)]);
+
+        let theme_config =
+            ThemeConfig::from_config_value(&config_with_theme_value(theme_value)).unwrap();
+        assert_eq!(theme_config.themes.len(), 1);
+        assert!(theme_config.themes[0].is_builtin());
     }
 }


### PR DESCRIPTION
## Summary

Interim support for Q1's dual-theme map form, `format.html.theme: {light: [...], dark: [...]}` (bd-o76p01wb, discovered from #474's Connect-docs testbed work): the map now **parses**, only the **`light:` half is applied**, and a new **Q-14-3 warning** marks the ignored `dark:` entry — anchored at the `dark:` key with an ariadne span, coalesced across documents sharing the offending config. Previously every document using this form hard-failed with Q-14-1; on the Connect docs testbed that was all 351 files. Full dual-theme support (compile both CSS variants + toggle wiring) remains tracked separately (bd-0pic6).

Plan with design decisions and phase-by-phase evidence: `claude-notes/plans/2026-08-08-theme-light-dark-interim.md`.

## Design

- **quarto-sass** parses the pair: `ThemeConfig::from_config_value` recognizes a non-empty map whose keys are only `light`/`dark` (mirroring `extract_brand_ref`'s brand-pair precedent in the same file). The light half runs through a shared `from_theme_value` helper (null / `none` sentinel / string / array), so `{light: none}` suppresses Bootstrap, unknown names still raise Q-14-2, and nested maps stay Q-14-1. A `dark`-only map renders default Bootstrap. Maps with extra keys keep the Q-14-1 error (message now names the accepted shapes).
- **Warning carried as data, emitted by the stage**: quarto-sass stays diagnostics-free — the ignored `dark:` key's `SourceInfo` rides on the new `ThemeConfig::dark_theme_ignored` field, and `CompileThemeCssStage` converts it into the Q-14-3 warning via `ctx.add_diagnostic` (once per document; not emitted by `BootstrapJsStage`, which parses the same config). A light-only map is a fully-honored spelling and does not warn.
- **Latent bug fixed for free**: `BootstrapJsStage` treated the map form's parse failure as `suppress_bootstrap`, silently shipping themed CSS without Bootstrap JS.
- `highlight-style: {light, dark}` needs no interim work — Q2 currently has no `highlight-style` reader (tree-sitter highlighting), so the map passes through inert. Wiring it up belongs to the full-support strand.

## Test plan

- TDD: 11 quarto-sass unit tests, 2 stage tests (`compile_theme_css`, `bootstrap_js`), Q-14-3 catalog registration, and 3 integration tests driving the real `render_to_file` path — all written first and observed failing.
- Full workspace suite: 11,135 passed. Full `cargo xtask verify` (including hub-client/WASM leg): green, re-run after rebasing onto post-#474 `main`.

## Real-world verification

- Minimal fixture through `q2 render`: exit 0; `Warning: [Q-14-3]` with a span pointing at the `dark:` key in `_quarto.yml`; compiled CSS contains the light marker rule and no dark rule. Output inspected directly.
- Connect docs testbed with the posit-docs extension's theme map **unflattened**: **351/351 files render, exit 0**, Q-14-3 printed exactly once ("Affected files: … (and 348 others)"), light theme (Open Sans / posit orange) in the site CSS, dark-only background absent. (quarto-openapi's contributed pre-render was temporarily neutralized — its Deno-style `.ts` failing under Node is the separate bd-wch2dotq gap.)

Noted for follow-up (in the plan, not blocking): the Q-14-3 warning renders span-less when the offending map lives in an extension's `_extension.yml` (print-time source repair only covers `_quarto.yml`), and quarto-openapi's manifest uses `contributes: format:` (singular), which Q2's manifest validator rejects — possibly relevant to bd-of20unsb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)