### PR TITLE
FileId/span hardening, phase A part 2: doc-level resource binding, Q-5-17 hardening, complete candidate lists (bd-nv4p0eb1)

### DIFF
--- a/claude-notes/plans/2026-08-09-fileid-span-hardening-phase-a.md
+++ b/claude-notes/plans/2026-08-09-fileid-span-hardening-phase-a.md
@@ -73,9 +73,12 @@ Working conventions for this phase:
       arg compared Rust-side against AttributionLookup::blamed_file_id
       (fed by bd-vmlhw7nx's AttributionData.file_id); two-arg calls keep
       the historical contract.*
-- [ ] **D4 / bd-h5rfw3ao (p3):** harden `project_type_error`
+- [x] **D4 / bd-h5rfw3ao (p3):** harden `project_type_error`
       (`project/mod.rs:903`) — route through `bind_config_source` (or add the
       hash-equality guard) + a test pinning the invariant.
+      *Done 2026-08-09: bind_config_source over config_path ++ manifest
+      paths; dead content params removed; pin test in
+      unknown_project_type.rs.*
 
 ### Coverage completion (correct sites, incomplete candidates)
 

--- a/claude-notes/plans/2026-08-09-fileid-span-hardening-phase-a.md
+++ b/claude-notes/plans/2026-08-09-fileid-span-hardening-phase-a.md
@@ -95,9 +95,12 @@ Working conventions for this phase:
 - [x] **D7 (in bd-r64mj1aa):** register extension manifests in
       `MetadataMergeStage` so doc-scoped diagnostics anchored in
       `_extension.yml` get spans.
-- [ ] **D9 / bd-fc3mf161 (p3, may defer):** `pipeline.rs:800/:834/:1006` — thread
+- [x] **D9 / bd-fc3mf161 — DEFERRED (p4):** `pipeline.rs:800/:834/:1006` — thread
       the document's real SourceContext into the `StageError` fallback arm
       instead of rebuilding a single-file context.
+      *Deferred with evidence 2026-08-09: no StageError emitter produces
+      config-anchored diagnostics (all use Structured post-#478), so the
+      span-loss case is unreachable and untestable; see strand comment.*
 
 ### Guardrails
 
@@ -129,9 +132,9 @@ Working conventions for this phase:
 ### Phase exit
 
 - [ ] All strands above closed (tests green, e2e-verified where user-visible)
-- [ ] Write the step-2 memo for the quarto-source-map agent (Option B API,
+- [x] Write the step-2 memo for the quarto-source-map agent (Option B API,
       deprecation plan, quarto-yaml migration; declares Option C end-state)
-      — separate plan doc, linked from bd-nv4p0eb1
+      — `claude-notes/plans/2026-08-09-quarto-source-map-option-b-memo.md`
 - [ ] Update bd-nv4p0eb1 with phase-A completion evidence
 
 ## Session log
@@ -146,10 +149,12 @@ Working conventions for this phase:
   bd-u0tldu4z (flaky quarto-hub admin_collect_lifecycle test, unrelated
   to this work — no quarto-xml dep edge, green in isolation and on
   rerun). NOT pushed — awaiting user approval.
-- **Next session:** bd-fc3mf161 (D9, may defer) is the only unblocked
-  code item; bd-x113wg9v / bd-h5rfw3ao / bd-r64mj1aa wait on PR #478's
-  merge (then also remove the two temporary BLESSED_SUFFIXES entries in
-  the lint). Then the step-2 quarto-source-map memo (phase exit).
+- **2026-08-09 (session 1, part 3, post #478+#482 merges):** bd-x113wg9v,
+  bd-h5rfw3ao, bd-r64mj1aa done (temporary lint blessings and two more
+  inline allowances removed along the way); bd-fc3mf161 deferred to p4
+  with unreachability evidence; step-2 memo written. Phase A code
+  complete on `feature/bd-nv4p0eb1-span-hardening` (rebased-on/merged
+  main after #482).
 
 ## Details / decisions
 

--- a/claude-notes/plans/2026-08-09-fileid-span-hardening-phase-a.md
+++ b/claude-notes/plans/2026-08-09-fileid-span-hardening-phase-a.md
@@ -39,11 +39,14 @@ Working conventions for this phase:
       braid/bd-itj2mjkr-engine-slot-desync (remap made conditional, not
       additive; debug_assert judged unnecessary once the id comes from
       the add_file return). Awaiting PR/merge before strand close.*
-- [ ] **D3 / bd-x113wg9v (p2):** doc-level `resource_error_to_parse_error`
+- [x] **D3 / bd-x113wg9v (p2):** doc-level `resource_error_to_parse_error`
       mis-bind. Depends on PR #478. Fixture: `resources:` pattern declared in
       `_metadata.yml`, assert Q-5-1 snippet names the `_metadata.yml`. Fix:
       route through `bind_config_source` with candidates
       `[doc path, config_path] ++ extension_manifest_paths ++ dir-layer paths`.
+      *Done 2026-08-09 via new bind_source_candidates (two-scheme pairs)
+      + directory_metadata_paths_for_document; both temporary lint
+      blessings removed in the same commit.*
 - [x] **P2 / bd-f6h40a9r (p2):** `writers/incremental.rs:704-708` + `:747-766`
       foreign-offset fallback. Fix: `preimage_in` miss ⇒ re-serialize the
       inline (no `inline_source_span` fallback into foreign coordinates);

--- a/claude-notes/plans/2026-08-09-fileid-span-hardening-phase-a.md
+++ b/claude-notes/plans/2026-08-09-fileid-span-hardening-phase-a.md
@@ -82,14 +82,17 @@ Working conventions for this phase:
 
 ### Coverage completion (correct sites, incomplete candidates)
 
-- [ ] **D5 / bd-r64mj1aa (p2, covers D6/D7):** `commands/render.rs` `attach_config_source` /
+- [x] **D5 / bd-r64mj1aa (p2, covers D6/D7):** `commands/render.rs` `attach_config_source` /
       `config_source_context`: extend candidates with
       `extension_manifest_paths` (+ dir-layer `_metadata.yml` paths for the
       per-page groups). Depends on PR #478.
-- [ ] **D6 (in bd-r64mj1aa):** `theme_error_candidates`
+      *Done 2026-08-09, all three legs; per-page layer coverage comes via
+      D7's metadata_merge registration on the structured path; new shared
+      register_config_source; zero lint allowances left in render.rs.*
+- [x] **D6 (in bd-r64mj1aa):** `theme_error_candidates`
       (`compile_theme_css.rs:633`): add `extension_manifest_paths` and the
       doc's dir-layer paths.
-- [ ] **D7 (in bd-r64mj1aa):** register extension manifests in
+- [x] **D7 (in bd-r64mj1aa):** register extension manifests in
       `MetadataMergeStage` so doc-scoped diagnostics anchored in
       `_extension.yml` get spans.
 - [ ] **D9 / bd-fc3mf161 (p3, may defer):** `pipeline.rs:800/:834/:1006` — thread

--- a/claude-notes/plans/2026-08-09-quarto-source-map-option-b-memo.md
+++ b/claude-notes/plans/2026-08-09-quarto-source-map-option-b-memo.md
@@ -1,0 +1,140 @@
+# Memo: quarto-source-map binding-API redesign (Option B), with Option C as the declared end-state
+
+**Audience:** the agent/session working in `posit-dev/quarto-source-map`
+(and, for the migration leg, `posit-dev/quarto-yaml`).
+**Origin:** q2's FileId/span integrity audit, bd-nv4p0eb1 —
+`claude-notes/research/2026-08-09-fileid-span-integrity-audit.md` (in the
+quarto-dev/q2 repo; read it first, especially §1, §4, §5).
+**Public context:** posit-dev/quarto-yaml#17 records the quarto-yaml-side
+findings; q2 PR #482 and the follow-up phase-A branch contain the q2-side
+mitigations that this redesign makes structurally unnecessary.
+
+## Why (one paragraph)
+
+A source span is semantically a triple *(file identity, byte range, file
+content)*. The current API lets each leg travel and be re-bound
+independently: `FileId(pub usize)` is freely constructible,
+`SourceContext::add_file_with_id(id, path, content)` accepts any pairing,
+`get_file` silently aliases unregistered small ids onto dense slots, and
+content is re-read from disk at render time. q2 has now fixed ten+ concrete
+bugs of this class (wrong-file ariadne spans, mis-sliced writer output,
+misattributed provenance) and installed guards/lints — but the bad state
+remains representable, and new call sites in new shapes will keep
+appearing. Option B makes the *pairing* unrepresentable at the API seam;
+Option C (the declared end-state) makes the whole rebinding step
+nonexistent.
+
+## Constraints (already decided in q2 review — do not relitigate)
+
+1. **Paths are opaque string keys.** No canonicalization, no path
+   interpretation, no filesystem probing inside quarto-source-map. This is
+   what makes the scheme work identically under q2's hub-client VFS
+   (`/project/...` paths) and native. If spelling instability needs
+   fixing, it happens at the consumer's minting boundary
+   (q2's `SystemRuntime::canonicalize` is the per-setting normalizer).
+2. **Binding takes content, mandatorily.** `bind_path(path, content)` —
+   the caller reads via its own runtime and hands over the string. This
+   *removes* filesystem awareness from the library (today's
+   `add_file(path, None)` disk fallback, and the render-time re-reads in
+   `map_offset`, are exactly what degrades in WASM and what drifts under
+   watch/preview). Pin-parse-time-content semantics are the decided
+   contract.
+3. **Uniform lookup, not fallback removal.** Close the dense/sparse
+   aliasing hole by having `add_file` also record its id in the sparse
+   map, so lookup is uniform — do NOT delete positional resolution
+   outright (pampa's `FileId(0)` convention must keep working unchanged).
+4. **Complexity class stays O(n).** No per-node memory blowups.
+
+## Option B work items (quarto-source-map)
+
+1. **`FileId::for_path(&str) -> FileId`** — move the path→id derivation
+   into quarto-source-map. Same recipe as
+   `quarto_yaml::file_id_for_filename` *for now* (DefaultHasher over the
+   string), BUT: make the hash width stable across targets (u64-based,
+   not `as usize` — the usize truncation to 32 bits on wasm32 plus
+   `add_file_with_id`'s panic-on-duplicate is a latent crash,
+   posit-dev/quarto-yaml#17 item Y4). This is a hash-recipe change on
+   wasm32 only; coordinate the release with quarto-yaml re-exporting the
+   new function (see migration below). Note `FileId(pub usize)` likely
+   needs to become u64-backed or the hash needs masking — design point
+   for the implementing agent; the constraint is: identical ids for
+   identical spellings on every target.
+2. **`SourceContext::bind_path(path: &str, content: String) -> FileId`**
+   — derives the id internally via `FileId::for_path`; a caller can no
+   longer pair an arbitrary id with arbitrary content. Duplicate binding
+   with identical content: no-op returning the id. With different
+   content: first-wins + a debug-log (never a panic).
+3. **Reserve `FileId::UNKNOWN` (`usize::MAX`)** — the sentinel for
+   anonymous/synthetic provenance. `get_file` and `map_offset` return
+   `None` for it unconditionally. (q2's quarto-xml already mints
+   `FileId(usize::MAX)` as `ANONYMOUS_FILE_ID` in anticipation; quarto-yaml's
+   `parse()` dummy `FileId(0)` migrates to it — Y2.)
+4. **Uniform lookup** (constraint 3): `add_file` registers in the sparse
+   map too; `get_file` consults the map only. Dense ids keep resolving;
+   `FileId(0)` dummies stop aliasing.
+5. **Typed `resolve_byte_range`** — return `(FileId, Range<usize>)`, not
+   `(usize, usize, usize)`. Deprecate the old shape for one release.
+6. **Construction validation** — `debug_assert!(start <= end)` in
+   `original`/`substring`; `substring` debug-asserts child range within
+   parent length where knowable.
+7. **Renderer defense** (quarto-error-reporting, separate crate, same
+   family): refuse to render an `Original` span whose offsets exceed the
+   bound file's length (degrade span-less; today's clamp turns detectable
+   mis-binds into plausible spans), and drop the span when a `Concat`'s
+   endpoints map into different files.
+8. **Deprecations:** `add_file_with_id` (replaced by `bind_path`; one
+   release deprecated, then removed), raw-tuple `resolve_byte_range`
+   (same cycle). These crates have external Posit consumers — follow
+   quarto-yaml's release runbook (version-bump PR; CI publishes).
+
+## quarto-yaml migration (posit-dev/quarto-yaml)
+
+- Re-export `FileId::for_path` as `file_id_for_filename` (deprecated
+  alias) so the documented stability contract holds through the
+  transition; parse-side id minting switches to the source-map function.
+- `parse()`'s `FileId(0)` dummy → `FileId::UNKNOWN` (issue #17, Y2).
+- `parse_with_parent`: `debug_assert!(parent.length() == content.len())`
+  in `parse_impl` + fix the wrong doc example (Y1 — the example passes a
+  `0..1000` parent while narrating "extracted at offset 10-50").
+- Validation-crate items V1-V3 from issue #17 ride along where cheap
+  (single owning context handle; `SourceRange` offsets from
+  `resolve_byte_range` so they share a base with `filename`; delete the
+  inline hash re-implementation in `diagnostic.rs` test helpers).
+
+## q2 follow-up (after the release lands; file as q2 strands then)
+
+- Bump pins; migrate `bind_config_source` / `bind_source_candidates` /
+  `register_config_source` internals to `bind_path`; extend the
+  `add-file-with-id` xtask lint to flag the deprecated API tree-wide.
+- quarto-xml: replace `ANONYMOUS_FILE_ID` with the upstream
+  `FileId::UNKNOWN`.
+- Re-audit `span_assert.rs`'s `SuspiciousDefault` heuristic (the
+  `{0,0,0}` special case) against the new sentinel.
+
+## Option C — the declared end-state (design RFC, not this release)
+
+`Original { file: Arc<SourceFileHandle>, start, end }` where the handle
+owns path + pinned parse-time content (+ lazy `FileInformation`).
+`SourceContext` becomes an interner producing handles; diagnostic sites
+stop building contexts entirely; `remap_file_ids` and the positional
+file-table serialization (q2's P4) dissolve. FileId survives only as a
+serialization artifact. **Design B's API so C is a body-swap, not a
+signature churn** — e.g. `bind_path` returning a `FileId` today can
+return a handle-convertible newtype tomorrow; don't add new API that
+leaks the usize-ness of ids. Memory cost was reviewed and accepted in q2
+(Substring already pays an Arc per node; content pinning is bounded by
+files with live spans). Write the C RFC in the quarto-source-map repo
+after B ships, folding in what the B migration teaches.
+
+## Acceptance criteria for B
+
+- A test in quarto-source-map proving the old bad state is
+  unrepresentable through the new API (no way to bind content under a
+  non-derived id).
+- A test proving `FileId(0)`-dummy spans resolve to `None` in a context
+  with dense files (the aliasing hole).
+- wasm32 + native id-equality test for `FileId::for_path`.
+- quarto-yaml's suite green against the new source-map release;
+  q2's workspace green after the pin bump (q2 runs its own e2e span
+  tests: `extension_config_spans.rs`, `render_scripts_cli.rs`,
+  `unknown_project_type.rs`, `table_caption_provenance.rs`).

--- a/crates/quarto-core/src/config_sources.rs
+++ b/crates/quarto-core/src/config_sources.rs
@@ -61,17 +61,46 @@ pub fn bind_config_source<'a>(
     info: &SourceInfo,
     candidates: impl IntoIterator<Item = &'a Path>,
 ) -> Option<&'a Path> {
+    bind_source_candidates(
+        source_context,
+        info,
+        candidates.into_iter().map(|p| {
+            let fid = quarto_yaml::file_id_for_filename(&p.to_string_lossy());
+            (fid, p)
+        }),
+    )
+}
+
+/// Generalization of [`bind_config_source`] for candidate lists that
+/// span **both** FileId schemes: quarto-yaml filename-hash ids for
+/// standalone config files, and dense parse-context ids for documents
+/// (a document's front-matter spans root at the `FileId` its own
+/// parse context assigned — `FileId(0)` for the primary slot — not at
+/// a filename hash). The caller supplies each candidate as an
+/// explicit `(FileId, &Path)` pair; the first pair whose id equals
+/// `info`'s resolved id is registered (content permitting) and
+/// returned. Same never-bind-a-non-match contract as
+/// [`bind_config_source`]. Precedent:
+/// `theme_diagnostic::sass_error_to_parse_error`'s candidate list.
+pub fn bind_source_candidates<'a>(
+    source_context: &mut SourceContext,
+    info: &SourceInfo,
+    candidates: impl IntoIterator<Item = (FileId, &'a Path)>,
+) -> Option<&'a Path> {
     let (fid_usize, _, _) = info.resolve_byte_range()?;
     let fid = FileId(fid_usize);
-    for candidate in candidates {
-        let name = candidate.to_string_lossy();
-        if quarto_yaml::file_id_for_filename(&name) != fid {
+    for (candidate_id, candidate) in candidates {
+        if candidate_id != fid {
             continue;
         }
         if source_context.get_file(fid).is_none()
             && let Ok(content) = std::fs::read_to_string(candidate)
         {
-            source_context.add_file_with_id(fid, name.into_owned(), Some(content));
+            source_context.add_file_with_id(
+                fid,
+                candidate.to_string_lossy().into_owned(),
+                Some(content),
+            );
         }
         return Some(candidate);
     }

--- a/crates/quarto-core/src/config_sources.rs
+++ b/crates/quarto-core/src/config_sources.rs
@@ -107,6 +107,27 @@ pub fn bind_source_candidates<'a>(
     None
 }
 
+/// Register `path` in `source_context` under its own derived FileId
+/// (`quarto_yaml::file_id_for_filename` of the path's spelling),
+/// content permitting. The triple cannot mis-pair — id, path, and
+/// content all come from the one `path` — so this is the safe way to
+/// pre-register a *known* config source for later span rendering
+/// (as opposed to [`bind_config_source`], which selects among
+/// candidates by a diagnostic's resolved id). Returns `true` when the
+/// file was registered (or already present).
+pub fn register_config_source(source_context: &mut SourceContext, path: &Path) -> bool {
+    let name = path.to_string_lossy();
+    let fid = quarto_yaml::file_id_for_filename(&name);
+    if source_context.get_file(fid).is_some() {
+        return true;
+    }
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return false;
+    };
+    source_context.add_file_with_id(fid, name.into_owned(), Some(content));
+    true
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/quarto-core/src/project/mod.rs
+++ b/crates/quarto-core/src/project/mod.rs
@@ -406,13 +406,9 @@ impl ResolvedProjectType {
 /// the previous `.ok().unwrap_or_default()` fallback silently rendered
 /// e.g. a `type: posit-docs` website as a bare default project.
 ///
-/// `content` is the already-read text of `config_path`, registered
-/// into the error's `SourceContext` so diagnostics render a snippet
-/// pointing at the offending `type:` scalar.
 fn resolve_project_type(
     metadata: &mut ConfigValue,
     config_path: &Path,
-    content: &str,
     extensions: &[crate::extension::Extension],
     load_diagnostics: &[quarto_error_reporting::DiagnosticMessage],
     runtime: &dyn SystemRuntime,
@@ -427,7 +423,7 @@ fn resolve_project_type(
             "`project.type` must be a string.".to_string(),
             &type_source,
             config_path,
-            content,
+            extensions,
             Vec::new(),
             Vec::new(),
         ));
@@ -442,7 +438,6 @@ fn resolve_project_type(
         &type_str,
         &type_source,
         config_path,
-        content,
         extensions,
         load_diagnostics,
         runtime,
@@ -465,7 +460,6 @@ fn resolve_custom_project_type(
     type_str: &str,
     type_source: &quarto_source_map::SourceInfo,
     config_path: &Path,
-    content: &str,
     extensions: &[crate::extension::Extension],
     load_diagnostics: &[quarto_error_reporting::DiagnosticMessage],
     runtime: &dyn SystemRuntime,
@@ -502,7 +496,7 @@ fn resolve_custom_project_type(
             format!("`{type_str}` is not a recognized project type."),
             type_source,
             config_path,
-            content,
+            extensions,
             hints,
             load_diagnostics.to_vec(),
         ));
@@ -908,31 +902,44 @@ fn project_type_error(
     problem: String,
     type_source: &quarto_source_map::SourceInfo,
     config_path: &Path,
-    content: &str,
+    extensions: &[crate::extension::Extension],
     extra_hints: Vec<String>,
     extra_diagnostics: Vec<quarto_error_reporting::DiagnosticMessage>,
 ) -> QuartoError {
     use quarto_error_reporting::DiagnosticMessageBuilder;
-    use quarto_source_map::{FileId, SourceContext};
+    use quarto_source_map::SourceContext;
 
+    // Candidate-matched binding (bd-h5rfw3ao): today `type_source`
+    // always originates in `config_path` (both call sites run before
+    // any extension-fragment merge), but that was enforced only by
+    // call ordering. Matching by re-derived FileId keeps the anchor
+    // correct even if a merged (extension-contributed) `project.type`
+    // ever reaches this path — and degrades span-less, never
+    // wrong-file, for anything else.
+    let manifest_paths: Vec<std::path::PathBuf> = extensions
+        .iter()
+        .map(|e| e.path.join("_extension.yml"))
+        .collect();
     let mut source_context = SourceContext::new();
-    if let Some((fid_usize, _, _)) = type_source.resolve_byte_range() {
-        // Sound only by call ordering: both project_type_error call sites
-        // run before any extension-fragment merge, so type_source provably
-        // originates in config_path. bd-h5rfw3ao tracks hardening this via
-        // bind_config_source.
-        // lint:allow(add-file-with-id) — pre-merge, single possible source
-        source_context.add_file_with_id(
-            FileId(fid_usize),
-            config_path.to_string_lossy().into_owned(),
-            Some(content.to_string()),
-        );
-    }
+    let matched = crate::config_sources::bind_config_source(
+        &mut source_context,
+        type_source,
+        std::iter::once(config_path).chain(manifest_paths.iter().map(std::path::PathBuf::as_path)),
+    );
 
     let mut builder = DiagnosticMessageBuilder::error("Unknown project type")
         .with_code("Q-5-17")
         .with_location(type_source.clone())
-        .problem(problem)
+        .problem(problem);
+    if let Some(path) = matched
+        && path != config_path
+    {
+        builder = builder.add_info(format!(
+            "The `project.type` value is contributed by the extension manifest `{}`.",
+            path.display()
+        ));
+    }
+    builder = builder
         .add_hint("Built-in project types are `default`, `website`, `book`, and `manuscript`.");
     for hint in extra_hints {
         builder = builder.add_hint(hint);
@@ -1358,7 +1365,6 @@ impl ProjectContext {
         let resolved = resolve_project_type(
             &mut metadata,
             path,
-            &content,
             &extensions,
             &load_diagnostics,
             runtime,

--- a/crates/quarto-core/src/project/mod.rs
+++ b/crates/quarto-core/src/project/mod.rs
@@ -131,73 +131,90 @@ pub fn directory_metadata_for_document(
         return Ok(Vec::new());
     }
 
-    // Canonicalize the document path so strip_prefix works reliably.
-    // project.dir is always canonical (from ProjectContext::discover), but
-    // callers may pass relative paths (e.g., WASM render_qmd with VFS paths).
     let document_path = runtime
         .canonicalize(document_path)
         .unwrap_or_else(|_| document_path.to_path_buf());
-
-    let project_dir = &project.dir;
     let document_dir = document_path
         .parent()
         .ok_or_else(|| QuartoError::Other("Document has no parent directory".into()))?;
 
-    // Get relative path from project root to document directory
-    let relative_path = match document_dir.strip_prefix(project_dir) {
-        Ok(rel) => rel,
-        Err(_) => {
-            // Document is not under project directory
-            return Ok(Vec::new());
-        }
-    };
-
-    // Split into directory components
-    let components: Vec<_> = relative_path.components().collect();
-    if components.is_empty() {
-        // Document is in project root, no directories to walk
-        return Ok(Vec::new());
-    }
-
     let mut layers = Vec::new();
-    let mut current_dir = project_dir.clone();
+    for path in directory_metadata_paths_for_document(project, &document_path, runtime) {
+        // Parse the metadata file
+        let content = runtime
+            .file_read_string(&path)
+            .map_err(|e| QuartoError::Other(format!("Failed to read {}: {}", path.display(), e)))?;
 
-    // Walk through each directory from project root toward document
-    // (but not including project root itself - we start from first subdir)
-    for component in components {
-        current_dir = current_dir.join(component);
+        let filename = path.to_string_lossy().to_string();
+        let yaml = quarto_yaml::parse_file(&content, &filename).map_err(|e| {
+            QuartoError::Other(format!(
+                "Directory metadata validation failed for {}: {}",
+                path.display(),
+                e
+            ))
+        })?;
 
-        // Look for _metadata.yml or _metadata.yaml
-        let metadata_path = find_metadata_file(&current_dir, runtime);
+        // Convert to ConfigValue with ProjectConfig interpretation context
+        let mut diagnostics = DiagnosticCollector::new();
+        let mut metadata =
+            yaml_to_config_value(yaml, InterpretationContext::ProjectConfig, &mut diagnostics);
 
-        if let Some(path) = metadata_path {
-            // Parse the metadata file
-            let content = runtime.file_read_string(&path).map_err(|e| {
-                QuartoError::Other(format!("Failed to read {}: {}", path.display(), e))
-            })?;
+        // Adjust !path values to be relative to document directory
+        let layer_dir = path.parent().expect("metadata file has a directory");
+        adjust_paths_to_document_dir(&mut metadata, layer_dir, document_dir);
 
-            let filename = path.to_string_lossy().to_string();
-            let yaml = quarto_yaml::parse_file(&content, &filename).map_err(|e| {
-                QuartoError::Other(format!(
-                    "Directory metadata validation failed for {}: {}",
-                    path.display(),
-                    e
-                ))
-            })?;
-
-            // Convert to ConfigValue with ProjectConfig interpretation context
-            let mut diagnostics = DiagnosticCollector::new();
-            let mut metadata =
-                yaml_to_config_value(yaml, InterpretationContext::ProjectConfig, &mut diagnostics);
-
-            // Adjust !path values to be relative to document directory
-            adjust_paths_to_document_dir(&mut metadata, &current_dir, document_dir);
-
-            layers.push((path, metadata));
-        }
+        layers.push((path, metadata));
     }
 
     Ok(layers)
+}
+
+/// Enumerate the `_metadata.yml` / `_metadata.yaml` layer files that
+/// apply to `document_path`, outermost directory first — the same
+/// walk, and crucially the **same path spelling**, as
+/// [`directory_metadata_for_document`] (the spelling is what
+/// `quarto_yaml::parse_file` hashed into each layer's FileId, so
+/// diagnostic assembly re-derives layer ids from these exact paths;
+/// bd-x113wg9v). Returns an empty list for single-file projects and
+/// for documents outside the project directory.
+///
+/// Callers that already canonicalized `document_path` (as
+/// [`directory_metadata_for_document`] does) pass it through; the
+/// function canonicalizes again defensively, which is idempotent.
+pub fn directory_metadata_paths_for_document(
+    project: &ProjectContext,
+    document_path: &Path,
+    runtime: &dyn SystemRuntime,
+) -> Vec<PathBuf> {
+    if project.is_single_file {
+        return Vec::new();
+    }
+    // Canonicalize so strip_prefix works reliably. project.dir is always
+    // canonical (from ProjectContext::discover), but callers may pass
+    // relative paths (e.g., WASM render_qmd with VFS paths).
+    let document_path = runtime
+        .canonicalize(document_path)
+        .unwrap_or_else(|_| document_path.to_path_buf());
+    let project_dir = &project.dir;
+    let Some(document_dir) = document_path.parent() else {
+        return Vec::new();
+    };
+    let Ok(relative_path) = document_dir.strip_prefix(project_dir) else {
+        // Document is not under project directory
+        return Vec::new();
+    };
+
+    let mut paths = Vec::new();
+    let mut current_dir = project_dir.clone();
+    // Walk through each directory from project root toward document
+    // (but not including project root itself - we start from first subdir)
+    for component in relative_path.components() {
+        current_dir = current_dir.join(component);
+        if let Some(path) = find_metadata_file(&current_dir, runtime) {
+            paths.push(path);
+        }
+    }
+    paths
 }
 
 /// Find `_metadata.yml` or `_metadata.yaml` in a directory.

--- a/crates/quarto-core/src/project/mod.rs
+++ b/crates/quarto-core/src/project/mod.rs
@@ -1362,13 +1362,8 @@ impl ProjectContext {
         // field below is extracted. An unresolvable `project.type` is
         // a hard error (Q-5-17), not a silent fall-back to the
         // default kind.
-        let resolved = resolve_project_type(
-            &mut metadata,
-            path,
-            &extensions,
-            &load_diagnostics,
-            runtime,
-        )?;
+        let resolved =
+            resolve_project_type(&mut metadata, path, &extensions, &load_diagnostics, runtime)?;
         let project_kind = resolved.kind;
 
         // Merge `contributes.metadata.project` from every discovered

--- a/crates/quarto-core/src/project_resources.rs
+++ b/crates/quarto-core/src/project_resources.rs
@@ -895,53 +895,60 @@ fn resource_error_diagnostic(
     }
 }
 
-/// Build a [`crate::error::ParseError`] from a [`ResourceError`],
-/// loading `source_file` so the resulting diagnostic can render an
-/// Ariadne snippet pointing at the offending YAML scalar.
-///
-/// The [`SourceInfo`] inside `err` already carries a [`FileId`] —
-/// the same `hash(filename)` that `quarto_yaml::parse_file` computes
-/// when it produces source-tracked YAML. We register `source_file`
-/// in a fresh [`SourceContext`] under that exact FileId so the
-/// renderer can resolve offsets back to line/column in the file's
-/// content.
-///
-/// **Provenance contract:** the caller guarantees the error's
-/// SourceInfo actually originates from `source_file` — true for the
-/// per-document call sites, whose patterns come from the declaring
-/// document. For *project-level* patterns, which an extension may
-/// have contributed from its `_extension.yml`, use
-/// [`resource_error_to_config_parse_error`] instead (bd-p86nlm92);
-/// binding the wrong file here renders the right offsets against the
-/// wrong text. (Per-document patterns merged in from
-/// `_metadata.yml`-style layers can still mis-bind under this
-/// contract — tracked as part of the systematic audit, bd-nv4p0eb1.)
-///
-/// If `source_file` cannot be read (rare; the YAML *was* read once
-/// already during parse) or the [`SourceInfo`] has no resolvable
-/// FileId (Concat / FilterProvenance), the diagnostic degrades to a
-/// span-less message — still tidyverse-shaped, still better than
-/// `Error: …` plain text.
-pub fn resource_error_to_parse_error(
+/// Document-level variant of
+/// [`resource_error_to_config_parse_error`] (bd-x113wg9v): a
+/// document's effective `resources:` list is *merged* metadata, so an
+/// entry can be declared in the document's own front matter (spans
+/// rooted at the doc parse context's dense `FileId(0)`), inherited
+/// from a directory `_metadata.yml` layer or `_quarto.yml`, or
+/// contributed by an extension manifest (all three: quarto-yaml
+/// filename-hash FileIds). The candidate list carries both id schemes
+/// via [`crate::config_sources::bind_source_candidates`]; the first
+/// id match is bound, an inherited match gets an info line naming the
+/// declaring file, and no match degrades span-less — never a wrong
+/// span. (The predecessor bound `doc_source` unconditionally,
+/// rendering a `_metadata.yml` entry's offsets against the `.qmd`'s
+/// text.)
+pub fn resource_error_to_doc_parse_error(
     err: ResourceError,
-    source_file: &Path,
+    doc_source: &Path,
+    project: &crate::project::ProjectContext,
+    runtime: &dyn quarto_system_runtime::SystemRuntime,
 ) -> crate::error::ParseError {
     use quarto_source_map::{FileId, SourceContext};
 
-    let mut source_context = SourceContext::new();
-    if let Some((fid_usize, _, _)) = err.source_info().resolve_byte_range() {
-        let content = std::fs::read_to_string(source_file).ok();
-        source_context.add_file_with_id(
-            FileId(fid_usize),
-            source_file.to_string_lossy().into_owned(),
-            content,
-        );
-    }
+    let config = &project.config;
+    let layer_paths =
+        crate::project::directory_metadata_paths_for_document(project, doc_source, runtime);
+    let hash = |p: &Path| quarto_yaml::file_id_for_filename(&p.to_string_lossy());
 
-    crate::error::ParseError::new(
-        vec![resource_error_diagnostic(&err).build()],
-        source_context,
-    )
+    let mut source_context = SourceContext::new();
+    let candidates = std::iter::once((FileId(0), doc_source))
+        .chain(config.config_path.as_deref().map(|p| (hash(p), p)))
+        .chain(
+            config
+                .extension_manifest_paths
+                .iter()
+                .map(|p| (hash(p), p.as_path())),
+        )
+        .chain(layer_paths.iter().map(|p| (hash(p), p.as_path())));
+    let matched = crate::config_sources::bind_source_candidates(
+        &mut source_context,
+        err.source_info(),
+        candidates,
+    );
+
+    let mut builder = resource_error_diagnostic(&err);
+    if let Some(path) = matched
+        && path != doc_source
+    {
+        builder = builder.add_info(format!(
+            "This `resources` entry is inherited from `{}`, not declared in `{}`.",
+            path.display(),
+            doc_source.display()
+        ));
+    }
+    crate::error::ParseError::new(vec![builder.build()], source_context)
 }
 
 /// Project-level variant of [`resource_error_to_parse_error`]
@@ -1032,9 +1039,11 @@ pub fn collect_static_resources_with_diagnostics(
         // from the profile (cached or not), against the document
         // that declared them.
         if let Some(rejected) = profile.rejected_resources.first() {
-            return Err(resource_error_to_parse_error(
+            return Err(resource_error_to_doc_parse_error(
                 rejected.clone().into_error(project_root),
                 &doc_source_abs,
+                project,
+                runtime,
             ));
         }
         if profile.resource_globs.is_empty() {
@@ -1057,7 +1066,12 @@ pub fn collect_static_resources_with_diagnostics(
             )?);
             Ok(())
         })() {
-            return Err(resource_error_to_parse_error(e, &doc_source_abs));
+            return Err(resource_error_to_doc_parse_error(
+                e,
+                &doc_source_abs,
+                project,
+                runtime,
+            ));
         }
     }
 
@@ -1973,7 +1987,11 @@ mod tests {
         )
         .unwrap_err();
 
-        let parse_err = resource_error_to_parse_error(err, &yaml_path);
+        let config = crate::project::ProjectConfig {
+            config_path: Some(yaml_path.clone()),
+            ..Default::default()
+        };
+        let parse_err = resource_error_to_config_parse_error(err, &config);
         assert_eq!(parse_err.diagnostics.len(), 1);
         let d = &parse_err.diagnostics[0];
         assert_eq!(d.code.as_deref(), Some("Q-5-1"));

--- a/crates/quarto-core/src/stage/stages/compile_theme_css.rs
+++ b/crates/quarto-core/src/stage/stages/compile_theme_css.rs
@@ -622,23 +622,38 @@ impl PipelineStage for CompileThemeCssStage {
 }
 
 /// FileId candidates for rendering a theme-config diagnostic's source
-/// span. The offending `theme:` value can live in either the project's
-/// `_quarto.yml` (most common) or the document's own frontmatter (when
-/// the document overrides `theme:`); the two use different FileId
-/// schemes:
+/// span. The merged `theme:` value can live in the project's
+/// `_quarto.yml`, the document's own frontmatter, a directory
+/// `_metadata.yml` layer, or a contributing extension's
+/// `_extension.yml` (bd-r64mj1aa) — two FileId schemes:
 ///
-/// - `_quarto.yml` uses the YAML parser's hash-based FileId (via
+/// - Standalone YAML files use the parser's hash-based FileId (via
 ///   `quarto_yaml::file_id_for_filename`).
 /// - The document uses pampa's primary `FileId(0)`.
 fn theme_error_candidates(
     ctx: &StageContext,
-) -> Vec<(quarto_source_map::FileId, &std::path::Path)> {
-    let mut candidates: Vec<(quarto_source_map::FileId, &std::path::Path)> = Vec::new();
+) -> Vec<(quarto_source_map::FileId, std::path::PathBuf)> {
+    let hash =
+        |p: &std::path::Path| quarto_yaml::file_id_for_filename(&p.to_string_lossy());
+    let mut candidates: Vec<(quarto_source_map::FileId, std::path::PathBuf)> = Vec::new();
     if let Some(p) = ctx.project.config.config_path.as_deref() {
-        let fid = quarto_yaml::file_id_for_filename(&p.to_string_lossy());
+        candidates.push((hash(p), p.to_path_buf()));
+    }
+    candidates.push((
+        quarto_source_map::FileId(0),
+        ctx.document.input.to_path_buf(),
+    ));
+    for p in &ctx.project.config.extension_manifest_paths {
+        candidates.push((hash(p), p.clone()));
+    }
+    for p in crate::project::directory_metadata_paths_for_document(
+        &ctx.project,
+        &ctx.document.input,
+        ctx.runtime.as_ref(),
+    ) {
+        let fid = hash(&p);
         candidates.push((fid, p));
     }
-    candidates.push((quarto_source_map::FileId(0), ctx.document.input.as_path()));
     candidates
 }
 

--- a/crates/quarto-core/src/stage/stages/compile_theme_css.rs
+++ b/crates/quarto-core/src/stage/stages/compile_theme_css.rs
@@ -633,16 +633,12 @@ impl PipelineStage for CompileThemeCssStage {
 fn theme_error_candidates(
     ctx: &StageContext,
 ) -> Vec<(quarto_source_map::FileId, std::path::PathBuf)> {
-    let hash =
-        |p: &std::path::Path| quarto_yaml::file_id_for_filename(&p.to_string_lossy());
+    let hash = |p: &std::path::Path| quarto_yaml::file_id_for_filename(&p.to_string_lossy());
     let mut candidates: Vec<(quarto_source_map::FileId, std::path::PathBuf)> = Vec::new();
     if let Some(p) = ctx.project.config.config_path.as_deref() {
         candidates.push((hash(p), p.to_path_buf()));
     }
-    candidates.push((
-        quarto_source_map::FileId(0),
-        ctx.document.input.to_path_buf(),
-    ));
+    candidates.push((quarto_source_map::FileId(0), ctx.document.input.clone()));
     for p in &ctx.project.config.extension_manifest_paths {
         candidates.push((hash(p), p.clone()));
     }

--- a/crates/quarto-core/src/stage/stages/metadata_merge.rs
+++ b/crates/quarto-core/src/stage/stages/metadata_merge.rs
@@ -317,6 +317,14 @@ impl PipelineStage for MetadataMergeStage {
             for (path, _) in &dir_layer_entries {
                 register(path);
             }
+            // Extension manifests too (bd-r64mj1aa): values merged from
+            // `contributes.metadata` / `contributes.format` keep their
+            // `_extension.yml`-hash FileIds, and without this registration
+            // every doc-scoped diagnostic anchored in a manifest rendered
+            // span-less.
+            for path in &ctx.project.config.extension_manifest_paths {
+                register(path);
+            }
         }
 
         let dir_layers: Vec<_> = dir_layer_entries

--- a/crates/quarto-core/src/theme_diagnostic.rs
+++ b/crates/quarto-core/src/theme_diagnostic.rs
@@ -12,6 +12,8 @@
 //! The "Parse" in `ParseError` is historical — the type is just a
 //! `Vec<DiagnosticMessage>` + `SourceContext` envelope.
 
+use std::path::PathBuf;
+#[cfg(test)]
 use std::path::Path;
 
 use quarto_error_reporting::DiagnosticMessageBuilder;
@@ -50,30 +52,23 @@ use crate::error::ParseError;
 /// the source snippet.
 pub fn sass_error_to_parse_error(
     err: &SassError,
-    candidate_sources: &[(FileId, &Path)],
+    candidate_sources: &[(FileId, PathBuf)],
 ) -> ParseError {
     let location = sass_error_location(err);
 
+    // Candidate-matched binding via the shared helper (this function
+    // was the original precedent for it; bd-m6wmztln → bd-r64mj1aa):
+    // registers only the candidate whose id equals the diagnostic's
+    // resolved id, only with readable content. No match ⇒ span-less
+    // render — never a wrong span.
     let mut source_context = SourceContext::new();
-    if let Some(loc) = &location
-        && let Some((fid_usize, _, _)) = loc.resolve_byte_range()
-        && let Some((file_id, source_file)) =
-            candidate_sources.iter().find(|(fid, _)| fid.0 == fid_usize)
-        && let Ok(content) = std::fs::read_to_string(source_file)
-    {
-        // Only register the file when we actually have its content.
-        // A SourceFile with `content = None` triggers ariadne to
-        // re-read from disk at render time and panic on absence —
-        // which would mask the diagnostic with a noisier error.
-        // No content ⇒ span-less render, same as no location.
-        // *file_id comes from the caller-supplied candidate list entry
-        // whose id equals the diagnostic's resolved id (the
-        // bind_config_source precedent).
-        // lint:allow(add-file-with-id) — candidate-matched above
-        source_context.add_file_with_id(
-            *file_id,
-            source_file.to_string_lossy().into_owned(),
-            Some(content),
+    if let Some(loc) = &location {
+        crate::config_sources::bind_source_candidates(
+            &mut source_context,
+            loc,
+            candidate_sources
+                .iter()
+                .map(|(fid, p)| (*fid, p.as_path())),
         );
     }
 
@@ -229,7 +224,7 @@ mod tests {
             location: Some(location.clone()),
         };
 
-        let parse_err = sass_error_to_parse_error(&err, &[(file_id_for(&yaml_path), &yaml_path)]);
+        let parse_err = sass_error_to_parse_error(&err, &[(file_id_for(&yaml_path), yaml_path.clone())]);
         assert_eq!(parse_err.diagnostics.len(), 1);
         let d = &parse_err.diagnostics[0];
         assert_eq!(d.code.as_deref(), Some("Q-14-1"));
@@ -282,7 +277,7 @@ mod tests {
             message: "no source info available".to_string(),
             location: None,
         };
-        let parse_err = sass_error_to_parse_error(&err, &[(FileId(0), Path::new("/nonexistent"))]);
+        let parse_err = sass_error_to_parse_error(&err, &[(FileId(0), PathBuf::from("/nonexistent"))]);
         assert_eq!(parse_err.diagnostics.len(), 1);
         let d = &parse_err.diagnostics[0];
         assert_eq!(d.code.as_deref(), Some("Q-14-1"));
@@ -345,7 +340,7 @@ mod tests {
             location: Some(location.clone()),
         };
 
-        let parse_err = sass_error_to_parse_error(&err, &[(file_id_for(&yaml_path), &yaml_path)]);
+        let parse_err = sass_error_to_parse_error(&err, &[(file_id_for(&yaml_path), yaml_path.clone())]);
         assert_eq!(parse_err.diagnostics.len(), 1);
         let d = &parse_err.diagnostics[0];
         assert_eq!(d.code.as_deref(), Some("Q-14-2"));
@@ -384,7 +379,7 @@ mod tests {
             name: "whatever".to_string(),
             location: None,
         };
-        let parse_err = sass_error_to_parse_error(&err, &[(FileId(0), Path::new("/nonexistent"))]);
+        let parse_err = sass_error_to_parse_error(&err, &[(FileId(0), PathBuf::from("/nonexistent"))]);
         let d = &parse_err.diagnostics[0];
         assert_eq!(d.code.as_deref(), Some("Q-14-2"));
         assert_eq!(d.location, None);
@@ -417,7 +412,7 @@ mod tests {
             location: Some(location.clone()),
         };
 
-        let parse_err = sass_error_to_parse_error(&err, &[(file_id_for(&yaml_path), &yaml_path)]);
+        let parse_err = sass_error_to_parse_error(&err, &[(file_id_for(&yaml_path), yaml_path.clone())]);
         assert_eq!(parse_err.diagnostics.len(), 1);
         let d = &parse_err.diagnostics[0];
         assert_eq!(d.code.as_deref(), Some("Q-14-4"));
@@ -456,7 +451,7 @@ mod tests {
             path: std::path::PathBuf::from("/somewhere/nope.scss"),
             location: None,
         };
-        let parse_err = sass_error_to_parse_error(&err, &[(FileId(0), Path::new("/nonexistent"))]);
+        let parse_err = sass_error_to_parse_error(&err, &[(FileId(0), PathBuf::from("/nonexistent"))]);
         let d = &parse_err.diagnostics[0];
         assert_eq!(d.code.as_deref(), Some("Q-14-4"));
         assert_eq!(d.location, None);

--- a/crates/quarto-core/src/theme_diagnostic.rs
+++ b/crates/quarto-core/src/theme_diagnostic.rs
@@ -12,9 +12,9 @@
 //! The "Parse" in `ParseError` is historical — the type is just a
 //! `Vec<DiagnosticMessage>` + `SourceContext` envelope.
 
-use std::path::PathBuf;
 #[cfg(test)]
 use std::path::Path;
+use std::path::PathBuf;
 
 use quarto_error_reporting::DiagnosticMessageBuilder;
 use quarto_sass::SassError;
@@ -66,9 +66,7 @@ pub fn sass_error_to_parse_error(
         crate::config_sources::bind_source_candidates(
             &mut source_context,
             loc,
-            candidate_sources
-                .iter()
-                .map(|(fid, p)| (*fid, p.as_path())),
+            candidate_sources.iter().map(|(fid, p)| (*fid, p.as_path())),
         );
     }
 
@@ -224,7 +222,8 @@ mod tests {
             location: Some(location.clone()),
         };
 
-        let parse_err = sass_error_to_parse_error(&err, &[(file_id_for(&yaml_path), yaml_path.clone())]);
+        let parse_err =
+            sass_error_to_parse_error(&err, &[(file_id_for(&yaml_path), yaml_path.clone())]);
         assert_eq!(parse_err.diagnostics.len(), 1);
         let d = &parse_err.diagnostics[0];
         assert_eq!(d.code.as_deref(), Some("Q-14-1"));
@@ -277,7 +276,8 @@ mod tests {
             message: "no source info available".to_string(),
             location: None,
         };
-        let parse_err = sass_error_to_parse_error(&err, &[(FileId(0), PathBuf::from("/nonexistent"))]);
+        let parse_err =
+            sass_error_to_parse_error(&err, &[(FileId(0), PathBuf::from("/nonexistent"))]);
         assert_eq!(parse_err.diagnostics.len(), 1);
         let d = &parse_err.diagnostics[0];
         assert_eq!(d.code.as_deref(), Some("Q-14-1"));
@@ -340,7 +340,8 @@ mod tests {
             location: Some(location.clone()),
         };
 
-        let parse_err = sass_error_to_parse_error(&err, &[(file_id_for(&yaml_path), yaml_path.clone())]);
+        let parse_err =
+            sass_error_to_parse_error(&err, &[(file_id_for(&yaml_path), yaml_path.clone())]);
         assert_eq!(parse_err.diagnostics.len(), 1);
         let d = &parse_err.diagnostics[0];
         assert_eq!(d.code.as_deref(), Some("Q-14-2"));
@@ -379,7 +380,8 @@ mod tests {
             name: "whatever".to_string(),
             location: None,
         };
-        let parse_err = sass_error_to_parse_error(&err, &[(FileId(0), PathBuf::from("/nonexistent"))]);
+        let parse_err =
+            sass_error_to_parse_error(&err, &[(FileId(0), PathBuf::from("/nonexistent"))]);
         let d = &parse_err.diagnostics[0];
         assert_eq!(d.code.as_deref(), Some("Q-14-2"));
         assert_eq!(d.location, None);
@@ -412,7 +414,8 @@ mod tests {
             location: Some(location.clone()),
         };
 
-        let parse_err = sass_error_to_parse_error(&err, &[(file_id_for(&yaml_path), yaml_path.clone())]);
+        let parse_err =
+            sass_error_to_parse_error(&err, &[(file_id_for(&yaml_path), yaml_path.clone())]);
         assert_eq!(parse_err.diagnostics.len(), 1);
         let d = &parse_err.diagnostics[0];
         assert_eq!(d.code.as_deref(), Some("Q-14-4"));
@@ -451,7 +454,8 @@ mod tests {
             path: std::path::PathBuf::from("/somewhere/nope.scss"),
             location: None,
         };
-        let parse_err = sass_error_to_parse_error(&err, &[(FileId(0), PathBuf::from("/nonexistent"))]);
+        let parse_err =
+            sass_error_to_parse_error(&err, &[(FileId(0), PathBuf::from("/nonexistent"))]);
         let d = &parse_err.diagnostics[0];
         assert_eq!(d.code.as_deref(), Some("Q-14-4"));
         assert_eq!(d.location, None);

--- a/crates/quarto/src/commands/render.rs
+++ b/crates/quarto/src/commands/render.rs
@@ -746,8 +746,15 @@ fn execute_single_doc(
     let mut project = ProjectContext::discover(&input, runtime_arc.as_ref())
         .context("Failed to discover project context")?;
     // Captured before the pipeline mutably borrows `project`; used to
-    // restore config-anchored source snippets at print time.
+    // restore config-anchored source snippets at print time. Manifests
+    // included: merged values can anchor in an extension's
+    // `_extension.yml` (bd-r64mj1aa).
     let config_path = project.config.config_path.clone();
+    let config_sources: Vec<PathBuf> = config_path
+        .iter()
+        .cloned()
+        .chain(project.config.extension_manifest_paths.iter().cloned())
+        .collect();
 
     quarto_util::user_status!(args.quiet, "Rendering single file: {}", input.display());
 
@@ -781,7 +788,7 @@ fn execute_single_doc(
         summary.promote_warnings_to_errors();
     }
 
-    print_render_diagnostics(&summary, args, config_path.as_deref());
+    print_render_diagnostics(&summary, args, &config_sources);
 
     // bd-ooleh: a single-file render has no "Rendered N of M" line to
     // augment, so the error/warning counts get their own line — printed
@@ -820,8 +827,15 @@ fn execute_project(
     let mut project = ProjectContext::discover(&project_dir, runtime_arc.as_ref())
         .context("Failed to discover project context")?;
     // Captured before the pipeline mutably borrows `project`; used to
-    // restore config-anchored source snippets at print time.
+    // restore config-anchored source snippets at print time. Manifests
+    // included: merged values can anchor in an extension's
+    // `_extension.yml` (bd-r64mj1aa).
     let config_path = project.config.config_path.clone();
+    let config_sources: Vec<PathBuf> = config_path
+        .iter()
+        .cloned()
+        .chain(project.config.extension_manifest_paths.iter().cloned())
+        .collect();
 
     // bd-w348iu63: warn about the likely `pre_render` / `post_render`
     // misspellings (Q2 has no schema layer; unknown keys are
@@ -921,7 +935,7 @@ fn execute_project(
         summary.promote_warnings_to_errors();
     }
 
-    print_render_diagnostics(&summary, args, config_path.as_deref());
+    print_render_diagnostics(&summary, args, &config_sources);
 
     let rendered = summary.outputs.len();
     if let Some(mut line) = render_summary_line(false, total_files, rendered, &project.output_dir) {
@@ -1032,12 +1046,12 @@ fn should_exit_nonzero<O: quarto_core::project::orchestrator::OutputDiagnostics>
 fn print_render_diagnostics(
     summary: &quarto_core::project::orchestrator::ProjectRenderSummary,
     args: &RenderArgs,
-    config_path: Option<&Path>,
+    config_sources: &[PathBuf],
 ) {
     if args.json_errors {
-        print_render_diagnostics_json(summary, config_path);
+        print_render_diagnostics_json(summary, config_sources);
     } else {
-        print_render_diagnostics_text(summary, args.quiet, config_path);
+        print_render_diagnostics_text(summary, args.quiet, config_sources);
     }
 
     // bd-c5u2g: emit per-process engine-discovery counters when
@@ -1072,63 +1086,39 @@ fn print_render_diagnostics(
 /// the config path, which is what the diagnostics' `SourceInfo`
 /// carries — the same trick [`attach_config_source`] plays for
 /// coalesced per-page diagnostics.
-fn config_source_context(config_path: Option<&Path>) -> Option<SourceContext> {
-    let config_path = config_path?;
-    let config_str = config_path.to_string_lossy();
-    let content = std::fs::read_to_string(config_path).ok()?;
+fn config_source_context(candidates: &[PathBuf]) -> Option<SourceContext> {
+    if candidates.is_empty() {
+        return None;
+    }
     let mut ctx = SourceContext::new();
-    // The id is derived from the registered path itself, so the triple
-    // cannot mis-pair.
-    // lint:allow(add-file-with-id) — id from file_id_for_filename(path)
-    ctx.add_file_with_id(
-        quarto_yaml::file_id_for_filename(&config_str),
-        config_str.into_owned(),
-        Some(content),
-    );
-    Some(ctx)
+    let mut registered = false;
+    for path in candidates {
+        registered |= quarto_core::config_sources::register_config_source(&mut ctx, path);
+    }
+    registered.then_some(ctx)
 }
 
-fn attach_config_source(group: &mut CoalescedDiagnostic, config_path: Option<&Path>) {
-    use quarto_source_map::FileId;
-
-    let Some(config_path) = config_path else {
-        return;
-    };
+fn attach_config_source(group: &mut CoalescedDiagnostic, candidates: &[PathBuf]) {
     let Some(loc) = group.representative.location.as_ref() else {
         return;
     };
-    let Some((fid, _, _)) = loc.resolve_byte_range() else {
-        return;
-    };
-    if group
-        .source_context
-        .as_ref()
-        .is_some_and(|c| c.get_file(FileId(fid)).is_some())
-    {
-        return;
-    }
-    // `parse_config` hashed `config_path.to_string_lossy()`; only a
-    // diagnostic actually anchored in this config file matches.
-    let config_str = config_path.to_string_lossy();
-    if quarto_yaml::file_id_for_filename(&config_str) != FileId(fid) {
-        return;
-    }
-    let Ok(content) = std::fs::read_to_string(config_path) else {
-        return;
-    };
-    group
-        .source_context
-        .get_or_insert_with(SourceContext::new)
-        // Guarded above: registers only when
-        // file_id_for_filename(config_str) == FileId(fid).
-        // lint:allow(add-file-with-id) — hash-equality guarded
-        .add_file_with_id(FileId(fid), config_str.into_owned(), Some(content));
+    // Candidate-matched: only the file whose re-derived FileId equals
+    // the diagnostic's resolved id gets registered (bind_config_source
+    // no-ops when the group's own context already resolves the id, and
+    // never binds a non-match). Candidates cover `_quarto.yml` plus
+    // every discovered extension manifest (bd-r64mj1aa).
+    let ctx = group.source_context.get_or_insert_with(SourceContext::new);
+    quarto_core::config_sources::bind_config_source(
+        ctx,
+        loc,
+        candidates.iter().map(PathBuf::as_path),
+    );
 }
 
 fn print_render_diagnostics_text(
     summary: &quarto_core::project::orchestrator::ProjectRenderSummary,
     quiet: bool,
-    config_path: Option<&Path>,
+    config_sources: &[PathBuf],
 ) {
     for failure in &summary.pass1_failures {
         eprintln!(
@@ -1169,7 +1159,7 @@ fn print_render_diagnostics_text(
             eprintln!("error: {}: {}", failure.input.display(), failure.error);
         }
     }
-    let project_ctx = config_source_context(config_path);
+    let project_ctx = config_source_context(config_sources);
     for diagnostic in &summary.project_diagnostics {
         eprintln!("{}", diagnostic.to_text(project_ctx.as_ref()));
     }
@@ -1194,7 +1184,7 @@ fn print_render_diagnostics_text(
             })
         });
         for mut group in coalesce_by_source(entries) {
-            attach_config_source(&mut group, config_path);
+            attach_config_source(&mut group, config_sources);
             eprintln!("{}", group.to_text());
         }
 
@@ -1267,7 +1257,7 @@ fn detect_single_input_format(inputs: &[String]) -> Option<String> {
 /// emits NDJSON instead.
 fn print_render_diagnostics_json(
     summary: &quarto_core::project::orchestrator::ProjectRenderSummary,
-    config_path: Option<&Path>,
+    config_sources: &[PathBuf],
 ) {
     // Pass-1 failures: emit one JsonPass1Failure per failure. If the
     // failure has structured diagnostics + a source context, attach
@@ -1327,7 +1317,7 @@ fn print_render_diagnostics_json(
     // project-scope with no span; those anchored in `_quarto.yml`
     // (the `project.render` glob diagnostics, Q-5-13/14/15) resolve
     // through the config's source context.
-    let project_ctx = config_source_context(config_path).unwrap_or_default();
+    let project_ctx = config_source_context(config_sources).unwrap_or_default();
     for diagnostic in &summary.project_diagnostics {
         emit_json_line(&diagnostic_to_json(diagnostic, &project_ctx));
     }

--- a/crates/quarto/tests/integration/extension_config_spans.rs
+++ b/crates/quarto/tests/integration/extension_config_spans.rs
@@ -165,3 +165,102 @@ fn out_of_project_resource_declared_in_doc_names_doc() {
         "snippet should anchor in the declaring document; got: {stderr}"
     );
 }
+
+/// A `project.render` pattern contributed by an extension that escapes
+/// the project root gets a Q-5-14 warning — anchored in the extension
+/// manifest, not span-less (bd-r64mj1aa, D5 leg).
+#[test]
+fn escaping_render_pattern_from_extension_anchors_in_extension_yml() {
+    let temp = TempDir::new().unwrap();
+    let project = temp.path().canonicalize().unwrap();
+    write_file(
+        &project.join("_quarto.yml"),
+        "project:\n  type: website\n  output-dir: _site\n  render:\n    - \"*.qmd\"\n",
+    );
+    write_file(
+        &project.join("index.qmd"),
+        "---\ntitle: Home\n---\n\nHome body.\n",
+    );
+    write_file(
+        &project.join("_extensions/acme/wanderer/_extension.yml"),
+        "title: wanderer\nauthor: Acme\nversion: 0.0.1\ncontributes:\n  metadata:\n    project:\n      render:\n        - \"../outside/*.qmd\"\n",
+    );
+
+    let out = run_q2_render(&project);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("[Q-5-14]"),
+        "escaping render pattern should warn Q-5-14; got: {stderr}"
+    );
+    assert!(
+        stderr.contains("_extension.yml:"),
+        "Q-5-14 snippet should anchor in the contributing manifest; got: {stderr}"
+    );
+}
+
+/// A missing theme file declared by an extension's
+/// `contributes.metadata` anchors its Q-14-4 in the manifest
+/// (bd-r64mj1aa, D6/D7 leg).
+#[test]
+fn missing_theme_from_extension_anchors_in_extension_yml() {
+    let temp = TempDir::new().unwrap();
+    let project = temp.path().canonicalize().unwrap();
+    write_file(
+        &project.join("_quarto.yml"),
+        "project:\n  type: website\n  output-dir: _site\n",
+    );
+    write_file(
+        &project.join("index.qmd"),
+        "---\ntitle: Home\n---\n\nHome body.\n",
+    );
+    write_file(
+        &project.join("_extensions/acme/themer/_extension.yml"),
+        "title: themer\nauthor: Acme\nversion: 0.0.1\ncontributes:\n  metadata:\n    format:\n      html:\n        theme: no-such-theme-file.scss\n",
+    );
+
+    let out = run_q2_render(&project);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("[Q-14-4]"),
+        "missing theme file should raise Q-14-4; got: {stderr}"
+    );
+    assert!(
+        stderr.contains("_extension.yml:"),
+        "Q-14-4 snippet should anchor in the contributing manifest; got: {stderr}"
+    );
+}
+
+/// A missing theme file declared in a directory `_metadata.yml` layer
+/// anchors its Q-14-4 in that layer file (bd-r64mj1aa, D6 leg).
+#[test]
+fn missing_theme_from_metadata_yml_anchors_in_metadata_yml() {
+    let temp = TempDir::new().unwrap();
+    let project = temp.path().canonicalize().unwrap();
+    write_file(
+        &project.join("_quarto.yml"),
+        "project:\n  type: website\n  output-dir: _site\n",
+    );
+    write_file(
+        &project.join("index.qmd"),
+        "---\ntitle: Home\n---\n\nHome body.\n",
+    );
+    write_file(
+        &project.join("blog/_metadata.yml"),
+        "format:\n  html:\n    theme: no-such-theme-file.scss\n",
+    );
+    write_file(
+        &project.join("blog/post.qmd"),
+        "---\ntitle: Post\n---\n\nPost body.\n",
+    );
+
+    let out = run_q2_render(&project);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("[Q-14-4]"),
+        "missing theme file should raise Q-14-4; got: {stderr}"
+    );
+    assert!(
+        stderr.contains("_metadata.yml:"),
+        "Q-14-4 snippet should anchor in the declaring layer; got: {stderr}"
+    );
+}

--- a/crates/quarto/tests/integration/extension_config_spans.rs
+++ b/crates/quarto/tests/integration/extension_config_spans.rs
@@ -83,3 +83,85 @@ fn out_of_project_resource_contributed_by_extension_names_extension_yml() {
         "snippet must not anchor in _quarto.yml (the pattern is not declared there); got: {stderr}"
     );
 }
+
+/// An out-of-project `resources` pattern inherited from a directory
+/// `_metadata.yml` layer must anchor its Q-5-1 snippet in that
+/// `_metadata.yml` — not in the document that inherited it
+/// (bd-x113wg9v, the doc-level sibling of bd-p86nlm92).
+#[test]
+fn out_of_project_resource_from_metadata_yml_names_metadata_yml() {
+    let temp = TempDir::new().unwrap();
+    let project = temp.path().canonicalize().unwrap();
+    write_file(
+        &project.join("_quarto.yml"),
+        "project:\n  type: website\n  output-dir: _site\n",
+    );
+    write_file(
+        &project.join("index.qmd"),
+        "---\ntitle: Home\n---\n\nHome body.\n",
+    );
+    write_file(
+        &project.join("blog/_metadata.yml"),
+        "resources:\n  - \"../../escape.csv\"\n",
+    );
+    write_file(
+        &project.join("blog/post.qmd"),
+        "---\ntitle: Post\n---\n\nPost body.\n",
+    );
+
+    let out = run_q2_render(&project);
+    assert!(
+        !out.status.success(),
+        "out-of-project resource pattern must abort the render"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("[Q-5-1]"),
+        "diagnostic should carry the Q-5-1 code; got: {stderr}"
+    );
+    assert!(
+        stderr.contains("_metadata.yml:"),
+        "snippet should anchor in the declaring _metadata.yml; got: {stderr}"
+    );
+    assert!(
+        !stderr.contains("post.qmd:"),
+        "snippet must not anchor in the inheriting document; got: {stderr}"
+    );
+}
+
+/// Control: a `resources` pattern declared in the document's own
+/// frontmatter keeps anchoring in that document (the doc's spans root
+/// at its dense FileId, not a filename hash — the candidate list must
+/// carry both id schemes).
+#[test]
+fn out_of_project_resource_declared_in_doc_names_doc() {
+    let temp = TempDir::new().unwrap();
+    let project = temp.path().canonicalize().unwrap();
+    write_file(
+        &project.join("_quarto.yml"),
+        "project:\n  type: website\n  output-dir: _site\n",
+    );
+    write_file(
+        &project.join("index.qmd"),
+        "---\ntitle: Home\n---\n\nHome body.\n",
+    );
+    write_file(
+        &project.join("blog/post.qmd"),
+        "---\ntitle: Post\nresources:\n  - \"../../escape.csv\"\n---\n\nPost body.\n",
+    );
+
+    let out = run_q2_render(&project);
+    assert!(
+        !out.status.success(),
+        "out-of-project resource pattern must abort the render"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("[Q-5-1]"),
+        "diagnostic should carry the Q-5-1 code; got: {stderr}"
+    );
+    assert!(
+        stderr.contains("post.qmd:"),
+        "snippet should anchor in the declaring document; got: {stderr}"
+    );
+}

--- a/crates/quarto/tests/integration/unknown_project_type.rs
+++ b/crates/quarto/tests/integration/unknown_project_type.rs
@@ -174,3 +174,34 @@ fn website_type_control_renders_shared_libs() {
         "source tree must stay clean; found: {source_tree_files_dirs:?}"
     );
 }
+
+/// Pin (bd-h5rfw3ao): the Q-5-17 snippet anchors at the `type:` value
+/// in `_quarto.yml`. Guards the candidate-matched binding refactor —
+/// `project_type_error` must keep anchoring correctly in the file the
+/// span actually originates from.
+#[test]
+fn unknown_type_snippet_anchors_in_quarto_yml() {
+    let temp = TempDir::new().unwrap();
+    let dir = canonical(temp.path());
+    write_file(
+        &dir.join("_quarto.yml"),
+        "project:\n  type: no-such-type-anywhere\n",
+    );
+    write_file(&dir.join("index.qmd"), "---\ntitle: Home\n---\n\nBody.\n");
+
+    let output = run_q2_render(&dir);
+    assert!(!output.status.success(), "unknown type must abort");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("[Q-5-17]"),
+        "diagnostic should carry Q-5-17; got: {stderr}"
+    );
+    assert!(
+        stderr.contains("_quarto.yml:2:"),
+        "snippet should anchor at the type: line of _quarto.yml; got: {stderr}"
+    );
+    assert!(
+        stderr.contains("no-such-type-anywhere"),
+        "snippet should show the offending value; got: {stderr}"
+    );
+}

--- a/crates/xtask/src/lint/add_file_with_id.rs
+++ b/crates/xtask/src/lint/add_file_with_id.rs
@@ -48,13 +48,6 @@ const BLESSED_SUFFIXES: &[&str] = &[
     "quarto-core/src/stage/stages/metadata_merge.rs",
     // Test-only span-assertion helpers; self-consistent by construction.
     "quarto-config/src/span_assert.rs",
-    // TEMPORARY: rewritten by PR #478 (bd-m6wmztln) to use
-    // bind_config_source; blessed here to avoid inline-comment conflicts
-    // with the in-flight branch. Remove after #478 merges.
-    "quarto-core/src/project/render_scripts.rs",
-    // TEMPORARY: doc-level path is bd-x113wg9v; project-level path is
-    // rewritten by PR #478. Remove once both land.
-    "quarto-core/src/project_resources.rs",
 ];
 
 /// Check a file for `add_file_with_id` calls outside blessed locations.


### PR DESCRIPTION
## What

Phase A of the FileId/span integrity hardening, part 2 (bd-nv4p0eb1) — the strands that were blocked on #478's `bind_config_source` + `extension_manifest_paths`, now that #478 and #482 have merged. Same conventions as #482: one `--no-ff` merge per strand, every fix TDD red-first, e2e through the real `q2` binary where user-visible.

Assessment: `claude-notes/research/2026-08-09-fileid-span-integrity-audit.md`
Plan: `claude-notes/plans/2026-08-09-fileid-span-hardening-phase-a.md` (now fully checked off)

## The fixes

- **bd-x113wg9v — doc-level `resources:` diagnostics bind the declaring file.** A document's effective `resources:` is merged metadata: entries can be declared in its front matter (spans rooted at the doc parse context's dense `FileId(0)`), inherited from a directory `_metadata.yml` or `_quarto.yml`, or contributed by an extension manifest (filename-hash FileIds). The old `resource_error_to_parse_error` bound the `.qmd` unconditionally — the red run showed Q-5-1 underlining `post.qmd`'s front matter at the `_metadata.yml`'s offsets. Now: new `config_sources::bind_source_candidates` (explicit `(FileId, Path)` pairs spanning both id schemes) + new `project::directory_metadata_paths_for_document` (the layer walk factored from `directory_metadata_for_document`, preserving the exact path spelling the FileIds were hashed from). Inherited matches get an "inherited from" info line. E2E-inspected: anchors `blog/_metadata.yml:2:5`, underlining the offending pattern.
- **bd-h5rfw3ao — `project_type_error` hardened.** Q-5-17 assembly bound `_quarto.yml` unchecked, sound only by an undocumented call-ordering invariant. Now candidate-matched via `bind_config_source` over config + discovered manifests (info line on a manifest match); the dead `content` parameters are gone from three signatures; pin test asserts the `_quarto.yml:2` anchor.
- **bd-r64mj1aa — candidate lists completed (D5+D6+D7).** Three legs closing the audit's span-less degradations, each with a red e2e first:
  - `MetadataMergeStage` registers extension manifests alongside `_quarto.yml` and the dir layers, so doc-scoped diagnostics anchored in `_extension.yml` render spans on the structured path.
  - `theme_error_candidates` adds manifests + the doc's `_metadata.yml` layers; `sass_error_to_parse_error` (the original candidate-matching precedent) now delegates to the shared helper.
  - The render-summary helpers (`config_source_context` / `attach_config_source`) take a candidate list (config + manifests) and delegate to `register_config_source` / `bind_config_source` — deleting the last two `lint:allow(add-file-with-id)` markers in `render.rs`.
  - Red symptoms fixed: Q-5-14 for an extension-contributed escaping `project.render` pattern, and Q-14-4 for missing theme files declared in a manifest and in a `_metadata.yml` — all three now anchor in the declaring file.
- **Lint cleanup:** both temporary `BLESSED_SUFFIXES` entries removed (`render_scripts.rs` is `add_file_with_id`-free since #478; `project_resources.rs`'s last raw call died with the replaced function).
- **bd-fc3mf161 deferred to p4 with evidence:** no `StageError` emitter produces config-anchored diagnostics (all use the `Structured` path post-#478), so its span-loss scenario is unreachable and honestly untestable today.

Also included: `claude-notes/plans/2026-08-09-quarto-source-map-option-b-memo.md` — the step-2 memo for the upstream quarto-source-map binding-API redesign (Option B spec with the VFS constraints resolved in review, deprecation plan, quarto-yaml migration, Option C forward-compatibility requirements, acceptance criteria).

## Testing

- TDD red-first throughout: four e2e reds (Q-5-1, Q-5-14, 2× Q-14-4) each demonstrating the exact audited symptom before the fix; one pin test (green through the bd-h5rfw3ao refactor by design).
- Workspace: 11221 tests pass; full `cargo xtask verify` green at branch head (fmt + clippy + custom lint + Rust tests + hub/WASM legs). No snapshot files changed.

Strands: bd-x113wg9v, bd-h5rfw3ao, bd-r64mj1aa closed on merge; bd-nv4p0eb1 carries the audit trail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
