### PR TITLE
Honor execute-visibility options (echo/output/warning/include) in both engines

### DIFF
--- a/claude-notes/plans/2026-08-14-issue-523-execute-visibility.md
+++ b/claude-notes/plans/2026-08-14-issue-523-execute-visibility.md
@@ -1,0 +1,470 @@
+# GH issue #523 — `code-fold` vs `execute: echo: false`: assessment and fix plan
+
+**Issue:** https://github.com/quarto-dev/q2/issues/523 (third-party report, 2026-08-13)
+**Strand:** bd-nn2fou8h (main). Adjacent: bd-fjfizas7 (engine inference).
+Related: bd-1tl09 / bd-g1prx (code-fold), bd-moef1ec4 (`eval`), bd-cymkcyaf (format-level
+execute defaults).
+**Reported against:** q2 0.20.0 (macOS arm64 release tarball)
+**Verified against:** `main` @ `3ac596e0` (0.21.0-dev) — `git log v0.20.0..HEAD` touches neither
+`engine/jupyter/text_execute.rs` nor `engine/knitr/`, so 0.20.0 and today's `main` behave
+identically on this path.
+**Q1 reference:** `quarto` on PATH, version `99.9.9` (dev checkout at `external-sources/quarto-cli`
+@ `45caede32`).
+
+## TL;DR
+
+The reported *symptom* is real: `execute: echo: false` does not hide cell source in q2.
+The reported *cause* is not. `code-fold: true` has **zero** effect on q2's output — with and
+without it the rendered HTML is byte-identical. `code-fold` is not implemented in q2 at all
+(tracked separately as bd-1tl09 / bd-g1prx), so it cannot be overriding anything.
+
+The actual defect is broader than the report:
+
+- **The jupyter engine ignores the entire execute-visibility family.** `echo`, `output`,
+  `warning`, and `include` are unimplemented at both document scope (`execute:`) and cell
+  scope (`#|`). The engine unconditionally echoes source and unconditionally emits every output.
+- **The knitr engine ignores document-scope `execute:` entirely** and *actively overrides* it:
+  `build_format_config` throws the document's metadata away and hardcodes `echo: true`.
+  Per-cell `#| echo: false` does work there, because knitr/R handles it below q2.
+
+So the user-visible contract "`execute: echo: false` hides the code" is broken in q2 for both
+engines, in three different ways, none of which involve `code-fold`.
+
+## Verification
+
+All fixtures rendered with `target/debug/q2 render <f>.qmd` and, for comparison,
+`quarto render <f>.qmd --to html`. Outputs inspected directly (grep + read), not inferred
+from exit codes.
+
+### 1. The reported repro — confirmed symptom
+
+`fold.qmd` (the issue's fixture verbatim) rendered by q2:
+
+```html
+<div class="cell">
+<div class="sourceCode cell-code code-with-copy"><pre class="sourceCode python"><code
+class="sourceCode python">…print(&quot;OUTPUT&quot;)…</code></pre></div>
+<div class="cell-output cell-output-stdout">
+<pre class="code-with-copy"><code>OUTPUT</code></pre>
+```
+
+Source is echoed despite `execute: echo: false`. **Confirmed.**
+
+Q1 on the same file emits only:
+
+```html
+<div class="cell-output cell-output-stdout">
+<pre><code>OUTPUT</code></pre>
+```
+
+**Q1 behaviour is as the reporter describes.**
+
+### 2. The reported isolation — NOT reproduced
+
+The issue states that removing `code-fold: true` makes q2 honour `echo: false`. It does not.
+`nofold.qmd` (identical but `format: html`) produces output that is **byte-identical** to
+`fold.html` modulo the filename:
+
+```
+$ diff <(sed 's/fold/X/g' fold.html) <(sed 's/nofold/X/g;s/fold/X/g' nofold.html)
+$ echo $?
+0
+```
+
+`code-fold: true` changes nothing whatsoever. There is no interaction between the two options
+in q2, because one of them is a no-op. I could not reconstruct a variant of the reporter's
+document where `code-fold` changes `echo` behaviour; the claim appears to be a mis-attribution
+during isolation. It does not affect the validity of the underlying bug report.
+
+### 3. `code-fold` is entirely unimplemented (both engines, both block kinds)
+
+| Fixture | q2 | Q1 |
+| --- | --- | --- |
+| `code-fold: true` + executed `{python}` cell (echo on) | no `<details>` | `<details class="code-fold"><summary>Code</summary>` |
+| `code-fold: true` + plain ```` ```python ```` block | no `<details>` | no `<details>` |
+
+Note the second row: Q1 does **not** fold plain code blocks either. `quarto-post/foldcode.lua`
+bails unless the block carries the `cell-code` class, so folding is an executed-cell feature in
+Q1 too.
+
+**q2 should not preserve that restriction.** Folding non-executable blocks is a long-standing Q1
+feature request (quarto-cli#4693, open since 2023-03-08), and the reason Q1 cannot do it is
+filter placement, not design — see also quarto-cli#8345 ("code-folding should be part of
+rendering") and #4675 ("Extend the behavior of DecoratedCodeBlock", so custom writers can handle
+folding). bd-1tl09's Generate/Render split is exactly the architecture those issues ask for, so
+q2 should read fold attributes from any `CodeBlock`. Recorded on bd-g1prx (comment `c-zswhv43a`),
+which supersedes an earlier comment of mine that said the opposite.
+
+### 4. Scope of the echo breakage — wider than reported
+
+| Fixture | Option | q2 result |
+| --- | --- | --- |
+| jupyter, `execute: echo: false` | doc scope | **ignored** — source echoed |
+| jupyter, `#\| echo: false` | cell scope | **ignored** — source echoed |
+| jupyter, `execute: {output: false, warning: false}` + `#\| include: false` | both | **all ignored** — source, stdout, and the `UserWarning` all emitted |
+| knitr, `execute: echo: false` | doc scope | **ignored** — source echoed |
+| knitr, `#\| echo: false` | cell scope | honoured (knitr/R does it) |
+
+### 5. Adjacent observation #1 (engine inference) — confirmed, and slightly worse
+
+A `.qmd` with `{python}` cells and no `engine:` key falls back to the markdown engine, executes
+nothing, and says nothing — `-v` prints no engine-selection or skipped-execution line. Q1 infers
+the jupyter engine and executes.
+
+Beyond the silence, the fallback also leaks the brace syntax into the HTML as a literal class:
+
+```html
+<pre class="{python} code-with-copy"><code>print(&quot;NOENGINE&quot;)</code></pre>
+```
+
+That is a distinct cosmetic bug (a `{python}` CSS class is never meaningful) worth fixing even
+if inference lands later.
+
+Root cause is known and deliberate: `crates/quarto-core/src/engine/detection.rs:20-25` lists
+"code block languages (`{python}` → jupyter)" under *Future Enhancements*.
+
+### 6. Adjacent observation #2 (`embed-resources`) — confirmed, out of scope
+
+`embed-resources: true` has no implementation in q2 (the key exists only in the schema at
+`crates/pampa/test-fixtures/schemas/document-render.yml:34`; no consumer in any crate). A doc
+with `embed-resources: true` still emits `<link rel="stylesheet" href="embed_files/styles.css">`.
+**Per Carlos (2026-08-14), this is deliberately not a Q2 priority — no strand filed, no work
+planned.** Recorded here only so the issue can be answered accurately.
+
+## Root causes
+
+1. **Jupyter — unconditional echo.**
+   `crates/quarto-core/src/engine/jupyter/text_execute.rs:412` `render_cell()` always calls
+   `echoed_source_fence()`, and `format_outputs()` always emits every output. The engine already
+   has the machinery to do better: `resolve_allow_errors()` (`:324`) resolves `error:` via
+   `merge_cell_over_scope(doc_scope, cell_config)`, and `document_execute_scope()` (`:278`)
+   already extracts the document's `execute:` map. `echo` was simply never wired to it —
+   bd-ohvl879u deliberately scoped itself to `error:` and left the rest to follow-ups
+   (bd-moef1ec4 covers `eval`; visibility was never filed until now).
+
+2. **Knitr — document metadata discarded.**
+   `crates/quarto-core/src/engine/knitr/mod.rs:255`:
+
+   ```rust
+   fn build_format_config(ctx: &ExecutionContext) -> KnitrFormatConfig {
+       KnitrFormatConfig::with_defaults(&ctx.format)
+   }
+   ```
+
+   `ExecuteConfig::with_defaults()` (`engine/knitr/format.rs:~370`) hardcodes
+   `echo: Some(Value::Bool(true))`, `warning: Some(true)`, `include: Some(true)`, … The R side
+   *does* consume these (`resources/rmd/hooks.R` reads `code-fold`, `echo`, etc.), so the wire
+   format is fine — nothing ever populates it from the document. Document-scope `execute:` is
+   not merely ignored, it is overwritten with `true`.
+
+3. **`ExecutionContext` carries no document metadata.**
+   `crates/quarto-core/src/engine/context.rs` has `engine_config` (the engine's own sub-map) but
+   not the merged `execute:` scope. Jupyter works around this by re-parsing the front matter out
+   of its own serialized input string (`document_execute_scope`), which knitr cannot reuse
+   because its config crosses a JSON boundary to R. The stage that builds the context
+   (`stage/stages/engine_execution.rs:375`) *does* have the merged AST in hand.
+
+## What Q1 does (the contract to match)
+
+- `src/core/jupyter/tags.ts` — `shouldInclude(cell, options, context)` for
+  `echo | output | warning | include`: **cell option wins over `options.execute[context]`**;
+  absent in both, the format default applies (`echo: true` for plain HTML — verified in
+  bd-cymkcyaf that plain HTML does *not* default echo off; only revealjs/beamer/pptx/dashboard do).
+- `shouldHide(...)` + `keepHidden`: under `render: keep-hidden: true`, hidden content is still
+  emitted but tagged with the `.hidden` class rather than dropped.
+- `echo: "fenced"` is a third value (emit the cell as a fenced ```` ```` ```` block including its
+  YAML options) — `echoFenced()` in the same file.
+- `src/resources/filters/quarto-post/foldcode.lua` — folding applies only to blocks classed
+  `cell-code`, honours a document-level `param("code-fold")` default plus per-block override,
+  maps `true → "hide"`, `show → open`, and propagates a `hidden` class onto the `<details>`.
+
+## Target semantics
+
+Pinned empirically against Q1 (`keep-md: true`, jupyter engine, one cell), then translated into
+q2 terms. **q2 is not required to reproduce Q1's post-engine markdown byte-for-byte** (Carlos,
+2026-08-14) — Q1's shape is inspiration, not contract. What must match is the *observable*
+behaviour, so the tests below assert on semantics, not on Q1's exact fences.
+
+| Option (doc or cell) | Q1 post-engine result | q2 target |
+| --- | --- | --- |
+| `echo: false` | cell div kept, source fence dropped, outputs kept | same |
+| `output: false` | source fence kept, all output divs dropped | same |
+| `warning: false` | `stream`/`stderr` outputs filtered out entirely; stdout kept | same |
+| `include: false` | **nothing emitted at all** — no cell div | same |
+| `echo: false` + `output: false` | **nothing emitted at all** — no empty cell div | same |
+| cell option vs doc scope | cell wins (`shouldInclude`) | same |
+
+The last two rows are the subtle ones. Q1 builds the div opener but only writes it "if there is
+actually content in the div" (`jupyter.ts` ~1466), so a cell whose code *and* outputs are all
+suppressed leaves no wrapper behind. q2's `render_cell` currently emits the wrapper
+unconditionally, so this is a real behavioural item, not a formatting detail.
+
+### Scope — decided (Carlos, 2026-08-14)
+
+Do the **whole visibility family** (`echo`, `output`, `warning`, `include`) for **both jupyter
+and knitr** in one pass. `eval` stays with bd-moef1ec4 (it changes whether the kernel runs, not
+what is shown). `keep-hidden` and `echo: "fenced"` are deferred follow-ups: neither has a
+consumer in q2 today, and `keep-hidden` needs `.hidden` CSS q2 has not ported. (`echo: "fenced"`
+comes nearly free on the knitr side — `execute.R` already sets `fenced.echo` — so forwarding it
+is fine there; the jupyter side is what gets deferred.)
+
+### Key finding that shapes Phase 3
+
+q2's knitr R scripts are **already a faithful port** of Q1's: `resources/rmd/execute.R:307-335`
+reads `format$execute` for `echo` (including `"fenced"`), `warning`, `message`, `include`,
+`output` (mapping `false` → `results="hide"`, `fig.show="hide"`), `eval`, and `error`. Nothing on
+the R side needs to change — the only defect is that nothing populates `format$execute` from the
+document.
+
+**Trap to avoid:** `execute.R` uses `isTRUE(format$execute[["warning"]])` and
+`isTRUE(format$execute[["include"]])`, so an *absent* key reads as **false**, not true. The
+current `ExecuteConfig::with_defaults()` exists precisely to supply those `true`s. Phase 3 must
+therefore **overlay** the document's `execute:` onto the defaults, never replace them — passing
+the document map through verbatim would set `include` to false for every chunk and blank the
+document.
+
+## Work items
+
+TDD throughout: every phase writes its failing test first and confirms it fails.
+
+### Phase 0 — Tests first
+
+- [x] New `crates/quarto-core/tests/integration/engine_visibility.rs` (registered in
+      `main.rs`), modelled on `engine_error_policy.rs`: real engines via `record_capture`,
+      skipping when the engine is unavailable.
+- [x] Jupyter matrix — for each of `echo`/`output`/`warning`/`include`, one doc-scope and one
+      cell-scope test.
+- [x] Precedence: `execute: echo: false` + `#| echo: true` ⇒ source shown (and the mirror,
+      doc-true + cell-false).
+- [x] No-empty-wrapper: `#| echo: false` + `#| output: false` ⇒ no `.cell` div at all.
+- [x] Knitr matrix — doc-scope `echo`/`warning`/`include`/`output`; cell-scope already works, so
+      one cell-scope test as a regression guard.
+- [x] Regression test pinned to the issue's exact fixture (`code-fold: true` + `echo: false`)
+      asserting no `.cell-code` survives.
+- [x] Confirm every new test fails before touching implementation, and that each fails for the
+      *expected* reason (not a harness error).
+
+**Phase 0 result (2026-08-14):** 19 tests, **15 fail / 4 pass**. Every failure is semantic
+("expected source echoed = false, got true", "warning must be filtered out", "cell must leave no
+markup behind") — none is a harness error. The 4 passing are the two no-`execute:`-key default
+guards, `knitr_cell_echo_false_still_hides_source` (knitr resolves `#|` itself), and
+`jupyter_cell_echo_true_overrides_document_echo_false` (passes vacuously today, since echo is
+always on). Knitr's doc-scope tests fail exactly like jupyter's, confirming the second root
+cause independently.
+
+Two content-marker conventions worth keeping if these tests are extended: cell bodies build
+their output by concatenation (`print("O" + "UT")`) so `contains("OUT")` distinguishes output
+from echoed source, and `.cell` is asserted as a *substring* so one check covers the wrapper
+plus everything nested in it.
+
+### Phase 1 — Plumb the merged `execute:` scope into `ExecutionContext`
+
+- [x] Add `execute_scope: Option<ConfigValue>` + `with_execute_scope()` to `ExecutionContext`.
+- [x] Populate it in `engine_execution.rs` from the merged metadata already held there — read
+      per-iteration from `ast.meta`, so a second engine in a sequence sees the front matter of
+      the input it is actually handed (exactly what the old re-parse gave it).
+- [x] Retire `text_execute.rs::document_execute_scope()`'s front-matter re-parse in favour of the
+      field. `front_matter_range` had no other consumer; both are deleted (−1940 bytes), along
+      with the now-unused `InterpretationContext` import.
+
+### Phase 2 — Jupyter honours the visibility family
+
+- [x] `resolve_cell_options()` (replacing `resolve_allow_errors`) returns the merged map once;
+      `resolved_flag()` reads individual keys off it. `error:` now goes through the same path.
+- [x] `CellVisibility { echo, output, warning }` + `resolve()`, mirroring `shouldInclude`: cell
+      option, else doc scope, else `true`.
+- [x] `include: false` ⇒ emit nothing for the cell (`CellVisibility::HIDDEN` collapses the rest,
+      matching Q1's early bail in `mdFromCodeCell`).
+- [x] `echo: false` ⇒ no source fence; `output: false` ⇒ no output divs; `warning: false` ⇒ drop
+      stderr-stream outputs (`is_warning_output`, Q1's `isWarningOutput`).
+- [x] `output: false` also silences warnings — Q1 suppresses every output under it, so the
+      warning channel must not leak past a cell whose outputs were switched off.
+- [x] Suppress the `.cell` wrapper when neither code nor any output survives.
+- [x] 9 new unit tests in `text_execute.rs` covering resolution and emission without a kernel.
+
+### Phase 3 — Knitr receives the document's execute options
+
+- [x] `ExecuteConfig::overlay_document_scope()` (in `format.rs`, beside the struct it maps) and
+      `build_format_config()` applies it over `with_defaults()` — overlay, not replace.
+- [x] Forwards exactly the keys the R scripts read. `freeze` is deliberately skipped: nothing on
+      the R side consumes it (it is resolved before an engine runs).
+- [x] String reads go through `as_plain_text()`, not `as_str()`: `echo: fenced` in front-matter
+      context is stored as `PandocInlines`, for which `as_str()` returns `None` and the option
+      would vanish (the `metadata-as-str` lint documents this trap).
+- [x] `error:` now agrees across engines, and gained two tests in `engine_error_policy.rs`:
+      doc-level `execute: error: true` lets a failing knitr chunk render (it could not before —
+      `with_defaults` pinned `error: false`), and the mirror, that an un-annotated knitr error
+      still fails the render.
+
+### Phase 4 — Verification
+
+- [x] `cargo nextest run --workspace` — **11954 passed**, 197 skipped, 0 failed.
+- [x] Full `cargo xtask verify` (not `--skip-hub-build`, since `ExecutionContext` is in
+      `wasm-quarto-hub-client`'s dependency closure) — **all 14 steps passed**.
+- [x] **End-to-end through the binary** — see the evidence section below.
+- [x] Spot-check `q2 preview` on a visibility-bearing document (full WASM chain via
+      `cargo xtask verify`, then `cargo build --bin q2` to re-embed) — see below.
+- [x] File the deferred follow-ups: **bd-tskkw5dq** (`keep-hidden` + jupyter `echo: "fenced"`)
+      and **bd-42202ipf** (pre-existing capture-splice mis-pairing, found during Phase 2).
+
+## End-to-end evidence (2026-08-14)
+
+Rendered through the real binary, HTML inspected directly — not inferred from exit codes.
+
+**The issue's exact fixture**, `cargo run --bin q2 -- render fold.qmd`:
+
+```html
+<main class="content" id="quarto-document-content">
+…
+<div class="cell">
+<div class="cell-output cell-output-stdout">
+<pre class="code-with-copy"><code>OUTPUT</code></pre>
+</div>
+</div>
+</main>
+```
+
+Only the output. No `sourceCode python` block — matching Q1 on the same file, and closing the
+reported bug.
+
+Three more, same method:
+
+| Fixture | Expectation | Observed |
+| --- | --- | --- |
+| knitr, `execute: echo: false` | source hidden, output kept | 0 `sourceCode` matches; `KNITROUT` present |
+| jupyter, `#\| include: false`, prose either side | no cell markup at all | 0 `class="cell"`; both prose blocks intact |
+| jupyter, `execute: warning: false` | stderr dropped, stdout kept | no `cell-output-stderr` div; `STDOUT_OK` present |
+| jupyter, no `execute:` key | unchanged behaviour | `sourceCode python` present |
+
+*One measurement correction worth recording*: the `warning: false` fixture wrote
+`warnings.warn("WARNME")`, so `grep -c WARNME` returned 1 and briefly looked like a failure. The
+single match was the **echoed source line** (echo is on in that fixture), and the HTML contains
+no `cell-output-stderr` div at all. This is exactly the trap the integration tests avoid by
+splitting content markers across a concatenation — the e2e fixture should have done the same.
+
+### Phase 0 — Tests first
+
+- `crates/quarto-core/tests/integration/` — extend the existing engine-parity suite
+  (`engine_output_parity.rs`) with a visibility matrix: for each of `echo`/`output`/`warning`/
+  `include`, for doc scope and cell scope, for both engines, assert on the rendered markdown.
+- Assert the precedence rule directly: `execute: echo: false` + `#| echo: true` ⇒ shown.
+- A regression test pinned to the issue's exact fixture (`code-fold: true` + `echo: false`)
+  asserting no `.cell-code` block survives.
+- Confirm all of these fail before touching implementation.
+
+### Phase 1 — Plumb the merged `execute:` scope into `ExecutionContext`
+
+- Add `execute_scope: Option<ConfigValue>` + `with_execute_scope()` to `ExecutionContext`.
+- Populate it in `engine_execution.rs` from the merged metadata already held there.
+- Retire `text_execute.rs::document_execute_scope()`'s front-matter re-parse in favour of the
+  field (it exists only because the field did not). Keep `front_matter_range` if still used
+  elsewhere; delete if not.
+
+### Phase 2 — Jupyter honours the visibility family
+
+- Add a `resolve_visibility()` alongside `resolve_allow_errors()`, mirroring Q1's
+  `shouldInclude`: cell option, else doc scope, else default `true`.
+- `render_cell()` takes the resolved flags: skip `echoed_source_fence()` when `echo` is false;
+  skip the whole `::: {.cell}` wrapper when `include` is false; skip outputs when `output` is
+  false; filter stderr/warning outputs when `warning` is false.
+- Q1 parity detail to preserve: a cell with no visible content should not leave an empty
+  `::: {.cell}` div behind (check against Q1's output for `include: false`).
+
+### Phase 3 — Knitr receives the document's execute options
+
+- `build_format_config()` reads `ctx.execute_scope` and populates `ExecuteConfig` (`echo`,
+  `warning`, `error`, `include`, `output`, `fig-*`, `df-print`, …) over the current defaults.
+- Verify the R side actually consumes each key we forward before claiming support for it;
+  forward only what `hooks.R`/`execute.R` reads, and note the rest.
+- Watch the interaction with the existing `error:` policy — jupyter resolves `error` in Rust,
+  knitr in R. They must not disagree.
+
+### Phase 4 — Verification
+
+- `cargo nextest run --workspace`.
+- `cargo xtask verify --skip-hub-build` (Rust-only unless `ExecutionContext` changes ripple into
+  `wasm-quarto-hub-client`; if they do, full `cargo xtask verify`).
+- **End-to-end through the binary**, per CLAUDE.md: render the issue's exact `fold.qmd` with
+  `cargo run --bin q2 -- render fold.qmd`, inspect the HTML, and record the invocation + output
+  snippet in this document.
+- Spot-check `q2 preview` on a visibility-bearing document (needs the full WASM rebuild chain —
+  `npm run build:wasm` → `cargo xtask build-q2-preview-spa` → `cargo build --bin q2`).
+
+### Out of scope (separate strands)
+
+- **`code-fold`** — bd-g1prx (Phase 3 of the bd-1tl09 decorations epic), already planned in
+  `claude-notes/plans/2026-05-19-code-block-features.md`. Annotated there via bd-g1prx comment
+  `c-zswhv43a`: q2 should fold *any* code block, not just `.cell-code`, resolving
+  quarto-cli#4693/#8345/#4675. Doc-level-default scope **decided** (Carlos, 2026-08-14, comment
+  `c-dyfdgmr1`): the document default stays cell-scoped; plain blocks fold only via an
+  affirmative per-block attribute. q2 already parses and forwards that attribute today —
+  ```` ```{.scss code-fold="true"} ```` reaches the writer as `data-code-fold="true"` — so the
+  opt-in needs no parser work, only a Generate-transform reader plus attribute stripping.
+- **Engine inference from cell languages** — bd-fjfizas7 (filed `discovered-from` the main
+  strand), which also covers the literal `{python}` class leak.
+- **`keep-hidden` / `echo: "fenced"`** — follow-ups after Phase 2.
+- **`embed-resources`** — not a Q2 priority; no strand.
+
+## Suggested reply to the reporter
+
+Worth answering, since their isolation step was wrong and someone else may repeat it: the bug is
+real and confirmed, `code-fold` is not the cause (it is unimplemented and inert), the real scope
+is "the execute-visibility options are not implemented for the jupyter engine and document-scope
+`execute:` is dropped by the knitr engine", observation #1 is confirmed and tracked, and
+observation #2 is known but deliberately not prioritized for Quarto 2.
+
+## Reproduction fixtures
+
+Kept inline rather than committed; recreate under any scratch dir.
+
+```yaml
+# fold.qmd — the issue's fixture
+---
+title: t
+format:
+  html:
+    code-fold: true
+engine: jupyter
+execute:
+  echo: false
+---
+```
+followed by a ```` ```{python} ```` cell containing `print("OUTPUT")`.
+
+Variants used: `nofold.qmd` (`format: html`), `cellecho.qmd` (`#| echo: false`, no doc scope),
+`foldecho.qmd` (`code-fold: true`, echo on), `plainfold.qmd` (`code-fold` + non-executable
+block), `knitrecho.qmd` / `knitrcell.qmd` (knitr doc/cell scope), `vis.qmd`
+(`output`/`warning`/`include`), `noengine.qmd` (no `engine:` key).
+
+
+## Preview verification, and a pre-existing bug it exposed
+
+`q2 preview` renders through the WASM client and splices *captured* engine output into the live
+AST, so it needed its own check — the render path passing proves nothing about it (the
+2026-05-20 stale-WASM incident in `CLAUDE.md`).
+
+**The feature works in preview.** A single-file preview of a doc with `execute: echo: false`,
+inspected through CDP in the rendered iframe: `div.cell` = 1, `.cell-code` = 0,
+`pre.sourceCode` = 0, one `.cell-output-stdout` containing `OUTPUT_VISIBLE`. Page text is prose,
+output, prose — no source anywhere.
+
+**The check also confirmed bd-42202ipf empirically** (previously only a code trace). Two
+*adjacent* cells, the first `#| include: false`:
+
+```
+div.cell count: 1
+pre classes: ['sourceCode python :: print("SECOND_CELL_OUTPUT")',
+              'code-with-copy :: SECOND_CELL_OUTPUT',
+              '{python} code-with-copy :: print("SECOND_CELL_OUTPUT")']
+```
+
+The hidden cell's position renders the *second* cell's output; the second cell falls through to
+raw source (note the literal `{python}` class). The second cell's content appears twice, and the
+cell the author hid is the one showing output.
+
+**It is pre-existing.** The same fixture under knitr — whose `include: false` path this work does
+not touch — produces the identical DOM. bd-nn2fou8h only widens which documents reach it.
+
+*Method note:* editing the `.qmd` while `q2 preview` runs did **not** re-capture in single-file
+mode; the page kept showing both cells as raw source, which masks the bug. Restarting the preview
+against the final content is what exposes it.

--- a/crates/quarto-core/src/engine/context.rs
+++ b/crates/quarto-core/src/engine/context.rs
@@ -54,6 +54,21 @@ pub struct ExecutionContext {
     /// this would contain the `{ kernel: python3 }` map.
     pub engine_config: Option<ConfigValue>,
 
+    /// The document's merged `execute:` scope, if it has one.
+    ///
+    /// This is the document-level default every cell option resolves
+    /// against: cell `#|` options merge *over* this map, cell wins
+    /// (Q1's `shouldInclude` in `src/core/jupyter/tags.ts`). It comes
+    /// from the fully merged metadata — `MetadataMergeStage` runs
+    /// before engine execution — so project `_quarto.yml` defaults and
+    /// profile overlays are already folded in.
+    ///
+    /// Engines that need it: jupyter resolves `echo`/`output`/
+    /// `warning`/`include`/`error` against it in Rust; knitr forwards
+    /// it to R as `format$execute`, where `execute.R` builds
+    /// `opts_chunk` from it (bd-nn2fou8h).
+    pub execute_scope: Option<ConfigValue>,
+
     /// Source provenance for the input text.
     ///
     /// Maps byte offsets in the engine's input `&str` back to original source
@@ -97,6 +112,7 @@ impl ExecutionContext {
             format: format.into(),
             quiet: false,
             engine_config: None,
+            execute_scope: None,
             // "no source location known yet" sentinel; `with_source_info`
             // overwrites this with the real qmd serialization range before
             // any consumer reads it.
@@ -140,6 +156,12 @@ impl ExecutionContext {
     ) -> Self {
         self.source_info = source_info;
         self.source_context = source_context;
+        self
+    }
+
+    /// Set the document's merged `execute:` scope (bd-nn2fou8h).
+    pub fn with_execute_scope(mut self, execute_scope: Option<ConfigValue>) -> Self {
+        self.execute_scope = execute_scope;
         self
     }
 }

--- a/crates/quarto-core/src/engine/jupyter/text_execute.rs
+++ b/crates/quarto-core/src/engine/jupyter/text_execute.rs
@@ -15,7 +15,7 @@ use std::path::{Path, PathBuf};
 
 use regex::Regex;
 
-use quarto_pandoc_types::config_value::{ConfigValue, InterpretationContext};
+use quarto_pandoc_types::config_value::ConfigValue;
 use quarto_source_map::SourceInfo;
 
 use super::daemon::daemon;
@@ -177,10 +177,13 @@ async fn execute_blocks_inner(
         .await?;
 
     // Document-level defaults for cell options (bd-ohvl879u): the
-    // input's front matter is the pipeline's fully merged metadata
-    // (MetadataMergeStage runs before engine execution), so its
-    // `execute` map is the scope cell options merge over.
-    let doc_scope = document_execute_scope(input, ctx);
+    // pipeline's fully merged metadata (MetadataMergeStage runs before
+    // engine execution) carries the `execute` map that cell options
+    // merge over. The stage hands it to us directly (bd-nn2fou8h);
+    // this used to be recovered by re-parsing the front matter of our
+    // own serialized input, which only knitr's JSON-to-R boundary made
+    // untenable to share.
+    let doc_scope = ctx.execute_scope.clone();
 
     // Build output by processing blocks in order
     let mut output = String::new();
@@ -221,7 +224,11 @@ async fn execute_blocks_inner(
                     message: format!("cell options are not valid YAML{at}: {e}"),
                 }
             })?;
-        let allow_errors = resolve_allow_errors(doc_scope.as_ref(), cell.options);
+        let resolved = resolve_cell_options(doc_scope.as_ref(), cell.options);
+        // Q1's default `execute: error: false` — a raising cell aborts
+        // unless something opts in.
+        let allow_errors = resolved_flag(resolved.as_ref(), "error", false);
+        let visibility = CellVisibility::resolve(resolved.as_ref());
 
         // Execute the code — the partitioned code only, without the
         // option lines (Q1 strips them too, so cell magics work).
@@ -246,14 +253,19 @@ async fn execute_blocks_inner(
             });
         }
 
-        // Emit the whole cell — echoed (option-stripped) source plus
-        // outputs — in the Quarto-canonical `::: {.cell}` shape.
+        // Emit the visible parts of the cell — echoed (option-stripped)
+        // source plus outputs — in the Quarto-canonical `::: {.cell}`
+        // shape. `begin_cell` runs for every *executed* cell, visible
+        // or not, so figure file names stay keyed to a cell's position
+        // in the document rather than shifting when an earlier cell is
+        // hidden.
         fig.begin_cell();
         output.push_str(&render_cell(
             &block.language,
             &cell.code,
             &exec_result,
             &mut fig,
+            visibility,
         ));
 
         last_end = block.end;
@@ -272,59 +284,17 @@ async fn execute_blocks_inner(
     Ok(result)
 }
 
-/// The `execute` scope of the document's (already merged) metadata,
-/// read from the engine input's front matter. `None` when the input
-/// has no front matter or no `execute` map.
-fn document_execute_scope(input: &str, ctx: &ExecutionContext) -> Option<ConfigValue> {
-    let (start, end) = front_matter_range(input)?;
-    let parent = SourceInfo::substring(ctx.source_info.clone(), start, end);
-    let parsed = match quarto_yaml::parse_with_parent(&input[start..end], parent) {
-        Ok(parsed) => parsed,
-        Err(e) => {
-            // The front matter was serialized by our own pipeline; a
-            // parse failure here is an internal inconsistency, not a
-            // user error — don't take the render down over defaults.
-            tracing::warn!("engine input front matter did not re-parse: {e}");
-            return None;
-        }
-    };
-    let mut collector = pampa::utils::diagnostic_collector::DiagnosticCollector::new();
-    let config = pampa::pandoc::meta::yaml_to_config_value(
-        parsed,
-        InterpretationContext::DocumentMetadata,
-        &mut collector,
-    );
-    config.get("execute").cloned()
-}
-
-/// Byte range of the YAML between the input's leading `---` fence and
-/// its closing `---` line (exclusive of both delimiter lines).
-fn front_matter_range(input: &str) -> Option<(usize, usize)> {
-    let rest = input.strip_prefix("---")?;
-    let rest = rest
-        .strip_prefix("\r\n")
-        .or_else(|| rest.strip_prefix('\n'))?;
-    let fm_start = input.len() - rest.len();
-    let mut search = 0;
-    while let Some(pos) = rest[search..].find("\n---") {
-        let abs = search + pos;
-        let after = &rest[abs + 4..];
-        if after.is_empty() || after.starts_with('\n') || after.starts_with('\r') {
-            // Include the newline that ends the last YAML line.
-            return Some((fm_start, fm_start + abs + 1));
-        }
-        search = abs + 4;
-    }
-    None
-}
-
-/// Resolve the effective `error:` option for one cell: cell options
-/// merged over the document's `execute` scope (cell wins), absent
-/// everywhere = false (Q1's default `execute: error: false`).
-fn resolve_allow_errors(
+/// One cell's options resolved against the document: the cell's `#|`
+/// map merged *over* the document's `execute` scope, so a cell option
+/// wins wherever both set the same key (Q1's `shouldInclude`, and the
+/// scoped resolution bd-ohvl879u introduced for `error:`).
+///
+/// `None` when neither scope supplied anything — callers then fall
+/// back to per-option defaults.
+fn resolve_cell_options(
     doc_scope: Option<&ConfigValue>,
     options: Option<quarto_yaml::YamlWithSourceInfo>,
-) -> bool {
+) -> Option<ConfigValue> {
     let cell_config = options.map(|o| {
         let (config, diagnostics) = options_to_config(o);
         for d in diagnostics {
@@ -333,10 +303,81 @@ fn resolve_allow_errors(
         config
     });
     merge_cell_over_scope(doc_scope, cell_config.as_ref())
-        .as_ref()
-        .and_then(|merged| merged.get("error"))
+}
+
+/// Read a boolean option out of resolved cell options, falling back to
+/// `default` when the key is absent or not a boolean.
+fn resolved_flag(resolved: Option<&ConfigValue>, key: &str, default: bool) -> bool {
+    resolved
+        .and_then(|merged| merged.get(key))
         .and_then(|v| v.as_bool())
-        .unwrap_or(false)
+        .unwrap_or(default)
+}
+
+/// Which parts of a cell reach the output (bd-nn2fou8h).
+///
+/// Mirrors Q1's `shouldInclude` family (`src/core/jupyter/tags.ts`):
+/// each key is resolved cell-over-document and defaults to `true`, so
+/// a document that says nothing keeps today's fully-visible behaviour.
+///
+/// `include: false` is the master switch — Q1 bails on the whole cell
+/// before consulting anything else (`mdFromCodeCell`'s
+/// `if (!includeCell(...)) return []`), which is why [`Self::resolve`]
+/// collapses the other flags rather than leaving callers to remember
+/// the precedence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct CellVisibility {
+    /// Echo the cell's source.
+    echo: bool,
+    /// Emit the cell's outputs.
+    output: bool,
+    /// Keep stderr-stream outputs (Python warnings land there).
+    warning: bool,
+}
+
+impl CellVisibility {
+    /// Everything visible — the default for a cell with no options and
+    /// a document with no `execute:` scope.
+    const VISIBLE: Self = Self {
+        echo: true,
+        output: true,
+        warning: true,
+    };
+
+    /// Nothing at all reaches the output (`include: false`).
+    const HIDDEN: Self = Self {
+        echo: false,
+        output: false,
+        warning: false,
+    };
+
+    fn resolve(resolved: Option<&ConfigValue>) -> Self {
+        // Neither the cell nor the document said anything — the
+        // everything-visible default, which is also what q2 did
+        // before any of these options were honoured.
+        if resolved.is_none() {
+            return Self::VISIBLE;
+        }
+        if !resolved_flag(resolved, "include", true) {
+            return Self::HIDDEN;
+        }
+        Self {
+            echo: resolved_flag(resolved, "echo", true),
+            output: resolved_flag(resolved, "output", true),
+            // Q1 filters stderr under `output: false` too — the option
+            // suppresses every output, warnings included.
+            warning: resolved_flag(resolved, "warning", true)
+                && resolved_flag(resolved, "output", true),
+        }
+    }
+}
+
+/// Whether an output is a "warning" for visibility purposes: a stderr
+/// stream. Mirrors Q1's `isWarningOutput` in
+/// `src/core/jupyter/jupyter.ts` — the kernel gives no richer signal,
+/// so stderr is the whole definition.
+fn is_warning_output(output: &CellOutput) -> bool {
+    matches!(output, CellOutput::Stream { name, .. } if name == "stderr")
 }
 
 /// The first error a cell produced, from its outputs or its status.
@@ -409,17 +450,36 @@ fn ticks_for_code(text: &str) -> String {
 /// engine cell with exactly one wrapper Div, and the Bootstrap CSS
 /// targets `.cell .cell-output-* pre code`. A cell with no outputs
 /// still gets the wrapper (knitr wraps output-less chunks too).
+///
+/// `visibility` (bd-nn2fou8h) decides which halves survive. When it
+/// suppresses *both* the source and every output, the cell emits the
+/// empty string rather than an empty wrapper: `<div class="cell">`
+/// with nothing in it is still a box in the rendered page, and Q1
+/// likewise builds its div opener but writes it only "if there is
+/// actually content in the div" (`jupyter.ts`). knitr behaves the
+/// same way — an `include: false` chunk leaves no wrapper — so this
+/// keeps the two engines agreeing.
 fn render_cell(
     language: &str,
     code: &str,
     result: &KernelExecuteResult,
     fig: &mut FigureWriter,
+    visibility: CellVisibility,
 ) -> String {
-    format!(
-        "::: {{.cell}}\n\n{}\n{}\n:::\n",
-        echoed_source_fence(language, code),
-        format_outputs(result, fig)
-    )
+    let source = if visibility.echo && !code.trim().is_empty() {
+        echoed_source_fence(language, code)
+    } else {
+        String::new()
+    };
+    let outputs = if visibility.output {
+        format_outputs(result, fig, visibility.warning)
+    } else {
+        String::new()
+    };
+    if source.is_empty() && outputs.trim().is_empty() {
+        return String::new();
+    }
+    format!("::: {{.cell}}\n\n{source}\n{outputs}\n:::\n")
 }
 
 /// Reconstruct the echoed source fence for an executed cell.
@@ -565,12 +625,25 @@ impl FigureWriter {
 /// **last** (a matplotlib bundle carries an image plus a text
 /// fallback; the image must win). `text/markdown` and jupyter-widget
 /// payloads remain unhandled (follow-up).
-fn format_outputs(result: &KernelExecuteResult, fig: &mut FigureWriter) -> String {
+fn format_outputs(
+    result: &KernelExecuteResult,
+    fig: &mut FigureWriter,
+    show_warnings: bool,
+) -> String {
     const IMAGE_MIMES: [&str; 3] = ["image/svg+xml", "image/png", "image/jpeg"];
 
     let mut output = String::new();
 
     for cell_output in &result.outputs {
+        // `warning: false` drops stderr streams — where Python's
+        // `warnings` module and most library chatter land. Q1 applies
+        // exactly this filter (`isWarningOutput`: output_type
+        // "stream" with name "stderr") before emitting anything.
+        // Errors are a separate output kind and are never dropped
+        // here; the error *policy* decides those.
+        if !show_warnings && is_warning_output(cell_output) {
+            continue;
+        }
         match cell_output {
             CellOutput::Stream { name, text } => {
                 output.push_str(&fenced_output_div(
@@ -709,6 +782,167 @@ fn strip_ansi_codes(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // === bd-nn2fou8h: execute-visibility resolution ===
+    //
+    // Resolution and emission are unit-testable without a kernel; the
+    // end-to-end matrix (both engines, doc and cell scope) lives in
+    // `tests/integration/engine_visibility.rs`.
+
+    /// Build resolved cell options from YAML source, as
+    /// `resolve_cell_options` would after merging.
+    fn resolved(yaml: &str) -> Option<ConfigValue> {
+        let parsed = quarto_yaml::parse(yaml).expect("test YAML parses");
+        let (config, _) = options_to_config(parsed);
+        Some(config)
+    }
+
+    fn result_with(outputs: Vec<CellOutput>) -> KernelExecuteResult {
+        KernelExecuteResult {
+            status: ExecuteStatus::Ok,
+            outputs,
+            execution_count: Some(1),
+        }
+    }
+
+    fn stream(name: &str, text: &str) -> CellOutput {
+        CellOutput::Stream {
+            name: name.to_string(),
+            text: text.to_string(),
+        }
+    }
+
+    fn render(code: &str, outputs: Vec<CellOutput>, visibility: CellVisibility) -> String {
+        let mut fig = FigureWriter::new(Path::new("/nonexistent/doc.qmd"));
+        render_cell("python", code, &result_with(outputs), &mut fig, visibility)
+    }
+
+    #[test]
+    fn test_visibility_defaults_to_fully_visible() {
+        assert_eq!(CellVisibility::resolve(None), CellVisibility::VISIBLE);
+        assert_eq!(
+            CellVisibility::resolve(resolved("error: true").as_ref()),
+            CellVisibility::VISIBLE,
+            "an unrelated option must not change visibility"
+        );
+    }
+
+    #[test]
+    fn test_visibility_reads_each_key() {
+        assert!(!CellVisibility::resolve(resolved("echo: false").as_ref()).echo);
+        assert!(!CellVisibility::resolve(resolved("output: false").as_ref()).output);
+        assert!(!CellVisibility::resolve(resolved("warning: false").as_ref()).warning);
+        // Independence: hiding one must not hide the others.
+        let v = CellVisibility::resolve(resolved("echo: false").as_ref());
+        assert!(v.output && v.warning);
+    }
+
+    #[test]
+    fn test_include_false_hides_everything() {
+        assert_eq!(
+            CellVisibility::resolve(resolved("include: false").as_ref()),
+            CellVisibility::HIDDEN
+        );
+        // include: false wins even when another key says "show me".
+        assert_eq!(
+            CellVisibility::resolve(resolved("include: false\necho: true").as_ref()),
+            CellVisibility::HIDDEN
+        );
+    }
+
+    /// `output: false` suppresses every output, warnings included — so
+    /// a cell must not leak stderr through the warning channel after
+    /// its outputs were switched off.
+    #[test]
+    fn test_output_false_implies_warnings_hidden() {
+        let v = CellVisibility::resolve(resolved("output: false\nwarning: true").as_ref());
+        assert!(!v.warning, "output: false must also silence warnings");
+    }
+
+    #[test]
+    fn test_render_cell_omits_source_when_echo_false() {
+        let md = render(
+            "print(1)",
+            vec![stream("stdout", "1")],
+            CellVisibility {
+                echo: false,
+                ..CellVisibility::VISIBLE
+            },
+        );
+        assert!(!md.contains(".cell-code"), "no source fence; got:\n{md}");
+        assert!(!md.contains("print(1)"), "no source text; got:\n{md}");
+        assert!(md.contains("::: {.cell}"), "wrapper kept; got:\n{md}");
+        assert!(md.contains("cell-output-stdout"), "output kept; got:\n{md}");
+    }
+
+    #[test]
+    fn test_render_cell_omits_outputs_when_output_false() {
+        let md = render(
+            "print(1)",
+            vec![stream("stdout", "1")],
+            CellVisibility {
+                output: false,
+                ..CellVisibility::VISIBLE
+            },
+        );
+        assert!(md.contains(".cell-code"), "source kept; got:\n{md}");
+        assert!(!md.contains("cell-output"), "no output div; got:\n{md}");
+    }
+
+    #[test]
+    fn test_render_cell_drops_stderr_when_warning_false() {
+        let md = render(
+            "warn()",
+            vec![
+                stream("stderr", "UserWarning: boom"),
+                stream("stdout", "ok"),
+            ],
+            CellVisibility {
+                warning: false,
+                ..CellVisibility::VISIBLE
+            },
+        );
+        assert!(!md.contains("boom"), "stderr dropped; got:\n{md}");
+        assert!(md.contains("ok"), "stdout kept; got:\n{md}");
+    }
+
+    /// Nothing visible ⇒ no wrapper at all. An empty `::: {.cell}`
+    /// still paints a `<div class="cell">` box in the output.
+    #[test]
+    fn test_render_cell_emits_nothing_when_fully_hidden() {
+        assert_eq!(
+            render(
+                "print(1)",
+                vec![stream("stdout", "1")],
+                CellVisibility::HIDDEN
+            ),
+            ""
+        );
+        // Same when echo and output are individually off rather than
+        // via include.
+        assert_eq!(
+            render(
+                "print(1)",
+                vec![stream("stdout", "1")],
+                CellVisibility {
+                    echo: false,
+                    output: false,
+                    warning: false,
+                }
+            ),
+            ""
+        );
+    }
+
+    /// An output-less cell keeps its wrapper as long as the source is
+    /// echoed — knitr wraps output-less chunks too, and the preview
+    /// capture splice pairs cells to wrappers.
+    #[test]
+    fn test_render_cell_keeps_wrapper_for_output_less_cell() {
+        let md = render("x = 1", vec![], CellVisibility::VISIBLE);
+        assert!(md.contains("::: {.cell}"), "wrapper kept; got:\n{md}");
+        assert!(md.contains(".cell-code"), "source kept; got:\n{md}");
+    }
 
     #[test]
     fn test_parse_code_blocks_single() {
@@ -889,7 +1123,7 @@ print("hello")
             text: "Hello, World!\n".to_string(),
         }]);
         assert_eq!(
-            format_outputs(&result, &mut test_fig()),
+            format_outputs(&result, &mut test_fig(), true),
             "\n::: {.cell-output .cell-output-stdout}\n\n```\nHello, World!\n```\n\n:::\n"
         );
     }
@@ -901,7 +1135,7 @@ print("hello")
             text: "warning\n".to_string(),
         }]);
         assert_eq!(
-            format_outputs(&result, &mut test_fig()),
+            format_outputs(&result, &mut test_fig(), true),
             "\n::: {.cell-output .cell-output-stderr}\n\n```\nwarning\n```\n\n:::\n"
         );
     }
@@ -916,7 +1150,7 @@ print("hello")
             metadata: serde_json::json!({}),
         }]);
         assert_eq!(
-            format_outputs(&result, &mut test_fig()),
+            format_outputs(&result, &mut test_fig(), true),
             "\n::: {.cell-output .cell-output-display}\n\n```\n5\n```\n\n:::\n"
         );
     }
@@ -930,7 +1164,7 @@ print("hello")
             metadata: serde_json::json!({}),
         }]);
         assert_eq!(
-            format_outputs(&result, &mut test_fig()),
+            format_outputs(&result, &mut test_fig(), true),
             "\n::: {.cell-output .cell-output-display}\n\n```{=html}\n<b>5</b>\n```\n\n:::\n"
         );
     }
@@ -943,7 +1177,7 @@ print("hello")
             traceback: vec!["Traceback...".to_string()],
         }]);
         assert_eq!(
-            format_outputs(&result, &mut test_fig()),
+            format_outputs(&result, &mut test_fig(), true),
             "\n::: {.cell-output .cell-output-error}\n\n```\nNameError: name 'x' is not defined\nTraceback...\n```\n\n:::\n"
         );
     }
@@ -957,7 +1191,7 @@ print("hello")
             text: "```\n".to_string(),
         }]);
         assert_eq!(
-            format_outputs(&result, &mut test_fig()),
+            format_outputs(&result, &mut test_fig(), true),
             "\n::: {.cell-output .cell-output-stdout}\n\n````\n```\n````\n\n:::\n"
         );
     }
@@ -970,7 +1204,13 @@ print("hello")
             metadata: serde_json::json!({}),
         }]);
         assert_eq!(
-            render_cell("python", "2 + 3\n", &result, &mut test_fig()),
+            render_cell(
+                "python",
+                "2 + 3\n",
+                &result,
+                &mut test_fig(),
+                CellVisibility::VISIBLE,
+            ),
             "::: {.cell}\n\n```{.python .cell-code}\n2 + 3\n```\n\n::: {.cell-output .cell-output-display}\n\n```\n5\n```\n\n:::\n\n:::\n"
         );
     }
@@ -1000,7 +1240,7 @@ print("hello")
             metadata: serde_json::json!({}),
         }]);
 
-        let md = format_outputs(&result, &mut test_fig());
+        let md = format_outputs(&result, &mut test_fig(), true);
         assert!(
             !md.contains("<Figure size"),
             "image must beat the text/plain fallback; got:\n{md}"
@@ -1030,7 +1270,7 @@ print("hello")
             metadata: serde_json::json!({}),
         }]);
 
-        let md = format_outputs(&result, &mut fig);
+        let md = format_outputs(&result, &mut fig, true);
         assert_eq!(
             md,
             "\n::: {.cell-output-display}\n\n![](pyfig_files/figure-html/cell-1-output-1.png)\n\n:::\n"
@@ -1067,7 +1307,7 @@ print("hello")
             metadata: serde_json::json!({}),
         }]);
 
-        let md = format_outputs(&result, &mut fig);
+        let md = format_outputs(&result, &mut fig, true);
         assert!(
             md.contains("![](doc_files/figure-html/cell-1-output-1.svg)"),
             "got:\n{md}"
@@ -1095,7 +1335,7 @@ print("hello")
             metadata: serde_json::json!({}),
         }]);
 
-        let md = format_outputs(&result, &mut test_fig());
+        let md = format_outputs(&result, &mut test_fig(), true);
         assert!(md.contains("{=html}"), "html must win; got:\n{md}");
         assert!(!md.contains("![]("), "no image when html wins; got:\n{md}");
     }
@@ -1119,7 +1359,7 @@ print("hello")
         };
         let result = ok_result(vec![png_output(), png_output()]);
 
-        let md = format_outputs(&result, &mut fig);
+        let md = format_outputs(&result, &mut fig, true);
         assert!(md.contains("cell-1-output-1.png"), "got:\n{md}");
         assert!(md.contains("cell-1-output-2.png"), "got:\n{md}");
         assert!(
@@ -1145,7 +1385,7 @@ print("hello")
             metadata: serde_json::json!({}),
         }]);
 
-        let md = format_outputs(&result, &mut test_fig());
+        let md = format_outputs(&result, &mut test_fig(), true);
         assert!(md.contains("fallback"), "got:\n{md}");
         assert!(!md.contains("[Image output]"), "got:\n{md}");
     }
@@ -1161,7 +1401,7 @@ print("hello")
             metadata: serde_json::json!({}),
         }]);
         assert_eq!(
-            format_outputs(&result, &mut test_fig()),
+            format_outputs(&result, &mut test_fig(), true),
             "\n::: {.cell-output .cell-output-display}\n\n[Image output]\n\n:::\n"
         );
     }
@@ -1201,7 +1441,7 @@ print("hello")
             metadata: serde_json::json!({}),
         }]);
         assert_eq!(
-            format_outputs(&result, &mut test_fig()),
+            format_outputs(&result, &mut test_fig(), true),
             "\n::: {.cell-output .cell-output-display}\n\n```\n42\n```\n\n:::\n"
         );
     }
@@ -1214,7 +1454,13 @@ print("hello")
         // too.
         let result = ok_result(vec![]);
         assert_eq!(
-            render_cell("python", "x = 1\n", &result, &mut test_fig()),
+            render_cell(
+                "python",
+                "x = 1\n",
+                &result,
+                &mut test_fig(),
+                CellVisibility::VISIBLE,
+            ),
             "::: {.cell}\n\n```{.python .cell-code}\nx = 1\n```\n\n:::\n"
         );
     }

--- a/crates/quarto-core/src/engine/knitr/format.rs
+++ b/crates/quarto-core/src/engine/knitr/format.rs
@@ -32,8 +32,10 @@
 
 use std::collections::HashMap;
 
+use quarto_pandoc_types::ConfigValue;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use yaml_rust2::Yaml;
 
 /// Complete format configuration for knitr execution.
 ///
@@ -295,11 +297,214 @@ impl ExecuteConfig {
             extra: HashMap::new(),
         }
     }
+
+    /// Overlay the document's merged `execute:` scope onto these
+    /// defaults (bd-nn2fou8h).
+    ///
+    /// **Overlay, never replace.** `resources/rmd/execute.R` reads
+    /// several keys through `isTRUE(...)`, so an *absent* key there
+    /// means **false**, not "unset":
+    ///
+    /// ```r
+    /// warning = isTRUE(format$execute[["warning"]]),
+    /// include = isTRUE(format$execute[["include"]]),
+    /// ```
+    ///
+    /// [`Self::with_defaults`] exists precisely to supply those
+    /// `true`s. Handing R the document's `execute:` map verbatim would
+    /// therefore set `include` to false for every chunk and render a
+    /// blank document — which is why this method starts from the
+    /// defaults and only overwrites keys the document actually set.
+    ///
+    /// Keys are exactly the ones the R scripts read (`execute.R`
+    /// `opts_chunk`, `hooks.R`). `freeze` is deliberately not
+    /// forwarded: nothing on the R side consumes it — it is resolved
+    /// higher up, before an engine ever runs.
+    pub fn overlay_document_scope(&mut self, scope: &ConfigValue) {
+        if let Some(v) = number(scope, "fig-width") {
+            self.fig_width = Some(v);
+        }
+        if let Some(v) = number(scope, "fig-height") {
+            self.fig_height = Some(v);
+        }
+        if let Some(v) = number(scope, "fig-asp") {
+            self.fig_asp = Some(v);
+        }
+        if let Some(v) = number(scope, "fig-dpi") {
+            self.fig_dpi = Some(v as u32);
+        }
+        if let Some(v) = text(scope, "fig-format") {
+            self.fig_format = Some(v);
+        }
+        if let Some(v) = text(scope, "df-print") {
+            self.df_print = Some(v);
+        }
+        if let Some(v) = flag(scope, "eval") {
+            self.eval = Some(v);
+        }
+        if let Some(v) = flag(scope, "warning") {
+            self.warning = Some(v);
+        }
+        if let Some(v) = flag(scope, "error") {
+            self.error = Some(v);
+        }
+        if let Some(v) = flag(scope, "include") {
+            self.include = Some(v);
+        }
+        if let Some(v) = flag(scope, "enabled") {
+            self.enabled = Some(v);
+        }
+        if let Some(v) = flag(scope, "debug") {
+            self.debug = Some(v);
+        }
+        // Tri-state keys: a boolean or a keyword (`echo: fenced`,
+        // `output: asis`). `execute.R` compares both forms.
+        if let Some(v) = flag_or_keyword(scope, "echo") {
+            self.echo = Some(v);
+        }
+        if let Some(v) = flag_or_keyword(scope, "output") {
+            self.output = Some(v);
+        }
+        if let Some(v) = flag_or_keyword(scope, "cache") {
+            self.cache = Some(v);
+        }
+    }
+}
+
+fn flag(scope: &ConfigValue, key: &str) -> Option<bool> {
+    scope.get(key)?.as_bool()
+}
+
+/// A string-valued option. Uses `as_plain_text`, not `as_str`: a bare
+/// YAML string in document-metadata context is stored as
+/// `ConfigValueKind::PandocInlines`, for which `as_str` returns `None`
+/// and the option would be silently dropped (the `metadata-as-str`
+/// lint exists for exactly this trap).
+fn text(scope: &ConfigValue, key: &str) -> Option<String> {
+    scope.get(key)?.as_plain_text()
+}
+
+/// A numeric option, accepting both YAML integer and real spellings
+/// (`fig-width: 7` and `fig-width: 7.5`).
+fn number(scope: &ConfigValue, key: &str) -> Option<f64> {
+    let value = scope.get(key)?;
+    if let Some(i) = value.as_int() {
+        return Some(i as f64);
+    }
+    match value.as_yaml()? {
+        Yaml::Real(s) => s.parse::<f64>().ok(),
+        _ => None,
+    }
+}
+
+/// An option that is either a boolean or a keyword string, preserved
+/// as-is for the R side to compare (`echo: fenced`, `output: asis`).
+fn flag_or_keyword(scope: &ConfigValue, key: &str) -> Option<Value> {
+    let value = scope.get(key)?;
+    if let Some(b) = value.as_bool() {
+        return Some(Value::Bool(b));
+    }
+    value.as_plain_text().map(Value::String)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // === bd-nn2fou8h: document `execute:` scope overlay ===
+
+    /// A document `execute:` map, as the pipeline hands it to the
+    /// engine.
+    fn scope(yaml: &str) -> ConfigValue {
+        let parsed = quarto_yaml::parse(yaml).expect("test YAML parses");
+        let (config, _) = crate::cell_options::options_to_config(parsed);
+        config
+    }
+
+    fn overlaid(yaml: &str) -> ExecuteConfig {
+        let mut execute = ExecuteConfig::with_defaults();
+        execute.overlay_document_scope(&scope(yaml));
+        execute
+    }
+
+    /// The trap this method exists to avoid: `execute.R` reads
+    /// `include`/`warning` through `isTRUE()`, so dropping the
+    /// defaults for keys the document didn't mention would render a
+    /// blank document.
+    #[test]
+    fn test_overlay_preserves_defaults_for_untouched_keys() {
+        let execute = overlaid("echo: false");
+        assert_eq!(execute.echo, Some(Value::Bool(false)), "echo overridden");
+        assert_eq!(execute.include, Some(true), "include default preserved");
+        assert_eq!(execute.warning, Some(true), "warning default preserved");
+        assert_eq!(execute.eval, Some(true), "eval default preserved");
+        assert_eq!(execute.error, Some(false), "error default preserved");
+        assert_eq!(execute.fig_width, Some(7.0), "fig-width default preserved");
+    }
+
+    #[test]
+    fn test_overlay_reads_booleans() {
+        let execute = overlaid("warning: false\ninclude: false\nerror: true\neval: false");
+        assert_eq!(execute.warning, Some(false));
+        assert_eq!(execute.include, Some(false));
+        assert_eq!(execute.error, Some(true));
+        assert_eq!(execute.eval, Some(false));
+    }
+
+    /// `echo` and `output` are tri-state: the keyword forms must reach
+    /// R intact, because `execute.R` compares them by string
+    /// (`identical(format$execute[["echo"]], "fenced")`).
+    #[test]
+    fn test_overlay_preserves_keyword_forms() {
+        assert_eq!(
+            overlaid("echo: fenced").echo,
+            Some(Value::String("fenced".to_string()))
+        );
+        assert_eq!(
+            overlaid("output: asis").output,
+            Some(Value::String("asis".to_string()))
+        );
+        assert_eq!(overlaid("output: false").output, Some(Value::Bool(false)));
+    }
+
+    /// Numbers arrive as YAML integers or reals; both must land as
+    /// `f64` rather than being silently dropped.
+    #[test]
+    fn test_overlay_reads_numbers_in_both_spellings() {
+        let execute = overlaid("fig-width: 9.5\nfig-height: 4\nfig-dpi: 300");
+        assert_eq!(execute.fig_width, Some(9.5), "real");
+        assert_eq!(execute.fig_height, Some(4.0), "integer");
+        assert_eq!(execute.fig_dpi, Some(300));
+    }
+
+    #[test]
+    fn test_overlay_reads_strings() {
+        assert_eq!(
+            overlaid("df-print: kable").df_print,
+            Some("kable".to_string())
+        );
+        assert_eq!(
+            overlaid("fig-format: svg").fig_format,
+            Some("svg".to_string())
+        );
+    }
+
+    /// `freeze` is resolved before an engine runs and no R code reads
+    /// it, so it is deliberately not forwarded.
+    #[test]
+    fn test_overlay_does_not_forward_freeze() {
+        assert_eq!(overlaid("freeze: true").freeze, None);
+    }
+
+    /// The overlaid config still serializes under the kebab-case names
+    /// the R scripts index by.
+    #[test]
+    fn test_overlaid_config_serializes_with_kebab_case_keys() {
+        let json = serde_json::to_value(overlaid("echo: false\nfig-width: 9.5")).unwrap();
+        assert_eq!(json["echo"], Value::Bool(false));
+        assert_eq!(json["fig-width"], serde_json::json!(9.5));
+        assert_eq!(json["include"], Value::Bool(true));
+    }
 
     #[test]
     fn test_format_config_serialization() {

--- a/crates/quarto-core/src/engine/knitr/mod.rs
+++ b/crates/quarto-core/src/engine/knitr/mod.rs
@@ -251,9 +251,19 @@ impl ExecutionEngine for KnitrEngine {
 
 /// Build format configuration from execution context.
 ///
-/// Creates a [`KnitrFormatConfig`] with settings appropriate for the target format.
+/// Creates a [`KnitrFormatConfig`] with settings appropriate for the target format,
+/// then overlays the document's merged `execute:` scope on top (bd-nn2fou8h).
+///
+/// Before that overlay this function ignored the document entirely, so
+/// `execute: echo: false` was not merely dropped — the hardcoded
+/// `echo: true` default actively overrode it, and every document-scope
+/// execute option was inert for knitr (GH issue #523).
 fn build_format_config(ctx: &ExecutionContext) -> KnitrFormatConfig {
-    KnitrFormatConfig::with_defaults(&ctx.format)
+    let mut config = KnitrFormatConfig::with_defaults(&ctx.format);
+    if let Some(scope) = ctx.execute_scope.as_ref() {
+        config.execute.overlay_document_scope(scope);
+    }
+    config
 }
 
 /// Post-process knitr markdown output.

--- a/crates/quarto-core/src/stage/stages/engine_execution.rs
+++ b/crates/quarto-core/src/stage/stages/engine_execution.rs
@@ -384,6 +384,13 @@ impl PipelineStage for EngineExecutionStage {
                 Some(ctx.project.dir.clone())
             })
             .with_engine_config(engine_config)
+            // The document's merged `execute:` scope — the default every
+            // cell option resolves against (bd-nn2fou8h). Read from the
+            // AST being serialized *this* iteration, so a second engine
+            // in a sequence sees the front matter of the input it is
+            // actually given, exactly as the jupyter engine's old
+            // front-matter re-parse did.
+            .with_execute_scope(ast.meta.get("execute").cloned())
             .with_source_info(qmd_source_info, source_context_arc.clone())
             .with_project_env({
                 let mut pairs = crate::project::environment::env_for_subprocess(&ctx.project_env);

--- a/crates/quarto-core/tests/integration/engine_error_policy.rs
+++ b/crates/quarto-core/tests/integration/engine_error_policy.rs
@@ -114,6 +114,46 @@ fn document_execute_error_true_allows_plain_cell_error() {
     );
 }
 
+/// knitr's half of the doc-level allow (bd-nn2fou8h). The two engines
+/// must agree on `execute: error: true`, and until the document's
+/// `execute:` scope reached knitr they could not: `build_format_config`
+/// ignored the document and `ExecuteConfig::with_defaults` pinned
+/// `error: false`, so R halted on the failing chunk no matter what the
+/// front matter said.
+#[test]
+fn knitr_document_execute_error_true_allows_plain_cell_error() {
+    if !engine_available("knitr") {
+        eprintln!("Skipping test: knitr not available");
+        return;
+    }
+    let captures = run(
+        "---\ntitle: Error policy\nengine: knitr\nexecute:\n  error: true\n---\n\nBefore.\n\n```{r}\nstop(\"boom\")\n```\n",
+    )
+    .expect("document-level execute.error: true must allow the render to proceed under knitr too");
+    let md = result_markdown(&captures);
+    assert!(
+        md.contains("boom"),
+        "error text must be embedded under doc-level allow; got:\n{md}"
+    );
+}
+
+/// The mirror: with no `execute: error:` anywhere, knitr must still
+/// fail the render — the overlay must not have loosened the default.
+#[test]
+fn knitr_plain_cell_error_still_fails_the_render() {
+    if !engine_available("knitr") {
+        eprintln!("Skipping test: knitr not available");
+        return;
+    }
+    let result = run(
+        "---\ntitle: Error policy\nengine: knitr\n---\n\nBefore.\n\n```{r}\nstop(\"boom\")\n```\n",
+    );
+    assert!(
+        result.is_err(),
+        "an un-annotated cell error must still fail the render under knitr"
+    );
+}
+
 #[test]
 fn cell_error_false_overrides_document_allow() {
     if !engine_available("jupyter") {

--- a/crates/quarto-core/tests/integration/engine_visibility.rs
+++ b/crates/quarto-core/tests/integration/engine_visibility.rs
@@ -1,0 +1,435 @@
+//! bd-nn2fou8h: execute-visibility options (`echo`, `output`,
+//! `warning`, `include`) must be honoured by both engines, at document
+//! scope (`execute:`) and at cell scope (`#|`), with the cell winning.
+//!
+//! Reported as GH issue #523 ("`code-fold: true` silently overrides
+//! `execute: echo: false`"). `code-fold` was a red herring — it is
+//! unimplemented and inert; the real defect is that jupyter ignored the
+//! whole family and knitr discarded document-scope `execute:` entirely.
+//!
+//! Drives the real engines through `record_capture` (the same producer
+//! path `q2 render` / `q2 preview` / `q2 provide-hub` use) and asserts
+//! on the post-engine markdown, mirroring `engine_error_policy.rs`.
+//! Tests skip when the engine isn't installed.
+//!
+//! **Assertion style.** q2 is not required to reproduce Q1's
+//! post-engine markdown byte-for-byte, so these tests assert on
+//! observable semantics — "is the source echoed", "did the warning
+//! survive" — via the structural markers downstream consumers key on
+//! (`.cell`, `.cell-code`, `.cell-output`) plus content markers.
+//!
+//! **Content markers are split across concatenation on purpose.** A
+//! cell whose body reads `print("O" + "UT")` produces the output text
+//! `OUT` while its *source* contains no `OUT` substring, so a single
+//! `contains("OUT")` distinguishes "the output survived" from "the
+//! echoed source survived". Writing `print("OUT")` instead would make
+//! every output assertion silently also match the echo.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use quarto_core::engine::EngineRegistry;
+use quarto_core::engine::preview_record::record_capture;
+use quarto_core::project::ProjectContext;
+use quarto_system_runtime::{NativeRuntime, SystemRuntime};
+
+fn engine_available(name: &str) -> bool {
+    EngineRegistry::default()
+        .get(name)
+        .is_some_and(|e| e.is_available())
+}
+
+fn fixture(
+    content: &str,
+) -> (
+    tempfile::TempDir,
+    PathBuf,
+    ProjectContext,
+    Arc<dyn SystemRuntime>,
+) {
+    let dir = tempfile::tempdir().unwrap();
+    let qmd_path = dir.path().join("doc.qmd");
+    std::fs::write(&qmd_path, content).unwrap();
+    let runtime: Arc<dyn SystemRuntime> = Arc::new(NativeRuntime::new());
+    let project = ProjectContext::discover(&qmd_path, runtime.as_ref()).unwrap();
+    (dir, qmd_path, project, runtime)
+}
+
+/// Post-engine markdown for `content`, or a panic with the engine error.
+fn run(content: &str) -> String {
+    let (_tmp, path, project, runtime) = fixture(content);
+    let captures = pollster::block_on(record_capture(&path, &project, runtime, None))
+        .unwrap_or_else(|e| panic!("record_capture failed: {e:?}"));
+    assert_eq!(captures.len(), 1, "expected exactly one engine capture");
+    captures[0]
+        .result
+        .get("markdown")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string()
+}
+
+// ---------------------------------------------------------------------
+// Document fixtures
+//
+// `OUT` is produced only at runtime (see the module note on split
+// markers); `SRCMARK` appears only in the source. Prose before and
+// after the cell proves the document itself rendered when a cell is
+// expected to vanish entirely.
+// ---------------------------------------------------------------------
+
+/// Python cell printing `OUT`; its source contains `SRCMARK` but no
+/// literal `OUT`.
+const PY_CELL: &str = "SRCMARK = \"O\" + \"UT\"\nprint(SRCMARK)";
+
+/// R cell printing `OUT`; same split-marker property.
+const R_CELL: &str = "SRCMARK <- paste0(\"O\", \"UT\")\ncat(SRCMARK, \"\\n\")";
+
+/// Python cell emitting a stderr warning (`WARNME`) *and* stdout
+/// (`OUT`), so a warning-only assertion can tell the two apart.
+const PY_WARN_CELL: &str =
+    "import warnings\nwarnings.warn(\"WARN\" + \"ME\")\nprint(\"O\" + \"UT\")";
+
+/// R equivalent of [`PY_WARN_CELL`].
+const R_WARN_CELL: &str = "warning(\"WARN\", \"ME\")\ncat(paste0(\"O\", \"UT\"), \"\\n\")";
+
+fn doc(engine: &str, lang: &str, doc_execute: &str, cell_options: &str, cell: &str) -> String {
+    format!(
+        "---\ntitle: Visibility\nengine: {engine}\n{doc_execute}---\n\nBefore.\n\n\
+         ```{{{lang}}}\n{cell_options}{cell}\n```\n\nAfter.\n"
+    )
+}
+
+fn jupyter_doc(doc_execute: &str, cell_options: &str) -> String {
+    doc("jupyter", "python", doc_execute, cell_options, PY_CELL)
+}
+
+fn knitr_doc(doc_execute: &str, cell_options: &str) -> String {
+    doc("knitr", "r", doc_execute, cell_options, R_CELL)
+}
+
+/// Both prose blocks survived — i.e. the document rendered and only the
+/// cell's visibility is under test.
+fn assert_prose_intact(md: &str) {
+    assert!(
+        md.contains("Before.") && md.contains("After."),
+        "surrounding prose must be untouched; got:\n{md}"
+    );
+}
+
+fn assert_source_echoed(md: &str, echoed: bool) {
+    assert_eq!(
+        md.contains(".cell-code"),
+        echoed,
+        "expected source echoed = {echoed}; got:\n{md}"
+    );
+    assert_eq!(
+        md.contains("SRCMARK"),
+        echoed,
+        "expected cell source text present = {echoed}; got:\n{md}"
+    );
+}
+
+fn assert_output_present(md: &str, present: bool) {
+    assert_eq!(
+        md.contains("OUT"),
+        present,
+        "expected cell output present = {present}; got:\n{md}"
+    );
+}
+
+/// No trace of the cell at all — not even an empty `.cell` wrapper.
+/// `.cell` is a prefix of `.cell-code`/`.cell-output`, so this single
+/// check covers the wrapper and everything that could live inside it.
+fn assert_no_cell_at_all(md: &str) {
+    assert!(
+        !md.contains(".cell"),
+        "cell must leave no markup behind (not even an empty wrapper); got:\n{md}"
+    );
+    assert!(
+        !md.contains("SRCMARK") && !md.contains("OUT"),
+        "neither source nor output may survive; got:\n{md}"
+    );
+    assert_prose_intact(md);
+}
+
+// =====================================================================
+// Jupyter — document scope
+// =====================================================================
+
+#[test]
+fn jupyter_doc_echo_false_hides_source_keeps_output() {
+    if !engine_available("jupyter") {
+        eprintln!("Skipping test: jupyter not available");
+        return;
+    }
+    let md = run(&jupyter_doc("execute:\n  echo: false\n", ""));
+    assert_source_echoed(&md, false);
+    assert_output_present(&md, true);
+    assert_prose_intact(&md);
+}
+
+#[test]
+fn jupyter_doc_output_false_hides_output_keeps_source() {
+    if !engine_available("jupyter") {
+        eprintln!("Skipping test: jupyter not available");
+        return;
+    }
+    let md = run(&jupyter_doc("execute:\n  output: false\n", ""));
+    assert_source_echoed(&md, true);
+    assert_output_present(&md, false);
+    assert!(
+        !md.contains(".cell-output"),
+        "no output div may survive output: false; got:\n{md}"
+    );
+}
+
+#[test]
+fn jupyter_doc_warning_false_drops_stderr_keeps_stdout() {
+    if !engine_available("jupyter") {
+        eprintln!("Skipping test: jupyter not available");
+        return;
+    }
+    let md = run(&doc(
+        "jupyter",
+        "python",
+        "execute:\n  warning: false\n",
+        "",
+        PY_WARN_CELL,
+    ));
+    assert!(
+        !md.contains("WARNME"),
+        "stderr warning must be filtered out; got:\n{md}"
+    );
+    assert!(
+        md.contains("OUT"),
+        "stdout must survive warning: false; got:\n{md}"
+    );
+}
+
+#[test]
+fn jupyter_doc_include_false_emits_nothing() {
+    if !engine_available("jupyter") {
+        eprintln!("Skipping test: jupyter not available");
+        return;
+    }
+    let md = run(&jupyter_doc("execute:\n  include: false\n", ""));
+    assert_no_cell_at_all(&md);
+}
+
+// =====================================================================
+// Jupyter — cell scope
+// =====================================================================
+
+#[test]
+fn jupyter_cell_echo_false_hides_source_keeps_output() {
+    if !engine_available("jupyter") {
+        eprintln!("Skipping test: jupyter not available");
+        return;
+    }
+    let md = run(&jupyter_doc("", "#| echo: false\n"));
+    assert_source_echoed(&md, false);
+    assert_output_present(&md, true);
+}
+
+#[test]
+fn jupyter_cell_output_false_hides_output_keeps_source() {
+    if !engine_available("jupyter") {
+        eprintln!("Skipping test: jupyter not available");
+        return;
+    }
+    let md = run(&jupyter_doc("", "#| output: false\n"));
+    assert_source_echoed(&md, true);
+    assert_output_present(&md, false);
+}
+
+#[test]
+fn jupyter_cell_warning_false_drops_stderr_keeps_stdout() {
+    if !engine_available("jupyter") {
+        eprintln!("Skipping test: jupyter not available");
+        return;
+    }
+    let md = run(&doc(
+        "jupyter",
+        "python",
+        "",
+        "#| warning: false\n",
+        PY_WARN_CELL,
+    ));
+    assert!(
+        !md.contains("WARNME"),
+        "stderr warning must be filtered out; got:\n{md}"
+    );
+    assert!(md.contains("OUT"), "stdout must survive; got:\n{md}");
+}
+
+#[test]
+fn jupyter_cell_include_false_emits_nothing() {
+    if !engine_available("jupyter") {
+        eprintln!("Skipping test: jupyter not available");
+        return;
+    }
+    let md = run(&jupyter_doc("", "#| include: false\n"));
+    assert_no_cell_at_all(&md);
+}
+
+// =====================================================================
+// Jupyter — precedence and wrapper suppression
+// =====================================================================
+
+#[test]
+fn jupyter_cell_echo_true_overrides_document_echo_false() {
+    if !engine_available("jupyter") {
+        eprintln!("Skipping test: jupyter not available");
+        return;
+    }
+    let md = run(&jupyter_doc("execute:\n  echo: false\n", "#| echo: true\n"));
+    assert_source_echoed(&md, true);
+    assert!(
+        !md.contains("#|"),
+        "option lines must be stripped from the echo; got:\n{md}"
+    );
+}
+
+#[test]
+fn jupyter_cell_echo_false_overrides_document_echo_true() {
+    if !engine_available("jupyter") {
+        eprintln!("Skipping test: jupyter not available");
+        return;
+    }
+    let md = run(&jupyter_doc("execute:\n  echo: true\n", "#| echo: false\n"));
+    assert_source_echoed(&md, false);
+    assert_output_present(&md, true);
+}
+
+/// A cell with neither visible source nor visible output must not leave
+/// an empty `::: {.cell}` wrapper behind. Q1 builds the div opener but
+/// writes it only "if there is actually content in the div"
+/// (`jupyter.ts`); q2's `render_cell` emitted it unconditionally.
+#[test]
+fn jupyter_fully_hidden_cell_leaves_no_wrapper() {
+    if !engine_available("jupyter") {
+        eprintln!("Skipping test: jupyter not available");
+        return;
+    }
+    let md = run(&jupyter_doc("", "#| echo: false\n#| output: false\n"));
+    assert_no_cell_at_all(&md);
+}
+
+/// The exact fixture from GH issue #523. `code-fold: true` is inert in
+/// q2 (unimplemented — bd-g1prx), so it must not affect `echo` either
+/// way: the source is hidden because `execute: echo: false` says so.
+#[test]
+fn issue_523_code_fold_does_not_resurrect_hidden_source() {
+    if !engine_available("jupyter") {
+        eprintln!("Skipping test: jupyter not available");
+        return;
+    }
+    let md = run(
+        "---\ntitle: t\nformat:\n  html:\n    code-fold: true\nengine: jupyter\nexecute:\n  echo: false\n---\n\n```{python}\nSRCMARK = \"O\" + \"UT\"\nprint(SRCMARK)\n```\n",
+    );
+    assert_source_echoed(&md, false);
+    assert_output_present(&md, true);
+}
+
+// =====================================================================
+// Knitr
+//
+// The R scripts already read every one of these keys off
+// `format$execute` (resources/rmd/execute.R); the defect was that
+// nothing populated it from the document. Cell scope has always worked
+// (knitr resolves `#|` options itself), so the cell-scope test here is
+// a regression guard rather than a new behaviour.
+// =====================================================================
+
+#[test]
+fn knitr_doc_echo_false_hides_source_keeps_output() {
+    if !engine_available("knitr") {
+        eprintln!("Skipping test: knitr not available");
+        return;
+    }
+    let md = run(&knitr_doc("execute:\n  echo: false\n", ""));
+    assert_source_echoed(&md, false);
+    assert_output_present(&md, true);
+    assert_prose_intact(&md);
+}
+
+#[test]
+fn knitr_doc_output_false_hides_output_keeps_source() {
+    if !engine_available("knitr") {
+        eprintln!("Skipping test: knitr not available");
+        return;
+    }
+    let md = run(&knitr_doc("execute:\n  output: false\n", ""));
+    assert_source_echoed(&md, true);
+    assert_output_present(&md, false);
+}
+
+#[test]
+fn knitr_doc_warning_false_drops_warning_keeps_stdout() {
+    if !engine_available("knitr") {
+        eprintln!("Skipping test: knitr not available");
+        return;
+    }
+    let md = run(&doc(
+        "knitr",
+        "r",
+        "execute:\n  warning: false\n",
+        "",
+        R_WARN_CELL,
+    ));
+    assert!(
+        !md.contains("WARNME"),
+        "warning must be filtered out; got:\n{md}"
+    );
+    assert!(md.contains("OUT"), "stdout must survive; got:\n{md}");
+}
+
+#[test]
+fn knitr_doc_include_false_emits_nothing() {
+    if !engine_available("knitr") {
+        eprintln!("Skipping test: knitr not available");
+        return;
+    }
+    let md = run(&knitr_doc("execute:\n  include: false\n", ""));
+    assert_no_cell_at_all(&md);
+}
+
+/// Regression guard: knitr resolves `#|` options itself, so this
+/// already worked. It must keep working once the document scope is
+/// forwarded (a naive `execute:` passthrough that dropped the
+/// `include: true` default would blank every chunk instead).
+#[test]
+fn knitr_cell_echo_false_still_hides_source() {
+    if !engine_available("knitr") {
+        eprintln!("Skipping test: knitr not available");
+        return;
+    }
+    let md = run(&knitr_doc("", "#| echo: false\n"));
+    assert_source_echoed(&md, false);
+    assert_output_present(&md, true);
+}
+
+/// Defaults must survive the document-scope plumbing: with no
+/// `execute:` key at all, source and output are both visible.
+#[test]
+fn knitr_no_execute_key_keeps_defaults() {
+    if !engine_available("knitr") {
+        eprintln!("Skipping test: knitr not available");
+        return;
+    }
+    let md = run(&knitr_doc("", ""));
+    assert_source_echoed(&md, true);
+    assert_output_present(&md, true);
+}
+
+#[test]
+fn jupyter_no_execute_key_keeps_defaults() {
+    if !engine_available("jupyter") {
+        eprintln!("Skipping test: jupyter not available");
+        return;
+    }
+    let md = run(&jupyter_doc("", ""));
+    assert_source_echoed(&md, true);
+    assert_output_present(&md, true);
+}

--- a/crates/quarto-core/tests/integration/main.rs
+++ b/crates/quarto-core/tests/integration/main.rs
@@ -20,6 +20,7 @@ pub mod document_profile_pipeline;
 pub mod engine_error_policy;
 pub mod engine_merge;
 pub mod engine_output_parity;
+pub mod engine_visibility;
 pub mod extension_metadata;
 pub mod fail_fast;
 pub mod get_config_merge;


### PR DESCRIPTION
Fixes #523. Strand: bd-nn2fou8h.

## What the issue reported, and what was actually wrong

#523 reported `code-fold: true` silently overriding `execute: echo: false`. The symptom is real; the attributed cause is not — `code-fold` is unimplemented in q2 and completely inert (renders with and without it are byte-identical), so it cannot override anything.

The real defect is wider than reported:

- **The jupyter engine ignored the entire visibility family** — `echo`, `output`, `warning`, `include` — at *both* document scope (`execute:`) and cell scope (`#|`). `render_cell` always echoed the source; `format_outputs` always emitted every output.
- **The knitr engine didn't merely ignore document-scope `execute:`, it overrode it.** `build_format_config` discarded the document metadata and `ExecuteConfig::with_defaults` pinned `echo: true`.

Verified against Q1 (`external-sources/quarto-cli`) throughout. Full assessment, Q1 comparison, and evidence: `claude-notes/plans/2026-08-14-issue-523-execute-visibility.md`.

## The fix, in three parts

**1. `ExecutionContext` carries the document's merged `execute:` scope**, populated by `EngineExecutionStage` from `ast.meta`. This *retires* the jupyter engine's workaround of re-parsing the front matter out of its own serialized input (`document_execute_scope` + `front_matter_range`, both deleted) — that existed only because the field didn't, and knitr couldn't reuse it across its JSON-to-R boundary.

**2. Jupyter resolves the family through `CellVisibility`**, mirroring Q1's `shouldInclude` (`src/core/jupyter/tags.ts`): cell option over document scope, default `true`. `include: false` suppresses the cell entirely; `warning: false` drops stderr streams (Q1's `isWarningOutput`); `output: false` also silences warnings, since Q1 suppresses every output under it.

A cell with neither visible source nor surviving output no longer leaves an **empty `.cell` wrapper** — an empty `<div class="cell">` is still a box in the page, Q1 writes its div opener only when there's content for it, and knitr already emits nothing for a hidden chunk.

**3. `ExecuteConfig::overlay_document_scope` layers the document's `execute:` onto the defaults for knitr.** The R side needed **no change at all**: `resources/rmd/execute.R` already reads every one of these keys off `format$execute` — nothing had ever populated it.

Two traps worth calling out for review:

- **Overlay, never replace.** `execute.R` reads `warning`/`include` through `isTRUE()`, so an *absent* key means **false**. Handing R the document's map verbatim would set `include: false` for every chunk and render blank documents. `test_overlay_preserves_defaults_for_untouched_keys` pins this.
- **`as_plain_text`, not `as_str`.** A bare YAML string in front-matter context is `PandocInlines`, for which `as_str()` returns `None` — `echo: fenced` would silently vanish. (Same trap the `metadata-as-str` lint exists for.)

## Bonus: a cross-engine disagreement this exposed

Document-level `execute: error: true` now reaches knitr. Previously `with_defaults` pinned `error: false`, so jupyter honored the doc-level allow (bd-ohvl879u) and knitr silently didn't. Two tests added to `engine_error_policy.rs`.

## Tests

Written first. **Confirmed 15 failing before implementation**, each for a semantic reason rather than a harness error.

- `engine_visibility.rs` (new, 19 tests): both engines × both scopes, precedence in both directions, no-empty-wrapper, plus a regression test pinned to the issue's exact fixture.
- 9 jupyter unit tests (resolution + emission, no kernel needed), 8 knitr overlay unit tests (numeric/keyword/string paths the integration tests don't reach), 2 knitr error-policy tests.

Cell bodies build their output by concatenation (`print("O" + "UT")`) so `contains("OUT")` distinguishes *output* from *echoed source* — without that, every output assertion silently also matches the echo.

## Verification

- `cargo nextest run --workspace`: **11954 passed**, 0 failed.
- Full `cargo xtask verify` (not `--skip-hub-build`, since `ExecutionContext` is in `wasm-quarto-hub-client`'s closure): **all 14 steps passed**.
- clippy / `cargo fmt` / `cargo xtask lint`: clean. **No snapshot files added, modified, or removed.**
- **E2E through the binary** on the issue's exact fixture — now emits only the output div, no `sourceCode` block, matching Q1.
- **`q2 preview` verified in a real browser** (full WASM chain rebuilt first): `div.cell` = 1, `.cell-code` = 0, `pre.sourceCode` = 0, one `.cell-output-stdout`.

## Follow-ups filed (not fixed here)

- **bd-42202ipf** — the preview capture-splice mis-pairs *adjacent* cells when the first is hidden: the hidden cell's position renders the next cell's output, and that cell falls through to raw source. Found while verifying this work, reproduced in a live preview session, and **proven pre-existing** by reproducing the identical DOM under knitr — whose `include: false` path this PR doesn't touch. This PR only widens which documents reach it. Preview-only; render is unaffected.
- **bd-tskkw5dq** — deferred `keep-hidden` and jupyter `echo: "fenced"`. Note knitr's `fenced` half works via this PR, so the engines currently disagree on that value.
- **bd-6gpwbmzt** — pre-existing `#[serde(flatten)]` `HashMap` in the knitr format config (the determinism rule prohibits it; low practical impact since R indexes by key).
- **bd-fjfizas7** — adjacent observation #1 from the issue: `{python}` cells with no `engine:` key silently skip execution, and leak a literal `{python}` CSS class.

Adjacent observation #2 from the issue (`embed-resources`) is confirmed unimplemented but deliberately not a Q2 priority — no strand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)