### PR TITLE
link-format attribute: author control over llms companion link targets

### DIFF
--- a/claude-notes/plans/2026-08-17-llms-link-target-annotation.md
+++ b/claude-notes/plans/2026-08-17-llms-link-target-annotation.md
@@ -3,7 +3,7 @@
 **Date:** 2026-08-17
 **Braid:** bd-llms-link-target-annotation-0zo2ppgx
 **Checkout:** main (investigation committed in place; implementation should get its own branch/worktree)
-**Status:** Investigation — pending design alignment with user. **Do not start implementation until the user gives the go-ahead.**
+**Status:** Design aligned 2026-08-17 (all five questions resolved — see Resolved design decisions). Ready to implement on a dedicated branch/worktree.
 
 ## Triage verdict
 
@@ -12,7 +12,7 @@ strand describes, the attribute slot (`Link::attr` kv pairs) is already
 plumbed through the parser, and the transform ordering (link-rewrite at the
 start of Finalization, llms capture at the tail) happens to be exactly the
 order the feature needs. One genuine design wrinkle surfaced (attribute
-stripping when llms-txt is *off* — see question 4); the rest is scoping and
+stripping when llms-txt is *off* — resolved as decision 4); the rest was scoping and
 naming.
 
 ## Issue context
@@ -47,7 +47,7 @@ on `window.location.pathname` in client-side JS, because Quarto (1 and 2)
 exposes no way to obtain a companion href. It hardcodes Q1's `.llms.md` and
 404s against q2's `.md` companions. Note: the *button* itself is an
 `include-in-header` HTML fragment, which a body-link attribute cannot serve
-— see design question 5.
+— resolved as decision 5 (follow-up bd-3n4fpr3g).
 
 Origin context: first proposed as a fix for companion-shadows-source-path
 namespace overlap, and rejected for that (measured ~100% false-positive rate
@@ -104,76 +104,121 @@ All verified at HEAD (main, post-`0ff7d795`):
   be emitted verbatim into the HTML `<a>` (the writer emits kv attrs), and
   `sanitize_attr` (llms.rs:331) only strips `data-*`/`aria-*`/`role`/
   `tabindex`, so it would leak into the companion too. Both consumers must
-  strip it; when llms is **off**, nothing currently would — question 4.
+  strip it; when llms is **off**, nothing currently would — decision 4.
 - **Repro** copied to
   `claude-notes/plans/llms-link-target-annotation-investigation/repro/`
   (`.md`-source 2-page website with `llms-txt: true`; render and compare
   `_site/index.html` vs `_site/index.md` to see the blanket retarget with no
   available override).
 
-## Proposed phases (draft)
+## Resolved design decisions (2026-08-17)
 
-Skeleton only — contents wait on the design discussion.
+1. **Attribute stays `link-format`, values `html` | `llms` — deliberately
+   general.** The generality is a feature, not a leak: Quarto 1 has long
+   lacked a facility for multi-output documents (`format: {html, docx,
+   pdf}`) to cross-link between their own output formats (Q1 does it
+   hackily in sidebars). Under this framing llms-txt is the "md" output of
+   a website, and `link-format` is the seed of a general
+   pick-the-output-format-of-a-link facility that can later grow a `pdf`
+   (etc.) value. The value `llms` also matches the conditional-content
+   format token (`when-format="llms"`).
 
-- **Phase 0 — Test plan (TDD).** Unit tests at both call sites
-  (retarget-skip with the html pin; companion resolution with the llms pin,
-  including draft/404/llms-off/unknown-target misses); e2e additions to
-  `crates/quarto-core/tests/integration/llms_txt.rs` (pinned links in both
-  outputs; attribute stripped from both outputs; attr inert when llms-txt
-  off); docs-page + catalog tests for any new Q-code.
-- **Phase 1 — `link-format="html"`** (opt out of companion retarget):
-  attr check at llms.rs:768, strip after consumption.
-- **Phase 2 — `link-format="llms"`** (target the companion from HTML):
-  resolution in `LinkRewriteTransform`/`resolve_doc_relative_href` mapping
-  output href through `companion_href`, gated on companion eligibility;
-  strip after consumption; diagnostics for unsatisfiable pins (question 3).
-- **Phase 3 — attribute hygiene when llms-txt is off** (per question 4's
-  answer).
-- **Phase 4 — Docs**: `docs/guides/projects/llms-txt.qmd` section; error
-  pages for new Q-codes in the same commit (error-docs lint).
+2. **Target spelling: source paths only (max-DRY).** Link *targets* are
+   always authored as source paths (`guide/index.qmd` / `guide/index.md`),
+   as body links are today; the *attribute* alone determines which output
+   format the link resolves to. The attribute's material purpose is to
+   steer the rewrite; its diagnostic purpose is to check the request is
+   consistent and warn otherwise. No fragment-only/self-link spelling; no
+   output-path (`.html`) spelling blessed for the attribute. Links inside
+   `RawBlock`/`RawInline` get no help — standard "you may do it, but
+   you're breaking the warranty" territory.
 
-## Open design questions for the user
+3. **Diagnostics: warn on unsatisfiable pins, fall back to the html
+   output.** A decorated link that cannot be honored warns with one new
+   Q-code (docs page in the same commit, per the error-docs lint):
+   `link-format="llms"` when llms-txt is disabled; target is a
+   draft/404/non-page or not resolvable as a source path; value neither
+   `html` nor `llms`. Undecorated links stay diagnostic-free, exactly as
+   today.
 
-1. **Attribute name and values.** The strand proposes
-   `link-format="html" | "llms"`. The value `llms` matches the existing
-   conditional-content format token (`when-format="llms"`), which argues
-   for it over `md`/`companion`. Is `link-format` the right key? (It reads
-   as "format of the link target", but a future reader might expect it to
-   affect e.g. PDF output too — it is llms-specific today. Alternative:
-   `llms-link="keep-html" | "target"`-style naming that wears its scope.)
-2. **Target spelling under `link-format="llms"`.** What may the author
-   write? (a) a source path (`guide/index.md` / `guide/index.qmd`),
-   resolved through the index then mapped to the companion — consistent
-   with how all body links are authored today (recommended); (b) also
-   accept the output spelling (`guide/index.html`); (c) also accept it on
-   a *fragment-only or self* link (e.g. `[](){link-format="llms"}`) as
-   "this page's companion"? The Connect-docs button wants the *current*
-   page's companion, so (c) is the only spelling that serves it from
-   markdown — but see question 5.
-3. **Diagnostics for unsatisfiable pins.** The strand promises "no new
-   diagnostics" for undecorated links, but a *decorated* link that cannot
-   be honored seems worth a warning: `link-format="llms"` when llms-txt is
-   disabled, when the target is a draft/404/non-page, or when the value is
-   neither `html` nor `llms`. Warn-and-fall-back-to-`.html` with one new
-   Q-code (docs page same commit)? Or stay fully silent to keep the
-   feature diagnostic-free?
-4. **Attribute stripping when llms-txt is off.** `link-format="html"` must
-   *survive* link-rewrite (start of Finalization) so capture (tail) can
-   honor it — but when llms is off, capture self-gates out and the attr
-   would leak into the emitted HTML. Options: (a) `LinkRewriteTransform`
-   strips it eagerly when `llms_view_active` is false (it already walks
-   every link; near-zero cost); (b) let `LlmsCaptureTransform`'s disabled
-   path do a cheap link-only scrub walk; (c) accept the leak (rejected —
-   it's author-visible noise in the DOM). I lean (a).
-5. **Is the "current page's companion href" affordance in scope?** The
-   real-world case-2 motivator (Connect docs button) lives in an
-   `include-in-header` HTML fragment, which cannot carry a Pandoc link
-   attribute. Serving it needs the companion href exposed another way — a
-   template variable / metadata field (e.g. `quarto.doc.llms-href`) or a
-   shortcode. Should this strand (a) stay attribute-only and file the
-   href-exposure as a separate discovered-from strand, or (b) include it?
-   (a) keeps this strand small; the strand text itself only asks for the
-   attribute.
+4. **Attribute hygiene: `LinkRewriteTransform` strips `link-format`
+   eagerly when `llms_view_active` is false** (it already walks every
+   link; near-zero cost). When llms *is* active, the attr survives to
+   `LlmsCaptureTransform`, which consumes it for the llms view and must
+   also scrub it from the original (HTML-bound) AST after cloning.
+
+5. **Companion-href exposure is a follow-up: bd-3n4fpr3g**
+   (discovered-from this strand). Shortcode, metadata/template variable,
+   and a Lua API entry point are all wanted, but there is not enough
+   context to design the exposure surface well yet. This strand stays
+   attribute-only.
+
+## Phases and work items
+
+TDD throughout: each phase's tests written and observed failing before
+implementation.
+
+### Phase 0 — Test plan (failing tests first)
+
+- [ ] Unit tests, capture side (llms.rs): a Link carrying
+      `link-format="html"` is not retargeted in the llms view and the
+      attr is absent from both views; undecorated sibling link still
+      retargets (control).
+- [ ] Unit tests, rewrite side (link_rewrite.rs): source-path link with
+      `link-format="llms"` resolves to the companion href (page-relative,
+      depth ≥ 1 case included); attr stripped; fragment/query tails
+      preserved.
+- [ ] Unit tests, diagnostics: `link-format="llms"` with llms-txt off /
+      draft target / 404 / unresolvable source path / unknown attr value
+      each warn with the new Q-code and fall back to the html resolution;
+      undecorated links never warn (pin).
+- [ ] Unit test, hygiene: with llms-txt off, `link-format` (both values)
+      is stripped by `LinkRewriteTransform` and behavior is exactly
+      today's.
+- [ ] E2E additions to `crates/quarto-core/tests/integration/llms_txt.rs`:
+      render the investigation repro extended with decorated links; assert
+      the html page links the `.md` companion under `link-format="llms"`,
+      the companion keeps `.html` under `link-format="html"`, and neither
+      output contains the string `link-format`.
+- [ ] Pinning test: in a `.qmd`-source project a literal
+      `[x](guide/index.md)` (undecorated) still falls through silently as
+      a static resource (bd-6d2wj4zp D6 — must not regress).
+- [ ] Q-code catalog entry + `docs/errors/` page (error-docs lint green).
+
+### Phase 1 — `link-format="html"` (opt out of companion retarget)
+
+- [ ] Attr check at the Link call site (llms.rs:768) — skip
+      `retarget_href`, strip the attr (both views; original AST scrub per
+      decision 4).
+- [ ] Listing synthesizer call site (llms.rs:490) untouched (no authored
+      attrs — verify with a comment/test).
+
+### Phase 2 — `link-format="llms"` (target the companion from HTML)
+
+- [ ] `LinkRewriteTransform`: on a decorated link, resolve the source path
+      via `ProjectIndex::lookup_by_source`, gate on llms enabled +
+      `profile_has_companion`, map through `companion_href`, relativize
+      via the resolver; strip the attr; emit the Phase-0 diagnostics on
+      any miss and fall back to normal resolution.
+- [ ] Confirm the capture pass leaves the resulting `.md` link untouched
+      in the companion (retarget only touches `.html` paths — pin with a
+      test).
+
+### Phase 3 — Attribute hygiene when llms-txt is off
+
+- [ ] Eager strip in `LinkRewriteTransform` when `llms_view_active` is
+      false (decision 4), including the warn-on-`llms`-value diagnostic
+      from Phase 0.
+
+### Phase 4 — E2E verification + docs
+
+- [ ] `cargo run --bin q2 -- render` on the investigation repro; inspect
+      `_site/index.html` and `_site/index.md`; record invocation + output
+      snippet here.
+- [ ] User-facing docs: `docs/guides/projects/llms-txt.qmd` section on
+      `link-format` (rendered with `cargo run --bin q2 -- render docs/`).
+- [ ] Full `cargo xtask verify` before push (quarto-core change → WASM
+      leg).
 
 ## Risks / tradeoffs (draft)
 
@@ -181,7 +226,7 @@ Skeleton only — contents wait on the design discussion.
   site (llms.rs:768), not inside the pure helper — keeps the existing unit
   tests (`retarget_rewrites_eligible_links_only`) valid and the listing
   synthesizer unaffected.
-- **New Q-code cost.** Any diagnostic decision in question 3 drags in a
+- **New Q-code cost.** Decision 3's warning drags in a
   catalog entry + `docs/errors/` page in the same commit (error-docs lint
   enforces this).
 - **WASM surface.** No `RenderOutput`/wire-shape changes anticipated — this

--- a/claude-notes/plans/2026-08-17-llms-link-target-annotation.md
+++ b/claude-notes/plans/2026-08-17-llms-link-target-annotation.md
@@ -261,8 +261,9 @@ green pins — attr-survival and the D6 static fallthrough).
       worktree. Filed **bd-u7kdy6fy** (discovered-from this strand);
       worked around by copying the main checkout's staged
       `docs/examples/` (gitignored).
-- [ ] Full `cargo xtask verify` before push (quarto-core change → WASM
-      leg).
+- [x] Full `cargo xtask verify` green in the worktree, 2026-08-17
+      (all 14 steps, including the WASM/hub-client legs), after
+      commit `d33e82c3`. Ready for push pending user approval.
 
 ## Risks / tradeoffs (draft)
 

--- a/claude-notes/plans/2026-08-17-llms-link-target-annotation.md
+++ b/claude-notes/plans/2026-08-17-llms-link-target-annotation.md
@@ -1,0 +1,196 @@
+# llms-txt: author-facing link-target annotation (bd-llms-link-target-annotation-0zo2ppgx)
+
+**Date:** 2026-08-17
+**Braid:** bd-llms-link-target-annotation-0zo2ppgx
+**Checkout:** main (investigation committed in place; implementation should get its own branch/worktree)
+**Status:** Investigation — pending design alignment with user. **Do not start implementation until the user gives the go-ahead.**
+
+## Triage verdict
+
+**Ready to design.** Both transforms the feature touches exist exactly as the
+strand describes, the attribute slot (`Link::attr` kv pairs) is already
+plumbed through the parser, and the transform ordering (link-rewrite at the
+start of Finalization, llms capture at the tail) happens to be exactly the
+order the feature needs. One genuine design wrinkle surfaced (attribute
+stripping when llms-txt is *off* — see question 4); the rest is scoping and
+naming.
+
+## Issue context
+
+Feature, priority 3, label `websites`, filed today (2026-08-17) by Carlos —
+assumptions fresh. With `website.llms-txt: true`, two things an author
+cannot express:
+
+1. **Keep a link on the HTML page even inside the markdown companion** —
+   `LlmsCaptureTransform` blanket-retargets every same-site `.html` link
+   whose target has a companion to its `.md` sibling; the only escapes are
+   drafts, the 404 page, external URLs, and non-page resources.
+2. **Point a link at the markdown companion from the HTML page** — a "view
+   the markdown for this page" affordance is unauthorable:
+   `LinkRewriteTransform` resolves any source-path link to the `.html`
+   output href, so the companion is unreachable by authored link (in
+   `.md`-source projects unconditionally; in `.qmd`-source projects a
+   literal `.md` href happens to fall through as a static resource, but by
+   accident, with no contract).
+
+Proposed mechanism (from the strand): a link attribute honored by both
+transforms —
+
+    [text](guide/index.md){link-format="html"}   # companion keeps .html
+    [text](guide/index.md){link-format="llms"}   # HTML page links companion
+
+Absent the attribute, behavior is exactly today's — purely opt-in.
+
+Real-world motivation for case 2: the Posit Connect docs' "Copy for LLM /
+View as Markdown" button pair computes the companion URL by string surgery
+on `window.location.pathname` in client-side JS, because Quarto (1 and 2)
+exposes no way to obtain a companion href. It hardcodes Q1's `.llms.md` and
+404s against q2's `.md` companions. Note: the *button* itself is an
+`include-in-header` HTML fragment, which a body-link attribute cannot serve
+— see design question 5.
+
+Origin context: first proposed as a fix for companion-shadows-source-path
+namespace overlap, and rejected for that (measured ~100% false-positive rate
+on the Connect docs; full analysis preserved at
+`claude-notes/plans/llms-link-target-annotation-investigation/origin-repro-README.md`).
+The expressiveness gap stands on its own; the strand asks only for that.
+
+## Dependency graph
+
+**Empty in the q2 skein** (`dep tree` / `dep list`: no edges). Context comes
+from outside the graph:
+
+- **Parent feature**: bd-llms-txt-unimplemented-oih6z6j7 (in_progress —
+  implementation merged to main in `2c144619`, plus follow-ups `b7bfeef8`,
+  `0ff7d795`). Its plan
+  (`claude-notes/plans/2026-08-14-llms-txt-website-support.md`) resolved
+  decision 4 as "rewrite in-body links to `.md` siblings" — this strand adds
+  the per-link override that decision didn't contemplate.
+- **Origin strand** br-llms-link-target-annotation-nf84d314 lives in the
+  Connect-docs-port skein (not resolvable from here).
+- Sibling open llms strands, none conflicting: bd-to3vh0od (code
+  annotations, inert), bd-3ar95048 (section-heading markup flattening).
+
+## What the code looks like today
+
+All verified at HEAD (main, post-`0ff7d795`):
+
+- **Retarget side** — `retarget_href`
+  (`crates/quarto-core/src/transforms/llms.rs:813`): pure
+  `(&str, &ViewContext) -> String`; called from `clean_inline` for body
+  links (llms.rs:768) and from the listing-item synthesizer (llms.rs:490).
+  Skips external/fragment/`data:`/`mailto:`, non-`.html` paths, and targets
+  whose profile fails `profile_has_companion` (draft / 404 / non-html).
+  **No attribute check** — the caller at :768 has the `Link` (and thus
+  `link.attr`) in hand, so an attr-aware skip belongs at the call site, not
+  in the pure href helper. The listing call site synthesizes links with no
+  authored attrs — unaffected.
+- **Rewrite side** — `resolve_doc_relative_href`
+  (`crates/quarto-core/src/transforms/navigation_href.rs:328`), called from
+  `LinkRewriteTransform` (`transforms/link_rewrite.rs:239`): resolves via
+  `ProjectIndex::lookup_by_source`, returns the target's **output href**
+  (`.html`). `.md` misses stay deliberately silent (bd-6d2wj4zp D6) and fall
+  through to static-resource resolution. `profile.output_href` →
+  companion href mapping already exists as `companion_href` (llms.rs:125),
+  and companion eligibility as `profile_has_companion` (llms.rs:134) — both
+  `pub`, both reusable from link_rewrite.
+- **Ordering is favorable**: `LinkRewriteTransform` runs at the start of
+  Finalization, `LlmsCaptureTransform` at the tail (pipeline.rs:1501,
+  unconditionally registered, self-gated on `llms_view_active`). So an attr
+  consumed by link-rewrite is gone before capture; an attr left for capture
+  survives to it. Capture clones the AST for the llms view **and holds
+  `&mut ast`** for the HTML side, so it can strip consumed attrs from both.
+- **Leak check (verified)**: today an authored `{link-format="html"}` would
+  be emitted verbatim into the HTML `<a>` (the writer emits kv attrs), and
+  `sanitize_attr` (llms.rs:331) only strips `data-*`/`aria-*`/`role`/
+  `tabindex`, so it would leak into the companion too. Both consumers must
+  strip it; when llms is **off**, nothing currently would — question 4.
+- **Repro** copied to
+  `claude-notes/plans/llms-link-target-annotation-investigation/repro/`
+  (`.md`-source 2-page website with `llms-txt: true`; render and compare
+  `_site/index.html` vs `_site/index.md` to see the blanket retarget with no
+  available override).
+
+## Proposed phases (draft)
+
+Skeleton only — contents wait on the design discussion.
+
+- **Phase 0 — Test plan (TDD).** Unit tests at both call sites
+  (retarget-skip with the html pin; companion resolution with the llms pin,
+  including draft/404/llms-off/unknown-target misses); e2e additions to
+  `crates/quarto-core/tests/integration/llms_txt.rs` (pinned links in both
+  outputs; attribute stripped from both outputs; attr inert when llms-txt
+  off); docs-page + catalog tests for any new Q-code.
+- **Phase 1 — `link-format="html"`** (opt out of companion retarget):
+  attr check at llms.rs:768, strip after consumption.
+- **Phase 2 — `link-format="llms"`** (target the companion from HTML):
+  resolution in `LinkRewriteTransform`/`resolve_doc_relative_href` mapping
+  output href through `companion_href`, gated on companion eligibility;
+  strip after consumption; diagnostics for unsatisfiable pins (question 3).
+- **Phase 3 — attribute hygiene when llms-txt is off** (per question 4's
+  answer).
+- **Phase 4 — Docs**: `docs/guides/projects/llms-txt.qmd` section; error
+  pages for new Q-codes in the same commit (error-docs lint).
+
+## Open design questions for the user
+
+1. **Attribute name and values.** The strand proposes
+   `link-format="html" | "llms"`. The value `llms` matches the existing
+   conditional-content format token (`when-format="llms"`), which argues
+   for it over `md`/`companion`. Is `link-format` the right key? (It reads
+   as "format of the link target", but a future reader might expect it to
+   affect e.g. PDF output too — it is llms-specific today. Alternative:
+   `llms-link="keep-html" | "target"`-style naming that wears its scope.)
+2. **Target spelling under `link-format="llms"`.** What may the author
+   write? (a) a source path (`guide/index.md` / `guide/index.qmd`),
+   resolved through the index then mapped to the companion — consistent
+   with how all body links are authored today (recommended); (b) also
+   accept the output spelling (`guide/index.html`); (c) also accept it on
+   a *fragment-only or self* link (e.g. `[](){link-format="llms"}`) as
+   "this page's companion"? The Connect-docs button wants the *current*
+   page's companion, so (c) is the only spelling that serves it from
+   markdown — but see question 5.
+3. **Diagnostics for unsatisfiable pins.** The strand promises "no new
+   diagnostics" for undecorated links, but a *decorated* link that cannot
+   be honored seems worth a warning: `link-format="llms"` when llms-txt is
+   disabled, when the target is a draft/404/non-page, or when the value is
+   neither `html` nor `llms`. Warn-and-fall-back-to-`.html` with one new
+   Q-code (docs page same commit)? Or stay fully silent to keep the
+   feature diagnostic-free?
+4. **Attribute stripping when llms-txt is off.** `link-format="html"` must
+   *survive* link-rewrite (start of Finalization) so capture (tail) can
+   honor it — but when llms is off, capture self-gates out and the attr
+   would leak into the emitted HTML. Options: (a) `LinkRewriteTransform`
+   strips it eagerly when `llms_view_active` is false (it already walks
+   every link; near-zero cost); (b) let `LlmsCaptureTransform`'s disabled
+   path do a cheap link-only scrub walk; (c) accept the leak (rejected —
+   it's author-visible noise in the DOM). I lean (a).
+5. **Is the "current page's companion href" affordance in scope?** The
+   real-world case-2 motivator (Connect docs button) lives in an
+   `include-in-header` HTML fragment, which cannot carry a Pandoc link
+   attribute. Serving it needs the companion href exposed another way — a
+   template variable / metadata field (e.g. `quarto.doc.llms-href`) or a
+   shortcode. Should this strand (a) stay attribute-only and file the
+   href-exposure as a separate discovered-from strand, or (b) include it?
+   (a) keeps this strand small; the strand text itself only asks for the
+   attribute.
+
+## Risks / tradeoffs (draft)
+
+- **`retarget_href` purity.** The attr check must live at the Link call
+  site (llms.rs:768), not inside the pure helper — keeps the existing unit
+  tests (`retarget_rewrites_eligible_links_only`) valid and the listing
+  synthesizer unaffected.
+- **New Q-code cost.** Any diagnostic decision in question 3 drags in a
+  catalog entry + `docs/errors/` page in the same commit (error-docs lint
+  enforces this).
+- **WASM surface.** No `RenderOutput`/wire-shape changes anticipated — this
+  is AST-transform-internal — but `quarto-core` changes still require full
+  `cargo xtask verify` before push (CLAUDE.md).
+- **`.qmd`-source projects' accidental `.md` pass-through.** Today a
+  literal `[x](guide/index.md)` in a `.qmd` project reaches the companion
+  by falling through to static-resource resolution. Once `link-format="llms"`
+  exists, that accidental path becomes redundant but must not regress
+  (bd-6d2wj4zp D6 keeps `.md` misses silent) — worth a pinning test.
+- **Pre-flight verify**: `cargo xtask verify --skip-hub-build` green at
+  HEAD, all 14 steps passed (12213 tests), 2026-08-17.

--- a/claude-notes/plans/2026-08-17-llms-link-target-annotation.md
+++ b/claude-notes/plans/2026-08-17-llms-link-target-annotation.md
@@ -160,63 +160,107 @@ implementation.
 
 ### Phase 0 — Test plan (failing tests first)
 
-- [ ] Unit tests, capture side (llms.rs): a Link carrying
+All written 2026-08-17 and observed failing as expected before
+implementation (15 tests: 13 red for missing behavior, 2 trivially
+green pins — attr-survival and the D6 static fallthrough).
+
+- [x] Unit tests, capture side (llms.rs): a Link carrying
       `link-format="html"` is not retargeted in the llms view and the
       attr is absent from both views; undecorated sibling link still
       retargets (control).
-- [ ] Unit tests, rewrite side (link_rewrite.rs): source-path link with
+- [x] Unit tests, rewrite side (link_rewrite.rs): source-path link with
       `link-format="llms"` resolves to the companion href (page-relative,
       depth ≥ 1 case included); attr stripped; fragment/query tails
       preserved.
-- [ ] Unit tests, diagnostics: `link-format="llms"` with llms-txt off /
+- [x] Unit tests, diagnostics: `link-format="llms"` with llms-txt off /
       draft target / 404 / unresolvable source path / unknown attr value
       each warn with the new Q-code and fall back to the html resolution;
       undecorated links never warn (pin).
-- [ ] Unit test, hygiene: with llms-txt off, `link-format` (both values)
+- [x] Unit test, hygiene: with llms-txt off, `link-format` (both values)
       is stripped by `LinkRewriteTransform` and behavior is exactly
       today's.
-- [ ] E2E additions to `crates/quarto-core/tests/integration/llms_txt.rs`:
+- [x] E2E additions to `crates/quarto-core/tests/integration/llms_txt.rs`:
       render the investigation repro extended with decorated links; assert
       the html page links the `.md` companion under `link-format="llms"`,
       the companion keeps `.html` under `link-format="html"`, and neither
       output contains the string `link-format`.
-- [ ] Pinning test: in a `.qmd`-source project a literal
+- [x] Pinning test: in a `.qmd`-source project a literal
       `[x](guide/index.md)` (undecorated) still falls through silently as
       a static resource (bd-6d2wj4zp D6 — must not regress).
-- [ ] Q-code catalog entry + `docs/errors/` page (error-docs lint green).
+- [x] Q-code catalog entry + `docs/errors/` page (error-docs lint green).
 
 ### Phase 1 — `link-format="html"` (opt out of companion retarget)
 
-- [ ] Attr check at the Link call site (llms.rs:768) — skip
-      `retarget_href`, strip the attr (both views; original AST scrub per
-      decision 4).
-- [ ] Listing synthesizer call site (llms.rs:490) untouched (no authored
-      attrs — verify with a comment/test).
+- [x] Attr check at the Link call site (`clean_inline`'s Link arm) —
+      reads the pin before `sanitize_attr` (whose `kv_noise` now also
+      consumes `link-format`), skips `retarget_href` when pinned; the
+      html-bound AST is scrubbed by a `strip_kv` in
+      `keep_inline_in_html`'s Link arm.
+- [x] Listing synthesizer call site untouched (synthesized links carry
+      no authored attrs; existing listing tests unchanged and green).
 
 ### Phase 2 — `link-format="llms"` (target the companion from HTML)
 
-- [ ] `LinkRewriteTransform`: on a decorated link, resolve the source path
-      via `ProjectIndex::lookup_by_source`, gate on llms enabled +
-      `profile_has_companion`, map through `companion_href`, relativize
-      via the resolver; strip the attr; emit the Phase-0 diagnostics on
-      any miss and fall back to normal resolution.
-- [ ] Confirm the capture pass leaves the resulting `.md` link untouched
-      in the companion (retarget only touches `.html` paths — pin with a
-      test).
+- [x] `LinkRewriteTransform::apply_link_format`: resolves the source
+      path via `resolve_doc_relative_target` + `lookup_by_source`, gates
+      on `llms_view_active` + `profile_has_companion`, maps through
+      `companion_href` and the resolver's `page_url_for` (tail
+      preserved); strips the attr; Q-13-9 on every unsatisfiable case
+      with fallback to `resolve_undecorated`. Satisfiable `html` pins
+      keep the attr for `LlmsCaptureTransform`.
+- [x] Capture pass leaves the resulting `.md` link untouched in the
+      companion (retarget only touches `.html` paths; pinned by
+      `llms_link_format_llms_links_companion_from_html`).
+- [x] **Refinement discovered during implementation (TDD'd
+      2026-08-17):** the `llms`-pin gate is *config-level*
+      (`llms_companions_enabled` = website + `llms-txt: true`), not
+      the linking page's own format — a revealjs deck legitimately
+      links another page's companion
+      (`link_format_llms_from_revealjs_page_succeeds`). And
+      `profile_has_companion` now requires
+      `lua_format_for(format_id) == "html"`: a revealjs page renders
+      to `.html` but capture never runs for it, so it has no
+      companion. This also fixes a **pre-existing** hole where the
+      blanket retarget pointed companion links at a slide deck's
+      nonexistent `.md` sibling
+      (`retarget_leaves_revealjs_targets_alone`).
 
 ### Phase 3 — Attribute hygiene when llms-txt is off
 
-- [ ] Eager strip in `LinkRewriteTransform` when `llms_view_active` is
-      false (decision 4), including the warn-on-`llms`-value diagnostic
-      from Phase 0.
+- [x] Eager strip in `LinkRewriteTransform` when `llms_view_active` is
+      false (decision 4), including the warn-on-`llms`-value diagnostic;
+      the transform's no-index/no-resolver early return was removed so
+      the walk always consumes the attribute (pure no-op otherwise —
+      both helpers return `raw` verbatim without index/resolver).
 
 ### Phase 4 — E2E verification + docs
 
-- [ ] `cargo run --bin q2 -- render` on the investigation repro; inspect
-      `_site/index.html` and `_site/index.md`; record invocation + output
-      snippet here.
-- [ ] User-facing docs: `docs/guides/projects/llms-txt.qmd` section on
-      `link-format` (rendered with `cargo run --bin q2 -- render docs/`).
+- [x] `cargo run --bin q2 -- render <scratch>/link-format-e2e` (the
+      investigation repro extended with decorated links; `.md`-source
+      website, `llms-txt: true`). Output inspected. `_site/index.html`:
+      `<a href="index.md">View this page as Markdown</a>` (llms
+      self-pin), `<a href="guide/index.md">guide markdown</a>` (llms
+      cross-pin), `<a href="guide/index.html">guide pinned</a>` (html
+      pin), `<a href="guide/index.html">guide</a>` (undecorated).
+      `_site/index.md` companion: `(index.md)`, `(guide/index.md)`,
+      html pin kept `(guide/index.html)`, undecorated retargeted
+      `(guide/index.md)`. `grep -c link-format` = 0 in both outputs.
+      Second fixture without `llms-txt`: render succeeds with
+      `Warning: [Q-13-9]` carrying the exact source span of the URL
+      (`index.md:5:6`) plus problem + hint.
+- [x] User-facing docs: "Choosing a link's target: `link-format`"
+      section in `docs/guides/projects/llms-txt.qmd`; error page
+      `docs/errors/navigation/Q-13-9.qmd`. Verified:
+      `cargo run --bin q2 -- render docs/` → 244/244 rendered; the
+      section and Q-13-9 page appear in `_site`; the 31 warnings are
+      pre-existing (`brand.qmd` / `figures.qmd` Q-13-4/Q-5-6, none in
+      the touched pages, no Q-13-9 fired).
+- [x] Discovered while rendering docs from the worktree:
+      `cargo xtask stage-doc-examples` resolves `repo_root()` via
+      `--git-common-dir` and stages the **main checkout**, not the
+      worktree. Filed **bd-u7kdy6fy** (discovered-from this strand);
+      worked around by copying the main checkout's staged
+      `docs/examples/` (gitignored).
 - [ ] Full `cargo xtask verify` before push (quarto-core change → WASM
       leg).
 

--- a/claude-notes/plans/llms-link-target-annotation-investigation/origin-repro-README.md
+++ b/claude-notes/plans/llms-link-target-annotation-investigation/origin-repro-README.md
@@ -1,0 +1,120 @@
+# llms-txt companions occupy the source-path namespace in the output tree
+
+Observed with **q2 0.22.0** (`q2 (quarto 2) 0.22.0`).
+
+`q2 render` in this directory, then look at the output tree.
+
+## What happens
+
+With `website.llms-txt: true`, q2 writes each page's markdown companion to
+`<page>.md` — the same relative path the *source* file occupies. For a
+project whose pages are `.md` files (like the Connect docs), the output
+tree ends up carrying a file at every source path:
+
+```
+_site/index.html          _site/index.md
+_site/guide/index.html    _site/guide/index.md
+```
+
+This is deliberate: q2's design plan (`claude-notes/plans/2026-08-14-llms-txt-website-support.md`,
+decision 2) chose `<page>.md` over Quarto 1's `<page>.llms.md` because it
+is the ecosystem convention, gated on a collision-safe write mechanism.
+That mechanism exists and works — see "What is already guarded" below.
+
+The unguarded consequence is on the *serve* side. A link that names a
+source path and does not go through q2's link rewriter now resolves to
+the companion instead of 404ing. `index.md` in this repro has three links
+to the same page:
+
+| link as authored | href emitted |
+|---|---|
+| `[guide](guide/index.md)` (markdown) | `guide/index.html` ✅ rewritten |
+| `[guide](guide/index.html)` (markdown) | `guide/index.html` ✅ |
+| `<a href="guide/index.md">` (raw HTML) | `guide/index.md` ⚠️ verbatim |
+
+The rewriter itself is not confused — it drives off the source index, and
+every markdown link is rewritten correctly. But q2 does not parse HTML, so
+the raw-HTML href passes through untouched, and `_site/guide/index.md` now
+exists. The reader who clicks it gets raw markdown (served as
+`text/markdown` or downloaded, depending on the host) instead of the page.
+
+Before llms-txt existed, that same link was a 404: loud, and catchable by
+any link checker. Now it is a 200 serving the wrong content — the failure
+mode q2's own Q-5-24 rationale ("a silently wrong file is worse than
+failing") exists to avoid, moved from the write side to the serve side.
+
+Raw HTML is the form this repro pins because it is self-contained. The
+same shadowing applies to any other href the rewriter does not reach.
+
+**How much does that matter?** Measured on the Connect docs, very little:
+1670 in-body markdown `.md` links are all rewritten correctly, as are the
+161 config `file:` entries (a navbar `href: index.md` renders as
+`../../index.html` on a depth-2 page), and there are zero raw-HTML `.md`
+hrefs in the sources. Exactly one link escapes — `quarto-tiers.url:
+"/admin/licensing/index.md#product-tiers"` in `_quarto.yml`, a *custom
+metadata key* read by the posit-docs project type, which q2 has no way to
+recognize as a link. That one entry accounts for all 49 affected pages,
+and it is already `br-root-absolute-assets-1o6yy4mx`'s subject.
+
+So q2 rewrites every link it owns. The cost of the shadowing is not wrong
+rendering — it is lost *detectability*: that link used to 404.
+
+## Scope check: only `.md` sources are exposed
+
+With `.qmd` sources the source-path namespace and the companion namespace
+do not overlap, so nothing is shadowed. Verified: in a `.qmd` project, a
+raw-HTML link to `guide/index.qmd` renders verbatim and **404s** — the
+loud failure you want — while only the `.md` spelling finds a companion.
+The exposure is exactly `.md` sources + `llms-txt`.
+
+## Expected
+
+Given the measured blast radius, the rendering behavior is defensible as
+is. What is worth fixing is detection:
+
+1. **Tooling (this repo).** `llms-info/tools/site-asset-check.py --links`
+   currently reports the shadowed references as resolving. It should treat
+   a target that is both a page source path and a companion path as
+   suspect. This is where the real fix belongs.
+2. **Docs.** Point the one escaping `quarto-tiers.url` at the `.html` path
+   — tracked in `br-root-absolute-assets-1o6yy4mx`.
+3. **q2, optional.** A distinct `.llms.md` namespace would restore 404-ing
+   at the cost of the ecosystem convention. Not obviously worth it.
+
+Rejected: requiring authors to decorate ambiguous links with an attribute
+(`link-format="html"` vs `"llms"`) and warning on undecorated ones. Pass-2
+detection is feasible — `LinkRewriteTransform` holds the `ProjectIndex`,
+the website config, and each resolved target — but the mechanism aims at
+the wrong population. The 1670 links that could carry an attribute are the
+ones already correct; the single escapee is custom metadata that cannot
+carry a Pandoc attribute. The warning would fire at ~100% false positive.
+
+Worth pursuing separately: there is no way to author a link that
+*deliberately* targets a companion, nor to opt out of
+`LlmsCaptureTransform`'s blanket `.html`→`.md` retarget (its only escapes
+are drafts, 404, external URLs, and non-page resources). An attribute
+would fit that architecture cleanly — as an expressiveness feature, not as
+a fix for this.
+
+## Quarto 1 for comparison
+
+Q1 writes `<page>.llms.md`, so the source-path namespace stays empty in the
+output tree and a source-path link 404s. Q1 also rewrote raw-HTML hrefs,
+because it parsed the rendered HTML — q2 deliberately does not, which is
+settled (see `br-website-image-resources-vwy2548v`) and not what this
+strand contests.
+
+## What is already guarded
+
+The write side. A user file at a companion path is not clobbered — q2
+keeps a `.quarto/llms-manifest.json` ledger and errors on any planned
+write it cannot prove is its own:
+
+```
+Error [Q-5-28]: `about.md` already exists in the output directory and was
+not generated by `llms-txt`
+```
+
+Verified separately (page `about.qmd` plus a hand-written `about.md`
+declared in `project.resources`). That guard is working as designed; this
+strand is about the namespace overlap it does not address.

--- a/claude-notes/plans/llms-link-target-annotation-investigation/repro/_quarto.yml
+++ b/claude-notes/plans/llms-link-target-annotation-investigation/repro/_quarto.yml
@@ -1,0 +1,11 @@
+project:
+  type: website
+  render:
+    - "**/*.md"
+website:
+  title: Companion namespace
+  llms-txt: true
+  sidebar:
+    contents:
+      - index.md
+      - guide/index.md

--- a/claude-notes/plans/llms-link-target-annotation-investigation/repro/guide/index.md
+++ b/claude-notes/plans/llms-link-target-annotation-investigation/repro/guide/index.md
@@ -1,0 +1,6 @@
+---
+title: Guide
+---
+
+This page renders to `guide/index.html`. Its llms companion is written to
+`guide/index.md` — the same relative path the source file has.

--- a/claude-notes/plans/llms-link-target-annotation-investigation/repro/index.md
+++ b/claude-notes/plans/llms-link-target-annotation-investigation/repro/index.md
@@ -1,0 +1,13 @@
+---
+title: Home
+---
+
+Three links, all naming the same page.
+
+- markdown link to the source path: [guide](guide/index.md)
+- markdown link to the output path: [guide](guide/index.html)
+
+```{=html}
+<p>raw HTML link to the source path:
+<a href="guide/index.md">guide</a></p>
+```

--- a/crates/quarto-core/src/transforms/link_rewrite.rs
+++ b/crates/quarto-core/src/transforms/link_rewrite.rs
@@ -41,7 +41,9 @@
 //!   (standalone single-doc render) — doc-link resolution needs the
 //!   index (Decision 7). Images still rewrite whenever a
 //!   [`ResourceResolverContext`] is attached; with neither index nor
-//!   resolver the transform short-circuits entirely.
+//!   resolver the walk still runs but rewrites nothing — it only
+//!   consumes `link-format` attributes (see [`LINK_FORMAT_ATTR`]),
+//!   which must never reach a writer.
 //!
 //! ## Pipeline placement
 //!
@@ -53,18 +55,34 @@
 //! nodes. The walk recurses through `Inline::Custom` slots
 //! defensively, in case any custom nodes remain.
 
+use quarto_error_reporting::{DiagnosticMessage, DiagnosticMessageBuilder};
 use quarto_pandoc_types::Slot;
 use quarto_pandoc_types::block::Block;
-use quarto_pandoc_types::inline::{Inline, Inlines};
+use quarto_pandoc_types::inline::{Inline, Inlines, Link};
 use quarto_pandoc_types::pandoc::Pandoc;
+use quarto_source_map::SourceInfo;
 
 use crate::Result;
 use crate::project::index::ProjectIndex;
 use crate::render::RenderContext;
 use crate::resource_resolver::ResourceResolverContext;
 use crate::transform::{AstTransform, TransformPhase};
+use crate::transforms::llms::{companion_href, profile_has_companion, strip_kv};
 use crate::transforms::navigation_active::page_relative_source;
-use crate::transforms::navigation_href::{resolve_doc_relative_href, resolve_static_resource_href};
+use crate::transforms::navigation_href::{
+    resolve_doc_relative_href, resolve_doc_relative_target, resolve_static_resource_href,
+};
+
+/// Attribute selecting which *output* of the target page a body link
+/// points at (bd-llms-link-target-annotation-0zo2ppgx). Recognized
+/// values today: `"html"` (keep the link on the HTML page, even
+/// inside llms markdown companions) and `"llms"` (point the link at
+/// the target page's markdown companion). The target must be written
+/// as a project *source* path (`guide/index.qmd`-style); the
+/// attribute alone selects the output. Consumed by this transform
+/// and, for the surviving `html` pin, by `LlmsCaptureTransform` — it
+/// must never reach a writer.
+pub const LINK_FORMAT_ATTR: &str = "link-format";
 
 /// Body-content link rewriter (Phase 6).
 pub struct LinkRewriteTransform;
@@ -94,14 +112,13 @@ impl AstTransform for LinkRewriteTransform {
     async fn transform(&self, ast: &mut Pandoc, ctx: &mut RenderContext) -> Result<()> {
         let index = ctx.project_index.as_deref();
         let resolver = ctx.resource_resolver.as_ref();
+        let llms_enabled = crate::transforms::llms::llms_companions_enabled(&ast.meta, ctx);
+        let llms_active = crate::transforms::llms::llms_view_active(&ast.meta, ctx);
 
-        // Nothing to resolve against: no index (so links can't be
-        // looked up — Decision 7) and no resolver (so image targets
-        // would pass through verbatim anyway). Skip the walk.
-        if index.is_none() && resolver.is_none() {
-            return Ok(());
-        }
-
+        // With no index (Decision 7) and no resolver, links and
+        // images pass through — but the walk still runs: it owns
+        // consuming `link-format` attributes, which must not reach
+        // the writer even in a bare standalone render.
         let source = page_relative_source(ctx);
 
         // Move diagnostics into a local buffer so the helper can
@@ -111,6 +128,8 @@ impl AstTransform for LinkRewriteTransform {
             source: &source,
             index,
             resolver,
+            llms_enabled,
+            llms_active,
             diagnostics: &mut local_diags,
         };
         for block in &mut ast.blocks {
@@ -128,6 +147,16 @@ struct LinkRewriter<'a> {
     /// (Decision 7) while image targets still rewrite.
     index: Option<&'a ProjectIndex>,
     resolver: Option<&'a ResourceResolverContext>,
+    /// `llms_companions_enabled`: the project generates markdown
+    /// companions (website + `llms-txt: true`). Gates `llms`-pin
+    /// satisfiability — any page of the site, whatever its own
+    /// format, may target another page's companion.
+    llms_enabled: bool,
+    /// `llms_view_active`: this render's own llms view (companions
+    /// enabled *and* plain html format). Gates whether an `html` pin
+    /// survives to its consumer (`LlmsCaptureTransform` runs only
+    /// then).
+    llms_active: bool,
     diagnostics: &'a mut Vec<quarto_error_reporting::DiagnosticMessage>,
 }
 
@@ -236,16 +265,10 @@ impl<'a> LinkRewriter<'a> {
                 // text could itself contain rewritable inlines
                 // (uncommon, but possible after filter passes).
                 self.visit_inlines(&mut link.content);
-                if let Some(index) = self.index {
-                    let new_url = resolve_doc_relative_href(
-                        &link.target.0,
-                        self.source,
-                        self.resolver,
-                        Some(index),
-                        link.target_source.url.clone(),
-                        self.diagnostics,
-                    );
-                    link.target.0 = new_url;
+                if link.attr.2.contains_key(LINK_FORMAT_ATTR) {
+                    self.apply_link_format(link);
+                } else {
+                    self.resolve_undecorated(link);
                 }
             }
             Inline::Image(img) => {
@@ -309,6 +332,107 @@ impl<'a> LinkRewriter<'a> {
         }
     }
 
+    /// The undecorated body-link resolution: source path → output
+    /// href through the index (Decision 7: pass-through without one).
+    fn resolve_undecorated(&mut self, link: &mut Link) {
+        if let Some(index) = self.index {
+            let new_url = resolve_doc_relative_href(
+                &link.target.0,
+                self.source,
+                self.resolver,
+                Some(index),
+                link.target_source.url.clone(),
+                self.diagnostics,
+            );
+            link.target.0 = new_url;
+        }
+    }
+
+    /// Handle a `link-format`-decorated link.
+    ///
+    /// The one case that leaves the attribute in place is a
+    /// satisfiable `html` pin: `LlmsCaptureTransform` (tail of
+    /// Finalization) is its consumer — it skips the companion
+    /// retarget and scrubs the attribute from both views. Every
+    /// other path consumes the attribute here; unsatisfiable
+    /// requests warn with Q-13-9 and fall back to the undecorated
+    /// resolution.
+    fn apply_link_format(&mut self, link: &mut Link) {
+        let value = link
+            .attr
+            .2
+            .get(LINK_FORMAT_ATTR)
+            .cloned()
+            .unwrap_or_default();
+        let raw = link.target.0.clone();
+        let location = link.target_source.url.clone();
+
+        // The target page, under the source-paths-only rule: the
+        // href must name a project source (`.qmd` / `.md`) that is
+        // in the index.
+        let target_profile = resolve_doc_relative_target(&raw, self.source)
+            .and_then(|p| self.index.and_then(|idx| idx.lookup_by_source(&p)));
+
+        // Satisfiable `html` pin: resolve normally, keep the attr.
+        if value == "html" && self.llms_active && target_profile.is_some() {
+            self.resolve_undecorated(link);
+            return;
+        }
+
+        // `None` = consume silently; `Some` = warn with this problem.
+        let failure: Option<String> = match value.as_str() {
+            // Inert pin: with the llms view off nothing would ever
+            // retarget the link, so the request is trivially
+            // honored.
+            "html" if !self.llms_active => None,
+            "html" => Some(format!(
+                "`{raw}` is not a project source path in the render set, \
+                 so there is no page output to pin."
+            )),
+            "llms" if !self.llms_enabled => Some(
+                "Markdown companions only exist on a website with \
+                 `llms-txt: true` set under `website:`."
+                    .to_string(),
+            ),
+            "llms" => match target_profile {
+                None => Some(format!(
+                    "`{raw}` is not a project source path in the render set, \
+                     so it has no markdown companion to target."
+                )),
+                Some(profile) if !profile_has_companion(profile) => Some(format!(
+                    "`{raw}` resolves to a page with no markdown companion \
+                     (drafts and the 404 page are excluded)."
+                )),
+                Some(profile) => {
+                    // Satisfied: point the link at the companion,
+                    // page-relative, keeping any ?query/#fragment
+                    // tail as written.
+                    let companion = companion_href(&profile.output_href)
+                        .expect("companion-eligible pages render to .html");
+                    let tail = raw.find(['#', '?']).map_or("", |i| &raw[i..]);
+                    let url = match self.resolver {
+                        Some(r) => r.page_url_for(&companion),
+                        None => companion,
+                    };
+                    link.target.0 = format!("{url}{tail}");
+                    strip_kv(&mut link.attr, &mut link.attr_source, LINK_FORMAT_ATTR);
+                    return;
+                }
+            },
+            other => Some(format!(
+                "`{other}` is not a recognized link-format value \
+                 (expected \"html\" or \"llms\")."
+            )),
+        };
+
+        strip_kv(&mut link.attr, &mut link.attr_source, LINK_FORMAT_ATTR);
+        if let Some(problem) = failure {
+            self.diagnostics
+                .push(link_format_warning(problem, location));
+        }
+        self.resolve_undecorated(link);
+    }
+
     fn visit_slot(&mut self, slot: &mut Slot) {
         match slot {
             Slot::Block(b) => self.visit_block(b),
@@ -321,6 +445,23 @@ impl<'a> LinkRewriter<'a> {
             Slot::Inlines(is) => self.visit_inlines(is),
         }
     }
+}
+
+/// Q-13-9: a `link-format` request that cannot be honored. The
+/// render proceeds with the undecorated resolution.
+fn link_format_warning(problem: String, location: Option<SourceInfo>) -> DiagnosticMessage {
+    let mut builder = DiagnosticMessageBuilder::warning("link-format request cannot be honored")
+        .with_code("Q-13-9")
+        .problem(problem)
+        .add_hint(
+            "Write the target as the page's source path (e.g. `guide/index.qmd`) \
+             and use `link-format=\"html\"` or `link-format=\"llms\"`. The \
+             attribute was ignored.",
+        );
+    if let Some(loc) = location {
+        builder = builder.with_location(loc);
+    }
+    builder.build()
 }
 
 #[cfg(test)]
@@ -875,6 +1016,439 @@ mod tests {
             vec!["../hero.png"],
             "VFS-root mode must preserve the user-written image path"
         );
+    }
+
+    // ---- link-format attribute (bd-llms-link-target-annotation-0zo2ppgx) ----
+    //
+    // `link-format="llms"` retargets a source-path link at the target
+    // page's markdown companion; `link-format="html"` survives this
+    // transform (LlmsCaptureTransform consumes it) when the llms view
+    // is active and is silently stripped when it is not. Unsatisfiable
+    // pins warn with Q-13-9 and fall back to the normal resolution.
+
+    use crate::project::ProjectKind;
+
+    fn llms_meta() -> ConfigValue {
+        let entry = |k: &str, v: ConfigValue| ConfigMapEntry {
+            key: k.to_string(),
+            key_source: SourceInfo::for_test(),
+            value: v,
+        };
+        let website = ConfigValue::new_map(
+            vec![entry(
+                "llms-txt",
+                ConfigValue::new_bool(true, SourceInfo::for_test()),
+            )],
+            SourceInfo::for_test(),
+        );
+        ConfigValue::new_map(vec![entry("website", website)], SourceInfo::for_test())
+    }
+
+    fn link_with_kv(url: &str, text: &str, kv: &[(&str, &str)]) -> Inline {
+        let mut map = hashlink::LinkedHashMap::new();
+        for (k, v) in kv {
+            map.insert(k.to_string(), v.to_string());
+        }
+        Inline::Link(Link {
+            attr: (String::new(), vec![], map),
+            content: vec![Inline::Str(Str {
+                text: text.to_string(),
+                source_info: SourceInfo::for_test(),
+            })],
+            target: (url.to_string(), String::new()),
+            source_info: SourceInfo::for_test(),
+            attr_source: AttrSourceInfo::empty(),
+            target_source: TargetSourceInfo::empty(),
+        })
+    }
+
+    /// Like [`run`], but with control over the llms view: when
+    /// `llms_enabled` the project is a website with
+    /// `website.llms-txt: true` in the metadata (the
+    /// `llms_view_active` predicate holds).
+    async fn run_cfg(
+        blocks: Vec<Block>,
+        source_doc: &str,
+        output_href: &str,
+        index_profiles: Vec<DocumentProfile>,
+        with_index: bool,
+        llms_enabled: bool,
+    ) -> (Vec<Block>, Vec<quarto_error_reporting::DiagnosticMessage>) {
+        let mut project = make_project();
+        if llms_enabled {
+            project.config.project_kind = ProjectKind::Website;
+        }
+        let input_path = format!("/project/{}", source_doc);
+        let doc = DocumentInfo::from_path(&input_path);
+        let format = Format::html();
+        let binaries = BinaryDependencies::new();
+        let mut ctx = RenderContext::new(&project, &doc, &format, &binaries);
+        if with_index {
+            ctx = ctx.with_project_index(Arc::new(ProjectIndex::new(index_profiles)));
+        }
+        let page_output = format!("/project/_site/{}", output_href);
+        let stem = std::path::Path::new(output_href)
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("index");
+        ctx.resource_resolver = Some(ResourceResolverContext::website(
+            "/project/_site",
+            page_output,
+            "site_libs",
+            stem,
+        ));
+        let mut ast = Pandoc {
+            meta: if llms_enabled {
+                llms_meta()
+            } else {
+                empty_meta()
+            },
+            blocks,
+        };
+        LinkRewriteTransform::new()
+            .transform(&mut ast, &mut ctx)
+            .await
+            .unwrap();
+        (ast.blocks, ctx.diagnostics)
+    }
+
+    fn first_link(blocks: &[Block]) -> &Link {
+        for b in blocks {
+            if let Block::Paragraph(p) = b {
+                for i in &p.content {
+                    if let Inline::Link(l) = i {
+                        return l;
+                    }
+                }
+            }
+        }
+        panic!("no link found");
+    }
+
+    fn assert_q13_9(diags: &[quarto_error_reporting::DiagnosticMessage], context: &str) {
+        assert_eq!(
+            diags.len(),
+            1,
+            "{context}: expected exactly one diagnostic; got {:?}",
+            diags.iter().map(|d| d.title.clone()).collect::<Vec<_>>()
+        );
+        assert_eq!(
+            diags[0].code.as_deref(),
+            Some("Q-13-9"),
+            "{context}: expected Q-13-9; got {:?}",
+            diags[0].code
+        );
+    }
+
+    /// `link-format="llms"` on a source-path link resolves to the
+    /// target page's markdown companion, consuming the attribute.
+    #[tokio::test]
+    async fn link_format_llms_rewrites_to_companion() {
+        let blocks = vec![para(vec![link_with_kv(
+            "about.qmd",
+            "About",
+            &[("link-format", "llms")],
+        )])];
+        let (out, diags) = run_cfg(
+            blocks,
+            "index.qmd",
+            "index.html",
+            vec![make_profile("about.qmd", "about.html")],
+            true,
+            true,
+        )
+        .await;
+        let link = first_link(&out);
+        assert_eq!(link.target.0, "about.md");
+        assert!(
+            !link.attr.2.contains_key("link-format"),
+            "attribute must be consumed"
+        );
+        assert!(diags.is_empty(), "satisfied pin must not diagnose");
+    }
+
+    /// The companion rewrite is page-relative and keeps the fragment:
+    /// a depth-1 page linking `../about.qmd#sec` gets
+    /// `../about.md#sec`.
+    #[tokio::test]
+    async fn link_format_llms_relativizes_and_keeps_fragment() {
+        let blocks = vec![para(vec![link_with_kv(
+            "../about.qmd#sec",
+            "About",
+            &[("link-format", "llms")],
+        )])];
+        let (out, diags) = run_cfg(
+            blocks,
+            "guide/intro.qmd",
+            "guide/intro.html",
+            vec![
+                make_profile("about.qmd", "about.html"),
+                make_profile("guide/intro.qmd", "guide/intro.html"),
+            ],
+            true,
+            true,
+        )
+        .await;
+        assert_eq!(first_link(&out).target.0, "../about.md#sec");
+        assert!(diags.is_empty());
+    }
+
+    /// `link-format="llms"` when llms-txt is not enabled: Q-13-9
+    /// warning, attribute stripped, normal `.html` resolution.
+    #[tokio::test]
+    async fn link_format_llms_warns_when_llms_disabled() {
+        let blocks = vec![para(vec![link_with_kv(
+            "about.qmd",
+            "About",
+            &[("link-format", "llms")],
+        )])];
+        let (out, diags) = run_cfg(
+            blocks,
+            "index.qmd",
+            "index.html",
+            vec![make_profile("about.qmd", "about.html")],
+            true,
+            false,
+        )
+        .await;
+        let link = first_link(&out);
+        assert_eq!(link.target.0, "about.html", "falls back to html output");
+        assert!(!link.attr.2.contains_key("link-format"));
+        assert_q13_9(&diags, "llms pin with llms-txt disabled");
+    }
+
+    /// `link-format="llms"` targeting a draft (no companion): Q-13-9
+    /// warning, fallback to the `.html` output.
+    #[tokio::test]
+    async fn link_format_llms_draft_target_warns() {
+        let draft = DocumentProfile {
+            draft: true,
+            ..make_profile("about.qmd", "about.html")
+        };
+        let blocks = vec![para(vec![link_with_kv(
+            "about.qmd",
+            "About",
+            &[("link-format", "llms")],
+        )])];
+        let (out, diags) =
+            run_cfg(blocks, "index.qmd", "index.html", vec![draft], true, true).await;
+        let link = first_link(&out);
+        assert_eq!(link.target.0, "about.html", "falls back to html output");
+        assert!(!link.attr.2.contains_key("link-format"));
+        assert_q13_9(&diags, "llms pin on a draft target");
+    }
+
+    /// An unknown `link-format` value warns and is stripped; the link
+    /// resolves exactly as if undecorated.
+    #[tokio::test]
+    async fn link_format_unknown_value_warns() {
+        let blocks = vec![para(vec![link_with_kv(
+            "about.qmd",
+            "About",
+            &[("link-format", "pdf")],
+        )])];
+        let (out, diags) = run_cfg(
+            blocks,
+            "index.qmd",
+            "index.html",
+            vec![make_profile("about.qmd", "about.html")],
+            true,
+            true,
+        )
+        .await;
+        let link = first_link(&out);
+        assert_eq!(link.target.0, "about.html");
+        assert!(!link.attr.2.contains_key("link-format"));
+        assert_q13_9(&diags, "unknown link-format value");
+    }
+
+    /// With the llms view active, `link-format="html"` survives this
+    /// transform — `LlmsCaptureTransform` (which runs later) is its
+    /// consumer. The target resolves normally.
+    #[tokio::test]
+    async fn link_format_html_survives_for_capture_when_llms_active() {
+        let blocks = vec![para(vec![link_with_kv(
+            "about.qmd",
+            "About",
+            &[("link-format", "html")],
+        )])];
+        let (out, diags) = run_cfg(
+            blocks,
+            "index.qmd",
+            "index.html",
+            vec![make_profile("about.qmd", "about.html")],
+            true,
+            true,
+        )
+        .await;
+        let link = first_link(&out);
+        assert_eq!(link.target.0, "about.html");
+        assert_eq!(
+            link.attr.2.get("link-format").map(String::as_str),
+            Some("html"),
+            "html pin must ride through to LlmsCaptureTransform"
+        );
+        assert!(diags.is_empty());
+    }
+
+    /// With the llms view inactive, `link-format="html"` is stripped
+    /// silently (nothing downstream consumes it) and behavior is
+    /// exactly the undecorated behavior.
+    #[tokio::test]
+    async fn link_format_html_stripped_silently_when_llms_inactive() {
+        let blocks = vec![para(vec![link_with_kv(
+            "about.qmd",
+            "About",
+            &[("link-format", "html")],
+        )])];
+        let (out, diags) = run_cfg(
+            blocks,
+            "index.qmd",
+            "index.html",
+            vec![make_profile("about.qmd", "about.html")],
+            true,
+            false,
+        )
+        .await;
+        let link = first_link(&out);
+        assert_eq!(link.target.0, "about.html");
+        assert!(
+            !link.attr.2.contains_key("link-format"),
+            "inactive-view html pin must be scrubbed before the writer"
+        );
+        assert!(diags.is_empty(), "inactive-view html pin is silent");
+    }
+
+    /// `link-format` on a target that is not a resolvable project
+    /// source path (an external URL) is inconsistent per the design's
+    /// source-paths-only rule: Q-13-9, attribute stripped, target
+    /// untouched.
+    #[tokio::test]
+    async fn link_format_html_external_target_warns() {
+        let blocks = vec![para(vec![link_with_kv(
+            "https://example.com/x",
+            "X",
+            &[("link-format", "html")],
+        )])];
+        let (out, diags) = run_cfg(
+            blocks,
+            "index.qmd",
+            "index.html",
+            vec![make_profile("about.qmd", "about.html")],
+            true,
+            true,
+        )
+        .await;
+        let link = first_link(&out);
+        assert_eq!(link.target.0, "https://example.com/x");
+        assert!(!link.attr.2.contains_key("link-format"));
+        assert_q13_9(&diags, "link-format on an external target");
+    }
+
+    /// An `llms` pin targeting a revealjs page warns: slide decks
+    /// render to `.html` but never get a markdown companion, so the
+    /// pin cannot be honored.
+    #[tokio::test]
+    async fn link_format_llms_to_revealjs_target_warns() {
+        let slides = DocumentProfile {
+            format_id: "revealjs".to_string(),
+            ..make_profile("slides.qmd", "slides.html")
+        };
+        let blocks = vec![para(vec![link_with_kv(
+            "slides.qmd",
+            "Slides",
+            &[("link-format", "llms")],
+        )])];
+        let (out, diags) =
+            run_cfg(blocks, "index.qmd", "index.html", vec![slides], true, true).await;
+        let link = first_link(&out);
+        assert_eq!(link.target.0, "slides.html", "falls back to html output");
+        assert!(!link.attr.2.contains_key("link-format"));
+        assert_q13_9(&diags, "llms pin on a revealjs target");
+    }
+
+    /// An `llms` pin is satisfiable *from* any page of the site — a
+    /// revealjs deck can link another page's markdown companion. The
+    /// gate is config-level (`llms-txt: true` on a website), not the
+    /// linking page's own format.
+    #[tokio::test]
+    async fn link_format_llms_from_revealjs_page_succeeds() {
+        let mut project = make_project();
+        project.config.project_kind = ProjectKind::Website;
+        let doc = DocumentInfo::from_path("/project/slides.qmd");
+        let mut format = Format::html();
+        format.target_format = "revealjs".to_string();
+        let binaries = BinaryDependencies::new();
+        let mut ctx = RenderContext::new(&project, &doc, &format, &binaries);
+        ctx = ctx.with_project_index(Arc::new(ProjectIndex::new(vec![make_profile(
+            "about.qmd",
+            "about.html",
+        )])));
+        ctx.resource_resolver = Some(ResourceResolverContext::website(
+            "/project/_site",
+            "/project/_site/slides.html",
+            "site_libs",
+            "slides",
+        ));
+        let mut ast = Pandoc {
+            meta: llms_meta(),
+            blocks: vec![para(vec![link_with_kv(
+                "about.qmd",
+                "About notes",
+                &[("link-format", "llms")],
+            )])],
+        };
+        LinkRewriteTransform::new()
+            .transform(&mut ast, &mut ctx)
+            .await
+            .unwrap();
+        let link = first_link(&ast.blocks);
+        assert_eq!(
+            link.target.0, "about.md",
+            "the deck links the html page's companion"
+        );
+        assert!(!link.attr.2.contains_key("link-format"));
+        assert!(
+            ctx.diagnostics.is_empty(),
+            "satisfiable cross-format pin must not diagnose; got {:?}",
+            ctx.diagnostics
+                .iter()
+                .map(|d| d.title.clone())
+                .collect::<Vec<_>>()
+        );
+    }
+
+    /// Even with neither index nor resolver (bare standalone render),
+    /// the transform must still walk the AST to consume `link-format`
+    /// attributes — an unsatisfiable `llms` pin warns, and nothing
+    /// leaks into the writer.
+    #[tokio::test]
+    async fn link_format_consumed_without_index_and_resolver() {
+        let blocks = vec![para(vec![link_with_kv(
+            "about.qmd",
+            "About",
+            &[("link-format", "llms")],
+        )])];
+        let project = make_project();
+        let doc = DocumentInfo::from_path("/project/index.qmd");
+        let format = Format::html();
+        let binaries = BinaryDependencies::new();
+        let mut ctx = RenderContext::new(&project, &doc, &format, &binaries);
+        let mut ast = Pandoc {
+            meta: empty_meta(),
+            blocks,
+        };
+        LinkRewriteTransform::new()
+            .transform(&mut ast, &mut ctx)
+            .await
+            .unwrap();
+        let link = first_link(&ast.blocks);
+        assert_eq!(link.target.0, "about.qmd", "no resolution without index");
+        assert!(
+            !link.attr.2.contains_key("link-format"),
+            "attribute must be consumed even on the no-index path"
+        );
+        assert_q13_9(&ctx.diagnostics, "llms pin in a standalone render");
     }
 
     /// Images rewrite even without a `ProjectIndex` — static-resource

--- a/crates/quarto-core/src/transforms/llms.rs
+++ b/crates/quarto-core/src/transforms/llms.rs
@@ -46,14 +46,18 @@
 //! - retargets same-site `.html` links to their `.md` siblings when
 //!   the target page has a companion (non-draft, non-404 pages in
 //!   the project index), keeping fragments. Links to drafts, the
-//!   404 page, external URLs, and non-page resources are untouched.
+//!   404 page, external URLs, and non-page resources are untouched —
+//!   as are links the author pinned with `link-format="html"`
+//!   (bd-llms-link-target-annotation-0zo2ppgx; the pin rides through
+//!   `LinkRewriteTransform` and is consumed here).
 //!
 //! The main-AST cleanup ([`resolve_marker_classes`]) then removes
 //! `.quarto-llms-keep` subtrees (they were retained solely for the
 //! capture) and strips the `.quarto-llms-omit` marker class from
-//! nodes that stay in the HTML. This cleanup runs even when the
-//! page itself is skipped (draft / 404): the markers must never
-//! reach the HTML writer.
+//! nodes that stay in the HTML, along with any surviving
+//! `link-format` pins. This cleanup runs even when the page itself
+//! is skipped (draft / 404): the markers must never reach the HTML
+//! writer.
 
 use std::path::Path;
 
@@ -115,8 +119,18 @@ pub const HREF_404: &str = "404.html";
 /// first only plants marker classes when it is true, and the second
 /// is the only thing that cleans them up.
 pub fn llms_view_active(meta: &ConfigValue, ctx: &RenderContext) -> bool {
-    ctx.project.config.project_kind == ProjectKind::Website
+    llms_companions_enabled(meta, ctx)
         && crate::format::lua_format_for(&ctx.format.target_format) == "html"
+}
+
+/// Config-level half of [`llms_view_active`]: this project generates
+/// markdown companions (website + `llms-txt: true`), regardless of
+/// the current page's own format. This is the gate for *targeting* a
+/// companion (`link-format="llms"` in `LinkRewriteTransform`): a
+/// revealjs deck gets no companion itself, but can legitimately link
+/// another page's.
+pub fn llms_companions_enabled(meta: &ConfigValue, ctx: &RenderContext) -> bool {
+    ctx.project.config.project_kind == ProjectKind::Website
         && crate::project::website_config::website_llms_txt_enabled(meta)
 }
 
@@ -129,10 +143,16 @@ pub fn companion_href(output_href: &str) -> Option<String> {
 }
 
 /// Does this profile get a companion? Non-draft, non-404, `.html`
-/// output. The single answer shared by capture (link retargeting)
-/// and post-render (index assembly) so they can't drift.
+/// output, **plain html format** (a revealjs deck renders to `.html`
+/// but capture never runs for it — see [`llms_view_active`] — so it
+/// has no companion). The single answer shared by capture (link
+/// retargeting), `link-format` resolution, and post-render (index
+/// assembly) so they can't drift.
 pub fn profile_has_companion(profile: &crate::document_profile::DocumentProfile) -> bool {
-    !profile.draft && profile.output_href != HREF_404 && profile.output_href.ends_with(".html")
+    !profile.draft
+        && profile.output_href != HREF_404
+        && profile.output_href.ends_with(".html")
+        && crate::format::lua_format_for(&profile.format_id) == "html"
 }
 
 /// See the module docs. Registered at the tail of the Finalization
@@ -343,7 +363,13 @@ fn sanitize_attr(attr: &mut Attr, attr_source: &mut AttrSourceInfo) {
     attr.1.retain(|c| !class_noise(c));
 
     let kv_noise = |k: &str| {
-        k.starts_with("data-") || k.starts_with("aria-") || matches!(k, "role" | "tabindex")
+        k.starts_with("data-")
+            || k.starts_with("aria-")
+            || matches!(k, "role" | "tabindex")
+            // Pipeline-internal link-output selector; its consumers
+            // (LinkRewriteTransform and the Link arm of
+            // `clean_inline`) read it before this strip.
+            || k == crate::transforms::link_rewrite::LINK_FORMAT_ATTR
     };
     if attr.2.len() == attr_source.attributes.len() {
         let keep: Vec<bool> = attr.2.keys().map(|k| !kv_noise(k)).collect();
@@ -763,9 +789,21 @@ fn clean_inline_into(mut inline: Inline, cx: &ViewContext, out: &mut Vec<Inline>
                 out.extend(children);
                 return;
             }
+            // An authored `link-format="html"` pin opts this link out
+            // of the companion retarget
+            // (bd-llms-link-target-annotation-0zo2ppgx). Read it
+            // before `sanitize_attr`, which consumes the attribute —
+            // it is pipeline-internal and never reaches the writer.
+            let html_pinned = link
+                .attr
+                .2
+                .get(crate::transforms::link_rewrite::LINK_FORMAT_ATTR)
+                .is_some_and(|v| v == "html");
             sanitize_attr(&mut link.attr, &mut link.attr_source);
             clean_inlines(&mut link.content, cx);
-            link.target.0 = retarget_href(&link.target.0, cx);
+            if !html_pinned {
+                link.target.0 = retarget_href(&link.target.0, cx);
+            }
             out.push(Inline::Link(link));
         }
         Inline::Image(mut image) => {
@@ -1003,7 +1041,17 @@ fn keep_inline_in_html(inline: &mut Inline) -> bool {
         Inline::SmallCaps(i) => resolve_marker_inlines(&mut i.content),
         Inline::Quoted(i) => resolve_marker_inlines(&mut i.content),
         Inline::Cite(i) => resolve_marker_inlines(&mut i.content),
-        Inline::Link(i) => resolve_marker_inlines(&mut i.content),
+        Inline::Link(i) => {
+            // A surviving `link-format="html"` pin (left in place by
+            // LinkRewriteTransform for the llms view's benefit) is
+            // consumed here so it never reaches the HTML writer.
+            strip_kv(
+                &mut i.attr,
+                &mut i.attr_source,
+                crate::transforms::link_rewrite::LINK_FORMAT_ATTR,
+            );
+            resolve_marker_inlines(&mut i.content);
+        }
         Inline::Image(i) => resolve_marker_inlines(&mut i.content),
         Inline::Note(note) => resolve_marker_classes(&mut note.content),
         _ => {}
@@ -1023,6 +1071,22 @@ fn strip_class(attr: &mut Attr, attr_source: &mut AttrSourceInfo, class: &str) {
         attr_source.classes.clear();
     }
     attr.1.retain(|c| c != class);
+}
+
+/// Remove one key-value attribute, keeping the parallel
+/// `AttrSourceInfo.attributes` aligned (same discipline as
+/// [`strip_class`]). Shared with `LinkRewriteTransform`, which
+/// consumes `link-format` attributes on every path but the one that
+/// deliberately leaves the pin for [`LlmsCaptureTransform`].
+pub(crate) fn strip_kv(attr: &mut Attr, attr_source: &mut AttrSourceInfo, key: &str) {
+    if attr.2.len() == attr_source.attributes.len() {
+        let keep: Vec<bool> = attr.2.keys().map(|k| k != key).collect();
+        let mut it = keep.iter();
+        attr_source.attributes.retain(|_| *it.next().unwrap());
+    } else if attr.2.keys().any(|k| k == key) {
+        attr_source.attributes.clear();
+    }
+    attr.2.retain(|k, _| k != key);
 }
 
 /// Add a marker class, keeping `AttrSourceInfo.classes` aligned.
@@ -1063,8 +1127,19 @@ mod tests {
         DocumentProfile {
             source_path: std::path::PathBuf::from(href.replace(".html", ".qmd")),
             output_href: href.to_string(),
+            format_id: "html".to_string(),
             draft,
             ..Default::default()
+        }
+    }
+
+    /// A revealjs page: renders to `.html` like any slide deck, but
+    /// never gets a companion (capture only runs for the plain html
+    /// format).
+    fn slides_profile(href: &str) -> DocumentProfile {
+        DocumentProfile {
+            format_id: "revealjs".to_string(),
+            ..profile(href, false)
         }
     }
 
@@ -1124,5 +1199,135 @@ mod tests {
         assert!(!profile_has_companion(&profile("about.html", true)));
         assert!(!profile_has_companion(&profile("404.html", false)));
         assert!(!profile_has_companion(&profile("feed.xml", false)));
+    }
+
+    /// A revealjs page renders to `.html` but capture never runs for
+    /// it (`llms_view_active` requires the plain html format), so no
+    /// companion exists — the predicate must say so, or companions
+    /// would carry dead `.md` links to slide decks.
+    #[test]
+    fn profile_has_companion_excludes_non_html_formats() {
+        assert!(!profile_has_companion(&slides_profile("slides.html")));
+        // The preview pseudo-format maps to html and does get one.
+        let preview = DocumentProfile {
+            format_id: "q2-preview".to_string(),
+            ..profile("about.html", false)
+        };
+        assert!(profile_has_companion(&preview));
+    }
+
+    /// Links to a revealjs page keep their `.html` target in the
+    /// companion — its `.md` sibling is never written.
+    #[test]
+    fn retarget_leaves_revealjs_targets_alone() {
+        let index = ProjectIndex::new(vec![
+            profile("about.html", false),
+            slides_profile("slides.html"),
+        ]);
+        let cx = ViewContext {
+            index: Some(&index),
+            cur_dir: String::new(),
+            listings: &[],
+        };
+        assert_eq!(retarget_href("slides.html", &cx), "slides.html");
+        assert_eq!(retarget_href("about.html", &cx), "about.md");
+    }
+
+    // ---- link-format attribute (bd-llms-link-target-annotation-0zo2ppgx) ----
+
+    use quarto_pandoc_types::attr::{AttrSourceInfo, TargetSourceInfo};
+    use quarto_pandoc_types::block::Paragraph;
+    use quarto_pandoc_types::inline::{Link, Str};
+    use quarto_source_map::SourceInfo;
+
+    fn attr_link(url: &str, kv: &[(&str, &str)]) -> Inline {
+        let mut map = hashlink::LinkedHashMap::new();
+        for (k, v) in kv {
+            map.insert(k.to_string(), v.to_string());
+        }
+        Inline::Link(Link {
+            attr: (String::new(), vec![], map),
+            content: vec![Inline::Str(Str {
+                text: "x".to_string(),
+                source_info: SourceInfo::for_test(),
+            })],
+            target: (url.to_string(), String::new()),
+            source_info: SourceInfo::for_test(),
+            attr_source: AttrSourceInfo::empty(),
+            target_source: TargetSourceInfo::empty(),
+        })
+    }
+
+    fn para(content: Vec<Inline>) -> Block {
+        Block::Paragraph(Paragraph {
+            content,
+            source_info: SourceInfo::for_test(),
+        })
+    }
+
+    fn collect_links(blocks: &[Block]) -> Vec<&Link> {
+        let mut links = Vec::new();
+        for b in blocks {
+            if let Block::Paragraph(p) = b {
+                for i in &p.content {
+                    if let Inline::Link(l) = i {
+                        links.push(l);
+                    }
+                }
+            }
+        }
+        links
+    }
+
+    /// A `link-format="html"` pin keeps the `.html` target inside the
+    /// llms view (no companion retarget), and the attribute itself is
+    /// consumed — it must not leak into the emitted markdown. An
+    /// undecorated sibling link still retargets (control).
+    #[test]
+    fn link_format_html_pin_keeps_html_in_llms_view() {
+        let index = ProjectIndex::new(vec![profile("about.html", false)]);
+        let cx = ViewContext {
+            index: Some(&index),
+            cur_dir: String::new(),
+            listings: &[],
+        };
+        let blocks = vec![para(vec![
+            attr_link("about.html", &[("link-format", "html")]),
+            attr_link("about.html", &[]),
+        ])];
+        let out = build_llms_view(blocks, &cx);
+        let links = collect_links(&out);
+        assert_eq!(links.len(), 2, "both links survive into the view");
+        assert_eq!(
+            links[0].target.0, "about.html",
+            "pinned link keeps its .html target in the companion"
+        );
+        assert!(
+            !links[0].attr.2.contains_key("link-format"),
+            "the link-format attribute is consumed, not emitted"
+        );
+        assert_eq!(
+            links[1].target.0, "about.md",
+            "undecorated control link still retargets"
+        );
+    }
+
+    /// The html-view scrub (`resolve_marker_classes`) removes a
+    /// surviving `link-format` attribute so it never reaches the HTML
+    /// writer; the link target is untouched.
+    #[test]
+    fn link_format_attr_scrubbed_from_html_view() {
+        let mut blocks = vec![para(vec![attr_link(
+            "about.html",
+            &[("link-format", "html")],
+        )])];
+        resolve_marker_classes(&mut blocks);
+        let links = collect_links(&blocks);
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].target.0, "about.html", "target untouched");
+        assert!(
+            !links[0].attr.2.contains_key("link-format"),
+            "link-format must be scrubbed from the HTML-bound AST"
+        );
     }
 }

--- a/crates/quarto-core/tests/integration/llms_txt.rs
+++ b/crates/quarto-core/tests/integration/llms_txt.rs
@@ -926,3 +926,174 @@ fn llms_user_provided_llms_txt_collision_fails() {
         "diagnostic should name the contested path; got:\n{rendered}"
     );
 }
+
+// ═══════════════════════════════════════════════════════════════════
+// link-format attribute (bd-llms-link-target-annotation-0zo2ppgx)
+// ═══════════════════════════════════════════════════════════════════
+
+/// Read a summary output's rendered HTML by output file name.
+fn html_output(summary: &ProjectRenderSummary, name: &str) -> String {
+    let path = summary
+        .outputs
+        .iter()
+        .find(|o| o.output_path.file_name().and_then(|s| s.to_str()) == Some(name))
+        .unwrap_or_else(|| panic!("{name} output not found"))
+        .output_path
+        .clone();
+    read(&path)
+}
+
+/// All per-page diagnostic codes across the summary's outputs.
+fn output_diag_codes(summary: &ProjectRenderSummary) -> Vec<String> {
+    summary
+        .outputs
+        .iter()
+        .flat_map(|o| o.render_output.diagnostics.iter())
+        .filter_map(|d| d.code.clone())
+        .collect()
+}
+
+/// Two-page llms site whose index body carries the given markdown.
+fn two_page_site(index_body: &str) -> impl FnOnce(&Path) + '_ {
+    move |dir: &Path| {
+        write(
+            &dir.join("_quarto.yml"),
+            "project:\n  type: website\n  output-dir: _site\n\
+             website:\n  title: \"Test Site\"\n  llms-txt: true\n",
+        );
+        write(
+            &dir.join("index.qmd"),
+            &format!("---\ntitle: Home\n---\n\n{index_body}\n"),
+        );
+        write(
+            &dir.join("about.qmd"),
+            "---\ntitle: About\n---\n\nAbout body.\n",
+        );
+    }
+}
+
+/// `link-format="html"` keeps the link on the HTML page even inside
+/// the markdown companion; the attribute never reaches either output.
+#[test]
+fn llms_link_format_html_pins_link_in_companion() {
+    let (project_dir, summary) = render_project(two_page_site(
+        "See [pinned](about.qmd){link-format=\"html\"} and [normal](about.qmd).",
+    ));
+
+    let companion = read(&project_dir.join("_site/index.md"));
+    assert_contains(
+        &companion,
+        "[pinned](about.html)",
+        "html-pinned link keeps .html in the companion",
+    );
+    assert_contains(
+        &companion,
+        "[normal](about.md)",
+        "undecorated link still retargets to the companion",
+    );
+    assert_not_contains(&companion, "link-format", "attr consumed in companion");
+
+    let html = html_output(&summary, "index.html");
+    assert_contains(&html, "href=\"about.html\"", "html page links html");
+    assert_not_contains(&html, "link-format", "attr consumed in HTML");
+    assert!(
+        output_diag_codes(&summary).is_empty(),
+        "satisfied pins must not diagnose; got {:?}",
+        output_diag_codes(&summary)
+    );
+}
+
+/// `link-format="llms"` points the HTML page at the target's markdown
+/// companion — including a self-link, the "view this page as
+/// markdown" affordance.
+#[test]
+fn llms_link_format_llms_links_companion_from_html() {
+    let (project_dir, summary) = render_project(two_page_site(
+        "[View as Markdown](index.qmd){link-format=\"llms\"} or read \
+         [about's markdown](about.qmd){link-format=\"llms\"}.",
+    ));
+
+    let html = html_output(&summary, "index.html");
+    assert_contains(
+        &html,
+        "href=\"index.md\"",
+        "self-link targets this page's companion",
+    );
+    assert_contains(
+        &html,
+        "href=\"about.md\"",
+        "cross-page llms pin targets the sibling companion",
+    );
+    assert_not_contains(&html, "link-format", "attr consumed in HTML");
+
+    // Inside the companion the links already point at .md and stay put.
+    let companion = read(&project_dir.join("_site/index.md"));
+    assert_contains(
+        &companion,
+        "(index.md)",
+        "companion keeps the .md self-link",
+    );
+    assert_contains(&companion, "(about.md)", "companion keeps the .md link");
+    assert_not_contains(&companion, "link-format", "attr consumed in companion");
+    assert!(
+        output_diag_codes(&summary).is_empty(),
+        "satisfied pins must not diagnose; got {:?}",
+        output_diag_codes(&summary)
+    );
+}
+
+/// `link-format="llms"` with `llms-txt` disabled cannot be honored:
+/// the render succeeds, the link falls back to the `.html` output,
+/// and a Q-13-9 warning names the problem.
+#[test]
+fn llms_link_format_warns_when_llms_txt_off() {
+    let (_dir, summary) = render_project(|dir| {
+        write(
+            &dir.join("_quarto.yml"),
+            "project:\n  type: website\n  output-dir: _site\n\
+             website:\n  title: \"Test Site\"\n",
+        );
+        write(
+            &dir.join("index.qmd"),
+            "---\ntitle: Home\n---\n\n\
+             [md](about.qmd){link-format=\"llms\"}\n",
+        );
+        write(
+            &dir.join("about.qmd"),
+            "---\ntitle: About\n---\n\nAbout body.\n",
+        );
+    });
+
+    let html = html_output(&summary, "index.html");
+    assert_contains(
+        &html,
+        "href=\"about.html\"",
+        "falls back to the html output",
+    );
+    assert_not_contains(&html, "link-format", "attr consumed even when llms is off");
+    let codes = output_diag_codes(&summary);
+    assert!(
+        codes.iter().any(|c| c == "Q-13-9"),
+        "expected Q-13-9 for an unsatisfiable llms pin; got {codes:?}"
+    );
+}
+
+/// Pin of bd-6d2wj4zp D6: an *undecorated* literal `.md` link in a
+/// `.qmd`-source project still falls through silently as a static
+/// resource — the link-format feature must not change that.
+#[test]
+fn llms_undecorated_md_link_stays_static() {
+    let (_dir, summary) = render_project(two_page_site("A [raw md link](about.md)."));
+
+    let html = html_output(&summary, "index.html");
+    assert_contains(
+        &html,
+        "href=\"about.md\"",
+        "undecorated .md link passes through as a static resource",
+    );
+    assert!(
+        output_diag_codes(&summary).is_empty(),
+        "undecorated .md links stay silent (D6); got {:?}",
+        output_diag_codes(&summary)
+    );
+}

--- a/crates/quarto-error-catalog/error_catalog.json
+++ b/crates/quarto-error-catalog/error_catalog.json
@@ -1447,5 +1447,12 @@
     "message_template": "The `toc-location` option has a value Quarto 2 does not support. Supported values are `left`, `right` (the default), and `body`. The `left-body` and `right-body` double-TOC values are not implemented yet and fall back to `left` / `right`; any other value falls back to the default `right`.",
     "docs_url": "https://quarto.org/docs/errors/navigation/Q-13-8",
     "since_version": "99.9.9"
+  },
+  "Q-13-9": {
+    "subsystem": "navigation",
+    "title": "link-format request cannot be honored",
+    "message_template": "A link carries a `link-format` attribute that names an unknown value or targets a page the requested output format does not cover. `link-format=\"llms\"` needs `website.llms-txt: true` on an HTML website render, a target written as a project source path, and a target page that gets a markdown companion (drafts and the 404 page do not). The attribute is ignored and the link resolves as if it were undecorated.",
+    "docs_url": "https://quarto.org/docs/errors/navigation/Q-13-9",
+    "since_version": "99.9.9"
   }
 }

--- a/docs/errors/navigation/Q-13-9.qmd
+++ b/docs/errors/navigation/Q-13-9.qmd
@@ -1,0 +1,72 @@
+---
+title: "link-format request cannot be honored"
+description: "A link carries a link-format attribute that names an unknown value or targets a page the requested output format does not cover."
+code: Q-13-9
+subsystem: navigation
+status: complete
+since: "99.9.9"
+categories:
+  - navigation
+  - websites
+---
+
+# `Q-13-9` — link-format request cannot be honored
+
+> A link carries a `link-format` attribute that names an unknown
+> value or targets a page the requested output format does not
+> cover. The attribute is ignored and the link resolves as if it
+> were undecorated.
+
+## What this means
+
+The `link-format` attribute selects which *output* of a target page
+a link should point at. On a website with `llms-txt: true`, every
+page has two outputs: the HTML page and its markdown companion.
+
+``` markdown
+[View as Markdown](guide/index.qmd){link-format="llms"}
+[Interactive demo](demo.qmd){link-format="html"}
+```
+
+The first form makes the rendered HTML page link to the target's
+markdown companion (`guide/index.md`). The second keeps a link
+pointing at the HTML page even inside markdown companions, which
+otherwise rewrite same-site links to their `.md` siblings.
+
+This warning fires when the request cannot be satisfied. The render
+still succeeds: the attribute is dropped and the link resolves
+exactly as it would without it.
+
+## Why this happens
+
+Common causes:
+
+- **`link-format="llms"` without `llms-txt: true`.** Markdown
+  companions only exist when the website sets
+  `website.llms-txt: true` in `_quarto.yml`.
+- **The target has no markdown companion.** Draft pages and the 404
+  page are excluded from companion generation, so a `llms` pin on a
+  link to them cannot be honored.
+- **The link target is not a project source path.** `link-format`
+  only applies to links written against a source file in the
+  project (`guide/index.qmd`-style). External URLs, anchors, and
+  static resources have a single form — there is no alternate
+  output to select.
+- **An unknown value.** Only `html` and `llms` are recognized
+  today.
+
+## How to fix
+
+- To link markdown companions, set `llms-txt: true` under `website:`
+  in `_quarto.yml`.
+- Write the link target as the target page's *source* path
+  (`guide/index.qmd`), not its output path or an external URL.
+- If the target is a draft, the companion does not exist — remove
+  the pin or publish the page.
+- Check the attribute value for typos: `link-format="html"` or
+  `link-format="llms"`.
+
+## Related
+
+- `Q-13-4` — body link referencing a missing document (the
+  undecorated-link counterpart of this diagnostic).

--- a/docs/guides/projects/llms-txt.qmd
+++ b/docs/guides/projects/llms-txt.qmd
@@ -76,6 +76,37 @@ Inside a companion, links to other pages of your site point at the
 stays inside the markdown mirror as it follows links. Links to
 drafts, external sites, and non-page files are left untouched.
 
+## Choosing a link's target: `link-format`
+
+Sometimes the automatic choice is not the one you want. The
+`link-format` link attribute picks which output of the target page a
+link points at:
+
+```markdown
+[View this page as Markdown](index.qmd){link-format="llms"}
+
+[Try the interactive demo](demo.qmd){link-format="html"}
+```
+
+- **`link-format="llms"`** points the link at the target page's
+  markdown companion — even on the HTML page. Use it for a "view as
+  markdown" affordance, or to hand AI-oriented reading paths to your
+  readers. Linking a page's *own* source path, as above, links its
+  own companion.
+- **`link-format="html"`** keeps the link on the HTML page, even
+  inside markdown companions (which normally rewrite same-site links
+  to `.md` siblings). Use it when the target's value is its rendered
+  presentation — an interactive demo, a figure gallery — and the
+  markdown mirror would miss the point.
+
+Write the target as the page's **source path** (`guide/index.qmd`),
+exactly as you would for any other internal link; the attribute alone
+selects the output. A request that cannot be honored — an unknown
+value, a target that isn't a project page, a `llms` pin without
+`llms-txt: true` or on a draft — leaves the link resolving normally
+and warns with
+[`Q-13-9`](../../errors/navigation/Q-13-9.qmd).
+
 ## Showing content only to AI tools (or only to people)
 
 The markdown mirror is a conditional-content target named `llms`.


### PR DESCRIPTION
Implements **bd-llms-link-target-annotation-0zo2ppgx**: with `website.llms-txt: true`, authors previously had no way to opt a link out of the companion `.html`→`.md` retarget, nor to point a link *at* a markdown companion from the HTML page. This adds the `link-format` link attribute, honored by `LinkRewriteTransform` and `LlmsCaptureTransform`.

**Plan / design record:** `claude-notes/plans/2026-08-17-llms-link-target-annotation.md` (five design decisions resolved with Carlos before implementation).

## What it does

```markdown
[View this page as Markdown](index.qmd){link-format="llms"}
[Try the interactive demo](demo.qmd){link-format="html"}
```

- **`link-format="llms"`** — the rendered HTML page links the target page's markdown companion (`index.md`). Targets are written as *source paths*; a page's own source path gives a "view as markdown" self-link. Satisfiable from any page of the site (config-level gate `llms_companions_enabled`), so a revealjs deck can link another page's companion.
- **`link-format="html"`** — the link stays on the HTML page even inside markdown companions (which otherwise rewrite same-site links to `.md` siblings). The pin rides through `LinkRewriteTransform` and is consumed by `LlmsCaptureTransform` in both views.
- **Unsatisfiable pins** (unknown value, non-source-path target, `llms` without `llms-txt: true`, draft/404/deck target) warn with new **Q-13-9** (catalog entry + `docs/errors/navigation/Q-13-9.qmd`) and fall back to the undecorated resolution, with the warning anchored at the URL's source span.
- The attribute is consumed on every path — it never reaches the HTML writer or the companion. Undecorated links are byte-for-byte unchanged (no new diagnostics for them).

## Also fixed (surfaced by TDD on the shared predicate)

`profile_has_companion` now requires the plain html format: a revealjs page renders to `.html` but capture never runs for it, so it has no companion — previously the blanket retarget pointed companion links at a deck's nonexistent `.md` sibling.

## Testing

- TDD throughout: 16 unit tests (`link_rewrite.rs`, `llms.rs`) + 4 e2e tests (`llms_txt.rs` integration, driving `ProjectPipeline`) written first and observed failing.
- Full workspace suite green (12232 tests); `cargo xtask lint` green; clippy `-D warnings` clean; **full `cargo xtask verify` green (14/14 steps incl. WASM/hub legs)**.
- End-to-end through the real binary: `q2 render` on a `.md`-source repro — HTML page shows `href="index.md"` (self pin), `href="guide/index.md"` (cross pin), `href="guide/index.html"` (html pin); companion mirrors it; zero `link-format` leaks; the no-llms-txt fixture warns `[Q-13-9]` at `index.md:5:6`.
- Docs: new "Choosing a link's target" section in `docs/guides/projects/llms-txt.qmd`; `q2 render docs/` green (244/244).

## Follow-ups filed

- **bd-3n4fpr3g** — expose the current page's companion href (shortcode / metadata / Lua API) for `include-in-header` fragments like the Connect docs' "View as Markdown" button.
- **bd-u7kdy6fy** — `cargo xtask stage-doc-examples` stages the main checkout when invoked from a worktree (`repo_root()` uses `--git-common-dir`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)