### PR TITLE
bd-duplicate-heading-ids-mou5z7ux: dedup heading ids across include boundaries

### DIFF
--- a/claude-notes/plans/2026-08-18-duplicate-heading-ids-includes.md
+++ b/claude-notes/plans/2026-08-18-duplicate-heading-ids-includes.md
@@ -3,25 +3,20 @@
 **Date:** 2026-08-18
 **Braid:** bd-duplicate-heading-ids-mou5z7ux (p2, bug, label `markdown`)
 **Checkout:** main checkout, branch `main` @ `4eaede00` at investigation time (implementation branch TBD)
-**Status:** Design aligned with user 2026-08-18 (answers recorded below). One residual design point (whole-document recompute vs. inserted-nodes-only, see Decision 2) surfaced back to the user; **implementation waits on that confirmation.**
+**Status:** Design aligned with user 2026-08-18, refined same day to the **scoped uniqueIdent** shape (Decision 2/5 below). Awaiting implementation go-ahead; Decision 4 (diagnostic) still open.
 
 ## Design decisions (user-aligned, 2026-08-18)
 
-1. **Fix shape: Option B.** Keep the reader assigning ids per-parse; add a document-level dedup pass keyed off `attr_source.id.is_none()`. User note for the future: id duplication is more general than includes (engine output, transform-fabricated headers), and the pass may eventually relocate to a single late stage that dedups everything — Option B's pass is exactly the code that would move.
-2. **Placement: tail of `IncludeExpansionStage::run()`**, gated on "at least one include was actually expanded" so the stage remains a strict no-op on documents without includes. **Residual point (awaiting user confirmation):** the user asked that the pass touch only the just-inserted nodes; the plan instead recomputes over the whole assembled document, for reasons argued in "Why whole-document recompute" below. The gate preserves the spirit (no includes → stage changes nothing); the whole-doc recompute preserves Q1 numbering in mixed inline+included cases.
-3. **Engine-output headings: out of scope.** Filed as **bd-4qjl87ax** (discovered-from this strand).
-4. **Duplicate explicit `{#id}` diagnostic:** implementable — `AttrSourceInfo.id` is `Some(source-span)` exactly when the author wrote the id, `None` when postprocess synthesized it (the qmd writer already relies on this at `crates/pampa/src/writers/qmd.rs:647-649`). Recommendation: follow-up strand, not folded in. **Awaiting user decision.**
-5. **Dedup universe: pandoc `uniqueIdent` parity.** The seen-set contains *all* header ids in document order — explicit and auto alike — and a colliding auto id probes `base-1`, `base-2`, … for the first free candidate (set-membership probe, not a per-base counter: an explicit `{#foo-1}` must push auto "Foo" to `foo-2`). Headers only, matching pandoc's `registerHeader`; explicit ids on divs/spans are not in the set. Explicit ids are never renamed.
-
-### Why whole-document recompute (Decision 2 residual)
-
-Restricting renumbering to just-inserted nodes sounds safer but:
-
-- The seen-set must include ids *outside* the inserted nodes anyway (an included heading colliding with an inline one is the general case), so "only look at inserted nodes" is not available; the question is only what may be *renamed*.
-- Renaming only inserted nodes diverges from Q1 whenever an included heading precedes an inline duplicate: Q1's counter runs in document order and renames the *later* (inline) one; inserted-only renaming would rename the earlier (included) one.
-- Whole-document recompute is idempotent for non-include content **provided the reader's per-parse pass implements the same uniqueIdent semantics** (Decision 5 forces that reader change anyway): every auto id recomputes to the value it already has, so untouched content is observably untouched — except where Q1 would also renumber, which is the bug being fixed.
-
-So: Decision 5 updates the reader's per-parse dedup to uniqueIdent semantics; the doc-level pass is the *same routine* re-run over the assembled document; the include-expansion gate keeps no-include documents byte-identical through the stage.
+1. **Fix shape: Option B.** Keep the reader assigning ids per-parse; add a post-include dedup pass keyed off `attr_source.id.is_none()`. User note for the future: id duplication is more general than includes (engine output, transform-fabricated headers); the scoped-pass mechanism below is designed to be re-runnable over other parts of the document later.
+2. **Placement + scope: tail of `IncludeExpansionStage::run()`, scoped uniqueIdent** (user refinement, second design round). The pass uses pandoc's `uniqueIdent` *algorithm* but scopes the **renameable set** to include-injected auto headers only. The **seen-set is still document-wide** — this asymmetry is load-bearing: an inline "H" colliding with an included "H" must be detected, and only the included one may be renamed. Concretely: pre-pass collects every non-renameable id (all headers outside included files, plus explicit ids anywhere, includes included files); main pass walks include-injected auto headers in document order, probing `base`, `base-1`, `base-2`, … (set-membership, not per-base counter) and inserting each assignment into the set. Recompute the base via `auto_generated_id(content)` rather than probing the fragment-assigned id, so results are independent of the fragment's internal numbering.
+   - **Why scoped beats whole-document recompute:** (a) zero behavior change outside include-injected headers — no reader change, no pampa snapshot churn; (b) **monotonicity composes**: once assigned, an id is never renamed by a later stage, so the same mechanism can run post-engine for bd-4qjl87ax (scope = engine-inserted headers) without invalidating ids `DocumentProfileStage` already observed — the tension that made bd-4qjl87ax hard under whole-doc recompute dissolves; (c) future generalization is "run the same process over a different scope", per the user's framing.
+   - **Injected-ness = file-id provenance:** the stage remaps each included parse's `FileId(0)` to a fresh file id; accumulate the set of included file ids during expansion and classify headers by their `SourceInfo` file id. Covers nested includes (each registered on recursion).
+   - Gate: skip the pass entirely when no include was expanded (stage stays a strict no-op).
+3. **Engine-output headings: out of scope.** Filed as **bd-4qjl87ax** (discovered-from this strand); the scoped mechanism is its intended future implementation.
+4. **Duplicate explicit `{#id}` diagnostic:** implementable — `AttrSourceInfo.id` is `Some(source-span)` exactly when the author wrote the id, `None` when postprocess synthesized it (qmd writer precedent at `crates/pampa/src/writers/qmd.rs:647-649`). Recommendation: follow-up strand, not folded in. **Awaiting user decision.**
+5. **Dedup algorithm: pandoc `uniqueIdent` parity in mechanism, not in document-wide outcome** (user decision, second round). The probe algorithm matches pandoc exactly (set-membership over explicit + assigned ids; headers only, matching pandoc's `registerHeader`; explicit ids never renamed), but it is applied only to the scoped renameable set. Accepted divergences from Q1, stated explicitly:
+   - When an included "H" *precedes* an inline "H": Q1 emits `h` (included) / `h-1` (inline); we emit `h-1` (included) / `h` (inline) — collision-free, reversed, because inline headers are never renameable.
+   - No-include documents are untouched, so the existing reader quirks stay: explicit `{#foo}` then auto "Foo" still both emit `foo`; the reader's per-base counter (vs. set probe) also stays. Pure-include repetition — the filed repro and the Connect-docs hit — matches Q1 exactly.
 
 ## Triage verdict (investigation, 2026-08-18)
 
@@ -63,39 +58,39 @@ Control (`control-inline.qmd`, same heading three times inline) correctly emits 
 
 ### Phase 0 — Tests first (TDD; all must fail or pin current behavior before Phase 1)
 
-pampa (uniqueIdent semantics in the reader — Decision 5):
+quarto-core (the filed bug; extend `crates/quarto-core/tests/integration/` per the integration-test layout rule — module inside the `integration` binary):
 
-- [ ] Explicit `{#foo}` then auto heading "Foo" → `foo-1` (fails today: emits colliding `foo`).
-- [ ] Explicit `{#foo-1}` present, then two auto "Foo" headings → `foo`, `foo-2` (set-probe, not counter — fails today).
-- [ ] Auto heading "Foo" then explicit `{#foo}` → explicit id kept verbatim (pin: explicit never renamed).
-- [ ] Empty-content heading base-id edge case: check `auto_generated_id` output for empty inlines against pandoc's `section` fallback; pin whatever we decide.
-- [ ] qmd-writer round-trip: a deduped header (`foo-1`) round-trips with an explicit `{#foo-1}` (existing behavior for `-N` ids — pin it).
-
-quarto-core (the filed bug):
-
-- [ ] Integration test: repeated include → `x`, `x-1`, `x-2` (fails today). Extend `crates/quarto-core/tests/integration/` per the integration-test layout rule (module inside the `integration` binary).
+- [ ] Repeated include → `x`, `x-1`, `x-2` (fails today).
 - [ ] Nested include (a.qmd includes b.qmd twice; b carries a heading).
-- [ ] Mixed ordering, Q1 parity: inline "H" then included "H" → included gets `-1`; included "H" then inline "H" → *inline* gets `-1` (this is the case that forces whole-document recompute).
-- [ ] Explicit `{#id}` inside an included file, included twice → both keep the id verbatim (no renaming), pinning Decision 4's premise.
+- [ ] Mixed ordering, scoped semantics (Decision 5): inline "H" then included "H" → included gets `h-1`; included "H" then inline "H" → **included** gets `h-1`, inline keeps `h` (documents the accepted Q1 divergence).
+- [ ] Set-probe, not counter: main doc has explicit `{#h-1}`, includes "H" twice → included get `h`, `h-2` (fails today; pins uniqueIdent probing).
+- [ ] Explicit `{#id}` inside an included file, included twice → both keep the id verbatim (no renaming; explicit ids are seen-set members but never renameable).
+- [ ] Non-injected headers are never renamed even on collision: two inline "H" duplicates + one included "H" → inline pair keeps its reader-assigned `h`, `h-1`; included gets `h-2`.
 - [ ] No-include document passes through `IncludeExpansionStage` unchanged (the gate).
 - [ ] Profile outline: `DocumentProfileStage` sees deduped ids (extend `document_profile_pipeline.rs`).
+
+pampa (pins only — the reader is deliberately untouched):
+
+- [ ] Empty-content heading base-id edge case: check `auto_generated_id` output for empty inlines (pandoc falls back to `section`); pin whatever we decide for the probe base.
+- [ ] qmd-writer round-trip: a deduped header (`h-1`) round-trips with an explicit `{#h-1}` (existing behavior for `-N` ids — pin it; applies equally to pass-assigned ids since `attr_source.id` stays `None` but the id no longer equals the recomputed base).
 
 End-to-end (per CLAUDE.md):
 
 - [ ] `cargo run --bin q2 -- render` on the committed fixture; inspect HTML for `x`, `x-1`, `x-2`; add a `toc-depth: 4` variant and inspect distinct `data-scroll-target`s.
 
-### Phase 1 — pampa: shared uniqueIdent routine
+### Phase 1 — the scoped uniqueIdent routine
 
-- [ ] Extract a document-level routine (working name `assign_unique_heading_ids(&mut Pandoc)`) in `pampa` (near `utils::autoid`): walk headers in document order; maintain `HashSet<String>` of used ids; for `attr_source.id.is_some()` insert verbatim; for auto headers recompute `auto_generated_id(content)` and probe `base`, `base-1`, `base-2`, …; write result and leave `attr_source.id` as `None`.
-- [ ] Restructure `postprocess()` to use it: `with_header` keeps attr-extraction/linebreak handling but stops assigning ids; the routine runs as a whole-doc pass at the end of postprocess. Single source of truth for both call sites.
-- [ ] Traversal scope must match current `with_header` filter reach (headers inside divs, blockquotes, list items, etc.).
-- [ ] Run pampa + workspace snapshots; expected churn: only documents mixing explicit and auto ids that now probe differently (intended, Decision 5). Audit and report per the snapshot policy.
+- [ ] Implement (working name `dedup_injected_heading_ids(&mut Pandoc, injected_file_ids: &HashSet<FileId>)`) — home: `quarto-core` next to the stage, since scoping by include provenance is a pipeline concept, but keep the probe helper generic enough to re-scope for bd-4qjl87ax. Pre-pass walk collects the seen-set (all non-injected header ids + explicit ids everywhere); main walk in document order over injected headers with `attr_source.id.is_none()`: recompute `auto_generated_id(content)`, probe `base`, `base-1`, …, assign, insert into set; leave `attr_source.id` as `None`.
+- [ ] Traversal scope must match the reader's `with_header` reach (headers inside divs, blockquotes, list items, footnote definitions, etc.) — use the standard filter traversal, not a top-level-blocks loop.
+- [ ] Unit tests for the routine itself (scoping, probing, explicit-id immunity).
 
-### Phase 2 — quarto-core: wire into IncludeExpansionStage
+### Phase 2 — wire into IncludeExpansionStage
 
-- [ ] At the tail of `run()`, if ≥1 include was expanded, run `assign_unique_heading_ids` over the assembled `Pandoc`.
-- [ ] Doc-comment the stage invariant: "after this stage, heading auto ids are document-unique (uniqueIdent semantics)". Note bd-4qjl87ax as the known post-engine gap.
+- [ ] Accumulate `injected_file_ids` during expansion (the `FileId(0) → new_file_id` remap already names them; nested includes covered by recursion).
+- [ ] At the tail of `run()`, if the set is non-empty, run the routine over the assembled `Pandoc`.
+- [ ] Doc-comment the stage invariant: "after this stage, include-injected heading auto ids are unique against the whole document (pandoc uniqueIdent probe); pre-existing ids are never renamed". Note bd-4qjl87ax as the known post-engine gap and the intended reuse of this mechanism.
 - [ ] Confirm coverage of all builders (native/WASM/analysis/orchestrator) via the Phase 0 integration tests where practical.
+- [ ] Snapshot audit: expected churn is **zero** outside documents with includes whose headings collide; any other churn is a red flag (snapshot policy).
 
 ### Phase 3 — Verification & close-out
 
@@ -108,8 +103,8 @@ End-to-end (per CLAUDE.md):
 
 ## Risks / tradeoffs
 
-- **Intended id changes beyond the filed bug:** Decision 5 changes ids in documents mixing explicit and auto ids (`foo` → `foo-1` after an explicit `{#foo}`). Q1-parity is the defensible target; snapshot diffs must be audited, not rubber-stamped.
-- The doc-level pass recomputes with the same `auto_generated_id` the reader used (pre-shortcode-expansion content; `Shortcode` inlines skipped by explicit decision — bd-2wv8431v), so recompute-to-same-value holds for untouched headers.
-- `attr_source.id.is_none()` as the auto-id discriminator: qmd writer precedent is strong; spot-check transform-fabricated headers (none should exist pre-include-expansion, but verify).
-- Duplicated-logic risk is retired by sharing one routine between postprocess and the stage (Phase 1).
-- Deduped ids round-trip through the qmd writer as explicit `{#foo-1}` (writer's suppress-check compares against the recomputed base). Existing behavior; pinned in Phase 0.
+- **Accepted Q1 divergences are enumerated in Decision 5** (included-before-inline renames the included heading, not the inline one; no-include documents keep today's reader quirks). Both are deliberate; tests document them so future parity work is a conscious change, not drift.
+- The pass recomputes with the same `auto_generated_id` the reader used (pre-shortcode-expansion content; `Shortcode` inlines skipped by explicit decision — bd-2wv8431v), so an injected heading with no collision recomputes to the id it already carries.
+- `attr_source.id.is_none()` as the auto-id discriminator: qmd writer precedent is strong; spot-check that nothing fabricates headers with empty attr_source before include expansion (none should exist that early, but verify).
+- File-id provenance as "injected": verify that every include occurrence's headers land in the accumulated file-id set (per-occurrence remap; nested recursion), and that no main-document header can share a file id with an included file (circular includes are already rejected).
+- Deduped/pass-assigned ids round-trip through the qmd writer as explicit `{#h-1}` (writer's suppress-check compares against the recomputed base). Existing behavior for reader-deduped ids; pinned in Phase 0.

--- a/claude-notes/plans/2026-08-18-duplicate-heading-ids-includes.md
+++ b/claude-notes/plans/2026-08-18-duplicate-heading-ids-includes.md
@@ -1,0 +1,87 @@
+# Heading identifiers are not disambiguated across include boundaries (bd-duplicate-heading-ids-mou5z7ux)
+
+**Date:** 2026-08-18
+**Braid:** bd-duplicate-heading-ids-mou5z7ux (p2, bug, label `markdown`)
+**Checkout:** main checkout, branch `main` @ `4eaede00` (investigation only; implementation branch TBD)
+**Status:** Investigation — pending design alignment with user. **Do not start implementation until the user gives the go-ahead.**
+
+## Triage verdict
+
+**Ready to design.** The bug reproduces at HEAD exactly as filed, the root cause named in the strand is accurate (verified against the code), and the main open work is choosing between two fix shapes and a placement — questions below.
+
+## Issue context
+
+Filed 2026-08-18 by Carlos (fresh — no staleness risk). A fragment with a heading, included N times via `{{< include >}}`, emits the same auto-generated id N times. Q1 emits `create-the-integration`, `-1`, `-2` because its include is a textual splice *before* pandoc parses, so pandoc's `uniqueIdent` sees one document. Consequences: invalid HTML (duplicate ids) and dead TOC entries (all point at the first occurrence). No diagnostic; exit 0.
+
+Real-world hit: Posit Connect docs port — 7 duplicate heading ids across 2 OAuth-integration pages (5-tab tabsets each including `_azure_intro.qmd` per tab). Origin strand in the connect-docs skein: br-duplicate-heading-ids-ye3j3gkr.
+
+## Dependency graph
+
+Sparse — one edge:
+
+- **related: bd-2wv8431v** (open, p4) — "Heading ids do not reflect shortcode expansion." Same underlying shape: the auto id is decided **too early and too locally** (in the reader's postprocess, per-parse). That strand was deliberately deferred ("design it then, not now" — nobody has asked for it). It matters here because the *maximal* fix (move auto-id assignment out of the reader entirely, to a document-level pass after include **and** shortcode expansion) would resolve both; the minimal fix resolves only this one.
+- Also referenced in the description (not an edge): **bd-tabset-headings-in-toc-t04ie7f7** (open, p2) — why those headings reach the TOC at all. Independent; no ordering constraint between the two fixes.
+- No `discovered-from` or `blocks` edges; the urgency pin is the Connect-docs port itself.
+
+## What the code looks like today
+
+All paths in the strand check out at HEAD (`4eaede00`):
+
+- `crates/pampa/src/pandoc/treesitter_utils/postprocess.rs:903` — `seen_ids: HashMap<String, usize>` local to one `postprocess()` call; the `with_header` closure (:931) assigns `auto_generated_id` + `-N` dedup **only when `attr.0` is empty**.
+- `crates/quarto-core/src/stage/stages/include_expansion.rs:218` — child file parsed standalone via `pampa::readers::qmd::read(...)`; each child parse gets a fresh `seen_ids`.
+- **`AttrSourceInfo.id` already discriminates auto vs. author-written ids.** The qmd writer (`crates/pampa/src/writers/qmd.rs:647-649`) suppresses ids where `header.attr_source.id.is_none() && attr.0 == auto_generated_id(content)`. A document-level pass can use the same test — the strand's "parser leaves the id empty" trick is *one* way to get that discrimination, but not the only one.
+- Pipeline builders that run `IncludeExpansionStage` (a fix must cover all, or live where they all pass through):
+  - `build_html_pipeline_stages` / `build_pipeline_stages_with_registry` (`pipeline.rs:293`) — native render
+  - `build_wasm_html_pipeline` (`pipeline.rs:560`) — hub-client / preview WASM
+  - `build_analysis_pipeline` (`pipeline.rs:713`)
+  - orchestrator profile pass (`project/orchestrator.rs:1944`)
+  - `quarto-preview/src/config.rs:296` runs the stage standalone for dep-tracking
+- Downstream consumers of heading ids, in stage order: `DocumentProfileStage` (outline), `LinkResolutionStage`, `PreEngineSugaringStage` (crossref registry), engines, user filters, then in `AstTransformsStage`: `PanelTabsetTransform` → `ShortcodeResolveTransform` → `SectionizeTransform` (copies id onto section Div) → crossref → `TocGenerateTransform`. Ids must be final before `DocumentProfileStage` for the profile outline to be right.
+
+**Reproduced at HEAD** (fixture committed at `claude-notes/plans/duplicate-heading-ids-includes-investigation/repro/`):
+
+```
+$ cargo run --bin q2 -- render claude-notes/plans/duplicate-heading-ids-includes-investigation/repro/index.qmd
+$ grep -o 'id="create-the-integration[^"]*"' .../repro/index.html
+id="create-the-integration"
+id="create-the-integration"
+id="create-the-integration"
+```
+
+Control (`control-inline.qmd`, same three headings written inline in one file) correctly emits `create-the-integration`, `-1`, `-2` — confirming the gap is scope, not logic. (Output was inspected directly; TOC entries didn't appear in the minimal fixture because level-4 headings sit below the default `toc-depth`, but the id collision is format-independent.)
+
+## Fix shapes considered
+
+**Option A — strand's suggestion (maximal):** the reader stops assigning auto ids ("empty = wants one"); a document-level pass on the assembled AST assigns + dedups. Cleanest semantics and the shape bd-2wv8431v eventually needs (run it after shortcode expansion too). But blast radius is large: every standalone pampa consumer (pampa CLI, wasm-qmd-parser, qmd-syntax-helper, hub-client) either needs the pass appended to its own entry point or changes behavior; the qmd writer's round-trip check and a wall of snapshots are implicated; and the pass must be wired into every pipeline builder.
+
+**Option B — minimal (recommended):** keep the reader as-is; add a document-level **re-dedup pass over the assembled AST** that recomputes ids for exactly the headers with `attr_source.id.is_none()` (auto-assigned): reset to `auto_generated_id(content)`, re-dedup in document order with one fresh map. Deterministic, idempotent (a no-include document is unchanged, since the per-parse pass already produced the document-level answer), and it does **not** make fragment parses depend on splice position — the fragment parse stays independently cacheable; only the assembled document is renumbered. No parser, writer, or snapshot churn. Does not advance bd-2wv8431v, but that strand is p4 and deferred by explicit decision.
+
+**Rejected (by the strand, agreed):** threading a shared `seen_ids` into child parses — makes parse results position-dependent.
+
+## Proposed phases (draft — assumes Option B; renumber if A is chosen)
+
+- **Phase 0 — Test plan (TDD).**
+  - quarto-core integration test: repeated include → ids `x`, `x-1`, `x-2` (fails today).
+  - Control: inline repeats unchanged; explicit `{#id}` headings never renumbered (fails-safe today, pins behavior).
+  - Nested include (`a.qmd` includes `b.qmd` twice, each carrying a heading).
+  - Profile test: `DocumentProfileStage` outline sees deduped ids (extends `document_profile_pipeline.rs`).
+  - E2e per CLAUDE.md: `q2 render` of the committed fixture, inspect HTML (and a TOC-visible variant with `toc-depth: 4` to pin the scroll-target fix).
+- **Phase 1 — Document-level re-dedup pass** (function over `Pandoc`, lives in pampa or quarto-core — see Q2) + unit tests.
+- **Phase 2 — Wire into the pipeline** at the chosen placement; confirm all four builders + `quarto-preview` are covered; WASM leg via full `cargo xtask verify`.
+- **Phase 3 (optional, see Q4) — duplicate-explicit-id diagnostic** (new Q-code, catalog entry + `docs/errors/` page in the same commit per lint rule).
+- **Phase N — Docs** (if user-visible behavior notes are warranted) + close-out; comment on br-duplicate-heading-ids-ye3j3gkr in the connect-docs skein after a release ships the fix.
+
+## Open design questions for the user
+
+1. **Fix shape.** Option B (document-level re-dedup of auto ids, keyed off `attr_source.id.is_none()`) or Option A (reader stops assigning; document-level assignment — the bd-2wv8431v-compatible shape)? I recommend **B**: it fixes the filed bug with a small, testable surface, and A remains available later since B's pass is exactly where A's assignment would live.
+2. **Placement.** (a) Tail of `IncludeExpansionStage::run()` — every builder gets it for free, invariant stays local ("after this stage, auto ids are document-unique"); or (b) a separate stage/pass added to each of the four builders — cleaner separation, but four call sites to keep in sync (and future builders can forget it). I lean (a).
+3. **Engine-output headings.** Q1 assigns ids *after* the engine runs (knitr/jupyter output is part of the text pandoc parses); q2's `EngineExecutionStage` runs after include expansion, so a heading emitted by a code cell could still collide post-fix. Fixing that would mean renumbering *after* engines — but `DocumentProfileStage` (outline) runs pre-engine and wants final ids, so there's a real tension. Treat as out of scope + file a follow-up strand, or fold in now?
+4. **Duplicate explicit `{#id}` diagnostic.** The fix deliberately never renumbers author-written ids, and today nothing warns when two collide. In scope here (new Q-code + docs page), or a follow-up strand?
+5. **Dedup universe.** Pandoc's `uniqueIdent` avoids collisions against *all* seen ids, including explicit ones (auto heading "Foo" after an explicit `{#foo}` becomes `foo-1`); q2's current pass dedups only among auto ids. Preserve current (auto-only) semantics at document level, or seed the map with explicit ids for closer pandoc parity? (Auto-only is the no-surprise choice; parity is a one-liner but changes ids in documents that mix the two.)
+
+## Risks / tradeoffs (draft)
+
+- Any renumbering changes ids some site may already link to — but those links were ambiguous/dead anyway; Q1 parity is the defensible target.
+- The re-dedup pass must recompute with the same `auto_generated_id` the reader used (content is pre-shortcode-expansion at that point; `Shortcode` inlines are skipped by explicit decision — bd-2wv8431v) or ids would drift from the per-parse result in the no-include case.
+- `attr_source.id.is_none()` as the "auto id" discriminator must hold for all header producers; the qmd writer already relies on it, which is good precedent, but engine-spliced or transform-fabricated headers should be spot-checked.
+- Snapshot churn expected to be zero for Option B (no-include documents are fixpoints); any churn that does appear is a red flag worth review, per the CLAUDE.md snapshot policy.

--- a/claude-notes/plans/2026-08-18-duplicate-heading-ids-includes.md
+++ b/claude-notes/plans/2026-08-18-duplicate-heading-ids-includes.md
@@ -3,7 +3,7 @@
 **Date:** 2026-08-18
 **Braid:** bd-duplicate-heading-ids-mou5z7ux (p2, bug, label `markdown`)
 **Checkout:** main checkout, branch `main` @ `4eaede00` at investigation time (implementation branch TBD)
-**Status:** Design aligned with user 2026-08-18, refined same day to the **scoped uniqueIdent** shape (Decision 2/5 below). Awaiting implementation go-ahead; Decision 4 (diagnostic) still open.
+**Status:** Implemented 2026-08-18 on branch `braid/bd-duplicate-heading-ids-mou5z7ux` (go-ahead given same day). Phases 0–2 complete, all verification green. Decision 4's diagnostic filed as follow-up **bd-8wf5brc8**. Remaining: PR + merge, then strand close-out (Phase 3 tail items).
 
 ## Design decisions (user-aligned, 2026-08-18)
 
@@ -58,45 +58,45 @@ Control (`control-inline.qmd`, same heading three times inline) correctly emits 
 
 ### Phase 0 — Tests first (TDD; all must fail or pin current behavior before Phase 1)
 
-quarto-core (the filed bug; extend `crates/quarto-core/tests/integration/` per the integration-test layout rule — module inside the `integration` binary):
+quarto-core (the filed bug; new module `tests/integration/include_heading_id_dedup.rs`, registered in `main.rs`; reuses `include_expansion_diagnostics::render_fixture`). **Written 2026-08-18; all 7 behavior tests fail with the expected duplicate-id collisions; the 2 pins pass:**
 
-- [ ] Repeated include → `x`, `x-1`, `x-2` (fails today).
-- [ ] Nested include (a.qmd includes b.qmd twice; b carries a heading).
-- [ ] Mixed ordering, scoped semantics (Decision 5): inline "H" then included "H" → included gets `h-1`; included "H" then inline "H" → **included** gets `h-1`, inline keeps `h` (documents the accepted Q1 divergence).
-- [ ] Set-probe, not counter: main doc has explicit `{#h-1}`, includes "H" twice → included get `h`, `h-2` (fails today; pins uniqueIdent probing).
-- [ ] Explicit `{#id}` inside an included file, included twice → both keep the id verbatim (no renaming; explicit ids are seen-set members but never renameable).
-- [ ] Non-injected headers are never renamed even on collision: two inline "H" duplicates + one included "H" → inline pair keeps its reader-assigned `h`, `h-1`; included gets `h-2`.
-- [ ] No-include document passes through `IncludeExpansionStage` unchanged (the gate).
-- [ ] Profile outline: `DocumentProfileStage` sees deduped ids (extend `document_profile_pipeline.rs`).
+- [x] Repeated include → `x`, `x-1`, `x-2` (`repeated_include_disambiguates_heading_ids` — FAILS as expected).
+- [x] Nested include (`nested_repeated_include_disambiguates` — FAILS as expected).
+- [x] Mixed ordering, scoped semantics (`inline_then_included_duplicate`, `included_then_inline_duplicate_renames_the_included_one` — both FAIL as expected; the latter documents the accepted Q1 divergence).
+- [x] Set-probe, not counter (`probe_skips_explicitly_taken_suffix` — FAILS as expected).
+- [x] Explicit `{#id}` inside an included file, included twice → kept verbatim (`explicit_id_in_included_file_kept_verbatim` — passes today, pins).
+- [x] Non-injected headers never renamed (`inline_duplicates_keep_reader_ids_included_probes_past` — FAILS as expected).
+- [x] No-include document unchanged (`no_include_document_keeps_reader_dedup` — passes today, pins; the byte-identical gate itself gets a unit test in Phase 2).
+- [x] Profile outline sees deduped ids (`profile_outline_ids_deduped_across_includes` in `document_profile_pipeline.rs` — FAILS as expected).
 
 pampa (pins only — the reader is deliberately untouched):
 
-- [ ] Empty-content heading base-id edge case: check `auto_generated_id` output for empty inlines (pandoc falls back to `section`); pin whatever we decide for the probe base.
-- [ ] qmd-writer round-trip: a deduped header (`h-1`) round-trips with an explicit `{#h-1}` (existing behavior for `-N` ids — pin it; applies equally to pass-assigned ids since `attr_source.id` stays `None` but the id no longer equals the recomputed base).
+- [x] Empty-content heading base-id edge: already pinned by existing tests (`test_auto_id_empty_falls_back_to_section`, `test_auto_id_repeated_empty_headings_are_deduplicated` — `auto_generated_id` falls back to `section`, matching pandoc; nothing to add).
+- [x] qmd-writer round-trip of a deduped id (`test_deduped_id_roundtrips_as_explicit_attr` in `test_heading_auto_id.rs` — passes, pins `{#setup-1}` emission).
 
 End-to-end (per CLAUDE.md):
 
-- [ ] `cargo run --bin q2 -- render` on the committed fixture; inspect HTML for `x`, `x-1`, `x-2`; add a `toc-depth: 4` variant and inspect distinct `data-scroll-target`s.
+- [x] `cargo run --bin q2 -- render` on the committed fixture (2026-08-18, post-fix): `index.qmd` emits `id="create-the-integration"`, `-1`, `-2`; new `toc-variant.qmd` (`toc-depth: 4`) emits three distinct `data-scroll-target`s (`#create-the-integration`, `-1`, `-2`). Output inspected directly via grep on the rendered HTML.
 
 ### Phase 1 — the scoped uniqueIdent routine
 
-- [ ] Implement (working name `dedup_injected_heading_ids(&mut Pandoc, injected_file_ids: &HashSet<FileId>)`) — home: `quarto-core` next to the stage, since scoping by include provenance is a pipeline concept, but keep the probe helper generic enough to re-scope for bd-4qjl87ax. Pre-pass walk collects the seen-set (all non-injected header ids + explicit ids everywhere); main walk in document order over injected headers with `attr_source.id.is_none()`: recompute `auto_generated_id(content)`, probe `base`, `base-1`, …, assign, insert into set; leave `attr_source.id` as `None`.
-- [ ] Traversal scope must match the reader's `with_header` reach (headers inside divs, blockquotes, list items, footnote definitions, etc.) — use the standard filter traversal, not a top-level-blocks loop.
-- [ ] Unit tests for the routine itself (scoping, probing, explicit-id immunity).
+- [x] Implemented as **`pampa::utils::autoid::dedup_scoped_heading_ids(doc: Pandoc, in_scope: impl FnMut(&Header) -> bool) -> Pandoc`** — home moved from the planned quarto-core location into `pampa`'s `autoid` module (deliberate improvement: pampa owns id-assignment semantics and the filter machinery; the generic scope predicate keeps include-provenance policy in the caller). Pass 1 seeds the seen-set (all non-renameable ids: explicit anywhere + out-of-scope headers); pass 2 probes renameable headers in document order (`base`, `base-1`, … set-membership), recomputing the base via `auto_generated_id`. `attr_source.id` stays `None`. Assigned via mutate-and-return-`Unchanged` (the `with_cite` precedent) — `FilterResult(_, true)` would re-apply the filter to the returned header and double-probe it.
+- [x] Traversal via pampa's standard `topdown_traverse` filter — same reach as the reader's `with_header`.
+- [x] Unit tests (5) in `crates/pampa/tests/integration/test_heading_auto_id.rs`: scope-only renaming, set-probe vs counter, explicit-id immunity, empty-scope identity, recompute-ignores-fragment-numbering. All pass.
 
 ### Phase 2 — wire into IncludeExpansionStage
 
-- [ ] Accumulate `injected_file_ids` during expansion (the `FileId(0) → new_file_id` remap already names them; nested includes covered by recursion).
-- [ ] At the tail of `run()`, if the set is non-empty, run the routine over the assembled `Pandoc`.
-- [ ] Doc-comment the stage invariant: "after this stage, include-injected heading auto ids are unique against the whole document (pandoc uniqueIdent probe); pre-existing ids are never renamed". Note bd-4qjl87ax as the known post-engine gap and the intended reuse of this mechanism.
-- [ ] Confirm coverage of all builders (native/WASM/analysis/orchestrator) via the Phase 0 integration tests where practical.
-- [ ] Snapshot audit: expected churn is **zero** outside documents with includes whose headings collide; any other churn is a red flag (snapshot policy).
+- [x] `IncludeExpander` accumulates `injected_file_ids: HashSet<FileId>` (inserted at the splice point, per occurrence; error paths never reach it); `expand_includes_in_blocks` returns the set.
+- [x] Tail of `run()`: when the set is non-empty, `dedup_scoped_heading_ids` runs over the assembled AST with the predicate `header.source_info.root_file_id() ∈ injected_file_ids`. Gate keeps no-include documents bit-identical (`no_include_document_ast_is_untouched` unit test, passes).
+- [x] Stage invariant doc-comment written at the call site (uniqueIdent probe, monotonic ids, bd-4qjl87ax gap noted).
+- [x] Builder coverage: native pipeline via the 8 `include_heading_id_dedup` integration tests; profile/orchestrator path via `profile_outline_ids_deduped_across_includes`. (WASM builder shares the same stage; verified by the full `cargo xtask verify` in Phase 3.)
+- [x] Snapshot audit: **zero snapshot churn** — the full workspace run passed with no `.snap` file modified, exactly as predicted (no-include documents are untouched by the gate; the fixture suite has no colliding-include snapshots).
 
 ### Phase 3 — Verification & close-out
 
-- [ ] `cargo build --workspace`, `cargo nextest run --workspace`.
-- [ ] Full `cargo xtask verify` (quarto-core changed → WASM leg affected).
-- [ ] E2e render inspection recorded in the session transcript (invocation + output snippet).
+- [x] `cargo nextest run --workspace` — 12334/12334 passed (2026-08-18; build implied). Clippy + `cargo fmt --check` clean on changed crates.
+- [x] Full `cargo xtask verify` — all steps passed (2026-08-18), including the hub-build/WASM legs.
+- [x] E2e render inspection recorded in the session transcript and in this plan (Phase 0 End-to-end item: exact invocation + grep output).
 - [ ] Optional: re-run the site-wide duplicate-id scan on the connect-docs port to confirm 7 → 0.
 - [ ] Close strand; comment on br-duplicate-heading-ids-ye3j3gkr (connect-docs skein) that the fix needs the next q2 release to verify there.
 - [ ] If user opts in on the diagnostic (Decision 4): file the follow-up strand.

--- a/claude-notes/plans/2026-08-18-duplicate-heading-ids-includes.md
+++ b/claude-notes/plans/2026-08-18-duplicate-heading-ids-includes.md
@@ -2,86 +2,114 @@
 
 **Date:** 2026-08-18
 **Braid:** bd-duplicate-heading-ids-mou5z7ux (p2, bug, label `markdown`)
-**Checkout:** main checkout, branch `main` @ `4eaede00` (investigation only; implementation branch TBD)
-**Status:** Investigation — pending design alignment with user. **Do not start implementation until the user gives the go-ahead.**
+**Checkout:** main checkout, branch `main` @ `4eaede00` at investigation time (implementation branch TBD)
+**Status:** Design aligned with user 2026-08-18 (answers recorded below). One residual design point (whole-document recompute vs. inserted-nodes-only, see Decision 2) surfaced back to the user; **implementation waits on that confirmation.**
 
-## Triage verdict
+## Design decisions (user-aligned, 2026-08-18)
 
-**Ready to design.** The bug reproduces at HEAD exactly as filed, the root cause named in the strand is accurate (verified against the code), and the main open work is choosing between two fix shapes and a placement — questions below.
+1. **Fix shape: Option B.** Keep the reader assigning ids per-parse; add a document-level dedup pass keyed off `attr_source.id.is_none()`. User note for the future: id duplication is more general than includes (engine output, transform-fabricated headers), and the pass may eventually relocate to a single late stage that dedups everything — Option B's pass is exactly the code that would move.
+2. **Placement: tail of `IncludeExpansionStage::run()`**, gated on "at least one include was actually expanded" so the stage remains a strict no-op on documents without includes. **Residual point (awaiting user confirmation):** the user asked that the pass touch only the just-inserted nodes; the plan instead recomputes over the whole assembled document, for reasons argued in "Why whole-document recompute" below. The gate preserves the spirit (no includes → stage changes nothing); the whole-doc recompute preserves Q1 numbering in mixed inline+included cases.
+3. **Engine-output headings: out of scope.** Filed as **bd-4qjl87ax** (discovered-from this strand).
+4. **Duplicate explicit `{#id}` diagnostic:** implementable — `AttrSourceInfo.id` is `Some(source-span)` exactly when the author wrote the id, `None` when postprocess synthesized it (the qmd writer already relies on this at `crates/pampa/src/writers/qmd.rs:647-649`). Recommendation: follow-up strand, not folded in. **Awaiting user decision.**
+5. **Dedup universe: pandoc `uniqueIdent` parity.** The seen-set contains *all* header ids in document order — explicit and auto alike — and a colliding auto id probes `base-1`, `base-2`, … for the first free candidate (set-membership probe, not a per-base counter: an explicit `{#foo-1}` must push auto "Foo" to `foo-2`). Headers only, matching pandoc's `registerHeader`; explicit ids on divs/spans are not in the set. Explicit ids are never renamed.
+
+### Why whole-document recompute (Decision 2 residual)
+
+Restricting renumbering to just-inserted nodes sounds safer but:
+
+- The seen-set must include ids *outside* the inserted nodes anyway (an included heading colliding with an inline one is the general case), so "only look at inserted nodes" is not available; the question is only what may be *renamed*.
+- Renaming only inserted nodes diverges from Q1 whenever an included heading precedes an inline duplicate: Q1's counter runs in document order and renames the *later* (inline) one; inserted-only renaming would rename the earlier (included) one.
+- Whole-document recompute is idempotent for non-include content **provided the reader's per-parse pass implements the same uniqueIdent semantics** (Decision 5 forces that reader change anyway): every auto id recomputes to the value it already has, so untouched content is observably untouched — except where Q1 would also renumber, which is the bug being fixed.
+
+So: Decision 5 updates the reader's per-parse dedup to uniqueIdent semantics; the doc-level pass is the *same routine* re-run over the assembled document; the include-expansion gate keeps no-include documents byte-identical through the stage.
+
+## Triage verdict (investigation, 2026-08-18)
+
+**Ready to design** (now: designed). Bug reproduces at HEAD exactly as filed; root cause confirmed against the code.
 
 ## Issue context
 
-Filed 2026-08-18 by Carlos (fresh — no staleness risk). A fragment with a heading, included N times via `{{< include >}}`, emits the same auto-generated id N times. Q1 emits `create-the-integration`, `-1`, `-2` because its include is a textual splice *before* pandoc parses, so pandoc's `uniqueIdent` sees one document. Consequences: invalid HTML (duplicate ids) and dead TOC entries (all point at the first occurrence). No diagnostic; exit 0.
+Filed 2026-08-18 by Carlos. A fragment with a heading, included N times via `{{< include >}}`, emits the same auto-generated id N times. Q1 emits `create-the-integration`, `-1`, `-2` because its include is a textual splice *before* pandoc parses, so pandoc's `uniqueIdent` sees one document. Consequences: invalid HTML (duplicate ids) and dead TOC entries (all point at the first occurrence). No diagnostic; exit 0.
 
 Real-world hit: Posit Connect docs port — 7 duplicate heading ids across 2 OAuth-integration pages (5-tab tabsets each including `_azure_intro.qmd` per tab). Origin strand in the connect-docs skein: br-duplicate-heading-ids-ye3j3gkr.
 
 ## Dependency graph
 
-Sparse — one edge:
-
-- **related: bd-2wv8431v** (open, p4) — "Heading ids do not reflect shortcode expansion." Same underlying shape: the auto id is decided **too early and too locally** (in the reader's postprocess, per-parse). That strand was deliberately deferred ("design it then, not now" — nobody has asked for it). It matters here because the *maximal* fix (move auto-id assignment out of the reader entirely, to a document-level pass after include **and** shortcode expansion) would resolve both; the minimal fix resolves only this one.
-- Also referenced in the description (not an edge): **bd-tabset-headings-in-toc-t04ie7f7** (open, p2) — why those headings reach the TOC at all. Independent; no ordering constraint between the two fixes.
-- No `discovered-from` or `blocks` edges; the urgency pin is the Connect-docs port itself.
+- **related: bd-2wv8431v** (open, p4) — heading ids don't reflect shortcode expansion; same "id decided too early and too locally" shape. Deliberately deferred. Option B here does not advance it, but the doc-level pass is where its eventual fix would live.
+- **discovered-from (outgoing): bd-4qjl87ax** — engine-output heading collisions, filed during this design (Decision 3).
+- Referenced, independent: **bd-tabset-headings-in-toc-t04ie7f7** (why those headings reach the TOC at all).
 
 ## What the code looks like today
 
-All paths in the strand check out at HEAD (`4eaede00`):
+All paths verified at `4eaede00`:
 
-- `crates/pampa/src/pandoc/treesitter_utils/postprocess.rs:903` — `seen_ids: HashMap<String, usize>` local to one `postprocess()` call; the `with_header` closure (:931) assigns `auto_generated_id` + `-N` dedup **only when `attr.0` is empty**.
-- `crates/quarto-core/src/stage/stages/include_expansion.rs:218` — child file parsed standalone via `pampa::readers::qmd::read(...)`; each child parse gets a fresh `seen_ids`.
-- **`AttrSourceInfo.id` already discriminates auto vs. author-written ids.** The qmd writer (`crates/pampa/src/writers/qmd.rs:647-649`) suppresses ids where `header.attr_source.id.is_none() && attr.0 == auto_generated_id(content)`. A document-level pass can use the same test — the strand's "parser leaves the id empty" trick is *one* way to get that discrimination, but not the only one.
-- Pipeline builders that run `IncludeExpansionStage` (a fix must cover all, or live where they all pass through):
-  - `build_html_pipeline_stages` / `build_pipeline_stages_with_registry` (`pipeline.rs:293`) — native render
-  - `build_wasm_html_pipeline` (`pipeline.rs:560`) — hub-client / preview WASM
-  - `build_analysis_pipeline` (`pipeline.rs:713`)
-  - orchestrator profile pass (`project/orchestrator.rs:1944`)
-  - `quarto-preview/src/config.rs:296` runs the stage standalone for dep-tracking
-- Downstream consumers of heading ids, in stage order: `DocumentProfileStage` (outline), `LinkResolutionStage`, `PreEngineSugaringStage` (crossref registry), engines, user filters, then in `AstTransformsStage`: `PanelTabsetTransform` → `ShortcodeResolveTransform` → `SectionizeTransform` (copies id onto section Div) → crossref → `TocGenerateTransform`. Ids must be final before `DocumentProfileStage` for the profile outline to be right.
+- `crates/pampa/src/pandoc/treesitter_utils/postprocess.rs:903` — `seen_ids: HashMap<String, usize>` local to one `postprocess()` call; `with_header` (:931) assigns `auto_generated_id` + `-N` (per-base counter) **only when `attr.0` is empty**; explicit ids are not recorded in the map.
+- `crates/quarto-core/src/stage/stages/include_expansion.rs:218` — child parsed standalone via `pampa::readers::qmd::read(...)`; fresh `seen_ids` per child.
+- `AttrSourceInfo.id` (`crates/quarto-pandoc-types/src/attr.rs:52`) discriminates auto (`None`) vs. author-written (`Some`) ids; qmd writer precedent at `writers/qmd.rs:647-649`.
+- Pipeline builders running `IncludeExpansionStage` (all covered for free by the tail placement): native render (`pipeline.rs:293`), WASM (`pipeline.rs:560`), analysis (`pipeline.rs:713`), orchestrator profile pass (`project/orchestrator.rs:1944`), plus `quarto-preview/src/config.rs:296` (dep-tracking).
+- Downstream id consumers in stage order: `DocumentProfileStage` (outline) → `LinkResolutionStage` → `PreEngineSugaringStage` → engines → user filters → `AstTransformsStage` (`PanelTabsetTransform` → `ShortcodeResolveTransform` → `SectionizeTransform` → crossref → `TocGenerateTransform`). Tail-of-include placement lands before all of them.
 
-**Reproduced at HEAD** (fixture committed at `claude-notes/plans/duplicate-heading-ids-includes-investigation/repro/`):
+**Reproduced at HEAD** (fixture at `claude-notes/plans/duplicate-heading-ids-includes-investigation/repro/`):
 
 ```
-$ cargo run --bin q2 -- render claude-notes/plans/duplicate-heading-ids-includes-investigation/repro/index.qmd
+$ cargo run --bin q2 -- render .../repro/index.qmd
 $ grep -o 'id="create-the-integration[^"]*"' .../repro/index.html
-id="create-the-integration"
-id="create-the-integration"
-id="create-the-integration"
+id="create-the-integration"   (x3)
 ```
 
-Control (`control-inline.qmd`, same three headings written inline in one file) correctly emits `create-the-integration`, `-1`, `-2` — confirming the gap is scope, not logic. (Output was inspected directly; TOC entries didn't appear in the minimal fixture because level-4 headings sit below the default `toc-depth`, but the id collision is format-independent.)
+Control (`control-inline.qmd`, same heading three times inline) correctly emits base, `-1`, `-2` — the gap is scope, not logic.
 
-## Fix shapes considered
+## Implementation plan
 
-**Option A — strand's suggestion (maximal):** the reader stops assigning auto ids ("empty = wants one"); a document-level pass on the assembled AST assigns + dedups. Cleanest semantics and the shape bd-2wv8431v eventually needs (run it after shortcode expansion too). But blast radius is large: every standalone pampa consumer (pampa CLI, wasm-qmd-parser, qmd-syntax-helper, hub-client) either needs the pass appended to its own entry point or changes behavior; the qmd writer's round-trip check and a wall of snapshots are implicated; and the pass must be wired into every pipeline builder.
+### Phase 0 — Tests first (TDD; all must fail or pin current behavior before Phase 1)
 
-**Option B — minimal (recommended):** keep the reader as-is; add a document-level **re-dedup pass over the assembled AST** that recomputes ids for exactly the headers with `attr_source.id.is_none()` (auto-assigned): reset to `auto_generated_id(content)`, re-dedup in document order with one fresh map. Deterministic, idempotent (a no-include document is unchanged, since the per-parse pass already produced the document-level answer), and it does **not** make fragment parses depend on splice position — the fragment parse stays independently cacheable; only the assembled document is renumbered. No parser, writer, or snapshot churn. Does not advance bd-2wv8431v, but that strand is p4 and deferred by explicit decision.
+pampa (uniqueIdent semantics in the reader — Decision 5):
 
-**Rejected (by the strand, agreed):** threading a shared `seen_ids` into child parses — makes parse results position-dependent.
+- [ ] Explicit `{#foo}` then auto heading "Foo" → `foo-1` (fails today: emits colliding `foo`).
+- [ ] Explicit `{#foo-1}` present, then two auto "Foo" headings → `foo`, `foo-2` (set-probe, not counter — fails today).
+- [ ] Auto heading "Foo" then explicit `{#foo}` → explicit id kept verbatim (pin: explicit never renamed).
+- [ ] Empty-content heading base-id edge case: check `auto_generated_id` output for empty inlines against pandoc's `section` fallback; pin whatever we decide.
+- [ ] qmd-writer round-trip: a deduped header (`foo-1`) round-trips with an explicit `{#foo-1}` (existing behavior for `-N` ids — pin it).
 
-## Proposed phases (draft — assumes Option B; renumber if A is chosen)
+quarto-core (the filed bug):
 
-- **Phase 0 — Test plan (TDD).**
-  - quarto-core integration test: repeated include → ids `x`, `x-1`, `x-2` (fails today).
-  - Control: inline repeats unchanged; explicit `{#id}` headings never renumbered (fails-safe today, pins behavior).
-  - Nested include (`a.qmd` includes `b.qmd` twice, each carrying a heading).
-  - Profile test: `DocumentProfileStage` outline sees deduped ids (extends `document_profile_pipeline.rs`).
-  - E2e per CLAUDE.md: `q2 render` of the committed fixture, inspect HTML (and a TOC-visible variant with `toc-depth: 4` to pin the scroll-target fix).
-- **Phase 1 — Document-level re-dedup pass** (function over `Pandoc`, lives in pampa or quarto-core — see Q2) + unit tests.
-- **Phase 2 — Wire into the pipeline** at the chosen placement; confirm all four builders + `quarto-preview` are covered; WASM leg via full `cargo xtask verify`.
-- **Phase 3 (optional, see Q4) — duplicate-explicit-id diagnostic** (new Q-code, catalog entry + `docs/errors/` page in the same commit per lint rule).
-- **Phase N — Docs** (if user-visible behavior notes are warranted) + close-out; comment on br-duplicate-heading-ids-ye3j3gkr in the connect-docs skein after a release ships the fix.
+- [ ] Integration test: repeated include → `x`, `x-1`, `x-2` (fails today). Extend `crates/quarto-core/tests/integration/` per the integration-test layout rule (module inside the `integration` binary).
+- [ ] Nested include (a.qmd includes b.qmd twice; b carries a heading).
+- [ ] Mixed ordering, Q1 parity: inline "H" then included "H" → included gets `-1`; included "H" then inline "H" → *inline* gets `-1` (this is the case that forces whole-document recompute).
+- [ ] Explicit `{#id}` inside an included file, included twice → both keep the id verbatim (no renaming), pinning Decision 4's premise.
+- [ ] No-include document passes through `IncludeExpansionStage` unchanged (the gate).
+- [ ] Profile outline: `DocumentProfileStage` sees deduped ids (extend `document_profile_pipeline.rs`).
 
-## Open design questions for the user
+End-to-end (per CLAUDE.md):
 
-1. **Fix shape.** Option B (document-level re-dedup of auto ids, keyed off `attr_source.id.is_none()`) or Option A (reader stops assigning; document-level assignment — the bd-2wv8431v-compatible shape)? I recommend **B**: it fixes the filed bug with a small, testable surface, and A remains available later since B's pass is exactly where A's assignment would live.
-2. **Placement.** (a) Tail of `IncludeExpansionStage::run()` — every builder gets it for free, invariant stays local ("after this stage, auto ids are document-unique"); or (b) a separate stage/pass added to each of the four builders — cleaner separation, but four call sites to keep in sync (and future builders can forget it). I lean (a).
-3. **Engine-output headings.** Q1 assigns ids *after* the engine runs (knitr/jupyter output is part of the text pandoc parses); q2's `EngineExecutionStage` runs after include expansion, so a heading emitted by a code cell could still collide post-fix. Fixing that would mean renumbering *after* engines — but `DocumentProfileStage` (outline) runs pre-engine and wants final ids, so there's a real tension. Treat as out of scope + file a follow-up strand, or fold in now?
-4. **Duplicate explicit `{#id}` diagnostic.** The fix deliberately never renumbers author-written ids, and today nothing warns when two collide. In scope here (new Q-code + docs page), or a follow-up strand?
-5. **Dedup universe.** Pandoc's `uniqueIdent` avoids collisions against *all* seen ids, including explicit ones (auto heading "Foo" after an explicit `{#foo}` becomes `foo-1`); q2's current pass dedups only among auto ids. Preserve current (auto-only) semantics at document level, or seed the map with explicit ids for closer pandoc parity? (Auto-only is the no-surprise choice; parity is a one-liner but changes ids in documents that mix the two.)
+- [ ] `cargo run --bin q2 -- render` on the committed fixture; inspect HTML for `x`, `x-1`, `x-2`; add a `toc-depth: 4` variant and inspect distinct `data-scroll-target`s.
 
-## Risks / tradeoffs (draft)
+### Phase 1 — pampa: shared uniqueIdent routine
 
-- Any renumbering changes ids some site may already link to — but those links were ambiguous/dead anyway; Q1 parity is the defensible target.
-- The re-dedup pass must recompute with the same `auto_generated_id` the reader used (content is pre-shortcode-expansion at that point; `Shortcode` inlines are skipped by explicit decision — bd-2wv8431v) or ids would drift from the per-parse result in the no-include case.
-- `attr_source.id.is_none()` as the "auto id" discriminator must hold for all header producers; the qmd writer already relies on it, which is good precedent, but engine-spliced or transform-fabricated headers should be spot-checked.
-- Snapshot churn expected to be zero for Option B (no-include documents are fixpoints); any churn that does appear is a red flag worth review, per the CLAUDE.md snapshot policy.
+- [ ] Extract a document-level routine (working name `assign_unique_heading_ids(&mut Pandoc)`) in `pampa` (near `utils::autoid`): walk headers in document order; maintain `HashSet<String>` of used ids; for `attr_source.id.is_some()` insert verbatim; for auto headers recompute `auto_generated_id(content)` and probe `base`, `base-1`, `base-2`, …; write result and leave `attr_source.id` as `None`.
+- [ ] Restructure `postprocess()` to use it: `with_header` keeps attr-extraction/linebreak handling but stops assigning ids; the routine runs as a whole-doc pass at the end of postprocess. Single source of truth for both call sites.
+- [ ] Traversal scope must match current `with_header` filter reach (headers inside divs, blockquotes, list items, etc.).
+- [ ] Run pampa + workspace snapshots; expected churn: only documents mixing explicit and auto ids that now probe differently (intended, Decision 5). Audit and report per the snapshot policy.
+
+### Phase 2 — quarto-core: wire into IncludeExpansionStage
+
+- [ ] At the tail of `run()`, if ≥1 include was expanded, run `assign_unique_heading_ids` over the assembled `Pandoc`.
+- [ ] Doc-comment the stage invariant: "after this stage, heading auto ids are document-unique (uniqueIdent semantics)". Note bd-4qjl87ax as the known post-engine gap.
+- [ ] Confirm coverage of all builders (native/WASM/analysis/orchestrator) via the Phase 0 integration tests where practical.
+
+### Phase 3 — Verification & close-out
+
+- [ ] `cargo build --workspace`, `cargo nextest run --workspace`.
+- [ ] Full `cargo xtask verify` (quarto-core changed → WASM leg affected).
+- [ ] E2e render inspection recorded in the session transcript (invocation + output snippet).
+- [ ] Optional: re-run the site-wide duplicate-id scan on the connect-docs port to confirm 7 → 0.
+- [ ] Close strand; comment on br-duplicate-heading-ids-ye3j3gkr (connect-docs skein) that the fix needs the next q2 release to verify there.
+- [ ] If user opts in on the diagnostic (Decision 4): file the follow-up strand.
+
+## Risks / tradeoffs
+
+- **Intended id changes beyond the filed bug:** Decision 5 changes ids in documents mixing explicit and auto ids (`foo` → `foo-1` after an explicit `{#foo}`). Q1-parity is the defensible target; snapshot diffs must be audited, not rubber-stamped.
+- The doc-level pass recomputes with the same `auto_generated_id` the reader used (pre-shortcode-expansion content; `Shortcode` inlines skipped by explicit decision — bd-2wv8431v), so recompute-to-same-value holds for untouched headers.
+- `attr_source.id.is_none()` as the auto-id discriminator: qmd writer precedent is strong; spot-check transform-fabricated headers (none should exist pre-include-expansion, but verify).
+- Duplicated-logic risk is retired by sharing one routine between postprocess and the stage (Phase 1).
+- Deduped ids round-trip through the qmd writer as explicit `{#foo-1}` (writer's suppress-check compares against the recomputed base). Existing behavior; pinned in Phase 0.

--- a/claude-notes/plans/duplicate-heading-ids-includes-investigation/README.md
+++ b/claude-notes/plans/duplicate-heading-ids-includes-investigation/README.md
@@ -1,0 +1,11 @@
+# bd-duplicate-heading-ids-mou5z7ux investigation fixtures
+
+Minimal repro for the include-boundary heading-id collision, mirroring
+the external repro at ~/repos/github/cscheid/q2-connect-docs/llms-info/repros/duplicate-heading-ids/.
+
+- `repro/index.qmd` — includes `_shared.qmd` three times; at main @ 4eaede00,
+  `q2 render` emits `id="create-the-integration"` three times (expected: base, -1, -2).
+- `repro/control-inline.qmd` — same heading repeated inline; correctly emits base, -1, -2.
+
+Run: `cargo run --bin q2 -- render claude-notes/plans/duplicate-heading-ids-includes-investigation/repro/index.qmd`
+then grep the emitted HTML for `id="create-the-integration`.

--- a/claude-notes/plans/duplicate-heading-ids-includes-investigation/README.md
+++ b/claude-notes/plans/duplicate-heading-ids-includes-investigation/README.md
@@ -4,8 +4,12 @@ Minimal repro for the include-boundary heading-id collision, mirroring
 the external repro at ~/repos/github/cscheid/q2-connect-docs/llms-info/repros/duplicate-heading-ids/.
 
 - `repro/index.qmd` — includes `_shared.qmd` three times; at main @ 4eaede00,
-  `q2 render` emits `id="create-the-integration"` three times (expected: base, -1, -2).
-- `repro/control-inline.qmd` — same heading repeated inline; correctly emits base, -1, -2.
+  `q2 render` emitted `id="create-the-integration"` three times (expected: base, -1, -2).
+  Fixed by the scoped uniqueIdent pass (branch braid/bd-duplicate-heading-ids-mou5z7ux).
+- `repro/toc-variant.qmd` — same, with `toc-depth: 4` so the headings reach the
+  TOC; post-fix each TOC entry carries a distinct `data-scroll-target`.
+- `repro/control-inline.qmd` — same heading repeated inline; correctly emits
+  base, -1, -2 both before and after the fix (reader per-parse dedup).
 
 Run: `cargo run --bin q2 -- render claude-notes/plans/duplicate-heading-ids-includes-investigation/repro/index.qmd`
 then grep the emitted HTML for `id="create-the-integration`.

--- a/claude-notes/plans/duplicate-heading-ids-includes-investigation/repro/_shared.qmd
+++ b/claude-notes/plans/duplicate-heading-ids-includes-investigation/repro/_shared.qmd
@@ -1,0 +1,3 @@
+#### Create the integration
+
+Shared boilerplate, included once per provider.

--- a/claude-notes/plans/duplicate-heading-ids-includes-investigation/repro/control-inline.qmd
+++ b/claude-notes/plans/duplicate-heading-ids-includes-investigation/repro/control-inline.qmd
@@ -1,0 +1,11 @@
+#### Create the integration
+
+A
+
+#### Create the integration
+
+B
+
+#### Create the integration
+
+C

--- a/claude-notes/plans/duplicate-heading-ids-includes-investigation/repro/index.qmd
+++ b/claude-notes/plans/duplicate-heading-ids-includes-investigation/repro/index.qmd
@@ -1,0 +1,16 @@
+---
+title: Repeated heading text
+toc: true
+---
+
+## Provider A
+
+{{< include _shared.qmd >}}
+
+## Provider B
+
+{{< include _shared.qmd >}}
+
+## Provider C
+
+{{< include _shared.qmd >}}

--- a/claude-notes/plans/duplicate-heading-ids-includes-investigation/repro/toc-variant.qmd
+++ b/claude-notes/plans/duplicate-heading-ids-includes-investigation/repro/toc-variant.qmd
@@ -1,0 +1,17 @@
+---
+title: Repeated heading text
+toc: true
+toc-depth: 4
+---
+
+## Provider A
+
+{{< include _shared.qmd >}}
+
+## Provider B
+
+{{< include _shared.qmd >}}
+
+## Provider C
+
+{{< include _shared.qmd >}}

--- a/crates/pampa/src/utils/autoid.rs
+++ b/crates/pampa/src/utils/autoid.rs
@@ -3,7 +3,11 @@
  * Copyright (c) 2025 Posit, PBC
  */
 
-use crate::pandoc::{Inline, Inlines};
+use std::collections::HashSet;
+
+use crate::filter_context::FilterContext;
+use crate::filters::{Filter, FilterReturn::Unchanged, topdown_traverse};
+use crate::pandoc::{Header, Inline, Inlines, Pandoc};
 
 /// Identifier Pandoc falls back to when a heading's text yields nothing.
 ///
@@ -133,4 +137,80 @@ pub fn auto_generated_id(inlines: &Inlines) -> String {
     } else {
         ident.to_string()
     }
+}
+
+/// Re-derive and disambiguate the auto-generated ids of a *subset* of a
+/// document's headers, using Pandoc's `uniqueIdent` probe.
+///
+/// `in_scope` selects which headers are **renameable**; a header is
+/// only ever renamed when it is in scope *and* its id was
+/// auto-generated (`attr_source.id.is_none()` — author-written `{#id}`
+/// attributes are never touched, in or out of scope). The collision
+/// seen-set, by contrast, is **document-wide**: it is seeded with every
+/// non-renameable header id (explicit ids anywhere, plus all ids of
+/// out-of-scope headers), so a renameable header collides with — and
+/// probes past — ids it must coexist with, wherever they live.
+///
+/// The probe matches Pandoc's `uniqueIdent`: recompute the base with
+/// [`auto_generated_id`], take it if free, otherwise the first free
+/// `base-1`, `base-2`, …. Set membership, not a per-base counter — an
+/// explicit `{#base-1}` elsewhere pushes the probe to `base-2`.
+///
+/// Scoping is the caller's policy. `IncludeExpansionStage` passes
+/// "headers spliced in from an included file" so that a fragment
+/// included twice stops emitting the same id twice while everything
+/// outside the includes keeps the ids the reader assigned
+/// (bd-duplicate-heading-ids-mou5z7ux); a future post-engine pass can
+/// re-run the same routine scoped to engine-inserted headers
+/// (bd-4qjl87ax). Because assigned ids join the seen-set and
+/// out-of-scope ids are never rewritten, repeated applications over
+/// disjoint scopes compose: once assigned, an id is stable.
+pub fn dedup_scoped_heading_ids<F>(doc: Pandoc, mut in_scope: F) -> Pandoc
+where
+    F: FnMut(&Header) -> bool,
+{
+    // Lookup-only set (never iterated): probing order is document
+    // order, so the output is deterministic regardless of hash order.
+    let mut seen: HashSet<String> = HashSet::new();
+
+    // Pass 1: seed the seen-set with every id this pass must not
+    // rename — explicit ids anywhere, and all out-of-scope header ids.
+    let doc = {
+        let mut filter = Filter::new().with_header(|header, _ctx| {
+            let renameable = header.attr_source.id.is_none() && in_scope(&header);
+            if !renameable && !header.attr.0.is_empty() {
+                seen.insert(header.attr.0.clone());
+            }
+            Unchanged(header)
+        });
+        topdown_traverse(doc, &mut filter, &mut FilterContext::new())
+    };
+
+    // Pass 2: walk renameable headers in document order, probing each
+    // recomputed base against the set. Mutating and returning
+    // `Unchanged` (the postprocess `with_cite` precedent) keeps normal
+    // recursion into the header's content without re-applying the
+    // filter to the header itself — a `FilterResult(_, true)` re-visit
+    // would find its own id in the set and rename it again.
+    let mut filter = Filter::new().with_header(|mut header, _ctx| {
+        if header.attr_source.id.is_none() && in_scope(&header) {
+            let base = auto_generated_id(&header.content);
+            let unique = if seen.contains(&base) {
+                let mut n = 1usize;
+                loop {
+                    let candidate = format!("{base}-{n}");
+                    if !seen.contains(&candidate) {
+                        break candidate;
+                    }
+                    n += 1;
+                }
+            } else {
+                base
+            };
+            seen.insert(unique.clone());
+            header.attr.0 = unique;
+        }
+        Unchanged(header)
+    });
+    topdown_traverse(doc, &mut filter, &mut FilterContext::new())
 }

--- a/crates/pampa/tests/integration/test_heading_auto_id.rs
+++ b/crates/pampa/tests/integration/test_heading_auto_id.rs
@@ -277,3 +277,135 @@ fn test_auto_id_distinct_quoted_headings_do_not_collide() {
     let ids = heading_ids("## Using a \"raw\" volume\n\n## Using a \"cooked\" volume\n");
     assert_eq!(ids, vec!["using-a-raw-volume", "using-a-cooked-volume"]);
 }
+
+// ============================================================================
+// qmd writer round-trip of deduplicated ids
+// (bd-duplicate-heading-ids-mou5z7ux Phase 0 pin)
+// ============================================================================
+
+#[test]
+fn test_deduped_id_roundtrips_as_explicit_attr() {
+    // A deduplicated auto id (`setup-1`) no longer equals what
+    // `auto_generated_id` would recompute from the heading content
+    // (`setup`), so the qmd writer must emit it as an explicit `{#setup-1}`
+    // — otherwise a re-parse would reassign ids and anchors would drift.
+    // This applies identically to ids assigned by the document-level
+    // scoped-dedup pass, which also leaves `attr_source.id` as `None`.
+    let (ast, _, _) = pampa::readers::qmd::read(
+        b"## Setup\n\nFirst.\n\n## Setup\n\nSecond.\n",
+        false,
+        "test.qmd",
+        &mut std::io::sink(),
+        true,
+        None,
+    )
+    .expect("Failed to parse QMD");
+
+    let mut buf = Vec::new();
+    pampa::writers::qmd::write(&ast, &mut buf).expect("Failed to write QMD");
+    let written = String::from_utf8(buf).expect("utf8");
+
+    assert!(
+        !written.contains("{#setup}"),
+        "the first heading's id matches its recomputed base and must be \
+         suppressed; got:\n{written}"
+    );
+    assert!(
+        written.contains("## Setup {#setup-1}"),
+        "the deduped heading must round-trip with an explicit id; got:\n{written}"
+    );
+}
+
+// ============================================================================
+// dedup_scoped_heading_ids (bd-duplicate-heading-ids-mou5z7ux)
+//
+// Unit tests for the scoped uniqueIdent routine. Include-splicing is
+// simulated by parsing fragments separately (so the reader assigns each a
+// fresh per-parse id, exactly like IncludeExpansionStage's standalone child
+// parses) and concatenating their blocks; the scope predicate then selects
+// the "injected" headers by level, standing in for the stage's file-id
+// provenance test.
+// ============================================================================
+
+fn parse_blocks(input: &str) -> Vec<Block> {
+    let (pandoc, _, _) = pampa::readers::qmd::read(
+        input.as_bytes(),
+        false,
+        "test.qmd",
+        &mut std::io::sink(),
+        true,
+        None,
+    )
+    .expect("Failed to parse QMD");
+    pandoc.blocks
+}
+
+fn doc_from_blocks(blocks: Vec<Block>) -> pampa::pandoc::Pandoc {
+    pampa::pandoc::Pandoc {
+        meta: Default::default(),
+        blocks,
+    }
+}
+
+fn header_ids_in(doc: &pampa::pandoc::Pandoc) -> Vec<String> {
+    doc.blocks
+        .iter()
+        .filter_map(|b| match b {
+            Block::Header(h) => Some(h.attr.0.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+#[test]
+fn test_dedup_scoped_renames_only_in_scope() {
+    // "## H" (main) and "### H" (fragment) parsed separately both get `h`.
+    let mut blocks = parse_blocks("## H\n");
+    blocks.extend(parse_blocks("### H\n"));
+    let doc =
+        pampa::utils::autoid::dedup_scoped_heading_ids(doc_from_blocks(blocks), |h| h.level == 3);
+    assert_eq!(header_ids_in(&doc), vec!["h", "h-1"]);
+}
+
+#[test]
+fn test_dedup_scoped_probe_is_set_membership_not_counter() {
+    // An explicit `{#h-1}` outside the scope forces the probe to skip it.
+    let mut blocks = parse_blocks("## Other {#h-1}\n");
+    blocks.extend(parse_blocks("### H\n"));
+    blocks.extend(parse_blocks("### H\n"));
+    let doc =
+        pampa::utils::autoid::dedup_scoped_heading_ids(doc_from_blocks(blocks), |h| h.level == 3);
+    assert_eq!(header_ids_in(&doc), vec!["h-1", "h", "h-2"]);
+}
+
+#[test]
+fn test_dedup_scoped_explicit_ids_in_scope_untouched() {
+    // Explicit ids are never renamed even when in scope and colliding.
+    let mut blocks = parse_blocks("### Stable {#stable}\n");
+    blocks.extend(parse_blocks("### Stable {#stable}\n"));
+    let doc =
+        pampa::utils::autoid::dedup_scoped_heading_ids(doc_from_blocks(blocks), |h| h.level == 3);
+    assert_eq!(header_ids_in(&doc), vec!["stable", "stable"]);
+}
+
+#[test]
+fn test_dedup_scoped_empty_scope_is_identity() {
+    let mut blocks = parse_blocks("## H\n");
+    blocks.extend(parse_blocks("## H\n"));
+    let doc = pampa::utils::autoid::dedup_scoped_heading_ids(doc_from_blocks(blocks), |_| false);
+    // Both keep the colliding reader-assigned id: nothing is in scope.
+    assert_eq!(header_ids_in(&doc), vec!["h", "h"]);
+}
+
+#[test]
+fn test_dedup_scoped_recompute_ignores_fragment_internal_numbering() {
+    // A fragment with two identical headings parses to `h`, `h-1`
+    // internally. The scoped pass recomputes from content, so after an
+    // out-of-scope `h` is seeded, the fragment's pair probes to `h-1`,
+    // `h-2` — not `h-1`, `h-1-1`.
+    let mut blocks = parse_blocks("## H\n");
+    blocks.extend(parse_blocks("### H\n\n### H\n"));
+    let doc =
+        pampa::utils::autoid::dedup_scoped_heading_ids(doc_from_blocks(blocks), |h| h.level == 3);
+    assert_eq!(header_ids_in(&doc), vec!["h", "h-1", "h-2"]);
+}

--- a/crates/quarto-core/src/stage/stages/include_expansion.rs
+++ b/crates/quarto-core/src/stage/stages/include_expansion.rs
@@ -81,7 +81,36 @@ impl PipelineStage for IncludeExpansionStage {
         let doc_path = doc.path.clone();
         include_stack.insert(doc_path.clone());
 
-        expand_includes_in_blocks(&mut doc, ctx, &doc_path, &mut include_stack)?;
+        let injected_file_ids =
+            expand_includes_in_blocks(&mut doc, ctx, &doc_path, &mut include_stack)?;
+
+        // Post-expansion invariant (bd-duplicate-heading-ids-mou5z7ux):
+        // auto-generated ids of include-injected headers are unique
+        // against the whole document, via pandoc's `uniqueIdent` probe.
+        // Only injected headers are ever renamed — ids assigned before
+        // this stage (the reader's per-parse dedup) are stable, so the
+        // stage is a strict no-op on documents without includes, and a
+        // future post-engine pass can re-run the same routine scoped to
+        // engine-inserted headers without invalidating ids downstream
+        // consumers (DocumentProfileStage's outline, cross-doc links)
+        // have already observed (bd-4qjl87ax). Known gap, by that same
+        // decision: a heading emitted by a code cell can still collide
+        // (engines run after this stage).
+        if !injected_file_ids.is_empty() {
+            let ast = std::mem::replace(
+                &mut doc.ast,
+                quarto_pandoc_types::pandoc::Pandoc {
+                    meta: quarto_pandoc_types::config_value::ConfigValue::default(),
+                    blocks: Vec::new(),
+                },
+            );
+            doc.ast = pampa::utils::autoid::dedup_scoped_heading_ids(ast, |header| {
+                header
+                    .source_info
+                    .root_file_id()
+                    .is_some_and(|id| injected_file_ids.contains(&id))
+            });
+        }
 
         Ok(PipelineData::DocumentAst(doc))
     }
@@ -89,12 +118,17 @@ impl PipelineStage for IncludeExpansionStage {
 
 /// Document-level entry point: expand include shortcodes at every
 /// block-list position in the AST (bd-1fz3vh99), recursively.
+///
+/// Returns the set of `FileId`s registered for spliced-in include
+/// content — the provenance record for the post-expansion heading-id
+/// dedup (bd-duplicate-heading-ids-mou5z7ux). Empty iff no include was
+/// expanded.
 fn expand_includes_in_blocks(
     doc: &mut DocumentAst,
     ctx: &mut StageContext,
     current_file: &Path,
     include_stack: &mut HashSet<PathBuf>,
-) -> Result<(), PipelineError> {
+) -> Result<HashSet<quarto_source_map::FileId>, PipelineError> {
     // Destructure so the expander can hold the document-level state
     // alongside a mutable borrow of the block tree.
     let DocumentAst {
@@ -104,14 +138,17 @@ fn expand_includes_in_blocks(
         recorded_includes,
         ..
     } = doc;
+    let mut injected_file_ids = HashSet::new();
     let mut expander = IncludeExpander {
         ctx,
         ast_context,
         source_context,
         recorded_includes,
         include_stack,
+        injected_file_ids: &mut injected_file_ids,
     };
-    expander.expand_blocks(&mut ast.blocks, current_file)
+    expander.expand_blocks(&mut ast.blocks, current_file)?;
+    Ok(injected_file_ids)
 }
 
 /// Walks the block tree expanding include shortcodes, carrying the
@@ -125,6 +162,13 @@ struct IncludeExpander<'a> {
     source_context: &'a mut quarto_source_map::SourceContext,
     recorded_includes: &'a mut Vec<IncludeEntry>,
     include_stack: &'a mut HashSet<PathBuf>,
+    /// `FileId`s registered for spliced-in include content (one per
+    /// include occurrence, nested levels included). This is the
+    /// provenance record the post-expansion heading-id dedup keys on:
+    /// a header whose `SourceInfo` roots in one of these files was
+    /// injected by this stage (bd-duplicate-heading-ids-mou5z7ux).
+    /// Lookup-only set — never iterated.
+    injected_file_ids: &'a mut HashSet<quarto_source_map::FileId>,
 }
 
 impl IncludeExpander<'_> {
@@ -349,6 +393,12 @@ impl IncludeExpander<'_> {
             // (still a stable identifier for hashing). Dedupe so a
             // child included twice in different positions appears once.
             record_include(self.recorded_includes, &canonical, &content);
+
+            // The child's blocks are about to be spliced in; remember
+            // their FileId so the post-expansion heading-id dedup can
+            // recognize them as injected. (Error paths above never get
+            // here — nothing was spliced, nothing to record.)
+            self.injected_file_ids.insert(new_file_id);
 
             // Recursively expand the included blocks BEFORE splicing:
             // nested includes resolve against the included file's own
@@ -2197,6 +2247,35 @@ mod tests {
         assert_eq!(
             first_code_text(&doc.ast.blocks),
             "{{< meta version >}}\nspliced"
+        );
+    }
+
+    #[tokio::test]
+    async fn no_include_document_ast_is_untouched() {
+        // The heading-id dedup at the tail of `run()` gates on "at
+        // least one include was expanded": a document with no includes
+        // must come out of the stage with a bit-identical AST
+        // (bd-duplicate-heading-ids-mou5z7ux, design decision 2).
+        let runtime = Arc::new(MockFileRuntime::new(vec![]));
+        let mut ctx = make_stage_context(runtime);
+        let doc = parse_to_doc_ast(
+            "## Setup\n\nFirst.\n\n## Setup\n\nSecond.\n",
+            "/project/doc.qmd",
+        );
+        let before = doc.ast.clone();
+
+        let out = IncludeExpansionStage::new()
+            .run(PipelineData::DocumentAst(doc), &mut ctx)
+            .await
+            .expect("stage runs");
+        let PipelineData::DocumentAst(doc) = out else {
+            panic!("stage must return DocumentAst");
+        };
+
+        assert!(ctx.diagnostics.is_empty(), "{:?}", ctx.diagnostics);
+        assert_eq!(
+            doc.ast, before,
+            "a document with no includes must pass through the stage unchanged"
         );
     }
 

--- a/crates/quarto-core/tests/integration/document_profile_pipeline.rs
+++ b/crates/quarto-core/tests/integration/document_profile_pipeline.rs
@@ -412,6 +412,53 @@ async fn profile_sees_heading_from_included_file() {
     );
 }
 
+/// Walk an outline (and nested children) collecting entry ids in
+/// document order.
+fn collect_outline_ids(outline: &[pampa::toc::TocEntry]) -> Vec<String> {
+    fn walk(entry: &pampa::toc::TocEntry, out: &mut Vec<String>) {
+        out.push(entry.id.clone());
+        for child in &entry.children {
+            walk(child, out);
+        }
+    }
+    let mut ids = Vec::new();
+    for entry in outline {
+        walk(entry, &mut ids);
+    }
+    ids
+}
+
+#[tokio::test]
+async fn profile_outline_ids_deduped_across_includes() {
+    // bd-duplicate-heading-ids-mou5z7ux: the scoped uniqueIdent pass
+    // runs at the tail of IncludeExpansionStage, i.e. *before* the
+    // DocumentProfile checkpoint — so the profile outline (consumed by
+    // sidebars, cross-doc links, incremental rebuilds) must already see
+    // the disambiguated ids, not three copies of the same one.
+    let temp = tempfile::TempDir::new().expect("tempdir");
+    let project_dir = temp
+        .path()
+        .canonicalize()
+        .unwrap_or_else(|_| temp.path().to_path_buf());
+
+    let child_path = project_dir.join("child.qmd");
+    std::fs::write(&child_path, "## Child Heading\n\nChild body.\n").expect("write child");
+
+    let parent_path = project_dir.join("parent.qmd");
+    let parent_content: &[u8] = b"---\ntitle: Parent\n---\n\n\
+        {{< include child.qmd >}}\n\n{{< include child.qmd >}}\n";
+
+    let bundle = run_head_pipeline_in_dir(&project_dir, &parent_path, parent_content).await;
+
+    let ids = collect_outline_ids(&bundle.profile.outline);
+    assert_eq!(
+        ids,
+        vec!["child-heading", "child-heading-1"],
+        "profile outline must carry disambiguated ids \
+         (bd-duplicate-heading-ids-mou5z7ux); got: {ids:?}"
+    );
+}
+
 #[tokio::test]
 async fn profile_records_direct_include_in_includes_field() {
     // bd-r82e: a parent that pulls in `{{< include child.qmd >}}`

--- a/crates/quarto-core/tests/integration/include_heading_id_dedup.rs
+++ b/crates/quarto-core/tests/integration/include_heading_id_dedup.rs
@@ -1,0 +1,258 @@
+/*
+ * tests/integration/include_heading_id_dedup.rs
+ * Copyright (c) 2026 Posit, PBC
+ *
+ * Heading-id disambiguation across include boundaries
+ * (bd-duplicate-heading-ids-mou5z7ux).
+ */
+
+//! A fragment carrying a heading, included more than once, must not
+//! emit the same auto-generated id verbatim every time. The fix is a
+//! **scoped uniqueIdent** pass at the tail of `IncludeExpansionStage`:
+//! pandoc's probe algorithm (`base`, `base-1`, `base-2`, … against a
+//! seen-set), where the *renameable* set is only the include-injected
+//! auto headers but the *seen-set* is the whole document.
+//!
+//! Deliberate divergences from Quarto 1, pinned here so they stay
+//! conscious decisions rather than drift (design round 2, plan
+//! `claude-notes/plans/2026-08-18-duplicate-heading-ids-includes.md`):
+//!
+//! - When an included heading *precedes* an inline duplicate, the
+//!   *included* one is renamed (Q1's whole-document counter would
+//!   rename the later, inline one). Inline headers are never
+//!   renameable.
+//! - Author-written `{#id}` attributes are never renamed, even when
+//!   they collide (a diagnostic for that case is bd-8wf5brc8).
+//!
+//! These tests drive the full HTML pipeline via `render_fixture` and
+//! assert on the emitted section ids in document order.
+
+use crate::include_expansion_diagnostics::render_fixture;
+
+/// Collect `id="..."` attribute values from `html`, in document order,
+/// keeping only ids equal to `base` or `base-<digits>`.
+fn ids_with_base(html: &str, base: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut rest = html;
+    while let Some(pos) = rest.find("id=\"") {
+        let after = &rest[pos + 4..];
+        let Some(end) = after.find('"') else { break };
+        let id = &after[..end];
+        let is_match = id == base
+            || (id.len() > base.len() + 1
+                && id.starts_with(base)
+                && id.as_bytes()[base.len()] == b'-'
+                && id[base.len() + 1..].bytes().all(|b| b.is_ascii_digit()));
+        if is_match {
+            out.push(id.to_string());
+        }
+        rest = &after[end..];
+    }
+    out
+}
+
+/// The filed repro: one heading in a shared fragment, included once per
+/// provider section. Expected: `create-the-integration`, `-1`, `-2` —
+/// matching Quarto 1 exactly (pure-include repetition).
+#[tokio::test]
+async fn repeated_include_disambiguates_heading_ids() {
+    let output = render_fixture(
+        &[
+            (
+                "index.qmd",
+                "## Provider A\n\n{{< include _shared.qmd >}}\n\n\
+                 ## Provider B\n\n{{< include _shared.qmd >}}\n\n\
+                 ## Provider C\n\n{{< include _shared.qmd >}}\n",
+            ),
+            (
+                "_shared.qmd",
+                "#### Create the integration\n\nShared boilerplate.\n",
+            ),
+        ],
+        "index.qmd",
+    )
+    .await;
+
+    assert_eq!(
+        ids_with_base(&output.html, "create-the-integration"),
+        vec![
+            "create-the-integration",
+            "create-the-integration-1",
+            "create-the-integration-2"
+        ],
+        "each include occurrence must get a distinct id; html was:\n{}",
+        output.html
+    );
+}
+
+/// Nested includes: the parent includes a file that itself includes the
+/// heading-carrying fragment twice. Both occurrences arrive through the
+/// recursive expansion and must be disambiguated.
+#[tokio::test]
+async fn nested_repeated_include_disambiguates() {
+    let output = render_fixture(
+        &[
+            ("index.qmd", "{{< include _a.qmd >}}\n"),
+            (
+                "_a.qmd",
+                "{{< include _b.qmd >}}\n\n{{< include _b.qmd >}}\n",
+            ),
+            ("_b.qmd", "## Fragment heading\n\nBody.\n"),
+        ],
+        "index.qmd",
+    )
+    .await;
+
+    assert_eq!(
+        ids_with_base(&output.html, "fragment-heading"),
+        vec!["fragment-heading", "fragment-heading-1"],
+        "nested include occurrences must be disambiguated; html was:\n{}",
+        output.html
+    );
+}
+
+/// An inline heading followed by an included duplicate: the included
+/// one probes to `-1`. This matches Quarto 1 (document order).
+#[tokio::test]
+async fn inline_then_included_duplicate() {
+    let output = render_fixture(
+        &[
+            (
+                "index.qmd",
+                "## Setup\n\nInline body.\n\n{{< include _child.qmd >}}\n",
+            ),
+            ("_child.qmd", "## Setup\n\nIncluded body.\n"),
+        ],
+        "index.qmd",
+    )
+    .await;
+
+    assert_eq!(
+        ids_with_base(&output.html, "setup"),
+        vec!["setup", "setup-1"],
+        "included duplicate must probe past the inline id; html was:\n{}",
+        output.html
+    );
+}
+
+/// An included heading followed by an inline duplicate: the *included*
+/// one is renamed even though it appears first (inline headers are
+/// never renameable). Deliberate divergence from Quarto 1, which would
+/// emit `setup` (included) / `setup-1` (inline).
+#[tokio::test]
+async fn included_then_inline_duplicate_renames_the_included_one() {
+    let output = render_fixture(
+        &[
+            (
+                "index.qmd",
+                "{{< include _child.qmd >}}\n\n## Setup\n\nInline body.\n",
+            ),
+            ("_child.qmd", "## Setup\n\nIncluded body.\n"),
+        ],
+        "index.qmd",
+    )
+    .await;
+
+    assert_eq!(
+        ids_with_base(&output.html, "setup"),
+        vec!["setup-1", "setup"],
+        "the included heading is renamed; the inline one keeps its id; html was:\n{}",
+        output.html
+    );
+}
+
+/// uniqueIdent probes a *set*, not a per-base counter: with `setup-1`
+/// already taken by an explicit author id, the second included `Setup`
+/// must skip to `setup-2`.
+#[tokio::test]
+async fn probe_skips_explicitly_taken_suffix() {
+    let output = render_fixture(
+        &[
+            (
+                "index.qmd",
+                "## Other section {#setup-1}\n\nBody.\n\n\
+                 {{< include _child.qmd >}}\n\n{{< include _child.qmd >}}\n",
+            ),
+            ("_child.qmd", "## Setup\n\nIncluded body.\n"),
+        ],
+        "index.qmd",
+    )
+    .await;
+
+    assert_eq!(
+        ids_with_base(&output.html, "setup"),
+        vec!["setup-1", "setup", "setup-2"],
+        "probe must skip the explicit `setup-1`; html was:\n{}",
+        output.html
+    );
+}
+
+/// Author-written `{#id}` attributes are never renamed, even when the
+/// same fragment (and thus the same explicit id) is included twice.
+/// The resulting duplicate is invalid HTML; warning about it is
+/// bd-8wf5brc8, not this fix's job.
+#[tokio::test]
+async fn explicit_id_in_included_file_kept_verbatim() {
+    let output = render_fixture(
+        &[
+            (
+                "index.qmd",
+                "{{< include _child.qmd >}}\n\n{{< include _child.qmd >}}\n",
+            ),
+            ("_child.qmd", "## Stable heading {#stable}\n\nBody.\n"),
+        ],
+        "index.qmd",
+    )
+    .await;
+
+    assert_eq!(
+        ids_with_base(&output.html, "stable"),
+        vec!["stable", "stable"],
+        "explicit ids must never be renamed; html was:\n{}",
+        output.html
+    );
+}
+
+/// Headers outside included content are never renamed: the reader's
+/// per-parse dedup result for inline duplicates stands, and the
+/// included duplicate probes past it.
+#[tokio::test]
+async fn inline_duplicates_keep_reader_ids_included_probes_past() {
+    let output = render_fixture(
+        &[
+            (
+                "index.qmd",
+                "## Setup\n\nFirst.\n\n## Setup\n\nSecond.\n\n{{< include _child.qmd >}}\n",
+            ),
+            ("_child.qmd", "## Setup\n\nIncluded body.\n"),
+        ],
+        "index.qmd",
+    )
+    .await;
+
+    assert_eq!(
+        ids_with_base(&output.html, "setup"),
+        vec!["setup", "setup-1", "setup-2"],
+        "inline pair keeps reader-assigned ids; included probes to -2; html was:\n{}",
+        output.html
+    );
+}
+
+/// A document with no includes is untouched by the pass (the stage
+/// gates on "at least one include expanded"): the reader's per-parse
+/// dedup remains exactly what renders. Pins today's behavior.
+#[tokio::test]
+async fn no_include_document_keeps_reader_dedup() {
+    let output = render_fixture(
+        &[("index.qmd", "## Setup\n\nFirst.\n\n## Setup\n\nSecond.\n")],
+        "index.qmd",
+    )
+    .await;
+
+    assert_eq!(
+        ids_with_base(&output.html, "setup"),
+        vec!["setup", "setup-1"],
+        "inline-only documents keep reader dedup; html was:\n{}",
+        output.html
+    );
+}

--- a/crates/quarto-core/tests/integration/main.rs
+++ b/crates/quarto-core/tests/integration/main.rs
@@ -29,6 +29,7 @@ pub mod get_config_merge;
 pub mod idempotence;
 pub mod include_code_fence;
 pub mod include_expansion_diagnostics;
+pub mod include_heading_id_dedup;
 pub mod include_nested_expansion;
 pub mod include_project_absolute;
 pub mod include_resolve_pipeline;


### PR DESCRIPTION
## Summary

A fragment carrying a heading, included N times via `{{< include >}}`, emitted the same auto-generated id N times — invalid HTML, and every TOC entry pointed at the first occurrence. The reader's per-parse `seen_ids` map never saw the assembled document because `IncludeExpansionStage` parses each included file standalone (Q1 doesn't have the problem: its include is a textual splice before pandoc parses).

**Fix: a scoped uniqueIdent pass at the tail of `IncludeExpansionStage`.**

- New routine `pampa::utils::autoid::dedup_scoped_heading_ids`: pandoc's `uniqueIdent` probe (set membership over `base`, `base-1`, `base-2`, … — not a per-base counter, so an explicit `{#base-1}` pushes the probe to `base-2`) with a caller-supplied scope predicate.
- The stage scopes **renaming** to include-injected auto headers (classified by `SourceInfo` root `FileId` against the `FileId`s registered at splice time, nested includes included), while the collision **seen-set** is document-wide.
- Author-written `{#id}` attributes are never renamed (a diagnostic for explicit collisions is filed as bd-8wf5brc8).
- Documents without includes pass through bit-identical (gated; unit-tested).
- Ids are monotonic — once assigned, no later stage renames them — so the same routine can re-run post-engine scoped to engine-inserted headers (bd-4qjl87ax, the known remaining gap).

**Accepted Q1 divergence** (design decision, pinned by test): when an included heading *precedes* an inline duplicate, the *included* one is renamed (Q1's whole-document counter renames the later, inline one). Pure-include repetition — the real-world case — matches Q1 exactly.

Design record: `claude-notes/plans/2026-08-18-duplicate-heading-ids-includes.md`.

## Tests

Written first; 7 failed with the expected duplicate-id collisions before the fix:

- `crates/quarto-core/tests/integration/include_heading_id_dedup.rs` — 8 full-pipeline tests (repeated include, nested, mixed orderings both ways, set-probe vs counter, explicit-id immunity in and out of scope, no-include pin).
- `profile_outline_ids_deduped_across_includes` — the `DocumentProfileStage` outline sees final ids.
- Stage unit test pinning the no-include bit-identical gate.
- pampa: 5 unit tests for the routine + a qmd-writer round-trip pin (deduped id emitted as explicit `{#setup-1}`).

**No snapshot changes** — zero `.snap` files modified, as predicted.

## Verification

- `cargo nextest run --workspace`: 12334/12334 passed.
- Full `cargo xtask verify` green (incl. WASM/hub legs).
- E2e via `cargo run --bin q2 -- render` on the committed repro fixture: ids `create-the-integration`/`-1`/`-2` and three distinct `data-scroll-target`s; also re-rendered the originating connect-docs repro (website project) with the same result.

Follow-ups filed: bd-4qjl87ax (engine-output headings), bd-8wf5brc8 (duplicate explicit-id diagnostic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)