### PR TITLE
smoke-all: hold fixture patterns under source-location, gate on fixture PRs

### DIFF
--- a/.github/workflows/hub-client-e2e.yml
+++ b/.github/workflows/hub-client-e2e.yml
@@ -169,12 +169,42 @@ jobs:
           cd hub-client
           npx playwright test
 
+      # Did this PR touch smoke-all fixtures? If so we run smoke-all below, so
+      # a fixture can't be authored against `q2 render` (no source-location),
+      # land green, and then sit red in a nightly nobody watches — which is
+      # exactly how three fixtures were born red (bd-nhn7snpg).
+      #
+      # This is a step-level gate on purpose. `on.pull_request.paths` would
+      # filter the whole WORKFLOW, which would stop the fast interactive E2E
+      # gate from running on every other PR.
+      #
+      # The explicit fetch is load-bearing: actions/checkout clones shallow,
+      # so without it there is no base commit to diff against. Two-dot diff
+      # (not three-dot) for the same reason — no merge-base in a shallow clone.
+      - name: Did this PR touch smoke-all fixtures?
+        id: smoke_changed
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch --depth=1 origin "${{ github.base_ref }}"
+          if git diff --quiet FETCH_HEAD HEAD -- crates/quarto/tests/smoke-all/; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No smoke-all fixture changes; skipping smoke-all."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Smoke-all fixtures changed:"
+            git diff --name-only FETCH_HEAD HEAD -- crates/quarto/tests/smoke-all/
+          fi
+
       # Smoke-all: full render pipeline matrix (~80 tests). Runs nightly
-      # (schedule trigger) or on demand (workflow_dispatch with run-smoke-all=true).
-      # Skipped for every push/PR. Use this to verify render correctness after
-      # changes to the WASM pipeline or theme resolution.
-      - name: Run smoke-all E2E tests (nightly + opt-in)
-        if: inputs.run-smoke-all == true || github.event_name == 'schedule'
+      # (schedule trigger), on demand (workflow_dispatch with run-smoke-all=true),
+      # and on PRs that touch smoke-all fixtures. Otherwise skipped for push/PR.
+      # Use this to verify render correctness after changes to the WASM
+      # pipeline or theme resolution.
+      - name: Run smoke-all E2E tests (nightly + opt-in + fixture PRs)
+        if: >-
+          inputs.run-smoke-all == true
+          || github.event_name == 'schedule'
+          || steps.smoke_changed.outputs.changed == 'true'
         env:
           # Worker count override. Scheduled nightlies leave inputs unset, so
           # this is empty → the config uses its default (3). A workflow_dispatch

--- a/crates/quarto/tests/smoke-all/extensions/contract-doc-shortcodes/test.qmd
+++ b/crates/quarto/tests/smoke-all/extensions/contract-doc-shortcodes/test.qmd
@@ -7,7 +7,16 @@ _quarto:
   tests:
     html:
       ensureFileRegexMatches:
-        - ["strong>_bringit_", "Shortcode Error \\(shorty\\): error message", "Shortcode Error \\(shorty\\): error_args"]
+        # `strong[^>]*>` not `strong>`: the hub preview renders with
+        # `source-location: full`, which puts data-sid/data-loc on the opening
+        # tag, so the text no longer sits flush against `>`. Both renderers
+        # must satisfy this pattern.
+        #
+        # The `!str` tag is load-bearing: assertion strings are otherwise
+        # parsed as markdown, where `[...]` reads as reference-link syntax and
+        # emits a warning — and this fixture asserts noErrorsOrWarnings by
+        # default, so that warning would fail it.
+        - [!str "strong[^>]*>_bringit_", "Shortcode Error \\(shorty\\): error message", "Shortcode Error \\(shorty\\): error_args"]
 ---
 
 {{< shorty _bringit_ >}}

--- a/crates/quarto/tests/smoke-all/extensions/contract-return-coercions/test.qmd
+++ b/crates/quarto/tests/smoke-all/extensions/contract-return-coercions/test.qmd
@@ -6,7 +6,12 @@ _quarto:
     html:
       noErrors: true
       ensureFileRegexMatches:
-        - ["RET-STRING", "strong>RET-INLINE", "RET-INLINES", "RET-BLOCK", "RET-BLOCKS-1", "RET-BLOCKS-2", "RET-ARRAY"]
+        # `strong[^>]*>` not `strong>`: the hub preview renders with
+        # `source-location: full`, which puts data-sid/data-loc on the opening
+        # tag, so the text no longer sits flush against `>`. Both renderers
+        # must satisfy this pattern. `!str` keeps the `[...]` from being parsed
+        # as markdown reference-link syntax, which emits a warning.
+        - ["RET-STRING", !str "strong[^>]*>RET-INLINE", "RET-INLINES", "RET-BLOCK", "RET-BLOCKS-1", "RET-BLOCKS-2", "RET-ARRAY"]
 ---
 
 String: {{< rstr >}}

--- a/crates/quarto/tests/smoke-all/quarto-test/callout-title-attribute.qmd
+++ b/crates/quarto/tests/smoke-all/quarto-test/callout-title-attribute.qmd
@@ -7,8 +7,17 @@ _quarto:
       ensureHtmlElements:
         - ["div.callout-note.callout-titled", "div.callout-title-container span.screen-reader-only"]
       ensureFileRegexMatches:
-        - ['<span class="screen-reader-only">Note</span>Off-Host Execution', "<code>renv</code>"]
-        - ["callout-title-container flex-fill\">\\s*Note\\s*</div>"]
+        # The `[^>]*` slots absorb data-sid/data-loc: the hub preview renders
+        # with `source-location: full`, so every tag here carries them, while
+        # the native runner renders without. These patterns must hold on both.
+        # `!str` keeps the `[...]` and `<...>` from being parsed as markdown
+        # (reference-link syntax / raw HTML), which emits warnings.
+        - [!str '<span class="screen-reader-only"[^>]*>Note</span>Off-Host Execution', !str "<code[^>]*>renv</code>"]
+        # Negative guard: the pre-fix behavior dropped title= and left the
+        # bare callout type as the heading. `[^>]*` matters here too — without
+        # it the guard is vacuous under `source-location: full`, where the div
+        # always carries attributes, so it could never catch that regression.
+        - [!str "callout-title-container flex-fill\"[^>]*>\\s*Note\\s*</div>"]
       noErrors: true
 ---
 


### PR DESCRIPTION
Fixes the three smoke-all fixtures that have been red in the nightly E2E,
and closes the loop that let them land red in the first place.

Braid: bd-nhn7snpg

## What was wrong

Three fixtures assert markup adjacency — `strong>_bringit_`,
`<code>renv</code>`, `<span class="screen-reader-only">Note</span>…`.
That holds under `q2 render`, but the hub preview renders with
`format.html.source-location: full`, which puts `data-sid`/`data-loc` on
the opening tag, so the text no longer sits flush against `>`.

Nothing regressed. The fixtures never passed the preview harness:

| Fixture | Added by | First nightly red |
|---|---|---|
| `extensions/contract-doc-shortcodes` | #450 (2026-07-31) | 2026-08-01 |
| `extensions/contract-return-coercions` | #450 (2026-07-31) | 2026-08-01 |
| `quarto-test/callout-title-attribute` | #496 (2026-08-10) | 2026-08-11 |

The nightly's last green was 2026-07-31 — the night before #450 landed.

## Why nobody saw it

These fixtures have three consumers, and only one renders the way
preview does:

| Consumer | Renders with | Catches this |
|---|---|---|
| `smoke_all.rs` (native, every PR) | no source-location | no |
| `smokeAll.wasm.test.ts` (vitest, every PR) | no source-location | no |
| `smoke-all.spec.ts` (Playwright) | `source-location: full` | **yes** |

The Playwright leg was nightly/dispatch-only, so an author validated
against `q2 render`, saw two green gates, landed, and the failure
surfaced next morning in a run nobody watches.

## Changes

**Patterns** get `[^>]*` slots so they hold under both renderers, plus
`!str` so the `[...]`/`<...>` aren't parsed as markdown reference-link
syntax or raw HTML — warnings that fail the fixtures'
`noErrorsOrWarnings` assertions. `!str` is q2's documented opt-out, the
`yaml` package the E2E discovery uses resolves it to the plain scalar,
and other fixtures in the tree already use it.

**The negative guard** in `callout-title-attribute` got the same
treatment for a sharper reason: without it that guard is *vacuous* under
source-location. It looks for `flex-fill">` followed by a bare `Note`,
but the div always carries attributes there, so it could never match —
including in the regression it exists to catch (`title=` dropped to the
bare callout type). It was passing for the wrong reason.

**CI** now runs smoke-all on PRs touching `crates/quarto/tests/smoke-all/**`.
This is a step-level gate on purpose: `on.pull_request.paths` filters the
whole workflow and would stop the fast interactive E2E gate from running
on every other PR. The explicit fetch is load-bearing (checkout is
shallow) and the diff is two-dot for the same reason.

## Verification

- All 12 positive patterns and the negative guard checked against real
  renders under **both** configs — plain and `source-location: full`,
  with the harness's `stripSourceTrackingSpans` applied. Confirmed the
  4 failures first, then 0 after.
- Negative guard confirmed to catch the regression it guards, by
  constructing the regressed markup: old pattern misses it, new one
  catches it.
- Full native smoke-all: 118 passed / 0 failed.
- hub-client `test:wasm`: 131/131 (after rebuilding WASM — a stale local
  artifact predating #498 initially showed a false failure in
  `includes/in-code-fence`, which is green with a fresh build).
- `cargo xtask verify --skip-hub-build`: all 14 steps pass.
- Path-detection logic exercised both directions.

Since this PR touches smoke-all fixtures, it triggers its own new gate —
the Playwright smoke-all leg should run here and go green.

Test fixtures and CI only; no shipping code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)