### PR TITLE
hub-client: stop reconciler resurrecting deleted projects (bd-f5a0c6rv)

### DIFF
--- a/claude-notes/plans/2026-08-21-project-set-deletion-tombstones.md
+++ b/claude-notes/plans/2026-08-21-project-set-deletion-tombstones.md
@@ -1,0 +1,159 @@
+# Project-set deletion tombstones (latest-wins reconcile)
+
+Branch: `bugfix/bd-f5a0c6rv-project-set-deletion-tombstones`
+Strand: bd-f5a0c6rv (bug, in progress)
+Status: **applied** — this file records what shipped, not what is planned.
+
+## Context / problem
+
+Deleting a project from the synced project set (the × button in
+ProjectSelector, "Remove from this device" in ProjectsHome) appeared to
+work but the project came back on the next page load.
+
+Root cause: the delete path only mutated the synced Automerge document
+(`useCollectionSets.removeProject` → `projectSetService.removeProjectFromCollection`).
+Every project also has a row in the legacy IndexedDB `projects` store
+(written by the share-route handler, imports, and project creation), and
+the delete path never touched it. On the next load, the "connected"
+effect in `useCollectionSets` runs `reconcileIntoConnectedProjectSet()`,
+which upserts any IDB row missing from the synced set — so the stale row
+resurrected the deleted project. The same mechanism could resurrect
+cross-device: browser B's stale IDB row would re-add a project deleted
+on browser A once B reconnected.
+
+## Design decision
+
+Latest-wins on per-key deletion tombstones, per user direction.
+
+- `ProjectSetDocument` gains `tombstones?: Record<key, deletedAtISO>`.
+  Optional: existing documents lack the map; it is lazily created inside
+  the first `change()` that deletes something. No schema version bump —
+  the field is forward-compatible in both directions (old clients ignore
+  the extra map; new code treats its absence as "no deletions yet").
+- `removeProjectFromSet` deletes the entry AND stamps the tombstone.
+  `addProjectToSet` (and every direct-write path) clears it: a re-add
+  wins over an earlier delete.
+- The reconciler compares each candidate IDB row's `lastAccessed`
+  against the key's tombstone. Tombstone at-or-newer → the row is a
+  stale pre-delete copy: skip it and purge it from IDB. Row newer → a
+  genuine later access/re-add: restore it. Ties go to the deletion (a
+  simultaneous delete/re-add pair can't loop, because the re-add clears
+  the tombstone).
+
+Rejected alternative: a single whole-set `lastModified` (or
+`lastDeletedAt`) timestamp. The set is too chatty — touches, renames and
+summary updates would advance the stamp and suppress legitimate pending
+share-link adds (the reconciler's raison d'être), and purging on that
+verdict could permanently lose never-synced projects. One timestamp can
+also only record one event, so later deletions of project Y clobber the
+resolution window for earlier deletions of project X. The reconciler's
+question is per-key, so the timestamp must be per-key.
+
+## What was applied
+
+### ts-packages/quarto-automerge-schema
+
+- [x] `src/index.ts`: `ProjectSetDocument.tombstones?: Record<string, string>`
+- [x] `src/index.ts`: `removeProjectFromSet(doc, id, now?)` writes the
+      tombstone (only when an entry was actually removed)
+- [x] `src/index.ts`: `addProjectToSet` clears the key's tombstone on
+      both the add and update paths (heals torn present+tombstoned state
+      after concurrent add/delete merges)
+- [x] `src/index.ts`: new `getProjectSetTombstones(doc)` reader (`{}`
+      for pre-tombstone documents)
+- [x] `src/projectSet.test.ts`: 5 new tests (tombstone written, no
+      tombstone for absent entries, re-add clears, update path clears,
+      legacy-doc reader)
+- [x] `dist/` rebuilt (`npm run build`); dist is gitignored
+
+### hub-client
+
+- [x] `services/projectSetService.ts`: `addProjectsBulk` and
+      `moveProjectBetweenCollections` clear tombstones for keys they
+      (re-)add; new `getRootTombstones()` accessor
+- [x] `services/projectSetReconciler.ts`: `computeReconcileAdds` takes
+      an optional tombstones map and skips losing rows; new
+      `computeReconcilePurges` returns tombstone-losing rows;
+      `reconcileIntoConnectedProjectSet` purges losers from IDB before
+      adding winners (shared `dedupeByKey` / `tombstoneWins` helpers)
+- [x] `services/projectStorage.ts`: new `deleteProjectByIndexDocId`
+      purge helper — deletes all rows matching the canonical key, both
+      `automerge:`-prefixed and unprefixed historical variants
+- [x] `hooks/useCollectionSets.ts`: `removeProject` unchanged in
+      behaviour (pure set operation); comment documents the tombstone
+      mechanism. The reconciler is the single place that resolves
+      IDB-vs-set conflicts — no hook-level IDB delete
+- [x] `services/projectSetReconciler.test.ts`: mocks extended
+      (`getRootTombstones`, `deleteProjectByIndexDocId`); 6 new
+      latest-wins tests + 2 purge-orchestration tests
+- [x] `services/projectStorage.test.ts`: 4 new tests for
+      `deleteProjectByIndexDocId` (exact, prefix variants, duplicate
+      rows, no-op)
+
+## Resulting semantics
+
+- Delete from the set → entry removed everywhere this browser is
+  subscribed, tombstone stamped. Next load: reconciler purges the stale
+  IDB row instead of resurrecting it.
+- Cross-device: the tombstone syncs with the document, so browser B's
+  reconciler reaches the same verdict and purges its own stale row.
+- Re-add after delete (share link revisited, project re-opened) wins:
+  the newer `lastAccessed` beats the tombstone, and the add clears it.
+- Import of an old project-list export does NOT restore a project
+  deleted after the export was made (the tombstone is newer). Consistent
+  with latest-wins; an explicit "import means restore" path would clear
+  tombstones for imported ids — not implemented, see follow-ups.
+- Mixed client versions: old clients don't write tombstones, so their
+  deletions can still be resurrected by stale IDB rows until upgraded.
+
+## Verification
+
+- `ts-packages/quarto-automerge-schema`: `npm run build` clean;
+  `vitest run` — 72 passed (4 files)
+- `hub-client`: `vitest run` on projectSetReconciler, projectStorage,
+  projectSetService.connect, projectSetService.debug, projectSetStorage —
+  68 passed (5 files)
+- `hub-client`: `npm run typecheck` clean
+- Grep sweep: every direct `doc.projects[key]` write path maintains
+  tombstones (addProjectsBulk, moveProjectBetweenCollections,
+  addProjectToSet); no bypassing writers remain
+
+## Follow-ups (not applied)
+
+- Import-as-restore: `importProjectsAndReconcile` could clear tombstones
+  for explicitly imported ids.
+- `useProjectSet` (dead predecessor hook) shares the reconciler, so it
+  inherits the fix automatically; the hook itself remains unused.
+- Optional: expose tombstones in the `quartoDebug.am` debug snapshot
+  (`getProjectSetDebugSnapshot`) for field diagnosis.
+
+## Deferred: outbox semantics for the legacy `projects` store
+
+Tracked as strand bd-ec8eop0c (discovered-from bd-f5a0c6rv).
+Discussed 2026-08-21; decision was to ship tombstones as-is and revisit.
+
+The `projects` IDB store is currently a permanent shadow of the synced
+set (rows re-created/touched on every project open because URL routes
+are keyed by the IDB row uuid — `#/p/<local-id>`, see useRouting.ts and
+App.tsx `handleSelectProject`). Best practice would be outbox semantics:
+rows written only when the set is unreachable, drained by the reconciler
+once confirmed in the set (`deleteProjectByIndexDocId` is already the
+drain mechanism).
+
+Staged path when revisited:
+
+1. Route by `indexDocId` instead of the local row uuid, with a legacy
+   fallback so existing bookmarks/history still resolve (touches
+   utils/routing, App.tsx, ProjectSelector, ProjectsHome, share handler).
+2. Remove the shadow writes (`handleOpen` in ProjectsHome,
+   ProjectSelector open paths) that the routing coupling forces.
+3. Reconciler drains rows after `addProjectsBulk` confirms them.
+4. Optional: drain post-migration backup rows after the pointer commit;
+   v6 migration normalizing `automerge:`-prefix duality.
+
+Why tombstones stay even with an outbox: a genuinely pending row on an
+offline browser (share link clicked while disconnected) cannot be
+ordered against a deletion made on another browser without a deletion
+record. The outbox removes the cause of stale rows; tombstones make
+deletions ordered events. Same-browser correctness is achievable with
+the outbox alone; cross-device is not.

--- a/hub-client/changelog.md
+++ b/hub-client/changelog.md
@@ -23,6 +23,10 @@ WASM rebuild is needed for a changelog-only edit.
 
 -->
 
+### 2026-08-21
+
+- [`837de60b`](https://github.com/quarto-dev/q2/commits/837de60b): Fix deleted projects reappearing on the next page load — deleting a project now records a tombstone that syncs with the project set, so the on-load reconciler purges the stale local copy instead of resurrecting it, on every browser.
+
 ### 2026-08-19
 
 - [`6ddab98b`](https://github.com/quarto-dev/q2/commits/6ddab98b): Fix the hub app getting stuck on old versions (GH #447) — the app now checks for updates hourly and whenever a backgrounded tab is revisited, hidden tabs reload themselves onto the new version automatically, and visible tabs get an "Update available" toast with a Reload button instead of being reloaded mid-edit. Offline caching is slimmer too: the install-time cache drops from about 56 MB to about 14 MB because the WASM parser, Monaco editor workers, and the sass compiler now live in on-demand caches, so updates are far less likely to fail to install.

--- a/hub-client/src/hooks/useCollectionSets.ts
+++ b/hub-client/src/hooks/useCollectionSets.ts
@@ -363,7 +363,11 @@ export function useCollectionSets(): [CollectionSetsState, CollectionSetsActions
   const removeProject = useCallback((indexDocId: string) => {
     // Personal removal: root plus every subscribed collection this browser
     // can see. Other members of shared collections are unaffected (their
-    // own root supersets still hold the project).
+    // own root supersets still hold the project). Each removal also writes
+    // a deletion tombstone into that set's document; the on-load reconciler
+    // compares tombstones against stale legacy IDB rows (latest-wins) and
+    // purges the losers, so deletions survive page reloads — and other
+    // browsers' reconcilers reach the same verdict once the tombstone syncs.
     for (const c of projectSetService.listCollections()) {
       projectSetService.removeProjectFromCollection(c.docId, indexDocId);
     }

--- a/hub-client/src/services/projectSetReconciler.test.ts
+++ b/hub-client/src/services/projectSetReconciler.test.ts
@@ -14,15 +14,19 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 vi.mock('./projectStorage', () => ({
   importData: vi.fn(),
   listProjects: vi.fn(),
+  deleteProjectByIndexDocId: vi.fn(),
 }));
 vi.mock('./projectSetService', () => ({
   isConnected: vi.fn(),
   listProjects: vi.fn(),
   addProjectsBulk: vi.fn(),
+  getRootTombstones: vi.fn(() => ({})),
 }));
 
 import {
   computeReconcileAdds,
+  computeReconcilePurges,
+  reconcileIntoConnectedProjectSet,
   importProjectsAndReconcile,
   type ReconcilableEntry,
 } from './projectSetReconciler';
@@ -183,6 +187,126 @@ describe('importProjectsAndReconcile', () => {
 
     await expect(importProjectsAndReconcile('not json')).rejects.toThrow('Invalid import format');
     expect(mockIsConnected).not.toHaveBeenCalled();
+    expect(mockAddBulk).not.toHaveBeenCalled();
+  });
+});
+
+describe('tombstones (latest-wins)', () => {
+  it('suppresses an IDB row whose deletion tombstone is newer', () => {
+    // Regression: deleting a project from the set used to leave the IDB row
+    // behind, and the on-load reconcile resurrected it on the next load.
+    const stale = idb({
+      indexDocId: 'automerge:abc',
+      lastAccessed: '2026-04-10T00:00:00.000Z',
+    });
+    expect(
+      computeReconcileAdds([stale], [], { abc: '2026-04-16T00:00:00.000Z' }),
+    ).toEqual([]);
+  });
+
+  it('adds an IDB row newer than its tombstone — the later access wins', () => {
+    const fresh = idb({
+      indexDocId: 'automerge:abc',
+      lastAccessed: '2026-04-17T00:00:00.000Z',
+    });
+    expect(
+      computeReconcileAdds([fresh], [], { abc: '2026-04-16T00:00:00.000Z' }),
+    ).toEqual([fresh]);
+  });
+
+  it('delete wins ties', () => {
+    const tie = idb({
+      indexDocId: 'automerge:abc',
+      lastAccessed: '2026-04-16T00:00:00.000Z',
+    });
+    expect(
+      computeReconcileAdds([tie], [], { abc: '2026-04-16T00:00:00.000Z' }),
+    ).toEqual([]);
+  });
+
+  it('matches tombstones by canonical key regardless of prefix', () => {
+    const row = idb({
+      indexDocId: 'abc', // unprefixed historical row
+      lastAccessed: '2026-04-10T00:00:00.000Z',
+    });
+    expect(
+      computeReconcileAdds([row], [], { abc: '2026-04-16T00:00:00.000Z' }),
+    ).toEqual([]);
+  });
+
+  it('computeReconcilePurges returns exactly the tombstone-losing rows', () => {
+    const stale = idb({
+      indexDocId: 'automerge:abc',
+      lastAccessed: '2026-04-10T00:00:00.000Z',
+    });
+    const fresh = idb({
+      indexDocId: 'automerge:def',
+      lastAccessed: '2026-04-17T00:00:00.000Z',
+    });
+    const tombstones = {
+      abc: '2026-04-16T00:00:00.000Z',
+      def: '2026-04-16T00:00:00.000Z',
+    };
+    expect(computeReconcilePurges([stale, fresh], [], tombstones)).toEqual([stale]);
+  });
+
+  it('computeReconcilePurges never proposes rows still present in the set', () => {
+    // Torn state (entry present AND tombstone present, possible after a
+    // concurrent add/delete merge): the live entry wins, nothing to purge.
+    const row = idb({
+      indexDocId: 'automerge:abc',
+      lastAccessed: '2026-04-10T00:00:00.000Z',
+    });
+    expect(
+      computeReconcilePurges(
+        [row],
+        [{ indexDocId: 'automerge:abc' }],
+        { abc: '2026-04-16T00:00:00.000Z' },
+      ),
+    ).toEqual([]);
+  });
+});
+
+describe('reconcileIntoConnectedProjectSet', () => {
+  const mockListIdb = vi.mocked(projectStorage.listProjects);
+  const mockIsConnected = vi.mocked(projectSetService.isConnected);
+  const mockListSet = vi.mocked(projectSetService.listProjects);
+  const mockAddBulk = vi.mocked(projectSetService.addProjectsBulk);
+  const mockGetTombstones = vi.mocked(projectSetService.getRootTombstones);
+  const mockDelete = vi.mocked(projectStorage.deleteProjectByIndexDocId);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetTombstones.mockReturnValue({});
+  });
+
+  it('purges tombstone-losing IDB rows and reconciles only the winners', async () => {
+    mockIsConnected.mockReturnValue(true);
+    mockListIdb.mockResolvedValue([
+      idb({ indexDocId: 'automerge:stale', lastAccessed: '2026-04-10T00:00:00.000Z' }),
+      idb({ indexDocId: 'automerge:fresh', lastAccessed: '2026-04-17T00:00:00.000Z' }),
+    ] as never);
+    mockListSet.mockReturnValue([]);
+    mockGetTombstones.mockReturnValue({ stale: '2026-04-16T00:00:00.000Z' });
+    mockAddBulk.mockReturnValue(1);
+
+    const added = await reconcileIntoConnectedProjectSet();
+
+    expect(mockDelete).toHaveBeenCalledTimes(1);
+    expect(mockDelete).toHaveBeenCalledWith('automerge:stale');
+    expect(mockAddBulk).toHaveBeenCalledWith([
+      expect.objectContaining({ indexDocId: 'automerge:fresh' }),
+    ]);
+    expect(added).toBe(1);
+  });
+
+  it('does not purge when the set is not connected', async () => {
+    mockIsConnected.mockReturnValue(false);
+
+    const added = await reconcileIntoConnectedProjectSet();
+
+    expect(added).toBe(0);
+    expect(mockDelete).not.toHaveBeenCalled();
     expect(mockAddBulk).not.toHaveBeenCalled();
   });
 });

--- a/hub-client/src/services/projectSetReconciler.ts
+++ b/hub-client/src/services/projectSetReconciler.ts
@@ -9,9 +9,19 @@
  * synced set). The reconciler closes that gap: once the project set becomes
  * connected, we compare IDB against it and upsert anything missing.
  *
- * This module is split into a pure `computeReconcileAdds` (unit-tested) and
- * an imperative `reconcileIntoConnectedProjectSet` that wires it up to the
- * real services. Keep the pure function pure.
+ * Deletions are the flip side of that comparison. An entry absent from the
+ * set is ambiguous — "never synced" and "deleted" look identical — so
+ * deletions write a tombstone (key -> deletion timestamp) into the set
+ * document. A missing IDB row is re-added only when its lastAccessed is
+ * NEWER than the tombstone (latest one wins); otherwise the stale row is
+ * purged from IDB so it can never resurrect the project. Because the
+ * tombstones sync with the document, a deletion made on one browser also
+ * wins on every other browser's reconcile.
+ *
+ * This module is split into pure `computeReconcileAdds` /
+ * `computeReconcilePurges` (unit-tested) and an imperative
+ * `reconcileIntoConnectedProjectSet` that wires them up to the real
+ * services. Keep the pure functions pure.
  *
  * See claude-notes/plans/2026-04-16-share-link-project-not-added.md.
  */
@@ -34,20 +44,13 @@ export interface ReconcilableEntry {
 }
 
 /**
- * Return the IDB entries that are missing from the synced project set.
- *
- * Comparison is by the `automerge:`-stripped indexDocId (same key as the
- * project set's Record). If IDB contains multiple rows that resolve to the
- * same key (which can happen historically because two code paths stored
- * the id with and without the prefix), the most-recently-accessed one wins.
+ * Dedupe IDB rows by canonical key, keeping the most recently accessed.
+ * (IDB can hold two rows for the same key because code paths historically
+ * stored the id with and without the `automerge:` prefix.)
  */
-export function computeReconcileAdds(
+function dedupeByKey(
   idbProjects: ReadonlyArray<ReconcilableEntry>,
-  setEntries: ReadonlyArray<Pick<ProjectSetEntry, 'indexDocId'>>,
-): ReconcilableEntry[] {
-  const setKeys = new Set(setEntries.map((e) => projectSetKey(e.indexDocId)));
-
-  // Dedupe IDB rows by canonical key, keeping the most recently accessed.
+): Map<string, ReconcilableEntry> {
   const byKey = new Map<string, ReconcilableEntry>();
   for (const entry of idbProjects) {
     const key = projectSetKey(entry.indexDocId);
@@ -56,12 +59,68 @@ export function computeReconcileAdds(
       byKey.set(key, entry);
     }
   }
+  return byKey;
+}
+
+/**
+ * Latest-wins verdict for one key: the deletion tombstone wins when it is
+ * at or newer than the row's last access (ties go to the deletion — a
+ * simultaneous delete/re-add pair resolved this way can't loop, because
+ * the re-add clears the tombstone).
+ */
+function tombstoneWins(
+  tombstones: Record<string, string>,
+  key: string,
+  lastAccessed: string,
+): boolean {
+  const deletedAt = tombstones[key];
+  return deletedAt !== undefined && deletedAt >= lastAccessed;
+}
+
+/**
+ * Return the IDB entries that are missing from the synced project set and
+ * not suppressed by a deletion tombstone.
+ *
+ * Comparison is by the `automerge:`-stripped indexDocId (same key as the
+ * project set's Record). If IDB contains multiple rows that resolve to the
+ * same key, the most-recently-accessed one is the candidate.
+ */
+export function computeReconcileAdds(
+  idbProjects: ReadonlyArray<ReconcilableEntry>,
+  setEntries: ReadonlyArray<Pick<ProjectSetEntry, 'indexDocId'>>,
+  tombstones: Record<string, string> = {},
+): ReconcilableEntry[] {
+  const setKeys = new Set(setEntries.map((e) => projectSetKey(e.indexDocId)));
 
   const adds: ReconcilableEntry[] = [];
-  for (const [key, entry] of byKey) {
-    if (!setKeys.has(key)) adds.push(entry);
+  for (const [key, entry] of dedupeByKey(idbProjects)) {
+    if (setKeys.has(key)) continue;
+    // A tombstone at or newer than the row's last access means this row is
+    // a stale pre-delete copy, not a project waiting to be restored.
+    if (tombstoneWins(tombstones, key, entry.lastAccessed)) continue;
+    adds.push(entry);
   }
   return adds;
+}
+
+/**
+ * Return the IDB rows that lost to a deletion tombstone — stale local
+ * copies of projects deleted from the set. Callers purge them so they can
+ * never resurrect the project on a later reconcile.
+ */
+export function computeReconcilePurges(
+  idbProjects: ReadonlyArray<ReconcilableEntry>,
+  setEntries: ReadonlyArray<Pick<ProjectSetEntry, 'indexDocId'>>,
+  tombstones: Record<string, string>,
+): ReconcilableEntry[] {
+  const setKeys = new Set(setEntries.map((e) => projectSetKey(e.indexDocId)));
+
+  const purges: ReconcilableEntry[] = [];
+  for (const [key, entry] of dedupeByKey(idbProjects)) {
+    if (setKeys.has(key)) continue;
+    if (tombstoneWins(tombstones, key, entry.lastAccessed)) purges.push(entry);
+  }
+  return purges;
 }
 
 /**
@@ -78,7 +137,15 @@ export async function reconcileIntoConnectedProjectSet(): Promise<number> {
 
   const idbProjects = await projectStorage.listProjects();
   const setEntries = projectSetService.listProjects();
-  const adds = computeReconcileAdds(idbProjects, setEntries);
+  const tombstones = projectSetService.getRootTombstones();
+
+  // Purge stale local copies of deleted projects first, so a losing row
+  // can never resurrect its project on a later load.
+  for (const entry of computeReconcilePurges(idbProjects, setEntries, tombstones)) {
+    await projectStorage.deleteProjectByIndexDocId(entry.indexDocId);
+  }
+
+  const adds = computeReconcileAdds(idbProjects, setEntries, tombstones);
   if (adds.length === 0) return 0;
 
   return projectSetService.addProjectsBulk(adds);

--- a/hub-client/src/services/projectSetService.ts
+++ b/hub-client/src/services/projectSetService.ts
@@ -38,6 +38,7 @@ import {
   updateProjectSummaryInSet,
   setProjectSetName,
   projectSetKey,
+  getProjectSetTombstones,
 } from '@quarto/quarto-automerge-schema';
 import type { CollectionPointerEntry } from './storage/types';
 
@@ -708,6 +709,8 @@ export function moveProjectBetweenCollections(
     if (!doc.projects[key]) {
       doc.projects[key] = copy;
     }
+    // The move re-adds the project here, winning over any tombstone.
+    if (doc.tombstones && key in doc.tombstones) delete doc.tombstones[key];
   });
   from.handle.change(doc => {
     removeProjectFromSet(doc, indexDocId);
@@ -810,6 +813,16 @@ export function getProject(indexDocId: string): ProjectSetEntry | undefined {
 }
 
 /**
+ * Deletion tombstones of the root set (map key -> ISO deletion timestamp).
+ * The reconciler compares these against a candidate IDB row's lastAccessed
+ * for latest-wins: a row at or older than its tombstone stays deleted.
+ */
+export function getRootTombstones(): Record<string, string> {
+  const doc = rootConnection()?.handle.doc();
+  return doc ? getProjectSetTombstones(doc) : {};
+}
+
+/**
  * Add a project to the root set.
  */
 export function addProject(
@@ -897,6 +910,8 @@ export function addProjectsBulk(
           addedAt: now,
           lastAccessed: entry.lastAccessed ?? now,
         };
+        // A (re-)add wins over any earlier deletion tombstone.
+        if (doc.tombstones && key in doc.tombstones) delete doc.tombstones[key];
         added++;
       }
     }

--- a/hub-client/src/services/projectStorage.test.ts
+++ b/hub-client/src/services/projectStorage.test.ts
@@ -16,6 +16,7 @@ import {
   updateProject,
   touchProject,
   deleteProject,
+  deleteProjectByIndexDocId,
   exportData,
   importData,
   closeDatabase,
@@ -132,6 +133,51 @@ describe('projectStorage', () => {
 
       const deleted = await getProject(project.id);
       expect(deleted).toBeUndefined();
+    });
+  });
+
+  describe('deleteProjectByIndexDocId', () => {
+    it('deletes the row matching the indexDocId', async () => {
+      await addProject('automerge:del-1', 'ws://localhost:3030', 'Keep');
+      await addProject('automerge:del-2', 'ws://localhost:3030', 'Delete Me');
+
+      const deleted = await deleteProjectByIndexDocId('automerge:del-2');
+
+      expect(deleted).toBe(1);
+      const projects = await listProjects();
+      expect(projects).toHaveLength(1);
+      expect(projects[0].description).toBe('Keep');
+    });
+
+    it('matches a prefixed id given unprefixed and vice versa', async () => {
+      await addProject('automerge:prefixed', 'ws://localhost:3030', 'Prefixed');
+      await addProject('unprefixed', 'ws://localhost:3030', 'Unprefixed');
+
+      expect(await deleteProjectByIndexDocId('prefixed')).toBe(1);
+      expect(await deleteProjectByIndexDocId('automerge:unprefixed')).toBe(1);
+
+      expect(await listProjects()).toHaveLength(0);
+    });
+
+    it('deletes both rows when prefixed and unprefixed duplicates exist', async () => {
+      // Historical duality: two code paths stored the id with and without
+      // the prefix (the unique index only guards identical strings).
+      await addProject('automerge:dup', 'ws://localhost:3030', 'Prefixed Row');
+      await addProject('dup', 'ws://localhost:3030', 'Unprefixed Row');
+
+      const deleted = await deleteProjectByIndexDocId('automerge:dup');
+
+      expect(deleted).toBe(2);
+      expect(await listProjects()).toHaveLength(0);
+    });
+
+    it('is a no-op when nothing matches', async () => {
+      await addProject('automerge:present', 'ws://localhost:3030', 'Present');
+
+      const deleted = await deleteProjectByIndexDocId('automerge:absent');
+
+      expect(deleted).toBe(0);
+      expect(await listProjects()).toHaveLength(1);
     });
   });
 

--- a/hub-client/src/services/projectStorage.ts
+++ b/hub-client/src/services/projectStorage.ts
@@ -5,6 +5,7 @@
  * with the schema versioning/migration system.
  */
 import type { ProjectEntry } from '@quarto/preview-renderer/types/project';
+import { projectSetKey } from '@quarto/quarto-automerge-schema';
 import type { ExportData, UserSettings } from './storage/types';
 import { getCollectionPointers } from './projectSetStorage';
 import {
@@ -102,6 +103,34 @@ export async function touchProject(id: string): Promise<void> {
 export async function deleteProject(id: string): Promise<void> {
   const db = await getDb();
   await db.delete(STORES.PROJECTS, id);
+}
+
+/**
+ * Delete every project entry matching an index document ID.
+ *
+ * Historical rows exist both with and without the `automerge:` prefix
+ * (see projectSetReconciler), so both variants are matched. The reconciler
+ * uses this to purge rows that lost to a deletion tombstone, so a stale
+ * local copy can never resurrect a deleted project.
+ *
+ * @returns The number of rows deleted.
+ */
+export async function deleteProjectByIndexDocId(indexDocId: string): Promise<number> {
+  const db = await getDb();
+  const key = projectSetKey(indexDocId);
+  const tx = db.transaction(STORES.PROJECTS, 'readwrite');
+  const store = tx.objectStore(STORES.PROJECTS);
+  const index = store.index('indexDocId');
+  let deleted = 0;
+  for (const variant of [key, `automerge:${key}`]) {
+    const primaryKey = await index.getKey(variant);
+    if (primaryKey !== undefined) {
+      await store.delete(primaryKey);
+      deleted++;
+    }
+  }
+  await tx.done;
+  return deleted;
 }
 
 /**

--- a/ts-packages/quarto-automerge-schema/src/index.ts
+++ b/ts-packages/quarto-automerge-schema/src/index.ts
@@ -180,6 +180,16 @@ export interface ProjectSetDocument {
    * collections existed; the UI supplies a default until the user names it.
    */
   name?: string;
+  /**
+   * Deletion tombstones: map key -> ISO timestamp of the deletion, written
+   * by `removeProjectFromSet` and cleared by `addProjectToSet`. An entry
+   * absent from `projects` is ambiguous without these — "never synced" and
+   * "deleted" look identical — so reconcilers compare the tombstone against
+   * a candidate's lastAccessed and let the latest one win. Optional:
+   * documents created before tombstones existed simply lack the map until
+   * the first deletion lazily initializes it.
+   */
+  tombstones?: Record<string, string>;
 }
 
 /**
@@ -211,11 +221,18 @@ export function addProjectToSet(
 ): boolean {
   const key = projectSetKey(entry.indexDocId);
   const timestamp = now ?? new Date().toISOString();
+
+  // A (re-)add wins over any earlier deletion tombstone — latest-wins.
+  let changed = false;
+  if (doc.tombstones && key in doc.tombstones) {
+    delete doc.tombstones[key];
+    changed = true;
+  }
+
   const existing = doc.projects[key];
 
   if (existing) {
     // Update mutable fields if changed
-    let changed = false;
     if (existing.description !== entry.description) {
       existing.description = entry.description;
       changed = true;
@@ -238,21 +255,34 @@ export function addProjectToSet(
 }
 
 /**
- * Remove a project from a ProjectSetDocument.
- * Must be called inside an Automerge `change()` callback.
+ * Remove a project from a ProjectSetDocument, leaving a deletion tombstone
+ * (the key's deletion timestamp) so reconcilers can apply latest-wins
+ * against stale local copies. Must be called inside an Automerge `change()`
+ * callback.
  *
  * @returns true if the entry was removed
  */
 export function removeProjectFromSet(
   doc: ProjectSetDocument,
   indexDocId: string,
+  now?: string,
 ): boolean {
   const key = projectSetKey(indexDocId);
-  if (doc.projects[key]) {
-    delete doc.projects[key];
-    return true;
-  }
-  return false;
+  if (!doc.projects[key]) return false;
+  delete doc.projects[key];
+  if (!doc.tombstones) doc.tombstones = {};
+  doc.tombstones[key] = now ?? new Date().toISOString();
+  return true;
+}
+
+/**
+ * Read the deletion-tombstone map (key -> ISO deletion timestamp), or an
+ * empty object when the document predates tombstones.
+ */
+export function getProjectSetTombstones(
+  doc: ProjectSetDocument,
+): Record<string, string> {
+  return doc.tombstones ?? {};
 }
 
 /**

--- a/ts-packages/quarto-automerge-schema/src/projectSet.test.ts
+++ b/ts-packages/quarto-automerge-schema/src/projectSet.test.ts
@@ -16,6 +16,7 @@ import {
   touchProjectInSet,
   updateProjectSummaryInSet,
   setProjectSetName,
+  getProjectSetTombstones,
 } from './index.js';
 import type { ProjectSetDocument } from './index.js';
 
@@ -168,6 +169,79 @@ describe('ProjectSetDocument schema helpers', () => {
       const result = removeProjectFromSet(doc, 'proj1');
       expect(result).toBe(true);
       expect(doc.projects['proj1']).toBeUndefined();
+    });
+  });
+
+  describe('tombstones', () => {
+    it('removeProjectFromSet records a deletion tombstone', () => {
+      const doc = emptyDoc();
+      addProjectToSet(doc, {
+        indexDocId: 'automerge:proj1',
+        syncServer: 'wss://sync.example.com',
+        description: 'To Remove',
+      });
+
+      const result = removeProjectFromSet(doc, 'automerge:proj1', '2026-08-21T10:00:00.000Z');
+
+      expect(result).toBe(true);
+      expect(doc.projects['proj1']).toBeUndefined();
+      expect(doc.tombstones).toEqual({ proj1: '2026-08-21T10:00:00.000Z' });
+      expect(getProjectSetTombstones(doc)).toEqual({ proj1: '2026-08-21T10:00:00.000Z' });
+    });
+
+    it('removeProjectFromSet of an absent project writes no tombstone', () => {
+      const doc = emptyDoc();
+
+      const result = removeProjectFromSet(doc, 'automerge:ghost');
+
+      expect(result).toBe(false);
+      expect(doc.tombstones).toBeUndefined();
+    });
+
+    it('addProjectToSet clears the tombstone — a re-add wins over the delete', () => {
+      const doc = emptyDoc();
+      addProjectToSet(doc, {
+        indexDocId: 'automerge:proj1',
+        syncServer: 'wss://sync.example.com',
+        description: 'Project',
+      });
+      removeProjectFromSet(doc, 'automerge:proj1', '2026-08-21T10:00:00.000Z');
+
+      addProjectToSet(doc, {
+        indexDocId: 'automerge:proj1',
+        syncServer: 'wss://sync.example.com',
+        description: 'Project',
+      });
+
+      expect(doc.projects['proj1']).toBeDefined();
+      expect(doc.tombstones).toEqual({});
+    });
+
+    it('addProjectToSet update path also clears a lingering tombstone', () => {
+      // Torn state after a concurrent add/delete merge: entry present AND
+      // tombstone present. The add heals it.
+      const doc = emptyDoc();
+      addProjectToSet(doc, {
+        indexDocId: 'automerge:proj1',
+        syncServer: 'wss://sync.example.com',
+        description: 'Project',
+      });
+      doc.tombstones = { proj1: '2026-08-21T10:00:00.000Z' };
+
+      const result = addProjectToSet(doc, {
+        indexDocId: 'automerge:proj1',
+        syncServer: 'wss://sync.example.com',
+        description: 'Project',
+      });
+
+      expect(result).toBe(true); // clearing the tombstone counts as a change
+      expect(doc.tombstones).toEqual({});
+    });
+
+    it('getProjectSetTombstones returns {} for documents predating tombstones', () => {
+      const doc = emptyDoc();
+      expect(doc.tombstones).toBeUndefined();
+      expect(getProjectSetTombstones(doc)).toEqual({});
     });
   });
 


### PR DESCRIPTION
## Problem

Deleting a project from the synced project set (× in ProjectSelector, "Remove from this device" in ProjectsHome) appeared to work, but the project came back on the next page load.

**Root cause:** the delete path only mutated the synced Automerge document. The legacy IndexedDB `projects` row survived, and the on-load reconciler (`reconcileIntoConnectedProjectSet`) upserts any IDB row missing from the set — resurrecting the deletion, same-browser and cross-device.

## Fix: per-key deletion tombstones, latest-wins

- **`@quarto/quarto-automerge-schema`**: `ProjectSetDocument` gains an optional `tombstones?: Record<key, deletedAtISO>` map (absent on existing docs, lazily created on first delete — forward-compatible both directions, no version bump). `removeProjectFromSet` stamps the tombstone; `addProjectToSet` clears it (a re-add wins).
- **hub-client service**: `addProjectsBulk` and `moveProjectBetweenCollections` clear tombstones for keys they re-add; new `getRootTombstones()` accessor.
- **Reconciler**: latest-wins — an IDB row at/older than its tombstone is a stale pre-delete copy and is purged (new `deleteProjectByIndexDocId`, covering the prefixed/unprefixed historical duality); a newer row is a genuine later access and is re-added. Ties go to the deletion.
- Because tombstones sync with the document, a deletion made on one browser also wins on every other browser's reconcile.

## Verification

- Schema package: 72 tests pass (5 new tombstone tests)
- hub-client: full suite 979 tests pass (88 files), incl. 10 new reconciler/storage tests
- Both typechecks clean; grep sweep confirms no `doc.projects` write path bypasses tombstone maintenance

Strand: bd-f5a0c6rv (follow-up bd-ec8eop0c tracks the deferred outbox-semantics refactor of the legacy store)
Plan: `claude-notes/plans/2026-08-21-project-set-deletion-tombstones.md`