### PR TITLE
Decode named HTML entity references in prose (bd-named-entities-w6xbfftj)

### DIFF
--- a/claude-notes/plans/2026-08-10-named-entity-references-dropped.md
+++ b/claude-notes/plans/2026-08-10-named-entity-references-dropped.md
@@ -3,7 +3,7 @@
 **Date:** 2026-08-10
 **Braid:** bd-named-entities-w6xbfftj (bug, P1, labels `pampa`, `parity`)
 **Checkout:** main @ `0cb8abce` (investigated in place; no worktree created)
-**Status:** Investigation — pending design alignment with user. **Do not start implementation until the user gives the go-ahead.**
+**Status:** Design settled 2026-08-10 (user answered all design questions; see below). Ready for implementation on go-ahead.
 
 ## Triage verdict
 
@@ -98,34 +98,33 @@ Skeleton only — actual phase contents wait on the design discussion.
 - **Phase 4 — Bookkeeping.** Close strand; grammar-regex cleanup tracked in
   bd-v8qc9zyc (discovered-from).
 
-## Open design questions for the user
+## Design decisions (settled with user, 2026-08-10)
 
-1. **Table sharing mechanism.** Expose `HTML_ENTITIES_JSON` from
-   `tree-sitter-qmd`'s Rust bindings via `include_str!` (recommended — same
-   pattern as `NODE_TYPES`, single source of truth, no file copying), vs.
-   copying the JSON into pampa, vs. pulling a third-party entities crate?
-2. **Parse strategy.** Lazy `OnceLock<HashMap>` + serde_json over the 146 KB
-   JSON at first use (recommended — simple, one-time cost), vs. build-time
-   codegen (phf / generated match)? The WASM path also runs this, so parse cost
-   is paid in the browser once per module instance.
-3. **Lookup-miss behavior.** Emit the original text verbatim (recommended —
-   mirrors the numeric handler's unparseable fallback and covers the grammar's
-   bogus truncated alternatives), or emit nothing / warn?
-4. **Grammar regex cleanup scope.** Fix `html_entity_regex()` (filter to
-   semicolon-terminated keys) in this strand — requires `tree-sitter generate;
-   tree-sitter build` and grammar re-testing — or keep it in the separate
-   discovered strand and land the converter fix alone first (recommended)?
-5. **Smart typography interplay.** Decoded entities bypass
-   `apply_smart_typography` (so `&quot;` stays a straight quote), matching the
-   numeric-reference handler and Pandoc. Confirm that's the wanted behavior.
+1. **Table sharing mechanism:** expose `HTML_ENTITIES_JSON` from
+   `tree-sitter-qmd`'s Rust bindings via `include_str!` (same pattern as
+   `NODE_TYPES`; single source of truth).
+2. **Parse strategy:** lazy `OnceLock<HashMap>` + serde_json at first use.
+3. **Lookup-miss behavior:** emit the original text verbatim, **no warning**.
+   Rationale: the `entity_reference` regex is generated from the same table
+   the converter looks up in, so every node the grammar produces is a known
+   name — the only reachable misses are the ~106 bogus truncated alternatives
+   from the bd-v8qc9zyc regex bug (`&AM;`, `&AEli;`), which essentially never
+   occur in real prose and become unreachable once that strand lands.
+   Genuinely unknown references (`&foo;`) never match the regex and are
+   already literal text, matching CommonMark/Pandoc. (If we ever want to
+   catch typo'd entity names, that's a separate prose lint, not this arm.)
+4. **Grammar regex cleanup:** stays in the separate strand bd-v8qc9zyc;
+   this strand lands the converter fix alone.
+5. **Smart typography:** decoded entities bypass `apply_smart_typography`
+   (`&quot;` stays a straight quote), matching the numeric handler and Pandoc.
 
-## Risks / tradeoffs (draft)
+## Risks / tradeoffs
 
-- **qmd-writer re-escaping.** Decoding `&gt;` to a literal `>` in a `Str` means
-  the qmd writer emits `>`; at line start that would re-parse as a blockquote.
-  Numeric references have exactly this exposure today, so it's a pre-existing
-  writer-escaping question, not new to this fix — but the roundtrip test should
-  pin whichever behavior we get.
+- **qmd-writer re-escaping — verified NOT an issue.** The qmd writer already
+  backslash-escapes markdown-significant characters in `Str` content:
+  `&#62; not a blockquote` round-trips as `\> not a blockquote`, and mid-line
+  `A &#62; B` as `A \> B` (verified at `0cb8abce` via
+  `pampa -t qmd`). The roundtrip test pins this behavior for named entities.
 - **Snapshot churn.** Any existing snapshots containing dropped entities will
   change (correctly). Per CLAUDE.md, count and summarize them in the commit.
 - **WASM leg.** pampa changes flow into `wasm-quarto-hub-client`; full

--- a/claude-notes/plans/2026-08-10-named-entity-references-dropped.md
+++ b/claude-notes/plans/2026-08-10-named-entity-references-dropped.md
@@ -1,0 +1,132 @@
+# Named HTML entity references silently dropped in prose (bd-named-entities-w6xbfftj)
+
+**Date:** 2026-08-10
+**Braid:** bd-named-entities-w6xbfftj (bug, P1, labels `pampa`, `parity`)
+**Checkout:** main @ `0cb8abce` (investigated in place; no worktree created)
+**Status:** Investigation — pending design alignment with user. **Do not start implementation until the user gives the go-ahead.**
+
+## Triage verdict
+
+**Ready to design.** The strand's root-cause analysis is accurate at HEAD, the fix
+surface is small and well-localized (one new match arm in pampa + one exported
+constant in tree-sitter-qmd's Rust bindings), and the open questions are about
+mechanism choices, not missing context.
+
+## Issue context
+
+Filed 2026-08-10 by Carlos (same day as this investigation — no staleness risk).
+Named entity references in prose (`&gt;`, `&lt;`, `&amp;`, `&quot;`, `&nbsp;`,
+`&copy;`, …) are dropped from output with no diagnostic; numeric references
+(`&#62;`, `&#x40;`) work. Q1/Pandoc/CommonMark resolve named references to their
+characters. Real-world hit: Posit Connect docs use named entities in 13 files —
+UI breadcrumbs like `**APIs & Services** &gt; **Credentials**` lose their `>`
+separators. Origin strand in the connect-docs porting skein:
+br-named-entities-zu8jp8pw.
+
+## Dependency graph
+
+**Empty** — no edges in this skein (`braid dep tree` / `dep list` show only the
+strand itself). The filing context lives in the connect-docs skein
+(br-named-entities-zu8jp8pw), quoted in the description. No incoming `blocks`
+pressure; the P1 comes from the docs-porting impact.
+
+## What the code looks like today
+
+All paths in the description check out at `0cb8abce`:
+
+- **Grammar side (produces the node):**
+  `crates/tree-sitter-qmd/common/common.js:41` defines
+  `entity_reference: $ => html_entity_regex()`; the regex builder
+  (`common.js:173-181`) is generated from `common/html_entities.json` — the
+  WHATWG entities table (2,231 keys, `name → {codepoints, characters}`,
+  includes multi-codepoint entities like `&NotEqualTilde;` → `"≂̸"`).
+  `entity_reference` appears in prose, table cells, link labels/destinations, etc.
+- **Converter side (drops the node):**
+  `crates/pampa/src/pandoc/treesitter.rs:845` has a match arm only for
+  `"numeric_character_reference"` (→ `process_numeric_character_reference` in
+  `treesitter_utils/numeric_character_reference.rs`). `"entity_reference"` has
+  **no arm** and falls to the default at `treesitter.rs:1695`, which writes an
+  "Unhandled node kind" warning to the *verbose* buffer only and returns
+  `IntermediateUnknown` — which is dropped. Hence "silent."
+- **Sharing precedent:** `crates/tree-sitter-qmd/bindings/rust/lib.rs` already
+  exports `include_str!` constants (`HIGHLIGHT_QUERY`, `INJECTION_QUERY`,
+  `NODE_TYPES`), and `pampa` already depends on `tree-sitter-qmd`. Exposing
+  `HTML_ENTITIES_JSON` the same way gives both sides one source of truth.
+
+Repro captured at
+`claude-notes/plans/named-entity-references-dropped-investigation/repro.qmd`
+(copied from the strand's external repro dir; Q1-verified expected output in the
+strand description). Reproduction at HEAD: see `investigation-notes.md` in the
+same directory.
+
+### Discovered while investigating: grammar regex mangles legacy entity names
+
+`html_entity_regex()` builds alternatives with
+`name.substring(1, name.length - 1)` — correct for the 2,125 semicolon-
+terminated keys (strips `&` and `;`), but the WHATWG table also carries 106
+legacy no-semicolon keys (`&AMP`, `&AElig`, …) whose **last letter** gets
+stripped instead, producing bogus alternatives (`AM`, `AEli`, …). Net effect:
+`&AM;` parses as `entity_reference` (then would miss any name→char lookup),
+while the actual legacy forms (`&AMP` bare) don't match — the latter is
+*correct* per CommonMark (only semicolon-terminated entities are recognized in
+markdown), the former is a real but minor grammar bug. Filed as
+**bd-v8qc9zyc** (discovered-from this strand); the converter must handle
+lookup misses gracefully regardless.
+
+## Proposed phases (draft)
+
+Skeleton only — actual phase contents wait on the design discussion.
+
+- **Phase 0 — Test plan (TDD, failing tests first).**
+  - pampa unit/snapshot tests: `&gt;` → `Str ">"`; `&nbsp;` → U+00A0 (not
+    a plain space); `&copy;` → `©`; multi-codepoint `&NotEqualTilde;` → `≂̸`;
+    lookup-miss fallback (e.g. `&AM;`) → literal text; entity inside emphasis /
+    table cell; numeric refs unchanged.
+  - qmd→json→qmd roundtrip test per pampa CLAUDE.md.
+  - End-to-end: `q2 render` of the repro fixture, inspect HTML output.
+- **Phase 1 — Expose the table.** `pub const HTML_ENTITIES_JSON: &str =
+  include_str!("../../common/html_entities.json")` in
+  `tree-sitter-qmd/bindings/rust/lib.rs` (mirrors `NODE_TYPES`).
+- **Phase 2 — Converter arm.** New `treesitter_utils/entity_reference.rs`
+  mirroring `process_numeric_character_reference`; lazy `OnceLock` map parsed
+  from the shared JSON (name → `characters` string, which already handles
+  multi-codepoint); match arm in `treesitter.rs`; miss → emit original text.
+- **Phase 3 — End-to-end verification.** Repro render + output inspection,
+  `cargo nextest run --workspace`, `cargo xtask verify --skip-hub-build`
+  (grammar untouched ⇒ no tree-sitter regen; WASM leg affected via pampa ⇒
+  consider full verify before push).
+- **Phase 4 — Bookkeeping.** Close strand; grammar-regex cleanup tracked in
+  bd-v8qc9zyc (discovered-from).
+
+## Open design questions for the user
+
+1. **Table sharing mechanism.** Expose `HTML_ENTITIES_JSON` from
+   `tree-sitter-qmd`'s Rust bindings via `include_str!` (recommended — same
+   pattern as `NODE_TYPES`, single source of truth, no file copying), vs.
+   copying the JSON into pampa, vs. pulling a third-party entities crate?
+2. **Parse strategy.** Lazy `OnceLock<HashMap>` + serde_json over the 146 KB
+   JSON at first use (recommended — simple, one-time cost), vs. build-time
+   codegen (phf / generated match)? The WASM path also runs this, so parse cost
+   is paid in the browser once per module instance.
+3. **Lookup-miss behavior.** Emit the original text verbatim (recommended —
+   mirrors the numeric handler's unparseable fallback and covers the grammar's
+   bogus truncated alternatives), or emit nothing / warn?
+4. **Grammar regex cleanup scope.** Fix `html_entity_regex()` (filter to
+   semicolon-terminated keys) in this strand — requires `tree-sitter generate;
+   tree-sitter build` and grammar re-testing — or keep it in the separate
+   discovered strand and land the converter fix alone first (recommended)?
+5. **Smart typography interplay.** Decoded entities bypass
+   `apply_smart_typography` (so `&quot;` stays a straight quote), matching the
+   numeric-reference handler and Pandoc. Confirm that's the wanted behavior.
+
+## Risks / tradeoffs (draft)
+
+- **qmd-writer re-escaping.** Decoding `&gt;` to a literal `>` in a `Str` means
+  the qmd writer emits `>`; at line start that would re-parse as a blockquote.
+  Numeric references have exactly this exposure today, so it's a pre-existing
+  writer-escaping question, not new to this fix — but the roundtrip test should
+  pin whichever behavior we get.
+- **Snapshot churn.** Any existing snapshots containing dropped entities will
+  change (correctly). Per CLAUDE.md, count and summarize them in the commit.
+- **WASM leg.** pampa changes flow into `wasm-quarto-hub-client`; full
+  `cargo xtask verify` (not just `--skip-hub-build`) before push.

--- a/claude-notes/plans/2026-08-10-named-entity-references-dropped.md
+++ b/claude-notes/plans/2026-08-10-named-entity-references-dropped.md
@@ -3,7 +3,7 @@
 **Date:** 2026-08-10
 **Braid:** bd-named-entities-w6xbfftj (bug, P1, labels `pampa`, `parity`)
 **Checkout:** main @ `0cb8abce` (investigated in place; no worktree created)
-**Status:** Design settled 2026-08-10 (user answered all design questions; see below). Ready for implementation on go-ahead.
+**Status:** Implemented 2026-08-10; all phases complete, full verify green. Discovered follow-ups: bd-v8qc9zyc (grammar regex), bd-96fswwce (combining-mark parse failure).
 
 ## Triage verdict
 
@@ -73,30 +73,88 @@ markdown), the former is a real but minor grammar bug. Filed as
 **bd-v8qc9zyc** (discovered-from this strand); the converter must handle
 lookup misses gracefully regardless.
 
-## Proposed phases (draft)
+## Work items
 
-Skeleton only — actual phase contents wait on the design discussion.
+### Phase 0 — Tests first (TDD; run and verify each fails before implementing)
 
-- **Phase 0 — Test plan (TDD, failing tests first).**
-  - pampa unit/snapshot tests: `&gt;` → `Str ">"`; `&nbsp;` → U+00A0 (not
-    a plain space); `&copy;` → `©`; multi-codepoint `&NotEqualTilde;` → `≂̸`;
-    lookup-miss fallback (e.g. `&AM;`) → literal text; entity inside emphasis /
-    table cell; numeric refs unchanged.
-  - qmd→json→qmd roundtrip test per pampa CLAUDE.md.
-  - End-to-end: `q2 render` of the repro fixture, inspect HTML output.
-- **Phase 1 — Expose the table.** `pub const HTML_ENTITIES_JSON: &str =
-  include_str!("../../common/html_entities.json")` in
-  `tree-sitter-qmd/bindings/rust/lib.rs` (mirrors `NODE_TYPES`).
-- **Phase 2 — Converter arm.** New `treesitter_utils/entity_reference.rs`
-  mirroring `process_numeric_character_reference`; lazy `OnceLock` map parsed
-  from the shared JSON (name → `characters` string, which already handles
-  multi-codepoint); match arm in `treesitter.rs`; miss → emit original text.
-- **Phase 3 — End-to-end verification.** Repro render + output inspection,
-  `cargo nextest run --workspace`, `cargo xtask verify --skip-hub-build`
-  (grammar untouched ⇒ no tree-sitter regen; WASM leg affected via pampa ⇒
-  consider full verify before push).
-- **Phase 4 — Bookkeeping.** Close strand; grammar-regex cleanup tracked in
-  bd-v8qc9zyc (discovered-from).
+- [x] Coverage tests in
+      `crates/pampa/tests/integration/test_treesitter_coverage.rs` (new
+      "Entity reference tests" section): `&gt;` → `Str ">"`; `&nbsp;` →
+      `Str "\u{00A0}"` (not a plain space); `&copy;` → `©`; multi-codepoint
+      `&NotEqualTilde;` → `"≂̸"`; lookup-miss `&AM;` → literal `"&AM;"`;
+      `&quot;` → straight `"` (no smart typography); entity inside emphasis.
+- [x] Native snapshot fixture
+      `crates/pampa/tests/snapshots/native/entity-references.qmd`
+      (insta snapshot lands in `crates/pampa/snapshots/native/`).
+- [x] Roundtrip fixture
+      `crates/pampa/tests/roundtrip_tests/qmd-json-qmd/named_entities.qmd`
+      (driver is a fixpoint check — JSON-after-reparse equality, so `&gt;`
+      re-emitting as `\>` is fine).
+- [x] Smoke-all fixture under `crates/quarto/tests/smoke-all/` asserting the
+      rendered HTML contains the decoded characters (end-to-end through the
+      real render path).
+- [x] Run the new tests; confirm each fails for the expected reason
+      (entities dropped). Verified 2026-08-10: all 7 coverage tests fail
+      (e.g. got `"A  B"`, want `"A > B"`; `&AM;` confirmed parsing as
+      entity_reference and dropped); native snapshot `.snap.new` showed the
+      dropped-entity AST (deleted, to be accepted post-fix); smoke-all fails
+      all four named-entity patterns and trips the illegal pattern
+      `Named: A  B`; roundtrip consistency also fails pre-fix (doubled
+      Spaces are not reparse-stable). Tests committed together with the fix
+      so main never carries a red suite.
+
+### Phase 1 — Expose the table
+
+- [x] `pub const HTML_ENTITIES_JSON: &str =
+      include_str!("../../common/html_entities.json")` in
+      `crates/tree-sitter-qmd/bindings/rust/lib.rs` (mirrors `NODE_TYPES`).
+
+### Phase 2 — Converter arm
+
+- [x] New `crates/pampa/src/pandoc/treesitter_utils/entity_reference.rs`:
+      lazy `OnceLock<HashMap<String, String>>` parsed from
+      `HTML_ENTITIES_JSON` (key → `characters`); `process_entity_reference`
+      mirroring the numeric handler; miss → emit original text verbatim,
+      no warning.
+- [x] Match arm `"entity_reference"` in
+      `crates/pampa/src/pandoc/treesitter.rs`.
+- [x] New tests pass; snapshot accepted after review
+      (`crates/pampa/snapshots/native/entity-references.snap`, new file —
+      shows decoded entities, straight quotes, `&AM;` verbatim).
+- [x] **Discovered: qmd writer must escape `"`.** The roundtrip fixture
+      exposed that a straight `"` in a `Str` (reachable via `&quot;` /
+      `&#34;` / programmatic ASTs) was written bare and re-read as
+      `Quoted DoubleQuote`. Fixed in `escape_markdown`
+      (`crates/pampa/src/writers/qmd.rs`): `"` → `\"`, which re-reads as
+      the literal straight quote. Fixture extended with a numeric `&#34;`
+      line to pin the pre-existing exposure.
+- [x] **Discovered: parser rejects decomposed Unicode (combining marks) in
+      prose** — filed as **bd-96fswwce**. `x ≂̸ y` (U+2242 U+0338 — exactly
+      what `&NotEqualTilde;` decodes to) and `e` + U+0301 both fail to
+      parse, while precomposed `é` is fine. Entity decoding to the AST works
+      (unit test + native snapshot cover it), but written-out qmd containing
+      the combining sequence is un-reparseable, so the roundtrip fixture
+      deliberately omits multi-codepoint entities; bd-96fswwce's fix should
+      re-add `&NotEqualTilde;` there.
+
+### Phase 3 — Verification
+
+- [x] `cargo nextest run --workspace`: 11231 tests run, 11231 passed
+      (2 leaky), 197 skipped — no regressions.
+- [x] End-to-end: `cargo run --bin q2 -- render
+      claude-notes/plans/named-entity-references-dropped-investigation/repro.qmd`,
+      output inspected. Rendered HTML now reads
+      `Named: A &gt; B &lt; C &amp; D &quot;E&quot; F<NBSP>G © H.` — with
+      the NBSP verified byte-level (`46 c2 a0 47`) and © present; the
+      numeric-reference line unchanged. (Render artifacts deleted after
+      inspection; the fixture stays.)
+- [x] Full `cargo xtask verify` (pampa flows into the WASM leg): all steps passed.
+
+### Phase 4 — Bookkeeping
+
+- [x] Update this plan; commit (document snapshot changes per CLAUDE.md).
+- [x] Close bd-named-entities-w6xbfftj (grammar-regex cleanup stays in
+      bd-v8qc9zyc).
 
 ## Design decisions (settled with user, 2026-08-10)
 

--- a/claude-notes/plans/named-entity-references-dropped-investigation/investigation-notes.md
+++ b/claude-notes/plans/named-entity-references-dropped-investigation/investigation-notes.md
@@ -1,0 +1,62 @@
+# Investigation notes — bd-named-entities-w6xbfftj
+
+Investigated 2026-08-10 at main @ `0cb8abce`. Pre-flight
+`cargo xtask verify --skip-hub-build` passed before any changes.
+
+## Reproduction at HEAD
+
+```
+$ printf 'A &gt; B &nbsp; C &#62; D\n' | cargo run -q -p pampa --bin pampa -- -t native
+[ Para [Str "A", Space, Space, Str "B", Space, Space, Str "C", Space, Str ">", Space, Str "D"] ]
+```
+
+- `&gt;` and `&nbsp;` are gone entirely (note the doubled `Space` where each
+  entity used to sit).
+- Numeric `&#62;` correctly becomes `Str ">"`.
+
+`repro.qmd` in this directory is copied from the strand's external repro
+(`~/repos/github/cscheid/q2-connect-docs/llms-info/repros/named-entities-dropped/`),
+which carries the Q1-verified expected output.
+
+## Where the node dies
+
+The grammar produces `entity_reference` (regex over
+`crates/tree-sitter-qmd/common/html_entities.json`, built in
+`common/common.js` `html_entity_regex()`); the pampa inline converter match in
+`crates/pampa/src/pandoc/treesitter.rs` has an arm for
+`numeric_character_reference` (line ~845) but none for `entity_reference`, so
+it hits the default arm (line ~1695), which only writes
+`[TOP-LEVEL MISSING NODE] Warning: Unhandled node kind: entity_reference`
+to the verbose buffer and returns `IntermediateUnknown` — dropped downstream.
+That's why the loss is silent in normal renders.
+
+## Entity table facts (for the fix)
+
+- `html_entities.json` is the WHATWG table: 2,231 keys of the form `"&name;"`
+  (and 106 legacy `"&name"` without semicolon), each with `codepoints` and a
+  pre-composed `characters` string — multi-codepoint entities
+  (`"&NotEqualTilde;"` → `"≂̸"`, U+2242 U+0338) need no special handling if we
+  emit `characters` directly.
+- Node text is the full `&name;`, which is exactly the JSON key — direct map
+  lookup, no trimming needed (for the semicolon-terminated forms the grammar
+  matches).
+- `tree-sitter-qmd/bindings/rust/lib.rs` already exports `include_str!`
+  constants (`NODE_TYPES` etc.) — precedent for exporting the JSON to pampa.
+
+## Discovered grammar bug (filed separately)
+
+`html_entity_regex()` maps every key through
+`name.substring(1, name.length - 1)`. For the 106 legacy no-semicolon keys
+this strips the final *letter* instead of a `;`: `&AMP` contributes the
+alternative `AM`, `&AElig` contributes `AEli`, etc. Consequences:
+
+- Bogus references like `&AM;` / `&AEli;` parse as `entity_reference`
+  (converter must fall back to literal text on lookup miss).
+- Bare legacy forms (`&AMP` without `;`) do **not** match — which is actually
+  correct for markdown (CommonMark only recognizes semicolon-terminated
+  entities), so the fix is to *filter* those keys out of the regex, not to
+  support them.
+
+Fix belongs in the grammar (filter `Object.keys(...).filter(n => n.endsWith(';'))`),
+requires `tree-sitter generate; tree-sitter build` + grammar tests — tracked as
+its own strand linked `discovered-from` this one.

--- a/claude-notes/plans/named-entity-references-dropped-investigation/repro.qmd
+++ b/claude-notes/plans/named-entity-references-dropped-investigation/repro.qmd
@@ -1,0 +1,7 @@
+---
+title: Named entities
+---
+
+Named: A &gt; B &lt; C &amp; D &quot;E&quot; F&nbsp;G &copy; H.
+
+Numeric: A &#62; B &#60; C &#38; D.

--- a/crates/pampa/snapshots/native/entity-references.snap
+++ b/crates/pampa/snapshots/native/entity-references.snap
@@ -1,0 +1,6 @@
+---
+source: crates/pampa/tests/integration/test.rs
+assertion_line: 550
+expression: output
+---
+[ Para [Str "Named:", Space, Str "A", Space, Str ">", Space, Str "B", Space, Str "<", Space, Str "C", Space, Str "&", Space, Str "D", Space, Str "\"E\"", Space, Str "F G", Space, Str "©", Space, Str "H."], Para [Str "Multi-codepoint:", Space, Str "x", Space, Str "≂̸", Space, Str "y."], Para [Str "Unknown:", Space, Str "A", Space, Str "&AM;", Space, Str "B", Space, Str "stays", Space, Str "literal."], Para [Str "Numeric:", Space, Str "A", Space, Str ">", Space, Str "B", Space, Str "<", Space, Str "C", Space, Str "&", Space, Str "D."] ]

--- a/crates/pampa/src/pandoc/treesitter.rs
+++ b/crates/pampa/src/pandoc/treesitter.rs
@@ -15,6 +15,7 @@ use crate::pandoc::treesitter_utils::document::process_document;
 use crate::pandoc::treesitter_utils::editorial_marks::{
     process_delete, process_editcomment, process_highlight, process_insert,
 };
+use crate::pandoc::treesitter_utils::entity_reference::process_entity_reference;
 use crate::pandoc::treesitter_utils::fenced_code_block::process_fenced_code_block;
 use crate::pandoc::treesitter_utils::fenced_div_block::process_fenced_div_block;
 use crate::pandoc::treesitter_utils::info_string::process_info_string;
@@ -845,6 +846,7 @@ fn native_visitor<T: Write>(
         "numeric_character_reference" => {
             process_numeric_character_reference(node, input_bytes, context)
         }
+        "entity_reference" => process_entity_reference(node, input_bytes, context),
         "autolink" => process_uri_autolink(node, input_bytes, context),
         "pandoc_space" => PandocNativeIntermediate::IntermediateInline(Inline::Space(Space {
             source_info: node_source_info_with_context(node, context),

--- a/crates/pampa/src/pandoc/treesitter_utils/entity_reference.rs
+++ b/crates/pampa/src/pandoc/treesitter_utils/entity_reference.rs
@@ -1,0 +1,57 @@
+/*
+ * entity_reference.rs
+ * Copyright (c) 2026 Posit, PBC
+ */
+
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
+use crate::pandoc::ast_context::ASTContext;
+use crate::pandoc::inline::{Inline, Str};
+use crate::pandoc::location::node_source_info_with_context;
+use crate::pandoc::treesitter_utils::pandocnativeintermediate::PandocNativeIntermediate;
+
+/// Named-entity lookup table (`"&gt;"` → `">"`), parsed lazily from the same
+/// WHATWG JSON the grammar's `entity_reference` regex is generated from
+/// (`tree_sitter_qmd::HTML_ENTITIES_JSON`), so both sides share one source of
+/// truth. The `characters` field is the pre-composed replacement string, which
+/// covers multi-codepoint entities (`&NotEqualTilde;` → U+2242 U+0338).
+fn entity_table() -> &'static HashMap<String, String> {
+    static TABLE: OnceLock<HashMap<String, String>> = OnceLock::new();
+    TABLE.get_or_init(|| {
+        #[derive(serde::Deserialize)]
+        struct Entry {
+            characters: String,
+        }
+        let entries: HashMap<String, Entry> =
+            serde_json::from_str(tree_sitter_qmd::HTML_ENTITIES_JSON)
+                .expect("tree-sitter-qmd's html_entities.json must be valid JSON");
+        entries
+            .into_iter()
+            .map(|(name, entry)| (name, entry.characters))
+            .collect()
+    })
+}
+
+/// Process named entity references to their character values:
+/// `&gt;` => `>`, `&nbsp;` => U+00A0, `&copy;` => `©`, etc.
+///
+/// A name missing from the table passes through verbatim. The regex the
+/// grammar matched with is generated from the same table, so misses are only
+/// reachable through its mangled legacy-name alternatives (bd-v8qc9zyc) —
+/// never from well-formed input — hence no diagnostic.
+pub fn process_entity_reference(
+    node: &tree_sitter::Node,
+    input_bytes: &[u8],
+    context: &ASTContext,
+) -> PandocNativeIntermediate {
+    let text = node.utf8_text(input_bytes).unwrap();
+    let result_text = match entity_table().get(text) {
+        Some(characters) => characters.clone(),
+        None => text.to_string(),
+    };
+    PandocNativeIntermediate::IntermediateInline(Inline::Str(Str {
+        text: result_text,
+        source_info: node_source_info_with_context(node, context),
+    }))
+}

--- a/crates/pampa/src/pandoc/treesitter_utils/mod.rs
+++ b/crates/pampa/src/pandoc/treesitter_utils/mod.rs
@@ -12,6 +12,7 @@ pub mod code_span_helpers;
 pub mod commonmark_attribute;
 pub mod document;
 pub mod editorial_marks;
+pub mod entity_reference;
 pub mod fenced_code_block;
 pub mod fenced_div_block;
 pub mod info_string;

--- a/crates/pampa/src/writers/qmd.rs
+++ b/crates/pampa/src/writers/qmd.rs
@@ -1512,6 +1512,11 @@ fn escape_markdown(text: &str, start_prev_is_alnum: bool) -> String {
             '{' => result.push_str("\\{"), // Attribute span open: bare { in
             '}' => result.push_str("\\}"), // a Str body is always a parse
             // error in qmd. Always escape.
+            '"' => result.push_str("\\\""), // A bare " in a Str body would be
+            // re-read as a smart quote (Quoted DoubleQuote); `\"` re-reads as
+            // the literal straight quote. Str bodies only contain " via
+            // character references (&quot;, &#34;) or programmatic ASTs —
+            // parsed quotation marks become Quoted nodes instead.
 
             // Smart typography → ASCII source spelling, emitted UNescaped so the
             // reader re-converts it back to the Unicode character.
@@ -1569,7 +1574,7 @@ fn escape_markdown(text: &str, start_prev_is_alnum: bool) -> String {
             }
 
             // Characters that don't need escaping in most contexts:
-            // , + ! ? = : ; / ( ) % & "
+            // , + ! ? = : ; / ( ) % &
             // These are only special in very specific contexts and escaping them
             // everywhere would make output unnecessarily verbose.
             _ => result.push(ch),

--- a/crates/pampa/tests/integration/test_treesitter_coverage.rs
+++ b/crates/pampa/tests/integration/test_treesitter_coverage.rs
@@ -666,3 +666,84 @@ fn test_list_item_multiple_blocks_with_paragraph() {
         );
     }
 }
+
+// ============================================================================
+// Named entity reference tests (bd-named-entities-w6xbfftj)
+// ============================================================================
+
+/// Flatten a paragraph's inline sequence to plain text (Str + Space only;
+/// any other inline renders as nothing, which the assertions would catch).
+fn para_text(pandoc: &pampa::pandoc::Pandoc, index: usize) -> String {
+    let Block::Paragraph(para) = &pandoc.blocks[index] else {
+        panic!("Expected paragraph at block {}", index);
+    };
+    inlines_text(&para.content)
+}
+
+fn inlines_text(inlines: &[Inline]) -> String {
+    let mut out = String::new();
+    for inline in inlines {
+        match inline {
+            Inline::Str(s) => out.push_str(&s.text),
+            Inline::Space(_) => out.push(' '),
+            other => panic!("Unexpected inline in entity test: {:?}", other),
+        }
+    }
+    out
+}
+
+#[test]
+fn test_entity_reference_gt_lt_amp() {
+    let pandoc = parse_qmd("A &gt; B &lt; C &amp; D");
+    assert_eq!(para_text(&pandoc, 0), "A > B < C & D");
+}
+
+#[test]
+fn test_entity_reference_nbsp_is_u00a0() {
+    // &nbsp; must decode to U+00A0, not a regular space
+    let pandoc = parse_qmd("F&nbsp;G");
+    assert_eq!(para_text(&pandoc, 0), "F\u{00a0}G");
+}
+
+#[test]
+fn test_entity_reference_copy() {
+    let pandoc = parse_qmd("&copy; 2026");
+    assert_eq!(para_text(&pandoc, 0), "\u{00a9} 2026");
+}
+
+#[test]
+fn test_entity_reference_multi_codepoint() {
+    // &NotEqualTilde; decodes to two codepoints: U+2242 U+0338
+    let pandoc = parse_qmd("x &NotEqualTilde; y");
+    assert_eq!(para_text(&pandoc, 0), "x \u{2242}\u{0338} y");
+}
+
+#[test]
+fn test_entity_reference_unknown_emits_verbatim() {
+    // "&AM;" currently parses as entity_reference (truncated legacy alternative
+    // from the grammar regex, see bd-v8qc9zyc) but is not a valid entity name;
+    // it must survive as literal text. This assertion also holds after the
+    // grammar fix, when it becomes plain text.
+    let pandoc = parse_qmd("A &AM; B");
+    assert_eq!(para_text(&pandoc, 0), "A &AM; B");
+}
+
+#[test]
+fn test_entity_reference_quot_bypasses_smart_typography() {
+    // Decoded entities are literal characters: &quot; stays a straight quote,
+    // it is NOT smart-quoted (matches Pandoc and the numeric-reference handler).
+    let pandoc = parse_qmd("A &quot;B&quot; C");
+    assert_eq!(para_text(&pandoc, 0), "A \u{0022}B\u{0022} C");
+}
+
+#[test]
+fn test_entity_reference_inside_emphasis() {
+    let pandoc = parse_qmd("*A &gt; B*");
+    let Block::Paragraph(para) = &pandoc.blocks[0] else {
+        panic!("Expected paragraph");
+    };
+    let Some(Inline::Emph(emph)) = para.content.first() else {
+        panic!("Expected emphasis as first inline, got {:?}", para.content);
+    };
+    assert_eq!(inlines_text(&emph.content), "A > B");
+}

--- a/crates/pampa/tests/roundtrip_tests/qmd-json-qmd/named_entities.qmd
+++ b/crates/pampa/tests/roundtrip_tests/qmd-json-qmd/named_entities.qmd
@@ -1,0 +1,5 @@
+Named: A &gt; B &lt; C &amp; D &quot;E&quot; F&nbsp;G &copy; H.
+
+Numeric: A &#62; B &#60; C.
+
+Numeric quote: A &#34;E&#34; B.

--- a/crates/pampa/tests/snapshots/native/entity-references.qmd
+++ b/crates/pampa/tests/snapshots/native/entity-references.qmd
@@ -1,0 +1,7 @@
+Named: A &gt; B &lt; C &amp; D &quot;E&quot; F&nbsp;G &copy; H.
+
+Multi-codepoint: x &NotEqualTilde; y.
+
+Unknown: A &AM; B stays literal.
+
+Numeric: A &#62; B &#60; C &#38; D.

--- a/crates/quarto/tests/smoke-all/quarto-test/named-entities.qmd
+++ b/crates/quarto/tests/smoke-all/quarto-test/named-entities.qmd
@@ -1,0 +1,21 @@
+---
+title: Named Entities
+format: html
+_quarto:
+  tests:
+    html:
+      noErrors: true
+      ensureFileRegexMatches:
+        - ["Named: A &gt; B &lt; C &amp; D", "Nbsp: F G", "Copy: © H", "Multi: x ≂̸ y", "Numeric: A &gt; B"]
+        - ["Named: A  B"]
+---
+
+Named: A &gt; B &lt; C &amp; D.
+
+Nbsp: F&nbsp;G.
+
+Copy: &copy; H.
+
+Multi: x &NotEqualTilde; y.
+
+Numeric: A &#62; B.

--- a/crates/tree-sitter-qmd/bindings/rust/lib.rs
+++ b/crates/tree-sitter-qmd/bindings/rust/lib.rs
@@ -39,6 +39,13 @@ pub const INJECTION_QUERY: &str = include_str!("../../tree-sitter-markdown/queri
 /// [`node-types.json`]: https://tree-sitter.github.io/tree-sitter/using-parsers#static-node-types
 pub const NODE_TYPES: &str = include_str!("../../tree-sitter-markdown/src/node-types.json");
 
+/// The WHATWG HTML entities table (`name → {codepoints, characters}`) that the
+/// grammar's `entity_reference` regex is generated from (see
+/// `common/common.js` `html_entity_regex()`). Exposed so consumers resolving
+/// `entity_reference` nodes decode against the same table the grammar matched
+/// with. Source: <https://html.spec.whatwg.org/multipage/entities.json>.
+pub const HTML_ENTITIES_JSON: &str = include_str!("../../common/html_entities.json");
+
 mod parser;
 
 pub use parser::*;


### PR DESCRIPTION
## Summary

- Named entity references in prose (`&gt;`, `&nbsp;`, `&copy;`, …) were silently dropped: the tree-sitter grammar produces `entity_reference` inline nodes, but the pampa converter had no match arm for them (numeric references already worked). New `process_entity_reference` decodes them via the same WHATWG table the grammar's regex is generated from — exposed from tree-sitter-qmd's Rust bindings as `HTML_ENTITIES_JSON` (`include_str!`, mirroring `NODE_TYPES`) and parsed lazily into a `OnceLock` map. The table's pre-composed `characters` field handles multi-codepoint entities (`&NotEqualTilde;` → U+2242 U+0338). Unknown names pass through verbatim (only reachable via the grammar's mangled legacy-name alternatives — bd-v8qc9zyc).
- Also fixes a pre-existing qmd-writer gap the new roundtrip fixture caught: a straight `"` in a `Str` body (reachable via `&quot;` / `&#34;` / programmatic ASTs) was written bare and re-read as `Quoted DoubleQuote`; `escape_markdown` now emits `\"`.

Real-world impact: Posit Connect docs use named entities in 13 files (UI breadcrumbs like `**APIs & Services** &gt; **Credentials**` lost their separators).

**Snapshot changes:** 1 new snapshot file (`crates/pampa/snapshots/native/entity-references.snap`, for the new fixture); no existing snapshots modified.

Follow-ups filed: bd-v8qc9zyc (grammar regex mangles the 106 legacy no-semicolon entity names), bd-96fswwce (parser rejects decomposed Unicode combining marks; multi-codepoint entities are omitted from the roundtrip fixture until that lands).

Plan: `claude-notes/plans/2026-08-10-named-entity-references-dropped.md`

## Test plan

- [x] 7 coverage tests (fail-first verified): decode, NBSP=U+00A0, multi-codepoint, unknown-name passthrough, straight-quote/no-smart-typography, inside emphasis
- [x] Native snapshot fixture + roundtrip (fixpoint) fixture + smoke-all fixture (end-to-end HTML assertions, NBSP byte-verified)
- [x] `cargo nextest run --workspace`: 11231 passed
- [x] Full `cargo xtask verify` (incl. WASM leg): green
- [x] Manual: `cargo run --bin q2 -- render` of the repro — output inspected

🤖 Generated with [Claude Code](https://claude.com/claude-code)