### PR TITLE
Forward the underlying markdown diagnostic through Q-1-20 for config values

### DIFF
--- a/claude-notes/plans/2026-08-19-q120-forward-underlying-diagnostic.md
+++ b/claude-notes/plans/2026-08-19-q120-forward-underlying-diagnostic.md
@@ -142,7 +142,7 @@ investigation dir's `observed-output.txt` for the captured render output.
 
 ### Phase 3 — Verification + docs
 
-- [ ] Full `cargo xtask verify` green (includes `cargo nextest run
+- [x] Full `cargo xtask verify` green (includes `cargo nextest run
   --workspace`; pampa is in the WASM closure).
 - [x] End-to-end: `cargo run --bin q2 -- render` on the repro fixture;
   captured output (`repro/observed-output.txt`, inspected) shows the
@@ -150,10 +150,10 @@ investigation dir's `observed-output.txt` for the captured render output.
   ("This key-value pair cannot appear before the class specifier." /
   "This class specifier appears after the key-value pair.") plus an
   `ℹ [Q-2-3] Key-value Pair Before Class Specifier in Attribute` footer.
-- [ ] Check `docs/errors/yaml/Q-1-20.qmd` — message text unchanged (decision
+- [x] Check `docs/errors/yaml/Q-1-20.qmd` — message text unchanged (decision
   4), so likely no edit; update only if it shows example output that now
   differs materially.
-- [ ] Close the strand.
+- [x] Close the strand (commit 4e116ba5).
 
 ## Risks / tradeoffs (draft)
 

--- a/claude-notes/plans/2026-08-19-q120-forward-underlying-diagnostic.md
+++ b/claude-notes/plans/2026-08-19-q120-forward-underlying-diagnostic.md
@@ -1,0 +1,153 @@
+# Q-1-20 discards the underlying markdown diagnostic for config values (bd-q120-masks-config-md-diagnostic-a039r80t)
+
+**Date:** 2026-08-19
+**Braid:** bd-q120-masks-config-md-diagnostic-a039r80t
+**Checkout:** main checkout at `/Users/cscheid/rooms/room-3/q2`, branch `main` @ `6bee9ebe`
+**Status:** Investigation — pending design alignment with user. **Do not start implementation until the user gives the go-ahead.**
+
+## Triage verdict
+
+**Ready to design.** The strand's root-cause analysis is accurate at HEAD, the repro
+reproduces, and the fix surface is small — but the strand's optimistic note that
+"the child spans should already be in config coordinates" is **wrong**, and that
+changes the shape of the fix (a span-remapping step is required, see below).
+
+## Issue context
+
+Filed 2026-08-20 (UTC) by a Claude session in the external `q2-connect-docs` repo
+(origin strand `br-q120-masks-config-md-diagnostic-irbgj5ht` in that repo's skein).
+Type: feature, priority 3, label `diagnostics`. Status: open.
+
+When a config metadata value fails to parse as markdown,
+`parse_yaml_string_as_markdown_to_config` (crates/pampa/src/pandoc/meta.rs) emits
+only the generic Q-1-20 ("Could not parse '…' as markdown", plus the `!str` hint)
+and **discards the underlying parser diagnostics** — the `Err(_parse_errors)` arm's
+leading underscore says it. The same markdown in a document body produces the
+precise Q-2-3 ("Key-value Pair Before Class Specifier in Attribute") with a
+two-part span. Porting relevance: Pandoc/Q1 accept either attribute order, so
+kv-before-class markdown that worked for years in Q1 configs fails in q2 configs
+with no explanation of *what* to fix.
+
+## Dependency graph
+
+**Empty** — no edges in this repo's skein (`braid dep tree` / `dep list` show
+nothing). The discovered-from context lives in the *external* q2-connect-docs
+skein and is summarized in the description itself, which is unusually thorough.
+No incoming `blocks` pressure; priority 3 reflects that.
+
+## What the code looks like today
+
+All paths in the description still exist with the described shape (verified at
+`6bee9ebe`):
+
+- **The discard site:** `crates/pampa/src/pandoc/meta.rs:120` —
+  `Err(_parse_errors)` receives `Vec<DiagnosticMessage>` from
+  `readers::qmd::read` and drops it, then builds the generic Q-1-20 in both the
+  `!md` (error) and untagged (warning) branches.
+- **The Ok arm one branch up** (meta.rs:107–111) already forwards
+  recursive-parse *warnings* into the collector, so the forwarding plumbing
+  exists — for the Ok path only.
+
+### Key correction to the strand's suggested fix
+
+The strand asserts "the parse is seeded with the scalar's SourceInfo, so the
+child spans should already be in config coordinates." **That holds only for the
+Ok path.** Ok-path spans are built via `node_source_info_with_context` /
+`range_to_source_info_with_context` (crates/pampa/src/pandoc/location.rs:214,
+257), which reroot through `context.parent_source_info` with
+`SourceInfo::substring`. The **Err path does not**: `readers::qmd::read`
+(crates/pampa/src/readers/qmd.rs:131) calls `produce_diagnostic_messages`
+*without* the parent SourceInfo, and the generic generator
+(crates/quarto-parse-errors/src/error_generation.rs:139, 217) builds every
+location — the main span *and* the note spans — as
+`SourceInfo::from_range(FileId(0), …)`, i.e. raw offsets into the embedded
+string against the throwaway `<metadata>` file. Forwarding those diagnostics
+naively would render spans against the wrong file — exactly the bd-m6wmztln
+bug class the `add-file-with-id` lint exists for. **The fix must remap child
+spans** (`SourceInfo::substring(parent, start, end)` using each location's
+resolved byte range) before forwarding.
+
+### Remapping is possible in-tree
+
+`DiagnosticMessage` (quarto-error-reporting 0.2.1) exposes `location`,
+`details: Vec<DetailItem>` (each with `location: Option<SourceInfo>`), and
+`kind` as **public fields**, so a remap/demote helper needs no new API in the
+externalized crate.
+
+### Who benefits
+
+Non-test callers of `readers::qmd::read` with `Some(parent_source_info)`:
+`pandoc/meta.rs:103` (this strand) and `lua/config_value.rs:620` (Lua-filter
+config values). Rerooting at the source (option B below) fixes both.
+
+### Repro (reproduced at HEAD)
+
+In-repo fixture: `claude-notes/plans/q120-forward-underlying-diagnostic-investigation/repro/`
+(`q2 render` there shows the generic Q-1-20 warning for the footer config and
+the precise Q-2-3 error for the identical text in `body-control.qmd`). See the
+investigation dir's `observed-output.txt` for the captured render output.
+
+## Proposed phases (draft)
+
+Skeleton only — actual phase contents wait on the design discussion.
+
+- **Phase 0 — Test plan (TDD).** Unit tests in `pampa::pandoc::meta` following
+  the existing `config_string_image_target_source_reroots_through_parent`
+  pattern: parse `![logo](x.svg){width="65px" .light-content}` with a parent
+  `SourceInfo::original(FileId(7), 100, …)`; assert the emitted diagnostics
+  carry the underlying Q-2-3 content AND that every forwarded span
+  (`location` + detail locations) `resolve_byte_range()`s into FileId(7) at
+  shifted offsets. Plus an end-to-end render test against the repro fixture
+  shape (per the end-to-end verification policy).
+- **Phase 1 — Span rerooting for Err-path diagnostics.** Either in
+  `readers::qmd::read` / `produce_diagnostic_messages` (at birth) or via a
+  remap helper applied in `meta.rs` (post-hoc) — see design question 1.
+- **Phase 2 — Forward the diagnostics from `parse_yaml_string_as_markdown_to_config`.**
+  Attach/emit remapped child diagnostics in both the `!md` and untagged
+  branches; resolve the severity question (design question 2).
+- **Phase 3 — End-to-end verification + docs.** Render the repro fixture via
+  `cargo run --bin q2 -- render`, inspect stderr; update
+  `docs/errors/*/Q-1-20.qmd` if the message shape changed.
+
+## Open design questions for the user
+
+1. **Where to reroot the spans.** (a) At birth: thread `parent_source_info`
+   into `readers::qmd::read`'s error path so `produce_diagnostic_messages`
+   builds rerooted spans — matches how the Ok path behaves, and fixes the Lua
+   `config_value.rs` caller for free; requires a signature change in
+   `quarto-parse-errors::produce_diagnostic_messages` (in-tree, cheap). (b)
+   Post-hoc: a `remap_diagnostic_into_parent(diag, parent)` helper applied only
+   in `meta.rs` — smaller blast radius, but leaves the Err path's
+   coordinate-domain trap armed for the next caller. I lean (a).
+2. **Severity in the untagged branch.** Today an untagged config value that
+   fails to parse is a *warning* + literal-text fallback; the underlying parser
+   diagnostics are *errors*. Forwarding them as errors would turn a
+   warn-and-continue situation into a render failure. Options: (a) demote
+   forwarded children to warnings (`kind` is a pub field); (b) fold the
+   children into the single Q-1-20 warning as located details
+   (`add_info_at`-style), keeping one diagnostic; (c) keep them errors
+   (behavior change). For the `!md` branch the parse failure is already an
+   error, so children can stay errors there. I lean (b) for untagged — one
+   diagnostic, Q-1-20 stays the code, the child's message + two-part span
+   become its details — and (b)-or-sibling-errors for `!md`.
+3. **All children or first?** A config string that fails to parse can produce
+   several diagnostics (the generator dedups by position but can still emit
+   more than one). Forward all, or first-N with a "and N more" note? (Config
+   strings are short; I lean "all".)
+4. **Does Q-1-20's own text change?** If children are folded in as details,
+   the "Could not parse '…' as markdown" problem line could drop the raw value
+   echo (the span already shows it) — or stay unchanged for snapshot stability.
+   Any change ripples into snapshots and possibly `docs/errors` examples.
+
+## Risks / tradeoffs (draft)
+
+- **Snapshot churn:** Q-1-20 renders in existing snapshot tests; changing its
+  detail structure will touch snapshots (must be called out per the snapshot
+  policy).
+- **quarto-error-reporting is external:** the plan above deliberately uses only
+  public fields; if the design lands on needing a real "nested diagnostic"
+  concept, that becomes an upstream (posit-dev/quarto-error-reporting) change
+  and a version bump — scope grows.
+- **The Err-path coordinate-domain trap** (spans in `FileId(0)`-of-a-throwaway
+  context) is a latent bug class beyond this strand; option 1(a) retires it,
+  option 1(b) leaves it documented-but-armed.

--- a/claude-notes/plans/2026-08-19-q120-forward-underlying-diagnostic.md
+++ b/claude-notes/plans/2026-08-19-q120-forward-underlying-diagnostic.md
@@ -3,7 +3,7 @@
 **Date:** 2026-08-19
 **Braid:** bd-q120-masks-config-md-diagnostic-a039r80t
 **Checkout:** main checkout at `/Users/cscheid/rooms/room-3/q2`, branch `main` @ `6bee9ebe`
-**Status:** Investigation — pending design alignment with user. **Do not start implementation until the user gives the go-ahead.**
+**Status:** Design settled 2026-08-20 (user answered all four questions); implementation in progress.
 
 ## Triage verdict
 
@@ -87,57 +87,73 @@ In-repo fixture: `claude-notes/plans/q120-forward-underlying-diagnostic-investig
 the precise Q-2-3 error for the identical text in `body-control.qmd`). See the
 investigation dir's `observed-output.txt` for the captured render output.
 
-## Proposed phases (draft)
+## Settled design (user answered 2026-08-20)
 
-Skeleton only — actual phase contents wait on the design discussion.
+1. **Reroot at birth** (option a). Implementation refinement: the reroot
+   happens inside `readers::qmd::read` immediately before the `Err` return —
+   *after* `produce_diagnostic_messages` and the pruning/widening passes, which
+   do their offset arithmetic in the raw-input-bytes domain and must keep doing
+   so. From every caller's perspective the diagnostics are born rerooted; the
+   Lua `config_value.rs:620` caller is fixed for free; no signature change in
+   `quarto-parse-errors` needed.
+2. **Fold children into the single Q-1-20 diagnostic as located details**
+   (option b). Untagged branch stays a warning; `!md` branch stays an error;
+   in both, each child diagnostic's title (+code) and its located notes become
+   `add_info_at` details on the Q-1-20 message. No severity change.
+3. **Forward all children.** Revisit only on a compelling real-world "too
+   many diagnostics" case.
+4. **Q-1-20's own text unchanged.**
 
-- **Phase 0 — Test plan (TDD).** Unit tests in `pampa::pandoc::meta` following
-  the existing `config_string_image_target_source_reroots_through_parent`
-  pattern: parse `![logo](x.svg){width="65px" .light-content}` with a parent
-  `SourceInfo::original(FileId(7), 100, …)`; assert the emitted diagnostics
-  carry the underlying Q-2-3 content AND that every forwarded span
-  (`location` + detail locations) `resolve_byte_range()`s into FileId(7) at
-  shifted offsets. Plus an end-to-end render test against the repro fixture
-  shape (per the end-to-end verification policy).
-- **Phase 1 — Span rerooting for Err-path diagnostics.** Either in
-  `readers::qmd::read` / `produce_diagnostic_messages` (at birth) or via a
-  remap helper applied in `meta.rs` (post-hoc) — see design question 1.
-- **Phase 2 — Forward the diagnostics from `parse_yaml_string_as_markdown_to_config`.**
-  Attach/emit remapped child diagnostics in both the `!md` and untagged
-  branches; resolve the severity question (design question 2).
-- **Phase 3 — End-to-end verification + docs.** Render the repro fixture via
-  `cargo run --bin q2 -- render`, inspect stderr; update
-  `docs/errors/*/Q-1-20.qmd` if the message shape changed.
+## Phases
 
-## Open design questions for the user
+### Phase 0 — Tests (TDD, written first, verified failing)
 
-1. **Where to reroot the spans.** (a) At birth: thread `parent_source_info`
-   into `readers::qmd::read`'s error path so `produce_diagnostic_messages`
-   builds rerooted spans — matches how the Ok path behaves, and fixes the Lua
-   `config_value.rs` caller for free; requires a signature change in
-   `quarto-parse-errors::produce_diagnostic_messages` (in-tree, cheap). (b)
-   Post-hoc: a `remap_diagnostic_into_parent(diag, parent)` helper applied only
-   in `meta.rs` — smaller blast radius, but leaves the Err path's
-   coordinate-domain trap armed for the next caller. I lean (a).
-2. **Severity in the untagged branch.** Today an untagged config value that
-   fails to parse is a *warning* + literal-text fallback; the underlying parser
-   diagnostics are *errors*. Forwarding them as errors would turn a
-   warn-and-continue situation into a render failure. Options: (a) demote
-   forwarded children to warnings (`kind` is a pub field); (b) fold the
-   children into the single Q-1-20 warning as located details
-   (`add_info_at`-style), keeping one diagnostic; (c) keep them errors
-   (behavior change). For the `!md` branch the parse failure is already an
-   error, so children can stay errors there. I lean (b) for untagged — one
-   diagnostic, Q-1-20 stays the code, the child's message + two-part span
-   become its details — and (b)-or-sibling-errors for `!md`.
-3. **All children or first?** A config string that fails to parse can produce
-   several diagnostics (the generator dedups by position but can still emit
-   more than one). Forward all, or first-N with a "and N more" note? (Config
-   strings are short; I lean "all".)
-4. **Does Q-1-20's own text change?** If children are folded in as details,
-   the "Could not parse '…' as markdown" problem line could drop the raw value
-   echo (the span already shows it) — or stay unchanged for snapshot stability.
-   Any change ripples into snapshots and possibly `docs/errors` examples.
+- [x] `pampa::pandoc::meta` unit test (untagged): parse
+  `![logo](images/logo.svg){width="65px" .light-content}` with parent
+  `SourceInfo::original(FileId(7), 100, …)`; assert single Q-1-20 warning
+  whose details carry the Q-2-3 content, with every detail location
+  resolving into FileId(7) at offsets shifted by 100.
+  (`config_string_parse_failure_forwards_underlying_diagnostic`)
+- [x] `pampa::pandoc::meta` unit test (`!md` branch): same input via
+  `parse_yaml_string_as_markdown_to_config(…, is_explicit_md = true, …)`;
+  assert error kind + forwarded located details.
+  (`explicit_md_parse_failure_forwards_underlying_diagnostic`)
+- [x] Reroot test at the `read` level (covers the Lua caller path):
+  `readers::qmd::tests::err_path_diagnostics_reroot_through_parent_source_info`.
+- [x] All three verified failing before the fix (FileId(0), raw offsets
+  38..52 observed in the failure output).
+
+### Phase 1 — Reroot Err-path diagnostics in `readers::qmd::read`
+
+- [x] `reroot_diagnostics_into_parent` walks each diagnostic's `location` +
+  `details[].location` and rebuilds them as
+  `SourceInfo::substring(parent, start, end)` from the resolved byte range.
+- [x] Applied when `context.parent_source_info` is `Some`, after pruning,
+  before `return Err(diagnostics)`.
+
+### Phase 2 — Forward children from `parse_yaml_string_as_markdown_to_config`
+
+- [x] `fold_child_diagnostics` in `meta.rs`, applied in both the `!md` and
+  untagged branches. Folding shape (refined after e2e inspection): the
+  child's `problem` becomes the located label on the child's main span —
+  so the config rendering mirrors the body rendering exactly — and
+  `[code] title` becomes a location-less Info footer line; child details
+  keep their own `DetailKind`; child hints forwarded with exact-dup dedup.
+
+### Phase 3 — Verification + docs
+
+- [ ] Full `cargo xtask verify` green (includes `cargo nextest run
+  --workspace`; pampa is in the WASM closure).
+- [x] End-to-end: `cargo run --bin q2 -- render` on the repro fixture;
+  captured output (`repro/observed-output.txt`, inspected) shows the
+  Q-1-20 warning on `_quarto.yml:8` carrying the Q-2-3 two-part span
+  ("This key-value pair cannot appear before the class specifier." /
+  "This class specifier appears after the key-value pair.") plus an
+  `ℹ [Q-2-3] Key-value Pair Before Class Specifier in Attribute` footer.
+- [ ] Check `docs/errors/yaml/Q-1-20.qmd` — message text unchanged (decision
+  4), so likely no edit; update only if it shows example output that now
+  differs materially.
+- [ ] Close the strand.
 
 ## Risks / tradeoffs (draft)
 

--- a/claude-notes/plans/q120-forward-underlying-diagnostic-investigation/README.md
+++ b/claude-notes/plans/q120-forward-underlying-diagnostic-investigation/README.md
@@ -1,0 +1,36 @@
+# Investigation artifacts — bd-q120-masks-config-md-diagnostic-a039r80t
+
+Plan: `../2026-08-19-q120-forward-underlying-diagnostic.md`
+
+## repro/
+
+Minimal in-repo version of the external repro
+(`q2-connect-docs/llms-info/repros/q120-masks-config-md-diagnostic/`).
+A website project whose `_quarto.yml` `page-footer.center` contains
+markdown that fails q2's attribute grammar (key-value pair before
+class specifier):
+
+```markdown
+![logo](images/logo.svg){width="65px" .light-content}
+```
+
+`body-control.qmd` contains the identical text in a document body.
+
+Run:
+
+```bash
+cargo run --bin q2 -- render claude-notes/plans/q120-forward-underlying-diagnostic-investigation/repro
+```
+
+Observed at main @ 6bee9ebe (captured, ANSI-stripped, in
+`repro/observed-output.txt`):
+
+- body-control.qmd → **Q-2-3** error with the precise two-part span
+  ("This key-value pair cannot appear before the class specifier" /
+  "This class specifier appears after the key-value pair").
+- _quarto.yml footer → only the generic **Q-1-20** warning
+  ("Could not parse '…' as markdown" + `!str` hint). The underlying
+  Q-2-3 is discarded at `crates/pampa/src/pandoc/meta.rs:120`
+  (`Err(_parse_errors)`).
+
+`_site/` output is deleted before commit; re-render to regenerate.

--- a/claude-notes/plans/q120-forward-underlying-diagnostic-investigation/repro/_quarto.yml
+++ b/claude-notes/plans/q120-forward-underlying-diagnostic-investigation/repro/_quarto.yml
@@ -1,0 +1,8 @@
+project:
+  type: website
+
+website:
+  title: "q120 repro"
+  page-footer:
+    center: |
+      ![logo](images/logo.svg){width="65px" .light-content}

--- a/claude-notes/plans/q120-forward-underlying-diagnostic-investigation/repro/body-control.qmd
+++ b/claude-notes/plans/q120-forward-underlying-diagnostic-investigation/repro/body-control.qmd
@@ -1,0 +1,1 @@
+![logo](images/logo.svg){width="65px" .light-content}

--- a/claude-notes/plans/q120-forward-underlying-diagnostic-investigation/repro/images/logo.svg
+++ b/claude-notes/plans/q120-forward-underlying-diagnostic-investigation/repro/images/logo.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"/>

--- a/claude-notes/plans/q120-forward-underlying-diagnostic-investigation/repro/index.qmd
+++ b/claude-notes/plans/q120-forward-underlying-diagnostic-investigation/repro/index.qmd
@@ -1,0 +1,5 @@
+---
+title: Home
+---
+
+hello

--- a/claude-notes/plans/q120-forward-underlying-diagnostic-investigation/repro/observed-output.txt
+++ b/claude-notes/plans/q120-forward-underlying-diagnostic-investigation/repro/observed-output.txt
@@ -1,0 +1,22 @@
+Rendering project: /Users/cscheid/rooms/room-3/q2/claude-notes/plans/q120-forward-underlying-diagnostic-investigation/repro (type: website)
+warning: profile-pass skipped /Users/cscheid/rooms/room-3/q2/claude-notes/plans/q120-forward-underlying-diagnostic-investigation/repro/body-control.qmd: Error: [Q-2-3] Key-value Pair Before Class Specifier in Attribute
+   ╭─[ ]8;;file:///Users/cscheid/rooms/room-3/q2/claude-notes/plans/q120-forward-underlying-diagnostic-investigation/repro/body-control.qmd#1:39\/Users/cscheid/rooms/room-3/q2/claude-notes/plans/q120-forward-underlying-diagnostic-investigation/repro/body-control.qmd:1:39]8;;\ ]
+   │
+ 1 │ ![logo](images/logo.svg){width="65px" .light-content}
+   │                          ──────┬───── ───────┬──────  
+   │                                ╰────────────────────── This key-value pair cannot appear before the class specifier.
+   │                                              │        
+   │                                              ╰──────── This class specifier appears after the key-value pair.
+───╯
+
+Warning: [Q-1-20] Failed to parse metadata value as markdown
+   ╭─[ ]8;;file:///Users/cscheid/rooms/room-3/q2/claude-notes/plans/q120-forward-underlying-diagnostic-investigation/repro/_quarto.yml#8:7\/Users/cscheid/rooms/room-3/q2/claude-notes/plans/q120-forward-underlying-diagnostic-investigation/repro/_quarto.yml:8:7]8;;\ ]
+   │
+ 8 │       ![logo](images/logo.svg){width="65px" .light-content}
+   │       ──────────────────────────┬──────────────────────────  
+   │                                 ╰──────────────────────────── Could not parse '![logo](images/logo.svg){width="65px" .light-content}
+' as markdown
+───╯
+ℹ Add the `!str` tag to treat this as a plain string, or fix the markdown syntax
+
+Rendered 1 of 2 files to /Users/cscheid/rooms/room-3/q2/claude-notes/plans/q120-forward-underlying-diagnostic-investigation/repro/_site — 1 error, 1 warning

--- a/claude-notes/plans/q120-forward-underlying-diagnostic-investigation/repro/observed-output.txt
+++ b/claude-notes/plans/q120-forward-underlying-diagnostic-investigation/repro/observed-output.txt
@@ -13,10 +13,15 @@ Warning: [Q-1-20] Failed to parse metadata value as markdown
    ╭─[ ]8;;file:///Users/cscheid/rooms/room-3/q2/claude-notes/plans/q120-forward-underlying-diagnostic-investigation/repro/_quarto.yml#8:7\/Users/cscheid/rooms/room-3/q2/claude-notes/plans/q120-forward-underlying-diagnostic-investigation/repro/_quarto.yml:8:7]8;;\ ]
    │
  8 │       ![logo](images/logo.svg){width="65px" .light-content}
-   │       ──────────────────────────┬──────────────────────────  
+   │       ──────────────────────────┬────┬─────────────┬───────  
+   │                                 │    ╰─────────────────────── This key-value pair cannot appear before the class specifier.
+   │                                 │                  │         
+   │                                 │                  ╰───────── This class specifier appears after the key-value pair.
+   │                                 │                            
    │                                 ╰──────────────────────────── Could not parse '![logo](images/logo.svg){width="65px" .light-content}
 ' as markdown
 ───╯
+ℹ [Q-2-3] Key-value Pair Before Class Specifier in Attribute
 ℹ Add the `!str` tag to treat this as a plain string, or fix the markdown syntax
 
 Rendered 1 of 2 files to /Users/cscheid/rooms/room-3/q2/claude-notes/plans/q120-forward-underlying-diagnostic-investigation/repro/_site — 1 error, 1 warning

--- a/crates/pampa/src/pandoc/meta.rs
+++ b/crates/pampa/src/pandoc/meta.rs
@@ -80,6 +80,63 @@ fn unwrap_lone_figure(kind: &mut ConfigValueKind) {
     *kind = ConfigValueKind::PandocInlines(vec![Inline::Image(image)]);
 }
 
+/// Fold the recursive parse's own diagnostics into the Q-1-20 message as
+/// located details, so the author learns *what* is wrong with the markdown
+/// rather than just that it failed
+/// (bd-q120-masks-config-md-diagnostic-a039r80t). Child spans arrive
+/// already rerooted into the config file by `readers::qmd::read`'s Err
+/// path; Q-1-20's severity (warning untagged, error under `!md`) is the
+/// severity of the whole folded message.
+fn fold_child_diagnostics(
+    mut builder: quarto_error_reporting::DiagnosticMessageBuilder,
+    children: &[quarto_error_reporting::DiagnosticMessage],
+) -> quarto_error_reporting::DiagnosticMessageBuilder {
+    use quarto_error_reporting::DetailKind;
+
+    let mut seen_hints = std::collections::HashSet::new();
+    for child in children {
+        // The child's `problem` is its anchored explanation (the ariadne
+        // renderer draws it as the label on the child's main span), so
+        // fold it in as the located label — the config rendering then
+        // mirrors what the same markdown produces in a document body.
+        // The code + title identify the underlying error in a footer
+        // line, where the author can search for it.
+        let identity = match &child.code {
+            Some(code) => format!("[{}] {}", code, child.title),
+            None => child.title.clone(),
+        };
+        builder = match (&child.location, &child.problem) {
+            (Some(location), Some(problem)) => builder
+                .add_info_at(problem.as_str().to_string(), location.clone())
+                .add_info(identity),
+            (Some(location), None) => builder.add_info_at(identity, location.clone()),
+            (None, Some(problem)) => builder
+                .add_info(identity)
+                .add_info(problem.as_str().to_string()),
+            (None, None) => builder.add_info(identity),
+        };
+        for detail in &child.details {
+            let text = detail.content.as_str().to_string();
+            builder = match (&detail.location, &detail.kind) {
+                (Some(location), DetailKind::Error) => {
+                    builder.add_detail_at(text, location.clone())
+                }
+                (Some(location), DetailKind::Info) => builder.add_info_at(text, location.clone()),
+                (Some(location), _) => builder.add_note_at(text, location.clone()),
+                (None, DetailKind::Error) => builder.add_detail(text),
+                (None, DetailKind::Info) => builder.add_info(text),
+                (None, _) => builder.add_note(text),
+            };
+        }
+        for hint in &child.hints {
+            if seen_hints.insert(hint.as_str().to_string()) {
+                builder = builder.add_hint(hint.as_str().to_string());
+            }
+        }
+    }
+    builder
+}
+
 /// Parse a YAML string as markdown and return ConfigValue with PandocInlines/PandocBlocks.
 ///
 /// - If `is_explicit_md` is true: This is a !md tagged value, ERROR on parse failure
@@ -117,32 +174,36 @@ fn parse_yaml_string_as_markdown_to_config(
             }
             ConfigValueKind::PandocBlocks(pandoc.blocks)
         }
-        Err(_parse_errors) => {
-            if is_explicit_md {
+        Err(parse_errors) => {
+            let diagnostic = if is_explicit_md {
                 // !md tag: ERROR on parse failure
-                let diagnostic =
+                fold_child_diagnostics(
                     DiagnosticMessageBuilder::error("Failed to parse !md tagged value")
                         .with_code("Q-1-20")
                         .with_location(source_info.clone())
                         .problem("The `!md` tag requires valid markdown syntax")
-                        .add_detail(format!("Could not parse: {}", value))
-                        .add_hint("Remove the `!md` tag or fix the markdown syntax")
-                        .build();
-                diagnostics.add(diagnostic);
+                        .add_detail(format!("Could not parse: {}", value)),
+                    &parse_errors,
+                )
+                .add_hint("Remove the `!md` tag or fix the markdown syntax")
+                .build()
             } else {
                 // Untagged: WARN on parse failure
-                let diagnostic = DiagnosticMessageBuilder::warning(
-                    "Failed to parse metadata value as markdown",
+                fold_child_diagnostics(
+                    DiagnosticMessageBuilder::warning(
+                        "Failed to parse metadata value as markdown",
+                    )
+                    .with_code("Q-1-20")
+                    .with_location(source_info.clone())
+                    .problem(format!("Could not parse '{}' as markdown", value)),
+                    &parse_errors,
                 )
-                .with_code("Q-1-20")
-                .with_location(source_info.clone())
-                .problem(format!("Could not parse '{}' as markdown", value))
                 .add_hint(
                     "Add the `!str` tag to treat this as a plain string, or fix the markdown syntax",
                 )
-                .build();
-                diagnostics.add(diagnostic);
-            }
+                .build()
+            };
+            diagnostics.add(diagnostic);
 
             // Return error recovery span. The bytes are the raw YAML
             // value; reuse the caller's source_info so attribution
@@ -956,5 +1017,114 @@ mod tests {
         let result =
             yaml_to_config_value(yaml, InterpretationContext::ProjectConfig, &mut diagnostics);
         assert!(matches!(result.value, ConfigValueKind::Expr(_)));
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Forwarding the underlying parser diagnostic on config-string
+    // parse failure (bd-q120-masks-config-md-diagnostic-a039r80t).
+    //
+    // A config value that fails to parse as markdown must not reduce
+    // to the generic Q-1-20 "could not parse" — the underlying parser
+    // diagnostic (e.g. Q-2-3, kv-pair before class specifier) is
+    // folded into the Q-1-20 message as located details, with spans
+    // rerooted into the file the scalar was authored in.
+    // ─────────────────────────────────────────────────────────────
+
+    /// Markdown that fails q2's attribute grammar with Q-2-3
+    /// (key-value pair before class specifier) — accepted by
+    /// Pandoc/Q1, so common in ported configs.
+    const KV_BEFORE_CLASS: &str = r#"![logo](images/logo.svg){width="65px" .light-content}"#;
+
+    #[test]
+    fn config_string_parse_failure_forwards_underlying_diagnostic() {
+        use quarto_source_map::FileId;
+        let parent =
+            quarto_source_map::SourceInfo::original(FileId(7), 100, 100 + KV_BEFORE_CLASS.len());
+        let mut diagnostics = Vec::new();
+        let _ = parse_config_string_as_markdown(KV_BEFORE_CLASS, &parent, &mut diagnostics);
+
+        assert_eq!(
+            diagnostics.len(),
+            1,
+            "children fold into the single Q-1-20, got {:#?}",
+            diagnostics
+        );
+        let diag = &diagnostics[0];
+        assert_eq!(diag.code.as_deref(), Some("Q-1-20"));
+        assert!(
+            matches!(diag.kind, quarto_error_reporting::DiagnosticKind::Warning),
+            "untagged branch stays a warning"
+        );
+
+        let detail_texts: Vec<&str> = diag.details.iter().map(|d| d.content.as_str()).collect();
+        assert!(
+            detail_texts
+                .iter()
+                .any(|t| t.contains("Key-value Pair Before Class Specifier")),
+            "the child diagnostic's title must be folded in, got {:?}",
+            detail_texts
+        );
+        assert!(
+            detail_texts
+                .iter()
+                .any(|t| t.contains("cannot appear before the class specifier")),
+            "the child's located notes must be folded in, got {:?}",
+            detail_texts
+        );
+
+        let mut located = 0;
+        for det in &diag.details {
+            if let Some(loc) = &det.location {
+                let (fid, start, end) = loc
+                    .resolve_byte_range()
+                    .expect("forwarded detail spans must resolve");
+                assert_eq!(fid, 7, "detail spans must reroot into the parent's file");
+                assert!(
+                    start >= 100 && end <= 100 + KV_BEFORE_CLASS.len(),
+                    "detail span {}..{} must land inside the scalar's range in the parent",
+                    start,
+                    end
+                );
+                located += 1;
+            }
+        }
+        assert!(
+            located >= 2,
+            "the child's two-part span must survive forwarding, got {:#?}",
+            diag.details
+        );
+    }
+
+    #[test]
+    fn explicit_md_parse_failure_forwards_underlying_diagnostic() {
+        use quarto_source_map::FileId;
+        let parent =
+            quarto_source_map::SourceInfo::original(FileId(7), 100, 100 + KV_BEFORE_CLASS.len());
+        let mut collector = crate::utils::diagnostic_collector::DiagnosticCollector::new();
+        let _ =
+            parse_yaml_string_as_markdown_to_config(KV_BEFORE_CLASS, &parent, true, &mut collector);
+        let diagnostics = collector.into_diagnostics();
+
+        assert_eq!(diagnostics.len(), 1, "got {:#?}", diagnostics);
+        let diag = &diagnostics[0];
+        assert_eq!(diag.code.as_deref(), Some("Q-1-20"));
+        assert!(
+            matches!(diag.kind, quarto_error_reporting::DiagnosticKind::Error),
+            "!md branch stays an error"
+        );
+        assert!(
+            diag.details.iter().any(|d| d
+                .content
+                .as_str()
+                .contains("Key-value Pair Before Class Specifier")),
+            "the child diagnostic must be folded in, got {:#?}",
+            diag.details
+        );
+        for det in &diag.details {
+            if let Some(loc) = &det.location {
+                let (fid, _, _) = loc.resolve_byte_range().expect("must resolve");
+                assert_eq!(fid, 7, "detail spans must reroot into the parent's file");
+            }
+        }
     }
 }

--- a/crates/pampa/src/readers/qmd.rs
+++ b/crates/pampa/src/readers/qmd.rs
@@ -148,6 +148,9 @@ pub fn read<T: Write>(
                     prune_diagnostics_by_error_nodes(diagnostics, &error_nodes, &outer_nodes);
             }
 
+            if let Some(parent) = &context.parent_source_info {
+                reroot_diagnostics_into_parent(&mut diagnostics, parent);
+            }
             return Err(diagnostics);
         }
     }
@@ -255,4 +258,81 @@ pub fn read<T: Write>(
     let warnings = error_collector.into_diagnostics();
 
     Ok((result, context, warnings))
+}
+
+/// Reroot Err-path diagnostic spans through `parent`.
+///
+/// `produce_diagnostic_messages` and the pruning/widening passes after it
+/// do their offset arithmetic in the raw-input-bytes domain, against this
+/// parse's own `FileId(0)`. Under a recursive parse of an embedded string
+/// (config values, `!md` metadata, Lua-filter config values) those are
+/// offsets *into the string*; returning them unmapped hands the caller
+/// spans against the wrong file. Rebuild each span as a substring of the
+/// parent — the same rerooting `range_to_source_info_with_context`
+/// applies on the Ok path.
+fn reroot_diagnostics_into_parent(
+    diagnostics: &mut [quarto_error_reporting::DiagnosticMessage],
+    parent: &quarto_source_map::SourceInfo,
+) {
+    let reroot = |location: &mut Option<quarto_source_map::SourceInfo>| {
+        if let Some(loc) = location
+            && let Some((_file_id, start, end)) = loc.resolve_byte_range()
+        {
+            *loc = quarto_source_map::SourceInfo::substring(parent.clone(), start, end);
+        }
+    };
+    for diagnostic in diagnostics {
+        reroot(&mut diagnostic.location);
+        for detail in &mut diagnostic.details {
+            reroot(&mut detail.location);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    /// Err-path diagnostics must reroot through `parent_source_info`
+    /// exactly like Ok-path spans do
+    /// (bd-q120-masks-config-md-diagnostic-a039r80t): a recursive
+    /// parse of an embedded string (config values, `!md` metadata,
+    /// Lua-filter config values) that *fails* must not hand back
+    /// spans at raw offsets-into-the-string against the throwaway
+    /// `<metadata>` context's FileId(0).
+    #[test]
+    fn err_path_diagnostics_reroot_through_parent_source_info() {
+        use quarto_source_map::FileId;
+        let text = "![logo](images/logo.svg){width=\"65px\" .light-content}\n";
+        let parent = quarto_source_map::SourceInfo::original(FileId(3), 50, 50 + text.len());
+        let mut sink = std::io::sink();
+        let err = super::read(
+            text.as_bytes(),
+            false,
+            "<metadata>",
+            &mut sink,
+            true,
+            Some(parent),
+        )
+        .expect_err("kv-before-class must fail to parse");
+        assert!(!err.is_empty());
+        for diag in &err {
+            let loc = diag
+                .location
+                .as_ref()
+                .expect("Err-path diagnostic must carry a location");
+            let (fid, start, end) = loc.resolve_byte_range().expect("location must resolve");
+            assert_eq!(
+                fid, 3,
+                "Err-path spans must reroot into the parent's file, got {:#?}",
+                diag
+            );
+            assert!(start >= 50 && end <= 50 + text.len());
+            for det in &diag.details {
+                if let Some(l) = &det.location {
+                    let (f, ds, de) = l.resolve_byte_range().expect("detail must resolve");
+                    assert_eq!(f, 3, "detail spans must reroot too, got {:#?}", diag);
+                    assert!(ds >= 50 && de <= 50 + text.len());
+                }
+            }
+        }
+    }
 }

--- a/docs/errors/yaml/Q-1-20.qmd
+++ b/docs/errors/yaml/Q-1-20.qmd
@@ -53,9 +53,11 @@ The `!str` tag tells Quarto to skip markdown parsing for this
 value, so any of the characters above pass through unchanged.
 
 For values you genuinely want to render as markdown, fix the
-markdown so that it parses. The hint in the error message points
-at the value Quarto was unable to parse; the surrounding context
-in the YAML file shows what the metadata is.
+markdown so that it parses. The message includes the underlying
+markdown parser's diagnostic — the same error the text would
+produce in a document body, with spans pointing into your YAML
+file — so it shows exactly which part of the value failed to
+parse, and why.
 
 If the value is explicitly tagged `!md` and you do not actually
 need markdown interpretation, remove the tag.


### PR DESCRIPTION
## Summary

`bd-q120-masks-config-md-diagnostic-a039r80t`: a config metadata value that fails to parse as markdown used to produce only the generic Q-1-20 "could not parse" message, discarding the parser diagnostic that explains *what* is wrong with the markdown. Notably, markdown that Pandoc/Q1 accept (key-value pair before class specifier) fails in q2 configs with no clue what to fix.

Two changes in `pampa`:

- **`readers::qmd::read` now reroots Err-path diagnostic spans through `parent_source_info`** (`SourceInfo::substring`), the same rerooting the Ok path already applies via `range_to_source_info_with_context`. Previously the Err path returned spans at raw offsets against the recursive parse's throwaway `FileId(0)` context, so they could not be forwarded safely. Also fixes Lua-filter config values (the other production caller passing a parent).
- **`parse_yaml_string_as_markdown_to_config` folds the child diagnostics into the Q-1-20 message as located details**: the child's problem text becomes the label on the child's main span (mirroring what the same markdown produces in a document body), `[code] title` becomes an Info footer line, child details keep their `DetailKind`, child hints are forwarded with exact-duplicate dedup. Untagged values stay a warning; `!md` values stay an error.

Before (config value): only `Warning: [Q-1-20] … Could not parse '…' as markdown`.

After:

```
Warning: [Q-1-20] Failed to parse metadata value as markdown   (_quarto.yml:8)
 8 │       ![logo](images/logo.svg){width="65px" .light-content}
   │                                 ╰─ This key-value pair cannot appear before the class specifier.
   │                                              ╰─ This class specifier appears after the key-value pair.
   │                  ╰─ Could not parse '…' as markdown
ℹ [Q-2-3] Key-value Pair Before Class Specifier in Attribute
ℹ Add the `!str` tag to treat this as a plain string, or fix the markdown syntax
```

## Testing

- TDD: three tests written first and verified failing (`meta.rs` untagged + `!md` branches; `readers::qmd` Err-path reroot test that also covers the Lua caller path).
- Full `cargo xtask verify` green (workspace build + tests, ts-packages, hub-client build incl. WASM, hub tests). No snapshot files changed.
- End-to-end via `cargo run --bin q2 -- render` on the committed repro fixture (`claude-notes/plans/q120-forward-underlying-diagnostic-investigation/repro/`); captured, inspected output committed as `observed-output.txt`.

Plan: `claude-notes/plans/2026-08-19-q120-forward-underlying-diagnostic.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)