### PR TITLE
Strip symbols from release binaries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -298,6 +298,14 @@ runtimelib = { git = "https://github.com/cscheid/runtimed", rev = "fc58eb48139a3
 jupyter-protocol = { git = "https://github.com/cscheid/runtimed", rev = "fc58eb48139a30cc559ac5973cb6debb00375b88" }
 
 # Profiles must be set at the workspace level
+[profile.release]
+# Strip the symbol table from shipped binaries (bd-p0p4r9b2): ~21.6 MiB
+# of 172k mangled Rust symbols that are never used at runtime. Panic
+# file:line messages are unaffected (Location lives in rodata, not the
+# symtab). Profiling uses [profile.release-perf], which overrides this
+# with strip = false.
+strip = "symbols"
+
 [profile.dev]
 # Tell `rustc` to optimize for small code size to
 # work around "too many locals" error from wasm-pack


### PR DESCRIPTION
## What

Adds `strip = "symbols" to `[profile.release]`. The release build already ships no DWARF debug info (`debug = false`); this removes the remaining symbol table — 172k mangled Rust symbol names + addresses, **measured 21.6 MiB** of the binary — that is never used at runtime.

## What we lose (and why it's fine)

- `RUST_BACKTRACE=1` frames and user OS crash reports become address-only. Nothing in the tree captures backtraces programmatically (no `Backtrace::capture`, no native panic hook), so no feature regresses; if crash symbolication is ever needed, the release job can archive an unstripped binary as a CI artifact (follow-up, not here).
- Panic `file:line:col` messages are unaffected (`core::panic::Location` lives in rodata, not the symtab). Unwinding is untouched (`__unwind_info`/`__eh_frame` stay). Dynamic symbols survive (linking unaffected).
- Profiling is unaffected by design: `[profile.release-perf]` already carries `strip = false` for samply/perf.

## Verification (local, macOS arm64)

- `cargo build --release --locked --bin q2`: binary stripped — `nm` shows 369 residual dynamic symbols (was 166,964), `__LINKEDIT` 23.1 → 2.0 MiB.
- Release workflow gates run green on the stripped bytes: `q2 --version`, `q2 mcp --launcher-info` (real bundle, no placeholder). The `--print-asset-manifest-hashes` gate doesn't exist on main yet (lands with #464).
- Packaging/signing path dry-run mirroring `release.yml`: `tar -czf` single-member tarball → `shasum -a 256 -c` roundtrip → `minisign -S`/`-V` with a throwaway key and filename trusted comment: **signature and comment verified**. Signing happens in the release job over the tarball bytes, so stripping (a link-time change) cannot break it by construction; this proves the mechanics end-to-end on the new bytes.

Strand: bd-p0p4r9b2