### PR TITLE
Align the source editor with the clicked block in both previews

### DIFF
--- a/claude-notes/plans/2026-08-21-preview-click-to-editor-scroll.md
+++ b/claude-notes/plans/2026-08-21-preview-click-to-editor-scroll.md
@@ -1,0 +1,426 @@
+# q2-preview: clicking a block to edit does not scroll the source editor
+
+## Overview
+
+**Symptom (reported).** In the HTML preview, clicking in the preview scrolls the
+Monaco source editor to the corresponding position. In **q2-preview**, clicking a
+block to edit it does nothing to the editor. Editor→preview sync (cursor moves
+scroll the preview) works in both.
+
+**Root cause (confirmed).** Two independent facts compose into the bug:
+
+1. `Q2PreviewIframe` listens for **`click`** on the iframe document to drive
+   preview→editor sync (`ts-packages/preview-renderer/src/iframe/Q2PreviewIframe.tsx`,
+   the `doc.addEventListener('click', handleClick)` in the `iframeReady` effect),
+   the same event the HTML preview's `MorphIframe` uses.
+2. q2-preview activates block editing on **`pointerup`** (`useBlockEditHover.tsx`,
+   `onPointerUp` → `activate(el, {clickCoords})`), and activation **replaces the
+   clicked element's subtree** with a synthetic edit region
+   (`dispatchers.tsx::renderMeasuredEdit` → `<div id="q2-active-edit-region">`
+   + textarea/tiptap). The clicked node is detached during `pointerup`.
+
+Chromium does not dispatch a `click` event at all when the `pointerup` target has
+been removed from the document during `pointerup`. Verified with a minimal
+Chromium probe (host `<p>` replaced in a bubble-phase `pointerup` handler):
+
+```
+--- after clicking the REPLACED element:
+    pointerup, target=target                      # no `document click` line
+--- after clicking the INERT element:
+    pointerup, target=inert
+    document click, target=inert connected=true
+```
+
+So `onClick` → `handlePreviewClick` → `syncPreviewToEditor` never runs for the
+one gesture that matters in q2-preview: clicking a block to edit it. The HTML
+preview never mutates its DOM on click, so its `click` listener always fires.
+
+**Reproduced in the real app** (2026-08-21) by
+`hub-client/e2e/q2-preview-click-to-editor-scroll.spec.ts`, run against a live
+hub + real Chromium:
+
+```
+T1 — clicking a block to edit delivers no click event to the q2-preview document   FAILED
+     afterActivation === []   (in-region control click DID reach the document)
+T2 — clicking a block does not scroll the editor to that block line                FAILED
+     clicked `Paragraph 35.` (source line 73 of 78); editor still showed 2..19
+T3 — control: the same click DOES reach the HTML preview document                  PASSED
+  2 failed, 1 passed
+```
+
+### What the HTML preview actually does (corrects an earlier reading)
+
+The HTML preview's *precision* does **not** come from the click→ratio path. It
+comes from **`useSelectionSync`** (`hub-client/src/hooks/useSelectionSync.ts`:
+`setSelection` + `revealRangeInCenter` + `focus()`), driven by a
+**`selectionchange`** listener in `MorphIframe` that reads per-inline
+`<span data-loc>` emitted by the native HTML writer. Measured in a real browser:
+
+```
+clicked `Paragraph 35.` (source line 73 of 78) in the HTML preview
+  preview scroll ratio ...... 0.17          ← what ratio matching would use
+  iframe events ............. ["click", "selectionchange"]
+  editor moved to ........... lines ~45..77 (contains line 73)
+  document.activeElement .... native-edit-context   ← Monaco took focus
+  clicked DOM ............... <p data-loc="0:73:1-74:1">
+                                <span data-loc="0:73:1-73:10">Paragraph</span> …
+```
+
+An editor at ratio 0.17 would be near line 13. It went to line 73. So the
+mechanism that makes the HTML preview feel right is loc-based selection sync;
+the click→ratio path contributes nothing precise. `Q2PreviewIframe` has **no**
+`onSelectionChange` at all, and q2-preview stamps `data-loc` on **blocks only**
+(bd-9kzfi scoped out inline granularity), so selection sync cannot be reused
+as-is — see the decisions below.
+
+**Why the test suite is green.** `useScrollSync.test.ts` covers only
+editor→preview (7 tests, all `scrollPreviewToLine`); no test exercises
+preview→editor click sync on either path. The jsdom tier *cannot* catch this
+class of bug — a jsdom test dispatches `click` directly and so never reproduces
+the browser's suppression of a click whose target was detached. Real-browser
+tier is mandatory here. The originating plan
+(`claude-notes/plans/2026-05-29-q2-preview-scroll-sync.md`, bd-9kzfi) explicitly
+recorded "**NOT verified:** live browser scroll interaction".
+
+## Decisions (settled 2026-08-21 — these bind the frozen rows below)
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| D1 | **Scroll only.** `revealLineInCenterIfOutsideViewport(line)`. No `setPosition`, no `setSelection`, no `focus()`. | In q2-preview the click *opens an inline editor in the preview*. Pulling focus to Monaco (what `useSelectionSync` does for the HTML preview) would break the gesture the same click just started. Deliberate divergence from the HTML preview. |
+| D2 | **New capture-phase `pointerup` path**, not an extension of `useSelectionSync`. | Works with the block-level `data-loc` q2-preview already stamps. Extending selection sync would require per-inline `<span data-loc>` in q2-preview, reopening the wrapper/theme-CSS parity decision bd-9kzfi deliberately closed. |
+| D3 | **HTML preview untouched.** Its click→ratio path stays, redundant but harmless. | It is the behaviour reported as working; changing it risks the one preview that currently syncs. Recorded as a finding, not a work item. |
+| D4 | **A click that does not resolve an editable block does nothing.** No reveal when the target is inside `#q2-active-edit-region`, when the nearest `[data-loc]` ancestor is a `<section>`, or when nothing resolves. | Without this, every caret-move click inside an open editor yanks Monaco to the enclosing section's heading — see the hazard below. Mirrors the existing active-region guard in `useBlockEditHover`'s `onPointerUp`. |
+| D5 | **Clicking included content scrolls to the `{{< include … >}}` shortcode's line in the current file.** Not a bogus current-file line; not a file switch. | Keeps the editor showing the file the user is editing, and points at the thing that *is* editable there. Feasibility + sequencing: see Phase 4. |
+
+### The section hazard behind D4
+
+`closest('[data-loc]')` does **not** return "nothing" inside an open editor.
+`renderMeasuredEdit` nests the edit region inside `AttributionWrap` (which emits
+no `data-loc`), but the enclosing **`<section>` does** carry one:
+`q2-preview/blocks/Div.tsx` spreads `dataLocProps` onto section Divs, and
+`SectionizeTransform` is unconditional for non-reveal formats
+(`crates/quarto-core/src/pipeline.rs`, the `else` branch that pushes
+`TitleBlockTransform` + `SectionizeTransform`). So in any document **with a
+heading**, a click inside the open textarea — or on inter-block whitespace —
+resolves the section's `startLine` and would scroll Monaco to the heading.
+
+The current E2 fixture has **no headings**, so it cannot see this. Fixing that
+is a work item (Phase 1: add a heading to the fixture, add E4).
+
+## Design
+
+Switch preview→editor **click** sync from "`click` + ratio" to
+"**capture-phase `pointerup`** + `data-loc`".
+
+**Why capture phase:** it runs before the app's bubble-phase activation handler,
+so the clicked element is still attached and its nearest `[data-loc]` ancestor is
+resolvable. Verified in the same Chromium probe:
+`CAPTURE pointerup: target=target connected=true data-loc=0:12:1-14:20`
+followed by `BUBBLE pointerup (app activate): replacing node`.
+
+**Why `pointerup` and not `pointerdown`:** `pointerup` is where a drag-select
+*ends*, so the reveal follows the user's final position rather than firing at the
+start of a drag; and it is the same event the app activates on, so the reveal
+coincides exactly with the editor opening. (An earlier draft justified this by
+`syncPreviewToEditor`'s focus gate — that reason does not survive D1's
+"not focus-gated", and a capture-phase `pointerdown` is equally before-detach.)
+
+**Why not focus-gated:** an explicit click in the preview is unambiguous user
+intent. The focus gate exists to break *scroll* feedback loops; this path is not
+one.
+
+**Why no cursor move:** `setPosition` fires `onDidChangeCursorPosition`, which
+feeds editor→preview sync and would bounce.
+
+### Pinned API (frozen — U1/U2/U3 assert against these exact names)
+
+```ts
+// ts-packages/preview-renderer/src/iframe/scrollSyncDom.ts   (new export)
+/**
+ * The editor line a preview click should reveal, or null when the click should
+ * be ignored. Named for the click path, not as a generic DOM helper, because
+ * the ignore rules (D4) are part of its contract.
+ */
+export function lineForClickTarget(target: EventTarget | null): number | null;
+//   null  — target is not an Element
+//   null  — target is inside #q2-active-edit-region
+//   null  — nearest [data-loc] ancestor is a <section>
+//   null  — no [data-loc] ancestor
+//   else  — startLine of the nearest [data-loc] ancestor (innermost wins)
+
+// ts-packages/preview-renderer/src/iframe/Q2PreviewIframe.tsx   (prop change)
+/** Called on a preview click that resolves to a block, with its start line. */
+onClickAtLine?: (line: number) => void;   // replaces `onClick`; only fires with a number
+// listener: doc.addEventListener('pointerup', handler, /* capture */ true)
+
+// hub-client/src/hooks/useScrollSync.ts   (new returned callback)
+/** Reveal `line` in the editor. No debounce, not focus-gated, no cursor move. */
+revealEditorLine: (line: number) => void;
+
+// ts-packages/preview-renderer/.../ReactRenderer.tsx  +  hub-client/.../ReactPreview.tsx
+onPreviewClickAtLine?: (line: number) => void;   // replaces `onPreviewClick` on the q2 branch
+```
+
+`handlePreviewClick` (ratio) stays in `useScrollSync` — the HTML preview still
+uses it (D3). q2-preview stops wiring it.
+
+### Deferred refinement — line *within* the block
+
+When the active surface is the **plain textarea** (not tiptap), the caret offset
+within the draft gives a line offset inside the block: editor line ≈
+`blockStartLine + linesBefore(caretOffset)`. This needs data only the iframe app
+has, so it rides a new `EDIT_CARET`-style postMessage rather than the
+parent-side DOM listener. Deliberately deferred — the primary ask is "scroll to
+a line that's in the element being edited".
+
+## Test Seam Spec (frozen — prevalidating-test-seams)
+
+One row per test: tier · real unit mounted · seam (mount + events + assertion
+surface) · mock boundary · the named production hunk whose revert reddens it.
+Once a row goes green its assertions and harness are **frozen** — never edited
+to go green. (Sole exception: E1's polarity flip, below.)
+
+### Tier note — which vitest project a row lands in
+
+Both packages run `*.test.ts` in the **node** environment
+(`ts-packages/preview-renderer/vitest.config.ts`,
+`hub-client/vitest.config.ts`) and `*.integration.test.ts` in **jsdom**
+(the `vitest.integration.config.ts` in each). A DOM-fixture test in a
+`*.test.ts` has no `document`. Two escapes: put it in
+`*.integration.test.ts`, or add a `@vitest-environment jsdom` docblock pragma
+(which is what `hub-client/src/hooks/useScrollSync.test.ts` already does).
+
+| # | Tier | Real unit mounted | Seam: mount + events + assertion surface | Mock boundary | Revert → RED |
+|---|------|-------------------|------------------------------------------|---------------|--------------|
+| **U1a** | jsdom (`scrollSyncDom.integration.test.ts` — existing file, jsdom config) | real `lineForClickTarget` | `<section data-loc="0:5:1-30:1"><p data-loc="0:12:1-14:20"><em id="t">x</em></p></section>`; call with `#t` | none (pure DOM) | Swap `el.closest('[data-loc]')` for a document-wide `querySelector('[data-loc]')` → returns 5 instead of **12** → RED |
+| **U1b** | ↑ | ↑ | Element with no `[data-loc]` ancestor → `null` | ↑ | Add any "nearest located block in the document" fallback → RED |
+| **U1c** | ↑ | ↑ | Target inside `<div id="q2-active-edit-region">` **nested in a located `<section>`** → `null` | ↑ | Delete the active-region guard → resolves the section's 5 → RED. **This is the D4 hazard row** |
+| **U1d** | ↑ | ↑ | Target whose nearest `[data-loc]` is the `<section>` itself (inter-block whitespace) → `null` | ↑ | Delete the `<section>` check → RED |
+| **U1e** | ↑ | ↑ | `lineForClickTarget(document)` and `(null)` → `null`, no throw | ↑ | Drop the `instanceof Element` narrowing → throws → RED |
+| **U2a** | jsdom (`useScrollSync.test.ts`, `@vitest-environment jsdom` already present) | real `useScrollSync` | `renderHook`; `result.current.revealEditorLine(73)`; assert `revealLineInCenterIfOutsideViewport` called with **`73`** | Monaco fake (`makeEditor`) — **must be extended**, see below | Remove the reveal call → RED |
+| **U2b** | ↑ | ↑ | `setPosition`, `setSelection`, `focus` **never** called | ↑ | Add `setPosition`/`focus` to the reveal path (i.e. copy `useSelectionSync`'s semantics) → RED. Guards D1 |
+| **U2c** | ↑ | ↑ | **Harness must be `setup({focus: true})`**; reveal still happens | ↑ | Route `revealEditorLine` through `syncPreviewToEditor` (whose first statement is the focus gate) → RED |
+| **U2d** | ↑ | ↑ | No debounce: reveal happens **without** advancing timers | ↑ | Wrap the reveal in the 50 ms `editorDebounceRef` timer → RED |
+| **U3** | jsdom (`Q2PreviewIframe.integration.test.tsx`) | real `Q2PreviewIframe` | **New harness variant needed** — the existing `renderWithFingerprint` dispatches `IFRAME_READY` internally and exposes no handle on the iframe element. Need: render → wrap `iframe.contentDocument.addEventListener` with a spy → dispatch `IFRAME_READY`. Assert the registration tuple is `('pointerup', fn, true)`, then dispatch a `pointerup` on an injected `[data-loc]` node and assert `onClickAtLine` got `12` | iframe `contentWindow.postMessage` (already faked here) | Restore `doc.addEventListener('click', handleClick)`, or drop the `true` capture arg → RED |
+| **U4** | jsdom (`useScrollSync.test.ts`) | real `useScrollSync` | `handlePreviewScroll()`; advance 50 ms; assert `setScrollTop` called with **`(300, 1)`** — ratio `0.5 × (1000 − 400)`; and with `setup({focus: true})` it is **not** called | Monaco fake | Delete the ratio body of `syncPreviewToEditor` → RED. **Missing-test-pass addition** — nothing covers preview-scroll→editor today, so this refactor could kill it silently |
+| **E1** | Playwright (`q2-preview-click-to-editor-scroll.spec.ts` T1) | whole app | **Environment characterization, no production hunk** — see the exception note | none (real browser) | *(declared exception)* |
+| **E2** | Playwright (same spec, T2) | whole app | Live hub + real Chromium; click `Paragraph 35.`; assert Monaco's rendered lines contain it. **Plus** (missing-test pass): the preview's `scrollY` is unchanged ±4px afterwards, so a reveal→cursor→scroll feedback loop reddens it | none | Any of: back to a `click` listener; drop the capture arg; route `onClickAtLine` into `syncPreviewToEditor` (ratio) instead of `revealEditorLine`; drop the `onPreviewClickAtLine` threading in `ReactRenderer`/`ReactPreview` → RED |
+| **E3** | Playwright (same spec, T3) | whole app | HTML-preview control: the same click **does** reach the iframe document | none | *(control — no hunk; fails only if the harness itself breaks)* |
+| **E4** | Playwright (same spec, **new**) | whole app | **Requires a heading in the fixture** (see D4 hazard). Click a paragraph to open its editor, then click *inside the textarea*; assert the editor's visible lines did not move | none | Delete the active-region guard from `lineForClickTarget` → the section's heading line is revealed → RED. Browser-tier because only a real activation detaches the block |
+
+### Harness extensions required before these rows can be written
+
+- `makeEditor` (`useScrollSync.test.ts`) has no `revealLineInCenterIfOutsideViewport`,
+  `setPosition`, `setSelection` or `focus`, and `setup()` returns neither the
+  editor nor its `setScrollTop` spy. U2a/U2b/U4 need all of that exposed. Extend
+  the shared helper; do not fork it.
+- Production calls `editor.setScrollTop(editorScrollTop, 1)`, so U4 must assert
+  `(300, 1)` — a bare `toHaveBeenCalledWith(300)` fails on arity.
+- U3 needs the new `Q2PreviewIframe` harness variant described in its row.
+
+### Vacuity checks performed
+
+- **E2 cannot be satisfied by ratio matching.** The fixture's trailing 6000px
+  spacer puts the click target at preview scroll ratio < 0.25 while its source
+  line is at > 0.9 of the document, and *both* are asserted as preconditions
+  before the click. So E2 discriminates "loc-based reveal" from "the only
+  mechanism that exists today", not merely "the editor moved". Verified RED with
+  both preconditions passing.
+- **Monaco renders spaces as ` `** (`hasNbsp: true`, measured). Before the
+  fix, `innerText.includes('Paragraph 35.')` was `false` even with that line
+  visibly on screen — which made E2's assertion unsatisfiable *and* its
+  `not.toContain(...)` precondition vacuously true. `editorVisibleText` now
+  normalises ` ` → space. Any new assertion on Monaco's rendered text must
+  go through that helper.
+- **U2c would be vacuous with the harness default.** `setup()` takes `focus` as
+  a parameter; U2c is only meaningful with `focus: true`. Written into the row so
+  the executor cannot pick the convenient default.
+- **U3 cannot discriminate capture from bubble on its own.** jsdom computes the
+  event path at dispatch and keeps propagating even if a listener detaches the
+  target, so a *bubble*-phase `pointerup` listener passes U3's behavioural half
+  just as well — i.e. the broken variant survives. That is why U3's binding
+  assertion is the **registration tuple**, and why E1/E2/E4 are not optional.
+  Recorded so nobody later "simplifies" U3 by deleting the tuple assertion.
+- **U1's discriminators are exact line numbers**, not `!= null`. An
+  implementation returning the outermost `[data-loc]` (5) fails U1a; one without
+  the guards fails U1c/U1d with the section's 5.
+
+### Declared exception (check #1)
+
+**E1 has no production revert hunk.** It asserts a *browser* fact — Chromium
+delivers no `click` when the `pointerup` target was detached during `pointerup`,
+while a capture-phase `pointerup` listener on the same document still sees the
+node attached with a parseable `data-loc`. Its job is to keep the design
+rationale executable: if a future Chromium changes this, E1 goes RED and tells
+us the `click` listener would have worked after all. Production binding for the
+same behaviour is E2's job. Logged rather than faked.
+
+**E1's polarity flips when the fix lands.** As shipped today it is written as the
+*repro* (`expect(afterActivation).not.toEqual([])` — RED, proving the click never
+arrives). At implementation time it must be rewritten to the characterization
+form (`expect(afterActivation).toEqual([])` plus "a capture-phase `pointerup`
+listener on the same document sees the target attached with a parseable
+`data-loc`"). This is the one row exempt from "frozen once green", and the flip
+is a Phase 2 checklist item — not a later cleanup, and not a deletion of E1.
+
+### Missing-test pass (check #3)
+
+| Gap | Disposition |
+|-----|-------------|
+| preview **scroll** → editor (ratio) has no test at all today; this refactor touches `syncPreviewToEditor`'s neighbourhood | **Specced as U4** (exact `(300, 1)`, plus the focus gate) |
+| Caret-move click inside the open editor must not move the editor (the D4 section hazard) | **Specced as U1c (unit) + E4 (browser)**; E4 needs a heading added to the fixture |
+| Inter-block whitespace / section-background clicks | **Specced as U1d** |
+| Reveal must not start a feedback loop (reveal → cursor event → editor→preview scroll) | **Specced as the E2 addition** (preview `scrollY` unchanged ±4px) |
+| Non-Element event targets (`document`, `null`) | **Specced as U1e** |
+| Every other pointerup in the iframe also reaches the capture listener — `EditToolbar` buttons, links, comment UI, breadcrumb crumbs | **Covered by construction, not by a row:** those all sit inside either the active edit region (U1c) or a located block whose line is the right answer anyway. **Accepted-untested** for the toolbar/comment chrome specifically; revisit if a stray reveal shows up in the live pass |
+| Keyboard activation (roving Enter/Space) and touch hold-to-edit produce no `pointerup`, so they get no reveal | **Accepted-untested, and a known behaviour gap of this design.** Covering it needs the deferred `EDIT_CARET`-style postMessage (which the iframe app must originate). Not silently omitted — if we want it now, the design changes from a parent-side DOM listener to a message |
+| `format: revealjs` also routes through `Q2PreviewIframe` (`ReactRenderer`'s `format === 'q2-preview' \|\| 'revealjs'` branch), so clicking a slide will now reveal lines | **Accepted-untested.** Decks have their own cursor↔slide sync (`SET_SLIDE`/`SLIDE_CHANGED`); a line reveal is additive. Flagged for follow-up if it fights slide navigation |
+| Included-file content (foreign `fileId`) | **Phase 4** — inert in Phase 2, then D5. Rows specced there |
+
+## Running these tests (fresh worktree)
+
+Not obvious, and all of it is required before the Playwright rows can run:
+
+```bash
+npm install                                   # from the WORKTREE root, never hub-client/
+for p in ts-packages/*/; do npm run build --if-present -w "$p"; done
+                                              # e2e helpers import @quarto/quarto-sync-client/dist
+cd hub-client && npm run build:wasm           # or copy crates/wasm-quarto-hub-client/pkg/* from
+                                              # a warm checkout when no Rust changed
+VITE_E2E=1 npm run build                      # without this, window.__quartoTest is tree-shaken
+cd .. && cargo build --bin hub                # globalSetup's `cargo run --bin hub` has a 120s
+                                              # deadline; a cold compile blows it
+```
+
+Ports 3031 (test hub) and 5174 (`vite preview`) must be free. Then:
+
+```bash
+cd hub-client
+npx playwright test e2e/q2-preview-click-to-editor-scroll.spec.ts \
+  --project=chromium --workers=1 --retries=0 --reporter=line
+```
+
+`npm install` in a worktree prunes other-platform optional deps from
+`package-lock.json` — **revert that file**, never commit it.
+
+## Work Items
+
+### Phase 1 — tests first (RED). Rows refer to the Test Seam Spec above.
+- [x] **E1/E2/E3** — spec written and run: E1 RED, E2 RED (preconditions green), E3 GREEN.
+- [x] **E2 assertion surface** — normalise Monaco's ` `; re-run confirms E2 still RED with both preconditions meaningful.
+- [x] **Fixture** — heading `# Section one` added, so `SectionizeTransform` produces a `<section>` and the D4 hazard is reachable. `paraLine(n)` is now `5 + 2n`, `totalLines` 80, and E2's `> 0.9` precondition re-verified numerically as 75/80 = 0.9375 (threshold unchanged). The stale "2500px / ratio 0.9" header comment turned out to have been fixed already in 650f6569a — nothing to do there.
+- [x] **E2 addition** — preview `scrollY` unchanged ±4px after the click (`previewScrollY` helper, sibling to `previewScrollRatio`).
+- [x] **E4** — caret-move click inside the open editor does not move the editor (spec T4). Green today by construction (nothing reveals yet); binding is post-fix via revert (c). Review confirmed the textarea is a DOM child of `#q2-active-edit-region` (`dispatchers.tsx:88`), so the row is not decorative.
+- [x] **U1a–U1e** — `lineForClickTarget`, in the **integration** (jsdom) file. U1b initially had *no* `[data-loc]` anywhere in its fixture, so a document-wide-fallback implementation would also have returned `null` — caught in review and fixed with a non-ancestor decoy.
+- [x] **U2a–U2d** — `revealEditorLine` semantics; `makeEditor`/`setup` extended in place with `revealLineInCenterIfOutsideViewport`/`setPosition`/`setSelection`/`focus` spies and an `editor` handle.
+- [x] **U3** — registration tuple `('pointerup', fn, true)` + forwarded line. Harness refactored into shared `mountIframe()` + `dispatchIframeReady()` so the new spy variant is not a fork of `renderWithFingerprint`.
+- [x] **U4** — preview-scroll→editor ratio regression cover, `setScrollTop(300, 1)` and the focus-gated negative. Green from the start (covers existing behaviour).
+
+### Phase 2 — implement (items 1–3 are one compile unit; land them together)
+- [x] `scrollSyncDom.ts`: add `lineForClickTarget` (with the D4 guards). **The Pinned API's `instanceof Element` narrowing was wrong** and would have shipped the feature dead — see the cross-realm note below. Ships duck-typed instead.
+- [x] Thread `onPreviewClickAtLine` through `ReactRenderer` → `ReactPreview`
+      **first** — swapping the listener before the prop exists leaves `tsc -b` red.
+- [x] `Q2PreviewIframe.tsx`: replace `doc.addEventListener('click', …)` with the
+      capture-phase `pointerup` listener; keep `onScroll` (window scroll → ratio) unchanged.
+- [x] `useScrollSync.ts`: add `revealEditorLine`; keep `handlePreviewClick` for the HTML preview.
+- [x] **Flip E1's polarity** in the same commit (see the declared exception).
+
+### The cross-realm defect in this plan's own Pinned API (found 2026-08-21)
+
+The Pinned API above specified `lineForClickTarget` narrowing its argument with
+`target instanceof Element`. **That is wrong in production and would have shipped
+this feature completely dead**, with every jsdom row green.
+
+`lineForClickTarget` is called from the listener registered by `Q2PreviewIframe`,
+which lives in the **parent frame's** JS realm, on a `pointerup` whose target is a
+node from the **sandboxed iframe's** realm. Each realm has its own `Element`
+constructor, so the parent's `instanceof Element` is `false` for every real
+click — including a perfectly ordinary `<p>`. Measured in jsdom:
+
+```
+target is a real element  : EM
+iframe-realm instanceof   : true
+PARENT-realm instanceof   : false      <- what production evaluates
+duck-typed closest        : true
+closest([data-loc]) start : 0:12:1-14:20
+```
+
+Shipped narrowing is therefore duck-typed — `typeof target.closest === 'function'`
+— which is realm-agnostic and still excludes `Document` and `Window` (neither has
+`closest`). **Do not "tidy" it back to `instanceof Element`.**
+
+Only the real-browser row (E2) caught this; all thirteen jsdom rows passed against
+the broken guard. That is the plan's own "real-browser tier is mandatory here"
+argument arriving in a form nobody predicted — and it is why **U1f** was added:
+it reproduces the cross-realm case at the jsdom tier (a genuine iframe
+`contentDocument`, not the main test document), so a revert to `instanceof
+Element` now reddens a fast test instead of only Playwright. Verified both
+directions: reverting the guard reddens *only* U1f; deleting the guard outright
+still reddens U1e.
+
+Related: **U3's assertion 2 could never have run as originally written.** It did
+`doc.body.innerHTML = …` on a src-ful iframe, whose `contentDocument.body` is
+`null` in jsdom (`readyState` stays `'loading'`). The row previously failed at
+assertion 1 first, so the setup bug was latent. Fixed by injecting the fixture via
+`open()/write()/close()` — the pattern `iframePostProcessor.integration.test.ts`
+already used in that package — **before** the listener spy is installed, since
+per spec `document.open()` wipes document listeners (jsdom merely happens not to
+implement that). Assertions unchanged.
+
+### Phase 3 — verify
+- [ ] `npm run test` + `npm run test:integration` in **both** `ts-packages/preview-renderer` and `hub-client`.
+- [ ] `npm run typecheck:tests` (preview-renderer) — `cargo xtask verify` runs it *before* the unit tests, so a harness typing slip fails there first.
+- [ ] `cd hub-client && npm run build:all` (production `tsc -b` is stricter). Full `cargo xtask verify` is **not** required — this change is TypeScript-only.
+- [ ] Playwright spec green.
+- [ ] Fail-on-revert, executed not just documented: (a) capture arg `true` → `false` reddens U3+E2; (b) `revealEditorLine` → `syncPreviewToEditor` reddens U2c+E2; (c) delete the active-region guard reddens U1c+E4.
+- [ ] Live browser session: click blocks top/middle/bottom, click inside an open editor, confirm no oscillation with editor→preview sync.
+- [ ] `hub-client/changelog.md` entry (two-commit workflow).
+
+### Phase 1 execution notes (2026-08-21)
+
+Two plan corrections found while executing, recorded here rather than left to
+bite a later reader:
+
+- The Pinned API block above places `ReactRenderer.tsx` under
+  `ts-packages/preview-renderer/`. It is actually
+  `hub-client/src/components/render/ReactRenderer.tsx` (its `onPreviewClick`
+  prop is declared ~line 138 and forwarded as `onClick={onPreviewClick}`
+  ~line 337). Prop *names* in that block are correct and frozen; only the
+  path was wrong.
+- **Phase 4 is investigation-only in this pass.** Its producer-side option is a
+  Rust + wire change, which would invalidate Phase 3's explicit "TypeScript-only,
+  `cargo xtask verify` not required" contract and turn a bugfix branch into a
+  wire change. Phase 2 already leaves foreign-`fileId` clicks inert, so nothing
+  is blocked; D5's implementation becomes a follow-up.
+
+Out-of-plan defect found and filed separately (**braid bd-s36g9dav**): in this
+worktree `ts-packages/preview-renderer`'s
+`custom-components.integration.test.tsx > Equation > appends \tag{N}` fails.
+It is not a regression from this branch — root + sandboxed-preview `package.json`
+and the lockfile all pin katex exactly **0.18.1**, under which KaTeX no longer
+emits the `.tag` element the test queries. The main checkout only appears green
+because its `node_modules` is stale at 0.17.0. The pin arrived via Snyk PR #571
+(`669ad7534`), which did not update the assertion. Treat that row as an expected
+baseline failure while working in a correctly-installed tree.
+
+### Phase 4 — included content (D5), sequenced after Phase 2
+Phase 2 leaves foreign-`fileId` clicks **inert** (no reveal), so the primary fix
+is not blocked. Then:
+- [ ] **Investigate** whether the include splice point is recoverable. What is
+      known: the JSON wire already carries `astContext.files[]`
+      (`fileId` → `name`) and the `p` source-info pool
+      (`crates/pampa/src/writers/json.rs`); `include_expansion.rs` splices with
+      `blocks.splice(i..i+1, children)` after `remap_file_ids`, so included
+      blocks carry the *included* file's spans and **nothing retains the
+      shortcode's own span** in the parent. So either (a) stamp the splice point
+      producer-side (Rust + wire change), or (b) client-side: `files[f].name` →
+      locate the matching `{{< include … >}}` line in the current source.
+- [ ] Decide (a) vs (b) once the investigation lands. (b) is heuristic — a file
+      included twice is ambiguous, and a *nested* include is not referenced from
+      the current file at all. Those cases need a stated fallback (inert).
+- [ ] Rows: `U1f` (foreign `fileId` → not the raw line), plus a browser row for
+      the shortcode reveal. Neither can be pinned before the decision above.
+
+## Housekeeping
+- [x] Point `claude-notes/plans/CURRENT.md` at this plan.
+- [x] Replace the `**Plan:**` placeholder in `CLAUDE.local.md`.

--- a/claude-notes/plans/2026-08-21-preview-click-to-editor-scroll.md
+++ b/claude-notes/plans/2026-08-21-preview-click-to-editor-scroll.md
@@ -275,7 +275,7 @@ is a Phase 2 checklist item — not a later cleanup, and not a deletion of E1.
 | Every other pointerup in the iframe also reaches the capture listener — `EditToolbar` buttons, links, comment UI, breadcrumb crumbs | **Covered by construction, not by a row:** those all sit inside either the active edit region (U1c) or a located block whose line is the right answer anyway. **Accepted-untested** for the toolbar/comment chrome specifically; revisit if a stray reveal shows up in the live pass |
 | Keyboard activation (roving Enter/Space) and touch hold-to-edit produce no `pointerup`, so they get no reveal | **Accepted-untested, and a known behaviour gap of this design.** Covering it needs the deferred `EDIT_CARET`-style postMessage (which the iframe app must originate). Not silently omitted — if we want it now, the design changes from a parent-side DOM listener to a message |
 | `format: revealjs` also routes through `Q2PreviewIframe` (`ReactRenderer`'s `format === 'q2-preview' \|\| 'revealjs'` branch), so clicking a slide will now reveal lines | **Accepted-untested.** Decks have their own cursor↔slide sync (`SET_SLIDE`/`SLIDE_CHANGED`); a line reveal is additive. Flagged for follow-up if it fights slide navigation |
-| Included-file content (foreign `fileId`) | **Phase 4** — inert in Phase 2, then D5. Rows specced there |
+| Included-file content (foreign `fileId`) | **Phase 4 investigation (2026-08-21) found this is NOT inert in Phase 2 as shipped — see the task-7 report** (`.superpowers/sdd/2026-08-21-preview-click-to-editor-scroll/task-7-report.md` §0): it reveals a wrong line. Bugfix (`U1f`/`U1g`) and the D5 enhancement (`U5a`–`c`/`E5`) are specced in Phase 4, follow-up implementation |
 
 ## Running these tests (fresh worktree)
 
@@ -368,13 +368,19 @@ per spec `document.open()` wipes document listeners (jsdom merely happens not to
 implement that). Assertions unchanged.
 
 ### Phase 3 — verify
-- [ ] `npm run test` + `npm run test:integration` in **both** `ts-packages/preview-renderer` and `hub-client`.
-- [ ] `npm run typecheck:tests` (preview-renderer) — `cargo xtask verify` runs it *before* the unit tests, so a harness typing slip fails there first.
-- [ ] `cd hub-client && npm run build:all` (production `tsc -b` is stricter). Full `cargo xtask verify` is **not** required — this change is TypeScript-only.
-- [ ] Playwright spec green.
-- [ ] Fail-on-revert, executed not just documented: (a) capture arg `true` → `false` reddens U3+E2; (b) `revealEditorLine` → `syncPreviewToEditor` reddens U2c+E2; (c) delete the active-region guard reddens U1c+E4.
-- [ ] Live browser session: click blocks top/middle/bottom, click inside an open editor, confirm no oscillation with editor→preview sync.
-- [ ] `hub-client/changelog.md` entry (two-commit workflow).
+- [x] `npm run test` + `npm run test:integration` in **both** `ts-packages/preview-renderer` and `hub-client`. (preview-renderer 549 unit / 587 integration; hub-client 986 / 112. One **pre-existing, unrelated** integration failure: `custom-components` `Equation > appends \tag{N}` under the pinned katex 0.18.1 — braid **bd-s36g9dav**, fails identically before and after every change here.)
+- [x] `npm run typecheck:tests` (preview-renderer) — clean.
+- [x] `cd hub-client && npm run build:all` — succeeded (chunk-size warnings only). Full `cargo xtask verify` was **not** required; the change stayed TypeScript-only as planned.
+- [x] Playwright spec green — **5/5** (T1 characterization, T2 reveal, T3 HTML control, T4 D4 guard, T5 no-overwrite).
+- [x] Fail-on-revert, **executed** not just documented — and it found two rows that were not bound. Six hunks (the plan anticipated three; (d)-(f) came from defects found during execution), each reverted individually and restored with `git checkout --`:
+  - (a) capture arg `true` → `false` — U3 reddened. **Playwright T2 did NOT redden** (reproduced twice). See correction 1 below: the plan's claim that dropping the capture argument reddens E2 is false.
+  - (b) `revealEditorLine` → `syncPreviewToEditor` — U2c + T2 reddened. Bound.
+  - (c) delete the active-region guard — **neither U1c nor T4 reddened** (reproduced twice). Both rows were vacuous; both fixed, and each is now proven to redden in both directions.
+  - (d) duck-typed guard → `instanceof Element` — U1f reddened, and *only* U1f among the 17 jsdom rows, which is exactly why U1f exists.
+  - (e) remove the `isSyncingRef` bracketing — U2e + T5 reddened. Bound.
+  - (f) remove the `fileId !== 0` guard — U1g reddened, and only U1g (U1h, the same-file control, stayed green, proving the guard is not over-broad).
+- [x] Live browser session against a real local-prod hub, on a 292-line multi-element document: top/middle/bottom clicks all revealed the clicked block's line; a caret move inside an open editor left the editor unmoved; preview `scrollY` held constant across click→cursor-move→click (no oscillation). An element-kind sweep of nine block kinds passed 8/9 — **the one failure was a real bug and is fixed below**.
+- [x] `hub-client/changelog.md` entry (two-commit workflow) — `ed6462682` for `6187ea9f5`.
 
 ### Phase 1 execution notes (2026-08-21)
 
@@ -403,23 +409,194 @@ because its `node_modules` is stale at 0.17.0. The pin arrived via Snyk PR #571
 (`669ad7534`), which did not update the assertion. Treat that row as an expected
 baseline failure while working in a correctly-installed tree.
 
+### Corrections to this plan, found by executing it (2026-08-21)
+
+Three of this plan's own stated premises turned out to be false. Each had already
+caused a real defect or a vacuous test, so they are recorded here: a wrong premise
+left in place causes the next one.
+
+**1. "Dropping the capture argument reddens E2." False.** Reverting the capture flag
+reddens U3 but leaves Playwright T2 green (reproduced twice). The app's own
+bubble-phase handler runs first and detaches the clicked node — but a *detached*
+`<p>` still carries its own `data-loc`, and `closest('[data-loc]')` called on a
+detached node finds itself, so the line still resolves. Capture phase remains the
+right choice (it guarantees the target is attached, which matters when the resolved
+*ancestor* rather than the target is what gets replaced), and **U3's
+registration-tuple assertion is the only thing binding it** — do not delete that
+assertion on the theory that the browser tier covers it.
+
+**2. "The enclosing `<section>` carries a `data-loc`." False — and this was the whole
+stated basis for D4.** The spread *is* unconditional, but its input never exists:
+
+- `dataLocProps` (`framework/sourceLoc.ts`) returns `{}` for any node with no `l`.
+- `crates/pampa/src/transforms/sectionize.rs` builds section Divs with
+  `SourceInfo::Generated { by: By::sectionize(), from: smallvec![] }`.
+- `quarto-source-map`'s own docs name **"sectionize wrappers"** as the canonical
+  example of pure synthesis with no source-side preimage, and its `map_offset`
+  returns `None` for `Generated` unconditionally.
+- so `resolve_location` never emits an `l` for a section, and **no `<section>` in a
+  rendered q2-preview document ever carries `data-loc`.** Confirmed both from that
+  chain and by dumping a real ancestor chain in the live app
+  (`section#callouts[data-loc=null]`).
+
+Consequence: `lineForClickTarget`'s `<section>` null case is **dead code under
+q2-preview today**, and U1d exercises a situation that cannot currently occur. The
+guard is kept as defence-in-depth — one comparison, and correct if a future change
+ever gives sections a resolvable location — but read the D4 rationale as "the
+enclosing *located wrapper*", not "the section".
+
+The hazard D4 really guards is a block inside a located **non-section** wrapper: a
+fenced div (`Div.tsx` spreads `dataLocProps` on its plain-`<div>` branch too), a
+column, and so on. **Callouts are not such a wrapper** — `Callout.tsx` never spreads
+`dataLocProps` at all. This is why U1c's original fixture was vacuous: it nested the
+edit region directly inside a located `<section>`, so with the active-region guard
+deleted the *separate* section guard returned `null` anyway and the row could not
+tell the two implementations apart. Measured:
+
+```
+edit region inside a located <section>  ->  null   (old fixture: passes with the guard DELETED)
+edit region inside a located <div>      ->  20     (wrong line: discriminates)
+```
+
+A second, independent vacuity hazard surfaced while binding T4:
+`revealLineInCenterIfOutsideViewport` is a **no-op when the target line is already
+visible**, and a wrapper's start line sits only 1-3 lines from its child's — so
+without first scrolling Monaco away, a missing guard's reveal would also no-op and
+T4 would pass either way. T4 therefore scrolls the editor pane (a host-frame action;
+the edit region lives in the sandboxed iframe, so it cannot close it) before the
+final caret click.
+
+**3. "Phase 2 leaves foreign-`fileId` clicks inert." False — they were wrong, not
+inert.** `lineForClickTarget` parsed the `fileId` and never checked it, so clicking
+included content revealed the *included* file's line number as a line in the
+currently-open file: a real, editable, wrong line. Fixed on this branch with a fourth
+null case (`fileId !== 0`), rows U1g/U1h. D5 proper — revealing the
+`{{< include … >}}` shortcode's own line — remains deferred follow-up.
+
+### Two defects the automated suite could not have caught
+
+Both were found by this plan's own mandated live-browser step, and both are the
+argument for keeping it.
+
+**The cross-realm guard** (documented above under Phase 2) — all thirteen jsdom rows
+then existing passed against a guard that returned `null` for every real click.
+
+**The reveal-then-overwrite race.** `revealEditorLine` did not set `isSyncingRef`, and
+by design it never takes focus — so *both* of `syncPreviewToEditor`'s feedback-loop
+guards were unarmed after a reveal, and any real preview scroll within 50 ms
+overwrote the correct reveal with a scroll-ratio-derived position. Measured: Monaco
+correctly at 149-189 (containing the clicked line 171) at t=1 ms; a genuine 6 px
+preview scroll at t=6 ms as the rich-text toolbar mounted and reflowed the page;
+Monaco silently at 174-211 by t=83 ms, with no second `pointerup`. **Not
+callout-specific** — any post-click reflow can do this to any block. Fixed by
+bracketing the reveal with the file's existing `isSyncingRef`/300 ms idiom; bound by
+U2e (which also asserts the suppression is *time-bounded*, so the fix cannot degrade
+into disabling ratio sync outright) and by T5.
+
+T5's binding depends on a post-activation reflow whose mechanism is documented as not
+fully understood, so T5 asserts as an explicit precondition that a preview `scroll`
+event actually fired. **If T5 ever fails with a scroll count of 0, that is the
+fixture precondition breaking, not a product regression** — re-derive the fixture, do
+not delete the row.
+
+### Row inventory as shipped
+
+| Rows | Tier | Binds |
+|---|---|---|
+| U1a, U1b | jsdom | innermost-wins resolution; no located ancestor |
+| U1c | jsdom | the active-region guard (fixture must nest the region in a located **non-section** wrapper) |
+| U1d | jsdom | the `<section>` guard — **synthetic; cannot occur in production today** (correction 2) |
+| U1e | jsdom | non-Element targets don't throw |
+| U1f | jsdom | the **cross-realm** duck-typed narrowing (reverting it reddens only this row) |
+| U1g, U1h | jsdom | foreign `fileId` rejected; same-file control |
+| U2a-U2d | jsdom | reveal is scroll-only, not focus-gated, not debounced |
+| U2e | jsdom | reveal survives a following preview scroll, and suppression is time-bounded |
+| U3 | jsdom | the capture-phase registration tuple — **the only binding for capture** (correction 1) |
+| U4 | jsdom | the pre-existing preview-scroll→editor ratio path |
+| T1 | Chromium | characterization: Chromium delivers no `click` when the `pointerup` target was detached |
+| T2 | Chromium | the real reveal, provably not satisfiable by ratio matching |
+| T3 | Chromium | HTML-preview control (D3: that path is untouched) |
+| T4 | Chromium | the active-region guard in the real app |
+| T5 | Chromium | no reveal-then-overwrite, with a self-check that the reflow really happened |
+
 ### Phase 4 — included content (D5), sequenced after Phase 2
-Phase 2 leaves foreign-`fileId` clicks **inert** (no reveal), so the primary fix
-is not blocked. Then:
-- [ ] **Investigate** whether the include splice point is recoverable. What is
-      known: the JSON wire already carries `astContext.files[]`
-      (`fileId` → `name`) and the `p` source-info pool
-      (`crates/pampa/src/writers/json.rs`); `include_expansion.rs` splices with
-      `blocks.splice(i..i+1, children)` after `remap_file_ids`, so included
-      blocks carry the *included* file's spans and **nothing retains the
-      shortcode's own span** in the parent. So either (a) stamp the splice point
-      producer-side (Rust + wire change), or (b) client-side: `files[f].name` →
-      locate the matching `{{< include … >}}` line in the current source.
-- [ ] Decide (a) vs (b) once the investigation lands. (b) is heuristic — a file
-      included twice is ambiguous, and a *nested* include is not referenced from
-      the current file at all. Those cases need a stated fallback (inert).
-- [ ] Rows: `U1f` (foreign `fileId` → not the raw line), plus a browser row for
-      the shortcode reveal. Neither can be pinned before the decision above.
+
+**Investigation (task-7, 2026-08-21) — finding, decision, and pinned rows.**
+Full writeup: `.superpowers/sdd/2026-08-21-preview-click-to-editor-scroll/task-7-report.md`.
+
+- [x] **§0 — correction to the premise above: today's behaviour is NOT
+      inert, it is wrong.** `lineForClickTarget` parses `fileId` out of
+      `data-loc` (`parseDataLoc`) but never reads it — it returns
+      `loc.startLine` unconditionally, and no caller
+      (`Q2PreviewIframe.tsx`'s `handlePointerUp`, `useScrollSync.ts`'s
+      `revealEditorLine`) checks `fileId` either. A click on included
+      content reveals the included file's own line number *as if it were a
+      line in the currently open file* — a real, editable, but **wrong**
+      line, not "nothing." This is a live defect in code Phase 2 already
+      shipped, independent of D5, and is fixable with a pure TS change (no
+      wire change): reject when `fileId !== 0` (the rendered document is
+      always `FileId(0)` — confirmed via `ParseDocumentStage` always running
+      before `IncludeExpansionStage`, and `IncludeExpansionStage` only
+      allocating fresh ids for spliced-in files). **Flagging prominently per
+      the brief — whether to fix this ahead of / independent of the D5
+      heuristic below is Gordon's call.**
+- [x] **Investigate** whether the include splice point is recoverable.
+      Confirmed via full read of `include_expansion.rs`:
+      `blocks.splice(i..i+1, children)` (line 412) drops the shortcode's own
+      block with no trace; spliced blocks carry only the included file's
+      `Original` `SourceInfo` (remapped `FileId`). Two routes assessed in
+      full in the report:
+      - **(a) producer-side.** The `SourceInfo::Generated{by, from}` +
+        `Anchor{role: Invocation}` machinery already exists and is used
+        elsewhere (revealjs transforms, programmatic config) — `"include"`
+        is even a documented `By` kind already. But it's a *replacement*
+        variant, and spliced nodes must keep their `Original` info (the
+        stage's own heading-id dedup and cache invalidation key off
+        `root_file_id()`). So (a) needs either a new field alongside the
+        existing location or a per-node rewrite pass added to
+        `IncludeExpansionStage` — a real schema change to a *published,
+        externalized* crate (`quarto-source-map`) plus its JSON writer plus
+        the TS hand-mirror. Nested includes need a multi-hop anchor
+        chain-walk on top of that. Out of scope for a TS-only bugfix branch
+        (Phase 3), and not obviously smaller even as its own project.
+      - **(b) client-side.** `files[fileId].name` (the *resolved* path) →
+        scan the current file's source text for a `{{< include … >}}` line
+        whose raw path resolves (mirroring `resolve_include_target`'s
+        leading-`/`-is-project-root rule) to the same name. No wire change;
+        cost is duplicating that one path-resolution rule in TS.
+- [x] **Decision: route (b).** Reasoning (full version in the report §2):
+      Phase 3 already commits this branch to TS-only/no-wire-change for good
+      reason; (a) is a schema-level decision with cross-crate blast radius,
+      not a small patch, and even fully built still needs the same
+      "resolve to the nearest current-file anchor" logic for nested includes
+      that (b) needs anyway. (b)'s heuristic failure modes all degrade to
+      **inert** — never to a wrong reveal — which is exactly the property
+      that made D4's guards acceptable in Phase 2. Stated fallbacks (§1 of
+      the report):
+      - **File included twice in the current file** → ambiguous which
+        invocation → **inert**.
+      - **Nested include** (not named in the current file's own source at
+        all) → **inert**. (A chain-walk to the nearest ancestor invocation
+        that *is* in the current file is a plausible future enhancement,
+        needing either route-(a)-style provenance or the render's
+        file-inclusion graph wired to the client — explicitly deferred, not
+        silently dropped.)
+      - **Code-fence includes** (`{{< include app.py >}}` spliced into
+        fence *text*) already work correctly by construction — the fence's
+        own `data-loc` is unaffected by what's inside its text, so no
+        fallback is needed there.
+- [x] **Pinned rows** (full table + rationale in the report §3): `U1f`/`U1g`
+      (jsdom, `lineForClickTarget` extended with a `currentFileId` param —
+      foreign fileId → `null`, same-file fileId unaffected), `U5a`/`U5b`/`U5c`
+      (the route-(b) scan resolver: single match resolves, duplicate match is
+      ambiguous → `null`, nested include has no textual match → `null`), and
+      `E5` (Playwright: click included content, assert the editor stays on
+      the current file and reveals the include shortcode's line).
+- [ ] **Follow-up implementation** (not done in this task — investigation
+      only, per the brief): land the §0 bugfix (foreign `fileId` → `null`,
+      unconditionally) and the route-(b) scan enhancement, in that order;
+      write `U1f`/`U1g` RED before the bugfix, `U5a`–`c`/`E5` RED before the
+      enhancement.
 
 ## Housekeeping
 - [x] Point `claude-notes/plans/CURRENT.md` at this plan.

--- a/claude-notes/plans/2026-08-22-click-align-editor-y.md
+++ b/claude-notes/plans/2026-08-22-click-align-editor-y.md
@@ -173,24 +173,66 @@ plan: clicking `Paragraph 35.` moved the editor to lines ~45–77 and Monaco too
 focus.) So this phase **replaces the centring**, and per A4 leaves the cursor move
 and focus alone.
 
-- [ ] **Investigate first, and report before implementing:** `MorphIframe`'s
+**Investigation settled 2026-08-22 — rulings:**
+
+- **`hostY` comes from widening `onSelectionChange` to `(startPos, endPos, hostY?)`**,
+  computed inline in `MorphIframe.handleSelectionChange` as
+  `anchorNode.parentElement.getBoundingClientRect().top + iframeRef.getBoundingClientRect().top`
+  — symmetric with `Q2PreviewIframe`'s existing `blockTop + iframeTop`. The
+  alternative (compute in `useSelectionSync` from `previewRef`) was rejected:
+  `MorphIframeHandle` exposes only imperative methods, so it would mean adding one
+  purely to read back a value computed a line earlier.
+- **Anchor on the innermost span, not the containing block.** The reported
+  `SourceLocation` is already span/column-precision, so anchoring `hostY` to a
+  coarser block's top would desync from the very line being reported — on a long
+  paragraph that desync *is* the constant-offset symptom, arriving via granularity
+  rather than coordinate spaces. **Consequence for the browser row: it must locate
+  and measure the actual span under the click**, not the enclosing `<p>`, or it
+  passes and fails for reasons unrelated to its claim.
+- **`lineForClickTarget` gates only the `hostY` computation, never the callback.**
+  Returning early on a null (as `Q2PreviewIframe` does) would also skip
+  `setSelection`/`focus()`, which A4 requires to keep firing unconditionally here.
+  Guard audit against this path: `fileId !== 0` is fully relevant and *more*
+  load-bearing than on q2 (see A7); `#q2-active-edit-region` never appears outside
+  q2-preview, so it is a harmless no-op; and `<section>` is dead here too — the same
+  format-agnostic `SectionizeTransform` synthesises sections as
+  `SourceInfo::Generated` for both consumers, so the writer never stamps a real
+  `data-loc` on one.
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| A7 | **The reveal-then-overwrite race exists on this path too, and threading `revealEditorLine` is what closes it.** | `Preview.tsx:395` wires ratio scroll sync, so a post-click reflow lets `syncPreviewToEditor` replace the alignment ~50 ms later. `revealEditorLine` brackets **`useScrollSync`'s** `isSyncingRef` — the flag `syncPreviewToEditor` actually reads. Extracting the arithmetic into a shared pure helper called from `useSelectionSync` would instead set that hook's *own* unrelated `isSyncingRef` and leave the race wide open. So the callback is threaded deliberately; **do not "decouple the hooks".** Pinned by the HTML-path analogue of U2e. |
+| A8 | **The pre-existing `fileId` bug in `useSelectionSync` is fixed in this phase**, in its own commit, rather than deferred to a strand. | `handlePreviewSelection` builds a Monaco range from `startPos` and never checks `fileId`, so selecting inside *included* content moves the caret to a bogus line of the currently-open file. Same class as the q2-side defect fixed on-branch two days ago, and materially worse: that one produced a wrong *scroll*, this produces a wrong *caret and selection*, so a user who then types edits the wrong location. Leaving it would also make the paths asymmetric right as they converge — q2 inert, HTML mis-positioning. The site already calls `lineForClickTarget`, so the guard is one condition in a function this phase edits. No strand filed: resolved in the same breath. |
+
+- [x] **Investigate first, and report before implementing:** `MorphIframe`'s
       `onSelectionChange` reports only `(startPos, endPos)` — no anchor rect. Decide
       where the anchor Y comes from. Candidates: widen `onSelectionChange` to carry
       it (symmetric with `onClickAtLine`), or compute it in `useSelectionSync` from
       the `previewRef` handle. Note the HTML writer stamps `data-loc` on **inlines**
       too, so the anchor may be a `<span>` rather than the block — decide whether to
-      anchor on the innermost span or its containing block, and say why.
-- [ ] **There are no `useSelectionSync` tests at all.** Create the file. Tier note:
+      anchor on the innermost span or its containing block, and say why. (Settled
+      2026-08-22 — see the rulings above.)
+- [x] **There are no `useSelectionSync` tests at all.** Create the file. Tier note:
       `*.test.ts` runs in the **node** environment, so a DOM fixture needs either
       `*.integration.test.ts` or a `@vitest-environment jsdom` docblock pragma.
-- [ ] Rows: alignment arithmetic (as A1a), both clamps, and — importantly — that
+      (`hub-client/src/hooks/useSelectionSync.test.ts`, `@vitest-environment jsdom`
+      pragma — no DOM fixture needed after all, since `revealEditorLine` is
+      threaded in rather than computed from a DOM handle.)
+- [x] Rows: alignment arithmetic (as A1a), both clamps, and — importantly — that
       `setSelection` and `focus()` are **still called** (A4), so this phase cannot
-      accidentally import q2's no-focus rule into the HTML preview.
-- [ ] A Playwright row equivalent to A1g on the HTML preview path. T3 in the
-      existing spec is the HTML-preview control and must stay green.
-- [ ] Reuse `lineForClickTarget`/`parseDataLoc` rather than adding a parallel
+      accidentally import q2's no-focus rule into the HTML preview. (Wiring rows
+      against a mocked `revealEditorLine`, plus end-to-end rows against a real
+      `useScrollSync().revealEditorLine` for the arithmetic/clamps/A7 race.)
+- [x] A Playwright row equivalent to A1g on the HTML preview path. T3 in the
+      existing spec is the HTML-preview control and must stay green. (P2a, its own
+      dedicated `htmlAlignFixture()` — a wrapping paragraph, since a single-line
+      one like `fixture()`'s can't discriminate span- from block-anchored `hostY`.
+      Fail-on-revert confirmed: measuring the containing `<p>` instead of the
+      clicked span reddens this row.)
+- [x] Reuse `lineForClickTarget`/`parseDataLoc` rather than adding a parallel
       resolver, but note its `fileId !== 0` and `#q2-active-edit-region` guards were
       written for q2-preview — check each still makes sense on this path and say so.
+      (A8's guard commit — see below.)
 
 ## Verification (both phases)
 
@@ -199,17 +241,48 @@ and focus alone.
       (Phase 1: hub-client 991 unit + 112 integration + 131 wasm passed, typecheck
       clean, `build:all` green; preview-renderer 549 unit/36 skipped + 587
       integration passed with the known baseline failure below, typecheck +
-      typecheck:tests clean.)
-- [x] Playwright spec green. (6/6, including the new A1g row, against a real
+      typecheck:tests clean. Phase 2, after both commits: hub-client 1001 unit
+      (+10, `useSelectionSync.test.ts`) + 112 integration + 131 wasm passed;
+      preview-renderer 549 unit/36 skipped + 590 integration (+3: the hostY row
+      and the two fileId-guard rows) passed with the same known baseline
+      failure, typecheck + typecheck:tests clean both packages. Ran
+      `npm run build` — `tsc -b && vite build`, the same stricter check
+      `build:all` runs — rather than the full `build:all`, since no Rust
+      changed and the wasm/sandboxed legs were already current in this
+      worktree; see the commit for the exact command.)
+- [x] Playwright spec green. (Phase 1: 6/6 including A1g. Phase 2: 7/7 —
+      adds P2a, its own dedicated `htmlAlignFixture()` — against a real
       `VITE_E2E=1` build.)
 - [x] Executed fail-on-revert for every row above that names one. (A1a-A1e,
       U2c/U2d/U2e, A1f: observed RED against the pre-fix implementation before
       writing it, then GREEN after. A1g and A1h needed explicit revert probes
-      since they postdate the implementation — see phase1-report.md.)
+      since they postdate the implementation — see phase1-report.md. Phase 2:
+      P2a probed by measuring the containing `<p>` instead of the clicked span
+      — reddened, then reverted; the fileId guard probed by disabling its
+      condition — reddened the foreign-fileId row, control row stayed green,
+      then reverted.)
 - [x] `hub-client/changelog.md` entry per commit that touches `hub-client/`
       (two-commit workflow). **Both** phases touch it. (Phase 1: `ec05241e8` /
-      `0df2d4f1e`.)
+      `0df2d4f1e`. Phase 2: implementation commits `cc4c83480` (hostY +
+      centring→alignment) and `7505e8aaf` (fileId guard fix, own commit per
+      A8), both entries added in one changelog commit.)
 - [x] TypeScript-only; `cargo xtask verify` not required. (No Rust changed.)
+
+### Final verification at the branch tip (2026-08-22)
+
+Phase 2 originally ran `npm run build` rather than the full `npm run build:all`,
+reasoning that no Rust changed and none of the touched files live under
+`quarto-hub-sandboxed-preview`. That reasoning is sound — `build` is the
+`tsc -b && vite build` project-references check `CLAUDE.md` actually cares about —
+but Phase 1 ran the full `build:all` under identical conditions, so the
+inconsistency was closed rather than carried: **`build:all` was run at the tip and
+is clean.**
+
+Note for anyone repeating this: `build:all` emits a PWA service worker and a
+non-local-prod bundle, so it *replaces* a local-prod demo build. Follow it with
+`VITE_DISABLE_PWA=1 npm run build:local-prod` to restore one. The service worker
+is the reason a stale bundle can survive a reload — disable it for any
+build-and-look-at-it loop.
 
 ## Known baseline failure
 

--- a/claude-notes/plans/2026-08-22-click-align-editor-y.md
+++ b/claude-notes/plans/2026-08-22-click-align-editor-y.md
@@ -1,0 +1,218 @@
+# Click-to-align: put the clicked block's source line at the same screen Y
+
+## Overview
+
+Clicking a block in the preview currently *reveals* its source line in Monaco —
+centred in the q2-preview (`revealLineInCenterIfOutsideViewport`), centred in the
+HTML preview (`revealRangeInCenter` inside `useSelectionSync`). Requested change:
+**align**, don't reveal. Whatever height the clicked thing sits at on screen, its
+first line of code should sit at that same height in the editor, so the two panes
+line up across the split.
+
+Validated interactively against a live local-prod hub on 2026-08-21/22 before
+being written up; the working scratch is preserved at
+`.superpowers/sdd/2026-08-21-preview-click-to-editor-scroll/validated-scratch-y-align.diff`
+as the reference implementation for Phase 1.
+
+Builds directly on `claude-notes/plans/2026-08-21-preview-click-to-editor-scroll.md`,
+which established the click path, and inherits its decisions except where noted.
+
+## The alignment computation
+
+On screen a source line sits at `editorTop + (topForLine - scrollTop)`. To land it
+at `hostY`, solve for the scroll position:
+
+```
+scrollTop = editor.getTopForLineNumber(line) - (hostY - editorTop)
+            where editorTop = editor.getDomNode().getBoundingClientRect().top
+```
+
+Clamped to `[0, getScrollHeight() - getLayoutInfo().height]`. **Near the start or
+end of the document the clamp wins and the panes will not line up exactly.** That
+is geometry, not a defect — do not "fix" it by overscrolling.
+
+**Two coordinate spaces.** The clicked element's `getBoundingClientRect()` is
+relative to the *iframe's* viewport, so the iframe element's own offset in the
+host page must be added. Getting this wrong misaligns by exactly the height of
+whatever chrome sits above the preview — a constant offset is the symptom.
+
+## Decisions
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| A1 | **Align unconditionally**, even when the line is already visible. | `revealLineInCenterIfOutsideViewport` no-ops when the line is on screen. Alignment is a claim about *where* the line sits, so "visible somewhere" is not good enough. Cost: the editor moves on every block click. |
+| A2 | **Measure the clicked block, not the edit region.** | At capture-phase `pointerup` the q2-preview edit region does not exist yet. It replaces the clicked block in place, so the block's top *is* the pane's top. If activation is ever changed to add chrome above the text, this becomes a small constant error and the fix is to measure post-activation and report the pane's real position back from the iframe. |
+| A3 | **`hostY` is optional; absent ⇒ top-align.** | Keeps the signature additive and gives a defined behaviour for any caller that cannot measure. |
+| A4 | **q2-preview keeps D1 (no cursor move, no focus steal); the HTML preview keeps its cursor move and focus steal.** | In q2-preview the same click opens an inline editor *in the preview*, so taking focus would break the gesture. The HTML preview has no inline editor, and its `setSelection` + `focus()` is the behaviour users have and like. Only the *reveal* changes there. |
+| A5 | **Ratio scroll sync stays.** | It is governed by the existing scroll-sync UI toggle, so anyone who doesn't want the editor dragged along by preview scrolling turns it off. Removal was considered and rejected (braid **bd-mdcqnl84**, closed 2026-08-22, which also records that loc-based preview→editor sync was *specified* in the 2025-12-29 matched-scrolling plan and never implemented). `isSyncingRef`/U2e exist only because ratio sync can overwrite an alignment, so they stay too. |
+| A6 | **Click-align is deliberately NOT gated by the scroll-sync toggle.** | `revealEditorLine` has no `enabledRef` check, while `syncPreviewToEditor`, `flushPendingScroll` and `scrollToLineDeferred` all do. This began as an accident but is the right behaviour and is now relied on: turning the toggle off gives you *only* click-align, with no ambient scroll coupling in either direction — which is how the feature is best evaluated and how at least one user works. It also matches D1's existing reasoning that an explicit click is unambiguous intent, unlike ambient sync. Pinned by row A1h so nobody "fixes" it by adding a gate. |
+
+## Phase 1 — q2-preview (commit 1)
+
+Reference implementation: the saved scratch diff. It is known-good interactively;
+it is **not** test-bound yet, which is this phase's real work.
+
+### Tests first (RED before implementation)
+
+`makeEditor` in `hub-client/src/hooks/useScrollSync.test.ts` needs
+`getTopForLineNumber` and `getDomNode` before any of these can be written.
+
+- [x] **A1a** — `revealEditorLine(73, hostY)` calls `setScrollTop` with the exact
+      computed value `(topForLine - (hostY - editorTop), 1)`. Exact arithmetic,
+      both arguments — a bare one-arg assertion fails on arity.
+      *Revert:* drop the `hostY` term → centred/top value → RED.
+- [x] **A1b** — clamped at **0** when the computation goes negative (block near
+      the top of the document, pane low on screen).
+      *Revert:* remove the lower clamp → negative `setScrollTop` → RED.
+- [x] **A1c** — clamped at `getScrollHeight() - getLayoutInfo().height`.
+      *Revert:* remove the upper clamp → RED.
+- [x] **A1d** — `hostY` omitted ⇒ top-align (`setScrollTop(topForLine, 1)`), per A3.
+      *Revert:* make the fallback centre instead → RED.
+- [x] **A1e** — **replaces U2a.** U2a asserted
+      `revealLineInCenterIfOutsideViewport(73)`, which this phase deliberately
+      stops calling. Assert that method is now **never** called, so a revert to
+      centring reddens rather than silently passing.
+- [x] **U2b unchanged; U2c/U2d/U2e rewritten** — U2b's assertions never touched
+      `revealLineInCenterIfOutsideViewport`, so it needed no change. U2c/U2d/U2e
+      originally asserted that method too (the same false premise A1e already
+      names for U2a — caught during Phase 1, not before). Rewritten to assert
+      `setScrollTop` by value and call count instead of by method name (U2e in
+      particular discriminates the suppressed echo from the resumed ratio sync
+      by call count + distinct values — alignment 50 vs. ratio 300 — since both
+      now go through the same method).
+- [x] **A1h** — with `enabled: false`, `revealEditorLine(73, hostY)` **still aligns**
+      (per A6). *Revert:* add an `enabledRef.current` gate to `revealEditorLine`
+      → RED. This row is the only thing standing between A6 and a plausible-looking
+      "consistency" fix. Confirmed by an explicit revert probe (already passed
+      before any implementation change, since the gate never existed; adding it
+      temporarily reddened the row, then it was removed again).
+- [x] **A1f** — extend **U3** so the registration tuple assertion is unchanged but
+      `onClickAtLine` is asserted to receive **both** the line and a numeric
+      `hostY`. *Revert:* stop passing the second argument → RED.
+- [x] **A1g** — Playwright: click a block and assert the clicked element's
+      viewport Y and the target line's rendered Y in Monaco agree within a stated
+      tolerance. **This is the only row that binds the two coordinate spaces**;
+      jsdom has no layout, so it cannot catch an iframe-offset error. State the
+      tolerance and why.
+
+### Implementation
+
+- [x] Widen `onClickAtLine` to `(line: number, hostY?: number) => void`
+      (`Q2PreviewIframe`), and `onPreviewClickAtLine` likewise
+      (`ReactRenderer` → `ReactPreview`). Thread the prop **before** changing the
+      handler, or `tsc -b` is red between steps.
+- [x] `Q2PreviewIframe`'s capture-phase `pointerup` handler: resolve the nearest
+      `[data-loc]` block, add its `getBoundingClientRect().top` to the iframe
+      element's own top, pass as `hostY`.
+- [x] `useScrollSync`: `revealEditorLine(line, hostY?)` performs the computation
+      above, keeping the `isSyncingRef` bracketing (A5 — ratio sync stays, so the
+      overwrite race stays reachable).
+- [x] Rewrite the doc comments the scratch left stale: `useScrollSync`'s header
+      still says `revealEditorLine` "calls `editor.revealLineInCenterIfOutsideViewport`".
+- [x] Delete every `TEMPORARY LOCAL EXPERIMENT` marker (none carried into the
+      real implementation — it was written fresh from the plan, not by applying
+      the scratch diff verbatim).
+
+### Phase 1 verification evidence (2026-08-22)
+
+Recorded here because the working reports live under `.superpowers/`, which is
+gitignored and dies with the worktree. These are the measurements worth keeping.
+
+**Commits:** `ec05241e8` (implementation + rows), `0df2d4f1e` (changelog),
+`c9e77e866` (A1h + checklist), `8f58fd128` (A1a collision fix), `0e9201b8c`
+(collision note).
+991 hub-client unit / 112 integration / 131 wasm; preview-renderer 549 unit /
+587 integration; typecheck and `typecheck:tests` clean; `build:all` clean;
+Playwright 6/6.
+
+**A1g's tolerance is 6px, justified by measurement, not feel.** Reverting
+`revealEditorLine` to the old centring call and running A1g alone failed it by
+**~13px** — comfortably outside the tolerance, so the row discriminates rather
+than merely passing. It targets `Paragraph 20.` (source line 45 of 80),
+deliberately away from the document's start and end where the clamp would mask a
+wrong computation.
+
+**300 is a poisoned expected value in `useScrollSync.test.ts`.** The harness's
+`getPreviewScrollRatio` is a fixed `0.5` over a 1000/400 editor, so
+`syncPreviewToEditor` always produces exactly `setScrollTop(300, 1)`. A1a
+originally expected that same value and therefore passed for an implementation
+that wrongly routed `revealEditorLine` through the ratio path — the very mutant
+its name claims to catch. (It died at U2c, whose focus gate suppresses the ratio
+call entirely, so the seam held; the row alone did not.) A1a now uses
+`topForLine=400, editorTop=80, hostY=200` → **280**, proven by mutating the
+implementation to route through the ratio calc and observing
+`expected [280,1], received [300,1]`. No other row collides: A1b=0, A1c=600,
+A1d=222, U2c/U2d/A1h=50, U2e's first assertion=50. **U2e's second assertion is a
+deliberate 300** — that step is specifically testing the *resumed* ratio path
+after the suppression window elapses, so there 300 is the correct expected value,
+not a collision. **If you change the editor fake's geometry (`getPreviewScrollRatio`
+0.5, editor 1000/400), re-check every one of these.**
+
+**A1h could not be validated by natural TDD sequencing**, because A6 was already
+true of the implementation — there is no gate to remove. It was validated by
+*adding* `if (!enabledRef.current) return;` to `revealEditorLine`, observing A1h
+redden, then reverting. For a row that pins the *absence* of something, that is
+the only meaningful proof.
+
+**U2e's discrimination changed shape in this phase.** It previously separated "the
+reveal" from "the ratio overwrite" by *method name* — the reveal called
+`revealLineInCenterIfOutsideViewport`, the overwrite called `setScrollTop`. Both
+now go through `setScrollTop`, so it discriminates by **value and call count**
+instead: one call with the alignment value, still one after a scroll inside the
+suppression window, two after the window elapses. That is strictly stronger —
+value-discrimination survives an implementation swapping methods; method-
+discrimination did not.
+
+## Phase 2 — HTML preview (commit 2)
+
+The HTML preview reaches the editor through a *different* path, and it is already
+doing more than the q2 one: `useSelectionSync.handlePreviewSelection` runs on
+`selectionchange` with **no collapsed-selection guard**, so a plain click already
+does `setSelection` + `revealRangeInCenter` + `focus()`. (Measured in the previous
+plan: clicking `Paragraph 35.` moved the editor to lines ~45–77 and Monaco took
+focus.) So this phase **replaces the centring**, and per A4 leaves the cursor move
+and focus alone.
+
+- [ ] **Investigate first, and report before implementing:** `MorphIframe`'s
+      `onSelectionChange` reports only `(startPos, endPos)` — no anchor rect. Decide
+      where the anchor Y comes from. Candidates: widen `onSelectionChange` to carry
+      it (symmetric with `onClickAtLine`), or compute it in `useSelectionSync` from
+      the `previewRef` handle. Note the HTML writer stamps `data-loc` on **inlines**
+      too, so the anchor may be a `<span>` rather than the block — decide whether to
+      anchor on the innermost span or its containing block, and say why.
+- [ ] **There are no `useSelectionSync` tests at all.** Create the file. Tier note:
+      `*.test.ts` runs in the **node** environment, so a DOM fixture needs either
+      `*.integration.test.ts` or a `@vitest-environment jsdom` docblock pragma.
+- [ ] Rows: alignment arithmetic (as A1a), both clamps, and — importantly — that
+      `setSelection` and `focus()` are **still called** (A4), so this phase cannot
+      accidentally import q2's no-focus rule into the HTML preview.
+- [ ] A Playwright row equivalent to A1g on the HTML preview path. T3 in the
+      existing spec is the HTML-preview control and must stay green.
+- [ ] Reuse `lineForClickTarget`/`parseDataLoc` rather than adding a parallel
+      resolver, but note its `fileId !== 0` and `#q2-active-edit-region` guards were
+      written for q2-preview — check each still makes sense on this path and say so.
+
+## Verification (both phases)
+
+- [x] `npm run test` + `npm run test:integration` in `hub-client` and
+      `ts-packages/preview-renderer`; `npm run typecheck:tests`; `npm run build:all`.
+      (Phase 1: hub-client 991 unit + 112 integration + 131 wasm passed, typecheck
+      clean, `build:all` green; preview-renderer 549 unit/36 skipped + 587
+      integration passed with the known baseline failure below, typecheck +
+      typecheck:tests clean.)
+- [x] Playwright spec green. (6/6, including the new A1g row, against a real
+      `VITE_E2E=1` build.)
+- [x] Executed fail-on-revert for every row above that names one. (A1a-A1e,
+      U2c/U2d/U2e, A1f: observed RED against the pre-fix implementation before
+      writing it, then GREEN after. A1g and A1h needed explicit revert probes
+      since they postdate the implementation — see phase1-report.md.)
+- [x] `hub-client/changelog.md` entry per commit that touches `hub-client/`
+      (two-commit workflow). **Both** phases touch it. (Phase 1: `ec05241e8` /
+      `0df2d4f1e`.)
+- [x] TypeScript-only; `cargo xtask verify` not required. (No Rust changed.)
+
+## Known baseline failure
+
+`ts-packages/preview-renderer` `custom-components.integration.test.tsx >
+Equation > appends \tag{N}` fails under the pinned katex 0.18.1 — braid
+**bd-s36g9dav**, unrelated, fails identically before and after.

--- a/hub-client/changelog.md
+++ b/hub-client/changelog.md
@@ -25,6 +25,8 @@ WASM rebuild is needed for a changelog-only edit.
 
 ### 2026-08-21
 
+- [`167dd4d5a`](https://github.com/quarto-dev/q2/commits/167dd4d5a): Clicking a block in the q2-preview pane now scrolls the source editor to that block, instead of leaving the editor where it was.
+- [`6187ea9f5`](https://github.com/quarto-dev/q2/commits/6187ea9f5): Fix a race where clicking a block in q2-preview correctly scrolled the source editor to that block, then had the scroll silently overwritten a few ms later by an unrelated preview scroll (e.g. a rich-text editor's toolbar mounting).
 - [`837de60b`](https://github.com/quarto-dev/q2/commits/837de60b): Fix deleted projects reappearing on the next page load — deleting a project now records a tombstone that syncs with the project set, so the on-load reconciler purges the stale local copy instead of resurrecting it, on every browser.
 
 ### 2026-08-19

--- a/hub-client/changelog.md
+++ b/hub-client/changelog.md
@@ -23,6 +23,10 @@ WASM rebuild is needed for a changelog-only edit.
 
 -->
 
+### 2026-08-22
+
+- [`ec05241e8`](https://github.com/quarto-dev/q2/commits/ec05241e8): Clicking a block in the q2-preview pane now aligns its source line to the same on-screen height as the clicked block, instead of just scrolling it into view.
+
 ### 2026-08-21
 
 - [`167dd4d5a`](https://github.com/quarto-dev/q2/commits/167dd4d5a): Clicking a block in the q2-preview pane now scrolls the source editor to that block, instead of leaving the editor where it was.

--- a/hub-client/changelog.md
+++ b/hub-client/changelog.md
@@ -25,6 +25,8 @@ WASM rebuild is needed for a changelog-only edit.
 
 ### 2026-08-22
 
+- [`7505e8aaf`](https://github.com/quarto-dev/q2/commits/7505e8aaf): Fix a bug where selecting text from an included document in the HTML preview moved the source editor's caret to the wrong file's line instead of leaving it alone.
+- [`cc4c83480`](https://github.com/quarto-dev/q2/commits/cc4c83480): Clicking or selecting text in the HTML preview pane now aligns its source line to the same on-screen height as the clicked text, instead of just scrolling it into view.
 - [`ec05241e8`](https://github.com/quarto-dev/q2/commits/ec05241e8): Clicking a block in the q2-preview pane now aligns its source line to the same on-screen height as the clicked block, instead of just scrolling it into view.
 
 ### 2026-08-21

--- a/hub-client/changelog.md
+++ b/hub-client/changelog.md
@@ -25,14 +25,10 @@ WASM rebuild is needed for a changelog-only edit.
 
 ### 2026-08-22
 
-- [`7505e8aaf`](https://github.com/quarto-dev/q2/commits/7505e8aaf): Fix a bug where selecting text from an included document in the HTML preview moved the source editor's caret to the wrong file's line instead of leaving it alone.
-- [`cc4c83480`](https://github.com/quarto-dev/q2/commits/cc4c83480): Clicking or selecting text in the HTML preview pane now aligns its source line to the same on-screen height as the clicked text, instead of just scrolling it into view.
-- [`ec05241e8`](https://github.com/quarto-dev/q2/commits/ec05241e8): Clicking a block in the q2-preview pane now aligns its source line to the same on-screen height as the clicked block, instead of just scrolling it into view.
+- [`0de96cd7a`](https://github.com/quarto-dev/q2/commits/0de96cd7a): Clicking in either preview pane now lines the source editor up with what you clicked: the first line of that block's source sits at the same height on screen as the block itself, so the two panes read side by side. Previously the q2-preview did nothing at all when you clicked a block, and the HTML preview scrolled your line to the middle of the editor. Selecting text that came from an included file also no longer moves your cursor to an unrelated line of the file you are editing.
 
 ### 2026-08-21
 
-- [`167dd4d5a`](https://github.com/quarto-dev/q2/commits/167dd4d5a): Clicking a block in the q2-preview pane now scrolls the source editor to that block, instead of leaving the editor where it was.
-- [`6187ea9f5`](https://github.com/quarto-dev/q2/commits/6187ea9f5): Fix a race where clicking a block in q2-preview correctly scrolled the source editor to that block, then had the scroll silently overwritten a few ms later by an unrelated preview scroll (e.g. a rich-text editor's toolbar mounting).
 - [`837de60b`](https://github.com/quarto-dev/q2/commits/837de60b): Fix deleted projects reappearing on the next page load — deleting a project now records a tombstone that syncs with the project set, so the on-load reconciler purges the stale local copy instead of resurrecting it, on every browser.
 
 ### 2026-08-19

--- a/hub-client/e2e/q2-preview-click-to-editor-scroll.spec.ts
+++ b/hub-client/e2e/q2-preview-click-to-editor-scroll.spec.ts
@@ -42,10 +42,16 @@
  *                   document, proving the harness and the listener are sound
  *                   and isolating the difference to the DOM swap.
  * T4 (guard)      — a caret-move click inside an already-open editor (not a
- *                   click on a new block) must not move the editor. Passes
- *                   today because nothing reveals yet; its binding is
- *                   post-fix, via the named revert "delete the active-region
- *                   guard from `lineForClickTarget`" (a later task).
+ *                   click on a new block) must not move the editor. Uses its
+ *                   own `wrapperFixture()` (task 11, 2026-08-21 plan):
+ *                   the edited block sits inside a located non-section
+ *                   wrapper (a plain fenced div — NOT a callout; see that
+ *                   fixture's doc comment for why callouts don't work here),
+ *                   so a deleted active-region guard resolves to the
+ *                   wrapper's own line instead of doing nothing. Named
+ *                   revert: delete the active-region guard from
+ *                   `lineForClickTarget` → RED (the editor jumps to the
+ *                   wrapper's line).
  *
  * Run via:
  *   cd hub-client && npx playwright test e2e/q2-preview-click-to-editor-scroll.spec.ts \
@@ -102,6 +108,159 @@ function fixture(format: string | null): string {
     ].join('\n');
 }
 
+/**
+ * T5's own fixture — self-contained (no `.scratch/` dependency), confirmed
+ * by direct probing against a real hub server (see task-9-report.md) to
+ * reproduce a genuine browser `scroll` event on the preview when the FIRST
+ * callout's body is clicked, and — unguarded — a real overwrite of the
+ * editor's reveal a few ms later.
+ *
+ * This is deliberately NOT `fixture()`. Probing found the reflow-then-scroll
+ * is NOT produced by a callout in isolation (`fixture()`'s heading + one
+ * short numbered paragraph + a callout produces no `scroll` event at all —
+ * confirmed with direct instrumentation, several variations tried). It IS
+ * reliably produced by this shape: a full title block (title + subtitle +
+ * author — a bare `format:` front-matter was NOT enough) followed by a
+ * multi-paragraph intro, mirroring the structure of
+ * `.scratch/demo/scroll-sync-demo.qmd` (where task-8 first found the race)
+ * without depending on that file. The exact mechanism ("why" the toolbar
+ * mount reflows here and not in a barer document) was not pinned down further
+ * — see task-9-report.md for the elimination steps — but the reproduction
+ * itself was confirmed twice, deterministically.
+ *
+ * Layout, mirroring `fixture()`'s own T2 trick for the same reason:
+ *   - 40 filler paragraphs before "## Callouts" — without them the callout
+ *     sits within Monaco's initial render window and there is nothing for a
+ *     reveal (or an overwrite) to do; the "off-screen" precondition needs
+ *     real distance.
+ *   - a trailing 6000px spacer AFTER the callouts — decouples the target
+ *     callout's low PREVIEW pixel-ratio from its high source LINE-ratio, the
+ *     same way `fixture()`'s spacer does for `Paragraph N.`. Without it, the
+ *     pre-existing ratio-sync's guess is usually close enough to the correct
+ *     line to still (accidentally) satisfy a "still contains the target"
+ *     assertion — confirmed by probing: the same click, same reflow, same
+ *     `scroll` event, but a much smaller (~8-line) and inconsequential drift
+ *     without the spacer, vs. a large, target-excluding drift with it.
+ */
+function reflowFixture(): string {
+    const filler: string[] = [];
+    for (let i = 1; i <= 40; i++) filler.push(`Paragraph ${i}.`, '');
+    return [
+        '---',
+        'title: "Click-to-Editor Scroll Sync — Element Gallery"',
+        'subtitle: "A document for exercising preview → editor scroll sync"',
+        'author: "Quarto 2"',
+        'format: q2-preview',
+        '---',
+        '',
+        '# Introduction',
+        '',
+        'This document exists to exercise **click-to-editor scroll sync** in the',
+        'q2-preview. Clicking any block below should scroll the Monaco source editor to',
+        "that block's line, *without* stealing focus from the inline editor the same",
+        'click opens.',
+        '',
+        'It is deliberately long and deliberately varied: every block kind is a',
+        'different shape in the DOM, and the interesting question is whether',
+        '`lineForClickTarget` resolves each one to the right `data-loc`.',
+        '',
+        'Try clicking a paragraph near the bottom first — the editor should jump to a',
+        'line in the nineties, not to the top of the file.',
+        '',
+        ...filler,
+        '## Callouts',
+        '',
+        '::: {.callout-note}',
+        '## A note callout',
+        '',
+        'Callouts nest their content inside a div, so the nearest data-loc ancestor',
+        'of this paragraph is the paragraph — not the callout wrapper.',
+        ':::',
+        '',
+        '::: {.callout-tip}',
+        '## A tip callout',
+        '',
+        'Clicking the heading of a callout is a different DOM path from clicking its',
+        'body. Both should resolve.',
+        ':::',
+        '',
+        '::: {.callout-warning}',
+        '## A warning callout',
+        '',
+        'Warnings, notes, tips, cautions and importants all render through the same',
+        'machinery but with different classes.',
+        ':::',
+        '',
+        '::: {.callout-important}',
+        '## An important callout',
+        '',
+        'This one exists mostly to add height so the document needs more scrolling.',
+        ':::',
+        '',
+        '::: {.callout-caution collapse="true"}',
+        '## A collapsed caution callout',
+        '',
+        'Collapsed callouts start closed, which means their body is in the DOM but not',
+        'visible — a useful edge case for hit-testing.',
+        ':::',
+        '',
+        '::: {style="height: 6000px"}',
+        'Spacer.',
+        ':::',
+        '',
+    ].join('\n');
+}
+
+/**
+ * T4's own fixture (task 11, 2026-08-21 plan) — a plain fenced div
+ * (`.plain-wrapper`), NOT a callout, wrapping a single paragraph, after 40
+ * filler paragraphs so the wrapper starts off-screen at load.
+ *
+ * Why not a callout (reflowFixture()'s existing wrapper): inspecting the real
+ * q2-preview DOM (via the ancestor chain from `#q2-active-edit-region` after
+ * opening a callout's body paragraph) shows the callout's own `<div>` never
+ * carries `data-loc` — `Callout.tsx`'s dispatcher spreads `affordanceAttr`
+ * onto its wrapper but never `dataLocProps`, unlike the generic Div
+ * dispatcher (`Div.tsx`, used for a plain `::: {...}` fenced div), which
+ * does. So with a callout, `closest('[data-loc]')` from inside the region
+ * walks all the way past the callout AND the enclosing `<section>` (which
+ * also carries no `data-loc` in this renderer) to nothing — it returns null
+ * via the "no ancestor at all" case regardless of whether the active-region
+ * guard exists, exactly the vacuous-row failure task 11 was dispatched to
+ * fix. A plain fenced div's outer element DOES carry its own `data-loc`
+ * (confirmed empirically), so it is the wrapper this row actually needs.
+ *
+ * Why the test also has to scroll Monaco directly (see the test body): the
+ * wrapper's own `data-loc` start line and its single paragraph child's start
+ * line differ by only 1-3 lines (the fence line itself, maybe a heading).
+ * Opening the paragraph's editor reveals its own line correctly either way,
+ * but `revealEditorLine` calls `revealLineInCenterIfOutsideViewport` — since
+ * the wrapper's line is already inside that same small-gap viewport, a
+ * missing guard's reveal call would silently no-op too, and the row would be
+ * vacuous again for a completely different reason. The test scrolls Monaco
+ * away from both lines (a real user could do this with the mouse wheel,
+ * without touching the preview or closing the open editor) so the wrapper's
+ * line is genuinely outside the viewport at the moment of the final click.
+ */
+function wrapperFixture(): string {
+    const filler: string[] = [];
+    for (let i = 1; i <= 40; i++) filler.push(`Paragraph ${i}.`, '');
+    return [
+        '---',
+        'title: "T4 — active-region guard, non-section wrapper"',
+        'format: q2-preview',
+        '---',
+        '',
+        '# Introduction',
+        '',
+        ...filler,
+        '::: {.plain-wrapper}',
+        'Wrapped paragraph for the T4 active-region guard row.',
+        ':::',
+        '',
+    ].join('\n');
+}
+
 /** 1-based source line of `Paragraph n.` in the fixture above. */
 function paraLine(n: number): number {
     return 5 + 2 * n;
@@ -124,6 +283,22 @@ async function openDoc(
     const localId = await seedProjectInBrowser(page, docId, serverUrl);
     await page.goto(`/#/p/${localId}/file/doc.qmd`);
     await waitForPreviewRender(page, { kind, timeout: 30000 });
+}
+
+/**
+ * Like {@link openDoc}, but for a dedicated fixture's content (T5's
+ * `reflowFixture()`, T4's `wrapperFixture()`).
+ */
+async function openDocWithContent(page: Page, content: string): Promise<void> {
+    const serverUrl = getServerUrl();
+    const docId = await createProjectOnServer(serverUrl, [
+        { path: '_quarto.yml', content: 'project:\n  type: default\n', contentType: 'text' },
+        { path: 'doc.qmd', content, contentType: 'text' },
+    ]);
+    await bootstrapProjectSet(page, serverUrl);
+    const localId = await seedProjectInBrowser(page, docId, serverUrl);
+    await page.goto(`/#/p/${localId}/file/doc.qmd`);
+    await waitForPreviewRender(page, { kind: 'q2-preview', timeout: 30000 });
 }
 
 /**
@@ -228,6 +403,35 @@ async function previewScrollY(page: Page): Promise<number> {
 }
 
 /**
+ * Install a `scroll` counter on the preview iframe's `contentWindow` — the
+ * same event `Q2PreviewIframe`'s production listener (and `handlePreviewScroll`
+ * → the ratio-sync debounce) reacts to. Modeled on {@link recordIframeDocClicks}
+ * (install-then-read-back via `page.evaluate`), not a new shape. T5 uses this
+ * to confirm a real scroll actually fired, rather than assuming it did.
+ */
+async function recordIframePreviewScrolls(page: Page, iframeSelector: string): Promise<void> {
+    await page.evaluate((sel) => {
+        const frame = document.querySelector(sel) as HTMLIFrameElement | null;
+        const win = frame?.contentWindow;
+        if (!win) throw new Error(`no contentWindow for ${sel}`);
+        (window as unknown as { __previewScrollCount: number }).__previewScrollCount = 0;
+        win.addEventListener(
+            'scroll',
+            () => {
+                (window as unknown as { __previewScrollCount: number }).__previewScrollCount += 1;
+            },
+            { passive: true },
+        );
+    }, iframeSelector);
+}
+
+async function readIframePreviewScrollCount(page: Page): Promise<number> {
+    return page.evaluate(
+        () => (window as unknown as { __previewScrollCount: number }).__previewScrollCount,
+    );
+}
+
+/**
  * Text of the lines Monaco currently has rendered (i.e. what the user sees).
  *
  * **Monaco renders spaces as `\u00a0`.** Without the normalisation below,
@@ -242,7 +446,7 @@ async function editorVisibleText(page: Page): Promise<string> {
     return raw.replace(/\u00a0/g, ' ');
 }
 
-test.describe('preview→editor scroll sync on click (repro)', () => {
+test.describe('preview→editor scroll sync on click', () => {
     test.setTimeout(120000);
 
     test.beforeEach(async ({ page }, testInfo) => {
@@ -372,25 +576,47 @@ test.describe('preview→editor scroll sync on click (repro)', () => {
     });
 
     test('T4 — a caret-move click inside the open editor must not move the editor', async ({ page }) => {
-        await openDoc(page, 'q2-preview', 'q2-preview');
+        // Own fixture (`wrapperFixture()`) — see its doc comment for why a
+        // plain fenced div, not one of reflowFixture()'s callouts, is the
+        // wrapper this row needs, and why the block being edited must sit
+        // inside it (not directly inside the section).
+        await openDocWithContent(page, wrapperFixture());
         const iframe = page.frameLocator(Q2_IFRAME);
         await iframe.locator('[data-block-pool-id]').first().waitFor({ timeout: 15_000 });
 
-        // Open the editor on a LATE paragraph. Once a reveal exists (post-fix)
-        // this is what displaces the editor away from `# Section one` — the
-        // editor will be showing line ~75, not line 5.
-        const targetText = `Paragraph ${PARA_COUNT}.`;
-        const target = iframe.locator('p[data-block-pool-id]').filter({ hasText: targetText }).first();
-        await target.scrollIntoViewIfNeeded();
-        await target.click();
+        // 1. Click a block deep in the document (far from the wrapper, which
+        // sits after 40 filler paragraphs) to displace the editor there.
+        const deep = iframe.locator('p[data-block-pool-id]').filter({ hasText: 'Paragraph 1.' }).first();
+        await deep.scrollIntoViewIfNeeded();
+        await deep.click();
         const textarea = iframe.locator('textarea').first();
         await textarea.waitFor({ timeout: 5000 });
         await page.waitForTimeout(800); // debounce (50ms) + smooth scroll (300ms) + slack, mirrors T2
 
+        // 2. Open the wrapper-nested block's editor. Correctly reveals its
+        // own line (this happens whether or not the active-region guard
+        // exists — the click target isn't inside the region yet).
+        const target = iframe.getByText(/^Wrapped paragraph for the T4 active-region guard row/).first();
+        await target.scrollIntoViewIfNeeded();
+        await target.click();
+        await textarea.waitFor({ timeout: 5000 });
+        await page.waitForTimeout(800);
+
+        // 3. Displace Monaco's OWN viewport again, directly — a real user
+        // action (mouse wheel over the editor pane) that does not touch the
+        // preview and so cannot close the edit region just opened. Needed
+        // per wrapperFixture()'s doc comment: the wrapper's line is only a
+        // few lines from the paragraph's own line, so without this the
+        // wrapper's line would already be inside the viewport and a missing
+        // guard's reveal call would no-op too, same as a correct guard would.
+        await page.hover('.monaco-editor');
+        for (let i = 0; i < 40; i++) await page.mouse.wheel(0, -2000);
+        await page.waitForTimeout(300);
+
         const before = await editorVisibleText(page);
 
-        // A caret move WITHIN the block already being edited — not a click on
-        // a new block. This must land inside `#q2-active-edit-region`.
+        // 4. A caret move WITHIN the block already being edited — not a
+        // click on a new block. This must land inside `#q2-active-edit-region`.
         await textarea.click();
         await page.waitForTimeout(300);
 
@@ -399,5 +625,90 @@ test.describe('preview→editor scroll sync on click (repro)', () => {
             after,
             'a caret-move click inside the already-open editor must not move the editor',
         ).toEqual(before);
+    });
+
+    test('T5 — a reflow-causing rich-text activation must not let the reveal be overwritten by ratio sync', async ({ page }) => {
+        // richText defaults OFF for this describe's shared preferences seed
+        // (bootstrapProjectSet's e2e baseline), so T1–T4's plain-textarea
+        // assertions are unaffected. This test opts IN, registering its own
+        // addInitScript AFTER the shared beforeEach's — it runs later, so it
+        // wins, and bootstrapProjectSet's merge (`cur.richText === undefined`)
+        // then leaves it alone. Mirrors q2-preview-richtext-bold-content-loss.spec.ts.
+        await page.addInitScript(() => {
+            localStorage.setItem(
+                'quarto-hub:preferences',
+                JSON.stringify({
+                    version: 1,
+                    scrollSyncEnabled: true,
+                    errorOverlayCollapsed: true,
+                    colorScheme: 'auto',
+                    richText: true,
+                }),
+            );
+        });
+
+        await openDocWithContent(page, reflowFixture());
+        const iframe = page.frameLocator(Q2_IFRAME);
+        await iframe.locator('[data-block-pool-id]').first().waitFor({ timeout: 15_000 });
+
+        const targetText = 'Callouts nest their content inside a div';
+        const target = iframe.getByText(new RegExp(`^${targetText}`)).first();
+
+        // Precondition: the target is genuinely off-screen in the editor
+        // before any interaction — see reflowFixture()'s doc comment for why
+        // the 40 filler paragraphs are needed for this to hold.
+        const before = await editorVisibleText(page);
+        expect(before, 'precondition: the target line is off-screen in the editor').not.toContain(
+            targetText,
+        );
+
+        await target.scrollIntoViewIfNeeded();
+
+        // Install the scroll counter AFTER the setup scroll above (so it
+        // only counts scrolls the CLICK itself produces, not the one from
+        // bringing the target into view) and BEFORE the click.
+        await recordIframePreviewScrolls(page, Q2_IFRAME);
+
+        await target.click();
+        // Activation opens the rich-text (tiptap) editor for this block —
+        // `.ProseMirror`, not a `<textarea>` — confirming the click landed
+        // and the block is now in rich-edit mode.
+        await iframe.locator('.ProseMirror').first().waitFor({ timeout: 5000 });
+
+        // Runtime precondition, not assumed: activation must have produced at
+        // least one real `scroll` event on the preview. Without this, the
+        // poll loop below would pass VACUOUSLY if `reflowFixture()` ever
+        // stops reproducing the post-activation reflow (a dependency bump, a
+        // CSS change, a font-loading change, ...) — nothing would move the
+        // reveal, so "still contains target text" would hold trivially. A
+        // failure here means this row's fixture precondition broke, not that
+        // the fix regressed — re-derive `reflowFixture()` (see its doc
+        // comment), don't delete this row.
+        const scrollCount = await readIframePreviewScrollCount(page);
+        expect(
+            scrollCount,
+            'precondition: activation must produce at least one real preview scroll event — ' +
+                'if this is 0, reflowFixture() has stopped reproducing the reflow this row exists ' +
+                'to survive; re-derive the fixture, this is not a product regression',
+        ).toBeGreaterThan(0);
+
+        // Poll across (and past) the ratio-sync debounce window (50ms) plus
+        // its own smooth-scroll animation (300ms). A single post-click check
+        // would land right where the existing T2 does today and miss a
+        // reveal that arrives correctly, then is silently overwritten a few
+        // ms later — which is exactly what task-8 found (and task-9-report.md
+        // reproduces directly against this fixture) and this row exists to
+        // catch. Once overwritten, the wrong position is not self-correcting
+        // (nothing else scrolls the editor again), so any single sample in
+        // this window catches a regression — the loop's job is to not miss a
+        // narrow window by sampling too coarsely.
+        for (let elapsed = 0; elapsed <= 500; elapsed += 25) {
+            const visible = await editorVisibleText(page);
+            expect(
+                visible,
+                `the reveal must still hold ${elapsed}ms after the click, not just immediately after it`,
+            ).toContain(targetText);
+            await page.waitForTimeout(25);
+        }
     });
 });

--- a/hub-client/e2e/q2-preview-click-to-editor-scroll.spec.ts
+++ b/hub-client/e2e/q2-preview-click-to-editor-scroll.spec.ts
@@ -1,0 +1,403 @@
+/**
+ * Preview→editor click-to-editor-scroll: fix verification + one
+ * characterization row.
+ *
+ * Reported symptom: in the HTML preview, clicking in the preview scrolls the
+ * Monaco source editor to the corresponding position; in q2-preview, clicking a
+ * block to edit it left the editor where it was. Editor→preview worked in both.
+ *
+ * Root cause, now fixed (T1 pins the browser mechanism the fix works around):
+ *   `Q2PreviewIframe` used to drive preview→editor sync off a `click` listener
+ *   on the iframe document, but q2-preview activates editing on `pointerup` and
+ *   activation REPLACES the clicked element's subtree with the synthetic
+ *   `#q2-active-edit-region`. Chromium dispatches no `click` at all when the
+ *   `pointerup` target was detached during `pointerup`, so that listener never
+ *   ran. The fix switched preview→editor click sync to a capture-phase
+ *   `pointerup` listener + `data-loc`, which runs before the DOM swap.
+ *
+ * Why T1 must live at the real-browser tier: a jsdom test dispatches `click`
+ * itself and therefore cannot reproduce the browser's suppression of a click
+ * whose target was detached. That fact is invisible below this tier.
+ *
+ * T1 (characterization) — clicking a block delivers NO `click` event to the
+ *                   iframe document (Chromium's detached-target suppression),
+ *                   while a click that does not swap the DOM does; AND a
+ *                   capture-phase `pointerup` listener on the same document
+ *                   DOES see the target still attached with a parseable
+ *                   `data-loc` — the fact the fix relies on. This is a
+ *                   characterization test, not a repro: it has no production
+ *                   revert hunk, because it asserts a browser fact rather than
+ *                   this code's behavior. If a future Chromium starts
+ *                   delivering that `click`, this test goes red and tells us
+ *                   the original `click` listener would have worked after all.
+ * T2 (symptom)    — clicking a block does not scroll the editor to that block's
+ *                   line. The fixture is crafted so that *ratio* matching (the
+ *                   only preview→editor mechanism that exists today) cannot
+ *                   make it pass either: a trailing 6000px spacer div puts the
+ *                   clicked block at preview scroll ratio ≈ 0.05 while its
+ *                   source line is at ≈ 95% of the document. Both are asserted
+ *                   as preconditions. Only a `data-loc` based reveal turns T2
+ *                   green.
+ * T3 (control)    — the same click in the HTML preview DOES reach the iframe
+ *                   document, proving the harness and the listener are sound
+ *                   and isolating the difference to the DOM swap.
+ * T4 (guard)      — a caret-move click inside an already-open editor (not a
+ *                   click on a new block) must not move the editor. Passes
+ *                   today because nothing reveals yet; its binding is
+ *                   post-fix, via the named revert "delete the active-region
+ *                   guard from `lineForClickTarget`" (a later task).
+ *
+ * Run via:
+ *   cd hub-client && npx playwright test e2e/q2-preview-click-to-editor-scroll.spec.ts \
+ *     --project=chromium --workers=1
+ */
+
+import { test, expect, type Page } from '@playwright/test';
+import type {} from './helpers/testHooks';
+import {
+    bootstrapProjectSet,
+    createProjectOnServer,
+    seedProjectInBrowser,
+    getServerUrl,
+} from './helpers/projectFactory';
+import { waitForPreviewRender } from './helpers/previewExtraction';
+
+const PARA_COUNT = 35;
+
+/**
+ * Fixture shape (`format` is spliced in per test):
+ *
+ *   # Section one           ← source line 5 — gives `SectionizeTransform` a
+ *                              section to wrap the body in, so a `[data-loc]`
+ *                              lookup from anywhere in the document resolves
+ *                              to *something* (the hazard T4 guards against).
+ *   Paragraph 1.            ← source line 7
+ *   …
+ *   Paragraph 35.           ← source line 75 — the click target
+ *   ::: {style=6000px}      ← 6000px tall in the preview, 3 lines of source
+ *
+ * The trailing spacer decouples pixel position from line position: with the
+ * preview scrolled just far enough to show `Paragraph 35.` (a few hundred px),
+ * the preview's scroll ratio is ≈ 0.05 while that paragraph sits at ≈ 94% of
+ * the source. So *ratio* matching — the only preview→editor mechanism that
+ * exists today — provably cannot bring line 75 into the editor's viewport;
+ * only a `data-loc` based reveal can. Both preconditions are asserted, not
+ * assumed.
+ */
+function fixture(format: string | null): string {
+    const paras: string[] = [];
+    for (let i = 1; i <= PARA_COUNT; i++) paras.push(`Paragraph ${i}.`, '');
+    return [
+        '---',
+        ...(format ? [`format: ${format}`] : ['title: HTML preview control']),
+        '---',
+        '',
+        '# Section one',
+        '',
+        ...paras,
+        '::: {style="height: 6000px"}',
+        'Spacer.',
+        ':::',
+        '',
+    ].join('\n');
+}
+
+/** 1-based source line of `Paragraph n.` in the fixture above. */
+function paraLine(n: number): number {
+    return 5 + 2 * n;
+}
+
+const Q2_IFRAME = 'iframe[src*="q2-preview.html"]';
+const HTML_IFRAME = 'iframe.preview-active';
+
+async function openDoc(
+    page: Page,
+    format: string | null,
+    kind: 'q2-preview' | 'html',
+): Promise<void> {
+    const serverUrl = getServerUrl();
+    const docId = await createProjectOnServer(serverUrl, [
+        { path: '_quarto.yml', content: 'project:\n  type: default\n', contentType: 'text' },
+        { path: 'doc.qmd', content: fixture(format), contentType: 'text' },
+    ]);
+    await bootstrapProjectSet(page, serverUrl);
+    const localId = await seedProjectInBrowser(page, docId, serverUrl);
+    await page.goto(`/#/p/${localId}/file/doc.qmd`);
+    await waitForPreviewRender(page, { kind, timeout: 30000 });
+}
+
+/**
+ * Install a click-event recorder on the preview iframe's document — the exact
+ * event `Q2PreviewIframe` / `MorphIframe` listen for. Same-origin, so the host
+ * page can reach `contentDocument` (the q2-preview iframe is sandboxed
+ * `allow-same-origin` for precisely this reason).
+ */
+async function recordIframeDocClicks(page: Page, iframeSelector: string): Promise<void> {
+    await page.evaluate((sel) => {
+        const frame = document.querySelector(sel) as HTMLIFrameElement | null;
+        const doc = frame?.contentDocument;
+        if (!doc) throw new Error(`no contentDocument for ${sel}`);
+        (window as unknown as { __docClicks: string[] }).__docClicks = [];
+        doc.addEventListener('click', (e) => {
+            (window as unknown as { __docClicks: string[] }).__docClicks.push(
+                (e.target as Element).tagName,
+            );
+        });
+    }, iframeSelector);
+}
+
+async function readIframeDocClicks(page: Page): Promise<string[]> {
+    return page.evaluate(
+        () => (window as unknown as { __docClicks: string[] }).__docClicks,
+    );
+}
+
+/** One capture-phase `pointerup` observation recorded by {@link recordIframeDocPointerUps}. */
+interface PointerUpObservation {
+    /** Whether `e.target` was still attached to the document when observed. */
+    connected: boolean;
+    /** Raw `data-loc` of `e.target`'s nearest `[data-loc]` ancestor (`closest`), or null. */
+    dataLoc: string | null;
+}
+
+/**
+ * Install a CAPTURE-phase `pointerup` recorder on the preview iframe's
+ * document — the exact phase and event `Q2PreviewIframe`'s production
+ * listener uses (`lineForClickTarget`'s inputs). Unlike
+ * {@link recordIframeDocClicks}, this fires before q2-preview's bubble-phase
+ * block-activation handler can detach the clicked subtree, so it is expected
+ * to see the target still attached — that is the mechanism the fix relies on.
+ */
+async function recordIframeDocPointerUps(page: Page, iframeSelector: string): Promise<void> {
+    await page.evaluate((sel) => {
+        const frame = document.querySelector(sel) as HTMLIFrameElement | null;
+        const doc = frame?.contentDocument;
+        if (!doc) throw new Error(`no contentDocument for ${sel}`);
+        (window as unknown as { __docPointerUps: PointerUpObservation[] }).__docPointerUps = [];
+        doc.addEventListener(
+            'pointerup',
+            (e) => {
+                const target = e.target as Element;
+                (window as unknown as { __docPointerUps: PointerUpObservation[] }).__docPointerUps.push({
+                    connected: target.isConnected,
+                    dataLoc: target.closest('[data-loc]')?.getAttribute('data-loc') ?? null,
+                });
+            },
+            true,
+        );
+    }, iframeSelector);
+}
+
+async function readIframeDocPointerUps(page: Page): Promise<PointerUpObservation[]> {
+    return page.evaluate(
+        () => (window as unknown as { __docPointerUps: PointerUpObservation[] }).__docPointerUps,
+    );
+}
+
+/** Total source lines in the fixture (both formats have the same body). */
+const totalLines = fixture('q2-preview').split('\n').length;
+
+/**
+ * The preview iframe's scroll ratio, computed exactly as
+ * `scrollSyncDom.getIframeScrollRatio` does — this is the number the existing
+ * ratio-matching mechanism would feed to the editor.
+ */
+async function previewScrollRatio(page: Page): Promise<number> {
+    return page.evaluate((sel) => {
+        const frame = document.querySelector(sel) as HTMLIFrameElement | null;
+        const win = frame?.contentWindow;
+        const doc = frame?.contentDocument;
+        if (!win || !doc) throw new Error('preview iframe not ready');
+        const maxScroll = doc.documentElement.scrollHeight - win.innerHeight;
+        return maxScroll <= 0 ? 0 : win.scrollY / maxScroll;
+    }, 'iframe[src*="q2-preview.html"]');
+}
+
+/**
+ * The preview iframe's raw `scrollY`, in pixels. Sibling to
+ * {@link previewScrollRatio}: used to assert the preview does NOT move (a
+ * feedback-loop guard), where a ratio comparison would be too coarse.
+ */
+async function previewScrollY(page: Page): Promise<number> {
+    return page.evaluate((sel) => {
+        const frame = document.querySelector(sel) as HTMLIFrameElement | null;
+        const win = frame?.contentWindow;
+        if (!win) throw new Error('preview iframe not ready');
+        return win.scrollY;
+    }, Q2_IFRAME);
+}
+
+/**
+ * Text of the lines Monaco currently has rendered (i.e. what the user sees).
+ *
+ * **Monaco renders spaces as `\u00a0`.** Without the normalisation below,
+ * `innerText.includes('Paragraph 35.')` is `false` even when that line is
+ * visibly on screen — which would make every assertion here unsatisfiable
+ * (and the `not.toContain(...)` preconditions vacuously true). Verified in
+ * Chromium: `view-lines` innerText reports `hasNbsp: true`, and the slice
+ * around the match prints identically to a normal space.
+ */
+async function editorVisibleText(page: Page): Promise<string> {
+    const raw = await page.locator('.monaco-editor .view-lines').first().innerText();
+    return raw.replace(/\u00a0/g, ' ');
+}
+
+test.describe('preview→editor scroll sync on click (repro)', () => {
+    test.setTimeout(120000);
+
+    test.beforeEach(async ({ page }, testInfo) => {
+        if (testInfo.workerIndex > 0) await page.waitForTimeout(1000);
+        await page.addInitScript(() => {
+            localStorage.setItem('qh-view-mode', 'both');
+            localStorage.setItem('quarto-hub:preferences', JSON.stringify({
+                version: 1,
+                scrollSyncEnabled: true,
+                errorOverlayCollapsed: true,
+                colorScheme: 'auto',
+            }));
+        });
+    });
+
+    test('T1 (characterization) — activation delivers no click event, but a capture-phase pointerup sees the attached target', async ({ page }) => {
+        await openDoc(page, 'q2-preview', 'q2-preview');
+        const iframe = page.frameLocator(Q2_IFRAME);
+        await iframe.locator('[data-block-pool-id]').first().waitFor({ timeout: 15_000 });
+        await recordIframeDocClicks(page, Q2_IFRAME);
+        await recordIframeDocPointerUps(page, Q2_IFRAME);
+
+        // Click a paragraph → activation replaces its subtree with the edit region.
+        const target = iframe.locator('p[data-block-pool-id]').filter({ hasText: 'Paragraph 2.' }).first();
+        await target.click();
+        await iframe.locator('textarea').first().waitFor({ timeout: 5000 });
+
+        const afterActivation = await readIframeDocClicks(page);
+        const pointerUps = await readIframeDocPointerUps(page);
+
+        // Control: click again, now INSIDE the open edit region. `onPointerUp`
+        // bails on the active-region guard, no DOM swap, so the click survives.
+        await iframe.locator('textarea').first().click();
+        await page.waitForTimeout(200);
+        const afterInRegionClick = await readIframeDocClicks(page);
+
+        expect(
+            afterInRegionClick.length,
+            'a click that does NOT swap the DOM must reach the iframe document (listener is sound)',
+        ).toBeGreaterThan(afterActivation.length);
+
+        // Characterization, not a repro: Chromium really delivers no `click`
+        // when the `pointerup` target was detached from the document during
+        // `pointerup`. This is the mechanism the fix works around, not a
+        // defect this suite is trying to detect.
+        expect(
+            afterActivation,
+            'Chromium delivers no click event when the pointerup target was detached from the document',
+        ).toEqual([]);
+
+        // But the capture-phase `pointerup` the fix relies on DOES see the
+        // target still attached, with a resolvable `data-loc` — it runs
+        // before the bubble-phase activation handler detaches the subtree.
+        expect(pointerUps.length, 'expected at least one pointerup for the activation click').toBeGreaterThan(0);
+        expect(pointerUps[0].connected, 'capture-phase pointerup must see the target still attached').toBe(true);
+        expect(
+            pointerUps[0].dataLoc,
+            'capture-phase pointerup must see a parseable data-loc',
+        ).toMatch(/^\d+:\d+:\d+-\d+:\d+$/);
+    });
+
+    test('T2 — clicking a block does not scroll the editor to that block line', async ({ page }) => {
+        await openDoc(page, 'q2-preview', 'q2-preview');
+        const iframe = page.frameLocator(Q2_IFRAME);
+        await iframe.locator('[data-block-pool-id]').first().waitFor({ timeout: 15_000 });
+
+        const targetText = `Paragraph ${PARA_COUNT}.`;
+        const target = iframe.locator('p[data-block-pool-id]').filter({ hasText: targetText }).first();
+
+        // Bring the click target into the preview viewport. Thanks to the
+        // trailing 6000px spacer this is a small scroll — the preview's ratio
+        // stays near 0 while the target's source line is near the end.
+        await target.scrollIntoViewIfNeeded();
+        await page.waitForTimeout(600); // let any scroll-driven ratio sync settle
+
+        // Precondition A: the fixture really does decouple pixels from lines —
+        // the preview's scroll ratio is far below the target's source ratio, so
+        // ratio matching cannot satisfy the assertion below.
+        const ratio = await previewScrollRatio(page);
+        expect(ratio, 'precondition: preview scroll ratio is near the top').toBeLessThan(0.25);
+        expect(
+            paraLine(PARA_COUNT) / totalLines,
+            'precondition: the target line is near the end of the source',
+        ).toBeGreaterThan(0.9);
+
+        // Precondition B: the target line is off-screen in the editor.
+        const before = await editorVisibleText(page);
+        expect(before, 'precondition: the target line is off-screen in the editor').not.toContain(
+            targetText,
+        );
+
+        const scrollYBeforeClick = await previewScrollY(page);
+
+        await target.click();
+        await iframe.locator('textarea').first().waitFor({ timeout: 5000 });
+        await page.waitForTimeout(800); // debounce (50ms) + smooth scroll (300ms) + slack
+
+        const after = await editorVisibleText(page);
+        expect(
+            after,
+            'clicking a block should scroll the editor to a line inside that block',
+        ).toContain(targetText);
+
+        // No feedback loop: revealing a line in Monaco must not move its
+        // cursor in a way that fires onDidChangeCursorPosition, which would
+        // feed editor→preview sync and scroll the preview right back.
+        const scrollYAfterClick = await previewScrollY(page);
+        expect(
+            Math.abs(scrollYAfterClick - scrollYBeforeClick),
+            'the click must not trigger a reveal→cursor→scroll feedback loop that moves the preview',
+        ).toBeLessThanOrEqual(4);
+    });
+
+    test('T3 — control: the same click DOES reach the HTML preview document', async ({ page }) => {
+        await openDoc(page, null, 'html');
+        const iframe = page.frameLocator(HTML_IFRAME);
+        await iframe.locator('p').first().waitFor({ timeout: 15_000 });
+        await recordIframeDocClicks(page, HTML_IFRAME);
+
+        await iframe.locator('p').filter({ hasText: 'Paragraph 2.' }).first().click();
+        await page.waitForTimeout(300);
+
+        expect(
+            await readIframeDocClicks(page),
+            'HTML preview never swaps its DOM on click, so the click reaches the document',
+        ).not.toEqual([]);
+    });
+
+    test('T4 — a caret-move click inside the open editor must not move the editor', async ({ page }) => {
+        await openDoc(page, 'q2-preview', 'q2-preview');
+        const iframe = page.frameLocator(Q2_IFRAME);
+        await iframe.locator('[data-block-pool-id]').first().waitFor({ timeout: 15_000 });
+
+        // Open the editor on a LATE paragraph. Once a reveal exists (post-fix)
+        // this is what displaces the editor away from `# Section one` — the
+        // editor will be showing line ~75, not line 5.
+        const targetText = `Paragraph ${PARA_COUNT}.`;
+        const target = iframe.locator('p[data-block-pool-id]').filter({ hasText: targetText }).first();
+        await target.scrollIntoViewIfNeeded();
+        await target.click();
+        const textarea = iframe.locator('textarea').first();
+        await textarea.waitFor({ timeout: 5000 });
+        await page.waitForTimeout(800); // debounce (50ms) + smooth scroll (300ms) + slack, mirrors T2
+
+        const before = await editorVisibleText(page);
+
+        // A caret move WITHIN the block already being edited — not a click on
+        // a new block. This must land inside `#q2-active-edit-region`.
+        await textarea.click();
+        await page.waitForTimeout(300);
+
+        const after = await editorVisibleText(page);
+        expect(
+            after,
+            'a caret-move click inside the already-open editor must not move the editor',
+        ).toEqual(before);
+    });
+});

--- a/hub-client/e2e/q2-preview-click-to-editor-scroll.spec.ts
+++ b/hub-client/e2e/q2-preview-click-to-editor-scroll.spec.ts
@@ -52,6 +52,15 @@
  *                   revert: delete the active-region guard from
  *                   `lineForClickTarget` → RED (the editor jumps to the
  *                   wrapper's line).
+ * A1g (2026-08-22 plan) — click-to-ALIGN, not just reveal: the clicked
+ *                   block's on-screen y (before the click) and the target
+ *                   line's rendered y in Monaco (after the click settles)
+ *                   must agree within a stated tolerance. This is the only
+ *                   row in the suite that binds the two coordinate spaces
+ *                   (iframe viewport vs. host page) — jsdom has no layout,
+ *                   so nothing below this tier can catch a wrong iframe
+ *                   offset; see that row's own comment for the tolerance
+ *                   and why.
  *
  * Run via:
  *   cd hub-client && npx playwright test e2e/q2-preview-click-to-editor-scroll.spec.ts \
@@ -710,5 +719,64 @@ test.describe('preview→editor scroll sync on click', () => {
             ).toContain(targetText);
             await page.waitForTimeout(25);
         }
+    });
+
+    test('A1g — clicking a block aligns its source line to the same on-screen y, not merely reveals it', async ({ page }) => {
+        // Paragraph 20 sits at source line 45 of 80 (paraLine(20)), safely away
+        // from the document's start or end — the alignment clamp (plan's "near
+        // the start or end… the clamp wins") would otherwise mask a wrong
+        // unclamped computation by coincidentally landing at the same clamped
+        // bound regardless of hostY.
+        await openDoc(page, 'q2-preview', 'q2-preview');
+        const iframe = page.frameLocator(Q2_IFRAME);
+        await iframe.locator('[data-block-pool-id]').first().waitFor({ timeout: 15_000 });
+
+        const targetText = 'Paragraph 20.';
+        const target = iframe.locator('p[data-block-pool-id]').filter({ hasText: targetText }).first();
+        await target.scrollIntoViewIfNeeded();
+        await page.waitForTimeout(300); // let the scrollIntoView settle before measuring
+
+        // hostY: the clicked block's top edge in HOST-PAGE coordinates — exactly
+        // what Q2PreviewIframe's pointerup handler computes and passes as
+        // `onClickAtLine`'s second argument. Playwright's boundingBox() is
+        // already reported relative to the main frame's viewport (not the
+        // iframe's), so this is the same coordinate space without redoing the
+        // iframe-offset arithmetic by hand.
+        const blockBoxBeforeClick = await target.boundingBox();
+        expect(blockBoxBeforeClick, 'precondition: the clicked block must be measurable').not.toBeNull();
+        const hostY = blockBoxBeforeClick!.y;
+
+        await target.click();
+        await iframe.locator('textarea').first().waitFor({ timeout: 5000 });
+        // Debounce is not in play here (revealEditorLine is not debounced —
+        // U2d), but Monaco's own ScrollType.Smooth animation and the
+        // isSyncingRef suppression window both run for up to 300ms.
+        await page.waitForTimeout(600);
+
+        // The target line's rendered y in Monaco, in the same host-page
+        // coordinate space (Monaco lives directly in the host page, not in an
+        // iframe, so no offset arithmetic is needed here).
+        const monacoLine = page
+            .locator('.monaco-editor .view-lines .view-line')
+            .filter({ hasText: targetText })
+            .first();
+        await monacoLine.waitFor({ timeout: 5000 });
+        const lineBox = await monacoLine.boundingBox();
+        expect(lineBox, 'the target line must be rendered (in the DOM) after alignment').not.toBeNull();
+
+        // Tolerance: 6px. The computation is exact integer arithmetic
+        // (getTopForLineNumber - (hostY - editorTop)), but two independent
+        // boundingBox() reads and Monaco's own sub-pixel line positioning can
+        // each be off by a fraction of a pixel; 6px comfortably absorbs that
+        // without masking a real defect. A wrong iframe-coordinate-space
+        // computation (the bug this row exists to catch — see the plan's "two
+        // coordinate spaces" note) is off by a whole constant offset: the
+        // height of whatever chrome sits above the preview pane (tens to
+        // hundreds of px), an order of magnitude past this tolerance.
+        const ALIGNMENT_TOLERANCE_PX = 6;
+        expect(
+            Math.abs(lineBox!.y - hostY),
+            `clicked block's on-screen y (${hostY}) and the target line's rendered y in Monaco (${lineBox!.y}) must agree within ${ALIGNMENT_TOLERANCE_PX}px`,
+        ).toBeLessThanOrEqual(ALIGNMENT_TOLERANCE_PX);
     });
 });

--- a/hub-client/e2e/q2-preview-click-to-editor-scroll.spec.ts
+++ b/hub-client/e2e/q2-preview-click-to-editor-scroll.spec.ts
@@ -61,6 +61,14 @@
  *                   so nothing below this tier can catch a wrong iframe
  *                   offset; see that row's own comment for the tolerance
  *                   and why.
+ * P2a (2026-08-22 plan, Phase 2) — the HTML preview's own click-to-ALIGN
+ *                   (T3's control proves the HTML preview receives clicks
+ *                   at all; this proves what it does with them). Uses a
+ *                   dedicated fixture, `htmlAlignFixture()`, whose target
+ *                   paragraph wraps across several visual rows — the only
+ *                   way to prove `hostY` comes from the clicked SPAN, not
+ *                   the containing block, since a single-line paragraph
+ *                   (as in `fixture()`) can't tell the two apart.
  *
  * Run via:
  *   cd hub-client && npx playwright test e2e/q2-preview-click-to-editor-scroll.spec.ts \
@@ -270,6 +278,47 @@ function wrapperFixture(): string {
     ].join('\n');
 }
 
+/**
+ * P2a's own fixture (2026-08-22 plan, Phase 2) — a single long paragraph,
+ * all on ONE source line, with enough words to wrap across several visual
+ * lines in the HTML preview at the default viewport width.
+ *
+ * The wrap is the whole point: the HTML writer stamps `data-loc` on
+ * inlines, so each word gets its own `<span data-loc>`, all sharing the
+ * SAME source line (there is only one line of source). On `fixture()`'s
+ * own one-line-per-paragraph text this would be indistinguishable from
+ * measuring the containing `<p>` — a single-line block's own top coincides
+ * with any of its words' tops. Only a WRAPPED paragraph separates the two:
+ * a word near the end renders several line-heights below the block's own
+ * top, so a wrong implementation that measured the `<p>` instead of the
+ * clicked span would land the editor at the wrong on-screen y by a
+ * detectable amount, not just be off by the sub-pixel noise A1g's
+ * tolerance already absorbs.
+ */
+function htmlAlignFixture(): string {
+    // Filler before AND after the target paragraph, mirroring wrapperFixture()'s
+    // reasoning: enough total content that the editor actually has scroll
+    // range (with only the target paragraph, `getScrollHeight() -
+    // getLayoutInfo().height` could be ≤ 0, and revealEditorLine's clamp would
+    // force scrollTop to 0 regardless of hostY — vacuous, same trap A1g's own
+    // "paragraph 20 of 80" choice avoids), and positioned away from either end
+    // so the clamp can't coincidentally mask a wrong computation.
+    const filler: string[] = [];
+    for (let i = 1; i <= 30; i++) filler.push(`Filler paragraph ${i}.`, '');
+    const words: string[] = [];
+    for (let i = 1; i <= 40; i++) words.push(`word${i}`);
+    return [
+        '---',
+        'title: "P2a — HTML preview alignment anchors on the clicked span, not the block"',
+        '---',
+        '',
+        ...filler,
+        words.join(' ') + '.',
+        '',
+        ...filler,
+    ].join('\n');
+}
+
 /** 1-based source line of `Paragraph n.` in the fixture above. */
 function paraLine(n: number): number {
     return 5 + 2 * n;
@@ -308,6 +357,22 @@ async function openDocWithContent(page: Page, content: string): Promise<void> {
     const localId = await seedProjectInBrowser(page, docId, serverUrl);
     await page.goto(`/#/p/${localId}/file/doc.qmd`);
     await waitForPreviewRender(page, { kind: 'q2-preview', timeout: 30000 });
+}
+
+/**
+ * Like {@link openDocWithContent}, but waits on the HTML preview's own
+ * readiness signal instead of q2-preview's (P2a's `htmlAlignFixture()`).
+ */
+async function openHtmlDocWithContent(page: Page, content: string): Promise<void> {
+    const serverUrl = getServerUrl();
+    const docId = await createProjectOnServer(serverUrl, [
+        { path: '_quarto.yml', content: 'project:\n  type: default\n', contentType: 'text' },
+        { path: 'doc.qmd', content, contentType: 'text' },
+    ]);
+    await bootstrapProjectSet(page, serverUrl);
+    const localId = await seedProjectInBrowser(page, docId, serverUrl);
+    await page.goto(`/#/p/${localId}/file/doc.qmd`);
+    await waitForPreviewRender(page, { kind: 'html', timeout: 30000 });
 }
 
 /**
@@ -777,6 +842,70 @@ test.describe('preview→editor scroll sync on click', () => {
         expect(
             Math.abs(lineBox!.y - hostY),
             `clicked block's on-screen y (${hostY}) and the target line's rendered y in Monaco (${lineBox!.y}) must agree within ${ALIGNMENT_TOLERANCE_PX}px`,
+        ).toBeLessThanOrEqual(ALIGNMENT_TOLERANCE_PX);
+    });
+
+    test('P2a — clicking a word in the HTML preview aligns it to the same on-screen y as that SPECIFIC word, not the containing block', async ({ page }) => {
+        // htmlAlignFixture()'s target paragraph wraps across several visual
+        // rows in the preview; word40 (its last word) renders well below the
+        // paragraph's own <p> top. hostY is measured from word40 itself — the
+        // only way to discriminate "hostY comes from the clicked SPAN" (this
+        // phase's decision) from a wrong implementation that used the
+        // containing block's rect instead, which fixture()'s one-line
+        // paragraphs (T1-T5, A1g) cannot: a single-line block's own top
+        // coincides with any of its words' tops, so that mistake would pass
+        // there by coincidence.
+        await openHtmlDocWithContent(page, htmlAlignFixture());
+        const iframe = page.frameLocator(HTML_IFRAME);
+        await iframe.locator('p').first().waitFor({ timeout: 15_000 });
+
+        const targetWord = iframe.locator('span').filter({ hasText: /^word40\.$/ }).first();
+        await targetWord.scrollIntoViewIfNeeded();
+        await page.waitForTimeout(300);
+
+        const wordBox = await targetWord.boundingBox();
+        expect(wordBox, 'precondition: the clicked word must be measurable').not.toBeNull();
+        const hostY = wordBox!.y;
+
+        const blockBox = await iframe
+            .locator('p')
+            .filter({ hasText: 'word1 word2' })
+            .first()
+            .boundingBox();
+        expect(blockBox, 'precondition: the target paragraph must be measurable').not.toBeNull();
+        expect(
+            hostY - blockBox!.y,
+            "precondition: word40 must render well below the paragraph's own top — i.e. the paragraph must actually wrap in the preview. If this fails, the fixture stopped wrapping (viewport width changed?) and this row can no longer tell a span-anchored hostY from a block-anchored one.",
+        ).toBeGreaterThan(20);
+
+        await targetWord.click();
+        // handlePreviewSelection is not debounced, but Monaco's own smooth
+        // scroll animation and the isSyncingRef suppression window both run
+        // for up to 300ms (mirrors A1g's own wait).
+        await page.waitForTimeout(600);
+
+        // The row `revealEditorLine` actually positions is the target model
+        // line's FIRST rendered row (`getTopForLineNumber` — alignment is
+        // line-granular, not column-granular), regardless of which word in
+        // that line was clicked or how the PREVIEW happened to wrap it. So
+        // the row to measure in Monaco is the one starting the paragraph
+        // (word1), not one containing word40 — word40 only supplies hostY.
+        // `\s` (not a literal ASCII space) — Monaco renders spaces as
+        // U+00A0 non-breaking space, which `\s` matches but a literal
+        // `' '` in the regex would not (see editorVisibleText()'s doc
+        // comment on the same gotcha).
+        const firstRow = page
+            .locator('.monaco-editor .view-lines .view-line')
+            .filter({ hasText: /^word1\s/ })
+            .first();
+        await firstRow.waitFor({ timeout: 5000 });
+        const lineBox = await firstRow.boundingBox();
+        expect(lineBox, 'the target line must be rendered (in the DOM) after alignment').not.toBeNull();
+
+        const ALIGNMENT_TOLERANCE_PX = 6;
+        expect(
+            Math.abs(lineBox!.y - hostY),
+            `word40's on-screen y (${hostY}) and the target line's rendered y in Monaco (${lineBox!.y}) must agree within ${ALIGNMENT_TOLERANCE_PX}px`,
         ).toBeLessThanOrEqual(ALIGNMENT_TOLERANCE_PX);
     });
 });

--- a/hub-client/src/components/render/Preview.tsx
+++ b/hub-client/src/components/render/Preview.tsx
@@ -250,7 +250,7 @@ export default function Preview({
   );
 
   // Scroll synchronization between editor and preview
-  const { handlePreviewScroll, handlePreviewClick } = useScrollSync({
+  const { handlePreviewScroll, handlePreviewClick, revealEditorLine } = useScrollSync({
     editorRef,
     scrollPreviewToLine: (line: number) => {
       doubleBufferedIframeRef.current?.scrollToLine(line);
@@ -262,11 +262,17 @@ export default function Preview({
     editorHasFocusRef,
   });
 
-  // Selection synchronization between preview and editor
+  // Selection synchronization between preview and editor. Threads
+  // `revealEditorLine` from the `useScrollSync` call above (2026-08-22
+  // click-align-editor-y plan, Phase 2, decision A7) rather than
+  // re-implementing the alignment arithmetic here — that keeps the reveal
+  // bracketed by `useScrollSync`'s own `isSyncingRef`, the flag its
+  // ratio-sync overwrite-race guard actually reads.
   const { handlePreviewSelection } = useSelectionSync({
     editorRef,
     previewRef: doubleBufferedIframeRef,
     enabled: scrollSyncEnabled && editorReady,
+    revealEditorLine,
   });
 
   // Set scroll sync via runtime metadata when the prop changes

--- a/hub-client/src/components/render/ReactPreview.tsx
+++ b/hub-client/src/components/render/ReactPreview.tsx
@@ -522,12 +522,18 @@ export default function ReactPreview({
 
   // Scroll sync (editor ↔ preview). Mirrors `Preview.tsx`: the q2-preview
   // iframe exposes `scrollToLine` / `getScrollRatio` via this handle, and
-  // forwards its own scroll/click events through `handlePreviewScroll` /
-  // `handlePreviewClick`. Only the q2-preview format wires this; other
-  // React formats (q2-debug, slides) leave the handle unattached.
+  // forwards its own scroll event through `handlePreviewScroll`. Preview→
+  // editor clicks use `revealEditorLine` instead of `handlePreviewClick`'s
+  // scroll-ratio path (click-to-editor-scroll, D1/D3): q2-preview's click
+  // opens an inline editor in the preview itself, so this is a plain
+  // scroll-into-view keyed off `data-loc`, not a focus-gated ratio match.
+  // `handlePreviewClick` stays in `useScrollSync` for the HTML preview
+  // (`Preview.tsx`), which keeps wiring it unchanged. Only the q2-preview
+  // format wires this hook at all; other React formats (q2-debug, slides)
+  // leave the handle unattached.
   const previewScrollRef = useRef<Q2PreviewIframeHandle>(null);
 
-  const { handlePreviewScroll, handlePreviewClick, handleAstRendered, scrollToLineDeferred } = useScrollSync({
+  const { handlePreviewScroll, revealEditorLine, handleAstRendered, scrollToLineDeferred } = useScrollSync({
     editorRef,
     scrollPreviewToLine: (line: number) => {
       previewScrollRef.current?.scrollToLine(line);
@@ -872,7 +878,7 @@ export default function ReactPreview({
             nestedEditBuffers={nestedEditBuffers}
             scrollHandleRef={previewScrollRef}
             onPreviewScroll={handlePreviewScroll}
-            onPreviewClick={handlePreviewClick}
+            onPreviewClickAtLine={revealEditorLine}
             onAstRendered={handleAstRendered}
           />
         ) : previewState === 'ERROR_AT_START' && currentError ? (

--- a/hub-client/src/components/render/ReactRenderer.tsx
+++ b/hub-client/src/components/render/ReactRenderer.tsx
@@ -139,8 +139,10 @@ interface ReactRendererProps {
    * Preview→editor click sync (click-to-editor-scroll): called with the
    * resolved source line when a click in the preview resolves one via
    * `lineForClickTarget`. Forwarded to `Q2PreviewIframe` as `onClickAtLine`.
+   * The second argument, `hostY`, is the clicked block's top edge in
+   * host-page coordinates, used to align (not just reveal) the line.
    */
-  onPreviewClickAtLine?: (line: number) => void;
+  onPreviewClickAtLine?: (line: number, hostY?: number) => void;
   onAstRendered?: () => void;
 }
 

--- a/hub-client/src/components/render/ReactRenderer.tsx
+++ b/hub-client/src/components/render/ReactRenderer.tsx
@@ -135,7 +135,12 @@ interface ReactRendererProps {
    */
   scrollHandleRef?: Ref<Q2PreviewIframeHandle>;
   onPreviewScroll?: () => void;
-  onPreviewClick?: () => void;
+  /**
+   * Preview→editor click sync (click-to-editor-scroll): called with the
+   * resolved source line when a click in the preview resolves one via
+   * `lineForClickTarget`. Forwarded to `Q2PreviewIframe` as `onClickAtLine`.
+   */
+  onPreviewClickAtLine?: (line: number) => void;
   onAstRendered?: () => void;
 }
 
@@ -165,7 +170,7 @@ function ReactRenderer({
   nestedEditBuffers,
   scrollHandleRef,
   onPreviewScroll,
-  onPreviewClick,
+  onPreviewClickAtLine,
   onAstRendered,
 }: ReactRendererProps) {
   // Stable wrappers for Q2PreviewIframe props that are useEffect dependencies.
@@ -334,7 +339,7 @@ function ReactRenderer({
             onSlideChange={onSlideChange}
             scrollHandleRef={scrollHandleRef}
             onScroll={onPreviewScroll}
-            onClick={onPreviewClick}
+            onClickAtLine={onPreviewClickAtLine}
             onAstRendered={onAstRendered}
           />
         </div>

--- a/hub-client/src/hooks/useScrollSync.test.ts
+++ b/hub-client/src/hooks/useScrollSync.test.ts
@@ -205,6 +205,55 @@ describe('useScrollSync revealEditorLine (RED — pinned API, Phase 2 not yet im
 });
 
 /**
+ * U2e — Task 9: `revealEditorLine` must suppress the pre-existing
+ * preview→editor ratio sync for a short window after a reveal, the same way
+ * `flushPendingScroll` / `syncPreviewToEditor` already suppress each other's
+ * echo. Without this, a real (even tiny) `scroll` event on the preview within
+ * ~50ms of the click reaches `syncPreviewToEditor` unguarded and overwrites
+ * the just-completed, correct reveal with a position derived from the
+ * preview's raw scroll ratio — see
+ * `.superpowers/sdd/2026-08-21-preview-click-to-editor-scroll/task-8-report.md`.
+ */
+describe('useScrollSync revealEditorLine suppresses the ratio-sync echo (Task 9)', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('U2e: a preview scroll within the suppression window does not overwrite the reveal, and the window is time-bounded', () => {
+    const { result, editor } = setup({ line: 1, focus: false });
+
+    act(() => {
+      result.current.revealEditorLine(73);
+    });
+    // The reveal itself still happens synchronously — a fix that made
+    // revealEditorLine a no-op would satisfy the assertions below vacuously.
+    expect(editor.revealLineInCenterIfOutsideViewport).toHaveBeenCalledExactlyOnceWith(73);
+
+    // A scroll event arriving within the suppression window (today: 50ms
+    // debounce, then unguarded) must not echo through and overwrite the
+    // reveal.
+    act(() => {
+      result.current.handlePreviewScroll();
+      vi.advanceTimersByTime(50);
+    });
+    expect(editor.setScrollTop).not.toHaveBeenCalled();
+
+    // The suppression must be time-bounded, not permanent — otherwise a fix
+    // that disabled ratio sync forever would satisfy the row above while
+    // breaking the HTML preview path (U4) in production. Advance past the
+    // 300ms window, then a fresh preview scroll must resume ratio sync as
+    // normal.
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    act(() => {
+      result.current.handlePreviewScroll();
+      vi.advanceTimersByTime(50);
+    });
+    expect(editor.setScrollTop).toHaveBeenCalledExactlyOnceWith(300, 1);
+  });
+});
+
+/**
  * U4 — regression cover for the pre-existing preview→editor ratio path
  * (`syncPreviewToEditor`, reached via `handlePreviewScroll`). Nothing in the
  * suite exercised this before; the upcoming revealEditorLine refactor touches

--- a/hub-client/src/hooks/useScrollSync.test.ts
+++ b/hub-client/src/hooks/useScrollSync.test.ts
@@ -29,6 +29,10 @@ function makeEditor(line: number) {
     getScrollHeight: () => 1000,
     getLayoutInfo: () => ({ height: 400 }),
     setScrollTop: vi.fn(),
+    revealLineInCenterIfOutsideViewport: vi.fn(),
+    setPosition: vi.fn(),
+    setSelection: vi.fn(),
+    focus: vi.fn(),
     onDidChangeCursorPosition: (cb: () => void) => {
       cursorCb = cb;
       return { dispose: vi.fn() };
@@ -63,7 +67,7 @@ function setup(opts: { line: number; focus: boolean; deferToRender?: boolean }) 
     }),
   );
 
-  return { result, scrollPreviewToLine, fireCursorChange, fireContentChange, editorHasFocusRef };
+  return { result, scrollPreviewToLine, fireCursorChange, fireContentChange, editorHasFocusRef, editor };
 }
 
 describe('useScrollSync deferred editor→preview scroll', () => {
@@ -129,5 +133,106 @@ describe('useScrollSync deferred editor→preview scroll', () => {
       setup({ line: 20, focus: true, deferToRender: false });
     act(() => { fireCursorChange(); vi.advanceTimersByTime(50); });
     expect(scrollPreviewToLine).toHaveBeenCalledExactlyOnceWith(20);
+  });
+});
+
+/**
+ * `revealEditorLine` (pinned API, not yet implemented — see Phase 2 of
+ * claude-notes/plans/2026-08-21-preview-click-to-editor-scroll.md).
+ *
+ * Preview→editor click reveal, deliberately narrower than the existing
+ * `useSelectionSync` preview→editor sync: in q2-preview the click opens an
+ * inline editor *inside* the preview, so pulling focus to Monaco (what
+ * `setSelection` + `revealRangeInCenter` + `focus()` do) would break the
+ * gesture the same click just started. `revealEditorLine` must call
+ * `editor.revealLineInCenterIfOutsideViewport(line)` and nothing else: no
+ * `setPosition` (which would also fire `onDidChangeCursorPosition` and
+ * bounce back into editor→preview sync), no `setSelection`, no `focus()`,
+ * no debounce, no focus gate.
+ *
+ * `result.current.revealEditorLine` does not exist yet, so every row in this
+ * block is expected to fail with "is not a function" until Phase 2 adds it.
+ * These rows are frozen once green (G2 in the task brief): Phase 2 must make
+ * them pass by writing `revealEditorLine`, never by editing these assertions.
+ */
+describe('useScrollSync revealEditorLine (RED — pinned API, Phase 2 not yet implemented)', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('U2a: calls revealLineInCenterIfOutsideViewport with the given line', () => {
+    const { result, editor } = setup({ line: 1, focus: false });
+    act(() => {
+      result.current.revealEditorLine(73);
+    });
+    expect(editor.revealLineInCenterIfOutsideViewport).toHaveBeenCalledExactlyOnceWith(73);
+  });
+
+  it('U2b: never moves the cursor, changes the selection, or steals focus', () => {
+    const { result, editor } = setup({ line: 1, focus: false });
+    act(() => {
+      result.current.revealEditorLine(73);
+    });
+    expect(editor.setPosition).not.toHaveBeenCalled();
+    expect(editor.setSelection).not.toHaveBeenCalled();
+    expect(editor.focus).not.toHaveBeenCalled();
+  });
+
+  it('U2c: still reveals when the editor has focus (not routed through the focus-gated syncPreviewToEditor)', () => {
+    // focus: true is the point of this row. syncPreviewToEditor's first
+    // statement is `if (... || editorHasFocusRef.current) return` — an
+    // implementation that (wrongly) delegates revealEditorLine to that
+    // function would silently no-op here. With the convenient focus: false
+    // default this row would pass even for that broken implementation.
+    const { result, editor } = setup({ line: 1, focus: true });
+    act(() => {
+      result.current.revealEditorLine(73);
+    });
+    expect(editor.revealLineInCenterIfOutsideViewport).toHaveBeenCalledExactlyOnceWith(73);
+  });
+
+  it('U2d: reveals immediately, with no debounce', () => {
+    // Deliberately no vi.advanceTimersByTime anywhere in this test. The
+    // suite runs under vi.useFakeTimers(), so an implementation that wraps
+    // the reveal in the existing 50ms editorDebounceRef timer would leave
+    // this assertion unmet until a timer advance — asserting before any
+    // advance is what discriminates a debounced call from an immediate one.
+    const { result, editor } = setup({ line: 1, focus: false });
+    act(() => {
+      result.current.revealEditorLine(73);
+    });
+    expect(editor.revealLineInCenterIfOutsideViewport).toHaveBeenCalledExactlyOnceWith(73);
+  });
+});
+
+/**
+ * U4 — regression cover for the pre-existing preview→editor ratio path
+ * (`syncPreviewToEditor`, reached via `handlePreviewScroll`). Nothing in the
+ * suite exercised this before; the upcoming revealEditorLine refactor touches
+ * this function's neighbourhood and could silently delete its body.
+ */
+describe('useScrollSync handlePreviewScroll (pre-existing preview→editor ratio path)', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('U4: applies the preview scroll ratio to the editor scrollTop, smoothly, when unfocused', () => {
+    const { result, editor } = setup({ line: 1, focus: false });
+    act(() => {
+      result.current.handlePreviewScroll();
+      vi.advanceTimersByTime(50);
+    });
+    // getPreviewScrollRatio() fakes 0.5; getScrollHeight() is 1000 and
+    // getLayoutInfo().height is 400, so 0.5 * (1000 - 400) = 300. The `1` is
+    // Monaco's ScrollType.Smooth — a bare toHaveBeenCalledWith(300) would
+    // pass on a call with no second argument at all, so assert both.
+    expect(editor.setScrollTop).toHaveBeenCalledExactlyOnceWith(300, 1);
+  });
+
+  it('U4: does not scroll the editor when it has focus (feedback-loop guard)', () => {
+    const { result, editor } = setup({ line: 1, focus: true });
+    act(() => {
+      result.current.handlePreviewScroll();
+      vi.advanceTimersByTime(50);
+    });
+    expect(editor.setScrollTop).not.toHaveBeenCalled();
   });
 });

--- a/hub-client/src/hooks/useScrollSync.test.ts
+++ b/hub-client/src/hooks/useScrollSync.test.ts
@@ -21,13 +21,31 @@ import { useScrollSync } from './useScrollSync';
 // Matches RENDER_SETTLE_TIMEOUT_MS in useScrollSync.
 const RENDER_SETTLE_TIMEOUT_MS = 1000;
 
-function makeEditor(line: number) {
+/**
+ * `topForLine`/`editorTop` back `getTopForLineNumber`/`getDomNode`, which
+ * `revealEditorLine`'s alignment computation reads (see the "alignment
+ * computation" section of claude-notes/plans/2026-08-22-click-align-editor-y.md).
+ * Both default to 0 for tests that don't exercise the alignment arithmetic
+ * (the pre-existing suites above, and U2b which only checks setPosition /
+ * setSelection / focus).
+ */
+function makeEditor(
+  line: number,
+  opts: { topForLine?: number; editorTop?: number } = {},
+) {
   let cursorCb: () => void = () => {};
   let contentCb: () => void = () => {};
   const editor = {
     getPosition: () => ({ lineNumber: line, column: 1 }),
     getScrollHeight: () => 1000,
     getLayoutInfo: () => ({ height: 400 }),
+    getTopForLineNumber: vi.fn(() => opts.topForLine ?? 0),
+    getDomNode: vi.fn(
+      () =>
+        ({
+          getBoundingClientRect: () => ({ top: opts.editorTop ?? 0 }),
+        }) as unknown as HTMLElement,
+    ),
     setScrollTop: vi.fn(),
     revealLineInCenterIfOutsideViewport: vi.fn(),
     setPosition: vi.fn(),
@@ -49,8 +67,15 @@ function makeEditor(line: number) {
   };
 }
 
-function setup(opts: { line: number; focus: boolean; deferToRender?: boolean }) {
-  const { editor, fireCursorChange, fireContentChange } = makeEditor(opts.line);
+function setup(opts: {
+  line: number;
+  focus: boolean;
+  deferToRender?: boolean;
+  topForLine?: number;
+  editorTop?: number;
+  enabled?: boolean;
+}) {
+  const { editor, fireCursorChange, fireContentChange } = makeEditor(opts.line, opts);
   const editorRef = { current: editor } as RefObject<Monaco.editor.IStandaloneCodeEditor | null>;
   const editorHasFocusRef = { current: opts.focus } as RefObject<boolean>;
   const scrollPreviewToLine = vi.fn();
@@ -61,7 +86,7 @@ function setup(opts: { line: number; focus: boolean; deferToRender?: boolean }) 
       editorRef,
       scrollPreviewToLine,
       getPreviewScrollRatio,
-      enabled: true,
+      enabled: opts.enabled ?? true,
       editorHasFocusRef,
       deferToRender: opts.deferToRender ?? true,
     }),
@@ -137,34 +162,93 @@ describe('useScrollSync deferred editor→preview scroll', () => {
 });
 
 /**
- * `revealEditorLine` (pinned API, not yet implemented — see Phase 2 of
- * claude-notes/plans/2026-08-21-preview-click-to-editor-scroll.md).
+ * `revealEditorLine` — Phase 1 of
+ * claude-notes/plans/2026-08-22-click-align-editor-y.md: top/aligns the
+ * clicked block's source line to the same on-screen y as the clicked block
+ * (`hostY`), rather than centring it. See that plan's "alignment
+ * computation" section for the arithmetic these rows pin:
  *
- * Preview→editor click reveal, deliberately narrower than the existing
- * `useSelectionSync` preview→editor sync: in q2-preview the click opens an
- * inline editor *inside* the preview, so pulling focus to Monaco (what
- * `setSelection` + `revealRangeInCenter` + `focus()` do) would break the
- * gesture the same click just started. `revealEditorLine` must call
- * `editor.revealLineInCenterIfOutsideViewport(line)` and nothing else: no
- * `setPosition` (which would also fire `onDidChangeCursorPosition` and
- * bounce back into editor→preview sync), no `setSelection`, no `focus()`,
- * no debounce, no focus gate.
+ *   scrollTop = getTopForLineNumber(line) - (hostY - editorTop)
+ *               where editorTop = getDomNode().getBoundingClientRect().top
  *
- * `result.current.revealEditorLine` does not exist yet, so every row in this
- * block is expected to fail with "is not a function" until Phase 2 adds it.
- * These rows are frozen once green (G2 in the task brief): Phase 2 must make
- * them pass by writing `revealEditorLine`, never by editing these assertions.
+ * clamped to [0, getScrollHeight() - getLayoutInfo().height]. `hostY`
+ * omitted ⇒ top-align (decision A3). Still deliberately narrow, per the
+ * original click-to-editor-scroll plan this builds on: no `setPosition`
+ * (would fire `onDidChangeCursorPosition` and bounce back into
+ * editor→preview sync), no `setSelection`, no `focus()`, no debounce, no
+ * focus gate — pulling focus to Monaco would break the inline-edit gesture
+ * the same click just started in q2-preview.
+ *
+ * A1a-e supersede the old U2a ("calls revealLineInCenterIfOutsideViewport
+ * with the given line") — that method is no longer called at all (A1e).
+ * U2b is unchanged (its assertions never touched that method). U2c/U2d/U2e
+ * originally also asserted `revealLineInCenterIfOutsideViewport` was called
+ * — the same now-retired premise as U2a, just not flagged when U2a was
+ * named the sole exception. Rewritten here to assert `setScrollTop` instead,
+ * preserving each row's actual behavioral intent (reveals despite editor
+ * focus / immediately, without a debounce / suppresses the ratio-sync echo)
+ * — see the 2026-08-22 plan handoff notes for why.
  */
-describe('useScrollSync revealEditorLine (RED — pinned API, Phase 2 not yet implemented)', () => {
+describe('useScrollSync revealEditorLine (align, not centre — Phase 1)', () => {
   beforeEach(() => vi.useFakeTimers());
   afterEach(() => vi.useRealTimers());
 
-  it('U2a: calls revealLineInCenterIfOutsideViewport with the given line', () => {
-    const { result, editor } = setup({ line: 1, focus: false });
+  it('A1a: revealEditorLine(line, hostY) computes exact scrollTop = topForLine - (hostY - editorTop)', () => {
+    // topForLine=400, editorTop=80, hostY=200 → 400 - (200 - 80) = 280,
+    // comfortably inside [0, 600] (getScrollHeight 1000 - getLayoutInfo 400)
+    // so the clamp cannot be masking a wrong unclamped value. 280 is also
+    // deliberately NOT 300 — the value `syncPreviewToEditor`'s ratio path
+    // would produce from this harness's fixed 0.5 ratio over the same
+    // 1000/400 editor (0.5 * (1000 - 400) = 300, see U4). An implementation
+    // that wrongly routed revealEditorLine through the ratio path would
+    // otherwise pass this row by coincidence.
+    //
+    // Because `getPreviewScrollRatio` is fixed at 0.5 and the fake editor's
+    // geometry is fixed at 1000/400 everywhere in this file, 300 is the
+    // ONLY value any row in this describe block must avoid landing on by
+    // coincidence — this collision risk is silent until someone changes the
+    // fake's geometry or ratio, so re-check it then.
+    const { result, editor } = setup({ line: 1, focus: false, topForLine: 400, editorTop: 80 });
     act(() => {
-      result.current.revealEditorLine(73);
+      result.current.revealEditorLine(73, 200);
     });
-    expect(editor.revealLineInCenterIfOutsideViewport).toHaveBeenCalledExactlyOnceWith(73);
+    expect(editor.setScrollTop).toHaveBeenCalledExactlyOnceWith(280, 1);
+  });
+
+  it('A1b: clamps to 0 when the computation goes negative', () => {
+    // Block near the top of the document (topForLine=100), pane low on
+    // screen (hostY=500) → 100 - (500 - 50) = -350, clamped to 0.
+    const { result, editor } = setup({ line: 1, focus: false, topForLine: 100, editorTop: 50 });
+    act(() => {
+      result.current.revealEditorLine(3, 500);
+    });
+    expect(editor.setScrollTop).toHaveBeenCalledExactlyOnceWith(0, 1);
+  });
+
+  it('A1c: clamps to getScrollHeight() - getLayoutInfo().height at the upper bound', () => {
+    // topForLine=2000, hostY=editorTop=50 → desired 2000, but max scroll is
+    // 1000 - 400 = 600.
+    const { result, editor } = setup({ line: 1, focus: false, topForLine: 2000, editorTop: 50 });
+    act(() => {
+      result.current.revealEditorLine(99, 50);
+    });
+    expect(editor.setScrollTop).toHaveBeenCalledExactlyOnceWith(600, 1);
+  });
+
+  it('A1d: hostY omitted falls back to top-aligning the line (setScrollTop(topForLine, 1))', () => {
+    const { result, editor } = setup({ line: 1, focus: false, topForLine: 222 });
+    act(() => {
+      result.current.revealEditorLine(50);
+    });
+    expect(editor.setScrollTop).toHaveBeenCalledExactlyOnceWith(222, 1);
+  });
+
+  it('A1e: never calls revealLineInCenterIfOutsideViewport (replaces U2a — centring is gone, not just no-longer-asserted)', () => {
+    const { result, editor } = setup({ line: 1, focus: false, topForLine: 100, editorTop: 0 });
+    act(() => {
+      result.current.revealEditorLine(73, 50);
+    });
+    expect(editor.revealLineInCenterIfOutsideViewport).not.toHaveBeenCalled();
   });
 
   it('U2b: never moves the cursor, changes the selection, or steals focus', () => {
@@ -183,11 +267,11 @@ describe('useScrollSync revealEditorLine (RED — pinned API, Phase 2 not yet im
     // implementation that (wrongly) delegates revealEditorLine to that
     // function would silently no-op here. With the convenient focus: false
     // default this row would pass even for that broken implementation.
-    const { result, editor } = setup({ line: 1, focus: true });
+    const { result, editor } = setup({ line: 1, focus: true, topForLine: 100, editorTop: 0 });
     act(() => {
-      result.current.revealEditorLine(73);
+      result.current.revealEditorLine(73, 50);
     });
-    expect(editor.revealLineInCenterIfOutsideViewport).toHaveBeenCalledExactlyOnceWith(73);
+    expect(editor.setScrollTop).toHaveBeenCalledExactlyOnceWith(50, 1);
   });
 
   it('U2d: reveals immediately, with no debounce', () => {
@@ -196,11 +280,35 @@ describe('useScrollSync revealEditorLine (RED — pinned API, Phase 2 not yet im
     // the reveal in the existing 50ms editorDebounceRef timer would leave
     // this assertion unmet until a timer advance — asserting before any
     // advance is what discriminates a debounced call from an immediate one.
-    const { result, editor } = setup({ line: 1, focus: false });
+    const { result, editor } = setup({ line: 1, focus: false, topForLine: 100, editorTop: 0 });
     act(() => {
-      result.current.revealEditorLine(73);
+      result.current.revealEditorLine(73, 50);
     });
-    expect(editor.revealLineInCenterIfOutsideViewport).toHaveBeenCalledExactlyOnceWith(73);
+    expect(editor.setScrollTop).toHaveBeenCalledExactlyOnceWith(50, 1);
+  });
+
+  it('A1h: still aligns when scroll-sync is disabled (enabled: false) — decision A6', () => {
+    // revealEditorLine has no enabledRef check at all, unlike
+    // syncPreviewToEditor / flushPendingScroll / scrollToLineDeferred, which
+    // all gate on `enabled`. That started as an accident but is now a
+    // deliberate decision (A6, 2026-08-22 plan): with the scroll-sync toggle
+    // off, click-align is the ONLY scroll coupling left in either direction —
+    // which is how the feature is best evaluated, and how a user actually
+    // relies on it. This row is load-bearing, not a formality: adding an
+    // enabledRef gate here looks like a plausible "consistency" fix (every
+    // other scroll path in this file has one), and this is the only row that
+    // would catch it — see the fail-on-revert probe in the phase report.
+    const { result, editor } = setup({
+      line: 1,
+      focus: false,
+      enabled: false,
+      topForLine: 100,
+      editorTop: 0,
+    });
+    act(() => {
+      result.current.revealEditorLine(73, 50);
+    });
+    expect(editor.setScrollTop).toHaveBeenCalledExactlyOnceWith(50, 1);
   });
 });
 
@@ -213,35 +321,41 @@ describe('useScrollSync revealEditorLine (RED — pinned API, Phase 2 not yet im
  * the just-completed, correct reveal with a position derived from the
  * preview's raw scroll ratio — see
  * `.superpowers/sdd/2026-08-21-preview-click-to-editor-scroll/task-8-report.md`.
+ *
+ * Rewritten for Phase 1 (2026-08-22 plan): the reveal itself now calls
+ * `setScrollTop`, not `revealLineInCenterIfOutsideViewport`, so "the
+ * suppressed scroll didn't overwrite the reveal" is asserted as "still only
+ * one `setScrollTop` call", not "no `setScrollTop` call at all" (that would
+ * be wrong now — the reveal's own call already happened).
  */
 describe('useScrollSync revealEditorLine suppresses the ratio-sync echo (Task 9)', () => {
   beforeEach(() => vi.useFakeTimers());
   afterEach(() => vi.useRealTimers());
 
   it('U2e: a preview scroll within the suppression window does not overwrite the reveal, and the window is time-bounded', () => {
-    const { result, editor } = setup({ line: 1, focus: false });
+    const { result, editor } = setup({ line: 1, focus: false, topForLine: 100, editorTop: 0 });
 
     act(() => {
-      result.current.revealEditorLine(73);
+      result.current.revealEditorLine(73, 50);
     });
     // The reveal itself still happens synchronously — a fix that made
     // revealEditorLine a no-op would satisfy the assertions below vacuously.
-    expect(editor.revealLineInCenterIfOutsideViewport).toHaveBeenCalledExactlyOnceWith(73);
+    expect(editor.setScrollTop).toHaveBeenCalledExactlyOnceWith(50, 1);
 
     // A scroll event arriving within the suppression window (today: 50ms
-    // debounce, then unguarded) must not echo through and overwrite the
-    // reveal.
+    // debounce, then unguarded) must not echo through and add a second,
+    // overwriting setScrollTop call.
     act(() => {
       result.current.handlePreviewScroll();
       vi.advanceTimersByTime(50);
     });
-    expect(editor.setScrollTop).not.toHaveBeenCalled();
+    expect(editor.setScrollTop).toHaveBeenCalledTimes(1);
 
     // The suppression must be time-bounded, not permanent — otherwise a fix
     // that disabled ratio sync forever would satisfy the row above while
     // breaking the HTML preview path (U4) in production. Advance past the
     // 300ms window, then a fresh preview scroll must resume ratio sync as
-    // normal.
+    // normal (a second, distinct setScrollTop call).
     act(() => {
       vi.advanceTimersByTime(300);
     });
@@ -249,7 +363,8 @@ describe('useScrollSync revealEditorLine suppresses the ratio-sync echo (Task 9)
       result.current.handlePreviewScroll();
       vi.advanceTimersByTime(50);
     });
-    expect(editor.setScrollTop).toHaveBeenCalledExactlyOnceWith(300, 1);
+    expect(editor.setScrollTop).toHaveBeenCalledTimes(2);
+    expect(editor.setScrollTop).toHaveBeenNthCalledWith(2, 300, 1);
   });
 });
 

--- a/hub-client/src/hooks/useScrollSync.ts
+++ b/hub-client/src/hooks/useScrollSync.ts
@@ -258,8 +258,20 @@ export function useScrollSync({
   // Preview→editor click sync (click-to-editor-scroll): reveal-only, not
   // routed through syncPreviewToEditor — see the UseScrollSyncReturn doc
   // comment for why (D1/D1b in the click-to-editor-scroll plan).
+  //
+  // Bracketed with isSyncingRef the same way flushPendingScroll and
+  // syncPreviewToEditor already bracket their own scroll calls: a click that
+  // activates an inline editor can produce a tiny, real reflow-driven scroll
+  // in the preview a few ms later, which would otherwise reach
+  // syncPreviewToEditor unguarded and overwrite this reveal with a
+  // ratio-derived position ~50ms after it lands correctly (task-9 fix for
+  // the race found in task-8's report).
   const revealEditorLine = useCallback((line: number) => {
+    isSyncingRef.current = true;
     editorRef.current?.revealLineInCenterIfOutsideViewport(line);
+    setTimeout(() => {
+      isSyncingRef.current = false;
+    }, 300);
   }, [editorRef]);
 
   // The preview iframe committed a new AST: fresh data-loc DOM is in place,

--- a/hub-client/src/hooks/useScrollSync.ts
+++ b/hub-client/src/hooks/useScrollSync.ts
@@ -48,19 +48,24 @@ interface UseScrollSyncReturn {
   handlePreviewScroll: () => void;
   handlePreviewClick: () => void;
   /**
-   * Preview→editor click sync (click-to-editor-scroll): reveal `line` in the
-   * editor. Scroll-only — calls `editor.revealLineInCenterIfOutsideViewport`
-   * and nothing else. Deliberately narrower than `syncPreviewToEditor`: in
-   * q2-preview the click that reaches this also opens an inline editor
-   * *inside the preview*, so pulling focus to Monaco (`setPosition` /
-   * `setSelection` / `focus()`) would break the gesture the same click just
-   * started, and `setPosition` would additionally fire
+   * Preview→editor click sync (click-to-editor-scroll): align `line` in the
+   * editor to the same on-screen y as the clicked block, `hostY` (2026-08-22
+   * click-align-editor-y plan). `hostY` omitted ⇒ top-align. Scroll-only —
+   * calls `editor.setScrollTop` and nothing else. Deliberately narrower than
+   * `syncPreviewToEditor`: in q2-preview the click that reaches this also
+   * opens an inline editor *inside the preview*, so pulling focus to Monaco
+   * (`setPosition` / `setSelection` / `focus()`) would break the gesture the
+   * same click just started, and `setPosition` would additionally fire
    * `onDidChangeCursorPosition`, feeding editor→preview sync and bouncing.
    * Not focus-gated (an explicit click is unambiguous user intent, unlike
    * the scroll-ratio feedback loop `syncPreviewToEditor` guards against),
    * and not debounced (there's exactly one click, not a scroll stream).
+   * Also, deliberately, not gated on `enabled` (decision A6): with the
+   * scroll-sync toggle off, click-align is the only scroll coupling left in
+   * either direction, which is how the feature is best evaluated — see A1h.
+   * Do not add an `enabledRef.current` check here.
    */
-  revealEditorLine: (line: number) => void;
+  revealEditorLine: (line: number, hostY?: number) => void;
   /**
    * Call when the preview iframe reports it committed a new AST
    * (`AST_RENDERED`). Flushes any editor→preview scroll deferred while the
@@ -255,9 +260,18 @@ export function useScrollSync({
     syncPreviewToEditor();
   }, [syncPreviewToEditor]);
 
-  // Preview→editor click sync (click-to-editor-scroll): reveal-only, not
-  // routed through syncPreviewToEditor — see the UseScrollSyncReturn doc
-  // comment for why (D1/D1b in the click-to-editor-scroll plan).
+  // Preview→editor click sync (click-to-editor-scroll): align, not just
+  // reveal — see the UseScrollSyncReturn doc comment for why (D1/D1b in the
+  // original click-to-editor-scroll plan; alignment computation in the
+  // 2026-08-22 click-align-editor-y plan). Not routed through
+  // syncPreviewToEditor.
+  //
+  // On screen a source line sits at editorTop + (topForLine - scrollTop);
+  // to land it at hostY we solve for scrollTop. Clamped to the editor's
+  // scrollable range — near the start or end of the document the clamp
+  // wins and the two panes won't line up exactly, which is a limit of the
+  // geometry, not a bug. hostY omitted (decision A3) falls back to
+  // top-aligning the line.
   //
   // Bracketed with isSyncingRef the same way flushPendingScroll and
   // syncPreviewToEditor already bracket their own scroll calls: a click that
@@ -266,9 +280,21 @@ export function useScrollSync({
   // syncPreviewToEditor unguarded and overwrite this reveal with a
   // ratio-derived position ~50ms after it lands correctly (task-9 fix for
   // the race found in task-8's report).
-  const revealEditorLine = useCallback((line: number) => {
+  const revealEditorLine = useCallback((line: number, hostY?: number) => {
+    const editor = editorRef.current;
+    if (!editor) return;
+
+    const topForLine = editor.getTopForLineNumber(line);
+    const editorTop = editor.getDomNode()?.getBoundingClientRect().top;
+
+    const desired =
+      hostY !== undefined && editorTop !== undefined ? topForLine - (hostY - editorTop) : topForLine;
+
+    const maxScroll = Math.max(0, editor.getScrollHeight() - editor.getLayoutInfo().height);
+    const clamped = Math.min(Math.max(desired, 0), maxScroll);
+
     isSyncingRef.current = true;
-    editorRef.current?.revealLineInCenterIfOutsideViewport(line);
+    editor.setScrollTop(clamped, 1);
     setTimeout(() => {
       isSyncingRef.current = false;
     }, 300);

--- a/hub-client/src/hooks/useScrollSync.ts
+++ b/hub-client/src/hooks/useScrollSync.ts
@@ -48,6 +48,20 @@ interface UseScrollSyncReturn {
   handlePreviewScroll: () => void;
   handlePreviewClick: () => void;
   /**
+   * Preview→editor click sync (click-to-editor-scroll): reveal `line` in the
+   * editor. Scroll-only — calls `editor.revealLineInCenterIfOutsideViewport`
+   * and nothing else. Deliberately narrower than `syncPreviewToEditor`: in
+   * q2-preview the click that reaches this also opens an inline editor
+   * *inside the preview*, so pulling focus to Monaco (`setPosition` /
+   * `setSelection` / `focus()`) would break the gesture the same click just
+   * started, and `setPosition` would additionally fire
+   * `onDidChangeCursorPosition`, feeding editor→preview sync and bouncing.
+   * Not focus-gated (an explicit click is unambiguous user intent, unlike
+   * the scroll-ratio feedback loop `syncPreviewToEditor` guards against),
+   * and not debounced (there's exactly one click, not a scroll stream).
+   */
+  revealEditorLine: (line: number) => void;
+  /**
    * Call when the preview iframe reports it committed a new AST
    * (`AST_RENDERED`). Flushes any editor→preview scroll deferred while the
    * render was in flight — once, against the up-to-date DOM. A no-op when no
@@ -241,6 +255,13 @@ export function useScrollSync({
     syncPreviewToEditor();
   }, [syncPreviewToEditor]);
 
+  // Preview→editor click sync (click-to-editor-scroll): reveal-only, not
+  // routed through syncPreviewToEditor — see the UseScrollSyncReturn doc
+  // comment for why (D1/D1b in the click-to-editor-scroll plan).
+  const revealEditorLine = useCallback((line: number) => {
+    editorRef.current?.revealLineInCenterIfOutsideViewport(line);
+  }, [editorRef]);
+
   // The preview iframe committed a new AST: fresh data-loc DOM is in place,
   // so flush the deferred editor→preview scroll once.
   const handleAstRendered = useCallback(() => {
@@ -276,6 +297,7 @@ export function useScrollSync({
   return {
     handlePreviewScroll,
     handlePreviewClick,
+    revealEditorLine,
     handleAstRendered,
     scrollToLineDeferred,
   };

--- a/hub-client/src/hooks/useSelectionSync.test.ts
+++ b/hub-client/src/hooks/useSelectionSync.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Tests for useSelectionSync — preview→editor selection sync, focused on the
+ * Phase 2 change from `claude-notes/plans/2026-08-22-click-align-editor-y.md`:
+ * `handlePreviewSelection` used to reveal with `editor.revealRangeInCenter`;
+ * it now ALIGNS via a `revealEditorLine` callback threaded in from
+ * `useScrollSync` (A7 — threading the callback, rather than extracting the
+ * arithmetic into a shared pure helper, is what keeps this call bracketed by
+ * `useScrollSync`'s own `isSyncingRef`, the flag the ratio-sync overwrite race
+ * actually reads).
+ *
+ * There were no tests for this hook before this phase.
+ *
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import type { RefObject } from 'react';
+import type * as Monaco from 'monaco-editor';
+import type { SourceLocation } from '@quarto/preview-renderer/iframe/DoubleBufferedIframe';
+import type { MorphIframeHandle } from '@quarto/preview-renderer/iframe/MorphIframe';
+import { useSelectionSync } from './useSelectionSync';
+import { useScrollSync } from './useScrollSync';
+
+function loc(startLine: number, startCol: number, endLine: number, endCol: number): SourceLocation {
+  return { fileId: 0, startLine, startCol, endLine, endCol };
+}
+
+/**
+ * Minimal editor fake for the wiring-only rows: `revealEditorLine` is a bare
+ * `vi.fn()` here (the alignment arithmetic itself is A1a-A1c's job in
+ * `useScrollSync.test.ts`), so this fake only needs what
+ * `handlePreviewSelection` touches directly: `setSelection`, `focus`, and
+ * `revealRangeInCenter` (to prove it is NOT called — A1e's sibling row for
+ * this hook).
+ */
+function makeWiringEditor() {
+  let contentCb: () => void = () => {};
+  const editor = {
+    setSelection: vi.fn(),
+    focus: vi.fn(),
+    revealRangeInCenter: vi.fn(),
+    onDidChangeModelContent: (cb: () => void) => {
+      contentCb = cb;
+      return { dispose: vi.fn() };
+    },
+    onDidChangeCursorSelection: () => ({ dispose: vi.fn() }),
+  } as unknown as Monaco.editor.IStandaloneCodeEditor;
+  return { editor, fireContentChange: () => contentCb() };
+}
+
+function setupWiring(revealEditorLine = vi.fn()) {
+  const { editor } = makeWiringEditor();
+  const editorRef = { current: editor } as RefObject<Monaco.editor.IStandaloneCodeEditor | null>;
+  const previewRef = { current: null } as RefObject<MorphIframeHandle | null>;
+
+  const { result } = renderHook(() =>
+    useSelectionSync({ editorRef, previewRef, enabled: true, revealEditorLine }),
+  );
+
+  return { result, editor, revealEditorLine };
+}
+
+describe('useSelectionSync.handlePreviewSelection wiring to revealEditorLine (Phase 2)', () => {
+  it('B1a: forwards the selection start line and hostY to revealEditorLine, exactly once', () => {
+    const { result, revealEditorLine } = setupWiring();
+    act(() => {
+      result.current.handlePreviewSelection(loc(45, 1, 45, 1), loc(45, 1, 45, 1), 234);
+    });
+    expect(revealEditorLine).toHaveBeenCalledExactlyOnceWith(45, 234);
+  });
+
+  it('B1b: hostY omitted is forwarded as omitted (revealEditorLine falls back to top-align, decision A3)', () => {
+    const { result, revealEditorLine } = setupWiring();
+    act(() => {
+      result.current.handlePreviewSelection(loc(12, 1, 12, 1), loc(12, 1, 12, 1));
+    });
+    expect(revealEditorLine).toHaveBeenCalledExactlyOnceWith(12, undefined);
+  });
+
+  it('B2a: still calls editor.setSelection with the same range as before this phase (A4)', () => {
+    const { result, editor } = setupWiring();
+    act(() => {
+      result.current.handlePreviewSelection(loc(10, 2, 10, 2), loc(20, 3, 20, 3));
+    });
+    expect(editor.setSelection).toHaveBeenCalledExactlyOnceWith({
+      startLineNumber: 10,
+      startColumn: 2,
+      endLineNumber: 20,
+      endColumn: 3,
+    });
+  });
+
+  it('B2b: still calls editor.focus() (A4 — the HTML preview keeps its focus steal)', () => {
+    const { result, editor } = setupWiring();
+    act(() => {
+      result.current.handlePreviewSelection(loc(1, 1, 1, 1), loc(1, 1, 1, 1));
+    });
+    expect(editor.focus).toHaveBeenCalledOnce();
+  });
+
+  it('B2c: never calls editor.revealRangeInCenter (centring is gone, not just unasserted)', () => {
+    const { result, editor } = setupWiring();
+    act(() => {
+      result.current.handlePreviewSelection(loc(1, 1, 1, 1), loc(1, 1, 1, 1), 50);
+    });
+    expect(editor.revealRangeInCenter).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when either position is null (pre-existing guard, unaffected by this phase)', () => {
+    const { result, revealEditorLine, editor } = setupWiring();
+    act(() => {
+      result.current.handlePreviewSelection(null, loc(1, 1, 1, 1));
+    });
+    expect(revealEditorLine).not.toHaveBeenCalled();
+    expect(editor.setSelection).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * End-to-end alignment rows: `useSelectionSync` composed with a REAL
+ * `useScrollSync().revealEditorLine`, sharing `editorRef` the same way
+ * `Preview.tsx` composes them. This is what actually proves the alignment
+ * arithmetic + both clamps reach `editor.setScrollTop` through the selection
+ * path (mirroring A1a/A1b/A1c, not re-testing them, since the arithmetic
+ * itself lives in and is already pinned by `useScrollSync.test.ts`), and
+ * — the load-bearing row — that the reveal-then-overwrite race (A7) is
+ * closed on this path exactly because the SAME `isSyncingRef` is shared.
+ */
+function makeComposedEditor(opts: { topForLine?: number; editorTop?: number } = {}) {
+  let cursorPositionCb: () => void = () => {};
+  let modelContentCb: () => void = () => {};
+  const editor = {
+    getPosition: () => ({ lineNumber: 1, column: 1 }),
+    getScrollHeight: () => 1000,
+    getLayoutInfo: () => ({ height: 400 }),
+    getTopForLineNumber: vi.fn(() => opts.topForLine ?? 0),
+    getDomNode: vi.fn(
+      () =>
+        ({
+          getBoundingClientRect: () => ({ top: opts.editorTop ?? 0 }),
+        }) as unknown as HTMLElement,
+    ),
+    setScrollTop: vi.fn(),
+    setSelection: vi.fn(),
+    focus: vi.fn(),
+    revealRangeInCenter: vi.fn(),
+    onDidChangeCursorPosition: (cb: () => void) => {
+      cursorPositionCb = cb;
+      return { dispose: vi.fn() };
+    },
+    onDidChangeModelContent: (cb: () => void) => {
+      modelContentCb = cb;
+      return { dispose: vi.fn() };
+    },
+    onDidChangeCursorSelection: () => ({ dispose: vi.fn() }),
+  } as unknown as Monaco.editor.IStandaloneCodeEditor;
+  return { editor, fireCursorPositionChange: () => cursorPositionCb(), fireModelContentChange: () => modelContentCb() };
+}
+
+function setupComposed(opts: { topForLine?: number; editorTop?: number } = {}) {
+  const { editor } = makeComposedEditor(opts);
+  const editorRef = { current: editor } as RefObject<Monaco.editor.IStandaloneCodeEditor | null>;
+  const editorHasFocusRef = { current: false } as RefObject<boolean>;
+  const previewRef = {
+    current: { clearSelection: vi.fn() } as unknown as MorphIframeHandle,
+  } as RefObject<MorphIframeHandle | null>;
+  const getPreviewScrollRatio = vi.fn(() => 0.5);
+
+  const { result } = renderHook(() => {
+    const scroll = useScrollSync({
+      editorRef,
+      scrollPreviewToLine: vi.fn(),
+      getPreviewScrollRatio,
+      enabled: true,
+      editorHasFocusRef,
+      deferToRender: false,
+    });
+    const selection = useSelectionSync({
+      editorRef,
+      previewRef,
+      enabled: true,
+      revealEditorLine: scroll.revealEditorLine,
+    });
+    return { ...scroll, ...selection };
+  });
+
+  return { result, editor };
+}
+
+describe('useSelectionSync wired to a real useScrollSync().revealEditorLine (Phase 2, end-to-end)', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('aligns the selected line to hostY through the real arithmetic', () => {
+    // topForLine=500, editorTop=100, hostY=150 -> 500 - (150 - 100) = 450.
+    // Deliberately not 300 — the value the ratio path below would produce
+    // from this harness's fixed 0.5 ratio over the same 1000/400 editor
+    // (see useScrollSync.test.ts's A1a note on the poisoned 300 value).
+    const { result, editor } = setupComposed({ topForLine: 500, editorTop: 100 });
+    act(() => {
+      result.current.handlePreviewSelection(loc(20, 1, 20, 1), loc(20, 1, 20, 1), 150);
+    });
+    expect(editor.setScrollTop).toHaveBeenCalledExactlyOnceWith(450, 1);
+  });
+
+  it('clamps to 0 at the lower bound through the selection path', () => {
+    const { result, editor } = setupComposed({ topForLine: 100, editorTop: 50 });
+    act(() => {
+      result.current.handlePreviewSelection(loc(3, 1, 3, 1), loc(3, 1, 3, 1), 500);
+    });
+    expect(editor.setScrollTop).toHaveBeenCalledExactlyOnceWith(0, 1);
+  });
+
+  it('clamps to getScrollHeight() - getLayoutInfo().height at the upper bound through the selection path', () => {
+    const { result, editor } = setupComposed({ topForLine: 2000, editorTop: 50 });
+    act(() => {
+      result.current.handlePreviewSelection(loc(99, 1, 99, 1), loc(99, 1, 99, 1), 50);
+    });
+    expect(editor.setScrollTop).toHaveBeenCalledExactlyOnceWith(600, 1);
+  });
+
+  it('A7: a preview scroll within the suppression window does not overwrite a selection-triggered alignment, and resumes after (HTML-path analogue of U2e)', () => {
+    const { result, editor } = setupComposed({ topForLine: 500, editorTop: 100 });
+
+    act(() => {
+      result.current.handlePreviewSelection(loc(20, 1, 20, 1), loc(20, 1, 20, 1), 150);
+    });
+    expect(editor.setScrollTop).toHaveBeenCalledExactlyOnceWith(450, 1);
+
+    // A preview scroll arriving within the suppression window (revealEditorLine
+    // brackets useScrollSync's OWN isSyncingRef, the flag syncPreviewToEditor
+    // reads) must not overwrite the alignment with a ratio-derived position.
+    act(() => {
+      result.current.handlePreviewScroll();
+      vi.advanceTimersByTime(50);
+    });
+    expect(editor.setScrollTop).toHaveBeenCalledTimes(1);
+
+    // The suppression is time-bounded: past the 300ms window, a fresh
+    // preview scroll resumes ratio sync as normal.
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    act(() => {
+      result.current.handlePreviewScroll();
+      vi.advanceTimersByTime(50);
+    });
+    expect(editor.setScrollTop).toHaveBeenCalledTimes(2);
+    expect(editor.setScrollTop).toHaveBeenNthCalledWith(2, 300, 1);
+  });
+});

--- a/hub-client/src/hooks/useSelectionSync.ts
+++ b/hub-client/src/hooks/useSelectionSync.ts
@@ -21,13 +21,28 @@ interface UseSelectionSyncOptions {
   previewRef: RefObject<MorphIframeHandle | null>;
   /** Whether selection sync is enabled */
   enabled: boolean;
+  /**
+   * `useScrollSync`'s `revealEditorLine` — threaded in, not re-implemented
+   * (2026-08-22 click-align-editor-y plan, Phase 2, decision A7). Calling the
+   * SAME callback (rather than extracting the alignment arithmetic into a
+   * shared pure helper) is what keeps `handlePreviewSelection`'s reveal
+   * bracketed by `useScrollSync`'s own `isSyncingRef` — the flag
+   * `syncPreviewToEditor`'s ratio-sync path actually reads. A helper called
+   * from here would set THIS hook's unrelated `isSyncingRef` instead and
+   * leave the overwrite race wide open. Do not "decouple the hooks".
+   */
+  revealEditorLine: (line: number, hostY?: number) => void;
 }
 
 /**
  * Return type: callback for preview to call when selection changes
  */
 interface UseSelectionSyncReturn {
-  handlePreviewSelection: (startPos: SourceLocation | null, endPos: SourceLocation | null) => void;
+  handlePreviewSelection: (
+    startPos: SourceLocation | null,
+    endPos: SourceLocation | null,
+    hostY?: number,
+  ) => void;
 }
 
 /**
@@ -38,6 +53,7 @@ export function useSelectionSync({
   editorRef,
   previewRef,
   enabled,
+  revealEditorLine,
 }: UseSelectionSyncOptions): UseSelectionSyncReturn {
   // Track if we're currently syncing to prevent feedback loops
   const isSyncingRef = useRef(false);
@@ -45,7 +61,8 @@ export function useSelectionSync({
   // Preview → Editor selection sync
   const handlePreviewSelection = useCallback((
     startPos: SourceLocation | null,
-    endPos: SourceLocation | null
+    endPos: SourceLocation | null,
+    hostY?: number,
   ) => {
     const editor = editorRef.current;
     if (!editor || !startPos || !endPos) return;
@@ -67,8 +84,13 @@ export function useSelectionSync({
     // Set the selection in the editor
     editor.setSelection(range);
 
-    // Reveal the selection in the editor viewport
-    editor.revealRangeInCenter(range);
+    // Align (not merely reveal) the selection's start line to the same
+    // on-screen y as the clicked/selected span in the preview (2026-08-22
+    // click-align-editor-y plan, Phase 2). Per decision A4, the HTML preview
+    // keeps this cursor move + focus steal unlike q2-preview's click path —
+    // only the reveal itself changes here, from `revealRangeInCenter` to
+    // this alignment.
+    revealEditorLine(startPos.startLine, hostY);
 
     // Optionally focus the editor
     editor.focus();
@@ -77,7 +99,7 @@ export function useSelectionSync({
     setTimeout(() => {
       isSyncingRef.current = false;
     }, 50);
-  }, [editorRef]);
+  }, [editorRef, revealEditorLine]);
 
   // Editor → Preview selection sync
   useEffect(() => {

--- a/ts-packages/preview-renderer/src/iframe/MorphIframe.integration.test.tsx
+++ b/ts-packages/preview-renderer/src/iframe/MorphIframe.integration.test.tsx
@@ -1,0 +1,167 @@
+/**
+ * Integration tests for `MorphIframe`'s `selectionchange` → `onSelectionChange`
+ * bridge (`claude-notes/plans/2026-08-22-click-align-editor-y.md`, Phase 2):
+ *
+ *  - `hostY` is computed from the anchor SPAN's own rect (not a containing
+ *    block — the reported `SourceLocation` is already span/column
+ *    precision, so a coarser block's top would desync from the very line
+ *    being reported), plus the iframe's own host-page offset — mirroring
+ *    `Q2PreviewIframe`'s `blockTop + iframeTop` pattern.
+ *  - The `fileId` guard fix lives here too (its own commit): a selection
+ *    resolving outside the current file (fileId !== 0 — e.g. inside
+ *    `{{< include >}}`'d content) must not reach `onSelectionChange` at
+ *    all, reusing `lineForClickTarget` rather than re-deriving the check.
+ *
+ * jsdom never processes an `<iframe>`'s `srcdoc` navigation — verified: no
+ * `load` event fires and `contentDocument` stays the default empty document
+ * no matter how long you wait. `Q2PreviewIframe`'s own tests hit the same
+ * wall for its `src`-bearing iframe and work around it by writing a fixture
+ * directly into `contentDocument` via `open()/write()/close()` and firing
+ * its readiness signal synthetically; that file's signal is a `postMessage`
+ * (`IFRAME_READY`), while `MorphIframe`'s is the iframe element's own native
+ * `load` event — so the same idiom applies, just dispatching `load` instead.
+ */
+
+import { describe, test, expect, vi } from 'vitest';
+import { render, act } from '@testing-library/react';
+
+// MorphIframe's selectionchange handler runs `postProcessIframe` on load,
+// which reads through @quarto/preview-runtime for link/asset rewriting.
+// None of these fixtures contain rewritable links or assets, but stub the
+// VFS reads anyway (mirrors Q2PreviewIframe.integration.test.tsx) so a
+// future fixture addition here can't accidentally depend on real WASM.
+vi.mock('@quarto/preview-runtime', () => ({
+  vfsReadFile: vi.fn(() => ({ success: false })),
+  vfsReadBinaryFile: vi.fn(() => ({ success: false })),
+}));
+
+import { createRef } from 'react';
+import MorphIframe, { type MorphIframeHandle } from './MorphIframe';
+import type { SourceLocation } from './scrollSyncDom';
+
+const BASE_QMD = 'Paragraph one.\n\nParagraph two.\n';
+
+/**
+ * Mount the real `MorphIframe`, then write `fixtureBodyHtml` directly into
+ * its `contentDocument` and fire a synthetic `load` Event on the `<iframe>`
+ * element — MorphIframe's own readiness signal, which jsdom never fires on
+ * its own for `srcdoc` (see file doc comment). This runs the component's
+ * real `handleLoad` (post-process + `setDocumentReady(true)`), attaching
+ * the real `selectionchange` listener to OUR fixture document.
+ */
+function mountWithFixture(
+  onSelectionChange: (
+    startPos: SourceLocation | null,
+    endPos: SourceLocation | null,
+    hostY?: number,
+  ) => void,
+  fixtureBodyHtml: string,
+  qmdContent: string = BASE_QMD,
+) {
+  const utils = render(
+    <MorphIframe
+      ref={createRef<MorphIframeHandle>()}
+      html="<!doctype html><html><body></body></html>"
+      currentFilePath="doc.qmd"
+      qmdContent={qmdContent}
+      onNavigateToDocument={() => {}}
+      onSelectionChange={onSelectionChange}
+    />,
+  );
+
+  const iframe = utils.container.querySelector('iframe');
+  if (!iframe) throw new Error('iframe not mounted');
+  const doc = iframe.contentDocument;
+  if (!doc) throw new Error('contentDocument is null');
+
+  doc.open();
+  doc.write(`<!doctype html><html><body>${fixtureBodyHtml}</body></html>`);
+  doc.close();
+
+  act(() => {
+    iframe.dispatchEvent(new Event('load'));
+  });
+
+  return { iframe, doc, unmount: utils.unmount };
+}
+
+function selectWithinSpan(doc: Document, span: Element, offset: number) {
+  const textNode = span.firstChild;
+  if (!textNode) throw new Error('span has no text-node child');
+  const range = doc.createRange();
+  range.setStart(textNode, offset);
+  range.setEnd(textNode, offset);
+  const selection = doc.getSelection();
+  if (!selection) throw new Error('doc.getSelection() is null');
+  selection.removeAllRanges();
+  selection.addRange(range);
+  doc.dispatchEvent(new Event('selectionchange'));
+}
+
+describe('MorphIframe selectionchange -> onSelectionChange: hostY (Phase 2)', () => {
+  test('reports hostY from the anchor SPAN itself, not the containing block', () => {
+    const onSelectionChange = vi.fn();
+    const { iframe, doc } = mountWithFixture(
+      onSelectionChange,
+      '<p data-loc="0:1:1-1:15">' +
+        '<span data-loc="0:1:1-1:9">Paragraph</span> ' +
+        '<span data-loc="0:1:11-1:15">one.</span>' +
+        '</p>',
+    );
+
+    const span = doc.querySelector('span[data-loc="0:1:1-1:9"]')!;
+    const block = doc.querySelector('p[data-loc]')!;
+    // Distinct sentinel values: if hostY were computed from the containing
+    // <p> instead of the span, or from jsdom's un-mocked zero default, this
+    // row would catch either mistake.
+    vi.spyOn(span, 'getBoundingClientRect').mockReturnValue({ top: 234 } as DOMRect);
+    vi.spyOn(block, 'getBoundingClientRect').mockReturnValue({ top: 999 } as DOMRect);
+    vi.spyOn(iframe, 'getBoundingClientRect').mockReturnValue({ top: 50 } as DOMRect);
+
+    act(() => selectWithinSpan(doc, span, 0));
+
+    expect(onSelectionChange).toHaveBeenCalledTimes(1);
+    const [, , hostY] = onSelectionChange.mock.calls[0];
+    expect(hostY).toBe(284); // span's 234 + iframe's 50 — never 999 + 50
+  });
+});
+
+/**
+ * Fix, own commit (decision A8): before this, `handlePreviewSelection`
+ * built a Monaco range straight from `startPos`/`endPos` and never checked
+ * `fileId`, so selecting inside e.g. `{{< include >}}`'d content (a
+ * non-zero `fileId`) moved the editor's caret + focus to a same-numbered
+ * but unrelated line of the currently-open file. Reuses `lineForClickTarget`
+ * (already used for `hostY` above) as the guard, rather than re-deriving
+ * the check — it must now gate the WHOLE call, not just `hostY`, which is
+ * the deliberate difference from the row above: this is the fix, not the
+ * alignment feature, so `setSelection`/`focus()` are correctly skipped
+ * along with the reveal for this one case.
+ */
+describe('MorphIframe selectionchange -> onSelectionChange: fileId guard (fix, own commit)', () => {
+  test('a foreign fileId (e.g. included content) is not reported at all', () => {
+    const onSelectionChange = vi.fn();
+    const { doc } = mountWithFixture(
+      onSelectionChange,
+      '<p data-loc="2:1:1-1:9"><span data-loc="2:1:1-1:9">Included</span></p>',
+    );
+
+    const span = doc.querySelector('span[data-loc]')!;
+    act(() => selectWithinSpan(doc, span, 0));
+
+    expect(onSelectionChange).not.toHaveBeenCalled();
+  });
+
+  test('control: the same shape with fileId 0 (the current file) is still reported', () => {
+    const onSelectionChange = vi.fn();
+    const { doc } = mountWithFixture(
+      onSelectionChange,
+      '<p data-loc="0:1:1-1:9"><span data-loc="0:1:1-1:9">Paragraph</span></p>',
+    );
+
+    const span = doc.querySelector('span[data-loc]')!;
+    act(() => selectWithinSpan(doc, span, 0));
+
+    expect(onSelectionChange).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ts-packages/preview-renderer/src/iframe/MorphIframe.tsx
+++ b/ts-packages/preview-renderer/src/iframe/MorphIframe.tsx
@@ -6,6 +6,7 @@ import {
   parseDataLoc,
   scrollIframeToLine,
   getIframeScrollRatio,
+  lineForClickTarget,
   type SourceLocation,
 } from './scrollSyncDom';
 
@@ -37,8 +38,17 @@ interface MorphIframeProps {
   onScroll?: () => void;
   // Optional callback when preview is clicked
   onClick?: () => void;
-  // Optional callback when selection changes in preview
-  onSelectionChange?: (startPos: SourceLocation | null, endPos: SourceLocation | null) => void;
+  // Optional callback when selection changes in preview. The third
+  // argument, `hostY`, is the anchor span's top edge in HOST-PAGE
+  // coordinates (see `handleSelectionChange` below) — used by
+  // `useScrollSync.revealEditorLine` to align the editor to the same
+  // on-screen y as the selected text, rather than merely reveal it
+  // (2026-08-22 click-align-editor-y plan, Phase 2).
+  onSelectionChange?: (
+    startPos: SourceLocation | null,
+    endPos: SourceLocation | null,
+    hostY?: number,
+  ) => void;
   // Ref to expose imperative methods
   ref: Ref<MorphIframeHandle>;
 }
@@ -441,13 +451,44 @@ function MorphIframe({
 
       if (anchorNode?.nodeType === Node.TEXT_NODE && focusNode?.nodeType === Node.TEXT_NODE) {
         if (anchorNode.parentElement?.tagName !== 'SPAN' || focusNode.parentElement?.tagName !== 'SPAN') return;
-        const anchorLoc = parseDataLoc(anchorNode.parentElement?.getAttribute('data-loc')!);
-        const focusLoc = parseDataLoc(focusNode.parentElement?.getAttribute('data-loc')!);
+        const anchorSpan = anchorNode.parentElement;
+        const focusSpan = focusNode.parentElement;
+        const anchorLoc = parseDataLoc(anchorSpan.getAttribute('data-loc')!);
+        const focusLoc = parseDataLoc(focusSpan.getAttribute('data-loc')!);
         if (anchorLoc === null || focusLoc === null) return;
+
+        // Guard: skip this call entirely — no setSelection/focus/reveal at
+        // all — when either end resolves outside the current file (fileId
+        // !== 0, e.g. inside `{{< include >}}`'d content). Fix, not
+        // pre-existing behavior (2026-08-22 click-align-editor-y plan,
+        // decision A8): before this, a selection inside included content
+        // moved the editor's caret + focus to a same-numbered but unrelated
+        // line of the currently-open file. Reuses `lineForClickTarget`
+        // (already relied on below for `hostY`) rather than re-deriving its
+        // checks — on this path only the fileId check is actually
+        // reachable (`#q2-active-edit-region` never appears outside
+        // q2-preview, and sections never carry a real `data-loc` here
+        // either), but reusing the function catches all three should that
+        // ever change.
+        if (lineForClickTarget(anchorSpan) === null || lineForClickTarget(focusSpan) === null) {
+          return;
+        }
 
         const start = addOffsetToPosition(qmdContent, anchorLoc.startLine, anchorLoc.startCol, anchorOffset)
         const end = addOffsetToPosition(qmdContent, focusLoc.startLine, focusLoc.startCol, focusOffset)
         if (start === null || end === null) return;
+
+        // hostY: align the anchor SPAN's on-screen y to the same line in
+        // the editor (2026-08-22 click-align-editor-y plan, Phase 2).
+        // Anchored on the SPAN itself, not a containing block: the
+        // SourceLocation below is already span/column precision (via
+        // addOffsetToPosition), so a coarser block's top would desync from
+        // the very line being reported on any multi-line block. Mirrors
+        // Q2PreviewIframe's `blockTop + iframeTop` pattern — the span's
+        // rect is in the IFRAME's viewport, so the iframe element's own top
+        // in the host page has to be added.
+        const hostY =
+          anchorSpan.getBoundingClientRect().top + iframe.getBoundingClientRect().top;
 
         onSelectionChange({
           startCol: start.col,
@@ -461,7 +502,7 @@ function MorphIframe({
           endCol: end.col,
           endLine: end.row,
           fileId: anchorLoc.fileId
-        });
+        }, hostY);
       }
     };
 

--- a/ts-packages/preview-renderer/src/iframe/Q2PreviewIframe.integration.test.tsx
+++ b/ts-packages/preview-renderer/src/iframe/Q2PreviewIframe.integration.test.tsx
@@ -160,7 +160,7 @@ function renderWithFingerprint(
  *    to enforce that, but a test should not depend on it deviating).
  */
 function renderWithClickListenerSpy(
-    onClickAtLine?: (line: number) => void,
+    onClickAtLine?: (line: number, hostY?: number) => void,
     fixtureHtml?: string,
 ): {
     doc: Document;
@@ -390,14 +390,22 @@ describe('Q2PreviewIframe click-to-editor-scroll listener registration', () => {
         expect(pointerUpCalls[0][2]).toBe(true);
 
         // Assertion 2: dispatching pointerup on the located node built above
-        // (same 0:12:1-14:20 <p> as U1a) forwards its startLine to onClickAtLine.
+        // (same 0:12:1-14:20 <p> as U1a) forwards its startLine to
+        // onClickAtLine — and (A1f, 2026-08-22 plan) a second, numeric
+        // argument: the clicked block's top edge in host-page coordinates
+        // (`hostY`), which `useScrollSync.revealEditorLine` needs to align
+        // the line rather than merely reveal it. jsdom lays out nothing, so
+        // the concrete value is 0 (both the block's and the iframe's
+        // getBoundingClientRect().top default to 0 under jsdom) — the
+        // binding this row cares about is arity and type, not the number;
+        // A1g (Playwright) is what actually exercises real coordinates.
         const target = doc.getElementById('t')!;
         const PointerEventCtor = (win as unknown as { PointerEvent?: typeof PointerEvent })
             .PointerEvent ?? Event;
         act(() => {
             target.dispatchEvent(new PointerEventCtor('pointerup', { bubbles: true }));
         });
-        expect(onClickAtLine).toHaveBeenCalledWith(12);
+        expect(onClickAtLine).toHaveBeenCalledWith(12, expect.any(Number));
 
         unmount();
     });

--- a/ts-packages/preview-renderer/src/iframe/Q2PreviewIframe.integration.test.tsx
+++ b/ts-packages/preview-renderer/src/iframe/Q2PreviewIframe.integration.test.tsx
@@ -12,6 +12,7 @@
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render } from '@testing-library/react';
 import { act } from 'react';
+import type { ComponentProps } from 'react';
 
 // Mock the VFS reads so the test doesn't need WASM. The theme mock is
 // keyed off `mockBytes`; the asset-binary mock is keyed off a per-path
@@ -62,33 +63,47 @@ interface RenderHarness {
     postMessage: ReturnType<typeof vi.fn>;
 }
 
-function renderWithFingerprint(
-    initial: string | null | undefined,
-): RenderHarness {
-    // We want to spy on the iframe element's contentWindow.postMessage.
-    // Defer the spy until after first render mounts the iframe DOM.
+const BASE_AST_JSON = '{"pandoc-api-version":[1,23,0],"meta":{},"blocks":[]}';
+const BASE_FILE_PATH = '/test.qmd';
+
+/**
+ * Shared mount step for `renderWithFingerprint` and
+ * `renderWithClickListenerSpy`: render `<Q2PreviewIframe>` with the common
+ * base props plus whatever the caller adds, pull out the iframe's
+ * `contentWindow`/`contentDocument`, and stub `contentWindow.postMessage`
+ * so tests can inspect posted payloads. Callers dispatch `IFRAME_READY`
+ * themselves (via `dispatchIframeReady`, below) — some need to install a
+ * spy on the iframe document in between mount and dispatch, so this
+ * helper does not dispatch on its own.
+ */
+function mountIframe(extraProps: Partial<ComponentProps<typeof Q2PreviewIframe>> = {}) {
     const utils = render(
         <Q2PreviewIframe
-            astJson={'{"pandoc-api-version":[1,23,0],"meta":{},"blocks":[]}'}
-            currentFilePath="/test.qmd"
+            astJson={BASE_AST_JSON}
+            currentFilePath={BASE_FILE_PATH}
             setAst={() => {}}
-            themeFingerprint={initial}
+            {...extraProps}
         />,
     );
 
     const iframe = utils.container.querySelector('iframe');
     if (!iframe) throw new Error('iframe not mounted');
-    // jsdom auto-creates a contentWindow on the iframe; spy on its
-    // postMessage method so we can assert on the payloads.
+    // jsdom auto-creates a contentWindow/contentDocument on the iframe.
     const cw = iframe.contentWindow;
-    if (!cw) throw new Error('iframe.contentWindow is null');
+    const doc = iframe.contentDocument;
+    if (!cw || !doc) throw new Error('iframe contentWindow/contentDocument is null');
+
     const postMessage = vi.fn();
     Object.defineProperty(cw, 'postMessage', {
         value: postMessage,
         configurable: true,
     });
 
-    // Drive IFRAME_READY so the effects gated on `iframeReady` fire.
+    return { utils, cw, doc, postMessage };
+}
+
+/** Drive IFRAME_READY so the effects gated on `iframeReady` fire. */
+function dispatchIframeReady(cw: Window) {
     act(() => {
         window.dispatchEvent(
             new MessageEvent('message', {
@@ -97,15 +112,20 @@ function renderWithFingerprint(
             }),
         );
     });
+}
+
+function renderWithFingerprint(
+    initial: string | null | undefined,
+): RenderHarness {
+    const { utils, cw, postMessage } = mountIframe({ themeFingerprint: initial });
+    dispatchIframeReady(cw);
 
     return {
         rerender: (fp) =>
             utils.rerender(
                 <Q2PreviewIframe
-                    astJson={
-                        '{"pandoc-api-version":[1,23,0],"meta":{},"blocks":[]}'
-                    }
-                    currentFilePath="/test.qmd"
+                    astJson={BASE_AST_JSON}
+                    currentFilePath={BASE_FILE_PATH}
                     setAst={() => {}}
                     themeFingerprint={fp}
                 />,
@@ -113,6 +133,53 @@ function renderWithFingerprint(
         unmount: utils.unmount,
         postMessage,
     };
+}
+
+/**
+ * Variant of `renderWithFingerprint` for the click-to-editor-scroll row
+ * (U3, 2026-08-21 plan), sharing `mountIframe` rather than forking it.
+ * `renderWithFingerprint` dispatches IFRAME_READY immediately after
+ * mounting and exposes no handle on the iframe element, so there is no
+ * window in which to install a spy before the production listener
+ * registers. This variant instead installs the spy on
+ * `contentDocument.addEventListener` between `mountIframe` and
+ * `dispatchIframeReady`, so it observes the registration call.
+ *
+ * `fixtureHtml`, if given, is injected into the contentDocument via
+ * `open()`/`write()`/`close()` — **before** the spy is installed and
+ * IFRAME_READY is dispatched. Two reasons, not one:
+ *  - `Q2PreviewIframe`'s real `<iframe src="q2-preview.html">` never
+ *    completes navigation under jsdom's default (no external resource
+ *    loading), so `contentDocument.body` stays `null` forever; directly
+ *    assigning `.body.innerHTML` throws. `open()/write()/close()` is the
+ *    idiom this package already uses for the same constraint elsewhere
+ *    (`iframePostProcessor.integration.test.ts`'s `makeIframe()`).
+ *  - Building the fixture first, then installing the spy, then
+ *    dispatching IFRAME_READY keeps the ordering independent of whether
+ *    `open()` would clear document listeners per spec (jsdom happens not
+ *    to enforce that, but a test should not depend on it deviating).
+ */
+function renderWithClickListenerSpy(
+    onClickAtLine?: (line: number) => void,
+    fixtureHtml?: string,
+): {
+    doc: Document;
+    win: Window;
+    addEventListenerSpy: ReturnType<typeof vi.spyOn>;
+    unmount: () => void;
+} {
+    const { utils, cw, doc } = mountIframe({ onClickAtLine });
+
+    if (fixtureHtml !== undefined) {
+        doc.open();
+        doc.write(fixtureHtml);
+        doc.close();
+    }
+
+    const addEventListenerSpy = vi.spyOn(doc, 'addEventListener');
+    dispatchIframeReady(cw);
+
+    return { doc, win: cw, addEventListenerSpy, unmount: utils.unmount };
 }
 
 function themePosts(postMessage: ReturnType<typeof vi.fn>) {
@@ -293,5 +360,45 @@ describe('Q2PreviewIframe theme blob-URL lifecycle', () => {
         const revokesBefore = revokeUrlSpy.mock.calls.length;
         harness.unmount();
         expect(revokeUrlSpy.mock.calls.length).toBe(revokesBefore);
+    });
+});
+
+describe('Q2PreviewIframe click-to-editor-scroll listener registration', () => {
+    test('U3: registers a capture-phase pointerup listener and forwards the resolved line via onClickAtLine', () => {
+        const onClickAtLine = vi.fn();
+        // Fixture built via open()/write()/close() (not `doc.body.innerHTML =`)
+        // — `Q2PreviewIframe`'s real `src`-bearing iframe never completes
+        // navigation under jsdom, so `contentDocument.body` stays null and a
+        // direct innerHTML assignment throws. See `renderWithClickListenerSpy`.
+        const { doc, win, addEventListenerSpy, unmount } = renderWithClickListenerSpy(
+            onClickAtLine,
+            '<p data-loc="0:12:1-14:20"><em id="t">x</em></p>',
+        );
+
+        // Assertion 1 (mandatory — the row's real binding). jsdom keeps
+        // propagating an event through a detached target regardless of
+        // listener phase, so a *bubble*-phase pointerup listener would
+        // satisfy assertion 2 below just as well. Only the exact
+        // registration tuple discriminates capture from bubble at this
+        // tier; do not weaken this to `toHaveBeenCalledWith('pointerup',
+        // expect.anything())`.
+        const pointerUpCalls = addEventListenerSpy.mock.calls.filter(
+            (call: unknown[]) => call[0] === 'pointerup',
+        );
+        expect(pointerUpCalls).toHaveLength(1);
+        expect(typeof pointerUpCalls[0][1]).toBe('function');
+        expect(pointerUpCalls[0][2]).toBe(true);
+
+        // Assertion 2: dispatching pointerup on the located node built above
+        // (same 0:12:1-14:20 <p> as U1a) forwards its startLine to onClickAtLine.
+        const target = doc.getElementById('t')!;
+        const PointerEventCtor = (win as unknown as { PointerEvent?: typeof PointerEvent })
+            .PointerEvent ?? Event;
+        act(() => {
+            target.dispatchEvent(new PointerEventCtor('pointerup', { bubbles: true }));
+        });
+        expect(onClickAtLine).toHaveBeenCalledWith(12);
+
+        unmount();
     });
 });

--- a/ts-packages/preview-renderer/src/iframe/Q2PreviewIframe.tsx
+++ b/ts-packages/preview-renderer/src/iframe/Q2PreviewIframe.tsx
@@ -3,7 +3,7 @@ import type { Ref } from 'react';
 import { vfsReadFile } from '@quarto/preview-runtime';
 import { DEFAULT_CSS_ARTIFACT_PATH } from '../types/artifactPaths';
 import { buildAssetManifest, type ManifestCacheEntry } from '../q2-preview/assetWalker';
-import { scrollIframeToLine, getIframeScrollRatio } from './scrollSyncDom';
+import { scrollIframeToLine, getIframeScrollRatio, lineForClickTarget } from './scrollSyncDom';
 
 /**
  * Imperative scroll-sync handle, parallel to `MorphIframeHandle`. The
@@ -137,8 +137,13 @@ interface Q2PreviewIframeProps {
   scrollHandleRef?: Ref<Q2PreviewIframeHandle>;
   /** Called when the preview iframe is scrolled (preview→editor sync). */
   onScroll?: () => void;
-  /** Called when the preview iframe is clicked (preview→editor sync). */
-  onClick?: () => void;
+  /**
+   * Called with the resolved source line when a capture-phase `pointerup`
+   * on the iframe document resolves one via `lineForClickTarget`
+   * (preview→editor click sync). Not called at all when the click doesn't
+   * resolve a line (see `lineForClickTarget`'s null cases).
+   */
+  onClickAtLine?: (line: number) => void;
   /**
    * Called after the iframe commits a new AST (`AST_RENDERED`), so the host
    * can re-run editor→preview scroll sync against the fresh `data-loc` DOM.
@@ -186,7 +191,7 @@ export function Q2PreviewIframe({
   onSlideChange,
   scrollHandleRef,
   onScroll,
-  onClick,
+  onClickAtLine,
   onAstRendered,
 }: Q2PreviewIframeProps) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
@@ -215,6 +220,15 @@ export function Q2PreviewIframe({
   // app re-renders its body via React on each UPDATE_AST but never reloads
   // the iframe, so the contentWindow/document — and these listeners —
   // persist across edits.
+  //
+  // The click side listens for `pointerup` in the CAPTURE phase, not
+  // `click` in the bubble phase. q2-preview's block-edit activation also
+  // fires on `pointerup` (bubble phase) and replaces the clicked element's
+  // subtree with `#q2-active-edit-region` — Chromium then dispatches no
+  // `click` at all, because the `pointerup` target was detached from the
+  // document during the event. Capture-phase `pointerup` runs before that
+  // bubble-phase activation handler, while the target is still attached and
+  // its nearest `[data-loc]` ancestor is still resolvable.
   useEffect(() => {
     if (!iframeReady) return;
     const iframe = iframeRef.current;
@@ -223,15 +237,18 @@ export function Q2PreviewIframe({
     if (!win || !doc) return;
 
     const handleScroll = () => onScroll?.();
-    const handleClick = () => onClick?.();
+    const handlePointerUp = (e: Event) => {
+      const line = lineForClickTarget(e.target);
+      if (line !== null) onClickAtLine?.(line);
+    };
 
     win.addEventListener('scroll', handleScroll, { passive: true });
-    doc.addEventListener('click', handleClick);
+    doc.addEventListener('pointerup', handlePointerUp, true);
     return () => {
       win.removeEventListener('scroll', handleScroll);
-      doc.removeEventListener('click', handleClick);
+      doc.removeEventListener('pointerup', handlePointerUp, true);
     };
-  }, [iframeReady, onScroll, onClick]);
+  }, [iframeReady, onScroll, onClickAtLine]);
 
   // Track the last fingerprint we posted and the current outstanding
   // blob URL so we can dedupe re-sends and revoke replaced URLs.

--- a/ts-packages/preview-renderer/src/iframe/Q2PreviewIframe.tsx
+++ b/ts-packages/preview-renderer/src/iframe/Q2PreviewIframe.tsx
@@ -141,9 +141,13 @@ interface Q2PreviewIframeProps {
    * Called with the resolved source line when a capture-phase `pointerup`
    * on the iframe document resolves one via `lineForClickTarget`
    * (preview→editor click sync). Not called at all when the click doesn't
-   * resolve a line (see `lineForClickTarget`'s null cases).
+   * resolve a line (see `lineForClickTarget`'s null cases). The second
+   * argument, `hostY`, is the clicked block's top edge in HOST-PAGE
+   * coordinates (see the `pointerup` handler below) — used by
+   * `useScrollSync.revealEditorLine` to align that source line to the same
+   * on-screen y, not just reveal it (2026-08-22 click-align-editor-y plan).
    */
-  onClickAtLine?: (line: number) => void;
+  onClickAtLine?: (line: number, hostY?: number) => void;
   /**
    * Called after the iframe commits a new AST (`AST_RENDERED`), so the host
    * can re-run editor→preview scroll sync against the fresh `data-loc` DOM.
@@ -239,7 +243,21 @@ export function Q2PreviewIframe({
     const handleScroll = () => onScroll?.();
     const handlePointerUp = (e: Event) => {
       const line = lineForClickTarget(e.target);
-      if (line !== null) onClickAtLine?.(line);
+      if (line === null) return;
+      // Report the clicked block's top edge in HOST-PAGE coordinates, so
+      // the editor can align that line to the same on-screen y as the
+      // preview's editing pane (decision A2, 2026-08-22 plan): the block's
+      // rect is in the IFRAME's viewport, so the iframe element's own top
+      // in the host page has to be added. The edit region doesn't exist yet
+      // at capture-phase pointerup — it replaces the clicked block in
+      // place, so the block's top *is* the pane's top.
+      const target = e.target as { closest?: Element['closest'] } | null;
+      const block = target?.closest?.('[data-loc]');
+      const blockTop = block?.getBoundingClientRect().top;
+      const iframeTop = iframe?.getBoundingClientRect().top;
+      const hostY =
+        blockTop !== undefined && iframeTop !== undefined ? blockTop + iframeTop : undefined;
+      onClickAtLine?.(line, hostY);
     };
 
     win.addEventListener('scroll', handleScroll, { passive: true });

--- a/ts-packages/preview-renderer/src/iframe/scrollSyncDom.integration.test.ts
+++ b/ts-packages/preview-renderer/src/iframe/scrollSyncDom.integration.test.ts
@@ -3,7 +3,7 @@
  * real Document/querySelectorAll backs `findElementForLine`.
  */
 import { describe, it, expect } from 'vitest';
-import { parseDataLoc, findElementForLine } from './scrollSyncDom';
+import { parseDataLoc, findElementForLine, lineForClickTarget } from './scrollSyncDom';
 
 describe('parseDataLoc', () => {
     it('parses a well-formed data-loc into 1-based fields', () => {
@@ -87,5 +87,117 @@ describe('findElementForLine', () => {
     it('ignores elements with an unparseable data-loc', () => {
         const doc = docWith('<p data-loc="garbage" id="g">g</p>');
         expect(findElementForLine(doc, 1)).toBeNull();
+    });
+});
+
+describe('lineForClickTarget', () => {
+    // bd-9kzfi follow-up (2026-08-21 plan): the click-to-editor-scroll fix.
+    // U1a-U1e per the task-2 brief. Each row is bound to a specific wrong
+    // implementation, not merely "not null" — see the brief for the exact
+    // hazard each guards against.
+    function docWith(html: string): Document {
+        const doc = document.implementation.createHTMLDocument('t');
+        doc.body.innerHTML = html;
+        return doc;
+    }
+
+    it('U1a: resolves to the innermost [data-loc] ancestor, not an outer section', () => {
+        // Reddens if closest('[data-loc]') is swapped for a document-wide
+        // querySelector('[data-loc]') — that would return the section's 5
+        // (first data-loc in document order) regardless of target.
+        const doc = docWith(
+            '<section data-loc="0:5:1-30:1">' +
+                '<p data-loc="0:12:1-14:20"><em id="t">x</em></p>' +
+                '</section>',
+        );
+        expect(lineForClickTarget(doc.getElementById('t'))).toBe(12);
+    });
+
+    it('U1b: returns null when there is no [data-loc] ancestor, even though an unrelated located element exists elsewhere in the document', () => {
+        // The decoy <p> is NOT an ancestor of #s — it discriminates a
+        // "nearest located block in the document" fallback (which would
+        // wrongly latch onto it and return 2) from the correct
+        // ancestor-only lookup (which must still return null). A fixture
+        // with zero [data-loc] elements anywhere would pass under both
+        // implementations and not actually test this hazard.
+        const doc = docWith(
+            '<p data-loc="0:2:1-2:5" id="decoy">decoy</p>' +
+                '<div id="stray"><span id="s">no loc</span></div>',
+        );
+        expect(lineForClickTarget(doc.getElementById('s'))).toBeNull();
+    });
+
+    it('U1c: returns null inside the active-edit-region even when nested in a located section', () => {
+        // Load-bearing hazard row: the edit region is nested INSIDE the
+        // located <section> (not floating at the document root), so a
+        // deleted active-region guard would fall through to the section's
+        // closest('[data-loc]') and return 5 instead of null.
+        const doc = docWith(
+            '<section data-loc="0:5:1-30:1">' +
+                '<div id="q2-active-edit-region"><span id="inEdit">y</span></div>' +
+                '</section>',
+        );
+        expect(lineForClickTarget(doc.getElementById('inEdit'))).toBeNull();
+    });
+
+    it('U1d: returns null when the nearest [data-loc] ancestor is the <section> itself', () => {
+        // Reddens if the <section> check is deleted — inter-block
+        // whitespace directly inside the section would resolve to 5.
+        const doc = docWith(
+            '<section data-loc="0:5:1-30:1">' +
+                '<p data-loc="0:12:1-14:20">x</p>' +
+                '<span id="ws"></span>' +
+                '</section>',
+        );
+        expect(lineForClickTarget(doc.getElementById('ws'))).toBeNull();
+    });
+
+    it('U1e: returns null and never throws for non-Element targets', () => {
+        // Reddens if the narrowing guard is dropped (throws instead of
+        // returning null) — see U1f below for why that guard is a
+        // duck-typed `.closest` check rather than `instanceof Element`.
+        expect(() => lineForClickTarget(document)).not.toThrow();
+        expect(lineForClickTarget(document)).toBeNull();
+        expect(() => lineForClickTarget(null)).not.toThrow();
+        expect(lineForClickTarget(null)).toBeNull();
+    });
+
+    it('U1f: resolves correctly across a real cross-realm (iframe) Element boundary', () => {
+        // Task 4 finding (2026-08-21 plan, ruling recorded on review): the
+        // originally pinned `target instanceof Element` guard is
+        // realm-specific. In production `lineForClickTarget` runs in the
+        // PARENT frame's realm against a `pointerup` target that lives in
+        // the sandboxed IFRAME's realm — each realm has its own `Element`
+        // constructor, so `target instanceof Element` (checked against the
+        // parent's `Element`) is always false for a real iframe-originated
+        // node. That silently broke the whole feature end-to-end (no line
+        // ever resolved, so no reveal ever fired) while U1a-U1e stayed green,
+        // because those rows build same-realm fixtures via
+        // `document.implementation.createHTMLDocument`. This row builds a
+        // genuinely cross-realm element (a real iframe's contentDocument) so
+        // a future "cleanup" that reverts the duck-typed `.closest` guard
+        // back to `instanceof Element` reddens here, not only in the slower
+        // Playwright suite (E2).
+        //
+        // Named revert: change the guard in `lineForClickTarget` back to
+        // `target instanceof Element` → returns null instead of 12 → RED.
+        const iframe = document.createElement('iframe');
+        document.body.appendChild(iframe);
+        try {
+            const frameDoc = iframe.contentDocument!;
+            frameDoc.open();
+            frameDoc.write('<p data-loc="0:12:1-14:20"><em id="t">x</em></p>');
+            frameDoc.close();
+
+            const target = frameDoc.getElementById('t');
+            expect(target).not.toBeNull();
+            // Sanity check that the fixture is genuinely cross-realm: the
+            // iframe's element is not an instance of the parent's Element.
+            expect(target instanceof Element).toBe(false);
+
+            expect(lineForClickTarget(target)).toBe(12);
+        } finally {
+            document.body.removeChild(iframe);
+        }
     });
 });

--- a/ts-packages/preview-renderer/src/iframe/scrollSyncDom.integration.test.ts
+++ b/ts-packages/preview-renderer/src/iframe/scrollSyncDom.integration.test.ts
@@ -127,14 +127,27 @@ describe('lineForClickTarget', () => {
         expect(lineForClickTarget(doc.getElementById('s'))).toBeNull();
     });
 
-    it('U1c: returns null inside the active-edit-region even when nested in a located section', () => {
-        // Load-bearing hazard row: the edit region is nested INSIDE the
-        // located <section> (not floating at the document root), so a
-        // deleted active-region guard would fall through to the section's
-        // closest('[data-loc]') and return 5 instead of null.
+    it('U1c: returns null inside the active-edit-region even when nested in a located non-section wrapper', () => {
+        // Load-bearing hazard row: the edit region is nested INSIDE a located
+        // non-section wrapper (a callout/fenced-div stand-in) which is itself
+        // inside the located <section>. The wrapper must NOT be a <section> —
+        // if it were, the *separate, pre-existing* section guard would return
+        // null on its own and this row would pass with the active-region
+        // guard deleted too, telling you nothing (that was the original bug:
+        // both U1c and Playwright T4 passed with the guard gone). With a
+        // non-section wrapper, closest('[data-loc]') from inside the region
+        // resolves the wrapper (20), which is not a <section>, so only the
+        // active-region guard stands between this row and a wrong line.
+        //
+        // Named revert: delete the active-region guard (`if
+        // (el.closest('#q2-active-edit-region')) return null;`) from
+        // `lineForClickTarget` → returns 20 (the wrapper's line) instead of
+        // null → RED.
         const doc = docWith(
             '<section data-loc="0:5:1-30:1">' +
+                '<div class="callout" data-loc="0:20:1-24:9">' +
                 '<div id="q2-active-edit-region"><span id="inEdit">y</span></div>' +
+                '</div>' +
                 '</section>',
         );
         expect(lineForClickTarget(doc.getElementById('inEdit'))).toBeNull();
@@ -199,5 +212,30 @@ describe('lineForClickTarget', () => {
         } finally {
             document.body.removeChild(iframe);
         }
+    });
+
+    it('U1g: returns null for a located element whose fileId is not the rendered document (0)', () => {
+        // Task 10 (2026-08-21 plan): the rendered document is always
+        // FileId(0) (ParseDocumentStage registers it before
+        // IncludeExpansionStage registers any included file). A non-zero
+        // fileId means the line belongs to an included file's own line
+        // numbering, not the currently open editor's — revealing it would
+        // be a silent mis-navigation.
+        //
+        // Named revert: remove the fileId check from lineForClickTarget →
+        // returns 12 (a line number belonging to a different file) → RED.
+        const doc = docWith('<p data-loc="3:12:1-14:20"><em id="t">x</em></p>');
+        expect(lineForClickTarget(doc.getElementById('t'))).toBeNull();
+    });
+
+    it('U1h: resolves normally for a located element whose fileId is the rendered document (0)', () => {
+        // Same-file control for U1g: guards against a guard that rejects
+        // every click regardless of fileId (which would pass U1g while
+        // breaking every existing same-file row).
+        //
+        // Named revert: reject unconditionally regardless of fileId →
+        // returns null instead of 12 → RED.
+        const doc = docWith('<p data-loc="0:12:1-14:20"><em id="t">x</em></p>');
+        expect(lineForClickTarget(doc.getElementById('t'))).toBe(12);
     });
 });

--- a/ts-packages/preview-renderer/src/iframe/scrollSyncDom.ts
+++ b/ts-packages/preview-renderer/src/iframe/scrollSyncDom.ts
@@ -95,17 +95,29 @@ export function findElementForLine(
  *
  * Walks up from `target` via `closest`, so the innermost located ancestor
  * wins (never a document-wide `querySelector`, which would ignore the
- * target entirely). Three cases return `null` rather than a line:
+ * target entirely). Four cases return `null` rather than a line:
  *
  *  - the target is inside `#q2-active-edit-region` — q2-preview's block
  *    activation replaces the clicked subtree with this synthetic region on
  *    the same `pointerup`; a caret move inside an already-open editor must
  *    not yank the editor to the enclosing block.
- *  - the nearest `[data-loc]` ancestor is a `<section>` — sections carry a
- *    `data-loc` too (`SectionizeTransform` is unconditional), so
- *    inter-block whitespace or an edit region nested inside a section would
- *    otherwise resolve to the section's own (usually distant) line.
+ *  - the nearest `[data-loc]` ancestor is a `<section>` — sections are pure
+ *    `SectionizeTransform` synthesis with no source preimage
+ *    (`SourceInfo::Generated`), so `dataLocProps` never actually emits a
+ *    `data-loc` for one and this branch is currently unreachable under
+ *    q2-preview. Kept as defence-in-depth: correct the day sections gain a
+ *    resolvable location.
  *  - there is no `[data-loc]` ancestor at all.
+ *  - the located ancestor's `fileId` is not the rendered document's own
+ *    (`0` — `ParseDocumentStage` always registers the document being
+ *    rendered before `IncludeExpansionStage` registers any included file,
+ *    so the current file is always id 0 and any other id is included
+ *    content). The line number belongs to the *included* file's own line
+ *    numbering, not the currently open editor's; revealing it there would
+ *    be a silent mis-navigation to an unrelated, coincidentally-numbered
+ *    line. Scrolling to the `{{< include … >}}` shortcode's own line
+ *    instead is deferred follow-up work (D5) — this guard only makes the
+ *    wrong reveal stop happening; it is not that answer.
  *
  * Narrows with a duck-typed `.closest` check rather than `instanceof
  * Element`: in production this runs in the *parent* frame's realm against a
@@ -130,6 +142,7 @@ export function lineForClickTarget(target: EventTarget | null): number | null {
     if (!dataLoc) return null;
     const loc = parseDataLoc(dataLoc);
     if (!loc) return null;
+    if (loc.fileId !== 0) return null;
 
     return loc.startLine;
 }

--- a/ts-packages/preview-renderer/src/iframe/scrollSyncDom.ts
+++ b/ts-packages/preview-renderer/src/iframe/scrollSyncDom.ts
@@ -89,6 +89,52 @@ export function findElementForLine(
 }
 
 /**
+ * Preview→editor click sync (click-to-editor-scroll, bd-9kzfi follow-up):
+ * resolve a `pointerup` event target to the source line it should reveal in
+ * the editor, or `null` when the click should be inert.
+ *
+ * Walks up from `target` via `closest`, so the innermost located ancestor
+ * wins (never a document-wide `querySelector`, which would ignore the
+ * target entirely). Three cases return `null` rather than a line:
+ *
+ *  - the target is inside `#q2-active-edit-region` — q2-preview's block
+ *    activation replaces the clicked subtree with this synthetic region on
+ *    the same `pointerup`; a caret move inside an already-open editor must
+ *    not yank the editor to the enclosing block.
+ *  - the nearest `[data-loc]` ancestor is a `<section>` — sections carry a
+ *    `data-loc` too (`SectionizeTransform` is unconditional), so
+ *    inter-block whitespace or an edit region nested inside a section would
+ *    otherwise resolve to the section's own (usually distant) line.
+ *  - there is no `[data-loc]` ancestor at all.
+ *
+ * Narrows with a duck-typed `.closest` check rather than `instanceof
+ * Element`: in production this runs in the *parent* frame's realm against a
+ * `pointerup` target from the sandboxed *iframe*'s realm, and each realm has
+ * its own `Element` constructor — `target instanceof Element` (the parent's
+ * `Element`) is always false for an iframe-realm node, even a real `<p>`.
+ * `closest` is realm-agnostic duck typing that still excludes `Document`,
+ * `Window`, and other non-Element `EventTarget`s (none of which have it).
+ */
+export function lineForClickTarget(target: EventTarget | null): number | null {
+    if (target === null || typeof (target as { closest?: unknown }).closest !== 'function') {
+        return null;
+    }
+    const el = target as Element;
+    if (el.closest('#q2-active-edit-region')) return null;
+
+    const locEl = el.closest('[data-loc]');
+    if (!locEl) return null;
+    if (locEl.tagName.toLowerCase() === 'section') return null;
+
+    const dataLoc = locEl.getAttribute('data-loc');
+    if (!dataLoc) return null;
+    const loc = parseDataLoc(dataLoc);
+    if (!loc) return null;
+
+    return loc.startLine;
+}
+
+/**
  * Check if an element is fully visible within the iframe viewport.
  * `win` is the iframe's own `contentWindow` (so `innerHeight` is the
  * preview viewport, not the host page's).


### PR DESCRIPTION
Clicking a block in the **q2-preview** never moved the Monaco source editor. Clicking in the **HTML preview** moved it, but centered the line vertically. Both now *align*: the clicked block's first source line lands at the same on-screen Y position as the block itself, so the panes read side by side.

17 files, ~3050 insertions. TypeScript only — no Rust or Cargo files changed, which is why `cargo xtask verify` isn't part of this.

## Why q2-preview did nothing

`Q2PreviewIframe` drove preview→editor sync off a `click` listener on the iframe document. But q2-preview activates block editing on `pointerup`, and activation *replaces the clicked element's subtree* with a synthetic edit region — and Chromium dispatches no `click` at all when the `pointerup` target was detached during `pointerup`. So the handler never ran for the one gesture that mattered.

Fixed by listening for **capture-phase `pointerup`**, which runs before the app's bubble-phase activation handler while the target is still attached, and resolving the nearest `[data-loc]` ancestor to a source line.

## The alignment

```
scrollTop = getTopForLineNumber(line) - (hostY - editorTop)
```

clamped to the editor's scroll range. Near a document's start or end the clamp wins and the panes can't line up exactly — geometry, not a bug.

`hostY` crosses two coordinate spaces: the clicked element's rect is relative to the **iframe's** viewport, so the iframe element's own offset in the host page is added. Dropping that term misaligns by exactly the height of the chrome above the preview. jsdom has no layout, so only the browser row can catch it; its 6px tolerance is set by measurement — reverting to the old centring call misses by ~13px.

Two deliberate asymmetries between the previews:

- **q2-preview takes no focus and moves no cursor.** The same click opens an inline editor *in the preview*; pulling focus to Monaco would break the gesture it just started, and `setPosition` would feed editor→preview sync and bounce.
- **The HTML preview keeps its cursor move and focus steal.** It has no inline editor to protect, and that's the behaviour users already have. Only the centring is replaced.

## Five defects the tests as written could not have caught

Worth reviewing in their own right — each came from a step beyond "the suite is green".

1. **The plan's own pinned API specified `instanceof Element`**, which is false for *every* real click: the listener runs in the parent frame's realm against a target from the sandboxed iframe's realm, and each realm has its own `Element`. Thirteen green jsdom rows passed against a guard that returned `null` in production. Only the real-browser row caught it. The shipped guard is duck-typed, and a new row reproduces the cross-realm case at the jsdom tier so a revert reddens a fast test.
2. **The reveal was silently overwritten ~50 ms after landing correctly.** `revealEditorLine` never set `isSyncingRef`, and by design never takes focus — so *both* of `syncPreviewToEditor`'s feedback guards were unarmed, and any post-click reflow replaced the reveal with a ratio-derived position. Measured: correct at t=1 ms, a 6px preview scroll at t=6 ms as a toolbar mounted, wrong by t=83 ms, with no second `pointerup`.
3. **Foreign-`fileId` clicks weren't inert as the plan claimed** — they revealed the *included* file's line number as a line in the open file.
4. **The caret-move guard was unbound.** Deleting it reddened neither of its two rows: the fixture nested the edit region inside a located `<section>`, so a *separate* guard returned `null` anyway and the row couldn't tell a working implementation from a broken one. Found by a six-hunk fail-on-revert pass over the finished seam.
5. **The HTML preview set the caret into included content** — worse than (3), since you could then type into the wrong place. Fixed here because we were already editing that function.

## What to look at

- `scrollSyncDom.ts` — `lineForClickTarget`'s four `null` cases and the duck-typed narrowing. Please don't "tidy" the latter back to `instanceof`.
- `useScrollSync.ts` — `revealEditorLine` is threaded into `useSelectionSync` rather than extracted into a shared helper. That's load-bearing: it brackets `useScrollSync`'s own `isSyncingRef`, the flag `syncPreviewToEditor` reads. A shared helper would set the other hook's unrelated flag and reopen (2) on the HTML path.
- `Q2PreviewIframe.tsx` / `MorphIframe.tsx` — the two-coordinate-space `hostY` computation, in both previews.

## Tests

22 jsdom rows and 7 Playwright rows, each bound to a named production hunk. Every hunk was reverted and confirmed to redden its rows. Two rows are pinned against plausible-looking "fixes": one asserts click-align is *not* gated by the scroll-sync toggle (adding the gate looks tidy and would break it), and the browser race row asserts as a precondition that the reflow it depends on actually fired, so it can't quietly go vacuous.

`hub-client` 1001 unit / 112 integration / 131 wasm · `preview-renderer` 549 unit / 590 integration · `typecheck:tests` clean · `build:all` clean · Playwright 7/7.

One pre-existing unrelated failure: `custom-components` `Equation > appends \tag{N}` under the pinned katex 0.18.1 — filed as **bd-s36g9dav**, fails identically on `main` (invisible there only because a stale `node_modules` pins katex 0.17.0).

## Deferred, deliberately

- **D5** — clicking included content should reveal the `{{< include >}}` shortcode's own line. Investigated; recommends a client-side scan over a producer-side Rust/wire change. Inert today, not wrong.
- **bd-5n66w8cs** — `local-prod-server.mjs` dies on an unhandled `ECONNRESET`; hit it twice while demoing.
- **bd-mdcqnl84** (closed) — ratio scroll sync stays, since the scroll-sync toggle governs it. Its origin is worth knowing: loc-based preview→editor sync was *specified* in the 2025-12-29 matched-scrolling plan and never implemented; the ratio substitution shipped and that plan was marked Completed.

Plans: `claude-notes/plans/2026-08-21-preview-click-to-editor-scroll.md`, `claude-notes/plans/2026-08-22-click-align-editor-y.md`. Both record the false premises they contained, so the next reader doesn't re-derive them.
