### PR TITLE
smoke-all: correct the !str rationale in three fixture comments

### DIFF
--- a/crates/quarto/tests/smoke-all/extensions/contract-doc-shortcodes/test.qmd
+++ b/crates/quarto/tests/smoke-all/extensions/contract-doc-shortcodes/test.qmd
@@ -13,9 +13,12 @@ _quarto:
         # must satisfy this pattern.
         #
         # The `!str` tag is load-bearing: assertion strings are otherwise
-        # parsed as markdown, where `[...]` reads as reference-link syntax and
-        # emits a warning — and this fixture asserts noErrorsOrWarnings by
-        # default, so that warning would fail it.
+        # parsed as markdown, and the `*` quantifier reads as an unclosed
+        # emphasis marker — [Q-1-20] Failed to parse metadata value as
+        # markdown. This fixture asserts noErrorsOrWarnings by default, so that
+        # warning fails it. (Verified: the same pattern with `+` instead of `*`
+        # parses clean, so the `*` is the trigger — not the brackets, which are
+        # fine on their own.)
         - [!str "strong[^>]*>_bringit_", "Shortcode Error \\(shorty\\): error message", "Shortcode Error \\(shorty\\): error_args"]
 ---
 

--- a/crates/quarto/tests/smoke-all/extensions/contract-return-coercions/test.qmd
+++ b/crates/quarto/tests/smoke-all/extensions/contract-return-coercions/test.qmd
@@ -9,8 +9,10 @@ _quarto:
         # `strong[^>]*>` not `strong>`: the hub preview renders with
         # `source-location: full`, which puts data-sid/data-loc on the opening
         # tag, so the text no longer sits flush against `>`. Both renderers
-        # must satisfy this pattern. `!str` keeps the `[...]` from being parsed
-        # as markdown reference-link syntax, which emits a warning.
+        # must satisfy this pattern. `!str` stops the value being parsed as
+        # markdown, where the `*` quantifier reads as an unclosed emphasis
+        # marker and emits [Q-1-20]. (The brackets are harmless on their own;
+        # the same pattern with `+` instead of `*` parses clean.)
         - ["RET-STRING", !str "strong[^>]*>RET-INLINE", "RET-INLINES", "RET-BLOCK", "RET-BLOCKS-1", "RET-BLOCKS-2", "RET-ARRAY"]
 ---
 

--- a/crates/quarto/tests/smoke-all/quarto-test/callout-title-attribute.qmd
+++ b/crates/quarto/tests/smoke-all/quarto-test/callout-title-attribute.qmd
@@ -10,8 +10,11 @@ _quarto:
         # The `[^>]*` slots absorb data-sid/data-loc: the hub preview renders
         # with `source-location: full`, so every tag here carries them, while
         # the native runner renders without. These patterns must hold on both.
-        # `!str` keeps the `[...]` and `<...>` from being parsed as markdown
-        # (reference-link syntax / raw HTML), which emits warnings.
+        # `!str` stops the values being parsed as markdown. Two things would
+        # warn here: the `*` quantifier reads as an unclosed emphasis marker,
+        # and the literal `<span>`/`<code>` read as raw HTML — both surface as
+        # [Q-1-20]. (Brackets alone are harmless; swapping `*` for `+` clears
+        # the first warning but not the second.)
         - [!str '<span class="screen-reader-only"[^>]*>Note</span>Off-Host Execution', !str "<code[^>]*>renv</code>"]
         # Negative guard: the pre-fix behavior dropped title= and left the
         # bare callout type as the heading. `[^>]*` matters here too — without


### PR DESCRIPTION
Follow-up to #503. Comments only — no pattern, assertion, or workflow
logic changed.

Braid: bd-nhn7snpg

## What was wrong

The comments I added in #503 named the wrong trigger. They said `[...]`
reads as markdown reference-link syntax and warns. It doesn't — `a[b]c`
parses clean in both metadata and body. I asserted it twice without
isolating the variable.

The actual trigger is the `*` quantifier, read as an unclosed emphasis
marker → `[Q-1-20] Failed to parse metadata value as markdown`.
Verified by swapping the quantifier:

| Pattern | Result |
|---|---|
| `strong[^>]*>_bringit_` | `[Q-1-20]` |
| `strong[^>]+>_bringit_` | clean |
| `<code[^>]*>renv</code>` | `[Q-1-20]` |
| `<code[^>]+>renv</code>` | `[Q-1-20]` (still — the literal `<code>` warns as raw HTML) |

So `callout-title-attribute` has two independent reasons for `!str`;
the contract fixtures have one. Comments now say so.

`!str` was and remains the right fix. Only the explanation was wrong.

## Also filed

bd-ysvldsa5, for the one genuine inconsistency found while isolating
this: `{a, b, c}` parses clean in the body but warns in metadata — same
input, different verdict by position. The `*` and `<...>` cases are
*not* defects; they're consistent with qmd's deliberate dialect
strictness (unclosed emphasis is a hard error in the body, `Q-2-12`, so
metadata warning on it is if anything the lenient path).

## Verification

`git diff` touches nothing but `#` lines; all three fixtures still pass
the native runner (1 passed / 0 failed each).

Note this PR touches smoke-all fixtures, so the gate added in #503 fires
here — the Playwright smoke-all leg should run and go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)