### PR TITLE
Backfill error catalog + docs pages for Q-2-36/37/38

### DIFF
--- a/crates/quarto-error-catalog/error_catalog.json
+++ b/crates/quarto-error-catalog/error_catalog.json
@@ -412,6 +412,27 @@
     "docs_url": "https://quarto.org/docs/errors/markdown/Q-2-35",
     "since_version": "99.9.9"
   },
+  "Q-2-36": {
+    "subsystem": "markdown",
+    "title": "Old-style knitr chunk options are not supported",
+    "message_template": "Quarto Markdown does not support knitr-style chunk options in the header. Move options into the body using `#| key: value` syntax, or use the Pandoc class form `{.r ...}` instead of `{r ...}`.",
+    "docs_url": "https://quarto.org/docs/errors/markdown/Q-2-36",
+    "since_version": "99.9.9"
+  },
+  "Q-2-37": {
+    "subsystem": "markdown",
+    "title": "Line break in link destination",
+    "message_template": "An inline link destination cannot contain a line break.",
+    "docs_url": "https://quarto.org/docs/errors/markdown/Q-2-37",
+    "since_version": "99.9.9"
+  },
+  "Q-2-38": {
+    "subsystem": "markdown",
+    "title": "Unclosed Attribute Specifier",
+    "message_template": "I reached the end of the block before finding a closing '}' for the attribute specifier.",
+    "docs_url": "https://quarto.org/docs/errors/markdown/Q-2-38",
+    "since_version": "99.9.9"
+  },
   "Q-2-39": {
     "subsystem": "markdown",
     "title": "Grid tables are not supported",

--- a/crates/quarto-error-catalog/src/lib.rs
+++ b/crates/quarto-error-catalog/src/lib.rs
@@ -107,6 +107,53 @@ mod tests {
         );
     }
 
+    // bd-cx1det1y: Q-2-36/37/38 catalog presence (backfill — these corpus
+    // codes shipped without catalog entries).
+    #[test]
+    fn error_catalog_has_q_2_36() {
+        let info = ERROR_CATALOG
+            .get("Q-2-36")
+            .expect("Q-2-36 must be in the catalog");
+        assert_eq!(info.subsystem, "markdown");
+        assert_eq!(
+            info.title,
+            "Old-style knitr chunk options are not supported"
+        );
+        assert!(
+            info.message_template.contains("#| key: value"),
+            "Q-2-36 message must point at the body-options syntax; got: {}",
+            info.message_template
+        );
+    }
+
+    #[test]
+    fn error_catalog_has_q_2_37() {
+        let info = ERROR_CATALOG
+            .get("Q-2-37")
+            .expect("Q-2-37 must be in the catalog");
+        assert_eq!(info.subsystem, "markdown");
+        assert_eq!(info.title, "Line break in link destination");
+        assert!(
+            info.message_template.contains("line break"),
+            "Q-2-37 message must name the line-break restriction; got: {}",
+            info.message_template
+        );
+    }
+
+    #[test]
+    fn error_catalog_has_q_2_38() {
+        let info = ERROR_CATALOG
+            .get("Q-2-38")
+            .expect("Q-2-38 must be in the catalog");
+        assert_eq!(info.subsystem, "markdown");
+        assert_eq!(info.title, "Unclosed Attribute Specifier");
+        assert!(
+            info.message_template.contains("closing '}'"),
+            "Q-2-38 message must mention the missing closing brace; got: {}",
+            info.message_template
+        );
+    }
+
     // L8 / bd-rqgx: Q-12-14 catalog presence.
     #[test]
     fn error_catalog_has_q_12_14() {

--- a/docs/errors/markdown/Q-2-36.qmd
+++ b/docs/errors/markdown/Q-2-36.qmd
@@ -1,0 +1,75 @@
+---
+title: "Old-style knitr chunk options are not supported"
+description: "A code block declared knitr-style options in its header instead of Quarto's `#| key: value` body syntax."
+code: Q-2-36
+subsystem: markdown
+status: stub
+since: "99.9.9"
+categories:
+  - markdown
+---
+
+# `Q-2-36` — Old-style knitr chunk options are not supported
+
+> Quarto Markdown does not support knitr-style chunk options in the
+> header. Move options into the body using `#| key: value` syntax, or
+> use the Pandoc class form `{.r ...}` instead of `{r ...}`.
+
+## What this means
+
+An executable code block declared its options inside the header
+braces, knitr-style:
+
+````markdown
+```{r, echo=FALSE}
+1 + 1
+```
+````
+
+Quarto Markdown reads chunk options from the *body* of the block, not
+the header. Header forms that R Markdown accepted — a bare label
+(`{r test}`), a comma after the language (`{r, echo=FALSE}`), or
+space-separated `key=value` pairs (`{r echo=FALSE}`) — are all
+rejected with this error.
+
+## Why this happens
+
+- **Documents ported from R Markdown / older Quarto.** knitr chunk
+  headers like `{r label, echo=FALSE, fig.width=7}` were the standard
+  way to set options there.
+- **Muscle memory.** Even in new documents, the knitr header form is
+  easy to reach for.
+
+## How to fix
+
+Move each option into the body of the block using `#| key: value`
+syntax:
+
+````markdown
+```{r}
+#| echo: false
+1 + 1
+```
+````
+
+Chunk labels become `#| label:`:
+
+````markdown
+```{r}
+#| label: test
+1 + 1
+```
+````
+
+If you only wanted a Pandoc class on a non-executable block — not
+chunk options — write the language with a leading dot:
+
+````markdown
+```{.r}
+1 + 1
+```
+````
+
+## Related errors
+
+- [`Q-2-8`](Q-2-8.qmd) — the retired warning code this error replaced.

--- a/docs/errors/markdown/Q-2-37.qmd
+++ b/docs/errors/markdown/Q-2-37.qmd
@@ -1,0 +1,56 @@
+---
+title: "Line break in link destination"
+description: "An inline link's destination URL was split across two lines; destinations must stay on one line."
+code: Q-2-37
+subsystem: markdown
+status: stub
+since: "99.9.9"
+categories:
+  - markdown
+---
+
+# `Q-2-37` — Line break in link destination
+
+> An inline link destination cannot contain a line break.
+
+## What this means
+
+The destination of an inline link — the URL between `(` and `)` —
+was interrupted by a line break:
+
+```markdown
+[text](https://example.
+com/path)
+```
+
+A link destination must sit entirely on one line, from the opening
+parenthesis through the closing one.
+
+## Why this happens
+
+- **Hard-wrapped prose.** An editor (or a formatter with a line-length
+  limit) wrapped a long line in the middle of a URL.
+- **A stray newline while editing**, splitting the URL before the
+  closing parenthesis:
+
+  ```markdown
+  [text](https://example.com/path
+  )
+  ```
+
+## How to fix
+
+Join the destination back onto a single line, even if that makes the
+line long:
+
+```markdown
+[text](https://example.com/path)
+```
+
+Markdown source lines can be arbitrarily long; if your editor
+hard-wraps, exempt long link lines from wrapping rather than breaking
+the URL.
+
+## Related errors
+
+- [`Q-2-38`](Q-2-38.qmd) — unclosed attribute specifier.

--- a/docs/errors/markdown/Q-2-38.qmd
+++ b/docs/errors/markdown/Q-2-38.qmd
@@ -1,0 +1,61 @@
+---
+title: "Unclosed Attribute Specifier"
+description: "An attribute specifier (`{...}`) was opened but never closed before the end of the block."
+code: Q-2-38
+subsystem: markdown
+status: stub
+since: "99.9.9"
+categories:
+  - markdown
+---
+
+# `Q-2-38` — Unclosed Attribute Specifier
+
+> I reached the end of the block before finding a closing `}` for the
+> attribute specifier.
+
+## What this means
+
+An attribute specifier — the `{...}` annotation that attaches classes,
+ids, or key-value pairs to a span, link, or image — was opened with
+`{` but the block ended before a matching `}` appeared:
+
+```markdown
+[text]{#my-id
+```
+
+The parser reads everything up to the end of the block looking for
+the closing brace, so the error is reported at the end of the block
+rather than at the opening `{`.
+
+## Why this happens
+
+- **A forgotten closing brace** after an id, class, or key-value pair:
+  `[text]{.important` instead of `[text]{.important}`.
+- **An attribute list spread across lines that never closes:**
+
+  ```markdown
+  [text]{
+    .cls
+    width="200px"
+  ```
+
+- **A deleted or truncated line** that took the `}` with it.
+
+## How to fix
+
+Add the missing `}`:
+
+```markdown
+[text]{#my-id}
+```
+
+If you did not intend an attribute at all and want a literal `{` in
+your text, escape it as `\{` — see
+[`Q-2-41`](Q-2-41.qmd) for the literal-brace rules.
+
+## Related errors
+
+- [`Q-2-41`](Q-2-41.qmd) — curly braces are reserved for attribute
+  syntax (the error for brace runs that are not attribute-shaped).
+- [`Q-2-37`](Q-2-37.qmd) — line break in link destination.

--- a/docs/errors/markdown/Q-2-41.qmd
+++ b/docs/errors/markdown/Q-2-41.qmd
@@ -82,4 +82,4 @@ the request returns [the task]{#task-guid} immediately.
 
 ## Related errors
 
-- `Q-2-38` — unclosed attribute specifier.
+- [`Q-2-38`](Q-2-38.qmd) — unclosed attribute specifier.

--- a/docs/errors/markdown/Q-2-8.qmd
+++ b/docs/errors/markdown/Q-2-8.qmd
@@ -12,7 +12,8 @@ categories:
 # `Q-2-8` — Unsupported Code Block Syntax
 
 > Reserved code, historically used for an old-style knitr-options
-> warning that has since been promoted to error `Q-2-36`.
+> warning that has since been promoted to error
+> [`Q-2-36`](Q-2-36.qmd).
 
 ## What this means
 
@@ -20,7 +21,8 @@ This code was once a warning Quarto raised when a code block was
 written with knitr-style header options — options listed inside
 the chunk header braces alongside the language tag — instead of
 Quarto's `#|` syntax. That diagnostic was later upgraded to an
-error and renumbered `Q-2-36`. The catalog retains this code so
+error and renumbered [`Q-2-36`](Q-2-36.qmd). The catalog retains
+this code so
 older messages remain resolvable, but no current Quarto release
 emits it.
 


### PR DESCRIPTION
## Summary

Q-2-36 (old-style knitr chunk options), Q-2-37 (line break in link destination), and Q-2-38 (unclosed attribute specifier) all fire at runtime from the error corpus, but none of them existed in `crates/quarto-error-catalog/error_catalog.json` or had a page under `docs/errors/markdown/` — `scripts/audit-error-codes.py` flagged all three as referenced-but-uncataloged. Q-2-36 skipped docs deliberately at ship time (#197), before the per-code docs convention firmed up.

Braid: bd-cx1det1y (discovered-from bd-brace-escape-hint-0tmemkyt / PR #483)

## Changes

- **Catalog entries** for all three codes: subsystem `markdown`, titles and `message_template`s matching the corpus JSONs, `docs_url` per convention, `since_version` `99.9.9` placeholder.
- **TDD presence tests** in `quarto-error-catalog` mirroring the existing Q-2-40 test — written first, watched fail on absence, pass with the entries.
- **Docs pages** `docs/errors/markdown/Q-2-{36,37,38}.qmd` per the `docs/errors/README.md` template, status `stub`.
- **Cross-reference promotions** in the same commit, per the README convention (code span → link once the target page exists): `Q-2-8.qmd` → `Q-2-36`, `Q-2-41.qmd` → `Q-2-38`; the new pages link `Q-2-8`, `Q-2-37`, `Q-2-38`, and `Q-2-41` among themselves.

## Verification

- `quarto-error-catalog`: 15/15 tests pass.
- Full `cargo xtask verify` (all steps including the hub-client WASM leg, which embeds the catalog): green.
- Docs render 193/193 (`cargo run --bin q2 -- render docs/`); the three pages appear in the errors index; all remaining `Q-13-4` link warnings trace to pre-existing guide pages, none in `docs/errors/`.
- `scripts/audit-error-codes.py` no longer reports Q-2-36/37/38.
- Snapshot impact: zero `.snap` files changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)