### PR TITLE
Website TOC title: use toc-title-website ("On this page") on website pages

### DIFF
--- a/claude-notes/plans/2026-08-14-website-toc-title-on-this-page.md
+++ b/claude-notes/plans/2026-08-14-website-toc-title-on-this-page.md
@@ -1,0 +1,151 @@
+# Website TOC title uses `toc-title-document` instead of `toc-title-website` (bd-website-toc-title-wn80ymab)
+
+**Date:** 2026-08-14
+**Braid:** bd-website-toc-title-wn80ymab (bug, p3, label `toc`)
+**Branch:** investigated on `main` @ `094c0a80` (no worktree created — see "Where this should land")
+**Status:** Investigation — pending design alignment with user. **Do not start implementation until the user gives the go-ahead.**
+
+## Triage verdict
+
+**Ready to design.** The diagnosis in the strand is correct and confirmed at HEAD; the localized data is already shipped; the fix is a two-line key selection in one transform. The only genuinely open questions are *which predicate* gates the key choice — Q1 gates on three conditions, and the strand's suggested source (`ast.meta`) is the weakest of the available options.
+
+## Pre-flight state at HEAD
+
+`cargo xtask verify --skip-hub-build` on `main` @ `094c0a80`: build clean, **11259/12063 tests passed, 1 failed** —
+`quarto-preview::integration config_endpoint::config_reports_embedded_asset_manifest_hashes`
+("a real embedded viewer dist must advertise assets.viewer", `config_endpoint.rs:311`).
+
+Diagnosed as **local build-artifact state, not a code regression, and unrelated to this strand**:
+`q2-preview-spa/dist/` exists and is non-placeholder (so the test takes its strict `else` branch)
+but contains no `viewer/` subdirectory and no manifest file — the artifacts the skipped
+hub-build leg would produce. The test arrived recently with `f366cb5d` ("preview: SPA asset
+manifest + config handshake", bd-ee2fqm95), so this checkout's dist simply predates the
+manifest it now asserts on. No strand filed: CI runs the full build, so I can't tell from here
+whether `verify --skip-hub-build` is self-inconsistent in general or just against this stale
+dist. Flagging for the user rather than guessing.
+
+Nothing in this investigation changed code, so no failure here is attributable to it.
+
+## Issue context
+
+Filed 2026-08-14 by Carlos Scheidegger (same day as this investigation — no staleness risk). Priority 3, type bug, label `toc`.
+
+On a website project, q2 renders the page-TOC heading as "Table of contents" where Q1 renders "On this page". Q1's language catalog carries two keys and picks by context:
+
+```yaml
+toc-title-document: "Table of contents"   # standalone documents
+toc-title-website: "On this page"         # website pages
+```
+
+q2's `TocGenerateTransform` always consults `toc-title-document`.
+
+Real-world impact: every Posit Connect docs page with a TOC (~324 of 352) shows the wrong string. The porting project currently masks it in visual-comparison sweeps with `--mask '^(On this page|Table of contents)$'`.
+
+## Dependency graph
+
+**Empty.** `braid dep list` returns no edges and `braid dep tree` shows the strand alone. No incoming `blocks` pressure, no `discovered-from` parent in this skein.
+
+The context that *would* have come from the graph is carried in the description instead, and it checks out:
+
+- **bd-llhlzd7p** (closed) — "Localization / internationalization support". Established the title precedence chain (user `toc-title` > localized term > English literal) on 2026-07-17. Confirmed: that decision simply never contemplated the website/document split.
+- **bd-toc-smart-quotes-6nro57ed** (closed) — the recent TOC-title markup work (`25866ab0`) that rewrote the same precedence block to read the user value as *inlines* rather than text. Confirmed: it did not touch the key choice, and its comment block is the one this change edits.
+- **br-website-toc-title-q8mgt5gn** — origin strand in the separate connect-docs porting skein (not in this skein, so not linkable here).
+
+Cross-skein origin plus same-day filing means the "why" is intact even without edges; no archaeology needed.
+
+## What the code looks like today
+
+All paths in the description still exist with the described shape.
+
+**The offending block** — `crates/quarto-core/src/transforms/toc_generate.rs:139-146`:
+
+```rust
+let title = ast
+    .meta
+    .get("toc-title")
+    .and_then(config_value_to_inlines)
+    .or_else(|| {
+        crate::language::LanguageTerms::from_meta(&ast.meta)
+            .and_then(|t| t.get("toc-title-document").map(plain_inlines))
+    })
+    .or_else(|| Some(plain_inlines("Table of Contents")));
+```
+
+Note the transform signature takes `_ctx: &mut RenderContext` — **currently unused**. That is the fix's lever (see below).
+
+**The localized data is present.** 34 of 36 files under `resources/language/` define `toc-title-website`; `_language.yml` itself defines it. `LanguageTerms::get` (`crates/quarto-core/src/language.rs:140`) is a free-form map lookup with no key allowlist, so `t.get("toc-title-website")` resolves with no plumbing work.
+
+**Website detection is already idiomatic in this codebase.** `ctx.project.project_kind() == ProjectKind::Website`, with precedent at `crates/quarto-core/src/transforms/website_bootstrap_icons.rs:73` and `crates/quarto-core/src/transforms/page_nav_generate.rs:62`.
+
+**What Q1 actually does** — `external-sources/quarto-cli/src/command/render/pandoc.ts:493-500`:
+
+```ts
+options.format.metadata[kTocTitle] = options.format.language[
+  (projectIsWebsite(options.project) && !projectIsBook(options.project) &&
+      isHtmlOutput(options.format.pandoc, true))
+    ? kTocTitleWebsite
+    : kTocTitleDocument
+];
+```
+
+Three conditions, and two of them matter for us:
+
+1. `projectIsWebsite && !projectIsBook` — Q1's `projectIsWebsite` returns true for books too (book extends website), hence the exclusion. **q2 needs no equivalent**: `ProjectKind::Website` and `ProjectKind::Book` are distinct variants, so `== Website` excludes books for free.
+2. `isHtmlOutput(pandoc, /* strict */ true)` — verified at `external-sources/quarto-cli/src/config/format.ts:57-74`: `strict: true` matches only `html`/`html4`/`html5` (plus dashboards) and **excludes revealjs and epub**. q2's `Format::is_html()` delegates to `is_html_based()`, which *includes* `Revealjs` (`crates/quarto-core/src/format.rs:66`). So `is_html()` is **not** the Q1-equivalent predicate — see design question 2.
+
+**Format gating is not free here.** `TocGenerateTransform` is pushed unconditionally into the pipeline (`crates/quarto-core/src/pipeline.rs:1365`), and the surrounding comment is explicit that this is deliberate: "All generates run before any renders so a future user filter or *non-HTML pipeline* sees a complete `navigation.*` subtree before rendering." So the transform genuinely does run for PDF/DOCX renders of a website project, and an unconditional website-keyed title would put "On this page" into a PDF — which Q1 would not do.
+
+**Reproducible at HEAD — confirmed end-to-end.** Repro at `/Users/cscheid/repos/github/cscheid/q2-connect-docs/llms-info/repros/website-toc-title/` (one-page website; `_site/` and `_site-q1/` both committed for comparison). Not duplicated into this repo — see "Risks" on end-to-end verification below.
+
+Rendered with a binary freshly built from `main` @ `094c0a80`:
+
+```
+$ /Users/cscheid/rooms/room-2/q2/target/debug/q2 render .
+Rendering project: …/repros/website-toc-title (type: website)
+Rendered 1 of 1 files to …/repros/website-toc-title/_site
+
+$ grep -o '<h2 id="toc-title">[^<]*</h2>' _site/index.html
+<h2 id="toc-title">Table of contents</h2>          # q2  — wrong
+
+$ grep -o '<h2 id="toc-title">[^<]*</h2>' _site-q1/index.html
+<h2 id="toc-title">On this page</h2>               # Q1  — expected
+```
+
+Output inspected directly, not inferred from exit status. Note the CLI itself reports `type: website`, confirming the project kind is resolved and available at render time — the fix's predicate is present, just unconsulted. The re-render left the repro repo byte-identical (`git status` clean), so the committed `_site/` already reflected current behavior.
+
+**Blast radius is small.** `grep -rl "Table of contents" --include="*.snap" crates/` returns **zero** snapshots. Existing `toc-title-document` assertions live in `language_resolve.rs`, `language_catalog.rs`, and `language_pipeline.rs` and test the *catalog*, not the transform's key choice — none should need to change. The transform's own test harness (`make_test_project`, `toc_generate.rs:212`) builds a `ProjectContext` with `ProjectConfig::default()`, so a website variant is a one-line `config.project_kind = ProjectKind::Website` (precedent: `page_nav_generate.rs:532`).
+
+## Proposed phases (draft)
+
+- **Phase 0 — Test plan (TDD, failing first).**
+  - Unit, `toc_generate.rs`: website project → title is the `toc-title-website` term; default project → `toc-title-document`; website + user `toc-title` → user value still wins; website + `lang: pt` → "Nesta página".
+  - Whichever format-gating answer lands (design question 2) gets its own case.
+  - One end-to-end test through `render_document_to_file` on a website fixture, per the repo's end-to-end rule — the unit tests bypass the real project-config path.
+- **Phase 1 — Key selection.** Thread the predicate through the (currently unused) `ctx` and pick the key. Update the precedence-chain comment, which is load-bearing documentation for two prior strands.
+- **Phase 2 — End-to-end verification.** `cargo run --bin q2 -- render` on the repro directory; inspect `_site/index.html` for `<h2 id="toc-title">On this page</h2>`; record the invocation + output snippet in this plan.
+- **Phase 3 — Docs.** Probably none: this restores Q1-compatible default behavior rather than adding a user-facing knob. Confirm no `docs/` page documents "Table of contents" as the website default.
+
+## Open design questions for the user
+
+1. **Detection source: `ctx.project.project_kind()` or `ast.meta`?**
+   The strand suggests reading website-ness from `ast.meta` ("website-ness is detectable there"). I'd recommend **against** it and use `ctx.project.project_kind() == ProjectKind::Website` instead. A `website:` key in merged metadata is not the same claim as "this project's type is website" — a standalone document that sets a stray `website:` key would misfire, and custom project types resolve their *base* kind into `project_kind`, so the typed check handles them correctly for free. The cost is touching the transform's currently-unused `_ctx` parameter, which seems like the right trade. Do you agree, or is there a reason the meta route was preferred?
+
+2. **Do we mirror Q1's `isHtmlOutput(…, strict = true)` gate, and how strictly?**
+   Three options, and this is the one real decision:
+   - **(a) No format gate** — website project → website title, all formats. Simplest, but a website project rendered to PDF gets "On this page", diverging from Q1.
+   - **(b) Gate on `Format::is_html()`** — one-liner, but that predicate *includes* revealjs, so a revealjs page in a website project would get "On this page" where Q1 gives it "Table of contents".
+   - **(c) Gate on `identifier == FormatIdentifier::Html`** — exactly Q1's strict semantics. Marginally more code, no new helper needed.
+   I lean **(c)** for bug-for-bug parity, since the whole point of the strand is Q1 fidelity. But (b) is defensible if you'd rather not encode a revealjs distinction nobody has asked about. Which do you want?
+
+3. **Should the English literal fallback change too?**
+   The final fallback is the hardcoded `"Table of Contents"` (note: capital C, unlike the catalog's "Table of contents"). It only fires in stage-less unit tests where no catalog is loaded. Leave it alone, or make it context-aware for symmetry? I lean leave it — it's a test-only path and changing it invites confusion about which string is canonical.
+
+4. **Where should this land?**
+   No worktree or branch was created (per this skill's contract). Given the tiny diff and empty dependency graph, a topic branch off `main` seems right rather than a worktree. Confirm, or point me at an integration line if this should ride along with other connect-docs parity work.
+
+## Risks / tradeoffs (draft)
+
+- **Low risk overall.** One transform, no snapshot churn, localized data already shipped, and the strand is same-day fresh so no staleness.
+- **The comment block is load-bearing.** The precedence-chain comment at `toc_generate.rs:122-138` documents decisions from bd-llhlzd7p and bd-toc-smart-quotes-6nro57ed and the `as_str`/`as_plain_text` trap from bd-y89ihf0i. Extend it; don't rewrite it away.
+- **End-to-end verification needs a website fixture.** The repro lives outside this repo. Per the repo's end-to-end rule, Phase 2 should either render that external directory explicitly or add a small in-repo website fixture. Slight preference for an in-repo fixture so the regression stays testable in CI, but that's a judgment call worth confirming alongside question 4.
+- **`toc-title-website` is currently unreferenced in q2 Rust code** — this change is its first consumer. Checked whether the same latent gap exists elsewhere: `grep -oE '^[a-z0-9-]+-(website|document):' resources/language/_language.yml` returns exactly `toc-title-document` and `toc-title-website`, so **`toc-title` is the catalog's only context-keyed pair**. No follow-up strand needed; this fix closes the category.

--- a/claude-notes/plans/2026-08-14-website-toc-title-on-this-page.md
+++ b/claude-notes/plans/2026-08-14-website-toc-title-on-this-page.md
@@ -2,8 +2,8 @@
 
 **Date:** 2026-08-14
 **Braid:** bd-website-toc-title-wn80ymab (bug, p3, label `toc`)
-**Branch:** investigated on `main` @ `094c0a80` (no worktree created — see "Where this should land")
-**Status:** Design settled (2026-08-14) — see "Design decisions" below. Ready to implement on a topic branch off `main`. **Awaiting the user's go-ahead to start Phase 0.**
+**Branch:** `braid/bd-website-toc-title-wn80ymab`, off `main` @ `094c0a80`
+**Status:** In progress — Phase 0 (tests) complete and confirmed red. Implementing Phase 1.
 
 ## Triage verdict
 
@@ -125,22 +125,83 @@ Output inspected directly, not inferred from exit status. Note the CLI itself re
 
 **Blast radius is small.** `grep -rl "Table of contents" --include="*.snap" crates/` returns **zero** snapshots. Existing `toc-title-document` assertions live in `language_resolve.rs`, `language_catalog.rs`, and `language_pipeline.rs` and test the *catalog*, not the transform's key choice — none should need to change. The transform's own test harness (`make_test_project`, `toc_generate.rs:212`) builds a `ProjectContext` with `ProjectConfig::default()`, so a website variant is a one-line `config.project_kind = ProjectKind::Website` (precedent: `page_nav_generate.rs:532`).
 
-## Proposed phases (draft)
+## Work items
 
-- **Phase 0 — Test plan (TDD, failing first).**
-  - Unit, `toc_generate.rs`: website project → title is the `toc-title-website` term; default project → `toc-title-document`; website + user `toc-title` → user value still wins; website + `lang: pt` → "Nesta página".
-  - Website project rendering **revealjs** → `toc-title-document` (guards decision 2's strict
-    gate against a later drift to `Format::is_html()`).
-  - Website project with **no `website:` key** in `_quarto.yml` → still `toc-title-website`
-    (pins the project-kind semantics; this case is confirmed broken today, see below).
-  - Book project → `toc-title-document` (Q1 parity via the distinct `ProjectKind` variant).
-  - One end-to-end test through `render_document_to_file` on a website fixture, per the repo's end-to-end rule — the unit tests bypass the real project-config path.
-- **Phase 1 — Key selection.** Replace `_ctx` with `ctx` and select the key on
-  `ctx.project.project_kind() == ProjectKind::Website && ctx.format.identifier == FormatIdentifier::Html`.
-  Update the precedence-chain comment, which is load-bearing documentation for two prior
-  strands — extend it, don't rewrite it away.
-- **Phase 2 — End-to-end verification.** `cargo run --bin q2 -- render` on the repro directory; inspect `_site/index.html` for `<h2 id="toc-title">On this page</h2>`; record the invocation + output snippet in this plan.
-- **Phase 3 — Docs.** Probably none: this restores Q1-compatible default behavior rather than adding a user-facing knob. Confirm no `docs/` page documents "Table of contents" as the website default.
+**Branch:** `braid/bd-website-toc-title-wn80ymab`, off `main` @ `094c0a80`.
+(`main` was reset back to `origin/main` so the two plan commits live only on this branch,
+per the PR #529 convention.)
+
+### Phase 0 — Tests (TDD: written and confirmed failing before any implementation) — **DONE**
+
+Unit tests in `crates/quarto-core/src/transforms/toc_generate.rs` (hand-built `RenderContext`),
+end-to-end tests in `crates/quarto-core/tests/integration/toc_title_context.rs` (real
+`ProjectPipeline` over a temp project, so `project.type` is resolved by
+`ProjectContext::discover` exactly as under `q2 render`).
+
+- [x] Unit: website project + HTML → `toc-title-website` term
+- [x] Unit: default (non-project) → `toc-title-document` (regression guard)
+- [x] Unit: website + user `toc-title` → user value still wins (precedence unchanged)
+- [x] Unit: website + `lang: pt` → "Nesta página" (localization still flows)
+- [x] Unit: website + **revealjs** → `toc-title-document` (guards decision 2's strict gate
+      against a later drift to `Format::is_html()`)
+- [x] Unit: website + **PDF** → `toc-title-document` (the transform runs for every format)
+- [x] Unit: **book** project → `toc-title-document` (Q1 parity via the distinct `ProjectKind`)
+- [x] Unit: website with no catalog → English literal unchanged (pins decision 3)
+- [x] E2E: website project → "On this page"
+- [x] E2E: website with **no `website:` key** → "On this page" (pins project-kind semantics)
+- [x] E2E: default project → "Table of contents"
+- [x] E2E: book project → "Table of contents"
+- [x] E2E: user `toc-title` outranks the website term
+- [x] E2E: `lang: pt` website → "Nesta página"
+- [x] Confirm every new test fails for the right reason
+
+**Red state recorded (pre-implementation).** 5 of 14 fail — exactly the ones encoding the new
+behavior; the other 9 are regression guards that pin currently-correct behavior and must stay
+green through the change. A guard passing before implementation is the point, not a weak test.
+
+```
+unit  website_html_uses_toc_title_website        left: "Table of contents"  right: "On this page"
+unit  website_uses_the_localized_website_term    left: "Índice"             right: "Nesta página"
+e2e   website_project_uses_the_website_term      left: "Table of contents"  right: "On this page"
+e2e   website_project_without_a_website_key_…    left: "Table of contents"  right: "On this page"
+e2e   website_term_is_localized                  left: "Índice"             right: "Nesta página"
+```
+
+The two localized failures report `Índice` — Portuguese for the *document* term — which
+confirms `_language-pt.yml` loads and the tests fail purely on **key selection**, not on a
+broken catalog. Without that check a passing post-fix assertion could have been a false green.
+
+Harness note: `render_index_with_toc` / `toc_nav` in `toc_markup.rs` were widened to
+`pub(crate)` and reused rather than cloning ~50 lines of `ProjectPipeline` setup. Both files are
+sibling modules of the single `integration` binary (`.claude/rules/integration-tests.md`), so
+this is an ordinary intra-binary import.
+
+### Phase 1 — Implementation
+
+- [ ] Replace `_ctx` with `ctx`; select the key on
+      `ctx.project.project_kind() == ProjectKind::Website && ctx.format.identifier == FormatIdentifier::Html`
+- [ ] Extend the precedence-chain comment (load-bearing docs for bd-llhlzd7p,
+      bd-toc-smart-quotes-6nro57ed, bd-y89ihf0i — extend, don't rewrite away)
+- [ ] All Phase 0 tests green
+- [ ] `cargo nextest run --workspace` clean (monorepo rule: crate-local tests are not enough)
+
+### Phase 2 — End-to-end verification
+
+- [ ] `q2 render` the external repro → `<h2 id="toc-title">On this page</h2>`
+- [ ] `q2 render` the no-`website:`-key probe → same
+- [ ] Non-website single doc still renders "Table of contents"
+- [ ] Live `q2 preview` of a website project shows the website title (closes the parity gap
+      that was verified only by reading call sites)
+- [ ] Record invocations + observed output in this plan
+
+### Phase 3 — Wrap-up
+
+- [ ] Confirm no `docs/` page documents "Table of contents" as the website default
+- [ ] `cargo xtask lint` clean
+- [ ] `cargo xtask verify` (full, incl. hub build) — also re-checks the stale-dist failure
+- [ ] Re-check `config_reports_embedded_asset_manifest_hashes`; file a strand only if it
+      survives the full rebuild
+- [ ] Record final commit hashes here
 
 ## Design decisions (settled 2026-08-14 with user)
 

--- a/claude-notes/plans/2026-08-14-website-toc-title-on-this-page.md
+++ b/claude-notes/plans/2026-08-14-website-toc-title-on-this-page.md
@@ -3,7 +3,8 @@
 **Date:** 2026-08-14
 **Braid:** bd-website-toc-title-wn80ymab (bug, p3, label `toc`)
 **Branch:** `braid/bd-website-toc-title-wn80ymab`, off `main` @ `094c0a80`
-**Status:** In progress — Phase 0 (tests) complete and confirmed red. Implementing Phase 1.
+**Status:** **Complete** — all phases done. Full `cargo xtask verify` green (14/14 steps,
+12077/12077 tests). Ready for PR.
 
 ## Triage verdict
 
@@ -29,6 +30,21 @@ full rebuild** (i.e. a `cargo xtask verify` without `--skip-hub-build`). Re-chec
 work's PR goes up.
 
 Nothing in this investigation changed code, so no failure here is attributable to it.
+
+**RESOLVED (Phase 2).** It did *not* survive a full rebuild — **no strand filed**, as agreed.
+
+The initial diagnosis ("stale local dist") was right but incomplete; the *reason* it was stale
+turned out to be specific and recent. `npm run build:wasm` had never succeeded in this checkout
+because it requires `wasm-opt` (binaryen), which was added to the build on **2026-08-13 — one
+day before this work** — by `1eeaae5d` (bd-ee0qcq3c). `dev_setup.rs:211` checks for it but
+deliberately declines to install it, so nothing had provisioned it. With binaryen installed, the
+full chain completed, `q2-preview-spa/dist/spa-manifest.json` was produced, and the test passes:
+
+```
+PASS quarto-preview::integration config_endpoint::config_reports_embedded_asset_manifest_hashes
+```
+
+The underlying toolchain sprawl is filed separately as **bd-aag27gmv**.
 
 ## Issue context
 
@@ -197,23 +213,102 @@ comparison it warns about; and a named function is what a future reader greps fo
 Used `--no-fail-fast` for the workspace run: the first pass cancelled 795 tests after the known
 failure, which would have hidden any second regression behind an already-expected red.
 
-### Phase 2 — End-to-end verification
+### Phase 2 — End-to-end verification — **DONE**
 
-- [ ] `q2 render` the external repro → `<h2 id="toc-title">On this page</h2>`
-- [ ] `q2 render` the no-`website:`-key probe → same
-- [ ] Non-website single doc still renders "Table of contents"
-- [ ] Live `q2 preview` of a website project shows the website title (closes the parity gap
-      that was verified only by reading call sites)
-- [ ] Record invocations + observed output in this plan
+All through the real `q2` binary, output inspected directly (not inferred from exit status).
 
-### Phase 3 — Wrap-up
+- [x] Original repro → `<h2 id="toc-title">On this page</h2>`, byte-matching the committed Q1 reference
+- [x] Website with no `website:` key → same
+- [x] `lang: pt` website → `Nesta página`
+- [x] Default project → `Table of contents`
+- [x] Book project → `Table of contents`
+- [x] Bare single-file render (no project) → `Table of contents`
+- [x] Live `q2 preview` of a website project → `On this page`
+- [x] The q2 docs site (a real website project) → `On this page`
 
-- [ ] Confirm no `docs/` page documents "Table of contents" as the website default
-- [ ] `cargo xtask lint` clean
-- [ ] `cargo xtask verify` (full, incl. hub build) — also re-checks the stale-dist failure
-- [ ] Re-check `config_reports_embedded_asset_manifest_hashes`; file a strand only if it
-      survives the full rebuild
-- [ ] Record final commit hashes here
+```
+$ q2 render .                       # …/repros/website-toc-title  (type: website)
+$ grep -o '<h2 id="toc-title">[^<]*</h2>' _site/index.html
+<h2 id="toc-title">On this page</h2>          # q2   — was "Table of contents"
+$ grep -o '<h2 id="toc-title">[^<]*</h2>' _site-q1/index.html
+<h2 id="toc-title">On this page</h2>          # Q1   — reference, now matched
+
+website-no-website-key   <h2 id="toc-title">On this page</h2>
+website-pt               <h2 id="toc-title">Nesta página</h2>
+default-project          <h2 id="toc-title">Table of contents</h2>
+book-project             <h2 id="toc-title">Table of contents</h2>
+standalone (no project)  <h2 id="toc-title">Table of contents</h2>
+```
+
+**Preview parity — now verified empirically, not by reading call sites.** After the full
+WASM → SPA → binary chain, `q2 preview` on a website project served, inside the
+`q2-preview Renderer` iframe:
+
+```js
+{ tocTitleId: "toc-title", text: "On this page", tag: "H2" }
+```
+
+This closes the risk flagged during design. The check used the no-`website:`-key project, so it
+exercises the `ProjectKind` path rather than a metadata key.
+
+**Trap avoided:** a plain `cargo build --bin q2` would have re-embedded the *old* SPA and shown
+pre-change output while every test passed — the 2026-05-20 incident in `CLAUDE.md`. The
+documented chain (`npm run build:wasm` → `cargo xtask build-q2-preview-spa` →
+`cargo build --bin q2`) was run in full.
+
+**Toolchain detour.** `npm run build:wasm` initially failed: `wasm-opt` (binaryen) was missing.
+Not a stale-environment accident — `wasm-opt` was added to the build **2026-08-13, one day
+before this work**, by `1eeaae5d` (live-share payload reduction, bd-ee0qcq3c); `8024198b` then
+added binaryen to three CI workflows. `dev_setup.rs:211` checks for it but deliberately does not
+install it, so this checkout had never provisioned it. Installed binaryen 132 (matching CI's
+pin) and the chain completed.
+
+That also **resolved the pre-flight failure**: `config_reports_embedded_asset_manifest_hashes`
+now passes. Its cause was the same one — the hub-build leg had never completed here, so
+`q2-preview-spa/dist/` had no manifest. Not a code defect, and **no strand needed** for it.
+
+The wider toolchain sprawl this exposed is filed as **bd-aag27gmv** (p2, discovered-from this
+strand): two parallel toolchains (`wasm-pack` for `wasm-qmd-parser` vs
+cargo + `wasm-bindgen-cli` + `wasm-opt` for `wasm-quarto-hub-client`) and three pinning
+strategies, including a **one-sided binaryen pin** — CI pins `binaryen@132.0.0` with a comment
+claiming it matches local dev, but local dev has no pin at all, so the two agree only by luck
+until Homebrew ships 133.
+
+### Phase 3 — Wrap-up — **DONE**
+
+- [x] Confirm no `docs/` page documents "Table of contents" as the website default — none did.
+      Went further and **added** documentation (see below), since the change makes
+      `toc-title-document` silently ineffective on websites.
+- [x] `cargo xtask lint` — clean, 989 files
+- [x] `cargo xtask verify` (full, incl. hub build + WASM) — **all 14 steps passed**,
+      **12077 tests run, 12077 passed, 0 failed**
+- [x] Re-check `config_reports_embedded_asset_manifest_hashes` — passes; **no strand filed**
+- [x] Record final commit hashes
+
+**Docs.** The plan predicted "probably none". That was wrong in a useful way: nothing documented
+the old default, but the *new* behavior needs documenting, because a user overriding
+`toc-title-document` on a website now gets no effect and no diagnostic. Added a "Table of
+Contents Title" subsection to `docs/guides/authoring/document-language.qmd`, parallel to the
+existing "Cross-Reference Titles and Prefixes" — the page's other context-keyed term family.
+Rendered with q2 (never `quarto render`; docs/ is a Q2 site) and inspected.
+
+### Commits (branch `braid/bd-website-toc-title-wn80ymab`)
+
+| Commit | Contents |
+|--------|----------|
+| `0e02e399` | Investigation + plan skeleton |
+| `4b3e5e99` | Settled design decisions (incl. correction to the question-1 analysis) |
+| `d7e75e34` | Phase 0 — 14 failing tests (5 red, 9 guards) |
+| `38feb52e` | Phase 1 — `toc_title_term(ctx)` implementation |
+| `7875b2ff` | Docs — context-keyed TOC title |
+
+No snapshot files (`.snap`) were added, modified, or removed by this work.
+
+### Follow-up filed
+
+- **bd-aag27gmv** (p2, task, discovered-from this strand) — consolidate the accumulated WASM
+  build toolchains. Two parallel toolchains and three pinning strategies, including a one-sided
+  binaryen pin where CI claims parity with local dev that local dev does not uphold.
 
 ## Design decisions (settled 2026-08-14 with user)
 

--- a/claude-notes/plans/2026-08-14-website-toc-title-on-this-page.md
+++ b/claude-notes/plans/2026-08-14-website-toc-title-on-this-page.md
@@ -176,14 +176,26 @@ Harness note: `render_index_with_toc` / `toc_nav` in `toc_markup.rs` were widene
 sibling modules of the single `integration` binary (`.claude/rules/integration-tests.md`), so
 this is an ordinary intra-binary import.
 
-### Phase 1 — Implementation
+### Phase 1 — Implementation — **DONE**
 
-- [ ] Replace `_ctx` with `ctx`; select the key on
+- [x] Replace `_ctx` with `ctx`; select the key on
       `ctx.project.project_kind() == ProjectKind::Website && ctx.format.identifier == FormatIdentifier::Html`
-- [ ] Extend the precedence-chain comment (load-bearing docs for bd-llhlzd7p,
-      bd-toc-smart-quotes-6nro57ed, bd-y89ihf0i — extend, don't rewrite away)
-- [ ] All Phase 0 tests green
-- [ ] `cargo nextest run --workspace` clean (monorepo rule: crate-local tests are not enough)
+- [x] Extend the precedence-chain comment (load-bearing docs for bd-llhlzd7p,
+      bd-toc-smart-quotes-6nro57ed, bd-y89ihf0i — extended, not rewritten away)
+- [x] All Phase 0 tests green (20 unit incl. 12 pre-existing; 15 e2e across
+      `toc_title_context` + `toc_markup`)
+- [x] `cargo nextest run --workspace --no-fail-fast` — **12077 run, 12076 passed, 1 failed**
+      (only the known stale-dist `config_reports_embedded_asset_manifest_hashes`, identical to
+      the pre-flight baseline)
+
+The predicate lives in a named free function, `toc_title_term(ctx) -> &'static str`, rather than
+inline in the precedence chain. Three reasons: the Q1 provenance and the three-condition
+derivation need somewhere to live; the `is_html_based()` trap deserves a comment attached to the
+comparison it warns about; and a named function is what a future reader greps for when asking
+"why does my PDF say On this page".
+
+Used `--no-fail-fast` for the workspace run: the first pass cancelled 795 tests after the known
+failure, which would have hidden any second regression behind an already-expected red.
 
 ### Phase 2 — End-to-end verification
 

--- a/claude-notes/plans/2026-08-14-website-toc-title-on-this-page.md
+++ b/claude-notes/plans/2026-08-14-website-toc-title-on-this-page.md
@@ -3,7 +3,7 @@
 **Date:** 2026-08-14
 **Braid:** bd-website-toc-title-wn80ymab (bug, p3, label `toc`)
 **Branch:** investigated on `main` @ `094c0a80` (no worktree created — see "Where this should land")
-**Status:** Investigation — pending design alignment with user. **Do not start implementation until the user gives the go-ahead.**
+**Status:** Design settled (2026-08-14) — see "Design decisions" below. Ready to implement on a topic branch off `main`. **Awaiting the user's go-ahead to start Phase 0.**
 
 ## Triage verdict
 
@@ -23,6 +23,10 @@ manifest + config handshake", bd-ee2fqm95), so this checkout's dist simply preda
 manifest it now asserts on. No strand filed: CI runs the full build, so I can't tell from here
 whether `verify --skip-hub-build` is self-inconsistent in general or just against this stale
 dist. Flagging for the user rather than guessing.
+
+**Agreed disposition (2026-08-14):** keep an eye on it; **file a strand only if it survives a
+full rebuild** (i.e. a `cargo xtask verify` without `--skip-hub-build`). Re-check before this
+work's PR goes up.
 
 Nothing in this investigation changed code, so no failure here is attributable to it.
 
@@ -111,6 +115,12 @@ $ grep -o '<h2 id="toc-title">[^<]*</h2>' _site-q1/index.html
 <h2 id="toc-title">On this page</h2>               # Q1  — expected
 ```
 
+A second probe — a website project with **no `website:` key at all** (`_quarto.yml` containing
+only `project: {type: website}`) — renders as `type: website` and likewise emits
+`<h2 id="toc-title">Table of contents</h2>`. That case is a Phase 0 test: it is a valid website
+project that Q1 would give "On this page", and it is invisible to any predicate keyed on the
+presence of a `website:` key.
+
 Output inspected directly, not inferred from exit status. Note the CLI itself reports `type: website`, confirming the project kind is resolved and available at render time — the fix's predicate is present, just unconsulted. The re-render left the repro repo byte-identical (`git status` clean), so the committed `_site/` already reflected current behavior.
 
 **Blast radius is small.** `grep -rl "Table of contents" --include="*.snap" crates/` returns **zero** snapshots. Existing `toc-title-document` assertions live in `language_resolve.rs`, `language_catalog.rs`, and `language_pipeline.rs` and test the *catalog*, not the transform's key choice — none should need to change. The transform's own test harness (`make_test_project`, `toc_generate.rs:212`) builds a `ProjectContext` with `ProjectConfig::default()`, so a website variant is a one-line `config.project_kind = ProjectKind::Website` (precedent: `page_nav_generate.rs:532`).
@@ -119,13 +129,73 @@ Output inspected directly, not inferred from exit status. Note the CLI itself re
 
 - **Phase 0 — Test plan (TDD, failing first).**
   - Unit, `toc_generate.rs`: website project → title is the `toc-title-website` term; default project → `toc-title-document`; website + user `toc-title` → user value still wins; website + `lang: pt` → "Nesta página".
-  - Whichever format-gating answer lands (design question 2) gets its own case.
+  - Website project rendering **revealjs** → `toc-title-document` (guards decision 2's strict
+    gate against a later drift to `Format::is_html()`).
+  - Website project with **no `website:` key** in `_quarto.yml` → still `toc-title-website`
+    (pins the project-kind semantics; this case is confirmed broken today, see below).
+  - Book project → `toc-title-document` (Q1 parity via the distinct `ProjectKind` variant).
   - One end-to-end test through `render_document_to_file` on a website fixture, per the repo's end-to-end rule — the unit tests bypass the real project-config path.
-- **Phase 1 — Key selection.** Thread the predicate through the (currently unused) `ctx` and pick the key. Update the precedence-chain comment, which is load-bearing documentation for two prior strands.
+- **Phase 1 — Key selection.** Replace `_ctx` with `ctx` and select the key on
+  `ctx.project.project_kind() == ProjectKind::Website && ctx.format.identifier == FormatIdentifier::Html`.
+  Update the precedence-chain comment, which is load-bearing documentation for two prior
+  strands — extend it, don't rewrite it away.
 - **Phase 2 — End-to-end verification.** `cargo run --bin q2 -- render` on the repro directory; inspect `_site/index.html` for `<h2 id="toc-title">On this page</h2>`; record the invocation + output snippet in this plan.
 - **Phase 3 — Docs.** Probably none: this restores Q1-compatible default behavior rather than adding a user-facing knob. Confirm no `docs/` page documents "Table of contents" as the website default.
 
-## Open design questions for the user
+## Design decisions (settled 2026-08-14 with user)
+
+1. **Detection source: `ctx.project.project_kind() == ProjectKind::Website`.** Both routes
+   were verified viable — see the corrected analysis below. Chosen because the two fail
+   differently: the meta route's failure mode is a silent wrong string, the ctx route's is a
+   compile error.
+2. **Format gating: option (c)** — `identifier == FormatIdentifier::Html`, matching Q1's
+   `isHtmlOutput(strict = true)` exactly (excludes revealjs and epub). Do **not** use
+   `Format::is_html()`, which delegates to `is_html_based()` and includes `Revealjs`.
+3. **English literal fallback: leave `"Table of Contents"` as-is.** Test-only path; changing it
+   invites confusion about which string is canonical.
+4. **Landing: topic branch off `main`**, headed for a PR soon. No worktree, no integration line.
+
+### Correction to the question-1 analysis
+
+The investigation's first pass claimed the `ast.meta` route was *structurally incapable* of
+detecting website-ness, on the assumption that `project:` is stripped from merged metadata.
+**That was wrong.** The strip at `metadata_merge.rs:146` (`.filter(|e| e.key != "project")`)
+applies only to *extension contribution* layers, not the project config layer. Verified by probe:
+
+```
+_quarto.yml:  project: {type: website}, website: {title: "Has Key"}
+index.qmd:    projecttype=[{{< meta project.type >}}]
+
+rendered:     projecttype=website        # project.type IS in merged metadata
+```
+
+`resolve_project_type` (`project/mod.rs:412`) also rewrites a custom `project.type` to its
+built-in base kind before `parse_config`, so the meta route normalizes custom types correctly
+too. Both routes are correct today. The separate empirical finding — that a valid website
+project with `project: type: website` and **no `website:` key** renders as `type: website` and
+still gets the wrong title — rules out only the *weakest* meta variant (presence of a `website:`
+key), not the `project.type` variant.
+
+**Why `ctx` still wins.** Not capability — failure mode:
+
+| | `ast.meta.project.type` | `ctx.project.project_kind()` |
+|---|---|---|
+| Type safety | stringly-typed | typed enum |
+| `as_str()` inlines trap | **live** — front-matter `project.type` is `PandocInlines`; needs `as_plain_text()` (bd-y89ihf0i) | none |
+| `metadata-as-str` lint | fires; needs `lint:allow` | none |
+| Book exclusion | manual | free (distinct variant) |
+| Architectural standing | incidental — merge stage calls `project` "a project-config concern, merged into the project config" | the value `project_type_for()` dispatches on |
+| Failure if upstream changes | **silent** wrong string | compile error |
+
+**Preview/WASM parity checked** (the one real risk to the ctx route): the two WASM call sites
+building `ProjectContext` with `ProjectConfig::default()` — hence `ProjectKind::Default` — are
+`parse_qmd_to_ast_with_attribution` (`lib.rs:789`) and `render_qmd_content` (`lib.rs:1099`), both
+content-string entry points with no project on disk, where `Default` is the correct answer.
+Project-aware entry points use `ProjectContext::discover` (`lib.rs:1010, 1059, 1222, 1252, 1320,
+1341`). No parity hazard found — **verified by reading call sites, not by running a preview**;
+Phase 2 should confirm in a live preview of a website project.
+
+## Original open design questions (superseded by the decisions above)
 
 1. **Detection source: `ctx.project.project_kind()` or `ast.meta`?**
    The strand suggests reading website-ness from `ast.meta` ("website-ness is detectable there"). I'd recommend **against** it and use `ctx.project.project_kind() == ProjectKind::Website` instead. A `website:` key in merged metadata is not the same claim as "this project's type is website" — a standalone document that sets a stray `website:` key would misfire, and custom project types resolve their *base* kind into `project_kind`, so the typed check handles them correctly for free. The cost is touching the transform's currently-unused `_ctx` parameter, which seems like the right trade. Do you agree, or is there a reason the meta route was preferred?

--- a/crates/quarto-core/src/transforms/toc_generate.rs
+++ b/crates/quarto-core/src/transforms/toc_generate.rs
@@ -40,9 +40,56 @@ use pampa::toc::{TocConfig, config_value_to_inlines, generate_toc, plain_inlines
 use quarto_pandoc_types::pandoc::Pandoc;
 
 use crate::Result;
+use crate::format::FormatIdentifier;
+use crate::project::ProjectKind;
 use crate::render::RenderContext;
 use crate::transform::{AstTransform, TransformPhase};
 use crate::transforms::is_feature_disabled;
+
+/// The language-catalog term holding the TOC title for this render.
+///
+/// Quarto 1 keys the title off render context
+/// (`src/command/render/pandoc.ts:493`):
+///
+/// ```text
+/// projectIsWebsite(project) && !projectIsBook(project)
+///     && isHtmlOutput(format.pandoc, /* strict */ true)
+///     ? "toc-title-website"      // "On this page"
+///     : "toc-title-document"     // "Table of contents"
+/// ```
+///
+/// Two of Q1's three conditions carry over; the third is free:
+///
+/// - **Website.** Read from [`ProjectKind`], not from a `website:` key in
+///   merged metadata. A website project need not define `website:` at
+///   all (`project: {type: website}` alone is valid and Q1 still calls it
+///   a website), and a stray `website:` key in a standalone document is
+///   not a claim about project type. `project_kind` also already holds
+///   the *base* kind for custom project types (`resolve_project_type`
+///   rewrites them), so extension-defined website types work unchanged.
+/// - **Not a book.** Free here: Q1's `projectIsWebsite` is true for books
+///   (book extends website), which is why it needs `!projectIsBook`.
+///   [`ProjectKind::Book`] is a distinct variant, so `== Website`
+///   excludes books already.
+/// - **Strict HTML.** `isHtmlOutput(…, strict = true)` matches only
+///   `html`/`html4`/`html5` — it **excludes revealjs and epub**. So this
+///   compares [`FormatIdentifier::Html`] directly and deliberately does
+///   *not* use [`Format::is_html`], which delegates to `is_html_based()`
+///   and would also match [`FormatIdentifier::Revealjs`]. The format
+///   check is load-bearing rather than incidental: `TocGenerateTransform`
+///   is pushed into the pipeline for *every* format (see the
+///   Navigation-phase comment in `pipeline.rs`), so without it a PDF
+///   render of a website project would say "On this page".
+fn toc_title_term(ctx: &RenderContext) -> &'static str {
+    let is_website = ctx.project.project_kind() == ProjectKind::Website;
+    let is_strict_html = ctx.format.identifier == FormatIdentifier::Html;
+
+    if is_website && is_strict_html {
+        "toc-title-website"
+    } else {
+        "toc-title-document"
+    }
+}
 
 /// Transform that generates TOC from document headings.
 ///
@@ -79,7 +126,7 @@ impl AstTransform for TocGenerateTransform {
         TransformPhase::Navigation
     }
 
-    async fn transform(&self, ast: &mut Pandoc, _ctx: &mut RenderContext) -> Result<()> {
+    async fn transform(&self, ast: &mut Pandoc, ctx: &mut RenderContext) -> Result<()> {
         // Affirmative disable: `toc: false` in merged metadata suppresses
         // generation. Handled explicitly so the intent is symmetric with the
         // render transform (which also short-circuits on `toc: false`) and
@@ -135,13 +182,24 @@ impl AstTransform for TocGenerateTransform {
         // The two fallbacks are genuinely plain text — a localized term
         // from the language catalog, and an English literal — so they
         // are wrapped in a single `Str`.
+        //
+        // Which localized term depends on context
+        // (bd-website-toc-title-wn80ymab): website pages get
+        // `toc-title-website` ("On this page"), everything else gets
+        // `toc-title-document` ("Table of contents"). See
+        // `toc_title_term` for the predicate and its Q1 provenance. The
+        // *English literal* stays context-free by decision — it only
+        // fires when no catalog is loaded at all, which is a stage-less
+        // unit-test path, and giving it two spellings would just muddy
+        // which string is canonical.
         let title = ast
             .meta
             .get("toc-title")
             .and_then(config_value_to_inlines)
             .or_else(|| {
+                let term = toc_title_term(ctx);
                 crate::language::LanguageTerms::from_meta(&ast.meta)
-                    .and_then(|t| t.get("toc-title-document").map(plain_inlines))
+                    .and_then(|t| t.get(term).map(plain_inlines))
             })
             .or_else(|| Some(plain_inlines("Table of Contents")));
 

--- a/crates/quarto-core/src/transforms/toc_generate.rs
+++ b/crates/quarto-core/src/transforms/toc_generate.rs
@@ -566,4 +566,219 @@ mod tests {
             "the Strong node must survive; got {inlines:?}"
         );
     }
+
+    // -----------------------------------------------------------------
+    // bd-website-toc-title-wn80ymab: the TOC title term is context-keyed.
+    //
+    // Quarto 1's language catalog carries two keys and picks between them
+    // (`src/command/render/pandoc.ts:493`):
+    //
+    //     projectIsWebsite(project) && !projectIsBook(project)
+    //         && isHtmlOutput(format.pandoc, /* strict */ true)
+    //         ? "toc-title-website"      // "On this page"
+    //         : "toc-title-document"     // "Table of contents"
+    //
+    // q2 needs no `!projectIsBook` equivalent: Q1's `projectIsWebsite` is
+    // true for books (book extends website), whereas `ProjectKind::Book`
+    // is a distinct variant here, so `== Website` excludes it already.
+    //
+    // `strict` matters: it restricts the website title to `html`/`html4`/
+    // `html5` and **excludes revealjs**. `Format::is_html()` delegates to
+    // `is_html_based()`, which *includes* `Revealjs` — so it is the wrong
+    // predicate. These tests pin the identifier check instead.
+    // -----------------------------------------------------------------
+
+    /// The two catalog terms, as `LanguageResolveStage` injects them at
+    /// `quarto.language` (see `LanguageTerms::from_meta`).
+    fn config_language_terms(document: &str, website: &str) -> ConfigValue {
+        config_map(vec![(
+            "language",
+            config_map(vec![
+                ("toc-title-document", config_str(document)),
+                ("toc-title-website", config_str(website)),
+            ]),
+        )])
+    }
+
+    /// `toc: true` plus the English catalog terms — the shape a real
+    /// render reaches this transform with.
+    fn meta_with_terms() -> ConfigValue {
+        config_map(vec![
+            ("toc", config_bool(true)),
+            (
+                "quarto",
+                config_language_terms("Table of contents", "On this page"),
+            ),
+        ])
+    }
+
+    fn make_project_of_kind(kind: crate::project::ProjectKind) -> ProjectContext {
+        let mut project = make_test_project();
+        project.config.project_kind = kind;
+        project.is_single_file = false;
+        project
+    }
+
+    fn two_section_blocks() -> Vec<Block> {
+        vec![
+            make_header(2, "intro", "Introduction"),
+            make_para("Content."),
+            make_header(2, "methods", "Methods"),
+            make_para("More content."),
+        ]
+    }
+
+    /// Flatten the generated `navigation.toc.title` to plain text.
+    ///
+    /// Deliberately local rather than reaching for a shared helper: the
+    /// title is stored as inlines (bd-toc-smart-quotes-6nro57ed), and
+    /// these tests only ever assert on plain-text terms.
+    fn toc_title_text(ast: &Pandoc) -> String {
+        let title = ast
+            .meta
+            .get_path(&["navigation", "toc", "title"])
+            .expect("navigation.toc.title");
+        let inlines = pampa::toc::config_value_to_inlines(title).expect("title inlines");
+        inlines
+            .iter()
+            .map(|i| match i {
+                Inline::Str(s) => s.text.clone(),
+                Inline::Space(_) => " ".to_string(),
+                other => panic!("unexpected inline in a plain-text title: {other:?}"),
+            })
+            .collect()
+    }
+
+    /// Run the transform over `blocks` with the given project + format.
+    async fn title_for(meta: ConfigValue, project: &ProjectContext, format: &Format) -> String {
+        let mut ast = Pandoc {
+            meta,
+            blocks: two_section_blocks(),
+        };
+        let doc = DocumentInfo::from_path("/project/doc.qmd");
+        let binaries = BinaryDependencies::new();
+        let mut ctx = RenderContext::new(project, &doc, format, &binaries);
+
+        TocGenerateTransform::new()
+            .transform(&mut ast, &mut ctx)
+            .await
+            .unwrap();
+
+        toc_title_text(&ast)
+    }
+
+    /// The headline case: a website page renders "On this page".
+    #[tokio::test]
+    async fn website_html_uses_toc_title_website() {
+        let project = make_project_of_kind(crate::project::ProjectKind::Website);
+        let title = title_for(meta_with_terms(), &project, &Format::html()).await;
+        assert_eq!(
+            title, "On this page",
+            "a website page must use the `toc-title-website` term"
+        );
+    }
+
+    /// Regression guard for the standalone-document case, which is what
+    /// the transform did unconditionally before this change.
+    #[tokio::test]
+    async fn default_project_uses_toc_title_document() {
+        let project = make_project_of_kind(crate::project::ProjectKind::Default);
+        let title = title_for(meta_with_terms(), &project, &Format::html()).await;
+        assert_eq!(
+            title, "Table of contents",
+            "a standalone document must keep the `toc-title-document` term"
+        );
+    }
+
+    /// A user-supplied `toc-title` keeps top precedence on a website —
+    /// the context split must not disturb the chain decided in
+    /// bd-llhlzd7p.
+    #[tokio::test]
+    async fn user_toc_title_still_wins_on_a_website() {
+        let project = make_project_of_kind(crate::project::ProjectKind::Website);
+        let meta = config_map(vec![
+            ("toc", config_bool(true)),
+            ("toc-title", config_str("My Contents")),
+            (
+                "quarto",
+                config_language_terms("Table of contents", "On this page"),
+            ),
+        ]);
+        let title = title_for(meta, &project, &Format::html()).await;
+        assert_eq!(
+            title, "My Contents",
+            "an explicit `toc-title` must outrank the localized website term"
+        );
+    }
+
+    /// Localization still flows through the website branch: the term is
+    /// read from the catalog, not hardcoded per-context.
+    #[tokio::test]
+    async fn website_uses_the_localized_website_term() {
+        let project = make_project_of_kind(crate::project::ProjectKind::Website);
+        let meta = config_map(vec![
+            ("toc", config_bool(true)),
+            ("lang", config_str("pt")),
+            ("quarto", config_language_terms("Índice", "Nesta página")),
+        ]);
+        let title = title_for(meta, &project, &Format::html()).await;
+        assert_eq!(
+            title, "Nesta página",
+            "the website term must come from the language catalog"
+        );
+    }
+
+    /// Q1 gates on `isHtmlOutput(…, strict = true)`, which excludes
+    /// revealjs. Pins decision 2 against a later drift to
+    /// `Format::is_html()` (which would match `Revealjs` and break this).
+    #[tokio::test]
+    async fn website_revealjs_uses_toc_title_document() {
+        let project = make_project_of_kind(crate::project::ProjectKind::Website);
+        let revealjs = Format::from_format_string("revealjs").expect("revealjs format");
+        let title = title_for(meta_with_terms(), &project, &revealjs).await;
+        assert_eq!(
+            title, "Table of contents",
+            "revealjs is excluded by Q1's strict isHtmlOutput, so it keeps the document term"
+        );
+    }
+
+    /// A non-HTML render of a website project keeps the document term —
+    /// the transform runs for every format (see the Navigation-phase
+    /// comment in `pipeline.rs`), so the gate has to be explicit.
+    #[tokio::test]
+    async fn website_pdf_uses_toc_title_document() {
+        let project = make_project_of_kind(crate::project::ProjectKind::Website);
+        let title = title_for(meta_with_terms(), &project, &Format::pdf()).await;
+        assert_eq!(
+            title, "Table of contents",
+            "a PDF render of a website project must not say \"On this page\""
+        );
+    }
+
+    /// Q1 excludes books explicitly (`!projectIsBook`); q2 gets it free
+    /// from `ProjectKind::Book` being a distinct variant. Pinned so a
+    /// future `is_website_like()` helper cannot silently absorb books.
+    #[tokio::test]
+    async fn book_project_uses_toc_title_document() {
+        let project = make_project_of_kind(crate::project::ProjectKind::Book);
+        let title = title_for(meta_with_terms(), &project, &Format::html()).await;
+        assert_eq!(
+            title, "Table of contents",
+            "a book must keep the document term, matching Q1's !projectIsBook guard"
+        );
+    }
+
+    /// The English literal fallback stays context-free (decision 3): it
+    /// only fires when no catalog is loaded, which is a stage-less
+    /// unit-test path.
+    #[tokio::test]
+    async fn website_without_a_catalog_falls_back_to_the_english_literal() {
+        let project = make_project_of_kind(crate::project::ProjectKind::Website);
+        let meta = config_map(vec![("toc", config_bool(true))]);
+        let title = title_for(meta, &project, &Format::html()).await;
+        assert_eq!(
+            title, "Table of Contents",
+            "with no catalog the transform keeps its English literal, uncontextualized"
+        );
+    }
 }

--- a/crates/quarto-core/tests/integration/main.rs
+++ b/crates/quarto-core/tests/integration/main.rs
@@ -66,6 +66,7 @@ pub mod sidebar_pipeline;
 pub mod theme_light_dark;
 pub mod title_block_pipeline;
 pub mod toc_markup;
+pub mod toc_title_context;
 pub mod video_shortcode_preview;
 pub mod website_aliases;
 pub mod website_post_render;

--- a/crates/quarto-core/tests/integration/toc_markup.rs
+++ b/crates/quarto-core/tests/integration/toc_markup.rs
@@ -41,7 +41,17 @@ fn write(path: &Path, contents: &str) {
 /// Build a single-page website project whose `index.qmd` has `toc: true`
 /// and the given body, render it through the real pipeline, and return
 /// the rendered `index.html`.
-fn render_index_with_toc(body: &str, extra_frontmatter: &str, project_yml: Option<&str>) -> String {
+///
+/// `pub(crate)` so `toc_title_context` can drive the same real render
+/// path without cloning ~50 lines of pipeline setup. The two files are
+/// sibling modules of the one `integration` binary (see
+/// `.claude/rules/integration-tests.md`), so this is an ordinary
+/// intra-binary import, not a test depending on another test.
+pub(crate) fn render_index_with_toc(
+    body: &str,
+    extra_frontmatter: &str,
+    project_yml: Option<&str>,
+) -> String {
     let temp = TempDir::new().unwrap();
     let project_dir = temp
         .path()
@@ -97,7 +107,9 @@ fn render_index_with_toc(body: &str, extra_frontmatter: &str, project_yml: Optio
 /// Slice out the `<nav id="TOC">…</nav>` region so assertions cannot
 /// accidentally match the document body (which renders the same markup
 /// correctly today and would mask a TOC regression).
-fn toc_nav(html: &str) -> String {
+///
+/// `pub(crate)` for the same reason as [`render_index_with_toc`].
+pub(crate) fn toc_nav(html: &str) -> String {
     let start = html
         .find("<nav id=\"TOC\"")
         .unwrap_or_else(|| panic!("no <nav id=\"TOC\"> in rendered HTML:\n{html}"));

--- a/crates/quarto-core/tests/integration/toc_title_context.rs
+++ b/crates/quarto-core/tests/integration/toc_title_context.rs
@@ -1,0 +1,131 @@
+/*
+ * toc_title_context.rs
+ * Copyright (c) 2026 Posit, PBC
+ *
+ * bd-website-toc-title-wn80ymab: the TOC title term is context-keyed —
+ * website pages get `toc-title-website` ("On this page"), everything
+ * else gets `toc-title-document` ("Table of contents").
+ */
+
+//! End-to-end coverage for **which** language term the TOC title uses.
+//!
+//! Quarto 1 picks between two catalog keys
+//! (`src/command/render/pandoc.ts:493`):
+//!
+//! ```text
+//! projectIsWebsite(project) && !projectIsBook(project)
+//!     && isHtmlOutput(format.pandoc, /* strict */ true)
+//!     ? "toc-title-website"      // "On this page"
+//!     : "toc-title-document"     // "Table of contents"
+//! ```
+//!
+//! q2 always used `toc-title-document`, so every website page in a
+//! ported site said "Table of contents" (~324 of 352 pages in the Posit
+//! Connect docs port).
+//!
+//! The unit tests in `crates/quarto-core/src/transforms/toc_generate.rs`
+//! cover the predicate itself against a hand-built `RenderContext`.
+//! These tests exist because that harness **bypasses the real
+//! project-config path**: they drive `ProjectPipeline` over a temp
+//! project on disk, so `project.type` is resolved by
+//! `ProjectContext::discover` exactly as it is under `q2 render`.
+//!
+//! Plan: `claude-notes/plans/2026-08-14-website-toc-title-on-this-page.md`.
+
+use crate::toc_markup::{render_index_with_toc, toc_nav};
+
+/// The rendered `<h2 id="toc-title">…</h2>` text, sliced from the TOC
+/// nav so a matching string elsewhere on the page cannot mask a defect.
+fn toc_title(html: &str) -> String {
+    let nav = toc_nav(html);
+    let open = "<h2 id=\"toc-title\">";
+    let start = nav
+        .find(open)
+        .unwrap_or_else(|| panic!("no {open} in TOC nav:\n{nav}"))
+        + open.len();
+    let rest = &nav[start..];
+    let end = rest
+        .find("</h2>")
+        .unwrap_or_else(|| panic!("unterminated toc-title in TOC nav:\n{nav}"));
+    rest[..end].to_string()
+}
+
+const BODY: &str = "## Section One\n\nBody.\n\n## Section Two\n\nMore body.\n";
+
+/// The headline case: a website project renders "On this page".
+#[test]
+fn website_project_uses_the_website_term() {
+    let html = render_index_with_toc(BODY, "", None);
+    assert_eq!(
+        toc_title(&html),
+        "On this page",
+        "a website page must render the `toc-title-website` term"
+    );
+}
+
+/// A website project needs no `website:` key to be a website — the
+/// project *type* is what decides.
+///
+/// This case is why the fix keys off `ProjectKind` rather than the
+/// presence of a `website:` key in merged metadata: this config is a
+/// valid website (the CLI reports `type: website`) and Q1 gives it
+/// "On this page", but it has no `website:` key at all.
+#[test]
+fn website_project_without_a_website_key_uses_the_website_term() {
+    let html = render_index_with_toc(BODY, "", Some("project:\n  type: website\n"));
+    assert_eq!(
+        toc_title(&html),
+        "On this page",
+        "website-ness comes from `project.type`, not from a `website:` key"
+    );
+}
+
+/// Regression guard: a non-website project keeps "Table of contents".
+#[test]
+fn default_project_uses_the_document_term() {
+    let html = render_index_with_toc(BODY, "", Some("project:\n  type: default\n"));
+    assert_eq!(
+        toc_title(&html),
+        "Table of contents",
+        "a default project must keep the `toc-title-document` term"
+    );
+}
+
+/// Q1 excludes books explicitly (`!projectIsBook`, because its
+/// `projectIsWebsite` is true for books too). q2 gets this free from
+/// `ProjectKind::Book` being a distinct variant — pinned so a future
+/// "website-like" helper cannot silently absorb books.
+#[test]
+fn book_project_uses_the_document_term() {
+    let html = render_index_with_toc(BODY, "", Some("project:\n  type: book\n"));
+    assert_eq!(
+        toc_title(&html),
+        "Table of contents",
+        "a book must keep the `toc-title-document` term, matching Q1's !projectIsBook guard"
+    );
+}
+
+/// An explicit `toc-title` outranks the localized term on a website —
+/// the precedence chain from bd-llhlzd7p is unchanged.
+#[test]
+fn user_toc_title_outranks_the_website_term() {
+    let html = render_index_with_toc(BODY, "toc-title: \"My Contents\"\n", None);
+    assert_eq!(
+        toc_title(&html),
+        "My Contents",
+        "an explicit `toc-title` must win over the website term"
+    );
+}
+
+/// Localization flows through the website branch: with `lang: pt` the
+/// website term comes from `_language-pt.yml`, not from a hardcoded
+/// English string.
+#[test]
+fn website_term_is_localized() {
+    let html = render_index_with_toc(BODY, "", Some("project:\n  type: website\nlang: pt\n"));
+    assert_eq!(
+        toc_title(&html),
+        "Nesta página",
+        "the website term must be read from the language catalog"
+    );
+}

--- a/docs/guides/authoring/document-language.qmd
+++ b/docs/guides/authoring/document-language.qmd
@@ -124,6 +124,36 @@ language:
 ---
 ```
 
+### Table of Contents Title
+
+The table of contents heading comes from one of two terms, chosen by context:
+
+| Term | Used for | English default |
+|------|----------|-----------------|
+| `toc-title-website` | pages of a `type: website` project rendered to HTML | On this page |
+| `toc-title-document` | everything else — standalone documents, books, and non-HTML output | Table of contents |
+
+Override whichever one applies to what you are rendering. On a website, setting
+`toc-title-document` has no effect on your pages:
+
+``` yaml
+---
+lang: es
+language:
+  toc-title-website: "En esta página"
+---
+```
+
+To set the heading for a single document regardless of context, use the `toc-title` option
+instead — it takes precedence over both terms and accepts markdown:
+
+``` yaml
+---
+toc: true
+toc-title: "On **this** page"
+---
+```
+
 ## Custom Translations
 
 To use a language Quarto doesn't ship a translation for:


### PR DESCRIPTION
Fixes bd-website-toc-title-wn80ymab.

On a website project, q2 rendered the page-TOC heading as "Table of contents" where Quarto 1 renders "On this page". Q1's language catalog carries two keys and picks between them by context; q2 always consulted `toc-title-document`. Real-world impact: ~324 of 352 pages in the Posit Connect docs port, currently masked in that project's visual-comparison sweeps.

## The fix

`toc_title_term(ctx)` in `crates/quarto-core/src/transforms/toc_generate.rs` selects the term. Mirrors Q1's condition at `src/command/render/pandoc.ts:493`:

```
projectIsWebsite(project) && !projectIsBook(project)
    && isHtmlOutput(format.pandoc, /* strict */ true)
```

Two of the three conditions carry over; the third is free:

- **Website** — read from `ProjectKind`, not from a `website:` key in merged metadata. `project: {type: website}` alone is a valid website (Q1 agrees), and a stray `website:` key in a standalone document is not a project-type claim. Custom project types already resolve to their base kind, so extension-defined website types work unchanged.
- **Not a book** — free here. Q1 needs `!projectIsBook` because its `projectIsWebsite` is true for books; `ProjectKind::Book` is a distinct variant.
- **Strict HTML** — compares `FormatIdentifier::Html` directly and deliberately **not** `Format::is_html()`, which delegates to `is_html_based()` and would also match `Revealjs`. Q1's `strict: true` excludes revealjs and epub. This check is load-bearing rather than incidental: `TocGenerateTransform` is pushed into the pipeline for *every* format, so without it a PDF render of a website project would say "On this page".

No new plumbing was needed — 34 of 36 files under `resources/language/` already ship `toc-title-website`, and `LanguageTerms::get` is a free-form lookup with no key allowlist. Only the key choice was missing.

## Tests

14 new: 8 unit (hand-built `RenderContext`) and 6 end-to-end (real `ProjectPipeline` over a temp project, so `project.type` resolves via `ProjectContext::discover` exactly as under `q2 render`).

Written first and confirmed red. 5 failed for the right reason; the other 9 are regression guards pinning currently-correct behavior (default / book / revealjs / pdf / user-title / no-catalog) that must stay green. The two localized failures reported `Índice` — Portuguese for the *document* term — which confirmed `_language-pt.yml` loads and the tests failed purely on key selection rather than a broken catalog.

`toc_markup.rs`'s pipeline harness was widened to `pub(crate)` and reused rather than cloning ~50 lines of setup; both files are sibling modules of the single `integration` binary.

## Verification

Full `cargo xtask verify` (incl. hub build + WASM): **14/14 steps, 12077/12077 tests**. Re-run after rebasing onto current `main`: **12130/12130**. `cargo xtask lint` clean. **No snapshot files added, modified, or removed.**

End-to-end through the real binary, output inspected:

```
$ q2 render .                    # repro website project
<h2 id="toc-title">On this page</h2>      # q2  — was "Table of contents"
<h2 id="toc-title">On this page</h2>      # Q1  — reference, now matched

website, no `website:` key   On this page
website, lang: pt            Nesta página
default project              Table of contents
book project                 Table of contents
standalone (no project)      Table of contents
```

Live `q2 preview` of a website project, after the full WASM → SPA → binary chain:

```js
{ tocTitleId: "toc-title", text: "On this page", tag: "H2" }
```

That last check matters: a plain `cargo build --bin q2` would have re-embedded the *old* SPA and shown pre-change output while every test passed (the 2026-05-20 incident in `CLAUDE.md`).

## Docs

Added a "Table of Contents Title" subsection to `docs/guides/authoring/document-language.qmd`, parallel to the existing "Cross-Reference Titles and Prefixes". The plan initially predicted no docs were needed; that was wrong. Nothing documented the *old* default, but the new behavior makes `toc-title-document` silently ineffective on websites with no diagnostic — precisely what a user cannot debug unaided. Rendered with q2 and inspected.

## Follow-up filed

**bd-aag27gmv** (p2) — consolidate the accumulated WASM build toolchains. Surfaced when `npm run build:wasm` failed here: `wasm-opt` (binaryen) became a hard dependency on 2026-08-13 via `1eeaae5d`, and `dev_setup.rs` checks for it but declines to install it. Two parallel toolchains coexist (`wasm-pack` for `wasm-qmd-parser` vs cargo + `wasm-bindgen-cli` + `wasm-opt` for `wasm-quarto-hub-client`) with three pinning strategies, including a one-sided binaryen pin: CI pins `binaryen@132.0.0` with a comment claiming byte-parity with local dev, but local dev has no pin at all.

Plan: `claude-notes/plans/2026-08-14-website-toc-title-on-this-page.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
