### PR TITLE
Shut down Jupyter kernels when their kernel scope ends (bd-hxhnnlzs)

### DIFF
--- a/claude-notes/plans/2026-08-10-jupyter-kernel-leak.md
+++ b/claude-notes/plans/2026-08-10-jupyter-kernel-leak.md
@@ -121,8 +121,12 @@ Phase 2 — fix the lifecycle:
       pre-existing rot in `#[ignore]`d tests that nested-runtime-panic
       on main too — filed as bd-yaccefzk). Zero new orphans after the
       run (was ~15).
-- [ ] `cargo nextest run --workspace` + `cargo xtask verify` green;
-      zero new orphans across the full workspace run.
+- [x] `cargo nextest run --workspace` green (11273/11273) with zero
+      new orphans across the full run (was ~15); full
+      `cargo xtask verify` (incl. WASM leg) and `cargo xtask lint`
+      green. Manual end-to-end: `q2 render` of a two-python-doc
+      website → correct output, zero orphans, no stale
+      connection files.
 
 Phase 3 — hygiene (optional, decide with user):
 

--- a/claude-notes/plans/2026-08-10-jupyter-kernel-leak.md
+++ b/claude-notes/plans/2026-08-10-jupyter-kernel-leak.md
@@ -1,0 +1,150 @@
+# Jupyter kernel process leak (bd-hxhnnlzs)
+
+**Strand:** bd-hxhnnlzs — "Jupyter kernels leak as orphan processes from test runs (2338 accumulated)"
+**Status:** investigated 2026-08-10; root cause confirmed on both suspected paths. Fix not yet started.
+**Investigation record:** braid comment `c-1jzpdrgf` on the strand (this document is the durable copy).
+
+## Overview
+
+Every process that executes a Jupyter document — the test suite *and* the
+production `q2 render` CLI — leaks one ipykernel process per
+`(kernel_name, working_dir)` pair. The kernel reparents to launchd
+(PPID 1), idles forever holding ~6 listening TCP sockets, and leaves its
+`kernel-<uuid>.json` connection file behind in `~/Library/Jupyter/runtime/`.
+On 2026-08-10 a dev machine had accumulated 2338 orphans and 4932 stale
+connection files.
+
+### Root cause
+
+The kernel daemon is a process-global static:
+
+- `crates/quarto-core/src/engine/jupyter/daemon.rs:330` —
+  `static DAEMON: OnceLock<Arc<JupyterDaemon>>` holds every
+  `KernelSession` in a `RwLock<HashMap<…>>`.
+- `daemon.rs:155` — kernel `Child` processes are spawned with
+  `kill_on_drop(true)`, so the **only** automatic cleanup is the drop of
+  the `Child` handle.
+- Rust never drops statics at process exit → the `Child` is never
+  dropped → `kill_on_drop` never fires → the kernel outlives the
+  spawning process and reparents to PID 1.
+- `KernelSession::Drop` (session.rs) is what deletes the connection
+  file; since it never runs, the file leaks too.
+
+Supporting facts:
+
+- No non-test code calls `shutdown_all()` or `shutdown_session()`.
+- `cleanup_idle_sessions()` (the 5-minute idle reaper) has **zero
+  callers** anywhere in the tree — dead code. The
+  `DEFAULT_IDLE_TIMEOUT` gives a false sense of a safety net.
+- `KernelSession::shutdown()` never sends a Jupyter
+  `shutdown_request`; it goes straight to `start_kill()` (SIGKILL).
+  Acceptable as a backstop, but not a graceful shutdown.
+
+### Empirical confirmation (2026-08-10)
+
+Both leak paths were reproduced by diffing
+`ps -axo pid,ppid,command | grep '[i]pykernel_launcher'` before/after:
+
+1. **Test path.** One test:
+
+   ```
+   cargo nextest run -p quarto-core -E 'binary(integration) & test(plain_cell_error_fails_the_render)'
+   ```
+
+   → exactly 1 new PPID-1 orphan, 6 listening sockets (`lsof -i`),
+   connection file intact (proving `Drop` never ran). nextest is
+   process-per-test, so **each python-executing test leaks one
+   kernel**. The observed ~15 orphans per `cargo nextest run
+   --workspace` matches the python-executing tests that go through the
+   render path with no shutdown: `engine_error_policy` (7) +
+   `engine_output_parity` (7–8) + `capture_splice_engines` (2–3).
+   `jupyter_integration.rs` tests call `shutdown_session` explicitly
+   and only leak if an assert fails first. During the investigation a
+   concurrent workspace run on the same machine independently leaked
+   exactly 15 orphans, all with cwds in nextest temp dirs.
+
+2. **Production path.** A minimal doc (`engine: jupyter`, one
+   `{python}` cell) rendered with
+   `cargo run --bin q2 -- render doc.qmd` → 1 orphan whose cwd (via
+   `lsof -d cwd`) was the doc's directory. **Every `q2 render` of a
+   jupyter document leaks a kernel.** This — not the test suite — is
+   what explains 2338 accumulated orphans.
+
+Attribution technique for future debugging: an orphan's cwd identifies
+its spawner (nextest temp dir vs. document dir), and connection-file
+mtime brackets the spawn time.
+
+## Work Items
+
+Phase 1 — regression test (TDD: must fail before the fix):
+
+- [x] `crates/quarto-core/tests/integration/jupyter_kernel_cleanup.rs`
+      — drives `record_capture`, watches an isolated
+      `JUPYTER_RUNTIME_DIR` for `kernel-*.json`, asserts kernel ports
+      are dead and files removed after the call returns. Verified
+      failing pre-fix ("kernel still listening on shell port …").
+- [x] `crates/quarto/tests/integration/jupyter_kernel_cleanup_e2e.rs`
+      — drives the real `q2 render` on a two-python-doc project;
+      additionally asserts exactly ONE kernel served both docs
+      (pinning warm-kernel reuse). Verified failing pre-fix.
+
+Phase 2 — fix the lifecycle:
+
+- [x] Refcounted `KernelScope` (daemon.rs): inner scope in
+      `execute_qmd` (no caller can leak), outer scopes in `q2 render`
+      (around `pipeline.run()`, dropped before any `process::exit`),
+      `q2 preview` and `q2 provide-hub` (server lifetime, sync side of
+      `block_on` so the graceful path is available). Last scope out
+      runs `shutdown_all_blocking()`.
+- [x] Graceful shutdown: `KernelSession::shutdown_blocking` sends
+      `shutdown_request` on the control channel (private
+      current-thread runtime; skipped when already on a tokio runtime
+      thread), waits bounded, then `start_kill()` backstop + reap +
+      connection-file removal. Async `shutdown()` delegates to it.
+- [x] Deleted the never-called idle-timeout machinery
+      (`cleanup_idle_sessions`, `with_idle_timeout`,
+      `DEFAULT_IDLE_TIMEOUT`, `last_used`/`touch`).
+- [x] **Discovered + fixed: startup TOCTOU race** — concurrent renders
+      sharing a session key both spawned kernels (read-check → long
+      spawn → insert; loser evicted+killed). Every project render hit
+      it. Fixed with a `start_lock` + re-check.
+- [x] **Discovered + fixed: cross-call session reuse never worked** —
+      sessions held ZeroMQ sockets/Child bound to a per-call
+      throwaway runtime; genuine reuse failed with "Tokio context …
+      being shutdown" (masked by the TOCTOU race always re-spawning).
+      Sessions now live on a shared `ENGINE_RUNTIME`
+      (`engine_runtime()` in daemon.rs); `execute_blocks_async` uses
+      it instead of building a runtime per call.
+- [x] Panic-safety scopes added to the direct-daemon-API tests in
+      `jupyter_integration.rs`.
+- [x] Full jupyter test set green (24/26; the 2 failures are
+      pre-existing rot in `#[ignore]`d tests that nested-runtime-panic
+      on main too — filed as bd-yaccefzk). Zero new orphans after the
+      run (was ~15).
+- [ ] `cargo nextest run --workspace` + `cargo xtask verify` green;
+      zero new orphans across the full workspace run.
+
+Phase 3 — hygiene (optional, decide with user):
+
+- [ ] Consider a startup sweep for stale `kernel-*.json` files whose
+      port owner is gone. (Not in the bd-hxhnnlzs PR.)
+
+## Details / design notes
+
+- **Why an exit hook and not per-render teardown everywhere:** kernel
+  reuse across renders is the point of the daemon for `q2 preview`
+  (warm kernel = fast re-render). For one-shot `q2 render`, teardown at
+  end of invocation is correct. The fix likely wants both: an owned
+  daemon handle whose scope ends with the CLI invocation, plus a
+  signal/exit path for preview.
+- **Why the tests leak even though some call `shutdown_session`:** the
+  leaking tests never touch the daemon API — they render documents
+  through the normal pipeline (`text_execute.rs:167` calls the global
+  `daemon()`), so there is no handle for them to shut down. Fixing the
+  production lifecycle fixes the tests for free.
+- **`kill_on_drop(true)` is fine but insufficient:** it only helps if
+  the `Child` drops while the process is alive. Keep it as a backstop
+  for panic/error paths; do not rely on it for normal exit.
+- Cleanup performed 2026-08-10: user killed all 2338 orphans and
+  deleted stale connection files; the investigation session killed the
+  2 orphans it created.

--- a/crates/quarto-core/src/engine/jupyter/daemon.rs
+++ b/crates/quarto-core/src/engine/jupyter/daemon.rs
@@ -10,25 +10,38 @@
 //! The `JupyterDaemon` manages kernel lifecycle:
 //! - Starting kernels on demand
 //! - Reusing existing kernels for the same (kernel, working_dir) pair
-//! - Shutting down idle kernels
 //! - Cleaning up on shutdown
+//!
+//! # Kernel scopes (bd-hxhnnlzs)
+//!
+//! The daemon is a process-global static, and Rust never drops statics
+//! — so nothing implicit ever shuts these kernels down. Left alone,
+//! every spawned kernel outlives the process, reparents to PID 1, and
+//! idles forever (2338 of them accumulated on one dev machine).
+//!
+//! Lifetime is therefore managed explicitly with refcounted **kernel
+//! scopes**: every execution path that can spawn a kernel holds a
+//! [`KernelScope`] (the jupyter engine's `execute_qmd` acquires one
+//! around each engine run, so no caller can leak by accident), and
+//! long-lived callers that want kernel reuse across engine runs — a
+//! `q2 render` project invocation, the `q2 preview` server — hold an
+//! outer scope for their own lifetime. When the last scope drops, all
+//! sessions are shut down: `shutdown_request`, kill backstop,
+//! connection-file removal.
 
 use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr};
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use jupyter_protocol::ConnectionInfo;
-use tokio::sync::RwLock;
+use tokio::sync::{Mutex, RwLock};
 use uuid::Uuid;
 
 use super::error::{JupyterError, Result};
 use super::kernelspec;
 use super::session::{KernelSession, SessionKey};
-
-/// Default timeout before idle kernels are shut down.
-const DEFAULT_IDLE_TIMEOUT: Duration = Duration::from_secs(300); // 5 minutes
 
 /// In-process daemon managing Jupyter kernel sessions.
 ///
@@ -38,8 +51,14 @@ const DEFAULT_IDLE_TIMEOUT: Duration = Duration::from_secs(300); // 5 minutes
 pub struct JupyterDaemon {
     /// Active kernel sessions.
     sessions: RwLock<HashMap<SessionKey, KernelSession>>,
-    /// Idle timeout before shutting down unused kernels.
-    idle_timeout: Duration,
+    /// Serializes kernel startup. Starting a kernel takes seconds and
+    /// many await points; without this lock two concurrent renders of
+    /// documents sharing a session key would both miss the sessions
+    /// map and both spawn, with the loser's kernel evicted on insert
+    /// (observed as duplicate ipykernel processes under project
+    /// renders, bd-hxhnnlzs). Also keeps concurrent port allocations
+    /// (`peek_ports`) from racing each other.
+    start_lock: Mutex<()>,
 }
 
 impl JupyterDaemon {
@@ -47,15 +66,7 @@ impl JupyterDaemon {
     pub fn new() -> Self {
         Self {
             sessions: RwLock::new(HashMap::new()),
-            idle_timeout: DEFAULT_IDLE_TIMEOUT,
-        }
-    }
-
-    /// Create a daemon with custom idle timeout.
-    pub fn with_idle_timeout(idle_timeout: Duration) -> Self {
-        Self {
-            sessions: RwLock::new(HashMap::new()),
-            idle_timeout,
+            start_lock: Mutex::new(()),
         }
     }
 
@@ -86,7 +97,28 @@ impl JupyterDaemon {
             }
         }
 
-        // Start a new kernel
+        if active_scopes() == 0 {
+            // Not fatal — but this kernel will live until the process
+            // exits (or until some other scope closes), which is
+            // exactly the leak bd-hxhnnlzs is about. Callers should
+            // hold a `kernel_scope()`.
+            tracing::warn!(
+                kernel = %key.kernel_name,
+                "starting a Jupyter kernel outside any kernel scope; \
+                 nothing will shut it down automatically"
+            );
+        }
+
+        // Serialize startup and re-check: a concurrent caller may have
+        // finished starting this very session while we awaited the
+        // lock (the read-check/spawn/insert sequence is not atomic).
+        let _starting = self.start_lock.lock().await;
+        {
+            let sessions = self.sessions.read().await;
+            if sessions.contains_key(&key) {
+                return Ok(key);
+            }
+        }
         self.start_kernel(&key, extra_env).await?;
 
         Ok(key)
@@ -197,7 +229,6 @@ impl JupyterDaemon {
             iopub_socket,
             session_id,
             execution_count: 0,
-            last_used: Instant::now(),
             working_dir: key.working_dir.clone(),
         };
 
@@ -244,10 +275,7 @@ impl JupyterDaemon {
         F: FnOnce(&mut KernelSession) -> R,
     {
         let mut sessions = self.sessions.write().await;
-        sessions.get_mut(key).map(|session| {
-            session.touch();
-            f(session)
-        })
+        sessions.get_mut(key).map(f)
     }
 
     /// Execute code in a kernel session.
@@ -261,7 +289,6 @@ impl JupyterDaemon {
     ) -> Option<Result<super::execute::ExecuteResult>> {
         let mut sessions = self.sessions.write().await;
         if let Some(session) = sessions.get_mut(key) {
-            session.touch();
             Some(session.execute(code).await)
         } else {
             None
@@ -288,22 +315,25 @@ impl JupyterDaemon {
         Ok(())
     }
 
-    /// Cleanup idle sessions that have exceeded the timeout.
-    pub async fn cleanup_idle_sessions(&self) {
-        let now = Instant::now();
-        let mut sessions = self.sessions.write().await;
-
-        let idle_keys: Vec<SessionKey> = sessions
-            .iter()
-            .filter(|(_, session)| now.duration_since(session.last_used) > self.idle_timeout)
-            .map(|(key, _)| key.clone())
-            .collect();
-
-        for key in idle_keys {
-            if let Some(mut session) = sessions.remove(&key) {
-                tracing::info!(kernel = %key.kernel_name, "Shutting down idle kernel");
-                let _ = session.shutdown().await;
-            }
+    /// Shutdown all kernel sessions without needing an async context.
+    ///
+    /// This is the teardown path of the last [`KernelScope`] (which
+    /// runs in `Drop`, hence sync). `try_write` cannot fail there in
+    /// practice — a held write lock would mean a kernel is mid-execute,
+    /// and scopes outlive the executions they cover — but if it ever
+    /// does, warn rather than block or panic; the per-`Child`
+    /// `kill_on_drop` remains as the final backstop.
+    pub fn shutdown_all_blocking(&self) {
+        let Ok(mut sessions) = self.sessions.try_write() else {
+            tracing::warn!(
+                "kernel sessions locked during scope teardown; \
+                 skipping shutdown (kill-on-drop remains as backstop)"
+            );
+            return;
+        };
+        for (key, mut session) in sessions.drain() {
+            tracing::info!(kernel = %key.kernel_name, "Shutting down kernel");
+            session.shutdown_blocking();
         }
     }
 
@@ -336,26 +366,109 @@ pub fn daemon() -> Arc<JupyterDaemon> {
         .clone()
 }
 
+/// Long-lived runtime that owns every kernel session's resources.
+///
+/// Kernel ZeroMQ sockets and the kernel `Child` are tokio resources
+/// bound to the runtime they were created on. Sessions outlive a
+/// single engine run (that's the point of the daemon), so they must
+/// not be created on a per-call runtime: reusing a session whose
+/// runtime was dropped fails with "A Tokio 1.x context was found, but
+/// it is being shutdown". Before bd-hxhnnlzs this was masked by the
+/// startup race — every "reuse" actually re-spawned a fresh kernel and
+/// evicted (killed) the old one.
+///
+/// One worker thread is plenty: engine executions serialize on the
+/// sessions lock anyway. Being a static, the runtime is never dropped;
+/// kernels are shut down by the [`KernelScope`] machinery, not by
+/// runtime teardown.
+static ENGINE_RUNTIME: std::sync::OnceLock<tokio::runtime::Runtime> = std::sync::OnceLock::new();
+
+/// The shared engine runtime. All daemon session operations —
+/// spawning, executing, async shutdown — must run on it.
+pub(crate) fn engine_runtime() -> &'static tokio::runtime::Runtime {
+    ENGINE_RUNTIME.get_or_init(|| {
+        tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .thread_name("jupyter-daemon")
+            .enable_all()
+            .build()
+            .expect("building the shared Jupyter engine runtime")
+    })
+}
+
+/// Number of currently-open [`KernelScope`]s.
+static ACTIVE_SCOPES: AtomicUsize = AtomicUsize::new(0);
+
+fn active_scopes() -> usize {
+    ACTIVE_SCOPES.load(Ordering::SeqCst)
+}
+
+/// RAII handle keeping the global kernel pool alive (bd-hxhnnlzs).
+///
+/// When the last open scope drops, every session in the global daemon
+/// is shut down ([`JupyterDaemon::shutdown_all_blocking`]). The
+/// jupyter engine acquires one around each engine run, so kernels
+/// never outlive the work that spawned them; callers that want kernel
+/// reuse *across* engine runs (a project render, a preview server)
+/// hold an additional scope for their own lifetime.
+///
+/// Scope drops must happen on the normal return path — `Drop` does not
+/// run across `std::process::exit`, so hold scopes tightly around the
+/// work rather than around exit-calling code.
+#[must_use = "the kernel pool shuts down when the last scope drops; \
+              bind to a named guard for the intended lifetime"]
+pub struct KernelScope {
+    _not_send_sync_constructible: (),
+}
+
+/// Open a [`KernelScope`].
+pub fn kernel_scope() -> KernelScope {
+    ACTIVE_SCOPES.fetch_add(1, Ordering::SeqCst);
+    KernelScope {
+        _not_send_sync_constructible: (),
+    }
+}
+
+impl Drop for KernelScope {
+    fn drop(&mut self) {
+        let was = ACTIVE_SCOPES.fetch_sub(1, Ordering::SeqCst);
+        debug_assert!(was > 0, "KernelScope refcount underflow");
+        // Last scope out shuts down the pool. A concurrent
+        // `kernel_scope()` call racing this transition could get its
+        // fresh kernel torn down; in practice every spawning path runs
+        // under a scope that is still open here, and the cost of the
+        // race is a kernel restart, not a leak.
+        if was == 1
+            && let Some(daemon) = DAEMON.get()
+        {
+            daemon.shutdown_all_blocking();
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_daemon_creation() {
-        let daemon = JupyterDaemon::new();
-        assert_eq!(daemon.idle_timeout, DEFAULT_IDLE_TIMEOUT);
-    }
-
-    #[test]
-    fn test_daemon_custom_timeout() {
-        let timeout = Duration::from_secs(60);
-        let daemon = JupyterDaemon::with_idle_timeout(timeout);
-        assert_eq!(daemon.idle_timeout, timeout);
-    }
 
     #[tokio::test]
     async fn test_daemon_initial_state() {
         let daemon = JupyterDaemon::new();
         assert_eq!(daemon.session_count().await, 0);
+    }
+
+    #[test]
+    fn test_kernel_scope_refcount() {
+        // nextest runs each test in its own process, so the global
+        // counter starts at 0 and nothing else touches it.
+        assert_eq!(active_scopes(), 0);
+        let outer = kernel_scope();
+        {
+            let _inner = kernel_scope();
+            assert_eq!(active_scopes(), 2);
+        }
+        // Inner drop must not tear down while an outer scope is open.
+        assert_eq!(active_scopes(), 1);
+        drop(outer);
+        assert_eq!(active_scopes(), 0);
     }
 }

--- a/crates/quarto-core/src/engine/jupyter/execute.rs
+++ b/crates/quarto-core/src/engine/jupyter/execute.rs
@@ -92,7 +92,6 @@ impl KernelSession {
         code: &str,
         exec_timeout: Duration,
     ) -> Result<ExecuteResult> {
-        self.touch();
         let _execution_count = self.next_execution_count();
 
         // Build execute request
@@ -209,8 +208,6 @@ impl KernelSession {
         if expressions.is_empty() {
             return Ok(Vec::new());
         }
-
-        self.touch();
 
         // Build user_expressions map
         let user_expressions: std::collections::HashMap<String, String> = expressions

--- a/crates/quarto-core/src/engine/jupyter/mod.rs
+++ b/crates/quarto-core/src/engine/jupyter/mod.rs
@@ -44,7 +44,7 @@ mod kernelspec;
 mod session;
 mod text_execute;
 
-pub use daemon::{JupyterDaemon, daemon};
+pub use daemon::{JupyterDaemon, KernelScope, daemon, kernel_scope};
 pub use error::{JupyterError, Result};
 pub use execute::{CellOutput, ExecuteResult, ExecuteStatus, MimeBundle};
 pub use kernelspec::{ResolvedKernel, find_kernelspec, is_jupyter_language, list_kernelspecs};

--- a/crates/quarto-core/src/engine/jupyter/session.rs
+++ b/crates/quarto-core/src/engine/jupyter/session.rs
@@ -13,7 +13,7 @@
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
-use jupyter_protocol::{ConnectionInfo, JupyterMessage, KernelInfoRequest};
+use jupyter_protocol::{ConnectionInfo, JupyterMessage, KernelInfoRequest, ShutdownRequest};
 use runtimelib::{ClientIoPubConnection, ClientShellConnection};
 use tokio::process::Child;
 use tokio::time::timeout;
@@ -23,6 +23,17 @@ use super::kernelspec::ResolvedKernel;
 
 /// Default timeout for waiting for kernel to become ready.
 const KERNEL_READY_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Budget for connecting to the control channel and sending
+/// `shutdown_request` during graceful shutdown.
+const SHUTDOWN_REQUEST_TIMEOUT: Duration = Duration::from_secs(1);
+
+/// How long a kernel gets to exit after `shutdown_request` before the
+/// SIGKILL backstop fires.
+const GRACEFUL_EXIT_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// How long to wait for the process to be reaped after a kill signal.
+const KILL_REAP_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// Information about a running kernel.
 #[derive(Debug, Clone)]
@@ -63,8 +74,6 @@ pub struct KernelSession {
     pub(crate) session_id: String,
     /// Execution counter for this session.
     pub(crate) execution_count: u32,
-    /// Last activity timestamp.
-    pub(crate) last_used: Instant,
     /// Working directory for this session.
     pub(crate) working_dir: PathBuf,
 }
@@ -198,29 +207,97 @@ impl KernelSession {
         Ok(())
     }
 
-    /// Shutdown the kernel gracefully.
+    /// Shutdown the kernel: graceful `shutdown_request` first (when
+    /// possible), SIGKILL backstop, then connection-file cleanup.
     pub async fn shutdown(&mut self) -> Result<()> {
-        // Kill the process
-        if let Err(e) = self.process.start_kill() {
-            tracing::warn!("Failed to kill kernel process: {}", e);
-        }
-
-        // Wait for it to exit (with timeout)
-        let _ = tokio::time::timeout(std::time::Duration::from_secs(5), self.process.wait()).await;
-
-        // Clean up connection file
-        if self.connection_file.exists()
-            && let Err(e) = tokio::fs::remove_file(&self.connection_file).await
-        {
-            tracing::warn!("Failed to remove connection file: {}", e);
-        }
-
+        self.shutdown_blocking();
         Ok(())
     }
 
-    /// Update the last-used timestamp.
-    pub(crate) fn touch(&mut self) {
-        self.last_used = Instant::now();
+    /// Runtime-independent shutdown (bd-hxhnnlzs). Deliberately sync so
+    /// it can run from a `Drop` impl, from pollster-driven callers, and
+    /// from inside a tokio runtime alike:
+    ///
+    /// 1. **Graceful**: send `shutdown_request` on the control channel
+    ///    and give the kernel [`GRACEFUL_EXIT_TIMEOUT`] to exit. The
+    ///    send needs a private current-thread tokio runtime, so this
+    ///    step is skipped when already on a tokio runtime thread
+    ///    (building a nested runtime would panic there) — the backstop
+    ///    below still reclaims the process.
+    /// 2. **Backstop**: kill the process and wait (bounded, via
+    ///    `try_wait` polling — tokio's async `wait` is unusable here
+    ///    because the process was spawned on a different, possibly
+    ///    dropped, runtime).
+    /// 3. Remove the connection file.
+    pub(crate) fn shutdown_blocking(&mut self) {
+        if !self.has_exited() && tokio::runtime::Handle::try_current().is_err() {
+            match tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+            {
+                Ok(rt) => {
+                    // The `timeout` must be constructed inside
+                    // `block_on`: it arms its timer eagerly and
+                    // panics without a current runtime.
+                    let sent = rt.block_on(async {
+                        timeout(SHUTDOWN_REQUEST_TIMEOUT, async {
+                            let mut control = runtimelib::create_client_control_connection(
+                                &self.connection_info,
+                                &self.session_id,
+                            )
+                            .await?;
+                            let message: JupyterMessage = ShutdownRequest { restart: false }.into();
+                            control.send(message).await
+                        })
+                        .await
+                    });
+                    if matches!(sent, Ok(Ok(()))) {
+                        self.wait_for_exit(GRACEFUL_EXIT_TIMEOUT);
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!("could not build runtime for graceful kernel shutdown: {e}");
+                }
+            }
+        }
+
+        if !self.has_exited() {
+            if let Err(e) = self.process.start_kill() {
+                tracing::warn!("Failed to kill kernel process: {}", e);
+            }
+            if !self.wait_for_exit(KILL_REAP_TIMEOUT) {
+                tracing::warn!(
+                    kernel = %self.kernel.name,
+                    "kernel process did not exit after kill signal"
+                );
+            }
+        }
+
+        if self.connection_file.exists()
+            && let Err(e) = std::fs::remove_file(&self.connection_file)
+        {
+            tracing::warn!("Failed to remove connection file: {}", e);
+        }
+    }
+
+    /// Whether the kernel process has exited (best-effort; errors from
+    /// `try_wait` count as exited, matching [`Self::is_alive`]).
+    fn has_exited(&mut self) -> bool {
+        !matches!(self.process.try_wait(), Ok(None))
+    }
+
+    /// Poll `try_wait` until the process exits or `deadline` elapses.
+    fn wait_for_exit(&mut self, deadline: Duration) -> bool {
+        let start = Instant::now();
+        loop {
+            if self.has_exited() {
+                return true;
+            }
+            if start.elapsed() > deadline {
+                return false;
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
     }
 
     /// Increment and return the execution count.

--- a/crates/quarto-core/src/engine/jupyter/text_execute.rs
+++ b/crates/quarto-core/src/engine/jupyter/text_execute.rs
@@ -62,6 +62,12 @@ pub fn execute_qmd(
     // Determine the kernel from the first code block
     let kernel_name = map_language_to_kernel(&blocks[0].language);
 
+    // bd-hxhnnlzs: hold a kernel scope for the duration of this engine
+    // run. If no outer scope (render invocation, preview server) is
+    // open, the kernels spawned below are shut down when this guard
+    // drops — no caller of the jupyter engine can leak a kernel.
+    let _kernel_scope = super::daemon::kernel_scope();
+
     // Execute via async runtime
     let result = execute_blocks_async(input, &blocks, &kernel_name, ctx);
 
@@ -148,13 +154,12 @@ fn execute_blocks_async(
     kernel_name: &str,
     ctx: &ExecutionContext,
 ) -> JupyterResult<ExecuteResult> {
-    // Use tokio runtime to execute async code
-    let rt = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .map_err(|e| JupyterError::RuntimeLibError(e.to_string()))?;
-
-    rt.block_on(execute_blocks_inner(input, blocks, kernel_name, ctx))
+    // Drive the execution on the shared engine runtime — NOT a
+    // per-call runtime. Kernel sessions (ZeroMQ sockets, the kernel
+    // Child) are tokio resources bound to the runtime that created
+    // them; a per-call runtime made every cross-call session reuse
+    // fail with "Tokio context ... is being shutdown" (bd-hxhnnlzs).
+    super::daemon::engine_runtime().block_on(execute_blocks_inner(input, blocks, kernel_name, ctx))
 }
 
 /// Inner async function that does the actual execution.

--- a/crates/quarto-core/tests/integration/jupyter_integration.rs
+++ b/crates/quarto-core/tests/integration/jupyter_integration.rs
@@ -67,6 +67,10 @@ async fn test_kernel_execute_print() {
         return;
     }
 
+    // bd-hxhnnlzs: panic-safety — if an assertion below fails before
+    // the explicit shutdown_session, this scope's drop still tears the
+    // kernel down instead of leaking it to PID 1.
+    let _kernel_scope = quarto_core::engine::jupyter::kernel_scope();
     let daemon = daemon();
     let working_dir = std::env::current_dir().unwrap();
 
@@ -119,6 +123,10 @@ async fn test_kernel_execute_expression() {
         return;
     }
 
+    // bd-hxhnnlzs: panic-safety — if an assertion below fails before
+    // the explicit shutdown_session, this scope's drop still tears the
+    // kernel down instead of leaking it to PID 1.
+    let _kernel_scope = quarto_core::engine::jupyter::kernel_scope();
     let daemon = daemon();
     let working_dir = std::env::current_dir().unwrap();
 
@@ -162,6 +170,10 @@ async fn test_kernel_execute_error() {
         return;
     }
 
+    // bd-hxhnnlzs: panic-safety — if an assertion below fails before
+    // the explicit shutdown_session, this scope's drop still tears the
+    // kernel down instead of leaking it to PID 1.
+    let _kernel_scope = quarto_core::engine::jupyter::kernel_scope();
     let daemon = daemon();
     let working_dir = std::env::current_dir().unwrap();
 
@@ -235,6 +247,10 @@ async fn test_kernel_execute_matplotlib() {
         return;
     }
 
+    // bd-hxhnnlzs: panic-safety — if an assertion below fails before
+    // the explicit shutdown_session, this scope's drop still tears the
+    // kernel down instead of leaking it to PID 1.
+    let _kernel_scope = quarto_core::engine::jupyter::kernel_scope();
     let daemon = daemon();
     let working_dir = std::env::current_dir().unwrap();
 

--- a/crates/quarto-core/tests/integration/jupyter_kernel_cleanup.rs
+++ b/crates/quarto-core/tests/integration/jupyter_kernel_cleanup.rs
@@ -1,0 +1,193 @@
+//! bd-hxhnnlzs: Jupyter kernels must not outlive the work that spawned
+//! them. Every kernel spawned during an engine execution (here driven
+//! through `record_capture`, the same producer path `q2 render` /
+//! `q2 preview` / `q2 provide-hub` use) must be shut down — process
+//! killed, connection file removed — by the time the outermost kernel
+//! scope ends, instead of surviving in the process-global daemon until
+//! the process exits and the kernel reparents to PID 1.
+//!
+//! The test isolates kernel connection files via `JUPYTER_RUNTIME_DIR`
+//! (honored by `runtimelib::dirs::runtime_dir()`), watches that
+//! directory while the render runs to learn each kernel's ZeroMQ
+//! ports, and then asserts that after `record_capture` returns nothing
+//! is listening on those ports and no connection files remain.
+//!
+//! Tests skip when the jupyter engine isn't installed — same gating as
+//! engine_error_policy.rs.
+
+use std::net::TcpStream;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
+
+use quarto_core::engine::EngineRegistry;
+use quarto_core::engine::preview_record::record_capture;
+use quarto_core::project::ProjectContext;
+use quarto_system_runtime::{NativeRuntime, SystemRuntime};
+
+fn engine_available(name: &str) -> bool {
+    EngineRegistry::default()
+        .get(name)
+        .is_some_and(|e| e.is_available())
+}
+
+/// Ports recorded from one observed `kernel-*.json` connection file.
+#[derive(Debug, Clone)]
+struct ObservedKernel {
+    file_name: String,
+    shell_port: u16,
+    control_port: u16,
+}
+
+/// Poll `dir` for `kernel-*.json` files until `stop` is set, recording
+/// each distinct file's ports. Files are written atomically enough for
+/// this purpose (a few hundred bytes); a partial read simply retries
+/// on the next tick because the entry is only recorded once it parses.
+fn watch_connection_files(
+    dir: PathBuf,
+    stop: Arc<AtomicBool>,
+) -> std::thread::JoinHandle<Vec<ObservedKernel>> {
+    std::thread::spawn(move || {
+        let mut seen: Vec<ObservedKernel> = Vec::new();
+        while !stop.load(Ordering::Relaxed) {
+            if let Ok(entries) = std::fs::read_dir(&dir) {
+                for entry in entries.flatten() {
+                    let name = entry.file_name().to_string_lossy().into_owned();
+                    if !(name.starts_with("kernel-") && name.ends_with(".json")) {
+                        continue;
+                    }
+                    if seen.iter().any(|k| k.file_name == name) {
+                        continue;
+                    }
+                    let Ok(text) = std::fs::read_to_string(entry.path()) else {
+                        continue;
+                    };
+                    let Ok(json) = serde_json::from_str::<serde_json::Value>(&text) else {
+                        continue;
+                    };
+                    let port = |key: &str| {
+                        json.get(key)
+                            .and_then(|v| v.as_u64())
+                            .map_or(0, |p| p as u16)
+                    };
+                    let (shell_port, control_port) = (port("shell_port"), port("control_port"));
+                    if shell_port != 0 && control_port != 0 {
+                        seen.push(ObservedKernel {
+                            file_name: name,
+                            shell_port,
+                            control_port,
+                        });
+                    }
+                }
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        seen
+    })
+}
+
+/// True while something accepts TCP connections on `port` (the ZeroMQ
+/// sockets of a live kernel do; a killed kernel's ports refuse).
+fn port_is_open(port: u16) -> bool {
+    TcpStream::connect_timeout(&([127, 0, 0, 1], port).into(), Duration::from_millis(250)).is_ok()
+}
+
+/// Wait (bounded) for a condition that becomes true once the kernel is
+/// fully torn down; returns whether it did.
+fn eventually(deadline: Duration, mut cond: impl FnMut() -> bool) -> bool {
+    let start = Instant::now();
+    loop {
+        if cond() {
+            return true;
+        }
+        if start.elapsed() > deadline {
+            return false;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+fn remaining_connection_files(dir: &Path) -> Vec<String> {
+    std::fs::read_dir(dir)
+        .map(|entries| {
+            entries
+                .flatten()
+                .map(|e| e.file_name().to_string_lossy().into_owned())
+                .filter(|n| n.starts_with("kernel-") && n.ends_with(".json"))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+#[test]
+fn record_capture_shuts_down_spawned_kernels() {
+    if !engine_available("jupyter") {
+        eprintln!("Skipping test: jupyter not available");
+        return;
+    }
+
+    let dir = tempfile::tempdir().unwrap();
+    let runtime_dir = dir.path().join("jupyter-runtime");
+    std::fs::create_dir_all(&runtime_dir).unwrap();
+
+    // Isolate connection files so the watcher only sees kernels this
+    // test spawned. Safe: nextest runs each test in its own process,
+    // and the daemon reads the variable after this point.
+    // lint note: `set_var` is unsafe in edition 2024 because of
+    // concurrent readers; this test's process is single-threaded here.
+    unsafe { std::env::set_var("JUPYTER_RUNTIME_DIR", &runtime_dir) };
+
+    let qmd_path = dir.path().join("doc.qmd");
+    std::fs::write(
+        &qmd_path,
+        "---\ntitle: Kernel cleanup\nengine: jupyter\n---\n\n```{python}\nprint(\"cleanup-test\")\n```\n",
+    )
+    .unwrap();
+    let runtime: Arc<dyn SystemRuntime> = Arc::new(NativeRuntime::new());
+    let project = ProjectContext::discover(&qmd_path, runtime.as_ref()).unwrap();
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let watcher = watch_connection_files(runtime_dir.clone(), stop.clone());
+
+    let captures = pollster::block_on(record_capture(&qmd_path, &project, runtime, None))
+        .expect("render of a healthy python cell succeeds");
+    assert!(!captures.is_empty(), "engine capture was produced");
+
+    stop.store(true, Ordering::Relaxed);
+    let observed = watcher.join().unwrap();
+
+    // The engine must actually have spawned a kernel, otherwise the
+    // assertions below are vacuous.
+    assert!(
+        !observed.is_empty(),
+        "watcher saw no kernel-*.json — the jupyter engine did not run \
+         (JUPYTER_RUNTIME_DIR not honored, or the render skipped execution)"
+    );
+
+    // bd-hxhnnlzs: by the time record_capture returns, every spawned
+    // kernel must be dead (ports closed) and its connection file gone.
+    for kernel in &observed {
+        for (label, port) in [
+            ("shell", kernel.shell_port),
+            ("control", kernel.control_port),
+        ] {
+            assert!(
+                eventually(Duration::from_secs(5), || !port_is_open(port)),
+                "kernel {} still listening on {} port {} after record_capture \
+                 returned — the kernel process leaked (bd-hxhnnlzs)",
+                kernel.file_name,
+                label,
+                port,
+            );
+        }
+    }
+    assert!(
+        eventually(Duration::from_secs(5), || {
+            remaining_connection_files(&runtime_dir).is_empty()
+        }),
+        "stale connection files left in JUPYTER_RUNTIME_DIR after \
+         record_capture returned: {:?} (bd-hxhnnlzs)",
+        remaining_connection_files(&runtime_dir),
+    );
+}

--- a/crates/quarto-core/tests/integration/main.rs
+++ b/crates/quarto-core/tests/integration/main.rs
@@ -30,6 +30,7 @@ pub mod include_project_absolute;
 pub mod include_resolve_pipeline;
 pub mod incremental_rebuild;
 pub mod jupyter_integration;
+pub mod jupyter_kernel_cleanup;
 pub mod language_catalog;
 pub mod language_pipeline;
 pub mod language_resolve;

--- a/crates/quarto/src/commands/preview.rs
+++ b/crates/quarto/src/commands/preview.rs
@@ -52,6 +52,12 @@ pub fn execute(args: PreviewArgs) -> Result<()> {
     // Multi-threaded runtime for the same reasons quarto hub uses
     // one: samod, websockets, file watching, periodic sync.
     let runtime = tokio::runtime::Runtime::new()?;
+    // bd-hxhnnlzs: hold a kernel scope for the server's lifetime so
+    // re-renders reuse warm kernels. It drops after `block_on` returns
+    // (the hub server resolves SIGINT/SIGTERM/Ctrl-C into a graceful
+    // return), outside the runtime — so kernels get the polite
+    // `shutdown_request` path before the kill backstop.
+    let _kernel_scope = quarto_core::engine::jupyter::kernel_scope();
     runtime.block_on(run(args))
 }
 

--- a/crates/quarto/src/commands/provide_hub.rs
+++ b/crates/quarto/src/commands/provide_hub.rs
@@ -57,6 +57,10 @@ pub fn execute(args: ProvideHubArgs) -> Result<()> {
     // A full multi-threaded runtime: the auth bridge's stdout reader and the
     // samod sync both run as background tasks.
     let runtime = tokio::runtime::Runtime::new()?;
+    // bd-hxhnnlzs: kernels spawned for execution requests stay warm for
+    // the provider's lifetime; the scope drops after `block_on` returns
+    // (Ctrl-C resolves `run_watch` normally), shutting them all down.
+    let _kernel_scope = quarto_core::engine::jupyter::kernel_scope();
     runtime.block_on(run(args))
 }
 

--- a/crates/quarto/src/commands/render.rs
+++ b/crates/quarto/src/commands/render.rs
@@ -771,7 +771,15 @@ fn execute_single_doc(
     .with_format_override(args.to.clone())
     .with_fail_fast(args.fail_fast);
 
-    let mut summary = match pollster::block_on(pipeline.run()) {
+    // bd-hxhnnlzs: keep Jupyter kernels warm across the whole pipeline
+    // run. Scoped to the `block_on` (not the surrounding function)
+    // because the error paths below call `std::process::exit`, which
+    // skips destructors — the scope must close before any exit.
+    let run_result = {
+        let _kernel_scope = quarto_core::engine::jupyter::kernel_scope();
+        pollster::block_on(pipeline.run())
+    };
+    let mut summary = match run_result {
         Ok(s) => s,
         Err(QuartoError::Parse(parse_error)) => {
             if args.json_errors {
@@ -923,7 +931,15 @@ fn execute_project(
         pipeline = pipeline.with_mode(RenderMode::Subset(set));
     }
 
-    let mut summary = match pollster::block_on(pipeline.run()) {
+    // bd-hxhnnlzs: one kernel scope for the whole project render, so
+    // documents sharing a (kernel, dir) session key reuse one warm
+    // kernel. Scoped to the `block_on` because the error paths below
+    // call `std::process::exit`, which skips destructors.
+    let run_result = {
+        let _kernel_scope = quarto_core::engine::jupyter::kernel_scope();
+        pollster::block_on(pipeline.run())
+    };
+    let mut summary = match run_result {
         Ok(s) => s,
         Err(QuartoError::Parse(parse_error)) => {
             if args.json_errors {

--- a/crates/quarto/tests/integration/jupyter_kernel_cleanup_e2e.rs
+++ b/crates/quarto/tests/integration/jupyter_kernel_cleanup_e2e.rs
@@ -1,0 +1,207 @@
+//! bd-hxhnnlzs: `q2 render` must not orphan Jupyter kernels. Before
+//! this fix, every render of a jupyter document left its kernel
+//! running forever (reparented to PID 1, ~6 listening sockets, stale
+//! `kernel-*.json` in the Jupyter runtime dir) because the kernel
+//! daemon lives in a process-global static whose sessions are never
+//! shut down and never dropped.
+//!
+//! This drives the real `q2` binary the way a user would, isolating
+//! kernel connection files via `JUPYTER_RUNTIME_DIR` (honored by
+//! `runtimelib::dirs::runtime_dir()`). A watcher thread records each
+//! kernel's ports while the render runs; after the process exits the
+//! test asserts every observed kernel is dead and its connection file
+//! removed.
+//!
+//! The project fixture has TWO python documents in the same directory
+//! on purpose: they share a daemon session key, and the render-scoped
+//! kernel scope must keep the kernel warm across documents (exactly
+//! one kernel observed) while still shutting it down at the end.
+//!
+//! Skips when the jupyter engine isn't installed — same gating as the
+//! quarto-core engine tests.
+
+use std::net::TcpStream;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
+
+fn jupyter_available() -> bool {
+    quarto_core::engine::EngineRegistry::default()
+        .get("jupyter")
+        .is_some_and(|e| e.is_available())
+}
+
+/// Ports recorded from one observed `kernel-*.json` connection file.
+#[derive(Debug, Clone)]
+struct ObservedKernel {
+    file_name: String,
+    shell_port: u16,
+    control_port: u16,
+}
+
+/// Poll `dir` for `kernel-*.json` files until `stop` is set, recording
+/// each distinct file's ports. A partially-written file simply fails
+/// to parse and retries on the next tick.
+fn watch_connection_files(
+    dir: PathBuf,
+    stop: Arc<AtomicBool>,
+) -> std::thread::JoinHandle<Vec<ObservedKernel>> {
+    std::thread::spawn(move || {
+        let mut seen: Vec<ObservedKernel> = Vec::new();
+        while !stop.load(Ordering::Relaxed) {
+            if let Ok(entries) = std::fs::read_dir(&dir) {
+                for entry in entries.flatten() {
+                    let name = entry.file_name().to_string_lossy().into_owned();
+                    if !(name.starts_with("kernel-") && name.ends_with(".json")) {
+                        continue;
+                    }
+                    if seen.iter().any(|k| k.file_name == name) {
+                        continue;
+                    }
+                    let Ok(text) = std::fs::read_to_string(entry.path()) else {
+                        continue;
+                    };
+                    let Ok(json) = serde_json::from_str::<serde_json::Value>(&text) else {
+                        continue;
+                    };
+                    let port = |key: &str| {
+                        json.get(key)
+                            .and_then(|v| v.as_u64())
+                            .map_or(0, |p| p as u16)
+                    };
+                    let (shell_port, control_port) = (port("shell_port"), port("control_port"));
+                    if shell_port != 0 && control_port != 0 {
+                        seen.push(ObservedKernel {
+                            file_name: name,
+                            shell_port,
+                            control_port,
+                        });
+                    }
+                }
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        seen
+    })
+}
+
+/// True while something accepts TCP connections on `port`.
+fn port_is_open(port: u16) -> bool {
+    TcpStream::connect_timeout(&([127, 0, 0, 1], port).into(), Duration::from_millis(250)).is_ok()
+}
+
+/// Wait (bounded) for a teardown condition; returns whether it held.
+fn eventually(deadline: Duration, mut cond: impl FnMut() -> bool) -> bool {
+    let start = Instant::now();
+    loop {
+        if cond() {
+            return true;
+        }
+        if start.elapsed() > deadline {
+            return false;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+fn remaining_connection_files(dir: &Path) -> Vec<String> {
+    std::fs::read_dir(dir)
+        .map(|entries| {
+            entries
+                .flatten()
+                .map(|e| e.file_name().to_string_lossy().into_owned())
+                .filter(|n| n.starts_with("kernel-") && n.ends_with(".json"))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+#[test]
+fn render_leaves_no_kernel_behind() {
+    if !jupyter_available() {
+        eprintln!("Skipping test: jupyter not available");
+        return;
+    }
+
+    let dir = tempfile::tempdir().unwrap();
+    let project_dir = dir.path().join("proj");
+    std::fs::create_dir_all(&project_dir).unwrap();
+    std::fs::write(
+        project_dir.join("_quarto.yml"),
+        "project:\n  type: website\n",
+    )
+    .unwrap();
+    std::fs::write(
+        project_dir.join("a.qmd"),
+        "---\ntitle: a\nengine: jupyter\n---\n\n```{python}\nprint(\"doc-a\")\n```\n",
+    )
+    .unwrap();
+    std::fs::write(
+        project_dir.join("b.qmd"),
+        "---\ntitle: b\nengine: jupyter\n---\n\n```{python}\nprint(\"doc-b\")\n```\n",
+    )
+    .unwrap();
+
+    let runtime_dir = dir.path().join("jupyter-runtime");
+    std::fs::create_dir_all(&runtime_dir).unwrap();
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let watcher = watch_connection_files(runtime_dir.clone(), stop.clone());
+
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_q2"))
+        .arg("render")
+        .arg(&project_dir)
+        .env("JUPYTER_RUNTIME_DIR", &runtime_dir)
+        .output()
+        .expect("q2 render runs");
+
+    stop.store(true, Ordering::Relaxed);
+    let observed = watcher.join().unwrap();
+
+    assert!(
+        output.status.success(),
+        "q2 render failed.\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    // Both documents actually executed their cells.
+    for (doc, needle) in [("a.html", "doc-a"), ("b.html", "doc-b")] {
+        let html =
+            std::fs::read_to_string(project_dir.join("_site").join(doc)).expect("rendered output");
+        assert!(html.contains(needle), "{doc} contains executed output");
+    }
+
+    // The render-scoped kernel pool keeps one kernel warm across the
+    // two documents (same kernel + working dir → same session); more
+    // than one observed kernel means per-document restarts crept in.
+    assert_eq!(
+        observed.len(),
+        1,
+        "expected the two python docs to share one kernel, observed: {observed:?}"
+    );
+
+    // bd-hxhnnlzs: after the q2 process exits, the kernel must be dead
+    // and its connection file removed.
+    let kernel = &observed[0];
+    for (label, port) in [
+        ("shell", kernel.shell_port),
+        ("control", kernel.control_port),
+    ] {
+        assert!(
+            eventually(Duration::from_secs(5), || !port_is_open(port)),
+            "kernel {} still listening on {} port {} after q2 render exited — \
+             the kernel process leaked (bd-hxhnnlzs)",
+            kernel.file_name,
+            label,
+            port,
+        );
+    }
+    assert!(
+        eventually(Duration::from_secs(5), || {
+            remaining_connection_files(&runtime_dir).is_empty()
+        }),
+        "stale connection files left after q2 render exited: {:?} (bd-hxhnnlzs)",
+        remaining_connection_files(&runtime_dir),
+    );
+}

--- a/crates/quarto/tests/integration/main.rs
+++ b/crates/quarto/tests/integration/main.rs
@@ -8,6 +8,7 @@ pub mod create;
 pub mod extension_config_spans;
 pub mod get_config_cli;
 pub mod json_errors;
+pub mod jupyter_kernel_cleanup_e2e;
 pub mod preview_cli;
 pub mod render_cli_e2e;
 pub mod render_exit_codes;


### PR DESCRIPTION
## Summary

Fixes the Jupyter kernel process leak (bd-hxhnnlzs): every process that executed a Jupyter document — the test suite and `q2 render` alike — leaked one ipykernel process per (kernel, working dir). 2338 orphans had accumulated on one dev machine, each reparented to PID 1 and holding ~6 listening sockets, plus 4932 stale `kernel-*.json` connection files.

**Root cause:** kernel sessions live in a process-global `static DAEMON`, statics never drop, so the kernel `Child`'s `kill_on_drop` never fired and nothing ever called `shutdown_all()` (the idle reaper had zero callers).

**Fix — refcounted `KernelScope`:**
- The jupyter engine's `execute_qmd` holds an inner scope around each engine run, so *no caller can leak by accident*.
- Outer scopes in `q2 render` (around `pipeline.run()`, dropped before any `process::exit`), `q2 preview`, and `q2 provide-hub` (server lifetime) keep kernels warm across documents / re-renders.
- When the last scope drops, all sessions are shut down: `shutdown_request` on the control channel (when a private runtime is possible), SIGKILL backstop, bounded reap, connection-file removal.

**Two adjacent latent bugs surfaced by the new e2e test, both fixed:**
- **Startup TOCTOU:** concurrent renders sharing a session key both spawned kernels (read-check → multi-second spawn → insert; the loser was evicted and killed). Every two-doc project render hit this. Now serialized behind a `start_lock` with a re-check.
- **Cross-call session reuse never actually worked:** sessions held ZeroMQ sockets and the kernel `Child` bound to a per-call throwaway tokio runtime, so genuine reuse failed with "Tokio context … being shutdown" (masked by the TOCTOU race always re-spawning). Sessions now live on a shared long-lived `ENGINE_RUNTIME`.

Also deletes the never-called idle-timeout machinery and adds panic-safety scopes to the direct-daemon-API tests.

## Tests (TDD — written first, verified failing pre-fix)

- `quarto-core` `jupyter_kernel_cleanup.rs`: drives `record_capture` under an isolated `JUPYTER_RUNTIME_DIR`, records each spawned kernel's ports from its connection file, asserts ports are dead + files removed when it returns.
- `quarto` `jupyter_kernel_cleanup_e2e.rs`: drives the real `q2` binary on a two-python-doc website; asserts **exactly one** kernel served both docs (pinning warm reuse) and nothing survives process exit.
- Both skip when jupyter isn't installed, same gating as the existing engine tests.

## Verification

- `cargo nextest run --workspace`: 11273/11273 passed, **zero orphaned kernels after the run** (previously ~15 per run).
- Full `cargo xtask verify` (incl. WASM leg) and `cargo xtask lint`: green.
- Manual end-to-end: `cargo run --bin q2 -- render <two-python-doc website>` → "Rendered 2 of 2 files", executed outputs present in both HTML files, zero orphan processes, zero stale connection files (output inspected).
- The two `#[ignore]`d `jupyter_integration` pipeline tests fail on main with a pre-existing nested-runtime panic — filed as bd-yaccefzk, not a regression from this change.

Plan/findings: `claude-notes/plans/2026-08-10-jupyter-kernel-leak.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)