### PR TITLE
Q-2-41: bare-brace parse errors now hint at escaping literal braces

### DIFF
--- a/claude-notes/plans/2026-08-09-bare-brace-escape-hint.md
+++ b/claude-notes/plans/2026-08-09-bare-brace-escape-hint.md
@@ -1,0 +1,152 @@
+# pampa: bare-brace parse error should hint at escaping literal braces (bd-brace-escape-hint-0tmemkyt)
+
+**Date:** 2026-08-09
+**Braid:** bd-brace-escape-hint-0tmemkyt (feature, p2, label `diagnostics`)
+**Branch:** `main` @ `ec8a35f9` (investigation committed in place; no worktree created)
+**Status:** Investigation — pending design alignment with user. **Do not start implementation until the user gives the go-ahead.**
+
+## Triage verdict
+
+**Ready to design.** The mechanism is proven (Q-2-36 "path B" pure-corpus
+precedent), the target `(state, sym)` pairs are captured and verified
+unclaimed in the autogen table, and the repro is confirmed at HEAD. What
+remains is wording, case scope, highlight treatment, and code/catalog
+registration — all user-facing decisions.
+
+## Issue context
+
+Filed 2026-08-09 by Carlos. A bare brace run in prose — e.g. `the request
+returns the task {guid} immediately.` — is a fatal parse error in q2,
+reported only with the generic fallback "Parse error: unexpected character
+or token here". Single-file render produces no output; project render
+silently drops the page (`warning: profile-pass skipped <file>`).
+
+The brace reservation is **by design and not in question**: escaped braces
+`\{...\}` parse cleanly in q2 and render identically under Pandoc, so
+escaping is the correct Q1-compatible source fix. The strand asks only for
+a **targeted diagnostic** hinting at escaping when the fallback fires at a
+brace run.
+
+Real-world driver: porting Q1 projects — REST API docs write path
+parameters as `{name}` constantly (the generated Posit Connect API
+reference hit this dozens of times across ~160 endpoints). Origin strand in
+the connect-docs skein: `br-brace-escape-hint-z8vy6sis`; external repro at
+`~/repos/github/cscheid/q2-connect-docs/llms-info/repros/bare-braces-parse-error/`
+(README states expected vs. actual; a copy of the repro's behavior facts is
+in this plan's investigation dir).
+
+## Dependency graph
+
+**Empty** — no edges in this skein (`braid dep tree` / `dep list` show
+nothing). The why-filed context lives in the origin strand in the
+connect-docs project skein (`br-brace-escape-hint-z8vy6sis`) and is fully
+restated in this strand's description, so nothing is lost.
+
+## What the code looks like today
+
+All paths in the strand description check out at HEAD:
+
+- Generic fallback: `crates/quarto-parse-errors/src/error_generation.rs:243-249`
+  (`DiagnosticMessageBuilder::error("Parse error").problem("unexpected character or token here")`).
+- Reproduced at HEAD (`ec8a35f9`): `cargo run --bin pampa -- repro.qmd`
+  emits the generic fallback with the highlight on the word *inside* the
+  braces. Fixture: `claude-notes/plans/bare-brace-escape-hint-investigation/repro.qmd`.
+- Error-state capture (full table + collision check in
+  `bare-brace-escape-hint-investigation/error-states.md`):
+  - Prose `{guid}` → `(2613, _language_specifier_token)` — **unclaimed** in
+    `_autogen-table.json`.
+  - Link-text `{guid}` → `(2589, _language_specifier_token)` — **unclaimed**.
+  - `[text]{guid}` (attribute-intent typo) → **same** `(2613, _language_specifier_token)`;
+    one mapping covers both readings, so the message must serve both.
+  - Unclosed `trailing {guid` at EOL → `(2613, shortcode_name)` — different
+    lookahead; separate scope decision.
+- Mechanism precedent: Q-2-36 (`claude-notes/plans/2026-05-14-q-2-36-knitr-style-chunk-options.md`,
+  commit `666f8b7e`), path B — add a corpus JSON under
+  `crates/pampa/resources/error-corpus/`, run
+  `./crates/pampa/scripts/build_error_table.ts` (deno) to regenerate
+  `case-files/*.qmd` + `_autogen-table.json`, and the corpus snapshot tests
+  in pampa glob the new case files automatically. **No grammar, scanner, or
+  error_generation.rs change needed.**
+- Error code numbering: highest existing is Q-2-40 → **Q-2-41** is next
+  free. Note: corpus codes and `crates/quarto-error-catalog/error_catalog.json`
+  are not fully synced today (Q-2-36 has a corpus entry but no catalog
+  entry; Q-2-40 has a catalog entry) — registration is a design question
+  below.
+
+## Proposed phases (draft)
+
+Skeleton only — contents wait on the design discussion.
+
+- **Phase 0 — Test plan (TDD).** Add `Q-2-41.json` corpus entry with the
+  agreed cases; regenerate the table; confirm the new case-file snapshots
+  under `crates/pampa/snapshots/error-corpus/` show the targeted message
+  (before regeneration, running the case inputs shows the generic fallback
+  — that asymmetry is the failing-test artifact, same shape as Q-2-36
+  Phase 0b).
+- **Phase 1 — Corpus + table regeneration.** Land the corpus entry, the
+  regenerated `_autogen-table.json`, and generated `case-files/Q-2-41-*.qmd`.
+- **Phase 2 — Highlight treatment (if any).** Depending on design answer:
+  nothing (keep narrow token highlight), or enroll Q-2-41 in
+  `widen_diagnostic_to_line` (`crates/pampa/src/readers/qmd_error_messages.rs`),
+  or new brace-run widening (probably over-engineering — flag if we get here).
+- **Phase 3 — End-to-end verification.** `cargo run --bin pampa --` on the
+  fixtures + `cargo run --bin q2 -- render` on a copy of the repro
+  (single-file and project-render forms, since the project form is where
+  the page-drop symptom shows); full workspace nextest; snapshot-change
+  report per CLAUDE.md.
+- **Phase 4 — Docs + catalog (per design answers).** Possibly register
+  Q-2-41 in `quarto-error-catalog`; possibly a line in docs/ about escaping
+  literal braces.
+
+## Open design questions for the user
+
+1. **Message wording.** `(2613, _language_specifier_token)` fires for both
+   prose braces (`task {guid}`) and attribute-intent typos
+   (`[text]{guid}`), so the message should serve both readers, like
+   Q-2-36's either/or wording. Draft:
+   *"Curly braces are reserved for attribute syntax in Quarto markdown.
+   To write literal braces, escape them as `\{...\}`. If you meant to
+   attach an attribute, use `.class` / `#id` / `key="value"` syntax, e.g.
+   `[text]{.class}`."* — Adjust title/message/hint split? (Corpus entries
+   render the `message` as the inline span label, as Q-2-36 does.)
+2. **Case scope.** Definitely: bare-paragraph brace run + brace run inside
+   link text (the two states from the strand). Also include the unclosed
+   `trailing {guid` EOL form, which is a *different* pair
+   `(2613, shortcode_name)`? Risk: that lookahead may also fire for broken
+   shortcode syntax (`{{< ... >}}` typos) — mapping it to a brace-escape
+   message could mislead shortcode authors. My lean: leave it out, note it
+   as a possible follow-up.
+3. **Highlight treatment.** Today the fallback highlights the word inside
+   the braces (`guid`), excluding the braces themselves. Options:
+   (a) accept the default narrow highlight — the message text carries the
+   meaning; (b) enroll Q-2-41 in `widen_diagnostic_to_line` like
+   Q-2-35/Q-2-36 — but prose lines can be long, and line-wide underlines
+   on a paragraph feel worse than on a code-block header. My lean: (a).
+4. **Error code + catalog registration.** Use Q-2-41? And should it be
+   registered in `crates/quarto-error-catalog/error_catalog.json` (Q-2-40
+   is registered; Q-2-36 never was)? If the catalog is meant to be the
+   authoritative code registry, this is also a chance to backfill Q-2-36 —
+   or file that as a separate chore strand.
+5. **Docs.** Q-2-36 deliberately added no docs page. Is there an existing
+   docs/ page on qmd syntax differences where "braces are reserved; escape
+   literal braces as `\{...\}`" belongs, or skip docs entirely and let the
+   diagnostic carry it?
+
+## Risks / tradeoffs (draft)
+
+- **State-number churn.** Corpus mappings key on LR state numbers; any
+  grammar regeneration renumbers states and the build script re-derives
+  them from the case files. That's the established maintenance model
+  (all 37 existing codes live with it) — no new risk, just worth knowing
+  the mapping is example-derived, not hand-pinned.
+- **Overbreadth of the mapping.** Any input that lands in
+  `(2613, _language_specifier_token)` gets the brace-escape message. The
+  captures suggest this state is specifically "just consumed `{` in inline
+  context, content isn't valid attribute syntax", and the either/or wording
+  covers the plausible intents. If a colliding non-brace input surfaces
+  later, the corpus snapshot tests would show it.
+- **The page-drop symptom is out of scope.** The silent
+  `profile-pass skipped` project-render behavior (page dropped from site on
+  parse error) is pre-existing reader/render architecture, not part of this
+  strand. If the user wants that loudness improved, it should be its own
+  strand.

--- a/claude-notes/plans/2026-08-09-bare-brace-escape-hint.md
+++ b/claude-notes/plans/2026-08-09-bare-brace-escape-hint.md
@@ -3,7 +3,24 @@
 **Date:** 2026-08-09
 **Braid:** bd-brace-escape-hint-0tmemkyt (feature, p2, label `diagnostics`)
 **Branch:** `main` @ `ec8a35f9` (investigation committed in place; no worktree created)
-**Status:** Investigation — pending design alignment with user. **Do not start implementation until the user gives the go-ahead.**
+**Status:** Design settled with user (2026-08-09) — implementation in progress.
+
+## Settled design decisions (user-confirmed 2026-08-09)
+
+1. **Wording:** approved as drafted (see Phase 1 below for the exact strings).
+2. **Scope:** narrow — only the two `_language_specifier_token` states
+   (bare-paragraph and link-text brace runs). The unclosed `{guid` EOL form
+   (`(2613, shortcode_name)`) is deliberately left out: that lookahead
+   likely also fires for shortcode typos, and we have overdesigned
+   diagnostics before and had to trim them back.
+3. **Highlight:** keep the default narrow token highlight; no
+   `widen_diagnostic_to_line` enrollment.
+4. **Code:** Q-2-41, registered in `crates/quarto-error-catalog/error_catalog.json`
+   from the start. The Q-2-36/37/38 catalog+docs lapses are filed as
+   **bd-cx1det1y** (chore, discovered-from this strand).
+5. **Docs:** write a draft docs page (`docs/errors/markdown/Q-2-41.qmd`)
+   per the `docs/errors/README.md` template — do not repeat the Q-2-36
+   skip.
 
 ## Triage verdict
 
@@ -73,64 +90,85 @@ All paths in the strand description check out at HEAD:
   entry; Q-2-40 has a catalog entry) — registration is a design question
   below.
 
-## Proposed phases (draft)
+## Work items
 
-Skeleton only — contents wait on the design discussion.
+### Phase 0 — TDD baseline (failing-test artifact)
 
-- **Phase 0 — Test plan (TDD).** Add `Q-2-41.json` corpus entry with the
-  agreed cases; regenerate the table; confirm the new case-file snapshots
-  under `crates/pampa/snapshots/error-corpus/` show the targeted message
-  (before regeneration, running the case inputs shows the generic fallback
-  — that asymmetry is the failing-test artifact, same shape as Q-2-36
-  Phase 0b).
-- **Phase 1 — Corpus + table regeneration.** Land the corpus entry, the
-  regenerated `_autogen-table.json`, and generated `case-files/Q-2-41-*.qmd`.
-- **Phase 2 — Highlight treatment (if any).** Depending on design answer:
-  nothing (keep narrow token highlight), or enroll Q-2-41 in
-  `widen_diagnostic_to_line` (`crates/pampa/src/readers/qmd_error_messages.rs`),
-  or new brace-run widening (probably over-engineering — flag if we get here).
-- **Phase 3 — End-to-end verification.** `cargo run --bin pampa --` on the
-  fixtures + `cargo run --bin q2 -- render` on a copy of the repro
-  (single-file and project-render forms, since the project form is where
-  the page-drop symptom shows); full workspace nextest; snapshot-change
-  report per CLAUDE.md.
-- **Phase 4 — Docs + catalog (per design answers).** Possibly register
-  Q-2-41 in `quarto-error-catalog`; possibly a line in docs/ about escaping
-  literal braces.
+- [x] Confirmed at HEAD (`ec8a35f9`) that both case inputs produce the
+  generic fallback "Parse error: unexpected character or token here"
+  (prose case via `repro.qmd`, states captured in
+  `bare-brace-escape-hint-investigation/error-states.md`). The corpus
+  mechanism's failing-test artifact is this asymmetry: before table
+  regeneration the case inputs show the fallback; after, they must show
+  `[Q-2-41]` (same shape as Q-2-36 Phase 0b).
 
-## Open design questions for the user
+### Phase 1 — Corpus entry + table regeneration
 
-1. **Message wording.** `(2613, _language_specifier_token)` fires for both
-   prose braces (`task {guid}`) and attribute-intent typos
-   (`[text]{guid}`), so the message should serve both readers, like
-   Q-2-36's either/or wording. Draft:
-   *"Curly braces are reserved for attribute syntax in Quarto markdown.
-   To write literal braces, escape them as `\{...\}`. If you meant to
-   attach an attribute, use `.class` / `#id` / `key="value"` syntax, e.g.
-   `[text]{.class}`."* — Adjust title/message/hint split? (Corpus entries
-   render the `message` as the inline span label, as Q-2-36 does.)
-2. **Case scope.** Definitely: bare-paragraph brace run + brace run inside
-   link text (the two states from the strand). Also include the unclosed
-   `trailing {guid` EOL form, which is a *different* pair
-   `(2613, shortcode_name)`? Risk: that lookahead may also fire for broken
-   shortcode syntax (`{{< ... >}}` typos) — mapping it to a brace-escape
-   message could mislead shortcode authors. My lean: leave it out, note it
-   as a possible follow-up.
-3. **Highlight treatment.** Today the fallback highlights the word inside
-   the braces (`guid`), excluding the braces themselves. Options:
-   (a) accept the default narrow highlight — the message text carries the
-   meaning; (b) enroll Q-2-41 in `widen_diagnostic_to_line` like
-   Q-2-35/Q-2-36 — but prose lines can be long, and line-wide underlines
-   on a paragraph feel worse than on a code-block header. My lean: (a).
-4. **Error code + catalog registration.** Use Q-2-41? And should it be
-   registered in `crates/quarto-error-catalog/error_catalog.json` (Q-2-40
-   is registered; Q-2-36 never was)? If the catalog is meant to be the
-   authoritative code registry, this is also a chance to backfill Q-2-36 —
-   or file that as a separate chore strand.
-5. **Docs.** Q-2-36 deliberately added no docs page. Is there an existing
-   docs/ page on qmd syntax differences where "braces are reserved; escape
-   literal braces as `\{...\}`" belongs, or skip docs entirely and let the
-   diagnostic carry it?
+- [x] Add `crates/pampa/resources/error-corpus/Q-2-41.json`:
+  - code `Q-2-41`, title **"Curly braces are reserved for attribute syntax"**
+  - message: *"Curly braces are reserved for attribute syntax in Quarto
+    markdown. To write literal braces, escape them as `\{...\}`. If you
+    meant to attach an attribute, use `.class` / `#id` / `key="value"`
+    syntax, e.g. `[text]{.class}`."*
+  - cases: `prose` (`the request returns the task {guid} immediately.`)
+    and `link-text` (`see [the {guid} link](https://example.com) here.`);
+    `captures: []`, no notes (narrow highlight by design).
+- [x] Run `./crates/pampa/scripts/build_error_table.ts` (deno, from
+  `crates/pampa/`); confirmed `case-files/Q-2-41-{prose,link-text}.qmd`
+  generated and exactly two new `_autogen-table.json` entries at
+  `(2613, _language_specifier_token)` and `(2589, _language_specifier_token)`
+  (diff purely additive: +30 lines, 0 deletions — no state renumbering).
+  Duplicate-pair warnings unchanged (pre-existing Q-2-10/Q-2-11/… ones
+  only, none for Q-2-41). Stray `deno.lock` created by the deno run was
+  removed (deleted deliberately in a258b2ae).
+- [x] `cargo run --bin pampa --` on both case files → `[Q-2-41]` with the
+  approved message; narrow highlight on the word inside the braces.
+  Controls verified: `\{guid\}` → literal text, `[text]{.cls}` → Span,
+  `[text]{guid}` → Q-2-41 (either/or wording serves it).
+- [x] pampa test suite: **4300/4300 pass, 2 skipped.** Zero snapshot
+  changes (matches Q-2-36 experience: corpus snapshot tests glob
+  top-level `error-corpus/*.qmd`, which is empty; the `case-files/`
+  iterating tests assert diagnostics are produced).
+
+### Phase 2 — Catalog + docs
+
+- [x] Registered Q-2-41 in `crates/quarto-error-catalog/error_catalog.json`
+  (subsystem `markdown`, `docs_url`
+  `https://quarto.org/docs/errors/markdown/Q-2-41`, `since_version`
+  `99.9.9` placeholder, matching Q-2-40's shape).
+- [x] Added `docs/errors/markdown/Q-2-41.qmd` per the README template
+  (front matter matching the catalog; status `stub`; What this means /
+  Why this happens / How to fix, escaped-brace + attribute-syntax fix
+  examples; `Q-2-38` cross-ref left as a code span per convention since
+  that page doesn't exist yet).
+- [x] `cargo run --bin q2 -- render docs/` — **190/190 files rendered**;
+  page appears at `_site/errors/markdown/Q-2-41.html` and in the errors
+  index listing. The 25 warnings are pre-existing missing-image warnings
+  in `guides/authoring/figures.qmd`, unrelated.
+
+### Phase 3 — End-to-end verification
+
+- [x] Single-file: `cargo run --bin q2 -- render repro.qmd` → output
+  carries `[Q-2-41] Curly braces are reserved for attribute syntax` with
+  the full hint text pointing at the brace run (observed output recorded
+  in "Verification output" below).
+- [x] Project render (page-drop symptom): fixture website with `index.qmd`
+  (good) + `bad.qmd` (bare braces) → `warning: profile-pass skipped
+  …/bad.qmd: Error: [Q-2-41] Curly braces are reserved for attribute
+  syntax`, `Rendered 1 of 2 files … — 1 error`. The skip warning now
+  names the targeted diagnostic instead of the generic parse error.
+- [x] `cargo nextest run -p pampa`: 4300/4300. Workspace build + tests +
+  hub legs via full `cargo xtask verify` — **all steps passed** (see
+  Phase 4).
+- [x] Snapshot changes: **zero** `.snap` files added or modified.
+
+### Phase 4 — Commit / wrap-up
+
+- [x] Full `cargo xtask verify` (all 14 steps, including hub-client
+  TypeScript + Vite + WASM build and hub tests): **all passed.**
+- [x] Committed on `main`; **not pushed** (awaiting explicit approval).
+- [ ] Close bd-brace-escape-hint-0tmemkyt after user sign-off.
+- [ ] bd-cx1det1y (Q-2-36/37/38 backfill) stays open for a separate session.
 
 ## Risks / tradeoffs (draft)
 
@@ -150,3 +188,52 @@ Skeleton only — contents wait on the design discussion.
   parse error) is pre-existing reader/render architecture, not part of this
   strand. If the user wants that loudness improved, it should be its own
   strand.
+
+## Verification output (end-to-end, output inspected)
+
+### Single-file render (the strand's verbatim example)
+
+```
+$ cargo run --bin q2 -- render <scratch>/repro.qmd
+Rendering single file: <scratch>/repro.qmd
+warning: profile-pass skipped <scratch>/repro.qmd: Error: [Q-2-41] Curly braces are reserved for attribute syntax
+   ╭─[ <scratch>/repro.qmd:1:31 ]
+   │
+ 1 │ the request returns the task {guid} immediately.
+   │                               ──┬─
+   │                                 ╰─── Curly braces are reserved for attribute syntax in Quarto markdown.
+   │                                      To write literal braces, escape them as `\{...\}`. If you meant to
+   │                                      attach an attribute, use `.class` / `#id` / `key="value"` syntax,
+   │                                      e.g. `[text]{.class}`.
+───╯
+
+1 error
+```
+
+(ANSI + hyperlink escapes stripped; the message renders as one long span
+label in the terminal.)
+
+### Project render (page-drop form)
+
+```
+$ cargo run --bin q2 -- render <scratch>/brace-proj      # index.qmd good, bad.qmd has bare braces
+warning: profile-pass skipped <scratch>/brace-proj/bad.qmd: Error: [Q-2-41] Curly braces are reserved for attribute syntax
+Rendered 1 of 2 files to <scratch>/brace-proj/_site — 1 error
+```
+
+### Controls (pampa)
+
+```
+$ printf 'escaped \{guid\} braces.\n' | cargo run --bin pampa --
+[ Para [Str "escaped", Space, Str "{guid}", Space, Str "braces."] ]      # escaped braces → literal text
+$ printf 'attr [text]{.cls} span.\n' | cargo run --bin pampa --
+[ Para [… Span ( "" , ["cls"] , [] ) [Str "text"] …] ]                   # valid attribute → clean parse
+$ printf 'typo [text]{guid} span.\n' | cargo run --bin pampa --
+Error: [Q-2-41] Curly braces are reserved for attribute syntax           # attr typo → same either/or hint
+```
+
+### Docs render
+
+`cargo run --bin q2 -- render docs/` → 190/190 files;
+`_site/errors/markdown/Q-2-41.html` exists and the errors index lists
+"Curly braces are reserved for attribute syntax".

--- a/claude-notes/plans/2026-08-09-bare-brace-escape-hint.md
+++ b/claude-notes/plans/2026-08-09-bare-brace-escape-hint.md
@@ -166,8 +166,15 @@ All paths in the strand description check out at HEAD:
 
 - [x] Full `cargo xtask verify` (all 14 steps, including hub-client
   TypeScript + Vite + WASM build and hub tests): **all passed.**
-- [x] Committed on `main`; **not pushed** (awaiting explicit approval).
-- [ ] Close bd-brace-escape-hint-0tmemkyt after user sign-off.
+- [x] Per user direction, moved the two commits to branch
+  `braid/bd-brace-escape-hint-0tmemkyt`, rebased onto the new
+  `origin/main` tip (PR #482 touched no parser/grammar/corpus files, so
+  the captured LR states are unaffected), re-verified with
+  `cargo xtask verify --skip-hub-build` (green), and reset local `main`
+  to `origin/main`.
+- [x] Pushed as `feature/bd-brace-escape-hint-0tmemkyt`; **PR #483**:
+  https://github.com/quarto-dev/q2/pull/483
+- [ ] Close bd-brace-escape-hint-0tmemkyt after the PR merges.
 - [ ] bd-cx1det1y (Q-2-36/37/38 backfill) stays open for a separate session.
 
 ## Risks / tradeoffs (draft)

--- a/claude-notes/plans/bare-brace-escape-hint-investigation/error-states.md
+++ b/claude-notes/plans/bare-brace-escape-hint-investigation/error-states.md
@@ -1,0 +1,45 @@
+# Parser error-state captures for bare-brace inputs
+
+Captured 2026-08-09 at `main` @ `ec8a35f9` via:
+
+```
+printf '<input>\n' | cargo run --bin pampa -- --_internal-report-error-state | jq '.errorStates'
+```
+
+| Input | Error state(s) `(state, sym)` | Notes |
+| --- | --- | --- |
+| `a {guid} b.` | `(2613, _language_specifier_token)` | Bare brace run in prose — the strand's primary case |
+| `the request returns the task {guid} immediately.` | `(2613, _language_specifier_token)` | Strand's verbatim example, same state |
+| `a {guid} b and {other} c.` | `(2613, _language_specifier_token)` ×2 | Two runs, same state each time |
+| `empty {} braces.` | `(2613, _language_specifier_token)` | Empty braces, same state |
+| `multi {two words} braces.` | `(2613, _language_specifier_token)` | Multi-word content, same state |
+| `[text]{guid} attr-like.` | `(2613, _language_specifier_token)` | **Attribute-intent typo hits the same state** — hint wording must serve this reader too |
+| `see [the {guid} link](https://example.com) here.` | `(2589, _language_specifier_token)` | Brace run inside link text — second state to map |
+| `trailing {guid` (unclosed, EOL) | `(2613, shortcode_name)` | Different lookahead sym — separate mapping decision |
+| `[text]{#id unclosed.` | `(2705, shortcode_name)` | Unclosed attribute — out of scope for this strand |
+
+## Collision check against `_autogen-table.json`
+
+- `state == 2613`: only claimed as `(2613, _close_block)` → `Q-2-2/simple`. **`(2613, _language_specifier_token)` is free.**
+- `state == 2589`: no entries. **Free.**
+- `sym == _language_specifier_token`: only claimed at `(2638, …)` → `Q-2-36/bare-label`. No overlap.
+
+Conclusion: both target `(state, sym)` pairs are unclaimed; a pure corpus
+addition (Q-2-36 "path B" mechanism) maps them without touching grammar,
+scanner, or the fallback code in
+`crates/quarto-parse-errors/src/error_generation.rs`.
+
+## Observed fallback output at HEAD (`repro.qmd`)
+
+```
+Error: Parse error
+   ╭─[ repro.qmd:1:31 ]
+   │
+ 1 │ the request returns the task {guid} immediately.
+   │                               ──┬─
+   │                                 ╰─── unexpected character or token here
+───╯
+```
+
+Highlight lands on the word *inside* the braces (`guid`), not on the brace
+run — relevant to the highlight-widening design question.

--- a/claude-notes/plans/bare-brace-escape-hint-investigation/repro.qmd
+++ b/claude-notes/plans/bare-brace-escape-hint-investigation/repro.qmd
@@ -1,0 +1,1 @@
+the request returns the task {guid} immediately.

--- a/crates/pampa/resources/error-corpus/Q-2-41.json
+++ b/crates/pampa/resources/error-corpus/Q-2-41.json
@@ -1,0 +1,20 @@
+{
+  "code": "Q-2-41",
+  "title": "Curly braces are reserved for attribute syntax",
+  "message": "Curly braces are reserved for attribute syntax in Quarto markdown. To write literal braces, escape them as `\\{...\\}`. If you meant to attach an attribute, use `.class` / `#id` / `key=\"value\"` syntax, e.g. `[text]{.class}`.",
+  "notes": [],
+  "cases": [
+    {
+      "name": "prose",
+      "description": "Bare brace run in prose (the strand's verbatim example; REST API docs write path parameters like {guid} constantly).",
+      "content": "the request returns the task {guid} immediately.\n",
+      "captures": []
+    },
+    {
+      "name": "link-text",
+      "description": "Brace run inside link text; fails at a different LR state (2589) than the bare-paragraph form (2613).",
+      "content": "see [the {guid} link](https://example.com) here.\n",
+      "captures": []
+    }
+  ]
+}

--- a/crates/pampa/resources/error-corpus/_autogen-table.json
+++ b/crates/pampa/resources/error-corpus/_autogen-table.json
@@ -18024,6 +18024,36 @@
     "name": "Q-2-38/multi-line-eof-two-kvs"
   },
   {
+    "column": 30,
+    "row": 0,
+    "state": 2613,
+    "sym": "_language_specifier_token",
+    "errorInfo": {
+      "code": "Q-2-41",
+      "title": "Curly braces are reserved for attribute syntax",
+      "message": "Curly braces are reserved for attribute syntax in Quarto markdown. To write literal braces, escape them as `\\{...\\}`. If you meant to attach an attribute, use `.class` / `#id` / `key=\"value\"` syntax, e.g. `[text]{.class}`.",
+      "captures": [],
+      "notes": [],
+      "hints": []
+    },
+    "name": "Q-2-41/prose"
+  },
+  {
+    "column": 10,
+    "row": 0,
+    "state": 2589,
+    "sym": "_language_specifier_token",
+    "errorInfo": {
+      "code": "Q-2-41",
+      "title": "Curly braces are reserved for attribute syntax",
+      "message": "Curly braces are reserved for attribute syntax in Quarto markdown. To write literal braces, escape them as `\\{...\\}`. If you meant to attach an attribute, use `.class` / `#id` / `key=\"value\"` syntax, e.g. `[text]{.class}`.",
+      "captures": [],
+      "notes": [],
+      "hints": []
+    },
+    "name": "Q-2-41/link-text"
+  },
+  {
     "column": 17,
     "row": 0,
     "state": 1771,

--- a/crates/pampa/resources/error-corpus/case-files/Q-2-41-link-text.qmd
+++ b/crates/pampa/resources/error-corpus/case-files/Q-2-41-link-text.qmd
@@ -1,0 +1,1 @@
+see [the {guid} link](https://example.com) here.

--- a/crates/pampa/resources/error-corpus/case-files/Q-2-41-prose.qmd
+++ b/crates/pampa/resources/error-corpus/case-files/Q-2-41-prose.qmd
@@ -1,0 +1,1 @@
+the request returns the task {guid} immediately.

--- a/crates/quarto-error-catalog/error_catalog.json
+++ b/crates/quarto-error-catalog/error_catalog.json
@@ -426,6 +426,13 @@
     "docs_url": "https://quarto.org/docs/errors/markdown/Q-2-40",
     "since_version": "99.9.9"
   },
+  "Q-2-41": {
+    "subsystem": "markdown",
+    "title": "Curly braces are reserved for attribute syntax",
+    "message_template": "Curly braces are reserved for attribute syntax in Quarto markdown. To write literal braces, escape them as `\\{...\\}`. If you meant to attach an attribute, use `.class` / `#id` / `key=\"value\"` syntax, e.g. `[text]{.class}`.",
+    "docs_url": "https://quarto.org/docs/errors/markdown/Q-2-41",
+    "since_version": "99.9.9"
+  },
   "Q-3-1": {
     "subsystem": "writer",
     "title": "IO Error During Write",

--- a/docs/errors/markdown/Q-2-41.qmd
+++ b/docs/errors/markdown/Q-2-41.qmd
@@ -1,0 +1,85 @@
+---
+title: "Curly braces are reserved for attribute syntax"
+description: "A curly-brace run in body text is not valid attribute syntax; literal braces must be escaped."
+code: Q-2-41
+subsystem: markdown
+status: stub
+since: "99.9.9"
+categories:
+  - markdown
+---
+
+# `Q-2-41` — Curly braces are reserved for attribute syntax
+
+> Curly braces are reserved for attribute syntax in Quarto markdown.
+> To write literal braces, escape them as `\{...\}`. If you meant to
+> attach an attribute, use `.class` / `#id` / `key="value"` syntax,
+> e.g. `[text]{.class}`.
+
+## What this means
+
+Quarto markdown reserves curly braces for attribute syntax — the
+`{.class}`, `{#id}`, and `{key="value"}` annotations that attach
+attributes to spans, links, images, and code blocks. A brace run in
+body text that is not valid attribute syntax, such as
+
+```markdown
+the request returns the task {guid} immediately.
+```
+
+is a parse error, not literal text. Pandoc and Quarto 1 render brace
+runs like this as literal text, so this error commonly appears when
+porting existing documents.
+
+## Why this happens
+
+- **Literal braces in prose.** The most common source is text that
+  uses braces as placeholders — REST API documentation writes path
+  parameters like `/v1/content/{guid}/bundles` constantly.
+- **Braces inside link text.** The same reservation applies inside
+  link text: `[the {guid} link](https://example.com)` fails the same
+  way.
+- **Malformed attribute syntax.** Writing `[text]{guid}` when you
+  meant `[text]{.guid}` (a class) or `[text]{#guid}` (an id) lands in
+  the same error, because a bare word is not valid attribute syntax.
+
+## How to fix
+
+If you want literal braces in the output, escape both braces with
+backslashes:
+
+```markdown
+the request returns the task \{guid\} immediately.
+```
+
+This renders as `the request returns the task {guid} immediately.` —
+and Pandoc renders the identical escaped source the same way, so the
+escaped form stays portable.
+
+If you meant to attach an attribute, use attribute syntax: a class
+(`[text]{.myclass}`), an id (`[text]{#myid}`), or a key-value pair
+(`[text]{key="value"}`).
+
+## Example
+
+Bad input:
+
+```markdown
+the request returns the task {guid} immediately.
+```
+
+Corrected (literal braces):
+
+```markdown
+the request returns the task \{guid\} immediately.
+```
+
+Corrected (attribute intended):
+
+```markdown
+the request returns [the task]{#task-guid} immediately.
+```
+
+## Related errors
+
+- `Q-2-38` — unclosed attribute specifier.


### PR DESCRIPTION
## Summary

A bare brace run in prose — e.g. `the request returns the task {guid} immediately.` — is a fatal parse error in q2, previously reported only with the generic fallback *"Parse error: unexpected character or token here"*. This is a common stumble when porting Q1/Pandoc projects (REST API docs write path parameters as `{name}` constantly), and in a project render the failing page is silently dropped from the site.

The brace reservation itself is by design; this PR only adds a targeted diagnostic. Those inputs now fire:

> **[Q-2-41] Curly braces are reserved for attribute syntax**
> Curly braces are reserved for attribute syntax in Quarto markdown. To write literal braces, escape them as `\{...\}`. If you meant to attach an attribute, use `.class` / `#id` / `key="value"` syntax, e.g. `[text]{.class}`.

Braid: bd-brace-escape-hint-0tmemkyt · Plan: `claude-notes/plans/2026-08-09-bare-brace-escape-hint.md`

## Approach

Pure error-corpus addition (the Q-2-36 "path B" precedent) — no grammar, scanner, or `error_generation.rs` change:

- `Q-2-41.json` corpus entry with two cases: **prose** braces, which fail at `(2613, _language_specifier_token)`, and **link-text** braces at `(2589, _language_specifier_token)`. Both `(state, sym)` pairs were verified unclaimed; the `_autogen-table.json` diff is purely additive (no state renumbering).
- Attribute-intent typos (`[text]{guid}`) hit the same parser state and get the same either/or message, which is why the wording covers both readings.
- The unclosed `{guid` end-of-line form is deliberately **not** mapped: its lookahead (`shortcode_name`) likely also fires for shortcode typos, where a brace-escape hint would mislead.
- Narrow token highlight kept (no `widen_diagnostic_to_line` enrollment) — line-wide underlines suit code-block headers, not prose paragraphs.
- Q-2-41 is registered in `quarto-error-catalog` and documented at `docs/errors/markdown/Q-2-41.qmd` (status `stub`) from the start. The discovered catalog+docs lapses for Q-2-36/37/38 are filed as **bd-cx1det1y**.

## Verification

- pampa suite 4300/4300; full `cargo xtask verify` (including WASM leg) green pre-rebase; `cargo xtask verify --skip-hub-build` green post-rebase (the intervening main commits touch no parser/grammar/corpus files, so LR states are unaffected).
- End-to-end through `q2 render`, output inspected: single-file render shows `[Q-2-41]` with the full hint; project render's `profile-pass skipped` warning now names the targeted diagnostic (`Rendered 1 of 2 files — 1 error`).
- Controls: `\{guid\}` → literal text; `[text]{.cls}` → clean `Span`; `[text]{guid}` → Q-2-41.
- Docs render 190/190; the new page appears in the errors index.
- Snapshot impact: **zero** `.snap` files changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)