### PR TITLE
Process mermaid %%| cell options: captions, cross-references, alt text (bd-mermaid-cell-options-9wo3crl0)

### DIFF
--- a/claude-notes/plans/2026-08-10-mermaid-cell-options.md
+++ b/claude-notes/plans/2026-08-10-mermaid-cell-options.md
@@ -5,7 +5,8 @@
 **Branch:** `feature/bd-mermaid-cell-options-9wo3crl0` (no worktree; the
 investigation commit `f44b3a81` moved onto this branch and `main` was rewound to
 `a217ab5a`, so the whole strand lands as one PR)
-**Status:** Design settled 2026-08-10 — implementing. See "Resolved decisions".
+**Status:** Implemented 2026-08-10, pending review. `cargo xtask verify` (full)
+passes. See "Resolved decisions" and the verification record.
 
 ## Triage verdict
 
@@ -245,19 +246,91 @@ be numbered. This is the strand's most important architectural constraint.
 - [x] **Phase 5 — `fig-alt` + `fig-scap` (fixes D3)** (commit `02cfccf4`).
       Stop consuming what cannot be routed; route `fig-alt` into `accDescr:`
       per decision 2.
-- [ ] **Phase 6 — Diagnostics.** Unknown-key warning for diagram cells and the
-      `#|`-in-mermaid warning, both source-mapped, per decisions 4 and 5.
-- [ ] **Phase 7 — End-to-end + preview verification.** `q2 render` on the
-      probes with output inspected and recorded here; confirm the React preview
-      path shows the same structure (`MermaidCodeBlock.tsx` touched only if the
-      parity check demands it).
-- [ ] **Phase 8 — Docs.** `docs/guides/authoring/diagrams.qmd` gains a captions
-      and alt-text section.
-- [ ] **Phase 9 (separate strand) — `qmd-syntax-helper` rule** rewriting
-      ```` ```{mermaid} ```` → ```` ```mermaid ````. With decision 5 this rule
-      should also rewrite the option marker to `%%|`. File before this PR
-      merges; rule surface is `crates/qmd-syntax-helper/src/rule.rs`,
-      conversions in `src/conversions/`.
+- [x] **Phase 6 — Diagnostics** (commit `0233f3cc`). Q-2-42 (option ignored on
+      a diagram cell, distinguishing unknown from recognized-but-unroutable)
+      and Q-2-43 (`#|` where `%%|` is expected), both source-mapped to the
+      offending key.
+- [x] **Phase 7 — End-to-end + preview verification.** See below.
+- [x] **Phase 8 — Docs.** `docs/guides/authoring/diagrams.qmd` gains a
+      "Captions, cross-references, and alt text" section, and the
+      "Differences from Quarto 1" list drops captions/labels/cross-references.
+      New worked example `examples/diagrams/03-mermaid-captions` registered in
+      `examples/manifest.yml`.
+- [x] **Phase 9 — filed as its own strand, bd-vg8p5yoj**: `qmd-syntax-helper`
+      rule rewriting ```` ```{mermaid} ```` → ```` ```mermaid ````. Cell
+      options need no rewrite — Q1 documents already write `%%|`, which is
+      exactly what this strand made q2 accept.
+
+## Verification record (Phase 7)
+
+**`cargo xtask verify` (full, including the hub/WASM leg): all steps passed.**
+
+### `q2 render`
+
+`cargo run --bin q2 -- render claude-notes/plans/mermaid-cell-options-investigation/probe.qmd`,
+output inspected:
+
+- **B1** (`%%| fig-cap` + `%%| fig-alt`, no label) →
+  `<div class="quarto-figure quarto-figure-center"><figure><pre class="mermaid">`
+  whose second line is `accDescr: Two nodes connected by an arrow.`, followed by
+  `<figcaption>A tiny flowchart.</figcaption>`.
+- **B2** (`%%| label: fig-diagram` + `%%| fig-cap`) → the numbered float,
+  `<figcaption id="fig-diagram-caption">Figure 1: A labelled flowchart.</figcaption>`,
+  and `@fig-diagram` resolving to a live `Figure 1` link (it previously emitted
+  `?fig-diagram?` plus an unresolved-crossref warning).
+- **B3** (`#|` in a mermaid fence) → left inert, with Q-2-43 reported at
+  `probe.qmd:28:1` — the exact line of the `#|` run.
+- **B4** (a `%%|` below the first code line) → left as an ordinary comment.
+
+`…/probe4.qmd` exercises the diagnostics: Q-2-42 at `9:5` (`echo`) and `10:5`
+(`theme`) with the caret on the key, Q-2-42 at `20:5` naming `fig-scap` as
+recognized-but-ineffective, and **no** diagnostics from the ```` ```{python} ````
+cell in the same document.
+
+### The accessibility claim, verified against real mermaid
+
+Both browser routes were unavailable in this session (the claude-in-chrome
+extension was not connected; the chrome-devtools MCP profile was locked by an
+already-running Chrome). Instead the claim was verified **headlessly against
+real mermaid 11.12.0** — the version `MERMAID_VERSION` pins — under jsdom, with
+the exact text `inject_acc_descr` emits:
+
+```
+desc text        : "Two nodes connected by an arrow."
+aria-describedby : chart-desc-probe
+desc id          : chart-desc-probe
+ids match        : true
+placement-before : REJECTED — UnknownDiagramError: No diagram type detected …
+```
+
+So the injected line becomes `<desc>` inside the SVG with the SVG's
+`aria-describedby` pointing at it, and the negative control confirms the
+placement constraint is real: `accDescr:` *before* the diagram-type line is
+rejected outright, which is why the directive is inserted after the first
+declaration line rather than at the top.
+
+**Not verified:** how the result presents in an actual screen reader, and the
+`q2 preview` UI in a live browser session.
+
+### Preview parity
+
+Pinned by `pipeline::tests::render_qmd_to_preview_ast_processes_mermaid_cell_options`:
+the preview AST carries the `Figure` wrapper, the caption inlines, the injected
+`accDescr:`, and no `%%|` — while the diagram still arrives as a `CodeBlock` for
+`MermaidCodeBlock.tsx` (`mermaid-render` stays on
+`Q2_PREVIEW_TRANSFORM_EXCLUDED`). That is the intended difference between the
+surfaces, and the test pins it so neither list can drift silently.
+
+Reading that AST surfaced an unrelated pre-existing issue, filed as
+**bd-e3m3rkik**: because `mermaid-render` is excluded from preview,
+`CodeBlockRenderTransform` *does* see mermaid blocks there and wraps them in
+copy-button chrome that `q2 render` suppresses by transform ordering.
+
+### Docs
+
+`cargo run --bin q2 -- render docs/` → 194 of 194 files, no errors. The
+diagrams page carries the new section and the `Demo 3` cross-reference to the
+embedded example.
 
 ## Risks / tradeoffs (draft)
 

--- a/claude-notes/plans/2026-08-10-mermaid-cell-options.md
+++ b/claude-notes/plans/2026-08-10-mermaid-cell-options.md
@@ -246,9 +246,9 @@ be numbered. This is the strand's most important architectural constraint.
 - [x] **Phase 5 — `fig-alt` + `fig-scap` (fixes D3)** (commit `02cfccf4`).
       Stop consuming what cannot be routed; route `fig-alt` into `accDescr:`
       per decision 2.
-- [x] **Phase 6 — Diagnostics** (commit `0233f3cc`). Q-2-42 (option ignored on
+- [x] **Phase 6 — Diagnostics** (commit `0233f3cc`, renumbered on rebase). Q-2-47 (option ignored on
       a diagram cell, distinguishing unknown from recognized-but-unroutable)
-      and Q-2-43 (`#|` where `%%|` is expected), both source-mapped to the
+      and Q-2-48 (`#|` where `%%|` is expected), both source-mapped to the
       offending key.
 - [x] **Phase 7 — End-to-end + preview verification.** See below.
 - [x] **Phase 8 — Docs.** `docs/guides/authoring/diagrams.qmd` gains a
@@ -260,6 +260,22 @@ be numbered. This is the strand's most important architectural constraint.
       rule rewriting ```` ```{mermaid} ```` → ```` ```mermaid ````. Cell
       options need no rewrite — Q1 documents already write `%%|`, which is
       exactly what this strand made q2 accept.
+
+## Rebase note: error codes renumbered
+
+The branch was rebased onto `origin/main` before opening the PR, and
+`main` had meanwhile claimed **Q-2-42 through Q-2-46** (conditional-content
+attributes, callout titles, reference-style links — PR #497). The two codes
+added here were renumbered **Q-2-42 → Q-2-47** and **Q-2-43 → Q-2-48**; the
+catalog conflict was resolved by keeping `main`'s entries and appending the
+renumbered pair. The Phase 6 commit *message* still names the pre-rebase
+numbers — the code, catalog, tests and this plan all use the final ones.
+
+Worth knowing for the next person: `error_catalog.json` is an append-heavy
+shared file with no reservation mechanism, so two branches adding codes in
+the same window will always collide there. The conflict is mechanical, but
+the renumber has to be chased through every `with_code(...)` call, its
+tests, and any prose that quotes the code.
 
 ## Verification record (Phase 7)
 
@@ -278,12 +294,12 @@ output inspected:
   `<figcaption id="fig-diagram-caption">Figure 1: A labelled flowchart.</figcaption>`,
   and `@fig-diagram` resolving to a live `Figure 1` link (it previously emitted
   `?fig-diagram?` plus an unresolved-crossref warning).
-- **B3** (`#|` in a mermaid fence) → left inert, with Q-2-43 reported at
+- **B3** (`#|` in a mermaid fence) → left inert, with Q-2-48 reported at
   `probe.qmd:28:1` — the exact line of the `#|` run.
 - **B4** (a `%%|` below the first code line) → left as an ordinary comment.
 
-`…/probe4.qmd` exercises the diagnostics: Q-2-42 at `9:5` (`echo`) and `10:5`
-(`theme`) with the caret on the key, Q-2-42 at `20:5` naming `fig-scap` as
+`…/probe4.qmd` exercises the diagnostics: Q-2-47 at `9:5` (`echo`) and `10:5`
+(`theme`) with the caret on the key, Q-2-47 at `20:5` naming `fig-scap` as
 recognized-but-ineffective, and **no** diagnostics from the ```` ```{python} ````
 cell in the same document.
 

--- a/claude-notes/plans/2026-08-10-mermaid-cell-options.md
+++ b/claude-notes/plans/2026-08-10-mermaid-cell-options.md
@@ -2,10 +2,10 @@
 
 **Date:** 2026-08-10
 **Braid:** bd-mermaid-cell-options-9wo3crl0
-**Branch:** `main` (investigation committed in place — no worktree was created; see
-"Where this should land" below)
-**Status:** Investigation — pending design alignment with user. **Do not start
-implementation until the user gives the go-ahead.**
+**Branch:** `feature/bd-mermaid-cell-options-9wo3crl0` (no worktree; the
+investigation commit `f44b3a81` moved onto this branch and `main` was rewound to
+`a217ab5a`, so the whole strand lands as one PR)
+**Status:** Design settled 2026-08-10 — implementing. See "Resolved decisions".
 
 ## Triage verdict
 
@@ -173,84 +173,86 @@ too, without touching `MermaidCodeBlock.tsx`. Doing the work inside
 from preview) *and* would land after `crossref-render`, so a `label:` could never
 be numbered. This is the strand's most important architectural constraint.
 
-## Proposed phases (draft)
+## Resolved decisions (Carlos, 2026-08-10)
 
-Skeleton only — contents wait on the design discussion below.
+1. **Unlabelled `fig-cap` emits `Block::Figure`.** A bare `fig-cap` with no
+   `label:` becomes a real `Figure` node, which the HTML writer already renders
+   as `<figure>…<figcaption>` with no number and no float scaffolding. Rationale
+   worth preserving: *Q1 could not do this because its cell handling was entirely
+   textual — it had to emit markdown and let a filter rebuild the structure. We
+   are working on the AST, so we can construct the node directly.* Labelled
+   captions keep going through the existing crossref float Div, which is what
+   gives them `Figure N:` numbering and `aria-describedby`.
 
-- **Phase 0 — Test plan (TDD, failing first).** Unit tests in
-  `cell_options` (mermaid → `%%`), in `codeblock_shorthand` (prefix selection,
-  YAML-quoted values, inline captions, `fig-alt` routing), and at least one
-  end-to-end `q2 render` fixture asserting `<figcaption>` + the accessible-name
-  markup on a `%%|` mermaid block. Per CLAUDE.md, the e2e test must drive the
-  real render path, not `render_qmd_to_html` with defaults.
-- **Phase 1 — Teach `cell_options` about mermaid.** Add `"mermaid" => ("%%",
-  None)` to `comment_syntax_for`. Cheap, isolated, testable.
-- **Phase 2 — Migrate `codeblock_shorthand` onto the `cell_options` facility.**
-  Replace the hard-coded `"#|"` matcher with a language-driven one (language =
-  the code block's first class, minus brace form). Fixes D1 for free. Needs care
-  around the `passthrough` set, which currently relies on line-level rewriting.
-- **Phase 3 — Route `fig-alt` (D3) and parse caption inlines (D2).** Decide the
-  markup for the accessible name (question 2) and stop dropping `fig-scap`.
-- **Phase 4 — Unlabelled `fig-cap`.** Make `fig-cap` without `label:` produce a
-  caption (question 1).
-- **Phase 5 — Preview verification.** Confirm the React path renders the same
-  structure; only touch `MermaidCodeBlock.tsx` if the parity check says so.
-- **Phase 6 — Docs.** `docs/guides/authoring/diagrams.qmd` has no captions/alt
-  section; add one showing the `%%|` form.
-- **Phase 7 (separate strand?) — `qmd-syntax-helper` rule** rewriting
-  ```` ```{mermaid} ```` → ```` ```mermaid ````, and `%%|`/`#|` normalization if
-  we settle on one marker. Rule surface: `crates/qmd-syntax-helper/src/rule.rs`,
-  conversions in `src/conversions/`.
+2. **`fig-alt` is injected as mermaid's native `accDescr:` directive** (option
+   (c)). It survives mermaid.js's replacement of the `<pre>` with an inline
+   `<svg>`, which `aria-label` on the `<pre>` would not.
+   **Recorded for the future:** option (a) — putting the accessible name on the
+   emitted element — *becomes the right answer once we render diagrams
+   server-side for PDF/print output.* At that point there is a real image element
+   to carry `alt`, the runtime SVG swap no longer happens, and `accDescr:` inside
+   the diagram source stops being the mechanism that reaches assistive tech. Any
+   future server-side-rendering strand should revisit this decision rather than
+   assume `accDescr:` generalizes.
 
-## Open design questions for the user
+3. **D1, D2 and D3 are all fixed on this strand**, one commit per defect so the
+   PR reads as a sequence of reviewable changes. The three `discovered-from`
+   strands (bd-5jcmmj1f, bd-sdpp9rw4, bd-il6pxq4f) stay open as the record and
+   close when this lands.
 
-1. **Unlabelled `fig-cap`.** Today a caption only appears when there is also a
-   `label:` that classifies as a crossref — `codeblock_shorthand` returns early
-   otherwise (probe C4: nothing happens). Q1 emits an unnumbered
-   `<figure><figcaption>` for a bare `fig-cap`. Should q2 do the same — and if
-   so, via a `Block::Figure` (which the HTML writer already renders with a bare
-   `<figcaption>`), or by extending the Div scaffold to an id-less float? This
-   matters a lot for the Connect docs, where captions may well appear without
-   labels.
+4. **Unknown option keys warn, with a source-mapped diagnostic.** This is what
+   makes migrating onto `cell_options::partition_cell_options` load-bearing
+   rather than incidental: it is the only path that carries real spans, so the
+   diagnostic can point at the offending key rather than at the block.
+   **Scope limit — important:** the warning applies to *non-executable* diagram
+   cells only. For an executable cell (` ```{python} `) an unrecognized key is
+   normally an engine option (`echo`, `eval`, `warning`, engine-specific keys)
+   and must keep passing through silently; warning there would fire on
+   essentially every real document. So "unknown key" is defined against the
+   recognized set *for a diagram language*, and the executable path keeps its
+   current passthrough behavior.
 
-2. **What markup does `fig-alt` produce?** The output here is `<pre
-   class="mermaid">` that mermaid.js replaces with an inline `<svg>` at runtime —
-   there is no `<img alt>` to hang it on. Candidates: (a) `aria-label` on the
-   `<pre>`; (b) a visually-hidden `<div>` plus `aria-describedby` (note the
-   figure scaffold *already* emits `aria-describedby` pointing at the
-   figcaption — a second description would need reconciling); (c) mermaid's own
-   `accDescr:`/`accTitle:` directives injected into the diagram source, which is
-   the mermaid-native answer and survives the SVG swap. I lean toward (c) with
-   (a) as a fallback, but it's a real decision and it's the accessibility story
-   for those Connect pages.
+5. **Q1 parity on the marker: ` ```mermaid ` accepts `%%|` only.** `#|` in a
+   mermaid fence stops being a cell-option marker — a deliberate behavior change
+   from what probe B3 does today. Rationale: q2 is in `0.*`; being strict now
+   avoids teaching people that `#|` is universal. Consequence worth handling:
+   `#` is *not* a mermaid comment character, so a leftover `#| …` line becomes
+   diagram source and mermaid renders a syntax error. A leading run of `#|` lines
+   in a mermaid block therefore gets its own diagnostic pointing at `%%|`,
+   so the failure is legible rather than a broken diagram.
 
-3. **Scope: do D1/D2/D3 get fixed here or split out?** They are pre-existing
-   general bugs in the `#|` shorthand, not mermaid regressions. D3 (`fig-alt`
-   dropped) is unavoidable here. D1 (quotes) falls out of the `cell_options`
-   migration whether we want it or not. D2 (markdown captions) is genuinely
-   separable. Options: (i) fix all three on this strand, (ii) fix D1+D3 here and
-   file D2, (iii) file all three and make this strand depend on them. Whichever
-   we pick, D1 and D2 will move existing snapshots — expect a snapshot diff to
-   report per the CLAUDE.md snapshot policy.
+6. **Lands on `feature/bd-mermaid-cell-options-9wo3crl0`**, no worktree. The
+   investigation commit moved onto the branch; `main` was rewound to `a217ab5a`.
 
-4. **Which option keys are honoured, and what happens to the rest?** The strand
-   asks. Beyond `label` / `fig-cap` / `fig-alt`: `fig-scap`? `fig-align`?
-   `mermaid-format`/`theme` (which overlap bd-sehm2rha / bd-nj25kgbu)? And for
-   unrecognized keys: today unconsumed `#|`/`%%|` lines are *left in the code
-   body* — harmless for mermaid (`%%` is a comment, the diagram still draws) but
-   visible in the source and visible in `q2 preview`. Q1 strips every option
-   line. Do we strip all of them, and do unknown keys warn or go quiet?
+## Phases
 
-5. **One marker or two?** Should ```` ```mermaid ```` accept `%%|` *only* (Q1
-   parity), or keep accepting `#|` as well (which works today, per probe B3, and
-   which someone may already depend on)? Accepting both is the compatible
-   choice; accepting only `%%|` is the principled one and would be a behavior
-   regression for B3-shaped documents.
-
-6. **Where should this land?** I investigated on `main` in the primary checkout
-   and committed only the plan + probes there. Say the word and I'll set up
-   `cargo xtask create-worktree bd-mermaid-cell-options-9wo3crl0` for the
-   implementation, or tell me which branch you want it on.
+- [x] **Phase 0 — Investigation** (commit `f44b3a81`): plan + probes.
+- [ ] **Phase 1 — `cell_options` learns mermaid.** Add `"mermaid" => ("%%",
+      None)` to `comment_syntax_for`, with tests (including that a matlab/tikz
+      `%` cell and a mermaid `%%` cell do not cross-talk).
+- [ ] **Phase 2 — Migrate `codeblock_shorthand` onto `cell_options` (fixes
+      D1).** Language-aware prefix selection (language = the block's first
+      class, brace forms excluded) + real YAML parsing, replacing the
+      hard-coded `"#|"` matcher and `split_once(':')`. Makes `%%|` work and
+      makes quoted captions come out unquoted.
+- [ ] **Phase 3 — Caption inlines (fixes D2).** Parse `fig-cap` as markdown
+      inlines instead of a single `Str`.
+- [ ] **Phase 4 — `fig-alt` + `fig-scap` (fixes D3).** Stop dropping them;
+      route `fig-alt` into `accDescr:` per decision 2.
+- [ ] **Phase 5 — Unlabelled `fig-cap` → `Block::Figure`** per decision 1.
+- [ ] **Phase 6 — Diagnostics.** Unknown-key warning for diagram cells and the
+      `#|`-in-mermaid warning, both source-mapped, per decisions 4 and 5.
+- [ ] **Phase 7 — End-to-end + preview verification.** `q2 render` on the
+      probes with output inspected and recorded here; confirm the React preview
+      path shows the same structure (`MermaidCodeBlock.tsx` touched only if the
+      parity check demands it).
+- [ ] **Phase 8 — Docs.** `docs/guides/authoring/diagrams.qmd` gains a captions
+      and alt-text section.
+- [ ] **Phase 9 (separate strand) — `qmd-syntax-helper` rule** rewriting
+      ```` ```{mermaid} ```` → ```` ```mermaid ````. With decision 5 this rule
+      should also rewrite the option marker to `%%|`. File before this PR
+      merges; rule surface is `crates/qmd-syntax-helper/src/rule.rs`,
+      conversions in `src/conversions/`.
 
 ## Risks / tradeoffs (draft)
 
@@ -262,7 +264,8 @@ Skeleton only — contents wait on the design discussion below.
   the largest single risk on this plan.
 - **`passthrough` semantics.** `strip_consumed_lines` keeps unconsumed option
   lines *textually*, which the engine then re-parses. Moving to structured
-  parsing means deciding how to re-emit them (or whether to, per question 4).
+  parsing means deciding how to re-emit them. Per decision 4 the executable path
+  keeps textual passthrough; only diagram cells consume every key.
 - **Language detection.** Picking the comment syntax needs the block's language,
   which for a plain fence is the first class. Brace-form classes arrive as
   `{mermaid}` (see the existing `brace_form_mermaid_cell_untouched` test) —

--- a/claude-notes/plans/2026-08-10-mermaid-cell-options.md
+++ b/claude-notes/plans/2026-08-10-mermaid-cell-options.md
@@ -1,0 +1,279 @@
+# Mermaid `%%|` cell options are not processed (bd-mermaid-cell-options-9wo3crl0)
+
+**Date:** 2026-08-10
+**Braid:** bd-mermaid-cell-options-9wo3crl0
+**Branch:** `main` (investigation committed in place — no worktree was created; see
+"Where this should land" below)
+**Status:** Investigation — pending design alignment with user. **Do not start
+implementation until the user gives the go-ahead.**
+
+## Triage verdict
+
+**Ready to design**, and the shape is much smaller than the strand assumed: the
+caption/figure/crossref machinery already works end-to-end for a mermaid fence —
+it just keys off the `#|` marker instead of mermaid's `%%|`. The narrow fix is to
+make the pre-engine cell-option desugar *language-aware*. Two adjacent gaps
+surfaced during the probe that are **not** mermaid-specific and probably want
+their own strands.
+
+## Issue context
+
+Filed 2026-08-10 by Carlos, `feature`, priority 1, label `parity`, no dependency
+edges. Direction recorded in the description: q2 standardizes on the **GFM
+spelling** (```` ```mermaid ````), not Q1's ```` ```{mermaid} ```` executable-cell
+form. Phase one (diagrams render at all) is already done via
+`crates/quarto-core/src/transforms/mermaid.rs` (bd-5m4ga0s1, plan
+`claude-notes/plans/2026-07-20-mermaid-regular-rendering.md`). The live work is
+phase two: pull the `%%|` cell options out of the diagram source and route
+`fig-cap` / `fig-alt` into the output.
+
+Real-world driver: the Posit Connect docs port — 33 diagrams across 14 pages, all
+in the Q1 brace form. Rewriting them to the GFM spelling makes them draw
+immediately; captions and `fig-alt` accessible descriptions stay lost until this
+strand lands.
+
+## Dependency graph
+
+**Empty.** `braid dep tree` and `braid dep list` both return no edges — no
+incoming pressure from a blocked strand, and no `discovered-from` parent in this
+skein. The origin strand lives in a *different* skein (the connect-docs porting
+project, `br-mermaid-cell-options-r52f8p3v`) and is not reachable from here; the
+strand description carries the context that edge would have.
+
+Neighbors found by text search (informational only, no edges):
+
+- **bd-5m4ga0s1** (closed) — the transform this strand extends.
+- **bd-c3dtpe36** (open) — "Mermaid render component for q2-preview
+  (experiment → built-in path)". Owns the React side; relevant to the
+  preview/render parity question below.
+- **bd-sehm2rha**, **bd-nj25kgbu** (open) — mermaid *theming* (`$mermaid-*` SCSS
+  vars, `--mermaid-*` CSS bridge, `mermaid:` document metadata). Adjacent
+  surface: whichever of these lands first settles where mermaid-scoped
+  *document* metadata is read, which interacts with question 4 below.
+
+## What the code looks like today
+
+Everything the strand description points at still exists with the described
+shape. HEAD is `a217ab5a`; `cargo xtask verify --skip-hub-build` is green after a
+WASM rebuild (the one failure — a `named-entities` hub-client WASM smoke test —
+was **stale WASM**, not a real regression: `npm run build:wasm` followed by the
+same suite passes clean. Skipping the hub *build* still runs the hub *tests*
+against whatever `.wasm` is on disk, which is the trap here).
+
+### The relevant machinery, and how it actually composes
+
+Three pieces, in pipeline order:
+
+1. **`crates/quarto-core/src/cell_options/mod.rs`** — q2's single, proper
+   cell-option facility: `comment_syntax_for(language)` (a port of Q1's
+   `kLangCommentChars`), `partition_cell_options()` splitting a cell body into a
+   YAML options block + code with real source attribution, `options_to_config()`,
+   `merge_cell_over_scope()`. **It has no `mermaid` entry**, so mermaid falls
+   through to the `#` default. Q1 keeps mermaid's `%%` in
+   `src/resources/filters/modules/constants.lua` (`mermaid = {"%%"}`) and on the
+   handler (`comment: "%%"` in `src/core/handlers/mermaid.ts`), *not* in
+   `kLangCommentChars` — which is exactly why the port missed it.
+
+2. **`crates/quarto-core/src/crossref/codeblock_shorthand.rs`**, run from
+   `PreEngineSugaringStage` (`stage/stages/pre_engine_sugaring.rs:142`) — the
+   desugar that turns
+
+   ```
+   ```mermaid
+   #| label: fig-x
+   #| fig-cap: A caption.
+   …
+   ```
+   ```
+
+   into `Div(#fig-x)[ CodeBlock, Paragraph(caption) ]`. **It does not use the
+   `cell_options` facility**: it carries its own `parse_cell_options()` that
+   hard-codes the literal `"#|"` prefix and does a naive `split_once(':')`
+   instead of parsing YAML. (The `cell_options` module doc explicitly names this
+   matcher as a consumer that "should migrate here" — that migration never
+   happened.)
+
+3. **`crates/quarto-core/src/transforms/mermaid.rs`** — `Finalization`-phase
+   transform, recurses into `Div`/`Figure`/lists, rewrites the `CodeBlock` to
+   `RawBlock("html", "<pre class=\"mermaid\">…</pre>")`, appends the pinned-CDN
+   module script once. Excluded from the preview pipeline
+   (`Q2_PREVIEW_TRANSFORM_EXCLUDED`) so the raw `CodeBlock` survives to
+   `ts-packages/preview-renderer/src/q2-preview/blocks/MermaidCodeBlock.tsx`.
+
+Because (2) runs pre-engine and (3) recurses into `Div`, the two compose
+**already**. That is the key finding.
+
+### Probe results at HEAD
+
+Repro + probes committed under
+`claude-notes/plans/mermaid-cell-options-investigation/`. Rendered with
+`cargo run --bin q2 -- render <probe>.qmd`; HTML inspected directly.
+
+| probe | source | observed at HEAD |
+|---|---|---|
+| B1 | ```` ```mermaid ```` + `%%\| fig-cap` / `%%\| fig-alt`, no label | options verbatim in `<pre>`, no figure, no caption, no alt — **the reported bug** |
+| B2 | ```` ```mermaid ```` + `%%\| label: fig-diagram` + `%%\| fig-cap` | options verbatim; `@fig-diagram` emits `?fig-diagram?` + an unresolved-crossref warning |
+| **B3** | ```` ```mermaid ```` + **`#\|`** `label` + `fig-cap` | **fully works** — `<div id="fig-hash" class="quarto-float quarto-figure">`, `<figure>`, `<div aria-describedby="fig-hash-caption">`, `<figcaption>Figure 1: …</figcaption>`, and the diagram still converts to `<pre class="mermaid">` |
+| B4 | a `%%\|` line *below* the first code line | correctly left alone (leading-run-only semantics already hold) |
+
+So the entire figure/caption/crossref/`aria-describedby` path is live for mermaid
+today. **The only thing missing for the labelled case is that `%%|` isn't
+recognized as mermaid's option marker.** Verbatim from B3's output:
+
+```html
+<div id="fig-hash" class="quarto-float quarto-figure quarto-figure-center">
+<figure class="quarto-float quarto-float-fig">
+<div aria-describedby="fig-hash-caption">
+<pre class="mermaid">
+flowchart LR
+  I --&gt; J
+</pre>
+</div>
+<figcaption id="fig-hash-caption" class="quarto-float-caption-bottom quarto-float-caption quarto-float-fig">
+<p>Figure 1: &quot;Hash-prefixed.&quot;</p>
+</figcaption>
+</figure>
+</div>
+```
+
+### Three defects the probe exposed in the *shared* shorthand path
+
+These are **not mermaid-specific** — probe3 reproduces all three on a
+```` ```python ```` cell with `#|` options, so every `#|` code cell in the tree is
+affected. Note the `&quot;` in B3's figcaption above:
+
+- **D1 — quoted YAML strings keep their quotes.** `#| fig-cap: "Quoted caption."`
+  renders as `Figure 2: "Quoted caption."` (literal quote characters). Cause:
+  `parse_cell_options`' `split_once(':')` + `trim()` instead of YAML parsing.
+- **D2 — markdown in captions is not parsed.** `#| fig-cap: A *emphasized*
+  caption with [a link](…)` renders the asterisks and brackets literally. Cause:
+  `caption_paragraph()` builds a single `Inline::Str` rather than parsing the
+  caption as inlines.
+- **D3 — `fig-alt` (and `fig-scap`) are consumed and silently dropped.**
+  `partition_options()` classifies `<reftype>-alt` and `<reftype>-scap` as
+  *consumed* — removing them from the code body — but only `<reftype>-cap` is
+  ever read back into the Div scaffold. The text vanishes with no warning. Since
+  `fig-alt` is precisely what the strand cares about (the accessibility of the
+  Connect reference-architecture pages rests on it), **D3 is on this strand's
+  critical path** even though it is a general bug.
+
+Both D1 and D2 disappear naturally if the shorthand is migrated onto
+`cell_options::partition_cell_options` (real YAML) plus an inline parse for the
+caption — which is the same migration that makes `%%|` work. That argues for
+doing the migration rather than bolting a second prefix onto the ad-hoc parser.
+
+### Preview / render parity comes for free
+
+`PreEngineSugaringStage` is a *stage*, and `Q2_PREVIEW_TRANSFORM_EXCLUDED` only
+filters *transforms*. The stage runs in all three pipelines (`pipeline.rs:321`,
+`:573`, `:707`). So if option-stripping and figure-scaffolding happen at the
+pre-engine stage, `q2 preview` gets the stripped source and the caption structure
+too, without touching `MermaidCodeBlock.tsx`. Doing the work inside
+`transforms/mermaid.rs` instead would **break parity** (the transform is excluded
+from preview) *and* would land after `crossref-render`, so a `label:` could never
+be numbered. This is the strand's most important architectural constraint.
+
+## Proposed phases (draft)
+
+Skeleton only — contents wait on the design discussion below.
+
+- **Phase 0 — Test plan (TDD, failing first).** Unit tests in
+  `cell_options` (mermaid → `%%`), in `codeblock_shorthand` (prefix selection,
+  YAML-quoted values, inline captions, `fig-alt` routing), and at least one
+  end-to-end `q2 render` fixture asserting `<figcaption>` + the accessible-name
+  markup on a `%%|` mermaid block. Per CLAUDE.md, the e2e test must drive the
+  real render path, not `render_qmd_to_html` with defaults.
+- **Phase 1 — Teach `cell_options` about mermaid.** Add `"mermaid" => ("%%",
+  None)` to `comment_syntax_for`. Cheap, isolated, testable.
+- **Phase 2 — Migrate `codeblock_shorthand` onto the `cell_options` facility.**
+  Replace the hard-coded `"#|"` matcher with a language-driven one (language =
+  the code block's first class, minus brace form). Fixes D1 for free. Needs care
+  around the `passthrough` set, which currently relies on line-level rewriting.
+- **Phase 3 — Route `fig-alt` (D3) and parse caption inlines (D2).** Decide the
+  markup for the accessible name (question 2) and stop dropping `fig-scap`.
+- **Phase 4 — Unlabelled `fig-cap`.** Make `fig-cap` without `label:` produce a
+  caption (question 1).
+- **Phase 5 — Preview verification.** Confirm the React path renders the same
+  structure; only touch `MermaidCodeBlock.tsx` if the parity check says so.
+- **Phase 6 — Docs.** `docs/guides/authoring/diagrams.qmd` has no captions/alt
+  section; add one showing the `%%|` form.
+- **Phase 7 (separate strand?) — `qmd-syntax-helper` rule** rewriting
+  ```` ```{mermaid} ```` → ```` ```mermaid ````, and `%%|`/`#|` normalization if
+  we settle on one marker. Rule surface: `crates/qmd-syntax-helper/src/rule.rs`,
+  conversions in `src/conversions/`.
+
+## Open design questions for the user
+
+1. **Unlabelled `fig-cap`.** Today a caption only appears when there is also a
+   `label:` that classifies as a crossref — `codeblock_shorthand` returns early
+   otherwise (probe C4: nothing happens). Q1 emits an unnumbered
+   `<figure><figcaption>` for a bare `fig-cap`. Should q2 do the same — and if
+   so, via a `Block::Figure` (which the HTML writer already renders with a bare
+   `<figcaption>`), or by extending the Div scaffold to an id-less float? This
+   matters a lot for the Connect docs, where captions may well appear without
+   labels.
+
+2. **What markup does `fig-alt` produce?** The output here is `<pre
+   class="mermaid">` that mermaid.js replaces with an inline `<svg>` at runtime —
+   there is no `<img alt>` to hang it on. Candidates: (a) `aria-label` on the
+   `<pre>`; (b) a visually-hidden `<div>` plus `aria-describedby` (note the
+   figure scaffold *already* emits `aria-describedby` pointing at the
+   figcaption — a second description would need reconciling); (c) mermaid's own
+   `accDescr:`/`accTitle:` directives injected into the diagram source, which is
+   the mermaid-native answer and survives the SVG swap. I lean toward (c) with
+   (a) as a fallback, but it's a real decision and it's the accessibility story
+   for those Connect pages.
+
+3. **Scope: do D1/D2/D3 get fixed here or split out?** They are pre-existing
+   general bugs in the `#|` shorthand, not mermaid regressions. D3 (`fig-alt`
+   dropped) is unavoidable here. D1 (quotes) falls out of the `cell_options`
+   migration whether we want it or not. D2 (markdown captions) is genuinely
+   separable. Options: (i) fix all three on this strand, (ii) fix D1+D3 here and
+   file D2, (iii) file all three and make this strand depend on them. Whichever
+   we pick, D1 and D2 will move existing snapshots — expect a snapshot diff to
+   report per the CLAUDE.md snapshot policy.
+
+4. **Which option keys are honoured, and what happens to the rest?** The strand
+   asks. Beyond `label` / `fig-cap` / `fig-alt`: `fig-scap`? `fig-align`?
+   `mermaid-format`/`theme` (which overlap bd-sehm2rha / bd-nj25kgbu)? And for
+   unrecognized keys: today unconsumed `#|`/`%%|` lines are *left in the code
+   body* — harmless for mermaid (`%%` is a comment, the diagram still draws) but
+   visible in the source and visible in `q2 preview`. Q1 strips every option
+   line. Do we strip all of them, and do unknown keys warn or go quiet?
+
+5. **One marker or two?** Should ```` ```mermaid ```` accept `%%|` *only* (Q1
+   parity), or keep accepting `#|` as well (which works today, per probe B3, and
+   which someone may already depend on)? Accepting both is the compatible
+   choice; accepting only `%%|` is the principled one and would be a behavior
+   regression for B3-shaped documents.
+
+6. **Where should this land?** I investigated on `main` in the primary checkout
+   and committed only the plan + probes there. Say the word and I'll set up
+   `cargo xtask create-worktree bd-mermaid-cell-options-9wo3crl0` for the
+   implementation, or tell me which branch you want it on.
+
+## Risks / tradeoffs (draft)
+
+- **Blast radius of the `codeblock_shorthand` migration.** That desugar feeds
+  every `#|` code cell in the tree — engine round-tripping
+  (`crossref/roundtrip_tests.rs` depends on the Div-at-matching-depth invariant),
+  crossref fixtures, and snapshots. The `cell_options` facility is the right
+  destination, but the switch from line-level string surgery to YAML parsing is
+  the largest single risk on this plan.
+- **`passthrough` semantics.** `strip_consumed_lines` keeps unconsumed option
+  lines *textually*, which the engine then re-parses. Moving to structured
+  parsing means deciding how to re-emit them (or whether to, per question 4).
+- **Language detection.** Picking the comment syntax needs the block's language,
+  which for a plain fence is the first class. Brace-form classes arrive as
+  `{mermaid}` (see the existing `brace_form_mermaid_cell_untouched` test) —
+  whatever normalization we add must not accidentally start matching brace cells,
+  which are deliberately engine territory.
+- **The `%%|` prefix collides with matlab/tikz.** `comment_syntax_for` maps those
+  to `%`, so a matlab cell's `%|` and a mermaid cell's `%%|` are different
+  markers. `option_content_ranges` strips the prefix then requires `|` — a
+  mermaid line `%%| x` under a `%` syntax would see `%| x` and fail the `|`
+  check, so there's no silent cross-talk. Worth a test either way.
+- **`aria-describedby` double-description** (question 2) — the figure scaffold
+  already emits one; adding a second description without a plan produces
+  confusing screen-reader output, which would be an own-goal on an
+  accessibility-motivated change.

--- a/claude-notes/plans/2026-08-10-mermaid-cell-options.md
+++ b/claude-notes/plans/2026-08-10-mermaid-cell-options.md
@@ -227,19 +227,24 @@ be numbered. This is the strand's most important architectural constraint.
 ## Phases
 
 - [x] **Phase 0 — Investigation** (commit `f44b3a81`): plan + probes.
-- [ ] **Phase 1 — `cell_options` learns mermaid.** Add `"mermaid" => ("%%",
+- [x] **Phase 1 — `cell_options` learns mermaid** (commit `3407e7db`). Add `"mermaid" => ("%%",
       None)` to `comment_syntax_for`, with tests (including that a matlab/tikz
       `%` cell and a mermaid `%%` cell do not cross-talk).
-- [ ] **Phase 2 — Migrate `codeblock_shorthand` onto `cell_options` (fixes
-      D1).** Language-aware prefix selection (language = the block's first
+- [x] **Phase 2 — Migrate `codeblock_shorthand` onto `cell_options` (fixes
+      D1)** (commit `6347b3b3`). Language-aware prefix selection (language = the block's first
       class, brace forms excluded) + real YAML parsing, replacing the
       hard-coded `"#|"` matcher and `split_once(':')`. Makes `%%|` work and
       makes quoted captions come out unquoted.
-- [ ] **Phase 3 — Caption inlines (fixes D2).** Parse `fig-cap` as markdown
-      inlines instead of a single `Str`.
-- [ ] **Phase 4 — `fig-alt` + `fig-scap` (fixes D3).** Stop dropping them;
-      route `fig-alt` into `accDescr:` per decision 2.
-- [ ] **Phase 5 — Unlabelled `fig-cap` → `Block::Figure`** per decision 1.
+- [x] **Phase 3 — Caption inlines (fixes D2)** (commit `d8c01072`). Parse
+      `fig-cap` as markdown inlines instead of a single `Str`.
+- [x] **Phase 4 — Unlabelled `fig-cap` → `Block::Figure`** per decision 1
+      (commit `1adc3ece`); `fig-scap` → `Caption::short`.
+      *Swapped with the original Phase 5*: the unlabelled path had to exist
+      before `fig-alt` could compose with it, otherwise Phase 5 would have
+      built a structure Phase 4 immediately tore down.
+- [x] **Phase 5 — `fig-alt` + `fig-scap` (fixes D3)** (commit `02cfccf4`).
+      Stop consuming what cannot be routed; route `fig-alt` into `accDescr:`
+      per decision 2.
 - [ ] **Phase 6 — Diagnostics.** Unknown-key warning for diagram cells and the
       `#|`-in-mermaid warning, both source-mapped, per decisions 4 and 5.
 - [ ] **Phase 7 — End-to-end + preview verification.** `q2 render` on the

--- a/claude-notes/plans/mermaid-cell-options-investigation/.gitignore
+++ b/claude-notes/plans/mermaid-cell-options-investigation/.gitignore
@@ -1,0 +1,4 @@
+# Render output from the probes; regenerate, never commit.
+*.html
+*_files/
+.quarto/

--- a/claude-notes/plans/mermaid-cell-options-investigation/.quarto/render-manifest.json
+++ b/claude-notes/plans/mermaid-cell-options-investigation/.quarto/render-manifest.json
@@ -1,0 +1,7 @@
+{
+  "version": 1,
+  "rendered_files": [
+    "probe3.html"
+  ],
+  "resources": []
+}

--- a/claude-notes/plans/mermaid-cell-options-investigation/.quarto/render-manifest.json
+++ b/claude-notes/plans/mermaid-cell-options-investigation/.quarto/render-manifest.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "rendered_files": [
-    "probe3.html"
+    "probe.html"
   ],
   "resources": []
 }

--- a/claude-notes/plans/mermaid-cell-options-investigation/.quarto/render-manifest.json
+++ b/claude-notes/plans/mermaid-cell-options-investigation/.quarto/render-manifest.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "rendered_files": [
-    "probe.html"
+    "probe4.html"
   ],
   "resources": []
 }

--- a/claude-notes/plans/mermaid-cell-options-investigation/.quarto/render-manifest.json
+++ b/claude-notes/plans/mermaid-cell-options-investigation/.quarto/render-manifest.json
@@ -1,7 +1,0 @@
-{
-  "version": 1,
-  "rendered_files": [
-    "probe4.html"
-  ],
-  "resources": []
-}

--- a/claude-notes/plans/mermaid-cell-options-investigation/README.md
+++ b/claude-notes/plans/mermaid-cell-options-investigation/README.md
@@ -1,0 +1,21 @@
+# Investigation artifacts — bd-mermaid-cell-options-9wo3crl0
+
+Probes used for the findings in
+`claude-notes/plans/2026-08-10-mermaid-cell-options.md`. Render each with
+`cargo run --bin q2 -- render claude-notes/plans/mermaid-cell-options-investigation/<file>.qmd`
+from the repo root, then read the generated HTML. (The `.html`/`_files`
+outputs are not committed.)
+
+- `repro.qmd` — copy of the strand's three-section probe (from the
+  local-only `q2-connect-docs` repo). A: GFM fence works; B: `%%|`
+  options survive verbatim; C: `{mermaid}` brace form unrecognized.
+- `probe.qmd` — marker-prefix probe. B1 `%%|` without label, B2 `%%|`
+  with label, **B3 `#|` with label (works fully today)**, B4 non-leading
+  `%%|` (correctly left as a comment).
+- `probe2.qmd` — caption fidelity on the working `#|` path: C1 unquoted
+  caption (good), C2 quoted caption (quotes leak into the figcaption) +
+  `fig-alt` (silently dropped), C3 markdown caption (not parsed), C4
+  `fig-cap` with no label (nothing happens).
+- `probe3.qmd` — the same caption defects on a plain ```python``` cell,
+  establishing that they are general `#|`-shorthand bugs and not
+  mermaid-specific.

--- a/claude-notes/plans/mermaid-cell-options-investigation/README.md
+++ b/claude-notes/plans/mermaid-cell-options-investigation/README.md
@@ -19,3 +19,6 @@ outputs are not committed.)
 - `probe3.qmd` — the same caption defects on a plain ```python``` cell,
   establishing that they are general `#|`-shorthand bugs and not
   mermaid-specific.
+- `probe4.qmd` — diagnostics (Phase 6): unknown keys on a diagram cell,
+  a recognized-but-unroutable key, and an executable cell that must stay
+  silent.

--- a/claude-notes/plans/mermaid-cell-options-investigation/probe.qmd
+++ b/claude-notes/plans/mermaid-cell-options-investigation/probe.qmd
@@ -1,0 +1,40 @@
+---
+title: Mermaid cell-option probe
+---
+
+## B1: fig-cap + fig-alt, no label
+
+```mermaid
+%%| fig-cap: "A tiny flowchart."
+%%| fig-alt: "Two nodes connected by an arrow."
+flowchart LR
+  E --> F
+```
+
+## B2: label + fig-cap (crossref shape, mermaid comment prefix)
+
+```mermaid
+%%| label: fig-diagram
+%%| fig-cap: "A labelled flowchart."
+flowchart LR
+  G --> H
+```
+
+See @fig-diagram.
+
+## B3: hash-prefix cell options in a mermaid fence
+
+```mermaid
+#| label: fig-hash
+#| fig-cap: "Hash-prefixed."
+flowchart LR
+  I --> J
+```
+
+## B4: non-leading %%| comment stays a comment
+
+```mermaid
+flowchart LR
+  K --> L
+%%| this is just a comment
+```

--- a/claude-notes/plans/mermaid-cell-options-investigation/probe2.qmd
+++ b/claude-notes/plans/mermaid-cell-options-investigation/probe2.qmd
@@ -1,0 +1,39 @@
+---
+title: Probe 2 — quoting and fig-alt
+---
+
+## C1: unquoted caption
+
+```mermaid
+#| label: fig-a
+#| fig-cap: Unquoted caption.
+flowchart LR
+  A --> B
+```
+
+## C2: quoted caption + fig-alt
+
+```mermaid
+#| label: fig-b
+#| fig-cap: "Quoted caption."
+#| fig-alt: "Accessible description."
+flowchart LR
+  C --> D
+```
+
+## C3: markdown in caption
+
+```mermaid
+#| label: fig-c
+#| fig-cap: A *emphasized* caption with [a link](https://example.com).
+flowchart LR
+  E --> F
+```
+
+## C4: fig-cap with no label
+
+```mermaid
+#| fig-cap: Caption without a label.
+flowchart LR
+  G --> H
+```

--- a/claude-notes/plans/mermaid-cell-options-investigation/probe3.qmd
+++ b/claude-notes/plans/mermaid-cell-options-investigation/probe3.qmd
@@ -1,0 +1,10 @@
+---
+title: Probe 3 — is the quoting/markdown gap mermaid-specific?
+---
+
+```python
+#| label: fig-py
+#| fig-cap: "A *quoted and emphasized* caption."
+#| fig-alt: "Alt text here."
+print(1)
+```

--- a/claude-notes/plans/mermaid-cell-options-investigation/probe4.qmd
+++ b/claude-notes/plans/mermaid-cell-options-investigation/probe4.qmd
@@ -1,0 +1,33 @@
+---
+title: Probe 4 — diagnostics
+---
+
+## Unknown option on a diagram cell
+
+```mermaid
+%%| fig-cap: A flowchart.
+%%| echo: false
+%%| theme: dark
+flowchart LR
+  A --> B
+```
+
+## Recognized but unroutable
+
+```mermaid
+%%| label: fig-d
+%%| fig-cap: Long caption.
+%%| fig-scap: Short.
+flowchart LR
+  C --> D
+```
+
+## Executable cell stays silent
+
+```{python}
+#| label: fig-p
+#| fig-cap: A plot.
+#| echo: false
+#| warning: false
+plot()
+```

--- a/claude-notes/plans/mermaid-cell-options-investigation/repro.qmd
+++ b/claude-notes/plans/mermaid-cell-options-investigation/repro.qmd
@@ -1,0 +1,28 @@
+---
+title: Mermaid syntax forms and cell options
+---
+
+## A: GFM fence, no cell options — works today
+
+```mermaid
+flowchart LR
+  A --> B
+```
+
+## B: GFM fence with `%%|` cell options — options ignored
+
+```mermaid
+%%| fig-cap: "A tiny flowchart."
+%%| fig-alt: "Two nodes connected by an arrow."
+flowchart LR
+  E --> F
+```
+
+## C: brace cell, the Quarto 1 form — not recognized
+
+```{mermaid}
+%%| fig-cap: "A tiny flowchart."
+%%| fig-alt: "Two nodes connected by an arrow."
+flowchart LR
+  C --> D
+```

--- a/crates/quarto-core/src/cell_options/mod.rs
+++ b/crates/quarto-core/src/cell_options/mod.rs
@@ -82,6 +82,13 @@ pub fn comment_syntax_for(language: &str) -> CommentSyntax {
         "scala" | "csharp" | "fsharp" | "cpp" | "cc" | "java" | "groovy" | "kotlin" | "js"
         | "d3" | "node" | "sass" | "scss" | "go" | "asy" | "dot" | "ojs" | "rust" => ("//", None),
         "matlab" | "tikz" => ("%", None),
+        // Not in Q1's kLangCommentChars: mermaid's `%%` lives on the
+        // language handler (`comment: "%%"` in core/handlers/mermaid.ts)
+        // and in filters/modules/constants.lua, which is why the
+        // original port of this table missed it
+        // (bd-mermaid-cell-options-9wo3crl0). Distinct from matlab's
+        // single `%` — see `mermaid_and_matlab_markers_do_not_cross_talk`.
+        "mermaid" => ("%%", None),
         "c" | "css" => ("/*", Some("*/")),
         "sas" => ("*", Some(";")),
         "sql" | "mysql" | "psql" | "lua" | "haskell" => ("--", None),
@@ -333,6 +340,7 @@ mod tests {
             ("java", "//"),
             ("matlab", "%"),
             ("tikz", "%"),
+            ("mermaid", "%%"),
             ("fortran", "!"),
             ("apl", "⍝"),
             ("stata", "*"),
@@ -341,6 +349,63 @@ mod tests {
             assert_eq!(syn.prefix, prefix, "prefix for {lang}");
             assert_eq!(syn.suffix, None, "suffix for {lang}");
         }
+    }
+
+    /// mermaid's `%%` and matlab/tikz's `%` are adjacent but must not
+    /// cross-talk: a mermaid option line read under matlab's syntax
+    /// sees `%| …` after stripping one `%`, which fails the `|` check,
+    /// and a matlab option line under mermaid's syntax fails the
+    /// prefix check. Neither direction silently half-parses
+    /// (bd-mermaid-cell-options-9wo3crl0).
+    #[test]
+    fn mermaid_and_matlab_markers_do_not_cross_talk() {
+        let mermaid = comment_syntax_for("mermaid");
+        let matlab = comment_syntax_for("matlab");
+
+        assert!(
+            option_content_ranges("%%| fig-cap: A caption.\n", &mermaid).is_some(),
+            "`%%|` must be an option line under mermaid syntax"
+        );
+        assert!(
+            option_content_ranges("%%| fig-cap: A caption.\n", &matlab).is_none(),
+            "`%%|` must NOT be an option line under matlab syntax"
+        );
+        assert!(
+            option_content_ranges("%| label: x\n", &matlab).is_some(),
+            "`%|` must be an option line under matlab syntax"
+        );
+        assert!(
+            option_content_ranges("%| label: x\n", &mermaid).is_none(),
+            "`%|` must NOT be an option line under mermaid syntax"
+        );
+    }
+
+    /// End-to-end partition on a mermaid cell: the leading `%%|` run
+    /// becomes the options document, the diagram source is what
+    /// remains, and a `%%|` line *below* the first code line stays in
+    /// the body as an ordinary mermaid comment.
+    #[test]
+    fn partition_mermaid_cell() {
+        let body = "%%| label: fig-x\n%%| fig-cap: A caption.\n\
+                    flowchart LR\n  A --> B\n%%| not an option\n";
+        let cell = partition("mermaid", body);
+        assert_eq!(cell.code, "flowchart LR\n  A --> B\n%%| not an option\n");
+        let options = cell.options.expect("mermaid cell has options");
+        assert!(options.is_hash());
+        assert_eq!(
+            options
+                .get_hash_value("label")
+                .and_then(|v| v.yaml.as_str().map(|s| s.to_string()))
+                .as_deref(),
+            Some("fig-x")
+        );
+        assert_eq!(
+            options
+                .get_hash_value("fig-cap")
+                .and_then(|v| v.yaml.as_str().map(|s| s.to_string()))
+                .as_deref(),
+            Some("A caption.")
+        );
     }
 
     #[test]

--- a/crates/quarto-core/src/crossref/codeblock_shorthand.rs
+++ b/crates/quarto-core/src/crossref/codeblock_shorthand.rs
@@ -51,14 +51,19 @@
 //! real YAML is what makes `fig-cap: "A caption."` arrive *without* its
 //! quotes, and what gives every key a source span to hang a diagnostic on.
 //!
-//! Each parsed option is then partitioned:
+//! Each parsed option is then either:
 //!
-//! - **Consumed** (lifted into the Div scaffold and removed from the code
-//!   block body): `label`, `<reftype>-cap`, `<reftype>-scap`, `<reftype>-alt`.
-//!   The `<reftype>` prefix set is taken from the [`RefTypeRegistry`], so
-//!   user-declared categories work out of the box.
-//! - **Passed to the engine** (left in the body): everything else
-//!   (`echo`, `eval`, engine-specific options, etc.).
+//! - **Consumed** — lifted into the wrapper and removed from the code
+//!   block body. Only keys q2 can actually route are consumed: `label`
+//!   and `<reftype>-cap` (the `<reftype>` set comes from the
+//!   [`RefTypeRegistry`], so user-declared categories work out of the
+//!   box), plus `fig-scap` on the unlabelled figure path and `fig-alt`
+//!   on a diagram cell.
+//! - **Passed to the engine** — left in the body. This is everything
+//!   else (`echo`, `eval`, engine-specific options), *and* any
+//!   recognized key q2 has nowhere to put in this position. Consuming
+//!   what cannot be routed is how `fig-alt` used to vanish silently
+//!   (bd-il6pxq4f); leaving it in the body keeps it reachable.
 //!
 //! Only the **leading run** of option lines counts — the first line that
 //! isn't an option line starts the code. For mermaid this is what keeps a
@@ -136,118 +141,187 @@ fn try_desugar_code_block(
     let language = language_of(cb);
     let parsed = parse_cell_options(&language, &cb.text, body_source_for(cb, sources));
 
-    match parsed.get("label") {
-        // A `label:` that classifies as a crossref: build the float Div
-        // the crossref pipeline numbers and renders.
-        Some(label) => {
-            let def = registry.classify_cite_id(label)?;
-            desugar_as_float(cb, &parsed, label, &def.ref_type.clone(), diagnostics)
-        }
-        // No label at all: a caption still deserves a figure, just an
-        // unnumbered one. A `label:` that is *not* a crossref means the
-        // author is naming the cell for the engine — leave it alone.
-        None => desugar_as_figure(cb, &parsed, diagnostics),
-    }
-}
-
-/// The labelled path: `::: {#fig-x} <code> <caption> :::`, which the
-/// crossref transforms later turn into a numbered float.
-fn desugar_as_float(
-    cb: &quarto_pandoc_types::block::CodeBlock,
-    parsed: &CellOptions,
-    label: &str,
-    ref_type: &str,
-    diagnostics: &mut Vec<DiagnosticMessage>,
-) -> Option<Block> {
-    // Classify each option key as consumed vs. passed-through.
-    let (consumed, passthrough) = partition_options(parsed, ref_type);
-
-    // Extract the caption from the consumed set, if any.
-    let caption = consumed.get(&format!("{ref_type}-cap")).copied();
-
-    let new_code_block = strip_options(cb, &consumed, &parsed.syntax);
-    let _ = passthrough; // kept as-is in the body; explicit for clarity.
-
-    // Build the Div scaffold.
-    let mut div_content: Blocks = vec![new_code_block];
-    if let Some(caption) = caption {
-        div_content.push(caption_paragraph(caption, diagnostics));
-    }
-
-    let attr = (
-        label.to_string(),
-        Vec::new(),
-        hashlink::LinkedHashMap::new(),
-    );
-    Some(Block::Div(Div {
-        attr,
-        content: div_content,
-        source_info: cb.source_info.clone(),
-        attr_source: AttrSourceInfo::empty(),
-    }))
-}
-
-/// The unlabelled path (decision 1): `fig-cap` with no `label:` becomes
-/// a plain [`Block::Figure`], which the HTML writer renders as
-/// `<figure>…<figcaption>` with no number and no float scaffolding.
-///
-/// Q1 could not do this — its cell handling was textual, so it emitted
-/// markdown and let a filter rebuild the structure. Working on the AST,
-/// the node can be constructed directly.
-///
-/// Only `fig-cap`/`fig-scap` are honoured here: without a label there is
-/// no ref-type to derive a category from, and an unnumbered non-figure
-/// float is not a thing q2 models.
-fn desugar_as_figure(
-    cb: &quarto_pandoc_types::block::CodeBlock,
-    parsed: &CellOptions,
-    diagnostics: &mut Vec<DiagnosticMessage>,
-) -> Option<Block> {
-    let caption = parsed.values.get("fig-cap")?;
-    let short = parsed.values.get("fig-scap");
-
+    // Keys this cell's options let us act on. Everything else stays in
+    // the body: an option q2 cannot route is the engine's to interpret,
+    // and consuming it would discard it silently (bd-il6pxq4f).
     let mut consumed: std::collections::HashMap<String, &OptionValue> =
         std::collections::HashMap::new();
-    consumed.insert("fig-cap".to_string(), caption);
-    if let Some(short) = short {
-        consumed.insert("fig-scap".to_string(), short);
-    }
-
-    let new_code_block = strip_options(cb, &consumed, &parsed.syntax);
-
-    let long = match caption_paragraph(caption, diagnostics) {
-        Block::Paragraph(p) => vec![Block::Plain(Plain {
-            content: p.content,
-            source_info: p.source_info,
-        })],
-        other => vec![other],
+    let mut consume = |key: String| {
+        parsed.values.get(&key).inspect(|v| {
+            consumed.insert(key.clone(), v);
+        })
     };
 
-    Some(Block::Figure(Figure {
-        attr: (String::new(), Vec::new(), hashlink::LinkedHashMap::new()),
-        caption: Caption {
-            short: short.map(|s| caption_inlines(s, diagnostics)),
-            long: Some(long),
-            source_info: caption.value_source.clone(),
+    // Which wrapper the caption options call for.
+    let wrapper = match parsed.get("label") {
+        // A `label:` that classifies as a crossref: the float Div the
+        // crossref pipeline numbers and renders. A label that is *not*
+        // a crossref means the author is naming the cell for the
+        // engine — no wrapper, and the label stays in the body.
+        Some(label) => match registry.classify_cite_id(label) {
+            Some(def) => {
+                let ref_type = def.ref_type.clone();
+                let label = label.to_string();
+                consume("label".to_string());
+                let caption = consume(format!("{ref_type}-cap"));
+                Wrapper::Float { label, caption }
+            }
+            None => Wrapper::None,
         },
-        content: vec![new_code_block],
-        source_info: cb.source_info.clone(),
-        attr_source: AttrSourceInfo::empty(),
-    }))
-}
+        // No label: a caption still deserves a figure, just an
+        // unnumbered one (decision 1).
+        None => match consume("fig-cap".to_string()) {
+            Some(caption) => {
+                let short = consume("fig-scap".to_string());
+                Wrapper::Figure { caption, short }
+            }
+            None => Wrapper::None,
+        },
+    };
 
-/// Clone `cb` with the `consumed` option lines removed from its body.
-fn strip_options(
-    cb: &quarto_pandoc_types::block::CodeBlock,
-    consumed: &std::collections::HashMap<String, &OptionValue>,
-    syntax: &CommentSyntax,
-) -> Block {
-    Block::CodeBlock(quarto_pandoc_types::block::CodeBlock {
+    // Accessibility (decision 2), independent of any wrapper: a lone
+    // `fig-alt` on a diagram is reason enough to rewrite the cell.
+    let acc_descr = if is_diagram_language(&language) {
+        consume("fig-alt".to_string()).map(|v| v.value.clone())
+    } else {
+        None
+    };
+
+    if consumed.is_empty() {
+        return None;
+    }
+
+    let mut text = strip_consumed_lines(&cb.text, &consumed, &parsed.syntax);
+    if let Some(description) = acc_descr {
+        text = inject_acc_descr(&text, &description);
+    }
+    let new_code_block = Block::CodeBlock(quarto_pandoc_types::block::CodeBlock {
         attr: cb.attr.clone(),
-        text: strip_consumed_lines(&cb.text, consumed, syntax),
+        text,
         source_info: cb.source_info.clone(),
         attr_source: cb.attr_source.clone(),
+    });
+
+    Some(match wrapper {
+        Wrapper::Float { label, caption } => {
+            let mut content: Blocks = vec![new_code_block];
+            if let Some(caption) = caption {
+                content.push(caption_paragraph(caption, diagnostics));
+            }
+            Block::Div(Div {
+                attr: (label, Vec::new(), hashlink::LinkedHashMap::new()),
+                content,
+                source_info: cb.source_info.clone(),
+                attr_source: AttrSourceInfo::empty(),
+            })
+        }
+        Wrapper::Figure { caption, short } => {
+            let long = match caption_paragraph(caption, diagnostics) {
+                Block::Paragraph(p) => vec![Block::Plain(Plain {
+                    content: p.content,
+                    source_info: p.source_info,
+                })],
+                other => vec![other],
+            };
+            Block::Figure(Figure {
+                attr: (String::new(), Vec::new(), hashlink::LinkedHashMap::new()),
+                caption: Caption {
+                    short: short.map(|s| caption_inlines(s, diagnostics)),
+                    long: Some(long),
+                    source_info: caption.value_source.clone(),
+                },
+                content: vec![new_code_block],
+                source_info: cb.source_info.clone(),
+                attr_source: AttrSourceInfo::empty(),
+            })
+        }
+        // Nothing to wrap — the cell was rewritten in place (today only
+        // by the accessibility injection).
+        Wrapper::None => new_code_block,
     })
+}
+
+/// What the cell's caption options call for around the rewritten code
+/// block.
+enum Wrapper<'a> {
+    /// `::: {#fig-x} <code> <caption> :::` — the crossref transforms
+    /// later turn this into a numbered float.
+    Float {
+        label: String,
+        caption: Option<&'a OptionValue>,
+    },
+    /// A plain [`Block::Figure`]: the HTML writer renders it as
+    /// `<figure>…<figcaption>` with no number and no float scaffolding.
+    ///
+    /// Q1 could not do this — its cell handling was textual, so it
+    /// emitted markdown and let a filter rebuild the structure. Working
+    /// on the AST, the node can be constructed directly.
+    ///
+    /// Only `fig-cap`/`fig-scap` reach here: without a label there is no
+    /// ref-type to derive a category from, and an unnumbered non-figure
+    /// float is not a thing q2 models.
+    Figure {
+        caption: &'a OptionValue,
+        short: Option<&'a OptionValue>,
+    },
+    /// No wrapper; the code block stands on its own.
+    None,
+}
+
+/// Languages whose cells q2 renders as a client-side diagram, and for
+/// which [`inject_acc_descr`] therefore knows how to carry `fig-alt`.
+fn is_diagram_language(language: &str) -> bool {
+    language.eq_ignore_ascii_case("mermaid")
+}
+
+/// Carry `fig-alt` into a mermaid diagram as its native `accDescr:`
+/// directive (decision 2).
+///
+/// mermaid.js replaces the `<pre class="mermaid">` with an inline
+/// `<svg>` at runtime, so an attribute on the `<pre>` would not reach
+/// assistive technology; `accDescr:` becomes the SVG's own description
+/// and survives the swap. It has to sit **after** the diagram-type
+/// declaration — mermaid rejects it before — so it is inserted after the
+/// first line that is neither blank nor a `%%` comment.
+///
+/// The description is folded onto a single line: a newline would
+/// terminate the single-line form, and mermaid's multi-line
+/// `accDescr { … }` form has no escape for a `}` appearing in the text.
+/// Prose alt text loses no meaning to the fold.
+///
+/// **Revisit when diagrams are rendered server-side** (PDF/print): with
+/// a real image element in the output, the accessible name belongs in
+/// that element's `alt`, and `accDescr:` inside the source stops being
+/// the mechanism that reaches assistive tech.
+fn inject_acc_descr(source: &str, description: &str) -> String {
+    let folded = description.split_whitespace().collect::<Vec<_>>().join(" ");
+    if folded.is_empty() {
+        return source.to_string();
+    }
+
+    let mut out = String::with_capacity(source.len() + folded.len() + 16);
+    let mut injected = false;
+    for line in source.lines() {
+        out.push_str(line);
+        out.push('\n');
+        let trimmed = line.trim();
+        if !injected && !trimmed.is_empty() && !trimmed.starts_with("%%") {
+            out.push_str("  accDescr: ");
+            out.push_str(&folded);
+            out.push('\n');
+            injected = true;
+        }
+    }
+    if !injected {
+        // A diagram with no declaration line at all (empty or
+        // comments-only): there is nothing for the directive to attach
+        // to, so leave the source alone.
+        return source.to_string();
+    }
+    if !source.ends_with('\n') && out.ends_with('\n') {
+        out.pop();
+    }
+    out
 }
 
 /// The cell's language: the block's first class, with a brace-form
@@ -387,33 +461,6 @@ fn scalar_to_string(node: &quarto_yaml::YamlWithSourceInfo) -> Option<String> {
         Yaml::Boolean(b) => Some(b.to_string()),
         _ => None,
     }
-}
-
-/// Partition parsed options into (consumed, passthrough). `ref_type` is
-/// used to recognize `<reftype>-cap`-style keys against the current
-/// category.
-fn partition_options<'a>(
-    parsed: &'a CellOptions,
-    ref_type: &str,
-) -> (
-    std::collections::HashMap<String, &'a OptionValue>,
-    std::collections::HashMap<String, &'a OptionValue>,
-) {
-    let mut consumed = std::collections::HashMap::new();
-    let mut passthrough = std::collections::HashMap::new();
-
-    let cap_key = format!("{ref_type}-cap");
-    let scap_key = format!("{ref_type}-scap");
-    let alt_key = format!("{ref_type}-alt");
-
-    for (k, v) in &parsed.values {
-        if k == "label" || *k == cap_key || *k == scap_key || *k == alt_key {
-            consumed.insert(k.clone(), v);
-        } else {
-            passthrough.insert(k.clone(), v);
-        }
-    }
-    (consumed, passthrough)
 }
 
 /// Remove the `<marker> key: ...` lines in `consumed` from the head of
@@ -756,6 +803,103 @@ mod tests {
         let before = blocks.clone();
         desugar(&mut blocks, &reg);
         assert_eq!(blocks, before);
+    }
+
+    /// Decision 2: `fig-alt` on a mermaid diagram becomes mermaid's own
+    /// `accDescr:` directive, which survives mermaid.js replacing the
+    /// `<pre>` with an inline `<svg>` at runtime. It must land *after*
+    /// the diagram-type line — mermaid rejects it before.
+    #[test]
+    fn mermaid_fig_alt_becomes_acc_descr() {
+        let reg = RefTypeRegistry::builtin();
+        let mut blocks = vec![code_in(
+            "mermaid",
+            "%%| fig-alt: Two nodes connected by an arrow.\nflowchart LR\n  A --> B\n",
+        )];
+        desugar(&mut blocks, &reg);
+
+        let Block::CodeBlock(cb) = &blocks[0] else {
+            panic!("a lone fig-alt needs no wrapper; got {:?}", blocks[0]);
+        };
+        assert_eq!(
+            cb.text, "flowchart LR\n  accDescr: Two nodes connected by an arrow.\n  A --> B\n",
+            "accDescr must follow the diagram-type line"
+        );
+    }
+
+    /// A newline in the description would terminate mermaid's
+    /// single-line `accDescr:`, so the text is folded onto one line.
+    /// Prose alt text loses nothing; the block form would instead break
+    /// on any `}` in the description.
+    #[test]
+    fn mermaid_multiline_fig_alt_is_folded() {
+        let reg = RefTypeRegistry::builtin();
+        let mut blocks = vec![code_in(
+            "mermaid",
+            "%%| fig-alt: |\n%%|   Two nodes.\n%%|   An arrow joins them.\nflowchart LR\n  A --> B\n",
+        )];
+        desugar(&mut blocks, &reg);
+
+        let Block::CodeBlock(cb) = &blocks[0] else {
+            panic!("expected a CodeBlock, got {:?}", blocks[0]);
+        };
+        assert!(
+            cb.text
+                .contains("accDescr: Two nodes. An arrow joins them.\n"),
+            "multi-line alt must fold to one line; got:\n{}",
+            cb.text
+        );
+    }
+
+    /// fig-alt composes with the caption paths rather than replacing
+    /// them: the figure still gets its caption, the diagram still gets
+    /// its accessible description.
+    #[test]
+    fn mermaid_fig_alt_composes_with_a_caption() {
+        let reg = RefTypeRegistry::builtin();
+        let mut blocks = vec![code_in(
+            "mermaid",
+            "%%| fig-cap: A tiny flowchart.\n%%| fig-alt: Two nodes.\nflowchart LR\n  A --> B\n",
+        )];
+        desugar(&mut blocks, &reg);
+
+        let Block::Figure(fig) = &blocks[0] else {
+            panic!("expected Figure, got {:?}", blocks[0]);
+        };
+        let Block::CodeBlock(cb) = &fig.content[0] else {
+            panic!()
+        };
+        assert!(
+            cb.text.contains("accDescr: Two nodes."),
+            "got:\n{}",
+            cb.text
+        );
+        assert!(!cb.text.contains("%%|"), "got:\n{}", cb.text);
+    }
+
+    /// D3 (bd-il6pxq4f): `fig-alt` on a cell q2 cannot route it for is
+    /// left in the body so the engine can use it — never consumed and
+    /// silently discarded, which is what used to happen.
+    #[test]
+    fn non_mermaid_fig_alt_is_not_dropped() {
+        let reg = RefTypeRegistry::builtin();
+        let mut blocks = vec![code(
+            "#| label: fig-py\n#| fig-cap: A plot.\n#| fig-alt: Alt text here.\nplot()\n",
+        )];
+        desugar(&mut blocks, &reg);
+
+        let Block::Div(div) = &blocks[0] else {
+            panic!()
+        };
+        let Block::CodeBlock(cb) = &div.content[0] else {
+            panic!()
+        };
+        assert!(
+            cb.text.contains("#| fig-alt: Alt text here."),
+            "fig-alt must survive for the engine; got:\n{}",
+            cb.text
+        );
+        assert!(!cb.text.contains("fig-cap"), "got:\n{}", cb.text);
     }
 
     /// A brace-form executable cell still resolves to its language's

--- a/crates/quarto-core/src/crossref/codeblock_shorthand.rs
+++ b/crates/quarto-core/src/crossref/codeblock_shorthand.rs
@@ -64,6 +64,7 @@
 //! isn't an option line starts the code. For mermaid this is what keeps a
 //! `%%|` further down the diagram an ordinary comment.
 
+use quarto_error_reporting::DiagnosticMessage;
 use quarto_pandoc_types::attr::AttrSourceInfo;
 use quarto_pandoc_types::block::{Block, Blocks, Div, Paragraph};
 use quarto_pandoc_types::inline::{Inline, Inlines, Str};
@@ -78,28 +79,37 @@ use crate::cell_options::{CommentSyntax, comment_syntax_for, partition_cell_opti
 ///
 /// `sources` is the document's [`SourceContext`], used to anchor each
 /// cell's option spans in the original file — see [`body_source_for`].
-pub fn desugar_blocks(blocks: &mut Blocks, registry: &RefTypeRegistry, sources: &SourceContext) {
+/// `diagnostics` collects anything the desugar has to say about the
+/// options it read (today: a caption that does not parse as markdown).
+pub fn desugar_blocks(
+    blocks: &mut Blocks,
+    registry: &RefTypeRegistry,
+    sources: &SourceContext,
+    diagnostics: &mut Vec<DiagnosticMessage>,
+) {
     // We iterate by index because we may replace the current slot.
     let mut i = 0;
     while i < blocks.len() {
         // Recurse into containers.
         match &mut blocks[i] {
-            Block::BlockQuote(bq) => desugar_blocks(&mut bq.content, registry, sources),
-            Block::Div(div) => desugar_blocks(&mut div.content, registry, sources),
+            Block::BlockQuote(bq) => {
+                desugar_blocks(&mut bq.content, registry, sources, diagnostics)
+            }
+            Block::Div(div) => desugar_blocks(&mut div.content, registry, sources, diagnostics),
             Block::OrderedList(ol) => {
                 for item in &mut ol.content {
-                    desugar_blocks(item, registry, sources);
+                    desugar_blocks(item, registry, sources, diagnostics);
                 }
             }
             Block::BulletList(bl) => {
                 for item in &mut bl.content {
-                    desugar_blocks(item, registry, sources);
+                    desugar_blocks(item, registry, sources, diagnostics);
                 }
             }
             Block::DefinitionList(dl) => {
                 for (_term, defs) in &mut dl.content {
                     for def in defs {
-                        desugar_blocks(def, registry, sources);
+                        desugar_blocks(def, registry, sources, diagnostics);
                     }
                 }
             }
@@ -108,7 +118,7 @@ pub fn desugar_blocks(blocks: &mut Blocks, registry: &RefTypeRegistry, sources: 
 
         // Try to desugar this block.
         if let Block::CodeBlock(cb) = &blocks[i]
-            && let Some(replacement) = try_desugar_code_block(cb, registry, sources)
+            && let Some(replacement) = try_desugar_code_block(cb, registry, sources, diagnostics)
         {
             blocks[i] = replacement;
         }
@@ -120,6 +130,7 @@ fn try_desugar_code_block(
     cb: &quarto_pandoc_types::block::CodeBlock,
     registry: &RefTypeRegistry,
     sources: &SourceContext,
+    diagnostics: &mut Vec<DiagnosticMessage>,
 ) -> Option<Block> {
     let language = language_of(cb);
     let parsed = parse_cell_options(&language, &cb.text, body_source_for(cb, sources));
@@ -133,10 +144,8 @@ fn try_desugar_code_block(
     // Classify each option key as consumed vs. passed-through.
     let (consumed, passthrough) = partition_options(&parsed, &ref_type);
 
-    // Extract the caption text from the consumed set, if any.
-    let caption_text = consumed
-        .get(&format!("{ref_type}-cap"))
-        .map(|s| s.to_string());
+    // Extract the caption from the consumed set, if any.
+    let caption = consumed.get(&format!("{ref_type}-cap")).copied();
 
     // Rewrite the code block's text to drop the consumed lines.
     let new_text = strip_consumed_lines(&cb.text, &consumed, &parsed.syntax);
@@ -151,8 +160,8 @@ fn try_desugar_code_block(
 
     // Build the Div scaffold.
     let mut div_content: Blocks = vec![new_code_block];
-    if let Some(text) = caption_text {
-        div_content.push(caption_paragraph(&text, cb.source_info.clone()));
+    if let Some(caption) = caption {
+        div_content.push(caption_paragraph(caption, diagnostics));
     }
 
     let attr = (identifier, Vec::new(), hashlink::LinkedHashMap::new());
@@ -235,6 +244,9 @@ struct OptionValue {
         reason = "consumed by the unknown-key diagnostics in Phase 6"
     )]
     key_source: SourceInfo,
+    /// Provenance of the value scalar — the anchor a re-parse of the
+    /// value (e.g. a caption read as markdown) hangs its spans off.
+    value_source: SourceInfo,
 }
 
 impl CellOptions {
@@ -274,6 +286,7 @@ fn parse_cell_options(language: &str, text: &str, body_source: SourceInfo) -> Ce
                 OptionValue {
                     value,
                     key_source: entry.key.source_info.clone(),
+                    value_source: entry.value.source_info.clone(),
                 },
             );
         }
@@ -306,8 +319,8 @@ fn partition_options<'a>(
     parsed: &'a CellOptions,
     ref_type: &str,
 ) -> (
-    std::collections::HashMap<String, &'a str>,
-    std::collections::HashMap<String, &'a str>,
+    std::collections::HashMap<String, &'a OptionValue>,
+    std::collections::HashMap<String, &'a OptionValue>,
 ) {
     let mut consumed = std::collections::HashMap::new();
     let mut passthrough = std::collections::HashMap::new();
@@ -318,9 +331,9 @@ fn partition_options<'a>(
 
     for (k, v) in &parsed.values {
         if k == "label" || *k == cap_key || *k == scap_key || *k == alt_key {
-            consumed.insert(k.clone(), v.value.as_str());
+            consumed.insert(k.clone(), v);
         } else {
-            passthrough.insert(k.clone(), v.value.as_str());
+            passthrough.insert(k.clone(), v);
         }
     }
     (consumed, passthrough)
@@ -335,7 +348,7 @@ fn partition_options<'a>(
 /// rather than re-serialized from the parsed map.
 fn strip_consumed_lines(
     text: &str,
-    consumed: &std::collections::HashMap<String, &str>,
+    consumed: &std::collections::HashMap<String, &OptionValue>,
     syntax: &CommentSyntax,
 ) -> String {
     let mut out = String::new();
@@ -369,15 +382,52 @@ fn strip_consumed_lines(
     out
 }
 
-fn caption_paragraph(text: &str, source_info: SourceInfo) -> Block {
-    let content: Inlines = vec![Inline::Str(Str {
-        text: text.to_string(),
-        source_info: source_info.clone(),
-    })];
+/// Build the caption paragraph from a `<reftype>-cap` option.
+///
+/// The caption is **markdown**, not literal text: `fig-cap: A *strong*
+/// claim` must reach the figcaption as an `Emph`, exactly as it would
+/// from front matter (bd-sdpp9rw4). Parsing goes through the same
+/// entry point document metadata uses, anchored at the value's own span
+/// so inline positions resolve into the option line.
+///
+/// A caption that parses to several blocks (rare — it would take a list
+/// or a heading in a `fig-cap`) keeps only the first paragraph's
+/// inlines; a caption that does not parse at all falls back to literal
+/// text, with `parse_config_string_as_markdown`'s own Q-1-20 warning
+/// carried into `diagnostics`.
+fn caption_paragraph(caption: &OptionValue, diagnostics: &mut Vec<DiagnosticMessage>) -> Block {
+    let source_info = caption.value_source.clone();
+    let kind = pampa::pandoc::meta::parse_config_string_as_markdown(
+        &caption.value,
+        &source_info,
+        diagnostics,
+    );
+
+    let content: Inlines = match kind {
+        quarto_pandoc_types::ConfigValueKind::PandocInlines(inlines) => inlines,
+        quarto_pandoc_types::ConfigValueKind::PandocBlocks(blocks) => blocks
+            .into_iter()
+            .find_map(|b| match b {
+                Block::Paragraph(p) => Some(p.content),
+                Block::Plain(p) => Some(p.content),
+                _ => None,
+            })
+            .unwrap_or_else(|| literal_caption(&caption.value, &source_info)),
+        _ => literal_caption(&caption.value, &source_info),
+    };
+
     Block::Paragraph(Paragraph {
         content,
         source_info,
     })
+}
+
+/// Fallback caption inlines: the option's text, verbatim.
+fn literal_caption(text: &str, source_info: &SourceInfo) -> Inlines {
+    vec![Inline::Str(Str {
+        text: text.to_string(),
+        source_info: source_info.clone(),
+    })]
 }
 
 #[cfg(test)]
@@ -412,7 +462,7 @@ mod tests {
     }
 
     fn desugar(blocks: &mut Blocks, reg: &RefTypeRegistry) {
-        desugar_blocks(blocks, reg, &sources());
+        desugar_blocks(blocks, reg, &sources(), &mut Vec::new());
     }
 
     #[test]
@@ -465,10 +515,7 @@ mod tests {
         let Block::Paragraph(p) = &div.content[1] else {
             panic!("expected a caption paragraph");
         };
-        let Inline::Str(s) = &p.content[0] else {
-            panic!()
-        };
-        assert_eq!(s.text, "A labelled flowchart.");
+        assert_eq!(plain_text(&p.content), "A labelled flowchart.");
     }
 
     /// Decision 5: mermaid takes `%%|` *only*. `#|` is not a mermaid
@@ -503,10 +550,61 @@ mod tests {
         let Block::Paragraph(p) = &div.content[1] else {
             panic!()
         };
-        let Inline::Str(s) = &p.content[0] else {
+        assert_eq!(plain_text(&p.content), "A quoted caption.");
+    }
+
+    /// D2 (bd-sdpp9rw4): a caption is markdown, so `*emphasized*` must
+    /// reach the figcaption as an `Emph` and `[text](url)` as a `Link` —
+    /// not as literal asterisks and brackets in a single `Str`.
+    #[test]
+    fn caption_markdown_is_parsed_into_inlines() {
+        let reg = RefTypeRegistry::builtin();
+        let mut blocks = vec![code(
+            "#| label: fig-md\n#| fig-cap: A *strong* claim, see [the docs](https://example.com).\nprint('hi')\n",
+        )];
+        desugar(&mut blocks, &reg);
+
+        let Block::Div(div) = &blocks[0] else {
             panic!()
         };
-        assert_eq!(s.text, "A quoted caption.");
+        let Block::Paragraph(p) = &div.content[1] else {
+            panic!("expected a caption paragraph")
+        };
+        assert!(
+            p.content.iter().any(|i| matches!(i, Inline::Emph(_))),
+            "caption must carry an Emph; got {:?}",
+            p.content
+        );
+        assert!(
+            p.content.iter().any(|i| matches!(i, Inline::Link(_))),
+            "caption must carry a Link; got {:?}",
+            p.content
+        );
+        let flat = plain_text(&p.content);
+        assert!(
+            !flat.contains('*') && !flat.contains('['),
+            "markdown punctuation must not survive literally; got {flat:?}"
+        );
+    }
+
+    /// Flatten inlines to their visible text, for assertions that care
+    /// about what a reader sees rather than the node shape.
+    fn plain_text(inlines: &Inlines) -> String {
+        let mut out = String::new();
+        fn walk(inlines: &Inlines, out: &mut String) {
+            for inline in inlines {
+                match inline {
+                    Inline::Str(s) => out.push_str(&s.text),
+                    Inline::Space(_) => out.push(' '),
+                    Inline::Emph(e) => walk(&e.content, out),
+                    Inline::Strong(s) => walk(&s.content, out),
+                    Inline::Link(l) => walk(&l.content, out),
+                    _ => {}
+                }
+            }
+        }
+        walk(inlines, &mut out);
+        out
     }
 
     /// A brace-form executable cell still resolves to its language's
@@ -552,10 +650,7 @@ mod tests {
         let Block::Paragraph(p) = &div.content[1] else {
             panic!();
         };
-        let Inline::Str(s) = &p.content[0] else {
-            panic!()
-        };
-        assert_eq!(s.text, "A plot.");
+        assert_eq!(plain_text(&p.content), "A plot.");
     }
 
     #[test]
@@ -593,10 +688,7 @@ mod tests {
         let Block::Paragraph(p) = &div.content[1] else {
             panic!()
         };
-        let Inline::Str(s) = &p.content[0] else {
-            panic!()
-        };
-        assert_eq!(s.text, "Summary.");
+        assert_eq!(plain_text(&p.content), "Summary.");
     }
 
     #[test]
@@ -623,7 +715,12 @@ mod tests {
     #[test]
     fn strip_consumed_lines_preserves_trailing_newline_absence() {
         let text = "#| label: fig-x\nprint('hi')";
-        let consumed = [("label".to_string(), "fig-x")].into_iter().collect();
+        let label = OptionValue {
+            value: "fig-x".to_string(),
+            key_source: si(),
+            value_source: si(),
+        };
+        let consumed = [("label".to_string(), &label)].into_iter().collect();
         let out = strip_consumed_lines(text, &consumed, &comment_syntax_for("python"));
         assert_eq!(out, "print('hi')");
     }

--- a/crates/quarto-core/src/crossref/codeblock_shorthand.rs
+++ b/crates/quarto-core/src/crossref/codeblock_shorthand.rs
@@ -69,7 +69,7 @@
 //! isn't an option line starts the code. For mermaid this is what keeps a
 //! `%%|` further down the diagram an ordinary comment.
 
-use quarto_error_reporting::DiagnosticMessage;
+use quarto_error_reporting::{DiagnosticMessage, DiagnosticMessageBuilder};
 use quarto_pandoc_types::attr::AttrSourceInfo;
 use quarto_pandoc_types::block::{Block, Blocks, Div, Figure, Paragraph, Plain};
 use quarto_pandoc_types::caption::Caption;
@@ -139,7 +139,12 @@ fn try_desugar_code_block(
     diagnostics: &mut Vec<DiagnosticMessage>,
 ) -> Option<Block> {
     let language = language_of(cb);
-    let parsed = parse_cell_options(&language, &cb.text, body_source_for(cb, sources));
+    let body_source = body_source_for(cb, sources);
+    let parsed = parse_cell_options(&language, &cb.text, body_source.clone());
+
+    if is_diagram_language(&language) {
+        warn_wrong_marker(&cb.text, &parsed, &body_source, diagnostics);
+    }
 
     // Keys this cell's options let us act on. Everything else stays in
     // the body: an option q2 cannot route is the engine's to interpret,
@@ -186,6 +191,11 @@ fn try_desugar_code_block(
     } else {
         None
     };
+
+    // A diagram cell has no engine to hand the leftovers to (decision 4).
+    if is_diagram_language(&language) {
+        warn_unconsumed_options(&parsed, &consumed, diagnostics);
+    }
 
     if consumed.is_empty() {
         return None;
@@ -272,6 +282,107 @@ enum Wrapper<'a> {
 /// which [`inject_acc_descr`] therefore knows how to carry `fig-alt`.
 fn is_diagram_language(language: &str) -> bool {
     language.eq_ignore_ascii_case("mermaid")
+}
+
+/// Every option key a diagram cell can act on. A key outside this set is
+/// unknown; a key inside it that still went unconsumed had nowhere to go
+/// *in this position* (e.g. `fig-scap` on a numbered float).
+///
+/// **Grow this list when a feature starts honouring a key.** Q1 accepts
+/// `theme` and `mermaid-format` on mermaid cells; q2 does not yet, so
+/// they warn here — correctly, today. The mermaid theming strands
+/// (bd-sehm2rha, bd-nj25kgbu) should add `theme` when they land, or
+/// authors who follow Q1 will get a warning for an option that works.
+const DIAGRAM_OPTION_KEYS: &[&str] = &["label", "fig-cap", "fig-scap", "fig-alt"];
+
+/// Report options a diagram cell carried but nothing acted on
+/// (decision 4).
+///
+/// This is deliberately scoped to diagram cells. On an **executable**
+/// cell an unrecognized key is normally an engine option (`echo`,
+/// `eval`, `warning`, engine-specific keys) that the engine reads from
+/// the body, so warning there would fire on essentially every real
+/// document. A diagram cell has no engine at all — every option is q2's
+/// to interpret, and one q2 does not interpret is a mistake.
+fn warn_unconsumed_options(
+    parsed: &CellOptions,
+    consumed: &std::collections::HashMap<String, &OptionValue>,
+    diagnostics: &mut Vec<DiagnosticMessage>,
+) {
+    // Sorted so a cell with several stray options reports them in a
+    // stable order rather than the hash map's.
+    let mut leftover: Vec<(&String, &OptionValue)> = parsed
+        .values
+        .iter()
+        .filter(|(key, _)| !consumed.contains_key(*key))
+        .collect();
+    leftover.sort_by(|a, b| a.0.cmp(b.0));
+
+    for (key, option) in leftover {
+        let recognized = DIAGRAM_OPTION_KEYS.contains(&key.as_str());
+        let problem = if recognized {
+            format!("`{key}` is a Quarto cell option, but it has no effect on this diagram.")
+        } else {
+            format!("`{key}` is not a cell option a diagram cell understands.")
+        };
+        let hint = if recognized {
+            "Remove it, or move it to a position where it applies."
+        } else {
+            "Diagram cells accept `label`, `fig-cap`, `fig-scap`, and `fig-alt`. \
+             A diagram has no execution engine, so other options have nowhere to go."
+        };
+        diagnostics.push(
+            DiagnosticMessageBuilder::warning("Cell option ignored on a diagram cell")
+                .with_code("Q-2-47")
+                .with_location(option.key_source.clone())
+                .problem(problem)
+                .add_hint(hint)
+                .build(),
+        );
+    }
+}
+
+/// Report a leading run of `#|` lines in a diagram cell (decision 5).
+///
+/// `#|` used to work here, and stopping is deliberate — but `#` is not a
+/// mermaid comment, so the leftover lines become diagram source and
+/// mermaid fails to parse them. Without this the author sees a broken
+/// diagram and no explanation.
+///
+/// Only fires when the cell's own marker found nothing: a cell that
+/// correctly uses `%%|` and happens to contain a `#|` further down is
+/// writing diagram content, not options.
+fn warn_wrong_marker(
+    text: &str,
+    parsed: &CellOptions,
+    body_source: &SourceInfo,
+    diagnostics: &mut Vec<DiagnosticMessage>,
+) {
+    if !parsed.values.is_empty() {
+        return;
+    }
+    let Some(first) = text.lines().next() else {
+        return;
+    };
+    let Some(rest) = first.strip_prefix('#') else {
+        return;
+    };
+    if !rest.trim_start_matches([' ', '\t']).starts_with('|') {
+        return;
+    }
+
+    diagnostics.push(
+        DiagnosticMessageBuilder::warning("Wrong cell-option marker for a diagram cell")
+            .with_code("Q-2-48")
+            .with_location(SourceInfo::substring(
+                body_source.clone(),
+                0,
+                first.len().min(body_source.length()),
+            ))
+            .problem("`#|` is not a mermaid comment, so these lines are read as diagram source.")
+            .add_hint("Write mermaid cell options as `%%|` — the marker follows the cell language's own comment syntax.")
+            .build(),
+    );
 }
 
 /// Carry `fig-alt` into a mermaid diagram as its native `accDescr:`
@@ -900,6 +1011,104 @@ mod tests {
             cb.text
         );
         assert!(!cb.text.contains("fig-cap"), "got:\n{}", cb.text);
+    }
+
+    fn desugar_collecting(blocks: &mut Blocks, reg: &RefTypeRegistry) -> Vec<DiagnosticMessage> {
+        let mut diagnostics = Vec::new();
+        desugar_blocks(blocks, reg, &sources(), &mut diagnostics);
+        diagnostics
+    }
+
+    /// Decision 4: a diagram cell has no engine to hand leftover options
+    /// to, so an option q2 does not act on is a mistake worth naming —
+    /// and the diagnostic points at the key, not at the block.
+    #[test]
+    fn unknown_option_on_a_diagram_cell_warns() {
+        let reg = RefTypeRegistry::builtin();
+        let mut blocks = vec![code_in(
+            "mermaid",
+            "%%| fig-cap: A flowchart.\n%%| echo: false\nflowchart LR\n  A --> B\n",
+        )];
+        let diagnostics = desugar_collecting(&mut blocks, &reg);
+
+        assert_eq!(diagnostics.len(), 1, "got {diagnostics:?}");
+        let d = &diagnostics[0];
+        assert_eq!(d.code.as_deref(), Some("Q-2-47"));
+        assert!(
+            format!("{d:?}").contains("echo"),
+            "the diagnostic must name the offending key; got {d:?}"
+        );
+        assert!(
+            d.location.is_some(),
+            "the diagnostic must be source-mapped; got {d:?}"
+        );
+    }
+
+    /// The engine path keeps its silence: `echo`/`eval`/engine-specific
+    /// keys are the engine's business, and warning on them would fire on
+    /// essentially every real document.
+    #[test]
+    fn unknown_option_on_an_executable_cell_is_silent() {
+        let reg = RefTypeRegistry::builtin();
+        let mut blocks = vec![code_in(
+            "{python}",
+            "#| label: fig-p\n#| fig-cap: A plot.\n#| echo: false\n#| warning: false\nplot()\n",
+        )];
+        let diagnostics = desugar_collecting(&mut blocks, &reg);
+        assert!(diagnostics.is_empty(), "got {diagnostics:?}");
+    }
+
+    /// Decision 5's other half: `#|` in a mermaid fence is now inert, so
+    /// say why rather than letting mermaid fail on the leftover lines.
+    #[test]
+    fn hash_marker_in_a_mermaid_cell_warns() {
+        let reg = RefTypeRegistry::builtin();
+        let mut blocks = vec![code_in(
+            "mermaid",
+            "#| label: fig-hash\n#| fig-cap: Hash-prefixed.\nflowchart LR\n  A --> B\n",
+        )];
+        let diagnostics = desugar_collecting(&mut blocks, &reg);
+
+        assert_eq!(diagnostics.len(), 1, "got {diagnostics:?}");
+        let d = &diagnostics[0];
+        assert_eq!(d.code.as_deref(), Some("Q-2-48"));
+        assert!(
+            d.location.is_some(),
+            "the diagnostic must be source-mapped; got {d:?}"
+        );
+    }
+
+    /// A `%%` comment that is not an option line is just a comment.
+    #[test]
+    fn plain_mermaid_comment_does_not_warn() {
+        let reg = RefTypeRegistry::builtin();
+        let mut blocks = vec![code_in(
+            "mermaid",
+            "%% just a comment\nflowchart LR\n  A --> B\n",
+        )];
+        let diagnostics = desugar_collecting(&mut blocks, &reg);
+        assert!(diagnostics.is_empty(), "got {diagnostics:?}");
+    }
+
+    /// A recognized key q2 cannot route *in this position* is still
+    /// reported — `fig-scap` has nowhere to go on a numbered float — but
+    /// the reason differs from an unknown key, so the message says so.
+    #[test]
+    fn recognized_but_unroutable_option_warns_on_a_diagram_cell() {
+        let reg = RefTypeRegistry::builtin();
+        let mut blocks = vec![code_in(
+            "mermaid",
+            "%%| label: fig-d\n%%| fig-cap: Long.\n%%| fig-scap: Short.\nflowchart LR\n  A --> B\n",
+        )];
+        let diagnostics = desugar_collecting(&mut blocks, &reg);
+
+        assert_eq!(diagnostics.len(), 1, "got {diagnostics:?}");
+        assert_eq!(diagnostics[0].code.as_deref(), Some("Q-2-47"));
+        assert!(
+            format!("{:?}", diagnostics[0]).contains("fig-scap"),
+            "got {:?}",
+            diagnostics[0]
+        );
     }
 
     /// A brace-form executable cell still resolves to its language's

--- a/crates/quarto-core/src/crossref/codeblock_shorthand.rs
+++ b/crates/quarto-core/src/crossref/codeblock_shorthand.rs
@@ -66,7 +66,8 @@
 
 use quarto_error_reporting::DiagnosticMessage;
 use quarto_pandoc_types::attr::AttrSourceInfo;
-use quarto_pandoc_types::block::{Block, Blocks, Div, Paragraph};
+use quarto_pandoc_types::block::{Block, Blocks, Div, Figure, Paragraph, Plain};
+use quarto_pandoc_types::caption::Caption;
 use quarto_pandoc_types::inline::{Inline, Inlines, Str};
 use quarto_source_map::{SourceContext, SourceInfo};
 use yaml_rust2::Yaml;
@@ -135,28 +136,37 @@ fn try_desugar_code_block(
     let language = language_of(cb);
     let parsed = parse_cell_options(&language, &cb.text, body_source_for(cb, sources));
 
-    // Find a `label:` that classifies as a crossref.
-    let label = parsed.get("label")?;
-    let def = registry.classify_cite_id(label)?;
-    let identifier = label.to_string();
-    let ref_type = def.ref_type.clone();
+    match parsed.get("label") {
+        // A `label:` that classifies as a crossref: build the float Div
+        // the crossref pipeline numbers and renders.
+        Some(label) => {
+            let def = registry.classify_cite_id(label)?;
+            desugar_as_float(cb, &parsed, label, &def.ref_type.clone(), diagnostics)
+        }
+        // No label at all: a caption still deserves a figure, just an
+        // unnumbered one. A `label:` that is *not* a crossref means the
+        // author is naming the cell for the engine — leave it alone.
+        None => desugar_as_figure(cb, &parsed, diagnostics),
+    }
+}
 
+/// The labelled path: `::: {#fig-x} <code> <caption> :::`, which the
+/// crossref transforms later turn into a numbered float.
+fn desugar_as_float(
+    cb: &quarto_pandoc_types::block::CodeBlock,
+    parsed: &CellOptions,
+    label: &str,
+    ref_type: &str,
+    diagnostics: &mut Vec<DiagnosticMessage>,
+) -> Option<Block> {
     // Classify each option key as consumed vs. passed-through.
-    let (consumed, passthrough) = partition_options(&parsed, &ref_type);
+    let (consumed, passthrough) = partition_options(parsed, ref_type);
 
     // Extract the caption from the consumed set, if any.
     let caption = consumed.get(&format!("{ref_type}-cap")).copied();
 
-    // Rewrite the code block's text to drop the consumed lines.
-    let new_text = strip_consumed_lines(&cb.text, &consumed, &parsed.syntax);
-    let _ = passthrough; // kept as-is in `new_text`; explicit for clarity.
-
-    let new_code_block = Block::CodeBlock(quarto_pandoc_types::block::CodeBlock {
-        attr: cb.attr.clone(),
-        text: new_text,
-        source_info: cb.source_info.clone(),
-        attr_source: cb.attr_source.clone(),
-    });
+    let new_code_block = strip_options(cb, &consumed, &parsed.syntax);
+    let _ = passthrough; // kept as-is in the body; explicit for clarity.
 
     // Build the Div scaffold.
     let mut div_content: Blocks = vec![new_code_block];
@@ -164,13 +174,80 @@ fn try_desugar_code_block(
         div_content.push(caption_paragraph(caption, diagnostics));
     }
 
-    let attr = (identifier, Vec::new(), hashlink::LinkedHashMap::new());
+    let attr = (
+        label.to_string(),
+        Vec::new(),
+        hashlink::LinkedHashMap::new(),
+    );
     Some(Block::Div(Div {
         attr,
         content: div_content,
         source_info: cb.source_info.clone(),
         attr_source: AttrSourceInfo::empty(),
     }))
+}
+
+/// The unlabelled path (decision 1): `fig-cap` with no `label:` becomes
+/// a plain [`Block::Figure`], which the HTML writer renders as
+/// `<figure>…<figcaption>` with no number and no float scaffolding.
+///
+/// Q1 could not do this — its cell handling was textual, so it emitted
+/// markdown and let a filter rebuild the structure. Working on the AST,
+/// the node can be constructed directly.
+///
+/// Only `fig-cap`/`fig-scap` are honoured here: without a label there is
+/// no ref-type to derive a category from, and an unnumbered non-figure
+/// float is not a thing q2 models.
+fn desugar_as_figure(
+    cb: &quarto_pandoc_types::block::CodeBlock,
+    parsed: &CellOptions,
+    diagnostics: &mut Vec<DiagnosticMessage>,
+) -> Option<Block> {
+    let caption = parsed.values.get("fig-cap")?;
+    let short = parsed.values.get("fig-scap");
+
+    let mut consumed: std::collections::HashMap<String, &OptionValue> =
+        std::collections::HashMap::new();
+    consumed.insert("fig-cap".to_string(), caption);
+    if let Some(short) = short {
+        consumed.insert("fig-scap".to_string(), short);
+    }
+
+    let new_code_block = strip_options(cb, &consumed, &parsed.syntax);
+
+    let long = match caption_paragraph(caption, diagnostics) {
+        Block::Paragraph(p) => vec![Block::Plain(Plain {
+            content: p.content,
+            source_info: p.source_info,
+        })],
+        other => vec![other],
+    };
+
+    Some(Block::Figure(Figure {
+        attr: (String::new(), Vec::new(), hashlink::LinkedHashMap::new()),
+        caption: Caption {
+            short: short.map(|s| caption_inlines(s, diagnostics)),
+            long: Some(long),
+            source_info: caption.value_source.clone(),
+        },
+        content: vec![new_code_block],
+        source_info: cb.source_info.clone(),
+        attr_source: AttrSourceInfo::empty(),
+    }))
+}
+
+/// Clone `cb` with the `consumed` option lines removed from its body.
+fn strip_options(
+    cb: &quarto_pandoc_types::block::CodeBlock,
+    consumed: &std::collections::HashMap<String, &OptionValue>,
+    syntax: &CommentSyntax,
+) -> Block {
+    Block::CodeBlock(quarto_pandoc_types::block::CodeBlock {
+        attr: cb.attr.clone(),
+        text: strip_consumed_lines(&cb.text, consumed, syntax),
+        source_info: cb.source_info.clone(),
+        attr_source: cb.attr_source.clone(),
+    })
 }
 
 /// The cell's language: the block's first class, with a brace-form
@@ -397,13 +474,24 @@ fn strip_consumed_lines(
 /// carried into `diagnostics`.
 fn caption_paragraph(caption: &OptionValue, diagnostics: &mut Vec<DiagnosticMessage>) -> Block {
     let source_info = caption.value_source.clone();
+    Block::Paragraph(Paragraph {
+        content: caption_inlines(caption, diagnostics),
+        source_info,
+    })
+}
+
+/// The inline content of a caption option — see [`caption_paragraph`]
+/// for the parsing contract. Split out because a short caption
+/// (`fig-scap`) is `Inlines`, not a block.
+fn caption_inlines(caption: &OptionValue, diagnostics: &mut Vec<DiagnosticMessage>) -> Inlines {
+    let source_info = caption.value_source.clone();
     let kind = pampa::pandoc::meta::parse_config_string_as_markdown(
         &caption.value,
         &source_info,
         diagnostics,
     );
 
-    let content: Inlines = match kind {
+    match kind {
         quarto_pandoc_types::ConfigValueKind::PandocInlines(inlines) => inlines,
         quarto_pandoc_types::ConfigValueKind::PandocBlocks(blocks) => blocks
             .into_iter()
@@ -414,12 +502,7 @@ fn caption_paragraph(caption: &OptionValue, diagnostics: &mut Vec<DiagnosticMess
             })
             .unwrap_or_else(|| literal_caption(&caption.value, &source_info)),
         _ => literal_caption(&caption.value, &source_info),
-    };
-
-    Block::Paragraph(Paragraph {
-        content,
-        source_info,
-    })
+    }
 }
 
 /// Fallback caption inlines: the option's text, verbatim.
@@ -605,6 +688,74 @@ mod tests {
         }
         walk(inlines, &mut out);
         out
+    }
+
+    /// Decision 1: a `fig-cap` with no `label:` is a caption on an
+    /// *unnumbered* figure. Emitting `Block::Figure` directly is the
+    /// AST-level answer Q1 could not reach — its cell handling was
+    /// textual, so it had to emit markdown and let a filter rebuild the
+    /// structure.
+    #[test]
+    fn unlabelled_fig_cap_becomes_a_figure() {
+        let reg = RefTypeRegistry::builtin();
+        let mut blocks = vec![code_in(
+            "mermaid",
+            "%%| fig-cap: Caption without a label.\nflowchart LR\n  A --> B\n",
+        )];
+        desugar(&mut blocks, &reg);
+
+        let Block::Figure(fig) = &blocks[0] else {
+            panic!("expected Figure, got {:?}", blocks[0]);
+        };
+        assert_eq!(fig.attr.0, "", "an unlabelled figure carries no id");
+        let Block::CodeBlock(cb) = &fig.content[0] else {
+            panic!("figure must wrap the diagram");
+        };
+        assert!(!cb.text.contains("%%|"));
+        assert!(cb.text.contains("flowchart LR"));
+
+        let long = fig.caption.long.as_ref().expect("caption present");
+        let Block::Plain(p) = &long[0] else {
+            panic!("expected a Plain caption block, got {:?}", long[0]);
+        };
+        assert_eq!(plain_text(&p.content), "Caption without a label.");
+        assert!(fig.caption.short.is_none());
+    }
+
+    /// `fig-scap` is the short caption, which `Caption::short` models
+    /// directly. It used to be consumed and dropped (bd-il6pxq4f).
+    #[test]
+    fn unlabelled_fig_scap_sets_the_short_caption() {
+        let reg = RefTypeRegistry::builtin();
+        let mut blocks = vec![code_in(
+            "mermaid",
+            "%%| fig-cap: The long caption.\n%%| fig-scap: Short.\nflowchart LR\n  A --> B\n",
+        )];
+        desugar(&mut blocks, &reg);
+
+        let Block::Figure(fig) = &blocks[0] else {
+            panic!("expected Figure, got {:?}", blocks[0]);
+        };
+        let short = fig.caption.short.as_ref().expect("short caption present");
+        assert_eq!(plain_text(short), "Short.");
+        let Block::CodeBlock(cb) = &fig.content[0] else {
+            panic!()
+        };
+        assert!(
+            !cb.text.contains("fig-scap"),
+            "a consumed fig-scap must leave the body; got:\n{}",
+            cb.text
+        );
+    }
+
+    /// No label and no caption: nothing to build, block untouched.
+    #[test]
+    fn unlabelled_uncaptioned_block_untouched() {
+        let reg = RefTypeRegistry::builtin();
+        let mut blocks = vec![code_in("mermaid", "flowchart LR\n  A --> B\n")];
+        let before = blocks.clone();
+        desugar(&mut blocks, &reg);
+        assert_eq!(blocks, before);
     }
 
     /// A brace-form executable cell still resolves to its language's

--- a/crates/quarto-core/src/crossref/codeblock_shorthand.rs
+++ b/crates/quarto-core/src/crossref/codeblock_shorthand.rs
@@ -41,8 +41,17 @@
 //!
 //! ## Cell-option partitioning
 //!
-//! The `#|` block is parsed line-by-line. Each line matching `#| <key>:
-//! <value>` (leading whitespace tolerated) is partitioned:
+//! The option marker follows the **cell's language**, not a fixed `#|`:
+//! python/R use `#|`, lua/sql `--|`, js/rust `//|`, and mermaid `%%|`.
+//! The syntax comes from [`crate::cell_options::comment_syntax_for`], and
+//! the option block itself is split off and parsed as YAML by
+//! [`crate::cell_options::partition_cell_options`] — the shared facility,
+//! rather than the ad-hoc `split_once(':')` matcher this module used to
+//! carry (bd-mermaid-cell-options-9wo3crl0, bd-5jcmmj1f). Going through
+//! real YAML is what makes `fig-cap: "A caption."` arrive *without* its
+//! quotes, and what gives every key a source span to hang a diagnostic on.
+//!
+//! Each parsed option is then partitioned:
 //!
 //! - **Consumed** (lifted into the Div scaffold and removed from the code
 //!   block body): `label`, `<reftype>-cap`, `<reftype>-scap`, `<reftype>-alt`.
@@ -51,41 +60,46 @@
 //! - **Passed to the engine** (left in the body): everything else
 //!   (`echo`, `eval`, engine-specific options, etc.).
 //!
-//! Lines that don't match `#| key: value` shape pass through untouched.
-//! The first line that isn't a `#|` line stops cell-option parsing — the
-//! remainder of `text` is treated as code body.
+//! Only the **leading run** of option lines counts — the first line that
+//! isn't an option line starts the code. For mermaid this is what keeps a
+//! `%%|` further down the diagram an ordinary comment.
 
 use quarto_pandoc_types::attr::AttrSourceInfo;
 use quarto_pandoc_types::block::{Block, Blocks, Div, Paragraph};
 use quarto_pandoc_types::inline::{Inline, Inlines, Str};
-use quarto_source_map::SourceInfo;
+use quarto_source_map::{SourceContext, SourceInfo};
+use yaml_rust2::Yaml;
 
 use super::RefTypeRegistry;
+use crate::cell_options::{CommentSyntax, comment_syntax_for, partition_cell_options};
 
 /// Walk the top-level block list, desugaring any code-block shorthand in
 /// place.
-pub fn desugar_blocks(blocks: &mut Blocks, registry: &RefTypeRegistry) {
+///
+/// `sources` is the document's [`SourceContext`], used to anchor each
+/// cell's option spans in the original file — see [`body_source_for`].
+pub fn desugar_blocks(blocks: &mut Blocks, registry: &RefTypeRegistry, sources: &SourceContext) {
     // We iterate by index because we may replace the current slot.
     let mut i = 0;
     while i < blocks.len() {
         // Recurse into containers.
         match &mut blocks[i] {
-            Block::BlockQuote(bq) => desugar_blocks(&mut bq.content, registry),
-            Block::Div(div) => desugar_blocks(&mut div.content, registry),
+            Block::BlockQuote(bq) => desugar_blocks(&mut bq.content, registry, sources),
+            Block::Div(div) => desugar_blocks(&mut div.content, registry, sources),
             Block::OrderedList(ol) => {
                 for item in &mut ol.content {
-                    desugar_blocks(item, registry);
+                    desugar_blocks(item, registry, sources);
                 }
             }
             Block::BulletList(bl) => {
                 for item in &mut bl.content {
-                    desugar_blocks(item, registry);
+                    desugar_blocks(item, registry, sources);
                 }
             }
             Block::DefinitionList(dl) => {
                 for (_term, defs) in &mut dl.content {
                     for def in defs {
-                        desugar_blocks(def, registry);
+                        desugar_blocks(def, registry, sources);
                     }
                 }
             }
@@ -94,7 +108,7 @@ pub fn desugar_blocks(blocks: &mut Blocks, registry: &RefTypeRegistry) {
 
         // Try to desugar this block.
         if let Block::CodeBlock(cb) = &blocks[i]
-            && let Some(replacement) = try_desugar_code_block(cb, registry)
+            && let Some(replacement) = try_desugar_code_block(cb, registry, sources)
         {
             blocks[i] = replacement;
         }
@@ -105,23 +119,27 @@ pub fn desugar_blocks(blocks: &mut Blocks, registry: &RefTypeRegistry) {
 fn try_desugar_code_block(
     cb: &quarto_pandoc_types::block::CodeBlock,
     registry: &RefTypeRegistry,
+    sources: &SourceContext,
 ) -> Option<Block> {
-    let parsed = parse_cell_options(&cb.text);
+    let language = language_of(cb);
+    let parsed = parse_cell_options(&language, &cb.text, body_source_for(cb, sources));
 
     // Find a `label:` that classifies as a crossref.
     let label = parsed.get("label")?;
     let def = registry.classify_cite_id(label)?;
-    let identifier = label.clone();
+    let identifier = label.to_string();
     let ref_type = def.ref_type.clone();
 
     // Classify each option key as consumed vs. passed-through.
     let (consumed, passthrough) = partition_options(&parsed, &ref_type);
 
     // Extract the caption text from the consumed set, if any.
-    let caption_text = consumed.get(&format!("{ref_type}-cap")).cloned();
+    let caption_text = consumed
+        .get(&format!("{ref_type}-cap"))
+        .map(|s| s.to_string());
 
     // Rewrite the code block's text to drop the consumed lines.
-    let new_text = strip_consumed_lines(&cb.text, &consumed);
+    let new_text = strip_consumed_lines(&cb.text, &consumed, &parsed.syntax);
     let _ = passthrough; // kept as-is in `new_text`; explicit for clarity.
 
     let new_code_block = Block::CodeBlock(quarto_pandoc_types::block::CodeBlock {
@@ -146,40 +164,150 @@ fn try_desugar_code_block(
     }))
 }
 
-/// Parse `#| key: value` lines from the head of `text`. Returns the
-/// parsed map; stops at the first non-`#|` line.
+/// The cell's language: the block's first class, with a brace-form
+/// wrapper removed (` ```{python} ` parses to the class `{python}`, and
+/// its options are still `#|`). An unclassed block reports `""`, which
+/// [`comment_syntax_for`] maps to the `#` default.
+fn language_of(cb: &quarto_pandoc_types::block::CodeBlock) -> String {
+    let Some(first) = cb.attr.1.first() else {
+        return String::new();
+    };
+    first
+        .strip_prefix('{')
+        .and_then(|s| s.strip_suffix('}'))
+        .unwrap_or(first)
+        .to_string()
+}
+
+/// Provenance for `cb.text`.
 ///
-/// Preserves original insertion order is not needed — we only need
-/// lookups, so a HashMap is fine.
-fn parse_cell_options(text: &str) -> std::collections::HashMap<String, String> {
-    let mut out = std::collections::HashMap::new();
-    for line in text.lines() {
-        let trimmed = line.trim_start();
-        let rest = match trimmed.strip_prefix("#|") {
-            Some(s) => s,
-            None => break,
-        };
-        let rest = rest.trim_start();
-        if let Some((key, value)) = rest.split_once(':') {
-            let key = key.trim().to_string();
-            let value = value.trim().to_string();
-            if !key.is_empty() {
-                out.insert(key, value);
-            }
+/// `CodeBlock::source_info` spans the **whole fenced block** — opening
+/// fence, info string, content, closing fence — so it cannot be used
+/// directly as the body's source: every offset would be shifted by the
+/// length of the fence line. Locate `cb.text` inside the block's own
+/// source text and return the matching substring span.
+///
+/// Falls back to the block's span when the body is not a contiguous
+/// substring of it. That happens legitimately: a fence inside a
+/// blockquote or a list item has its continuation markers (`> `,
+/// indentation) stripped from `text` by the parser, so no contiguous
+/// range matches. Diagnostics then point at the block rather than the
+/// exact key — coarser, but never *wrong*, which is the property that
+/// matters (the alternative, binding an assumed span to real content,
+/// is the failure mode `add_file_with_id` is lint-gated against).
+fn body_source_for(
+    cb: &quarto_pandoc_types::block::CodeBlock,
+    sources: &SourceContext,
+) -> SourceInfo {
+    let block = cb.source_info.clone();
+    if cb.text.is_empty() {
+        return block;
+    }
+    let Some((file_id, start, end)) = block.resolve_byte_range() else {
+        return block;
+    };
+    let Some(file) = sources.get_file(quarto_source_map::FileId(file_id)) else {
+        return block;
+    };
+    let Some(block_text) = file.content.as_deref().and_then(|c| c.get(start..end)) else {
+        return block;
+    };
+    match block_text.find(&cb.text) {
+        Some(offset) => SourceInfo::substring(block, offset, offset + cb.text.len()),
+        None => block,
+    }
+}
+
+/// A cell's parsed option block: scalar values by key, plus the comment
+/// syntax its language uses (needed to strip the consumed lines back out
+/// of the body).
+struct CellOptions {
+    values: std::collections::HashMap<String, OptionValue>,
+    syntax: CommentSyntax,
+}
+
+/// One option's scalar value and the provenance of its **key**, which is
+/// what a diagnostic about the option should point at.
+struct OptionValue {
+    value: String,
+    #[allow(
+        dead_code,
+        reason = "consumed by the unknown-key diagnostics in Phase 6"
+    )]
+    key_source: SourceInfo,
+}
+
+impl CellOptions {
+    fn get(&self, key: &str) -> Option<&str> {
+        self.values.get(key).map(|v| v.value.as_str())
+    }
+}
+
+/// Split `text` into `<marker> key: value` options + code per
+/// `language`'s comment syntax, and return the options' scalar values.
+///
+/// Non-scalar values (sequences, mappings) are skipped: no key this
+/// module consumes takes one, and the engine reads the body text
+/// directly rather than this map.
+///
+/// A malformed options block yields no options and leaves the block
+/// alone. It is deliberately **not** reported here: the engine-execution
+/// stage re-partitions the same cell and already fails the render with a
+/// located diagnostic (`engine_error_policy::malformed_cell_options_fail_the_render`),
+/// so reporting here too would double-report the same mistake.
+fn parse_cell_options(language: &str, text: &str, body_source: SourceInfo) -> CellOptions {
+    let syntax = comment_syntax_for(language);
+    let mut values = std::collections::HashMap::new();
+
+    if let Ok(part) = partition_cell_options(language, text, body_source)
+        && let Some(options) = part.options
+        && let Some(entries) = options.as_hash()
+    {
+        for entry in entries {
+            let (Some(key), Some(value)) =
+                (entry.key.yaml.as_str(), scalar_to_string(&entry.value))
+            else {
+                continue;
+            };
+            values.insert(
+                key.to_string(),
+                OptionValue {
+                    value,
+                    key_source: entry.key.source_info.clone(),
+                },
+            );
         }
     }
-    out
+
+    CellOptions { values, syntax }
+}
+
+/// Render a scalar YAML node as the string this module works with.
+/// `None` for arrays, hashes, and null.
+fn scalar_to_string(node: &quarto_yaml::YamlWithSourceInfo) -> Option<String> {
+    if !node.is_scalar() {
+        return None;
+    }
+    match &node.yaml {
+        Yaml::String(s) => Some(s.clone()),
+        Yaml::Integer(i) => Some(i.to_string()),
+        // `Real` keeps the scalar's original text, so a numeric caption
+        // reaches the reader exactly as written.
+        Yaml::Real(r) => Some(r.clone()),
+        Yaml::Boolean(b) => Some(b.to_string()),
+        _ => None,
+    }
 }
 
 /// Partition parsed options into (consumed, passthrough). `ref_type` is
 /// used to recognize `<reftype>-cap`-style keys against the current
 /// category.
-fn partition_options(
-    parsed: &std::collections::HashMap<String, String>,
+fn partition_options<'a>(
+    parsed: &'a CellOptions,
     ref_type: &str,
 ) -> (
-    std::collections::HashMap<String, String>,
-    std::collections::HashMap<String, String>,
+    std::collections::HashMap<String, &'a str>,
+    std::collections::HashMap<String, &'a str>,
 ) {
     let mut consumed = std::collections::HashMap::new();
     let mut passthrough = std::collections::HashMap::new();
@@ -188,43 +316,48 @@ fn partition_options(
     let scap_key = format!("{ref_type}-scap");
     let alt_key = format!("{ref_type}-alt");
 
-    for (k, v) in parsed {
+    for (k, v) in &parsed.values {
         if k == "label" || *k == cap_key || *k == scap_key || *k == alt_key {
-            consumed.insert(k.clone(), v.clone());
+            consumed.insert(k.clone(), v.value.as_str());
         } else {
-            passthrough.insert(k.clone(), v.clone());
+            passthrough.insert(k.clone(), v.value.as_str());
         }
     }
     (consumed, passthrough)
 }
 
-/// Remove the `#| key: ...` lines in `consumed` from the head of `text`.
-/// Leaves lines for keys not in `consumed` (and all lines after the first
-/// non-`#|` line) untouched.
+/// Remove the `<marker> key: ...` lines in `consumed` from the head of
+/// `text`. Leaves lines for keys not in `consumed` (and all lines after
+/// the first non-option line) untouched.
+///
+/// This stays line-oriented on purpose: unconsumed options must reach the
+/// engine byte-for-byte as the author wrote them, so the body is edited
+/// rather than re-serialized from the parsed map.
 fn strip_consumed_lines(
     text: &str,
-    consumed: &std::collections::HashMap<String, String>,
+    consumed: &std::collections::HashMap<String, &str>,
+    syntax: &CommentSyntax,
 ) -> String {
     let mut out = String::new();
     let mut in_header = true;
     for line in text.lines() {
         if in_header {
-            let trimmed = line.trim_start();
-            if let Some(rest) = trimmed.strip_prefix("#|") {
-                let rest = rest.trim_start();
-                if let Some((key, _value)) = rest.split_once(':')
-                    && consumed.contains_key(key.trim())
-                {
-                    // Drop this line.
+            if let Some(rest) = line.strip_prefix(syntax.prefix) {
+                let rest = rest.trim_start_matches([' ', '\t']);
+                if let Some(rest) = rest.strip_prefix('|') {
+                    if let Some((key, _value)) = rest.split_once(':')
+                        && consumed.contains_key(key.trim())
+                    {
+                        // Drop this line.
+                        continue;
+                    }
+                    // Option line that isn't consumed — keep it.
+                    out.push_str(line);
+                    out.push('\n');
                     continue;
                 }
-                // `#|` line that isn't consumed — keep it.
-                out.push_str(line);
-                out.push('\n');
-                continue;
-            } else {
-                in_header = false;
             }
+            in_header = false;
         }
         out.push_str(line);
         out.push('\n');
@@ -260,28 +393,137 @@ mod tests {
     }
 
     fn code(text: &str) -> Block {
+        code_in("python", text)
+    }
+
+    fn code_in(language: &str, text: &str) -> Block {
         Block::CodeBlock(CodeBlock {
-            attr: (String::new(), vec!["python".into()], LinkedHashMap::new()),
+            attr: (String::new(), vec![language.into()], LinkedHashMap::new()),
             text: text.to_string(),
             source_info: si(),
             attr_source: AttrSourceInfo::empty(),
         })
     }
 
+    /// Tests don't need real provenance — the desugar only uses it to
+    /// give parsed option spans something to hang off.
+    fn sources() -> SourceContext {
+        SourceContext::new()
+    }
+
+    fn desugar(blocks: &mut Blocks, reg: &RefTypeRegistry) {
+        desugar_blocks(blocks, reg, &sources());
+    }
+
     #[test]
     fn parses_cell_options() {
-        let opts =
-            parse_cell_options("#| label: fig-plot\n#| fig-cap: \"My caption\"\nprint('hi')\n");
-        assert_eq!(&opts["label"], "fig-plot");
-        assert!(opts["fig-cap"].contains("My caption"));
-        assert!(!opts.contains_key("print('hi')"));
+        let opts = parse_cell_options(
+            "python",
+            "#| label: fig-plot\n#| fig-cap: \"My caption\"\nprint('hi')\n",
+            si(),
+        );
+        assert_eq!(opts.get("label"), Some("fig-plot"));
+        assert_eq!(opts.get("fig-cap"), Some("My caption"));
+        assert_eq!(opts.get("print('hi')"), None);
     }
 
     #[test]
     fn stops_at_first_non_pipe_line() {
-        let opts = parse_cell_options("#| label: fig-one\nprint('hi')\n#| fig-cap: Too late");
-        assert_eq!(&opts["label"], "fig-one");
-        assert!(!opts.contains_key("fig-cap"));
+        let opts = parse_cell_options(
+            "python",
+            "#| label: fig-one\nprint('hi')\n#| fig-cap: Too late",
+            si(),
+        );
+        assert_eq!(opts.get("label"), Some("fig-one"));
+        assert_eq!(opts.get("fig-cap"), None);
+    }
+
+    /// The option marker follows the *cell language*, so a mermaid
+    /// diagram uses `%%|` (bd-mermaid-cell-options-9wo3crl0).
+    #[test]
+    fn mermaid_percent_options_desugar() {
+        let reg = RefTypeRegistry::builtin();
+        let mut blocks = vec![code_in(
+            "mermaid",
+            "%%| label: fig-diagram\n%%| fig-cap: A labelled flowchart.\nflowchart LR\n  A --> B\n",
+        )];
+        desugar(&mut blocks, &reg);
+
+        let Block::Div(div) = &blocks[0] else {
+            panic!("expected Div, got {:?}", blocks[0]);
+        };
+        assert_eq!(div.attr.0, "fig-diagram");
+        let Block::CodeBlock(cb) = &div.content[0] else {
+            panic!("expected the diagram code block");
+        };
+        assert!(
+            !cb.text.contains("%%|"),
+            "consumed option lines must leave the diagram source; got:\n{}",
+            cb.text
+        );
+        assert!(cb.text.contains("flowchart LR"));
+        let Block::Paragraph(p) = &div.content[1] else {
+            panic!("expected a caption paragraph");
+        };
+        let Inline::Str(s) = &p.content[0] else {
+            panic!()
+        };
+        assert_eq!(s.text, "A labelled flowchart.");
+    }
+
+    /// Decision 5: mermaid takes `%%|` *only*. `#|` is not a mermaid
+    /// comment at all, so treating it as an option marker would teach
+    /// authors that `#|` is universal. The block is left untouched.
+    #[test]
+    fn mermaid_hash_options_are_not_cell_options() {
+        let reg = RefTypeRegistry::builtin();
+        let mut blocks = vec![code_in(
+            "mermaid",
+            "#| label: fig-hash\n#| fig-cap: Hash-prefixed.\nflowchart LR\n  A --> B\n",
+        )];
+        let before = blocks.clone();
+        desugar(&mut blocks, &reg);
+        assert_eq!(blocks, before);
+    }
+
+    /// D1 (bd-5jcmmj1f): option values are YAML, so a double-quoted
+    /// caption must reach the figcaption *without* its quotes. The old
+    /// `split_once(':')` matcher carried them through verbatim.
+    #[test]
+    fn quoted_caption_loses_its_quotes() {
+        let reg = RefTypeRegistry::builtin();
+        let mut blocks = vec![code(
+            "#| label: fig-q\n#| fig-cap: \"A quoted caption.\"\nprint('hi')\n",
+        )];
+        desugar(&mut blocks, &reg);
+
+        let Block::Div(div) = &blocks[0] else {
+            panic!()
+        };
+        let Block::Paragraph(p) = &div.content[1] else {
+            panic!()
+        };
+        let Inline::Str(s) = &p.content[0] else {
+            panic!()
+        };
+        assert_eq!(s.text, "A quoted caption.");
+    }
+
+    /// A brace-form executable cell still resolves to its language's
+    /// comment syntax — `{python}` is `#`, not the unknown-language
+    /// default reached by looking up the literal class `{python}`.
+    #[test]
+    fn brace_form_cell_uses_its_language_syntax() {
+        let reg = RefTypeRegistry::builtin();
+        let mut blocks = vec![code_in(
+            "{python}",
+            "#| label: fig-brace\n#| fig-cap: Braced.\nprint('hi')\n",
+        )];
+        desugar(&mut blocks, &reg);
+        let Block::Div(div) = &blocks[0] else {
+            panic!("expected Div, got {:?}", blocks[0]);
+        };
+        assert_eq!(div.attr.0, "fig-brace");
     }
 
     #[test]
@@ -290,7 +532,7 @@ mod tests {
         let mut blocks = vec![code(
             "#| label: fig-plot\n#| fig-cap: A plot.\n#| echo: false\nprint('hi')\n",
         )];
-        desugar_blocks(&mut blocks, &reg);
+        desugar(&mut blocks, &reg);
         assert_eq!(blocks.len(), 1);
         let Block::Div(div) = &blocks[0] else {
             panic!("expected Div, got {:?}", blocks[0]);
@@ -321,7 +563,7 @@ mod tests {
         let reg = RefTypeRegistry::builtin();
         let mut blocks = vec![code("#| echo: false\nprint('hi')\n")];
         let before = blocks.clone();
-        desugar_blocks(&mut blocks, &reg);
+        desugar(&mut blocks, &reg);
         assert_eq!(blocks, before);
     }
 
@@ -332,7 +574,7 @@ mod tests {
         let reg = RefTypeRegistry::builtin();
         let mut blocks = vec![code("#| label: my-section\nprint('hi')\n")];
         let before = blocks.clone();
-        desugar_blocks(&mut blocks, &reg);
+        desugar(&mut blocks, &reg);
         assert_eq!(blocks, before);
     }
 
@@ -342,7 +584,7 @@ mod tests {
         let mut blocks = vec![code(
             "#| label: tbl-data\n#| tbl-cap: Summary.\nsummary(df)\n",
         )];
-        desugar_blocks(&mut blocks, &reg);
+        desugar(&mut blocks, &reg);
         let Block::Div(div) = &blocks[0] else {
             panic!()
         };
@@ -365,7 +607,7 @@ mod tests {
         let mut blocks = vec![code(
             "#| label: tbl-x\n#| fig-cap: Misplaced.\n#| tbl-cap: Correct.\nsummary(df)\n",
         )];
-        desugar_blocks(&mut blocks, &reg);
+        desugar(&mut blocks, &reg);
         let Block::Div(div) = &blocks[0] else {
             panic!()
         };
@@ -381,11 +623,8 @@ mod tests {
     #[test]
     fn strip_consumed_lines_preserves_trailing_newline_absence() {
         let text = "#| label: fig-x\nprint('hi')";
-        let consumed = [("label".to_string(), "fig-x".to_string())]
-            .iter()
-            .cloned()
-            .collect();
-        let out = strip_consumed_lines(text, &consumed);
+        let consumed = [("label".to_string(), "fig-x")].into_iter().collect();
+        let out = strip_consumed_lines(text, &consumed, &comment_syntax_for("python"));
         assert_eq!(out, "print('hi')");
     }
 
@@ -400,7 +639,7 @@ mod tests {
             attr_source: AttrSourceInfo::empty(),
         });
         let mut blocks = vec![outer];
-        desugar_blocks(&mut blocks, &reg);
+        desugar(&mut blocks, &reg);
         let Block::Div(wrapper) = &blocks[0] else {
             panic!()
         };

--- a/crates/quarto-core/src/pipeline.rs
+++ b/crates/quarto-core/src/pipeline.rs
@@ -2802,6 +2802,72 @@ mod tests {
         );
     }
 
+    /// bd-mermaid-cell-options-9wo3crl0: mermaid `%%|` cell options are
+    /// processed by `PreEngineSugaringStage`, which is a *stage* — while
+    /// `Q2_PREVIEW_TRANSFORM_EXCLUDED` only filters *transforms*. So the
+    /// preview AST must carry the same structure `q2 render` emits: a
+    /// Figure wrapping the diagram, the options gone from the diagram
+    /// source, and `fig-alt` folded into mermaid's `accDescr:`.
+    ///
+    /// The `mermaid-render` transform stays excluded here (the raw
+    /// CodeBlock has to reach `MermaidCodeBlock.tsx`), so the diagram
+    /// arrives as a CodeBlock rather than a `<pre>` RawBlock — that is
+    /// the intended difference, and this test pins it so a future change
+    /// to either list cannot silently diverge the two surfaces.
+    #[test]
+    fn render_qmd_to_preview_ast_processes_mermaid_cell_options() {
+        let content = "---\ntitle: Test\nformat: q2-preview\n---\n\n\
+                        ```mermaid\n\
+                        %%| fig-cap: A tiny flowchart.\n\
+                        %%| fig-alt: Two nodes connected by an arrow.\n\
+                        flowchart LR\n  A --> B\n\
+                        ```\n"
+            .as_bytes();
+
+        let project = make_test_project();
+        let doc = DocumentInfo::from_path("/project/test.qmd");
+        let format = Format::from_format_string("q2-preview").unwrap();
+        let binaries = BinaryDependencies::new();
+        let mut ctx = RenderContext::new(&project, &doc, &format, &binaries);
+
+        let runtime = make_test_runtime();
+        let output = pollster::block_on(render_qmd_to_preview_ast(
+            content,
+            "test.qmd",
+            &mut ctx,
+            runtime,
+            None,
+            Vec::new(),
+        ))
+        .expect("q2-preview render");
+
+        let json = &output.ast_json;
+        assert!(
+            json.contains("\"Figure\""),
+            "preview AST must carry the Figure wrapper; got:\n{json}"
+        );
+        // The caption is markdown, so it arrives as separate Str/Space
+        // inlines rather than one contiguous string.
+        for word in ["\"tiny\"", "\"flowchart.\""] {
+            assert!(
+                json.contains(word),
+                "preview AST must carry the caption word {word}; got:\n{json}"
+            );
+        }
+        assert!(
+            json.contains("accDescr: Two nodes connected by an arrow."),
+            "preview AST must carry the injected accDescr; got:\n{json}"
+        );
+        assert!(
+            !json.contains("%%|"),
+            "consumed option lines must not reach the preview; got:\n{json}"
+        );
+        assert!(
+            json.contains("\"CodeBlock\""),
+            "the raw CodeBlock must survive for MermaidCodeBlock.tsx; got:\n{json}"
+        );
+    }
+
     /// Phase 1P: the `q2-slides` preview pseudo-format must run the reveal
     /// slide construction (`RevealSlidesTransform`) and return the
     /// section-structured AST — the shared contract the SPA renders with a

--- a/crates/quarto-core/src/stage/stages/pre_engine_sugaring.rs
+++ b/crates/quarto-core/src/stage/stages/pre_engine_sugaring.rs
@@ -139,7 +139,11 @@ impl PipelineStage for PreEngineSugaringStage {
         // Desugar code-block crossref shorthand into the canonical Div
         // scaffold so engine execution sees plain code blocks. The walk
         // uses the finalized registry so user-declared categories work.
-        codeblock_shorthand::desugar_blocks(&mut doc.ast.blocks, &registry);
+        codeblock_shorthand::desugar_blocks(
+            &mut doc.ast.blocks,
+            &registry,
+            &doc.ast_context.source_context,
+        );
 
         ctx.ref_type_registry = Some(registry);
         // Only seed the index if no prior stage has set one. Idempotent so

--- a/crates/quarto-core/src/stage/stages/pre_engine_sugaring.rs
+++ b/crates/quarto-core/src/stage/stages/pre_engine_sugaring.rs
@@ -143,6 +143,7 @@ impl PipelineStage for PreEngineSugaringStage {
             &mut doc.ast.blocks,
             &registry,
             &doc.ast_context.source_context,
+            &mut ctx.diagnostics,
         );
 
         ctx.ref_type_registry = Some(registry);

--- a/crates/quarto-core/tests/integration/crossref_fixtures.rs
+++ b/crates/quarto-core/tests/integration/crossref_fixtures.rs
@@ -53,7 +53,11 @@ async fn run_crossref(
     // metadata.
 
     // Step 2: code-block shorthand desugar.
-    quarto_core::crossref::codeblock_shorthand::desugar_blocks(&mut ast.blocks, &registry);
+    quarto_core::crossref::codeblock_shorthand::desugar_blocks(
+        &mut ast.blocks,
+        &registry,
+        &quarto_source_map::SourceContext::new(),
+    );
 
     // Step 3: front-end transforms. We build a minimal RenderContext for
     // the async transform API.
@@ -797,7 +801,11 @@ async fn run_crossref_rendered(
     let extracted = metadata::read(&ast.meta, &mut registry);
     registry.extend_from_promised(&extracted.promised_ids);
 
-    quarto_core::crossref::codeblock_shorthand::desugar_blocks(&mut ast.blocks, &registry);
+    quarto_core::crossref::codeblock_shorthand::desugar_blocks(
+        &mut ast.blocks,
+        &registry,
+        &quarto_source_map::SourceContext::new(),
+    );
 
     use quarto_core::format::Format;
     use quarto_core::project::{DocumentInfo, ProjectConfig, ProjectContext};

--- a/crates/quarto-core/tests/integration/crossref_fixtures.rs
+++ b/crates/quarto-core/tests/integration/crossref_fixtures.rs
@@ -57,6 +57,7 @@ async fn run_crossref(
         &mut ast.blocks,
         &registry,
         &quarto_source_map::SourceContext::new(),
+        &mut Vec::new(),
     );
 
     // Step 3: front-end transforms. We build a minimal RenderContext for
@@ -805,6 +806,7 @@ async fn run_crossref_rendered(
         &mut ast.blocks,
         &registry,
         &quarto_source_map::SourceContext::new(),
+        &mut Vec::new(),
     );
 
     use quarto_core::format::Format;

--- a/crates/quarto-error-catalog/error_catalog.json
+++ b/crates/quarto-error-catalog/error_catalog.json
@@ -1363,5 +1363,19 @@
     "message_template": "A line of the form `[ref]: https://example.com` is a link reference definition, which quarto-markdown does not collect. It renders as a visible paragraph instead of disappearing. Move the URL into an inline link — `[text](url)` — at each use site and delete the definition line. `qmd-syntax-helper convert -r reference-links` does both.",
     "docs_url": "https://quarto.org/docs/errors/markdown/Q-2-46",
     "since_version": "99.9.9"
+  },
+  "Q-2-47": {
+    "subsystem": "markdown",
+    "title": "Cell option ignored on a diagram cell",
+    "message_template": "A diagram cell has no execution engine to pass unrecognized options to, so this option has no effect. Diagram cells accept `label`, `fig-cap`, `fig-scap`, and `fig-alt`.",
+    "docs_url": "https://quarto.org/docs/errors/markdown/Q-2-47",
+    "since_version": "99.9.9"
+  },
+  "Q-2-48": {
+    "subsystem": "markdown",
+    "title": "Wrong cell-option marker for a diagram cell",
+    "message_template": "Cell options are written in the cell language's own comment syntax. A mermaid diagram comments with `%%`, so its options are `%%|` — `#|` is not a mermaid comment and becomes part of the diagram, which mermaid then fails to parse.",
+    "docs_url": "https://quarto.org/docs/errors/markdown/Q-2-48",
+    "since_version": "99.9.9"
   }
 }

--- a/docs/guides/authoring/diagrams.qmd
+++ b/docs/guides/authoring/diagrams.qmd
@@ -100,6 +100,94 @@ Diagrams render on their slides at natural size — including slides that
 are not visible when the deck first loads. [View source](https://github.com/quarto-dev/q2/tree/main/examples/diagrams/02-mermaid-revealjs)
 ::::
 
+## Captions, cross-references, and alt text
+
+A diagram can carry options, written at the top of the block, one per
+line, after a `%%|` marker. The marker is Mermaid's own comment syntax —
+each language uses its own, the way `#|` serves Python and R — so a
+diagram with options is still valid Mermaid.
+
+`fig-cap` gives the diagram a caption:
+
+````markdown
+```mermaid
+%%| fig-cap: The path a change takes from commit to production.
+flowchart LR
+  commit --> build
+  build --> test
+  test --> deploy
+```
+````
+
+Add a `label` beginning with `fig-` and the diagram becomes a numbered
+figure you can cross-reference with `@fig-…`, exactly like any other
+Quarto figure:
+
+````markdown
+```mermaid
+%%| label: fig-review
+%%| fig-cap: The review cycle, which repeats until a draft is approved.
+%%| fig-alt: A draft moves to review; review either publishes it or sends it back to draft.
+flowchart LR
+  Draft --> Review
+  Review --> Published
+  Review --> Draft
+```
+
+@fig-review shows the loop a draft goes through.
+````
+
+`fig-alt` is the description assistive technology reads. Because a
+diagram is drawn as an SVG rather than an image, the description is
+carried into the diagram itself as Mermaid's `accDescr:` directive,
+which becomes the drawing's accessible description. **A diagram that
+conveys information the surrounding text does not should always have a
+`fig-alt`** — the caption names the diagram, the alt text describes it.
+
+@demo-mermaid-captions shows both forms in one document:
+
+:::: {#demo-mermaid-captions .embed-example-iframe file="/examples/diagrams/03-mermaid-captions/document.html"}
+````markdown
+---
+title: "Diagram captions and alt text"
+---
+
+A `fig-cap` gives the diagram a caption:
+
+```mermaid
+%%| fig-cap: The path a change takes from commit to production.
+flowchart LR
+  commit --> build
+  build --> test
+  test --> deploy
+```
+
+Add a `label` beginning with `fig-` and the diagram becomes numbered and
+cross-referenceable. `fig-alt` supplies the description assistive
+technology reads:
+
+```mermaid
+%%| label: fig-review
+%%| fig-cap: The review cycle, which repeats until a draft is approved.
+%%| fig-alt: A draft moves to review; review either publishes it or sends it back to draft.
+flowchart LR
+  Draft --> Review
+  Review --> Published
+  Review --> Draft
+```
+
+@fig-review shows the loop a draft goes through.
+````
+
+An uncaptioned diagram, a captioned one, and a numbered one that body
+text refers to. [View source](https://github.com/quarto-dev/q2/tree/main/examples/diagrams/03-mermaid-captions)
+::::
+
+Diagram blocks accept `label`, `fig-cap`, `fig-scap`, and `fig-alt`. A
+diagram has no execution engine to interpret anything else, so Quarto
+warns about an option it cannot act on rather than passing it silently
+into the drawing.
+
 ## How diagrams render
 
 Quarto draws diagrams in the browser: the rendered page keeps your
@@ -120,12 +208,13 @@ with the diagram source, in place of the drawing.
 ## Differences from Quarto 1
 
 Quarto 1 embeds diagrams through executable cells — ```` ```{mermaid} ````
-with `%%|` cell options — and Quarto 2 does not yet recognize that
-form: only the plain ```` ```mermaid ```` fence renders. The following
-Quarto 1 diagram features are also not yet available:
+— and Quarto 2 does not recognize that form: only the plain
+fence ```` ```mermaid ```` renders. To move a Quarto 1 document over, drop
+the braces; the diagram body and its `%%|` options need no other change.
+
+The following Quarto 1 diagram features are not yet available:
 
 - Graphviz (`{dot}`) diagrams
-- Figure captions, labels, and cross-references on diagrams
 - Sizing options (`fig-width`, `fig-height`, `fig-responsive`)
 - Pre-rendered PNG/SVG output for print formats (`mermaid-format`)
 - Theming (Mermaid currently renders with its default theme regardless

--- a/examples/diagrams/03-mermaid-captions/README.md
+++ b/examples/diagrams/03-mermaid-captions/README.md
@@ -1,0 +1,44 @@
+# 03-mermaid-captions — Captions, cross-references, and alt text on diagrams
+
+A `format: html` document with two Mermaid diagrams carrying `%%|` cell
+options: one captioned, one captioned *and* labelled so it is numbered
+and cross-referenceable.
+
+## What this demonstrates
+
+- **`%%|` cell options.** Diagram options go at the top of the block,
+  one per line. The marker follows the cell language's own comment
+  syntax — `%%` for Mermaid, the way `#|` serves Python and R.
+- **`fig-cap` without a label.** The diagram is wrapped in a `<figure>`
+  with a `<figcaption>` and no number.
+- **`label` + `fig-cap`.** A `fig-`prefixed label makes the diagram a
+  numbered float that `@fig-…` can reference.
+- **`fig-alt`.** The description is carried into the diagram as
+  Mermaid's own `accDescr:` directive, which becomes the drawing's
+  accessible description.
+
+## How to run
+
+From the repository root:
+
+```bash
+cargo run --bin q2 -- render examples/diagrams/03-mermaid-captions
+```
+
+The page is written next to the source as `document.html`.
+
+## What to look for
+
+- The first diagram inside `<div class="quarto-figure quarto-figure-center">`
+  → `<figure>` → `<pre class="mermaid">` → `<figcaption>`, with no
+  "Figure N:" prefix.
+- The second inside `<div id="fig-review" class="quarto-float …">`, whose
+  `<figcaption id="fig-review-caption">` reads "Figure 1: …", and the
+  body text linking to it via `<a href="#fig-review" class="quarto-xref">Figure 1</a>`.
+- `accDescr: A draft moves to review; …` as the second line of the
+  second `<pre class="mermaid">` — after the `flowchart LR` declaration,
+  which is where Mermaid requires it. When the page loads, Mermaid turns
+  that line into a `<desc>` element inside the SVG and points the SVG's
+  `aria-describedby` at it.
+- No `%%|` lines anywhere in the output: the options are consumed, not
+  passed through to the drawing.

--- a/examples/diagrams/03-mermaid-captions/_quarto.yml
+++ b/examples/diagrams/03-mermaid-captions/_quarto.yml
@@ -1,0 +1,2 @@
+project:
+  type: default

--- a/examples/diagrams/03-mermaid-captions/document.qmd
+++ b/examples/diagrams/03-mermaid-captions/document.qmd
@@ -1,0 +1,33 @@
+---
+title: "Diagram captions and alt text"
+---
+
+Diagram options are written at the top of the block, one per line, after
+a `%%|` marker — `%%` is Mermaid's comment syntax, so each language uses
+its own.
+
+A `fig-cap` gives the diagram a caption:
+
+```mermaid
+%%| fig-cap: The path a change takes from commit to production.
+flowchart LR
+  commit --> build
+  build --> test
+  test --> deploy
+```
+
+Add a `label` beginning with `fig-` and the diagram becomes numbered and
+cross-referenceable. `fig-alt` supplies the description assistive
+technology reads:
+
+```mermaid
+%%| label: fig-review
+%%| fig-cap: The review cycle, which repeats until a draft is approved.
+%%| fig-alt: A draft moves to review; review either publishes it or sends it back to draft.
+flowchart LR
+  Draft --> Review
+  Review --> Published
+  Review --> Draft
+```
+
+@fig-review shows the loop a draft goes through.

--- a/examples/manifest.yml
+++ b/examples/manifest.yml
@@ -33,3 +33,4 @@ projects:
   - presentations/11-auto-stretch
   - diagrams/01-mermaid-basic
   - diagrams/02-mermaid-revealjs
+  - diagrams/03-mermaid-captions


### PR DESCRIPTION
Processes mermaid `%%|` cell options, so `fig-cap` / `fig-alt` on a
```` ```mermaid ```` fence reach the output instead of sitting verbatim in the
diagram source (bd-mermaid-cell-options-9wo3crl0).

Plan, design rationale and full verification record:
`claude-notes/plans/2026-08-10-mermaid-cell-options.md`.

## The finding that shaped this

The caption / figure / crossref machinery **already worked** for a mermaid
fence — it just keyed off the `#|` marker. At the previous HEAD, a
```` ```mermaid ```` block with `#| label:` + `#| fig-cap:` rendered a full
`quarto-float` figure with numbering and `aria-describedby`; only the `%%|`
spelling was unrecognized. `cell_options::comment_syntax_for` had no mermaid
entry, because Q1 keeps mermaid's `%%` on the language handler and in
`constants.lua` rather than in `kLangCommentChars`, which is what that table
was ported from.

The architectural constraint: this has to happen in `PreEngineSugaringStage`,
not in `transforms/mermaid.rs`. That transform is on
`Q2_PREVIEW_TRANSFORM_EXCLUDED` (so preview would diverge) *and* runs after
`crossref-render` (so a `label:` could never be numbered). Doing it pre-engine
gives preview/render parity for free.

## What changed, commit by commit

| | |
|---|---|
| `cell_options` learns mermaid's `%%` | with a cross-talk test against matlab/tikz's single `%` |
| shorthand migrated onto `cell_options` | language-aware marker + real YAML parsing, replacing a private `#|`-only `split_once(':')` matcher |
| `fig-cap` parsed as markdown inlines | via the same entry point document metadata uses |
| unlabelled `fig-cap` → `Block::Figure` | `fig-scap` → `Caption::short` |
| `fig-alt` → mermaid's `accDescr:` | and stop consuming options we cannot route |
| Q-2-47 / Q-2-48 diagnostics | source-mapped to the offending key |
| preview-parity test, docs, worked example | |

Three pre-existing defects in the shared `#|` shorthand are fixed along the
way — all reproduced on a plain ```` ```python ```` cell first, so they were
never mermaid-specific:

- **bd-5jcmmj1f** — `fig-cap: "A caption."` rendered as `Figure 1: "A caption."`
  with literal quote characters.
- **bd-sdpp9rw4** — `fig-cap: A *strong* claim` rendered the asterisks
  literally.
- **bd-il6pxq4f** — `fig-alt` and `fig-scap` were consumed (stripped from the
  body) but never read back out; the text vanished with no warning. Authors who
  wrote `fig-alt` believed they had an accessible description and did not.

## Behavior changes worth reviewing

**`#|` in a mermaid fence is no longer a cell-option marker.** Deliberate
(Q1 parity; q2 is in `0.*` and accepting both would teach that `#|` is
universal), but it is a *visible* break: `#` is not a mermaid comment, so
leftover lines become diagram source and mermaid fails on them. Q-2-48 reports
this at the exact source line rather than leaving a silently broken diagram.

**A diagram cell warns about options it cannot act on** (Q-2-47), scoped to
diagram cells only. On an executable cell an unrecognized key is normally an
engine option (`echo`, `eval`, …), so warning there would fire on essentially
every real document. Q1 accepts `theme` and `mermaid-format` on mermaid cells
and q2 does not yet, so those warn today — `DIAGRAM_OPTION_KEYS` carries a note
to add `theme` when the mermaid theming strands land.

**`fig-alt` on a non-diagram cell is now left in the body** for the engine
instead of being consumed. Strictly better than the previous silent drop, and
for jupyter/knitr `fig-alt` is a real engine option.

## Verification

`cargo xtask verify` (full, including the hub/WASM leg) passes on the rebased
base. **No snapshot files changed** anywhere in the workspace.

End-to-end through the binary, output inspected — e.g. a `%%| fig-cap` +
`%%| fig-alt` diagram with no label now emits:

```html
<div class="quarto-figure quarto-figure-center">
<figure>
<pre class="mermaid">
flowchart LR
  accDescr: Two nodes connected by an arrow.
  E --&gt; F
</pre>
<figcaption>
A tiny flowchart.
</figcaption>
</figure>
</div>
```

**The accessibility claim was verified against real mermaid 11.12.0** (the
pinned version) under jsdom, because both browser routes were unavailable in
the session: the injected line becomes `<desc>` inside the SVG with the SVG's
`aria-describedby` pointing at it, and a negative control confirms mermaid
*rejects* `accDescr:` placed before the diagram-type line — which is why the
directive is inserted after the first declaration line rather than at the top.

Not verified: presentation in an actual screen reader, and the `q2 preview` UI
in a live browser session.

## Note for reviewers

`main` claimed Q-2-42 … Q-2-46 while this branch was in flight (#497), so the
two codes here were renumbered to **Q-2-47 / Q-2-48** during the rebase. The
Phase 6 commit *message* still names the pre-rebase numbers; code, catalog,
tests and plan all use the final ones.

## Follow-ups filed

- **bd-vg8p5yoj** — `qmd-syntax-helper` rule rewriting ```` ```{mermaid} ````
  → ```` ```mermaid ````. This is the other half of the Connect-docs story:
  all 33 diagrams there are brace-form and still render as source text until
  it lands. Cell options need no rewrite — Q1 documents already write `%%|`.
- **bd-e3m3rkik** — pre-existing, surfaced while reading the preview AST:
  because `mermaid-render` is excluded from preview, `CodeBlockRenderTransform`
  wraps mermaid blocks in copy-button chrome there that `q2 render` suppresses
  by transform ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
