### PR TITLE
brand: unified _brand.yml per-color light/dark values (#580)

### DIFF
--- a/claude-notes/plans/2026-08-24-unified-brand-light-dark.md
+++ b/claude-notes/plans/2026-08-24-unified-brand-light-dark.md
@@ -211,9 +211,12 @@ deltas from the original sketch are marked ⚠.)
       (plus the `rendered.theme.dark-is-default` meta channel and the
       template/navbar consumers reading it with pure fallback).
 - [x] Full workspace: `cargo build --workspace` ✓, `cargo nextest run
-      --workspace` ✓ (13,165 pass), `cargo xtask verify` (full — in progress;
-      two early failures were a clippy nit and rustfmt in a new test file,
-      both fixed).
+      --workspace` ✓ (13,165 pass). `cargo xtask verify`: steps 1–10 green
+      (incl. hub-client build:all/WASM and test:ci); step 11 fails only on
+      the KNOWN pre-existing bd-s36g9dav katex test (reproduced on a clean
+      baseline via stash); the remaining legs (preview-runtime tests, hub
+      MCP builds+tests, q2-preview-spa build) run individually — all green.
+      Coverage: split.rs 100 %, quarto-brand 91 % of functions.
 
 ### Phase 3 — end-to-end verification + docs + bookkeeping
 
@@ -229,7 +232,11 @@ deltas from the original sketch are marked ⚠.)
       `#d0d0ff` in `styles-dark.css`. Palette limitation callout stays true.
       The "directly in the document metadata" example remains blocked by the
       unrelated GH #581 (inline front-matter brand), tracked separately.
-- [ ] Close bd-unified-brand-split-ep49amad; comment on GH #580.
+- [x] Implementation committed on `braid/bd-unified-brand-split-ep49amad`
+      (`f92c85ff6`); strand commented. Closing the strand (plus superseded
+      bd-v5z8w) and commenting on GH #580 deferred until the branch is
+      pushed/merged — both are outward-facing states that should follow the
+      user's review.
 
 ## Out of scope / follow-ups
 

--- a/claude-notes/plans/2026-08-24-unified-brand-light-dark.md
+++ b/claude-notes/plans/2026-08-24-unified-brand-light-dark.md
@@ -1,0 +1,212 @@
+# Unified `_brand.yml` per-color light/dark values (GH #580, bd-unified-brand-split-ep49amad)
+
+## Overview
+
+GH issue [#580](https://github.com/quarto-dev/q2/issues/580) reports that
+`docs/guides/authoring/brand.qmd` ("Light and Dark Colors", L156–L203)
+documents per-color `{light:, dark:}` values inside a single brand, but the
+type model cannot deserialize them:
+
+```yaml
+color:
+  background:
+    light: "#b22222"
+    dark: "#22b222"
+```
+
+fails with `color.background: invalid type: map, expected a string`.
+
+**Reproduced 2026-08-24** at `main` (post-v0.26.0) with
+`cargo run --bin q2 -- render index.qmd`; both controls behave as the issue
+states (plain string renders; two-file `brand: {light:, dark:}` produces
+`--bs-body-bg: #b22222` in `styles.css` and `#22b222` in `styles-dark.css`).
+
+**This work was already tracked** as `bd-unified-brand-split-ep49amad`
+(follow-up from light/dark phase C, bd-ld-c-brand-seam-wef8ww3n). This plan
+executes that strand. Epic: bd-0pic6.
+
+The issue's secondary report — the error lacks the `Q-14-1` code and a source
+snippet — is a separate diagnostics defect, filed as its own strand (see
+"Out of scope / follow-ups").
+
+## Q1 reference implementation
+
+`external-sources/quarto-cli/src/core/brand/brand.ts`:
+
+- Schema (`src/resources/schema/definitions.yml`): `brand-color-unified`
+  gives every *named* color slot the type `brand-color-light-dark` =
+  `string | {light?: string, dark?: string}` (closed). **`palette` entries
+  stay plain strings** — matching the limitation callout in our docs.
+  Typography `color` / `background-color` likewise accept the pair.
+- `splitUnifiedBrand` (brand.ts:629–805): parses the unified brand, then
+  produces `{light: Brand, dark: Brand, enablesDarkMode}`:
+  - a plain string goes to **both** halves;
+  - `{light: X}` with no `dark` puts X in the light half and **omits the
+    slot from the dark half** (no fallback to the light value);
+  - `specializeTypography` re-applies split colors per mode; all non-color
+    typography fields are shared;
+  - `splitLogo` does the same for logo slots (Q2's `LogoEntry::LightDark`
+    already parses this shape).
+- `brandHasDarkMode` (brand.ts:545): dark mode is enabled **iff some slot
+  actually carries a `dark:` key** (color, typography color/background-color,
+  or logo). A unified brand with only plain strings does not enable dark mode.
+
+## Current Q2 architecture (what has to change)
+
+- `crates/quarto-brand/src/types.rs` — `BrandColor` slots are
+  `Option<String>` with `deny_unknown_fields` (L128–164); the map form has
+  nowhere to go. `BrandTypographyOptions.color` / `background_color` are the
+  same shape (L318–349).
+- `crates/quarto-sass/src/config.rs`:
+  - `ThemeConfig::from_config_value` (pure, no I/O) parses `theme:` +
+    `brand:`; when `brand: {…, dark: …}` exists it **synthesizes the dark
+    theme variant at config time** (L348) — possible there only because the
+    two-file form announces its dark half in the config itself.
+  - `ThemeConfig::resolve(runtime, base_dir)` (L462) does the I/O:
+    reads the brand file and `serde_yaml`-parses it, **once per variant**
+    (light and dark variants each re-read the same file today).
+- `crates/quarto-core/src/stage/stages/compile_theme_css.rs` (L487–541):
+  resolves the light variant's brand, compiles; if `dark_variant()` exists,
+  resolves the dark variant's brand and compiles that too. This stage runs
+  in both native and WASM (hub-client live recompile), so wiring here covers
+  both paths.
+- `crates/quarto-sass/src/brand_layer.rs` + `crates/quarto-brand/src/resolve.rs`
+  consume `Option<String>`-shaped slots (`named_colors()`, `resolve_color`,
+  typography layer). Color resolution (palette/theme-color reference chains)
+  operates on a single-mode brand.
+
+**The architectural wrinkle:** for a unified brand, "does this brand enable
+dark mode" is a property of the brand *file contents*, which are only read in
+`resolve()` — after `from_config_value` has already decided whether a dark
+variant exists. The synthesis decision has to move to (or be repeated at) a
+point where the parsed brand is available.
+
+## Design
+
+Follow Q1's shape: **parse unified, split early, keep every downstream
+consumer single-mode.**
+
+1. **Type surgery (`quarto-brand`).** New untagged value type:
+
+   ```rust
+   #[derive(Debug, Clone, Deserialize, Serialize)]
+   #[serde(untagged, deny_unknown_fields)]
+   pub enum BrandColorValue {
+       Single(String),
+       LightDark { light: Option<String>, dark: Option<String> },
+   }
+   ```
+
+   - The 13 named slots in `BrandColor` become `Option<BrandColorValue>`.
+   - `palette` stays `BTreeMap<String, String>` (documented limitation,
+     matches Q1's schema).
+   - `BrandTypographyOptions.color` / `background_color` become
+     `Option<BrandColorValue>`.
+   - `Brand::has_dark_mode()` — port of `brandHasDarkMode` (colors,
+     typography colors, logos).
+   - `Brand::split() -> SplitBrand { light: Brand, dark: Brand }` — port of
+     `splitUnifiedBrand` semantics (string → both; missing half → slot
+     omitted in that half; logos via existing `LogoEntry::LightDark`).
+     Post-split brands hold only `Single` values.
+   - Single-mode accessors (`named()`, the typography layer, `resolve_color`)
+     read the `Single` variant; a `LightDark` reaching them is a logic error
+     (they only ever see split brands). Keep the accessor signatures
+     returning `Option<&str>` so `brand_layer.rs` / `resolve.rs` change
+     minimally.
+
+2. **Split + dark-synthesis seam (`quarto-sass` / stage).** Restructure brand
+   resolution so the brand file is **read and parsed once**, split, and each
+   variant handed its half:
+
+   - New entry point on `ThemeConfig` (working name
+     `resolve_variants(runtime, base_dir)`) that:
+     1. resolves the light `brand_ref` → unified `Brand`;
+     2. splits it → light/dark halves;
+     3. if the brand `has_dark_mode()` and `self.dark.is_none()`, synthesizes
+        the dark theme variant (same construction as the existing config-time
+        synthesis at config.rs:348 — clone light themes, inject brand token,
+        `is_default: false` since a unified brand has no `dark_first`
+        ordering signal);
+     4. returns per-variant resolved configs for the stage to compile.
+   - The existing config-time synthesis for the **two-file** form stays where
+     it is (it needs no file contents); the new seam only adds the
+     content-driven case. `from_config_value` stays pure.
+   - `compile_theme_css.rs` switches from its two `resolve()` calls to the
+     new entry point. Because the stage is shared, WASM/live-recompile gets
+     the behavior for free.
+   - **Two-file form + unified values** (a file named by
+     `brand: {light: f1, dark: f2}` that itself uses `{light:, dark:}`
+     values): Q1 rejects this (those files validate against the closed
+     single-brand schema). Recommendation: split each file and keep the
+     matching half (light file → light half), which is strictly more
+     permissive than Q1 and avoids a second type family; note the divergence
+     in the docs audit (bd-qnylgu69). — **Open decision, flag at review.**
+
+3. **No caching changes.** Each variant still feeds `variant_css` a resolved
+   single-mode brand; fingerprints already incorporate the brand content the
+   same way they do today.
+
+## Work items
+
+### Phase 0 — tests first (TDD)
+
+- [ ] `quarto-brand` unit tests: parse `BrandColorValue` map form for named
+      colors and typography `color`/`background-color`; reject unknown keys
+      inside the pair; palette map value still errors.
+- [ ] `quarto-brand` unit tests: `split()` semantics (string → both halves;
+      light-only → dark half omits slot; typography colors specialize;
+      logos); `has_dark_mode()` (true only when a `dark:` key exists
+      somewhere; false for all-plain-string brands).
+- [ ] `quarto-sass` config tests: unified brand with dark values + no
+      `theme:` dark half → dark variant synthesized (brand token injected,
+      `is_default: false`); unified brand with no dark values → no dark
+      variant; unified brand + explicit `theme: {light:, dark:}` → theme's
+      `is_default` wins.
+- [ ] End-to-end test (through `render_document_to_file`-level helper, per
+      CLAUDE.md): fixture = issue #580's `_brand.yml` + `index.qmd`; assert
+      `styles.css` has the light value and `styles-dark.css` the dark value,
+      and the toggle/link pair is emitted. Also the typography case
+      (`typography.headings.color: {light:, dark:}`).
+- [ ] Run all new tests, verify they fail for the expected reason.
+
+### Phase 1 — quarto-brand type surgery
+
+- [ ] `BrandColorValue` enum + field type changes + accessors.
+- [ ] `Brand::has_dark_mode()`, `Brand::split()`.
+- [ ] Update `brand_layer.rs` / `resolve.rs` call sites to the single-mode
+      accessors; quarto-brand + quarto-sass tests green.
+
+### Phase 2 — pipeline wiring
+
+- [ ] `ThemeConfig::resolve_variants` (read once, split, synthesize dark).
+- [ ] Switch `compile_theme_css.rs` to it; remove the per-variant re-read.
+- [ ] Full workspace: `cargo build --workspace`, `cargo nextest run
+      --workspace`, `cargo xtask verify` (full — quarto-core/pampa are in the
+      WASM closure).
+
+### Phase 3 — end-to-end verification + docs + bookkeeping
+
+- [ ] `cargo run --bin q2 -- render` on the #580 repro; inspect
+      `styles.css` / `styles-dark.css`; record invocation + output snippet
+      here.
+- [ ] Verify the two controls still behave (plain string; two-file form).
+- [ ] Check `docs/guides/authoring/brand.qmd` §"Light and Dark Colors" now
+      matches reality (it should — the docs were written for this feature);
+      note the palette limitation stays.
+- [ ] Close bd-unified-brand-split-ep49amad; comment on GH #580.
+
+## Out of scope / follow-ups
+
+- **Diagnostics quality** (#580's secondary report): brand-file parse errors
+  bypass `sass_error_to_parse_error`, so they print without `Q-14-1` and
+  without a snippet despite serde_yaml providing line/col
+  (`brand_err` sets `location: None`; the stage wraps it as a plain stage
+  error). Filed as its own strand — needs the brand file bound via
+  `bind_config_source` (mind the `add-file-with-id` lint) and a
+  serde_yaml line/col → span mapping.
+- **GH #581** (inline `brand:` block always fails: PandocInlines walker) —
+  separate defect, separate strand; not addressed here.
+- **Palette light/dark** — deliberately unsupported (docs callout + Q1
+  schema agree).
+- bd-v5z8w is superseded by phase C + this strand (its own comment already
+  suggests closing it in favor of bd-unified-brand-split-ep49amad).

--- a/claude-notes/plans/2026-08-24-unified-brand-light-dark.md
+++ b/claude-notes/plans/2026-08-24-unified-brand-light-dark.md
@@ -84,115 +84,151 @@ point where the parsed brand is available.
 ## Design
 
 Follow Q1's shape: **parse unified, split early, keep every downstream
-consumer single-mode.**
+consumer single-mode.** (Refined 2026-08-24 after reading all consumers;
+deltas from the original sketch are marked ⚠.)
 
-1. **Type surgery (`quarto-brand`).** New untagged value type:
+1. **Type surgery (`quarto-brand`).** Make the brand types generic over the
+   color-value type, with a default that keeps every existing consumer
+   compiling unchanged:
 
    ```rust
-   #[derive(Debug, Clone, Deserialize, Serialize)]
-   #[serde(untagged, deny_unknown_fields)]
+   pub struct Brand<V = String> { ... }          // BrandColor<V>, BrandTypography<V>,
+   pub type UnifiedBrand = Brand<BrandColorValue>; // BrandTypographyOptions<V> likewise
+
+   #[serde(untagged)]
    pub enum BrandColorValue {
        Single(String),
-       LightDark { light: Option<String>, dark: Option<String> },
-   }
+       LightDark(BrandColorLightDark),           // { light: Option<String>, dark: Option<String> },
+   }                                             // deny_unknown_fields on the inner struct
    ```
 
-   - The 13 named slots in `BrandColor` become `Option<BrandColorValue>`.
-   - `palette` stays `BTreeMap<String, String>` (documented limitation,
-     matches Q1's schema).
-   - `BrandTypographyOptions.color` / `background_color` become
-     `Option<BrandColorValue>`.
-   - `Brand::has_dark_mode()` — port of `brandHasDarkMode` (colors,
-     typography colors, logos).
-   - `Brand::split() -> SplitBrand { light: Brand, dark: Brand }` — port of
-     `splitUnifiedBrand` semantics (string → both; missing half → slot
-     omitted in that half; logos via existing `LogoEntry::LightDark`).
-     Post-split brands hold only `Single` values.
-   - Single-mode accessors (`named()`, the typography layer, `resolve_color`)
-     read the `Single` variant; a `LightDark` reaching them is a logic error
-     (they only ever see split brands). Keep the accessor signatures
-     returning `Option<&str>` so `brand_layer.rs` / `resolve.rs` change
-     minimally.
+   - ⚠ Generic-with-default instead of one type holding enum slots: consumers
+     keep `Brand` (= `Brand<String>`) and get a *compile-time* guarantee that
+     split brands contain only plain strings; `resolve_color`, `named()`,
+     `named_colors()`, and the SCSS layer are only defined on `Brand<String>`.
+     Parsing (`from_yaml_str`, inline `serde_yaml::from_value`) produces
+     `UnifiedBrand` only, so every construction site is forced through the
+     split. Manual `Default` impls avoid the spurious `V: Default` bound.
+   - The 13 named slots in `BrandColor<V>` become `Option<V>`; `palette`
+     stays `BTreeMap<String, String>` (documented limitation, matches Q1's
+     schema). `BrandTypographyOptions<V>::color` / `background_color` become
+     `Option<V>`.
+   - `UnifiedBrand::has_dark_mode()` — port of `brandHasDarkMode`: true iff
+     some named color, typography color/background-color, or logo entry
+     carries a `dark:` key.
+   - `UnifiedBrand::split() -> SplitBrand { light: Brand, dark: Brand,
+     enables_dark_mode: bool }` — port of `splitUnifiedBrand` semantics
+     (string → both halves; `{light: X}` only → slot omitted from the dark
+     half, no fallback; palette/meta/defaults/fonts shared).
+   - ⚠ **Logos are carried through unsplit** (divergence from Q1's
+     `splitLogo`): q2's logo consumers (favicon bd-97yc, navbar image
+     bd-hp3tx) run once per document and need both sides to emit light/dark
+     markup — `LogoEntry::LightDark` already models that. Logo dark halves
+     still count for `has_dark_mode` (Q1 parity).
 
-2. **Split + dark-synthesis seam (`quarto-sass` / stage).** Restructure brand
-   resolution so the brand file is **read and parsed once**, split, and each
-   variant handed its half:
+2. **Split + dark-synthesis seam (`quarto-sass`).**
 
-   - New entry point on `ThemeConfig` (working name
-     `resolve_variants(runtime, base_dir)`) that:
-     1. resolves the light `brand_ref` → unified `Brand`;
-     2. splits it → light/dark halves;
-     3. if the brand `has_dark_mode()` and `self.dark.is_none()`, synthesizes
-        the dark theme variant (same construction as the existing config-time
-        synthesis at config.rs:348 — clone light themes, inject brand token,
-        `is_default: false` since a unified brand has no `dark_first`
-        ordering signal);
-     4. returns per-variant resolved configs for the stage to compile.
-   - The existing config-time synthesis for the **two-file** form stays where
-     it is (it needs no file contents); the new seam only adds the
-     content-driven case. `from_config_value` stays pure.
-   - `compile_theme_css.rs` switches from its two `resolve()` calls to the
-     new entry point. Because the stage is shared, WASM/live-recompile gets
-     the behavior for free.
-   - **Two-file form + unified values** (a file named by
-     `brand: {light: f1, dark: f2}` that itself uses `{light:, dark:}`
-     values): Q1 rejects this (those files validate against the closed
-     single-brand schema). Recommendation: split each file and keep the
-     matching half (light file → light half), which is strictly more
-     permissive than Q1 and avoids a second type family; note the divergence
-     in the docs audit (bd-qnylgu69). — **Open decision, flag at review.**
+   - ⚠ `parse_highlight_style` gains a side product: when no dark variant
+     exists at config time, the dark-applicable highlight name (the pair's
+     `dark:` value, or the scalar resolved with `dark = true`) is stashed in
+     a new `ThemeConfig::deferred_dark_highlight` field instead of being
+     dropped. This keeps `from_config_value` pure while letting a
+     later-synthesized dark variant get the right palette (e.g.
+     `highlight-style: a11y` → `a11y-dark`).
+   - New `ThemeConfig::resolve_variants(self, runtime, base_dir) ->
+     Result<ResolvedVariants, SassError>`:
+     1. resolves the light `brand_ref` → `UnifiedBrand` → `split()`;
+     2. if `enables_dark_mode && self.dark.is_none() && !suppress_bootstrap`,
+        synthesizes the `DarkThemeConfig` (clone light themes — brand token
+        already injected — `is_default: false`, `highlight_style:
+        deferred_dark_highlight`, `brand_ref` = light ref);
+     3. resolves the dark variant's brand: same ref as light → reuse the
+        split's dark half (single file read); different ref (two-file form)
+        → read + split that file and take its **dark** half;
+     4. returns `ResolvedVariants { config /* with synthesized dark */,
+        light_brand: Option<ResolvedBrand>, dark_brand: Option<ResolvedBrand> }`.
+   - The existing config-time synthesis for the two-file form stays where it
+     is. `ThemeConfig::resolve` / `ResolvedThemeConfig` are subsumed by
+     `resolve_variants` and get removed/privatized once callers migrate.
+   - `resolve_brand` (favicon/site-level helper) and `resolve_brand_layers`
+     parse unified + split and use the **light** half — logo behavior
+     unchanged since logos pass through the split intact.
+   - Two-file form + unified values inside a file: split and take the
+     matching half (light file → light half). More permissive than Q1
+     (which rejects); noted for the docs audit (bd-qnylgu69).
 
-3. **No caching changes.** Each variant still feeds `variant_css` a resolved
-   single-mode brand; fingerprints already incorporate the brand content the
+3. **Decision flow (`quarto-core`).** ⚠ THREE consumers independently
+   re-derive "does a dark variant exist / which is default" from config:
+   `CompileThemeCssStage`, `render_with_compiled_template`
+   (template.rs:837 — color-scheme meta + color-mode script), and
+   `navbar_generate.rs:88` (dark-mode toggle). Content-driven enablement
+   breaks the two pure re-derivations. Fix: the stage — which runs at
+   position 11, before `AstTransformsStage` (13, navbar) and
+   `ApplyTemplateStage` (17) — records the decision in doc metadata as
+   `rendered.theme.dark-is-default: bool` (precedent:
+   `rendered.includes.*`). Both downstream consumers read that key first
+   and fall back to the current pure derivation when absent (direct-call
+   and unit-test contexts where the stage never ran → behavior unchanged).
+
+4. **No caching changes.** Each variant still feeds `variant_css` a resolved
+   single-mode brand; fingerprints already incorporate brand content the
    same way they do today.
 
 ## Work items
 
 ### Phase 0 — tests first (TDD)
 
-- [ ] `quarto-brand` unit tests: parse `BrandColorValue` map form for named
+- [x] `quarto-brand` unit tests: parse `BrandColorValue` map form for named
       colors and typography `color`/`background-color`; reject unknown keys
       inside the pair; palette map value still errors.
-- [ ] `quarto-brand` unit tests: `split()` semantics (string → both halves;
+- [x] `quarto-brand` unit tests: `split()` semantics (string → both halves;
       light-only → dark half omits slot; typography colors specialize;
       logos); `has_dark_mode()` (true only when a `dark:` key exists
       somewhere; false for all-plain-string brands).
-- [ ] `quarto-sass` config tests: unified brand with dark values + no
+- [x] `quarto-sass` config tests: unified brand with dark values + no
       `theme:` dark half → dark variant synthesized (brand token injected,
       `is_default: false`); unified brand with no dark values → no dark
       variant; unified brand + explicit `theme: {light:, dark:}` → theme's
       `is_default` wins.
-- [ ] End-to-end test (through `render_document_to_file`-level helper, per
+- [x] End-to-end test (through `render_document_to_file`-level helper, per
       CLAUDE.md): fixture = issue #580's `_brand.yml` + `index.qmd`; assert
       `styles.css` has the light value and `styles-dark.css` the dark value,
       and the toggle/link pair is emitted. Also the typography case
       (`typography.headings.color: {light:, dark:}`).
-- [ ] Run all new tests, verify they fail for the expected reason.
+- [x] Run all new tests, verify they fail for the expected reason.
 
 ### Phase 1 — quarto-brand type surgery
 
-- [ ] `BrandColorValue` enum + field type changes + accessors.
-- [ ] `Brand::has_dark_mode()`, `Brand::split()`.
-- [ ] Update `brand_layer.rs` / `resolve.rs` call sites to the single-mode
+- [x] `BrandColorValue` enum + field type changes + accessors.
+- [x] `Brand::has_dark_mode()`, `Brand::split()` (new `split.rs`).
+- [x] Update `brand_layer.rs` / `resolve.rs` call sites to the single-mode
       accessors; quarto-brand + quarto-sass tests green.
 
 ### Phase 2 — pipeline wiring
 
-- [ ] `ThemeConfig::resolve_variants` (read once, split, synthesize dark).
-- [ ] Switch `compile_theme_css.rs` to it; remove the per-variant re-read.
-- [ ] Full workspace: `cargo build --workspace`, `cargo nextest run
-      --workspace`, `cargo xtask verify` (full — quarto-core/pampa are in the
-      WASM closure).
+- [x] `ThemeConfig::resolve_variants` (read once, split, synthesize dark).
+- [x] Switch `compile_theme_css.rs` to it; remove the per-variant re-read
+      (plus the `rendered.theme.dark-is-default` meta channel and the
+      template/navbar consumers reading it with pure fallback).
+- [x] Full workspace: `cargo build --workspace` ✓, `cargo nextest run
+      --workspace` ✓ (13,165 pass), `cargo xtask verify` (full — in progress;
+      two early failures were a clippy nit and rustfmt in a new test file,
+      both fixed).
 
 ### Phase 3 — end-to-end verification + docs + bookkeeping
 
-- [ ] `cargo run --bin q2 -- render` on the #580 repro; inspect
-      `styles.css` / `styles-dark.css`; record invocation + output snippet
-      here.
-- [ ] Verify the two controls still behave (plain string; two-file form).
-- [ ] Check `docs/guides/authoring/brand.qmd` §"Light and Dark Colors" now
-      matches reality (it should — the docs were written for this feature);
-      note the palette limitation stays.
+- [x] `cargo run --bin q2 -- render` on the #580 repro; inspected
+      `styles.css` / `styles-dark.css`; recorded in the Phase 1–2 log below.
+- [x] Verify the two controls still behave (plain string; two-file form) —
+      covered by `unified_brand_all_plain_stays_single_variant` (e2e),
+      `two_file_brand_resolves_each_variants_file` (sass), and the whole
+      pre-existing `theme_light_dark` suite (26/26 green).
+- [x] Check `docs/guides/authoring/brand.qmd` §"Light and Dark Colors" now
+      matches reality: rendered the section's exact `_brand.yml` example —
+      light headings color lands in `styles.css` (as minified `#114`), dark
+      `#d0d0ff` in `styles-dark.css`. Palette limitation callout stays true.
+      The "directly in the document metadata" example remains blocked by the
+      unrelated GH #581 (inline front-matter brand), tracked separately.
 - [ ] Close bd-unified-brand-split-ep49amad; comment on GH #580.
 
 ## Out of scope / follow-ups
@@ -210,3 +246,43 @@ consumer single-mode.**
   schema agree).
 - bd-v5z8w is superseded by phase C + this strand (its own comment already
   suggests closing it in favor of bd-unified-brand-split-ep49amad).
+
+## Phase 0 log (2026-08-24)
+
+- Tests written: `crates/quarto-brand/tests/integration/light_dark_test.rs` (20 tests),
+  `crates/quarto-sass/tests/integration/brand_light_dark_test.rs` (11 tests),
+  4 e2e tests appended to `crates/quarto-core/tests/integration/brand_render.rs`.
+- Failure verified: the 3 feature e2e tests fail with exactly the GH #580 error
+  (`color.background: invalid type: map, expected a string at line 3 column 5`);
+  the all-plain control passes. quarto-brand / quarto-sass test binaries fail to
+  compile on the missing `UnifiedBrand` / `resolve_variants` API, as expected
+  for type-surgery TDD.
+
+## Phase 1–2 log (2026-08-24)
+
+- **quarto-brand**: `Brand<V = String>` generic (`UnifiedBrand = Brand<BrandColorValue>`);
+  explicit `#[serde(bound(...))]` needed on the four generic structs (serde's
+  syntactic inference otherwise demands `V: Default` for `#[serde(default)]`
+  fields); manual `Default` impls; new `split.rs` with `SplitBrand`,
+  `has_dark_mode`, callback-macro field lists shared with `types.rs`.
+  All parse entry points now produce `UnifiedBrand`; existing tests migrated
+  to `.split().light`. 70/70 tests pass (20 new).
+- **quarto-sass**: `resolve()`/`ResolvedThemeConfig` replaced by
+  `resolve_variants()`/`ResolvedVariants{config, light_brand, dark_brand}`;
+  `load_split_brand` is the single brand-deserialization point;
+  `deferred_dark_highlight` reserve slot on `ThemeConfig` filled by
+  `parse_highlight_style` when no dark variant exists at parse time.
+  277/277 tests pass (11 new). One test expectation fixed during TDD:
+  `github` is itself adaptive, so a pair's `dark: github` correctly resolves
+  to `github-dark` — the non-adaptive verbatim case now uses `dracula`.
+- **quarto-core**: stage reads brand once via `resolve_variants`; records
+  `rendered.theme.dark-is-default` in doc meta after storing a variant pair;
+  `render_with_compiled_template` and `navbar_generate` read that key first,
+  keeping their pure config derivation as fallback for stage-less pipelines.
+- **Full workspace**: 13,165 tests pass.
+- **Real-binary e2e** (per CLAUDE.md): `cargo run --bin q2 -- render index.qmd`
+  on the exact #580 fixture → `styles.css` has `--bs-body-bg: #b22222`,
+  `styles-dark.css` has `--bs-body-bg: #22b222`; HTML carries
+  `quarto-color-scheme` + `quarto-color-alternate` + `quarto-color-scheme-extra`
+  links, `<meta name="color-scheme" content="light">`, and
+  `data-author-prefers-dark="false"`. Output inspected directly.

--- a/crates/quarto-brand/src/lib.rs
+++ b/crates/quarto-brand/src/lib.rs
@@ -13,19 +13,27 @@
 mod error;
 mod resolve;
 mod resolved;
+mod split;
 mod types;
 
 pub use error::BrandError;
 pub use resolved::ResolvedBrand;
+pub use split::SplitBrand;
 pub use types::{
-    Brand, BrandColor, BrandDefaults, BrandFont, BrandFontFile, BrandFontFileEntry,
-    BrandFontGoogle, BrandFontStyle, BrandFontSystem, BrandFontWeight, BrandFontWeightAtom,
-    BrandLogo, BrandLogoExplicit, BrandLogoResource, BrandMeta, BrandMetaLink, BrandMetaName,
-    BrandRef, BrandTypography, BrandTypographyOptions, LogoEntry,
+    Brand, BrandColor, BrandColorLightDark, BrandColorValue, BrandDefaults, BrandFont,
+    BrandFontFile, BrandFontFileEntry, BrandFontGoogle, BrandFontStyle, BrandFontSystem,
+    BrandFontWeight, BrandFontWeightAtom, BrandLogo, BrandLogoExplicit, BrandLogoResource,
+    BrandMeta, BrandMetaLink, BrandMetaName, BrandRef, BrandTypography, BrandTypographyOptions,
+    LogoEntry, UnifiedBrand,
 };
 
-impl Brand {
+impl UnifiedBrand {
     /// Parse a `_brand.yml` document from a YAML string.
+    ///
+    /// Parsing always produces the **unified** form (color values may
+    /// be plain strings or `{light:, dark:}` pairs); call
+    /// [`UnifiedBrand::split`] to obtain the single-mode [`Brand`]s
+    /// the rest of the pipeline consumes.
     pub fn from_yaml_str(yaml: &str) -> Result<Self, BrandError> {
         serde_yaml::from_str(yaml).map_err(BrandError::Parse)
     }

--- a/crates/quarto-brand/src/resolve.rs
+++ b/crates/quarto-brand/src/resolve.rs
@@ -100,13 +100,13 @@ fn ordered_chain(seen: &HashSet<String>, repeat: &str) -> String {
 
 // ── typography ──────────────────────────────────────────────────────
 
-impl Brand {
+impl<V> Brand<V> {
     /// Lookup a font slot by name. Returns the options for `base`,
     /// `headings`, `link`, `monospace`, `monospace-inline`, or
     /// `monospace-block`. For `monospace-{inline,block}` see
     /// [`effective_monospace_inline`] / [`effective_monospace_block`]
     /// which apply Q1's merge-with-generic-monospace semantics.
-    pub fn font_slot(&self, name: &str) -> Option<&BrandTypographyOptions> {
+    pub fn font_slot(&self, name: &str) -> Option<&BrandTypographyOptions<V>> {
         let t = self.typography.as_ref()?;
         match name {
             "base" => t.base.as_ref(),
@@ -127,7 +127,10 @@ impl Brand {
     /// Effective `monospace-inline` options: a merge of `monospace`
     /// (as defaults) with `monospace-inline` (overriding) — matching
     /// Q1's `{ ...monospace, ...monospaceInline }` spread.
-    pub fn effective_monospace_inline(&self) -> Option<BrandTypographyOptions> {
+    pub fn effective_monospace_inline(&self) -> Option<BrandTypographyOptions<V>>
+    where
+        V: Clone,
+    {
         merge_mono(
             self.font_slot("monospace"),
             self.font_slot("monospace-inline"),
@@ -136,7 +139,10 @@ impl Brand {
 
     /// Effective `monospace-block` options: a merge of `monospace`
     /// (as defaults) with `monospace-block` (overriding).
-    pub fn effective_monospace_block(&self) -> Option<BrandTypographyOptions> {
+    pub fn effective_monospace_block(&self) -> Option<BrandTypographyOptions<V>>
+    where
+        V: Clone,
+    {
         merge_mono(
             self.font_slot("monospace"),
             self.font_slot("monospace-block"),
@@ -146,10 +152,10 @@ impl Brand {
 
 /// Merge two optional font-options objects with the second winning
 /// per-field (Q1's spread semantics).
-fn merge_mono(
-    base: Option<&BrandTypographyOptions>,
-    over: Option<&BrandTypographyOptions>,
-) -> Option<BrandTypographyOptions> {
+fn merge_mono<V: Clone>(
+    base: Option<&BrandTypographyOptions<V>>,
+    over: Option<&BrandTypographyOptions<V>>,
+) -> Option<BrandTypographyOptions<V>> {
     match (base, over) {
         (None, None) => None,
         (Some(b), None) => Some(b.clone()),
@@ -172,7 +178,7 @@ fn merge_mono(
 
 // ── logo ────────────────────────────────────────────────────────────
 
-impl Brand {
+impl<V> Brand<V> {
     /// Lookup a logo by size keyword: `small`, `medium`, or `large`.
     pub fn logo(&self, name: &str) -> Option<&LogoEntry> {
         let l = self.logo.as_ref()?;

--- a/crates/quarto-brand/src/split.rs
+++ b/crates/quarto-brand/src/split.rs
@@ -1,0 +1,211 @@
+//! Splitting a [`UnifiedBrand`] into its light and dark halves.
+//!
+//! Port of Q1's `splitUnifiedBrand` / `brandHasDarkMode`
+//! (`external-sources/quarto-cli/src/core/brand/brand.ts:545,629`),
+//! with one deliberate divergence: **logo entries are carried through
+//! unsplit**. Q1's `splitLogo` collapses a `{light:, dark:}` logo pair
+//! into a per-mode resource because its `Brand` class is per-mode
+//! everywhere; q2's logo consumers (the favicon fallback bd-97yc, the
+//! navbar brand image bd-hp3tx) run once per document and need both
+//! sides to emit light/dark markup — which [`LogoEntry::LightDark`]
+//! already models. Logo dark sides still count for
+//! [`UnifiedBrand::has_dark_mode`] (Q1 parity).
+
+use crate::types::{
+    Brand, BrandColor, BrandColorValue, BrandTypography, BrandTypographyOptions, LogoEntry,
+    UnifiedBrand, for_each_named_color_slot, for_each_typography_slot,
+};
+
+/// The result of [`UnifiedBrand::split`]: one single-mode [`Brand`]
+/// per variant, plus Q1's `enablesDarkMode` flag.
+///
+/// Both halves always exist — for an all-plain brand they are equal —
+/// and `enables_dark_mode` says whether the brand's *content* asks for
+/// a dark variant (some value carries an explicit `dark:` side).
+/// Consumers that compile a dark variant for other reasons (a declared
+/// `theme: {light:, dark:}` pair) use `dark` regardless of the flag.
+#[derive(Debug, Clone)]
+pub struct SplitBrand {
+    /// The light half: every pair collapsed to its `light:` side.
+    pub light: Brand,
+    /// The dark half: every pair collapsed to its `dark:` side. A
+    /// pair with no `dark:` side leaves the slot absent in this half
+    /// (Q1: no fallback to the light value).
+    pub dark: Brand,
+    /// Q1's `enablesDarkMode`: true iff some named color, typography
+    /// color/background-color, or logo entry carries a `dark:` side.
+    pub enables_dark_mode: bool,
+}
+
+impl UnifiedBrand {
+    /// Q1's `brandHasDarkMode`: does any value in this brand carry an
+    /// explicit `dark:` side? Plain strings and light-only pairs do
+    /// not count.
+    pub fn has_dark_mode(&self) -> bool {
+        if let Some(c) = &self.color {
+            macro_rules! any_color_dark {
+                ($($field:ident),+) => {
+                    $(
+                        if c.$field.as_ref().is_some_and(BrandColorValue::has_dark) {
+                            return true;
+                        }
+                    )+
+                };
+            }
+            for_each_named_color_slot!(any_color_dark);
+        }
+        if let Some(t) = &self.typography {
+            macro_rules! any_typography_dark {
+                ($($field:ident),+) => {
+                    $(
+                        if let Some(opts) = &t.$field {
+                            if opts.color.as_ref().is_some_and(BrandColorValue::has_dark)
+                                || opts
+                                    .background_color
+                                    .as_ref()
+                                    .is_some_and(BrandColorValue::has_dark)
+                            {
+                                return true;
+                            }
+                        }
+                    )+
+                };
+            }
+            for_each_typography_slot!(any_typography_dark);
+        }
+        if let Some(logo) = &self.logo {
+            for entry in [&logo.small, &logo.medium, &logo.large]
+                .into_iter()
+                .flatten()
+            {
+                if matches!(entry, LogoEntry::LightDark { dark: Some(_), .. }) {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    /// Split into single-mode halves (Q1's `splitUnifiedBrand`).
+    ///
+    /// - A plain string goes to **both** halves.
+    /// - A `{light:, dark:}` pair sends each side to its half; a
+    ///   missing side leaves the slot absent in that half.
+    /// - `palette`, `meta`, `defaults`, `typography.fonts`, and all
+    ///   non-color typography fields are shared.
+    /// - Logo entries are carried through unchanged (see the module
+    ///   docs for why this diverges from Q1's `splitLogo`).
+    pub fn split(self) -> SplitBrand {
+        let enables_dark_mode = self.has_dark_mode();
+        let (light_color, dark_color) = match &self.color {
+            Some(c) => {
+                let (l, d) = split_color(c);
+                (Some(l), Some(d))
+            }
+            None => (None, None),
+        };
+        let (light_typography, dark_typography) = match &self.typography {
+            Some(t) => {
+                let (l, d) = split_typography(t);
+                (Some(l), Some(d))
+            }
+            None => (None, None),
+        };
+        let light = Brand {
+            meta: self.meta.clone(),
+            color: light_color,
+            typography: light_typography,
+            logo: self.logo.clone(),
+            defaults: self.defaults.clone(),
+        };
+        let dark = Brand {
+            meta: self.meta,
+            color: dark_color,
+            typography: dark_typography,
+            logo: self.logo,
+            defaults: self.defaults,
+        };
+        SplitBrand {
+            light,
+            dark,
+            enables_dark_mode,
+        }
+    }
+}
+
+fn split_color(c: &BrandColor<BrandColorValue>) -> (BrandColor, BrandColor) {
+    let mut light = BrandColor {
+        palette: c.palette.clone(),
+        ..Default::default()
+    };
+    let mut dark = BrandColor {
+        palette: c.palette.clone(),
+        ..Default::default()
+    };
+    macro_rules! split_slots {
+        ($($field:ident),+) => {
+            $(
+                if let Some(v) = &c.$field {
+                    light.$field = v.light().map(str::to_string);
+                    dark.$field = v.dark().map(str::to_string);
+                }
+            )+
+        };
+    }
+    for_each_named_color_slot!(split_slots);
+    (light, dark)
+}
+
+fn split_typography(t: &BrandTypography<BrandColorValue>) -> (BrandTypography, BrandTypography) {
+    let mut light = BrandTypography {
+        fonts: t.fonts.clone(),
+        ..Default::default()
+    };
+    let mut dark = BrandTypography {
+        fonts: t.fonts.clone(),
+        ..Default::default()
+    };
+    macro_rules! split_slots {
+        ($($field:ident),+) => {
+            $(
+                if let Some(opts) = &t.$field {
+                    let (l, d) = split_typography_options(opts);
+                    light.$field = Some(l);
+                    dark.$field = Some(d);
+                }
+            )+
+        };
+    }
+    for_each_typography_slot!(split_slots);
+    (light, dark)
+}
+
+fn split_typography_options(
+    o: &BrandTypographyOptions<BrandColorValue>,
+) -> (BrandTypographyOptions, BrandTypographyOptions) {
+    let shared = BrandTypographyOptions {
+        family: o.family.clone(),
+        size: o.size.clone(),
+        line_height: o.line_height.clone(),
+        weight: o.weight.clone(),
+        style: o.style.clone(),
+        color: None,
+        background_color: None,
+        decoration: o.decoration.clone(),
+    };
+    let mut light = shared.clone();
+    let mut dark = shared;
+    light.color = o.color.as_ref().and_then(|v| v.light()).map(str::to_string);
+    dark.color = o.color.as_ref().and_then(|v| v.dark()).map(str::to_string);
+    light.background_color = o
+        .background_color
+        .as_ref()
+        .and_then(|v| v.light())
+        .map(str::to_string);
+    dark.background_color = o
+        .background_color
+        .as_ref()
+        .and_then(|v| v.dark())
+        .map(str::to_string);
+    (light, dark)
+}

--- a/crates/quarto-brand/src/types.rs
+++ b/crates/quarto-brand/src/types.rs
@@ -37,17 +37,36 @@ pub enum BrandRef {
 ///
 /// Every section is optional — Q1 accepts a brand with just colors, or
 /// just typography, etc.
-#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+///
+/// `Brand` is generic over the color-value type `V`, mirroring Q1's
+/// `BrandUnified` / `BrandSingle` split
+/// (`external-sources/quarto-cli/src/core/brand/brand.ts`):
+///
+/// - [`UnifiedBrand`] (= `Brand<BrandColorValue>`) is the **parse
+///   form**: every named color slot and typography color accepts
+///   either a plain string or a `{light:, dark:}` pair. This is the
+///   only form [`Brand::from_yaml_str`](crate::UnifiedBrand) produces.
+/// - `Brand` (= `Brand<String>`, the default) is the **single-mode
+///   form** every downstream consumer (color resolution, SCSS layer,
+///   favicon/navbar) works with. It is obtained via
+///   [`UnifiedBrand::split`](crate::SplitBrand), which distributes
+///   each pair to its half — so the type system guarantees consumers
+///   never see an unsplit light/dark value.
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct Brand {
+#[serde(bound(
+    deserialize = "V: serde::Deserialize<'de>",
+    serialize = "V: serde::Serialize"
+))]
+pub struct Brand<V = String> {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub meta: Option<BrandMeta>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub color: Option<BrandColor>,
+    pub color: Option<BrandColor<V>>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub typography: Option<BrandTypography>,
+    pub typography: Option<BrandTypography<V>>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub logo: Option<BrandLogo>,
@@ -58,6 +77,26 @@ pub struct Brand {
     /// independently and Q1 itself parses it permissively.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub defaults: Option<BrandDefaults>,
+}
+
+/// The unified parse form of a brand: color values may be plain
+/// strings or `{light:, dark:}` pairs. See [`Brand`] for the
+/// unified/single distinction and [`UnifiedBrand::split`] for the way
+/// down to the single-mode form.
+pub type UnifiedBrand = Brand<BrandColorValue>;
+
+// Manual `Default` (a derive would add a spurious `V: Default` bound;
+// every field is an `Option`/container that defaults without one).
+impl<V> Default for Brand<V> {
+    fn default() -> Self {
+        Self {
+            meta: None,
+            color: None,
+            typography: None,
+            logo: None,
+            defaults: None,
+        }
+    }
 }
 
 // ── meta ────────────────────────────────────────────────────────────
@@ -125,43 +164,146 @@ pub struct BrandMetaLinks {
 
 // ── color ───────────────────────────────────────────────────────────
 
-#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+/// A color value in the **unified** brand form: either a plain string
+/// (applies to both modes) or a `{light:, dark:}` pair.
+///
+/// Mirrors Q1's `brand-color-light-dark` schema
+/// (`external-sources/quarto-cli/src/resources/schema/definitions.yml`).
+/// Only *named* color slots and typography colors accept this shape;
+/// `palette` entries stay plain strings (a documented limitation
+/// shared with Q1).
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum BrandColorValue {
+    /// A plain color string; the split sends it to both halves.
+    Single(String),
+    /// A per-mode pair; each half of the split receives its side, and
+    /// a missing side means the slot is simply absent in that half
+    /// (Q1: no fallback to the other side).
+    LightDark(BrandColorLightDark),
+}
+
+/// The `{light:, dark:}` pair form of [`BrandColorValue`].
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct BrandColor {
+pub struct BrandColorLightDark {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub light: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dark: Option<String>,
+}
+
+impl BrandColorValue {
+    /// The value the **light** half of a split receives: the plain
+    /// string, or the pair's `light:` side.
+    pub fn light(&self) -> Option<&str> {
+        match self {
+            BrandColorValue::Single(s) => Some(s.as_str()),
+            BrandColorValue::LightDark(pair) => pair.light.as_deref(),
+        }
+    }
+
+    /// The value the **dark** half of a split receives: the plain
+    /// string, or the pair's `dark:` side.
+    pub fn dark(&self) -> Option<&str> {
+        match self {
+            BrandColorValue::Single(s) => Some(s.as_str()),
+            BrandColorValue::LightDark(pair) => pair.dark.as_deref(),
+        }
+    }
+
+    /// Whether this value carries an explicit `dark:` side — the
+    /// per-value input to Q1's `enablesDarkMode`: only actual `dark:`
+    /// keys enable dark mode; plain strings and light-only pairs do
+    /// not.
+    pub fn has_dark(&self) -> bool {
+        matches!(
+            self,
+            BrandColorValue::LightDark(BrandColorLightDark { dark: Some(_), .. })
+        )
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+#[serde(bound(
+    deserialize = "V: serde::Deserialize<'de>",
+    serialize = "V: serde::Serialize"
+))]
+pub struct BrandColor<V = String> {
     /// Named color aliases.  Iteration order matters — Q1 preserves
     /// source order so that downstream code generates `$brand-foo`
     /// variables in the same order they were authored.
+    ///
+    /// Deliberately NOT generic over `V`: palette entries stay plain
+    /// strings even in the unified form (Q1's `brand-color-unified`
+    /// schema keeps `palette` at `brand-color-value`; the docs carry
+    /// the matching limitation callout).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub palette: Option<BTreeMap<String, String>>,
 
     // Bootstrap theme color slots
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub primary: Option<String>,
+    pub primary: Option<V>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub secondary: Option<String>,
+    pub secondary: Option<V>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub tertiary: Option<String>,
+    pub tertiary: Option<V>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub success: Option<String>,
+    pub success: Option<V>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub info: Option<String>,
+    pub info: Option<V>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub warning: Option<String>,
+    pub warning: Option<V>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub danger: Option<String>,
+    pub danger: Option<V>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub light: Option<String>,
+    pub light: Option<V>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub dark: Option<String>,
+    pub dark: Option<V>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub emphasis: Option<String>,
+    pub emphasis: Option<V>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub link: Option<String>,
+    pub link: Option<V>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub background: Option<String>,
+    pub background: Option<V>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub foreground: Option<String>,
+    pub foreground: Option<V>,
 }
+
+impl<V> Default for BrandColor<V> {
+    fn default() -> Self {
+        Self {
+            palette: None,
+            primary: None,
+            secondary: None,
+            tertiary: None,
+            success: None,
+            info: None,
+            warning: None,
+            danger: None,
+            light: None,
+            dark: None,
+            emphasis: None,
+            link: None,
+            background: None,
+            foreground: None,
+        }
+    }
+}
+
+/// The 13 named theme-color slots, as `(name, accessor)` pairs shared
+/// by the single-mode accessors, the split, and `has_dark_mode`.
+/// Order matches the Bootstrap theme map (and `named_colors`).
+macro_rules! for_each_named_color_slot {
+    ($macro:ident) => {
+        $macro!(
+            primary, secondary, tertiary, success, info, warning, danger, light, dark, emphasis,
+            link, background, foreground
+        )
+    };
+}
+pub(crate) use for_each_named_color_slot;
 
 impl BrandColor {
     /// Lookup a named theme color (not the palette).
@@ -231,9 +373,13 @@ impl BrandColor {
 
 // ── typography ──────────────────────────────────────────────────────
 
-#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct BrandTypography {
+#[serde(bound(
+    deserialize = "V: serde::Deserialize<'de>",
+    serialize = "V: serde::Serialize"
+))]
+pub struct BrandTypography<V = String> {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub fonts: Vec<BrandFont>,
 
@@ -242,40 +388,71 @@ pub struct BrandTypography {
         deserialize_with = "deserialize_typography_options",
         skip_serializing_if = "Option::is_none"
     )]
-    pub base: Option<BrandTypographyOptions>,
+    pub base: Option<BrandTypographyOptions<V>>,
     #[serde(
         default,
         deserialize_with = "deserialize_typography_options",
         skip_serializing_if = "Option::is_none"
     )]
-    pub headings: Option<BrandTypographyOptions>,
+    pub headings: Option<BrandTypographyOptions<V>>,
     #[serde(
         default,
         deserialize_with = "deserialize_typography_options",
         skip_serializing_if = "Option::is_none"
     )]
-    pub link: Option<BrandTypographyOptions>,
+    pub link: Option<BrandTypographyOptions<V>>,
     #[serde(
         default,
         deserialize_with = "deserialize_typography_options",
         skip_serializing_if = "Option::is_none"
     )]
-    pub monospace: Option<BrandTypographyOptions>,
+    pub monospace: Option<BrandTypographyOptions<V>>,
     #[serde(
         default,
         rename = "monospace-inline",
         deserialize_with = "deserialize_typography_options",
         skip_serializing_if = "Option::is_none"
     )]
-    pub monospace_inline: Option<BrandTypographyOptions>,
+    pub monospace_inline: Option<BrandTypographyOptions<V>>,
     #[serde(
         default,
         rename = "monospace-block",
         deserialize_with = "deserialize_typography_options",
         skip_serializing_if = "Option::is_none"
     )]
-    pub monospace_block: Option<BrandTypographyOptions>,
+    pub monospace_block: Option<BrandTypographyOptions<V>>,
 }
+
+impl<V> Default for BrandTypography<V> {
+    fn default() -> Self {
+        Self {
+            fonts: Vec::new(),
+            base: None,
+            headings: None,
+            link: None,
+            monospace: None,
+            monospace_inline: None,
+            monospace_block: None,
+        }
+    }
+}
+
+/// The 6 typography font slots, as a callback-macro over field names
+/// (same pattern as [`for_each_named_color_slot`]); used by the split
+/// and `has_dark_mode`.
+macro_rules! for_each_typography_slot {
+    ($macro:ident) => {
+        $macro!(
+            base,
+            headings,
+            link,
+            monospace,
+            monospace_inline,
+            monospace_block
+        )
+    };
+}
+pub(crate) use for_each_typography_slot;
 
 /// Accept either a bare string (treated as `{ family: <string> }`) or
 /// a full options map. Matches Q1's `_brand.yml` shorthand:
@@ -287,20 +464,21 @@ pub struct BrandTypography {
 ///     family: Rubik
 ///     weight: 400
 /// ```
-fn deserialize_typography_options<'de, D>(
+fn deserialize_typography_options<'de, D, V>(
     deserializer: D,
-) -> Result<Option<BrandTypographyOptions>, D::Error>
+) -> Result<Option<BrandTypographyOptions<V>>, D::Error>
 where
     D: serde::Deserializer<'de>,
+    V: serde::Deserialize<'de>,
 {
     #[derive(Deserialize)]
     #[serde(untagged)]
-    enum StringOrOptions {
+    enum StringOrOptions<V> {
         Family(String),
-        Options(BrandTypographyOptions),
+        Options(BrandTypographyOptions<V>),
     }
 
-    let opt = Option::<StringOrOptions>::deserialize(deserializer)?;
+    let opt = Option::<StringOrOptions<V>>::deserialize(deserializer)?;
     Ok(opt.map(|v| match v {
         StringOrOptions::Family(s) => BrandTypographyOptions {
             family: Some(s),
@@ -315,9 +493,13 @@ where
 /// Q1 accepts either a string (treated as `{ family: <string> }`) or a
 /// map. We always normalize the string form at parse time via the
 /// `untagged` enum below.
-#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct BrandTypographyOptions {
+#[serde(bound(
+    deserialize = "V: serde::Deserialize<'de>",
+    serialize = "V: serde::Serialize"
+))]
+pub struct BrandTypographyOptions<V = String> {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub family: Option<String>,
 
@@ -338,17 +520,32 @@ pub struct BrandTypographyOptions {
     pub style: Option<BrandFontStyle>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub color: Option<String>,
+    pub color: Option<V>,
 
     #[serde(
         default,
         rename = "background-color",
         skip_serializing_if = "Option::is_none"
     )]
-    pub background_color: Option<String>,
+    pub background_color: Option<V>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub decoration: Option<String>,
+}
+
+impl<V> Default for BrandTypographyOptions<V> {
+    fn default() -> Self {
+        Self {
+            family: None,
+            size: None,
+            line_height: None,
+            weight: None,
+            style: None,
+            color: None,
+            background_color: None,
+            decoration: None,
+        }
+    }
 }
 
 // The YAML can use either a bare string or a map for typography

--- a/crates/quarto-brand/tests/integration/color_test.rs
+++ b/crates/quarto-brand/tests/integration/color_test.rs
@@ -15,7 +15,10 @@
 use quarto_brand::{Brand, BrandError};
 
 fn brand(yaml: &str) -> Brand {
-    Brand::from_yaml_str(yaml).expect("parse")
+    quarto_brand::UnifiedBrand::from_yaml_str(yaml)
+        .expect("parse")
+        .split()
+        .light
 }
 
 #[test]

--- a/crates/quarto-brand/tests/integration/light_dark_test.rs
+++ b/crates/quarto-brand/tests/integration/light_dark_test.rs
@@ -1,0 +1,368 @@
+//! Unified `_brand.yml` light/dark values: parsing and splitting
+//! (bd-unified-brand-split-ep49amad, GH #580).
+//!
+//! Q1 reference: `splitUnifiedBrand` / `brandHasDarkMode` in
+//! `external-sources/quarto-cli/src/core/brand/brand.ts`, and the
+//! `brand-color-light-dark` schema in
+//! `src/resources/schema/definitions.yml`. The parse form is the
+//! *unified* brand ([`UnifiedBrand`]), where every named color slot
+//! and typography color accepts either a plain string or a
+//! `{light:, dark:}` pair; [`UnifiedBrand::split`] produces the two
+//! single-mode [`Brand`]s the render pipeline consumes.
+
+use quarto_brand::{BrandColorValue, LogoEntry, UnifiedBrand};
+
+fn parse(yaml: &str) -> UnifiedBrand {
+    UnifiedBrand::from_yaml_str(yaml).expect("unified brand must parse")
+}
+
+// ── parsing ─────────────────────────────────────────────────────────
+
+#[test]
+fn named_color_accepts_light_dark_pair() {
+    // The literal shape from GH #580.
+    let brand = parse("color:\n  background:\n    light: \"#b22221\"\n    dark: \"#22b221\"\n");
+    let color = brand.color.as_ref().expect("color section");
+    match color.background.as_ref().expect("background set") {
+        BrandColorValue::LightDark(pair) => {
+            assert_eq!(pair.light.as_deref(), Some("#b22221"));
+            assert_eq!(pair.dark.as_deref(), Some("#22b221"));
+        }
+        other => panic!("expected LightDark, got {other:?}"),
+    }
+}
+
+#[test]
+fn named_color_plain_string_still_parses_as_single() {
+    let brand = parse("color:\n  primary: \"#3366c1\"\n");
+    let color = brand.color.as_ref().expect("color section");
+    match color.primary.as_ref().expect("primary set") {
+        BrandColorValue::Single(s) => assert_eq!(s, "#3366c1"),
+        other => panic!("expected Single, got {other:?}"),
+    }
+}
+
+#[test]
+fn pair_with_unknown_key_is_rejected() {
+    let err = UnifiedBrand::from_yaml_str(
+        "color:\n  background:\n    light: \"#b22221\"\n    bogus: \"#22b221\"\n",
+    );
+    assert!(
+        err.is_err(),
+        "a light/dark pair with an unknown key must not parse: {err:?}"
+    );
+}
+
+#[test]
+fn palette_entry_light_dark_map_is_rejected() {
+    // Deliberate limitation, matching Q1's schema (`brand-color-unified`
+    // keeps `palette` values plain strings) and the callout in
+    // docs/guides/authoring/brand.qmd.
+    let err = UnifiedBrand::from_yaml_str(
+        "color:\n  palette:\n    accent:\n      light: \"#b22221\"\n      dark: \"#22b221\"\n",
+    );
+    assert!(
+        err.is_err(),
+        "palette entries must stay plain strings: {err:?}"
+    );
+}
+
+#[test]
+fn typography_colors_accept_light_dark_pairs() {
+    let brand = parse(concat!(
+        "typography:\n",
+        "  headings:\n",
+        "    family: Rubik\n",
+        "    color:\n",
+        "      light: \"#111143\"\n",
+        "      dark: \"#d0d0fe\"\n",
+        "  monospace:\n",
+        "    background-color:\n",
+        "      light: \"#f0f0f1\"\n",
+        "      dark: \"#20202f\"\n",
+    ));
+    let typography = brand.typography.as_ref().expect("typography section");
+    let headings = typography.headings.as_ref().expect("headings slot");
+    assert_eq!(headings.family.as_deref(), Some("Rubik"));
+    match headings.color.as_ref().expect("headings color") {
+        BrandColorValue::LightDark(pair) => {
+            assert_eq!(pair.light.as_deref(), Some("#111143"));
+            assert_eq!(pair.dark.as_deref(), Some("#d0d0fe"));
+        }
+        other => panic!("expected LightDark, got {other:?}"),
+    }
+    let monospace = typography.monospace.as_ref().expect("monospace slot");
+    match monospace
+        .background_color
+        .as_ref()
+        .expect("monospace background-color")
+    {
+        BrandColorValue::LightDark(pair) => {
+            assert_eq!(pair.light.as_deref(), Some("#f0f0f1"));
+            assert_eq!(pair.dark.as_deref(), Some("#20202f"));
+        }
+        other => panic!("expected LightDark, got {other:?}"),
+    }
+}
+
+// ── splitting ───────────────────────────────────────────────────────
+
+#[test]
+fn split_plain_string_lands_in_both_halves() {
+    let split = parse("color:\n  primary: \"#3366c1\"\n").split();
+    let light = split.light.color.as_ref().expect("light color");
+    let dark = split.dark.color.as_ref().expect("dark color");
+    assert_eq!(light.primary.as_deref(), Some("#3366c1"));
+    assert_eq!(dark.primary.as_deref(), Some("#3366c1"));
+    assert!(!split.enables_dark_mode);
+}
+
+#[test]
+fn split_pair_distributes_halves() {
+    let split =
+        parse("color:\n  background:\n    light: \"#b22221\"\n    dark: \"#22b221\"\n").split();
+    assert_eq!(
+        split
+            .light
+            .color
+            .as_ref()
+            .and_then(|c| c.background.as_deref()),
+        Some("#b22221")
+    );
+    assert_eq!(
+        split
+            .dark
+            .color
+            .as_ref()
+            .and_then(|c| c.background.as_deref()),
+        Some("#22b221")
+    );
+    assert!(split.enables_dark_mode);
+}
+
+#[test]
+fn split_light_only_pair_omits_slot_from_dark_half() {
+    // Q1: `{light: X}` puts X in the light half and OMITS the slot
+    // from the dark half — no fallback to the light value.
+    let split = parse("color:\n  background:\n    light: \"#b22221\"\n").split();
+    assert_eq!(
+        split
+            .light
+            .color
+            .as_ref()
+            .and_then(|c| c.background.as_deref()),
+        Some("#b22221")
+    );
+    assert_eq!(
+        split
+            .dark
+            .color
+            .as_ref()
+            .and_then(|c| c.background.as_deref()),
+        None,
+        "dark half must not inherit the light-only value"
+    );
+    assert!(
+        !split.enables_dark_mode,
+        "a light-only pair does not enable dark mode (Q1: enablesDarkMode checks `dark`)"
+    );
+}
+
+#[test]
+fn split_dark_only_pair_omits_slot_from_light_half() {
+    let split = parse("color:\n  background:\n    dark: \"#22b221\"\n").split();
+    assert_eq!(
+        split
+            .light
+            .color
+            .as_ref()
+            .and_then(|c| c.background.as_deref()),
+        None
+    );
+    assert_eq!(
+        split
+            .dark
+            .color
+            .as_ref()
+            .and_then(|c| c.background.as_deref()),
+        Some("#22b221")
+    );
+    assert!(split.enables_dark_mode);
+}
+
+#[test]
+fn split_shares_palette_meta_and_defaults() {
+    let split = parse(concat!(
+        "meta:\n",
+        "  name: Acme\n",
+        "color:\n",
+        "  palette:\n",
+        "    brand-blue: \"#0066cd\"\n",
+        "  primary: brand-blue\n",
+        "defaults:\n",
+        "  bootstrap:\n",
+        "    enable-rounded: false\n",
+    ))
+    .split();
+    for half in [&split.light, &split.dark] {
+        assert_eq!(
+            half.color
+                .as_ref()
+                .and_then(|c| c.palette.as_ref())
+                .and_then(|p| p.get("brand-blue"))
+                .map(String::as_str),
+            Some("#0066cd"),
+            "palette must be shared by both halves"
+        );
+        assert_eq!(
+            half.meta
+                .as_ref()
+                .and_then(|m| m.name.as_ref())
+                .and_then(|n| n.full_name()),
+            Some("Acme"),
+            "meta must be shared by both halves"
+        );
+        assert!(
+            half.defaults
+                .as_ref()
+                .is_some_and(|d| d.bootstrap().is_some()),
+            "defaults must be shared by both halves"
+        );
+    }
+}
+
+#[test]
+fn split_specializes_typography_colors_and_keeps_shared_fields() {
+    let split = parse(concat!(
+        "typography:\n",
+        "  fonts:\n",
+        "    - family: Rubik\n",
+        "      source: google\n",
+        "  headings:\n",
+        "    family: Rubik\n",
+        "    weight: 600\n",
+        "    color:\n",
+        "      light: \"#111143\"\n",
+        "      dark: \"#d0d0fe\"\n",
+    ))
+    .split();
+    for (half, expected) in [(&split.light, "#111143"), (&split.dark, "#d0d0fe")] {
+        let typography = half.typography.as_ref().expect("typography survives split");
+        assert_eq!(typography.fonts.len(), 1, "fonts list shared");
+        let headings = typography.headings.as_ref().expect("headings slot");
+        assert_eq!(headings.family.as_deref(), Some("Rubik"));
+        assert!(headings.weight.is_some(), "non-color fields shared");
+        assert_eq!(headings.color.as_deref(), Some(expected));
+    }
+    assert!(split.enables_dark_mode);
+}
+
+#[test]
+fn split_typography_light_only_color_omits_dark_side() {
+    let split = parse(concat!(
+        "typography:\n",
+        "  headings:\n",
+        "    family: Rubik\n",
+        "    color:\n",
+        "      light: \"#111143\"\n",
+    ))
+    .split();
+    let dark_headings = split
+        .dark
+        .typography
+        .as_ref()
+        .and_then(|t| t.headings.as_ref())
+        .expect("headings slot survives in the dark half");
+    assert_eq!(dark_headings.family.as_deref(), Some("Rubik"));
+    assert_eq!(dark_headings.color, None);
+    assert!(!split.enables_dark_mode);
+}
+
+#[test]
+fn split_carries_logo_pair_through_unchanged() {
+    // Deliberate divergence from Q1's splitLogo: q2's logo consumers
+    // (favicon, navbar image) run once per document and need both
+    // sides — `LogoEntry::LightDark` models that already, so the
+    // split leaves logo entries intact in both halves.
+    let split = parse(concat!(
+        "logo:\n",
+        "  small:\n",
+        "    light: light-logo.png\n",
+        "    dark: dark-logo.png\n",
+        "  medium: plain-logo.png\n",
+    ))
+    .split();
+    for half in [&split.light, &split.dark] {
+        let logo = half.logo.as_ref().expect("logo section survives split");
+        match logo.small.as_ref().expect("small slot") {
+            LogoEntry::LightDark { light, dark } => {
+                assert_eq!(light.as_ref().map(|r| r.path()), Some("light-logo.png"));
+                assert_eq!(dark.as_ref().map(|r| r.path()), Some("dark-logo.png"));
+            }
+            other => panic!("logo pair must be carried through, got {other:?}"),
+        }
+        match logo.medium.as_ref().expect("medium slot") {
+            LogoEntry::Single(r) => assert_eq!(r.path(), "plain-logo.png"),
+            other => panic!("single logo must stay single, got {other:?}"),
+        }
+    }
+    assert!(
+        split.enables_dark_mode,
+        "a logo dark half enables dark mode (Q1 parity)"
+    );
+}
+
+// ── has_dark_mode ───────────────────────────────────────────────────
+
+#[test]
+fn has_dark_mode_false_for_all_plain_brand() {
+    let brand = parse(concat!(
+        "color:\n",
+        "  primary: \"#3366c1\"\n",
+        "  background: \"#fefefd\"\n",
+        "typography:\n",
+        "  headings:\n",
+        "    color: \"#111143\"\n",
+        "logo:\n",
+        "  small: logo.png\n",
+    ));
+    assert!(!brand.has_dark_mode());
+}
+
+#[test]
+fn has_dark_mode_true_for_color_dark_value() {
+    assert!(parse("color:\n  primary:\n    dark: \"#22b221\"\n").has_dark_mode());
+}
+
+#[test]
+fn has_dark_mode_false_for_light_only_pair() {
+    assert!(!parse("color:\n  primary:\n    light: \"#b22221\"\n").has_dark_mode());
+}
+
+#[test]
+fn has_dark_mode_true_for_typography_color_dark_value() {
+    assert!(
+        parse("typography:\n  headings:\n    color:\n      dark: \"#d0d0fe\"\n").has_dark_mode()
+    );
+}
+
+#[test]
+fn has_dark_mode_true_for_typography_background_color_dark_value() {
+    assert!(
+        parse("typography:\n  monospace:\n    background-color:\n      dark: \"#20202f\"\n")
+            .has_dark_mode()
+    );
+}
+
+#[test]
+fn has_dark_mode_true_for_logo_dark_side() {
+    assert!(
+        parse("logo:\n  small:\n    light: l.png\n    dark: d.png\n").has_dark_mode(),
+        "a logo with a dark side enables dark mode"
+    );
+}
+
+#[test]
+fn has_dark_mode_false_for_logo_light_only() {
+    assert!(!parse("logo:\n  small:\n    light: l.png\n").has_dark_mode());
+}

--- a/crates/quarto-brand/tests/integration/logo_test.rs
+++ b/crates/quarto-brand/tests/integration/logo_test.rs
@@ -8,7 +8,10 @@ use std::path::Path;
 use quarto_brand::{Brand, BrandLogoResource};
 
 fn brand(yaml: &str) -> Brand {
-    Brand::from_yaml_str(yaml).expect("parse")
+    quarto_brand::UnifiedBrand::from_yaml_str(yaml)
+        .expect("parse")
+        .split()
+        .light
 }
 
 #[test]

--- a/crates/quarto-brand/tests/integration/main.rs
+++ b/crates/quarto-brand/tests/integration/main.rs
@@ -2,6 +2,7 @@
 //! See bd-xvdop / claude-notes/plans/2026-05-28-integration-test-consolidation.md.
 
 pub mod color_test;
+pub mod light_dark_test;
 pub mod logo_test;
 pub mod parse_test;
 pub mod resolved_test;

--- a/crates/quarto-brand/tests/integration/parse_test.rs
+++ b/crates/quarto-brand/tests/integration/parse_test.rs
@@ -17,7 +17,10 @@ fn load_fixture(rel_path: &str) -> Brand {
     let path = fixtures_dir().join(rel_path);
     let yaml =
         std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
-    Brand::from_yaml_str(&yaml).unwrap_or_else(|e| panic!("parse {}: {e}", path.display()))
+    quarto_brand::UnifiedBrand::from_yaml_str(&yaml)
+        .unwrap_or_else(|e| panic!("parse {}: {e}", path.display()))
+        .split()
+        .light
 }
 
 #[test]
@@ -107,7 +110,8 @@ fn parse_nested_brand() {
 #[test]
 fn unknown_top_level_key_is_rejected() {
     let yaml = "color:\n  primary: red\nnot_a_real_key: oops\n";
-    let err = Brand::from_yaml_str(yaml).expect_err("should reject unknown key");
+    let err =
+        quarto_brand::UnifiedBrand::from_yaml_str(yaml).expect_err("should reject unknown key");
     let msg = err.to_string();
     assert!(
         msg.contains("not_a_real_key") || msg.contains("unknown field"),

--- a/crates/quarto-brand/tests/integration/resolved_test.rs
+++ b/crates/quarto-brand/tests/integration/resolved_test.rs
@@ -14,7 +14,10 @@ use std::path::{Path, PathBuf};
 use quarto_brand::{Brand, ResolvedBrand};
 
 fn brand(yaml: &str) -> Brand {
-    Brand::from_yaml_str(yaml).expect("parse")
+    quarto_brand::UnifiedBrand::from_yaml_str(yaml)
+        .expect("parse")
+        .split()
+        .light
 }
 
 /// A brand loaded from `<project>/<subdir>/_brand.yml`.

--- a/crates/quarto-brand/tests/integration/typography_test.rs
+++ b/crates/quarto-brand/tests/integration/typography_test.rs
@@ -10,7 +10,10 @@
 use quarto_brand::Brand;
 
 fn brand(yaml: &str) -> Brand {
-    Brand::from_yaml_str(yaml).expect("parse")
+    quarto_brand::UnifiedBrand::from_yaml_str(yaml)
+        .expect("parse")
+        .split()
+        .light
 }
 
 #[test]

--- a/crates/quarto-core/src/project/website_config.rs
+++ b/crates/quarto-core/src/project/website_config.rs
@@ -376,7 +376,7 @@ mod tests {
     mod resolved_favicon {
         use super::*;
         use crate::project::ProjectConfig;
-        use quarto_brand::{Brand, ResolvedBrand};
+        use quarto_brand::{ResolvedBrand, UnifiedBrand as Brand};
         use std::path::PathBuf;
 
         const PROJECT_DIR: &str = "/project";
@@ -396,7 +396,10 @@ mod tests {
                     dir.join(brand_subdir)
                 };
                 ResolvedBrand::new(
-                    Brand::from_yaml_str(yaml).expect("parse brand"),
+                    Brand::from_yaml_str(yaml)
+                        .expect("parse brand")
+                        .split()
+                        .light,
                     Some(brand_dir),
                 )
             });

--- a/crates/quarto-core/src/stage/stages/compile_theme_css.rs
+++ b/crates/quarto-core/src/stage/stages/compile_theme_css.rs
@@ -296,7 +296,7 @@ impl PipelineStage for CompileThemeCssStage {
         input: PipelineData,
         ctx: &mut StageContext,
     ) -> Result<PipelineData, PipelineError> {
-        let PipelineData::DocumentAst(doc) = input else {
+        let PipelineData::DocumentAst(mut doc) = input else {
             return Err(PipelineError::unexpected_input(
                 self.name(),
                 self.input_kind(),
@@ -484,55 +484,59 @@ impl PipelineStage for CompileThemeCssStage {
             .parent()
             .map_or_else(|| PathBuf::from("."), |p| p.to_path_buf());
 
-        // Resolve each variant's brand (bd-0pic6 phase C: the dark
-        // half of a `brand: {light:, dark:}` pair drives the dark
-        // compile; a single brand is shared by both variants via the
-        // parse-time fallback). I/O happens here. Failures are
+        // Resolve every brand and attach any dark variant the brand
+        // *content* calls for (bd-0pic6 phase C + the unified split,
+        // bd-unified-brand-split-ep49amad): the brand file is read
+        // ONCE, parsed as a unified brand ({light:, dark:} values
+        // allowed), and split — the light variant compiles with the
+        // light half, the dark variant with the dark half; a brand
+        // whose content enables dark mode synthesizes the dark
+        // variant right here. I/O happens here. Failures are
         // user-facing configuration errors (missing `_brand.yml`,
         // invalid YAML, unknown brand shape) — propagate them rather
         // than silently shipping DEFAULT_CSS, same reasoning as the
         // `from_config_value` error path above.
         let resolved = theme_config
-            .clone()
-            .resolve(ctx.runtime.as_ref(), &ctx.project.dir)
+            .resolve_variants(ctx.runtime.as_ref(), &ctx.project.dir)
             .map_err(|e| {
                 PipelineError::stage_error(self.name(), format!("brand resolution: {e}"))
             })?;
+        let theme_config = &resolved.config;
 
         // The ThemeContexts borrow a local Arc clone of the runtime
         // (not `ctx`) so `ctx` stays mutably borrowable inside
         // `variant_css`.
         let runtime = ctx.runtime.clone();
         let mut theme_context = ThemeContext::new(document_dir.clone(), runtime.as_ref());
-        if let Some(brand) = resolved.brand.as_ref() {
-            let brand_dir = resolved
-                .brand_dir
-                .clone()
-                .unwrap_or_else(|| ctx.project.dir.clone());
-            theme_context = theme_context.with_brand(brand, brand_dir);
+        if let Some(rb) = resolved.light_brand.as_ref() {
+            let brand_dir = rb.dir.clone().unwrap_or_else(|| ctx.project.dir.clone());
+            theme_context = theme_context.with_brand(&rb.brand, brand_dir);
         }
 
-        let light_css =
-            variant_css(ctx, &theme_config, &theme_context, &doc_vars, cache_ok).await?;
+        let light_css = variant_css(ctx, theme_config, &theme_context, &doc_vars, cache_ok).await?;
 
         if let Some(dark_cfg) = theme_config.dark_variant() {
-            let resolved_dark = dark_cfg
-                .clone()
-                .resolve(ctx.runtime.as_ref(), &ctx.project.dir)
-                .map_err(|e| {
-                    PipelineError::stage_error(self.name(), format!("dark brand resolution: {e}"))
-                })?;
             let mut dark_context = ThemeContext::new(document_dir, runtime.as_ref());
-            if let Some(brand) = resolved_dark.brand.as_ref() {
-                let brand_dir = resolved_dark
-                    .brand_dir
-                    .clone()
-                    .unwrap_or_else(|| ctx.project.dir.clone());
-                dark_context = dark_context.with_brand(brand, brand_dir);
+            if let Some(rb) = resolved.dark_brand.as_ref() {
+                let brand_dir = rb.dir.clone().unwrap_or_else(|| ctx.project.dir.clone());
+                dark_context = dark_context.with_brand(&rb.brand, brand_dir);
             }
             let dark_css = variant_css(ctx, &dark_cfg, &dark_context, &doc_vars, cache_ok).await?;
             let dark_is_default = theme_config.dark.as_ref().is_some_and(|d| d.is_default);
             store_variant_pair(ctx, light_css, dark_css, dark_is_default);
+            // Record the pair decision where the downstream consumers
+            // can read it (`rendered.theme.dark-is-default`). The
+            // color-mode script/meta (ApplyTemplateStage) and the
+            // navbar toggle (AstTransformsStage) both run after this
+            // stage but cannot re-derive a CONTENT-driven dark
+            // variant from config alone — this key is the single
+            // source of truth; their config re-derivation remains
+            // only as a fallback for pipelines that skip this stage.
+            let si = doc.ast.meta.source_info.clone();
+            doc.ast.meta.insert_path(
+                &["rendered", "theme", "dark-is-default"],
+                quarto_pandoc_types::ConfigValue::new_bool(dark_is_default, si),
+            );
         } else {
             // Single variant: plain, attribute-free link — byte-identical
             // to the pre-light/dark output.

--- a/crates/quarto-core/src/template.rs
+++ b/crates/quarto-core/src/template.rs
@@ -833,11 +833,27 @@ pub fn render_with_compiled_template(
     //
     // Only the full template references these variables; setting them
     // elsewhere is inert.
-    let dark_theme_default = if let Ok(theme_config) =
+    //
+    // The pair decision is read from `rendered.theme.dark-is-default`
+    // — recorded by `CompileThemeCssStage`, the single source of
+    // truth. That includes dark variants synthesized from
+    // unified-brand *content* (bd-unified-brand-split-ep49amad),
+    // which a pure config re-parse here cannot see. The config
+    // re-derivation remains only as a fallback for callers that never
+    // ran the theme stage (unit tests, direct template rendering).
+    let recorded_dark_default = meta
+        .get("rendered")
+        .and_then(|v| v.get("theme"))
+        .and_then(|v| v.get("dark-is-default"))
+        .and_then(|v| v.as_bool());
+    let derived_dark_default = || {
         quarto_sass::ThemeConfig::from_config_value(meta)
-        && let Some(dark) = &theme_config.dark
+            .ok()
+            .and_then(|c| c.dark.map(|d| d.is_default))
+    };
+    let dark_theme_default = if let Some(author_prefers_dark) =
+        recorded_dark_default.or_else(derived_dark_default)
     {
-        let author_prefers_dark = dark.is_default;
         let respect = meta
             .get("respect-user-color-scheme")
             .and_then(|v| v.as_bool())

--- a/crates/quarto-core/src/transforms/navbar_generate.rs
+++ b/crates/quarto-core/src/transforms/navbar_generate.rs
@@ -85,8 +85,21 @@ impl AstTransform for NavbarGenerateTransform {
         // `formatDarkMode(format) !== undefined` navbar/sidebar
         // darkToggle. Parse errors mean the theme stage will fail the
         // render anyway; treat as "no toggle" here.
-        navbar.dark_mode_toggle =
-            quarto_sass::ThemeConfig::from_config_value(&ast.meta).is_ok_and(|c| c.dark.is_some());
+        // The pair decision recorded by CompileThemeCssStage
+        // (`rendered.theme.dark-is-default`) is the source of truth —
+        // it includes dark variants synthesized from unified-brand
+        // content, which the config re-parse below cannot see. The
+        // re-derivation stays as a fallback for pipelines that skip
+        // the theme stage.
+        let recorded_pair = ast
+            .meta
+            .get("rendered")
+            .and_then(|v| v.get("theme"))
+            .and_then(|v| v.get("dark-is-default"))
+            .is_some();
+        navbar.dark_mode_toggle = recorded_pair
+            || quarto_sass::ThemeConfig::from_config_value(&ast.meta)
+                .is_ok_and(|c| c.dark.is_some());
 
         // bd-qor9a — resolve each href against the YAML file it was
         // authored in. Frontmatter-rooted hrefs become project-root-

--- a/crates/quarto-core/tests/integration/brand_render.rs
+++ b/crates/quarto-core/tests/integration/brand_render.rs
@@ -177,3 +177,246 @@ fn theme_brand_without_brand_key_fails_loudly() {
         "error message should mention brand, got: {msg}"
     );
 }
+
+// ── unified light/dark brand (bd-unified-brand-split-ep49amad, GH #580) ──
+
+/// Collect `(path, contents)` for every CSS file under the resources
+/// dir, so assertions can distinguish which *file* carries a value.
+fn css_files_by_path(resources_dir: &Path) -> Vec<(std::path::PathBuf, String)> {
+    walkdir::WalkDir::new(resources_dir)
+        .follow_links(false)
+        .into_iter()
+        .filter_map(Result::ok)
+        .filter(|e| e.path().extension().and_then(|x| x.to_str()) == Some("css"))
+        .map(|e| {
+            let p = e.path().to_path_buf();
+            let contents = std::fs::read_to_string(&p).unwrap();
+            (p, contents)
+        })
+        .collect()
+}
+
+/// The exact reproduction from GH #580: a single-file render whose
+/// front matter names a `_brand.yml` that uses per-color `{light:,
+/// dark:}` values. The light value must land in the light stylesheet
+/// and the dark value in the dark one, matching what the two-file
+/// `brand: {light:, dark:}` form already does.
+#[test]
+fn unified_brand_light_dark_renders_both_stylesheets() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    write(
+        &root.join("_brand.yml"),
+        "color:\n  background:\n    light: \"#b22221\"\n    dark: \"#22b221\"\n",
+    );
+    write(
+        &root.join("index.qmd"),
+        "---\nformat: html\nbrand: _brand.yml\n---\n\nHello.\n",
+    );
+
+    let runtime: Arc<dyn SystemRuntime> = Arc::new(NativeRuntime::new());
+    let result = render_to_file(
+        &root.join("index.qmd"),
+        "html",
+        &RenderToFileOptions {
+            quiet: true,
+            ..Default::default()
+        },
+        runtime,
+    )
+    .expect("a unified light/dark brand must render (GH #580)");
+
+    let files = css_files_by_path(&result.resources_dir);
+    let light = files
+        .iter()
+        .find(|(_, css)| css.contains("--bs-body-bg: #b22221"))
+        .expect("some CSS file must carry the light background");
+    let dark = files
+        .iter()
+        .find(|(_, css)| css.contains("--bs-body-bg: #22b221"))
+        .expect("some CSS file must carry the dark background");
+    assert_ne!(
+        light.0, dark.0,
+        "light and dark variants must be separate CSS files"
+    );
+
+    // The dual-variant machinery must fully engage: attributed links,
+    // the trailing light-copy link (light is the author default for a
+    // unified brand), and the color-mode runtime.
+    let html = std::fs::read_to_string(&result.output_path).unwrap();
+    assert!(
+        html.contains(r#"class="quarto-color-scheme" id="quarto-bootstrap""#),
+        "attributed light link must be present"
+    );
+    assert!(
+        html.contains(r#"class="quarto-color-scheme quarto-color-alternate""#),
+        "attributed dark (alternate) link must be present"
+    );
+    assert!(
+        html.contains(r#"class="quarto-color-scheme-extra""#),
+        "light is the author default → trailing light-copy link"
+    );
+    assert!(
+        html.contains(r#"<meta name="color-scheme" content="light">"#),
+        "author-default-light meta hint"
+    );
+    assert!(
+        html.contains(r#"data-author-prefers-dark="false""#),
+        "color-mode script must be configured for light default"
+    );
+}
+
+/// Project-config shape from docs/guides/authoring/brand.qmd: the
+/// brand is named in `_quarto.yml`, and typography colors carry
+/// pairs too. Each hex must land only in its own variant's CSS.
+#[test]
+fn unified_brand_typography_colors_split_per_variant() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    write(
+        &root.join("_quarto.yml"),
+        "project:\n  type: default\nbrand: _brand.yml\n",
+    );
+    write(
+        &root.join("_brand.yml"),
+        concat!(
+            "color:\n",
+            "  background:\n",
+            "    light: \"#fefefd\"\n",
+            "    dark: \"#333231\"\n",
+            "typography:\n",
+            "  headings:\n",
+            "    color:\n",
+            "      light: \"#111143\"\n",
+            "      dark: \"#d0d0fe\"\n",
+        ),
+    );
+    write(
+        &root.join("index.qmd"),
+        "---\nformat: html\n---\n\n# Heading\n",
+    );
+
+    let runtime: Arc<dyn SystemRuntime> = Arc::new(NativeRuntime::new());
+    let result = render_to_file(
+        &root.join("index.qmd"),
+        "html",
+        &RenderToFileOptions {
+            quiet: true,
+            ..Default::default()
+        },
+        runtime,
+    )
+    .expect("project-level unified brand must render");
+
+    let files = css_files_by_path(&result.resources_dir);
+    let light = files
+        .iter()
+        .find(|(_, css)| css.contains("#fefefd"))
+        .expect("light background present in some CSS file");
+    let dark = files
+        .iter()
+        .find(|(_, css)| css.contains("#333231"))
+        .expect("dark background present in some CSS file");
+    assert_ne!(light.0, dark.0);
+    assert!(
+        light.1.contains("#111143") && !light.1.contains("#d0d0fe"),
+        "light headings color only in the light variant"
+    );
+    assert!(
+        dark.1.contains("#d0d0fe") && !dark.1.contains("#111143"),
+        "dark headings color only in the dark variant"
+    );
+}
+
+/// A unified brand with no dark values must NOT enable dark mode:
+/// single stylesheet, no attributed links, no color-mode runtime
+/// (Q1's `enablesDarkMode` counts only actual `dark:` keys).
+#[test]
+fn unified_brand_all_plain_stays_single_variant() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    write(
+        &root.join("_brand.yml"),
+        "color:\n  background: \"#fefefd\"\n  primary: \"#3366c1\"\n",
+    );
+    write(
+        &root.join("index.qmd"),
+        "---\nformat: html\nbrand: _brand.yml\n---\n\nHello.\n",
+    );
+
+    let runtime: Arc<dyn SystemRuntime> = Arc::new(NativeRuntime::new());
+    let result = render_to_file(
+        &root.join("index.qmd"),
+        "html",
+        &RenderToFileOptions {
+            quiet: true,
+            ..Default::default()
+        },
+        runtime,
+    )
+    .expect("plain brand must render");
+
+    let files = css_files_by_path(&result.resources_dir);
+    assert!(
+        !files
+            .iter()
+            .any(|(p, _)| p.file_name().and_then(|n| n.to_str()) == Some("styles-dark.css")),
+        "no dark values → no dark stylesheet"
+    );
+    let html = std::fs::read_to_string(&result.output_path).unwrap();
+    assert!(
+        !html.contains("quarto-color-scheme"),
+        "no dark values → plain, attribute-free links"
+    );
+    assert!(
+        !html.contains("quarto-color-mode"),
+        "no dark values → no color-mode runtime"
+    );
+}
+
+/// The navbar dark-mode toggle must appear when the ONLY dark signal
+/// is unified brand content (no `theme: {light:, dark:}` pair) — the
+/// toggle decision may not be re-derived from config alone.
+#[test]
+fn unified_brand_enables_navbar_toggle() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    write(
+        &root.join("_quarto.yml"),
+        concat!(
+            "project:\n",
+            "  type: website\n",
+            "website:\n",
+            "  navbar:\n",
+            "    left:\n",
+            "      - href: index.qmd\n",
+            "        text: Home\n",
+            "brand: _brand.yml\n",
+        ),
+    );
+    write(
+        &root.join("_brand.yml"),
+        "color:\n  background:\n    light: \"#fefefd\"\n    dark: \"#333231\"\n",
+    );
+    write(
+        &root.join("index.qmd"),
+        "---\ntitle: Home\n---\n\n# Hello\n",
+    );
+
+    let runtime: Arc<dyn SystemRuntime> = Arc::new(NativeRuntime::new());
+    let result = render_to_file(
+        &root.join("index.qmd"),
+        "html",
+        &RenderToFileOptions {
+            quiet: true,
+            ..Default::default()
+        },
+        runtime,
+    )
+    .expect("website with unified brand must render");
+    let html = std::fs::read_to_string(&result.output_path).unwrap();
+    assert!(
+        html.contains(r#"class="quarto-color-scheme-toggle"#),
+        "navbar must carry the dark-mode toggle when brand content enables dark mode"
+    );
+}

--- a/crates/quarto-sass/src/config.rs
+++ b/crates/quarto-sass/src/config.rs
@@ -28,7 +28,7 @@
 
 use std::path::{Path, PathBuf};
 
-use quarto_brand::{Brand, BrandRef, ResolvedBrand};
+use quarto_brand::{BrandRef, ResolvedBrand};
 use quarto_pandoc_types::ConfigValue;
 use quarto_source_map::SourceInfo;
 use quarto_system_runtime::SystemRuntime;
@@ -121,6 +121,17 @@ pub struct ThemeConfig {
     /// darkness (`theme: darkly` + `a11y` → `a11y-dark`). `None` →
     /// the default palette.
     pub highlight_style: Option<HighlightStyle>,
+
+    /// The dark-resolved highlight palette held in reserve when NO
+    /// dark variant exists at config-parse time (the scalar name
+    /// resolved with `dark = true`, or the dropped `dark:` half of a
+    /// `highlight-style:` pair). [`ThemeConfig::resolve_variants`]
+    /// moves it onto a dark variant it synthesizes from unified-brand
+    /// content, so `highlight-style: a11y` + a brand with `dark:`
+    /// values still yields `a11y-dark` in the dark compile. Unused
+    /// when a dark variant was declared in config (that variant got
+    /// its palette directly in `parse_highlight_style`).
+    pub deferred_dark_highlight: Option<HighlightStyle>,
 }
 
 /// The parsed `dark:` half of a `theme: {light: …, dark: …}` pair
@@ -186,26 +197,34 @@ pub struct HighlightStyle {
     pub location: Option<SourceInfo>,
 }
 
-/// Resolved form of [`ThemeConfig`] with the brand file loaded and
-/// parsed.
+/// The fully resolved theme configuration: the config (with any
+/// content-synthesized dark variant attached) plus each variant's
+/// half of the split brand.
 ///
-/// Produced by [`ThemeConfig::resolve`]. Carries everything the SCSS
-/// pipeline needs to compile the document's CSS, including the typed
-/// `Brand` value when the configuration requests one.
-#[derive(Debug, Clone, Default)]
-pub struct ResolvedThemeConfig {
-    pub themes: Vec<ThemeSpec>,
-    pub minified: bool,
-    pub suppress_bootstrap: bool,
-    pub brand: Option<Brand>,
-    /// Directory the brand file was loaded from (for resolving
-    /// relative `@font-face` URLs). `None` when brand was inline.
-    pub brand_dir: Option<PathBuf>,
-    /// The dark variant, carried through unchanged from
-    /// [`ThemeConfig::dark`]. (The brand is resolved once and shared
-    /// by both variants until the brand light/dark seam lands —
-    /// bd-ld-c-brand-seam-wef8ww3n.)
-    pub dark: Option<DarkThemeConfig>,
+/// Produced by [`ThemeConfig::resolve_variants`] — the single place
+/// brand I/O happens. The unified brand file is read and parsed
+/// once, split into light/dark halves
+/// ([`quarto_brand::UnifiedBrand::split`]), and each half handed to
+/// its variant; when the brand *content* enables dark mode (some
+/// value carries a `dark:` side — Q1's `enablesDarkMode`) and no dark
+/// variant was declared in config, one is synthesized here
+/// (bd-unified-brand-split-ep49amad).
+#[derive(Debug, Clone)]
+pub struct ResolvedVariants {
+    /// The theme configuration, including a dark variant synthesized
+    /// from unified-brand content when applicable. Use
+    /// [`ThemeConfig::dark_variant`] on it to project the dark
+    /// compile's config, exactly as with a config-declared pair.
+    pub config: ThemeConfig,
+    /// The light variant's brand (the split's light half), with the
+    /// directory it was read from. `None` when no brand is configured
+    /// (or `theme: none` suppressed it).
+    pub light_brand: Option<ResolvedBrand>,
+    /// The dark variant's brand (the split's dark half — of the same
+    /// file when the dark variant shares the light `brand_ref`, or of
+    /// its own file in the two-file `brand: {light:, dark:}` form).
+    /// `None` when there is no dark variant or it has no brand.
+    pub dark_brand: Option<ResolvedBrand>,
 }
 
 impl ThemeConfig {
@@ -221,6 +240,7 @@ impl ThemeConfig {
             brand_ref: None,
             dark: None,
             highlight_style: None,
+            deferred_dark_highlight: None,
         }
     }
 
@@ -238,6 +258,7 @@ impl ThemeConfig {
             brand_ref: None,
             dark: None,
             highlight_style: None,
+            deferred_dark_highlight: None,
         }
     }
 
@@ -433,6 +454,7 @@ impl ThemeConfig {
                 brand_ref: None,
                 dark: None,
                 highlight_style: None,
+                deferred_dark_highlight: None,
             });
         }
         let located = extract_theme_specs(value)?;
@@ -449,66 +471,90 @@ impl ThemeConfig {
             brand_ref: None,
             dark: None,
             highlight_style: None,
+            deferred_dark_highlight: None,
         })
     }
 
-    /// Resolve any [`BrandRef`] in this config by reading the brand
-    /// file (if it's a path) and parsing it into a typed [`Brand`].
+    /// Resolve every [`BrandRef`] in this config — the single place
+    /// brand I/O happens — and attach any dark variant the brand
+    /// *content* calls for.
+    ///
+    /// Each referenced brand is read once, parsed as a
+    /// [`quarto_brand::UnifiedBrand`] (values may be plain strings or
+    /// `{light:, dark:}` pairs), and split; the light variant gets
+    /// the light half, the dark variant the dark half. When the split
+    /// reports `enables_dark_mode` (Q1's `enablesDarkMode`: some value
+    /// carries an explicit `dark:` side) and no dark variant was
+    /// declared in config, a dark variant is synthesized from the
+    /// light theme list — it then flows through dual compilation,
+    /// link emission, and the toggle exactly like a `theme:`-declared
+    /// pair (bd-unified-brand-split-ep49amad, GH #580).
     ///
     /// `base_dir` is the directory relative paths in [`BrandRef::Path`]
     /// are resolved against (typically the project root). The
     /// `runtime` provides cross-platform file access — native
     /// `std::fs` on the CLI, the VFS on WASM.
-    pub fn resolve(
-        self,
+    pub fn resolve_variants(
+        mut self,
         runtime: &dyn SystemRuntime,
         base_dir: &Path,
-    ) -> Result<ResolvedThemeConfig, SassError> {
-        let (brand, brand_dir) = match self.brand_ref {
-            None => (None, None),
-            Some(BrandRef::Path(rel_path)) => {
-                let full_path = if rel_path.is_absolute() {
-                    rel_path.clone()
-                } else {
-                    base_dir.join(&rel_path)
-                };
-                let bytes = runtime.file_read(&full_path).map_err(|e| {
-                    SassError::Io(std::io::Error::other(format!(
-                        "reading brand file {}: {e}",
-                        full_path.display()
-                    )))
-                })?;
-                let yaml =
-                    std::str::from_utf8(&bytes).map_err(|e| SassError::InvalidThemeConfig {
-                        message: format!(
-                            "brand file {} is not valid UTF-8: {e}",
-                            full_path.display()
-                        ),
-                        location: None,
-                    })?;
-                let brand = Brand::from_yaml_str(yaml).map_err(brand_err)?;
-                let dir = full_path
-                    .parent()
-                    .map_or_else(|| PathBuf::from("."), Path::to_path_buf);
-                (Some(brand), Some(dir))
+    ) -> Result<ResolvedVariants, SassError> {
+        let light_split = match &self.brand_ref {
+            None => None,
+            Some(brand_ref) => Some(load_split_brand(brand_ref, runtime, base_dir)?),
+        };
+
+        // Content-driven dark-mode enablement: synthesize the dark
+        // variant the way the config-time path does for an explicit
+        // `brand: {…, dark: …}` pair (`from_config_value`), cloning
+        // the light theme list (brand token already injected there).
+        // A unified brand has no ordering signal, so light stays the
+        // author default. The highlight palette comes from the
+        // reserve slot `parse_highlight_style` filled (`a11y` →
+        // `a11y-dark`; a pair's `dark:` value verbatim).
+        if let Some((split, _)) = &light_split
+            && split.enables_dark_mode
+            && self.dark.is_none()
+            && !self.suppress_bootstrap
+        {
+            self.dark = Some(DarkThemeConfig {
+                themes: self.themes.clone(),
+                theme_locations: self.theme_locations.clone(),
+                suppress_bootstrap: false,
+                is_default: false,
+                key_location: None,
+                highlight_style: self.deferred_dark_highlight.clone(),
+                brand_ref: self.brand_ref.clone(),
+            });
+        }
+
+        let light_brand = light_split
+            .as_ref()
+            .map(|(split, dir)| ResolvedBrand::new(split.light.clone(), dir.clone()));
+
+        let dark_brand = match self.dark.as_ref().and_then(|d| d.brand_ref.as_ref()) {
+            None => None,
+            Some(dark_ref) if Some(dark_ref) == self.brand_ref.as_ref() => {
+                // Same file as the light variant (single-file brand,
+                // or per-layer fallback): reuse the split — one read,
+                // one parse.
+                light_split
+                    .as_ref()
+                    .map(|(split, dir)| ResolvedBrand::new(split.dark.clone(), dir.clone()))
             }
-            Some(BrandRef::Inline(value)) => {
-                let brand: Brand =
-                    serde_yaml::from_value(*value).map_err(|e| SassError::InvalidThemeConfig {
-                        message: format!("inline brand block: {e}"),
-                        location: None,
-                    })?;
-                (Some(brand), None)
+            Some(dark_ref) => {
+                // Two-file form: the dark variant's own file
+                // contributes its dark half (for a plain single-mode
+                // file the halves are identical).
+                let (split, dir) = load_split_brand(dark_ref, runtime, base_dir)?;
+                Some(ResolvedBrand::new(split.dark, dir))
             }
         };
 
-        Ok(ResolvedThemeConfig {
-            themes: self.themes,
-            minified: self.minified,
-            suppress_bootstrap: self.suppress_bootstrap,
-            brand,
-            brand_dir,
-            dark: self.dark,
+        Ok(ResolvedVariants {
+            config: self,
+            light_brand,
+            dark_brand,
         })
     }
 
@@ -531,6 +577,7 @@ impl ThemeConfig {
             brand_ref: d.brand_ref.clone(),
             dark: None,
             highlight_style: d.highlight_style.clone(),
+            deferred_dark_highlight: None,
         })
     }
 
@@ -577,27 +624,60 @@ pub fn resolve_brand(
     base_dir: &Path,
 ) -> Result<Option<ResolvedBrand>, SassError> {
     // Single-variant consumers (reveal, favicon fallback) use the
-    // LIGHT brand; per-variant selection is the HTML dual-compile
-    // path's concern (bd-0pic6 phase C).
+    // LIGHT half; per-variant selection is the HTML dual-compile
+    // path's concern (bd-0pic6 phase C). Logos pass through the split
+    // intact, so logo consumers see the full light/dark logo pairs.
     let Some(brand_ref) = extract_brand_refs(config.get("brand"))?.light else {
         return Ok(None);
     };
-    // Reuse ThemeConfig's brand resolution (path/inline → typed Brand).
-    let resolved = ThemeConfig {
-        themes: Vec::new(),
-        theme_locations: Vec::new(),
-        minified: true,
-        suppress_bootstrap: false,
-        title_block_layer: true,
-        brand_ref: Some(brand_ref),
-        dark: None,
-        highlight_style: None,
-    }
-    .resolve(runtime, base_dir)?;
+    let (split, dir) = load_split_brand(&brand_ref, runtime, base_dir)?;
+    Ok(Some(ResolvedBrand::new(split.light, dir)))
+}
 
-    Ok(resolved
-        .brand
-        .map(|brand| ResolvedBrand::new(brand, resolved.brand_dir)))
+/// Read and parse one [`BrandRef`] into a split brand plus the
+/// directory it was read from (`None` for inline blocks).
+///
+/// The parse form is [`quarto_brand::UnifiedBrand`] — color values may
+/// be plain strings or `{light:, dark:}` pairs — which is immediately
+/// split into single-mode halves. This is the only place a brand is
+/// deserialized; every consumer works with a half of the split.
+fn load_split_brand(
+    brand_ref: &BrandRef,
+    runtime: &dyn SystemRuntime,
+    base_dir: &Path,
+) -> Result<(quarto_brand::SplitBrand, Option<PathBuf>), SassError> {
+    match brand_ref {
+        BrandRef::Path(rel_path) => {
+            let full_path = if rel_path.is_absolute() {
+                rel_path.clone()
+            } else {
+                base_dir.join(rel_path)
+            };
+            let bytes = runtime.file_read(&full_path).map_err(|e| {
+                SassError::Io(std::io::Error::other(format!(
+                    "reading brand file {}: {e}",
+                    full_path.display()
+                )))
+            })?;
+            let yaml = std::str::from_utf8(&bytes).map_err(|e| SassError::InvalidThemeConfig {
+                message: format!("brand file {} is not valid UTF-8: {e}", full_path.display()),
+                location: None,
+            })?;
+            let brand = quarto_brand::UnifiedBrand::from_yaml_str(yaml).map_err(brand_err)?;
+            let dir = full_path
+                .parent()
+                .map_or_else(|| PathBuf::from("."), Path::to_path_buf);
+            Ok((brand.split(), Some(dir)))
+        }
+        BrandRef::Inline(value) => {
+            let brand: quarto_brand::UnifiedBrand = serde_yaml::from_value((**value).clone())
+                .map_err(|e| SassError::InvalidThemeConfig {
+                    message: format!("inline brand block: {e}"),
+                    location: None,
+                })?;
+            Ok((brand.split(), None))
+        }
+    }
 }
 
 /// Resolve a `_brand.yml` (from the `brand:` key) into SCSS layers, independent
@@ -914,12 +994,18 @@ fn parse_highlight_style(config: &ConfigValue, result: &mut ThemeConfig) -> Resu
                 });
             };
             // A dark highlight palette needs a dark theme variant to
-            // ride on; without one it has no compile to affect.
+            // ride on. Without one it is held in reserve: a dark
+            // variant synthesized later from unified-brand content
+            // (`resolve_variants`) picks it up from
+            // `deferred_dark_highlight`.
+            let hs = HighlightStyle {
+                name: resolve_adaptive_highlight(&name, true),
+                location: Some(dark_value.source_info.clone()),
+            };
             if let Some(dark_half) = result.dark.as_mut() {
-                dark_half.highlight_style = Some(HighlightStyle {
-                    name: resolve_adaptive_highlight(&name, true),
-                    location: Some(dark_value.source_info.clone()),
-                });
+                dark_half.highlight_style = Some(hs);
+            } else {
+                result.deferred_dark_highlight = Some(hs);
             }
         }
         return Ok(());
@@ -937,11 +1023,16 @@ fn parse_highlight_style(config: &ConfigValue, result: &mut ThemeConfig) -> Resu
         name: resolve_adaptive_highlight(&name, light_is_dark),
         location: Some(value.source_info.clone()),
     });
+    let dark_hs = HighlightStyle {
+        name: resolve_adaptive_highlight(&name, true),
+        location: Some(value.source_info.clone()),
+    };
     if let Some(dark_half) = result.dark.as_mut() {
-        dark_half.highlight_style = Some(HighlightStyle {
-            name: resolve_adaptive_highlight(&name, true),
-            location: Some(value.source_info.clone()),
-        });
+        dark_half.highlight_style = Some(dark_hs);
+    } else {
+        // Held in reserve for a dark variant synthesized from
+        // unified-brand content (`resolve_variants`).
+        result.deferred_dark_highlight = Some(dark_hs);
     }
     Ok(())
 }
@@ -2380,9 +2471,13 @@ mod tests {
             ThemeConfig::from_config_value(&config_with_theme_value(theme_value)).unwrap();
         let runtime = quarto_system_runtime::NativeRuntime::new();
         let resolved = theme_config
-            .resolve(&runtime, Path::new("."))
+            .resolve_variants(&runtime, Path::new("."))
             .expect("resolve without brand does no I/O");
-        let dark = resolved.dark.as_ref().expect("dark half carried through");
+        let dark = resolved
+            .config
+            .dark
+            .as_ref()
+            .expect("dark half carried through");
         assert_eq!(dark.themes.len(), 1);
         assert!(dark.themes[0].is_builtin());
     }

--- a/crates/quarto-sass/src/lib.rs
+++ b/crates/quarto-sass/src/lib.rs
@@ -67,7 +67,7 @@ pub use compile::{
     compile_theme_css, compile_with_doc_vars,
 };
 pub use config::{
-    DarkThemeConfig, HighlightStyle, ResolvedThemeConfig, ThemeConfig, resolve_brand,
+    DarkThemeConfig, HighlightStyle, ResolvedVariants, ThemeConfig, resolve_brand,
     resolve_brand_layers,
 };
 pub use error::SassError;

--- a/crates/quarto-sass/tests/integration/brand_compile_test.rs
+++ b/crates/quarto-sass/tests/integration/brand_compile_test.rs
@@ -23,7 +23,10 @@ fn load_brand(rel: &str) -> Brand {
     let path = fixtures_dir().join(rel);
     let yaml =
         std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
-    Brand::from_yaml_str(&yaml).unwrap_or_else(|e| panic!("parse: {e}"))
+    quarto_brand::UnifiedBrand::from_yaml_str(&yaml)
+        .unwrap_or_else(|e| panic!("parse: {e}"))
+        .split()
+        .light
 }
 
 /// Concatenate all layers into a single SCSS string in the same order

--- a/crates/quarto-sass/tests/integration/brand_config_test.rs
+++ b/crates/quarto-sass/tests/integration/brand_config_test.rs
@@ -163,13 +163,13 @@ fn resolve_no_brand_produces_resolved_with_brand_none() {
     let config = flattened_config(vec![("theme", scalar_string("cosmo"))]);
     let theme_config = ThemeConfig::from_config_value(&config).unwrap();
     let resolved = theme_config
-        .resolve(
+        .resolve_variants(
             &quarto_system_runtime::NativeRuntime::new(),
             std::path::Path::new("/tmp"),
         )
         .expect("resolve");
-    assert!(resolved.brand.is_none());
-    assert_eq!(resolved.themes.len(), 1);
+    assert!(resolved.light_brand.is_none());
+    assert_eq!(resolved.config.themes.len(), 1);
 }
 
 #[test]
@@ -189,12 +189,12 @@ fn resolve_inline_brand_parses_typed_brand() {
     let config = flattened_config(vec![("brand", brand_value)]);
     let theme_config = ThemeConfig::from_config_value(&config).unwrap();
     let resolved = theme_config
-        .resolve(
+        .resolve_variants(
             &quarto_system_runtime::NativeRuntime::new(),
             std::path::Path::new("/tmp"),
         )
         .expect("resolve");
-    let brand = resolved.brand.expect("resolved brand");
+    let brand = resolved.light_brand.expect("resolved brand").brand;
     let color = brand.color.expect("color");
     assert_eq!(color.primary.as_deref(), Some("#abc"));
 }
@@ -209,9 +209,9 @@ fn resolve_path_brand_reads_from_runtime() {
     let config = flattened_config(vec![("brand", scalar_string("_brand.yml"))]);
     let theme_config = ThemeConfig::from_config_value(&config).unwrap();
     let resolved = theme_config
-        .resolve(&quarto_system_runtime::NativeRuntime::new(), dir.path())
+        .resolve_variants(&quarto_system_runtime::NativeRuntime::new(), dir.path())
         .expect("resolve");
-    let brand = resolved.brand.expect("brand");
+    let brand = resolved.light_brand.expect("brand").brand;
     let color = brand.color.expect("color");
     assert_eq!(color.primary.as_deref(), Some("#def"));
 }

--- a/crates/quarto-sass/tests/integration/brand_layer_test.rs
+++ b/crates/quarto-sass/tests/integration/brand_layer_test.rs
@@ -17,7 +17,10 @@ use quarto_brand::Brand;
 use quarto_sass::brand_to_layers;
 
 fn brand(yaml: &str) -> Brand {
-    Brand::from_yaml_str(yaml).expect("parse")
+    quarto_brand::UnifiedBrand::from_yaml_str(yaml)
+        .expect("parse")
+        .split()
+        .light
 }
 
 // ── color layer ─────────────────────────────────────────────────────

--- a/crates/quarto-sass/tests/integration/brand_light_dark_test.rs
+++ b/crates/quarto-sass/tests/integration/brand_light_dark_test.rs
@@ -1,0 +1,351 @@
+//! Unified `_brand.yml` light/dark splitting through
+//! `ThemeConfig::resolve_variants` (bd-unified-brand-split-ep49amad,
+//! GH #580).
+//!
+//! A single brand whose color/typography values carry `{light:,
+//! dark:}` pairs must (a) parse, (b) synthesize a dark theme variant
+//! when the brand content enables dark mode (Q1's `enablesDarkMode`),
+//! and (c) hand each variant its half of the split brand. The
+//! two-file `brand: {light:, dark:}` form keeps its config-time
+//! synthesis and now also takes the matching half of each file.
+
+use std::path::Path;
+
+use quarto_pandoc_types::{ConfigMapEntry, ConfigValue, ConfigValueKind, MergeOp};
+use quarto_sass::ThemeConfig;
+use quarto_source_map::SourceInfo;
+use quarto_system_runtime::NativeRuntime;
+use yaml_rust2::Yaml;
+
+// ── config-construction helpers (same shapes as brand_config_test) ──
+
+fn flattened_config(entries: Vec<(&str, ConfigValue)>) -> ConfigValue {
+    let map_entries = entries
+        .into_iter()
+        .map(|(k, v)| ConfigMapEntry {
+            key: k.to_string(),
+            key_source: SourceInfo::for_test(),
+            value: v,
+        })
+        .collect();
+    ConfigValue {
+        value: ConfigValueKind::Map(map_entries),
+        source_info: SourceInfo::for_test(),
+        merge_op: MergeOp::Concat,
+    }
+}
+
+fn map_config(entries: Vec<(&str, ConfigValue)>) -> ConfigValue {
+    // Same construction; a nested map value (e.g. the `{light:, dark:}`
+    // pair form of `brand:` / `highlight-style:`).
+    flattened_config(entries)
+}
+
+fn scalar_string(s: &str) -> ConfigValue {
+    ConfigValue {
+        value: ConfigValueKind::scalar(Yaml::String(s.to_string())),
+        source_info: SourceInfo::for_test(),
+        merge_op: MergeOp::Concat,
+    }
+}
+
+/// The unified `_brand.yml` used by most tests: a background pair.
+const UNIFIED_BRAND_YAML: &str =
+    "color:\n  background:\n    light: \"#b22221\"\n    dark: \"#22b221\"\n";
+
+fn write_brand(dir: &Path, name: &str, contents: &str) {
+    std::fs::write(dir.join(name), contents).unwrap();
+}
+
+fn resolve(config: &ConfigValue, dir: &Path) -> quarto_sass::ResolvedVariants {
+    ThemeConfig::from_config_value(config)
+        .expect("config parses")
+        .resolve_variants(&NativeRuntime::new(), dir)
+        .expect("resolve_variants")
+}
+
+fn background_of(rb: &Option<quarto_brand::ResolvedBrand>) -> Option<String> {
+    rb.as_ref()?.brand.color.as_ref()?.background.clone()
+}
+
+// ── content-driven dark-variant synthesis ───────────────────────────
+
+#[test]
+fn unified_brand_file_synthesizes_dark_variant() {
+    let dir = tempfile::tempdir().unwrap();
+    write_brand(dir.path(), "_brand.yml", UNIFIED_BRAND_YAML);
+    let config = flattened_config(vec![
+        ("theme", scalar_string("cosmo")),
+        ("brand", scalar_string("_brand.yml")),
+    ]);
+    let rv = resolve(&config, dir.path());
+
+    let dark = rv
+        .config
+        .dark
+        .as_ref()
+        .expect("brand dark values must synthesize a dark variant");
+    assert!(
+        !dark.is_default,
+        "a unified brand has no ordering signal; light stays the author default"
+    );
+    assert_eq!(
+        dark.themes.len(),
+        rv.config.themes.len(),
+        "synthesized dark variant clones the light theme list"
+    );
+    assert!(
+        dark.themes.iter().any(quarto_sass::ThemeSpec::is_brand),
+        "synthesized dark variant must carry the brand token"
+    );
+
+    assert_eq!(background_of(&rv.light_brand).as_deref(), Some("#b22221"));
+    assert_eq!(background_of(&rv.dark_brand).as_deref(), Some("#22b221"));
+}
+
+#[test]
+fn unified_brand_all_plain_stays_single_variant() {
+    let dir = tempfile::tempdir().unwrap();
+    write_brand(
+        dir.path(),
+        "_brand.yml",
+        "color:\n  background: \"#b22221\"\n",
+    );
+    let config = flattened_config(vec![
+        ("theme", scalar_string("cosmo")),
+        ("brand", scalar_string("_brand.yml")),
+    ]);
+    let rv = resolve(&config, dir.path());
+    assert!(
+        rv.config.dark.is_none(),
+        "no dark values → no synthesized dark variant"
+    );
+    assert_eq!(background_of(&rv.light_brand).as_deref(), Some("#b22221"));
+    assert!(rv.dark_brand.is_none());
+}
+
+#[test]
+fn unified_brand_light_only_pair_stays_single_variant() {
+    let dir = tempfile::tempdir().unwrap();
+    write_brand(
+        dir.path(),
+        "_brand.yml",
+        "color:\n  background:\n    light: \"#b22221\"\n",
+    );
+    let config = flattened_config(vec![
+        ("theme", scalar_string("cosmo")),
+        ("brand", scalar_string("_brand.yml")),
+    ]);
+    let rv = resolve(&config, dir.path());
+    assert!(
+        rv.config.dark.is_none(),
+        "a light-only pair does not enable dark mode"
+    );
+}
+
+#[test]
+fn theme_none_suppresses_brand_and_synthesis() {
+    // `theme: none` drops the brand per the existing mutual-exclusion
+    // rule; brand content must not resurrect a dark variant.
+    let dir = tempfile::tempdir().unwrap();
+    write_brand(dir.path(), "_brand.yml", UNIFIED_BRAND_YAML);
+    let config = flattened_config(vec![
+        ("theme", scalar_string("none")),
+        ("brand", scalar_string("_brand.yml")),
+    ]);
+    let rv = resolve(&config, dir.path());
+    assert!(rv.config.dark.is_none());
+    assert!(rv.light_brand.is_none());
+    assert!(rv.dark_brand.is_none());
+}
+
+#[test]
+fn explicit_theme_pair_uses_brand_halves_without_double_synthesis() {
+    let dir = tempfile::tempdir().unwrap();
+    write_brand(dir.path(), "_brand.yml", UNIFIED_BRAND_YAML);
+    let theme = map_config(vec![
+        ("light", scalar_string("cosmo")),
+        ("dark", scalar_string("darkly")),
+    ]);
+    let config = flattened_config(vec![
+        ("theme", theme),
+        ("brand", scalar_string("_brand.yml")),
+    ]);
+    let rv = resolve(&config, dir.path());
+
+    let dark = rv.config.dark.as_ref().expect("declared dark variant");
+    assert!(
+        dark.themes
+            .iter()
+            .any(|t| t.as_builtin().map(|b| b.name()) == Some("darkly")),
+        "declared dark theme list wins (no synthesized clone of the light list)"
+    );
+    assert_eq!(background_of(&rv.light_brand).as_deref(), Some("#b22221"));
+    assert_eq!(background_of(&rv.dark_brand).as_deref(), Some("#22b221"));
+}
+
+// ── two-file form (existing seam) takes matching halves ─────────────
+
+#[test]
+fn two_file_brand_resolves_each_variants_file() {
+    let dir = tempfile::tempdir().unwrap();
+    write_brand(
+        dir.path(),
+        "light-brand.yml",
+        "color:\n  background: \"#b22221\"\n",
+    );
+    write_brand(
+        dir.path(),
+        "dark-brand.yml",
+        "color:\n  background: \"#22b221\"\n",
+    );
+    let brand = map_config(vec![
+        ("light", scalar_string("light-brand.yml")),
+        ("dark", scalar_string("dark-brand.yml")),
+    ]);
+    let config = flattened_config(vec![("theme", scalar_string("cosmo")), ("brand", brand)]);
+    let rv = resolve(&config, dir.path());
+
+    assert!(rv.config.dark.is_some(), "two-file form enables dark mode");
+    assert_eq!(background_of(&rv.light_brand).as_deref(), Some("#b22221"));
+    assert_eq!(background_of(&rv.dark_brand).as_deref(), Some("#22b221"));
+}
+
+#[test]
+fn two_file_brand_with_pairs_takes_matching_half() {
+    // A file named by the dark side that itself uses `{light:, dark:}`
+    // values contributes its DARK half (more permissive than Q1, which
+    // rejects pairs inside a mode-specific file; noted in bd-qnylgu69).
+    let dir = tempfile::tempdir().unwrap();
+    write_brand(
+        dir.path(),
+        "light-brand.yml",
+        "color:\n  background: \"#b22221\"\n",
+    );
+    write_brand(
+        dir.path(),
+        "dark-brand.yml",
+        "color:\n  background:\n    light: \"#fefefd\"\n    dark: \"#22b221\"\n",
+    );
+    let brand = map_config(vec![
+        ("light", scalar_string("light-brand.yml")),
+        ("dark", scalar_string("dark-brand.yml")),
+    ]);
+    let config = flattened_config(vec![("theme", scalar_string("cosmo")), ("brand", brand)]);
+    let rv = resolve(&config, dir.path());
+    assert_eq!(background_of(&rv.dark_brand).as_deref(), Some("#22b221"));
+}
+
+#[test]
+fn single_file_brand_dark_variant_gets_dark_half_when_theme_pair_declared() {
+    // `brand: file` + `theme: {light:, dark:}`: the dark variant falls
+    // back to the light brand ref; it must receive the DARK half of
+    // the split, not a copy of the light half.
+    let dir = tempfile::tempdir().unwrap();
+    write_brand(
+        dir.path(),
+        "_brand.yml",
+        "color:\n  background:\n    light: \"#b22221\"\n  foreground: \"#333332\"\n",
+    );
+    let theme = map_config(vec![
+        ("light", scalar_string("cosmo")),
+        ("dark", scalar_string("darkly")),
+    ]);
+    let config = flattened_config(vec![
+        ("theme", theme),
+        ("brand", scalar_string("_brand.yml")),
+    ]);
+    let rv = resolve(&config, dir.path());
+    // background is light-only → omitted from the dark half...
+    assert_eq!(background_of(&rv.dark_brand), None);
+    // ...while the plain foreground reaches both halves.
+    let dark_fg = rv
+        .dark_brand
+        .as_ref()
+        .and_then(|rb| rb.brand.color.as_ref())
+        .and_then(|c| c.foreground.clone());
+    assert_eq!(dark_fg.as_deref(), Some("#333332"));
+}
+
+// ── inline unified brand ────────────────────────────────────────────
+
+#[test]
+fn inline_unified_brand_synthesizes_dark_variant() {
+    let mut pair = yaml_rust2::yaml::Hash::new();
+    pair.insert(Yaml::String("light".into()), Yaml::String("#b22221".into()));
+    pair.insert(Yaml::String("dark".into()), Yaml::String("#22b221".into()));
+    let mut color_map = yaml_rust2::yaml::Hash::new();
+    color_map.insert(Yaml::String("background".into()), Yaml::Hash(pair));
+    let mut brand_map = yaml_rust2::yaml::Hash::new();
+    brand_map.insert(Yaml::String("color".into()), Yaml::Hash(color_map));
+    let brand_value = ConfigValue {
+        value: ConfigValueKind::scalar(Yaml::Hash(brand_map)),
+        source_info: SourceInfo::for_test(),
+        merge_op: MergeOp::Concat,
+    };
+
+    let config = flattened_config(vec![
+        ("theme", scalar_string("cosmo")),
+        ("brand", brand_value),
+    ]);
+    let rv = resolve(&config, Path::new("."));
+    assert!(rv.config.dark.is_some());
+    assert_eq!(background_of(&rv.light_brand).as_deref(), Some("#b22221"));
+    assert_eq!(background_of(&rv.dark_brand).as_deref(), Some("#22b221"));
+}
+
+// ── highlight-style flows to the synthesized dark variant ───────────
+
+#[test]
+fn scalar_adaptive_highlight_reaches_synthesized_dark_variant() {
+    let dir = tempfile::tempdir().unwrap();
+    write_brand(dir.path(), "_brand.yml", UNIFIED_BRAND_YAML);
+    let config = flattened_config(vec![
+        ("theme", scalar_string("cosmo")),
+        ("brand", scalar_string("_brand.yml")),
+        ("highlight-style", scalar_string("a11y")),
+    ]);
+    let rv = resolve(&config, dir.path());
+    assert_eq!(
+        rv.config.highlight_style.as_ref().map(|h| h.name.as_str()),
+        Some("a11y-light")
+    );
+    assert_eq!(
+        rv.config
+            .dark
+            .as_ref()
+            .and_then(|d| d.highlight_style.as_ref())
+            .map(|h| h.name.as_str()),
+        Some("a11y-dark"),
+        "the synthesized dark variant must get the dark-resolved adaptive palette"
+    );
+}
+
+#[test]
+fn pair_highlight_style_dark_value_reaches_synthesized_dark_variant() {
+    let dir = tempfile::tempdir().unwrap();
+    write_brand(dir.path(), "_brand.yml", UNIFIED_BRAND_YAML);
+    // `dracula` is deliberately NON-adaptive: the pair's dark value
+    // must arrive verbatim (an adaptive name like `github` would be
+    // resolved to `github-dark`, same as in the declared-pair path).
+    let highlight = map_config(vec![
+        ("light", scalar_string("a11y")),
+        ("dark", scalar_string("dracula")),
+    ]);
+    let config = flattened_config(vec![
+        ("theme", scalar_string("cosmo")),
+        ("brand", scalar_string("_brand.yml")),
+        ("highlight-style", highlight),
+    ]);
+    let rv = resolve(&config, dir.path());
+    assert_eq!(
+        rv.config
+            .dark
+            .as_ref()
+            .and_then(|d| d.highlight_style.as_ref())
+            .map(|h| h.name.as_str()),
+        Some("dracula"),
+        "the pair's dark: highlight value must not be dropped when the dark \
+         variant is synthesized from brand content"
+    );
+}

--- a/crates/quarto-sass/tests/integration/main.rs
+++ b/crates/quarto-sass/tests/integration/main.rs
@@ -4,6 +4,7 @@
 pub mod brand_compile_test;
 pub mod brand_config_test;
 pub mod brand_layer_test;
+pub mod brand_light_dark_test;
 pub mod compile_all_themes_test;
 pub mod custom_theme_test;
 pub mod embedded_compile_test;

--- a/crates/quarto/src/commands/use_cmd/source.rs
+++ b/crates/quarto/src/commands/use_cmd/source.rs
@@ -98,7 +98,11 @@ pub fn read_source_brand(source: &Path, target_label: &str) -> Result<SourceBran
     // Parse before planning anything. `quarto-brand` uses
     // `deny_unknown_fields`, so a typo'd key is caught here rather than
     // becoming a render-time surprise in the user's project.
-    let brand = Brand::from_yaml_str(&text).map_err(|e| {
+    // Parse as the unified form ({light:, dark:} color values allowed
+    // — the file is copied verbatim, so unified content stays intact);
+    // asset collection reads fonts and logos, which the split carries
+    // identically in both halves, so the light half suffices.
+    let brand = quarto_brand::UnifiedBrand::from_yaml_str(&text).map_err(|e| {
         CommandFailure::new(
             format!("{target_label} does not contain a valid brand"),
             format!(
@@ -108,6 +112,7 @@ pub fn read_source_brand(source: &Path, target_label: &str) -> Result<SourceBran
         )
     })?;
 
+    let brand = brand.split().light;
     let brand_dir = brand_file.parent().unwrap_or(source);
     let assets = collect_assets(&brand, brand_dir);
 


### PR DESCRIPTION
Implements per-color `{light:, dark:}` values in a single `_brand.yml` (or inline `brand:` block), closing the gap reported in #580: the docs documented this shape but the type model rejected it. Port of Q1's `splitUnifiedBrand` / `brandHasDarkMode`.

Fixes #580. Tracker: bd-unified-brand-split-ep49amad (supersedes bd-v5z8w). Plan: `claude-notes/plans/2026-08-24-unified-brand-light-dark.md`.

## What

```yaml
color:
  background:
    light: "#b22222"
    dark: "#22b222"
```

now renders: the light value lands in `styles.css`, the dark value in `styles-dark.css`, and a brand whose content carries any `dark:` side enables dark mode (dual compile, attributed links, color-mode script, navbar toggle) — matching what the two-file `brand: {light:, dark:}` form already did. Typography `color` / `background-color` pairs work too; `palette` entries deliberately stay plain strings (documented limitation, Q1 parity).

## How

- **quarto-brand**: `Brand<V = String>` generic (Q1's BrandUnified/BrandSingle distinction). `UnifiedBrand = Brand<BrandColorValue>` is the only parse form; `UnifiedBrand::split()` produces the single-mode halves, so the type system guarantees downstream consumers never see an unsplit pair. New `split.rs` with `SplitBrand` / `has_dark_mode`. Deliberate divergence from Q1's `splitLogo`: logo entries are carried through unsplit — q2's favicon/navbar consumers run once per document and need both sides (`LogoEntry::LightDark` models that); logo dark sides still enable dark mode.
- **quarto-sass**: `ThemeConfig::resolve()` / `ResolvedThemeConfig` replaced by `resolve_variants()` / `ResolvedVariants` — the brand file is read **once**, split, each variant handed its half; content-driven dark synthesis happens here. New `deferred_dark_highlight` slot so `highlight-style: a11y` (or a pair's `dark:` value) still reaches a dark variant synthesized after config parsing. The two-file form now takes the matching half of each file (a pair inside a mode-specific file works; Q1 rejects — noted for the docs audit bd-qnylgu69).
- **quarto-core**: `CompileThemeCssStage` records the pair decision as `rendered.theme.dark-is-default` in doc metadata; the template's color-mode block and the navbar-toggle transform read that key first (their pure config re-derivation cannot see content-driven dark variants) and keep the re-derivation as a fallback for stage-less pipelines.

## Behavior change

A brand whose **only** dark signal is a logo `{light:, dark:}` pair previously produced a single variant; it now enables dark mode (Q1 parity, needed by the navbar logo work bd-hp3tx).

## Testing

- TDD: 35 new tests written and verified failing first — 20 quarto-brand (parse/split/has_dark_mode), 11 quarto-sass (`resolve_variants`, synthesis, highlight flow), 4 e2e renders including the exact #580 repro and the navbar-toggle case.
- Full workspace suite green (13,165 tests). `cargo xtask verify` green through the WASM/hub-client legs; the only failure is the known pre-existing katex issue bd-s36g9dav (reproduced on a clean baseline).
- Real-binary e2e: `q2 render` on the #580 fixture → `--bs-body-bg: #b22222` in `styles.css`, `#22b222` in `styles-dark.css`, attributed link pair + `quarto-color-scheme-extra` + color-mode script in the HTML. The docs section's own example (`typography.headings.color` pair) verified as well.

The secondary report in #580 (missing `Q-14-1` code / snippet on brand parse errors) is tracked separately as bd-i2nfb8f0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)