### PR TITLE
Resolve sidebar dir index by stem, not hardcoded .qmd (bd-sidebar-dir-index-md-5khf3lds)

### DIFF
--- a/claude-notes/plans/2026-08-19-sidebar-dir-index-md.md
+++ b/claude-notes/plans/2026-08-19-sidebar-dir-index-md.md
@@ -3,7 +3,7 @@
 **Date:** 2026-08-19
 **Braid:** bd-sidebar-dir-index-md-5khf3lds
 **Branch:** `main` @ `f387bd68` (investigation committed in place; no worktree created)
-**Status:** Investigation — pending design alignment with user. **Do not start implementation until the user gives the go-ahead.**
+**Status:** Design questions answered by user 2026-08-19 — approved for TDD implementation. See "Design decisions" below.
 
 ## Triage verdict
 
@@ -50,11 +50,20 @@ In `section_for_dir`, resolve the directory's index profile **by stem** instead 
 - **Phase 2 — End-to-end verification.** `cargo run --bin q2 -- render` on the investigation repro; inspect `#quarto-sidebar` in `guides/alpha.html`; confirm rename-to-`.qmd` equivalence. Spot-check the Connect docs site if available. Full workspace test suite + snapshot audit (report any `.snap` deltas).
 - **Phase 3 — Docs.** Likely none needed (this is parity, not new surface); confirm `docs/` doesn't document the `.qmd`-only limitation anywhere.
 
-## Open design questions for the user
+## Design decisions (answered by user, 2026-08-19)
 
-1. **Tie-break when both `guides/index.qmd` and `guides/index.md` exist.** Q1 uses `engineValidExtensions()` order (first existing wins). Options: (a) fixed preference order `qmd` > `md` (matches Q1's practical outcome, deterministic, cheap); (b) `ProjectIndex` insertion order (simplest but order is walk-dependent). Recommendation: (a).
-2. **Search domain: `members` vs the whole `ProjectIndex`.** Today the header lookup goes through `index.lookup_by_source` (whole index) while children come from `members` (draft-filtered, matcher-filtered candidates). Resolving the index within `members` instead is simpler, guarantees the promoted page actually belongs to the section, and — as a side effect — stops a **draft** `index.qmd` from being promoted to a linked header (today it would be, since drafts are filtered out of candidates but not out of the lookup). Is that draft-behavior change desirable (I believe yes — Q1 doesn't link drafts), or should we preserve the whole-index lookup?
-3. **Case sensitivity of the stem match.** `is_top_level_index` matches `Index.qmd` case-insensitively (`eq_ignore_ascii_case`). Should `section_for_dir` do the same for consistency? (Href would still use the actual path.) Recommendation: yes, mirror `is_top_level_index`.
+1. **Tie-break when both `guides/index.qmd` and `guides/index.md` exist:** fixed preference order, `qmd` > `md` (> anything else, in member order). User: "might need tweaking, but for now it'll do."
+2. **Search domain:** resolve the index within `members` (the draft-filtered, matcher-filtered candidates), not the whole `ProjectIndex`. Side effect accepted: a **draft** directory index is no longer promoted to a linked section header. User also flagged the broader question — does q2 have a *structural* mechanism preventing draft pages from being linked anywhere? — delegated to a study agent; its outcome (summary or new-strand recommendation) is tracked separately from this fix.
+3. **Case sensitivity:** the stem match is **case-sensitive** (`stem == "index"` exactly). User's call: case-insensitive matching invites trouble across case-sensitive vs case-preserving/insensitive filesystems (macOS). Note this deliberately diverges from `is_top_level_index`'s `eq_ignore_ascii_case`; the broader case-handling inconsistency is filed as discovered work (low priority) rather than fixed here.
+
+## Work items
+
+- [x] Phase 0 — failing tests written and observed to fail (6 new tests in `sidebar_auto.rs`; `auto_bare_directory_section_uses_md_dir_index`, `auto_all_promotes_md_dir_index`, `auto_draft_dir_index_is_not_promoted` failed at HEAD exactly as predicted; the nested/tie-break/case-sensitivity guards passed at HEAD by design)
+- [x] Phase 1 — stem-based index resolution in `section_for_dir` (members domain, direct-child only, case-sensitive, `.qmd` > `.md` > other preference; `index: &ProjectIndex` param dropped from `section_for_dir`/`group_with_subdirs`; all 24 sidebar_auto tests pass)
+- [x] Phase 2 — full workspace tests + snapshot audit (12,902 passed, 0 failed; **zero `.snap` files changed**)
+- [x] Phase 2 — end-to-end repro render verified: `cargo run --bin q2 -- render claude-notes/plans/sidebar-dir-index-md-investigation/repro`, inspected `_site/guides/alpha.html` — header is `<a href="index.html">The Guides Landing Page</a>`, children exactly Alpha/Beta. See RESULTS.md "Post-fix verification".
+- [x] File discovered-work strand: case-sensitivity inconsistency → **bd-0yp90370** (p3)
+- [x] Draft-link study agent outcome recorded → audit at `claude-notes/research/2026-08-19-draft-visibility-audit.md`; recommendation accepted, filed **bd-zeormbsa** (p2, "Centralize draft visibility: a single is_linkable predicate on ProjectIndex"), linked related to bd-w0o9 / bd-p4sc / bd-4zdf. Headline: 25 ProjectIndex access sites, only 6 draft-checked; live leaks in sitemap, listings/RSS, body links, explicit nav items.
 
 ## Risks / tradeoffs (draft)
 

--- a/claude-notes/plans/2026-08-19-sidebar-dir-index-md.md
+++ b/claude-notes/plans/2026-08-19-sidebar-dir-index-md.md
@@ -1,0 +1,63 @@
+# Sidebar `contents: <dir>` shorthand only recognizes `index.qmd` (bd-sidebar-dir-index-md-5khf3lds)
+
+**Date:** 2026-08-19
+**Braid:** bd-sidebar-dir-index-md-5khf3lds
+**Branch:** `main` @ `f387bd68` (investigation committed in place; no worktree created)
+**Status:** Investigation — pending design alignment with user. **Do not start implementation until the user gives the go-ahead.**
+
+## Triage verdict
+
+**Ready to design.** The strand's root-cause analysis is confirmed accurate at HEAD, the fix is small and localized (one function, `section_for_dir` in `crates/quarto-core/src/transforms/sidebar_auto.rs`), and the repro reproduces. Two design questions below (tie-break order, search domain) are the only open decisions.
+
+## Issue context
+
+Filed 2026-08-19 by Carlos Scheidegger, priority 2, type bug, label `navigation`. The sidebar `contents: <directory>` shorthand promotes the directory's landing page to the section header only when it is `index.qmd`. With `index.md` — discoverable since `.md` became a first-class input (bd-6d2wj4zp) when matched by an explicit `project.render` pattern — the landing page is neither promoted (header falls back to capitalized dir name, no href) nor excluded from the child list. Prev/next pagination shifts as a consequence.
+
+Real-world hit: the Posit Connect docs (`contents: how-to`, all landing pages `.md`) — the last remaining sidebar difference in the 451-page port. Origin strand in the connect-docs porting skein: `br-l18qnflo`, follow-up to the dir-shorthand feature bd-sidebar-contents-dir-shorthand-z7arvhx8.
+
+## Dependency graph
+
+The graph is **empty in this skein** — no edges. Context instead comes from the strand description itself, which names:
+
+- **bd-sidebar-contents-dir-shorthand-z7arvhx8** (in_progress): the feature that introduced `AutoSpec::Path` dir-shorthand expansion and, with it, `section_for_dir`. Its plan recorded a known limitation about nesting depth; the hardcoded extension was a second, quieter MVP shortcut ("Only `.qmd` is discoverable by Phase-1 project walking; that's fine for MVP") whose premise `.md` render support later invalidated.
+- **br-l18qnflo**: the connect-docs skein origin (not resolvable from this skein; context is summarized in the description).
+
+## What the code looks like today
+
+Confirmed at HEAD (= v0.24.0):
+
+- `crates/quarto-core/src/transforms/sidebar_auto.rs:356` — `let index_src = format!("{}/index.qmd", dir);` with the stale MVP comment. Drives both the header promotion (`lookup_by_source`) and the child-exclusion filter at line 383. This is the **only** production occurrence of the hardcoded pattern (all other `index.qmd` hits in the workspace are test fixtures).
+- `section_for_dir` is called only from `group_with_subdirs` (line 347), which serves **both** `auto: true` (`Scope::Grouped`) and the bare-directory shorthand (`AutoSpec::Path` + `is_bare_directory`). One fix covers both entry points.
+- The stale premise: `crates/quarto-core/src/project/discovery.rs` has `FIXED_RENDERABLE = &["qmd", "md"]` — `.md` profiles do land in the `ProjectIndex` when an explicit `project.render` pattern matches them.
+- Neighboring code already does stem-based matching: `is_top_level_index` (line 300) checks `file_stem().eq_ignore_ascii_case("index")` — a model for the fix.
+- Q1 parity reference: `indexFileHrefForDir` in `external-sources/quarto-cli/src/project/types/website/website-sidebar-auto.ts:234` probes `index<ext>` over `engineValidExtensions()` **in order** and takes the first that exists — extension-agnostic with a deterministic preference order.
+
+**Repro:** `claude-notes/plans/sidebar-dir-index-md-investigation/repro/` — a website with `sidebar.contents: guides`, `guides/index.md` ("The Guides Landing Page"), `guides/alpha.qmd`, `guides/beta.qmd`, and `project.render` including `**/*.md`. Expected (Q1): section header "The Guides Landing Page" (href to the landing page) with children Alpha Guide, Beta Guide. Actual at HEAD: header "Guides", no href, landing page listed as a third child. See `RESULTS.md` in the investigation dir for the observed render output.
+
+## Proposed fix (sketch)
+
+In `section_for_dir`, resolve the directory's index profile **by stem** instead of by hardcoded extension: find the profile whose source path is a *direct* child of `dir` with file stem `index` (any extension the `ProjectIndex` admitted). Use that resolved source string for both the header href and the child-exclusion filter — both symptoms are one fix. Nested `dir/sub/index.md` must not match.
+
+## Proposed phases (draft)
+
+- **Phase 0 — Test plan (TDD, failing tests first).** Unit tests in `sidebar_auto.rs`'s test module (helpers `make_profile` et al. already exist):
+  - `index.md` in a bare-dir shorthand → promoted to section header (title + href), excluded from children.
+  - Same under `auto: true` grouping.
+  - `dir/sub/index.md` is **not** promoted for `dir`'s section.
+  - Tie-break: dir with both `index.qmd` and `index.md` → deterministic winner (per design Q1).
+  - Pagination-adjacent assertion: child list ordering/count with `.md` index excluded (prev/next is downstream of the entry list, so entry-level tests cover it).
+- **Phase 1 — Implement** stem-based index resolution in `section_for_dir` (single function; delete the stale MVP comment).
+- **Phase 2 — End-to-end verification.** `cargo run --bin q2 -- render` on the investigation repro; inspect `#quarto-sidebar` in `guides/alpha.html`; confirm rename-to-`.qmd` equivalence. Spot-check the Connect docs site if available. Full workspace test suite + snapshot audit (report any `.snap` deltas).
+- **Phase 3 — Docs.** Likely none needed (this is parity, not new surface); confirm `docs/` doesn't document the `.qmd`-only limitation anywhere.
+
+## Open design questions for the user
+
+1. **Tie-break when both `guides/index.qmd` and `guides/index.md` exist.** Q1 uses `engineValidExtensions()` order (first existing wins). Options: (a) fixed preference order `qmd` > `md` (matches Q1's practical outcome, deterministic, cheap); (b) `ProjectIndex` insertion order (simplest but order is walk-dependent). Recommendation: (a).
+2. **Search domain: `members` vs the whole `ProjectIndex`.** Today the header lookup goes through `index.lookup_by_source` (whole index) while children come from `members` (draft-filtered, matcher-filtered candidates). Resolving the index within `members` instead is simpler, guarantees the promoted page actually belongs to the section, and — as a side effect — stops a **draft** `index.qmd` from being promoted to a linked header (today it would be, since drafts are filtered out of candidates but not out of the lookup). Is that draft-behavior change desirable (I believe yes — Q1 doesn't link drafts), or should we preserve the whole-index lookup?
+3. **Case sensitivity of the stem match.** `is_top_level_index` matches `Index.qmd` case-insensitively (`eq_ignore_ascii_case`). Should `section_for_dir` do the same for consistency? (Href would still use the actual path.) Recommendation: yes, mirror `is_top_level_index`.
+
+## Risks / tradeoffs (draft)
+
+- Snapshot exposure: website-render snapshot tests that exercise sidebars may shift if any fixture has a directory `index.md`; expected to be zero or small, but the snapshot-audit step in Phase 2 covers it.
+- The draft-index behavior change in design Q2 (if accepted) is a subtle semantic change beyond the reported bug; it should be called out in the commit message and covered by its own test.
+- No cross-crate surface: `quarto-navigation`'s `sidebar.rs` parses the shorthand; expansion lives entirely in `quarto-core`. WASM leg is in scope for `cargo xtask verify` (change is under `quarto-core`).

--- a/claude-notes/plans/sidebar-dir-index-md-investigation/RESULTS.md
+++ b/claude-notes/plans/sidebar-dir-index-md-investigation/RESULTS.md
@@ -51,6 +51,26 @@ filter (line 383). `.md` inputs are first-class in discovery
 (`FIXED_RENDERABLE = &["qmd", "md"]`, `crates/quarto-core/src/project/discovery.rs`),
 so the "only .qmd is discoverable" MVP comment is stale.
 
+## Post-fix verification (same day, after the stem-based fix)
+
+Re-ran the identical invocation after implementing stem-based index resolution
+in `section_for_dir`. Observed in `_site/guides/alpha.html`:
+
+```html
+<a href="index.html" class="sidebar-item-text sidebar-link">The Guides Landing Page</a>
+...
+<ul id="quarto-sidebar-section-0" ...>
+  <li>... <a href="alpha.html">Alpha Guide</a> ...</li>
+  <li>... <a href="beta.html">Beta Guide</a> ...</li>
+</ul>
+```
+
+Header promoted with href, landing page no longer a child — the Q1 shape.
+Output inspected directly (not inferred from exit status). The pagination
+symptom is covered at the entry-list level by the unit tests (prev/next is
+derived from the entry list downstream); the repro does not enable page
+navigation, matching the original minimal repro's scope.
+
 ## Repro contents
 
 `repro/`: website project, `sidebar.contents: guides`, `project.render` includes `**/*.md`;

--- a/claude-notes/plans/sidebar-dir-index-md-investigation/RESULTS.md
+++ b/claude-notes/plans/sidebar-dir-index-md-investigation/RESULTS.md
@@ -1,0 +1,58 @@
+# Investigation results — bd-sidebar-dir-index-md-5khf3lds
+
+**Date:** 2026-08-19, at `main` @ `f387bd68` (v0.24.0).
+
+## Invocation
+
+```
+cargo run --bin q2 -- render claude-notes/plans/sidebar-dir-index-md-investigation/repro
+# Rendered 4 of 4 files to .../repro/_site
+```
+
+Then inspected `_site/guides/alpha.html`'s `#quarto-sidebar`.
+
+## Observed (HEAD, buggy)
+
+```html
+<a class="sidebar-item-text sidebar-link text-start" data-bs-toggle="collapse"
+   data-bs-target="#quarto-sidebar-section-0" ...>Guides</a>
+...
+<ul id="quarto-sidebar-section-0" class="collapse list-unstyled sidebar-section depth1 show">
+  <li>... <a href="alpha.html">Alpha Guide</a> ...</li>
+  <li>... <a href="beta.html">Beta Guide</a> ...</li>
+  <li>... <a href="index.html">The Guides Landing Page</a> ...</li>  <!-- BUG: should be the header -->
+</ul>
+```
+
+Both symptoms in one render:
+
+1. Section header text is the capitalized directory name **"Guides"** with **no href**,
+   instead of the landing page's title "The Guides Landing Page" linking to `guides/index.html`.
+2. `guides/index.md` is **not excluded** from the child list — it appears as a third sibling,
+   which also shifts prev/next pagination (the landing page becomes an entry in the page order).
+
+## Expected (Q1 behavior, and q2's own behavior when the file is `index.qmd`)
+
+Section header "The Guides Landing Page" with `href="index.html"`, children exactly
+Alpha Guide and Beta Guide. Per the strand: renaming `guides/index.md` → `index.qmd`
+makes q2 match Q1 exactly (verified in the external repro at
+`/Users/cscheid/repos/github/cscheid/q2-connect-docs/llms-info/repros/sidebar-dir-shorthand-index-page/`).
+
+## Root cause (confirmed)
+
+`crates/quarto-core/src/transforms/sidebar_auto.rs:356`:
+
+```rust
+let index_src = format!("{}/index.qmd", dir);
+```
+
+drives both the header lookup (`index.lookup_by_source`, line 357) and the child-exclusion
+filter (line 383). `.md` inputs are first-class in discovery
+(`FIXED_RENDERABLE = &["qmd", "md"]`, `crates/quarto-core/src/project/discovery.rs`),
+so the "only .qmd is discoverable" MVP comment is stale.
+
+## Repro contents
+
+`repro/`: website project, `sidebar.contents: guides`, `project.render` includes `**/*.md`;
+`guides/index.md` (title "The Guides Landing Page"), `guides/alpha.qmd`, `guides/beta.qmd`.
+`_site/` output is gitignored; re-render to regenerate.

--- a/claude-notes/plans/sidebar-dir-index-md-investigation/repro/.gitignore
+++ b/claude-notes/plans/sidebar-dir-index-md-investigation/repro/.gitignore
@@ -1,0 +1,2 @@
+_site/
+.quarto/

--- a/claude-notes/plans/sidebar-dir-index-md-investigation/repro/_quarto.yml
+++ b/claude-notes/plans/sidebar-dir-index-md-investigation/repro/_quarto.yml
@@ -1,0 +1,10 @@
+project:
+  type: website
+  render:
+    - "**/*.qmd"
+    - "**/*.md"
+
+website:
+  title: "Sidebar dir-shorthand index.md repro"
+  sidebar:
+    contents: guides

--- a/claude-notes/plans/sidebar-dir-index-md-investigation/repro/guides/alpha.qmd
+++ b/claude-notes/plans/sidebar-dir-index-md-investigation/repro/guides/alpha.qmd
@@ -1,0 +1,5 @@
+---
+title: Alpha Guide
+---
+
+First guide.

--- a/claude-notes/plans/sidebar-dir-index-md-investigation/repro/guides/beta.qmd
+++ b/claude-notes/plans/sidebar-dir-index-md-investigation/repro/guides/beta.qmd
@@ -1,0 +1,5 @@
+---
+title: Beta Guide
+---
+
+Second guide.

--- a/claude-notes/plans/sidebar-dir-index-md-investigation/repro/guides/index.md
+++ b/claude-notes/plans/sidebar-dir-index-md-investigation/repro/guides/index.md
@@ -1,0 +1,5 @@
+---
+title: The Guides Landing Page
+---
+
+Landing page for the guides section. Note the `.md` extension.

--- a/claude-notes/plans/sidebar-dir-index-md-investigation/repro/index.qmd
+++ b/claude-notes/plans/sidebar-dir-index-md-investigation/repro/index.qmd
@@ -1,0 +1,5 @@
+---
+title: Home
+---
+
+Site landing page.

--- a/claude-notes/research/2026-08-19-draft-visibility-audit.md
+++ b/claude-notes/research/2026-08-19-draft-visibility-audit.md
@@ -1,0 +1,109 @@
+# Draft visibility in q2: audit of enforcement sites
+
+**Date:** 2026-08-19. Produced by a study agent during the
+bd-sidebar-dir-index-md-5khf3lds investigation, after the user asked whether
+q2 has a *structural* mechanism preventing draft pages from being linked, or
+whether each feature must remember to filter. Answer: **ad-hoc per-feature,
+and most features don't.** Follow-up strand: see "Recommendation" below.
+
+## Where the flag lives
+
+- `crates/quarto-core/src/document_profile.rs:444` — `pub draft: bool` on
+  `DocumentProfile`; set in exactly one place (`document_profile.rs:793`)
+  from front-matter/merged-metadata `draft: true` (strict bool, default
+  false).
+- q2 has **no** `website.drafts:` list and **no** `website.draft-mode:` key.
+  `crates/quarto-core/src/transforms/draft_alert.rs:70-77` records this:
+  every q2 draft is in Q1's `visible` mode (bd-w0o9 tracks the config
+  surface). The only schema hits for those keys are inert pampa test
+  fixtures copied from Q1.
+- Drafts are **always fully rendered** (asserted as intended in
+  `crates/quarto-core/tests/integration/llms_txt.rs:568`), get their
+  resources copied, and receive only a banner + `<meta
+  name="quarto:status" content="draft">` (`draft_alert.rs`,
+  `template.rs:271`). There is no Q1-style `draft-remove` post-processor.
+- The `_`/dot-prefix discovery exclusion
+  (`crates/quarto-core/src/project/discovery.rs:378`) is genuinely
+  structural but orthogonal: it makes files invisible to the whole
+  pipeline; `draft: true` does not.
+
+## Enforcement tally
+
+`ProjectIndex` (`crates/quarto-core/src/project/index.rs`) has **zero**
+draft-aware accessors (`new / profiles / lookup_by_source / lookup_by_href /
+is_empty / len`). Non-test code reads `.draft` on only **5 lines** in the
+workspace, in 3 subsystems:
+
+| file:line | what |
+|---|---|
+| `sidebar_auto.rs:219,228,246` | `.filter(\|p\| !p.draft)` per `AutoSpec` arm |
+| `aliases.rs:340` | `if profile.draft { continue }` in `plan_alias_stubs` |
+| `llms.rs:152` | `!profile.draft` inside `profile_has_companion` |
+
+Across the workspace: **25 `ProjectIndex` access sites; 6 apply a draft
+check, 19 do not.** Enumeration sites (10): filtered — `sidebar_auto.rs:214`,
+`llms_post_render.rs:121`, `website_post_render.rs:815`; unfiltered —
+`website_post_render.rs:513-514` (sitemap), `listing_generate.rs:184`
+(listings), `aliases.rs:527`, `project_resources.rs:901,1121`,
+`dependency_graph.rs:138,209`. Lookup sites (15): checked — `llms.rs:288`,
+`llms.rs:885`, `link_rewrite.rs:374` (all via `profile_has_companion`);
+unchecked — `sidebar_auto.rs:357` (fixed by
+bd-sidebar-dir-index-md-5khf3lds), `navigation_href.rs:184,354`,
+`sidebar_generate.rs:268`, `navigation_enrich.rs:57`,
+`llms_post_render.rs:443,605,608`, `website_canonical_url.rs:62`,
+`resource_report.rs:102`, `dependency_graph.rs:152,164`.
+
+The best-shaped existing piece is `profile_has_companion`
+(`llms.rs:145-156`) — "the single answer shared by capture, `link-format`
+resolution, and post-render so they can't drift" — the right shape, but
+scoped to llms companion eligibility, not linkability.
+
+## Live leak sites found
+
+1. **Auto-sidebar section header** — `sidebar_auto.rs:357` promoted a draft
+   `<dir>/index.qmd` to a linked, titled section header. *Fixed by
+   bd-sidebar-dir-index-md-5khf3lds* (index now resolved among the
+   draft-filtered members).
+2. **Breadcrumbs** — second-order from (1): `breadcrumbs_render.rs` walks
+   the resolved sidebar, so a leaked header reached the trail too.
+3. **Sitemap** — `website_post_render.rs:513-514` enumerates all profiles;
+   drafts get `<url><loc>` entries. Q1 gates this
+   (`website-sitemap.ts:176-178`). Tracked: **bd-4zdf**.
+4. **Listings / RSS** — `listing_generate.rs:184` has no draft check
+   anywhere in `project/listing/**`; feed items derive from listing items,
+   so drafts reach `index.xml`. Q1 filters
+   (`website-listing-read.ts:1106`). **No strand covered this** before the
+   centralization strand below.
+5. **Body / cross-document links** — `navigation_href.rs:354` +
+   `link_rewrite.rs` rewrite links to drafts normally; Q1 unlinks
+   (`website-utils.ts:100`). Tracked: **bd-p4sc**.
+6. **Explicit navbar/sidebar/footer items** — `navigation_href.rs:184`
+   resolves author-written nav hrefs with no check, and
+   `quarto_navigation::NavigationItem` has no `draft` field at all; Q1
+   carries `draft?: boolean` on the item and gates in the nav templates.
+7. **Enrichment** — `navigation_enrich.rs:57`, `sidebar_generate.rs:268`
+   pull a draft's title into nav labels (mild; author asked for the item).
+8. **llms.txt home metadata** — `llms_post_render.rs:443` reads
+   `lookup_by_href("index.html")` uncheckd for site title/description.
+9. **`warn_aliases_ignored`** (`aliases.rs:527`) — diagnostics-only.
+
+## Q1's mechanism shape (for comparison)
+
+Q1 is also per-feature at the call site, but factors the policy into shared
+predicates in `website-utils.ts` (`projectDraftMode` — default **`gone`**,
+forced `visible` under preview; `isDraftVisible`; `isProjectDraft`), and has
+two backstops q2 lacks: `resolveInputTarget` returns `{outputHref, draft}`
+so the bit travels with every resolution, and default `draft-mode: gone`
+empties leaked pages at post-process. q2's default is Q1's `visible` mode
+with none of the guards — strictest-content, weakest-enforcement corner.
+
+## Recommendation (acted on)
+
+Open a strand to centralize the policy: an `is_linkable` /
+`linkable_profiles()` surface on `ProjectIndex` in the shape of
+`profile_has_companion`, routed through every enumeration/lookup site; a
+`draft: bool` on `NavigationItem` for explicit nav entries; landed *before*
+bd-w0o9's `draft-mode` config so `visible`/`unlinked`/`gone` becomes one
+policy value read in one place; bd-p4sc and bd-4zdf become thin consumers.
+Include a guard test that no non-test code reads `.draft` outside the
+predicate.

--- a/crates/quarto-core/src/transforms/sidebar_auto.rs
+++ b/crates/quarto-core/src/transforms/sidebar_auto.rs
@@ -162,7 +162,7 @@ pub fn expand_spec(
     }
 
     match scope {
-        Scope::Grouped => group_with_subdirs(&candidates, index),
+        Scope::Grouped => group_with_subdirs(&candidates),
         Scope::Flat => flatten_as_links(&candidates),
     }
 }
@@ -310,7 +310,7 @@ fn is_top_level_index(profile: &DocumentProfile) -> bool {
 
 /// Group a candidate list into top-level links + per-subdir sections.
 /// Used for `auto: true`.
-fn group_with_subdirs(candidates: &[&DocumentProfile], index: &ProjectIndex) -> Vec<SidebarEntry> {
+fn group_with_subdirs(candidates: &[&DocumentProfile]) -> Vec<SidebarEntry> {
     // Partition: top-level files vs items grouped by their first path
     // component. Built as a `Vec<(dir_name, Vec<&Profile>)>` so
     // insertion order is preserved deterministically (independent of
@@ -344,17 +344,43 @@ fn group_with_subdirs(candidates: &[&DocumentProfile], index: &ProjectIndex) -> 
     // Then subdirectory sections.
     for (dir, mut members) in dir_groups {
         sort_profiles(&mut members);
-        out.push(section_for_dir(&dir, &members, index));
+        out.push(section_for_dir(&dir, &members));
     }
 
     out
 }
 
-fn section_for_dir(dir: &str, members: &[&DocumentProfile], index: &ProjectIndex) -> SidebarEntry {
-    // Find the directory's own `index.*` if present. Only `.qmd` is
-    // discoverable by Phase-1 project walking; that's fine for MVP.
-    let index_src = format!("{}/index.qmd", dir);
-    let index_profile = index.lookup_by_source(std::path::Path::new(&index_src));
+fn section_for_dir(dir: &str, members: &[&DocumentProfile]) -> SidebarEntry {
+    // Find the directory's own landing page among the members: a
+    // *direct* child `<dir>/index.<ext>`, matched by stem so any
+    // extension discovery admitted can win, with a fixed preference
+    // order (`.qmd` over `.md` over anything else, mirroring Q1's
+    // `engineValidExtensions()` probe order). Resolving among the
+    // members — not the whole `ProjectIndex` — keeps drafts out of the
+    // header. The stem match is case-sensitive on purpose:
+    // case-insensitive matching misbehaves across case-sensitive vs
+    // case-preserving filesystems (bd-sidebar-dir-index-md-5khf3lds).
+    let prefix = format!("{}/", dir);
+    let index_profile = members
+        .iter()
+        .filter(|p| {
+            source_fwd_slash(p)
+                .strip_prefix(&prefix)
+                .is_some_and(|rest| {
+                    !rest.contains('/')
+                        && std::path::Path::new(rest)
+                            .file_stem()
+                            .is_some_and(|stem| stem == "index")
+                })
+        })
+        .min_by_key(
+            |p| match p.source_path.extension().and_then(|e| e.to_str()) {
+                Some("qmd") => 0,
+                Some("md") => 1,
+                _ => 2,
+            },
+        )
+        .copied();
 
     let (text_cv, href) = match index_profile {
         Some(p) => {
@@ -364,7 +390,7 @@ fn section_for_dir(dir: &str, members: &[&DocumentProfile], index: &ProjectIndex
                     &title,
                     SourceInfo::generated(By::programmatic_config()),
                 )),
-                Some(index_src.clone()),
+                Some(source_fwd_slash(p)),
             )
         }
         None => (
@@ -376,11 +402,11 @@ fn section_for_dir(dir: &str, members: &[&DocumentProfile], index: &ProjectIndex
         ),
     };
 
-    // Exclude the index from the child list (it's already the section
-    // header's href).
+    // Exclude the promoted index from the child list (it's already the
+    // section header's href).
     let contents: Vec<SidebarEntry> = members
         .iter()
-        .filter(|p| source_fwd_slash(p) != index_src)
+        .filter(|p| href.as_deref() != Some(source_fwd_slash(p).as_str()))
         .map(|p| link_entry(p))
         .collect();
 
@@ -610,6 +636,218 @@ mod tests {
                 );
                 assert_eq!(href.as_deref(), Some("how-to/index.qmd"));
                 assert_eq!(contents.len(), 2, "index is the header, not a child");
+            }
+            other => panic!("expected Section, got {:?}", other),
+        }
+    }
+
+    /// bd-sidebar-dir-index-md-5khf3lds — the directory index is
+    /// resolved by stem, not by a hardcoded `.qmd` extension. An
+    /// `index.md` landing page (a first-class input when an explicit
+    /// `project.render` pattern admits it) is promoted to the section
+    /// header and excluded from the children, exactly like `index.qmd`.
+    #[test]
+    fn auto_bare_directory_section_uses_md_dir_index() {
+        let profiles = vec![
+            make_profile("guides/index.md", "The Guides Landing Page"),
+            make_profile("guides/alpha.qmd", "Alpha Guide"),
+            make_profile("guides/beta.qmd", "Beta Guide"),
+        ];
+        let index = ProjectIndex::new(profiles);
+        let mut diags = Vec::new();
+        let entries = expand_spec(&AutoSpec::Path("guides".to_string()), &index, &mut diags);
+        assert_eq!(entries.len(), 1);
+        match &entries[0] {
+            SidebarEntry::Section {
+                text,
+                href,
+                contents,
+                ..
+            } => {
+                assert_eq!(
+                    text.as_ref().unwrap().as_plain_text().as_deref(),
+                    Some("The Guides Landing Page"),
+                    "index.md title becomes the section header"
+                );
+                assert_eq!(href.as_deref(), Some("guides/index.md"));
+                assert_eq!(contents.len(), 2, "index.md is the header, not a child");
+                for entry in contents {
+                    match entry {
+                        SidebarEntry::Link { item, .. } => {
+                            let href = item.href.as_deref().unwrap();
+                            assert!(
+                                !href.ends_with("index.md"),
+                                "index.md leaked into children: {}",
+                                href
+                            );
+                        }
+                        other => panic!("expected Link, got {:?}", other),
+                    }
+                }
+            }
+            other => panic!("expected Section, got {:?}", other),
+        }
+    }
+
+    /// bd-sidebar-dir-index-md-5khf3lds — same promotion under
+    /// `auto: true` grouping, which shares `section_for_dir` with the
+    /// bare-directory shorthand.
+    #[test]
+    fn auto_all_promotes_md_dir_index() {
+        let profiles = vec![
+            make_profile("docs/index.md", "Docs Home"),
+            make_profile("docs/a.qmd", "A"),
+        ];
+        let index = ProjectIndex::new(profiles);
+        let mut diags = Vec::new();
+        let entries = expand_spec(&AutoSpec::All, &index, &mut diags);
+        assert_eq!(entries.len(), 1);
+        match &entries[0] {
+            SidebarEntry::Section {
+                text,
+                href,
+                contents,
+                ..
+            } => {
+                assert_eq!(
+                    text.as_ref().unwrap().as_plain_text().as_deref(),
+                    Some("Docs Home")
+                );
+                assert_eq!(href.as_deref(), Some("docs/index.md"));
+                assert_eq!(contents.len(), 1, "only a.qmd remains a child");
+            }
+            other => panic!("expected Section, got {:?}", other),
+        }
+    }
+
+    /// bd-sidebar-dir-index-md-5khf3lds — only a *direct* child
+    /// `index.*` is the directory's landing page. A nested
+    /// `docs/deep/index.md` must not be promoted to `docs`' header.
+    #[test]
+    fn auto_nested_index_is_not_promoted() {
+        let profiles = vec![
+            make_profile("docs/top.qmd", "Top"),
+            make_profile("docs/deep/index.md", "Deep Landing"),
+        ];
+        let index = ProjectIndex::new(profiles);
+        let mut diags = Vec::new();
+        let entries = expand_spec(&AutoSpec::Path("docs".to_string()), &index, &mut diags);
+        assert_eq!(entries.len(), 1);
+        match &entries[0] {
+            SidebarEntry::Section {
+                text,
+                href,
+                contents,
+                ..
+            } => {
+                assert_eq!(
+                    text.as_ref().unwrap().as_plain_text().as_deref(),
+                    Some("Docs"),
+                    "nested index.md does not name the section"
+                );
+                assert_eq!(href.as_deref(), None);
+                assert_eq!(contents.len(), 2, "nested index.md stays a child");
+            }
+            other => panic!("expected Section, got {:?}", other),
+        }
+    }
+
+    /// bd-sidebar-dir-index-md-5khf3lds — when a directory has both
+    /// `index.qmd` and `index.md`, the fixed preference order picks
+    /// `.qmd` (mirroring Q1's `engineValidExtensions()` probe order).
+    /// Only the *promoted* index is excluded from the children; the
+    /// losing index file stays listed. (Two same-stem indexes collide
+    /// on output anyway — this just keeps the loser visible rather
+    /// than silently hiding a document.)
+    #[test]
+    fn auto_dir_index_tie_break_prefers_qmd() {
+        let profiles = vec![
+            make_profile("guides/index.md", "MD Landing"),
+            make_profile("guides/index.qmd", "QMD Landing"),
+            make_profile("guides/a.qmd", "A"),
+        ];
+        let index = ProjectIndex::new(profiles);
+        let mut diags = Vec::new();
+        let entries = expand_spec(&AutoSpec::Path("guides".to_string()), &index, &mut diags);
+        assert_eq!(entries.len(), 1);
+        match &entries[0] {
+            SidebarEntry::Section {
+                text,
+                href,
+                contents,
+                ..
+            } => {
+                assert_eq!(
+                    text.as_ref().unwrap().as_plain_text().as_deref(),
+                    Some("QMD Landing")
+                );
+                assert_eq!(href.as_deref(), Some("guides/index.qmd"));
+                assert_eq!(contents.len(), 2, "a.qmd plus the losing index.md");
+            }
+            other => panic!("expected Section, got {:?}", other),
+        }
+    }
+
+    /// bd-sidebar-dir-index-md-5khf3lds — the index is resolved among
+    /// the *members* (draft-filtered candidates), not the whole
+    /// `ProjectIndex`, so a draft landing page is not promoted to a
+    /// linked section header.
+    #[test]
+    fn auto_draft_dir_index_is_not_promoted() {
+        let profiles = vec![
+            make_profile_draft("guides/index.qmd", "Draft Landing"),
+            make_profile("guides/a.qmd", "A"),
+        ];
+        let index = ProjectIndex::new(profiles);
+        let mut diags = Vec::new();
+        let entries = expand_spec(&AutoSpec::Path("guides".to_string()), &index, &mut diags);
+        assert_eq!(entries.len(), 1);
+        match &entries[0] {
+            SidebarEntry::Section {
+                text,
+                href,
+                contents,
+                ..
+            } => {
+                assert_eq!(
+                    text.as_ref().unwrap().as_plain_text().as_deref(),
+                    Some("Guides"),
+                    "draft index must not name the section"
+                );
+                assert_eq!(href.as_deref(), None, "draft index must not be linked");
+                assert_eq!(contents.len(), 1, "only a.qmd");
+            }
+            other => panic!("expected Section, got {:?}", other),
+        }
+    }
+
+    /// bd-sidebar-dir-index-md-5khf3lds — the stem match is
+    /// case-sensitive by design (case-insensitive matching misbehaves
+    /// across case-sensitive vs case-preserving filesystems). An
+    /// `Index.md` is an ordinary child, not the landing page.
+    #[test]
+    fn auto_dir_index_stem_match_is_case_sensitive() {
+        let profiles = vec![
+            make_profile("guides/Index.md", "Cased Landing"),
+            make_profile("guides/a.qmd", "A"),
+        ];
+        let index = ProjectIndex::new(profiles);
+        let mut diags = Vec::new();
+        let entries = expand_spec(&AutoSpec::Path("guides".to_string()), &index, &mut diags);
+        assert_eq!(entries.len(), 1);
+        match &entries[0] {
+            SidebarEntry::Section {
+                text,
+                href,
+                contents,
+                ..
+            } => {
+                assert_eq!(
+                    text.as_ref().unwrap().as_plain_text().as_deref(),
+                    Some("Guides")
+                );
+                assert_eq!(href.as_deref(), None);
+                assert_eq!(contents.len(), 2, "Index.md stays a child");
             }
             other => panic!("expected Section, got {:?}", other),
         }


### PR DESCRIPTION
## Summary

The sidebar `contents: <directory>` shorthand (and `auto: true` grouping) only recognized a directory's landing page when it was `index.qmd`: `section_for_dir` built the index path by string concatenation with a hardcoded extension. With an `index.md` landing page — a first-class input when an explicit `project.render` pattern admits it — the section header fell back to the capitalized directory name, and the landing page was listed as an ordinary child (also shifting prev/next pagination). Q1 promotes the landing page regardless of extension. Real-world hit: the Posit Connect docs (`contents: how-to`, all landing pages `.md`) — the last remaining sidebar differences in that 451-page port.

`section_for_dir` now resolves the landing page **by stem** among the draft-filtered members: any *direct* child `<dir>/index.<ext>`, preferring `.qmd` over `.md` over anything else (mirroring Q1's `engineValidExtensions()` probe order). The resolved source drives both the header title/href and the child-exclusion filter, so both symptoms are one fix.

Two deliberate semantic points (design-reviewed with @cscheid):

- The stem match is **case-sensitive** — case-insensitive matching misbehaves across case-sensitive vs case-preserving filesystems. The broader case-handling policy question is tracked as bd-0yp90370.
- Resolving among **members** (not the whole `ProjectIndex`) means a **draft** directory index is no longer promoted to a linked section header. The audit this prompted (drafts also leak into sitemap, listings/RSS, and body links) is committed at `claude-notes/research/2026-08-19-draft-visibility-audit.md` and tracked as bd-zeormbsa.

## Test plan

- Six new unit tests in `sidebar_auto.rs`; the three covering the bug (`index.md` promotion under both the shorthand and `auto: true`, draft-index non-promotion) were run and observed to **fail at HEAD before the fix** (TDD). The other three guard nesting depth, the `.qmd` > `.md` tie-break, and case sensitivity.
- Full workspace suite: 12,902 tests passed, zero `.snap` files changed.
- End-to-end: `cargo run --bin q2 -- render` on the committed repro (`claude-notes/plans/sidebar-dir-index-md-investigation/repro/`); inspected `_site/guides/alpha.html` — the section header is now `<a href="index.html">The Guides Landing Page</a>` with exactly the two guides as children. Pre/post render output recorded in the investigation `RESULTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)