### PR TITLE
Bump samod to 0.13.0 and automerge to 3.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,16 +213,16 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "automerge"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b78abcbba93428b9465b26cb2816a5b4654cce507f099a84a8c1b311cb3633"
+checksum = "c1b59cbd9e7685a1ac6bf6046ddcd8acb550fa5bf03c09f6c1056728a742b40d"
 dependencies = [
  "cfg-if",
  "flate2",
  "getrandom 0.4.2",
  "hex",
  "hexane",
- "itertools",
+ "itertools 0.15.0",
  "leb128",
  "rand 0.10.1",
  "rustc-hash",
@@ -1935,9 +1935,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hexane"
-version = "0.2.1"
+version = "1.0.0-alpha.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f4ecba0bb4e14df997df7cab6d1b584c6432d8865cf2adfced814706d715a7b"
+checksum = "81df830f11babb0eee9a082e09135ef0a7d8791f3fe9b279bb9485bf7eaf23e0"
 dependencies = [
  "leb128",
  "thiserror 2.0.18",
@@ -2386,6 +2386,15 @@ name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
 dependencies = [
  "either",
 ]
@@ -4815,8 +4824,8 @@ dependencies = [
 
 [[package]]
 name = "samod"
-version = "0.12.3"
-source = "git+https://github.com/quarto-dev/samod.git?branch=access-policy#56c83568bb7a35d2cbdf322f67ccc5fb2fdc25e9"
+version = "0.13.0"
+source = "git+https://github.com/shikokuchuo/samod.git?branch=access-policy#067679615bb9d950d59a4e276ae4d3cfd7fa1e62"
 dependencies = [
  "async-channel",
  "automerge",
@@ -4838,8 +4847,8 @@ dependencies = [
 
 [[package]]
 name = "samod-core"
-version = "0.12.3"
-source = "git+https://github.com/quarto-dev/samod.git?branch=access-policy#56c83568bb7a35d2cbdf322f67ccc5fb2fdc25e9"
+version = "0.13.0"
+source = "git+https://github.com/shikokuchuo/samod.git?branch=access-policy#067679615bb9d950d59a4e276ae4d3cfd7fa1e62"
 dependencies = [
  "automerge",
  "base64 0.21.7",
@@ -6574,7 +6583,7 @@ dependencies = [
  "cranelift-frontend",
  "cranelift-native",
  "gimli",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "object",
  "pulley-interpreter",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4825,7 +4825,7 @@ dependencies = [
 [[package]]
 name = "samod"
 version = "0.13.0"
-source = "git+https://github.com/shikokuchuo/samod.git?branch=access-policy#067679615bb9d950d59a4e276ae4d3cfd7fa1e62"
+source = "git+https://github.com/quarto-dev/samod.git?branch=access-policy#067679615bb9d950d59a4e276ae4d3cfd7fa1e62"
 dependencies = [
  "async-channel",
  "automerge",
@@ -4848,7 +4848,7 @@ dependencies = [
 [[package]]
 name = "samod-core"
 version = "0.13.0"
-source = "git+https://github.com/shikokuchuo/samod.git?branch=access-policy#067679615bb9d950d59a4e276ae4d3cfd7fa1e62"
+source = "git+https://github.com/quarto-dev/samod.git?branch=access-policy#067679615bb9d950d59a4e276ae4d3cfd7fa1e62"
 dependencies = [
  "automerge",
  "base64 0.21.7",

--- a/crates/quarto-hub-provider/Cargo.toml
+++ b/crates/quarto-hub-provider/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/lib.rs"
 # Automerge sync via the same samod fork the hub uses. Must match quarto-hub's
 # version/branch exactly, else samod (and its automerge) resolve to a second copy
 # and DocHandle types no longer unify across the crate boundary.
-samod = { version = "0.13.0", git = "https://github.com/shikokuchuo/samod.git", branch = "access-policy", features = ["tokio", "tungstenite"] }
+samod = { version = "0.13.0", git = "https://github.com/quarto-dev/samod.git", branch = "access-policy", features = ["tokio", "tungstenite"] }
 # Reused index-document model (file list, capture sidecar) for the join+list path.
 quarto-hub = { path = "../quarto-hub" }
 # Read file documents out of the VFS during materialization (must match the

--- a/crates/quarto-hub-provider/Cargo.toml
+++ b/crates/quarto-hub-provider/Cargo.toml
@@ -16,12 +16,12 @@ path = "src/lib.rs"
 # Automerge sync via the same samod fork the hub uses. Must match quarto-hub's
 # version/branch exactly, else samod (and its automerge) resolve to a second copy
 # and DocHandle types no longer unify across the crate boundary.
-samod = { version = "0.12.3", git = "https://github.com/quarto-dev/samod.git", branch = "access-policy", features = ["tokio", "tungstenite"] }
+samod = { version = "0.13.0", git = "https://github.com/shikokuchuo/samod.git", branch = "access-policy", features = ["tokio", "tungstenite"] }
 # Reused index-document model (file list, capture sidecar) for the join+list path.
 quarto-hub = { path = "../quarto-hub" }
 # Read file documents out of the VFS during materialization (must match the
 # version quarto-hub uses so DocHandle::with_document hands us the same type).
-automerge = { version = "0.10.0", features = ["utf16-indexing"] }
+automerge = { version = "0.11.0", features = ["utf16-indexing"] }
 # Node discovery + the embedded hub-mcp bundle (we spawn its auth-stream entry).
 quarto-mcp-launcher = { path = "../quarto-mcp-launcher" }
 

--- a/crates/quarto-hub/Cargo.toml
+++ b/crates/quarto-hub/Cargo.toml
@@ -47,7 +47,7 @@ time = "0.3"
 # non-BMP characters (emoji etc.) — each emoji is 1 code point but 2 UTF-16 code units.
 automerge = { version = "0.11.0", features = ["utf16-indexing"] }
 # samod fork carrying the synchronous AccessPolicy trait.
-samod = { version = "0.13.0", git = "https://github.com/shikokuchuo/samod.git", branch = "access-policy", features = ["tokio", "axum", "tungstenite"] }
+samod = { version = "0.13.0", git = "https://github.com/quarto-dev/samod.git", branch = "access-policy", features = ["tokio", "axum", "tungstenite"] }
 
 # Async streams (for samod event handling)
 futures = "0.3"

--- a/crates/quarto-hub/Cargo.toml
+++ b/crates/quarto-hub/Cargo.toml
@@ -45,9 +45,9 @@ time = "0.3"
 # utf16-indexing: use UTF-16 code units for text indices, matching the JS/WASM client.
 # Without this, the Rust default is UnicodeCodePoint, which disagrees with JS on
 # non-BMP characters (emoji etc.) — each emoji is 1 code point but 2 UTF-16 code units.
-automerge = { version = "0.10.0", features = ["utf16-indexing"] }
-# Vendored samod fork carrying the synchronous AccessPolicy trait (long-term home).
-samod = { version = "0.12.3", git = "https://github.com/quarto-dev/samod.git", branch = "access-policy", features = ["tokio", "axum", "tungstenite"] }
+automerge = { version = "0.11.0", features = ["utf16-indexing"] }
+# samod fork carrying the synchronous AccessPolicy trait.
+samod = { version = "0.13.0", git = "https://github.com/shikokuchuo/samod.git", branch = "access-policy", features = ["tokio", "axum", "tungstenite"] }
 
 # Async streams (for samod event handling)
 futures = "0.3"

--- a/crates/quarto-preview/Cargo.toml
+++ b/crates/quarto-preview/Cargo.toml
@@ -22,8 +22,8 @@ thiserror.workspace = true
 # Match quarto-hub's versions so `capture_driver::read_capture_from_doc`
 # can talk to samod directly (it reads back the binary doc Phase C.1
 # writes; Phase C.4 reuses the same wire format in the WASM/SPA layer).
-automerge = { version = "0.10.0", features = ["utf16-indexing"] }
-samod = { version = "0.12.3", git = "https://github.com/quarto-dev/samod.git", branch = "access-policy", features = ["tokio"] }
+automerge = { version = "0.11.0", features = ["utf16-indexing"] }
+samod = { version = "0.13.0", git = "https://github.com/shikokuchuo/samod.git", branch = "access-policy", features = ["tokio"] }
 
 quarto-core.workspace = true
 quarto-error-reporting = { workspace = true, features = ["json"] }

--- a/crates/quarto-preview/Cargo.toml
+++ b/crates/quarto-preview/Cargo.toml
@@ -23,7 +23,7 @@ thiserror.workspace = true
 # can talk to samod directly (it reads back the binary doc Phase C.1
 # writes; Phase C.4 reuses the same wire format in the WASM/SPA layer).
 automerge = { version = "0.11.0", features = ["utf16-indexing"] }
-samod = { version = "0.13.0", git = "https://github.com/shikokuchuo/samod.git", branch = "access-policy", features = ["tokio"] }
+samod = { version = "0.13.0", git = "https://github.com/quarto-dev/samod.git", branch = "access-policy", features = ["tokio"] }
 
 quarto-core.workspace = true
 quarto-error-reporting = { workspace = true, features = ["json"] }

--- a/hub-client/changelog.md
+++ b/hub-client/changelog.md
@@ -25,7 +25,7 @@ WASM rebuild is needed for a changelog-only edit.
 
 ### 2026-08-12
 
-- [`e5769e5b`](https://github.com/quarto-dev/q2/commits/e5769e5b): Bump the samod sync library to 0.13.0 (now from shikokuchuo/samod, access-policy branch) and the JS automerge package to 3.4.1.
+- [`e5769e5b`](https://github.com/quarto-dev/q2/commits/e5769e5b): Bump the samod sync library to 0.13.0 and the JS automerge package to 3.4.1.
 
 ### 2026-08-07
 

--- a/hub-client/changelog.md
+++ b/hub-client/changelog.md
@@ -23,6 +23,10 @@ WASM rebuild is needed for a changelog-only edit.
 
 -->
 
+### 2026-08-12
+
+- [`e5769e5b`](https://github.com/quarto-dev/q2/commits/e5769e5b): Bump the samod sync library to 0.13.0 (now from shikokuchuo/samod, access-policy branch) and the JS automerge package to 3.4.1.
+
 ### 2026-08-07
 
 - [`279d7e5e`](https://github.com/quarto-dev/q2/commits/279d7e5e): `.md` files are now first-class source files: they sync into hub projects, get live preview, outline, folding, diagnostics, and qmd highlighting in the editor, and cross-document links into `.md` pages navigate like `.qmd` ones.

--- a/hub-client/package.json
+++ b/hub-client/package.json
@@ -36,7 +36,7 @@
     "bootstrap-test-fixtures": "npx tsx e2e/scripts/regenerate-fixtures.ts"
   },
   "dependencies": {
-    "@automerge/automerge": "^3.2.6",
+    "@automerge/automerge": "^3.4.1",
     "@automerge/automerge-repo": "^2.5.6",
     "@automerge/automerge-repo-network-websocket": "^2.5.6",
     "@automerge/automerge-repo-react-hooks": "2.5.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
       "version": "0.0.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@automerge/automerge": "^3.2.6",
+        "@automerge/automerge": "^3.4.1",
         "@automerge/automerge-repo": "^2.5.6",
         "@automerge/automerge-repo-network-websocket": "^2.5.6",
         "@automerge/automerge-repo-react-hooks": "2.5.6",
@@ -140,9 +140,9 @@
       "license": "ISC"
     },
     "node_modules/@automerge/automerge": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@automerge/automerge/-/automerge-3.2.6.tgz",
-      "integrity": "sha512-9/GXXfYYWNVGpnbRrGQzTNU4fWZ3XaEMeEg0OrpK4pvlQSpkmUBoirEb/4TMK6BwMysZGV5Yeneq3wwc7RNGfg==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@automerge/automerge/-/automerge-3.4.1.tgz",
+      "integrity": "sha512-zsZpbs/iDPvp+ZojIYd+gxmbcPVz2Xbkcx778G8zrt3E0zS+6saHJOm666lOuZyNRlTV4wHw9qzGTKueedeCsQ==",
       "license": "MIT"
     },
     "node_modules/@automerge/automerge-repo": {
@@ -242,7 +242,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -1967,7 +1966,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1991,7 +1989,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2013,7 +2010,6 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -2672,23 +2668,6 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
-    },
-    "node_modules/@floating-ui/core": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
-      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@floating-ui/utils": "^0.2.11"
-      }
-    },
-    "node_modules/@floating-ui/utils": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
-      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/@hono/node-server": {
       "version": "1.19.14",
@@ -4026,7 +4005,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -4125,7 +4103,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.27.1.tgz",
       "integrity": "sha512-rV6Qn4wmC6BxfF+4mu6bqGWj9vA4oXXhsrpXaJL2uhjxeHAGofjwcHof2X84VYzeyXgdlsGmqKie4TAppVXZUQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -4348,7 +4325,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.27.1.tgz",
       "integrity": "sha512-c2Upru7lj0/ZV/Ibww6cNz6sUS8m6Dp/9uygFhYcZOd3X8M0xBIEk42c6m6SQehkPziVA8QOgNJz7sMqsbz1OQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -4482,7 +4458,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.27.1.tgz",
       "integrity": "sha512-1Tdx9faw8k0/83V6X+xCDVhV8yElGt95JxeW3YMkKQJI56QdlPz0xOdJPlMiSGJKinPyVier+x9LJD/YZUZIaw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -4497,7 +4472,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.27.1.tgz",
       "integrity": "sha512-Ffjx+vimmBU7zH/KrpXzJid3+pziCe/VL2aexSTP63cyQwKQ65LkFkCKaIsSpFdQQuakVZBGWjCA5RoBV852pw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
         "prosemirror-commands": "^1.6.2",
@@ -4609,7 +4583,6 @@
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
       "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.20.7",
         "@babel/types": "^7.20.7",
@@ -4796,7 +4769,6 @@
       "integrity": "sha512-RSpUJGmvsJ1ZeBehQZFhIdpsz+bIpES0nIQXko4Ybq+N+kX6XvOq3Jo+iJ82FWLdblFq85AsMikd3m35jgezYg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -4820,7 +4792,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4830,7 +4801,6 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4931,7 +4901,6 @@
       "integrity": "sha512-5B7PfA2e1NQGCnDHd/0lW7W3gvp3d59Ryw54FYO8Uswxo9f6ikw3AZV+Xj/TvpImmpsiYyUqAfhC6kJID1jF6w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.61.0",
         "@typescript-eslint/types": "8.61.0",
@@ -5388,7 +5357,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5421,7 +5389,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -5748,7 +5715,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -6699,7 +6665,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6976,7 +6941,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -7666,7 +7630,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
       "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -8463,7 +8426,6 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -8926,7 +8888,6 @@
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
       "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "dompurify": "3.2.7",
         "marked": "14.0.0"
@@ -9709,7 +9670,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9719,7 +9679,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -9927,8 +9886,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/reveal.js/-/reveal.js-6.0.0.tgz",
       "integrity": "sha512-RayDr1FL3Jglnf6p9xHGJ0U18va96PiuLs/JHnd1cdDOXvC+3lsXKe6ujl7PX0pvnhNW2Tpqnr6PEKpJVO2exw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/reveal.js-menu": {
       "version": "2.1.0",
@@ -9958,7 +9916,6 @@
       "integrity": "sha512-I4KW6iuRpuu2uHBLraZ1wNZe0DP7lnRha+VJ9tNaYVaVgKhW0aI3h4RYnoRPeql0flHm/Co55b7snEDcOfOJrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.9"
       },
@@ -11164,7 +11121,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11414,7 +11370,6 @@
       "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -12856,7 +12811,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
       "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -12941,7 +12895,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -13439,7 +13392,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@automerge/automerge": "^3.2.6",
+        "@automerge/automerge": "^3.4.1",
         "@automerge/automerge-repo": "^2.5.1",
         "@quarto/pandoc-types": "*",
         "@quarto/preview-renderer": "*",
@@ -13510,7 +13463,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@automerge/automerge": "^3.2.6",
+        "@automerge/automerge": "^3.4.1",
         "@automerge/automerge-repo": "^2.5.1",
         "@automerge/automerge-repo-network-websocket": "^2.5.1",
         "@automerge/automerge-repo-storage-indexeddb": "^2.5.4",

--- a/ts-packages/preview-runtime/package.json
+++ b/ts-packages/preview-runtime/package.json
@@ -41,7 +41,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@automerge/automerge": "^3.2.6",
+    "@automerge/automerge": "^3.4.1",
     "@automerge/automerge-repo": "^2.5.1",
     "@quarto/pandoc-types": "*",
     "@quarto/preview-renderer": "*",

--- a/ts-packages/quarto-sync-client/package.json
+++ b/ts-packages/quarto-sync-client/package.json
@@ -28,7 +28,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@automerge/automerge": "^3.2.6",
+    "@automerge/automerge": "^3.4.1",
     "@automerge/automerge-repo": "^2.5.1",
     "@automerge/automerge-repo-network-websocket": "^2.5.1",
     "@automerge/automerge-repo-storage-indexeddb": "^2.5.4",


### PR DESCRIPTION
This version bump is required as we hit a panic in `q2 preview --allow-edit`. The panic is fixed upstream in js 3.4.1/ rust 0.11.0.

## Summary
- samod 0.12.3 → 0.13.0 (quarto-dev/samod@access-policy)
- Rust automerge 0.10.0 → 0.11.0 in quarto-hub, quarto-hub-provider, quarto-preview to match the samod 0.13.0 workspace pin — a mismatch would resolve a second automerge copy and split DocHandle types across crates
- @automerge/automerge ^3.2.6 → ^3.4.1 in hub-client, quarto-sync-client, preview-runtime; lockfile resolves exactly 3.4.1

## Verification
- cargo xtask verify: all 14 steps passed (workspace build, nextest, ts-packages builds, hub-client build incl. WASM, hub-client tests)
- hub-client changelog render test (test:wasm) passed