### PR TITLE
Recover doc ids from case-folded splay dirs (bd-eb2wnxkp Part A + collect guard)

### DIFF
--- a/claude-notes/plans/2026-08-10-flaky-admin-collect-lifecycle.md
+++ b/claude-notes/plans/2026-08-10-flaky-admin-collect-lifecycle.md
@@ -189,6 +189,26 @@ Unchanged from bd-eb2wnxkp's plan: `list_doc_ids_filesystem`
     id; with a `zz/not-a-doc-id` pair added, the binary refused
     ("does not correspond to any valid document id … refusing to guess") and
     exited 1. Output inspected in both runs.
+- [x] Phase 1b — **Belt-and-braces collect guard** (user answered eb2wnxkp
+  open question 4 "yes, defense in depth" on 2026-08-11):
+  `locate_all_doc_dirs` + `locate_verified` in
+  `crates/quarto-hub/src/admin/collect.rs` map every recoverable id to the
+  on-disk director(ies) whose *actual names* round-trip to it via
+  `recover_doc_id`. A candidate that does not round-trip to exactly one real
+  directory is skipped (with reason) regardless of its liveness verdict, and
+  the quarantine rename source comes from this map — never from `doc_dir`
+  construction + filesystem case-folding. `doc_dir` remains only for
+  constructing restore destinations, documented as such. Tests: 3 unit tests
+  (folded dir located by actual name; absent id refused; duplicate-dir
+  ambiguity refused on case-sensitive filesystems, resolved where the
+  filesystem folds) + 1 integration test (folded orphan still correctly
+  quarantined under its true id). Note: the guard's refusal path is
+  unreachable through the CLI on a healthy store *by design* (every other
+  layer already defends); it is exercised at unit level and through
+  `collect()` itself, the same function the CLI dispatches to.
+- [x] Phase 1c — User answered eb2wnxkp open question 2 (2026-08-11): fix
+  stays in quarto-hub (done); upstream proposal filed as **bd-3uw7uufa**
+  (related: bd-eb2wnxkp).
 - [ ] Phase 2 — Future dedicated verification (bd-u0tldu4z stays open for
   this, per user): 150+-iteration stress loop over the
   `admin_collect_lifecycle` + `admin_scan_real_store` families

--- a/claude-notes/plans/2026-08-10-flaky-admin-collect-lifecycle.md
+++ b/claude-notes/plans/2026-08-10-flaky-admin-collect-lifecycle.md
@@ -3,7 +3,10 @@
 **Date:** 2026-08-10
 **Braid:** bd-u0tldu4z (bug, p3 as filed — but see verdict)
 **Branch:** `main` (main checkout; no worktree — investigation only, per `/investigate-beads`)
-**Status:** Investigation — pending design alignment with user. **Do not start implementation until the user gives the go-ahead.**
+**Status:** Part A implemented on `main` (user go-ahead 2026-08-10: "do Part A of
+bd-eb2wnxkp here"). bd-u0tldu4z stays open for a future dedicated stress
+verification; moved-store scenario confirmed out of scope; Parts B/C of the
+eb2wnxkp plan remain open questions on that strand.
 
 ## Triage verdict
 
@@ -152,19 +155,46 @@ Unchanged from bd-eb2wnxkp's plan: `list_doc_ids_filesystem`
 
 ## Proposed phases (draft)
 
-The implementation lives in bd-eb2wnxkp's plan (Phases 1-9 there). For
-**this** strand:
-
-- Phase 0 — Link `caused-by` bd-eb2wnxkp; correct the strand description's
-  load hypothesis (comment with captured evidence). *(Done this session.)*
-- Phase 1 — Fold this session's ★ corner cases into the eb2wnxkp plan's test
-  phase (the `st/` collision test; the moved-store note in out-of-scope), plus
-  one test-hygiene item: `collect_reverification_skips_rereferenced_candidate`
-  should assert `candidates.len()` before indexing `candidates[0]`.
-- Phase 2 — After the eb2wnxkp fix lands: 150+-iteration stress loop over the
+- [x] Phase 0 — Link `caused-by` bd-eb2wnxkp; correct the strand description's
+  load hypothesis (comment with captured evidence).
+- [x] Phase 1 — **Part A implemented** (user-scoped: Part A only, on `main`):
+  - `recover_doc_id(prefix, rest)` in `crates/quarto-hub/src/admin/scan.rs`:
+    tests the ≤4 case variants of the 2-char splay prefix against
+    `DocumentId::from_str` (bs58check), dedups by parsed id preferring the
+    as-read casing (legacy-UUID hex parses case-insensitively — several
+    casings, one id — and must not read as Ambiguous; returning the as-read
+    *string* also keeps hypothetical UUID-form stores byte-compatible, leaving
+    instance B untangled for Part B). Zero matches → `Unidentifiable`,
+    multiple distinct ids → `Ambiguous`; both hard-fail.
+  - `list_doc_ids_filesystem` is now fallible; `hub admin scan` (main.rs) and
+    `collect()` abort on error ("refusing to collect: …"); recovery that
+    changes casing emits `tracing::warn!`.
+  - Over-broad module-doc safety claim narrowed (re-verification covers
+    staleness, not systematic mis-identification).
+  - Tests (TDD, red confirmed before implementation): 5 unit tests with
+    checksum-verified fixtures (incl. the ★ `st/` collision id
+    `StntkRJtG7hVPkKPY4Qkeu6f5bZ` and digit-prefix `26tzBsg…`); 2
+    deterministic hand-built-splay integration tests (platform-independent);
+    1 end-to-end collect test (live doc with case-renamed splay dir is not
+    quarantined; runtime case-insensitivity probe, skips honestly on
+    case-sensitive filesystems). New file
+    `tests/integration/admin_doc_id_recovery.rs`.
+  - Test hygiene: `collect_reverification_skips_rereferenced_candidate` now
+    asserts `candidates.len()` before indexing.
+  - E2E through the real binary (per end-to-end verification policy):
+    `cargo run --bin hub -- admin scan --data-dir <hand-built store> --json`
+    on a store with a folded `2C/` dir emitted
+    `WARN … on_disk=2C/PADPZ85aBLaaLaLrS2BNcVza1n
+    recovered=2cPADPZ85aBLaaLaLrS2BNcVza1n` and the manifest carried the true
+    id; with a `zz/not-a-doc-id` pair added, the binary refused
+    ("does not correspond to any valid document id … refusing to guess") and
+    exited 1. Output inspected in both runs.
+- [ ] Phase 2 — Future dedicated verification (bd-u0tldu4z stays open for
+  this, per user): 150+-iteration stress loop over the
   `admin_collect_lifecycle` + `admin_scan_real_store` families
   (`stress.sh` in the investigation dir); close bd-u0tldu4z on a clean loop,
-  citing the count.
+  citing the count. (A first post-fix loop was run this session — see strand
+  comment — but the dedicated verification pass remains open.)
 
 ## Open design questions for the user
 

--- a/claude-notes/plans/2026-08-10-flaky-admin-collect-lifecycle.md
+++ b/claude-notes/plans/2026-08-10-flaky-admin-collect-lifecycle.md
@@ -1,0 +1,190 @@
+# Flaky test: admin_collect_lifecycle fails intermittently in full-workspace runs (bd-u0tldu4z)
+
+**Date:** 2026-08-10
+**Braid:** bd-u0tldu4z (bug, p3 as filed — but see verdict)
+**Branch:** `main` (main checkout; no worktree — investigation only, per `/investigate-beads`)
+**Status:** Investigation — pending design alignment with user. **Do not start implementation until the user gives the go-ahead.**
+
+## Triage verdict
+
+**Root cause identified — bd-u0tldu4z is a duplicate manifestation of
+bd-eb2wnxkp** (doc-id case-folding on case-insensitive filesystems), not a
+timing/parallel-load race as the strand description hypothesized. The fix is
+bd-eb2wnxkp's already-written plan
+(`claude-notes/plans/2026-07-28-doc-id-identity-from-paths.md`, on branch
+`braid/bd-eb2wnxkp-listdocidsfilesystem-reconstructs-doc-ids`), whose Part A is
+exactly the migration-free case-variant recovery the user proposed this
+session (evaluated below). Recommendation: link `caused-by`, keep bd-u0tldu4z
+open only as the "confirm the test is stable under a stress loop after the fix"
+tracking item, and green-light bd-eb2wnxkp's plan.
+
+## The evidence (new this session)
+
+The strand asked for the one thing nobody had: captured failure output (both
+prior sightings were fail-fast full-workspace runs). A 150-iteration stress
+loop of the two `admin_collect_lifecycle` tests on `main` @ `59bbccb9`
+(macOS/APFS) produced **3 failures in 142 iterations (~2%/iteration)**, all
+with the same signature — ids identical in 27 of 28 characters, differing
+**only in the case of character index 1**:
+
+| # | iter | test / line | left (path-derived) | right (true id) |
+|---|------|-------------|--------------------|-----------------|
+| 1 | 21  | `collect_lifecycle_quarantine_restore_purge` :117 | `2CPAD…` | `2cPAD…` |
+| 2 | 35  | `collect_lifecycle_quarantine_restore_purge` :117 | `2VuTE…` | `2vuTE…` |
+| 3 | 142 | `collect_reverification_skips_rereferenced_candidate` :205 | `2RS54…` | `2rS54…` |
+
+Logs + loop script: `flaky-admin-collect-lifecycle-investigation/`.
+
+This kills the "timing/state sensitivity under parallel load" hypothesis in
+the strand description: the loop ran the tests **in isolation** (3 tests per
+iteration, no workspace load) and still failed at the background rate. The
+failure is a function of the random doc-id draw, not of load. It *looks*
+load-correlated only because a full-workspace run is one more draw from a ~2-3%
+Bernoulli, and full runs are when people watch.
+
+Failure #3 is at `admin_collect_lifecycle.rs:205` — the same line as the
+2026-08-09 GitHub Actions macOS flake recorded on bd-eb2wnxkp (c-tjflqt1c).
+That CI occurrence showed two *entirely different* ids rather than a case
+flip; that variant is also explained by the same root cause: that test asserts
+`manifest.candidates[0].doc_id == orphan_id` **without first asserting
+`candidates.len() == 1`**. When the *live* doc (rather than the orphan) is the
+one whose path-derived id is mis-cased, it fails the live-set membership check
+and wrongly joins the candidate list; `candidates[0]` is then the mis-cased
+live id — a completely different string from `orphan_id`. One mechanism, two
+victims, two signatures.
+
+Note also: all five observed collisions across both strands have a leading
+character in `{2,3}` — the bs58check leading character of a fixed-width
+payload is heavily skewed, which is why the collision rate (~2-3% per store)
+is far above the naive uniform-alphabet estimate (~0.1%/pair). The rate is
+real; the tests will keep flaking until the recovery lands.
+
+## Evaluation of the proposed workaround (this session's question)
+
+> Could we search for the prefix (and files) case-insensitively — try `AbC`,
+> then `abc`, `aBc`, … — so existing deployments keep their filesystem layout?
+
+**Yes — and this is already the chosen design in bd-eb2wnxkp's plan (Part A,
+`recover_doc_id`), with one crucial refinement: the case-variant search must be
+validated by the bs58check checksum, not by mere case-insensitive matching.**
+Details and corrections:
+
+1. **The splay prefix is 2 characters, not 3** (samod `key_to_path`:
+   `component.chars().take(2)`), so there are **at most 4** case variants
+   (fewer when a prefix char is a digit, which has no case). Cheap.
+
+2. **Direction matters.** *Lookup* by a known id (`load_range([id])`,
+   `doc_dir(id)`) needs no search on macOS/Windows — the case-insensitive
+   filesystem resolves any casing to the folded directory automatically. The
+   broken direction is **enumeration**: `list_doc_ids_filesystem` reads
+   *directory names* and reconstructs ids, and a folded level-1 dir yields the
+   first-creator's casing for every id under it. So the case-variant search is
+   applied at reconstruction time: generate the ≤4 case variants of the 2-char
+   prefix, and let `DocumentId::from_str` (base58**check**, 4-byte checksum)
+   pick the true one — exactly one variant parses, at ~2⁻³² false-accept odds.
+
+3. **Why the checksum is essential:** two genuinely distinct valid ids can
+   differ only in case. Naive case-insensitive matching would conflate them —
+   trading the false-orphan bug for a wrong-document bug. bd-eb2wnxkp's plan
+   already rejected unvalidated case-insensitive comparison for this reason;
+   checksum validation is what makes the search sound.
+
+4. **The user's core motivation is fully preserved:** zero on-disk changes, no
+   migration for existing deployments (which the plan also demands — layout is
+   samod's, shared with the JS implementation).
+
+Corner cases inventoried (most already in the eb2wnxkp plan; the starred ones
+are new from this session and should be folded in):
+
+- **Level-2 dirs keep true casing** — created fresh under the (possibly
+  folded) level-1 dir; APFS/NTFS are case-preserving. Only the 2-char prefix
+  needs variants. A level-2 fold requires two docs whose 26-char rests also
+  case-fold (~negligible for random ids); the `Ambiguous`/`Unidentifiable`
+  hard-fail arms catch it if it ever happens.
+- **Variants outside the base58 alphabet** (`0 O I l` excluded): fail to
+  parse; natural rejection, no special case.
+- **Digit-only prefixes:** no case variants; the as-read id must parse or is
+  `Unidentifiable`.
+- ★ **The `st/orage-adapter-id` entry:** every store has an `st/` level-1 dir
+  (adapter identity, a *file* at level 2, skipped via `is_dir`). A doc id
+  starting `St`/`ST`/`sT` folds **into** that pre-existing `st/` dir on
+  macOS/Windows, so its id reads back as `st…`. `recover_doc_id` handles it,
+  but this deserves an explicit test — it is the one collision every store is
+  guaranteed to be primed for.
+- ★ **Store copied case-insensitive → case-sensitive FS** (dev macOS →
+  Linux prod restore): a folded dir survives the copy, and on Linux the
+  exact-case `load_range`/`doc_dir` lookup **misses** it — the doc loads
+  empty and becomes invisible (skipped, neither live nor candidate). This is
+  the one place the *lookup*-direction case-variant search would matter.
+  Recommend: out of scope for the fix (the mandatory recovery `warn!` already
+  tells the operator the store has folded dirs); note it in the plan's
+  out-of-scope list.
+- **Unicode/NFD normalization:** N/A — base58 is ASCII.
+- **Case-sensitive platforms run the same code** — the as-read id parses as
+  its own single variant; no platform gating, deterministic tests everywhere.
+
+## Issue context
+
+Filed 2026-08-09 (discovered during bd-nv4p0eb1 verification), p3 bug.
+Two comments record recurrences on 2026-08-10 (a different test in the same
+family, and the original test again), both fail-fast, no captured output.
+Description's hypothesis: "likely timing/state sensitivity … under parallel
+load" — now disproven (see evidence).
+
+## Dependency graph
+
+- **discovered-from:** bd-nv4p0eb1 (closed — the add-file-with-id lint audit).
+  Purely incidental: the flake surfaced during that strand's full-workspace
+  verification; no semantic connection.
+- **No other edges** — but a strong latent edge exists: bd-eb2wnxkp
+  (in_progress, p1) describes the same mechanism, measured the same rate, and
+  its comment c-tjflqt1c already logged one of this family's CI failures.
+  **Action item: add `caused-by` bd-eb2wnxkp.**
+
+## What the code looks like today
+
+Unchanged from bd-eb2wnxkp's plan: `list_doc_ids_filesystem`
+(`crates/quarto-hub/src/admin/scan.rs:80`) still does
+`format!("{prefix}{rest}")` over raw dir names; `normalize_id`
+(`classify.rs:162`) is still a string strip; ids flow as `String` through
+`LoadedDoc`/`live_doc_ids`/`collect`. Reproduced at HEAD (`59bbccb9`) at
+~2%/iteration. Pre-flight `cargo xtask verify --skip-hub-build` green.
+
+## Proposed phases (draft)
+
+The implementation lives in bd-eb2wnxkp's plan (Phases 1-9 there). For
+**this** strand:
+
+- Phase 0 — Link `caused-by` bd-eb2wnxkp; correct the strand description's
+  load hypothesis (comment with captured evidence). *(Done this session.)*
+- Phase 1 — Fold this session's ★ corner cases into the eb2wnxkp plan's test
+  phase (the `st/` collision test; the moved-store note in out-of-scope), plus
+  one test-hygiene item: `collect_reverification_skips_rereferenced_candidate`
+  should assert `candidates.len()` before indexing `candidates[0]`.
+- Phase 2 — After the eb2wnxkp fix lands: 150+-iteration stress loop over the
+  `admin_collect_lifecycle` + `admin_scan_real_store` families
+  (`stress.sh` in the investigation dir); close bd-u0tldu4z on a clean loop,
+  citing the count.
+
+## Open design questions for the user
+
+1. **Strand disposition.** Close bd-u0tldu4z now as duplicate-in-effect of
+   bd-eb2wnxkp (its fix covers this), or keep it open as the post-fix
+   stress-verification tracking item (my lean — it is the only artifact that
+   remembers the *test-side* verification obligation)?
+2. **Go-ahead for bd-eb2wnxkp's plan?** It has been awaiting review since
+   2026-07-28 with 5 open questions of its own; the flake family has now been
+   sighted 5 times. This session's finding is that its Part A is exactly the
+   migration-free workaround you proposed. Do you want to answer its open
+   questions and start implementation (in its existing branch/worktree)?
+3. **Moved-store scenario.** Confirm the ★ case (folded store copied to a
+   case-sensitive filesystem) stays out of scope — the alternative is adding
+   case-variant search to the lookup direction too, which widens the change
+   for a scenario we have never observed.
+
+## Risks / tradeoffs (draft)
+
+- Closing this strand without the stress-loop phase would repeat the original
+  trap: at a 2-3% rate, a single green run means nothing.
+- The eb2wnxkp branch is 13 days old (based on `main` @ `270d58b5`); expect a
+  rebase before implementation.

--- a/claude-notes/plans/flaky-admin-collect-lifecycle-investigation/failure-1-iter-21.log
+++ b/claude-notes/plans/flaky-admin-collect-lifecycle-investigation/failure-1-iter-21.log
@@ -1,0 +1,14 @@
+  stderr ───
+
+    thread 'admin_collect_lifecycle::collect_lifecycle_quarantine_restore_purge' (23616380) panicked at crates/quarto-hub/tests/integration/admin_collect_lifecycle.rs:117:5:
+    assertion `left == right` failed
+      left: "2CPADPZ85aBLaaLaLrS2BNcVza1n"
+     right: "2cPADPZ85aBLaaLaLrS2BNcVza1n"
+    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+
+        PASS [   0.021s] (2/3) quarto-hub::integration admin_collect_lifecycle::collect_refuses_wrong_data_dir_and_held_lock
+        PASS [   0.023s] (3/3) quarto-hub::integration admin_collect_lifecycle::collect_reverification_skips_rereferenced_candidate
+────────────
+     Summary [   0.024s] 3 tests run: 2 passed, 1 failed, 451 skipped
+        FAIL [   0.021s] (1/3) quarto-hub::integration admin_collect_lifecycle::collect_lifecycle_quarantine_restore_purge
+error: test run failed

--- a/claude-notes/plans/flaky-admin-collect-lifecycle-investigation/failure-2-iter-35.log
+++ b/claude-notes/plans/flaky-admin-collect-lifecycle-investigation/failure-2-iter-35.log
@@ -1,0 +1,14 @@
+  stderr ───
+
+    thread 'admin_collect_lifecycle::collect_lifecycle_quarantine_restore_purge' (23621105) panicked at crates/quarto-hub/tests/integration/admin_collect_lifecycle.rs:117:5:
+    assertion `left == right` failed
+      left: "2VuTEjDn18HXaFd3u95EKH7gomnh"
+     right: "2vuTEjDn18HXaFd3u95EKH7gomnh"
+    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+
+        PASS [   0.027s] (2/3) quarto-hub::integration admin_collect_lifecycle::collect_refuses_wrong_data_dir_and_held_lock
+        PASS [   0.032s] (3/3) quarto-hub::integration admin_collect_lifecycle::collect_reverification_skips_rereferenced_candidate
+────────────
+     Summary [   0.033s] 3 tests run: 2 passed, 1 failed, 451 skipped
+        FAIL [   0.025s] (1/3) quarto-hub::integration admin_collect_lifecycle::collect_lifecycle_quarantine_restore_purge
+error: test run failed

--- a/claude-notes/plans/flaky-admin-collect-lifecycle-investigation/failure-3-iter-142.log
+++ b/claude-notes/plans/flaky-admin-collect-lifecycle-investigation/failure-3-iter-142.log
@@ -1,0 +1,14 @@
+  stderr ───
+
+    thread 'admin_collect_lifecycle::collect_reverification_skips_rereferenced_candidate' (23714830) panicked at crates/quarto-hub/tests/integration/admin_collect_lifecycle.rs:205:5:
+    assertion `left == right` failed
+      left: "2RS54Qe1QkGa9DeqiN658FjzSmNG"
+     right: "2rS54Qe1QkGa9DeqiN658FjzSmNG"
+    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+
+        PASS [   0.018s] (2/3) quarto-hub::integration admin_collect_lifecycle::collect_refuses_wrong_data_dir_and_held_lock
+        PASS [   0.026s] (3/3) quarto-hub::integration admin_collect_lifecycle::collect_lifecycle_quarantine_restore_purge
+────────────
+     Summary [   0.026s] 3 tests run: 2 passed, 1 failed, 451 skipped
+        FAIL [   0.017s] (1/3) quarto-hub::integration admin_collect_lifecycle::collect_reverification_skips_rereferenced_candidate
+error: test run failed

--- a/claude-notes/plans/flaky-admin-collect-lifecycle-investigation/stress.sh
+++ b/claude-notes/plans/flaky-admin-collect-lifecycle-investigation/stress.sh
@@ -1,0 +1,17 @@
+#!/bin/zsh
+# Stress loop for bd-u0tldu4z: capture failure output of the
+# admin_collect_lifecycle tests (flaky ~3%/run per bd-eb2wnxkp measurement).
+cd /Users/cscheid/rooms/room-1/q2 || exit 1
+OUTDIR=/private/tmp/claude-501/-Users-cscheid-rooms-room-1-q2/32600a45-9169-48c8-a48a-c5d18af39218/scratchpad/stress-out
+mkdir -p "$OUTDIR"
+FAILS=0
+for i in $(seq 1 150); do
+  LOG="$OUTDIR/run.log"
+  if ! cargo nextest run -p quarto-hub -E 'test(admin_collect_lifecycle)' --no-fail-fast > "$LOG" 2>&1; then
+    FAILS=$((FAILS+1))
+    cp "$LOG" "$OUTDIR/failure-$FAILS-iter-$i.log"
+    echo "FAILURE $FAILS at iteration $i"
+    [ "$FAILS" -ge 3 ] && break
+  fi
+done
+echo "done: $FAILS failures in $i iterations"

--- a/crates/quarto-hub/src/admin/collect.rs
+++ b/crates/quarto-hub/src/admin/collect.rs
@@ -27,7 +27,9 @@ use sha2::{Digest as _, Sha256};
 
 use super::classify::DocKind;
 use super::manifest::{CandidateDoc, MANIFEST_VERSION, ScanManifest};
-use super::scan::{ScanOptions, list_doc_ids_filesystem, live_doc_ids, load_all_docs};
+use super::scan::{
+    ScanOptions, list_doc_ids_filesystem, live_doc_ids, load_all_docs, recover_doc_id,
+};
 use crate::resource::read_capture_meta;
 
 /// Version of the `batch.json` schema written into quarantine batches.
@@ -116,10 +118,74 @@ impl AdminLock {
 
 /// The splayed on-disk directory of a doc's chunks:
 /// `<automerge>/<first-2-chars>/<rest>` (samod's `key_to_path`).
+///
+/// Only used to *construct* destinations (restore). Anything that
+/// removes or moves data must locate its source through
+/// [`locate_all_doc_dirs`] instead: constructing a path from an id
+/// and letting a case-insensitive filesystem resolve it is the lossy
+/// channel that mis-identified documents in the first place
+/// (bd-eb2wnxkp).
 fn doc_dir(automerge_dir: &Path, doc_id: &str) -> PathBuf {
     let first_two: String = doc_id.chars().take(2).collect();
     let rest: String = doc_id.chars().skip(2).collect();
     automerge_dir.join(first_two).join(rest)
+}
+
+/// Belt-and-braces guard (bd-eb2wnxkp): map every recoverable doc id
+/// in the store to the on-disk director(ies) whose *actual names*
+/// round-trip to it via [`recover_doc_id`]. The quarantine path only
+/// trusts this map — an id that does not round-trip to exactly one
+/// real directory is refused regardless of its liveness verdict.
+/// Pairs that fail recovery are skipped here (enumeration has already
+/// hard-failed the collection on those before this runs).
+fn locate_all_doc_dirs(
+    automerge_dir: &Path,
+) -> Result<std::collections::HashMap<String, Vec<PathBuf>>, String> {
+    let mut map: std::collections::HashMap<String, Vec<PathBuf>> = std::collections::HashMap::new();
+    let level1 = std::fs::read_dir(automerge_dir)
+        .map_err(|e| format!("cannot read {}: {e}", automerge_dir.display()))?;
+    for l1 in level1.flatten() {
+        if !l1.path().is_dir() {
+            continue;
+        }
+        let Some(prefix) = l1.file_name().to_str().map(str::to_string) else {
+            continue;
+        };
+        let Ok(level2) = std::fs::read_dir(l1.path()) else {
+            continue;
+        };
+        for l2 in level2.flatten() {
+            if !l2.path().is_dir() {
+                continue;
+            }
+            let name = l2.file_name();
+            let Some(rest) = name.to_str() else {
+                continue;
+            };
+            if let Ok(id) = recover_doc_id(&prefix, rest) {
+                map.entry(id).or_default().push(l2.path());
+            }
+        }
+    }
+    Ok(map)
+}
+
+/// Resolve `doc_id` through the round-trip map: exactly one on-disk
+/// directory, or a refusal reason.
+fn locate_verified(
+    doc_dirs: &std::collections::HashMap<String, Vec<PathBuf>>,
+    doc_id: &str,
+) -> Result<PathBuf, String> {
+    match doc_dirs.get(doc_id).map(Vec::as_slice) {
+        Some([one]) => Ok(one.clone()),
+        None | Some([]) => Err(
+            "id does not round-trip to any storage directory; refusing to quarantine".to_string(),
+        ),
+        Some(many) => Err(format!(
+            "id round-trips to {} distinct storage directories; refusing to quarantine",
+            many.len()
+        )),
+    }
 }
 
 /// Re-verify + quarantine. Dry-run unless `execute`.
@@ -171,10 +237,16 @@ pub async fn collect(
     };
     let now = chrono::Utc::now();
 
+    // Defense in depth: every candidate must also round-trip to
+    // exactly one real directory (checked again at rename time).
+    let doc_dirs =
+        locate_all_doc_dirs(&automerge_dir).map_err(|e| format!("refusing to collect: {e}"))?;
+
     let mut verified = Vec::new();
     let mut skipped = Vec::new();
     for candidate in &manifest.candidates {
-        let reason = verify_candidate(candidate, &docs, &live, &opts, now);
+        let reason = verify_candidate(candidate, &docs, &live, &opts, now)
+            .and_then(|()| locate_verified(&doc_dirs, &candidate.doc_id).map(|_| ()));
         match reason {
             Ok(()) => verified.push(candidate.clone()),
             Err(why) => skipped.push((candidate.doc_id.clone(), why)),
@@ -202,7 +274,12 @@ pub async fn collect(
 
     let mut batch_docs = Vec::new();
     for candidate in &verified {
-        let src = doc_dir(&automerge_dir, &candidate.doc_id);
+        // The rename source comes from the round-trip map — the real
+        // on-disk directory names — never from doc_dir construction,
+        // which a case-insensitive filesystem would resolve even for a
+        // mis-identified id (bd-eb2wnxkp).
+        let src = locate_verified(&doc_dirs, &candidate.doc_id)
+            .map_err(|why| format!("{}: {why}", candidate.doc_id))?;
         let chunks =
             hash_dir_files(&src).map_err(|e| format!("hashing {} failed: {e}", src.display()))?;
         let dst = batch_docs_dir.join(&candidate.doc_id);
@@ -467,4 +544,68 @@ fn hash_dir_files(dir: &Path) -> std::io::Result<Vec<BatchChunk>> {
     walk(dir, dir, &mut out)?;
     out.sort_by(|a, b| a.rel_path.cmp(&b.rel_path));
     Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Checksum-verified real id (see scan.rs tests): the case-flip
+    /// `2CPAD…` fails to parse, so recovery is unambiguous.
+    const TRUE_ID: &str = "2cPADPZ85aBLaaLaLrS2BNcVza1n";
+
+    fn add_doc_dir(automerge_dir: &Path, l1: &str, l2: &str) {
+        let dir = automerge_dir.join(l1).join(l2);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("snapshot"), b"x").unwrap();
+    }
+
+    #[test]
+    fn locate_resolves_folded_dir_by_actual_name() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let automerge_dir = temp.path().join("automerge");
+        // On-disk casing is folded ("2C"); the id's true prefix is "2c".
+        add_doc_dir(&automerge_dir, "2C", &TRUE_ID[2..]);
+        let map = locate_all_doc_dirs(&automerge_dir).unwrap();
+        let path = locate_verified(&map, TRUE_ID).unwrap();
+        // The located path carries the REAL directory name, not a
+        // constructed one — this is what makes the rename sound even
+        // on case-sensitive filesystems holding a folded store.
+        assert!(path.ends_with(Path::new("2C").join(&TRUE_ID[2..])));
+    }
+
+    #[test]
+    fn locate_refuses_id_absent_from_storage() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let automerge_dir = temp.path().join("automerge");
+        std::fs::create_dir_all(&automerge_dir).unwrap();
+        let map = locate_all_doc_dirs(&automerge_dir).unwrap();
+        let err = locate_verified(&map, TRUE_ID).unwrap_err();
+        assert!(err.contains("does not round-trip"), "got: {err}");
+    }
+
+    #[test]
+    fn locate_refuses_ambiguous_duplicate_dirs() {
+        // Two directories that both round-trip to the same id can only
+        // coexist on a case-SENSITIVE filesystem (a folded store copied
+        // from macOS, say). Where the filesystem folds them into one,
+        // the single entry must resolve fine — branch on what the
+        // filesystem actually did.
+        let temp = tempfile::TempDir::new().unwrap();
+        let automerge_dir = temp.path().join("automerge");
+        add_doc_dir(&automerge_dir, "2c", &TRUE_ID[2..]);
+        add_doc_dir(&automerge_dir, "2C", &TRUE_ID[2..]);
+        let level1_entries = std::fs::read_dir(&automerge_dir).unwrap().count();
+        let map = locate_all_doc_dirs(&automerge_dir).unwrap();
+        match level1_entries {
+            2 => {
+                let err = locate_verified(&map, TRUE_ID).unwrap_err();
+                assert!(err.contains("distinct storage directories"), "got: {err}");
+            }
+            1 => {
+                locate_verified(&map, TRUE_ID).unwrap();
+            }
+            n => panic!("unexpected level-1 entry count {n}"),
+        }
+    }
 }

--- a/crates/quarto-hub/src/admin/collect.rs
+++ b/crates/quarto-hub/src/admin/collect.rs
@@ -159,7 +159,10 @@ pub async fn collect(
     // Re-verification (principle 5): recompute kind + liveness + age
     // against CURRENT storage, with the manifest's own gate options.
     let storage = samod::storage::TokioFilesystemStorage::new(&automerge_dir);
-    let doc_ids = list_doc_ids_filesystem(&automerge_dir);
+    // A pair we cannot identify aborts the collection outright: the
+    // collector must never act on a guessed doc id (bd-eb2wnxkp).
+    let doc_ids =
+        list_doc_ids_filesystem(&automerge_dir).map_err(|e| format!("refusing to collect: {e}"))?;
     let docs = load_all_docs(&storage, &doc_ids).await;
     let live = live_doc_ids(&docs);
     let opts = ScanOptions {

--- a/crates/quarto-hub/src/admin/scan.rs
+++ b/crates/quarto-hub/src/admin/scan.rs
@@ -12,7 +12,11 @@
 //! semantics. (No stronger consistency exists anywhere in this system
 //! — an offline store can equally be behind a peer.) The collector
 //! re-verifies against current storage before acting, so scan-time
-//! staleness cannot cause an unsafe collection.
+//! *staleness* cannot cause an unsafe collection. (Staleness only:
+//! re-verification recomputes from the same inputs, so a *systematic*
+//! mis-identification — e.g. a doc id mis-read from a case-folded
+//! path, bd-eb2wnxkp — would survive it. That class is prevented at
+//! enumeration time by [`recover_doc_id`].)
 
 use std::collections::{BTreeMap, HashMap, HashSet};
 
@@ -60,6 +64,115 @@ pub struct LoadedDoc {
     pub bad_chunks: usize,
 }
 
+/// A splay directory pair that cannot be soundly mapped back to a
+/// document id (see [`recover_doc_id`]).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RecoverError {
+    /// No case variant of the level-1 prefix yields an id that passes
+    /// bs58check (or parses as a legacy UUID). Either the store is
+    /// corrupt or a non-samod directory is sitting inside `automerge/`.
+    Unidentifiable { prefix: String, rest: String },
+    /// More than one case variant parses to a *distinct* id — a
+    /// bs58check collision (~2⁻³² per variant). Refuse rather than
+    /// guess.
+    Ambiguous { prefix: String, rest: String },
+}
+
+impl std::fmt::Display for RecoverError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RecoverError::Unidentifiable { prefix, rest } => write!(
+                f,
+                "directory pair {prefix}/{rest} does not correspond to any valid \
+                 document id (no case variant of {prefix:?} passes the id checksum); \
+                 refusing to guess — is this a samod store?"
+            ),
+            RecoverError::Ambiguous { prefix, rest } => write!(
+                f,
+                "directory pair {prefix}/{rest} matches more than one valid document \
+                 id across case variants of {prefix:?}; refusing to guess"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for RecoverError {}
+
+/// All casings of `s` (each ASCII-alphabetic char × {lower, upper}).
+/// For the 2-char splay prefix this is at most 4 strings. Variants
+/// containing characters outside the base58 alphabet simply fail to
+/// parse downstream — no special-casing needed.
+fn case_variants(s: &str) -> Vec<String> {
+    let mut variants = vec![String::new()];
+    for c in s.chars() {
+        let mut alts = vec![c];
+        if c.is_ascii_alphabetic() {
+            alts.push(if c.is_ascii_uppercase() {
+                c.to_ascii_lowercase()
+            } else {
+                c.to_ascii_uppercase()
+            });
+        }
+        variants = variants
+            .iter()
+            .flat_map(|prefix| {
+                alts.iter().map(move |a| {
+                    let mut v = prefix.clone();
+                    v.push(*a);
+                    v
+                })
+            })
+            .collect();
+    }
+    variants
+}
+
+/// Recover the true doc id from a samod splay directory pair.
+///
+/// Base58 is case-sensitive; APFS/NTFS fold case. When two ids' 2-char
+/// prefixes differ only by case, both docs share one on-disk level-1
+/// directory, and the id read back inherits the first-creator's casing
+/// (bd-eb2wnxkp). Only level-1 can fold this way — level-2 dirs are
+/// created fresh inside it with their writer's casing — so testing the
+/// ≤4 case variants of the prefix against the id's own checksum
+/// (samod's `DocumentId` is base58**check**; a wrong casing false-accepts
+/// at ~2⁻³²) identifies the true id. Zero or multiple distinct matches
+/// hard-fail: those arms guard the folding-is-prefix-only assumption,
+/// so if it is ever violated it breaks loudly instead of silently.
+///
+/// Returns the id as the *string that parsed* (not the parsed id's
+/// canonical re-encoding): `DocumentId::from_str` also accepts legacy
+/// UUID text, whose hex parses case-insensitively — several variant
+/// strings can name the same id, and re-encoding a UUID-form id to
+/// bs58check would break the path round-trip for such stores. Variants
+/// are deduplicated by parsed id, preferring the as-read casing.
+pub fn recover_doc_id(prefix: &str, rest: &str) -> Result<String, RecoverError> {
+    use std::str::FromStr;
+    let mut matches: Vec<(String, samod::DocumentId)> = Vec::new();
+    // case_variants yields the as-read casing first, so first-match-wins
+    // dedup keeps the on-disk casing when several casings parse to the
+    // same id (legacy UUID hex is case-insensitive).
+    for variant in case_variants(prefix) {
+        let candidate = format!("{variant}{rest}");
+        if let Ok(id) = samod::DocumentId::from_str(&candidate)
+            && !matches.iter().any(|(_, seen)| *seen == id)
+        {
+            matches.push((candidate, id));
+        }
+    }
+    match matches.len() {
+        1 => Ok(matches.pop().expect("len checked").0),
+        0 => Err(RecoverError::Unidentifiable {
+            prefix: prefix.to_string(),
+            rest: rest.to_string(),
+        }),
+        _ => Err(RecoverError::Ambiguous {
+            prefix: prefix.to_string(),
+            rest: rest.to_string(),
+        }),
+    }
+}
+
 /// Enumerate document ids from a **filesystem** samod store.
 ///
 /// Enumeration is deliberately NOT done through
@@ -70,17 +183,26 @@ pub struct LoadedDoc {
 /// in half. samod itself only ever uses per-doc prefixes (where the
 /// mapping round-trips); whole-store enumeration is simply outside
 /// the `Storage` contract. So we enumerate by mirroring the splay:
-/// doc id = `<level-1 dir name>` + `<level-2 dir name>`. Per-doc
-/// chunk loading then goes through the adapter (`load_range([id])`),
-/// which is correct on every backend.
+/// doc id = `<level-1 dir name>` + `<level-2 dir name>` — with the
+/// level-1 name treated as *possibly case-folded* and recovered via
+/// [`recover_doc_id`], because directory names are a lossy channel on
+/// case-insensitive filesystems (bd-eb2wnxkp).
+///
+/// Errors abort the listing (and with it any scan/collect): a pair we
+/// cannot identify makes the whole enumeration untrustworthy, and the
+/// collector must never act on a guessed id. When recovery changes
+/// the casing relative to the on-disk name, a warning is emitted so
+/// the operator knows the store has a folded directory.
 ///
 /// The adapter's own identity record (`st/orage-adapter-id`) is a
 /// *file* at level 2, not a directory, so the `is_dir` requirement
 /// skips it structurally.
-pub fn list_doc_ids_filesystem(automerge_dir: &std::path::Path) -> Vec<String> {
+pub fn list_doc_ids_filesystem(
+    automerge_dir: &std::path::Path,
+) -> Result<Vec<String>, RecoverError> {
     let mut out = Vec::new();
     let Ok(level1) = std::fs::read_dir(automerge_dir) else {
-        return out;
+        return Ok(out);
     };
     for l1 in level1.flatten() {
         if !l1.path().is_dir() {
@@ -97,12 +219,22 @@ pub fn list_doc_ids_filesystem(automerge_dir: &std::path::Path) -> Vec<String> {
                 continue;
             }
             if let Some(rest) = l2.file_name().to_str() {
-                out.push(format!("{prefix}{rest}"));
+                let id = recover_doc_id(&prefix, rest)?;
+                if !id.starts_with(&prefix) {
+                    tracing::warn!(
+                        on_disk = %format!("{prefix}/{rest}"),
+                        recovered = %id,
+                        "doc id recovered from case-folded splay directory \
+                         (case-insensitive filesystem); store layout is intact \
+                         but two ids share this level-1 directory"
+                    );
+                }
+                out.push(id);
             }
         }
     }
     out.sort();
-    out
+    Ok(out)
 }
 
 /// Load and classify the given documents through the storage adapter.
@@ -299,6 +431,74 @@ mod tests {
     use automerge::transaction::Transactable;
     use automerge::{ObjType, ROOT};
     use samod::storage::InMemoryStorage;
+
+    // ── recover_doc_id (bd-eb2wnxkp) ────────────────────────────────
+    // Fixture ids are real bs58check strings whose checksums were
+    // verified independently; their case-flipped prefixes fail to
+    // parse, which is the property recovery relies on. TRUE_ID was
+    // captured from an actual store (see
+    // claude-notes/plans/flaky-admin-collect-lifecycle-investigation/).
+    const TRUE_ID: &str = "2cPADPZ85aBLaaLaLrS2BNcVza1n";
+    const ST_ID: &str = "StntkRJtG7hVPkKPY4Qkeu6f5bZ";
+    const DIGIT_ID: &str = "26tzBsgAf68x9HnriDHKZHQkhp4R";
+
+    #[test]
+    fn case_variants_cover_alphabetic_chars_only() {
+        let mut v = case_variants("2c");
+        v.sort();
+        assert_eq!(v, vec!["2C", "2c"]);
+        let mut v = case_variants("st");
+        v.sort();
+        assert_eq!(v, vec!["ST", "St", "sT", "st"]);
+        assert_eq!(case_variants("26"), vec!["26"]);
+    }
+
+    #[test]
+    fn recover_accepts_true_casing_unchanged() {
+        assert_eq!(recover_doc_id("2c", &TRUE_ID[2..]).unwrap(), TRUE_ID);
+        assert_eq!(recover_doc_id("26", &DIGIT_ID[2..]).unwrap(), DIGIT_ID);
+    }
+
+    #[test]
+    fn recover_fixes_case_folded_prefix() {
+        // The regression: the on-disk level-1 dir carries the wrong
+        // casing; the checksum identifies the true id.
+        assert_eq!(recover_doc_id("2C", &TRUE_ID[2..]).unwrap(), TRUE_ID);
+        // All three wrong casings of the St id map back to it.
+        for folded in ["st", "ST", "sT"] {
+            assert_eq!(recover_doc_id(folded, &ST_ID[2..]).unwrap(), ST_ID);
+        }
+    }
+
+    #[test]
+    fn recover_rejects_unidentifiable_pair() {
+        // No case variant of a garbage pair passes the checksum…
+        assert!(matches!(
+            recover_doc_id("zz", "not-a-doc-id"),
+            Err(RecoverError::Unidentifiable { .. })
+        ));
+        // …including a digits-only prefix, which has no variants at all.
+        assert!(matches!(
+            recover_doc_id("26", "garbage"),
+            Err(RecoverError::Unidentifiable { .. })
+        ));
+        // NOTE: the Ambiguous arm needs two distinct ids differing only
+        // in prefix casing to both pass bs58check — a ~2⁻³² collision we
+        // cannot construct. Covered by inspection; the arm exists to
+        // guard the folding-is-prefix-only assumption.
+    }
+
+    #[test]
+    fn recover_keeps_legacy_uuid_ids_as_read() {
+        // DocumentId::from_str also accepts legacy UUID text, whose hex
+        // parses case-insensitively — several casings name the SAME id.
+        // That must not read as Ambiguous, and the on-disk casing must
+        // be preserved (re-encoding would break the path round-trip).
+        let uuid = "1a2b3c4d-5e6f-4a1b-8c2d-3e4f5a6b7c8d";
+        assert_eq!(recover_doc_id("1a", &uuid[2..]).unwrap(), uuid);
+        let folded = format!("1A{}", &uuid[2..]);
+        assert_eq!(recover_doc_id("1A", &uuid[2..]).unwrap(), folded);
+    }
 
     use crate::resource::{
         CAPTURE_MIME_TYPE, CaptureDocMeta, create_binary_document, create_capture_document,

--- a/crates/quarto-hub/src/main.rs
+++ b/crates/quarto-hub/src/main.rs
@@ -223,7 +223,7 @@ async fn run_admin(cmd: AdminCommand) -> anyhow::Result<()> {
                 );
             }
             let storage = samod::storage::TokioFilesystemStorage::new(&automerge_dir);
-            let doc_ids = scan_mod::list_doc_ids_filesystem(&automerge_dir);
+            let doc_ids = scan_mod::list_doc_ids_filesystem(&automerge_dir)?;
             let manifest = scan_mod::scan(
                 &storage,
                 &doc_ids,

--- a/crates/quarto-hub/tests/integration/admin_collect_lifecycle.rs
+++ b/crates/quarto-hub/tests/integration/admin_collect_lifecycle.rs
@@ -98,7 +98,7 @@ fn tree_fingerprint(dir: &Path) -> Vec<(String, u64)> {
 async fn scan_store(hub_dir: &Path) -> quarto_hub::admin::manifest::ScanManifest {
     let automerge_dir = hub_dir.join("automerge");
     let storage = TokioFilesystemStorage::new(&automerge_dir);
-    let ids = list_doc_ids_filesystem(&automerge_dir);
+    let ids = list_doc_ids_filesystem(&automerge_dir).unwrap();
     // The manifest's dataDir must be the HUB dir (collect's contract).
     scan(
         &storage,
@@ -136,7 +136,11 @@ async fn collect_lifecycle_quarantine_restore_purge() {
     // Orphan's chunks moved (not copied, not deleted).
     let orphan_quarantined = batch_dir.join("docs").join(&orphan_id);
     assert!(orphan_quarantined.is_dir());
-    assert!(!list_doc_ids_filesystem(&hub_dir.join("automerge")).contains(&orphan_id));
+    assert!(
+        !list_doc_ids_filesystem(&hub_dir.join("automerge"))
+            .unwrap()
+            .contains(&orphan_id)
+    );
     // batch.json embeds the manifest + chunk hashes.
     let record: quarto_hub::admin::collect::BatchRecord =
         serde_json::from_slice(&std::fs::read(batch_dir.join("batch.json")).unwrap()).unwrap();
@@ -165,7 +169,9 @@ async fn collect_lifecycle_quarantine_restore_purge() {
     assert_eq!(results.len(), 1);
     assert!(results[0].1.is_ok(), "restore failed: {:?}", results[0].1);
     assert!(
-        list_doc_ids_filesystem(&hub_dir.join("automerge")).contains(&orphan_id),
+        list_doc_ids_filesystem(&hub_dir.join("automerge"))
+            .unwrap()
+            .contains(&orphan_id),
         "orphan chunks back in place"
     );
     // Restored doc loads as a valid capture again.
@@ -202,6 +208,11 @@ async fn collect_lifecycle_quarantine_restore_purge() {
 async fn collect_reverification_skips_rereferenced_candidate() {
     let (_temp, hub_dir, orphan_id, _live_id) = build_store().await;
     let manifest = scan_store(&hub_dir).await;
+    // Assert the count before indexing: when this test flaked under
+    // bd-eb2wnxkp, a mis-identified LIVE doc joined the candidate list
+    // and candidates[0] was a completely different id — confusing the
+    // failure signature.
+    assert_eq!(manifest.candidates.len(), 1);
     assert_eq!(manifest.candidates[0].doc_id, orphan_id);
 
     // Between scan and collect, the orphan becomes referenced again
@@ -235,7 +246,11 @@ async fn collect_reverification_skips_rereferenced_candidate() {
         outcome.skipped[0].1
     );
     // Nothing moved.
-    assert!(list_doc_ids_filesystem(&hub_dir.join("automerge")).contains(&orphan_id));
+    assert!(
+        list_doc_ids_filesystem(&hub_dir.join("automerge"))
+            .unwrap()
+            .contains(&orphan_id)
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/quarto-hub/tests/integration/admin_doc_id_recovery.rs
+++ b/crates/quarto-hub/tests/integration/admin_doc_id_recovery.rs
@@ -217,3 +217,84 @@ async fn collect_does_not_quarantine_live_doc_with_folded_dir() {
         ctx.repo().stop().await;
     }
 }
+
+/// The complement: a folded ORPHAN must still be correctly
+/// quarantined. The rename source now comes from the round-trip map
+/// (actual on-disk names), so folding must neither block collection
+/// nor mis-target it. Case-insensitive filesystems only.
+#[tokio::test(flavor = "multi_thread")]
+async fn collect_quarantines_folded_orphan_by_actual_dir_name() {
+    let temp = TempDir::new().unwrap();
+    if !fs_is_case_insensitive(temp.path()) {
+        eprintln!("SKIP: filesystem is case-sensitive; fold cannot occur here");
+        return;
+    }
+    let project_root = temp.path().join("project");
+    std::fs::create_dir(&project_root).unwrap();
+    std::fs::write(project_root.join("a.qmd"), "# Hello\n").unwrap();
+
+    let storage = StorageManager::new(&project_root).unwrap();
+    let hub_dir = storage.hub_dir().to_path_buf();
+    let ctx = HubContext::new(storage, HubConfig::default())
+        .await
+        .unwrap();
+    let orphan = ctx.repo().create(old_capture_doc()).await.unwrap();
+    let orphan_id = orphan.document_id().to_string();
+    drop(orphan);
+    ctx.repo().stop().await;
+    drop(ctx); // releases hub.lock, which collect() must acquire
+
+    // Fold the orphan's level-1 splay dir.
+    let automerge_dir = hub_dir.join("automerge");
+    let prefix: String = orphan_id.chars().take(2).collect();
+    let folded: String = {
+        let mut done = false;
+        prefix
+            .chars()
+            .map(|c| {
+                if !done && c.is_ascii_alphabetic() {
+                    done = true;
+                    if c.is_ascii_uppercase() {
+                        c.to_ascii_lowercase()
+                    } else {
+                        c.to_ascii_uppercase()
+                    }
+                } else {
+                    c
+                }
+            })
+            .collect()
+    };
+    if folded == prefix {
+        eprintln!("SKIP: orphan doc id {orphan_id} has a caseless splay prefix");
+        return;
+    }
+    std::fs::rename(automerge_dir.join(&prefix), automerge_dir.join(&folded)).unwrap();
+
+    let fs_storage = TokioFilesystemStorage::new(&automerge_dir);
+    let ids = list_doc_ids_filesystem(&automerge_dir).unwrap();
+    assert!(ids.contains(&orphan_id), "true id recovered (got {ids:?})");
+    let manifest = scan(
+        &fs_storage,
+        &ids,
+        &hub_dir.canonicalize().unwrap().to_string_lossy(),
+        &ScanOptions::default(),
+    )
+    .await;
+    assert!(
+        manifest.candidates.iter().any(|c| c.doc_id == orphan_id),
+        "folded orphan is a candidate under its true id"
+    );
+
+    let outcome = collect(&hub_dir, &manifest, true).await.unwrap();
+    assert!(outcome.verified.iter().any(|c| c.doc_id == orphan_id));
+    let batch_dir = outcome.batch_dir.expect("batch created");
+    // Quarantined under the TRUE id, and gone from the store.
+    assert!(batch_dir.join("docs").join(&orphan_id).is_dir());
+    assert!(
+        !list_doc_ids_filesystem(&automerge_dir)
+            .unwrap()
+            .contains(&orphan_id),
+        "orphan chunks moved out of the store"
+    );
+}

--- a/crates/quarto-hub/tests/integration/admin_doc_id_recovery.rs
+++ b/crates/quarto-hub/tests/integration/admin_doc_id_recovery.rs
@@ -1,0 +1,219 @@
+//! Doc-id recovery from case-folded splay directories (bd-eb2wnxkp,
+//! bd-u0tldu4z).
+//!
+//! samod splays a doc id across `<first-2-chars>/<rest>/`. Base58 is
+//! case-sensitive but APFS/NTFS are not: when two ids' 2-char prefixes
+//! differ only by case, both land in one on-disk directory and every id
+//! read back through it inherits the first-creator's casing.
+//! `list_doc_ids_filesystem` must recover the true id by testing the
+//! ≤4 case variants of the prefix against bs58check's checksum.
+//!
+//! The hand-built-directory tests are deterministic on every platform
+//! (no random id draw — the flake they replace fired ~2%/run). The
+//! collect-level test needs a real case-insensitive filesystem and
+//! skips honestly elsewhere.
+//!
+//! Fixture ids are real bs58check strings (checksum-verified): the
+//! case-flipped variants used here fail to parse, which is exactly the
+//! property recovery relies on.
+
+use std::path::Path;
+
+use quarto_hub::admin::collect::collect;
+use quarto_hub::admin::scan::{ScanOptions, list_doc_ids_filesystem, scan};
+use quarto_hub::context::{HubConfig, HubContext};
+use quarto_hub::index::CaptureRef;
+use quarto_hub::resource::{CaptureDocMeta, create_capture_document_at};
+use quarto_hub::storage::StorageManager;
+use samod::storage::TokioFilesystemStorage;
+use tempfile::TempDir;
+
+/// True id captured from a real store (see
+/// `claude-notes/plans/flaky-admin-collect-lifecycle-investigation/`).
+/// `2CPAD…` (the case-flip) fails bs58check.
+const TRUE_ID: &str = "2cPADPZ85aBLaaLaLrS2BNcVza1n";
+
+/// A valid id whose prefix case-folds into samod's always-present
+/// `st/` splay dir (`st/orage-adapter-id` adapter identity).
+const ST_ID: &str = "StntkRJtG7hVPkKPY4Qkeu6f5bZ";
+
+/// Build `<automerge>/<l1>/<l2>/` with one chunk-like file inside.
+fn add_doc_dir(automerge_dir: &Path, l1: &str, l2: &str) {
+    let dir = automerge_dir.join(l1).join(l2);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("snapshot"), b"x").unwrap();
+}
+
+#[test]
+fn list_recovers_true_id_from_case_folded_splay_dir() {
+    let temp = TempDir::new().unwrap();
+    let automerge_dir = temp.path().join("automerge");
+    // The doc's true id is 2cPAD…, but the on-disk level-1 dir carries
+    // the folded casing "2C" (first-creator wins on APFS/NTFS).
+    add_doc_dir(&automerge_dir, "2C", &TRUE_ID[2..]);
+    // samod's adapter identity: a *file* at level 2, skipped via is_dir.
+    let st = automerge_dir.join("st");
+    std::fs::create_dir_all(&st).unwrap();
+    std::fs::write(st.join("orage-adapter-id"), b"id").unwrap();
+
+    let ids = list_doc_ids_filesystem(&automerge_dir).unwrap();
+    assert_eq!(ids, vec![TRUE_ID.to_string()]);
+}
+
+#[test]
+fn list_recovers_id_folded_into_adapter_st_dir() {
+    // Every store has an `st/` level-1 dir (adapter identity), so a doc
+    // id starting St/ST/sT is *guaranteed* a folding partner: on a
+    // case-insensitive filesystem its chunks land inside `st/` and the
+    // id reads back as `st…`.
+    let temp = TempDir::new().unwrap();
+    let automerge_dir = temp.path().join("automerge");
+    let st = automerge_dir.join("st");
+    std::fs::create_dir_all(&st).unwrap();
+    std::fs::write(st.join("orage-adapter-id"), b"id").unwrap();
+    add_doc_dir(&automerge_dir, "st", &ST_ID[2..]);
+
+    let ids = list_doc_ids_filesystem(&automerge_dir).unwrap();
+    assert_eq!(ids, vec![ST_ID.to_string()]);
+}
+
+/// Runtime probe: does `dir`'s filesystem fold case?
+fn fs_is_case_insensitive(dir: &Path) -> bool {
+    let probe = dir.join("CaseProbeQ2");
+    std::fs::write(&probe, b"x").unwrap();
+    let hit = dir.join("caseprobeq2").exists();
+    std::fs::remove_file(&probe).ok();
+    hit
+}
+
+fn old_capture_doc() -> automerge::Automerge {
+    create_capture_document_at(
+        b"gzipped-capture-bytes",
+        &CaptureDocMeta {
+            source_path: "a.qmd".into(),
+            engines: vec!["knitr".into()],
+        },
+        "2020-01-01T00:00:00+00:00",
+    )
+    .unwrap()
+}
+
+/// The data-loss scenario end to end: a LIVE doc whose splay dir
+/// carries folded casing must classify as live (not orphaned) and must
+/// survive `collect --execute`.
+///
+/// Forces the fold deterministically by case-renaming the live doc's
+/// level-1 dir — no random draw. Only meaningful where the filesystem
+/// folds case; skips honestly elsewhere.
+#[tokio::test(flavor = "multi_thread")]
+async fn collect_does_not_quarantine_live_doc_with_folded_dir() {
+    let temp = TempDir::new().unwrap();
+    if !fs_is_case_insensitive(temp.path()) {
+        eprintln!("SKIP: filesystem is case-sensitive; fold cannot occur here");
+        return;
+    }
+    let project_root = temp.path().join("project");
+    std::fs::create_dir(&project_root).unwrap();
+    std::fs::write(project_root.join("a.qmd"), "# Hello\n").unwrap();
+
+    let storage = StorageManager::new(&project_root).unwrap();
+    let hub_dir = storage.hub_dir().to_path_buf();
+    let ctx = HubContext::new(storage, HubConfig::default())
+        .await
+        .unwrap();
+    let live = ctx.repo().create(old_capture_doc()).await.unwrap();
+    let live_id = live.document_id().to_string();
+    ctx.index()
+        .set_capture(
+            "a.qmd",
+            &CaptureRef {
+                capture_doc_id: live_id.clone(),
+                staleness: Some(false),
+                state: None,
+                last_error: None,
+            },
+        )
+        .unwrap();
+    let orphan = ctx.repo().create(old_capture_doc()).await.unwrap();
+    let orphan_id = orphan.document_id().to_string();
+    drop(orphan);
+    drop(live);
+    ctx.repo().stop().await;
+    drop(ctx); // releases hub.lock, which collect() must acquire
+
+    // Force the fold on the LIVE doc: flip the case of an alphabetic
+    // char in its level-1 splay dir name. (A digits-only prefix has no
+    // case to fold — vanishingly rare; skip honestly.)
+    let automerge_dir = hub_dir.join("automerge");
+    let prefix: String = live_id.chars().take(2).collect();
+    let folded: String = {
+        let mut done = false;
+        prefix
+            .chars()
+            .map(|c| {
+                if !done && c.is_ascii_alphabetic() {
+                    done = true;
+                    if c.is_ascii_uppercase() {
+                        c.to_ascii_lowercase()
+                    } else {
+                        c.to_ascii_uppercase()
+                    }
+                } else {
+                    c
+                }
+            })
+            .collect()
+    };
+    if folded == prefix {
+        eprintln!("SKIP: live doc id {live_id} has a caseless splay prefix");
+        return;
+    }
+    std::fs::rename(automerge_dir.join(&prefix), automerge_dir.join(&folded)).unwrap();
+
+    // Scan: the live doc must NOT appear as a candidate; the orphan's
+    // id must come back with its true casing.
+    let fs_storage = TokioFilesystemStorage::new(&automerge_dir);
+    let ids = list_doc_ids_filesystem(&automerge_dir).unwrap();
+    assert!(
+        ids.contains(&live_id),
+        "recovery must yield the live doc's true id (got {ids:?})"
+    );
+    let manifest = scan(
+        &fs_storage,
+        &ids,
+        &hub_dir.canonicalize().unwrap().to_string_lossy(),
+        &ScanOptions::default(),
+    )
+    .await;
+    assert_eq!(
+        manifest
+            .candidates
+            .iter()
+            .map(|c| c.doc_id.as_str())
+            .collect::<Vec<_>>(),
+        vec![orphan_id.as_str()],
+        "only the orphan may be a candidate; the folded live doc must stay live"
+    );
+
+    // Execute the collection; the live doc must survive and still load.
+    let outcome = collect(&hub_dir, &manifest, true).await.unwrap();
+    assert_eq!(outcome.verified.len(), 1);
+    assert_eq!(outcome.verified[0].doc_id, orphan_id);
+    {
+        use std::str::FromStr;
+        let storage = StorageManager::new(temp.path().join("project")).unwrap();
+        let ctx = HubContext::new(storage, HubConfig::default())
+            .await
+            .unwrap();
+        let handle = ctx
+            .repo()
+            .find(samod::DocumentId::from_str(&live_id).unwrap())
+            .await
+            .unwrap();
+        assert!(
+            handle.is_some(),
+            "live capture must still load after collect"
+        );
+        ctx.repo().stop().await;
+    }
+}

--- a/crates/quarto-hub/tests/integration/admin_scan_real_store.rs
+++ b/crates/quarto-hub/tests/integration/admin_scan_real_store.rs
@@ -65,7 +65,7 @@ async fn scan_real_store_finds_orphaned_capture_only() {
 
     // Scan offline through the same adapter the server uses.
     let fs_storage = TokioFilesystemStorage::new(&automerge_dir);
-    let doc_ids = list_doc_ids_filesystem(&automerge_dir);
+    let doc_ids = list_doc_ids_filesystem(&automerge_dir).unwrap();
     assert!(
         doc_ids.len() >= 4,
         "expected at least index + file + 2 captures; got {doc_ids:?}"

--- a/crates/quarto-hub/tests/integration/main.rs
+++ b/crates/quarto-hub/tests/integration/main.rs
@@ -7,6 +7,7 @@
 //! provider, test hub, tracing capture) live in [`support`].
 
 pub mod admin_collect_lifecycle;
+pub mod admin_doc_id_recovery;
 pub mod admin_scan_real_store;
 pub mod auth_bearer;
 pub mod login_nonce;


### PR DESCRIPTION
## Summary

Fixes the macOS/Windows doc-id mis-identification in the `hub admin` scan/collect tooling (bd-eb2wnxkp) and, with it, the ~2%-per-run macOS CI flake in the `admin_collect_lifecycle` / `admin_scan_real_store` test families (bd-u0tldu4z).

samod splays a doc id across `<2-char-prefix>/<rest>/` directories. Base58 is case-sensitive; APFS/NTFS are not: when two ids' prefixes differ only by case, both docs share one level-1 directory and every id read back through it inherits the first-creator's casing. A mis-cased **live** doc then fails the string-compared live-set check, classifies as orphaned, and becomes eligible for quarantine — the data-loss path. Stress evidence: 3 failures in 142 isolated iterations pre-fix, all the case-flip signature; captured logs in `claude-notes/plans/flaky-admin-collect-lifecycle-investigation/`.

### Part A — checksum-validated case-variant recovery (`fb1e2818`/rebased)

- `recover_doc_id(prefix, rest)` tests the ≤4 case variants of the splay prefix against `DocumentId`'s bs58check checksum: exactly one parses (~2⁻³² false accept); zero or multiple distinct matches hard-fail (`Unidentifiable`/`Ambiguous`) so the collector never acts on a guessed id.
- `list_doc_ids_filesystem` is now fallible; `hub admin scan` and `collect()` abort on error; recovery that changes casing emits a warning.
- Recovery returns the recovered id *string*, deduped by parsed id preferring the as-read casing — legacy-UUID hex parses case-insensitively (several casings, one id) and must neither read as ambiguous nor be re-encoded.
- **On-disk layout unchanged — no store migration.**

### Defense in depth — collect round-trip guard (`7657c71d`/rebased)

`collect()` maps every recoverable id to the on-disk director(ies) whose *actual names* round-trip to it; a candidate that doesn't round-trip to exactly one real directory is skipped regardless of liveness, and the quarantine rename source comes from that map — never from path construction + filesystem case-folding.

## Test plan

- [x] TDD red confirmed pre-fix (deterministic hand-built-splay tests; no random id draw)
- [x] 8 unit tests on checksum-verified fixtures, incl. the always-present `st/` adapter-dir collision and duplicate-dir ambiguity
- [x] 4 integration tests, incl. end-to-end: folded live doc survives `collect --execute`; folded orphan still quarantined under its true id (runtime case-insensitivity probe; skip honestly on case-sensitive filesystems)
- [x] E2E through the real binary: `hub admin scan` on a hand-built folded store emits the recovery warning and the true id in the manifest; refusal exits 1
- [x] Full workspace: 11483/11483; `cargo xtask verify --skip-hub-build` green
- [x] Post-fix stress: **150/150 clean iterations** (pre-fix baseline 3/142)
- [ ] CI on macOS runners — the point of this PR; the flake fired there most recently (PR #479)

Braid: bd-eb2wnxkp (in_progress; Parts B/C still open), bd-u0tldu4z (stays open for a dedicated post-merge stress verification), bd-3uw7uufa (upstream samod follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)