### PR TITLE
Expand {{< include >}} inside fenced code blocks (bd-include-in-code-block-f8mvtczn)

### DIFF
--- a/claude-notes/plans/2026-08-10-include-in-code-block.md
+++ b/claude-notes/plans/2026-08-10-include-in-code-block.md
@@ -1,0 +1,164 @@
+# `{{< include >}}` inside a fenced code block is not expanded (bd-include-in-code-block-f8mvtczn)
+
+**Date:** 2026-08-10
+**Braid:** `bd-include-in-code-block-f8mvtczn` (bug, P1, label `parity`)
+**Branch:** `main` @ `bcdbce6b` — investigated in place, no worktree created
+**Status:** Investigation — pending design alignment with user. **Do not start implementation until the user gives the go-ahead.**
+
+## Triage verdict
+
+**Ready to design** — the bug reproduces byte-for-byte at HEAD, the mechanism is fully understood, and there is a clean fix site; but the investigation found that the strand's own **suggested fix direction lands in the wrong pipeline stage**, so the location question has to be settled before implementation starts.
+
+## Issue context
+
+An `include` shortcode standing alone inside a fenced code block — the standard Q1 idiom for embedding a source file as a listing —
+
+````markdown
+```{.python filename="app.py"}
+{{< include app.py >}}
+```
+````
+
+renders with the entire fence body replaced by the single token `?include`. Q1 splices the included file's raw text into the fence and the listing renders as a syntax-highlighted copy of `app.py`.
+
+A `Q-17-4` "Include not expanded" warning does fire, so this is not silent — but its hint ("Put the include shortcode in its own paragraph, surrounded by blank lines") is actively wrong here: the shortcode belongs inside the fence, and following the hint would change what the page means.
+
+**Real-world impact.** Filed against the Posit Connect docs port: 21 files, ~44 listings, ~1300 lines of embedded source — the single largest remaining content loss in that port. Every cookbook integration recipe embeds its `requirements.txt` / `app.py` / `app.R` / `manifest.json` this way, so the recipes lose the code they exist to show. Worst case is `cookbook/content/integrations/databricks/viewer/python/index.qmd` — ten such listings across five framework tabs, all showing `?include`.
+
+Filed 2026-08-10 by Carlos Scheidegger; status `open`, priority 1, type `bug`, label `parity`. Not stale — filed today.
+
+## Dependency graph
+
+**Empty.** `braid dep tree` shows the strand alone; `braid dep list` returns no edges.
+
+The strand names an origin (`br-4kslym5r`) in the **connect-docs porting skein**, which is a different braid document — so the "discovered-from" context is not reachable from this skein and is instead captured in prose in the strand description (the Connect-docs port, quantified above).
+
+Consequence for the calculus: no incoming `blocks` pressure from other strands in this skein, so urgency comes entirely from the Connect-docs port, not from internal dependents. Nothing here is blocked on anything else.
+
+Adjacent (not linked, but the relevant prior work): **bd-fz6gwfq0** — the 0.16.0 text-level shortcode work that made `{{< meta … >}}` expand inside code fences. That is the machinery that currently eats the include.
+
+## What the code looks like today
+
+Every path the strand names still exists with the shape it describes. Spot-check at `bcdbce6b`:
+
+### Reproduces at HEAD — confirmed
+
+```bash
+cargo run --bin q2 -- render claude-notes/plans/include-in-code-block-investigation/repro
+```
+
+emits the `Q-17-4` warning at `index.qmd:8:1` and produces
+
+```html
+<pre class="sourceCode python" data-filename="app.py"><code class="sourceCode python">?<span class="hl-variable">include</span></code></pre>
+```
+
+Byte-identical to the strand's recorded symptom. The control include at top level in the same document expands correctly. Fixture + captured output: `claude-notes/plans/include-in-code-block-investigation/`.
+
+### Half one — `IncludeExpansionStage` cannot reach a code fence
+
+`crates/quarto-core/src/stage/stages/include_expansion.rs`:
+
+- `extract_include_path` (`:507`) matches only `Block::Paragraph` / `Block::Plain` whose sole inline is an `include` shortcode.
+- `child_block_lists_mut` (`:385`) is the documented **single source of truth** for "where can an include appear": Div, BlockQuote, Bullet/Ordered/Definition list items, Figure, `NoteDefinitionFencedBlock`, Table cells. A `CodeBlock` is a leaf (its content is a `String`), so it falls into the `_ => Vec::new()` arm and is unreachable by construction.
+- The pinning test `extract_include_path_from_non_paragraph` (`:646`) asserts a CodeBlock yields `None`. Any fix revisits it.
+
+Note that `expand_blocks` *does* visit every `CodeBlock` — as an element `blocks[i]` of some block list at any nesting depth. What it cannot do is descend *into* one. That matters: a fix at this site needs no new traversal, only a new per-block action.
+
+### Half two — `ShortcodeResolveTransform` is what writes `?include`
+
+`crates/quarto-core/src/transforms/shortcode_resolve.rs`:
+
+- The `Block::CodeBlock(code_block)` arm (`:1834`) calls `expand_text_in_place` on `code_block.text` unless `code_shortcode_opt_out` (`:1509`) fires.
+- `dispatch_shortcode` has no `include` handler by design; the `shortcode.name == "include"` branch (`:630`) returns `ShortcodeResult::Error` with the `Q-17-4` diagnostic.
+- `expand_text_segments` (`:1489-1493`) handles `Error` by pushing `'?'` then the shortcode name — hence `?include` replacing the whole body.
+
+So the mechanism that already makes `{{< meta … >}}` work inside a fence is the same mechanism that eats the include, and it operates on exactly the right data: raw text.
+
+### The finding that changes the fix site — the profile checkpoint
+
+The strand suggests fixing this **in the text-expansion path** (`ShortcodeResolveTransform`). That site cannot satisfy the strand's own dependency-tracking requirement:
+
+| # | Stage (from `pipeline.rs:220-231`) |
+|---|---|
+| 3 | `IncludeExpansionStage` — records `IncludeEntry` via `record_include` |
+| 4 | `IncludeResolveStage` |
+| 6 | **`DocumentProfileStage`** — *drains* the include side-channel into `DocumentProfile.includes` (`document_profile.rs:422`, profile version 2, `bd-r82e`) |
+| 8 | `UnwrapProfileStage` |
+| 13 | `AstTransformsStage` — where `ShortcodeResolveTransform` runs (`pipeline.rs:1205`) |
+
+By the time the transform runs, the profile is already extracted, and **profiles are read-only** per `claude-notes/designs/document-profile-contract.md` (CLAUDE.md restates the rule: a feature needing state not in the profile moves its producer *earlier*, it does not back-patch). A code-fence include registered at stage 13 could not reach `DocumentProfile.includes`, so editing `app.py` would not rebuild the page that embeds it.
+
+Supporting facts for the alternative site (`IncludeExpansionStage`):
+
+- It already holds everything the fix needs: `ctx.runtime.file_read`, `base_dir` (`current_file.parent()`), `ctx.project.dir`, `recorded_includes`, and the cycle-detection `include_stack`.
+- `parse_text_shortcodes` (`crates/quarto-core/src/transforms/shortcode_text.rs:50`) is `pub` and reusable from the stage — the same textual parser the transform uses.
+- Splicing the file text into `code_block.text` at stage 3 means the shortcode is *gone* before stage 13, so `Q-17-4` naturally stops firing for this shape without touching the diagnostic's condition. That preserves the existing invariant documented at `shortcode_resolve.rs:623-629` ("includes are expanded … before transforms run") rather than carving an exception into it.
+
+### `code_shortcode_opt_out` has a timing wrinkle at the earlier site
+
+`code_shortcode_opt_out` checks two things:
+
+- `shortcodes="false"` — **authored**, so visible at stage 3. Fine.
+- `.cell-code` — **engine-produced**. It is written by the Jupyter engine (`crates/quarto-core/src/engine/jupyter/text_execute.rs:440`), which runs at `EngineExecutionStage`, *after* `IncludeExpansionStage`. So no block carries `.cell-code` at stage 3.
+
+This is not a blocker but it is a real semantic decision: at stage 3 an authored executable cell is still ```` ```{python} ````, so an include inside one would be spliced into the cell's *source* before the engine executes it. Q1's text-level model does the same thing, but q2's current opt-out contract says `.cell-code` means "print as-is". The two only collide for engine-*output* code, which cannot contain an authored include — but the reasoning should be written down, not discovered later.
+
+The predicate itself is private to `shortcode_resolve.rs`; sharing it (rather than duplicating) is a small refactor.
+
+### Preview dependency graph
+
+`quarto-preview/src/deps.rs` reuses `collect_include_paths` (`include_expansion.rs:437`), which walks via the same `child_block_lists_mut` accessor and `extract_include_path`. The doc comment on `child_block_lists_mut` explicitly says the two walkers share it "so the two can never drift". A code-fence include must be added to **both** the expander and the collector, ideally through one shared helper, or the preview dep-graph silently drifts from the renderer.
+
+### Existing tests and fixtures in the blast radius
+
+- `crates/quarto-core/src/stage/stages/include_expansion.rs:646` — `extract_include_path_from_non_paragraph`, pins CodeBlock → `None`.
+- `crates/quarto-core/tests/integration/include_expansion_diagnostics.rs:247-261` — asserts `Q-17-4` fires for the unsupported position.
+- `crates/quarto-core/tests/integration/include_nested_expansion.rs:23` — asserts `Q-17-4` does *not* fire for supported nesting.
+- `crates/quarto/tests/smoke-all/includes/nested/nested.qmd:12` — asserts the `Q-17-4` text appears.
+- `crates/quarto/tests/smoke-all/includes/code-cell/` — **different shape**, do not confuse: it includes a *file containing* a code cell. A new fixture should be named something like `includes/in-code-fence/`.
+- `docs/errors/include/Q-17-4.qmd` — user-facing error page; its "What this means" and "How to fix" both assume the only unsupported position is inline-in-a-sentence. Needs updating either way.
+
+No snapshot anywhere currently pins the literal string `?include`.
+
+## Proposed phases (draft)
+
+Skeleton only — contents wait on the design discussion below.
+
+- **Phase 0 — Test plan (TDD, failing first).**
+  - Unit: a code-fence include is recognized and its target resolved (relative, and leading-`/` project-root).
+  - Unit: `shortcodes="false"` still opts out.
+  - Integration: the fence body equals the file's bytes; no `Q-17-4`.
+  - Integration: dependency recorded — the included file appears in `DocumentProfile.includes` / the preview dep set.
+  - Smoke-all fixture `includes/in-code-fence/`.
+  - Revisit `extract_include_path_from_non_paragraph` and the `Q-17-4` assertions above.
+- **Phase 1 — Textual splice at the chosen stage** (see Q1 below): read the target, replace the shortcode span in `code_block.text` verbatim, no parsing, no re-indentation.
+- **Phase 2 — Dependency tracking**: `record_include` for the fence target; extend `collect_include_paths` (or a shared helper) so the preview dep-graph agrees.
+- **Phase 3 — Opt-out + recursion semantics**: `shortcodes="false"` wins; decide the recursion/cycle rule (Q3).
+- **Phase 4 — Diagnostics**: confirm `Q-17-4` stops firing for this shape; adjust the hint if it survives in any code-adjacent position.
+- **Phase 5 — Docs**: `docs/errors/include/Q-17-4.qmd`, plus documenting the fence idiom wherever includes are described.
+- **Phase 6 — Verify against the real corpus**: re-render the Connect-docs repro set and confirm the ~44 listings come back.
+
+## Open design questions for the user
+
+1. **Fix site — the central question.** The strand suggests handling `include` inside `ShortcodeResolveTransform`'s text-expansion path. The investigation argues for `IncludeExpansionStage` instead, because the transform runs *after* the `DocumentProfileStage` checkpoint and therefore cannot register the include as a dependency without violating the read-only-profile contract. Do you agree the fix belongs in `IncludeExpansionStage`? (If you prefer the transform site, we need a third answer for how dependencies get recorded — moving the profile checkpoint is the only route I see, and that is a much larger change.)
+
+2. **Scope of recognition inside a fence.** Q1 substitutes textually anywhere in the code text. Do we match that (any `{{< include … >}}` occurrence in `code_block.text`, possibly several, possibly mid-line), or restrict v1 to the observed idiom — a shortcode that is the sole content of its own line? The strand's corpus only exercises the sole-content case; the permissive rule is simpler to implement but harder to un-ship.
+
+3. **Recursion.** The strand proposes "no recursion inside a code fence — a file included into a fence is code, not qmd" as the defensible v1, and asks that it be a decision rather than an accident. Confirm? If we do not recurse, do we still push the target onto the cycle stack (so `a.py` including itself is impossible by construction), or is recursion-off enough?
+
+4. **Non-`.qmd` targets and trailing newlines.** `app.py`'s bytes end with a newline; the fence body does too. Do we splice bytes verbatim and let the writer normalize, or trim exactly one trailing newline so the fence has no blank last line? Q1's behavior here should be checked against a real Q1 render before we pin a test.
+
+5. **The `.cell-code` timing wrinkle.** Do we accept that at include-expansion time an authored executable cell (```` ```{python} ````) gets its include spliced into the cell source *before* execution — matching Q1's text-level model — or do we deliberately skip fences whose first class names a known engine language? I lean toward matching Q1 (splice), with the reasoning recorded in a comment.
+
+6. **`Q-17-4`'s future.** Once this shape is expanded at stage 3, the warning stops firing for it. Does `Q-17-4` keep its current single hint (now correct only for the inline-in-a-sentence case), or do we want position-aware hint text while we are here?
+
+7. **Reject the alternatives explicitly?** The strand raises a fence attribute (```` ```{.python include="app.py"} ````) or a dedicated `embed-file` shortcode, and argues for rejecting them because they make every existing Q1 document wrong. Should the plan record that rejection formally (so it is not re-litigated), and is the "could be added later as an additional affordance" door worth leaving open in writing?
+
+## Risks / tradeoffs (draft)
+
+- **Cross-walker drift.** The expander and the preview dep collector share `child_block_lists_mut` precisely so they cannot diverge. A code-fence include is a *new kind* of position that does not fit that accessor's shape (it is not a block list). Adding it to both walkers without a shared helper reintroduces exactly the drift the current design prevents. Design the shared helper first.
+- **Changing an invariant with a written rationale.** `shortcode_resolve.rs:623-629` documents "any `include` still present here is inline among other content, the one unsupported position." The `IncludeExpansionStage` fix keeps that sentence true; the transform-site fix falsifies it. Worth weighing when answering Q1.
+- **Test churn is modest but load-bearing.** Four test sites plus a docs page assert today's behavior. None of them are snapshots, so the changes are explicit and reviewable — good. The pinning unit test `extract_include_path_from_non_paragraph` should be *rewritten*, not deleted, so the new contract stays pinned.
+- **Unverified against real Q1.** The expected-output details in Q4 (trailing newline, indentation) are taken from the strand's prose, not from a side-by-side Q1 render performed in this investigation. Before pinning snapshot-grade expectations, run `quarto render` on the repro and diff. (The strand's README claims to carry expected-vs-actual markup; that file lives in the local-only Connect-docs checkout and was not consulted here.)
+- **No incoming dependencies** means nothing else in this skein breaks whichever way we go — the risk is confined to include semantics.

--- a/claude-notes/plans/2026-08-10-include-in-code-block.md
+++ b/claude-notes/plans/2026-08-10-include-in-code-block.md
@@ -2,8 +2,8 @@
 
 **Date:** 2026-08-10
 **Braid:** `bd-include-in-code-block-f8mvtczn` (bug, P1, label `parity`)
-**Branch:** `main` @ `bcdbce6b` — investigated in place, no worktree created
-**Status:** Design settled (2026-08-10) — see **Design decisions** below. One decision (D4, trailing newline) carries a recommendation that **reverses the user's initial lean** on new evidence and needs a yes/no before Phase 1. Everything else is pinned.
+**Branch:** `braid/include-in-code-block-f8mvtczn`, off `main` @ `bcdbce6b`
+**Status:** Implemented, fully verified, **awaiting review before commit**. All decisions (D1–D7 plus D3a/D3b/D4a found during implementation) are settled and recorded below.
 
 ## Triage verdict
 
@@ -33,23 +33,63 @@ So "Q1 substitutes textually anywhere in the code text" — as the strand's fram
 
 Note the `^\s*` — Q1 accepts an *indented* include line and splices without re-indenting. We should match that.
 
-### D3 — Recursion: none inside a code fence ✅ settled, and it is a deliberate divergence
+### D3 — Recursion: recurse, matching Q1 ✅ settled (reversed 2026-08-10)
 
-A file included into a fence is code, not qmd; its contents are spliced and not re-scanned.
+**Originally settled as "no recursion"; reversed during implementation** once D3a (below) showed that "no recursion" could not deliver what it promised. Spliced text **is** re-scanned for include lines, exactly as Q1's `standaloneInclude` (`src/core/handlers/include-standalone.ts`) does.
 
-**Q1 does recurse**, so this is a divergence, not parity. `standaloneInclude` (`src/core/handlers/include-standalone.ts`) is the *same* code path for both positions, and its `retrieveInclude` re-scans the included text line-by-line for further block-shortcode includes and recurses.
+Consequences:
 
-Where the divergence is observable: including a `.qmd` into a fence in order to *show* its source. Q1 would expand include lines inside that snippet; we would print them literally. Printing them literally is arguably the better behavior for a listing — but it is a difference, and it should be documented (that is bd-cq0xhxg5).
+- A `.qmd` embedded as a listing shows the same content it would show as a page. Authors who want the *literal* source, shortcodes and all, use `shortcodes="false"` — the documented mechanism for exactly that.
+- Cycles are real and must be caught: a document that embeds itself in a listing carries the same include line in the spliced copy, so it would recurse forever. Handled with the existing `include_stack` (canonicalized paths) and a `Q-17-1` warning; the offending line is dropped.
+- **Nested paths anchor at the including file's directory**, matching how block-position includes nest (bd-1fz3vh99). Q1 anchors nested fence includes at the *document* instead (`standaloneInclude` resolves against `target.source` at every level). Ours is the more consistent rule and the one q2 already documents; a deliberate, narrow divergence.
+- The parity gap this decision used to introduce is gone, which shrinks what bd-cq0xhxg5 has to explain.
 
-For non-qmd targets the divergence is unreachable in practice: a bare `{{< include … >}}` line in a `.py`/`.R`/`.json` file is a syntax error in that language.
+Q1 trivia worth not copying: its cycle detection checks the *resolved* path (`retrievedFiles.indexOf(path)`) but pushes the *raw* filename (`retrievedFiles.push(filename)`), so it only catches cycles when the two coincide. Our `canonicalize`-based `include_stack` is already correct; don't regress toward Q1 here.
 
-**Cycle stack:** with recursion off, a fence include cannot start a cycle, so pushing onto `include_stack` is not needed for correctness. Recommend pushing anyway for uniformity and cheap future-proofing if recursion is ever enabled — decide at implementation time; it is not load-bearing.
+### D3a — Why D3 was reversed ✅ resolved
 
-Q1 trivia worth not copying: its cycle detection checks the *resolved* path (`retrievedFiles.indexOf(path)`) but pushes the *raw* filename (`retrievedFiles.push(filename)`), so it only catches cycles when the two coincide. Our existing `canonicalize`-based `include_stack` is already correct; don't regress toward Q1 here.
+**Found during implementation (2026-08-10), verified end-to-end.** D3 says a file included into a fence has its own include lines "printed literally". That does not happen — and cannot, without an additional change.
 
-### D4 — Trailing newline: ⚠️ recommend trimming exactly one — reverses the initial lean
+The spliced text still contains `{{< include inner.qmd >}}`. That text reaches `ShortcodeResolveTransform` at stage 13, which does exactly what it does today for any unhandled include in code text: emits the `?include` token plus a `Q-17-4` warning. So the strand's own bug reappears one level down.
 
-The initial lean was "splice verbatim". The evidence says trimming exactly one trailing newline is what reproduces Q1's *rendered output*, and that verbatim would regress the entire motivating corpus. Detail:
+Measured, with `outer.qmd` = `top line\n{{< include inner.qmd >}}\nbottom line\n` spliced into a `.markdown` fence:
+
+```html
+<pre class="markdown code-with-copy"><code>top line
+?include
+bottom line</code></pre>
+```
+
+plus a `Q-17-4` whose location points at the *outer* fence — doubly misleading, since the author never wrote an include there.
+
+Three ways out:
+
+1. **Recurse (Q1 parity).** Re-scan spliced content for include lines, using the `include_stack` for cycles. No include survives to stage 13, so the problem vanishes by construction, and the D3 divergence disappears (shrinking bd-cq0xhxg5's scope). Cost: a listing that embeds a `.qmd` shows the *expanded* text, not the file's literal source. Users wanting literal source have `shortcodes="false"` — which is already the documented mechanism for exactly that.
+2. **Preserve unhandled includes in code text.** In the code/raw text arms of `ShortcodeResolveTransform`, treat an `include` shortcode as `Preserve` (emit its source text verbatim) instead of dispatching it to the error branch. The invariant that makes this sound: after stage 3, every *authored* fence include has been expanded, so anything still present must have come from spliced content — and literal is the right rendering for it. Keeps D3's intent and makes it actually true. Cost: a new (small) rule in the transform, and the `?include` token stops existing for fences entirely.
+3. **Escape includes in spliced content.** Rewrite `{{< include … >}}` to the escaped `{{{< … >}}}` form while splicing. Works, but it is a text mutation the author never wrote, and it creates an asymmetry with `{{< meta … >}}` in the same fence. Not recommended.
+
+**Chosen: option 1 (recurse).** It is the Q1-parity answer, needs no new rule in the shortcode transform, and makes the nested `?include` impossible by construction rather than by special-casing. Pinned by `code_fence_include_recurses`, `code_fence_include_cycle_reports_and_drops_line`, `code_fence_include_of_self_reports_cycle` (unit) and `nested_code_fence_include_expands_without_token`, `self_including_code_fence_reports_a_cycle` (full pipeline).
+
+### D3b — Unhandled includes in code text are preserved, not `?include`-ed ✅ settled
+
+**Found by the widened Q1 comparison (2026-08-10).** Line-strict recognition (D2) means a *mid-line* include in a fence is deliberately not expanded — but the leftover shortcode then reached `ShortcodeResolveTransform` and came out as `?include`, corrupting the listing. Same failure mode as D3a, but for authored (not spliced) text, so recursion does not cover it.
+
+Measured before the fix, for `x = 1  {{< include a.py >}}` in a `.python` fence:
+
+| | rendered |
+|---|---|
+| Q1 | `x = 1  {{< include a.py >}}` (untouched, silent) |
+| q2 | `x = 1  ?include` + a `Q-17-4` warning |
+
+Fix: `expand_text_segments` takes an `UnhandledInclude` mode; the two **code** text contexts (`Block::CodeBlock`, `Inline::Code`) pass `Preserve`, which emits the shortcode's source text instead of the error marker and suppresses the diagnostic. Every other text context (raw blocks/inlines, math, attribute values, link targets, `rendered.includes.*` slots) keeps `Report`.
+
+Why `Preserve` is sound rather than a papering-over: after stage 3, every include occupying a whole line of a non-opted-out fence has been expanded. Anything still present in code text is there because the line-strict rule declined it — so the author's literal text *is* the correct output. Q1 reaches the same result by never matching the line in the first place.
+
+The check keys off the dispatch *result* (`Error` whose key is `include`), not the shortcode name, so a user-supplied Lua handler named `include` still takes precedence.
+
+### D4 — Trailing newline: trim exactly one ✅ settled
+
+The initial lean was "splice verbatim"; the evidence below reversed it, and the user accepted the reversal. **Trim exactly one trailing `\n`, plus the `\r` of a preceding `\r\n`.** Detail:
 
 **What Q1's source does.** `standaloneInclude` appends a newline fragment after the content:
 
@@ -77,7 +117,18 @@ Either branch ends the spliced text with `\n\n`. So Q1 *adds* a blank line.
 
 **On the "users can't force an intentional trailing newline" concern.** They can, symmetrically with how the parser already treats fences: end the file with two newlines — one is consumed by the trim, one remains. That is the same affordance a hand-written fence has.
 
-**Recommendation:** trim exactly one trailing `\n` (and the `\r` of a preceding `\r\n`) from the spliced bytes. Equivalent framing, possibly cleaner to implement: splice verbatim, then normalize the resulting `code_block.text` to the parser's own convention. Needs a yes/no before Phase 1.
+**Decision:** trim exactly one trailing `\n` (and the `\r` of a preceding `\r\n`) from the spliced bytes.
+
+### D4a — Consecutive includes in one fence: no blank separator (divergence) ✅ settled
+
+Two include lines in one fence:
+
+| | rendered |
+|---|---|
+| Q1 | `AAA\n\nBBB` |
+| q2 | `AAA\nBBB` |
+
+Q1's blank line is the same `standaloneInclude` artifact D4 documents — it appends `"\n"` after each spliced file because in *markdown* a blank line separates blocks. Inside a fence it is noise, and at the end of a fence Pandoc's re-read deletes it (which is why the single-include case shows none). Applying D4's endorsed principle uniformly — normalize to the parser's convention rather than inherit markdown-separator artifacts — means no separator here either. Pinned by `code_fence_include_expands_multiple_targets`.
 
 ### D5 — `.cell-code` timing: accept the splice-before-execution semantics ✅ settled
 
@@ -213,31 +264,66 @@ The predicate itself is private to `shortcode_resolve.rs`; sharing it (rather th
 
 No snapshot anywhere currently pins the literal string `?include`.
 
-## Proposed phases
+## Work items
 
-Now grounded in the settled decisions. Contents are still draft at the work-item level.
+Branch: `braid/include-in-code-block-f8mvtczn`. D4 settled 2026-08-10: **trim exactly one trailing `\n`** (plus a preceding `\r`).
 
-- **Phase 0 — Test plan (TDD, failing first).**
-  - Unit: a line-strict code-fence include is recognized; mid-line and multi-per-line occurrences are **not** (D2).
-  - Unit: target resolution matches `resolve_include_target` — relative to the declaring file, leading `/` project-root-relative.
-  - Unit: an indented include line splices without re-indentation (D2).
-  - Unit: `shortcodes="false"` opts out (D5).
-  - Unit: trailing-newline handling per D4, once decided.
-  - Integration: the fence body equals the file's content; no `Q-17-4` (D6).
-  - Integration: dependency recorded — the target appears in `DocumentProfile.includes` and in the preview dep set.
-  - Integration: an included `.qmd` inside a fence shows its own include lines **literally** (D3, the deliberate divergence).
-  - Smoke-all fixture `includes/in-code-fence/` — note `includes/code-cell/` already exists and is a *different* shape (a file containing a cell, included at top level); do not conflate.
-  - Rewrite (do not delete) `extract_include_path_from_non_paragraph` so the new contract stays pinned.
-- **Phase 1 — Line-strict recognizer + textual splice in `IncludeExpansionStage`** (D1, D2): scan `code_block.text` line-wise, splice the target's content in place, no parsing, no re-indentation, per-D4 trailing-newline handling.
-- **Phase 2 — Dependency tracking**: `record_include` for the fence target; extend `collect_include_paths` through a **shared helper** so the preview dep-graph cannot drift (see Risks).
-- **Phase 3 — Opt-out + recursion**: `shortcodes="false"` wins (D5); no recursion (D3); decide the `include_stack` push at implementation time.
-- **Phase 4 — Diagnostics**: confirm `Q-17-4` no longer fires for this shape (should fall out of D1 with no diagnostic change); update the four test sites that assert today's behavior.
-- **Phase 5 — Docs**: edit `docs/errors/include/Q-17-4.qmd` ("sole content of its own paragraph" is no longer the whole story). The larger authoring-docs gap is tracked separately as **bd-cq0xhxg5**.
-- **Phase 6 — Verify against the real corpus**: re-render the Connect-docs set and confirm the ~44 listings come back; diff against a `quarto render` of the same tree.
+### Phase 0 — Test plan (TDD: written and failing first)
 
-## Remaining question for the user
+- [x] Unit: line-strict recognizer accepts a lone `{{< include x >}}` line (leading/trailing whitespace ok)
+- [x] Unit: recognizer rejects mid-line, two-per-line, and non-`include` shortcodes (D2)
+- [x] Unit: recognizer rejects the escaped form `{{{< include x >}}}`
+- [x] Unit: trailing-newline trim — exactly one `\n`, and `\r\n` → nothing (D4)
+- [x] Unit: `shortcodes="false"` opts out (D5)
+- [x] Unit: indented include line splices without re-indentation (D2)
+- [x] Integration: fence body equals the target's content; no `Q-17-4` (D6)
+- [x] Integration: missing target → `Q-17-2`, no `?include` leakage
+- [x] Integration: dependency recorded in `DocumentProfile.includes`
+- [x] Integration: `.qmd` included into a fence expands recursively, no `?include` (D3, revised)
+- [x] Smoke-all fixture `includes/in-code-fence/` (note: `includes/code-cell/` is a *different* shape — do not conflate)
+- [x] Rewrite (do not delete) `extract_include_path_from_non_paragraph` so the new contract stays pinned
 
-**D4 only** — trailing newline. Everything else is settled. The recommendation (trim exactly one) reverses the initial lean toward verbatim, on the evidence recorded in D4: Q1's rendered output has no trailing blank line, q2 has no normalizing re-read, and a verbatim splice would add a spurious blank final line to essentially every listing.
+### Phase 1 — Recognizer + textual splice in `IncludeExpansionStage` (D1, D2)
+
+- [x] Share `code_shortcode_opt_out` out of `shortcode_resolve.rs` (make `pub(crate)`)
+- [x] Add the shared recognition helper (single source of truth, mirroring `child_block_lists_mut`'s role)
+- [x] Splice in `expand_blocks`: read target, replace the line, no parsing, no re-indentation, D4 trim
+- [x] Diagnostics on read failure, consistent with the block-position arms
+
+### Phase 2 — Dependency tracking
+
+- [x] `record_include` for each fence target
+- [x] Extend `collect_include_paths` through the *same* helper so the preview dep-graph cannot drift
+- [x] Confirm `quarto-preview`'s `extract_include_deps` picks it up
+
+### Phase 3 — Opt-out + recursion
+
+- [x] `shortcodes="false"` wins (D5)
+- [x] Recursion with `include_stack` cycle detection + `Q-17-1` (D3, revised)
+
+### Phase 4 — Diagnostics
+
+- [x] Confirm `Q-17-4` no longer fires for the fence shape (should fall out of D1)
+- [x] Update the four existing test sites that assert today's behavior
+
+### Phase 5 — Docs
+
+- [x] `docs/errors/include/Q-17-4.qmd` — "sole content of its own paragraph" is no longer the whole story
+- [ ] (separate strand **bd-cq0xhxg5**) authoring-docs gap
+
+### Phase 6 — Verification
+
+- [x] `cargo nextest run --workspace`
+- [x] `cargo xtask verify` (WASM leg: `quarto-core` is in hub-client's dependency closure) — all 14 steps green
+- [x] End-to-end through the binary on the repro, output inspected (CLAUDE.md requirement)
+- [x] Widen the Q1 comparison: multi-include fences, indented includes, `.qmd`-into-fence, mid-line
+- [x] Re-render the Connect-docs corpus and confirm the ~44 listings come back
+
+**Result (2026-08-10).** 44 fence includes across 20 files, matching the strand's count. Full render: `352 of 352 files`. Corpus-wide `?include` count in the rendered HTML dropped to **1**, and that one is *not* a fence — it is the raw-HTML shape the strand itself calls docs-fixable (`licenses/index.md`: an include directly under an HTML comment with no blank line, swallowed into a `RawBlock`). It still reports `Q-17-4`, and there the existing hint — "put the include in its own paragraph, surrounded by blank lines" — is exactly right. The worst-case page, `cookbook/content/integrations/databricks/viewer/python/index.qmd`, now renders all its listings including a 92-line `app.py`, with zero `?include`.
+
+## Open questions
+
+None. D1–D7 are settled; implementation is underway.
 
 ## Follow-ups filed
 

--- a/claude-notes/plans/2026-08-10-include-in-code-block.md
+++ b/claude-notes/plans/2026-08-10-include-in-code-block.md
@@ -3,11 +3,103 @@
 **Date:** 2026-08-10
 **Braid:** `bd-include-in-code-block-f8mvtczn` (bug, P1, label `parity`)
 **Branch:** `main` @ `bcdbce6b` — investigated in place, no worktree created
-**Status:** Investigation — pending design alignment with user. **Do not start implementation until the user gives the go-ahead.**
+**Status:** Design settled (2026-08-10) — see **Design decisions** below. One decision (D4, trailing newline) carries a recommendation that **reverses the user's initial lean** on new evidence and needs a yes/no before Phase 1. Everything else is pinned.
 
 ## Triage verdict
 
-**Ready to design** — the bug reproduces byte-for-byte at HEAD, the mechanism is fully understood, and there is a clean fix site; but the investigation found that the strand's own **suggested fix direction lands in the wrong pipeline stage**, so the location question has to be settled before implementation starts.
+**Ready to design** — the bug reproduces byte-for-byte at HEAD, the mechanism is fully understood, and there is a clean fix site; but the investigation found that the strand's own **suggested fix direction lands in the wrong pipeline stage**, so the location question had to be settled before implementation started. It now is (D1).
+
+## Design decisions
+
+Settled with the user on 2026-08-10. Each records what Q1 actually does, verified against `external-sources/quarto-cli` @ `abc6a78ed` and a real `quarto render` of the repro.
+
+### D1 — Fix site: `IncludeExpansionStage` ✅ settled
+
+The fix goes in `IncludeExpansionStage` (stage 3), not `ShortcodeResolveTransform` (stage 13). Rationale in "The finding that changes the fix site" below: the transform runs after the `DocumentProfileStage` checkpoint and so cannot register the include as a dependency without violating the read-only-profile contract.
+
+The stage already walks the AST regardless, so recognizing a code-fence include there is a small parser plus a new per-block action — no new traversal.
+
+### D2 — Recognition: strict, one shortcode alone on its own line ✅ settled
+
+v1 recognizes an include **only** when the shortcode is the sole content of a line within `code_block.text` (leading/trailing whitespace permitted). Mid-line and multiple-per-line occurrences are not recognized. The permissive rule stays available as a future widening; a strict rule can be relaxed later, a permissive one cannot be tightened.
+
+**This matches Q1 exactly** — a finding that emerged after the decision was made and confirms it. Q1's `processMarkdownIncludes` (`src/core/handlers/base.ts:355-380`) splits each cell into lines and tests each with `isBlockShortcode`, whose regex is anchored to the whole line:
+
+```js
+content.match(/^\s*{{< (?!\/\*)(.+?)(?<!\*\/) >}}\s*$/)
+```
+
+So "Q1 substitutes textually anywhere in the code text" — as the strand's framing implied — is **wrong**. Q1 is line-strict. Strict is parity, not a divergence.
+
+Note the `^\s*` — Q1 accepts an *indented* include line and splices without re-indenting. We should match that.
+
+### D3 — Recursion: none inside a code fence ✅ settled, and it is a deliberate divergence
+
+A file included into a fence is code, not qmd; its contents are spliced and not re-scanned.
+
+**Q1 does recurse**, so this is a divergence, not parity. `standaloneInclude` (`src/core/handlers/include-standalone.ts`) is the *same* code path for both positions, and its `retrieveInclude` re-scans the included text line-by-line for further block-shortcode includes and recurses.
+
+Where the divergence is observable: including a `.qmd` into a fence in order to *show* its source. Q1 would expand include lines inside that snippet; we would print them literally. Printing them literally is arguably the better behavior for a listing — but it is a difference, and it should be documented (that is bd-cq0xhxg5).
+
+For non-qmd targets the divergence is unreachable in practice: a bare `{{< include … >}}` line in a `.py`/`.R`/`.json` file is a syntax error in that language.
+
+**Cycle stack:** with recursion off, a fence include cannot start a cycle, so pushing onto `include_stack` is not needed for correctness. Recommend pushing anyway for uniformity and cheap future-proofing if recursion is ever enabled — decide at implementation time; it is not load-bearing.
+
+Q1 trivia worth not copying: its cycle detection checks the *resolved* path (`retrievedFiles.indexOf(path)`) but pushes the *raw* filename (`retrievedFiles.push(filename)`), so it only catches cycles when the two coincide. Our existing `canonicalize`-based `include_stack` is already correct; don't regress toward Q1 here.
+
+### D4 — Trailing newline: ⚠️ recommend trimming exactly one — reverses the initial lean
+
+The initial lean was "splice verbatim". The evidence says trimming exactly one trailing newline is what reproduces Q1's *rendered output*, and that verbatim would regress the entire motivating corpus. Detail:
+
+**What Q1's source does.** `standaloneInclude` appends a newline fragment after the content:
+
+```js
+textFragments.push(includeSrc.value.endsWith("\n") ? "\n" : "\n\n");
+```
+
+Either branch ends the spliced text with `\n\n`. So Q1 *adds* a blank line.
+
+**What Q1 actually renders.** Not that. `quarto render` of the repro produces exactly three highlighted lines — `cb1-1`, `cb1-2`, `cb1-3` — with **no trailing blank line**. Q1 gets away with the appended newline because the spliced markdown is re-read by Pandoc's markdown reader, which normalizes trailing whitespace inside a fence.
+
+**Why q2 cannot rely on that.** q2 emits HTML directly from the AST — there is no Pandoc re-read (see CLAUDE.md, "No DOM postprocessor"). Two measurements at HEAD:
+
+- The qmd parser's convention for a fence whose last line has content is **no trailing newline**: ```` ```{.python}\nimport os\n\nprint("hi")\n``` ```` yields `CodeBlock.text == "import os\n\nprint(\"hi\")"`. A source blank line before the closing fence *does* yield a trailing `"\n"`, so the trailing newline is representable and meaningful.
+- The HTML writer emits `escape_html(&codeblock.text)` verbatim (`crates/pampa/src/writers/html.rs:1478`). Rendered side by side:
+
+  ```
+  with a trailing newline:  …<span class="hl-variable">os</span>\n</code></pre>
+  without:                  …<span class="hl-variable">os</span></code></pre>
+  ```
+
+  A newline immediately before `</code></pre>` is *not* stripped by the HTML spec (only one immediately after `<pre>` is), so it renders as an empty final line.
+
+**Consequence.** Nearly every source file ends with a newline (POSIX convention; most editors and linters enforce it). Splicing verbatim would therefore give *every* listing a spurious blank last line — the default case, not an edge case — and would break parity for all ~44 Connect-docs listings, which is the reason this strand exists.
+
+**On the "users can't force an intentional trailing newline" concern.** They can, symmetrically with how the parser already treats fences: end the file with two newlines — one is consumed by the trim, one remains. That is the same affordance a hand-written fence has.
+
+**Recommendation:** trim exactly one trailing `\n` (and the `\r` of a preceding `\r\n`) from the spliced bytes. Equivalent framing, possibly cleaner to implement: splice verbatim, then normalize the resulting `code_block.text` to the parser's own convention. Needs a yes/no before Phase 1.
+
+### D5 — `.cell-code` timing: accept the splice-before-execution semantics ✅ settled
+
+At stage 3 an authored executable cell is still ```` ```{python} ````; `.cell-code` is written later by the Jupyter engine (`crates/quarto-core/src/engine/jupyter/text_execute.rs:440`) at `EngineExecutionStage`. So an include inside an authored executable cell gets spliced into the cell's *source* before the engine runs it. This matches Q1's text-level model and is accepted.
+
+Rationale to record in a comment at the fix site: q2's tooling and diagnostics are meant to keep executable cell source parseable as the target language (hence `#|`, `//|` for cell metadata), so a user reaching this state unintentionally should be caught upstream. Engine *output* code — the case `.cell-code` exists to protect — cannot contain an authored include, so the two never actually collide.
+
+`shortcodes="false"` is authored and therefore visible at stage 3; it must keep winning.
+
+Q1 quirk not to copy: Q1's opt-out test is `newCells[i].value.search(/\s*```\s*{\s*shortcodes\s*=\s*false\s*}/)`, which only matches a fence whose attributes are *exactly* `{shortcodes=false}` — ```` ```{.python shortcodes=false} ```` does **not** opt out in Q1. Our `code_shortcode_opt_out` is attribute-based and correct; keep it.
+
+### D6 — `Q-17-4` ✅ settled by construction
+
+Once the fence shape is expanded at stage 3, the shortcode is gone before stage 13 and `Q-17-4` stops firing for it automatically — no change to the diagnostic's condition, and the invariant documented at `shortcode_resolve.rs:623-629` stays true. The remaining firing position is inline-in-a-sentence, which the current hint already describes correctly. Keep the hint as is.
+
+`docs/errors/include/Q-17-4.qmd` still needs a small edit: its "What this means" says expansion requires the shortcode be "the sole content of its own paragraph", which will no longer be the whole story.
+
+### D7 — Alternatives rejected ✅ settled
+
+A fence attribute (```` ```{.python include="app.py"} ````) and a dedicated `embed-file` shortcode are **rejected**. Both would make every existing Q1 document wrong and would require a `qmd-syntax-helper` migration rule to repair them, whereas supporting the existing spelling costs those documents nothing. Recorded here so it is not re-litigated.
+
+Not left open in writing as a promised future affordance — if someone wants one later, they can make the case then.
 
 ## Issue context
 
@@ -121,44 +213,41 @@ The predicate itself is private to `shortcode_resolve.rs`; sharing it (rather th
 
 No snapshot anywhere currently pins the literal string `?include`.
 
-## Proposed phases (draft)
+## Proposed phases
 
-Skeleton only — contents wait on the design discussion below.
+Now grounded in the settled decisions. Contents are still draft at the work-item level.
 
 - **Phase 0 — Test plan (TDD, failing first).**
-  - Unit: a code-fence include is recognized and its target resolved (relative, and leading-`/` project-root).
-  - Unit: `shortcodes="false"` still opts out.
-  - Integration: the fence body equals the file's bytes; no `Q-17-4`.
-  - Integration: dependency recorded — the included file appears in `DocumentProfile.includes` / the preview dep set.
-  - Smoke-all fixture `includes/in-code-fence/`.
-  - Revisit `extract_include_path_from_non_paragraph` and the `Q-17-4` assertions above.
-- **Phase 1 — Textual splice at the chosen stage** (see Q1 below): read the target, replace the shortcode span in `code_block.text` verbatim, no parsing, no re-indentation.
-- **Phase 2 — Dependency tracking**: `record_include` for the fence target; extend `collect_include_paths` (or a shared helper) so the preview dep-graph agrees.
-- **Phase 3 — Opt-out + recursion semantics**: `shortcodes="false"` wins; decide the recursion/cycle rule (Q3).
-- **Phase 4 — Diagnostics**: confirm `Q-17-4` stops firing for this shape; adjust the hint if it survives in any code-adjacent position.
-- **Phase 5 — Docs**: `docs/errors/include/Q-17-4.qmd`, plus documenting the fence idiom wherever includes are described.
-- **Phase 6 — Verify against the real corpus**: re-render the Connect-docs repro set and confirm the ~44 listings come back.
+  - Unit: a line-strict code-fence include is recognized; mid-line and multi-per-line occurrences are **not** (D2).
+  - Unit: target resolution matches `resolve_include_target` — relative to the declaring file, leading `/` project-root-relative.
+  - Unit: an indented include line splices without re-indentation (D2).
+  - Unit: `shortcodes="false"` opts out (D5).
+  - Unit: trailing-newline handling per D4, once decided.
+  - Integration: the fence body equals the file's content; no `Q-17-4` (D6).
+  - Integration: dependency recorded — the target appears in `DocumentProfile.includes` and in the preview dep set.
+  - Integration: an included `.qmd` inside a fence shows its own include lines **literally** (D3, the deliberate divergence).
+  - Smoke-all fixture `includes/in-code-fence/` — note `includes/code-cell/` already exists and is a *different* shape (a file containing a cell, included at top level); do not conflate.
+  - Rewrite (do not delete) `extract_include_path_from_non_paragraph` so the new contract stays pinned.
+- **Phase 1 — Line-strict recognizer + textual splice in `IncludeExpansionStage`** (D1, D2): scan `code_block.text` line-wise, splice the target's content in place, no parsing, no re-indentation, per-D4 trailing-newline handling.
+- **Phase 2 — Dependency tracking**: `record_include` for the fence target; extend `collect_include_paths` through a **shared helper** so the preview dep-graph cannot drift (see Risks).
+- **Phase 3 — Opt-out + recursion**: `shortcodes="false"` wins (D5); no recursion (D3); decide the `include_stack` push at implementation time.
+- **Phase 4 — Diagnostics**: confirm `Q-17-4` no longer fires for this shape (should fall out of D1 with no diagnostic change); update the four test sites that assert today's behavior.
+- **Phase 5 — Docs**: edit `docs/errors/include/Q-17-4.qmd` ("sole content of its own paragraph" is no longer the whole story). The larger authoring-docs gap is tracked separately as **bd-cq0xhxg5**.
+- **Phase 6 — Verify against the real corpus**: re-render the Connect-docs set and confirm the ~44 listings come back; diff against a `quarto render` of the same tree.
 
-## Open design questions for the user
+## Remaining question for the user
 
-1. **Fix site — the central question.** The strand suggests handling `include` inside `ShortcodeResolveTransform`'s text-expansion path. The investigation argues for `IncludeExpansionStage` instead, because the transform runs *after* the `DocumentProfileStage` checkpoint and therefore cannot register the include as a dependency without violating the read-only-profile contract. Do you agree the fix belongs in `IncludeExpansionStage`? (If you prefer the transform site, we need a third answer for how dependencies get recorded — moving the profile checkpoint is the only route I see, and that is a much larger change.)
+**D4 only** — trailing newline. Everything else is settled. The recommendation (trim exactly one) reverses the initial lean toward verbatim, on the evidence recorded in D4: Q1's rendered output has no trailing blank line, q2 has no normalizing re-read, and a verbatim splice would add a spurious blank final line to essentially every listing.
 
-2. **Scope of recognition inside a fence.** Q1 substitutes textually anywhere in the code text. Do we match that (any `{{< include … >}}` occurrence in `code_block.text`, possibly several, possibly mid-line), or restrict v1 to the observed idiom — a shortcode that is the sole content of its own line? The strand's corpus only exercises the sole-content case; the permissive rule is simpler to implement but harder to un-ship.
+## Follow-ups filed
 
-3. **Recursion.** The strand proposes "no recursion inside a code fence — a file included into a fence is code, not qmd" as the defensible v1, and asks that it be a decision rather than an accident. Confirm? If we do not recurse, do we still push the target onto the cycle stack (so `a.py` including itself is impossible by construction), or is recursion-off enough?
-
-4. **Non-`.qmd` targets and trailing newlines.** `app.py`'s bytes end with a newline; the fence body does too. Do we splice bytes verbatim and let the writer normalize, or trim exactly one trailing newline so the fence has no blank last line? Q1's behavior here should be checked against a real Q1 render before we pin a test.
-
-5. **The `.cell-code` timing wrinkle.** Do we accept that at include-expansion time an authored executable cell (```` ```{python} ````) gets its include spliced into the cell source *before* execution — matching Q1's text-level model — or do we deliberately skip fences whose first class names a known engine language? I lean toward matching Q1 (splice), with the reasoning recorded in a comment.
-
-6. **`Q-17-4`'s future.** Once this shape is expanded at stage 3, the warning stops firing for it. Does `Q-17-4` keep its current single hint (now correct only for the inline-in-a-sentence case), or do we want position-aware hint text while we are here?
-
-7. **Reject the alternatives explicitly?** The strand raises a fence attribute (```` ```{.python include="app.py"} ````) or a dedicated `embed-file` shortcode, and argues for rejecting them because they make every existing Q1 document wrong. Should the plan record that rejection formally (so it is not re-litigated), and is the "could be added later as an additional affordance" door worth leaving open in writing?
+- **bd-cq0xhxg5** (docs, P2, `discovered-from` this strand) — document the two include expansion mechanisms: AST-splice at block positions vs textual splice inside code fences. The audit found `include` is absent from the built-ins table in `docs/guides/authoring/shortcodes.qmd`, absent from its "Where shortcodes are evaluated" section, and that there is no includes guide page at all — includes are documented only through the four `Q-17-*` error pages. Write it once this strand lands, so the docs describe shipped behavior.
 
 ## Risks / tradeoffs (draft)
 
 - **Cross-walker drift.** The expander and the preview dep collector share `child_block_lists_mut` precisely so they cannot diverge. A code-fence include is a *new kind* of position that does not fit that accessor's shape (it is not a block list). Adding it to both walkers without a shared helper reintroduces exactly the drift the current design prevents. Design the shared helper first.
-- **Changing an invariant with a written rationale.** `shortcode_resolve.rs:623-629` documents "any `include` still present here is inline among other content, the one unsupported position." The `IncludeExpansionStage` fix keeps that sentence true; the transform-site fix falsifies it. Worth weighing when answering Q1.
+- **Invariant preserved, not broken.** `shortcode_resolve.rs:623-629` documents "any `include` still present here is inline among other content, the one unsupported position." D1's site keeps that sentence true (the transform-site alternative would have falsified it) — a point in D1's favor, now settled.
 - **Test churn is modest but load-bearing.** Four test sites plus a docs page assert today's behavior. None of them are snapshots, so the changes are explicit and reviewable — good. The pinning unit test `extract_include_path_from_non_paragraph` should be *rewritten*, not deleted, so the new contract stays pinned.
-- **Unverified against real Q1.** The expected-output details in Q4 (trailing newline, indentation) are taken from the strand's prose, not from a side-by-side Q1 render performed in this investigation. Before pinning snapshot-grade expectations, run `quarto render` on the repro and diff. (The strand's README claims to carry expected-vs-actual markup; that file lives in the local-only Connect-docs checkout and was not consulted here.)
+- **A deliberate Q1 divergence ships with this** (D3, no recursion inside a fence). It is defensible and arguably better for listings, but it is a parity gap on a strand labeled `parity`. bd-cq0xhxg5 is where it gets explained to users; make sure that lands rather than being dropped once the code works.
+- **Q1 comparison is now done, at one data point.** `quarto render` of the repro was run against `external-sources/quarto-cli` @ `abc6a78ed`; source was read for the recursion, opt-out and newline logic. Not yet compared: multi-include fences, indented includes, `.qmd`-into-fence, and the full Connect-docs corpus. Phase 6 should widen this before the work is called done.
 - **No incoming dependencies** means nothing else in this skein breaks whichever way we go — the risk is confined to include semantics.

--- a/claude-notes/plans/include-in-code-block-investigation/README.md
+++ b/claude-notes/plans/include-in-code-block-investigation/README.md
@@ -1,0 +1,40 @@
+# Investigation artifacts — bd-include-in-code-block-f8mvtczn
+
+## `repro/`
+
+Self-contained copy of the repro the strand points at (the original lives
+in a local-only checkout, `~/repos/github/cscheid/q2-connect-docs/llms-info/
+repros/include-in-code-block/`, so it is duplicated here to keep the
+record reproducible from this repo alone).
+
+- `index.qmd` — a `{{< include app.py >}}` alone inside a
+  ```` ```{.python filename="app.py"} ```` fence, plus a top-level
+  include of the same file as a **control**.
+- `app.py` — three-line include target.
+- `_quarto.yml` — minimal website project.
+
+Run:
+
+```bash
+cargo run --bin q2 -- render claude-notes/plans/include-in-code-block-investigation/repro
+```
+
+## `observed-at-head.html`
+
+The rendered fence, extracted from `_site/index.html` at
+`main` @ `bcdbce6b` (2026-08-10):
+
+```html
+<pre class="sourceCode python" data-filename="app.py"><code class="sourceCode python">?<span class="hl-variable">include</span></code></pre>
+```
+
+Byte-identical to the symptom recorded in the strand (which observed
+0.16.0 and re-verified at `b2b6100c`). The `Q-17-4` warning also fires,
+pointing at lines 8–10 with the hint "Put the include shortcode in its
+own paragraph, surrounded by blank lines".
+
+The control include at top level expands correctly, confirming the
+failure is specific to the code-fence position.
+
+`_site/` and `.quarto/` are deleted after rendering — do not commit
+build output.

--- a/claude-notes/plans/include-in-code-block-investigation/observed-at-head.html
+++ b/claude-notes/plans/include-in-code-block-investigation/observed-at-head.html
@@ -1,0 +1,1 @@
+<pre class="sourceCode python" data-filename="app.py"><code class="sourceCode python">?<span class="hl-variable">include</span></code></pre></div>

--- a/claude-notes/plans/include-in-code-block-investigation/repro/_quarto.yml
+++ b/claude-notes/plans/include-in-code-block-investigation/repro/_quarto.yml
@@ -1,0 +1,5 @@
+project:
+  type: website
+
+website:
+  title: "Include inside a fenced code block"

--- a/claude-notes/plans/include-in-code-block-investigation/repro/app.py
+++ b/claude-notes/plans/include-in-code-block-investigation/repro/app.py
@@ -1,0 +1,3 @@
+import os
+
+print("hello from app.py")

--- a/claude-notes/plans/include-in-code-block-investigation/repro/index.qmd
+++ b/claude-notes/plans/include-in-code-block-investigation/repro/index.qmd
@@ -1,0 +1,14 @@
+---
+title: Include inside a fenced code block
+---
+
+Quarto 1 splices the included file's text into the code fence, so the
+listing below shows the contents of `app.py`.
+
+```{.python filename="app.py"}
+{{< include app.py >}}
+```
+
+Control: the same include at top level (works in both engines).
+
+{{< include app.py >}}

--- a/crates/quarto-core/src/stage/stages/include_expansion.rs
+++ b/crates/quarto-core/src/stage/stages/include_expansion.rs
@@ -30,6 +30,7 @@ use async_trait::async_trait;
 use quarto_pandoc_types::block::Blocks;
 use quarto_pandoc_types::shortcode::ShortcodeArg;
 use quarto_pandoc_types::{Block, Inline};
+use quarto_source_map::SourceInfo;
 
 use crate::document_profile::IncludeEntry;
 use crate::stage::data::DocumentAst;
@@ -146,6 +147,13 @@ impl IncludeExpander<'_> {
         let mut i = 0;
         while i < blocks.len() {
             let Some(include_path) = extract_include_path(&blocks[i]) else {
+                // A code fence is a leaf with no child block list, but
+                // its *text* can carry includes (the Q1 listing idiom
+                // — bd-include-in-code-block-f8mvtczn). Those splice
+                // textually and in place; the block itself stays.
+                if let Block::CodeBlock(code_block) = &mut blocks[i] {
+                    self.expand_code_fence(code_block, current_file);
+                }
                 for list in child_block_lists_mut(&mut blocks[i]) {
                     self.expand_blocks(list, current_file)?;
                 }
@@ -356,6 +364,148 @@ impl IncludeExpander<'_> {
         }
         Ok(())
     }
+
+    /// Splice code-fence includes into `code_block.text`
+    /// (bd-include-in-code-block-f8mvtczn).
+    ///
+    /// This is the one include position where Q1's *textual* model is
+    /// the right model rather than a legacy quirk: the destination is
+    /// raw text, not a block list, so the fence-corruption hazards that
+    /// motivated the AST approach elsewhere do not apply. The target's
+    /// bytes go in verbatim — no parsing, no re-indentation (Q1 does
+    /// neither), one trailing newline trimmed (see
+    /// [`trim_one_trailing_newline`]).
+    ///
+    /// **Recursive**, matching Q1: spliced text is itself re-scanned for
+    /// include lines, so a `.qmd` embedded as a listing shows the same
+    /// content it would show as a page. Q1's `standaloneInclude`
+    /// (`src/core/handlers/include-standalone.ts`) does the same, with
+    /// the same cycle guard. Recursion is also what keeps a nested
+    /// include from surviving to `ShortcodeResolveTransform`, which
+    /// renders any unhandled include as the `?include` token this whole
+    /// change exists to remove.
+    ///
+    /// Nested paths anchor at the *including file's* directory, matching
+    /// how block-position includes nest (bd-1fz3vh99). Q1 anchors nested
+    /// fence includes at the document instead; ours is the more
+    /// consistent rule and the one q2 already documents.
+    ///
+    /// Runs before the engine, so an authored executable cell has its
+    /// include spliced into the cell source *before* execution — again
+    /// matching Q1's text-level model. The `.cell-code` half of the
+    /// opt-out cannot fire here (the engine writes that class later),
+    /// but `shortcodes="false"` is authored and does.
+    ///
+    /// Errors are non-fatal: a diagnostic is pushed and the offending
+    /// line is dropped. Dropping rather than leaving it matters for the
+    /// same `?include` reason.
+    fn expand_code_fence(
+        &mut self,
+        code_block: &mut quarto_pandoc_types::block::CodeBlock,
+        current_file: &Path,
+    ) {
+        let includes = code_fence_includes(code_block);
+        if includes.is_empty() {
+            return;
+        }
+        code_block.text = self.splice_fence_text(
+            &code_block.text,
+            includes,
+            current_file,
+            &code_block.source_info,
+        );
+    }
+
+    /// Replace each include line in `text` with its target's content,
+    /// recursively. `location` anchors any diagnostic at the originating
+    /// fence — nested text has no source span of its own.
+    fn splice_fence_text(
+        &mut self,
+        text: &str,
+        includes: Vec<(usize, String)>,
+        current_file: &Path,
+        location: &SourceInfo,
+    ) -> String {
+        let base_dir = current_file.parent().unwrap_or(Path::new("."));
+        // `(line index, replacement)` in ascending line order, mirroring
+        // `code_fence_includes`. `None` means the line is dropped.
+        let mut replacements: Vec<(usize, Option<String>)> = Vec::with_capacity(includes.len());
+
+        for (line_idx, raw_path) in includes {
+            let resolved = resolve_include_target(base_dir, &self.ctx.project.dir, &raw_path);
+            let canonical = resolved.canonicalize().unwrap_or_else(|_| resolved.clone());
+
+            // A file that embeds itself as a listing would recurse
+            // forever: the spliced copy carries the same include line.
+            if self.include_stack.contains(&canonical) {
+                self.ctx.diagnostics.push(
+                    quarto_error_reporting::DiagnosticMessageBuilder::warning("Circular include")
+                        .with_code("Q-17-1")
+                        .with_location(location.clone())
+                        .problem(format!(
+                            "Circular include detected: '{}' is already being included",
+                            resolved.display()
+                        ))
+                        .add_hint("Check for files that include each other, directly or indirectly")
+                        .build(),
+                );
+                replacements.push((line_idx, None));
+                continue;
+            }
+
+            match self.ctx.runtime.file_read(&resolved) {
+                Ok(bytes) => {
+                    // Record before trimming: the render depends on the
+                    // file's real bytes, so the cache-invalidation hash
+                    // must cover them all (bd-r82e).
+                    record_include(self.recorded_includes, &canonical, &bytes);
+                    let content = String::from_utf8_lossy(trim_one_trailing_newline(&bytes));
+
+                    let nested = code_fence_include_lines(&content, location);
+                    let spliced = if nested.is_empty() {
+                        content.into_owned()
+                    } else {
+                        self.include_stack.insert(canonical.clone());
+                        let out = self.splice_fence_text(&content, nested, &resolved, location);
+                        self.include_stack.remove(&canonical);
+                        out
+                    };
+                    replacements.push((line_idx, Some(spliced)));
+                }
+                Err(e) => {
+                    self.ctx.diagnostics.push(
+                        quarto_error_reporting::DiagnosticMessageBuilder::warning(
+                            "Include file not found",
+                        )
+                        .with_code("Q-17-2")
+                        .with_location(location.clone())
+                        .problem(format!(
+                            "Could not read included file '{}': {}",
+                            resolved.display(),
+                            e
+                        ))
+                        .build(),
+                    );
+                    replacements.push((line_idx, None));
+                }
+            }
+        }
+
+        // Sequential merge — both sequences run in ascending line
+        // order, so one pass with a cursor suffices.
+        let mut pending = replacements.into_iter().peekable();
+        let rebuilt: Vec<String> = text
+            .split('\n')
+            .enumerate()
+            .filter_map(|(idx, line)| match pending.peek() {
+                // `Some(text)` splices the file in; `None` drops a line
+                // whose include could not be read.
+                Some((at, _)) if *at == idx => pending.next().and_then(|(_, text)| text),
+                _ => Some(line.to_string()),
+            })
+            .collect();
+        rebuilt.join("\n")
+    }
 }
 
 /// Remap the `FileId`s in a diagnostic's primary location and every
@@ -441,6 +591,12 @@ pub fn collect_include_paths(blocks: &mut Blocks) -> Vec<String> {
                 out.push(path);
                 continue;
             }
+            // Code-fence includes are dependencies too: without them,
+            // editing the embedded source file never rebuilds the page
+            // that shows it (bd-include-in-code-block-f8mvtczn).
+            if let Block::CodeBlock(code_block) = block {
+                out.extend(code_fence_includes(code_block).into_iter().map(|(_, p)| p));
+            }
             for list in child_block_lists_mut(block) {
                 walk(list, out);
             }
@@ -489,6 +645,104 @@ fn resolve_include_target(base_dir: &Path, project_dir: &Path, raw: &str) -> Pat
     } else {
         base_dir.join(raw)
     }
+}
+
+/// Recognize a `{{< include … >}}` occupying a whole line of code-fence
+/// text, returning its raw path argument.
+///
+/// **Line-strict** (bd-include-in-code-block-f8mvtczn): the shortcode
+/// must be the sole content of the line, modulo surrounding whitespace
+/// — which is exactly Q1's rule (`isBlockShortcode` anchors
+/// `/^\s*{{< … >}}\s*$/` in `src/core/lib/parse-shortcode.ts`). A
+/// shortcode sharing its line with code is left alone, so the rule can
+/// be widened later without invalidating documents; it could not be
+/// narrowed again.
+///
+/// Parsing goes through [`parse_text_shortcodes`], the same text-level
+/// parser `ShortcodeResolveTransform` uses, rather than a second
+/// hand-rolled matcher. That is what makes the escaped form
+/// (`{{{< include … >}}}`, which arrives as a literal segment) fall out
+/// correctly instead of needing its own special case.
+///
+/// [`parse_text_shortcodes`]: crate::transforms::parse_text_shortcodes
+fn code_fence_include_line(line: &str, source_info: &SourceInfo) -> Option<String> {
+    let segments = crate::transforms::parse_text_shortcodes(line, source_info)?;
+
+    // Exactly one shortcode, and every other segment blank.
+    let mut shortcode = None;
+    for segment in &segments {
+        match segment {
+            crate::transforms::TextSegment::Literal(text) => {
+                if !text.trim().is_empty() {
+                    return None;
+                }
+            }
+            crate::transforms::TextSegment::Shortcode(s) => {
+                if shortcode.is_some() {
+                    return None;
+                }
+                shortcode = Some(s);
+            }
+        }
+    }
+
+    let shortcode = shortcode?;
+    if shortcode.name != "include" {
+        return None;
+    }
+    shortcode.positional_args.first().and_then(|arg| match arg {
+        ShortcodeArg::String(s) => Some(s.clone()),
+        _ => None,
+    })
+}
+
+/// Every include a code fence's text contributes, as
+/// `(line index, raw path)` in document order.
+///
+/// This is the **single source of truth** for "does this fence contain
+/// an include", in the same way [`child_block_lists_mut`] is for
+/// block-list positions: the expander
+/// ([`IncludeExpander::expand_code_fence`]) and the path collector
+/// ([`collect_include_paths`], which feeds the preview dep-graph) both
+/// go through it, so neither can drift from the other. It also owns the
+/// opt-out check, so "which fences are off-limits" is answered in one
+/// place too.
+fn code_fence_includes(code_block: &quarto_pandoc_types::block::CodeBlock) -> Vec<(usize, String)> {
+    if crate::transforms::code_shortcode_opt_out(&code_block.attr) {
+        return Vec::new();
+    }
+    code_fence_include_lines(&code_block.text, &code_block.source_info)
+}
+
+/// The include lines in a block of fence text, as `(line index, raw
+/// path)`.
+///
+/// Split out from [`code_fence_includes`] because recursion re-scans
+/// *spliced* text, which has no `CodeBlock` of its own — the opt-out is
+/// a property of the originating fence and is checked once, there.
+fn code_fence_include_lines(text: &str, source_info: &SourceInfo) -> Vec<(usize, String)> {
+    text.split('\n')
+        .enumerate()
+        .filter_map(|(idx, line)| code_fence_include_line(line, source_info).map(|p| (idx, p)))
+        .collect()
+}
+
+/// Drop exactly one trailing newline (and the `\r` of a `\r\n`).
+///
+/// The qmd parser's convention for a fence whose last line has content
+/// is text *without* a trailing newline, and the HTML writer emits that
+/// text verbatim — so splicing a POSIX source file's bytes as-is would
+/// give every listing a blank final line. Q1's rendered output has
+/// none: it appends newlines when splicing, but Pandoc's markdown
+/// re-read absorbs them. q2 emits HTML straight from the AST with no
+/// such re-read, so the normalization has to happen here.
+///
+/// Exactly one, not all: a file ending in two newlines is how an author
+/// asks for a blank final line, the same affordance a hand-written
+/// fence has.
+fn trim_one_trailing_newline(bytes: &[u8]) -> &[u8] {
+    let bytes = bytes.strip_suffix(b"\n").unwrap_or(bytes);
+    bytes.strip_suffix(b"\r").unwrap_or(bytes)
 }
 
 /// Check if a block is a paragraph (or plain block) containing only an
@@ -644,14 +898,185 @@ mod tests {
 
     #[test]
     fn extract_include_path_from_non_paragraph() {
-        // Code blocks are never includes
-        let block = Block::CodeBlock(quarto_pandoc_types::block::CodeBlock {
-            attr: quarto_pandoc_types::attr::empty_attr(),
-            text: "{{< include file.qmd >}}".to_string(),
+        // `extract_include_path` recognizes *block-position* includes
+        // only. A code fence is not one: its include lives in the
+        // fence's text and is recognized by `code_fence_includes`
+        // instead (bd-include-in-code-block-f8mvtczn). The two
+        // recognizers are disjoint by design — this test pins both
+        // halves so neither silently grows into the other's territory.
+        let block = make_code_block("{{< include file.qmd >}}", &[], &[]);
+        assert_eq!(extract_include_path(&block), None);
+
+        let Block::CodeBlock(code_block) = &block else {
+            unreachable!()
+        };
+        assert_eq!(
+            code_fence_includes(code_block),
+            vec![(0, "file.qmd".to_string())]
+        );
+    }
+
+    // === Code-fence includes (bd-include-in-code-block-f8mvtczn) ===
+
+    fn make_code_block(text: &str, classes: &[&str], kvs: &[(&str, &str)]) -> Block {
+        let mut attrs = hashlink::LinkedHashMap::new();
+        for (k, v) in kvs {
+            attrs.insert(k.to_string(), v.to_string());
+        }
+        Block::CodeBlock(quarto_pandoc_types::block::CodeBlock {
+            attr: (
+                String::new(),
+                classes.iter().map(|c| c.to_string()).collect(),
+                attrs,
+            ),
+            text: text.to_string(),
             source_info: SourceInfo::for_test(),
             attr_source: quarto_pandoc_types::attr::AttrSourceInfo::empty(),
-        });
-        assert_eq!(extract_include_path(&block), None);
+        })
+    }
+
+    /// Recognize on one line, for the strictness tests.
+    fn recognize(line: &str) -> Option<String> {
+        code_fence_include_line(line, &SourceInfo::for_test())
+    }
+
+    #[test]
+    fn code_fence_line_accepts_lone_include() {
+        assert_eq!(recognize("{{< include app.py >}}"), Some("app.py".into()));
+    }
+
+    #[test]
+    fn code_fence_line_accepts_surrounding_whitespace() {
+        // Q1's `isBlockShortcode` anchors with `^\s*…\s*$`, so an
+        // indented include line is still an include (and splices
+        // without re-indentation).
+        assert_eq!(
+            recognize("    {{< include app.py >}}"),
+            Some("app.py".into())
+        );
+        assert_eq!(
+            recognize("\t{{< include app.py >}}  "),
+            Some("app.py".into())
+        );
+        // A trailing `\r` from CRLF input counts as whitespace.
+        assert_eq!(recognize("{{< include app.py >}}\r"), Some("app.py".into()));
+    }
+
+    #[test]
+    fn code_fence_line_accepts_quoted_path() {
+        assert_eq!(
+            recognize(r#"{{< include "my file.py" >}}"#),
+            Some("my file.py".into())
+        );
+    }
+
+    #[test]
+    fn code_fence_line_rejects_mid_line() {
+        // D2: strict — the shortcode must be the sole content of its
+        // line. Relaxing this later is possible; tightening is not.
+        assert_eq!(recognize("x = 1  {{< include app.py >}}"), None);
+        assert_eq!(recognize("{{< include app.py >}} # trailing"), None);
+    }
+
+    #[test]
+    fn code_fence_line_rejects_two_per_line() {
+        assert_eq!(recognize("{{< include a.py >}}{{< include b.py >}}"), None);
+    }
+
+    #[test]
+    fn code_fence_line_rejects_other_shortcodes() {
+        // `{{< meta … >}}` in a fence keeps its existing text-level
+        // behavior via ShortcodeResolveTransform; include expansion
+        // must not claim it.
+        assert_eq!(recognize("{{< meta version >}}"), None);
+        assert_eq!(recognize("{{< var key >}}"), None);
+    }
+
+    #[test]
+    fn code_fence_line_rejects_escaped_include() {
+        // `{{{< … >}}}` is the documented "render literally" form.
+        assert_eq!(recognize("{{{< include app.py >}}}"), None);
+    }
+
+    #[test]
+    fn code_fence_line_rejects_include_without_path() {
+        assert_eq!(recognize("{{< include >}}"), None);
+    }
+
+    #[test]
+    fn code_fence_line_rejects_plain_code() {
+        assert_eq!(recognize("import os"), None);
+        assert_eq!(recognize(""), None);
+    }
+
+    #[test]
+    fn code_fence_includes_reports_every_line_in_order() {
+        let block = make_code_block(
+            "before\n{{< include a.py >}}\nmiddle\n{{< include b.py >}}",
+            &["python"],
+            &[],
+        );
+        let Block::CodeBlock(cb) = &block else {
+            unreachable!()
+        };
+        assert_eq!(
+            code_fence_includes(cb),
+            vec![(1, "a.py".to_string()), (3, "b.py".to_string())]
+        );
+    }
+
+    #[test]
+    fn code_fence_includes_respects_shortcodes_false() {
+        // D5: the authored opt-out must keep winning. This is how the
+        // docs show include syntax without expanding it.
+        let block = make_code_block(
+            "{{< include app.py >}}",
+            &["markdown"],
+            &[("shortcodes", "false")],
+        );
+        let Block::CodeBlock(cb) = &block else {
+            unreachable!()
+        };
+        assert_eq!(code_fence_includes(cb), vec![]);
+    }
+
+    #[test]
+    fn code_fence_includes_respects_cell_code_class() {
+        // `.cell-code` is engine-produced and cannot carry an authored
+        // include at this stage, but the opt-out predicate is shared
+        // with ShortcodeResolveTransform and must behave identically.
+        let block = make_code_block("{{< include app.py >}}", &["python", "cell-code"], &[]);
+        let Block::CodeBlock(cb) = &block else {
+            unreachable!()
+        };
+        assert_eq!(code_fence_includes(cb), vec![]);
+    }
+
+    // === Trailing-newline normalization (D4) ===
+
+    #[test]
+    fn trim_one_trailing_newline_removes_exactly_one() {
+        // q2's parser yields fence text WITHOUT a trailing newline for
+        // a content-final line, and the HTML writer emits the text
+        // verbatim — so splicing a POSIX file's bytes as-is would add a
+        // blank final line to every listing. Q1's rendered output has
+        // none (Pandoc's markdown re-read absorbs it); q2 has no such
+        // re-read, so the trim happens here.
+        assert_eq!(trim_one_trailing_newline(b"import os\n"), b"import os");
+        assert_eq!(trim_one_trailing_newline(b"import os\r\n"), b"import os");
+    }
+
+    #[test]
+    fn trim_one_trailing_newline_keeps_the_rest() {
+        // Two trailing newlines is how an author asks for a blank final
+        // line — the same affordance a hand-written fence has.
+        assert_eq!(trim_one_trailing_newline(b"import os\n\n"), b"import os\n");
+    }
+
+    #[test]
+    fn trim_one_trailing_newline_is_a_noop_without_one() {
+        assert_eq!(trim_one_trailing_newline(b"import os"), b"import os");
+        assert_eq!(trim_one_trailing_newline(b""), b"");
     }
 
     #[test]
@@ -1546,6 +1971,247 @@ mod tests {
         assert!(
             has_code_block,
             "Expected a CodeBlock from included file in the AST"
+        );
+    }
+
+    // === Includes inside a fenced code block ===
+    // (bd-include-in-code-block-f8mvtczn; the Q1 listing idiom)
+
+    /// The text of the first code block anywhere in `blocks`.
+    fn first_code_text(blocks: &[Block]) -> String {
+        fn walk(blocks: &[Block]) -> Option<String> {
+            for block in blocks {
+                if let Block::CodeBlock(cb) = block {
+                    return Some(cb.text.clone());
+                }
+                if let Block::Div(div) = block
+                    && let Some(found) = walk(&div.content)
+                {
+                    return Some(found);
+                }
+            }
+            None
+        }
+        walk(blocks).expect("expected a code block")
+    }
+
+    const APP_PY: &str = "import os\n\nprint(\"hello\")\n";
+
+    #[test]
+    fn code_fence_include_splices_file_text() {
+        let (doc, ctx) = expand(
+            "```{.python filename=\"app.py\"}\n{{< include app.py >}}\n```",
+            vec![("/project/app.py", APP_PY)],
+        );
+        assert!(ctx.diagnostics.is_empty(), "{:?}", ctx.diagnostics);
+        // Exactly the file's content, with the one trailing newline
+        // trimmed (D4) so the listing has no blank final line.
+        assert_eq!(
+            first_code_text(&doc.ast.blocks),
+            "import os\n\nprint(\"hello\")"
+        );
+    }
+
+    #[test]
+    fn code_fence_include_keeps_surrounding_lines() {
+        let (doc, ctx) = expand(
+            "```{.python}\n# header\n{{< include app.py >}}\n# footer\n```",
+            vec![("/project/app.py", "body\n")],
+        );
+        assert!(ctx.diagnostics.is_empty(), "{:?}", ctx.diagnostics);
+        assert_eq!(first_code_text(&doc.ast.blocks), "# header\nbody\n# footer");
+    }
+
+    #[test]
+    fn code_fence_include_does_not_reindent() {
+        // Q1 splices at column 0 regardless of the include line's own
+        // indentation; matching that keeps existing documents stable.
+        let (doc, ctx) = expand(
+            "```{.python}\n    {{< include app.py >}}\n```",
+            vec![("/project/app.py", "a\n  b\n")],
+        );
+        assert!(ctx.diagnostics.is_empty(), "{:?}", ctx.diagnostics);
+        assert_eq!(first_code_text(&doc.ast.blocks), "a\n  b");
+    }
+
+    #[test]
+    fn code_fence_include_expands_multiple_targets() {
+        let (doc, ctx) = expand(
+            "```{.python}\n{{< include a.py >}}\n{{< include b.py >}}\n```",
+            vec![("/project/a.py", "AAA\n"), ("/project/b.py", "BBB\n")],
+        );
+        assert!(ctx.diagnostics.is_empty(), "{:?}", ctx.diagnostics);
+        assert_eq!(first_code_text(&doc.ast.blocks), "AAA\nBBB");
+    }
+
+    #[test]
+    fn code_fence_include_records_dependency() {
+        // Without this the preview never rebuilds the page when the
+        // embedded source file changes.
+        let (doc, _ctx) = expand(
+            "```{.python}\n{{< include app.py >}}\n```",
+            vec![("/project/app.py", APP_PY)],
+        );
+        let recorded: Vec<_> = doc
+            .recorded_includes
+            .iter()
+            .map(|e| e.path.clone())
+            .collect();
+        assert_eq!(recorded, vec![PathBuf::from("/project/app.py")]);
+    }
+
+    #[test]
+    fn code_fence_include_resolves_project_absolute_path() {
+        let (doc, ctx) = expand(
+            "```{.python}\n{{< include /shared/app.py >}}\n```",
+            vec![("/project/shared/app.py", "shared\n")],
+        );
+        assert!(ctx.diagnostics.is_empty(), "{:?}", ctx.diagnostics);
+        assert_eq!(first_code_text(&doc.ast.blocks), "shared");
+    }
+
+    #[test]
+    fn code_fence_include_missing_file_reports_and_drops_line() {
+        let (doc, ctx) = expand("```{.python}\nkept\n{{< include gone.py >}}\n```", vec![]);
+        let codes: Vec<_> = ctx
+            .diagnostics
+            .iter()
+            .filter_map(|d| d.code.clone())
+            .collect();
+        assert_eq!(codes, vec!["Q-17-2".to_string()]);
+        // The unresolved shortcode must not survive into the fence:
+        // ShortcodeResolveTransform would later render it as the
+        // `?include` token this strand exists to remove.
+        let text = first_code_text(&doc.ast.blocks);
+        assert_eq!(text, "kept");
+        assert!(!text.contains("include"), "got {text:?}");
+    }
+
+    #[test]
+    fn code_fence_include_respects_shortcodes_false() {
+        let (doc, ctx) = expand(
+            "```{.markdown shortcodes=\"false\"}\n{{< include app.py >}}\n```",
+            vec![("/project/app.py", APP_PY)],
+        );
+        assert!(ctx.diagnostics.is_empty(), "{:?}", ctx.diagnostics);
+        assert_eq!(first_code_text(&doc.ast.blocks), "{{< include app.py >}}");
+    }
+
+    #[test]
+    fn code_fence_include_inside_div_expands() {
+        // Fences nest wherever block lists do; the walker must reach
+        // them at every level, not just the top.
+        let (doc, ctx) = expand(
+            "::: {.panel}\n```{.python}\n{{< include app.py >}}\n```\n:::",
+            vec![("/project/app.py", "nested\n")],
+        );
+        assert!(ctx.diagnostics.is_empty(), "{:?}", ctx.diagnostics);
+        assert_eq!(first_code_text(&doc.ast.blocks), "nested");
+    }
+
+    #[test]
+    fn code_fence_include_recurses() {
+        // D3 (revised): spliced text is re-scanned, matching Q1's
+        // `standaloneInclude`. Recursion is also what stops a nested
+        // include from surviving to ShortcodeResolveTransform, which
+        // would render it as `?include` — the very bug being fixed,
+        // one level down.
+        let (doc, ctx) = expand(
+            "```{.markdown}\n{{< include outer.qmd >}}\n```",
+            vec![
+                (
+                    "/project/outer.qmd",
+                    "top\n{{< include inner.qmd >}}\nbot\n",
+                ),
+                ("/project/inner.qmd", "INNER\n"),
+            ],
+        );
+        assert!(ctx.diagnostics.is_empty(), "{:?}", ctx.diagnostics);
+        assert_eq!(first_code_text(&doc.ast.blocks), "top\nINNER\nbot");
+    }
+
+    #[test]
+    fn code_fence_include_recursion_anchors_at_the_including_file() {
+        // Nested paths resolve against the file that declared them, as
+        // block-position includes do (bd-1fz3vh99) — not against the
+        // document. (Q1 anchors at the document here; ours is the
+        // consistent rule.)
+        let (doc, ctx) = expand(
+            "```{.markdown}\n{{< include sub/outer.qmd >}}\n```",
+            vec![
+                ("/project/sub/outer.qmd", "{{< include sibling.qmd >}}\n"),
+                ("/project/sub/sibling.qmd", "FROM-SUBDIR\n"),
+            ],
+        );
+        assert!(ctx.diagnostics.is_empty(), "{:?}", ctx.diagnostics);
+        assert_eq!(first_code_text(&doc.ast.blocks), "FROM-SUBDIR");
+    }
+
+    #[test]
+    fn code_fence_include_cycle_reports_and_drops_line() {
+        // A file that embeds itself as a listing would recurse forever:
+        // the spliced copy carries the same include line.
+        let (doc, ctx) = expand(
+            "```{.markdown}\n{{< include a.qmd >}}\n```",
+            vec![
+                ("/project/a.qmd", "A-TOP\n{{< include b.qmd >}}\n"),
+                ("/project/b.qmd", "B-TOP\n{{< include a.qmd >}}\n"),
+            ],
+        );
+        let codes: Vec<_> = ctx
+            .diagnostics
+            .iter()
+            .filter_map(|d| d.code.clone())
+            .collect();
+        assert_eq!(codes, vec!["Q-17-1".to_string()]);
+        // Expansion stops at the cycle; the offending line is dropped
+        // rather than left to become `?include`.
+        assert_eq!(first_code_text(&doc.ast.blocks), "A-TOP\nB-TOP");
+    }
+
+    #[test]
+    fn code_fence_include_of_self_reports_cycle() {
+        // The document itself is already on the include stack.
+        let (doc, ctx) = expand(
+            "```{.markdown}\n{{< include doc.qmd >}}\n```",
+            vec![("/project/doc.qmd", "anything\n")],
+        );
+        let codes: Vec<_> = ctx
+            .diagnostics
+            .iter()
+            .filter_map(|d| d.code.clone())
+            .collect();
+        assert_eq!(codes, vec!["Q-17-1".to_string()]);
+        assert_eq!(first_code_text(&doc.ast.blocks), "");
+    }
+
+    #[test]
+    fn code_fence_include_leaves_other_shortcodes_alone() {
+        // `{{< meta … >}}` keeps its text-level expansion downstream;
+        // include expansion must not consume or disturb it.
+        let (doc, ctx) = expand(
+            "```{.python}\n{{< meta version >}}\n{{< include app.py >}}\n```",
+            vec![("/project/app.py", "spliced\n")],
+        );
+        assert!(ctx.diagnostics.is_empty(), "{:?}", ctx.diagnostics);
+        assert_eq!(
+            first_code_text(&doc.ast.blocks),
+            "{{< meta version >}}\nspliced"
+        );
+    }
+
+    #[test]
+    fn collect_include_paths_finds_code_fence_targets() {
+        // The preview dep-graph shares this walker with the expander;
+        // if it misses fence includes, editing the embedded file never
+        // rebuilds the page that shows it.
+        let mut doc = parse_to_doc_ast(
+            "{{< include block.qmd >}}\n\n```{.python}\n{{< include fence.py >}}\n```",
+            "/project/doc.qmd",
+        );
+        assert_eq!(
+            collect_include_paths(&mut doc.ast.blocks),
+            vec!["block.qmd".to_string(), "fence.py".to_string()]
         );
     }
 }

--- a/crates/quarto-core/src/transforms/mod.rs
+++ b/crates/quarto-core/src/transforms/mod.rs
@@ -121,6 +121,7 @@ pub use page_nav_render::PageNavRenderTransform;
 pub use proof::ProofSugarTransform;
 pub use resource_collector::{ResourceCollectorTransform, collect_referenced_asset_urls};
 pub use sectionize::SectionizeTransform;
+pub(crate) use shortcode_resolve::code_shortcode_opt_out;
 pub use shortcode_resolve::{ShortcodeResolveTransform, extract_shortcode_paths};
 pub(crate) use shortcode_text::{TextSegment, parse_text_shortcodes};
 pub use sidebar_generate::SidebarGenerateTransform;

--- a/crates/quarto-core/src/transforms/shortcode_resolve.rs
+++ b/crates/quarto-core/src/transforms/shortcode_resolve.rs
@@ -1439,11 +1439,32 @@ async fn expand_include_slot_shortcodes(
                 &item.source_info,
                 diagnostics,
                 lua_engine,
+                UnhandledInclude::Report,
             )
             .await;
             item.value = ConfigValueKind::Scalar(yaml_rust2::Yaml::String(expanded));
         }
     }
+}
+
+/// What a text context does with an `include` shortcode that reached
+/// this transform — i.e. one `IncludeExpansionStage` did not expand.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum UnhandledInclude {
+    /// Emit the `?include` marker and the Q-17-4 diagnostic. Correct
+    /// where the include really was dropped and contributes nothing.
+    Report,
+    /// Emit the shortcode's source text verbatim.
+    ///
+    /// Used for **code text**, where `?include` would corrupt a listing
+    /// (bd-include-in-code-block-f8mvtczn). Every include that occupies
+    /// a whole line of a fence is expanded back at stage 3; one still
+    /// here shares its line with code, which the line-strict rule
+    /// deliberately does not treat as an include — so the author's
+    /// literal text is what belongs in the output. Q1 does the same,
+    /// and silently: its `isBlockShortcode` never matches the line, so
+    /// nothing touches it.
+    Preserve,
 }
 
 /// Stringify a parsed segment list, dispatching each shortcode through
@@ -1455,6 +1476,7 @@ async fn expand_text_segments(
     source_info: &SourceInfo,
     diagnostics: &mut Vec<DiagnosticMessage>,
     lua_engine: &mut Option<LuaEngineState>,
+    unhandled_include: UnhandledInclude,
 ) -> String {
     use crate::transforms::TextSegment;
 
@@ -1487,9 +1509,16 @@ async fn expand_text_segments(
                         );
                     }
                     ShortcodeResult::Error(error) => {
-                        diagnostics.push(error.diagnostic);
-                        out.push('?');
-                        out.push_str(&error.key);
+                        if unhandled_include == UnhandledInclude::Preserve && error.key == "include"
+                        {
+                            // Code text: print what the author wrote.
+                            // See `UnhandledInclude`.
+                            out.push_str(&pampa::writers::qmd::shortcode_source_text(&shortcode));
+                        } else {
+                            diagnostics.push(error.diagnostic);
+                            out.push('?');
+                            out.push_str(&error.key);
+                        }
                     }
                     ShortcodeResult::Preserve => {
                         out.push_str(&pampa::writers::qmd::shortcode_source_text(&shortcode));
@@ -1506,7 +1535,15 @@ async fn expand_text_segments(
 /// code (`.cell-code` — the engine already processed the text, so it
 /// must print as-is) or an explicit `shortcodes="false"` attribute
 /// (the documented technique for displaying shortcode syntax).
-fn code_shortcode_opt_out(attr: &Attr) -> bool {
+///
+/// Shared with `IncludeExpansionStage`, which honors the same opt-out
+/// when splicing a `{{< include … >}}` inside a code fence
+/// (bd-include-in-code-block-f8mvtczn) — one predicate so the two
+/// passes cannot disagree about which fences are off-limits. Note the
+/// `.cell-code` half is unreachable from that earlier stage (the class
+/// is written later, by the engine); it is included anyway so the
+/// definition stays single-sourced.
+pub(crate) fn code_shortcode_opt_out(attr: &Attr) -> bool {
     attr.1.iter().any(|class| class == "cell-code")
         || attr.2.get("shortcodes").is_some_and(|v| v == "false")
 }
@@ -1522,6 +1559,7 @@ async fn expand_text_in_place(
     source_info: &SourceInfo,
     diagnostics: &mut Vec<DiagnosticMessage>,
     lua_engine: &mut Option<LuaEngineState>,
+    unhandled_include: UnhandledInclude,
 ) {
     if let Some(segments) = crate::transforms::parse_text_shortcodes(text, source_info) {
         *text = expand_text_segments(
@@ -1531,6 +1569,7 @@ async fn expand_text_in_place(
             source_info,
             diagnostics,
             lua_engine,
+            unhandled_include,
         )
         .await;
     }
@@ -1554,6 +1593,7 @@ async fn expand_attr_value_shortcodes(
             source_info,
             diagnostics,
             lua_engine,
+            UnhandledInclude::Report,
         )
         .await;
     }
@@ -1840,6 +1880,7 @@ fn resolve_block<'a>(
                         &code_block.source_info,
                         diagnostics,
                         lua_engine,
+                        UnhandledInclude::Preserve,
                     )
                     .await;
                 }
@@ -1852,6 +1893,7 @@ fn resolve_block<'a>(
                     &raw_block.source_info,
                     diagnostics,
                     lua_engine,
+                    UnhandledInclude::Report,
                 )
                 .await;
             }
@@ -2028,6 +2070,7 @@ fn recurse_inline<'a>(
                     source_info,
                     diagnostics,
                     lua_engine,
+                    UnhandledInclude::Report,
                 )
                 .await;
                 resolve_inlines(content, transform, metadata, diagnostics, lua_engine).await;
@@ -2097,6 +2140,7 @@ fn recurse_inline<'a>(
                         &code.source_info,
                         diagnostics,
                         lua_engine,
+                        UnhandledInclude::Preserve,
                     )
                     .await;
                 }
@@ -2109,6 +2153,7 @@ fn recurse_inline<'a>(
                     &raw.source_info,
                     diagnostics,
                     lua_engine,
+                    UnhandledInclude::Report,
                 )
                 .await;
             }
@@ -2120,6 +2165,7 @@ fn recurse_inline<'a>(
                     &math.source_info,
                     diagnostics,
                     lua_engine,
+                    UnhandledInclude::Report,
                 )
                 .await;
             }

--- a/crates/quarto-core/tests/integration/include_code_fence.rs
+++ b/crates/quarto-core/tests/integration/include_code_fence.rs
@@ -1,0 +1,332 @@
+/*
+ * tests/integration/include_code_fence.rs
+ * Copyright (c) 2026 Posit, PBC
+ *
+ * Full-pipeline contract for `{{< include >}}` inside a fenced code
+ * block (bd-include-in-code-block-f8mvtczn).
+ */
+
+//! The Quarto 1 idiom for embedding a source file as a listing is an
+//! include standing alone inside a fenced code block. Before this
+//! change the whole fence body rendered as the single token
+//! `?include`, with a `Q-17-4` warning whose hint ("put it in its own
+//! paragraph") was actively wrong for this position.
+//!
+//! These tests drive the **real HTML pipeline** — through
+//! `AstTransformsStage`, where `ShortcodeResolveTransform` produced
+//! that `?include` — because the stage-level unit tests in
+//! `include_expansion.rs` cannot see it. That transform is the reason
+//! this file exists: a fix verified only at the stage would look
+//! correct and still ship the bug.
+//!
+//! Plan: `claude-notes/plans/2026-08-10-include-in-code-block.md`.
+
+use crate::include_expansion_diagnostics::{codes, render_fixture};
+
+const APP_PY: &str = "import os\n\nprint(\"hello from app.py\")\n";
+
+/// Strip tags and unescape the entities the HTML writer emits, leaving
+/// the text a reader actually sees. Used where syntax-highlighting
+/// markup would otherwise dominate the assertion.
+fn visible_text(html: &str) -> String {
+    let mut out = String::new();
+    let mut in_tag = false;
+    for ch in html.chars() {
+        match ch {
+            '<' => in_tag = true,
+            '>' => in_tag = false,
+            c if !in_tag => out.push(c),
+            _ => {}
+        }
+    }
+    out.replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&amp;", "&")
+}
+
+/// The rendered `<code>` body of the first listing in `html`.
+///
+/// Deliberately class-agnostic: a `.python` fence renders with
+/// `sourceCode` highlighting classes while a `.markdown` one does not,
+/// and both shapes appear in these tests.
+fn listing_body(html: &str) -> String {
+    let start = html
+        .find("<pre")
+        .unwrap_or_else(|| panic!("no listing in output:\n{html}"));
+    let rest = &html[start..];
+    let code_at = rest
+        .find("<code")
+        .unwrap_or_else(|| panic!("listing has no <code> element:\n{rest}"));
+    let open = code_at + rest[code_at..].find('>').expect("unclosed <code> tag") + 1;
+    let end = rest.find("</code>").expect("listing closes its <code>");
+    rest[open..end].to_string()
+}
+
+#[tokio::test]
+async fn code_fence_include_renders_the_file_contents() {
+    let output = render_fixture(
+        &[
+            (
+                "index.qmd",
+                "---\ntitle: Listing\n---\n\n\
+                 ```{.python filename=\"app.py\"}\n\
+                 {{< include app.py >}}\n\
+                 ```\n",
+            ),
+            ("app.py", APP_PY),
+        ],
+        "index.qmd",
+    )
+    .await;
+
+    assert!(
+        output.diagnostics.is_empty(),
+        "expected a clean render, got {:?}",
+        codes(&output)
+    );
+
+    let body = listing_body(&output.html);
+    // The `?include` token is what this strand exists to remove.
+    assert!(
+        !output.html.contains("?include"),
+        "fence body still shows the error token:\n{body}"
+    );
+    // Content is present and syntax-highlighted (it went through the
+    // normal listing path, not a raw dump).
+    assert!(body.contains("import"), "missing file content:\n{body}");
+    assert!(
+        body.contains("hello from app.py"),
+        "missing file content:\n{body}"
+    );
+    assert!(
+        body.contains("<span class=\"hl-"),
+        "expected highlighting spans:\n{body}"
+    );
+    // The fence's own attributes survive the splice.
+    assert!(
+        output.html.contains("data-filename=\"app.py\""),
+        "lost the filename attribute"
+    );
+    // D4: exactly one trailing newline trimmed, so the listing has no
+    // blank final line. Q1's rendered output has none either.
+    assert!(
+        !body.ends_with('\n'),
+        "listing gained a trailing blank line: {body:?}"
+    );
+}
+
+#[tokio::test]
+async fn code_fence_include_does_not_warn_q_17_4() {
+    // The warning still exists for genuinely unsupported positions,
+    // but this shape is now supported — and its old hint ("put the
+    // shortcode in its own paragraph") would have told the author to
+    // change what the page means.
+    let output = render_fixture(
+        &[
+            (
+                "index.qmd",
+                "---\ntitle: Listing\n---\n\n```{.python}\n{{< include app.py >}}\n```\n",
+            ),
+            ("app.py", APP_PY),
+        ],
+        "index.qmd",
+    )
+    .await;
+
+    assert!(
+        !codes(&output).contains(&"Q-17-4"),
+        "unexpected Q-17-4: {:?}",
+        codes(&output)
+    );
+}
+
+#[tokio::test]
+async fn opted_out_code_fence_shows_the_shortcode_literally() {
+    // `shortcodes="false"` is how documentation displays the syntax
+    // itself; it must keep winning over expansion.
+    let output = render_fixture(
+        &[
+            (
+                "index.qmd",
+                "---\ntitle: Listing\n---\n\n\
+                 ```{.markdown shortcodes=\"false\"}\n\
+                 {{< include app.py >}}\n\
+                 ```\n",
+            ),
+            ("app.py", APP_PY),
+        ],
+        "index.qmd",
+    )
+    .await;
+
+    assert!(
+        output.diagnostics.is_empty(),
+        "expected a clean render, got {:?}",
+        codes(&output)
+    );
+    assert!(
+        output.html.contains("{{&lt; include app.py &gt;}}"),
+        "opted-out fence should show the shortcode literally:\n{}",
+        output.html
+    );
+    assert!(
+        !output.html.contains("hello from app.py"),
+        "opted-out fence must not splice the file"
+    );
+}
+
+#[tokio::test]
+async fn mid_line_include_in_a_fence_stays_literal() {
+    // Recognition is line-strict (D2, matching Q1), so this is *not*
+    // an include — but before the fix the leftover shortcode still
+    // reached ShortcodeResolveTransform and came out as `?include`,
+    // corrupting the listing. Q1 renders the line untouched and
+    // silently; so do we.
+    let output = render_fixture(
+        &[
+            (
+                "index.qmd",
+                "---\ntitle: Listing\n---\n\n```{.python}\nx = 1  {{< include app.py >}}\n```\n",
+            ),
+            ("app.py", APP_PY),
+        ],
+        "index.qmd",
+    )
+    .await;
+
+    let body = listing_body(&output.html);
+    assert!(
+        !body.contains("?include"),
+        "mid-line include corrupted the listing:\n{body}"
+    );
+    // Compare the visible text: the line is syntax-highlighted, so the
+    // markup around it is not what this test is about.
+    assert_eq!(visible_text(&body), "x = 1  {{< include app.py >}}");
+}
+
+#[tokio::test]
+async fn mid_line_include_in_inline_code_stays_literal() {
+    // Same rule for inline code spans.
+    let output = render_fixture(
+        &[
+            (
+                "index.qmd",
+                "---\ntitle: Listing\n---\n\nSee `x = {{< include app.py >}}` here.\n",
+            ),
+            ("app.py", APP_PY),
+        ],
+        "index.qmd",
+    )
+    .await;
+
+    assert!(
+        !output.html.contains("?include"),
+        "inline code corrupted:\n{}",
+        output.html
+    );
+    assert!(
+        output
+            .html
+            .contains("<code>x = {{&lt; include app.py &gt;}}</code>"),
+        "expected literal shortcode text in the code span:\n{}",
+        output.html
+    );
+}
+
+#[tokio::test]
+async fn nested_code_fence_include_expands_without_token() {
+    // The case that made "no recursion" untenable: with the spliced
+    // text left alone, `{{< include inner.qmd >}}` survived to
+    // ShortcodeResolveTransform and came out as `?include` — the
+    // strand's own bug, one level down, plus a Q-17-4 pointing at a
+    // fence the author never put an include in. Recursion (Q1's
+    // behavior) removes the shortcode before that transform runs.
+    let output = render_fixture(
+        &[
+            (
+                "index.qmd",
+                "---\ntitle: Listing\n---\n\n```{.markdown}\n{{< include outer.qmd >}}\n```\n",
+            ),
+            (
+                "outer.qmd",
+                "top line\n{{< include inner.qmd >}}\nbottom line\n",
+            ),
+            ("inner.qmd", "INNER-CONTENT\n"),
+        ],
+        "index.qmd",
+    )
+    .await;
+
+    assert!(
+        output.diagnostics.is_empty(),
+        "expected a clean render, got {:?}",
+        codes(&output)
+    );
+    assert!(
+        !output.html.contains("?include"),
+        "nested include leaked the error token:\n{}",
+        output.html
+    );
+    let body = listing_body(&output.html);
+    assert!(
+        body.contains("INNER-CONTENT"),
+        "nested include did not expand:\n{body}"
+    );
+    assert!(
+        body.contains("top line") && body.contains("bottom line"),
+        "lost the surrounding lines:\n{body}"
+    );
+}
+
+#[tokio::test]
+async fn self_including_code_fence_reports_a_cycle() {
+    // Embedding a document in its own listing would recurse forever:
+    // the spliced copy carries the same include line.
+    let output = render_fixture(
+        &[(
+            "index.qmd",
+            "---\ntitle: Listing\n---\n\n```{.markdown}\n{{< include index.qmd >}}\n```\n",
+        )],
+        "index.qmd",
+    )
+    .await;
+
+    assert!(
+        codes(&output).contains(&"Q-17-1"),
+        "expected a circular-include warning, got {:?}",
+        codes(&output)
+    );
+    assert!(
+        !output.html.contains("?include"),
+        "cycle leaked the error token:\n{}",
+        output.html
+    );
+}
+
+#[tokio::test]
+async fn missing_code_fence_include_reports_q_17_2_without_token() {
+    let output = render_fixture(
+        &[(
+            "index.qmd",
+            "---\ntitle: Listing\n---\n\n```{.python}\nkept = 1\n{{< include gone.py >}}\n```\n",
+        )],
+        "index.qmd",
+    )
+    .await;
+
+    assert!(
+        codes(&output).contains(&"Q-17-2"),
+        "expected a missing-file warning, got {:?}",
+        codes(&output)
+    );
+    // The unresolved line is dropped rather than left to become
+    // `?include` downstream.
+    assert!(
+        !output.html.contains("?include"),
+        "unresolved include leaked the error token:\n{}",
+        output.html
+    );
+    let body = listing_body(&output.html);
+    assert!(body.contains("kept"), "lost the surrounding code:\n{body}");
+}

--- a/crates/quarto-core/tests/integration/main.rs
+++ b/crates/quarto-core/tests/integration/main.rs
@@ -24,6 +24,7 @@ pub mod extension_metadata;
 pub mod fail_fast;
 pub mod get_config_merge;
 pub mod idempotence;
+pub mod include_code_fence;
 pub mod include_expansion_diagnostics;
 pub mod include_nested_expansion;
 pub mod include_project_absolute;

--- a/crates/quarto-preview/src/deps.rs
+++ b/crates/quarto-preview/src/deps.rs
@@ -141,9 +141,12 @@ pub async fn deps_handler(
 /// then walks every block-list position for the same "is this an
 /// include shortcode?" shape [`IncludeExpansionStage`] uses (via the
 /// shared [`collect_include_paths`] walker, which mirrors the
-/// expander's traversal exactly). Paths are resolved relative to
-/// `page_rel`'s directory and emitted as forward-slash
-/// project-relative strings, deduplicated and sorted.
+/// expander's traversal exactly). That includes the *text* of code
+/// fences, where a lone `{{< include … >}}` line embeds a source file
+/// as a listing (bd-include-in-code-block-f8mvtczn) — those targets are
+/// dependencies too. Paths are resolved relative to `page_rel`'s
+/// directory and emitted as forward-slash project-relative strings,
+/// deduplicated and sorted.
 ///
 /// On parse failure, returns an empty list — see the module-level
 /// fail-open rationale.
@@ -358,13 +361,31 @@ mod tests {
     }
 
     #[test]
-    fn include_inside_code_block_is_not_a_dep() {
-        // Shortcode syntax inside a fenced code block is just text;
-        // the AST walker only sees a `Block::CodeBlock`, no
-        // shortcode inlines. (The regex implementation we replaced
-        // would have incorrectly matched this — that's the bug the
-        // AST-based approach fixes.)
-        let src = "# A\n\n```\n{{< include foo.qmd >}}\n```\n";
+    fn include_inside_code_block_is_a_dep() {
+        // bd-include-in-code-block-f8mvtczn: a lone include inside a
+        // fence splices the target's text into the listing (the Q1
+        // idiom for embedding a source file), so the embedded file is
+        // a real dependency — editing it must rebuild the page that
+        // shows it. This reverses the earlier contract, when a fence
+        // include was inert text.
+        let src = "# A\n\n```{.python}\n{{< include app.py >}}\n```\n";
+        assert_eq!(deps_for(src, "index.qmd"), vec!["app.py"]);
+    }
+
+    #[test]
+    fn include_inside_opted_out_code_block_is_not_a_dep() {
+        // `shortcodes="false"` means the fence displays the syntax
+        // rather than expanding it, so there is nothing to depend on.
+        let src = "# A\n\n```{.markdown shortcodes=\"false\"}\n{{< include app.py >}}\n```\n";
+        assert!(deps_for(src, "index.qmd").is_empty());
+    }
+
+    #[test]
+    fn mid_line_include_inside_code_block_is_not_a_dep() {
+        // Recognition is line-strict (Q1's `isBlockShortcode`), so a
+        // shortcode sharing its line with code is inert text and
+        // contributes no dependency.
+        let src = "# A\n\n```{.python}\nx = 1  {{< include app.py >}}\n```\n";
         assert!(deps_for(src, "index.qmd").is_empty());
     }
 

--- a/crates/quarto/tests/smoke-all/includes/in-code-fence/app.py
+++ b/crates/quarto/tests/smoke-all/includes/in-code-fence/app.py
@@ -1,0 +1,3 @@
+import os
+
+print("FENCE-INCLUDE-MARKER-XYZ", os.name)

--- a/crates/quarto/tests/smoke-all/includes/in-code-fence/in-code-fence.qmd
+++ b/crates/quarto/tests/smoke-all/includes/in-code-fence/in-code-fence.qmd
@@ -1,0 +1,28 @@
+---
+title: Include Inside a Fenced Code Block
+format: html
+_quarto:
+  tests:
+    html:
+      noErrors: true
+      ensureFileRegexMatches:
+        - ["FENCE-INCLUDE-MARKER-XYZ", "data-filename=\"app.py\"", "OPTED-OUT-MARKER-XYZ"]
+        - ["\\?include", "Q-17-4"]
+      ensureHtmlElements:
+        - ["pre.sourceCode.python code.sourceCode.python"]
+---
+
+The Quarto 1 listing idiom: an include standing alone inside a fenced
+code block splices the target's text into the fence
+(bd-include-in-code-block-f8mvtczn).
+
+```{.python filename="app.py"}
+{{< include app.py >}}
+```
+
+`shortcodes="false"` still opts out, so the shortcode shows literally —
+this is how documentation displays the syntax itself.
+
+```{.markdown shortcodes="false"}
+OPTED-OUT-MARKER-XYZ {{< include app.py >}}
+```

--- a/docs/errors/include/Q-17-4.qmd
+++ b/docs/errors/include/Q-17-4.qmd
@@ -17,11 +17,11 @@ categories:
 ## What this means
 
 Quarto expands `{{{< include >}}}` shortcodes that stand alone: the
-shortcode must be the sole content of its own paragraph. This
-warning fires when an include shortcode is written somewhere the
-expansion pass does not reach — for example inline, in the middle
-of a sentence. The shortcode is not expanded and contributes no
-content to the output.
+shortcode must be the sole content of its own paragraph, or of its
+own line inside a fenced code block. This warning fires when an
+include shortcode is written somewhere the expansion pass does not
+reach — for example inline, in the middle of a sentence. The
+shortcode is not expanded and contributes no content to the output.
 
 Note the difference from `Q-16-3` "Unknown Shortcode": the name
 `include` is recognized; the problem is the position, not the
@@ -37,10 +37,23 @@ Common causes:
 - **Missing blank lines** around the shortcode, causing it to be
   parsed as part of an adjacent paragraph instead of standing
   alone.
+- **An include sharing its line with code**, inside a fenced code
+  block — `x = 1  {{{< include app.py >}}}`. Inside a fence the
+  shortcode must occupy a line of its own.
 
-(Includes nested inside containers — fenced divs, callouts,
-blockquotes, list items, tables — *are* expanded; only the inline
-position is unsupported.)
+Includes nested inside containers — fenced divs, callouts,
+blockquotes, list items, tables — *are* expanded. So is an include
+alone on its own line inside a fenced code block, which embeds the
+target file's text as a listing:
+
+````{.markdown shortcodes="false"}
+```{.python filename="app.py"}
+{{< include app.py >}}
+```
+````
+
+Only the inline position, and a shortcode sharing its line with
+other content, are unsupported.
 
 ## How to fix
 


### PR DESCRIPTION
## The bug

An `include` standing alone inside a fenced code block — the Quarto 1 idiom for embedding a source file as a listing —

````markdown
```{.python filename="app.py"}
{{< include app.py >}}
```
````

rendered with the entire fence body replaced by the token `?include`. A `Q-17-4` warning fired, but its hint ("put the include shortcode in its own paragraph, surrounded by blank lines") was actively wrong here — following it would change what the page means.

Motivating corpus: the Posit Connect docs port, where this is the single largest content loss — **44 listings across 20 files**, ~1300 lines of embedded source. Every cookbook integration recipe embeds its `requirements.txt` / `app.py` / `app.R` this way.

## Why the fix is in `IncludeExpansionStage`, not the transform

The strand originally proposed handling this in `ShortcodeResolveTransform`'s text-expansion path — which is where `?include` is written. That site cannot work: the transform runs in `AstTransformsStage` (pipeline stage 13), *after* `DocumentProfileStage` (stage 6) drains the include side-channel into `DocumentProfile.includes`. Profiles are read-only, so an include registered there could never become a dependency — editing `app.py` would not rebuild the page embedding it.

`IncludeExpansionStage` (stage 3) already holds `ctx.runtime`, `base_dir`, `project_dir`, `recorded_includes` and the cycle stack, and expanding there means the shortcode is gone before stage 13 — so `Q-17-4` stops firing for this shape with no change to the diagnostic, preserving the invariant documented at `shortcode_resolve.rs`.

## Behavior

Verified against `quarto-cli` @ `abc6a78ed` (source read) and a real `quarto render` of the repro.

| | |
|---|---|
| **Recognition** | Line-strict — the shortcode must be the sole content of its line. This matches Q1's `isBlockShortcode` (`/^\s*{{< … >}}\s*$/`) exactly; the strand's "Q1 substitutes anywhere in code text" framing was wrong. Indented include lines splice without re-indentation, as Q1 does. |
| **Recursion** | On, matching Q1's `standaloneInclude`. Cycles caught via the existing canonicalized `include_stack` (`Q-17-1`). |
| **Trailing newline** | Exactly one trimmed. Q1 *appends* newlines but Pandoc's markdown re-read absorbs them; q2 emits HTML straight from the AST, so without the trim every listing gains a blank final line. |
| **Opt-out** | `shortcodes="false"` still wins. The predicate is now shared with `ShortcodeResolveTransform` instead of duplicated. |
| **Leftovers** | An unhandled include in *code* text is preserved verbatim rather than becoming `?include`. Mid-line includes are deliberately unrecognized, and Q1 leaves them untouched and silent. |
| **Dependencies** | Fence targets flow through the shared `collect_include_paths` walker, so the preview dep-graph rebuilds a page when its embedded file changes. |

### Deliberate divergences from Q1

- **Consecutive includes in one fence** — Q1 renders `AAA\n\nBBB`, we render `AAA\nBBB`. Q1's blank line is the same `standaloneInclude` artifact as the trailing-newline case: a markdown block separator that is noise inside a fence.
- **Nested-path anchor** — we resolve nested includes against the *including file's* directory (matching block-position includes, bd-1fz3vh99); Q1 resolves against the document. Confirmed empirically: Q1 fatally aborts the render on `sub/outer.qmd` including a sibling.

## Verification

- `cargo xtask verify` — all 14 steps green, WASM/hub-client leg included
- 19 unit tests + 8 full-pipeline integration tests (`include_code_fence.rs`) + 1 smoke-all fixture (`includes/in-code-fence/`)
- Full workspace: 11,376 tests passing; clippy and `cargo fmt` clean
- **No snapshot files added, modified, or removed**
- Three `quarto-preview` dep tests updated — they pinned the old "a fence include is not a dependency" contract

### End-to-end on the real corpus

`352 of 352` files rendered. Corpus-wide `?include` count dropped to **1**, and that one is not a fence — it is the raw-HTML shape the strand itself calls docs-fixable (`licenses/index.md`: an include directly under an HTML comment, swallowed into a `RawBlock`), where `Q-17-4`'s existing hint is exactly right. The worst-case page (`databricks/viewer/python/index.qmd`, ten listings across five framework tabs) renders all of them, including a 92-line `app.py`.

## Follow-up

**bd-cq0xhxg5** (docs, P2) — `include` is absent from the built-ins table in `docs/guides/authoring/shortcodes.qmd`, absent from its "Where shortcodes are evaluated" section, and there is no includes guide page at all. Filed to document the two expansion mechanisms once this lands.

Plan with full decision record: `claude-notes/plans/2026-08-10-include-in-code-block.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)