### PR TITLE
Sidebar: contents: <directory> shorthand, and expand sidebars before selecting

### DIFF
--- a/claude-notes/plans/2026-08-12-sidebar-contents-dir-shorthand.md
+++ b/claude-notes/plans/2026-08-12-sidebar-contents-dir-shorthand.md
@@ -2,17 +2,18 @@
 
 **Date:** 2026-08-12
 **Braid:** `bd-sidebar-contents-dir-shorthand-z7arvhx8` (bug, p1, label `navigation`)
-**Branch:** investigated in the **main checkout** on `main` @ `152ed8fb`. No worktree
-was created — see "Where to do the work" below.
-**Status:** Investigation — pending design alignment with user.
-**Do not start implementation until the user gives the go-ahead.**
+**Branch:** `braid/bd-sidebar-contents-dir-shorthand-z7arvhx8`, off `main` @
+`152ed8fb`, in the **main checkout** (no worktree — user's call, Q5).
+**Also fixes:** `bd-4feoon8u` (multi-sidebar `auto:` selection).
+**Status:** Design settled 2026-08-13 — implementing.
 
 ## Triage verdict
 
 **Ready to design** — the bug is real, reproducible at HEAD, and precisely
 located. But the fix the strand proposes is **necessary and not sufficient**:
 it repairs the minimal repro while leaving the real-world Connect-docs failure
-in place. Two further decisions are needed before implementation (Q1/Q2 below).
+in place. Two further decisions were needed before implementation; both are
+settled below.
 
 ## Issue context
 
@@ -171,7 +172,7 @@ index.html             sidebar=0
 So **a pre-existing bug exists today, independent of this strand**: a
 multi-sidebar project using explicit `auto: <dir>` loses that sidebar entirely.
 Filed as `bd-4feoon8u` (`discovered-from` this
-strand). See Q4 for whether to fold the fix in here.
+strand), and fixed on this branch (D4).
 
 Note `resolve_sidebar_membership`
 (`crates/quarto-core/src/project/sidebar_membership.rs:77`) *does* expand before
@@ -188,97 +189,98 @@ not compensate.
   string, and every `chapters` hit in the tree is a test fixture directory name.
   When books land, they should route through whatever this fix establishes.
 
-## Proposed phases (draft)
+## Design decisions (settled 2026-08-13)
 
-Contents depend on the answers to Q1/Q2 below.
+**D1 — `auto: <bare dir>` produces a titled section too (full Q1 parity).**
+One spelling, one behavior. `contents: <dir>` then routes to
+`AutoSpec::Path` and needs no representation of its own.
 
-- **Phase 0 — Pin with failing tests.** Both failures are already reproduced
-  (the repro for the shorthand, the committed probe for the selection gap), so
-  this phase is about turning them into tests. Write failing tests: (a) parse —
-  scalar `contents: guides` produces the chosen `Auto` representation;
-  (b) expansion — it yields a titled section matching Q1's shape;
-  (c) end-to-end — a multi-sidebar project renders `#quarto-sidebar` on the
-  directory's pages. Confirm each fails before touching implementation.
-- **Phase 1 — Parse.** Route the scalar shorthand in `parse_contents` (`:528`).
-  One site covers both top-level and nested `contents:`, matching Q1's recursion.
-- **Phase 2 — Expansion shape.** Make a bare-directory spec expand via
-  `section_for_dir` rather than `flatten_as_links`. Shape determined by Q1.
-- **Phase 3 — Selection ordering.** Make `sidebar_for_page` see expanded
-  contents, per Q2.
-- **Phase 4 — End-to-end verification.** `cargo run --bin q2 -- render` on the
-  repro *and* the multi-sidebar probe; diff the sidebar DOM against
-  `_site-q1/`. Per CLAUDE.md, record the invocation and observed output.
-- **Phase 5 — Docs + error catalog.** Document the shorthand. Check whether
-  `Q-13-6` ("`auto:` matched no documents") wording still reads correctly when
-  the user wrote `contents: <dir>` and never typed `auto:`.
+The implementation falls out more cleanly than expected: `group_with_subdirs`
+partitions candidates by their *first path component*. When every candidate is
+beneath `how-to/`, `top_level` is empty and `dir_groups` has exactly one entry,
+so it already returns `vec![section_for_dir("how-to", …)]` — precisely Q1's
+shape. So D1 is **not** a new code path; it is choosing `Scope::All` instead of
+`Scope::Flat` for a bare-directory `AutoSpec::Path`.
 
-## Open design questions for the user
+Consequence: `auto_path_scopes_to_subdir` ("Test 21", `sidebar_auto.rs:504`) is
+rewritten — it asserts the behavior we are deliberately changing. Globs
+(`auto: docs/*`, `auto: docs/**/*.qmd`) are unaffected and stay flat.
 
-**Q1. Should `auto: <bare dir>` also produce a titled section, or only the new
-`contents: <dir>` shorthand?**
+**D2 — Expand before selecting.** Hoist expansion above `sidebar_for_page` and
+expand *every* declared sidebar, then pick. Correct by construction, and it is
+also the fix for `bd-4feoon8u`.
 
-In Q1 these are the same code path and both produce sections. In q2 they would
-diverge unless we change `auto:` too.
+The trap: this transform runs **per page**, so naively expanding all sidebars
+would fire `Q-13-6` ("`auto:` matched no documents") for unselected sidebars on
+every page. Expansion must therefore collect diagnostics **per sidebar**, and
+only the picked sidebar's diagnostics may reach `ctx.diagnostics`. Same applies
+to `strip_auto`'s `Q-13-5` on the no-index path.
 
-- **(a) Full Q1 parity** — make a bare-directory `AutoSpec::Path` expand via
-  `section_for_dir`; `contents: <dir>` then routes to `AutoSpec::Path` and the
-  strand's one-line fix genuinely suffices. Cost: changes documented `auto:`
-  behavior and rewrites `auto_path_scopes_to_subdir` (Test 21). *My
-  recommendation* — one spelling, one behavior, matches Q1, smallest surface.
-- **(b) Keep `auto:` flat; give the shorthand its own representation** (e.g. an
-  `AutoSpec::Dir(String)` variant, or a grouping flag). No existing behavior
-  changes. Cost: two different meanings for what Q1 treats as one spelling, and
-  a lasting parity gap on `auto:`.
+**D3 — Directory-ness comes from the project index, not the filesystem.** A
+pattern is a bare directory when it carries no glob metacharacter *and* at least
+one indexed profile lives beneath it. No I/O, WASM-safe.
 
-Note this only bites for a bare directory. `auto: docs/*` and `auto: docs/**/*.qmd`
-are globs, not directories, and stay flat under either option.
+Accepted quirk (user-confirmed): an empty or unindexed directory is not
+recognised as a directory and falls through to the `Q-13-6` empty-match warning.
+Unavoidable under the WASM/automerge project representation.
 
-**Q2. How should sidebar selection see through `auto:`?**
+**D4 — `bd-4feoon8u` is fixed here.** It is the same change as D2; splitting
+would be artificial.
 
-- **(a) Expand before selecting** — hoist `expand_auto` above `sidebar_for_page`
-  and expand each candidate sidebar, then pick. Correct by construction and also
-  fixes the pre-existing `auto:`-in-multi-sidebar bug. Cost: expands every
-  declared sidebar instead of just the chosen one, per page.
-  *My recommendation.*
-- **(b) Teach `contains_source_path` to match `Auto` specs directly** against the
-  glob without expanding. Cheaper, but duplicates matching logic in a second
-  place and risks the two drifting.
+**D5 — Branch, not worktree.** `braid/bd-sidebar-contents-dir-shorthand-z7arvhx8`
+in the main checkout.
 
-**Q3. Should "is this a directory?" be decided from the project index or the
-filesystem?** Q1 stats the filesystem. q2's expansion is index-driven and must
-work under WASM. I'd suggest **treating it as a directory when any indexed
-profile lives beneath it** — no I/O, WASM-safe, and consistent with the fact that
-only indexed documents can ever become entries. Confirm that's acceptable, since
-it means an empty or unindexed directory behaves as "not a directory" and falls
-through to the `Q-13-6` empty-match warning.
+## Phases
 
-**Q4. Should `bd-4feoon8u` be fixed here, or on its own?** The pre-existing
-multi-sidebar `auto:` selection bug is now filed separately (it reproduces with
-today's syntax, so it deserves its own record either way). But the Connect-docs
-case cannot be fixed without it. I'd implement both under this plan and close
-`bd-4feoon8u` with the same PR — confirm, or say if you want them split across
-branches.
+- [x] **Phase 1 — Expansion shape (D1, D3).** *Test first.*
+      `sidebar_auto.rs`: add the index-driven bare-directory test; select
+      `Scope::All` for such a spec in `collect_candidates`. Rewrite Test 21 to
+      the new contract and keep the glob tests green as the regression fence.
+- [ ] **Phase 2 — Parse the shorthand.** *Test first.*
+      `sidebar.rs:528`: route a scalar `contents:` that is neither `auto` nor a
+      separator to `SidebarEntry::Auto(AutoSpec::Path(s))`. One site covers both
+      top-level and nested `contents:`, matching Q1's recursion. Bare strings in
+      an *array* are untouched (Q1 parity — they stay `Link`/`Separator`).
+- [ ] **Phase 3 — Selection ordering (D2, `bd-4feoon8u`).** *Test first.*
+      `sidebar_generate.rs`: resolve hrefs + expand every parsed sidebar, then
+      `sidebar_for_page`, then enrich + active-state. Per-sidebar diagnostics;
+      only the picked sidebar's are emitted.
+- [ ] **Phase 4 — End-to-end verification.** `cargo run --bin q2 -- render` on
+      both the minimal repro and the committed multi-sidebar probe; compare the
+      sidebar DOM against the repro's `_site-q1/`. Per CLAUDE.md, record the
+      exact invocation and observed output in this plan.
+- [ ] **Phase 5 — Docs.** Document the shorthand and the `auto: <dir>` section
+      shape. Re-read `Q-13-6`'s wording for the case where the user wrote
+      `contents: <dir>` and never typed `auto:`.
+- [ ] **Phase 6 — Full `cargo xtask verify`** (not `--skip-hub-build`;
+      `quarto-core` is WASM-relevant), then request push approval.
 
-**Q5. Where should the work happen?** This investigation ran in the main
-checkout, which is clean at `origin/main`. Per the skill I did not create a
-branch or worktree. Given this touches `quarto-core` (WASM-relevant) and wants a
-full `cargo xtask verify`, a worktree via
-`cargo xtask create-worktree bd-sidebar-contents-dir-shorthand-z7arvhx8` seems
-right — but that's your call.
+## Known limitation (deliberate, not a regression)
 
-## Risks / tradeoffs (draft)
+`section_for_dir` builds its children as flat links, so documents nested
+*deeper* than one level under the directory (`how-to/deep/x.qmd` under
+`auto: how-to`) appear as flat entries rather than a nested sub-section. Q1
+recurses arbitrarily (`nodesToEntries`). This matches q2's existing one-level
+`group_with_subdirs` behavior and is out of scope here; file a follow-up if the
+Connect docs need it.
 
-- **Behavior change to a shipped feature.** Under option Q1(a), any project
-  relying on `auto: <dir>` producing a flat list gets a titled section instead.
-  This is Q1 parity, but it *is* a visible change for existing q2 users.
+## Risks / tradeoffs
+
+- **Behavior change to a shipped feature.** Per D1, any project relying on
+  `auto: <dir>` producing a flat list gets a titled section instead. This is Q1
+  parity, but it *is* a visible change for existing q2 users and should be
+  called out in the release notes.
 - **Selection ordering is load-bearing and under-tested.** The
   `sidebar_for_page` → `expand_auto` order looks incidental rather than
   designed. Changing it affects every multi-sidebar project, and the
   Rule-2 wildcard currently masks the defect in every single-sidebar project —
-  which is why this went unnoticed. Phase 0's probe should pin the current
-  behavior before it moves.
+  which is why this went unnoticed. The committed probe pins the pre-fix
+  behavior; Phase 3 must keep single-sidebar projects working unchanged.
 - **`quarto-core` is WASM-relevant**, so full `cargo xtask verify` (not
   `--skip-hub-build`) is required before pushing, per CLAUDE.md.
+- **Per-page cost.** D2 expands every declared sidebar on every page instead of
+  just the picked one. Fine at Connect-docs scale; worth a look if a project ever
+  declares many sidebars over many pages.
 - **Machine contention.** Sibling checkouts at `~/rooms/room-N/q2` share this
   disk and CPU; `verify` runs here are slow and have previously died on disk
   space. Budget for it.

--- a/claude-notes/plans/2026-08-12-sidebar-contents-dir-shorthand.md
+++ b/claude-notes/plans/2026-08-12-sidebar-contents-dir-shorthand.md
@@ -252,8 +252,27 @@ in the main checkout.
 - [x] **Phase 5 — Docs.** Document the shorthand and the `auto: <dir>` section
       shape. Re-read `Q-13-6`'s wording for the case where the user wrote
       `contents: <dir>` and never typed `auto:`.
-- [ ] **Phase 6 — Full `cargo xtask verify`** (not `--skip-hub-build`;
+- [x] **Phase 6 — Full `cargo xtask verify`** (not `--skip-hub-build`;
       `quarto-core` is WASM-relevant), then request push approval.
+
+## Phase 6 — verification gate (2026-08-13)
+
+- `cargo xtask lint` — all checks passed (961 files).
+- `cargo nextest run --workspace` — **11834 passed**, 0 failed.
+- `cargo xtask verify` — **fails at step 4/14 on pre-existing tree-sitter
+  grammar failures, unrelated to this branch.** Confirmed by checking out `main`
+  and running `tree-sitter test` in
+  `crates/tree-sitter-qmd/tree-sitter-markdown`: the baseline produces the
+  *identical* result, `601 parses / 590 successful / 11 failed / 98.17%`. The
+  failing cases (`dot run at token start`, `bd-miif1k1z: adjacent definitions`,
+  `multiple punctuation marks`) are grammar tests with no connection to sidebars.
+  This is a condition of the checkout, not a regression — but it does mean
+  **`cargo xtask verify` cannot run clean here until the grammar is regenerated**.
+- `cargo xtask verify --skip-treesitter-tests --skip-treesitter-crlf-tests` —
+  **EXIT=0, all 14 steps passed**, including the WASM/hub-client leg
+  (steps 7-8) that `--skip-hub-build` would have skipped. This is the leg that
+  matters here, since `quarto-core` is in `wasm-quarto-hub-client`'s
+  dependency closure.
 
 ## Phase 4 — end-to-end verification (2026-08-13)
 

--- a/claude-notes/plans/2026-08-12-sidebar-contents-dir-shorthand.md
+++ b/claude-notes/plans/2026-08-12-sidebar-contents-dir-shorthand.md
@@ -1,0 +1,289 @@
+# Sidebar `contents: <directory>` shorthand renders a broken sidebar (bd-sidebar-contents-dir-shorthand-z7arvhx8)
+
+**Date:** 2026-08-12
+**Braid:** `bd-sidebar-contents-dir-shorthand-z7arvhx8` (bug, p1, label `navigation`)
+**Branch:** investigated in the **main checkout** on `main` @ `152ed8fb`. No worktree
+was created — see "Where to do the work" below.
+**Status:** Investigation — pending design alignment with user.
+**Do not start implementation until the user gives the go-ahead.**
+
+## Triage verdict
+
+**Ready to design** — the bug is real, reproducible at HEAD, and precisely
+located. But the fix the strand proposes is **necessary and not sufficient**:
+it repairs the minimal repro while leaving the real-world Connect-docs failure
+in place. Two further decisions are needed before implementation (Q1/Q2 below).
+
+## Issue context
+
+A website sidebar whose `contents:` is a bare directory name renders no usable
+navigation. Q1 treats the directory as an auto-generation source; q2 treats the
+string as a single href and emits one dead link — and in a multi-sidebar project
+it emits no sidebar element at all.
+
+Filed 2026-08-13 by Claude (q2-connect-docs) against q2 0.19.0, re-verified on
+0.20.0. Priority 1. Origin strand `br-sidebar-contents-dir-shorthand-8rvnztv6`
+lives in the connect-docs skein.
+
+## Dependency graph
+
+**Empty.** `braid dep tree` shows the strand alone; `braid dep list` returns no
+edges. The `discovered-from` context the strand references
+(`br-sidebar-contents-dir-shorthand-8rvnztv6`, and `br-wu5cbkws` for the Connect
+impact) is in a *different skein* and is not reachable from here — the strand
+description is the only carrier of that context, which is why it is unusually
+detailed.
+
+No incoming `blocks` edges, so nothing in this skein is waiting on it. The
+urgency is external: the Connect docs port.
+
+## What the code looks like today
+
+Every file and line the strand cites still exists and has the described shape.
+Nothing has touched `crates/quarto-navigation` since the v0.20.0 release merge.
+
+### Root cause (confirmed)
+
+`parse_contents` — `crates/quarto-navigation/src/sidebar.rs:528` — special-cases
+exactly one bare string:
+
+```rust
+if let Some(s) = cv.as_plain_text() {
+    if s == "auto" {
+        return vec![SidebarEntry::Auto(AutoSpec::All)];
+    }
+    return vec![SidebarEntry::from_plain_string(&s, cv.source_info.clone())];
+}
+```
+
+`from_plain_string` (`:288`) classifies a 3+-dash run as a separator and
+*everything else* as an href. So `contents: guides` becomes
+`SidebarEntry::Link { href: "guides" }`.
+
+Confirmed in the repro's committed output — `_site/guides/first.html` contains
+`href="guides"`, which from `guides/first.html` resolves to `guides/guides`.
+(Minor correction to the strand: the element is `<nav id="quarto-sidebar">`, not
+a `<div>`. Worth knowing when writing the regression assertion.)
+
+### What Q1 actually does (read from source, not inferred)
+
+`external-sources/quarto-cli/src/project/types/website/website-sidebar-auto.ts:96`,
+`normalizeSidebarItems`:
+
+```js
+if (typeof items === "string") {
+  if (items === "auto") items = [{ auto: true }];
+  else                  items = [{ auto: items }];   // <-- the shorthand
+}
+```
+
+So in Q1 **`contents: guides` is literally `contents: [{auto: "guides"}]`.** The
+strand's suggested routing is exactly Q1's rule.
+
+Two further Q1 facts settle the strand's open questions:
+
+1. **The shorthand is scalar-only.** A bare string that is an *array element*
+   goes through a different function — `normalizeSidebarItem` in
+   `src/project/project-config.ts:24` — which makes it `{href}` if the path
+   exists on disk and `{text}` (a plain label) otherwise. It is never turned
+   into an `auto`. Ordering confirmed at `website-navigation.ts:1051-1058`:
+   `expandAutoSidebarItems` runs on the whole `contents` first, then
+   `normalizeSidebarItem` runs per resulting item. `expandAutoSidebarItems`
+   also recurses into nested `item.contents`, so the shorthand applies to
+   nested section `contents:` too.
+
+   This resolves the strand's "one judgement call" (`contents: intro.qmd`):
+   **Q1 makes no special case.** A scalar is always an `auto`; a scalar naming a
+   single file simply auto-expands to that one file. No extension sniffing, no
+   file-vs-directory branch is needed at the *parse* site.
+
+2. **Q1's `auto: <dir>` also produces a section.** `globsFromAuto` rewrites an
+   existing directory to `<dir>/**`, and `isAutoDir` (`:113`) re-shuffles the
+   node set so the directory becomes a wrapping node. Q1 decides "is a
+   directory" by filesystem existence (`safeExistsSync` + `isDirectory`).
+
+Verified against the repro's committed Q1 output — `_site-q1/guides/first.html`
+has a `sidebar-item-section` titled **"Guides"** (capitalized directory name,
+because `guides/` has no `index.qmd`), expanded, with the two guides nested and
+**no href on the section header**.
+
+### The machinery q2 already has — and the gap
+
+`section_for_dir` (`crates/quarto-core/src/transforms/sidebar_auto.rs:320`)
+already builds exactly Q1's shape: section text from the directory's
+`index.qmd` title or `capitalize(dir)`, href to that index when present, children
+excluding the index. The repro's Q1 output matches its no-index branch precisely.
+
+**But `AutoSpec::Path` never reaches it.** `collect_candidates` (`:200`) hardwires
+`AutoSpec::Path` to `Scope::Flat`, so `expand_spec` calls `flatten_as_links`.
+Only `AutoSpec::All` gets `group_with_subdirs`. This is deliberate and pinned by
+`auto_path_scopes_to_subdir` (`:504`, "Test 21"), which asserts `auto: docs`
+yields flat `Link`s.
+
+So **routing the bare string to `AutoSpec::Path` alone produces a flat run of
+links, not Q1's titled section.** The strand anticipated this ("confirm the
+expansion produces Q1's section-with-title shape") — it is a real gap, and it is
+where design question Q1 below comes from.
+
+### The second defect: selection runs before expansion
+
+This is not in the strand, and it is why the fix as proposed would **not** fix
+the Connect docs.
+
+In `SidebarGenerateTransform`
+(`crates/quarto-core/src/transforms/sidebar_generate.rs`):
+
+- `sidebar_for_page(...)` is called at **`:89`**
+- `expand_auto(...)` is called at **`:127`**
+
+Selection therefore operates on *unexpanded* contents. And `contains_source_path`
+(`crates/quarto-navigation/src/sidebar.rs:647`) explicitly ignores
+`SidebarEntry::Auto(_)` (`:663`).
+
+`sidebar_for_page`'s rules explain both reported symptoms as one root cause:
+
+- **Minimal repro (one sidebar, no `id`)** — Rule 2, the single-sidebar wildcard
+  (`:637`), applies the sidebar regardless of containment. You get the sidebar
+  *with* the dead link. Matches the observed output.
+- **Connect docs (several sidebars)** — Rule 2 does not apply, so Rule 3
+  (containment) runs. The only entry is `Link { href: "how-to" }`, which matches
+  no page source, so **no sidebar is selected at all**. Matches the reported
+  "no `#quarto-sidebar` element whatsoever".
+
+Consequence: if the shorthand becomes `SidebarEntry::Auto(...)` and nothing else
+changes, Rule 3 still cannot see through it, and the Connect-docs pages still get
+no sidebar.
+
+**This is confirmed empirically, not inferred.** A probe fixture at
+`claude-notes/plans/sidebar-contents-dir-shorthand-investigation/multi-sidebar-auto/`
+declares two `id:`-bearing sidebars — defeating the Rule-2 wildcard, the same
+shape as the Connect docs — where one is defined by an explicit `auto: how-to`.
+It uses only syntax q2 supports today. Rendered at `main` @ `152ed8fb`:
+
+```
+how-to/index.html      sidebar=0
+how-to/one.html        sidebar=0
+how-to/two.html        sidebar=0
+other/alpha.html       sidebar=1
+index.html             sidebar=0
+```
+
+So **a pre-existing bug exists today, independent of this strand**: a
+multi-sidebar project using explicit `auto: <dir>` loses that sidebar entirely.
+Filed as `bd-4feoon8u` (`discovered-from` this
+strand). See Q4 for whether to fold the fix in here.
+
+Note `resolve_sidebar_membership`
+(`crates/quarto-core/src/project/sidebar_membership.rs:77`) *does* expand before
+walking, but it feeds Phase 8's dependency graph, not sidebar selection — it does
+not compensate.
+
+### Scope notes from the strand, resolved
+
+- **Listings** — *not affected*. `crates/quarto-core/src/project/listing/config.rs:631`
+  is an independent `parse_contents` that turns a scalar `contents:` into a
+  `ListingContents::Glob`, which is already correct for listings.
+- **Book chapters** — *nothing to check*. q2 has no `book.chapters:` parser;
+  `ProjectKind::Book` (`project/mod.rs:317`) is only an accepted project-type
+  string, and every `chapters` hit in the tree is a test fixture directory name.
+  When books land, they should route through whatever this fix establishes.
+
+## Proposed phases (draft)
+
+Contents depend on the answers to Q1/Q2 below.
+
+- **Phase 0 — Pin with failing tests.** Both failures are already reproduced
+  (the repro for the shorthand, the committed probe for the selection gap), so
+  this phase is about turning them into tests. Write failing tests: (a) parse —
+  scalar `contents: guides` produces the chosen `Auto` representation;
+  (b) expansion — it yields a titled section matching Q1's shape;
+  (c) end-to-end — a multi-sidebar project renders `#quarto-sidebar` on the
+  directory's pages. Confirm each fails before touching implementation.
+- **Phase 1 — Parse.** Route the scalar shorthand in `parse_contents` (`:528`).
+  One site covers both top-level and nested `contents:`, matching Q1's recursion.
+- **Phase 2 — Expansion shape.** Make a bare-directory spec expand via
+  `section_for_dir` rather than `flatten_as_links`. Shape determined by Q1.
+- **Phase 3 — Selection ordering.** Make `sidebar_for_page` see expanded
+  contents, per Q2.
+- **Phase 4 — End-to-end verification.** `cargo run --bin q2 -- render` on the
+  repro *and* the multi-sidebar probe; diff the sidebar DOM against
+  `_site-q1/`. Per CLAUDE.md, record the invocation and observed output.
+- **Phase 5 — Docs + error catalog.** Document the shorthand. Check whether
+  `Q-13-6` ("`auto:` matched no documents") wording still reads correctly when
+  the user wrote `contents: <dir>` and never typed `auto:`.
+
+## Open design questions for the user
+
+**Q1. Should `auto: <bare dir>` also produce a titled section, or only the new
+`contents: <dir>` shorthand?**
+
+In Q1 these are the same code path and both produce sections. In q2 they would
+diverge unless we change `auto:` too.
+
+- **(a) Full Q1 parity** — make a bare-directory `AutoSpec::Path` expand via
+  `section_for_dir`; `contents: <dir>` then routes to `AutoSpec::Path` and the
+  strand's one-line fix genuinely suffices. Cost: changes documented `auto:`
+  behavior and rewrites `auto_path_scopes_to_subdir` (Test 21). *My
+  recommendation* — one spelling, one behavior, matches Q1, smallest surface.
+- **(b) Keep `auto:` flat; give the shorthand its own representation** (e.g. an
+  `AutoSpec::Dir(String)` variant, or a grouping flag). No existing behavior
+  changes. Cost: two different meanings for what Q1 treats as one spelling, and
+  a lasting parity gap on `auto:`.
+
+Note this only bites for a bare directory. `auto: docs/*` and `auto: docs/**/*.qmd`
+are globs, not directories, and stay flat under either option.
+
+**Q2. How should sidebar selection see through `auto:`?**
+
+- **(a) Expand before selecting** — hoist `expand_auto` above `sidebar_for_page`
+  and expand each candidate sidebar, then pick. Correct by construction and also
+  fixes the pre-existing `auto:`-in-multi-sidebar bug. Cost: expands every
+  declared sidebar instead of just the chosen one, per page.
+  *My recommendation.*
+- **(b) Teach `contains_source_path` to match `Auto` specs directly** against the
+  glob without expanding. Cheaper, but duplicates matching logic in a second
+  place and risks the two drifting.
+
+**Q3. Should "is this a directory?" be decided from the project index or the
+filesystem?** Q1 stats the filesystem. q2's expansion is index-driven and must
+work under WASM. I'd suggest **treating it as a directory when any indexed
+profile lives beneath it** — no I/O, WASM-safe, and consistent with the fact that
+only indexed documents can ever become entries. Confirm that's acceptable, since
+it means an empty or unindexed directory behaves as "not a directory" and falls
+through to the `Q-13-6` empty-match warning.
+
+**Q4. Should `bd-4feoon8u` be fixed here, or on its own?** The pre-existing
+multi-sidebar `auto:` selection bug is now filed separately (it reproduces with
+today's syntax, so it deserves its own record either way). But the Connect-docs
+case cannot be fixed without it. I'd implement both under this plan and close
+`bd-4feoon8u` with the same PR — confirm, or say if you want them split across
+branches.
+
+**Q5. Where should the work happen?** This investigation ran in the main
+checkout, which is clean at `origin/main`. Per the skill I did not create a
+branch or worktree. Given this touches `quarto-core` (WASM-relevant) and wants a
+full `cargo xtask verify`, a worktree via
+`cargo xtask create-worktree bd-sidebar-contents-dir-shorthand-z7arvhx8` seems
+right — but that's your call.
+
+## Risks / tradeoffs (draft)
+
+- **Behavior change to a shipped feature.** Under option Q1(a), any project
+  relying on `auto: <dir>` producing a flat list gets a titled section instead.
+  This is Q1 parity, but it *is* a visible change for existing q2 users.
+- **Selection ordering is load-bearing and under-tested.** The
+  `sidebar_for_page` → `expand_auto` order looks incidental rather than
+  designed. Changing it affects every multi-sidebar project, and the
+  Rule-2 wildcard currently masks the defect in every single-sidebar project —
+  which is why this went unnoticed. Phase 0's probe should pin the current
+  behavior before it moves.
+- **`quarto-core` is WASM-relevant**, so full `cargo xtask verify` (not
+  `--skip-hub-build`) is required before pushing, per CLAUDE.md.
+- **Machine contention.** Sibling checkouts at `~/rooms/room-N/q2` share this
+  disk and CPU; `verify` runs here are slow and have previously died on disk
+  space. Budget for it.
+- **The repro under-tests the real failure.** Its single sidebar hits the Rule-2
+  wildcard, so it cannot show the total-sidebar-loss symptom. Do not treat a
+  green repro as proof the Connect-docs case is fixed — that is what the
+  `multi-sidebar-auto` probe is for. Per the repro's README, it also does not
+  demonstrate the prev/next pagination loss.

--- a/claude-notes/plans/2026-08-12-sidebar-contents-dir-shorthand.md
+++ b/claude-notes/plans/2026-08-12-sidebar-contents-dir-shorthand.md
@@ -236,16 +236,16 @@ in the main checkout.
       `sidebar_auto.rs`: add the index-driven bare-directory test; select
       `Scope::All` for such a spec in `collect_candidates`. Rewrite Test 21 to
       the new contract and keep the glob tests green as the regression fence.
-- [ ] **Phase 2 — Parse the shorthand.** *Test first.*
+- [x] **Phase 2 — Parse the shorthand.** *Test first.*
       `sidebar.rs:528`: route a scalar `contents:` that is neither `auto` nor a
       separator to `SidebarEntry::Auto(AutoSpec::Path(s))`. One site covers both
       top-level and nested `contents:`, matching Q1's recursion. Bare strings in
       an *array* are untouched (Q1 parity — they stay `Link`/`Separator`).
-- [ ] **Phase 3 — Selection ordering (D2, `bd-4feoon8u`).** *Test first.*
+- [x] **Phase 3 — Selection ordering (D2, `bd-4feoon8u`).** *Test first.*
       `sidebar_generate.rs`: resolve hrefs + expand every parsed sidebar, then
       `sidebar_for_page`, then enrich + active-state. Per-sidebar diagnostics;
       only the picked sidebar's are emitted.
-- [ ] **Phase 4 — End-to-end verification.** `cargo run --bin q2 -- render` on
+- [x] **Phase 4 — End-to-end verification.** `cargo run --bin q2 -- render` on
       both the minimal repro and the committed multi-sidebar probe; compare the
       sidebar DOM against the repro's `_site-q1/`. Per CLAUDE.md, record the
       exact invocation and observed output in this plan.
@@ -254,6 +254,58 @@ in the main checkout.
       `contents: <dir>` and never typed `auto:`.
 - [ ] **Phase 6 — Full `cargo xtask verify`** (not `--skip-hub-build`;
       `quarto-core` is WASM-relevant), then request push approval.
+
+## Phase 4 — end-to-end verification (2026-08-13)
+
+Both fixtures rendered through the real binary (`cargo build --bin q2`), output
+inspected by hand. Not inferred from test results.
+
+### Minimal repro — `contents: guides`
+
+```
+$ q2 render   # in .../repros/sidebar-contents-dir-shorthand/
+Rendered 3 of 3 files
+```
+
+`_site/guides/first.html` now emits, where it previously emitted a single
+`href="guides"` dead link:
+
+```html
+<li class="sidebar-item sidebar-item-section">
+  <a ... data-bs-target="#quarto-sidebar-section-0" aria-expanded="true">Guides</a>
+  ...
+  <ul id="quarto-sidebar-section-0" class="collapse list-unstyled sidebar-section depth1 show">
+    <li class="sidebar-item"><a href="first.html" class="sidebar-item-text sidebar-link active">
+      <span class="menu-text">First Guide</span></a></li>
+    <li class="sidebar-item"><a href="second.html" class="sidebar-item-text sidebar-link">
+      <span class="menu-text">Second Guide</span></a></li>
+  </ul>
+</li>
+```
+
+Structurally identical to `_site-q1/guides/first.html`: a
+`sidebar-item-section` titled **Guides**, expanded (`aria-expanded="true"`,
+`sidebar-section depth1 show`), both guides nested, current page `active`.
+Remaining cosmetic deltas are pre-existing and unrelated to this fix — Q1 writes
+`../guides/first.html` where q2 writes `first.html` (both resolve), and Q1 wraps
+the section header text in `<span class="menu-text">`.
+
+### Multi-sidebar probe — `bd-4feoon8u`
+
+```
+$ q2 render   # in claude-notes/plans/sidebar-contents-dir-shorthand-investigation/multi-sidebar-auto/
+Rendered 5 of 5 files
+
+how-to/index.html      sidebar=1      (was 0)
+how-to/one.html        sidebar=1      (was 0)
+how-to/two.html        sidebar=1      (was 0)
+other/alpha.html       sidebar=1      (unchanged)
+index.html             sidebar=0      (unchanged — in neither sidebar)
+```
+
+And each page gets the *correct* sidebar, not merely some sidebar:
+`how-to/one.html` carries the **How To** sidebar (How To Index / Guide One /
+Guide Two); `other/alpha.html` still carries **Other**.
 
 ## Known limitation (deliberate, not a regression)
 

--- a/claude-notes/plans/2026-08-12-sidebar-contents-dir-shorthand.md
+++ b/claude-notes/plans/2026-08-12-sidebar-contents-dir-shorthand.md
@@ -259,20 +259,33 @@ in the main checkout.
 
 - `cargo xtask lint` — all checks passed (961 files).
 - `cargo nextest run --workspace` — **11834 passed**, 0 failed.
-- `cargo xtask verify` — **fails at step 4/14 on pre-existing tree-sitter
-  grammar failures, unrelated to this branch.** Confirmed by checking out `main`
-  and running `tree-sitter test` in
-  `crates/tree-sitter-qmd/tree-sitter-markdown`: the baseline produces the
-  *identical* result, `601 parses / 590 successful / 11 failed / 98.17%`. The
-  failing cases (`dot run at token start`, `bd-miif1k1z: adjacent definitions`,
-  `multiple punctuation marks`) are grammar tests with no connection to sidebars.
-  This is a condition of the checkout, not a regression — but it does mean
-  **`cargo xtask verify` cannot run clean here until the grammar is regenerated**.
-- `cargo xtask verify --skip-treesitter-tests --skip-treesitter-crlf-tests` —
-  **EXIT=0, all 14 steps passed**, including the WASM/hub-client leg
-  (steps 7-8) that `--skip-hub-build` would have skipped. This is the leg that
-  matters here, since `quarto-core` is in `wasm-quarto-hub-client`'s
-  dependency closure.
+- `cargo xtask verify` — **EXIT=0, all 14 steps passed, no skips.** This
+  includes the WASM/hub-client leg (steps 7-8) that `--skip-hub-build` would
+  have skipped — the leg that matters here, since `quarto-core` is in
+  `wasm-quarto-hub-client`'s dependency closure.
+
+### A false alarm worth recording
+
+The first `cargo xtask verify` run on this branch aborted at step 4/14 with 11
+failing tree-sitter grammar tests (`601 parses / 590 successful / 98.17%`).
+Checking out `main` reproduced it identically, so it was not a regression — but
+the initial conclusion, "the grammar needs regenerating before verify can run
+clean here," was **wrong**, and the `--skip-treesitter-tests` workaround was
+unnecessary.
+
+CI runs the same `tree-sitter test` in the same directory
+(`.github/workflows/test-suite.yml:171`) and passed on all four runners, which
+is what prompted a closer look:
+
+- `tree-sitter generate` changed **no tracked files** — the committed parser was
+  already in sync with `grammar.js`.
+- Re-running the tests afterward gives **601/601, 100%**.
+- The stale thing was `crates/tree-sitter-qmd/tree-sitter-markdown/markdown.dylib`,
+  a **gitignored build artifact**.
+
+So: a stale local `.dylib`, not a grammar problem and not a branch problem. If
+you see grammar failures that `main` also reproduces, run `tree-sitter generate`
+in that directory before concluding anything about the grammar.
 
 ## Phase 4 — end-to-end verification (2026-08-13)
 

--- a/claude-notes/plans/2026-08-12-sidebar-contents-dir-shorthand.md
+++ b/claude-notes/plans/2026-08-12-sidebar-contents-dir-shorthand.md
@@ -249,7 +249,7 @@ in the main checkout.
       both the minimal repro and the committed multi-sidebar probe; compare the
       sidebar DOM against the repro's `_site-q1/`. Per CLAUDE.md, record the
       exact invocation and observed output in this plan.
-- [ ] **Phase 5 — Docs.** Document the shorthand and the `auto: <dir>` section
+- [x] **Phase 5 — Docs.** Document the shorthand and the `auto: <dir>` section
       shape. Re-read `Q-13-6`'s wording for the case where the user wrote
       `contents: <dir>` and never typed `auto:`.
 - [ ] **Phase 6 — Full `cargo xtask verify`** (not `--skip-hub-build`;

--- a/claude-notes/plans/q-2-10-possessive-apostrophe-investigation/detached-errors.stderr
+++ b/claude-notes/plans/q-2-10-possessive-apostrophe-investigation/detached-errors.stderr
@@ -1,0 +1,1 @@
+/bin/bash: timeout: command not found

--- a/claude-notes/plans/sidebar-contents-dir-shorthand-investigation/multi-sidebar-auto/.gitignore
+++ b/claude-notes/plans/sidebar-contents-dir-shorthand-investigation/multi-sidebar-auto/.gitignore
@@ -1,0 +1,2 @@
+_site/
+.quarto/

--- a/claude-notes/plans/sidebar-contents-dir-shorthand-investigation/multi-sidebar-auto/README.md
+++ b/claude-notes/plans/sidebar-contents-dir-shorthand-investigation/multi-sidebar-auto/README.md
@@ -1,0 +1,63 @@
+# Probe: multi-sidebar `auto:` selection
+
+Investigation artifact for `bd-sidebar-contents-dir-shorthand-z7arvhx8`.
+Plan: `claude-notes/plans/2026-08-12-sidebar-contents-dir-shorthand.md`.
+
+## What this probes
+
+Whether q2 can select a sidebar whose membership is defined only by an
+**unexpanded `auto:` entry**, in a project with **more than one** sidebar.
+
+This uses only syntax q2 supports today (`auto: how-to`), so it is
+independent of the `contents: <dir>` shorthand bug itself. It isolates the
+*second* defect found during investigation:
+
+- `sidebar_for_page` runs at `transforms/sidebar_generate.rs:89`
+- `expand_auto` runs at `transforms/sidebar_generate.rs:127`
+
+so selection sees unexpanded contents, and `contains_source_path`
+(`quarto-navigation/src/sidebar.rs:647`) ignores `SidebarEntry::Auto(_)`
+(`:663`).
+
+Two sidebars are declared, both with `id:`, which defeats the
+single-sidebar wildcard (`sidebar.rs:637`) and forces Rule 3 containment
+matching — the same configuration shape as the Connect docs.
+
+## Confirmed failure at `main` @ `152ed8fb` (2026-08-12)
+
+```bash
+cargo run --bin q2 -- render claude-notes/plans/sidebar-contents-dir-shorthand-investigation/multi-sidebar-auto
+cd _site && for f in how-to/index.html how-to/one.html how-to/two.html other/alpha.html index.html; do
+  printf "%-22s sidebar=%s\n" "$f" "$(grep -c 'id="quarto-sidebar"' $f)"
+done
+```
+
+Observed:
+
+```
+how-to/index.html      sidebar=0
+how-to/one.html        sidebar=0
+how-to/two.html        sidebar=0
+other/alpha.html       sidebar=1
+index.html             sidebar=0
+```
+
+All three `how-to` pages carry **no** `#quarto-sidebar` element, exactly as
+the ordering analysis predicts: the `howto` sidebar's only entry is an
+unexpanded `Auto`, and containment cannot match through it.
+`other/alpha.html` still gets its sidebar because it names a page directly.
+(`index.html` having none is expected — it is in neither sidebar.)
+
+This confirms the defect is **pre-existing and independent of the
+`contents: <dir>` shorthand**, and that fixing only the shorthand's parse
+would leave the Connect-docs failure in place.
+
+## Expected after a fix
+
+All three `how-to` pages get the `howto` sidebar, with entries for
+`index`, `one` and `two`.
+
+## Expected after a fix
+
+All three `how-to` pages get the `howto` sidebar, with entries for
+`index`, `one` and `two`.

--- a/claude-notes/plans/sidebar-contents-dir-shorthand-investigation/multi-sidebar-auto/_quarto.yml
+++ b/claude-notes/plans/sidebar-contents-dir-shorthand-investigation/multi-sidebar-auto/_quarto.yml
@@ -1,0 +1,13 @@
+project:
+  type: website
+website:
+  title: "Multi-sidebar auto probe"
+  sidebar:
+    - id: howto
+      title: "How To"
+      contents:
+        - auto: how-to
+    - id: other
+      title: "Other"
+      contents:
+        - other/alpha.qmd

--- a/claude-notes/plans/sidebar-contents-dir-shorthand-investigation/multi-sidebar-auto/how-to/index.qmd
+++ b/claude-notes/plans/sidebar-contents-dir-shorthand-investigation/multi-sidebar-auto/how-to/index.qmd
@@ -1,0 +1,5 @@
+---
+title: "How To Index"
+---
+
+Index.

--- a/claude-notes/plans/sidebar-contents-dir-shorthand-investigation/multi-sidebar-auto/how-to/one.qmd
+++ b/claude-notes/plans/sidebar-contents-dir-shorthand-investigation/multi-sidebar-auto/how-to/one.qmd
@@ -1,0 +1,5 @@
+---
+title: "Guide One"
+---
+
+One.

--- a/claude-notes/plans/sidebar-contents-dir-shorthand-investigation/multi-sidebar-auto/how-to/two.qmd
+++ b/claude-notes/plans/sidebar-contents-dir-shorthand-investigation/multi-sidebar-auto/how-to/two.qmd
@@ -1,0 +1,5 @@
+---
+title: "Guide Two"
+---
+
+Two.

--- a/claude-notes/plans/sidebar-contents-dir-shorthand-investigation/multi-sidebar-auto/index.qmd
+++ b/claude-notes/plans/sidebar-contents-dir-shorthand-investigation/multi-sidebar-auto/index.qmd
@@ -1,0 +1,5 @@
+---
+title: "Home"
+---
+
+Home.

--- a/claude-notes/plans/sidebar-contents-dir-shorthand-investigation/multi-sidebar-auto/other/alpha.qmd
+++ b/claude-notes/plans/sidebar-contents-dir-shorthand-investigation/multi-sidebar-auto/other/alpha.qmd
@@ -1,0 +1,5 @@
+---
+title: "Alpha"
+---
+
+Alpha.

--- a/crates/quarto-core/src/transforms/sidebar_auto.rs
+++ b/crates/quarto-core/src/transforms/sidebar_auto.rs
@@ -162,7 +162,7 @@ pub fn expand_spec(
     }
 
     match scope {
-        Scope::All => group_with_subdirs(&candidates, index),
+        Scope::Grouped => group_with_subdirs(&candidates, index),
         Scope::Flat => flatten_as_links(&candidates),
     }
 }
@@ -175,12 +175,36 @@ fn auto_spec_debug(spec: &AutoSpec) -> String {
     }
 }
 
-/// The "scope" of an auto spec — whether it's a whole-project sweep
-/// (which may produce grouped Sections) or a scoped sub-path (which
-/// produces a flat list).
+/// The "scope" of an auto spec — whether its matches get partitioned
+/// into per-directory Sections, or emitted as a flat list of links.
 enum Scope {
-    All,
+    Grouped,
     Flat,
+}
+
+/// Does this `auto:` pattern name a **directory**?
+///
+/// bd-sidebar-contents-dir-shorthand-z7arvhx8 D3. Q1 answers this by
+/// stat-ing the filesystem (`safeExistsSync` + `isDirectory` in
+/// `website-sidebar-auto.ts`). q2 cannot: expansion is driven by the
+/// `ProjectIndex` and has to work under WASM, where there is no
+/// filesystem to stat. So we answer it from the index instead — a
+/// pattern is a directory when it carries no glob metacharacter *and*
+/// at least one matched document lives beneath it.
+///
+/// The deliberate consequence (accepted when this was designed): an
+/// empty or unindexed directory is not recognised as one. It matches
+/// nothing, so `expand_spec` returns early with the `Q-13-6`
+/// empty-match warning before scope is ever consulted.
+fn is_bare_directory(pattern: &str, candidates: &[&DocumentProfile]) -> bool {
+    let pattern = pattern.trim_end_matches('/');
+    if pattern.is_empty() || pattern.contains(['*', '?', '[', ']', '{', '}']) {
+        return false;
+    }
+    let prefix = format!("{}/", pattern);
+    candidates
+        .iter()
+        .any(|p| source_fwd_slash(p).starts_with(&prefix))
 }
 
 fn collect_candidates<'a>(
@@ -195,7 +219,7 @@ fn collect_candidates<'a>(
                 .filter(|p| !p.draft)
                 .filter(|p| !is_top_level_index(p))
                 .collect();
-            (candidates, Scope::All)
+            (candidates, Scope::Grouped)
         }
         AutoSpec::Path(pat) => {
             let matcher = auto_matcher(std::slice::from_ref(pat));
@@ -204,7 +228,16 @@ fn collect_candidates<'a>(
                 .filter(|p| !p.draft)
                 .filter(|p| matches_spec(p, matcher.as_ref()))
                 .collect();
-            (candidates, Scope::Flat)
+            // D1 — a bare directory is Q1's "auto-dir": the directory
+            // becomes a wrapping node. Every candidate then shares a
+            // first path component, so `group_with_subdirs` collapses
+            // to exactly one titled section. Globs stay flat.
+            let scope = if is_bare_directory(pat, &candidates) {
+                Scope::Grouped
+            } else {
+                Scope::Flat
+            };
+            (candidates, scope)
         }
         AutoSpec::Paths(pats) => {
             let matcher = auto_matcher(pats);
@@ -500,9 +533,18 @@ mod tests {
         }
     }
 
-    /// Test 21 — `auto: docs` scopes to the subdirectory and flattens.
+    /// Test 21 — `auto: docs` scopes to the subdirectory and wraps the
+    /// matches in a section titled after the directory.
+    ///
+    /// bd-sidebar-contents-dir-shorthand-z7arvhx8 D1: this asserted a
+    /// *flat* list of links until Q1 parity landed. Q1 treats a bare
+    /// directory as an auto-dir and re-roots the node set so the
+    /// directory becomes a wrapping node (`isAutoDir` in
+    /// `website-sidebar-auto.ts`), which is what the section below is.
+    /// Globs (`docs/*`, `docs/**/*.qmd`) are *not* directories and stay
+    /// flat — see the tests that follow.
     #[test]
-    fn auto_path_scopes_to_subdir() {
+    fn auto_bare_directory_wraps_in_titled_section() {
         let profiles = vec![
             make_profile("a.qmd", "A"),
             make_profile("docs/b.qmd", "B"),
@@ -511,16 +553,111 @@ mod tests {
         let index = ProjectIndex::new(profiles);
         let mut diags = Vec::new();
         let entries = expand_spec(&AutoSpec::Path("docs".to_string()), &index, &mut diags);
-        assert_eq!(entries.len(), 2);
-        for entry in &entries {
-            match entry {
-                SidebarEntry::Link { item, .. } => {
-                    let href = item.href.as_deref().unwrap();
-                    assert!(href.starts_with("docs/"), "got href {}", href);
+        assert_eq!(entries.len(), 1, "one section, not a flat run of links");
+        match &entries[0] {
+            SidebarEntry::Section {
+                text,
+                href,
+                contents,
+                ..
+            } => {
+                assert_eq!(
+                    text.as_ref().unwrap().as_plain_text().as_deref(),
+                    Some("Docs"),
+                    "no docs/index.qmd, so the title is the capitalized dir name"
+                );
+                assert_eq!(href.as_deref(), None, "no index.qmd means no header link");
+                assert_eq!(contents.len(), 2, "b and c");
+                for entry in contents {
+                    match entry {
+                        SidebarEntry::Link { item, .. } => {
+                            let href = item.href.as_deref().unwrap();
+                            assert!(href.starts_with("docs/"), "got href {}", href);
+                        }
+                        other => panic!("expected Link, got {:?}", other),
+                    }
                 }
-                other => panic!("expected Link, got {:?}", other),
             }
+            other => panic!("expected Section, got {:?}", other),
         }
+    }
+
+    /// D1 + D3 — a bare directory that *has* an `index.qmd` takes its
+    /// title and href from that index, and excludes it from the
+    /// children. This is the shape Q1 emits for the Connect docs'
+    /// `contents: how-to`.
+    #[test]
+    fn auto_bare_directory_section_uses_dir_index() {
+        let profiles = vec![
+            make_profile("how-to/index.qmd", "How To Guides"),
+            make_profile("how-to/one.qmd", "One"),
+            make_profile("how-to/two.qmd", "Two"),
+        ];
+        let index = ProjectIndex::new(profiles);
+        let mut diags = Vec::new();
+        let entries = expand_spec(&AutoSpec::Path("how-to".to_string()), &index, &mut diags);
+        assert_eq!(entries.len(), 1);
+        match &entries[0] {
+            SidebarEntry::Section {
+                text,
+                href,
+                contents,
+                ..
+            } => {
+                assert_eq!(
+                    text.as_ref().unwrap().as_plain_text().as_deref(),
+                    Some("How To Guides")
+                );
+                assert_eq!(href.as_deref(), Some("how-to/index.qmd"));
+                assert_eq!(contents.len(), 2, "index is the header, not a child");
+            }
+            other => panic!("expected Section, got {:?}", other),
+        }
+    }
+
+    /// D3 — directory-ness is decided from the *project index*, never
+    /// the filesystem (WASM-safe). A spec naming a single document is
+    /// not a directory, so it stays a flat link rather than becoming a
+    /// section wrapping itself.
+    #[test]
+    fn auto_single_file_spec_is_not_a_directory() {
+        let profiles = vec![
+            make_profile("intro.qmd", "Intro"),
+            make_profile("a.qmd", "A"),
+        ];
+        let index = ProjectIndex::new(profiles);
+        let mut diags = Vec::new();
+        let entries = expand_spec(&AutoSpec::Path("intro.qmd".to_string()), &index, &mut diags);
+        assert_eq!(entries.len(), 1);
+        match &entries[0] {
+            SidebarEntry::Link { item, .. } => {
+                assert_eq!(item.href.as_deref(), Some("intro.qmd"));
+            }
+            other => panic!("expected Link, got {:?}", other),
+        }
+    }
+
+    /// D1 — an explicit glob is not a bare directory even when it
+    /// happens to select a whole directory's worth of documents. This
+    /// is the fence that keeps `docs/*` from silently becoming a
+    /// section.
+    #[test]
+    fn auto_glob_spec_stays_flat() {
+        let profiles = vec![
+            make_profile("docs/b.qmd", "B"),
+            make_profile("docs/c.qmd", "C"),
+        ];
+        let index = ProjectIndex::new(profiles);
+        let mut diags = Vec::new();
+        let entries = expand_spec(&AutoSpec::Path("docs/*".to_string()), &index, &mut diags);
+        assert_eq!(entries.len(), 2, "glob stays flat");
+        assert!(
+            entries
+                .iter()
+                .all(|e| matches!(e, SidebarEntry::Link { .. })),
+            "expected all Links, got {:?}",
+            entries
+        );
     }
 
     /// `auto: docs/*` matches the documents directly in `docs/` —
@@ -570,8 +707,16 @@ mod tests {
         assert_eq!(entries.len(), 2);
     }
 
-    /// A bare directory still means everything beneath it (D4), so
-    /// the most common spelling is unaffected by the change above.
+    /// A bare directory still *matches* everything beneath it
+    /// (bd-mt7a6uc4 D4), including nested documents. Since
+    /// bd-sidebar-contents-dir-shorthand-z7arvhx8 D1 those matches
+    /// arrive wrapped in the directory's section rather than as a flat
+    /// run, so the count is asserted on the section's children.
+    ///
+    /// Note the known limitation recorded in that plan: `section_for_dir`
+    /// builds children as flat links, so `docs/deep/nested.qmd` appears
+    /// as a plain entry rather than a nested `deep` sub-section. Q1
+    /// recurses arbitrarily; q2 is one level deep here.
     #[test]
     fn auto_bare_directory_still_matches_nested_documents() {
         let profiles = vec![
@@ -581,7 +726,21 @@ mod tests {
         let index = ProjectIndex::new(profiles);
         let mut diags = Vec::new();
         let entries = expand_spec(&AutoSpec::Path("docs".to_string()), &index, &mut diags);
-        assert_eq!(entries.len(), 2);
+        assert_eq!(entries.len(), 1, "one section for docs/");
+        match &entries[0] {
+            SidebarEntry::Section { contents, .. } => {
+                assert_eq!(contents.len(), 2, "top and the nested document");
+                let hrefs: Vec<&str> = contents
+                    .iter()
+                    .map(|e| match e {
+                        SidebarEntry::Link { item, .. } => item.href.as_deref().unwrap(),
+                        other => panic!("expected Link, got {:?}", other),
+                    })
+                    .collect();
+                assert!(hrefs.contains(&"docs/deep/nested.qmd"));
+            }
+            other => panic!("expected Section, got {:?}", other),
+        }
     }
 
     /// Character classes reach `auto:` too, and `!` excludes.

--- a/crates/quarto-core/src/transforms/sidebar_generate.rs
+++ b/crates/quarto-core/src/transforms/sidebar_generate.rs
@@ -74,7 +74,7 @@ impl AstTransform for SidebarGenerateTransform {
             return Ok(());
         };
 
-        let sidebars = Sidebar::parse_list_from_config(&sidebar_cv);
+        let mut sidebars = Sidebar::parse_list_from_config(&sidebar_cv);
         if sidebars.is_empty() {
             return Ok(());
         }
@@ -86,13 +86,64 @@ impl AstTransform for SidebarGenerateTransform {
         // need to consult the index just to know "which page is this".
         let page_source = page_relative_source(ctx);
 
-        let Some(picked) = sidebar_for_page(&sidebars, &page_source, &ast.meta) else {
+        // bd-4feoon8u — resolve and expand **every** sidebar *before*
+        // picking one. `sidebar_for_page`'s containment rule matches
+        // page source paths against entry hrefs, and an unexpanded
+        // `Auto` entry has no href to match, so selecting first meant a
+        // sidebar defined only by `auto:` was never chosen and its
+        // pages rendered with no sidebar at all. Single-sidebar
+        // projects were masked by the wildcard rule, which is why this
+        // only ever showed up in multi-sidebar projects.
+        //
+        // Each sidebar gets its **own** diagnostics sink: this
+        // transform runs once per page, so emitting the warnings of
+        // sidebars we then discard would repeat them on every page of
+        // the project. Only the picked sidebar's diagnostics survive,
+        // below.
+        let mut per_sidebar_diags: Vec<Vec<quarto_error_reporting::DiagnosticMessage>> =
+            Vec::with_capacity(sidebars.len());
+        for sidebar in &mut sidebars {
+            let mut diags = Vec::new();
+
+            // bd-qor9a — resolve each href against the YAML file it was
+            // authored in. Frontmatter-rooted hrefs (`introduction.qmd`
+            // declared inside `docs/guide/index.qmd`) become
+            // `docs/guide/introduction.qmd` here; `_quarto.yml` and
+            // `_metadata.yml` entries (whose hash-based FileId isn't in
+            // the per-doc SourceContext) degrade to today's
+            // project-root-relative behaviour.
+            if let Some(source_context) = ctx.source_context {
+                resolve_hrefs(&mut sidebar.contents, source_context, &ctx.project.dir);
+            }
+
+            if let Some(index) = ctx.project_index.as_deref() {
+                expand_auto(sidebar, index, &mut diags);
+                // Enrich hand-written bare-path entries (e.g.
+                // `- about.qmd`) with the referenced document's title
+                // when no `text:` was supplied. Format-agnostic: fills
+                // in `text`, never touches `href`.
+                enrich_text_from_index(&mut sidebar.contents, index);
+            } else {
+                // Standalone render: no project index, so any `Auto`
+                // entries can't be expanded. They are dropped with a
+                // warning.
+                strip_auto(sidebar, &mut diags);
+            }
+
+            per_sidebar_diags.push(diags);
+        }
+
+        let Some(picked_idx) = sidebar_for_page(&sidebars, &page_source, &ast.meta)
+            .map(|picked| sidebar_index_of(&sidebars, picked))
+        else {
             // No sidebar matches this page. That's not an error —
             // the template slot is conditional; absence is fine.
             return Ok(());
         };
 
-        let mut resolved: Sidebar = picked.clone();
+        let mut resolved: Sidebar = sidebars.swap_remove(picked_idx);
+        let mut local_diags = std::mem::take(&mut ctx.diagnostics);
+        local_diags.append(&mut per_sidebar_diags[picked_idx]);
 
         // Resolve `SidebarTitle::Default` against `website.title` so
         // `navigation.sidebar` is fully resolved by the time the render
@@ -107,37 +158,11 @@ impl AstTransform for SidebarGenerateTransform {
             resolved.title = SidebarTitle::Text(title_cv);
         }
 
-        // Pull diagnostics out of RenderContext temporarily so
-        // helpers can borrow it mutably. We put them back before
-        // returning.
-        let mut local_diags = std::mem::take(&mut ctx.diagnostics);
-
-        // bd-qor9a — resolve each href against the YAML file it was
-        // authored in. Frontmatter-rooted hrefs (`introduction.qmd`
-        // declared inside `docs/guide/index.qmd`) become
-        // `docs/guide/introduction.qmd` here; `_quarto.yml` and
-        // `_metadata.yml` entries (whose hash-based FileId isn't in
-        // the per-doc SourceContext) degrade to today's
-        // project-root-relative behaviour.
-        if let Some(source_context) = ctx.source_context {
-            resolve_hrefs(&mut resolved.contents, source_context, &ctx.project.dir);
-        }
-
-        if let Some(index) = ctx.project_index.as_deref() {
-            expand_auto(&mut resolved, index, &mut local_diags);
-            // Enrich hand-written bare-path entries (e.g. `- about.qmd`)
-            // with the referenced document's title when no `text:`
-            // was supplied. Format-agnostic: fills in `text`, never
-            // touches `href`.
-            enrich_text_from_index(&mut resolved.contents, index);
-            // Active-state: does the current page appear in this
-            // sidebar's resolved contents? If so, mark and expand.
+        // Active-state: does the current page appear in this sidebar's
+        // resolved contents? If so, mark and expand. Runs after
+        // selection because it mutates only the sidebar we keep.
+        if ctx.project_index.is_some() {
             let _ = resolve_active_state(&mut resolved, &page_source);
-        } else {
-            // Standalone render: no project index, so any `Auto`
-            // entries can't be expanded. They are dropped with a
-            // warning.
-            strip_auto(&mut resolved, &mut local_diags);
         }
 
         ctx.diagnostics = local_diags;
@@ -147,6 +172,19 @@ impl AstTransform for SidebarGenerateTransform {
 
         Ok(())
     }
+}
+
+/// Recover the position of the sidebar `sidebar_for_page` picked.
+///
+/// `sidebar_for_page` hands back a borrow into the slice we passed it,
+/// so pointer identity is exact here — and it lets us take the picked
+/// sidebar by value (and index its diagnostics) without cloning every
+/// sidebar or making the selection API return an index.
+fn sidebar_index_of(sidebars: &[Sidebar], picked: &Sidebar) -> usize {
+    sidebars
+        .iter()
+        .position(|sb| std::ptr::eq(sb, picked))
+        .expect("sidebar_for_page returns a borrow into the slice it was given")
 }
 
 /// bd-qor9a — walk the parsed sidebar and resolve every entry's `href`
@@ -322,6 +360,121 @@ mod tests {
             .await
             .unwrap();
         (ast.meta, ctx.diagnostics)
+    }
+
+    /// bd-4feoon8u — in a project with more than one sidebar, a sidebar
+    /// whose membership comes only from an `auto:` entry must still be
+    /// selected for the pages beneath that directory.
+    ///
+    /// Selection used to run *before* expansion, and
+    /// `contains_source_path` ignores unexpanded `Auto` entries, so
+    /// these pages got no sidebar at all. The single-sidebar wildcard
+    /// (`sidebar_for_page` rule 2) masked this everywhere except
+    /// multi-sidebar projects — which is the Connect-docs shape.
+    #[tokio::test]
+    async fn sidebar_generate_selects_auto_only_sidebar_among_several() {
+        let index = Arc::new(ProjectIndex::new(vec![
+            make_profile("how-to/index.qmd", "How To Guides"),
+            make_profile("how-to/one.qmd", "One"),
+            make_profile("other/alpha.qmd", "Alpha"),
+        ]));
+        let sidebars = arr(vec![
+            config_map(vec![
+                ("id", s("howto")),
+                (
+                    "contents",
+                    arr(vec![config_map(vec![("auto", s("how-to"))])]),
+                ),
+            ]),
+            config_map(vec![
+                ("id", s("other")),
+                ("contents", arr(vec![s("other/alpha.qmd")])),
+            ]),
+        ]);
+        let meta = config_map(vec![("website", config_map(vec![("sidebar", sidebars)]))]);
+
+        let (out, _diags) =
+            run_transform_with(meta.clone(), Some(index.clone()), "how-to/one.qmd").await;
+        let picked = out
+            .get_path(&["navigation", "sidebar"])
+            .expect("how-to/one.qmd must get a sidebar");
+        assert_eq!(
+            picked.get("id").and_then(|v| v.as_plain_text()).as_deref(),
+            Some("howto"),
+        );
+
+        // The other sidebar must still win for its own page.
+        let (out, _diags) = run_transform_with(meta, Some(index), "other/alpha.qmd").await;
+        assert_eq!(
+            out.get_path(&["navigation", "sidebar"])
+                .and_then(|v| v.get("id"))
+                .and_then(|v| v.as_plain_text())
+                .as_deref(),
+            Some("other"),
+        );
+    }
+
+    /// The whole point of the strand: `contents: how-to` must behave
+    /// like `auto: how-to`, end to end through the transform.
+    #[tokio::test]
+    async fn sidebar_generate_expands_directory_shorthand() {
+        let index = Arc::new(ProjectIndex::new(vec![
+            make_profile("how-to/index.qmd", "How To Guides"),
+            make_profile("how-to/one.qmd", "One"),
+            make_profile("how-to/two.qmd", "Two"),
+        ]));
+        let meta = config_map(vec![(
+            "website",
+            config_map(vec![(
+                "sidebar",
+                config_map(vec![("contents", s("how-to"))]),
+            )]),
+        )]);
+        let (out, _diags) = run_transform_with(meta, Some(index), "how-to/one.qmd").await;
+        let contents = out
+            .get_path(&["navigation", "sidebar", "contents"])
+            .and_then(|v| v.as_array().map(|a| a.to_vec()))
+            .expect("expected expanded contents");
+        assert_eq!(contents.len(), 1, "one section for how-to/");
+        let section = &contents[0];
+        assert_eq!(
+            section.get("section").and_then(|v| v.as_plain_text()),
+            Some("How To Guides".to_string()),
+        );
+        let children = section
+            .get("contents")
+            .and_then(|v| v.as_array().map(|a| a.to_vec()))
+            .expect("section children");
+        assert_eq!(children.len(), 2, "one and two; index is the header");
+    }
+
+    /// bd-4feoon8u guard — expanding every sidebar to make selection
+    /// work must not leak the *unselected* sidebars' `auto:`
+    /// diagnostics. This transform runs once per page, so a stray
+    /// Q-13-6 here would be emitted on every page of the project.
+    #[tokio::test]
+    async fn sidebar_generate_hides_unselected_sidebar_diagnostics() {
+        let index = Arc::new(ProjectIndex::new(vec![make_profile(
+            "other/alpha.qmd",
+            "Alpha",
+        )]));
+        let sidebars = arr(vec![
+            config_map(vec![
+                ("id", s("empty")),
+                ("contents", arr(vec![config_map(vec![("auto", s("nope"))])])),
+            ]),
+            config_map(vec![
+                ("id", s("other")),
+                ("contents", arr(vec![s("other/alpha.qmd")])),
+            ]),
+        ]);
+        let meta = config_map(vec![("website", config_map(vec![("sidebar", sidebars)]))]);
+        let (_out, diags) = run_transform_with(meta, Some(index), "other/alpha.qmd").await;
+        assert!(
+            !diags.iter().any(|d| format!("{:?}", d).contains("Q-13-6")),
+            "unselected sidebar's empty-match warning leaked: {:?}",
+            diags
+        );
     }
 
     /// Test 30 — `sidebar: false` at document level suppresses Generate.

--- a/crates/quarto-navigation/src/sidebar.rs
+++ b/crates/quarto-navigation/src/sidebar.rs
@@ -529,14 +529,30 @@ fn parse_contents(cv: Option<&ConfigValue>) -> Vec<SidebarEntry> {
     let Some(cv) = cv else {
         return Vec::new();
     };
-    // Shorthand: `contents: auto` is Q1-idiomatic.
+    // A **scalar** `contents:` is an `auto:` spec. Q1's
+    // `normalizeSidebarItems` (website-sidebar-auto.ts) rewrites
+    // `contents: <s>` to `[{auto: true}]` when `<s>` is "auto" and to
+    // `[{auto: <s>}]` for every other string — so `contents: guides`
+    // auto-generates the directory's entries, and `contents: intro.qmd`
+    // expands to that one document. There is no file-vs-directory
+    // branch here on purpose; expansion resolves it (D1/D3 of
+    // bd-sidebar-contents-dir-shorthand-z7arvhx8).
+    //
+    // This is deliberately **scalar-only**. A bare string inside a
+    // `contents:` *array* is not an auto spec — Q1 sends those through
+    // `normalizeSidebarItem` (project-config.ts), which yields a link
+    // or a plain label. Those still take the `from_plain_string` route
+    // in `SidebarEntry::from_config_value`.
     if let Some(s) = cv.as_plain_text() {
         if s == "auto" {
             return vec![SidebarEntry::Auto(AutoSpec::All)];
         }
-        // A single path is a single-entry list. The ConfigValue's own
-        // source_info identifies the YAML scalar (bd-qor9a).
-        return vec![SidebarEntry::from_plain_string(&s, cv.source_info.clone())];
+        // A lone separator is not a path; keep it a separator rather
+        // than an auto spec that could only ever match nothing.
+        if is_separator_string(&s) {
+            return vec![SidebarEntry::Separator];
+        }
+        return vec![SidebarEntry::Auto(AutoSpec::Path(s))];
     }
     // Normal case: array of entries.
     if let Some(arr) = cv.as_array() {
@@ -1082,20 +1098,85 @@ mod tests {
         }
     }
 
-    /// Bare string at top-level contents is accepted as a single-entry
-    /// shorthand (matches Q1).
+    /// A scalar `contents:` is an `auto:` spec — Q1's
+    /// `normalizeSidebarItems` turns `contents: <s>` into
+    /// `[{auto: <s>}]` for every string but `auto` itself.
+    ///
+    /// bd-sidebar-contents-dir-shorthand-z7arvhx8: this previously
+    /// asserted a `Link`, which is what made `contents: guides` render
+    /// a dead link. A file-shaped scalar goes down the same path — Q1
+    /// makes no file-vs-directory distinction here, because expansion
+    /// resolves it: a spec naming one document expands to one link.
     #[test]
-    fn parse_sidebar_bare_string_contents_is_single_entry() {
+    fn parse_sidebar_bare_string_contents_is_auto_spec() {
         let cv = map(vec![("contents", s("hello.qmd"))]);
         let list = Sidebar::parse_list_from_config(&cv);
         assert_eq!(list.len(), 1);
         assert_eq!(list[0].contents.len(), 1);
         match &list[0].contents[0] {
-            SidebarEntry::Link { item } => {
-                assert_eq!(item.href.as_deref(), Some("hello.qmd"));
-            }
-            other => panic!("expected single Link, got {:?}", other),
+            SidebarEntry::Auto(AutoSpec::Path(p)) => assert_eq!(p, "hello.qmd"),
+            other => panic!("expected Auto(Path), got {:?}", other),
         }
+    }
+
+    /// The reported bug: `contents: guides` must become an auto spec
+    /// so expansion can generate the directory's entries.
+    #[test]
+    fn parse_sidebar_directory_shorthand_is_auto_spec() {
+        let cv = map(vec![("contents", s("guides"))]);
+        let list = Sidebar::parse_list_from_config(&cv);
+        match &list[0].contents[0] {
+            SidebarEntry::Auto(AutoSpec::Path(p)) => assert_eq!(p, "guides"),
+            other => panic!("expected Auto(Path), got {:?}", other),
+        }
+    }
+
+    /// The shorthand reaches nested section `contents:` too — Q1's
+    /// `expandAutoSidebarItems` recurses into `item.contents`.
+    #[test]
+    fn parse_sidebar_directory_shorthand_applies_to_nested_section() {
+        let cv = map(vec![(
+            "contents",
+            arr(vec![map(vec![
+                ("section", s("Guides")),
+                ("contents", s("guides")),
+            ])]),
+        )]);
+        let list = Sidebar::parse_list_from_config(&cv);
+        match &list[0].contents[0] {
+            SidebarEntry::Section { contents, .. } => match &contents[0] {
+                SidebarEntry::Auto(AutoSpec::Path(p)) => assert_eq!(p, "guides"),
+                other => panic!("expected nested Auto(Path), got {:?}", other),
+            },
+            other => panic!("expected Section, got {:?}", other),
+        }
+    }
+
+    /// Fence: the shorthand is **scalar-only**. A bare string that is
+    /// an *array element* stays a `Link`, matching Q1, where array
+    /// items go through `normalizeSidebarItem` (project-config.ts) and
+    /// never become an `auto`.
+    #[test]
+    fn parse_sidebar_bare_string_in_array_stays_a_link() {
+        let cv = map(vec![("contents", arr(vec![s("guides"), s("about.qmd")]))]);
+        let list = Sidebar::parse_list_from_config(&cv);
+        assert_eq!(list[0].contents.len(), 2);
+        for entry in &list[0].contents {
+            assert!(
+                matches!(entry, SidebarEntry::Link { .. }),
+                "array elements must stay Links, got {:?}",
+                entry
+            );
+        }
+    }
+
+    /// Fence: a scalar separator is still a separator, not an auto
+    /// spec that would match nothing and warn.
+    #[test]
+    fn parse_sidebar_scalar_separator_is_not_auto() {
+        let cv = map(vec![("contents", s("---"))]);
+        let list = Sidebar::parse_list_from_config(&cv);
+        assert!(matches!(list[0].contents[0], SidebarEntry::Separator));
     }
 
     /// `contents: auto` shorthand expands to a single `Auto(All)` entry.

--- a/docs/errors/navigation/Q-13-6.qmd
+++ b/docs/errors/navigation/Q-13-6.qmd
@@ -17,12 +17,36 @@ categories:
 ## What this means
 
 A sidebar `auto:` entry asks Quarto to fill the sidebar with
-every document matching a path or glob — `auto: posts/` for
+every document matching a path or glob — `auto: posts` for
 everything under `posts/`, `auto: "**/*.qmd"` for every `.qmd`
 in the project, and so on. This warning fires when the
 expansion runs against a real project index but finds nothing.
 The sidebar still renders; the `auto:` entry contributes no
 items.
+
+## You may see this without having written `auto:`
+
+Writing a sidebar's `contents:` as a single string is shorthand
+for `auto:`. These two are the same configuration:
+
+``` yaml
+website:
+  sidebar:
+    contents: guides
+```
+
+``` yaml
+website:
+  sidebar:
+    contents:
+      - auto: guides
+```
+
+So a mistyped directory name in the short form reports this
+`auto:` warning even though the word never appears in your
+`_quarto.yml`. The shorthand applies only when `contents:` is a
+single string — entries in a `contents:` *list* are ordinary
+links, not `auto:` specs.
 
 ## Why this happens
 
@@ -34,6 +58,11 @@ Common causes:
 - **The directory holds only excluded files** — underscore-
   prefixed names, hidden directories, or files filtered out
   by `project.render`.
+- **The directory holds no documents Quarto renders.** A
+  directory is only recognized as one when the project index
+  contains at least one document beneath it. A directory of
+  images or data files, with no `.qmd` alongside them, matches
+  nothing and reports this warning.
 
 ## How to fix
 


### PR DESCRIPTION
Fixes `bd-sidebar-contents-dir-shorthand-z7arvhx8`. Also fixes `bd-4feoon8u`.

A website sidebar whose `contents:` is a bare directory name rendered no
usable navigation. Quarto 1 treats the directory as an auto-generation
source; q2 treated the string as a single href and emitted one dead link
— and in a multi-sidebar project it emitted no sidebar element at all.

## Three changes, not one

The strand proposed routing the bare string to `AutoSpec::Path`. That is
necessary but not sufficient — it fixes the minimal repro while leaving
the real-world failure (the Posit Connect docs) in place.

**1. Parse — a scalar `contents:` is an `auto:` spec** (`quarto-navigation`)

Q1's `normalizeSidebarItems` rewrites `contents: <s>` to `[{auto: <s>}]`
for every string but `auto`. q2 sent everything except `auto` to
`from_plain_string`, so `contents: guides` became a link to the
unresolvable path `guides`.

No file-vs-directory branch here, on purpose: Q1 has none, because
expansion resolves it — a spec naming one document expands to one link.
Deliberately **scalar-only**; a bare string inside a `contents:` *array*
is not an auto spec (Q1 sends those through `normalizeSidebarItem`,
yielding a link or a label). Both are fenced by tests.

**2. Expansion shape — a bare directory produces a titled section** (`quarto-core`)

`collect_candidates` hardwired `AutoSpec::Path` to `Scope::Flat`, so a
directory expanded to a flat run of links rather than Q1's titled
section. Q1's `auto: <dir>` produces a section too (`isAutoDir`
re-roots the node set), so this was a parity gap in `auto:` as well.

Not a new code path: when every candidate shares a first path component,
`group_with_subdirs` already collapses to exactly one `section_for_dir`.
So this is a scope choice. Directory-ness is decided from the
`ProjectIndex` — no glob metacharacter, plus at least one matched
document beneath it — never the filesystem, because expansion is
index-driven and must work under WASM.

**3. Selection — expand every sidebar before picking one** (`quarto-core`)

`sidebar_for_page` ran *before* `expand_auto`, and containment matching
has no href to match on an unexpanded `Auto`, so a sidebar defined only
by `auto:` was never selected and its pages rendered with no sidebar at
all. The single-sidebar wildcard rule masked this everywhere except
multi-sidebar projects — which is why the minimal repro shows only a
dead link while the real site loses the whole sidebar.

This is `bd-4feoon8u`, a pre-existing bug reproducible with today's
syntax. Because the transform runs once per page, each sidebar expands
into its own diagnostics sink and only the picked sidebar's diagnostics
are emitted — otherwise every page would carry the `Q-13-5`/`Q-13-6`
warnings of sidebars it does not use. A test fences that leak.

## Behavior change worth release notes

Projects relying on `auto: <dir>` producing a flat list now get a titled
section. This is Q1 parity, but it is user-visible.

## Verification

End-to-end through the `q2` binary on both fixtures, output inspected —
not inferred from tests.

The minimal repro now emits Q1's structure: a `sidebar-item-section`
titled **Guides**, expanded (`aria-expanded="true"`, `sidebar-section
depth1 show`), both guides nested, current page `active`. Previously a
single `href="guides"` dead link.

A multi-sidebar probe (committed under the plan's investigation dir):

```
how-to/index.html      sidebar=1      (was 0)
how-to/one.html        sidebar=1      (was 0)
how-to/two.html        sidebar=1      (was 0)
other/alpha.html       sidebar=1      (unchanged)
index.html             sidebar=0      (unchanged — in neither sidebar)
```

Each page gets the *correct* sidebar, not merely some sidebar.

Gates: `cargo xtask lint` clean (961 files); `cargo nextest run
--workspace` **11834 passed**; `cargo xtask verify` **EXIT=0 across all
14 steps**, including the WASM/hub-client leg that `quarto-core` changes
require.

> **Note on tree-sitter (resolved):** an earlier revision of this PR
> flagged tree-sitter grammar failures as a pre-existing local problem.
> That was a false alarm. CI runs the same `tree-sitter test` and passes;
> locally the culprit was a stale gitignored `markdown.dylib`.
> `tree-sitter generate` (which changes no tracked files) restores
> 601/601. Full `cargo xtask verify` now passes with **no skips**,
> EXIT=0 across all 14 steps.

## Docs

`docs/errors/navigation/Q-13-6.qmd` gains a section explaining the
scalar shorthand, because that warning is now reachable from a spelling
that never mentions `auto:`.

No snapshot files were added, modified, or removed.

## Follow-ups filed, not folded in

- `bd-gba8n0r2` (docs, p2) — `docs/` has no user-facing guide for
  website sidebars at all, so there is nowhere to document the shorthand
  as a feature; the `Q-13-6` note is a troubleshooting stopgap.
- `bd-dje564or` (bug, p3) — `auto:` expansion is one level deep where Q1
  nests arbitrarily. Predates this work and is inherited by routing bare
  directories through the same machinery; recorded as a known limitation
  and pinned by a test.

Plan, including the reading of Q1's source that settled the design:
`claude-notes/plans/2026-08-12-sidebar-contents-dir-shorthand.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)