### PR TITLE
Navbar logo: default styling, Q1 brand markup, and light/dark variants (bd-navbar-logo-unstyled-gbzd8vcu)

### DIFF
--- a/claude-notes/plans/2026-08-19-navbar-logo-brand-markup.md
+++ b/claude-notes/plans/2026-08-19-navbar-logo-brand-markup.md
@@ -116,14 +116,14 @@ Theme CSS + end-to-end (drive the real render path per repo policy):
 
 ### Phase 5 — End-to-end verification
 
-- [ ] Extend the investigation repro with a dark variant (`logo: {light: logo.svg, dark: logo-dark.svg}` + a dark theme) and re-render via `cargo run --bin q2 -- render …`.
-- [ ] Inspect: theme CSS has the rules; HTML has the new structure; both variant imgs present with correct classes; logo files copied to `_site`.
-- [ ] Browser eyeball (24px logo beside title; toggle flips variants). Record invocation + output snippet per repo policy.
-- [ ] Full workspace suite + `cargo xtask verify` (WASM leg — quarto-navigation feeds the preview path).
+- [x] Repro extended with a dark variant + `theme: {light: cosmo, dark: darkly}`; rendered via `cargo run --bin q2 -- render …`.
+- [x] Inspected: both compiled theme variants ship the rules; HTML has the full Q1 structure with the classed variant pair; both logo files copied. Evidence + snippets in the investigation NOTES.md.
+- [x] Browser eyeball (chrome-devtools MCP over a served `_site`): light logo at computed 24px beside the title, dark img `display:none`; toggle flips `body` to `quarto-dark` and swaps the pair. Screenshots inspected in both modes.
+- [x] Full `cargo xtask verify` (WASM + hub-client leg) passes. Two environment-only hiccups fixed along the way, unrelated to this change: stale `q2-preview-spa/dist` (regenerated, pre-flight) and a missing `@esbuild/darwin-arm64` optional dep in node_modules (installed; the hub-mcp bundle suite then passed).
 
 ### Phase 6 — Docs
 
-- [ ] Update the docs/ website's navbar documentation: logo shapes (string / `{path,alt}` / `{light,dark}` / `false`), default 24px sizing, and the CSS override hooks (`.navbar-brand-logo .navbar-logo { … }`) now matching Q1. Render docs/ with q2 to verify.
+- [x] New page `docs/guides/projects/navbar-logo.qmd` (logo shapes incl. `{light, dark}` and `false`, default 24px sizing, CSS override hooks), wired into the docs sidebar next to breadcrumbs.qmd. `q2 render docs/` succeeds (253/253; no warnings from the new page) and the page appears in the rendered sidebar.
 
 ## Strands
 

--- a/claude-notes/plans/2026-08-19-navbar-logo-brand-markup.md
+++ b/claude-notes/plans/2026-08-19-navbar-logo-brand-markup.md
@@ -81,12 +81,12 @@ Parsing (`navbar.rs` unit tests) — all landed, verified red (30 compile errors
 - [x] Round-trip serialization re-emits the authored shape (`logo_single_roundtrips_as_string_wire_shape`, `logo_variants_roundtrip_as_light_dark_map`).
 - [x] Each variant path carries its own `SourceInfo` (`logo_variant_sources_captured_and_round_tripped`).
 
-Markup (`render_html.rs` unit tests):
-- [ ] Logo + title → `navbar-brand-container` div wrapping a `navbar-brand navbar-brand-logo` anchor (img inside) + separate `navbar-brand` anchor with `navbar-title` span; both anchors href = `logo_href || home_url`.
-- [ ] Identical variants → **one** `<img class="navbar-logo">` (no variant class — deliberate deviation from Q1, which duplicates the img; behavior is identical because the pair is normalized).
-- [ ] Distinct variants → two imgs, `navbar-logo light-content` / `navbar-logo dark-content`.
-- [ ] Title-only → container + title anchor, no logo anchor. Logo-only → container + logo anchor, no title anchor. Neither → no brand at all (existing behavior).
-- [ ] `navbar_to_html` wrapper div carries `navbar-container container-fluid`.
+Markup (`render_html.rs` unit tests) — all landed, verified red (7 failing pre-implementation) then green:
+- [x] Logo + title → container + dual anchors + `navbar-title` span; shared href (`brand_emits_container_with_logo_and_title_anchors`, `brand_both_anchors_share_the_logo_href`).
+- [x] Identical variants → one unclassed `<img class="navbar-logo">` (`brand_single_logo_img_has_no_variant_class`).
+- [x] Distinct variants → `light-content`/`dark-content` img pair (`brand_distinct_variants_emit_light_and_dark_imgs`).
+- [x] Title-only / logo-only / neither (`brand_title_only_omits_logo_anchor`, `brand_logo_only_omits_title_anchor`; hidden-title test pre-existing).
+- [x] Wrapper carries `navbar-container container-fluid` (`navbar_wrapper_carries_navbar_container_class` + updated `navbar_wraps_body_in_container_fluid`).
 
 Theme CSS + end-to-end (drive the real render path per repo policy):
 - [x] Website render test asserting the compiled `quarto-theme-*.css` contains `.navbar-logo` with `max-height` (and `.navbar-brand-container`) — `pipeline_theme_css_ships_navbar_brand_rules` in `navbar_footer_pipeline.rs`; verified failing before the SCSS change, passing after.
@@ -104,8 +104,9 @@ Theme CSS + end-to-end (drive the real render path per repo policy):
 
 ### Phase 3 — Markup restructure
 
-- [ ] Rework `render_brand` to the Q1 container/dual-anchor shape (Phase 0 markup specs), single img when halves are identical, two variant-classed imgs otherwise.
-- [ ] Add `navbar-container` to the navbar wrapper div (line 84 only).
+- [x] Rework `render_brand` to the Q1 container/dual-anchor shape, single img when halves are identical, two variant-classed imgs otherwise.
+- [x] Add `navbar-container` to the navbar wrapper div (navbar only; footer/secondary-nav untouched).
+- [x] Existing-assertion churn: `navbar_with_title_and_left_items` (span shape), `navbar_wraps_body_in_container_fluid` (wrapper class), `shortcode_config_pipeline::plain_config_strings_unchanged` (`</span></a>` suffix). No `.snap` files reference the brand markup; full workspace suite green (12,915).
 
 ### Phase 4 — Downstream consumers
 

--- a/claude-notes/plans/2026-08-19-navbar-logo-brand-markup.md
+++ b/claude-notes/plans/2026-08-19-navbar-logo-brand-markup.md
@@ -3,40 +3,28 @@
 **Date:** 2026-08-19
 **Braid:** bd-navbar-logo-unstyled-gbzd8vcu
 **Checkout:** main @ `f387bd68` (investigation ran in the main checkout; no worktree created)
-**Status:** Investigation — pending design alignment with user. **Do not start implementation until the user gives the go-ahead.**
+**Status:** Plan finalized after design alignment with Carlos (2026-08-19). Awaiting go-ahead to implement.
 
-## Triage verdict
+## Design decisions (settled with Carlos, 2026-08-19)
 
-**Ready to design.** Both defects are confirmed at HEAD, the fix sites are localized and well understood (`render_brand` in `crates/quarto-navigation/src/render_html.rs` + the quarto-nav port region of `resources/scss/bootstrap/_bootstrap-rules.scss`), and the Q1 reference markup/CSS has been captured verbatim below. The remaining questions are scope choices (how much of Q1's brand-container CSS to port alongside the markup), not missing information.
+1. **Companion CSS:** port `.navbar-logo` sizing, the `.navbar-brand-container` layout rules (`min-width: 0; display: flex; align-items: center` + the `lg` `margin-right: 1em`), `.navbar-brand.navbar-brand-logo { margin-right: 4px; display: inline-flex }`, `.navbar-brand { overflow: hidden; text-overflow: ellipsis }`, and `.navbar-container { width: 100% }`. **Omit** the `max-width: calc(100% - 115px)` clamp for now — it reserves ~115px for the hamburger toggler + search icon so an over-wide brand truncates instead of pushing them off-screen on narrow viewports; it only bites in narrow-viewport layouts q2 hasn't fully ported, so it moves to the follow-up strand below.
+2. **Q1's navbar ordering system** (`$navbar-title-order` / `$navbar-toggler-order` `order:` rules + the `margin !important` pair): **skip here**. q2 already parses `navbar.toggle-position` into `Navbar::toggle_position` but nothing consumes it in SCSS. Follow-up strand filed: wire toggle-position into the ordering variables, port the `order:`/margin rules, and pick up the width clamp from (1). → **bd-navbar-ordering follow-up** (see § Strands).
+3. **`navbar-container` class:** add it — `navbar_to_html`'s wrapper (render_html.rs:84) becomes `class="navbar-container container-fluid"`. Only that site: the footer (line 183) and secondary-nav (line 315) `container-fluid` wrappers are different components, untouched.
+4. **Href fallback:** keep q2's relative `logo_href || home_url` fallback for **both** anchors (consistent with the root-relative-paths design, bd-root-relative-paths-design-fc5pvkcv). We adopt Q1's class hooks, not its absolute `/index.html` fallback.
+5. **Light/dark logo variants: in scope.** The light/dark epic (PR #537, bd-0pic6 phases A–E) already landed the machinery this needs: `body.quarto-light .dark-content { display: none !important }` / `body.quarto-dark .light-content { … }` ship in `resources/scss/bootstrap/dist/scss/_light-dark.scss`, the toggle syncs the body class, and `Navbar::dark_mode_toggle` already tells the navbar transform whether the format has a dark variant. So the logo work is config parsing + markup + asset copying — no new CSS machinery.
 
 ## Issue context
 
-Filed 2026-08-19 by Carlos (fresh — no staleness risk), type `bug`, priority 2, label `navigation`, status `open`. Origin strand `br-navbar-logo-unstyled-varhly4s` lives in the connect-docs porting skein (different skein; not resolvable here).
+Filed 2026-08-19 by Carlos, type `bug`, priority 2, label `navigation`. Origin strand `br-navbar-logo-unstyled-varhly4s` in the connect-docs porting skein. Real-world hit: Posit Connect docs render the Connect mark at full 512px SVG size in every page's navbar.
 
-A `website.navbar.logo` renders at the image's natural size — a 512px SVG swallows the navbar — instead of Q1's 24px logo beside the title. Two independent defects:
+Two defects, confirmed at HEAD via the committed repro (`claude-notes/plans/navbar-logo-brand-markup-investigation/`, NOTES.md has the evidence):
 
-1. **No default sizing rule.** Q1 ships `.navbar-logo { max-height: 24px; width: auto; padding-right: 4px }` (`quarto-cli src/resources/projects/website/navigation/quarto-nav.scss:196`). q2 emits `class="navbar-logo"` on the img but no stylesheet anywhere targets it.
-2. **Brand markup structure differs**, killing the Q1 user-CSS override path (`.navbar-brand-logo .navbar-logo { … }` selectors silently stop matching). Real-world hit: the Posit Connect docs.
+1. **No default sizing rule** — Q1 ships `.navbar-logo { max-height: 24px; width: auto; padding-right: 4px }` (`quarto-nav.scss:196`); q2's compiled theme CSS has zero `navbar-logo` occurrences.
+2. **Brand markup shape** — q2 inlines the img into the single title anchor; Q1's `navbar-brand-container` / `navbar-brand-logo` / `navbar-title` hooks (which user CSS keys on) are absent.
 
-## Dependency graph
+## Q1 reference (captured from external-sources/quarto-cli)
 
-**Empty in this skein** — `braid dep tree` shows only the strand itself; `braid dep list` shows no edges. The discovered-from context lives in the external connect-docs skein (`br-navbar-logo-unstyled-varhly4s`), summarized in the description. No incoming `blocks` pressure; urgency comes from the Connect-docs porting effort, not from other q2 strands.
-
-## What the code looks like today
-
-All paths in the description check out at HEAD (`f387bd68`):
-
-- **Markup emission:** `render_brand` at `crates/quarto-navigation/src/render_html.rs:497-543` inlines the logo img into the single title anchor:
-  ```html
-  <a class="navbar-brand" href="./"><img src="logo.svg" alt="…" class="navbar-logo"> Title</a>
-  ```
-  Called from `navbar_to_html` (line 87), inside a plain `<div class="container-fluid">` (line 84; Q1 uses `navbar-container container-fluid`).
-- **Navbar model:** `crates/quarto-navigation/src/navbar.rs:106-117` — `logo: Option<String>` + `logo_alt`/`logo_href` + paired `SourceInfo` fields. No light/dark variant support (Q1's `logo.light`/`logo.dark` normalizes richer YAML shapes).
-- **Styles:** `resources/scss/bootstrap/_bootstrap-rules.scss` is where Q1's `quarto-nav.scss` rules are ported piecemeal, each with a Q1 source-line comment (e.g. lines 353, 412, 478, 572; navbar block at ~2377). **No `.navbar-logo`, `.navbar-brand-container`, or `.navbar-brand-logo` rule exists anywhere in `crates/` or `resources/`** — the only `navbar-logo` hits are tests asserting the img tag is emitted, plus the logo-copy machinery (`copy_navbar_logo` in `website_post_render.rs`, href rebasing in `navbar_render.rs` / `metadata_path_resolution.rs`), which is orthogonal and works.
-
-### Q1 reference (captured from external-sources/quarto-cli)
-
-`navbrand.ejs` — the target markup shape:
+### Markup (`navbrand.ejs`)
 
 ```html
 <div class="navbar-brand-container mx-auto">
@@ -50,56 +38,100 @@ All paths in the description check out at HEAD (`f387bd68`):
 </div>
 ```
 
-Notable deltas vs. q2 today: separate logo anchor with hook classes; title wrapped in `<span class="navbar-title">` (q2 emits no such span); container div with `mx-auto`; **Q1's title anchor href is `logo-href || '/index.html'`** while q2 falls back to `home_url` (relative `./`-style). q2's relative-href behavior is arguably better (root-relative-paths work, bd-root-relative-paths-design-fc5pvkcv); the fallback semantics need a decision, not blind copying.
-
-`quarto-nav.scss` — CSS that accompanies the structure (lines 116-170 + 196):
+### CSS (`quarto-nav.scss:116-170, 196`)
 
 ```scss
 .navbar-container { width: 100%; }
 .navbar-brand { overflow: hidden; text-overflow: ellipsis; }
 .navbar-brand-container {
-  max-width: calc(100% - 115px);
+  max-width: calc(100% - 115px);      // OMITTED here → follow-up strand
   min-width: 0;
   display: flex;
   align-items: center;
   @include media-breakpoint-up(lg) { margin-right: 1em; }
 }
 .navbar-brand.navbar-brand-logo { margin-right: 4px; display: inline-flex; }
-.navbar .navbar-brand-container { order: $navbar-title-order; }
-.navbar .navbar-container > .navbar-brand-container { margin-left: 0 !important; margin-right: 0 !important; }
+// order:/margin-!important rules → follow-up strand
 .navbar-logo { max-height: 24px; width: auto; padding-right: 4px; }
 ```
 
-(The `order:` rules belong to Q1's navbar-component ordering system — `$navbar-title-order` etc. — which q2 has not ported; probably out of scope.)
+### Logo-spec semantics (`definitions.yml` `logo-light-dark-specifier`, `brand.ts::resolveLogo`, `website-shared.ts:136-150`)
 
-### Repro at HEAD
+Q1 accepts `logo:` as `false` | string | `{path, alt}` | `{light: <string|{path,alt}>, dark: <string|{path,alt}>}`; a bare string can also name a brand.yml logo resource, and an absent `logo:` falls back to brand logos (`small`→`medium`→`large`). Normalization always produces a `{light, dark}` pair: string/`{path,alt}` fill both halves; with `{light, dark}`, a missing light falls back to dark unconditionally, and a missing dark falls back to light when a dark brand exists. Top-level `logo-alt` is folded into the string form as `{path, alt}`.
 
-Local fixture: `claude-notes/plans/navbar-logo-brand-markup-investigation/repro/` (mirrors the strand's external repro at `~/repos/github/cscheid/q2-connect-docs/llms-info/repros/navbar-logo-unstyled/`). Render with `cargo run --bin q2 -- render <fixture-dir>`; confirm via grep that the generated `site_libs/quarto/quarto-theme-*.css` has no `navbar-logo` rule and the HTML has the inlined-img brand shape. (Confirmed at f387bd68 — see investigation notes.)
+**q2 scope:** the `false` / string / `{path, alt}` / `{light, dark}` shapes with cross-fallback between variants. Brand.yml logo-name indirection and the no-logo→brand fallback are **out of scope** (related: bd-v5z8w, which tracks wiring brand light/dark generally).
 
-## Proposed phases (draft)
+## What the code looks like today
 
-Skeleton only — actual phase contents wait on the design discussion.
+- `crates/quarto-navigation/src/navbar.rs:106-117` — `logo: Option<String>` + `logo_alt` + `logo_href`, each path paired with a `SourceInfo` (`logo_source`, `logo_href_source`) so the path resolver knows the authoring file. Parsing at lines 181-193 (`as_plain_text()`); config round-trip serialization at ~275-310.
+- `crates/quarto-navigation/src/render_html.rs:497-543` — `render_brand` builds the single-anchor markup; called from `navbar_to_html` at line 87 inside the line-84 `container-fluid` div.
+- Consumers of `navbar.logo` downstream: `copy_navbar_logo` (`quarto-core/src/project/website_post_render.rs:128`) copies the logo file into `_site`; `NavbarRenderTransform` (`quarto-core/src/transforms/navbar_render.rs`) rebases the logo src per page; `metadata_path_resolution` tests pin the authoring-dir resolution behavior via `logo_source`.
+- Light/dark infra (from the epic): `_light-dark.scss` content rules; `compile_theme_css.rs` dual-variant compile + `quarto-color-scheme` link attributes; `template.rs:955-975` appends `quarto-light`/`quarto-dark` body class; `Navbar::dark_mode_toggle` set by `NavbarGenerateTransform` when the format has a dark variant.
 
-- **Phase 0 — Test plan (TDD).** Failing tests first:
-  - `render_html.rs` unit tests asserting the new brand markup shape (container div, separate `navbar-brand-logo` anchor, `navbar-title` span, logo+title / logo-only / title-only / neither cases).
-  - An end-to-end website render test asserting the compiled theme CSS contains a `.navbar-logo` `max-height` rule (route through the real render path per end-to-end policy).
-  - Inventory of existing assertions that will need updating: `render_html.rs:1236-1294` unit tests, `navbar_render.rs:872-984`, `shortcode_config_pipeline.rs` (4 sites), `navbar_footer_pipeline.rs`, `metadata_path_resolution.rs`, plus any HTML snapshots containing `navbar-brand`.
-- **Phase 1 — SCSS default rules.** Add `.navbar-logo` sizing + the brand-container/brand-logo companion rules to the quarto-nav port region of `_bootstrap-rules.scss`, with Q1 source-line comments per house style.
-- **Phase 2 — Brand markup restructure.** Rework `render_brand` to emit Q1's container + dual-anchor shape; update `navbar_to_html` container class if we adopt `navbar-container` (design question 3).
-- **Phase 3 — End-to-end verification.** Render the investigation fixture, inspect HTML + theme CSS, record invocation + output snippet per repo policy; ideally eyeball in a browser.
-- **Phase 4 — Docs.** Check `docs/` website navbar-logo docs mention the override hooks; note light/dark variant follow-up strand.
+## Phases
 
-## Open design questions for the user
+### Phase 0 — Test plan (TDD: failing tests first)
 
-1. **How much companion CSS to port?** Just `.navbar-logo` + the minimal `.navbar-brand-container` / `.navbar-brand.navbar-brand-logo` rules that make the new structure lay out correctly — or also `.navbar-brand { overflow: hidden; text-overflow: ellipsis }`, `.navbar-container { width: 100% }`, and the `max-width: calc(100% - 115px)` clamp? (The clamp interacts with search/tools q2 may not render the same way.)
-2. **Q1's navbar-ordering system (`$navbar-title-order` etc.)** governs the `order:`/`margin !important` rules on `.navbar-brand-container`. Port those two rules verbatim, or skip the ordering system entirely for now (my lean: skip; q2 has no toggle-position option)?
-3. **`navbar-container` class:** q2 emits bare `container-fluid`; Q1 emits `navbar-container container-fluid` and user CSS may key on it too. Add it in the same change (my lean: yes, it's one string) or keep scope to the brand?
-4. **Title-anchor href fallback:** Q1 uses `logo-href || '/index.html'` for *both* anchors; q2 currently uses `logo_href || home_url` (relative). Keep q2's relative fallback for both anchors (my lean: yes — consistent with the root-relative-paths design), matching Q1's class hooks but not its absolute-path fallback?
-5. **Light/dark logo variants (`logo.light`/`logo.dark`, `light-content`/`dark-content` imgs):** the strand suggests deferring to general dark-mode support. File a follow-up strand linked `related`, and emit a single variant-less `<img class="navbar-logo">` inside the new anchor for now?
+Parsing (`navbar.rs` unit tests):
+- [ ] `logo: path.svg` → single variant pair with identical halves; `logo_alt` fills alt.
+- [ ] `logo: {path: p, alt: a}` → both halves get `p`/`a`.
+- [ ] `logo: {light: l.svg, dark: d.svg}` → distinct halves; per-variant `{path, alt}` objects honored; per-variant alt wins over top-level `logo-alt`.
+- [ ] `logo: {light: l.svg}` → dark falls back to light (and the mirror case).
+- [ ] `logo: false` → no logo, no error.
+- [ ] Round-trip serialization re-emits the authored shape (string stays string; distinct variants re-emit `{light, dark}`).
+- [ ] Each variant path carries its own `SourceInfo`.
 
-## Risks / tradeoffs (draft)
+Markup (`render_html.rs` unit tests):
+- [ ] Logo + title → `navbar-brand-container` div wrapping a `navbar-brand navbar-brand-logo` anchor (img inside) + separate `navbar-brand` anchor with `navbar-title` span; both anchors href = `logo_href || home_url`.
+- [ ] Identical variants → **one** `<img class="navbar-logo">` (no variant class — deliberate deviation from Q1, which duplicates the img; behavior is identical because the pair is normalized).
+- [ ] Distinct variants → two imgs, `navbar-logo light-content` / `navbar-logo dark-content`.
+- [ ] Title-only → container + title anchor, no logo anchor. Logo-only → container + logo anchor, no title anchor. Neither → no brand at all (existing behavior).
+- [ ] `navbar_to_html` wrapper div carries `navbar-container container-fluid`.
 
-- **Snapshot/test churn:** every test asserting `<a class="navbar-brand" href="…">Title</a>` breaks; the inventory above looks complete but a workspace-wide grep after the change is mandatory.
-- **`mx-auto` on the container** centers the brand when the navbar has free space; combined with q2's possibly-different navbar flex layout (no ported ordering rules) this could visibly move the title. Phase 3's browser eyeball is the guard.
-- **Preview parity:** the SPA preview path renders navbars through the same `quarto-navigation` code, but theme CSS delivery differs — verify preview picks up the new rules (and remember the WASM rebuild chain if checking via `q2 preview`).
-- Defect 1 alone (the SCSS rule) already fixes the "512px logo swallows the navbar" symptom; defect 2 is what un-breaks user overrides. If we want a minimal ship, Phase 1 is independently landable.
+Theme CSS + end-to-end (drive the real render path per repo policy):
+- [ ] Website render test asserting the compiled `quarto-theme-*.css` contains `.navbar-logo` with `max-height` (and `.navbar-brand-container`).
+- [ ] Existing-assertion inventory to update: `render_html.rs:1236-1294`, `navbar_render.rs:872-984`, `shortcode_config_pipeline.rs` (4 sites), `navbar_footer_pipeline.rs`, `metadata_path_resolution.rs:212-248`, plus a workspace-wide grep for `navbar-brand` in `.snap` files after the change.
+
+### Phase 1 — SCSS default rules
+
+- [ ] Add the decided rule set (§ decisions 1) to the quarto-nav port region of `resources/scss/bootstrap/_bootstrap-rules.scss`, each with a Q1 source-line comment per house style; note the clamp + order rules as deliberately deferred (follow-up strand id in the comment).
+
+### Phase 2 — Logo variant model
+
+- [ ] Replace `Navbar::logo: Option<String>` (+ `logo_source`) with a normalized variant pair, e.g. `logo: Option<NavbarLogo>` where `NavbarLogo { light: LogoVariant, dark: LogoVariant }`, `LogoVariant { path: String, alt: Option<String>, source: SourceInfo }`; keep `logo_alt` parsing folding into variants that lack alt.
+- [ ] Parsing per Phase 0 specs; round-trip serialization preserves authored shape.
+
+### Phase 3 — Markup restructure
+
+- [ ] Rework `render_brand` to the Q1 container/dual-anchor shape (Phase 0 markup specs), single img when halves are identical, two variant-classed imgs otherwise.
+- [ ] Add `navbar-container` to the navbar wrapper div (line 84 only).
+
+### Phase 4 — Downstream consumers
+
+- [ ] `copy_navbar_logo`: copy each distinct variant file (dedupe identical paths).
+- [ ] `NavbarRenderTransform` src rebasing + authoring-dir resolution: operate per-variant using each variant's `SourceInfo`.
+- [ ] Sweep remaining `navbar.logo` consumers (`grep -rn '\.logo' crates/quarto-core/src crates/quarto-navigation/src`).
+
+### Phase 5 — End-to-end verification
+
+- [ ] Extend the investigation repro with a dark variant (`logo: {light: logo.svg, dark: logo-dark.svg}` + a dark theme) and re-render via `cargo run --bin q2 -- render …`.
+- [ ] Inspect: theme CSS has the rules; HTML has the new structure; both variant imgs present with correct classes; logo files copied to `_site`.
+- [ ] Browser eyeball (24px logo beside title; toggle flips variants). Record invocation + output snippet per repo policy.
+- [ ] Full workspace suite + `cargo xtask verify` (WASM leg — quarto-navigation feeds the preview path).
+
+### Phase 6 — Docs
+
+- [ ] Update the docs/ website's navbar documentation: logo shapes (string / `{path,alt}` / `{light,dark}` / `false`), default 24px sizing, and the CSS override hooks (`.navbar-brand-logo .navbar-logo { … }`) now matching Q1. Render docs/ with q2 to verify.
+
+## Strands
+
+- This plan: bd-navbar-logo-unstyled-gbzd8vcu (in_progress).
+- Follow-up **bd-y5y10oir** (filed at plan finalization, discovered-from this strand): navbar ordering system — wire `toggle-position` into `$navbar-title-order`/`$navbar-toggler-order` SCSS, port the `order:`/`margin !important` rules and the `.navbar-brand-container` width clamp.
+- Related, not touched: bd-v5z8w (brand light/dark wiring — brand-logo indirection/fallback lands there or after it), bd-l1rx9yzh (light/dark-content CSS port — appears already delivered by the epic's `_light-dark.scss`; flagged to Carlos for close).
+
+## Risks / tradeoffs
+
+- **Test/snapshot churn** across every `navbar-brand` assertion — inventory in Phase 0; workspace-wide grep mandatory before declaring done.
+- **`mx-auto` on the container** centers the brand when the navbar has free space; without Q1's ordering rules the flex layout could visibly shift the title. Phase 5's browser eyeball is the guard; the ordering follow-up is the durable fix.
+- **Model change ripples**: `Navbar::logo` type change touches quarto-core transforms and the WASM/preview path — full `cargo xtask verify` (not just `--skip-hub-build`) required before commit.
+- **Single-img deviation** from Q1's always-two-imgs markup: user CSS keying on `.light-content` specifically won't match single-logo sites; keying on `.navbar-logo`/`.navbar-brand-logo` (the documented hooks) works. Accepted.

--- a/claude-notes/plans/2026-08-19-navbar-logo-brand-markup.md
+++ b/claude-notes/plans/2026-08-19-navbar-logo-brand-markup.md
@@ -1,0 +1,105 @@
+# Navbar logo unstyled: theme ships no `.navbar-logo` rule and brand markup drops Q1's `navbar-brand-logo` structure (bd-navbar-logo-unstyled-gbzd8vcu)
+
+**Date:** 2026-08-19
+**Braid:** bd-navbar-logo-unstyled-gbzd8vcu
+**Checkout:** main @ `f387bd68` (investigation ran in the main checkout; no worktree created)
+**Status:** Investigation — pending design alignment with user. **Do not start implementation until the user gives the go-ahead.**
+
+## Triage verdict
+
+**Ready to design.** Both defects are confirmed at HEAD, the fix sites are localized and well understood (`render_brand` in `crates/quarto-navigation/src/render_html.rs` + the quarto-nav port region of `resources/scss/bootstrap/_bootstrap-rules.scss`), and the Q1 reference markup/CSS has been captured verbatim below. The remaining questions are scope choices (how much of Q1's brand-container CSS to port alongside the markup), not missing information.
+
+## Issue context
+
+Filed 2026-08-19 by Carlos (fresh — no staleness risk), type `bug`, priority 2, label `navigation`, status `open`. Origin strand `br-navbar-logo-unstyled-varhly4s` lives in the connect-docs porting skein (different skein; not resolvable here).
+
+A `website.navbar.logo` renders at the image's natural size — a 512px SVG swallows the navbar — instead of Q1's 24px logo beside the title. Two independent defects:
+
+1. **No default sizing rule.** Q1 ships `.navbar-logo { max-height: 24px; width: auto; padding-right: 4px }` (`quarto-cli src/resources/projects/website/navigation/quarto-nav.scss:196`). q2 emits `class="navbar-logo"` on the img but no stylesheet anywhere targets it.
+2. **Brand markup structure differs**, killing the Q1 user-CSS override path (`.navbar-brand-logo .navbar-logo { … }` selectors silently stop matching). Real-world hit: the Posit Connect docs.
+
+## Dependency graph
+
+**Empty in this skein** — `braid dep tree` shows only the strand itself; `braid dep list` shows no edges. The discovered-from context lives in the external connect-docs skein (`br-navbar-logo-unstyled-varhly4s`), summarized in the description. No incoming `blocks` pressure; urgency comes from the Connect-docs porting effort, not from other q2 strands.
+
+## What the code looks like today
+
+All paths in the description check out at HEAD (`f387bd68`):
+
+- **Markup emission:** `render_brand` at `crates/quarto-navigation/src/render_html.rs:497-543` inlines the logo img into the single title anchor:
+  ```html
+  <a class="navbar-brand" href="./"><img src="logo.svg" alt="…" class="navbar-logo"> Title</a>
+  ```
+  Called from `navbar_to_html` (line 87), inside a plain `<div class="container-fluid">` (line 84; Q1 uses `navbar-container container-fluid`).
+- **Navbar model:** `crates/quarto-navigation/src/navbar.rs:106-117` — `logo: Option<String>` + `logo_alt`/`logo_href` + paired `SourceInfo` fields. No light/dark variant support (Q1's `logo.light`/`logo.dark` normalizes richer YAML shapes).
+- **Styles:** `resources/scss/bootstrap/_bootstrap-rules.scss` is where Q1's `quarto-nav.scss` rules are ported piecemeal, each with a Q1 source-line comment (e.g. lines 353, 412, 478, 572; navbar block at ~2377). **No `.navbar-logo`, `.navbar-brand-container`, or `.navbar-brand-logo` rule exists anywhere in `crates/` or `resources/`** — the only `navbar-logo` hits are tests asserting the img tag is emitted, plus the logo-copy machinery (`copy_navbar_logo` in `website_post_render.rs`, href rebasing in `navbar_render.rs` / `metadata_path_resolution.rs`), which is orthogonal and works.
+
+### Q1 reference (captured from external-sources/quarto-cli)
+
+`navbrand.ejs` — the target markup shape:
+
+```html
+<div class="navbar-brand-container mx-auto">
+  <a href="{logo-href || '/index.html'}" class="navbar-brand navbar-brand-logo">
+    <img src="…" alt="…" class="navbar-logo light-content" />
+    <img src="…" alt="…" class="navbar-logo dark-content" />   <!-- only with dark variant -->
+  </a>
+  <a class="navbar-brand" href="{logo-href || '/index.html'}">
+    <span class="navbar-title">{title}</span>
+  </a>
+</div>
+```
+
+Notable deltas vs. q2 today: separate logo anchor with hook classes; title wrapped in `<span class="navbar-title">` (q2 emits no such span); container div with `mx-auto`; **Q1's title anchor href is `logo-href || '/index.html'`** while q2 falls back to `home_url` (relative `./`-style). q2's relative-href behavior is arguably better (root-relative-paths work, bd-root-relative-paths-design-fc5pvkcv); the fallback semantics need a decision, not blind copying.
+
+`quarto-nav.scss` — CSS that accompanies the structure (lines 116-170 + 196):
+
+```scss
+.navbar-container { width: 100%; }
+.navbar-brand { overflow: hidden; text-overflow: ellipsis; }
+.navbar-brand-container {
+  max-width: calc(100% - 115px);
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  @include media-breakpoint-up(lg) { margin-right: 1em; }
+}
+.navbar-brand.navbar-brand-logo { margin-right: 4px; display: inline-flex; }
+.navbar .navbar-brand-container { order: $navbar-title-order; }
+.navbar .navbar-container > .navbar-brand-container { margin-left: 0 !important; margin-right: 0 !important; }
+.navbar-logo { max-height: 24px; width: auto; padding-right: 4px; }
+```
+
+(The `order:` rules belong to Q1's navbar-component ordering system — `$navbar-title-order` etc. — which q2 has not ported; probably out of scope.)
+
+### Repro at HEAD
+
+Local fixture: `claude-notes/plans/navbar-logo-brand-markup-investigation/repro/` (mirrors the strand's external repro at `~/repos/github/cscheid/q2-connect-docs/llms-info/repros/navbar-logo-unstyled/`). Render with `cargo run --bin q2 -- render <fixture-dir>`; confirm via grep that the generated `site_libs/quarto/quarto-theme-*.css` has no `navbar-logo` rule and the HTML has the inlined-img brand shape. (Confirmed at f387bd68 — see investigation notes.)
+
+## Proposed phases (draft)
+
+Skeleton only — actual phase contents wait on the design discussion.
+
+- **Phase 0 — Test plan (TDD).** Failing tests first:
+  - `render_html.rs` unit tests asserting the new brand markup shape (container div, separate `navbar-brand-logo` anchor, `navbar-title` span, logo+title / logo-only / title-only / neither cases).
+  - An end-to-end website render test asserting the compiled theme CSS contains a `.navbar-logo` `max-height` rule (route through the real render path per end-to-end policy).
+  - Inventory of existing assertions that will need updating: `render_html.rs:1236-1294` unit tests, `navbar_render.rs:872-984`, `shortcode_config_pipeline.rs` (4 sites), `navbar_footer_pipeline.rs`, `metadata_path_resolution.rs`, plus any HTML snapshots containing `navbar-brand`.
+- **Phase 1 — SCSS default rules.** Add `.navbar-logo` sizing + the brand-container/brand-logo companion rules to the quarto-nav port region of `_bootstrap-rules.scss`, with Q1 source-line comments per house style.
+- **Phase 2 — Brand markup restructure.** Rework `render_brand` to emit Q1's container + dual-anchor shape; update `navbar_to_html` container class if we adopt `navbar-container` (design question 3).
+- **Phase 3 — End-to-end verification.** Render the investigation fixture, inspect HTML + theme CSS, record invocation + output snippet per repo policy; ideally eyeball in a browser.
+- **Phase 4 — Docs.** Check `docs/` website navbar-logo docs mention the override hooks; note light/dark variant follow-up strand.
+
+## Open design questions for the user
+
+1. **How much companion CSS to port?** Just `.navbar-logo` + the minimal `.navbar-brand-container` / `.navbar-brand.navbar-brand-logo` rules that make the new structure lay out correctly — or also `.navbar-brand { overflow: hidden; text-overflow: ellipsis }`, `.navbar-container { width: 100% }`, and the `max-width: calc(100% - 115px)` clamp? (The clamp interacts with search/tools q2 may not render the same way.)
+2. **Q1's navbar-ordering system (`$navbar-title-order` etc.)** governs the `order:`/`margin !important` rules on `.navbar-brand-container`. Port those two rules verbatim, or skip the ordering system entirely for now (my lean: skip; q2 has no toggle-position option)?
+3. **`navbar-container` class:** q2 emits bare `container-fluid`; Q1 emits `navbar-container container-fluid` and user CSS may key on it too. Add it in the same change (my lean: yes, it's one string) or keep scope to the brand?
+4. **Title-anchor href fallback:** Q1 uses `logo-href || '/index.html'` for *both* anchors; q2 currently uses `logo_href || home_url` (relative). Keep q2's relative fallback for both anchors (my lean: yes — consistent with the root-relative-paths design), matching Q1's class hooks but not its absolute-path fallback?
+5. **Light/dark logo variants (`logo.light`/`logo.dark`, `light-content`/`dark-content` imgs):** the strand suggests deferring to general dark-mode support. File a follow-up strand linked `related`, and emit a single variant-less `<img class="navbar-logo">` inside the new anchor for now?
+
+## Risks / tradeoffs (draft)
+
+- **Snapshot/test churn:** every test asserting `<a class="navbar-brand" href="…">Title</a>` breaks; the inventory above looks complete but a workspace-wide grep after the change is mandatory.
+- **`mx-auto` on the container** centers the brand when the navbar has free space; combined with q2's possibly-different navbar flex layout (no ported ordering rules) this could visibly move the title. Phase 3's browser eyeball is the guard.
+- **Preview parity:** the SPA preview path renders navbars through the same `quarto-navigation` code, but theme CSS delivery differs — verify preview picks up the new rules (and remember the WASM rebuild chain if checking via `q2 preview`).
+- Defect 1 alone (the SCSS rule) already fixes the "512px logo swallows the navbar" symptom; defect 2 is what un-breaks user overrides. If we want a minimal ship, Phase 1 is independently landable.

--- a/claude-notes/plans/2026-08-19-navbar-logo-brand-markup.md
+++ b/claude-notes/plans/2026-08-19-navbar-logo-brand-markup.md
@@ -89,12 +89,12 @@ Markup (`render_html.rs` unit tests):
 - [ ] `navbar_to_html` wrapper div carries `navbar-container container-fluid`.
 
 Theme CSS + end-to-end (drive the real render path per repo policy):
-- [ ] Website render test asserting the compiled `quarto-theme-*.css` contains `.navbar-logo` with `max-height` (and `.navbar-brand-container`).
+- [x] Website render test asserting the compiled `quarto-theme-*.css` contains `.navbar-logo` with `max-height` (and `.navbar-brand-container`) — `pipeline_theme_css_ships_navbar_brand_rules` in `navbar_footer_pipeline.rs`; verified failing before the SCSS change, passing after.
 - [ ] Existing-assertion inventory to update: `render_html.rs:1236-1294`, `navbar_render.rs:872-984`, `shortcode_config_pipeline.rs` (4 sites), `navbar_footer_pipeline.rs`, `metadata_path_resolution.rs:212-248`, plus a workspace-wide grep for `navbar-brand` in `.snap` files after the change.
 
 ### Phase 1 — SCSS default rules
 
-- [ ] Add the decided rule set (§ decisions 1) to the quarto-nav port region of `resources/scss/bootstrap/_bootstrap-rules.scss`, each with a Q1 source-line comment per house style; note the clamp + order rules as deliberately deferred (follow-up strand id in the comment).
+- [x] Add the decided rule set (§ decisions 1) to the quarto-nav port region of `resources/scss/bootstrap/_bootstrap-rules.scss`, each with a Q1 source-line comment per house style; note the clamp + order rules as deliberately deferred (follow-up strand id in the comment). Placed next to the existing `.navbar` block; `quarto-sass` theme-compile suite green.
 
 ### Phase 2 — Logo variant model
 

--- a/claude-notes/plans/2026-08-19-navbar-logo-brand-markup.md
+++ b/claude-notes/plans/2026-08-19-navbar-logo-brand-markup.md
@@ -72,14 +72,14 @@ Q1 accepts `logo:` as `false` | string | `{path, alt}` | `{light: <string|{path,
 
 ### Phase 0 — Test plan (TDD: failing tests first)
 
-Parsing (`navbar.rs` unit tests):
-- [ ] `logo: path.svg` → single variant pair with identical halves; `logo_alt` fills alt.
-- [ ] `logo: {path: p, alt: a}` → both halves get `p`/`a`.
-- [ ] `logo: {light: l.svg, dark: d.svg}` → distinct halves; per-variant `{path, alt}` objects honored; per-variant alt wins over top-level `logo-alt`.
-- [ ] `logo: {light: l.svg}` → dark falls back to light (and the mirror case).
-- [ ] `logo: false` → no logo, no error.
-- [ ] Round-trip serialization re-emits the authored shape (string stays string; distinct variants re-emit `{light, dark}`).
-- [ ] Each variant path carries its own `SourceInfo`.
+Parsing (`navbar.rs` unit tests) — all landed, verified red (30 compile errors pre-model) then green:
+- [x] `logo: path.svg` → single variant pair with identical halves; `logo_alt` fills alt (`logo_string_parses_as_single_pair`).
+- [x] `logo: {path: p, alt: a}` → both halves get `p`/`a` (`logo_path_alt_object_parses_as_single_pair`; `logo_object_alt_wins_over_logo_alt_key`).
+- [x] `logo: {light: l.svg, dark: d.svg}` → distinct halves; per-variant `{path, alt}` objects honored; per-variant alt wins over top-level `logo-alt` (`logo_light_dark_distinct_variants`).
+- [x] `logo: {light: l.svg}` → dark falls back to light (and the mirror case) (`logo_light_only_falls_back_to_dark` / `logo_dark_only_falls_back_to_light`).
+- [x] `logo: false` → no logo, no error (`logo_false_is_none`; plus `logo_empty_map_is_none`).
+- [x] Round-trip serialization re-emits the authored shape (`logo_single_roundtrips_as_string_wire_shape`, `logo_variants_roundtrip_as_light_dark_map`).
+- [x] Each variant path carries its own `SourceInfo` (`logo_variant_sources_captured_and_round_tripped`).
 
 Markup (`render_html.rs` unit tests):
 - [ ] Logo + title → `navbar-brand-container` div wrapping a `navbar-brand navbar-brand-logo` anchor (img inside) + separate `navbar-brand` anchor with `navbar-title` span; both anchors href = `logo_href || home_url`.
@@ -98,8 +98,9 @@ Theme CSS + end-to-end (drive the real render path per repo policy):
 
 ### Phase 2 — Logo variant model
 
-- [ ] Replace `Navbar::logo: Option<String>` (+ `logo_source`) with a normalized variant pair, e.g. `logo: Option<NavbarLogo>` where `NavbarLogo { light: LogoVariant, dark: LogoVariant }`, `LogoVariant { path: String, alt: Option<String>, source: SourceInfo }`; keep `logo_alt` parsing folding into variants that lack alt.
-- [ ] Parsing per Phase 0 specs; round-trip serialization preserves authored shape.
+- [x] Replace `Navbar::logo: Option<String>` (+ `logo_source`) with a normalized variant pair: `logo: Option<NavbarLogo>`, `NavbarLogo { light, dark }`, `LogoVariant { path, alt, source }`; `logo_alt` folds into variants that lack alt (the separate `logo_alt` field is gone). Exported from `quarto_navigation`.
+- [x] Parsing per Phase 0 specs; round-trip: single logo re-emits the historical `logo: <path>` + `logo-alt:` wire shape, distinct variants a `{light, dark}` map (string when no alt, `{path, alt}` otherwise), per-variant path `SourceInfo` preserved.
+- [x] Consumers adapted per-variant (pulled forward from Phase 4 by the compile): `copy_navbar_logo` copies each distinct variant; `navbar_generate` resolves each path against its own source; `navbar_render` rebases each path per page. `render_brand` got a minimal single-img shim (light variant) pending Phase 3.
 
 ### Phase 3 — Markup restructure
 

--- a/claude-notes/plans/2026-08-19-navbar-logo-brand-markup.md
+++ b/claude-notes/plans/2026-08-19-navbar-logo-brand-markup.md
@@ -110,9 +110,9 @@ Theme CSS + end-to-end (drive the real render path per repo policy):
 
 ### Phase 4 — Downstream consumers
 
-- [ ] `copy_navbar_logo`: copy each distinct variant file (dedupe identical paths).
-- [ ] `NavbarRenderTransform` src rebasing + authoring-dir resolution: operate per-variant using each variant's `SourceInfo`.
-- [ ] Sweep remaining `navbar.logo` consumers (`grep -rn '\.logo' crates/quarto-core/src crates/quarto-navigation/src`).
+- [x] `copy_navbar_logo`: copies each distinct variant file (dedupe identical paths). (Landed with Phase 2.)
+- [x] `NavbarRenderTransform` src rebasing + `navbar_generate` authoring-dir resolution: per-variant using each variant's `SourceInfo`. (Landed with Phase 2.)
+- [x] Sweep remaining `navbar.logo` consumers — grep clean; the only consumers are the four known sites. New end-to-end coverage: `pipeline_navbar_logo_variants_rebased_and_copied` (distinct variants rebased per page at depth 0 and 2, variant classes present, both files copied).
 
 ### Phase 5 — End-to-end verification
 

--- a/claude-notes/plans/navbar-logo-brand-markup-investigation/NOTES.md
+++ b/claude-notes/plans/navbar-logo-brand-markup-investigation/NOTES.md
@@ -26,6 +26,39 @@ Observed output (inspected by hand):
 - Markup: `external-sources/quarto-cli/src/resources/projects/website/templates/navbrand.ejs`
 - CSS: `external-sources/quarto-cli/src/resources/projects/website/navigation/quarto-nav.scss` lines 116–170 (brand container/logo layout) and 196 (`.navbar-logo` sizing). Both captured verbatim in the plan.
 
+## End-to-end verification after the fix (2026-08-19, phase 5)
+
+Fixture extended with a dark theme (`theme: {light: cosmo, dark: darkly}`)
+and distinct variants (`logo: {light: logo.svg, dark: logo-dark.svg}` +
+`logo-alt`). Invocation:
+
+```
+cargo run --bin q2 -- render claude-notes/plans/navbar-logo-brand-markup-investigation/repro
+```
+
+Observed output (inspected by hand):
+
+- **Markup** (`_site/index.html`) — full Q1 shape:
+
+  ```html
+  <div class="navbar-brand-container mx-auto"><a href="./" class="navbar-brand navbar-brand-logo"><img src="logo.svg" alt="Repro logo" class="navbar-logo light-content"><img src="logo-dark.svg" alt="Repro logo" class="navbar-logo dark-content"></a><a class="navbar-brand" href="./"><span class="navbar-title">Navbar Logo Repro</span></a></div>
+  ```
+
+- **CSS**: both compiled variants (`quarto-theme-*.css` and
+  `quarto-theme-dark-*.css`) contain
+  `.navbar-logo{max-height:24px;width:auto;padding-right:4px}`,
+  `.navbar-brand-container{min-width:0;display:flex;align-items:center}`
+  (+ the lg `margin-right:1em` media rule), and the
+  `body.quarto-light .dark-content{display:none !important}` toggling
+  pair.
+- **Assets**: both `logo.svg` and `logo-dark.svg` copied into `_site/`.
+- **Browser** (chrome-devtools MCP against the served `_site`): light
+  mode renders the light logo at a computed 24px beside the title with
+  the dark img `display:none`; clicking the color-scheme toggle flips
+  `body` to `quarto-dark` and swaps the imgs (dark at 24px, light
+  hidden). Screenshots inspected in both modes — 24px logo beside the
+  title, navbar intact.
+
 ## Pre-flight note (unrelated to the strand)
 
 `cargo xtask verify --skip-hub-build` initially failed one test:

--- a/claude-notes/plans/navbar-logo-brand-markup-investigation/NOTES.md
+++ b/claude-notes/plans/navbar-logo-brand-markup-investigation/NOTES.md
@@ -1,0 +1,38 @@
+# Investigation notes — bd-navbar-logo-unstyled-gbzd8vcu
+
+**Date:** 2026-08-19, main @ `f387bd68`.
+
+## Repro confirmation at HEAD
+
+Invocation:
+
+```
+cargo run --bin q2 -- render claude-notes/plans/navbar-logo-brand-markup-investigation/repro
+```
+
+Observed output (inspected by hand):
+
+- **Defect 1 (no sizing rule):** `_site/site_libs/quarto/quarto-theme-8de4e546dab01d3a.css` contains **zero** occurrences of `navbar-logo` (`grep -c` → 0). The 512×512 `logo.svg` therefore renders at natural size.
+- **Defect 2 (markup shape):** `_site/index.html` brand markup is the single inlined anchor:
+
+  ```html
+  <a class="navbar-brand" href="./"><img src="logo.svg" alt="Repro logo" class="navbar-logo"> Navbar Logo Repro</a>
+  ```
+
+  No `navbar-brand-container`, no `navbar-brand-logo` anchor, no `navbar-title` span — Q1's user-CSS hooks are absent.
+
+## Q1 reference targets
+
+- Markup: `external-sources/quarto-cli/src/resources/projects/website/templates/navbrand.ejs`
+- CSS: `external-sources/quarto-cli/src/resources/projects/website/navigation/quarto-nav.scss` lines 116–170 (brand container/logo layout) and 196 (`.navbar-logo` sizing). Both captured verbatim in the plan.
+
+## Pre-flight note (unrelated to the strand)
+
+`cargo xtask verify --skip-hub-build` initially failed one test:
+`quarto-preview::integration config_endpoint::config_reports_embedded_asset_manifest_hashes`
+("a real embedded viewer dist must advertise assets.viewer"). Cause: this
+checkout's `q2-preview-spa/dist/` predated the spa-manifest feature — real
+dist, no `spa-manifest.json` — so the embedded dist advertised no hash.
+`cargo xtask build-q2-preview-spa` regenerated the dist (manifest hash
+`cf5ec75d…`), after which the test and the **full workspace suite passed:
+12896/12896** (198 skipped). Stale local artifact, not a code regression.

--- a/claude-notes/plans/navbar-logo-brand-markup-investigation/repro/.gitignore
+++ b/claude-notes/plans/navbar-logo-brand-markup-investigation/repro/.gitignore
@@ -1,0 +1,2 @@
+_site/
+.quarto/

--- a/claude-notes/plans/navbar-logo-brand-markup-investigation/repro/_quarto.yml
+++ b/claude-notes/plans/navbar-logo-brand-markup-investigation/repro/_quarto.yml
@@ -1,0 +1,11 @@
+project:
+  type: website
+
+website:
+  title: "Navbar Logo Repro"
+  navbar:
+    logo: logo.svg
+    logo-alt: "Repro logo"
+    left:
+      - href: index.qmd
+        text: Home

--- a/claude-notes/plans/navbar-logo-brand-markup-investigation/repro/_quarto.yml
+++ b/claude-notes/plans/navbar-logo-brand-markup-investigation/repro/_quarto.yml
@@ -1,10 +1,18 @@
 project:
   type: website
 
+format:
+  html:
+    theme:
+      light: cosmo
+      dark: darkly
+
 website:
   title: "Navbar Logo Repro"
   navbar:
-    logo: logo.svg
+    logo:
+      light: logo.svg
+      dark: logo-dark.svg
     logo-alt: "Repro logo"
     left:
       - href: index.qmd

--- a/claude-notes/plans/navbar-logo-brand-markup-investigation/repro/index.qmd
+++ b/claude-notes/plans/navbar-logo-brand-markup-investigation/repro/index.qmd
@@ -1,0 +1,6 @@
+---
+title: "Home"
+---
+
+The navbar logo above should render at 24px height beside the title,
+not at the SVG's natural 512px size.

--- a/claude-notes/plans/navbar-logo-brand-markup-investigation/repro/logo-dark.svg
+++ b/claude-notes/plans/navbar-logo-brand-markup-investigation/repro/logo-dark.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512"><circle cx="256" cy="256" r="240" fill="#f0f0f1"/><text x="256" y="300" font-size="200" text-anchor="middle" fill="#1a1a2e" font-family="sans-serif">Q</text></svg>

--- a/claude-notes/plans/navbar-logo-brand-markup-investigation/repro/logo.svg
+++ b/claude-notes/plans/navbar-logo-brand-markup-investigation/repro/logo.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512"><circle cx="256" cy="256" r="240" fill="#4b8bbe"/><text x="256" y="300" font-size="200" text-anchor="middle" fill="white" font-family="sans-serif">Q</text></svg>

--- a/crates/quarto-core/src/project/website_post_render.rs
+++ b/crates/quarto-core/src/project/website_post_render.rs
@@ -136,37 +136,46 @@ pub(super) fn copy_navbar_logo(
     let Some(navbar) = quarto_navigation::resolve_navbar(meta) else {
         return Ok(());
     };
-    let Some(raw) = navbar.logo else {
+    let Some(logo) = navbar.logo else {
         return Ok(());
     };
-    // External logo URLs are served by whoever hosts them (mirrors
-    // the favicon rule, and checks before slash-stripping so
-    // protocol-relative `//host/x` is never misread as site-rooted).
-    if quarto_util::is_external_url(&raw) {
-        return Ok(());
+    // Copy each distinct variant file (a single logo has identical
+    // halves; copying the same path twice would be harmless but noisy).
+    let mut paths: Vec<&str> = vec![&logo.light.path];
+    if logo.dark.path != logo.light.path {
+        paths.push(&logo.dark.path);
     }
-    let normalized = raw.strip_prefix('/').unwrap_or(&raw);
-    if normalized.is_empty() {
-        return Ok(());
-    }
+    for raw in paths {
+        // External logo URLs are served by whoever hosts them (mirrors
+        // the favicon rule, and checks before slash-stripping so
+        // protocol-relative `//host/x` is never misread as site-rooted).
+        if quarto_util::is_external_url(raw) {
+            continue;
+        }
+        let normalized = raw.strip_prefix('/').unwrap_or(raw);
+        if normalized.is_empty() {
+            continue;
+        }
 
-    let src = project.dir.join(normalized);
-    let exists = runtime.path_exists(&src, None).map_err(|e| {
-        QuartoError::other(format!(
-            "Failed to probe navbar logo source {}: {}",
-            src.display(),
-            e
-        ))
-    })?;
-    if !exists {
-        diagnostics.push(DiagnosticMessage::warning(format!(
-            "website.navbar.logo refers to missing file '{}'",
-            normalized
-        )));
-        return Ok(());
-    }
+        let src = project.dir.join(normalized);
+        let exists = runtime.path_exists(&src, None).map_err(|e| {
+            QuartoError::other(format!(
+                "Failed to probe navbar logo source {}: {}",
+                src.display(),
+                e
+            ))
+        })?;
+        if !exists {
+            diagnostics.push(DiagnosticMessage::warning(format!(
+                "website.navbar.logo refers to missing file '{}'",
+                normalized
+            )));
+            continue;
+        }
 
-    copy_asset_file(project, runtime, normalized, "navbar logo")
+        copy_asset_file(project, runtime, normalized, "navbar logo")?;
+    }
+    Ok(())
 }
 
 /// Copy images referenced from `page-footer` regions — Text regions

--- a/crates/quarto-core/src/transforms/navbar_generate.rs
+++ b/crates/quarto-core/src/transforms/navbar_generate.rs
@@ -103,19 +103,22 @@ impl AstTransform for NavbarGenerateTransform {
                     &ctx.project.dir,
                 );
             }
-            // Same treatment for the logo path itself (Case A of
+            // Same treatment for the logo paths themselves (Case A of
             // bd-root-relative-paths-design-fc5pvkcv): a logo authored
             // in a doc's frontmatter or a directory `_metadata.yml`
             // resolves against the authoring file's directory;
             // `_quarto.yml`-rooted values degrade to project-root-
-            // relative unchanged.
+            // relative unchanged. Each light/dark variant resolves
+            // against its own authoring scalar's source.
             if let Some(logo) = navbar.logo.as_mut() {
-                *logo = resolve_metadata_path(
-                    logo,
-                    &navbar.logo_source,
-                    source_context,
-                    &ctx.project.dir,
-                );
+                for variant in [&mut logo.light, &mut logo.dark] {
+                    variant.path = resolve_metadata_path(
+                        &variant.path,
+                        &variant.source,
+                        source_context,
+                        &ctx.project.dir,
+                    );
+                }
             }
         }
 

--- a/crates/quarto-core/src/transforms/navbar_render.rs
+++ b/crates/quarto-core/src/transforms/navbar_render.rs
@@ -118,7 +118,12 @@ impl AstTransform for NavbarRenderTransform {
         // transform — relativized per page so it resolves at every
         // depth. Not an index lookup: the logo is a file, not a doc.
         if let Some(logo) = navbar.logo.as_mut() {
-            *logo = resolve_root_relative_resource_href(logo, ctx.resource_resolver.as_ref());
+            for variant in [&mut logo.light, &mut logo.dark] {
+                variant.path = resolve_root_relative_resource_href(
+                    &variant.path,
+                    ctx.resource_resolver.as_ref(),
+                );
+            }
         }
         // Navbar title markdown (Case C): Link/Image targets inside
         // the title's parsed markdown resolve like footer text
@@ -991,10 +996,20 @@ mod tests {
 
     async fn render_navbar_logo(logo: &str) -> String {
         use crate::resource_resolver::ResourceResolverContext;
+        use quarto_navigation::{LogoVariant, NavbarLogo};
+        use quarto_source_map::{By, SourceInfo};
 
+        let variant = LogoVariant {
+            path: logo.to_string(),
+            alt: None,
+            source: SourceInfo::generated(By::programmatic_config()),
+        };
         let navbar = Navbar {
             title: NavbarTitle::Text(s("Site")),
-            logo: Some(logo.to_string()),
+            logo: Some(NavbarLogo {
+                light: variant.clone(),
+                dark: variant,
+            }),
             ..Navbar::with_defaults()
         };
         let mut meta = ConfigValue::default();

--- a/crates/quarto-core/tests/fixtures/phase5-single-doc-baseline/expected_hashes.txt
+++ b/crates/quarto-core/tests/fixtures/phase5-single-doc-baseline/expected_hashes.txt
@@ -373,5 +373,16 @@
 # useful cross-check rather than a coincidence: it confirms both notes' claims
 # that the tabset change is script-list-only and the mobile-nav template change
 # is byte-neutral for single-doc renders (no navbar, no secondary nav).
+# Re-captured 2026-08-19 (bd-navbar-logo-unstyled-gbzd8vcu, phase 1):
+# styles.css hash updated because the navbar-brand rules were ported
+# from Q1's quarto-nav.scss into `_bootstrap-rules.scss`:
+# `.navbar-container { width: 100% }` (116-118), the `.navbar-brand`
+# ellipsis pair (120-123), the `.navbar-brand-container` flex layout
+# minus the width clamp (125-134; clamp deferred to bd-y5y10oir),
+# `.navbar-brand.navbar-brand-logo` spacing (136-139), and the
+# `.navbar-logo { max-height: 24px; … }` sizing rule (196) that stops
+# a natural-size logo from swallowing the navbar. doc.html hash
+# unchanged: none of the new selectors match a single-doc body (no
+# navbar), and `<head>` is unaffected.
 doc.html a0540297514ad41734a23e91c9511134b1fa469281ec470339571ffd5d404494
-doc_files/styles.css 8de4e546dab01d3a04e713987e89c8796e218edd1cb30207bc6dda73c58ff845
+doc_files/styles.css b14c1db209937ed1779b6460ea494dce4c1e762cf770c71df6ecc159a9dd8c37

--- a/crates/quarto-core/tests/integration/navbar_footer_pipeline.rs
+++ b/crates/quarto-core/tests/integration/navbar_footer_pipeline.rs
@@ -21,6 +21,7 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use regex::Regex;
 use tempfile::TempDir;
 
 use quarto_core::format::Format;
@@ -557,5 +558,94 @@ fn pipeline_footer_text_image_and_link_resolve_per_page_and_copy() {
     assert!(
         project_dir.join("_site/images/x.svg").exists(),
         "footer image must be copied to the output tree (decision 5)"
+    );
+}
+
+// === bd-navbar-logo-unstyled-gbzd8vcu: theme ships navbar brand CSS ======
+
+/// The compiled theme bundle must ship default styling for the navbar
+/// brand: `.navbar-logo` sizing (Q1 quarto-nav.scss:196) plus the
+/// `.navbar-brand-container` / `.navbar-brand-logo` layout rules the
+/// restructured brand markup relies on. Before the fix, the generated
+/// `quarto-theme-*.css` contained no `navbar-logo` occurrence at all,
+/// so a 512px SVG rendered at natural size and swallowed the navbar.
+#[test]
+fn pipeline_theme_css_ships_navbar_brand_rules() {
+    let (project_dir, _outputs) = render_project(|project_dir| {
+        write(
+            &project_dir.join("_quarto.yml"),
+            "project:\n  type: website\n  output-dir: _site\n\
+             website:\n  navbar:\n    title: Site\n    logo: logo.svg\n    left:\n      - index.qmd\n",
+        );
+        write(
+            &project_dir.join("logo.svg"),
+            "<svg xmlns=\"http://www.w3.org/2000/svg\"/>\n",
+        );
+        write(
+            &project_dir.join("index.qmd"),
+            "---\ntitle: Home\n---\n\nH.\n",
+        );
+    });
+
+    let libs_dir = project_dir.join("_site/site_libs/quarto");
+    let theme_css_path = std::fs::read_dir(&libs_dir)
+        .unwrap_or_else(|e| panic!("read {}: {}", libs_dir.display(), e))
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .find(|p| {
+            p.file_name()
+                .and_then(|s| s.to_str())
+                .is_some_and(|s| s.starts_with("quarto-theme-") && s.ends_with(".css"))
+        })
+        .expect("a quarto-theme-*.css under site_libs/quarto/");
+    let css = read(&theme_css_path);
+
+    // Q1 quarto-nav.scss:196 — the default logo sizing. Assert the
+    // full declaration set so a partial port can't pass.
+    let logo_rule = Regex::new(
+        r"\.navbar-logo\s*\{[^}]*max-height:\s*24px;[^}]*width:\s*auto;[^}]*padding-right:\s*4px",
+    )
+    .unwrap();
+    assert!(
+        logo_rule.is_match(&css),
+        "theme CSS must ship the .navbar-logo sizing rule; searched {}",
+        theme_css_path.display()
+    );
+
+    // Q1 quarto-nav.scss:125-134 — brand container flex layout
+    // (width clamp deliberately omitted: bd-y5y10oir).
+    let container_rule = Regex::new(
+        r"\.navbar-brand-container\s*\{[^}]*min-width:\s*0;[^}]*display:\s*flex;[^}]*align-items:\s*center",
+    )
+    .unwrap();
+    assert!(
+        container_rule.is_match(&css),
+        "theme CSS must ship the .navbar-brand-container layout rule"
+    );
+
+    // Q1 quarto-nav.scss:136-139 — logo anchor spacing.
+    let brand_logo_rule = Regex::new(
+        r"\.navbar-brand\.navbar-brand-logo\s*\{[^}]*margin-right:\s*4px;[^}]*display:\s*inline-flex",
+    )
+    .unwrap();
+    assert!(
+        brand_logo_rule.is_match(&css),
+        "theme CSS must ship the .navbar-brand.navbar-brand-logo rule"
+    );
+
+    // Q1 quarto-nav.scss:120-123 — long titles truncate with ellipsis.
+    let brand_rule =
+        Regex::new(r"\.navbar-brand\s*\{[^}]*overflow:\s*hidden;[^}]*text-overflow:\s*ellipsis")
+            .unwrap();
+    assert!(
+        brand_rule.is_match(&css),
+        "theme CSS must ship the .navbar-brand ellipsis rule"
+    );
+
+    // Q1 quarto-nav.scss:116-118.
+    let navbar_container_rule = Regex::new(r"\.navbar-container\s*\{[^}]*width:\s*100%").unwrap();
+    assert!(
+        navbar_container_rule.is_match(&css),
+        "theme CSS must ship the .navbar-container width rule"
     );
 }

--- a/crates/quarto-core/tests/integration/navbar_footer_pipeline.rs
+++ b/crates/quarto-core/tests/integration/navbar_footer_pipeline.rs
@@ -649,3 +649,75 @@ fn pipeline_theme_css_ships_navbar_brand_rules() {
         "theme CSS must ship the .navbar-container width rule"
     );
 }
+
+/// Distinct light/dark logo variants flow through the whole pipeline
+/// (bd-navbar-logo-unstyled-gbzd8vcu): both paths are rebased
+/// per-page, both imgs carry their variant content class, and both
+/// files are copied into the output tree.
+#[test]
+fn pipeline_navbar_logo_variants_rebased_and_copied() {
+    let (project_dir, _outputs) = render_project(|project_dir| {
+        write(
+            &project_dir.join("_quarto.yml"),
+            "project:\n  type: website\n  output-dir: _site\n\
+             website:\n  navbar:\n    title: Site\n    logo:\n      light: images/l.svg\n      dark:\n        path: images/d.svg\n        alt: Dark logo\n    left:\n      - index.qmd\n",
+        );
+        write(
+            &project_dir.join("images/l.svg"),
+            "<svg xmlns=\"http://www.w3.org/2000/svg\"/>\n",
+        );
+        write(
+            &project_dir.join("images/d.svg"),
+            "<svg xmlns=\"http://www.w3.org/2000/svg\"/>\n",
+        );
+        write(
+            &project_dir.join("index.qmd"),
+            "---\ntitle: Home\n---\n\nH.\n",
+        );
+        write(
+            &project_dir.join("deep/deeper/page.qmd"),
+            "---\ntitle: Deep\n---\n\nD.\n",
+        );
+    });
+
+    let root_html = read(&project_dir.join("_site/index.html"));
+    assert!(
+        root_html
+            .contains("<img src=\"images/l.svg\" alt=\"\" class=\"navbar-logo light-content\">"),
+        "root page light img depth-0 relative with light-content class; got: {}",
+        root_html
+            .lines()
+            .find(|l| l.contains("navbar-logo"))
+            .unwrap_or("<no navbar-logo line>")
+    );
+    assert!(
+        root_html.contains(
+            "<img src=\"images/d.svg\" alt=\"Dark logo\" class=\"navbar-logo dark-content\">"
+        ),
+        "root page dark img with its own alt and dark-content class; got: {}",
+        root_html
+            .lines()
+            .find(|l| l.contains("navbar-logo"))
+            .unwrap_or("<no navbar-logo line>")
+    );
+
+    let deep_html = read(&project_dir.join("_site/deep/deeper/page.html"));
+    assert!(
+        deep_html.contains("<img src=\"../../images/l.svg\"")
+            && deep_html.contains("<img src=\"../../images/d.svg\""),
+        "depth-2 page must rebase both variant srcs; got: {}",
+        deep_html
+            .lines()
+            .find(|l| l.contains("navbar-logo"))
+            .unwrap_or("<no navbar-logo line>")
+    );
+
+    assert!(
+        project_dir.join("_site/images/l.svg").exists(),
+        "light variant file must be copied to the output tree"
+    );
+    assert!(
+        project_dir.join("_site/images/d.svg").exists(),
+        "dark variant file must be copied to the output tree"
+    );
+}

--- a/crates/quarto-core/tests/integration/shortcode_config_pipeline.rs
+++ b/crates/quarto-core/tests/integration/shortcode_config_pipeline.rs
@@ -540,7 +540,7 @@ fn plain_config_strings_unchanged() {
         title_line(html)
     );
     assert!(
-        html.contains(">Plain Site</a>"),
+        html.contains(">Plain Site</span></a>"),
         "plain navbar brand unchanged; got: {}",
         line_containing(html, "navbar-brand")
     );

--- a/crates/quarto-navigation/src/lib.rs
+++ b/crates/quarto-navigation/src/lib.rs
@@ -28,7 +28,9 @@ pub mod sidebar;
 
 pub use footer::{FooterBorder, FooterRegion, PageFooter, resolve_page_footer};
 pub use item::{BareScalar, NavigationItem};
-pub use navbar::{CollapseBelow, Navbar, NavbarTitle, TogglePosition, resolve_navbar};
+pub use navbar::{
+    CollapseBelow, LogoVariant, Navbar, NavbarLogo, NavbarTitle, TogglePosition, resolve_navbar,
+};
 pub use page_nav::PageNavigation;
 pub use sidebar::{
     AutoSpec, Crumb, Sidebar, SidebarEntry, SidebarStyle, SidebarTitle, breadcrumb_trail,

--- a/crates/quarto-navigation/src/navbar.rs
+++ b/crates/quarto-navigation/src/navbar.rs
@@ -99,17 +99,58 @@ impl TogglePosition {
     }
 }
 
+/// One resolved navbar-logo variant: a path, its optional alt text,
+/// and the `SourceInfo` of the YAML scalar that authored the path
+/// (bd-root-relative-paths-design-fc5pvkcv — mirroring
+/// `logo_href_source`, bd-qor9a) so the resolver knows which YAML
+/// file the path was authored in.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LogoVariant {
+    pub path: String,
+    pub alt: Option<String>,
+    pub source: SourceInfo,
+}
+
+/// Normalized navbar logo: always a light/dark pair, mirroring Q1's
+/// `resolveLogo` normalization of the `logo-light-dark-specifier`
+/// YAML shapes (bd-navbar-logo-unstyled-gbzd8vcu). A single-logo
+/// spec (string or `{path, alt}`) fills both halves identically; a
+/// `{light, dark}` spec with one half missing falls back to the
+/// other. Brand.yml logo-name indirection is out of scope
+/// (bd-v5z8w).
+#[derive(Debug, Clone, PartialEq)]
+pub struct NavbarLogo {
+    pub light: LogoVariant,
+    pub dark: LogoVariant,
+}
+
+impl NavbarLogo {
+    /// Both halves render as one image: same path, same alt. (The
+    /// renderer then emits a single unclassed `<img>` instead of a
+    /// `light-content`/`dark-content` pair.)
+    pub fn is_single(&self) -> bool {
+        self.light.path == self.dark.path && self.light.alt == self.dark.alt
+    }
+
+    /// The shared path of a single-image logo, `None` when the
+    /// variants differ.
+    pub fn single_path(&self) -> Option<&str> {
+        if self.is_single() {
+            Some(&self.light.path)
+        } else {
+            None
+        }
+    }
+}
+
 /// Fully resolved navbar configuration.
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct Navbar {
     pub title: NavbarTitle,
-    pub logo: Option<String>,
-    /// `SourceInfo` of the YAML scalar that produced `logo`.
-    /// bd-root-relative-paths-design-fc5pvkcv — paired with `logo`
-    /// (mirroring `logo_href_source`, bd-qor9a) so the resolver knows
-    /// which YAML file the logo path was authored in.
-    pub logo_source: SourceInfo,
-    pub logo_alt: Option<String>,
+    /// Normalized logo pair; `None` when unset or `logo: false`.
+    /// Alt text lives per-variant (a sibling `logo-alt:` key fills
+    /// variants that lack their own `alt`).
+    pub logo: Option<NavbarLogo>,
     pub logo_href: Option<String>,
     /// `SourceInfo` of the YAML scalar that produced `logo_href`.
     /// bd-qor9a — paired with `logo_href` so the resolver knows which
@@ -140,8 +181,6 @@ impl Navbar {
         Self {
             title: NavbarTitle::Default,
             logo: None,
-            logo_source: SourceInfo::generated(By::programmatic_config()),
-            logo_alt: None,
             logo_href: None,
             logo_href_source: SourceInfo::generated(By::programmatic_config()),
             background: None,
@@ -178,13 +217,10 @@ impl Navbar {
             };
         }
 
+        let logo_alt = cv.get("logo-alt").and_then(|v| v.as_plain_text());
         if let Some(logo_cv) = cv.get("logo") {
-            nav.logo = logo_cv.as_plain_text();
-            if nav.logo.is_some() {
-                nav.logo_source = logo_cv.source_info.clone();
-            }
+            nav.logo = parse_logo(logo_cv, logo_alt.as_deref());
         }
-        nav.logo_alt = cv.get("logo-alt").and_then(|v| v.as_plain_text());
         if let Some(logo_href_cv) = cv.get("logo-href") {
             nav.logo_href = logo_href_cv.as_plain_text();
             if nav.logo_href.is_some() {
@@ -254,11 +290,38 @@ impl Navbar {
             }),
         }
 
-        // logo round-trips its source_info
+        // logo round-trips each variant path's source_info
         // (bd-root-relative-paths-design-fc5pvkcv) so the generate-time
-        // path resolver can locate the authoring YAML file.
-        push_optional_string(&mut entries, "logo", &self.logo, &self.logo_source);
-        push_optional_string(&mut entries, "logo-alt", &self.logo_alt, &info);
+        // path resolver can locate the authoring YAML file. A single
+        // logo re-emits the historical `logo: <path>` + `logo-alt:`
+        // wire shape; distinct variants emit a `{light, dark}` map.
+        if let Some(logo) = &self.logo {
+            if logo.is_single() {
+                entries.push(ConfigMapEntry {
+                    key: "logo".to_string(),
+                    key_source: info.clone(),
+                    value: ConfigValue::new_string(&logo.light.path, logo.light.source.clone()),
+                });
+                push_optional_string(&mut entries, "logo-alt", &logo.light.alt, &info);
+            } else {
+                let variant_entry = |key: &str, v: &LogoVariant| ConfigMapEntry {
+                    key: key.to_string(),
+                    key_source: info.clone(),
+                    value: logo_variant_to_config_value(v, &info),
+                };
+                entries.push(ConfigMapEntry {
+                    key: "logo".to_string(),
+                    key_source: info.clone(),
+                    value: ConfigValue::new_map(
+                        vec![
+                            variant_entry("light", &logo.light),
+                            variant_entry("dark", &logo.dark),
+                        ],
+                        info.clone(),
+                    ),
+                });
+            }
+        }
         // logo-href round-trips its source_info (bd-qor9a) so the
         // diagnostic surface can locate it back in the YAML.
         push_optional_string(
@@ -353,6 +416,97 @@ fn parse_item_list(cv: Option<&ConfigValue>) -> Vec<NavigationItem> {
     arr.iter()
         .filter_map(NavigationItem::from_config_value)
         .collect()
+}
+
+/// Parse the `logo:` value into a normalized light/dark pair.
+///
+/// Accepted shapes (Q1's `logo-light-dark-specifier`, minus brand.yml
+/// logo-name indirection — bd-v5z8w): `false` (returns `None`), a
+/// plain string, a `{path, alt}` map, or a `{light, dark}` map whose
+/// halves are each a string or `{path, alt}`. A missing half falls
+/// back to the other; `logo_alt` (the sibling `logo-alt:` key) fills
+/// any variant that lacks its own `alt`.
+fn parse_logo(cv: &ConfigValue, logo_alt: Option<&str>) -> Option<NavbarLogo> {
+    if cv.as_bool().is_some() {
+        // `logo: false` disables; `logo: true` is meaningless — no path.
+        return None;
+    }
+
+    let fill_alt = |mut v: LogoVariant| {
+        if v.alt.is_none() {
+            v.alt = logo_alt.map(str::to_string);
+        }
+        v
+    };
+
+    // `{light, dark}` shape — take it whenever either key is present.
+    let light = cv.get("light").and_then(parse_logo_variant);
+    let dark = cv.get("dark").and_then(parse_logo_variant);
+    if light.is_some() || dark.is_some() {
+        let light = light.map(&fill_alt);
+        let dark = dark.map(&fill_alt);
+        // Cross-fallback: a missing half mirrors the other (Q1
+        // resolveLogo semantics, unconditional in Q2 — we have no
+        // brand to gate the dark half on).
+        let (light, dark) = match (light, dark) {
+            (Some(l), Some(d)) => (l, d),
+            (Some(l), None) => (l.clone(), l),
+            (None, Some(d)) => (d.clone(), d),
+            (None, None) => unreachable!("guarded by is_some above"),
+        };
+        return Some(NavbarLogo { light, dark });
+    }
+
+    // String or `{path, alt}` shape: one image for both modes.
+    let single = fill_alt(parse_logo_variant(cv)?);
+    Some(NavbarLogo {
+        light: single.clone(),
+        dark: single,
+    })
+}
+
+/// Parse one variant: a plain string or a `{path, alt}` map. The
+/// variant's `source` is the path scalar's `SourceInfo`.
+fn parse_logo_variant(cv: &ConfigValue) -> Option<LogoVariant> {
+    if let Some(path_cv) = cv.get("path") {
+        let path = path_cv.as_plain_text()?;
+        return Some(LogoVariant {
+            path,
+            alt: cv.get("alt").and_then(|v| v.as_plain_text()),
+            source: path_cv.source_info.clone(),
+        });
+    }
+    let path = cv.as_plain_text()?;
+    Some(LogoVariant {
+        path,
+        alt: None,
+        source: cv.source_info.clone(),
+    })
+}
+
+/// Serialize one variant for the `{light, dark}` wire shape: a plain
+/// string (carrying the path's `SourceInfo`) when there is no alt, a
+/// `{path, alt}` map otherwise.
+fn logo_variant_to_config_value(v: &LogoVariant, info: &SourceInfo) -> ConfigValue {
+    let path_value = ConfigValue::new_string(&v.path, v.source.clone());
+    match &v.alt {
+        None => path_value,
+        Some(alt) => ConfigValue::new_map(
+            vec![
+                ConfigMapEntry {
+                    key: "path".to_string(),
+                    key_source: info.clone(),
+                    value: path_value,
+                },
+                ConfigMapEntry {
+                    key: "alt".to_string(),
+                    key_source: info.clone(),
+                    value: ConfigValue::new_string(alt, info.clone()),
+                },
+            ],
+            info.clone(),
+        ),
+    }
 }
 
 fn push_optional_string(
@@ -529,7 +683,10 @@ mod tests {
         ]);
         let meta = map(vec![("website", map(vec![("navbar", navbar_cv)]))]);
         let nav = resolve_navbar(&meta).expect("website.navbar must resolve");
-        assert_eq!(nav.logo.as_deref(), Some("quarto.png"));
+        assert_eq!(
+            nav.logo.as_ref().and_then(|l| l.single_path()),
+            Some("quarto.png")
+        );
         assert_eq!(nav.left.len(), 1);
         assert_eq!(nav.left[0].href.as_deref(), Some("index.qmd"));
     }
@@ -550,7 +707,7 @@ mod tests {
         ]);
         let nav = resolve_navbar(&meta).unwrap();
         assert_eq!(
-            nav.logo.as_deref(),
+            nav.logo.as_ref().and_then(|l| l.single_path()),
             Some("top.png"),
             "top-level logo must win"
         );
@@ -581,11 +738,13 @@ mod tests {
         assert!(resolve_navbar(&meta).is_none());
     }
 
-    /// Case A (bd-root-relative-paths-design-fc5pvkcv): `logo` is
-    /// paired with the YAML scalar's `SourceInfo` — like `logo-href`
-    /// (bd-qor9a) — so the generate-transform can resolve a
-    /// frontmatter-authored logo path against the authoring file.
-    /// Capture and round-trip both directions.
+    /// Case A (bd-root-relative-paths-design-fc5pvkcv): a
+    /// string-form `logo` is paired with the YAML scalar's
+    /// `SourceInfo` — like `logo-href` (bd-qor9a) — so the
+    /// generate-transform can resolve a frontmatter-authored logo
+    /// path against the authoring file. Capture and round-trip both
+    /// directions. (The distinct-variant case is covered by
+    /// `logo_variant_sources_captured_and_round_tripped`.)
     #[test]
     fn logo_source_captured_and_round_tripped() {
         use quarto_source_map::FileId;
@@ -596,16 +755,18 @@ mod tests {
         )]);
         let meta = map(vec![("navbar", navbar_cv)]);
         let nav = resolve_navbar(&meta).expect("navbar must resolve");
-        assert_eq!(nav.logo.as_deref(), Some("images/logo.svg"));
+        let logo = nav.logo.as_ref().unwrap();
+        assert_eq!(logo.single_path(), Some("images/logo.svg"));
         assert_eq!(
-            nav.logo_source, logo_loc,
-            "logo_source must capture the YAML scalar's SourceInfo"
+            logo.light.source, logo_loc,
+            "the variant source must capture the YAML scalar's SourceInfo"
         );
 
         let reparsed = Navbar::from_config_value(&nav.to_config_value());
         assert_eq!(
-            reparsed.logo_source, logo_loc,
-            "logo_source must survive the to/from round-trip"
+            reparsed.logo.as_ref().unwrap().light.source,
+            logo_loc,
+            "the variant source must survive the to/from round-trip"
         );
     }
 
@@ -655,5 +816,217 @@ mod tests {
         let cv = original.to_config_value();
         let reparsed = Navbar::from_config_value(&cv);
         assert_eq!(reparsed, original);
+    }
+
+    // === Logo light/dark variants (bd-navbar-logo-unstyled-gbzd8vcu) ====
+    //
+    // Q1's `logo-light-dark-specifier` accepts `false` | string |
+    // `{path, alt}` | `{light, dark}` (each variant string or
+    // `{path, alt}`), and `resolveLogo` normalizes every shape to a
+    // light/dark pair with cross-fallback. These tests pin the same
+    // normalization for Q2 (minus brand.yml indirection — bd-v5z8w).
+
+    #[test]
+    fn logo_string_parses_as_single_pair() {
+        let navbar_cv = map(vec![("logo", s("quarto.png")), ("logo-alt", s("Q logo"))]);
+        let meta = map(vec![("navbar", navbar_cv)]);
+        let nav = resolve_navbar(&meta).unwrap();
+        let logo = nav.logo.as_ref().expect("logo must parse");
+        assert_eq!(logo.light.path, "quarto.png");
+        assert_eq!(logo.dark.path, "quarto.png");
+        assert_eq!(logo.light.alt.as_deref(), Some("Q logo"));
+        assert_eq!(logo.dark.alt.as_deref(), Some("Q logo"));
+        assert!(logo.is_single(), "identical halves must read as single");
+        assert_eq!(logo.single_path(), Some("quarto.png"));
+    }
+
+    #[test]
+    fn logo_path_alt_object_parses_as_single_pair() {
+        let navbar_cv = map(vec![(
+            "logo",
+            map(vec![("path", s("img/p.svg")), ("alt", s("Alt text"))]),
+        )]);
+        let meta = map(vec![("navbar", navbar_cv)]);
+        let nav = resolve_navbar(&meta).unwrap();
+        let logo = nav.logo.as_ref().expect("logo must parse");
+        assert!(logo.is_single());
+        assert_eq!(logo.light.path, "img/p.svg");
+        assert_eq!(logo.light.alt.as_deref(), Some("Alt text"));
+        assert_eq!(logo.dark.alt.as_deref(), Some("Alt text"));
+    }
+
+    #[test]
+    fn logo_object_alt_wins_over_logo_alt_key() {
+        // The object's own `alt` is more specific than the sibling
+        // `logo-alt` key.
+        let navbar_cv = map(vec![
+            ("logo", map(vec![("path", s("p.svg")), ("alt", s("inner"))])),
+            ("logo-alt", s("outer")),
+        ]);
+        let meta = map(vec![("navbar", navbar_cv)]);
+        let nav = resolve_navbar(&meta).unwrap();
+        let logo = nav.logo.as_ref().unwrap();
+        assert_eq!(logo.light.alt.as_deref(), Some("inner"));
+    }
+
+    #[test]
+    fn logo_light_dark_distinct_variants() {
+        let navbar_cv = map(vec![
+            (
+                "logo",
+                map(vec![
+                    ("light", s("l.svg")),
+                    ("dark", map(vec![("path", s("d.svg")), ("alt", s("Dark"))])),
+                ]),
+            ),
+            ("logo-alt", s("Generic")),
+        ]);
+        let meta = map(vec![("navbar", navbar_cv)]);
+        let nav = resolve_navbar(&meta).unwrap();
+        let logo = nav.logo.as_ref().expect("logo must parse");
+        assert!(!logo.is_single());
+        assert_eq!(logo.single_path(), None);
+        assert_eq!(logo.light.path, "l.svg");
+        assert_eq!(logo.dark.path, "d.svg");
+        // Per-variant alt wins; `logo-alt` fills variants that lack one.
+        assert_eq!(logo.dark.alt.as_deref(), Some("Dark"));
+        assert_eq!(logo.light.alt.as_deref(), Some("Generic"));
+    }
+
+    #[test]
+    fn logo_light_only_falls_back_to_dark() {
+        let navbar_cv = map(vec![("logo", map(vec![("light", s("l.svg"))]))]);
+        let meta = map(vec![("navbar", navbar_cv)]);
+        let nav = resolve_navbar(&meta).unwrap();
+        let logo = nav.logo.as_ref().expect("logo must parse");
+        assert!(logo.is_single(), "missing dark must fall back to light");
+        assert_eq!(logo.dark.path, "l.svg");
+    }
+
+    #[test]
+    fn logo_dark_only_falls_back_to_light() {
+        let navbar_cv = map(vec![("logo", map(vec![("dark", s("d.svg"))]))]);
+        let meta = map(vec![("navbar", navbar_cv)]);
+        let nav = resolve_navbar(&meta).unwrap();
+        let logo = nav.logo.as_ref().expect("logo must parse");
+        assert!(logo.is_single(), "missing light must fall back to dark");
+        assert_eq!(logo.light.path, "d.svg");
+    }
+
+    #[test]
+    fn logo_false_is_none() {
+        let navbar_cv = map(vec![("logo", b(false)), ("title", s("Site"))]);
+        let meta = map(vec![("navbar", navbar_cv)]);
+        let nav = resolve_navbar(&meta).unwrap();
+        assert!(nav.logo.is_none(), "logo: false must disable the logo");
+    }
+
+    #[test]
+    fn logo_empty_map_is_none() {
+        let navbar_cv = map(vec![("logo", map(vec![])), ("title", s("Site"))]);
+        let meta = map(vec![("navbar", navbar_cv)]);
+        let nav = resolve_navbar(&meta).unwrap();
+        assert!(nav.logo.is_none(), "an empty logo map carries no path");
+    }
+
+    #[test]
+    fn logo_single_roundtrips_as_string_wire_shape() {
+        // A single logo re-emits the historical wire shape
+        // (`logo: <path>` + `logo-alt:`), so stored metadata stays
+        // stable for single-logo sites.
+        let navbar_cv = map(vec![("logo", s("quarto.png")), ("logo-alt", s("Q"))]);
+        let meta = map(vec![("navbar", navbar_cv)]);
+        let nav = resolve_navbar(&meta).unwrap();
+
+        let cv = nav.to_config_value();
+        assert_eq!(
+            cv.get("logo").and_then(|v| v.as_plain_text()).as_deref(),
+            Some("quarto.png"),
+            "single logo must serialize as a plain string"
+        );
+        assert_eq!(
+            cv.get("logo-alt")
+                .and_then(|v| v.as_plain_text())
+                .as_deref(),
+            Some("Q")
+        );
+
+        let reparsed = Navbar::from_config_value(&cv);
+        assert_eq!(reparsed.logo, nav.logo);
+    }
+
+    #[test]
+    fn logo_variants_roundtrip_as_light_dark_map() {
+        let navbar_cv = map(vec![(
+            "logo",
+            map(vec![
+                ("light", map(vec![("path", s("l.svg")), ("alt", s("L"))])),
+                ("dark", s("d.svg")),
+            ]),
+        )]);
+        let meta = map(vec![("navbar", navbar_cv)]);
+        let nav = resolve_navbar(&meta).unwrap();
+        let cv = nav.to_config_value();
+
+        let logo_cv = cv.get("logo").expect("logo entry");
+        assert_eq!(
+            logo_cv
+                .get("light")
+                .and_then(|l| l.get("path"))
+                .and_then(|v| v.as_plain_text())
+                .as_deref(),
+            Some("l.svg"),
+            "distinct variants must serialize as a light/dark map"
+        );
+
+        let reparsed = Navbar::from_config_value(&cv);
+        assert_eq!(reparsed.logo, nav.logo);
+    }
+
+    /// Case A (bd-root-relative-paths-design-fc5pvkcv), extended to
+    /// variants: each variant's `path` keeps the `SourceInfo` of the
+    /// YAML scalar that authored it, and both survive the round-trip,
+    /// so the generate-transform can resolve each against its own
+    /// authoring file.
+    #[test]
+    fn logo_variant_sources_captured_and_round_tripped() {
+        use quarto_source_map::FileId;
+        let light_loc = SourceInfo::original(FileId(7), 4, 19);
+        let dark_loc = SourceInfo::original(FileId(9), 6, 21);
+        let navbar_cv = map(vec![(
+            "logo",
+            map(vec![
+                (
+                    "light",
+                    ConfigValue::new_string("images/l.svg", light_loc.clone()),
+                ),
+                (
+                    "dark",
+                    ConfigValue::new_string("images/d.svg", dark_loc.clone()),
+                ),
+            ]),
+        )]);
+        let meta = map(vec![("navbar", navbar_cv)]);
+        let nav = resolve_navbar(&meta).expect("navbar must resolve");
+        let logo = nav.logo.as_ref().unwrap();
+        assert_eq!(
+            logo.light.source, light_loc,
+            "light path must capture its YAML scalar's SourceInfo"
+        );
+        assert_eq!(
+            logo.dark.source, dark_loc,
+            "dark path must capture its YAML scalar's SourceInfo"
+        );
+
+        let reparsed = Navbar::from_config_value(&nav.to_config_value());
+        let relogo = reparsed.logo.as_ref().unwrap();
+        assert_eq!(
+            relogo.light.source, light_loc,
+            "light source must survive the to/from round-trip"
+        );
+        assert_eq!(
+            relogo.dark.source, dark_loc,
+            "dark source must survive the to/from round-trip"
+        );
     }
 }

--- a/crates/quarto-navigation/src/render_html.rs
+++ b/crates/quarto-navigation/src/render_html.rs
@@ -25,7 +25,7 @@ use quarto_source_map::{By, SourceInfo};
 
 use crate::footer::{FooterBorder, FooterRegion, PageFooter};
 use crate::item::NavigationItem;
-use crate::navbar::{Navbar, NavbarTitle};
+use crate::navbar::{LogoVariant, Navbar, NavbarTitle};
 use crate::page_nav::PageNavigation;
 use crate::sidebar::{Crumb, Sidebar, SidebarEntry, SidebarStyle, SidebarTitle};
 
@@ -81,7 +81,10 @@ pub fn navbar_to_html(
     }
     html.push_str(">\n");
 
-    html.push_str("  <div class=\"container-fluid\">\n");
+    // `navbar-container` is a Q1 hook class (quarto-nav.scss sizes it
+    // and user CSS keys on it); `container-fluid` supplies Bootstrap's
+    // gutter padding.
+    html.push_str("  <div class=\"navbar-container container-fluid\">\n");
 
     // Brand (title + logo).
     if let Some(brand_html) = render_brand(navbar, document_title_fallback, home_url) {
@@ -494,23 +497,47 @@ fn render_page_nav_side(html: &mut String, side: &str, item: Option<&NavigationI
 
 // --- Private helpers ---------------------------------------------------------
 
+/// Render the navbar brand in Q1's `navbrand.ejs` shape
+/// (bd-navbar-logo-unstyled-gbzd8vcu): a `.navbar-brand-container`
+/// div wrapping a `.navbar-brand.navbar-brand-logo` anchor for the
+/// logo and a separate `.navbar-brand` anchor with a `.navbar-title`
+/// span — the hooks Q1-documented user CSS keys on. Both anchors use
+/// `logo_href || home_url` (Q2 keeps the relative fallback instead of
+/// Q1's absolute `/index.html` — bd-root-relative-paths-design).
+///
+/// Deliberate deviation from Q1: a single logo (identical normalized
+/// halves) emits ONE unclassed `<img class="navbar-logo">` where Q1
+/// duplicates it as `light-content` + `dark-content`; distinct
+/// variants emit the classed pair, toggled by `_light-dark.scss`'s
+/// `body.quarto-light`/`body.quarto-dark` rules.
 fn render_brand(navbar: &Navbar, fallback: Option<&ConfigValue>, home_url: &str) -> Option<String> {
-    let href = navbar.logo_href.as_deref().unwrap_or(home_url);
-    let logo_img = navbar.logo.as_ref().map(|logo| {
-        let alt = logo
-            .light
-            .alt
-            .as_deref()
-            .map(escape_attr)
-            .unwrap_or_default();
+    let href = escape_attr(navbar.logo_href.as_deref().unwrap_or(home_url));
+
+    let logo_anchor = navbar.logo.as_ref().map(|logo| {
+        let img = |variant: &LogoVariant, class: &str| {
+            format!(
+                "<img src=\"{}\" alt=\"{}\" class=\"{}\">",
+                escape_attr(&variant.path),
+                variant.alt.as_deref().map(escape_attr).unwrap_or_default(),
+                class
+            )
+        };
+        let imgs = if logo.is_single() {
+            img(&logo.light, "navbar-logo")
+        } else {
+            format!(
+                "{}{}",
+                img(&logo.light, "navbar-logo light-content"),
+                img(&logo.dark, "navbar-logo dark-content")
+            )
+        };
         format!(
-            "<img src=\"{}\" alt=\"{}\" class=\"navbar-logo\">",
-            escape_attr(&logo.light.path),
-            alt
+            "<a href=\"{}\" class=\"navbar-brand navbar-brand-logo\">{}</a>",
+            href, imgs
         )
     });
 
-    let title_html = match &navbar.title {
+    let title_anchor = match &navbar.title {
         NavbarTitle::Hidden => None,
         NavbarTitle::Text(cv) => Some(render_text(cv)),
         // The fallback (`website.title` → document `title`) is a
@@ -518,27 +545,29 @@ fn render_brand(navbar: &Navbar, fallback: Option<&ConfigValue>, home_url: &str)
         // once ConfigMarkdownTransform has run — render as inlines
         // (raw HTML honored) instead of being flattened and escaped.
         NavbarTitle::Default => fallback.map(render_text),
-    };
+    }
+    .map(|title_html| {
+        format!(
+            "<a class=\"navbar-brand\" href=\"{}\"><span class=\"navbar-title\">{}</span></a>",
+            href, title_html
+        )
+    });
 
     // Nothing to show? Skip brand entirely.
-    if logo_img.is_none() && title_html.is_none() {
+    if logo_anchor.is_none() && title_anchor.is_none() {
         return None;
     }
 
     let mut inner = String::new();
-    if let Some(l) = logo_img {
+    if let Some(l) = logo_anchor {
         inner.push_str(&l);
     }
-    if let Some(t) = title_html {
-        if !inner.is_empty() {
-            inner.push(' ');
-        }
+    if let Some(t) = title_anchor {
         inner.push_str(&t);
     }
 
     Some(format!(
-        "<a class=\"navbar-brand\" href=\"{}\">{}</a>",
-        escape_attr(href),
+        "<div class=\"navbar-brand-container mx-auto\">{}</div>",
         inner
     ))
 }
@@ -1153,7 +1182,7 @@ mod tests {
     use super::*;
     use crate::footer::PageFooter;
     use crate::item::NavigationItem;
-    use crate::navbar::{CollapseBelow, Navbar, TogglePosition};
+    use crate::navbar::{CollapseBelow, LogoVariant, Navbar, NavbarLogo, TogglePosition};
     use quarto_pandoc_types::config_value::ConfigValue;
     use quarto_pandoc_types::inline::{Inline, Str, Strong};
     use quarto_source_map::SourceInfo;
@@ -1234,7 +1263,9 @@ mod tests {
         assert!(html.contains("<nav class=\"navbar navbar-expand-lg bg-primary\""));
         assert!(html.contains("data-bs-theme=\"dark\""));
         // Brand href falls back to the supplied home_url when no logo_href.
-        assert!(html.contains("<a class=\"navbar-brand\" href=\"./\">My Site</a>"));
+        assert!(html.contains(
+            "<a class=\"navbar-brand\" href=\"./\"><span class=\"navbar-title\">My Site</span></a>"
+        ));
         assert!(html.contains("href=\"index.qmd\""));
         assert!(html.contains("Home"));
     }
@@ -1299,6 +1330,176 @@ mod tests {
         assert!(
             !html.contains("href=\"../\""),
             "home_url must not be used when logo_href is set; html: {}",
+            html
+        );
+    }
+
+    // === Brand structure (bd-navbar-logo-unstyled-gbzd8vcu) =============
+    //
+    // Q1's `navbrand.ejs` shape: a `.navbar-brand-container` div
+    // wrapping a `.navbar-brand.navbar-brand-logo` anchor (the logo
+    // img(s)) and a separate `.navbar-brand` title anchor with a
+    // `.navbar-title` span. User CSS documented against Q1 keys on
+    // these hooks. Q2 deviation (deliberate): a single logo emits ONE
+    // unclassed img where Q1 duplicates it as light-content +
+    // dark-content; behavior is identical because the pair is
+    // normalized (see NavbarLogo::is_single).
+
+    fn logo_variant(path: &str, alt: Option<&str>) -> LogoVariant {
+        LogoVariant {
+            path: path.to_string(),
+            alt: alt.map(str::to_string),
+            source: SourceInfo::for_test(),
+        }
+    }
+
+    fn single_logo(path: &str, alt: Option<&str>) -> NavbarLogo {
+        let v = logo_variant(path, alt);
+        NavbarLogo {
+            light: v.clone(),
+            dark: v,
+        }
+    }
+
+    #[test]
+    fn brand_emits_container_with_logo_and_title_anchors() {
+        let navbar = Navbar {
+            title: NavbarTitle::Text(s("My Site")),
+            logo: Some(single_logo("logo.svg", Some("Site logo"))),
+            ..Navbar::with_defaults()
+        };
+        let html = navbar_to_html(&navbar, None, "./");
+        assert!(
+            html.contains("<div class=\"navbar-brand-container mx-auto\">"),
+            "brand must be wrapped in the Q1 container; html: {}",
+            html
+        );
+        assert!(
+            html.contains(
+                "<a href=\"./\" class=\"navbar-brand navbar-brand-logo\">\
+                 <img src=\"logo.svg\" alt=\"Site logo\" class=\"navbar-logo\"></a>"
+            ),
+            "logo must live in its own navbar-brand-logo anchor; html: {}",
+            html
+        );
+        assert!(
+            html.contains(
+                "<a class=\"navbar-brand\" href=\"./\">\
+                 <span class=\"navbar-title\">My Site</span></a>"
+            ),
+            "title must live in a separate anchor with a navbar-title span; html: {}",
+            html
+        );
+    }
+
+    #[test]
+    fn brand_distinct_variants_emit_light_and_dark_imgs() {
+        let navbar = Navbar {
+            title: NavbarTitle::Text(s("Site")),
+            logo: Some(NavbarLogo {
+                light: logo_variant("l.svg", Some("Light")),
+                dark: logo_variant("d.svg", Some("Dark")),
+            }),
+            ..Navbar::with_defaults()
+        };
+        let html = navbar_to_html(&navbar, None, "./");
+        assert!(
+            html.contains("<img src=\"l.svg\" alt=\"Light\" class=\"navbar-logo light-content\">"),
+            "light variant img with light-content class; html: {}",
+            html
+        );
+        assert!(
+            html.contains("<img src=\"d.svg\" alt=\"Dark\" class=\"navbar-logo dark-content\">"),
+            "dark variant img with dark-content class; html: {}",
+            html
+        );
+    }
+
+    #[test]
+    fn brand_single_logo_img_has_no_variant_class() {
+        let navbar = Navbar {
+            title: NavbarTitle::Text(s("Site")),
+            logo: Some(single_logo("logo.svg", None)),
+            ..Navbar::with_defaults()
+        };
+        let html = navbar_to_html(&navbar, None, "./");
+        assert!(
+            html.contains("<img src=\"logo.svg\" alt=\"\" class=\"navbar-logo\">"),
+            "single logo emits one unclassed img; html: {}",
+            html
+        );
+        assert!(
+            !html.contains("light-content") && !html.contains("dark-content"),
+            "no variant classes for a single logo; html: {}",
+            html
+        );
+    }
+
+    #[test]
+    fn brand_logo_only_omits_title_anchor() {
+        let navbar = Navbar {
+            title: NavbarTitle::Hidden,
+            logo: Some(single_logo("logo.svg", None)),
+            ..Navbar::with_defaults()
+        };
+        let html = navbar_to_html(&navbar, None, "./");
+        assert!(html.contains("<div class=\"navbar-brand-container mx-auto\">"));
+        assert!(html.contains("navbar-brand navbar-brand-logo"));
+        assert!(
+            !html.contains("navbar-title"),
+            "no title anchor when the title is hidden; html: {}",
+            html
+        );
+    }
+
+    #[test]
+    fn brand_title_only_omits_logo_anchor() {
+        let navbar = Navbar {
+            title: NavbarTitle::Text(s("Site")),
+            ..Navbar::with_defaults()
+        };
+        let html = navbar_to_html(&navbar, None, "./");
+        assert!(html.contains("<div class=\"navbar-brand-container mx-auto\">"));
+        assert!(html.contains("<span class=\"navbar-title\">Site</span>"));
+        assert!(
+            !html.contains("navbar-brand-logo"),
+            "no logo anchor without a logo; html: {}",
+            html
+        );
+    }
+
+    #[test]
+    fn brand_both_anchors_share_the_logo_href() {
+        let navbar = Navbar {
+            title: NavbarTitle::Text(s("Site")),
+            logo: Some(single_logo("logo.svg", None)),
+            logo_href: Some("about.html".to_string()),
+            ..Navbar::with_defaults()
+        };
+        let html = navbar_to_html(&navbar, None, "../");
+        assert!(
+            html.contains("<a href=\"about.html\" class=\"navbar-brand navbar-brand-logo\">"),
+            "logo anchor uses logo_href; html: {}",
+            html
+        );
+        assert!(
+            html.contains("<a class=\"navbar-brand\" href=\"about.html\">"),
+            "title anchor uses the same logo_href; html: {}",
+            html
+        );
+        assert!(!html.contains("href=\"../\""), "home_url must not leak in");
+    }
+
+    #[test]
+    fn navbar_wrapper_carries_navbar_container_class() {
+        let navbar = Navbar {
+            title: NavbarTitle::Text(s("Site")),
+            ..Navbar::with_defaults()
+        };
+        let html = navbar_to_html(&navbar, None, "./");
+        assert!(
+            html.contains("<div class=\"navbar-container container-fluid\">"),
+            "the navbar wrapper div must carry Q1's navbar-container class; html: {}",
             html
         );
     }
@@ -1473,11 +1674,13 @@ mod tests {
     fn navbar_wraps_body_in_container_fluid() {
         // Sanity-check the navbar's existing container wrapper; same
         // rationale as the footer, and guards against regressions.
+        // The wrapper also carries Q1's `navbar-container` hook class
+        // (bd-navbar-logo-unstyled-gbzd8vcu).
         let navbar = Navbar::with_defaults();
         let html = navbar_to_html(&navbar, Some(&s("Doc")), "./");
         assert!(
-            html.contains("<div class=\"container-fluid\">"),
-            "navbar should wrap body in .container-fluid: {}",
+            html.contains("<div class=\"navbar-container container-fluid\">"),
+            "navbar should wrap body in .navbar-container.container-fluid: {}",
             html
         );
     }

--- a/crates/quarto-navigation/src/render_html.rs
+++ b/crates/quarto-navigation/src/render_html.rs
@@ -496,15 +496,16 @@ fn render_page_nav_side(html: &mut String, side: &str, item: Option<&NavigationI
 
 fn render_brand(navbar: &Navbar, fallback: Option<&ConfigValue>, home_url: &str) -> Option<String> {
     let href = navbar.logo_href.as_deref().unwrap_or(home_url);
-    let logo_img = navbar.logo.as_deref().map(|logo| {
-        let alt = navbar
-            .logo_alt
+    let logo_img = navbar.logo.as_ref().map(|logo| {
+        let alt = logo
+            .light
+            .alt
             .as_deref()
             .map(escape_attr)
             .unwrap_or_default();
         format!(
             "<img src=\"{}\" alt=\"{}\" class=\"navbar-logo\">",
-            escape_attr(logo),
+            escape_attr(&logo.light.path),
             alt
         )
     });

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -31,6 +31,7 @@ website:
             - guides/authoring/index.qmd
             - guides/projects/create.qmd
             - guides/projects/paths.qmd
+            - guides/projects/navbar-logo.qmd
             - guides/projects/breadcrumbs.qmd
             - guides/projects/render-list.qmd
             - guides/projects/aliases.qmd

--- a/docs/guides/projects/navbar-logo.qmd
+++ b/docs/guides/projects/navbar-logo.qmd
@@ -1,0 +1,63 @@
+---
+title: Navbar logo
+---
+
+## Overview
+
+A website navbar can show a logo to the left of the title. Point
+`website.navbar.logo` at an image in your project:
+
+```yaml
+website:
+  title: "My Site"
+  navbar:
+    logo: images/logo.png
+    logo-alt: "My Site logo"
+```
+
+The logo renders at a maximum height of 24px beside the site title,
+and both link to the site's home page (override the link target with
+`logo-href:`).
+
+## Light and dark variants
+
+Sites with a [dark theme](../formats/html/themes.qmd#dark-mode) can supply a
+different logo for each color mode:
+
+```yaml
+website:
+  navbar:
+    logo:
+      light: images/logo.png
+      dark: images/logo-dark.png
+```
+
+The logo matching the active color mode is shown; toggling the color
+scheme swaps it. Each variant can also carry its own alt text:
+
+```yaml
+website:
+  navbar:
+    logo:
+      light:
+        path: images/logo.png
+        alt: "Logo on light background"
+      dark:
+        path: images/logo-dark.png
+        alt: "Logo on dark background"
+```
+
+If only one variant is given, it is used in both modes. Use
+`logo: false` to suppress the logo entirely.
+
+## Styling
+
+The default 24px sizing can be overridden with CSS. The logo image
+carries the `navbar-logo` class and sits inside its own
+`navbar-brand-logo` anchor:
+
+```css
+.navbar-brand-logo .navbar-logo {
+  max-height: 32px;
+}
+```

--- a/resources/scss/bootstrap/_bootstrap-rules.scss
+++ b/resources/scss/bootstrap/_bootstrap-rules.scss
@@ -2379,6 +2379,56 @@ div.callout.callout-style-default > .callout-header {
   color: $navbar-fg;
 }
 
+// Navbar brand: container + logo styling (bd-navbar-logo-unstyled-gbzd8vcu).
+// Ported from quarto-cli `projects/website/navigation/quarto-nav.scss`
+// against the Q1 `navbrand.ejs` markup shape, which Q2's
+// `render_brand` (quarto-navigation/src/render_html.rs) now emits:
+// `.navbar-brand-container` wrapping a `.navbar-brand.navbar-brand-logo`
+// anchor (the logo img) and a separate `.navbar-brand` title anchor.
+//
+// Deliberately NOT ported (both bd-y5y10oir): the
+// `.navbar-brand-container { max-width: calc(100% - 115px) }` clamp
+// (reserves toggler+search space on narrow viewports) and the
+// `$navbar-title-order`/`$navbar-toggler-order` `order:` system with
+// its `margin !important` pair — Q2 parses `toggle-position` but does
+// not yet wire it into SCSS.
+
+// quarto-nav.scss:116-118.
+.navbar-container {
+  width: 100%;
+}
+
+// quarto-nav.scss:120-123 — long titles truncate instead of overflowing.
+.navbar-brand {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+// quarto-nav.scss:125-134 (minus the width clamp — bd-y5y10oir).
+.navbar-brand-container {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+
+  @include media-breakpoint-up(lg) {
+    margin-right: 1em;
+  }
+}
+
+// quarto-nav.scss:136-139 — spacing between logo anchor and title anchor.
+.navbar-brand.navbar-brand-logo {
+  margin-right: 4px;
+  display: inline-flex;
+}
+
+// quarto-nav.scss:196 — the default logo sizing. Without this a
+// 512px SVG renders at natural size and swallows the navbar.
+.navbar-logo {
+  max-height: 24px;
+  width: auto;
+  padding-right: 4px;
+}
+
 .navbar .quarto-color-scheme-toggle:not(.alternate) .bi::before {
   background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="#{colorToRGBA($navbar-light-color)}" class="bi bi-toggle-off" viewBox="0 0 16 16"><path d="M11 4a4 4 0 0 1 0 8H8a4.992 4.992 0 0 0 2-4 4.992 4.992 0 0 0-2-4h3zm-6 8a4 4 0 1 1 0-8 4 4 0 0 1 0 8zM0 8a5 5 0 0 0 5 5h6a5 5 0 0 0 0-10H5a5 5 0 0 0-5 5z"/></svg>');
 }


### PR DESCRIPTION
## Summary

A `website.navbar.logo` rendered at the image's natural size (a 512px SVG swallowed the navbar) because of two independent defects, both fixed here:

1. **No default sizing rule** — Q1's theme bundle ships `.navbar-logo { max-height: 24px; ... }`; q2 emitted the class but no stylesheet targeted it. The theme bundle now ports the navbar brand rules from Q1's `quarto-nav.scss` into `_bootstrap-rules.scss` (`.navbar-logo`, `.navbar-brand-container` flex layout, `.navbar-brand.navbar-brand-logo`, `.navbar-brand` ellipsis, `.navbar-container` width). The width clamp and `$navbar-title-order` ordering system are deliberately deferred to bd-y5y10oir.
2. **Brand markup dropped Q1's hooks** — user CSS keyed on `.navbar-brand-logo` / `.navbar-brand-container` / `.navbar-title` silently stopped matching. `render_brand` now emits Q1's `navbrand.ejs` structure (container div, separate logo anchor, title anchor with `navbar-title` span), and the navbar wrapper carries Q1's `navbar-container` class.

Per design alignment, the PR also adds **light/dark logo variants**, riding the light/dark theme epic's existing content-class CSS: `Navbar::logo` is a normalized light/dark `LogoVariant` pair accepting `false` | string | `{path, alt}` | `{light, dark}` with cross-fallback and per-variant alt + `SourceInfo`. Distinct variants emit a `light-content`/`dark-content` img pair (toggled by `body.quarto-light/quarto-dark`); a single logo emits one unclassed img (deliberate deviation from Q1's duplicated pair — behavior is identical). Both variant files are copied to `_site` and rebased per page.

Real-world motivation: the Posit Connect docs' navbar logo. Plan: `claude-notes/plans/2026-08-19-navbar-logo-brand-markup.md`.

## Test plan

- TDD throughout: 11 parsing/round-trip tests (`navbar.rs`), 7 markup tests (`render_html.rs`), theme-CSS pipeline test + distinct-variant pipeline test (`navbar_footer_pipeline.rs`) — each verified failing before its implementation.
- Full workspace suite green (12,916); full `cargo xtask verify` (incl. WASM + hub-client leg) green.
- End-to-end: repro rendered through the real `q2 render`, output inspected; live-browser check confirms the light logo at a computed 24px and the color-scheme toggle swapping to the dark variant (evidence in `claude-notes/plans/navbar-logo-brand-markup-investigation/NOTES.md`).

## Snapshot / baseline changes

- No `.snap` files changed. One baseline re-capture: `phase5-single-doc-baseline/expected_hashes.txt` `styles.css` hash (CSS-only — the new selectors match nothing in a single-doc body; `doc.html` hash unchanged), with an explanatory note per that file's convention.
- Docs: new `docs/guides/projects/navbar-logo.qmd` + sidebar entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)