### PR TITLE
Fix the behave F4 crash-relaunch witness's race on the async launch marker (bd-qlnkdw9u)

### DIFF
--- a/claude-notes/plans/2026-08-19-behave-f4-launch-marker-race.md
+++ b/claude-notes/plans/2026-08-19-behave-f4-launch-marker-race.md
@@ -1,0 +1,118 @@
+# behave F4 crash-relaunch e2e: async launch-marker race (bd-qlnkdw9u)
+
+## Overview
+
+`behave_engine_e2e::f4_crash_yields_process_crashed_then_transparently_relaunches`
+failed on PR #560's CI (ubuntu-latest, run 32279995673, 2026-08-19) — an
+unrelated, lockfile-only PR. The assertion at
+`crates/quarto-core/tests/integration/behave_engine_e2e.rs:681` expected
+`count_containing("BEHAVE_LAUNCH_MARKER:1") == 2` and got 1:
+
+```
+captured engine_host messages: ["engine-host connected over loopback TCP",
+ "engine-host spawned", "BEHAVE_LAUNCH_MARKER:1",
+ "BEHAVE_CRASH_MARKER: intentional crash for Phase 4b-F crash-path e2e",
+ "engine-host connected over loopback TCP", "engine-host spawned"]
+```
+
+**This is a test-side race, not a product bug.** The "crash" in the CI log is
+the fixture's own intentional `BEHAVE_CRASH` → `Deno.exit(1)`, and the crash
+recovery demonstrably worked: witness 1 ("engine-host spawned" seen twice,
+line 668) passed, and execute-2 had already returned `Ok` before the failing
+assertion ran. What was missing is process #2's `BEHAVE_LAUNCH_MARKER:1`
+stderr line — and only in the *capture*, not in reality.
+
+### Root cause
+
+The two witnesses have different delivery paths:
+
+- `"engine-host spawned"` is a `tracing` event emitted **synchronously on the
+  calling thread** inside `ensure_started_inner` (`ts_process.rs:978`), so it
+  is always captured before `execute()` returns.
+- `BEHAVE_LAUNCH_MARKER:1` is written by the fixture's `console.error`, flows
+  through the child's **stderr pipe**, and is forwarded into `tracing` by the
+  **background stderr-forwarding thread** (`ts_process.rs::stderr_loop`,
+  ~:1582). This path is fully decoupled from the request/response transport:
+  execute-2 completing guarantees nothing about when (or whether yet) the
+  marker line has been forwarded. On a loaded ubuntu runner the forwarder
+  simply hadn't run when the bare `count_containing()` executed.
+
+### Precedent
+
+Exactly this race hit F3 on 2026-08-18 (loaded ubuntu runner, passed on
+macos-latest, same commit) and was fixed in `ae01254ce` by introducing
+`LaunchMarkerCapture::wait_for_count_containing` (bounded poll + trailing
+settle that preserves the `== expected` upper bound). That commit applied the
+helper to F3's `:2` relaunch witness only; F4's witness-2 — and the other
+async-marker equality checks in F3/F4 that rest on fixed 200 ms sleeps —
+stayed bare. CI has now reproduced the documented failure mode at one of
+those remaining sites.
+
+## The fix
+
+Convert every assertion in `behave_engine_e2e.rs` that counts an
+**asynchronously delivered** stderr marker from bare
+`count_containing()` (guarded only by a fixed 200 ms sleep) to
+`wait_for_count_containing(needle, expected, 10s)`:
+
+- F4 line ~681 (the CI failure): `BEHAVE_LAUNCH_MARKER:1` == 2 after
+  execute-2 — the mandatory fix.
+- F4 lines ~637/~644: crash marker == 1 and `BEHAVE_LAUNCH_MARKER:1` == 1
+  before execute-2 (same class; replaces the fixed 200 ms sleep).
+- F3 line ~468: `BEHAVE_LAUNCH_MARKER:1` == 1 before execute-2 (same class;
+  replaces the fixed 200 ms sleep). The `:2 == 0` absence check at ~475 keeps
+  its protection via the preceding wait's trailing settle.
+
+Assertions on `"engine-host spawned"` stay bare — that event is synchronous
+and cannot race. The helper's trailing settle preserves each `== expected`
+upper bound (a spurious extra marker/relaunch still fails), so no binding is
+weakened.
+
+## TDD note (fail-first evidence)
+
+The race depends on the stderr-forwarder losing a scheduling race, which is
+not deterministically reproducible on an idle dev machine. To honor the
+fail-first discipline anyway, verification uses a **temporary, local-only
+delay injection** in `stderr_loop` (sleep before forwarding lines containing
+`BEHAVE_LAUNCH_MARKER`; never committed):
+
+1. With the delay injected and only the *pre*-execute-2 checks hardened,
+   F4 must fail at the witness-2 assertion with the exact CI signature
+   (spawned == 2 captured, marker count 1).
+2. With the full fix applied (delay still injected), F4 must pass.
+3. Delay removed; normal runs + a repetition loop confirm stability.
+
+## Work items
+
+- [x] File strand bd-qlnkdw9u; link this plan
+- [x] Worktree `.worktrees/bd-qlnkdw9u-behave-f4-crash-relaunch`
+- [x] Write this plan document
+- [x] Harden F4 pre-execute-2 async checks (~:637, ~:644) with `wait_for_count_containing`
+- [x] Fail-first: injected stderr delay (750 ms on marker lines) reproduces the
+      CI failure exactly — panic at :681, `left: 1, right: 2`, identical
+      captured-messages list, hardened pre-checks and the synchronous
+      spawned == 2 witness all passing
+- [x] Fix: witness-2 (~:681) uses `wait_for_count_containing(_, 2, 10s)`;
+      full behave suite 6/6 green with the delay still injected
+- [x] Harden F3 pre-execute-2 check (~:468) the same way; remove the fixed sleeps
+- [x] Remove the temporary delay injection (`git diff` clean on `src/`)
+- [x] Run the behave e2e suite normally (6/6) + F4 repetition loop (30/30)
+- [x] Full `cargo nextest run --workspace` (12907/12907 passed, 198 skipped)
+      + review checklist (fmt clean, clippy clean, no HashMap/TODO in diff)
+- [x] Commit; braid comment with results
+
+## Results (2026-08-19)
+
+Fail-first evidence: with a local-only 750 ms delay injected into
+`stderr_loop` for `BEHAVE_LAUNCH_MARKER` lines and only the pre-execute-2
+checks hardened, F4 failed at the witness-2 assertion with the exact CI
+signature — panic at `behave_engine_e2e.rs:681`, `left: 1, right: 2`, and a
+captured-messages list identical to the CI run's. With the witness-2 fix
+applied and the delay still injected, the full behave suite passed 6/6
+(proving the fix tolerates a forwarder stall far larger than the one CI
+hit). Delay reverted; `git diff` on `crates/quarto-core/src/` is empty —
+this change touches only the test file. Normal runs: behave suite 6/6, F4
+30/30 in a repetition loop, full workspace suite green. All fixed
+200 ms sleeps in the file are gone; every async-marker equality check now
+rides the bounded-poll helper, while the synchronous "engine-host spawned"
+assertions stay bare (they cannot race).

--- a/crates/quarto-core/tests/integration/behave_engine_e2e.rs
+++ b/crates/quarto-core/tests/integration/behave_engine_e2e.rs
@@ -461,11 +461,14 @@ fn f3_timeout_poisons_then_transparently_relaunches() {
         "expected Err(Timeout) from the QUARTO_SLOW execute under a 1s window; got {r1:?}"
     );
 
-    // Give the background stderr-forwarding thread a moment to deliver
-    // execute-1's own launch marker before checking the pre-execute-2 count.
-    std::thread::sleep(Duration::from_millis(200));
+    // Execute-1's own launch marker arrives via the background
+    // stderr-forwarding thread, so a bare count races it (the same async
+    // delivery behind the F3/F4 CI flakes — see `wait_for_count_containing`).
+    // Bounded poll, not a fixed sleep; the helper's trailing settle preserves
+    // this `== 1` upper bound and shields the `:2 == 0` absence check below
+    // exactly as the removed 200ms sleep did.
     assert_eq!(
-        capture.count_containing("BEHAVE_LAUNCH_MARKER:1"),
+        capture.wait_for_count_containing("BEHAVE_LAUNCH_MARKER:1", 1, Duration::from_secs(10)),
         1,
         "expected exactly one initial launch (execute-1's own ensure_launched); \
          captured engine_host messages: {:?}",
@@ -627,21 +630,21 @@ fn f4_crash_yields_process_crashed_then_transparently_relaunches() {
         "expected Err(ProcessCrashed) from the BEHAVE_CRASH execute; got {r1:?}"
     );
 
-    // Give the background stderr-forwarding thread a moment to deliver
-    // process #1's launch marker + crash marker before checking the
-    // pre-execute-2 counts. `handle_crash` itself already sleeps ~250ms
-    // waiting for the stderr thread to drain before broadcasting
-    // ProcessCrashed, so this is a small top-up, not the primary wait.
-    std::thread::sleep(Duration::from_millis(200));
+    // The crash marker and process #1's launch marker arrive via the
+    // background stderr-forwarding thread, so bare counts race it — the same
+    // async delivery that made this test's witness-2 assertion flake on a
+    // loaded ubuntu runner (2026-08-19, PR #560 CI; see
+    // `wait_for_count_containing`). Bounded polls, not fixed sleeps; the
+    // helper's trailing settle preserves the `== 1` upper bounds.
     assert_eq!(
-        capture.count_containing("BEHAVE_CRASH_MARKER"),
+        capture.wait_for_count_containing("BEHAVE_CRASH_MARKER", 1, Duration::from_secs(10)),
         1,
         "expected the crash marker behave.ts writes immediately before \
          Deno.exit(1); captured engine_host messages: {:?}",
         capture.all()
     );
     assert_eq!(
-        capture.count_containing("BEHAVE_LAUNCH_MARKER:1"),
+        capture.wait_for_count_containing("BEHAVE_LAUNCH_MARKER:1", 1, Duration::from_secs(10)),
         1,
         "expected exactly one initial launch in process #1 (execute-1's own \
          ensure_launched, before the crash); captured engine_host messages: {:?}",
@@ -677,9 +680,14 @@ fn f4_crash_yields_process_crashed_then_transparently_relaunches() {
     // `launch()` call -- process #2's `_behaveLaunchCount` starts fresh at 0
     // (crash wiped process #1's in-memory state), so a genuine relaunch
     // prints "BEHAVE_LAUNCH_MARKER:1" AGAIN, not ":2" (see the module
-    // comment above for why this differs from F3's witness shape).
+    // comment above for why this differs from F3's witness shape). Bounded
+    // poll, not a bare count: unlike witness 1's synchronous "engine-host
+    // spawned" event, this marker rides the background stderr forwarder, and
+    // a bare count raced it on a loaded ubuntu runner (2026-08-19, PR #560
+    // CI — the F4 twin of the F3 flake `wait_for_count_containing` was
+    // introduced for).
     assert_eq!(
-        capture.count_containing("BEHAVE_LAUNCH_MARKER:1"),
+        capture.wait_for_count_containing("BEHAVE_LAUNCH_MARKER:1", 2, Duration::from_secs(10)),
         2,
         "expected TWO independent first-launches (one per process) between \
          execute-1 and execute-2; captured engine_host messages: {:?}",


### PR DESCRIPTION
## Summary

`behave_engine_e2e::f4_crash_yields_process_crashed_then_transparently_relaunches` flaked on PR #560's CI (ubuntu-latest, run 32279995673) — an unrelated, lockfile-only PR. Its witness-2 assertion counted `BEHAVE_LAUNCH_MARKER:1` with a bare `count_containing()` immediately after execute-2 returned, but that marker is delivered by the background stderr-forwarding thread (`ts_process.rs::stderr_loop`), fully decoupled from the request/response transport — on the loaded runner it hadn't been forwarded yet. The crash recovery itself worked: both `"engine-host spawned"` events were captured (that event fires synchronously on the calling thread) and execute-2 had already returned `Ok`.

This is the F4 twin of the F3 flake fixed in `ae01254ce` (2026-08-18), which introduced `wait_for_count_containing` (bounded poll + trailing settle) but applied it only to F3's `:2` witness.

## The fix

Test-only; no production code changes. Every assertion in `behave_engine_e2e.rs` that counts an **asynchronously delivered** stderr marker now uses `wait_for_count_containing(_, expected, 10s)`:

- F4's witness-2 (`BEHAVE_LAUNCH_MARKER:1 == 2` after execute-2) — the CI failure.
- The pre-execute-2 checks in F3 and F4 (same race class; their fixed 200 ms sleeps are removed).

Synchronous `"engine-host spawned"` assertions stay bare — they cannot race. The helper's trailing settle preserves each `== expected` upper bound, so no binding is weakened (a spurious extra launch/relaunch still fails).

Root-cause writeup: `claude-notes/plans/2026-08-19-behave-f4-launch-marker-race.md` (included in this PR).

## Test plan

- **Fail-first repro**: with a temporary, uncommitted 750 ms delay injected into `stderr_loop` for marker lines and only the pre-checks hardened, F4 failed at the witness-2 assertion with the *byte-for-byte identical* signature to the CI failure (`left: 1, right: 2`, same captured-messages list).
- With the fix applied and the delay still injected, the behave suite passed 6/6 — the fix tolerates a forwarder stall far larger than the one CI hit.
- Delay reverted (`git diff` on `crates/quarto-core/src/` empty). Normal runs: behave suite 6/6, F4 green 30/30 in a repetition loop.
- Full `cargo nextest run --workspace` green (12907/12907, 198 skipped); full `cargo xtask verify --skip-hub-build` green.

Strand: bd-qlnkdw9u.

🤖 Generated with [Claude Code](https://claude.com/claude-code)