### PR TITLE
Sidebar Section falls back to text: for display text; warn on section:+text: conflict (Q-13-10)

### DIFF
--- a/claude-notes/plans/2026-08-19-sidebar-section-text-fallback.md
+++ b/claude-notes/plans/2026-08-19-sidebar-section-text-fallback.md
@@ -3,7 +3,7 @@
 **Date:** 2026-08-19
 **Braid:** bd-sidebar-section-text-ignored-sdp5g7ns
 **Checkout:** `main` @ `e6ac236d` (investigation ran in the main checkout; no worktree created)
-**Status:** Investigation — pending design alignment with user. **Do not start implementation until the user gives the go-ahead.**
+**Status:** Design settled with user (2026-08-19); see "Design decisions" below. Ready to implement pending user go-ahead on this revision.
 
 ## Triage verdict
 
@@ -49,25 +49,56 @@ let text = section_text
 
 **Repro:** copied (sources only) to `claude-notes/plans/sidebar-section-text-fallback-investigation/repro/` from the connect-docs repro. **Confirmed end-to-end at `e6ac236d`**: `cargo run --bin q2 -- render` on a scratch copy renders the section label as "The Much Longer Landing Page Title" instead of the configured "Short Name", while the contents-less "Plain Item" entry renders correctly. Observed markup captured in `sidebar-section-text-fallback-investigation/observed-output.md`.
 
-## Proposed phases (draft)
+## Design decisions (settled with user, 2026-08-19)
+
+1. **Precedence: `section:` wins, plus a new warning.** Q1's `normalizeSidebarItem`
+   (`external-sources/quarto-cli/src/project/project-config.ts:47-69`) does
+   `item.text = section` when `section:` is present and is not an existing file path —
+   unconditionally overwriting any author-supplied `text:`. So `section:`-wins matches Q1,
+   and the draft `.or_else` fallback is correct. Per user decision we additionally emit a
+   **new warning (next free code: Q-13-10)** when an entry carries *both* keys, since q2
+   can diagnose what Q1 silently clobbers.
+   - Emission-site constraint: `SidebarEntry::from_config_value` is diagnostic-free and
+     must stay that way (it's called from reparse paths and per-page). Emit from a
+     quarto-core transform holding the `&mut Vec<DiagnosticMessage>` sink, modeled on
+     Q-13-5/Q-13-6 in `crates/quarto-core/src/transforms/sidebar_auto.rs:37-49`, and fire
+     **once per project, not once per page** (see the Q-13-6 dedup guard test at
+     `sidebar_generate.rs:456-476`). Likely site: wherever the sidebar ConfigValue is
+     first scanned project-wide; detect the key conflict on the raw ConfigValue.
+   - Lint obligations in the same commit: catalog entry in
+     `crates/quarto-error-catalog/error_catalog.json`, docs page
+     `docs/errors/navigation/Q-13-10.qmd`, sidebar entry in `docs/_quarto.yml`
+     (`error-docs-page-missing` + `error-docs-sidebar-unlisted` enforce this).
+2. **`text:` as inlines: already consistent with Q1 — no change.** Q1 renders sidebar
+   item/section text as markdown inlines via the navigation markdown pipeline
+   (`sidebarContentsHandler` in `website-navigation-md.ts` feeds `item.text` through
+   Pandoc and splices rendered HTML back in). q2 already does the same:
+   `as_plain_text()` (`config_value.rs:675-684`) accepts `PandocInlines` (it's a shape
+   check, not a formatting restriction), the Section keeps the full inline structure, and
+   `render_text` (`render_html.rs:892-894`) renders it via `inlines_to_html`. Verified
+   end-to-end at HEAD: `text: "*Plain* Item"` renders `<span class="menu-text"><em>Plain</em> Item</span>`.
+   The fix should carry a regression test that a `text:`-fallback Section preserves
+   formatting (my earlier design-question premise that the filter drops formatted values
+   was wrong).
+3. **Verification depth: full `cargo xtask verify`** (quarto-navigation is in
+   hub-client's WASM dependency closure).
+
+## Proposed phases
 
 - **Phase 0 — Test plan (TDD).**
-  - Unit test in `sidebar.rs` tests: object with `text:` + `href:`/`file:` + `contents:` parses as `Section` with `text: Some("…")` (currently fails).
-  - Unit test: `section:` wins over `text:` when both present (or whatever precedence Q1 has — see design question 1).
-  - Pipeline/integration test in `crates/quarto-core/tests/integration/sidebar_pipeline.rs`: rendered sidebar HTML shows the configured `text:`, not the page title (exercises the enrichment interplay).
-- **Phase 1 — Fix.** One-expression change in the Section branch of `SidebarEntry::from_config_value`.
-- **Phase 2 — End-to-end verification.** `cargo run --bin q2 -- render` on the investigation repro; inspect `_site/*.html` sidebar markup. Full workspace tests + `cargo xtask verify --skip-hub-build` (quarto-navigation is WASM-reachable via quarto-core, so consider full verify — see design question 3).
-- **Phase 3 — Close out.** Changelog entry if the repo convention calls for one; close the strand.
-
-No docs phase expected: `docs/` documents `text:` as a sidebar-item key already; this is a conformance fix, not a new feature.
-
-## Open design questions for the user
-
-1. **Precedence when both `section:` and `text:` are present.** The draft gives `section:` priority (`.or_else`). Q1 accepts both spellings; do we know (or care to match) what Q1 does when an author writes *both* on one entry? Straw answer: `section:` wins, matching the draft — but if you'd rather diagnose the conflict (a Q-code warning), that grows the change.
-2. **Non-plain-text `text:` values.** The filter drops a `text:` whose value isn't plain text (e.g. formatted inlines), same as `section:` today — the entry falls back to page title silently. Fine to keep the existing silent behavior for both spellings, or worth a diagnostic while we're here? Straw answer: keep as-is, file a separate strand if desired.
-3. **Verification depth.** `quarto-navigation` feeds the WASM preview path. Plain `--skip-hub-build` verify, or full `cargo xtask verify` before commit? Straw answer: full verify, since the crate is in hub-client's dependency closure.
+  - Unit test in `sidebar.rs` tests: `text:` + `href:`/`file:` + `contents:` parses as `Section` with `text: Some(…)` (currently fails).
+  - Unit test: `section:` wins when both `section:` and `text:` are present.
+  - Unit test: `text:`-fallback Section preserves `PandocInlines` formatting.
+  - Warning test: both-keys entry emits Q-13-10 exactly once per project (model: Q-13-5 test in `sidebar_auto.rs:858-881`, Q-13-6 dedup test in `sidebar_generate.rs`).
+  - Pipeline/integration test in `crates/quarto-core/tests/integration/sidebar_pipeline.rs`: rendered sidebar HTML shows the configured `text:`, not the page title.
+- **Phase 1 — Parse fix.** `.or_else(|| cv.get("text").cloned())` in the Section branch of `SidebarEntry::from_config_value`.
+- **Phase 2 — Q-13-10 warning.** Catalog entry + emission in quarto-core + docs page `docs/errors/navigation/Q-13-10.qmd` + `docs/_quarto.yml` sidebar entry, all in one commit (lint-enforced).
+- **Phase 3 — End-to-end verification.** `cargo run --bin q2 -- render` on the investigation repro; inspect `_site/*.html` sidebar markup; full `cargo xtask verify`.
+- **Phase 4 — Close out.** Close the strand.
 
 ## Risks / tradeoffs (draft)
 
 - Very low risk: single-expression parse change, well-fenced by branch order (Link and Heading branches unaffected).
 - The `section:`-normalizing serialization means `text:`-authored config changes spelling across a roundtrip. No current consumer is known to care (reparse is stable), but any future "write config back to YAML" feature would rewrite user spelling. Not worth acting on now; noting for the record.
+- The Q-13-10 warning's emission site must not be the parser (reparse paths would double-emit) and must dedup across pages; this is the only genuinely fiddly part of the change.
+- Discovered parity gap, filed separately: Q1's `section:` value doubles as a *file path* (`project-config.ts:54-59` — if the value names an existing file it becomes `href`, and the author's `text:` survives). q2 treats `section:` purely as display text. Filed as bd-byrb9yqi (discovered-from this one).

--- a/claude-notes/plans/2026-08-19-sidebar-section-text-fallback.md
+++ b/claude-notes/plans/2026-08-19-sidebar-section-text-fallback.md
@@ -116,12 +116,12 @@ exist to compile, so they can't precede Phase 1 usefully).
 
 ### Phase 2 — Q-13-10 warning
 
-- [ ] Scanner tests in quarto-navigation (`section_text_conflicts`, per-sidebar grouping, nested contents recursion) — written first, observed failing.
-- [ ] Scanner implementation in `crates/quarto-navigation/src/sidebar.rs`.
-- [ ] Emission test in `sidebar_generate.rs` tests: both-keys entry produces a Q-13-10 diagnostic for the picked sidebar (model: Q-13-5/Q-13-6 tests) — written first, observed failing.
-- [ ] Catalog entry Q-13-10 in `crates/quarto-error-catalog/error_catalog.json` + emission in `sidebar_generate.rs` with `.with_location()` on the ignored `text:` value.
-- [ ] Docs page `docs/errors/navigation/Q-13-10.qmd` + sidebar entry in `docs/_quarto.yml` (lint-enforced, same commit).
-- [ ] `cargo xtask lint` green; full workspace tests green; commit.
+- [x] Scanner tests in quarto-navigation (`section_text_conflicts_per_sidebar`: both-keys flagging, per-sidebar grouping, nested contents recursion) — written first, observed failing to compile (API absent).
+- [x] Scanner implementation in `crates/quarto-navigation/src/sidebar.rs` (`SectionTextConflict` + `section_text_conflicts_per_sidebar`, exported from lib.rs).
+- [x] Emission tests in `sidebar_generate.rs`: both-keys entry produces Q-13-10 naming both labels; conflict in an *unselected* sidebar does not warn — positive test observed failing first.
+- [x] Catalog entry Q-13-10 in `crates/quarto-error-catalog/error_catalog.json` + emission in `sidebar_generate.rs` with `.with_location()` on the ignored `text:` value.
+- [x] Docs page `docs/errors/navigation/Q-13-10.qmd` + sidebar entry in `docs/_quarto.yml` (lint-enforced, same commit).
+- [x] `cargo xtask lint` green; full workspace tests green (12,868 passed); commit.
 
 ### Phase 3 — End-to-end verification
 

--- a/claude-notes/plans/2026-08-19-sidebar-section-text-fallback.md
+++ b/claude-notes/plans/2026-08-19-sidebar-section-text-fallback.md
@@ -59,12 +59,24 @@ let text = section_text
    **new warning (next free code: Q-13-10)** when an entry carries *both* keys, since q2
    can diagnose what Q1 silently clobbers.
    - Emission-site constraint: `SidebarEntry::from_config_value` is diagnostic-free and
-     must stay that way (it's called from reparse paths and per-page). Emit from a
-     quarto-core transform holding the `&mut Vec<DiagnosticMessage>` sink, modeled on
-     Q-13-5/Q-13-6 in `crates/quarto-core/src/transforms/sidebar_auto.rs:37-49`, and fire
-     **once per project, not once per page** (see the Q-13-6 dedup guard test at
-     `sidebar_generate.rs:456-476`). Likely site: wherever the sidebar ConfigValue is
-     first scanned project-wide; detect the key conflict on the raw ConfigValue.
+     must stay that way (it's called from reparse paths and per-page; quarto-navigation
+     deliberately has no quarto-error-reporting dependency). Emit from
+     `SidebarGenerateTransform` in quarto-core, modeled on Q-13-5/Q-13-6 in
+     `crates/quarto-core/src/transforms/sidebar_auto.rs:37-49`.
+   - **Correction to the earlier "once per project" assumption** (verified empirically
+     2026-08-19): the existing convention is **per-page emission for the picked sidebar**.
+     A no-match `auto:` on a 4-page site emits Q-13-6 four times at HEAD; the
+     per-sidebar-diags dance in `sidebar_generate.rs:98-146` only prevents *discarded*
+     sidebars from warning. There is no project-level diagnostic dedup machinery anywhere
+     in quarto-core. Q-13-10 follows the same convention (picked sidebar, per page) for
+     consistency; the systemic repetition issue is filed separately (see below).
+   - Mechanism: a pure scanner in quarto-navigation next to the parser
+     (`section_text_conflicts`-style, returning the conflicting entries' source infos and
+     label texts, grouped per sidebar to match `parse_list_from_config` indexing — sidebar
+     shape knowledge stays in the crate that owns the shape), consumed by
+     `sidebar_generate.rs`, which builds the `DiagnosticMessage`s (with
+     `.with_location(...)` on the ignored `text:` value, cf. `toc_location.rs:160-172`)
+     and pushes them into the existing per-sidebar diags vectors.
    - Lint obligations in the same commit: catalog entry in
      `crates/quarto-error-catalog/error_catalog.json`, docs page
      `docs/errors/navigation/Q-13-10.qmd`, sidebar entry in `docs/_quarto.yml`
@@ -83,18 +95,43 @@ let text = section_text
 3. **Verification depth: full `cargo xtask verify`** (quarto-navigation is in
    hub-client's WASM dependency closure).
 
-## Proposed phases
+## Work items
 
-- **Phase 0 — Test plan (TDD).**
-  - Unit test in `sidebar.rs` tests: `text:` + `href:`/`file:` + `contents:` parses as `Section` with `text: Some(…)` (currently fails).
-  - Unit test: `section:` wins when both `section:` and `text:` are present.
-  - Unit test: `text:`-fallback Section preserves `PandocInlines` formatting.
-  - Warning test: both-keys entry emits Q-13-10 exactly once per project (model: Q-13-5 test in `sidebar_auto.rs:858-881`, Q-13-6 dedup test in `sidebar_generate.rs`).
-  - Pipeline/integration test in `crates/quarto-core/tests/integration/sidebar_pipeline.rs`: rendered sidebar HTML shows the configured `text:`, not the page title.
-- **Phase 1 — Parse fix.** `.or_else(|| cv.get("text").cloned())` in the Section branch of `SidebarEntry::from_config_value`.
-- **Phase 2 — Q-13-10 warning.** Catalog entry + emission in quarto-core + docs page `docs/errors/navigation/Q-13-10.qmd` + `docs/_quarto.yml` sidebar entry, all in one commit (lint-enforced).
-- **Phase 3 — End-to-end verification.** `cargo run --bin q2 -- render` on the investigation repro; inspect `_site/*.html` sidebar markup; full `cargo xtask verify`.
-- **Phase 4 — Close out.** Close the strand.
+Each phase is TDD-internally: its tests are written and observed failing before its
+implementation. Warning tests live at the head of Phase 2 (they need the scanner API to
+exist to compile, so they can't precede Phase 1 usefully).
+
+### Phase 0 — Parse + pipeline tests (written first, observed failing)
+
+- [x] Unit test in `sidebar.rs`: `text:` + `file:` + `contents:` parses as `Section` with `text: Some(…)` and the file as `href` (currently fails).
+- [x] Unit test in `sidebar.rs`: `section:` wins when both `section:` and `text:` are present.
+- [x] Unit test in `sidebar.rs`: `text:`-fallback Section preserves `PandocInlines` formatting (not flattened to plain text).
+- [x] Integration test in `crates/quarto-core/tests/integration/sidebar_pipeline.rs`: rendered sidebar HTML shows the configured `text:`, not the linked page's title.
+- [x] Run the new tests; record the expected failures. *(Observed 2026-08-19: `parse_sidebar_text_with_contents_is_section_with_text` and `parse_sidebar_text_fallback_preserves_inlines` fail on `text: None`; `parse_sidebar_section_key_wins_over_text` passes trivially at HEAD as a precedence lock; `pipeline_section_with_text_key_shows_configured_text` fails with the sidebar rendering `sidebar-link">The Much Longer Landing Page Title</a>` — the exact bug symptom.)*
+
+### Phase 1 — Parse fix
+
+- [x] `.or_else(|| cv.get("text").cloned())` in the Section branch of `SidebarEntry::from_config_value`.
+- [x] Phase 0 tests pass; full workspace tests green (12,863 passed); commit.
+
+### Phase 2 — Q-13-10 warning
+
+- [ ] Scanner tests in quarto-navigation (`section_text_conflicts`, per-sidebar grouping, nested contents recursion) — written first, observed failing.
+- [ ] Scanner implementation in `crates/quarto-navigation/src/sidebar.rs`.
+- [ ] Emission test in `sidebar_generate.rs` tests: both-keys entry produces a Q-13-10 diagnostic for the picked sidebar (model: Q-13-5/Q-13-6 tests) — written first, observed failing.
+- [ ] Catalog entry Q-13-10 in `crates/quarto-error-catalog/error_catalog.json` + emission in `sidebar_generate.rs` with `.with_location()` on the ignored `text:` value.
+- [ ] Docs page `docs/errors/navigation/Q-13-10.qmd` + sidebar entry in `docs/_quarto.yml` (lint-enforced, same commit).
+- [ ] `cargo xtask lint` green; full workspace tests green; commit.
+
+### Phase 3 — End-to-end verification
+
+- [ ] `cargo run --bin q2 -- render` on the investigation repro; inspect `_site/*.html` sidebar markup (configured text, formatted-inlines case, Q-13-10 warning on a both-keys fixture).
+- [ ] Full `cargo xtask verify` (no skips).
+- [ ] Commit (if anything changed since Phase 2's commit).
+
+### Phase 4 — Close out
+
+- [ ] Update this plan's status; close the strand with `braid close`.
 
 ## Risks / tradeoffs (draft)
 

--- a/claude-notes/plans/2026-08-19-sidebar-section-text-fallback.md
+++ b/claude-notes/plans/2026-08-19-sidebar-section-text-fallback.md
@@ -1,0 +1,73 @@
+# Sidebar item with `text:` + `file:` + `contents:` renders the page title, ignoring `text:` (bd-sidebar-section-text-ignored-sdp5g7ns)
+
+**Date:** 2026-08-19
+**Braid:** bd-sidebar-section-text-ignored-sdp5g7ns
+**Checkout:** `main` @ `e6ac236d` (investigation ran in the main checkout; no worktree created)
+**Status:** Investigation — pending design alignment with user. **Do not start implementation until the user gives the go-ahead.**
+
+## Triage verdict
+
+**Ready to design.** The bug is confirmed at HEAD by code reading, the root cause named in the strand is accurate, and the fix is a one-expression change with clear test seams; the only open questions are small behavioral edge cases (precedence and Q1 parity details) listed below.
+
+## Issue context
+
+Filed today (2026-08-19) by Carlos, priority 2, type bug, label `navigation`. A sidebar entry with `text:` + `file:` (or `href:`) + `contents:` should display the configured `text:` (Q1 behavior for section-with-landing-page items), but q2 shows the linked page's title instead. Real-world impact: the Posit Connect docs port's Cookbook sidebar shows "Posit Connect Cookbook" instead of "Cookbook" across ~109 pages. Observed on q2 0.19.0 through 0.24.0.
+
+The strand already contains a root-cause analysis and a suggested fix, both of which this investigation confirmed (below).
+
+## Dependency graph
+
+**Empty.** `braid dep tree` shows only the strand itself; `braid dep list` shows no edges. The origin strand (`br-sidebar-section-text-ignored-yr34ofdu`) lives in the separate connect-docs porting skein, not this one, so no in-skein `discovered-from` edge exists. No incoming pressure, but the strand description itself carries the discovery context.
+
+## What the code looks like today
+
+Two cooperating sites produce the symptom — both verified at `e6ac236d`:
+
+1. **Parse drops `text:`** — `SidebarEntry::from_config_value`, `crates/quarto-navigation/src/sidebar.rs:229-236`. Any object with `contents:` (or `section:`) takes the Section branch, and Section display text is read from the `section:` key *only*:
+   ```rust
+   let section_text = cv.get("section").cloned();
+   ...
+   let text = section_text.filter(|v| v.as_plain_text().is_some());
+   ```
+   `text:` is never consulted, so the Section comes out with `text: None`.
+
+2. **Enrichment fills the gap with the page title** — `enrich_text_from_index`, `crates/quarto-core/src/transforms/sidebar_generate.rs:266-275`. A Section with `text: None` and an href gets its text from the project index profile's title. That fallback is correct and desirable for genuinely text-less sections (`href:` + `contents:` only); it just should never fire for entries that *did* configure a `text:`.
+
+Adjacent facts that shape the fix:
+
+- **`text:` + `file:` without `contents:`** skips the Section branch entirely, parses as a leaf `Link`, and renders correctly today (confirmed in strand and by reading the branch order at `sidebar.rs:235`).
+- **The Heading branch** (`sidebar.rs:265-273`, `text:` with no link bits) sits *after* the Section branch, so adding a `text:` fallback inside the Section branch can't shadow it.
+- **Serialization normalizes to `section:`** — `SidebarEntry::to_config_value` (`sidebar.rs:315-321`) always emits Section text under the `section:` key. After the fix, a `text:`-authored section roundtrips to the `section:` spelling, which reparses to an identical Section. Entry-level roundtrip stability holds after one normalization; the existing roundtrip test (`roundtrip_sidebar_to_config_value`, `sidebar.rs:1108`) constructs from Rust values and is unaffected.
+
+The suggested fix from the strand is right:
+
+```rust
+let text = section_text
+    .or_else(|| cv.get("text").cloned())
+    .filter(|v| v.as_plain_text().is_some());
+```
+
+**Repro:** copied (sources only) to `claude-notes/plans/sidebar-section-text-fallback-investigation/repro/` from the connect-docs repro. **Confirmed end-to-end at `e6ac236d`**: `cargo run --bin q2 -- render` on a scratch copy renders the section label as "The Much Longer Landing Page Title" instead of the configured "Short Name", while the contents-less "Plain Item" entry renders correctly. Observed markup captured in `sidebar-section-text-fallback-investigation/observed-output.md`.
+
+## Proposed phases (draft)
+
+- **Phase 0 — Test plan (TDD).**
+  - Unit test in `sidebar.rs` tests: object with `text:` + `href:`/`file:` + `contents:` parses as `Section` with `text: Some("…")` (currently fails).
+  - Unit test: `section:` wins over `text:` when both present (or whatever precedence Q1 has — see design question 1).
+  - Pipeline/integration test in `crates/quarto-core/tests/integration/sidebar_pipeline.rs`: rendered sidebar HTML shows the configured `text:`, not the page title (exercises the enrichment interplay).
+- **Phase 1 — Fix.** One-expression change in the Section branch of `SidebarEntry::from_config_value`.
+- **Phase 2 — End-to-end verification.** `cargo run --bin q2 -- render` on the investigation repro; inspect `_site/*.html` sidebar markup. Full workspace tests + `cargo xtask verify --skip-hub-build` (quarto-navigation is WASM-reachable via quarto-core, so consider full verify — see design question 3).
+- **Phase 3 — Close out.** Changelog entry if the repo convention calls for one; close the strand.
+
+No docs phase expected: `docs/` documents `text:` as a sidebar-item key already; this is a conformance fix, not a new feature.
+
+## Open design questions for the user
+
+1. **Precedence when both `section:` and `text:` are present.** The draft gives `section:` priority (`.or_else`). Q1 accepts both spellings; do we know (or care to match) what Q1 does when an author writes *both* on one entry? Straw answer: `section:` wins, matching the draft — but if you'd rather diagnose the conflict (a Q-code warning), that grows the change.
+2. **Non-plain-text `text:` values.** The filter drops a `text:` whose value isn't plain text (e.g. formatted inlines), same as `section:` today — the entry falls back to page title silently. Fine to keep the existing silent behavior for both spellings, or worth a diagnostic while we're here? Straw answer: keep as-is, file a separate strand if desired.
+3. **Verification depth.** `quarto-navigation` feeds the WASM preview path. Plain `--skip-hub-build` verify, or full `cargo xtask verify` before commit? Straw answer: full verify, since the crate is in hub-client's dependency closure.
+
+## Risks / tradeoffs (draft)
+
+- Very low risk: single-expression parse change, well-fenced by branch order (Link and Heading branches unaffected).
+- The `section:`-normalizing serialization means `text:`-authored config changes spelling across a roundtrip. No current consumer is known to care (reparse is stable), but any future "write config back to YAML" feature would rewrite user spelling. Not worth acting on now; noting for the record.

--- a/claude-notes/plans/2026-08-19-sidebar-section-text-fallback.md
+++ b/claude-notes/plans/2026-08-19-sidebar-section-text-fallback.md
@@ -3,7 +3,7 @@
 **Date:** 2026-08-19
 **Braid:** bd-sidebar-section-text-ignored-sdp5g7ns
 **Checkout:** `main` @ `e6ac236d` (investigation ran in the main checkout; no worktree created)
-**Status:** Design settled with user (2026-08-19); see "Design decisions" below. Ready to implement pending user go-ahead on this revision.
+**Status:** Complete (2026-08-19). Fix in `a93b908e`, Q-13-10 warning in `5c9ee27d`, verification evidence in `sidebar-section-text-fallback-investigation/observed-output.md`. Full `cargo xtask verify` green.
 
 ## Triage verdict
 
@@ -125,17 +125,18 @@ exist to compile, so they can't precede Phase 1 usefully).
 
 ### Phase 3 — End-to-end verification
 
-- [ ] `cargo run --bin q2 -- render` on the investigation repro; inspect `_site/*.html` sidebar markup (configured text, formatted-inlines case, Q-13-10 warning on a both-keys fixture).
-- [ ] Full `cargo xtask verify` (no skips).
-- [ ] Commit (if anything changed since Phase 2's commit).
+- [x] `cargo run --bin q2 -- render` on the investigation repro; inspect `_site/*.html` sidebar markup (configured text, formatted-inlines case, Q-13-10 warning on a both-keys fixture). Evidence in `sidebar-section-text-fallback-investigation/observed-output.md`.
+- [x] Full `cargo xtask verify` (no skips) — all 14 steps green. *(One environment repair along the way, unrelated to this change: `node_modules/@esbuild/darwin-arm64` had gone missing after this session's earlier `npm install`, failing quarto-hub-mcp's bundle test; fixed with `npm install --no-save @esbuild/darwin-arm64@0.28.0`.)*
+- [x] `cargo run --bin q2 -- render docs/` renders the site including the new Q-13-10 page (253/253 files; `errors/navigation/Q-13-10.html` present with correct title; the 40 render warnings are pre-existing docs-site issues, none referencing this change).
+- [x] Commit (plan + investigation notes updates).
 
 ### Phase 4 — Close out
 
-- [ ] Update this plan's status; close the strand with `braid close`.
+- [x] Update this plan's status; close the strand with `braid close`.
 
 ## Risks / tradeoffs (draft)
 
 - Very low risk: single-expression parse change, well-fenced by branch order (Link and Heading branches unaffected).
 - The `section:`-normalizing serialization means `text:`-authored config changes spelling across a roundtrip. No current consumer is known to care (reparse is stable), but any future "write config back to YAML" feature would rewrite user spelling. Not worth acting on now; noting for the record.
-- The Q-13-10 warning's emission site must not be the parser (reparse paths would double-emit) and must dedup across pages; this is the only genuinely fiddly part of the change.
+- The Q-13-10 warning's emission site must not be the parser (reparse paths would double-emit). Per-page repetition turned out to be a non-issue for this code: `coalesce_by_source` (bd-mg3ckvp7, `render.rs:1250-1272`) groups per-page diagnostics that share a source location, and Q-13-10 carries one — a 4-page site prints the warning once with an "Affected files:" tail (verified end-to-end). Q-13-5/Q-13-6 repeat per page only because they carry no location; that observation moved to bd-drdx1pew.
 - Discovered parity gap, filed separately: Q1's `section:` value doubles as a *file path* (`project-config.ts:54-59` — if the value names an existing file it becomes `href`, and the author's `text:` survives). q2 treats `section:` purely as display text. Filed as bd-byrb9yqi (discovered-from this one).

--- a/claude-notes/plans/sidebar-section-text-fallback-investigation/observed-output.md
+++ b/claude-notes/plans/sidebar-section-text-fallback-investigation/observed-output.md
@@ -1,0 +1,25 @@
+# End-to-end confirmation at HEAD (`e6ac236d`, 2026-08-19)
+
+Invocation (repro sources copied to a scratch dir so `_site/` stays out of the repo):
+
+```
+cargo run --bin q2 -- render <scratch>/repro-run
+# Rendered 4 of 4 files to <scratch>/repro-run/_site
+```
+
+Observed sidebar markup in `_site/index.html`:
+
+```
+sidebar-item-text sidebar-link">The Much Longer Landing Page Title
+...
+<span class="menu-text">Inner</span>
+<span class="menu-text">Plain Item</span>
+```
+
+- The `text: "Short Name"` + `file: landing.qmd` + `contents:` entry renders as
+  **"The Much Longer Landing Page Title"** (the landing page's title) — the bug.
+- The `text: "Plain Item"` + `file: plain.qmd` entry (no `contents:`) renders its
+  configured text correctly — matching the Link-branch analysis.
+
+Output was inspected directly (grep of the rendered HTML above), not inferred
+from exit status.

--- a/claude-notes/plans/sidebar-section-text-fallback-investigation/observed-output.md
+++ b/claude-notes/plans/sidebar-section-text-fallback-investigation/observed-output.md
@@ -23,3 +23,42 @@ sidebar-item-text sidebar-link">The Much Longer Landing Page Title
 
 Output was inspected directly (grep of the rendered HTML above), not inferred
 from exit status.
+
+# End-to-end verification after the fix (Phase 3, 2026-08-19)
+
+All runs: `cargo run --bin q2 -- render <scratch>/repro-run`, output inspected
+by grepping `_site/index.html` / stderr directly.
+
+**1. Original repro (`text: "Short Name"` + `file:` + `contents:`):**
+
+```
+sidebar-item-text sidebar-link">Short Name</a>
+```
+
+The configured label renders; the landing page's title no longer leaks in.
+
+**2. Formatted label (`text: "*Short* Name"`):**
+
+```
+sidebar-link"><em>Short</em> Name</a>
+sidebar-link"><span class="menu-text"><em>Plain</em> Item</span></a>
+```
+
+PandocInlines survive the fallback in both section headers and leaf items.
+
+**3. Both-keys conflict (`section: "Winning Label"` + `text: "Losing Label"`):**
+
+```
+Warning: [Q-13-10] Sidebar entry has both `section:` and `text:`
+  ╭─[ …/_quarto.yml:9:15 ]
+9 │         text: "Losing Label"
+  │               ───────┬─────
+Affected files: index.qmd, inner.qmd, landing.qmd (and 1 other)
+...
+sidebar-link">Winning Label</a>
+```
+
+`section:` wins in the rendered sidebar; the warning prints once for the whole
+4-page render (not once per page) because it carries a source location and
+`coalesce_by_source` groups identical located diagnostics — see bd-drdx1pew
+for why the location-less Q-13-5/Q-13-6 still repeat.

--- a/claude-notes/plans/sidebar-section-text-fallback-investigation/repro/README.md
+++ b/claude-notes/plans/sidebar-section-text-fallback-investigation/repro/README.md
@@ -1,0 +1,32 @@
+# Sidebar item with `text:` + `file:` + `contents:` renders the page title, not `text:`
+
+**Observed with:** q2 0.19.0; re-verified failing on 0.24.0.
+**Repro:** `q2 render` in this directory; compare with
+`quarto render --output-dir _site-q1`.
+
+A sidebar item that has both `text:` and `contents:` (a section-style
+item with an explicit landing page) should display its configured
+`text:`. q2 displays the linked page's title instead.
+
+Root cause: `SidebarEntry::from_config_value`
+(`crates/quarto-navigation/src/sidebar.rs`) treats any entry with
+`contents:` as a `Section` and reads its display text from the
+`section:` key only. When the entry uses `text:` (no `section:` key),
+the section text comes out `None` and rendering falls back to the
+`file:` page's title. Items with `text:` + `file:` but **no**
+`contents:` ("Plain Item" here) render correctly.
+
+## Expected (Quarto 1)
+
+The sidebar entry for `landing.qmd` reads "Short Name" (the configured
+`text:`).
+
+## Actual (q2 0.19.0)
+
+It reads "The Much Longer Landing Page Title" (the page's own title).
+
+## Impact in the Connect docs port
+
+The Cookbook sidebar's landing item shows "Posit Connect Cookbook"
+instead of the configured "Cookbook" on all ~109 cookbook pages. Found
+via br-wu5cbkws.

--- a/claude-notes/plans/sidebar-section-text-fallback-investigation/repro/_quarto.yml
+++ b/claude-notes/plans/sidebar-section-text-fallback-investigation/repro/_quarto.yml
@@ -1,0 +1,13 @@
+project:
+  type: website
+website:
+  title: "Sidebar Text Repro"
+  sidebar:
+    title: "Repro Guide"
+    contents:
+      - text: "Short Name"
+        file: landing.qmd
+        contents:
+          - inner.qmd
+      - text: "Plain Item"
+        file: plain.qmd

--- a/claude-notes/plans/sidebar-section-text-fallback-investigation/repro/index.qmd
+++ b/claude-notes/plans/sidebar-section-text-fallback-investigation/repro/index.qmd
@@ -1,0 +1,5 @@
+---
+title: "Home"
+---
+
+Home page.

--- a/claude-notes/plans/sidebar-section-text-fallback-investigation/repro/inner.qmd
+++ b/claude-notes/plans/sidebar-section-text-fallback-investigation/repro/inner.qmd
@@ -1,0 +1,5 @@
+---
+title: "Inner"
+---
+
+Inner page.

--- a/claude-notes/plans/sidebar-section-text-fallback-investigation/repro/landing.qmd
+++ b/claude-notes/plans/sidebar-section-text-fallback-investigation/repro/landing.qmd
@@ -1,0 +1,5 @@
+---
+title: "The Much Longer Landing Page Title"
+---
+
+Landing page.

--- a/claude-notes/plans/sidebar-section-text-fallback-investigation/repro/plain.qmd
+++ b/claude-notes/plans/sidebar-section-text-fallback-investigation/repro/plain.qmd
@@ -1,0 +1,5 @@
+---
+title: "Plain Page Title"
+---
+
+Plain page.

--- a/crates/quarto-core/src/transforms/sidebar_generate.rs
+++ b/crates/quarto-core/src/transforms/sidebar_generate.rs
@@ -25,7 +25,11 @@
 //! - `website.sidebar` absent — nothing to resolve.
 
 use quarto_config::resolve_website_value;
-use quarto_navigation::{Sidebar, SidebarTitle, resolve_active_state, sidebar_for_page};
+use quarto_error_reporting::{DiagnosticMessage, DiagnosticMessageBuilder};
+use quarto_navigation::{
+    SectionTextConflict, Sidebar, SidebarTitle, resolve_active_state,
+    section_text_conflicts_per_sidebar, sidebar_for_page,
+};
 use quarto_pandoc_types::pandoc::Pandoc;
 
 use crate::Result;
@@ -100,10 +104,19 @@ impl AstTransform for SidebarGenerateTransform {
         // sidebars we then discard would repeat them on every page of
         // the project. Only the picked sidebar's diagnostics survive,
         // below.
+        // Q-13-10 — entries carrying both `section:` and `text:` are
+        // detected on the raw config value (the parser silently lets
+        // `section:` win); grouped per sidebar so, like the auto:
+        // warnings below, only the picked sidebar's conflicts surface.
+        let conflicts_per_sidebar = section_text_conflicts_per_sidebar(&sidebar_cv);
+
         let mut per_sidebar_diags: Vec<Vec<quarto_error_reporting::DiagnosticMessage>> =
             Vec::with_capacity(sidebars.len());
-        for sidebar in &mut sidebars {
+        for (sidebar_idx, sidebar) in sidebars.iter_mut().enumerate() {
             let mut diags = Vec::new();
+            for conflict in conflicts_per_sidebar.get(sidebar_idx).into_iter().flatten() {
+                diags.push(section_text_conflict_warning(conflict));
+            }
 
             // bd-qor9a — resolve each href against the YAML file it was
             // authored in. Frontmatter-rooted hrefs (`introduction.qmd`
@@ -172,6 +185,26 @@ impl AstTransform for SidebarGenerateTransform {
 
         Ok(())
     }
+}
+
+/// Q-13-10: a sidebar entry carries both `section:` and `text:`.
+/// The two are alternate spellings for a section's display label;
+/// `section:` takes precedence (Q1 parity) and the `text:` value is
+/// ignored — bd-sidebar-section-text-ignored-sdp5g7ns.
+fn section_text_conflict_warning(conflict: &SectionTextConflict) -> DiagnosticMessage {
+    let section_label = conflict.section_label.as_deref().unwrap_or("…");
+    let text_label = conflict.text_label.as_deref().unwrap_or("…");
+    DiagnosticMessageBuilder::warning("Sidebar entry has both `section:` and `text:`")
+        .with_code("Q-13-10")
+        .problem(format!(
+            "`section: \"{section_label}\"` takes precedence; `text: \"{text_label}\"` is ignored."
+        ))
+        .add_hint(
+            "Remove one of the two keys — they are alternate spellings of a \
+             section's display label.",
+        )
+        .with_location(conflict.text_source.clone())
+        .build()
 }
 
 /// Recover the position of the sidebar `sidebar_for_page` picked.
@@ -574,6 +607,67 @@ mod tests {
         assert!(
             diags.iter().any(|d| d.code.as_deref() == Some("Q-13-5")),
             "should emit Q-13-5 for the dropped auto entry; got: {:?}",
+            diags
+        );
+    }
+
+    /// bd-sidebar-section-text-ignored-sdp5g7ns — an entry carrying
+    /// both `section:` and `text:` warns with Q-13-10 (the `text:`
+    /// value is ignored; `section:` wins, Q1 parity).
+    #[tokio::test]
+    async fn sidebar_generate_warns_on_section_text_conflict() {
+        let conflict_entry = config_map(vec![
+            ("section", s("From Section")),
+            ("text", s("From Text")),
+            ("contents", arr(vec![s("about.qmd")])),
+        ]);
+        let sidebar_cv = config_map(vec![("contents", arr(vec![conflict_entry]))]);
+        let meta = config_map(vec![("website", config_map(vec![("sidebar", sidebar_cv)]))]);
+        let index = Arc::new(ProjectIndex::new(vec![make_profile("about.qmd", "About")]));
+        let (_out, diags) = run_transform_with(meta, Some(index), "about.qmd").await;
+        let diag = diags
+            .iter()
+            .find(|d| d.code.as_deref() == Some("Q-13-10"))
+            .unwrap_or_else(|| {
+                panic!("expected Q-13-10 for the both-keys entry; got: {:?}", diags)
+            });
+        let rendered = format!("{:?}", diag);
+        assert!(
+            rendered.contains("From Section") && rendered.contains("From Text"),
+            "warning should name both labels; got: {rendered}"
+        );
+    }
+
+    /// The Q-13-10 warning follows the picked-sidebar rule: a conflict
+    /// in an *unselected* sidebar must not warn on this page (same
+    /// guard as Q-13-6 in
+    /// `sidebar_generate_hides_unselected_sidebar_diagnostics`).
+    #[tokio::test]
+    async fn sidebar_generate_hides_unselected_sidebar_section_text_conflict() {
+        let conflict_entry = config_map(vec![
+            ("section", s("From Section")),
+            ("text", s("From Text")),
+            ("contents", arr(vec![s("elsewhere/page.qmd")])),
+        ]);
+        let sidebars = arr(vec![
+            config_map(vec![
+                ("id", s("conflicted")),
+                ("contents", arr(vec![conflict_entry])),
+            ]),
+            config_map(vec![
+                ("id", s("other")),
+                ("contents", arr(vec![s("other/alpha.qmd")])),
+            ]),
+        ]);
+        let meta = config_map(vec![("website", config_map(vec![("sidebar", sidebars)]))]);
+        let index = Arc::new(ProjectIndex::new(vec![
+            make_profile("elsewhere/page.qmd", "Page"),
+            make_profile("other/alpha.qmd", "Alpha"),
+        ]));
+        let (_out, diags) = run_transform_with(meta, Some(index), "other/alpha.qmd").await;
+        assert!(
+            !diags.iter().any(|d| d.code.as_deref() == Some("Q-13-10")),
+            "unselected sidebar's section/text conflict leaked: {:?}",
             diags
         );
     }

--- a/crates/quarto-core/tests/integration/sidebar_pipeline.rs
+++ b/crates/quarto-core/tests/integration/sidebar_pipeline.rs
@@ -500,3 +500,56 @@ fn pipeline_renders_explicit_sidebar_title_literally() {
         "website.title must not appear when sidebar.title is explicit"
     );
 }
+
+// === bd-sidebar-section-text-ignored-sdp5g7ns =============================
+
+/// A sidebar entry with `text:` + `file:` + `contents:` (a section
+/// with an explicit landing page) must display its configured `text:`
+/// — not the landing page's title. Before the fix, the parser dropped
+/// `text:` in the Section branch and `enrich_text_from_index` filled
+/// the gap with the page title.
+#[test]
+fn pipeline_section_with_text_key_shows_configured_text() {
+    let (_dir, outputs) = render_project(|project_dir| {
+        write(
+            &project_dir.join("_quarto.yml"),
+            "project:\n  type: website\n  output-dir: _site\n\
+             website:\n  sidebar:\n    contents:\n\
+             \x20     - text: \"Short Name\"\n\
+             \x20       file: landing.qmd\n\
+             \x20       contents:\n\
+             \x20         - inner.qmd\n\
+             \x20     - index.qmd\n",
+        );
+        write(
+            &project_dir.join("index.qmd"),
+            "---\ntitle: Home\n---\n\nWelcome.\n",
+        );
+        write(
+            &project_dir.join("landing.qmd"),
+            "---\ntitle: The Much Longer Landing Page Title\n---\n\nLanding.\n",
+        );
+        write(
+            &project_dir.join("inner.qmd"),
+            "---\ntitle: Inner\n---\n\nInner.\n",
+        );
+    });
+
+    // Inspect a page other than landing.html so the landing page's
+    // title can only appear via the sidebar (not the page's own
+    // <title>/<h1>).
+    let index_html = find_html(&outputs, "index");
+    assert!(
+        index_html.contains("class=\"sidebar-item-text sidebar-link\">Short Name</a>"),
+        "sidebar section header must show the configured `text:`; \
+         got sidebar region: {}",
+        index_html
+            .find("<nav id=\"quarto-sidebar\"")
+            .map_or("<no sidebar nav>", |i| &index_html
+                [i..(i + 2000).min(index_html.len())])
+    );
+    assert!(
+        !index_html.contains("The Much Longer Landing Page Title"),
+        "the landing page's title must not leak into another page's sidebar"
+    );
+}

--- a/crates/quarto-error-catalog/error_catalog.json
+++ b/crates/quarto-error-catalog/error_catalog.json
@@ -1496,5 +1496,12 @@
     "message_template": "A link carries a `link-format` attribute that names an unknown value or targets a page the requested output format does not cover. `link-format=\"llms\"` needs `website.llms-txt: true` on an HTML website render, a target written as a project source path, and a target page that gets a markdown companion (drafts and the 404 page do not). The attribute is ignored and the link resolves as if it were undecorated.",
     "docs_url": "https://quarto.org/docs/errors/navigation/Q-13-9",
     "since_version": "99.9.9"
+  },
+  "Q-13-10": {
+    "subsystem": "navigation",
+    "title": "Sidebar entry has both section: and text:",
+    "message_template": "A sidebar entry carries both a `section:` and a `text:` key. They are alternate spellings for a section's display label, and `section:` takes precedence — the `text:` value is ignored. Remove one of the two keys.",
+    "docs_url": "https://quarto.org/docs/errors/navigation/Q-13-10",
+    "since_version": "99.9.9"
   }
 }

--- a/crates/quarto-navigation/src/lib.rs
+++ b/crates/quarto-navigation/src/lib.rs
@@ -31,6 +31,6 @@ pub use item::{BareScalar, NavigationItem};
 pub use navbar::{CollapseBelow, Navbar, NavbarTitle, TogglePosition, resolve_navbar};
 pub use page_nav::PageNavigation;
 pub use sidebar::{
-    AutoSpec, Crumb, Sidebar, SidebarEntry, SidebarStyle, SidebarTitle, breadcrumb_trail,
-    resolve_active_state, sidebar_for_page,
+    AutoSpec, Crumb, SectionTextConflict, Sidebar, SidebarEntry, SidebarStyle, SidebarTitle,
+    breadcrumb_trail, resolve_active_state, section_text_conflicts_per_sidebar, sidebar_for_page,
 };

--- a/crates/quarto-navigation/src/sidebar.rs
+++ b/crates/quarto-navigation/src/sidebar.rs
@@ -233,7 +233,14 @@ impl SidebarEntry {
         // key, or has `contents:`. (Q1 lets sections go text-less when
         // they only have `href:` + `contents:`.)
         if section_text.is_some() || has_contents {
-            let text = section_text.filter(|v| v.as_plain_text().is_some());
+            // Display text: `section:` wins, `text:` is the fallback
+            // spelling. Q1 accepts both for a section-with-contents
+            // entry (its `normalizeSidebarItem` overwrites `text` with
+            // the `section:` value when both are present) —
+            // bd-sidebar-section-text-ignored-sdp5g7ns.
+            let text = section_text
+                .or_else(|| cv.get("text").cloned())
+                .filter(|v| v.as_plain_text().is_some());
             let (href, href_source) = cv
                 .get("href")
                 .and_then(|v| v.as_plain_text().map(|s| (s, v.source_info.clone())))
@@ -1296,6 +1303,113 @@ mod tests {
                 assert_eq!(cv.as_plain_text().as_deref(), Some("Section label"));
             }
             other => panic!("expected Heading, got {:?}", other),
+        }
+    }
+
+    /// bd-sidebar-section-text-ignored-sdp5g7ns — an entry with
+    /// `text:` + `file:` + `contents:` is a Section whose display text
+    /// comes from `text:`. Q1 accepts both `section:` and `text:` as a
+    /// section's label spelling; without the fallback the Section's
+    /// text is `None` and enrichment replaces it with the linked
+    /// page's title.
+    #[test]
+    fn parse_sidebar_text_with_contents_is_section_with_text() {
+        let entry = map(vec![
+            ("text", s("Short Name")),
+            ("file", s("landing.qmd")),
+            ("contents", arr(vec![s("inner.qmd")])),
+        ]);
+        let cv = map(vec![("contents", arr(vec![entry]))]);
+        let list = Sidebar::parse_list_from_config(&cv);
+        match &list[0].contents[0] {
+            SidebarEntry::Section {
+                text,
+                href,
+                contents,
+                ..
+            } => {
+                assert_eq!(
+                    text.as_ref().and_then(|v| v.as_plain_text()).as_deref(),
+                    Some("Short Name"),
+                    "Section display text must fall back to `text:` when `section:` is absent"
+                );
+                assert_eq!(href.as_deref(), Some("landing.qmd"));
+                assert_eq!(contents.len(), 1);
+            }
+            other => panic!("expected Section, got {:?}", other),
+        }
+    }
+
+    /// When an entry carries both `section:` and `text:`, `section:`
+    /// wins — matching Q1's `normalizeSidebarItem`, which overwrites
+    /// `item.text` with the `section:` value.
+    #[test]
+    fn parse_sidebar_section_key_wins_over_text() {
+        let entry = map(vec![
+            ("section", s("From Section")),
+            ("text", s("From Text")),
+            ("contents", arr(vec![s("inner.qmd")])),
+        ]);
+        let cv = map(vec![("contents", arr(vec![entry]))]);
+        let list = Sidebar::parse_list_from_config(&cv);
+        match &list[0].contents[0] {
+            SidebarEntry::Section { text, .. } => {
+                assert_eq!(
+                    text.as_ref().and_then(|v| v.as_plain_text()).as_deref(),
+                    Some("From Section"),
+                    "`section:` must take precedence over `text:`"
+                );
+            }
+            other => panic!("expected Section, got {:?}", other),
+        }
+    }
+
+    /// The `text:` fallback keeps the full inline structure — a
+    /// formatted label (`text: "*Short* Name"` arrives as
+    /// PandocInlines) must survive to the renderer, not flatten to
+    /// plain text.
+    #[test]
+    fn parse_sidebar_text_fallback_preserves_inlines() {
+        use quarto_pandoc_types::config_value::ConfigValueKind;
+        use quarto_pandoc_types::inline::{Emph, Inline, Str};
+        let str_inline = |text: &str| {
+            Inline::Str(Str {
+                text: text.to_string(),
+                source_info: SourceInfo::for_test(),
+            })
+        };
+        let inlines = vec![
+            Inline::Emph(Emph {
+                content: vec![str_inline("Short")],
+                source_info: SourceInfo::for_test(),
+            }),
+            str_inline("Name"),
+        ];
+        let entry = map(vec![
+            (
+                "text",
+                ConfigValue::new_inlines(inlines, SourceInfo::for_test()),
+            ),
+            ("file", s("landing.qmd")),
+            ("contents", arr(vec![s("inner.qmd")])),
+        ]);
+        let cv = map(vec![("contents", arr(vec![entry]))]);
+        let list = Sidebar::parse_list_from_config(&cv);
+        match &list[0].contents[0] {
+            SidebarEntry::Section { text, .. } => {
+                let text = text.as_ref().expect("Section text from `text:` fallback");
+                match &text.value {
+                    ConfigValueKind::PandocInlines(inls) => {
+                        assert!(
+                            matches!(inls[0], Inline::Emph(_)),
+                            "Emph inline must survive the fallback; got {:?}",
+                            inls
+                        );
+                    }
+                    other => panic!("expected PandocInlines to be preserved, got {:?}", other),
+                }
+            }
+            other => panic!("expected Section, got {:?}", other),
         }
     }
 

--- a/crates/quarto-navigation/src/sidebar.rs
+++ b/crates/quarto-navigation/src/sidebar.rs
@@ -937,6 +937,70 @@ fn dedupe_items_by_href(list: &mut Vec<FlatEntry>) {
     });
 }
 
+/// A sidebar entry that carries both `section:` and `text:` keys.
+/// The two are alternate spellings for a section's display label;
+/// `section:` wins and the `text:` value is ignored (Q1 parity —
+/// bd-sidebar-section-text-ignored-sdp5g7ns). Reported by
+/// [`section_text_conflicts_per_sidebar`] so quarto-core can warn
+/// (Q-13-10) without this crate taking a diagnostics dependency.
+#[derive(Debug, Clone)]
+pub struct SectionTextConflict {
+    /// Plain text of the winning `section:` value, when extractable.
+    pub section_label: Option<String>,
+    /// Plain text of the ignored `text:` value, when extractable.
+    pub text_label: Option<String>,
+    /// Source location of the ignored `text:` value.
+    pub text_source: SourceInfo,
+}
+
+/// Scan the top-level `website.sidebar:` config value for entries
+/// carrying both `section:` and `text:`. Returns one list per
+/// sidebar, indexed to match [`Sidebar::parse_list_from_config`]
+/// (array form → one element per map item; object form → a single
+/// element; anything else → empty), so callers can attribute each
+/// conflict to the sidebar it appears in.
+pub fn section_text_conflicts_per_sidebar(cv: &ConfigValue) -> Vec<Vec<SectionTextConflict>> {
+    if let Some(arr) = cv.as_array() {
+        return arr
+            .iter()
+            .filter(|v| v.as_map_entries().is_some())
+            .map(section_text_conflicts_in_sidebar)
+            .collect();
+    }
+    if cv.as_map_entries().is_some() {
+        return vec![section_text_conflicts_in_sidebar(cv)];
+    }
+    Vec::new()
+}
+
+fn section_text_conflicts_in_sidebar(cv: &ConfigValue) -> Vec<SectionTextConflict> {
+    let mut out = Vec::new();
+    collect_section_text_conflicts(cv.get("contents"), &mut out);
+    out
+}
+
+fn collect_section_text_conflicts(
+    contents: Option<&ConfigValue>,
+    out: &mut Vec<SectionTextConflict>,
+) {
+    let Some(items) = contents.and_then(|cv| cv.as_array()) else {
+        return;
+    };
+    for item in items {
+        if item.as_map_entries().is_none() {
+            continue;
+        }
+        if let (Some(section_cv), Some(text_cv)) = (item.get("section"), item.get("text")) {
+            out.push(SectionTextConflict {
+                section_label: section_cv.as_plain_text(),
+                text_label: text_cv.as_plain_text(),
+                text_source: text_cv.source_info.clone(),
+            });
+        }
+        collect_section_text_conflicts(item.get("contents"), out);
+    }
+}
+
 /// External-URL classifier. Local copy here so `quarto-navigation`
 /// stays free of a `quarto-core` dep; semantics match
 /// `quarto-core::transforms::navigation_href::is_external`.
@@ -1411,6 +1475,77 @@ mod tests {
             }
             other => panic!("expected Section, got {:?}", other),
         }
+    }
+
+    /// Q-13-10 scanner — an entry with both `section:` and `text:` is
+    /// reported with both labels and the ignored `text:` value's
+    /// location; clean entries (either spelling alone) are not.
+    #[test]
+    fn section_text_conflicts_flags_both_keys_entry() {
+        let entry = map(vec![
+            ("section", s("From Section")),
+            ("text", s("From Text")),
+            ("contents", arr(vec![s("inner.qmd")])),
+        ]);
+        let clean_text = map(vec![
+            ("text", s("Clean")),
+            ("file", s("clean.qmd")),
+            ("contents", arr(vec![s("leaf.qmd")])),
+        ]);
+        let clean_section = map(vec![
+            ("section", s("Also Clean")),
+            ("contents", arr(vec![s("other.qmd")])),
+        ]);
+        let cv = map(vec![(
+            "contents",
+            arr(vec![entry, clean_text, clean_section]),
+        )]);
+        let per_sidebar = section_text_conflicts_per_sidebar(&cv);
+        assert_eq!(per_sidebar.len(), 1, "object form is a single sidebar");
+        assert_eq!(
+            per_sidebar[0].len(),
+            1,
+            "exactly the both-keys entry is flagged"
+        );
+        let c = &per_sidebar[0][0];
+        assert_eq!(c.section_label.as_deref(), Some("From Section"));
+        assert_eq!(c.text_label.as_deref(), Some("From Text"));
+    }
+
+    /// The scanner recurses into nested section contents.
+    #[test]
+    fn section_text_conflicts_recurses_into_nested_contents() {
+        let inner_conflict = map(vec![
+            ("section", s("Inner")),
+            ("text", s("Ignored")),
+            ("contents", arr(vec![s("x.qmd")])),
+        ]);
+        let outer = map(vec![
+            ("section", s("Outer")),
+            ("contents", arr(vec![inner_conflict])),
+        ]);
+        let cv = map(vec![("contents", arr(vec![outer]))]);
+        let per_sidebar = section_text_conflicts_per_sidebar(&cv);
+        assert_eq!(per_sidebar[0].len(), 1);
+        assert_eq!(per_sidebar[0][0].section_label.as_deref(), Some("Inner"));
+    }
+
+    /// Array form groups conflicts per sidebar, indexed to match
+    /// `parse_list_from_config`.
+    #[test]
+    fn section_text_conflicts_groups_per_sidebar() {
+        let conflict = map(vec![
+            ("section", s("A")),
+            ("text", s("B")),
+            ("contents", arr(vec![s("x.qmd")])),
+        ]);
+        let sb1 = map(vec![("id", s("one")), ("contents", arr(vec![conflict]))]);
+        let sb2 = map(vec![("id", s("two")), ("contents", arr(vec![s("y.qmd")]))]);
+        let cv = arr(vec![sb1, sb2]);
+        let per_sidebar = section_text_conflicts_per_sidebar(&cv);
+        assert_eq!(per_sidebar.len(), 2);
+        assert_eq!(per_sidebar[0].len(), 1);
+        assert!(per_sidebar[1].is_empty());
     }
 
     /// `collapse-level: 4` overrides the default.

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -241,6 +241,7 @@ website:
             - errors/navigation/Q-13-7.qmd
             - errors/navigation/Q-13-8.qmd
             - errors/navigation/Q-13-9.qmd
+            - errors/navigation/Q-13-10.qmd
         - section: "template"
           contents:
             - errors/template/Q-10-1.qmd

--- a/docs/errors/navigation/Q-13-10.qmd
+++ b/docs/errors/navigation/Q-13-10.qmd
@@ -1,0 +1,88 @@
+---
+title: "Sidebar entry has both section: and text:"
+description: "A sidebar entry carries both a section: and a text: key; section: takes precedence and the text: value is ignored."
+code: Q-13-10
+subsystem: navigation
+status: complete
+since: "99.9.9"
+categories:
+  - navigation
+  - websites
+---
+
+# `Q-13-10` — Sidebar entry has both `section:` and `text:`
+
+> A sidebar entry carries both a `section:` and a `text:` key. They
+> are alternate spellings for a section's display label, and
+> `section:` takes precedence — the `text:` value is ignored.
+
+## What this means
+
+A sidebar entry that has `contents:` is a *section*, and its display
+label can be spelled two ways:
+
+``` yaml
+website:
+  sidebar:
+    contents:
+      # spelling 1: section:
+      - section: Guides
+        contents:
+          - guides/intro.qmd
+
+      # spelling 2: text: (often with a landing page)
+      - text: Guides
+        file: guides/index.qmd
+        contents:
+          - guides/intro.qmd
+```
+
+Both are accepted. This warning fires when a single entry uses
+*both* keys at once:
+
+``` yaml
+      - section: Guides
+        text: All the Guides    # ignored — this line has no effect
+        contents:
+          - guides/intro.qmd
+```
+
+Only one of the two values can be the label. Quarto uses the
+`section:` value and ignores the `text:` value. The render still
+succeeds.
+
+## Why this happens
+
+Common causes:
+
+- **Leftover key after a refactor.** The entry started as
+  `text:` + `contents:` and a `section:` key was added later (or
+  vice versa), leaving both spellings in place.
+- **Copy-paste between entries.** A leaf link (`text:` + `href:`)
+  was converted into a section by pasting `section:` and
+  `contents:` from a neighboring entry without removing `text:`.
+
+## How to fix
+
+Keep exactly one of the two keys:
+
+``` yaml
+# either
+- section: Guides
+  contents:
+    - guides/intro.qmd
+
+# or
+- text: Guides
+  file: guides/index.qmd
+  contents:
+    - guides/intro.qmd
+```
+
+If the two values differ, the one you keep should be the label you
+actually want in the sidebar.
+
+## Related
+
+- `Q-13-5` — sidebar `auto:` entry dropped (no project index).
+- `Q-13-6` — sidebar `auto:` entry matched no documents.


### PR DESCRIPTION
Fixes bd-sidebar-section-text-ignored-sdp5g7ns: a sidebar entry configured with `text:` + `file:` (or `href:`) + `contents:` displayed the linked page's title instead of the configured `text:`, replacing deliberately short labels with full page headings on every page of a site (seen in the Posit Connect docs port, where "Cookbook" rendered as "Posit Connect Cookbook" across ~109 pages).

## What changed

- **Parse fix** (`a93b908e`): `SidebarEntry::from_config_value`'s Section branch now falls back to `text:` when `section:` is absent. Q1 accepts both spellings (its `normalizeSidebarItem` overwrites `text` with the `section:` value when both are present), so `section:` keeps precedence. Formatted labels (`text: "*Short* Name"` → PandocInlines) survive the fallback.
- **Q-13-10 warning** (`5c9ee27d`): an entry carrying *both* `section:` and `text:` now warns that `text:` is ignored, with a source span on the ignored value. Detection is a pure scanner in `quarto-navigation` (no diagnostics dependency added); emission goes through `SidebarGenerateTransform`'s existing per-sidebar diags, so only the picked sidebar's conflicts surface. Catalog entry, `docs/errors/navigation/Q-13-10.qmd`, and docs sidebar entry included (lint-enforced).

## Testing

TDD throughout — every test was written first and observed failing:

- Unit: `text:` fallback, `section:`-wins precedence lock, PandocInlines preservation, scanner (flagging / nested recursion / per-sidebar grouping).
- Transform: Q-13-10 emitted naming both labels; conflict in an *unselected* sidebar stays silent.
- Integration: `ProjectPipeline` render shows the configured `text:`, not the page title.
- End-to-end via `q2 render` on a minimal repro (committed under `claude-notes/plans/sidebar-section-text-fallback-investigation/`): configured label renders, `<em>` markup survives, Q-13-10 prints once per project (it carries a location, so `coalesce_by_source` groups it) with the span pointing at the ignored `text:` line.
- Full `cargo xtask verify` (no skips) green; `docs/` renders 253/253 pages including the new error page.

Discovered along the way, filed separately: bd-byrb9yqi (Q1 treats a `section:` value naming an existing file as the section's href; q2 doesn't) and bd-drdx1pew (location-less Q-13-5/Q-13-6 repeat per page because they miss the coalescer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)