### PR TITLE
TOC entries carry inline markup (bd-toc-smart-quotes-6nro57ed)

### DIFF
--- a/claude-notes/designs/document-profile-contract.md
+++ b/claude-notes/designs/document-profile-contract.md
@@ -57,7 +57,7 @@ produced.
 | `categories`, `keywords` | Arrays of plain-text strings. A single scalar value is lifted into a one-element list. |
 | `draft` | Boolean. Defaults to `false` when the key is missing or non-boolean. |
 | `order` | `Option<i32>` sort key from `order:` frontmatter. `None` when the key is absent or non-integer. Consumed by Phase-2's auto-sidebar sort (`claude-notes/plans/2026-04-24-websites-phase-2.md`). Added v1-additive (no version bump). |
-| `outline` | `Vec<pampa::toc::TocEntry>` built from the raw block sequence at `OUTLINE_MAX_DEPTH = 6`. **Always un-numbered**: `TocEntry::number == None` for every entry and every descendant. |
+| `outline` | `Vec<pampa::toc::TocEntry>` built from the raw block sequence at `OUTLINE_MAX_DEPTH = 6`. **Always un-numbered**: `TocEntry::number == None` for every entry and every descendant. Since v11, `TocEntry::title` is `Inlines`, not `String` — the outline carries the heading's inline markup verbatim. Consumers that want text project it themselves (`pampa::writers::plaintext::inlines_to_string`). |
 | `includes` | `Vec<IncludeEntry { path, content_hash }>` recording every file whose contents were spliced into the parent AST via `{{< include child.qmd >}}`. Populated by `IncludeExpansionStage` via a side-channel on `DocumentAst.recorded_includes`, drained into the profile by `DocumentProfileStage`. Direct + transitive children appear; cycles are pre-truncated. **Phase-8 cache invalidation depends on this field** (`bd-r82e`). Default empty. |
 | `nav_dependencies` | `Vec<PathBuf>` of project-relative `.qmd` paths the user explicitly declares as cross-doc dependencies via `meta.project.nav-dependencies`. The Phase-8 dependency graph adds an edge to each declared target. The escape hatch for Lua filters that walk siblings without using sidebar / link / prev-next channels. Default empty. |
 | `always_render` | `bool` from `meta.project.always-render`. When `true`, Mode B (subset render) pulls this page into the render set if any of its dependents is among the user-named targets. Mode A re-renders every page anyway, so this flag has no Mode-A effect. Default `false`. |
@@ -473,3 +473,34 @@ Tracking: `bd-creo` (CLI strictness), `bd-mwtf` /
   `DocumentProfileError::VersionMismatch` and silently regenerated,
   identical to every prior bump.
   Plan: `claude-notes/plans/2026-08-12-aliases-redirect-stubs.md`.
+
+- **2026-08-13 — v11 (`bd-toc-smart-quotes-6nro57ed`).** Changes
+  `outline`'s entry titles from `String` to `Inlines`
+  (`pampa::toc::TocEntry::title`).
+
+  The flattened title was lossy in a way that produced a visible
+  defect: a heading `## Using a "raw" volume` rendered with curly
+  quotes but its TOC entry rendered `Using a raw volume`, because the
+  flattener recursed into `Inline::Quoted` without emitting the
+  delimiters. Inline code, emphasis, and math spans were dropped the
+  same way — Quarto 1 renders all of them inside TOC entries.
+
+  The fix is to stop flattening at all. `TocEntry::title` now carries
+  the heading's inlines, and each consumer decides what to do with
+  them: the HTML TOC renders them through the inline writer (stripping
+  links and notes, which an `<a>` cannot nest); consumers wanting
+  plain text call `pampa::writers::plaintext::inlines_to_string`.
+
+  This is the profile-side consequence of that decision, and it is
+  deliberate: the outline is meant to be a *faithful semantic
+  outline*, so encoding one renderer's structural constraint (or one
+  consumer's plain-text preference) into the stored shape would be
+  exactly the kind of lossy back-patching the "profiles are read-only"
+  rule exists to prevent.
+
+  **Serialized shape changes**: a title that was `"Top"` is now an
+  array of inline nodes. v10 cache entries on disk are rejected with
+  `DocumentProfileError::VersionMismatch` and silently regenerated,
+  identical to every prior bump — `DOCUMENT_PROFILE_VERSION` is in the
+  cache-key hash domain, so stale entries are never even looked up.
+  Plan: `claude-notes/plans/2026-08-13-toc-smart-quotes.md`.

--- a/claude-notes/plans/2026-08-13-toc-smart-quotes.md
+++ b/claude-notes/plans/2026-08-13-toc-smart-quotes.md
@@ -3,17 +3,34 @@
 **Date:** 2026-08-13
 **Braid:** bd-toc-smart-quotes-6nro57ed
 **Branch:** `main` @ `0dcd7e83` (investigated in the main checkout — no worktree was created)
-**Status:** Investigation — pending design alignment with user. **Do not start implementation until the user gives the go-ahead.**
+**Status:** Scope settled 2026-08-13 — **TOC entries carry inlines**; the narrow glyph fix is
+*not* being done. Phases below are drafted against that decision but the phase contents are
+still skeletal. **Do not start implementation until the user gives the go-ahead.**
 
 ## Triage verdict
 
-**Ready to design.** The bug reproduces exactly as described at HEAD, the root cause named in
-the strand is correct and unchanged, and the fix is a three-line arm — but the investigation
-turned up a wider fact that should shape the scope decision: **Quarto 1 preserves *inline
-markup* in TOC entries, and q2 flattens every heading to plain text.** The quote glyphs are
-the visible tip of that flattening. We can ship the narrow glyph fix now, but the user should
-decide explicitly whether it is an interim step toward inline-carrying TOC entries or the
-whole answer.
+**Ready to design, as an epic rather than a patch.** The bug reproduces exactly as described
+at HEAD and the root cause named in the strand is correct — but the strand's own fix is a
+symptom fix. The real defect is that **Quarto 1 preserves inline markup in TOC entries and q2
+flattens every heading to plain text** (`TocEntry.title: String`). Dropped quote glyphs are
+the one symptom the Connect corpus happens to hit; `<code>`, `<em>`, `<strong>` and math
+spans are lost the same way.
+
+### Scope decision (user, 2026-08-13)
+
+Do the larger task here, phased. Specifically:
+
+- **The narrow glyph fix is skipped.** It would be deleted wholesale by the real fix: once
+  `TocEntry.title` is `Inlines`, `generate_toc` clones header content and
+  `toc.rs::inlines_to_text` ceases to exist. Confirmed there is no residue keeping it alive —
+  the *only* production read of `entry.title` is `html_escape(&entry.title)` at
+  `toc_render.rs:143` (no `title=` attribute, no `aria-label`, no plain-text sink). The one
+  scenario that would justify it is a release cutting mid-epic and needing the Connect docs
+  correct in the interim; absent that it is churn plus a second place encoding quote-glyph
+  policy.
+- **Consolidation (`bd-zzke`) is sequenced after, not merged in.** See "The wider family"
+  below — the TOC work *removes* one of the copies, so it shrinks that strand rather than
+  depending on it.
 
 ## Issue context
 
@@ -171,86 +188,142 @@ Note that `quarto-config/src/format.rs:129` has the same content-losing shape as
 **Important caveat for anyone tempted to delegate to the existing correct writer:**
 `plaintext::inlines_to_string` is *not* a drop-in for the TOC. It writes `Code` as
 `` `code` `` with backticks (plaintext.rs:126) and `LineBreak` as `\n` — both wrong for a
-TOC label, and the backticks would be a visible regression against today's output. Any
-consolidation has to be parameterized (a "flavor" enum or a small options struct), not a
-straight substitution.
+TOC label, and the backticks would be a visible regression against today's output.
+
+### A consolidation strand already exists: `bd-zzke` (deferred)
+
+**"Consolidate six divergent inlines_to_(plain_)text helpers"**, `chore`, P3, filed
+2026-05-06, status **`deferred`**. Its description already proposes the options-driven shape
+(`PlainTextOptions { wrap_quoted, line_break_as, include_code, include_notes, ... }`), and
+there is a standing code comment pointing at it at `metadata_normalize.rs:121-127`
+("if a third in-crate consumer arrives, file bd-zzke ... rather than continuing to add new
+call sites here"). It lists **6** sites; the survey above found ~10 production ones, so it
+undercounts and its description should be refreshed.
+
+**Are the axes essential or incidental?** Mostly incidental, which is the fact that makes
+consolidation tractable:
+
+| axis | verdict |
+|---|---|
+| `Quoted` glyphs (curly / ASCII / none) | **incidental** — curly is right everywhere. `template.rs`'s ASCII is a bug; even `autoid` can take curly, since its slug filter strips non-alphanumerics anyway |
+| unknown-kind handling (`_ => {}` vs exhaustive) | **incidental** — should be exhaustive everywhere; that is what stops the next new inline kind from silently regressing this class |
+| HTML escaping (`html.rs:1253`) | **not an axis** — a sink concern, `escape(flatten(x))` |
+| `Code` as `` `code` `` vs bare | **essential** — `plaintext.rs` is deliberately markdown-flavored ("mimics markdown writer") for `<title>` / meta tags |
+| `LineBreak` `\n` vs space | **essential** — tracks single-line vs multi-line targets |
+
+So roughly **2–3 named flavors**, not ten. The design risk worth guarding against is the
+options struct degenerating into N independent booleans (2^N reachable behaviors, one used
+per site, no reviewable set of intended ones) — that is the copies plus indirection, and
+harder to change because every edit becomes cross-crate. Mitigation: make the *public* API a
+small named-flavor enum and keep any options struct private.
+
+**Sequencing:** `bd-zzke` is **not** a prerequisite for this epic and should not be merged
+into it. Making TOC entries carry inlines *deletes* `toc.rs::inlines_to_text` outright,
+shrinking `bd-zzke`'s surface. Un-defer it separately, after, with the corrected site list.
+
+## The three constraints that make this an epic
+
+These are why "change `String` to `Inlines`" is not a one-commit change.
+
+1. **`TocEntry` is an on-disk, versioned contract.** It is `DocumentProfile.outline`
+   (`document_profile.rs:453`), serialized to disk and read back by incremental rebuilds.
+   Changing `title`'s type is a profile-shape change and requires a **`profile_version` bump**
+   (currently >= 4) per `claude-notes/designs/document-profile-contract.md`. Today the only
+   production reader of `.outline` is the profile itself — all other hits are tests
+   (`document_profile_pipeline.rs:202-206,400`) — so the migration cost is low, but the
+   version discipline is mandatory.
+2. **`navigation.toc` is a documented user/filter override point.** `TocGenerateTransform`
+   deliberately skips generation when `navigation.toc` already exists in metadata
+   (`toc_generate.rs`), so hand-written YAML with plain-string titles must keep working.
+   `TocEntry::from_config_value` (toc.rs:146) reads `title` via `as_plain_text()`; it will
+   need to accept *either* a YAML string (promoting it to a single `Str`, or parsing it as
+   markdown — see Q1 below) or `PandocInlines`. The round-trip becomes asymmetric and must
+   stay backward-compatible.
+3. **The render side has a precedent, so it is not new surface.**
+   `pampa::writers::html::write_inlines_to` is `pub` (html.rs:2018) and quarto-core already
+   uses exactly this pattern to render `PandocInlines` metadata to HTML
+   (`template.rs:961`, `revealjs/footer_logo.rs:187`). `toc_render` swapping
+   `html_escape(&entry.title)` for `write_inlines_to` follows an established path.
 
 ## Proposed phases (draft)
 
-Skeleton only — contents wait on the design discussion.
+Skeleton only — contents wait on the remaining design questions.
 
 - **Phase 0 — Test plan (TDD, failing first).**
-  - Unit: `inlines_to_text` over `Quoted{DoubleQuote}` → `“…”`, `Quoted{SingleQuote}` → `‘…’`,
-    nested quotes, quoted span adjacent to `Str`. Lands next to the existing
-    `test_inlines_to_text_*` tests at toc.rs:813.
-  - End-to-end: a `toc: true` document with a quoted heading, driven through
-    `render_document_to_file` (the pattern in
-    `crates/quarto-core/tests/integration/render_page_in_project.rs`), asserting the TOC
-    anchor's label text — **not** `render_qmd_to_html` with defaults. There is currently no
-    e2e TOC test at all, which is why this shipped.
-  - Verify both fail at HEAD before touching `toc.rs`.
-- **Phase 1 — The glyph fix.** Emit delimiters from `q.quote_type` in the `toc.rs:424` arm.
-- **Phase 2 — Sibling copies (scope TBD, see Q2).** `template.rs:1081` emits straight ASCII
-  regardless of `quote_type`, so a single-quoted span comes out double-quoted — a real bug
-  with the same shape. `citeproc_filter.rs:935` and `html.rs:1253` drop delimiters.
-- **Phase 3 — Follow-up strands (file, don't implement).** Consolidation of the flattener
-  family; TOC-entries-carry-inlines.
-- **Phase 4 — Verification.** `cargo xtask verify --skip-hub-build`, plus a re-render of both
-  investigation fixtures with the output pasted into this plan.
+  - End-to-end first, because its absence is why this shipped: a `toc: true` document whose
+    headings carry a quoted span, inline code, emphasis, math and a link, driven through
+    `render_document_to_file` (pattern: `crates/quarto-core/tests/integration/`
+    `render_page_in_project.rs`) — **not** `render_qmd_to_html` with defaults. Assert the TOC
+    anchor's inner HTML against the Q1 shape captured in
+    `toc-smart-quotes-investigation/OBSERVED.md`. There is currently **no e2e TOC test at
+    all**.
+  - Unit: `TocEntry` round-trips through `ConfigValue` preserving inlines;
+    `from_config_value` still accepts a legacy plain-string title.
+  - Verify all fail at HEAD before touching anything.
+- **Phase 1 — `TocEntry.title: Inlines`.** Change the type; `generate_toc` clones header
+  content instead of flattening. Delete `toc.rs::inlines_to_text` and its two unit tests.
+  Update `to_config_value` to emit `ConfigValueKind::PandocInlines` and `from_config_value`
+  to accept both shapes. Bump `profile_version` and add the change-log entry to the profile
+  contract doc.
+- **Phase 2 — `toc_render` emits markup.** Replace `html_escape(&entry.title)` with
+  `pampa::writers::html::write_inlines_to`. Cross-check against Q1's `<code>` / `<em>` /
+  `<strong>` / `<span class="math inline">` shapes.
+- **Phase 3 — Sweep the TOC-adjacent remainder.** `NavigationToc.title` (the TOC *heading*,
+  toc.rs:181) is still a `String` read via `as_str()` at toc.rs:214 — decide whether
+  `toc-title` gets the same treatment (Q2 below).
+- **Phase 4 — Verification.** `cargo xtask verify`, plus a re-render of both investigation
+  fixtures with the output appended to `OBSERVED.md` alongside the Q1 capture.
+- **Phase 5 — Follow-ups (file, don't implement).** Un-defer `bd-zzke` with the corrected
+  ~10-site list; leave bd-heading-id-drops-inline-content-fl84n3ql to its own strand.
 
-No docs phase: this is a bug fix with no user-facing option.
+No docs phase: no new user-facing option — this is q2 catching up to Q1's existing behavior.
 
 ## Open design questions for the user
 
-1. **Scope of *this* strand: glyphs only, or inlines-carrying TOC entries?**
-   Q1 renders `<code>`, `<em>`, `<strong>` and math spans inside TOC entries; q2 renders
-   none of them. Fixing the glyphs makes the quoted-heading case match Q1 exactly, and
-   leaves the markup divergence untouched. My recommendation: **do the glyph fix here** (it
-   is correct under either future, small, and testable), and file a separate strand for
-   "TOC entries should carry inlines, not a flattened `String`" — that one changes
-   `TocEntry`, its `ConfigValue` serialization, and `toc_render`'s `html_escape` call, and
-   deserves its own design. Do you want it filed, and at what priority?
+Questions 1, 2 and 5 from the first round are settled (see "Scope decision" above).
+Remaining:
 
-2. **Do the sibling copies get fixed in the same change?**
-   `template.rs:1081` is arguably worse than the strand's own bug (it *changes* a single
-   quote into a double quote, rather than dropping delimiters). Options: (a) fix only
-   `toc.rs`, file the rest; (b) fix `toc.rs` + `template.rs` (both are quote-type bugs) and
-   file the rest; (c) fix all four `pampa`/`quarto-core` copies in one sweep. I lean (b) —
-   one commit per defect class, and `template.rs`'s output feeds document templates where a
-   wrong glyph is equally visible.
+1. **Legacy string titles in `navigation.toc`: promote or parse?**
+   When a user or Lua filter hand-writes `navigation.toc` with
+   `title: "My **bold** section"`, should `from_config_value` (a) wrap it as a single `Str`
+   — literal, no markup, backward-identical; or (b) run it through the qmd inline parser so
+   hand-written entries get the same markup support as generated ones? I lean **(a)**, with
+   the markup path available by writing `PandocInlines` — because (b) silently changes the
+   meaning of existing YAML that happens to contain `*` or `_`. Your call.
 
-3. **Consolidation: worth a strand, and what shape?**
-   Twelve call sites, four incompatible answers. A single parameterized helper in
-   `quarto-pandoc-types` (or `pampa::writers::plaintext` with a flavor argument) would fix
-   the class, but it is a cross-crate refactor touching the LSP, config, citeproc and
-   listing paths, and the flavors genuinely differ (backticks vs. bare code; `\n` vs. space
-   for `LineBreak`; escaped vs. raw). File as its own strand, or leave it as a known-wart
-   note in this plan?
+2. **Does `toc-title` get the same treatment?**
+   `NavigationToc.title` is the TOC's own heading (`<h2 id="toc-title">`), still a `String`
+   read via `as_str()` (toc.rs:214). Q1 renders it through Pandoc too, so
+   `toc-title: "On **this** page"` would produce markup there. Include it in this epic, or
+   leave it and file separately? I lean **include it** — same defect, same phase, and
+   leaving it makes the module internally inconsistent.
+
+3. **`bd-zzke`: un-defer now or after this lands?**
+   It shrinks once the TOC stops flattening. I lean **after**, so its site audit runs
+   against the post-epic tree rather than being redone. Either way its description needs the
+   corrected site list (it lists 6; there are ~10).
 
 4. **Should this be fixed jointly with bd-heading-id-drops-inline-content-fl84n3ql?**
-   Both strands say "worth fixing together." They share a heading and a root cause *class*,
-   but not a code path, and the autoid one has an open judgement call of its own (whether
-   quote glyphs should even reach the slug filter — Pandoc strips them anyway, so recursing
-   without delimiters gives the right slug either way). My recommendation: **fix them in
-   sequence on one branch**, glyphs first, with the autoid fix's `Quoted` arm deliberately
-   *not* emitting delimiters — and say so in a comment, since that asymmetry will otherwise
-   look like the bug we just fixed. Agree, or do you want them fully independent?
-
-5. **Graph hygiene.** Shall I add `braid dep add bd-toc-smart-quotes-6nro57ed
-   bd-heading-id-drops-inline-content-fl84n3ql --type related` so the linkage lives in the
-   graph rather than only in a comment? (Not done unilaterally.)
+   (Carried over.) They share a heading and a root-cause *class*, but not a code path — and
+   this epic no longer touches `toc.rs::inlines_to_text` at all, which weakens the "fix
+   together" case further. The autoid strand is now cleanly independent, and its own
+   judgement call (whether quote glyphs reach the slug filter) is moot since the slug filter
+   strips non-alphanumerics anyway. My recommendation is now **fully independent strands**,
+   contra the first round.
 
 ## Risks / tradeoffs (draft)
 
-- **Snapshot churn.** Any `.snap` covering a TOC with a quoted heading will change. Grep
-  before implementing; per `CLAUDE.md`, snapshot changes must be counted and summarized in
-  the commit message. Expected to be near-zero given how rare quoted headings are, but this
-  must be confirmed, not assumed.
-- **The fix is provably safe on the escaping axis.** `toc_render.rs:143` runs
-  `html_escape(&entry.title)`; curly quotes are not escaped and need no entity. There is
-  already a test at toc_render.rs:422 covering a title containing `<b>HTML</b> & "quotes"`.
-- **Interim-fix risk.** If question 1 goes toward inlines-carrying entries, the Phase 1 arm
-  is thrown away later. It is three lines and it makes the output correct today — cheap
-  enough that this is not an argument against it, but worth naming.
-- **No e2e TOC coverage exists.** Adding the first one is a small tax on this strand and a
-  standing benefit; the absence is the reason a visible TOC defect reached a release.
+- **`profile_version` bump has downstream reach.** Cached profiles on disk become
+  unreadable and must be rejected on mismatch (the contract requires it). Confirm the
+  incremental-rebuild path degrades to a full rebuild rather than erroring.
+- **Snapshot churn is now expected to be broad, not near-zero.** Every snapshot covering a
+  TOC whose headings contain *any* inline markup — code, emphasis, links — changes, not just
+  quoted ones. Per `CLAUDE.md`, count them, summarize what changed, and flag anything
+  surprising. Measure this in Phase 0 rather than discovering it in Phase 2.
+- **`html_escape` disappears from the title path.** Escaping moves inside
+  `write_inlines_to`. The existing test at toc_render.rs:422 (title containing
+  `<b>HTML</b> & "quotes"`) encodes the *old* contract and needs rethinking: a literal `<b>`
+  typed in a heading arrives as `Str("<b>")` and must still be escaped, while a `RawInline`
+  must not be. Worth an explicit test.
+- **No e2e TOC coverage exists.** Adding the first one is a small tax and a standing
+  benefit; its absence is the reason a visible TOC defect reached a release.

--- a/claude-notes/plans/2026-08-13-toc-smart-quotes.md
+++ b/claude-notes/plans/2026-08-13-toc-smart-quotes.md
@@ -3,9 +3,9 @@
 **Date:** 2026-08-13
 **Braid:** bd-toc-smart-quotes-6nro57ed
 **Branch:** `main` @ `0dcd7e83` (investigated in the main checkout — no worktree was created)
-**Status:** **Design settled 2026-08-13** — all open questions answered (see "Decisions"
-below). Phases are drafted against those decisions. **Do not start implementation until the
-user gives the go-ahead.**
+**Status:** **In progress.** Design settled 2026-08-13 (see "Decisions"); implementation
+authorized by the user the same day. Progress is tracked in the Work items checklist below —
+Phase 0 done, Phase 1 next.
 
 ## Triage verdict
 
@@ -280,20 +280,44 @@ These are why "change `String` to `Inlines`" is not a one-commit change.
 Phase boundaries are commit points (per `CLAUDE.md`'s commit-and-continue rule). Checked
 items are done and committed.
 
-### Phase 0 — Test plan (TDD, failing first)
+### Phase 0 — Test plan (TDD, failing first) — **DONE**
 
-- [ ] End-to-end test: a `toc: true` document whose headings carry a quoted span, inline
-      code, emphasis, math and a link, driven through `render_document_to_file` (pattern:
-      `crates/quarto-core/tests/integration/render_page_in_project.rs`) — **not**
-      `render_qmd_to_html` with defaults. Assert the TOC anchor's inner HTML against the Q1
-      shape in `toc-smart-quotes-investigation/OBSERVED.md`. There is currently **no e2e TOC
-      test at all**, which is why this shipped.
-- [ ] Unit: `TocEntry` round-trips through `ConfigValue` preserving inlines.
-- [ ] Unit: `from_config_value` accepts both `PandocInlines` and `Scalar(String)` (the
-      latter wrapped as a single `Str`).
-- [ ] Measure snapshot churn now rather than discovering it in Phase 2 (see Risks).
-- [ ] Confirm every new test fails at HEAD, for the expected reason, before touching
-      production code.
+- [x] End-to-end test file `crates/quarto-core/tests/integration/toc_markup.rs`, driving the
+      real CLI path (`ProjectPipeline` -> `RenderToFileRenderer` -> `render_document_to_file`)
+      against a temp project and reading the HTML off disk. Nine tests; expected shapes are
+      Q1's, from `toc-smart-quotes-investigation/OBSERVED.md`.
+- [x] Confirmed every test fails at HEAD for the expected reason (see below).
+- [x] Measured snapshot churn — **it is zero**.
+- [ ] ~~Unit: `TocEntry` round-trips through `ConfigValue` preserving inlines~~ — moved to
+      Phase 1. These test an API that does not exist until the type changes; writing them
+      now would not compile, which is not a useful red signal (and would break the crate
+      build). They land with the change they describe.
+
+**Red/green split at HEAD: 5 fail, 4 pass.** The four that pass are guarding behavior the
+epic must *preserve*, so they are regression guards rather than missing red:
+
+| test | at HEAD | why |
+|---|---|---|
+| `toc_entry_keeps_quote_glyphs` | **FAIL** | `Using a raw volume` — the strand's bug |
+| `toc_entry_keeps_inline_markup` | **FAIL** | `Use code and em and strong` — flattened |
+| `toc_entry_keeps_inline_math` | **FAIL** | `Math x+y inline` — span lost |
+| `toc_title_from_frontmatter_keeps_markup` | **FAIL** | `On this page` — parsed, then flattened |
+| `toc_title_from_project_config_keeps_markup` | **FAIL** | `On **this** page` — never parsed |
+| `toc_entry_keeps_str_internal_smart_typography` | pass | control (reader-side rewrites) |
+| `toc_entry_strips_links_but_keeps_their_text` | pass | forward guard for the Phase 2 strip |
+| `toc_entry_drops_footnotes` | pass | forward guard (`Note` skipped today) |
+| `toc_entry_escapes_literal_markup_characters` | pass | guard for escaping after `html_escape` goes |
+
+The two `toc-title` rows are worth reading together: **the same YAML fails two different
+ways** depending on source, which is the `InterpretationContext` split from decision 2
+showing up empirically rather than as an argument. Front matter parses the markdown and then
+`as_plain_text()` discards it; project config never parses it, so the asterisks reach the
+page verbatim.
+
+**Snapshot churn: zero.** No `.snap` file in the tree contains `id="TOC"`, `nav-link`, or
+`toc-title` (245 snapshots checked), and no Rust test outside this new file asserts on TOC
+HTML. The Risks section had this flagged as a broad hazard; it is nil — for the same reason
+the defect shipped, namely that the TOC had no test coverage at all.
 
 ### Phase 1 — `TocEntry.title: Inlines`
 
@@ -309,10 +333,30 @@ items are done and committed.
 ### Phase 2 — `toc_render` emits markup
 
 - [ ] Replace `html_escape(&entry.title)` with `pampa::writers::html::write_inlines_to`.
+- [ ] **Strip links and notes at render time** (see the decision below) so the TOC's own
+      `<a>` never wraps a nested `<a>`.
 - [ ] Cross-check output against Q1's `<code>` / `<em>` / `<strong>` /
       `<span class="math inline">` shapes.
 - [ ] Rework the `toc_render.rs:422` test: a literal `<b>` typed in a heading arrives as
       `Str("<b>")` and must still be escaped; a `RawInline` must not be.
+
+> **Design decision (2026-08-13, during Phase 0): strip at render, not at generation.**
+>
+> `## Math $x+y$ and a [link](https://example.com)` renders in Q1's TOC as
+> `Math <span class="math inline">\(x+y\)</span> and a link` — the link's *text* survives, the
+> anchor does not. Pandoc does this with `deLink`/`deNote` before emitting the TOC, for the
+> obvious reason: `<a>` cannot legally nest, and the TOC entry is itself an `<a>`. A naive
+> `write_inlines_to` over raw header content would emit invalid HTML.
+>
+> The stripping belongs in `toc_render` (Phase 2), **not** in `generate_toc` (Phase 1),
+> because `TocEntry` is also `DocumentProfile.outline` — a general-purpose semantic outline
+> that project features consume. "An anchor may not nest" is a constraint of *this HTML
+> rendering*, not a fact about the document's heading structure, and the profile contract
+> says profiles are read-only and consumers should not have to re-derive what was thrown
+> away. So: keep the profile faithful, strip where the constraint actually applies.
+>
+> Scope of the strip, mirroring Pandoc: `Link` unwraps to its content; `Note` and
+> `NoteReference` are dropped. Everything else renders.
 
 ### Phase 3 — `toc-title` gets the same treatment (decision 2)
 
@@ -327,6 +371,31 @@ items are done and committed.
       (`meta_annotations.rs` `ANNOTATIONS` and `config_markdown.rs`
       `MARKDOWN_CONFIG_PATHS`) — this is `bd-qzn1azon`'s whole scope, and Phase 3 is already
       editing one of them. Close `bd-qzn1azon` when done.
+- [ ] **Preview parity** (found in Phase 0, see below): emit the *rendered* title HTML into
+      `rendered.navigation.toc-title`, switch `template.rs:213` to it, and switch
+      `PreviewDocument.tsx:184` + `TocSlot` to consume it via `dangerouslySetInnerHTML`.
+- [ ] Extend `PreviewDocument.integration.test.tsx` (the TOC cases at :383-420) for the new
+      shape, and run `npm run build:all` from `hub-client/` — per `CLAUDE.md`, passing tests
+      are not sufficient for TS changes.
+
+> **Preview/render parity constraint (found during Phase 0).**
+>
+> The TOC *entries* are safe: `TocRenderTransform` writes the inner `<ul>` as an HTML string
+> to `rendered.navigation.toc`, and the preview injects it with `dangerouslySetInnerHTML`
+> (`chromeSlots.tsx` `TocSlot`). Markup added in Phases 1-2 flows through untouched.
+>
+> The **title** does not. `PreviewDocument.tsx:184-186` reads
+> `navigation.toc.title` through `extractMetaString` and passes it to `TocSlot` as a
+> `title: string` prop, rendered as a React *text node*. Turning that metadata value into
+> `Inlines` makes `extractMetaString` return nothing, so the preview would silently drop the
+> `<h2 id="toc-title">` while `q2 render` still emits it — a preview/render divergence of
+> exactly the kind `.claude/skills/preview-render-parity` exists to chase, and invisible to
+> every Rust test.
+>
+> Fix: give the title the same treatment the entries already get — render it to HTML in
+> `TocRenderTransform` and publish it under `rendered.navigation.*`. That keeps one seam
+> ("`rendered.*` is HTML produced from metadata") instead of inventing a second, and both
+> consumers read the same value.
 
 ### Phase 4 — Verification
 

--- a/claude-notes/plans/2026-08-13-toc-smart-quotes.md
+++ b/claude-notes/plans/2026-08-13-toc-smart-quotes.md
@@ -3,9 +3,9 @@
 **Date:** 2026-08-13
 **Braid:** bd-toc-smart-quotes-6nro57ed
 **Branch:** `main` @ `0dcd7e83` (investigated in the main checkout — no worktree was created)
-**Status:** **In progress.** Design settled 2026-08-13 (see "Decisions"); implementation
-authorized by the user the same day. Progress is tracked in the Work items checklist below —
-Phase 0 done, Phase 1 next.
+**Status:** **Complete** (2026-08-13). All five phases done; `cargo xtask verify` green,
+11,846/11,846 workspace tests pass, end-to-end verified through the `q2` binary. See
+"Outcome" at the end of the Work items.
 
 ## Triage verdict
 
@@ -456,11 +456,36 @@ walk inline nodes) would duplicate the HTML writer in TypeScript.
 - [x] Re-rendered all three investigation fixtures; output appended to `OBSERVED.md`.
 - [x] Snapshot changes: **none**, as Phase 0 predicted.
 
-### Phase 5 — Follow-ups (file, don't implement)
+### Phase 5 — Follow-ups — **DONE**
 
-- [ ] Un-defer `bd-zzke` with the corrected ~10-site list.
-- [ ] Leave `bd-heading-id-drops-inline-content-fl84n3ql` to its own strand (`related` edge
-      added 2026-08-13).
+- [x] `bd-zzke` un-deferred (`deferred` -> `open`) with a rewritten description: the
+      corrected 10-site table, the essential-vs-incidental axis analysis, the named-flavour
+      warning about options-struct combinatorics, and a note that `toc.rs`'s copy is already
+      gone. Linked `related` to this strand and to the autoid one.
+- [x] `bd-qzn1azon` **closed** — its whole scope (a "see also, and when to pick which" note
+      in both key-path registries) landed in Phase 3.
+- [x] `bd-d7ljiz9q` filed earlier in this session: `!str` cannot opt a project-config key out
+      of markdown parsing. Not in scope here; it becomes more load-bearing as the blessed set
+      grows.
+- [x] `bd-heading-id-drops-inline-content-fl84n3ql` left to its own strand, per decision 4,
+      with the `related` edge added.
+
+## Outcome
+
+All phases complete. The strand's own symptom and the wider defect behind it are both fixed,
+end-to-end verified through the `q2` binary, and covered by the tree's first end-to-end TOC
+tests.
+
+| | before | after |
+|---|---|---|
+| `## Using a "raw" volume` | `Using a raw volume` | `Using a “raw” volume` |
+| `` ## Use `code` and *em* `` | `Use code and em` | `Use <code>code</code> and <em>em</em>` |
+| `## Math $x+y$ and a [link](…)` | `Math x+y and a link` | `Math <span class="math inline">\(x+y\)</span> and a link` |
+| `toc-title` in front matter | markup flattened | markup rendered |
+| `toc-title` in `_quarto.yml` | markup never parsed | markup rendered |
+
+Not fixed, deliberately: the anchor ids (`#using-a-volume`, `#math-and-a`) are the sibling
+strand's defect in `autoid::collect_text`, a different code path.
 
 No docs phase: no new user-facing option — this is q2 catching up to Q1's existing behavior.
 

--- a/claude-notes/plans/2026-08-13-toc-smart-quotes.md
+++ b/claude-notes/plans/2026-08-13-toc-smart-quotes.md
@@ -234,11 +234,13 @@ These are why "change `String` to `Inlines`" is not a one-commit change.
    version discipline is mandatory.
 2. **`navigation.toc` is a documented user/filter override point.** `TocGenerateTransform`
    deliberately skips generation when `navigation.toc` already exists in metadata
-   (`toc_generate.rs`), so hand-written YAML with plain-string titles must keep working.
-   `TocEntry::from_config_value` (toc.rs:146) reads `title` via `as_plain_text()`; it will
-   need to accept *either* a YAML string (promoting it to a single `Str`, or parsing it as
-   markdown — see Q1 below) or `PandocInlines`. The round-trip becomes asymmetric and must
-   stay backward-compatible.
+   (`toc_generate.rs`), so hand-written overrides must keep working.
+   `TocEntry::from_config_value` (toc.rs:146) reads `title` via `as_plain_text()` and must
+   accept both shapes the metadata layer can hand it: `PandocInlines` (front matter, or
+   `!md`-tagged project config — use directly) and `Scalar(String)` (project config's
+   literal default, or programmatic construction — wrap as a single `Str`). Note the parse
+   already happened upstream at YAML-load time per `InterpretationContext`; this is not a
+   re-parsing decision. See Q1/Q2 below for the context split and its consequence.
 3. **The render side has a precedent, so it is not new surface.**
    `pampa::writers::html::write_inlines_to` is `pub` (html.rs:2018) and quarto-core already
    uses exactly this pattern to render `PandocInlines` metadata to HTML
@@ -283,20 +285,52 @@ No docs phase: no new user-facing option — this is q2 catching up to Q1's exis
 Questions 1, 2 and 5 from the first round are settled (see "Scope decision" above).
 Remaining:
 
-1. **Legacy string titles in `navigation.toc`: promote or parse?**
-   When a user or Lua filter hand-writes `navigation.toc` with
-   `title: "My **bold** section"`, should `from_config_value` (a) wrap it as a single `Str`
-   — literal, no markup, backward-identical; or (b) run it through the qmd inline parser so
-   hand-written entries get the same markup support as generated ones? I lean **(a)**, with
-   the markup path available by writing `PandocInlines` — because (b) silently changes the
-   meaning of existing YAML that happens to contain `*` or `_`. Your call.
+1. ~~**Legacy string titles: promote or parse?**~~ **Withdrawn — the premise was wrong.**
+   Markdown parsing of metadata strings happens at **YAML-load time**, not in
+   `from_config_value`. The `InterpretationContext` (config_value.rs:104-135) sets the
+   default per source, and the two sources have **opposite defaults**:
 
-2. **Does `toc-title` get the same treatment?**
-   `NavigationToc.title` is the TOC's own heading (`<h2 id="toc-title">`), still a `String`
-   read via `as_str()` (toc.rs:214). Q1 renders it through Pandoc too, so
-   `toc-title: "On **this** page"` would produce markup there. Include it in this epic, or
-   leave it and file separately? I lean **include it** — same defect, same phase, and
-   leaving it makes the module internally inconsistent.
+   | source | untagged string | opt out / in |
+   |---|---|---|
+   | document front matter (`DocumentMetadata`) | **parsed as markdown** → `PandocInlines` | `!str` keeps it literal |
+   | `_quarto.yml` (`ProjectConfig`) | **kept literal** → `Scalar(String)` | `!md` parses it |
+
+   So a front-matter `navigation.toc` entry with `title: "My **bold** section"` already
+   arrives as `PandocInlines` carrying a `Strong`. Today `as_plain_text()` (toc.rs:146)
+   throws that markup away — which is the *same defect this epic fixes*, not a separate
+   decision. Nothing to re-parse; carrying inlines just stops discarding what is already
+   there.
+
+   What survives is narrower and has an answer that follows from the existing contract: a
+   `Scalar(String)` reaching `from_config_value` came from project config (literal by
+   design) or from programmatic construction, so it should be **wrapped as a single `Str`**.
+   Re-parsing it would bypass `ProjectConfig`'s deliberate literal-by-default rule; the
+   sanctioned way to opt a project-config key into markdown is the registry — see Q2.
+
+2. **Should `toc-title` be blessed in `MARKDOWN_CONFIG_PATHS`?** *(the real question Q1 was
+   groping at)*
+   `toc-title` is read from merged metadata via `as_plain_text()`
+   (`toc_generate.rs:125-133`), so it inherits the split above:
+
+   - front matter — `toc-title: "On **this** page"` → `PandocInlines`, markup **available**
+     (and currently discarded by `as_plain_text`, fixed by this epic);
+   - `_quarto.yml` — same YAML → `Scalar(String)`, markup **never parsed**, because
+     `toc-title` is **not** in `MARKDOWN_CONFIG_PATHS`
+     (`transforms/config_markdown.rs:84-122`, which blesses `website.title`, navbar/sidebar
+     titles, `page-footer` regions and nav-item `text`).
+
+   So after this epic a project-level `toc-title` would still be markup-free while a
+   document-level one renders — a split with no principled justification, since `toc-title`
+   is presentation text exactly like `website.title` and `sidebar.title` next to it in the
+   registry. Adding `&["toc-title"]` is a one-line change and the module documents this as
+   the growth path ("Growing the feature = adding a line here").
+
+   I lean **yes, bless it, in this epic**. Two caveats worth your call: it is a behavior
+   change for existing `_quarto.yml` files whose `toc-title` happens to contain `*` or `_`
+   (the `!str` opt-out does not work in project config — documented limitation at
+   config_markdown.rs:40-45), and `NavigationToc.title` is currently `String` read via
+   `as_str()` (toc.rs:214), so blessing it only pays off if that field also becomes
+   `Inlines` in Phase 3.
 
 3. **`bd-zzke`: un-defer now or after this lands?**
    It shrinks once the TOC stops flattening. I lean **after**, so its site audit runs

--- a/claude-notes/plans/2026-08-13-toc-smart-quotes.md
+++ b/claude-notes/plans/2026-08-13-toc-smart-quotes.md
@@ -1,0 +1,256 @@
+# TOC entry drops the quote glyphs around a quoted span (bd-toc-smart-quotes-6nro57ed)
+
+**Date:** 2026-08-13
+**Braid:** bd-toc-smart-quotes-6nro57ed
+**Branch:** `main` @ `0dcd7e83` (investigated in the main checkout — no worktree was created)
+**Status:** Investigation — pending design alignment with user. **Do not start implementation until the user gives the go-ahead.**
+
+## Triage verdict
+
+**Ready to design.** The bug reproduces exactly as described at HEAD, the root cause named in
+the strand is correct and unchanged, and the fix is a three-line arm — but the investigation
+turned up a wider fact that should shape the scope decision: **Quarto 1 preserves *inline
+markup* in TOC entries, and q2 flattens every heading to plain text.** The quote glyphs are
+the visible tip of that flattening. We can ship the narrow glyph fix now, but the user should
+decide explicitly whether it is an interim step toward inline-carrying TOC entries or the
+whole answer.
+
+## Issue context
+
+`bug`, priority 3, filed 2026-08-13 by Carlos Scheidegger, label `toc`. Very recent and
+very thoroughly written — the description already names the exact arm, the exact file/line,
+and the surrounding controls. Nothing has aged.
+
+Source `## Using a "raw" volume` with `toc: true`:
+
+| | heading | TOC entry |
+|---|---|---|
+| Quarto 1 | Using a “raw” volume | Using a “raw” volume |
+| q2 @ 0dcd7e83 | Using a “raw” volume | Using a raw volume |
+
+Controls (apostrophe, en dash) survive in both places because they are `Str`-internal
+rewrites by `apply_smart_typography`; the failing case is the one that becomes an
+`Inline::Quoted` node.
+
+## Dependency graph
+
+**Empty.** `braid dep tree` shows the strand alone; `braid dep list` prints nothing. No
+`discovered-from`, no `blocks`, no `related` edges — the only linkage is a free-text comment
+pointing at **bd-heading-id-drops-inline-content-fl84n3ql**.
+
+That changes the calculus in two ways:
+
+- No incoming pressure. Nothing is blocked on this; priority 3 is honest.
+- The "why was this filed" context lives in the descriptions rather than the graph. Both
+  strands were filed the same afternoon out of the same Connect-docs porting session
+  (origin strands `br-toc-smart-quotes-pw1vkzj8` / `br-heading-id-drops-inline-content-lxwiqh33`
+  in the q2-connect-docs skein), from **the same heading** —
+  `Option 2: Using a “raw” NFS volume` in
+  `admin/getting-started/off-host-install/configure-helm-chart`.
+
+**Recommendation: add the missing `related` edge** between the two strands so the graph
+carries what the comment currently carries. (Not done unilaterally — see design question 5.)
+
+The sibling strand is the *more severe* of the pair: `autoid::collect_text` handles only
+five inline kinds and drops the rest **without recursing**, so whole words vanish from
+anchor ids. This strand's helper recurses correctly and only drops the delimiters.
+
+## What the code looks like today
+
+Every path in the description still exists with the shape described.
+
+`crates/pampa/src/toc.rs:409` — `inlines_to_text`, the TOC label flattener. The match is
+**exhaustive** (no `_` arm), so the change is genuinely localized:
+
+```rust
+Inline::Quoted(q) => text.push_str(&inlines_to_text(&q.content)),   // toc.rs:424
+```
+
+Reached from `generate_toc` (toc.rs:251) via `TocGenerateTransform`
+(`crates/quarto-core/src/transforms/toc_generate.rs:139`, phase `Navigation`).
+
+`TocEntry.title` is a `String`, documented as *"Heading text (plain text, not inlines)"*
+(toc.rs:77). It is serialized into `navigation.toc` metadata via `to_config_value`
+(toc.rs:108) and rendered by `TocRenderTransform`, which pushes it through
+`html_escape(&entry.title)` (`crates/quarto-core/src/transforms/toc_render.rs:143`).
+**Curly quotes therefore need no escaping and are safe to emit** — the escape happens at
+render, and U+201C/U+201D pass through untouched.
+
+`Quoted` is built by the reader (`process_quoted`,
+`crates/pampa/src/pandoc/treesitter_utils/quote_helpers.rs:101`), which keeps `quote_type`
+and discards the delimiter *children*. So the quote type is known and available by the time
+the TOC runs; it is simply not consulted. Not an ordering problem.
+
+`apply_smart_typography` is called **unconditionally** by the reader
+(`treesitter.rs:621,801,835`). The `smart` extension appears in `options.rs` as a parseable
+name but nothing gates the rewrite on it today, and the HTML writer
+(`crates/pampa/src/writers/html.rs:929-935`) always emits curly glyphs. So "always curly"
+in the TOC is consistent with everything else in the tree right now.
+
+### Reproduced at HEAD
+
+Fixture copied in-tree at `claude-notes/plans/toc-smart-quotes-investigation/repro/`
+(from the strand's repro directory).
+
+```
+$ cargo run --bin q2 -- render claude-notes/plans/toc-smart-quotes-investigation/repro
+```
+
+Rendered `_site/index.html`, inspected directly:
+
+```html
+<h2 id="toc-title">Table of contents</h2>
+<ul>
+<li>
+<a href="#using-a-volume" class="nav-link" data-scroll-target="#using-a-volume">
+Using a raw volume                        <!-- glyphs gone -->
+</a>
+...
+<section id="using-a-volume" class="section level2">
+<h2>Using a “raw” volume</h2>              <!-- heading correct -->
+```
+
+Quarto 1 on the same source, for comparison:
+
+```html
+<li><a href="#using-a-raw-volume" ... >Using a “raw” volume</a></li>
+```
+
+Confirmed on both counts: the heading keeps U+201C/U+201D, the TOC label loses them, and the
+two controls (`repository’s`, `Gallery – really`) are correct in q2.
+
+### New finding: q2's TOC flattens *all* markup, not just quotes
+
+A second probe fixture at `claude-notes/plans/toc-smart-quotes-investigation/markup-probe/`
+(headings with code, emphasis, strong, math, and a link) rendered under both engines:
+
+**Quarto 1** (`_site-q1/index.html`):
+
+```html
+<a ... >Use <code>code</code> and <em>em</em> and <strong>strong</strong></a>
+<a ... >Math <span class="math inline">\(x+y\)</span> and a link</a>
+```
+
+**q2 @ 0dcd7e83** (`_site/index.html`):
+
+```html
+<a ... >Use code and em and strong</a>
+<a ... >Math x+y and a link</a>
+```
+
+Q1 keeps the inline markup in the TOC; q2 flattens to text by construction (`TocEntry.title:
+String`). The dropped quote glyphs are one symptom of that design choice, and the *only* one
+the strand's Connect-docs corpus happens to hit. (The probe also re-demonstrates the sibling
+autoid bug: q2 gives the math heading the id `math-and-a` where Q1 gives
+`math-xy-and-a-link`.)
+
+### The wider family: nine hand-rolled inline→text flatteners, all disagreeing
+
+`grep` for this shape across the workspace:
+
+| location | `Quoted` arm | exhaustive? |
+|---|---|---|
+| `pampa/src/writers/plaintext.rs:389` (`inlines_to_string`) | **curly**, from `quote_type` | yes |
+| `pampa/src/writers/html.rs:929` (real HTML writer) | **curly**, from `quote_type` | yes |
+| `pampa/src/toc.rs:409` | recurses, **no delimiters** | yes |
+| `pampa/src/citeproc_filter.rs:935` | recurses, no delimiters | no (`_`) |
+| `pampa/src/utils/autoid.rs:9` | **not handled at all** (content lost) | no (`_`) |
+| `pampa/src/writers/html.rs:1253` (`write_inlines_as_text`) | recurses, no delimiters | no (`_`) |
+| `quarto-core/src/template.rs:1064` | **straight ASCII `"` both sides**, ignores `quote_type` | no (`_`) |
+| `quarto-core/src/transforms/metadata_normalize.rs:128` | straight ASCII `'` / `"`, from `quote_type` | — |
+| `quarto-pandoc-types/src/config_value.rs:22` | recurses, no delimiters | — |
+| `quarto-lsp-core/src/analysis.rs:720` | recurses, no delimiters | — |
+| `quarto-config/src/format.rs:129` | **not handled** — `Str`/`Space` only, content lost | no (`_`) |
+| `quarto-core/src/transforms/listing_render.rs:633` | not handled (`Str`/`Space`/`Link` only) — *test helper* | no (`_`) |
+
+Four different answers to one question. This is the mechanism by which the class of bug
+keeps reappearing, and it is what makes a TOC label and the anchor it points at diverge.
+Note that `quarto-config/src/format.rs:129` has the same content-losing shape as
+`autoid.rs` — it is a second instance of the sibling strand's defect, in a different crate.
+
+**Important caveat for anyone tempted to delegate to the existing correct writer:**
+`plaintext::inlines_to_string` is *not* a drop-in for the TOC. It writes `Code` as
+`` `code` `` with backticks (plaintext.rs:126) and `LineBreak` as `\n` — both wrong for a
+TOC label, and the backticks would be a visible regression against today's output. Any
+consolidation has to be parameterized (a "flavor" enum or a small options struct), not a
+straight substitution.
+
+## Proposed phases (draft)
+
+Skeleton only — contents wait on the design discussion.
+
+- **Phase 0 — Test plan (TDD, failing first).**
+  - Unit: `inlines_to_text` over `Quoted{DoubleQuote}` → `“…”`, `Quoted{SingleQuote}` → `‘…’`,
+    nested quotes, quoted span adjacent to `Str`. Lands next to the existing
+    `test_inlines_to_text_*` tests at toc.rs:813.
+  - End-to-end: a `toc: true` document with a quoted heading, driven through
+    `render_document_to_file` (the pattern in
+    `crates/quarto-core/tests/integration/render_page_in_project.rs`), asserting the TOC
+    anchor's label text — **not** `render_qmd_to_html` with defaults. There is currently no
+    e2e TOC test at all, which is why this shipped.
+  - Verify both fail at HEAD before touching `toc.rs`.
+- **Phase 1 — The glyph fix.** Emit delimiters from `q.quote_type` in the `toc.rs:424` arm.
+- **Phase 2 — Sibling copies (scope TBD, see Q2).** `template.rs:1081` emits straight ASCII
+  regardless of `quote_type`, so a single-quoted span comes out double-quoted — a real bug
+  with the same shape. `citeproc_filter.rs:935` and `html.rs:1253` drop delimiters.
+- **Phase 3 — Follow-up strands (file, don't implement).** Consolidation of the flattener
+  family; TOC-entries-carry-inlines.
+- **Phase 4 — Verification.** `cargo xtask verify --skip-hub-build`, plus a re-render of both
+  investigation fixtures with the output pasted into this plan.
+
+No docs phase: this is a bug fix with no user-facing option.
+
+## Open design questions for the user
+
+1. **Scope of *this* strand: glyphs only, or inlines-carrying TOC entries?**
+   Q1 renders `<code>`, `<em>`, `<strong>` and math spans inside TOC entries; q2 renders
+   none of them. Fixing the glyphs makes the quoted-heading case match Q1 exactly, and
+   leaves the markup divergence untouched. My recommendation: **do the glyph fix here** (it
+   is correct under either future, small, and testable), and file a separate strand for
+   "TOC entries should carry inlines, not a flattened `String`" — that one changes
+   `TocEntry`, its `ConfigValue` serialization, and `toc_render`'s `html_escape` call, and
+   deserves its own design. Do you want it filed, and at what priority?
+
+2. **Do the sibling copies get fixed in the same change?**
+   `template.rs:1081` is arguably worse than the strand's own bug (it *changes* a single
+   quote into a double quote, rather than dropping delimiters). Options: (a) fix only
+   `toc.rs`, file the rest; (b) fix `toc.rs` + `template.rs` (both are quote-type bugs) and
+   file the rest; (c) fix all four `pampa`/`quarto-core` copies in one sweep. I lean (b) —
+   one commit per defect class, and `template.rs`'s output feeds document templates where a
+   wrong glyph is equally visible.
+
+3. **Consolidation: worth a strand, and what shape?**
+   Twelve call sites, four incompatible answers. A single parameterized helper in
+   `quarto-pandoc-types` (or `pampa::writers::plaintext` with a flavor argument) would fix
+   the class, but it is a cross-crate refactor touching the LSP, config, citeproc and
+   listing paths, and the flavors genuinely differ (backticks vs. bare code; `\n` vs. space
+   for `LineBreak`; escaped vs. raw). File as its own strand, or leave it as a known-wart
+   note in this plan?
+
+4. **Should this be fixed jointly with bd-heading-id-drops-inline-content-fl84n3ql?**
+   Both strands say "worth fixing together." They share a heading and a root cause *class*,
+   but not a code path, and the autoid one has an open judgement call of its own (whether
+   quote glyphs should even reach the slug filter — Pandoc strips them anyway, so recursing
+   without delimiters gives the right slug either way). My recommendation: **fix them in
+   sequence on one branch**, glyphs first, with the autoid fix's `Quoted` arm deliberately
+   *not* emitting delimiters — and say so in a comment, since that asymmetry will otherwise
+   look like the bug we just fixed. Agree, or do you want them fully independent?
+
+5. **Graph hygiene.** Shall I add `braid dep add bd-toc-smart-quotes-6nro57ed
+   bd-heading-id-drops-inline-content-fl84n3ql --type related` so the linkage lives in the
+   graph rather than only in a comment? (Not done unilaterally.)
+
+## Risks / tradeoffs (draft)
+
+- **Snapshot churn.** Any `.snap` covering a TOC with a quoted heading will change. Grep
+  before implementing; per `CLAUDE.md`, snapshot changes must be counted and summarized in
+  the commit message. Expected to be near-zero given how rare quoted headings are, but this
+  must be confirmed, not assumed.
+- **The fix is provably safe on the escaping axis.** `toc_render.rs:143` runs
+  `html_escape(&entry.title)`; curly quotes are not escaped and need no entity. There is
+  already a test at toc_render.rs:422 covering a title containing `<b>HTML</b> & "quotes"`.
+- **Interim-fix risk.** If question 1 goes toward inlines-carrying entries, the Phase 1 arm
+  is thrown away later. It is three lines and it makes the output correct today — cheap
+  enough that this is not an argument against it, but worth naming.
+- **No e2e TOC coverage exists.** Adding the first one is a small tax on this strand and a
+  standing benefit; the absence is the reason a visible TOC defect reached a release.

--- a/claude-notes/plans/2026-08-13-toc-smart-quotes.md
+++ b/claude-notes/plans/2026-08-13-toc-smart-quotes.md
@@ -275,46 +275,72 @@ These are why "change `String` to `Inlines`" is not a one-commit change.
    (`template.rs:961`, `revealjs/footer_logo.rs:187`). `toc_render` swapping
    `html_escape(&entry.title)` for `write_inlines_to` follows an established path.
 
-## Proposed phases
+## Work items
 
-Drafted against the settled decisions above. Phase boundaries are commit points (per
-`CLAUDE.md`'s commit-and-continue rule); the work items inside each still want a pass with
-fresh eyes at implementation time.
+Phase boundaries are commit points (per `CLAUDE.md`'s commit-and-continue rule). Checked
+items are done and committed.
 
-- **Phase 0 — Test plan (TDD, failing first).**
-  - End-to-end first, because its absence is why this shipped: a `toc: true` document whose
-    headings carry a quoted span, inline code, emphasis, math and a link, driven through
-    `render_document_to_file` (pattern: `crates/quarto-core/tests/integration/`
-    `render_page_in_project.rs`) — **not** `render_qmd_to_html` with defaults. Assert the TOC
-    anchor's inner HTML against the Q1 shape captured in
-    `toc-smart-quotes-investigation/OBSERVED.md`. There is currently **no e2e TOC test at
-    all**.
-  - Unit: `TocEntry` round-trips through `ConfigValue` preserving inlines;
-    `from_config_value` accepts both `PandocInlines` and `Scalar(String)` (the latter
-    wrapped as a single `Str`).
-  - Measure snapshot churn here rather than discovering it in Phase 2 (see Risks).
-  - Verify all fail at HEAD before touching anything.
-- **Phase 1 — `TocEntry.title: Inlines`.** Change the type; `generate_toc` clones header
-  content instead of flattening. Delete `toc.rs::inlines_to_text` and its two unit tests.
-  Update `to_config_value` to emit `ConfigValueKind::PandocInlines` and `from_config_value`
-  to accept both shapes. Bump `profile_version` and add the change-log entry to the profile
-  contract doc.
-- **Phase 2 — `toc_render` emits markup.** Replace `html_escape(&entry.title)` with
-  `pampa::writers::html::write_inlines_to`. Cross-check against Q1's `<code>` / `<em>` /
-  `<strong>` / `<span class="math inline">` shapes.
-- **Phase 3 — `toc-title` gets the same treatment (decision 2).** Two parts:
-  - `NavigationToc.title: Option<Inlines>` (toc.rs:181), read from merged metadata without
-    `as_plain_text()` flattening (toc_generate.rs:125-133, toc.rs:214), rendered through
-    `write_inlines_to` into `<h2 id="toc-title">`.
-  - Add `&["toc-title"]` to `MARKDOWN_CONFIG_PATHS` (config_markdown.rs:84-122) so a
-    project-level `toc-title` gets the same markdown semantics as a front-matter one.
-    Test both sources. Confirm the localized-term fallback path
-    (`toc-title-document` via `LanguageTerms`) still yields plain text sensibly — it returns
-    a `String` today and will need wrapping.
-- **Phase 4 — Verification.** `cargo xtask verify`, plus a re-render of both investigation
-  fixtures with the output appended to `OBSERVED.md` alongside the Q1 capture.
-- **Phase 5 — Follow-ups (file, don't implement).** Un-defer `bd-zzke` with the corrected
-  ~10-site list; leave bd-heading-id-drops-inline-content-fl84n3ql to its own strand.
+### Phase 0 — Test plan (TDD, failing first)
+
+- [ ] End-to-end test: a `toc: true` document whose headings carry a quoted span, inline
+      code, emphasis, math and a link, driven through `render_document_to_file` (pattern:
+      `crates/quarto-core/tests/integration/render_page_in_project.rs`) — **not**
+      `render_qmd_to_html` with defaults. Assert the TOC anchor's inner HTML against the Q1
+      shape in `toc-smart-quotes-investigation/OBSERVED.md`. There is currently **no e2e TOC
+      test at all**, which is why this shipped.
+- [ ] Unit: `TocEntry` round-trips through `ConfigValue` preserving inlines.
+- [ ] Unit: `from_config_value` accepts both `PandocInlines` and `Scalar(String)` (the
+      latter wrapped as a single `Str`).
+- [ ] Measure snapshot churn now rather than discovering it in Phase 2 (see Risks).
+- [ ] Confirm every new test fails at HEAD, for the expected reason, before touching
+      production code.
+
+### Phase 1 — `TocEntry.title: Inlines`
+
+- [ ] Change the field type; `generate_toc` clones header content instead of flattening.
+- [ ] Delete `toc.rs::inlines_to_text` and its two unit tests.
+- [ ] `to_config_value` emits `ConfigValueKind::PandocInlines`.
+- [ ] `from_config_value` accepts both shapes.
+- [ ] Bump `profile_version` and add the change-log entry to
+      `claude-notes/designs/document-profile-contract.md`.
+- [ ] Confirm the incremental-rebuild path degrades to a full rebuild on version mismatch
+      rather than erroring.
+
+### Phase 2 — `toc_render` emits markup
+
+- [ ] Replace `html_escape(&entry.title)` with `pampa::writers::html::write_inlines_to`.
+- [ ] Cross-check output against Q1's `<code>` / `<em>` / `<strong>` /
+      `<span class="math inline">` shapes.
+- [ ] Rework the `toc_render.rs:422` test: a literal `<b>` typed in a heading arrives as
+      `Str("<b>")` and must still be escaped; a `RawInline` must not be.
+
+### Phase 3 — `toc-title` gets the same treatment (decision 2)
+
+- [ ] `NavigationToc.title: Option<Inlines>` (toc.rs:181), read from merged metadata without
+      `as_plain_text()` flattening (toc_generate.rs:125-133, toc.rs:214).
+- [ ] Render it through `write_inlines_to` into `<h2 id="toc-title">`.
+- [ ] Wrap the localized-term fallback (`toc-title-document` via `LanguageTerms`) — it
+      returns a `String` today.
+- [ ] Add `&["toc-title"]` to `MARKDOWN_CONFIG_PATHS` (config_markdown.rs:84-122); test both
+      the front-matter and the `_quarto.yml` source.
+- [ ] Add the "see also, and when to pick which" cross-reference note to *both* registries
+      (`meta_annotations.rs` `ANNOTATIONS` and `config_markdown.rs`
+      `MARKDOWN_CONFIG_PATHS`) — this is `bd-qzn1azon`'s whole scope, and Phase 3 is already
+      editing one of them. Close `bd-qzn1azon` when done.
+
+### Phase 4 — Verification
+
+- [ ] `cargo xtask verify` (full, not `--skip-hub-build` — `quarto-core` and
+      `quarto-pandoc-types` are both touched).
+- [ ] Re-render both investigation fixtures; append the output to `OBSERVED.md` beside the
+      Q1 capture.
+- [ ] Count and summarize snapshot changes per `CLAUDE.md`; flag anything surprising.
+
+### Phase 5 — Follow-ups (file, don't implement)
+
+- [ ] Un-defer `bd-zzke` with the corrected ~10-site list.
+- [ ] Leave `bd-heading-id-drops-inline-content-fl84n3ql` to its own strand (`related` edge
+      added 2026-08-13).
 
 No docs phase: no new user-facing option — this is q2 catching up to Q1's existing behavior.
 
@@ -343,16 +369,18 @@ Kept for the record, since the reasoning is easy to re-litigate:
   construction, so **wrap it as a single `Str`**. Re-parsing would bypass `ProjectConfig`'s
   deliberate default; the registry (decision 2) is the sanctioned opt-in.
 
-## One gap worth filing separately
+## Adjacent gap — filed as `bd-d7ljiz9q`
 
-The user's standing rationale for blessing more keys is that `!str` / `!path` give authors
-control. That is true in document front matter and **false in project config**: after load,
+The standing rationale for blessing more keys is that `!str` / `!path` give authors control.
+That is true in document front matter and **false in project config**: after load,
 `!str`-tagged and untagged strings are both `Scalar(String)`, so a blessed key cannot be
 opted out of markdown parsing from `_quarto.yml` (documented at config_markdown.rs:40-45).
 
-This is accepted for `toc-title` specifically. But as the blessed set grows — `bd-xygsu15r`
-is the next one queued — the missing opt-out becomes more load-bearing, and it is the one
-mechanism the broader policy leans on. Not filed; offered.
+Accepted for `toc-title` specifically (decision 2). But as the blessed set grows —
+`bd-xygsu15r` is next in the queue — the missing opt-out becomes more load-bearing, and it
+is the one mechanism the broader policy leans on. **Filed 2026-08-13 as `bd-d7ljiz9q`**
+(`bug`, P2, `discovered-from` this strand, `related` to `bd-qzn1azon`), with three
+non-decided fix directions. **Not in this epic's scope.**
 
 ## Risks / tradeoffs (draft)
 

--- a/claude-notes/plans/2026-08-13-toc-smart-quotes.md
+++ b/claude-notes/plans/2026-08-13-toc-smart-quotes.md
@@ -326,10 +326,14 @@ the defect shipped, namely that the TOC had no test coverage at all.
       covering the round-trip and both accepted title shapes).
 - [x] `to_config_value` emits `ConfigValueKind::PandocInlines`.
 - [x] `from_config_value` accepts both shapes, via the new `config_value_to_inlines`.
-- [ ] Bump `profile_version` and add the change-log entry to
-      `claude-notes/designs/document-profile-contract.md`.
-- [ ] Confirm the incremental-rebuild path degrades to a full rebuild on version mismatch
-      rather than erroring.
+- [x] Bump `profile_version` (10 -> **11**) and add the change-log entry to
+      `claude-notes/designs/document-profile-contract.md` (done in Phase 3's commit, as
+      planned).
+- [x] Confirm the incremental-rebuild path degrades to a full rebuild on version mismatch
+      rather than erroring. **It does, two ways:** `DOCUMENT_PROFILE_VERSION` is in the
+      cache-key hash domain (`cache_key.rs:166`), so stale entries are never looked up at
+      all; and if one somehow were, `profile_cache::load` treats a shape mismatch as a miss
+      rather than an error (`load_rejects_corrupt_json_as_miss`).
 
 > **Phases 1 and 2 landed in one commit, deliberately.** `toc_render` is the type's only
 > production consumer, so the tree cannot compile with the type changed and the renderer
@@ -407,52 +411,50 @@ there when it is un-deferred.
 > Scope of the strip, mirroring Pandoc: `Link` unwraps to its content; `Note` and
 > `NoteReference` are dropped. Everything else renders.
 
-### Phase 3 — `toc-title` gets the same treatment (decision 2)
+### Phase 3 — `toc-title` gets the same treatment (decision 2) — **DONE**
 
-- [ ] `NavigationToc.title: Option<Inlines>` (toc.rs:181), read from merged metadata without
-      `as_plain_text()` flattening (toc_generate.rs:125-133, toc.rs:214).
-- [ ] Render it through `write_inlines_to` into `<h2 id="toc-title">`.
-- [ ] Wrap the localized-term fallback (`toc-title-document` via `LanguageTerms`) — it
-      returns a `String` today.
-- [ ] Add `&["toc-title"]` to `MARKDOWN_CONFIG_PATHS` (config_markdown.rs:84-122); test both
-      the front-matter and the `_quarto.yml` source.
-- [ ] Add the "see also, and when to pick which" cross-reference note to *both* registries
-      (`meta_annotations.rs` `ANNOTATIONS` and `config_markdown.rs`
-      `MARKDOWN_CONFIG_PATHS`) — this is `bd-qzn1azon`'s whole scope, and Phase 3 is already
-      editing one of them. Close `bd-qzn1azon` when done.
-- [ ] **Preview parity** (found in Phase 0, see below): emit the *rendered* title HTML into
-      `rendered.navigation.toc-title`, switch `template.rs:213` to it, and switch
-      `PreviewDocument.tsx:184` + `TocSlot` to consume it via `dangerouslySetInnerHTML`.
-- [ ] Extend `PreviewDocument.integration.test.tsx` (the TOC cases at :383-420) for the new
-      shape, and run `npm run build:all` from `hub-client/` — per `CLAUDE.md`, passing tests
-      are not sufficient for TS changes.
+- [x] `NavigationToc.title: Option<Inlines>`, read from merged metadata without
+      `as_plain_text()` flattening (`toc_generate.rs`, `toc.rs`). The two fallbacks
+      (localized `toc-title-document`, English default) are genuinely plain text and get
+      wrapped with the new `plain_inlines`.
+- [x] Render it through `render_toc_label` into `<h2 id="toc-title">`.
+- [x] Add `&["toc-title"]` to `MARKDOWN_CONFIG_PATHS`; both sources tested.
+- [x] Cross-reference note added to *both* registries (`bd-qzn1azon`'s whole scope) — a
+      four-row comparison table in each module header saying when to pick which.
+- [x] **Preview parity**: `rendered.navigation.toc-title` published by `TocRenderTransform`;
+      `template.rs` and `PreviewDocument.tsx` both read it; `TocSlot` takes `titleHtml`.
+- [x] `PreviewDocument.integration.test.tsx` updated, plus a new case asserting markup
+      renders as HTML rather than escaped text. 577 preview tests pass.
 
-> **Preview/render parity constraint (found during Phase 0).**
->
-> The TOC *entries* are safe: `TocRenderTransform` writes the inner `<ul>` as an HTML string
-> to `rendered.navigation.toc`, and the preview injects it with `dangerouslySetInnerHTML`
-> (`chromeSlots.tsx` `TocSlot`). Markup added in Phases 1-2 flows through untouched.
->
-> The **title** does not. `PreviewDocument.tsx:184-186` reads
-> `navigation.toc.title` through `extractMetaString` and passes it to `TocSlot` as a
-> `title: string` prop, rendered as a React *text node*. Turning that metadata value into
-> `Inlines` makes `extractMetaString` return nothing, so the preview would silently drop the
-> `<h2 id="toc-title">` while `q2 render` still emits it — a preview/render divergence of
-> exactly the kind `.claude/skills/preview-render-parity` exists to chase, and invisible to
-> every Rust test.
->
-> Fix: give the title the same treatment the entries already get — render it to HTML in
-> `TocRenderTransform` and publish it under `rendered.navigation.*`. That keeps one seam
-> ("`rendered.*` is HTML produced from metadata") instead of inventing a second, and both
-> consumers read the same value.
+**End-to-end verification** (`cargo run --bin q2 -- render`, output inspected) — the two
+sources that used to disagree now agree:
 
-### Phase 4 — Verification
+```html
+<!-- _quarto.yml: toc-title: "On **this** page" -->
+<h2 id="toc-title">On <strong>this</strong> page</h2>
 
-- [ ] `cargo xtask verify` (full, not `--skip-hub-build` — `quarto-core` and
-      `quarto-pandoc-types` are both touched).
-- [ ] Re-render both investigation fixtures; append the output to `OBSERVED.md` beside the
-      Q1 capture.
-- [ ] Count and summarize snapshot changes per `CLAUDE.md`; flag anything surprising.
+<!-- front matter: toc-title: "In *this* document" -->
+<h2 id="toc-title">In <em>this</em> document</h2>
+```
+
+Before this phase the first rendered literal `**this**` and the second rendered `this` with
+the emphasis silently dropped.
+
+**Design note — why the title is pre-rendered rather than left in metadata.** There are two
+consumers with different capabilities: the doctemplate can interpolate an HTML string, and
+the preview's `TocSlot` reads metadata through `extractMetaString`, which cannot see
+`PandocInlines` at all. Publishing one rendered value under `rendered.*` — the seam that
+already means "HTML produced from metadata", and already how the TOC *entries* reach the
+preview — keeps both consumers reading the same bytes. The alternative (teach the TS side to
+walk inline nodes) would duplicate the HTML writer in TypeScript.
+
+### Phase 4 — Verification — **DONE**
+
+- [x] `cargo xtask verify` (full, including the WASM/hub-client leg) — **all steps passed**.
+- [x] `cargo nextest run --workspace` — **11,846 / 11,846 pass**, 197 skipped.
+- [x] `cargo xtask lint` — clean.
+- [x] Re-rendered all three investigation fixtures; output appended to `OBSERVED.md`.
+- [x] Snapshot changes: **none**, as Phase 0 predicted.
 
 ### Phase 5 — Follow-ups (file, don't implement)
 

--- a/claude-notes/plans/2026-08-13-toc-smart-quotes.md
+++ b/claude-notes/plans/2026-08-13-toc-smart-quotes.md
@@ -3,9 +3,9 @@
 **Date:** 2026-08-13
 **Braid:** bd-toc-smart-quotes-6nro57ed
 **Branch:** `main` @ `0dcd7e83` (investigated in the main checkout — no worktree was created)
-**Status:** Scope settled 2026-08-13 — **TOC entries carry inlines**; the narrow glyph fix is
-*not* being done. Phases below are drafted against that decision but the phase contents are
-still skeletal. **Do not start implementation until the user gives the go-ahead.**
+**Status:** **Design settled 2026-08-13** — all open questions answered (see "Decisions"
+below). Phases are drafted against those decisions. **Do not start implementation until the
+user gives the go-ahead.**
 
 ## Triage verdict
 
@@ -16,21 +16,47 @@ flattens every heading to plain text** (`TocEntry.title: String`). Dropped quote
 the one symptom the Connect corpus happens to hit; `<code>`, `<em>`, `<strong>` and math
 spans are lost the same way.
 
-### Scope decision (user, 2026-08-13)
+## Decisions (user, 2026-08-13)
 
-Do the larger task here, phased. Specifically:
+All settled; nothing is awaiting an answer.
 
-- **The narrow glyph fix is skipped.** It would be deleted wholesale by the real fix: once
-  `TocEntry.title` is `Inlines`, `generate_toc` clones header content and
-  `toc.rs::inlines_to_text` ceases to exist. Confirmed there is no residue keeping it alive —
-  the *only* production read of `entry.title` is `html_escape(&entry.title)` at
-  `toc_render.rs:143` (no `title=` attribute, no `aria-label`, no plain-text sink). The one
-  scenario that would justify it is a release cutting mid-epic and needing the Connect docs
-  correct in the interim; absent that it is churn plus a second place encoding quote-glyph
-  policy.
-- **Consolidation (`bd-zzke`) is sequenced after, not merged in.** See "The wider family"
-  below — the TOC work *removes* one of the copies, so it shrinks that strand rather than
-  depending on it.
+1. **Do the larger task here, phased: TOC entries carry inlines.** The narrow glyph fix is
+   **skipped** — it would be deleted wholesale by the real fix, since once `TocEntry.title`
+   is `Inlines`, `generate_toc` clones header content and `toc.rs::inlines_to_text` ceases
+   to exist. Confirmed there is no residue keeping it alive: the *only* production read of
+   `entry.title` is `html_escape(&entry.title)` at `toc_render.rs:143` (no `title=`
+   attribute, no `aria-label`, no plain-text sink). The one scenario that would justify it
+   is a release cutting mid-epic and needing the Connect docs correct in the interim.
+
+2. **`NavigationToc.title` also becomes `Inlines`, and `toc-title` gets blessed in
+   `MARKDOWN_CONFIG_PATHS`** — both in this epic. The two caveats were accepted knowingly:
+   the behavior change for existing `_quarto.yml` files whose `toc-title` contains `*` or
+   `_`, and the fact that `!str` cannot opt out in project config
+   (config_markdown.rs:40-45). Standing rationale from the user: *"It's good for us to parse
+   more YAML fields into Markdown in general, especially since we have `!str` and `!path` as
+   mechanisms for controlling that behavior in Quarto 2."*
+
+   **Implementation note — pick the right registry.** The tree has *two* key-path tables and
+   `bd-qzn1azon` exists because someone already extended the wrong one:
+   `pampa/src/pandoc/meta_annotations.rs` `ANNOTATIONS` is load-time and for keys whose value
+   is **not** markdown (globs, paths); `quarto-core/src/transforms/config_markdown.rs`
+   `MARKDOWN_CONFIG_PATHS` is transform-time over merged metadata and is the one for
+   presentation strings. `toc-title` goes in the latter.
+
+   **Precedent to follow:** `bd-xygsu15r` (sidebar `section:`) is the same one-line-registry
+   shape. It was split out because that field *also* feeds section identity, so blessing it
+   needs a check that `as_plain_text()` id derivation still behaves. `toc-title` has no such
+   entanglement — the `<h2 id="toc-title">` id is a literal constant, not derived from the
+   title — so this is the easy case.
+
+3. **Consolidation (`bd-zzke`) is sequenced after, not merged in.** See "The wider family"
+   below — the TOC work *removes* one of the copies, so it shrinks that strand rather than
+   depending on it. Its description still needs the corrected site list (it lists 6; there
+   are ~10).
+
+4. **`bd-heading-id-drops-inline-content-fl84n3ql` stays fully independent.** Same
+   root-cause class, different code path; this epic no longer touches
+   `toc.rs::inlines_to_text` at all.
 
 ## Issue context
 
@@ -66,7 +92,9 @@ That changes the calculus in two ways:
   `admin/getting-started/off-host-install/configure-helm-chart`.
 
 **Recommendation: add the missing `related` edge** between the two strands so the graph
-carries what the comment currently carries. (Not done unilaterally — see design question 5.)
+carries what the comment currently carries. `related` is informational — it does not gate
+`ready` — so it is compatible with decision 4 (keep the fixes independent). Not done
+unilaterally; still offered.
 
 The sibling strand is the *more severe* of the pair: `autoid::collect_text` handles only
 five inline kinds and drops the rest **without recursing**, so whole words vanish from
@@ -247,9 +275,11 @@ These are why "change `String` to `Inlines`" is not a one-commit change.
    (`template.rs:961`, `revealjs/footer_logo.rs:187`). `toc_render` swapping
    `html_escape(&entry.title)` for `write_inlines_to` follows an established path.
 
-## Proposed phases (draft)
+## Proposed phases
 
-Skeleton only — contents wait on the remaining design questions.
+Drafted against the settled decisions above. Phase boundaries are commit points (per
+`CLAUDE.md`'s commit-and-continue rule); the work items inside each still want a pass with
+fresh eyes at implementation time.
 
 - **Phase 0 — Test plan (TDD, failing first).**
   - End-to-end first, because its absence is why this shipped: a `toc: true` document whose
@@ -260,7 +290,9 @@ Skeleton only — contents wait on the remaining design questions.
     `toc-smart-quotes-investigation/OBSERVED.md`. There is currently **no e2e TOC test at
     all**.
   - Unit: `TocEntry` round-trips through `ConfigValue` preserving inlines;
-    `from_config_value` still accepts a legacy plain-string title.
+    `from_config_value` accepts both `PandocInlines` and `Scalar(String)` (the latter
+    wrapped as a single `Str`).
+  - Measure snapshot churn here rather than discovering it in Phase 2 (see Risks).
   - Verify all fail at HEAD before touching anything.
 - **Phase 1 — `TocEntry.title: Inlines`.** Change the type; `generate_toc` clones header
   content instead of flattening. Delete `toc.rs::inlines_to_text` and its two unit tests.
@@ -270,9 +302,15 @@ Skeleton only — contents wait on the remaining design questions.
 - **Phase 2 — `toc_render` emits markup.** Replace `html_escape(&entry.title)` with
   `pampa::writers::html::write_inlines_to`. Cross-check against Q1's `<code>` / `<em>` /
   `<strong>` / `<span class="math inline">` shapes.
-- **Phase 3 — Sweep the TOC-adjacent remainder.** `NavigationToc.title` (the TOC *heading*,
-  toc.rs:181) is still a `String` read via `as_str()` at toc.rs:214 — decide whether
-  `toc-title` gets the same treatment (Q2 below).
+- **Phase 3 — `toc-title` gets the same treatment (decision 2).** Two parts:
+  - `NavigationToc.title: Option<Inlines>` (toc.rs:181), read from merged metadata without
+    `as_plain_text()` flattening (toc_generate.rs:125-133, toc.rs:214), rendered through
+    `write_inlines_to` into `<h2 id="toc-title">`.
+  - Add `&["toc-title"]` to `MARKDOWN_CONFIG_PATHS` (config_markdown.rs:84-122) so a
+    project-level `toc-title` gets the same markdown semantics as a front-matter one.
+    Test both sources. Confirm the localized-term fallback path
+    (`toc-title-document` via `LanguageTerms`) still yields plain text sensibly — it returns
+    a `String` today and will need wrapping.
 - **Phase 4 — Verification.** `cargo xtask verify`, plus a re-render of both investigation
   fixtures with the output appended to `OBSERVED.md` alongside the Q1 capture.
 - **Phase 5 — Follow-ups (file, don't implement).** Un-defer `bd-zzke` with the corrected
@@ -282,68 +320,39 @@ No docs phase: no new user-facing option — this is q2 catching up to Q1's exis
 
 ## Open design questions for the user
 
-Questions 1, 2 and 5 from the first round are settled (see "Scope decision" above).
-Remaining:
+**None — design is settled.** See "Decisions" above. The two questions that were live in
+round two are recorded there as decisions 2 and 3; the round-one questions about scope and
+about pairing with the autoid strand are decisions 1 and 4.
 
-1. ~~**Legacy string titles: promote or parse?**~~ **Withdrawn — the premise was wrong.**
-   Markdown parsing of metadata strings happens at **YAML-load time**, not in
-   `from_config_value`. The `InterpretationContext` (config_value.rs:104-135) sets the
-   default per source, and the two sources have **opposite defaults**:
+Kept for the record, since the reasoning is easy to re-litigate:
 
-   | source | untagged string | opt out / in |
-   |---|---|---|
-   | document front matter (`DocumentMetadata`) | **parsed as markdown** → `PandocInlines` | `!str` keeps it literal |
-   | `_quarto.yml` (`ProjectConfig`) | **kept literal** → `Scalar(String)` | `!md` parses it |
+- **"Legacy string titles: promote or parse?" was withdrawn — the premise was wrong.**
+  Markdown parsing of metadata strings happens at **YAML-load time**, not in
+  `from_config_value`. The `InterpretationContext` (config_value.rs:104-135) sets the
+  default per source, and the two sources have **opposite defaults**:
 
-   So a front-matter `navigation.toc` entry with `title: "My **bold** section"` already
-   arrives as `PandocInlines` carrying a `Strong`. Today `as_plain_text()` (toc.rs:146)
-   throws that markup away — which is the *same defect this epic fixes*, not a separate
-   decision. Nothing to re-parse; carrying inlines just stops discarding what is already
-   there.
+  | source | untagged string | opt out / in |
+  |---|---|---|
+  | document front matter (`DocumentMetadata`) | **parsed as markdown** -> `PandocInlines` | `!str` keeps it literal |
+  | `_quarto.yml` (`ProjectConfig`) | **kept literal** -> `Scalar(String)` | `!md` parses it |
 
-   What survives is narrower and has an answer that follows from the existing contract: a
-   `Scalar(String)` reaching `from_config_value` came from project config (literal by
-   design) or from programmatic construction, so it should be **wrapped as a single `Str`**.
-   Re-parsing it would bypass `ProjectConfig`'s deliberate literal-by-default rule; the
-   sanctioned way to opt a project-config key into markdown is the registry — see Q2.
+  So a front-matter `title: "My **bold** section"` already arrives as `PandocInlines`
+  carrying a `Strong`; `as_plain_text()` (toc.rs:146) discards it. That is the defect this
+  epic fixes, not a decision to make. The residual — what to do with a `Scalar(String)` —
+  follows from the contract: it came from project config (literal by design) or programmatic
+  construction, so **wrap it as a single `Str`**. Re-parsing would bypass `ProjectConfig`'s
+  deliberate default; the registry (decision 2) is the sanctioned opt-in.
 
-2. **Should `toc-title` be blessed in `MARKDOWN_CONFIG_PATHS`?** *(the real question Q1 was
-   groping at)*
-   `toc-title` is read from merged metadata via `as_plain_text()`
-   (`toc_generate.rs:125-133`), so it inherits the split above:
+## One gap worth filing separately
 
-   - front matter — `toc-title: "On **this** page"` → `PandocInlines`, markup **available**
-     (and currently discarded by `as_plain_text`, fixed by this epic);
-   - `_quarto.yml` — same YAML → `Scalar(String)`, markup **never parsed**, because
-     `toc-title` is **not** in `MARKDOWN_CONFIG_PATHS`
-     (`transforms/config_markdown.rs:84-122`, which blesses `website.title`, navbar/sidebar
-     titles, `page-footer` regions and nav-item `text`).
+The user's standing rationale for blessing more keys is that `!str` / `!path` give authors
+control. That is true in document front matter and **false in project config**: after load,
+`!str`-tagged and untagged strings are both `Scalar(String)`, so a blessed key cannot be
+opted out of markdown parsing from `_quarto.yml` (documented at config_markdown.rs:40-45).
 
-   So after this epic a project-level `toc-title` would still be markup-free while a
-   document-level one renders — a split with no principled justification, since `toc-title`
-   is presentation text exactly like `website.title` and `sidebar.title` next to it in the
-   registry. Adding `&["toc-title"]` is a one-line change and the module documents this as
-   the growth path ("Growing the feature = adding a line here").
-
-   I lean **yes, bless it, in this epic**. Two caveats worth your call: it is a behavior
-   change for existing `_quarto.yml` files whose `toc-title` happens to contain `*` or `_`
-   (the `!str` opt-out does not work in project config — documented limitation at
-   config_markdown.rs:40-45), and `NavigationToc.title` is currently `String` read via
-   `as_str()` (toc.rs:214), so blessing it only pays off if that field also becomes
-   `Inlines` in Phase 3.
-
-3. **`bd-zzke`: un-defer now or after this lands?**
-   It shrinks once the TOC stops flattening. I lean **after**, so its site audit runs
-   against the post-epic tree rather than being redone. Either way its description needs the
-   corrected site list (it lists 6; there are ~10).
-
-4. **Should this be fixed jointly with bd-heading-id-drops-inline-content-fl84n3ql?**
-   (Carried over.) They share a heading and a root-cause *class*, but not a code path — and
-   this epic no longer touches `toc.rs::inlines_to_text` at all, which weakens the "fix
-   together" case further. The autoid strand is now cleanly independent, and its own
-   judgement call (whether quote glyphs reach the slug filter) is moot since the slug filter
-   strips non-alphanumerics anyway. My recommendation is now **fully independent strands**,
-   contra the first round.
+This is accepted for `toc-title` specifically. But as the blessed set grows — `bd-xygsu15r`
+is the next one queued — the missing opt-out becomes more load-bearing, and it is the one
+mechanism the broader policy leans on. Not filed; offered.
 
 ## Risks / tradeoffs (draft)
 

--- a/claude-notes/plans/2026-08-13-toc-smart-quotes.md
+++ b/claude-notes/plans/2026-08-13-toc-smart-quotes.md
@@ -319,26 +319,75 @@ page verbatim.
 HTML. The Risks section had this flagged as a broad hazard; it is nil — for the same reason
 the defect shipped, namely that the TOC had no test coverage at all.
 
-### Phase 1 — `TocEntry.title: Inlines`
+### Phase 1 — `TocEntry.title: Inlines` — **DONE** (landed with Phase 2)
 
-- [ ] Change the field type; `generate_toc` clones header content instead of flattening.
-- [ ] Delete `toc.rs::inlines_to_text` and its two unit tests.
-- [ ] `to_config_value` emits `ConfigValueKind::PandocInlines`.
-- [ ] `from_config_value` accepts both shapes.
+- [x] Change the field type; `generate_toc` clones header content instead of flattening.
+- [x] Delete `toc.rs::inlines_to_text` and its two unit tests (replaced by four new ones
+      covering the round-trip and both accepted title shapes).
+- [x] `to_config_value` emits `ConfigValueKind::PandocInlines`.
+- [x] `from_config_value` accepts both shapes, via the new `config_value_to_inlines`.
 - [ ] Bump `profile_version` and add the change-log entry to
       `claude-notes/designs/document-profile-contract.md`.
 - [ ] Confirm the incremental-rebuild path degrades to a full rebuild on version mismatch
       rather than erroring.
 
-### Phase 2 — `toc_render` emits markup
+> **Phases 1 and 2 landed in one commit, deliberately.** `toc_render` is the type's only
+> production consumer, so the tree cannot compile with the type changed and the renderer
+> untouched. The alternative — a temporary `as_plain_text()` flatten in `toc_render` to keep
+> Phase 1 self-contained — is exactly the "TODO that undoes existing work" `CLAUDE.md`
+> forbids. One commit, both changes.
+>
+> The two `profile_version` items are **deliberately still open** and move to Phase 3's
+> commit: they are a contract change with its own doc update, and keeping them separate from
+> the behavior change keeps both reviewable.
 
-- [ ] Replace `html_escape(&entry.title)` with `pampa::writers::html::write_inlines_to`.
-- [ ] **Strip links and notes at render time** (see the decision below) so the TOC's own
-      `<a>` never wraps a nested `<a>`.
-- [ ] Cross-check output against Q1's `<code>` / `<em>` / `<strong>` /
-      `<span class="math inline">` shapes.
-- [ ] Rework the `toc_render.rs:422` test: a literal `<b>` typed in a heading arrives as
-      `Str("<b>")` and must still be escaped; a `RawInline` must not be.
+### Phase 2 — `toc_render` emits markup — **DONE**
+
+- [x] Replace `html_escape(&entry.title)` with `pampa::writers::html::write_inlines_to`,
+      via the new `render_toc_label`.
+- [x] **Strip links and notes at render time** (`strip_links_and_notes`, exhaustive match)
+      so the TOC's own `<a>` never wraps a nested `<a>`.
+- [x] Cross-checked against Q1 — output is **byte-identical** for both probe entries
+      (see the end-to-end record in `OBSERVED.md`).
+- [x] Reworked the escaping test and added two unit tests (`test_renders_toc_label_with_markup`,
+      `test_toc_label_strips_links_and_notes`).
+
+**End-to-end verification** (`cargo run --bin q2 -- render <fixture>`, output inspected):
+
+```html
+<!-- repro/ — the strand's own case -->
+<a href="#using-a-volume" class="nav-link" data-scroll-target="#using-a-volume">
+Using a “raw” volume
+</a>
+
+<!-- markup-probe/ — matches Quarto 1 exactly, link stripped -->
+<a href="#use-code-and-em-and-strong" ...>
+Use <code>code</code> and <em>em</em> and <strong>strong</strong>
+</a>
+<a href="#math-and-a" ...>
+Math <span class="math inline">\(x+y\)</span> and a link
+</a>
+```
+
+(The `#math-and-a` id is still wrong — that is the sibling strand
+`bd-heading-id-drops-inline-content-fl84n3ql`, deliberately out of scope per decision 4.)
+
+**Downstream blast radius, measured:** exactly two files needed updating —
+`toc_render.rs` (the intended consumer) and `document_profile.rs` +
+`document_profile_pipeline.rs` tests, which now project titles to text with
+`pampa::writers::plaintext::inlines_to_string`. That projection is the
+"consumers that cannot render markup project it themselves" clause of the new
+`TocEntry::title` contract, using the one flattener in the tree that is already correct.
+
+**Test status at this commit:** 11,843 of 11,845 workspace tests pass. The two `toc-title`
+tests are `#[ignore]`d with a reason naming Phase 3, so the tree is green; Phase 3 removes
+the attribute as its first act.
+
+**Incidental finding (not filed):** the tree has no shared inline-walking utility — every
+transform hand-rolls its own `visit_inline` (link_rewrite, crossref_index, equation_label,
+attribution_render, resource_collector, …). `strip_links_and_notes` is one more. That is the
+same family as `bd-zzke` but a different shape (transform vs. flatten); worth mentioning
+there when it is un-deferred.
 
 > **Design decision (2026-08-13, during Phase 0): strip at render, not at generation.**
 >

--- a/claude-notes/plans/toc-smart-quotes-investigation/.gitignore
+++ b/claude-notes/plans/toc-smart-quotes-investigation/.gitignore
@@ -1,0 +1,4 @@
+# Render output from the probe fixtures — regenerate with `q2 render`.
+_site/
+_site-q1/
+.quarto/

--- a/claude-notes/plans/toc-smart-quotes-investigation/OBSERVED.md
+++ b/claude-notes/plans/toc-smart-quotes-investigation/OBSERVED.md
@@ -1,0 +1,87 @@
+# Observed output at HEAD `0dcd7e83` (2026-08-13)
+
+Both fixtures were rendered with both engines; the `_site` / `_site-q1` trees are
+*not* committed (build artifacts). The excerpts below are the inspected output.
+
+Reproduce with:
+
+```bash
+cargo run --bin q2 -- render claude-notes/plans/toc-smart-quotes-investigation/repro
+cargo run --bin q2 -- render claude-notes/plans/toc-smart-quotes-investigation/markup-probe
+# Quarto 1 comparison (run inside the fixture directory):
+quarto render --output-dir _site-q1
+```
+
+## `repro/` — the strand's case
+
+**q2 @ `0dcd7e83`**, `_site/index.html`:
+
+```html
+<nav id="TOC" role="doc-toc" class="toc-active">
+<h2 id="toc-title">Table of contents</h2>
+<ul>
+<li>
+<a href="#using-a-volume" class="nav-link" data-scroll-target="#using-a-volume">
+Using a raw volume
+</a>
+</li>
+<li>
+<a href="#finding-your-repositorys-identifiers" class="nav-link" data-scroll-target="#finding-your-repositorys-identifiers">
+Finding your repository’s identifiers
+</a>
+</li>
+<li>
+<a href="#whats-in-the-gallery-really" class="nav-link" data-scroll-target="#whats-in-the-gallery-really">
+What’s in the Gallery – really
+</a>
+</li>
+</ul>
+</nav>
+...
+<section id="using-a-volume" class="section level2">
+<h2>Using a “raw” volume</h2>
+```
+
+The heading keeps U+201C/U+201D; the TOC label loses them. Both controls
+(`repository’s`, `Gallery – really`) are correct.
+
+**Quarto 1**, `_site-q1/index.html`:
+
+```html
+<li><a href="#using-a-raw-volume" id="toc-using-a-raw-volume" class="nav-link active" data-scroll-target="#using-a-raw-volume">Using a “raw” volume</a></li>
+<li><a href="#finding-your-repositorys-identifiers" ...>Finding your repository’s identifiers</a></li>
+<li><a href="#whats-in-the-gallery-really" ...>What’s in the Gallery – really</a></li>
+```
+
+(The `#using-a-raw-volume` vs. `#using-a-volume` id difference is the sibling
+strand bd-heading-id-drops-inline-content-fl84n3ql, not this one.)
+
+## `markup-probe/` — does the TOC keep inline markup at all?
+
+Headings: `## Use \`code\` and *em* and **strong**` and
+`## Math $x+y$ and a [link](https://example.com)`.
+
+**Quarto 1** keeps the markup:
+
+```html
+<li><a href="#use-code-and-em-and-strong" ...>Use <code>code</code> and <em>em</em> and <strong>strong</strong></a></li>
+<li><a href="#math-xy-and-a-link" ...>Math <span class="math inline">\(x+y\)</span> and a link</a></li>
+```
+
+**q2 @ `0dcd7e83`** flattens it:
+
+```html
+<a href="#use-code-and-em-and-strong" class="nav-link" data-scroll-target="#use-code-and-em-and-strong">
+Use code and em and strong
+</a>
+<a href="#math-and-a" class="nav-link" data-scroll-target="#math-and-a">
+Math x+y and a link
+</a>
+```
+
+Two things here:
+
+1. `TocEntry.title` is a `String` by construction, so *all* inline markup is lost
+   in q2 TOC entries — the missing quote glyphs are one symptom of that.
+2. `#math-and-a` (q2) vs. `#math-xy-and-a-link` (Q1) is the sibling autoid bug
+   again, this time swallowing `Math` and `Link` content.

--- a/claude-notes/plans/toc-smart-quotes-investigation/OBSERVED.md
+++ b/claude-notes/plans/toc-smart-quotes-investigation/OBSERVED.md
@@ -85,3 +85,57 @@ Two things here:
    in q2 TOC entries — the missing quote glyphs are one symptom of that.
 2. `#math-and-a` (q2) vs. `#math-xy-and-a-link` (Q1) is the sibling autoid bug
    again, this time swallowing `Math` and `Link` content.
+
+---
+
+# After the fix — q2 @ phase 3 (2026-08-13)
+
+Same invocations as above. All three fixtures re-rendered and inspected.
+
+## `repro/` — the strand's own case
+
+```html
+<a href="#using-a-volume" class="nav-link" data-scroll-target="#using-a-volume">
+Using a “raw” volume
+</a>
+<a href="#finding-your-repositorys-identifiers" ...>
+Finding your repository’s identifiers
+</a>
+<a href="#whats-in-the-gallery-really" ...>
+What’s in the Gallery – really
+</a>
+```
+
+Matches Quarto 1. (The `#using-a-volume` id is still wrong — sibling strand
+bd-heading-id-drops-inline-content-fl84n3ql, deliberately out of scope.)
+
+## `markup-probe/` — byte-identical to Quarto 1
+
+```html
+<a href="#use-code-and-em-and-strong" ...>
+Use <code>code</code> and <em>em</em> and <strong>strong</strong>
+</a>
+<a href="#math-and-a" ...>
+Math <span class="math inline">\(x+y\)</span> and a link
+</a>
+```
+
+Note `and a link`, not `and a <a href=…>link</a>`: links are unwrapped at render
+time (`strip_links_and_notes`, mirroring pandoc's `deLink`) because the TOC entry
+is itself an `<a>` and anchors cannot nest. Quarto 1 does the same.
+
+## `toc-title-probe/` — the two config sources now agree
+
+```html
+<!-- index.html — _quarto.yml: toc-title: "On **this** page" -->
+<h2 id="toc-title">On <strong>this</strong> page</h2>
+
+<!-- frontmatter.html — front matter: toc-title: "In *this* document" -->
+<h2 id="toc-title">In <em>this</em> document</h2>
+```
+
+Before the fix these diverged: the project-config form rendered the asterisks
+literally (never markdown-parsed, because `toc-title` was not in
+`MARKDOWN_CONFIG_PATHS`), while the front-matter form rendered `On this page`
+with the emphasis silently flattened away by `as_plain_text()`. Same YAML, two
+different failures — the `InterpretationContext` split.

--- a/claude-notes/plans/toc-smart-quotes-investigation/markup-probe/_quarto.yml
+++ b/claude-notes/plans/toc-smart-quotes-investigation/markup-probe/_quarto.yml
@@ -1,0 +1,4 @@
+project:
+  type: website
+website:
+  title: "Markup probe"

--- a/claude-notes/plans/toc-smart-quotes-investigation/markup-probe/index.qmd
+++ b/claude-notes/plans/toc-smart-quotes-investigation/markup-probe/index.qmd
@@ -1,0 +1,12 @@
+---
+title: "Markup probe"
+toc: true
+---
+
+## Use `code` and *em* and **strong**
+
+Probe: does the TOC entry keep inline markup?
+
+## Math $x+y$ and a [link](https://example.com)
+
+Probe: math and links.

--- a/claude-notes/plans/toc-smart-quotes-investigation/repro/README.md
+++ b/claude-notes/plans/toc-smart-quotes-investigation/repro/README.md
@@ -1,0 +1,58 @@
+# TOC entries lose the quote glyphs around a quoted span
+
+**Observed with:** q2 0.19.0, re-verified 0.20.0 (binary; HEAD 0dcd7e83).
+**Repro:** `q2 render` in this directory; compare with
+`quarto render --output-dir _site-q1`.
+
+The heading `## Using a "raw" volume` renders with curly quotes, but its
+TOC entry drops the quote characters entirely — the two disagree within
+one page. This is specific to `Inline::Quoted` nodes: apostrophes and
+dashes, which are `Str`-internal smart-typography rewrites, come through
+correctly in both places (headings 2 and 3 are the controls).
+
+## Expected (Quarto 1)
+
+```
+heading:  Using a “raw” volume
+TOC:      Using a “raw” volume
+```
+
+## Actual (q2 0.20.0)
+
+```
+heading:  Using a “raw” volume
+TOC:      Using a raw volume          <-- glyphs gone
+```
+
+Controls, correct in both engines:
+
+| heading source | heading | TOC |
+|---|---|---|
+| `repository's identifiers` | `repository’s` | `repository’s` |
+| `Gallery -- really` | `Gallery – really` | `Gallery – really` |
+
+## Root cause
+
+`crates/pampa/src/toc.rs:424` recurses into the quoted content but never
+emits the delimiters, and ignores `q.quote_type`:
+
+```rust
+Inline::Quoted(q) => text.push_str(&inlines_to_text(&q.content)),
+```
+
+The match there is exhaustive (no `_` arm), so this is a localized fix.
+Note that the sibling helper in `crates/quarto-core/src/template.rs:1081`
+*does* emit delimiters, but straight ones.
+
+## Impact in the Connect docs port
+
+One heading in the whole corpus: `Option 2: Using a “raw” NFS volume` in
+`admin/getting-started/off-host-install/configure-helm-chart`. Found via
+br-wu5cbkws.
+
+## Related
+
+The same heading also gets a wrong anchor id under q2, via a different
+code path (`crates/pampa/src/utils/autoid.rs`) that drops the quoted
+content outright. That is a separate bug with its own repro at
+`../heading-id-drops-inline-content/`.

--- a/claude-notes/plans/toc-smart-quotes-investigation/repro/_quarto.yml
+++ b/claude-notes/plans/toc-smart-quotes-investigation/repro/_quarto.yml
@@ -1,0 +1,4 @@
+project:
+  type: website
+website:
+  title: "TOC Quotes Repro"

--- a/claude-notes/plans/toc-smart-quotes-investigation/repro/index.qmd
+++ b/claude-notes/plans/toc-smart-quotes-investigation/repro/index.qmd
@@ -1,0 +1,18 @@
+---
+title: "Home"
+toc: true
+---
+
+## Using a "raw" volume
+
+The failing case: a `Quoted` inline in the heading. The heading renders
+with curly quotes; the TOC entry loses the quote glyphs entirely.
+
+## Finding your repository's identifiers
+
+Control: an apostrophe is smartified inside a `Str`, not a `Quoted`
+node. Both heading and TOC entry get U+2019.
+
+## What's in the Gallery -- really
+
+Control: en dash, also a `Str`-internal transform. Both agree.

--- a/claude-notes/plans/toc-smart-quotes-investigation/toc-title-probe/_quarto.yml
+++ b/claude-notes/plans/toc-smart-quotes-investigation/toc-title-probe/_quarto.yml
@@ -1,0 +1,5 @@
+project:
+  type: website
+website:
+  title: "toc-title probe"
+toc-title: "On **this** page"

--- a/claude-notes/plans/toc-smart-quotes-investigation/toc-title-probe/frontmatter.qmd
+++ b/claude-notes/plans/toc-smart-quotes-investigation/toc-title-probe/frontmatter.qmd
@@ -1,0 +1,9 @@
+---
+title: "Front-matter toc-title"
+toc: true
+toc-title: "In *this* document"
+---
+
+## A section
+
+Body.

--- a/claude-notes/plans/toc-smart-quotes-investigation/toc-title-probe/index.qmd
+++ b/claude-notes/plans/toc-smart-quotes-investigation/toc-title-probe/index.qmd
@@ -1,0 +1,8 @@
+---
+title: "Project-level toc-title"
+toc: true
+---
+
+## A section
+
+Body.

--- a/crates/pampa/src/pandoc/meta_annotations.rs
+++ b/crates/pampa/src/pandoc/meta_annotations.rs
@@ -46,6 +46,34 @@
 //!   (`format.*.listing.contents` covers per-format nesting).
 //!   Matching is exact-length, never a suffix match, so a user's
 //!   unrelated `my.listing.contents` key is not captured.
+//!
+//! ## See also: the *other* key-path table, and when to pick which
+//!
+//! There are two registries in the tree that decide how a config
+//! string is interpreted, and picking the wrong one is a mistake that
+//! has already been made once (bd-qzn1azon; the
+//! `bd-page-footer-items-f4th80mj` handoff located its bug correctly
+//! and then proposed fixing it here):
+//!
+//! | | this table (`ANNOTATIONS`) | `MARKDOWN_CONFIG_PATHS` |
+//! |---|---|---|
+//! | when | **load time**, per untagged scalar | **transform time**, over merged metadata |
+//! | for | values that are **not** markdown — globs, paths | website *presentation* strings that **are** markdown |
+//! | effect | picks a non-markdown [`Interpretation`] | re-parses `Scalar(String)` as qmd |
+//! | honours `!str` | yes — explicit tags win | no — the tag is gone by then |
+//!
+//! Rule of thumb: **adding markdown semantics to a presentation key
+//! goes in `MARKDOWN_CONFIG_PATHS`; protecting a machine-facing key
+//! from markdown goes here.** Load-time parsing was considered and
+//! rejected for the presentation class — see
+//! `claude-notes/plans/2026-08-10-shortcodes-website-config-includes.md`.
+//!
+//! `MARKDOWN_CONFIG_PATHS` lives in
+//! `crates/quarto-core/src/transforms/config_markdown.rs` (no intra-doc
+//! link: `quarto-core` depends on `pampa`, not the other way round).
+//!
+//! Both tables are documented as temporary, pending schema-driven
+//! interpretation.
 
 use quarto_config::Interpretation;
 

--- a/crates/pampa/src/toc.rs
+++ b/crates/pampa/src/toc.rs
@@ -21,7 +21,8 @@
 //!
 //! let config = TocConfig {
 //!     depth: 3,
-//!     title: Some("Contents".to_string()),
+//!     // Inlines, not a String — `toc-title` carries markup.
+//!     title: Some(vec![Inline::Str(Str::from("Contents"))]),
 //! };
 //!
 //! let toc = generate_toc(&document.blocks, &config);
@@ -56,8 +57,10 @@ pub struct TocConfig {
     /// Maximum heading depth to include (1-6, default: 3)
     pub depth: i32,
 
-    /// Title for the TOC (e.g., "Table of Contents")
-    pub title: Option<String>,
+    /// Title for the TOC (e.g. "Table of Contents"), as inlines.
+    ///
+    /// Carries markup — see [`NavigationToc::title`].
+    pub title: Option<Inlines>,
 }
 
 impl Default for TocConfig {
@@ -86,7 +89,7 @@ impl Default for TocConfig {
 ///
 /// Programmatically-constructed values (Lua filters, tests) also arrive
 /// as `Scalar(String)` and get the same literal treatment.
-fn config_value_to_inlines(cv: &ConfigValue) -> Option<Inlines> {
+pub fn config_value_to_inlines(cv: &ConfigValue) -> Option<Inlines> {
     if let ConfigValueKind::PandocInlines(inlines) = &cv.value {
         return Some(inlines.clone());
     }
@@ -96,6 +99,18 @@ fn config_value_to_inlines(cv: &ConfigValue) -> Option<Inlines> {
         text,
         source_info: cv.source_info.clone(),
     })])
+}
+
+/// Wrap literal text as a single `Str` inline.
+///
+/// For values that are genuinely plain text and must stay literal — a
+/// localized term from the language catalog, a built-in English default
+/// — rather than markdown that happens not to contain markup.
+pub fn plain_inlines(text: impl Into<String>) -> Inlines {
+    vec![Inline::Str(Str {
+        text: text.into(),
+        source_info: SourceInfo::generated(By::programmatic_config()),
+    })]
 }
 
 /// A single entry in the TOC.
@@ -224,9 +239,15 @@ impl TocEntry {
 /// Complete TOC structure stored at `navigation.toc` in document metadata.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct NavigationToc {
-    /// Title for the TOC (e.g., "Table of Contents")
+    /// Title for the TOC (e.g. "Table of Contents"), as inlines.
+    ///
+    /// Inlines rather than a `String` for the same reason as
+    /// [`TocEntry::title`]: Quarto 1 renders `toc-title` through Pandoc,
+    /// so `toc-title: "On **this** page"` produces markup, and flattening
+    /// it here would silently discard what the metadata layer already
+    /// parsed (bd-toc-smart-quotes-6nro57ed).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub title: Option<String>,
+    pub title: Option<Inlines>,
 
     /// Root entries (top-level headings)
     pub entries: Vec<TocEntry>,
@@ -242,7 +263,7 @@ impl NavigationToc {
             entries.push(ConfigMapEntry {
                 key: "title".to_string(),
                 key_source: source_info.clone(),
-                value: ConfigValue::new_string(title, source_info.clone()),
+                value: ConfigValue::new_inlines(title.clone(), source_info.clone()),
             });
         }
 
@@ -259,7 +280,9 @@ impl NavigationToc {
 
     /// Create a NavigationToc from a ConfigValue.
     pub fn from_config_value(cv: &ConfigValue) -> Option<Self> {
-        let title = cv.get("title").and_then(|v| v.as_str().map(String::from));
+        // `as_str()` would return `None` for the `PandocInlines` a
+        // front-matter `toc-title` produces — the `metadata-as-str` trap.
+        let title = cv.get("title").and_then(config_value_to_inlines);
 
         let entries = if let Some(entries_cv) = cv.get("entries") {
             if let Some(arr) = entries_cv.as_array() {
@@ -725,11 +748,11 @@ mod tests {
 
         let config = TocConfig {
             depth: 3,
-            title: Some("Contents".to_string()),
+            title: Some(plain("Contents")),
         };
         let toc = generate_toc(&blocks, &config);
 
-        assert_eq!(toc.title, Some("Contents".to_string()));
+        assert_eq!(toc.title, Some(plain("Contents")));
         assert_eq!(toc.entries.len(), 1);
     }
 
@@ -792,7 +815,7 @@ mod tests {
     #[test]
     fn test_navigation_toc_to_config_value() {
         let toc = NavigationToc {
-            title: Some("Table of Contents".to_string()),
+            title: Some(plain("Table of Contents")),
             entries: vec![TocEntry {
                 id: "intro".to_string(),
                 title: plain("Introduction"),
@@ -804,7 +827,11 @@ mod tests {
 
         let cv = toc.to_config_value();
 
-        assert_eq!(cv.get("title").unwrap().as_str(), Some("Table of Contents"));
+        // `PandocInlines`, not a scalar — `as_str()` returns `None`.
+        assert_eq!(
+            cv.get("title").map(|v| &v.value),
+            Some(&ConfigValueKind::PandocInlines(plain("Table of Contents")))
+        );
         let entries = cv.get("entries").unwrap().as_array().unwrap();
         assert_eq!(entries.len(), 1);
     }
@@ -812,7 +839,7 @@ mod tests {
     #[test]
     fn test_navigation_toc_roundtrip() {
         let original = NavigationToc {
-            title: Some("Contents".to_string()),
+            title: Some(plain("Contents")),
             entries: vec![
                 TocEntry {
                     id: "a".to_string(),

--- a/crates/pampa/src/toc.rs
+++ b/crates/pampa/src/toc.rs
@@ -44,8 +44,8 @@
 //! The function detects sectionized structure and extracts headers accordingly.
 
 use crate::pandoc::block::{Block, Div, Header};
-use crate::pandoc::inline::Inline;
-use quarto_pandoc_types::config_value::{ConfigMapEntry, ConfigValue};
+use crate::pandoc::inline::{Inline, Inlines, Str};
+use quarto_pandoc_types::config_value::{ConfigMapEntry, ConfigValue, ConfigValueKind};
 use quarto_source_map::{By, SourceInfo};
 use serde::{Deserialize, Serialize};
 use yaml_rust2::Yaml;
@@ -69,6 +69,35 @@ impl Default for TocConfig {
     }
 }
 
+/// Read a metadata value as inlines, accepting either shape the
+/// interpretation layer can hand us.
+///
+/// `InterpretationContext` resolves an untagged YAML string at *load*
+/// time, and the two sources have opposite defaults
+/// (`quarto_pandoc_types::config_value::InterpretationContext`):
+///
+/// - document front matter parses markdown, giving `PandocInlines` —
+///   used as-is;
+/// - `_quarto.yml` keeps strings literal, giving `Scalar(String)` —
+///   wrapped in a single `Str`, deliberately *not* re-parsed. Project
+///   config is literal by design; the sanctioned way to opt a key into
+///   markdown there is `config_markdown.rs`'s `MARKDOWN_CONFIG_PATHS`
+///   registry, not an ad-hoc parse here.
+///
+/// Programmatically-constructed values (Lua filters, tests) also arrive
+/// as `Scalar(String)` and get the same literal treatment.
+fn config_value_to_inlines(cv: &ConfigValue) -> Option<Inlines> {
+    if let ConfigValueKind::PandocInlines(inlines) = &cv.value {
+        return Some(inlines.clone());
+    }
+    // Any other scalar shape: take its plain text and wrap it literally.
+    let text = cv.as_plain_text()?;
+    Some(vec![Inline::Str(Str {
+        text,
+        source_info: cv.source_info.clone(),
+    })])
+}
+
 /// A single entry in the TOC.
 ///
 /// Represents a heading in the document with its metadata for TOC rendering.
@@ -77,8 +106,24 @@ pub struct TocEntry {
     /// Section ID for linking (e.g., "introduction")
     pub id: String,
 
-    /// Heading text (plain text, not inlines)
-    pub title: String,
+    /// Heading content, as inlines.
+    ///
+    /// Carries the heading's inline markup verbatim — emphasis, code,
+    /// math, quoted spans and their delimiters. This is deliberately
+    /// *not* flattened to a `String`: Quarto 1 renders `<code>`, `<em>`
+    /// and math spans inside TOC entries, and flattening also silently
+    /// dropped `Quoted` delimiters, so a TOC label disagreed with the
+    /// heading it pointed at (bd-toc-smart-quotes-6nro57ed).
+    ///
+    /// Consumers that cannot render markup are responsible for
+    /// projecting it themselves. Renderers with structural constraints
+    /// are likewise responsible for their own filtering — the HTML TOC
+    /// strips links and notes at render time (`toc_render`), because
+    /// "an anchor may not nest" is a fact about that output, not about
+    /// the document's heading structure. This field is also
+    /// `DocumentProfile::outline`, which is meant to be a faithful
+    /// semantic outline.
+    pub title: Inlines,
 
     /// Heading level (1-6)
     pub level: i32,
@@ -105,7 +150,7 @@ impl TocEntry {
             ConfigMapEntry {
                 key: "title".to_string(),
                 key_source: source_info.clone(),
-                value: ConfigValue::new_string(&self.title, source_info.clone()),
+                value: ConfigValue::new_inlines(self.title.clone(), source_info.clone()),
             },
             ConfigMapEntry {
                 key: "level".to_string(),
@@ -139,11 +184,14 @@ impl TocEntry {
     }
 
     /// Create a TocEntry from a ConfigValue.
+    ///
+    /// The `title` accepts either shape the metadata layer can produce —
+    /// see [`config_value_to_inlines`].
     pub fn from_config_value(cv: &ConfigValue) -> Option<Self> {
         // Use as_plain_text() to handle both scalar strings and PandocInlines
         // (YAML values like `id: "tldr"` may be parsed as MetaInlines in document frontmatter)
         let id = cv.get("id")?.as_plain_text()?;
-        let title = cv.get("title")?.as_plain_text()?;
+        let title = config_value_to_inlines(cv.get("title")?)?;
         // Accept both integer and string-encoded integer for level
         // (YAML parsing may convert integers to strings in some contexts)
         let level_cv = cv.get("level")?;
@@ -261,7 +309,7 @@ pub fn generate_toc(blocks: &[Block], config: &TocConfig) -> NavigationToc {
 /// Internal representation during collection
 struct FlatTocEntry {
     id: String,
-    title: String,
+    title: Inlines,
     level: i32,
     number: Option<String>,
 }
@@ -354,8 +402,9 @@ fn extract_entry_from_section(div: &Div, max_depth: i32) -> Option<FlatTocEntry>
         }
     })?;
 
-    // Extract title text from header
-    let title = inlines_to_text(&header.content);
+    // Carry the heading's inlines verbatim; markup is preserved and
+    // format-specific filtering happens at render time.
+    let title = header.content.clone();
 
     // Check for unnumbered class (on header or section)
     let is_numbered = !classes.iter().any(|c| c == "unnumbered")
@@ -390,8 +439,8 @@ fn extract_entry_from_header(header: &Header, max_depth: i32) -> Option<FlatTocE
         return None;
     }
 
-    // Extract title text
-    let title = inlines_to_text(&header.content);
+    // Carry the heading's inlines verbatim (see above).
+    let title = header.content.clone();
 
     // Check for unnumbered class
     let is_numbered = !classes.iter().any(|c| c == "unnumbered");
@@ -403,43 +452,6 @@ fn extract_entry_from_header(header: &Header, max_depth: i32) -> Option<FlatTocE
         // TODO: Implement actual section numbering
         number: if is_numbered { None } else { None },
     })
-}
-
-/// Convert inlines to plain text for TOC title.
-fn inlines_to_text(inlines: &[Inline]) -> String {
-    let mut text = String::new();
-    for inline in inlines {
-        match inline {
-            Inline::Str(s) => text.push_str(&s.text),
-            Inline::Space(_) => text.push(' '),
-            Inline::SoftBreak(_) | Inline::LineBreak(_) => text.push(' '),
-            Inline::Code(c) => text.push_str(&c.text),
-            Inline::Emph(e) => text.push_str(&inlines_to_text(&e.content)),
-            Inline::Underline(u) => text.push_str(&inlines_to_text(&u.content)),
-            Inline::Strong(s) => text.push_str(&inlines_to_text(&s.content)),
-            Inline::Strikeout(s) => text.push_str(&inlines_to_text(&s.content)),
-            Inline::Superscript(s) => text.push_str(&inlines_to_text(&s.content)),
-            Inline::Subscript(s) => text.push_str(&inlines_to_text(&s.content)),
-            Inline::SmallCaps(s) => text.push_str(&inlines_to_text(&s.content)),
-            Inline::Quoted(q) => text.push_str(&inlines_to_text(&q.content)),
-            Inline::Cite(c) => text.push_str(&inlines_to_text(&c.content)),
-            Inline::Link(l) => text.push_str(&inlines_to_text(&l.content)),
-            Inline::Image(i) => text.push_str(&inlines_to_text(&i.content)),
-            Inline::Note(_) => {}          // Skip footnotes in TOC
-            Inline::NoteReference(_) => {} // Skip note references
-            Inline::Span(s) => text.push_str(&inlines_to_text(&s.content)),
-            Inline::Math(m) => text.push_str(&m.text),
-            Inline::RawInline(_) => {} // Skip raw content
-            Inline::Shortcode(_) => {} // Skip shortcodes
-            Inline::Attr(_) => {}      // Skip attribute nodes
-            Inline::Insert(i) => text.push_str(&inlines_to_text(&i.content)),
-            Inline::Delete(_) => {} // Skip deleted content
-            Inline::Highlight(h) => text.push_str(&inlines_to_text(&h.content)),
-            Inline::EditComment(_) => {} // Skip edit comments
-            Inline::Custom(_) => {}      // Skip custom nodes
-        }
-    }
-    text
 }
 
 /// Build hierarchical structure from flat entries based on levels.
@@ -499,6 +511,15 @@ mod tests {
 
     fn dummy_source_info() -> SourceInfo {
         SourceInfo::for_test()
+    }
+
+    /// A title made of one literal `Str`, for the many tests that only
+    /// care about the surrounding structure rather than the markup.
+    fn plain(text: &str) -> Inlines {
+        vec![Inline::Str(Str {
+            text: text.to_string(),
+            source_info: dummy_source_info(),
+        })]
     }
 
     fn make_header(level: usize, id: &str, classes: Vec<&str>, text: &str) -> Block {
@@ -587,7 +608,7 @@ mod tests {
 
         assert_eq!(toc.entries.len(), 3);
         assert_eq!(toc.entries[0].id, "intro");
-        assert_eq!(toc.entries[0].title, "Introduction");
+        assert_eq!(toc.entries[0].title, plain("Introduction"));
         assert_eq!(toc.entries[0].level, 2);
         assert_eq!(toc.entries[1].id, "methods");
         assert_eq!(toc.entries[2].id, "results");
@@ -633,7 +654,7 @@ mod tests {
 
         assert_eq!(toc.entries.len(), 2);
         assert_eq!(toc.entries[0].id, "intro");
-        assert_eq!(toc.entries[0].title, "Introduction");
+        assert_eq!(toc.entries[0].title, plain("Introduction"));
         assert_eq!(toc.entries[1].id, "methods");
     }
 
@@ -716,12 +737,12 @@ mod tests {
     fn test_toc_entry_to_config_value() {
         let entry = TocEntry {
             id: "intro".to_string(),
-            title: "Introduction".to_string(),
+            title: plain("Introduction"),
             level: 2,
             number: Some("1.1".to_string()),
             children: vec![TocEntry {
                 id: "sub".to_string(),
-                title: "Subsection".to_string(),
+                title: plain("Subsection"),
                 level: 3,
                 number: None,
                 children: vec![],
@@ -731,7 +752,13 @@ mod tests {
         let cv = entry.to_config_value();
 
         assert_eq!(cv.get("id").unwrap().as_str(), Some("intro"));
-        assert_eq!(cv.get("title").unwrap().as_str(), Some("Introduction"));
+        // The title is `PandocInlines`, not a scalar — `as_str()` returns
+        // `None` for it (the `metadata-as-str` lint's whole point), so
+        // assert on the inline content itself.
+        assert_eq!(
+            cv.get("title").map(|v| &v.value),
+            Some(&ConfigValueKind::PandocInlines(plain("Introduction")))
+        );
         assert_eq!(cv.get("level").unwrap().as_int(), Some(2));
         assert_eq!(cv.get("number").unwrap().as_str(), Some("1.1"));
 
@@ -744,12 +771,12 @@ mod tests {
     fn test_toc_entry_roundtrip() {
         let original = TocEntry {
             id: "test".to_string(),
-            title: "Test Section".to_string(),
+            title: plain("Test Section"),
             level: 2,
             number: Some("1".to_string()),
             children: vec![TocEntry {
                 id: "nested".to_string(),
-                title: "Nested".to_string(),
+                title: plain("Nested"),
                 level: 3,
                 number: None,
                 children: vec![],
@@ -768,7 +795,7 @@ mod tests {
             title: Some("Table of Contents".to_string()),
             entries: vec![TocEntry {
                 id: "intro".to_string(),
-                title: "Introduction".to_string(),
+                title: plain("Introduction"),
                 level: 1,
                 number: None,
                 children: vec![],
@@ -789,14 +816,14 @@ mod tests {
             entries: vec![
                 TocEntry {
                     id: "a".to_string(),
-                    title: "Section A".to_string(),
+                    title: plain("Section A"),
                     level: 1,
                     number: None,
                     children: vec![],
                 },
                 TocEntry {
                     id: "b".to_string(),
-                    title: "Section B".to_string(),
+                    title: plain("Section B"),
                     level: 1,
                     number: None,
                     children: vec![],
@@ -810,48 +837,177 @@ mod tests {
         assert_eq!(original, restored);
     }
 
+    // -----------------------------------------------------------------
+    // title-as-inlines (bd-toc-smart-quotes-6nro57ed)
+    // -----------------------------------------------------------------
+
+    /// `to_config_value` must emit the title as `PandocInlines`, and
+    /// `from_config_value` must read it back unchanged. This is the
+    /// round-trip `navigation.toc` metadata depends on: the entries are
+    /// serialized into metadata by `TocGenerateTransform` and parsed
+    /// back out by `TocRenderTransform`.
     #[test]
-    fn test_inlines_to_text_simple() {
-        let inlines = vec![Inline::Str(Str {
-            text: "Hello World".to_string(),
-            source_info: dummy_source_info(),
-        })];
+    fn test_toc_entry_config_value_round_trip_preserves_inlines() {
+        use crate::pandoc::inline::{Code, QuoteType, Quoted};
 
-        assert_eq!(inlines_to_text(&inlines), "Hello World");
-    }
-
-    #[test]
-    fn test_inlines_to_text_with_formatting() {
-        use crate::pandoc::inline::{Emph, Space, Strong};
-
-        let inlines = vec![
+        let title = vec![
             Inline::Str(Str {
-                text: "Hello".to_string(),
+                text: "Using a ".to_string(),
                 source_info: dummy_source_info(),
             }),
-            Inline::Space(Space {
-                source_info: dummy_source_info(),
-            }),
-            Inline::Strong(Strong {
+            Inline::Quoted(Quoted {
+                quote_type: QuoteType::DoubleQuote,
                 content: vec![Inline::Str(Str {
-                    text: "bold".to_string(),
+                    text: "raw".to_string(),
                     source_info: dummy_source_info(),
                 })],
                 source_info: dummy_source_info(),
             }),
-            Inline::Space(Space {
+            Inline::Code(Code {
+                text: "volume".to_string(),
+                attr: (String::new(), vec![], LinkedHashMap::new()),
+                source_info: dummy_source_info(),
+                attr_source: AttrSourceInfo::empty(),
+            }),
+        ];
+
+        let original = TocEntry {
+            id: "using-a-raw-volume".to_string(),
+            title: title.clone(),
+            level: 2,
+            number: None,
+            children: vec![],
+        };
+
+        let restored = TocEntry::from_config_value(&original.to_config_value()).unwrap();
+
+        assert_eq!(
+            restored.title, title,
+            "the quoted span and the code span must survive the metadata round-trip"
+        );
+        assert_eq!(restored.id, original.id);
+        assert_eq!(restored.level, original.level);
+    }
+
+    /// A hand-written `navigation.toc` from `_quarto.yml` arrives as
+    /// `Scalar(String)` because `InterpretationContext::ProjectConfig`
+    /// keeps strings literal. It must still parse, wrapped in a single
+    /// `Str` — and deliberately *not* re-parsed as markdown.
+    #[test]
+    fn test_toc_entry_accepts_scalar_string_title_literally() {
+        let cv = ConfigValue::new_map(
+            vec![
+                ConfigMapEntry {
+                    key: "id".to_string(),
+                    key_source: dummy_source_info(),
+                    value: ConfigValue::new_string("sec", dummy_source_info()),
+                },
+                ConfigMapEntry {
+                    key: "title".to_string(),
+                    key_source: dummy_source_info(),
+                    value: ConfigValue::new_string("A **literal** title", dummy_source_info()),
+                },
+                ConfigMapEntry {
+                    key: "level".to_string(),
+                    key_source: dummy_source_info(),
+                    value: ConfigValue::new_scalar(Yaml::Integer(2), dummy_source_info()),
+                },
+            ],
+            dummy_source_info(),
+        );
+
+        let entry = TocEntry::from_config_value(&cv).expect("legacy string title must parse");
+
+        assert_eq!(
+            entry.title,
+            vec![Inline::Str(Str {
+                text: "A **literal** title".to_string(),
+                source_info: dummy_source_info(),
+            })],
+            "a project-config string is literal: one Str, asterisks intact, no Strong"
+        );
+    }
+
+    /// A front-matter title arrives already parsed as `PandocInlines`;
+    /// it must be used as-is rather than flattened.
+    #[test]
+    fn test_toc_entry_accepts_pandoc_inlines_title() {
+        use crate::pandoc::inline::Strong;
+
+        let inlines = vec![Inline::Strong(Strong {
+            content: vec![Inline::Str(Str {
+                text: "bold".to_string(),
+                source_info: dummy_source_info(),
+            })],
+            source_info: dummy_source_info(),
+        })];
+
+        let cv = ConfigValue::new_map(
+            vec![
+                ConfigMapEntry {
+                    key: "id".to_string(),
+                    key_source: dummy_source_info(),
+                    value: ConfigValue::new_string("sec", dummy_source_info()),
+                },
+                ConfigMapEntry {
+                    key: "title".to_string(),
+                    key_source: dummy_source_info(),
+                    value: ConfigValue::new_inlines(inlines.clone(), dummy_source_info()),
+                },
+                ConfigMapEntry {
+                    key: "level".to_string(),
+                    key_source: dummy_source_info(),
+                    value: ConfigValue::new_scalar(Yaml::Integer(2), dummy_source_info()),
+                },
+            ],
+            dummy_source_info(),
+        );
+
+        let entry = TocEntry::from_config_value(&cv).unwrap();
+        assert_eq!(entry.title, inlines);
+    }
+
+    /// `generate_toc` must hand the heading's inlines through untouched
+    /// — including the `Quoted` node whose delimiters the old flattener
+    /// silently dropped.
+    #[test]
+    fn test_generate_toc_carries_heading_inlines() {
+        use crate::pandoc::inline::{QuoteType, Quoted};
+
+        let header_content = vec![
+            Inline::Str(Str {
+                text: "Using a ".to_string(),
                 source_info: dummy_source_info(),
             }),
-            Inline::Emph(Emph {
+            Inline::Quoted(Quoted {
+                quote_type: QuoteType::DoubleQuote,
                 content: vec![Inline::Str(Str {
-                    text: "italic".to_string(),
+                    text: "raw".to_string(),
                     source_info: dummy_source_info(),
                 })],
                 source_info: dummy_source_info(),
             }),
         ];
 
-        assert_eq!(inlines_to_text(&inlines), "Hello bold italic");
+        let blocks = vec![Block::Header(Header {
+            level: 2,
+            attr: (
+                "using-a-raw-volume".to_string(),
+                vec![],
+                LinkedHashMap::new(),
+            ),
+            content: header_content.clone(),
+            source_info: dummy_source_info(),
+            attr_source: AttrSourceInfo::empty(),
+        })];
+
+        let toc = generate_toc(&blocks, &TocConfig::default());
+
+        assert_eq!(toc.entries.len(), 1);
+        assert_eq!(
+            toc.entries[0].title, header_content,
+            "the TOC entry must carry the heading's inlines verbatim"
+        );
     }
 
     #[test]

--- a/crates/quarto-core/src/document_profile.rs
+++ b/crates/quarto-core/src/document_profile.rs
@@ -1046,6 +1046,14 @@ mod tests {
         ast
     }
 
+    /// Project a TOC entry title to plain text for assertions. The
+    /// profile's outline carries inlines (bd-toc-smart-quotes-6nro57ed);
+    /// consumers that want text project it themselves, and the
+    /// plain-text writer is the shared way to do that.
+    fn title_text(title: &quarto_pandoc_types::Inlines) -> String {
+        pampa::writers::plaintext::inlines_to_string(title).0
+    }
+
     fn entry_ids(entries: &[TocEntry]) -> Vec<&str> {
         entries.iter().map(|e| e.id.as_str()).collect()
     }
@@ -1098,11 +1106,11 @@ Deep text.
         assert_eq!(profile.outline.len(), 2, "two top-level headings");
         let first = &profile.outline[0];
         assert_eq!(first.level, 1);
-        assert_eq!(first.title, "Top");
+        assert_eq!(title_text(&first.title), "Top");
         assert_eq!(entry_ids(&first.children), vec!["sub"]);
         assert_eq!(first.children[0].level, 2);
         assert_eq!(entry_ids(&first.children[0].children), vec!["deep"]);
-        assert_eq!(profile.outline[1].title, "Top two");
+        assert_eq!(title_text(&profile.outline[1].title), "Top two");
         assert!(
             all_unnumbered(&profile.outline),
             "profile outline must be un-numbered"

--- a/crates/quarto-core/src/document_profile.rs
+++ b/crates/quarto-core/src/document_profile.rs
@@ -92,7 +92,18 @@ use thiserror::Error;
 ///   which is also the only place a diagnostic survives profile
 ///   caching (see `rejected_resources` for the same lesson learned
 ///   the hard way).
-pub const DOCUMENT_PROFILE_VERSION: u32 = 10;
+/// - `11`: `bd-toc-smart-quotes-6nro57ed`. Changes `outline`'s entry
+///   titles from `String` to `Inlines` (`TocEntry::title`). The
+///   outline now carries the heading's inline markup — emphasis,
+///   code, math, and the quoted-span delimiters a flattened title
+///   silently dropped — so it is a faithful semantic outline rather
+///   than a lossy projection. **Serialized shape changes**: a title
+///   that was `"Top"` is now an array of inline nodes, so v10
+///   profiles fail to deserialize at the field level and cached
+///   profiles must be regenerated. Consumers wanting plain text
+///   project it themselves with
+///   `pampa::writers::plaintext::inlines_to_string`.
+pub const DOCUMENT_PROFILE_VERSION: u32 = 11;
 
 /// Depth used when extracting the heading outline at the profile
 /// checkpoint.
@@ -1798,8 +1809,8 @@ Body.
     }
 
     #[test]
-    fn document_profile_version_is_10() {
-        assert_eq!(DOCUMENT_PROFILE_VERSION, 10);
+    fn document_profile_version_is_11() {
+        assert_eq!(DOCUMENT_PROFILE_VERSION, 11);
     }
 
     /// A v3 profile (the pre-listings shape) must be rejected by

--- a/crates/quarto-core/src/template.rs
+++ b/crates/quarto-core/src/template.rs
@@ -149,7 +149,9 @@ $endfor$
 /// - `$page-layout$` - page layout type (article, full, etc.)
 /// - `$version$` - Quarto version for generator meta tag
 /// - `$rendered.navigation.toc$` - Rendered TOC HTML (if toc: true)
-/// - `$navigation.toc.title$` - TOC title (if set)
+/// - `$rendered.navigation.toc-title$` - TOC title, rendered to HTML
+///   (if set). Pre-rendered rather than read from `navigation.toc.title`
+///   because the title carries inline markup — see `toc_render`.
 /// - `$rendered.navigation.navbar$` - Rendered navbar HTML (if navbar: set)
 /// - `$rendered.navigation.sidebar$` - Rendered sidebar HTML (if website.sidebar: set)
 /// - `$rendered.navigation.page_navigation$` - Rendered prev/next page-nav strip
@@ -212,8 +214,8 @@ $endif$
 $if(rendered.navigation.toc)$
 <div id="quarto-margin-sidebar" class="sidebar margin-sidebar">
 <nav id="TOC" role="doc-toc" class="toc-active">
-$if(navigation.toc.title)$
-<h2 id="toc-title">$navigation.toc.title$</h2>
+$if(rendered.navigation.toc-title)$
+<h2 id="toc-title">$rendered.navigation.toc-title$</h2>
 $endif$
 $rendered.navigation.toc$
 </nav>

--- a/crates/quarto-core/src/transforms/config_markdown.rs
+++ b/crates/quarto-core/src/transforms/config_markdown.rs
@@ -50,6 +50,28 @@
 //! `MetadataNormalizeTransform` / `WebsiteTitlePrefixTransform`
 //! (which flatten the resolved values into `pagetitle`).
 //!
+//! ## See also: the *other* key-path table, and when to pick which
+//!
+//! The sibling registry is `ANNOTATIONS` in
+//! `crates/pampa/src/pandoc/meta_annotations.rs`. Extending the wrong
+//! one is a mistake that has already been made (bd-qzn1azon):
+//!
+//! | | [`MARKDOWN_CONFIG_PATHS`] (this table) | `ANNOTATIONS` |
+//! |---|---|---|
+//! | when | **transform time**, over merged metadata | **load time**, per untagged scalar |
+//! | for | website *presentation* strings that **are** markdown | values that are **not** markdown — globs, paths |
+//! | effect | re-parses `Scalar(String)` as qmd | picks a non-markdown `Interpretation` |
+//! | honours `!str` | no — the tag is gone by then (see the limitation above, bd-d7ljiz9q) | yes — explicit tags win |
+//!
+//! Rule of thumb: **adding markdown semantics to a presentation key
+//! goes here; protecting a machine-facing key from markdown goes in
+//! `ANNOTATIONS`.** Load-time parsing was considered and rejected for
+//! this class — see
+//! `claude-notes/plans/2026-08-10-shortcodes-website-config-includes.md`.
+//!
+//! Both tables are documented as temporary, pending schema-driven
+//! interpretation.
+//!
 //! [`ShortcodeResolveTransform`]: crate::transforms::ShortcodeResolveTransform
 
 use quarto_analysis::AnalysisContext;
@@ -119,6 +141,14 @@ const MARKDOWN_CONFIG_PATHS: &[&[&str]] = &[
     &["page-footer", "left", "*"],
     &["page-footer", "center", "*"],
     &["page-footer", "right", "*"],
+    // The table-of-contents heading (bd-toc-smart-quotes-6nro57ed).
+    // Presentation text like the titles above, and Quarto 1 renders it
+    // through Pandoc. Without this, `toc-title: "On **this** page"`
+    // renders markup from front matter but shows literal asterisks from
+    // `_quarto.yml` — the same YAML behaving two ways. Unlike the
+    // sidebar's `section:` (bd-xygsu15r), no id is derived from it: the
+    // `<h2 id="toc-title">` id is a literal constant.
+    &["toc-title"],
 ];
 
 /// AST transform: apply [`MARKDOWN_CONFIG_PATHS`] to merged metadata.

--- a/crates/quarto-core/src/transforms/toc_generate.rs
+++ b/crates/quarto-core/src/transforms/toc_generate.rs
@@ -36,7 +36,7 @@
 //!         children: [...]
 //! ```
 
-use pampa::toc::{TocConfig, generate_toc};
+use pampa::toc::{TocConfig, config_value_to_inlines, generate_toc, plain_inlines};
 use quarto_pandoc_types::pandoc::Pandoc;
 
 use crate::Result;
@@ -121,17 +121,29 @@ impl AstTransform for TocGenerateTransform {
         // Title precedence (decided 2026-07-17, bd-llhlzd7p): user
         // `toc-title` metadata > localized `toc-title-document` term >
         // English literal (stage-less unit-test fallback).
-        // `as_plain_text` (not `as_str`): a bare `toc-title` front-matter string
-        // is stored as `ConfigValueKind::PandocInlines`. (bd-y89ihf0i)
+        //
+        // The user-supplied value is read as **inlines**, not text
+        // (bd-toc-smart-quotes-6nro57ed). A front-matter `toc-title` is
+        // already `ConfigValueKind::PandocInlines`, so `as_plain_text()`
+        // — the previous read, itself a fix for the `as_str()` trap in
+        // bd-y89ihf0i — was discarding markup the metadata layer had
+        // just parsed. A `_quarto.yml` `toc-title` arrives as
+        // `Scalar(String)` and gets markdown semantics from
+        // `MARKDOWN_CONFIG_PATHS` upstream, so by here both sources
+        // agree.
+        //
+        // The two fallbacks are genuinely plain text — a localized term
+        // from the language catalog, and an English literal — so they
+        // are wrapped in a single `Str`.
         let title = ast
             .meta
             .get("toc-title")
-            .and_then(|v| v.as_plain_text())
+            .and_then(config_value_to_inlines)
             .or_else(|| {
                 crate::language::LanguageTerms::from_meta(&ast.meta)
-                    .and_then(|t| t.get("toc-title-document").map(|s| s.to_string()))
+                    .and_then(|t| t.get("toc-title-document").map(plain_inlines))
             })
-            .or_else(|| Some("Table of Contents".to_string()));
+            .or_else(|| Some(plain_inlines("Table of Contents")));
 
         let config = TocConfig { depth, title };
 
@@ -441,7 +453,12 @@ mod tests {
         transform.transform(&mut ast, &mut ctx).await.unwrap();
 
         let toc = ast.meta.get_path(&["navigation", "toc"]).unwrap();
-        assert_eq!(toc.get("title").unwrap().as_str(), Some("Contents"));
+        // The title is `PandocInlines` now, so `as_str()` returns
+        // `None` — project it instead (bd-toc-smart-quotes-6nro57ed).
+        assert_eq!(
+            toc.get("title").unwrap().as_plain_text().as_deref(),
+            Some("Contents")
+        );
     }
 
     #[tokio::test]
@@ -491,8 +508,62 @@ mod tests {
 
         let toc = ast.meta.get_path(&["navigation", "toc"]).unwrap();
         assert_eq!(
-            toc.get("title").unwrap().as_str(),
+            toc.get("title").unwrap().as_plain_text().as_deref(),
             Some("Table of Contents")
+        );
+    }
+
+    /// A `toc-title` carrying markup keeps it: the front-matter value is
+    /// already `PandocInlines`, and the transform must not flatten it
+    /// (bd-toc-smart-quotes-6nro57ed).
+    #[tokio::test]
+    async fn test_toc_title_keeps_inline_markup() {
+        use quarto_pandoc_types::inline::Strong;
+
+        let styled = ConfigValue::new_inlines(
+            vec![
+                Inline::Str(Str {
+                    text: "On ".to_string(),
+                    source_info: dummy_source_info(),
+                }),
+                Inline::Strong(Strong {
+                    content: vec![Inline::Str(Str {
+                        text: "this".to_string(),
+                        source_info: dummy_source_info(),
+                    })],
+                    source_info: dummy_source_info(),
+                }),
+            ],
+            dummy_source_info(),
+        );
+
+        let mut ast = Pandoc {
+            meta: config_map(vec![("toc", config_bool(true)), ("toc-title", styled)]),
+            blocks: vec![
+                make_header(2, "intro", "Introduction"),
+                make_para("Content."),
+            ],
+        };
+
+        let project = make_test_project();
+        let doc = DocumentInfo::from_path("/project/doc.qmd");
+        let format = Format::html();
+        let binaries = BinaryDependencies::new();
+        let mut ctx = RenderContext::new(&project, &doc, &format, &binaries);
+
+        TocGenerateTransform::new()
+            .transform(&mut ast, &mut ctx)
+            .await
+            .unwrap();
+
+        let title = ast
+            .meta
+            .get_path(&["navigation", "toc", "title"])
+            .expect("toc title");
+        let inlines = pampa::toc::config_value_to_inlines(title).expect("inlines");
+        assert!(
+            inlines.iter().any(|i| matches!(i, Inline::Strong(_))),
+            "the Strong node must survive; got {inlines:?}"
         );
     }
 }

--- a/crates/quarto-core/src/transforms/toc_render.rs
+++ b/crates/quarto-core/src/transforms/toc_render.rs
@@ -43,6 +43,10 @@
 
 use pampa::toc::{NavigationToc, TocEntry};
 use quarto_pandoc_types::config_value::ConfigValue;
+use quarto_pandoc_types::inline::{
+    Cite, Delete, EditComment, Emph, Highlight, Inline, Inlines, Insert, Quoted, SmallCaps, Span,
+    Strikeout, Strong, Subscript, Superscript, Underline,
+};
 use quarto_pandoc_types::pandoc::Pandoc;
 use quarto_source_map::{By, SourceInfo};
 
@@ -120,6 +124,130 @@ impl AstTransform for TocRenderTransform {
     }
 }
 
+/// Strip the inlines a TOC entry label cannot carry, mirroring Pandoc's
+/// `deLink` / `deNote`.
+///
+/// Two kinds have to go:
+///
+/// - **`Link`** — the entry *is* an `<a>`, and anchors may not nest.
+///   Pandoc unwraps the link to its content, so the link's text still
+///   reads in the TOC; Quarto 1 does the same (`## … and a [link](…)`
+///   yields `… and a link`).
+/// - **`Note` / `NoteReference`** — a footnote marker in a TOC entry is
+///   noise, and rendering the note body there would duplicate it.
+///
+/// Everything else renders. This filtering deliberately lives at *render*
+/// time rather than in `generate_toc`: `TocEntry` is also
+/// `DocumentProfile::outline`, a faithful semantic outline, and "an
+/// anchor may not nest" is a constraint of this HTML output, not a fact
+/// about the document's headings.
+///
+/// The match is exhaustive on purpose — a new `Inline` variant should
+/// force a decision here rather than silently fall through a `_` arm,
+/// which is how the flattener this replaced accumulated its bugs.
+fn strip_links_and_notes(inlines: &[Inline]) -> Inlines {
+    let mut out = Inlines::new();
+    for inline in inlines {
+        match inline {
+            // Unwrap: keep the text, drop the anchor.
+            Inline::Link(l) => out.extend(strip_links_and_notes(&l.content)),
+
+            // Drop entirely.
+            Inline::Note(_) | Inline::NoteReference(_) => {}
+
+            // Recurse into containers, preserving the wrapper.
+            Inline::Emph(e) => out.push(Inline::Emph(Emph {
+                content: strip_links_and_notes(&e.content),
+                ..e.clone()
+            })),
+            Inline::Underline(u) => out.push(Inline::Underline(Underline {
+                content: strip_links_and_notes(&u.content),
+                ..u.clone()
+            })),
+            Inline::Strong(s) => out.push(Inline::Strong(Strong {
+                content: strip_links_and_notes(&s.content),
+                ..s.clone()
+            })),
+            Inline::Strikeout(s) => out.push(Inline::Strikeout(Strikeout {
+                content: strip_links_and_notes(&s.content),
+                ..s.clone()
+            })),
+            Inline::Superscript(s) => out.push(Inline::Superscript(Superscript {
+                content: strip_links_and_notes(&s.content),
+                ..s.clone()
+            })),
+            Inline::Subscript(s) => out.push(Inline::Subscript(Subscript {
+                content: strip_links_and_notes(&s.content),
+                ..s.clone()
+            })),
+            Inline::SmallCaps(s) => out.push(Inline::SmallCaps(SmallCaps {
+                content: strip_links_and_notes(&s.content),
+                ..s.clone()
+            })),
+            Inline::Quoted(q) => out.push(Inline::Quoted(Quoted {
+                content: strip_links_and_notes(&q.content),
+                ..q.clone()
+            })),
+            Inline::Cite(c) => out.push(Inline::Cite(Cite {
+                content: strip_links_and_notes(&c.content),
+                ..c.clone()
+            })),
+            Inline::Span(s) => out.push(Inline::Span(Span {
+                content: strip_links_and_notes(&s.content),
+                ..s.clone()
+            })),
+            Inline::Insert(i) => out.push(Inline::Insert(Insert {
+                content: strip_links_and_notes(&i.content),
+                ..i.clone()
+            })),
+            Inline::Delete(d) => out.push(Inline::Delete(Delete {
+                content: strip_links_and_notes(&d.content),
+                ..d.clone()
+            })),
+            Inline::Highlight(h) => out.push(Inline::Highlight(Highlight {
+                content: strip_links_and_notes(&h.content),
+                ..h.clone()
+            })),
+            Inline::EditComment(e) => out.push(Inline::EditComment(EditComment {
+                content: strip_links_and_notes(&e.content),
+                ..e.clone()
+            })),
+            // An Image's `content` is alt text, not rendered children —
+            // leave the node intact so the writer emits the `<img>`.
+            Inline::Image(_)
+            // Leaves.
+            | Inline::Str(_)
+            | Inline::Space(_)
+            | Inline::SoftBreak(_)
+            | Inline::LineBreak(_)
+            | Inline::Code(_)
+            | Inline::Math(_)
+            | Inline::RawInline(_)
+            | Inline::Shortcode(_)
+            | Inline::Attr(_)
+            | Inline::Custom(_) => out.push(inline.clone()),
+        }
+    }
+    out
+}
+
+/// Render a TOC entry label to HTML through the real inline writer, so a
+/// label matches the heading it points at (bd-toc-smart-quotes-6nro57ed).
+///
+/// This is the same `write_inlines_to` quarto-core already uses to render
+/// inline metadata (`template.rs`, `revealjs/footer_logo.rs`); it handles
+/// escaping, so the label no longer goes through `html_escape`.
+fn render_toc_label(title: &[Inline]) -> String {
+    let stripped = strip_links_and_notes(title);
+    let mut out: Vec<u8> = Vec::new();
+    match pampa::writers::html::write_inlines_to(&stripped, &mut out) {
+        // Writing to a Vec cannot fail; the lossy conversion is for the
+        // impossible case rather than an expected one.
+        Ok(()) => String::from_utf8_lossy(&out).into_owned(),
+        Err(_) => String::new(),
+    }
+}
+
 /// Render TOC entries to HTML string (recursive).
 fn render_toc_entries_to_html(entries: &[TocEntry]) -> String {
     if entries.is_empty() {
@@ -140,7 +268,7 @@ fn render_toc_entries_to_html(entries: &[TocEntry]) -> String {
                 html_escape(number)
             ));
         }
-        html.push_str(&html_escape(&entry.title));
+        html.push_str(&render_toc_label(&entry.title));
         html.push_str("\n</a>\n");
 
         if !entry.children.is_empty() {
@@ -185,10 +313,19 @@ mod tests {
         }
     }
 
+    /// A title made of one literal `Str`. Tests that care about markup
+    /// build their own inlines.
+    fn plain_title(text: &str) -> Inlines {
+        vec![Inline::Str(quarto_pandoc_types::inline::Str {
+            text: text.to_string(),
+            source_info: dummy_source_info(),
+        })]
+    }
+
     fn make_toc_entry(id: &str, title: &str, level: i32) -> TocEntry {
         TocEntry {
             id: id.to_string(),
-            title: title.to_string(),
+            title: plain_title(title),
             level,
             number: None,
             children: vec![],
@@ -318,7 +455,7 @@ mod tests {
             title: None,
             entries: vec![TocEntry {
                 id: "chapter".to_string(),
-                title: "Chapter 1".to_string(),
+                title: plain_title("Chapter 1"),
                 level: 1,
                 number: None,
                 children: vec![
@@ -367,12 +504,12 @@ mod tests {
             title: None,
             entries: vec![TocEntry {
                 id: "intro".to_string(),
-                title: "Introduction".to_string(),
+                title: plain_title("Introduction"),
                 level: 1,
                 number: Some("1".to_string()),
                 children: vec![TocEntry {
                     id: "background".to_string(),
-                    title: "Background".to_string(),
+                    title: plain_title("Background"),
                     level: 2,
                     number: Some("1.1".to_string()),
                     children: vec![],
@@ -413,6 +550,16 @@ mod tests {
 
     #[tokio::test]
     async fn test_renders_toc_escapes_special_chars() {
+        // The label no longer goes through `html_escape` — escaping now
+        // happens inside the inline writer. The distinction that matters
+        // after that change: characters *typed* in a heading arrive as
+        // `Str` content and must still be escaped, so a literal `<b>`
+        // renders as text rather than opening a tag. (A `RawInline`
+        // would legitimately pass through; that is a different node and
+        // is not what a plain heading produces.)
+        //
+        // The entry `id` still goes through `html_escape` — it is an
+        // attribute value, not inline content.
         let mut ast = Pandoc {
             meta: ConfigValue::default(),
             blocks: vec![],
@@ -422,7 +569,7 @@ mod tests {
             title: None,
             entries: vec![TocEntry {
                 id: "intro-with-<script>".to_string(),
-                title: "Title with <b>HTML</b> & \"quotes\"".to_string(),
+                title: plain_title("Title with <b>HTML</b> & \"quotes\""),
                 level: 1,
                 number: None,
                 children: vec![],
@@ -446,11 +593,91 @@ mod tests {
             .unwrap();
         let html = rendered.as_str().unwrap();
 
-        // Check that HTML is escaped
-        assert!(html.contains("&lt;b&gt;HTML&lt;/b&gt;"));
-        assert!(html.contains("&amp;"));
-        assert!(html.contains("&quot;quotes&quot;"));
-        assert!(html.contains("intro-with-&lt;script&gt;"));
+        assert!(
+            html.contains("&lt;b&gt;HTML&lt;/b&gt;"),
+            "literal angle brackets in heading text must be escaped; got: {html}"
+        );
+        assert!(html.contains("&amp;"), "literal ampersand must be escaped");
+        assert!(
+            html.contains("intro-with-&lt;script&gt;"),
+            "the entry id is an attribute value and stays html_escape'd"
+        );
+    }
+
+    /// bd-toc-smart-quotes-6nro57ed: the label carries the heading's
+    /// markup rather than a flattened projection.
+    #[tokio::test]
+    async fn test_renders_toc_label_with_markup() {
+        use quarto_pandoc_types::inline::{Code, QuoteType, Quoted, Str};
+
+        let title = vec![
+            Inline::Str(Str {
+                text: "Using a ".to_string(),
+                source_info: dummy_source_info(),
+            }),
+            Inline::Quoted(Quoted {
+                quote_type: QuoteType::DoubleQuote,
+                content: vec![Inline::Str(Str {
+                    text: "raw".to_string(),
+                    source_info: dummy_source_info(),
+                })],
+                source_info: dummy_source_info(),
+            }),
+            Inline::Str(Str {
+                text: " ".to_string(),
+                source_info: dummy_source_info(),
+            }),
+            Inline::Code(Code {
+                text: "volume".to_string(),
+                attr: (String::new(), vec![], hashlink::LinkedHashMap::new()),
+                source_info: dummy_source_info(),
+                attr_source: quarto_pandoc_types::attr::AttrSourceInfo::empty(),
+            }),
+        ];
+
+        let html = render_toc_label(&title);
+
+        assert_eq!(
+            html, "Using a \u{201C}raw\u{201D} <code>volume</code>",
+            "quote delimiters and the code span must both render"
+        );
+    }
+
+    /// Links are unwrapped (anchors may not nest) and notes dropped,
+    /// mirroring pandoc's `deLink` / `deNote`.
+    #[tokio::test]
+    async fn test_toc_label_strips_links_and_notes() {
+        use quarto_pandoc_types::inline::{Link, Note, Str};
+
+        let title = vec![
+            Inline::Str(Str {
+                text: "See ".to_string(),
+                source_info: dummy_source_info(),
+            }),
+            Inline::Link(Link {
+                attr: (String::new(), vec![], hashlink::LinkedHashMap::new()),
+                content: vec![Inline::Str(Str {
+                    text: "the docs".to_string(),
+                    source_info: dummy_source_info(),
+                })],
+                target: ("https://example.com".to_string(), String::new()),
+                source_info: dummy_source_info(),
+                attr_source: quarto_pandoc_types::attr::AttrSourceInfo::empty(),
+                target_source: quarto_pandoc_types::attr::TargetSourceInfo::empty(),
+            }),
+            Inline::Note(Note {
+                content: vec![],
+                source_info: dummy_source_info(),
+            }),
+        ];
+
+        let html = render_toc_label(&title);
+
+        assert_eq!(html, "See the docs", "link text kept, anchor and note gone");
+        assert!(
+            !html.contains("<a"),
+            "a nested anchor would be invalid inside the TOC entry's own <a>"
+        );
     }
 
     #[tokio::test]

--- a/crates/quarto-core/src/transforms/toc_render.rs
+++ b/crates/quarto-core/src/transforms/toc_render.rs
@@ -120,6 +120,26 @@ impl AstTransform for TocRenderTransform {
             ConfigValue::new_string(&html, SourceInfo::generated(By::programmatic_config())),
         );
 
+        // The TOC's own heading carries markup too, so it gets the same
+        // treatment as the entries: rendered here and published under
+        // `rendered.*`, rather than left as metadata for each consumer to
+        // stringify. That matters because there are *two* consumers — the
+        // doctemplate (`$rendered.navigation.toc-title$`) and the preview
+        // renderer's `TocSlot` — and the preview reads metadata through
+        // `extractMetaString`, which cannot see `PandocInlines`. One
+        // rendered value keeps `q2 preview` and `q2 render` in agreement
+        // (bd-toc-smart-quotes-6nro57ed).
+        if let Some(ref title) = toc.title {
+            let title_html = render_toc_label(title);
+            ast.meta.insert_path(
+                &["rendered", "navigation", "toc-title"],
+                ConfigValue::new_string(
+                    &title_html,
+                    SourceInfo::generated(By::programmatic_config()),
+                ),
+            );
+        }
+
         Ok(())
     }
 }
@@ -404,7 +424,7 @@ mod tests {
         };
 
         let toc = NavigationToc {
-            title: Some("Contents".to_string()),
+            title: Some(plain_title("Contents")),
             entries: vec![
                 make_toc_entry("intro", "Introduction", 1),
                 make_toc_entry("methods", "Methods", 1),
@@ -730,7 +750,7 @@ mod tests {
         };
 
         let toc = NavigationToc {
-            title: Some("Contents".to_string()),
+            title: Some(plain_title("Contents")),
             entries: vec![], // Empty entries
         };
         ast.meta
@@ -1141,10 +1161,33 @@ mod tests {
         // Should have rendered TOC
         assert!(ast.meta.contains_path(&["rendered", "navigation", "toc"]));
 
-        // The title is stored in navigation.toc.title for the template to use
-        // (the render transform doesn't include it in the HTML output)
+        // The title stays in `navigation.toc.title` as inlines, and is
+        // *also* published pre-rendered at `rendered.navigation.toc-title`
+        // — that rendered value is what both the doctemplate and the
+        // preview's TocSlot read (bd-toc-smart-quotes-6nro57ed). It is
+        // kept out of `rendered.navigation.toc` proper, which is only the
+        // inner `<ul>`.
         let toc = ast.meta.get_path(&["navigation", "toc"]).unwrap();
         let title = toc.get("title").unwrap().as_plain_text().unwrap();
         assert_eq!(title, "Quick Links");
+
+        let rendered_title = ast
+            .meta
+            .get_path(&["rendered", "navigation", "toc-title"])
+            .expect("rendered toc-title")
+            .as_str()
+            .expect("rendered toc-title is a string");
+        assert_eq!(rendered_title, "Quick Links");
+
+        let entries_html = ast
+            .meta
+            .get_path(&["rendered", "navigation", "toc"])
+            .unwrap()
+            .as_str()
+            .unwrap();
+        assert!(
+            !entries_html.contains("Quick Links"),
+            "the title must not be duplicated into the entries markup"
+        );
     }
 }

--- a/crates/quarto-core/tests/integration/document_profile_pipeline.rs
+++ b/crates/quarto-core/tests/integration/document_profile_pipeline.rs
@@ -199,11 +199,14 @@ async fn pipeline_profile_matches_metadata() {
 
     // Outline: two top-level sections, first has one subsection.
     assert_eq!(profile.outline.len(), 2, "two top-level headings");
-    assert_eq!(profile.outline[0].title, "Section one");
+    assert_eq!(title_text(&profile.outline[0].title), "Section one");
     assert_eq!(profile.outline[0].level, 1);
     assert_eq!(profile.outline[0].children.len(), 1);
-    assert_eq!(profile.outline[0].children[0].title, "Subsection");
-    assert_eq!(profile.outline[1].title, "Section two");
+    assert_eq!(
+        title_text(&profile.outline[0].children[0].title),
+        "Subsection"
+    );
+    assert_eq!(title_text(&profile.outline[1].title), "Section two");
 
     // The inner ast is still present and usable.
     assert!(
@@ -364,9 +367,13 @@ async fn run_head_pipeline_in_dir(
 /// Walk every entry in an outline (and its nested children) and collect
 /// their titles, so we can check for the presence of a specific heading
 /// without assuming tree shape.
+fn title_text(title: &quarto_pandoc_types::Inlines) -> String {
+    pampa::writers::plaintext::inlines_to_string(title).0
+}
+
 fn collect_outline_titles(outline: &[pampa::toc::TocEntry]) -> Vec<String> {
     fn walk(entry: &pampa::toc::TocEntry, out: &mut Vec<String>) {
-        out.push(entry.title.clone());
+        out.push(pampa::writers::plaintext::inlines_to_string(&entry.title).0);
         for child in &entry.children {
             walk(child, out);
         }

--- a/crates/quarto-core/tests/integration/main.rs
+++ b/crates/quarto-core/tests/integration/main.rs
@@ -63,6 +63,7 @@ pub mod shortcode_text_contexts;
 pub mod sidebar_pipeline;
 pub mod theme_light_dark;
 pub mod title_block_pipeline;
+pub mod toc_markup;
 pub mod video_shortcode_preview;
 pub mod website_aliases;
 pub mod website_post_render;

--- a/crates/quarto-core/tests/integration/toc_markup.rs
+++ b/crates/quarto-core/tests/integration/toc_markup.rs
@@ -286,6 +286,7 @@ fn toc_entry_escapes_literal_markup_characters() {
 /// metadata layer (`InterpretationContext::DocumentMetadata`), so its
 /// markup must reach the rendered `<h2 id="toc-title">`.
 #[test]
+#[ignore = "phase 3 of bd-toc-smart-quotes-6nro57ed: NavigationToc.title becomes Inlines and toc-title gets blessed in MARKDOWN_CONFIG_PATHS"]
 fn toc_title_from_frontmatter_keeps_markup() {
     let html = render_index_with_toc(
         "## Section\n\nBody.\n",
@@ -305,6 +306,7 @@ fn toc_title_from_frontmatter_keeps_markup() {
 /// only gets markdown semantics once `toc-title` is blessed in
 /// `MARKDOWN_CONFIG_PATHS`.
 #[test]
+#[ignore = "phase 3 of bd-toc-smart-quotes-6nro57ed: NavigationToc.title becomes Inlines and toc-title gets blessed in MARKDOWN_CONFIG_PATHS"]
 fn toc_title_from_project_config_keeps_markup() {
     let html = render_index_with_toc(
         "## Section\n\nBody.\n",

--- a/crates/quarto-core/tests/integration/toc_markup.rs
+++ b/crates/quarto-core/tests/integration/toc_markup.rs
@@ -1,0 +1,328 @@
+/*
+ * toc_markup.rs
+ * Copyright (c) 2026 Posit, PBC
+ *
+ * bd-toc-smart-quotes-6nro57ed: TOC entries must carry the heading's
+ * inline markup, not a flattened plain-text projection.
+ */
+
+//! End-to-end coverage for markup in table-of-contents entries.
+//!
+//! Before this file there was **no end-to-end TOC test at all**, which is
+//! why a visible defect — TOC labels disagreeing with the headings they
+//! point at — reached a release. Every test here drives the real CLI
+//! render path (`ProjectPipeline` -> `RenderToFileRenderer` ->
+//! `render_document_to_file`) against a temp project and inspects the
+//! HTML actually written to disk.
+//!
+//! The expected shapes are Quarto 1's, captured in
+//! `claude-notes/plans/toc-smart-quotes-investigation/OBSERVED.md`.
+//!
+//! Plan: `claude-notes/plans/2026-08-13-toc-smart-quotes.md`.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use tempfile::TempDir;
+
+use quarto_core::format::Format;
+use quarto_core::project::ProjectContext;
+use quarto_core::project::orchestrator::{ProjectPipeline, RenderMode, project_type_for};
+use quarto_core::render_to_file::RenderToFileOptions;
+use quarto_system_runtime::{NativeRuntime, SystemRuntime};
+
+fn write(path: &Path, contents: &str) {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(path, contents).unwrap();
+}
+
+/// Build a single-page website project whose `index.qmd` has `toc: true`
+/// and the given body, render it through the real pipeline, and return
+/// the rendered `index.html`.
+fn render_index_with_toc(body: &str, extra_frontmatter: &str, project_yml: Option<&str>) -> String {
+    let temp = TempDir::new().unwrap();
+    let project_dir = temp
+        .path()
+        .canonicalize()
+        .unwrap_or_else(|_| temp.path().to_path_buf());
+
+    write(
+        &project_dir.join("_quarto.yml"),
+        project_yml.unwrap_or("project:\n  type: website\nwebsite:\n  title: \"TOC test\"\n"),
+    );
+    write(
+        &project_dir.join("index.qmd"),
+        &format!("---\ntitle: \"Home\"\ntoc: true\n{extra_frontmatter}---\n\n{body}"),
+    );
+
+    let runtime: Arc<dyn SystemRuntime> = Arc::new(NativeRuntime::new());
+    let mut project = ProjectContext::discover(&project_dir, runtime.as_ref()).expect("discover");
+    let options = RenderToFileOptions::default();
+    let project_type = project_type_for(&project);
+    let mut pipeline = ProjectPipeline::new(
+        &mut project,
+        project_type,
+        Format::html(),
+        "html",
+        &options,
+        runtime.clone(),
+    );
+
+    let summary = pollster::block_on(pipeline.run()).expect("pipeline run");
+    assert!(
+        summary.pass1_failures.is_empty(),
+        "pass1 failures: {:?}",
+        summary
+            .pass1_failures
+            .iter()
+            .map(|f| (&f.input, &f.error))
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        summary.pass2_failures.is_empty(),
+        "pass2 failures: {:?}",
+        summary
+            .pass2_failures
+            .iter()
+            .map(|f| (&f.input, &f.error))
+            .collect::<Vec<_>>()
+    );
+
+    let out: PathBuf = project.output_dir.clone();
+    std::fs::read_to_string(out.join("index.html")).expect("rendered index.html")
+}
+
+/// Slice out the `<nav id="TOC">…</nav>` region so assertions cannot
+/// accidentally match the document body (which renders the same markup
+/// correctly today and would mask a TOC regression).
+fn toc_nav(html: &str) -> String {
+    let start = html
+        .find("<nav id=\"TOC\"")
+        .unwrap_or_else(|| panic!("no <nav id=\"TOC\"> in rendered HTML:\n{html}"));
+    let rest = &html[start..];
+    let end = rest.find("</nav>").expect("unterminated <nav id=\"TOC\">") + "</nav>".len();
+    rest[..end].to_string()
+}
+
+/// The inner HTML of each TOC entry anchor, in document order.
+fn toc_entry_labels(html: &str) -> Vec<String> {
+    let nav = toc_nav(html);
+    let mut labels = Vec::new();
+    let mut rest = nav.as_str();
+    while let Some(open) = rest.find("<a ") {
+        let after_open = &rest[open..];
+        let Some(gt) = after_open.find('>') else {
+            break;
+        };
+        let body_start = gt + 1;
+        let Some(close) = after_open.find("</a>") else {
+            break;
+        };
+        labels.push(after_open[body_start..close].trim().to_string());
+        rest = &after_open[close + "</a>".len()..];
+    }
+    labels
+}
+
+// ---------------------------------------------------------------------
+// The strand's own case
+// ---------------------------------------------------------------------
+
+/// bd-toc-smart-quotes-6nro57ed. A quoted span in a heading renders with
+/// curly quotes; its TOC entry must not drop the delimiters.
+///
+/// Quarto 1: `Using a “raw” volume` in both places.
+#[test]
+fn toc_entry_keeps_quote_glyphs() {
+    let html = render_index_with_toc("## Using a \"raw\" volume\n\nBody.\n", "", None);
+
+    assert!(
+        html.contains("<h2>Using a \u{201C}raw\u{201D} volume</h2>"),
+        "precondition: the heading itself should already render curly quotes; got:\n{}",
+        toc_nav(&html)
+    );
+    assert_eq!(
+        toc_entry_labels(&html),
+        vec!["Using a \u{201C}raw\u{201D} volume".to_string()],
+        "TOC entry must carry the same quote glyphs as the heading it points at"
+    );
+}
+
+/// Controls from the strand: an apostrophe and an en dash are
+/// `Str`-internal smart-typography rewrites and already survive. If these
+/// ever fail, the bug is in the reader, not in the TOC.
+#[test]
+fn toc_entry_keeps_str_internal_smart_typography() {
+    let html = render_index_with_toc(
+        "## Finding your repository's identifiers\n\nBody.\n\n## What's in the Gallery -- really\n\nBody.\n",
+        "",
+        None,
+    );
+
+    assert_eq!(
+        toc_entry_labels(&html),
+        vec![
+            "Finding your repository\u{2019}s identifiers".to_string(),
+            "What\u{2019}s in the Gallery \u{2013} really".to_string(),
+        ]
+    );
+}
+
+// ---------------------------------------------------------------------
+// The wider defect: all inline markup is flattened
+// ---------------------------------------------------------------------
+
+/// Quarto 1 renders `Use <code>code</code> and <em>em</em> and
+/// <strong>strong</strong>` in the TOC entry. q2 flattened all of it.
+#[test]
+fn toc_entry_keeps_inline_markup() {
+    let html = render_index_with_toc("## Use `code` and *em* and **strong**\n\nBody.\n", "", None);
+
+    assert_eq!(
+        toc_entry_labels(&html),
+        vec!["Use <code>code</code> and <em>em</em> and <strong>strong</strong>".to_string()]
+    );
+}
+
+/// Inline math survives into the TOC entry with the same span shape the
+/// heading uses.
+#[test]
+fn toc_entry_keeps_inline_math() {
+    let html = render_index_with_toc("## Math $x+y$ inline\n\nBody.\n", "", None);
+
+    let labels = toc_entry_labels(&html);
+    assert_eq!(labels.len(), 1, "one heading");
+    assert!(
+        labels[0].contains("<span class=\"math inline\">"),
+        "TOC entry should carry the math span; got {:?}",
+        labels[0]
+    );
+    assert!(
+        labels[0].contains("x+y"),
+        "TOC entry should carry the math text; got {:?}",
+        labels[0]
+    );
+}
+
+// ---------------------------------------------------------------------
+// Render-time stripping (Phase 2 decision)
+// ---------------------------------------------------------------------
+
+/// A link inside a heading must contribute its *text* to the TOC entry
+/// but not its anchor: the entry is itself an `<a>`, and anchors cannot
+/// nest. Pandoc does this with `deLink`; Quarto 1's output for
+/// `## Math $x+y$ and a [link](…)` is `… and a link`.
+#[test]
+fn toc_entry_strips_links_but_keeps_their_text() {
+    let html = render_index_with_toc(
+        "## See [the docs](https://example.com) now\n\nBody.\n",
+        "",
+        None,
+    );
+
+    let labels = toc_entry_labels(&html);
+    assert_eq!(labels, vec!["See the docs now".to_string()]);
+
+    // Belt and braces: no nested anchor anywhere in the nav.
+    let nav = toc_nav(&html);
+    assert!(
+        !nav.contains("https://example.com"),
+        "the heading's link href must not appear inside the TOC nav:\n{nav}"
+    );
+}
+
+/// A footnote in a heading must not drag the footnote reference into the
+/// TOC entry. Pandoc strips these with `deNote`.
+#[test]
+fn toc_entry_drops_footnotes() {
+    let html = render_index_with_toc(
+        "## Heading with a note^[the note text]\n\nBody.\n",
+        "",
+        None,
+    );
+
+    let labels = toc_entry_labels(&html);
+    assert_eq!(labels.len(), 1, "one heading");
+    assert!(
+        !labels[0].contains("the note text"),
+        "footnote body must not appear in the TOC entry; got {:?}",
+        labels[0]
+    );
+    assert!(
+        labels[0].starts_with("Heading with a note"),
+        "heading text should survive; got {:?}",
+        labels[0]
+    );
+}
+
+/// Angle brackets typed literally in a heading are `Str` content and must
+/// still be escaped once the title stops being a plain `String` that
+/// `html_escape` handled wholesale.
+#[test]
+fn toc_entry_escapes_literal_markup_characters() {
+    let html = render_index_with_toc("## A \\<b\\> and an & ampersand\n\nBody.\n", "", None);
+
+    let labels = toc_entry_labels(&html);
+    assert_eq!(labels.len(), 1, "one heading");
+    assert!(
+        labels[0].contains("&lt;b&gt;"),
+        "literal angle brackets must be escaped, not emitted as a tag; got {:?}",
+        labels[0]
+    );
+    assert!(
+        labels[0].contains("&amp;"),
+        "literal ampersand must be escaped; got {:?}",
+        labels[0]
+    );
+}
+
+// ---------------------------------------------------------------------
+// Phase 3: toc-title
+// ---------------------------------------------------------------------
+
+/// `toc-title` in document front matter is parsed as markdown by the
+/// metadata layer (`InterpretationContext::DocumentMetadata`), so its
+/// markup must reach the rendered `<h2 id="toc-title">`.
+#[test]
+fn toc_title_from_frontmatter_keeps_markup() {
+    let html = render_index_with_toc(
+        "## Section\n\nBody.\n",
+        "toc-title: \"On **this** page\"\n",
+        None,
+    );
+
+    let nav = toc_nav(&html);
+    assert!(
+        nav.contains("<h2 id=\"toc-title\">On <strong>this</strong> page</h2>"),
+        "front-matter toc-title markup should survive; got:\n{nav}"
+    );
+}
+
+/// `toc-title` in `_quarto.yml` is `Scalar(String)` at load time
+/// (`InterpretationContext::ProjectConfig` keeps strings literal), so it
+/// only gets markdown semantics once `toc-title` is blessed in
+/// `MARKDOWN_CONFIG_PATHS`.
+#[test]
+fn toc_title_from_project_config_keeps_markup() {
+    let html = render_index_with_toc(
+        "## Section\n\nBody.\n",
+        "",
+        Some(
+            "project:\n  type: website\nwebsite:\n  title: \"TOC test\"\ntoc-title: \"On **this** page\"\n",
+        ),
+    );
+
+    let nav = toc_nav(&html);
+    assert!(
+        nav.contains("<h2 id=\"toc-title\">On <strong>this</strong> page</h2>"),
+        "project-config toc-title markup should survive once toc-title is blessed in \
+         MARKDOWN_CONFIG_PATHS; got:\n{nav}"
+    );
+}
+
+/// Guard against the `RenderMode` import going unused if the harness is
+/// ever refactored to the active-page form.
+#[allow(dead_code)]
+fn _render_mode_is_available(_m: RenderMode) {}

--- a/crates/quarto-core/tests/integration/toc_markup.rs
+++ b/crates/quarto-core/tests/integration/toc_markup.rs
@@ -286,7 +286,6 @@ fn toc_entry_escapes_literal_markup_characters() {
 /// metadata layer (`InterpretationContext::DocumentMetadata`), so its
 /// markup must reach the rendered `<h2 id="toc-title">`.
 #[test]
-#[ignore = "phase 3 of bd-toc-smart-quotes-6nro57ed: NavigationToc.title becomes Inlines and toc-title gets blessed in MARKDOWN_CONFIG_PATHS"]
 fn toc_title_from_frontmatter_keeps_markup() {
     let html = render_index_with_toc(
         "## Section\n\nBody.\n",
@@ -306,7 +305,6 @@ fn toc_title_from_frontmatter_keeps_markup() {
 /// only gets markdown semantics once `toc-title` is blessed in
 /// `MARKDOWN_CONFIG_PATHS`.
 #[test]
-#[ignore = "phase 3 of bd-toc-smart-quotes-6nro57ed: NavigationToc.title becomes Inlines and toc-title gets blessed in MARKDOWN_CONFIG_PATHS"]
 fn toc_title_from_project_config_keeps_markup() {
     let html = render_index_with_toc(
         "## Section\n\nBody.\n",

--- a/ts-packages/preview-renderer/src/q2-preview/PreviewDocument.integration.test.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/PreviewDocument.integration.test.tsx
@@ -384,13 +384,15 @@ describe('PreviewDocument chrome injection (Phase F.2)', () => {
         const tocInnerUl =
             '<ul><li data-test="toc-li"><a href="#sec">Section</a></li></ul>';
         const { container } = mount({
-            navigation: metaMap([
-                {
-                    key: 'toc',
-                    value: metaMap([{ key: 'title', value: ms('Contents') }]),
-                },
-            ]),
-            rendered: renderedNavigation({ toc: tocInnerUl }),
+            // The title comes from `rendered.navigation['toc-title']`,
+            // not `navigation.toc.title`: it carries inline markup, so
+            // TocRenderTransform renders it and both the preview and
+            // q2 render's template read the rendered value
+            // (bd-toc-smart-quotes-6nro57ed).
+            rendered: renderedNavigation({
+                toc: tocInnerUl,
+                'toc-title': 'Contents',
+            }),
         });
         // Wrapper structure mirrors template.rs:189-200.
         const margin = container.querySelector(
@@ -408,15 +410,33 @@ describe('PreviewDocument chrome injection (Phase F.2)', () => {
         expect(tocNav!.querySelector('li[data-test="toc-li"]')).not.toBeNull();
     });
 
-    it('TOC: missing navigation.toc.title omits the <h2>', () => {
+    it('TOC: missing rendered toc-title omits the <h2>', () => {
         const tocInnerUl = '<ul><li>Sec</li></ul>';
         const { container } = mount({
-            // No `navigation.toc.title` → tocTitle is empty → no <h2>.
+            // No `rendered.navigation['toc-title']` → empty → no <h2>.
             rendered: renderedNavigation({ toc: tocInnerUl }),
         });
         const tocNav = container.querySelector('#quarto-margin-sidebar nav#TOC');
         expect(tocNav).not.toBeNull();
         expect(tocNav!.querySelector('h2#toc-title')).toBeNull();
+    });
+
+    it('TOC: toc-title markup renders as HTML, not escaped text', () => {
+        // `toc-title: "On **this** page"` reaches the preview as
+        // rendered HTML. Rendering it as a React text node — which is
+        // what reading `navigation.toc.title` used to do — would show
+        // the tags literally, or drop the title entirely once the
+        // metadata value became PandocInlines.
+        const { container } = mount({
+            rendered: renderedNavigation({
+                toc: '<ul><li>Sec</li></ul>',
+                'toc-title': 'On <strong>this</strong> page',
+            }),
+        });
+        const h2 = container.querySelector('#quarto-margin-sidebar h2#toc-title');
+        expect(h2).not.toBeNull();
+        expect(h2!.querySelector('strong')).not.toBeNull();
+        expect(h2!.textContent).toBe('On this page');
     });
 
     it('renders page-navigation INSIDE main, after children', () => {

--- a/ts-packages/preview-renderer/src/q2-preview/PreviewDocument.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/PreviewDocument.tsx
@@ -177,13 +177,22 @@ export const PreviewDocument = ({
     const footerHtml = extractMetaString(
         getMetaPath(meta, ['rendered', 'navigation', 'footer']),
     );
-    // TocGenerateTransform always sets `navigation.toc.title`
-    // (default "Table of Contents" — toc_generate.rs:113-119), but
-    // a user can still override or set it to empty. Surface it
-    // verbatim; the slot omits the `<h2>` when the title is empty.
-    const tocTitle =
-        extractMetaString(getMetaPath(meta, ['navigation', 'toc', 'title'])) ??
-        '';
+    // TocGenerateTransform always sets the TOC title (default
+    // "Table of Contents" — toc_generate.rs), but a user can still
+    // override it or set it to empty; the slot omits the `<h2>` when
+    // the title is empty.
+    //
+    // Read the *rendered* value, not `navigation.toc.title`: the title
+    // carries inline markup (`toc-title: "On **this** page"`), so the
+    // metadata value is `PandocInlines`, which `extractMetaString`
+    // cannot see. `TocRenderTransform` renders it to HTML alongside the
+    // entries, and `q2 render`'s template reads the same key — which is
+    // what keeps preview and render in agreement
+    // (bd-toc-smart-quotes-6nro57ed).
+    const tocTitleHtml =
+        extractMetaString(
+            getMetaPath(meta, ['rendered', 'navigation', 'toc-title']),
+        ) ?? '';
     // `meta.rendered.includes.header` collects favicon / RSS links /
     // any user includes-in-header (already a list; q2 render's
     // template wires `$header-includes$` into `<head>`). The banner
@@ -293,7 +302,7 @@ export const PreviewDocument = ({
 
                 {/* TOC — INSIDE quarto-content, before main
                     (template.rs:189-200). */}
-                {tocHtml ? <TocSlot html={tocHtml} title={tocTitle} /> : null}
+                {tocHtml ? <TocSlot html={tocHtml} titleHtml={tocTitleHtml} /> : null}
 
                 <main
                     className={`content${bannerTitleBlock ? ' quarto-banner-title-block' : ''}`}

--- a/ts-packages/preview-renderer/src/q2-preview/chromeSlots.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/chromeSlots.tsx
@@ -94,21 +94,35 @@ FooterSlot.displayName = 'FooterSlot';
  * into `meta.rendered.navigation.toc`. The wrapping
  * `<div id="quarto-margin-sidebar"><nav id="TOC"><h2>...</h2>`
  * is supplied by the template (template.rs:189-200), so this slot
- * only fills the inner `<ul>`. Memo keyed on (html, title) so a
+ * only fills the inner `<ul>`. Memo keyed on (html, titleHtml) so a
  * `toc-title:` edit re-renders correctly without tearing the DOM
  * for content edits.
+ *
+ * `titleHtml` is HTML, not text: `toc-title` carries inline markup
+ * (`toc-title: "On **this** page"`), so `TocRenderTransform` renders
+ * it to `meta.rendered.navigation.toc-title` and both this slot and
+ * `q2 render`'s template read that one value
+ * (bd-toc-smart-quotes-6nro57ed). It is writer output, escaped at the
+ * source, which is the same trust boundary as `html` above.
  */
-export const TocSlot = memo(({ html, title }: SlotProps & { title: string }) => (
-    <div
-        id="quarto-margin-sidebar"
-        className="sidebar margin-sidebar"
-    >
-        <nav id="TOC" role="doc-toc" className="toc-active">
-            {title && <h2 id="toc-title">{title}</h2>}
-            <div dangerouslySetInnerHTML={{ __html: html }} />
-        </nav>
-    </div>
-));
+export const TocSlot = memo(
+    ({ html, titleHtml }: SlotProps & { titleHtml: string }) => (
+        <div
+            id="quarto-margin-sidebar"
+            className="sidebar margin-sidebar"
+        >
+            <nav id="TOC" role="doc-toc" className="toc-active">
+                {titleHtml && (
+                    <h2
+                        id="toc-title"
+                        dangerouslySetInnerHTML={{ __html: titleHtml }}
+                    />
+                )}
+                <div dangerouslySetInnerHTML={{ __html: html }} />
+            </nav>
+        </div>
+    ),
+);
 TocSlot.displayName = 'TocSlot';
 
 interface HeaderIncludesProps {


### PR DESCRIPTION
Fixes **bd-toc-smart-quotes-6nro57ed**. Plan: `claude-notes/plans/2026-08-13-toc-smart-quotes.md`.

## The bug, and the bug behind it

A heading `## Using a "raw" volume` rendered with curly quotes but its TOC entry rendered `Using a raw volume` — the two disagreeing on one page. The delimiters were lost because `pampa::toc::inlines_to_text` recursed into `Inline::Quoted` without emitting them.

Investigating turned up the wider defect: **q2's TOC flattened *all* inline markup**, because `TocEntry::title` was a `String`. Quarto 1 renders `<code>`, `<em>`, `<strong>` and math spans inside TOC entries; q2 rendered none of them. The quote glyphs were the one symptom the Connect docs corpus happened to hit.

So this fixes the class, not the symptom.

| | before | after |
|---|---|---|
| `## Using a "raw" volume` | `Using a raw volume` | `Using a “raw” volume` |
| `` ## Use `code` and *em* `` | `Use code and em` | `Use <code>code</code> and <em>em</em>` |
| `## Math $x+y$ and a [link](…)` | `Math x+y and a link` | `Math <span class="math inline">\(x+y\)</span> and a link` |
| `toc-title` in front matter | markup flattened away | markup rendered |
| `toc-title` in `_quarto.yml` | markup never parsed | markup rendered |

Output is byte-identical to Quarto 1 on the markup probe.

## What changed

**`TocEntry::title` and `NavigationToc::title` are now `Inlines`.** `generate_toc` clones the heading's content instead of flattening it, and `toc.rs::inlines_to_text` is deleted — one of ~10 divergent inline-flatteners in the tree, and the one whose `Quoted` arm dropped delimiters.

**`toc_render` renders through the real inline writer** (`pampa::writers::html::write_inlines_to`, already how `template.rs` renders inline metadata). Escaping moves inside the writer; the entry `id` stays `html_escape`'d, being an attribute value.

**Links and notes are stripped at render time** (`strip_links_and_notes`, mirroring pandoc's `deLink`/`deNote`): a TOC entry *is* an `<a>`, and anchors cannot nest, so a link unwraps to its text. This deliberately lives in `toc_render` rather than `generate_toc` — `TocEntry` is also `DocumentProfile::outline`, which should stay a faithful semantic outline. "An anchor may not nest" is a fact about this HTML output, not about the document's headings.

**`toc-title` is blessed in `MARKDOWN_CONFIG_PATHS`.** Before, the same YAML failed two different ways depending on where it was written — the `InterpretationContext` split, visible on the page: `_quarto.yml` never parsed the markdown (`ProjectConfig` keeps strings literal), while front matter parsed it and then `as_plain_text()` threw it away.

**`profile_version` 10 → 11**, with a change-log entry in the contract doc. Degradation is clean two ways: the version is in the cache-key hash domain so stale entries are never looked up, and a shape mismatch is a cache *miss*, not an error.

## Preview/render parity

`PreviewDocument.tsx` read `navigation.toc.title` via `extractMetaString`, which cannot see `PandocInlines` — so the preview would have silently dropped `<h2 id="toc-title">` while `q2 render` still emitted it. Invisible to every Rust test.

Fixed by publishing the rendered title at `rendered.navigation.toc-title`; `template.rs` and `TocSlot` now read the same bytes — the seam the TOC *entries* already used. The alternative would have been reimplementing the HTML writer in TypeScript.

## Tests

Adds `crates/quarto-core/tests/integration/toc_markup.rs` — **the first end-to-end TOC coverage in the tree**, which is why this defect reached a release. It drives the real CLI path (`ProjectPipeline` → `RenderToFileRenderer` → `render_document_to_file`) against a temp project and reads the HTML off disk. Written first: 5 red / 4 green at the base commit, the 4 green being guards for behavior that had to be preserved.

- `cargo xtask verify` (full, incl. WASM + hub-client legs): passes
- `cargo nextest run --workspace`: 11,846 / 11,846
- 577 preview-renderer tests, incl. a new markup-in-`toc-title` case
- `cargo xtask lint`: clean
- **No snapshot changes** — no `.snap` in the tree covers the TOC

End-to-end verified through `cargo run --bin q2 -- render` on three fixtures; the invocations and inspected output are recorded in `claude-notes/plans/toc-smart-quotes-investigation/OBSERVED.md`, alongside the Quarto 1 captures they are compared against.

## Side effects on other strands

- **Closes bd-qzn1azon.** Its entire scope was a "see also, and when to pick which" note in both key-path registries (`meta_annotations.rs` `ANNOTATIONS` vs `config_markdown.rs` `MARKDOWN_CONFIG_PATHS`) — this PR was editing one of them anyway. Both now carry a comparison table; extending the wrong one has already caused a bug once.
- **Un-defers bd-zzke** with a corrected survey: it listed 6 flattener sites, there are 10 (one fewer now). Adds the essential-vs-incidental axis analysis showing they collapse to ~2–3 named flavours.
- **Files bd-d7ljiz9q**: `!str` cannot opt a project-config key out of markdown parsing — the escape hatch the "bless more keys" direction leans on is absent in exactly the context blessing applies to.

## Deliberately out of scope

The anchor ids are still wrong (`#using-a-volume`, `#math-and-a`). That is **bd-heading-id-drops-inline-content-fl84n3ql** — the same root-cause *class* in `autoid::collect_text`, but a different code path, kept independent by design decision.

## Known behavior change

Blessing `toc-title` changes rendering for any existing `_quarto.yml` whose `toc-title` contains `*` or `_`, and per bd-d7ljiz9q there is no `!str` opt-out in project config. Accepted knowingly — see the plan's decision 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
