### PR TITLE
page-footer item text: render lone images, resolve Link/Image targets, raise Q-5-6 (bd-page-footer-image-items-stmpikgo)

### DIFF
--- a/claude-notes/plans/2026-08-18-page-footer-image-items.md
+++ b/claude-notes/plans/2026-08-18-page-footer-image-items.md
@@ -115,12 +115,23 @@ tests written and verified first.
   `repro/` deep page's item-level targets now match the region control
   (`../../images/logo.svg`, `../../index.html`); only the raw-HTML
   `{=html}` variant remains untouched (fc5pvkcv Case B, out of scope).
-- [ ] **Phase 3 — Blocks walker.** `rewrite_config_blocks` companion in
-  `navigation_href.rs` that walks block containers (including *into*
-  `Figure` — persisting the node, rewriting targets inside it, decision 3)
-  and delegates to `rewrite_config_inlines` at inline positions. Wire into
-  the `PandocBlocks` arms of the Text-region and item-text call sites.
-  Tests: multi-paragraph `!md` region/item text with image + link.
+- [x] **Phase 3 — Blocks walker.** *Done 2026-08-18.*
+  `rewrite_config_blocks` in `navigation_href.rs` (container coverage
+  mirrors `ResourceCollectorTransform`'s visitor; Figures persist —
+  targets inside content and caption rewrite, no unwrap). Wired via
+  `rewrite_config_text`'s `PandocBlocks` arm, which now also serves the
+  footer Text-region and navbar-title call sites (refactored off their
+  inlines-only matches). Two additional gaps found and fixed along the way:
+  (a) `FooterRegion::from_config_value` classified a `PandocBlocks` region
+  as `Empty` (because `as_plain_text` is `None` for blocks), silently
+  dropping the whole region — now classifies as `Text`; (b) `render_text`
+  dropped persisted `Figure`s — `push_blocks_text` now renders a figure's
+  image content (caption stays out of the one-line region). Failing-first
+  tests at the walker, classifier, and renderer levels plus a blocks-shaped
+  footer transform test; workspace green (12323). End-to-end fixture
+  `repro-md-blocks/`: an `!md` two-block center region renders
+  `<img src="../../images/logo.svg">` and `<a href="../../index.html">`
+  on the deep page.
 - [ ] **Phase 4 — Uniform Q-5-6 for footer images (decision 4).**
   Extend `copy_footer_images` to walk `Items` regions (item `text:` +
   `bare_text`, recursing into `menu`) and `PandocBlocks` values using the

--- a/claude-notes/plans/2026-08-18-page-footer-image-items.md
+++ b/claude-notes/plans/2026-08-18-page-footer-image-items.md
@@ -132,15 +132,27 @@ tests written and verified first.
   `repro-md-blocks/`: an `!md` two-block center region renders
   `<img src="../../images/logo.svg">` and `<a href="../../index.html">`
   on the deep page.
-- [ ] **Phase 4 — Uniform Q-5-6 for footer images (decision 4).**
-  Extend `copy_footer_images` to walk `Items` regions (item `text:` +
-  `bare_text`, recursing into `menu`) and `PandocBlocks` values using the
-  shared collectors; build a `ResourceCopyIntent` per collected URL with
-  `origin` = the Image node's span (remaps into `_quarto.yml`), and report
-  misses via `missing_resource_diagnostic` (Q-5-6) instead of the uncoded
-  string warning. Once per project (post-render) to avoid per-page warning
-  duplication. Tests: `repro-missing/` end-to-end — all four rows of the
-  matrix produce exactly one spanned Q-5-6 each (plus the body control).
+- [x] **Phase 4 — Uniform Q-5-6 for footer images (decision 4).**
+  *Done 2026-08-18.* `copy_footer_images` now collects `ImageRef`s
+  (URL + span, body-collector origin rule) from Text regions (inlines,
+  blocks, raw scalars) *and* Items regions (item `text:` + `bare_text`,
+  `menu` recursion); misses go through `ResourceCopyIntent` +
+  `missing_resource_diagnostic` — a real Q-5-6, once per project.
+  Root-caused and fixed a mis-anchoring bug this surfaced in pampa:
+  `range_to_source_info_with_context` (`location.rs`) ignored
+  `parent_source_info`, so every attr/target sub-span in a *re-parsed*
+  string (image URL spans, link targets, code-fence info strings, 11 call
+  sites) was `Original(FileId(0), offsets-into-the-string)` — the exact
+  wrong-text hazard the pipe_table/section comments warn about. It now
+  reroots as a `Substring` of the parent like node spans do. Failing-first
+  tests: 4 integration tests (missing Text-region → Q-5-6 with location;
+  missing item image → Q-5-6; present item image → copied; `!md` blocks →
+  Q-5-6) + a pampa reroot unit test. Workspace green (12328), zero
+  snapshot churn. End-to-end (`repro-missing/`): footer Q-5-6 renders an
+  Ariadne snippet into `_quarto.yml` line 6 at the reference; one known
+  imprecision — quoted scalars underline one column early because
+  quarto-yaml scalar spans include the quotes; filed **bd-70krno7a**
+  (discovered-from) for content spans rather than hacking a `-1`.
 - [ ] **Phase 5 — Verification + docs.** Full `cargo xtask verify`;
   end-to-end render of both repros recorded in this plan; changelog/strand
   notes. Check whether `docs/errors/quarto/Q-5-6.qmd` needs wording updates

--- a/claude-notes/plans/2026-08-18-page-footer-image-items.md
+++ b/claude-notes/plans/2026-08-18-page-footer-image-items.md
@@ -102,14 +102,19 @@ tests written and verified first.
   → inlines (both with alt text and `![](y)`, which never desugars);
   `render_text` on the resulting value is non-empty. Review snapshot churn
   across the workspace (shared parse path; `!md` values included — see risks).
-- [ ] **Phase 2 — Defect 2: route item text through the inline rewriter.**
-  Shared helper (likely on/near `rewrite_items_hrefs`) that runs
-  `rewrite_config_inlines` over `item.text` and `item.bare_text` when
-  `PandocInlines`, recursing into `item.menu` — wired into all three
-  surfaces: `footer_render.rs`, `navbar_render.rs`, `sidebar_render.rs`
-  (decision 2). Tests: unit per surface (root-absolute + relative image
-  `src`, `.qmd`→`.html` link); end-to-end render of `repro/` asserting the
-  deep page's footer markup.
+- [x] **Phase 2 — Defect 2: route item text through the inline rewriter.**
+  *Done 2026-08-18.* Shared helpers `rewrite_config_text` +
+  `rewrite_item_text` in `navigation_href.rs`, wired into all three
+  surfaces: footer `rewrite_items_hrefs`, navbar
+  `rewrite_navigation_item_hrefs` (menus included), sidebar
+  `rewrite_hrefs` (Link item text, Section titles, Headings — all
+  markdown-blessed by `sidebar.contents.**.text`). `bare_text` needs no
+  render-time handling: the Generate transform demotes it into `text`
+  before Render runs and the emitter never reads it. Failing-first tests
+  per surface at a depth-1 resolver; workspace green (12319). End-to-end:
+  `repro/` deep page's item-level targets now match the region control
+  (`../../images/logo.svg`, `../../index.html`); only the raw-HTML
+  `{=html}` variant remains untouched (fc5pvkcv Case B, out of scope).
 - [ ] **Phase 3 — Blocks walker.** `rewrite_config_blocks` companion in
   `navigation_href.rs` that walks block containers (including *into*
   `Figure` — persisting the node, rewriting targets inside it, decision 3)

--- a/claude-notes/plans/2026-08-18-page-footer-image-items.md
+++ b/claude-notes/plans/2026-08-18-page-footer-image-items.md
@@ -153,13 +153,18 @@ tests written and verified first.
   imprecision — quoted scalars underline one column early because
   quarto-yaml scalar spans include the quotes; filed **bd-70krno7a**
   (discovered-from) for content spans rather than hacking a `-1`.
-- [ ] **Phase 5 — Verification + docs.** Full `cargo xtask verify`;
-  end-to-end render of both repros recorded in this plan; changelog/strand
-  notes. Check whether `docs/errors/quarto/Q-5-6.qmd` needs wording updates
-  for the config-reference case.
+- [x] **Phase 5 — Verification + docs.** *Done 2026-08-18.* Full
+  `cargo xtask verify` (Rust + hub-client/WASM legs) passed; `cargo xtask
+  lint` clean. All three fixtures re-rendered and recorded above.
+  `docs/errors/project/Q-5-6.qmd` updated for the config-reference case
+  (once-per-render, anchored in `_quarto.yml`). No hub-client changes, so
+  no changelog entry needed.
 
-Possible follow-up strands (file, don't do here): upgrade `copy_navbar_logo`'s
-generic warning to the same Q-5-6 shape; sidebar `logo`; favicon.
+Follow-up strands filed (discovered-from this strand):
+- **bd-0jo6fnb7** — upgrade `copy_navbar_logo` / `copy_favicon` warnings to
+  the same spanned Q-5-6 shape.
+- **bd-70krno7a** — quarto-yaml content spans for quoted scalars (footer
+  Q-5-6 underlines one column early on quoted scalars).
 
 ## Design decisions (2026-08-18, aligned with user)
 
@@ -286,3 +291,19 @@ Matches the strand's tables exactly: lone-image items render empty; item-level
 targets are untouched (root-absolute stays root-absolute, relative stays
 page-relative-wrong, `.qmd` never becomes `.html`); the region-level control
 in the same footer is fully resolved.
+
+## End-to-end results after the fixes (2026-08-18, post-Phase-4)
+
+All three fixtures re-rendered with the fixed binary
+(`cargo run --bin q2 -- render <fixture>`), output inspected:
+
+- **`repro/`** deep page: every markdown item now matches the region control —
+  lone images render `<img src="../../images/logo.svg">`, item-level links
+  emit `href="../../index.html"`. Only the raw-HTML `{=html}` item keeps its
+  literal `/images/logo.svg` (fc5pvkcv Case B, expected).
+- **`repro-md-blocks/`** deep page: the `!md` two-block center region renders
+  `<img src="../../images/logo.svg" alt="block image"><a href="../../index.html">block link</a>`.
+- **`repro-missing/`**: "Rendered 1 of 1 — 2 warnings": one **Q-5-6** for the
+  footer (deduped by URL across the three footer references), with an Ariadne
+  snippet into `_quarto.yml` line 6 underlining the reference (one column
+  early for the quoted scalar — bd-70krno7a), plus the body-control Q-5-6.

--- a/claude-notes/plans/2026-08-18-page-footer-image-items.md
+++ b/claude-notes/plans/2026-08-18-page-footer-image-items.md
@@ -89,7 +89,12 @@ Condensed:
 Per-phase test-first per CLAUDE.md TDD; each phase lands with its failing
 tests written and verified first.
 
-- [ ] **Phase 1 — Defect 1: lone-Figure unwrap at the config parse.**
+- [x] **Phase 1 — Defect 1: lone-Figure unwrap at the config parse.**
+  *Done 2026-08-18.* `unwrap_lone_figure` in `crates/pampa/src/pandoc/meta.rs`,
+  applied only in `parse_config_string_as_markdown` (the `!md` path keeps
+  Figure semantics; pinned by test). Five unit tests (failing-first); full
+  workspace suite green, zero snapshot churn. End-to-end verified: lone-image
+  footer items now render `<img>` in `repro/` (src still unrebased — Phase 2).
   In `parse_yaml_string_as_markdown_to_config` (`crates/pampa/src/pandoc/meta.rs`),
   after the existing lone-`Paragraph` unwrap, also unwrap
   `blocks == [Figure]` back to its `Image` → `PandocInlines([Image])`.

--- a/claude-notes/plans/2026-08-18-page-footer-image-items.md
+++ b/claude-notes/plans/2026-08-18-page-footer-image-items.md
@@ -3,7 +3,8 @@
 **Date:** 2026-08-18
 **Braid:** bd-page-footer-image-items-stmpikgo
 **Branch:** `main` (investigation committed in place; implementation branch TBD by user)
-**Status:** Investigation — pending design alignment with user. **Do not start implementation until the user gives the go-ahead.**
+**Status:** Design aligned 2026-08-18 (user answered all five questions; see
+§ Design decisions). Ready to turn into implementation phases.
 
 ## Triage verdict
 
@@ -83,60 +84,123 @@ Condensed:
 `repro/` under the investigation dir is a copy of the external repro
 (`~/repos/github/cscheid/q2-connect-docs/llms-info/repros/page-footer-image-items/`).
 
-## Proposed phases (draft)
+## Proposed phases
 
-Skeleton only — contents wait on the design discussion.
+Per-phase test-first per CLAUDE.md TDD; each phase lands with its failing
+tests written and verified first.
 
-- **Phase 0 — Test plan (TDD).** Failing tests first:
-  - unit: `parse_config_string_as_markdown("![x](y)")` yields inlines (or:
-    `render_text` on a lone-image value is non-empty), per the chosen fix level;
-  - unit: `rewrite_items_hrefs` rewrites Image `src` and Link `href` inside
-    `item.text` (root-absolute and relative, `.qmd`→`.html`);
-  - integration: end-to-end render of the repro project asserting the deep
-    page's footer markup (drive the real binary path per CLAUDE.md).
-- **Phase 1 — Defect 1:** make a lone-image config string survive to
-  rendering (fix level per design question 1).
-- **Phase 2 — Defect 2:** route item `text:`/`bare_text` inlines through
-  `rewrite_config_inlines` in `rewrite_items_hrefs`, symmetric with the
-  existing `menu` recursion; decide `PandocBlocks` handling.
-- **Phase 3 — Scope extension (per design question 2):** same routing for
-  navbar/sidebar item text, and/or the `PandocBlocks` Text-region gap.
-- **Phase 4 — Diagnostics (per design question 4):** missing-resource
-  warnings for footer references, if in scope.
-- **Phase 5 — Docs** (user-facing only if behavior visibly changes; likely
-  just changelog/strand notes).
+- [ ] **Phase 1 — Defect 1: lone-Figure unwrap at the config parse.**
+  In `parse_yaml_string_as_markdown_to_config` (`crates/pampa/src/pandoc/meta.rs`),
+  after the existing lone-`Paragraph` unwrap, also unwrap
+  `blocks == [Figure]` back to its `Image` → `PandocInlines([Image])`.
+  Tests: pampa unit tests for `parse_config_string_as_markdown("![x](y)")`
+  → inlines (both with alt text and `![](y)`, which never desugars);
+  `render_text` on the resulting value is non-empty. Review snapshot churn
+  across the workspace (shared parse path; `!md` values included — see risks).
+- [ ] **Phase 2 — Defect 2: route item text through the inline rewriter.**
+  Shared helper (likely on/near `rewrite_items_hrefs`) that runs
+  `rewrite_config_inlines` over `item.text` and `item.bare_text` when
+  `PandocInlines`, recursing into `item.menu` — wired into all three
+  surfaces: `footer_render.rs`, `navbar_render.rs`, `sidebar_render.rs`
+  (decision 2). Tests: unit per surface (root-absolute + relative image
+  `src`, `.qmd`→`.html` link); end-to-end render of `repro/` asserting the
+  deep page's footer markup.
+- [ ] **Phase 3 — Blocks walker.** `rewrite_config_blocks` companion in
+  `navigation_href.rs` that walks block containers (including *into*
+  `Figure` — persisting the node, rewriting targets inside it, decision 3)
+  and delegates to `rewrite_config_inlines` at inline positions. Wire into
+  the `PandocBlocks` arms of the Text-region and item-text call sites.
+  Tests: multi-paragraph `!md` region/item text with image + link.
+- [ ] **Phase 4 — Uniform Q-5-6 for footer images (decision 4).**
+  Extend `copy_footer_images` to walk `Items` regions (item `text:` +
+  `bare_text`, recursing into `menu`) and `PandocBlocks` values using the
+  shared collectors; build a `ResourceCopyIntent` per collected URL with
+  `origin` = the Image node's span (remaps into `_quarto.yml`), and report
+  misses via `missing_resource_diagnostic` (Q-5-6) instead of the uncoded
+  string warning. Once per project (post-render) to avoid per-page warning
+  duplication. Tests: `repro-missing/` end-to-end — all four rows of the
+  matrix produce exactly one spanned Q-5-6 each (plus the body control).
+- [ ] **Phase 5 — Verification + docs.** Full `cargo xtask verify`;
+  end-to-end render of both repros recorded in this plan; changelog/strand
+  notes. Check whether `docs/errors/quarto/Q-5-6.qmd` needs wording updates
+  for the config-reference case.
 
-## Open design questions for the user
+Possible follow-up strands (file, don't do here): upgrade `copy_navbar_logo`'s
+generic warning to the same Q-5-6 shape; sidebar `logo`; favicon.
 
-1. **Fix level for defect 1 (lone image → Figure → dropped).** Two candidates:
-   - **(a) In `parse_yaml_string_as_markdown_to_config`** (`meta.rs`): also
-     unwrap a lone `Figure` back to its image → `PandocInlines([Image])`.
-     Config strings are inline presentation contexts; a figure with caption
-     semantics is arguably never wanted there. This fixes *every* consumer
-     (item text, region text, navbar/sidebar text, titles) and — because the
-     value becomes `PandocInlines` — the existing rewrite branches then work
-     on it, fixing the lone-image resolution case for free.
-   - **(b) In `render_text`/`block_inlines`**: teach the renderer to unwrap
-     `Figure` to its image. Narrower, but leaves the value as `PandocBlocks`,
-     which the rewrite branches skip — so defect 2's fix would then also need
-     a blocks walker. My read is (a) is the right level; confirm?
-2. **Scope of defect 2's fix.** Strand scopes to page-footer items. The navbar
-   item-text gap (bonus finding b) is the same missing call in a sibling
-   transform. Fix footer-only here and file a discovered-from strand for
-   navbar/sidebar, or fix all three surfaces in this pass (shared helper on
-   `NavigationItem`)?
-3. **`PandocBlocks` handling in the rewriters.** With 1(a) chosen, lone images
-   become inlines, but multi-block `!md` text (items or regions) still skips
-   rewriting (bonus finding a). Add a `rewrite_config_blocks` walker now, or
-   file separately? (`render_text` already renders blocks, so blocks *do*
-   reach the page with unresolved targets today.)
-4. **Diagnostics.** The strand notes a broken footer reference is silent while
-   the same reference in body content raises Q-5-6. Does `rewrite_config_inlines`
-   already emit Q-13-x diagnostics once the text is actually routed through it
-   (i.e. does defect 2's fix close most of the gap for free), and is a
-   missing-file warning for footer images in scope here or a separate strand?
-5. **Priority.** Filed P2 to match the origin strand but described as "the
-   blocker under a P1". Bump to P1?
+## Design decisions (2026-08-18, aligned with user)
+
+1. **Fix level for defect 1: (a), confirmed.** Unwrap a lone `Figure` back to
+   its image in `parse_yaml_string_as_markdown_to_config` (`meta.rs`) —
+   "a figure with caption semantics is arguably never wanted there." The value
+   becomes `PandocInlines([Image])`, so every consumer (render, inline
+   rewriters, `copy_footer_images`' image collection) works on it for free.
+2. **Scope of defect 2: all three surfaces.** Route item `text:`/`bare_text`
+   inlines through the rewriter for page-footer, navbar, and sidebar items in
+   this pass (shared helper), not footer-only.
+3. **Blocks walker: yes, in this pass** — with the explicit note that **in
+   block settings `Figure` nodes should persist**: the blocks walker rewrites
+   Link/Image targets *inside* figures (and other block containers), it does
+   not unwrap them. Only the config-string parse (decision 1) unwraps, and
+   only for the lone-image case. The inline and block walkers are
+   intentionally different in this respect.
+4. **Diagnostics: raise Q-5-6 uniformly.** The user's framing: footer content
+   should behave "more or less equivalent to what would happen in our pipeline
+   if it lived inside a `::: footer` div" in the body. Investigation findings
+   (see § Q4 investigation below): `rewrite_config_inlines` emits Q-13-x for
+   *links* only; *images* get a pure URL rewrite with no existence check. The
+   missing-file story is owned by the copy machinery, which today is a
+   three-way asymmetry. The fix direction: footer/nav config images go through
+   `ResourceCopyIntent` + `missing_resource_diagnostic` (Q-5-6, spanned at the
+   YAML reference) instead of the bespoke uncoded warning.
+5. **Priority: stays P2.**
+
+## Q4 investigation: the current diagnostic + copy matrix
+
+Verified by code reading and the `repro-missing/` fixture (all referencing the
+same nonexistent `/images/nope.svg`; `cargo run --bin q2 -- render …/repro-missing`):
+
+| reference site | copy attempted? | diagnostic today |
+|---|---|---|
+| body image (control) | yes (`ResourceCollectorTransform` → intent) | **Q-5-6 warning, spanned at the reference** |
+| region-level `Text`, image with sibling inline | yes (`copy_footer_images`) | generic `Warning: page-footer image refers to missing file '…'` — **no code, no span, no docs URL** |
+| region-level `Text`, **lone** image | **no** — the Figure gap hits `copy_footer_images` too (its `PandocInlines` match fails on `PandocBlocks([Figure])`) | **silent** |
+| item-level `text:` image | **no** — `copy_footer_images` walks only `FooterRegion::Text`, skipping `Items` entirely (the same asymmetry as defect 2) | **silent** |
+
+Mechanics established:
+
+- **Q-5-6 producer/consumer split.** Producers push
+  `ResourceCopyIntent { src, dest, origin: SourceInfo }` onto
+  `RenderContext::resource_copies`; the shared drain
+  (`enqueue_resource_copies`, `resource_copy_diagnostics.rs:121`) probes
+  existence and emits `missing_resource_diagnostic` (Q-5-6, located at
+  `origin`) for missing sources. The body producer is
+  `ResourceCollectorTransform` (Finalization), which walks **`ast.blocks`
+  only** — footer inlines live in `ast.meta`, so they never produce intents.
+- **A config-image precedent exists**: `title_banner.rs:148` pushes a
+  `ResourceCopyIntent` for the banner image (with a generated span;
+  ours can do better — see below).
+- **Spans can point into `_quarto.yml`.** `parse_config_string_as_markdown`
+  threads the YAML scalar's `SourceInfo` into the qmd reader, so Image nodes
+  in parsed config text carry remappable spans — a footer Q-5-6 can underline
+  the reference inside `_quarto.yml` the way the body one underlines the qmd.
+- **`copy_footer_images`** (`website_post_render.rs:183`, native-only,
+  post-render, once per project) re-parses raw scalars itself via
+  `parse_config_string_as_markdown` — so decision 1's Figure unwrap
+  automatically fixes its lone-image gap too. Its missing-file warning is
+  an uncoded, span-less `DiagnosticMessage::warning`. `copy_navbar_logo`
+  has the same generic-warning style (out of scope here, but the same
+  upgrade applies if we want full uniformity later).
+- **Duplication consideration.** The footer appears on every page: if the
+  per-doc pipeline emitted the intents, a missing footer image would warn
+  once *per rendered page* (352× on the Connect docs). The post-render hook
+  runs once per project, which is the natural dedup point. Proposed shape:
+  keep collection/copy in `copy_footer_images` (extended to Items regions
+  and blocks via the shared walkers), but build a `ResourceCopyIntent` per
+  URL and report misses through `missing_resource_diagnostic` so the
+  user-visible warning is the same Q-5-6, spanned at the YAML reference.
+  (A body `::: footer` div would technically warn per page; once-per-project
+  with the same code+span is the "more or less equivalent" reading.)
 
 ## Risks / tradeoffs (draft)
 

--- a/claude-notes/plans/2026-08-18-page-footer-image-items.md
+++ b/claude-notes/plans/2026-08-18-page-footer-image-items.md
@@ -1,0 +1,191 @@
+# page-footer item text: lone image dropped; no link/image target resolved (bd-page-footer-image-items-stmpikgo)
+
+**Date:** 2026-08-18
+**Braid:** bd-page-footer-image-items-stmpikgo
+**Branch:** `main` (investigation committed in place; implementation branch TBD by user)
+**Status:** Investigation — pending design alignment with user. **Do not start implementation until the user gives the go-ahead.**
+
+## Triage verdict
+
+**Ready to design.** Both defects are confirmed at HEAD by code inspection and
+end-to-end repro; the mechanisms are exactly as the strand describes, the fix
+sites are small and known, and the only open questions are scope choices
+(fix level for defect 1, whether defect 2's fix covers navbar/sidebar too).
+
+## Issue context
+
+Filed 2026-08-18 (today) by Carlos, P2 bug, labels `parity`, `websites`. Two
+independent silent defects in page-footer *item* `text:` (the `- text: "..."`
+list form), with the *region*-level `text:` form as a working control:
+
+1. **A lone-image item renders empty.** `text: '![x](/images/logo.svg)'` →
+   `<li class="nav-item"></li>`. Wrapping the image in a link or adding any
+   sibling inline makes it survive.
+2. **Nothing inside item `text:` is resolved.** Link/Image targets in item text
+   are never rebased (`/images/logo.svg` stays root-absolute; `.qmd` never
+   becomes `.html`), while the identical markdown in a region-level `text:`
+   is fully resolved. 404s on any page below the site root; no diagnostic
+   (body-content equivalents raise Q-5-6).
+
+Real-world driver: the Posit Connect docs port (served from a subdirectory,
+`https://docs.posit.co/connect/`) — its footer carries four images whose
+obvious markdown-image workaround is defeated by exactly these two defects.
+Origin strand in the connect-docs skein: `br-page-footer-image-items-sjto1juf`.
+Filed P2 but is the blocker under a P1 there.
+
+## Dependency graph
+
+No parent/children; two `related` edges, both `in_progress`:
+
+- **related: bd-page-footer-items-f4th80mj** (P1) — the strand that *made*
+  item `text:` markdown-parsed at all (five defects: escaping, bare-string
+  items, shortcodes, entities, href-less anchors). This new strand is the
+  next layer of the same surface: text now parses, but images/links inside it
+  aren't first-class. The `MARKDOWN_CONFIG_PATHS` entries for
+  `page-footer.**.text` / navbar / sidebar carry its bd id in a comment.
+- **related: bd-root-relative-paths-design-fc5pvkcv** (P1, design) — the
+  three-case design for site-root-relative paths. Defect 2's machinery
+  (`rewrite_config_inlines`, "Case C") was built under it; the call-site
+  comment in `footer_render.rs` states the intent that this transform "owns"
+  footer-inline resolution — item text was simply never routed through it.
+
+No `discovered-from` edge in braid, but the description records the origin
+session. No incoming `blocks` edges; urgency comes from the connect-docs port.
+
+## What the code looks like today
+
+Everything the strand points at exists unchanged at `main` @ 5b6774d1. Full
+trace with line numbers: `page-footer-image-items-investigation/code-trace.md`.
+Condensed:
+
+- **Defect 1** is a three-hop interaction: `ConfigMarkdownTransform` parses
+  item text via `pampa::pandoc::meta::parse_config_string_as_markdown`; the qmd
+  reader's postprocess desugars a single-image paragraph into `Block::Figure`
+  (`postprocess.rs:978`); `meta.rs:75` only unwraps a lone `Paragraph` to
+  `PandocInlines`, so the value stays `PandocBlocks([Figure])`; and
+  `render_text`'s `block_inlines` (`render_html.rs:913`) matches only
+  `Plain|Paragraph|Header` → empty string.
+- **Defect 2** is one missing call: `rewrite_items_hrefs`
+  (`footer_render.rs:147`) rewrites `item.href` and recurses into `item.menu`
+  but never touches `item.text`/`item.bare_text`, while the `Text` region
+  branch one match-arm up calls `rewrite_config_inlines` (which already
+  handles Link + Image recursively, `navigation_href.rs:488`).
+- **Bonus finding (a):** the `Text` region branch matches only `PandocInlines`
+  — a `PandocBlocks` text region (multi-paragraph `!md`, or a lone image
+  today) silently skips the rewrite as well.
+- **Bonus finding (b):** navbar (and presumably sidebar) item `text:` has the
+  same defect-2 gap — `navbar_render.rs` rewrites item hrefs and the navbar
+  *title's* inlines, but not item text inlines. Since f4th80mj blessed
+  `navbar.**.text` / `sidebar.contents.**.text` as markdown, the same repro
+  shape should misbehave there. Not yet verified end-to-end.
+
+**Reproduced end-to-end at HEAD** (see § End-to-end verification below):
+`repro/` under the investigation dir is a copy of the external repro
+(`~/repos/github/cscheid/q2-connect-docs/llms-info/repros/page-footer-image-items/`).
+
+## Proposed phases (draft)
+
+Skeleton only — contents wait on the design discussion.
+
+- **Phase 0 — Test plan (TDD).** Failing tests first:
+  - unit: `parse_config_string_as_markdown("![x](y)")` yields inlines (or:
+    `render_text` on a lone-image value is non-empty), per the chosen fix level;
+  - unit: `rewrite_items_hrefs` rewrites Image `src` and Link `href` inside
+    `item.text` (root-absolute and relative, `.qmd`→`.html`);
+  - integration: end-to-end render of the repro project asserting the deep
+    page's footer markup (drive the real binary path per CLAUDE.md).
+- **Phase 1 — Defect 1:** make a lone-image config string survive to
+  rendering (fix level per design question 1).
+- **Phase 2 — Defect 2:** route item `text:`/`bare_text` inlines through
+  `rewrite_config_inlines` in `rewrite_items_hrefs`, symmetric with the
+  existing `menu` recursion; decide `PandocBlocks` handling.
+- **Phase 3 — Scope extension (per design question 2):** same routing for
+  navbar/sidebar item text, and/or the `PandocBlocks` Text-region gap.
+- **Phase 4 — Diagnostics (per design question 4):** missing-resource
+  warnings for footer references, if in scope.
+- **Phase 5 — Docs** (user-facing only if behavior visibly changes; likely
+  just changelog/strand notes).
+
+## Open design questions for the user
+
+1. **Fix level for defect 1 (lone image → Figure → dropped).** Two candidates:
+   - **(a) In `parse_yaml_string_as_markdown_to_config`** (`meta.rs`): also
+     unwrap a lone `Figure` back to its image → `PandocInlines([Image])`.
+     Config strings are inline presentation contexts; a figure with caption
+     semantics is arguably never wanted there. This fixes *every* consumer
+     (item text, region text, navbar/sidebar text, titles) and — because the
+     value becomes `PandocInlines` — the existing rewrite branches then work
+     on it, fixing the lone-image resolution case for free.
+   - **(b) In `render_text`/`block_inlines`**: teach the renderer to unwrap
+     `Figure` to its image. Narrower, but leaves the value as `PandocBlocks`,
+     which the rewrite branches skip — so defect 2's fix would then also need
+     a blocks walker. My read is (a) is the right level; confirm?
+2. **Scope of defect 2's fix.** Strand scopes to page-footer items. The navbar
+   item-text gap (bonus finding b) is the same missing call in a sibling
+   transform. Fix footer-only here and file a discovered-from strand for
+   navbar/sidebar, or fix all three surfaces in this pass (shared helper on
+   `NavigationItem`)?
+3. **`PandocBlocks` handling in the rewriters.** With 1(a) chosen, lone images
+   become inlines, but multi-block `!md` text (items or regions) still skips
+   rewriting (bonus finding a). Add a `rewrite_config_blocks` walker now, or
+   file separately? (`render_text` already renders blocks, so blocks *do*
+   reach the page with unresolved targets today.)
+4. **Diagnostics.** The strand notes a broken footer reference is silent while
+   the same reference in body content raises Q-5-6. Does `rewrite_config_inlines`
+   already emit Q-13-x diagnostics once the text is actually routed through it
+   (i.e. does defect 2's fix close most of the gap for free), and is a
+   missing-file warning for footer images in scope here or a separate strand?
+5. **Priority.** Filed P2 to match the origin strand but described as "the
+   blocker under a P1". Bump to P1?
+
+## Risks / tradeoffs (draft)
+
+- **Fix 1(a) changes a shared parse path** (`parse_config_string_as_markdown`
+  feeds every blessed config key). Unwrapping lone figures there could change
+  snapshot output for other keys — e.g. a `website.title` or `about` text that
+  is a lone image (unlikely but possible). Snapshot churn must be reviewed per
+  the CLAUDE.md snapshot policy. Note `!md`-tagged values take a different
+  path (already `PandocBlocks` at load); decide whether they get the same
+  unwrap or keep figure semantics.
+- **The lone-figure unwrap must not fire for genuinely block contexts** — the
+  same pampa parse is used for document metadata (`!md` in frontmatter?);
+  verify the unwrap lives only on the config-string path (or is behaviorally
+  safe everywhere).
+- **Both related strands are `in_progress`** — f4th80mj (item-text rendering)
+  and fc5pvkcv (path design) touch the same files; coordinate to avoid
+  conflicting in-flight edits.
+- The empty-caption edge (`![](x)`) does *not* desugar to Figure (postprocess
+  requires non-empty caption) — tests should pin both variants.
+
+## End-to-end verification (investigation)
+
+Run at HEAD (`main` @ 5b6774d1, 2026-08-18), pre-flight
+`cargo xtask verify --skip-hub-build` green first. Output inspected directly.
+
+- Invocation: `cargo run --bin q2 -- render claude-notes/plans/page-footer-image-items-investigation/repro`
+  ("Rendered 2 of 2 files", exit 0, **no diagnostics** — confirming the
+  silent-failure claim).
+- Observed footer in `_site/deep/deeper/index.html` (page two levels deep):
+
+```html
+<div class="nav-footer-left">
+  <ul class="nav footer-items">
+    <li class="nav-item"></li>                                     <!-- lone image: DROPPED (defect 1) -->
+    <li class="nav-item"></li>                                     <!-- lone image, relative: DROPPED -->
+    <li class="nav-item"><a href="https://posit.co"><img src="images/logo.svg" alt="wrapped in a link"></a></li>  <!-- survives but src unrebased -->
+    <li class="nav-item"><img src="images/logo.svg" alt="image"> beside text</li>                                 <!-- survives but src unrebased -->
+    <li class="nav-item"><img src="/images/logo.svg" alt="raw html"></li>
+  </ul>
+</div>
+<div class="nav-footer-center"><img src="../../images/logo.svg" alt="region-level"> and a <a href="../../index.html">region-level link</a></div>  <!-- CONTROL: fully resolved -->
+<div class="nav-footer-right">
+  <ul class="nav footer-items">
+    <li class="nav-item"><img src="/images/logo.svg" alt="item-level"> and an <a href="/index.qmd">item-level link</a></li>  <!-- defect 2: untouched -->
+  </ul>
+</div>
+```
+
+Matches the strand's tables exactly: lone-image items render empty; item-level
+targets are untouched (root-absolute stays root-absolute, relative stays
+page-relative-wrong, `.qmd` never becomes `.html`); the region-level control
+in the same footer is fully resolved.

--- a/claude-notes/plans/page-footer-image-items-investigation/code-trace.md
+++ b/claude-notes/plans/page-footer-image-items-investigation/code-trace.md
@@ -1,0 +1,79 @@
+# Code trace — bd-page-footer-image-items-stmpikgo (2026-08-18, main @ 5b6774d1)
+
+Both defects confirmed present at HEAD by code inspection. The strand's file
+references are all current; nothing in the area has been refactored since filing.
+
+## Defect 1 — lone-image item renders empty
+
+Full mechanism, three hops:
+
+1. `ConfigMarkdownTransform` (`crates/quarto-core/src/transforms/config_markdown.rs`)
+   matches `page-footer.**.text` in `MARKDOWN_CONFIG_PATHS` and calls
+   `parse_scalar_string_in_place` → `pampa::pandoc::meta::parse_config_string_as_markdown`.
+
+2. `parse_yaml_string_as_markdown_to_config` (`crates/pampa/src/pandoc/meta.rs:49`)
+   parses the string as a qmd document. The qmd reader's postprocess pass
+   (`crates/pampa/src/pandoc/treesitter_utils/postprocess.rs:978`, `with_paragraph`)
+   desugars a single-image paragraph into `Block::Figure`. Back in `meta.rs:75`,
+   the "unwrap to inlines" check only matches `blocks.len() == 1 && Paragraph`,
+   so a lone image stays `ConfigValueKind::PandocBlocks([Figure])` while any
+   sibling inline keeps the block a `Paragraph` → `PandocInlines`.
+
+3. `render_text` (`crates/quarto-navigation/src/render_html.rs:892`), `PandocBlocks`
+   branch, calls `block_inlines` (line 913) which matches only
+   `Plain | Paragraph | Header` and returns `None` for `Figure` → empty string.
+
+Note the figure desugar only fires when the image has a non-empty caption
+(`!image.content.is_empty()`), which is why `![lone image](...)` (alt text =
+caption) vanishes; `![](...)` would survive. Consistent with the strand's table.
+
+## Defect 2 — item text inlines never routed through the href/src rewriter
+
+`FooterRenderTransform::transform` (`crates/quarto-core/src/transforms/footer_render.rs:89-106`)
+calls `rewrite_region_hrefs` per region:
+
+- `FooterRegion::Text(cv)` → `rewrite_config_inlines(...)` — rewrites Link + Image
+  targets inside the parsed inlines. This is the region-level control that works.
+  (Note: only the `PandocInlines` kind is matched — a `PandocBlocks` text region,
+  e.g. multi-paragraph `!md` or a lone image pre-fix, is silently skipped too.)
+- `FooterRegion::Items(items)` → `rewrite_items_hrefs(...)` (line 147) — rewrites
+  `item.href`, recurses into `item.menu`, **never looks at `item.text` or
+  `item.bare_text`**. That is the entire defect.
+
+`rewrite_config_inlines` lives in
+`crates/quarto-core/src/transforms/navigation_href.rs:488` and already handles
+both `Inline::Link` and `Inline::Image` recursively. The fix is plumbing, not
+new machinery.
+
+## Scope observation: navbar and sidebar have the same item-text gap
+
+`navbar_render.rs` rewrites item hrefs via its own `rewrite_navigation_item_hrefs`
+(line 163) and rewrites the navbar *title's* inlines (line 125-136), but item
+`text:` inlines are not rewritten there either. Since
+bd-page-footer-items-f4th80mj made `navbar.left/right.**.text` and
+`sidebar.contents.**.text` markdown-parsed (see `MARKDOWN_CONFIG_PATHS`), a
+navbar item `text: '![x](/images/logo.svg)'` presumably hits the same two
+defects. Not verified end-to-end; the strand scopes to page-footer, but the fix
+for defect 2 wants to be a shared helper.
+
+## Item text kinds to handle
+
+`NavigationItem.text: Option<ConfigValue>` (`crates/quarto-navigation/src/item.rs:47`)
+and `bare_text: Option<Box<ConfigValue>>` (footer bare-scalar items, demoted to
+text when unresolvable). After `ConfigMarkdownTransform` each may be:
+
+- `PandocInlines` — the common case (single-paragraph markdown);
+- `PandocBlocks` — lone image (today), or multi-block `!md` text;
+- `Scalar(String)` — pre-transform / non-blessed paths (render_text escapes it).
+
+A rewrite of item text must at least handle `PandocInlines`; whether
+`PandocBlocks` is handled by a blocks-walking wrapper or made rarer by fixing
+defect 1 at the parse level is a design question (see plan).
+
+## Repro
+
+`repro/` here is a copy of the sources from
+`/Users/cscheid/repos/github/cscheid/q2-connect-docs/llms-info/repros/page-footer-image-items/`
+(same tables in its README.md). Run `cargo run --bin q2 -- render <this dir>/repro`
+and inspect `_site/deep/deeper/index.html`. Verified at HEAD 5b6774d1 — see the
+plan's "What the code looks like today" for the observed output.

--- a/claude-notes/plans/page-footer-image-items-investigation/code-trace.md
+++ b/claude-notes/plans/page-footer-image-items-investigation/code-trace.md
@@ -70,6 +70,18 @@ A rewrite of item text must at least handle `PandocInlines`; whether
 `PandocBlocks` is handled by a blocks-walking wrapper or made rarer by fixing
 defect 1 at the parse level is a design question (see plan).
 
+## Q4 addendum (diagnostics/copy matrix)
+
+Investigated after design alignment — full findings in the plan's "Q4
+investigation" section. Key sites: `rewrite_config_inlines` emits Q-13-x for
+Links (via `resolve_href_for_html`) but nothing for Images
+(`resolve_root_relative_resource_href` is a pure rewrite); Q-5-6 is produced
+by the `ResourceCopyIntent` drain (`resource_copy_diagnostics.rs:121`) fed by
+`ResourceCollectorTransform`, which walks `ast.blocks` only;
+`copy_footer_images` (`website_post_render.rs:183`) owns the footer-image copy
+but skips `Items` regions and `PandocBlocks` values and warns without code or
+span. Fixture: `repro-missing/`.
+
 ## Repro
 
 `repro/` here is a copy of the sources from

--- a/claude-notes/plans/page-footer-image-items-investigation/repro-md-blocks/.gitignore
+++ b/claude-notes/plans/page-footer-image-items-investigation/repro-md-blocks/.gitignore
@@ -1,0 +1,2 @@
+_site/
+.quarto/

--- a/claude-notes/plans/page-footer-image-items-investigation/repro-md-blocks/_quarto.yml
+++ b/claude-notes/plans/page-footer-image-items-investigation/repro-md-blocks/_quarto.yml
@@ -1,0 +1,9 @@
+project:
+  type: website
+website:
+  title: "md blocks footer"
+  page-footer:
+    center: !md |
+      ![block image](/images/logo.svg)
+
+      [block link](/index.qmd)

--- a/claude-notes/plans/page-footer-image-items-investigation/repro-md-blocks/deep/deeper/index.qmd
+++ b/claude-notes/plans/page-footer-image-items-investigation/repro-md-blocks/deep/deeper/index.qmd
@@ -1,0 +1,5 @@
+---
+title: Deep
+---
+
+Two directories down.

--- a/claude-notes/plans/page-footer-image-items-investigation/repro-md-blocks/images/logo.svg
+++ b/claude-notes/plans/page-footer-image-items-investigation/repro-md-blocks/images/logo.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20"><rect width="20" height="20" fill="%23c33"/></svg>

--- a/claude-notes/plans/page-footer-image-items-investigation/repro-md-blocks/index.qmd
+++ b/claude-notes/plans/page-footer-image-items-investigation/repro-md-blocks/index.qmd
@@ -1,0 +1,5 @@
+---
+title: Home
+---
+
+Root page.

--- a/claude-notes/plans/page-footer-image-items-investigation/repro-missing/.gitignore
+++ b/claude-notes/plans/page-footer-image-items-investigation/repro-missing/.gitignore
@@ -1,0 +1,2 @@
+_site/
+.quarto/

--- a/claude-notes/plans/page-footer-image-items-investigation/repro-missing/_quarto.yml
+++ b/claude-notes/plans/page-footer-image-items-investigation/repro-missing/_quarto.yml
@@ -1,0 +1,9 @@
+project:
+  type: website
+website:
+  title: "missing footer image"
+  page-footer:
+    left: '![region-level missing, with sibling](/images/nope.svg) beside text'
+    center: '![region-level missing, lone](/images/nope.svg)'
+    right:
+      - text: '![item-level missing](/images/nope.svg) beside text'

--- a/claude-notes/plans/page-footer-image-items-investigation/repro-missing/index.qmd
+++ b/claude-notes/plans/page-footer-image-items-investigation/repro-missing/index.qmd
@@ -1,0 +1,7 @@
+---
+title: Home
+---
+
+Body control referencing the same missing file:
+
+![body missing](/images/nope.svg)

--- a/claude-notes/plans/page-footer-image-items-investigation/repro/.gitignore
+++ b/claude-notes/plans/page-footer-image-items-investigation/repro/.gitignore
@@ -1,0 +1,2 @@
+_site/
+.quarto/

--- a/claude-notes/plans/page-footer-image-items-investigation/repro/README.md
+++ b/claude-notes/plans/page-footer-image-items-investigation/repro/README.md
@@ -1,0 +1,106 @@
+# `page-footer` item `text:`: a lone image is dropped, and no link or image target is resolved
+
+**Observed with:** q2 0.23.0.
+**Repro:** `q2 render` in this directory; look at
+`_site/deep/deeper/index.html`, a page two directories down, where a
+correct path has to read `../../images/logo.svg`.
+
+q2 parses a `page-footer` item's `text:` as markdown — bold, emphasis,
+code and links all render. Two things then go wrong, independently: a
+lone image is dropped, and nothing inside an item's `text:` has its
+paths resolved.
+
+## Defect 1 — a lone image renders nothing
+
+| footer item `text:` | rendered `<li>` |
+|---|---|
+| `![lone image](/images/logo.svg)` | *(empty)* |
+| `![lone image, relative](images/logo.svg)` | *(empty)* |
+| `[![wrapped in a link](images/logo.svg)](https://posit.co)` | `<a …><img …></a>` |
+| `![image](images/logo.svg) beside text` | `<img …> beside text` |
+| `` `<img src="/images/logo.svg" …>`{=html} `` | `<img …>` |
+
+An image that is the item's *only* content disappears; wrap it in a
+link, or put any other inline beside it, and it survives.
+
+The mechanism is a two-step. `with_paragraph` in
+`crates/pampa/src/pandoc/treesitter_utils/postprocess.rs` desugars a
+single-image paragraph into a `Figure`. Then `block_inlines` in
+`crates/quarto-navigation/src/render_html.rs`, which is how
+`render_text` gets inlines out of a parsed-markdown `ConfigValue`,
+matches only `Plain`, `Paragraph` and `Header` and returns `None` for
+everything else — including `Figure`. The item renders as the empty
+string. Adding any sibling inline keeps the block a `Paragraph`, which
+is exactly why the workarounds work.
+
+A footer item is an inline context, so the fix is presumably to unwrap
+the `Figure` back to its image rather than to teach `block_inlines`
+about figure captions.
+
+## Defect 2 — nothing inside an *item's* `text:` is resolved
+
+Not just images, and not just root-absolute paths: no `Link` or `Image`
+target inside a footer **item's** `text:` is rewritten at all. The
+control is a *region-level* `text:` carrying the identical markdown, in
+the same footer of the same render, two directories deep:
+
+```
+page-footer.center: '![x](/images/logo.svg) … [y](/index.qmd)'
+  ->  src="../../images/logo.svg"   href="../../index.html"      resolved
+
+page-footer.right[0].text: (the same string)
+  ->  src="/images/logo.svg"        href="/index.qmd"            untouched
+```
+
+The region-level side rebases the path *and* rewrites `.qmd` to
+`.html`. The item-level side does neither, so every such reference
+404s on any page below the site root.
+
+`crates/quarto-core/src/transforms/footer_render.rs` shows why, and
+that the intent was the opposite. Its call site is commented "Rewrite
+hrefs in each Items region, **and Link/Image targets inside Text
+regions' parsed markdown**", and `rewrite_region_hrefs` splits:
+
+- `FooterRegion::Text(cv)` → `rewrite_config_inlines(...)`, which walks
+  the inlines and rewrites both node kinds. This is the control above.
+- `FooterRegion::Items(items)` → `rewrite_items_hrefs(...)`, which
+  touches `item.href` and recurses into `item.menu` — and never looks
+  at `item.text`, which is where an item's markdown inlines live.
+
+So the machinery exists and is invoked one branch over. Item text was
+simply never routed through it.
+
+**Nothing warns, and the asymmetry extends to diagnostics.** Write
+`![x](images/logo.svg)` in the body of `deep/deeper/index.qmd` and q2
+raises `Q-5-6 Referenced resource not found`, correctly, because
+`deep/deeper/images/logo.svg` does not exist. The footer items here
+point at exactly that missing file and the render is clean, exit 0.
+
+## Why this matters for the Connect port
+
+It closes off what looked like the docs-side fix for
+br-root-absolute-assets-1o6yy4mx. That strand's four surviving
+root-absolute paths are `<img>` tags inside `` `…`{=html} `` in
+`_quarto.yml`'s `page-footer`, and the recorded plan was to "move the
+markup out of raw HTML into a form q2 owns and resolves". Measured
+here, that form does not currently exist: written as markdown the
+images are either dropped (lone) or left unrebased (everything else),
+which is no better than the raw HTML they would replace.
+
+## A note on the Quarto 1 comparison
+
+`_site-q1/` is **not** a clean control for defect 1. The Quarto 1 dev
+build used here (99.9.9) does not parse footer `text:` as markdown at
+all — it emits the literal `![lone image](…)` source — so it has no
+opinion on how a lone image should render. The frozen Connect docs Q1
+render *does* show the footer images working, so released Q1 behaves
+differently again; treat the markdown half of this repro as a statement
+about q2 only.
+
+For defect 2 it *is* a clean control, and a striking one: Q1 rewrote
+`src="/images/logo.svg"` to `src="../../images/logo.svg"` **inside a
+string it was otherwise emitting literally**, because its deno-dom pass
+rewrites the rendered HTML rather than the AST. That is the mechanism
+q2 deliberately does not have, and the reason
+br-root-absolute-assets-1o6yy4mx needed a design decision rather than a
+patch.

--- a/claude-notes/plans/page-footer-image-items-investigation/repro/_quarto.yml
+++ b/claude-notes/plans/page-footer-image-items-investigation/repro/_quarto.yml
@@ -1,0 +1,15 @@
+project:
+  type: website
+website:
+  title: "page-footer image items"
+  page-footer:
+    # Region-level text: the control. Its inlines ARE resolved.
+    center: '![region-level](/images/logo.svg) and a [region-level link](/index.qmd)'
+    left:
+      - text: '![lone image](/images/logo.svg)'
+      - text: '![lone image, relative](images/logo.svg)'
+      - text: '[![wrapped in a link](images/logo.svg)](https://posit.co)'
+      - text: '![image](images/logo.svg) beside text'
+      - text: '`<img src="/images/logo.svg" alt="raw html">`{=html}'
+    right:
+      - text: '![item-level](/images/logo.svg) and an [item-level link](/index.qmd)'

--- a/claude-notes/plans/page-footer-image-items-investigation/repro/deep/deeper/index.qmd
+++ b/claude-notes/plans/page-footer-image-items-investigation/repro/deep/deeper/index.qmd
@@ -1,0 +1,14 @@
+---
+title: Two deep
+---
+
+A page two directories down, where a correct path must be `../../images/logo.svg`.
+
+Control — the same root-absolute path written in the document body:
+
+![body image, root-absolute](/images/logo.svg)
+
+(Add `![x](images/logo.svg)` here too and q2 raises `Q-5-6 Referenced
+resource not found`, because `deep/deeper/images/logo.svg` does not
+exist. The footer items below point at exactly that missing file and
+say nothing.)

--- a/claude-notes/plans/page-footer-image-items-investigation/repro/images/logo.svg
+++ b/claude-notes/plans/page-footer-image-items-investigation/repro/images/logo.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20"><rect width="20" height="20" fill="%23c33"/></svg>

--- a/claude-notes/plans/page-footer-image-items-investigation/repro/index.qmd
+++ b/claude-notes/plans/page-footer-image-items-investigation/repro/index.qmd
@@ -1,0 +1,5 @@
+---
+title: Home
+---
+
+Site root page.

--- a/crates/pampa/src/pandoc/location.rs
+++ b/crates/pampa/src/pandoc/location.rs
@@ -248,6 +248,19 @@ pub fn range_to_source_info_with_context(
     range: &quarto_source_map::Range,
     ctx: &ASTContext,
 ) -> quarto_source_map::SourceInfo {
+    // Under a re-parse of an embedded string (config strings, `!md`
+    // metadata), spans must reroot through the parent `SourceInfo`
+    // exactly like node spans do (`node_source_info_with_context`) —
+    // an `Original` at raw offsets-into-the-string would render a
+    // diagnostic against the wrong text
+    // (bd-page-footer-image-items-stmpikgo, Phase 4).
+    if let Some(parent) = &ctx.parent_source_info {
+        return quarto_source_map::SourceInfo::substring(
+            parent.clone(),
+            range.start.offset,
+            range.end.offset,
+        );
+    }
     let file_id = ctx
         .primary_file_id()
         .unwrap_or(quarto_source_map::FileId(0));

--- a/crates/pampa/src/pandoc/meta.rs
+++ b/crates/pampa/src/pandoc/meta.rs
@@ -745,6 +745,40 @@ mod tests {
         );
     }
 
+    /// Sub-spans (an image target's URL span) must reroot through the
+    /// parent `SourceInfo` exactly like node spans do
+    /// (bd-page-footer-image-items-stmpikgo, Phase 4): a consumer that
+    /// anchors a diagnostic at `target_source.url` must land inside
+    /// the config file the scalar was authored in, not at raw
+    /// offsets-into-the-scalar against `FileId(0)`.
+    #[test]
+    fn config_string_image_target_source_reroots_through_parent() {
+        use quarto_source_map::FileId;
+        let parent = quarto_source_map::SourceInfo::original(FileId(7), 100, 160);
+        let mut diagnostics = Vec::new();
+        let kind =
+            parse_config_string_as_markdown("![x](images/logo.svg)", &parent, &mut diagnostics);
+        let ConfigValueKind::PandocInlines(inlines) = kind else {
+            panic!("expected PandocInlines");
+        };
+        let Inline::Image(img) = &inlines[0] else {
+            panic!("expected Image inline");
+        };
+        let url_si = img
+            .target_source
+            .url
+            .as_ref()
+            .expect("URL span must be tracked");
+        let (fid, start, end) = url_si
+            .resolve_byte_range()
+            .expect("URL span must resolve to a byte range");
+        assert_eq!(fid, 7, "URL span must resolve into the parent's file");
+        // "![x](" is 5 bytes into the scalar, which starts at parent
+        // offset 100.
+        assert_eq!(start, 105, "URL span must shift by the parent's start");
+        assert_eq!(end, 105 + "images/logo.svg".len());
+    }
+
     #[test]
     fn explicit_md_lone_image_keeps_figure_semantics() {
         // `!md`-tagged values are explicit block-context markdown:

--- a/crates/pampa/src/pandoc/meta.rs
+++ b/crates/pampa/src/pandoc/meta.rs
@@ -37,9 +37,47 @@ pub fn parse_config_string_as_markdown(
     diagnostics: &mut Vec<quarto_error_reporting::DiagnosticMessage>,
 ) -> ConfigValueKind {
     let mut collector = crate::utils::diagnostic_collector::DiagnosticCollector::new();
-    let kind = parse_yaml_string_as_markdown_to_config(value, source_info, false, &mut collector);
+    let mut kind =
+        parse_yaml_string_as_markdown_to_config(value, source_info, false, &mut collector);
     diagnostics.extend(collector.into_diagnostics());
+    unwrap_lone_figure(&mut kind);
     kind
+}
+
+/// Undo the qmd reader's single-image-paragraph → `Figure` desugar for
+/// config strings (bd-page-footer-image-items-stmpikgo).
+///
+/// Config strings are inline presentation contexts — footer/navbar
+/// item text, titles, captions — where figure-with-caption semantics
+/// is never wanted: consumers render inlines and would drop a Figure
+/// block on the floor. A lone image with alt text is the one shape
+/// the reader turns into a Figure, so unwrap it back to the image the
+/// author wrote, reassembling the attr the desugar split (id on the
+/// figure, classes/attributes on the image).
+///
+/// Deliberately *not* applied to `!md`-tagged values
+/// ([`parse_yaml_string_as_markdown_to_config`] with
+/// `is_explicit_md = true`): those are explicit block-context
+/// markdown, where figures persist.
+fn unwrap_lone_figure(kind: &mut ConfigValueKind) {
+    use quarto_pandoc_types::Block;
+
+    let ConfigValueKind::PandocBlocks(blocks) = kind else {
+        return;
+    };
+    let [Block::Figure(figure)] = &mut blocks[..] else {
+        return;
+    };
+    let [Block::Plain(plain)] = &mut figure.content[..] else {
+        return;
+    };
+    let [Inline::Image(image)] = &mut plain.content[..] else {
+        return;
+    };
+    image.attr.0 = figure.attr.0.clone();
+    image.attr_source.id = figure.attr_source.id.clone();
+    let image = image.clone();
+    *kind = ConfigValueKind::PandocInlines(vec![Inline::Image(image)]);
 }
 
 /// Parse a YAML string as markdown and return ConfigValue with PandocInlines/PandocBlocks.
@@ -620,6 +658,112 @@ mod tests {
             "map entries under contents extend the key path, so record \
              fields keep the markdown default; got {:?}",
             title.value
+        );
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Lone-figure unwrap in config strings
+    // (bd-page-footer-image-items-stmpikgo).
+    //
+    // Config strings are inline presentation contexts (footer/navbar
+    // item text, titles, captions); figure-with-caption semantics is
+    // never wanted there. The qmd reader's postprocess desugars a
+    // single-image paragraph into a Figure, which — without the
+    // unwrap — leaves the value as PandocBlocks([Figure]) that inline
+    // renderers and rewriters drop on the floor.
+    // ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn config_string_lone_image_unwraps_to_inline_image() {
+        let mut diagnostics = Vec::new();
+        let kind = parse_config_string_as_markdown(
+            "![lone image](images/logo.svg)",
+            &si(),
+            &mut diagnostics,
+        );
+        let ConfigValueKind::PandocInlines(inlines) = kind else {
+            panic!("lone image must unwrap to PandocInlines, got {:?}", kind);
+        };
+        assert_eq!(inlines.len(), 1, "exactly the image, got {:?}", inlines);
+        let Inline::Image(img) = &inlines[0] else {
+            panic!("expected Image inline, got {:?}", inlines[0]);
+        };
+        assert_eq!(img.target.0, "images/logo.svg");
+        assert!(
+            !img.content.is_empty(),
+            "alt text must survive the round-trip through the figure desugar"
+        );
+    }
+
+    #[test]
+    fn config_string_lone_image_without_alt_is_inline_image() {
+        // No alt text → the postprocess figure desugar never fires
+        // (it requires a non-empty caption); pin the behavior so both
+        // variants land in the same shape.
+        let mut diagnostics = Vec::new();
+        let kind = parse_config_string_as_markdown("![](images/logo.svg)", &si(), &mut diagnostics);
+        let ConfigValueKind::PandocInlines(inlines) = kind else {
+            panic!("expected PandocInlines, got {:?}", kind);
+        };
+        assert!(
+            matches!(&inlines[..], [Inline::Image(_)]),
+            "got {:?}",
+            inlines
+        );
+    }
+
+    #[test]
+    fn config_string_lone_image_unwrap_restores_attr() {
+        // The figure desugar splits the attr: the id moves to the
+        // figure, classes/attributes stay on the image. The unwrap
+        // must reassemble the image the author wrote.
+        let mut diagnostics = Vec::new();
+        let kind = parse_config_string_as_markdown(
+            "![x](logo.svg){#the-id .the-class}",
+            &si(),
+            &mut diagnostics,
+        );
+        let ConfigValueKind::PandocInlines(inlines) = kind else {
+            panic!("expected PandocInlines, got {:?}", kind);
+        };
+        let Inline::Image(img) = &inlines[0] else {
+            panic!("expected Image inline, got {:?}", inlines[0]);
+        };
+        assert_eq!(img.attr.0, "the-id", "id must move back from the figure");
+        assert_eq!(img.attr.1, vec!["the-class".to_string()]);
+    }
+
+    #[test]
+    fn config_string_image_with_sibling_inline_stays_inlines() {
+        let mut diagnostics = Vec::new();
+        let kind =
+            parse_config_string_as_markdown("![x](logo.svg) beside text", &si(), &mut diagnostics);
+        assert!(
+            matches!(kind, ConfigValueKind::PandocInlines(_)),
+            "got {:?}",
+            kind
+        );
+    }
+
+    #[test]
+    fn explicit_md_lone_image_keeps_figure_semantics() {
+        // `!md`-tagged values are explicit block-context markdown:
+        // a lone image there keeps its Figure (decision 3 of the
+        // 2026-08-18 plan — figures persist in block settings).
+        let mut collector = crate::utils::diagnostic_collector::DiagnosticCollector::new();
+        let kind = parse_yaml_string_as_markdown_to_config(
+            "![lone image](images/logo.svg)",
+            &si(),
+            true,
+            &mut collector,
+        );
+        let ConfigValueKind::PandocBlocks(blocks) = &kind else {
+            panic!("expected PandocBlocks, got {:?}", kind);
+        };
+        assert!(
+            matches!(&blocks[..], [quarto_pandoc_types::Block::Figure(_)]),
+            "got {:?}",
+            blocks
         );
     }
 

--- a/crates/quarto-core/src/project/website_post_render.rs
+++ b/crates/quarto-core/src/project/website_post_render.rs
@@ -169,16 +169,24 @@ pub(super) fn copy_navbar_logo(
     copy_asset_file(project, runtime, normalized, "navbar logo")
 }
 
-/// Copy images referenced from `page-footer` text regions into the
-/// output tree.
+/// Copy images referenced from `page-footer` regions — Text regions
+/// *and* item `text:` (bd-page-footer-image-items-stmpikgo, Phase 4)
+/// — into the output tree.
 ///
 /// Decision 5 of bd-root-relative-paths-design-fc5pvkcv, footer
 /// edition: a footer-region markdown image (`![](/images/x.svg)`) is
-/// a config-declared asset like the favicon and navbar logo, so it
-/// gets the same warn-and-continue copy. External URLs and `data:`
-/// URIs are skipped; a leading `/` is site-root-relative and strips
-/// to the project-relative path; `?query`/`#fragment` tails are
-/// dropped for the file probe.
+/// a config-declared asset like the favicon and navbar logo. External
+/// URLs and `data:` URIs are skipped; a leading `/` is
+/// site-root-relative and strips to the project-relative path;
+/// `?query`/`#fragment` tails are dropped for the file probe.
+///
+/// A missing file raises the same **`Q-5-6`** warning the identical
+/// reference would raise in a document body, located at the reference
+/// inside the config file (the CLI's project-diagnostic printer binds
+/// `_quarto.yml` into the source context, so the span renders as an
+/// Ariadne snippet). Running here — once per project, post-render —
+/// rather than in the per-doc pipeline is what keeps a broken footer
+/// reference from warning once per rendered page.
 #[cfg(not(target_arch = "wasm32"))]
 pub(super) fn copy_footer_images(
     project: &ProjectContext,
@@ -186,7 +194,6 @@ pub(super) fn copy_footer_images(
     diagnostics: &mut Vec<DiagnosticMessage>,
 ) -> Result<()> {
     use quarto_navigation::FooterRegion;
-    use quarto_pandoc_types::config_value::ConfigValueKind;
 
     let Some(meta) = project.config.metadata.as_ref() else {
         return Ok(());
@@ -195,39 +202,16 @@ pub(super) fn copy_footer_images(
         return Ok(());
     };
 
-    let mut urls: Vec<String> = Vec::new();
+    let mut refs: Vec<ImageRef> = Vec::new();
     for region in [&footer.left, &footer.center, &footer.right] {
-        let FooterRegion::Text(cv) = region else {
-            continue;
-        };
-        match &cv.value {
-            ConfigValueKind::PandocInlines(inlines) => {
-                collect_inline_image_urls(inlines, &mut urls);
-            }
-            // At post-render time the project config still holds the
-            // raw scalar — markdown-izing config strings
-            // (`ConfigMarkdownTransform`) happens in the per-doc
-            // pipeline. Parse the same way here; parse warnings are
-            // dropped, the per-doc pipeline already reported them.
-            ConfigValueKind::Scalar(_) => {
-                let Some(text) = cv.as_plain_text() else {
-                    continue;
-                };
-                let mut parse_diags = Vec::new();
-                let kind = pampa::pandoc::meta::parse_config_string_as_markdown(
-                    &text,
-                    &cv.source_info,
-                    &mut parse_diags,
-                );
-                if let ConfigValueKind::PandocInlines(inlines) = &kind {
-                    collect_inline_image_urls(inlines, &mut urls);
-                }
-            }
-            _ => {}
+        match region {
+            FooterRegion::Text(cv) => collect_config_text_images(cv, &mut refs),
+            FooterRegion::Items(items) => collect_items_images(items, &mut refs),
+            FooterRegion::Empty => {}
         }
     }
 
-    for raw in urls {
+    for ImageRef { url: raw, origin } in refs {
         if quarto_util::is_external_url(&raw) {
             continue;
         }
@@ -245,10 +229,16 @@ pub(super) fn copy_footer_images(
             ))
         })?;
         if !exists {
-            diagnostics.push(DiagnosticMessage::warning(format!(
-                "page-footer image refers to missing file '{}'",
-                normalized
-            )));
+            // Uniform missing-resource shape (Q-5-6): the same
+            // intent-based diagnostic the body's resource-copy drain
+            // emits, anchored at the reference in the YAML.
+            let intent = crate::render::ResourceCopyIntent {
+                src,
+                dest: project.output_dir.join(normalized),
+                origin,
+            };
+            diagnostics
+                .push(crate::resource_copy_diagnostics::missing_resource_diagnostic(&intent));
             continue;
         }
         copy_asset_file(project, runtime, normalized, "page-footer image")?;
@@ -256,35 +246,160 @@ pub(super) fn copy_footer_images(
     Ok(())
 }
 
-/// Collect `Image` target URLs from config-region inlines, in order,
-/// deduplicated, recursing through formatting containers.
+/// One collected image reference: the raw authored URL plus the span
+/// to anchor a `Q-5-6` at — the URL's own span when the parse tracked
+/// it, else the whole image's.
 #[cfg(not(target_arch = "wasm32"))]
-fn collect_inline_image_urls(
+struct ImageRef {
+    url: String,
+    origin: quarto_source_map::SourceInfo,
+}
+
+/// Collect image references from a text-bearing config value in any
+/// of its shapes: parsed inlines, parsed blocks, or a raw scalar.
+///
+/// At post-render time the project config still holds raw scalars —
+/// markdown-izing config strings (`ConfigMarkdownTransform`) happens
+/// in the per-doc pipeline — so scalars are re-parsed the same way
+/// here; parse warnings are dropped, the per-doc pipeline already
+/// reported them. The parse threads the scalar's `SourceInfo`
+/// through, so collected spans remap into the config file.
+#[cfg(not(target_arch = "wasm32"))]
+fn collect_config_text_images(
+    cv: &quarto_pandoc_types::config_value::ConfigValue,
+    out: &mut Vec<ImageRef>,
+) {
+    use quarto_pandoc_types::config_value::ConfigValueKind;
+    match &cv.value {
+        ConfigValueKind::PandocInlines(inlines) => collect_inline_image_refs(inlines, out),
+        ConfigValueKind::PandocBlocks(blocks) => collect_block_image_refs(blocks, out),
+        ConfigValueKind::Scalar(_) => {
+            let Some(text) = cv.as_plain_text() else {
+                return;
+            };
+            let mut parse_diags = Vec::new();
+            let kind = pampa::pandoc::meta::parse_config_string_as_markdown(
+                &text,
+                &cv.source_info,
+                &mut parse_diags,
+            );
+            match &kind {
+                ConfigValueKind::PandocInlines(inlines) => collect_inline_image_refs(inlines, out),
+                ConfigValueKind::PandocBlocks(blocks) => collect_block_image_refs(blocks, out),
+                _ => {}
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Collect image references from footer items: each item's `text:`
+/// and (bare-scalar) `bare_text`, recursing into `menu` symmetrically
+/// with the render-time walkers.
+#[cfg(not(target_arch = "wasm32"))]
+fn collect_items_images(items: &[quarto_navigation::NavigationItem], out: &mut Vec<ImageRef>) {
+    for item in items {
+        if let Some(cv) = &item.text {
+            collect_config_text_images(cv, out);
+        }
+        if let Some(cv) = &item.bare_text {
+            collect_config_text_images(cv, out);
+        }
+        collect_items_images(&item.menu, out);
+    }
+}
+
+/// Collect image references from block containers. Coverage mirrors
+/// `transforms::navigation_href::rewrite_config_blocks` for the
+/// container shapes that plausibly occur in config text; figures
+/// contribute the image in their content (and any images in their
+/// caption).
+#[cfg(not(target_arch = "wasm32"))]
+fn collect_block_image_refs(blocks: &[quarto_pandoc_types::block::Block], out: &mut Vec<ImageRef>) {
+    use quarto_pandoc_types::block::Block;
+    for block in blocks {
+        match block {
+            Block::Plain(p) => collect_inline_image_refs(&p.content, out),
+            Block::Paragraph(p) => collect_inline_image_refs(&p.content, out),
+            Block::Header(h) => collect_inline_image_refs(&h.content, out),
+            Block::LineBlock(lb) => {
+                for line in &lb.content {
+                    collect_inline_image_refs(line, out);
+                }
+            }
+            Block::BlockQuote(bq) => collect_block_image_refs(&bq.content, out),
+            Block::OrderedList(ol) => {
+                for item in &ol.content {
+                    collect_block_image_refs(item, out);
+                }
+            }
+            Block::BulletList(bl) => {
+                for item in &bl.content {
+                    collect_block_image_refs(item, out);
+                }
+            }
+            Block::DefinitionList(dl) => {
+                for (term, defs) in &dl.content {
+                    collect_inline_image_refs(term, out);
+                    for def in defs {
+                        collect_block_image_refs(def, out);
+                    }
+                }
+            }
+            Block::Div(d) => collect_block_image_refs(&d.content, out),
+            Block::Figure(f) => {
+                if let Some(short) = &f.caption.short {
+                    collect_inline_image_refs(short, out);
+                }
+                if let Some(long) = &f.caption.long {
+                    collect_block_image_refs(long, out);
+                }
+                collect_block_image_refs(&f.content, out);
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Collect `Image` target references from config-region inlines, in
+/// order, deduplicated by URL (the first occurrence keeps its span),
+/// recursing through formatting containers. The span follows the body
+/// collector's rule (`ResourceCollectorTransform`): the URL's own
+/// span when the parse tracked it, else the whole image's.
+#[cfg(not(target_arch = "wasm32"))]
+fn collect_inline_image_refs(
     inlines: &[quarto_pandoc_types::inline::Inline],
-    out: &mut Vec<String>,
+    out: &mut Vec<ImageRef>,
 ) {
     use quarto_pandoc_types::inline::Inline;
     for inline in inlines {
         match inline {
             Inline::Image(img) => {
-                if !out.contains(&img.target.0) {
-                    out.push(img.target.0.clone());
+                if !out.iter().any(|r| r.url == img.target.0) {
+                    out.push(ImageRef {
+                        url: img.target.0.clone(),
+                        origin: img
+                            .target_source
+                            .url
+                            .clone()
+                            .unwrap_or_else(|| img.source_info.clone()),
+                    });
                 }
-                collect_inline_image_urls(&img.content, out);
+                collect_inline_image_refs(&img.content, out);
             }
-            Inline::Link(l) => collect_inline_image_urls(&l.content, out),
-            Inline::Emph(e) => collect_inline_image_urls(&e.content, out),
-            Inline::Strong(s) => collect_inline_image_urls(&s.content, out),
-            Inline::Underline(u) => collect_inline_image_urls(&u.content, out),
-            Inline::Strikeout(s) => collect_inline_image_urls(&s.content, out),
-            Inline::Superscript(s) => collect_inline_image_urls(&s.content, out),
-            Inline::Subscript(s) => collect_inline_image_urls(&s.content, out),
-            Inline::SmallCaps(s) => collect_inline_image_urls(&s.content, out),
-            Inline::Quoted(q) => collect_inline_image_urls(&q.content, out),
-            Inline::Span(s) => collect_inline_image_urls(&s.content, out),
-            Inline::Insert(i) => collect_inline_image_urls(&i.content, out),
-            Inline::Delete(d) => collect_inline_image_urls(&d.content, out),
-            Inline::Highlight(h) => collect_inline_image_urls(&h.content, out),
+            Inline::Link(l) => collect_inline_image_refs(&l.content, out),
+            Inline::Emph(e) => collect_inline_image_refs(&e.content, out),
+            Inline::Strong(s) => collect_inline_image_refs(&s.content, out),
+            Inline::Underline(u) => collect_inline_image_refs(&u.content, out),
+            Inline::Strikeout(s) => collect_inline_image_refs(&s.content, out),
+            Inline::Superscript(s) => collect_inline_image_refs(&s.content, out),
+            Inline::Subscript(s) => collect_inline_image_refs(&s.content, out),
+            Inline::SmallCaps(s) => collect_inline_image_refs(&s.content, out),
+            Inline::Quoted(q) => collect_inline_image_refs(&q.content, out),
+            Inline::Span(s) => collect_inline_image_refs(&s.content, out),
+            Inline::Insert(i) => collect_inline_image_refs(&i.content, out),
+            Inline::Delete(d) => collect_inline_image_refs(&d.content, out),
+            Inline::Highlight(h) => collect_inline_image_refs(&h.content, out),
             _ => {}
         }
     }

--- a/crates/quarto-core/src/transforms/footer_render.rs
+++ b/crates/quarto-core/src/transforms/footer_render.rs
@@ -128,17 +128,15 @@ fn rewrite_region_hrefs(
             rewrite_items_hrefs(items, resolver, index, diagnostics);
         }
         FooterRegion::Text(cv) => {
-            if let quarto_pandoc_types::config_value::ConfigValueKind::PandocInlines(inlines) =
-                &mut cv.value
-            {
-                crate::transforms::navigation_href::rewrite_config_inlines(
-                    inlines,
-                    resolver,
-                    index,
-                    &NavSurface::PageFooter,
-                    diagnostics,
-                );
-            }
+            // Handles both the common `PandocInlines` shape and
+            // multi-block `!md` text (`PandocBlocks`).
+            crate::transforms::navigation_href::rewrite_config_text(
+                cv,
+                resolver,
+                index,
+                &NavSurface::PageFooter,
+                diagnostics,
+            );
         }
         FooterRegion::Empty => {}
     }
@@ -431,6 +429,61 @@ mod tests {
         assert!(html.contains("href=\"about.html\""), "got: {}", html);
         assert!(!html.contains("href=\"about.qmd\""));
         assert!(diags.is_empty());
+    }
+
+    /// A `ConfigValue` holding parsed markdown blocks — the shape
+    /// multi-block `!md` footer text takes.
+    fn blocks_cv(blocks: Vec<quarto_pandoc_types::block::Block>) -> ConfigValue {
+        ConfigValue {
+            value: quarto_pandoc_types::config_value::ConfigValueKind::PandocBlocks(blocks),
+            source_info: SourceInfo::for_test(),
+            merge_op: Default::default(),
+        }
+    }
+
+    /// Phase 3 of bd-page-footer-image-items-stmpikgo: a
+    /// `PandocBlocks`-shaped Text region (multi-paragraph `!md` text)
+    /// resolves its Link/Image targets like the inline-shaped one.
+    #[tokio::test]
+    async fn footer_render_text_region_blocks_resolve_at_depth() {
+        use quarto_pandoc_types::block::{Block, Paragraph};
+        let footer = PageFooter {
+            center: FooterRegion::Text(blocks_cv(vec![
+                Block::Paragraph(Paragraph {
+                    content: vec![footer_image("/images/x.svg", "logo")],
+                    source_info: SourceInfo::for_test(),
+                }),
+                Block::Paragraph(Paragraph {
+                    content: vec![footer_link("docs.qmd", "docs")],
+                    source_info: SourceInfo::for_test(),
+                }),
+            ])),
+            ..PageFooter::default()
+        };
+        let mut meta = ConfigValue::default();
+        meta.insert_path(&["navigation", "footer"], footer.to_config_value());
+        let index = Arc::new(ProjectIndex::new(vec![profile(
+            "docs.qmd",
+            "docs.html",
+            "Docs",
+        )]));
+        let (out, diags) = run_at_depth(meta, Some(index)).await;
+        let html = out
+            .get_path(&["rendered", "navigation", "footer"])
+            .unwrap()
+            .as_plain_text()
+            .unwrap();
+        assert!(
+            html.contains("src=\"../images/x.svg\""),
+            "blocks-shaped text-region image must relativize; got: {}",
+            html
+        );
+        assert!(
+            html.contains("href=\"../docs.html\""),
+            "blocks-shaped text-region link must resolve; got: {}",
+            html
+        );
+        assert!(diags.is_empty(), "got diagnostics: {:?}", diags);
     }
 
     /// Defect 2 of bd-page-footer-image-items-stmpikgo: an *item's*

--- a/crates/quarto-core/src/transforms/footer_render.rs
+++ b/crates/quarto-core/src/transforms/footer_render.rs
@@ -164,6 +164,16 @@ fn rewrite_items_hrefs(
                 diagnostics,
             );
         }
+        // An item's parsed-markdown `text:` carries Link/Image targets
+        // that resolve exactly like a Text region's
+        // (bd-page-footer-image-items-stmpikgo, defect 2).
+        crate::transforms::navigation_href::rewrite_item_text(
+            item,
+            resolver,
+            index,
+            &NavSurface::PageFooter,
+            diagnostics,
+        );
         // Footer items rarely nest `menu`, but the type allows it —
         // handle symmetrically with navbar.
         if !item.menu.is_empty() {
@@ -421,6 +431,49 @@ mod tests {
         assert!(html.contains("href=\"about.html\""), "got: {}", html);
         assert!(!html.contains("href=\"about.qmd\""));
         assert!(diags.is_empty());
+    }
+
+    /// Defect 2 of bd-page-footer-image-items-stmpikgo: an *item's*
+    /// `text:` markdown resolves exactly like a Text region's — Image
+    /// targets relativize per page, `.qmd` links resolve through the
+    /// index. (Menu-child text is covered by the navbar test — the
+    /// footer emitter doesn't render dropdowns.)
+    #[tokio::test]
+    async fn footer_render_item_text_inlines_resolve_at_depth() {
+        let footer = PageFooter {
+            right: FooterRegion::Items(vec![NavigationItem {
+                text: Some(inlines_cv(vec![
+                    footer_image("/images/x.svg", "logo"),
+                    footer_link("docs.qmd", "docs"),
+                ])),
+                ..NavigationItem::default()
+            }]),
+            ..PageFooter::default()
+        };
+        let mut meta = ConfigValue::default();
+        meta.insert_path(&["navigation", "footer"], footer.to_config_value());
+        let index = Arc::new(ProjectIndex::new(vec![profile(
+            "docs.qmd",
+            "docs.html",
+            "Docs",
+        )]));
+        let (out, diags) = run_at_depth(meta, Some(index)).await;
+        let html = out
+            .get_path(&["rendered", "navigation", "footer"])
+            .unwrap()
+            .as_plain_text()
+            .unwrap();
+        assert!(
+            html.contains("src=\"../images/x.svg\""),
+            "item-text image must relativize from the depth-1 page; got: {}",
+            html
+        );
+        assert!(
+            html.contains("href=\"../docs.html\""),
+            "item-text .qmd link must resolve through the index; got: {}",
+            html
+        );
+        assert!(diags.is_empty(), "got diagnostics: {:?}", diags);
     }
 
     /// ~~Phase 3 test 42~~ — DELIBERATELY INVERTED by

--- a/crates/quarto-core/src/transforms/navbar_render.rs
+++ b/crates/quarto-core/src/transforms/navbar_render.rs
@@ -35,7 +35,7 @@ use crate::resource_resolver::ResourceResolverContext;
 use crate::transform::{AstTransform, TransformPhase};
 use crate::transforms::is_feature_disabled;
 use crate::transforms::navigation_href::{
-    NavSurface, resolve_href_for_html, resolve_root_relative_resource_href, rewrite_config_inlines,
+    NavSurface, resolve_href_for_html, resolve_root_relative_resource_href,
 };
 
 pub struct NavbarRenderTransform;
@@ -121,13 +121,11 @@ impl AstTransform for NavbarRenderTransform {
             *logo = resolve_root_relative_resource_href(logo, ctx.resource_resolver.as_ref());
         }
         // Navbar title markdown (Case C): Link/Image targets inside
-        // the title's parsed inlines resolve like footer text regions.
-        if let NavbarTitle::Text(cv) = &mut navbar.title
-            && let quarto_pandoc_types::config_value::ConfigValueKind::PandocInlines(inlines) =
-                &mut cv.value
-        {
-            rewrite_config_inlines(
-                inlines.as_mut_slice(),
+        // the title's parsed markdown resolve like footer text
+        // regions (inlines and `!md` blocks alike).
+        if let NavbarTitle::Text(cv) = &mut navbar.title {
+            crate::transforms::navigation_href::rewrite_config_text(
+                cv,
                 ctx.resource_resolver.as_ref(),
                 ctx.project_index.as_deref(),
                 &NavSurface::Navbar,

--- a/crates/quarto-core/src/transforms/navbar_render.rs
+++ b/crates/quarto-core/src/transforms/navbar_render.rs
@@ -180,6 +180,16 @@ fn rewrite_navigation_item_hrefs(
                 diagnostics,
             );
         }
+        // An item's parsed-markdown `text:` carries Link/Image targets
+        // that resolve like the navbar title's
+        // (bd-page-footer-image-items-stmpikgo, defect 2).
+        crate::transforms::navigation_href::rewrite_item_text(
+            item,
+            resolver,
+            index,
+            &NavSurface::Navbar,
+            diagnostics,
+        );
         if !item.menu.is_empty() {
             rewrite_navigation_item_hrefs(&mut item.menu, resolver, index, diagnostics);
         }
@@ -367,6 +377,135 @@ mod tests {
             .as_plain_text()
             .unwrap();
         assert!(html.contains("Doc Title"));
+    }
+
+    /// A `ConfigValue` holding parsed markdown inlines — the shape
+    /// item `text:` takes after `ConfigMarkdownTransform`.
+    fn inlines_cv(inlines: Vec<quarto_pandoc_types::inline::Inline>) -> ConfigValue {
+        ConfigValue {
+            value: quarto_pandoc_types::config_value::ConfigValueKind::PandocInlines(inlines),
+            source_info: SourceInfo::for_test(),
+            merge_op: Default::default(),
+        }
+    }
+
+    fn nav_image(url: &str, alt: &str) -> quarto_pandoc_types::inline::Inline {
+        use quarto_pandoc_types::attr::{AttrSourceInfo, TargetSourceInfo};
+        use quarto_pandoc_types::inline::{Image, Inline, Str};
+        Inline::Image(Image {
+            attr: Default::default(),
+            content: vec![Inline::Str(Str {
+                text: alt.to_string(),
+                source_info: SourceInfo::for_test(),
+            })],
+            target: (url.to_string(), String::new()),
+            source_info: SourceInfo::for_test(),
+            attr_source: AttrSourceInfo::empty(),
+            target_source: TargetSourceInfo::empty(),
+        })
+    }
+
+    fn nav_link(url: &str, text: &str) -> quarto_pandoc_types::inline::Inline {
+        use quarto_pandoc_types::attr::{AttrSourceInfo, TargetSourceInfo};
+        use quarto_pandoc_types::inline::{Inline, Link, Str};
+        Inline::Link(Link {
+            attr: Default::default(),
+            content: vec![Inline::Str(Str {
+                text: text.to_string(),
+                source_info: SourceInfo::for_test(),
+            })],
+            target: (url.to_string(), String::new()),
+            source_info: SourceInfo::for_test(),
+            attr_source: AttrSourceInfo::empty(),
+            target_source: TargetSourceInfo::empty(),
+        })
+    }
+
+    /// Like `run_with`, but wires a website resolver pinned at a
+    /// depth-1 page (`docs/api.html`) so page-relative resolution is
+    /// observable.
+    async fn run_at_depth(
+        meta: ConfigValue,
+        index: Option<Arc<ProjectIndex>>,
+    ) -> (ConfigValue, Vec<DiagnosticMessage>) {
+        use crate::resource_resolver::ResourceResolverContext;
+        let mut ast = Pandoc {
+            meta,
+            blocks: vec![],
+        };
+        let project = make_test_project();
+        let doc = DocumentInfo::from_path("/project/docs/api.qmd");
+        let format = Format::html();
+        let binaries = BinaryDependencies::new();
+        let resolver = ResourceResolverContext::website(
+            "/project/_site",
+            "/project/_site/docs/api.html",
+            "site_libs",
+            "api",
+        );
+        let mut ctx =
+            RenderContext::new(&project, &doc, &format, &binaries).with_resource_resolver(resolver);
+        if let Some(idx) = index {
+            ctx = ctx.with_project_index(idx);
+        }
+        NavbarRenderTransform::new()
+            .transform(&mut ast, &mut ctx)
+            .await
+            .unwrap();
+        (ast.meta, ctx.diagnostics)
+    }
+
+    /// Defect 2 of bd-page-footer-image-items-stmpikgo, navbar
+    /// edition: a navbar item's `text:` markdown resolves like the
+    /// navbar title's — Image targets relativize per page, `.qmd`
+    /// links resolve through the index. Covers a top-level item and a
+    /// dropdown `menu` child (rendered by the navbar, unlike footer
+    /// menus).
+    #[tokio::test]
+    async fn navbar_render_item_text_inlines_resolve_at_depth() {
+        let navbar = Navbar {
+            left: vec![NavigationItem {
+                text: Some(inlines_cv(vec![
+                    nav_image("/images/x.svg", "logo"),
+                    nav_link("docs.qmd", "docs"),
+                ])),
+                menu: vec![NavigationItem {
+                    text: Some(inlines_cv(vec![nav_image("images/y.svg", "nested")])),
+                    ..NavigationItem::default()
+                }],
+                ..NavigationItem::default()
+            }],
+            ..Navbar::with_defaults()
+        };
+        let mut meta = ConfigValue::default();
+        meta.insert_path(&["navigation", "navbar"], navbar.to_config_value());
+        let index = Arc::new(ProjectIndex::new(vec![profile(
+            "docs.qmd",
+            "docs.html",
+            "Docs",
+        )]));
+        let (out, diags) = run_at_depth(meta, Some(index)).await;
+        let html = out
+            .get_path(&["rendered", "navigation", "navbar"])
+            .unwrap()
+            .as_plain_text()
+            .unwrap();
+        assert!(
+            html.contains("src=\"../images/x.svg\""),
+            "item-text image must relativize from the depth-1 page; got: {}",
+            html
+        );
+        assert!(
+            html.contains("href=\"../docs.html\""),
+            "item-text .qmd link must resolve through the index; got: {}",
+            html
+        );
+        assert!(
+            html.contains("src=\"../images/y.svg\""),
+            "menu-child item-text image must resolve too; got: {}",
+            html
+        );
+        assert!(diags.is_empty(), "got diagnostics: {:?}", diags);
     }
 
     // --- Phase 3 href rewriting -----------------------------------

--- a/crates/quarto-core/src/transforms/navigation_href.rs
+++ b/crates/quarto-core/src/transforms/navigation_href.rs
@@ -485,6 +485,46 @@ pub fn resolve_root_relative_resource_href(
 /// makes plain markdown the natural form for config-declared imagery
 /// and links — the pure emitter in `quarto-navigation` receives
 /// fully-resolved targets and stays resolver-free.
+/// Rewrite Link/Image targets inside a text-bearing config value — a
+/// nav item's parsed-markdown `text:`, a sidebar section title, a
+/// sidebar heading (bd-page-footer-image-items-stmpikgo, defect 2).
+///
+/// Only `PandocInlines` values carry resolvable targets today;
+/// scalar values are literal text and pass through untouched.
+/// (`PandocBlocks` — multi-block `!md` text — is the Phase 3 blocks
+/// walker's territory.)
+pub fn rewrite_config_text(
+    cv: &mut quarto_pandoc_types::ConfigValue,
+    resolver: Option<&ResourceResolverContext>,
+    index: Option<&ProjectIndex>,
+    surface: &NavSurface<'_>,
+    diagnostics: &mut Vec<DiagnosticMessage>,
+) {
+    if let quarto_pandoc_types::config_value::ConfigValueKind::PandocInlines(inlines) =
+        &mut cv.value
+    {
+        rewrite_config_inlines(inlines, resolver, index, surface, diagnostics);
+    }
+}
+
+/// Rewrite the text-bearing field of one navigation item through
+/// [`rewrite_config_text`]. `menu` recursion stays with the callers'
+/// item walkers, which already descend. (`bare_text` needs no
+/// treatment here: the Generate transforms either demote it into
+/// `text` or drop it before Render runs, and the emitter never reads
+/// it.)
+pub fn rewrite_item_text(
+    item: &mut quarto_navigation::NavigationItem,
+    resolver: Option<&ResourceResolverContext>,
+    index: Option<&ProjectIndex>,
+    surface: &NavSurface<'_>,
+    diagnostics: &mut Vec<DiagnosticMessage>,
+) {
+    if let Some(cv) = item.text.as_mut() {
+        rewrite_config_text(cv, resolver, index, surface, diagnostics);
+    }
+}
+
 pub fn rewrite_config_inlines(
     inlines: &mut [quarto_pandoc_types::inline::Inline],
     resolver: Option<&ResourceResolverContext>,

--- a/crates/quarto-core/src/transforms/navigation_href.rs
+++ b/crates/quarto-core/src/transforms/navigation_href.rs
@@ -500,10 +500,158 @@ pub fn rewrite_config_text(
     surface: &NavSurface<'_>,
     diagnostics: &mut Vec<DiagnosticMessage>,
 ) {
-    if let quarto_pandoc_types::config_value::ConfigValueKind::PandocInlines(inlines) =
-        &mut cv.value
-    {
-        rewrite_config_inlines(inlines, resolver, index, surface, diagnostics);
+    match &mut cv.value {
+        quarto_pandoc_types::config_value::ConfigValueKind::PandocInlines(inlines) => {
+            rewrite_config_inlines(inlines, resolver, index, surface, diagnostics);
+        }
+        quarto_pandoc_types::config_value::ConfigValueKind::PandocBlocks(blocks) => {
+            rewrite_config_blocks(blocks, resolver, index, surface, diagnostics);
+        }
+        _ => {}
+    }
+}
+
+/// Block-level companion to [`rewrite_config_inlines`] for
+/// `PandocBlocks`-shaped config text (multi-block `!md` values).
+///
+/// Walks block containers and delegates every inline position to
+/// [`rewrite_config_inlines`]. `Figure` nodes **persist** — the walk
+/// descends into their content and caption and rewrites targets
+/// there, it never unwraps them (decision 3 of
+/// bd-page-footer-image-items-stmpikgo: figures keep their semantics
+/// in block settings; only the config-string *parse* unwraps a lone
+/// figure). Container coverage mirrors the body's
+/// `ResourceCollectorTransform` visitor; leaf blocks with no
+/// resolvable targets (code, raw, rules, note-definition scaffolding)
+/// pass through.
+pub fn rewrite_config_blocks(
+    blocks: &mut [quarto_pandoc_types::block::Block],
+    resolver: Option<&ResourceResolverContext>,
+    index: Option<&ProjectIndex>,
+    surface: &NavSurface<'_>,
+    diagnostics: &mut Vec<DiagnosticMessage>,
+) {
+    use quarto_pandoc_types::Slot;
+    use quarto_pandoc_types::block::Block;
+    for block in blocks.iter_mut() {
+        match block {
+            Block::Plain(p) => {
+                rewrite_config_inlines(&mut p.content, resolver, index, surface, diagnostics);
+            }
+            Block::Paragraph(p) => {
+                rewrite_config_inlines(&mut p.content, resolver, index, surface, diagnostics);
+            }
+            Block::Header(h) => {
+                rewrite_config_inlines(&mut h.content, resolver, index, surface, diagnostics);
+            }
+            Block::LineBlock(lb) => {
+                for line in &mut lb.content {
+                    rewrite_config_inlines(line, resolver, index, surface, diagnostics);
+                }
+            }
+            Block::BlockQuote(bq) => {
+                rewrite_config_blocks(&mut bq.content, resolver, index, surface, diagnostics);
+            }
+            Block::OrderedList(ol) => {
+                for item in &mut ol.content {
+                    rewrite_config_blocks(item, resolver, index, surface, diagnostics);
+                }
+            }
+            Block::BulletList(bl) => {
+                for item in &mut bl.content {
+                    rewrite_config_blocks(item, resolver, index, surface, diagnostics);
+                }
+            }
+            Block::DefinitionList(dl) => {
+                for (term, defs) in &mut dl.content {
+                    rewrite_config_inlines(term, resolver, index, surface, diagnostics);
+                    for def in defs {
+                        rewrite_config_blocks(def, resolver, index, surface, diagnostics);
+                    }
+                }
+            }
+            Block::Div(d) => {
+                rewrite_config_blocks(&mut d.content, resolver, index, surface, diagnostics);
+            }
+            Block::Figure(f) => {
+                // The figure persists; only the targets inside it
+                // (its image content and any caption links) rewrite.
+                if let Some(short) = &mut f.caption.short {
+                    rewrite_config_inlines(short, resolver, index, surface, diagnostics);
+                }
+                if let Some(long) = &mut f.caption.long {
+                    rewrite_config_blocks(long, resolver, index, surface, diagnostics);
+                }
+                rewrite_config_blocks(&mut f.content, resolver, index, surface, diagnostics);
+            }
+            Block::Table(t) => {
+                if let Some(short) = &mut t.caption.short {
+                    rewrite_config_inlines(short, resolver, index, surface, diagnostics);
+                }
+                if let Some(long) = &mut t.caption.long {
+                    rewrite_config_blocks(long, resolver, index, surface, diagnostics);
+                }
+                for row in t.head.rows.iter_mut().chain(t.foot.rows.iter_mut()) {
+                    for cell in &mut row.cells {
+                        rewrite_config_blocks(
+                            &mut cell.content,
+                            resolver,
+                            index,
+                            surface,
+                            diagnostics,
+                        );
+                    }
+                }
+                for body in &mut t.bodies {
+                    for row in &mut body.body {
+                        for cell in &mut row.cells {
+                            rewrite_config_blocks(
+                                &mut cell.content,
+                                resolver,
+                                index,
+                                surface,
+                                diagnostics,
+                            );
+                        }
+                    }
+                }
+            }
+            Block::Custom(c) => {
+                for (_name, slot) in &mut c.slots {
+                    match slot {
+                        Slot::Block(block) => rewrite_config_blocks(
+                            std::slice::from_mut(block),
+                            resolver,
+                            index,
+                            surface,
+                            diagnostics,
+                        ),
+                        Slot::Blocks(blocks) => {
+                            rewrite_config_blocks(blocks, resolver, index, surface, diagnostics)
+                        }
+                        Slot::Inline(inline) => rewrite_config_inlines(
+                            std::slice::from_mut(inline),
+                            resolver,
+                            index,
+                            surface,
+                            diagnostics,
+                        ),
+                        Slot::Inlines(inlines) => {
+                            rewrite_config_inlines(inlines, resolver, index, surface, diagnostics)
+                        }
+                    }
+                }
+            }
+            // Leaves with no resolvable targets — same set the body's
+            // `ResourceCollectorTransform` treats as terminal.
+            Block::CodeBlock(_)
+            | Block::RawBlock(_)
+            | Block::HorizontalRule(_)
+            | Block::BlockMetadata(_)
+            | Block::NoteDefinitionPara(_)
+            | Block::NoteDefinitionFencedBlock(_)
+            | Block::CaptionBlock(_) => {}
+        }
     }
 }
 
@@ -769,6 +917,129 @@ mod tests {
         ctx.add_file("<anonymous>".to_string(), None);
         let id = ctx.add_file(abs, None);
         (ctx, SourceInfo::original(id, 0, 0))
+    }
+
+    // ---- Phase 3 of bd-page-footer-image-items-stmpikgo:
+    // ---- rewrite_config_blocks ------------------------------------
+
+    fn test_image(url: &str) -> quarto_pandoc_types::inline::Inline {
+        use quarto_pandoc_types::attr::{AttrSourceInfo, TargetSourceInfo};
+        use quarto_pandoc_types::inline::{Image, Inline};
+        Inline::Image(Image {
+            attr: Default::default(),
+            content: vec![],
+            target: (url.to_string(), String::new()),
+            source_info: SourceInfo::for_test(),
+            attr_source: AttrSourceInfo::empty(),
+            target_source: TargetSourceInfo::empty(),
+        })
+    }
+
+    fn test_link(url: &str) -> quarto_pandoc_types::inline::Inline {
+        use quarto_pandoc_types::attr::{AttrSourceInfo, TargetSourceInfo};
+        use quarto_pandoc_types::inline::{Inline, Link};
+        Inline::Link(Link {
+            attr: Default::default(),
+            content: vec![],
+            target: (url.to_string(), String::new()),
+            source_info: SourceInfo::for_test(),
+            attr_source: AttrSourceInfo::empty(),
+            target_source: TargetSourceInfo::empty(),
+        })
+    }
+
+    fn plain(
+        inlines: Vec<quarto_pandoc_types::inline::Inline>,
+    ) -> quarto_pandoc_types::block::Block {
+        use quarto_pandoc_types::block::{Block, Plain};
+        Block::Plain(Plain {
+            content: inlines,
+            source_info: SourceInfo::for_test(),
+        })
+    }
+
+    /// The blocks walker rewrites Link/Image targets inside block
+    /// containers — and *persists* Figure nodes, rewriting the image
+    /// inside and the caption's links rather than unwrapping
+    /// (decision 3: figures keep their semantics in block settings;
+    /// only the config-string *parse* unwraps lone figures).
+    #[test]
+    fn config_blocks_walk_rewrites_targets_and_persists_figures() {
+        use quarto_pandoc_types::Caption;
+        use quarto_pandoc_types::block::{Block, Figure, Paragraph};
+
+        let mut blocks = vec![
+            Block::Figure(Figure {
+                attr: Default::default(),
+                caption: Caption {
+                    short: None,
+                    long: Some(vec![plain(vec![test_link("docs.qmd")])]),
+                    source_info: SourceInfo::for_test(),
+                },
+                content: vec![plain(vec![test_image("/images/x.svg")])],
+                source_info: SourceInfo::for_test(),
+                attr_source: quarto_pandoc_types::AttrSourceInfo::empty(),
+            }),
+            Block::Paragraph(Paragraph {
+                content: vec![test_image("images/y.svg")],
+                source_info: SourceInfo::for_test(),
+            }),
+        ];
+
+        let resolver = crate::resource_resolver::ResourceResolverContext::website(
+            "/project/_site",
+            "/project/_site/docs/api.html",
+            "site_libs",
+            "api",
+        );
+        let index =
+            crate::project::index::ProjectIndex::new(vec![profile("docs.qmd", "docs.html")]);
+        let mut diags = Vec::new();
+        rewrite_config_blocks(
+            &mut blocks,
+            Some(&resolver),
+            Some(&index),
+            &surf(),
+            &mut diags,
+        );
+
+        let Block::Figure(figure) = &blocks[0] else {
+            panic!("figure must persist, got {:?}", blocks[0]);
+        };
+        let Block::Plain(fig_plain) = &figure.content[0] else {
+            panic!("figure content shape changed");
+        };
+        let quarto_pandoc_types::inline::Inline::Image(img) = &fig_plain.content[0] else {
+            panic!("figure image shape changed");
+        };
+        assert_eq!(
+            img.target.0, "../images/x.svg",
+            "image inside a figure must relativize"
+        );
+        let Some(long) = &figure.caption.long else {
+            panic!("caption dropped");
+        };
+        let Block::Plain(cap_plain) = &long[0] else {
+            panic!("caption shape changed");
+        };
+        let quarto_pandoc_types::inline::Inline::Link(link) = &cap_plain.content[0] else {
+            panic!("caption link shape changed");
+        };
+        assert_eq!(
+            link.target.0, "../docs.html",
+            "caption link must resolve through the index"
+        );
+        let Block::Paragraph(para) = &blocks[1] else {
+            panic!("paragraph shape changed");
+        };
+        let quarto_pandoc_types::inline::Inline::Image(img2) = &para.content[0] else {
+            panic!("paragraph image shape changed");
+        };
+        assert_eq!(
+            img2.target.0, "../images/y.svg",
+            "sibling paragraph image must relativize"
+        );
+        assert!(diags.is_empty(), "got: {:?}", diags);
     }
 
     /// Frontmatter sibling-relative case. The reproducer from

--- a/crates/quarto-core/src/transforms/sidebar_render.rs
+++ b/crates/quarto-core/src/transforms/sidebar_render.rs
@@ -261,6 +261,7 @@ fn rewrite_hrefs(
     surface: NavSurface<'_>,
     diagnostics: &mut Vec<DiagnosticMessage>,
 ) {
+    use crate::transforms::navigation_href::{rewrite_config_text, rewrite_item_text};
     for entry in entries.iter_mut() {
         match entry {
             SidebarEntry::Link { item } => {
@@ -279,8 +280,12 @@ fn rewrite_hrefs(
                         diagnostics,
                     );
                 }
+                // Parsed-markdown `text:` carries Link/Image targets
+                // (bd-page-footer-image-items-stmpikgo, defect 2).
+                rewrite_item_text(item, resolver, index, &surface, diagnostics);
             }
             SidebarEntry::Section {
+                text,
                 href,
                 href_source,
                 contents,
@@ -297,9 +302,15 @@ fn rewrite_hrefs(
                         diagnostics,
                     );
                 }
+                if let Some(text) = text.as_mut() {
+                    rewrite_config_text(text, resolver, index, &surface, diagnostics);
+                }
                 rewrite_hrefs(contents, resolver, index, surface.clone(), diagnostics);
             }
-            SidebarEntry::Separator | SidebarEntry::Heading(_) | SidebarEntry::Auto(_) => {}
+            SidebarEntry::Heading(text) => {
+                rewrite_config_text(text, resolver, index, &surface, diagnostics);
+            }
+            SidebarEntry::Separator | SidebarEntry::Auto(_) => {}
         }
     }
 }
@@ -389,6 +400,144 @@ mod tests {
             .await
             .unwrap();
         (ast.meta, ctx.diagnostics)
+    }
+
+    /// A `ConfigValue` holding parsed markdown inlines — the shape
+    /// entry `text:` takes after `ConfigMarkdownTransform`.
+    fn inlines_cv(inlines: Vec<quarto_pandoc_types::inline::Inline>) -> ConfigValue {
+        ConfigValue {
+            value: quarto_pandoc_types::config_value::ConfigValueKind::PandocInlines(inlines),
+            source_info: SourceInfo::for_test(),
+            merge_op: Default::default(),
+        }
+    }
+
+    fn nav_image(url: &str, alt: &str) -> quarto_pandoc_types::inline::Inline {
+        use quarto_pandoc_types::attr::{AttrSourceInfo, TargetSourceInfo};
+        use quarto_pandoc_types::inline::{Image, Inline, Str};
+        Inline::Image(Image {
+            attr: Default::default(),
+            content: vec![Inline::Str(Str {
+                text: alt.to_string(),
+                source_info: SourceInfo::for_test(),
+            })],
+            target: (url.to_string(), String::new()),
+            source_info: SourceInfo::for_test(),
+            attr_source: AttrSourceInfo::empty(),
+            target_source: TargetSourceInfo::empty(),
+        })
+    }
+
+    fn nav_link(url: &str, text: &str) -> quarto_pandoc_types::inline::Inline {
+        use quarto_pandoc_types::attr::{AttrSourceInfo, TargetSourceInfo};
+        use quarto_pandoc_types::inline::{Inline, Link, Str};
+        Inline::Link(Link {
+            attr: Default::default(),
+            content: vec![Inline::Str(Str {
+                text: text.to_string(),
+                source_info: SourceInfo::for_test(),
+            })],
+            target: (url.to_string(), String::new()),
+            source_info: SourceInfo::for_test(),
+            attr_source: AttrSourceInfo::empty(),
+            target_source: TargetSourceInfo::empty(),
+        })
+    }
+
+    /// Defect 2 of bd-page-footer-image-items-stmpikgo, sidebar
+    /// edition: parsed-markdown `text:` resolves across every
+    /// text-bearing entry shape — a Link item's label, a Section
+    /// title, a Heading — Image targets relativize per page and
+    /// `.qmd` links resolve through the index.
+    #[tokio::test]
+    async fn render_entry_text_inlines_resolve_at_depth() {
+        use crate::resource_resolver::ResourceResolverContext;
+
+        let sb = Sidebar {
+            contents: vec![
+                SidebarEntry::Link {
+                    item: NavigationItem {
+                        text: Some(inlines_cv(vec![nav_image("/images/x.svg", "logo")])),
+                        ..NavigationItem::default()
+                    },
+                },
+                SidebarEntry::Section {
+                    text: Some(inlines_cv(vec![nav_image("images/y.svg", "sect")])),
+                    href: None,
+                    href_source: SourceInfo::for_test(),
+                    id: Some("sec".to_string()),
+                    contents: vec![SidebarEntry::Link {
+                        item: NavigationItem {
+                            text: Some(inlines_cv(vec![nav_link("docs.qmd", "docs")])),
+                            ..NavigationItem::default()
+                        },
+                    }],
+                    expanded: true,
+                },
+                SidebarEntry::Heading(inlines_cv(vec![nav_image("images/z.svg", "head")])),
+            ],
+            ..Sidebar::with_defaults()
+        };
+        let mut meta = ConfigValue::default();
+        meta.insert_path(&["navigation", "sidebar"], sb.to_config_value());
+        let index = Arc::new(ProjectIndex::new(vec![make_profile(
+            "docs.qmd",
+            "docs.html",
+            "Docs",
+        )]));
+
+        let mut ast = Pandoc {
+            meta,
+            blocks: vec![],
+        };
+        let project = make_project();
+        let doc = DocumentInfo::from_path("/project/guide/installation.qmd");
+        let format = Format::html();
+        let binaries = BinaryDependencies::new();
+        let resolver = ResourceResolverContext::website(
+            "/project/_site",
+            "/project/_site/guide/installation.html",
+            "site_libs",
+            "installation",
+        );
+        let mut ctx = RenderContext::new(&project, &doc, &format, &binaries)
+            .with_project_index(index)
+            .with_resource_resolver(resolver);
+        SidebarRenderTransform::new()
+            .transform(&mut ast, &mut ctx)
+            .await
+            .unwrap();
+        let html = ast
+            .meta
+            .get_path(&["rendered", "navigation", "sidebar"])
+            .unwrap()
+            .as_plain_text()
+            .unwrap();
+        assert!(
+            html.contains("src=\"../images/x.svg\""),
+            "link-item text image must relativize; got: {}",
+            html
+        );
+        assert!(
+            html.contains("src=\"../images/y.svg\""),
+            "section-title image must relativize; got: {}",
+            html
+        );
+        assert!(
+            html.contains("href=\"../docs.html\""),
+            "nested link-item text .qmd link must resolve; got: {}",
+            html
+        );
+        assert!(
+            html.contains("src=\"../images/z.svg\""),
+            "heading image must relativize; got: {}",
+            html
+        );
+        assert!(
+            ctx.diagnostics.is_empty(),
+            "got diagnostics: {:?}",
+            ctx.diagnostics
+        );
     }
 
     /// Test 28 — .qmd leaf href gets rewritten to the profile's

--- a/crates/quarto-core/tests/integration/website_post_render.rs
+++ b/crates/quarto-core/tests/integration/website_post_render.rs
@@ -457,8 +457,11 @@ fn pipeline_navbar_logo_missing_diagnoses_continues() {
     );
 }
 
-/// Decision 5, footer edition: a footer text-region image whose file
-/// is missing warns (naming the file) and the render continues.
+/// Decision 5, footer edition — upgraded by
+/// bd-page-footer-image-items-stmpikgo Phase 4: a footer text-region
+/// image whose file is missing raises the same **Q-5-6** the identical
+/// reference would raise in a document body, located at the reference
+/// in `_quarto.yml`, and the render continues.
 #[test]
 fn pipeline_footer_image_missing_diagnoses_continues() {
     let (project_dir, summary) = render_project(|project_dir| {
@@ -477,18 +480,120 @@ fn pipeline_footer_image_missing_diagnoses_continues() {
         !project_dir.join("_site/images/gone.svg").exists(),
         "missing footer image must not be written"
     );
+    assert_footer_q_5_6(&summary, "gone.svg");
+}
+
+/// Assert exactly the uniform-diagnostic contract of Phase 4
+/// (bd-page-footer-image-items-stmpikgo): a Q-5-6 warning whose
+/// rendered text names the missing file and which carries a source
+/// location (the reference inside `_quarto.yml`).
+fn assert_footer_q_5_6(summary: &ProjectRenderSummary, missing: &str) {
+    let diag = summary
+        .project_diagnostics
+        .iter()
+        .find(|d| d.code.as_deref() == Some("Q-5-6"))
+        .unwrap_or_else(|| {
+            panic!(
+                "expected a Q-5-6 diagnostic; got: {:?}",
+                summary
+                    .project_diagnostics
+                    .iter()
+                    .map(|d| (d.code.clone(), d.title.clone()))
+                    .collect::<Vec<_>>()
+            )
+        });
+    let text = diag.to_text(None);
     assert!(
-        summary
+        text.contains(missing),
+        "Q-5-6 must name the missing file `{missing}`; got: {text}"
+    );
+    assert!(
+        diag.location.is_some(),
+        "Q-5-6 must carry the reference's source location"
+    );
+}
+
+/// Phase 4, items edition: an *item's* `text:` image gets the same
+/// treatment — missing file raises Q-5-6, present file is copied into
+/// the output tree (previously Items regions were skipped entirely).
+#[test]
+fn pipeline_footer_item_image_missing_raises_q_5_6() {
+    let (project_dir, summary) = render_project(|project_dir| {
+        write(
+            &project_dir.join("_quarto.yml"),
+            "project:\n  type: website\n  output-dir: _site\n\
+             website:\n  page-footer:\n    right:\n      - text: \"![](/images/gone.svg)\"\n",
+        );
+        write(
+            &project_dir.join("index.qmd"),
+            "---\ntitle: Home\n---\n\nH.\n",
+        );
+    });
+
+    assert!(
+        !project_dir.join("_site/images/gone.svg").exists(),
+        "missing footer item image must not be written"
+    );
+    assert_footer_q_5_6(&summary, "gone.svg");
+}
+
+/// Phase 4, items edition, present-file half: the item image is
+/// copied to the output tree like a Text region's.
+#[test]
+fn pipeline_footer_item_image_present_is_copied() {
+    let (project_dir, summary) = render_project(|project_dir| {
+        write(
+            &project_dir.join("_quarto.yml"),
+            "project:\n  type: website\n  output-dir: _site\n\
+             website:\n  page-footer:\n    right:\n      - text: \"![](/images/logo.svg)\"\n",
+        );
+        std::fs::create_dir_all(project_dir.join("images")).unwrap();
+        write(&project_dir.join("images/logo.svg"), "<svg></svg>");
+        write(
+            &project_dir.join("index.qmd"),
+            "---\ntitle: Home\n---\n\nH.\n",
+        );
+    });
+
+    assert!(
+        project_dir.join("_site/images/logo.svg").exists(),
+        "footer item image must be copied into the output tree"
+    );
+    assert!(
+        !summary
             .project_diagnostics
             .iter()
-            .any(|d| d.title.contains("gone.svg")),
-        "expected a diagnostic mentioning 'gone.svg'; got: {:?}",
+            .any(|d| d.code.as_deref() == Some("Q-5-6")),
+        "no Q-5-6 for a present file; got: {:?}",
         summary
             .project_diagnostics
             .iter()
             .map(|d| d.title.clone())
             .collect::<Vec<_>>()
     );
+}
+
+/// Phase 4, blocks edition: an `!md` multi-block region's missing
+/// image raises Q-5-6 too (the collector walks `PandocBlocks`).
+#[test]
+fn pipeline_footer_md_blocks_image_missing_raises_q_5_6() {
+    let (project_dir, summary) = render_project(|project_dir| {
+        write(
+            &project_dir.join("_quarto.yml"),
+            "project:\n  type: website\n  output-dir: _site\n\
+             website:\n  page-footer:\n    center: !md |\n      ![](/images/gone.svg)\n\n      second paragraph\n",
+        );
+        write(
+            &project_dir.join("index.qmd"),
+            "---\ntitle: Home\n---\n\nH.\n",
+        );
+    });
+
+    assert!(
+        !project_dir.join("_site/images/gone.svg").exists(),
+        "missing footer image must not be written"
+    );
+    assert_footer_q_5_6(&summary, "gone.svg");
 }
 
 // ═══════════════════════════════════════════════════════════════════

--- a/crates/quarto-navigation/src/footer.rs
+++ b/crates/quarto-navigation/src/footer.rs
@@ -63,7 +63,17 @@ impl FooterRegion {
         }
 
         // A plain-textable scalar (including PandocInlines) is text.
-        if cv.as_plain_text().is_some() {
+        // So is a `PandocBlocks` value — multi-block `!md` text —
+        // which `as_plain_text` can't flatten
+        // (bd-page-footer-image-items-stmpikgo, Phase 3); `render_text`
+        // renders its blocks and the render transform rewrites their
+        // Link/Image targets.
+        if cv.as_plain_text().is_some()
+            || matches!(
+                cv.value,
+                quarto_pandoc_types::config_value::ConfigValueKind::PandocBlocks(_)
+            )
+        {
             return FooterRegion::Text(cv.clone());
         }
 
@@ -273,6 +283,27 @@ mod tests {
 
     fn arr(items: Vec<ConfigValue>) -> ConfigValue {
         ConfigValue::new_array(items, SourceInfo::for_test())
+    }
+
+    /// A `PandocBlocks`-shaped region value (multi-block `!md` text)
+    /// classifies as `Text`, not `Empty`
+    /// (bd-page-footer-image-items-stmpikgo, Phase 3):
+    /// `as_plain_text` is `None` for blocks, so the plain-textable
+    /// check alone silently dropped the whole region.
+    #[test]
+    fn blocks_shaped_region_is_text() {
+        use quarto_pandoc_types::block::{Block, Paragraph};
+        use quarto_pandoc_types::config_value::ConfigValueKind;
+        let blocks_cv = ConfigValue {
+            value: ConfigValueKind::PandocBlocks(vec![Block::Paragraph(Paragraph {
+                content: vec![],
+                source_info: SourceInfo::for_test(),
+            })]),
+            source_info: SourceInfo::for_test(),
+            merge_op: Default::default(),
+        };
+        let region = FooterRegion::from_config_value(Some(&blocks_cv));
+        assert!(matches!(region, FooterRegion::Text(_)), "got {:?}", region);
     }
 
     /// Defect 2 (bd-page-footer-items-f4th80mj) — a bare string in a

--- a/crates/quarto-navigation/src/render_html.rs
+++ b/crates/quarto-navigation/src/render_html.rs
@@ -896,17 +896,30 @@ fn render_text(cv: &ConfigValue) -> String {
             // Footers written as `!md "multi-paragraph"` arrive as blocks.
             // For our single-line regions, concatenate block text as HTML.
             let mut out = String::new();
-            for block in blocks {
-                if let Some(inlines) = block_inlines(block) {
-                    out.push_str(&inlines_to_html(inlines));
-                }
-            }
+            push_blocks_text(&mut out, blocks);
             out
         }
         _ => cv
             .as_plain_text()
             .map(|s| escape_html(&s))
             .unwrap_or_default(),
+    }
+}
+
+/// Concatenate the inline HTML of a block sequence for single-line
+/// nav regions. Inline-bearing blocks contribute their inlines; a
+/// `Figure` contributes its *content* — the image — and drops the
+/// caption, because a figcaption has no place in a one-line footer
+/// (bd-page-footer-image-items-stmpikgo, Phase 3; an `!md` lone image
+/// parses to a persisted Figure). Other block shapes are skipped.
+fn push_blocks_text(out: &mut String, blocks: &[quarto_pandoc_types::block::Block]) {
+    use quarto_pandoc_types::block::Block;
+    for block in blocks {
+        if let Block::Figure(figure) = block {
+            push_blocks_text(out, &figure.content);
+        } else if let Some(inlines) = block_inlines(block) {
+            out.push_str(&inlines_to_html(inlines));
+        }
     }
 }
 
@@ -1153,6 +1166,55 @@ mod tests {
             text: text.to_string(),
             source_info: SourceInfo::for_test(),
         })
+    }
+
+    /// `render_text` on `PandocBlocks` renders a `Figure`'s image
+    /// (bd-page-footer-image-items-stmpikgo, Phase 3): an `!md` lone
+    /// image parses to a persisted Figure, and nav regions are
+    /// single-line inline contexts, so the figure contributes its
+    /// image — the caption stays out of the footer.
+    #[test]
+    fn render_text_blocks_renders_figure_image() {
+        use quarto_pandoc_types::Caption;
+        use quarto_pandoc_types::attr::{AttrSourceInfo, TargetSourceInfo};
+        use quarto_pandoc_types::block::{Block, Figure, Plain};
+        use quarto_pandoc_types::config_value::ConfigValueKind;
+        use quarto_pandoc_types::inline::Image;
+
+        let image = Inline::Image(Image {
+            attr: Default::default(),
+            content: vec![str_inline("cap")],
+            target: ("images/logo.svg".to_string(), String::new()),
+            source_info: SourceInfo::for_test(),
+            attr_source: AttrSourceInfo::empty(),
+            target_source: TargetSourceInfo::empty(),
+        });
+        let cv = ConfigValue {
+            value: ConfigValueKind::PandocBlocks(vec![Block::Figure(Figure {
+                attr: Default::default(),
+                caption: Caption {
+                    short: None,
+                    long: Some(vec![Block::Plain(Plain {
+                        content: vec![str_inline("cap")],
+                        source_info: SourceInfo::for_test(),
+                    })]),
+                    source_info: SourceInfo::for_test(),
+                },
+                content: vec![Block::Plain(Plain {
+                    content: vec![image],
+                    source_info: SourceInfo::for_test(),
+                })],
+                source_info: SourceInfo::for_test(),
+                attr_source: AttrSourceInfo::empty(),
+            })]),
+            source_info: SourceInfo::for_test(),
+            merge_op: Default::default(),
+        };
+        let html = render_text(&cv);
+        assert_eq!(
+            html, "<img src=\"images/logo.svg\" alt=\"cap\">",
+            "exactly the figure's image — no figcaption text, no wrapper"
+        );
     }
 
     #[test]

--- a/docs/errors/project/Q-5-6.qmd
+++ b/docs/errors/project/Q-5-6.qmd
@@ -23,10 +23,18 @@ file into the rendered output so the link resolves in the
 published site. This warning fires when the referenced source
 file does not exist on disk: there is nothing to copy.
 
+The same check applies to markdown images in website
+configuration — a `page-footer` region or item `text:` in
+`_quarto.yml`. Those references are project-wide, so a missing
+file there warns once per render (not once per page), with the
+diagnostic pointing at the reference inside the configuration
+file.
+
 This is a **warning**, not an error. The render continues and
 produces output; the missing file is simply left out. The
-diagnostic points at the reference in your source document so
-you can see exactly which link is affected.
+diagnostic points at the reference in your source document (or
+configuration file) so you can see exactly which link is
+affected.
 
 ## Why this happens
 


### PR DESCRIPTION
Fixes both defects of `bd-page-footer-image-items-stmpikgo` (page-footer item `text:`: a lone image is dropped, and no Link/Image target inside item text is resolved), plus the diagnostic gap and several adjacent holes the fix surfaced. Plan: `claude-notes/plans/2026-08-18-page-footer-image-items.md`; investigation fixtures under `claude-notes/plans/page-footer-image-items-investigation/`.

## What changed, by phase

1. **Lone-Figure unwrap at the config parse** (`pampa::pandoc::meta`). A config string like `text: '![logo](/images/logo.svg)'` parses as a single-image paragraph, which the qmd reader desugars into a `Figure`; inline consumers then dropped the block, rendering an empty `<li>`. `parse_config_string_as_markdown` now unwraps the lone Figure back to the Image (reassembling the id the desugar moved to the figure attr). `!md`-tagged values keep figure semantics.
2. **Item `text:` routed through the Link/Image rewriter** on all three nav surfaces via new shared helpers `rewrite_config_text` / `rewrite_item_text` (`navigation_href.rs`): footer items, navbar items + dropdown menus, sidebar link items, section titles, and headings. Item-level images/links now rebase per page and resolve `.qmd` → output href exactly like region-level text.
3. **Blocks walker** `rewrite_config_blocks` for `PandocBlocks`-shaped config text (multi-block `!md`), with Figures persisting (targets inside content and caption rewrite; no unwrap). Two adjacent gaps fixed: `FooterRegion::from_config_value` silently classified blocks-shaped regions as `Empty`, and `render_text` dropped Figures (now renders the figure's image; captions stay out of one-line regions).
4. **Uniform Q-5-6 for missing footer images.** `copy_footer_images` now collects `(url, span)` from every region shape — Text inlines/blocks/raw scalars, item `text:`, `bare_text`, nested menus — and reports misses via `ResourceCopyIntent` + `missing_resource_diagnostic`: the same spanned Q-5-6 a body reference raises, once per project, with an Ariadne snippet into `_quarto.yml`. Root-caused a pampa span bug this surfaced: `range_to_source_info_with_context` ignored `parent_source_info`, so attr/target sub-spans in any re-parsed embedded string were mis-anchored to `Original(FileId(0), …)`; they now reroot as `Substring` of the parent like node spans.
5. **Docs**: `docs/errors/project/Q-5-6.qmd` covers the config-reference case.

## Verification

- TDD throughout: every fix landed with failing-first tests (pampa parse unit tests; per-surface transform tests at a depth-1 resolver; walker/classifier/renderer unit tests; four `website_post_render` integration tests).
- `cargo nextest run --workspace` green (12,328 tests), zero snapshot changes; full `cargo xtask verify` (incl. hub-client/WASM legs) and `cargo xtask lint` pass.
- End-to-end on the committed fixtures: item-level footer targets now match the region-level control on a page two directories deep; `!md` block regions render image + link resolved; a missing footer image renders one spanned Q-5-6 (plus the body control), exit still 0.

## Follow-ups filed

- `bd-70krno7a` — quarto-yaml content spans: quoted scalars underline one column early because scalar spans include the quotes.
- `bd-0jo6fnb7` — upgrade `copy_navbar_logo` / `copy_favicon` warnings to the same spanned Q-5-6 shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
