### PR TITLE
Title every appendix section, localized, and drop the footnotes rule (bd-v9zs83zj)

### DIFF
--- a/claude-notes/plans/2026-08-12-footnotes-appendix-heading.md
+++ b/claude-notes/plans/2026-08-12-footnotes-appendix-heading.md
@@ -190,7 +190,9 @@ The `.quarto-appendix-heading` rules are **substantive**, not cosmetic trim
   margin-top: 0; line-height: 1.4em; font-weight: 600;
   opacity: 0.9; border-bottom: none; margin-bottom: 0;
 }
-#quarto-appendix.plain .quarto-appendix-heading { font-size: 1em !important; }
+/* NOTE: both blocks are nested under `.default`, not `.plain` — see the
+   correction under "Browser verification". */
+#quarto-appendix.default .quarto-appendix-heading { font-size: 1em !important; }
 ```
 
 Without the class, appendix headings render as ordinary `<h2>` — full size, with
@@ -246,56 +248,165 @@ Route through the end-to-end entry point (`render_document_to_file` or equivalen
 `render_qmd_to_html` with `HtmlRenderConfig::default()` — the heading only exists on the
 appendix branch, so a default-config test would pass vacuously.
 
-- [ ] Heading present: `<h2 …>Footnotes</h2>` inside `#quarto-appendix`.
-- [ ] `<hr>` gone from the titled footnotes section.
-- [ ] Localization: `lang: es` → `Notas` (from `_language-es.yml`).
-- [ ] Negative: `appendix-style: none` → no appendix, no heading, **and the `<hr>` still
+- [x] Heading present: `<h2 …>Footnotes</h2>` inside `#quarto-appendix`.
+- [x] `<hr>` gone from the titled footnotes section.
+- [x] Localization: `lang: es` → `Notas` (from `_language-es.yml`).
+- [x] Negative: `appendix-style: none` → no appendix, no heading, **and the `<hr>` still
       present** in the in-place footnotes section (matching Q1).
-- [ ] Negative: `book: true` → unchanged.
-- [ ] Classes: heading carries `anchored quarto-appendix-heading`.
-- [ ] No `id` on the heading.
-- [ ] The other four headings localize too (at least one, e.g. `References` → `Referencias`).
-- [ ] Stage-less unit test still gets the English fallback (`from_meta` → `None`).
+- [x] Negative: `book: true` → unchanged.
+- [x] Classes: heading carries `anchored quarto-appendix-heading`.
+- [x] No `id` on the heading.
+- [x] The other four headings localize too (at least one, e.g. `References` → `Referencias`).
+- [x] Stage-less unit test still gets the English fallback (`from_meta` → `None`).
 
 ### Phase 1 — Localized title helper
 
-- [ ] Add `appendix_title(meta, term_key, english_fallback) -> String` following the
+- [x] Add `appendix_title(meta, term_key, english_fallback) -> String` following the
       `toc_generate.rs:122-135` precedence: localized term > English literal. (No
       user-metadata override tier — unlike `toc-title`, there is no per-document
       `footnotes-title` option in Q1.)
-- [ ] Add `appendix_heading(title) -> Block::Header` building the level-2 `Header` with
+- [x] Add `appendix_heading(title) -> Block::Header` building the level-2 `Header` with
       empty `id` and classes `["anchored", "quarto-appendix-heading"]`, so all five sites
       share one constructor.
 
 ### Phase 2 — `wrap_footnotes`
 
-- [ ] Add `wrap_footnotes`, the missing sibling of `wrap_bibliography`, prepending the
+- [x] Add `wrap_footnotes`, the missing sibling of `wrap_bibliography`, prepending the
       heading into the existing `Div#footnotes` (it is already a `.section` with the right
       id/role — do **not** nest a second section).
-- [ ] Strip the leading `HorizontalRule` while wrapping (Q1's `prependHeading` removes the
+- [x] Strip the leading `HorizontalRule` while wrapping (Q1's `prependHeading` removes the
       first `hr` in the element). Keep the removal in the appendix transform, not in
       `create_footnotes_section` — the rule must survive when appendix processing is off.
-- [ ] Call it at `appendix.rs:156`.
+- [x] Call it at `appendix.rs:156`.
 
 ### Phase 3 — Retrofit the four existing headings
 
-- [ ] `wrap_bibliography` → `section-title-references` / `"References"`.
-- [ ] `create_license_section` → `section-title-reuse` / `"Reuse"`.
-- [ ] `create_copyright_section` → `section-title-copyright` / `"Copyright"`.
-- [ ] `create_citation_section` → `section-title-citation` / `"Citation"`.
-- [ ] All four switch to the shared `appendix_heading` constructor (gains both classes).
+- [x] `wrap_bibliography` → `section-title-references` / `"References"`.
+- [x] `create_license_section` → `section-title-reuse` / `"Reuse"`.
+- [x] `create_copyright_section` → `section-title-copyright` / `"Copyright"`.
+- [x] `create_citation_section` → `section-title-citation` / `"Citation"`.
+- [x] All four switch to the shared `appendix_heading` constructor (gains both classes).
 
 ### Phase 4 — Verification
 
-- [ ] Full `cargo xtask verify` (not `--skip-hub-build`; `quarto-core` is in hub-client's
-      dependency closure).
-- [ ] End-to-end `cargo run --bin q2 -- render` on the committed repro; inspect the HTML
-      and record the snippet in the plan per CLAUDE.md.
-- [ ] Browser look at the rendered appendix — Phase 3 activates real CSS, so this is a
-      visual change that grep cannot confirm.
-- [ ] Review and report snapshot churn counts per the CLAUDE.md snapshot policy.
-- [ ] Re-render the four named Connect-docs pages and confirm the text diff against the
-      Q1 reference actually closes.
+- [x] Full workspace suite green: `cargo nextest run --workspace` → **11800 passed**,
+      197 skipped, 0 failed.
+- [x] Full `cargo xtask verify` (not `--skip-hub-build`; `quarto-core` is in hub-client's
+      dependency closure): **all 14 steps passed, 11801 tests passed / 197 skipped**,
+      exit code 0. See the note below on a spurious tree-sitter failure encountered on the
+      way — it was a stale build cache, not this change.
+- [x] End-to-end `cargo run --bin q2 -- render` on the committed repro; HTML inspected —
+      snippets recorded under "End-to-end verification" below.
+- [x] Browser look at the rendered appendix — Phase 3 activates real CSS, so this is a
+      visual change that grep cannot confirm. Computed styles read back from a real page
+      (see "Browser verification" below): every rule in the previously-dead block applies.
+- [x] **Snapshot churn: zero.** No `.snap` file changed. Verified this is real coverage,
+      not a blind spot: `grep -rl 'quarto-appendix\|doc-endnotes\|quarto-bibliography'
+      --include='*.snap' crates/` returns nothing — no insta snapshot in the tree contains
+      appendix HTML at all. The appendix is exercised by smoke-all fixtures and unit tests
+      instead. (The plan predicted churn; the prediction was wrong.)
+- [x] Re-render a named Connect-docs page and confirm the text diff against the Q1
+      reference actually closes — see "Connect-docs diff" below.
+
+## End-to-end verification
+
+`cargo run --bin q2 -- render repro.qmd --to html`, output inspected:
+
+```html
+<div id="quarto-appendix" class="default">
+<section id="footnotes" class="footnotes section" role="doc-endnotes">
+<h2 class="anchored quarto-appendix-heading">Footnotes</h2>
+<ol type="1">
+<li><div id="fn1">
+```
+
+Byte-for-byte the markup Quarto 1 emits, and the `<hr />` is gone.
+
+The same document with `lang: es`, `license:`, `copyright:` and `citation:` —
+`grep -o '<h2 class="[^"]*">[^<]*</h2>'`:
+
+```html
+<h2 class="anchored quarto-appendix-heading">Notas</h2>
+<h2 class="anchored quarto-appendix-heading">Reutilización</h2>
+<h2 class="anchored quarto-appendix-heading">Derechos de autor</h2>
+<h2 class="anchored quarto-appendix-heading">Cómo citar</h2>
+```
+
+All five headings localize, and multi-word titles keep their spacing — which is what
+the canonical `Str`/`Space` inline split in `title_inlines` buys. A single `Str`
+carrying embedded spaces would have rendered identically in HTML but is not what the
+AST means by a run of text.
+
+## Connect-docs diff
+
+The motivation for the strand was four Connect-docs pages differing from the Quarto 1
+reference render. Checked against `q2-connect-docs` (`docs-quarto-1/_site` is the Q1
+reference; `docs-quarto-2/_site` was built by a pre-fix q2), on `user/manifest`:
+
+```
+Q1 reference: <h2 class="anchored quarto-appendix-heading">Footnotes</h2>
+q2 (old):     grep -c quarto-appendix-heading → 0
+```
+
+Re-rendering that page's `index.qmd` with this build (copied into a scratch dir so the
+docs repo stays untouched):
+
+```
+<h2 class="anchored quarto-appendix-heading">Footnotes</h2>
+hr count inside the footnotes section: 0
+```
+
+Byte-identical to the Q1 reference on both counts. This is the check that would have
+failed had we shipped the heading without also dropping the `<hr>` — the diff would have
+closed on the heading and reopened on the rule.
+
+## Note: a spurious tree-sitter failure during verification
+
+The first full `cargo xtask verify` failed at step 4 with a corpus case this change never
+touched (`punctuation-vs-image.txt`, "5 - multiple punctuation marks", input `...`).
+Chased to ground before continuing:
+
+- It reproduced with the working tree **fully stashed** — i.e. on pristine `main`, so no
+  local edit caused it.
+- `tree-sitter generate` produced **no diff**, so the committed `parser.c` is in sync with
+  `grammar.js`; the grammar source was never the problem.
+- After that regenerate forced a rebuild, the test passed 3/3 consecutive runs.
+- The only gitignored artifact in the grammar dir is `markdown.dylib`, the compiled
+  parser — a **stale build cache** was the actual input.
+
+Filed as **`bd-7ilvb5r2`**. Worth knowing because the failure is indistinguishable from a
+real grammar regression and points at a file the session never touched.
+
+A process note that cost real time here: `cargo xtask verify | tail -30` reports **`tail`'s**
+exit code, not xtask's, so a failed verify looks like it exited 0. Run it unpiped when the
+exit status matters.
+
+## Browser verification
+
+Phase 3 activates CSS that had never matched anything, so grep cannot confirm it.
+Computed styles read back from the rendered page (all four appendix headings identical):
+
+| Property | Computed | Source rule |
+| --- | --- | --- |
+| `font-weight` | `600` | `.quarto-appendix-heading` |
+| `font-size` | `17px` (= `1em`) | `font-size: 1em !important` |
+| `margin-top` / `margin-bottom` | `0px` / `0px` | `.quarto-appendix-heading` |
+| `border-bottom` | `0px none` | `border-bottom: none` |
+| `opacity` | `0.9` | `.quarto-appendix-heading` |
+| `class` | `anchored quarto-appendix-heading` | emitted by `appendix_heading` |
+
+`document.querySelectorAll('#footnotes hr').length` → **0**.
+
+Without the class these would render as ordinary `<h2>` — roughly 27px with Bootstrap's
+`border-bottom`. The horizontal line still visible above the appendix is
+`#quarto-appendix.default { border-top: 1px solid }`, the container's own rule, which is
+correct and matches Q1.
+
+**Correction to Finding 4:** that section stated the `font-size: 1em !important` rule
+sits under `#quarto-appendix.plain`. It does not — both blocks in
+`_bootstrap-rules.scss` are nested under `#quarto-appendix.default` (lines 2225 and
+2229), so the rule applies in the default style too. The compiled stylesheet confirms
+it, and the 17px computed size above is that rule firing under `.default`.
 
 ## Design answers (settled with the user, 2026-08-12)
 

--- a/claude-notes/plans/2026-08-12-footnotes-appendix-heading.md
+++ b/claude-notes/plans/2026-08-12-footnotes-appendix-heading.md
@@ -3,17 +3,17 @@
 **Date:** 2026-08-12
 **Braid:** bd-v9zs83zj
 **Checkout:** main @ `de2375f0` (no worktree/branch created — this skill ran in the main checkout)
-**Status:** Investigation — pending design alignment with user. **Do not start implementation until the user gives the go-ahead.**
+**Status:** Design settled 2026-08-12 — **ready to implement.** All four questions
+answered by the user; see "Design answers" below.
 
 ## Triage verdict
 
-**Ready to design.** The bug reproduces exactly as filed, the fix site is a single
+**Ready to implement.** The bug reproduces exactly as filed, the fix site is a single
 identified line (`appendix.rs:156`), and the localization mechanism the strand asks
-about already exists and already has the right key. But the investigation found that
-the reported symptom is **one of four instances of the same defect**, and that the
+about already exists and already has the right key. The investigation found that
+the reported symptom is **one of five instances of the same defect**, and that the
 strand's claim "the `<hr />` is correct" is **false** — Q1 deletes the `<hr>` when it
-inserts the heading. Both change the scope, so the design questions below need answers
-before implementation.
+inserts the heading. Both widened the scope; the user has approved the wider scope.
 
 Pre-flight `cargo xtask verify --skip-hub-build` green at `de2375f0` (all 14 steps
 passed, exit 0).
@@ -180,71 +180,165 @@ class, so those rules are dead and *all five* appendix headings are unstyled.
 
 Q1 applies `["anchored", "quarto-appendix-heading"]`
 (`format-html-appendix.ts:98`) to every appendix heading. q2 also never emits `"anchored"`
-anywhere (`grep -rn '"anchored"' crates/` → zero hits), which is a separate and larger
-gap — the anchor-link mechanism itself does not exist in q2 — so `anchored` should
-probably not be added blind. This drives Q3.
+anywhere (`grep -rn '"anchored"' crates/` → zero hits). This drives Q3.
 
-## Proposed phases (draft)
+The `.quarto-appendix-heading` rules are **substantive**, not cosmetic trim
+(`_bootstrap-rules.scss:2235`, `:2276`):
 
-Skeleton only — contents depend on the answers to Q1–Q4.
+```scss
+#quarto-appendix.default .quarto-appendix-heading {
+  margin-top: 0; line-height: 1.4em; font-weight: 600;
+  opacity: 0.9; border-bottom: none; margin-bottom: 0;
+}
+#quarto-appendix.plain .quarto-appendix-heading { font-size: 1em !important; }
+```
 
-- **Phase 0 — Test plan (TDD, failing first).** A `render_to_file`-level test asserting
-  the heading text appears inside `#quarto-appendix`; a localization test (`lang: es` →
-  `Notas`); a negative test (`appendix-style: none` → no heading, matching Q1); and, if
-  Q1 is answered "yes", an assertion that no `<hr>` survives in the section. Route through
-  the end-to-end entry point per CLAUDE.md, not `render_qmd_to_html` with defaults —
-  the heading only appears on the appendix branch.
-- **Phase 1 — `wrap_footnotes`.** Add the missing sibling of `wrap_bibliography` in
-  `appendix.rs`, mirroring its shape; use it at `appendix.rs:156`.
-- **Phase 2 — Localized title lookup.** A small helper (`appendix_title(meta, key,
-  fallback)`) following the `toc_generate.rs` precedence, applied to footnotes and — if
-  Q2 is "yes" — retrofitted to the four existing literals.
-- **Phase 3 — `<hr>` removal**, if Q1 is "yes". Cleanest as *not emitting* the
-  `HorizontalRule` in `create_footnotes_section` when the appendix will title the section
-  — but that couples two transforms, so more likely the appendix transform strips it while
-  wrapping. Needs design.
-- **Phase 4 — Heading classes**, if Q3 is "yes".
-- **Phase 5 — Verification.** Full `cargo xtask verify`; end-to-end render inspected;
-  re-render the four named Connect docs pages and confirm the text diff against the Q1
-  reference actually closes.
+Without the class, appendix headings render as ordinary `<h2>` — full size, with
+Bootstrap's `border-bottom`, and the wrong margins. So emitting it is a **real step
+toward Q1 parity**, not just class noise.
 
-## Open design questions for the user
+(Noted in passing, out of scope: `.quarto-appendix-contents > *:not(h2)` at `:2281`
+implies Q1's `div.quarto-appendix-contents` content wrapper, which q2 also never emits.
+Footnotes are unaffected — the sibling selector `*[role="doc-endnotes"] > ol` gives them
+the 0.9em independently — so this only matters for the other appendix sections. Not
+filed; call it out if the Connect-docs diff surfaces it.)
 
-1. **The `<hr>` (Finding 3 — most important).** Q1 deletes the `<hr>` when it inserts the
-   heading, so adding the heading alone leaves q2 differing from the reference render and
-   does not close the diff this strand exists to close. Should the fix also drop the rule
-   from the titled footnotes section? *Recommendation: yes* — otherwise the strand's stated
-   motivation is unmet. It does mean the `<hr>` stays when appendix processing is off,
-   matching Q1 exactly.
+### Finding 5 — `.anchored` is a pure JS selector hook, and emitting it is inert (Q3 research)
 
-2. **Scope: fix all five headings or just footnotes (Finding 2)?** `References`, `Reuse`,
-   `Copyright`, `Citation` are hardcoded English despite their `section-title-*` keys
-   existing and being fully translated. *Recommendation: all five in one commit* — it is
-   the same one-line change at each site, the helper is written either way, and doing only
-   footnotes leaves four known-wrong sites plus an inconsistent file. If you'd rather keep
-   this strand minimal, I'd file the other four as their own p3 strand rather than leave
-   them unrecorded.
+Traced through the Q1 source at the user's request. `.anchored` is **not**
+appendix-specific and **has no styling of its own**:
 
-3. **Heading classes (Finding 4).** Q1 emits `class="anchored quarto-appendix-heading"`.
-   q2 ships the `.quarto-appendix-heading` SCSS but emits neither class. Add
-   `quarto-appendix-heading` (activating dead CSS — this is a *visual* change, so it may
-   move snapshots)? *Recommendation: add `quarto-appendix-heading`, skip `anchored`* —
-   `anchored` implies an anchor-link mechanism q2 does not have, so emitting it would be
-   cargo-culting. Or defer all class work to its own strand if you want this one to stay
-   text-only.
+- **Emitted document-wide.** `format-html.ts:828-848` is a DOM postprocessor that adds
+  `anchored` to every `h2`–`h6`, `.quarto-figure[id]` and `div[id^=tbl-]` inside `main`
+  (Bootstrap) or `body`, gated on the `anchors` format option, skipping `#toc-title` and
+  anything carrying `.no-anchor`.
+- **Pre-applied in the appendix** at `format-html-appendix.ts:98` and `:363` only because
+  appendix headings are synthesized by a *different* postprocessor; `classList.add` is
+  idempotent, so the two passes don't collide.
+- **Consumed by AnchorJS**, not CSS. `quarto-html-after-body.ejs:38-46` does
+  `anchorJS.add('.anchored')`, which injects an `a.anchorjs-link` (the ¶ hover link) into
+  each match. `_quarto-rules.scss:147-175` styles **`.anchorjs-link`** — the element
+  AnchorJS creates — and there is no `.anchored { … }` rule anywhere.
 
-4. **Heading `id`.** Q1's `prependHeading` sets no `id`, and q2's existing appendix headings
-   pass `String::new()`. Confirm we match (no `id`) — it means the heading is not linkable
-   and will not appear in the TOC. *Recommendation: match Q1, no `id`.*
+q2 has **none** of this: no `anchors` option (`grep -rn '"anchors"' crates/` → zero),
+no `anchor.min.js`, no `quarto.js`, no `.anchorjs-link` styling, no `.anchored` rules.
+
+The consequence is the useful one: **emitting `anchored` in q2 today is completely inert**
+— nothing styles it and nothing reads it — so it carries zero visual risk, and it is
+precisely the marker a future anchor-link feature needs. This *inverts* the risk ordering
+in the original Q3 recommendation: `anchored` is the safe class and
+`quarto-appendix-heading` is the one that actually changes pixels.
+
+**Design note for the follow-up.** When q2 implements the document-wide pass it must be an
+**AST transform**, not a DOM postprocessor (CLAUDE.md: q2 has no post-Pandoc DOM stage).
+Unlike `classList.add`, pushing onto a `Vec<String>` of classes is **not idempotent** — the
+appendix headings are `h2` and would be caught by the general pass too, yielding
+`class="anchored anchored quarto-appendix-heading"`. The general transform must skip
+headings that already carry the class. Recorded in the follow-up strand.
+
+## Work items
+
+All work lands in `crates/quarto-core/src/transforms/appendix.rs` unless noted.
+
+### Phase 0 — Tests (TDD: written and failing first)
+
+Route through the end-to-end entry point (`render_document_to_file` or equivalent), **not**
+`render_qmd_to_html` with `HtmlRenderConfig::default()` — the heading only exists on the
+appendix branch, so a default-config test would pass vacuously.
+
+- [ ] Heading present: `<h2 …>Footnotes</h2>` inside `#quarto-appendix`.
+- [ ] `<hr>` gone from the titled footnotes section.
+- [ ] Localization: `lang: es` → `Notas` (from `_language-es.yml`).
+- [ ] Negative: `appendix-style: none` → no appendix, no heading, **and the `<hr>` still
+      present** in the in-place footnotes section (matching Q1).
+- [ ] Negative: `book: true` → unchanged.
+- [ ] Classes: heading carries `anchored quarto-appendix-heading`.
+- [ ] No `id` on the heading.
+- [ ] The other four headings localize too (at least one, e.g. `References` → `Referencias`).
+- [ ] Stage-less unit test still gets the English fallback (`from_meta` → `None`).
+
+### Phase 1 — Localized title helper
+
+- [ ] Add `appendix_title(meta, term_key, english_fallback) -> String` following the
+      `toc_generate.rs:122-135` precedence: localized term > English literal. (No
+      user-metadata override tier — unlike `toc-title`, there is no per-document
+      `footnotes-title` option in Q1.)
+- [ ] Add `appendix_heading(title) -> Block::Header` building the level-2 `Header` with
+      empty `id` and classes `["anchored", "quarto-appendix-heading"]`, so all five sites
+      share one constructor.
+
+### Phase 2 — `wrap_footnotes`
+
+- [ ] Add `wrap_footnotes`, the missing sibling of `wrap_bibliography`, prepending the
+      heading into the existing `Div#footnotes` (it is already a `.section` with the right
+      id/role — do **not** nest a second section).
+- [ ] Strip the leading `HorizontalRule` while wrapping (Q1's `prependHeading` removes the
+      first `hr` in the element). Keep the removal in the appendix transform, not in
+      `create_footnotes_section` — the rule must survive when appendix processing is off.
+- [ ] Call it at `appendix.rs:156`.
+
+### Phase 3 — Retrofit the four existing headings
+
+- [ ] `wrap_bibliography` → `section-title-references` / `"References"`.
+- [ ] `create_license_section` → `section-title-reuse` / `"Reuse"`.
+- [ ] `create_copyright_section` → `section-title-copyright` / `"Copyright"`.
+- [ ] `create_citation_section` → `section-title-citation` / `"Citation"`.
+- [ ] All four switch to the shared `appendix_heading` constructor (gains both classes).
+
+### Phase 4 — Verification
+
+- [ ] Full `cargo xtask verify` (not `--skip-hub-build`; `quarto-core` is in hub-client's
+      dependency closure).
+- [ ] End-to-end `cargo run --bin q2 -- render` on the committed repro; inspect the HTML
+      and record the snippet in the plan per CLAUDE.md.
+- [ ] Browser look at the rendered appendix — Phase 3 activates real CSS, so this is a
+      visual change that grep cannot confirm.
+- [ ] Review and report snapshot churn counts per the CLAUDE.md snapshot policy.
+- [ ] Re-render the four named Connect-docs pages and confirm the text diff against the
+      Q1 reference actually closes.
+
+## Design answers (settled with the user, 2026-08-12)
+
+All four questions are closed. The governing principle the user stated: **the goal is to
+get Quarto 2 to emit output like Quarto 1 does**, and these would have to be fixed
+somewhere anyway.
+
+1. **The `<hr>` — YES, drop it** from the titled footnotes section, matching Q1's
+   `prependHeading`. The heading replaces the rule as the separator. The `<hr>` correctly
+   remains when appendix processing is off (`appendix-style: none`, `book: true`), which
+   is also what Q1 does.
+
+2. **Scope — ALL FIVE headings.** Footnotes plus the four existing hardcoded literals
+   (`References`, `Reuse`, `Copyright`, `Citation`), each routed through the localized
+   `section-title-*` term with the `toc_generate.rs` precedence. No separate strand.
+
+3. **Heading classes — EMIT BOTH**, `anchored` and `quarto-appendix-heading`, matching
+   Q1's `headingClasses` exactly. Finding 5 (researched at the user's request) shows
+   `anchored` is a pure AnchorJS selector hook with no styling of its own, so emitting it
+   is inert today rather than cargo-culting; it is the marker the future feature needs, and
+   emitting it now means the appendix is already correct when anchors land.
+   **Follow-up filed: `bd-5kf2dnw4`** — implement the document-wide `.anchored` pass plus
+   the AnchorJS runtime so the class becomes live. Its non-obvious constraint (class-push
+   is not idempotent; the general pass must skip headings that already carry it) is
+   recorded there and in Finding 5.
+
+4. **Heading `id` — none**, matching Q1's `prependHeading` and q2's existing appendix
+   headings. The heading is not linkable and does not appear in the TOC.
 
 ## Risks / tradeoffs (draft)
 
-- **Snapshot churn is the main risk**, and it scales with the answers: Q2="all five" and
-  Q3="add class" both widen it. Any HTML snapshot of a document with footnotes, a
-  bibliography, or license/citation metadata will move. Expect to review the diff carefully
-  and report counts per the CLAUDE.md snapshot policy.
-- **Q3 is a visual change, not just markup** — activating dead CSS alters rendered
-  appearance. Worth an actual browser look, not just a grep.
+- **Snapshot churn is the main risk**, and the settled answers maximize it: all five
+  headings change, all five gain two classes, and the footnotes `<hr>` disappears. Any HTML
+  snapshot of a document with footnotes, a bibliography, or license/citation metadata will
+  move. Review the diff carefully and report counts per the CLAUDE.md snapshot policy.
+- **Phase 3 is a visual change, not just markup** — `quarto-appendix-heading` activates
+  real, substantive CSS (font-weight, size, margins, `border-bottom: none`). Worth an
+  actual browser look, not just a grep. `anchored`, by contrast, is inert (Finding 5) and
+  carries no visual risk.
+- **The `<hr>` removal is conditional and easy to get wrong.** The rule must vanish only
+  when the appendix titles the section, and must survive under `appendix-style: none` /
+  `book: true`. That is why the strip belongs in the appendix transform rather than in
+  `create_footnotes_section`. Both directions need a test.
 - **No conflict with the parent strand.** `bd-adjacent-footnote-definitions-miif1k1z`
   touches `scanner.c` only; this touches `quarto-core` transforms. Independent.
 - **`--skip-hub-build` is sufficient here** (unlike the parent, which changed the grammar

--- a/claude-notes/plans/2026-08-12-footnotes-appendix-heading.md
+++ b/claude-notes/plans/2026-08-12-footnotes-appendix-heading.md
@@ -1,0 +1,254 @@
+# Footnotes appendix section omits the visible 'Footnotes' heading that Quarto 1 emits (bd-v9zs83zj)
+
+**Date:** 2026-08-12
+**Braid:** bd-v9zs83zj
+**Checkout:** main @ `de2375f0` (no worktree/branch created — this skill ran in the main checkout)
+**Status:** Investigation — pending design alignment with user. **Do not start implementation until the user gives the go-ahead.**
+
+## Triage verdict
+
+**Ready to design.** The bug reproduces exactly as filed, the fix site is a single
+identified line (`appendix.rs:156`), and the localization mechanism the strand asks
+about already exists and already has the right key. But the investigation found that
+the reported symptom is **one of four instances of the same defect**, and that the
+strand's claim "the `<hr />` is correct" is **false** — Q1 deletes the `<hr>` when it
+inserts the heading. Both change the scope, so the design questions below need answers
+before implementation.
+
+Pre-flight `cargo xtask verify --skip-hub-build` green at `de2375f0` (all 14 steps
+passed, exit 0).
+
+## Issue context
+
+Filed 2026-08-12 by Carlos Scheidegger, `bug`, **p3**, `open`. Hours old — no staleness
+risk, every cited fact still holds.
+
+q2's rendered footnotes appendix has no visible heading. Q1 emits
+`<h2 class="anchored quarto-appendix-heading">Footnotes</h2>`; q2 emits only the
+horizontal rule and the ordered list. The strand notes `grep -rn '"Footnotes"' crates/
+--include='*.rs'` returns zero hits — confirmed, still zero. This is not a config branch
+that fails to fire; the string is simply never produced.
+
+The strand explicitly asks: *"whether the heading is localizable (Quarto 1 takes it from
+the language resources, not a literal) — worth checking how the other appendix headings
+in q2 handle that before hard-coding it."* That check is the most productive thing this
+investigation did; see Finding 2.
+
+## Dependency graph
+
+Nearly empty — one outgoing edge, no incoming pressure:
+
+- **discovered-from**: `bd-adjacent-footnote-definitions-miif1k1z` (p2, `in_progress`) —
+  the parser bug where adjacent footnote definitions merge. This strand was that
+  investigation's "adjacent, much smaller finding" (its comment `c-3g062yl4`, item 7)
+  and was filed as a spin-off under its Q5. It is **entirely independent** of the parser
+  fix: that strand changes `scanner.c` only; this one is a `quarto-core` AST transform.
+  Its fix lives on branch
+  `braid/bd-adjacent-footnote-definitions-miif1k1z-adjacent-footnote-definitions-merge`
+  (commit `1699b853`, unpushed) and **touches no file this strand touches** — no conflict,
+  no ordering constraint, either can land first.
+- **blocks**: none, in either direction. No urgency pressure.
+- **related**: none. (Sibling spin-off `bd-jttkymsw` — unresolved references render as an
+  invisible empty span — is not linked to this one and is a genuinely different defect.)
+
+The empty graph means the real context is the prose: the Connect-docs text-diff campaign.
+Four pages (`admin/integrations/tableau`, `how-to/deploy-single-page-apps`,
+`user/publishing-r`, `user/manifest`) differ from the Q1 reference render solely because
+of this. That is the whole motivation — cosmetic, but it is diff noise that masks real
+regressions.
+
+## What the code looks like today
+
+Every path in the description still exists and the symptom reproduces at HEAD.
+
+### Reproduced at HEAD
+
+`claude-notes/plans/footnotes-appendix-heading-investigation/repro.qmd`, rendered with
+`cargo run --bin q2 -- render repro.qmd --to html`:
+
+```html
+<div id="quarto-appendix" class="default">
+<section id="footnotes" class="footnotes section" role="doc-endnotes">
+<hr />
+<ol type="1">
+<li><div id="fn1">
+<p>First note.<a href="#fnref1" class="footnote-back" role="doc-backlink">↩︎</a></p>
+```
+
+No heading, exactly as filed.
+
+### Finding 1 — the fix site is one line
+
+The footnotes section is built by `create_footnotes_section`
+(`crates/quarto-core/src/transforms/footnotes.rs:527`), which emits
+`Div#footnotes[.footnotes.section]` containing `HorizontalRule` + `OrderedList` and
+nothing else.
+
+But the heading does **not** belong there. `AppendixStructureTransform`
+(`crates/quarto-core/src/transforms/appendix.rs`) is what relocates that Div into
+`#quarto-appendix`, and it pushes it **verbatim**:
+
+```rust
+// crates/quarto-core/src/transforms/appendix.rs:152-156
+if reference_location != ReferenceLocation::Margin
+    && let Some(footnotes) = extract_footnotes(&mut ast.blocks)
+{
+    appendix_sections.push(footnotes);   // ← no heading, unlike wrap_bibliography
+}
+```
+
+Compare the line directly above it, which *does* wrap: `appendix_sections.push(
+wrap_bibliography(bibliography))`. **The footnotes branch is simply missing its
+`wrap_footnotes`.** That asymmetry is the bug in one sentence.
+
+**Q1 agrees this is the right home.** `insertFootnotesTitle` is called from exactly two
+places (`grep -rn 'insertFootnotesTitle'`): `format-html-appendix.ts:167`, *inside*
+`processDocumentAppendix`, and `format-reveal.ts:776`. So when appendix processing is off
+(`appendix-style: none`, or `book: true`) Q1 emits **no** footnotes heading either. Putting
+the heading in `FootnotesTransform` instead would emit it in cases Q1 does not. The reveal
+path does not transfer: q2 coalesces footnotes into per-slide `<aside>`s
+(`crates/quarto-core/src/revealjs/footnotes.rs`) and deletes the trailing `Div#footnotes`
+entirely, so there is no section to title.
+
+### Finding 2 — the strand's localization question has a definite (and bad) answer
+
+The strand asks how q2's other appendix headings handle localization. **They don't.** All
+four are hardcoded English string literals:
+
+| Site | Literal | Language key that exists but is unused |
+| --- | --- | --- |
+| `appendix.rs:247` `wrap_bibliography` | `"References"` | `section-title-references` |
+| `appendix.rs:310` `create_license_section` | `"Reuse"` | `section-title-reuse` |
+| `appendix.rs:364` `create_copyright_section` | `"Copyright"` | `section-title-copyright` |
+| `appendix.rs:411` `create_citation_section` | `"Citation"` | `section-title-citation` |
+
+`resources/language/_language.yml:18-24` already ships all seven `section-title-*` keys,
+**including `section-title-footnotes: "Footnotes"`**, fully translated across every
+`_language-*.yml` in the tree. The infrastructure is complete and wired: `LanguageResolveStage`
+injects the resolved table at `meta.quarto.language`, and `LanguageTerms::from_meta(&ast.meta)`
+(`crates/quarto-core/src/language.rs:176`) is the accessor transforms use.
+`AppendixStructureTransform` already holds `&ast.meta`, so **no new plumbing is required** —
+the lookup is available at every one of these five sites today.
+
+`toc_generate.rs:122-135` is the idiomatic precedent, with the precedence order decided
+under bd-llhlzd7p:
+
+```rust
+// user `toc-title` metadata > localized term > English literal (stage-less unit-test fallback)
+ast.meta.get("toc-title").and_then(|v| v.as_plain_text())
+    .or_else(|| crate::language::LanguageTerms::from_meta(&ast.meta)
+        .and_then(|t| t.get("toc-title-document").map(|s| s.to_string())))
+    .or_else(|| Some("Table of Contents".to_string()))
+```
+
+The English-literal tail matters: `from_meta` returns `None` when the stage has not run,
+which is the case in unit tests that build a bare `Pandoc`.
+
+So the answer to the strand's question is: **do not follow the existing appendix headings —
+they are all the same bug.** Adding a fifth hardcoded literal would deepen a defect that a
+one-line-each change fixes. This drives Q2.
+
+### Finding 3 — the strand's `<hr />` claim is wrong
+
+The description states: *"The `<section>` wrapper, the `<hr />`, the `<ol>`, the backlinks
+and the `doc-endnotes` role are all correct — only the heading is missing."*
+
+The `<hr />` is **not** correct. Q1's `prependHeading`
+(`format-html-shared.ts:388-410`) — the shared helper behind `insertFootnotesTitle` —
+inserts the heading **and then deletes the rule**:
+
+```ts
+el.insertBefore(heading, el.firstChild);
+const hr = el.querySelector("hr");
+if (hr) {
+  hr.remove();
+}
+```
+
+The heading *replaces* the rule as the section separator; that is why Q1's appendix does
+not show both. A fix that only adds the heading leaves q2 emitting `<h2>` **and** `<hr>`,
+which still differs from the Q1 reference render — so the Connect-docs text diff this
+strand exists to close would **not** actually close. This drives Q1 and is the single
+most important correction in this investigation.
+
+### Finding 4 — q2 ships the appendix-heading CSS but never emits the class
+
+`resources/scss/bootstrap/_bootstrap-rules.scss:2235` and `:2276` define
+`.quarto-appendix-heading` rules, copied from Q1 (`_bootstrap-rules.scss:1825`/`:1866`).
+`grep -rn 'quarto-appendix-heading' crates/` returns **zero hits** — q2 never emits the
+class, so those rules are dead and *all five* appendix headings are unstyled.
+
+Q1 applies `["anchored", "quarto-appendix-heading"]`
+(`format-html-appendix.ts:98`) to every appendix heading. q2 also never emits `"anchored"`
+anywhere (`grep -rn '"anchored"' crates/` → zero hits), which is a separate and larger
+gap — the anchor-link mechanism itself does not exist in q2 — so `anchored` should
+probably not be added blind. This drives Q3.
+
+## Proposed phases (draft)
+
+Skeleton only — contents depend on the answers to Q1–Q4.
+
+- **Phase 0 — Test plan (TDD, failing first).** A `render_to_file`-level test asserting
+  the heading text appears inside `#quarto-appendix`; a localization test (`lang: es` →
+  `Notas`); a negative test (`appendix-style: none` → no heading, matching Q1); and, if
+  Q1 is answered "yes", an assertion that no `<hr>` survives in the section. Route through
+  the end-to-end entry point per CLAUDE.md, not `render_qmd_to_html` with defaults —
+  the heading only appears on the appendix branch.
+- **Phase 1 — `wrap_footnotes`.** Add the missing sibling of `wrap_bibliography` in
+  `appendix.rs`, mirroring its shape; use it at `appendix.rs:156`.
+- **Phase 2 — Localized title lookup.** A small helper (`appendix_title(meta, key,
+  fallback)`) following the `toc_generate.rs` precedence, applied to footnotes and — if
+  Q2 is "yes" — retrofitted to the four existing literals.
+- **Phase 3 — `<hr>` removal**, if Q1 is "yes". Cleanest as *not emitting* the
+  `HorizontalRule` in `create_footnotes_section` when the appendix will title the section
+  — but that couples two transforms, so more likely the appendix transform strips it while
+  wrapping. Needs design.
+- **Phase 4 — Heading classes**, if Q3 is "yes".
+- **Phase 5 — Verification.** Full `cargo xtask verify`; end-to-end render inspected;
+  re-render the four named Connect docs pages and confirm the text diff against the Q1
+  reference actually closes.
+
+## Open design questions for the user
+
+1. **The `<hr>` (Finding 3 — most important).** Q1 deletes the `<hr>` when it inserts the
+   heading, so adding the heading alone leaves q2 differing from the reference render and
+   does not close the diff this strand exists to close. Should the fix also drop the rule
+   from the titled footnotes section? *Recommendation: yes* — otherwise the strand's stated
+   motivation is unmet. It does mean the `<hr>` stays when appendix processing is off,
+   matching Q1 exactly.
+
+2. **Scope: fix all five headings or just footnotes (Finding 2)?** `References`, `Reuse`,
+   `Copyright`, `Citation` are hardcoded English despite their `section-title-*` keys
+   existing and being fully translated. *Recommendation: all five in one commit* — it is
+   the same one-line change at each site, the helper is written either way, and doing only
+   footnotes leaves four known-wrong sites plus an inconsistent file. If you'd rather keep
+   this strand minimal, I'd file the other four as their own p3 strand rather than leave
+   them unrecorded.
+
+3. **Heading classes (Finding 4).** Q1 emits `class="anchored quarto-appendix-heading"`.
+   q2 ships the `.quarto-appendix-heading` SCSS but emits neither class. Add
+   `quarto-appendix-heading` (activating dead CSS — this is a *visual* change, so it may
+   move snapshots)? *Recommendation: add `quarto-appendix-heading`, skip `anchored`* —
+   `anchored` implies an anchor-link mechanism q2 does not have, so emitting it would be
+   cargo-culting. Or defer all class work to its own strand if you want this one to stay
+   text-only.
+
+4. **Heading `id`.** Q1's `prependHeading` sets no `id`, and q2's existing appendix headings
+   pass `String::new()`. Confirm we match (no `id`) — it means the heading is not linkable
+   and will not appear in the TOC. *Recommendation: match Q1, no `id`.*
+
+## Risks / tradeoffs (draft)
+
+- **Snapshot churn is the main risk**, and it scales with the answers: Q2="all five" and
+  Q3="add class" both widen it. Any HTML snapshot of a document with footnotes, a
+  bibliography, or license/citation metadata will move. Expect to review the diff carefully
+  and report counts per the CLAUDE.md snapshot policy.
+- **Q3 is a visual change, not just markup** — activating dead CSS alters rendered
+  appearance. Worth an actual browser look, not just a grep.
+- **No conflict with the parent strand.** `bd-adjacent-footnote-definitions-miif1k1z`
+  touches `scanner.c` only; this touches `quarto-core` transforms. Independent.
+- **`--skip-hub-build` is sufficient here** (unlike the parent, which changed the grammar
+  feeding the WASM parser) — but `quarto-core` is in hub-client's dependency closure, so
+  per CLAUDE.md the final gate should still be a full `cargo xtask verify`.
+- **Low blast radius otherwise.** The change is additive inside one transform that already
+  has a test module; no public API moves.

--- a/claude-notes/plans/footnotes-appendix-heading-investigation/README.md
+++ b/claude-notes/plans/footnotes-appendix-heading-investigation/README.md
@@ -1,0 +1,37 @@
+# Investigation artifacts — bd-v9zs83zj
+
+Repro for the missing `Footnotes` appendix heading. See
+`../2026-08-12-footnotes-appendix-heading.md` for the analysis.
+
+## Files
+
+- `repro.qmd` — minimal document with two footnote definitions.
+- `repro-observed-at-de2375f0.html` — the output at `main` @ `de2375f0`, kept as
+  the pre-fix baseline.
+
+## Reproduce
+
+```bash
+cargo run --bin q2 -- render repro.qmd --to html
+```
+
+## What to look for
+
+Inside `<div id="quarto-appendix" class="default">`:
+
+```html
+<section id="footnotes" class="footnotes section" role="doc-endnotes">
+<hr />
+<ol type="1">
+```
+
+Quarto 1 emits, in place of that `<hr />`:
+
+```html
+<h2 class="anchored quarto-appendix-heading">Footnotes</h2>
+```
+
+Two differences, not one — the heading is absent **and** the `<hr>` is present.
+Q1's `prependHeading` (`format-html-shared.ts:388-410`) removes the rule when it
+inserts the heading. The strand description asserts the `<hr />` is correct; it is
+not. See Finding 3 in the plan.

--- a/claude-notes/plans/footnotes-appendix-heading-investigation/repro-observed-at-de2375f0.html
+++ b/claude-notes/plans/footnotes-appendix-heading-investigation/repro-observed-at-de2375f0.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="generator" content="quarto-rust-0.19.0">
+<title>Footnote heading repro</title>
+<link rel="stylesheet" href="repro_files/styles.css">
+<script src="repro_files/bootstrap.bundle.min.js"></script>
+<script src="repro_files/clipboard.min.js"></script>
+<script src="repro_files/code-copy-init.js"></script>
+</head>
+<body class="fullcontent quarto-light">
+
+<div id="quarto-content" class="quarto-container page-columns page-rows-contents page-layout-article">
+
+<main class="content" id="quarto-document-content">
+
+<header id="title-block-header" class="quarto-title-block default">
+<div class="quarto-title">
+<h1 class="title">Footnote heading repro</h1>
+</div>
+<div class="quarto-title-meta">
+</div>
+
+</header>
+
+
+<p>Some text with a note.<span id="fnref1"><sup><a href="#fn1" class="footnote-ref" role="doc-noteref">1</a></sup></span></p>
+<p>More text with another.<span id="fnref2"><sup><a href="#fn2" class="footnote-ref" role="doc-noteref">2</a></sup></span></p>
+<div id="quarto-appendix" class="default">
+<section id="footnotes" class="footnotes section" role="doc-endnotes">
+<hr />
+<ol type="1">
+<li><div id="fn1">
+<p>First note.<a href="#fnref1" class="footnote-back" role="doc-backlink">↩︎</a></p>
+</div>
+</li>
+<li><div id="fn2">
+<p>Second note.<a href="#fnref2" class="footnote-back" role="doc-backlink">↩︎</a></p>
+</div>
+</li>
+</ol>
+</section>
+</div>
+
+</main>
+</div>
+</body>
+</html>

--- a/claude-notes/plans/footnotes-appendix-heading-investigation/repro.qmd
+++ b/claude-notes/plans/footnotes-appendix-heading-investigation/repro.qmd
@@ -1,0 +1,11 @@
+---
+title: Footnote heading repro
+---
+
+Some text with a note.[^a]
+
+More text with another.[^b]
+
+[^a]: First note.
+
+[^b]: Second note.

--- a/crates/quarto-core/src/transforms/appendix.rs
+++ b/crates/quarto-core/src/transforms/appendix.rs
@@ -47,7 +47,7 @@ use hashlink::LinkedHashMap;
 use quarto_pandoc_types::Blocks;
 use quarto_pandoc_types::attr::AttrSourceInfo;
 use quarto_pandoc_types::block::{Block, Div, Header, Paragraph};
-use quarto_pandoc_types::inline::{Inline, Link, Str};
+use quarto_pandoc_types::inline::{Inline, Link, Space, Str};
 use quarto_pandoc_types::pandoc::Pandoc;
 use quarto_source_map::{By, SourceInfo};
 use smallvec::smallvec;
@@ -145,14 +145,14 @@ impl AstTransform for AppendixStructureTransform {
         if reference_location != ReferenceLocation::Margin
             && let Some(bibliography) = extract_bibliography(&mut ast.blocks)
         {
-            appendix_sections.push(wrap_bibliography(bibliography));
+            appendix_sections.push(wrap_bibliography(bibliography, &ast.meta));
         }
 
         // 3. Collect footnotes section (if not margin mode)
         if reference_location != ReferenceLocation::Margin
             && let Some(footnotes) = extract_footnotes(&mut ast.blocks)
         {
-            appendix_sections.push(footnotes);
+            appendix_sections.push(wrap_footnotes(footnotes, &ast.meta));
         }
 
         // 4. Create metadata-driven sections
@@ -236,24 +236,128 @@ fn extract_footnotes(blocks: &mut Vec<Block>) -> Option<Block> {
     footnotes
 }
 
+/// The localized title for an appendix section.
+///
+/// Precedence follows `toc_generate.rs` (decided under bd-llhlzd7p): the
+/// resolved `section-title-*` term when [`LanguageResolveStage`] has run,
+/// otherwise the English literal. `LanguageTerms::from_meta` returns `None`
+/// when the stage has not run — the case in stage-less unit tests — which is
+/// what the literal tail is for.
+///
+/// There is deliberately **no** per-document override tier here: unlike
+/// `toc-title`, Quarto 1 exposes no `footnotes-title`-style option for these
+/// sections, so metadata is not consulted beyond the language table.
+///
+/// [`LanguageResolveStage`]: crate::stage::stages::language_resolve
+fn appendix_title(meta: &ConfigValue, term_key: &str, english: &str) -> String {
+    crate::language::LanguageTerms::from_meta(meta)
+        .and_then(|terms| terms.get(term_key).map(str::to_string))
+        // A term explicitly set to null round-trips as an empty string; an
+        // untitled section is never what the reader wants, so fall through.
+        .filter(|title| !title.is_empty())
+        .unwrap_or_else(|| english.to_string())
+}
+
+/// Split a title into canonical Pandoc inlines.
+///
+/// Titles are `Str`/`Space` alternations rather than one `Str` carrying
+/// embedded spaces, which is what the AST means by a run of text. Every
+/// English appendix title happens to be a single word, so this only shows up
+/// once localized — `section-title-copyright` is "Derechos de autor" in
+/// Spanish and "Droits d'auteur" in French.
+fn title_inlines(title: &str, source_info: &SourceInfo) -> Vec<Inline> {
+    let mut inlines = Vec::new();
+    for (i, word) in title.split_whitespace().enumerate() {
+        if i > 0 {
+            inlines.push(Inline::Space(Space {
+                source_info: source_info.clone(),
+            }));
+        }
+        inlines.push(Inline::Str(Str {
+            text: word.to_string(),
+            source_info: source_info.clone(),
+        }));
+    }
+    inlines
+}
+
+/// Build the level-2 heading that titles an appendix section.
+///
+/// Mirrors Quarto 1's `prependHeading` + `headingClasses`
+/// (`format-html-appendix.ts:98`): no id — the heading is not linkable and
+/// does not enter the TOC — and the classes `anchored quarto-appendix-heading`.
+///
+/// `quarto-appendix-heading` drives real styling that q2 already ships
+/// (`resources/scss/bootstrap/_bootstrap-rules.scss`). `anchored` is inert
+/// here: in Quarto 1 it is a selector hook AnchorJS reads to inject heading
+/// anchor links, and q2 ships neither that runtime nor any rule matching the
+/// class. It is emitted anyway so the appendix is already correct when
+/// heading anchors land — see bd-5kf2dnw4, which must skip headings that
+/// already carry the class (pushing onto a `Vec<String>` is not idempotent
+/// the way Quarto 1's `classList.add` is).
+fn appendix_heading(meta: &ConfigValue, term_key: &str, english: &str) -> Block {
+    let source_info = SourceInfo::Generated {
+        by: By::appendix(),
+        from: smallvec![],
+    };
+    Block::Header(Header {
+        level: 2,
+        attr: (
+            String::new(),
+            vec![
+                "anchored".to_string(),
+                "quarto-appendix-heading".to_string(),
+            ],
+            LinkedHashMap::new(),
+        ),
+        content: title_inlines(&appendix_title(meta, term_key, english), &source_info),
+        source_info,
+        attr_source: AttrSourceInfo::empty(),
+    })
+}
+
+/// Title the footnotes section in place.
+///
+/// The section built by `FootnotesTransform` is already a `.section` Div with
+/// the right id and `doc-endnotes` role, so the heading is prepended into it
+/// rather than nesting a second section around it.
+///
+/// The leading `<hr>` is dropped: Quarto 1's `prependHeading` removes the
+/// rule when it inserts the heading (`format-html-shared.ts:405-409`), the
+/// heading taking over as the section separator. The strip lives here, not in
+/// `create_footnotes_section`, because the rule must survive when appendix
+/// processing is off and no heading is ever added (bd-v9zs83zj).
+fn wrap_footnotes(footnotes: Block, meta: &ConfigValue) -> Block {
+    let mut div = match footnotes {
+        Block::Div(div) => div,
+        // `extract_footnotes` only ever yields a Div; nothing to title otherwise.
+        other => return other,
+    };
+
+    if let Some(pos) = div
+        .content
+        .iter()
+        .position(|b| matches!(b, Block::HorizontalRule(_)))
+    {
+        div.content.remove(pos);
+    }
+
+    div.content.insert(
+        0,
+        appendix_heading(meta, "section-title-footnotes", "Footnotes"),
+    );
+    Block::Div(div)
+}
+
 /// Wrap bibliography in a section with appropriate attributes.
-fn wrap_bibliography(bibliography: Block) -> Block {
+fn wrap_bibliography(bibliography: Block, meta: &ConfigValue) -> Block {
     let source_info = SourceInfo::Generated {
         by: By::appendix(),
         from: smallvec![],
     };
 
     // Create header for the bibliography section
-    let header = Block::Header(Header {
-        level: 2,
-        attr: (String::new(), Vec::new(), LinkedHashMap::new()),
-        content: vec![Inline::Str(Str {
-            text: "References".to_string(),
-            source_info: source_info.clone(),
-        })],
-        source_info: source_info.clone(),
-        attr_source: AttrSourceInfo::empty(),
-    });
+    let header = appendix_heading(meta, "section-title-references", "References");
 
     Block::Div(Div {
         attr: (
@@ -307,16 +411,7 @@ fn create_license_section(meta: &ConfigValue) -> Option<Block> {
         from: smallvec![],
     };
 
-    let header = Block::Header(Header {
-        level: 2,
-        attr: (String::new(), Vec::new(), LinkedHashMap::new()),
-        content: vec![Inline::Str(Str {
-            text: "Reuse".to_string(),
-            source_info: source_info.clone(),
-        })],
-        source_info: source_info.clone(),
-        attr_source: AttrSourceInfo::empty(),
-    });
+    let header = appendix_heading(meta, "section-title-reuse", "Reuse");
 
     let content = Block::Paragraph(Paragraph {
         content: vec![Inline::Str(Str {
@@ -361,16 +456,7 @@ fn create_copyright_section(meta: &ConfigValue) -> Option<Block> {
         from: smallvec![],
     };
 
-    let header = Block::Header(Header {
-        level: 2,
-        attr: (String::new(), Vec::new(), LinkedHashMap::new()),
-        content: vec![Inline::Str(Str {
-            text: "Copyright".to_string(),
-            source_info: source_info.clone(),
-        })],
-        source_info: source_info.clone(),
-        attr_source: AttrSourceInfo::empty(),
-    });
+    let header = appendix_heading(meta, "section-title-copyright", "Copyright");
 
     let content = Block::Paragraph(Paragraph {
         content: vec![Inline::Str(Str {
@@ -408,16 +494,7 @@ fn create_citation_section(meta: &ConfigValue) -> Option<Block> {
         from: smallvec![],
     };
 
-    let header = Block::Header(Header {
-        level: 2,
-        attr: (String::new(), Vec::new(), LinkedHashMap::new()),
-        content: vec![Inline::Str(Str {
-            text: "Citation".to_string(),
-            source_info: source_info.clone(),
-        })],
-        source_info: source_info.clone(),
-        attr_source: AttrSourceInfo::empty(),
-    });
+    let header = appendix_heading(meta, "section-title-citation", "Citation");
 
     // Create citation content based on what's available
     let content_inlines = if let Some(url) = citation_url {
@@ -466,8 +543,8 @@ fn create_citation_section(meta: &ConfigValue) -> Option<Block> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use quarto_pandoc_types::ConfigMapEntry;
     use quarto_pandoc_types::block::Plain;
+    use quarto_pandoc_types::{ConfigMapEntry, ConfigValueKind};
     use quarto_source_map::{FileId, Location, Range};
 
     use crate::format::Format;
@@ -523,6 +600,97 @@ mod tests {
             source_info: dummy_source_info(),
             attr_source: AttrSourceInfo::empty(),
         })
+    }
+
+    /// Metadata carrying a resolved `quarto.language` table, shaped exactly as
+    /// `LanguageResolveStage` injects it. Transforms read it back through
+    /// `LanguageTerms::from_meta`.
+    fn make_meta_with_lang(lang: &str) -> ConfigValue {
+        let terms = crate::language::resolve_language(lang, &[]);
+        make_meta(vec![
+            meta_entry(
+                "lang",
+                ConfigValue::new_string(lang.to_string(), dummy_source_info()),
+            ),
+            meta_entry(
+                "quarto",
+                make_meta(vec![meta_entry("language", terms.to_config_value())]),
+            ),
+        ])
+    }
+
+    /// A footnotes section shaped like the one `create_footnotes_section`
+    /// actually emits: an `<hr>` followed by the note list. The plain
+    /// `make_footnotes_section` helper omits the rule, which is precisely the
+    /// element the appendix transform has to strip (bd-v9zs83zj).
+    fn make_footnotes_section_with_rule() -> Block {
+        Block::Div(Div {
+            attr: (
+                "footnotes".to_string(),
+                vec!["footnotes".to_string(), "section".to_string()],
+                LinkedHashMap::from_iter([("role".to_string(), "doc-endnotes".to_string())]),
+            ),
+            content: vec![
+                Block::HorizontalRule(quarto_pandoc_types::block::HorizontalRule {
+                    source_info: dummy_source_info(),
+                }),
+                Block::Plain(Plain {
+                    content: vec![make_str("Footnote content")],
+                    source_info: dummy_source_info(),
+                }),
+            ],
+            source_info: dummy_source_info(),
+            attr_source: AttrSourceInfo::empty(),
+        })
+    }
+
+    /// The `Header` an appendix section leads with.
+    fn section_heading(block: &Block) -> &Header {
+        let Block::Div(div) = block else {
+            panic!("expected a section Div, got {block:?}");
+        };
+        match div.content.first() {
+            Some(Block::Header(h)) => h,
+            other => panic!("expected a leading Header, got {other:?}"),
+        }
+    }
+
+    /// Flattened text of a heading's inlines. Titles are `Str`/`Space`
+    /// alternations, so `Space` has to render as a space rather than be
+    /// skipped — otherwise "Derechos de autor" reads as "Derechosdeautor".
+    fn heading_text(header: &Header) -> String {
+        header
+            .content
+            .iter()
+            .map(|inline| match inline {
+                Inline::Str(s) => s.text.as_str(),
+                Inline::Space(_) => " ",
+                other => panic!("unexpected inline in an appendix heading: {other:?}"),
+            })
+            .collect()
+    }
+
+    /// The sections inside the `#quarto-appendix` container, which the
+    /// transform appends as the document's last block.
+    fn appendix_sections(ast: &Pandoc) -> &[Block] {
+        let Some(Block::Div(div)) = ast.blocks.last() else {
+            panic!("expected a trailing appendix Div");
+        };
+        assert_eq!(div.attr.0, "quarto-appendix");
+        &div.content
+    }
+
+    /// Run the transform over `ast` with a throwaway HTML render context.
+    async fn run_transform(ast: &mut Pandoc) {
+        let project = make_test_project();
+        let doc = DocumentInfo::from_path("/project/doc.qmd");
+        let format = Format::html();
+        let binaries = BinaryDependencies::new();
+        let mut ctx = RenderContext::new(&project, &doc, &format, &binaries);
+        AppendixStructureTransform::new()
+            .transform(ast, &mut ctx)
+            .await
+            .unwrap();
     }
 
     fn make_footnotes_section() -> Block {
@@ -927,5 +1095,218 @@ mod tests {
             }
             other => panic!("Expected Generated, got {:?}", other),
         }
+    }
+
+    // ---------------------------------------------------------------
+    // Appendix section headings (bd-v9zs83zj)
+    //
+    // Quarto 1 titles every appendix section from a `section-title-*`
+    // language term and tags the heading `anchored quarto-appendix-heading`
+    // (`format-html-appendix.ts:98`). The footnotes section additionally
+    // loses its `<hr>`, because Q1's `prependHeading` removes the rule when
+    // it inserts the heading (`format-html-shared.ts:405-409`).
+    // ---------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_footnotes_section_gets_heading() {
+        let mut ast = Pandoc {
+            meta: ConfigValue::default(),
+            blocks: vec![make_footnotes_section_with_rule()],
+        };
+        run_transform(&mut ast).await;
+
+        let heading = section_heading(&appendix_sections(&ast)[0]);
+        assert_eq!(heading_text(heading), "Footnotes");
+        assert_eq!(heading.level, 2);
+    }
+
+    #[tokio::test]
+    async fn test_appendix_heading_has_q1_classes_and_no_id() {
+        let mut ast = Pandoc {
+            meta: ConfigValue::default(),
+            blocks: vec![make_footnotes_section_with_rule()],
+        };
+        run_transform(&mut ast).await;
+
+        let (id, classes, attrs) = &section_heading(&appendix_sections(&ast)[0]).attr;
+        // Q1's `prependHeading` sets no id: the heading is not linkable and
+        // does not enter the TOC.
+        assert_eq!(id, "");
+        assert_eq!(classes, &["anchored", "quarto-appendix-heading"]);
+        assert!(attrs.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_footnotes_rule_removed_when_titled() {
+        let mut ast = Pandoc {
+            meta: ConfigValue::default(),
+            blocks: vec![make_footnotes_section_with_rule()],
+        };
+        run_transform(&mut ast).await;
+
+        let Block::Div(footnotes) = &appendix_sections(&ast)[0] else {
+            panic!("expected the footnotes Div");
+        };
+        assert!(
+            !footnotes
+                .content
+                .iter()
+                .any(|b| matches!(b, Block::HorizontalRule(_))),
+            "the heading replaces the rule as the separator; got {:?}",
+            footnotes.content
+        );
+        // The note content itself must survive the strip.
+        assert!(
+            footnotes
+                .content
+                .iter()
+                .any(|b| matches!(b, Block::Plain(_))),
+            "footnote content was dropped along with the rule"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_footnotes_rule_kept_when_appendix_disabled() {
+        // With no appendix to title the section, the rule is the only
+        // separator the reader gets — so it must stay. Q1 agrees: it only
+        // titles footnotes from inside `processDocumentAppendix`.
+        let mut ast = Pandoc {
+            meta: make_meta(vec![meta_entry(
+                "appendix-style",
+                ConfigValue::new_string("none".to_string(), dummy_source_info()),
+            )]),
+            blocks: vec![make_footnotes_section_with_rule()],
+        };
+        run_transform(&mut ast).await;
+
+        let Some(Block::Div(footnotes)) = ast.blocks.last() else {
+            panic!("expected the footnotes Div to stay in place");
+        };
+        assert_eq!(footnotes.attr.0, "footnotes");
+        assert!(
+            footnotes
+                .content
+                .iter()
+                .any(|b| matches!(b, Block::HorizontalRule(_))),
+            "the rule must survive when the appendix never titles the section"
+        );
+        assert!(
+            !footnotes
+                .content
+                .iter()
+                .any(|b| matches!(b, Block::Header(_))),
+            "no heading may be added when appendix processing is off"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_footnotes_rule_kept_for_book_format() {
+        // Books skip appendix processing entirely, so — as with
+        // `appendix-style: none` — nothing titles the section and the rule
+        // stays.
+        let mut ast = Pandoc {
+            meta: make_meta(vec![meta_entry(
+                "book",
+                ConfigValue::new_bool(true, dummy_source_info()),
+            )]),
+            blocks: vec![make_footnotes_section_with_rule()],
+        };
+        run_transform(&mut ast).await;
+
+        let Some(Block::Div(footnotes)) = ast.blocks.last() else {
+            panic!("expected the footnotes Div to stay in place");
+        };
+        assert_eq!(footnotes.attr.0, "footnotes");
+        assert!(
+            footnotes
+                .content
+                .iter()
+                .any(|b| matches!(b, Block::HorizontalRule(_))),
+            "the rule must survive in book format"
+        );
+        assert!(
+            !footnotes
+                .content
+                .iter()
+                .any(|b| matches!(b, Block::Header(_))),
+            "no heading may be added in book format"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_footnotes_heading_english_fallback_without_language_stage() {
+        // `LanguageTerms::from_meta` returns None when the resolve stage has
+        // not run (as in these stage-less unit tests). The English literal is
+        // the documented fallback tier, per `toc_generate.rs`.
+        let mut ast = Pandoc {
+            meta: ConfigValue::default(),
+            blocks: vec![make_footnotes_section_with_rule()],
+        };
+        run_transform(&mut ast).await;
+
+        assert_eq!(
+            heading_text(section_heading(&appendix_sections(&ast)[0])),
+            "Footnotes"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_footnotes_heading_localized() {
+        let mut ast = Pandoc {
+            meta: make_meta_with_lang("es"),
+            blocks: vec![make_footnotes_section_with_rule()],
+        };
+        run_transform(&mut ast).await;
+
+        assert_eq!(
+            heading_text(section_heading(&appendix_sections(&ast)[0])),
+            "Notas"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_all_appendix_headings_localized() {
+        // Every section the transform can emit takes its title from the
+        // matching `section-title-*` term, not an English literal.
+        let mut meta_entries = match &make_meta_with_lang("es").value {
+            ConfigValueKind::Map(entries) => entries.clone(),
+            _ => unreachable!("make_meta_with_lang builds a map"),
+        };
+        meta_entries.push(meta_entry(
+            "license",
+            ConfigValue::new_string("CC BY 4.0".to_string(), dummy_source_info()),
+        ));
+        meta_entries.push(meta_entry(
+            "copyright",
+            ConfigValue::new_string("Posit, PBC".to_string(), dummy_source_info()),
+        ));
+        meta_entries.push(meta_entry(
+            "citation",
+            make_meta(vec![meta_entry(
+                "url",
+                ConfigValue::new_string("https://example.com".to_string(), dummy_source_info()),
+            )]),
+        ));
+
+        let mut ast = Pandoc {
+            meta: make_meta(meta_entries),
+            blocks: vec![make_bibliography(), make_footnotes_section_with_rule()],
+        };
+        run_transform(&mut ast).await;
+
+        let titles: Vec<String> = appendix_sections(&ast)
+            .iter()
+            .map(|s| heading_text(section_heading(s)))
+            .collect();
+        assert_eq!(
+            titles,
+            vec![
+                "Referencias",       // section-title-references
+                "Notas",             // section-title-footnotes
+                "Reutilización",     // section-title-reuse
+                "Derechos de autor", // section-title-copyright
+                "Cómo citar",        // section-title-citation
+            ]
+        );
     }
 }

--- a/crates/quarto/tests/smoke-all/appendix/_quarto.yml
+++ b/crates/quarto/tests/smoke-all/appendix/_quarto.yml
@@ -1,0 +1,2 @@
+project:
+  title: Appendix Tests

--- a/crates/quarto/tests/smoke-all/appendix/footnotes-heading-style-none.qmd
+++ b/crates/quarto/tests/smoke-all/appendix/footnotes-heading-style-none.qmd
@@ -1,0 +1,23 @@
+---
+title: Footnotes keep their rule when the appendix is off
+appendix-style: none
+format: html
+_quarto:
+  tests:
+    html:
+      noErrors: true
+      # With appendix processing disabled the footnotes section is never
+      # relocated or titled, so it keeps the `<hr>` it was built with.
+      # Quarto 1 behaves the same way: `insertFootnotesTitle` is only
+      # reached from inside `processDocumentAppendix` (bd-v9zs83zj).
+      ensureHtmlElements:
+        - ["section#footnotes hr"]
+        - ["div#quarto-appendix", "h2.quarto-appendix-heading"]
+      ensureFileRegexMatches:
+        - []
+        - [">Footnotes</h2>"]
+---
+
+Text with a note.[^a]
+
+[^a]: Only note.

--- a/crates/quarto/tests/smoke-all/appendix/footnotes-heading.qmd
+++ b/crates/quarto/tests/smoke-all/appendix/footnotes-heading.qmd
@@ -1,0 +1,26 @@
+---
+title: Footnotes appendix heading
+format: html
+_quarto:
+  tests:
+    html:
+      noErrors: true
+      ensureHtmlElements:
+        - [
+            "div#quarto-appendix section#footnotes h2.anchored.quarto-appendix-heading",
+          ]
+        # The heading replaces the rule as the section separator, matching
+        # Quarto 1's `prependHeading` (bd-v9zs83zj). No `<hr>` may survive
+        # inside the titled footnotes section.
+        - ["div#quarto-appendix section#footnotes hr"]
+      ensureFileRegexMatches:
+        - [">Footnotes</h2>"]
+---
+
+Text with a note.[^a]
+
+More text with another.[^b]
+
+[^a]: First note.
+
+[^b]: Second note.

--- a/crates/quarto/tests/smoke-all/localization/lang-es-appendix-headings.qmd
+++ b/crates/quarto/tests/smoke-all/localization/lang-es-appendix-headings.qmd
@@ -1,0 +1,22 @@
+---
+title: Appendix heading localization
+lang: es
+format: html
+license: "CC BY 4.0"
+copyright: "Posit, PBC"
+citation:
+  url: https://example.com/doc
+_quarto:
+  tests:
+    html:
+      noErrors: true
+      # Every appendix heading takes its text from the `section-title-*`
+      # language terms, not an English literal (bd-v9zs83zj).
+      ensureFileRegexMatches:
+        - ["Notas", "Reutilización", "Derechos de autor", "Cómo citar"]
+        - ["Footnotes", "Reuse", "Copyright", "Citation"]
+---
+
+Texto con una nota.[^a]
+
+[^a]: Primera nota.


### PR DESCRIPTION
Closes bd-v9zs83zj.

q2's footnotes appendix had no visible heading. `appendix.rs` pushed the extracted
footnotes Div **verbatim**, where the branch directly above it calls
`wrap_bibliography`. That asymmetry is the bug in one sentence; this adds the missing
`wrap_footnotes`.

Two things widened the fix beyond the strand's title, both agreed before implementation.

### 1. The `<hr>` goes too — the strand's premise was wrong here

The strand states the `<hr />` is correct and only the heading is missing. It isn't.
Quarto 1's `prependHeading` (`format-html-shared.ts:405-409`) inserts the heading **and
removes the rule** — the heading takes over as the section separator. Shipping the
heading alone would leave q2 emitting both, and the Connect-docs diff this strand exists
to close would *not* have closed.

The strip lives in the appendix transform, **not** in `create_footnotes_section`, so the
rule survives when appendix processing is off (`appendix-style: none`, `book: true`).
That matches Q1, which only titles footnotes from inside `processDocumentAppendix`.

### 2. All five headings, not one

`References` / `Reuse` / `Copyright` / `Citation` were hardcoded English despite
`section-title-*` keys existing in `_language.yml` and being fully translated across
every `_language-*.yml`. They now route through the same localized lookup, following
`toc_generate.rs`'s precedence (localized term > English literal — the literal covering
stage-less unit tests, where `LanguageTerms::from_meta` returns `None`).

### Heading shape

`class="anchored quarto-appendix-heading"`, no `id` — matching Q1 exactly.

- `quarto-appendix-heading` activates SCSS q2 **already shipped but never matched**
  (`_bootstrap-rules.scss`). This is a real visual change.
- `anchored` is **inert** in q2: in Q1 it is an AnchorJS selector hook, and q2 ships
  neither the runtime nor any rule for it. Emitted so the appendix is already correct
  when heading anchors land — follow-up **bd-5kf2dnw4**, which must skip headings that
  already carry the class, since `Vec<String>` push is not idempotent the way
  `classList.add` is.

Titles split into canonical `Str`/`Space` inlines rather than one `Str` with embedded
spaces. Never observable in English (every title is one word); required once localized
(`Derechos de autor`).

## Review notes

The two **must-not-change** cases — `appendix-style: none` and `book: true` — passed
before *and* after the change. They are the guard on the conditional `<hr>` strip.

`appendix_title` filters an empty resolved term before falling back: a language term set
to null round-trips as `Some("")`, which would emit a heading with no text.

Not using pampa's `split_string_to_inlines` — it is Lua-module-scoped and hardcodes
`By::unknown()` provenance; the local helper carries `By::appendix()`.

## Testing

7 new unit tests in `appendix.rs` + 3 smoke-all fixtures, **all confirmed failing
first** (6 unit failures, 7 regex mismatches).

**Snapshots: zero changed.** Verified this is real coverage rather than a blind spot —
no `.snap` in the tree contains appendix HTML at all (`quarto-appendix` /
`doc-endnotes` / `quarto-bibliography` all return nothing). The appendix is covered by
smoke-all and unit tests instead.

Full `cargo xtask verify` (not `--skip-hub-build`): **14/14 steps, 11801 passed, 197
skipped**.

End-to-end, three ways:

1. `cargo run --bin q2 -- render` → `<h2 class="anchored quarto-appendix-heading">Footnotes</h2>`,
   no `<hr>`. Byte-identical to Q1.
2. Computed styles read back from a real browser page: `font-weight 600`,
   `font-size 17px` (= `1em`), margins `0`, `border-bottom none`, `opacity .9` — every
   rule in the previously-dead block now applies. `#footnotes hr` → 0.
3. The `user/manifest` Connect-docs page re-rendered and compared against the Q1
   reference site: previously 0 occurrences of `quarto-appendix-heading`, now matching
   exactly.

Design rationale and the full investigation are in
`claude-notes/plans/2026-08-12-footnotes-appendix-heading.md`.

## Unrelated, filed separately

The first full verify failed at step 4 on a tree-sitter corpus case this change never
touches. Chased down: it reproduces on pristine `main` with the tree stashed,
`tree-sitter generate` yields no diff (so `parser.c` is in sync with `grammar.js`), and
it passes 3/3 after a forced rebuild. The culprit is the stale gitignored
`markdown.dylib` build cache. Filed as **bd-7ilvb5r2**; not a grammar bug and not this
change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
