### PR TITLE
Bump workspace version to 0.18.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "comrak-to-pandoc"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "comrak",
  "hashlink",
@@ -3536,7 +3536,7 @@ dependencies = [
 
 [[package]]
 name = "quarto"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3582,7 +3582,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-analysis"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "insta",
  "quarto-error-reporting",
@@ -3608,7 +3608,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-brand"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "pathdiff",
  "quarto-util",
@@ -3620,7 +3620,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-citeproc"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "glob",
  "hashlink",
@@ -3654,7 +3654,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-core"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3710,7 +3710,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-csl"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "insta",
  "quarto-error-reporting",
@@ -3738,7 +3738,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-error-catalog"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "once_cell",
  "quarto-error-reporting",
@@ -3774,7 +3774,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-highlight"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "hashlink",
  "insta",
@@ -3803,7 +3803,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-highlight-encoding"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3811,7 +3811,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-hub"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "automerge",
@@ -3855,7 +3855,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-hub-provider"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "automerge",
  "ciborium",
@@ -3881,7 +3881,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-lsp"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "insta",
@@ -3897,7 +3897,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-lsp-core"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "insta",
  "pampa",
@@ -3920,7 +3920,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-mcp-launcher"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -3936,7 +3936,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-navigation"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "quarto-config",
  "quarto-pandoc-types",
@@ -3971,7 +3971,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-preview"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "automerge",
@@ -4003,7 +4003,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-project-create"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "quarto-doctemplate",
  "serde",
@@ -4014,7 +4014,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-publish"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4039,7 +4039,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-sass"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "grass",
  "include_dir",
@@ -4062,7 +4062,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-source-fetch"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "flate2",
  "tar",
@@ -4085,7 +4085,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-system-runtime"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4103,7 +4103,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-test"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "quarto-core",
@@ -4120,7 +4120,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-trace"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "flate2",
  "serde",
@@ -4131,7 +4131,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-trace-server"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4158,7 +4158,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-util"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -4166,7 +4166,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-xml"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "insta",
  "quarto-error-reporting",
@@ -4386,7 +4386,7 @@ dependencies = [
 
 [[package]]
 name = "reconcile-viewer"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "clap",
  "hashlink",
@@ -6425,7 +6425,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-printf-fmt"
-version = "0.17.0"
+version = "0.18.0"
 
 [[package]]
 name = "wasmparser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.17.0"
+version = "0.18.0"
 authors = ["Posit Software, PBC"]
 homepage = "https://github.com/posit-dev/quarto-markdown-syntax"
 keywords = ["parser"]

--- a/crates/wasm-quarto-hub-client/Cargo.lock
+++ b/crates/wasm-quarto-hub-client/Cargo.lock
@@ -377,7 +377,7 @@ dependencies = [
 
 [[package]]
 name = "comrak-to-pandoc"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "comrak",
  "hashlink",
@@ -2074,7 +2074,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-analysis"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "quarto-error-reporting",
  "quarto-pandoc-types",
@@ -2096,7 +2096,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-brand"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "pathdiff",
  "quarto-util",
@@ -2107,7 +2107,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-citeproc"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "glob",
  "hashlink",
@@ -2138,7 +2138,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-core"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2190,7 +2190,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-csl"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "quarto-error-reporting",
  "quarto-source-map",
@@ -2241,7 +2241,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-highlight"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "once_cell",
  "quarto-highlight-encoding",
@@ -2267,7 +2267,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-highlight-encoding"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2275,7 +2275,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-lsp-core"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "pampa",
  "pollster",
@@ -2296,7 +2296,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-navigation"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "quarto-config",
  "quarto-pandoc-types",
@@ -2331,7 +2331,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-project-create"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "quarto-doctemplate",
  "serde",
@@ -2341,7 +2341,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-sass"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "include_dir",
  "once_cell",
@@ -2371,7 +2371,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-system-runtime"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -2388,7 +2388,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-trace"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "flate2",
  "serde",
@@ -2406,7 +2406,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-util"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -2414,7 +2414,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-xml"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "quarto-error-reporting",
  "quarto-source-map",
@@ -4021,7 +4021,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-printf-fmt"
-version = "0.17.0"
+version = "0.18.0"
 
 [[package]]
 name = "wasm-quarto-hub-client"


### PR DESCRIPTION
Version bump for the v0.18.0 release (13 commits since v0.17.0).

- Root `Cargo.toml` `[workspace.package].version` → `0.18.0`
- Both lockfiles refreshed: root `Cargo.lock` and
  `crates/wasm-quarto-hub-client/Cargo.lock` (that crate declares its own
  `[workspace]`, so a root `cargo update --workspace` does not reach it).
- `cargo build --bin q2 --locked` → `q2 (quarto 2) 0.18.0`
- `cargo xtask verify` (full, including the hub/WASM leg): all 14 steps
  passed, working tree left clean.

Lockfile diff contains workspace version entries only — no external
dependency movement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)