### PR TITLE
Table listings: honor fields/field-display-names/field-links (bd-listing-table-fields-peg1w3b3)

### DIFF
--- a/claude-notes/plans/2026-08-09-listing-table-fields.md
+++ b/claude-notes/plans/2026-08-09-listing-table-fields.md
@@ -3,74 +3,94 @@
 **Date:** 2026-08-09
 **Braid:** bd-listing-table-fields-peg1w3b3 (bug, P1, label `listings`)
 **Branch:** `main` (investigated in place; no worktree created)
-**Status:** Investigation — pending design alignment with user. **Do not start implementation until the user gives the go-ahead.**
+**Status:** Design settled with user (2026-08-09) — implementation in progress.
+**Follow-up:** bd-bl1e00r6 (sort-ui/filter-ui/table-hover interactive parity, discovered-from this strand)
 
-## Triage verdict
+## Problem
 
-**Ready to design.** The symptom reproduces at HEAD, the root cause is unambiguous (static built-in table templates cannot express a dynamic column set), the config and binding layers already carry everything the fix needs, and Q1's reference implementation pins the target semantics. The remaining work is choosing the mechanism (pre-rendered binding keys vs. dynamically generated template source) and pinning per-field cell rendering rules.
+The built-in table listing templates are static: `listing-table.template` hardcodes `| Title | Date | Author |` and `item-table.template` hardcodes `| [$title$]($path$){.no-external} | $date$ | $author$ |`. Consequences:
 
-## Issue context
+- `fields:` is ignored — a `fields: [title]` listing still renders three columns.
+- `field-display-names:` is ignored for headers.
+- Items missing `date`/`author` produce "Undefined variable" doctemplate diagnostics, surfaced as one Q-12-10 warning per listing (the binding deliberately omits absent optional fields so `$if(field)$` works).
 
-Filed 2026-08-09 by Carlos (same day as this investigation — no staleness risk). A `type: table` listing with `fields: [title]` still renders three columns (Title | Date | Author); `field-display-names:` is ignored for headers; items missing `date`/`author` produce per-item "Undefined variable" doctemplate diagnostics surfaced as one Q-12-10 warning per listing.
+Reproduced at HEAD (`main` @ 4bb32844) with the committed repro under `claude-notes/plans/listing-table-fields-investigation/repro/` — rendered output was inspected: `<th>Title</th><th>Date</th><th>Author</th>` + `Q-12-10 … Undefined variable: date`.
 
-Real-world hit: Posit Connect docs `how-to/index.md` (`type: table, fields: [title], field-display-names: {title: "How To"}`) renders three columns (two empty) + 8 diagnostics vs. Q1's single "How To" column.
+doctemplate is Pandoc-style/logic-less (no `item[field]` indexing), so no static template can render an author-chosen column set — the dynamism must come from Rust.
 
-## Dependency graph
+## Settled design (user-aligned 2026-08-09)
 
-**Empty.** `braid dep tree` / `dep list` show no edges in this skein. The origin strand (`br-listing-table-fields-hes1dsib`) lives in the *connect-docs porting* skein, not this one — the description carries its context forward. No incoming `blocks` pressure here, but the P1 + real-world-docs hit sets the urgency.
+1. **Mechanism (A): pre-rendered binding keys.** The binding computes `listing.table-header` (markdown header + separator rows) and a per-item `table-row` markdown string; the two table templates shrink to interpolating those. Additive to the L8 binding contract; follows the `image-html`/`category-html` pre-rendered-helper precedent. Templates stay static/readable; L8 shadowing untouched.
+2. **Header names: Q1 parity.** Built-in default display-name map overlaid with the author's `field-display-names`; unknown fields fall back to the **raw field name**. Q1's defaults (from `_language.yml`, English hardcoded for now — Q2 has no format.language yet): `image → " "`, `date → "Date"`, `title → "Title"`, `description → "Description"`, `author → "Author"`, `filename → "File Name"`, `date-modified → "Modified"`, `file-modified → "Modified"`, `subtitle → "Subtitle"`, `reading-time → "Reading Time"`, `word-count → "Word Count"`, `categories → "Categories"`.
+3. **Cell rendering: Q1 parity** (from `listing-table.ejs.md` `readField`/`outputValue`/`outputLink` + `website-listing-read.ts`):
+   - `image` → the existing `image-html` helper output.
+   - Curated fields read from the item struct: `title`, `subtitle`, `description`, `author`, `authors` (join `", "`), `date`/`date-modified` (pre-formatted, as the binding already does), `categories` (join `", "`), `reading-time` (`"N min read"`), `word-count`, `filename`.
+   - Unknown fields → dotted-path lookup into the item's `extra` map (`a.b` walks nested maps, Q1 `readField` parity); array values join `", "`.
+   - Missing value → **empty cell** (Q1 emits `&nbsp;`; empty cell is the markdown-table equivalent).
+   - **`field-links`**: new config option, Q1 default for table listings is `[title, filename]` (empty for other types). A linked field's cell becomes `[<value>](<path>){.no-external}` when the item has a path and the value is non-empty. (Q1's extra `listing-<field>` classes exist to serve list.js — deferred to bd-bl1e00r6.)
+4. **Cell escaping:** escape `|` → `\|` and flatten newlines to spaces inside cell values; accept that some documents need markdown changes for Quarto 2. Values otherwise pass through as markdown (consistent with the other templates' `$title$` interpolation).
+5. **Interactive parity (sort-ui anchors, filter-ui, table-hover onclick, list.js classes) is out of scope** → filed as bd-bl1e00r6.
 
-## What the code looks like today
+### Additional Q1-parity findings from the source study
 
-Reproduced at HEAD (`main` @ 4bb32844) with the repro under
-`claude-notes/plans/listing-table-fields-investigation/repro/` (copied from the
-connect-docs repro, build artifacts stripped, extended with
-`field-display-names: {title: "How To"}`):
+- **Default table field order is `[date, title, author]`** (`kDefaultTableFields`) — Q2's `apply_type_defaults` already matches, but the hardcoded template header order (Title|Date|Author) doesn't. Post-fix, default tables render **Date | Title | Author**. This is a deliberate parity change; expect snapshot churn (must be documented per snapshot policy).
+- **Q1 filters *default* (not author-explicit) fields by presence in items** (`website-listing-read.ts:578` — keep `image` always; if the filter empties the list, fall back to all item fields). Author-explicit `fields:` is used verbatim. This is what prevents an all-empty Author column on default tables. Q2 applies type defaults at config-parse time with no item knowledge, so implementing this needs an explicit-fields flag on `Listing` and a presence-filter at render time (items are known in `render_one`).
 
-```
-$ cargo run --bin q2 -- render .   # in the repro dir
-Warning [Q-12-10]: Listing `guides` doctemplate produced 4 diagnostic(s); first: Undefined variable: date
-```
+## Implementation notes
 
-Rendered `_site/index.html` has `<th>Title</th><th>Date</th><th>Author</th>` — `fields:` and `field-display-names:` both ignored. Output was inspected directly.
+- Config: `crates/quarto-core/src/project/listing/config.rs` — parse `field-links` (string list) into `Listing::field_links`; add `fields_explicit: bool` set when the author supplied `fields:`; `apply_type_defaults` fills `field_links` (`[title, filename]` for Table, `[]` otherwise).
+- Binding: `crates/quarto-core/src/project/listing/binding.rs` (+ possibly `helpers.rs`) — display-name resolution, cell rendering, `table-header` on the listing map, `table-row` on the item map. Computed unconditionally (cheap; custom templates may use them).
+- Presence filter: `crates/quarto-core/src/transforms/listing_render.rs::render_one` (or just before `build_listing_context`) — when `!fields_explicit`, filter `listing.fields` to fields present in ≥1 item (keeping `image`), Q1 fallback semantics.
+- Templates: `templates/listing-table.template` → wrapper + `$listing.table-header$` + items loop; `templates/item-table.template` → `$table-row$`. Keep the `item-table` partial so L8 shadowing still works.
+- The re-parse path means pre-rendered markdown strings in the binding "just work" (template output is parsed as qmd).
 
-Where each piece lives:
+## Work items
 
-- **Config already parses everything.** `crates/quarto-core/src/project/listing/config.rs` parses `fields` (line 466) and `field-display-names` (line 469, into `Listing::field_display_names: BTreeMap<String, String>`, with Q-12-5 on non-string values). Table-type default fields are `[date, title, author]` (line ~887).
-- **The binding carries `fields` but nothing table-shaped.** `binding.rs::build_listing_map` exposes `listing.fields` as a list and `build_item_map` computes per-item `show.*` flags from `listing.fields`; optional item fields are *omitted* when absent (deliberately, so `$if(field)$` works) — which is exactly why the hardcoded `$date$` reference produces "Undefined variable" for date-less items.
-- **The templates are static.** `templates/listing-table.template` hardcodes the `| Title | Date | Author |` header; `templates/item-table.template` hardcodes the three cells. Both are `include_str!`-embedded and served via `MemoryResolver` (`templates.rs`), so L8 custom templates can shadow them by name.
-- **The template language can't fix this alone.** doctemplate is Pandoc-style/logic-less: there is no dynamic map indexing (`item[field]`), so no static template can render an author-chosen column set. The dynamism has to come from Rust — either in the binding or in generated template source.
-- **Render path:** `transforms/listing_render.rs::render_one` → `render_builtin` compiles the embedded source, renders against the binding, re-parses the output as qmd markdown, splices into the AST. Template output being *markdown* (re-parsed) means pre-rendered markdown strings in the binding work naturally.
+### Phase 0 — Tests (TDD: written first, verified failing)
 
-### Q1 reference semantics (external-sources/quarto-cli)
+- [ ] Survey existing listing test layout (binding unit tests, listing_render tests, any project-render integration fixtures) and decide where each new test lives.
+- [ ] e2e/regression: `fields: [title]` + `field-display-names: {title: "How To"}` table listing renders exactly one `How To` column and **zero** Q-12-10 warnings (drive the real render path per end-to-end verification policy).
+- [ ] Missing-value tolerance: `fields: [title, date]` where one item lacks `date` → empty cell, no diagnostic.
+- [ ] Default table (no `fields:`): Date | Title | Author order; and with items lacking `author`, the Author column is dropped (presence filter); author-explicit `fields:` is never presence-filtered.
+- [ ] Binding unit tests: `table-header` (display-name overlay, raw-name fallback, `image → " "` header), `table-row` (curated fields, dotted-path `extra` lookup, array join, empty cell for missing, `\|` escaping, newline flattening), `field-links` linking behavior (title linked by default; non-linked field plain; `field-links: []` unlinks title).
+- [ ] Config unit tests: `field-links` parsing, table default `[title, filename]`, `fields_explicit` flag.
+- [ ] Run new tests, confirm they fail for the expected reason before implementing.
 
-`src/resources/projects/website/listing/listing-table.ejs.md` loops `listing.fields` for both `<th>` headers and `<td>` cells:
+### Phase 1 — Config
 
-- **Headers:** `utilities.fieldName(field)` = merged display-name map — built-in localized defaults (`_language.yml`: Title, Date, Author, Description, File Name, Modified, Subtitle, Reading Time, Word Count, Categories) overlaid with the author's `field-display-names`; unknown fields fall back to the **raw field name** (not title-case).
-- **Cells:** `outputValue` special-cases `image` (img/placeholder), joins array values with `", "`, supports dotted-path field access, and wraps linked fields via `outputLink` (default `field-links` includes `title`; missing values render `&nbsp;`).
-- Q1 emits a raw **HTML** table (with sort-ui anchor headers, `table-hover` row onclick, `metadataAttrs` per row); Q2's current template emits a markdown pipe table.
+- [ ] Parse `field-links` into `Listing::field_links: Vec<String>` (Q-12-5-style diagnostic on wrong type, consistent with neighbors).
+- [ ] Add `fields_explicit: bool` (set in the `"fields"` parse arm).
+- [ ] `apply_type_defaults`: default `field_links` per type.
+- [ ] Phase-1 unit tests pass.
 
-## Proposed phases (draft)
+### Phase 2 — Binding
 
-Skeleton only — actual phase contents wait on the design discussion.
+- [ ] Display-name resolution helper (defaults map + author overlay + raw fallback).
+- [ ] Cell renderer: per-field value lookup (curated → struct, unknown → dotted-path `extra`), image special-case, join rules, escaping, `field-links` wrapping.
+- [ ] `listing.table-header` + per-item `table-row` keys wired into `build_listing_map`/`build_item_map`.
+- [ ] Phase-2 unit tests pass.
 
-- **Phase 0 — Test plan (TDD).** Failing tests first: (a) end-to-end project render fixture (`type: table, fields: [title], field-display-names`) asserting a single "How To" column and zero Q-12-10 warnings; (b) binding unit tests for whatever new keys the design settles on; (c) missing-value tolerance (item without `date` in a `fields: [title, date]` listing → empty cell, no diagnostic); (d) default-fields table still renders Title | Date | Author unchanged (snapshot parity).
-- **Phase 1 — Binding/mechanism.** Compute the dynamic column set from `listing.fields` + `field_display_names` (mechanism per design question 1).
-- **Phase 2 — Templates.** Rewrite `listing-table.template` / `item-table.template` to consume the new mechanism; confirm L8 shadowing story still holds.
-- **Phase 3 — End-to-end verification + docs.** Re-run the committed repro through `q2 render`, inspect output, update `docs/` listing documentation if it describes table columns.
+### Phase 3 — Templates + presence filter
 
-## Open design questions for the user
+- [ ] Rewrite `listing-table.template` / `item-table.template` to consume the new keys.
+- [ ] Presence-filter default fields in the render transform (author-explicit fields verbatim).
+- [ ] Full workspace test run; review + document every changed `.snap` (expect table-column-order churn).
 
-1. **Mechanism.** Two candidates:
-   - **(A) Pre-rendered binding keys** — the binding computes e.g. `listing.table-header` (header + separator rows) and a per-item `table-row` (or per-item `table-cells`) markdown string; the templates shrink to interpolating those. Keeps templates static, is purely *additive* to the L8 binding contract (non-breaking per binding.rs's contract note), and follows the existing precedent of pre-rendered helpers (`image-html`, `category-html`, `metadata-attrs`).
-   - **(B) Dynamically generated template source** — `top_level_template_source` becomes listing-aware and emits per-listing template text. More invasive: it breaks the "templates are readable canonical reference files" property and complicates L8 partial shadowing of `item-table`.
-   I lean (A); confirm?
-2. **Header fallback for fields without a display name.** Q1 parity = port the built-in default display-name map (Title, Date, Author, Reading Time, …) and fall back to the **raw field name** for unknown/extra fields. The strand suggests title-case fallback instead. Which do we want — Q1 parity, or title-case as a deliberate Q2 improvement?
-3. **Per-field cell rendering rules.** Proposed: `title` → `[$title$]($path$){.no-external}` link (as today); `image` → `image-html`; `date`/`date-modified` → pre-formatted strings (already in the binding); `categories`/`authors` → comma-joined; unknown fields → `extra.*` lookup; missing value → empty cell. Q1 also supports dotted-path fields (`a.b`) and a `field-links` option (which fields become links) — in scope now, or deferred to a follow-up strand?
-4. **Cell escaping.** A markdown pipe table breaks on cell values containing `|` (or block content). Escape `|` as `\|` and accept the limitation, or switch the table listing to raw-HTML emission like Q1 (bigger change, but sidesteps the whole class)?
-5. **Sort-ui/hover parity.** Q1 table headers are sortable anchors and `table-hover` adds row onclick. The current Q2 template has neither, so this bug's scope could stay "columns only" with sort-ui parity as a separate filed strand. Agree?
+### Phase 4 — End-to-end verification + docs
 
-## Risks / tradeoffs (draft)
+- [ ] `cargo run --bin q2 -- render` on the committed repro; inspect `_site/index.html` for the single `How To` column and absence of Q-12-10; record invocation + output snippet here.
+- [ ] Render `docs/` with q2 and spot-check any table listings.
+- [ ] Update `docs/` listing documentation if it describes table columns / `field-display-names` / `field-links`.
+- [ ] `cargo xtask verify` (full — quarto-core changes affect the WASM leg).
 
-- The binding is the **load-bearing public contract for L8 custom templates** (binding.rs header comment): adding keys is safe, but if we *change* what `item-table` receives or how the built-in table templates are structured, custom templates that shadow `item-table`/`listing-table` by name will see the new call shape. Worth a call-out in the commit either way.
-- Option (B) would interact with `builtins_resolver()`'s six static names and the `Custom`-type fallback path; option (A) leaves both untouched.
-- Snapshot churn: default table listings (no `fields:` override) must render byte-identically or the change needs snapshot review per the CLAUDE.md snapshot policy.
+## Risks / tradeoffs
+
+- The binding is the **load-bearing L8 public contract**: `table-header`/`table-row` are additive (safe), but custom templates that shadow `item-table` keep receiving the full item map — unchanged shape, no break expected. Call out the new keys in the commit.
+- Default-table column order changes to Date | Title | Author (Q1 parity). Snapshot churn must be reviewed and documented per CLAUDE.md snapshot policy.
+- Presence filtering changes `show.*` flags for default/grid listings whose items lack curated fields — aligns with Q1, but worth watching in snapshot review.
+- English-hardcoded default display names; revisit when Q2 grows language/i18n support.
+
+## Investigation record (2026-08-09)
+
+- Repro: `claude-notes/plans/listing-table-fields-investigation/repro/` — `cargo run --bin q2 -- render .` → `Warning [Q-12-10]: Listing 'guides' doctemplate produced 4 diagnostic(s); first: Undefined variable: date`; `_site/index.html` shows `<th>Title</th><th>Date</th><th>Author</th>` despite `fields: [title]` + `field-display-names`. Output inspected directly.
+- Q1 references: `external-sources/quarto-cli/src/resources/projects/website/listing/listing-table.ejs.md` (template loop, readField/outputValue), `src/project/types/website/listing/website-listing-template.ts` (fieldName/outputLink utilities), `src/project/types/website/listing/website-listing-read.ts` (defaultFieldDisplayNames, kDefaultFieldLinks, kDefaultTableFields, suggested-field presence filter), `src/resources/language/_language.yml` (listing-page-field-* strings).

--- a/claude-notes/plans/2026-08-09-listing-table-fields.md
+++ b/claude-notes/plans/2026-08-09-listing-table-fields.md
@@ -48,40 +48,48 @@ doctemplate is Pandoc-style/logic-less (no `item[field]` indexing), so no static
 
 ### Phase 0 — Tests (TDD: written first, verified failing)
 
-- [ ] Survey existing listing test layout (binding unit tests, listing_render tests, any project-render integration fixtures) and decide where each new test lives.
-- [ ] e2e/regression: `fields: [title]` + `field-display-names: {title: "How To"}` table listing renders exactly one `How To` column and **zero** Q-12-10 warnings (drive the real render path per end-to-end verification policy).
-- [ ] Missing-value tolerance: `fields: [title, date]` where one item lacks `date` → empty cell, no diagnostic.
-- [ ] Default table (no `fields:`): Date | Title | Author order; and with items lacking `author`, the Author column is dropped (presence filter); author-explicit `fields:` is never presence-filtered.
-- [ ] Binding unit tests: `table-header` (display-name overlay, raw-name fallback, `image → " "` header), `table-row` (curated fields, dotted-path `extra` lookup, array join, empty cell for missing, `\|` escaping, newline flattening), `field-links` linking behavior (title linked by default; non-linked field plain; `field-links: []` unlinks title).
-- [ ] Config unit tests: `field-links` parsing, table default `[title, filename]`, `fields_explicit` flag.
-- [ ] Run new tests, confirm they fail for the expected reason before implementing.
+- [x] Survey existing listing test layout — homes chosen: `binding.rs` test mod (unit), `transforms/listing_render.rs` test mod (transform + diags), `tests/integration/listing_pipeline.rs` (e2e via `render_project`). Per-file warnings don't reach `ProjectRenderSummary`, so the no-Q-12-10 assertion lives at the transform level (`run_transform` returns diags).
+- [x] e2e: `table_fields_and_display_names_render_single_column` (+ transform-level `table_fields_subset_renders_single_column_without_diagnostics` for the zero-diagnostics half).
+- [x] Missing-value tolerance: `table_row_missing_value_renders_empty_cell`.
+- [x] Default table order + presence filter: `table_default_fields_presence_filtered_and_ordered` (e2e), `defaulted_table_fields_presence_filtered_when_no_author`, `explicit_fields_never_presence_filtered`, `presence_filter_keeps_image_field` (binding).
+- [x] Binding unit tests: header overlay/raw-fallback/image-blank; row link+date, escaping, newline flattening, dotted-path extra, array join, authors/categories join, reading-time, image cell, field-links unlink/filename.
+- [x] Config unit tests: field-links defaults (table/non-table), explicit-empty survives defaults, explicit list, `fields_explicit` true/false/empty-list.
+- [x] Scaffolding so the batch compiles: `Listing.field_links` → `Option<Vec<String>>` (None = unspecified), new `Listing.fields_explicit: bool` (both behavior-neutral).
+- [x] Ran the batch: 18+ tests fail for the expected reasons (missing `table-header`/`table-row` keys, Q-12-10 diags present, hardcoded columns in HTML); 4 pass as scaffolding-covered regression guards.
 
 ### Phase 1 — Config
 
-- [ ] Parse `field-links` into `Listing::field_links: Vec<String>` (Q-12-5-style diagnostic on wrong type, consistent with neighbors).
-- [ ] Add `fields_explicit: bool` (set in the `"fields"` parse arm).
-- [ ] `apply_type_defaults`: default `field_links` per type.
-- [ ] Phase-1 unit tests pass.
+- [x] `field-links` was already parsed (never consumed); re-typed as `Option<Vec<String>>` so explicit `field-links: []` survives defaulting.
+- [x] `fields_explicit: bool` set in the `"fields"` parse arm (explicit-but-empty list counts as defaulted).
+- [x] `apply_type_defaults` fills `field_links` (`[title, filename]` for Table, `[]` otherwise).
+- [x] Phase-1 unit tests pass.
 
 ### Phase 2 — Binding
 
-- [ ] Display-name resolution helper (defaults map + author overlay + raw fallback).
-- [ ] Cell renderer: per-field value lookup (curated → struct, unknown → dotted-path `extra`), image special-case, join rules, escaping, `field-links` wrapping.
-- [ ] `listing.table-header` + per-item `table-row` keys wired into `build_listing_map`/`build_item_map`.
-- [ ] Phase-2 unit tests pass.
+- [x] `default_display_name` (Q1 `_language.yml` map, English) + `display_name` overlay with raw-name fallback.
+- [x] Cell renderer: `item_field_display_value` (curated → struct fields, unknown → `extra_field_value` literal-then-dotted lookup, arrays join `", "`), image → `image-html`, `escape_table_cell` (`\|`, newline flattening), `field-links` wrapping as `[value](path){.no-external}`.
+- [x] `listing.table-header` + `listing.field-links` + per-item `table-row` wired in; `effective_fields` presence filter lives in `build_listing_context` (binding layer, not the render transform — shared by every consumer incl. WASM) and feeds `listing.fields`, `show.*`, header and rows uniformly.
+- [x] Phase-2 unit tests pass.
 
 ### Phase 3 — Templates + presence filter
 
-- [ ] Rewrite `listing-table.template` / `item-table.template` to consume the new keys.
-- [ ] Presence-filter default fields in the render transform (author-explicit fields verbatim).
-- [ ] Full workspace test run; review + document every changed `.snap` (expect table-column-order churn).
+- [x] `item-table.template` → `$table-row$`; `listing-table.template` → `$listing.table-header$` + a `$for(items)$ $it:item-table()$ $endfor$` loop. The for-loop (not `$items:item-table()$`) is load-bearing: the doctemplate resolver chomps a partial's final newline (Pandoc `removeFinalNl` parity), so bare iterated application merges all rows onto one line. **This was a latent bug in the old template too** — any table listing with ≥2 items merged its rows into a single `<tr>`; the block-based default/grid templates survive the same chomp only by div-fence arity absorption (`:::` + `:::` → a longer valid fence). Row-structure assertions (`<tr` count) added to both e2e tests.
+- [x] Presence filter (implemented in binding, see Phase 2).
+- [x] Full workspace test run: 11179 passed, 197 skipped. **Zero snapshot churn** — no existing `.snap` covered table listing markup.
 
 ### Phase 4 — End-to-end verification + docs
 
-- [ ] `cargo run --bin q2 -- render` on the committed repro; inspect `_site/index.html` for the single `How To` column and absence of Q-12-10; record invocation + output snippet here.
-- [ ] Render `docs/` with q2 and spot-check any table listings.
-- [ ] Update `docs/` listing documentation if it describes table columns / `field-display-names` / `field-links`.
-- [ ] `cargo xtask verify` (full — quarto-core changes affect the WASM leg).
+- [x] Real-binary verification on the committed repro:
+  - Invocation: `cargo run --bin q2 -- render .` in `claude-notes/plans/listing-table-fields-investigation/repro/`
+  - Output inspected (`_site/index.html`): single `<th>How To</th>`, one `<tr>` per item with linked titles (`<a href="one/index.html" class="no-external">First guide</a>`), **zero warnings** (previously: three hardcoded columns + `Q-12-10 … Undefined variable: date`).
+- [x] Rendered `docs/` with q2 (189/189 files). The error-catalog index (`docs/errors/index.qmd`, itself a `type: table` listing with `fields`/`field-display-names`/`field-links`) now renders its four declared columns with correct headers and linked titles. Its `code`/`subsystem`/`status` cells are empty because those are bare top-level frontmatter keys, which Q2's profile contract only routes into `ListingItem.extra` via an explicit `listing-item.extra:` opt-in — a deliberate design boundary (see `document_profile.rs`), **not** regressed by this change (those columns never rendered before either). Filed as **bd-0t4e07jk** (discovered-from) with the design options rather than deciding unilaterally.
+- [x] docs/ prose: no user-facing page documents table listing columns yet beyond Q-12-5's `field-display-names` description, which stays accurate; nothing to update for this fix.
+- [x] `cargo xtask verify` (full incl. WASM/hub-client legs) passed on the final tree. One clippy `-D warnings` finding (`map_unwrap_or`) fixed along the way. Side effect: the WASM crate's standalone `Cargo.lock` picked up the 0.13.0 → 0.14.0 workspace version bumps (leftover from the v0.14.0 release; the excluded-from-workspace lockfile only refreshes when the WASM leg builds).
+- [x] Pre-commit review checklist (`claude-notes/instructions/review.md`): no new HashMap/FxHashMap imports (new maps are `BTreeMap`/ordered slices), no `#[serde(flatten)]`, no TODOs, `cargo fmt --check` clean, clippy clean, 11179 workspace tests + full verify green, zero snapshot changes. Staged; awaiting user approval to commit.
+
+## Session log
+
+- **2026-08-09 (session 1):** investigation, design alignment, full implementation (Phases 0–3 complete, Phase 4 verification done except final `cargo xtask verify` + commit). Discovered + filed: bd-bl1e00r6 (interactive table parity), bd-0t4e07jk (bare-frontmatter listing fields).
 
 ## Risks / tradeoffs
 

--- a/claude-notes/plans/2026-08-09-listing-table-fields.md
+++ b/claude-notes/plans/2026-08-09-listing-table-fields.md
@@ -1,0 +1,76 @@
+# Table listings ignore fields/field-display-names (bd-listing-table-fields-peg1w3b3)
+
+**Date:** 2026-08-09
+**Braid:** bd-listing-table-fields-peg1w3b3 (bug, P1, label `listings`)
+**Branch:** `main` (investigated in place; no worktree created)
+**Status:** Investigation — pending design alignment with user. **Do not start implementation until the user gives the go-ahead.**
+
+## Triage verdict
+
+**Ready to design.** The symptom reproduces at HEAD, the root cause is unambiguous (static built-in table templates cannot express a dynamic column set), the config and binding layers already carry everything the fix needs, and Q1's reference implementation pins the target semantics. The remaining work is choosing the mechanism (pre-rendered binding keys vs. dynamically generated template source) and pinning per-field cell rendering rules.
+
+## Issue context
+
+Filed 2026-08-09 by Carlos (same day as this investigation — no staleness risk). A `type: table` listing with `fields: [title]` still renders three columns (Title | Date | Author); `field-display-names:` is ignored for headers; items missing `date`/`author` produce per-item "Undefined variable" doctemplate diagnostics surfaced as one Q-12-10 warning per listing.
+
+Real-world hit: Posit Connect docs `how-to/index.md` (`type: table, fields: [title], field-display-names: {title: "How To"}`) renders three columns (two empty) + 8 diagnostics vs. Q1's single "How To" column.
+
+## Dependency graph
+
+**Empty.** `braid dep tree` / `dep list` show no edges in this skein. The origin strand (`br-listing-table-fields-hes1dsib`) lives in the *connect-docs porting* skein, not this one — the description carries its context forward. No incoming `blocks` pressure here, but the P1 + real-world-docs hit sets the urgency.
+
+## What the code looks like today
+
+Reproduced at HEAD (`main` @ 4bb32844) with the repro under
+`claude-notes/plans/listing-table-fields-investigation/repro/` (copied from the
+connect-docs repro, build artifacts stripped, extended with
+`field-display-names: {title: "How To"}`):
+
+```
+$ cargo run --bin q2 -- render .   # in the repro dir
+Warning [Q-12-10]: Listing `guides` doctemplate produced 4 diagnostic(s); first: Undefined variable: date
+```
+
+Rendered `_site/index.html` has `<th>Title</th><th>Date</th><th>Author</th>` — `fields:` and `field-display-names:` both ignored. Output was inspected directly.
+
+Where each piece lives:
+
+- **Config already parses everything.** `crates/quarto-core/src/project/listing/config.rs` parses `fields` (line 466) and `field-display-names` (line 469, into `Listing::field_display_names: BTreeMap<String, String>`, with Q-12-5 on non-string values). Table-type default fields are `[date, title, author]` (line ~887).
+- **The binding carries `fields` but nothing table-shaped.** `binding.rs::build_listing_map` exposes `listing.fields` as a list and `build_item_map` computes per-item `show.*` flags from `listing.fields`; optional item fields are *omitted* when absent (deliberately, so `$if(field)$` works) — which is exactly why the hardcoded `$date$` reference produces "Undefined variable" for date-less items.
+- **The templates are static.** `templates/listing-table.template` hardcodes the `| Title | Date | Author |` header; `templates/item-table.template` hardcodes the three cells. Both are `include_str!`-embedded and served via `MemoryResolver` (`templates.rs`), so L8 custom templates can shadow them by name.
+- **The template language can't fix this alone.** doctemplate is Pandoc-style/logic-less: there is no dynamic map indexing (`item[field]`), so no static template can render an author-chosen column set. The dynamism has to come from Rust — either in the binding or in generated template source.
+- **Render path:** `transforms/listing_render.rs::render_one` → `render_builtin` compiles the embedded source, renders against the binding, re-parses the output as qmd markdown, splices into the AST. Template output being *markdown* (re-parsed) means pre-rendered markdown strings in the binding work naturally.
+
+### Q1 reference semantics (external-sources/quarto-cli)
+
+`src/resources/projects/website/listing/listing-table.ejs.md` loops `listing.fields` for both `<th>` headers and `<td>` cells:
+
+- **Headers:** `utilities.fieldName(field)` = merged display-name map — built-in localized defaults (`_language.yml`: Title, Date, Author, Description, File Name, Modified, Subtitle, Reading Time, Word Count, Categories) overlaid with the author's `field-display-names`; unknown fields fall back to the **raw field name** (not title-case).
+- **Cells:** `outputValue` special-cases `image` (img/placeholder), joins array values with `", "`, supports dotted-path field access, and wraps linked fields via `outputLink` (default `field-links` includes `title`; missing values render `&nbsp;`).
+- Q1 emits a raw **HTML** table (with sort-ui anchor headers, `table-hover` row onclick, `metadataAttrs` per row); Q2's current template emits a markdown pipe table.
+
+## Proposed phases (draft)
+
+Skeleton only — actual phase contents wait on the design discussion.
+
+- **Phase 0 — Test plan (TDD).** Failing tests first: (a) end-to-end project render fixture (`type: table, fields: [title], field-display-names`) asserting a single "How To" column and zero Q-12-10 warnings; (b) binding unit tests for whatever new keys the design settles on; (c) missing-value tolerance (item without `date` in a `fields: [title, date]` listing → empty cell, no diagnostic); (d) default-fields table still renders Title | Date | Author unchanged (snapshot parity).
+- **Phase 1 — Binding/mechanism.** Compute the dynamic column set from `listing.fields` + `field_display_names` (mechanism per design question 1).
+- **Phase 2 — Templates.** Rewrite `listing-table.template` / `item-table.template` to consume the new mechanism; confirm L8 shadowing story still holds.
+- **Phase 3 — End-to-end verification + docs.** Re-run the committed repro through `q2 render`, inspect output, update `docs/` listing documentation if it describes table columns.
+
+## Open design questions for the user
+
+1. **Mechanism.** Two candidates:
+   - **(A) Pre-rendered binding keys** — the binding computes e.g. `listing.table-header` (header + separator rows) and a per-item `table-row` (or per-item `table-cells`) markdown string; the templates shrink to interpolating those. Keeps templates static, is purely *additive* to the L8 binding contract (non-breaking per binding.rs's contract note), and follows the existing precedent of pre-rendered helpers (`image-html`, `category-html`, `metadata-attrs`).
+   - **(B) Dynamically generated template source** — `top_level_template_source` becomes listing-aware and emits per-listing template text. More invasive: it breaks the "templates are readable canonical reference files" property and complicates L8 partial shadowing of `item-table`.
+   I lean (A); confirm?
+2. **Header fallback for fields without a display name.** Q1 parity = port the built-in default display-name map (Title, Date, Author, Reading Time, …) and fall back to the **raw field name** for unknown/extra fields. The strand suggests title-case fallback instead. Which do we want — Q1 parity, or title-case as a deliberate Q2 improvement?
+3. **Per-field cell rendering rules.** Proposed: `title` → `[$title$]($path$){.no-external}` link (as today); `image` → `image-html`; `date`/`date-modified` → pre-formatted strings (already in the binding); `categories`/`authors` → comma-joined; unknown fields → `extra.*` lookup; missing value → empty cell. Q1 also supports dotted-path fields (`a.b`) and a `field-links` option (which fields become links) — in scope now, or deferred to a follow-up strand?
+4. **Cell escaping.** A markdown pipe table breaks on cell values containing `|` (or block content). Escape `|` as `\|` and accept the limitation, or switch the table listing to raw-HTML emission like Q1 (bigger change, but sidesteps the whole class)?
+5. **Sort-ui/hover parity.** Q1 table headers are sortable anchors and `table-hover` adds row onclick. The current Q2 template has neither, so this bug's scope could stay "columns only" with sort-ui parity as a separate filed strand. Agree?
+
+## Risks / tradeoffs (draft)
+
+- The binding is the **load-bearing public contract for L8 custom templates** (binding.rs header comment): adding keys is safe, but if we *change* what `item-table` receives or how the built-in table templates are structured, custom templates that shadow `item-table`/`listing-table` by name will see the new call shape. Worth a call-out in the commit either way.
+- Option (B) would interact with `builtins_resolver()`'s six static names and the `Custom`-type fallback path; option (A) leaves both untouched.
+- Snapshot churn: default table listings (no `fields:` override) must render byte-identically or the change needs snapshot review per the CLAUDE.md snapshot policy.

--- a/claude-notes/plans/listing-table-fields-investigation/repro/README.md
+++ b/claude-notes/plans/listing-table-fields-investigation/repro/README.md
@@ -1,0 +1,36 @@
+# q2 table listings ignore `fields:` / `field-display-names:`
+
+**Observed with:** q2 0.14.0
+**Repro:** `q2 render` in this directory.
+
+## Expected (Quarto 1)
+
+A `type: table` listing with `fields: [title]` renders a one-column
+table; `field-display-names` renames the header (see
+`docs-quarto-1/_site/how-to/index.html`: single "How To" column).
+
+## Actual (q2)
+
+The built-in table item template is hard-coded to three columns:
+
+```
+| [$title$]($path$){.no-external} | $date$ | $author$ |
+```
+
+(`crates/quarto-core/src/project/listing/templates/item-table.template`)
+
+- `fields:` and `field-display-names:` are ignored; output always has
+  Title | Date | Author columns (empty when items lack those fields).
+- Each item missing `date`/`author` produces "Undefined variable"
+  doctemplate diagnostics, surfaced as one `Q-12-10` warning
+  ("Listing `guides` doctemplate produced N diagnostic(s)").
+
+In the Connect docs this hits `how-to/index.md` (the only `type: table`
+listing): renders three columns instead of one, 8 diagnostics.
+
+## Incidental finding while building this repro
+
+A standalone project of `.md` files renders **0 files** unless
+`project.render` includes a `"**/*.md"` pattern — q2's Q-PROJECT-EMPTY
+diagnostic explains this well, but beware when building repros: a
+"clean" run may have rendered nothing.

--- a/claude-notes/plans/listing-table-fields-investigation/repro/_quarto.yml
+++ b/claude-notes/plans/listing-table-fields-investigation/repro/_quarto.yml
@@ -1,0 +1,4 @@
+project:
+  type: website
+  render:
+    - "**/*.md"

--- a/claude-notes/plans/listing-table-fields-investigation/repro/index.md
+++ b/claude-notes/plans/listing-table-fields-investigation/repro/index.md
@@ -1,0 +1,13 @@
+---
+title: Repro
+listing:
+  id: guides
+  contents: "./*/index.md"
+  type: table
+  fields: [title]
+  field-display-names:
+    title: "How To"
+---
+
+::: {#guides}
+:::

--- a/claude-notes/plans/listing-table-fields-investigation/repro/one/index.md
+++ b/claude-notes/plans/listing-table-fields-investigation/repro/one/index.md
@@ -1,0 +1,5 @@
+---
+title: First guide
+---
+
+Hello.

--- a/claude-notes/plans/listing-table-fields-investigation/repro/two/index.md
+++ b/claude-notes/plans/listing-table-fields-investigation/repro/two/index.md
@@ -1,0 +1,5 @@
+---
+title: Second guide
+---
+
+World.

--- a/crates/quarto-core/src/project/listing/binding.rs
+++ b/crates/quarto-core/src/project/listing/binding.rs
@@ -53,7 +53,6 @@ pub fn build_listing_context(
 ) -> TemplateContext {
     let mut ctx = TemplateContext::new();
 
-    ctx.insert("listing", build_listing_map(listing));
     // Effective date style for date-typed item fields (bd-13f821l5):
     // listing-level `date-format` > document `date-format` > `medium`
     // — Q1's precedence in website-listing-template.ts, with items
@@ -68,16 +67,57 @@ pub fn build_listing_context(
                 .and_then(|v| v.as_plain_text())
         })
         .map_or(DateStyle::Medium, |s| DateStyle::parse(&s));
+    // Effective field set: author-explicit `fields:` verbatim;
+    // defaulted sets presence-filtered against the items (Q1
+    // parity, bd-listing-table-fields-peg1w3b3). Everything below
+    // (the `listing.fields` binding, `show.*`, the table
+    // header/rows) reads this list, not `listing.fields`.
+    let fields = effective_fields(listing, items, &date_style);
+    ctx.insert("listing", build_listing_map(listing, &fields));
     ctx.insert(
         "items",
-        build_items_list(listing, items, host_dir, &date_style),
+        build_items_list(listing, items, host_dir, &date_style, &fields),
     );
     ctx.insert("project", build_project_map(project_meta));
 
     ctx
 }
 
-fn build_listing_map(listing: &Listing) -> TemplateValue {
+/// Q1 parity (`website-listing-read.ts` suggested-fields filter):
+/// a *defaulted* field set keeps only fields at least one item
+/// carries — `image` always survives (a listing-level
+/// `image-placeholder` can fill it at render time). If the filter
+/// empties the list, keep the unfiltered defaults (defensive;
+/// `title` is non-optional on [`ListingItem`], so built-in default
+/// sets can never fully empty). Author-explicit `fields:` is used
+/// verbatim.
+fn effective_fields(
+    listing: &Listing,
+    items: &[ListingItem],
+    date_style: &DateStyle,
+) -> Vec<String> {
+    if listing.fields_explicit {
+        return listing.fields.clone();
+    }
+    let filtered: Vec<String> = listing
+        .fields
+        .iter()
+        .filter(|f| {
+            f.as_str() == "image"
+                || items
+                    .iter()
+                    .any(|it| item_field_display_value(it, f, date_style).is_some())
+        })
+        .cloned()
+        .collect();
+    if filtered.is_empty() {
+        listing.fields.clone()
+    } else {
+        filtered
+    }
+}
+
+fn build_listing_map(listing: &Listing, fields: &[String]) -> TemplateValue {
     let mut m = HashMap::new();
     m.insert("id".to_string(), TemplateValue::String(listing.id.clone()));
     m.insert(
@@ -87,12 +127,30 @@ fn build_listing_map(listing: &Listing) -> TemplateValue {
     m.insert(
         "fields".to_string(),
         TemplateValue::List(
-            listing
-                .fields
+            fields
                 .iter()
                 .map(|s| TemplateValue::String(s.clone()))
                 .collect(),
         ),
+    );
+    m.insert(
+        "field-links".to_string(),
+        TemplateValue::List(
+            listing
+                .field_links
+                .as_deref()
+                .unwrap_or_default()
+                .iter()
+                .map(|s| TemplateValue::String(s.clone()))
+                .collect(),
+        ),
+    );
+    // Pre-rendered markdown header for the table built-in: the
+    // header row (display names) + the separator row
+    // (bd-listing-table-fields-peg1w3b3).
+    m.insert(
+        "table-header".to_string(),
+        TemplateValue::String(table_header(fields, &listing.field_display_names)),
     );
     m.insert(
         "page-size".to_string(),
@@ -175,12 +233,13 @@ fn build_items_list(
     items: &[ListingItem],
     host_dir: &str,
     date_style: &DateStyle,
+    fields: &[String],
 ) -> TemplateValue {
     TemplateValue::List(
         items
             .iter()
             .enumerate()
-            .map(|(i, item)| build_item_map(listing, item, i, host_dir, date_style))
+            .map(|(i, item)| build_item_map(listing, item, i, host_dir, date_style, fields))
             .collect(),
     )
 }
@@ -200,6 +259,7 @@ fn build_item_map(
     index: usize,
     host_dir: &str,
     date_style: &DateStyle,
+    fields: &[String],
 ) -> TemplateValue {
     let mut m = HashMap::new();
 
@@ -302,10 +362,8 @@ fn build_item_map(
     // `outputHref` retains the rendered .html path for templates
     // (e.g. L7's placeholder href, RSS feed item URLs) that need
     // the post-render output href specifically.
-    m.insert(
-        "path".to_string(),
-        TemplateValue::String(host_relative_qmd(&item.source_path, host_dir)),
-    );
+    let path = host_relative_qmd(&item.source_path, host_dir);
+    m.insert("path".to_string(), TemplateValue::String(path.clone()));
     m.insert(
         "outputHref".to_string(),
         TemplateValue::String(item.output_href.clone()),
@@ -323,7 +381,10 @@ fn build_item_map(
 
     // Pre-rendered helper strings.
     let img_html = helpers::image_html(item, listing, host_dir);
-    m.insert("image-html".to_string(), TemplateValue::String(img_html));
+    m.insert(
+        "image-html".to_string(),
+        TemplateValue::String(img_html.clone()),
+    );
     m.insert(
         "metadata-attrs".to_string(),
         TemplateValue::String(helpers::metadata_attrs(item, index)),
@@ -370,16 +431,187 @@ fn build_item_map(
         m.insert("extra".to_string(), TemplateValue::Map(extra));
     }
 
-    // Per-item show flags computed from listing.fields. Templates
-    // that want to know "did the listing config say to show field
-    // X?" read `$item.show.<field>$` (Q1 semantics).
+    // Per-item show flags computed from the effective field set
+    // (author-explicit fields, or presence-filtered defaults).
+    // Templates that want to know "did the listing config say to
+    // show field X?" read `$item.show.<field>$` (Q1 semantics).
     let mut show = HashMap::new();
-    for field in &listing.fields {
+    for field in fields {
         show.insert(field.clone(), TemplateValue::Bool(true));
     }
     m.insert("show".to_string(), TemplateValue::Map(show));
 
+    // Pre-rendered markdown table row for the table built-in
+    // (bd-listing-table-fields-peg1w3b3). Uses the values already
+    // computed above (path for linked cells, image-html for the
+    // image column).
+    m.insert(
+        "table-row".to_string(),
+        TemplateValue::String(table_row(
+            item, listing, fields, date_style, &path, &img_html,
+        )),
+    );
+
     TemplateValue::Map(m)
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Table listing pre-rendered strings
+// (bd-listing-table-fields-peg1w3b3)
+// ─────────────────────────────────────────────────────────────────
+
+/// Q1's built-in field display names (`_language.yml`
+/// `listing-page-field-*`, English hardcoded until Q2 grows
+/// language support). Unknown fields fall back to the raw field
+/// name — Q1's `utilities.fieldName` behavior, deliberately not
+/// title-cased.
+fn default_display_name(field: &str) -> &str {
+    match field {
+        "image" => " ",
+        "date" => "Date",
+        "title" => "Title",
+        "description" => "Description",
+        "author" => "Author",
+        "filename" => "File Name",
+        "date-modified" | "file-modified" => "Modified",
+        "subtitle" => "Subtitle",
+        "reading-time" => "Reading Time",
+        "word-count" => "Word Count",
+        "categories" => "Categories",
+        other => other,
+    }
+}
+
+fn display_name(field: &str, overrides: &std::collections::BTreeMap<String, String>) -> String {
+    overrides
+        .get(field)
+        .map_or_else(|| default_display_name(field), String::as_str)
+        .to_string()
+}
+
+/// Make a string safe inside one markdown pipe-table cell:
+/// newlines flatten to spaces (a cell is one line by definition)
+/// and `|` is escaped so it can't terminate the cell.
+fn escape_table_cell(s: &str) -> String {
+    s.replace("\r\n", " ")
+        .replace(['\n', '\r'], " ")
+        .replace('|', "\\|")
+}
+
+/// The pre-rendered `listing.table-header` value: header row from
+/// the effective fields (display-name overlay applied) plus the
+/// pipe-table separator row.
+fn table_header(
+    fields: &[String],
+    overrides: &std::collections::BTreeMap<String, String>,
+) -> String {
+    let names: Vec<String> = fields
+        .iter()
+        .map(|f| escape_table_cell(&display_name(f, overrides)))
+        .collect();
+    format!(
+        "| {} |\n|{}|",
+        names.join(" | "),
+        vec!["---"; fields.len().max(1)].join("|")
+    )
+}
+
+/// The pre-rendered per-item `table-row` value.
+fn table_row(
+    item: &ListingItem,
+    listing: &Listing,
+    fields: &[String],
+    date_style: &DateStyle,
+    path: &str,
+    image_html: &str,
+) -> String {
+    let linked = listing.field_links.as_deref().unwrap_or_default();
+    let cells: Vec<String> = fields
+        .iter()
+        .map(|field| {
+            if field == "image" {
+                return escape_table_cell(image_html);
+            }
+            let Some(value) = item_field_display_value(item, field, date_style) else {
+                return String::new();
+            };
+            let value = escape_table_cell(&value);
+            if !value.is_empty() && !path.is_empty() && linked.iter().any(|l| l == field) {
+                // Same link shape the templates use for titles;
+                // LinkRewriteTransform rewrites the `.qmd` target
+                // downstream.
+                format!("[{}]({}){{.no-external}}", value, path)
+            } else {
+                value
+            }
+        })
+        .collect();
+    format!("| {} |", cells.join(" | "))
+}
+
+/// Display value for one field of one item — the table-cell
+/// equivalent of Q1's `readField` + item-record pre-formatting.
+/// `None` means "the item doesn't carry this field" (renders as an
+/// empty cell; also drives presence filtering of defaulted field
+/// sets).
+fn item_field_display_value(
+    item: &ListingItem,
+    field: &str,
+    date_style: &DateStyle,
+) -> Option<String> {
+    match field {
+        "title" => Some(item.title.clone()),
+        "subtitle" => item.subtitle.clone(),
+        "description" => item.description.clone(),
+        "author" => item.author.clone(),
+        "authors" => (!item.authors.is_empty()).then(|| item.authors.join(", ")),
+        "date" => item.date.as_deref().map(|s| display_date(s, date_style)),
+        "date-modified" | "file-modified" => item
+            .date_modified
+            .as_deref()
+            .map(|s| display_date(s, date_style)),
+        "categories" => (!item.categories.is_empty()).then(|| item.categories.join(", ")),
+        "image-alt" => item.image_alt.clone(),
+        "reading-time" => item.reading_time_minutes.map(|n| format!("{} min read", n)),
+        "word-count" => item.word_count.map(|n| n.to_string()),
+        "filename" => item
+            .source_path
+            .file_name()
+            .and_then(|s| s.to_str())
+            .filter(|s| !s.is_empty())
+            .map(str::to_string),
+        _ => extra_field_value(&item.extra, field),
+    }
+}
+
+/// Free-form field lookup: literal key first, then Q1's
+/// dotted-path deref (`a.b` walks nested maps).
+fn extra_field_value(
+    extra: &std::collections::BTreeMap<String, ConfigValue>,
+    field: &str,
+) -> Option<String> {
+    if let Some(cv) = extra.get(field) {
+        return config_value_cell_string(cv);
+    }
+    if !field.contains('.') {
+        return None;
+    }
+    let mut parts = field.split('.');
+    let mut cv = extra.get(parts.next()?)?;
+    for part in parts {
+        cv = cv.get(part)?;
+    }
+    config_value_cell_string(cv)
+}
+
+/// Scalar → text; arrays join with `", "` (Q1 `readField`); maps
+/// have no cell representation.
+fn config_value_cell_string(cv: &ConfigValue) -> Option<String> {
+    if let Some(items) = cv.as_array() {
+        let parts: Vec<String> = items.iter().filter_map(config_value_cell_string).collect();
+        return Some(parts.join(", "));
+    }
+    cv.as_plain_text()
 }
 
 /// Compute a host-page-relative forward-slash path string for
@@ -799,6 +1031,260 @@ mod tests {
             m.get("category-html"),
             Some(&TemplateValue::String(String::new()))
         );
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // bd-listing-table-fields-peg1w3b3: dynamic table columns.
+    // `listing.table-header` + per-item `table-row` are pre-rendered
+    // markdown strings computed from listing.fields /
+    // field-display-names / field-links (Q1 parity).
+    // ─────────────────────────────────────────────────────────────
+
+    fn table_listing(fields: &[&str]) -> Listing {
+        let mut l = Listing {
+            id: "t".to_string(),
+            kind: ListingType::Table,
+            ..Listing::default()
+        };
+        apply_type_defaults(&mut l);
+        if !fields.is_empty() {
+            l.fields = fields.iter().map(|s| s.to_string()).collect();
+            l.fields_explicit = true;
+        }
+        // Decouple these unit tests from apply_type_defaults'
+        // field-links hydration; tests that want other linking set
+        // the field explicitly.
+        l.field_links
+            .get_or_insert_with(|| vec!["title".to_string(), "filename".to_string()]);
+        l
+    }
+
+    fn header_of(ctx: &TemplateContext) -> String {
+        let TemplateValue::String(s) = ctx
+            .get("listing")
+            .unwrap()
+            .get_path(&["table-header"])
+            .expect("listing.table-header present")
+            .clone()
+        else {
+            panic!("table-header not a string");
+        };
+        s
+    }
+
+    fn row_of(ctx: &TemplateContext) -> String {
+        let TemplateValue::List(arr) = ctx.get("items").unwrap() else {
+            panic!("items not a list");
+        };
+        let TemplateValue::Map(m) = &arr[0] else {
+            panic!("item not a map");
+        };
+        let TemplateValue::String(s) = m.get("table-row").expect("item table-row present") else {
+            panic!("table-row not a string");
+        };
+        s.clone()
+    }
+
+    fn ctx_for(l: &Listing, items: &[ListingItem]) -> TemplateContext {
+        build_listing_context(l, items, "posts", &ConfigValue::default())
+    }
+
+    #[test]
+    fn table_header_uses_display_name_overlay_and_defaults() {
+        let mut l = table_listing(&["date", "title", "author"]);
+        l.field_display_names
+            .insert("title".to_string(), "How To".to_string());
+        let ctx = ctx_for(&l, &[item("A")]);
+        assert_eq!(header_of(&ctx), "| Date | How To | Author |\n|---|---|---|");
+    }
+
+    #[test]
+    fn table_header_unknown_field_falls_back_to_raw_name() {
+        let l = table_listing(&["title", "status"]);
+        let ctx = ctx_for(&l, &[item("A")]);
+        assert_eq!(header_of(&ctx), "| Title | status |\n|---|---|");
+    }
+
+    // Q1's default display name for `image` is a single space.
+    #[test]
+    fn table_header_image_field_header_is_blank() {
+        let l = table_listing(&["image", "title"]);
+        let ctx = ctx_for(&l, &[item("A")]);
+        assert_eq!(header_of(&ctx), "|   | Title |\n|---|---|");
+    }
+
+    #[test]
+    fn table_row_links_title_and_formats_date() {
+        let l = table_listing(&["title", "date"]);
+        let ctx = ctx_for(&l, &[item("Hello")]);
+        assert_eq!(
+            row_of(&ctx),
+            "| [Hello](foo.qmd){.no-external} | Jan 1, 2026 |"
+        );
+    }
+
+    #[test]
+    fn table_row_missing_value_renders_empty_cell() {
+        let l = table_listing(&["title", "date"]);
+        let mut i = item("X");
+        i.date = None;
+        let ctx = ctx_for(&l, &[i]);
+        assert_eq!(row_of(&ctx), "| [X](foo.qmd){.no-external} |  |");
+    }
+
+    #[test]
+    fn table_row_escapes_pipes_and_flattens_newlines() {
+        let l = table_listing(&["title"]);
+        let mut i = item("A|B\nC");
+        i.date = None;
+        let ctx = ctx_for(&l, &[i]);
+        assert_eq!(row_of(&ctx), "| [A\\|B C](foo.qmd){.no-external} |");
+    }
+
+    #[test]
+    fn table_row_field_links_empty_unlinks_title() {
+        let mut l = table_listing(&["title"]);
+        l.field_links = Some(Vec::new());
+        let ctx = ctx_for(&l, &[item("Hello")]);
+        assert_eq!(row_of(&ctx), "| Hello |");
+    }
+
+    #[test]
+    fn table_row_filename_linked_by_default() {
+        let l = table_listing(&["filename"]);
+        let ctx = ctx_for(&l, &[item("X")]);
+        assert_eq!(row_of(&ctx), "| [foo.qmd](foo.qmd){.no-external} |");
+    }
+
+    #[test]
+    fn table_row_dotted_path_reads_nested_extra() {
+        use quarto_pandoc_types::ConfigMapEntry;
+        use quarto_source_map::SourceInfo;
+        let l = table_listing(&["title", "meta.status"]);
+        let mut i = item("X");
+        let inner = ConfigValue::new_map(
+            vec![ConfigMapEntry {
+                key: "status".to_string(),
+                key_source: SourceInfo::for_test(),
+                value: ConfigValue::new_string("draft", SourceInfo::for_test()),
+            }],
+            SourceInfo::for_test(),
+        );
+        i.extra.insert("meta".to_string(), inner);
+        let ctx = ctx_for(&l, &[i]);
+        assert_eq!(row_of(&ctx), "| [X](foo.qmd){.no-external} | draft |");
+    }
+
+    #[test]
+    fn table_row_array_extra_field_joins_with_comma() {
+        use quarto_pandoc_types::ConfigValue;
+        use quarto_source_map::SourceInfo;
+        let l = table_listing(&["tags"]);
+        let mut i = item("X");
+        i.extra.insert(
+            "tags".to_string(),
+            ConfigValue::new_array(
+                vec![
+                    ConfigValue::new_string("x", SourceInfo::for_test()),
+                    ConfigValue::new_string("y", SourceInfo::for_test()),
+                ],
+                SourceInfo::for_test(),
+            ),
+        );
+        let ctx = ctx_for(&l, &[i]);
+        assert_eq!(row_of(&ctx), "| x, y |");
+    }
+
+    #[test]
+    fn table_row_authors_and_categories_join_with_comma() {
+        let l = table_listing(&["authors", "categories"]);
+        let mut i = item("X");
+        i.authors = vec!["A".to_string(), "B".to_string()];
+        i.categories = vec!["rust".to_string(), "design".to_string()];
+        let ctx = ctx_for(&l, &[i]);
+        assert_eq!(row_of(&ctx), "| A, B | rust, design |");
+    }
+
+    #[test]
+    fn table_row_reading_time_uses_min_read_form() {
+        let l = table_listing(&["reading-time"]);
+        let ctx = ctx_for(&l, &[item("X")]);
+        assert_eq!(row_of(&ctx), "| 5 min read |");
+    }
+
+    #[test]
+    fn table_row_image_field_uses_image_html() {
+        let l = table_listing(&["image"]);
+        let mut i = item("X");
+        i.image = Some("static.png".to_string());
+        let ctx = ctx_for(&l, &[i]);
+        let row = row_of(&ctx);
+        assert!(row.contains("<img"), "expected inline img html: {row}");
+        assert!(!row.contains('\n'), "cell must be single-line: {row}");
+    }
+
+    // ── Presence filtering of *defaulted* fields (Q1 parity) ──
+
+    #[test]
+    fn defaulted_table_fields_presence_filtered_when_no_author() {
+        // Table default fields [date, title, author], NOT explicit.
+        let mut l = table_listing(&[]);
+        assert!(!l.fields_explicit);
+        l.field_links = Some(Vec::new());
+        let mut i = item("X");
+        i.author = None;
+        i.authors = Vec::new();
+        let ctx = ctx_for(&l, &[i]);
+        assert_eq!(header_of(&ctx), "| Date | Title |\n|---|---|");
+        assert_eq!(row_of(&ctx), "| Jan 1, 2026 | X |");
+        // The binding's fields list + show flags follow the filter.
+        let listing_map = ctx.get("listing").unwrap();
+        let TemplateValue::List(fields) = listing_map.get_path(&["fields"]).unwrap() else {
+            panic!("fields not a list");
+        };
+        assert_eq!(
+            fields,
+            &vec![
+                TemplateValue::String("date".to_string()),
+                TemplateValue::String("title".to_string())
+            ]
+        );
+        let TemplateValue::List(arr) = ctx.get("items").unwrap() else {
+            panic!()
+        };
+        let TemplateValue::Map(m) = &arr[0] else {
+            panic!()
+        };
+        let TemplateValue::Map(show) = m.get("show").unwrap() else {
+            panic!("show not a map");
+        };
+        assert!(!show.contains_key("author"));
+    }
+
+    #[test]
+    fn explicit_fields_never_presence_filtered() {
+        let mut l = table_listing(&["title", "author"]);
+        l.field_links = Some(Vec::new());
+        let mut i = item("X");
+        i.author = None;
+        i.authors = Vec::new();
+        let ctx = ctx_for(&l, &[i]);
+        assert_eq!(header_of(&ctx), "| Title | Author |\n|---|---|");
+        assert_eq!(row_of(&ctx), "| X |  |");
+    }
+
+    // `image` is exempt from presence filtering (Q1: placeholders
+    // can fill it at render time even when no item declares one).
+    #[test]
+    fn presence_filter_keeps_image_field() {
+        let mut l = table_listing(&[]);
+        l.fields = vec!["title".to_string(), "image".to_string()];
+        l.fields_explicit = false;
+        l.field_links = Some(Vec::new());
+        let mut i = item("X");
+        i.image = None;
+        let ctx = ctx_for(&l, &[i]);
+        assert_eq!(header_of(&ctx), "| Title |   |\n|---|---|");
     }
 
     #[test]

--- a/crates/quarto-core/src/project/listing/config.rs
+++ b/crates/quarto-core/src/project/listing/config.rs
@@ -37,9 +37,19 @@ pub struct Listing {
     pub kind: ListingType,
     pub contents: Vec<ListingContents>,
     pub fields: Vec<String>,
+    /// `true` when the author supplied a non-empty `fields:` list.
+    /// Author-explicit fields are used verbatim; defaulted fields are
+    /// presence-filtered against the hydrated items at render time
+    /// (Q1 parity, bd-listing-table-fields-peg1w3b3).
+    pub fields_explicit: bool,
     pub field_display_names: BTreeMap<String, String>,
     pub field_types: BTreeMap<String, ColumnType>,
-    pub field_links: Vec<String>,
+    /// Fields whose cell/entry value links to the item. `None` means
+    /// the author didn't specify; [`apply_type_defaults`] then fills
+    /// the Q1 default (`[title, filename]` for table listings, empty
+    /// otherwise). An author-explicit `field-links: []` stays `Some`
+    /// and disables linking entirely.
+    pub field_links: Option<Vec<String>>,
     pub field_sort: Vec<String>,
     pub field_filter: Vec<String>,
     pub field_required: Vec<String>,
@@ -85,9 +95,10 @@ impl Default for Listing {
             kind: ListingType::Default,
             contents: Vec::new(),
             fields: Vec::new(),
+            fields_explicit: false,
             field_display_names: BTreeMap::new(),
             field_types: BTreeMap::new(),
-            field_links: Vec::new(),
+            field_links: None,
             field_sort: Vec::new(),
             field_filter: Vec::new(),
             field_required: Vec::new(),
@@ -465,6 +476,9 @@ fn parse_one_listing(
             }
             "fields" => {
                 l.fields = parse_string_list(&entry.value);
+                // Explicit-but-empty `fields: []` falls through to
+                // the type defaults, same as omitting the key.
+                l.fields_explicit = !l.fields.is_empty();
             }
             "field-display-names" => {
                 l.field_display_names = parse_string_string_map(&entry.value, diagnostics);
@@ -472,7 +486,7 @@ fn parse_one_listing(
             "field-types" => {
                 l.field_types = parse_field_types(&entry.value, diagnostics);
             }
-            "field-links" => l.field_links = parse_string_list(&entry.value),
+            "field-links" => l.field_links = Some(parse_string_list(&entry.value)),
             "field-sort" => l.field_sort = parse_string_list(&entry.value),
             "field-filter" => l.field_filter = parse_string_list(&entry.value),
             "field-required" => l.field_required = parse_string_list(&entry.value),
@@ -917,6 +931,16 @@ pub fn apply_type_defaults(l: &mut Listing) {
         .into_iter()
         .map(String::from)
         .collect();
+    }
+    // Q1's `kDefaultFieldLinks`: table listings link title +
+    // filename cells; other types link nothing by default. An
+    // author-explicit `field-links:` (even `[]`) is already `Some`
+    // and wins.
+    if l.field_links.is_none() {
+        l.field_links = Some(match l.kind {
+            ListingType::Table => vec!["title".to_string(), "filename".to_string()],
+            _ => Vec::new(),
+        });
     }
     // Type-specific knobs (only fill None).
     match l.kind {
@@ -1446,6 +1470,76 @@ listing:
         assert!(listings[0].sort_ui);
         assert!(listings[0].filter_ui);
         assert_eq!(listings[0].page_size, 30);
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // bd-listing-table-fields-peg1w3b3: field-links defaults +
+    // explicit-fields tracking (Q1 parity for table listings).
+    // ─────────────────────────────────────────────────────────────
+
+    // Q1 `kDefaultFieldLinks` applies to table listings only.
+    #[test]
+    fn field_links_defaults_to_title_filename_for_table() {
+        let (listings, _) = parse(s("table"));
+        assert_eq!(
+            listings[0].field_links,
+            Some(vec!["title".to_string(), "filename".to_string()])
+        );
+    }
+
+    #[test]
+    fn field_links_defaults_to_empty_for_non_table_types() {
+        let (listings, _) = parse(s("default"));
+        assert_eq!(listings[0].field_links, Some(Vec::new()));
+        let (listings, _) = parse(s("grid"));
+        assert_eq!(listings[0].field_links, Some(Vec::new()));
+    }
+
+    // Author-explicit `field-links: []` disables linking; the table
+    // default must not overwrite it.
+    #[test]
+    fn field_links_explicit_empty_survives_table_defaults() {
+        let (listings, _) = parse(map(vec![
+            ("type", s("table")),
+            ("field-links", arr(vec![])),
+        ]));
+        assert_eq!(listings[0].field_links, Some(Vec::new()));
+    }
+
+    #[test]
+    fn field_links_explicit_list_parses() {
+        let (listings, _) = parse(map(vec![
+            ("type", s("table")),
+            ("field-links", arr(vec![s("author")])),
+        ]));
+        assert_eq!(listings[0].field_links, Some(vec!["author".to_string()]));
+    }
+
+    // `fields_explicit` gates render-time presence filtering: only
+    // *defaulted* field sets are filtered against the items.
+    #[test]
+    fn fields_explicit_true_when_author_supplies_fields() {
+        let (listings, _) = parse(map(vec![
+            ("type", s("table")),
+            ("fields", arr(vec![s("title")])),
+        ]));
+        assert!(listings[0].fields_explicit);
+        assert_eq!(listings[0].fields, vec!["title"]);
+    }
+
+    #[test]
+    fn fields_explicit_false_when_fields_defaulted() {
+        let (listings, _) = parse(s("table"));
+        assert!(!listings[0].fields_explicit);
+    }
+
+    // Explicit-but-empty `fields: []` falls back to the type default
+    // set and is treated as non-explicit (same as today).
+    #[test]
+    fn fields_empty_list_treated_as_defaulted() {
+        let (listings, _) = parse(map(vec![("type", s("table")), ("fields", arr(vec![]))]));
+        assert!(!listings[0].fields_explicit);
+        assert_eq!(listings[0].fields, vec!["date", "title", "author"]);
     }
 
     // template + non-custom type → Q-12-7

--- a/crates/quarto-core/src/project/listing/templates/item-table.template
+++ b/crates/quarto-core/src/project/listing/templates/item-table.template
@@ -1,1 +1,1 @@
-| [$title$]($path$){.no-external} | $date$ | $author$ |
+$table-row$

--- a/crates/quarto-core/src/project/listing/templates/listing-table.template
+++ b/crates/quarto-core/src/project/listing/templates/listing-table.template
@@ -1,7 +1,8 @@
 ::: {.quarto-listing-table-wrapper}
 
-| Title | Date | Author |
-|-------|------|--------|
-$items:item-table()$
+$listing.table-header$
+$for(items)$
+$it:item-table()$
+$endfor$
 
 :::

--- a/crates/quarto-core/src/transforms/listing_render.rs
+++ b/crates/quarto-core/src/transforms/listing_render.rs
@@ -640,6 +640,44 @@ mod tests {
         }
     }
 
+    // bd-listing-table-fields-peg1w3b3: a table listing with an
+    // author-explicit `fields:` subset must render only those
+    // columns and must not emit per-item "Undefined variable"
+    // doctemplate diagnostics (previously surfaced as Q-12-10) for
+    // curated fields the items lack.
+    #[tokio::test]
+    async fn table_fields_subset_renders_single_column_without_diagnostics() {
+        let mut listing = make_listing(ListingType::Table);
+        listing.fields = vec!["title".to_string()];
+        listing.fields_explicit = true;
+        listing
+            .field_display_names
+            .insert("title".to_string(), "How To".to_string());
+        // Neither item has a date; both have author "Jane" (which
+        // must not leak into the single-column table).
+        let items = vec![make_item("alpha", None), make_item("beta", None)];
+        let resolved = vec![ResolvedListing { listing, items }];
+        let (ast, diags) = run_transform(empty_pandoc(), resolved).await;
+        assert!(
+            diags.is_empty(),
+            "fields subset must not produce Q-12-10 diagnostics; got: {:?}",
+            diags
+        );
+        let rendered = format!("{:?}", ast);
+        assert!(
+            rendered.contains("How"),
+            "expected `How To` header in rendered table; got: {rendered}"
+        );
+        assert!(
+            !rendered.contains("Jane"),
+            "author column leaked into a fields: [title] table; got: {rendered}"
+        );
+        assert!(
+            !rendered.contains("Author"),
+            "Author header leaked into a fields: [title] table; got: {rendered}"
+        );
+    }
+
     // 33. render_emits_div_at_listing_id_slot
     #[tokio::test]
     async fn render_fills_explicit_slot() {

--- a/crates/quarto-core/tests/integration/listing_pipeline.rs
+++ b/crates/quarto-core/tests/integration/listing_pipeline.rs
@@ -317,6 +317,128 @@ fn table_type_emits_listing_table_wrapper() {
     assert!(host.contains("Jan 15, 2026"));
 }
 
+/// bd-listing-table-fields-peg1w3b3 e2e: `fields:` selects the
+/// column set and `field-display-names:` renames headers (the
+/// Posit Connect docs "How To" case). Items lacking date/author
+/// must not produce extra columns.
+#[test]
+fn table_fields_and_display_names_render_single_column() {
+    let (_dir, outputs) = render_project(|p| {
+        write(
+            &p.join("_quarto.yml"),
+            "project:\n  type: website\n  output-dir: _site\nwebsite:\n  title: \"My Site\"\n",
+        );
+        write(
+            &p.join("posts/index.qmd"),
+            "---\ntitle: Guides\nlisting:\n  id: guides\n  type: table\n  fields: [title]\n  field-display-names:\n    title: \"How To\"\nformat: html\n---\n\n::: {#guides}\n:::\n",
+        );
+        // Neither item has date or author.
+        write(
+            &p.join("posts/a.qmd"),
+            "---\ntitle: First guide\nformat: html\n---\n\nBody A.\n",
+        );
+        write(
+            &p.join("posts/b.qmd"),
+            "---\ntitle: Second guide\nformat: html\n---\n\nBody B.\n",
+        );
+    });
+
+    let host = html_for(&outputs, "index");
+    assert!(host.contains("quarto-listing-table-wrapper"));
+    // Exactly one column, renamed via field-display-names.
+    assert_eq!(
+        host.matches("<th>").count(),
+        1,
+        "expected exactly one table header cell; got:\n{}",
+        host
+    );
+    assert!(
+        host.contains("How To"),
+        "expected `How To` display-name header; got:\n{}",
+        host
+    );
+    assert!(
+        !host.contains("<th>Title") && !host.contains("<th>Date") && !host.contains("<th>Author"),
+        "hardcoded Title/Date/Author headers leaked; got:\n{}",
+        host
+    );
+    // Both items link to their pages.
+    assert!(host.contains("First guide") && host.contains("Second guide"));
+    assert!(host.contains(r#"href="a.html""#) && host.contains(r#"href="b.html""#));
+    // Each item is its own table row: 1 header + 2 body rows. (The
+    // doctemplate resolver chomps a partial's final newline, so a
+    // naive `$items:item-table()$` merges all rows into one — the
+    // listing template must iterate with per-row separation.)
+    assert_eq!(
+        host.matches("<tr").count(),
+        3,
+        "expected one header row + one row per item; got:\n{}",
+        host
+    );
+    assert!(
+        !host.contains("<td>|"),
+        "leaked pipe chars indicate merged table rows; got:\n{}",
+        host
+    );
+}
+
+/// bd-listing-table-fields-peg1w3b3 e2e: with no author-supplied
+/// `fields:`, the table default set `[date, title, author]` is
+/// presence-filtered against the items (Q1 parity) — items with no
+/// author ⇒ no Author column — and keeps Q1's Date-before-Title
+/// column order.
+#[test]
+fn table_default_fields_presence_filtered_and_ordered() {
+    let (_dir, outputs) = render_project(|p| {
+        write(
+            &p.join("_quarto.yml"),
+            "project:\n  type: website\n  output-dir: _site\nwebsite:\n  title: \"My Site\"\n",
+        );
+        write(
+            &p.join("posts/index.qmd"),
+            "---\ntitle: Blog\nlisting:\n  type: table\nformat: html\n---\n",
+        );
+        write(
+            &p.join("posts/a.qmd"),
+            "---\ntitle: First\ndate: 2026-01-15\nformat: html\n---\n\nBody.\n",
+        );
+        write(
+            &p.join("posts/b.qmd"),
+            "---\ntitle: Second\ndate: 2026-02-20\nformat: html\n---\n\nBody.\n",
+        );
+    });
+
+    let host = html_for(&outputs, "index");
+    assert_eq!(
+        host.matches("<th>").count(),
+        2,
+        "expected Date + Title columns only; got:\n{}",
+        host
+    );
+    assert!(
+        !host.contains("<th>Author"),
+        "Author column must be presence-filtered out; got:\n{}",
+        host
+    );
+    let p_date = host.find("<th>Date").expect("Date header missing");
+    let p_title = host.find("<th>Title").expect("Title header missing");
+    assert!(
+        p_date < p_title,
+        "expected Q1 column order Date | Title; positions: date={p_date}, title={p_title}"
+    );
+    // Cell data flows through: formatted date + linked titles.
+    assert!(host.contains("Jan 15, 2026") && host.contains("Feb 20, 2026"));
+    assert!(host.contains(r#"href="a.html""#) && host.contains(r#"href="b.html""#));
+    // One header row + one row per item (see the row-separation
+    // note in table_fields_and_display_names_render_single_column).
+    assert_eq!(
+        host.matches("<tr").count(),
+        3,
+        "expected one header row + one row per item; got:\n{}",
+        host
+    );
+}
+
 #[test]
 fn explicit_slot_div_id_is_filled() {
     // When the host page contains a Div with id matching

--- a/crates/wasm-quarto-hub-client/Cargo.lock
+++ b/crates/wasm-quarto-hub-client/Cargo.lock
@@ -377,7 +377,7 @@ dependencies = [
 
 [[package]]
 name = "comrak-to-pandoc"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "comrak",
  "hashlink",
@@ -2074,7 +2074,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-analysis"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "quarto-error-reporting",
  "quarto-pandoc-types",
@@ -2096,7 +2096,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-brand"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "pathdiff",
  "quarto-util",
@@ -2107,7 +2107,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-citeproc"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "glob",
  "hashlink",
@@ -2138,7 +2138,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-core"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2190,7 +2190,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-csl"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "quarto-error-reporting",
  "quarto-source-map",
@@ -2241,7 +2241,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-highlight"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "once_cell",
  "quarto-highlight-encoding",
@@ -2267,7 +2267,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-highlight-encoding"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2275,7 +2275,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-lsp-core"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "pampa",
  "pollster",
@@ -2296,7 +2296,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-navigation"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "quarto-config",
  "quarto-pandoc-types",
@@ -2331,7 +2331,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-project-create"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "quarto-doctemplate",
  "serde",
@@ -2341,7 +2341,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-sass"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "include_dir",
  "once_cell",
@@ -2371,7 +2371,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-system-runtime"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -2388,7 +2388,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-trace"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "flate2",
  "serde",
@@ -2406,7 +2406,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-util"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -2414,7 +2414,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-xml"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "quarto-error-reporting",
  "quarto-source-map",
@@ -4021,7 +4021,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-printf-fmt"
-version = "0.13.0"
+version = "0.14.0"
 
 [[package]]
 name = "wasm-quarto-hub-client"


### PR DESCRIPTION
## Summary

The built-in table listing templates hardcoded `| Title | Date | Author |`, ignoring `fields:` and `field-display-names:` and emitting a `Q-12-10` undefined-variable warning per listing for items lacking date/author (real-world hit: Posit Connect docs `how-to/index.md`).

The doctemplate language is logic-less, so dynamic columns come from Rust: the binding now pre-renders `listing.table-header` and a per-item `table-row` markdown string (additive L8 binding keys), and the table templates shrink to interpolating them.

Q1-parity semantics, per the design session recorded in `claude-notes/plans/2026-08-09-listing-table-fields.md`:

- **Headers:** built-in default display-name map (Title, Date, Author, …, `image → " "`) overlaid with `field-display-names`; unknown fields fall back to the raw field name.
- **Cells:** curated fields from the item struct; unknown fields via literal-then-dotted-path `extra` lookup; arrays join `", "`; `image` → `image-html`; missing values → empty cell (no more Q-12-10).
- **`field-links`:** new config surface (was parsed but unused), table default `[title, filename]`; typed `Option` so an explicit `field-links: []` genuinely unlinks.
- **Defaulted field sets** (no author `fields:`) are presence-filtered against the items — items with no authors ⇒ no Author column — and default order is Q1's **Date | Title | Author**.
- Cell values are pipe-escaped / newline-flattened (markdown pipe-table limitation, accepted in design).

### Latent bug also fixed

The doctemplate resolver chomps a partial's final newline (Pandoc `removeFinalNl` parity), so the old `$items:item-table()$` merged **every item into a single table row** for any table listing with ≥2 items. The listing template now iterates with `$for(items)$ $it:item-table()$ $endfor$`; both e2e tests assert row structure.

## Verification

- TDD: 27 new tests (config/binding/transform/e2e), written first and verified failing; 11179 workspace tests pass; **zero snapshot changes**; full `cargo xtask verify` (incl. WASM leg) green.
- Real-binary e2e on the committed repro (`claude-notes/plans/listing-table-fields-investigation/repro/`): single `<th>How To</th>`, one `<tr>` per item, linked titles, zero warnings. Also verified on `docs/errors/index.qmd` (itself a `type: table` listing).
- `wasm-quarto-hub-client/Cargo.lock` diff is the 0.13→0.14 workspace version bumps finally reaching the standalone lockfile (refreshes only when the WASM leg builds).

## Follow-ups filed

- **bd-bl1e00r6** — interactive table parity (sort-ui anchors, table-hover onclick, list.js field classes).
- **bd-0t4e07jk** — bare top-level frontmatter keys as listing fields (Q1 exposes all metadata; Q2 requires `listing-item.extra:` opt-in — design decision pending).

🤖 Generated with [Claude Code](https://claude.com/claude-code)