### PR TITLE
fix(hub-client): restore Safari preview link clicks via allow-scripts + injected CSP

### DIFF
--- a/.github/workflows/hub-client-e2e.yml
+++ b/.github/workflows/hub-client-e2e.yml
@@ -158,11 +158,15 @@ jobs:
       - name: Pre-build hub binary
         run: cargo build --bin hub
 
-      # Install Playwright browsers
+      # Install Playwright browsers. Webkit is needed for the q2#128
+      # Safari regression specs (the webkit project in
+      # playwright.config.ts); the browser install adds ~1-2 min to CI
+      # even though test time stays flat (the project is testMatch-scoped).
       - name: Install Playwright
         run: |
           cd hub-client
           npx playwright install --with-deps chromium
+          npx playwright install --with-deps webkit
 
       # Delete all snapshots if recreating from scratch
       - name: Delete all snapshots (recreate mode)

--- a/claude-notes/plans/2026-08-17-safari-preview-links.md
+++ b/claude-notes/plans/2026-08-17-safari-preview-links.md
@@ -236,6 +236,10 @@ Rejected alternatives:
       on webkit-2287). The third-party-embed / PDF-`<object>` spot-checks
       and the `object-src 'none'` decision remain for user verification on
       production.**
+      → **2026-08-18 later: user verified manually in real Safari —
+      clicking a cross-document link in the preview now works. The
+      third-party-embed / PDF-`<object>` spot-checks (which gate the
+      optional `object-src 'none'` addition) remain open.**
 - [x] Note expected cosmetic change: Chrome may log an "allow-scripts +
       allow-same-origin can escape sandboxing" console warning (already present
       for the q2-preview iframe); script tags in rendered HTML now log CSP

--- a/claude-notes/plans/2026-08-17-safari-preview-links.md
+++ b/claude-notes/plans/2026-08-17-safari-preview-links.md
@@ -1,0 +1,297 @@
+# Fix quarto-dev/q2#128 — hub-client preview links fail in Safari
+
+## Overview
+
+Clicking links in the hub-client HTML preview fails in Safari: the preview iframe
+navigates away and goes blank. Console shows:
+
+1. `Blocked script execution in 'https://quarto-hub.com/' because the document's
+   frame is sandboxed and the 'allow-scripts' permission is not set.`
+2. `Refused to display 'https://quarto-hub.com/team-sync/2026-04-15.qmd' in a
+   frame because it set 'X-Frame-Options' to 'DENY'.`
+
+### Root cause (confirmed)
+
+The default `format: html` preview is `MorphIframe`
+(`ts-packages/preview-renderer/src/iframe/MorphIframe.tsx:486`), a `srcdoc`
+iframe with `sandbox="allow-same-origin allow-popups"` — **no `allow-scripts`**.
+Link interception is done by `postProcessIframe`
+(`ts-packages/preview-renderer/src/utils/iframePostProcessor.ts`), which attaches
+`click` listeners from the *parent* realm onto elements inside the iframe
+document.
+
+Safari (WebKit bug [218086](https://bugs.webkit.org/show_bug.cgi?id=218086),
+open since 2020, still present 2025) **blocks parent-attached event listeners on
+a sandboxed frame that lacks `allow-scripts`**. Chrome/Firefox run them. So in
+Safari the `preventDefault()` in the click handler never runs, the iframe
+follows the raw href (resolved against the parent origin because `srcdoc` +
+`allow-same-origin`), the hub responds `X-Frame-Options: DENY`, and Safari shows
+a blank frame. Exactly the reported symptoms.
+
+The same root cause also breaks the other parent-attached listeners in Safari:
+scroll sync, click-to-position, and selection sync (`MorphIframe.tsx:414-480`),
+plus the Cmd+S keydown handler (`iframePostProcessor.ts:303-308`). This fix
+repairs all of them.
+
+### Fix strategy
+
+Add `allow-scripts` to the sandbox **and** neutralize in-document scripts with a
+CSP meta tag injected into every preview HTML payload (initial `srcdoc` and
+every morphdom update):
+
+```
+sandbox="allow-same-origin allow-scripts allow-popups"
+<meta http-equiv="Content-Security-Policy" content="script-src 'none'">
+```
+
+This is the workaround recommended in the WebKit bug itself (comment #5).
+`allow-scripts` clears WebKit's sandbox check so parent-attached listeners run;
+the CSP then blocks all script execution *inside* the document (script elements,
+inline `onclick` handlers, `javascript:` URLs) — which is precisely what the
+sandbox withholds today. CSP does not block `addEventListener`-registered
+listeners, so our handlers keep working.
+
+Security posture is preserved:
+
+- The `allow-scripts` + `allow-same-origin` escape vector requires a script
+  running in the iframe's realm; CSP `script-src 'none'` prevents that, and the
+  parent never injects `<script>` elements into the iframe (the script-inlining
+  block in `iframePostProcessor.ts:176-202` stays disabled).
+- The CSP meta must precede every script in document order, so injection is
+  specified as: insert immediately after the `<!DOCTYPE>` if present, else at
+  byte 0 — the parser places a leading `<meta>` in the implied `<head>`. This
+  is robust against head-like markup inside comments/titles/scripts and
+  uppercase tags, which a "first child of `<head>`" string search is not.
+  Post-fix the CSP is the *only* script mitigation, so an injection miss is a
+  same-origin escape; this contract is the highest-risk part of the
+  implementation.
+- The CSP meta is injected into *every* html payload — the initial `srcdoc`
+  assignment and every morphdom update — so it stays present in `<head>` for
+  the document's lifetime. Enforcement therefore never depends on whether a
+  parsed meta-CSP survives removal of the meta element (cross-browser
+  behavior the specs leave murky). User content can only add *stricter* CSPs,
+  never loosen ours.
+- Injection happens only in the hub-client preview path, never in the
+  `quarto-core` HTML writer — CLI renders keep working scripts.
+- Sandbox flags propagate to nested browsing contexts, so adding
+  `allow-scripts` lets third-party embedded iframes in preview content (e.g.
+  video embeds) run scripts — the CSP does not inherit into cross-origin
+  nested documents. This is normal web behavior (and unbreaks currently
+  scriptless embeds), but it is a posture change: noted, accepted, and
+  spot-checked manually in Phase 3.
+- Nested *same-origin* navigables (`<iframe src="/...">`, `<object>`,
+  framesets pointing at hub-origin pages) also gain script execution, and the
+  CSP does not follow into non-srcdoc nested documents either. The hub app
+  shell is frameable from same origin: nothing in this repo sets
+  `X-Frame-Options` on any route (the `DENY` on the `.qmd` route — error
+  #2 — comes from production nginx, which lives outside this repo), and the
+  issue's console error #1 shows `https://quarto-hub.com/` itself loading in
+  the frame in production. So preview content can embed hub pages that then
+  run with scripts, same-origin as the hub app. The nested content is the
+  hub's own code, so
+  practical exploitability is limited, but it weakens preview isolation.
+  Mitigations: (a) follow-up strand for CSP `frame-ancestors` on hub HTML
+  routes — covers `object`/`embed`, which XFO does not, and also fixes the
+  clickjacking exposure error #1 implies (filed in Phase 4); (b) optionally
+  add `object-src 'none'` to the injected CSP, decided by the PDF-embed
+  spot-check in Phase 3. Note the CSP *does* inherit into
+  srcdoc/about:blank nested documents, so that vector stays closed.
+- This change converts script-blocking from fail-closed to fail-open: today a
+  code path that forgets protection is still saved by the sandbox; after the
+  fix, one missed injection silently executes user scripts same-origin.
+  Mitigations: both `MorphIframe` payload paths route through the single
+  `injectPreviewCsp` call; a dev-mode tripwire in `postProcessIframe` warns
+  if the settled document lacks the meta (Phase 2); the disabled
+  script-inlining comment is updated so a future reader doesn't strip the
+  CSP; and any future srcdoc/innerHTML preview path must route through
+  `injectPreviewCsp`. Current srcdoc sites are all covered or correctly
+  excluded: `MorphIframe.tsx:269`, `DoubleBufferedIframe.tsx:345,353`, and
+  `AboutTab.tsx:191` (keeps no-`allow-scripts`).
+
+Rejected alternatives:
+
+- **`allow-scripts` without CSP** — turns the sandbox into a no-op (classic
+  escape combination) and would execute user-content scripts same-origin as the
+  hub app. Security regression.
+- **Navigation-as-message fallback** (detect the iframe's `load` event in the
+  parent, parse `contentWindow.location`, restore content) — works around the
+  bug without `allow-scripts`, but is a second, Safari-only code path with
+  uncertain behavior after XFO-blocked navigations. Kept as backup if real
+  Safari testing shows the CSP workaround insufficient.
+
+### Scope
+
+- **Affected / fixed:** `MorphIframe` (the live HTML preview). Also apply the
+  same one-line sandbox change + CSP injection to `DoubleBufferedIframe`
+  (`ts-packages/preview-renderer/src/iframe/DoubleBufferedIframe.tsx:347,355`),
+  an exported legacy component with the identical pattern.
+- **Unaffected:** `Q2PreviewIframe` (q2-preview path) already has
+  `allow-scripts`; its `installLinkHandlers` runs inside the iframe's own React
+  app. `Q2SandboxedPreviewIframe` renders a JSON dump (no links).
+- **Out of scope (follow-up strand):** relative links to non-renderable files
+  (e.g. `data.csv`) are intercepted by nobody and blank the iframe in *all*
+  browsers. Pre-existing separate bug.
+
+## Work items
+
+### Phase 0 — bookkeeping
+
+- [x] `braid create` a P1 bug strand referencing GitHub issue #128; link this plan
+- [x] Copy this plan to `claude-notes/plans/2026-08-17-safari-preview-links.md` per repo convention
+
+### Phase 1 — failing tests first (TDD)
+
+- [x] Unit tests for new util `injectPreviewCsp(html)` in
+      `ts-packages/preview-renderer/src/utils/previewCsp.test.ts`:
+      injects `<meta http-equiv="Content-Security-Policy" content="script-src 'none'">`
+      immediately after the `<!DOCTYPE>` if present, else at byte 0 (the
+      parser places a leading `<meta>` in the implied `<head>`); **never
+      inserts before `<!DOCTYPE html>`** — anything preceding the DOCTYPE
+      triggers Quirks Mode (see the srcdoc comment block in
+      `MorphIframe.tsx`); idempotent; leaves existing meta CSPs intact (they
+      can only restrict further). Adversarial cases (a "first child of
+      `<head>`" string search is spoofable — do not implement it that way):
+      head-like markup inside comments/`title`/`script`/`textarea`, uppercase
+      `<HEAD>`, no-`<head>` fragment starting with `<script>` — in every case
+      the meta must end up as the first element in document order
+- [x] Integration test (jsdom, pattern of `iframePostProcessor.integration.test.ts`):
+      rendering `MorphIframe` produces an iframe whose `sandbox` contains
+      `allow-scripts`, `allow-same-origin`, `allow-popups`, whose `srcdoc`
+      has the CSP meta as the first element in document order (before any
+      `<script>` in the payload), and whose `<head>` still contains the meta
+      after a morphdom content update
+- [x] Confirm the new unit/integration tests fail pre-fix (sandbox attribute /
+      srcdoc assertions)
+- [x] Playwright e2e regression spec `hub-client/e2e/preview-link-navigation.spec.ts`:
+      project with `index.qmd` linking to `other.qmd`; click the rendered link
+      inside the preview iframe; assert the editor switches to `other.qmd` and
+      the preview is not blank. Enable the commented-out `webkit` project in
+      `playwright.config.ts` (line ~74) scoped to this spec (per-project
+      `testMatch`) so added test time stays minimal. **Verify this spec fails
+      on WebKit before the fix** (requires `npx playwright install webkit`)
+- [x] Negative security e2e spec `hub-client/e2e/preview-script-blocking.spec.ts`:
+      a qmd whose rendered HTML contains a `<script>`, an inline `on*`
+      handler, a `javascript:` URL, and a nested `<iframe srcdoc="…">` with a
+      script — each attempting to mutate the parent (e.g. set
+      `top.document.title`); assert none execute. Extend the webkit project's
+      `testMatch` to cover this spec too, and run it under chromium as well:
+      jsdom enforces neither the sandbox nor CSP, so the no-scripts guarantee
+      can only be pinned in real browsers. This is the regression test for
+      the escape combination in "Rejected alternatives"
+- [x] Update `.github/workflows/hub-client-e2e.yml` to also install webkit
+      (`npx playwright install --with-deps webkit`, alongside chromium at line
+      ~165) — the webkit project fails in CI without it; the browser install
+      adds ~1-2 min to CI even though test time stays flat
+
+### Phase 2 — implementation
+
+- [x] Add `ts-packages/preview-renderer/src/utils/previewCsp.ts` exporting
+      `injectPreviewCsp(html: string): string` and the meta-tag constant,
+      implementing the after-DOCTYPE/byte-0 injection contract from Fix
+      strategy (not a `<head>` string search)
+- [x] `MorphIframe.tsx`: sandbox → `'allow-same-origin allow-scripts allow-popups'`;
+      apply `injectPreviewCsp` to `html` once at the top of the content effect
+      so **both** the initial `iframe.srcdoc = html` (line 269) and the
+      morphdom path (`tempContainer.innerHTML = html`, line 292) carry the
+      meta — morphdom then keeps it in `<head>`. Add a comment citing WebKit
+      bug 218086 and the inject-on-every-payload rationale
+- [x] `DoubleBufferedIframe.tsx`: same sandbox change + CSP injection at its
+      content-set site, for consistency of the exported API
+- [x] `iframePostProcessor.ts`: update the disabled script-inlining comment
+      (lines 176-202) — it currently says re-enabling only needs
+      `allow-scripts` in the sandbox; after this fix `allow-scripts` is
+      present but the CSP still blocks inlined scripts. Note the CSP so a
+      future reader doesn't uncomment the block and strip the CSP in confusion
+- [x] `iframePostProcessor.ts`: dev-mode tripwire in `postProcessIframe` — if
+      the settled document's `<head>` lacks the injected CSP meta, log a loud
+      warning (a missed injection now means user scripts execute same-origin;
+      the sandbox no longer catches it). Fail-open guard only; no production
+      behavior change
+- [x] Re-assert/defensive: in `postProcessIframe`, no change expected — verify
+      during implementation that morphdom preserves the injected meta in
+      `<head>` (it should: both the settled document and each new payload
+      carry it)
+
+### Phase 3 — verification
+
+- [x] `npm run test:ci` in `hub-client/` (unit + integration + wasm)
+- [x] `npm run build:all` in `hub-client/` (stricter than tsc --noEmit; required by CLAUDE.md)
+- [x] `npx playwright test preview-link-navigation` under chromium (no regression)
+      and webkit (fix confirmed); `npx playwright test
+      preview-script-blocking` under chromium and webkit (no script
+      execution)
+- [x] `cargo xtask verify` (full — hub-client build leg affected; ts-packages are
+      bundled from source)
+- [ ] End-to-end in a real browser per CLAUDE.md: `npm run local-prod`, open
+      http://127.0.0.1:8080 in **real Safari**, click a cross-doc link, confirm
+      file switch; also confirm scroll sync now works in Safari, and
+      spot-check a third-party embed (nested iframe) for the posture change
+      noted in Fix strategy, and a PDF `<object>` embed to decide whether
+      adding `object-src 'none'` to the injected CSP is safe. If real Safari
+      can't be driven from this session,
+      say so explicitly and rely on Playwright-WebKit evidence + user
+      verification on production
+      → **2026-08-18: real Safari could not be driven from the dev session
+      (headless). Relying on Playwright-WebKit evidence (both specs green
+      on webkit-2287). The third-party-embed / PDF-`<object>` spot-checks
+      and the `object-src 'none'` decision remain for user verification on
+      production.**
+- [x] Note expected cosmetic change: Chrome may log an "allow-scripts +
+      allow-same-origin can escape sandboxing" console warning (already present
+      for the q2-preview iframe); script tags in rendered HTML now log CSP
+      violations instead of sandbox violations
+
+### Phase 4 — repo process
+
+- [ ] hub-client `changelog.md` entry (two-commit workflow: change commit, then
+      changelog commit with the hash) — the fix lands in `ts-packages/` but
+      changes hub-client behavior and touches `hub-client/e2e/`
+- [ ] File follow-up braid strand: unintercepted relative links (non-.qmd)
+      blank the preview iframe in all browsers
+- [ ] File follow-up braid strand: send CSP `frame-ancestors` on hub HTML
+      routes (production nginx lives outside this repo) — covers `object`/
+      `embed` framing, which XFO does not, and closes the same-origin framing
+      exposure noted in Fix strategy (also a pre-existing clickjacking fix)
+- [ ] `braid close` the strand with a summary; comment on GitHub issue #128
+- [ ] Stage and commit; report snapshot/test status; **do not push without
+      explicit permission**
+
+## Details
+
+### Security audit
+
+This plan was security-audited on 2026-08-17; findings F1–F4 are incorporated
+above (injection-point contract, negative script-blocking e2e, same-origin
+nested-frame analysis, fail-open tripwire). One pre-existing issue was flagged
+but is out of scope: `Q2PreviewIframe` already ships
+`sandbox="allow-scripts allow-same-origin"` with no CSP while rendering user
+raw HTML via `dangerouslySetInnerHTML` — script elements inserted via
+innerHTML don't execute, but inline event handlers do, same-origin as the hub
+app. Candidate for its own follow-up strand.
+
+### Evidence chain
+
+| Symptom | Cause |
+|---|---|
+| `Blocked script execution … 'allow-scripts' … not set` | Sandbox-without-`allow-scripts` blocking script execution tied to the frame. Note the message names `https://quarto-hub.com/`, whereas WebKit 218086's repro reports `about:srcdoc` — so this line most likely shows scripts on a hub page the frame had *already navigated to* being blocked (which is also the same-origin frameability evidence used in Fix strategy). The listener blocking itself is confirmed by WebKit 218086 and by "works in Chrome", not by this console line |
+| `Refused to display …/2026-04-15.qmd … X-Frame-Options DENY` | Un-intercepted click → iframe navigates to href resolved against parent origin; hub sends XFO DENY |
+| Blank frame | XFO-blocked navigation replaces the `srcdoc` document |
+| Works in Chrome | Chrome runs parent-attached listeners → `preventDefault` → SPA file switch via `onQmdLinkClick` |
+
+### Key files
+
+- `ts-packages/preview-renderer/src/iframe/MorphIframe.tsx` — sandbox attr (line 486), srcdoc assignment (line 269)
+- `ts-packages/preview-renderer/src/iframe/DoubleBufferedIframe.tsx` — legacy, same pattern (lines 347, 355)
+- `ts-packages/preview-renderer/src/utils/iframePostProcessor.ts` — link handlers installed from parent realm
+- `ts-packages/preview-renderer/src/utils/previewCsp.ts` — **new** util
+- `hub-client/playwright.config.ts` — enable webkit project (currently commented out, line ~74)
+- `hub-client/e2e/` — new regression spec; follow patterns in `project-loading.spec.ts`, helpers in `e2e/helpers/`
+- `.github/workflows/hub-client-e2e.yml` — install webkit alongside chromium for CI
+
+### Test-environment caveat
+
+jsdom enforces neither WebKit's sandbox script blocking nor CSP at all, so
+vitest can only assert the mechanism (sandbox tokens, CSP meta
+presence/position). Both behavioral tests — link navigation and script
+blocking — must be Playwright (WebKit is real WebKit; the script-blocking
+spec also runs under chromium so the guarantee is pinned in both engines).

--- a/claude-notes/plans/2026-08-17-safari-preview-links.md
+++ b/claude-notes/plans/2026-08-17-safari-preview-links.md
@@ -243,18 +243,23 @@ Rejected alternatives:
 
 ### Phase 4 — repo process
 
-- [ ] hub-client `changelog.md` entry (two-commit workflow: change commit, then
+- [x] hub-client `changelog.md` entry (two-commit workflow: change commit, then
       changelog commit with the hash) — the fix lands in `ts-packages/` but
       changes hub-client behavior and touches `hub-client/e2e/`
-- [ ] File follow-up braid strand: unintercepted relative links (non-.qmd)
-      blank the preview iframe in all browsers
-- [ ] File follow-up braid strand: send CSP `frame-ancestors` on hub HTML
+      (change commit `7bb2d80f`, changelog commit `bf211a03`)
+- [x] File follow-up braid strand: unintercepted relative links (non-.qmd)
+      blank the preview iframe in all browsers → `bd-ddfyqmfm`
+- [x] File follow-up braid strand: send CSP `frame-ancestors` on hub HTML
       routes (production nginx lives outside this repo) — covers `object`/
       `embed` framing, which XFO does not, and closes the same-origin framing
       exposure noted in Fix strategy (also a pre-existing clickjacking fix)
-- [ ] `braid close` the strand with a summary; comment on GitHub issue #128
-- [ ] Stage and commit; report snapshot/test status; **do not push without
-      explicit permission**
+      → `bd-23es17uh`; also filed `bd-rpc3skz0` for the pre-existing
+      Q2PreviewIframe inline-handler exposure from the security audit
+- [x] `braid close` the strand with a summary (bd-sxx1az83 closed);
+      GitHub issue #128 comment skipped per user decision
+- [x] Stage and commit; report snapshot/test status; **do not push without
+      explicit permission** — commits `7bb2d80f` + `bf211a03` are local on
+      `main`, not pushed
 
 ## Details
 

--- a/hub-client/changelog.md
+++ b/hub-client/changelog.md
@@ -23,6 +23,10 @@ WASM rebuild is needed for a changelog-only edit.
 
 -->
 
+### 2026-08-18
+
+- [`7bb2d80f`](https://github.com/quarto-dev/q2/commits/7bb2d80f): Fix preview links in Safari — clicking a cross-document link in the HTML preview no longer navigates the preview away to a blank frame, and scroll/selection sync work in Safari again.
+
 ### 2026-08-14
 
 - [`9b60bbe2`](https://github.com/quarto-dev/q2/commits/9b60bbe2): Keep the WASM-driven theme/SASS cache in memory during `q2 preview` sessions (viewer and editor alike), so preview origins leave no IndexedDB databases behind at all.

--- a/hub-client/e2e/preview-link-navigation.spec.ts
+++ b/hub-client/e2e/preview-link-navigation.spec.ts
@@ -1,0 +1,90 @@
+/**
+ * Regression spec for quarto-dev/q2#128 (bd-sxx1az83): clicking a
+ * cross-document link in the hub-client HTML preview failed in Safari —
+ * the preview iframe navigated away and went blank.
+ *
+ * Root cause: WebKit bug 218086 blocks parent-attached event listeners
+ * on a sandboxed frame that lacks `allow-scripts`, so the post-processor's
+ * click interception never ran in Safari and the iframe followed the raw
+ * href. The fix adds `allow-scripts` to the MorphIframe sandbox (plus a
+ * CSP meta neutralizing in-document scripts — see
+ * preview-script-blocking.spec.ts).
+ *
+ * This spec is the one place the fix is verified against real WebKit:
+ * the `webkit` project in playwright.config.ts is scoped to it via
+ * testMatch. It also runs under chromium as a no-regression check.
+ */
+
+import { test, expect } from '@playwright/test';
+import {
+  bootstrapProjectSet,
+  createProjectOnServer,
+  seedProjectInBrowser,
+  getServerUrl,
+} from './helpers/projectFactory';
+
+test.describe('Preview link navigation (q2#128)', () => {
+  test('clicking a .qmd link in the preview switches the editor to that file', async ({
+    page,
+  }) => {
+    const serverUrl = getServerUrl();
+
+    const indexDocId = await createProjectOnServer(serverUrl, [
+      {
+        path: '_quarto.yml',
+        content: 'project:\n  type: default\n',
+        contentType: 'text',
+      },
+      {
+        path: 'index.qmd',
+        content: [
+          '---',
+          'title: Link Nav Index',
+          '---',
+          '',
+          '## Index page',
+          '',
+          '[Go to other](other.qmd)',
+        ].join('\n'),
+        contentType: 'text',
+      },
+      {
+        path: 'other.qmd',
+        content: [
+          '---',
+          'title: Link Nav Other',
+          '---',
+          '',
+          '## Other page',
+          '',
+          'Other document body text.',
+        ].join('\n'),
+        contentType: 'text',
+      },
+    ]);
+
+    await bootstrapProjectSet(page, serverUrl);
+    const localId = await seedProjectInBrowser(page, indexDocId, serverUrl);
+
+    await page.goto(`/#/p/${localId}/file/index.qmd`);
+
+    // Wait for the preview iframe to render index.qmd (up to 30s for
+    // WASM init + render).
+    const previewFrame = page.frameLocator('iframe.preview-active');
+    await expect(previewFrame.locator('body')).toContainText('Index page', {
+      timeout: 30000,
+    });
+
+    // Click the rendered cross-doc link inside the preview iframe.
+    await previewFrame.getByRole('link', { name: 'Go to other' }).click();
+
+    // The editor switches to other.qmd (SPA navigation, not an iframe
+    // navigation)…
+    await expect(page).toHaveURL(new RegExp(`/#/p/${localId}/file/other\\.qmd`));
+
+    // …and the preview shows the other document — not a blank frame.
+    await expect(previewFrame.locator('body')).toContainText('Other document body text', {
+      timeout: 30000,
+    });
+  });
+});

--- a/hub-client/e2e/preview-script-blocking.spec.ts
+++ b/hub-client/e2e/preview-script-blocking.spec.ts
@@ -1,0 +1,90 @@
+/**
+ * Negative security spec for quarto-dev/q2#128 (bd-sxx1az83).
+ *
+ * The Safari fix adds `allow-scripts` to the preview iframe sandbox —
+ * the classic sandbox-escape combination with `allow-same-origin` —
+ * and neutralizes in-document scripts with an injected CSP meta
+ * (`script-src 'none'`). This spec pins the guarantee that NO script in
+ * preview content executes, in real browsers (jsdom enforces neither the
+ * sandbox nor CSP, so this can only be e2e). It runs under both chromium
+ * and webkit (see the webkit project's testMatch in playwright.config.ts).
+ *
+ * Each vector below attempts to mutate the parent document's title. This
+ * spec is the regression test for the escape combination: it passes both
+ * pre-fix (sandbox blocks scripts) and post-fix (CSP blocks scripts), and
+ * fails if the CSP is ever lost while `allow-scripts` remains.
+ */
+
+import { test, expect } from '@playwright/test';
+import {
+  bootstrapProjectSet,
+  createProjectOnServer,
+  seedProjectInBrowser,
+  getServerUrl,
+} from './helpers/projectFactory';
+
+test.describe('Preview script blocking (q2#128)', () => {
+  test('no script in preview content executes — tag, inline handler, javascript: URL, nested srcdoc', async ({
+    page,
+  }) => {
+    const serverUrl = getServerUrl();
+
+    const indexDocId = await createProjectOnServer(serverUrl, [
+      {
+        path: '_quarto.yml',
+        content: 'project:\n  type: default\n',
+        contentType: 'text',
+      },
+      {
+        path: 'index.qmd',
+        content: [
+          '---',
+          'title: Script Blocking',
+          '---',
+          '',
+          '## Script blocking test',
+          '',
+          '```{=html}',
+          '<script id="evil-script">top.document.title = "PWNED-script-tag";</script>',
+          '<button type="button" id="evil-inline" onclick="top.document.title=\'PWNED-inline\'">inline handler</button>',
+          '<a id="evil-jsurl" href="javascript:top.document.title=\'PWNED-jsurl\'">javascript url</a>',
+          '<iframe id="evil-nested" srcdoc="&lt;script&gt;top.document.title=\'PWNED-nested\'&lt;/script&gt;"></iframe>',
+          '```',
+        ].join('\n'),
+        contentType: 'text',
+      },
+    ]);
+
+    await bootstrapProjectSet(page, serverUrl);
+    const localId = await seedProjectInBrowser(page, indexDocId, serverUrl);
+
+    await page.goto(`/#/p/${localId}/file/index.qmd`);
+
+    const previewFrame = page.frameLocator('iframe.preview-active');
+    await expect(previewFrame.locator('body')).toContainText('Script blocking test', {
+      timeout: 30000,
+    });
+
+    // Prove the attack payloads actually made it into the preview DOM —
+    // otherwise the no-execution assertions below are vacuous.
+    await expect(previewFrame.locator('script#evil-script')).toHaveCount(1);
+    await expect(previewFrame.locator('#evil-inline')).toHaveCount(1);
+    await expect(previewFrame.locator('#evil-jsurl')).toHaveCount(1);
+    await expect(previewFrame.locator('iframe#evil-nested')).toHaveCount(1);
+
+    // The app sets the title from file + project; capture it once the
+    // preview has settled, before poking the attack vectors.
+    const titleBefore = await page.title();
+
+    // Trigger the click-dependent vectors (the <script> tag and the
+    // nested srcdoc iframe would already have run on load if unblocked).
+    await previewFrame.locator('#evil-inline').click();
+    await previewFrame.locator('#evil-jsurl').click();
+
+    // Give any rogue script a real chance to run.
+    await page.waitForTimeout(500);
+
+    expect(await page.title()).toBe(titleBefore);
+    expect(await page.title()).not.toContain('PWNED');
+  });
+});

--- a/hub-client/playwright.config.ts
+++ b/hub-client/playwright.config.ts
@@ -70,10 +70,19 @@ export default defineConfig({
     //   name: 'firefox',
     //   use: { ...devices['Desktop Firefox'] },
     // },
-    // {
-    //   name: 'webkit',
-    //   use: { ...devices['Desktop Safari'] },
-    // },
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+      // Scoped to the Safari regression specs (quarto-dev/q2#128,
+      // bd-sxx1az83) so the added test time stays minimal. The
+      // script-blocking spec runs here AND under chromium: jsdom enforces
+      // neither the sandbox nor CSP, so the no-scripts guarantee can only
+      // be pinned in real browsers.
+      testMatch: [
+        '**/preview-link-navigation.spec.ts',
+        '**/preview-script-blocking.spec.ts',
+      ],
+    },
   ],
 
   // Serve the prebuilt hub-client bundle via `vite preview` rather than

--- a/ts-packages/preview-renderer/src/global.d.ts
+++ b/ts-packages/preview-renderer/src/global.d.ts
@@ -31,3 +31,19 @@ declare module 'virtual:quarto-attribution-viewer-css' {
     const content: string;
     export default content;
 }
+
+/**
+ * `import.meta.env` typing for the dev-mode tripwire in
+ * `utils/iframePostProcessor.ts`. Declared locally for the same reason
+ * as the module shims above: the package's standalone `tsc --noEmit`
+ * runs without Vite. The shapes match `vite/client`'s own declarations
+ * exactly, so the two merge cleanly when hub-client compiles this
+ * package's sources with `vite/client` in scope.
+ */
+interface ImportMetaEnv {
+    DEV: boolean;
+}
+
+interface ImportMeta {
+    readonly env: ImportMetaEnv;
+}

--- a/ts-packages/preview-renderer/src/iframe/DoubleBufferedIframe.tsx
+++ b/ts-packages/preview-renderer/src/iframe/DoubleBufferedIframe.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect, useCallback, useImperativeHandle } from 'react';
 import type { Ref } from 'react';
 import { postProcessIframe } from '../utils/iframePostProcessor';
+import { injectPreviewCsp } from '../utils/previewCsp';
 
 // Methods exposed via ref
 export interface DoubleBufferedIframeHandle {
@@ -173,10 +174,17 @@ function DoubleBufferedIframe({
 
   // When new HTML arrives, load it into the inactive iframe and mark swap as pending
   useEffect(() => {
+    // quarto-dev/q2#128: the sandbox below carries `allow-scripts` (see
+    // MorphIframe.tsx for the WebKit bug 218086 rationale), so every
+    // srcDoc payload goes through `injectPreviewCsp` — the injected CSP
+    // meta (`script-src 'none'`) is the only script mitigation in these
+    // iframes. The timestamp comment is appended AFTER injection so the
+    // meta stays the first element in document order.
+    //
     // Add unique timestamp to ensure srcDoc always changes, forcing onLoad to fire
     // Without this, if HTML is identical to what's already there, React won't update
     // the DOM and onLoad won't fire, breaking the swap mechanism
-    const uniqueHtml = html + `<!-- render-${Date.now()} -->`;
+    const uniqueHtml = injectPreviewCsp(html) + `<!-- render-${Date.now()} -->`;
 
     if (activeIframe === 'A') {
       setIframeBHtml(uniqueHtml);
@@ -344,7 +352,7 @@ function DoubleBufferedIframe({
         ref={iframeARef}
         srcDoc={iframeAHtml}
         title={`A`}
-        sandbox={'allow-same-origin allow-popups'}
+        sandbox={'allow-same-origin allow-scripts allow-popups'}
         onLoad={activeIframe === 'A' ? handleActiveLoad : handleInactiveLoad}
         className={activeIframe === 'A' ? 'preview-active' : 'preview-hidden'}
       />
@@ -352,7 +360,7 @@ function DoubleBufferedIframe({
         ref={iframeBRef}
         srcDoc={iframeBHtml}
         title={`B`}
-        sandbox={'allow-same-origin allow-popups'}
+        sandbox={'allow-same-origin allow-scripts allow-popups'}
         onLoad={activeIframe === 'B' ? handleActiveLoad : handleInactiveLoad}
         className={activeIframe === 'B' ? 'preview-active' : 'preview-hidden'}
       />

--- a/ts-packages/preview-renderer/src/iframe/MorphIframe.integration.test.tsx
+++ b/ts-packages/preview-renderer/src/iframe/MorphIframe.integration.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * Integration tests for MorphIframe's Safari link-interception fix
+ * (quarto-dev/q2#128, bd-sxx1az83).
+ *
+ * Pins the mechanism, which is all jsdom can see (jsdom enforces neither
+ * the sandbox attribute nor CSP):
+ *
+ *  1. The iframe sandbox carries `allow-scripts` alongside
+ *     `allow-same-origin`/`allow-popups`, so WebKit runs parent-attached
+ *     event listeners on the frame (WebKit bug 218086 blocks them
+ *     otherwise — that was the Safari link/scroll-sync failure).
+ *  2. Every payload the component emits (initial `srcdoc` and every
+ *     morphdom update) carries the CSP meta as the first element in
+ *     document order, so no script inside the preview document executes
+ *     even with `allow-scripts` set.
+ *
+ * Behavioral coverage (link navigation in WebKit, no script execution)
+ * lives in `hub-client/e2e/preview-link-navigation.spec.ts` and
+ * `preview-script-blocking.spec.ts` — real browsers only.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, act } from '@testing-library/react';
+import { createRef } from 'react';
+
+// Stub the WASM-backed VFS reads; postProcessIframe's resource-rewriting
+// passes call them but they're irrelevant to these assertions.
+vi.mock('@quarto/preview-runtime', () => ({
+  vfsReadFile: vi.fn().mockReturnValue({ success: false }),
+  vfsReadBinaryFile: vi.fn().mockReturnValue({ success: false }),
+}));
+
+import MorphIframe, { type MorphIframeHandle } from './MorphIframe';
+
+// The expected meta tag, specified independently of the implementation's
+// own constant so this test fails if either drifts.
+const CSP_META = '<meta http-equiv="Content-Security-Policy" content="script-src \'none\'">';
+
+function previewElement(html: string) {
+  return (
+    <MorphIframe
+      ref={createRef<MorphIframeHandle>()}
+      html={html}
+      currentFilePath="index.qmd"
+      projectFilePaths={['index.qmd', 'other.qmd']}
+      qmdContent=""
+      onNavigateToDocument={() => {}}
+    />
+  );
+}
+
+describe('MorphIframe sandbox + CSP (q2#128)', () => {
+  it('sets sandbox with allow-scripts, allow-same-origin, and allow-popups', () => {
+    const { container } = render(previewElement('<!DOCTYPE html><html><body>hi</body></html>'));
+    const iframe = container.querySelector('iframe');
+    expect(iframe).not.toBeNull();
+    const tokens = (iframe!.getAttribute('sandbox') ?? '').split(/\s+/).filter(Boolean);
+    expect(tokens).toContain('allow-scripts');
+    expect(tokens).toContain('allow-same-origin');
+    expect(tokens).toContain('allow-popups');
+  });
+
+  it('emits a srcdoc payload whose first element is the CSP meta, before any <script>', () => {
+    const { container } = render(
+      previewElement(
+        '<!DOCTYPE html><html><head><script src="libs/x.js"></script></head><body>hi</body></html>',
+      ),
+    );
+    const iframe = container.querySelector('iframe')!;
+    const srcdoc = iframe.getAttribute('srcdoc') ?? '';
+    // Immediately after the DOCTYPE — never before it (Quirks Mode).
+    expect(srcdoc.startsWith('<!DOCTYPE html>' + CSP_META)).toBe(true);
+    expect(srcdoc.indexOf(CSP_META)).toBeLessThan(srcdoc.indexOf('<script'));
+  });
+
+  it('keeps the CSP meta in <head> across a morphdom content update', () => {
+    const html1 = '<!DOCTYPE html><html><head><title>one</title></head><body>first</body></html>';
+    const html2 =
+      '<!DOCTYPE html><html><head><title>two</title><script src="libs/y.js"></script></head><body>second</body></html>';
+
+    const utils = render(previewElement(html1));
+    const iframe = utils.container.querySelector('iframe')!;
+
+    // jsdom neither parses `srcdoc` into the contentDocument nor fires
+    // its load event. Simulate the settled document exactly as the
+    // browser would have parsed the component's emitted payload, then
+    // fire the load the component waits for.
+    const settled = iframe.getAttribute('srcdoc')!;
+    act(() => {
+      iframe.contentDocument!.open();
+      iframe.contentDocument!.write(settled);
+      iframe.contentDocument!.close();
+      iframe.dispatchEvent(new Event('load'));
+    });
+
+    // Sanity: the settled document carries the meta in <head>.
+    expect(
+      iframe.contentDocument!.head.querySelector('meta[http-equiv="Content-Security-Policy"]'),
+    ).not.toBeNull();
+
+    // Morphdom update path (second payload).
+    act(() => {
+      utils.rerender(previewElement(html2));
+    });
+
+    const doc = iframe.contentDocument!;
+    const meta = doc.head.querySelector('meta[http-equiv="Content-Security-Policy"]');
+    expect(meta).not.toBeNull();
+    expect(meta!.getAttribute('content')).toBe("script-src 'none'");
+    // The meta still precedes every script in document order.
+    expect(doc.head.innerHTML.indexOf('Content-Security-Policy')).toBeLessThan(
+      doc.head.innerHTML.indexOf('<script'),
+    );
+    // And the morph actually applied the new content.
+    expect(doc.body.textContent).toContain('second');
+  });
+});

--- a/ts-packages/preview-renderer/src/iframe/MorphIframe.integration.test.tsx
+++ b/ts-packages/preview-renderer/src/iframe/MorphIframe.integration.test.tsx
@@ -68,7 +68,8 @@ describe('MorphIframe sandbox + CSP (q2#128)', () => {
     );
     const iframe = container.querySelector('iframe')!;
     const srcdoc = iframe.getAttribute('srcdoc') ?? '';
-    // Immediately after the DOCTYPE — never before it (Quirks Mode).
+    // Immediately after the DOCTYPE — never before it (injection
+    // contract documented in previewCsp.ts).
     expect(srcdoc.startsWith('<!DOCTYPE html>' + CSP_META)).toBe(true);
     expect(srcdoc.indexOf(CSP_META)).toBeLessThan(srcdoc.indexOf('<script'));
   });

--- a/ts-packages/preview-renderer/src/iframe/MorphIframe.tsx
+++ b/ts-packages/preview-renderer/src/iframe/MorphIframe.tsx
@@ -2,6 +2,7 @@ import { useRef, useEffect, useCallback, useImperativeHandle, useState } from 'r
 import type { Ref } from 'react';
 import morphdom from 'morphdom';
 import { postProcessIframe } from '../utils/iframePostProcessor';
+import { injectPreviewCsp } from '../utils/previewCsp';
 import {
   parseDataLoc,
   scrollIframeToLine,
@@ -232,6 +233,20 @@ function MorphIframe({
     const iframe = iframeRef.current;
     if (!iframe) return;
 
+    // quarto-dev/q2#128: the sandbox on this iframe carries
+    // `allow-scripts` so that WebKit runs the parent-attached event
+    // listeners installed by postProcessIframe and the listener effect
+    // below — WebKit bug 218086 blocks them on sandboxed frames lacking
+    // `allow-scripts`, which broke link interception / scroll sync /
+    // selection sync in Safari. Since `allow-scripts` +
+    // `allow-same-origin` is the classic sandbox-escape combination,
+    // EVERY payload — the initial `srcdoc` assignment and each morphdom
+    // update — goes through `injectPreviewCsp`, so the injected CSP meta
+    // (`script-src 'none'`) stays present in <head> for the document's
+    // whole lifetime. Post-fix that meta is the only script mitigation
+    // in the iframe; never set a payload here that bypassed injection.
+    const cspHtml = injectPreviewCsp(html);
+
     // Check if this is the first time we're setting content
     // An uninitialized iframe document will have an empty body
     const isFirstLoad = !isInitializedRef.current;
@@ -266,7 +281,7 @@ function MorphIframe({
         setDocumentReady(true);
       };
       iframe.addEventListener('load', handleLoad, { once: true });
-      iframe.srcdoc = html;
+      iframe.srcdoc = cspHtml;
 
       // If the effect re-runs with a new `html` before the previous
       // load event fires, the cleanup below removes the stale listener
@@ -289,7 +304,7 @@ function MorphIframe({
 
     // Create a temporary container with the new HTML
     const tempContainer = doc.createElement('html');
-    tempContainer.innerHTML = html;
+    tempContainer.innerHTML = cspHtml;
 
     // Morph the document's documentElement — updates both <head> and
     // <body> efficiently in place.
@@ -483,7 +498,11 @@ function MorphIframe({
     <iframe
       ref={iframeRef}
       title="Preview"
-      sandbox={'allow-same-origin allow-popups'}
+      // `allow-scripts` is required for WebKit to run our
+      // parent-attached listeners (bug 218086); the injected CSP meta
+      // (see the content effect above) is what keeps scripts inside the
+      // preview document from executing.
+      sandbox={'allow-same-origin allow-scripts allow-popups'}
       className="preview-active"
     />
   );

--- a/ts-packages/preview-renderer/src/utils/iframePostProcessor.ts
+++ b/ts-packages/preview-renderer/src/utils/iframePostProcessor.ts
@@ -9,6 +9,8 @@
  *   switch the active editor file (bd-lnd3).
  */
 
+/// <reference types="vite/client" />
+
 import { vfsReadFile, vfsReadBinaryFile } from '@quarto/preview-runtime';
 import { resolveRelativePath, guessMimeType } from './vfsPaths';
 
@@ -160,6 +162,27 @@ export function postProcessIframe(
   const doc = iframe.contentDocument;
   if (!doc) return;
 
+  // Dev-mode tripwire (quarto-dev/q2#128): the preview iframe sandbox now
+  // carries `allow-scripts` (WebKit bug 218086 workaround), so the CSP meta
+  // injected by `injectPreviewCsp` is the ONLY thing blocking script
+  // execution inside the preview document. A document that settled without
+  // it means a payload path forgot to route through `injectPreviewCsp` —
+  // and user scripts would execute same-origin as the hub app. Fail-open
+  // guard only; no production behavior change.
+  if (import.meta.env.DEV) {
+    const hasCspMeta = doc.head?.querySelector(
+      'meta[http-equiv="Content-Security-Policy"][content="script-src \'none\'"]',
+    );
+    if (!hasCspMeta) {
+      console.warn(
+        '[q2#128] Preview iframe document is missing the injected CSP meta ' +
+          "(script-src 'none'). With allow-scripts in the sandbox, scripts in " +
+          'preview content would execute same-origin as the hub app. Route the ' +
+          'payload through injectPreviewCsp (preview-renderer/src/utils/previewCsp.ts).',
+      );
+    }
+  }
+
   // Replace CSS links with data URIs (both /.quarto/ and libs/ paths)
   doc.querySelectorAll('link[rel="stylesheet"]').forEach((link) => {
     const href = link.getAttribute('href');
@@ -175,12 +198,18 @@ export function postProcessIframe(
 
   // DISABLED: Script inlining in the preview iframe is disabled until we
   // determine a safe way to allow script execution in the sandboxed iframe.
-  // The iframe sandbox does not include allow-scripts, so even if scripts
-  // were inlined they would not execute. Extension JS (kbd.js, video.min.js)
-  // works in native renders where the browser loads <script src="..."> normally.
+  // Extension JS (kbd.js, video.min.js) works in native renders where the
+  // browser loads <script src="..."> normally.
   //
-  // To re-enable, uncomment the block below AND add allow-scripts to the
-  // sandbox attribute in DoubleBufferedIframe.tsx and MorphIframe.tsx.
+  // To re-enable, uncommenting the block below is NOT sufficient. Since
+  // quarto-dev/q2#128 the sandbox DOES include allow-scripts (WebKit bug
+  // 218086 workaround — see MorphIframe.tsx), but every preview payload
+  // carries an injected CSP meta (`script-src 'none'` — see
+  // utils/previewCsp.ts) that still blocks inlined scripts. Re-enabling
+  // script execution would require removing that CSP, which reopens the
+  // allow-scripts + allow-same-origin sandbox escape and is caught by
+  // hub-client/e2e/preview-script-blocking.spec.ts. Do not strip the CSP
+  // to make this block work.
   //
   // let didInlineScripts = false;
   // doc.querySelectorAll('script[src]').forEach((script) => {

--- a/ts-packages/preview-renderer/src/utils/iframePostProcessor.ts
+++ b/ts-packages/preview-renderer/src/utils/iframePostProcessor.ts
@@ -9,10 +9,9 @@
  *   switch the active editor file (bd-lnd3).
  */
 
-/// <reference types="vite/client" />
-
 import { vfsReadFile, vfsReadBinaryFile } from '@quarto/preview-runtime';
 import { resolveRelativePath, guessMimeType } from './vfsPaths';
+import { PREVIEW_CSP_CONTENT } from './previewCsp';
 
 /**
  * VFS path under which the website renderer flushes its
@@ -171,7 +170,7 @@ export function postProcessIframe(
   // guard only; no production behavior change.
   if (import.meta.env.DEV) {
     const hasCspMeta = doc.head?.querySelector(
-      'meta[http-equiv="Content-Security-Policy"][content="script-src \'none\'"]',
+      `meta[http-equiv="Content-Security-Policy"][content="${PREVIEW_CSP_CONTENT}"]`,
     );
     if (!hasCspMeta) {
       console.warn(

--- a/ts-packages/preview-renderer/src/utils/previewCsp.test.ts
+++ b/ts-packages/preview-renderer/src/utils/previewCsp.test.ts
@@ -29,8 +29,8 @@ describe('injectPreviewCsp', () => {
 
   it('keeps the DOCTYPE first when leading whitespace/comments precede it', () => {
     // Per HTML5's initial insertion mode, whitespace and comments before
-    // the DOCTYPE are ignored, so this DOCTYPE still opts out of Quirks
-    // Mode — but only if we don't insert anything before it.
+    // the DOCTYPE are ignored, so this DOCTYPE still takes effect — but
+    // only if we don't insert anything before it.
     const html = '  <!-- banner -->\n<!DOCTYPE html><html><body>x</body></html>';
     const out = injectPreviewCsp(html);
     const doctypeEnd = out.indexOf('<!DOCTYPE html>') + '<!DOCTYPE html>'.length;
@@ -42,7 +42,10 @@ describe('injectPreviewCsp', () => {
     expect(out.startsWith(PREVIEW_CSP_META)).toBe(true);
   });
 
-  it('never inserts before the DOCTYPE (anything preceding it triggers Quirks Mode)', () => {
+  // Not Quirks Mode insurance: the HTML spec forces no-quirks for iframe
+  // srcdoc documents regardless of what precedes the DOCTYPE. DOCTYPE-first
+  // keeps the payload valid if it's ever served as a standalone document.
+  it('never inserts before the DOCTYPE', () => {
     const out = injectPreviewCsp('<!DOCTYPE html><html><body>x</body></html>');
     expect(out.indexOf('<!DOCTYPE html')).toBeGreaterThanOrEqual(0);
     expect(out.indexOf('<!DOCTYPE html')).toBeLessThan(out.indexOf(PREVIEW_CSP_META));

--- a/ts-packages/preview-renderer/src/utils/previewCsp.test.ts
+++ b/ts-packages/preview-renderer/src/utils/previewCsp.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Unit tests for `injectPreviewCsp` (quarto-dev/q2#128, bd-sxx1az83).
+ *
+ * The injection-point contract is the highest-risk part of the Safari
+ * preview-link fix: post-fix the injected CSP meta is the *only* script
+ * mitigation in the preview iframe (the sandbox gains `allow-scripts`),
+ * so an injection miss is a same-origin script-execution escape. These
+ * tests pin the contract at string level; parse-level checks ("the meta
+ * lands as the first element in document order") live in
+ * `MorphIframe.integration.test.tsx` (jsdom) and the behavioral
+ * no-scripts guarantee in `hub-client/e2e/preview-script-blocking.spec.ts`
+ * (real browsers — jsdom enforces neither sandbox nor CSP).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { injectPreviewCsp, PREVIEW_CSP_META } from './previewCsp';
+
+describe('injectPreviewCsp', () => {
+  it('injects immediately after the DOCTYPE when present', () => {
+    const html = '<!DOCTYPE html>\n<html><head></head><body>hi</body></html>';
+    const out = injectPreviewCsp(html);
+    expect(out.startsWith('<!DOCTYPE html>' + PREVIEW_CSP_META)).toBe(true);
+  });
+
+  it('matches the DOCTYPE case-insensitively', () => {
+    const out = injectPreviewCsp('<!doctype html><html><body>x</body></html>');
+    expect(out.startsWith('<!doctype html>' + PREVIEW_CSP_META)).toBe(true);
+  });
+
+  it('keeps the DOCTYPE first when leading whitespace/comments precede it', () => {
+    // Per HTML5's initial insertion mode, whitespace and comments before
+    // the DOCTYPE are ignored, so this DOCTYPE still opts out of Quirks
+    // Mode — but only if we don't insert anything before it.
+    const html = '  <!-- banner -->\n<!DOCTYPE html><html><body>x</body></html>';
+    const out = injectPreviewCsp(html);
+    const doctypeEnd = out.indexOf('<!DOCTYPE html>') + '<!DOCTYPE html>'.length;
+    expect(out.indexOf(PREVIEW_CSP_META)).toBe(doctypeEnd);
+  });
+
+  it('inserts at byte 0 when there is no DOCTYPE', () => {
+    const out = injectPreviewCsp('<html><body>x</body></html>');
+    expect(out.startsWith(PREVIEW_CSP_META)).toBe(true);
+  });
+
+  it('never inserts before the DOCTYPE (anything preceding it triggers Quirks Mode)', () => {
+    const out = injectPreviewCsp('<!DOCTYPE html><html><body>x</body></html>');
+    expect(out.indexOf('<!DOCTYPE html')).toBeGreaterThanOrEqual(0);
+    expect(out.indexOf('<!DOCTYPE html')).toBeLessThan(out.indexOf(PREVIEW_CSP_META));
+  });
+
+  it('is idempotent', () => {
+    const once = injectPreviewCsp('<!DOCTYPE html><html><body>x</body></html>');
+    expect(injectPreviewCsp(once)).toBe(once);
+    // Also for the no-DOCTYPE (byte 0) path.
+    const onceNoDoctype = injectPreviewCsp('<p>fragment</p>');
+    expect(injectPreviewCsp(onceNoDoctype)).toBe(onceNoDoctype);
+  });
+
+  it('leaves an existing user meta CSP intact (it can only restrict further)', () => {
+    const userMeta =
+      '<meta http-equiv="Content-Security-Policy" content="default-src \'self\'">';
+    const html = `<!DOCTYPE html><html><head>${userMeta}</head><body>x</body></html>`;
+    const out = injectPreviewCsp(html);
+    expect(out).toContain(userMeta);
+    // Ours comes first in document order.
+    expect(out.indexOf(PREVIEW_CSP_META)).toBeLessThan(out.indexOf(userMeta));
+  });
+
+  it('does not treat the meta string inside user content as already-injected', () => {
+    // A code sample in the document body quoting our meta must not
+    // suppress injection at the top — that would make the idempotency
+    // check a spoofable fail-open hole.
+    const html = `<!DOCTYPE html><html><body><code>${PREVIEW_CSP_META}</code></body></html>`;
+    const out = injectPreviewCsp(html);
+    expect(out.startsWith('<!DOCTYPE html>' + PREVIEW_CSP_META)).toBe(true);
+  });
+
+  it('puts the meta before any <script> in the payload', () => {
+    const html =
+      '<!DOCTYPE html><html><head><script src="libs/x.js"></script></head><body>x</body></html>';
+    const out = injectPreviewCsp(html);
+    expect(out.indexOf(PREVIEW_CSP_META)).toBeLessThan(out.indexOf('<script'));
+  });
+
+  // A "first child of <head>" string search is spoofable by markup that
+  // merely *looks* like a head in a naive scan. The contract instead:
+  // after the DOCTYPE if present, else byte 0 — so in every case the meta
+  // is the first element the parser sees.
+  describe('adversarial head-like markup (meta must be first in document order)', () => {
+    const cases: Array<[string, string]> = [
+      [
+        'head-like markup inside a comment',
+        '<!-- <head><script>alert(1)</script></head> --><html><body>x</body></html>',
+      ],
+      [
+        'head-like markup inside <title>',
+        '<html><head><title><head><script></title></head><body>x</body></html>',
+      ],
+      [
+        'head-like markup inside <script>',
+        '<html><head><script>var s = "<head>";</script></head><body>x</body></html>',
+      ],
+      [
+        'head-like markup inside <textarea>',
+        '<html><body><textarea><head></head></textarea></body></html>',
+      ],
+      ['uppercase <HEAD>', '<HTML><HEAD></HEAD><BODY>x</BODY></HTML>'],
+      [
+        'no-<head> fragment starting with <script>',
+        '<script>alert(1)</script><p>x</p>',
+      ],
+    ];
+    for (const [name, html] of cases) {
+      it(name, () => {
+        const out = injectPreviewCsp(html);
+        // None of these payloads have a DOCTYPE, so the meta must be at
+        // byte 0 — ahead of every tag, including the decoys.
+        expect(out.startsWith(PREVIEW_CSP_META)).toBe(true);
+      });
+    }
+  });
+});

--- a/ts-packages/preview-renderer/src/utils/previewCsp.ts
+++ b/ts-packages/preview-renderer/src/utils/previewCsp.ts
@@ -19,12 +19,18 @@
  */
 
 /**
- * The injected meta tag. `script-src 'none'` blocks every script-
+ * The injected policy. `script-src 'none'` blocks every script-
  * execution surface in the document. User content can only add *stricter*
  * CSPs (multiple CSPs intersect), never loosen this one.
+ *
+ * Exported separately from the meta tag so consumers that match the
+ * parsed meta (the dev-mode tripwire in iframePostProcessor.ts) derive
+ * from the same source instead of hardcoding a drift-prone second copy.
  */
-export const PREVIEW_CSP_META =
-  '<meta http-equiv="Content-Security-Policy" content="script-src \'none\'">';
+export const PREVIEW_CSP_CONTENT = "script-src 'none'";
+
+/** The injected meta tag, built from `PREVIEW_CSP_CONTENT`. */
+export const PREVIEW_CSP_META = `<meta http-equiv="Content-Security-Policy" content="${PREVIEW_CSP_CONTENT}">`;
 
 /**
  * Matches a leading DOCTYPE, including any whitespace/comments the HTML
@@ -42,10 +48,14 @@ const LEADING_DOCTYPE =
 
 /**
  * Return `html` with the preview CSP meta injected as the first element
- * in document order: immediately after the DOCTYPE if one is present
- * (anything preceding the DOCTYPE triggers Quirks Mode — see the srcdoc
- * comment block in MorphIframe.tsx), otherwise at byte 0 (the parser
- * places a leading `<meta>` in the implied `<head>`).
+ * in document order: immediately after the DOCTYPE if one is present,
+ * otherwise at byte 0 (the parser places a leading `<meta>` in the
+ * implied `<head>`). The operative invariant is meta-first — nothing may
+ * precede it, so it always beats any `<script>` in the payload. Keeping
+ * the DOCTYPE first is payload preservation, not Quirks Mode insurance:
+ * the HTML spec forces no-quirks for iframe srcdoc documents no matter
+ * what precedes the DOCTYPE; a leading `<meta>` would only break the
+ * DOCTYPE if the same payload were served as a standalone document.
  *
  * This is deliberately NOT a "first child of <head>" string search:
  * head-like markup inside comments/titles/scripts/textareas, or uppercase

--- a/ts-packages/preview-renderer/src/utils/previewCsp.ts
+++ b/ts-packages/preview-renderer/src/utils/previewCsp.ts
@@ -1,0 +1,65 @@
+/**
+ * CSP injection for the sandboxed HTML preview iframes
+ * (quarto-dev/q2#128, bd-sxx1az83).
+ *
+ * The preview iframe sandbox carries `allow-scripts` so that WebKit runs
+ * parent-attached event listeners on the frame — WebKit bug 218086
+ * (https://bugs.webkit.org/show_bug.cgi?id=218086) blocks them on
+ * sandboxed frames without it, which broke link interception, scroll
+ * sync, click-to-position, and selection sync in Safari. To preserve the
+ * sandbox's no-scripts guarantee, every preview HTML payload gets the CSP
+ * meta below injected: it blocks all script execution *inside* the
+ * document (script elements, inline `on*` handlers, `javascript:` URLs)
+ * while leaving `addEventListener`-registered listeners working.
+ *
+ * SECURITY: post-fix this meta is the *only* script mitigation in the
+ * preview iframe — an injection miss is a same-origin script-execution
+ * escape (`allow-scripts` + `allow-same-origin`). Every srcdoc/innerHTML
+ * preview path must route its payload through `injectPreviewCsp`.
+ */
+
+/**
+ * The injected meta tag. `script-src 'none'` blocks every script-
+ * execution surface in the document. User content can only add *stricter*
+ * CSPs (multiple CSPs intersect), never loosen this one.
+ */
+export const PREVIEW_CSP_META =
+  '<meta http-equiv="Content-Security-Policy" content="script-src \'none\'">';
+
+/**
+ * Matches a leading DOCTYPE, including any whitespace/comments the HTML
+ * parser's initial insertion mode would skip before it. Case-insensitive,
+ * and anchored at the very start of the payload so a `<!doctype` string
+ * inside user content can't move the injection point.
+ *
+ * The comment alternatives include the abrupt closings (`<!-->`,
+ * `<!--->`) the HTML5 spec accepts. Anything this pattern doesn't
+ * recognize simply falls back to byte-0 insertion, which is always safe
+ * for payloads without a DOCTYPE.
+ */
+const LEADING_DOCTYPE =
+  /^([\s\uFEFF]|<!--[\s\S]*?-->|<!--->|<!-->)*<!doctype[^>]*>/i;
+
+/**
+ * Return `html` with the preview CSP meta injected as the first element
+ * in document order: immediately after the DOCTYPE if one is present
+ * (anything preceding the DOCTYPE triggers Quirks Mode — see the srcdoc
+ * comment block in MorphIframe.tsx), otherwise at byte 0 (the parser
+ * places a leading `<meta>` in the implied `<head>`).
+ *
+ * This is deliberately NOT a "first child of <head>" string search:
+ * head-like markup inside comments/titles/scripts/textareas, or uppercase
+ * tags, would spoof the insertion point and let a `<script>` precede the
+ * meta — which the CSP would then fail to block.
+ *
+ * Idempotent: a payload already carrying the meta *at the injection
+ * point* is returned unchanged. A match anywhere else (e.g. quoted inside
+ * user content) does NOT count — that would make the check a spoofable
+ * fail-open hole.
+ */
+export function injectPreviewCsp(html: string): string {
+  const match = LEADING_DOCTYPE.exec(html);
+  const insertAt = match ? match[0].length : 0;
+  if (html.startsWith(PREVIEW_CSP_META, insertAt)) return html;
+  return html.slice(0, insertAt) + PREVIEW_CSP_META + html.slice(insertAt);
+}


### PR DESCRIPTION
## Fix preview links in Safari

Fixes #128.

### Problem

In Safari, a click on a link in the HTML preview opened a blank page in the preview frame.

### Root cause

The preview frame is sandboxed and did not include `allow-scripts`. WebKit blocks event listeners that the parent page attaches to a sandboxed frame ([WebKit bug 218086](https://bugs.webkit.org/show_bug.cgi?id=218086)). As a result, the click handler that intercepts links did not run in Safari. The preview frame followed the link itself. The hub server then refused to show the target page in a frame.

### The fix

- The sandbox now includes `allow-scripts`. The parent-attached listeners now run in WebKit.
- Each preview HTML payload gets an injected CSP meta tag: `script-src 'none'`. The tag blocks all scripts in the preview document: script elements, inline handlers, and `javascript:` URLs.
- The tag goes immediately after the `<!DOCTYPE>`. If the payload has no `<!DOCTYPE>`, the tag goes at the start of the payload.

### Security

`allow-scripts` plus `allow-same-origin` is a known sandbox-escape pair. The injected CSP tag is now the only blocker of scripts in the preview. If a preview document does not have the tag, a dev-mode warning fires. User content can add stricter CSP rules. User content cannot weaken this rule.

### Tests

- New unit and integration tests cover the injection and the sandbox attribute. They failed before the fix and pass after the fix.
- A new Playwright spec clicks a cross-document link in the preview. The spec reproduces the defect on real WebKit before the fix and passes after the fix.
- A second new Playwright spec proves that no script in preview content runs, on Chromium and on WebKit.
- Verified manually in real Safari: a click on a cross-document link in the preview now switches the editor to that file.
- CI now installs WebKit for these specs.
- Full `cargo xtask verify` passes.

### Not in this PR

- Follow-up strands: bd-ddfyqmfm (links to non-renderable files), bd-23es17uh (`frame-ancestors` header), bd-rpc3skz0 (Q2PreviewIframe inline handlers).
