### PR TITLE
Load project _environment files (bd-environment-files-372u9qbs)

### DIFF
--- a/claude-notes/plans/2026-08-09-environment-files-loading.md
+++ b/claude-notes/plans/2026-08-09-environment-files-loading.md
@@ -162,27 +162,113 @@ later if Posit external consumers want it); and whether multiline quoted
 values are worth supporting in v1 (proposal: yes — the grammar is small and
 Q1 accepts them).
 
-## Proposed phases (draft)
+## Implementation settled (2026-08-10, session 3)
 
-- Phase 0 — Test plan (TDD): failing tests first. Parser unit tests (dialect
-  cases above, span correctness); precedence tests (real env > `.local` >
-  `_environment`; real env never overwritten); `.required` diagnostic tests;
-  an end-to-end test driving the real render path (the repro fixture)
-  asserting `from-env-file` appears in output; WASM-path consideration per
-  `.claude/rules/wasm.md`.
-- Phase 1 — Span-annotated dotenv parser (quarto-source-map), `@std/dotenv`
-  dialect.
-- Phase 2 — `load_project_environment` in `StageContext` (modeled on
-  `load_project_variables`): read `_environment` + `_environment.local` (+
-  profile variants via a for-now-empty profile list), apply precedence, build
-  the project env map; `_environment.required` diagnostics.
-- Phase 3 — `EnvShortcodeHandler` consults the map (real env first, then map,
-  then fallback arg); Q-16-5 hint updated to mention `_environment`.
-- Phase 4 — Subprocess propagation: `Command::envs` for keys absent from the
-  real env at knitr/jupyter/render-script spawn sites.
-- Phase 5 — Docs (`docs/` user-facing; render with q2, not Q1). Document the
-  no-mutation policy's user-visible consequence: env-file changes require
-  restart (no preview re-watch).
+- Parser lives at `crates/quarto-core/src/project/environment.rs` (extractable
+  to its own crate later if external consumers appear).
+- Multiline quoted values (single- and double-quoted) ARE supported, matching
+  `@std/dotenv`.
+- FileId scheme: reuse `quarto_yaml::file_id_for_filename` so `_environment`
+  diagnostics bind file content through the existing
+  `config_sources::bind_config_source` machinery.
+
+## Work items
+
+### Phase 0 — Failing end-to-end test (TDD)
+
+- [x] End-to-end test driving the real render path: smoke-all fixture
+  `crates/quarto/tests/smoke-all/metadata/environment-files/` (`_quarto.yml` +
+  `_environment` + `_environment.local` + `index.qmd`); asserts both the base
+  value and the `.local` override appear, and that `?env:` markers and the
+  shadowed base value do NOT. **Observed failing at HEAD 2026-08-10**
+  (`SMOKE_FILTER=environment-files cargo nextest run -p quarto -E
+  'test(smoke_all)'`): 3 regex mismatches + 2 Q-16-5 warnings.
+
+### Phase 1 — Span-annotated dotenv parser
+
+- [x] Unit tests for the `@std/dotenv` dialect (37 tests, all listed cases
+  plus CRLF, BOM, UTF-8 values, duplicate keys, unterminated quotes, junk
+  lines, `$$`/lone-`$` literals, escaped `\$`, cycle termination).
+- [x] `parse_env_file(content, filename, lookup) -> ParsedEnvFile` in
+  `crates/quarto-core/src/project/environment.rs`, spans via
+  quarto-source-map, FileId via `quarto_yaml::file_id_for_filename`.
+  Expansion diverges from `@std/dotenv` only as documented in the module doc
+  (empty-string + diagnostic instead of `"undefined"`; bounded passes +
+  diagnostic instead of infinite loop; junk-line warning; first-`}` default).
+
+### Phase 2 — Project env map with precedence
+
+- [x] Precedence unit tests (`merge_env_layers`): `.local` beats
+  `_environment`; expansion sees higher-priority layers; real env wins in
+  expansion; same-file beats real env in expansion (@std semantics); layer
+  diagnostics collected.
+- [x] `_environment.required` tests (`check_required`): undefined required
+  var → diagnostic whose span resolves to the requiring key in
+  `_environment.required`; satisfied by real env or map → quiet.
+- [x] `load_project_environment(runtime, project, profiles: &[String], …)`
+  called from `StageContext::new` alongside `load_project_variables`;
+  `project_env` map (`LinkedHashMap`) stored on `StageContext`. Skipped in
+  single-file mode. Present-but-unreadable file warns (via `path_exists`);
+  missing files silent.
+
+### Phase 3 — env shortcode consults the map
+
+- [x] Tests: `{{< env NAME >}}` resolves from map when real env unset (map
+  beats fallback arg); real env wins over map; Q-16-5 still fires when
+  absent everywhere (hint updated to mention `_environment`).
+- [x] `EnvShortcodeHandler::new(project_env)` plumbed like `variables`
+  through `builtin_handlers` / `with_lua_support` /
+  `build_transform_pipeline` / `build_q2_preview_transform_pipeline` /
+  `AstTransformsStage` (ctx.project_env). WASM preview gets it free via
+  `StageContext::new` + VFS reads.
+- [x] **Phase 0 fixture now passes** (`SMOKE_FILTER=environment-files
+  cargo nextest run -p quarto -E 'test(smoke_all)'` → PASS).
+
+### Phase 4 — Subprocess propagation
+
+- [x] Tests: `env_for_subprocess` filters real-env-shadowed keys (unit);
+  `scripts_receive_project_env` spawns a real `sh` pre-render script that
+  reads the variable (unix-gated; Windows coverage = the shared filter unit
+  test + mechanical `cmd.env` application). knitr/jupyter spawn sites carry
+  the same pre-filtered pairs via `ExecutionContext::project_env` — not
+  spawn-tested (no R/jupyter in CI; replay bypasses spawning).
+- [x] Injection at all sites, real-env-wins preserved by pre-filtering with
+  `env_for_subprocess` (children inherit the real env; we only add keys it
+  lacks): knitr `CallROptions::project_env` → `call_r`'s `Command::envs`;
+  jupyter `JupyterDaemon::get_or_start_session(..., extra_env)` →
+  `start_kernel` spawn (spawn-time input; session key unchanged — a reused
+  session keeps its birth env, fine while a process serves one project);
+  render scripts `RenderScriptsContext::project_env` (applied before
+  `QUARTO_PROJECT_*` so those win), loaded at the five call sites (render
+  pre/post, publish pre/post, preview boot) via
+  `subprocess_env_for_project`.
+
+### Phase 5 — Docs + verification
+
+- [x] User-facing docs page `docs/guides/projects/environment.qmd` (files,
+  dialect, precedence, consumers, `.required`, restart-required note), added
+  to the docs sidebar and guides index; rendered with
+  `cargo run --bin q2 -- render docs/guides/projects/environment.qmd` and
+  output inspected.
+- [x] `cargo build --workspace` clean; `cargo nextest run --workspace`:
+  **11263 passed** (1 leaky, pre-existing), 197 skipped. `cargo xtask lint`
+  clean. Full **`cargo xtask verify` passed** (all 14 steps, WASM leg
+  included; one clippy nit — unnested or-pattern — fixed along the way).
+- [x] End-to-end verification through the real binary, output inspected:
+  - **Shortcode** — `env -u REPRO_VERSION cargo run --bin q2 -- render
+    claude-notes/plans/environment-files-loading-investigation/repro` →
+    `Version is <strong>from-env-file</strong>.` (was `?env:REPRO_VERSION` +
+    Q-16-5 before the fix; now zero warnings).
+  - **Engines (real R + real jupyter on this machine)** — scratchpad project
+    with `_environment` containing `Q2_E2E_ENGINE_VAR=engine-sees-me`;
+    `engine: jupyter` doc printing `os.environ.get(...)` rendered
+    `PYVAL:engine-sees-me`; `engine: knitr` doc with `Sys.getenv(...)`
+    rendered `RVAL: engine-sees-me`. Re-render with
+    `Q2_E2E_ENGINE_VAR=real-wins` exported → both cells print `real-wins`
+    (real environment beats the file in subprocesses too).
+  - **Render scripts** — covered by the spawning unit test
+    `scripts_receive_project_env` (real `sh` child reads the variable).
+- [ ] review.md checklist; commit (await user approval per review.md).
 
 ## Risks / tradeoffs (draft)
 

--- a/claude-notes/plans/2026-08-09-environment-files-loading.md
+++ b/claude-notes/plans/2026-08-09-environment-files-loading.md
@@ -3,7 +3,19 @@
 **Date:** 2026-08-09
 **Braid:** bd-environment-files-372u9qbs (feature, P1, label `parity`)
 **Checkout:** committed on `main` in the bd-eb2wnxkp worktree (the checkout `/investigate-beads` was invoked in; no new branch created — user decides where implementation lands)
-**Status:** Investigation — pending design alignment with user. **Do not start implementation until the user gives the go-ahead.**
+**Status:** Design questions answered by user (2026-08-10, recorded below); dotenv-parser research done. Awaiting follow-up on the parser recommendation before implementation.
+**Follow-up strand:** bd-ev8mk1rp (render profiles) — filed 2026-08-10, `discovered-from` this strand.
+
+## Design policy: Quarto 2 does not mutate the process environment
+
+Decided 2026-08-10. Q1 implements `_environment` (and `--profile`) by mutating the
+process env (`Deno.env.set`); that is not UB in Deno, but it still races in some
+scenarios and has caused real Q1 bugs. Rust's edition-2024 `unsafe` on
+`std::env::set_var` is a restriction we *want* to model, not work around: in q2,
+project environment values are **data plumbed to consumers** (shortcode handlers,
+subprocess spawn sites), never writes to the ambient environment — even if some
+rare Quarto projects need slight behavior changes as a result. Reading the real
+env (`std::env::var`) remains fine; it always wins over file-defined values.
 
 ## Triage verdict
 
@@ -42,24 +54,135 @@ Confirmed at HEAD (`8518ac79`); pre-flight `cargo xtask verify --skip-hub-build`
 - `QUARTO_PROFILE` itself may be defined in `_environment`/`_environment.local` (`dotenvQuartoProfile`) — a small bootstrapping wrinkle.
 - `_environment.required` validation is **effectively vestigial** in Q1: the code carries a FIXME noting the dotenv `safe` option it relied on was removed upstream; the current call validates nothing. Q1 in practice parses the file and does not enforce it.
 
-## Proposed phases (draft — contents wait on design answers)
+## Design decisions (answered by user, 2026-08-10)
 
-- Phase 0 — Test plan (TDD): failing tests first. Unit tests for the dotenv-file parser + precedence; an end-to-end test driving the real render path (the repro fixture) asserting `from-env-file` appears in output; a precedence test (exported real env beats file value); WASM-path consideration per `.claude/rules/wasm.md`.
-- Phase 1 — Dotenv file parsing + `load_project_environment` in `StageContext` (modeled on `load_project_variables`), with Q1 precedence.
-- Phase 2 — Consumption by `EnvShortcodeHandler` (real env first, then project env map, then fallback arg; Q-16-5 hint updated to mention `_environment`).
-- Phase 3 — (scope-dependent) propagation to engine subprocess + render-script spawn sites.
-- Phase 4 — (scope-dependent) `_environment.required` behavior; profile variants.
-- Phase 5 — Docs (`docs/` user-facing; render with q2, not Q1).
+1. **Injection mechanism: project env map, no process-env mutation.** See the
+   policy section above. Map lives on `StageContext` (modeled on `variables`),
+   loaded through `SystemRuntime` so WASM/hub-client gets it via the VFS.
+   `EnvShortcodeHandler` consults `std::env::var` first, then the map, then the
+   fallback arg.
+2. **Consumers: all of them, in this strand.** Besides the `env` shortcode, pass
+   the project env at spawn sites: knitr subprocess
+   (`engine/knitr/subprocess.rs`), jupyter (`engine/jupyter/*`, including the
+   daemon), and pre/post render scripts (`project/render_scripts.rs`) — via
+   `Command::envs(project_env)` so the child sees file-defined values but real
+   inherited env still wins (set only keys absent from the real env, preserving
+   the precedence rule).
+3. **Profiles: scoped out.** Filed **bd-ev8mk1rp** (render profiles:
+   `--profile`/`QUARTO_PROFILE` plumbing, `_quarto-<profile>.yml`,
+   `_environment-<profile>`), `discovered-from` this strand. The loader built
+   here should take a (currently always-empty) active-profile list so
+   bd-ev8mk1rp can feed it later without rework.
+4. **`_environment.required`: issue diagnostics.** Real enforcement, not Q1's
+   de-facto no-op: a required variable undefined at load time gets a diagnostic
+   (severity TBD in implementation — start with warning). With the span-carrying
+   parser (below), the diagnostic can point at the requiring line in
+   `_environment.required` and, when applicable, at where a value was defined.
+5. **Parser: hand-rolled, span-annotated via quarto-source-map.** Research
+   below; dotenvy is not event-based and carries no source positions, so we
+   write a small parser that produces `SourceInfo`-annotated entries, following
+   the quarto-yaml technique.
+6. **Single-file mode: project-scoped only**, matching `_variables.yml` and Q1
+   (`is_single_file` → no env files).
+7. **Preview reactivity: out of scope.** Q1's env-file watching is itself a
+   source of races. q2 semantics: environment changes require restarting the
+   process. (Documented behavior, not a gap.)
 
-## Open design questions for the user
+## Parser research (2026-08-10)
 
-1. **Injection mechanism.** Q1 mutates the process env. In Rust that means `std::env::set_var` — `unsafe` in edition 2024 and genuinely thread-unsafe (UB if another thread reads the env concurrently, and q2 renders documents in parallel). The `_variables.yml`-style alternative — a project env map on `StageContext`, consulted by `EnvShortcodeHandler` after `std::env::var` misses — is thread-safe and WASM-friendly (loads through `SystemRuntime`, so hub-client preview gets it via the VFS for free). I'd recommend the map. Agreed, or do you want process-env injection for maximal Q1 fidelity?
-2. **Which consumers, in this strand?** The map alone fixes the `env` shortcode (the filed symptom). Q1's injection also makes the variables visible to executed code (knitr/jupyter subprocesses) and pre/post render scripts. Include `.envs(project_env)` at those spawn sites now, or file it as a follow-up strand?
-3. **Profile variants.** q2 has no active-profile machinery (`--profile` is parsed and dropped). Options: (a) scope `_environment-<profile>` out of this strand and file profiles separately; (b) implement a minimal `QUARTO_PROFILE` env-var + `--profile` plumbing just enough for env files. I'd lean (a) — profiles deserve their own design (they also affect `_quarto-<profile>.yml` config merging, which q2 lacks too).
-4. **`_environment.required`.** Q1's validation is vestigial (broken upstream, FIXME in their source). Implement *actual* enforcement (error or warning when a required variable is undefined — arguably the useful behavior Q1 intended), or match Q1's de-facto no-op and just not choke on the file's presence?
-5. **Parser.** Hand-roll a small KEY=VALUE parser (comments, blank lines, optional quotes) in-tree, or take a dependency (`dotenvy`'s parser handles quoting/escaping/multiline)? The Connect docs file is plain `KEY=value` lines; a small in-tree parser keeps the WASM build lean, but a dependency buys edge-case fidelity with Q1's dotenv dialect.
-6. **Single-file mode.** `_variables.yml` is project-scoped in q2 (`is_single_file` → skipped), matching Q1. Same for `_environment`? (Q1 loads it during *project*-context creation, so project-scoped matches.)
-7. **Preview reactivity.** Q1 watches env files and re-renders on change. In scope here, or follow-up?
+Question: can `dotenvy` give us event-based parsing we could hang
+`quarto-source-map` annotations on (the way `quarto-yaml` builds
+`YamlWithSourceInfo` from `yaml-rust2`'s `MarkedEventReceiver` events, each
+carrying a `Marker`)? Answer: **no — hand-roll.**
+
+**dotenvy** (inspected from git `allan2/dotenvy`, scratchpad clone; released
+0.15.7 is 2023-03-22, git main is an unreleased 0.16 rework):
+
+- The parser (`dotenvy/src/parse.rs`, ~620 lines) is an internal
+  **line-oriented** recursive-descent parser: `parse_line(&str, …) ->
+  Option<(String, String)>`. Not event-based; there is no callback/visitor
+  surface to intercept. The public API is an iterator of `(String, String)`
+  pairs (`Iter`) or whole-file loads.
+- **No source positions on success.** Positions appear only inside
+  `ParseBufError::LineParse(line_contents, char_index)` on *errors* — and even
+  there it's a char offset into a detached line string, no line number, no file
+  offset. Annotating values would mean rewriting the parser, at which point the
+  dependency buys nothing.
+- **Hidden process-env read inside parsing:** `$VAR`/`${VAR}` substitution in
+  values falls back to `std::env::var` (`parse.rs:259`,
+  `apply_substitution`). Parsing output depends on ambient env state — hostile
+  to WASM, to determinism, and to our data-not-ambient policy.
+- Maintenance signal: no release since 2023; main carries an unreleased
+  breaking rework. (That rework, notably, returns a non-mutating `EnvMap` by
+  default and marks the env-mutating loads `unsafe` — independent validation of
+  our no-mutation policy.)
+- Dialect differences from Q1 anyway: e.g. dotenvy expands `$VAR` in unquoted
+  *and* double-quoted values; Q1's dialect expands only unquoted values. So the
+  dependency wouldn't even buy Q1 fidelity.
+
+**Q1's actual dialect** is `@std/dotenv` (JSR; import map pins 0.225.3,
+vendored dev copy 0.224.2 — the vendor tree isn't checked out in
+`external-sources/`, so this was read from `denoland/std` upstream). It is a
+whole-text regex parser with these semantics:
+
+- Optional `export ` prefix; keys must match `[a-zA-Z_][a-zA-Z0-9_]*` (invalid
+  keys are *skipped with a warning*, not fatal).
+- Three value forms: **single-quoted** (literal, may span multiple lines, no
+  escapes/expansion); **double-quoted** (multiline, escape sequences `\n` `\r`
+  `\t` `\"` `\'` `\\` expanded, no `$` expansion); **unquoted** (trimmed,
+  ` #` starts a trailing comment, and `$VAR` / `${VAR}` / `${VAR:-default}`
+  expansion applies).
+- Expansion resolves against earlier entries in the same parse, then the real
+  process env (`Deno.env.get`), then the `:-` default. (Again: env *read*
+  during parse — acceptable for us as a read, resolved at load time against
+  `std::env::var`, which is safe; in WASM the real-env lookup simply finds
+  nothing.)
+- Full-line comments (`#`) and blank lines skipped.
+
+**Plan:** hand-roll a parser targeting the `@std/dotenv` grammar above,
+producing per-entry `SourceInfo` spans (key span, value span) via
+`quarto-source-map`, with a `parse_with_parent`-style entry point like
+`quarto_yaml::parse_file` so diagnostics (Q-16-5, `.required` misses, future
+validation) can point at the defining line. Proposed shape:
+
+```rust
+struct EnvEntry {
+    key: String,
+    value: String,           // after unquoting/escapes/expansion
+    key_span: SourceInfo,
+    value_span: SourceInfo,  // span of the raw value text
+}
+fn parse_env_file(content: &str, filename: &str) -> (Vec<EnvEntry>, Vec<DiagnosticMessage>)
+```
+
+Open sub-questions for implementation (small, can be settled at design
+review): where the parser lives (proposal: a module in `quarto-core`, e.g.
+`crates/quarto-core/src/project/environment.rs`, extractable to its own crate
+later if Posit external consumers want it); and whether multiline quoted
+values are worth supporting in v1 (proposal: yes — the grammar is small and
+Q1 accepts them).
+
+## Proposed phases (draft)
+
+- Phase 0 — Test plan (TDD): failing tests first. Parser unit tests (dialect
+  cases above, span correctness); precedence tests (real env > `.local` >
+  `_environment`; real env never overwritten); `.required` diagnostic tests;
+  an end-to-end test driving the real render path (the repro fixture)
+  asserting `from-env-file` appears in output; WASM-path consideration per
+  `.claude/rules/wasm.md`.
+- Phase 1 — Span-annotated dotenv parser (quarto-source-map), `@std/dotenv`
+  dialect.
+- Phase 2 — `load_project_environment` in `StageContext` (modeled on
+  `load_project_variables`): read `_environment` + `_environment.local` (+
+  profile variants via a for-now-empty profile list), apply precedence, build
+  the project env map; `_environment.required` diagnostics.
+- Phase 3 — `EnvShortcodeHandler` consults the map (real env first, then map,
+  then fallback arg); Q-16-5 hint updated to mention `_environment`.
+- Phase 4 — Subprocess propagation: `Command::envs` for keys absent from the
+  real env at knitr/jupyter/render-script spawn sites.
+- Phase 5 — Docs (`docs/` user-facing; render with q2, not Q1). Document the
+  no-mutation policy's user-visible consequence: env-file changes require
+  restart (no preview re-watch).
 
 ## Risks / tradeoffs (draft)
 

--- a/claude-notes/plans/2026-08-09-environment-files-loading.md
+++ b/claude-notes/plans/2026-08-09-environment-files-loading.md
@@ -268,7 +268,9 @@ Q1 accepts them).
     (real environment beats the file in subprocesses too).
   - **Render scripts** — covered by the spawning unit test
     `scripts_receive_project_env` (real `sh` child reads the variable).
-- [ ] review.md checklist; commit (await user approval per review.md).
+- [x] review.md checklist done; committed as adc2281f and opened as PR #486
+  (https://github.com/quarto-dev/q2/pull/486, branch
+  feature/bd-environment-files-372u9qbs-load-environment-files).
 
 ## Risks / tradeoffs (draft)
 

--- a/claude-notes/plans/2026-08-09-environment-files-loading.md
+++ b/claude-notes/plans/2026-08-09-environment-files-loading.md
@@ -1,0 +1,69 @@
+# Project `_environment` files are not loaded (bd-environment-files-372u9qbs)
+
+**Date:** 2026-08-09
+**Braid:** bd-environment-files-372u9qbs (feature, P1, label `parity`)
+**Checkout:** committed on `main` in the bd-eb2wnxkp worktree (the checkout `/investigate-beads` was invoked in; no new branch created — user decides where implementation lands)
+**Status:** Investigation — pending design alignment with user. **Do not start implementation until the user gives the go-ahead.**
+
+## Triage verdict
+
+**Ready to design.** The symptom reproduces at HEAD, the Q1 reference implementation is small and fully understood, and q2 has an exact structural analog (`_variables.yml` loading) to model the fix on. The open questions are genuine design choices (injection mechanism, scope of consumers, profile support), not missing information.
+
+## Issue context
+
+q2 never reads Quarto 1's project environment-variable files (`_environment`, `_environment.local`, `_environment.required`, `_environment-<profile>`). `EnvShortcodeHandler` resolves `{{< env NAME >}}` against `std::env::var` only, so a variable defined solely in `_environment` renders the unresolved marker `?env:NAME` plus a Q-16-5 warning per use.
+
+Real-world hit: the Posit Connect docs port (352 pages) sets `CONNECT_VERSION` etc. in `_environment`; every `{{< env … >}}` use renders `?env:CONNECT_VERSION` site-wide unless the caller exports the variables manually.
+
+Strand filed 2026-08-10 (yesterday, UTC) by Carlos from the connect-docs porting effort (origin strand in that skein: `br-environment-files-n0joqkug`). Fresh — no stale assumptions.
+
+## Dependency graph
+
+- **related (incoming):** bd-shortcodes-in-metadata-bp06aub8 (open, P1) — filed alongside this one from the same connect-docs port. Shortcodes in `website.title` / `page-footer` / include files are not expanded at all (a *different* failure: config strings never pass through `ShortcodeResolveTransform`). The two compose: even after this strand is fixed, `{{< env CONNECT_VERSION >}}` in `website.title` stays literal until that one is fixed too. Whatever mechanism this strand introduces (project env map vs. process env) must be consumable from wherever that strand ends up expanding config-string shortcodes — worth designing with one eye on it.
+
+No blocks edges, no discovered-from in the braid skein (origin context lives in the connect-docs skein).
+
+## What the code looks like today
+
+Confirmed at HEAD (`8518ac79`); pre-flight `cargo xtask verify --skip-hub-build` green; symptom reproduced end-to-end (see `environment-files-loading-investigation/repro/`, rendered output shows `?env:REPRO_VERSION`).
+
+**q2 side:**
+
+- `crates/quarto-core/src/transforms/shortcode_resolve.rs:213` — `EnvShortcodeHandler::resolve` calls `std::env::var(&name)` directly, falls back to the optional second positional arg, else warns Q-16-5.
+- `rg _environment crates/` — zero hits. Nothing in project discovery/load touches these files.
+- **The structural analog:** `crates/quarto-core/src/stage/context.rs:246` + `load_project_variables` (`context.rs:761`) reads `<project>/_variables.yml` via `SystemRuntime` at `StageContext` construction (skipped when `project.is_single_file`), stores it on the context, and hands it to `ShortcodeResolveTransform::builtin_handlers(variables)` → `VarShortcodeHandler::new(variables)` (`shortcode_resolve.rs:454-458`). An `_environment` map can follow this path line-for-line.
+- **Profiles don't exist in q2:** `quarto render --profile` is parsed (`crates/quarto/src/main.rs:144`) but *dropped* — the `Commands::Render` destructure at `main.rs:748` elides it with `..` and `RenderArgs` has no field for it. No `QUARTO_PROFILE` handling anywhere. So `_environment-<profile>` has no active-profile source to key off yet.
+- **Engines spawn subprocesses:** `crates/quarto-core/src/engine/knitr/subprocess.rs`, `engine/jupyter/*`, and `project/render_scripts.rs` spawn real processes. Under Q1's process-env injection these inherit `_environment` values (R code doing `Sys.getenv("CONNECT_VERSION")` works). A map-only design must decide whether to pass the map at these spawn sites.
+
+**Q1 reference** (`external-sources/quarto-cli/src/quarto-core/dotenv.ts`, called from `project-context.ts:237` during project-context creation):
+
+- Files considered, later-wins priority: `_environment` < `_environment-<profile>` (per active profile) < `_environment.local`; a variable already present in the real process env is **never overwritten** (real env wins over all files).
+- Values are injected into the process env (`Deno.env.set`), with bookkeeping to back them out on re-render and a change event that triggers preview re-renders.
+- `QUARTO_PROFILE` itself may be defined in `_environment`/`_environment.local` (`dotenvQuartoProfile`) — a small bootstrapping wrinkle.
+- `_environment.required` validation is **effectively vestigial** in Q1: the code carries a FIXME noting the dotenv `safe` option it relied on was removed upstream; the current call validates nothing. Q1 in practice parses the file and does not enforce it.
+
+## Proposed phases (draft — contents wait on design answers)
+
+- Phase 0 — Test plan (TDD): failing tests first. Unit tests for the dotenv-file parser + precedence; an end-to-end test driving the real render path (the repro fixture) asserting `from-env-file` appears in output; a precedence test (exported real env beats file value); WASM-path consideration per `.claude/rules/wasm.md`.
+- Phase 1 — Dotenv file parsing + `load_project_environment` in `StageContext` (modeled on `load_project_variables`), with Q1 precedence.
+- Phase 2 — Consumption by `EnvShortcodeHandler` (real env first, then project env map, then fallback arg; Q-16-5 hint updated to mention `_environment`).
+- Phase 3 — (scope-dependent) propagation to engine subprocess + render-script spawn sites.
+- Phase 4 — (scope-dependent) `_environment.required` behavior; profile variants.
+- Phase 5 — Docs (`docs/` user-facing; render with q2, not Q1).
+
+## Open design questions for the user
+
+1. **Injection mechanism.** Q1 mutates the process env. In Rust that means `std::env::set_var` — `unsafe` in edition 2024 and genuinely thread-unsafe (UB if another thread reads the env concurrently, and q2 renders documents in parallel). The `_variables.yml`-style alternative — a project env map on `StageContext`, consulted by `EnvShortcodeHandler` after `std::env::var` misses — is thread-safe and WASM-friendly (loads through `SystemRuntime`, so hub-client preview gets it via the VFS for free). I'd recommend the map. Agreed, or do you want process-env injection for maximal Q1 fidelity?
+2. **Which consumers, in this strand?** The map alone fixes the `env` shortcode (the filed symptom). Q1's injection also makes the variables visible to executed code (knitr/jupyter subprocesses) and pre/post render scripts. Include `.envs(project_env)` at those spawn sites now, or file it as a follow-up strand?
+3. **Profile variants.** q2 has no active-profile machinery (`--profile` is parsed and dropped). Options: (a) scope `_environment-<profile>` out of this strand and file profiles separately; (b) implement a minimal `QUARTO_PROFILE` env-var + `--profile` plumbing just enough for env files. I'd lean (a) — profiles deserve their own design (they also affect `_quarto-<profile>.yml` config merging, which q2 lacks too).
+4. **`_environment.required`.** Q1's validation is vestigial (broken upstream, FIXME in their source). Implement *actual* enforcement (error or warning when a required variable is undefined — arguably the useful behavior Q1 intended), or match Q1's de-facto no-op and just not choke on the file's presence?
+5. **Parser.** Hand-roll a small KEY=VALUE parser (comments, blank lines, optional quotes) in-tree, or take a dependency (`dotenvy`'s parser handles quoting/escaping/multiline)? The Connect docs file is plain `KEY=value` lines; a small in-tree parser keeps the WASM build lean, but a dependency buys edge-case fidelity with Q1's dotenv dialect.
+6. **Single-file mode.** `_variables.yml` is project-scoped in q2 (`is_single_file` → skipped), matching Q1. Same for `_environment`? (Q1 loads it during *project*-context creation, so project-scoped matches.)
+7. **Preview reactivity.** Q1 watches env files and re-renders on change. In scope here, or follow-up?
+
+## Risks / tradeoffs (draft)
+
+- **Coordinate with bd-shortcodes-in-metadata-bp06aub8.** If config-string shortcode expansion lands with a different context type, the env source needs to be reachable from there too. Designing the env map as project-load data (not something buried in `StageContext` construction) keeps both consumers possible.
+- **WASM leg.** `shortcode_resolve.rs` runs in `wasm-quarto-hub-client`; anything touching it needs full `cargo xtask verify` (not `--skip-hub-build`) before commit. `std::env` in wasm32 is a per-instance stub — another reason to prefer the map.
+- **Per-document reload.** `load_project_variables` re-reads `_variables.yml` per `StageContext` (per document). Copying that pattern re-reads `_environment` per document too — fine for correctness (files are tiny), noted in case profiling objects on 352-page sites.
+- **Precedence subtlety.** "Real env wins" must be evaluated per-variable at *resolve* time (`std::env::var` first, then map), not by snapshotting the env at load time, or `-M`-style overrides and test isolation get weird.

--- a/claude-notes/plans/environment-files-loading-investigation/repro/.gitignore
+++ b/claude-notes/plans/environment-files-loading-investigation/repro/.gitignore
@@ -1,0 +1,2 @@
+_site/
+.quarto/

--- a/claude-notes/plans/environment-files-loading-investigation/repro/README.md
+++ b/claude-notes/plans/environment-files-loading-investigation/repro/README.md
@@ -1,0 +1,25 @@
+# Repro: `_environment` file ignored (bd-environment-files-372u9qbs)
+
+Copied from the origin repro at
+`/Users/cscheid/repos/github/cscheid/q2-connect-docs/llms-info/repros/environment-file-ignored/`.
+
+Run (make sure `REPRO_VERSION` is NOT exported):
+
+```bash
+env -u REPRO_VERSION cargo run --bin q2 -- render claude-notes/plans/environment-files-loading-investigation/repro
+```
+
+## Expected (Quarto 1 behavior)
+
+`_environment` contains `REPRO_VERSION=from-env-file`, so the body renders
+"Version is **from-env-file**."
+
+## Actual (q2 @ 8518ac79, confirmed 2026-08-09)
+
+The file is never read; the shortcode resolves against the process env only:
+
+```
+Version is <strong>?env:REPRO_VERSION</strong>.
+```
+
+plus one `[Q-16-5] Environment variable not set` warning per use.

--- a/claude-notes/plans/environment-files-loading-investigation/repro/_environment
+++ b/claude-notes/plans/environment-files-loading-investigation/repro/_environment
@@ -1,0 +1,1 @@
+REPRO_VERSION=from-env-file

--- a/claude-notes/plans/environment-files-loading-investigation/repro/_quarto.yml
+++ b/claude-notes/plans/environment-files-loading-investigation/repro/_quarto.yml
@@ -1,0 +1,2 @@
+project:
+  type: website

--- a/claude-notes/plans/environment-files-loading-investigation/repro/index.qmd
+++ b/claude-notes/plans/environment-files-loading-investigation/repro/index.qmd
@@ -1,0 +1,5 @@
+---
+title: Home
+---
+
+Version is {{< env REPRO_VERSION >}}.

--- a/crates/quarto-core/src/engine/context.rs
+++ b/crates/quarto-core/src/engine/context.rs
@@ -71,6 +71,14 @@ pub struct ExecutionContext {
     /// the context is finalized after include expansion and doesn't change
     /// during engine execution.
     pub source_context: Arc<SourceContext>,
+
+    /// Environment pairs from the project's `_environment` files to
+    /// pass to engine subprocesses, **already filtered** to keys the
+    /// real process environment does not define (see
+    /// [`crate::project::environment::env_for_subprocess`]). q2 never
+    /// mutates its own environment; executed code sees these values
+    /// only because spawn sites apply them with `Command::env`.
+    pub project_env: Vec<(String, String)>,
 }
 
 impl ExecutionContext {
@@ -94,7 +102,16 @@ impl ExecutionContext {
             // any consumer reads it.
             source_info: SourceInfo::generated(By::unknown()),
             source_context: Arc::new(SourceContext::new()),
+            project_env: Vec::new(),
         }
+    }
+
+    /// Set the project environment pairs passed to engine
+    /// subprocesses (pre-filtered by
+    /// [`crate::project::environment::env_for_subprocess`]).
+    pub fn with_project_env(mut self, project_env: Vec<(String, String)>) -> Self {
+        self.project_env = project_env;
+        self
     }
 
     /// Set the project directory.

--- a/crates/quarto-core/src/engine/jupyter/daemon.rs
+++ b/crates/quarto-core/src/engine/jupyter/daemon.rs
@@ -62,11 +62,19 @@ impl JupyterDaemon {
     /// Get or start a kernel session for the given key.
     ///
     /// If a session already exists for this (kernel, working_dir) pair,
-    /// it is reused. Otherwise, a new kernel is started.
+    /// it is reused. Otherwise, a new kernel is started with
+    /// `extra_env` applied on top of the inherited environment —
+    /// project `_environment` pairs pre-filtered so the real
+    /// environment wins. `extra_env` is a **spawn-time** input only:
+    /// the session key deliberately excludes it, so a reused session
+    /// keeps the env it was started with (sessions are keyed per
+    /// working dir, and a render/preview serves one project, so the
+    /// env is stable for a key's lifetime).
     pub async fn get_or_start_session(
         &self,
         kernel_name: &str,
         working_dir: &PathBuf,
+        extra_env: &[(String, String)],
     ) -> Result<SessionKey> {
         let key = SessionKey::new(kernel_name, working_dir.clone());
 
@@ -79,13 +87,13 @@ impl JupyterDaemon {
         }
 
         // Start a new kernel
-        self.start_kernel(&key).await?;
+        self.start_kernel(&key, extra_env).await?;
 
         Ok(key)
     }
 
     /// Start a new kernel for the given key.
-    async fn start_kernel(&self, key: &SessionKey) -> Result<()> {
+    async fn start_kernel(&self, key: &SessionKey, extra_env: &[(String, String)]) -> Result<()> {
         tracing::info!(kernel = %key.kernel_name, dir = %key.working_dir.display(),
             "Starting Jupyter kernel");
 
@@ -140,6 +148,7 @@ impl JupyterDaemon {
                 message: e.to_string(),
             })?
             .current_dir(&key.working_dir)
+            .envs(extra_env.iter().map(|(k, v)| (k, v)))
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped())
             .stdin(std::process::Stdio::piped())

--- a/crates/quarto-core/src/engine/jupyter/text_execute.rs
+++ b/crates/quarto-core/src/engine/jupyter/text_execute.rs
@@ -167,7 +167,9 @@ async fn execute_blocks_inner(
     let daemon = daemon();
 
     // Start or get existing kernel session
-    let key: SessionKey = daemon.get_or_start_session(kernel_name, &ctx.cwd).await?;
+    let key: SessionKey = daemon
+        .get_or_start_session(kernel_name, &ctx.cwd, &ctx.project_env)
+        .await?;
 
     // Document-level defaults for cell options (bd-ohvl879u): the
     // input's front matter is the pipeline's fully merged metadata

--- a/crates/quarto-core/src/engine/knitr/mod.rs
+++ b/crates/quarto-core/src/engine/knitr/mod.rs
@@ -190,6 +190,7 @@ impl ExecutionEngine for KnitrEngine {
         // Step 7: Build call options
         let call_options = CallROptions {
             quiet: ctx.quiet,
+            project_env: ctx.project_env.clone(),
             ..Default::default()
         };
 

--- a/crates/quarto-core/src/engine/knitr/subprocess.rs
+++ b/crates/quarto-core/src/engine/knitr/subprocess.rs
@@ -228,6 +228,12 @@ pub struct CallROptions {
     /// Optional callback to filter/transform stderr output on error.
     /// Receives the stderr content and returns the filtered version.
     pub stderr_filter: Option<fn(&str) -> String>,
+
+    /// Project `_environment` pairs to set on the Rscript child,
+    /// pre-filtered to keys the real environment does not define
+    /// (`crate::project::environment::env_for_subprocess`). The real
+    /// environment is inherited on spawn and always wins.
+    pub project_env: Vec<(String, String)>,
 }
 
 impl CallROptions {
@@ -358,6 +364,7 @@ where
     cmd.args(&args)
         .arg(&rmd_script)
         .current_dir(working_dir)
+        .envs(options.project_env.iter().map(|(k, v)| (k, v)))
         .stdin(Stdio::piped())
         .stdout(Stdio::piped());
 

--- a/crates/quarto-core/src/pipeline.rs
+++ b/crates/quarto-core/src/pipeline.rs
@@ -1177,6 +1177,7 @@ pub fn build_transform_pipeline(
     runtime: std::sync::Arc<dyn quarto_system_runtime::SystemRuntime>,
     target_format: String,
     variables: Option<quarto_pandoc_types::ConfigValue>,
+    project_env: hashlink::LinkedHashMap<String, String>,
 ) -> TransformPipeline {
     let mut pipeline: TransformPipeline = TransformPipeline::new();
 
@@ -1201,6 +1202,7 @@ pub fn build_transform_pipeline(
         runtime.clone(),
         lua_format,
         variables,
+        project_env,
     )));
     pipeline.push(Box::new(MetadataNormalizeTransform::new()));
     // Date normalization (bd-gx9cic8z P4): resolves today/now/
@@ -1539,6 +1541,7 @@ pub fn build_q2_preview_transform_pipeline(
     runtime: std::sync::Arc<dyn quarto_system_runtime::SystemRuntime>,
     target_format: String,
     variables: Option<quarto_pandoc_types::ConfigValue>,
+    project_env: hashlink::LinkedHashMap<String, String>,
 ) -> TransformPipeline {
     let mut pipeline = build_transform_pipeline(
         shortcode_paths,
@@ -1546,6 +1549,7 @@ pub fn build_q2_preview_transform_pipeline(
         runtime,
         target_format,
         variables,
+        project_env,
     );
     pipeline.retain_excluding(Q2_PREVIEW_TRANSFORM_EXCLUDED);
     pipeline
@@ -2703,7 +2707,14 @@ mod tests {
     #[test]
     fn q2_preview_transform_excluded_names_exist_in_html_pipeline() {
         let runtime = make_test_runtime();
-        let html = build_transform_pipeline(vec![], vec![], runtime, "html".to_string(), None);
+        let html = build_transform_pipeline(
+            vec![],
+            vec![],
+            runtime,
+            "html".to_string(),
+            None,
+            Default::default(),
+        );
         let html_names: Vec<&str> = html.iter().map(|t| t.name()).collect();
 
         let unknown: Vec<&&str> = Q2_PREVIEW_TRANSFORM_EXCLUDED
@@ -3135,6 +3146,7 @@ mod tests {
             runtime,
             "q2-preview".to_string(),
             None,
+            Default::default(),
         );
         let names: Vec<&str> = pipeline.iter().map(|t| t.name()).collect();
         assert!(
@@ -3158,6 +3170,7 @@ mod tests {
             runtime,
             "q2-preview".to_string(),
             None,
+            Default::default(),
         );
         let names: Vec<&str> = pipeline.iter().map(|t| t.name()).collect();
         for required in [
@@ -3204,7 +3217,14 @@ mod tests {
     #[test]
     fn html_pipeline_includes_code_block_decoration_transforms() {
         let runtime = make_test_runtime();
-        let pipeline = build_transform_pipeline(vec![], vec![], runtime, "html".to_string(), None);
+        let pipeline = build_transform_pipeline(
+            vec![],
+            vec![],
+            runtime,
+            "html".to_string(),
+            None,
+            Default::default(),
+        );
         let names: Vec<&str> = pipeline.iter().map(|t| t.name()).collect();
 
         let gen_pos = names.iter().position(|&n| n == "code-block-generate");
@@ -3266,8 +3286,14 @@ mod tests {
         // covers them automatically.
         for format in ["html", "revealjs"] {
             let runtime = make_test_runtime();
-            let pipeline =
-                build_transform_pipeline(vec![], vec![], runtime, format.to_string(), None);
+            let pipeline = build_transform_pipeline(
+                vec![],
+                vec![],
+                runtime,
+                format.to_string(),
+                None,
+                Default::default(),
+            );
             let steps: Vec<(&str, TransformPhase)> =
                 pipeline.iter().map(|t| (t.name(), t.phase())).collect();
 
@@ -3314,6 +3340,7 @@ mod tests {
             runtime,
             "q2-preview".to_string(),
             None,
+            Default::default(),
         );
         let names: Vec<&str> = pipeline.iter().map(|t| t.name()).collect();
         for required in ["code-block-generate", "code-block-render"] {
@@ -3333,8 +3360,14 @@ mod tests {
     fn mermaid_render_present_before_code_block_render() {
         for format in ["html", "revealjs"] {
             let runtime = make_test_runtime();
-            let pipeline =
-                build_transform_pipeline(vec![], vec![], runtime, format.to_string(), None);
+            let pipeline = build_transform_pipeline(
+                vec![],
+                vec![],
+                runtime,
+                format.to_string(),
+                None,
+                Default::default(),
+            );
             let names: Vec<&str> = pipeline.iter().map(|t| t.name()).collect();
 
             let mermaid_pos = names.iter().position(|&n| n == "mermaid-render");
@@ -3366,6 +3399,7 @@ mod tests {
                 runtime,
                 format.to_string(),
                 None,
+                Default::default(),
             );
             let names: Vec<&str> = pipeline.iter().map(|t| t.name()).collect();
             assert!(

--- a/crates/quarto-core/src/project/environment.rs
+++ b/crates/quarto-core/src/project/environment.rs
@@ -1,0 +1,1277 @@
+/*
+ * environment.rs
+ * Copyright (c) 2026 Posit, PBC
+ *
+ * Span-annotated parser for Quarto project environment files
+ * (`_environment` and variants) — bd-environment-files-372u9qbs.
+ */
+
+//! Parser for project environment files (`_environment`,
+//! `_environment.local`, `_environment.required`, and — once profiles
+//! exist, bd-ev8mk1rp — `_environment-<profile>`).
+//!
+//! Quarto 2 **never mutates the process environment**. Where Quarto 1
+//! loads these files into the ambient env (`Deno.env.set`), q2 parses
+//! them into a plain map that consumers receive as data: the `env`
+//! shortcode consults it after the real environment misses, and
+//! subprocess spawn sites pass it explicitly. The real process
+//! environment always wins over file-defined values.
+//!
+//! The grammar targets Quarto 1's actual dialect — `@std/dotenv`
+//! (JSR; Q1 pins 0.225.x) — rather than any Rust dotenv crate:
+//!
+//! - optional `export ` prefix; keys must match
+//!   `[A-Za-z_][A-Za-z0-9_]*` (invalid keys are skipped with a
+//!   warning, matching `@std/dotenv`'s console warning);
+//! - single-quoted values are literal (may span multiple lines; no
+//!   escapes, no expansion; one leading/trailing newline stripped);
+//! - double-quoted values (multiline as well) expand the escapes
+//!   `\n` `\r` `\t` `\"` `\'` `\\` and leave other `\x` sequences
+//!   untouched; no `$` expansion;
+//! - unquoted values are trimmed, a `#` starts a trailing comment,
+//!   and `$VAR` / `${VAR}` / `${VAR:-default}` expansion applies —
+//!   resolved against the same file's entries first (forward
+//!   references included, matching `@std/dotenv`'s post-parse
+//!   expansion), then a caller-provided lookup (the real environment
+//!   and previously-loaded files), then the `:-` default.
+//!
+//! Deliberate divergences from `@std/dotenv`, all in the direction of
+//! diagnostics instead of silent misbehavior:
+//!
+//! - a reference to a variable that resolves nowhere expands to the
+//!   empty string with a warning (`@std/dotenv` interpolates the
+//!   JavaScript string `"undefined"`);
+//! - circular references terminate with a warning after a bounded
+//!   number of passes (`@std/dotenv` loops forever);
+//! - a line that is not blank, not a comment, and not a `KEY=value`
+//!   entry gets a warning (`@std/dotenv` skips it silently);
+//! - a `${NAME:-default}` default ends at the first `}` (the
+//!   `@std/dotenv` regex greedily runs to the last `}` on the line).
+//!
+//! Every entry carries [`SourceInfo`] spans for its key and value.
+//! The [`quarto_source_map::FileId`] is derived with
+//! [`quarto_yaml::file_id_for_filename`] — the same scheme the YAML
+//! config stack uses — so diagnostics pointing into an environment
+//! file bind content through the existing
+//! [`crate::config_sources::bind_config_source`] machinery.
+
+use hashlink::LinkedHashMap;
+use quarto_error_reporting::{DiagnosticMessage, DiagnosticMessageBuilder};
+use quarto_source_map::{FileId, Location, Range, SourceInfo};
+use quarto_system_runtime::SystemRuntime;
+
+/// One `KEY=value` entry from an environment file.
+#[derive(Debug, Clone)]
+pub struct EnvEntry {
+    pub key: String,
+    /// The value after quote removal, escape processing, and `$`
+    /// expansion.
+    pub value: String,
+    /// Span of the key token.
+    pub key_span: SourceInfo,
+    /// Span of the raw value token (including quotes, when quoted).
+    pub value_span: SourceInfo,
+}
+
+/// Result of parsing one environment file.
+#[derive(Debug)]
+pub struct ParsedEnvFile {
+    /// Entries in first-definition order; a key defined twice keeps
+    /// its first position and last value (matching `@std/dotenv`).
+    pub entries: Vec<EnvEntry>,
+    /// Warnings (never errors — a malformed environment file must not
+    /// fail a render).
+    pub diagnostics: Vec<DiagnosticMessage>,
+}
+
+/// Upper bound on `$`-expansion passes over a value. `@std/dotenv`
+/// re-scans until no pattern remains, which loops forever on cycles;
+/// we stop here and warn instead.
+const MAX_EXPANSION_PASSES: usize = 8;
+
+/// Parse an environment file.
+///
+/// `lookup` resolves `$NAME` references that the file itself does not
+/// define — callers pass the real process environment plus any
+/// previously-loaded environment files (see the loader in this
+/// module). It is only consulted during value expansion; it does not
+/// affect which entries are returned.
+pub fn parse_env_file(
+    content: &str,
+    filename: &str,
+    lookup: &dyn Fn(&str) -> Option<String>,
+) -> ParsedEnvFile {
+    let file_id = quarto_yaml::file_id_for_filename(filename);
+    let mut parser = Parser::new(content, file_id);
+    parser.parse();
+    let Parser {
+        mut entries,
+        mut diagnostics,
+        ..
+    } = parser;
+
+    // `$` expansion for unquoted values, after the whole file has
+    // parsed: references see every entry in the file (forward ones
+    // included), with values as of the end of parsing — exactly
+    // `@std/dotenv`'s variablesMap semantics.
+    let raw_map: LinkedHashMap<String, String> = entries
+        .iter()
+        .map(|(k, e)| (k.clone(), e.value.clone()))
+        .collect();
+    for entry in entries.values_mut() {
+        if entry.unquoted && entry.value.contains('$') {
+            entry.value = expand_value(
+                &entry.value,
+                &raw_map,
+                lookup,
+                &entry.value_span,
+                &mut diagnostics,
+            );
+        }
+    }
+
+    ParsedEnvFile {
+        entries: entries
+            .into_iter()
+            .map(|(_, e)| EnvEntry {
+                key: e.key,
+                value: e.value,
+                key_span: e.key_span,
+                value_span: e.value_span,
+            })
+            .collect(),
+        diagnostics,
+    }
+}
+
+/// Merge parsed environment layers into one map.
+///
+/// `layers` come in **priority order, highest first** (`.local`, then
+/// profile variants in activation order, then `_environment`); the
+/// first definition of a key wins, mirroring Q1's "only set if not
+/// already set" reads. `real_env` is the real process environment
+/// (injected for testability; production passes `std::env::var`).
+///
+/// `$` references in a layer resolve against that layer's own entries
+/// first (see [`parse_env_file`]), then the real environment, then
+/// values from higher-priority layers — the same visibility Q1 gets
+/// from having already injected higher-priority files into the env.
+///
+/// The returned map holds **file-defined values only**. Consumers must
+/// keep checking the real environment first; a real variable always
+/// wins over these values.
+pub fn merge_env_layers(
+    layers: &[(String, String)],
+    real_env: &dyn Fn(&str) -> Option<String>,
+) -> (LinkedHashMap<String, String>, Vec<DiagnosticMessage>) {
+    let mut acc: LinkedHashMap<String, String> = LinkedHashMap::new();
+    let mut diagnostics = Vec::new();
+    for (filename, content) in layers {
+        let parsed = {
+            let lookup = |name: &str| real_env(name).or_else(|| acc.get(name).cloned());
+            parse_env_file(content, filename, &lookup)
+        };
+        diagnostics.extend(parsed.diagnostics);
+        for entry in parsed.entries {
+            acc.entry(entry.key).or_insert(entry.value);
+        }
+    }
+    (acc, diagnostics)
+}
+
+/// Check an `_environment.required` file against the real environment
+/// and the merged project env map, producing one warning per required
+/// variable that is defined in neither. The diagnostic points at the
+/// requiring line.
+pub fn check_required(
+    content: &str,
+    filename: &str,
+    real_env: &dyn Fn(&str) -> Option<String>,
+    env_map: &LinkedHashMap<String, String>,
+) -> Vec<DiagnosticMessage> {
+    // Expansion inside a `.required` file is irrelevant (only the
+    // keys matter), so resolve references against the merged map to
+    // avoid spurious undefined-variable noise.
+    let lookup = |name: &str| real_env(name).or_else(|| env_map.get(name).cloned());
+    let parsed = parse_env_file(content, filename, &lookup);
+    let mut diagnostics = parsed.diagnostics;
+    for entry in parsed.entries {
+        if real_env(&entry.key).is_none() && !env_map.contains_key(&entry.key) {
+            diagnostics.push(
+                DiagnosticMessageBuilder::warning("Required environment variable not defined")
+                    .problem(format!(
+                        "`{}` is listed in `{}` but is defined neither in the \
+                         environment nor in the project's environment files",
+                        entry.key, filename
+                    ))
+                    .add_hint(format!(
+                        "Set `{}` in the environment, in `_environment`, or in \
+                         `_environment.local`",
+                        entry.key
+                    ))
+                    .with_location(entry.key_span)
+                    .build(),
+            );
+        }
+    }
+    diagnostics
+}
+
+/// Load a project's environment files into a map, Q1-style.
+///
+/// Files considered, priority highest first: `_environment.local`,
+/// `_environment-<profile>` per active profile (activation order —
+/// always empty until bd-ev8mk1rp lands render profiles), and
+/// `_environment`. Missing files are normal. `_environment.required`
+/// contributes validation diagnostics only, never values.
+///
+/// Project-scoped like `_variables.yml`: single-file renders get an
+/// empty map (Q1 parity — env files load during project-context
+/// creation there too).
+pub fn load_project_environment(
+    runtime: &dyn SystemRuntime,
+    project: &crate::project::ProjectContext,
+    active_profiles: &[String],
+    diagnostics: &mut Vec<DiagnosticMessage>,
+) -> LinkedHashMap<String, String> {
+    if project.is_single_file {
+        return LinkedHashMap::new();
+    }
+
+    let mut names: Vec<String> = vec!["_environment.local".to_string()];
+    names.extend(
+        active_profiles
+            .iter()
+            .map(|p| format!("_environment-{}", p)),
+    );
+    names.push("_environment".to_string());
+
+    let mut layers: Vec<(String, String)> = Vec::new();
+    for name in names {
+        let path = project.dir.join(&name);
+        match runtime.file_read_string(&path) {
+            Ok(content) => layers.push((path.display().to_string(), content)),
+            Err(_) => {
+                // Distinguish "absent" (normal) from "present but
+                // unreadable" (worth a warning).
+                if matches!(runtime.path_exists(&path, None), Ok(true)) {
+                    diagnostics.push(
+                        DiagnosticMessageBuilder::warning("Environment file not loaded")
+                            .problem(format!(
+                                "`{}` exists but could not be read; its variables are \
+                                 unavailable",
+                                path.display()
+                            ))
+                            .build(),
+                    );
+                }
+            }
+        }
+    }
+
+    let real_env = |name: &str| std::env::var(name).ok();
+    let (env_map, mut merge_diags) = merge_env_layers(&layers, &real_env);
+    diagnostics.append(&mut merge_diags);
+
+    let required_path = project.dir.join("_environment.required");
+    if let Ok(content) = runtime.file_read_string(&required_path) {
+        diagnostics.extend(check_required(
+            &content,
+            &required_path.display().to_string(),
+            &real_env,
+            &env_map,
+        ));
+    }
+
+    env_map
+}
+
+/// The subset of the project env map to pass to a spawned subprocess:
+/// every pair whose key is **not** set in the real process environment.
+/// Children inherit the real environment on spawn, so applying these
+/// pairs with `Command::env(s)` preserves the precedence rule (real
+/// environment beats file values) without ever mutating our own env.
+pub fn env_for_subprocess(project_env: &LinkedHashMap<String, String>) -> Vec<(String, String)> {
+    project_env
+        .iter()
+        .filter(|(k, _)| std::env::var_os(k).is_none())
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect()
+}
+
+/// Convenience for spawn sites outside the render pipeline (pre/post
+/// render scripts): load the project's environment files and return
+/// the subprocess-safe pairs in one step. Loader diagnostics are
+/// dropped here — the same problems are already reported through
+/// [`crate::stage::StageContext`]'s startup diagnostics on every
+/// document render, and duplicating them per script run is noise.
+pub fn subprocess_env_for_project(
+    runtime: &dyn SystemRuntime,
+    project: &crate::project::ProjectContext,
+) -> Vec<(String, String)> {
+    let mut diagnostics = Vec::new();
+    let map = load_project_environment(runtime, project, &[], &mut diagnostics);
+    env_for_subprocess(&map)
+}
+
+/// Internal per-entry state before expansion.
+struct RawEntry {
+    key: String,
+    value: String,
+    key_span: SourceInfo,
+    value_span: SourceInfo,
+    /// Only unquoted values undergo `$` expansion.
+    unquoted: bool,
+}
+
+struct Parser<'a> {
+    content: &'a str,
+    /// Byte offset cursor. Always on a char boundary.
+    pos: usize,
+    file_id: FileId,
+    /// Byte offsets at which each line starts (for row/column).
+    line_starts: Vec<usize>,
+    entries: LinkedHashMap<String, RawEntry>,
+    diagnostics: Vec<DiagnosticMessage>,
+}
+
+impl<'a> Parser<'a> {
+    fn new(content: &'a str, file_id: FileId) -> Self {
+        // Skip a UTF-8 BOM so the first key doesn't start with it.
+        let start = if content.starts_with('\u{feff}') {
+            3
+        } else {
+            0
+        };
+        let mut line_starts = vec![0];
+        for (i, b) in content.bytes().enumerate() {
+            if b == b'\n' {
+                line_starts.push(i + 1);
+            }
+        }
+        Parser {
+            content,
+            pos: start,
+            file_id,
+            line_starts,
+            entries: LinkedHashMap::new(),
+            diagnostics: Vec::new(),
+        }
+    }
+
+    fn parse(&mut self) {
+        while self.pos < self.content.len() {
+            self.skip_whitespace_and_newlines();
+            if self.pos >= self.content.len() {
+                break;
+            }
+            if self.peek() == Some(b'#') {
+                self.skip_to_eol();
+                continue;
+            }
+            self.parse_entry();
+        }
+    }
+
+    fn parse_entry(&mut self) {
+        let entry_start = self.pos;
+
+        let (mut key_start, mut key) = self.scan_key_token();
+        self.skip_inline_whitespace();
+
+        if self.peek() != Some(b'=') {
+            // `export KEY=value` — `export` is a prefix only when a
+            // second token follows and leads to `=`.
+            if key == "export" {
+                let (ks, k) = self.scan_key_token();
+                self.skip_inline_whitespace();
+                if self.peek() == Some(b'=') && !k.is_empty() {
+                    key_start = ks;
+                    key = k;
+                } else {
+                    self.warn_junk_line(entry_start);
+                    return;
+                }
+            } else {
+                self.warn_junk_line(entry_start);
+                return;
+            }
+        }
+        if key.is_empty() {
+            self.warn_junk_line(entry_start);
+            return;
+        }
+        let key_span = self.span(key_start, key_start + key.len());
+
+        self.pos += 1; // consume '='
+        // `@std/dotenv` allows only spaces/tabs between `=` and the
+        // value (a newline ends an unquoted value).
+        self.skip_inline_whitespace();
+
+        let Some((value, value_span, unquoted)) = self.scan_value(entry_start) else {
+            return; // diagnostic already emitted
+        };
+
+        if !is_valid_key(&key) {
+            self.diagnostics.push(
+                DiagnosticMessageBuilder::warning("Invalid environment variable name")
+                    .problem(format!(
+                        "`{}` is not a valid variable name; the entry is ignored",
+                        key
+                    ))
+                    .add_hint(
+                        "Names must start with a letter or `_` and contain only \
+                         letters, digits, and `_`",
+                    )
+                    .with_location(key_span)
+                    .build(),
+            );
+            return;
+        }
+
+        // Duplicate keys: last value wins, first position is kept
+        // (matching `@std/dotenv`'s object-assignment semantics).
+        let entry = RawEntry {
+            key: key.clone(),
+            value,
+            key_span,
+            value_span,
+            unquoted,
+        };
+        if let Some(existing) = self.entries.get_mut(&key) {
+            *existing = entry;
+        } else {
+            self.entries.insert(key, entry);
+        }
+    }
+
+    /// Scan a run of key-token characters (`[^\s=#]`, stopping at
+    /// line ends). Returns (start offset, token).
+    fn scan_key_token(&mut self) -> (usize, String) {
+        let start = self.pos;
+        while let Some(b) = self.peek() {
+            if b.is_ascii_whitespace() || b == b'=' || b == b'#' {
+                break;
+            }
+            self.pos += utf8_len(b);
+        }
+        (start, self.content[start..self.pos].to_string())
+    }
+
+    /// Scan the value that follows `=`. Returns
+    /// `(value, value_span, unquoted)`, or `None` after emitting a
+    /// diagnostic (unterminated quote).
+    fn scan_value(&mut self, entry_start: usize) -> Option<(String, SourceInfo, bool)> {
+        match self.peek() {
+            Some(b'\'') => {
+                let open = self.pos;
+                let inner_start = open + 1;
+                let Some(rel) = self.content[inner_start..].find('\'') else {
+                    self.warn_unterminated_quote(entry_start, '\'');
+                    return None;
+                };
+                let close = inner_start + rel;
+                self.pos = close + 1;
+                self.skip_to_eol(); // trailing junk/comment discarded, as in @std/dotenv
+                let value = strip_quote_newlines(&self.content[inner_start..close]).to_string();
+                Some((value, self.span(open, close + 1), false))
+            }
+            Some(b'"') => {
+                let open = self.pos;
+                let inner_start = open + 1;
+                let mut close = None;
+                let mut chars = self.content[inner_start..].char_indices();
+                while let Some((i, c)) = chars.next() {
+                    match c {
+                        '\\' => {
+                            chars.next(); // escaped char (may be a newline)
+                        }
+                        '"' => {
+                            close = Some(inner_start + i);
+                            break;
+                        }
+                        _ => {}
+                    }
+                }
+                let Some(close) = close else {
+                    self.warn_unterminated_quote(entry_start, '"');
+                    return None;
+                };
+                self.pos = close + 1;
+                self.skip_to_eol();
+                let raw = strip_quote_newlines(&self.content[inner_start..close]);
+                Some((expand_escapes(raw), self.span(open, close + 1), false))
+            }
+            _ => {
+                // Unquoted: runs to end of line or a `#` (no
+                // preceding whitespace required, matching
+                // `@std/dotenv`'s `[^\r\n#]*`).
+                let start = self.pos;
+                while let Some(b) = self.peek() {
+                    if b == b'\n' || b == b'\r' || b == b'#' {
+                        break;
+                    }
+                    self.pos += utf8_len(b);
+                }
+                let raw = &self.content[start..self.pos];
+                let trimmed = raw.trim();
+                let tstart = start + (raw.len() - raw.trim_start().len());
+                let tend = tstart + trimmed.len();
+                self.skip_to_eol();
+                Some((trimmed.to_string(), self.span(tstart, tend), true))
+            }
+        }
+    }
+
+    fn warn_junk_line(&mut self, entry_start: usize) {
+        self.skip_to_eol_from(entry_start);
+        let line = self.content[entry_start..self.pos]
+            .trim_end_matches(['\n', '\r'])
+            .to_string();
+        let span = self.span(entry_start, entry_start + line.len());
+        self.diagnostics.push(
+            DiagnosticMessageBuilder::warning("Malformed environment file line")
+                .problem(format!(
+                    "`{}` is not a `KEY=value` entry; it is ignored",
+                    line
+                ))
+                .add_hint("Use `NAME=value`, `# comment`, or a blank line")
+                .with_location(span)
+                .build(),
+        );
+    }
+
+    fn warn_unterminated_quote(&mut self, entry_start: usize, quote: char) {
+        self.skip_to_eol_from(entry_start);
+        let span = self.span(entry_start, self.pos);
+        self.diagnostics.push(
+            DiagnosticMessageBuilder::warning("Unterminated quote in environment file")
+                .problem(format!(
+                    "value opened with `{}` is never closed; the entry is ignored",
+                    quote
+                ))
+                .with_location(span)
+                .build(),
+        );
+    }
+
+    fn peek(&self) -> Option<u8> {
+        self.content.as_bytes().get(self.pos).copied()
+    }
+
+    fn skip_inline_whitespace(&mut self) {
+        while matches!(self.peek(), Some(b' ' | b'\t')) {
+            self.pos += 1;
+        }
+    }
+
+    fn skip_whitespace_and_newlines(&mut self) {
+        while let Some(b) = self.peek() {
+            if b.is_ascii_whitespace() {
+                self.pos += 1;
+            } else {
+                break;
+            }
+        }
+    }
+
+    /// Advance past the end of the current line (consuming the
+    /// newline).
+    fn skip_to_eol(&mut self) {
+        while let Some(b) = self.peek() {
+            self.pos += utf8_len(b);
+            if b == b'\n' {
+                break;
+            }
+        }
+    }
+
+    /// Like [`skip_to_eol`], but starting the scan at `from` (used
+    /// for error recovery on the line an entry started on).
+    fn skip_to_eol_from(&mut self, from: usize) {
+        self.pos = self.pos.max(from);
+        self.skip_to_eol();
+    }
+
+    fn location(&self, offset: usize) -> Location {
+        let row = self
+            .line_starts
+            .partition_point(|&start| start <= offset)
+            .saturating_sub(1);
+        let line_start = self.line_starts[row];
+        let column = self.content[line_start..offset].chars().count();
+        Location {
+            offset,
+            row,
+            column,
+        }
+    }
+
+    fn span(&self, start: usize, end: usize) -> SourceInfo {
+        SourceInfo::from_range(
+            self.file_id,
+            Range {
+                start: self.location(start),
+                end: self.location(end),
+            },
+        )
+    }
+}
+
+fn is_valid_key(key: &str) -> bool {
+    let mut chars = key.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() || c == '_' => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+fn utf8_len(first_byte: u8) -> usize {
+    match first_byte {
+        0x00..=0x7f => 1,
+        0xc0..=0xdf => 2,
+        0xe0..=0xef => 3,
+        _ => 4,
+    }
+}
+
+/// Strip one leading and one trailing newline (`\r\n`, `\n`, or
+/// `\r`) inside a quoted value, matching `@std/dotenv`'s
+/// `'\r?\n?…\r?\n?'` quote groups.
+fn strip_quote_newlines(s: &str) -> &str {
+    let s = s
+        .strip_prefix("\r\n")
+        .or_else(|| s.strip_prefix('\n'))
+        .or_else(|| s.strip_prefix('\r'))
+        .unwrap_or(s);
+    s.strip_suffix("\r\n")
+        .or_else(|| s.strip_suffix('\n'))
+        .or_else(|| s.strip_suffix('\r'))
+        .unwrap_or(s)
+}
+
+/// Expand the escape sequences `@std/dotenv` supports in
+/// double-quoted values; any other `\x` stays as-is (backslash
+/// included).
+fn expand_escapes(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars();
+    while let Some(c) = chars.next() {
+        if c != '\\' {
+            out.push(c);
+            continue;
+        }
+        match chars.next() {
+            Some('n') => out.push('\n'),
+            Some('r') => out.push('\r'),
+            Some('t') => out.push('\t'),
+            Some('"') => out.push('"'),
+            Some('\'') => out.push('\''),
+            Some('\\') => out.push('\\'),
+            Some(other) => {
+                out.push('\\');
+                out.push(other);
+            }
+            None => out.push('\\'),
+        }
+    }
+    out
+}
+
+/// Run bounded `$`-expansion passes over an unquoted value.
+fn expand_value(
+    value: &str,
+    raw_map: &LinkedHashMap<String, String>,
+    lookup: &dyn Fn(&str) -> Option<String>,
+    value_span: &SourceInfo,
+    diagnostics: &mut Vec<DiagnosticMessage>,
+) -> String {
+    let mut current = value.to_string();
+    for _ in 0..MAX_EXPANSION_PASSES {
+        let (next, any_pattern) = expand_once(&current, raw_map, lookup, value_span, diagnostics);
+        if !any_pattern || next == current {
+            return next;
+        }
+        current = next;
+        if !current.contains('$') {
+            return current;
+        }
+    }
+    diagnostics.push(
+        DiagnosticMessageBuilder::warning("Environment variable expansion did not converge")
+            .problem(format!(
+                "expansion of `{}` still contains `$` references after {} passes \
+                 (possible circular reference)",
+                value, MAX_EXPANSION_PASSES
+            ))
+            .with_location(value_span.clone())
+            .build(),
+    );
+    current
+}
+
+/// One expansion pass. Returns the rewritten string and whether any
+/// expandable `$` pattern was found.
+fn expand_once(
+    input: &str,
+    raw_map: &LinkedHashMap<String, String>,
+    lookup: &dyn Fn(&str) -> Option<String>,
+    value_span: &SourceInfo,
+    diagnostics: &mut Vec<DiagnosticMessage>,
+) -> (String, bool) {
+    let mut out = String::with_capacity(input.len());
+    let mut any_pattern = false;
+    let chars: Vec<char> = input.chars().collect();
+    let mut i = 0;
+    while i < chars.len() {
+        let c = chars[i];
+        if c != '$' {
+            out.push(c);
+            i += 1;
+            continue;
+        }
+        // `${NAME}` / `${NAME:-default}` — no escape for this form in
+        // `@std/dotenv` (its lookbehind guards only the bare form).
+        if chars.get(i + 1) == Some(&'{') {
+            let mut j = i + 2;
+            while j < chars.len() && chars[j] != '}' {
+                j += 1;
+            }
+            if j >= chars.len() {
+                // Unterminated `${` — literal, keep scanning after it.
+                out.push('$');
+                out.push('{');
+                i += 2;
+                continue;
+            }
+            let inner: String = chars[i + 2..j].iter().collect();
+            let (name, default) = match inner.split_once(":-") {
+                Some((n, d)) => (n.to_string(), Some(d.to_string())),
+                None => (inner, None),
+            };
+            if name.is_empty() {
+                // `${}` (or `${:-…}`) has no name to expand; keep it
+                // verbatim, as @std/dotenv's `.+?` group would.
+                out.extend(&chars[i..=j]);
+                i = j + 1;
+                continue;
+            }
+            any_pattern = true;
+            out.push_str(&resolve_name(
+                &name,
+                default.as_deref(),
+                raw_map,
+                lookup,
+                value_span,
+                diagnostics,
+            ));
+            i = j + 1;
+            continue;
+        }
+        // Bare `$NAME` — suppressed when preceded by `\` (the
+        // backslash itself stays in the output, as in `@std/dotenv`).
+        let escaped = i > 0 && chars[i - 1] == '\\';
+        let mut j = i + 1;
+        while j < chars.len() && (chars[j].is_alphanumeric() || chars[j] == '_') {
+            j += 1;
+        }
+        if j == i + 1 || escaped {
+            out.push('$');
+            i += 1;
+            continue;
+        }
+        let name: String = chars[i + 1..j].iter().collect();
+        // Optional `:-default` after the bare form runs to the end of
+        // the value (matching the `@std/dotenv` regex's greedy `.+`).
+        let default: Option<String> =
+            if chars.get(j) == Some(&':') && chars.get(j + 1) == Some(&'-') {
+                let d: String = chars[j + 2..].iter().collect();
+                j = chars.len();
+                Some(d)
+            } else {
+                None
+            };
+        any_pattern = true;
+        out.push_str(&resolve_name(
+            &name,
+            default.as_deref(),
+            raw_map,
+            lookup,
+            value_span,
+            diagnostics,
+        ));
+        i = j;
+    }
+    (out, any_pattern)
+}
+
+fn resolve_name(
+    name: &str,
+    default: Option<&str>,
+    raw_map: &LinkedHashMap<String, String>,
+    lookup: &dyn Fn(&str) -> Option<String>,
+    value_span: &SourceInfo,
+    diagnostics: &mut Vec<DiagnosticMessage>,
+) -> String {
+    if let Some(v) = raw_map.get(name) {
+        return v.clone();
+    }
+    if let Some(v) = lookup(name) {
+        return v;
+    }
+    if let Some(d) = default {
+        return d.to_string();
+    }
+    diagnostics.push(
+        DiagnosticMessageBuilder::warning("Undefined variable in environment file")
+            .problem(format!(
+                "`${}` is not defined in this file, the environment, or a \
+                 previously-loaded environment file; it expands to the empty string",
+                name
+            ))
+            .add_hint(format!(
+                "Define `{}`, or provide a default with `${{{}:-default}}`",
+                name, name
+            ))
+            .with_location(value_span.clone())
+            .build(),
+    );
+    String::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn no_lookup(_: &str) -> Option<String> {
+        None
+    }
+
+    fn parse(content: &str) -> ParsedEnvFile {
+        parse_env_file(content, "_environment", &no_lookup)
+    }
+
+    fn values(parsed: &ParsedEnvFile) -> Vec<(&str, &str)> {
+        parsed
+            .entries
+            .iter()
+            .map(|e| (e.key.as_str(), e.value.as_str()))
+            .collect()
+    }
+
+    #[test]
+    fn plain_entries() {
+        let p = parse("A=hello\nB=world\n");
+        assert_eq!(values(&p), vec![("A", "hello"), ("B", "world")]);
+        assert!(p.diagnostics.is_empty());
+    }
+
+    #[test]
+    fn export_prefix() {
+        let p = parse("export A=1\n");
+        assert_eq!(values(&p), vec![("A", "1")]);
+        assert!(p.diagnostics.is_empty());
+    }
+
+    #[test]
+    fn export_as_key() {
+        // `export=x` and `export = x` define a variable literally
+        // named `export` (matches @std/dotenv's regex backtracking).
+        let p = parse("export=x\n");
+        assert_eq!(values(&p), vec![("export", "x")]);
+    }
+
+    #[test]
+    fn comments_and_blank_lines() {
+        let p = parse("\n# a comment\n\nA=1\n   # indented comment\n");
+        assert_eq!(values(&p), vec![("A", "1")]);
+        assert!(p.diagnostics.is_empty());
+    }
+
+    #[test]
+    fn unquoted_trailing_comment() {
+        let p = parse("A=hello # comment\nB=hello#no-space\n");
+        assert_eq!(values(&p), vec![("A", "hello"), ("B", "hello")]);
+    }
+
+    #[test]
+    fn unquoted_trimmed() {
+        let p = parse("A=   spaced out   \n");
+        assert_eq!(values(&p), vec![("A", "spaced out")]);
+    }
+
+    #[test]
+    fn unquoted_value_may_contain_equals() {
+        let p = parse("A=b=c\n");
+        assert_eq!(values(&p), vec![("A", "b=c")]);
+    }
+
+    #[test]
+    fn spaces_around_equals() {
+        let p = parse("A = 1\n");
+        assert_eq!(values(&p), vec![("A", "1")]);
+    }
+
+    #[test]
+    fn empty_value() {
+        let p = parse("A=\nB=1\n");
+        assert_eq!(values(&p), vec![("A", ""), ("B", "1")]);
+    }
+
+    #[test]
+    fn single_quoted_literal() {
+        let p = parse("A='  keeps  spaces  '\n");
+        assert_eq!(values(&p), vec![("A", "  keeps  spaces  ")]);
+    }
+
+    #[test]
+    fn single_quoted_no_expansion_no_escapes() {
+        let p = parse("B=x\nA='$B and \\n stay literal'\n");
+        assert_eq!(
+            values(&p),
+            vec![("B", "x"), ("A", "$B and \\n stay literal")]
+        );
+        assert!(p.diagnostics.is_empty());
+    }
+
+    #[test]
+    fn single_quoted_multiline() {
+        let p = parse("A='\nline1\nline2\n'\nB=after\n");
+        assert_eq!(values(&p), vec![("A", "line1\nline2"), ("B", "after")]);
+    }
+
+    #[test]
+    fn double_quoted_escapes() {
+        let p = parse(r#"A="a\nb\tc\"d\\e\'f""#);
+        assert_eq!(values(&p), vec![("A", "a\nb\tc\"d\\e'f")]);
+    }
+
+    #[test]
+    fn double_quoted_unknown_escape_kept() {
+        let p = parse(r#"A="a\xb""#);
+        assert_eq!(values(&p), vec![("A", "a\\xb")]);
+    }
+
+    #[test]
+    fn double_quoted_multiline() {
+        let p = parse("A=\"\nline1\nline2\n\"\nB=after\n");
+        assert_eq!(values(&p), vec![("A", "line1\nline2"), ("B", "after")]);
+    }
+
+    #[test]
+    fn double_quoted_no_dollar_expansion() {
+        let p = parse("B=x\nA=\"$B\"\n");
+        assert_eq!(values(&p), vec![("B", "x"), ("A", "$B")]);
+        assert!(p.diagnostics.is_empty());
+    }
+
+    #[test]
+    fn expansion_same_file() {
+        let p = parse("B=x\nA=$B\n");
+        assert_eq!(values(&p), vec![("B", "x"), ("A", "x")]);
+    }
+
+    #[test]
+    fn expansion_forward_reference() {
+        // @std/dotenv expands after parsing the whole file.
+        let p = parse("A=$B\nB=x\n");
+        assert_eq!(values(&p), vec![("A", "x"), ("B", "x")]);
+    }
+
+    #[test]
+    fn expansion_braced() {
+        let p = parse("B=x\nA=pre${B}post\n");
+        assert_eq!(values(&p), vec![("B", "x"), ("A", "prexpost")]);
+    }
+
+    #[test]
+    fn expansion_braced_default() {
+        let p = parse("A=${MISSING:-fallback}\n");
+        assert_eq!(values(&p), vec![("A", "fallback")]);
+        assert!(p.diagnostics.is_empty());
+    }
+
+    #[test]
+    fn expansion_bare_default_runs_to_end() {
+        let p = parse("A=$MISSING:-a b c\n");
+        assert_eq!(values(&p), vec![("A", "a b c")]);
+    }
+
+    #[test]
+    fn expansion_uses_lookup() {
+        let lookup = |name: &str| (name == "EXT").then(|| "ext-value".to_string());
+        let p = parse_env_file("A=$EXT\n", "_environment", &lookup);
+        assert_eq!(values(&p), vec![("A", "ext-value")]);
+    }
+
+    #[test]
+    fn expansion_same_file_beats_lookup() {
+        let lookup = |name: &str| (name == "B").then(|| "from-lookup".to_string());
+        let p = parse_env_file("B=in-file\nA=$B\n", "_environment", &lookup);
+        assert_eq!(values(&p), vec![("B", "in-file"), ("A", "in-file")]);
+    }
+
+    #[test]
+    fn expansion_undefined_is_empty_with_diagnostic() {
+        let p = parse("A=x${NOPE}y\n");
+        assert_eq!(values(&p), vec![("A", "xy")]);
+        assert_eq!(p.diagnostics.len(), 1);
+        let text = format!("{:?}", p.diagnostics[0]);
+        assert!(
+            text.contains("NOPE"),
+            "diagnostic names the variable: {text}"
+        );
+    }
+
+    #[test]
+    fn expansion_escaped_bare_dollar() {
+        // `\$B` is not expanded; the backslash stays (as in
+        // @std/dotenv).
+        let p = parse("B=x\nA=\\$B\n");
+        assert_eq!(values(&p), vec![("B", "x"), ("A", "\\$B")]);
+    }
+
+    #[test]
+    fn expansion_transitive() {
+        let p = parse("C=z\nB=$C\nA=$B\n");
+        assert_eq!(values(&p), vec![("C", "z"), ("B", "z"), ("A", "z")]);
+    }
+
+    #[test]
+    fn expansion_cycle_terminates_with_diagnostic() {
+        let p = parse("A=$B\nB=$A\n");
+        assert!(
+            p.diagnostics
+                .iter()
+                .any(|d| format!("{:?}", d).contains("did not converge")
+                    || format!("{:?}", d).contains("converge")),
+            "expected non-convergence diagnostic, got: {:?}",
+            p.diagnostics
+        );
+    }
+
+    #[test]
+    fn dollar_before_non_name_is_literal() {
+        let p = parse("A=costs $$ and $ signs\n");
+        assert_eq!(values(&p), vec![("A", "costs $$ and $ signs")]);
+        assert!(p.diagnostics.is_empty());
+    }
+
+    #[test]
+    fn invalid_key_skipped_with_diagnostic() {
+        let p = parse("1AB=x\nGOOD=1\n");
+        assert_eq!(values(&p), vec![("GOOD", "1")]);
+        assert_eq!(p.diagnostics.len(), 1);
+    }
+
+    #[test]
+    fn junk_line_warns() {
+        let p = parse("not a kv line\nA=1\n");
+        assert_eq!(values(&p), vec![("A", "1")]);
+        assert_eq!(p.diagnostics.len(), 1);
+        let text = format!("{:?}", p.diagnostics[0]);
+        assert!(text.contains("not a kv line"), "{text}");
+    }
+
+    #[test]
+    fn duplicate_key_last_wins_first_position() {
+        let p = parse("A=1\nB=2\nA=3\n");
+        assert_eq!(values(&p), vec![("A", "3"), ("B", "2")]);
+    }
+
+    #[test]
+    fn crlf_line_endings() {
+        let p = parse("A=1\r\nB=2\r\n");
+        assert_eq!(values(&p), vec![("A", "1"), ("B", "2")]);
+    }
+
+    #[test]
+    fn unterminated_quote_warns_and_skips() {
+        let p = parse("A='never closed\nB=1\n");
+        // The single-quote scan runs to EOF without a close; the
+        // entry is dropped with a diagnostic. B is consumed by the
+        // failed scan? No: the scan looks for a closing quote in the
+        // whole rest of the file — absent, so only A's line is
+        // skipped.
+        assert_eq!(values(&p), vec![("B", "1")]);
+        assert_eq!(p.diagnostics.len(), 1);
+    }
+
+    #[test]
+    fn spans_resolve_to_correct_bytes() {
+        let content = "FOO=bar\nBAZ='qux'\n";
+        let p = parse(content);
+        let fid = quarto_yaml::file_id_for_filename("_environment").0;
+
+        let (f0, s0, e0) = p.entries[0].key_span.resolve_byte_range().unwrap();
+        assert_eq!((f0, &content[s0..e0]), (fid, "FOO"));
+        let (_, s1, e1) = p.entries[0].value_span.resolve_byte_range().unwrap();
+        assert_eq!(&content[s1..e1], "bar");
+
+        let (_, s2, e2) = p.entries[1].key_span.resolve_byte_range().unwrap();
+        assert_eq!(&content[s2..e2], "BAZ");
+        // Quoted value spans include the quotes.
+        let (_, s3, e3) = p.entries[1].value_span.resolve_byte_range().unwrap();
+        assert_eq!(&content[s3..e3], "'qux'");
+    }
+
+    #[test]
+    fn span_of_trimmed_unquoted_value() {
+        let content = "A=   padded   \n";
+        let p = parse(content);
+        let (_, s, e) = p.entries[0].value_span.resolve_byte_range().unwrap();
+        assert_eq!(&content[s..e], "padded");
+    }
+
+    #[test]
+    fn bom_is_skipped() {
+        let p = parse("\u{feff}A=1\n");
+        assert_eq!(values(&p), vec![("A", "1")]);
+        assert!(p.diagnostics.is_empty());
+    }
+
+    #[test]
+    fn utf8_values() {
+        let p = parse("GREETING=olá mundo\n");
+        assert_eq!(values(&p), vec![("GREETING", "olá mundo")]);
+    }
+
+    // === merge_env_layers ===
+
+    fn layers(specs: &[(&str, &str)]) -> Vec<(String, String)> {
+        specs
+            .iter()
+            .map(|(f, c)| (f.to_string(), c.to_string()))
+            .collect()
+    }
+
+    fn no_env(_: &str) -> Option<String> {
+        None
+    }
+
+    #[test]
+    fn merge_local_beats_base() {
+        let (map, diags) = merge_env_layers(
+            &layers(&[
+                ("_environment.local", "A=local\n"),
+                ("_environment", "A=base\nB=only-base\n"),
+            ]),
+            &no_env,
+        );
+        assert_eq!(map.get("A").map(String::as_str), Some("local"));
+        assert_eq!(map.get("B").map(String::as_str), Some("only-base"));
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn merge_expansion_sees_higher_priority_layers() {
+        // A reference in `_environment` resolves to the value the
+        // higher-priority `.local` layer defined — the visibility Q1
+        // gets from injecting `.local` into the env first.
+        let (map, _) = merge_env_layers(
+            &layers(&[
+                ("_environment.local", "NAME=from-local\n"),
+                ("_environment", "GREETING=hi $NAME\n"),
+            ]),
+            &no_env,
+        );
+        assert_eq!(
+            map.get("GREETING").map(String::as_str),
+            Some("hi from-local")
+        );
+    }
+
+    #[test]
+    fn merge_expansion_real_env_wins_over_layers() {
+        let real = |name: &str| (name == "NAME").then(|| "from-real-env".to_string());
+        let (map, _) = merge_env_layers(
+            &layers(&[
+                ("_environment.local", "NAME=from-local\n"),
+                ("_environment", "GREETING=hi $NAME\n"),
+            ]),
+            &real,
+        );
+        assert_eq!(
+            map.get("GREETING").map(String::as_str),
+            Some("hi from-real-env")
+        );
+        // The map still carries the file value; consumers checking the
+        // real environment first is what makes the real value win.
+        assert_eq!(map.get("NAME").map(String::as_str), Some("from-local"));
+    }
+
+    #[test]
+    fn merge_same_file_beats_real_env_in_expansion() {
+        // @std/dotenv resolves same-file references before the
+        // environment.
+        let real = |name: &str| (name == "B").then(|| "real".to_string());
+        let (map, _) = merge_env_layers(&layers(&[("_environment", "B=file\nA=$B\n")]), &real);
+        assert_eq!(map.get("A").map(String::as_str), Some("file"));
+    }
+
+    #[test]
+    fn merge_collects_layer_diagnostics() {
+        let (map, diags) =
+            merge_env_layers(&layers(&[("_environment", "junk line\nA=1\n")]), &no_env);
+        assert_eq!(map.get("A").map(String::as_str), Some("1"));
+        assert_eq!(diags.len(), 1);
+    }
+
+    // === env_for_subprocess ===
+
+    #[test]
+    fn subprocess_env_filters_real_env_keys() {
+        // SAFETY: test-local variable name; nextest runs each test in
+        // its own process, so no cross-test env races.
+        unsafe { std::env::set_var("Q2_TEST_SUBPROC_SHADOWED", "real") };
+        let mut map = LinkedHashMap::new();
+        map.insert("Q2_TEST_SUBPROC_SHADOWED".to_string(), "file".to_string());
+        map.insert("Q2_TEST_SUBPROC_FRESH".to_string(), "file".to_string());
+        assert_eq!(
+            env_for_subprocess(&map),
+            vec![("Q2_TEST_SUBPROC_FRESH".to_string(), "file".to_string())]
+        );
+    }
+
+    // === check_required ===
+
+    #[test]
+    fn required_missing_var_warns_with_span() {
+        let content = "PRESENT=\nMISSING=example value\n";
+        let mut map = LinkedHashMap::new();
+        map.insert("PRESENT".to_string(), "x".to_string());
+        let diags = check_required(content, "_environment.required", &no_env, &map);
+        assert_eq!(diags.len(), 1);
+        let text = format!("{:?}", diags[0]);
+        assert!(text.contains("MISSING"), "{text}");
+        // The span points at the requiring key.
+        let loc = diags[0].location.as_ref().expect("diagnostic has a span");
+        let (fid, s, e) = loc.resolve_byte_range().unwrap();
+        assert_eq!(
+            fid,
+            quarto_yaml::file_id_for_filename("_environment.required").0
+        );
+        assert_eq!(&content[s..e], "MISSING");
+    }
+
+    #[test]
+    fn required_satisfied_by_real_env() {
+        let real = |name: &str| (name == "FROM_ENV").then(|| "1".to_string());
+        let diags = check_required(
+            "FROM_ENV=\n",
+            "_environment.required",
+            &real,
+            &LinkedHashMap::new(),
+        );
+        assert!(diags.is_empty(), "{diags:?}");
+    }
+
+    #[test]
+    fn required_all_satisfied_is_quiet() {
+        let mut map = LinkedHashMap::new();
+        map.insert("A".to_string(), "1".to_string());
+        let diags = check_required("A=\n", "_environment.required", &no_env, &map);
+        assert!(diags.is_empty(), "{diags:?}");
+    }
+}

--- a/crates/quarto-core/src/project/mod.rs
+++ b/crates/quarto-core/src/project/mod.rs
@@ -26,6 +26,7 @@
 pub mod cache_key;
 pub mod dependency_graph;
 pub mod discovery;
+pub mod environment;
 pub mod index;
 pub mod listing;
 pub mod orchestrator;

--- a/crates/quarto-core/src/project/render_scripts.rs
+++ b/crates/quarto-core/src/project/render_scripts.rs
@@ -282,6 +282,12 @@ mod exec {
         /// `QUARTO_PROJECT_SCRIPT_PROGRESS` hint (`"1"` on a
         /// multi-file render when not quiet).
         pub file_count: usize,
+        /// Project `_environment` pairs to set on script children,
+        /// pre-filtered to keys the real environment does not define
+        /// ([`crate::project::environment::env_for_subprocess`]).
+        /// Applied before the `QUARTO_PROJECT_*` variables, so those
+        /// win any collision.
+        pub project_env: &'a [(String, String)],
     }
 
     impl RenderScriptsContext<'_> {
@@ -388,6 +394,9 @@ mod exec {
 
         let mut cmd = build_script_command(ctx.project_dir, &tokens);
         cmd.current_dir(ctx.project_dir);
+        for (k, v) in ctx.project_env {
+            cmd.env(k, v);
+        }
         for (k, v) in env {
             cmd.env(k, v);
         }
@@ -885,6 +894,51 @@ mod tests {
                 assert!(render_scripts_unsupported_diagnostic(host, &config).is_none());
             }
         }
+    }
+
+    // ── project env propagation (bd-environment-files-372u9qbs) ─────
+
+    /// A pre-render script sees `_environment`-derived pairs passed
+    /// via `RenderScriptsContext::project_env`. Unix-only: the script
+    /// runs through `sh`; Windows coverage is the shared
+    /// `env_for_subprocess` unit tests plus the mechanical
+    /// `cmd.env` application.
+    #[cfg(unix)]
+    #[test]
+    fn scripts_receive_project_env() {
+        use quarto_source_map::By;
+
+        let dir = tempfile::tempdir().unwrap();
+        let project_dir = dir.path();
+        let out_path = project_dir.join("env-out.txt");
+
+        let script = RenderScript {
+            command: format!(
+                "sh -c \"printf %s $Q2_TEST_SCRIPT_ENV_VAR > {}\"",
+                out_path.display()
+            ),
+            source_info: SourceInfo::generated(By::unknown()),
+        };
+        let project_env = vec![(
+            "Q2_TEST_SCRIPT_ENV_VAR".to_string(),
+            "from-env-file".to_string(),
+        )];
+        let ctx = RenderScriptsContext {
+            project_dir,
+            output_dir: project_dir,
+            config_path: None,
+            extension_manifest_paths: &[],
+            render_all: true,
+            quiet: true,
+            file_count: 1,
+            project_env: &project_env,
+        };
+        run_render_scripts(ScriptPhase::PreRender, &[script], &ctx, &[])
+            .expect("script should succeed");
+        assert_eq!(
+            std::fs::read_to_string(&out_path).expect("script wrote the file"),
+            "from-env-file"
+        );
     }
 
     // ── error catalog registration ──────────────────────────────────

--- a/crates/quarto-core/src/stage/context.rs
+++ b/crates/quarto-core/src/stage/context.rs
@@ -86,6 +86,15 @@ pub struct StageContext {
     /// file does not exist.
     pub variables: Option<quarto_pandoc_types::ConfigValue>,
 
+    /// Project environment variables from `_environment` files
+    /// (`_environment` + `_environment.local`; profile variants once
+    /// bd-ev8mk1rp lands). File-defined values only — q2 never mutates
+    /// the process environment, and consumers must check the real
+    /// environment first so it always wins (see
+    /// [`crate::project::environment`]). Empty for single-file renders
+    /// (Q1 parity: env files are project-scoped).
+    pub project_env: hashlink::LinkedHashMap<String, String>,
+
     // === Mutable state ===
     /// Artifact store for dependencies and intermediates
     pub artifacts: ArtifactStore,
@@ -245,6 +254,15 @@ impl StageContext {
         let variables =
             load_project_variables(runtime.as_ref(), &project, &mut startup_diagnostics);
 
+        // Active profiles are always empty until bd-ev8mk1rp lands
+        // render-profile support.
+        let project_env = crate::project::environment::load_project_environment(
+            runtime.as_ref(),
+            &project,
+            &[],
+            &mut startup_diagnostics,
+        );
+
         Ok(Self {
             runtime,
             format,
@@ -253,6 +271,7 @@ impl StageContext {
             temp_dir: std::sync::OnceLock::new(),
             extensions,
             variables,
+            project_env,
             artifacts: ArtifactStore::new(),
             includes: PandocIncludes::default(),
             diagnostics: startup_diagnostics,

--- a/crates/quarto-core/src/stage/stages/ast_transforms.rs
+++ b/crates/quarto-core/src/stage/stages/ast_transforms.rs
@@ -142,6 +142,7 @@ impl PipelineStage for AstTransformsStage {
                     ctx.runtime.clone(),
                     ctx.format.target_format.clone(),
                     ctx.variables.clone(),
+                    ctx.project_env.clone(),
                 ),
                 _ => build_transform_pipeline(
                     shortcode_paths,
@@ -149,6 +150,7 @@ impl PipelineStage for AstTransformsStage {
                     ctx.runtime.clone(),
                     ctx.format.target_format.clone(),
                     ctx.variables.clone(),
+                    ctx.project_env.clone(),
                 ),
             };
             &jit_pipeline

--- a/crates/quarto-core/src/stage/stages/engine_execution.rs
+++ b/crates/quarto-core/src/stage/stages/engine_execution.rs
@@ -384,7 +384,10 @@ impl PipelineStage for EngineExecutionStage {
                 Some(ctx.project.dir.clone())
             })
             .with_engine_config(engine_config)
-            .with_source_info(qmd_source_info, source_context_arc.clone());
+            .with_source_info(qmd_source_info, source_context_arc.clone())
+            .with_project_env(crate::project::environment::env_for_subprocess(
+                &ctx.project_env,
+            ));
 
             trace_event!(ctx, EventLevel::Info, "executing engine: {}", engine.name());
             let mut result = engine

--- a/crates/quarto-core/src/transforms/shortcode_resolve.rs
+++ b/crates/quarto-core/src/transforms/shortcode_resolve.rs
@@ -176,12 +176,23 @@ fn positional_arg_to_string(arg: &ShortcodeArg) -> Option<String> {
 
 /// Built-in handler for `{{< env NAME >}}` / `{{< env NAME fallback >}}`.
 ///
-/// Reads a process environment variable; the optional second positional
-/// argument is the value used when the variable is unset (Q1 1.5, #8316).
-/// Unset with no fallback is a Q-16-5 warning (Q1 warned and emitted
-/// `?env`). On wasm32 `std::env::var` always errs, so `env` behaves as
-/// uniformly-unset there.
-pub struct EnvShortcodeHandler;
+/// Resolution order: the real process environment, then the project's
+/// `_environment` files (loaded into `project_env` by
+/// [`crate::project::environment::load_project_environment`] — q2
+/// never mutates the process env, so file values arrive as data), then
+/// the optional second positional argument (Q1 1.5, #8316). Unset
+/// everywhere with no fallback is a Q-16-5 warning (Q1 warned and
+/// emitted `?env`). On wasm32 `std::env::var` always errs, so only the
+/// project env map (loaded through the VFS) and fallbacks apply there.
+pub struct EnvShortcodeHandler {
+    project_env: hashlink::LinkedHashMap<String, String>,
+}
+
+impl EnvShortcodeHandler {
+    pub fn new(project_env: hashlink::LinkedHashMap<String, String>) -> Self {
+        Self { project_env }
+    }
+}
 
 impl ShortcodeHandler for EnvShortcodeHandler {
     fn name(&self) -> &str {
@@ -210,12 +221,15 @@ impl ShortcodeHandler for EnvShortcodeHandler {
             });
         };
 
-        let value = std::env::var(&name).ok().or_else(|| {
-            shortcode
-                .positional_args
-                .get(1)
-                .and_then(positional_arg_to_string)
-        });
+        let value = std::env::var(&name)
+            .ok()
+            .or_else(|| self.project_env.get(&name).cloned())
+            .or_else(|| {
+                shortcode
+                    .positional_args
+                    .get(1)
+                    .and_then(positional_arg_to_string)
+            });
 
         match value {
             Some(text) => ShortcodeResult::Inlines(vec![Inline::Str(Str {
@@ -229,7 +243,10 @@ impl ShortcodeHandler for EnvShortcodeHandler {
                         "Environment variable `{}` is not set and no fallback was given",
                         name
                     ))
-                    .add_hint("Set the variable, or pass a fallback: `{{< env NAME fallback >}}`")
+                    .add_hint(
+                        "Set the variable, define it in the project's `_environment` \
+                         file, or pass a fallback: `{{< env NAME fallback >}}`",
+                    )
                     .with_location(ctx.source_info.clone())
                     .build();
                 ShortcodeResult::Error(ShortcodeError {
@@ -441,7 +458,7 @@ impl ShortcodeResolveTransform {
     /// Used in tests that don't need Lua support.
     pub fn new() -> Self {
         Self {
-            handlers: Self::builtin_handlers(None),
+            handlers: Self::builtin_handlers(None, hashlink::LinkedHashMap::new()),
             lua_shortcode_paths: Vec::new(),
             extensions: Vec::new(),
             runtime: None,
@@ -449,12 +466,16 @@ impl ShortcodeResolveTransform {
         }
     }
 
-    /// The built-in Rust handlers: `meta`, `env`, and `var` (fed by the
-    /// project's `_variables.yml`, when present).
-    fn builtin_handlers(variables: Option<ConfigValue>) -> Vec<Box<dyn ShortcodeHandler>> {
+    /// The built-in Rust handlers: `meta`, `env` (fed by the project's
+    /// `_environment` files), and `var` (fed by the project's
+    /// `_variables.yml`, when present).
+    fn builtin_handlers(
+        variables: Option<ConfigValue>,
+        project_env: hashlink::LinkedHashMap<String, String>,
+    ) -> Vec<Box<dyn ShortcodeHandler>> {
         vec![
             Box::new(MetaShortcodeHandler),
-            Box::new(EnvShortcodeHandler),
+            Box::new(EnvShortcodeHandler::new(project_env)),
             Box::new(VarShortcodeHandler::new(variables)),
         ]
     }
@@ -469,9 +490,10 @@ impl ShortcodeResolveTransform {
         runtime: Arc<dyn SystemRuntime>,
         target_format: String,
         variables: Option<ConfigValue>,
+        project_env: hashlink::LinkedHashMap<String, String>,
     ) -> Self {
         Self {
-            handlers: Self::builtin_handlers(variables),
+            handlers: Self::builtin_handlers(variables, project_env),
             lua_shortcode_paths,
             extensions,
             runtime: Some(runtime),
@@ -1924,7 +1946,7 @@ mod tests {
 
     #[test]
     fn test_env_shortcode_handler_set_and_fallback() {
-        let handler = EnvShortcodeHandler;
+        let handler = EnvShortcodeHandler::new(Default::default());
         let meta = ConfigValue::new_map(vec![], dummy_source_info());
 
         // Set variable wins over fallback.
@@ -1971,6 +1993,72 @@ mod tests {
         match handler.resolve(&shortcode, &ctx, ResolutionContext::Inline) {
             ShortcodeResult::Error(err) => {
                 assert_eq!(err.key, "env:QUARTO_TEST_ENV_SC_UNSET");
+                assert!(format!("{:?}", err.diagnostic).contains("Q-16-5"));
+            }
+            _ => panic!("Expected Error"),
+        }
+    }
+
+    #[test]
+    fn test_env_shortcode_handler_project_env() {
+        let mut project_env = hashlink::LinkedHashMap::new();
+        project_env.insert(
+            "QUARTO_TEST_ENVFILE_ONLY".to_string(),
+            "from-file".to_string(),
+        );
+        project_env.insert(
+            "QUARTO_TEST_ENVFILE_SHADOWED".to_string(),
+            "from-file".to_string(),
+        );
+        let handler = EnvShortcodeHandler::new(project_env);
+        let meta = ConfigValue::new_map(vec![], dummy_source_info());
+
+        // Defined only in the project env map: map value used (even
+        // when a fallback arg is present — the map is a definition,
+        // not a fallback).
+        let shortcode = make_shortcode("env", vec!["QUARTO_TEST_ENVFILE_ONLY", "fallback"]);
+        let ctx = ShortcodeContext {
+            metadata: &meta,
+            source_info: &shortcode.source_info,
+        };
+        match handler.resolve(&shortcode, &ctx, ResolutionContext::Inline) {
+            ShortcodeResult::Inlines(inlines) => {
+                let Inline::Str(s) = &inlines[0] else {
+                    panic!("expected Str");
+                };
+                assert_eq!(s.text, "from-file");
+            }
+            other => panic!("Expected Inlines, got {:?}", std::mem::discriminant(&other)),
+        }
+
+        // Defined in both the real env and the map: the real
+        // environment wins (q2 never lets file values shadow it).
+        // SAFETY: test-local variable name; nextest runs each test in
+        // its own process, so no cross-test env races.
+        unsafe { std::env::set_var("QUARTO_TEST_ENVFILE_SHADOWED", "from-real-env") };
+        let shortcode = make_shortcode("env", vec!["QUARTO_TEST_ENVFILE_SHADOWED"]);
+        let ctx = ShortcodeContext {
+            metadata: &meta,
+            source_info: &shortcode.source_info,
+        };
+        match handler.resolve(&shortcode, &ctx, ResolutionContext::Inline) {
+            ShortcodeResult::Inlines(inlines) => {
+                let Inline::Str(s) = &inlines[0] else {
+                    panic!("expected Str");
+                };
+                assert_eq!(s.text, "from-real-env");
+            }
+            _ => panic!("Expected Inlines"),
+        }
+
+        // Absent everywhere: still the Q-16-5 error.
+        let shortcode = make_shortcode("env", vec!["QUARTO_TEST_ENVFILE_ABSENT"]);
+        let ctx = ShortcodeContext {
+            metadata: &meta,
+            source_info: &shortcode.source_info,
+        };
+        match handler.resolve(&shortcode, &ctx, ResolutionContext::Inline) {
+            ShortcodeResult::Error(err) => {
                 assert!(format!("{:?}", err.diagnostic).contains("Q-16-5"));
             }
             _ => panic!("Expected Error"),
@@ -2561,6 +2649,7 @@ mod tests {
                 runtime,
                 "html".to_string(),
                 None,
+                Default::default(),
             );
 
             let mut ast = Pandoc {
@@ -2610,6 +2699,7 @@ mod tests {
                 runtime,
                 "html".to_string(),
                 None,
+                Default::default(),
             );
 
             let mut ast = Pandoc {
@@ -2657,6 +2747,7 @@ mod tests {
                 runtime,
                 "html".to_string(),
                 None,
+                Default::default(),
             );
 
             let meta = ConfigValue::new_map(
@@ -2704,6 +2795,7 @@ mod tests {
                 runtime,
                 "html".to_string(),
                 None,
+                Default::default(),
             );
 
             let mut ast = Pandoc {
@@ -2757,6 +2849,7 @@ mod tests {
                 runtime,
                 "html".to_string(),
                 None,
+                Default::default(),
             );
 
             // Shortcode alone in Para → block context
@@ -2802,6 +2895,7 @@ mod tests {
                 runtime,
                 "html".to_string(),
                 None,
+                Default::default(),
             );
 
             let mut ast = Pandoc {
@@ -2857,6 +2951,7 @@ mod tests {
                 runtime,
                 "html".to_string(),
                 None,
+                Default::default(),
             );
 
             let tok = token_si();

--- a/crates/quarto-core/tests/integration/jupyter_integration.rs
+++ b/crates/quarto-core/tests/integration/jupyter_integration.rs
@@ -72,7 +72,7 @@ async fn test_kernel_execute_print() {
 
     // Start a kernel session
     let key = daemon
-        .get_or_start_session("python3", &working_dir)
+        .get_or_start_session("python3", &working_dir, &[])
         .await
         .expect("Failed to start kernel");
 
@@ -123,7 +123,7 @@ async fn test_kernel_execute_expression() {
     let working_dir = std::env::current_dir().unwrap();
 
     let key = daemon
-        .get_or_start_session("python3", &working_dir)
+        .get_or_start_session("python3", &working_dir, &[])
         .await
         .expect("Failed to start kernel");
 
@@ -166,7 +166,7 @@ async fn test_kernel_execute_error() {
     let working_dir = std::env::current_dir().unwrap();
 
     let key = daemon
-        .get_or_start_session("python3", &working_dir)
+        .get_or_start_session("python3", &working_dir, &[])
         .await
         .expect("Failed to start kernel");
 
@@ -239,7 +239,7 @@ async fn test_kernel_execute_matplotlib() {
     let working_dir = std::env::current_dir().unwrap();
 
     let key = daemon
-        .get_or_start_session("python3", &working_dir)
+        .get_or_start_session("python3", &working_dir, &[])
         .await
         .expect("Failed to start kernel");
 

--- a/crates/quarto-preview/src/lib.rs
+++ b/crates/quarto-preview/src/lib.rs
@@ -331,6 +331,8 @@ fn run_boot_pre_render_scripts(project_root: &std::path::Path) {
                 .map_or_else(|_| f.input.clone(), |r| r.to_path_buf())
         })
         .collect();
+    let script_env =
+        quarto_core::project::environment::subprocess_env_for_project(&runtime, &project);
     let ctx = render_scripts::RenderScriptsContext {
         project_dir: &project.dir,
         output_dir: &project.output_dir,
@@ -339,6 +341,7 @@ fn run_boot_pre_render_scripts(project_root: &std::path::Path) {
         render_all: true,
         quiet: false,
         file_count: input_files.len(),
+        project_env: &script_env,
     };
     if let Err(parse_error) = render_scripts::run_render_scripts(
         render_scripts::ScriptPhase::PreRender,

--- a/crates/quarto/src/commands/publish.rs
+++ b/crates/quarto/src/commands/publish.rs
@@ -222,6 +222,10 @@ impl PublishRenderer for ProjectPublishRenderer {
             if !project.config.pre_render_scripts.is_empty() {
                 let input_files =
                     publish_relative_paths(project.files.iter().map(|f| &f.input), &project.dir);
+                let script_env = quarto_core::project::environment::subprocess_env_for_project(
+                    runtime.as_ref(),
+                    &project,
+                );
                 let ctx = render_scripts::RenderScriptsContext {
                     project_dir: &project.dir,
                     output_dir: &project.output_dir,
@@ -230,6 +234,7 @@ impl PublishRenderer for ProjectPublishRenderer {
                     render_all: true,
                     quiet: false,
                     file_count: input_files.len(),
+                    project_env: &script_env,
                 };
                 render_scripts::run_render_scripts(
                     render_scripts::ScriptPhase::PreRender,
@@ -274,6 +279,10 @@ impl PublishRenderer for ProjectPublishRenderer {
                     summary.outputs.iter().map(|o| &o.output_path),
                     &project.dir,
                 );
+                let script_env = quarto_core::project::environment::subprocess_env_for_project(
+                    runtime.as_ref(),
+                    &project,
+                );
                 let ctx = render_scripts::RenderScriptsContext {
                     project_dir: &project.dir,
                     output_dir: &project.output_dir,
@@ -282,6 +291,7 @@ impl PublishRenderer for ProjectPublishRenderer {
                     render_all: true,
                     quiet: false,
                     file_count: summary.outputs.len(),
+                    project_env: &script_env,
                 };
                 render_scripts::run_render_scripts(
                     render_scripts::ScriptPhase::PostRender,

--- a/crates/quarto/src/commands/render.rs
+++ b/crates/quarto/src/commands/render.rs
@@ -850,6 +850,10 @@ fn execute_project(
             Some(t) => paths_relative_to(t.iter(), &project.dir),
             None => paths_relative_to(project.files.iter().map(|f| &f.input), &project.dir),
         };
+        let script_env = quarto_core::project::environment::subprocess_env_for_project(
+            runtime_arc.as_ref(),
+            &project,
+        );
         let ctx = render_scripts::RenderScriptsContext {
             project_dir: &project.dir,
             output_dir: &project.output_dir,
@@ -858,6 +862,7 @@ fn execute_project(
             render_all,
             quiet: args.quiet,
             file_count: input_files.len(),
+            project_env: &script_env,
         };
         if let Err(parse_error) = render_scripts::run_render_scripts(
             render_scripts::ScriptPhase::PreRender,
@@ -950,6 +955,10 @@ fn execute_project(
     if run_scripts && !project.config.post_render_scripts.is_empty() {
         let output_files =
             paths_relative_to(summary.outputs.iter().map(|o| &o.output_path), &project.dir);
+        let script_env = quarto_core::project::environment::subprocess_env_for_project(
+            runtime_arc.as_ref(),
+            &project,
+        );
         let ctx = render_scripts::RenderScriptsContext {
             project_dir: &project.dir,
             output_dir: &project.output_dir,
@@ -958,6 +967,7 @@ fn execute_project(
             render_all,
             quiet: args.quiet,
             file_count: total_files,
+            project_env: &script_env,
         };
         if let Err(parse_error) = render_scripts::run_render_scripts(
             render_scripts::ScriptPhase::PostRender,

--- a/crates/quarto/tests/smoke-all/metadata/environment-files/_environment
+++ b/crates/quarto/tests/smoke-all/metadata/environment-files/_environment
@@ -1,0 +1,2 @@
+Q2_TEST_ENVFILE_VAR=value-from-environment-file
+Q2_TEST_ENVFILE_LOCAL=base-value-should-lose

--- a/crates/quarto/tests/smoke-all/metadata/environment-files/_environment.local
+++ b/crates/quarto/tests/smoke-all/metadata/environment-files/_environment.local
@@ -1,0 +1,1 @@
+Q2_TEST_ENVFILE_LOCAL=local-override-wins

--- a/crates/quarto/tests/smoke-all/metadata/environment-files/_quarto.yml
+++ b/crates/quarto/tests/smoke-all/metadata/environment-files/_quarto.yml
@@ -1,0 +1,2 @@
+project:
+  type: default

--- a/crates/quarto/tests/smoke-all/metadata/environment-files/index.qmd
+++ b/crates/quarto/tests/smoke-all/metadata/environment-files/index.qmd
@@ -1,0 +1,14 @@
+---
+title: Environment files
+format: html
+_quarto:
+  tests:
+    html:
+      ensureFileRegexMatches:
+        - ["value-from-environment-file", "local-override-wins"]
+        - ["\\?env:", "base-value-should-lose"]
+---
+
+Base: {{< env Q2_TEST_ENVFILE_VAR >}}
+
+Local: {{< env Q2_TEST_ENVFILE_LOCAL >}}

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -30,6 +30,7 @@ website:
             - guides/projects/create.qmd
             - guides/projects/render-list.qmd
             - guides/projects/scripts.qmd
+            - guides/projects/environment.qmd
             - guides/publishing/index.qmd
     - id: Authoring
       collapse-level: 1

--- a/docs/guides/index.qmd
+++ b/docs/guides/index.qmd
@@ -11,3 +11,4 @@ title: Guides
 ## Projects
 
 - [Creating projects with `q2 create`](./projects/create.qmd)
+- [Project environment files](./projects/environment.qmd)

--- a/docs/guides/projects/environment.qmd
+++ b/docs/guides/projects/environment.qmd
@@ -1,0 +1,74 @@
+---
+title: "Project Environment Files"
+---
+
+Projects can define environment variables in files at the project
+root. Use them to keep version strings, dates, and other values out
+of your documents, and to configure the programs your project runs
+(code cells, pre/post render scripts).
+
+## The files
+
+| File | Purpose |
+|------|---------|
+| `_environment` | Variables shared by everyone; check it into version control. |
+| `_environment.local` | Per-machine overrides (tokens, local paths); add it to `.gitignore`. |
+| `_environment.required` | Names that must be defined for the project to render correctly. |
+
+Each file holds `KEY=value` lines:
+
+``` {.default filename="_environment"}
+# Comments and blank lines are fine
+PRODUCT_VERSION=2026.08.0
+COPYRIGHT_YEAR=2026
+GREETING="hello\nworld"        # double quotes expand \n, \t, …
+LITERAL='kept exactly as-is'   # single quotes are literal
+BANNER=v$PRODUCT_VERSION       # unquoted values expand $NAME
+FALLBACK=${UNDEFINED:-default} # with a default when NAME is unset
+```
+
+Values may span multiple lines inside quotes. An unquoted `$NAME`
+reference resolves against the same file first, then the real
+environment and the other environment files, then the `:-` default.
+
+## Precedence
+
+A variable defined in several places resolves in this order:
+
+1. the **real environment** — a variable exported in your shell (or
+   set by CI) always wins; environment files never override it;
+2. `_environment.local`;
+3. `_environment`.
+
+## Where the variables are visible
+
+- **The `env` shortcode.** `{{{< env PRODUCT_VERSION >}}}` renders
+  the value; the shortcode checks the real environment first, then
+  the project's environment files, then its optional fallback
+  argument (`{{{< env NAME fallback >}}}`).
+- **Executed code.** Code cells run by the Jupyter and knitr engines
+  see the variables (e.g. `Sys.getenv("PRODUCT_VERSION")` in R,
+  `os.environ` in Python).
+- **Pre and post render scripts.** Scripts receive the variables
+  alongside the `QUARTO_PROJECT_*` variables described in
+  [Pre and Post Render Scripts](scripts.qmd).
+
+Environment files are project-scoped: a single-file render outside
+any project (no `_quarto.yml`) does not load them.
+
+## Required variables
+
+List names in `_environment.required` to get a warning when a
+variable is defined neither in the environment nor in the project's
+environment files. The value part is a good place for an example:
+
+``` {.default filename="_environment.required"}
+CONNECT_API_KEY=your-api-key-here
+```
+
+## Changes require a fresh render
+
+Quarto 2 reads environment files when a render starts and never
+mutates the process environment. If you edit `_environment` while
+`quarto preview` is running, restart the preview to pick up the new
+values.


### PR DESCRIPTION
## Summary

Quarto 1 parity for project environment files: q2 now loads `_environment` and `_environment.local` from the project root with Q1 precedence (real process environment > `.local` > `_environment`), plus real validation of `_environment.required`. Fixes the Posit Connect docs porting blocker where every `{{< env CONNECT_VERSION >}}` rendered `?env:CONNECT_VERSION` site-wide.

**Design policy (differs from Q1 on purpose):** q2 never mutates the process environment. Q1 injects dotenv values with `Deno.env.set`, which races; Rust's edition-2024 `unsafe` on `set_var` is a restriction we model rather than work around. Values load into a project env map on `StageContext` and reach consumers as data:

- **`env` shortcode** — real env first, then the map, then the fallback argument (Q-16-5 hint updated).
- **Engine subprocesses** (knitr `Rscript`, jupyter kernels incl. the daemon) and **pre/post render scripts** (render, publish, preview boot) — pairs applied via `Command::env`, pre-filtered to keys the real environment does not define, so inherited values always win.
- **WASM / hub-client preview** — free via `StageContext` + VFS reads.

**Parser** (`quarto-core/src/project/environment.rs`): hand-rolled against Q1's actual dialect (`@std/dotenv` 0.225.x — `export` prefix, quoted multiline values, escapes, unquoted `$VAR`/`${VAR}`/`${VAR:-default}` expansion with same-file-first resolution). Rust dotenv crates were evaluated and rejected: `dotenvy` is line-oriented with no source positions and reads `std::env` inside `$VAR` substitution. Every entry carries quarto-source-map spans (FileId via `quarto_yaml::file_id_for_filename`), so `.required` warnings point at the requiring line. Deliberate divergences from `@std/dotenv` are documented in the module doc (diagnostics instead of `"undefined"` interpolation / infinite loops / silent skips).

**Scoped out:** `_environment-<profile>` awaits render-profile support (filed as bd-ev8mk1rp; the loader takes an always-empty profile list so it can slot in without rework). Preview re-render on env-file edits is intentionally unsupported — restart to pick up changes (documented).

**Docs:** new `guides/projects/environment.qmd` page.

## Test plan

- TDD: smoke-all fixture `metadata/environment-files` written first and observed failing at HEAD (3 regex mismatches + 2 Q-16-5 warnings); passes after.
- 48 unit tests: dialect cases (multiline quotes, escapes, expansion, cycles, CRLF/BOM/UTF-8), layer precedence, `.required` span assertions, subprocess filtering, plus a real-spawn render-scripts test (unix).
- No snapshot files changed. `cargo nextest run --workspace`: 11263 passed. Full `cargo xtask verify` (WASM leg included) green.
- E2E with real engines: jupyter (`os.environ`) and knitr (`Sys.getenv`) cells print the `_environment` value; exporting the variable in the shell makes both print the exported value instead.

Plan: `claude-notes/plans/2026-08-09-environment-files-loading.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)