### PR TITLE
Rebase format-extension bundled assets; hard-error on missing theme files (bd-of20unsb)

### DIFF
--- a/claude-notes/plans/2026-08-08-format-ext-theme-rebase.md
+++ b/claude-notes/plans/2026-08-08-format-ext-theme-rebase.md
@@ -213,8 +213,10 @@ precedent). Per design decision 2, these **fail the render** (hard error).
       present-file control passes). Note: `as_str()` handles Path-kind
       (config_value.rs:641), so the css template path is safe by
       construction — risk retired.
-- [ ] Phase 1: shared helper extracted; `rebase_fragment_paths` refactored;
-      existence-driven marking wired into `parse_formats`
+- [x] Phase 1: shared helper extracted (`extension/paths.rs`);
+      `rebase_fragment_paths` refactored onto it; existence-driven marking
+      wired into `parse_formats`. Commit `84f88c9f`; full workspace suite
+      green; smoke fixture passes.
 - [ ] Phase 2: Q-14-x registered in `quarto-error-catalog`; hard error wired;
       fallback retained for internal compile failures only
 - [ ] Phase 3: e2e verified via real binary; full `cargo xtask verify` green

--- a/claude-notes/plans/2026-08-08-format-ext-theme-rebase.md
+++ b/claude-notes/plans/2026-08-08-format-ext-theme-rebase.md
@@ -1,0 +1,221 @@
+# Format-extension theme/css paths not rebased: contributes.formats.html.theme silently drops bundled SCSS (bd-of20unsb)
+
+**Date:** 2026-08-08
+**Braid:** bd-of20unsb (P2, bug)
+**Checkout:** main worktree at `main` @ `e5fc4ffb` (post-merge of PR #474)
+**Status:** Investigation — pending design alignment with user. **Do not start implementation until the user gives the go-ahead.**
+
+## Triage verdict
+
+**Ready to design.** The bug reproduces at HEAD exactly as filed, the root cause is
+pinned to two specific code sites, and the machinery the candidate fix wants to
+reuse (bd-ad7i1pc6 Phase 4's existence-driven rebase) merged with PR #474 today.
+The remaining decisions are scoping/severity questions, listed at the bottom.
+
+## Issue context
+
+Filed today (2026-08-08) by Carlos, discovered during bd-ad7i1pc6 Phase 4
+verification (custom project types, PR #474 — now merged). A format extension
+declaring
+
+```yaml
+contributes:
+  formats:
+    html:
+      theme: [cosmo, fmt-theme.scss]
+```
+
+with `fmt-theme.scss` bundled next to `_extension.yml` silently loses the theme:
+the bundled SCSS never reaches the compiled CSS and no diagnostic is emitted.
+Pre-existing gap, independent of PR #474's changes (that PR fixed the analogous
+problem for `contributes.project` fragments only).
+
+## Dependency graph
+
+- **discovered-from: bd-ad7i1pc6** (in_progress, P1) — the custom-project-types
+  epic. Its Phase 4 built exactly the machinery this strand wants to reuse:
+  `rebase_fragment_paths` / `rebase_candidate` / `FRAGMENT_PATH_PATTERNS` in
+  `crates/quarto-core/src/project/mod.rs:681-814`, an existence-driven,
+  key-path-pattern-guarded rebase of extension-bundled paths. PR #474 merged
+  2026-08-08 20:42Z, so main now has it.
+- **Sibling strand worth knowing about:** bd-o76p01wb (P1, from the same
+  session) — the `theme: {light: […], dark: […]}` map form is a separate Q2 gap.
+  Whatever we do here for nested theme values only matters once that lands, but
+  handling map leaves costs nothing (the Phase 4 walker already does it).
+- No incoming `blocks` edges — nothing is waiting on this.
+
+## What the code looks like today
+
+### Reproduction (confirmed at `e5fc4ffb`)
+
+Fixture: `claude-notes/plans/format-ext-theme-rebase-investigation/repro/`
+(single `doc.qmd` with `format: fancyfmt-html`; `_extensions/fancyfmt/`
+contributes `theme: [cosmo, fmt-theme.scss]` with the SCSS bundled next to
+`_extension.yml`, carrying a `.fmt-theme-marker` rule).
+
+```
+$ cargo run --bin q2 -- render doc.qmd
+Rendering single file: .../repro/doc.qmd          # no warning, no error
+$ grep -c fmt-theme-marker doc_files/styles.css
+0
+$ wc -c doc_files/styles.css
+6996                                              # DEFAULT_CSS fallback
+```
+
+Two findings beyond the strand description:
+
+1. **The failure is worse than "drops the bundled SCSS": the *entire* theme
+   list is dropped.** `styles.css` is the 7 KB static `DEFAULT_CSS` — even the
+   valid `cosmo` entry is gone (a compiled cosmo is ~321 KB). One bad entry
+   nukes the whole theme.
+2. **The warning is invisible even with `-v`.** The fallback site logs via
+   `trace_event!(EventLevel::Warn, …)`, which routes to `tracing::warn!`;
+   nothing surfaced in the `-v` render output.
+
+Control: copying `fmt-theme.scss` next to `doc.qmd` produces a 321 KB
+`styles.css` containing `.fmt-theme-marker` — confirming the theme stage
+resolves custom theme paths relative to the *document* directory, and the
+missing piece is exactly the ext-dir → doc-dir rebase.
+
+### Root cause chain
+
+1. **Read side** — `crates/quarto-core/src/extension/read.rs:218`:
+   `PATH_VALUED_KEYS = ["template", "template-partials", "shortcodes"]` (plus
+   special-cased `filters`). `mark_path_valued_keys` flips only those keys'
+   string values to `ConfigValueKind::Path`. `theme`, `css`, `include-*` etc.
+   stay `Scalar`.
+2. **Merge side** — `crates/quarto-core/src/stage/stages/metadata_merge.rs:268-273`:
+   the extension format layer is rebased via
+   `adjust_paths_to_document_dir(&mut config, &ext_dir, &document_dir)`, which
+   (`project/mod.rs:227-270`) only touches `Path`-kind values. Scalar
+   `fmt-theme.scss` passes through unrebased.
+3. **Consume side** — `quarto-sass` parses `fmt-theme.scss` as
+   `ThemeSpec::Custom` (extension-based sniffing, `themes.rs:259-279`),
+   resolves it against the document dir, and `load_custom_theme`
+   (`themes.rs:573-615`) returns `SassError::CustomThemeNotFound`.
+4. **Silent drop** — `crates/quarto-core/src/stage/stages/compile_theme_css.rs:560-568`:
+   any compile error → `trace_event!(Warn, …)` + `store_default_css(ctx)`.
+   Not a user-facing diagnostic; the whole theme (including valid entries)
+   falls back to `DEFAULT_CSS`.
+
+### The machinery to reuse (bd-ad7i1pc6 Phase 4)
+
+`project/mod.rs:681-814`: `FRAGMENT_PATH_PATTERNS` (a key-path pattern table —
+`["format", "*", "theme"]`, `…"css"`, `…"include-in-header"`, etc.; arrays
+transparent; pattern exhaustion rebases every string leaf underneath, which is
+what makes `theme: {light: […], dark: […]}` work), `rebase_fragment_paths`
+(pattern walk), and `rebase_candidate` (the *existence check*: a string is a
+bundled file exactly when it exists under the extension dir — builtin names
+like `cosmo` simply don't exist there and pass through verbatim).
+
+**Key difference for this strand:** `contributes.project` fragments merge into
+*project config once*, so Phase 4 rewrites strings to project-root-relative
+`Path`s at parse time. `contributes.formats` layers merge *per document*, and
+`metadata_merge.rs:270` already rebases `Path`-kind values ext-dir → doc-dir.
+So here we do **not** need to rewrite the string at all — we only need to
+**mark** bundled-file strings as `ConfigValueKind::Path` (existence-driven,
+leaving the value ext-dir-relative), and the existing merge machinery does the
+rest. That is a strictly smaller intervention than Phase 4's.
+
+## Proposed fix (draft)
+
+Two independent halves, matching the strand's candidate fix:
+
+**Half A — existence-driven Path-marking for `contributes.formats`.**
+At read time (`extension/read.rs`), after the common-merge in `parse_formats`,
+walk each format's config with a pattern table equivalent to the `format.*.…`
+subset of `FRAGMENT_PATH_PATTERNS` (`theme`, `css`, `include-in-header`,
+`include-before-body`, `include-after-body`, `format-resources`) and flip
+string leaves to `Path` **iff the file exists under the extension dir**
+(thread `runtime` into `parse_contributes` — already available in
+`read_extension_with_org`). `template`/`template-partials`/`shortcodes`/
+`filters` keep their current unconditional marking. Likely refactor: extract
+the pattern-walk + existence-check core from `project/mod.rs` into a shared
+helper (parameterized by pattern table and "mark only" vs "rewrite to
+project-relative"), so the two sites can't drift.
+
+**Half B — a real diagnostic instead of the silent DEFAULT_CSS fallback.**
+`compile_theme_css.rs:560-568` currently treats every compile error the same.
+Split config-shaped errors (`CustomThemeNotFound`, `InvalidScssFile`) from
+internal compiler failures: config-shaped errors get a structured ariadne
+diagnostic via the existing `theme_diagnostic` infrastructure (new Q-14-x code
+in `quarto-error-catalog`, pointing at the offending `theme:` entry — the
+`from_config_value` error path at `compile_theme_css.rs:368-388` is the
+precedent). Whether they *fail the render* or *warn-and-fallback* is design
+question 2 below.
+
+## Proposed phases (draft)
+
+Skeleton only — contents wait on the design discussion.
+
+- **Phase 0 — Test plan (TDD).**
+  - `extension/read.rs` unit tests: bundled `theme: [cosmo, fmt-theme.scss]` →
+    `cosmo` stays Scalar, `fmt-theme.scss` becomes Path; non-existent file
+    stays Scalar; `css:`/`include-in-header:` marking; nested
+    `theme: {light: …}` leaves marked; existing template/filter tests stay
+    green.
+  - End-to-end integration test (per the repro shape, via the real render
+    path): compiled `styles.css` contains the extension rule AND the builtin
+    theme.
+  - Diagnostic test: `theme:` naming a file that exists nowhere → Q-14-x
+    surfaced (not silence, not bare DEFAULT_CSS).
+- **Phase 1 — Half A** (shared walk helper + read-time marking).
+- **Phase 2 — Half B** (Q-14-x diagnostic; register in catalog; snapshot).
+- **Phase 3 — E2E verification** (repro fixture through `cargo run --bin q2 --
+  render`, inspect `styles.css`; full `cargo xtask verify` — quarto-core is in
+  the WASM closure).
+- **Phase 4 — Docs**, if user-facing docs mention format extensions bundling
+  assets.
+
+## Open design questions for the user
+
+1. **Scope of Half A's key set.** Mirror the `format.*` subset of
+   `FRAGMENT_PATH_PATTERNS` exactly (`theme`, `css`, `include-in-header`,
+   `include-before-body`, `include-after-body`, `format-resources`), or start
+   narrower (`theme` + `css` only, per the strand title) and let the rest ride
+   along? Mirroring exactly keeps the two tables unifiable in the shared
+   helper; I lean toward the full subset.
+2. **Severity of a dangling theme entry (Half B).** When `theme:` names a
+   `.scss`/`.css` that resolves to no file: hard error (consistent with the
+   `from_config_value` precedent at `compile_theme_css.rs:368`, and with
+   "reveal theme unresolvable → error rather than wrong theme"), or visible
+   warning + compile the remaining entries (more forgiving, but partial
+   themes are their own confusion)? I lean toward hard error with a precise
+   ariadne span; note it changes behavior for *pre-existing* broken configs
+   that today silently get DEFAULT_CSS.
+3. **Also fix "one bad entry nukes valid entries"?** Under warn-and-continue
+   (Q2 option B) this needs per-entry error recovery inside
+   `process_theme_specs`; under hard-error it's moot. If hard-error, I'd file
+   nothing further.
+4. **Unconditional vs existence-driven for the legacy keys.** Should
+   `template`/`template-partials`/`shortcodes` stay unconditionally marked
+   (current behavior, they're always paths), or unify on existence-driven
+   marking? I lean strongly toward leaving them alone in this strand —
+   behavior change there is out of scope.
+5. **Where the shared helper lives.** `crates/quarto-core/src/extension/`
+   (new module, e.g. `extension/paths.rs`) with `project/mod.rs` importing it,
+   or keep two small copies? I lean toward extracting — the tables are the
+   part that must not drift.
+
+## Risks / tradeoffs (draft)
+
+- **Existence-driven marking is load-order-sensitive by design**: a file
+  added/removed next to `_extension.yml` changes classification. Same accepted
+  tradeoff as Phase 4 (documented at `project/mod.rs:676-680`).
+- **Hard-error choice in Q2 is a behavior change** for configs that are
+  *already* broken-but-silent today (they currently render with DEFAULT_CSS).
+  This is the same posture shift PR #473 made for unknown project types.
+- **`css:` consumers were not audited in this investigation** — Half A marks
+  them and the merge rebases them, but I did not verify every downstream
+  consumer of `css:` handles `Path`-kind values (the HTML writer link-emission
+  path). Phase 0's tests should cover one `css:` case end-to-end.
+- The `theme: {light:, dark:}` map form remains inert until bd-o76p01wb lands;
+  the marking walker should still handle map leaves so that fix composes.
+
+## Investigation artifacts
+
+- `claude-notes/plans/format-ext-theme-rebase-investigation/repro/` — minimal
+  reproduction (doc + fancyfmt extension). Render it with
+  `cargo run --bin q2 -- render doc.qmd` from inside the repro dir;
+  `grep fmt-theme-marker doc_files/styles.css` is the pass/fail probe
+  (0 hits = bug present, ≥1 = fixed). `doc_files/` output is not committed.

--- a/claude-notes/plans/2026-08-08-format-ext-theme-rebase.md
+++ b/claude-notes/plans/2026-08-08-format-ext-theme-rebase.md
@@ -3,7 +3,8 @@
 **Date:** 2026-08-08
 **Braid:** bd-of20unsb (P2, bug)
 **Checkout:** main worktree at `main` @ `e5fc4ffb` (post-merge of PR #474)
-**Status:** Investigation — pending design alignment with user. **Do not start implementation until the user gives the go-ahead.**
+**Status:** Design aligned 2026-08-08 (all five questions resolved — see Design
+decisions). **Awaiting user go-ahead to execute.**
 
 ## Triage verdict
 
@@ -141,14 +142,35 @@ internal compiler failures: config-shaped errors get a structured ariadne
 diagnostic via the existing `theme_diagnostic` infrastructure (new Q-14-x code
 in `quarto-error-catalog`, pointing at the offending `theme:` entry — the
 `from_config_value` error path at `compile_theme_css.rs:368-388` is the
-precedent). Whether they *fail the render* or *warn-and-fallback* is design
-question 2 below.
+precedent). Per design decision 2, these **fail the render** (hard error).
 
-## Proposed phases (draft)
+## Design decisions (aligned with user, 2026-08-08)
 
-Skeleton only — contents wait on the design discussion.
+1. **Key set: the full `format.*` subset of `FRAGMENT_PATH_PATTERNS`** —
+   `theme`, `css`, `include-in-header`, `include-before-body`,
+   `include-after-body`, `format-resources`.
+2. **Dangling theme entry → hard error** with an ariadne span. Rationale
+   (user): Q1 guessed at user intent because it lacked source-mapping infra;
+   Q2 is deliberately stricter because it can produce precise, idiomatic
+   errors. This intentionally changes behavior for configs that are already
+   broken-but-silent today (they currently get DEFAULT_CSS).
+3. **"One bad entry nukes valid entries" is moot** under hard-error; nothing
+   further to file.
+4. **Legacy keys (`template`/`template-partials`/`shortcodes`) stay
+   unconditionally marked.** Their values are always paths semantically (no
+   builtin-name ambiguity), and existence-driven marking there would convert
+   a clear missing-file error into silent document-dir fallback. No
+   overengineering now: the schema may eventually signal path entries in-band
+   (`file: …` object keys), which would obsolete sniffing entirely.
+5. **Shared helper, extracted** — pattern-walk + existence-check core moves to
+   a shared module (e.g. `crates/quarto-core/src/extension/paths.rs`);
+   `project/mod.rs` imports it. The pattern tables are the part that must not
+   drift; the unconditional-vs-existence-driven distinction is expressed and
+   documented there.
 
-- **Phase 0 — Test plan (TDD).**
+## Phases
+
+- **Phase 0 — Test plan (TDD; tests written and failing before any fix).**
   - `extension/read.rs` unit tests: bundled `theme: [cosmo, fmt-theme.scss]` →
     `cosmo` stays Scalar, `fmt-theme.scss` becomes Path; non-existent file
     stays Scalar; `css:`/`include-in-header:` marking; nested
@@ -157,45 +179,39 @@ Skeleton only — contents wait on the design discussion.
   - End-to-end integration test (per the repro shape, via the real render
     path): compiled `styles.css` contains the extension rule AND the builtin
     theme.
-  - Diagnostic test: `theme:` naming a file that exists nowhere → Q-14-x
-    surfaced (not silence, not bare DEFAULT_CSS).
-- **Phase 1 — Half A** (shared walk helper + read-time marking).
-- **Phase 2 — Half B** (Q-14-x diagnostic; register in catalog; snapshot).
-- **Phase 3 — E2E verification** (repro fixture through `cargo run --bin q2 --
-  render`, inspect `styles.css`; full `cargo xtask verify` — quarto-core is in
-  the WASM closure).
-- **Phase 4 — Docs**, if user-facing docs mention format extensions bundling
-  assets.
+  - Diagnostic test: `theme:` naming a file that exists nowhere → Q-14-x hard
+    error with a span at the offending entry (not silence, not DEFAULT_CSS).
+  - One `css:` case end-to-end (downstream Path-kind handling in the HTML
+    writer link-emission path was not audited during investigation).
+- **Phase 1 — Half A: shared helper + read-time marking.** Extract the
+  pattern-walk/existence-check core from `project/mod.rs` into
+  `extension/paths.rs`; refactor `rebase_fragment_paths` onto it (no behavior
+  change there); add existence-driven marking of the decision-1 key set in
+  `parse_formats` (thread `runtime` into `parse_contributes`).
+- **Phase 2 — Half B: Q-14-x hard error.** In `compile_theme_css.rs:560-568`,
+  split config-shaped errors (`CustomThemeNotFound`, `InvalidScssFile`) from
+  internal compiler failures; route the former through `theme_diagnostic`
+  as a new Q-14-x catalog code (following the `from_config_value` precedent
+  at `compile_theme_css.rs:368-388`); keep the DEFAULT_CSS fallback only for
+  internal failures.
+- **Phase 3 — E2E verification.** Repro fixture through
+  `cargo run --bin q2 -- render doc.qmd`; inspect `styles.css` for the marker
+  rule + cosmo; full `cargo xtask verify` (quarto-core is in the WASM
+  closure).
+- **Phase 4 — Docs.** Check whether `docs/` mentions format extensions
+  bundling assets; document the bundled-asset behavior if there's a natural
+  home.
 
-## Open design questions for the user
+## Work items
 
-1. **Scope of Half A's key set.** Mirror the `format.*` subset of
-   `FRAGMENT_PATH_PATTERNS` exactly (`theme`, `css`, `include-in-header`,
-   `include-before-body`, `include-after-body`, `format-resources`), or start
-   narrower (`theme` + `css` only, per the strand title) and let the rest ride
-   along? Mirroring exactly keeps the two tables unifiable in the shared
-   helper; I lean toward the full subset.
-2. **Severity of a dangling theme entry (Half B).** When `theme:` names a
-   `.scss`/`.css` that resolves to no file: hard error (consistent with the
-   `from_config_value` precedent at `compile_theme_css.rs:368`, and with
-   "reveal theme unresolvable → error rather than wrong theme"), or visible
-   warning + compile the remaining entries (more forgiving, but partial
-   themes are their own confusion)? I lean toward hard error with a precise
-   ariadne span; note it changes behavior for *pre-existing* broken configs
-   that today silently get DEFAULT_CSS.
-3. **Also fix "one bad entry nukes valid entries"?** Under warn-and-continue
-   (Q2 option B) this needs per-entry error recovery inside
-   `process_theme_specs`; under hard-error it's moot. If hard-error, I'd file
-   nothing further.
-4. **Unconditional vs existence-driven for the legacy keys.** Should
-   `template`/`template-partials`/`shortcodes` stay unconditionally marked
-   (current behavior, they're always paths), or unify on existence-driven
-   marking? I lean strongly toward leaving them alone in this strand —
-   behavior change there is out of scope.
-5. **Where the shared helper lives.** `crates/quarto-core/src/extension/`
-   (new module, e.g. `extension/paths.rs`) with `project/mod.rs` importing it,
-   or keep two small copies? I lean toward extracting — the tables are the
-   part that must not drift.
+- [ ] Phase 0: failing tests (read-time marking, e2e theme, Q-14-x
+      diagnostic, css case)
+- [ ] Phase 1: shared helper extracted; `rebase_fragment_paths` refactored;
+      existence-driven marking wired into `parse_formats`
+- [ ] Phase 2: Q-14-x registered in `quarto-error-catalog`; hard error wired;
+      fallback retained for internal compile failures only
+- [ ] Phase 3: e2e verified via real binary; full `cargo xtask verify` green
+- [ ] Phase 4: docs checked/updated
 
 ## Risks / tradeoffs (draft)
 

--- a/claude-notes/plans/2026-08-08-format-ext-theme-rebase.md
+++ b/claude-notes/plans/2026-08-08-format-ext-theme-rebase.md
@@ -204,6 +204,17 @@ precedent). Per design decision 2, these **fail the render** (hard error).
   bundling assets; document the bundled-asset behavior if there's a natural
   home.
 
+## Renumbering note (2026-08-08, post-rebase)
+
+The diagnostic originally shipped as Q-14-3, but PR #475 (bd-o76p01wb,
+light/dark theme maps) merged first and took Q-14-3 for its
+dark-variant-ignored warning. On rebasing this branch over #475 the
+missing-theme-file error was renumbered to **Q-14-4** (code, catalog,
+docs page, tests). The `theme_locations` machinery composes with #475
+unchanged: the light half of a `light:`/`dark:` pair flows through
+`from_theme_value` → `extract_theme_specs`, so its entries carry
+locations too.
+
 ## Work items
 
 - [x] Phase 0: failing tests (read-time marking, e2e theme, Q-14-x
@@ -211,7 +222,7 @@ precedent). Per design decision 2, these **fail the render** (hard error).
       as expected, 1 no-change guard passes); smoke-all fixture
       `extensions/format-with-theme/` (fails all 3 assertions — confirms
       `css:` links are dropped too, not just theme); CLI test
-      `theme_missing_file.rs` (Q-14-3 test fails on exit 0 as expected;
+      `theme_missing_file.rs` (Q-14-4 test fails on exit 0 as expected;
       present-file control passes). Note: `as_str()` handles Path-kind
       (config_value.rs:641), so the css template path is safe by
       construction — risk retired.
@@ -219,7 +230,7 @@ precedent). Per design decision 2, these **fail the render** (hard error).
       `rebase_fragment_paths` refactored onto it; existence-driven marking
       wired into `parse_formats`. Commit `84f88c9f`; full workspace suite
       green; smoke fixture passes.
-- [x] Phase 2: Q-14-3 registered in `quarto-error-catalog`; up-front
+- [x] Phase 2: Q-14-4 registered in `quarto-error-catalog`; up-front
       validation in `compile_theme_css` (before cache-key computation) hard-
       errors on dangling custom theme entries with an ariadne span at the
       offending `theme:` entry; DEFAULT_CSS fallback retained for internal
@@ -237,11 +248,11 @@ precedent). Per design decision 2, these **fail the render** (hard error).
       `cargo run --bin q2 -- render doc.qmd` → exit 0, `doc_files/styles.css`
       is 321 KB with `.fmt-theme-marker` present (was 7 KB DEFAULT_CSS with
       0 hits). (2) Dangling entry (`theme: [cosmo, nope.scss]`): exit 1,
-      Q-14-3 ariadne diagnostic with span pinned at `nope.scss` (line 5 col
+      Q-14-4 ariadne diagnostic with span pinned at `nope.scss` (line 5 col
       20) and resolved path in the message; output inspected in both cases.
       Full `cargo xtask verify` (WASM leg included): **passed** (exit 0,
       2026-08-08).
-- [x] Phase 4: docs — new `docs/errors/theme/Q-14-3.qmd` (listing index
+- [x] Phase 4: docs — new `docs/errors/theme/Q-14-4.qmd` (listing index
       auto-globs it) + format-extension paragraph in the extensions guide's
       "Bundled files" section; verified via `q2 render docs/` (189/189,
       page renders, cross-link resolves).

--- a/claude-notes/plans/2026-08-08-format-ext-theme-rebase.md
+++ b/claude-notes/plans/2026-08-08-format-ext-theme-rebase.md
@@ -204,8 +204,15 @@ precedent). Per design decision 2, these **fail the render** (hard error).
 
 ## Work items
 
-- [ ] Phase 0: failing tests (read-time marking, e2e theme, Q-14-x
-      diagnostic, css case)
+- [x] Phase 0: failing tests (read-time marking, e2e theme, Q-14-x
+      diagnostic, css case) — 7 unit tests in `extension/read.rs` (6 fail
+      as expected, 1 no-change guard passes); smoke-all fixture
+      `extensions/format-with-theme/` (fails all 3 assertions — confirms
+      `css:` links are dropped too, not just theme); CLI test
+      `theme_missing_file.rs` (Q-14-3 test fails on exit 0 as expected;
+      present-file control passes). Note: `as_str()` handles Path-kind
+      (config_value.rs:641), so the css template path is safe by
+      construction — risk retired.
 - [ ] Phase 1: shared helper extracted; `rebase_fragment_paths` refactored;
       existence-driven marking wired into `parse_formats`
 - [ ] Phase 2: Q-14-x registered in `quarto-error-catalog`; hard error wired;

--- a/claude-notes/plans/2026-08-08-format-ext-theme-rebase.md
+++ b/claude-notes/plans/2026-08-08-format-ext-theme-rebase.md
@@ -3,8 +3,10 @@
 **Date:** 2026-08-08
 **Braid:** bd-of20unsb (P2, bug)
 **Checkout:** main worktree at `main` @ `e5fc4ffb` (post-merge of PR #474)
-**Status:** Design aligned 2026-08-08 (all five questions resolved — see Design
-decisions). **Awaiting user go-ahead to execute.**
+**Status:** Implemented 2026-08-08, all phases complete on local `main`
+(commits `e2cda047` → docs). Full `cargo xtask verify` green (incl. WASM
+leg). **Not pushed — awaiting user review + push approval.** Follow-up
+filed: bd-qmpygp02 (`InvalidScssFile` silent fallback).
 
 ## Triage verdict
 
@@ -217,10 +219,32 @@ precedent). Per design decision 2, these **fail the render** (hard error).
       `rebase_fragment_paths` refactored onto it; existence-driven marking
       wired into `parse_formats`. Commit `84f88c9f`; full workspace suite
       green; smoke fixture passes.
-- [ ] Phase 2: Q-14-x registered in `quarto-error-catalog`; hard error wired;
-      fallback retained for internal compile failures only
-- [ ] Phase 3: e2e verified via real binary; full `cargo xtask verify` green
-- [ ] Phase 4: docs checked/updated
+- [x] Phase 2: Q-14-3 registered in `quarto-error-catalog`; up-front
+      validation in `compile_theme_css` (before cache-key computation) hard-
+      errors on dangling custom theme entries with an ariadne span at the
+      offending `theme:` entry; DEFAULT_CSS fallback retained for internal
+      compile failures only. `ThemeConfig.theme_locations` (parallel field,
+      deliberately not inside `ThemeSpec` — keeps the spec a pure value type
+      for Eq/Display/cache-key identity);
+      `SassError::CustomThemeNotFound.location`. Scope note:
+      `InvalidScssFile` (file exists, content lacks boundary markers) still
+      falls back silently — it only surfaces inside the compile call, whose
+      error is stringified; filed as bd-qmpygp02 (discovered-from this
+      strand) rather than widening this change untested. Commit follows
+      `84f88c9f`; full workspace suite green.
+- [x] Phase 3: e2e verified via real binary. (1) Original repro
+      (`claude-notes/plans/format-ext-theme-rebase-investigation/repro/`):
+      `cargo run --bin q2 -- render doc.qmd` → exit 0, `doc_files/styles.css`
+      is 321 KB with `.fmt-theme-marker` present (was 7 KB DEFAULT_CSS with
+      0 hits). (2) Dangling entry (`theme: [cosmo, nope.scss]`): exit 1,
+      Q-14-3 ariadne diagnostic with span pinned at `nope.scss` (line 5 col
+      20) and resolved path in the message; output inspected in both cases.
+      Full `cargo xtask verify` (WASM leg included): **passed** (exit 0,
+      2026-08-08).
+- [x] Phase 4: docs — new `docs/errors/theme/Q-14-3.qmd` (listing index
+      auto-globs it) + format-extension paragraph in the extensions guide's
+      "Bundled files" section; verified via `q2 render docs/` (189/189,
+      page renders, cross-link resolves).
 
 ## Risks / tradeoffs (draft)
 

--- a/claude-notes/plans/format-ext-theme-rebase-investigation/repro/_extensions/fancyfmt/_extension.yml
+++ b/claude-notes/plans/format-ext-theme-rebase-investigation/repro/_extensions/fancyfmt/_extension.yml
@@ -1,0 +1,7 @@
+title: Fancy Format
+author: Investigation
+version: 0.0.1
+contributes:
+  formats:
+    html:
+      theme: [cosmo, fmt-theme.scss]

--- a/claude-notes/plans/format-ext-theme-rebase-investigation/repro/_extensions/fancyfmt/fmt-theme.scss
+++ b/claude-notes/plans/format-ext-theme-rebase-investigation/repro/_extensions/fancyfmt/fmt-theme.scss
@@ -1,0 +1,7 @@
+/*-- scss:defaults --*/
+$fmt-theme-accent: rgb(1, 2, 3);
+
+/*-- scss:rules --*/
+.fmt-theme-marker {
+  color: $fmt-theme-accent;
+}

--- a/claude-notes/plans/format-ext-theme-rebase-investigation/repro/doc.qmd
+++ b/claude-notes/plans/format-ext-theme-rebase-investigation/repro/doc.qmd
@@ -1,0 +1,8 @@
+---
+title: Format extension theme repro
+format: fancyfmt-html
+---
+
+# Hello
+
+Body text with a [span]{.fmt-theme-marker}.

--- a/crates/quarto-core/src/extension/mod.rs
+++ b/crates/quarto-core/src/extension/mod.rs
@@ -16,6 +16,7 @@
 //! same name take priority (last-match-wins in `find_extension`).
 
 pub mod discover;
+pub(crate) mod paths;
 pub mod read;
 pub mod types;
 

--- a/crates/quarto-core/src/extension/paths.rs
+++ b/crates/quarto-core/src/extension/paths.rs
@@ -1,0 +1,170 @@
+/*
+ * extension/paths.rs
+ * Copyright (c) 2026 Posit, PBC
+ *
+ * Shared machinery for classifying extension-bundled file references
+ * in contributed config (bd-ad7i1pc6 Phase 4, bd-of20unsb).
+ */
+
+//! Pattern-guided discovery of extension-bundled file paths.
+//!
+//! Extensions contribute config fragments (`contributes.project`,
+//! `contributes.metadata`, `contributes.formats`) whose string values
+//! may name files bundled with the extension — theme SCSS, CSS,
+//! include snippets, templates. Those strings are written relative to
+//! the extension directory, but the merged config is consumed relative
+//! to the project root or document directory, so bundled references
+//! must be recognized and rebased.
+//!
+//! Two ingredients are shared by every consumer and live here so the
+//! key tables cannot drift between them:
+//!
+//! - [`walk_pattern_leaves`]: a key-path pattern walk over a
+//!   [`ConfigValue`] tree. `*` matches any map key; arrays are
+//!   transparent (a pattern position applies to every item). When a
+//!   pattern is exhausted at a node, the action is applied to every
+//!   string leaf underneath — this is what makes both the
+//!   `theme: [cosmo, custom.scss]` and `theme: {light: […], dark: …}`
+//!   forms work from a single `theme` pattern entry.
+//! - [`bundled_file_exists`]: the *existence check* that decides
+//!   whether an individual string names a bundled file. Rooted paths
+//!   and URLs are never bundled; otherwise the string is a bundled
+//!   file exactly when it exists under the extension dir. Builtin
+//!   theme names (`cosmo`), command lines, and document-relative
+//!   references simply don't exist there and pass through untouched.
+//!
+//! Two marking modes exist deliberately (bd-of20unsb design):
+//!
+//! - **Existence-driven** ([`mark_bundled_format_assets`], and the
+//!   fragment rebase in `crate::project`): for keys where a string may
+//!   be *either* a bundled file or something else (a builtin theme
+//!   name, a project-relative path). The filesystem disambiguates.
+//! - **Unconditional** (`PATH_VALUED_KEYS` in `crate::extension::read`):
+//!   for keys (`template`, `template-partials`, `shortcodes`, filter
+//!   entries) whose values are always paths semantically. An existence
+//!   check there would convert a clear missing-file error into a
+//!   silent document-dir fallback — worse, not better.
+//!
+//! A future manifest schema may signal path entries in-band (e.g.
+//! `file:` object keys), which would obsolete the sniffing; until
+//! then, keep both tables here-adjacent and documented.
+
+use std::path::Path;
+
+use quarto_pandoc_types::{ConfigValue, ConfigValueKind};
+use quarto_system_runtime::SystemRuntime;
+
+/// Keys in a *format* config map (`contributes.formats.<fmt>`) whose
+/// string values may name files bundled with the extension. The
+/// existence check decides per string; builtin theme names pass
+/// through. Mirrors the `format.*` subset of the
+/// `contributes.project` fragment table in `crate::project`
+/// (`FRAGMENT_PATH_PATTERNS`), minus `template`/`template-partials`,
+/// which are unconditionally path-valued and handled by
+/// `PATH_VALUED_KEYS` in `crate::extension::read`.
+pub(crate) const FORMAT_ASSET_PATTERNS: &[&[&str]] = &[
+    &["theme"],
+    &["css"],
+    &["include-in-header"],
+    &["include-before-body"],
+    &["include-after-body"],
+    &["format-resources"],
+];
+
+/// Walk `value` guided by key-path `patterns`, applying `action` to
+/// every string-like leaf (`Scalar` string or `Path`) reachable once a
+/// pattern is exhausted.
+///
+/// `*` matches any map key; arrays are transparent at any position.
+/// Nodes matching no pattern prefix are left untouched.
+pub(crate) fn walk_pattern_leaves(
+    value: &mut ConfigValue,
+    patterns: &[&[&str]],
+    action: &mut dyn FnMut(&mut ConfigValue),
+) {
+    if patterns.iter().any(|p| p.is_empty()) {
+        apply_to_string_leaves(value, action);
+        return;
+    }
+    match &mut value.value {
+        ConfigValueKind::Map(entries) => {
+            for entry in entries {
+                let next: Vec<&[&str]> = patterns
+                    .iter()
+                    .filter(|p| p[0] == "*" || p[0] == entry.key)
+                    .map(|p| &p[1..])
+                    .collect();
+                if !next.is_empty() {
+                    walk_pattern_leaves(&mut entry.value, &next, action);
+                }
+            }
+        }
+        // Arrays are transparent: items share the pattern position.
+        ConfigValueKind::Array(items) => {
+            for item in items {
+                walk_pattern_leaves(item, patterns, action);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Apply `action` to every `Scalar`-string or `Path` leaf under
+/// `value`, recursing through maps and arrays.
+fn apply_to_string_leaves(value: &mut ConfigValue, action: &mut dyn FnMut(&mut ConfigValue)) {
+    match &mut value.value {
+        ConfigValueKind::Map(entries) => {
+            for entry in entries {
+                apply_to_string_leaves(&mut entry.value, action);
+            }
+        }
+        ConfigValueKind::Array(items) => {
+            for item in items {
+                apply_to_string_leaves(item, action);
+            }
+        }
+        ConfigValueKind::Scalar(yaml_rust2::Yaml::String(_)) | ConfigValueKind::Path(_) => {
+            action(value);
+        }
+        _ => {}
+    }
+}
+
+/// Does `s` name a file bundled under `ext_dir`?
+///
+/// Rooted paths and URLs are never bundled references; otherwise the
+/// string is a bundled file exactly when it exists under the extension
+/// dir. (`path_exists` with kind `None` — directories count, matching
+/// the `contributes.project` fragment rebase, where e.g. resource
+/// entries may be directories.)
+pub(crate) fn bundled_file_exists(s: &str, ext_dir: &Path, runtime: &dyn SystemRuntime) -> bool {
+    if quarto_util::is_rooted(Path::new(s)) || s.starts_with("http://") || s.starts_with("https://")
+    {
+        return false;
+    }
+    runtime.path_exists(&ext_dir.join(s), None).unwrap_or(false)
+}
+
+/// Mark bundled-file references in one format's contributed config
+/// (`contributes.formats.<fmt>`) as [`ConfigValueKind::Path`], leaving
+/// the string ext-dir-relative (bd-of20unsb).
+///
+/// Unlike the `contributes.project` fragment rebase (which rewrites to
+/// project-root-relative because project config merges once), format
+/// layers merge **per document**, and `MetadataMergeStage` already
+/// rebases `Path`-kind values from the extension dir to the document
+/// dir — so marking is the entire job here.
+pub(crate) fn mark_bundled_format_assets(
+    format_config: &mut ConfigValue,
+    ext_dir: &Path,
+    runtime: &dyn SystemRuntime,
+) {
+    walk_pattern_leaves(format_config, FORMAT_ASSET_PATTERNS, &mut |leaf| {
+        let ConfigValueKind::Scalar(yaml_rust2::Yaml::String(s)) = &leaf.value else {
+            return;
+        };
+        if bundled_file_exists(s, ext_dir, runtime) {
+            leaf.value = ConfigValueKind::Path(s.clone());
+        }
+    });
+}

--- a/crates/quarto-core/src/extension/read.rs
+++ b/crates/quarto-core/src/extension/read.rs
@@ -94,7 +94,7 @@ pub fn read_extension_with_org(
         ))
     })?;
 
-    let contributes = parse_contributes(contributes_cv, ext_dir)?;
+    let contributes = parse_contributes(contributes_cv, ext_dir, runtime)?;
 
     Ok(Extension {
         id: if let Some(org) = ext_org {
@@ -135,12 +135,16 @@ fn derive_extension_id(ext_dir: &Path) -> (String, Option<String>) {
 }
 
 /// Parse the `contributes` section of an `_extension.yml`.
-fn parse_contributes(contributes: &ConfigValue, ext_dir: &Path) -> Result<Contributes> {
+fn parse_contributes(
+    contributes: &ConfigValue,
+    ext_dir: &Path,
+    runtime: &dyn SystemRuntime,
+) -> Result<Contributes> {
     let mut result = Contributes::default();
 
     // Parse formats with "common" key merging
     if let Some(formats_cv) = contributes.get("formats") {
-        result.formats = parse_formats(formats_cv, ext_dir)?;
+        result.formats = parse_formats(formats_cv, ext_dir, runtime)?;
     }
 
     // Parse filters
@@ -177,7 +181,8 @@ fn parse_contributes(contributes: &ConfigValue, ext_dir: &Path) -> Result<Contri
 /// The `common` key's values serve as defaults for all other format keys.
 fn parse_formats(
     formats_cv: &ConfigValue,
-    _ext_dir: &Path,
+    ext_dir: &Path,
+    runtime: &dyn SystemRuntime,
 ) -> Result<HashMap<String, ConfigValue>> {
     let mut result = HashMap::new();
 
@@ -206,6 +211,11 @@ fn parse_formats(
         // Convert known path-valued keys to ConfigValueKind::Path so that
         // adjust_paths_to_document_dir() will rebase them during metadata merge.
         mark_path_valued_keys(&mut merged_value);
+
+        // Existence-driven marking for keys whose strings may be either
+        // bundled files or something else (builtin theme names, doc-relative
+        // references) — the filesystem disambiguates (bd-of20unsb).
+        super::paths::mark_bundled_format_assets(&mut merged_value, ext_dir, runtime);
 
         result.insert(entry.key.clone(), merged_value);
     }

--- a/crates/quarto-core/src/extension/read.rs
+++ b/crates/quarto-core/src/extension/read.rs
@@ -977,6 +977,267 @@ contributes:
         }
     }
 
+    // --- bd-of20unsb: existence-driven Path marking for bundled ---
+    // --- format assets (theme / css / include-* / format-resources) ---
+
+    /// Create an asset file at `rel` under the extension dir, so the
+    /// existence-driven marking classifies the string as a bundled file.
+    fn write_asset(ext_dir: &Path, rel: &str) {
+        let p = ext_dir.join(rel);
+        fs::create_dir_all(p.parent().unwrap()).unwrap();
+        fs::write(&p, "/* asset */\n").unwrap();
+    }
+
+    #[test]
+    fn test_theme_bundled_scss_marked_as_path_builtin_stays_scalar() {
+        let tmp = TempDir::new().unwrap();
+        let ext_dir = tmp.path().join("_extensions/fancyfmt");
+        let file = write_extension(
+            &ext_dir,
+            r#"
+contributes:
+  formats:
+    html:
+      theme: [cosmo, fmt-theme.scss]
+"#,
+        );
+        write_asset(&ext_dir, "fmt-theme.scss");
+
+        let runtime = make_runtime();
+        let ext = read_extension(&file, &runtime).unwrap();
+
+        let html_meta = &ext.contributes.formats["html"];
+        let items = html_meta.get("theme").unwrap().as_array().unwrap();
+        assert_eq!(items.len(), 2);
+        // Built-in theme name: no such file under the extension dir,
+        // so it must stay Scalar (the theme stage resolves it by name).
+        assert!(
+            matches!(&items[0].value, ConfigValueKind::Scalar(_)),
+            "expected Scalar for builtin name `cosmo`, got {:?}",
+            items[0].value
+        );
+        // Bundled file: exists next to _extension.yml, so it must be
+        // marked Path (ext-dir-relative) for the merge-time rebase.
+        assert!(
+            matches!(&items[1].value, ConfigValueKind::Path(s) if s == "fmt-theme.scss"),
+            "expected Path(\"fmt-theme.scss\"), got {:?}",
+            items[1].value
+        );
+    }
+
+    #[test]
+    fn test_theme_scalar_bundled_file_marked_as_path() {
+        let tmp = TempDir::new().unwrap();
+        let ext_dir = tmp.path().join("_extensions/fancyfmt");
+        let file = write_extension(
+            &ext_dir,
+            r#"
+contributes:
+  formats:
+    html:
+      theme: fmt-theme.scss
+"#,
+        );
+        write_asset(&ext_dir, "fmt-theme.scss");
+
+        let runtime = make_runtime();
+        let ext = read_extension(&file, &runtime).unwrap();
+
+        let html_meta = &ext.contributes.formats["html"];
+        let theme = html_meta.get("theme").unwrap();
+        assert!(
+            matches!(&theme.value, ConfigValueKind::Path(s) if s == "fmt-theme.scss"),
+            "expected Path(\"fmt-theme.scss\"), got {:?}",
+            theme.value
+        );
+    }
+
+    #[test]
+    fn test_theme_missing_file_stays_scalar() {
+        // A `.scss` string with no matching bundled file is NOT the
+        // extension's to claim — it stays Scalar and resolves (or
+        // hard-errors) downstream relative to the document.
+        let tmp = TempDir::new().unwrap();
+        let ext_dir = tmp.path().join("_extensions/fancyfmt");
+        let file = write_extension(
+            &ext_dir,
+            r#"
+contributes:
+  formats:
+    html:
+      theme: [missing.scss]
+"#,
+        );
+
+        let runtime = make_runtime();
+        let ext = read_extension(&file, &runtime).unwrap();
+
+        let html_meta = &ext.contributes.formats["html"];
+        let items = html_meta.get("theme").unwrap().as_array().unwrap();
+        assert!(
+            matches!(&items[0].value, ConfigValueKind::Scalar(_)),
+            "expected Scalar for missing.scss (no bundled file), got {:?}",
+            items[0].value
+        );
+    }
+
+    #[test]
+    fn test_theme_nested_map_leaves_marked() {
+        // The light/dark map form: pattern exhaustion at `theme` marks
+        // every string leaf underneath, existence-driven per leaf.
+        // (Consumption of light/dark maps is bd-o76p01wb; marking now
+        // means that fix composes with this one.)
+        let tmp = TempDir::new().unwrap();
+        let ext_dir = tmp.path().join("_extensions/fancyfmt");
+        let file = write_extension(
+            &ext_dir,
+            r#"
+contributes:
+  formats:
+    html:
+      theme:
+        light: [flatly, fmt-light.scss]
+        dark: fmt-dark.scss
+"#,
+        );
+        write_asset(&ext_dir, "fmt-light.scss");
+        write_asset(&ext_dir, "fmt-dark.scss");
+
+        let runtime = make_runtime();
+        let ext = read_extension(&file, &runtime).unwrap();
+
+        let html_meta = &ext.contributes.formats["html"];
+        let theme = html_meta.get("theme").unwrap();
+        let light = theme.get("light").unwrap().as_array().unwrap();
+        assert!(
+            matches!(&light[0].value, ConfigValueKind::Scalar(_)),
+            "expected Scalar for builtin `flatly`, got {:?}",
+            light[0].value
+        );
+        assert!(
+            matches!(&light[1].value, ConfigValueKind::Path(s) if s == "fmt-light.scss"),
+            "expected Path(\"fmt-light.scss\"), got {:?}",
+            light[1].value
+        );
+        let dark = theme.get("dark").unwrap();
+        assert!(
+            matches!(&dark.value, ConfigValueKind::Path(s) if s == "fmt-dark.scss"),
+            "expected Path(\"fmt-dark.scss\"), got {:?}",
+            dark.value
+        );
+    }
+
+    #[test]
+    fn test_css_bundled_file_marked_missing_stays_scalar() {
+        let tmp = TempDir::new().unwrap();
+        let ext_dir = tmp.path().join("_extensions/fancyfmt");
+        let file = write_extension(
+            &ext_dir,
+            r#"
+contributes:
+  formats:
+    html:
+      css: [fmt-style.css, not-bundled.css]
+"#,
+        );
+        write_asset(&ext_dir, "fmt-style.css");
+
+        let runtime = make_runtime();
+        let ext = read_extension(&file, &runtime).unwrap();
+
+        let html_meta = &ext.contributes.formats["html"];
+        let items = html_meta.get("css").unwrap().as_array().unwrap();
+        assert!(
+            matches!(&items[0].value, ConfigValueKind::Path(s) if s == "fmt-style.css"),
+            "expected Path(\"fmt-style.css\"), got {:?}",
+            items[0].value
+        );
+        assert!(
+            matches!(&items[1].value, ConfigValueKind::Scalar(_)),
+            "expected Scalar for not-bundled.css, got {:?}",
+            items[1].value
+        );
+    }
+
+    #[test]
+    fn test_include_keys_bundled_files_marked() {
+        let tmp = TempDir::new().unwrap();
+        let ext_dir = tmp.path().join("_extensions/fancyfmt");
+        let file = write_extension(
+            &ext_dir,
+            r#"
+contributes:
+  formats:
+    html:
+      include-in-header: header.html
+      include-before-body: [before.html]
+      include-after-body: after.html
+"#,
+        );
+        write_asset(&ext_dir, "header.html");
+        write_asset(&ext_dir, "before.html");
+        write_asset(&ext_dir, "after.html");
+
+        let runtime = make_runtime();
+        let ext = read_extension(&file, &runtime).unwrap();
+
+        let html_meta = &ext.contributes.formats["html"];
+        for (key, expected) in [
+            ("include-in-header", "header.html"),
+            ("include-after-body", "after.html"),
+        ] {
+            let v = html_meta.get(key).unwrap();
+            assert!(
+                matches!(&v.value, ConfigValueKind::Path(s) if s == expected),
+                "{}: expected Path(\"{}\"), got {:?}",
+                key,
+                expected,
+                v.value
+            );
+        }
+        let before = html_meta
+            .get("include-before-body")
+            .unwrap()
+            .as_array()
+            .unwrap();
+        assert!(
+            matches!(&before[0].value, ConfigValueKind::Path(s) if s == "before.html"),
+            "expected Path(\"before.html\"), got {:?}",
+            before[0].value
+        );
+    }
+
+    #[test]
+    fn test_format_resources_bundled_subdir_file_marked() {
+        let tmp = TempDir::new().unwrap();
+        let ext_dir = tmp.path().join("_extensions/fancyfmt");
+        let file = write_extension(
+            &ext_dir,
+            r#"
+contributes:
+  formats:
+    html:
+      format-resources: [fonts/fancy.woff2]
+"#,
+        );
+        write_asset(&ext_dir, "fonts/fancy.woff2");
+
+        let runtime = make_runtime();
+        let ext = read_extension(&file, &runtime).unwrap();
+
+        let html_meta = &ext.contributes.formats["html"];
+        let items = html_meta
+            .get("format-resources")
+            .unwrap()
+            .as_array()
+            .unwrap();
+        assert!(
+            matches!(&items[0].value, ConfigValueKind::Path(s) if s == "fonts/fancy.woff2"),
+            "expected Path(\"fonts/fancy.woff2\"), got {:?}",
+            items[0].value
+        );
+    }
+
     #[test]
     fn test_shortcode_marking_doesnt_affect_other_keys() {
         let tmp = TempDir::new().unwrap();

--- a/crates/quarto-core/src/project/mod.rs
+++ b/crates/quarto-core/src/project/mod.rs
@@ -702,79 +702,26 @@ const FRAGMENT_PATH_PATTERNS: &[&[&str]] = &[
 /// Rebased values become [`ConfigValueKind::Path`] so the per-document
 /// metadata merge keeps adjusting them (project root → document dir)
 /// for documents in subdirectories.
+///
+/// The pattern walk and the bundled-file existence check are shared
+/// with the `contributes.formats` marking (bd-of20unsb) via
+/// [`crate::extension::paths`].
 fn rebase_fragment_paths(
     fragment: &mut ConfigValue,
     ext_dir: &Path,
     project_dir: &Path,
     runtime: &dyn SystemRuntime,
 ) {
-    fn walk(
-        value: &mut ConfigValue,
-        active: &[&[&str]],
-        ext_dir: &Path,
-        project_dir: &Path,
-        runtime: &dyn SystemRuntime,
-    ) {
-        if active.iter().any(|p| p.is_empty()) {
-            rebase_leaves(value, ext_dir, project_dir, runtime);
+    crate::extension::paths::walk_pattern_leaves(fragment, FRAGMENT_PATH_PATTERNS, &mut |leaf| {
+        let (ConfigValueKind::Scalar(yaml_rust2::Yaml::String(s)) | ConfigValueKind::Path(s)) =
+            &leaf.value
+        else {
             return;
+        };
+        if let Some(rebased) = rebase_candidate(s, ext_dir, project_dir, runtime) {
+            leaf.value = ConfigValueKind::Path(rebased);
         }
-        match &mut value.value {
-            ConfigValueKind::Map(entries) => {
-                for entry in entries {
-                    let next: Vec<&[&str]> = active
-                        .iter()
-                        .filter(|p| p[0] == "*" || p[0] == entry.key)
-                        .map(|p| &p[1..])
-                        .collect();
-                    if !next.is_empty() {
-                        walk(&mut entry.value, &next, ext_dir, project_dir, runtime);
-                    }
-                }
-            }
-            // Arrays are transparent: items share the pattern position.
-            ConfigValueKind::Array(items) => {
-                for item in items {
-                    walk(item, active, ext_dir, project_dir, runtime);
-                }
-            }
-            _ => {}
-        }
-    }
-
-    fn rebase_leaves(
-        value: &mut ConfigValue,
-        ext_dir: &Path,
-        project_dir: &Path,
-        runtime: &dyn SystemRuntime,
-    ) {
-        match &mut value.value {
-            ConfigValueKind::Map(entries) => {
-                for entry in entries {
-                    rebase_leaves(&mut entry.value, ext_dir, project_dir, runtime);
-                }
-            }
-            ConfigValueKind::Array(items) => {
-                for item in items {
-                    rebase_leaves(item, ext_dir, project_dir, runtime);
-                }
-            }
-            ConfigValueKind::Scalar(yaml_rust2::Yaml::String(s)) | ConfigValueKind::Path(s) => {
-                if let Some(rebased) = rebase_candidate(s, ext_dir, project_dir, runtime) {
-                    value.value = ConfigValueKind::Path(rebased);
-                }
-            }
-            _ => {}
-        }
-    }
-
-    walk(
-        fragment,
-        FRAGMENT_PATH_PATTERNS,
-        ext_dir,
-        project_dir,
-        runtime,
-    );
+    });
 }
 
 /// Decide whether `s` names a file bundled with the extension, and if
@@ -791,14 +738,10 @@ fn rebase_candidate(
     project_dir: &Path,
     runtime: &dyn SystemRuntime,
 ) -> Option<String> {
-    if quarto_util::is_rooted(Path::new(s)) || s.starts_with("http://") || s.starts_with("https://")
-    {
+    if !crate::extension::paths::bundled_file_exists(s, ext_dir, runtime) {
         return None;
     }
     let abs = ext_dir.join(s);
-    if !runtime.path_exists(&abs, None).unwrap_or(false) {
-        return None;
-    }
     let rebased = match pathdiff::diff_paths(&abs, project_dir) {
         Some(rel)
             if !matches!(

--- a/crates/quarto-core/src/stage/stages/compile_theme_css.rs
+++ b/crates/quarto-core/src/stage/stages/compile_theme_css.rs
@@ -36,7 +36,8 @@ use quarto_config::resolve_website_value;
 use quarto_pandoc_types::ConfigValue;
 use quarto_sass::{CSS_BUILD_ID, SassLayer, ThemeConfig, ThemeContext, compile_default_css};
 use quarto_system_runtime::{
-    SASS_CACHE_BUDGET_BYTES, SystemRuntime, cache_get_lru, cache_set_lru, ensure_namespace_version,
+    PathKind, SASS_CACHE_BUDGET_BYTES, SystemRuntime, cache_get_lru, cache_set_lru,
+    ensure_namespace_version,
 };
 
 use crate::artifact::{Artifact, ArtifactScope};
@@ -368,21 +369,10 @@ impl PipelineStage for CompileThemeCssStage {
         let theme_config = match ThemeConfig::from_config_value(&doc.ast.meta) {
             Ok(c) => c,
             Err(e) => {
-                // The error's source span can point at either the
-                // project's _quarto.yml (most common) OR the
-                // document's own frontmatter (when the document
-                // overrides `theme:`). Hand the converter both
-                // candidates with their FileId bindings:
-                // - _quarto.yml uses the YAML parser's hash-based
-                //   FileId (via `quarto_yaml::file_id_for_filename`).
-                // - The document uses pampa's primary FileId(0).
-                let mut candidates: Vec<(quarto_source_map::FileId, &std::path::Path)> = Vec::new();
-                if let Some(p) = ctx.project.config.config_path.as_deref() {
-                    let fid = quarto_yaml::file_id_for_filename(&p.to_string_lossy());
-                    candidates.push((fid, p));
-                }
-                candidates.push((quarto_source_map::FileId(0), ctx.document.input.as_path()));
-                let pe = crate::theme_diagnostic::sass_error_to_parse_error(&e, &candidates);
+                let pe = crate::theme_diagnostic::sass_error_to_parse_error(
+                    &e,
+                    &theme_error_candidates(ctx),
+                );
                 return Err(PipelineError::Structured(pe));
             }
         };
@@ -522,6 +512,37 @@ impl PipelineStage for CompileThemeCssStage {
             theme_context = theme_context.with_brand(brand, brand_dir);
         }
 
+        // Up-front validation: every custom theme entry must resolve
+        // to a real file (bd-of20unsb). Before this check, a dangling
+        // entry surfaced only as a compile failure swallowed by the
+        // DEFAULT_CSS fallback below — silently dropping the *entire*
+        // theme list, valid entries included. A dangling entry is a
+        // user-facing configuration error, so it gets the same
+        // structured hard-error treatment as the `from_config_value`
+        // path above: Q-14-4, with a span at the offending `theme:`
+        // entry.
+        for (i, spec) in theme_config.themes.iter().enumerate() {
+            let Some(path) = spec.as_custom() else {
+                continue;
+            };
+            let resolved_path = theme_context.resolve_path(path);
+            let exists = ctx
+                .runtime
+                .path_exists(&resolved_path, Some(PathKind::File))
+                .unwrap_or(false);
+            if !exists {
+                let err = quarto_sass::SassError::CustomThemeNotFound {
+                    path: resolved_path,
+                    location: theme_config.theme_locations.get(i).cloned().flatten(),
+                };
+                let pe = crate::theme_diagnostic::sass_error_to_parse_error(
+                    &err,
+                    &theme_error_candidates(ctx),
+                );
+                return Err(PipelineError::Structured(pe));
+            }
+        }
+
         let key = match cache_key(
             &theme_config,
             &theme_context,
@@ -598,6 +619,27 @@ impl PipelineStage for CompileThemeCssStage {
 
         Ok(PipelineData::DocumentAst(doc))
     }
+}
+
+/// FileId candidates for rendering a theme-config diagnostic's source
+/// span. The offending `theme:` value can live in either the project's
+/// `_quarto.yml` (most common) or the document's own frontmatter (when
+/// the document overrides `theme:`); the two use different FileId
+/// schemes:
+///
+/// - `_quarto.yml` uses the YAML parser's hash-based FileId (via
+///   `quarto_yaml::file_id_for_filename`).
+/// - The document uses pampa's primary `FileId(0)`.
+fn theme_error_candidates(
+    ctx: &StageContext,
+) -> Vec<(quarto_source_map::FileId, &std::path::Path)> {
+    let mut candidates: Vec<(quarto_source_map::FileId, &std::path::Path)> = Vec::new();
+    if let Some(p) = ctx.project.config.config_path.as_deref() {
+        let fid = quarto_yaml::file_id_for_filename(&p.to_string_lossy());
+        candidates.push((fid, p));
+    }
+    candidates.push((quarto_source_map::FileId(0), ctx.document.input.as_path()));
+    candidates
 }
 
 /// Length of the theme fingerprint hex prefix used in artifact
@@ -1591,10 +1633,7 @@ mod tests {
         ThemeConfig {
             themes: vec![spec],
             minified,
-            suppress_bootstrap: false,
-            title_block_layer: true,
-            brand_ref: None,
-            dark_theme_ignored: None,
+            ..ThemeConfig::default_bootstrap()
         }
     }
 
@@ -1602,10 +1641,7 @@ mod tests {
         ThemeConfig {
             themes: vec![ThemeSpec::Custom(PathBuf::from(path))],
             minified,
-            suppress_bootstrap: false,
-            title_block_layer: true,
-            brand_ref: None,
-            dark_theme_ignored: None,
+            ..ThemeConfig::default_bootstrap()
         }
     }
 

--- a/crates/quarto-core/src/theme_diagnostic.rs
+++ b/crates/quarto-core/src/theme_diagnostic.rs
@@ -101,6 +101,23 @@ pub fn sass_error_to_parse_error(
             }
             b.build()
         }
+        SassError::CustomThemeNotFound { path, location } => {
+            let mut b = DiagnosticMessageBuilder::error("Theme file not found")
+                .with_code("Q-14-4")
+                .problem(format!(
+                    "the `theme:` entry resolves to `{}`, which does not exist.",
+                    path.display()
+                ))
+                .add_hint(
+                    "Check the spelling and location of the file. Relative theme paths \
+                     resolve against the document's directory; extension-bundled themes \
+                     must sit next to the extension's `_extension.yml`?",
+                );
+            if let Some(loc) = location {
+                b = b.with_location(loc.clone());
+            }
+            b.build()
+        }
         // Fallback for SassError variants we haven't migrated yet.
         // Returning *something* structured is better than the legacy
         // plain `e.to_string()` form — no code is assigned because
@@ -121,6 +138,7 @@ fn sass_error_location(err: &SassError) -> Option<quarto_source_map::SourceInfo>
     match err {
         SassError::InvalidThemeConfig { location, .. } => location.clone(),
         SassError::UnknownTheme { location, .. } => location.clone(),
+        SassError::CustomThemeNotFound { location, .. } => location.clone(),
         _ => None,
     }
 }
@@ -277,7 +295,7 @@ mod tests {
         // Q-14-3 (dark-theme-variant-ignored warning, bd-o76p01wb) is
         // emitted by CompileThemeCssStage rather than this converter,
         // but it lives in the same subsystem and must be registered.
-        for code in ["Q-14-1", "Q-14-2", "Q-14-3"] {
+        for code in ["Q-14-1", "Q-14-2", "Q-14-3", "Q-14-4"] {
             let info = quarto_error_catalog::ERROR_CATALOG.get(code);
             assert!(
                 info.is_some(),
@@ -365,6 +383,78 @@ mod tests {
         let parse_err = sass_error_to_parse_error(&err, &[(FileId(0), Path::new("/nonexistent"))]);
         let d = &parse_err.diagnostics[0];
         assert_eq!(d.code.as_deref(), Some("Q-14-2"));
+        assert_eq!(d.location, None);
+    }
+
+    #[test]
+    fn custom_theme_not_found_renders_with_q144_code_and_span() {
+        // Parallel to unknown_theme_renders_with_q142_code_and_span,
+        // but for the CustomThemeNotFound variant (bd-of20unsb): a
+        // `theme:` entry naming a `.scss` file that resolves to no
+        // file must lift into a Q-14-4 ariadne diagnostic pointing at
+        // the offending entry, and its problem text must name the
+        // resolved path.
+        let temp = TempDir::new().unwrap();
+        let root = temp.path().canonicalize().unwrap();
+        let yaml_path = root.join("doc.qmd");
+        let contents = "---\nformat:\n  html:\n    theme: [cosmo, nope.scss]\n---\n";
+        std::fs::write(&yaml_path, contents).unwrap();
+
+        let entry_start = contents.find("nope.scss").unwrap();
+        let entry_end = entry_start + "nope.scss".len();
+        let location = SourceInfo::Original {
+            file_id: file_id_for(&yaml_path),
+            start_offset: entry_start,
+            end_offset: entry_end,
+        };
+
+        let err = SassError::CustomThemeNotFound {
+            path: root.join("nope.scss"),
+            location: Some(location.clone()),
+        };
+
+        let parse_err = sass_error_to_parse_error(&err, &[(file_id_for(&yaml_path), &yaml_path)]);
+        assert_eq!(parse_err.diagnostics.len(), 1);
+        let d = &parse_err.diagnostics[0];
+        assert_eq!(d.code.as_deref(), Some("Q-14-4"));
+        assert!(
+            d.title.contains("Theme file not found"),
+            "title was: {}",
+            d.title,
+        );
+        assert_eq!(d.location.as_ref(), Some(&location));
+
+        let opts = quarto_error_reporting::TextRenderOptions {
+            enable_hyperlinks: false,
+        };
+        let rendered = d.to_text_with_options(Some(&parse_err.source_context), &opts);
+        assert!(
+            rendered.contains("Q-14-4"),
+            "rendered output missing code Q-14-4:\n{}",
+            rendered,
+        );
+        assert!(
+            rendered.contains("nope.scss"),
+            "rendered output missing resolved path:\n{}",
+            rendered,
+        );
+        let stripped = strip_ansi(&rendered);
+        assert!(
+            stripped.contains("4 \u{2502}"),
+            "rendered output missing line marker for the `theme:` line:\n{}",
+            stripped,
+        );
+    }
+
+    #[test]
+    fn custom_theme_not_found_without_location_renders_span_less() {
+        let err = SassError::CustomThemeNotFound {
+            path: std::path::PathBuf::from("/somewhere/nope.scss"),
+            location: None,
+        };
+        let parse_err = sass_error_to_parse_error(&err, &[(FileId(0), Path::new("/nonexistent"))]);
+        let d = &parse_err.diagnostics[0];
+        assert_eq!(d.code.as_deref(), Some("Q-14-4"));
         assert_eq!(d.location, None);
     }
 }

--- a/crates/quarto-error-catalog/error_catalog.json
+++ b/crates/quarto-error-catalog/error_catalog.json
@@ -1091,6 +1091,13 @@
     "docs_url": "https://quarto.org/docs/errors/theme/Q-14-3",
     "since_version": "99.9.9"
   },
+  "Q-14-4": {
+    "subsystem": "theme",
+    "title": "Theme file not found",
+    "message_template": "A `theme:` entry names a `.scss`/`.css` file that does not exist at its resolved location. Relative theme paths resolve against the document's directory; extension-bundled themes must sit next to the extension's `_extension.yml`. Check the spelling and location of the file.",
+    "docs_url": "https://quarto.org/docs/errors/theme/Q-14-4",
+    "since_version": "99.9.9"
+  },
   "Q-15-1": {
     "subsystem": "crossref",
     "title": "Duplicate Crossref Identifier",

--- a/crates/quarto-sass/src/config.rs
+++ b/crates/quarto-sass/src/config.rs
@@ -60,6 +60,18 @@ pub struct ThemeConfig {
     /// Empty means use default Bootstrap theme (no Bootswatch customization).
     pub themes: Vec<ThemeSpec>,
 
+    /// Source location of each entry in `themes`, parallel by index
+    /// (`theme_locations[i]` locates `themes[i]`; consumers should
+    /// index with `.get(i)` rather than assume equal length).
+    ///
+    /// Populated by [`ThemeConfig::from_config_value`] from the YAML
+    /// values; `None` for entries without a source (programmatic
+    /// construction, the auto-injected `brand` token). Kept as a
+    /// parallel field — rather than inside [`ThemeSpec`] — so the
+    /// spec stays a pure value type ([`Eq`], [`std::fmt::Display`],
+    /// cache-key identity) unpolluted by provenance (bd-of20unsb).
+    pub theme_locations: Vec<Option<SourceInfo>>,
+
     /// Whether to produce minified CSS.
     ///
     /// Defaults to `true` for consistency with TypeScript Quarto.
@@ -125,8 +137,10 @@ pub struct ResolvedThemeConfig {
 impl ThemeConfig {
     /// Create a new ThemeConfig with the given themes.
     pub fn new(themes: Vec<ThemeSpec>, minified: bool) -> Self {
+        let theme_locations = vec![None; themes.len()];
         Self {
             themes,
+            theme_locations,
             minified,
             suppress_bootstrap: false,
             title_block_layer: true,
@@ -142,6 +156,7 @@ impl ThemeConfig {
     pub fn default_bootstrap() -> Self {
         Self {
             themes: Vec::new(),
+            theme_locations: Vec::new(),
             minified: true,
             suppress_bootstrap: false,
             title_block_layer: true,
@@ -235,6 +250,7 @@ impl ThemeConfig {
                 // Auto-inject brand at the end of the theme list.
                 result.brand_ref = Some(br);
                 result.themes.push(ThemeSpec::Brand);
+                result.theme_locations.push(None);
             }
             (Some(br), true) => {
                 // Token already present at user-specified position.
@@ -269,6 +285,7 @@ impl ThemeConfig {
             // `theme: none` sentinel: suppress Bootstrap entirely.
             return Ok(Self {
                 themes: Vec::new(),
+                theme_locations: Vec::new(),
                 minified: true,
                 suppress_bootstrap: true,
                 title_block_layer: true,
@@ -276,9 +293,14 @@ impl ThemeConfig {
                 dark_theme_ignored: None,
             });
         }
-        let themes = extract_theme_specs(value)?;
+        let located = extract_theme_specs(value)?;
+        let (themes, theme_locations) = located
+            .into_iter()
+            .map(|(spec, loc)| (spec, Some(loc)))
+            .unzip();
         Ok(Self {
             themes,
+            theme_locations,
             minified: true,
             suppress_bootstrap: false,
             title_block_layer: true,
@@ -386,6 +408,7 @@ pub fn resolve_brand(
     // Reuse ThemeConfig's brand resolution (path/inline → typed Brand).
     let resolved = ThemeConfig {
         themes: Vec::new(),
+        theme_locations: Vec::new(),
         minified: true,
         suppress_bootstrap: false,
         title_block_layer: true,
@@ -630,11 +653,11 @@ fn light_dark_pair(value: &ConfigValue) -> Option<LightDarkPair<'_>> {
 /// frontmatter may arrive as PandocInlines (parsed as markdown by pampa),
 /// while values from `_quarto.yml` / `_metadata.yml` arrive as Scalar strings.
 /// Both are handled transparently.
-fn extract_theme_specs(value: &ConfigValue) -> Result<Vec<ThemeSpec>, SassError> {
+fn extract_theme_specs(value: &ConfigValue) -> Result<Vec<(ThemeSpec, SourceInfo)>, SassError> {
     // Handle string value (single theme) — covers both Scalar and PandocInlines
     if let Some(s) = config_value_as_text(value) {
         let spec = ThemeSpec::parse(&s).map_err(|e| e.with_location(value.source_info.clone()))?;
-        return Ok(vec![spec]);
+        return Ok(vec![(spec, value.source_info.clone())]);
     }
 
     // Handle array value (multiple themes)
@@ -642,9 +665,10 @@ fn extract_theme_specs(value: &ConfigValue) -> Result<Vec<ThemeSpec>, SassError>
         let mut specs = Vec::with_capacity(items.len());
         for item in items {
             if let Some(s) = config_value_as_text(item) {
-                specs.push(
+                specs.push((
                     ThemeSpec::parse(&s).map_err(|e| e.with_location(item.source_info.clone()))?,
-                );
+                    item.source_info.clone(),
+                ));
             } else {
                 return Err(SassError::InvalidThemeConfig {
                     message: "theme array must contain only strings".to_string(),

--- a/crates/quarto-sass/src/error.rs
+++ b/crates/quarto-sass/src/error.rs
@@ -37,9 +37,17 @@ pub enum SassError {
     #[error("Theme file not found: {0}")]
     ThemeNotFound(String),
 
-    /// Custom theme file not found on filesystem
+    /// Custom theme file not found on filesystem.
+    ///
+    /// `location` is the SourceInfo of the theme entry that named the
+    /// file, when the caller has it (up-front validation in
+    /// quarto-core's compile stage); `None` from the lower-level
+    /// loader, which only knows the resolved path.
     #[error("Custom theme file not found: {path}")]
-    CustomThemeNotFound { path: PathBuf },
+    CustomThemeNotFound {
+        path: PathBuf,
+        location: Option<SourceInfo>,
+    },
 
     /// Custom SCSS file doesn't have layer boundary markers
     #[error("Custom SCSS file doesn't have layer boundary markers: {path}")]
@@ -84,6 +92,7 @@ impl SassError {
         match &mut self {
             SassError::UnknownTheme { location, .. }
             | SassError::InvalidThemeConfig { location, .. }
+            | SassError::CustomThemeNotFound { location, .. }
                 if location.is_none() =>
             {
                 *location = Some(loc);

--- a/crates/quarto-sass/src/themes.rs
+++ b/crates/quarto-sass/src/themes.rs
@@ -586,6 +586,7 @@ pub fn load_custom_theme(
     if !exists {
         return Err(SassError::CustomThemeNotFound {
             path: resolved_path,
+            location: None,
         });
     }
 
@@ -1109,7 +1110,7 @@ mod tests {
 
         assert!(result.is_err());
         match result {
-            Err(SassError::CustomThemeNotFound { path }) => {
+            Err(SassError::CustomThemeNotFound { path, .. }) => {
                 assert!(path.ends_with("missing.scss"));
             }
             _ => panic!("Expected CustomThemeNotFound error"),

--- a/crates/quarto/tests/integration/main.rs
+++ b/crates/quarto/tests/integration/main.rs
@@ -15,6 +15,7 @@ pub mod render_scripts_cli;
 pub mod revealjs_cli;
 pub mod smoke_all;
 pub mod strict_mode;
+pub mod theme_missing_file;
 pub mod trace_cli;
 pub mod unknown_project_type;
 pub mod use_brand;

--- a/crates/quarto/tests/integration/theme_missing_file.rs
+++ b/crates/quarto/tests/integration/theme_missing_file.rs
@@ -3,11 +3,11 @@
  * Copyright (c) 2026 Posit, PBC
  *
  * End-to-end CLI tests for the missing-custom-theme hard error
- * (bd-of20unsb, Q-14-3).
+ * (bd-of20unsb, Q-14-4).
  */
 
 //! A `theme:` entry naming a `.scss`/`.css` file that resolves to no
-//! file must fail the render with a structured Q-14-3 diagnostic.
+//! file must fail the render with a structured Q-14-4 diagnostic.
 //!
 //! Before the fix, `compile_theme_css` swallowed
 //! `SassError::CustomThemeNotFound` into a trace-level warning and
@@ -41,9 +41,9 @@ fn run_q2_render(cwd: &Path, args: &[&str]) -> std::process::Output {
 }
 
 /// The core contract: a dangling custom-theme entry fails the render
-/// with Q-14-3 instead of silently shipping DEFAULT_CSS.
+/// with Q-14-4 instead of silently shipping DEFAULT_CSS.
 #[test]
-fn missing_custom_theme_fails_with_q_14_3() {
+fn missing_custom_theme_fails_with_q_14_4() {
     let temp = TempDir::new().unwrap();
     let dir = temp.path();
     write_file(
@@ -59,8 +59,8 @@ fn missing_custom_theme_fails_with_q_14_3() {
         "missing custom theme must exit non-zero; stderr:\n{stderr}"
     );
     assert!(
-        stderr.contains("Q-14-3"),
-        "expected the Q-14-3 diagnostic on stderr; got:\n{stderr}"
+        stderr.contains("Q-14-4"),
+        "expected the Q-14-4 diagnostic on stderr; got:\n{stderr}"
     );
     assert!(
         stderr.contains("nope.scss"),

--- a/crates/quarto/tests/integration/theme_missing_file.rs
+++ b/crates/quarto/tests/integration/theme_missing_file.rs
@@ -1,0 +1,104 @@
+/*
+ * tests/integration/theme_missing_file.rs
+ * Copyright (c) 2026 Posit, PBC
+ *
+ * End-to-end CLI tests for the missing-custom-theme hard error
+ * (bd-of20unsb, Q-14-3).
+ */
+
+//! A `theme:` entry naming a `.scss`/`.css` file that resolves to no
+//! file must fail the render with a structured Q-14-3 diagnostic.
+//!
+//! Before the fix, `compile_theme_css` swallowed
+//! `SassError::CustomThemeNotFound` into a trace-level warning and
+//! shipped the static `DEFAULT_CSS` — dropping the *entire* theme
+//! list (including valid built-in entries) with exit code 0 and no
+//! user-visible message.
+//!
+//! TDD note: written before the fix; the failure mode observed on
+//! the unfixed tree is exit 0 with a 7 KB default `styles.css`.
+
+use std::path::Path;
+use std::process::Command;
+
+use tempfile::TempDir;
+
+const Q2_BIN: &str = env!("CARGO_BIN_EXE_q2");
+
+fn write_file(path: &Path, contents: &str) {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(path, contents).unwrap();
+}
+
+fn run_q2_render(cwd: &Path, args: &[&str]) -> std::process::Output {
+    let mut cmd = Command::new(Q2_BIN);
+    cmd.current_dir(cwd);
+    cmd.arg("render");
+    cmd.args(args);
+    cmd.output().expect("spawn q2 binary")
+}
+
+/// The core contract: a dangling custom-theme entry fails the render
+/// with Q-14-3 instead of silently shipping DEFAULT_CSS.
+#[test]
+fn missing_custom_theme_fails_with_q_14_3() {
+    let temp = TempDir::new().unwrap();
+    let dir = temp.path();
+    write_file(
+        &dir.join("doc.qmd"),
+        "---\ntitle: Missing theme\nformat:\n  html:\n    theme: [cosmo, nope.scss]\n---\n\nBody.\n",
+    );
+
+    let output = run_q2_render(dir, &["doc.qmd"]);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !output.status.success(),
+        "missing custom theme must exit non-zero; stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("Q-14-3"),
+        "expected the Q-14-3 diagnostic on stderr; got:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("nope.scss"),
+        "diagnostic must name the offending theme entry; got:\n{stderr}"
+    );
+    assert!(
+        !dir.join("doc.html").exists(),
+        "no HTML output must be written when the theme fails to resolve"
+    );
+}
+
+/// Control: the same shape with the file present renders fine — the
+/// validation must not reject resolvable custom themes or built-in
+/// names.
+#[test]
+fn present_custom_theme_still_renders() {
+    let temp = TempDir::new().unwrap();
+    let dir = temp.path();
+    write_file(
+        &dir.join("doc.qmd"),
+        "---\ntitle: Present theme\nformat:\n  html:\n    theme: [cosmo, real.scss]\n---\n\nBody.\n",
+    );
+    write_file(
+        &dir.join("real.scss"),
+        "/*-- scss:rules --*/\n.real-marker { color: #0a1b2c; }\n",
+    );
+
+    let output = run_q2_render(dir, &["doc.qmd"]);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "resolvable theme list must render; stderr:\n{stderr}"
+    );
+    let css = std::fs::read_to_string(dir.join("doc_files/styles.css"))
+        .expect("themed render must write doc_files/styles.css");
+    assert!(
+        css.contains("real-marker"),
+        "compiled CSS must contain the custom theme rule"
+    );
+}

--- a/crates/quarto/tests/smoke-all/extensions/format-with-theme/_extensions/fancyfmt/_extension.yml
+++ b/crates/quarto/tests/smoke-all/extensions/format-with-theme/_extensions/fancyfmt/_extension.yml
@@ -1,0 +1,8 @@
+title: Format With Theme Extension
+author: Test
+contributes:
+  formats:
+    html:
+      theme: [cosmo, fmt-theme.scss]
+      css:
+        - fmt-style.css

--- a/crates/quarto/tests/smoke-all/extensions/format-with-theme/_extensions/fancyfmt/fmt-style.css
+++ b/crates/quarto/tests/smoke-all/extensions/format-with-theme/_extensions/fancyfmt/fmt-style.css
@@ -1,0 +1,3 @@
+.fmt-style-marker {
+  border-color: #3d4e5f;
+}

--- a/crates/quarto/tests/smoke-all/extensions/format-with-theme/_extensions/fancyfmt/fmt-theme.scss
+++ b/crates/quarto/tests/smoke-all/extensions/format-with-theme/_extensions/fancyfmt/fmt-theme.scss
@@ -1,0 +1,7 @@
+/*-- scss:defaults --*/
+$fmt-theme-accent: #0a1b2c;
+
+/*-- scss:rules --*/
+.fmt-theme-marker {
+  color: $fmt-theme-accent;
+}

--- a/crates/quarto/tests/smoke-all/extensions/format-with-theme/_quarto.yml
+++ b/crates/quarto/tests/smoke-all/extensions/format-with-theme/_quarto.yml
@@ -1,0 +1,2 @@
+project:
+  type: default

--- a/crates/quarto/tests/smoke-all/extensions/format-with-theme/test.qmd
+++ b/crates/quarto/tests/smoke-all/extensions/format-with-theme/test.qmd
@@ -1,0 +1,22 @@
+---
+title: Format With Theme Test
+format: fancyfmt-html
+_quarto:
+  tests:
+    fancyfmt-html:
+      noErrors: true
+      ensureCssRegexMatches:
+        - ["fmt-theme-marker", "#0a1b2c"]
+      ensureFileRegexMatches:
+        - ["_extensions/fancyfmt/fmt-style\\.css"]
+---
+
+## Format With Theme
+
+A format extension bundling a theme SCSS (`fmt-theme.scss`) and a CSS
+file (`fmt-style.css`) next to its `_extension.yml`. The compiled CSS
+must contain the bundled theme's rule (rebased ext-dir → doc-dir,
+bd-of20unsb), and the rendered HTML must link the bundled CSS at its
+rebased path.
+
+A [span]{.fmt-theme-marker} using the theme rule.

--- a/docs/errors/theme/Q-14-3.qmd
+++ b/docs/errors/theme/Q-14-3.qmd
@@ -1,0 +1,59 @@
+---
+title: "Theme file not found"
+description: "A `theme:` entry names a `.scss` or `.css` file that does not exist at its resolved location."
+code: Q-14-3
+subsystem: theme
+status: stub
+since: "99.9.9"
+categories:
+  - theme
+---
+
+# `Q-14-3` — Theme File Not Found
+
+> A `theme:` entry names a `.scss` or `.css` file that does not
+> exist at its resolved location.
+
+## What this means
+
+A value in `theme:` (under `format.html` or a similar HTML-like
+format) ends in `.scss` or `.css`, so Quarto treats it as a path
+to a custom theme file — but no file exists at the place the path
+resolves to. The error message shows the fully resolved path
+Quarto looked at, and the render stops rather than shipping CSS
+that silently omits the theme.
+
+Relative theme paths resolve against the **document's**
+directory. Themes bundled with an extension (declared in the
+extension's `contributes.formats`) must sit next to the
+extension's `_extension.yml`; Quarto then rebases them
+automatically.
+
+## Why this happens
+
+Common causes:
+
+- **A typo in the file name**, or the file was moved or renamed
+  without updating `theme:`.
+- **A path written relative to the wrong base** — e.g. relative
+  to the project root for a document living in a subdirectory.
+  Check the resolved path in the error message to see where
+  Quarto actually looked.
+- **An extension manifest referencing a file the extension does
+  not ship** — the `theme:` entry in `contributes.formats` names
+  a file that is missing from the extension directory.
+
+## How to fix
+
+- Fix the spelling, or move the file to the resolved location
+  shown in the message.
+- For documents in subdirectories, write the path relative to the
+  document (or use a project-level `theme:` in `_quarto.yml`,
+  which Quarto rebases per document automatically).
+- For extensions, ship the file next to `_extension.yml` so the
+  bundled-file resolution picks it up.
+
+## Related
+
+- `Q-14-2` — unknown theme name: the value has no `.scss`/`.css`
+  extension and is not a built-in theme name either.

--- a/docs/errors/theme/Q-14-4.qmd
+++ b/docs/errors/theme/Q-14-4.qmd
@@ -1,7 +1,7 @@
 ---
 title: "Theme file not found"
 description: "A `theme:` entry names a `.scss` or `.css` file that does not exist at its resolved location."
-code: Q-14-3
+code: Q-14-4
 subsystem: theme
 status: stub
 since: "99.9.9"
@@ -9,7 +9,7 @@ categories:
   - theme
 ---
 
-# `Q-14-3` — Theme File Not Found
+# `Q-14-4` — Theme File Not Found
 
 > A `theme:` entry names a `.scss` or `.css` file that does not
 > exist at its resolved location.
@@ -57,3 +57,5 @@ Common causes:
 
 - `Q-14-2` — unknown theme name: the value has no `.scss`/`.css`
   extension and is not a built-in theme name either.
+- `Q-14-3` — dark theme variant not yet supported: the
+  `light:`/`dark:` map form renders only the `light:` half.

--- a/docs/guides/authoring/extensions.qmd
+++ b/docs/guides/authoring/extensions.qmd
@@ -93,7 +93,7 @@ Quarto's standard configuration merging applies, uniformly:
 
 Files the extension ships next to its manifest — SCSS themes, CSS, header includes, favicons, logos, scripts — are referenced with paths relative to the extension directory, as in the example above. Quarto resolves them automatically; your project does not need to spell out `_extensions/acme/fancy-docs/theme.scss`.
 
-The same resolution applies to format contributions (`contributes: formats:`): a format extension can bundle theme SCSS, CSS, or header includes next to its manifest and reference them by bare name. A `theme:` entry that names a `.scss`/`.css` file Quarto cannot find — bundled or otherwise — fails the render with [Q-14-3](../../errors/theme/Q-14-3.qmd).
+The same resolution applies to format contributions (`contributes: formats:`): a format extension can bundle theme SCSS, CSS, or header includes next to its manifest and reference them by bare name. A `theme:` entry that names a `.scss`/`.css` file Quarto cannot find — bundled or otherwise — fails the render with [Q-14-4](../../errors/theme/Q-14-4.qmd).
 
 ### Errors you might see
 

--- a/docs/guides/authoring/extensions.qmd
+++ b/docs/guides/authoring/extensions.qmd
@@ -93,6 +93,8 @@ Quarto's standard configuration merging applies, uniformly:
 
 Files the extension ships next to its manifest — SCSS themes, CSS, header includes, favicons, logos, scripts — are referenced with paths relative to the extension directory, as in the example above. Quarto resolves them automatically; your project does not need to spell out `_extensions/acme/fancy-docs/theme.scss`.
 
+The same resolution applies to format contributions (`contributes: formats:`): a format extension can bundle theme SCSS, CSS, or header includes next to its manifest and reference them by bare name. A `theme:` entry that names a `.scss`/`.css` file Quarto cannot find — bundled or otherwise — fails the render with [Q-14-3](../../errors/theme/Q-14-3.qmd).
+
 ### Errors you might see
 
 - **Unknown project type (Q-5-17)**: `project.type` is neither built-in nor provided by any extension in `_extensions/`. The message lists the project-type extensions that were found — check for typos, and check whether the extension failed to load.


### PR DESCRIPTION
Fixes bd-of20unsb: a format extension declaring `contributes.formats.html.theme: [cosmo, fmt-theme.scss]` with the SCSS bundled next to `_extension.yml` silently dropped the theme — the bundled file never reached the compiled CSS and no diagnostic fired. Investigation showed the failure is worse than filed: one dangling entry failed the whole SCSS compile, which fell back to the 7 KB static `DEFAULT_CSS`, dropping **every** theme entry (valid `cosmo` included) with exit 0 and only a trace-level warning invisible even with `-v`.

## What this does

**Half A — existence-driven Path marking (`84f88c9f`-equiv, Phase 1).** At extension read time, string leaves under `theme` / `css` / `include-in-header` / `include-before-body` / `include-after-body` / `format-resources` in `contributes.formats` are flipped `Scalar → Path` iff the string names a file that exists under the extension dir. The per-document metadata merge already rebases `Path`-kind values ext-dir → doc-dir, so marking alone makes bundled theme SCSS compile and bundled `css:` files link at their rebased paths. The pattern walk + bundled-file existence check are extracted to a shared `extension/paths.rs`, and the `contributes.project` fragment rebase (bd-ad7i1pc6 Phase 4) is refactored onto the same walker so the two key tables cannot drift. Legacy unconditional keys (`template`/`template-partials`/`shortcodes`/filters) are deliberately unchanged: they're always paths semantically, and an existence check there would turn a clear missing-file error into silent doc-dir fallback.

**Half B — Q-14-4 hard error (Phase 2).** Custom theme entries are validated up front in `CompileThemeCssStage` (before cache-key work): an entry that resolves to no file now fails the render with a structured ariadne diagnostic pinned at the offending `theme:` entry, naming the fully resolved path. Locations ride on a new `ThemeConfig.theme_locations` parallel field (kept out of `ThemeSpec` so the spec stays a pure value type for Eq/Display/cache-key identity). The `DEFAULT_CSS` fallback survives only for internal compiler failures. `InvalidScssFile`'s silent fallback is scoped out to bd-qmpygp02.

**Docs.** New `docs/errors/theme/Q-14-4.qmd` + a bundled-files paragraph for format extensions in the extensions guide (site rendered with q2, 189/189).

Note: this shipped locally as Q-14-3, but PR #475 (light/dark theme maps) merged first and took that code for its dark-variant warning — everything here is renumbered to **Q-14-4**, and the rebase was semantic (`from_config_value` was restructured by #475; `theme_locations` now flows through `from_theme_value`, so light-half entries carry locations too).

## Verification

- TDD throughout: Phase 0 commit lands 7 read-side unit tests, the `extensions/format-with-theme` smoke-all fixture, and CLI tests — all verified failing on the unfixed tree first (the fixture also proved `css:` links were dropped entirely).
- Full workspace suite green post-rebase: 11,146 passed.
- Full `cargo xtask verify` (incl. WASM leg) passed pre-rebase; the post-rebase WASM leg rides on CI here.
- E2E through the real binary: the repro fixture (`claude-notes/plans/format-ext-theme-rebase-investigation/repro/`) went from 7 KB fallback CSS with 0 marker hits to 321 KB compiled CSS containing the bundled rule; `theme: [cosmo, nope.scss]` exits 1 with Q-14-4 pinned at `nope.scss:5:20`.

Plan: `claude-notes/plans/2026-08-08-format-ext-theme-rebase.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
