### PR TITLE
Numeric config keys: stop silently dropping unquoted YAML numbers

### DIFF
--- a/claude-notes/plans/2026-08-20-listing-numeric-config-keys.md
+++ b/claude-notes/plans/2026-08-20-listing-numeric-config-keys.md
@@ -1,0 +1,132 @@
+# Listing numeric config keys silently ignore unquoted YAML integers (bd-yjsz6hdu)
+
+**Date:** 2026-08-20
+**Braid:** bd-yjsz6hdu (bug, p2, label `listings`)
+**Checkout:** main checkout, branch `main` @ `a72a2bb26` (no worktree — investigation only)
+**Status:** Investigation — pending design alignment with user. **Do not start implementation until the user gives the go-ahead.**
+
+## Triage verdict
+
+**Ready to design.** The class is fully enumerated (bigger than the strand's
+three named keys — see inventory), the fix shapes are clear, and the main open
+question is *altitude*: patch the listing sites onto the existing local helper,
+or promote proper numeric accessors to `ConfigValue` and retire the three
+independent hand-rolled variants that have now accumulated.
+
+## Issue context
+
+Filed 2026-08-20 by me, discovered during
+bd-listing-ellipsis-no-matching-l963osy1 (PR #570, merged): numeric listing
+options were read with `entry.value.as_plain_text().and_then(|s| s.parse().ok())`,
+but an unquoted YAML integer arrives as `ConfigValueKind::Scalar(Yaml::Integer)`,
+for which `as_plain_text()` returns `None` — the option is silently dropped and
+the default kept. PR #570 fixed `max-description-length` via a new local helper
+`parse_u32_scalar` (`as_int()` first, plain-text parse fallback) and left the
+siblings to this strand.
+
+## Dependency graph
+
+Single edge: `discovered-from` → bd-listing-ellipsis-no-matching-l963osy1
+(**closed**, PR #570). No dependents pin urgency; the class is latent until a
+user sets one of the affected keys unquoted — which is the *natural* way to
+write them (`page-size: 10`).
+
+## What the code looks like today (full inventory, 2026-08-20)
+
+Swept the workspace for `as_plain_text()` + `parse()` chains and bare
+`as_int()` reads.
+
+**Still broken — unquoted integer silently dropped** (the strand's core):
+
+| Site | Key | Note |
+|---|---|---|
+| `listing/config.rs:494` | `page-size` | currently inert downstream (no pagination emission, bd-nbv80e33) but parsed & bound |
+| `listing/config.rs:499` | `max-items` | `Option<…>` — quietly stays `None` |
+| `listing/config.rs:538` | `grid-columns` | grid class `quarto-listing-cols-N` wrong → falls to default 3 |
+| `listing/config.rs:893` | `feed: items:` | inside `parse_feed` — the audit the strand asked for found exactly this one |
+
+**Broken for unquoted *floats*** (`Yaml::Real` handled nowhere):
+
+- `revealjs/assemble.rs:238` `float_opt` — handles `as_int()` + string, but
+  `margin: 0.2` arrives as `Scalar(Yaml::Real("0.2"))` → both probes miss →
+  silently defaults to 0.1. (`margin` is the only `float_opt` consumer.)
+  Confirmed `Yaml::Real` is what the real front-matter path produces
+  (`pampa/src/pandoc/meta.rs:450`); `as_plain_text()` matches only
+  String/Path/Glob/Expr/PandocInlines.
+
+**Mirror-image miss — bare `as_int()` with no string fallback** (breaks on
+*quoted* numbers, `"3"`, which in front matter become `PandocInlines`):
+`document_profile.rs:798,905`, `revealjs/transform.rs:62`,
+`revealjs/assemble.rs:235` (`int_opt`), `extension/read.rs:566,584`,
+`template.rs:1240`. Lower severity (users rarely quote numbers) but the same
+class seen from the other side.
+
+**Existing hand-rolled robust readers — now three independent copies:**
+
+1. `pampa/src/toc.rs:240` — `level`: `as_int().or_else(plain-text-parse)`.
+2. `revealjs/assemble.rs:235-243` — `int_opt`/`float_opt` (float variant
+   incomplete, see above).
+3. `listing/config.rs:709` — `parse_u32_scalar` (PR #570).
+
+`ConfigValue` (in-tree `quarto-pandoc-types`) offers only strict `as_int()` /
+`as_bool()`; there is no `as_f64` at all (the revealjs comment says so
+explicitly) and nothing lenient.
+
+No repro fixture needed — the class is already pinned by a regression test
+from PR #570 (`max_description_length_accepts_unquoted_integer` travels the
+real YAML path); new tests would follow the same pattern per key.
+
+## Proposed phases (draft)
+
+- **Phase 0 — Tests (TDD).** Per-key regression tests through
+  `parse_from_yaml` (unquoted int for the four listing sites; unquoted float
+  for revealjs `margin` if in scope; quoted-string forms as regression
+  guards). Verify each fails first.
+- **Phase 1 — The accessor** (shape depends on Q1): either migrate the four
+  listing sites onto `parse_u32_scalar`, or add lenient numeric accessors to
+  `ConfigValue` (`quarto-pandoc-types`) — e.g. `as_i64_lenient()` /
+  `as_f64_lenient()` accepting Integer, Real (float case), and
+  parseable String/PandocInlines — and migrate.
+- **Phase 2 — Consumers.** Rewire the in-scope sites; retire the local
+  helpers that the chosen altitude obsoletes.
+- **Phase 3 — Verification.** Full workspace tests; `cargo xtask verify`
+  (quarto-pandoc-types/quarto-core → WASM leg); e2e render probe for one
+  listing key + `margin` if in scope.
+- **Phase 4 — Lint (optional, Q4).** xtask lint rule banning new
+  `as_plain_text().…parse()` chains outside the blessed accessor, in the
+  spirit of `metadata-as-str`.
+
+## Open design questions for the user
+
+1. **Altitude.** (a) Minimal: four one-line changes onto the existing
+   `parse_u32_scalar`, listing-only. (b) Foundational: add lenient numeric
+   accessors to `ConfigValue` in `quarto-pandoc-types` and migrate all three
+   hand-rolled helpers + the four broken sites onto them. (c) Radical: teach
+   `as_plain_text()` itself to render Integer/Real scalars as text — fixes
+   the class at the root but changes semantics for every existing caller
+   (blast radius includes the `metadata-as-str` lint's assumptions); I'd
+   recommend against (c). My read: **(b)** — a third hand-rolled copy just
+   appeared, which is the classic signal the abstraction wants to move down.
+2. **revealjs `margin:` float bug.** Include here (natural under altitude (b),
+   where `as_f64_lenient` exists anyway), or file as its own strand? My read:
+   include under (b); file separately if we pick (a).
+3. **Bare `as_int()` sites** (quoted-number miss, 7 call sites): migrate in
+   this strand, or file as a separate lower-priority strand? My read:
+   separate strand — different symptom, different severity, and this strand
+   stays reviewably small.
+4. **Lint rule.** Worth adding the `as_plain_text().…parse()` lint in this
+   strand (Phase 4), a follow-up strand, or not at all? My read: follow-up
+   strand — the pattern is subtle enough that it *will* be reintroduced, but
+   the lint design (which chains to flag, how to bless the accessor's own
+   fallback) deserves its own small scope.
+
+## Risks / tradeoffs (draft)
+
+- Altitude (b) touches `quarto-pandoc-types`, which `wasm-quarto-hub-client`
+  depends on → full `cargo xtask verify` mandatory before push (WASM leg).
+- Lenient accessors must define what happens for `Yaml::Real` when an
+  *integer* is requested (`page-size: 2.5`?) — recommend: integer accessor
+  rejects non-integral Real (keep default + stay silent, matching current
+  error posture; a diagnostic would be new behavior worth its own question).
+- The quoted-form tests double as guards that migrating off
+  `as_plain_text()`-first doesn't regress the currently-working string path.

--- a/claude-notes/plans/2026-08-20-listing-numeric-config-keys.md
+++ b/claude-notes/plans/2026-08-20-listing-numeric-config-keys.md
@@ -99,42 +99,45 @@ real YAML path); new tests would follow the same pattern per key.
 Commit structure (stacked): **A** accessors, **B** broken-site fixes,
 **C** bare-`as_int` migration. Each commit green on its own.
 
-- **Phase 0 — Failing tests for the broken sites (before commit B's fixes).**
-  - [ ] `parse_from_yaml` regression tests: unquoted `page-size`,
+- **Phase 0 — Failing tests for the broken sites (before commit B's fixes).** ✅
+  - [x] `parse_from_yaml` regression tests: unquoted `page-size`,
     `max-items`, `grid-columns`, `feed: items:`; quoted-string forms as
     guards for the currently-working path.
-  - [ ] revealjs `margin:` as `Yaml::Real` (via `new_scalar`) →
+  - [x] revealjs `margin:` as `Yaml::Real` (via `new_scalar`) →
     `v["margin"] == 0.2`; guard: int `margin` and default.
-  - [ ] Verify each fails at HEAD.
+  - [x] Verified: 5 bug tests failing at HEAD, 2 guards passing (2026-08-21).
 - **Phase 1 — Accessors (commit A).**
-  - [ ] `as_int_lenient() -> Option<i64>` and `as_f64_lenient() -> Option<f64>`
+  - [x] `as_int_lenient() -> Option<i64>` and `as_f64_lenient() -> Option<f64>`
     on `ConfigValue` (`quarto-pandoc-types/src/config_value.rs`) with unit
     tests (Integer, Real, quoted string, PandocInlines, garbage, Real-to-int
-    rejection, whitespace trim).
+    rejection, whitespace trim). **Commit A = `2e1bc26f1`.**
 - **Phase 2 — Broken-site + hand-rolled-reader migration (commit B).**
-  - [ ] listing `config.rs`: `page-size`, `max-items`, `grid-columns`,
+  - [x] listing `config.rs`: `page-size`, `max-items`, `grid-columns`,
     `feed.items` → via `parse_u32_scalar`, itself reimplemented over
     `as_int_lenient` (keeps the u32 clamp in one place).
-  - [ ] revealjs `int_opt`/`float_opt` → thin wrappers over the accessors
-    (or deleted if call sites read cleanly); fixes `margin:`.
-  - [ ] `pampa/src/toc.rs:240` `level` → `as_int_lenient` (behavior-neutral
-    consolidation; it was already robust).
+  - [x] revealjs `int_opt`/`float_opt` → thin wrappers over the accessors;
+    fixes `margin:`. (`int_opt` leniency also makes quoted `width:`/`height:`
+    integers parse instead of falling into the %-string branch.)
+  - [x] `pampa/src/toc.rs:240` `level` → `as_int_lenient` (behavior-neutral
+    consolidation; it was already robust). **Commit B = `1b1bb54fd`.**
 - **Phase 3 — Bare-`as_int` sites, quoted-number miss (commit C).**
-  - [ ] Failing tests first (quoted `"3"` / front-matter-inlines forms), then
-    migrate: `document_profile.rs:798` (`order:`), `:905`
-    (`extract_u32_field` — `reading-time-minutes`, `word-count`),
-    `revealjs/transform.rs:62` (`slide-level:`), `extension/read.rs:566,584`
-    (claim `priority`).
-  - [ ] **Excluded with rationale:** `template.rs:1240` — that `as_int()` is
+  - [x] Failing tests first (4 verified failing), then migrated: `order:`,
+    `extract_u32_field` (`reading-time-minutes`, `word-count`),
+    `slide-level:` (read extracted into testable `slide_level_from_meta`),
+    extension claim `priority` (both object forms). **Commit C = `544ba2321`.**
+  - [x] **Excluded with rationale:** `template.rs:1240` — that `as_int()` is
     a type-dispatch arm in `config_value_to_template_value` (bool → int →
     null → …), not an option read; string-to-int coercion there would change
     template semantics.
 - **Phase 4 — Verification.**
-  - [ ] Full workspace tests; full `cargo xtask verify`
-    (quarto-pandoc-types → WASM leg); snapshot audit.
-  - [ ] E2E probe through `cargo run --bin q2 -- render`: a listing with
-    unquoted `grid-columns` + a revealjs doc with `margin: 0.2`; inspect
-    output; record here.
+  - [x] Full `cargo xtask verify` (Rust + WASM + hub legs): all steps
+    passed (2026-08-21). Snapshot audit: zero .snap changes. Clippy clean
+    on all three touched crates; fmt clean.
+  - [x] E2E probe (2026-08-21): scratch website with `grid-columns: 4`
+    (unquoted) renders `quarto-listing-cols-4` (was silently cols-3);
+    revealjs doc with `margin: 0.2` renders `"margin": 0.2` in the deck
+    config (was silently 0.1). Output inspected by hand; invocation:
+    `cargo run --bin q2 -- render <scratch>`.
 
 ## Open design questions for the user
 

--- a/claude-notes/plans/2026-08-20-listing-numeric-config-keys.md
+++ b/claude-notes/plans/2026-08-20-listing-numeric-config-keys.md
@@ -2,8 +2,26 @@
 
 **Date:** 2026-08-20
 **Braid:** bd-yjsz6hdu (bug, p2, label `listings`)
-**Checkout:** main checkout, branch `main` @ `a72a2bb26` (no worktree — investigation only)
-**Status:** Investigation — pending design alignment with user. **Do not start implementation until the user gives the go-ahead.**
+**Checkout:** main checkout, branch `braid/bd-yjsz6hdu` (off `main` @ `a72a2bb26`)
+**Status:** Design aligned 2026-08-21; executing.
+
+## Design decisions (2026-08-21, aligned with user)
+
+1. **Altitude (b)**: lenient numeric accessors on `ConfigValue` in
+   `quarto-pandoc-types` (`as_int_lenient` / `as_f64_lenient`); migrate the
+   three hand-rolled readers + the four broken listing sites onto them.
+   Option (c) (making `as_plain_text` render numbers) rejected.
+2. **revealjs `margin:`** float bug included here.
+3. **Bare `as_int()` sites**: an additional phase in this strand (not a
+   separate strand), with **stacked, independently reviewable commits** —
+   accessors, then the broken-site migrations, then the bare-`as_int` phase.
+4. **Lint rule**: follow-up strand — filed as **bd-clqzz2rl**.
+
+Accessor semantics (from the risk note, now decided): the integer accessor
+accepts `Yaml::Integer` and parseable string/inlines forms and **rejects
+`Yaml::Real`** (a `page-size: 2.5` keeps the default, silently — matching the
+current error posture; diagnostics would be new behavior out of scope). The
+float accessor accepts Integer, Real, and parseable string/inlines forms.
 
 ## Triage verdict
 
@@ -76,25 +94,47 @@ No repro fixture needed — the class is already pinned by a regression test
 from PR #570 (`max_description_length_accepts_unquoted_integer` travels the
 real YAML path); new tests would follow the same pattern per key.
 
-## Proposed phases (draft)
+## Work items
 
-- **Phase 0 — Tests (TDD).** Per-key regression tests through
-  `parse_from_yaml` (unquoted int for the four listing sites; unquoted float
-  for revealjs `margin` if in scope; quoted-string forms as regression
-  guards). Verify each fails first.
-- **Phase 1 — The accessor** (shape depends on Q1): either migrate the four
-  listing sites onto `parse_u32_scalar`, or add lenient numeric accessors to
-  `ConfigValue` (`quarto-pandoc-types`) — e.g. `as_i64_lenient()` /
-  `as_f64_lenient()` accepting Integer, Real (float case), and
-  parseable String/PandocInlines — and migrate.
-- **Phase 2 — Consumers.** Rewire the in-scope sites; retire the local
-  helpers that the chosen altitude obsoletes.
-- **Phase 3 — Verification.** Full workspace tests; `cargo xtask verify`
-  (quarto-pandoc-types/quarto-core → WASM leg); e2e render probe for one
-  listing key + `margin` if in scope.
-- **Phase 4 — Lint (optional, Q4).** xtask lint rule banning new
-  `as_plain_text().…parse()` chains outside the blessed accessor, in the
-  spirit of `metadata-as-str`.
+Commit structure (stacked): **A** accessors, **B** broken-site fixes,
+**C** bare-`as_int` migration. Each commit green on its own.
+
+- **Phase 0 — Failing tests for the broken sites (before commit B's fixes).**
+  - [ ] `parse_from_yaml` regression tests: unquoted `page-size`,
+    `max-items`, `grid-columns`, `feed: items:`; quoted-string forms as
+    guards for the currently-working path.
+  - [ ] revealjs `margin:` as `Yaml::Real` (via `new_scalar`) →
+    `v["margin"] == 0.2`; guard: int `margin` and default.
+  - [ ] Verify each fails at HEAD.
+- **Phase 1 — Accessors (commit A).**
+  - [ ] `as_int_lenient() -> Option<i64>` and `as_f64_lenient() -> Option<f64>`
+    on `ConfigValue` (`quarto-pandoc-types/src/config_value.rs`) with unit
+    tests (Integer, Real, quoted string, PandocInlines, garbage, Real-to-int
+    rejection, whitespace trim).
+- **Phase 2 — Broken-site + hand-rolled-reader migration (commit B).**
+  - [ ] listing `config.rs`: `page-size`, `max-items`, `grid-columns`,
+    `feed.items` → via `parse_u32_scalar`, itself reimplemented over
+    `as_int_lenient` (keeps the u32 clamp in one place).
+  - [ ] revealjs `int_opt`/`float_opt` → thin wrappers over the accessors
+    (or deleted if call sites read cleanly); fixes `margin:`.
+  - [ ] `pampa/src/toc.rs:240` `level` → `as_int_lenient` (behavior-neutral
+    consolidation; it was already robust).
+- **Phase 3 — Bare-`as_int` sites, quoted-number miss (commit C).**
+  - [ ] Failing tests first (quoted `"3"` / front-matter-inlines forms), then
+    migrate: `document_profile.rs:798` (`order:`), `:905`
+    (`extract_u32_field` — `reading-time-minutes`, `word-count`),
+    `revealjs/transform.rs:62` (`slide-level:`), `extension/read.rs:566,584`
+    (claim `priority`).
+  - [ ] **Excluded with rationale:** `template.rs:1240` — that `as_int()` is
+    a type-dispatch arm in `config_value_to_template_value` (bool → int →
+    null → …), not an option read; string-to-int coercion there would change
+    template semantics.
+- **Phase 4 — Verification.**
+  - [ ] Full workspace tests; full `cargo xtask verify`
+    (quarto-pandoc-types → WASM leg); snapshot audit.
+  - [ ] E2E probe through `cargo run --bin q2 -- render`: a listing with
+    unquoted `grid-columns` + a revealjs doc with `margin: 0.2`; inspect
+    output; record here.
 
 ## Open design questions for the user
 

--- a/crates/pampa/src/toc.rs
+++ b/crates/pampa/src/toc.rs
@@ -232,12 +232,12 @@ impl TocEntry {
         let id = cv.get("id")?.as_plain_text()?;
         let title = config_value_to_inlines(cv.get("title")?)?;
         // Accept both integer and string-encoded integer for level
-        // (YAML parsing may convert integers to strings in some contexts)
-        let level_cv = cv.get("level")?;
-        let level = level_cv
-            .as_int()
-            .map(|i| i as i32)
-            .or_else(|| level_cv.as_plain_text().and_then(|s| s.parse::<i32>().ok()))?;
+        // (YAML parsing may convert integers to strings in some
+        // contexts) — `as_int_lenient` handles both (bd-yjsz6hdu).
+        let level = cv
+            .get("level")?
+            .as_int_lenient()
+            .and_then(|i| i32::try_from(i).ok())?;
         let number = cv.get("number").and_then(|v| v.as_plain_text());
 
         let children = if let Some(children_cv) = cv.get("children") {

--- a/crates/quarto-core/src/document_profile.rs
+++ b/crates/quarto-core/src/document_profile.rs
@@ -795,7 +795,7 @@ impl DocumentProfile {
             alias_sources: aliases.into_iter().map(|(_, info)| info).collect(),
             order: meta
                 .get("order")
-                .and_then(|v| v.as_int())
+                .and_then(|v| v.as_int_lenient())
                 .and_then(|i| i32::try_from(i).ok()),
             outline,
             // Phase-8 fields that come from the AST's `meta.project.*`
@@ -902,7 +902,7 @@ fn extract_listing_item(meta: &ConfigValue) -> ListingItemInfo {
 /// pattern used elsewhere in this module.
 fn extract_u32_field(meta: &ConfigValue, key: &str) -> Option<u32> {
     meta.get(key)
-        .and_then(|v| v.as_int())
+        .and_then(|v| v.as_int_lenient())
         .and_then(|i| u32::try_from(i).ok())
 }
 
@@ -1347,6 +1347,26 @@ Body.
         let ast = parse_qmd("---\ntitle: No order\n---\n\nBody.\n");
         let profile = DocumentProfile::extract(&ast, Path::new("x.qmd"), "x.html", "html");
         assert_eq!(profile.order, None);
+    }
+
+    // bd-yjsz6hdu Phase 3: quoted numbers in front matter become
+    // PandocInlines, which the strict `as_int()` misses — the option
+    // silently dropped.
+    #[test]
+    fn profile_extract_order_accepts_quoted_integer() {
+        let ast = parse_qmd("---\ntitle: Ordered\norder: \"3\"\n---\n\nBody.\n");
+        let profile = DocumentProfile::extract(&ast, Path::new("o.qmd"), "o.html", "html");
+        assert_eq!(profile.order, Some(3));
+    }
+
+    #[test]
+    fn profile_extract_listing_item_accepts_quoted_counts() {
+        let ast = parse_qmd(
+            "---\ntitle: T\nlisting-item:\n  reading-time-minutes: \"7\"\n  word-count: \"1200\"\n---\n\nBody.\n",
+        );
+        let profile = DocumentProfile::extract(&ast, Path::new("t.qmd"), "t.html", "html");
+        assert_eq!(profile.listing_item.reading_time_minutes, Some(7));
+        assert_eq!(profile.listing_item.word_count, Some(1200));
     }
 
     #[test]

--- a/crates/quarto-core/src/extension/read.rs
+++ b/crates/quarto-core/src/extension/read.rs
@@ -563,7 +563,7 @@ pub(crate) fn parse_static_language_claim(
                 // fallback key: object form is `{ priority?: int }`, kind is implicit Fallback
                 let priority = cv
                     .get("priority")
-                    .and_then(|v| v.as_int())
+                    .and_then(|v| v.as_int_lenient())
                     .map(|n| n as i32);
                 Some(StaticLanguageClaim {
                     kind: ClaimKind::Fallback,
@@ -581,7 +581,7 @@ pub(crate) fn parse_static_language_claim(
                 };
                 let priority = cv
                     .get("priority")
-                    .and_then(|v| v.as_int())
+                    .and_then(|v| v.as_int_lenient())
                     .map(|n| n as i32);
                 let when_class = cv
                     .get("whenClass")
@@ -1987,6 +1987,39 @@ contributes:
     }
 
     /// Shorthand claim values: `true` → Primary(None), number → Primary(Some(n)),
+    /// bd-yjsz6hdu Phase 3: a quoted `priority: "2"` arrives as a
+    /// string scalar, which the strict `as_int()` missed — the
+    /// priority silently dropped to `None`.
+    #[test]
+    fn test_engine_claim_priority_accepts_quoted_integer() {
+        let tmp = TempDir::new().unwrap();
+        let ext_dir = tmp.path().join("_extensions/my-ext");
+        let file = write_extension(
+            &ext_dir,
+            r#"
+title: Engine Extension
+author: Author
+contributes:
+  engines:
+    - path: engine.js
+      claims:
+        sql:
+          kind: interop
+          priority: "2"
+"#,
+        );
+        let runtime = make_runtime();
+        let ext = read_extension(&file, &runtime).unwrap();
+        match &ext.contributes.engines[0] {
+            EngineContribution::External { claims, .. } => {
+                let sql = &claims.as_ref().unwrap().get("sql").unwrap()[0];
+                assert_eq!(sql.kind, ClaimKind::Interop);
+                assert_eq!(sql.priority, Some(2));
+            }
+            other => panic!("expected External, got {:?}", other),
+        }
+    }
+
     /// `fallback: { priority: 0 }` → Fallback entry. Each still parses to a
     /// 1-element Vec (4c0 back-compat for the scalar/single-object shape).
     #[test]

--- a/crates/quarto-core/src/project/listing/config.rs
+++ b/crates/quarto-core/src/project/listing/config.rs
@@ -491,12 +491,12 @@ fn parse_one_listing(
             "field-filter" => l.field_filter = parse_string_list(&entry.value),
             "field-required" => l.field_required = parse_string_list(&entry.value),
             "page-size" => {
-                if let Some(n) = entry.value.as_plain_text().and_then(|s| s.parse().ok()) {
+                if let Some(n) = parse_u32_scalar(&entry.value) {
                     l.page_size = n;
                 }
             }
             "max-items" => {
-                l.max_items = entry.value.as_plain_text().and_then(|s| s.parse().ok());
+                l.max_items = parse_u32_scalar(&entry.value);
             }
             "filter-ui" => {
                 l.filter_ui = entry.value.as_bool().unwrap_or(l.filter_ui);
@@ -535,7 +535,7 @@ fn parse_one_listing(
                 }
             }
             "grid-columns" => {
-                l.grid_columns = entry.value.as_plain_text().and_then(|s| s.parse().ok());
+                l.grid_columns = parse_u32_scalar(&entry.value);
             }
             "grid-item-border" => {
                 l.grid_item_border = entry.value.as_bool();
@@ -699,18 +699,13 @@ fn parse_contents(
     }
 }
 
-/// Numeric config scalar: accepts an unquoted YAML integer (`40`,
-/// which arrives as `Yaml::Integer` — `as_plain_text()` returns
-/// `None` for it) as well as the quoted/inline string form (`"40"`).
-/// Out-of-range and non-numeric values yield `None` (caller keeps
-/// its default). Discovered via bd-listing-ellipsis-no-matching-
-/// l963osy1; migrating the sibling numeric keys still on the
-/// plain-text-only pattern is bd-yjsz6hdu.
+/// Numeric config scalar as `u32`: any scalar form a user can write
+/// (unquoted integer, quoted string, bare front-matter scalar) via
+/// [`ConfigValue::as_int_lenient`], clamped to `u32`. Out-of-range and
+/// non-numeric values yield `None` (caller keeps its default).
+/// History: bd-listing-ellipsis-no-matching-l963osy1 / bd-yjsz6hdu.
 fn parse_u32_scalar(value: &ConfigValue) -> Option<u32> {
-    if let Some(i) = value.as_int() {
-        return u32::try_from(i).ok();
-    }
-    value.as_plain_text().and_then(|s| s.parse().ok())
+    value.as_int_lenient().and_then(|i| u32::try_from(i).ok())
 }
 
 fn parse_string_list(value: &ConfigValue) -> Vec<String> {
@@ -890,7 +885,7 @@ fn parse_feed(value: &ConfigValue) -> Option<ListingFeedOptions> {
         for e in entries {
             match e.key.as_str() {
                 "items" => {
-                    feed.items = e.value.as_plain_text().and_then(|s| s.parse().ok());
+                    feed.items = parse_u32_scalar(&e.value);
                 }
                 "type" => {
                     feed.kind = match e.value.as_plain_text().as_deref() {
@@ -1211,6 +1206,75 @@ listing:
                 .max_description_length,
             40
         );
+    }
+
+    // bd-yjsz6hdu: the sibling numeric keys share the trap fixed for
+    // max-description-length above — unquoted YAML integers arrive as
+    // `Yaml::Integer`, which `as_plain_text()` doesn't cover.
+
+    #[test]
+    fn page_size_accepts_unquoted_integer() {
+        let yaml = "\
+listing:
+    contents: ./a.qmd
+    page-size: 10
+";
+        let (listings, _diags, _ctx) = parse_from_yaml(yaml);
+        assert_eq!(listings.first().expect("one listing").page_size, 10);
+    }
+
+    // Guard: the quoted-string form worked before bd-yjsz6hdu and must
+    // keep working after the accessor migration.
+    #[test]
+    fn page_size_accepts_quoted_integer() {
+        let yaml = "\
+listing:
+    contents: ./a.qmd
+    page-size: \"10\"
+";
+        let (listings, _diags, _ctx) = parse_from_yaml(yaml);
+        assert_eq!(listings.first().expect("one listing").page_size, 10);
+    }
+
+    #[test]
+    fn max_items_accepts_unquoted_integer() {
+        let yaml = "\
+listing:
+    contents: ./a.qmd
+    max-items: 5
+";
+        let (listings, _diags, _ctx) = parse_from_yaml(yaml);
+        assert_eq!(listings.first().expect("one listing").max_items, Some(5));
+    }
+
+    #[test]
+    fn grid_columns_accepts_unquoted_integer() {
+        let yaml = "\
+listing:
+    contents: ./a.qmd
+    type: grid
+    grid-columns: 4
+";
+        let (listings, _diags, _ctx) = parse_from_yaml(yaml);
+        assert_eq!(listings.first().expect("one listing").grid_columns, Some(4));
+    }
+
+    #[test]
+    fn feed_items_accepts_unquoted_integer() {
+        let yaml = "\
+listing:
+    contents: ./a.qmd
+    feed:
+        items: 5
+";
+        let (listings, _diags, _ctx) = parse_from_yaml(yaml);
+        let feed = listings
+            .first()
+            .expect("one listing")
+            .feed
+            .as_ref()
+            .expect("feed configured");
+        assert_eq!(feed.items, Some(5));
     }
 
     // bd-2mxo: L5 captures the `categories:` *key* span here purely to

--- a/crates/quarto-core/src/revealjs/assemble.rs
+++ b/crates/quarto-core/src/revealjs/assemble.rs
@@ -231,16 +231,15 @@ fn reveal_config_json(meta: &ConfigValue) -> String {
     fn str_opt(meta: &ConfigValue, key: &str) -> Option<String> {
         meta.get(key).and_then(|v| v.as_plain_text())
     }
+    // Lenient accessors (bd-yjsz6hdu): every scalar form a user can
+    // write — unquoted numbers included; `as_f64_lenient` is what
+    // handles an unquoted `margin: 0.2` (`Yaml::Real`), which the old
+    // hand-rolled reader here missed.
     fn int_opt(meta: &ConfigValue, key: &str) -> Option<i64> {
-        meta.get(key).and_then(|v| v.as_int())
+        meta.get(key).and_then(|v| v.as_int_lenient())
     }
-    // No `as_f64` on ConfigValue; accept an int or a parseable numeric string.
     fn float_opt(meta: &ConfigValue, key: &str) -> Option<f64> {
-        let v = meta.get(key)?;
-        if let Some(i) = v.as_int() {
-            return Some(i as f64);
-        }
-        v.as_plain_text().and_then(|s| s.trim().parse::<f64>().ok())
+        meta.get(key).and_then(|v| v.as_f64_lenient())
     }
 
     // Booleans — Quarto-1 opinionated defaults. `center: false` top-aligns
@@ -509,6 +508,38 @@ mod tests {
     }
     fn b(v: bool) -> ConfigValue {
         ConfigValue::new_bool(v, SourceInfo::generated(By::revealjs()))
+    }
+
+    // bd-yjsz6hdu: `margin: 0.2` in YAML arrives as
+    // `Scalar(Yaml::Real("0.2"))` — which neither `as_int()` nor
+    // `as_plain_text()` covers — so the value silently fell back to
+    // the 0.1 default.
+    #[test]
+    fn margin_accepts_unquoted_float() {
+        let real = ConfigValue::new_scalar(
+            yaml_rust2::Yaml::Real("0.2".to_string()),
+            SourceInfo::generated(By::revealjs()),
+        );
+        let m = meta(vec![("margin", real)]);
+        let v: serde_json::Value = serde_json::from_str(&reveal_config_json(&m)).unwrap();
+        assert_eq!(v["margin"], serde_json::json!(0.2));
+    }
+
+    // Guards: the integer and quoted-string forms worked before
+    // bd-yjsz6hdu and must keep working after the accessor migration.
+    #[test]
+    fn margin_accepts_unquoted_integer_and_quoted_string() {
+        let int = ConfigValue::new_scalar(
+            yaml_rust2::Yaml::Integer(1),
+            SourceInfo::generated(By::revealjs()),
+        );
+        let m = meta(vec![("margin", int)]);
+        let v: serde_json::Value = serde_json::from_str(&reveal_config_json(&m)).unwrap();
+        assert_eq!(v["margin"], serde_json::json!(1.0));
+
+        let m = meta(vec![("margin", s("0.3"))]);
+        let v: serde_json::Value = serde_json::from_str(&reveal_config_json(&m)).unwrap();
+        assert_eq!(v["margin"], serde_json::json!(0.3));
     }
 
     #[test]

--- a/crates/quarto-core/src/revealjs/transform.rs
+++ b/crates/quarto-core/src/revealjs/transform.rs
@@ -56,12 +56,7 @@ impl AstTransform for RevealSlidesTransform {
     }
 
     async fn transform(&self, ast: &mut Pandoc, _ctx: &mut RenderContext) -> Result<()> {
-        let slide_level = ast
-            .meta
-            .get("slide-level")
-            .and_then(|v| v.as_int())
-            .filter(|n| *n >= 1)
-            .map_or(DEFAULT_SLIDE_LEVEL, |n| n as usize);
+        let slide_level = slide_level_from_meta(&ast.meta);
 
         let title_slide = build_title_slide(&ast.meta);
 
@@ -74,6 +69,16 @@ impl AstTransform for RevealSlidesTransform {
         ast.blocks = slides;
         Ok(())
     }
+}
+
+/// Read `slide-level:` from the merged metadata. Values below 1 (and
+/// unparseable ones) fall back to [`DEFAULT_SLIDE_LEVEL`]. Lenient:
+/// accepts quoted and bare-scalar forms too (bd-yjsz6hdu).
+fn slide_level_from_meta(meta: &quarto_pandoc_types::ConfigValue) -> usize {
+    meta.get("slide-level")
+        .and_then(|v| v.as_int_lenient())
+        .filter(|n| *n >= 1)
+        .map_or(DEFAULT_SLIDE_LEVEL, |n| n as usize)
 }
 
 /// A plain-text inline run.
@@ -169,4 +174,55 @@ fn build_title_slide(meta: &quarto_pandoc_types::ConfigValue) -> Option<Block> {
         source_info: SourceInfo::generated(By::revealjs()),
         attr_source: AttrSourceInfo::empty(),
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use quarto_pandoc_types::{ConfigMapEntry, ConfigValue};
+    use quarto_source_map::{By, SourceInfo};
+
+    fn meta_with_slide_level(value: ConfigValue) -> ConfigValue {
+        ConfigValue::new_map(
+            vec![ConfigMapEntry {
+                key: "slide-level".to_string(),
+                key_source: SourceInfo::generated(By::revealjs()),
+                value,
+            }],
+            SourceInfo::generated(By::revealjs()),
+        )
+    }
+
+    #[test]
+    fn slide_level_defaults_and_reads_unquoted_integer() {
+        let empty = ConfigValue::new_map(vec![], SourceInfo::generated(By::revealjs()));
+        assert_eq!(slide_level_from_meta(&empty), DEFAULT_SLIDE_LEVEL);
+
+        let int = ConfigValue::new_scalar(
+            yaml_rust2::Yaml::Integer(3),
+            SourceInfo::generated(By::revealjs()),
+        );
+        assert_eq!(slide_level_from_meta(&meta_with_slide_level(int)), 3);
+    }
+
+    // bd-yjsz6hdu Phase 3: a quoted `slide-level: "3"` (or the
+    // PandocInlines a bare front-matter scalar becomes) was missed by
+    // the strict `as_int()` and silently fell back to the default.
+    #[test]
+    fn slide_level_accepts_quoted_integer() {
+        let quoted = ConfigValue::new_string("3", SourceInfo::generated(By::revealjs()));
+        assert_eq!(slide_level_from_meta(&meta_with_slide_level(quoted)), 3);
+    }
+
+    #[test]
+    fn slide_level_below_one_falls_back_to_default() {
+        let zero = ConfigValue::new_scalar(
+            yaml_rust2::Yaml::Integer(0),
+            SourceInfo::generated(By::revealjs()),
+        );
+        assert_eq!(
+            slide_level_from_meta(&meta_with_slide_level(zero)),
+            DEFAULT_SLIDE_LEVEL
+        );
+    }
 }

--- a/crates/quarto-pandoc-types/src/config_value.rs
+++ b/crates/quarto-pandoc-types/src/config_value.rs
@@ -664,6 +664,45 @@ impl ConfigValue {
         }
     }
 
+    /// Get an integer from any scalar form a user can write in config:
+    /// an unquoted YAML integer (`Yaml::Integer`), or a
+    /// parseable string form — quoted scalars, and the
+    /// `PandocInlines` that bare front-matter scalars become.
+    ///
+    /// `Yaml::Real` is deliberately rejected: a float where an integer
+    /// option is expected keeps the caller's default (matching the
+    /// silent-drop posture of config parsing generally).
+    ///
+    /// This is the intended accessor for numeric config options. The
+    /// strict [`Self::as_int`] misses quoted numbers, and
+    /// `as_plain_text().parse()` misses unquoted ones — each miss
+    /// silently drops the option (bd-yjsz6hdu).
+    pub fn as_int_lenient(&self) -> Option<i64> {
+        if let Some(i) = self.as_int() {
+            return Some(i);
+        }
+        if matches!(&self.value, ConfigValueKind::Scalar(Yaml::Real(_))) {
+            return None;
+        }
+        self.as_plain_text().and_then(|s| s.trim().parse().ok())
+    }
+
+    /// Get a float from any scalar form a user can write in config:
+    /// an unquoted YAML float (`Yaml::Real`) or integer
+    /// (`Yaml::Integer`), or a parseable string form — quoted scalars,
+    /// and the `PandocInlines` that bare front-matter scalars become.
+    ///
+    /// Companion to [`Self::as_int_lenient`]; before it existed, no
+    /// accessor handled `Yaml::Real` at all, so an unquoted
+    /// `margin: 0.2` was silently dropped (bd-yjsz6hdu).
+    pub fn as_f64_lenient(&self) -> Option<f64> {
+        match &self.value {
+            ConfigValueKind::Scalar(Yaml::Integer(i)) => Some(*i as f64),
+            ConfigValueKind::Scalar(Yaml::Real(r)) => r.trim().parse().ok(),
+            _ => self.as_plain_text().and_then(|s| s.trim().parse().ok()),
+        }
+    }
+
     /// Extract plain text from this value.
     ///
     /// Works for:
@@ -1039,6 +1078,78 @@ mod tests {
 
         let value_neg = ConfigValue::new_scalar(Yaml::Integer(-100), SourceInfo::for_test());
         assert_eq!(value_neg.as_int(), Some(-100));
+    }
+
+    // ── bd-yjsz6hdu: lenient numeric accessors ────────────────────
+
+    fn inlines_value(text: &str) -> ConfigValue {
+        use crate::inline::{Inline, Str};
+        ConfigValue::new_inlines(
+            vec![Inline::Str(Str {
+                text: text.to_string(),
+                source_info: SourceInfo::for_test(),
+            })],
+            SourceInfo::for_test(),
+        )
+    }
+
+    #[test]
+    fn test_as_int_lenient_accepts_all_scalar_forms() {
+        // Unquoted YAML integer.
+        let int = ConfigValue::new_scalar(Yaml::Integer(42), SourceInfo::for_test());
+        assert_eq!(int.as_int_lenient(), Some(42));
+        // Quoted scalar.
+        let quoted = ConfigValue::new_string("42", SourceInfo::for_test());
+        assert_eq!(quoted.as_int_lenient(), Some(42));
+        // Bare front-matter scalar (PandocInlines).
+        assert_eq!(inlines_value("42").as_int_lenient(), Some(42));
+        // Whitespace tolerated.
+        let padded = ConfigValue::new_string(" 42 ", SourceInfo::for_test());
+        assert_eq!(padded.as_int_lenient(), Some(42));
+        // Negative.
+        let neg = ConfigValue::new_scalar(Yaml::Integer(-7), SourceInfo::for_test());
+        assert_eq!(neg.as_int_lenient(), Some(-7));
+    }
+
+    #[test]
+    fn test_as_int_lenient_rejects_reals_and_garbage() {
+        // A float where an integer is expected keeps the default —
+        // even an integral-valued one (documented posture).
+        let real = ConfigValue::new_scalar(Yaml::Real("2.5".to_string()), SourceInfo::for_test());
+        assert_eq!(real.as_int_lenient(), None);
+        let integral_real =
+            ConfigValue::new_scalar(Yaml::Real("2.0".to_string()), SourceInfo::for_test());
+        assert_eq!(integral_real.as_int_lenient(), None);
+        // Non-numeric text.
+        let text = ConfigValue::new_string("many", SourceInfo::for_test());
+        assert_eq!(text.as_int_lenient(), None);
+        // Non-scalar shapes.
+        let map = ConfigValue::new_map(vec![], SourceInfo::for_test());
+        assert_eq!(map.as_int_lenient(), None);
+        let boolean = ConfigValue::new_bool(true, SourceInfo::for_test());
+        assert_eq!(boolean.as_int_lenient(), None);
+    }
+
+    #[test]
+    fn test_as_f64_lenient_accepts_all_scalar_forms() {
+        // Unquoted YAML float — the form no accessor covered before.
+        let real = ConfigValue::new_scalar(Yaml::Real("0.2".to_string()), SourceInfo::for_test());
+        assert_eq!(real.as_f64_lenient(), Some(0.2));
+        // Unquoted YAML integer widens.
+        let int = ConfigValue::new_scalar(Yaml::Integer(3), SourceInfo::for_test());
+        assert_eq!(int.as_f64_lenient(), Some(3.0));
+        // Quoted scalar and bare front-matter scalar.
+        let quoted = ConfigValue::new_string("0.25", SourceInfo::for_test());
+        assert_eq!(quoted.as_f64_lenient(), Some(0.25));
+        assert_eq!(inlines_value("0.25").as_f64_lenient(), Some(0.25));
+    }
+
+    #[test]
+    fn test_as_f64_lenient_rejects_garbage() {
+        let text = ConfigValue::new_string("wide", SourceInfo::for_test());
+        assert_eq!(text.as_f64_lenient(), None);
+        let boolean = ConfigValue::new_bool(true, SourceInfo::for_test());
+        assert_eq!(boolean.as_f64_lenient(), None);
     }
 
     #[test]


### PR DESCRIPTION
Fixes bd-yjsz6hdu. Plan: `claude-notes/plans/2026-08-20-listing-numeric-config-keys.md`. Discovered during PR #570, where `max-description-length: 40` (unquoted) turned out to be silently ignored — this PR fixes the rest of the class.

## The class

`as_plain_text()` returns `None` for `Yaml::Integer`/`Yaml::Real`, so every `as_plain_text().parse()` read drops *unquoted* numbers; conversely, strict `as_int()` drops *quoted* numbers (and the `PandocInlines` bare front-matter scalars become). Three hand-rolled robust readers had accumulated independently (toc.rs, revealjs, listing config). Review commit-by-commit — the three implementation commits are stacked and independently green:

1. **`2e1bc26f1` — accessors** (`quarto-pandoc-types`): `as_int_lenient()` / `as_f64_lenient()` on `ConfigValue`. The int accessor accepts unquoted integers, quoted scalars, and front-matter inlines; it deliberately rejects `Yaml::Real` (a float where an int option is expected keeps the default, matching config parsing's silent-drop posture). The float accessor additionally accepts `Yaml::Real` — previously handled by no accessor at all.
2. **`1b1bb54fd` — broken sites**: listing `page-size`, `max-items`, `grid-columns`, `feed: items:` (via `parse_u32_scalar`, reimplemented over the accessor); revealjs `int_opt`/`float_opt` (fixes unquoted `margin: 0.2` silently defaulting to 0.1); pampa `toc.rs` `level` consolidated (was already robust).
3. **`544ba2321` — bare-`as_int` sites** (quoted-number miss): `order:`, `reading-time-minutes`/`word-count`, `slide-level:` (read extracted into testable `slide_level_from_meta`), extension claim `priority`. Excluded with rationale: `template.rs` `config_value_to_template_value` — its `as_int()` is a type-dispatch arm, not an option read.

Follow-up lint (ban new `as_plain_text().parse()` numeric chains) is filed as bd-clqzz2rl.

## Verification

- TDD: 9 bug-regression tests verified failing before each fix; quoted/unquoted guard tests pin the previously-working forms.
- Full workspace suite green; full `cargo xtask verify` (Rust + WASM + hub-client legs) all passed; zero `.snap` changes; clippy/fmt clean.
- E2E through `cargo run --bin q2 -- render`: unquoted `grid-columns: 4` renders `quarto-listing-cols-4` (was silently 3); `margin: 0.2` lands as `"margin": 0.2` in the reveal deck config (was silently 0.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)