### PR TITLE
Headings inside tabsets, callouts and blockquotes no longer leak into the TOC

### DIFF
--- a/claude-notes/plans/2026-08-18-tabset-headings-in-toc.md
+++ b/claude-notes/plans/2026-08-18-tabset-headings-in-toc.md
@@ -332,24 +332,27 @@ q2 keeps the marker class *and* the Div, so 10 Connect-docs pages carry a
       rendered TOC omits it, because heading-consuming transforms run after the profile checkpoint.
       Filed as **bd-ca17fck0** and pinned by `outline_sees_headings_inside_divs`.
 
-## Phase 4 — End-to-end verification
+## Phase 4 — End-to-end verification ✅
 
-- [ ] `cargo nextest run --workspace`, then `cargo xtask verify` (full — pampa/quarto-core are in
-      hub-client's WASM closure).
-- [ ] Re-render the Connect corpus with the clean double-render method (see `FALLOUT-B.md` — an
-      incremental baseline invalidates the diff) and confirm: exact TOC parity with Q1 rises from
-      **421 → 444 of 451**, TOC entries added **= 0**, and the 2 `content-visible` regressions are
-      gone (target ≥ 446 once Phase 1 lands).
-- [ ] Review every changed page against Q1, not just the counts.
-- [ ] Record the invocations and observed output in this plan.
+- [x] `cargo nextest run --workspace`, then `cargo xtask verify` (full) — both green.
+- [x] Re-rendered clean. **421 → 444 of 451**, 0 entries added, and the 2 `content-visible`
+      regressions never materialized — Phase 1 removed their cause. The 444 (not 446) is because
+      those two pages carry a *separate*, pre-existing Q1-side id defect; see the Phase 3 notes.
+- [x] Reviewed every changed page against Q1: 25 closer, 426 unchanged, **0 further**. Every one
+      of the 44 removed entries was inside a `div.tab-pane` (HTML-parsed, not regex-matched); 20 of
+      them pointed into a pane with no `active` class.
+- [x] Invocations and observed output recorded in the per-phase verification sections above.
 
 ## Phase 5 — Bookkeeping
 
 - [ ] Close bd-8yjvs3bj (blockquote leak) as absorbed by Phase 3.
 - [ ] Close bd-26nryuwh (sectionize recursion) as delivered by Phase 2.
 - [x] File the conditional-content unwrap as its own strand (Phase 1) — **bd-wbnaa2ud**.
-- [ ] Docs: user-visible behavior change is "headings inside tabsets/callouts no longer appear in
-      the TOC" — check whether `docs/` says anything about TOC contents that needs updating.
+- [x] Docs: `docs/guides/authoring/tabsets.qmd:74` said tab-title headings are excluded and that
+      "deeper headings inside a tab stay part of that tab's content" — true but ambiguous, and
+      written when those headings *did* appear in the TOC. Rewritten to state the rule plainly, say
+      why, and reassure that the headings still render, get ids, and can be linked to. Rendered and
+      read the result; full `docs/` render clean (247 of 247).
 - [ ] Commit at each phase boundary; do not push without approval.
 
 ### Phase 1 verification (2026-08-18)

--- a/claude-notes/plans/2026-08-18-tabset-headings-in-toc.md
+++ b/claude-notes/plans/2026-08-18-tabset-headings-in-toc.md
@@ -482,3 +482,47 @@ The same 7 pre-existing differences remain.
 > the new `ts-packages/quarto-engine-host-deno` workspace needed `npm install`
 > after the rebase, and `@esbuild/darwin-arm64` was missing from `node_modules`
 > (optional platform dep), which failed `quarto-hub-mcp`'s bundle test.
+
+## Phase 6 — render-component fallout from Phase 2 (found by CI)
+
+PR #548's first CI run was green except **Hub-Client E2E**, where two kanban
+tests failed. Not flake, and not a test-only problem: Phase 2's sectionize
+recursion is visible to q2-preview render components, which read the AST as the
+pipeline leaves it.
+
+`kanban.tsx` scanned its own Div's direct children for `Header` blocks to build
+columns. After Phase 2 those children are section Divs, so it found none and
+rendered nothing. Reproduced outside the browser — `q2 render` on the fixture
+gives `<div class="kanban"><section id="backlog" class="section level2">` where
+it used to give `<div class="kanban"><h2 id="backlog">`.
+
+Three options were weighed (full write-up in the PR discussion): recurse only
+where the Div gets absorbed; update the component contract; or add a declaration
+mechanism so Rust can leave component-owned subtrees alone. **Rust cannot
+currently know which classes a component owns** — the binding lives in the TSX,
+which checks `classes.includes('kanban')` at render time — so the targeted skip
+was not available without new API.
+
+Worth recording: **recursion into non-absorbed Divs was never needed for the TOC
+fix.** A non-absorbed Div terminates the walk whether or not its contents are
+sectionized. The recursion buys DOM parity with Q1 and nothing else. That made
+"absorb-only recursion" a real option, at the cost of leaving bd-26nryuwh half
+delivered.
+
+**Decision (user, 2026-08-18): update the component contract.** Full Q1 DOM
+parity is kept; render-components are undocumented in `docs/` and some churn
+between components and the pipeline is expected while the API settles.
+
+- [x] `kanban.tsx` reads section Divs. The **write** path is deliberately left
+      alone — `edit.resolveSource` hands back the *source* node, which is
+      pre-transform, and emitting sections there would write them into the
+      user's `.qmd`. Both paths now carry comments saying so.
+- [x] `kanban_rc.jsx` (the copy-paste sample under `hub-client/`) had the same
+      pattern and would have shipped broken; same fix.
+- [x] Checked the other components: `comment.tsx` overrides `Block` and handles
+      a `Header` wherever it appears, so sectionizing does not hide it;
+      `drag.tsx` does not inspect headings. Both passed CI, consistent.
+- [x] Documented what a component receives, including the read/write asymmetry,
+      in `experimental-components/new/README.md`.
+- [x] Verified locally rather than by pushing and waiting: the two kanban specs
+      pass, and the full Playwright suite is **59 passed**.

--- a/claude-notes/plans/2026-08-18-tabset-headings-in-toc.md
+++ b/claude-notes/plans/2026-08-18-tabset-headings-in-toc.md
@@ -244,17 +244,25 @@ independently green, so the tree is never in a state where the TOC is wrong in a
 *remove* a TOC entry, and it is correct only once Phases 1 and 2 guarantee that every heading Q1
 lists lives in the section tree.
 
-## Phase 0 — Test harness and characterization tests
+## Phase 0 — Regression net for the rows that must keep working ✅
 
-- [ ] Promote `div-toc-probe` / `div-recursion-probe` fixtures into the workspace as a container
-      matrix: for each of {plain div, `content-visible`, `content-hidden`, `column-margin`,
-      `layout-ncol`, callout title, callout body, tabset pane, blockquote}, assert the TOC entries
-      and the section/div shape.
-- [ ] Write these as **characterization tests first** (asserting today's behavior, with the
-      divergent rows marked), so each later phase flips a known set of assertions rather than
-      landing untested behavior.
-- [ ] Route through an end-to-end entry point (`render_document_to_file` or the tabset-pipeline
-      integration style), not `render_qmd_to_html` with defaults — per CLAUDE.md's end-to-end rule.
+Revised from the original "characterization tests" idea. Writing tests that assert *today's buggy*
+behavior and flipping them later would leave the tree red across phase boundaries, which conflicts
+with the commit-at-clean-boundaries rule. Instead the fixtures split by direction:
+
+- **Phase 0** covers rows that already agree with Q1 and must not regress — these pass now and are
+  the safety net for Phase 3, the only phase that can remove an entry.
+- **Phases 1–3** each add fixtures for the rows they change: red before the fix, green after.
+
+Fixtures live in `crates/quarto/tests/smoke-all/toc-containers/` (declarative `ensureHtmlElements`
+with must-match / must-NOT-match selector lists; exercised by all three smoke-all runners — Rust,
+WASM Vitest, Playwright — which satisfies the end-to-end rule better than an in-process call).
+
+- [x] `plain-div-heading-in-toc.qmd` — a heading inside a plain Div stays listed.
+- [x] `column-margin-heading-in-toc.qmd` — same for `.column-margin`.
+- [x] `callout-title-not-in-toc.qmd` — a callout *title* stays unlisted, proving the protection is
+      the consume-first ordering rather than sectionize's reach.
+- [x] Verified the harness really exercises them (inverted one selector, watched it fail).
 
 ## Phase 1 — Conditional-content: unwrap the resolved wrapper (prerequisite)
 

--- a/claude-notes/plans/2026-08-18-tabset-headings-in-toc.md
+++ b/claude-notes/plans/2026-08-18-tabset-headings-in-toc.md
@@ -20,9 +20,20 @@ described at HEAD; what does not hold up is the explanation of *why Q1 differs*,
 >   narrow `.panel-tabset` skip does not close the bug.
 > - Recursion costs **zero test failures** (12306 passed on the spike). The blast radius feared
 >   in "Risks" below did not materialize.
-> - The three parts are **coupled**: recurse + restrict *without* pandoc's attribute-merge rule
->   under-collects (`.content-visible`, `.column-margin`, `layout-ncol` entries vanish). All
->   three must land together.
+> - The three parts are **coupled**: recurse + restrict *without* pandoc's absorb rule
+>   under-collects. All three must land together.
+>
+> **Fallout measured 2026-08-18** — full report:
+> `tabset-headings-in-toc-investigation/FALLOUT-B.md`; measured diff:
+> `…/spike-B.patch` (spike reverted). On the Connect docs port (451 pages):
+> **35 HTML pages change, 46 TOC entries removed, 0 added, and exact TOC parity
+> with Q1 goes 421 → 444.** Workspace tests: 12306 passed, 0 failed, no snapshot
+> churn. `docs/` (247 pages): 0 files changed.
+>
+> One new blocker surfaced: **2 pages regress**, and the cause is not (B). Q1
+> *unwraps* `.content-visible` Divs; q2 keeps them (10 pages corpus-wide, Q1: 0),
+> so the restricted walk stops at the Div. **(B) must be preceded by matching
+> Q1's conditional-content unwrapping**, or those 2 pages lose entries.
 > - Non-recursion is **not** what protects callout/tab titles — the transforms consume those
 >   Headers before sectionize runs. Q1 recurses and gets them right by the same mechanism.
 
@@ -159,8 +170,10 @@ phases differ substantially between them.
   asserting a `####` inside a tab does not appear in `nav#TOC`; the probe fixture promoted to a
   committed regression fixture.
 - **Phase 1 — Core change** (see design question 1).
-- **Phase 2 — Reconcile `sectionize_blocks`** (bd-26nryuwh) *(direction B only)* — recurse into Divs, merge attrs
-  when the Div id is empty, do not descend into `BlockQuote`.
+- **Phase 1.5 — Unwrap conditional-content Divs to match Q1** — a prerequisite discovered by the
+  fallout measurement; without it 2 pages lose TOC entries. Needs its own strand.
+- **Phase 2 — Reconcile `sectionize_blocks`** (bd-26nryuwh) *(direction B only)* — recurse into Divs,
+  apply pandoc's absorb rule (empty Div id + header-led run), do not descend into `BlockQuote`.
 - **Phase 3 — Sweep the fallout** — snapshots, `quarto-ast-reconcile` hashing, `llms.rs`,
   `idempotence.rs`, anything asserting on section structure.
 - **Phase 4 — Re-measure against the port** — rerun the Connect-docs chrome sweep; expect the
@@ -187,12 +200,15 @@ phases differ substantially between them.
    profile outline), or a generic pampa-owned opt-out class that quarto-core applies (clean
    layering, but applied by the transform it misses `extract_outline`, and it misses preview until
    bd-47afd5ro lands)?
-3. **Is the blockquote leak (bd-8yjvs3bj) in scope here, or does it stay its own strand?** Same root
-   cause; it falls out of (B) for free, and under (A) it needs its own two lines (delete the
-   `BlockQuote` arm).
-4. **Non-HTML and reveal formats.** `PanelTabsetTransform` self-gates to Bootstrap HTML, so
-   elsewhere the `.panel-tabset` Div passes through with headers intact. Should the TOC rule apply
-   uniformly across formats (it would under both A and B), or only where tabsets actually render?
+3. ~~**Is the blockquote leak (bd-8yjvs3bj) in scope here?**~~ **Settled:** it comes for free with
+   (B); bd-8yjvs3bj closes as absorbed once (B) lands.
+4. ~~**Non-HTML and reveal formats.**~~ **Settled: uniform.** The rule lives in pampa
+   (`sectionize_blocks` + `collect_toc_entries`), so it is format-agnostic by construction —
+   which also keeps the door open for filters that render tabsets for PDF targets. One trap to
+   carry into the plan: `SectionizeTransform` is pushed only in the non-reveal branch
+   (`pipeline.rs:1332`) while `TocGenerateTransform` is ungated (`:1387`), so a future revealjs
+   TOC would find no section tree. Verified q2 emits no `nav#TOC` for revealjs today, so this is
+   latent, not live — but sectionize should run for reveal too before anyone adds one.
 5. **How much snapshot churn is acceptable?** (B) changes rendered section markup for every heading
    nested in a Div. Worth a quick spike to count before committing to it?
 

--- a/claude-notes/plans/2026-08-18-tabset-headings-in-toc.md
+++ b/claude-notes/plans/2026-08-18-tabset-headings-in-toc.md
@@ -294,17 +294,20 @@ q2 keeps the marker class *and* the Div, so 10 Connect-docs pages carry a
 - [x] Update the module docs — the old text said surviving elements "keep their classes", which was
       the bug.
 
-## Phase 2 — `sectionize_blocks`: recurse into Divs + pandoc's absorb rule (bd-26nryuwh)
+## Phase 2 — `sectionize_blocks`: recurse into Divs + pandoc's absorb rule (bd-26nryuwh) ✅
 
-- [ ] Failing test: a heading inside a plain Div is wrapped in a section; a Div with an empty id
-      wrapping a single header-led run is absorbed, merging its classes/attrs into the section
-      (Q1: `class="level4 my-wrapper"`); a Div with a non-empty id keeps the Div and nests the
-      section inside; `BlockQuote` content is *not* sectionized.
-- [ ] Recurse into non-section Divs.
-- [ ] Implement the absorb rule. The spike's version (`spike-B.patch`) required `content.len() == 1`;
-      pandoc's real condition is a header-led run, so verify against a Div holding a section
-      *followed by* trailing blocks, and a Div holding two sibling sections.
-- [ ] Confirm the consume-first transforms still work: `CalloutTransform` / `PanelTabsetTransform`
+- [x] Failing tests — six unit tests in `sectionize.rs` plus the smoke-all fixture
+      `div-heading-becomes-section.qmd`. All six observed failing first; two of them initially
+      passed *vacuously* (satisfied by "nothing is sectionized at all") and were strengthened
+      until they failed for the right reason.
+- [x] Recurse into non-section Divs — `sectionize_div`.
+- [x] Implement the absorb rule. **The spike's `content.len() == 1` turned out to be exactly right**,
+      verified against Q1 rather than assumed — see the new probe
+      `tabset-headings-in-toc-investigation/absorb-rule-probe/`, whose five cases pin it: absorb iff
+      the Div has an **empty id** and its content is **exactly one section**; classes and key-values
+      merge onto that section. A Div with its own id, with content before the first heading, or with
+      two sibling headings is *not* absorbed.
+- [x] Confirm the consume-first transforms still work: `CalloutTransform` / `PanelTabsetTransform`
       run before sectionize and depend on **flat** Headers as direct Div children. Nothing here
       changes that, but the tabset/callout tests must stay green.
 
@@ -369,3 +372,30 @@ measurement spike — `admin/authentication/ldap-based/ldap-double-bind/index.ht
 ```
 
 (no wrapper Div; the heading is an ordinary sibling, exactly as in Q1).
+
+### Phase 2 verification (2026-08-18)
+
+`cargo xtask verify --skip-hub-build` → all steps pass (12324 Rust tests).
+`npm run test:wasm` → 131 passed.
+
+> **Stale-WASM trap, hit and confirmed.** `--skip-hub-build` leaves
+> `wasm-quarto-hub-client` built from *pre-change* Rust, and the WASM vitest
+> runner replays the whole smoke-all suite through it — so the new fixtures
+> failed there while passing natively, plus two spurious
+> "localStorage is not available for opaque origins" errors from the same stale
+> image. `npm run build:wasm` cleared all of it. Exactly the failure mode
+> CLAUDE.md documents; worth re-reading before trusting a `--skip-hub-build` run.
+
+Rendered shape now matches Q1 case for case:
+
+```html
+<section id="case-a" class="section level4 wrap-a">        <!-- absorbed -->
+<div id="has-id" class="wrap-b"><section id="case-b" …>    <!-- Div has an id -->
+<div class="wrap-c">[leading para]<section id="case-c" …> <!-- content first -->
+<blockquote><h4 id="quoted">                              <!-- not descended into -->
+```
+
+Connect corpus (clean double render): TOC changed on **0** pages — Phase 2 is
+TOC-neutral by design — while `<section>` elements rose **3626 → 3678**, i.e. 52
+headings that were bare `<hN>` inside a Div are now real sections. Exact TOC
+parity with Q1 holds at 421/451, waiting on Phase 3.

--- a/claude-notes/plans/2026-08-18-tabset-headings-in-toc.md
+++ b/claude-notes/plans/2026-08-18-tabset-headings-in-toc.md
@@ -457,3 +457,28 @@ byte-identical in their difference to the baseline:
 - `admin/process-management` — em-dash slug (`…selection---shiny…` vs `…selection-shiny…`);
 - four pages, incl. `how-to/use-renv-…`, with a pre-existing extra entry — the
   benign `toc:N` difference the strand already called out.
+
+## Re-measured after rebase onto current `main` (2026-08-18)
+
+`origin/main` moved from `5b6774d1` to `0c3542d0` during implementation, picking up
+bd-duplicate-heading-ids-mou5z7ux (heading-id dedup across include boundaries) —
+which touches the same pages. Rebased and re-measured both sides rather than
+trusting the earlier numbers.
+
+| | main `0c3542d0` | branch |
+| --- | --- | --- |
+| exact TOC match with Q1 | 421/451 | **444/451** |
+| TOC changed / entries removed / **added** | — | 25 pages / 44 / **0** |
+| vs Q1: closer / unchanged / **further** | — | 25 / 426 / **0** |
+
+All 44 removals inside a `div.tab-pane`; **18** in a pane with no `active` class.
+That dead-link count moved 20 → 18 because the id-dedup fix changed which pane a
+duplicated id resolves into — and 18 is exactly what the strand predicted.
+The same 7 pre-existing differences remain.
+
+`cargo xtask verify` (full) green on the rebased branch.
+
+> Two local environment stumbles worth noting, neither caused by this branch:
+> the new `ts-packages/quarto-engine-host-deno` workspace needed `npm install`
+> after the rebase, and `@esbuild/darwin-arm64` was missing from `node_modules`
+> (optional platform dep), which failed `quarto-hub-mcp`'s bundle test.

--- a/claude-notes/plans/2026-08-18-tabset-headings-in-toc.md
+++ b/claude-notes/plans/2026-08-18-tabset-headings-in-toc.md
@@ -230,3 +230,103 @@ phases differ substantially between them.
 - **Q1 comparison used a quarto-cli dev checkout** (`quarto --version` → `99.9.9`). The structural
   facts above (real AST from `render_tabset`; sections inside panes; the four probe rows) are
   stable behavior, not release-specific, but a release-Q1 spot-check is cheap if you want it.
+
+---
+
+# Implementation plan (approved 2026-08-18)
+
+**Direction: (B).** Branch `braid/bd-tabset-headings-in-toc-t04ie7f7` off `main` @ `0aa7cb7c`.
+
+Design questions 1–5 are settled (see above). Phases land in dependency order; each is
+independently green, so the tree is never in a state where the TOC is wrong in a *new* way.
+
+**Ordering constraint.** Phase 3 (restrict the walk) must come last: it is the only phase that can
+*remove* a TOC entry, and it is correct only once Phases 1 and 2 guarantee that every heading Q1
+lists lives in the section tree.
+
+## Phase 0 — Test harness and characterization tests
+
+- [ ] Promote `div-toc-probe` / `div-recursion-probe` fixtures into the workspace as a container
+      matrix: for each of {plain div, `content-visible`, `content-hidden`, `column-margin`,
+      `layout-ncol`, callout title, callout body, tabset pane, blockquote}, assert the TOC entries
+      and the section/div shape.
+- [ ] Write these as **characterization tests first** (asserting today's behavior, with the
+      divergent rows marked), so each later phase flips a known set of assertions rather than
+      landing untested behavior.
+- [ ] Route through an end-to-end entry point (`render_document_to_file` or the tabset-pipeline
+      integration style), not `render_qmd_to_html` with defaults — per CLAUDE.md's end-to-end rule.
+
+## Phase 1 — Conditional-content: unwrap the resolved wrapper (prerequisite)
+
+Q1's `content-hidden.lua` (`customnodes/content-hidden.lua:56`) resolves a **visible Div** by
+returning `el.content` — the wrapper disappears — after `clearHiddenVisibleAttributes` strips both
+marker classes and the condition attributes. Spans/CodeBlocks keep their element ("we keep the
+scaffolding element, as opposed to in the Div where we return the inlined content", `:154`).
+q2 keeps the marker class *and* the Div, so 10 Connect-docs pages carry a
+`<div class="content-visible">` Q1 does not emit.
+
+- [ ] Failing test: a visible `::: {.content-visible when-format="html"}` leaves no Div in the
+      output; a visible `[x]{.content-visible …}` Span keeps its Span; marker classes are gone in
+      both cases.
+- [ ] Strip the marker classes on surviving elements (Q1's `clearHiddenVisibleAttributes`).
+- [ ] Unwrap a resolved **Div** — but only what the feature itself contributed. After stripping the
+      marker class and condition attributes, unwrap iff nothing remains (empty id, no classes, no
+      attributes); otherwise keep a plain Div carrying the user's own attributes.
+      **Divergence from Q1, deliberate:** Q1 unconditionally returns `el.content`, discarding a
+      user's `#id` and extra classes. Preserving them is not lossy and costs nothing — pandoc's
+      absorb rule (Phase 2) merges an empty-id wrapper into the section anyway, so the TOC outcome
+      is identical. All 33 real uses in the Connect corpus are bare markers, where the two rules
+      coincide exactly.
+- [ ] Keep the llms two-view path intact (`.quarto-llms-omit` / `.quarto-llms-keep` markers are
+      applied *instead of* resolving; unwrapping must not fire on a marked element).
+- [ ] Update the module docs — the current text says surviving elements "keep their classes", which
+      is the bug.
+
+## Phase 2 — `sectionize_blocks`: recurse into Divs + pandoc's absorb rule (bd-26nryuwh)
+
+- [ ] Failing test: a heading inside a plain Div is wrapped in a section; a Div with an empty id
+      wrapping a single header-led run is absorbed, merging its classes/attrs into the section
+      (Q1: `class="level4 my-wrapper"`); a Div with a non-empty id keeps the Div and nests the
+      section inside; `BlockQuote` content is *not* sectionized.
+- [ ] Recurse into non-section Divs.
+- [ ] Implement the absorb rule. The spike's version (`spike-B.patch`) required `content.len() == 1`;
+      pandoc's real condition is a header-led run, so verify against a Div holding a section
+      *followed by* trailing blocks, and a Div holding two sibling sections.
+- [ ] Confirm the consume-first transforms still work: `CalloutTransform` / `PanelTabsetTransform`
+      run before sectionize and depend on **flat** Headers as direct Div children. Nothing here
+      changes that, but the tabset/callout tests must stay green.
+
+## Phase 3 — `collect_toc_entries`: walk only the section tree
+
+- [ ] Failing test: headings inside a tabset pane, a callout body, and a blockquote are absent from
+      the TOC; headings inside `content-visible` / `column-margin` / `layout-ncol` / a plain Div are
+      still present.
+- [ ] A non-section Div terminates the walk (pandoc's `sectionToListItem`).
+- [ ] Remove the `BlockQuote` arm.
+- [ ] Decide the un-sectionized fallback. `SectionizeTransform` is skipped for revealjs
+      (`pipeline.rs:1332`) while `TocGenerateTransform` is ungated (`:1387`). q2 emits no `nav#TOC`
+      for reveal today, so nothing breaks — but leave the code honest: either run sectionize for
+      reveal too, or document the precondition at `generate_toc`.
+- [ ] `document_profile.rs::extract_outline` calls `generate_toc` on the **pre-transform** AST
+      (`DocumentProfileStage` at `pipeline.rs:314` runs before `AstTransformsStage` at `:353`), so
+      its outline is un-sectionized. Check what the new rule does to it and record the answer.
+
+## Phase 4 — End-to-end verification
+
+- [ ] `cargo nextest run --workspace`, then `cargo xtask verify` (full — pampa/quarto-core are in
+      hub-client's WASM closure).
+- [ ] Re-render the Connect corpus with the clean double-render method (see `FALLOUT-B.md` — an
+      incremental baseline invalidates the diff) and confirm: exact TOC parity with Q1 rises from
+      **421 → 444 of 451**, TOC entries added **= 0**, and the 2 `content-visible` regressions are
+      gone (target ≥ 446 once Phase 1 lands).
+- [ ] Review every changed page against Q1, not just the counts.
+- [ ] Record the invocations and observed output in this plan.
+
+## Phase 5 — Bookkeeping
+
+- [ ] Close bd-8yjvs3bj (blockquote leak) as absorbed by Phase 3.
+- [ ] Close bd-26nryuwh (sectionize recursion) as delivered by Phase 2.
+- [ ] File the conditional-content unwrap as its own strand (Phase 1) so the fix is attributable.
+- [ ] Docs: user-visible behavior change is "headings inside tabsets/callouts no longer appear in
+      the TOC" — check whether `docs/` says anything about TOC contents that needs updating.
+- [ ] Commit at each phase boundary; do not push without approval.

--- a/claude-notes/plans/2026-08-18-tabset-headings-in-toc.md
+++ b/claude-notes/plans/2026-08-18-tabset-headings-in-toc.md
@@ -12,6 +12,20 @@ materially better fix than either option the strand proposes.** The bug reproduc
 described at HEAD; what does not hold up is the explanation of *why Q1 differs*, and the
 "two-line skip on `.panel-tabset`" that explanation motivates.
 
+> **Update 2026-08-18, after the recursion probe** (`tabset-headings-in-toc-investigation/div-recursion-probe/`).
+> Direction (B) is not merely "the principled option" — it is the only one that reaches parity,
+> and it is cheaper than this plan first estimated:
+>
+> - `.callout` **bodies leak too** — a third container beyond tabset panes and blockquotes. A
+>   narrow `.panel-tabset` skip does not close the bug.
+> - Recursion costs **zero test failures** (12306 passed on the spike). The blast radius feared
+>   in "Risks" below did not materialize.
+> - The three parts are **coupled**: recurse + restrict *without* pandoc's attribute-merge rule
+>   under-collects (`.content-visible`, `.column-margin`, `layout-ncol` entries vanish). All
+>   three must land together.
+> - Non-recursion is **not** what protects callout/tab titles — the transforms consume those
+>   Headers before sectionize runs. Q1 recurses and gets them right by the same mechanism.
+
 ## Issue context
 
 Filed 2026-08-18 by Carlos Scheidegger; `bug`, priority 2, label `html`, `open`. Follow-up to
@@ -184,9 +198,13 @@ phases differ substantially between them.
 
 ## Risks / tradeoffs (draft)
 
-- **(B) has real blast radius.** `sectionize_blocks` output feeds `quarto-ast-reconcile`'s hashing,
-  `llms.rs`, the idempotence tests, and the HTML writer's `section` detection. It is the right fix
-  and the expensive one.
+- **(B)'s blast radius measured lower than feared.** `sectionize_blocks` output feeds
+  `quarto-ast-reconcile`'s hashing, `llms.rs`, the idempotence tests, and the HTML writer's
+  `section` detection — but the recursion spike passed all 12306 workspace tests. The remaining
+  risk is the *attribute-merge* half (finding 5), which the spike did not implement.
+- **The merge rule is the subtle part.** Pandoc absorbs a Div into the section it wraps only under
+  specific conditions (empty Div id, header-led run). Getting it wrong silently drops TOC entries
+  rather than erroring — the exact failure the second spike hit.
 - **(A) is cheap but leaves known divergences on the floor** — the blockquote leak and the
   `div`-vs-`section` structure — both of which are port-visible.
 - **Preview stays divergent under any transform-side fix** until bd-47afd5ro; a collector-side fix

--- a/claude-notes/plans/2026-08-18-tabset-headings-in-toc.md
+++ b/claude-notes/plans/2026-08-18-tabset-headings-in-toc.md
@@ -264,7 +264,7 @@ WASM Vitest, Playwright — which satisfies the end-to-end rule better than an i
       the consume-first ordering rather than sectionize's reach.
 - [x] Verified the harness really exercises them (inverted one selector, watched it fail).
 
-## Phase 1 — Conditional-content: unwrap the resolved wrapper (prerequisite)
+## Phase 1 — Conditional-content: unwrap the resolved wrapper (prerequisite) ✅ (bd-wbnaa2ud)
 
 Q1's `content-hidden.lua` (`customnodes/content-hidden.lua:56`) resolves a **visible Div** by
 returning `el.content` — the wrapper disappears — after `clearHiddenVisibleAttributes` strips both
@@ -273,11 +273,14 @@ scaffolding element, as opposed to in the Div where we return the inlined conten
 q2 keeps the marker class *and* the Div, so 10 Connect-docs pages carry a
 `<div class="content-visible">` Q1 does not emit.
 
-- [ ] Failing test: a visible `::: {.content-visible when-format="html"}` leaves no Div in the
+- [x] Failing test: a visible `::: {.content-visible when-format="html"}` leaves no Div in the
       output; a visible `[x]{.content-visible …}` Span keeps its Span; marker classes are gone in
-      both cases.
-- [ ] Strip the marker classes on surviving elements (Q1's `clearHiddenVisibleAttributes`).
-- [ ] Unwrap a resolved **Div** — but only what the feature itself contributed. After stripping the
+      both cases. → `toc-containers/content-visible-{div-unwrapped,span-kept}.qmd`; both observed
+      failing on `div.content-visible` / `span.content-visible` before the fix.
+- [x] Strip the marker classes on surviving elements (Q1's `clearHiddenVisibleAttributes`) —
+      `strip_condition_attrs` now filters classes as well as attributes, keeping `attr_source`
+      aligned.
+- [x] Unwrap a resolved **Div** — but only what the feature itself contributed. After stripping the
       marker class and condition attributes, unwrap iff nothing remains (empty id, no classes, no
       attributes); otherwise keep a plain Div carrying the user's own attributes.
       **Divergence from Q1, deliberate:** Q1 unconditionally returns `el.content`, discarding a
@@ -285,10 +288,11 @@ q2 keeps the marker class *and* the Div, so 10 Connect-docs pages carry a
       absorb rule (Phase 2) merges an empty-id wrapper into the section anyway, so the TOC outcome
       is identical. All 33 real uses in the Connect corpus are bare markers, where the two rules
       coincide exactly.
-- [ ] Keep the llms two-view path intact (`.quarto-llms-omit` / `.quarto-llms-keep` markers are
+- [x] Keep the llms two-view path intact — falls out naturally: a tagged element carries
+      `.quarto-llms-omit`/`.quarto-llms-keep`, so it is not bare and keeps its Div. (`.quarto-llms-omit` / `.quarto-llms-keep` markers are
       applied *instead of* resolving; unwrapping must not fire on a marked element).
-- [ ] Update the module docs — the current text says surviving elements "keep their classes", which
-      is the bug.
+- [x] Update the module docs — the old text said surviving elements "keep their classes", which was
+      the bug.
 
 ## Phase 2 — `sectionize_blocks`: recurse into Divs + pandoc's absorb rule (bd-26nryuwh)
 
@@ -334,7 +338,34 @@ q2 keeps the marker class *and* the Div, so 10 Connect-docs pages carry a
 
 - [ ] Close bd-8yjvs3bj (blockquote leak) as absorbed by Phase 3.
 - [ ] Close bd-26nryuwh (sectionize recursion) as delivered by Phase 2.
-- [ ] File the conditional-content unwrap as its own strand (Phase 1) so the fix is attributable.
+- [x] File the conditional-content unwrap as its own strand (Phase 1) — **bd-wbnaa2ud**.
 - [ ] Docs: user-visible behavior change is "headings inside tabsets/callouts no longer appear in
       the TOC" — check whether `docs/` says anything about TOC contents that needs updating.
 - [ ] Commit at each phase boundary; do not push without approval.
+
+### Phase 1 verification (2026-08-18)
+
+`cargo nextest run --workspace` → **12308 passed, 0 failed** (2 new unit tests).
+
+End-to-end on the Connect corpus (clean double render,
+`cargo run --bin q2 -- render .` in `docs-quarto-2/`):
+
+| | baseline | after Phase 1 | Q1 |
+| --- | --- | --- | --- |
+| pages with a surviving `content-visible`/`content-hidden` Div | 10 | **0** | 0 |
+| exact TOC match with Q1 | 421/451 | 421/451 | — |
+| pages whose TOC changed | — | **0** | — |
+
+TOC-neutral by construction, which is the point: Phase 1 removes the obstruction
+Phase 3 would otherwise trip over. Inspected the page that regressed under the
+measurement spike — `admin/authentication/ldap-based/ldap-double-bind/index.html`
+— and it now matches Q1's shape:
+
+```html
+<section id="user-role-mapping" class="section level3">
+<h3>Automatic user role mapping</h3>
+<p>Posit Connect offers ways to map their user information…</p>
+<section id="using-group-memberships" class="section level4">
+```
+
+(no wrapper Div; the heading is an ordinary sibling, exactly as in Q1).

--- a/claude-notes/plans/2026-08-18-tabset-headings-in-toc.md
+++ b/claude-notes/plans/2026-08-18-tabset-headings-in-toc.md
@@ -1,0 +1,191 @@
+# Headings nested inside tabset panels leak into the TOC and point at hidden content (bd-tabset-headings-in-toc-t04ie7f7)
+
+**Date:** 2026-08-18
+**Braid:** bd-tabset-headings-in-toc-t04ie7f7
+**Branch:** `main` @ `5b6774d1` (investigated in the main checkout, per `/investigate-beads`; no worktree created)
+**Status:** Investigation — pending design alignment with user. **Do not start implementation until the user gives the go-ahead.**
+
+## Triage verdict
+
+**Ready to design — but the strand's stated root cause is wrong, and correcting it opens a
+materially better fix than either option the strand proposes.** The bug reproduces exactly as
+described at HEAD; what does not hold up is the explanation of *why Q1 differs*, and the
+"two-line skip on `.panel-tabset`" that explanation motivates.
+
+## Issue context
+
+Filed 2026-08-18 by Carlos Scheidegger; `bug`, priority 2, label `html`, `open`. Follow-up to
+bd-toc-tabset-titles-zq93gjvf (panel-tabset support, landed in 0.23.0), which fixed the *tab
+title* leak. Headings written **inside a tab body** still reach the TOC.
+
+Reproduced at HEAD (`5b6774d1`), repro at
+`/Users/cscheid/repos/github/cscheid/q2-connect-docs/llms-info/repros/tabset-headings-in-toc/`:
+
+```
+Q1: #configuration, #next-steps
+q2: #configuration, #create-the-integration, #create-the-integration-1, #next-steps
+```
+
+and `#create-the-integration-1` lives in `<div id="tabset-1-2" class="tab-pane">` — no `active`
+class, so `display:none`. All three reader-visible problems in the strand check out.
+
+Real-world impact per the strand: 25 of 451 Connect-docs pages, 44 leaked entries, 18 pointing at
+an inactive pane; the entire residual `toc:N` bucket of the 0.23.0 chrome sweep.
+
+## Dependency graph
+
+Thin — one edge out, none in.
+
+- **discovered-from → bd-toc-tabset-titles-zq93gjvf** (`in_progress`). The tabset-support strand,
+  landed on `main` via PR #543 (`5b6774d1`). Its plan is
+  `claude-notes/plans/2026-08-17-tabset-panel-tabset.md`; the markup contract it implements is
+  `claude-notes/plans/tabset-panel-tabset-investigation/q1-target-markup.html`. Nothing since
+  0.23.0 touches this area.
+- **Siblings** (same parent, both `open`, both informational here):
+  - bd-47afd5ro — q2-preview renders tabsets via a React `Tabset` component. Preview currently
+    excludes the transform pair entirely, so preview's TOC still shows *tab titles*. Any fix
+    placed in the **transform** (rather than the collector) is invisible to preview until that
+    strand lands; a fix in the collector is not.
+  - bd-y5j0m776 — revealjs tabset support. `PanelTabsetTransform` self-gates to non-reveal
+    Bootstrap HTML, so on reveal (and on non-HTML formats) the `.panel-tabset` Div passes through
+    with its headers intact.
+- No incoming `blocks`. Urgency comes from the Connect-docs port, not from a dependent strand.
+
+## What the code looks like today
+
+Every path in the description still exists and is accurate:
+
+- `PanelTabsetResolveTransform` — `crates/quarto-core/src/transforms/panel_tabset_resolve.rs`
+- pushed at `crates/quarto-core/src/pipeline.rs:1246` / `:1248`, well before
+  `SectionizeTransform` (`:1333`) and `TocGenerateTransform` (`:1387`)
+- `collect_toc_entries` — `crates/pampa/src/toc.rs:341`
+- `sectionize_blocks` — `crates/pampa/src/transforms/sectionize.rs:75`
+
+`cargo xtask verify` is green at `5b6774d1` (pre-flight, full run including the hub leg).
+
+### The strand's root cause is wrong about Q1
+
+The strand says Q1 excludes in-tab headings because
+`src/resources/filters/customnodes/panel-tabset.lua` "returns raw HTML for the whole tabset, so
+pandoc's TOC pass sees an opaque blob." It does not. `render_tabset`
+(`external-sources/quarto-cli/src/resources/filters/customnodes/panel-tabset.lua:72`) returns
+**real AST** — `Div(.panel-tabset)[ Plain(nav RawInlines), Div(.tab-content)[ Div(.tab-pane)[…] ] ]`
+— which is the *same shape* q2 emits. And Q1's render of the strand's own repro proves headings
+inside the panes survive to sectionizing time:
+
+```html
+<div id="tabset-1-1" class="tab-pane active" role="tabpanel" …>
+<section id="create-the-integration" class="level4">
+```
+
+The section exists in Q1's output. It is simply not in Q1's TOC.
+
+### The actual rule
+
+Probe fixture + captured results:
+`claude-notes/plans/tabset-headings-in-toc-investigation/div-toc-probe/`.
+
+Pandoc's TOC is **exactly the section tree**. `makeSections` recurses into Divs and, when the Div's
+id is empty, *merges* the Div's attributes into the section it wraps; it does **not** descend into
+`BlockQuote`. `sectionToListItem` then matches only `Div(_, _, Header : rest)` — a Div whose first
+child is not a `Header` ends the walk, with **no recursion past it**.
+
+One rule, four confirmed predictions (Q1 vs q2 at HEAD):
+
+| heading inside…            | Q1       | q2       |
+| -------------------------- | -------- | -------- |
+| plain `::: {.my-wrapper}`  | included | included |
+| `::: {.callout-note}`      | excluded | excluded |
+| `> blockquote`             | excluded | **included** ← q2-only leak, not yet filed |
+| `.panel-tabset` pane       | excluded | **included** ← this strand |
+
+- plain div → absorbed into a genuine section → in the TOC;
+- callout → the filter replaced it with non-section structure → gone;
+- blockquote → never sectionized → a bare `Header`, never matched → gone;
+- tabset → the section *is* there, but buried under `Div(.panel-tabset)`, whose first child is
+  `Plain(nav)`; the walk stops at that Div.
+
+### Where q2 diverges — two divergences, currently cancelling
+
+1. **`collect_toc_entries` over-collects.** It recurses into *every* non-section Div, and into
+   `BlockQuote`, and picks up bare `Header`s wherever it finds them.
+2. **`sectionize_blocks` under-sectionizes.** It never recurses into Divs at all. q2 emits
+   `<div class="my-wrapper"><h4 id=…>` where Q1 emits
+   `<section id="…" class="level4 my-wrapper">`.
+
+For a plain div the two errors cancel and q2 matches Q1 by accident. For a tabset pane and a
+blockquote they compound and q2 leaks. **This is why the strand's option (a) is not simply "two
+lines":** the narrow skip fixes the tabset, leaves the blockquote leak, and leaves the
+sectionize divergence — which is itself DOM noise for the port beyond the `toc:N` bucket.
+
+### The layering wrinkle the strand flags is real, and has a second edge
+
+The strand worries that pampa should not know the name of a quarto-core construct. There is a
+second, sharper problem with pushing the marker into the transform: **`DocumentProfileStage`
+(`pipeline.rs:314`) runs before `AstTransformsStage` (`:353`)**. `document_profile.rs:1017`
+(`extract_outline`) calls the same `generate_toc` on the *pre-transform* AST, so its outline today
+contains both the tab titles *and* the in-tab headings. A marker applied by
+`PanelTabsetTransform`/`…Resolve` never reaches it; a rule in the collector, or a check on the
+source `panel-tabset` class, covers both. (No in-tree consumer reads `profile.outline` yet, so
+this is correctness-in-waiting, not a live symptom.)
+
+## Proposed phases (draft)
+
+Skeleton only — which of the three directions below we take is the first design question, and the
+phases differ substantially between them.
+
+- **Phase 0 — Test plan (TDD, failing first).** Unit tests in `crates/pampa/src/toc.rs` for the
+  container rule; an end-to-end test in `crates/quarto-core/tests/integration/tabset_pipeline.rs`
+  asserting a `####` inside a tab does not appear in `nav#TOC`; the probe fixture promoted to a
+  committed regression fixture.
+- **Phase 1 — Core change** (see design question 1).
+- **Phase 2 — Reconcile `sectionize_blocks`** *(direction B only)* — recurse into Divs, merge attrs
+  when the Div id is empty, do not descend into `BlockQuote`.
+- **Phase 3 — Sweep the fallout** — snapshots, `quarto-ast-reconcile` hashing, `llms.rs`,
+  `idempotence.rs`, anything asserting on section structure.
+- **Phase 4 — Re-measure against the port** — rerun the Connect-docs chrome sweep; expect the
+  `toc:N` bucket to go to ~0.
+- **Phase 5 — Docs** if reader-facing behavior changes (direction C).
+
+## Open design questions for the user
+
+1. **Which direction?** Three, not two:
+   - **(A) Narrow.** Skip recursion into `.panel-tabset` Divs in `collect_toc_entries`. Smallest
+     diff, restores Q1 parity for this bug only. Leaves the blockquote leak and the sectionize
+     divergence. Needs a call on the layering wrinkle (see question 2).
+   - **(B) Principled — match Pandoc's section-tree rule.** Make `sectionize_blocks` mirror
+     `makeSections`, then make `collect_toc_entries` walk only the section tree. Fixes the tabset
+     leak, the blockquote leak, *and* the `div`-vs-`section` DOM divergence in one stroke, with no
+     `panel-tabset` knowledge in pampa. Larger blast radius (section markup changes for every
+     heading inside any Div). My recommendation, if you have appetite for the fallout.
+   - **(C) Keep the entries and make them work** — the strand's option (b): qualify each entry with
+     its owning tab title and have the TOC link activate the pane before scrolling. Note this is a
+     *divergence from Q1 by improvement*; given the port's goal is parity, I'd file it as its own
+     feature strand rather than fold it in here.
+2. **If (A): where does the marker live?** In `collect_toc_entries` keyed on the literal
+   `panel-tabset` class (layering smell, but works pre- *and* post-transform, so it also fixes the
+   profile outline), or a generic pampa-owned opt-out class that quarto-core applies (clean
+   layering, but applied by the transform it misses `extract_outline`, and it misses preview until
+   bd-47afd5ro lands)?
+3. **Is the blockquote leak in scope here, or its own strand?** It is the same root cause and falls
+   out of (B) for free; under (A) it needs its own two lines.
+4. **Non-HTML and reveal formats.** `PanelTabsetTransform` self-gates to Bootstrap HTML, so
+   elsewhere the `.panel-tabset` Div passes through with headers intact. Should the TOC rule apply
+   uniformly across formats (it would under both A and B), or only where tabsets actually render?
+5. **How much snapshot churn is acceptable?** (B) changes rendered section markup for every heading
+   nested in a Div. Worth a quick spike to count before committing to it?
+
+## Risks / tradeoffs (draft)
+
+- **(B) has real blast radius.** `sectionize_blocks` output feeds `quarto-ast-reconcile`'s hashing,
+  `llms.rs`, the idempotence tests, and the HTML writer's `section` detection. It is the right fix
+  and the expensive one.
+- **(A) is cheap but leaves known divergences on the floor** — the blockquote leak and the
+  `div`-vs-`section` structure — both of which are port-visible.
+- **Preview stays divergent under any transform-side fix** until bd-47afd5ro; a collector-side fix
+  is inherited by preview automatically. Worth weighing in question 2.
+- **The profile outline is silently wrong today** (tab titles *and* in-tab headings). No consumer
+  reads it yet, so nothing is visibly broken — but a transform-side fix bakes the wrongness in.
+- **Q1 comparison used a quarto-cli dev checkout** (`quarto --version` → `99.9.9`). The structural
+  facts above (real AST from `render_tabset`; sections inside panes; the four probe rows) are
+  stable behavior, not release-specific, but a release-Q1 spot-check is cheap if you want it.

--- a/claude-notes/plans/2026-08-18-tabset-headings-in-toc.md
+++ b/claude-notes/plans/2026-08-18-tabset-headings-in-toc.md
@@ -50,6 +50,12 @@ Thin — one edge out, none in.
     Bootstrap HTML, so on reveal (and on non-HTML formats) the `.panel-tabset` Div passes through
     with its headers intact.
 - No incoming `blocks`. Urgency comes from the Connect-docs port, not from a dependent strand.
+- **Filed during this investigation** (both `discovered-from` this strand):
+  - bd-8yjvs3bj — headings inside a blockquote leak into the TOC (same root cause, different
+    container).
+  - bd-26nryuwh — `sectionize_blocks` does not recurse into Divs, so q2 emits `<div><h4>` where Q1
+    emits `<section class="level4 …">`. This is the second half of the cancelling pair below, and
+    a prerequisite for direction (B).
 
 ## What the code looks like today
 
@@ -96,7 +102,7 @@ One rule, four confirmed predictions (Q1 vs q2 at HEAD):
 | -------------------------- | -------- | -------- |
 | plain `::: {.my-wrapper}`  | included | included |
 | `::: {.callout-note}`      | excluded | excluded |
-| `> blockquote`             | excluded | **included** ← q2-only leak, not yet filed |
+| `> blockquote`             | excluded | **included** ← q2-only leak (bd-8yjvs3bj) |
 | `.panel-tabset` pane       | excluded | **included** ← this strand |
 
 - plain div → absorbed into a genuine section → in the TOC;
@@ -109,7 +115,7 @@ One rule, four confirmed predictions (Q1 vs q2 at HEAD):
 
 1. **`collect_toc_entries` over-collects.** It recurses into *every* non-section Div, and into
    `BlockQuote`, and picks up bare `Header`s wherever it finds them.
-2. **`sectionize_blocks` under-sectionizes.** It never recurses into Divs at all. q2 emits
+2. **`sectionize_blocks` under-sectionizes** (filed as bd-26nryuwh). It never recurses into Divs at all. q2 emits
    `<div class="my-wrapper"><h4 id=…>` where Q1 emits
    `<section id="…" class="level4 my-wrapper">`.
 
@@ -139,7 +145,7 @@ phases differ substantially between them.
   asserting a `####` inside a tab does not appear in `nav#TOC`; the probe fixture promoted to a
   committed regression fixture.
 - **Phase 1 — Core change** (see design question 1).
-- **Phase 2 — Reconcile `sectionize_blocks`** *(direction B only)* — recurse into Divs, merge attrs
+- **Phase 2 — Reconcile `sectionize_blocks`** (bd-26nryuwh) *(direction B only)* — recurse into Divs, merge attrs
   when the Div id is empty, do not descend into `BlockQuote`.
 - **Phase 3 — Sweep the fallout** — snapshots, `quarto-ast-reconcile` hashing, `llms.rs`,
   `idempotence.rs`, anything asserting on section structure.
@@ -167,8 +173,9 @@ phases differ substantially between them.
    profile outline), or a generic pampa-owned opt-out class that quarto-core applies (clean
    layering, but applied by the transform it misses `extract_outline`, and it misses preview until
    bd-47afd5ro lands)?
-3. **Is the blockquote leak in scope here, or its own strand?** It is the same root cause and falls
-   out of (B) for free; under (A) it needs its own two lines.
+3. **Is the blockquote leak (bd-8yjvs3bj) in scope here, or does it stay its own strand?** Same root
+   cause; it falls out of (B) for free, and under (A) it needs its own two lines (delete the
+   `BlockQuote` arm).
 4. **Non-HTML and reveal formats.** `PanelTabsetTransform` self-gates to Bootstrap HTML, so
    elsewhere the `.panel-tabset` Div passes through with headers intact. Should the TOC rule apply
    uniformly across formats (it would under both A and B), or only where tabsets actually render?

--- a/claude-notes/plans/2026-08-18-tabset-headings-in-toc.md
+++ b/claude-notes/plans/2026-08-18-tabset-headings-in-toc.md
@@ -311,20 +311,26 @@ q2 keeps the marker class *and* the Div, so 10 Connect-docs pages carry a
       run before sectionize and depend on **flat** Headers as direct Div children. Nothing here
       changes that, but the tabset/callout tests must stay green.
 
-## Phase 3 — `collect_toc_entries`: walk only the section tree
+## Phase 3 — `collect_toc_entries`: walk only the section tree ✅
 
-- [ ] Failing test: headings inside a tabset pane, a callout body, and a blockquote are absent from
-      the TOC; headings inside `content-visible` / `column-margin` / `layout-ncol` / a plain Div are
-      still present.
-- [ ] A non-section Div terminates the walk (pandoc's `sectionToListItem`).
-- [ ] Remove the `BlockQuote` arm.
-- [ ] Decide the un-sectionized fallback. `SectionizeTransform` is skipped for revealjs
-      (`pipeline.rs:1332`) while `TocGenerateTransform` is ungated (`:1387`). q2 emits no `nav#TOC`
-      for reveal today, so nothing breaks — but leave the code honest: either run sectionize for
-      reveal too, or document the precondition at `generate_toc`.
-- [ ] `document_profile.rs::extract_outline` calls `generate_toc` on the **pre-transform** AST
-      (`DocumentProfileStage` at `pipeline.rs:314` runs before `AstTransformsStage` at `:353`), so
-      its outline is un-sectionized. Check what the new rule does to it and record the answer.
+- [x] Failing tests — three smoke-all fixtures (`tabset-pane-`, `callout-body-`,
+      `blockquote-heading-not-in-toc.qmd`) plus three unit tests in `toc.rs`. All observed failing
+      first. The unit tests needed **two** corrections before they failed honestly: the default
+      `TocConfig` depth of 3 was excluding the level-4 headings outright, and asserting on
+      `toc.entries` missed the leak entirely because `build_hierarchy` nests a leaked entry
+      *under* the preceding top-level section rather than beside it.
+- [x] A non-section Div terminates the walk (pandoc's `sectionToListItem`).
+- [x] Remove the `BlockQuote` arm (bd-8yjvs3bj).
+- [x] Un-sectionized fallback: documented the precondition in `pampa::toc`'s module docs and filed
+      **bd-tebu6o4a**. Running sectionize for reveal would change reveal's slide DOM and wants its
+      own testing; reveal emits no `nav#TOC` today, so this is a trap for the next person, not a
+      live bug.
+- [x] `document_profile.rs::extract_outline` — checked, and it *did* degrade: on un-sectionized
+      blocks the new rule dropped every heading written inside any `:::` block. Fixed by
+      sectionizing a copy before the walk, which restores the absorb rule so a transparent wrapper
+      disappears. One gap remains — a callout **title** is absorbed here and listed, while the
+      rendered TOC omits it, because heading-consuming transforms run after the profile checkpoint.
+      Filed as **bd-ca17fck0** and pinned by `outline_sees_headings_inside_divs`.
 
 ## Phase 4 — End-to-end verification
 
@@ -399,3 +405,47 @@ Connect corpus (clean double render): TOC changed on **0** pages — Phase 2 is
 TOC-neutral by design — while `<section>` elements rose **3626 → 3678**, i.e. 52
 headings that were bare `<hN>` inside a Div are now real sections. Exact TOC
 parity with Q1 holds at 421/451, waiting on Phase 3.
+
+### Phase 3 verification (2026-08-18)
+
+`cargo xtask verify` (full, including the hub-client build and its tests) → all
+steps pass; 12328 Rust tests.
+
+The strand's own repro, `q2-connect-docs/llms-info/repros/tabset-headings-in-toc/`:
+
+```
+$ cargo run --bin q2 -- render .
+Q1 TOC: ['configuration', 'next-steps']
+q2 TOC: ['configuration', 'next-steps']     ← was 4 entries, two of them dead
+```
+
+and the panes keep their real sections, exactly as Q1 does — the content is still
+there and still addressable, it is simply not listed:
+
+```html
+<div id="tabset-1-2" class="tab-pane" role="tabpanel" …>
+<section id="create-the-integration-1" class="section level4">
+```
+
+Connect corpus (451 pages, clean double render), inspected rather than counted:
+
+| | baseline | Phase 3 |
+| --- | --- | --- |
+| exact TOC match with Q1 | 421/451 | **444/451** |
+| pages closer to Q1 / unchanged / **further** | — | 25 / 426 / **0** |
+| TOC entries removed / **added** | — | 44 / **0** |
+
+Every one of the 44 removed entries was inside a `div.tab-pane` (checked with an
+HTML parser, not a regex); **20** of them sat in a pane carrying no `active`
+class — dead links a reader could not follow. The strand predicted 44 leaked
+entries and 18 dead; we measure 44 and 20.
+
+The 7 pages still differing from Q1 are all **pre-existing and unrelated**,
+byte-identical in their difference to the baseline:
+
+- two LDAP pages where *Q1* emits a garbled id containing an unresolved shortcode
+  blob (`b58fc729-…-group-membership-synchronization`); q2's ids are the correct
+  ones;
+- `admin/process-management` — em-dash slug (`…selection---shiny…` vs `…selection-shiny…`);
+- four pages, incl. `how-to/use-renv-…`, with a pre-existing extra entry — the
+  benign `toc:N` difference the strand already called out.

--- a/claude-notes/plans/2026-08-18-tabset-headings-in-toc.md
+++ b/claude-notes/plans/2026-08-18-tabset-headings-in-toc.md
@@ -345,15 +345,20 @@ q2 keeps the marker class *and* the Div, so 10 Connect-docs pages carry a
 
 ## Phase 5 — Bookkeeping
 
-- [ ] Close bd-8yjvs3bj (blockquote leak) as absorbed by Phase 3.
-- [ ] Close bd-26nryuwh (sectionize recursion) as delivered by Phase 2.
+- [ ] Close bd-8yjvs3bj (blockquote leak) as absorbed by Phase 3. *(outcome recorded as a comment;
+      holding the close for user review)*
+- [ ] Close bd-26nryuwh (sectionize recursion) as delivered by Phase 2. *(same)*
 - [x] File the conditional-content unwrap as its own strand (Phase 1) — **bd-wbnaa2ud**.
 - [x] Docs: `docs/guides/authoring/tabsets.qmd:74` said tab-title headings are excluded and that
       "deeper headings inside a tab stay part of that tab's content" — true but ambiguous, and
       written when those headings *did* appear in the TOC. Rewritten to state the rule plainly, say
       why, and reassure that the headings still render, get ids, and can be linked to. Rendered and
       read the result; full `docs/` render clean (247 of 247).
-- [ ] Commit at each phase boundary; do not push without approval.
+- [x] Commit at each phase boundary; do not push without approval. Five commits, `58dd896c` →
+      `cbf65a6b`, on `braid/bd-tabset-headings-in-toc-t04ie7f7`. **Not pushed.**
+- [x] Follow-ups filed during implementation: **bd-ca17fck0** (profile outline lists callout titles
+      the rendered TOC omits) and **bd-tebu6o4a** (reveal skips sectionize, so a future reveal TOC
+      would be empty).
 
 ### Phase 1 verification (2026-08-18)
 

--- a/claude-notes/plans/tabset-headings-in-toc-investigation/FALLOUT-B.md
+++ b/claude-notes/plans/tabset-headings-in-toc-investigation/FALLOUT-B.md
@@ -1,0 +1,130 @@
+# Measured fallout of direction (B), 2026-08-18
+
+Direction (B) = make `sectionize_blocks` recurse into non-section Divs and apply
+pandoc's absorb rule, then restrict `collect_toc_entries` to the section tree
+(and drop its `BlockQuote` arm).
+
+Spike implemented, measured, and **reverted**. The exact diff measured is
+`spike-B.patch` (33 added / 5 removed lines across two files). It is a
+throwaway — the absorb rule in it is deliberately conservative and is *not* a
+proposed implementation.
+
+## Method
+
+Two clean renders per corpus (`rm -rf _site .quarto`, render twice to reach
+steady state, then copy), so the diff reflects the code change and nothing
+else.
+
+> **A first pass got this wrong and it mattered.** The baseline was an
+> incremental render while the spike side was clean, which inflated the diff to
+> 131 files with link-rewriting and attribute-ordering noise
+> (`../../licensing/index.html#…` vs `/admin/licensing/index.md#…`). Redone
+> clean, the true number is 36. Any future re-measurement must double-render
+> both sides.
+
+## Corpus 1 — workspace test suite
+
+`cargo nextest run --workspace` → **12306 passed, 0 failed**, no snapshot
+changes. Same result for the recursion-only spike.
+
+That is not the reassurance it looks like: it means **the suite has no coverage
+of a heading nested inside a Div**. Phase 0's tests are new coverage, not
+regression guards.
+
+## Corpus 2 — `docs/` (q2's own site, 247 source files → 258 pages)
+
+**0 files changed.** The docs site has no headings nested in Divs. Useless as a
+canary for this change.
+
+## Corpus 3 — Connect docs port (352 source files → 451 pages)
+
+**36 files changed: 35 HTML + `sitemap.xml`** (a single `<lastmod>` timestamp).
+
+| measure | result |
+| --- | --- |
+| HTML pages changed | 35 (27 TOC + DOM, 8 DOM-only) |
+| TOC entries **removed** | 46 |
+| TOC entries **added** | 0 |
+| vs Q1: closer / unchanged / further | 25 / 8 / **2** |
+| **whole corpus, exact TOC match with Q1** | **421 → 444 of 451** |
+
+The 46 removals line up with the strand's independently-measured 44 leaked
+entries (the strand counted structurally; callout-body leaks account for the
+rest).
+
+### What a DOM-only change looks like
+
+The absorb rule firing — pandoc's exact behavior, class merged into the section:
+
+```diff
+-<div class="content-hidden">
+-<h4 id="username-limitations-without-service-credentials">Username limitations…</h4>
++<section id="username-limitations-without-service-credentials" class="section level4 content-hidden">
++<h4>Username limitations…</h4>
+ …
+-</div>
++</section>
+```
+
+TOC unchanged on that page: the entry was reached via the bare-`Header` path
+before and via the section path after.
+
+## The 2 regressions — root cause is NOT (B)
+
+`admin/authentication/ldap-based/{active-directory,ldap}-double-bind/index.html`
+lose `#using-group-memberships`, which Q1 keeps. Source
+(`admin/authentication/ldap-based/include/_users.qmd:184`):
+
+```markdown
+::: {.content-visible when-meta="authentication.double-bind"}
+Posit Connect offers ways to map their user information…      ← Para first
+#### Using group memberships
+```
+
+**Q1 deletes the `content-visible` Div entirely** — its conditional-content
+filter splices the contents into the parent section, so the heading is an
+ordinary sibling by TOC time:
+
+```html
+<section id="user-role-mapping" class="level3">
+<h3>Automatic user role mapping</h3>
+<p>Posit Connect offers ways to map…</p>
+<section id="using-group-memberships" class="level4">
+```
+
+**q2 keeps the Div** (`<div class="content-visible">`), so the restricted walk
+stops at it. Exposure: **10 q2 pages retain a `content-visible`/`content-hidden`
+Div; Q1 has 0.**
+
+So (B) carries a dependency that was not visible before this measurement:
+**conditional-content Divs must be unwrapped the way Q1 unwraps them**, or those
+pages lose entries. Under today's over-permissive collector the un-unwrapped Div
+is a harmless DOM difference; (B) converts it into a missing TOC entry.
+
+### Correction to `div-recursion-probe/README.md` finding 5
+
+That note attributed `.content-visible` headings surviving Q1's TOC to pandoc's
+**absorb** rule. Wrong: Q1 **unwraps** those Divs in its conditional-content
+filter. The probe could not distinguish the two (both yield a lone section with
+no wrapping Div); the Connect-docs case has a `Para` before the heading, which
+absorb cannot explain and unwrapping can. Absorb is real and does apply to
+arbitrary Divs — `.my-wrapper` → `class="level4 my-wrapper"`, and the
+`content-hidden` diff above — but it is not what saves `.content-visible`.
+
+## Latent trap, not a live one
+
+`SectionizeTransform` is pushed only in the non-reveal branch
+(`pipeline.rs:1332`), while `TocGenerateTransform` is ungated (`:1387`). Under
+(B) a revealjs TOC would find no section tree and come up empty. Verified that
+**q2 emits no `nav#TOC` for revealjs today**, so nothing breaks now — but
+whoever implements a reveal TOC (or bd-y5j0m376's reveal tabsets) inherits the
+trap unless sectionize runs there too.
+
+## Bottom line
+
+- Cost: 35 pages on the only corpus that exercises the feature; 0 test failures;
+  0 spurious TOC entries.
+- Benefit: **+23 pages to exact Q1 TOC parity** (421 → 444 of 451).
+- Blocker: unwrap conditional-content Divs first, or accept 2 known regressions.
+- Remaining 7 non-matching pages are pre-existing differences unrelated to this
+  change.

--- a/claude-notes/plans/tabset-headings-in-toc-investigation/absorb-rule-probe/.gitignore
+++ b/claude-notes/plans/tabset-headings-in-toc-investigation/absorb-rule-probe/.gitignore
@@ -1,0 +1,5 @@
+/.quarto/
+/_site/
+/_site-q1/
+
+**/*.quarto_ipynb

--- a/claude-notes/plans/tabset-headings-in-toc-investigation/absorb-rule-probe/_quarto.yml
+++ b/claude-notes/plans/tabset-headings-in-toc-investigation/absorb-rule-probe/_quarto.yml
@@ -1,0 +1,8 @@
+project:
+  type: website
+website:
+  title: "Absorb rule probe"
+format:
+  html:
+    toc: true
+    toc-depth: 4

--- a/claude-notes/plans/tabset-headings-in-toc-investigation/absorb-rule-probe/index.qmd
+++ b/claude-notes/plans/tabset-headings-in-toc-investigation/absorb-rule-probe/index.qmd
@@ -1,0 +1,49 @@
+---
+title: When does makeSections absorb a Div?
+---
+
+## A bare div, one heading
+
+::: {.wrap-a}
+### Case A
+
+Body.
+:::
+
+## Div with an id
+
+::: {#has-id .wrap-b}
+### Case B
+
+Body.
+:::
+
+## Leading content before the heading
+
+::: {.wrap-c}
+Leading para.
+
+### Case C
+
+Body.
+:::
+
+## Two sibling headings
+
+::: {.wrap-d}
+### Case D one
+
+Body.
+
+### Case D two
+
+Body.
+:::
+
+## Div with a key-value attribute
+
+::: {.wrap-e data-thing="x"}
+### Case E
+
+Body.
+:::

--- a/claude-notes/plans/tabset-headings-in-toc-investigation/div-recursion-probe/.gitignore
+++ b/claude-notes/plans/tabset-headings-in-toc-investigation/div-recursion-probe/.gitignore
@@ -1,0 +1,2 @@
+/.quarto/
+**/*.quarto_ipynb

--- a/claude-notes/plans/tabset-headings-in-toc-investigation/div-recursion-probe/.gitignore
+++ b/claude-notes/plans/tabset-headings-in-toc-investigation/div-recursion-probe/.gitignore
@@ -1,2 +1,4 @@
 /.quarto/
 **/*.quarto_ipynb
+/_site/
+/_site-q1/

--- a/claude-notes/plans/tabset-headings-in-toc-investigation/div-recursion-probe/README.md
+++ b/claude-notes/plans/tabset-headings-in-toc-investigation/div-recursion-probe/README.md
@@ -1,0 +1,125 @@
+# Probe: what would making `sectionize_blocks` recurse into Divs actually change?
+
+Companion to `../div-toc-probe/`. That probe established *the rule*; this one
+measures *the cost and the benefit* of acting on it, and answers the question
+"not recursing into divs seems to be what protects callouts and tabsets — what
+would recursing buy?"
+
+## Run
+
+```bash
+quarto render . --output-dir _site-q1     # Q1 (dev checkout, 99.9.9)
+cargo run --bin q2 -- render .            # q2 @ 5b6774d1
+```
+
+(`_site/`, `_site-q1/` not committed. `callout2.qmd` is a second fixture —
+a callout with both a title heading and a body heading.)
+
+## Finding 1 — non-recursion is *not* what protects callout/tab titles
+
+Those title Headers are **consumed** by `CalloutTransform` (pipeline.rs ~:1232)
+and `PanelTabsetTransform` (:1246) long before `SectionizeTransform` (:1333)
+runs. There is no Header left for sectionize to wrap, whether it recurses or
+not. Q1 is the proof by construction: pandoc's `makeSections` *does* recurse
+into Divs, and Q1 still gets tab and callout titles right — by the same
+consume-first mechanism.
+
+## Finding 2 — the parser already has the nesting; the reader discards it
+
+`pandoc_div`'s grammar rule is `repeat($._block)`, and `$._block` includes
+`$.section` (`tree-sitter-markdown/grammar.js:190`, `:965`). The CST for a
+heading inside a div really is nested:
+
+```
+document
+  section                      (## Real heading)
+    atx_heading
+    pandoc_div                 (.my-wrapper)
+      section                  (#### Heading inside a plain div)   ← nested
+        atx_heading
+        pandoc_paragraph
+```
+
+`process_section` (`crates/pampa/src/pandoc/treesitter_utils/section.rs:27`)
+then flattens it — `IntermediateSection(section) => blocks.extend(section)` —
+yielding `[Header 2, Div(.my-wrapper)[Header 4, Para]]`. `sectionize_blocks`
+rebuilds sections later from header levels, top level only.
+
+**But preserving the parser's sections instead is not a shortcut.**
+`PanelTabsetTransform` and `CalloutTransform` both scan for *flat* Headers as
+direct children of their Div ("the first Header inside the Div fixes the tab
+level"). Handing them pre-sectionized input breaks both. Sectionize belongs
+where it is — a late Normalization transform; the gap is that it doesn't
+recurse.
+
+## Finding 3 — the current TOC agreement is an equilibrium, and it is partial
+
+q2 has two divergences that cancel: the collector recurses into *every* Div,
+sectionize into *none*. Measured across container types (TOC
+`data-scroll-target` ids, Q1 vs q2 @ 5b6774d1):
+
+| heading inside…                   | Q1  | q2  | agree? |
+| --------------------------------- | --- | --- | ------ |
+| plain `::: {.my-wrapper}`          | in  | in  | ✅ |
+| `::: {.content-visible …}`         | in  | in  | ✅ |
+| `::: {.column-margin}`             | in  | in  | ✅ |
+| `::: {layout-ncol=2}`              | in  | in  | ✅ |
+| **`.callout` body**                | out | **in** | ❌ leak |
+| **`.panel-tabset` pane**           | out | **in** | ❌ leak |
+| **`> blockquote`**                 | out | **in** | ❌ leak |
+
+The cancellation is exact for **transparent** Divs — ones pandoc's
+`makeSections` *absorbs*, merging the Div's attributes into the section it
+wraps:
+
+```html
+<!-- Q1 -->  <section id="heading-in-a-layout-div" class="level3 quarto-layout-cell" …>
+<!-- q2 -->  <div data-layout-ncol="2"><h3 id="heading-in-a-layout-div">
+```
+
+It fails for **opaque** Divs — ones where a filter built real chrome, so the
+section ends up *nested inside* a Div rather than merged with it, and pandoc's
+`sectionToListItem` (which matches only `Div(_,_,Header:rest)`) stops at the
+Div:
+
+```html
+<!-- Q1, callout2.qmd: the section exists but is unreachable from the TOC walk -->
+<div class="callout …">
+  <div class="callout-header …">…</div>
+  <section id="body-heading" class="level4 callout-body-container callout-body">
+```
+
+So `.callout` bodies leak too — this is a **third** container beyond the
+tabset panes and blockquotes, which is what rules out a narrow
+`.panel-tabset`-only skip.
+
+## Finding 4 — cost of recursion: zero test failures
+
+Spike (2026-08-18): recurse into any Div lacking the `section` class, then
+`cargo nextest run --workspace` → **12306 passed, 0 failed**. The blast radius
+feared in the plan (reconcile hashing, `llms.rs`, idempotence, snapshots) did
+not materialize. Output changes as expected:
+
+```html
+<div class="content-visible">
+  <section id="section-inside-content-visible" class="section level3">
+```
+
+## Finding 5 — the attribute merge is load-bearing, not cosmetic
+
+Second spike, stacking the collector restriction (non-section Div terminates
+the walk; `BlockQuote` arm removed) on top of recursion:
+
+- `.callout` body → **matches Q1** ✅
+- `.panel-tabset` pane (the strand's repro) → **matches Q1** ✅
+- but `.content-visible`, `.column-margin`, `layout-ncol` → **entries lost** ❌
+
+Because recursion alone yields `Div(.content-visible) > Div(section)`, and the
+restricted walk stops at the outer Div. Q1 keeps those entries only because
+`makeSections` **merged** the Div away — there is no wrapping Div left to stop
+at.
+
+**The three parts are coupled.** Recursion + collector restriction *without*
+the merge under-collects. Any plan that takes this direction has to land all
+three: recurse, merge (when the Div's id is empty and it wraps a header-led
+run), restrict.

--- a/claude-notes/plans/tabset-headings-in-toc-investigation/div-recursion-probe/_quarto.yml
+++ b/claude-notes/plans/tabset-headings-in-toc-investigation/div-recursion-probe/_quarto.yml
@@ -1,0 +1,8 @@
+project:
+  type: website
+website:
+  title: "Div recursion probe"
+format:
+  html:
+    toc: true
+    toc-depth: 4

--- a/claude-notes/plans/tabset-headings-in-toc-investigation/div-recursion-probe/callout2.qmd
+++ b/claude-notes/plans/tabset-headings-in-toc-investigation/div-recursion-probe/callout2.qmd
@@ -1,0 +1,13 @@
+---
+title: Callout with a title heading and a body heading
+---
+
+## Outer
+
+::: {.callout-note}
+### Callout title
+
+#### Body heading
+
+Body.
+:::

--- a/claude-notes/plans/tabset-headings-in-toc-investigation/div-recursion-probe/index.qmd
+++ b/claude-notes/plans/tabset-headings-in-toc-investigation/div-recursion-probe/index.qmd
@@ -1,0 +1,37 @@
+---
+title: What would sectionize recursion change?
+---
+
+## Conditional content
+
+::: {.content-visible when-format="html"}
+### Section inside content-visible
+
+Body.
+:::
+
+## Callout body headings
+
+::: {.callout-note title="Callout with a body heading"}
+### Heading in a callout body
+
+Body.
+:::
+
+## Column margin
+
+::: {.column-margin}
+### Heading in the margin
+
+Body.
+:::
+
+## Grid layout
+
+::: {layout-ncol=2}
+### Heading in a layout div
+
+Body.
+:::
+
+## Done

--- a/claude-notes/plans/tabset-headings-in-toc-investigation/div-toc-probe/.gitignore
+++ b/claude-notes/plans/tabset-headings-in-toc-investigation/div-toc-probe/.gitignore
@@ -1,0 +1,2 @@
+/.quarto/
+**/*.quarto_ipynb

--- a/claude-notes/plans/tabset-headings-in-toc-investigation/div-toc-probe/.gitignore
+++ b/claude-notes/plans/tabset-headings-in-toc-investigation/div-toc-probe/.gitignore
@@ -1,2 +1,4 @@
 /.quarto/
 **/*.quarto_ipynb
+/_site/
+/_site-q1/

--- a/claude-notes/plans/tabset-headings-in-toc-investigation/div-toc-probe/README.md
+++ b/claude-notes/plans/tabset-headings-in-toc-investigation/div-toc-probe/README.md
@@ -1,0 +1,64 @@
+# Probe: which headings inside non-section containers reach the TOC?
+
+Purpose: establish the *actual* rule Quarto 1 / Pandoc use to decide what
+lands in the TOC, because bd-tabset-headings-in-toc-t04ie7f7's stated root
+cause ("Q1 rewrites the whole tabset to raw HTML, so nothing inside it can
+reach the TOC") is **wrong** — Q1's `render_tabset` returns real AST
+(`Div(.panel-tabset)[Plain(nav RawInlines), Div(.tab-content)[Div(.tab-pane)…]]`),
+the same shape q2 emits.
+
+## Run
+
+```bash
+quarto render . --output-dir _site-q1     # Q1 (dev checkout, reported 99.9.9)
+cargo run --bin q2 -- render .            # q2 @ 5b6774d1
+```
+
+(`_site/` and `_site-q1/` are not committed — regenerate them.)
+
+## Results captured 2026-08-18 (q2 @ 5b6774d1, quarto-cli dev 99.9.9)
+
+TOC `data-scroll-target` ids:
+
+| container            | Q1  | q2  |
+| -------------------- | --- | --- |
+| plain `::: {.my-wrapper}` | **included** | included |
+| `::: {.callout-note}`     | excluded | excluded |
+| `> blockquote`            | **excluded** | **included** ← q2-only leak |
+
+Rendered body structure for the plain-div case:
+
+```html
+<!-- Q1: the Div is ABSORBED into the section, class merged -->
+<section id="heading-inside-a-plain-div" class="level4 my-wrapper">
+  <h4 …>Heading inside a plain div</h4>
+
+<!-- q2: the Div survives, the header is never sectionized -->
+<div class="my-wrapper">
+  <h4 id="heading-inside-a-plain-div">Heading inside a plain div</h4>
+```
+
+## Conclusion — the real rule
+
+Pandoc's TOC is *exactly the section tree*. `makeSections` recurses into
+Divs and, when the Div has an empty id, **merges** the Div's attributes into
+the section it wraps; it does **not** descend into `BlockQuote`. Then
+`sectionToListItem` matches only `Div(_, _, Header : rest)` — a Div whose
+first child is not a Header terminates the walk, with no recursion past it.
+
+That single rule explains every row above *and* the tabset case:
+
+- plain div → absorbed into a real section → in the TOC;
+- callout → filter replaced it with non-section structure → gone;
+- blockquote → never sectionized → bare `Header`, never matched → gone;
+- tabset → the section *does* exist inside the pane
+  (`<section id="create-the-integration" class="level4">` is present in Q1's
+  render of the strand's repro), but it is buried under
+  `Div(.panel-tabset)` whose first child is `Plain(nav)` — the walk stops
+  there.
+
+q2 instead recurses into *every* Div and into `BlockQuote`
+(`collect_toc_entries`, `crates/pampa/src/toc.rs:341`), and its
+`sectionize_blocks` (`crates/pampa/src/transforms/sectionize.rs:75`) never
+recurses into Divs at all. The two divergences currently cancel out for the
+plain-div case and compound for the tabset and blockquote cases.

--- a/claude-notes/plans/tabset-headings-in-toc-investigation/div-toc-probe/_quarto.yml
+++ b/claude-notes/plans/tabset-headings-in-toc-investigation/div-toc-probe/_quarto.yml
@@ -1,0 +1,8 @@
+project:
+  type: website
+website:
+  title: "Div TOC probe"
+format:
+  html:
+    toc: true
+    toc-depth: 4

--- a/claude-notes/plans/tabset-headings-in-toc-investigation/div-toc-probe/index.qmd
+++ b/claude-notes/plans/tabset-headings-in-toc-investigation/div-toc-probe/index.qmd
@@ -1,0 +1,31 @@
+---
+title: Headings inside non-section Divs
+---
+
+## Real heading one
+
+### Plain div
+
+::: {.my-wrapper}
+#### Heading inside a plain div
+
+Body.
+:::
+
+### Callout
+
+::: {.callout-note}
+#### Heading inside a callout
+
+Body.
+:::
+
+### Blockquote
+
+> #### Heading inside a blockquote
+>
+> Body.
+
+## Real heading two
+
+Done.

--- a/claude-notes/plans/tabset-headings-in-toc-investigation/spike-B.patch
+++ b/claude-notes/plans/tabset-headings-in-toc-investigation/spike-B.patch
@@ -1,0 +1,70 @@
+# Throwaway spike for direction (B) -- NOT a proposed patch.
+# Recurse into non-section Divs, apply pandoc's absorb rule, restrict the
+# TOC walk to the section tree. Measured, then reverted. See README.md.
+diff --git a/crates/pampa/src/toc.rs b/crates/pampa/src/toc.rs
+index bab30f4a..1216684f 100644
+--- a/crates/pampa/src/toc.rs
++++ b/crates/pampa/src/toc.rs
+@@ -352,8 +352,8 @@ fn collect_toc_entries(blocks: &[Block], max_depth: i32) -> Vec<FlatTocEntry> {
+                     // Recurse into section content for nested sections
+                     entries.extend(collect_toc_entries(&div.content, max_depth));
+                 } else {
+-                    // Non-section Div - recurse into content
+-                    entries.extend(collect_toc_entries(&div.content, max_depth));
++                    // SPIKE(B) part 3: a non-section Div terminates the walk,
++                    // matching pandoc's sectionToListItem.
+                 }
+             }
+             Block::Header(header) => {
+@@ -363,9 +363,7 @@ fn collect_toc_entries(blocks: &[Block], max_depth: i32) -> Vec<FlatTocEntry> {
+                 }
+             }
+             // Other block types: recurse if they contain blocks
+-            Block::BlockQuote(bq) => {
+-                entries.extend(collect_toc_entries(&bq.content, max_depth));
+-            }
++            // SPIKE(B): BlockQuote arm removed (pandoc does not sectionize into it)
+             _ => {
+                 // Other blocks don't contain headers
+             }
+diff --git a/crates/pampa/src/transforms/sectionize.rs b/crates/pampa/src/transforms/sectionize.rs
+index f0357013..bb3d818d 100644
+--- a/crates/pampa/src/transforms/sectionize.rs
++++ b/crates/pampa/src/transforms/sectionize.rs
+@@ -83,6 +83,36 @@ pub fn sectionize_blocks(blocks: Vec<Block>) -> Vec<Block> {
+     let mut output: Vec<Block> = vec![];
+ 
+     for block in blocks {
++        // SPIKE(B) part 1+2: recurse into non-section Divs, then apply
++        // pandoc's makeSections absorb rule -- a Div with an empty id whose
++        // content is exactly one section is replaced by that section, with
++        // the Div's classes/kvs merged in.
++        let block = match block {
++            Block::Div(d) if !d.attr.1.iter().any(|c| c == "section") => {
++                let content = sectionize_blocks(d.content);
++                let absorbable = d.attr.0.is_empty()
++                    && content.len() == 1
++                    && matches!(&content[0],
++                        Block::Div(inner) if inner.attr.1.iter().any(|c| c == "section"));
++                if absorbable {
++                    let Block::Div(mut inner) = content.into_iter().next().unwrap() else {
++                        unreachable!()
++                    };
++                    for c in &d.attr.1 {
++                        if !inner.attr.1.contains(c) {
++                            inner.attr.1.push(c.clone());
++                        }
++                    }
++                    for (k, v) in &d.attr.2 {
++                        inner.attr.2.entry(k.clone()).or_insert_with(|| v.clone());
++                    }
++                    Block::Div(inner)
++                } else {
++                    Block::Div(Div { content, ..d })
++                }
++            }
++            other => other,
++        };
+         if let Block::Header(ref header) = block {
+             let level = header.level;
+             let (id, classes, attrs) = &header.attr;

--- a/crates/pampa/src/toc.rs
+++ b/crates/pampa/src/toc.rs
@@ -43,6 +43,30 @@
 //! - **Sectionized blocks**: Walk section Divs created by `sectionize_blocks`
 //!
 //! The function detects sectionized structure and extracts headers accordingly.
+//!
+//! ## The walk stops at a non-section Div
+//!
+//! The table of contents *is* the section tree. A `Div` that is not a
+//! section ends the walk, with no recursion past it — this is pandoc's
+//! rule, whose `sectionToListItem` matches only `Div(_, _, Header:rest)`
+//! and yields nothing for anything else.
+//!
+//! This is not a loss of reach, because `sectionize_blocks` *absorbs* a
+//! transparent wrapper — an empty-id `Div` around a single header-led
+//! run — into the section itself, so a heading inside `::: {.column-margin}`
+//! or a plain `:::` block is a section by the time we get here. What stays
+//! wrapped in a plain `Div` is filter-built chrome: a callout body, a
+//! tabset pane. Quarto 1 does not list those either, and listing them was
+//! actively harmful — the entries were indistinguishable from one another
+//! and every one past the first pointed at `display: none` content
+//! (bd-tabset-headings-in-toc-t04ie7f7).
+//!
+//! **Precondition:** callers that want headings nested in Divs to appear
+//! must pass blocks that have been through `sectionize_blocks`. See
+//! `SectionizeTransform`, which runs before `TocGenerateTransform`;
+//! `DocumentProfile::extract_outline` sectionizes a copy for the same
+//! reason. Revealjs skips `SectionizeTransform` and would therefore get
+//! an empty TOC — it emits none today, and bd-tebu6o4a tracks the trap.
 
 use crate::pandoc::block::{Block, Div, Header};
 use crate::pandoc::inline::{Inline, Inlines, Str};
@@ -343,18 +367,16 @@ fn collect_toc_entries(blocks: &[Block], max_depth: i32) -> Vec<FlatTocEntry> {
 
     for block in blocks {
         match block {
-            Block::Div(div) => {
-                // Check if this is a section Div
-                if is_section_div(div) {
-                    if let Some(entry) = extract_entry_from_section(div, max_depth) {
-                        entries.push(entry);
-                    }
-                    // Recurse into section content for nested sections
-                    entries.extend(collect_toc_entries(&div.content, max_depth));
-                } else {
-                    // Non-section Div - recurse into content
-                    entries.extend(collect_toc_entries(&div.content, max_depth));
+            // Only section Divs are walked. A Div that is not a section
+            // ends the walk, with no recursion past it — pandoc's
+            // `sectionToListItem` matches `Div(_, _, Header:rest)` and
+            // returns nothing for anything else.
+            Block::Div(div) if is_section_div(div) => {
+                if let Some(entry) = extract_entry_from_section(div, max_depth) {
+                    entries.push(entry);
                 }
+                // Recurse into section content for nested sections
+                entries.extend(collect_toc_entries(&div.content, max_depth));
             }
             Block::Header(header) => {
                 // Direct header (non-sectionized document)
@@ -362,12 +384,12 @@ fn collect_toc_entries(blocks: &[Block], max_depth: i32) -> Vec<FlatTocEntry> {
                     entries.push(entry);
                 }
             }
-            // Other block types: recurse if they contain blocks
-            Block::BlockQuote(bq) => {
-                entries.extend(collect_toc_entries(&bq.content, max_depth));
-            }
             _ => {
-                // Other blocks don't contain headers
+                // Nothing else carries a section. In particular
+                // `BlockQuote`: `sectionize_blocks` does not descend
+                // into one (matching pandoc's `makeSections`), so a
+                // quoted heading is never a section and is never
+                // listed. bd-8yjvs3bj.
             }
         }
     }
@@ -700,6 +722,107 @@ mod tests {
         assert_eq!(toc.entries[0].id, "main");
         assert_eq!(toc.entries[0].children.len(), 1);
         assert_eq!(toc.entries[0].children[0].id, "sub");
+    }
+
+    // ── the walk stops at a non-section Div ────────────────────────
+    //
+    // pandoc's `toTableOfContents` matches only `Div(_, _, Header:rest)`
+    // — a section — so a Div that is not one ends the walk with no
+    // recursion past it. Everything a reader expects to see in the TOC
+    // has already been *absorbed* into the section tree by
+    // `sectionize_blocks`; what remains wrapped in a plain Div is filter
+    // chrome (a callout, a tabset pane), and Quarto 1 does not list it.
+
+    /// Every id in the tree, depth-first. Checking only `toc.entries`
+    /// would miss a leaked entry, which `build_hierarchy` nests *under*
+    /// the preceding top-level section rather than beside it.
+    fn all_ids(entries: &[TocEntry]) -> Vec<String> {
+        let mut out = Vec::new();
+        for e in entries {
+            out.push(e.id.clone());
+            out.extend(all_ids(&e.children));
+        }
+        out
+    }
+
+    /// The default depth is 3, which would exclude the level-4 headings
+    /// these tests use for reasons that have nothing to do with the walk.
+    fn deep_config() -> TocConfig {
+        TocConfig {
+            depth: 4,
+            title: None,
+        }
+    }
+
+    fn make_plain_div(id: &str, classes: Vec<&str>, content: Vec<Block>) -> Block {
+        Block::Div(Div {
+            attr: (
+                id.to_string(),
+                classes.iter().map(|s| s.to_string()).collect(),
+                LinkedHashMap::new(),
+            ),
+            content,
+            source_info: dummy_source_info(),
+            attr_source: AttrSourceInfo::empty(),
+        })
+    }
+
+    #[test]
+    fn test_non_section_div_terminates_the_walk() {
+        // The shape a resolved tabset leaves behind: a section, real and
+        // correct, buried under two plain Divs.
+        let blocks = vec![
+            make_section(2, "configuration", vec![], "Configuration", vec![]),
+            make_plain_div(
+                "",
+                vec!["panel-tabset"],
+                vec![make_plain_div(
+                    "tabset-1-1",
+                    vec!["tab-pane"],
+                    vec![make_section(4, "in-a-tab", vec![], "In a tab", vec![])],
+                )],
+            ),
+            make_section(2, "next-steps", vec![], "Next steps", vec![]),
+        ];
+        let toc = generate_toc(&blocks, &deep_config());
+        assert_eq!(
+            all_ids(&toc.entries),
+            vec!["configuration", "next-steps"],
+            "the section inside the tab pane is real, but unreachable"
+        );
+    }
+
+    #[test]
+    fn test_section_nested_in_a_section_is_still_collected() {
+        // The walk must still recurse through *sections*, or the TOC
+        // would flatten to top-level headings only.
+        let blocks = vec![make_section(
+            2,
+            "outer",
+            vec![],
+            "Outer",
+            vec![make_section(3, "inner", vec![], "Inner", vec![])],
+        )];
+        let toc = generate_toc(&blocks, &TocConfig::default());
+        assert_eq!(toc.entries.len(), 1);
+        assert_eq!(toc.entries[0].id, "outer");
+        assert_eq!(toc.entries[0].children.len(), 1);
+        assert_eq!(toc.entries[0].children[0].id, "inner");
+    }
+
+    /// bd-8yjvs3bj. `makeSections` never descends into a `BlockQuote`, so
+    /// a heading quoted there is not a section and is not listed.
+    #[test]
+    fn test_blockquote_heading_is_not_collected() {
+        let blocks = vec![
+            make_section(2, "outer", vec![], "Outer", vec![]),
+            Block::BlockQuote(quarto_pandoc_types::block::BlockQuote {
+                content: vec![make_header(4, "quoted", vec![], "Quoted")],
+                source_info: dummy_source_info(),
+            }),
+        ];
+        let toc = generate_toc(&blocks, &deep_config());
+        assert_eq!(all_ids(&toc.entries), vec!["outer"]);
     }
 
     #[test]

--- a/crates/pampa/src/transforms/sectionize.rs
+++ b/crates/pampa/src/transforms/sectionize.rs
@@ -83,6 +83,9 @@ pub fn sectionize_blocks(blocks: Vec<Block>) -> Vec<Block> {
     let mut output: Vec<Block> = vec![];
 
     for block in blocks {
+        // Recurse into Divs first, so an inner heading is already a
+        // section by the time the absorb check below looks at it.
+        let block = sectionize_div(block);
         if let Block::Header(ref header) = block {
             let level = header.level;
             let (id, classes, attrs) = &header.attr;
@@ -163,6 +166,77 @@ pub fn sectionize_blocks(blocks: Vec<Block>) -> Vec<Block> {
     }
 
     output
+}
+
+/// Sectionize the content of a non-section `Div`, then apply pandoc's
+/// absorb rule.
+///
+/// `makeSections` recurses into Divs and replaces a Div by the section it
+/// wraps when — and only when — the Div has an **empty id** and its
+/// content is **exactly one section**; the Div's classes and key-values
+/// are merged onto that section. Anything else keeps the Div and nests
+/// the section(s) inside it.
+///
+/// The five cases are pinned by Quarto 1's render of
+/// `claude-notes/plans/tabset-headings-in-toc-investigation/absorb-rule-probe/`:
+/// a bare wrapper absorbs (`<section id="case-a" class="level3 wrap-a">`);
+/// a Div with its own id does not; leading content before the heading
+/// does not; two sibling headings do not; key-values are merged.
+///
+/// Blocks other than `Div` are returned untouched — in particular
+/// `BlockQuote`, which pandoc does not descend into, so a heading quoted
+/// there stays a bare `Header` and never reaches the table of contents.
+fn sectionize_div(block: Block) -> Block {
+    let Block::Div(div) = block else {
+        return block;
+    };
+    if is_section(&div.attr.1) {
+        return Block::Div(div);
+    }
+
+    let Div {
+        attr,
+        content,
+        source_info,
+        attr_source,
+    } = div;
+    let mut content = sectionize_blocks(content);
+
+    let absorbable = attr.0.is_empty()
+        && content.len() == 1
+        && matches!(&content[0], Block::Div(inner) if is_section(&inner.attr.1));
+    if !absorbable {
+        return Block::Div(Div {
+            attr,
+            content,
+            source_info,
+            attr_source,
+        });
+    }
+
+    let Some(Block::Div(mut section)) = content.pop() else {
+        unreachable!("checked by `absorbable`")
+    };
+    // The section keeps its own id (the header's) and its `section` /
+    // `levelN` markers; the wrapper contributes its classes and
+    // key-values. `attr_source` for the merged-in pieces is dropped:
+    // the section Div is `By::sectionize()`-generated anyway, and a
+    // stale offset would be worse than none.
+    for class in attr.1 {
+        if !section.attr.1.contains(&class) {
+            section.attr.1.push(class);
+        }
+    }
+    for (k, v) in attr.2 {
+        section.attr.2.entry(k).or_insert(v);
+    }
+    section.attr_source = AttrSourceInfo::empty();
+    Block::Div(section)
+}
+
+/// A Div produced by [`sectionize_blocks`] carries the `section` class.
+fn is_section(classes: &[String]) -> bool {
+    classes.iter().any(|c| c == "section")
 }
 
 #[cfg(test)]
@@ -575,6 +649,215 @@ mod tests {
         let Block::Header(_) = &div.content[0] else {
             panic!("Expected Header inside section");
         };
+    }
+
+    // ── recursion into Divs, and pandoc's absorb rule ──────────────
+    //
+    // Ground truth for every case below was captured from Quarto 1's
+    // render of `claude-notes/plans/tabset-headings-in-toc-investigation/
+    // absorb-rule-probe/`. pandoc's `makeSections` recurses into Divs and
+    // replaces a Div by the section it wraps when — and only when — the
+    // Div has an empty id and its content is exactly one section.
+
+    fn make_div(
+        id: &str,
+        classes: Vec<&str>,
+        attrs: Vec<(&str, &str)>,
+        content: Vec<Block>,
+    ) -> Block {
+        let mut attr_map = LinkedHashMap::new();
+        for (k, v) in attrs {
+            attr_map.insert(k.to_string(), v.to_string());
+        }
+        Block::Div(Div {
+            attr: (
+                id.to_string(),
+                classes.iter().map(|s| s.to_string()).collect(),
+                attr_map,
+            ),
+            content,
+            source_info: dummy_source_info(),
+            attr_source: AttrSourceInfo::empty(),
+        })
+    }
+
+    /// Unwrap a `Block::Div`, or panic with a useful message.
+    fn as_div<'a>(block: &'a Block, what: &str) -> &'a Div {
+        match block {
+            Block::Div(d) => d,
+            other => panic!("expected {what} to be a Div, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_sectionize_recurses_into_divs() {
+        // A heading inside a Div must become a section; before this it
+        // stayed a bare Header and the HTML writer emitted <div><h3>.
+        let blocks = vec![make_div(
+            "",
+            vec!["wrap"],
+            vec![],
+            vec![make_header(3, "inner", vec![], "Inner"), make_para("Body")],
+        )];
+        let result = sectionize_blocks(blocks);
+        assert_eq!(result.len(), 1);
+        let section = as_div(&result[0], "the absorbed wrapper");
+        assert_eq!(section.attr.0, "inner");
+        assert!(section.attr.1.contains(&"section".to_string()));
+    }
+
+    /// Case A: bare Div, one header-led run → absorbed, classes merged.
+    #[test]
+    fn test_sectionize_absorbs_bare_div_into_section() {
+        let blocks = vec![make_div(
+            "",
+            vec!["wrap-a"],
+            vec![],
+            vec![
+                make_header(3, "case-a", vec![], "Case A"),
+                make_para("Body"),
+            ],
+        )];
+        let result = sectionize_blocks(blocks);
+        assert_eq!(result.len(), 1, "the Div is replaced, not nested");
+        let section = as_div(&result[0], "section");
+        assert_eq!(section.attr.0, "case-a", "the header's id wins");
+        assert_eq!(
+            section.attr.1,
+            vec![
+                "section".to_string(),
+                "level3".to_string(),
+                "wrap-a".to_string()
+            ],
+            "the Div's classes are merged after the section markers"
+        );
+    }
+
+    /// Case B: a Div with its own id is *not* absorbed.
+    #[test]
+    fn test_sectionize_does_not_absorb_div_with_id() {
+        let blocks = vec![make_div(
+            "has-id",
+            vec!["wrap-b"],
+            vec![],
+            vec![make_header(3, "case-b", vec![], "Case B")],
+        )];
+        let result = sectionize_blocks(blocks);
+        let outer = as_div(&result[0], "the surviving wrapper");
+        assert_eq!(outer.attr.0, "has-id");
+        assert!(!outer.attr.1.contains(&"section".to_string()));
+        assert_eq!(outer.content.len(), 1);
+        let inner = as_div(&outer.content[0], "the nested section");
+        assert_eq!(inner.attr.0, "case-b");
+        assert!(inner.attr.1.contains(&"section".to_string()));
+    }
+
+    /// Case C: content before the first header blocks absorption.
+    #[test]
+    fn test_sectionize_does_not_absorb_div_with_leading_content() {
+        let blocks = vec![make_div(
+            "",
+            vec!["wrap-c"],
+            vec![],
+            vec![
+                make_para("Leading"),
+                make_header(3, "case-c", vec![], "Case C"),
+            ],
+        )];
+        let result = sectionize_blocks(blocks);
+        let outer = as_div(&result[0], "the surviving wrapper");
+        assert_eq!(outer.attr.1, vec!["wrap-c".to_string()]);
+        assert_eq!(outer.content.len(), 2, "leading para + one section");
+        assert!(matches!(outer.content[0], Block::Paragraph(_)));
+        assert!(
+            as_div(&outer.content[1], "nested section")
+                .attr
+                .1
+                .contains(&"section".to_string())
+        );
+    }
+
+    /// Case D: two sibling sections cannot collapse into one.
+    #[test]
+    fn test_sectionize_does_not_absorb_div_with_two_sections() {
+        let blocks = vec![make_div(
+            "",
+            vec!["wrap-d"],
+            vec![],
+            vec![
+                make_header(3, "d-one", vec![], "D one"),
+                make_header(3, "d-two", vec![], "D two"),
+            ],
+        )];
+        let result = sectionize_blocks(blocks);
+        let outer = as_div(&result[0], "the surviving wrapper");
+        assert_eq!(outer.attr.1, vec!["wrap-d".to_string()]);
+        assert_eq!(outer.content.len(), 2, "two sibling sections");
+        for (i, child) in outer.content.iter().enumerate() {
+            assert!(
+                as_div(child, "a nested section")
+                    .attr
+                    .1
+                    .contains(&"section".to_string()),
+                "child {i} is sectionized even though the Div is not absorbed"
+            );
+        }
+    }
+
+    /// Case E: key-value attributes are merged on absorption.
+    #[test]
+    fn test_sectionize_absorb_merges_key_values() {
+        let blocks = vec![make_div(
+            "",
+            vec!["wrap-e"],
+            vec![("data-thing", "x")],
+            vec![make_header(3, "case-e", vec![], "Case E")],
+        )];
+        let result = sectionize_blocks(blocks);
+        let section = as_div(&result[0], "section");
+        assert!(
+            section.attr.1.contains(&"section".to_string()),
+            "the Div was absorbed, so what remains is the section itself"
+        );
+        assert_eq!(section.attr.0, "case-e");
+        assert_eq!(
+            section.attr.2.get("data-thing").map(String::as_str),
+            Some("x")
+        );
+        assert!(section.attr.1.contains(&"wrap-e".to_string()));
+    }
+
+    /// An already-sectionized Div is left alone — sectionize must be
+    /// idempotent, and a `section` Div is not a candidate for absorbing.
+    #[test]
+    fn test_sectionize_is_idempotent_over_divs() {
+        let blocks = vec![make_div(
+            "",
+            vec!["wrap"],
+            vec![],
+            vec![make_header(3, "inner", vec![], "Inner")],
+        )];
+        let once = sectionize_blocks(blocks);
+        let twice = sectionize_blocks(once.clone());
+        assert_eq!(format!("{once:?}"), format!("{twice:?}"));
+    }
+
+    /// pandoc's `makeSections` does not descend into a `BlockQuote`, so a
+    /// heading there stays a bare Header (and thus out of the TOC).
+    #[test]
+    fn test_sectionize_does_not_descend_into_blockquote() {
+        let blocks = vec![Block::BlockQuote(quarto_pandoc_types::block::BlockQuote {
+            content: vec![make_header(3, "quoted", vec![], "Quoted")],
+            source_info: dummy_source_info(),
+        })];
+        let result = sectionize_blocks(blocks);
+        let Block::BlockQuote(bq) = &result[0] else {
+            panic!("blockquote survives")
+        };
+        assert!(
+            matches!(bq.content[0], Block::Header(_)),
+            "the heading stays a bare Header"
+        );
     }
 
     #[test]

--- a/crates/quarto-core/src/document_profile.rs
+++ b/crates/quarto-core/src/document_profile.rs
@@ -1053,9 +1053,36 @@ fn extract_structured_authors(meta: &ConfigValue) -> Vec<ProfileAuthor> {
 /// naturally produces `TocEntry::number == None`, but we scrub the
 /// tree defensively so the invariant holds even if `generate_toc`
 /// grows new numbering behavior.
+///
+/// ## Why this sectionizes first
+///
+/// `generate_toc` walks the *section tree* and stops at any `Div` that
+/// is not a section. The profile is extracted at `DocumentProfileStage`,
+/// long before `SectionizeTransform` runs, so the blocks here are flat
+/// `Header`s wrapped in raw author `Div`s. Walking them directly would
+/// drop every heading written inside a `:::` block — including ordinary
+/// ones like `::: {.content-visible}`, which the rendered TOC does list.
+/// Sectionizing a copy first restores the absorb rule, so a transparent
+/// wrapper disappears and its heading is an ordinary section.
+///
+/// ## Known limitation
+///
+/// This is close to, but not identical with, the rendered TOC. Transforms
+/// that *consume* a heading run after the profile checkpoint, so a callout
+/// **title** written as a heading is still absorbed into a section here
+/// and appears in the outline, while the rendered TOC omits it
+/// (`CalloutTransform` ate the `Header` before `SectionizeTransform` saw
+/// it). Tab titles and tabset/callout **body** headings are excluded
+/// correctly, because their wrappers hold more than a single section and
+/// so are never absorbed. Closing the gap entirely would mean running the
+/// heading-consuming transforms before the profile, which the profile
+/// contract deliberately does not do — see
+/// `claude-notes/designs/document-profile-contract.md`. Tracked as
+/// bd-ca17fck0.
 fn extract_outline(blocks: &[quarto_pandoc_types::block::Block]) -> Vec<TocEntry> {
+    let sectionized = pampa::transforms::sectionize_blocks(blocks.to_vec());
     let toc = generate_toc(
-        blocks,
+        &sectionized,
         &TocConfig {
             depth: OUTLINE_MAX_DEPTH,
             title: None,
@@ -1165,6 +1192,49 @@ Deep text.
         assert!(
             all_unnumbered(&profile.outline),
             "profile outline must be un-numbered"
+        );
+    }
+
+    /// The outline is built from the section tree, so it needs the same
+    /// sectionizing the render does — otherwise every heading written
+    /// inside a `:::` block disappears from it. Pins both the fix and
+    /// the known gap (see `extract_outline`'s docs).
+    #[test]
+    fn outline_sees_headings_inside_divs() {
+        let qmd = r#"---
+title: Outline containers
+---
+
+# Top
+
+::: {.content-visible when-format="html"}
+## Inside a transparent wrapper
+:::
+
+::: {.panel-tabset}
+## Tab one
+
+## Tab two
+:::
+"#;
+        let ast = parse_qmd(qmd);
+        let profile = DocumentProfile::extract(
+            &ast,
+            Path::new("outline-containers.qmd"),
+            "outline-containers.html",
+            "html",
+        );
+
+        let ids = entry_ids(&profile.outline[0].children);
+        assert!(
+            ids.contains(&"inside-a-transparent-wrapper"),
+            "an empty-id wrapper around one section is absorbed, so its \
+             heading is an ordinary section: {ids:?}"
+        );
+        assert!(
+            !ids.contains(&"tab-one") && !ids.contains(&"tab-two"),
+            "a tabset holds two sections, so it is never absorbed and the \
+             walk stops at it: {ids:?}"
         );
     }
 

--- a/crates/quarto-core/src/transforms/conditional_content.rs
+++ b/crates/quarto-core/src/transforms/conditional_content.rs
@@ -23,8 +23,33 @@
 //! - `unless-*` negates its kind;
 //! - `.content-visible` with no conditions is always visible,
 //!   `.content-hidden` with no conditions always hidden;
-//! - surviving elements keep their classes but lose the condition
-//!   attributes (Q1's `clearHiddenVisibleAttributes`).
+//! - surviving elements lose the marker class *and* the condition
+//!   attributes (Q1's `clearHiddenVisibleAttributes`,
+//!   `customnodes/content-hidden.lua:211`).
+//!
+//! ## Resolving the wrapper
+//!
+//! A conditional `Div` is scaffolding: it exists only to carry the
+//! condition. Q1 resolves a visible one by returning its *content*
+//! (`customnodes/content-hidden.lua:66`, `return el.content`), so the
+//! wrapper disappears from the output. Spans and CodeBlocks keep their
+//! element -- "this is only called on spans and codeblocks, so here we
+//! keep the scaffolding element, as opposed to in the Div where we
+//! return the inlined content" (`:154`).
+//!
+//! We unwrap a `Div` only when the wrapper carries nothing of its own
+//! after stripping (see [`is_bare_wrapper`]). Q1 unwraps
+//! unconditionally, discarding any `#id` or extra classes the author
+//! wrote; keeping those costs nothing and loses no parity, because an
+//! empty-id wrapper is absorbed into its section by `sectionize_blocks`
+//! regardless.
+//!
+//! Leaving the wrapper in place was a real defect, not a cosmetic one:
+//! `collect_toc_entries` walks only the section tree, and a surviving
+//! Div terminates that walk, so every heading inside a conditional
+//! block dropped out of the table of contents
+//! (bd-tabset-headings-in-toc-t04ie7f7, plan
+//! `claude-notes/plans/2026-08-18-tabset-headings-in-toc.md`).
 //!
 //! Semantics notes:
 //! - `when-format` uses the same alias table as Lua's
@@ -185,6 +210,18 @@ enum Verdict {
     KeepLlmsOnly,
 }
 
+/// What [`Walker::keep_block`] decided about a block.
+enum BlockAction {
+    /// Drop the block.
+    Drop,
+    /// Keep the block where it is.
+    Keep,
+    /// Replace the block with its own content — a resolved conditional
+    /// `Div` whose wrapper carried nothing of its own. See
+    /// [`is_bare_wrapper`].
+    Splice,
+}
+
 impl Walker<'_> {
     /// Evaluate an element's marker classes + condition attributes.
     fn verdict(&mut self, attr: &Attr, source_info: &quarto_source_map::SourceInfo) -> Verdict {
@@ -326,17 +363,36 @@ impl Walker<'_> {
     // ── recursion ───────────────────────────────────────────────────
 
     fn filter_blocks(&mut self, blocks: &mut Vec<Block>) {
-        blocks.retain_mut(|block| self.keep_block(block));
+        let taken = std::mem::take(blocks);
+        blocks.reserve(taken.len());
+        for mut block in taken {
+            match self.keep_block(&mut block) {
+                BlockAction::Drop => {}
+                BlockAction::Keep => blocks.push(block),
+                BlockAction::Splice => match block {
+                    Block::Div(div) => blocks.extend(div.content),
+                    // `Splice` is only ever issued for a `Div`.
+                    other => blocks.push(other),
+                },
+            }
+        }
     }
 
-    /// Decide whether `block` survives; recurse into whatever content
+    /// Decide what happens to `block`; recurse into whatever content
     /// it keeps.
-    fn keep_block(&mut self, block: &mut Block) -> bool {
+    fn keep_block(&mut self, block: &mut Block) -> BlockAction {
         match block {
             Block::Div(div) => {
+                let mut splice = false;
                 match self.verdict(&div.attr, &div.source_info) {
-                    Verdict::Remove => return false,
-                    Verdict::Keep => strip_condition_attrs(&mut div.attr, &mut div.attr_source),
+                    Verdict::Remove => return BlockAction::Drop,
+                    Verdict::Keep => {
+                        strip_condition_attrs(&mut div.attr, &mut div.attr_source);
+                        // The wrapper existed only to carry the
+                        // condition; with the condition resolved and
+                        // nothing else on it, Q1 returns its content.
+                        splice = is_bare_wrapper(&div.attr);
+                    }
                     Verdict::KeepTargetOnly => {
                         strip_condition_attrs(&mut div.attr, &mut div.attr_source);
                         llms::add_marker_class(
@@ -356,9 +412,12 @@ impl Walker<'_> {
                     Verdict::NotConditional => {}
                 }
                 self.filter_blocks(&mut div.content);
+                if splice {
+                    return BlockAction::Splice;
+                }
             }
             Block::CodeBlock(cb) => match self.verdict(&cb.attr, &cb.source_info) {
-                Verdict::Remove => return false,
+                Verdict::Remove => return BlockAction::Drop,
                 Verdict::Keep => strip_condition_attrs(&mut cb.attr, &mut cb.attr_source),
                 Verdict::KeepTargetOnly => {
                     strip_condition_attrs(&mut cb.attr, &mut cb.attr_source);
@@ -444,8 +503,9 @@ impl Walker<'_> {
                     use quarto_pandoc_types::custom::Slot;
                     match slot {
                         Slot::Block(b) => {
-                            // A slot holds exactly one block; removal
-                            // isn't representable, so only recurse.
+                            // A slot holds exactly one block; neither
+                            // removal nor splicing is representable,
+                            // so only recurse.
                             let _ = self.keep_block(b);
                         }
                         Slot::Blocks(bs) => self.filter_blocks(bs),
@@ -458,7 +518,7 @@ impl Walker<'_> {
             }
             _ => {}
         }
-        true
+        BlockAction::Keep
     }
 
     fn filter_inlines(&mut self, inlines: &mut Vec<Inline>) {
@@ -529,6 +589,40 @@ fn strip_condition_attrs(attr: &mut Attr, attr_source: &mut quarto_pandoc_types:
         attr_source.attributes.clear();
     }
     attr.2.retain(|k, _| !CONDITION_KEYS.contains(&k.as_str()));
+
+    // Q1's `clearHiddenVisibleAttributes` drops the marker classes too
+    // (`customnodes/content-hidden.lua:216`). They have done their job
+    // once the condition is resolved, and leaving them behind puts a
+    // `<div class="content-visible">` in the output that Q1 never emits.
+    let classes_aligned = attr.1.len() == attr_source.classes.len();
+    if classes_aligned {
+        let keep: Vec<bool> = attr
+            .1
+            .iter()
+            .map(|c| c != VISIBLE_CLASS && c != HIDDEN_CLASS)
+            .collect();
+        let mut it = keep.iter();
+        attr_source.classes.retain(|_| *it.next().unwrap());
+    } else {
+        attr_source.classes.clear();
+    }
+    attr.1.retain(|c| c != VISIBLE_CLASS && c != HIDDEN_CLASS);
+}
+
+/// True when a resolved conditional `Div` carries nothing of its own —
+/// no id, no classes, no attributes — once the marker class and the
+/// condition attributes have been stripped.
+///
+/// Q1 unwraps a visible conditional Div unconditionally
+/// (`customnodes/content-hidden.lua:66`, `return el.content`), which
+/// also discards any `#id` or extra classes the author wrote. We unwrap
+/// only what the feature itself contributed, so author attributes
+/// survive. The two rules coincide whenever the Div is a bare marker,
+/// which is every real use we have measured; and when they differ, an
+/// empty-id wrapper is absorbed into its section by `sectionize_blocks`
+/// anyway, so the TOC outcome is identical either way.
+fn is_bare_wrapper(attr: &Attr) -> bool {
+    attr.0.is_empty() && attr.1.is_empty() && attr.2.is_empty()
 }
 
 #[cfg(test)]
@@ -546,6 +640,16 @@ mod tests {
                 .map(|(k, v)| (k.to_string(), v.to_string()))
                 .collect(),
         )
+    }
+
+    fn plain(text: &str) -> Block {
+        Block::Plain(quarto_pandoc_types::block::Plain {
+            content: vec![Inline::Str(quarto_pandoc_types::inline::Str {
+                text: text.to_string(),
+                source_info: SourceInfo::generated(By::unknown()),
+            })],
+            source_info: SourceInfo::generated(By::unknown()),
+        })
     }
 
     fn div(classes: &[&str], kvs: &[(&str, &str)], text: &str) -> Block {
@@ -696,7 +800,7 @@ mod tests {
     }
 
     #[test]
-    fn surviving_element_loses_condition_attrs_keeps_class() {
+    fn surviving_element_loses_marker_class_and_conditions_keeps_the_rest() {
         let meta = empty_meta();
         let mut blocks = vec![div(
             &["content-visible", "keep-me"],
@@ -704,13 +808,47 @@ mod tests {
             "X",
         )];
         run(&mut blocks, "html", &["adv"], &meta);
+        // Author attributes remain, so the wrapper is not bare and the
+        // Div stays -- only what the feature contributed is removed.
         let Block::Div(d) = &blocks[0] else {
-            panic!("div survives")
+            panic!("div carrying author attrs survives")
         };
-        assert!(d.attr.1.contains(&"content-visible".to_string()));
+        assert!(
+            !d.attr.1.contains(&"content-visible".to_string()),
+            "marker class stripped (Q1's clearHiddenVisibleAttributes)"
+        );
         assert!(d.attr.1.contains(&"keep-me".to_string()));
         assert!(!d.attr.2.contains_key("when-profile"), "stripped");
         assert!(d.attr.2.contains_key("data-x"), "unrelated attrs kept");
+    }
+
+    #[test]
+    fn bare_wrapper_is_unwrapped() {
+        let meta = empty_meta();
+        let mut blocks = vec![div(&["content-visible"], &[("when-format", "html")], "X")];
+        run(&mut blocks, "html", &[], &meta);
+        assert_eq!(blocks.len(), 1, "content survives: {}", texts(&blocks));
+        assert!(
+            !matches!(blocks[0], Block::Div(_)),
+            "a wrapper carrying nothing of its own is spliced away"
+        );
+        assert!(texts(&blocks).contains("X"), "{}", texts(&blocks));
+    }
+
+    #[test]
+    fn wrapper_with_an_id_is_kept() {
+        let meta = empty_meta();
+        let mut blocks = vec![div(&["content-visible"], &[("when-format", "html")], "X")];
+        let Block::Div(d) = &mut blocks[0] else {
+            panic!("div")
+        };
+        d.attr.0 = "anchor".to_string();
+        run(&mut blocks, "html", &[], &meta);
+        let Block::Div(d) = &blocks[0] else {
+            panic!("a wrapper with an author id is not bare, so it survives")
+        };
+        assert_eq!(d.attr.0, "anchor", "author id preserved");
+        assert!(d.attr.1.is_empty(), "marker class still stripped");
     }
 
     #[test]
@@ -737,17 +875,27 @@ mod tests {
     #[test]
     fn nested_conditionals() {
         let meta = empty_meta();
+        // `adv` is not active, so the inner block is removed; the outer
+        // condition holds, so the outer's *other* content survives.
         let inner = div(&["content-visible"], &[("when-profile", "adv")], "INNER");
         let outer = Block::Div(Div {
             attr: attr(&["content-visible"], &[("when-format", "html")]),
-            content: vec![inner],
+            content: vec![inner, plain("OUTER")],
             source_info: SourceInfo::generated(By::unknown()),
             attr_source: AttrSourceInfo::empty(),
         });
         let mut blocks = vec![outer];
         run(&mut blocks, "html", &[], &meta);
-        assert_eq!(blocks.len(), 1, "outer survives");
         assert!(!texts(&blocks).contains("INNER"), "inner removed");
+        assert!(
+            texts(&blocks).contains("OUTER"),
+            "outer content survives: {}",
+            texts(&blocks)
+        );
+        assert!(
+            !blocks.iter().any(|b| matches!(b, Block::Div(_))),
+            "both bare wrappers are spliced away"
+        );
     }
 
     #[test]
@@ -789,20 +937,33 @@ mod tests {
             classes_of(&blocks[1]).iter().any(|c| c == LLMS_KEEP_CLASS),
             "LLMSONLY tagged keep"
         );
-        let both = classes_of(&blocks[2]);
+        // BOTH is fully resolved and its wrapper carried nothing of
+        // its own, so it is spliced away entirely -- no Div, no marker.
         assert!(
-            !both.iter().any(|c| c.starts_with("quarto-llms-")),
-            "BOTH carries no marker: {both:?}"
+            !matches!(blocks[2], Block::Div(_)),
+            "BOTH's wrapper is unwrapped once both views agree"
         );
-        // Condition attributes stripped from every survivor.
-        for b in &blocks {
-            let Block::Div(d) = b else { panic!("div") };
+        assert!(texts(&blocks).contains("BOTH"), "BOTH's content survives");
+
+        // The two tagged survivors keep their Div (the marker class
+        // makes them non-bare) and lose their condition attributes.
+        for b in &blocks[..2] {
+            let Block::Div(d) = b else {
+                panic!("tagged survivors stay wrapped")
+            };
             assert!(
                 d.attr
                     .2
                     .keys()
                     .all(|k| !k.starts_with("when-") && !k.starts_with("unless-")),
                 "condition attrs stripped"
+            );
+            assert!(
+                !d.attr
+                    .1
+                    .iter()
+                    .any(|c| c == "content-visible" || c == "content-hidden"),
+                "marker classes stripped"
             );
         }
     }

--- a/crates/quarto-core/src/transforms/conditional_content.rs
+++ b/crates/quarto-core/src/transforms/conditional_content.rs
@@ -832,7 +832,7 @@ mod tests {
             !matches!(blocks[0], Block::Div(_)),
             "a wrapper carrying nothing of its own is spliced away"
         );
-        assert!(texts(&blocks).contains("X"), "{}", texts(&blocks));
+        assert!(texts(&blocks).contains('X'), "{}", texts(&blocks));
     }
 
     #[test]

--- a/crates/quarto/tests/playwright-fixtures/q2-preview/render-components-kanban/kanban.tsx
+++ b/crates/quarto/tests/playwright-fixtures/q2-preview/render-components-kanban/kanban.tsx
@@ -1,6 +1,15 @@
 const React = window.React;
 const { renderChildren, usePreviewEdit } = window.__Q2_PREVIEW_RENDERER__;
 
+const inlineText = (inlines) => inlines.map(inline => {
+    if (inline.t === 'Str') return inline.c;
+    if (inline.t === 'Space') return ' ';
+    return '';
+}).join('');
+
+const isSection = (block) =>
+    block.t === 'Div' && block.c[0][1].includes('section');
+
 export const Div = (args) => {
     const edit = usePreviewEdit();
     const { node: div } = args;
@@ -11,41 +20,50 @@ export const Div = (args) => {
         return <div id={id} className={classes.join(' ')}>{renderChildren(args)}</div>;
     }
 
-    // Parse kanban structure from the transformed node (for display)
+    // Parse kanban structure from the *transformed* node, for display.
+    //
+    // Each column arrives as a section Div, not a bare Header:
+    // `SectionizeTransform` wraps every heading and the content that
+    // follows it, including headings nested inside a Div like this one.
+    //
+    //   Div(.kanban)
+    //     Div(#backlog .section .level2)[ Header(2) "backlog", BulletList ]
+    //     Div(#doing   .section .level2)[ Header(2) "doing",   BulletList ]
+    //
+    // Reading the transformed AST means reading it as the pipeline
+    // leaves it. The grouping is a convenience here — a column's heading
+    // and its cards arrive together instead of having to be stitched
+    // back up from a flat run of siblings.
     const blocks = div.c[1];
     const columns = [];
-    let currentColumn = null;
 
     for (const block of blocks) {
-        if (block.t === 'Header' && block.c[0] === 2) {
-            const title = block.c[2].map(inline => {
-                if (inline.t === 'Str') return inline.c;
-                if (inline.t === 'Space') return ' ';
-                return '';
-            }).join('');
-            currentColumn = { title, items: [] };
-            columns.push(currentColumn);
-        } else if (block.t === 'BulletList' && currentColumn) {
-            const items = block.c.map(listItem =>
-                listItem.map(b => {
-                    if (b.t === 'Plain' || b.t === 'Para') {
-                        return b.c.map(inline => {
-                            if (inline.t === 'Str') return inline.c;
-                            if (inline.t === 'Space') return ' ';
-                            return '';
-                        }).join('');
-                    }
-                    return '';
-                }).join('')
-            );
-            currentColumn.items.push(...items);
+        if (!isSection(block)) continue;
+        const children = block.c[1];
+        const header = children.find(b => b.t === 'Header' && b.c[0] === 2);
+        if (!header) continue;
+
+        const column = { title: inlineText(header.c[2]), items: [] };
+        for (const child of children) {
+            if (child.t !== 'BulletList') continue;
+            column.items.push(...child.c.map(listItem =>
+                listItem.map(b =>
+                    (b.t === 'Plain' || b.t === 'Para') ? inlineText(b.c) : ''
+                ).join('')
+            ));
         }
+        columns.push(column);
     }
 
     const onMove = (newColumns) => {
         const resolved = edit.resolveSource(div);
         if (!resolved) return;
 
+        // The write path is deliberately *not* symmetric with the read
+        // path above. `resolveSource` hands back the node as it appears
+        // in the source document, which is pre-transform: flat Headers,
+        // no sections. Emitting sections here would write them into the
+        // user's .qmd.
         const newBlocks = [];
         for (const col of newColumns) {
             newBlocks.push({

--- a/crates/quarto/tests/smoke-all/toc-containers/_quarto.yml
+++ b/crates/quarto/tests/smoke-all/toc-containers/_quarto.yml
@@ -1,0 +1,2 @@
+project:
+  title: TOC container tests

--- a/crates/quarto/tests/smoke-all/toc-containers/blockquote-heading-not-in-toc.qmd
+++ b/crates/quarto/tests/smoke-all/toc-containers/blockquote-heading-not-in-toc.qmd
@@ -1,0 +1,24 @@
+---
+format:
+  html:
+    toc: true
+    toc-depth: 4
+_quarto:
+  tests:
+    html:
+      noErrors: true
+      ensureHtmlElements:
+        - ["nav#TOC a[data-scroll-target=\"#outer\"]", "blockquote h4#quoted"]
+        - ["nav#TOC a[data-scroll-target=\"#quoted\"]"]
+---
+
+bd-8yjvs3bj. pandoc's `makeSections` does not descend into a
+`BlockQuote`, so a heading quoted there never becomes a section and never
+reaches the TOC. q2 used to collect it via an explicit `BlockQuote` arm
+in `collect_toc_entries`.
+
+## Outer
+
+> #### Quoted
+>
+> Body.

--- a/crates/quarto/tests/smoke-all/toc-containers/callout-body-heading-not-in-toc.qmd
+++ b/crates/quarto/tests/smoke-all/toc-containers/callout-body-heading-not-in-toc.qmd
@@ -1,0 +1,32 @@
+---
+format:
+  html:
+    toc: true
+    toc-depth: 4
+_quarto:
+  tests:
+    html:
+      noErrors: true
+      ensureHtmlElements:
+        - ["nav#TOC a[data-scroll-target=\"#outer\"]",
+           "div.callout-note section#body-heading"]
+        - ["nav#TOC a[data-scroll-target=\"#body-heading\"]"]
+---
+
+A heading in a callout *body* must not reach the TOC either — the same
+root cause as the tabset case, and a third container beyond the two the
+strand named.
+
+Quarto 1 sectionizes it (`<section id="body-heading" class="level4
+callout-body-container callout-body">`) but the walk stops at the
+enclosing `div.callout`.
+
+## Outer
+
+::: {.callout-note}
+### Callout title
+
+#### Body heading
+
+Body.
+:::

--- a/crates/quarto/tests/smoke-all/toc-containers/callout-title-not-in-toc.qmd
+++ b/crates/quarto/tests/smoke-all/toc-containers/callout-title-not-in-toc.qmd
@@ -1,0 +1,27 @@
+---
+format:
+  html:
+    toc: true
+    toc-depth: 4
+_quarto:
+  tests:
+    html:
+      noErrors: true
+      ensureHtmlElements:
+        - ["nav#TOC a[data-scroll-target=\"#outer\"]", "div.callout-note"]
+        - ["nav#TOC a[data-scroll-target=\"#callout-title\"]"]
+---
+
+A callout's *title* heading is consumed by `CalloutTransform`, which runs
+before `SectionizeTransform`, so it never reaches the TOC.
+
+Regression net: this must keep holding once sectionize recurses into Divs.
+The protection is the consume-first ordering, not sectionize's reach.
+
+## Outer
+
+::: {.callout-note}
+### Callout title
+
+Body.
+:::

--- a/crates/quarto/tests/smoke-all/toc-containers/column-margin-heading-in-toc.qmd
+++ b/crates/quarto/tests/smoke-all/toc-containers/column-margin-heading-in-toc.qmd
@@ -1,0 +1,25 @@
+---
+format:
+  html:
+    toc: true
+    toc-depth: 4
+_quarto:
+  tests:
+    html:
+      noErrors: true
+      ensureHtmlElements:
+        - ["nav#TOC a[data-scroll-target=\"#outer\"]",
+           "nav#TOC a[data-scroll-target=\"#inside-the-margin\"]"]
+---
+
+A heading inside `.column-margin` reaches the TOC, in Quarto 1 and in q2.
+
+Regression net for the TOC-walk restriction.
+
+## Outer
+
+::: {.column-margin}
+#### Inside the margin
+
+Body.
+:::

--- a/crates/quarto/tests/smoke-all/toc-containers/content-visible-div-unwrapped.qmd
+++ b/crates/quarto/tests/smoke-all/toc-containers/content-visible-div-unwrapped.qmd
@@ -1,0 +1,33 @@
+---
+format:
+  html:
+    toc: true
+    toc-depth: 4
+_quarto:
+  tests:
+    html:
+      noErrors: true
+      ensureHtmlElements:
+        - ["nav#TOC a[data-scroll-target=\"#outer\"]",
+           "nav#TOC a[data-scroll-target=\"#inside-conditional-content\"]"]
+        - ["div.content-visible", "div.content-hidden"]
+---
+
+Quarto 1 resolves a *visible* conditional Div by returning its content
+(`customnodes/content-hidden.lua:66`, `return el.content`), after
+`clearHiddenVisibleAttributes` strips both marker classes and the condition
+attributes. The wrapper exists only to carry the condition; once the
+condition is resolved there is nothing left for it to say.
+
+q2 used to keep the Div *and* its marker class, so pages carried a
+`<div class="content-visible">` Quarto 1 never emits.
+
+## Outer
+
+::: {.content-visible when-format="html"}
+Leading prose, so the Div is not merely a header wrapper.
+
+#### Inside conditional content
+
+Body.
+:::

--- a/crates/quarto/tests/smoke-all/toc-containers/content-visible-span-kept.qmd
+++ b/crates/quarto/tests/smoke-all/toc-containers/content-visible-span-kept.qmd
@@ -1,0 +1,21 @@
+---
+format:
+  html:
+_quarto:
+  tests:
+    html:
+      noErrors: true
+      ensureHtmlElements:
+        - ["span.keep-me"]
+        - ["span.content-visible", "span.content-hidden"]
+---
+
+Spans and CodeBlocks keep their scaffolding element — Quarto 1 unwraps only
+Divs ("this is only called on spans and codeblocks, so here we keep the
+scaffolding element, as opposed to in the Div where we return the inlined
+content", `customnodes/content-hidden.lua:154`). The marker class is still
+stripped.
+
+## Outer
+
+Visible [text]{.content-visible .keep-me when-format="html"} inline.

--- a/crates/quarto/tests/smoke-all/toc-containers/div-heading-becomes-section.qmd
+++ b/crates/quarto/tests/smoke-all/toc-containers/div-heading-becomes-section.qmd
@@ -1,0 +1,56 @@
+---
+format:
+  html:
+    toc: true
+    toc-depth: 4
+_quarto:
+  tests:
+    html:
+      noErrors: true
+      ensureHtmlElements:
+        - ["section.level4.wrap-a#case-a",
+           "div#has-id.wrap-b > section.level4#case-b",
+           "div.wrap-c > section.level4#case-c",
+           "blockquote > h4#quoted"]
+        - ["div.wrap-a", "section.wrap-b", "section.wrap-c", "blockquote section"]
+---
+
+pandoc's `makeSections` recurses into Divs and replaces a Div by the
+section it wraps when — and only when — the Div has an empty id and its
+content is exactly one section; the Div's classes and key-values are
+merged onto that section.
+
+Ground truth for each case is Quarto 1's render of
+`claude-notes/plans/tabset-headings-in-toc-investigation/absorb-rule-probe/`.
+
+## Absorbed: bare wrapper
+
+::: {.wrap-a}
+#### Case A
+
+Body.
+:::
+
+## Not absorbed: the Div has its own id
+
+::: {#has-id .wrap-b}
+#### Case B
+
+Body.
+:::
+
+## Not absorbed: content precedes the heading
+
+::: {.wrap-c}
+Leading para.
+
+#### Case C
+
+Body.
+:::
+
+## Not descended into: blockquote
+
+> #### Quoted
+>
+> Body.

--- a/crates/quarto/tests/smoke-all/toc-containers/plain-div-heading-in-toc.qmd
+++ b/crates/quarto/tests/smoke-all/toc-containers/plain-div-heading-in-toc.qmd
@@ -1,0 +1,27 @@
+---
+format:
+  html:
+    toc: true
+    toc-depth: 4
+_quarto:
+  tests:
+    html:
+      noErrors: true
+      ensureHtmlElements:
+        - ["nav#TOC a[data-scroll-target=\"#outer\"]",
+           "nav#TOC a[data-scroll-target=\"#inside-a-plain-div\"]"]
+---
+
+A heading inside a plain Div reaches the TOC, in Quarto 1 and in q2.
+
+Regression net for the TOC-walk restriction: a plain Div is *transparent*
+(pandoc's `makeSections` absorbs it into the section it wraps), so its
+heading must stay listed.
+
+## Outer
+
+::: {.my-wrapper}
+#### Inside a plain div
+
+Body.
+:::

--- a/crates/quarto/tests/smoke-all/toc-containers/tabset-pane-heading-not-in-toc.qmd
+++ b/crates/quarto/tests/smoke-all/toc-containers/tabset-pane-heading-not-in-toc.qmd
@@ -1,0 +1,50 @@
+---
+format:
+  html:
+    toc: true
+    toc-depth: 4
+_quarto:
+  tests:
+    html:
+      noErrors: true
+      ensureHtmlElements:
+        - ["nav#TOC a[data-scroll-target=\"#configuration\"]",
+           "nav#TOC a[data-scroll-target=\"#next-steps\"]",
+           "div.panel-tabset div.tab-pane#tabset-1-2 section#create-the-integration-1"]
+        - ["nav#TOC a[data-scroll-target=\"#create-the-integration\"]",
+           "nav#TOC a[data-scroll-target=\"#create-the-integration-1\"]"]
+---
+
+bd-tabset-headings-in-toc-t04ie7f7. A heading written *inside* a tab body
+must not reach the TOC.
+
+Quarto 1 lists only `#configuration` and `#next-steps` here. The section
+for each tab body does exist in Q1's output — it is simply unreachable
+from the TOC walk, which stops at the non-section `div.panel-tabset`.
+
+Two of the three original symptoms are visible in this document: the two
+entries were indistinguishable (same text, no tab context), and
+`#create-the-integration-1` sits in a pane with no `active` class, so
+following it scrolled to nothing.
+
+## Configuration
+
+::: {.panel-tabset}
+
+### Azure
+
+#### Create the integration
+
+Azure-specific instructions.
+
+### Google
+
+#### Create the integration
+
+Google-specific instructions.
+
+:::
+
+## Next steps
+
+Done.

--- a/docs/guides/authoring/tabsets.qmd
+++ b/docs/guides/authoring/tabsets.qmd
@@ -71,9 +71,17 @@ the `active` class to its heading:
 ## Python {.active}
 ```
 
-Headings that define tabs do not appear in the page's table of contents —
-only regular section headings do. Deeper headings inside a tab stay part
-of that tab's content.
+No heading inside a tabset appears in the page's table of contents —
+neither the headings that define the tabs nor any deeper headings you
+write inside a tab body. Only regular section headings are listed.
+
+This keeps the table of contents usable. Tabs very often share the same
+sub-headings — one per provider, language, or platform — so listing them
+would fill the contents with repeated entries that give the reader no way
+to tell them apart, and every entry but the one in the open tab would
+point at hidden content. Headings inside a tab still work normally in
+every other respect: they render, they get an id, and you can link to
+them directly.
 
 ## Tab groups
 

--- a/hub-client/changelog.md
+++ b/hub-client/changelog.md
@@ -23,6 +23,10 @@ WASM rebuild is needed for a changelog-only edit.
 
 -->
 
+### 2026-08-18
+
+- [`510b3ae7`](https://github.com/quarto-dev/q2/commits/510b3ae7): q2-preview render components now receive headings wrapped in section Divs, matching the rest of the pipeline; the bundled `kanban_rc.jsx` sample and the component README were updated to read that shape.
+
 ### 2026-08-14
 
 - [`9b60bbe2`](https://github.com/quarto-dev/q2/commits/9b60bbe2): Keep the WASM-driven theme/SASS cache in memory during `q2 preview` sessions (viewer and editor alike), so preview origins leave no IndexedDB databases behind at all.

--- a/hub-client/src/components/render/experimental-components/new/README.md
+++ b/hub-client/src/components/render/experimental-components/new/README.md
@@ -13,3 +13,41 @@ render-components:
 source-location: full
 ---
 ```
+## What a component receives
+
+A component is handed the AST **as the pipeline leaves it**, not as the
+author wrote it. Normalization transforms run first, and some of them
+restructure the very subtree a component is inspecting.
+
+The one that bites most often is `SectionizeTransform`. It wraps every
+heading, together with the content that follows, in a section `Div` —
+including headings nested inside a component's own `Div`:
+
+```
+::: {.kanban}
+## backlog
+* item one
+:::
+```
+
+reaches the component as
+
+```
+Div(.kanban)
+  Div(#backlog .section .level2)[ Header(2) "backlog", BulletList ]
+```
+
+not as a flat `[Header, BulletList]` run. `kanban_rc.jsx` shows the shape
+to expect; scanning a Div's direct children for `Header` nodes will find
+nothing.
+
+**Reading vs writing.** This applies to the node you *render*. Editing
+components resolve back to the *source* node (`edit.resolveSource`), which
+is pre-transform — flat headings, no sections — and edits written there
+must keep that shape, or sections end up in the user's `.qmd`. The two
+paths are deliberately asymmetric; see `kanban.tsx` in
+`crates/quarto/tests/playwright-fixtures/q2-preview/render-components-kanban/`.
+
+This coupling between components and the pipeline is real and, for now,
+unversioned: a pipeline change can require a component change. Expect some
+churn while the API settles.

--- a/hub-client/src/components/render/experimental-components/new/kanban_rc.jsx
+++ b/hub-client/src/components/render/experimental-components/new/kanban_rc.jsx
@@ -1,6 +1,15 @@
 const React = window.React;
 const { renderChildren } = window.__REACT_AST_DEBUG_RENDERER__;
 
+const inlineText = (inlines) => inlines.map(inline => {
+    if (inline.t === 'Str') return inline.c;
+    if (inline.t === 'Space') return ' ';
+    return '';
+}).join('');
+
+const isSection = (block) =>
+    block.t === 'Div' && block.c[0][1].includes('section');
+
 export const Div = (args) => {
     const { node: div, setLocalAst } = args;
 
@@ -11,39 +20,39 @@ export const Div = (args) => {
         return <div id={id} className={classes.join(' ')}>{renderChildren(args)}</div>;
     }
 
-    // Parse kanban structure
+    // Parse kanban structure.
+    //
+    // A component reads the AST as the pipeline leaves it, and by this
+    // point `SectionizeTransform` has wrapped every heading -- including
+    // headings nested inside a Div like this one -- together with the
+    // content that follows it:
+    //
+    //   Div(.kanban)
+    //     Div(#backlog .section .level2)[ Header(2) "backlog", BulletList ]
+    //     Div(#doing   .section .level2)[ Header(2) "doing",   BulletList ]
+    //
+    // So a column is a section Div, not a bare Header. The grouping is a
+    // convenience: the heading and its cards arrive together.
     const blocks = div.c[1];
     const columns = [];
-    let currentColumn = null;
 
     for (const block of blocks) {
-        if (block.t === 'Header' && block.c[0] === 2) {
-            // New column header
-            const title = block.c[2].map(inline => {
-                if (inline.t === 'Str') return inline.c;
-                if (inline.t === 'Space') return ' ';
-                return '';
-            }).join('');
+        if (!isSection(block)) continue;
+        const children = block.c[1];
+        const header = children.find(b => b.t === 'Header' && b.c[0] === 2);
+        if (!header) continue;
 
-            currentColumn = { title, items: [] };
-            columns.push(currentColumn);
-        } else if (block.t === 'BulletList' && currentColumn) {
-            // Items for current column
-            const items = block.c.map(listItem => {
-                // Each listItem is [Block] - an array of blocks
-                return listItem.map(b => {
-                    if (b.t === 'Plain' || b.t === 'Para') {
-                        return b.c.map(inline => {
-                            if (inline.t === 'Str') return inline.c;
-                            if (inline.t === 'Space') return ' ';
-                            return '';
-                        }).join('');
-                    }
-                    return '';
-                }).join('');
-            });
-            currentColumn.items.push(...items);
+        const column = { title: inlineText(header.c[2]), items: [] };
+        for (const child of children) {
+            if (child.t !== 'BulletList') continue;
+            // Each listItem is [Block] - an array of blocks.
+            column.items.push(...child.c.map(listItem =>
+                listItem.map(b =>
+                    (b.t === 'Plain' || b.t === 'Para') ? inlineText(b.c) : ''
+                ).join('')
+            ));
         }
+        columns.push(column);
     }
 
     return <KanbanBoard columns={columns} div={div} setLocalAst={setLocalAst} />;


### PR DESCRIPTION
Fixes bd-tabset-headings-in-toc-t04ie7f7. Also closes bd-8yjvs3bj, bd-26nryuwh, bd-wbnaa2ud.

Headings written *inside* a tabset panel leaked into the table of contents. They were indistinguishable from one another (tabs usually share sub-headings — one per provider or language), and every entry past the first pointed into a pane with no `active` class, i.e. `display: none`. On the Posit Connect docs port that was 44 entries across 25 pages, 18 of them dead links.

## The strand's stated root cause was wrong, and that mattered

The issue said Quarto 1 excludes these because its tabset filter rewrites the whole tabset to raw HTML, so pandoc's TOC pass sees an opaque blob — which motivated a two-line "skip `.panel-tabset`" fix.

It doesn't. Q1's `render_tabset` returns **real AST** in the same shape q2 emits, and Q1's own render of the repro contains `<section id="create-the-integration" class="level4">` *inside the pane*. The section is there; it just isn't in the TOC.

The real rule: **pandoc's TOC is exactly the section tree.** `sectionToListItem` matches only `Div(_, _, Header:rest)`, so the walk ends at any Div that isn't a section — and `Div(.panel-tabset)` starts with `Plain(nav)`. One rule predicts every container ([probe](claude-notes/plans/tabset-headings-in-toc-investigation/div-toc-probe/)):

| heading inside… | Q1 | q2 before |
| --- | --- | --- |
| plain `:::`, `.content-visible`, `.column-margin`, `layout-ncol` | listed | listed ✅ |
| `.panel-tabset` pane | not listed | **listed** ❌ |
| `.callout` body | not listed | **listed** ❌ |
| `> blockquote` | not listed | **listed** ❌ |

Callout bodies are a third leaking container the issue didn't name, which rules out a `.panel-tabset`-only skip.

q2 had **two divergences that cancelled**: `collect_toc_entries` recursed into every Div *and* into `BlockQuote`; `sectionize_blocks` recursed into neither. They cancel for *transparent* wrappers and compound for *opaque* ones.

## What this does

Three coupled changes — none is correct alone:

1. **Phase 1** — resolved conditional-content Divs are unwrapped and marker classes stripped, matching Q1's `content-hidden.lua`. Without this the restricted walk stops at a surviving `<div class="content-visible">` and drops legitimate headings (measured: 2 pages).
2. **Phase 2** — `sectionize_blocks` recurses into Divs and applies pandoc's absorb rule: replace the Div by the section it wraps iff the Div has an **empty id** and its content is **exactly one section**, merging classes and key-values. Pinned against Q1 by a [five-case probe](claude-notes/plans/tabset-headings-in-toc-investigation/absorb-rule-probe/).
3. **Phase 3** — the TOC walk stops at a non-section Div, and the `BlockQuote` arm is gone.

Phases 1 and 2 are TOC-neutral on their own; they put every heading Q1 lists into the section tree so Phase 3 can be strict.

## Verification

`cargo xtask verify` (full) green. Connect docs port, 451 pages, clean double render on both sides:

| | `main` | this branch |
| --- | --- | --- |
| exact TOC match with Q1 | 421/451 | **444/451** |
| TOC entries removed / **added** | — | 44 / **0** |
| pages closer to Q1 / unchanged / **further** | — | 25 / 426 / **0** |

All 44 removals were inside a `div.tab-pane` (HTML-parsed, not regex-matched); **18** sat in a pane with no `active` class. The issue predicted 44 leaked and 18 dead.

The 7 pages still differing from Q1 are pre-existing and byte-identical to `main`: two where *Q1* emits a garbled id containing an unresolved shortcode blob (q2's are correct), one em-dash slug, and four with the benign extra entry the issue already called out.

## Render components had to change with it

The first CI run surfaced this and it is the one behavioural ripple outside the TOC. q2-preview **render components** read the AST as the pipeline leaves it, and `kanban.tsx` scanned its own Div's direct children for `Header` blocks to build columns. After the sectionize change those children are section Divs:

```html
<div class="kanban">
<section id="backlog" class="section level2">   <!-- was <h2 id="backlog"> -->
```

Rust cannot know which classes a component owns — the binding lives in the TSX, which checks `classes.includes('kanban')` at render time — so leaving component-owned subtrees alone was not available without new API. The decision was to let the contract change: components receive the normalized AST. That keeps full Q1 DOM parity, and render-components are undocumented in `docs/` and expected to churn with the pipeline for now.

- `kanban.tsx` reads section Divs. Its **write** path is deliberately left flat — `edit.resolveSource` returns the *source* node, which is pre-transform, and emitting sections there would write them into the user's `.qmd`. Both paths carry comments saying so.
- `kanban_rc.jsx` (the copy-paste sample) had the same pattern and would have shipped broken.
- `experimental-components/new/README.md` now documents what a component receives, including the read/write asymmetry.
- `comment.tsx` overrides `Block` and handles a `Header` wherever it appears, so sectionizing does not hide it; `drag.tsx` does not inspect headings. Both were already green.

Worth recording for anyone revisiting this: **recursion into non-absorbed Divs was never needed for the TOC fix** — a non-absorbed Div terminates the walk either way. It buys DOM parity with Q1 and nothing else, so an "absorb-only recursion" variant remains available if this coupling ever costs more than the parity is worth.

## Notes for review

- **Deliberate divergence from Q1** in Phase 1: Q1 unwraps a conditional Div unconditionally, discarding a user's `#id` and extra classes. We unwrap only a *bare* wrapper. The rules coincide for all 33 real uses in the corpus, and an empty-id wrapper is absorbed into its section anyway.
- **`DocumentProfile::extract_outline`** runs pre-transform on un-sectionized blocks, where the new rule dropped every heading inside a `:::` block. It now sectionizes a copy. One gap remains (a callout *title* is listed there but not in the rendered TOC, because heading-consuming transforms run after the profile checkpoint) — filed as bd-ca17fck0, no consumer today.
- **Revealjs** skips `SectionizeTransform` while `TocGenerateTransform` is ungated, so a future reveal TOC would come up empty. Verified reveal emits no `nav#TOC` today, so this is latent; precondition documented, filed as bd-tebu6o4a.
- **No snapshot churn.** Zero `.snap` changes across all three phases.
- **Three tests initially passed vacuously** and were strengthened until they failed honestly — the default `TocConfig` depth of 3 was excluding the level-4 headings outright, and asserting on `toc.entries` missed the leak because `build_hierarchy` nests a leaked entry *under* the preceding section.

Plan and all measurements: `claude-notes/plans/2026-08-18-tabset-headings-in-toc.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

