### PR TITLE
hub-client: WCAG 2.2 A/AA compliance fixes

### DIFF
--- a/claude-notes/plans/2026-08-19-hub-client-wcag-22.md
+++ b/claude-notes/plans/2026-08-19-hub-client-wcag-22.md
@@ -92,8 +92,12 @@ indicator.
   semantics. 3 passed. Updated stale `getByRole('menu')` in
   projects-home.spec.ts (2 passed).
 - [x] Pre-commit checklist (claude-notes/instructions/review.md)
-- [ ] Commit 1: code; Commit 2: `hub-client/changelog.md` entry with
-  hash (two-commit workflow)
+- [x] Commit 1: code (`e71b1ac5`); Commit 2: `hub-client/changelog.md`
+  entry with hash (`0a100657`) — two-commit workflow
+- [x] `cargo xtask verify --skip-hub-build` green (needed a local
+  `npm install @esbuild/darwin-arm64@0.28.0 --no-save` — the optional
+  platform binary was missing from node_modules, breaking the
+  quarto-hub-mcp bundle test; environmental, unrelated to this diff)
 - [ ] Report; do NOT push without explicit approval
 
 ## Details

--- a/claude-notes/plans/2026-08-19-hub-client-wcag-22.md
+++ b/claude-notes/plans/2026-08-19-hub-client-wcag-22.md
@@ -1,0 +1,127 @@
+# hub-client WCAG 2.2 A/AA compliance
+
+Strand: bd-trkzm9rq
+Branch: `feature/bd-trkzm9rq-hub-client-wcag-22` (stacked on `feature/editor-projects-home-visual-alignment`)
+
+## Overview
+
+Audit of hub-client against WCAG 2.2 A/AA found a set of concrete
+violations. This plan fixes them in a stacked PR. No architectural
+changes; one small shared component (`ModalDialog`) is introduced so
+the three modal dialogs cannot drift apart on dialog semantics again.
+
+Audit notes (verified against source 2026-08-19):
+
+- **4.1.2 Name Role Value**: `NewFileDialog`, `NewAssetDialog`,
+  `ShareDialog` render `.ph-dialog` divs with no `role="dialog"`,
+  `aria-modal`, or `aria-labelledby`. `ShareDialog`'s close button has
+  no accessible name (only `&times;` text). The 8 inline dialogs in
+  `ProjectsHome` have the same gap, and its action menus use
+  `role="menu"` with plain `<button>` children (required-owned-elements
+  violation).
+- **2.4.3 Focus Order**: dialogs move focus in on open but never
+  return it on close; no Tab containment, so focus can fall behind the
+  modal backdrop.
+- **2.4.1 Bypass Blocks**: no skip-to-main link; `<main>` landmarks
+  exist (Editor `.editor-main`, ProjectsHome `.ph-main`) but have no
+  anchor target.
+- **2.5.8 Target Size Minimum (new in 2.2)**: `ViewToggleControl`
+  buttons are fixed 20x20px; `.close-btn` is a bare 24px glyph with
+  `padding: 0` (clickable width ~13px).
+- **2.4.7 Focus Visible**: `.close-btn` and `.rename-input`
+  (`outline: none`, no replacement) have no visible focus indicator.
+- **1.1.1 Non-text Content**: decorative SVGs in `ViewToggleControl`
+  lack `aria-hidden`.
+- **1.3.1 Info and Relationships**: `ProjectSelector` (classic home)
+  has no `<main>` landmark.
+
+Already compliant (checked, no action): Toast `role="status"`,
+EphemeralSessionBanner `role="status"`, connection/status indicators
+have text alongside color, form labels associated in all dialogs,
+`html lang="en"`, icon buttons in MinimalHeader have aria-labels,
+Escape/Enter handled in dialogs, `.ph-input:focus` border-color
+indicator.
+
+## Work Items
+
+### Phase 1 — tests first
+
+- [x] `ModalDialog.test.tsx`: role/aria-modal/aria-labelledby, Escape
+  closes, Tab stays trapped, focus returns to trigger on close
+- [x] Extend `NewFileDialog.integration.test.tsx`: dialog role +
+  labelledby assertions
+- [x] New `ShareDialog.test.tsx`: close button has accessible name,
+  dialog role
+- [x] `SkipLink.test.tsx`: renders first-focusable link targeting
+  `#main-content`
+- [x] `ViewToggleControl.test.tsx`: SVGs aria-hidden, aria-pressed
+- [x] Verify all new tests FAIL before implementing (verified:
+  module-not-found for new components; missing role/attributes for
+  existing ones)
+
+### Phase 2 — implementation
+
+- [x] `ModalDialog.tsx`: shared backdrop + `role="dialog"` +
+  `aria-modal="true"` + `aria-labelledby`, Escape handling, Tab trap,
+  focus restore; refactor NewFileDialog/NewAssetDialog/ShareDialog
+- [x] `ShareDialog` close button accessible name (via ModalDialog
+  header)
+- [x] `SkipLink.tsx` + render first in `App.tsx` main return;
+  `id="main-content"` + `tabIndex={-1}` on Editor `.editor-main` and
+  ProjectsHome `.ph-main`; visually-hidden-until-focus CSS
+- [x] `ProjectSelector`: `<main>` landmark
+- [x] `ViewToggleControl.css`: 20px -> 24px targets; SVGs aria-hidden;
+  aria-pressed on toggles
+- [x] `ui.css` `.close-btn`: 24x24 minimum box + `:focus-visible`
+  outline
+- [x] `FileSidebar.css` `.rename-input:focus`: visible indicator
+- [x] ProjectsHome: role/aria-modal/aria-labelledby on all 8 inline
+  dialogs; drop invalid `role="menu"` from action menus (plain button
+  groups; full ARIA menu keyboard pattern not implemented)
+
+### Phase 3 — verification
+
+- [x] `npm run test` (unit) green — 923 passed (83 files)
+- [x] `npm run test:integration` green — 111 passed (15 files)
+- [x] `npm run lint` — no new problems on changed files (28
+  pre-existing on both sides of the diff; new files clean)
+- [x] `npm run build:all` succeeds (required for hub-client)
+- [x] Playwright e2e spec (`e2e/accessibility.spec.ts`): skip link
+  focuses main; New File dialog exposes dialog role, contains Tab,
+  Escape closes, focus returns to trigger; ProjectsHome dialog
+  semantics. 3 passed. Updated stale `getByRole('menu')` in
+  projects-home.spec.ts (2 passed).
+- [x] Pre-commit checklist (claude-notes/instructions/review.md)
+- [ ] Commit 1: code; Commit 2: `hub-client/changelog.md` entry with
+  hash (two-commit workflow)
+- [ ] Report; do NOT push without explicit approval
+
+## Details
+
+- ModalDialog keeps each dialog's existing Enter-key behavior via an
+  `onKeyDown` passthrough; it owns Escape, trap, and restore only.
+- Skip link lives in `App.tsx`'s main return so it serves both the
+  projects-home and editor views; early-return screens (loading,
+  login, setup) are single-purpose and don't need it.
+- Font-size findings from the audit (11.5px/10.5px in ui.css) are NOT
+  WCAG violations (no minimum size in 2.2; 1.4.4 is about resize
+  capability) — deliberately out of scope.
+- Contrast findings were all >= 4.5:1 or marginal-but-passing — out of
+  scope.
+- Adding eslint-plugin-jsx-a11y / axe-core is a follow-up, not this
+  PR (new dependency, needs discussion).
+- ProjectsHome dialogs got ARIA semantics only; Tab containment there
+  would require extracting each inline dialog into a component (they
+  are conditionally rendered blocks, so no shared hook). Follow-up
+  candidate.
+
+## E2E verification record
+
+- `npx playwright test e2e/accessibility.spec.ts` — 3 passed:
+  skip link Tab -> focus -> Enter -> `main#main-content` focused;
+  New File dialog `role="dialog"`/`aria-modal`/accessible name,
+  autofocus into filename, Tab stays inside, Escape closes, focus
+  returns to the "+ New" trigger; ProjectsHome "New collection"
+  dialog semantics.
+- Output inspected via Playwright assertions (focused element,
+  attributes, visibility) — not just absence of errors.

--- a/hub-client/changelog.md
+++ b/hub-client/changelog.md
@@ -25,6 +25,7 @@ WASM rebuild is needed for a changelog-only edit.
 
 ### 2026-08-19
 
+- [`e71b1ac5`](https://github.com/quarto-dev/q2/commits/e71b1ac5): WCAG 2.2 accessibility pass — dialogs are announced as dialogs with titles, Tab stays inside an open dialog and focus returns to the button that opened it, a "Skip to main content" link leads the tab order, view-toggle and dialog close buttons meet the 24px minimum target size, and keyboard focus is always visible.
 - [`63f2a178`](https://github.com/quarto-dev/q2/commits/63f2a178): Tint the editor file sidebar with the same posit-blue alpha family as the other editor bars, so it no longer reads neutral gray next to them.
 
 ### 2026-08-18

--- a/hub-client/e2e/accessibility.spec.ts
+++ b/hub-client/e2e/accessibility.spec.ts
@@ -1,0 +1,125 @@
+/**
+ * E2E: WCAG 2.2 accessibility behaviors.
+ *
+ *   - Skip link is the first focusable element and moves focus to
+ *     #main-content (2.4.1 Bypass Blocks)
+ *   - The New File dialog exposes dialog semantics (4.1.2), contains
+ *     Tab within itself and returns focus to its trigger (2.4.3), and
+ *     closes on Escape (2.1.1)
+ *   - ProjectsHome dialogs expose dialog semantics (4.1.2)
+ *
+ * Strand: bd-trkzm9rq. Plan:
+ * claude-notes/plans/2026-08-19-hub-client-wcag-22.md
+ */
+
+import { test, expect } from '@playwright/test';
+import {
+  bootstrapProjectsHome,
+  createProjectOnServer,
+  getServerUrl,
+  seedProjectInBrowser,
+} from './helpers/projectFactory';
+
+test.describe('accessibility (WCAG 2.2)', () => {
+  // Each test bootstraps a project set and (for the dialog test) syncs a
+  // project and opens the editor — more than the default 30s budget.
+  test.setTimeout(90_000);
+
+  test('skip link is first in tab order and focuses the main landmark', async ({
+    page,
+  }) => {
+    const syncServer = getServerUrl();
+    await bootstrapProjectsHome(page, syncServer);
+
+    // Wait for the home to finish rendering so no loading screen consumes
+    // the first Tab press.
+    await expect(page.locator('main#main-content')).toBeVisible({ timeout: 15000 });
+
+    await page.keyboard.press('Tab');
+    const skipLink = page.locator('.skip-link');
+    await expect(skipLink).toBeFocused();
+    // The link becomes visible once focused (visually hidden otherwise).
+    await expect(skipLink).toBeVisible();
+
+    await page.keyboard.press('Enter');
+    await expect(page.locator('main#main-content')).toBeFocused();
+  });
+
+  test('New File dialog: semantics, Tab containment, Escape, focus restore', async ({
+    page,
+  }) => {
+    const syncServer = getServerUrl();
+    await bootstrapProjectsHome(page, syncServer);
+
+    // Seed a project and open it in the editor.
+    const indexDocId = await createProjectOnServer(syncServer, [
+      {
+        path: 'index.qmd',
+        content: '---\ntitle: A11y Project\n---\n\nHello.\n',
+        contentType: 'text',
+      },
+    ]);
+    await seedProjectInBrowser(page, indexDocId, syncServer, 'A11y Project');
+    const row = page.locator('.ph-row', { hasText: 'A11y Project' });
+    await expect(row).toBeVisible({ timeout: 15000 });
+    await row.locator('.ph-row-name').click();
+
+    // The editor's sidebar New-file button is the dialog trigger.
+    const newFileBtn = page.locator('.new-file-btn');
+    await expect(newFileBtn).toBeVisible({ timeout: 30000 });
+    await newFileBtn.click();
+
+    // 4.1.2: role="dialog", aria-modal, accessible name from the title.
+    const dialog = page.getByRole('dialog', { name: 'New file' });
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toHaveAttribute('aria-modal', 'true');
+    await expect(dialog.getByRole('button', { name: 'Close' })).toBeVisible();
+
+    // Initial focus lands in the filename input (existing behavior)...
+    await expect(dialog.getByLabel('Filename:')).toBeFocused({ timeout: 5000 });
+
+    // ...and 2.4.3: Tab never leaves the dialog — after cycling past the
+    // last action it wraps back to the close button.
+    for (let i = 0; i < 3; i++) {
+      await page.keyboard.press('Tab');
+    }
+    const focusInside = await page.evaluate(
+      () => document.activeElement?.closest('[role="dialog"]') !== null,
+    );
+    expect(focusInside).toBe(true);
+
+    // 2.1.1: Escape closes; 2.4.3: focus returns to the trigger button.
+    await page.keyboard.press('Escape');
+    await expect(dialog).not.toBeVisible();
+    await expect(newFileBtn).toBeFocused();
+  });
+
+  test('ProjectsHome dialogs expose dialog semantics', async ({ page }) => {
+    const syncServer = getServerUrl();
+    await bootstrapProjectsHome(page, syncServer);
+
+    // The "＋ New collection" button renders in the populated home layout,
+    // so seed a project to leave the empty state.
+    const indexDocId = await createProjectOnServer(syncServer, [
+      {
+        path: 'index.qmd',
+        content: '---\ntitle: Dialog Project\n---\n\nHello.\n',
+        contentType: 'text',
+      },
+    ]);
+    await seedProjectInBrowser(page, indexDocId, syncServer, 'Dialog Project');
+    await expect(
+      page.locator('.ph-row', { hasText: 'Dialog Project' }),
+    ).toBeVisible({ timeout: 15000 });
+
+    await page.getByRole('button', { name: '＋ New collection' }).click();
+    const dialog = page.getByRole('dialog', { name: 'New collection' });
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toHaveAttribute('aria-modal', 'true');
+
+    // Close via its Cancel button (these dialogs close on backdrop
+    // mouse-down and Cancel, not Escape).
+    await dialog.getByRole('button', { name: 'Cancel' }).click();
+    await expect(dialog).not.toBeVisible();
+  });
+});

--- a/hub-client/e2e/projects-home.spec.ts
+++ b/hub-client/e2e/projects-home.spec.ts
@@ -114,7 +114,7 @@ test.describe('Collections projects home', () => {
 
     // Right-click on a card opens the same contextual menu as its ⋯ button.
     await section.locator('.ph-card', { hasText: 'Alpha Project' }).click({ button: 'right' });
-    const menu = section.locator('.ph-card', { hasText: 'Alpha Project' }).getByRole('menu');
+    const menu = section.locator('.ph-card', { hasText: 'Alpha Project' }).locator('.ph-menu');
     await expect(menu).toBeVisible();
     await expect(menu.getByRole('button', { name: 'Open', exact: true })).toBeVisible();
     await page.keyboard.press('Escape');

--- a/hub-client/src/App.tsx
+++ b/hub-client/src/App.tsx
@@ -17,6 +17,7 @@ function DevHarnessLazy({ page }: { page: string }) {
 }
 import Editor from './components/Editor';
 import { ErrorBoundary } from './components/ErrorBoundary';
+import SkipLink from './components/SkipLink';
 import Toast from './components/Toast';
 import { ViewModeProvider } from './components/ViewModeContext';
 import { LoginScreen } from './components/auth/LoginScreen';
@@ -870,6 +871,7 @@ function App() {
 
   return (
     <>
+      <SkipLink />
       {!project ? (
         uiVariant === 'collections' ? (
           <ProjectsHome

--- a/hub-client/src/components/Editor.tsx
+++ b/hub-client/src/components/Editor.tsx
@@ -1014,7 +1014,7 @@ export default function Editor({ project, files, fileContents, onDisconnect, onC
         </div>
       )}
 
-      <main className={`editor-main view-mode-${viewMode}`}>
+      <main id="main-content" tabIndex={-1} className={`editor-main view-mode-${viewMode}`}>
         {!isFullscreenPreview && (
           <SidebarTabs disabled={replayState.isActive}>
             {(activeTab) => {

--- a/hub-client/src/components/FileSidebar.css
+++ b/hub-client/src/components/FileSidebar.css
@@ -180,8 +180,12 @@
   min-width: 0;
 }
 
+/* WCAG 2.4.7: keep a visible focus indicator — the base style already
+   has an accent border, so focus adds an offset outline in the same
+   accent to stay distinguishable. */
 .rename-input:focus {
-  outline: none;
+  outline: 2px solid var(--sidebar-active-accent);
+  outline-offset: 1px;
 }
 
 /* Drop overlay */

--- a/hub-client/src/components/ModalDialog.test.tsx
+++ b/hub-client/src/components/ModalDialog.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * Tests for the shared ModalDialog container.
+ *
+ * Verifies the WCAG 2.2 requirements the container owns:
+ * - 4.1.2 Name/Role/Value: role="dialog", aria-modal, aria-labelledby
+ * - 2.4.3 Focus Order: Tab containment and focus restore on close
+ * - 2.1.1 Keyboard: Escape closes; other keys pass through
+ *
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import type { KeyboardEvent } from 'react';
+import ModalDialog from './ModalDialog';
+
+afterEach(cleanup);
+
+function renderDialog(
+  onClose = vi.fn(),
+  onKeyDown?: (e: KeyboardEvent<HTMLDivElement>) => void,
+) {
+  return render(
+    <ModalDialog
+      title="Test dialog"
+      className="test-dialog"
+      onClose={onClose}
+      onKeyDown={onKeyDown}
+    >
+      <div className="dialog-content">
+        <button className="first-action">First</button>
+        <button className="second-action">Second</button>
+      </div>
+    </ModalDialog>,
+  );
+}
+
+describe('ModalDialog semantics', () => {
+  it('exposes role="dialog" with aria-modal and aria-labelledby pointing at the title', () => {
+    renderDialog();
+    const dialog = screen.getByRole('dialog');
+    expect(dialog.getAttribute('aria-modal')).toBe('true');
+    const labelId = dialog.getAttribute('aria-labelledby');
+    expect(labelId).toBeTruthy();
+    expect(document.getElementById(labelId!)?.textContent).toBe('Test dialog');
+  });
+
+  it('gives the close button an accessible name', () => {
+    renderDialog();
+    expect(screen.getByRole('button', { name: 'Close' })).toBeDefined();
+  });
+
+  it('applies the extra class to the dialog element', () => {
+    renderDialog();
+    expect(screen.getByRole('dialog').className).toContain('test-dialog');
+  });
+});
+
+describe('ModalDialog keyboard behavior', () => {
+  it('closes on Escape', () => {
+    const onClose = vi.fn();
+    renderDialog(onClose);
+    fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards other keys to the dialog-specific handler', () => {
+    const onKeyDown = vi.fn();
+    renderDialog(vi.fn(), onKeyDown);
+    fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Enter' });
+    expect(onKeyDown).toHaveBeenCalled();
+  });
+
+  it('keeps Tab cycling inside the dialog', () => {
+    renderDialog();
+    const closeBtn = screen.getByRole('button', { name: 'Close' });
+    const last = screen.getByText('Second');
+
+    last.focus();
+    expect(document.activeElement).toBe(last);
+
+    // Tab past the last focusable element wraps to the first.
+    fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Tab' });
+    expect(document.activeElement).toBe(closeBtn);
+
+    // Shift+Tab before the first wraps to the last.
+    fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Tab', shiftKey: true });
+    expect(document.activeElement).toBe(last);
+  });
+
+  it('restores focus to the previously focused element on unmount', () => {
+    const trigger = document.createElement('button');
+    trigger.textContent = 'Open dialog';
+    document.body.appendChild(trigger);
+    trigger.focus();
+
+    const { unmount } = renderDialog();
+    unmount();
+
+    expect(document.activeElement).toBe(trigger);
+    trigger.remove();
+  });
+});
+
+describe('ModalDialog backdrop', () => {
+  it('closes on backdrop click but not on dialog click', () => {
+    const onClose = vi.fn();
+    const { container } = renderDialog(onClose);
+
+    fireEvent.click(container.querySelector('.ph-dialog-backdrop')!);
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    onClose.mockClear();
+    fireEvent.click(screen.getByRole('dialog'));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/hub-client/src/components/ModalDialog.tsx
+++ b/hub-client/src/components/ModalDialog.tsx
@@ -1,0 +1,107 @@
+/**
+ * Modal Dialog
+ *
+ * Shared modal container for hub-client dialogs. Owns the WCAG 2.2
+ * dialog contract so individual dialogs cannot drift:
+ *
+ * - 4.1.2 Name/Role/Value: role="dialog", aria-modal="true", and
+ *   aria-labelledby pointing at the rendered title; the close button
+ *   always has an accessible name.
+ * - 2.1.1 Keyboard: Escape closes. Dialog-specific keys (e.g. Enter to
+ *   submit) are delegated via the onKeyDown prop.
+ * - 2.4.3 Focus Order: Tab/Shift+Tab cycle within the dialog while it
+ *   is open, and focus returns to the element that held it before the
+ *   dialog opened.
+ */
+
+import { useEffect, useId, useRef } from 'react';
+import type { HTMLAttributes, KeyboardEvent, ReactNode } from 'react';
+
+export interface ModalDialogProps {
+  /** Visible title; also the dialog's accessible name. */
+  title: string;
+  onClose: () => void;
+  /** Extra class for the dialog element, e.g. 'new-file-dialog'. */
+  className?: string;
+  /** Dialog-specific key handling (e.g. Enter to submit). Escape and Tab are owned by ModalDialog. */
+  onKeyDown?: (e: KeyboardEvent<HTMLDivElement>) => void;
+  /** Extra attributes forwarded to the dialog element (e.g. drag/drop handlers). */
+  dialogProps?: HTMLAttributes<HTMLDivElement>;
+  children?: ReactNode;
+}
+
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+export default function ModalDialog({
+  title,
+  onClose,
+  className,
+  onKeyDown,
+  dialogProps,
+  children,
+}: ModalDialogProps) {
+  const titleId = useId();
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  // Capture the element focused when the dialog opens and return focus
+  // to it when the dialog closes (unmounts).
+  const restoreFocusTo = useRef<Element | null>(null);
+  useEffect(() => {
+    restoreFocusTo.current = document.activeElement;
+    return () => {
+      if (restoreFocusTo.current instanceof HTMLElement) {
+        restoreFocusTo.current.focus();
+      }
+    };
+  }, []);
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Escape') {
+      onClose();
+      return;
+    }
+    if (e.key === 'Tab') {
+      const focusables =
+        dialogRef.current?.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
+      if (!focusables || focusables.length === 0) {
+        e.preventDefault();
+        return;
+      }
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+      return;
+    }
+    onKeyDown?.(e);
+  };
+
+  return (
+    <div className="ph-dialog-backdrop" onClick={onClose}>
+      <div
+        {...dialogProps}
+        ref={dialogRef}
+        className={`ph-dialog${className ? ` ${className}` : ''}`}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={handleKeyDown}
+      >
+        <div className="dialog-header">
+          <h2 id={titleId}>{title}</h2>
+          <button className="close-btn" onClick={onClose} aria-label="Close">
+            &times;
+          </button>
+        </div>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/hub-client/src/components/NewAssetDialog.tsx
+++ b/hub-client/src/components/NewAssetDialog.tsx
@@ -16,6 +16,7 @@ import {
   validateProjectPath,
   type AssetFilePreview,
 } from './fileUpload';
+import ModalDialog from './ModalDialog';
 import './NewAssetDialog.css';
 
 export interface NewAssetDialogProps {
@@ -216,34 +217,21 @@ export default function NewAssetDialog({
     }
   }, [canUpload, previews, entryErrors, composePath, onUploadAsset, onClose]);
 
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
-    },
-    [onClose]
-  );
-
   if (!isOpen) return null;
 
   const maxMB = FILE_SIZE_LIMITS.MAX_FILE_SIZE / (1024 * 1024);
 
   return (
-    <div className="ph-dialog-backdrop" onClick={onClose}>
-      <div
-        className="ph-dialog new-asset-dialog"
-        onClick={(e) => e.stopPropagation()}
-        onKeyDown={handleKeyDown}
-        onDragOver={handleDragOver}
-        onDragLeave={handleDragLeave}
-        onDrop={handleDrop}
-      >
-        <div className="dialog-header">
-          <h2>Add asset to project</h2>
-          <button className="close-btn" onClick={onClose} aria-label="Close">
-            &times;
-          </button>
-        </div>
-
+    <ModalDialog
+      title="Add asset to project"
+      className="new-asset-dialog"
+      onClose={onClose}
+      dialogProps={{
+        onDragOver: handleDragOver,
+        onDragLeave: handleDragLeave,
+        onDrop: handleDrop,
+      }}
+    >
         <div className="dialog-content">
           <div className="destination-input">
             <label htmlFor="asset-destination">Destination folder:</label>
@@ -361,7 +349,6 @@ export default function NewAssetDialog({
             {isUploading ? 'Uploading...' : 'Upload'}
           </button>
         </div>
-      </div>
-    </div>
+    </ModalDialog>
   );
 }

--- a/hub-client/src/components/NewFileDialog.integration.test.tsx
+++ b/hub-client/src/components/NewFileDialog.integration.test.tsx
@@ -317,4 +317,22 @@ describe('NewFileDialog', () => {
       });
     });
   });
+
+  describe('accessibility semantics', () => {
+    it('exposes role="dialog" with aria-modal and the title as accessible name', () => {
+      render(<NewFileDialog {...defaultProps} />);
+
+      const dialog = screen.getByRole('dialog');
+      expect(dialog).toHaveAttribute('aria-modal', 'true');
+      const labelId = dialog.getAttribute('aria-labelledby');
+      expect(labelId).toBeTruthy();
+      expect(document.getElementById(labelId!)).toHaveTextContent('New file');
+    });
+
+    it('gives the close button an accessible name', () => {
+      render(<NewFileDialog {...defaultProps} />);
+
+      expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument();
+    });
+  });
 });

--- a/hub-client/src/components/NewFileDialog.tsx
+++ b/hub-client/src/components/NewFileDialog.tsx
@@ -9,6 +9,7 @@
 
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { discoverTemplates, type ProjectTemplate } from '../services/templateService';
+import ModalDialog from './ModalDialog';
 import './NewFileDialog.css';
 
 export interface NewFileDialogProps {
@@ -107,33 +108,25 @@ export default function NewFileDialog({
     onClose();
   }, [filename, selectedTemplate, validateFilename, onCreateTextFile, onClose]);
 
+  // Enter submits; Escape and Tab containment are owned by ModalDialog.
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if (e.key === 'Enter') {
         handleCreateTextFile();
-      } else if (e.key === 'Escape') {
-        onClose();
       }
     },
-    [handleCreateTextFile, onClose]
+    [handleCreateTextFile]
   );
 
   if (!isOpen) return null;
 
   return (
-    <div className="ph-dialog-backdrop" onClick={onClose}>
-      <div
-        className="ph-dialog new-file-dialog"
-        onClick={(e) => e.stopPropagation()}
-        onKeyDown={handleKeyDown}
-      >
-        <div className="dialog-header">
-          <h2>New file</h2>
-          <button className="close-btn" onClick={onClose} aria-label="Close">
-            &times;
-          </button>
-        </div>
-
+    <ModalDialog
+      title="New file"
+      className="new-file-dialog"
+      onClose={onClose}
+      onKeyDown={handleKeyDown}
+    >
         <div className="dialog-content">
           <div className="text-file-form">
             {templates.length > 0 && (
@@ -189,7 +182,6 @@ export default function NewFileDialog({
             Create
           </button>
         </div>
-      </div>
-    </div>
+    </ModalDialog>
   );
 }

--- a/hub-client/src/components/ProjectSelector.tsx
+++ b/hub-client/src/components/ProjectSelector.tsx
@@ -543,7 +543,7 @@ export default function ProjectSelector({
   }
 
   return (
-    <div className="project-selector">
+    <main className="project-selector">
       <div className="modal">
         <div className="modal-header">
           <div className="header-text">
@@ -963,6 +963,6 @@ export default function ProjectSelector({
           </span>
         </div>
       </div>
-    </div>
+    </main>
   );
 }

--- a/hub-client/src/components/ProjectsHome.tsx
+++ b/hub-client/src/components/ProjectsHome.tsx
@@ -1008,8 +1008,11 @@ export default function ProjectsHome({
     );
   }
 
+  // Menus are plain groups of buttons, not ARIA menus: role="menu"
+  // would require menuitem children and the full menu keyboard pattern,
+  // which these action lists don't implement (WCAG 4.1.2).
   const renderProjectMenu = (item: ProjectItem) => (
-    <div className="ph-menu" role="menu">
+    <div className="ph-menu">
       <button className="ph-menu-item strong" onClick={() => { closeAllMenus(); handleOpen(item); }}>
         Open
       </button>
@@ -1407,7 +1410,7 @@ export default function ProjectsHome({
               </svg>
             </button>
             {openMenu === sortMenuKey && (
-              <div className="ph-menu ph-menu-right" role="menu">
+              <div className="ph-menu ph-menu-right">
                 {(['newest', 'oldest', 'name'] as SortOrder[]).map((o) => (
                   <button
                     key={o}
@@ -1437,7 +1440,7 @@ export default function ProjectsHome({
           </button>
           {membersFor === collection.id && renderMembersPopover(collection)}
           {openMenu === menuKey && (
-            <div className="ph-menu ph-menu-right" role="menu">
+            <div className="ph-menu ph-menu-right">
               <button
                 className="ph-menu-item"
                 onClick={() => { setOpenMenu(null); setMembersFor(collection.id); }}
@@ -1539,7 +1542,7 @@ export default function ProjectsHome({
               ＋ New ▾
             </button>
             {newMenuOpen && (
-              <div className="ph-menu ph-menu-right" role="menu">
+              <div className="ph-menu ph-menu-right">
                 <div className="ph-menu-label">START FROM — QUARTO PROJECT TYPES</div>
                 {(projectChoices.length > 0
                   ? projectChoices
@@ -1652,7 +1655,7 @@ export default function ProjectsHome({
       )}
       {isConnecting && <div className="ph-connecting">Connecting to sync server…</div>}
 
-      <main className="ph-main">
+      <main id="main-content" tabIndex={-1} className="ph-main">
         {items.length === 0 && collections.every((c) => c.entries.length === 0) ? (
           <div className="ph-empty-state">
             <h2>No projects yet</h2>
@@ -1777,8 +1780,8 @@ export default function ProjectsHome({
       {/* Duplicate (fork) */}
       {duplicateFor && (
         <div className="ph-dialog-backdrop" onMouseDown={() => { if (!duplicatingId) setDuplicateFor(null); }}>
-          <div className="ph-dialog" onMouseDown={(e) => e.stopPropagation()}>
-            <h2>Duplicate "{duplicateFor.description}"</h2>
+          <div className="ph-dialog" role="dialog" aria-modal="true" aria-labelledby="ph-dialog-title-duplicate" onMouseDown={(e) => e.stopPropagation()}>
+            <h2 id="ph-dialog-title-duplicate">Duplicate "{duplicateFor.description}"</h2>
             <p className="ph-dialog-hint">
               A fresh copy of all {duplicateFor.summary ? `${duplicateFor.summary.fileCount} ` : ''}files — no
               edit history carries over.
@@ -1822,8 +1825,8 @@ export default function ProjectsHome({
       {/* New collection */}
       {newCollectionDialog && (
         <div className="ph-dialog-backdrop" onMouseDown={() => setNewCollectionDialog(null)}>
-          <div className="ph-dialog" onMouseDown={(e) => e.stopPropagation()}>
-            <h2>New collection</h2>
+          <div className="ph-dialog" role="dialog" aria-modal="true" aria-labelledby="ph-dialog-title-new-collection" onMouseDown={(e) => e.stopPropagation()}>
+            <h2 id="ph-dialog-title-new-collection">New collection</h2>
             {newCollectionDialog.forProject && (
               <p className="ph-dialog-hint">The project will be moved onto it.</p>
             )}
@@ -1849,8 +1852,8 @@ export default function ProjectsHome({
       {/* Rename collection */}
       {renameCollectionTarget && (
         <div className="ph-dialog-backdrop" onMouseDown={() => setRenameCollectionTarget(null)}>
-          <div className="ph-dialog" onMouseDown={(e) => e.stopPropagation()}>
-            <h2>Rename collection</h2>
+          <div className="ph-dialog" role="dialog" aria-modal="true" aria-labelledby="ph-dialog-title-rename-collection" onMouseDown={(e) => e.stopPropagation()}>
+            <h2 id="ph-dialog-title-rename-collection">Rename collection</h2>
             <p className="ph-dialog-hint">Renames it for everyone subscribed to it.</p>
             <form
               onSubmit={(e) => {
@@ -1881,8 +1884,8 @@ export default function ProjectsHome({
       {/* Generic destructive confirmation */}
       {confirmState && (
         <div className="ph-dialog-backdrop" onMouseDown={() => setConfirmState(null)}>
-          <div className="ph-dialog" onMouseDown={(e) => e.stopPropagation()}>
-            <h2>{confirmState.title}</h2>
+          <div className="ph-dialog" role="dialog" aria-modal="true" aria-labelledby="ph-dialog-title-confirm" onMouseDown={(e) => e.stopPropagation()}>
+            <h2 id="ph-dialog-title-confirm">{confirmState.title}</h2>
             <p className="ph-dialog-hint">{confirmState.body}</p>
             <div className="ph-dialog-actions">
               <button type="button" className="ph-btn outline" onClick={() => setConfirmState(null)} autoFocus>
@@ -1903,8 +1906,8 @@ export default function ProjectsHome({
       {/* Shared-collection move warning */}
       {pendingMove && (
         <div className="ph-dialog-backdrop" onMouseDown={() => setPendingMove(null)}>
-          <div className="ph-dialog" onMouseDown={(e) => e.stopPropagation()}>
-            <h2>Move "{pendingMove.name}" out of {pendingMove.fromName}?</h2>
+          <div className="ph-dialog" role="dialog" aria-modal="true" aria-labelledby="ph-dialog-title-move" onMouseDown={(e) => e.stopPropagation()}>
+            <h2 id="ph-dialog-title-move">Move "{pendingMove.name}" out of {pendingMove.fromName}?</h2>
             <p className="ph-dialog-hint">
               Please note you're changing {pendingMove.othersCount === 1
                 ? "another person's"
@@ -1944,8 +1947,8 @@ export default function ProjectsHome({
       {/* Rename dialog */}
       {renameFor && (
         <div className="ph-dialog-backdrop" onMouseDown={() => setRenameFor(null)}>
-          <div className="ph-dialog" onMouseDown={(e) => e.stopPropagation()}>
-            <h2>Rename project</h2>
+          <div className="ph-dialog" role="dialog" aria-modal="true" aria-labelledby="ph-dialog-title-rename-project" onMouseDown={(e) => e.stopPropagation()}>
+            <h2 id="ph-dialog-title-rename-project">Rename project</h2>
             <form onSubmit={(e) => { e.preventDefault(); commitRename(); }}>
               <label className="ph-field-label" htmlFor="ph-rename">Name</label>
               <input
@@ -1968,8 +1971,8 @@ export default function ProjectsHome({
       {/* New project dialog */}
       {newDialogChoice && (
         <div className="ph-dialog-backdrop" onMouseDown={() => setNewDialogChoice(null)}>
-          <div className="ph-dialog" onMouseDown={(e) => e.stopPropagation()}>
-            <h2>New {newDialogChoice.name.toLowerCase()}</h2>
+          <div className="ph-dialog" role="dialog" aria-modal="true" aria-labelledby="ph-dialog-title-new-choice" onMouseDown={(e) => e.stopPropagation()}>
+            <h2 id="ph-dialog-title-new-choice">New {newDialogChoice.name.toLowerCase()}</h2>
             <p className="ph-dialog-hint">Starter files will be created for you</p>
             {formError && <div className="ph-error inline">{formError}</div>}
             <form onSubmit={handleCreate}>
@@ -2024,8 +2027,8 @@ export default function ProjectsHome({
       {/* Connect / Import dialog */}
       {addDialogOpen && (
         <div className="ph-dialog-backdrop" onMouseDown={() => setAddDialogOpen(false)}>
-          <div className="ph-dialog wide" onMouseDown={(e) => e.stopPropagation()}>
-            <h2>Add an existing project</h2>
+          <div className="ph-dialog wide" role="dialog" aria-modal="true" aria-labelledby="ph-dialog-title-add-existing" onMouseDown={(e) => e.stopPropagation()}>
+            <h2 id="ph-dialog-title-add-existing">Add an existing project</h2>
             <div className="ph-tabs">
               <button
                 className={`ph-tab ${addTab === 'connect' ? 'active' : ''}`}

--- a/hub-client/src/components/ShareDialog.test.tsx
+++ b/hub-client/src/components/ShareDialog.test.tsx
@@ -1,0 +1,42 @@
+/**
+ * Accessibility tests for ShareDialog.
+ *
+ * Regression coverage for the WCAG 2.2 audit findings:
+ * - 4.1.2: the dialog exposes role/aria-modal/aria-labelledby and the
+ *   close button has an accessible name (previously only "×" text)
+ *
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import ShareDialog from './ShareDialog';
+
+afterEach(cleanup);
+
+const defaultProps = {
+  isOpen: true,
+  shareableUrl: 'https://hub.example.com/p/abc#key',
+  onClose: vi.fn(),
+};
+
+describe('ShareDialog accessibility', () => {
+  it('exposes dialog semantics with the title as accessible name', () => {
+    render(<ShareDialog {...defaultProps} />);
+    const dialog = screen.getByRole('dialog');
+    expect(dialog.getAttribute('aria-modal')).toBe('true');
+    const labelId = dialog.getAttribute('aria-labelledby');
+    expect(labelId).toBeTruthy();
+    expect(document.getElementById(labelId!)?.textContent).toBe('Share Project');
+  });
+
+  it('gives the close button an accessible name', () => {
+    render(<ShareDialog {...defaultProps} />);
+    expect(screen.getByRole('button', { name: 'Close' })).toBeDefined();
+  });
+
+  it('does not render when closed', () => {
+    render(<ShareDialog {...defaultProps} isOpen={false} />);
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+});

--- a/hub-client/src/components/ShareDialog.tsx
+++ b/hub-client/src/components/ShareDialog.tsx
@@ -6,6 +6,7 @@
  */
 
 import { useState, useCallback, useRef, useEffect } from 'react';
+import ModalDialog from './ModalDialog';
 import './ShareDialog.css';
 
 export interface ShareDialogProps {
@@ -70,33 +71,25 @@ export default function ShareDialog({
     }
   }, [shareableUrl, onCopied, onClose]);
 
+  // Enter copies the link; Escape and Tab containment are owned by ModalDialog.
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        onClose();
-      } else if (e.key === 'Enter') {
+      if (e.key === 'Enter') {
         handleCopyLink();
       }
     },
-    [onClose, handleCopyLink]
+    [handleCopyLink]
   );
 
   if (!isOpen || !shareableUrl) return null;
 
   return (
-    <div className="ph-dialog-backdrop" onClick={onClose}>
-      <div
-        className="ph-dialog share-dialog"
-        onClick={(e) => e.stopPropagation()}
-        onKeyDown={handleKeyDown}
-      >
-        <div className="dialog-header">
-          <h2>Share Project</h2>
-          <button className="close-btn" onClick={onClose}>
-            &times;
-          </button>
-        </div>
-
+    <ModalDialog
+      title="Share Project"
+      className="share-dialog"
+      onClose={onClose}
+      onKeyDown={handleKeyDown}
+    >
         <div className="dialog-content">
           <div className="warning-box">
             <span className="warning-icon">&#9888;</span>
@@ -133,7 +126,6 @@ export default function ShareDialog({
             {copied ? 'Copied!' : 'Copy Link'}
           </button>
         </div>
-      </div>
-    </div>
+    </ModalDialog>
   );
 }

--- a/hub-client/src/components/SkipLink.css
+++ b/hub-client/src/components/SkipLink.css
@@ -1,0 +1,18 @@
+/* Skip link: visually hidden until focused (WCAG 2.4.1 Bypass Blocks). */
+
+.skip-link {
+  position: absolute;
+  top: -48px;
+  left: 8px;
+  z-index: 2000;
+  padding: 8px 16px;
+  background: var(--posit-blue);
+  color: #fff;
+  border-radius: 0 0 6px 6px;
+  font-size: 14px;
+  transition: top 0.15s ease;
+}
+
+.skip-link:focus-visible {
+  top: 0;
+}

--- a/hub-client/src/components/SkipLink.test.tsx
+++ b/hub-client/src/components/SkipLink.test.tsx
@@ -1,0 +1,19 @@
+/**
+ * Tests for the SkipLink component (WCAG 2.4.1 Bypass Blocks).
+ *
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import SkipLink from './SkipLink';
+
+afterEach(cleanup);
+
+describe('SkipLink', () => {
+  it('renders a link targeting the main content landmark', () => {
+    render(<SkipLink />);
+    const link = screen.getByRole('link', { name: 'Skip to main content' });
+    expect(link.getAttribute('href')).toBe('#main-content');
+  });
+});

--- a/hub-client/src/components/SkipLink.tsx
+++ b/hub-client/src/components/SkipLink.tsx
@@ -1,0 +1,18 @@
+/**
+ * Skip Link
+ *
+ * "Skip to main content" link — the first focusable element in the app
+ * (WCAG 2.4.1 Bypass Blocks). Visually hidden until focused. Targets
+ * the `#main-content` landmark rendered by the active view (Editor or
+ * ProjectsHome).
+ */
+
+import './SkipLink.css';
+
+export default function SkipLink() {
+  return (
+    <a href="#main-content" className="skip-link">
+      Skip to main content
+    </a>
+  );
+}

--- a/hub-client/src/components/ViewToggleControl.css
+++ b/hub-client/src/components/ViewToggleControl.css
@@ -9,8 +9,9 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 20px;
-  height: 20px;
+  /* WCAG 2.5.8: minimum 24x24 CSS px target size */
+  width: 24px;
+  height: 24px;
   background: var(--view-toggle-bg);
   border: none;
   border-radius: 2px;

--- a/hub-client/src/components/ViewToggleControl.test.tsx
+++ b/hub-client/src/components/ViewToggleControl.test.tsx
@@ -1,0 +1,45 @@
+/**
+ * Accessibility tests for ViewToggleControl.
+ *
+ * - 1.1.1: decorative SVG icons are aria-hidden so only the button
+ *   names are announced
+ * - 4.1.2: the active toggle exposes its state via aria-pressed
+ *
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import ViewToggleControl from './ViewToggleControl';
+import { ViewModeProvider } from './ViewModeContext';
+
+afterEach(cleanup);
+
+function renderControl() {
+  return render(
+    <ViewModeProvider>
+      <ViewToggleControl />
+    </ViewModeProvider>,
+  );
+}
+
+describe('ViewToggleControl accessibility', () => {
+  it('marks decorative icons aria-hidden', () => {
+    const { container } = renderControl();
+    const svgs = container.querySelectorAll('svg');
+    expect(svgs.length).toBe(3);
+    svgs.forEach((svg) => expect(svg.getAttribute('aria-hidden')).toBe('true'));
+  });
+
+  it('exposes pressed state on the active toggle', () => {
+    renderControl();
+    const markup = screen.getByRole('button', { name: 'Markup view' });
+    const split = screen.getByRole('button', { name: 'Split view' });
+    const preview = screen.getByRole('button', { name: 'Preview view' });
+
+    // Default view mode shows both panes.
+    expect(split.getAttribute('aria-pressed')).toBe('true');
+    expect(markup.getAttribute('aria-pressed')).toBe('false');
+    expect(preview.getAttribute('aria-pressed')).toBe('false');
+  });
+});

--- a/hub-client/src/components/ViewToggleControl.tsx
+++ b/hub-client/src/components/ViewToggleControl.tsx
@@ -15,8 +15,9 @@ export default function ViewToggleControl() {
         onClick={() => setViewMode('markup')}
         title="Expand markup"
         aria-label="Markup view"
+        aria-pressed={viewMode === 'markup'}
       >
-        <svg width="12" height="10" viewBox="0 0 12 10">
+        <svg width="12" height="10" viewBox="0 0 12 10" aria-hidden="true">
           <rect x="0" y="0" width="7" height="10" rx="0.5" fill="currentColor" />
           <rect x="9" y="0" width="3" height="10" rx="0.5" fill="currentColor" opacity="0.25" />
         </svg>
@@ -26,8 +27,9 @@ export default function ViewToggleControl() {
         onClick={() => setViewMode('both')}
         title="Split equally"
         aria-label="Split view"
+        aria-pressed={viewMode === 'both'}
       >
-        <svg width="12" height="10" viewBox="0 0 12 10">
+        <svg width="12" height="10" viewBox="0 0 12 10" aria-hidden="true">
           <rect x="0" y="0" width="5" height="10" rx="0.5" fill="currentColor" />
           <rect x="7" y="0" width="5" height="10" rx="0.5" fill="currentColor" />
         </svg>
@@ -37,8 +39,9 @@ export default function ViewToggleControl() {
         onClick={() => setViewMode('preview')}
         title="Expand preview"
         aria-label="Preview view"
+        aria-pressed={viewMode === 'preview'}
       >
-        <svg width="12" height="10" viewBox="0 0 12 10">
+        <svg width="12" height="10" viewBox="0 0 12 10" aria-hidden="true">
           <rect x="0" y="0" width="3" height="10" rx="0.5" fill="currentColor" opacity="0.25" />
           <rect x="5" y="0" width="7" height="10" rx="0.5" fill="currentColor" />
         </svg>

--- a/hub-client/src/ui.css
+++ b/hub-client/src/ui.css
@@ -348,10 +348,25 @@ select.ph-input { appearance: auto; }
   padding: 0;
   line-height: 1;
   transition: color 0.2s;
+  /* WCAG 2.5.8: the × glyph alone is narrower than the 24x24 CSS px
+     minimum target size; give the button a real 24x24 box. */
+  min-width: 24px;
+  min-height: 24px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .close-btn:hover {
   color: var(--editor-text);
+}
+
+/* WCAG 2.4.7: visible focus indicator (the button has no border or
+   background change on focus otherwise). */
+.close-btn:focus-visible {
+  outline: 2px solid var(--border-focus);
+  outline-offset: 2px;
+  border-radius: 4px;
 }
 
 .dialog-content {


### PR DESCRIPTION
## Summary

**Stacked PR** — base is `feature/editor-projects-home-visual-alignment`, not `main`. Merge that first (or retarget after it lands).

Audit-driven WCAG 2.2 A/AA compliance pass over hub-client (strand bd-trkzm9rq; plan: `claude-notes/plans/2026-08-19-hub-client-wcag-22.md`):

- **4.1.2 Name/Role/Value** — all modal dialogs now expose `role="dialog"`, `aria-modal`, and an accessible name. The three editor dialogs (NewFile, NewAsset, Share) share a new `ModalDialog` container; the eight ProjectsHome dialogs get the attributes inline. ShareDialog's close button was announced as "×" — it now has an accessible name. Also dropped `role="menu"` from the ProjectsHome action menus: they are plain button groups and don't implement the ARIA menu keyboard pattern, so the role was a required-owned-elements violation.
- **2.4.3 Focus Order** — `ModalDialog` contains Tab/Shift+Tab while open and restores focus to the trigger element on close.
- **2.4.1 Bypass Blocks** — "Skip to main content" link, first in tab order, targeting the `#main-content` landmark now present on both the Editor and ProjectsHome `<main>` elements; the classic ProjectSelector root becomes `<main>`.
- **2.5.8 Target Size Minimum (new in 2.2)** — view-toggle buttons 20×20 → 24×24; `.close-btn` gets a real 24×24 box (was a bare glyph, ~13px wide).
- **2.4.7 Focus Visible** — `.close-btn` and the FileSidebar rename input get visible focus indicators.
- **1.1.1 Non-text Content** — decorative view-toggle SVGs are `aria-hidden`; the toggles additionally expose `aria-pressed` state (4.1.2).

## Verification

- Tests written failing-first, then implementation (TDD).
- Unit: 923 passed (new suites for ModalDialog, SkipLink, ViewToggleControl, ShareDialog; aria assertions added to the NewFileDialog integration suite). Integration: 111 passed. WASM: 131 passed (changelog render gate).
- `npm run build:all` clean; `npm run lint` introduces no new problems on changed files.
- New `e2e/accessibility.spec.ts` drives a real browser: skip link Tab → focus → Enter → `main#main-content` focused; New File dialog semantics, autofocus, Tab containment, Escape close, focus restore to the "+ New" trigger; ProjectsHome dialog semantics. 3 passed. `projects-home.spec.ts` updated for the menu-role removal (2 passed).
- `cargo xtask verify --skip-hub-build` green.

## Out of scope (follow-ups)

- Sub-12px font sizes and marginal-but-passing contrast pairs (not WCAG 2.2 violations).
- `eslint-plugin-jsx-a11y` / axe-core tooling (new dependency — needs discussion).
- Tab containment for ProjectsHome's inline dialogs (requires extracting them into components first).
