### PR TITLE
Release v0.17.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "comrak-to-pandoc"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "comrak",
  "hashlink",
@@ -3536,7 +3536,7 @@ dependencies = [
 
 [[package]]
 name = "quarto"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3582,7 +3582,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-analysis"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "insta",
  "quarto-error-reporting",
@@ -3608,7 +3608,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-brand"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "pathdiff",
  "quarto-util",
@@ -3620,7 +3620,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-citeproc"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "glob",
  "hashlink",
@@ -3654,7 +3654,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-core"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3710,7 +3710,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-csl"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "insta",
  "quarto-error-reporting",
@@ -3738,7 +3738,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-error-catalog"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "once_cell",
  "quarto-error-reporting",
@@ -3774,7 +3774,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-highlight"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "hashlink",
  "insta",
@@ -3803,7 +3803,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-highlight-encoding"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3811,7 +3811,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-hub"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "automerge",
@@ -3855,7 +3855,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-hub-provider"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "automerge",
  "ciborium",
@@ -3881,7 +3881,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-lsp"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "insta",
@@ -3897,7 +3897,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-lsp-core"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "insta",
  "pampa",
@@ -3920,7 +3920,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-mcp-launcher"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -3936,7 +3936,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-navigation"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "quarto-config",
  "quarto-pandoc-types",
@@ -3971,7 +3971,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-preview"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "automerge",
@@ -4003,7 +4003,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-project-create"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "quarto-doctemplate",
  "serde",
@@ -4014,7 +4014,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-publish"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4039,7 +4039,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-sass"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "grass",
  "include_dir",
@@ -4062,7 +4062,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-source-fetch"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "flate2",
  "tar",
@@ -4085,7 +4085,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-system-runtime"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4103,7 +4103,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-test"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "quarto-core",
@@ -4120,7 +4120,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-trace"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "flate2",
  "serde",
@@ -4131,7 +4131,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-trace-server"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4158,7 +4158,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-util"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -4166,7 +4166,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-xml"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "insta",
  "quarto-error-reporting",
@@ -4386,7 +4386,7 @@ dependencies = [
 
 [[package]]
 name = "reconcile-viewer"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "clap",
  "hashlink",
@@ -6425,7 +6425,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-printf-fmt"
-version = "0.16.0"
+version = "0.17.0"
 
 [[package]]
 name = "wasmparser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.16.0"
+version = "0.17.0"
 authors = ["Posit Software, PBC"]
 homepage = "https://github.com/posit-dev/quarto-markdown-syntax"
 keywords = ["parser"]


### PR DESCRIPTION
Bumps `[workspace.package].version` to 0.17.0 so the `v0.17.0` tag matches
the manifest (the release workflow's preflight job enforces exact equality).

`Cargo.lock` churn is workspace-members-only (`cargo update --workspace`);
no external dependency moved. `cargo build --bin q2 --locked` succeeds and
`q2 --version` prints `q2 (quarto 2) 0.17.0`.

## What ships since v0.16.0

- `{{< include >}}` expansion inside fenced code blocks (#498)
- mermaid `%%|` cell options: fig-cap as markdown inlines, fig-scap short
  captions, fig-alt routed into mermaid's accDescr, source-mapped
  diagnostics Q-2-47/Q-2-48 (#499)
- Callout `title=` attribute honored, with the callout type kept for
  screen readers (#496)
- CommonMark email autolinks `<user@example.com>` (#495)
- Render-time warning for reference-style link syntax, Q-2-45/Q-2-46 (#497)

## CI notes

Main's push CI is green. The one red on main's HEAD run
(macos-latest, run 31441577535) was a flake — it re-ran green. Root cause
filed as bd-1w8e7c1e: `list_doc_ids_filesystem` reconstructs an automerge
doc id from directory names, which mis-cases ids on case-insensitive
filesystems when two ids collide case-insensitively in their first two
characters.

The nightly smoke-all E2E is red, as it has been every night through the
last five releases. Its one *new* failure
(`quarto-test/callout-title-attribute.qmd`) was investigated and is a test
harness defect, not a product defect — see bd-nhn7snpg. Under
`source-location: full` the writer puts `data-sid` on the
`screen-reader-only` span itself, so the harness's wrapper-span unwrapper
correctly leaves it in place and the fixture's literal regex misses.
`q2 render` and `q2 preview` both emit correct callout titles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)