### PR TITLE
Fix two macOS flakes in the workspace TS suites (GH #250)

### DIFF
--- a/ts-packages/quarto-hub-mcp/src/exit-drain.test.ts
+++ b/ts-packages/quarto-hub-mcp/src/exit-drain.test.ts
@@ -25,8 +25,44 @@ import { startTestHub, type TestHub } from './test-hub.js';
 // race by luck on loopback, masking the defect. Both levers matter:
 // many docs (per-doc synchronizer backlog) and real bytes (encode +
 // send time).
+//
+// Do not shrink this to make the test faster. The payload is what
+// makes the assertion bind, and the floor is high. Measured on an idle
+// 12-core M-series Mac with FILE_COUNT fixed at 64 (bd-yw3mcdkg):
+//
+//   payload             drain-to-exit   still red with the drain off?
+//   64 x 64 KB (4 MB)   1980-2028 ms    yes
+//   64 x 48 KB (3 MB)   1478-1490 ms    only sometimes
+//   64 x 32 KB (2 MB)        —          NO — passes with no drain at all
+//   64 x 16 KB (1 MB)    506- 612 ms    NO — passes with no drain at all
+//
+// Below ~3 MB everything is delivered before stdin even closes, so the
+// drain has nothing left to do and this test would pass against a
+// server that never drains — i.e. it would stop testing anything. That
+// is measured, not assumed: the drain was disabled and the test re-run
+// at each size above.
 const FILE_COUNT = 64;
 const FILE_BYTES = 64 * 1024;
+
+// The flip side of that floor: ~4 MB does not reliably clear the
+// production 3000 ms drain budget on a loaded 3-core CI runner (the
+// same payload that drains in ~2.0 s idle took 2353-2808 ms with this
+// machine merely busy), which is how this test failed on macOS in 2 of
+// 5 runs after PR #579 wired the suite into CI — ubuntu never failed.
+//
+// So this test overrides the budget rather than racing it. The default
+// stays 3000 ms for real sessions and is asserted elsewhere:
+// stdio-hygiene.test.ts pins the prompt stdin-EOF exit with live sync
+// connections, and the second test below exercises the case where the
+// budget actually binds (hub gone). This test's own subject is
+// narrower — no created document may be lost — so it should not also
+// be a throughput benchmark.
+//
+// Two alternatives were tried and rejected on measurement: shrinking
+// the payload stops the test binding (table above), and `retry` lets it
+// pass even with the drain deleted, because the drain-off failure is
+// probabilistic and one of three attempts gets through.
+const DRAIN_BUDGET_MS = 30_000;
 
 function accidentFiles() {
   return Array.from({ length: FILE_COUNT }, (_, i) => ({
@@ -58,7 +94,9 @@ describe('exit drains outbound sync (bd-10deu8h4)', () => {
 
   it('create_project then immediate stdin EOF must not lose the created docs', async () => {
     client = new McpTestClient();
-    await client.start(['--server', hub.url]);
+    await client.start(['--server', hub.url], {
+      envOverrides: { QUARTO_MCP_SHUTDOWN_DRAIN_MS: String(DRAIN_BUDGET_MS) },
+    });
 
     const result = await client.callTool('create_project', {
       files: accidentFiles(),
@@ -67,8 +105,13 @@ describe('exit drains outbound sync (bd-10deu8h4)', () => {
     expect(created.files).toHaveLength(FILE_COUNT);
 
     // The exact accident: the host closes stdin right after the tool
-    // call returns. The server must still exit promptly (bd-9jq2a060)…
-    expect(await client.endStdinAndWaitForExit(5000)).toBe(true);
+    // call returns. The server must still exit — the drain is
+    // event-driven and returns the moment the hub confirms, so this
+    // lands in ~2 s despite the raised budget. The bound here is a
+    // hang-detector, not a promptness assertion: prompt exit under the
+    // production 3000 ms budget is stdio-hygiene.test.ts's job, and
+    // pinning 5 s here as well is what made this test a throughput race.
+    expect(await client.endStdinAndWaitForExit(DRAIN_BUDGET_MS + 5000)).toBe(true);
 
     // …but not before the created documents reached the hub.
     expect(

--- a/ts-packages/quarto-hub-mcp/src/index.test.ts
+++ b/ts-packages/quarto-hub-mcp/src/index.test.ts
@@ -10,7 +10,12 @@
 
 import { describe, it, expect } from 'vitest';
 
-import { DEFAULT_SERVER_URL, parseArgs, parseRedirectPort } from './index.js';
+import {
+  DEFAULT_SERVER_URL,
+  parseArgs,
+  parseRedirectPort,
+  resolveShutdownDrainMs,
+} from './index.js';
 
 describe('parseRedirectPort', () => {
   it('accepts the bottom of the non-privileged range', () => {
@@ -70,5 +75,47 @@ describe('parseArgs server URL resolution', () => {
       QUARTO_HUB_SERVER: 'wss://env.example/ws',
     });
     expect(parsed.serverUrl).toBe('wss://flag.example/ws');
+  });
+});
+
+/**
+ * `QUARTO_MCP_SHUTDOWN_DRAIN_MS` — the shutdown drain budget's test
+ * seam (bd-yw3mcdkg).
+ *
+ * The production default stays 3000 ms: it is the "exit promptly"
+ * contract (bd-9jq2a060) that stdio-hygiene.test.ts asserts. The
+ * override exists because exit-drain.test.ts has to push ~4 MB through
+ * the drain to keep its assertion binding at all, and 4 MB does not
+ * reliably clear 3000 ms on a 3-core CI runner. Overriding the budget
+ * there removes a throughput race without touching the default that
+ * real `q2 mcp` sessions get.
+ *
+ * A malformed value must fall back to the default rather than throw —
+ * this is read during startup of a stdio server whose stdout belongs to
+ * the protocol, and a typo in someone's shell must not brick the server.
+ */
+describe('resolveShutdownDrainMs', () => {
+  it('defaults to 3000 ms when unset', () => {
+    expect(resolveShutdownDrainMs(undefined)).toBe(3000);
+  });
+
+  it('defaults when set to the empty string', () => {
+    expect(resolveShutdownDrainMs('')).toBe(3000);
+  });
+
+  it('accepts an explicit override', () => {
+    expect(resolveShutdownDrainMs('30000')).toBe(30000);
+  });
+
+  it('accepts 0, which disables the drain', () => {
+    // Deliberate: it is how the drain can be proven load-bearing
+    // without editing source (see exit-drain.test.ts's payload notes).
+    expect(resolveShutdownDrainMs('0')).toBe(0);
+  });
+
+  it('falls back to the default on a malformed value rather than throwing', () => {
+    expect(resolveShutdownDrainMs('abc')).toBe(3000);
+    expect(resolveShutdownDrainMs('3000.5')).toBe(3000);
+    expect(resolveShutdownDrainMs('-1')).toBe(3000);
   });
 });

--- a/ts-packages/quarto-hub-mcp/src/index.ts
+++ b/ts-packages/quarto-hub-mcp/src/index.ts
@@ -81,6 +81,39 @@ export function parseRedirectPort(raw: string): number {
   return port;
 }
 
+/** Production shutdown drain budget, in ms. See {@link resolveShutdownDrainMs}. */
+export const DEFAULT_SHUTDOWN_DRAIN_MS = 3000;
+
+/**
+ * The outbound-sync drain budget at shutdown, honouring the
+ * `QUARTO_MCP_SHUTDOWN_DRAIN_MS` test seam (bd-yw3mcdkg).
+ *
+ * The default is deliberately unchanged: 3000 ms is what keeps the
+ * stdin-EOF exit inside the 5 s promptness contract (bd-9jq2a060) that
+ * `stdio-hygiene.test.ts` asserts, and no real `q2 mcp` session sets
+ * the override.
+ *
+ * The seam exists because `exit-drain.test.ts` is squeezed from both
+ * sides: its assertion only binds with a payload big enough to still be
+ * in flight at EOF (~4 MB), and ~4 MB does not reliably clear 3000 ms on
+ * a 3-core CI runner. Overriding the budget in that one test removes a
+ * throughput race while leaving the shipped behaviour untouched. The
+ * alternatives were measured and rejected — a smaller payload stops the
+ * test binding at all, and a retry lets it pass even with the drain
+ * deleted.
+ *
+ * Malformed input falls back to the default instead of throwing: this is
+ * read while starting a stdio server whose stdout carries the protocol,
+ * and a typo in a shell profile must not brick the server. `0` is
+ * accepted and disables the drain — that is how the drain can be shown
+ * to be load-bearing without patching source.
+ */
+export function resolveShutdownDrainMs(raw: string | undefined): number {
+  if (raw === undefined || raw.trim() === '') return DEFAULT_SHUTDOWN_DRAIN_MS;
+  if (!/^\d+$/.test(raw.trim())) return DEFAULT_SHUTDOWN_DRAIN_MS;
+  return Number.parseInt(raw, 10);
+}
+
 export function parseArgs(
   argv: string[],
   env: NodeJS.ProcessEnv = process.env,
@@ -276,7 +309,13 @@ async function main(): Promise<void> {
   // when the hub is slow or unreachable. 3 s keeps the stdin-EOF exit
   // comfortably inside the 5 s promptness contract that
   // stdio-hygiene.test.ts asserts (bd-9jq2a060).
-  const SHUTDOWN_DRAIN_MS = 3000;
+  //
+  // Overridable via QUARTO_MCP_SHUTDOWN_DRAIN_MS for exit-drain.test.ts
+  // only (bd-yw3mcdkg); the default is unchanged and nothing in a real
+  // session sets it. See resolveShutdownDrainMs.
+  const SHUTDOWN_DRAIN_MS = resolveShutdownDrainMs(
+    process.env['QUARTO_MCP_SHUTDOWN_DRAIN_MS'],
+  );
 
   let shuttingDown = false;
   const shutdown = async (): Promise<void> => {

--- a/ts-packages/quarto-hub-mcp/src/mcp-test-client.ts
+++ b/ts-packages/quarto-hub-mcp/src/mcp-test-client.ts
@@ -49,11 +49,18 @@ export class McpTestClient {
    * (callers spread process.env themselves if they want it); when omitted
    * the child inherits process.env minus the auth-gating vars
    * (QUARTO_HUB_MCP_CLIENT_ID/SECRET) so the server runs unauthenticated
-   * regardless of the developer's shell (bd-uyiqciqk).
+   * regardless of the developer's shell (bd-uyiqciqk). `envOverrides`
+   * MERGES on top of whichever of those two applies — use it to set one
+   * variable without hand-rebuilding (and re-sanitising) the environment.
    */
   async start(
     args: string[],
-    opts?: { entry?: string; command?: { program: string; args: string[] }; env?: NodeJS.ProcessEnv },
+    opts?: {
+      entry?: string;
+      command?: { program: string; args: string[] };
+      env?: NodeJS.ProcessEnv;
+      envOverrides?: NodeJS.ProcessEnv;
+    },
   ): Promise<void> {
     const [program, leading] = opts?.command
       ? [opts.command.program, opts.command.args]
@@ -67,6 +74,11 @@ export class McpTestClient {
       env = { ...process.env };
       delete env['QUARTO_HUB_MCP_CLIENT_ID'];
       delete env['QUARTO_HUB_MCP_CLIENT_SECRET'];
+    }
+    // Applied last, so a test can set one variable without having to
+    // rebuild (and re-sanitise) the whole environment itself.
+    if (opts?.envOverrides) {
+      env = { ...env, ...opts.envOverrides };
     }
     this.proc = spawn(program, [...leading, ...args], {
       stdio: ['pipe', 'pipe', 'pipe'],

--- a/ts-packages/wasm-js-bridge/src/cache.js
+++ b/ts-packages/wasm-js-bridge/src/cache.js
@@ -118,10 +118,24 @@ function compositeKey(namespace, key) {
  */
 export async function jsCacheGet(namespace, key) {
   if (ephemeralMode()) {
-    const record = memoryStore.get(compositeKey(namespace, key));
+    const ck = compositeKey(namespace, key);
+    const record = memoryStore.get(ck);
     if (record == null) return null;
     // Touch-on-read, mirroring the IndexedDB path.
+    //
+    // Re-insert rather than only bumping the timestamp. `Date.now()` has
+    // millisecond resolution, and `evictMemoryIfNeeded` orders entries
+    // with `Array.prototype.sort`, which is stable -- so entries whose
+    // timestamps tie keep their Map insertion order. Enough cache
+    // activity fits inside one millisecond that ties are the common
+    // case, and a touched entry left at its original position then sorts
+    // to the *front* of the oldest-first list and is evicted first,
+    // exactly inverting what touch-on-read is for. Deleting and
+    // re-setting moves it to the end of the iteration order, so on a tie
+    // it is treated as the newest entry.
     record.timestamp = Date.now();
+    memoryStore.delete(ck);
+    memoryStore.set(ck, record);
     return record.value;
   }
   const database = await openDb();

--- a/ts-packages/wasm-js-bridge/src/cache.memory.test.ts
+++ b/ts-packages/wasm-js-bridge/src/cache.memory.test.ts
@@ -13,7 +13,7 @@
  * to the persistent path throws instead of silently passing.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
   jsCacheGet,
   jsCacheSet,
@@ -109,6 +109,37 @@ describe("cache bridge (ephemeral in-memory mode)", () => {
     }
 
     expect(await jsCacheGet("ns", "touched")).toEqual(value);
+  });
+
+  // The test above only fails when the whole body happens to land inside
+  // one Date.now() millisecond, which made it flaky rather than wrong
+  // (GH #250 surfaced it on a macOS runner). Pinning the clock forces
+  // that worst case every run: with every timestamp equal, the eviction
+  // order is decided purely by how jsCacheGet records a touch, so this
+  // binds the fix rather than the timing.
+  it("touch-on-read survives eviction when every timestamp ties", async () => {
+    const clock = vi.spyOn(Date, "now").mockReturnValue(1_000_000);
+    try {
+      const value = new Uint8Array([99]);
+
+      await jsCacheSet("ns", "touched", value);
+      for (let i = 1; i < MAX_ENTRIES; i++) {
+        await jsCacheSet("ns", `filler-${i}`, value);
+      }
+
+      expect(await jsCacheGet("ns", "touched")).toEqual(value);
+      for (let i = 0; i < 5; i++) {
+        await jsCacheSet("ns", `overflow-${i}`, value);
+      }
+
+      // "touched" was inserted first, so a stable sort over tied
+      // timestamps evicts it first unless the touch re-ordered it.
+      expect(await jsCacheGet("ns", "touched")).toEqual(value);
+      // And the untouched oldest filler is the one that should be gone.
+      expect(await jsCacheGet("ns", "filler-1")).toBeNull();
+    } finally {
+      clock.mockRestore();
+    }
   });
 
   it("does not persist across _resetDbHandle (the session boundary)", async () => {


### PR DESCRIPTION
Follow-up to #579 (GH #250), which wired the workspace TS suites into CI and
promptly surfaced two macOS flakes. They turned out to be unrelated — one real
bug, one test racing a real-time budget.

**`wasm-js-bridge` — a real logic bug.** `jsCacheGet`'s touch-on-read bumped
`record.timestamp` in place without moving the entry in the Map.
`evictMemoryIfNeeded` sorts *stably*, so tied timestamps fall back to insertion
order — and the entry we just touched, being oldest by insertion, got evicted
first. Exactly backwards. The fix re-inserts the key; the new test pins
`Date.now()` so every timestamp ties, which makes the case deterministic
instead of ~60% reproducible.

**`quarto-hub-mcp` `exit-drain` — the test, not the product.**
`SHUTDOWN_DRAIN_MS` is a hard 3 s budget to flush outbound sync before exit,
and the test pushes ~4 MB through it. Both of the obvious fixes were tried and
measured, and both are wrong:

- *Shrink the payload* — can't. Below ~3 MB the whole payload is delivered
  before stdin even closes, so the test passes against a server that never
  drains at all. The binding floor and the 3 s ceiling are only ~2× apart on a
  12-core Mac, and CI runners have 3 cores.
- *Add `retry`* — worse. With three attempts it passes with `drainMs: 0` at
  both 3 MB and 4 MB, because the drain-off failure is probabilistic. It would
  have looked like a fix while quietly making a data-loss test vacuous.

So instead there's a `QUARTO_MCP_SHUTDOWN_DRAIN_MS` seam: default unchanged at
3 s, set only by this one test. Promptness doesn't go unguarded — it's asserted
by `stdio-hygiene.test.ts` (real default, live sync connections) and by
exit-drain's second test, which covers the case where the budget actually
binds. Binding was verified rather than assumed: red 3/3 with the drain
disabled through the seam, green 3/3 idle and 6/6 at load average 15–21.

**On the rest of the job.** CI stops at the first red step, so the suites
behind a failure had never run. Locally all 12 tiers were run to completion, 30
iterations each under load (~1,656 tests per pass). Eleven were 30/30. The
twelfth, `quarto-sync-client`, has a pre-existing race (bd-7hd2gzf1) — 3
failures in 50 runs without `--retry`, traced to `connect()` resolving before
it has loaded files the index already lists. Not fixed here: I couldn't
reproduce it reliably or build a deterministic test for it, so `--retry=2`
stays and the details are in bd-l0oc6se2.

Two things deliberately left alone: that race, and the CI sampling bias itself
(a red step still skips every later one) — bd-u7zj5p9w.
