### PR TITLE
Preserve declared contents: order in listings; Q1-parity sort semantics (bd-listing-declared-order-3ixcvc4o)

### DIFF
--- a/claude-notes/plans/2026-08-09-listing-declared-order.md
+++ b/claude-notes/plans/2026-08-09-listing-declared-order.md
@@ -234,13 +234,19 @@ listings.
 
   Output inspected: bravo (declared first) now renders first. Pre-fix
   output (recorded above in "Repro at HEAD") had alpha first.
-- [ ] Sweep existing listing snapshots/fixtures for ordering churn; report
+- [x] Sweep existing listing snapshots/fixtures for ordering churn: full
+  workspace suite green means no snapshot beyond the 3 reported above was
+  affected; `cargo xtask lint` clean
 - [x] docs: no listings guide exists yet (bd-2nb6i1qv's scope — the new
   semantics belong in that guide when it's written). Updated
   `docs/errors/listing/Q-12-3.qmd` for the changed warning semantics
   (booleans accepted, `true` = default sort, warning only when no item
   defines the field, `listing-item: extra:` custom-field sorting).
-- [ ] `braid` bookkeeping: comment + close after user sign-off
+- [x] Full `cargo xtask verify` (Rust + WASM + hub-client legs): all
+  steps passed (2026-08-09)
+- [ ] `braid` bookkeeping: progress comment left (c-kj2wdi8p); close after
+  user sign-off
+- [ ] Push (awaiting user approval) → PR
 
 ## Design decisions (user, 2026-08-09)
 

--- a/claude-notes/plans/2026-08-09-listing-declared-order.md
+++ b/claude-notes/plans/2026-08-09-listing-declared-order.md
@@ -141,7 +141,24 @@ Skeleton only — actual phase contents wait on the design discussion.
 - **Phase 4 — Docs.** Note contents-order semantics in the listings docs
   (overlaps bd-2nb6i1qv, the listings-guide docs strand).
 
-## Open design questions for the user
+## Design decisions (user, 2026-08-09)
+
+1. **Ordering rule scope:** first-matching-pattern index for **all** patterns
+   (literal and wildcard alike), Q1-style. ✅ decided
+2. **Tie-break churn under sorts:** accepted — stable sorts over
+   first-pattern order; snapshot churn from ties only. ✅ decided
+3. **Default-sort parity:** default **can change** to Q1's
+   (`order asc, title asc`), provided the old behavior stays configurable.
+   *Pending clarification:* is per-listing `sort: date desc` (already works)
+   sufficient, or is a project-level default-sort knob wanted?
+4. **Q-12-3 shape:** *pending* — user asked to see the message
+   ("Unknown sort field `X`; values will compare as equal."); recommendation
+   on the table is any-item suppression (skip warning when at least one
+   item's `extra` has the field).
+5. **Description-preview regression fixture:** minimal repro is enough; no
+   connect-docs fixture. ✅ decided
+
+## Open design questions for the user (original)
 
 1. **Ordering rule scope.** Order by first-matching-pattern index for *all*
    patterns (literal and wildcard alike — this is exactly Q1's rule), or only

--- a/claude-notes/plans/2026-08-09-listing-declared-order.md
+++ b/claude-notes/plans/2026-08-09-listing-declared-order.md
@@ -1,0 +1,182 @@
+# Listings lose declared order of explicit `contents:` entries (bd-listing-declared-order-3ixcvc4o)
+
+**Date:** 2026-08-09
+**Braid:** bd-listing-declared-order-3ixcvc4o (origin: `br-listing-declared-order-qodof0f6` in the connect-docs porting skein)
+**Checkout:** main worktree (`/Users/cscheid/rooms/room-1/q2`, branch `main`)
+**Status:** Investigation — pending design alignment with user. **Do not start implementation until the user gives the go-ahead.**
+
+## Triage verdict
+
+**Ready to design.** The mechanism is fully understood, Q1's target semantics are pinned from source, the fix site is localized to `ListingGenerateTransform`'s item-collection loop, and a minimal repro exists (copied into `listing-declared-order-investigation/repro/`). A handful of scope questions below need answers before implementation.
+
+## Issue context
+
+P1 bug, filed 2026-08-09 (today) by Carlos, label `listings`. A listing whose
+`contents:` is a list of explicit paths renders items in project-index order
+(effectively path-alphabetical) regardless of declaration order, even with
+`sort: false`. Q1 preserves declared order; all 15 Posit Connect cookbook
+listing pages rely on it ("Getting Started" renders 4th instead of 1st).
+Second-order effect: post-render description previews extracted from
+listing-only section pages pick up the wrong first item.
+
+Related quirk to fix in the same pass: sorting by a `listing-item.extra`
+custom field *works* (`sort.rs::field_value` falls through to the extra map)
+but `is_known_sort_field` doesn't know extra fields, so a working
+custom-field sort emits a misleading Q-12-3 "values will compare as equal"
+warning.
+
+## Dependency graph
+
+**Empty** — no edges in the q2 skein. The strand was filed today from external
+repro work (connect-docs porting), so the "why" lives in its description and in
+the origin repro, not in graph context. There is an open **Listings feature
+epic (bd-61cd)** this strand is *not* linked to; linking it (`parent-child` or
+`related`) is cheap incidental hygiene — see incidental work below.
+
+## What the code looks like today
+
+All paths in the description exist at HEAD and the mechanism is confirmed by
+reading source:
+
+1. **Resolution** (`crates/quarto-core/src/project/listing/glob_resolve.rs`):
+   `contents:` entries become `GlobPattern`s via the shared
+   `crate::glob::resolve_patterns`. Order of the *patterns* is preserved in
+   `GlobResolution.globs`.
+2. **Matching** (`crates/quarto-core/src/transforms/listing_generate.rs`
+   ~lines 162–173): items are collected by iterating
+   `ctx.project_index.profiles()` (Pass-1 insertion order — project input
+   enumeration order) and testing each candidate against the compiled
+   `PatternSet::matches`. **This is where declaration order is lost**: the
+   loop is candidate-major, so item order = index order, never pattern order.
+3. **Sort** (`crates/quarto-core/src/project/listing/config.rs::parse_sort` +
+   `sort.rs::apply_sort`): `sort: false` → `Some(vec![])` → `apply_sort`
+   returns immediately (correct no-op), so the index order leaks through.
+
+Precedent already in-tree: `PatternSet::excluded` (`glob/matcher.rs` ~line
+171) exists precisely so `project.render` can walk its positive patterns in
+the author's listed order while keeping exclusions global. The listing fix
+can follow the same shape.
+
+Bonus per-pattern machinery already present: the Q-12-19 "matched nothing"
+diagnostic loop (`listing_generate.rs` ~lines 180–200) already compiles each
+positive pattern individually — first-matching-pattern-index computation can
+reuse (or share hoisted compiles with) that loop.
+
+### Q1 target semantics (pinned from `external-sources/quarto-cli`)
+
+- `src/core/path.ts::filterPaths`/`resolvePathGlobs`: **glob-major
+  iteration** — for each glob in declared order, append its matching files;
+  `ld.uniq` dedups keeping *first* occurrence. Net effect: items ordered by
+  first-matching-pattern index; within one pattern, candidate-set order.
+- `website-listing-read.ts::computeListingSort`: `sort: false` → `[]` (no
+  sorting, contents order preserved); `sort: true`/absent → `undefined` →
+  default sort.
+- **Q1's default sort is NOT date-desc**: when `sort:` is absent, title is a
+  hydrated field, and sources include document items, Q1 applies
+  `[{field: "order", asc}, {field: "title", asc}]` (`website-listing-read.ts`
+  ~line 637). `order` is a front-matter field (`kFieldOrder`) authors use for
+  curated ordering. q2's `listing_generate.rs` ~line 207 applies **date
+  desc** with a comment claiming it "Matches Q1 default" — that claim looks
+  wrong against current Q1 source. Scope question below.
+- q2's `is_known_sort_field` also doesn't include `order` (nor does
+  `hydrate_item` obviously surface it other than via `extra`).
+
+### Repro at HEAD (end-to-end, confirmed)
+
+Minimal repro copied to
+`claude-notes/plans/listing-declared-order-investigation/repro/` (declares
+`contents: [./bravo/index.md, ./alpha/index.md]` with `sort: false`).
+Rendered with the HEAD binary (2026-08-09, `main` @ 2f2f4be3, v0.14.0):
+
+```
+$ cd claude-notes/plans/listing-declared-order-investigation/repro
+$ cargo run --quiet --bin q2 -- render .
+Rendering project: .../repro (type: website)
+Rendered 3 of 3 files to .../repro/_site
+$ grep -n -o 'alpha/\|bravo/' _site/index.html
+36:alpha/
+39:alpha/
+45:bravo/
+48:bravo/
+```
+
+Output inspected: Alpha renders before Bravo despite the declared
+bravo-first order — **bug confirmed at HEAD**. (`_site/` is gitignored in
+the repro dir; regenerate with the command above.)
+
+### Pre-flight verify note
+
+`cargo xtask verify --skip-hub-build` at HEAD failed on one test:
+`quarto-hub::integration admin_collect_lifecycle::collect_reverification_skips_rereferenced_candidate`
+(assertion diff `2xPD…` vs `2XPD…` — a single case-flip in a doc id). This
+is the known macOS case-insensitive-filesystem flake tracked as
+**bd-eb2wnxkp** (this worktree's other in-flight strand; plan
+`claude-notes/plans/2026-07-28-doc-id-identity-from-paths.md` awaiting
+review). All 9,697 other tests that ran passed; the failure is unrelated to
+listings.
+
+## Proposed phases (draft)
+
+Skeleton only — actual phase contents wait on the design discussion.
+
+- **Phase 0 — Test plan (TDD).**
+  - Failing integration test: explicit two-entry `contents:` with
+    `sort: false` renders in declared order (drive through the listing
+    pipeline test harness in `tests/integration/listing_pipeline.rs`, plus
+    an end-to-end `q2 render` check on the repro fixture).
+  - Failing test: mixed literal + glob `contents:` orders by
+    first-matching-pattern index.
+  - Failing test: a working `extra`-field sort emits no Q-12-3.
+- **Phase 1 — Order-preserving item collection.** In
+  `ListingGenerateTransform`: order collected items by index of first
+  matching positive pattern (hoist per-pattern compiles, shared with the
+  Q-12-19 loop); negations stay global via `PatternSet::excluded`-style
+  logic. Stable within a pattern (keep index order).
+- **Phase 2 — Q-12-3 false positive.** Only warn on unknown sort fields when
+  the field is also absent from every item's `extra` map (or equivalent
+  design per user answer to Q4).
+- **Phase 3 — (scope-dependent) default-sort parity.** If Q3 below says yes:
+  align q2's absent-`sort:` default with Q1 (`order asc, title asc` vs
+  current `date desc`), or file as a separate strand.
+- **Phase 4 — Docs.** Note contents-order semantics in the listings docs
+  (overlaps bd-2nb6i1qv, the listings-guide docs strand).
+
+## Open design questions for the user
+
+1. **Ordering rule scope.** Order by first-matching-pattern index for *all*
+   patterns (literal and wildcard alike — this is exactly Q1's rule), or only
+   when every entry is a literal path? Recommendation: all patterns,
+   Q1-style; it's simpler and strictly more compatible.
+2. **Does the fix change ordering under an explicit sort or the default
+   sort?** With a stable sort applied afterwards, first-pattern order becomes
+   the tie-break order (Q1 gets the same effect for free). Any snapshot
+   churn would come from ties only. OK to accept that?
+3. **Default-sort parity.** q2's absent-`sort:` default is `date desc`,
+   commented as "Matches Q1 default", but current Q1 source applies
+   `order asc, title asc`. Fix here, file separately, or leave (perhaps q2
+   deliberately chose date-desc as the saner blog default)? This also decides
+   whether `order` should join `is_known_sort_field` / hydrated fields.
+4. **Q-12-3 fix shape.** Suppress the warning when *any* item's `extra` has
+   the field? When *all* items have it? Or downgrade the message to mention
+   the extra-field fallback? (Any-item suppression is the least chatty and
+   matches "the sort visibly works".)
+5. **Second-order description-preview effect.** The strand notes listing-only
+   section pages get wrong first-item previews. That should fall out of the
+   ordering fix automatically — is there a connect-docs page worth adding as
+   a regression fixture, or is the minimal repro enough?
+
+## Risks / tradeoffs (draft)
+
+- **Snapshot churn**: any existing listing snapshot whose item order depended
+  on index order under `sort: false` (or on tie order under sorts) may
+  change. Expected small; must be called out per snapshot policy.
+- **Per-pattern matching cost**: first-match-index needs per-pattern
+  `PatternSet`s; the Q-12-19 loop already pays this per listing, so hoisting
+  the compiles is likely a net wash or a win.
+- **Default-sort parity (Q3)** is behavior-visible for every listing without
+  an explicit `sort:` — riskier than the core fix; that's why it's split
+  into its own phase / possibly its own strand.
+- `ProjectDependencyGraph::build` also consumes `resolve_content_globs` —
+  the ordering fix must live in the *consumer* (listing generate), not in
+  shared glob resolution, to avoid perturbing the dependency-graph edge set
+  or other glob consumers (`project.render`, `resources:`, `sidebar.auto:`).

--- a/claude-notes/plans/2026-08-09-listing-declared-order.md
+++ b/claude-notes/plans/2026-08-09-listing-declared-order.md
@@ -148,28 +148,39 @@ listings.
 
 ## Work items
 
-### Phase 0 — Tests (TDD: write first, verify failures)
+### Phase 0 — Tests (TDD: write first, verify failures) — DONE 2026-08-09
 
-- [ ] `sort: false` + explicit two-entry `contents:` preserves declared
-  order (unit, `listing_generate.rs` harness)
-- [ ] Mixed literal + glob `contents:` orders by first-matching-pattern
-  index; within a glob, index order (unit)
-- [ ] Item matching multiple patterns counts for its **first** pattern only
-  (dedup / no duplicate items) (unit)
-- [ ] Q-12-19 still fires for a pattern whose only matches were claimed by
-  an earlier pattern? — NO: it must NOT fire (every matching pattern gets
-  credit); regression test (unit)
-- [ ] `sort: true` behaves like absent `sort:` (default sort) (unit)
-- [ ] Default sort (absent `sort:`) is `order asc, title asc` — items with
-  `order:` first (numeric asc), missing-order items after, title asc
-  tie-break (unit)
-- [ ] Table listings get the same default sort (unit)
-- [ ] Explicit `sort: date desc` still works (existing test keeps passing)
-- [ ] `sort: order` works as an explicit known field (unit, sort.rs)
-- [ ] Working `extra`-field sort emits **no** Q-12-3 (unit)
-- [ ] Typo'd sort field (no item has it) still emits Q-12-3 (unit)
-- [ ] End-to-end: repro fixture renders bravo-then-alpha
-  (smoke-all fixture or integration test + manual `q2 render` verification)
+- [x] `sort: false` + explicit two-entry `contents:` preserves declared
+  order (unit, `listing_generate.rs` harness) — fails as expected
+- [x] Mixed literal + glob `contents:` orders by first-matching-pattern
+  index; within a glob, index order (unit) — fails as expected
+- [x] Item matching multiple patterns counts for its **first** pattern only
+  (dedup / no duplicate items) (unit) — fails as expected
+- [x] Q-12-19 must NOT fire when a pattern's matches were claimed by an
+  earlier pattern (regression guard — passes today, pins semantics for the
+  reimplementation)
+- [x] `sort: true` behaves like absent `sort:` (default sort) (unit) —
+  fails as expected
+- [x] Default sort (absent `sort:`) is `order asc, title asc` (unit) —
+  fails as expected (fixture made date-discriminating after a first
+  version passed coincidentally; see missing-desc bug below)
+- [x] Table listings get the same default sort (unit) — fails as expected
+- [x] Explicit `sort: date desc` still works (existing tests unchanged)
+- [ ] `sort: order` works as an explicit known field (unit, sort.rs) —
+  deferred to Phase 2: needs `ListingItem.order` to exist to compile
+- [x] Working `extra`-field sort emits **no** Q-12-3 (unit) — fails as
+  expected
+- [x] Typo'd sort field (no item has it) still emits Q-12-3 (existing test
+  unchanged)
+- [x] End-to-end: `listing_pipeline::declared_contents_order_preserved_with_sort_false`
+  + updated `default_listing_renders_three_posts_in_default_order` — both
+  fail as expected
+- [x] **Discovered latent bug** (found because the first default-sort test
+  fixture passed coincidentally): `compare_items` applies the `Desc` flip
+  to the *whole* comparison, so missing-value items float to the TOP of
+  desc sorts — contradicting `compare_values`' documented "missing sorts
+  last regardless of direction" rule. Pinned by failing test
+  `missing_dates_sort_to_end_in_desc_too`; fix folded into Phase 2.
 
 ### Phase 1 — Order-preserving item collection
 

--- a/claude-notes/plans/2026-08-09-listing-declared-order.md
+++ b/claude-notes/plans/2026-08-09-listing-declared-order.md
@@ -149,12 +149,15 @@ Skeleton only — actual phase contents wait on the design discussion.
    first-pattern order; snapshot churn from ties only. ✅ decided
 3. **Default-sort parity:** default **can change** to Q1's
    (`order asc, title asc`), provided the old behavior stays configurable.
-   *Pending clarification:* is per-listing `sort: date desc` (already works)
-   sufficient, or is a project-level default-sort knob wanted?
-4. **Q-12-3 shape:** *pending* — user asked to see the message
-   ("Unknown sort field `X`; values will compare as equal."); recommendation
-   on the table is any-item suppression (skip warning when at least one
-   item's `extra` has the field).
+   **Working assumption** (flagged to user, overridable): per-listing
+   `sort: date desc` — which already works — satisfies "configurable"; no
+   new project-level default-sort knob in this pass. Consequence: `order`
+   joins `is_known_sort_field` and sorts via the front-matter `order` field
+   (through `extra` or hydrated explicitly).
+4. **Q-12-3 shape:** any-item suppression — "we only want the warning if
+   there's no information that can be used to determine an appropriate
+   sort." I.e. skip the warning when at least one item has a value for the
+   field (built-in or `extra`); keep it when no item does. ✅ decided
 5. **Description-preview regression fixture:** minimal repro is enough; no
    connect-docs fixture. ✅ decided
 

--- a/claude-notes/plans/2026-08-09-listing-declared-order.md
+++ b/claude-notes/plans/2026-08-09-listing-declared-order.md
@@ -115,31 +115,94 @@ is the known macOS case-insensitive-filesystem flake tracked as
 review). All 9,697 other tests that ran passed; the failure is unrelated to
 listings.
 
-## Proposed phases (draft)
+## Implementation notes (pre-work investigation, 2026-08-09)
 
-Skeleton only — actual phase contents wait on the design discussion.
+- `DocumentProfile` **already extracts top-level `order:`** front matter
+  (`order: Option<i32>`, `document_profile.rs:699`) — no profile_version
+  bump needed; only `hydrate_item`/`ListingItem`/`field_value` must surface
+  it.
+- Q1's default-sort condition (`hydratedFields.includes(title)` + document
+  sources) is satisfied by **all** built-in types — `kDefaultTableFields`
+  includes title — so the Q1-parity default `order asc, title asc` applies
+  uniformly, replacing both q2's `date desc` default *and* the table-type
+  "no default sort" special case.
+- Q1 `computeListingSort`: `sort: true` → default sort (same as absent).
+  q2's `parse_sort` currently sends `Boolean(true)` through
+  `as_plain_text`, which would produce a bogus `true` sort field —
+  fold the `sort: true` fix into this pass (parse_sort → `Option<Vec<_>>`,
+  `None` = use default).
+- Q-12-3 stays scoped to **unknown** fields only (per-user rule "warn only
+  when no information can determine a sort"): warn iff the field is not
+  built-in AND no item's `field_value` yields a value. Not extended to
+  built-in fields with all-absent values, because the internally-generated
+  default sort (`order asc`) would then warn on every listing whose items
+  lack `order:`.
+- Ordering fix lives in the **consumer** (`ListingGenerateTransform`), not
+  in shared glob resolution: track, per candidate, the index of the first
+  matching positive pattern (candidates iterate positive `PatternSet`s
+  individually, exclusions stay global), then stable-sort collected items
+  by that index. The per-positive compiles replace the Q-12-19 loop's
+  existing per-pattern recompiles (track `matched_any` per pattern —
+  every matching pattern gets credit, not just the first, preserving
+  current Q-12-19 semantics).
 
-- **Phase 0 — Test plan (TDD).**
-  - Failing integration test: explicit two-entry `contents:` with
-    `sort: false` renders in declared order (drive through the listing
-    pipeline test harness in `tests/integration/listing_pipeline.rs`, plus
-    an end-to-end `q2 render` check on the repro fixture).
-  - Failing test: mixed literal + glob `contents:` orders by
-    first-matching-pattern index.
-  - Failing test: a working `extra`-field sort emits no Q-12-3.
-- **Phase 1 — Order-preserving item collection.** In
-  `ListingGenerateTransform`: order collected items by index of first
-  matching positive pattern (hoist per-pattern compiles, shared with the
-  Q-12-19 loop); negations stay global via `PatternSet::excluded`-style
-  logic. Stable within a pattern (keep index order).
-- **Phase 2 — Q-12-3 false positive.** Only warn on unknown sort fields when
-  the field is also absent from every item's `extra` map (or equivalent
-  design per user answer to Q4).
-- **Phase 3 — (scope-dependent) default-sort parity.** If Q3 below says yes:
-  align q2's absent-`sort:` default with Q1 (`order asc, title asc` vs
-  current `date desc`), or file as a separate strand.
-- **Phase 4 — Docs.** Note contents-order semantics in the listings docs
-  (overlaps bd-2nb6i1qv, the listings-guide docs strand).
+## Work items
+
+### Phase 0 — Tests (TDD: write first, verify failures)
+
+- [ ] `sort: false` + explicit two-entry `contents:` preserves declared
+  order (unit, `listing_generate.rs` harness)
+- [ ] Mixed literal + glob `contents:` orders by first-matching-pattern
+  index; within a glob, index order (unit)
+- [ ] Item matching multiple patterns counts for its **first** pattern only
+  (dedup / no duplicate items) (unit)
+- [ ] Q-12-19 still fires for a pattern whose only matches were claimed by
+  an earlier pattern? — NO: it must NOT fire (every matching pattern gets
+  credit); regression test (unit)
+- [ ] `sort: true` behaves like absent `sort:` (default sort) (unit)
+- [ ] Default sort (absent `sort:`) is `order asc, title asc` — items with
+  `order:` first (numeric asc), missing-order items after, title asc
+  tie-break (unit)
+- [ ] Table listings get the same default sort (unit)
+- [ ] Explicit `sort: date desc` still works (existing test keeps passing)
+- [ ] `sort: order` works as an explicit known field (unit, sort.rs)
+- [ ] Working `extra`-field sort emits **no** Q-12-3 (unit)
+- [ ] Typo'd sort field (no item has it) still emits Q-12-3 (unit)
+- [ ] End-to-end: repro fixture renders bravo-then-alpha
+  (smoke-all fixture or integration test + manual `q2 render` verification)
+
+### Phase 1 — Order-preserving item collection
+
+- [ ] `listing_generate.rs`: per-positive-pattern `PatternSet`s hoisted;
+  candidate loop records first-match index + per-pattern `matched_any`
+- [ ] Stable-sort collected items by first-match pattern index
+- [ ] Q-12-19 loop consumes `matched_any` (drop per-item recompiles)
+- [ ] Phase-0 ordering tests pass; full workspace suite green
+
+### Phase 2 — Sort semantics
+
+- [ ] `parse_sort` → `Option<Vec<ListingSort>>` (`true`/absent → `None`,
+  `false` → `Some([])`); config plumbing updated
+- [ ] `ListingItem.order: Option<i32>` hydrated from `profile.order`;
+  exposed in template binding (`order` key) for Q1-compatible templates
+- [ ] `field_value("order")` → item.order (extra fallback preserved);
+  `order` added to `is_known_sort_field`
+- [ ] Default sort → `[order asc, title asc]`, all listing types (replaces
+  date-desc + table special case); update `default_sort_is_date_desc_*`
+  test per decision Q3
+- [ ] Q-12-3: warn only when field is unknown AND no item has a value
+  (`apply_sort` gains access to items — it already has them)
+- [ ] Full workspace suite green; snapshot changes reported per policy
+
+### Phase 3 — End-to-end verification + docs
+
+- [ ] `q2 render` on the committed repro fixture: bravo before alpha in
+  `_site/index.html`; output inspected and recorded in this plan
+- [ ] Sweep existing listing snapshots/fixtures for ordering churn; report
+- [ ] docs/ listings page: document declared-order semantics, `order:`
+  front matter, default sort, `sort: false`/`true` (coordinate with
+  bd-2nb6i1qv scope — keep this entry minimal)
+- [ ] `braid` bookkeeping: comment + close after user sign-off
 
 ## Design decisions (user, 2026-08-09)
 

--- a/claude-notes/plans/2026-08-09-listing-declared-order.md
+++ b/claude-notes/plans/2026-08-09-listing-declared-order.md
@@ -182,37 +182,64 @@ listings.
   last regardless of direction" rule. Pinned by failing test
   `missing_dates_sort_to_end_in_desc_too`; fix folded into Phase 2.
 
-### Phase 1 — Order-preserving item collection
+### Phase 1 — Order-preserving item collection — DONE 2026-08-09
 
-- [ ] `listing_generate.rs`: per-positive-pattern `PatternSet`s hoisted;
+- [x] `listing_generate.rs`: per-positive-pattern `PatternSet`s hoisted;
   candidate loop records first-match index + per-pattern `matched_any`
-- [ ] Stable-sort collected items by first-match pattern index
-- [ ] Q-12-19 loop consumes `matched_any` (drop per-item recompiles)
-- [ ] Phase-0 ordering tests pass; full workspace suite green
+- [x] Stable-sort collected items by first-match pattern index
+- [x] Q-12-19 loop consumes `matched_any` (drop per-item recompiles)
+- [x] Phase-0 ordering tests pass (4/4)
 
-### Phase 2 — Sort semantics
+### Phase 2 — Sort semantics — DONE 2026-08-09
 
-- [ ] `parse_sort` → `Option<Vec<ListingSort>>` (`true`/absent → `None`,
-  `false` → `Some([])`); config plumbing updated
-- [ ] `ListingItem.order: Option<i32>` hydrated from `profile.order`;
-  exposed in template binding (`order` key) for Q1-compatible templates
-- [ ] `field_value("order")` → item.order (extra fallback preserved);
-  `order` added to `is_known_sort_field`
-- [ ] Default sort → `[order asc, title asc]`, all listing types (replaces
-  date-desc + table special case); update `default_sort_is_date_desc_*`
-  test per decision Q3
-- [ ] Q-12-3: warn only when field is unknown AND no item has a value
-  (`apply_sort` gains access to items — it already has them)
-- [ ] Full workspace suite green; snapshot changes reported per policy
+- [x] `parse_sort` → `Option<Vec<ListingSort>>` (`true` → `None` = use
+  default, `false` → `Some([])` = no sorting); caller updated; malformed
+  message now says "or a boolean"; config tests 8b/8c added
+- [x] `ListingItem.order: Option<i32>` hydrated from `profile.order`;
+  exposed in template binding as `order`; 11 test-helper struct literals
+  updated mechanically
+- [x] `field_value("order")` → item.order (numeric via natural_compare);
+  `order` added to `is_known_sort_field`; unit test added (the deferred
+  Phase-0 item)
+- [x] Default sort → `[order asc, title asc]`, all listing types (replaces
+  date-desc + the table no-default special case)
+- [x] Q-12-3: warn only when the field is unknown AND no item has a value
+- [x] Missing-value desc fix: direction flip now applies only to the
+  value-to-value comparison; missing sorts last in both directions
+- [x] All 351 quarto-core listing tests green
+- [x] **Snapshot changes: 3 files** —
+  `integration__listing_pipeline__snapshot_builtin_default_with_categories_{default,cloud,unnumbered}_mode.snap`.
+  Cause: default-sort change; each diff is exactly the first and third
+  items swapping (old date-desc Third/Second/First → new title-asc
+  First/Second/Third) plus insta refreshing a stale `source:` header path
+  from the pre-`tests/integration/` layout. No markup changes.
+- [x] Full workspace suite green: 11,166 tests run, 11,166 passed
+  (2026-08-09; includes the quarto-hub suite — the bd-eb2wnxkp macOS
+  flake did not fire this run)
 
 ### Phase 3 — End-to-end verification + docs
 
-- [ ] `q2 render` on the committed repro fixture: bravo before alpha in
-  `_site/index.html`; output inspected and recorded in this plan
+- [x] `q2 render` on the committed repro fixture, post-fix (2026-08-09):
+
+  ```
+  $ cd claude-notes/plans/listing-declared-order-investigation/repro
+  $ rm -rf _site && cargo run --quiet --bin q2 -- render .
+  Rendered 3 of 3 files to .../repro/_site
+  $ grep -n -o 'alpha/\|bravo/' _site/index.html
+  36:bravo/
+  39:bravo/
+  45:alpha/
+  48:alpha/
+  ```
+
+  Output inspected: bravo (declared first) now renders first. Pre-fix
+  output (recorded above in "Repro at HEAD") had alpha first.
 - [ ] Sweep existing listing snapshots/fixtures for ordering churn; report
-- [ ] docs/ listings page: document declared-order semantics, `order:`
-  front matter, default sort, `sort: false`/`true` (coordinate with
-  bd-2nb6i1qv scope — keep this entry minimal)
+- [x] docs: no listings guide exists yet (bd-2nb6i1qv's scope — the new
+  semantics belong in that guide when it's written). Updated
+  `docs/errors/listing/Q-12-3.qmd` for the changed warning semantics
+  (booleans accepted, `true` = default sort, warning only when no item
+  defines the field, `listing-item: extra:` custom-field sorting).
 - [ ] `braid` bookkeeping: comment + close after user sign-off
 
 ## Design decisions (user, 2026-08-09)

--- a/claude-notes/plans/listing-declared-order-investigation/repro/.gitignore
+++ b/claude-notes/plans/listing-declared-order-investigation/repro/.gitignore
@@ -1,0 +1,2 @@
+_site/
+.quarto/

--- a/claude-notes/plans/listing-declared-order-investigation/repro/README.md
+++ b/claude-notes/plans/listing-declared-order-investigation/repro/README.md
@@ -1,0 +1,45 @@
+# q2 listings lose the declared order of explicit `contents:` entries
+
+**Observed with:** q2 0.14.0
+**Repro:** `q2 render` in this directory.
+
+## Expected (Quarto 1)
+
+With `sort: false` (or no sort), a listing whose `contents:` is a list
+of explicit paths preserves the declared order. The Connect cookbook
+relies on this: `cookbook/index.qmd` lists Getting Started first, and
+Q1 renders it first (see `docs-quarto-1/_site/cookbook/index.html`).
+
+## Actual (q2)
+
+`index.md` declares `contents: [./bravo/index.md, ./alpha/index.md]`
+but the listing renders Alpha before Bravo — items come out in
+path-alphabetical order regardless of declaration order.
+
+## Root cause area
+
+`contents:` entries are translated to glob patterns and resolved
+set-based through the shared glob engine
+(`crates/quarto-core/src/project/listing/glob_resolve.rs` →
+`crate::glob::resolve_patterns`, single-view matching), which loses
+per-pattern declaration order. `apply_sort` with `sort: false` is a
+no-op (correct), so the glob engine's ordering leaks through.
+
+A fix likely needs the resolution to remember which pattern matched
+each file (first-match wins) and order the item set by pattern index,
+Q1-style, at least when patterns are literal paths.
+
+## Downstream effect in the Connect docs
+
+All 15 cookbook listings (now `type: custom`) have curated `contents:`
+orders; q2 renders them alphabetized. Also second-order: the listing
+auto-description previews extracted from listing-only section pages
+pick up the wrong first item.
+
+## Related quirk (noting, not the bug)
+
+`sort:` by a custom field works via `listing-item: extra:` front
+matter (`sort.rs::field_value` falls through to `extra`), but
+`is_known_sort_field` doesn't know about extra fields, so a *working*
+custom-field sort still emits a misleading Q-12-3 "values will compare
+as equal" warning.

--- a/claude-notes/plans/listing-declared-order-investigation/repro/_quarto.yml
+++ b/claude-notes/plans/listing-declared-order-investigation/repro/_quarto.yml
@@ -1,0 +1,4 @@
+project:
+  type: website
+  render:
+    - "**/*.md"

--- a/claude-notes/plans/listing-declared-order-investigation/repro/alpha/index.md
+++ b/claude-notes/plans/listing-declared-order-investigation/repro/alpha/index.md
@@ -1,0 +1,5 @@
+---
+title: Alpha page
+---
+
+Alpha body.

--- a/claude-notes/plans/listing-declared-order-investigation/repro/bravo/index.md
+++ b/claude-notes/plans/listing-declared-order-investigation/repro/bravo/index.md
@@ -1,0 +1,5 @@
+---
+title: Bravo page
+---
+
+Bravo body.

--- a/claude-notes/plans/listing-declared-order-investigation/repro/index.md
+++ b/claude-notes/plans/listing-declared-order-investigation/repro/index.md
@@ -1,0 +1,13 @@
+---
+title: Repro
+listing:
+  id: things
+  sort: false
+  type: default
+  contents:
+    - ./bravo/index.md
+    - ./alpha/index.md
+---
+
+::: {#things}
+:::

--- a/crates/quarto-core/src/project/listing/binding.rs
+++ b/crates/quarto-core/src/project/listing/binding.rs
@@ -281,6 +281,9 @@ fn build_item_map(
             TemplateValue::String(n.to_string()),
         );
     }
+    if let Some(n) = item.order {
+        m.insert("order".to_string(), TemplateValue::String(n.to_string()));
+    }
 
     // Path bookkeeping.
     //
@@ -505,6 +508,7 @@ mod tests {
             image_lazy_loading: None,
             reading_time_minutes: Some(5),
             word_count: None,
+            order: None,
             source_path: PathBuf::from("posts/foo.qmd"),
             output_href: "posts/foo.html".to_string(),
             extra: BTreeMap::new(),

--- a/crates/quarto-core/src/project/listing/config.rs
+++ b/crates/quarto-core/src/project/listing/config.rs
@@ -494,7 +494,7 @@ fn parse_one_listing(
                 l.image_placeholder = entry.value.as_plain_text();
             }
             "sort" => {
-                l.sort = Some(parse_sort(&entry.value, diagnostics));
+                l.sort = parse_sort(&entry.value, diagnostics);
             }
             "template" => {
                 template_source = Some(&entry.value);
@@ -750,30 +750,40 @@ fn parse_field_types(
     out
 }
 
-fn parse_sort(value: &ConfigValue, diagnostics: &mut Vec<DiagnosticMessage>) -> Vec<ListingSort> {
-    if let ConfigValueKind::Scalar(Yaml::Boolean(false)) = &value.value {
-        return Vec::new();
+/// Parse the `sort:` value. `None` means "apply the default sort" —
+/// `sort: true` is Q1's explicit spelling of the default, so it
+/// parses the same as an absent key. `Some(vec![])` means sorting is
+/// explicitly disabled (`sort: false`); `Some(keys)` is an author
+/// sort spec.
+fn parse_sort(
+    value: &ConfigValue,
+    diagnostics: &mut Vec<DiagnosticMessage>,
+) -> Option<Vec<ListingSort>> {
+    if let ConfigValueKind::Scalar(Yaml::Boolean(b)) = &value.value {
+        return if *b { None } else { Some(Vec::new()) };
     }
     // String-shaped values (including the routine PandocInlines
     // wrapping of front-matter strings) flatten via `as_plain_text`,
     // mirroring `parse_contents` — see bd-2qjnd / bd-nwyp.
     if let Some(s) = value.as_plain_text() {
-        return vec![parse_one_sort_key(&s)];
+        return Some(vec![parse_one_sort_key(&s)]);
     }
     match &value.value {
-        ConfigValueKind::Array(items) => items
-            .iter()
-            .filter_map(|v| v.as_plain_text())
-            .map(|s| parse_one_sort_key(&s))
-            .collect(),
+        ConfigValueKind::Array(items) => Some(
+            items
+                .iter()
+                .filter_map(|v| v.as_plain_text())
+                .map(|s| parse_one_sort_key(&s))
+                .collect(),
+        ),
         _ => {
             push_diag(
                 diagnostics,
                 "Q-12-3",
-                "`sort:` must be a string, array of strings, or `false`.",
+                "`sort:` must be a string, array of strings, or a boolean.",
                 value,
             );
-            Vec::new()
+            Some(Vec::new())
         }
     }
 }
@@ -1384,6 +1394,25 @@ listing:
         assert_eq!(sort.len(), 1);
         assert_eq!(sort[0].field, "date");
         assert_eq!(sort[0].direction, SortDirection::Asc);
+    }
+
+    // 8b. sort: false → Some([]) — sorting explicitly disabled,
+    // declared contents order preserved downstream.
+    #[test]
+    fn sort_false_parses_to_empty_spec() {
+        let (listings, diags) = parse(map(vec![("sort", b(false))]));
+        assert_eq!(listings[0].sort.as_deref(), Some(&[][..]));
+        assert!(diags.is_empty(), "unexpected diagnostics: {diags:?}");
+    }
+
+    // 8c. sort: true → None — Q1's explicit spelling of "apply the
+    // default sort"; same as an absent key, and NOT a field named
+    // "true".
+    #[test]
+    fn sort_true_parses_like_absent() {
+        let (listings, diags) = parse(map(vec![("sort", b(true))]));
+        assert_eq!(listings[0].sort, None);
+        assert!(diags.is_empty(), "unexpected diagnostics: {diags:?}");
     }
 
     // 9. sort: ["date desc"] → Desc

--- a/crates/quarto-core/src/project/listing/feed/binding.rs
+++ b/crates/quarto-core/src/project/listing/feed/binding.rs
@@ -583,6 +583,7 @@ mod tests {
             image_lazy_loading: None,
             reading_time_minutes: None,
             word_count: None,
+            order: None,
             source_path: PathBuf::new(),
             output_href: String::new(),
             extra: BTreeMap::new(),

--- a/crates/quarto-core/src/project/listing/feed/link_inject.rs
+++ b/crates/quarto-core/src/project/listing/feed/link_inject.rs
@@ -224,6 +224,7 @@ mod tests {
             image_lazy_loading: None,
             reading_time_minutes: None,
             word_count: None,
+            order: None,
             source_path: PathBuf::from(format!("posts/{}.qmd", title)),
             output_href: format!("posts/{}.html", title),
             extra: BTreeMap::new(),

--- a/crates/quarto-core/src/project/listing/feed/stage.rs
+++ b/crates/quarto-core/src/project/listing/feed/stage.rs
@@ -658,6 +658,7 @@ mod tests {
             image_lazy_loading: None,
             reading_time_minutes: None,
             word_count: None,
+            order: None,
             source_path: PathBuf::from(format!("posts/{}.qmd", title)),
             output_href: format!("posts/{}.html", title),
             extra: BTreeMap::new(),

--- a/crates/quarto-core/src/project/listing/filter.rs
+++ b/crates/quarto-core/src/project/listing/filter.rs
@@ -161,6 +161,7 @@ mod tests {
             image_lazy_loading: None,
             reading_time_minutes: None,
             word_count: None,
+            order: None,
             source_path: PathBuf::from("posts/foo.qmd"),
             output_href: "posts/foo.html".to_string(),
             extra: extra_map,

--- a/crates/quarto-core/src/project/listing/helpers.rs
+++ b/crates/quarto-core/src/project/listing/helpers.rs
@@ -272,6 +272,7 @@ mod tests {
             image_lazy_loading: None,
             reading_time_minutes: None,
             word_count: None,
+            order: None,
             source_path: PathBuf::from("posts/foo.qmd"),
             output_href: "posts/foo.html".to_string(),
             extra: BTreeMap::new(),

--- a/crates/quarto-core/src/project/listing/item.rs
+++ b/crates/quarto-core/src/project/listing/item.rs
@@ -39,6 +39,11 @@ pub struct ListingItem {
     pub image_lazy_loading: Option<bool>,
     pub reading_time_minutes: Option<u32>,
     pub word_count: Option<u32>,
+    /// Author-curated position from top-level `order:` front matter
+    /// (via `DocumentProfile::order`). Primary key of the default
+    /// listing sort (`order asc, title asc`, Q1 parity —
+    /// bd-listing-declared-order-3ixcvc4o).
+    pub order: Option<i32>,
     /// Project-relative source path of the input file (forward-slash
     /// separated, matching `DocumentProfile::source_path`).
     pub source_path: PathBuf,
@@ -115,6 +120,7 @@ pub fn hydrate_item(profile: &DocumentProfile) -> ListingItem {
         image_lazy_loading: None,
         reading_time_minutes: li.reading_time_minutes,
         word_count: li.word_count,
+        order: profile.order,
         source_path: profile.source_path.clone(),
         output_href: profile.output_href.clone(),
         extra: li.extra.clone(),

--- a/crates/quarto-core/src/project/listing/sort.rs
+++ b/crates/quarto-core/src/project/listing/sort.rs
@@ -8,10 +8,12 @@
 //! Each [`crate::project::listing::config::ListingSort`] entry has
 //! a field name and a direction; the sort applies entries in
 //! declared order using a stable sort (so ties on the primary key
-//! retain the secondary-key ordering, etc.). Unknown sort fields
-//! are reported via `Q-12-3` and treated as if every item ties
-//! (i.e. no rearrangement) — this matches Q1's tolerant behavior
-//! for typos.
+//! retain the secondary-key ordering, etc.). A sort field that is
+//! neither built-in nor present on any item is reported via
+//! `Q-12-3` and treated as if every item ties (i.e. no
+//! rearrangement) — this matches Q1's tolerant behavior for typos
+//! while staying silent for working custom-field sorts through the
+//! `extra` map (bd-listing-declared-order-3ixcvc4o).
 
 use quarto_error_reporting::{DiagnosticMessage, DiagnosticMessageBuilder};
 use std::cmp::Ordering;
@@ -32,9 +34,17 @@ pub fn apply_sort(
         return;
     }
 
-    // Validate keys once.
+    // Validate keys once. Warn only when the sort has no information
+    // to work with: the field is not built-in AND no item carries a
+    // value for it (custom fields sort via the `extra` fallthrough
+    // in `field_value`, and a field present on only some items still
+    // sorts meaningfully — missing values last).
     for key in sort {
-        if !is_known_sort_field(&key.field) {
+        if !is_known_sort_field(&key.field)
+            && !items
+                .iter()
+                .any(|item| field_value(item, &key.field).is_some())
+        {
             diagnostics.push(
                 DiagnosticMessageBuilder::warning(format!(
                     "Unknown sort field `{}`; values will compare as equal.",
@@ -58,23 +68,22 @@ pub fn apply_sort(
 fn compare_items(a: &ListingItem, b: &ListingItem, key: &ListingSort) -> Ordering {
     let av = field_value(a, &key.field);
     let bv = field_value(b, &key.field);
-    let ord = compare_values(av.as_deref(), bv.as_deref());
-    match key.direction {
-        SortDirection::Asc => ord,
-        SortDirection::Desc => ord.reverse(),
-    }
-}
-
-fn compare_values(a: Option<&str>, b: Option<&str>) -> Ordering {
-    match (a, b) {
+    match (av.as_deref(), bv.as_deref()) {
         // Missing values sort *after* present values regardless of
-        // direction — matches Q1's "absent value at the bottom"
-        // intuition. The Asc/Desc flip in the caller handles
-        // direction; this function defines the canonical order.
+        // direction — the Asc/Desc flip applies only to the
+        // value-to-value comparison below. (Flipping the whole
+        // comparison floated missing-value items to the top of desc
+        // sorts; found during bd-listing-declared-order-3ixcvc4o.)
         (None, None) => Ordering::Equal,
         (None, Some(_)) => Ordering::Greater,
         (Some(_), None) => Ordering::Less,
-        (Some(a), Some(b)) => natural_compare(a, b),
+        (Some(a), Some(b)) => {
+            let ord = natural_compare(a, b);
+            match key.direction {
+                SortDirection::Asc => ord,
+                SortDirection::Desc => ord.reverse(),
+            }
+        }
     }
 }
 
@@ -109,6 +118,7 @@ fn field_value(item: &ListingItem, field: &str) -> Option<String> {
         "output-href" => Some(item.output_href.clone()),
         "reading-time" => item.reading_time_minutes.map(|n| n.to_string()),
         "word-count" => item.word_count.map(|n| n.to_string()),
+        "order" => item.order.map(|n| n.to_string()),
         // Fall through to extra map.
         _ => item.extra.get(field).and_then(|v| v.as_plain_text()),
     }
@@ -130,6 +140,7 @@ fn is_known_sort_field(field: &str) -> bool {
             | "output-href"
             | "reading-time"
             | "word-count"
+            | "order"
     )
 }
 
@@ -155,6 +166,7 @@ mod tests {
             image_lazy_loading: None,
             reading_time_minutes: None,
             word_count: None,
+            order: None,
             source_path: PathBuf::from(format!("posts/{}.qmd", title)),
             output_href: format!("posts/{}.html", title),
             extra: BTreeMap::new(),
@@ -240,6 +252,35 @@ mod tests {
         // order among missing items preserved (stable).
         assert_eq!(items[0].title, "b");
         assert!(items[1].title == "a" || items[1].title == "c");
+    }
+
+    // `order` is a known sort field (Q1's front-matter curation
+    // field, primary key of the default sort) and compares
+    // numerically: 2 < 10; missing order sorts last.
+    #[test]
+    fn sort_by_order_field_is_known_and_numeric() {
+        let with_order = |title: &str, order: Option<i32>| {
+            let mut item = make_item(title, None);
+            item.order = order;
+            item
+        };
+        let mut items = vec![
+            with_order("c", Some(10)),
+            with_order("plain", None),
+            with_order("b", Some(2)),
+            with_order("a", Some(1)),
+        ];
+        let sort = vec![ListingSort {
+            field: "order".to_string(),
+            direction: SortDirection::Asc,
+        }];
+        let mut diags = Vec::new();
+        apply_sort(&mut items, &sort, &mut diags);
+        assert!(diags.is_empty(), "order is a known field; got {:?}", diags);
+        assert_eq!(items[0].title, "a");
+        assert_eq!(items[1].title, "b");
+        assert_eq!(items[2].title, "c");
+        assert_eq!(items[3].title, "plain");
     }
 
     // The documented rule is "missing values sort after present

--- a/crates/quarto-core/src/project/listing/sort.rs
+++ b/crates/quarto-core/src/project/listing/sort.rs
@@ -242,6 +242,31 @@ mod tests {
         assert!(items[1].title == "a" || items[1].title == "c");
     }
 
+    // The documented rule is "missing values sort after present
+    // values regardless of direction" — the Desc flip must apply to
+    // the value comparison only, not to the missing-value rule.
+    // (Latent bug found during bd-listing-declared-order-3ixcvc4o:
+    // the flip was applied to the whole comparison, floating
+    // missing-value items to the top of desc sorts.)
+    #[test]
+    fn missing_dates_sort_to_end_in_desc_too() {
+        let mut items = vec![
+            make_item("a", None),
+            make_item("b", Some("2026-01-01")),
+            make_item("c", None),
+        ];
+        let sort = vec![ListingSort {
+            field: "date".to_string(),
+            direction: SortDirection::Desc,
+        }];
+        let mut diags = Vec::new();
+        apply_sort(&mut items, &sort, &mut diags);
+        assert_eq!(items[0].title, "b");
+        // Stable among the missing-value items.
+        assert_eq!(items[1].title, "a");
+        assert_eq!(items[2].title, "c");
+    }
+
     #[test]
     fn unknown_sort_field_emits_q_12_3() {
         let mut items = vec![make_item("a", None)];
@@ -253,5 +278,67 @@ mod tests {
         apply_sort(&mut items, &sort, &mut diags);
         assert_eq!(diags.len(), 1);
         assert_eq!(diags[0].code.as_deref(), Some("Q-12-3"));
+    }
+
+    fn make_item_with_extra(title: &str, key: &str, value: &str) -> ListingItem {
+        use quarto_pandoc_types::ConfigValue;
+        use quarto_source_map::SourceInfo;
+
+        let mut item = make_item(title, None);
+        item.extra.insert(
+            key.to_string(),
+            ConfigValue::new_string(value, SourceInfo::for_test()),
+        );
+        item
+    }
+
+    // bd-listing-declared-order-3ixcvc4o: a custom-field sort that
+    // works via the `extra` fallthrough must not be diagnosed as an
+    // unknown field — warn only when no item carries a value for it.
+    #[test]
+    fn extra_field_sort_sorts_and_emits_no_q_12_3() {
+        let mut items = vec![
+            make_item_with_extra("b", "difficulty", "2"),
+            make_item_with_extra("c", "difficulty", "10"),
+            make_item_with_extra("a", "difficulty", "1"),
+        ];
+        let sort = vec![ListingSort {
+            field: "difficulty".to_string(),
+            direction: SortDirection::Asc,
+        }];
+        let mut diags = Vec::new();
+        apply_sort(&mut items, &sort, &mut diags);
+        assert!(
+            diags.is_empty(),
+            "working extra-field sort must not warn; got {:?}",
+            diags
+        );
+        // Numeric comparison via natural_compare: 1, 2, 10.
+        assert_eq!(items[0].title, "a");
+        assert_eq!(items[1].title, "b");
+        assert_eq!(items[2].title, "c");
+    }
+
+    // The suppression is any-item: a field present on only SOME items
+    // still sorts meaningfully (missing values last), so no warning.
+    #[test]
+    fn sparse_extra_field_sort_emits_no_q_12_3() {
+        let mut items = vec![
+            make_item("plain", None),
+            make_item_with_extra("tagged", "difficulty", "1"),
+        ];
+        let sort = vec![ListingSort {
+            field: "difficulty".to_string(),
+            direction: SortDirection::Asc,
+        }];
+        let mut diags = Vec::new();
+        apply_sort(&mut items, &sort, &mut diags);
+        assert!(
+            diags.is_empty(),
+            "sparse field must not warn; got {:?}",
+            diags
+        );
+        assert_eq!(items[0].title, "tagged");
+        assert_eq!(items[1].title, "plain");
     }
 }

--- a/crates/quarto-core/src/transforms/categories_sidebar.rs
+++ b/crates/quarto-core/src/transforms/categories_sidebar.rs
@@ -410,6 +410,7 @@ mod tests {
             image_lazy_loading: None,
             reading_time_minutes: None,
             word_count: None,
+            order: None,
             source_path: PathBuf::from(format!("posts/{}.qmd", title)),
             output_href: format!("posts/{}.html", title),
             extra: BTreeMap::new(),

--- a/crates/quarto-core/src/transforms/listing_generate.rs
+++ b/crates/quarto-core/src/transforms/listing_generate.rs
@@ -308,6 +308,21 @@ mod tests {
         p
     }
 
+    fn make_profile_with_order(
+        source: &str,
+        output_href: &str,
+        title: &str,
+        order: i32,
+    ) -> DocumentProfile {
+        let mut p = make_profile(source, output_href, title);
+        p.order = Some(order);
+        p
+    }
+
+    fn titles(resolved: &[ResolvedListing]) -> Vec<&str> {
+        resolved[0].items.iter().map(|i| i.title.as_str()).collect()
+    }
+
     fn make_project(
         host: &str,
         profiles: Vec<DocumentProfile>,
@@ -529,22 +544,174 @@ mod tests {
         assert_eq!(resolved[0].items[1].title, "B");
     }
 
+    // Q1 parity (bd-listing-declared-order-3ixcvc4o): absent `sort:`
+    // applies `order asc, title asc` — NOT date desc. Every item
+    // carries a date, and the dates contradict both the order: values
+    // and the titles, so a date-driven default cannot produce the
+    // expected sequence.
     #[tokio::test]
-    async fn default_sort_is_date_desc_for_default_type() {
+    async fn default_sort_is_order_asc_then_title_asc() {
+        let with_order = |source: &str, href: &str, title: &str, date: &str, order: i32| {
+            let mut p = make_profile_with_date(source, href, title, date);
+            p.order = Some(order);
+            p
+        };
         let (resolved, _) = run_transform(
             map(vec![("listing", s("default"))]),
             "posts/index.qmd",
             vec![
-                make_profile_with_date("posts/a.qmd", "posts/a.html", "A", "2026-01-01"),
-                make_profile_with_date("posts/b.qmd", "posts/b.html", "B", "2026-03-01"),
-                make_profile_with_date("posts/c.qmd", "posts/c.html", "C", "2026-02-01"),
+                make_profile_with_date("posts/a.qmd", "posts/a.html", "Delta", "2026-04-01"),
+                with_order("posts/b.qmd", "posts/b.html", "Zulu", "2026-01-01", 1),
+                make_profile_with_date("posts/c.qmd", "posts/c.html", "Alpha", "2026-02-01"),
+                with_order("posts/d.qmd", "posts/d.html", "Mike", "2026-03-01", 2),
             ],
         )
         .await;
-        // No explicit sort → default = date desc.
-        assert_eq!(resolved[0].items[0].title, "B");
-        assert_eq!(resolved[0].items[1].title, "C");
-        assert_eq!(resolved[0].items[2].title, "A");
+        // order: 1 first, order: 2 second, then order-less items by
+        // title asc (missing order values sort last).
+        assert_eq!(titles(&resolved), ["Zulu", "Mike", "Alpha", "Delta"]);
+    }
+
+    // The default sort is uniform across listing types (Q1 applies it
+    // whenever `title` is among the hydrated fields, which holds for
+    // every built-in type — including table).
+    #[tokio::test]
+    async fn table_type_gets_default_sort_too() {
+        let (resolved, _) = run_transform(
+            map(vec![("listing", map(vec![("type", s("table"))]))]),
+            "posts/index.qmd",
+            vec![
+                make_profile_with_order("posts/a.qmd", "posts/a.html", "Second", 2),
+                make_profile_with_order("posts/b.qmd", "posts/b.html", "First", 1),
+            ],
+        )
+        .await;
+        assert_eq!(titles(&resolved), ["First", "Second"]);
+    }
+
+    // `sort: true` is Q1's "apply the default sort" — identical to an
+    // absent `sort:` key, and NOT a sort by a field named "true".
+    #[tokio::test]
+    async fn sort_true_behaves_like_absent_sort() {
+        let (resolved, diags) = run_transform(
+            map(vec![(
+                "listing",
+                map(vec![("type", s("default")), ("sort", b(true))]),
+            )]),
+            "posts/index.qmd",
+            vec![
+                make_profile_with_order("posts/a.qmd", "posts/a.html", "Second", 2),
+                make_profile_with_order("posts/b.qmd", "posts/b.html", "First", 1),
+            ],
+        )
+        .await;
+        assert!(
+            !diags.iter().any(|d| d.code.as_deref() == Some("Q-12-3")),
+            "sort: true must not diagnose; got {:?}",
+            diags
+        );
+        assert_eq!(titles(&resolved), ["First", "Second"]);
+    }
+
+    // bd-listing-declared-order-3ixcvc4o: with `sort: false`, explicit
+    // `contents:` entries render in declared order (Q1 semantics), not
+    // in project-index order.
+    #[tokio::test]
+    async fn sort_false_preserves_declared_contents_order() {
+        let (resolved, _) = run_transform(
+            map(vec![(
+                "listing",
+                map(vec![
+                    ("type", s("default")),
+                    ("sort", b(false)),
+                    ("contents", arr(vec![s("bravo.qmd"), s("alpha.qmd")])),
+                ]),
+            )]),
+            "index.qmd",
+            vec![
+                // Index order is alphabetical — the opposite of the
+                // declared order — to prove the reordering happens.
+                make_profile("alpha.qmd", "alpha.html", "Alpha"),
+                make_profile("bravo.qmd", "bravo.html", "Bravo"),
+            ],
+        )
+        .await;
+        assert_eq!(titles(&resolved), ["Bravo", "Alpha"]);
+    }
+
+    // Q1's rule generalizes to wildcard patterns: items are ordered by
+    // the index of the first pattern that matches them; within one
+    // pattern, project-index order.
+    #[tokio::test]
+    async fn contents_ordered_by_first_matching_pattern_index() {
+        let (resolved, _) = run_transform(
+            map(vec![(
+                "listing",
+                map(vec![
+                    ("type", s("default")),
+                    ("sort", b(false)),
+                    ("contents", arr(vec![s("z.qmd"), s("a*.qmd")])),
+                ]),
+            )]),
+            "index.qmd",
+            vec![
+                make_profile("a1.qmd", "a1.html", "A1"),
+                make_profile("a2.qmd", "a2.html", "A2"),
+                make_profile("z.qmd", "z.html", "Zed"),
+            ],
+        )
+        .await;
+        assert_eq!(titles(&resolved), ["Zed", "A1", "A2"]);
+    }
+
+    // An item matched by several patterns belongs to the FIRST one and
+    // appears exactly once.
+    #[tokio::test]
+    async fn item_matching_multiple_patterns_appears_once_at_first_pattern() {
+        let (resolved, _) = run_transform(
+            map(vec![(
+                "listing",
+                map(vec![
+                    ("type", s("default")),
+                    ("sort", b(false)),
+                    ("contents", arr(vec![s("b.qmd"), s("*.qmd")])),
+                ]),
+            )]),
+            "index.qmd",
+            vec![
+                make_profile("a.qmd", "a.html", "Aye"),
+                make_profile("b.qmd", "b.html", "Bee"),
+            ],
+        )
+        .await;
+        assert_eq!(titles(&resolved), ["Bee", "Aye"]);
+    }
+
+    // Q-12-19 ("matched nothing") must credit EVERY pattern an item
+    // matches, not just the first-match winner: `b*.qmd`'s only match
+    // is claimed by `b.qmd` for ordering purposes, but it still
+    // matched something.
+    #[tokio::test]
+    async fn q_12_19_silent_when_matches_claimed_by_earlier_pattern() {
+        let (resolved, diags) = run_transform(
+            map(vec![(
+                "listing",
+                map(vec![
+                    ("type", s("default")),
+                    ("sort", b(false)),
+                    ("contents", arr(vec![s("b.qmd"), s("b*.qmd")])),
+                ]),
+            )]),
+            "index.qmd",
+            vec![make_profile("b.qmd", "b.html", "Bee")],
+        )
+        .await;
+        assert_eq!(titles(&resolved), ["Bee"]);
+        assert!(
+            !diags.iter().any(|d| d.code.as_deref() == Some("Q-12-19")),
+            "no matched-nothing diag expected; got {:?}",
+            diags
+        );
     }
 
     #[tokio::test]

--- a/crates/quarto-core/src/transforms/listing_generate.rs
+++ b/crates/quarto-core/src/transforms/listing_generate.rs
@@ -41,7 +41,7 @@ use crate::glob::{GlobOptions, PatternSet, path_to_forward_slashes};
 use crate::project::listing::filter::apply_filters;
 use crate::project::listing::glob_resolve::resolve_content_globs;
 use crate::project::listing::sort::apply_sort;
-use crate::project::listing::{ResolvedListing, hydrate_item, parse_listings};
+use crate::project::listing::{ListingItem, ResolvedListing, hydrate_item, parse_listings};
 use crate::render::RenderContext;
 use crate::transform::{AstTransform, TransformPhase};
 use crate::transforms::is_feature_disabled;
@@ -135,13 +135,28 @@ impl AstTransform for ListingGenerateTransform {
                 );
             }
 
-            // Compile once per listing, then match every candidate.
-            // Resolution already validated these patterns, so the
-            // compile cannot fail; an empty set on the impossible
-            // path simply matches nothing.
+            // Compile the full set once for the global negation
+            // check, and each positive pattern individually: item
+            // collection orders by the FIRST pattern that matches a
+            // candidate (Q1's glob-major semantics,
+            // bd-listing-declared-order-3ixcvc4o), and the Q-12-19
+            // matched-nothing diagnostic credits EVERY pattern a
+            // candidate matches. Resolution already validated these
+            // patterns, so the compiles cannot fail; an empty set on
+            // the impossible path simply matches nothing.
+            let empty_set = || PatternSet::compile(&[], &GlobOptions::LISTING).unwrap();
             let patterns = resolution
                 .compile(&GlobOptions::LISTING)
-                .unwrap_or_else(|_| PatternSet::compile(&[], &GlobOptions::LISTING).unwrap());
+                .unwrap_or_else(|_| empty_set());
+            let positives: Vec<_> = resolution.positives().collect();
+            let positive_sets: Vec<PatternSet> = positives
+                .iter()
+                .map(|(glob, _)| {
+                    PatternSet::compile(std::slice::from_ref(*glob), &GlobOptions::LISTING)
+                        .unwrap_or_else(|_| empty_set())
+                })
+                .collect();
+            let mut matched_any = vec![false; positive_sets.len()];
 
             // Patterns the glob engine rejected (bd-mt7a6uc4).
             // Before, these matched nothing in silence — the same
@@ -159,30 +174,43 @@ impl AstTransform for ListingGenerateTransform {
                 );
             }
 
-            let mut items = Vec::new();
+            // Candidate-major collection, pattern-major order: tag
+            // each item with the index of its first matching
+            // pattern, then stable-sort by that index. Exclusions
+            // stay global — a `!` entry excludes a candidate no
+            // matter where it appears in `contents:`.
+            let mut ordered: Vec<(usize, ListingItem)> = Vec::new();
             if let Some(index) = ctx.project_index.as_deref() {
                 for profile in index.profiles() {
                     let candidate_path_str = path_to_forward_slashes(&profile.source_path);
                     if candidate_path_str == host_path_str {
                         continue;
                     }
-                    if patterns.matches(&candidate_path_str) {
-                        items.push(hydrate_item(profile));
+                    if patterns.excluded(&candidate_path_str) {
+                        continue;
+                    }
+                    let mut first_match: Option<usize> = None;
+                    for (i, set) in positive_sets.iter().enumerate() {
+                        if set.matches(&candidate_path_str) {
+                            matched_any[i] = true;
+                            first_match.get_or_insert(i);
+                        }
+                    }
+                    if let Some(pattern_idx) = first_match {
+                        ordered.push((pattern_idx, hydrate_item(profile)));
                     }
                 }
             }
+            ordered.sort_by_key(|(pattern_idx, _)| *pattern_idx);
+            let mut items: Vec<ListingItem> = ordered.into_iter().map(|(_, item)| item).collect();
 
             // A pattern that compiled, stayed in the project, and
             // still matched no document is almost always a Q1
             // assumption about `*` (D5/D7). Checked before
             // `include:`/`exclude:` filters run, so this reports on
             // the *glob*, not on a filter that emptied the set.
-            for (glob, source) in resolution.positives() {
-                let matched = items.iter().any(|item| {
-                    PatternSet::compile(std::slice::from_ref(glob), &GlobOptions::LISTING)
-                        .is_ok_and(|set| set.matches_path(&item.source_path))
-                });
-                if !matched {
+            for (i, (glob, source)) in positives.iter().enumerate() {
+                if !matched_any[i] {
                     diags.push(
                         crate::glob::diagnostics::matched_nothing(
                             "Q-12-19",
@@ -202,19 +230,30 @@ impl AstTransform for ListingGenerateTransform {
             apply_filters(&mut items, &listing.include, &listing.exclude);
 
             if let Some(sort) = listing.sort.as_ref() {
+                // `sort: false` parses to an empty spec, which
+                // `apply_sort` treats as a no-op — declared
+                // `contents:` order flows through untouched.
                 apply_sort(&mut items, sort, &mut diags);
             } else {
-                // Default sort: date descending. Matches Q1 default
-                // for the `default` and `grid` types; `table` keeps
-                // insertion order unless the author overrides.
-                use crate::project::listing::config::{ListingSort, ListingType, SortDirection};
-                if !matches!(listing.kind, ListingType::Table) {
-                    let default_sort = vec![ListingSort {
-                        field: "date".to_string(),
-                        direction: SortDirection::Desc,
-                    }];
-                    apply_sort(&mut items, &default_sort, &mut diags);
-                }
+                // Default sort (Q1 parity): `order asc, title asc`,
+                // uniformly across listing types — Q1 applies its
+                // default whenever `title` is among the hydrated
+                // fields, which holds for every built-in type
+                // (table included). Items without `order:` sort
+                // after curated ones, in title order
+                // (bd-listing-declared-order-3ixcvc4o).
+                use crate::project::listing::config::{ListingSort, SortDirection};
+                let default_sort = vec![
+                    ListingSort {
+                        field: "order".to_string(),
+                        direction: SortDirection::Asc,
+                    },
+                    ListingSort {
+                        field: "title".to_string(),
+                        direction: SortDirection::Asc,
+                    },
+                ];
+                apply_sort(&mut items, &default_sort, &mut diags);
             }
 
             if let Some(max) = listing.max_items {

--- a/crates/quarto-core/src/transforms/listing_render.rs
+++ b/crates/quarto-core/src/transforms/listing_render.rs
@@ -520,6 +520,7 @@ mod tests {
             image_lazy_loading: None,
             reading_time_minutes: Some(5),
             word_count: None,
+            order: None,
             source_path: PathBuf::from(format!("posts/{}.qmd", title)),
             output_href: format!("posts/{}.html", title),
             extra: BTreeMap::new(),

--- a/crates/quarto-core/tests/integration/listing_pipeline.rs
+++ b/crates/quarto-core/tests/integration/listing_pipeline.rs
@@ -109,9 +109,13 @@ fn html_for<'a>(outputs: &'a [(String, String)], stem: &str) -> &'a str {
 }
 
 /// L3 phase 6 §"e2e CLI verification" — exact-fixture render on
-/// the standard four-file blog setup.
+/// the standard four-file blog setup. Default sort is Q1's
+/// `order asc, title asc` (bd-listing-declared-order-3ixcvc4o):
+/// Third carries `order: 1` so it leads; First and Second have no
+/// `order:` and follow in title-asc order. (Dates are set so the
+/// pre-fix date-desc default would produce a different order.)
 #[test]
-fn default_listing_renders_three_posts_in_date_desc_order() {
+fn default_listing_renders_three_posts_in_default_order() {
     let (_dir, outputs) = render_project(|p| {
         write(
             &p.join("_quarto.yml"),
@@ -131,7 +135,7 @@ fn default_listing_renders_three_posts_in_date_desc_order() {
         );
         write(
             &p.join("posts/c.qmd"),
-            "---\ntitle: Third\ndate: 2026-03-05\nauthor: Carol\ndescription: Third desc.\nformat: html\n---\n\nThird body.\n",
+            "---\ntitle: Third\ndate: 2026-03-05\nauthor: Carol\ndescription: Third desc.\norder: 1\nformat: html\n---\n\nThird body.\n",
         );
     });
 
@@ -161,18 +165,18 @@ fn default_listing_renders_three_posts_in_date_desc_order() {
     assert!(host.contains("Second"));
     assert!(host.contains("Third"));
 
-    // Default sort = date desc → Third (Mar) before Second (Feb)
-    // before First (Jan). Find the three title positions and
-    // assert the ordering.
+    // Default sort = order asc, title asc → Third (order: 1) leads;
+    // First and Second (no order:) follow in title-asc order. Find
+    // the three title positions and assert the ordering.
     let p_third = host.find("Third").expect("Third missing");
     let p_second = host.find("Second").expect("Second missing");
     let p_first = host.find("First").expect("First missing");
     assert!(
-        p_third < p_second && p_second < p_first,
-        "expected date-desc ordering (Third, Second, First); positions: third={}, second={}, first={}",
+        p_third < p_first && p_first < p_second,
+        "expected default ordering (Third, First, Second); positions: third={}, first={}, second={}",
         p_third,
-        p_second,
-        p_first
+        p_first,
+        p_second
     );
 
     // L7 ran during `WebsiteProjectType::post_render`: the
@@ -203,6 +207,46 @@ fn default_listing_renders_three_posts_in_date_desc_order() {
     // Dates are pre-formatted at record-build with the `medium`
     // default (bd-13f821l5).
     assert!(host.contains("Jan 15, 2026"));
+}
+
+/// bd-listing-declared-order-3ixcvc4o: a curated `contents:` list
+/// with `sort: false` renders in declared order (Q1 semantics).
+/// Same shape as the committed minimal repro at
+/// `claude-notes/plans/listing-declared-order-investigation/repro/`:
+/// bravo is declared first but sorts after alpha both alphabetically
+/// and by project-index order, so only declaration-order handling
+/// can put it first. (Item files have distinct stems because the
+/// harness keys outputs by file stem.)
+#[test]
+fn declared_contents_order_preserved_with_sort_false() {
+    let (_dir, outputs) = render_project(|p| {
+        write(
+            &p.join("_quarto.yml"),
+            "project:\n  type: website\n  output-dir: _site\nwebsite:\n  title: \"My Site\"\n",
+        );
+        write(
+            &p.join("index.qmd"),
+            "---\ntitle: Home\nlisting:\n  id: things\n  type: default\n  sort: false\n  contents:\n    - bravo.qmd\n    - alpha.qmd\nformat: html\n---\n\n::: {#things}\n:::\n",
+        );
+        write(
+            &p.join("alpha.qmd"),
+            "---\ntitle: Alpha Page\nformat: html\n---\n\nAlpha body.\n",
+        );
+        write(
+            &p.join("bravo.qmd"),
+            "---\ntitle: Bravo Page\nformat: html\n---\n\nBravo body.\n",
+        );
+    });
+
+    let host = html_for(&outputs, "index");
+    let p_bravo = host.find("Bravo Page").expect("Bravo Page missing");
+    let p_alpha = host.find("Alpha Page").expect("Alpha Page missing");
+    assert!(
+        p_bravo < p_alpha,
+        "declared order (Bravo, Alpha) must be preserved; positions: bravo={}, alpha={}",
+        p_bravo,
+        p_alpha
+    );
 }
 
 /// Listing item links must travel through `LinkRewriteTransform`.

--- a/crates/quarto-core/tests/integration/snapshots/integration__listing_pipeline__snapshot_builtin_default_with_categories_cloud_mode.snap
+++ b/crates/quarto-core/tests/integration/snapshots/integration__listing_pipeline__snapshot_builtin_default_with_categories_cloud_mode.snap
@@ -1,14 +1,13 @@
 ---
-source: crates/quarto-core/tests/listing_pipeline.rs
-assertion_line: 776
+source: crates/quarto-core/tests/integration/listing_pipeline.rs
 expression: l5_owned_slice(host)
 ---
 === chip blocks ===
-<div class="listing-categories"><div class="listing-category" onclick="window.quartoListingCategory('ZWxt'); return false;">elm</div><div class="listing-category" onclick="window.quartoListingCategory('cnVzdA=='); return false;">rust</div></div>
+<div class="listing-categories"><div class="listing-category" onclick="window.quartoListingCategory('cnVzdA=='); return false;">rust</div><div class="listing-category" onclick="window.quartoListingCategory('ZGVzaWdu'); return false;">design</div></div>
 
 <div class="listing-categories"><div class="listing-category" onclick="window.quartoListingCategory('cnVzdA=='); return false;">rust</div></div>
 
-<div class="listing-categories"><div class="listing-category" onclick="window.quartoListingCategory('cnVzdA=='); return false;">rust</div><div class="listing-category" onclick="window.quartoListingCategory('ZGVzaWdu'); return false;">design</div></div>
+<div class="listing-categories"><div class="listing-category" onclick="window.quartoListingCategory('ZWxt'); return false;">elm</div><div class="listing-category" onclick="window.quartoListingCategory('cnVzdA=='); return false;">rust</div></div>
 
 === sidebar ===
 <h5 class="quarto-listing-category-title">Categories</h5>

--- a/crates/quarto-core/tests/integration/snapshots/integration__listing_pipeline__snapshot_builtin_default_with_categories_default_mode.snap
+++ b/crates/quarto-core/tests/integration/snapshots/integration__listing_pipeline__snapshot_builtin_default_with_categories_default_mode.snap
@@ -1,14 +1,13 @@
 ---
-source: crates/quarto-core/tests/listing_pipeline.rs
-assertion_line: 738
+source: crates/quarto-core/tests/integration/listing_pipeline.rs
 expression: l5_owned_slice(host)
 ---
 === chip blocks ===
-<div class="listing-categories"><div class="listing-category" onclick="window.quartoListingCategory('ZWxt'); return false;">elm</div></div>
+<div class="listing-categories"><div class="listing-category" onclick="window.quartoListingCategory('cnVzdA=='); return false;">rust</div><div class="listing-category" onclick="window.quartoListingCategory('ZGVzaWdu'); return false;">design</div></div>
 
 <div class="listing-categories"><div class="listing-category" onclick="window.quartoListingCategory('cnVzdA=='); return false;">rust</div></div>
 
-<div class="listing-categories"><div class="listing-category" onclick="window.quartoListingCategory('cnVzdA=='); return false;">rust</div><div class="listing-category" onclick="window.quartoListingCategory('ZGVzaWdu'); return false;">design</div></div>
+<div class="listing-categories"><div class="listing-category" onclick="window.quartoListingCategory('ZWxt'); return false;">elm</div></div>
 
 === sidebar ===
 <h5 class="quarto-listing-category-title">Categories</h5>

--- a/crates/quarto-core/tests/integration/snapshots/integration__listing_pipeline__snapshot_builtin_default_with_categories_unnumbered_mode.snap
+++ b/crates/quarto-core/tests/integration/snapshots/integration__listing_pipeline__snapshot_builtin_default_with_categories_unnumbered_mode.snap
@@ -1,14 +1,13 @@
 ---
-source: crates/quarto-core/tests/listing_pipeline.rs
-assertion_line: 812
+source: crates/quarto-core/tests/integration/listing_pipeline.rs
 expression: l5_owned_slice(host)
 ---
 === chip blocks ===
-<div class="listing-categories"><div class="listing-category" onclick="window.quartoListingCategory('ZWxt'); return false;">elm</div></div>
+<div class="listing-categories"><div class="listing-category" onclick="window.quartoListingCategory('cnVzdA=='); return false;">rust</div><div class="listing-category" onclick="window.quartoListingCategory('ZGVzaWdu'); return false;">design</div></div>
 
 <div class="listing-categories"><div class="listing-category" onclick="window.quartoListingCategory('cnVzdA=='); return false;">rust</div></div>
 
-<div class="listing-categories"><div class="listing-category" onclick="window.quartoListingCategory('cnVzdA=='); return false;">rust</div><div class="listing-category" onclick="window.quartoListingCategory('ZGVzaWdu'); return false;">design</div></div>
+<div class="listing-categories"><div class="listing-category" onclick="window.quartoListingCategory('ZWxt'); return false;">elm</div></div>
 
 === sidebar ===
 <h5 class="quarto-listing-category-title">Categories</h5>

--- a/crates/wasm-quarto-hub-client/Cargo.lock
+++ b/crates/wasm-quarto-hub-client/Cargo.lock
@@ -377,7 +377,7 @@ dependencies = [
 
 [[package]]
 name = "comrak-to-pandoc"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "comrak",
  "hashlink",
@@ -2074,7 +2074,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-analysis"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "quarto-error-reporting",
  "quarto-pandoc-types",
@@ -2096,7 +2096,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-brand"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "pathdiff",
  "quarto-util",
@@ -2107,7 +2107,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-citeproc"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "glob",
  "hashlink",
@@ -2138,7 +2138,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-core"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2190,7 +2190,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-csl"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "quarto-error-reporting",
  "quarto-source-map",
@@ -2241,7 +2241,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-highlight"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "once_cell",
  "quarto-highlight-encoding",
@@ -2267,7 +2267,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-highlight-encoding"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2275,7 +2275,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-lsp-core"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "pampa",
  "pollster",
@@ -2296,7 +2296,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-navigation"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "quarto-config",
  "quarto-pandoc-types",
@@ -2331,7 +2331,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-project-create"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "quarto-doctemplate",
  "serde",
@@ -2341,7 +2341,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-sass"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "include_dir",
  "once_cell",
@@ -2371,7 +2371,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-system-runtime"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -2388,7 +2388,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-trace"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "flate2",
  "serde",
@@ -2406,7 +2406,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-util"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -2414,7 +2414,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-xml"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "quarto-error-reporting",
  "quarto-source-map",
@@ -4021,7 +4021,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-printf-fmt"
-version = "0.13.0"
+version = "0.14.0"
 
 [[package]]
 name = "wasm-quarto-hub-client"

--- a/docs/errors/listing/Q-12-3.qmd
+++ b/docs/errors/listing/Q-12-3.qmd
@@ -11,40 +11,56 @@ categories:
 
 # `Q-12-3` — Unknown Sort Field
 
-> A listing `sort:` value refers to a field the listing does not
-> know how to sort on, or `sort:` has the wrong overall shape.
+> A listing `sort:` value refers to a field no listing item
+> defines, or `sort:` has the wrong overall shape.
 
 ## What this means
 
 The `sort:` key on a listing tells Quarto how to order the items.
 It accepts a single sort key as a string (`date desc`), an array
-of such keys, or `false` to disable sorting. This error fires
-in two related cases:
+of such keys, or a boolean — `false` disables sorting (items keep
+the order of your `contents:` entries), `true` explicitly asks
+for the default sort (`order asc, title asc`, the same as leaving
+`sort:` out). This warning fires in two related cases:
 
-- The named field is not one of the listing's known fields.
+- The named field is neither a built-in listing field nor a field
+  that any of the listing's items defines — so there is no
+  information to sort on, and all items compare as equal.
 - `sort:` is given a value that is neither string, array, nor
-  `false` — typically a map.
+  boolean — typically a map.
 
-The listing renders, but the unrecognized sort key is dropped
-(or sorting is disabled altogether).
+The listing still renders; the unusable sort key just has no
+effect.
+
+Sorting by a custom field does **not** trigger this warning as
+long as at least one item carries the field: values declared in a
+document's `listing-item: extra:` front matter are found by the
+sort, and items missing the field sort after the ones that have
+it.
 
 ## Why this happens
 
 Common causes:
 
 - **A typo in the field name** (`titel` instead of `title`).
-- **A field that exists on individual items but is not exposed
-  as a sortable column** (a custom front-matter field not
-  declared in `field-types:`).
+- **A custom field no item actually defines** — for example,
+  sorting on `difficulty` when no document declares it under
+  `listing-item: extra:`.
 - **A wrong shape for `sort:`** — for example, passing a map
-  where a string or array was expected.
+  where a string, array, or boolean was expected.
 
 ## How to fix
 
-Confirm the field name matches one of the listing's known
-fields. If you are sorting by a custom field, declare it under
-the listing's `field-types:` so the parser knows how to compare
-its values.
+Confirm the field name matches a built-in listing field (`title`,
+`date`, `author`, `order`, …) or a custom field your documents
+declare. To sort by a custom field, add it to each participating
+document's front matter:
+
+```yaml
+listing-item:
+  extra:
+    difficulty: 2
+```
 
 ## Related
 


### PR DESCRIPTION
Fixes bd-listing-declared-order-3ixcvc4o: a listing whose `contents:` is a curated list of explicit paths rendered items in project-index (path-alphabetical) order regardless of declaration order. All 15 Posit Connect cookbook listing pages rely on declared order; Q1 preserves it.

## Changes

- **Declared-order item collection**: `ListingGenerateTransform` tags each item with the index of the first `contents:` pattern that matches it and stable-sorts by that index — Q1's glob-major semantics, for literal and wildcard patterns alike. Exclusions (`!`) stay global; the Q-12-19 matched-nothing diagnostic now credits every pattern an item matches (pinned by a regression test), and its per-item pattern recompiles are gone.
- **`sort: true` = default sort** (Q1 parity): previously fell into the malformed-value branch; `parse_sort` now returns `Option<Vec<ListingSort>>` (`None` = use default, `Some([])` = `sort: false` = no sorting).
- **Default sort is Q1's `order asc, title asc`** for *all* listing types, replacing the date-desc default and the table no-default special case. Top-level `order:` front matter (already extracted into `DocumentProfile`) now flows into `ListingItem`, sorts numerically as a known field, and is exposed to custom templates as `order`. The old behavior stays reachable per-listing via `sort: date desc`.
- **Q-12-3 false positive fixed**: a custom-field sort that works via `listing-item: extra:` no longer warns; the warning fires only when the field is unknown *and* no item defines it. Error docs page updated.
- **Latent bug fixed**: descending sorts floated missing-value items to the top — the direction flip was applied to the missing-value rule instead of only the value-to-value comparison.

## Snapshot changes (3 files)

`integration__listing_pipeline__snapshot_builtin_default_with_categories_{default,cloud,unnumbered}_mode.snap`: pure item reordering from the default-sort change (old date-desc Third/Second/First → new title-asc First/Second/Third) plus insta refreshing a stale `source:` header path. No markup changes.

## Verification

- TDD: 11 failing tests written and verified failing before implementation (commit-separated).
- Full workspace suite: 11,166/11,166 passed; full `cargo xtask verify` (Rust + WASM + hub-client legs) green; `cargo xtask lint` clean.
- End-to-end: the minimal repro (committed under `claude-notes/plans/listing-declared-order-investigation/repro/`) renders declared order through the real `q2 render` binary; output inspected.

Plan: `claude-notes/plans/2026-08-09-listing-declared-order.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)