### PR TITLE
Callout: honor the title= attribute (bd-callout-custom-title-dropped-9qi1p7iw)

### DIFF
--- a/claude-notes/plans/2026-08-10-callout-title-attribute.md
+++ b/claude-notes/plans/2026-08-10-callout-title-attribute.md
@@ -8,8 +8,8 @@ q2-side strand above is the one to work.
 **Branch:** `braid/callout-title-attribute`, off `origin/main` @ `b2b6100c`.
 (Investigated on `docs/feature-porting-process`; cherry-picked across once main
 was current.)
-**Status:** Design settled — see "Decisions" below. Ready to implement,
-starting with Phase 0 tests.
+**Status:** Implemented. All phases complete; workspace suite green
+(11471/11471). Verified end to end — see `observed-output.md`, "After".
 
 ## Triage verdict
 
@@ -266,26 +266,70 @@ the ipynb design both need.
 
 ## Phases
 
-- **Phase 0 — Tests first (TDD).** Failing tests for: attribute only; heading
-  only; both (warning + one consumed); markdown in the attribute (code span in
-  the header); block-syntax value (warning, content ignored); empty attribute
-  (falls back to heading); H1 heading as title; and the `screen-reader-only`
-  span appearing for an attribute title. Plus a span assertion pinning the
-  exact-mapping cases.
-- **Phase 1 — Title source selection in `convert_div_to_callout`.**
-  Attribute-first with heading fallback; move the header removal into the
-  fallback branch; drop the `level >= 2` check; warn when both are present.
-- **Phase 2 — Parse + source mapping.** `parse_config_string_as_markdown` with
-  the length-derived parent above; `PandocInlines` straight through,
-  single-paragraph `PandocBlocks` unwrapped, everything else warned and
-  dropped. Use the guarded `theorem.rs:336-360` pattern for the index lookup.
-- **Phase 3 — Diagnostics.** Register the new warning(s) in
-  `quarto-error-catalog` if they need codes; confirm wording and spans against
-  the fixture.
-- **Phase 4 — End-to-end verification.** `q2 render` the fixture, inspect the
-  emitted `callout-title-container`, record invocation + output snippet per the
-  repo's end-to-end rule.
-- **Phase 5 — Docs**, if callout titles are documented under `docs/`.
+Error codes claimed: **Q-2-43** (title given twice) and **Q-2-44** (title
+attribute is not inline content). Highest existing is Q-2-42.
+
+### Phase 0 — Tests first (TDD)
+
+- [x] Real-source test helper (`parse_and_transform`) — parses qmd and returns
+      the parse's own `SourceContext`, so span assertions are meaningful
+- [x] Unit test: attribute-only title populates the title slot
+- [x] Unit test: heading-only title still works (regression — passes today)
+- [x] Unit test: both present → Q-2-43 warning, exactly one consumed
+- [x] Unit test: markdown in the attribute → code span in the title slot
+- [x] Unit test: block-syntax value → Q-2-44 warning, content ignored
+- [x] Unit test: `title=""` falls back to the heading (passes today)
+- [x] Unit test: H1 heading supplies the title (level check removed)
+- [x] Span test: exact mapping for a quoted, escape-free value
+- [x] Span test: exact mapping for a bare, unquoted value
+- [x] Span test: escaped value takes the bounded fallback, stays inside the
+      attribute extent
+- [x] Confirm every new test fails for the expected reason — 8 fail (empty
+      title slot / H1 ignored / no warning), 2 pass as intended regressions.
+      No compile or setup artifacts.
+- [x] HTML fixture: attribute title renders with the `screen-reader-only` span
+      (`crates/quarto/tests/smoke-all/quarto-test/callout-title-attribute.qmd`)
+
+### Phase 1 — Title source selection
+
+- [x] Read `title` first in `convert_div_to_callout`, heading as fallback
+- [x] Move the header removal into the fallback branch only
+- [x] Drop the `level >= 2` check
+- [x] Emit Q-2-43 when both are present (plus diagnostics threading through
+      `transform_blocks`/`transform_block`, which had no sink before)
+
+### Phase 2 — Parse + source mapping
+
+- [x] Length-derived parent `SourceInfo` (exact / exact / bounded-fallback) —
+      `attribute_value_source`
+- [x] `parse_config_string_as_markdown`; `PandocInlines` through,
+      single-paragraph `PandocBlocks` unwrapped, else Q-2-44
+- [x] Guarded `theorem.rs:336-360` index lookup for the value span
+
+### Phase 3 — Diagnostics
+
+- [x] Register Q-2-43 and Q-2-44 in `quarto-error-catalog`
+- [x] Verify wording and spans against the fixture — Q-2-43 renders with a
+      caret on the offending callout (repro.qmd:38)
+
+### Phase 4 — Verification
+
+- [x] `cargo nextest run --workspace` green — 11471/11471 passed (exit 0).
+      A first fail-fast run tripped `quarto-hub …collect_lifecycle_quarantine_restore_purge`;
+      that is the known flake bd-u0tldu4z (passes in isolation, green on the
+      complete rerun of the identical tree). Recurrence recorded on the strand.
+- [ ] `cargo xtask verify` (WASM leg — quarto-core is in hub-client's closure)
+- [x] End-to-end `q2 render` of the fixture; record invocation + output
+      (see `observed-output.md`, "After" section)
+- [ ] Review snapshot churn; count and summarize in the commit message
+
+### Phase 5 — Docs
+
+- [x] Error pages `docs/errors/markdown/Q-2-43.qmd` and `Q-2-44.qmd` (the
+      catalog's `docs_url` points at them; note Q-2-42 shipped without one, so
+      the convention is manual and unenforced)
+- [ ] No callouts *feature* page exists under `docs/` at all — `title=` has no
+      home to be documented in. Out of scope here; worth its own strand.
 
 ## Risks / tradeoffs
 
@@ -308,5 +352,42 @@ the ipynb design both need.
   parse are wrong regardless. Only matters if a re-parsed title itself contains
   an attribute; noted, not addressed here.
 - **`theorem.rs:317-319` documents the value span incorrectly** (claims it
-  excludes the quotes; the grammar includes them). Worth correcting while we
-  are here.
+  excludes the quotes; the grammar includes them). Filed as bd-bhxeoqoj.
+- **Shared-helper wart, accepted.** On an unparseable value
+  `parse_config_string_as_markdown` emits a Q-1-20 warning and wraps the text
+  in a span classed `yaml-markdown-syntax-error` (`meta.rs:87-115`) — YAML
+  wording on a div attribute. Reaching it requires markdown that fails to parse
+  as inline content, which is close to unreachable here, so this is noted
+  rather than worked around; fixing it belongs in the helper, not in callouts.
+
+## Discovered during implementation: two escaping layers
+
+Escaping a `#` in a callout title needs **two** backslashes, not one, and
+the reason is worth recording because it will surprise authors.
+
+Two independent unescape steps run in sequence:
+
+1. **The attribute layer** — `unescape_punctuation` collapses `\X` → `X`
+   for any ASCII punctuation, before anything markdown-related happens.
+2. **The markdown parser**, which has its own backslash-escape rules.
+
+Verified by render, not reasoned:
+
+| written | attribute layer stores | markdown reads | result |
+|---|---|---|---|
+| `title="\# Overview"` | `# Overview` | a heading | Q-2-44; title ignored |
+| `title="\\# Overview"` | `\# Overview` | escaped `#` | renders `# Overview` |
+
+The single-backslash form is the intuitive one and is exactly wrong: the
+attribute layer eats the backslash, handing the parser a bare `#`, which
+is the block content the author was trying to avoid.
+
+Pinned by `double_backslash_escapes_a_leading_hash` and
+`single_backslash_hash_is_still_a_heading`, and documented in
+`docs/errors/markdown/Q-2-44.qmd`.
+
+This is a *consequence* of the same two-representation split that causes
+the span drift (bd-mxa44voa) — the value the parser sees is not the text
+the author wrote. It is not a bug introduced here; it is pre-existing
+attribute behavior that only becomes reachable once attribute values are
+parsed as markdown.

--- a/claude-notes/plans/2026-08-10-callout-title-attribute.md
+++ b/claude-notes/plans/2026-08-10-callout-title-attribute.md
@@ -5,10 +5,11 @@
 **Origin strand:** `br-de85v0a8` — in the **connect-docs porting skein**, a
 *different* braid project. It does not resolve against the q2 skein; the
 q2-side strand above is the one to work.
-**Branch:** investigated on `docs/feature-porting-process` @ `d1a8ac9f` (the
-checkout the skill was invoked in — see "Where this should land" below).
-**Status:** Investigation — pending design alignment with user. **Do not start
-implementation until the user gives the go-ahead.**
+**Branch:** `braid/callout-title-attribute`, off `origin/main` @ `b2b6100c`.
+(Investigated on `docs/feature-porting-process`; cherry-picked across once main
+was current.)
+**Status:** Design settled — see "Decisions" below. Ready to implement,
+starting with Phase 0 tests.
 
 ## Triage verdict
 
@@ -160,65 +161,152 @@ Two smaller observations: `title=` is preserved on the outer div in every case
 literal empty `title=""` attribute (case 7) — Q1's behavior there was not
 checked.
 
-## Proposed phases (draft)
+## Decisions (settled with the user, 2026-08-10)
 
-- **Phase 0 — Reproduce + test plan (TDD).** Run `q2 render` on the fixture and
-  capture actual output. Write failing tests for: attribute only, heading only,
-  both (attribute wins, heading retained in body), markdown in the attribute,
-  empty attribute value (falls back to heading), and the `screen-reader-only`
-  span appearing for an attribute title.
-- **Phase 1 — Read `title` in `convert_div_to_callout`.** Attribute-first with
-  heading fallback; strip the leading header *only* in the fallback branch.
-- **Phase 2 — Title inlines + source attribution.** Whichever of plain-`Str` vs
-  markdown-parse the design questions settle on, with the theorem.rs-style
-  guarded span lookup.
-- **Phase 3 — End-to-end verification.** `q2 render` the fixture, inspect the
-  emitted `callout-title-container`, record the invocation and output snippet
-  per the repo's end-to-end rule.
-- **Phase 4 — Docs**, if callout titles are documented under `docs/`.
+1. **Full markdown parse of the attribute value.** Match Q1. Performance is
+   explicitly deferred — titles are tiny documents, and the fixed cost of
+   spinning up a tree-sitter parse is accepted for now.
+2. **`PandocBlocks` result:** if it is a single block containing a single
+   paragraph, take its inlines. Anything else → emit a **warning diagnostic**
+   and ignore the attribute's content.
+3. **Attribute + heading both present:** emit a **warning** and consume either
+   one (which one does not matter — it is almost certainly an authoring
+   mistake). This is a deliberate, warned divergence from Q1, which silently
+   prefers the attribute and leaves the heading in the body.
+4. **Heading level:** remove the `level >= 2` check at `callout.rs:202` so any
+   `Header` can supply the title, matching Q1's `resolveHeadingCaption`.
+5. **Branch:** `braid/callout-title-attribute`, off `origin/main`. No worktree —
+   this checkout is not shared.
 
-## Open design questions for the user
+## Source-mapping design (the ancillary problem)
 
-1. **Markdown in the attribute value: match Q1, or plain text?** Q1 parses
-   `title=` with `string_to_quarto_ast_inlines`, so `title="Use \`renv\`"`
-   renders a code span. The helper to do this exists and is already used from a
-   transform, so the faithful option is cheap — but it costs a full tree-sitter
-   document parse per attribute-titled callout, and `theorem.rs` sets the
-   opposite in-tree precedent (plain `Inline::Str` for `name=`). Full parity, or
-   plain `Str` now with parity deferred to its own strand?
-2. **If we parse: what to do with a `PandocBlocks` result?** A value containing
-   block syntax (or a blank line) returns `PandocBlocks`, which a title slot
-   cannot hold. Flatten to inlines (there is a `blocks_to_inlines` in
-   `title_block.rs:161`), or fall back to literal text? Q1's helper effectively
-   never produces this, so there is no Q1 answer to copy.
-3. **Both `title=` and a leading heading — match Q1 exactly?** Confirmed by the
-   repro (case 5) that q2 currently does the opposite of Q1 on *both* counts:
-   the heading wins and is consumed. Q1 lets the attribute win and leaves the
-   heading in the body, which renders what looks like a duplicate title. Mirror
-   Q1 exactly, or take the attribute but also consume the heading (arguably
-   nicer output, definite parity break)? And should q2 warn when both are
-   present? Q1 emits none, but this repo's diagnostics culture might justify
-   one.
-4. **Adjacent divergence — heading level.** Q1's `resolveHeadingCaption` accepts
-   *any* `Header`; q2 requires `level >= 2` (`callout.rs:202`), so an H1-led
-   callout takes the title path in Q1 but not in q2. In scope here, out of
-   scope, or file as a separate strand?
-5. **Where should this land?** The skill ran in the main checkout on
-   `docs/feature-porting-process`, which is a docs branch — a poor home for a
-   callout fix. I have committed only the plan + fixture there. Recommend a
-   worktree (`cargo xtask create-worktree bd-callout-custom-title-dropped-9qi1p7iw
-   --base main`) for the implementation; per the skill I have not created one.
+Re-parsing the attribute value is not just "call the parser." The value handed
+to the parser is **not** the text its `SourceInfo` describes, so naive nesting
+produces silently wrong locations.
 
-## Risks / tradeoffs (draft)
+### Why the obvious approach is wrong
 
-- **Low blast radius, high confidence.** The change is confined to the title
-  slot's construction; `callout_resolve.rs` already implements the correct Q1
-  shape and needs no edit. Everything downstream (the `screen-reader-only` span,
-  `callout-titled`) starts working by consequence.
-- **Snapshot churn.** Any existing callout snapshots for attribute-titled
-  callouts will change (title text plus a new `screen-reader-only` span). Per
-  the repo's snapshot rule, count and summarize these in the commit message.
-- **The `AttrSourceInfo` alignment invariant is known-broken** in two parser
-  paths (bd-3aolj, bd-1e6a5). Use the guarded theorem.rs pattern rather than
-  indexing blind; do not treat those bugs as blockers.
-- **Not verified end-to-end yet** — see the repro note above.
+`SourceInfo::substring(parent, start, end)` composes a **purely affine** map:
+`resolve_byte_range` computes `parent_start + start_offset`
+(`quarto-source-map-0.1.0/src/source_info.rs:194-200`, `:388-403`), with no
+validation, no clamping, and no access to any text. The nested reader feeds it
+byte offsets into the *inner* string
+(`crates/pampa/src/pandoc/location.rs:213-218`).
+
+But the two texts differ:
+
+- `Attr.2["title"]` is stored **unescaped and unquoted** —
+  `extract_quoted_text` strips the delimiters and `unescape_punctuation`
+  collapses `\X` → `X` for ASCII punctuation
+  (`crates/pampa/src/pandoc/treesitter_utils/text_helpers.rs:28-59`), called
+  from `treesitter.rs:1207-1212`.
+- `AttrSourceInfo.attributes[i].1` spans the **raw text including both
+  quotes** — the grammar aliases a token containing the delimiters
+  (`crates/tree-sitter-qmd/tree-sitter-markdown/grammar.js:580-585`), and
+  `commonmark_attribute.rs:39-51` records the full node range.
+
+Measured on a real render (`observed-output.md` and the probe below): for
+`title="Say \"hello\" now"` the stored value is 15 bytes while the span covers
+19. Passing the span as `parent_source_info` shifts every inline by +1 (the
+opening quote) and by one more byte per collapsed escape.
+
+Worked example, `` title="Use `renv` today" `` with the value span starting at
+byte 81: the `` `renv` `` code span sits at inner bytes 4..10, which maps to
+85..91, while its true location is 86..92.
+
+This is not merely a diagnostics concern: `SourceInfo::preimage_in` feeds the
+incremental writer's verbatim-copy decision, and a drifted range there can copy
+the wrong bytes.
+
+### Precedent: the mechanism is solved, the mapping is not
+
+- **Mechanism (fine).** `parse_config_string_as_markdown`
+  (`crates/pampa/src/pandoc/meta.rs:34`) is sync, wasm-safe, and already called
+  from an `AstTransform` at
+  `crates/quarto-core/src/transforms/config_markdown.rs:164`.
+- **Mapping (unsolved, tree-wide).** The YAML path has exactly this bug:
+  `quarto-yaml`'s `compute_scalar_len` spans the quotes while the *decoded*
+  scalar is handed to the nested parse, and nothing compensates. The design doc
+  `claude-notes/plans/2026-07-20-ipynb-surface-syntax-design.md:73-92` states
+  the constraint outright — `Substring`/`Concat` compose only affine maps, a
+  `Transformed` variant once existed and was removed as unused, and the YAML
+  analogue "currently punts."
+- **The one exemplary case** is cell options
+  (`crates/quarto-core/src/cell_options/mod.rs:33-43`), which stays exact
+  precisely because it never unescapes — it reassembles a `SourceInfo::concat`
+  of per-line substrings so every byte is a real source byte.
+
+### What we will do
+
+Detect drift **from lengths alone** — the span length is the raw length, and
+the value's length is known, so no source text is required. Let
+`span_len = end - start` of `attributes[i].1` and `n = value.len()`:
+
+| condition | meaning | parent to pass |
+|---|---|---|
+| `span_len == n` | bare, unquoted value | `substring(src, 0, n)` — **exact** |
+| `span_len == n + 2` | quoted, no escapes collapsed | `substring(src, 1, 1 + n)` — **exact** |
+| otherwise | escapes were collapsed | whole-value span — approximate |
+
+This needs no new infrastructure and no access to `SourceContext` (which is
+`Option` on `RenderContext` and can be content-stripped by
+`SourceContext::without_content()`, so depending on it would be fragile).
+
+The fallback is **bounded and safe, not merely tolerable**: unescaping only ever
+shrinks the string, so every mapped offset stays inside the attribute's raw
+extent. The error is at most `1 + #escapes` bytes and can never point at a
+neighbouring attribute. The exact path covers every case in our fixture and all
+~25 affected Connect pages; only a title containing a backslash escape takes
+the approximate path.
+
+Exact non-affine mapping (an offset map through the unescape, emitting
+`SourceInfo::concat` pieces around each escape) is deliberately **out of scope
+here** and filed separately — it is the same infrastructure the YAML path and
+the ipynb design both need.
+
+## Phases
+
+- **Phase 0 — Tests first (TDD).** Failing tests for: attribute only; heading
+  only; both (warning + one consumed); markdown in the attribute (code span in
+  the header); block-syntax value (warning, content ignored); empty attribute
+  (falls back to heading); H1 heading as title; and the `screen-reader-only`
+  span appearing for an attribute title. Plus a span assertion pinning the
+  exact-mapping cases.
+- **Phase 1 — Title source selection in `convert_div_to_callout`.**
+  Attribute-first with heading fallback; move the header removal into the
+  fallback branch; drop the `level >= 2` check; warn when both are present.
+- **Phase 2 — Parse + source mapping.** `parse_config_string_as_markdown` with
+  the length-derived parent above; `PandocInlines` straight through,
+  single-paragraph `PandocBlocks` unwrapped, everything else warned and
+  dropped. Use the guarded `theorem.rs:336-360` pattern for the index lookup.
+- **Phase 3 — Diagnostics.** Register the new warning(s) in
+  `quarto-error-catalog` if they need codes; confirm wording and spans against
+  the fixture.
+- **Phase 4 — End-to-end verification.** `q2 render` the fixture, inspect the
+  emitted `callout-title-container`, record invocation + output snippet per the
+  repo's end-to-end rule.
+- **Phase 5 — Docs**, if callout titles are documented under `docs/`.
+
+## Risks / tradeoffs
+
+- **Low blast radius on the rendering side.** `callout_resolve.rs` already
+  implements the correct Q1 shape and needs no edit; the
+  `screen-reader-only` span and `callout-titled` start working by consequence.
+- **Snapshot churn.** Attribute-titled callout snapshots will change (title
+  text plus a new `screen-reader-only` span). Per the repo's snapshot rule,
+  count and summarize them in the commit message and flag anything surprising.
+- **Warning on attribute+heading is a deliberate parity break** (decision 3).
+  Q1 is silent here. If the Connect docs turn out to use both together at any
+  scale, revisit before shipping.
+- **Removing the `level >= 2` check may change existing documents** where an H1
+  inside a callout was previously left in the body. Grep the corpus and check
+  snapshots.
+- **`AttrSourceInfo` positional alignment is known-broken** on duplicate keys
+  (bd-3aolj, bd-1e6a5) — use the guarded pattern, do not index blind.
+- **`commonmark_attribute.rs:44-49` fabricates `Original { FileId(0) }`**,
+  ignoring `parent_source_info` — so attribute spans produced *inside* a nested
+  parse are wrong regardless. Only matters if a re-parsed title itself contains
+  an attribute; noted, not addressed here.
+- **`theorem.rs:317-319` documents the value span incorrectly** (claims it
+  excludes the quotes; the grammar includes them). Worth correcting while we
+  are here.

--- a/claude-notes/plans/2026-08-10-callout-title-attribute.md
+++ b/claude-notes/plans/2026-08-10-callout-title-attribute.md
@@ -1,0 +1,224 @@
+# Callout `title=` attribute is ignored; header shows the type name instead of the author's title (bd-callout-custom-title-dropped-9qi1p7iw)
+
+**Date:** 2026-08-10
+**Braid:** `bd-callout-custom-title-dropped-9qi1p7iw` (P1, bug, label `parity`)
+**Origin strand:** `br-de85v0a8` — in the **connect-docs porting skein**, a
+*different* braid project. It does not resolve against the q2 skein; the
+q2-side strand above is the one to work.
+**Branch:** investigated on `docs/feature-porting-process` @ `d1a8ac9f` (the
+checkout the skill was invoked in — see "Where this should land" below).
+**Status:** Investigation — pending design alignment with user. **Do not start
+implementation until the user gives the go-ahead.**
+
+## Triage verdict
+
+**Ready to design.** The strand's root-cause analysis is accurate at HEAD, the
+fix site is a single function, the "parse a string as markdown inlines" helper
+the Q1-faithful fix needs already exists and is already called from an
+`AstTransform`, and there is a close in-tree precedent for the attribute-span
+handling. What is left is a genuine design choice (how faithful to Q1's
+markdown-parsing of the attribute, and how much adjacent divergence to absorb),
+which is what the questions below are for.
+
+## Issue context
+
+Filed 2026-08-10 by Carlos Scheidegger, so its assumptions are current — none
+of the usual "stale strand" risk. A callout written as
+
+```markdown
+::: {.callout-note title="Off-Host Execution"}
+:::
+```
+
+renders a header reading "Note". The author's title survives only as the
+`title=` attribute on the outer div (which Q1 also emits, so that part is
+correct). The output is otherwise a well-formed titled callout: `callout-titled`
+is set and `callout-title-container` is present — its *content* is the injected
+type display name.
+
+Q1 emits:
+
+```html
+<div class="callout-title-container flex-fill"><span class="screen-reader-only">Note</span>Off-Host Execution</div>
+```
+
+**Impact:** ~25 pages of the Posit Connect docs, which use the attribute form
+throughout. Readers see an unlabeled "Note"/"Warning"/"Important". No warning is
+emitted. Because the title is never marked user-supplied, the
+`screen-reader-only` type span is also skipped, so a titled and an untitled
+callout are indistinguishable to assistive technology — one fix addresses both.
+
+## Dependency graph
+
+**Empty.** `braid dep list` returns no edges and `braid dep tree` shows the
+strand alone. No incoming `blocks` pressure and no `discovered-from` parent in
+*this* skein — the "why filed" context lives in the connect-docs porting skein
+(`br-de85v0a8`) and, usefully, was copied verbatim into the description.
+
+Context therefore comes from the `parity` label instead. That cohort is 21
+strands from the same porting effort; 12 are closed, and the closed ones
+(`bd-named-entities-w6xbfftj`, `bd-obkvhlam`, `bd-fz6gwfq0`, …) are the model
+for how this kind of work usually lands here: a narrow Q1-behavior-matching fix
+plus focused regression tests. `bd-email-autolink-dropped-2jj38iiv` is the
+currently in-progress sibling of the same shape.
+
+## What the code looks like today
+
+Both files named in the strand exist and still have the shape described.
+
+- `crates/quarto-core/src/transforms/callout.rs:199-206` —
+  `convert_div_to_callout` builds `title_inlines` **only** from a leading
+  `Header` block. It reads `appearance`, `collapse`, and `icon` through
+  `extract_attr_value(&div.attr, …)` at `:209-214` but never reads `"title"`.
+  So the title slot set at `:253` is empty for an attribute-titled callout.
+- `crates/quarto-core/src/transforms/callout_resolve.rs:255-265` — with an
+  empty title and `appearance == "default"`, `resolve_callout` injects
+  `callout_display_name(...)` and sets `title_is_user_supplied = false`, which
+  at `:274-291` skips the `screen-reader-only` span. Both branches are correct
+  Q1 mirrors; they are simply fed the wrong input.
+
+**No existing test covers the attribute form.** `grep` over
+`crates/quarto-core/tests/` finds callout title hits only in language-term
+tests. The unit test at `callout.rs:388` (`test_convert_callout_with_title`)
+exercises the Header path only.
+
+### Q1's actual precedence (read, not assumed)
+
+`external-sources/quarto-cli/src/resources/filters/customnodes/callout.lua:48-50`:
+
+```lua
+local title = string_to_quarto_ast_inlines(div.attr.attributes["title"] or "")
+if not title or #title == 0 then
+  title = resolveHeadingCaption(div)
+end
+```
+
+Two consequences worth pinning down before implementing:
+
+1. **The attribute value is parsed as markdown inlines**, so
+   `title="Use \`renv\`"` yields a code span in the header.
+2. **The leading heading is only *removed* inside `resolveHeadingCaption`**
+   (`external-sources/quarto-cli/src/resources/filters/common/pandoc.lua:130-138`
+   does `div.content:remove(1)`). When `title=` is non-empty that function is
+   never called, so **a leading heading stays in the callout body**. A naive
+   port that strips the header unconditionally would diverge here.
+
+Q1 clears `appearance`/`collapse`/`icon` from `div.attr` but leaves `title` in
+place, matching what q2 already emits.
+
+### The helper the faithful fix needs already exists
+
+`pampa::pandoc::meta::parse_config_string_as_markdown(&str, &SourceInfo, &mut Vec<DiagnosticMessage>) -> ConfigValueKind`
+(`crates/pampa/src/pandoc/meta.rs:34`) is synchronous, needs no parser handle,
+is wasm-safe, and is **already called from an `AstTransform`** —
+`crates/quarto-core/src/transforms/config_markdown.rs:164`. It returns
+`PandocInlines` when the parse yields a single paragraph and `PandocBlocks`
+otherwise, and never fails (a parse error becomes a Q-1-20 warning plus a
+literal-text span). Passing a real parent `SourceInfo` makes every produced node
+a `SourceInfo::substring` of it — no throwaway `FileId`.
+
+### Precedent for reading the attribute's source span
+
+`AttrSourceInfo.attributes[i]` is the `(key_src, val_src)` for the i-th entry of
+the `LinkedHashMap` in insertion order
+(`crates/quarto-pandoc-types/src/attr.rs:52-56` and the invariant comment at
+`:28-50`). That invariant is **known-broken in two parser paths** (bd-3aolj,
+bd-1e6a5), so the documented pattern is a length guard plus `debug_assert` with
+a `None` fallback. `crates/quarto-core/src/transforms/theorem.rs:336-360` is
+the canonical example — and is a very close analogue, since it turns a `name=`
+attribute into title inlines. Note it produces a plain `Inline::Str` rather
+than markdown-parsing the value, which is one of the consistency questions
+below.
+
+### Repro
+
+Committed at `claude-notes/plans/callout-title-attribute-investigation/repro.qmd`,
+covering seven cases: attribute-titled, other type, untitled control,
+heading-titled, **both** (attribute wins, heading stays), markdown-in-attribute,
+and empty attribute (falls back to heading). The upstream two-case repro lives
+outside this repo at
+`/Users/cscheid/repos/github/cscheid/q2-connect-docs/llms-info/repros/callout-custom-title-dropped/`;
+the local copy is the durable one.
+
+**Reproduced end-to-end at HEAD.** `cargo run --bin q2 -- render …/repro.qmd`
+(exit 0, no warnings); the emitted `callout-title-container` for each case is
+recorded in
+`claude-notes/plans/callout-title-attribute-investigation/observed-output.md`.
+Cases 1, 2, and 6 drop the title as reported; cases 3, 4, and 7 are correct.
+
+**Case 5 is a divergence the strand did not call out**, and it changes the
+shape of the fix. With both `title=` and a leading heading, q2 lets the
+**heading win** *and* **consumes it from the body**; Q1 gives the attribute
+precedence *and* leaves the heading in the body. So the two behaviors are
+independent: adding an attribute-first branch fixes precedence but, if the
+existing unconditional header-strip stays where it is, the body is still wrong.
+Phase 1 has to move the removal into the fallback branch, not just reorder the
+lookup.
+
+Two smaller observations: `title=` is preserved on the outer div in every case
+(so the fix must read it without removing it), and `title=""` is emitted as a
+literal empty `title=""` attribute (case 7) — Q1's behavior there was not
+checked.
+
+## Proposed phases (draft)
+
+- **Phase 0 — Reproduce + test plan (TDD).** Run `q2 render` on the fixture and
+  capture actual output. Write failing tests for: attribute only, heading only,
+  both (attribute wins, heading retained in body), markdown in the attribute,
+  empty attribute value (falls back to heading), and the `screen-reader-only`
+  span appearing for an attribute title.
+- **Phase 1 — Read `title` in `convert_div_to_callout`.** Attribute-first with
+  heading fallback; strip the leading header *only* in the fallback branch.
+- **Phase 2 — Title inlines + source attribution.** Whichever of plain-`Str` vs
+  markdown-parse the design questions settle on, with the theorem.rs-style
+  guarded span lookup.
+- **Phase 3 — End-to-end verification.** `q2 render` the fixture, inspect the
+  emitted `callout-title-container`, record the invocation and output snippet
+  per the repo's end-to-end rule.
+- **Phase 4 — Docs**, if callout titles are documented under `docs/`.
+
+## Open design questions for the user
+
+1. **Markdown in the attribute value: match Q1, or plain text?** Q1 parses
+   `title=` with `string_to_quarto_ast_inlines`, so `title="Use \`renv\`"`
+   renders a code span. The helper to do this exists and is already used from a
+   transform, so the faithful option is cheap — but it costs a full tree-sitter
+   document parse per attribute-titled callout, and `theorem.rs` sets the
+   opposite in-tree precedent (plain `Inline::Str` for `name=`). Full parity, or
+   plain `Str` now with parity deferred to its own strand?
+2. **If we parse: what to do with a `PandocBlocks` result?** A value containing
+   block syntax (or a blank line) returns `PandocBlocks`, which a title slot
+   cannot hold. Flatten to inlines (there is a `blocks_to_inlines` in
+   `title_block.rs:161`), or fall back to literal text? Q1's helper effectively
+   never produces this, so there is no Q1 answer to copy.
+3. **Both `title=` and a leading heading — match Q1 exactly?** Confirmed by the
+   repro (case 5) that q2 currently does the opposite of Q1 on *both* counts:
+   the heading wins and is consumed. Q1 lets the attribute win and leaves the
+   heading in the body, which renders what looks like a duplicate title. Mirror
+   Q1 exactly, or take the attribute but also consume the heading (arguably
+   nicer output, definite parity break)? And should q2 warn when both are
+   present? Q1 emits none, but this repo's diagnostics culture might justify
+   one.
+4. **Adjacent divergence — heading level.** Q1's `resolveHeadingCaption` accepts
+   *any* `Header`; q2 requires `level >= 2` (`callout.rs:202`), so an H1-led
+   callout takes the title path in Q1 but not in q2. In scope here, out of
+   scope, or file as a separate strand?
+5. **Where should this land?** The skill ran in the main checkout on
+   `docs/feature-porting-process`, which is a docs branch — a poor home for a
+   callout fix. I have committed only the plan + fixture there. Recommend a
+   worktree (`cargo xtask create-worktree bd-callout-custom-title-dropped-9qi1p7iw
+   --base main`) for the implementation; per the skill I have not created one.
+
+## Risks / tradeoffs (draft)
+
+- **Low blast radius, high confidence.** The change is confined to the title
+  slot's construction; `callout_resolve.rs` already implements the correct Q1
+  shape and needs no edit. Everything downstream (the `screen-reader-only` span,
+  `callout-titled`) starts working by consequence.
+- **Snapshot churn.** Any existing callout snapshots for attribute-titled
+  callouts will change (title text plus a new `screen-reader-only` span). Per
+  the repo's snapshot rule, count and summarize these in the commit message.
+- **The `AttrSourceInfo` alignment invariant is known-broken** in two parser
+  paths (bd-3aolj, bd-1e6a5). Use the guarded theorem.rs pattern rather than
+  indexing blind; do not treat those bugs as blockers.
+- **Not verified end-to-end yet** — see the repro note above.

--- a/claude-notes/plans/callout-title-attribute-investigation/escape-drift-probe.md
+++ b/claude-notes/plans/callout-title-attribute-investigation/escape-drift-probe.md
@@ -1,0 +1,87 @@
+# Probe: attribute values are unescaped, but their spans are raw
+
+Evidence behind the source-mapping design in the plan. Run against
+`origin/main` @ `b2b6100c`.
+
+## Input
+
+```markdown
+::: {.callout-note title="Say \"hello\" now"}
+Body.
+:::
+
+::: {.callout-tip title="Use `renv` today"}
+Body.
+:::
+```
+
+## Invocation
+
+```
+cargo run --bin pampa -- --to json <file>
+```
+
+## Result
+
+The JSON carries `kvs` as `[key_source_id, value_source_id]` pairs into the
+`astContext.p` table of ranges.
+
+| | stored value | value span | raw bytes at that span |
+|---|---|---|---|
+| callout 1 | `Say "hello" now` (15 B) | `[25,44]` (19 B) | `"Say \"hello\" now"` |
+| callout 2 | `` Use `renv` today `` (16 B) | `[81,99]` (18 B) | ``"Use `renv` today"`` |
+
+Raw bytes confirmed with `dd if=<file> bs=1 skip=25 count=19`.
+
+So: **the stored value is unescaped and unquoted; the span is raw and
+quote-inclusive.** The two texts are not the same string, and the difference is
+not a constant shift.
+
+## Why that breaks naive nesting
+
+`SourceInfo::substring(parent, start, end)` is affine — `resolve_byte_range`
+does `parent_start + start_offset`
+(`quarto-source-map-0.1.0/src/source_info.rs:388-403`) — and the nested reader
+supplies offsets into the *inner* string
+(`crates/pampa/src/pandoc/location.rs:213-218`).
+
+Worked example, callout 2 (value span starts at byte 81):
+
+```
+inner:  U  s  e     `  r  e  n  v  `     t  o  d  a  y
+index:  0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15
+raw:   82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97
+```
+
+The `` `renv` `` code span is at inner `4..10`. Naive substring maps it to
+`85..91`. Its true location is `86..92` — off by one, the opening quote, with
+no escape involved. Each collapsed `\X` adds another byte of drift.
+
+Drift is one-directional: unescaping only ever shrinks, so `inner_len ≤
+span_len - 2` and every mapped offset stays *inside* the attribute's raw
+extent. Wrong, but bounded and never spilling into a neighbouring attribute —
+which is what makes the coarse fallback safe.
+
+## Where the transformation happens
+
+- `crates/pampa/src/pandoc/treesitter.rs:1207-1212` — `key_value_value` node:
+  stores `extract_quoted_text(text)` but keeps `node_location(node)` (the full,
+  quote-inclusive range).
+- `crates/pampa/src/pandoc/treesitter_utils/text_helpers.rs:28-59` —
+  `extract_quoted_text` strips delimiters; `unescape_punctuation` collapses
+  `\X` → `X` for ASCII punctuation, preserving `\` before non-punctuation and a
+  lone trailing `\`.
+- `crates/tree-sitter-qmd/tree-sitter-markdown/grammar.js:580-585` — the
+  aliased token includes the quote characters, which is why the span does.
+
+## Corollary: the same bug exists in the YAML path
+
+`quarto-yaml`'s `compute_scalar_len` deliberately spans the quotes ("which is
+what a diagnostic wants to underline") while `parse_config_string_as_markdown`
+is handed the *decoded* scalar
+(`crates/pampa/src/pandoc/meta.rs:59-66`, `:240-330`). Nothing compensates. See
+`claude-notes/plans/2026-07-20-ipynb-surface-syntax-design.md:73-92`, which
+states the affine-only constraint and notes the YAML analogue "currently
+punts."
+
+Filed separately; not a blocker for the callout fix.

--- a/claude-notes/plans/callout-title-attribute-investigation/escape-drift-probe.qmd
+++ b/claude-notes/plans/callout-title-attribute-investigation/escape-drift-probe.qmd
@@ -1,0 +1,7 @@
+::: {.callout-note title="Say \"hello\" now"}
+Body.
+:::
+
+::: {.callout-tip title="Use `renv` today"}
+Body.
+:::

--- a/claude-notes/plans/callout-title-attribute-investigation/observed-output.md
+++ b/claude-notes/plans/callout-title-attribute-investigation/observed-output.md
@@ -1,0 +1,67 @@
+# Observed output at HEAD (`docs/feature-porting-process` @ `d1a8ac9f`)
+
+Invocation, run from the repo root after `cargo xtask verify --skip-hub-build`
+passed (exit 0):
+
+```
+cargo run --quiet --bin q2 -- render claude-notes/plans/callout-title-attribute-investigation/repro.qmd
+```
+
+Exit 0, no warnings emitted. The generated `repro.html` / `repro_files/` were
+inspected and then deleted (build artifacts); the relevant fragments are quoted
+below verbatim.
+
+## `callout-title-container` contents, case by case
+
+| # | Fixture case | Rendered header | Q1-correct? |
+|---|---|---|---|
+| 1 | `title="Off-Host Execution"` | `Note` | ❌ title dropped |
+| 2 | `title="Data loss on deployment"` (warning) | `Warning` | ❌ title dropped |
+| 3 | untitled control | `Note` | ✅ |
+| 4 | heading title | `<span class="screen-reader-only">Note</span>Heading title` | ✅ |
+| 5 | **both** attribute + heading | `<span class="screen-reader-only">Note</span>This heading should remain in the body` | ❌ twice — heading won *and* was consumed |
+| 6 | markdown in attribute (`` `renv` ``) | `Tip` | ❌ title dropped |
+| 7 | `title=""` + heading | `<span class="screen-reader-only">Note</span>Fallback heading` | ✅ (incidentally — the attribute is ignored either way) |
+
+Raw fragments for the two most informative cases:
+
+```html
+<!-- case 1: the author's title survives only in the attribute -->
+<div class="callout callout-style-default callout-note callout-titled" title="Off-Host Execution">
+<div class="callout-header d-flex align-content-center">
+<div class="callout-icon-container">
+<i class="callout-icon"></i>
+</div>
+<div class="callout-title-container flex-fill">
+Note
+</div>
+</div>
+```
+
+```html
+<!-- case 5: heading wins over the attribute AND is removed from the body -->
+<div class="callout callout-style-default callout-note callout-titled" title="Attribute wins">
+...
+<div class="callout-title-container flex-fill">
+<span class="screen-reader-only">Note</span>This heading should remain in the body
+</div>
+</div>
+<div class="callout-body-container callout-body">
+<p>Body text.</p>
+</div>
+```
+
+## What this adds beyond the strand's description
+
+1. **The bug is confirmed at HEAD**, not merely inferred from code reading.
+2. **Case 5 is a *double* divergence** the strand did not call out. Q1 gives the
+   attribute precedence and leaves the heading in the body; q2 does the opposite
+   on both counts — the heading supplies the title and is consumed. A fix that
+   only adds an attribute branch without touching the heading-removal placement
+   would fix precedence and still leave the body wrong.
+3. **`title=` is preserved on the outer div** in every case, matching Q1 — so
+   the fix must read the attribute without removing it.
+4. **`title=""` renders as `title=""`** on the div (case 7). Worth deciding
+   whether an empty attribute should be emitted at all; Q1's behavior here was
+   not checked.
+5. **No diagnostic is emitted** in any case.

--- a/claude-notes/plans/callout-title-attribute-investigation/observed-output.md
+++ b/claude-notes/plans/callout-title-attribute-investigation/observed-output.md
@@ -1,4 +1,9 @@
-# Observed output at HEAD (`docs/feature-porting-process` @ `d1a8ac9f`)
+# Observed output — before and after the fix
+
+The "Before" section below is the baseline captured during investigation; the
+"After" section is the same fixture re-rendered once the fix landed.
+
+## Before (`docs/feature-porting-process` @ `d1a8ac9f`)
 
 Invocation, run from the repo root after `cargo xtask verify --skip-hub-build`
 passed (exit 0):
@@ -65,3 +70,65 @@ Note
    whether an empty attribute should be emitted at all; Q1's behavior here was
    not checked.
 5. **No diagnostic is emitted** in any case.
+
+---
+
+# After (branch `braid/callout-title-attribute`)
+
+Same invocation:
+
+```
+cargo run --quiet --bin q2 -- render claude-notes/plans/callout-title-attribute-investigation/repro.qmd
+```
+
+Exit 0. **One warning**, which is the intended new behavior:
+
+```
+Warning: [Q-2-43] Callout title given twice
+   ╭─[ …/repro.qmd:38:1 ]
+38 │╭─▶ ::: {.callout-note title="Attribute wins"}
+   ┆┆
+42 │├─▶ :::
+   │╰──────── This callout carries both a `title=` attribute and a leading
+   │          heading. The `title=` attribute is used and the heading is dropped.
+```
+
+The caret lands on the offending callout (case 5), not on a sibling.
+
+## `callout-title-container` contents, case by case
+
+| # | Fixture case | Rendered header | Q1-correct? |
+|---|---|---|---|
+| 1 | `title="Off-Host Execution"` | `<span class="screen-reader-only">Note</span>Off-Host Execution` | ✅ byte-identical to Q1 |
+| 2 | `title="Data loss on deployment"` (warning) | `<span class="screen-reader-only">Warning</span>Data loss on deployment` | ✅ |
+| 3 | untitled control | `Note` | ✅ unchanged, still no SR span |
+| 4 | heading title | `<span class="screen-reader-only">Note</span>Heading title` | ✅ unchanged |
+| 5 | **both** attribute + heading | `<span class="screen-reader-only">Note</span>Attribute wins` | ✅ attribute wins (Q1 precedence) + Q-2-43 |
+| 6 | markdown in attribute | `<span class="screen-reader-only">Tip</span>Use <code>renv</code> for reproducibility` | ✅ code span parsed |
+| 7 | `title=""` + heading | `<span class="screen-reader-only">Note</span>Fallback heading` | ✅ unchanged |
+
+Case 1 now matches the markup quoted in the strand's Q1 reference exactly.
+
+## Case 5 body — the heading is consumed
+
+```html
+<div class="callout callout-style-default callout-note callout-titled" title="Attribute wins">
+...
+<div class="callout-title-container flex-fill">
+<span class="screen-reader-only">Note</span>Attribute wins
+</div>
+</div>
+<div class="callout-body-container callout-body">
+<p>Body text.</p>
+</div>
+```
+
+`grep -c 'This heading should remain in the body' repro.html` → **0**. This is
+the deliberate, warned divergence from Q1 (decision 3): Q1 would leave the
+heading here, reading as a duplicate title.
+
+## Verification note
+
+The output above was read directly from the generated `repro.html`, not
+inferred from exit status. The HTML and its `_files/` directory were deleted
+afterwards as build artifacts; only this record is kept.

--- a/claude-notes/plans/callout-title-attribute-investigation/repro.qmd
+++ b/claude-notes/plans/callout-title-attribute-investigation/repro.qmd
@@ -1,0 +1,57 @@
+---
+title: Callout custom title
+---
+
+Case 1 — attribute-titled callout (the reported bug). Expected header:
+`<span class="screen-reader-only">Note</span>Off-Host Execution`.
+
+::: {.callout-note title="Off-Host Execution"}
+The author-supplied title should appear in the callout header.
+:::
+
+Case 2 — another type, to show it is not note-specific.
+
+::: {.callout-warning title="Data loss on deployment"}
+Same for other callout types.
+:::
+
+Case 3 — control: untitled callout. Header should show the type name
+("Note") with NO screen-reader-only span.
+
+::: {.callout-note}
+No custom title here.
+:::
+
+Case 4 — heading-titled callout (already works today). Header should
+show "Heading title" preceded by the screen-reader-only "Note".
+
+::: {.callout-note}
+## Heading title
+
+Body text.
+:::
+
+Case 5 — BOTH attribute and heading. Per Q1, the attribute wins AND the
+heading stays in the body (Q1 only strips the heading inside
+`resolveHeadingCaption`, which is not called when `title=` is non-empty).
+
+::: {.callout-note title="Attribute wins"}
+## This heading should remain in the body
+
+Body text.
+:::
+
+Case 6 — markdown inside the attribute value. Q1 parses it with
+`string_to_quarto_ast_inlines`, so this should render a code span.
+
+::: {.callout-tip title="Use `renv` for reproducibility"}
+Body text.
+:::
+
+Case 7 — empty attribute value: falls back to the heading branch.
+
+::: {.callout-note title=""}
+## Fallback heading
+
+Body text.
+:::

--- a/crates/quarto-core/src/transforms/callout.rs
+++ b/crates/quarto-core/src/transforms/callout.rs
@@ -36,10 +36,14 @@
 //! - `plain_data`: `{"type": "warning", "appearance": "default", ...}`
 //! - `attr`: Original Div attributes
 
-use quarto_pandoc_types::attr::Attr;
+use quarto_error_reporting::{DiagnosticMessage, DiagnosticMessageBuilder};
+use quarto_pandoc_types::attr::{Attr, AttrSourceInfo};
 use quarto_pandoc_types::block::{Block, Div};
+use quarto_pandoc_types::config_value::ConfigValueKind;
 use quarto_pandoc_types::custom::{CustomNode, Slot};
+use quarto_pandoc_types::inline::Inline;
 use quarto_pandoc_types::pandoc::Pandoc;
+use quarto_source_map::{By, SourceInfo};
 use serde_json::json;
 
 use crate::Result;
@@ -81,52 +85,62 @@ impl AstTransform for CalloutTransform {
 
     async fn transform(&self, ast: &mut Pandoc, ctx: &mut RenderContext) -> Result<()> {
         let registry = ctx.ref_type_registry.as_ref();
-        transform_blocks(&mut ast.blocks, registry);
+        let mut diagnostics: Vec<DiagnosticMessage> = Vec::new();
+        transform_blocks(&mut ast.blocks, registry, &mut diagnostics);
+        ctx.diagnostics.extend(diagnostics);
         Ok(())
     }
 }
 
 /// Transform a vector of blocks, converting callout Divs to CustomNodes.
-fn transform_blocks(blocks: &mut Vec<Block>, registry: Option<&RefTypeRegistry>) {
+fn transform_blocks(
+    blocks: &mut Vec<Block>,
+    registry: Option<&RefTypeRegistry>,
+    diagnostics: &mut Vec<DiagnosticMessage>,
+) {
     for block in blocks.iter_mut() {
-        transform_block(block, registry);
+        transform_block(block, registry, diagnostics);
     }
 }
 
 /// Transform a single block, potentially converting it to a CustomNode.
-fn transform_block(block: &mut Block, registry: Option<&RefTypeRegistry>) {
+fn transform_block(
+    block: &mut Block,
+    registry: Option<&RefTypeRegistry>,
+    diagnostics: &mut Vec<DiagnosticMessage>,
+) {
     // First, recursively transform any nested blocks
     match block {
         Block::BlockQuote(bq) => {
-            transform_blocks(&mut bq.content, registry);
+            transform_blocks(&mut bq.content, registry, diagnostics);
         }
         Block::OrderedList(ol) => {
             for item in &mut ol.content {
-                transform_blocks(item, registry);
+                transform_blocks(item, registry, diagnostics);
             }
         }
         Block::BulletList(bl) => {
             for item in &mut bl.content {
-                transform_blocks(item, registry);
+                transform_blocks(item, registry, diagnostics);
             }
         }
         Block::DefinitionList(dl) => {
             for (_term, defs) in &mut dl.content {
                 for def in defs {
-                    transform_blocks(def, registry);
+                    transform_blocks(def, registry, diagnostics);
                 }
             }
         }
         Block::Figure(fig) => {
-            transform_blocks(&mut fig.content, registry);
+            transform_blocks(&mut fig.content, registry, diagnostics);
         }
         Block::Div(div) => {
             // First transform nested content
-            transform_blocks(&mut div.content, registry);
+            transform_blocks(&mut div.content, registry, diagnostics);
 
             // Then check if this div is a callout and convert it
             if let Some(callout_type) = extract_callout_type(&div.attr) {
-                let custom = convert_div_to_callout(div, &callout_type, registry);
+                let custom = convert_div_to_callout(div, &callout_type, registry, diagnostics);
                 *block = Block::Custom(custom);
             }
         }
@@ -135,20 +149,20 @@ fn transform_block(block: &mut Block, registry: Option<&RefTypeRegistry>) {
             for body in &mut table.bodies {
                 for row in &mut body.body {
                     for cell in &mut row.cells {
-                        transform_blocks(&mut cell.content, registry);
+                        transform_blocks(&mut cell.content, registry, diagnostics);
                     }
                 }
             }
             // Transform table head
             for row in &mut table.head.rows {
                 for cell in &mut row.cells {
-                    transform_blocks(&mut cell.content, registry);
+                    transform_blocks(&mut cell.content, registry, diagnostics);
                 }
             }
             // Transform table foot
             for row in &mut table.foot.rows {
                 for cell in &mut row.cells {
-                    transform_blocks(&mut cell.content, registry);
+                    transform_blocks(&mut cell.content, registry, diagnostics);
                 }
             }
         }
@@ -156,8 +170,8 @@ fn transform_block(block: &mut Block, registry: Option<&RefTypeRegistry>) {
             // Transform blocks inside custom node slots
             for (_name, slot) in &mut custom.slots {
                 match slot {
-                    Slot::Block(b) => transform_block(b, registry),
-                    Slot::Blocks(bs) => transform_blocks(bs, registry),
+                    Slot::Block(b) => transform_block(b, registry, diagnostics),
+                    Slot::Blocks(bs) => transform_blocks(bs, registry, diagnostics),
                     _ => {}
                 }
             }
@@ -192,18 +206,54 @@ fn convert_div_to_callout(
     div: &mut Div,
     callout_type: &str,
     registry: Option<&RefTypeRegistry>,
+    diagnostics: &mut Vec<DiagnosticMessage>,
 ) -> CustomNode {
     let mut content_blocks = std::mem::take(&mut div.content);
-    let mut title_inlines = Vec::new();
 
-    // Check if the first block is a Header - if so, use it as the title
-    if let Some(Block::Header(header)) = content_blocks.first() {
-        // Only use H2 or lower as title (H1 would be document title)
-        if header.level >= 2 {
-            title_inlines = header.content.clone();
-            content_blocks.remove(0);
-        }
+    // Title precedence mirrors Q1's `callout.lua:48-50`: the `title=`
+    // attribute wins over a leading heading. Q1 accepts *any* header
+    // level (`resolveHeadingCaption`), so there is no level test here.
+    let attr_title = title_from_attribute(&div.attr, &div.attr_source, diagnostics);
+    let has_heading = matches!(content_blocks.first(), Some(Block::Header(_)));
+
+    // Where Q1 silently leaves the heading in the body when `title=` also
+    // supplies a title, we warn and consume it: carrying both is almost
+    // always an authoring mistake, and rendering the heading underneath a
+    // different title reads as a duplicate.
+    // (bd-callout-custom-title-dropped-9qi1p7iw, decision 3.)
+    if attr_title.is_some() && has_heading {
+        diagnostics.push(
+            DiagnosticMessageBuilder::warning("Callout title given twice")
+                .with_code("Q-2-43")
+                .problem(
+                    "This callout carries both a `title=` attribute and a leading heading. \
+                     The `title=` attribute is used and the heading is dropped.",
+                )
+                .with_location(div.source_info.clone())
+                .build(),
+        );
     }
+
+    let title_inlines = match attr_title {
+        Some(inlines) => {
+            if has_heading {
+                content_blocks.remove(0);
+            }
+            inlines
+        }
+        // Fall back to the leading heading. The removal lives *inside*
+        // this branch on purpose — Q1 only strips the header within
+        // `resolveHeadingCaption`, which it never reaches when `title=`
+        // is present.
+        None => match content_blocks.first() {
+            Some(Block::Header(header)) => {
+                let inlines = header.content.clone();
+                content_blocks.remove(0);
+                inlines
+            }
+            _ => Vec::new(),
+        },
+    };
 
     // Extract additional attributes from the div
     let appearance_raw =
@@ -264,6 +314,139 @@ fn extract_attr_value(attr: &Attr, key: &str) -> Option<String> {
     attrs.get(key).cloned()
 }
 
+/// Parse the `title=` attribute as markdown inlines, per Q1's
+/// `string_to_quarto_ast_inlines(div.attr.attributes["title"])`.
+///
+/// Returns `None` when the attribute is absent, empty, or does not reduce
+/// to inline content — in each case the caller falls back to a leading
+/// heading. The `title=` key is deliberately left on `div.attr`; Q1 keeps
+/// it on the rendered div, and so do we.
+fn title_from_attribute(
+    attr: &Attr,
+    attr_source: &AttrSourceInfo,
+    diagnostics: &mut Vec<DiagnosticMessage>,
+) -> Option<Vec<Inline>> {
+    let value = attr.2.get("title")?;
+    if value.is_empty() {
+        return None;
+    }
+
+    let parent = attribute_value_source(attr, attr_source, "title", value.len());
+
+    match pampa::pandoc::meta::parse_config_string_as_markdown(value, &parent, diagnostics) {
+        ConfigValueKind::PandocInlines(inlines) => Some(inlines),
+        ConfigValueKind::PandocBlocks(blocks) => match single_paragraph_inlines(blocks) {
+            Some(inlines) => Some(inlines),
+            None => {
+                diagnostics.push(
+                    DiagnosticMessageBuilder::warning(
+                        "Callout `title=` is not usable as inline content",
+                    )
+                    .with_code("Q-2-44")
+                    .problem(
+                        "A callout title must be a single line of inline markdown. \
+                         This value parses to block content, so it is ignored.",
+                    )
+                    .with_location(parent.clone())
+                    .build(),
+                );
+                None
+            }
+        },
+        _ => None,
+    }
+}
+
+/// Unwrap a single-paragraph (or single-`Plain`) block list to its inlines.
+fn single_paragraph_inlines(blocks: Vec<Block>) -> Option<Vec<Inline>> {
+    let mut iter = blocks.into_iter();
+    let first = iter.next()?;
+    if iter.next().is_some() {
+        return None;
+    }
+    match first {
+        Block::Paragraph(p) => Some(p.content),
+        Block::Plain(p) => Some(p.content),
+        _ => None,
+    }
+}
+
+/// The `SourceInfo` to use as the parent of a re-parsed attribute value.
+///
+/// This is subtler than it looks. `Attr.2` stores the value **unescaped
+/// and unquoted** (`extract_quoted_text` → `unescape_punctuation` in
+/// `pampa::pandoc::treesitter_utils::text_helpers`), while the recorded
+/// span covers the **raw, quote-inclusive** source, because the grammar
+/// token includes its delimiters. `SourceInfo::substring` composes only
+/// *affine* maps, so handing it the raw span shifts every parsed node by
+/// one (the opening quote) plus one more byte per collapsed escape — the
+/// same latent drift the YAML path has.
+///
+/// We do not need the source text to detect this: the span's length *is*
+/// the raw length, and the value's length is known.
+///
+/// | `span_len` vs `n` | meaning                    | result             |
+/// |-------------------|----------------------------|--------------------|
+/// | `== n`            | bare, unquoted value       | exact (as-is)      |
+/// | `== n + 2`        | quoted, no escapes         | exact (skip quote) |
+/// | otherwise         | escapes were collapsed     | bounded fallback   |
+///
+/// The fallback is safe rather than merely tolerable: unescaping only ever
+/// shrinks the string, so every mapped offset stays inside the attribute's
+/// own raw extent. The error is at most `1 + escapes` bytes and can never
+/// point at a neighbouring attribute.
+///
+/// Exact non-affine mapping is tracked by bd-mxa44voa, which is shared
+/// with the YAML and ipynb paths.
+fn attribute_value_source(
+    attr: &Attr,
+    attr_source: &AttrSourceInfo,
+    key: &str,
+    value_len: usize,
+) -> SourceInfo {
+    let generated = || SourceInfo::generated(By::callout());
+
+    let Some(index) = attr.2.keys().position(|k| k == key) else {
+        return generated();
+    };
+
+    // `AttrSourceInfo.attributes[i]` is positionally aligned with `Attr.2`
+    // in insertion order, but that invariant is broken on duplicate keys
+    // (bd-3aolj / bd-1e6a5). Guard rather than index blind — the pattern
+    // is borrowed from `theorem.rs`.
+    debug_assert!(
+        attr_source.attributes.is_empty() || attr.2.len() == attr_source.attributes.len(),
+        "AttrSourceInfo.attributes is out of sync with Attr.2 (bd-3aolj / bd-1e6a5): kvs={}, attr_source={}",
+        attr.2.len(),
+        attr_source.attributes.len(),
+    );
+    if attr.2.len() != attr_source.attributes.len() {
+        return generated();
+    }
+
+    let Some(value_source) = attr_source.attributes[index].1.clone() else {
+        return generated();
+    };
+
+    match value_source.resolve_byte_range() {
+        Some((_file_id, start, end)) if end >= start => {
+            let span_len = end - start;
+            if span_len == value_len {
+                // Bare value: the span already is the value's text.
+                value_source
+            } else if span_len == value_len + 2 {
+                // Quoted with nothing collapsed: step past the opening
+                // quote and the mapping is exact.
+                SourceInfo::substring(value_source, 1, 1 + value_len)
+            } else {
+                // Escapes were collapsed; no affine map exists.
+                value_source
+            }
+        }
+        _ => value_source,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -310,6 +493,312 @@ mod tests {
             vec![format!("callout-{}", callout_type)],
             hashlink::LinkedHashMap::new(),
         )
+    }
+
+    // ---------------------------------------------------------------
+    // `title=` attribute support (bd-callout-custom-title-dropped-9qi1p7iw)
+    //
+    // These tests parse REAL qmd text rather than hand-building a Div.
+    // That is load-bearing for two reasons:
+    //
+    //   1. The attribute value reaches `Attr.2` already *unescaped and
+    //      unquoted*, while its `AttrSourceInfo` span covers the raw,
+    //      quote-inclusive source. A hand-built fixture cannot express
+    //      that mismatch, so a wrong span would be invisible.
+    //   2. `SourceInfo::for_test()`-style spans are synthetic; per
+    //      `quarto_config::span_assert`'s module docs, span assertions
+    //      are only meaningful against text that was actually parsed.
+    // ---------------------------------------------------------------
+
+    /// Parse `text` as qmd and run `CalloutTransform` over it.
+    ///
+    /// Returns the transformed AST, the diagnostics the transform
+    /// emitted, and the `SourceContext` the parse produced (so spans can
+    /// be resolved back to the very bytes this text supplied).
+    async fn parse_and_transform(
+        text: &str,
+    ) -> (
+        Pandoc,
+        Vec<quarto_error_reporting::DiagnosticMessage>,
+        quarto_source_map::SourceContext,
+    ) {
+        let (mut ast, ast_context, _parse_diags) = pampa::readers::qmd::read(
+            text.as_bytes(),
+            false,
+            "test.qmd",
+            &mut std::io::sink(),
+            false,
+            None,
+        )
+        .expect("fixture should parse");
+
+        let project = make_test_project();
+        let doc = DocumentInfo::from_path("/project/doc.qmd");
+        let format = Format::html();
+        let binaries = BinaryDependencies::new();
+        let mut ctx = RenderContext::new(&project, &doc, &format, &binaries);
+
+        CalloutTransform::new()
+            .transform(&mut ast, &mut ctx)
+            .await
+            .unwrap();
+
+        (ast, ctx.diagnostics, ast_context.source_context)
+    }
+
+    /// The title slot's inlines for the first callout in `ast`.
+    fn title_inlines(ast: &Pandoc) -> &[quarto_pandoc_types::inline::Inline] {
+        let Some(Block::Custom(custom)) = ast.blocks.iter().find(|b| matches!(b, Block::Custom(_)))
+        else {
+            panic!("expected a Custom callout block; got {:?}", ast.blocks);
+        };
+        match custom.get_slot("title") {
+            Some(Slot::Inlines(inlines)) => inlines,
+            other => panic!("expected an Inlines title slot; got {other:?}"),
+        }
+    }
+
+    /// The content slot's blocks for the first callout in `ast`.
+    fn content_blocks(ast: &Pandoc) -> &[Block] {
+        let Some(Block::Custom(custom)) = ast.blocks.iter().find(|b| matches!(b, Block::Custom(_)))
+        else {
+            panic!("expected a Custom callout block");
+        };
+        match custom.get_slot("content") {
+            Some(Slot::Blocks(blocks)) => blocks,
+            other => panic!("expected a Blocks content slot; got {other:?}"),
+        }
+    }
+
+    /// Flatten inlines to their visible text, so assertions can name the
+    /// title a reader would see.
+    fn inlines_text(inlines: &[quarto_pandoc_types::inline::Inline]) -> String {
+        use quarto_pandoc_types::inline::Inline;
+        let mut out = String::new();
+        for inline in inlines {
+            match inline {
+                Inline::Str(s) => out.push_str(&s.text),
+                Inline::Space(_) => out.push(' '),
+                Inline::Code(c) => out.push_str(&c.text),
+                Inline::Emph(e) => out.push_str(&inlines_text(&e.content)),
+                Inline::Strong(s) => out.push_str(&inlines_text(&s.content)),
+                Inline::Span(s) => out.push_str(&inlines_text(&s.content)),
+                // Straight quotes in the source become `Quoted` inlines
+                // (Pandoc's smart-quote handling); render the delimiters
+                // back so assertions can name what a reader sees.
+                Inline::Quoted(q) => {
+                    let delim = match q.quote_type {
+                        quarto_pandoc_types::inline::QuoteType::DoubleQuote => '"',
+                        quarto_pandoc_types::inline::QuoteType::SingleQuote => '\'',
+                    };
+                    out.push(delim);
+                    out.push_str(&inlines_text(&q.content));
+                    out.push(delim);
+                }
+                _ => {}
+            }
+        }
+        out
+    }
+
+    fn diag_with_code<'a>(
+        diags: &'a [quarto_error_reporting::DiagnosticMessage],
+        code: &str,
+    ) -> &'a quarto_error_reporting::DiagnosticMessage {
+        diags
+            .iter()
+            .find(|d| d.code.as_deref() == Some(code))
+            .unwrap_or_else(|| panic!("expected a {code} diagnostic; got: {diags:?}"))
+    }
+
+    #[tokio::test]
+    async fn attribute_title_populates_the_title_slot() {
+        let (ast, diags, _ctx) =
+            parse_and_transform("::: {.callout-note title=\"Off-Host Execution\"}\nBody.\n:::\n")
+                .await;
+
+        assert_eq!(inlines_text(title_inlines(&ast)), "Off-Host Execution");
+        assert!(
+            diags.is_empty(),
+            "a plain attribute title should warn about nothing; got {diags:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn heading_title_still_works() {
+        let (ast, _diags, _ctx) =
+            parse_and_transform("::: {.callout-note}\n## Heading Title\n\nBody.\n:::\n").await;
+
+        assert_eq!(inlines_text(title_inlines(&ast)), "Heading Title");
+        // The heading is consumed, leaving only the body paragraph.
+        assert_eq!(content_blocks(&ast).len(), 1);
+    }
+
+    #[tokio::test]
+    async fn attribute_title_wins_over_heading_and_warns() {
+        let (ast, diags, _ctx) = parse_and_transform(
+            "::: {.callout-note title=\"Attribute wins\"}\n## Heading loses\n\nBody.\n:::\n",
+        )
+        .await;
+
+        // Q1's precedence: the attribute supplies the title.
+        assert_eq!(inlines_text(title_inlines(&ast)), "Attribute wins");
+        // Deliberate divergence from Q1: we consume the heading too,
+        // rather than leaving a duplicate-looking title in the body.
+        assert_eq!(
+            content_blocks(&ast).len(),
+            1,
+            "the heading should be consumed, leaving only the body"
+        );
+        diag_with_code(&diags, "Q-2-43");
+    }
+
+    #[tokio::test]
+    async fn markdown_in_attribute_title_is_parsed() {
+        let (ast, _diags, _ctx) =
+            parse_and_transform("::: {.callout-tip title=\"Use `renv` today\"}\nBody.\n:::\n")
+                .await;
+
+        use quarto_pandoc_types::inline::Inline;
+        let inlines = title_inlines(&ast);
+        assert!(
+            inlines
+                .iter()
+                .any(|i| matches!(i, Inline::Code(c) if c.text == "renv")),
+            "expected a Code inline for `renv`; got {inlines:?}"
+        );
+        assert_eq!(inlines_text(inlines), "Use renv today");
+    }
+
+    #[tokio::test]
+    async fn empty_attribute_title_falls_back_to_heading() {
+        let (ast, _diags, _ctx) =
+            parse_and_transform("::: {.callout-note title=\"\"}\n## Fallback\n\nBody.\n:::\n")
+                .await;
+
+        assert_eq!(inlines_text(title_inlines(&ast)), "Fallback");
+    }
+
+    #[tokio::test]
+    async fn level_one_heading_supplies_the_title() {
+        // Q1's `resolveHeadingCaption` accepts any Header level; q2 used
+        // to require level >= 2, leaving an H1 sitting in the body.
+        let (ast, _diags, _ctx) =
+            parse_and_transform("::: {.callout-note}\n# Big Title\n\nBody.\n:::\n").await;
+
+        assert_eq!(inlines_text(title_inlines(&ast)), "Big Title");
+        assert_eq!(content_blocks(&ast).len(), 1);
+    }
+
+    // --- Source mapping -------------------------------------------------
+    //
+    // The value handed to the nested parse is NOT the text its SourceInfo
+    // describes (unescaped + unquoted vs. raw + quoted), and
+    // `SourceInfo::substring` composes only affine maps. These pin the
+    // cases where we can still be exact, and bound the one where we
+    // cannot. See claude-notes/plans/callout-title-attribute-investigation/
+    // escape-drift-probe.md.
+
+    #[tokio::test]
+    async fn quoted_title_spans_map_exactly() {
+        let text = "::: {.callout-tip title=\"Use `renv` today\"}\nBody.\n:::\n";
+        let (ast, _diags, ctx) = parse_and_transform(text).await;
+
+        use quarto_pandoc_types::inline::Inline;
+        let code = title_inlines(&ast)
+            .iter()
+            .find_map(|i| match i {
+                Inline::Code(c) if c.text == "renv" => Some(c),
+                _ => None,
+            })
+            .expect("expected a Code inline");
+
+        let resolved = quarto_config::span_assert::resolve_span(&code.source_info, &ctx)
+            .expect("code span should resolve");
+        assert_eq!(
+            resolved.text, "`renv`",
+            "the code span must underline the backticked source, not a shifted window"
+        );
+    }
+
+    #[tokio::test]
+    async fn bare_unquoted_title_spans_map_exactly() {
+        let text = "::: {.callout-note title=Solo}\nBody.\n:::\n";
+        let (ast, _diags, ctx) = parse_and_transform(text).await;
+
+        let inlines = title_inlines(&ast);
+        assert_eq!(inlines_text(inlines), "Solo");
+
+        let resolved = quarto_config::span_assert::resolve_span(inlines[0].source_info(), &ctx)
+            .expect("title span should resolve");
+        assert_eq!(resolved.text, "Solo");
+    }
+
+    #[tokio::test]
+    async fn escaped_title_span_stays_inside_the_attribute() {
+        // `\"` collapses to `"`, so the value is shorter than its span and
+        // the mapping cannot be affine. We accept a bounded error, but it
+        // must never point outside the attribute's own raw extent.
+        let text = "::: {.callout-note title=\"Say \\\"hi\\\" now\"}\nBody.\n:::\n";
+        let (ast, _diags, ctx) = parse_and_transform(text).await;
+
+        let inlines = title_inlines(&ast);
+        assert_eq!(inlines_text(inlines), "Say \"hi\" now");
+
+        let resolved = quarto_config::span_assert::resolve_span(inlines[0].source_info(), &ctx)
+            .expect("title span should resolve");
+        let attribute_extent = "\"Say \\\"hi\\\" now\"";
+        assert!(
+            attribute_extent.contains(resolved.text.trim()),
+            "span text {:?} escaped the attribute extent {:?}",
+            resolved.text,
+            attribute_extent
+        );
+    }
+
+    #[tokio::test]
+    async fn double_backslash_escapes_a_leading_hash() {
+        // Two escaping layers run in sequence: the attribute layer
+        // unescapes first (`\\` → `\`), then the markdown parser reads
+        // `\#` as a literal `#`. A single backslash is consumed by the
+        // first layer and leaves a real heading behind — see
+        // `single_backslash_hash_is_still_a_heading`. Documented in
+        // docs/errors/markdown/Q-2-44.qmd.
+        let (ast, diags, _ctx) =
+            parse_and_transform("::: {.callout-note title=\"\\\\# Overview\"}\nBody.\n:::\n").await;
+
+        assert_eq!(inlines_text(title_inlines(&ast)), "# Overview");
+        assert!(
+            diags.is_empty(),
+            "an escaped hash is valid inline content; got {diags:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn single_backslash_hash_is_still_a_heading() {
+        // The counterpart to the test above: `\#` survives the attribute
+        // layer as a bare `#`, so the value parses as a heading.
+        let (ast, diags, _ctx) =
+            parse_and_transform("::: {.callout-note title=\"\\# Overview\"}\nBody.\n:::\n").await;
+
+        diag_with_code(&diags, "Q-2-44");
+        assert!(
+            title_inlines(&ast).is_empty(),
+            "the block-valued title should be ignored, leaving the slot empty \
+             for the resolver's default-title injection"
+        );
+    }
+
+    #[tokio::test]
+    async fn block_valued_title_warns_and_is_ignored() {
+        // A value that parses to more than a single paragraph cannot fill
+        // an inline title slot.
+        let text = "::: {.callout-note title=\"# Heading\"}\n## Fallback\n\nBody.\n:::\n";
+        let (ast, diags, _ctx) = parse_and_transform(text).await;
+
+        diag_with_code(&diags, "Q-2-44");
+        // Contents ignored → the heading fallback supplies the title.
+        assert_eq!(inlines_text(title_inlines(&ast)), "Fallback");
     }
 
     #[tokio::test]

--- a/crates/quarto-error-catalog/error_catalog.json
+++ b/crates/quarto-error-catalog/error_catalog.json
@@ -1335,5 +1335,19 @@
     "message_template": "An `{{< include >}}` shortcode appears in a position where include expansion does not apply, so it was not expanded. Includes are only expanded when the shortcode is the sole content of its own paragraph. Put the shortcode on its own line, surrounded by blank lines.",
     "docs_url": "https://quarto.org/docs/errors/include/Q-17-4",
     "since_version": "99.9.9"
+  },
+  "Q-2-43": {
+    "subsystem": "markdown",
+    "title": "Callout Title Given Twice",
+    "message_template": "A callout carries both a `title=` attribute and a leading heading. Only one title can be shown, so the `title=` attribute is used and the heading is dropped. Quarto 1 silently prefers the attribute and leaves the heading in the callout body, where it reads as a duplicate title; Quarto 2 reports it instead, because carrying both is almost always an authoring mistake. Remove whichever of the two you did not intend.",
+    "docs_url": "https://quarto.org/docs/errors/markdown/Q-2-43",
+    "since_version": "99.9.9"
+  },
+  "Q-2-44": {
+    "subsystem": "markdown",
+    "title": "Callout Title Is Not Inline Content",
+    "message_template": "A callout's `title=` attribute is parsed as markdown, but it must reduce to a single line of inline content. This value parses to block content (for example it begins with `#`, or contains a blank line), so it cannot fill the callout's title and is ignored. Write the title as plain inline markdown, or move the block content into the callout body.",
+    "docs_url": "https://quarto.org/docs/errors/markdown/Q-2-44",
+    "since_version": "99.9.9"
   }
 }

--- a/crates/quarto/tests/smoke-all/quarto-test/callout-title-attribute.qmd
+++ b/crates/quarto/tests/smoke-all/quarto-test/callout-title-attribute.qmd
@@ -1,0 +1,26 @@
+---
+title: Callout title attribute
+format: html
+_quarto:
+  tests:
+    html:
+      ensureHtmlElements:
+        - ["div.callout-note.callout-titled", "div.callout-title-container span.screen-reader-only"]
+      ensureFileRegexMatches:
+        - ['<span class="screen-reader-only">Note</span>Off-Host Execution', "<code>renv</code>"]
+        - ["callout-title-container flex-fill\">\\s*Note\\s*</div>"]
+      noErrors: true
+---
+
+The author-supplied `title=` must appear in the header, with the callout
+type kept for screen readers only (Q1 parity).
+
+::: {.callout-note title="Off-Host Execution"}
+Body text.
+:::
+
+Markdown inside the attribute is parsed, so this renders a code span.
+
+::: {.callout-tip title="Use `renv` today"}
+Body text.
+:::

--- a/docs/errors/markdown/Q-2-43.qmd
+++ b/docs/errors/markdown/Q-2-43.qmd
@@ -1,0 +1,79 @@
+---
+title: "Callout title given twice"
+description: "A callout carries both a `title=` attribute and a leading heading; the attribute wins and the heading is dropped."
+code: Q-2-43
+subsystem: markdown
+status: stub
+since: "99.9.9"
+categories:
+  - markdown
+---
+
+# `Q-2-43` — Callout title given twice
+
+> This callout carries both a `title=` attribute and a leading heading.
+> The `title=` attribute is used and the heading is dropped.
+
+## What this means
+
+A callout can take its title from either of two places:
+
+```markdown
+::: {.callout-note title="From the attribute"}
+Body.
+:::
+
+::: {.callout-note}
+## From a heading
+
+Body.
+:::
+```
+
+Writing both in one callout is ambiguous. Quarto uses the `title=`
+attribute — matching Quarto 1's precedence — and drops the heading.
+
+## Why this happens
+
+- **Adding a title to a callout that already had one.** A `title=`
+  attribute gets added to a callout whose heading was already serving as
+  its title, and the heading is left behind.
+- **Copying a callout** and editing only one of the two titles.
+- **A heading that was meant to be body content.** If the first block of
+  a callout is a heading, it is treated as the title, not as a section
+  inside the callout.
+
+## How to fix
+
+Delete whichever title you did not intend. To keep the attribute:
+
+```markdown
+::: {.callout-note title="Off-Host Execution"}
+Body.
+:::
+```
+
+To keep the heading, remove the attribute:
+
+```markdown
+::: {.callout-note}
+## Off-Host Execution
+
+Body.
+:::
+```
+
+If the heading really was meant as body content, move it below another
+block so it is no longer the callout's first child, or demote it to
+emphasized text.
+
+## Note for Quarto 1 users
+
+Quarto 1 accepts this silently: it also prefers the `title=` attribute,
+but leaves the heading in the callout body, where it renders directly
+beneath the title and reads as a duplicate. Quarto 2 reports the
+ambiguity instead, because carrying both is nearly always a mistake.
+
+## Related errors
+
+- [`Q-2-44`](Q-2-44.qmd) — a callout `title=` that is not inline content.

--- a/docs/errors/markdown/Q-2-44.qmd
+++ b/docs/errors/markdown/Q-2-44.qmd
@@ -1,0 +1,86 @@
+---
+title: "Callout title is not inline content"
+description: "A callout's `title=` attribute parses to block content, so it cannot fill the title and is ignored."
+code: Q-2-44
+subsystem: markdown
+status: stub
+since: "99.9.9"
+categories:
+  - markdown
+---
+
+# `Q-2-44` — Callout title is not inline content
+
+> A callout title must be a single line of inline markdown. This value
+> parses to block content, so it is ignored.
+
+## What this means
+
+A callout's `title=` attribute is parsed as markdown, so inline markup
+works and renders in the callout header:
+
+```markdown
+::: {.callout-tip title="Use `renv` for reproducibility"}
+Body.
+:::
+```
+
+The header shows *Use `renv` for reproducibility* with a real code span.
+
+A callout header can only hold **inline** content, though. If the value
+parses to block content — because it begins with a block marker such as
+`#`, or contains a blank line — there is nothing sensible to put in the
+header, so the attribute is ignored. The callout still renders, falling
+back to a leading heading if there is one, or to the callout type's name.
+
+## Why this happens
+
+- **A `#` at the start of the value.** `title="# Overview"` parses as a
+  heading, not as text beginning with a `#` character.
+- **A blank line inside the value**, which splits it into two paragraphs.
+- **Other leading block markers** — `>`, `-`, `1.`, or an indented code
+  block.
+
+## How to fix
+
+Write the title as plain inline markdown:
+
+```markdown
+::: {.callout-note title="Overview"}
+Body.
+:::
+```
+
+To show a literal `#` at the start of a title, escape it with **two**
+backslashes:
+
+```markdown
+::: {.callout-note title="\\# Overview"}
+Body.
+:::
+```
+
+Two escaping layers apply in sequence here, and one backslash is not
+enough. Attribute values are unescaped first, which turns `\#` into a
+plain `#` — and the markdown parser then reads that as a heading, which
+is the very error you were trying to avoid. Writing `\\#` survives the
+first layer as `\#`, which the markdown parser reads as an escaped,
+literal `#`.
+
+If you meant to add block content, put it in the callout body rather than
+the title:
+
+```markdown
+::: {.callout-note title="Overview"}
+## A heading in the body
+
+Body.
+:::
+```
+
+Note that a heading as the callout's *first* block is treated as its
+title — see [`Q-2-43`](Q-2-43.qmd).
+
+## Related errors
+
+- [`Q-2-43`](Q-2-43.qmd) — a callout title given both ways at once.


### PR DESCRIPTION
## The bug

A callout written as `::: {.callout-note title="Off-Host Execution"}` rendered a header reading **"Note"**. The author's title survived only as the `title=` attribute on the outer div. `convert_div_to_callout` built the title slot from a leading `Header` only and never read the attribute.

Because the title was never marked user-supplied, the `screen-reader-only` type span was skipped too — so a titled and an untitled callout were indistinguishable to assistive technology. Both are fixed by feeding the resolver the right input; `callout_resolve.rs` is unchanged, because it already implemented the correct Q1 shape.

Real-world impact: ~25 pages of the Posit Connect docs use the attribute form throughout.

**Before → after** (case 1 of the repro fixture):

```html
<!-- before -->
<div class="callout-title-container flex-fill">
Note
</div>

<!-- after — byte-identical to Q1 -->
<div class="callout-title-container flex-fill">
<span class="screen-reader-only">Note</span>Off-Host Execution
</div>
```

## Q1 parity

Per `callout.lua:48-50`, the `title=` attribute wins over a leading heading, and its value is parsed as markdown inlines — so ``title="Use `renv`"`` gets a real code span in the header.

The heading is now stripped **only in the fallback branch**. Q1 removes it inside `resolveHeadingCaption`, which it never reaches when `title=` is set; a naive port that stripped unconditionally would fix precedence and still corrupt the body. The `level >= 2` restriction is also gone — Q1 accepts any `Header` level.

## One deliberate divergence

When a callout carries **both** a `title=` and a leading heading, Q1 silently prefers the attribute and leaves the heading in the body, where it renders directly beneath the title and reads as a duplicate. We keep Q1's precedence but consume the heading and warn (**Q-2-43**), since carrying both is nearly always an authoring mistake. **Q-2-44** covers a `title=` that parses to block content: warned and ignored, falling back to the heading.

## The subtle part: source mapping

`Attr.2` stores the value **unescaped and unquoted**, while its `AttrSourceInfo` span covers the **raw, quote-inclusive** text (the grammar token includes its delimiters). The relationship is therefore piecewise-affine — and `SourceInfo::substring` composes only *affine* maps, with no clamp and no validation. Naive nesting drifts by +1 immediately (the opening quote) and one more byte per collapsed escape, **silently**.

Measured: for ``title="Use `renv` today"`` the code span maps to `85..91` when it really lives at `86..92`.

`attribute_value_source` derives the parent span from lengths alone — no source text, no `SourceContext` dependency (it is `Option` and can be content-stripped):

| condition | meaning | result |
|---|---|---|
| `span_len == n` | bare, unquoted | exact |
| `span_len == n + 2` | quoted, nothing collapsed | exact |
| otherwise | escapes collapsed | bounded fallback |

The fallback is safe rather than merely tolerable: unescaping only ever shrinks, so every offset stays inside the attribute's own raw extent. Exact non-affine mapping is filed as **bd-mxa44voa** — the YAML path has the identical latent bug, and `claude-notes/plans/2026-07-20-ipynb-surface-syntax-design.md:73-92` already documents the affine-only constraint.

## Note for authors

Escaping a leading `#` in a title takes **two** backslashes. The attribute layer unescapes first, so `\#` becomes a bare `#` that the markdown parser reads as a heading — the very error being avoided. `\\#` survives as `\#`. Verified by render and pinned by tests.

## Tests

12 new unit tests in `callout.rs`, plus a smoke-all HTML fixture. Three are span tests that parse **real qmd** rather than hand-built ASTs — synthetic `SourceInfo` cannot express the raw/unescaped mismatch, so a wrong span would be invisible by construction.

Also threads a diagnostics sink through `transform_blocks`/`transform_block`, which previously had none.

**No snapshot files added, modified, or removed.**

## Verification

- `cargo nextest run --workspace` — 11471/11471 passed
- `cargo xtask verify` **full, including the WASM leg** — all 14 steps, exit 0
- End-to-end `q2 render` of a 7-case repro, output inspected directly — see `claude-notes/plans/callout-title-attribute-investigation/observed-output.md`

Closes bd-callout-custom-title-dropped-9qi1p7iw. Origin: `br-de85v0a8` in the connect-docs porting skein.

🤖 Generated with [Claude Code](https://claude.com/claude-code)