### PR TITLE
qmd-syntax-helper: unparseable files are unanalyzable, never clean

### DIFF
--- a/claude-notes/plans/2026-08-17-syntax-helper-parse-masking.md
+++ b/claude-notes/plans/2026-08-17-syntax-helper-parse-masking.md
@@ -3,7 +3,7 @@
 **Date:** 2026-08-17
 **Braid:** bd-syntax-helper-parse-masking-w88mhedp
 **Checkout:** main checkout, branch `main` (investigation only — no implementation branch yet)
-**Status:** Investigation — pending design alignment with user. **Do not start implementation until the user gives the go-ahead.**
+**Status:** Design aligned 2026-08-17 (see "Design decisions" below) — **pending user go-ahead to implement.**
 
 ## Triage verdict
 
@@ -104,58 +104,102 @@ apostrophe escaped). Observed with
 
 (Repro transcript in `repro-transcript.txt` in the same directory.)
 
-## Proposed phases (draft)
+## Design decisions (aligned with user, 2026-08-17)
 
-Skeleton only — actual phase contents wait on the design discussion.
+1. **One synthesized per-file result** when requires-parse rules are skipped,
+   not one per rule. (User: needed given #2; otherwise indifferent.)
+2. **Third summary state, declared per rule.** "Unanalyzable" is tracked as a
+   distinct state, but refusal is **opt-in per rule**: many rules *expect*
+   unparseable input (grid-tables; every diagnostic-driven `q_2_*` rule reads
+   the parse error stream as its input) and must keep running on unparseable
+   files. Only rules that need a successful AST declare that they require one.
+3. **Hard per-file refusal for requires-parse rules in convert**, never
+   aborting the multi-file sweep; refusal is judged **at convergence** (an
+   earlier rule in the same run may repair the parse, after which the AST rule
+   runs normally — the compounding is preserved by re-probing each iteration).
+4. **`q-2-30` folded in** — it becomes a requires-parse rule like the two
+   bracket rules.
+5. **No wire-shape compatibility requirement.** Verified: no JSON schema for
+   `check --json` exists anywhere in the repo (the output is undocumented
+   serde-serialized `CheckResult` lines), so there is nothing to keep fresh
+   and we don't create one here. New optional fields are fine.
 
-- **Phase 0 — Test plan (TDD).** Integration tests in
-  `tests/integration/bracket_analysis_test.rs` (+ a new
-  parse-masking test module): unparseable file under `check -r
-  literal-brackets` / `-r reference-links` / `-r q-2-30` must NOT be reported
-  clean; summary counts must not include it in the success rate; convert must
-  not silently no-op; `convert -r all`-style iteration where an earlier rule
-  repairs the parse must still apply the AST rule afterward.
-- **Phase 1 — Make `analyze()` honest.** Return the parse failure (e.g.
-  `Result<Analysis, AnalyzeError>` or `Ok(AnalysisOutcome::Unparseable(codes))`)
-  instead of defaulting to empty; carry the Q-codes for the message.
-- **Phase 2 — Check-side surfacing.** Per design answer: synthesized
-  `CheckResult` ("file failed to parse; rule not applied") and/or a third
-  summary bucket ("Unanalyzable files: N") excluded from clean count and
-  success rate. Dedup when several AST rules run on the same file.
-- **Phase 3 — Convert-side behavior.** Skip-with-warning per iteration, final
-  post-convergence check: if the file still fails to parse and an AST rule was
-  requested, report it (non-✓) without aborting the multi-file sweep.
-- **Phase 4 — `q-2-30` alignment.** Apply the same treatment to its
-  independent `Err(_) => clean` site.
-- **Phase 5 — Docs.** Helper's user-facing docs / `--help` note: AST-based
-  rules require a parsing file; run `parse` / fix parse errors first.
+### Mechanism (assessed: moderate, fits existing architecture)
 
-## Open design questions for the user
+The `Rule` trait already has the "rule declares a property, driver interprets
+it" precedent in `opt_in_only()`. The change follows the same shape:
 
-1. **Check-output shape.** When an AST rule can't run, should each requested
-   AST rule emit its own `CheckResult` ("literal-brackets: file failed to
-   parse; rule not applied"), or should the file get **one** synthesized
-   parse-failure result regardless of how many AST rules were requested?
-   (One-per-rule is simpler to wire through `Rule::check`; one-per-file reads
-   better and doesn't inflate "Total issues".)
-2. **Summary bucket.** Is "file failed to parse" just another *issue* (file
-   counted in "Files with issues", success rate drops — minimal change), or a
-   genuine third state ("Unanalyzable: N" line, excluded from both clean and
-   issue counts)? The strand's option (b) implies the third state; it touches
-   `CheckResult`'s serialized JSON shape, which external consumers (the
-   connect-docs sweep scripts) may parse.
-3. **Convert semantics.** For `convert -r literal-brackets` on an unparseable
-   file: hard per-file refusal with a non-zero note in output (but *not*
-   aborting the rest of the sweep), or current silent no-op plus a
-   warning? And do you agree the check should be "still unparseable at
-   convergence" rather than "unparseable at iteration 1" (to preserve the
-   fix-then-apply compounding with e.g. `apostrophe-quotes`)?
-4. **Scope: `q-2-30`.** The strand names only `analyze()`-based rules; q-2-30
-   has the identical masking independently. Fold it into this fix (my
-   recommendation) or file it separately?
-5. **JSON stability.** `check --json` emits `CheckResult` lines consumed by
-   scripts. May we add a new optional field (e.g. `"unanalyzable": true`) /
-   new rule_name value, or must the wire shape stay byte-compatible?
+- **`Rule::requires_parse(&self) -> bool { false }`** — overridden to `true`
+  by `reference-links`, `literal-brackets`, `q-2-30`.
+- **Shared parse probe.** Hoist `ParseChecker::check_parse` into a shared
+  helper (it already returns the diagnostics). The check driver probes once
+  per file *only when* at least one requested rule requires parse; the convert
+  driver probes once per iteration under the same condition.
+- **Check driver** (`main.rs`): on probe failure, skip requires-parse rules,
+  run everything else normally, and synthesize one per-file `CheckResult`:
+  `has_issue: false`, new fields `unanalyzable: true` +
+  `skipped_rules: [names]`, `error_codes` from the probe, message
+  "file failed to parse (Q-2-10); N rule(s) not applied: …".
+- **Summary** (`print_check_summary`): new "Unanalyzable" bucket.
+  Clean = no findings AND nothing skipped; success rate = clean/total. A file
+  with both findings and skipped rules counts as with-issues *and* is listed
+  in the unanalyzable line (the two lines answer different questions:
+  "what needs fixing" vs "what did the sweep actually cover").
+- **Convert driver**: skip requires-parse rules while the probe fails in the
+  current iteration; after convergence, if any requested requires-parse rule
+  was never applied because the file still doesn't parse, print a per-file
+  `✗ … not applied: file does not parse (Q-2-10)` and continue the sweep.
+- **`analyze()` hardening**: change `Err(_) => Ok(Analysis::default())` to
+  propagate the parse diagnostics as an `Err` carrying the Q-codes, so no
+  future caller can silently reintroduce the masking. In driver flow the
+  probe runs first, so the rules only hit this path on direct library use.
+- **Secondary fix (discovered):** the check loop's `Err` arm
+  (`main.rs:116-125`) prints to stderr but still counts the file **clean** in
+  the summary — same masking family. Fold in: rule-error files get their own
+  small "Errors: N" accounting, excluded from clean.
+
+## Phases
+
+- **Phase 0 — Test plan (TDD, failing first).** In
+  `crates/qmd-syntax-helper/tests/integration/` (new `parse_masking_test.rs`,
+  registered in `main.rs`, alphabetized):
+  1. `check -r literal-brackets` on unparseable fixture → not clean; one
+     synthesized unanalyzable result with `skipped_rules` containing both the
+     rule name and the probe's Q-codes; summary shows Unanalyzable: 1,
+     success rate 0%.
+  2. Same for `-r reference-links` and `-r q-2-30`.
+  3. `check -r grid-tables` (non-requires-parse) on the same fixture → rule
+     still runs; no unanalyzable synthesis when no requires-parse rule was
+     requested.
+  4. `check -r all` → parse rule reports the failure AND requires-parse rules
+     are skipped (one synthesized result), diagnostic-driven rules still run.
+  5. `--json` output includes `unanalyzable`/`skipped_rules` fields.
+  6. Convert: `convert -r literal-brackets` on unparseable file → no edit,
+     per-file refusal note, sweep continues to next file (multi-file test).
+  7. Convert compounding: `convert -r apostrophe-quotes -r literal-brackets`
+     on a fixture whose only parse error is the apostrophe → iteration 1
+     fixes the parse, a later iteration applies literal-brackets; no refusal
+     note.
+  8. `analyze()` unit test: unparseable source → `Err` with Q-codes.
+- **Phase 1 — `analyze()` + trait.** `requires_parse()` on `Rule`; `analyze()`
+  returns `Err` with diagnostics; shared parse-probe helper; q-2-30 and the
+  two bracket rules override `requires_parse()`.
+- **Phase 2 — Check driver + summary.** Probe, skip, synthesize, new
+  `CheckResult` fields, summary buckets incl. the rule-error accounting fix.
+- **Phase 3 — Convert driver.** Per-iteration probe/skip + at-convergence
+  refusal report; multi-file sweep never aborts on refusal.
+- **Phase 4 — Docs.** `README.md` + `list-rules` note: requires-parse rules
+  and the "fix parse errors first (e.g. `convert -r apostrophe-quotes`)"
+  workflow, mirroring the connect-docs lesson.
+
+## Work items
+
+- [ ] Phase 0: failing integration tests (`parse_masking_test.rs`) + `analyze()` unit test
+- [ ] Phase 1: `Rule::requires_parse()`, `analyze()` → `Err`, shared parse probe, rule overrides
+- [ ] Phase 2: check driver skip/synthesize, `CheckResult` fields, summary buckets + rule-error accounting
+- [ ] Phase 3: convert per-iteration probe + at-convergence refusal
+- [ ] Phase 4: docs (README, list-rules note)
+- [ ] Full workspace tests + `cargo xtask verify --skip-hub-build`; end-to-end repro transcript re-run showing the fix
 
 ## Risks / tradeoffs (draft)
 

--- a/claude-notes/plans/2026-08-17-syntax-helper-parse-masking.md
+++ b/claude-notes/plans/2026-08-17-syntax-helper-parse-masking.md
@@ -1,0 +1,171 @@
+# qmd-syntax-helper: AST-based rules report unparseable files as clean (bd-syntax-helper-parse-masking-w88mhedp)
+
+**Date:** 2026-08-17
+**Braid:** bd-syntax-helper-parse-masking-w88mhedp
+**Checkout:** main checkout, branch `main` (investigation only — no implementation branch yet)
+**Status:** Investigation — pending design alignment with user. **Do not start implementation until the user gives the go-ahead.**
+
+## Triage verdict
+
+**Ready to design.** The bug is confirmed at HEAD with an in-tree repro, the
+root cause is exactly where the strand says it is, and the affected-rule set is
+now fully enumerated (it is slightly larger than the strand states: `q-2-30` is
+masked the same way). The remaining work is a design decision about *how* the
+"unanalyzable" state should surface in check output, summary counts, and
+convert — questions below.
+
+## Issue context
+
+Filed today (2026-08-17) by Carlos, p2 bug, labels `diagnostics`,
+`syntax-helper`. The AST-based rules (`reference-links`, `literal-brackets`,
+anything on `bracket_analysis::analyze`) report a file that fails to qmd-parse
+as **clean**: `check -r literal-brackets -r reference-links <file>` prints ✓,
+counts it as a clean file, and folds it into "Success rate: 100.0%". The
+operator of a scoped sweep gets an actively misleading all-clear — the rules
+never saw an AST at all.
+
+Real-world hit: during the Connect-docs port, a pre-migration
+`admin/security/index.md` failed to parse (3× Q-2-10 stray apostrophes), so a
+bracket sweep reported it clean while it contained four literal `[1]`–`[4]`
+brackets — exactly the content `literal-brackets` exists to save. Origin
+strand: `br-syntax-helper-parse-masking-fmwvbmq8` in the q2-connect-docs skein.
+
+## Dependency graph
+
+**Empty** — no edges in either direction in the q2 skein. The
+`discovered-from` context lives in a *different* skein (q2-connect-docs,
+`br-syntax-helper-parse-masking-fmwvbmq8`), summarized in the description.
+No incoming pressure; the strand is self-contained and freshly filed, so no
+staleness concerns.
+
+## What the code looks like today
+
+All paths from the description exist unchanged at HEAD (`0876e413`).
+
+**Root cause, confirmed** — `crates/qmd-syntax-helper/src/conversions/bracket_analysis.rs:165`:
+
+```rust
+let (doc, _ctx, _diags) = match parsed {
+    Ok(triple) => triple,
+    Err(_) => return Ok(Analysis::default()),   // parse failure ⇒ "clean"
+};
+```
+
+The doc comment on `analyze()` (lines 153–157) shows this was a *deliberate*
+choice for **convert** safety ("the rules leave it alone rather than editing a
+document whose structure we cannot trust. Parse errors are the `parse` rule's
+business, not ours") — but the same empty `Analysis` also flows into **check**,
+where "leave it alone" becomes "report clean".
+
+**Full masked-rule inventory** (rules that need a successful AST and swallow
+`Err`):
+
+| Rule | Call site | Err handling |
+|---|---|---|
+| `reference-links` | `reference_links.rs:142` (check), `:209` (convert) | via `analyze()` → default = clean |
+| `literal-brackets` | `literal_brackets.rs:82` (check), `:133` (convert) | via `analyze()` → default = clean |
+| `q-2-30` | `diagnostics/q_2_30.rs:70` | `Err(_) => return Ok(Vec::new())` — same masking, independent of `analyze()` |
+
+**Not affected:** the ~20 `q_2_*` conversion rules, `apostrophe-quotes`,
+`attribute-ordering`, `div-whitespace` are *diagnostic-driven* — a parse `Err`
+is their **input** (they scan the returned diagnostics for their code), so
+`Ok(_) => clean` is correct for them. `parse` and `syntax` obviously report
+failures. `grid-tables`/`definition-lists` are text-based.
+
+**Reporting machinery** (`main.rs`): `CheckResult` (rule.rs:18) has only
+`has_issue: bool`; `print_check_summary` (main.rs:425) derives
+`files_clean = total_files − files_with_issues` and the success rate. There is
+**no third state** — any fix that wants "unanalyzable ≠ clean ≠ has-findings"
+in the summary needs either a new `CheckResult` flavor or a synthesized
+parse-failure result.
+
+**Convert-side wrinkles** (both matter for the design):
+
+1. `main.rs:252-260` — a rule `convert()` returning `Err` **aborts the whole
+   run** (`return Err(e)`), skipping all remaining files. So "make analyze
+   return the error" naïvely turns one bad file into a dead sweep.
+2. The convert iteration loop (main.rs:217-310) applies all requested rules
+   repeatedly until convergence. Under `convert -r apostrophe-quotes -r
+   literal-brackets`, iteration 1's apostrophe fix can *make the file
+   parseable*, letting iteration 2's AST rule see it. A hard refusal on first
+   parse failure would break this useful compounding; the failure only matters
+   if the file **still** doesn't parse when the rule last ran.
+
+### Repro (in-tree, confirmed at HEAD)
+
+`claude-notes/plans/syntax-helper-parse-masking-investigation/` holds
+`input.qmd` (Q-2-10 stray apostrophe + one literal `[1]` + one `[the
+docs][gcc]` reference + definition) and `input-parseable.qmd` (identical,
+apostrophe escaped). Observed with
+`cargo run -p qmd-syntax-helper -- check -r literal-brackets -r reference-links <file>`:
+
+- `input.qmd` → **0 issues, "Success rate: 100.0%"** (the bug)
+- `input-parseable.qmd` → 2 findings (literal bracket + reference link)
+
+(Repro transcript in `repro-transcript.txt` in the same directory.)
+
+## Proposed phases (draft)
+
+Skeleton only — actual phase contents wait on the design discussion.
+
+- **Phase 0 — Test plan (TDD).** Integration tests in
+  `tests/integration/bracket_analysis_test.rs` (+ a new
+  parse-masking test module): unparseable file under `check -r
+  literal-brackets` / `-r reference-links` / `-r q-2-30` must NOT be reported
+  clean; summary counts must not include it in the success rate; convert must
+  not silently no-op; `convert -r all`-style iteration where an earlier rule
+  repairs the parse must still apply the AST rule afterward.
+- **Phase 1 — Make `analyze()` honest.** Return the parse failure (e.g.
+  `Result<Analysis, AnalyzeError>` or `Ok(AnalysisOutcome::Unparseable(codes))`)
+  instead of defaulting to empty; carry the Q-codes for the message.
+- **Phase 2 — Check-side surfacing.** Per design answer: synthesized
+  `CheckResult` ("file failed to parse; rule not applied") and/or a third
+  summary bucket ("Unanalyzable files: N") excluded from clean count and
+  success rate. Dedup when several AST rules run on the same file.
+- **Phase 3 — Convert-side behavior.** Skip-with-warning per iteration, final
+  post-convergence check: if the file still fails to parse and an AST rule was
+  requested, report it (non-✓) without aborting the multi-file sweep.
+- **Phase 4 — `q-2-30` alignment.** Apply the same treatment to its
+  independent `Err(_) => clean` site.
+- **Phase 5 — Docs.** Helper's user-facing docs / `--help` note: AST-based
+  rules require a parsing file; run `parse` / fix parse errors first.
+
+## Open design questions for the user
+
+1. **Check-output shape.** When an AST rule can't run, should each requested
+   AST rule emit its own `CheckResult` ("literal-brackets: file failed to
+   parse; rule not applied"), or should the file get **one** synthesized
+   parse-failure result regardless of how many AST rules were requested?
+   (One-per-rule is simpler to wire through `Rule::check`; one-per-file reads
+   better and doesn't inflate "Total issues".)
+2. **Summary bucket.** Is "file failed to parse" just another *issue* (file
+   counted in "Files with issues", success rate drops — minimal change), or a
+   genuine third state ("Unanalyzable: N" line, excluded from both clean and
+   issue counts)? The strand's option (b) implies the third state; it touches
+   `CheckResult`'s serialized JSON shape, which external consumers (the
+   connect-docs sweep scripts) may parse.
+3. **Convert semantics.** For `convert -r literal-brackets` on an unparseable
+   file: hard per-file refusal with a non-zero note in output (but *not*
+   aborting the rest of the sweep), or current silent no-op plus a
+   warning? And do you agree the check should be "still unparseable at
+   convergence" rather than "unparseable at iteration 1" (to preserve the
+   fix-then-apply compounding with e.g. `apostrophe-quotes`)?
+4. **Scope: `q-2-30`.** The strand names only `analyze()`-based rules; q-2-30
+   has the identical masking independently. Fold it into this fix (my
+   recommendation) or file it separately?
+5. **JSON stability.** `check --json` emits `CheckResult` lines consumed by
+   scripts. May we add a new optional field (e.g. `"unanalyzable": true`) /
+   new rule_name value, or must the wire shape stay byte-compatible?
+
+## Risks / tradeoffs (draft)
+
+- **Convert abort semantics** (main.rs:252) are a pre-existing sharp edge: any
+  `Err` from convert kills the whole multi-file run. Phase 3 must avoid
+  routing the new failure through that path, or deliberately change it —
+  flagging because it's a behavior change beyond the strand's ask.
+- **Success-rate consumers**: the connect-docs workflow reads the summary; any
+  change to counting semantics should be announced in that repo's skein
+  (origin strand `br-syntax-helper-parse-masking-fmwvbmq8`).
+- The `analyze()` doc comment's convert-safety rationale is still valid — the
+  fix must keep "never edit a file we can't parse" while removing "call it
+  clean".

--- a/claude-notes/plans/2026-08-17-syntax-helper-parse-masking.md
+++ b/claude-notes/plans/2026-08-17-syntax-helper-parse-masking.md
@@ -194,12 +194,35 @@ it" precedent in `opt_in_only()`. The change follows the same shape:
 
 ## Work items
 
-- [ ] Phase 0: failing integration tests (`parse_masking_test.rs`) + `analyze()` unit test
-- [ ] Phase 1: `Rule::requires_parse()`, `analyze()` → `Err`, shared parse probe, rule overrides
-- [ ] Phase 2: check driver skip/synthesize, `CheckResult` fields, summary buckets + rule-error accounting
-- [ ] Phase 3: convert per-iteration probe + at-convergence refusal
-- [ ] Phase 4: docs (README, list-rules note)
-- [ ] Full workspace tests + `cargo xtask verify --skip-hub-build`; end-to-end repro transcript re-run showing the fix
+- [x] Phase 0: failing integration tests (`parse_masking_test.rs`) + `analyze()` unit test
+      — 12 tests written first; verified red 8/12 pre-fix (4 green guards:
+      control fixtures, no-probe case, compounding).
+- [x] Phase 1: `Rule::requires_parse()`, `analyze()` → `Err`, shared parse probe
+      (`utils/parse_probe.rs`), rule overrides (literal-brackets,
+      reference-links, q-2-30; `parse` refactored onto the probe).
+- [x] Phase 2: check driver skip/synthesize, `CheckResult.unanalyzable`/
+      `skipped_rules` fields, summary buckets ("Unanalyzable files",
+      "Files with errors") + rule-error accounting.
+- [x] Phase 3: convert per-iteration probe + at-convergence refusal (stderr,
+      per file, sweep continues).
+- [x] Phase 4: docs (README "Rules that require a parsing file" section,
+      `list-rules` † marker).
+- [x] End-to-end verification through the binary: post-fix transcript at
+      `syntax-helper-parse-masking-investigation/post-fix-transcript.txt`
+      (unparseable → "Unanalyzable files: 1", success rate 0.0%, JSON record;
+      control → both findings). Crate suite 176/176.
+- [ ] Full workspace tests + `cargo xtask verify --skip-hub-build` before PR.
+
+## Implementation notes
+
+- The parse rule's JSON `error_codes` are now **deduplicated** (previously one
+  entry per diagnostic, so 3× Q-2-10 appeared three times). Wire-shape change
+  allowed per design decision 5.
+- `q-2-30::convert` now propagates the parse failure instead of returning a
+  0-fix "File does not parse" ConvertResult; in driver flow it is skipped
+  before convert is called.
+- A file whose *probe read* fails (unreadable) is accounted in
+  "Files with errors" and its rules are not run.
 
 ## Risks / tradeoffs (draft)
 

--- a/claude-notes/plans/2026-08-17-syntax-helper-parse-masking.md
+++ b/claude-notes/plans/2026-08-17-syntax-helper-parse-masking.md
@@ -211,7 +211,8 @@ it" precedent in `opt_in_only()`. The change follows the same shape:
       `syntax-helper-parse-masking-investigation/post-fix-transcript.txt`
       (unparseable → "Unanalyzable files: 1", success rate 0.0%, JSON record;
       control → both findings). Crate suite 176/176.
-- [ ] Full workspace tests + `cargo xtask verify --skip-hub-build` before PR.
+- [x] Full workspace tests (12259/12259) + `cargo xtask verify
+      --skip-hub-build` green ("All verification steps passed", 2026-08-17).
 
 ## Implementation notes
 

--- a/claude-notes/plans/syntax-helper-parse-masking-investigation/input-parseable.qmd
+++ b/claude-notes/plans/syntax-helper-parse-masking-investigation/input-parseable.qmd
@@ -1,0 +1,11 @@
+---
+title: "Parse-masking repro (parseable control)"
+---
+
+The admins\' console shows no parse error.
+
+Diagram key: [1] is the gateway node.
+
+See [the docs][gcc] for details.
+
+[gcc]: https://example.com/gcc

--- a/claude-notes/plans/syntax-helper-parse-masking-investigation/input.qmd
+++ b/claude-notes/plans/syntax-helper-parse-masking-investigation/input.qmd
@@ -1,0 +1,11 @@
+---
+title: "Parse-masking repro"
+---
+
+The admins ' console shows a stray-apostrophe parse error (Q-2-10).
+
+Diagram key: [1] is the gateway node.
+
+See [the docs][gcc] for details.
+
+[gcc]: https://example.com/gcc

--- a/claude-notes/plans/syntax-helper-parse-masking-investigation/post-fix-transcript.txt
+++ b/claude-notes/plans/syntax-helper-parse-masking-investigation/post-fix-transcript.txt
@@ -1,0 +1,34 @@
+=== AFTER FIX: AST rules on input.qmd (was the bug: reported clean) ===
+claude-notes/plans/syntax-helper-parse-masking-investigation/input.qmd
+  ⚠ file does not parse (Q-2-10); 2 rule(s) not applied: literal-brackets, reference-links
+
+
+=== Summary ===
+Total files:         1
+Files with issues:   0 ✓
+Unanalyzable files:  1 ⚠
+Clean files:         0 ✓
+
+Total issues found:  0
+Success rate:        0.0%
+
+=== AFTER FIX: --json ===
+{"rule_name":"unanalyzable","file_path":"claude-notes/plans/syntax-helper-parse-masking-investigation/input.qmd","has_issue":false,"issue_count":0,"message":"file does not parse (Q-2-10); 2 rule(s) not applied: literal-brackets, reference-links","error_codes":["Q-2-10"],"unanalyzable":true,"skipped_rules":["literal-brackets","reference-links"]}
+
+=== AFTER FIX: control still finds both ===
+claude-notes/plans/syntax-helper-parse-masking-investigation/input-parseable.qmd
+  ✗ Brackets in `[1]` will be silently deleted; they need escaping
+  ✗ `[the docs][gcc]` is a reference-style link to `gcc`, which does not render; it can be rewritten to the inline form
+
+
+=== Summary ===
+Total files:         1
+Files with issues:   1 ✗
+Clean files:         0 ✓
+
+Issues by rule:
+  literal-brackets: 1 issue(s) in 1 file(s)
+  reference-links: 1 issue(s) in 1 file(s)
+
+Total issues found:  2
+Success rate:        0.0%

--- a/claude-notes/plans/syntax-helper-parse-masking-investigation/repro-transcript.txt
+++ b/claude-notes/plans/syntax-helper-parse-masking-investigation/repro-transcript.txt
@@ -1,0 +1,43 @@
+=== parse check: input.qmd ===
+claude-notes/plans/syntax-helper-parse-masking-investigation/input.qmd
+  ✗ File failed to parse (1 error)
+
+
+=== Summary ===
+Total files:         1
+Files with issues:   1 ✗
+Clean files:         0 ✓
+
+Issues by rule:
+  parse: 1 issue(s) in 1 file(s)
+
+Total issues found:  1
+Success rate:        0.0%
+
+=== AST rules: input.qmd (the bug) ===
+
+=== Summary ===
+Total files:         1
+Files with issues:   0 ✓
+Clean files:         1 ✓
+
+Total issues found:  0
+Success rate:        100.0%
+
+=== AST rules: input-parseable.qmd (control) ===
+claude-notes/plans/syntax-helper-parse-masking-investigation/input-parseable.qmd
+  ✗ Brackets in `[1]` will be silently deleted; they need escaping
+  ✗ `[the docs][gcc]` is a reference-style link to `gcc`, which does not render; it can be rewritten to the inline form
+
+
+=== Summary ===
+Total files:         1
+Files with issues:   1 ✗
+Clean files:         0 ✓
+
+Issues by rule:
+  literal-brackets: 1 issue(s) in 1 file(s)
+  reference-links: 1 issue(s) in 1 file(s)
+
+Total issues found:  2
+Success rate:        0.0%

--- a/crates/qmd-syntax-helper/README.md
+++ b/crates/qmd-syntax-helper/README.md
@@ -112,6 +112,50 @@ Two things the rules deliberately do *not* do:
   removing them is what restores parity — but it does delete a line the
   author wrote.
 
+### Rules that require a parsing file
+
+Most rules run on any input: the diagnostic-driven `q-2-*` rules read parse
+*failures* as their input, and `grid-tables` works on raw text. But rules
+that walk the parsed AST — `reference-links`, `literal-brackets`, `q-2-30` —
+can only report findings when the file actually parses. On a file that does
+not, `check` **skips them and counts the file as unanalyzable** (never
+clean — it was not checked):
+
+```
+docs/admin/security/index.md
+  ⚠ file does not parse (Q-2-10); 2 rule(s) not applied: literal-brackets, reference-links
+
+=== Summary ===
+Total files:         1
+Files with issues:   0 ✓
+Unanalyzable files:  1 ⚠
+Clean files:         0 ✓
+```
+
+In `--json` mode the file gets one synthesized record with
+`"rule_name": "unanalyzable"`, `"unanalyzable": true`, the skipped rule
+names, and the parse error codes.
+
+`convert` skips these rules while the working copy fails to parse, re-probing
+each iteration — so a run that also fixes the parse errors (e.g.
+`convert -r apostrophe-quotes -r literal-brackets`) repairs the file first
+and then applies the AST rules in a later iteration. Only if the file
+*still* fails to parse when the run settles is the refusal reported (per
+file, on stderr; the sweep continues).
+
+The workflow for a tree with parse errors is therefore:
+
+```bash
+# 1. See what fails to parse and why
+qmd-syntax-helper check -r parse "docs/**/*.qmd"
+
+# 2. Fix the parse errors (automatically where a rule exists)
+qmd-syntax-helper convert -r all --in-place "docs/**/*.qmd"
+
+# 3. Now the AST-based sweeps are trustworthy
+qmd-syntax-helper check -r literal-brackets -r reference-links "docs/**/*.qmd"
+```
+
 ## Installation
 
 From the quarto-markdown repository:

--- a/crates/qmd-syntax-helper/src/conversions/apostrophe_quotes.rs
+++ b/crates/qmd-syntax-helper/src/conversions/apostrophe_quotes.rs
@@ -131,6 +131,7 @@ impl Rule for ApostropheQuotesConverter {
                 location: v.error_location,
                 error_code: Some("Q-2-10".to_string()),
                 error_codes: None,
+                ..Default::default()
             })
             .collect();
 

--- a/crates/qmd-syntax-helper/src/conversions/attribute_ordering.rs
+++ b/crates/qmd-syntax-helper/src/conversions/attribute_ordering.rs
@@ -242,6 +242,7 @@ impl Rule for AttributeOrderingConverter {
                 location: v.error_location,
                 error_code: None,
                 error_codes: None,
+                ..Default::default()
             })
             .collect();
 

--- a/crates/qmd-syntax-helper/src/conversions/bracket_analysis.rs
+++ b/crates/qmd-syntax-helper/src/conversions/bracket_analysis.rs
@@ -152,9 +152,15 @@ pub fn normalize_label(label: &str) -> String {
 
 /// Analyze `source`, returning every definition and finding.
 ///
-/// A file that does not parse yields an empty `Analysis`, so the rules leave
-/// it alone rather than editing a document whose structure we cannot trust.
-/// Parse errors are the `parse` rule's business, not ours.
+/// A file that does not parse is an **error** ([`ParseFailure`] carrying the
+/// diagnostic codes), never an empty analysis: an empty analysis is
+/// indistinguishable from "checked and clean", which once let scoped sweeps
+/// report unparseable files as clean (bd-syntax-helper-parse-masking-w88mhedp).
+/// The check/convert drivers probe files first (via
+/// [`crate::rule::Rule::requires_parse`]), so in driver flow the rules never
+/// reach this path; it protects direct library callers.
+///
+/// [`ParseFailure`]: crate::utils::parse_probe::ParseFailure
 pub fn analyze(source: &str, filename: &str) -> Result<Analysis> {
     let mut sink = std::io::sink();
     let parsed =
@@ -162,7 +168,9 @@ pub fn analyze(source: &str, filename: &str) -> Result<Analysis> {
 
     let (doc, _ctx, _diags) = match parsed {
         Ok(triple) => triple,
-        Err(_) => return Ok(Analysis::default()),
+        Err(diags) => {
+            return Err(crate::utils::parse_probe::ParseFailure::from_diagnostics(&diags).into());
+        }
     };
 
     let parts = collect_parts(doc, source);

--- a/crates/qmd-syntax-helper/src/conversions/definition_lists.rs
+++ b/crates/qmd-syntax-helper/src/conversions/definition_lists.rs
@@ -236,6 +236,7 @@ impl Rule for DefinitionListConverter {
                 }),
                 error_code: None,
                 error_codes: None,
+                ..Default::default()
             });
         }
 

--- a/crates/qmd-syntax-helper/src/conversions/grid_tables.rs
+++ b/crates/qmd-syntax-helper/src/conversions/grid_tables.rs
@@ -185,6 +185,7 @@ impl Rule for GridTableConverter {
                 }),
                 error_code: None,
                 error_codes: None,
+                ..Default::default()
             });
         }
 

--- a/crates/qmd-syntax-helper/src/conversions/literal_brackets.rs
+++ b/crates/qmd-syntax-helper/src/conversions/literal_brackets.rs
@@ -77,6 +77,12 @@ impl Rule for LiteralBracketsConverter {
         true
     }
 
+    /// Findings come from walking the parsed AST; without one there is
+    /// nothing to say, and "no findings" must not read as clean.
+    fn requires_parse(&self) -> bool {
+        true
+    }
+
     fn check(&self, file_path: &Path, _verbose: bool) -> Result<Vec<CheckResult>> {
         let content = read_file(file_path)?;
         let analysis = analyze(&content, &file_path.to_string_lossy())?;
@@ -116,6 +122,7 @@ impl Rule for LiteralBracketsConverter {
                 location: Some(source_location(&content, finding.start())),
                 error_code: None,
                 error_codes: None,
+                ..Default::default()
             });
         }
 

--- a/crates/qmd-syntax-helper/src/conversions/q_2_11.rs
+++ b/crates/qmd-syntax-helper/src/conversions/q_2_11.rs
@@ -141,6 +141,7 @@ impl Rule for Q211Converter {
                 location: v.error_location,
                 error_code: Some("Q-2-11".to_string()),
                 error_codes: None,
+                ..Default::default()
             })
             .collect();
 

--- a/crates/qmd-syntax-helper/src/conversions/q_2_12.rs
+++ b/crates/qmd-syntax-helper/src/conversions/q_2_12.rs
@@ -141,6 +141,7 @@ impl Rule for Q212Converter {
                 location: v.error_location,
                 error_code: Some("Q-2-12".to_string()),
                 error_codes: None,
+                ..Default::default()
             })
             .collect();
 

--- a/crates/qmd-syntax-helper/src/conversions/q_2_13.rs
+++ b/crates/qmd-syntax-helper/src/conversions/q_2_13.rs
@@ -141,6 +141,7 @@ impl Rule for Q213Converter {
                 location: v.error_location,
                 error_code: Some("Q-2-13".to_string()),
                 error_codes: None,
+                ..Default::default()
             })
             .collect();
 

--- a/crates/qmd-syntax-helper/src/conversions/q_2_15.rs
+++ b/crates/qmd-syntax-helper/src/conversions/q_2_15.rs
@@ -118,6 +118,7 @@ impl Rule for Q215Converter {
                 location: v.error_location,
                 error_code: Some("Q-2-15".to_string()),
                 error_codes: None,
+                ..Default::default()
             })
             .collect();
 

--- a/crates/qmd-syntax-helper/src/conversions/q_2_16.rs
+++ b/crates/qmd-syntax-helper/src/conversions/q_2_16.rs
@@ -141,6 +141,7 @@ impl Rule for Q216Converter {
                 location: v.error_location,
                 error_code: Some("Q-2-16".to_string()),
                 error_codes: None,
+                ..Default::default()
             })
             .collect();
 

--- a/crates/qmd-syntax-helper/src/conversions/q_2_17.rs
+++ b/crates/qmd-syntax-helper/src/conversions/q_2_17.rs
@@ -138,6 +138,7 @@ impl Rule for Q217Converter {
                 location: v.error_location,
                 error_code: Some("Q-2-17".to_string()),
                 error_codes: None,
+                ..Default::default()
             })
             .collect();
 

--- a/crates/qmd-syntax-helper/src/conversions/q_2_18.rs
+++ b/crates/qmd-syntax-helper/src/conversions/q_2_18.rs
@@ -138,6 +138,7 @@ impl Rule for Q218Converter {
                 location: v.error_location,
                 error_code: Some("Q-2-18".to_string()),
                 error_codes: None,
+                ..Default::default()
             })
             .collect();
 

--- a/crates/qmd-syntax-helper/src/conversions/q_2_19.rs
+++ b/crates/qmd-syntax-helper/src/conversions/q_2_19.rs
@@ -141,6 +141,7 @@ impl Rule for Q219Converter {
                 location: v.error_location,
                 error_code: Some("Q-2-19".to_string()),
                 error_codes: None,
+                ..Default::default()
             })
             .collect();
 

--- a/crates/qmd-syntax-helper/src/conversions/q_2_20.rs
+++ b/crates/qmd-syntax-helper/src/conversions/q_2_20.rs
@@ -141,6 +141,7 @@ impl Rule for Q220Converter {
                 location: v.error_location,
                 error_code: Some("Q-2-20".to_string()),
                 error_codes: None,
+                ..Default::default()
             })
             .collect();
 

--- a/crates/qmd-syntax-helper/src/conversions/q_2_21.rs
+++ b/crates/qmd-syntax-helper/src/conversions/q_2_21.rs
@@ -141,6 +141,7 @@ impl Rule for Q221Converter {
                 location: v.error_location,
                 error_code: Some("Q-2-21".to_string()),
                 error_codes: None,
+                ..Default::default()
             })
             .collect();
 

--- a/crates/qmd-syntax-helper/src/conversions/q_2_22.rs
+++ b/crates/qmd-syntax-helper/src/conversions/q_2_22.rs
@@ -141,6 +141,7 @@ impl Rule for Q222Converter {
                 location: v.error_location,
                 error_code: Some("Q-2-22".to_string()),
                 error_codes: None,
+                ..Default::default()
             })
             .collect();
 

--- a/crates/qmd-syntax-helper/src/conversions/q_2_23.rs
+++ b/crates/qmd-syntax-helper/src/conversions/q_2_23.rs
@@ -141,6 +141,7 @@ impl Rule for Q223Converter {
                 location: v.error_location,
                 error_code: Some("Q-2-23".to_string()),
                 error_codes: None,
+                ..Default::default()
             })
             .collect();
 

--- a/crates/qmd-syntax-helper/src/conversions/q_2_24.rs
+++ b/crates/qmd-syntax-helper/src/conversions/q_2_24.rs
@@ -138,6 +138,7 @@ impl Rule for Q224Converter {
                 location: v.error_location,
                 error_code: Some("Q-2-24".to_string()),
                 error_codes: None,
+                ..Default::default()
             })
             .collect();
 

--- a/crates/qmd-syntax-helper/src/conversions/q_2_25.rs
+++ b/crates/qmd-syntax-helper/src/conversions/q_2_25.rs
@@ -138,6 +138,7 @@ impl Rule for Q225Converter {
                 location: v.error_location,
                 error_code: Some("Q-2-25".to_string()),
                 error_codes: None,
+                ..Default::default()
             })
             .collect();
 

--- a/crates/qmd-syntax-helper/src/conversions/q_2_26.rs
+++ b/crates/qmd-syntax-helper/src/conversions/q_2_26.rs
@@ -141,6 +141,7 @@ impl Rule for Q226Converter {
                 location: v.error_location,
                 error_code: Some("Q-2-26".to_string()),
                 error_codes: None,
+                ..Default::default()
             })
             .collect();
 

--- a/crates/qmd-syntax-helper/src/conversions/q_2_28.rs
+++ b/crates/qmd-syntax-helper/src/conversions/q_2_28.rs
@@ -195,6 +195,7 @@ impl Rule for Q228Converter {
                 location: v.error_location,
                 error_code: Some("Q-2-28".to_string()),
                 error_codes: None,
+                ..Default::default()
             })
             .collect();
 

--- a/crates/qmd-syntax-helper/src/conversions/q_2_33.rs
+++ b/crates/qmd-syntax-helper/src/conversions/q_2_33.rs
@@ -164,6 +164,7 @@ impl Rule for Q233Converter {
                 location: v.error_location,
                 error_code: Some("Q-2-33".to_string()),
                 error_codes: None,
+                ..Default::default()
             })
             .collect();
 

--- a/crates/qmd-syntax-helper/src/conversions/q_2_5.rs
+++ b/crates/qmd-syntax-helper/src/conversions/q_2_5.rs
@@ -126,6 +126,7 @@ impl Rule for Q25Converter {
                 location: v.error_location,
                 error_code: Some("Q-2-5".to_string()),
                 error_codes: None,
+                ..Default::default()
             })
             .collect();
 

--- a/crates/qmd-syntax-helper/src/conversions/q_2_7.rs
+++ b/crates/qmd-syntax-helper/src/conversions/q_2_7.rs
@@ -150,6 +150,7 @@ impl Rule for Q27Converter {
                 location: v.error_location,
                 error_code: Some("Q-2-7".to_string()),
                 error_codes: None,
+                ..Default::default()
             })
             .collect();
 

--- a/crates/qmd-syntax-helper/src/conversions/reference_links.rs
+++ b/crates/qmd-syntax-helper/src/conversions/reference_links.rs
@@ -137,6 +137,12 @@ impl Rule for ReferenceLinksConverter {
         "Migrate reference-style links and images to the inline form"
     }
 
+    /// Findings come from walking the parsed AST; without one there is
+    /// nothing to say, and "no findings" must not read as clean.
+    fn requires_parse(&self) -> bool {
+        true
+    }
+
     fn check(&self, file_path: &Path, _verbose: bool) -> Result<Vec<CheckResult>> {
         let content = read_file(file_path)?;
         let analysis = analyze(&content, &file_path.to_string_lossy())?;
@@ -173,6 +179,7 @@ impl Rule for ReferenceLinksConverter {
                 location: Some(source_location(&content, finding.start())),
                 error_code: None,
                 error_codes: None,
+                ..Default::default()
             });
         }
 
@@ -192,6 +199,7 @@ impl Rule for ReferenceLinksConverter {
                 location: Some(source_location(&content, definition.line_start)),
                 error_code: None,
                 error_codes: None,
+                ..Default::default()
             });
         }
 

--- a/crates/qmd-syntax-helper/src/diagnostics/parse_check.rs
+++ b/crates/qmd-syntax-helper/src/diagnostics/parse_check.rs
@@ -1,34 +1,14 @@
-use anyhow::{Context, Result};
-use std::fs;
+use anyhow::Result;
 use std::path::Path;
 
 use crate::rule::{CheckResult, ConvertResult, Rule};
+use crate::utils::parse_probe::probe_file;
 
 pub struct ParseChecker {}
 
 impl ParseChecker {
     pub fn new() -> Result<Self> {
         Ok(Self {})
-    }
-
-    /// Check if a file parses successfully and return diagnostic messages if it fails
-    fn check_parse(
-        &self,
-        file_path: &Path,
-    ) -> Result<Option<Vec<quarto_error_reporting::DiagnosticMessage>>> {
-        let content = fs::read_to_string(file_path)
-            .with_context(|| format!("Failed to read file: {}", file_path.display()))?;
-
-        let mut sink = std::io::sink();
-        let filename = file_path.to_string_lossy();
-
-        let result =
-            pampa::readers::qmd::read(content.as_bytes(), false, &filename, &mut sink, true, None);
-
-        match result {
-            Ok(_) => Ok(None),
-            Err(diagnostics) => Ok(Some(diagnostics)),
-        }
     }
 }
 
@@ -42,38 +22,29 @@ impl Rule for ParseChecker {
     }
 
     fn check(&self, file_path: &Path, _verbose: bool) -> Result<Vec<CheckResult>> {
-        let diagnostics = self.check_parse(file_path)?;
-
-        match diagnostics {
+        match probe_file(file_path)? {
             None => Ok(vec![]),
-            Some(diags) => {
-                // Extract error codes from all diagnostics
-                let error_codes: Vec<String> =
-                    diags.iter().filter_map(|d| d.code.clone()).collect();
-
-                // Create a message that includes information about all errors
-                let message = if diags.len() == 1 {
+            Some(failure) => {
+                let message = if failure.error_count == 1 {
                     "File failed to parse (1 error)".to_string()
                 } else {
-                    format!("File failed to parse ({} errors)", diags.len())
+                    format!("File failed to parse ({} errors)", failure.error_count)
                 };
-
-                // Use the first error code as the primary one, or None if no codes
-                let primary_error_code = error_codes.first().cloned();
 
                 Ok(vec![CheckResult {
                     rule_name: self.name().to_string(),
                     file_path: file_path.to_string_lossy().to_string(),
                     has_issue: true,
-                    issue_count: diags.len(),
+                    issue_count: failure.error_count,
                     message: Some(message),
                     location: None, // Parse errors don't have a single location
-                    error_code: primary_error_code,
-                    error_codes: if error_codes.is_empty() {
+                    error_code: failure.error_codes.first().cloned(),
+                    error_codes: if failure.error_codes.is_empty() {
                         None
                     } else {
-                        Some(error_codes)
+                        Some(failure.error_codes)
                     },
+                    ..Default::default()
                 }])
             }
         }

--- a/crates/qmd-syntax-helper/src/diagnostics/q_2_30.rs
+++ b/crates/qmd-syntax-helper/src/diagnostics/q_2_30.rs
@@ -64,10 +64,15 @@ impl Q230Checker {
             None,
         );
 
-        // If parse fails, return empty violations (let parse rule handle it)
+        // A parse failure is an error, never an empty (= clean) result — an
+        // unparseable file was not checked (bd-syntax-helper-parse-masking-w88mhedp).
         let (pandoc_doc, _ast_context, _diagnostics) = match parse_result {
             Ok(result) => result,
-            Err(_) => return Ok(Vec::new()),
+            Err(diags) => {
+                return Err(
+                    crate::utils::parse_probe::ParseFailure::from_diagnostics(&diags).into(),
+                );
+            }
         };
 
         let mut violations = Vec::new();
@@ -144,12 +149,14 @@ impl Rule for Q230Checker {
         "Detect multi-paragraph footnotes using Pandoc indentation syntax"
     }
 
+    /// Detection walks the parsed AST's block sequence; without one there is
+    /// nothing to say, and "no findings" must not read as clean.
+    fn requires_parse(&self) -> bool {
+        true
+    }
+
     fn check(&self, file_path: &Path, _verbose: bool) -> Result<Vec<CheckResult>> {
-        // If file doesn't parse, return empty (let parse rule handle it)
-        let violations = match self.get_violations(file_path) {
-            Ok(v) => v,
-            Err(_) => return Ok(vec![]),
-        };
+        let violations = self.get_violations(file_path)?;
 
         let results: Vec<CheckResult> = violations
             .into_iter()
@@ -168,7 +175,7 @@ impl Rule for Q230Checker {
                 }),
                 error_code: Some("Q-2-30".to_string()),
                 error_codes: None,
-            })
+            ..Default::default() })
             .collect();
 
         Ok(results)
@@ -181,17 +188,7 @@ impl Rule for Q230Checker {
         _check_mode: bool,
         _verbose: bool,
     ) -> Result<ConvertResult> {
-        let violations = match self.get_violations(file_path) {
-            Ok(v) => v,
-            Err(_) => {
-                return Ok(ConvertResult {
-                    rule_name: self.name().to_string(),
-                    file_path: file_path.to_string_lossy().to_string(),
-                    fixes_applied: 0,
-                    message: Some("File does not parse - cannot check for Q-2-30".to_string()),
-                });
-            }
-        };
+        let violations = self.get_violations(file_path)?;
 
         // This is a linting diagnostic - no auto-fix available
         // Requires manual conversion to div syntax

--- a/crates/qmd-syntax-helper/src/main.rs
+++ b/crates/qmd-syntax-helper/src/main.rs
@@ -9,8 +9,10 @@ mod diagnostics;
 mod rule;
 mod utils;
 
-use rule::{Rule, RuleRegistry};
+use rule::{CheckResult, Rule, RuleRegistry};
+use std::collections::HashSet;
 use utils::glob_expand::expand_globs;
+use utils::parse_probe::probe_file;
 
 #[derive(Parser)]
 #[command(name = "qmd-syntax-helper")]
@@ -97,7 +99,21 @@ fn main() -> Result<()> {
             let total_files_checked = file_paths.len();
             let rules = resolve_rules(&registry, &rule_names, RuleUse::Check)?;
 
+            // Rules that walk the AST are skipped on files that fail to
+            // parse; such a file is accounted "unanalyzable", never clean
+            // (bd-syntax-helper-parse-masking-w88mhedp). Sorted because the
+            // registry iterates a HashMap.
+            let mut requires_parse_rules: Vec<String> = rules
+                .iter()
+                .filter(|r| r.requires_parse())
+                .map(|r| r.name().to_string())
+                .collect();
+            requires_parse_rules.sort();
+
             let mut all_results = Vec::new();
+            // Files where a rule (or the parse probe) failed outright — not
+            // checked, so never counted clean.
+            let mut error_files: HashSet<String> = HashSet::new();
 
             for file_path in file_paths {
                 // Print filename first in verbose mode
@@ -105,15 +121,42 @@ fn main() -> Result<()> {
                     println!("Checking: {}", file_path.display());
                 }
 
+                let path_str = file_path.to_string_lossy().to_string();
+
+                // Probe once per file, only when an AST-requiring rule was
+                // requested.
+                let parse_failure = if requires_parse_rules.is_empty() {
+                    None
+                } else {
+                    match probe_file(&file_path) {
+                        Ok(failure) => failure,
+                        Err(e) => {
+                            // Unreadable: every rule would fail identically.
+                            error_files.insert(path_str);
+                            if !json {
+                                if !verbose {
+                                    println!("{}", file_path.display());
+                                }
+                                eprintln!("  {} Error reading file: {}", "✗".red(), e);
+                            }
+                            continue;
+                        }
+                    }
+                };
+
                 // Collect results for this file
                 let mut file_results = Vec::new();
 
                 for rule in &rules {
+                    if parse_failure.is_some() && rule.requires_parse() {
+                        continue;
+                    }
                     match rule.check(&file_path, verbose && !json) {
                         Ok(results) => {
                             file_results.extend(results);
                         }
                         Err(e) => {
+                            error_files.insert(path_str.clone());
                             if !json {
                                 // For errors, print filename first if not verbose
                                 if !verbose {
@@ -125,33 +168,41 @@ fn main() -> Result<()> {
                     }
                 }
 
+                // One synthesized record per unparseable file: the skipped
+                // rules never saw an AST, so "no findings" from them would
+                // read as clean when the file was in fact not checked.
+                if let Some(failure) = &parse_failure {
+                    file_results.push(CheckResult {
+                        rule_name: "unanalyzable".to_string(),
+                        file_path: path_str.clone(),
+                        message: Some(format!(
+                            "{failure}; {} rule(s) not applied: {}",
+                            requires_parse_rules.len(),
+                            requires_parse_rules.join(", ")
+                        )),
+                        error_codes: if failure.error_codes.is_empty() {
+                            None
+                        } else {
+                            Some(failure.error_codes.clone())
+                        },
+                        unanalyzable: true,
+                        skipped_rules: Some(requires_parse_rules.clone()),
+                        ..Default::default()
+                    });
+                }
+
                 // Print results based on mode
                 if !json {
                     if verbose {
                         // Verbose: filename already printed, just print issues
-                        for result in &file_results {
-                            if result.has_issue {
-                                println!(
-                                    "  {} {}",
-                                    "✗".red(),
-                                    result.message.as_ref().unwrap_or(&String::new())
-                                );
-                            }
-                        }
+                        print_file_results(&file_results);
                     } else {
-                        // Non-verbose: only print filename if there are issues
-                        let has_issues = file_results.iter().any(|r| r.has_issue);
-                        if has_issues {
+                        // Non-verbose: only print filename if there is
+                        // something to say
+                        let printable = file_results.iter().any(|r| r.has_issue || r.unanalyzable);
+                        if printable {
                             println!("{}", file_path.display());
-                            for result in &file_results {
-                                if result.has_issue {
-                                    println!(
-                                        "  {} {}",
-                                        "✗".red(),
-                                        result.message.as_ref().unwrap_or(&String::new())
-                                    );
-                                }
-                            }
+                            print_file_results(&file_results);
                             println!(); // Blank line between files
                         }
                     }
@@ -163,7 +214,7 @@ fn main() -> Result<()> {
 
             // Print summary if not in JSON mode
             if !json {
-                print_check_summary(&all_results, total_files_checked);
+                print_check_summary(&all_results, total_files_checked, &error_files);
             }
 
             // Output handling
@@ -198,6 +249,19 @@ fn main() -> Result<()> {
             let rules = resolve_rules(&registry, &rule_names, RuleUse::Convert)?;
             let max_iter = if no_iteration { 1 } else { max_iterations };
 
+            // Rules that walk the AST are skipped while the working copy
+            // fails to parse. Re-probed every iteration: an earlier rule in
+            // the same run (e.g. apostrophe-quotes) may repair the parse
+            // error, after which the skipped rules apply normally. Only if
+            // the file *still* fails to parse at convergence is the skip
+            // reported (bd-syntax-helper-parse-masking-w88mhedp).
+            let mut requires_parse_rules: Vec<String> = rules
+                .iter()
+                .filter(|r| r.requires_parse())
+                .map(|r| r.name().to_string())
+                .collect();
+            requires_parse_rules.sort();
+
             for file_path in file_paths {
                 if verbose {
                     println!("Processing: {}", file_path.display());
@@ -223,9 +287,20 @@ fn main() -> Result<()> {
                         println!("  Iteration {}:", iteration);
                     }
 
+                    // Probe the working copy, only when an AST-requiring rule
+                    // was requested.
+                    let parse_failure = if requires_parse_rules.is_empty() {
+                        None
+                    } else {
+                        probe_file(&temp_path)?
+                    };
+
                     // Apply all rules to temp file (always in_place=true, check_mode=false on temp)
                     // We always write to temp since it's temporary; finalize_temp_file handles check_mode
                     for rule in &rules {
+                        if parse_failure.is_some() && rule.requires_parse() {
+                            continue;
+                        }
                         match rule.convert(&temp_path, true, false, verbose) {
                             Ok(mut result) => {
                                 if result.fixes_applied > 0 {
@@ -309,6 +384,21 @@ fn main() -> Result<()> {
                     }
                 }
 
+                // If the file still fails to parse now that the run has
+                // settled, the AST-requiring rules were never applied —
+                // refuse loudly (per file; the sweep continues).
+                if !requires_parse_rules.is_empty()
+                    && let Some(failure) = probe_file(&temp_path)?
+                {
+                    eprintln!(
+                        "  {} {}: {}; rule(s) not applied: {}",
+                        "⚠".yellow(),
+                        file_path.display(),
+                        failure,
+                        requires_parse_rules.join(", ")
+                    );
+                }
+
                 // Finalize: copy temp to original or print to stdout
                 finalize_temp_file(temp_file, &file_path, in_place, check_mode)?;
             }
@@ -319,22 +409,36 @@ fn main() -> Result<()> {
         Commands::ListRules => {
             println!("{}", "Available rules:".bold());
             let mut any_opt_in = false;
+            let mut any_requires_parse = false;
             for name in registry.list_names() {
                 let rule = registry.get(&name)?;
-                let marker = if rule.opt_in_only() {
+                let mut marker = String::new();
+                if rule.opt_in_only() {
                     any_opt_in = true;
-                    " *"
-                } else {
-                    ""
-                };
+                    marker.push_str(" *");
+                }
+                if rule.requires_parse() {
+                    any_requires_parse = true;
+                    marker.push_str(" †");
+                }
                 println!("  {}{} - {}", name.cyan(), marker, rule.description());
             }
-            if any_opt_in {
+            if any_opt_in || any_requires_parse {
                 println!();
+            }
+            if any_opt_in {
                 println!(
                     "  {} not applied by `convert -r all`; \
                      name it explicitly with `-r <rule>` to opt in.",
                     "*".cyan()
+                );
+            }
+            if any_requires_parse {
+                println!(
+                    "  {} needs the file to parse; on files that don't, `check` \
+                     counts the file unanalyzable and `convert` skips the rule \
+                     (fix parse errors first, e.g. `convert -r apostrophe-quotes`).",
+                    "†".cyan()
                 );
             }
             Ok(())
@@ -422,11 +526,37 @@ fn finalize_temp_file(
     Ok(())
 }
 
-fn print_check_summary(results: &[rule::CheckResult], total_files: usize) {
-    use std::collections::{HashMap, HashSet};
+/// Print one file's check results: `✗` per issue, `⚠` for the synthesized
+/// unanalyzable record.
+fn print_file_results(file_results: &[rule::CheckResult]) {
+    for result in file_results {
+        if result.has_issue {
+            println!(
+                "  {} {}",
+                "✗".red(),
+                result.message.as_ref().unwrap_or(&String::new())
+            );
+        } else if result.unanalyzable {
+            println!(
+                "  {} {}",
+                "⚠".yellow(),
+                result.message.as_ref().unwrap_or(&String::new())
+            );
+        }
+    }
+}
+
+fn print_check_summary(
+    results: &[rule::CheckResult],
+    total_files: usize,
+    error_files: &HashSet<String>,
+) {
+    use std::collections::HashMap;
 
     // Count files with issues (at least one result with has_issue=true)
     let mut files_with_issues = HashSet::new();
+    // Files where requires-parse rules were skipped: not checked, not clean.
+    let mut files_unanalyzable = HashSet::new();
     let mut total_issues = 0;
 
     // Track issues by rule type
@@ -434,6 +564,9 @@ fn print_check_summary(results: &[rule::CheckResult], total_files: usize) {
     let mut files_by_rule: HashMap<String, HashSet<String>> = HashMap::new();
 
     for result in results {
+        if result.unanalyzable {
+            files_unanalyzable.insert(&result.file_path);
+        }
         if result.has_issue {
             files_with_issues.insert(&result.file_path);
             total_issues += result.issue_count;
@@ -448,7 +581,15 @@ fn print_check_summary(results: &[rule::CheckResult], total_files: usize) {
     }
 
     let files_with_issues_count = files_with_issues.len();
-    let files_clean = total_files - files_with_issues_count;
+
+    // Clean means: every requested rule ran and none found anything. A file
+    // can be in more than one non-clean bucket (e.g. a parse-rule issue plus
+    // skipped AST rules), so clean is the complement of the union.
+    let mut not_clean: HashSet<&str> = HashSet::new();
+    not_clean.extend(files_with_issues.iter().map(|s| s.as_str()));
+    not_clean.extend(files_unanalyzable.iter().map(|s| s.as_str()));
+    not_clean.extend(error_files.iter().map(|s| s.as_str()));
+    let files_clean = total_files - not_clean.len();
 
     println!("\n{}", "=== Summary ===".bold());
     println!("Total files:         {}", total_files);
@@ -461,6 +602,20 @@ fn print_check_summary(results: &[rule::CheckResult], total_files: usize) {
             "✓".green()
         }
     );
+    if !files_unanalyzable.is_empty() {
+        println!(
+            "Unanalyzable files:  {} {}",
+            files_unanalyzable.len(),
+            "⚠".yellow()
+        );
+    }
+    if !error_files.is_empty() {
+        println!(
+            "Files with errors:   {} {}",
+            error_files.len(),
+            "⚠".yellow()
+        );
+    }
     println!("Clean files:         {} {}", files_clean, "✓".green());
 
     if !issues_by_rule.is_empty() {

--- a/crates/qmd-syntax-helper/src/rule.rs
+++ b/crates/qmd-syntax-helper/src/rule.rs
@@ -14,7 +14,7 @@ pub struct SourceLocation {
 
 /// Result of checking a file for a specific rule
 /// Each CheckResult represents a single violation
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct CheckResult {
     pub rule_name: String,
     pub file_path: String,
@@ -29,6 +29,17 @@ pub struct CheckResult {
     /// All error codes found (for parse rule with multiple errors)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error_codes: Option<Vec<String>>,
+    /// True on the synthesized per-file record (`rule_name: "unanalyzable"`)
+    /// emitted when requires-parse rules were skipped because the file does
+    /// not parse. Not an issue — the file was *not checked* by those rules,
+    /// and the summary counts it separately from both clean and has-issue
+    /// (bd-syntax-helper-parse-masking-w88mhedp).
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub unanalyzable: bool,
+    /// The requires-parse rules that were skipped, sorted by name. Only set
+    /// on the synthesized `unanalyzable` record.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub skipped_rules: Option<Vec<String>>,
 }
 
 /// Result of converting/fixing a file
@@ -61,6 +72,20 @@ pub trait Rule {
         check_mode: bool,
         verbose: bool,
     ) -> Result<ConvertResult>;
+
+    /// Whether this rule needs the file to parse into an AST before it can
+    /// say anything about it.
+    ///
+    /// Most rules read parse *failures* as their input (the diagnostic-driven
+    /// `q-2-*` rules) or work on raw text (`grid-tables`), so they run on any
+    /// file. A rule that walks the parsed AST instead — `reference-links`,
+    /// `literal-brackets`, `q-2-30` — can only report "no findings" when it
+    /// actually saw an AST; on an unparseable file the check/convert drivers
+    /// skip it and account for the file as *unanalyzable* rather than clean
+    /// (bd-syntax-helper-parse-masking-w88mhedp).
+    fn requires_parse(&self) -> bool {
+        false
+    }
 
     /// Whether `convert --rule all` applies this rule.
     ///

--- a/crates/qmd-syntax-helper/src/utils/mod.rs
+++ b/crates/qmd-syntax-helper/src/utils/mod.rs
@@ -1,3 +1,4 @@
 pub mod file_io;
 pub mod glob_expand;
+pub mod parse_probe;
 pub mod resources;

--- a/crates/qmd-syntax-helper/src/utils/parse_probe.rs
+++ b/crates/qmd-syntax-helper/src/utils/parse_probe.rs
@@ -1,0 +1,72 @@
+//! Shared "does this file parse?" probe (bd-syntax-helper-parse-masking-w88mhedp).
+//!
+//! Rules that walk the parsed AST (`Rule::requires_parse`) can only report
+//! "no findings" when they actually saw an AST. The check/convert drivers use
+//! this probe to decide, per file, whether those rules can run at all; the
+//! `parse` rule reuses it so the two agree on what "fails to parse" means.
+
+use anyhow::{Context, Result};
+use std::fmt;
+use std::path::Path;
+
+/// A failed parse probe: the file could not be parsed into an AST.
+#[derive(Debug, Clone)]
+pub struct ParseFailure {
+    /// Number of parse diagnostics reported.
+    pub error_count: usize,
+    /// Deduplicated diagnostic codes (e.g. `Q-2-10`), in first-occurrence
+    /// order. May be empty when the diagnostics carry no codes.
+    pub error_codes: Vec<String>,
+}
+
+impl ParseFailure {
+    pub fn from_diagnostics(diags: &[quarto_error_reporting::DiagnosticMessage]) -> Self {
+        let mut error_codes: Vec<String> = Vec::new();
+        for diag in diags {
+            if let Some(code) = &diag.code
+                && !error_codes.contains(code)
+            {
+                error_codes.push(code.clone());
+            }
+        }
+        Self {
+            error_count: diags.len(),
+            error_codes,
+        }
+    }
+
+    /// The codes joined for display — `Q-2-10, Q-2-5` — falling back to a
+    /// bare count when the diagnostics carry no codes.
+    pub fn codes_summary(&self) -> String {
+        if self.error_codes.is_empty() {
+            format!("{} error(s)", self.error_count)
+        } else {
+            self.error_codes.join(", ")
+        }
+    }
+}
+
+impl fmt::Display for ParseFailure {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "file does not parse ({})", self.codes_summary())
+    }
+}
+
+impl std::error::Error for ParseFailure {}
+
+/// Parse `content`, reporting `Some(ParseFailure)` when it fails.
+pub fn probe_content(content: &str, filename: &str) -> Option<ParseFailure> {
+    let mut sink = std::io::sink();
+    match pampa::readers::qmd::read(content.as_bytes(), false, filename, &mut sink, true, None) {
+        Ok(_) => None,
+        Err(diags) => Some(ParseFailure::from_diagnostics(&diags)),
+    }
+}
+
+/// Read and probe a file on disk. `Err` means the file could not be read at
+/// all; `Ok(Some(_))` means it was read but does not parse.
+pub fn probe_file(path: &Path) -> Result<Option<ParseFailure>> {
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("Failed to read file: {}", path.display()))?;
+    Ok(probe_content(&content, &path.to_string_lossy()))
+}

--- a/crates/qmd-syntax-helper/tests/integration/main.rs
+++ b/crates/qmd-syntax-helper/tests/integration/main.rs
@@ -6,6 +6,7 @@ pub mod attribute_ordering_test;
 pub mod bracket_analysis_test;
 pub mod grid_tables_test;
 pub mod literal_brackets_test;
+pub mod parse_masking_test;
 pub mod q_2_11_test;
 pub mod q_2_12_test;
 pub mod q_2_13_test;

--- a/crates/qmd-syntax-helper/tests/integration/parse_masking_test.rs
+++ b/crates/qmd-syntax-helper/tests/integration/parse_masking_test.rs
@@ -1,0 +1,372 @@
+//! Tests for bd-syntax-helper-parse-masking-w88mhedp: rules that need a
+//! successful AST must not report an unparseable file as clean.
+//!
+//! Before the fix, `bracket_analysis::analyze` turned a parse failure into an
+//! empty analysis, so `check -r literal-brackets -r reference-links` printed
+//! "Success rate: 100.0%" for a file the rules never saw. The same masking
+//! existed independently in q-2-30. The fix makes "unanalyzable" a distinct
+//! state: `analyze()` and the requires-parse rules' `check()` return an error
+//! on parse failure, and the check/convert drivers probe the file first, skip
+//! requires-parse rules, and report the skip explicitly.
+
+use qmd_syntax_helper::conversions::bracket_analysis::analyze;
+use qmd_syntax_helper::rule::RuleRegistry;
+use qmd_syntax_helper::utils::resources::ResourceManager;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Output;
+
+/// Q-2-10 (stray apostrophe: a space before `'` makes it read as a closing
+/// quote with no matching open) plus one undefined literal bracket and one
+/// reference-style link with its definition — the two findings the AST rules
+/// exist to produce, masked by the parse failure.
+const UNPARSEABLE: &str = "---\ntitle: \"Repro\"\n---\n\n\
+The admins ' console triggers Q-2-10.\n\n\
+Diagram key: [1] is the gateway node.\n\n\
+See [the docs][gcc] for details.\n\n\
+[gcc]: https://example.com/gcc\n";
+
+/// Identical, with the apostrophe escaped so the file parses.
+const PARSEABLE_CONTROL: &str = "---\ntitle: \"Repro\"\n---\n\n\
+The admins \\' console triggers no parse error.\n\n\
+Diagram key: [1] is the gateway node.\n\n\
+See [the docs][gcc] for details.\n\n\
+[gcc]: https://example.com/gcc\n";
+
+fn write_fixture(rm: &ResourceManager, name: &str, content: &str) -> PathBuf {
+    let path = rm.temp_dir().join(name);
+    fs::write(&path, content).unwrap();
+    path
+}
+
+fn run_bin(args: &[&str], paths: &[&Path]) -> Output {
+    let mut cmd = std::process::Command::new(env!("CARGO_BIN_EXE_qmd-syntax-helper"));
+    cmd.args(args);
+    for p in paths {
+        cmd.arg(p);
+    }
+    cmd.output().unwrap()
+}
+
+fn stdout_of(out: &Output) -> String {
+    String::from_utf8_lossy(&out.stdout).to_string()
+}
+
+fn stderr_of(out: &Output) -> String {
+    String::from_utf8_lossy(&out.stderr).to_string()
+}
+
+// ---------------------------------------------------------------------
+// Library level: parse failures are errors, not empty results
+// ---------------------------------------------------------------------
+
+#[test]
+fn analyze_returns_err_on_unparseable_source() {
+    let result = analyze(UNPARSEABLE, "test.qmd");
+    let err = result.expect_err("analyze must not turn a parse failure into an empty analysis");
+    assert!(
+        err.to_string().contains("Q-2-10"),
+        "error should carry the parse diagnostic codes, got: {err}"
+    );
+}
+
+#[test]
+fn analyze_succeeds_on_parseable_control() {
+    let analysis = analyze(PARSEABLE_CONTROL, "test.qmd").unwrap();
+    assert_eq!(
+        analysis.findings.len(),
+        2,
+        "control fixture must yield the literal bracket and the reference link"
+    );
+}
+
+#[test]
+fn requires_parse_declarations() {
+    let registry = RuleRegistry::new().unwrap();
+    for name in ["literal-brackets", "reference-links", "q-2-30"] {
+        assert!(
+            registry.get(name).unwrap().requires_parse(),
+            "{name} needs a successful AST and must declare requires_parse"
+        );
+    }
+    // Diagnostic-driven and text-based rules read unparseable files on
+    // purpose; they must keep running on them.
+    for name in ["parse", "apostrophe-quotes", "grid-tables", "q-2-5"] {
+        assert!(
+            !registry.get(name).unwrap().requires_parse(),
+            "{name} must not require a successful parse"
+        );
+    }
+}
+
+#[test]
+fn requires_parse_rule_checks_err_on_unparseable() {
+    let rm = ResourceManager::new().unwrap();
+    let file = write_fixture(&rm, "unparseable.qmd", UNPARSEABLE);
+    let registry = RuleRegistry::new().unwrap();
+
+    for name in ["literal-brackets", "reference-links", "q-2-30"] {
+        let result = registry.get(name).unwrap().check(&file, false);
+        let err = result.expect_err(&format!(
+            "{name}.check on an unparseable file must be an error, not a clean result"
+        ));
+        assert!(
+            err.to_string().contains("Q-2-10"),
+            "{name}'s error should carry the parse diagnostic codes, got: {err}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------
+// Binary level: check driver — skip, synthesize, summarize
+// ---------------------------------------------------------------------
+
+#[test]
+fn scoped_check_reports_unanalyzable_not_clean() {
+    let rm = ResourceManager::new().unwrap();
+    let file = write_fixture(&rm, "unparseable.qmd", UNPARSEABLE);
+
+    let out = run_bin(
+        &["check", "-r", "literal-brackets", "-r", "reference-links"],
+        &[&file],
+    );
+    let stdout = stdout_of(&out);
+
+    assert!(
+        stdout.contains("Unanalyzable files:  1"),
+        "summary must count the file as unanalyzable, got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("Clean files:         0"),
+        "an unanalyzable file must not be counted clean, got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("Success rate:        0.0%"),
+        "an unanalyzable file must not count toward the success rate, got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("file does not parse (Q-2-10)"),
+        "per-file output must say why the rules were skipped, got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("not applied: literal-brackets, reference-links"),
+        "per-file output must name the skipped rules, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn scoped_check_control_still_finds_both_issues() {
+    let rm = ResourceManager::new().unwrap();
+    let file = write_fixture(&rm, "control.qmd", PARSEABLE_CONTROL);
+
+    let out = run_bin(
+        &["check", "-r", "literal-brackets", "-r", "reference-links"],
+        &[&file],
+    );
+    let stdout = stdout_of(&out);
+
+    assert!(
+        stdout.contains("Files with issues:   1"),
+        "control file must report its findings, got:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("Unanalyzable"),
+        "a parseable file must not produce unanalyzable output, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn scoped_check_json_marks_unanalyzable() {
+    let rm = ResourceManager::new().unwrap();
+    let file = write_fixture(&rm, "unparseable.qmd", UNPARSEABLE);
+
+    let out = run_bin(
+        &[
+            "check",
+            "--json",
+            "-r",
+            "literal-brackets",
+            "-r",
+            "reference-links",
+        ],
+        &[&file],
+    );
+    let stdout = stdout_of(&out);
+
+    let records: Vec<serde_json::Value> = stdout
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| serde_json::from_str(l).unwrap())
+        .collect();
+    assert_eq!(
+        records.len(),
+        1,
+        "exactly one synthesized record for the file, got:\n{stdout}"
+    );
+    let rec = &records[0];
+    assert_eq!(rec["rule_name"], "unanalyzable");
+    assert_eq!(rec["has_issue"], false);
+    assert_eq!(rec["unanalyzable"], true);
+    assert_eq!(
+        rec["skipped_rules"],
+        serde_json::json!(["literal-brackets", "reference-links"]),
+        "skipped_rules must list the skipped rules in sorted order"
+    );
+    assert_eq!(rec["error_codes"], serde_json::json!(["Q-2-10"]));
+}
+
+#[test]
+fn check_all_skips_requires_parse_rules_but_runs_the_rest() {
+    let rm = ResourceManager::new().unwrap();
+    let file = write_fixture(&rm, "unparseable.qmd", UNPARSEABLE);
+
+    let out = run_bin(&["check", "-r", "all", "--json"], &[&file]);
+    let stdout = stdout_of(&out);
+
+    let records: Vec<serde_json::Value> = stdout
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| serde_json::from_str(l).unwrap())
+        .collect();
+
+    // The parse rule still reports the failure as its own finding.
+    assert!(
+        records
+            .iter()
+            .any(|r| r["rule_name"] == "parse" && r["has_issue"] == true),
+        "parse rule must still report the failure under -r all, got:\n{stdout}"
+    );
+    // The requires-parse rules are skipped, recorded in one synthesized
+    // per-file record (sorted for determinism — the registry iterates a
+    // HashMap).
+    let unanalyzable: Vec<_> = records
+        .iter()
+        .filter(|r| r["rule_name"] == "unanalyzable")
+        .collect();
+    assert_eq!(
+        unanalyzable.len(),
+        1,
+        "exactly one synthesized record per file, got:\n{stdout}"
+    );
+    assert_eq!(
+        unanalyzable[0]["skipped_rules"],
+        serde_json::json!(["literal-brackets", "q-2-30", "reference-links"]),
+    );
+}
+
+#[test]
+fn check_without_requires_parse_rules_never_probes() {
+    let rm = ResourceManager::new().unwrap();
+    let file = write_fixture(&rm, "unparseable.qmd", UNPARSEABLE);
+
+    // apostrophe-quotes is diagnostic-driven: the parse failure is its input.
+    let out = run_bin(&["check", "-r", "apostrophe-quotes"], &[&file]);
+    let stdout = stdout_of(&out);
+
+    assert!(
+        stdout.contains("Files with issues:   1"),
+        "apostrophe-quotes must still run on (and flag) the unparseable file, got:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("Unanalyzable"),
+        "no requires-parse rule requested, so no unanalyzable accounting, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn rule_error_files_are_not_counted_clean() {
+    let rm = ResourceManager::new().unwrap();
+    let path = rm.temp_dir().join("invalid-utf8.qmd");
+    fs::write(&path, [0xff, 0xfe, 0x00, 0x41]).unwrap();
+
+    let out = run_bin(&["check", "-r", "parse"], &[&path]);
+    let stdout = stdout_of(&out);
+
+    assert!(
+        stdout.contains("Files with errors:   1"),
+        "a file whose rules all error must be counted as an error file, got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("Clean files:         0"),
+        "a file whose rules all error must not be counted clean, got:\n{stdout}"
+    );
+}
+
+// ---------------------------------------------------------------------
+// Binary level: convert driver — per-file refusal, sweep continues
+// ---------------------------------------------------------------------
+
+#[test]
+fn convert_refuses_unparseable_file_without_aborting_sweep() {
+    let rm = ResourceManager::new().unwrap();
+    let bad = write_fixture(&rm, "bad.qmd", UNPARSEABLE);
+    let good = write_fixture(&rm, "good.qmd", PARSEABLE_CONTROL);
+
+    let out = run_bin(&["convert", "-r", "literal-brackets", "-i"], &[&bad, &good]);
+    let stderr = stderr_of(&out);
+
+    assert!(
+        out.status.success(),
+        "a refusal must not fail the sweep, stderr:\n{stderr}"
+    );
+    assert_eq!(
+        fs::read_to_string(&bad).unwrap(),
+        UNPARSEABLE,
+        "the unparseable file must be left untouched"
+    );
+    assert!(
+        fs::read_to_string(&good).unwrap().contains("\\[1\\]"),
+        "the sweep must continue past the refusal and convert the next file"
+    );
+    assert!(
+        stderr.contains("bad.qmd") && stderr.contains("not applied"),
+        "the refusal must be reported per file, got stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("literal-brackets") && stderr.contains("Q-2-10"),
+        "the refusal must name the skipped rule and the parse codes, got stderr:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("good.qmd"),
+        "the parseable file must not be reported as refused, got stderr:\n{stderr}"
+    );
+}
+
+/// Regression guard for the fix-then-apply compounding: an earlier rule in
+/// the same run repairs the parse error, so the requires-parse rule applies
+/// in a later iteration and no refusal is reported. (This worked before the
+/// fix — via the very empty-analysis path being removed — and must keep
+/// working with the driver-level skip.)
+#[test]
+fn convert_compounding_repairs_parse_then_applies_ast_rule() {
+    let rm = ResourceManager::new().unwrap();
+    let file = write_fixture(&rm, "compound.qmd", UNPARSEABLE);
+
+    let out = run_bin(
+        &[
+            "convert",
+            "-r",
+            "apostrophe-quotes",
+            "-r",
+            "literal-brackets",
+            "-i",
+        ],
+        &[&file],
+    );
+    let stderr = stderr_of(&out);
+    let converted = fs::read_to_string(&file).unwrap();
+
+    assert!(out.status.success(), "stderr:\n{stderr}");
+    assert!(
+        converted.contains("admins \\'"),
+        "apostrophe-quotes must repair the parse error, got:\n{converted}"
+    );
+    assert!(
+        converted.contains("\\[1\\]"),
+        "literal-brackets must apply once the file parses, got:\n{converted}"
+    );
+    assert!(
+        !stderr.contains("not applied"),
+        "no refusal when the parse error is repaired mid-run, got stderr:\n{stderr}"
+    );
+}


### PR DESCRIPTION
Fixes bd-syntax-helper-parse-masking-w88mhedp.

## Problem

The AST-walking qmd-syntax-helper rules — `reference-links`, `literal-brackets`, and (independently) `q-2-30` — reported files that fail to qmd-parse as **clean**: `bracket_analysis::analyze` turned a parse failure into an empty analysis, so `check -r literal-brackets -r reference-links <file>` printed `✓` and `Success rate: 100.0%` for a file the rules never saw. During the Connect-docs port this masked four literal `[1]`–`[4]` brackets in a page that failed to parse with Q-2-10 stray apostrophes — exactly the content `literal-brackets` exists to save.

## Fix

"Unanalyzable" is now a distinct state, declared per rule:

- **`Rule::requires_parse()`** (default `false`; like the existing `opt_in_only` pattern) is overridden by the three AST-requiring rules. Diagnostic-driven `q-2-*` rules and text-based rules keep running on unparseable files — a parse failure is literally their input.
- **`analyze()` and `q-2-30`** return the parse failure as an error carrying the Q-codes (`utils::parse_probe::ParseFailure`); the `parse` rule is refactored onto the same probe (its JSON `error_codes` are now deduplicated).
- **`check`** probes once per file when a requires-parse rule is requested, skips those rules on failure, and synthesizes one per-file record (`rule_name: "unanalyzable"`, sorted `skipped_rules`, `error_codes`). The summary gains `Unanalyzable files` / `Files with errors` buckets; clean now means "every requested rule ran and found nothing" (rule-check errors no longer count the file clean either).
- **`convert`** re-probes each iteration — a run that also fixes the parse errors (e.g. `convert -r apostrophe-quotes -r literal-brackets`) still applies the AST rules once the file parses — and reports a per-file refusal at convergence on stderr **without aborting the multi-file sweep**.
- Docs: README "Rules that require a parsing file" section; `list-rules` gains a `†` marker.

JSON wire shape: `CheckResult` gains optional `unanalyzable` / `skipped_rules` fields (additive; agreed no byte-compat requirement, and no schema exists).

## Before / after

```
$ qmd-syntax-helper check -r literal-brackets -r reference-links input.qmd   # Q-2-10 + masked findings
# before:                       # after:
=== Summary ===                 input.qmd
Total files:         1            ⚠ file does not parse (Q-2-10); 2 rule(s) not applied: literal-brackets, reference-links
Files with issues:   0 ✓
Clean files:         1 ✓        === Summary ===
                                Total files:         1
Total issues found:  0          Files with issues:   0 ✓
Success rate:        100.0%     Unanalyzable files:  1 ⚠
                                Clean files:         0 ✓
                                Success rate:        0.0%
```

## Testing

TDD: 12 integration tests written first (`tests/integration/parse_masking_test.rs`), 8 red pre-fix, 4 deliberate guards (control fixtures, no-probe case, convert compounding). Crate suite 176/176; workspace 12259/12259; `cargo xtask verify --skip-hub-build` green. End-to-end verified through the real binary; transcripts committed under `claude-notes/plans/syntax-helper-parse-masking-investigation/`.

Plan: `claude-notes/plans/2026-08-17-syntax-helper-parse-masking.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
