### PR TITLE
hub-client: deduplicate and regroup sidebar action buttons

### DIFF
--- a/hub-client/changelog.md
+++ b/hub-client/changelog.md
@@ -25,6 +25,7 @@ WASM rebuild is needed for a changelog-only edit.
 
 ### 2026-08-19
 
+- [`b62746e7`](https://github.com/quarto-dev/q2/commits/b62746e7): Sidebar cleanup — the Project tab no longer duplicates the header's switch-project button, Screenshot Preview moves from Settings to the Project tab next to Export ZIP, the Settings tab drops its Editor/Preview section headings so the toggles read as one flat list, and the Files header's New, Upload, and Print actions become equal-width icon buttons that always share one row (Print last).
 - [`e71b1ac5`](https://github.com/quarto-dev/q2/commits/e71b1ac5): WCAG 2.2 accessibility pass — dialogs are announced as dialogs with titles, Tab stays inside an open dialog and focus returns to the button that opened it, a "Skip to main content" link leads the tab order, view-toggle and dialog close buttons meet the 24px minimum target size, and keyboard focus is always visible.
 - [`63f2a178`](https://github.com/quarto-dev/q2/commits/63f2a178): Tint the editor file sidebar with the same posit-blue alpha family as the other editor bars, so it no longer reads neutral gray next to them.
 

--- a/hub-client/e2e/files-header.spec.ts
+++ b/hub-client/e2e/files-header.spec.ts
@@ -1,0 +1,78 @@
+/**
+ * E2E: Files header action row (bd-qhn2raky).
+ *
+ * The New/Upload buttons — and the conditional Print button — are
+ * icon-only buttons that share the header row at equal width and fill it,
+ * whether two or three are present. Guards the regression where three
+ * text buttons wrapped Upload onto a second row at the default 220px
+ * sidebar width.
+ */
+
+import { test, expect, type Page } from '@playwright/test';
+import {
+  bootstrapProjectsHome,
+  createProjectOnServer,
+  getServerUrl,
+  seedProjectInBrowser,
+} from './helpers/projectFactory';
+
+async function openEditor(page: Page, title: string, content: string) {
+  const syncServer = getServerUrl();
+  await bootstrapProjectsHome(page, syncServer);
+  const indexDocId = await createProjectOnServer(syncServer, [
+    { path: 'index.qmd', content, contentType: 'text' },
+  ]);
+  await seedProjectInBrowser(page, indexDocId, syncServer, title);
+  const row = page.locator('.ph-row', { hasText: title });
+  await expect(row).toBeVisible({ timeout: 15000 });
+  await row.locator('.ph-row-name').click();
+  await expect(page.locator('.new-file-btn')).toBeVisible({ timeout: 30000 });
+}
+
+async function expectSingleFullRow(page: Page, selectors: string[]) {
+  const boxes = [];
+  for (const sel of selectors) {
+    const btn = page.locator(sel);
+    await expect(btn).toBeVisible();
+    boxes.push((await btn.boundingBox())!);
+  }
+  // All on one row, equal width and height, in the given left-to-right order.
+  for (let i = 1; i < boxes.length; i++) {
+    expect(Math.abs(boxes[i].y - boxes[0].y)).toBeLessThan(1);
+    expect(Math.abs(boxes[i].width - boxes[0].width)).toBeLessThan(1);
+    expect(Math.abs(boxes[i].height - boxes[0].height)).toBeLessThan(1);
+    expect(boxes[i].x).toBeGreaterThan(boxes[i - 1].x);
+  }
+  // Together they fill the row: 24px horizontal padding + 6px gaps.
+  const headerBox = (await page.locator('.sidebar-header').boundingBox())!;
+  const totalWidth = boxes.reduce((sum, b) => sum + b.width, 0);
+  expect(totalWidth).toBeCloseTo(headerBox.width - 24 - 6 * (boxes.length - 1), 0);
+}
+
+test.describe('Files header action row', () => {
+  test.setTimeout(90_000);
+
+  test('New and Upload fill the row at equal width', async ({ page }) => {
+    await openEditor(page, 'Two Button Row', '---\ntitle: Two Button Row\n---\n\nHello.\n');
+
+    await expect(page.locator('.print-file-btn')).toHaveCount(0);
+    await expectSingleFullRow(page, ['.new-file-btn', '.upload-asset-btn']);
+  });
+
+  test('Print, New and Upload share one row at equal width', async ({ page }) => {
+    await openEditor(
+      page,
+      'Three Button Row',
+      '---\ntitle: Three Button Row\nformat: q2-preview\n---\n\nHello.\n',
+    );
+
+    // Print appears once the format is detected as printable, and is
+    // last in the row so the stable New/Upload pair doesn't shift.
+    await expect(page.locator('.print-file-btn')).toBeVisible({ timeout: 30000 });
+    await expectSingleFullRow(page, [
+      '.new-file-btn',
+      '.upload-asset-btn',
+      '.print-file-btn',
+    ]);
+  });
+});

--- a/hub-client/src/components/Editor.tsx
+++ b/hub-client/src/components/Editor.tsx
@@ -1050,7 +1050,6 @@ export default function Editor({ project, files, fileContents, onDisconnect, onC
                   return (
                     <ProjectTab
                       project={project}
-                      onChooseNewProject={onDisconnect}
                       onExportZip={exportProjectAsZip}
                     />
                   );

--- a/hub-client/src/components/FileSidebar.css
+++ b/hub-client/src/components/FileSidebar.css
@@ -21,19 +21,22 @@
   border-bottom: 1px solid var(--sidebar-border);
 }
 
-/* Sidebar-header buttons are .ph-btn.small.outline (ui.css); the only local
-   override is a fixed line-height so an emoji glyph's taller line box
-   (e.g. ⬆) doesn't make one button taller than the others. */
+/* Sidebar-header buttons are icon-only .ph-btn.small.outline (ui.css).
+   They grow to equal widths so together they fill the header row, whether
+   two or three (conditional Print) are present; inline-flex centers the
+   SVG glyph. */
 .sidebar-header .new-file-btn,
 .sidebar-header .upload-asset-btn,
 .sidebar-header .print-file-btn {
+  flex: 1 1 0;
+  /* Never shrink below the glyph: if the header is ever too narrow, the
+     buttons wrap whole rather than clip. */
+  min-width: min-content;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   line-height: 1.5;
   transition: all 0.2s;
-  /* Keep every button a single line so all three are the same height;
-     when the header is too narrow for all of them, they wrap as whole
-     buttons to a second row rather than one squeezing to two lines. */
-  white-space: nowrap;
-  flex-shrink: 0;
 }
 
 .sidebar-printable-error {

--- a/hub-client/src/components/FileSidebar.integration.test.tsx
+++ b/hub-client/src/components/FileSidebar.integration.test.tsx
@@ -46,6 +46,21 @@ describe('FileSidebar asset-upload integration', () => {
     cleanup();
   });
 
+  describe('header action buttons', () => {
+    it('New and Upload are icon-only buttons with exact accessible names', () => {
+      render(<FileSidebar {...baseProps} />);
+
+      const newBtn = screen.getByRole('button', { name: 'New file' });
+      const uploadBtn = screen.getByRole('button', { name: 'Upload asset' });
+
+      // Icon-only: no visible text, just an aria-hidden SVG glyph.
+      for (const btn of [newBtn, uploadBtn]) {
+        expect(btn.textContent).toBe('');
+        expect(btn.querySelector('svg[aria-hidden="true"]')).not.toBeNull();
+      }
+    });
+  });
+
   describe('Upload button', () => {
     it('calls onUploadFiles with empty files and root destination when nothing is selected', () => {
       const onUploadFiles = vi.fn();

--- a/hub-client/src/components/FileSidebar.tsx
+++ b/hub-client/src/components/FileSidebar.tsx
@@ -21,6 +21,70 @@ import { buildSnippet, type SearchFiles, type SearchResult } from '../services/s
 import { openPrintableDocument } from '../services/printableDocument';
 import './FileSidebar.css';
 
+/** Document with a plus — "new file". Matches the MinimalHeader icon style. */
+function FilePlusIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z" />
+      <path d="M14 2v4a2 2 0 0 0 2 2h4" />
+      <path d="M9 15h6" />
+      <path d="M12 12v6" />
+    </svg>
+  );
+}
+
+/** Arrow rising out of a tray — "upload". */
+function UploadIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+      <polyline points="17 8 12 3 7 8" />
+      <line x1="12" y1="3" x2="12" y2="15" />
+    </svg>
+  );
+}
+
+/** Printer — "open printable version". */
+function PrintIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <polyline points="6 9 6 2 18 2 18 9" />
+      <path d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2" />
+      <rect x="6" y="14" width="12" height="8" />
+    </svg>
+  );
+}
+
 export interface FileSidebarProps {
   files: FileEntry[];
   currentFile: FileEntry | null;
@@ -512,6 +576,22 @@ export default function FileSidebar({
       onClick={handleSidebarClick}
     >
       <div className="sidebar-header">
+        <button
+          className="ph-btn small outline new-file-btn"
+          onClick={onNewFile}
+          title="New file"
+          aria-label="New file"
+        >
+          <FilePlusIcon />
+        </button>
+        <button
+          className="ph-btn small outline upload-asset-btn"
+          onClick={handleUploadClick}
+          title="Upload asset"
+          aria-label="Upload asset"
+        >
+          <UploadIcon />
+        </button>
         {canOpenPrintable && (
           <button
             className="ph-btn small outline print-file-btn"
@@ -520,19 +600,9 @@ export default function FileSidebar({
             title="Open a printable version of this document in a new tab (use your browser's Print to save as PDF)"
             aria-label="Open printable version in a new tab"
           >
-            {isPreparingPrintable ? '…' : '🖨 Print'}
+            {isPreparingPrintable ? '…' : <PrintIcon />}
           </button>
         )}
-        <button className="ph-btn small outline new-file-btn" onClick={onNewFile} title="New file">
-          + New
-        </button>
-        <button
-          className="ph-btn small outline upload-asset-btn"
-          onClick={handleUploadClick}
-          title="Upload asset"
-        >
-          ⬆ Upload
-        </button>
       </div>
       {printableError && (
         <div className="sidebar-printable-error" role="alert">

--- a/hub-client/src/components/tabs/ProjectTab.css
+++ b/hub-client/src/components/tabs/ProjectTab.css
@@ -106,7 +106,9 @@
   margin-bottom: 4px;
 }
 
-.choose-project-btn {
+/* Neutral-outline secondary action, matching the removed choose-project
+   button's role next to the ghost-accent Export ZIP. */
+.screenshot-btn {
   width: 100%;
   padding: 10px 16px;
   background: none;
@@ -118,7 +120,12 @@
   transition: all 0.2s;
 }
 
-.choose-project-btn:hover {
+.screenshot-btn:hover {
   border-color: var(--posit-teal);
   color: var(--posit-teal);
+}
+
+.screenshot-btn:disabled {
+  opacity: 0.5;
+  cursor: wait;
 }

--- a/hub-client/src/components/tabs/ProjectTab.test.tsx
+++ b/hub-client/src/components/tabs/ProjectTab.test.tsx
@@ -1,11 +1,15 @@
 /**
- * Tests for the "Export ZIP" wiring in ProjectTab.
+ * Tests for ProjectTab.
  *
- * Scope: the component derives ONE project-folder slug and uses it for both
- * the in-archive top-level folder (passed to `onExportZip`) and the download
- * filename stem, so the two can never drift (GH #147). The slug is sanitized
- * via `projectFolderName`, so a hostile character in the project name must not
- * leak into either.
+ * Export ZIP wiring: the component derives ONE project-folder slug and uses
+ * it for both the in-archive top-level folder (passed to `onExportZip`) and
+ * the download filename stem, so the two can never drift (GH #147). The slug
+ * is sanitized via `projectFolderName`, so a hostile character in the project
+ * name must not leak into either.
+ *
+ * Screenshot Preview: the button captures the `.preview-pane` element via
+ * html2canvas and downloads a PNG. html2canvas is mocked here; we assert the
+ * right element is captured and a PNG download is triggered.
  *
  * The path normalization itself is exhaustively covered by node-env unit tests
  * (quarto-sync-client/export-zip.test.ts and project-folder-name.test.ts); here
@@ -15,9 +19,14 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
 import ProjectTab from './ProjectTab';
 import type { ProjectEntry } from '@quarto/preview-renderer/types/project';
+
+vi.mock('html2canvas', () => ({ default: vi.fn() }));
+import html2canvas from 'html2canvas';
+
+const mockHtml2canvas = vi.mocked(html2canvas);
 
 function makeProject(description: string): ProjectEntry {
   return {
@@ -30,7 +39,7 @@ function makeProject(description: string): ProjectEntry {
   };
 }
 
-describe('ProjectTab — Export ZIP wiring', () => {
+describe('ProjectTab', () => {
   let clickedDownloadNames: string[];
   let createElementSpy: ReturnType<typeof vi.spyOn>;
 
@@ -63,52 +72,77 @@ describe('ProjectTab — Export ZIP wiring', () => {
     cleanup();
   });
 
-  it('passes the sanitized slug as rootDir and reuses it for the filename', () => {
-    const onExportZip = vi.fn(() => new Uint8Array([1, 2, 3]));
-    render(
-      <ProjectTab
-        project={makeProject('Demo Playground')}
-        onChooseNewProject={() => {}}
-        onExportZip={onExportZip}
-      />,
-    );
+  describe('Export ZIP wiring', () => {
+    it('passes the sanitized slug as rootDir and reuses it for the filename', () => {
+      const onExportZip = vi.fn(() => new Uint8Array([1, 2, 3]));
+      render(<ProjectTab project={makeProject('Demo Playground')} onExportZip={onExportZip} />);
 
-    fireEvent.click(screen.getByText('Export ZIP'));
+      fireEvent.click(screen.getByText('Export ZIP'));
 
-    expect(onExportZip).toHaveBeenCalledWith('Demo-Playground');
-    expect(clickedDownloadNames).toEqual(['Demo-Playground.zip']);
+      expect(onExportZip).toHaveBeenCalledWith('Demo-Playground');
+      expect(clickedDownloadNames).toEqual(['Demo-Playground.zip']);
+    });
+
+    it('sanitizes hostile characters in the project name for both outputs', () => {
+      const onExportZip = vi.fn(() => new Uint8Array([1]));
+      render(<ProjectTab project={makeProject('Demo: Playground?')} onExportZip={onExportZip} />);
+
+      fireEvent.click(screen.getByText('Export ZIP'));
+
+      // ':' and '?' collapse to hyphens; folder and filename stay in lock-step.
+      expect(onExportZip).toHaveBeenCalledWith('Demo-Playground');
+      expect(clickedDownloadNames).toEqual(['Demo-Playground.zip']);
+    });
+
+    it('falls back to "project" when the name is empty', () => {
+      const onExportZip = vi.fn(() => new Uint8Array([1]));
+      render(<ProjectTab project={makeProject('')} onExportZip={onExportZip} />);
+
+      fireEvent.click(screen.getByText('Export ZIP'));
+
+      expect(onExportZip).toHaveBeenCalledWith('project');
+      expect(clickedDownloadNames).toEqual(['project.zip']);
+    });
   });
 
-  it('sanitizes hostile characters in the project name for both outputs', () => {
-    const onExportZip = vi.fn(() => new Uint8Array([1]));
-    render(
-      <ProjectTab
-        project={makeProject('Demo: Playground?')}
-        onChooseNewProject={() => {}}
-        onExportZip={onExportZip}
-      />,
-    );
+  describe('Screenshot Preview', () => {
+    let previewPane: HTMLElement;
 
-    fireEvent.click(screen.getByText('Export ZIP'));
+    beforeEach(() => {
+      previewPane = document.createElement('div');
+      previewPane.className = 'preview-pane';
+      document.body.appendChild(previewPane);
+      mockHtml2canvas.mockResolvedValue({
+        toBlob: (cb: (blob: Blob | null) => void) =>
+          cb(new Blob(['png'], { type: 'image/png' })),
+      } as unknown as HTMLCanvasElement);
+    });
 
-    // ':' and '?' collapse to hyphens; folder and filename stay in lock-step.
-    expect(onExportZip).toHaveBeenCalledWith('Demo-Playground');
-    expect(clickedDownloadNames).toEqual(['Demo-Playground.zip']);
+    afterEach(() => {
+      previewPane.remove();
+      mockHtml2canvas.mockReset();
+    });
+
+    it('captures the preview pane and downloads a PNG', async () => {
+      render(<ProjectTab project={makeProject('Demo')} onExportZip={vi.fn()} />);
+
+      fireEvent.click(screen.getByText('📸 Screenshot Preview'));
+
+      await waitFor(() =>
+        expect(
+          clickedDownloadNames.some((n) => /^preview-screenshot-.*\.png$/.test(n)),
+        ).toBe(true),
+      );
+      expect(mockHtml2canvas).toHaveBeenCalledWith(
+        previewPane,
+        expect.objectContaining({ useCORS: true }),
+      );
+    });
   });
 
-  it('falls back to "project" when the name is empty', () => {
-    const onExportZip = vi.fn(() => new Uint8Array([1]));
-    render(
-      <ProjectTab
-        project={makeProject('')}
-        onChooseNewProject={() => {}}
-        onExportZip={onExportZip}
-      />,
-    );
+  it('does not offer project switching — the header switcher owns that', () => {
+    render(<ProjectTab project={makeProject('Demo')} onExportZip={vi.fn()} />);
 
-    fireEvent.click(screen.getByText('Export ZIP'));
-
-    expect(onExportZip).toHaveBeenCalledWith('project');
-    expect(clickedDownloadNames).toEqual(['project.zip']);
+    expect(screen.queryByText('Choose New Project')).toBeNull();
   });
 });

--- a/hub-client/src/components/tabs/ProjectTab.tsx
+++ b/hub-client/src/components/tabs/ProjectTab.tsx
@@ -5,17 +5,20 @@
  * - Project name
  * - Index document ID (click to copy automerge URL)
  * - "Export ZIP" button to download all project files
- * - "Choose New Project" button
+ * - "Screenshot Preview" button to capture the preview pane as a PNG
+ *
+ * Project switching lives in the MinimalHeader switch-project button, not
+ * here.
  */
 
 import { useState, useCallback } from 'react';
+import html2canvas from 'html2canvas';
 import { projectFolderName } from '@quarto/quarto-sync-client';
 import type { ProjectEntry } from '@quarto/preview-renderer/types/project';
 import './ProjectTab.css';
 
 interface ProjectTabProps {
   project: ProjectEntry;
-  onChooseNewProject: () => void;
   /**
    * Produce the project ZIP, nesting every entry under `rootDir` (the
    * project-name folder). Callers should pass the same value used for the
@@ -24,10 +27,11 @@ interface ProjectTabProps {
   onExportZip: (rootDir: string) => Uint8Array;
 }
 
-export default function ProjectTab({ project, onChooseNewProject, onExportZip }: ProjectTabProps) {
+export default function ProjectTab({ project, onExportZip }: ProjectTabProps) {
   const [copied, setCopied] = useState(false);
   const [exporting, setExporting] = useState(false);
   const [exportError, setExportError] = useState<string | null>(null);
+  const [isCapturing, setIsCapturing] = useState(false);
 
   const handleCopyDocId = useCallback(async () => {
     try {
@@ -62,6 +66,46 @@ export default function ProjectTab({ project, onChooseNewProject, onExportZip }:
       setExporting(false);
     }
   }, [onExportZip, project.description]);
+
+  const handleScreenshot = useCallback(async () => {
+    try {
+      setIsCapturing(true);
+
+      // Find the preview pane element
+      const previewPane = document.querySelector('.preview-pane') as HTMLElement;
+
+      if (!previewPane) {
+        alert('Preview pane not found');
+        return;
+      }
+
+      // Capture the preview pane using html2canvas
+      const canvas = await html2canvas(previewPane, {
+        backgroundColor: '#ffffff',
+        useCORS: true,
+        logging: false,
+      });
+
+      // Convert canvas to blob and download
+      canvas.toBlob((blob) => {
+        if (blob) {
+          const url = URL.createObjectURL(blob);
+          const link = document.createElement('a');
+          link.href = url;
+          link.download = `preview-screenshot-${new Date().toISOString().slice(0, 19).replace(/:/g, '-')}.png`;
+          document.body.appendChild(link);
+          link.click();
+          document.body.removeChild(link);
+          URL.revokeObjectURL(url);
+        }
+      }, 'image/png');
+    } catch (error) {
+      console.error('Failed to capture screenshot:', error);
+      alert('Failed to capture screenshot. Please try again.');
+    } finally {
+      setIsCapturing(false);
+    }
+  }, []);
 
   // Display truncated doc ID (remove automerge: prefix, show first 8 chars)
   const truncatedDocId = project.indexDocId.replace(/^automerge:/, '').slice(0, 12) + '...';
@@ -101,8 +145,12 @@ export default function ProjectTab({ project, onChooseNewProject, onExportZip }:
         {exportError && (
           <div className="export-error">{exportError}</div>
         )}
-        <button className="choose-project-btn" onClick={onChooseNewProject}>
-          Choose New Project
+        <button
+          className="screenshot-btn"
+          onClick={handleScreenshot}
+          disabled={isCapturing}
+        >
+          {isCapturing ? 'Capturing...' : '📸 Screenshot Preview'}
         </button>
       </div>
     </div>

--- a/hub-client/src/components/tabs/SettingsTab.css
+++ b/hub-client/src/components/tabs/SettingsTab.css
@@ -11,14 +11,6 @@
   gap: 12px;
 }
 
-.section-label {
-  font-size: 11px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-  color: var(--editor-text-muted);
-}
-
 .setting-toggle {
   position: relative;
   display: flex;

--- a/hub-client/src/components/tabs/SettingsTab.test.tsx
+++ b/hub-client/src/components/tabs/SettingsTab.test.tsx
@@ -1,0 +1,50 @@
+/**
+ * Tests for SettingsTab.
+ *
+ * Settings holds preferences only. Actions that produce artifacts (Export
+ * ZIP, Screenshot Preview) live in the Project tab — the screenshot button
+ * used to live here and its absence is pinned by these tests.
+ *
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import SettingsTab from './SettingsTab';
+
+describe('SettingsTab', () => {
+  afterEach(cleanup);
+
+  it('renders the preference toggles', () => {
+    render(<SettingsTab scrollSyncEnabled={true} onScrollSyncChange={() => {}} />);
+
+    expect(screen.getByText('Scroll sync')).toBeTruthy();
+    expect(screen.getByText('Collapse error overlay')).toBeTruthy();
+    expect(screen.getByText('Nesting cursor')).toBeTruthy();
+    expect(screen.getByText('Rich-text editor')).toBeTruthy();
+  });
+
+  it('contains no action buttons — settings are preferences only', () => {
+    render(<SettingsTab scrollSyncEnabled={true} onScrollSyncChange={() => {}} />);
+
+    expect(screen.queryByRole('button')).toBeNull();
+    expect(screen.queryByText(/Screenshot/)).toBeNull();
+  });
+
+  it('has no section headings — the toggles read as one flat list', () => {
+    render(<SettingsTab scrollSyncEnabled={true} onScrollSyncChange={() => {}} />);
+
+    expect(screen.queryByText('Editor')).toBeNull();
+    expect(screen.queryByText('Preview')).toBeNull();
+    expect(document.querySelector('.section-label')).toBeNull();
+  });
+
+  it('calls onScrollSyncChange when the scroll sync toggle changes', () => {
+    const onScrollSyncChange = vi.fn();
+    render(<SettingsTab scrollSyncEnabled={true} onScrollSyncChange={onScrollSyncChange} />);
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /Scroll sync/ }));
+
+    expect(onScrollSyncChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/hub-client/src/components/tabs/SettingsTab.tsx
+++ b/hub-client/src/components/tabs/SettingsTab.tsx
@@ -4,11 +4,13 @@
  * Displays user settings:
  * - Scroll sync toggle
  * - Error overlay collapsed toggle
- * - Preview screenshot button
+ * - Nesting cursor toggle
+ * - Rich-text editor toggle
+ *
+ * Preferences only — actions that produce artifacts (Export ZIP, Screenshot
+ * Preview) live in the Project tab.
  */
 
-import { useState } from 'react';
-import html2canvas from 'html2canvas';
 import './SettingsTab.css';
 import { usePreference } from '../../hooks/usePreference';
 
@@ -24,52 +26,10 @@ export default function SettingsTab({
   const [errorOverlayCollapsed, setErrorOverlayCollapsed] = usePreference('errorOverlayCollapsed');
   const [unlockNestingCursor, setUnlockNestingCursor] = usePreference('unlockNestingCursor');
   const [richText, setRichText] = usePreference('richText');
-  const [isCapturing, setIsCapturing] = useState(false);
-
-  const handleScreenshot = async () => {
-    try {
-      setIsCapturing(true);
-
-      // Find the preview pane element
-      const previewPane = document.querySelector('.preview-pane') as HTMLElement;
-
-      if (!previewPane) {
-        alert('Preview pane not found');
-        return;
-      }
-
-      // Capture the preview pane using html2canvas
-      const canvas = await html2canvas(previewPane, {
-        backgroundColor: '#ffffff',
-        useCORS: true,
-        logging: false,
-      });
-
-      // Convert canvas to blob and download
-      canvas.toBlob((blob) => {
-        if (blob) {
-          const url = URL.createObjectURL(blob);
-          const link = document.createElement('a');
-          link.href = url;
-          link.download = `preview-screenshot-${new Date().toISOString().slice(0, 19).replace(/:/g, '-')}.png`;
-          document.body.appendChild(link);
-          link.click();
-          document.body.removeChild(link);
-          URL.revokeObjectURL(url);
-        }
-      }, 'image/png');
-    } catch (error) {
-      console.error('Failed to capture screenshot:', error);
-      alert('Failed to capture screenshot. Please try again.');
-    } finally {
-      setIsCapturing(false);
-    }
-  };
 
   return (
     <div className="settings-tab">
       <div className="settings-tab-section">
-        <label className="section-label">Editor</label>
         <label className="setting-toggle">
           <input
             type="checkbox"
@@ -81,9 +41,6 @@ export default function SettingsTab({
             Sync scroll position between editor and preview
           </span>
         </label>
-      </div>
-      <div className="settings-tab-section">
-        <label className="section-label">Preview</label>
         <label className="setting-toggle">
           <input
             type="checkbox"
@@ -118,29 +75,6 @@ export default function SettingsTab({
             raw markdown. Other blocks still use the plain text editor.
           </span>
         </label>
-        <div style={{ marginTop: '16px' }}>
-          <button
-            className="screenshot-button"
-            onClick={handleScreenshot}
-            disabled={isCapturing}
-            style={{
-              width: '100%',
-              padding: '8px 12px',
-              backgroundColor: '#007acc',
-              color: 'white',
-              border: 'none',
-              borderRadius: '4px',
-              cursor: isCapturing ? 'wait' : 'pointer',
-              fontSize: '13px',
-              fontWeight: 500,
-            }}
-          >
-            {isCapturing ? 'Capturing...' : '📸 Screenshot Preview'}
-          </button>
-          <span className="setting-description" style={{ marginTop: '8px', display: 'block' }}>
-            Capture the current preview as a PNG image
-          </span>
-        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
Stacked on the WCAG 2.2 PR (`feature/bd-trkzm9rq-hub-client-wcag-22`). Strands: bd-qhn2raky, bd-fj8sptb7.

## Changes

- **Project tab**: removed the "Choose New Project" button — the MinimalHeader switch-project button (top-left) calls the same `onDisconnect`, so the tab duplicated it. The unused `onChooseNewProject` prop is gone too.
- **Settings tab**: "Screenshot Preview" moved to the Project tab next to Export ZIP. It's an action that produces a download, not a preference; it also traded its one-off inline blue styling for the neutral outline used by secondary actions.
- **Settings tab**: the Editor/Preview section headings are gone — the four remaining toggles read as one flat list.
- **Files header**: New / Upload / Print are now icon-only buttons (file-plus, tray-arrow, printer — each with an aria-label and tooltip) that grow to equal widths and fill the row whether two or three are present. Print is last so the stable New/Upload pair never shifts when it appears. (Previously, three text buttons wrapped Upload onto a second row at the default 220px sidebar width.)

## Verification

- Tests written failing-first: restructured ProjectTab suite (prop removed; html2canvas mocked for the moved screenshot button), new SettingsTab suite pinning settings as preferences-only with no section headings, FileSidebar integration assertions for the icon buttons' accessible names.
- New committed e2e spec `e2e/files-header.spec.ts` asserts the buttons share one row at equal width and in stable left-to-right order in both the two- and three-button cases.
- `npm run test:ci` (unit + integration + wasm) and `npm run build:all` green; Playwright e2e 63 passed, 1 unrelated flaky in share-link-project-set (passed on retry).
- Real-browser visual checks with throwaway screenshot specs (deleted after): two-button row, three-button wrap regression, and the final icon row.