### PR TITLE
Give navigation item text: markdown semantics; fix page-footer item model

### DIFF
--- a/claude-notes/plans/2026-08-11-navigation-item-text-markdown-investigation/md-tag-control/_quarto.yml
+++ b/claude-notes/plans/2026-08-11-navigation-item-text-markdown-investigation/md-tag-control/_quarto.yml
@@ -1,0 +1,12 @@
+# q2-only control: with an explicit `!md` tag, footer item text: behaves
+# correctly — markdown parsed, entities resolved, shortcodes substituted.
+# Quarto 1 rejects the !md tag, so this cannot live in the parent config.
+project:
+  type: website
+
+website:
+  title: "!md control"
+  page-footer:
+    right:
+      - text: !md "Tagged &copy; <b>2026</b> *emph* {{< env REPRO_YEAR >}}"
+        href: "https://example.com/tagged"

--- a/claude-notes/plans/2026-08-11-navigation-item-text-markdown-investigation/md-tag-control/index.qmd
+++ b/claude-notes/plans/2026-08-11-navigation-item-text-markdown-investigation/md-tag-control/index.qmd
@@ -1,0 +1,5 @@
+---
+title: Home
+---
+
+Body text.

--- a/claude-notes/plans/2026-08-11-navigation-item-text-markdown-investigation/observed-output.txt
+++ b/claude-notes/plans/2026-08-11-navigation-item-text-markdown-investigation/observed-output.txt
@@ -1,0 +1,95 @@
+q2 @ 6dc835c2 (v0.17.0), REPRO_YEAR=2026
+============================================================
+<footer class="footer">
+  <div class="container-fluid">
+    <div class="nav-footer">
+    <div class="nav-footer-left">
+      <ul class="nav footer-items">
+        <li class="nav-item"><a href="https://example.com" class="nav-link">&lt;img src=&quot;logo.svg&quot; alt=&quot;Logo&quot; width=&quot;65px&quot; class=&quot;footer-logo&quot;&gt;</a></li>
+        <li class="nav-item"><a href="Copyright &amp;copy; 2015-{{&lt; env REPRO_YEAR &gt;}} Example, Inc. All Rights Reserved." class="nav-link"></a></li>
+      </ul>
+    </div>
+    <div class="nav-footer-center">Copyright © <b>2015</b>-2026 <em>Example</em>, Inc.</div>
+    <div class="nav-footer-right">
+      <ul class="nav footer-items">
+        <li class="nav-item"><a href="https://example.com/support" class="nav-link">Support</a></li>
+        <li class="nav-item"><a href="#" class="nav-link" aria-label="Cookie Prefs">&lt;a href=&quot;#&quot; id=&quot;open_preferences_center&quot;&gt;Cookie Preferences&lt;/a&gt;</a></li>
+      </ul>
+    </div>
+    </div>
+  </div>
+</footer>
+
+navbar item:
+<li class="nav-item"><a href="https://example.com" class="nav-link">Navbar &amp;copy; &lt;b&gt;bold&lt;/b&gt; *emph* {{&lt; env REPRO_YEAR &gt;}}</a></li>
+      </ul>
+    </div>
+  
+
+sidebar item:
+menu-text">Sidebar &amp;copy; *emph*</span></a>
+        </div>
+      </li>
+    </ul>
+  </div>
+</nav>
+
+<main class="conte
+
+!md control (separate project):
+<li class="nav-item"><a href="https://example.com/tagged" class="nav-link">Tagged © <b>2026</b> <em>emph</em> 2026</a></li>
+      </ul>
+    </div>
+    </div>
+  </div>
+</footer>
+</b
+
+
+Quarto 1 (v99.9.9 dev), REPRO_YEAR=2026
+============================================================
+<footer class="footer">
+  <div class="nav-footer">
+    <div class="nav-footer-left">
+      <ul class="footer-items list-unstyled">
+    <li class="nav-item">
+    <a class="nav-link" href="https://example.com">
+<p><img src="logo.svg" alt="Logo" width="65px" class="footer-logo"></p>
+</a>
+  </li>  
+    <li class="nav-item">
+ Copyright © 2015-2026 Example, Inc. All Rights Reserved.
+  </li>  
+</ul>
+    </div>   
+    <div class="nav-footer-center">
+<p>Copyright © <b>2015</b>-2026 <em>Example</em>, Inc.</p>
+</div>
+    <div class="nav-footer-right">
+      <ul class="footer-items list-unstyled">
+    <li class="nav-item">
+    <a class="nav-link" href="https://example.com/support">
+<p>Support</p>
+</a>
+  </li>  
+    <li class="nav-item">
+ <a href="#" id="open_preferences_center">Cookie Preferences</a>
+  </li>  
+</ul>
+    </div>
+  </div>
+</footer>
+
+navbar+sidebar items:
+menu-text">Navbar © <b>bold</b> <em>emph</em> 2026</span></a>
+  </li>  
+</ul>
+          </div> <!-- /navcollapse -->
+   
+menu-text">Sidebar © *emph*</span></a>
+  </div>
+</li>
+    </ul>
+    </div>
+</nav>
+<div id="quarto-sidebar-glass" class="

--- a/claude-notes/plans/2026-08-11-navigation-item-text-markdown-investigation/repro/_quarto.yml
+++ b/claude-notes/plans/2026-08-11-navigation-item-text-markdown-investigation/repro/_quarto.yml
@@ -1,0 +1,35 @@
+project:
+  type: website
+
+website:
+  title: "Footer items"
+  page-footer:
+    left:
+      # 1. text: is HTML-escaped instead of rendered
+      - text: <img src="logo.svg" alt="Logo" width="65px" class="footer-logo">
+        href: "https://example.com"
+      # 2. a bare-string item lands in href= with an empty link body
+      - Copyright &copy; 2015-{{< env REPRO_YEAR >}} Example, Inc. All Rights Reserved.
+    # control: the same string in center: renders correctly
+    center: |
+      Copyright &copy; <b>2015</b>-{{< env REPRO_YEAR >}} *Example*, Inc.
+    right:
+      - text: Support
+        href: "https://example.com/support"
+      # 3. an item with no href: is still wrapped in an anchor (href="#"),
+      #    so markup carrying its own <a> nests anchors once unescaped
+      - text: '<a href="#" id="open_preferences_center">Cookie Preferences</a>'
+        aria-label: "Cookie Prefs"
+      # (the `!md`-tagged control lives in md-tag-control/, because Quarto 1
+      #  rejects the q2-only !md tag and would not parse this file at all)
+
+  # Same defect, same field, different consumer: navbar and sidebar item
+  # text: is escaped identically, so this is not page-footer-specific.
+  navbar:
+    left:
+      - text: "Navbar &copy; <b>bold</b> *emph* {{< env REPRO_YEAR >}}"
+        href: "https://example.com"
+  sidebar:
+    contents:
+      - text: "Sidebar &copy; *emph*"
+        href: "https://example.com"

--- a/claude-notes/plans/2026-08-11-navigation-item-text-markdown-investigation/repro/index.qmd
+++ b/claude-notes/plans/2026-08-11-navigation-item-text-markdown-investigation/repro/index.qmd
@@ -1,0 +1,5 @@
+---
+title: Home
+---
+
+Body text.

--- a/claude-notes/plans/2026-08-11-navigation-item-text-markdown.md
+++ b/claude-notes/plans/2026-08-11-navigation-item-text-markdown.md
@@ -3,7 +3,16 @@
 **Date:** 2026-08-11
 **Braid:** bd-page-footer-items-f4th80mj (bug, P1, labels `parity` / `websites`)
 **Branch:** written on `main` @ `6dc835c2` in the main checkout (`/Users/cscheid/rooms/room-1/q2`). No worktree/branch was created — see "Where to do the work".
-**Status:** Investigation — pending design alignment with user. **Do not start implementation until the user gives the go-ahead.**
+**Status:** Design settled 2026-08-11 (all six questions answered by Carlos — see "Settled decisions"). Implementation in progress on branch `braid/bd-page-footer-items-f4th80mj-nav-item-text`.
+
+## Settled decisions (2026-08-11)
+
+1. **Mechanism: `MARKDOWN_CONFIG_PATHS`.** Confirmed. `ANNOTATIONS` in pampa is not touched.
+2. **Blast radius: option (b)** — the whole navigation item `text:` slice, including nested navbar `menu:` and all sidebar `contents` levels. *Not* in scope: `about.links[].text`, navbar tools, `website.sidebar.header/footer`, `margin-header/footer`, `body-header/footer`, `announcement`. Also deliberately out of scope: sidebar `section:` (a display-text sibling of `text:`, but it additionally feeds section identity, so it deserves its own check) — **follow-up strand filed**.
+3. **Sidebar: option (a)** — unify on markdown everywhere. q2 deliberately diverges from Q1's entities-only sidebar; that inconsistency is a Q1 bug we are comfortable not reproducing.
+4. **Inline parse** for item `text:`. q2's existing `center:` already omits Q1's `<p>`, so inline is the internally-consistent choice and avoids `<p>` inside `<a>`.
+5. **Recursive descent: option (a)**, with guards. Add a `**` segment to the pattern language, but bound the descent at an obviously-artificial depth (32) and emit a diagnostic rather than risking stack overflow. **Q-1-27 "Config Nesting Too Deep" already exists in the catalog as an un-emitted stub with a docs page** — wire it up rather than minting a new code. Carlos flagged a concern that the pattern language is growing; **regroup if the blast radius turns out to be large.**
+6. **Branch, not worktree** — `braid/bd-page-footer-items-f4th80mj-nav-item-text`. Needs a PR and review.
 
 ## Triage verdict
 

--- a/claude-notes/plans/2026-08-11-navigation-item-text-markdown.md
+++ b/claude-notes/plans/2026-08-11-navigation-item-text-markdown.md
@@ -2,8 +2,8 @@
 
 **Date:** 2026-08-11
 **Braid:** bd-page-footer-items-f4th80mj (bug, P1, labels `parity` / `websites`)
-**Branch:** written on `main` @ `6dc835c2` in the main checkout (`/Users/cscheid/rooms/room-1/q2`). No worktree/branch was created — see "Where to do the work".
-**Status:** Design settled 2026-08-11 (all six questions answered by Carlos — see "Settled decisions"). Implementation in progress on branch `braid/bd-page-footer-items-f4th80mj-nav-item-text`.
+**Branch:** `braid/bd-page-footer-items-f4th80mj-nav-item-text`, off `main` @ `6516a330`, in the main checkout (`/Users/cscheid/rooms/room-1/q2`) — no worktree, per decision 6. Investigation was committed on `main` first (`6632884b`).
+**Status:** **Implemented and verified.** All six design questions answered by Carlos (see "Settled decisions"); all five defects fixed and verified end-to-end; full workspace suite green. Awaiting PR + review.
 
 ## Settled decisions (2026-08-11)
 
@@ -230,6 +230,11 @@ Contents depend on the design answers below; ordering does not.
 - **Phase 5 — E2E verification + docs.** Render the committed repro through `q2 render`, diff against the Q1 baseline captured in `observed-output.txt`, and record the invocation + observed markup per the end-to-end verification rule. Re-check the Connect-docs site if convenient.
 
 ## Open design questions for the user
+
+> **All six were answered on 2026-08-11** — see "Settled decisions" at the
+> top for the answers as implemented. Kept below as the record of what was
+> asked and what each option would have meant. Note that question 2's
+> answer was later *refined by measurement*: see "Q1's bare-scalar rule".
 
 1. **Mechanism — confirm the registry.** Do you agree this belongs in `MARKDOWN_CONFIG_PATHS` (per the 2026-08-10 Design decision #2) rather than in pampa's `ANNOTATIONS`, contrary to the handoff's suggestion? *Recommendation: yes, registry.*
 

--- a/claude-notes/plans/2026-08-11-navigation-item-text-markdown.md
+++ b/claude-notes/plans/2026-08-11-navigation-item-text-markdown.md
@@ -1,0 +1,166 @@
+# Navigation item `text:` is HTML-escaped; bare-string page-footer item becomes an empty link (bd-page-footer-items-f4th80mj)
+
+**Date:** 2026-08-11
+**Braid:** bd-page-footer-items-f4th80mj (bug, P1, labels `parity` / `websites`)
+**Branch:** written on `main` @ `6dc835c2` in the main checkout (`/Users/cscheid/rooms/room-1/q2`). No worktree/branch was created — see "Where to do the work".
+**Status:** Investigation — pending design alignment with user. **Do not start implementation until the user gives the go-ahead.**
+
+## Triage verdict
+
+**Ready to design** — all five defects reproduce at HEAD, both root causes are confirmed empirically, and the fix mechanism is one the repo has *already designed and aligned on*; what remains is four scoping decisions, not open-ended research.
+
+The single most consequential finding: **the handoff's suggested fix direction points at the wrong mechanism.** It proposes extending `ANNOTATIONS` in `crates/pampa/src/pandoc/meta_annotations.rs` (load-time, per-key-path interpretation). But bd-shortcodes-in-metadata-bp06aub8 already built a *second*, purpose-built mechanism for exactly this class of bug — `ConfigMarkdownTransform` / `MARKDOWN_CONFIG_PATHS` in `crates/quarto-core/src/transforms/config_markdown.rs` — and its plan (`claude-notes/plans/2026-08-10-shortcodes-website-config-includes.md`, Design decision #2) explicitly (a) rejects the load-time approach and (b) names **item `text:` fields** as the intended growth path, "one-line additions". This strand is that growth step. Details in "Two mechanisms" below.
+
+## Issue context
+
+Filed 2026-08-11 by Carlos Scheidegger, one day old, no staleness concerns. Five defects in how `_quarto.yml` navigation item `text:` is interpreted and rendered, none of which emits a warning:
+
+1. `text:` is HTML-escaped instead of rendered as markdown/HTML.
+2. A bare-string page-footer item lands in `href=` with an **empty** link body.
+3. Shortcodes (`{{< env … >}}`) stay literal in item strings.
+4. Named entities (`&copy;`) stay literal there.
+5. An item with `text:` but no `href:` is still wrapped in `<a href="#">`.
+
+Real-world hit: the Posit Connect docs port, all 352 pages, on the most-seen chrome of the site.
+
+**(5) is a sequencing constraint, not an independent nice-to-have.** The cookie-preferences pattern carries its own `<a>` inside `text:`. Once (1) is fixed, that `<a>` becomes real markup inside q2's unconditional wrapping anchor — **nested anchors, invalid HTML**. (5) must land in the same pass as (1), and the test suite should pin that specific combination.
+
+## Dependency graph
+
+`braid dep tree` / `dep list` return **nothing** — the strand is an isolated node. That changes the calculus in two ways: no incoming urgency from dependents, and no `discovered-from` parent carrying the "why was this filed" context. The context instead lives in the strand's own (unusually thorough) description and in the referenced repro.
+
+Two strands are named in the description but *not* linked as edges; both are worth linking:
+
+- **bd-v7ixzsp5** (closed 2026-08-10, "Listing contents globs") — introduced the `ANNOTATIONS` key-path table the handoff proposes to extend. Reading its plan is what surfaced that a *different* mechanism supersedes it for this case.
+- **bd-shortcodes-in-metadata-bp06aub8** — introduced `ConfigMarkdownTransform`. Its plan is the design authority for this strand. Its status should be checked; if open, this strand plausibly belongs under it.
+
+Also named in that plan as adjacent gaps, not in scope here: **bd-fz6gwfq0** (Q1's text-level shortcode contexts: code, attributes, image `src`, link targets) and **bd-1fue1ly5** (listing markdown).
+
+## What the code looks like today
+
+Every path in the description still exists with the described shape; nothing has been refactored out from under it.
+
+### Reproduced at HEAD (not inferred)
+
+`cargo build --bin q2` at `6dc835c2`, then `REPRO_YEAR=2026 q2 render` on a copy of the repro. All five defects present. Full markup in `2026-08-11-navigation-item-text-markdown-investigation/observed-output.txt`; the repro configs are committed alongside it.
+
+q2 today:
+
+```html
+<div class="nav-footer-left">
+  <ul class="nav footer-items">
+    <li class="nav-item"><a href="https://example.com" class="nav-link">&lt;img src=&quot;logo.svg&quot; …&gt;</a></li>   <!-- (1) -->
+    <li class="nav-item"><a href="Copyright &amp;copy; 2015-{{&lt; env REPRO_YEAR &gt;}} …" class="nav-link"></a></li>    <!-- (2),(3),(4) -->
+  </ul>
+</div>
+<div class="nav-footer-center">Copyright © <b>2015</b>-2026 <em>Example</em>, Inc.</div>                                 <!-- control: correct -->
+<div class="nav-footer-right">
+  <ul class="nav footer-items">
+    <li class="nav-item"><a href="https://example.com/support" class="nav-link">Support</a></li>
+    <li class="nav-item"><a href="#" class="nav-link" aria-label="Cookie Prefs">&lt;a href=&quot;#&quot; …&gt;…&lt;/a&gt;</a></li>  <!-- (5) + nesting hazard -->
+  </ul>
+</div>
+```
+
+Navbar and sidebar are escaped identically — confirming the strand's "not page-footer-specific" claim:
+
+```html
+<li class="nav-item"><a href="https://example.com" class="nav-link">Navbar &amp;copy; &lt;b&gt;bold&lt;/b&gt; *emph* {{&lt; env REPRO_YEAR &gt;}}</a></li>
+<span class="menu-text">Sidebar &amp;copy; *emph*</span>
+```
+
+### Quarto 1 reference, re-measured here (v99.9.9 dev checkout)
+
+Two Q1 behaviors matter beyond what the strand records:
+
+```html
+<li class="nav-item">
+  <a class="nav-link" href="https://example.com">
+    <p><img src="logo.svg" alt="Logo" width="65px" class="footer-logo"></p>   <!-- NOTE: <p> — Q1 parses item text as BLOCKS -->
+  </a>
+</li>
+<li class="nav-item">
+  Copyright © 2015-2026 Example, Inc. All Rights Reserved.                     <!-- bare string: plain <li>, no anchor -->
+</li>
+<li class="nav-item">
+  <a href="#" id="open_preferences_center">Cookie Preferences</a>              <!-- href-less: NO wrapping anchor -->
+</li>
+```
+
+- **Q1 wraps footer item text in `<p>`** (block parse). q2's `center:` region emits no `<p>` today. So "match Q1" is ambiguous here — see design question 4.
+- **Q1's sidebar really does resolve entities but not markdown**: `Sidebar © *emph*` — entity resolved, `*emph*` literal. Confirmed empirically, and it *contradicts* the Q1 source survey in the 2026-08-10 plan (which lists `website.sidebar.contents[].text` as going through the markdown envelope). Q1 is internally inconsistent between navbar (`Navbar © <b>bold</b> <em>emph</em> 2026`) and sidebar. Design question 3.
+
+### Root cause A — interpretation, not rendering (defects 1, 3, 4)
+
+`render_text` (`crates/quarto-navigation/src/render_html.rs:695`) is already correct: it walks `PandocInlines`/`PandocBlocks` and escapes only literal scalars. Item `text:` simply arrives as a literal scalar, because untagged strings in `InterpretationContext::ProjectConfig` stay literal (`crates/pampa/src/pandoc/meta.rs:177` `yaml_to_config_value_at`).
+
+Verified decisively with the `!md` control project — same string, explicit tag:
+
+```
+<li class="nav-item"><a href="…/tagged" class="nav-link">Tagged © <b>2026</b> <em>emph</em> 2026</a></li>
+```
+
+Entity, raw HTML, emphasis, **and** the shortcode all resolve. **The renderer needs no change for 1/3/4** — and, importantly, shortcode resolution comes along for free once the value is inlines, because `ShortcodeResolveTransform` walks `ast.meta`.
+
+### Two mechanisms — and why the registry is the right one
+
+| | `ANNOTATIONS` (pampa) | `MARKDOWN_CONFIG_PATHS` (quarto-core) |
+|---|---|---|
+| File | `pampa/src/pandoc/meta_annotations.rs` | `quarto-core/src/transforms/config_markdown.rs` |
+| When | YAML **load** time | `Normalization` transform over **merged** metadata |
+| Strand | bd-v7ixzsp5 (globs) | bd-shortcodes-in-metadata-bp06aub8 |
+| Purpose | keys whose value is *not markdown* (globs, paths) | website **presentation** strings that *are* markdown |
+| Array wildcard | arrays transparent (elements share parent path) | explicit `*` segment per array level |
+| Provenance | per-source-file | provenance-independent (profiles + frontmatter overrides already merged) |
+
+The 2026-08-10 plan's Design decision #2 chose the registry deliberately: *"Parse happens at transform time over merged metadata …, not at project-config load: one site, provenance-independent …, no `InterpretationContext` change"* — and named the growth path: *"item `text:` fields, hrefs, margin/body header/footer, about links… the table supports array-wildcard paths from day one so those are one-line additions."*
+
+The registry already contains `website.page-footer.left/center/right`, with the comment *"Item-list regions are arrays and therefore skipped"* — this bug is precisely that skipped case. `center:` works today for exactly this reason; the two regions of one feature disagree because one is blessed and the other isn't.
+
+Ordering also favours the registry: `ConfigMarkdownTransform` runs in `Normalization` (`pipeline.rs:1219`), before `ShortcodeResolveTransform`, and well before the `Generate`-phase transforms that parse `NavigationItem`s — so items are constructed from already-parsed inlines. The registry is registered once in the shared `build_transform_pipeline`, so render and preview both get the fix.
+
+**Recommendation: extend `MARKDOWN_CONFIG_PATHS`; do not touch `ANNOTATIONS`.**
+
+### Root cause B — item model and footer renderer (defects 2, 5)
+
+- `NavigationItem::from_config_value` (`crates/quarto-navigation/src/item.rs:76`) tries `cv.as_plain_text()` *first* and treats any bare scalar as a **file path** → `href`, `text: None`. Right for navbars/sidebars (`- about.qmd`), wrong for page-footer regions. `enrich_navigation_items` would normally backfill `text` from the project index, but a copyright sentence matches no document, so the anchor body stays empty.
+  **Note:** blessing the array-element path in the registry does *not* fix this on its own — `as_plain_text()` returns `Some` for `PandocInlines` too, so a bare item would still be flattened into `href`. Defect 2 needs a footer-specific parse rule regardless.
+- `render_footer_item` (`render_html.rs:678`) emits `<li class="nav-item"><a …>` unconditionally, defaulting `href` to `"#"`.
+  **Precedent already in the tree:** the sidebar solved exactly this with `SidebarEntry::Heading` — rendered at `render_html.rs:478`, pinned by a test at `render_html.rs:1525` ("Heading must not be wrapped in an anchor"). The footer should mirror that shape rather than invent one.
+
+## Pre-flight
+
+`cargo xtask verify --skip-hub-build` at `6dc835c2`: Rust legs green; hub-client `test:wasm` reported 3 failures (`includes/in-code-fence`, `quarto-test/callout-title-attribute` ×2). **These were stale-WASM artifacts of `--skip-hub-build`, not real breakage** — after `cd hub-client && npm run build:wasm`, `npm run test:wasm` is 131/131 green. HEAD is clean. (Worth remembering: `--skip-hub-build` leaves `test:wasm` running against whatever WASM was last built.)
+
+## Proposed phases (draft)
+
+Contents depend on the design answers below; ordering does not.
+
+- **Phase 0 — Tests first.** Unit tests in `config_markdown.rs` for each newly blessed path (including negative cases: `href`/`icon` must stay scalar). Renderer tests in `quarto-navigation` for the href-less item and the bare-string footer item. One end-to-end fixture covering footer + navbar + sidebar in a single `_quarto.yml`, driven through the real binary. **Explicitly include the nested-anchor case** (`text:` containing `<a>`, no `href:`). Verify all fail first.
+- **Phase 1 — Registry entries** for navigation item `text:` (defects 1/3/4). Scope per design questions 1–3.
+- **Phase 2 — Footer bare-scalar → text** (defect 2), via a footer-specific constructor rather than changing the shared bare-scalar rule that navbars and sidebars depend on.
+- **Phase 3 — href-less footer item renders without an anchor** (defect 5), mirroring `SidebarEntry::Heading`. Must land with Phase 1.
+- **Phase 4 — Sidebar decision** applied (Q1-bug-compatible vs unified), whichever design question 3 settles on.
+- **Phase 5 — E2E verification + docs.** Render the committed repro through `q2 render`, diff against the Q1 baseline captured in `observed-output.txt`, and record the invocation + observed markup per the end-to-end verification rule. Re-check the Connect-docs site if convenient.
+
+## Open design questions for the user
+
+1. **Mechanism — confirm the registry.** Do you agree this belongs in `MARKDOWN_CONFIG_PATHS` (per the 2026-08-10 Design decision #2) rather than in pampa's `ANNOTATIONS`, contrary to the handoff's suggestion? *Recommendation: yes, registry.*
+
+2. **Blast radius of blessed paths.** The repro needs footer + navbar + sidebar item `text:`. The 2026-08-10 survey lists a wider navigation slice: navbar `menu:` (nested dropdowns), navbar tools, `about.links[].text`, `website.sidebar.header/footer`, `website.margin-header/footer`, `website.body-header/footer`, `website.announcement`. Do we (a) bless only what the repro covers, (b) take the whole *navigation item `text:`* slice including nested menus, or (c) take the whole survey? *Recommendation: (b) — nested `menu:` items are the same field and would otherwise be an obvious follow-up bug report.*
+
+3. **Sidebar: copy Q1's inconsistency, or unify?** Q1 renders navbar item text as full markdown but sidebar item text as entities-only (measured, above). q2 has no "entities-only" interpretation; building one is a new mechanism for the sole purpose of reproducing what looks like a Q1 bug. Options: (a) unify — markdown everywhere, accept the divergence from Q1's sidebar; (b) match Q1 exactly, building entity-only decoding; (c) leave the sidebar untouched for now and file it separately. *Recommendation: (a). If you want Q1-exactness, it should be a separate strand with its own justification.*
+
+4. **Inline or block parse for item `text:`?** Q1 emits `<p>` inside footer item anchors (block). q2's blessed `center:` currently emits no `<p>`. Should item text parse as inline (consistent with q2's existing footer regions, cleaner markup inside an `<a>`) or as blocks (byte-closer to Q1, but `<p>` inside `<a>` inside `<li>`)? *Recommendation: inline — and note that q2's existing `center:` already diverges from Q1 here, so "inline" is the internally-consistent choice.*
+
+5. **Recursive nesting in the registry.** `website.sidebar.contents[].text` nests arbitrarily deep (`contents` → `contents` → …), but the registry's `*` matches exactly one array level, so recursion cannot be expressed as a finite list of patterns. Do we (a) add a recursive-descent segment (`**`) to the pattern language, (b) enumerate a bounded depth (3–4 levels, silently wrong deeper), or (c) special-case the sidebar walk? This question only bites if question 3 answers (a) or (b). *Recommendation: (a) if the sidebar is in scope — a bounded depth is the kind of silent cliff this codebase's lint rules exist to prevent.*
+
+6. **Where should the work happen?** This plan is committed on `main` in the main checkout; no branch or worktree was created (per skill policy). Given the change touches `quarto-core` + `quarto-navigation` and will churn navigation snapshots, a worktree via `cargo xtask create-worktree` seems right — but that's your call to set up.
+
+## Risks / tradeoffs (draft)
+
+- **Behavior change for existing sites, silently.** Blessing more paths means any existing site whose item `text:` happens to contain `*`, `_`, `<`, or `&…;` changes rendering with no warning. Same tradeoff the 2026-08-10 strand already accepted for `website.title`, so it's precedent rather than a new risk — but the repro set should include a "text that looks like markdown but wasn't meant to be" case so the behavior is pinned, not incidental.
+- **`!str` cannot opt out.** Per `config_markdown.rs`'s own module docs, a `!str`-tagged project-config string is indistinguishable from an untagged one after load. So there is *no* escape hatch for an author who wants literal `*text*` in an item label, beyond backslash-escaping. Worth deciding whether that's acceptable at this blast radius, or whether the registry needs a genuine opt-out first.
+- **Sequencing is load-bearing.** Fixing (1) without (5) actively *creates* invalid HTML (nested anchors) on the Connect docs. Do not split these across PRs.
+- **Snapshot churn** across `quarto-navigation` and any website-fixture snapshots. Per the repo's snapshot policy, count and summarize them in the commit message, and flag anything that changed for a reason other than "item text is now rendered".
+- **Two mechanisms remain in the tree** after this. Both are documented as temporary pending schema-driven interpretation. Someone will propose extending the wrong one again; a cross-reference note in `meta_annotations.rs` pointing at `config_markdown.rs` (and vice versa) would be cheap insurance. Worth filing as a follow-up chore.

--- a/claude-notes/plans/2026-08-11-navigation-item-text-markdown.md
+++ b/claude-notes/plans/2026-08-11-navigation-item-text-markdown.md
@@ -20,6 +20,38 @@
 
 The single most consequential finding: **the handoff's suggested fix direction points at the wrong mechanism.** It proposes extending `ANNOTATIONS` in `crates/pampa/src/pandoc/meta_annotations.rs` (load-time, per-key-path interpretation). But bd-shortcodes-in-metadata-bp06aub8 already built a *second*, purpose-built mechanism for exactly this class of bug — `ConfigMarkdownTransform` / `MARKDOWN_CONFIG_PATHS` in `crates/quarto-core/src/transforms/config_markdown.rs` — and its plan (`claude-notes/plans/2026-08-10-shortcodes-website-config-includes.md`, Design decision #2) explicitly (a) rejects the load-time approach and (b) names **item `text:` fields** as the intended growth path, "one-line additions". This strand is that growth step. Details in "Two mechanisms" below.
 
+## Q1's bare-scalar rule (measured 2026-08-11)
+
+The strand and the original handoff both described defect 2 as "a bare
+footer string should be display text". **Measurement refuted that**, and
+the correction shaped the implementation, so it is recorded here.
+
+Given a project containing `about.qmd` (title "About Us"):
+
+| `_quarto.yml` footer item | Q1 output |
+|---|---|
+| `- about.qmd` | `<a class="nav-link" href="./about.html"><p>About Us</p></a>` |
+| `- https://example.com` | plain `<li>` text |
+| `- nonexistent.qmd` | plain `<li>` text |
+| `- Copyright 2026 Example, Inc.` | plain `<li>` text |
+
+So the rule is **resolution-dependent**: a bare scalar is a link *iff* it
+names a project document, and display text otherwise — a bare external
+URL included. That is exactly what q2's `enrich_navigation_items` already
+computes, which is why a blanket "bare scalar is text" rule broke four
+existing tests that encode the resolving case.
+
+Implementation consequence: the parser cannot decide, because it has no
+project index. `NavigationItem::bare_text` carries the original
+`ConfigValue` as a fallback and `FooterGenerateTransform` demotes items
+enrichment failed to resolve.
+
+**One deliberate divergence.** Demotion runs only when a project index was
+actually consulted. In a single-file render no index is attached, so
+*nothing* would resolve and every bare footer item would demote to text on
+no evidence at all. There, q2 keeps today's behavior (bare scalar stays an
+href). Q1 parity in that corner is untested and unclaimed.
+
 ## Issue context
 
 Filed 2026-08-11 by Carlos Scheidegger, one day old, no staleness concerns. Five defects in how `_quarto.yml` navigation item `text:` is interpreted and rendered, none of which emits a warning:
@@ -140,6 +172,51 @@ Ordering also favours the registry: `ConfigMarkdownTransform` runs in `Normaliza
 ## Pre-flight
 
 `cargo xtask verify --skip-hub-build` at `6dc835c2`: Rust legs green; hub-client `test:wasm` reported 3 failures (`includes/in-code-fence`, `quarto-test/callout-title-attribute` ×2). **These were stale-WASM artifacts of `--skip-hub-build`, not real breakage** — after `cd hub-client && npm run build:wasm`, `npm run test:wasm` is 131/131 green. HEAD is clean. (Worth remembering: `--skip-hub-build` leaves `test:wasm` running against whatever WASM was last built.)
+
+## Implementation record (2026-08-11)
+
+- [x] **Phase 0 — Tests first.** Seven tests written and confirmed red at
+      `dad4397b` (two regression guards green from the start). Registry
+      tests in `config_markdown.rs`; renderer tests in `render_html.rs`;
+      parse test in `footer.rs`.
+- [x] **Phase 1 — Registry entries + `**` + depth bound.** 14 new entries
+      in `MARKDOWN_CONFIG_PATHS`. `**` matches zero or more levels through
+      arrays *and* maps; descent bounded at `MAX_CONFIG_DEPTH = 32`,
+      reporting `Q-1-27` (a catalogued but never-emitted code) once per
+      walk via a latch.
+- [x] **Phase 2 — Bare footer scalars.** `BareScalar::TextIfUnresolved` +
+      `NavigationItem::bare_text` + `demote_unresolved_bare_items`. See
+      "Q1's bare-scalar rule" — this deviates from the drafted phase
+      because measurement showed the drafted rule was wrong.
+- [x] **Phase 3 — href-less footer item.** `render_footer_item` emits the
+      label directly in the `<li>`.
+- [x] **Phase 4 — Sidebar.** Covered by the `**` entry; markdown
+      everywhere (decision 3a).
+- [x] **Phase 5 — E2E + docs.** Verified through the binary (below);
+      `docs/guides/authoring/shortcodes.qmd` updated to list item `text:`;
+      `docs/errors/yaml/Q-1-27.qmd` rewritten to describe the walk that
+      now emits it rather than a hypothetical loader bound.
+
+**End-to-end verification.** `REPRO_YEAR=2026 q2 render` on the committed
+repro, output inspected:
+
+```html
+<li class="nav-item"><a href="https://example.com" class="nav-link"><img src="logo.svg" alt="Logo" width="65px" class="footer-logo"></a></li>
+<li class="nav-item">Copyright © 2015-2026 Example, Inc. All Rights Reserved.</li>
+...
+<li class="nav-item"><a href="#" id="open_preferences_center">Cookie Preferences</a></li>
+```
+
+plus navbar `Navbar © <b>bold</b> <em>emph</em> 2026` and sidebar
+`Sidebar © <em>emph</em>`. All five defects fixed; the cookie-preferences
+item emits exactly one anchor. Full workspace suite green (11659); **no
+snapshot files changed**.
+
+**Known consequence.** Item `text:` containing raw HTML now raises the
+informational `Q-2-9` ("HTML element converted to raw HTML") — the repro
+went from 4 to 7 such warnings. This is the same diagnostic `center:` and
+`website.title` already raise for blessed keys, not a new noise source,
+but sites with `<img>` in footer items will see it on every render.
 
 ## Proposed phases (draft)
 

--- a/crates/quarto-core/src/transforms/config_markdown.rs
+++ b/crates/quarto-core/src/transforms/config_markdown.rs
@@ -23,7 +23,13 @@
 //!
 //! **Registry.** [`MARKDOWN_CONFIG_PATHS`] lists the blessed key paths.
 //! A segment of `*` matches every element of an array at that
-//! position. Only `Scalar(String)` values are re-parsed: values that
+//! position; a segment of `**` matches zero or more levels of nesting
+//! through arrays *and* maps, which is what lets one entry cover a
+//! sidebar's recursive `contents:` or a navbar's nested `menu:`. `**`
+//! descent is bounded by [`MAX_CONFIG_DEPTH`] and reports
+//! [`CODE_CONFIG_NESTING_TOO_DEEP`] past it, so a config that has
+//! nested inside itself cannot overflow the stack.
+//! Only `Scalar(String)` values are re-parsed: values that
 //! are already `PandocInlines`/`PandocBlocks` (authored in document
 //! frontmatter, or `!md`-tagged) pass through untouched, as do
 //! non-string scalars (`title: false`), `!path` values, maps, and
@@ -92,6 +98,27 @@ const MARKDOWN_CONFIG_PATHS: &[&[&str]] = &[
     &["page-footer", "left"],
     &["page-footer", "center"],
     &["page-footer", "right"],
+    // Navigation item `text:` (bd-page-footer-items-f4th80mj). `**`
+    // covers the navbar's nested `menu:` and the sidebar's recursive
+    // `contents:` in one entry each.
+    &["website", "page-footer", "**", "text"],
+    &["page-footer", "**", "text"],
+    &["website", "navbar", "left", "**", "text"],
+    &["website", "navbar", "right", "**", "text"],
+    &["navbar", "left", "**", "text"],
+    &["navbar", "right", "**", "text"],
+    &["website", "sidebar", "contents", "**", "text"],
+    &["sidebar", "contents", "**", "text"],
+    // Bare-string items in a page-footer region are display text, not
+    // paths (defect 2), so they get markdown semantics too. Spelled out
+    // per region rather than as `page-footer.**`, which would sweep in
+    // `border`, `background`, hrefs and icons.
+    &["website", "page-footer", "left", "*"],
+    &["website", "page-footer", "center", "*"],
+    &["website", "page-footer", "right", "*"],
+    &["page-footer", "left", "*"],
+    &["page-footer", "center", "*"],
+    &["page-footer", "right", "*"],
 ];
 
 /// AST transform: apply [`MARKDOWN_CONFIG_PATHS`] to merged metadata.
@@ -134,32 +161,82 @@ pub fn apply_markdown_config_paths(
     meta: &mut ConfigValue,
     diagnostics: &mut Vec<DiagnosticMessage>,
 ) {
+    let mut walk = Walk {
+        diagnostics,
+        depth_reported: false,
+    };
     for pattern in MARKDOWN_CONFIG_PATHS {
-        apply_pattern(meta, pattern, diagnostics);
+        apply_pattern(meta, pattern, 0, &mut walk);
     }
+}
+
+/// State threaded through the registry walk: the diagnostic sink, plus
+/// a latch so an over-deep config reports [`CODE_CONFIG_NESTING_TOO_DEEP`]
+/// once rather than once per node per pattern.
+struct Walk<'a> {
+    diagnostics: &'a mut Vec<DiagnosticMessage>,
+    depth_reported: bool,
 }
 
 /// Walk one pattern; at the end of the path, markdown-parse a
 /// scalar-string value in place.
-fn apply_pattern(
-    value: &mut ConfigValue,
-    pattern: &[&str],
-    diagnostics: &mut Vec<DiagnosticMessage>,
-) {
+///
+/// `depth` counts levels descended *into the value tree* (not pattern
+/// segments consumed), so the `**` descent below cannot outrun
+/// [`MAX_CONFIG_DEPTH`].
+fn apply_pattern(value: &mut ConfigValue, pattern: &[&str], depth: usize, walk: &mut Walk) {
+    if depth > MAX_CONFIG_DEPTH {
+        if !walk.depth_reported {
+            walk.depth_reported = true;
+            let mut diagnostic = DiagnosticMessage::warning(format!(
+                "Configuration nesting exceeds the maximum depth of {MAX_CONFIG_DEPTH}. \
+                 Quarto stopped applying markdown semantics below this point. This \
+                 usually means a generated configuration has nested inside itself."
+            ))
+            .with_code(CODE_CONFIG_NESTING_TOO_DEEP);
+            diagnostic.location = Some(value.source_info.clone());
+            walk.diagnostics.push(diagnostic);
+        }
+        return;
+    }
+
     let Some((head, rest)) = pattern.split_first() else {
-        parse_scalar_string_in_place(value, diagnostics);
+        parse_scalar_string_in_place(value, walk.diagnostics);
         return;
     };
+
+    // `**` — recursive descent. Matches zero or more levels of nesting
+    // through both arrays and maps, so one entry covers a sidebar's
+    // arbitrarily-nested `contents:` and a navbar's nested `menu:`.
+    if *head == "**" {
+        // Zero levels: try to match the remainder right here.
+        apply_pattern(value, rest, depth, walk);
+        // One or more: keep `**` in play and descend a level.
+        match &mut value.value {
+            ConfigValueKind::Map(entries) => {
+                for entry in entries {
+                    apply_pattern(&mut entry.value, pattern, depth + 1, walk);
+                }
+            }
+            ConfigValueKind::Array(items) => {
+                for item in items {
+                    apply_pattern(item, pattern, depth + 1, walk);
+                }
+            }
+            _ => {}
+        }
+        return;
+    }
 
     match &mut value.value {
         ConfigValueKind::Map(entries) => {
             if let Some(entry) = entries.iter_mut().find(|e| e.key == *head) {
-                apply_pattern(&mut entry.value, rest, diagnostics);
+                apply_pattern(&mut entry.value, rest, depth + 1, walk);
             }
         }
         ConfigValueKind::Array(items) if *head == "*" => {
             for item in items {
-                apply_pattern(item, rest, diagnostics);
+                apply_pattern(item, rest, depth + 1, walk);
             }
         }
         _ => {}

--- a/crates/quarto-core/src/transforms/config_markdown.rs
+++ b/crates/quarto-core/src/transforms/config_markdown.rs
@@ -57,6 +57,19 @@ use crate::Result;
 use crate::render::RenderContext;
 use crate::transform::{AstTransform, TransformPhase};
 
+/// Maximum config nesting the registry walk will descend through
+/// before giving up and reporting [`CODE_CONFIG_NESTING_TOO_DEEP`].
+///
+/// Deliberately large and obviously artificial: real sidebars nest a
+/// handful of levels, so anything approaching this is a generated
+/// config that has recursed into itself. The bound exists to keep the
+/// `**` descent (below) from turning a pathological config into a
+/// stack overflow.
+const MAX_CONFIG_DEPTH: usize = 32;
+
+/// `Q-1-27` — config nesting exceeds [`MAX_CONFIG_DEPTH`].
+const CODE_CONFIG_NESTING_TOO_DEEP: &str = "Q-1-27";
+
 /// Blessed config key paths whose scalar-string values get markdown
 /// semantics. `*` matches every element of an array. Keys that can be
 /// authored both at top level and under `website:` appear in both
@@ -277,6 +290,222 @@ mod tests {
             kind_at(&meta, &["navbar", "title"]),
             ConfigValueKind::Scalar(Yaml::Boolean(false))
         ));
+    }
+
+    // --- Navigation item `text:` (bd-page-footer-items-f4th80mj) ----
+
+    fn arr(items: Vec<ConfigValue>) -> ConfigValue {
+        ConfigValue::new_array(items, SourceInfo::for_test())
+    }
+
+    /// Build `contents: [{text: …, contents: [{…}]}]` nested `depth`
+    /// levels deep, with a `text:` at every level.
+    fn nested_contents(depth: usize) -> ConfigValue {
+        let mut inner = map(vec![("text", s("*leaf*"))]);
+        for _ in 0..depth {
+            inner = map(vec![("text", s("*node*")), ("contents", arr(vec![inner]))]);
+        }
+        arr(vec![inner])
+    }
+
+    /// Navbar item `text:` becomes inlines — at the top level and
+    /// inside a nested `menu:` (decision 2: the whole item-text slice).
+    #[test]
+    fn navbar_item_text_parses_including_nested_menu() {
+        let submenu = map(vec![("text", s("Sub &copy; *emph*")), ("href", s("s.qmd"))]);
+        let item = map(vec![
+            ("text", s("Top *emph*")),
+            ("menu", arr(vec![submenu])),
+        ]);
+        let mut meta = map(vec![(
+            "website",
+            map(vec![("navbar", map(vec![("left", arr(vec![item]))]))]),
+        )]);
+        let mut diags = Vec::new();
+        apply_markdown_config_paths(&mut meta, &mut diags);
+
+        let left = meta
+            .get_path(&["website", "navbar", "left"])
+            .and_then(|v| v.as_array().map(|a| a.to_vec()))
+            .expect("left is an array");
+        assert!(
+            matches!(
+                &left[0].get("text").unwrap().value,
+                ConfigValueKind::PandocInlines(_)
+            ),
+            "navbar item text should be inlines; got {:?}",
+            left[0].get("text").unwrap().value
+        );
+        let sub = left[0].get("menu").unwrap().as_array().unwrap()[0].clone();
+        assert!(
+            matches!(
+                &sub.get("text").unwrap().value,
+                ConfigValueKind::PandocInlines(_)
+            ),
+            "nested menu item text should be inlines; got {:?}",
+            sub.get("text").unwrap().value
+        );
+        // `href` must stay a literal scalar — never markdown-parsed.
+        assert!(matches!(
+            &sub.get("href").unwrap().value,
+            ConfigValueKind::Scalar(_)
+        ));
+    }
+
+    /// Sidebar item `text:` becomes inlines at every `contents:` level
+    /// (decision 3: unify on markdown; decision 5: `**` descent).
+    #[test]
+    fn sidebar_item_text_parses_at_every_contents_depth() {
+        let mut meta = map(vec![(
+            "website",
+            map(vec![(
+                "sidebar",
+                map(vec![("contents", nested_contents(3))]),
+            )]),
+        )]);
+        let mut diags = Vec::new();
+        apply_markdown_config_paths(&mut meta, &mut diags);
+
+        // Walk down the four levels, asserting `text` is inlines at each.
+        let mut node = meta
+            .get_path(&["website", "sidebar", "contents"])
+            .and_then(|v| v.as_array().map(|a| a[0].clone()))
+            .expect("contents[0]");
+        for level in 0..4 {
+            assert!(
+                matches!(
+                    &node.get("text").unwrap().value,
+                    ConfigValueKind::PandocInlines(_)
+                ),
+                "sidebar text at level {} should be inlines; got {:?}",
+                level,
+                node.get("text").unwrap().value
+            );
+            let Some(next) = node
+                .get("contents")
+                .and_then(|c| c.as_array().map(|a| a[0].clone()))
+            else {
+                break;
+            };
+            node = next;
+        }
+    }
+
+    /// Page-footer item lists: a map item's `text:` and a *bare string*
+    /// item both become inlines (defects 1–4).
+    #[test]
+    fn footer_item_text_and_bare_string_parse() {
+        let items = arr(vec![
+            map(vec![
+                ("text", s("<b>logo</b>")),
+                ("href", s("https://e.com")),
+            ]),
+            s("Copyright &copy; *Example*"),
+        ]);
+        let mut meta = map(vec![(
+            "website",
+            map(vec![("page-footer", map(vec![("left", items)]))]),
+        )]);
+        let mut diags = Vec::new();
+        apply_markdown_config_paths(&mut meta, &mut diags);
+
+        let left = meta
+            .get_path(&["website", "page-footer", "left"])
+            .and_then(|v| v.as_array().map(|a| a.to_vec()))
+            .expect("left is an array");
+        assert!(
+            matches!(
+                &left[0].get("text").unwrap().value,
+                ConfigValueKind::PandocInlines(_)
+            ),
+            "footer item text should be inlines; got {:?}",
+            left[0].get("text").unwrap().value
+        );
+        assert!(
+            matches!(&left[1].value, ConfigValueKind::PandocInlines(_)),
+            "bare-string footer item should be inlines; got {:?}",
+            left[1].value
+        );
+    }
+
+    /// Item keys that are never markdown (`href`, `icon`, `rel`,
+    /// `target`, `aria-label`) stay literal scalars.
+    #[test]
+    fn item_non_text_keys_stay_scalar() {
+        let item = map(vec![
+            ("text", s("T")),
+            ("href", s("a*b*.qmd")),
+            ("icon", s("github")),
+            ("rel", s("me")),
+            ("target", s("_blank")),
+            ("aria-label", s("A *label*")),
+        ]);
+        let mut meta = map(vec![(
+            "website",
+            map(vec![("navbar", map(vec![("right", arr(vec![item]))]))]),
+        )]);
+        let mut diags = Vec::new();
+        apply_markdown_config_paths(&mut meta, &mut diags);
+
+        let it = meta
+            .get_path(&["website", "navbar", "right"])
+            .and_then(|v| v.as_array().map(|a| a[0].clone()))
+            .unwrap();
+        for key in ["href", "icon", "rel", "target", "aria-label"] {
+            assert!(
+                matches!(&it.get(key).unwrap().value, ConfigValueKind::Scalar(_)),
+                "`{}` must stay a literal scalar; got {:?}",
+                key,
+                it.get(key).unwrap().value
+            );
+        }
+    }
+
+    /// Recursive descent is bounded: a pathologically deep config emits
+    /// `Q-1-27` instead of recursing without limit (decision 5).
+    #[test]
+    fn recursive_descent_is_depth_bounded() {
+        let mut meta = map(vec![(
+            "website",
+            map(vec![(
+                "sidebar",
+                map(vec![("contents", nested_contents(MAX_CONFIG_DEPTH + 20))]),
+            )]),
+        )]);
+        let mut diags = Vec::new();
+        apply_markdown_config_paths(&mut meta, &mut diags);
+
+        assert!(
+            diags
+                .iter()
+                .any(|d| d.code.as_deref() == Some(CODE_CONFIG_NESTING_TOO_DEEP)),
+            "expected a {} diagnostic; got {:?}",
+            CODE_CONFIG_NESTING_TOO_DEEP,
+            diags.iter().map(|d| d.code.clone()).collect::<Vec<_>>()
+        );
+    }
+
+    /// The depth bound does not fire for ordinary configurations, and
+    /// only one diagnostic is emitted per over-deep descent.
+    #[test]
+    fn depth_bound_silent_for_ordinary_nesting() {
+        let mut meta = map(vec![(
+            "website",
+            map(vec![(
+                "sidebar",
+                map(vec![("contents", nested_contents(4))]),
+            )]),
+        )]);
+        let mut diags = Vec::new();
+        apply_markdown_config_paths(&mut meta, &mut diags);
+
+        assert!(
+            !diags
+                .iter()
+                .any(|d| d.code.as_deref() == Some(CODE_CONFIG_NESTING_TOO_DEEP)),
+            "ordinary nesting must not trip the depth bound; got {:?}",
+            diags.iter().map(|d| d.code.clone()).collect::<Vec<_>>()
+        );
     }
 
     /// Footer per-region string form parses; array (item-list) regions

--- a/crates/quarto-core/src/transforms/footer_generate.rs
+++ b/crates/quarto-core/src/transforms/footer_generate.rs
@@ -85,12 +85,55 @@ impl AstTransform for FooterGenerateTransform {
             enrich_footer_region(&mut footer.left, index);
             enrich_footer_region(&mut footer.center, index);
             enrich_footer_region(&mut footer.right, index);
+
+            // Anything enrichment could not resolve to a project document
+            // is display text, not a link (bd-page-footer-items-f4th80mj,
+            // defect 2).
+            //
+            // Deliberately inside the index branch: demotion is a claim
+            // that we *looked* for a matching document and did not find
+            // one. With no index attached (single-file renders) nothing
+            // resolves, so demoting there would turn every bare footer
+            // item into text on no evidence at all.
+            demote_unresolved_bare_items(&mut footer.left);
+            demote_unresolved_bare_items(&mut footer.center);
+            demote_unresolved_bare_items(&mut footer.right);
         }
 
         ast.meta
             .insert_path(&["navigation", "footer"], footer.to_config_value());
 
         Ok(())
+    }
+}
+
+/// Turn every unresolved bare-scalar item in a region into display text
+/// (bd-page-footer-items-f4th80mj, defect 2).
+///
+/// A bare scalar in a page-footer region is provisionally parsed as an
+/// href so href resolution and index enrichment can run over it. If
+/// enrichment found a matching document it filled `text`, and the item
+/// stays a link. If `text` is still empty the scalar named no document —
+/// it is a copyright line, an external URL, or a stale path — and Q1
+/// renders it as plain `<li>` text. Previously q2 emitted an anchor whose
+/// target was the sentence and whose body was empty.
+///
+/// Only items carrying [`NavigationItem::bare_text`] are eligible, so an
+/// explicit `href:` that misses the index keeps its anchor. The caller
+/// must only invoke this when a project index was actually consulted —
+/// see the call site.
+fn demote_unresolved_bare_items(region: &mut FooterRegion) {
+    let FooterRegion::Items(items) = region else {
+        return;
+    };
+    for item in items.iter_mut() {
+        let Some(bare) = item.bare_text.take() else {
+            continue;
+        };
+        if item.text.is_none() {
+            item.text = Some(*bare);
+            item.href = None;
+        }
     }
 }
 
@@ -294,6 +337,86 @@ mod tests {
     }
 
     // --- Phase 3 enrichment tests ---------------------------------
+
+    /// Defect 2 (bd-page-footer-items-f4th80mj) — Q1's rule, measured:
+    /// a bare footer scalar that resolves to a project document stays a
+    /// link with that document's title; anything else becomes display
+    /// text with no href.
+    #[tokio::test]
+    async fn footer_generate_demotes_unresolved_bare_items_to_text() {
+        let footer_cv = config_map(vec![(
+            "left",
+            arr(vec![
+                str_value("about.qmd"),               // resolves → link
+                str_value("Copyright 2026 Example."), // no match → text
+                str_value("https://example.com"),     // external → text
+            ]),
+        )]);
+        let meta = config_map(vec![("page-footer", footer_cv)]);
+        let index = Arc::new(ProjectIndex::new(vec![profile("about.qmd", "About")]));
+        let out = run_transform_with(meta, Some(index)).await;
+        let stored = out.get_path(&["navigation", "footer"]).unwrap();
+        let left = stored.get("left").and_then(|v| v.as_array()).unwrap();
+
+        assert_eq!(
+            left[0]
+                .get("text")
+                .and_then(|v| v.as_plain_text())
+                .as_deref(),
+            Some("About"),
+            "resolving bare item keeps its link and gains a title; got {:?}",
+            left[0]
+        );
+        assert!(
+            left[0].get("href").is_some(),
+            "resolving bare item keeps its href; got {:?}",
+            left[0]
+        );
+
+        for (idx, expected) in [
+            (1usize, "Copyright 2026 Example."),
+            (2, "https://example.com"),
+        ] {
+            assert_eq!(
+                left[idx]
+                    .get("text")
+                    .and_then(|v| v.as_plain_text())
+                    .as_deref(),
+                Some(expected),
+                "unresolved bare item {} should become text; got {:?}",
+                idx,
+                left[idx]
+            );
+            assert!(
+                left[idx].get("href").is_none(),
+                "unresolved bare item {} must drop its href; got {:?}",
+                idx,
+                left[idx]
+            );
+        }
+    }
+
+    /// An *explicit* `href:` that matches no document keeps its anchor —
+    /// only bare scalars are eligible for demotion.
+    #[tokio::test]
+    async fn footer_generate_keeps_explicit_href_without_index_match() {
+        let item = config_map(vec![("href", str_value("https://example.com/support"))]);
+        let footer_cv = config_map(vec![("right", arr(vec![item]))]);
+        let meta = config_map(vec![("page-footer", footer_cv)]);
+        let index = Arc::new(ProjectIndex::new(vec![profile("about.qmd", "About")]));
+        let out = run_transform_with(meta, Some(index)).await;
+        let stored = out.get_path(&["navigation", "footer"]).unwrap();
+        let right = stored.get("right").and_then(|v| v.as_array()).unwrap();
+        assert_eq!(
+            right[0]
+                .get("href")
+                .and_then(|v| v.as_plain_text())
+                .as_deref(),
+            Some("https://example.com/support"),
+            "explicit href must survive; got {:?}",
+            right[0]
+        );
+    }
 
     /// Phase 3 test 37 — bare-href items in a footer Items region
     /// get `text` from the matching profile.

--- a/crates/quarto-navigation/src/footer.rs
+++ b/crates/quarto-navigation/src/footer.rs
@@ -268,6 +268,45 @@ mod tests {
         ConfigValue::new_array(items, SourceInfo::for_test())
     }
 
+    /// Defect 2 (bd-page-footer-items-f4th80mj) — in a page-footer
+    /// region a bare string is *display text*, not a file path. Q1
+    /// renders it as plain `<li>` text; q2 used to put it in `href=`
+    /// with an empty link body.
+    #[test]
+    fn bare_string_footer_item_is_text_not_href() {
+        let meta = map(vec![(
+            "page-footer",
+            map(vec![(
+                "left",
+                arr(vec![s("Copyright 2015-2026 Example, Inc.")]),
+            )]),
+        )]);
+        let footer = resolve_page_footer(&meta).unwrap();
+        let FooterRegion::Items(items) = &footer.left else {
+            panic!("expected items, got {:?}", footer.left);
+        };
+        assert_eq!(items.len(), 1);
+        assert!(
+            items[0].href.is_none(),
+            "bare footer string must not become an href; got {:?}",
+            items[0].href
+        );
+        assert_eq!(
+            items[0].text.as_ref().and_then(|t| t.as_plain_text()),
+            Some("Copyright 2015-2026 Example, Inc.".to_string()),
+            "bare footer string must become the item's text"
+        );
+    }
+
+    /// The bare-scalar-is-text rule is page-footer-specific: navbars
+    /// and sidebars still read `- about.qmd` as a link target.
+    #[test]
+    fn navbar_bare_string_is_still_an_href() {
+        let item = NavigationItem::from_config_value(&s("about.qmd")).unwrap();
+        assert_eq!(item.href.as_deref(), Some("about.qmd"));
+        assert!(item.text.is_none());
+    }
+
     #[test]
     fn resolve_absent() {
         let meta = map(vec![]);

--- a/crates/quarto-navigation/src/footer.rs
+++ b/crates/quarto-navigation/src/footer.rs
@@ -19,7 +19,7 @@ use quarto_pandoc_types::ConfigMapEntry;
 use quarto_pandoc_types::config_value::ConfigValue;
 use quarto_source_map::{By, SourceInfo};
 
-use crate::item::NavigationItem;
+use crate::item::{BareScalar, NavigationItem};
 
 /// Content of a single footer region (`left`, `center`, or `right`).
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -43,11 +43,18 @@ impl FooterRegion {
             return FooterRegion::Empty;
         };
 
-        // Arrays are items.
+        // Arrays are items. In a footer region a bare scalar is a link
+        // only if it resolves to a project document, and display text
+        // otherwise (bd-page-footer-items-f4th80mj, defect 2) — unlike
+        // navbars and sidebars, where `- about.qmd` is always a link.
+        // The resolution check needs the project index, so it happens
+        // later, in `FooterGenerateTransform`'s demotion pass.
         if let Some(arr) = cv.as_array() {
             let items: Vec<NavigationItem> = arr
                 .iter()
-                .filter_map(NavigationItem::from_config_value)
+                .filter_map(|item| {
+                    NavigationItem::from_config_value_with(item, BareScalar::TextIfUnresolved)
+                })
                 .collect();
             if items.is_empty() {
                 return FooterRegion::Empty;
@@ -268,12 +275,13 @@ mod tests {
         ConfigValue::new_array(items, SourceInfo::for_test())
     }
 
-    /// Defect 2 (bd-page-footer-items-f4th80mj) — in a page-footer
-    /// region a bare string is *display text*, not a file path. Q1
-    /// renders it as plain `<li>` text; q2 used to put it in `href=`
-    /// with an empty link body.
+    /// Defect 2 (bd-page-footer-items-f4th80mj) — a bare string in a
+    /// page-footer region is parsed as a *provisional* href that also
+    /// retains `bare_text`, so `FooterGenerateTransform` can demote it to
+    /// display text when it resolves to no project document. (The
+    /// demotion itself is tested in `footer_generate`.)
     #[test]
-    fn bare_string_footer_item_is_text_not_href() {
+    fn bare_string_footer_item_retains_bare_text_fallback() {
         let meta = map(vec![(
             "page-footer",
             map(vec![(
@@ -286,15 +294,14 @@ mod tests {
             panic!("expected items, got {:?}", footer.left);
         };
         assert_eq!(items.len(), 1);
-        assert!(
-            items[0].href.is_none(),
-            "bare footer string must not become an href; got {:?}",
-            items[0].href
-        );
         assert_eq!(
-            items[0].text.as_ref().and_then(|t| t.as_plain_text()),
-            Some("Copyright 2015-2026 Example, Inc.".to_string()),
-            "bare footer string must become the item's text"
+            items[0]
+                .bare_text
+                .as_ref()
+                .and_then(|t| t.as_plain_text())
+                .as_deref(),
+            Some("Copyright 2015-2026 Example, Inc."),
+            "bare footer string must retain a display-text fallback"
         );
     }
 

--- a/crates/quarto-navigation/src/item.rs
+++ b/crates/quarto-navigation/src/item.rs
@@ -61,6 +61,21 @@ pub struct NavigationItem {
     /// Nested menu items. Only populated for dropdown entries; typically empty.
     pub menu: Vec<NavigationItem>,
 
+    /// For a page-footer item authored as a *bare scalar*: the original
+    /// `ConfigValue`, retained so the item can fall back to display text
+    /// when its provisional `href` turns out not to name a project
+    /// document (bd-page-footer-items-f4th80mj, defect 2 — see
+    /// [`BareScalar::TextIfUnresolved`]).
+    ///
+    /// `None` for every other shape, including navbar/sidebar bare
+    /// scalars, which are unconditionally hrefs. Boxed to keep
+    /// `NavigationItem` small — this field is set on a minority of items.
+    ///
+    /// Consumed by the footer transform's demotion pass; it does not
+    /// roundtrip through `to_config_value` because demotion happens
+    /// before serialization.
+    pub bare_text: Option<Box<ConfigValue>>,
+
     /// Whether this item represents the currently-rendered page.
     /// Set by the `mark_active` pass in Generate transforms; read by
     /// Render transforms when emitting the `active` class on the anchor.
@@ -70,18 +85,64 @@ pub struct NavigationItem {
     pub active: bool,
 }
 
+/// How a *bare scalar* item (`- something`) should be read.
+///
+/// The two navigation regions disagree, and both readings are right for
+/// their context (bd-page-footer-items-f4th80mj, defect 2):
+///
+/// - Navbars and sidebars: `- about.qmd` always means "link to this
+///   page", so a bare scalar is an **href**.
+/// - Page-footer regions: Q1 decides by *resolution*. A bare scalar that
+///   names a project document becomes a link carrying that document's
+///   title; anything else — `Copyright © 2026 …`, a bare external URL,
+///   a path that matches no document — is display text. Measured
+///   against Q1 (see the plan's "Q1's bare-scalar rule" section).
+///
+/// Because that decision needs the project index, the parser cannot make
+/// it. [`BareScalar::TextIfUnresolved`] therefore records the scalar in
+/// [`NavigationItem::bare_text`] *and* keeps it as a provisional href, so
+/// enrichment can run normally; the footer transform then demotes any
+/// item enrichment failed to resolve.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum BareScalar {
+    /// A bare scalar is always a link target (navbar, sidebar).
+    #[default]
+    Href,
+    /// A bare scalar is a link target if it resolves to a project
+    /// document, and display text otherwise (page-footer regions).
+    TextIfUnresolved,
+}
+
 impl NavigationItem {
     /// Parse a single item from a `ConfigValue` in one of the three accepted
     /// shapes. Returns `None` if the shape is unrecognisable (e.g. a number).
+    ///
+    /// Bare scalars are read as hrefs; see
+    /// [`from_config_value_with`](Self::from_config_value_with) for the
+    /// page-footer reading.
     pub fn from_config_value(cv: &ConfigValue) -> Option<Self> {
-        // Bare path form: `- about.qmd`. The source_info travels with
-        // the bare ConfigValue itself (no wrapping map node).
+        Self::from_config_value_with(cv, BareScalar::Href)
+    }
+
+    /// Like [`from_config_value`](Self::from_config_value), but with an
+    /// explicit policy for bare scalars.
+    pub fn from_config_value_with(cv: &ConfigValue, bare: BareScalar) -> Option<Self> {
+        // Bare form: `- about.qmd` (href) or `- Copyright © …` (text).
+        // The source_info travels with the bare ConfigValue itself (no
+        // wrapping map node).
         if let Some(s) = cv.as_plain_text() {
-            // Only treat as a path if it isn't a map or array. `as_plain_text`
-            // already narrows to scalar-ish shapes, so this is safe.
+            // Only a scalar-ish shape reaches here — `as_plain_text`
+            // already narrows out maps and arrays.
             return Some(NavigationItem {
                 href: Some(s),
                 href_source: cv.source_info.clone(),
+                // Keep the whole `ConfigValue`, not the flattened string:
+                // by this point `ConfigMarkdownTransform` may have turned
+                // it into `PandocInlines`, and `render_text` needs those.
+                bare_text: match bare {
+                    BareScalar::Href => None,
+                    BareScalar::TextIfUnresolved => Some(Box::new(cv.clone())),
+                },
                 ..NavigationItem::default()
             });
         }
@@ -146,6 +207,9 @@ impl NavigationItem {
             target,
             menu,
             active,
+            // Object form: the author wrote explicit keys, so there is no
+            // bare scalar to fall back to.
+            bare_text: None,
         })
     }
 

--- a/crates/quarto-navigation/src/lib.rs
+++ b/crates/quarto-navigation/src/lib.rs
@@ -27,7 +27,7 @@ pub mod render_html;
 pub mod sidebar;
 
 pub use footer::{FooterBorder, FooterRegion, PageFooter, resolve_page_footer};
-pub use item::NavigationItem;
+pub use item::{BareScalar, NavigationItem};
 pub use navbar::{CollapseBelow, Navbar, NavbarTitle, TogglePosition, resolve_navbar};
 pub use page_nav::PageNavigation;
 pub use sidebar::{

--- a/crates/quarto-navigation/src/render_html.rs
+++ b/crates/quarto-navigation/src/render_html.rs
@@ -677,9 +677,21 @@ fn render_footer_region(html: &mut String, class: &str, region: &FooterRegion) {
 
 fn render_footer_item(item: &NavigationItem, indent: usize) -> String {
     let pad = " ".repeat(indent);
-    let mut attrs = link_attrs(item);
     let label = render_item_label(item);
-    let href = item.href.as_deref().unwrap_or("#");
+
+    // No href: emit the label directly in the `<li>`, with no wrapping
+    // anchor (bd-page-footer-items-f4th80mj, defect 5). Q1 does the same,
+    // and the sidebar already takes this shape for `SidebarEntry::Heading`.
+    //
+    // This is not cosmetic: item `text:` is markdown now, so a label
+    // carrying its own `<a>` — the common cookie-preferences pattern —
+    // would otherwise land *inside* this anchor and produce nested
+    // anchors, which is invalid HTML.
+    let Some(href) = item.href.as_deref() else {
+        return format!("{}<li class=\"nav-item\">{}</li>\n", pad, label);
+    };
+
+    let mut attrs = link_attrs(item);
     attrs.insert(0, format!("href=\"{}\"", escape_attr(href)));
     attrs.insert(1, "class=\"nav-link\"".to_string());
     format!(

--- a/crates/quarto-navigation/src/render_html.rs
+++ b/crates/quarto-navigation/src/render_html.rs
@@ -1254,6 +1254,95 @@ mod tests {
         assert!(html.contains("border-top: none"));
     }
 
+    // --- href-less footer items (bd-page-footer-items-f4th80mj) -----
+
+    /// Defect 5 — an item with `text:` but no `href:` renders its label
+    /// directly in the `<li>`, with no wrapping anchor. Mirrors Q1 and
+    /// the sidebar's existing `SidebarEntry::Heading` precedent.
+    #[test]
+    fn footer_item_without_href_renders_without_anchor() {
+        let footer = PageFooter {
+            left: FooterRegion::Items(vec![NavigationItem {
+                text: Some(s("Just text")),
+                ..NavigationItem::default()
+            }]),
+            ..PageFooter::default()
+        };
+        let html = page_footer_to_html(&footer);
+        assert!(
+            html.contains("Just text"),
+            "label should be present; html: {}",
+            html
+        );
+        assert!(
+            !html.contains("href=\"#\""),
+            "href-less footer item must not be wrapped in <a href=\"#\">; html: {}",
+            html
+        );
+        assert!(
+            !html.contains("<a "),
+            "href-less footer item must emit no anchor at all; html: {}",
+            html
+        );
+    }
+
+    /// Defect 5, the case that forces it to land with defect 1: item
+    /// text carrying its own `<a>` must not end up nested inside a
+    /// wrapping anchor (invalid HTML). This is the cookie-preferences
+    /// pattern from the Posit Connect docs.
+    #[test]
+    fn footer_item_with_own_anchor_does_not_nest_anchors() {
+        use quarto_pandoc_types::inline::RawInline;
+        let raw = |t: &str| {
+            Inline::RawInline(RawInline {
+                format: "html".to_string(),
+                text: t.to_string(),
+                source_info: SourceInfo::for_test(),
+            })
+        };
+        let text = ConfigValue::new_inlines(
+            vec![
+                raw("<a href=\"#\" id=\"open_preferences_center\">"),
+                str_inline("Cookie Preferences"),
+                raw("</a>"),
+            ],
+            SourceInfo::for_test(),
+        );
+        let footer = PageFooter {
+            right: FooterRegion::Items(vec![NavigationItem {
+                text: Some(text),
+                ..NavigationItem::default()
+            }]),
+            ..PageFooter::default()
+        };
+        let html = page_footer_to_html(&footer);
+        assert_eq!(
+            html.matches("<a ").count(),
+            1,
+            "exactly one anchor (the author's own) should survive; html: {}",
+            html
+        );
+    }
+
+    /// An item that *does* have an href keeps its anchor.
+    #[test]
+    fn footer_item_with_href_still_renders_anchor() {
+        let footer = PageFooter {
+            left: FooterRegion::Items(vec![NavigationItem {
+                href: Some("https://example.com".to_string()),
+                text: Some(s("Support")),
+                ..NavigationItem::default()
+            }]),
+            ..PageFooter::default()
+        };
+        let html = page_footer_to_html(&footer);
+        assert!(
+            html.contains("<a href=\"https://example.com\""),
+            "item with href keeps its anchor; html: {}",
+            html
+        );
+    }
+
     #[test]
     fn footer_escapes_literal_text() {
         let footer = PageFooter {

--- a/crates/wasm-quarto-hub-client/Cargo.lock
+++ b/crates/wasm-quarto-hub-client/Cargo.lock
@@ -377,7 +377,7 @@ dependencies = [
 
 [[package]]
 name = "comrak-to-pandoc"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "comrak",
  "hashlink",
@@ -2074,7 +2074,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-analysis"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "quarto-error-reporting",
  "quarto-pandoc-types",
@@ -2096,7 +2096,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-brand"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "pathdiff",
  "quarto-util",
@@ -2107,7 +2107,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-citeproc"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "glob",
  "hashlink",
@@ -2138,7 +2138,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-core"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2190,7 +2190,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-csl"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "quarto-error-reporting",
  "quarto-source-map",
@@ -2241,7 +2241,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-highlight"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "once_cell",
  "quarto-highlight-encoding",
@@ -2267,7 +2267,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-highlight-encoding"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2275,7 +2275,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-lsp-core"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "pampa",
  "pollster",
@@ -2296,7 +2296,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-navigation"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "quarto-config",
  "quarto-pandoc-types",
@@ -2331,7 +2331,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-project-create"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "quarto-doctemplate",
  "serde",
@@ -2341,7 +2341,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-sass"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "include_dir",
  "once_cell",
@@ -2371,7 +2371,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-system-runtime"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -2388,7 +2388,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-trace"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "flate2",
  "serde",
@@ -2406,7 +2406,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-util"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -2414,7 +2414,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-xml"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "quarto-error-reporting",
  "quarto-source-map",
@@ -4021,7 +4021,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-printf-fmt"
-version = "0.16.0"
+version = "0.17.0"
 
 [[package]]
 name = "wasm-quarto-hub-client"

--- a/docs/errors/yaml/Q-1-27.qmd
+++ b/docs/errors/yaml/Q-1-27.qmd
@@ -16,14 +16,22 @@ categories:
 
 ## What this means
 
-Quarto's configuration loader places a bound on how deeply nested
-a configuration can be. The bound is large enough that ordinary
-project configurations sit comfortably inside it; this error fires
-only when nesting reaches unusual depths.
+Quarto places a bound on how deeply nested a configuration can be
+when it walks the configuration to decide which values carry
+markdown — for example the `text:` of a navigation item, which may
+sit at any depth inside a sidebar's nested `contents:`. The bound is
+large enough that ordinary project configurations sit comfortably
+inside it; this warning fires only when nesting reaches unusual
+depths.
 
-The bound is in place to protect the loader from infinite or
-near-infinite structures that could arise from accidental
-self-reference in generated configurations.
+The bound protects Quarto from infinite or near-infinite structures
+that could arise from accidental self-reference in generated
+configurations.
+
+Configuration below the bound is still read normally. What stops is
+the markdown interpretation of values beneath that point: a `text:`
+nested deeper than the bound renders as literal text rather than as
+markdown.
 
 ## Why this happens
 

--- a/docs/guides/authoring/shortcodes.qmd
+++ b/docs/guides/authoring/shortcodes.qmd
@@ -33,9 +33,11 @@ Shortcodes resolve in:
 - **Document metadata** — any front-matter value, e.g. a `subtitle`
   that interpolates `{{{< env PRODUCT_VERSION >}}}`.
 - **Website configuration strings** in `_quarto.yml`:
-  `website.title`, the navbar and sidebar titles, and `page-footer`
-  text regions. These values are treated as markdown, so inline
-  formatting and raw HTML work there too.
+  `website.title`, the navbar and sidebar titles, `page-footer` text
+  regions, and the `text:` of individual navigation items — navbar
+  entries (including nested `menu:` items), sidebar `contents:` entries
+  at every level, and page-footer items. These values are treated as
+  markdown, so inline formatting and raw HTML work there too.
 - **Include files** (`include-in-header`, `include-before-body`,
   `include-after-body`, and `{text: …}` entries). Include files get
   *textual* substitution: the shortcode is replaced in place, but the


### PR DESCRIPTION
Fixes bd-page-footer-items-f4th80mj (P1, `parity`/`websites`). Real-world hit: the Posit Connect docs port, all 352 pages, on the most-seen chrome of the site.

## What was broken

Navigation item `text:` written in `_quarto.yml` was HTML-escaped instead of rendered, and a bare-string page-footer item became an unusable empty link. Five defects, none of which emitted a warning:

1. `text:` escaped, so markup showed as literal text.
2. A bare-string footer item landed in `href=` with an **empty** link body.
3. Shortcodes stayed literal in item strings.
4. Named entities stayed literal there.
5. An item with `text:` but no `href:` was still wrapped in `<a href="#">`.

Not page-footer-specific — navbar and sidebar item `text:` were escaped identically. Meanwhile `page-footer.center` already worked, so two regions of one feature disagreed.

**(5) had to land with (1).** The common cookie-preferences pattern carries its own `<a>` inside `text:`. Fixing the escaping alone would have put that anchor *inside* q2's unconditional wrapping anchor — nested anchors, invalid HTML, on every page.

## Approach

**Defects 1/3/4 were interpretation, not rendering.** `render_text` already walked `PandocInlines` correctly; item `text:` simply arrived as a literal scalar, because untagged strings stay literal in `ProjectConfig` context. Confirmed by control: `!md`-tagging the identical string rendered it perfectly, with no renderer change.

Fixed by extending **`MARKDOWN_CONFIG_PATHS`** in `quarto-core/src/transforms/config_markdown.rs` — the registry bd-shortcodes-in-metadata-bp06aub8 built for exactly this class, whose plan explicitly rejected load-time parsing and named item `text:` fields as the growth path. pampa's `ANNOTATIONS` table is untouched. (The original bug report proposed extending `ANNOTATIONS`; that would have been the wrong mechanism.)

New in the pattern language: a **`**` segment** matching zero or more levels of nesting through arrays *and* maps, so one entry covers the sidebar's recursive `contents:` and the navbar's nested `menu:`. Descent is bounded at `MAX_CONFIG_DEPTH = 32` and reports **`Q-1-27`** past it — a code that already existed in the catalog, with a docs page, but had never been emitted by anything. That page has been rewritten to describe what actually emits it.

**Defect 2 follows Q1's real rule, which measurement showed is _not_ "bare scalar is text".** Given a project containing `about.qmd`:

| footer item | Q1 |
| --- | --- |
| `- about.qmd` | link titled "About Us" |
| `- https://example.com` | plain `<li>` text |
| `- nonexistent.qmd` | plain `<li>` text |
| `- Copyright 2026 Example, Inc.` | plain `<li>` text |

So it is **resolution-dependent**: a link iff it names a project document, display text otherwise — bare external URLs included. A blanket "bare scalar is text" rule broke four existing tests that encode the resolving case (`enrich_navigation_items` exists precisely to give `- about.qmd` its title).

Since that decision needs the project index, the parser records the scalar in `NavigationItem::bare_text` as a fallback and keeps a provisional href so enrichment runs normally; `FooterGenerateTransform` then demotes whatever enrichment could not resolve. **Demotion runs only when an index was actually consulted** — with no index attached (single-file renders) nothing resolves, so demoting there would convert every bare footer item to text on no evidence. That corner keeps today's behavior and does not claim Q1 parity.

**Defect 5:** `render_footer_item` emits the label directly in the `<li>` when there is no href, mirroring Q1 and the sidebar's existing `SidebarEntry::Heading`.

## Deliberate divergences from Q1

- **Sidebar item text is markdown here.** Q1 resolves entities but does *not* parse markdown in sidebar item text (measured), while it does in the navbar. That inconsistency looks like a Q1 bug; matching it would mean building an entities-only interpretation q2 does not have.
- **Item text parses as inline, not blocks.** Q1 emits `<p>` inside footer item anchors. q2's existing blessed `center:` region already omits it, so inline is the internally-consistent choice and avoids `<p>` inside `<a>`.

## Verification

- `cargo xtask verify` — all 14 steps passed.
- Full workspace suite green (11659). **No snapshot files changed.** `cargo xtask lint` clean.
- **End-to-end through the real binary** (`REPRO_YEAR=2026 q2 render` on the committed repro), output inspected:

```html
<li class="nav-item"><a href="https://example.com" class="nav-link"><img src="logo.svg" alt="Logo" width="65px" class="footer-logo"></a></li>
<li class="nav-item">Copyright © 2015-2026 Example, Inc. All Rights Reserved.</li>
<li class="nav-item"><a href="#" id="open_preferences_center">Cookie Preferences</a></li>
```

  plus navbar `Navbar © <b>bold</b> <em>emph</em> 2026` and sidebar `Sidebar © <em>emph</em>`. The cookie-preferences item emits exactly one anchor.
- Docs site (`q2 render docs/`): 229 files, 25 warnings — all pre-existing `Q-13-4`/`Q-5-6`, no `Q-1-27`, nested sidebar intact.

Repro configs and the recorded q2/Q1 markup are committed under `claude-notes/plans/2026-08-11-navigation-item-text-markdown-investigation/`.

## Reviewer notes

- **Silent behavior change.** Any existing site whose item `text:` contains `*`, `_`, `<`, or `&…;` now renders differently, with no warning. Same tradeoff already accepted for `website.title`; `!str` cannot opt a blessed key out (pre-existing documented limitation of the mechanism). Probably worth a release note.
- **`Q-2-9` noise.** Item `text:` carrying raw HTML now raises the informational "HTML element converted to raw HTML" — the repro went 4 → 7. Same diagnostic `center:` and `website.title` already raise, but sites with `<img>` in footer items will see it every render. Happy to file a suppression for blessed config keys if reviewers want one.
- **One unrelated commit** rides along: `6516a330` syncs `crates/wasm-quarto-hub-client/Cargo.lock` to 0.17.0 (regenerated by `npm run build:wasm`; the lockfile still carried 0.16.0 for in-workspace crates). No dependency changes. Easy to drop.

Follow-ups filed: **bd-qzn1azon** (sidebar `section:`, the display-text sibling deliberately left out of scope) and **bd-xygsu15r** (cross-reference the two config-interpretation tables, since the wrong one was proposed once already).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
