### PR TITLE
Bump workspace version to 0.24.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "comrak-to-pandoc"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "comrak",
  "hashlink",
@@ -4805,7 +4805,7 @@ dependencies = [
 
 [[package]]
 name = "quarto"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4852,7 +4852,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-analysis"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "insta",
  "quarto-error-reporting",
@@ -4878,7 +4878,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-brand"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "pathdiff",
  "quarto-util",
@@ -4890,7 +4890,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-citeproc"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "glob",
  "hashlink",
@@ -4924,7 +4924,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-core"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4982,7 +4982,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-csl"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "insta",
  "quarto-error-reporting",
@@ -5010,7 +5010,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-error-catalog"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "once_cell",
  "quarto-error-reporting",
@@ -5046,7 +5046,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-highlight"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "hashlink",
  "insta",
@@ -5075,7 +5075,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-highlight-encoding"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -5083,7 +5083,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-hub"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "automerge",
@@ -5127,7 +5127,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-hub-provider"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "automerge",
  "ciborium",
@@ -5153,7 +5153,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-lsp"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "insta",
@@ -5169,7 +5169,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-lsp-core"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "insta",
  "pampa",
@@ -5192,7 +5192,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-mcp-launcher"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -5208,7 +5208,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-navigation"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "quarto-config",
  "quarto-pandoc-types",
@@ -5218,7 +5218,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-p2p"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "axum",
  "futures",
@@ -5261,7 +5261,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-preview"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "automerge",
@@ -5299,7 +5299,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-project-create"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "quarto-doctemplate",
  "serde",
@@ -5310,7 +5310,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-publish"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5335,7 +5335,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-sass"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "grass",
  "include_dir",
@@ -5358,7 +5358,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-source-fetch"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "flate2",
  "tar",
@@ -5381,7 +5381,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-system-runtime"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5399,7 +5399,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-test"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "quarto-core",
@@ -5416,7 +5416,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-trace"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "flate2",
  "serde",
@@ -5427,7 +5427,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-trace-server"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -5454,7 +5454,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-util"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "dirs",
  "serde",
@@ -5463,7 +5463,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-xml"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "insta",
  "quarto-error-reporting",
@@ -5701,7 +5701,7 @@ dependencies = [
 
 [[package]]
 name = "reconcile-viewer"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "clap",
  "hashlink",
@@ -6708,7 +6708,7 @@ checksum = "ea06cc588e43c632923a55450401b8f25e628131571d4e1baea1bdfdb2b5ed06"
 
 [[package]]
 name = "spa-manifest"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -7957,7 +7957,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-printf-fmt"
-version = "0.23.0"
+version = "0.24.0"
 
 [[package]]
 name = "wasm-streams"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.23.0"
+version = "0.24.0"
 authors = ["Posit Software, PBC"]
 homepage = "https://github.com/posit-dev/quarto-markdown-syntax"
 keywords = ["parser"]

--- a/crates/wasm-quarto-hub-client/Cargo.lock
+++ b/crates/wasm-quarto-hub-client/Cargo.lock
@@ -377,7 +377,7 @@ dependencies = [
 
 [[package]]
 name = "comrak-to-pandoc"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "comrak",
  "hashlink",
@@ -2074,7 +2074,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-analysis"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "quarto-error-reporting",
  "quarto-pandoc-types",
@@ -2096,7 +2096,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-brand"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "pathdiff",
  "quarto-util",
@@ -2107,7 +2107,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-citeproc"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "glob",
  "hashlink",
@@ -2138,7 +2138,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-core"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2190,7 +2190,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-csl"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "quarto-error-reporting",
  "quarto-source-map",
@@ -2241,7 +2241,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-highlight"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "once_cell",
  "quarto-highlight-encoding",
@@ -2267,7 +2267,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-highlight-encoding"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2275,7 +2275,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-lsp-core"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "pampa",
  "pollster",
@@ -2296,7 +2296,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-navigation"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "quarto-config",
  "quarto-pandoc-types",
@@ -2331,7 +2331,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-project-create"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "quarto-doctemplate",
  "serde",
@@ -2341,7 +2341,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-sass"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "include_dir",
  "once_cell",
@@ -2372,7 +2372,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-system-runtime"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -2389,7 +2389,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-trace"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "flate2",
  "serde",
@@ -2407,7 +2407,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-util"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "dirs",
  "serde",
@@ -2416,7 +2416,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-xml"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "quarto-error-reporting",
  "quarto-source-map",
@@ -4023,7 +4023,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-printf-fmt"
-version = "0.23.0"
+version = "0.24.0"
 
 [[package]]
 name = "wasm-quarto-hub-client"


### PR DESCRIPTION
Version bump for the v0.24.0 release (release runbook step 2).

- `[workspace.package].version`: 0.23.0 → 0.24.0
- Both lockfiles updated: root `Cargo.lock` and
  `crates/wasm-quarto-hub-client/Cargo.lock` (separate lockfile — that
  crate declares its own `[workspace]`, so the root update doesn't
  reach it).

Only workspace member versions move; no external dependency versions
changed. Verified locally with `cargo build --bin q2 --locked`, which
prints `q2 (quarto 2) 0.24.0`, and a full WASM build produced no
further lockfile churn.

The release workflow's preflight job requires the tag to equal this
manifest version exactly, so this must merge before `v0.24.0` is tagged.