### PR TITLE
Bump workspace version to 0.23.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "comrak-to-pandoc"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "comrak",
  "hashlink",
@@ -4805,7 +4805,7 @@ dependencies = [
 
 [[package]]
 name = "quarto"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4852,7 +4852,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-analysis"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "insta",
  "quarto-error-reporting",
@@ -4878,7 +4878,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-brand"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "pathdiff",
  "quarto-util",
@@ -4890,7 +4890,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-citeproc"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "glob",
  "hashlink",
@@ -4924,7 +4924,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-core"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4980,7 +4980,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-csl"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "insta",
  "quarto-error-reporting",
@@ -5008,7 +5008,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-error-catalog"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "once_cell",
  "quarto-error-reporting",
@@ -5044,7 +5044,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-highlight"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "hashlink",
  "insta",
@@ -5073,7 +5073,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-highlight-encoding"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -5081,7 +5081,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-hub"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "automerge",
@@ -5125,7 +5125,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-hub-provider"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "automerge",
  "ciborium",
@@ -5151,7 +5151,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-lsp"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "insta",
@@ -5167,7 +5167,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-lsp-core"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "insta",
  "pampa",
@@ -5190,7 +5190,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-mcp-launcher"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -5206,7 +5206,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-navigation"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "quarto-config",
  "quarto-pandoc-types",
@@ -5216,7 +5216,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-p2p"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "axum",
  "futures",
@@ -5259,7 +5259,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-preview"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "automerge",
@@ -5297,7 +5297,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-project-create"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "quarto-doctemplate",
  "serde",
@@ -5308,7 +5308,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-publish"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5333,7 +5333,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-sass"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "grass",
  "include_dir",
@@ -5356,7 +5356,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-source-fetch"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "flate2",
  "tar",
@@ -5379,7 +5379,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-system-runtime"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5397,7 +5397,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-test"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "quarto-core",
@@ -5414,7 +5414,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-trace"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "flate2",
  "serde",
@@ -5425,7 +5425,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-trace-server"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-util"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -5460,7 +5460,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-xml"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "insta",
  "quarto-error-reporting",
@@ -5698,7 +5698,7 @@ dependencies = [
 
 [[package]]
 name = "reconcile-viewer"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "clap",
  "hashlink",
@@ -6705,7 +6705,7 @@ checksum = "ea06cc588e43c632923a55450401b8f25e628131571d4e1baea1bdfdb2b5ed06"
 
 [[package]]
 name = "spa-manifest"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -7954,7 +7954,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-printf-fmt"
-version = "0.22.0"
+version = "0.23.0"
 
 [[package]]
 name = "wasm-streams"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.22.0"
+version = "0.23.0"
 authors = ["Posit Software, PBC"]
 homepage = "https://github.com/posit-dev/quarto-markdown-syntax"
 keywords = ["parser"]

--- a/crates/wasm-quarto-hub-client/Cargo.lock
+++ b/crates/wasm-quarto-hub-client/Cargo.lock
@@ -377,7 +377,7 @@ dependencies = [
 
 [[package]]
 name = "comrak-to-pandoc"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "comrak",
  "hashlink",
@@ -2074,7 +2074,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-analysis"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "quarto-error-reporting",
  "quarto-pandoc-types",
@@ -2096,7 +2096,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-brand"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "pathdiff",
  "quarto-util",
@@ -2107,7 +2107,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-citeproc"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "glob",
  "hashlink",
@@ -2138,7 +2138,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-core"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2190,7 +2190,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-csl"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "quarto-error-reporting",
  "quarto-source-map",
@@ -2241,7 +2241,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-highlight"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "once_cell",
  "quarto-highlight-encoding",
@@ -2267,7 +2267,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-highlight-encoding"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2275,7 +2275,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-lsp-core"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "pampa",
  "pollster",
@@ -2296,7 +2296,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-navigation"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "quarto-config",
  "quarto-pandoc-types",
@@ -2331,7 +2331,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-project-create"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "quarto-doctemplate",
  "serde",
@@ -2341,7 +2341,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-sass"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "include_dir",
  "once_cell",
@@ -2371,7 +2371,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-system-runtime"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -2388,7 +2388,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-trace"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "flate2",
  "serde",
@@ -2406,7 +2406,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-util"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -2414,7 +2414,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-xml"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "quarto-error-reporting",
  "quarto-source-map",
@@ -4021,7 +4021,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-printf-fmt"
-version = "0.22.0"
+version = "0.23.0"
 
 [[package]]
 name = "wasm-quarto-hub-client"


### PR DESCRIPTION
Release bump for **v0.23.0** (32 commits since v0.22.0: light-dark theme epic, panel-tabset support, `format.html.css` copy/rebase, llms link-format annotation, Q-2-50 doubled-brace diagnostics).

Both lockfiles updated per the release runbook — the root `Cargo.lock` and `crates/wasm-quarto-hub-client/Cargo.lock` (separate workspace). No external dependency versions changed.

Verification:
- `cargo build --bin q2 --locked` → `q2 (quarto 2) 0.23.0`
- full `cargo xtask verify` green (Rust build + tests, ts-packages, hub-client build + tests, WASM, preview SPA), with no lockfile churn left behind

🤖 Generated with [Claude Code](https://claude.com/claude-code)