### PR TITLE
Add `q2 docs llms`: embed the docs-site llms.txt mirror in the binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,13 +125,19 @@ jobs:
 
   # Target-independent embedded payloads, built once: the WASM module
   # (wasm32, same bytes for every release target), the preview SPA that
-  # consumes it, and the trace viewer. Toolchain steps mirror
-  # hub-client-e2e.yml (the canonical WASM CI setup).
+  # consumes it, the trace viewer, and the `q2 docs llms` docs embed.
+  # Toolchain steps mirror hub-client-e2e.yml (the canonical WASM CI
+  # setup).
+  #
+  # The docs embed step compiles a host `q2` (to render `docs/`) on top
+  # of everything else, hence the wider timeout than the SPA builds
+  # alone needed — a cold rust-cache pays for the full q2 dependency
+  # tree here.
   web-payloads:
-    name: Build web payloads (SPA + trace viewer)
+    name: Build web payloads (SPA + trace viewer + docs embed)
     needs: preflight
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 75
     steps:
       - uses: actions/checkout@v6
         with:
@@ -190,12 +196,22 @@ jobs:
         run: npm run build
         working-directory: q2-preview-spa
 
+      # Docs embed for `q2 docs llms` (bd-hwop1zii). Target-independent
+      # like the SPA dists, so it is staged once here rather than on
+      # every build leg — where cross-compiled targets could not run the
+      # `q2` that renders the docs anyway. `build-agents-docs` builds a
+      # host `q2` itself (via `cargo run --bin q2`); a debug binary is
+      # fine, it only has to render.
+      - name: Stage docs embed (q2 docs llms)
+        run: cargo xtask build-agents-docs
+
       - uses: actions/upload-artifact@v7
         with:
           name: web-payloads
           path: |
             trace-viewer/dist
             q2-preview-spa/dist
+            agents-docs-dist
           retention-days: 7
           if-no-files-found: error
 
@@ -527,6 +543,33 @@ jobs:
               FAIL=1
             fi
           done
+
+          # Docs embed for `q2 docs llms` (bd-hwop1zii). A release binary
+          # must carry real docs, built from this tag's source — a
+          # placeholder ships a command that only knows how to say it is
+          # missing, and a foreign commit means the docs describe a
+          # different Quarto than the binary implements.
+          DOCS=$("$BIN" docs llms --embed-info)
+          printf '%s\n' "$DOCS"
+          if ! printf '%s' "$DOCS" | grep -q '^source: real$'; then
+            echo "::error::release binary embeds placeholder docs for \`q2 docs llms\`"
+            FAIL=1
+          fi
+          DOCS_COMMIT_LINE=$(printf '%s' "$DOCS" | grep '^commit: ' || true)
+          DOCS_SHA=${DOCS_COMMIT_LINE#commit: }
+          DOCS_SHA=${DOCS_SHA% (dirty)}
+          EXPECTED_SHA=$(git rev-parse HEAD)
+          if [ "$DOCS_SHA" != "$EXPECTED_SHA" ]; then
+            echo "::error::embedded docs were staged from $DOCS_SHA, expected this tag's $EXPECTED_SHA"
+            FAIL=1
+          fi
+          # Dirtiness is a diagnostic, not a correctness failure: the
+          # docs still came from this commit. Surface it rather than
+          # blocking the release, since it means something modified
+          # tracked files inside the web-payloads job.
+          case "$DOCS_COMMIT_LINE" in
+            *"(dirty)") echo "::warning::embedded docs were staged from a dirty tree at $EXPECTED_SHA" ;;
+          esac
           exit $FAIL
 
       # Live-share local asset serving (plan Phase 2, bd-ee2fqm95): a

--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,7 @@ resources/extension-build/deno.lock
 
 # Posit Assistant per-machine settings
 .posit/assistant/settings.json
+
+# `q2 docs llms` staged embed (cargo xtask build-agents-docs) — generated
+# from docs/_site; never commit it (bd-hwop1zii).
+agents-docs-dist/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -516,6 +516,34 @@ with a cargo warning); `q2 mcp` then fails at runtime pointing at the
 xtask. Design: `claude-notes/plans/2026-06-11-q2-mcp-hub-auth.md`
 (bd-81cfshmw).
 
+## Refreshing the embedded docs for `q2 docs llms`
+
+The same trap once more, with one twist. `q2 docs llms` (aliased as `q2
+agents-info`) serves the docs site's llms.txt mirror — the index, the
+per-page `.md` companions, and `llms-full.txt` — embedded from
+`agents-docs-dist/` via `include_dir!`. After changing anything under
+`docs/`, the embed is stale until you run:
+
+```bash
+cargo xtask build-agents-docs        # render docs/, stage agents-docs-dist/
+cargo build --bin q2                 # re-embed via include_dir!
+```
+
+The twist: staging *renders the docs with `q2` itself*, so unlike every
+other embed artifact this step runs **after** a Rust build, not before.
+`cargo xtask build-all` reflects that — its docs step comes last and
+ends with its own `cargo build --bin q2` (skip it with
+`--skip-agents-docs`).
+
+Diagnose staleness with `q2 docs llms --embed-info`, which prints the
+source commit, a `(dirty)` marker, and the page count. Fresh clones
+build fine without the staged tree (a placeholder is embedded, with a
+cargo warning); `q2 docs llms` then fails at runtime pointing at the
+xtask. `agents-docs-dist/` is generated and gitignored — never commit
+it. The release workflow stages it once in `web-payloads` and fails any
+leg whose binary reports a placeholder or a foreign commit. Design:
+`claude-notes/plans/2026-08-24-agents-info-command.md` (bd-hwop1zii).
+
 ## Build Commands
 
 - WASM build: `npm run build:all` (NOT `cargo build --target wasm32-unknown-unknown`)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4811,6 +4811,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "clap",
+ "include_dir",
  "inquire",
  "open",
  "openssl-sys",

--- a/claude-notes/instructions/release-runbook.md
+++ b/claude-notes/instructions/release-runbook.md
@@ -16,8 +16,9 @@ A GitHub Release at tag `vX.Y.Z` with, for five platforms
 `windows_amd64`):
 
 - `q2-<version>-<platform>.tar.gz` (`.zip` on Windows) — just the `q2`
-  binary; the hub MCP server, preview SPA, and trace viewer are all
-  embedded in it via `include_dir!`.
+  binary; the hub MCP server, preview SPA, trace viewer, and the docs
+  site's llms.txt mirror (`q2 docs llms`) are all embedded in it via
+  `include_dir!`.
 - `q2-<version>-<platform>.tar.gz.sha256` — checksum.
 - `q2-<version>-<platform>.tar.gz.minisig` — Ed25519 signature
   (Unix only; the Windows `.zip` is checksum-only, matching `install.ps1`).
@@ -148,14 +149,26 @@ gh run watch <run-id> --repo quarto-dev/q2     # or watch in the Actions UI
 ```
 
 Job graph: `preflight` → `web-payloads` (WASM → preview SPA + trace
-viewer, built once) → `build` matrix (5 platforms, each builds the
-per-target MCP bundle then the binary, then a **verify gate**) →
-`release` (combines checksums, signs every `.tar.gz`, publishes).
+viewer + the `q2 docs llms` docs embed, built once) → `build` matrix
+(5 platforms, each builds the per-target MCP bundle then the binary,
+then a **verify gate**) → `release` (combines checksums, signs every
+`.tar.gz`, publishes).
 
 The per-target verify gate is the anti-stale-embed guard: it fails the
 leg unless `q2 mcp --launcher-info` reports a real (non-placeholder)
-bundle, all three hub defaults as `bundled`, and a keyring addon for
-each platform in that leg's `KEYRING_PLATFORMS`.
+bundle, all three hub defaults as `bundled`, a keyring addon for each
+platform in that leg's `KEYRING_PLATFORMS`, and `q2 docs llms
+--embed-info` reports `source: real` at exactly this tag's commit. A
+`(dirty)` marker on that commit is a **warning**, not a failure — the
+docs still came from this commit, but something modified tracked files
+during the `web-payloads` job and is worth a look.
+
+The docs embed is staged in `web-payloads` (`cargo xtask
+build-agents-docs`), not per-leg: it is target-independent, and a
+cross-compiled leg could not run the `q2` that renders the docs
+anyway. Its `commit:` is captured *before* the render, so it records
+the sources the docs were built from rather than the render's own
+byproducts.
 
 ### 5. If a leg fails: fix, merge, re-tag
 

--- a/claude-notes/plans/2026-08-24-agents-info-command.md
+++ b/claude-notes/plans/2026-08-24-agents-info-command.md
@@ -2,9 +2,10 @@
 
 **Strand:** bd-hwop1zii
 **Date:** 2026-08-24
-**Status:** Phases 1–3 complete; Phase 4 complete except the final verify
-run and strand closure. Implemented on branch
-`braid/bd-hwop1zii-docs-llms-embed`.
+**Status:** All four phases complete and committed (`1fbc2b93` on
+`braid/bd-hwop1zii-docs-llms-embed`). Full workspace suite and
+`cargo xtask verify --skip-hub-build` green; end-to-end transcript
+recorded below. Awaiting user review — not pushed, strand still open.
 
 ## Overview
 
@@ -278,11 +279,15 @@ of it — the "noise next to the WASM" premise holds.
       no HashMap/serialization concerns, `cargo fmt --check` clean, clippy
       clean (two warnings of mine fixed: `write_with_newline`,
       `map_unwrap_or`), `cargo xtask lint` clean, no TODOs, no secrets
-- [ ] End-to-end verification (protocol below), transcript recorded here
-- [ ] `cargo xtask verify --skip-hub-build` minimum; full `cargo xtask
-      verify` if anything under quarto-core moved (not currently expected)
-- [ ] Close bd-hwop1zii; file follow-up strands (`docs serve`/`open`, MCP
-      tools, `--json`) as discovered-from
+- [x] End-to-end verification (protocol below), transcript recorded here
+- [x] `cargo xtask verify --skip-hub-build` — all 14 steps passed. Nothing
+      under `quarto-core` moved, so the WASM leg is unaffected; the changed
+      crates are `quarto` (bin) and `xtask` only.
+- [x] File follow-up strands as `discovered-from` (bd-x248xpyh,
+      bd-b6cocsxw, bd-dn81ol95)
+- [x] Committed as `1fbc2b93` on `braid/bd-hwop1zii-docs-llms-embed`
+      (19 files, no snapshot files added or modified)
+- [ ] Close bd-hwop1zii (after user review / merge)
 
 ## End-to-end verification protocol (Phase 4 gate)
 

--- a/claude-notes/plans/2026-08-24-agents-info-command.md
+++ b/claude-notes/plans/2026-08-24-agents-info-command.md
@@ -1,0 +1,376 @@
+# `q2 docs llms`: embed the docs-site llms.txt artifacts in the binary
+
+**Strand:** bd-hwop1zii
+**Date:** 2026-08-24
+**Status:** Phases 1–3 complete; Phase 4 complete except the final verify
+run and strand closure. Implemented on branch
+`braid/bd-hwop1zii-docs-llms-embed`.
+
+## Overview
+
+Embed the llms.txt artifact set that `q2 render docs/` already produces into
+the `q2` binary at build time, and expose it through a new `q2 docs llms`
+subcommand (with `q2 agents-info` as a visible top-level alias) so LLM agents
+can consume q2's documentation offline, straight from the binary they are
+already driving.
+
+`docs` is a namespace, not a command: bare `q2 docs` prints subcommand help,
+so humans are never handed the agent-facing markdown dump thinking it is "the
+docs". The namespace deliberately reserves room for a future human-facing
+embedded-docs mechanism (`q2 docs serve` / `q2 docs open` — q2 already embeds
+a SPA and ships an HTTP server in `quarto-preview`, so serving an embedded
+rendered `_site` for offline human reading is a natural later extension).
+
+The generation side shipped in v0.26.0 (bd-llms-txt-unimplemented-oih6z6j7,
+commits `2c144619` + `b7bfeef8`; closed 2026-08-24): rendering `docs/` writes
+
+- `_site/llms.txt` — sidebar-organized markdown index (titles + descriptions),
+- one `.md` companion per page (254 pages, ~1.1 MB at time of writing),
+- `_site/llms-full.txt` — reading-order concatenation (~544 KB).
+
+This feature is therefore **staging + embedding + CLI plumbing** — no new
+document processing. ~1.7 MB of raw text is noise next to the ~40 MB embedded
+preview-SPA WASM.
+
+**Prior art.** `braid agents-info` (naming precedent); the llms.txt convention
+(Answer.AI spec; Mintlify auto-hosts `/llms.txt` + `/llms-full.txt`); offline
+toolchain docs (`rustup doc`, `go doc`). No known SSG embeds its own rendered
+docs in its binary for agent consumption — this is a novel affordance.
+
+**Related strands:** bd-3n4fpr3g (expose companion href via
+shortcode/metadata), bd-3ar95048 (section-heading flattening), bd-to3vh0od
+(code-annotation text in companions), bd-hzsi (LLM skill for listing
+migration).
+
+## Design
+
+### CLI surface
+
+New `Commands::Docs` namespace in `crates/quarto/src/main.rs` with an `Llms`
+subcommand, implemented in `crates/quarto/src/commands/docs_llms.rs`. A
+visible top-level `Commands::AgentsInfo` alias forwards to `docs llms` with
+identical arguments; its help line reads "alias for `q2 docs llms`" (kept for
+guessability — an agent that knows `braid agents-info` will try it — but
+`docs llms` is canonical, and braid itself may adopt the `docs llms` shape
+later).
+
+| Invocation | Output |
+|---|---|
+| `q2 docs` | subcommand help (never document content) |
+| `q2 docs llms` | embedded `llms.txt` verbatim, preceded by a short preamble telling the agent each href is retrievable via `q2 docs llms <href>` |
+| `q2 docs llms --list` | one line per page: `href<TAB>title` (titles from the companion's leading `#` heading) |
+| `q2 docs llms <href>` | that page's `.md` companion |
+| `q2 docs llms --full` | embedded `llms-full.txt` verbatim |
+| `q2 docs llms --embed-info` | provenance: docs snapshot git commit + dirty flag, page count, placeholder-or-real (mirrors `q2 mcp --launcher-info`) |
+| `q2 agents-info ...` | alias: exactly `q2 docs llms ...` |
+
+`--full`, `--list`, `--embed-info`, and `<href>` are mutually exclusive
+(clap `conflicts_with` group). `--embed-info` stays under `llms` for now;
+promote it to `q2 docs embed-info` only when a second embed consumer (e.g.
+`docs serve`) appears.
+
+Href normalization for `<href>`: exact match on the `.md` href as printed in
+`llms.txt` wins; otherwise normalize `.qmd`/`.html` extensions and
+extensionless paths to `.md`, and accept a leading `./` or `/`. Miss → error
+listing near-matches (or pointing at `--list`), nonzero exit.
+
+### Staging: `cargo xtask build-agents-docs`
+
+New xtask (module `crates/xtask/src/build_agents_docs.rs`):
+
+1. Record provenance from git **before** rendering (see Phase 2's note on
+   why), then `cargo run --bin q2 -- render docs` — an in-place render, as
+   shipped; the scratch-output-dir idea in the original draft was dropped
+   because the ledger is keyed to the real output dir.
+2. Copy the ledger-listed artifacts (preserving the directory tree) into
+   **`agents-docs-dist/`** at the repo root (gitignored, sibling convention
+   to `q2-preview-spa/dist/`), clearing any stale tree first.
+3. Write `agents-docs-dist/embed-info.json`: `{ "commit": "<git rev-parse
+   HEAD>", "dirty": <bool> }`. No timestamp — keeps builds reproducible;
+   commit + dirty is what staleness diagnosis needs. The page count is
+   derived at runtime by walking the embed, so it cannot disagree with what
+   was actually embedded.
+
+Note: `_site/*.md` includes only llms companions plus any user-authored
+resource `.md` files; the Q-5-28 ledger (`llms_post_render.rs` manifest)
+records which files llms-txt generated. Staging copies the *generated* set —
+reading the ledger rather than globbing, so a stray resource `.md` cannot
+leak into the embed. (Confirmed usable in Phase 2; no fallback needed.)
+
+### Embedding: `build.rs` on the `quarto` bin crate
+
+Follows `crates/quarto-trace-server/build.rs` (env-var indirection for
+`include_dir!`):
+
+- If `agents-docs-dist/llms.txt` exists → embed `agents-docs-dist/`.
+- Otherwise → embed a generated placeholder dir (an `embed-info.json` with
+  `"placeholder": true`) and emit a cargo warning naming
+  `cargo xtask build-agents-docs`. Fresh clones stay buildable.
+- `rerun-if-changed` per file (the preview build.rs `watch_recursive`
+  pattern), so re-staging triggers re-embed.
+- Plain `include_dir!`, **no tar.zst** — 1.7 MB of text doesn't justify the
+  archive layer (bd-rem4bpee machinery exists if that ever changes).
+
+On a placeholder build, `q2 docs llms` (all modes except `--embed-info`,
+which reports the placeholder state) exits nonzero with instructions to run
+the xtask and rebuild.
+
+### The staleness trap (same as preview SPA / MCP bundle)
+
+A plain `cargo build --bin q2` embeds whatever `agents-docs-dist/` was last
+staged. Fresh docs require the chain:
+
+```bash
+cargo xtask build-agents-docs   # render docs/, stage artifacts
+cargo build --bin q2            # re-embed via include_dir!
+```
+
+Mitigations, all in scope:
+
+- CLAUDE.md section alongside "Verifying Rust changes in `q2 preview`".
+- `cargo xtask build-all` gains the staging step. Unlike the MCP bundle and
+  the SPAs it runs **last**, after the Rust build — staging renders the docs
+  with `q2` itself — and ends with its own `cargo build --bin q2`.
+- Release runbook + Release workflow: stage once in `web-payloads` (the
+  docs embed is target-independent, and a cross-compiled leg could not run
+  the `q2` that renders it), ship it in that job's artifact, and **assert
+  the embed is real** in each leg's verify gate (`q2 docs llms
+  --embed-info` must report `source: real` at exactly the tag's commit).
+  A `(dirty)` marker warns rather than fails: the docs still came from
+  that commit, so blocking a release over it would trade a real shipment
+  for a cosmetic signal.
+- `--embed-info` is the runtime diagnostic.
+
+### Decisions (settled in plan review, 2026-08-24)
+
+1. **Placeholder-tolerant dev builds; hard check only in the Release
+   workflow.**
+2. **Permissive href normalization** (exact `.md` match first).
+3. **Canonical name `q2 docs llms`**, inside a `q2 docs` namespace reserved
+   for embedded-docs mechanisms generally; **`q2 agents-info` kept as a
+   visible top-level alias**. Bare `q2 docs` prints help so humans aren't
+   misled into thinking the llms dump is the embedded human docs. (User
+   confirmed; braid parity is non-binding — braid is internal and may itself
+   move to this shape.)
+4. **Topic branch in the current checkout** (no worktree — single agent in
+   the repo, and it keeps cargo cleanup simpler; user decision 2026-08-24):
+   `braid/bd-hwop1zii-docs-llms-embed` off `main`.
+
+Deliberately out of scope — filed 2026-08-24 as `discovered-from`
+bd-hwop1zii:
+
+- **bd-x248xpyh** — human-facing offline docs: `q2 docs serve` / `q2 docs
+  open` (the reason `docs` is a namespace rather than a command).
+- **bd-b6cocsxw** — `--json` output for `--list` / `--embed-info`.
+- **bd-dn81ol95** — expose the embedded docs as `q2 mcp` tools
+  (search/fetch).
+- Any change to llms.txt generation itself (not filed; belongs to the
+  existing llms strands).
+
+## Phases and work items
+
+### Phase 1 — Tests + lookup module (TDD first)
+
+Pure logic, no embed yet: `docs_llms` module in the `quarto` crate whose
+functions take an `include_dir::Dir` (so tests inject a synthetic dir).
+
+- [x] Unit tests: href normalization table (`.md` exact, `.qmd`, `.html`,
+      extensionless, `./`- and `/`-prefixed, backslashes, trailing `/`,
+      dir→`index.md`, misses with suggestions)
+- [x] Unit tests: `--list` extraction (href + `#`-heading title; page with no
+      heading falls back to the stem)
+- [x] Unit tests: placeholder detection (missing `llms.txt` or
+      `embed-info.json` `placeholder:true`); error text names the xtask and
+      the rebuild step
+- [x] Unit tests: `--embed-info` rendering (real/dirty/missing-sidecar/
+      placeholder)
+- [x] Run tests, verify the not-yet-implemented ones fail as expected
+      (15/15 failed on `todo!()` stubs)
+- [x] Implement the module until green (15/15 pass;
+      `crates/quarto/src/commands/docs_llms.rs`, synthetic `Dir::new`
+      fixtures — no filesystem fixtures needed)
+
+Note: Phase 1 leaves dead-code warnings until the CLI consumes the module,
+and `cargo xtask verify` is `-D warnings`; Phase 3's CLI wiring therefore
+lands in the same commit as Phase 1 rather than adding a throwaway
+`#[allow(dead_code)]`. Execution order is 1 → 3 → 2 (build.rs embeds the
+placeholder fine before the xtask exists; the integration test accepts
+either state).
+
+### Phase 2 — `cargo xtask build-agents-docs`
+
+- [x] Implement staging (`crates/xtask/src/build_agents_docs.rs`: render
+      `docs/` in place via nested `cargo run --bin q2 -- render docs`, copy
+      the ledger-listed set, write `embed-info.json`) + 3 unit tests for
+      `stage_files` (unlisted `_site` files skipped, stale dist cleared,
+      missing-listed-file and ledger-without-`llms.txt` errors)
+- [x] Wire into `crates/xtask/src/main.rs` (`BuildAgentsDocs`)
+- [x] Run it; inspect `agents-docs-dist/` — see the run record below
+- [x] Add `agents-docs-dist/` to `.gitignore` (verified with
+      `git check-ignore`)
+
+**Staging decision, resolved:** the ledger *is* usable — the render writes
+`docs/.quarto/llms-manifest.json` (`{version, generated: [...]}`, 256
+output-dir-relative forward-slash paths including `llms.txt` and
+`llms-full.txt`), so the xtask copies exactly the generated set and never
+globs. It also refuses a ledger that doesn't list `llms.txt`. No fallback or
+caveat needed.
+
+**Render-in-place, not a scratch dir:** the plan sketched rendering to a
+scratch output dir to avoid disturbing `docs/_site`, but the ledger lives at
+`docs/.quarto/llms-manifest.json` and is keyed to the real output dir; a
+scratch render would desynchronize the two. Rendering in place is also
+exactly what CI does, so the staged bytes are the shipped bytes.
+
+**First run (2026-08-24):** `Rendered 254 of 254 files` → `agents-docs-dist/
+staged: 257 artifacts` (255 `.md` companions + `llms.txt` + `llms-full.txt`),
+1.7 MB, `embed-info {"commit":"e3b3d7d4…","dirty":true}`.
+
+### Phase 3 — build.rs + CLI wiring
+
+- [x] `build.rs` on the `quarto` crate: real-or-placeholder embed dir,
+      `QUARTO_DOCS_LLMS_EMBED_DIR` indirection, per-file rerun-if-changed,
+      cargo warning on placeholder (observed firing on the pre-staging build)
+- [x] Clap `docs` namespace + `llms` subcommand + top-level `agents-info`
+      alias; `commands/docs_llms.rs` dispatch to the Phase 1 module
+- [x] CLI parse unit tests: alias ≡ canonical across all five tails; bare
+      `q2 docs` yields `DisplayHelpOnMissingArgumentOrSubcommand`; seven
+      conflicting-mode combinations are `ArgumentConflict`
+- [x] Integration test `crates/quarto/tests/integration/docs_llms_cli.rs`
+      (registered, alphabetized) driving the real binary; every test passes
+      in BOTH embed states — verified by running the suite before staging
+      (placeholder, 8/8) and after (real, 8/8)
+- [x] `cargo nextest run --workspace` — 13028 tests, all passing (1 leaky,
+      pre-existing)
+
+**Bug found and fixed during Phase 3 verification (TDD):** piping the output
+(`q2 docs llms --full | head`) panicked with "failed printing to stdout:
+Broken pipe" — Rust ignores SIGPIPE, so an unguarded `print!` aborts when the
+reader goes away. For a command whose entire purpose is being piped into
+agents, `head`, and `grep`, that is a real defect. Regression test
+`closed_stdout_exits_quietly_without_panicking` written first (reproduced the
+panic), then fixed by routing all output through a `write_stdout` helper that
+treats `ErrorKind::BrokenPipe` as success.
+
+**Binary-size measurement:** debug `q2` is 143 MB; the 1.7 MB embed is ~1.2%
+of it — the "noise next to the WASM" premise holds.
+
+### Phase 4 — Docs, wiring, verification
+
+- [x] Docs page `docs/guides/embedded-docs.qmd` + `_quarto.yml` sidebar entry
+      (placed in the flat Guides section right after `projects/llms-txt.qmd`,
+      the feature it mirrors) — user-facing usage, not internals. Verified by
+      rendering: 255 of 255 files, page appears in `llms.txt` with its
+      description, and gets its own `.md` companion. Re-staged so the
+      embedded corpus includes it (256 pages).
+- [x] CLAUDE.md: staleness-trap section (after the `q2 mcp` one), noting the
+      twist that this embed is staged *after* the Rust build
+- [x] `cargo xtask build-all`: docs step added last (it needs the built
+      `q2`), ending with its own `cargo build --bin q2`;
+      `--skip-agents-docs` opt-out; implied off by `--skip-rust-build`.
+      `cargo xtask verify` has its own config and is unaffected — the docs
+      render does not slow the verify path.
+- [x] Release runbook + Release workflow: staging step in `web-payloads`
+      (target-independent, uploaded with the SPA dists and downloaded by
+      every build leg), plus a verify-gate assertion that the binary reports
+      `source: real` at exactly the tag's commit with no `(dirty)` marker
+- [x] Pre-commit review checklist (`claude-notes/instructions/review.md`):
+      no HashMap/serialization concerns, `cargo fmt --check` clean, clippy
+      clean (two warnings of mine fixed: `write_with_newline`,
+      `map_unwrap_or`), `cargo xtask lint` clean, no TODOs, no secrets
+- [ ] End-to-end verification (protocol below), transcript recorded here
+- [ ] `cargo xtask verify --skip-hub-build` minimum; full `cargo xtask
+      verify` if anything under quarto-core moved (not currently expected)
+- [ ] Close bd-hwop1zii; file follow-up strands (`docs serve`/`open`, MCP
+      tools, `--json`) as discovered-from
+
+## End-to-end verification protocol (Phase 4 gate)
+
+Per CLAUDE.md, tests are necessary but not sufficient. Before declaring done:
+
+```bash
+cargo xtask build-agents-docs
+cargo build --bin q2
+cargo run --bin q2 -- docs                        # subcommand help, no content
+cargo run --bin q2 -- docs llms                   # llms.txt + preamble
+cargo run --bin q2 -- docs llms --list            # 250+ href/title lines
+cargo run --bin q2 -- docs llms guides/projects/llms-txt.md
+cargo run --bin q2 -- docs llms guides/projects/llms-txt.qmd  # normalization
+cargo run --bin q2 -- docs llms --full | wc -c    # ~550 KB
+cargo run --bin q2 -- docs llms --embed-info      # real, correct commit
+cargo run --bin q2 -- docs llms no/such/page      # nonzero + helpful error
+cargo run --bin q2 -- agents-info --list          # alias ≡ docs llms --list
+```
+
+Inspect actual output (not absence of errors) and paste representative
+snippets into this file.
+
+### Observed transcript (2026-08-24, debug `q2`, real embed)
+
+Output inspected, not merely checked for exit status.
+
+```
+$ q2 docs                                 # namespace help, never content
+Documentation embedded in this binary
+Usage: q2 docs [OPTIONS] <COMMAND>
+Commands:
+  llms  Machine-readable documentation (llms.txt) for AI agents
+  help  Print this message or the help of the given subcommand(s)
+
+$ q2 docs llms --embed-info
+source: real
+commit: e3b3d7d4aae422274a7f3ff1c781019c24bfbb07 (dirty)
+pages: 256
+
+$ q2 docs llms | head -12
+<!--
+q2 embedded documentation index (llms.txt).
+Fetch one page:  q2 docs llms <href>   (hrefs listed below)
+List all pages:  q2 docs llms --list
+Whole corpus:    q2 docs llms --full
+-->
+
+# Quarto 2
+
+> Documentation for Quarto 2, the Rust-based rewrite of the Quarto publishing system
+
+## Guides
+
+$ q2 docs llms --list | wc -l
+     256
+$ q2 docs llms --list | grep embedded
+guides/embedded-docs.md	Embedded documentation for AI agents
+
+$ q2 docs llms guides/embedded-docs.md | head -3
+# Embedded documentation for AI agents
+
+## Overview
+
+$ q2 docs llms guides/embedded-docs.qmd | head -1   # .qmd normalization
+# Embedded documentation for AI agents
+
+$ q2 docs llms --full | wc -c
+  560949
+
+$ q2 agents-info --list | head -1                   # alias
+about.md	About
+
+$ q2 docs llms guides/embedded                      # miss
+Error: no embedded documentation page matches `guides/embedded`; did you mean one of:
+  guides/embedded-docs.md
+Use `q2 docs llms --list` to see every page.
+exit=1
+```
+
+The `(dirty)` marker is correct here — this transcript was taken from the
+feature branch with uncommitted work. Release builds assert its absence.
+
+## Progress log
+
+- 2026-08-24: Plan written. bd-llms-txt-unimplemented-oih6z6j7 confirmed
+  shipped (v0.26.0) and closed; its open child bd-to3vh0od re-linked as
+  discovered-from. bd-hwop1zii filed and linked to related strands.
+- 2026-08-24 (plan review): naming settled with user — canonical
+  `q2 docs llms` inside a `q2 docs` namespace (room reserved for future
+  human-facing `docs serve`/`open`), plus visible top-level `agents-info`
+  alias. Plan updated throughout; strand title/description updated.

--- a/crates/quarto/Cargo.toml
+++ b/crates/quarto/Cargo.toml
@@ -60,6 +60,10 @@ quarto-brand.workspace = true
 # `q2 use brand <source>`. Shared with `q2 add` when that lands.
 quarto-source-fetch = { path = "../quarto-source-fetch" }
 quarto-test.workspace = true
+# `q2 docs llms`: the docs-site llms.txt artifacts staged by
+# `cargo xtask build-agents-docs` are embedded via `include_dir!`
+# (bd-hwop1zii; see build.rs).
+include_dir.workspace = true
 serde_yaml.workspace = true
 tempfile = "3"
 # Phase D.1 (bd-kw93.8): auto-open browser tabs on `q2 preview`.

--- a/crates/quarto/build.rs
+++ b/crates/quarto/build.rs
@@ -1,0 +1,87 @@
+//! Build script that locates the embedded-docs tree for `q2 docs llms`
+//! (bd-hwop1zii).
+//!
+//! Mirrors `crates/quarto-trace-server/build.rs`. The `include_dir!`
+//! macro needs a concrete compile-time path; this script resolves it:
+//!
+//! 1. If `agents-docs-dist/llms.txt` exists at the workspace root (the
+//!    tree staged by `cargo xtask build-agents-docs`), embed that
+//!    directory.
+//! 2. Otherwise, write a placeholder directory into `OUT_DIR` — just an
+//!    `embed-info.json` marking the embed as a placeholder — and embed
+//!    that, so fresh clones build without the docs staged. `q2 docs
+//!    llms` then fails at runtime pointing at the xtask.
+//!
+//! The chosen path is exposed as `QUARTO_DOCS_LLMS_EMBED_DIR` via
+//! `cargo:rustc-env`, consumed by `src/commands/docs_llms.rs` through
+//! `include_dir!("$QUARTO_DOCS_LLMS_EMBED_DIR")`.
+
+use std::path::{Path, PathBuf};
+
+fn main() {
+    let manifest_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
+    let workspace_root = manifest_dir.join("..").join("..");
+    let real_dist = workspace_root.join("agents-docs-dist");
+
+    let embed_dir = if real_dist.join("llms.txt").is_file() {
+        real_dist.clone()
+    } else {
+        make_placeholder_dist()
+    };
+
+    println!(
+        "cargo:rustc-env=QUARTO_DOCS_LLMS_EMBED_DIR={}",
+        embed_dir.display()
+    );
+
+    // Re-run if the staged tree changes. A directory-mtime watch misses
+    // in-place file rewrites (re-staging overwrites files at the same
+    // paths), so emit one rerun-if-changed per file; the directory
+    // entry picks up additions and removals.
+    println!("cargo:rerun-if-changed={}", real_dist.display());
+    if real_dist.is_dir() {
+        watch_recursive(&real_dist);
+    }
+}
+
+/// Emit `cargo:rerun-if-changed=<path>` for every file and directory
+/// under `root`.
+fn watch_recursive(root: &Path) {
+    let entries = match std::fs::read_dir(root) {
+        Ok(it) => it,
+        Err(_) => return,
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        println!("cargo:rerun-if-changed={}", path.display());
+        if entry.file_type().is_ok_and(|t| t.is_dir()) {
+            watch_recursive(&path);
+        }
+    }
+}
+
+fn make_placeholder_dist() -> PathBuf {
+    let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
+    let dist = out_dir.join("docs-llms-placeholder");
+    std::fs::create_dir_all(&dist).expect("create docs-llms placeholder dir");
+
+    // The runtime detects a placeholder by the absence of `llms.txt`;
+    // the sidecar makes the state explicit for `--embed-info`.
+    let sidecar = dist.join("embed-info.json");
+    write_if_changed(&sidecar, "{\"placeholder\":true}\n");
+
+    println!(
+        "cargo:warning=agents-docs-dist/llms.txt not found; embedding a \
+         placeholder for `q2 docs llms`. Run `cargo xtask build-agents-docs` \
+         and rebuild to embed the real docs."
+    );
+
+    dist
+}
+
+fn write_if_changed(path: &Path, contents: &str) {
+    let existing = std::fs::read_to_string(path).ok();
+    if existing.as_deref() != Some(contents) {
+        std::fs::write(path, contents).expect("write placeholder embed-info.json");
+    }
+}

--- a/crates/quarto/src/commands/docs_llms.rs
+++ b/crates/quarto/src/commands/docs_llms.rs
@@ -1,0 +1,625 @@
+//! `q2 docs llms` — serve the embedded docs-site llms.txt artifacts
+//! (bd-hwop1zii).
+//!
+//! The `q2 docs` namespace exposes documentation embedded in the binary.
+//! This module implements its `llms` subcommand (aliased as the
+//! top-level `q2 agents-info`): the llms.txt index, per-page markdown
+//! companions, and llms-full.txt that `q2 render docs/` produces are
+//! staged by `cargo xtask build-agents-docs` into `agents-docs-dist/`
+//! and embedded via `include_dir!` (see this crate's `build.rs`).
+//!
+//! All lookup logic operates on an [`include_dir::Dir`] parameter so
+//! tests can drive it with a synthetic tree; only the thin CLI entry
+//! point binds the real embedded directory.
+//!
+//! Embed states:
+//! - **real**: `llms.txt` is present (staged by the xtask).
+//!   `embed-info.json` records provenance (git commit + dirty flag of
+//!   the staging checkout); it may be absent, in which case provenance
+//!   reads as unknown.
+//! - **placeholder**: no `llms.txt` (fresh clone; build.rs embedded a
+//!   stub). Every content mode fails with instructions; `--embed-info`
+//!   reports the state instead of failing.
+
+use include_dir::Dir;
+
+/// The docs tree staged by `cargo xtask build-agents-docs` (or the
+/// placeholder when it hasn't run); see `build.rs` for the resolution.
+static EMBEDDED_DOCS: Dir<'static> = include_dir::include_dir!("$QUARTO_DOCS_LLMS_EMBED_DIR");
+
+/// How to turn a placeholder embed into a real one. Referenced by the
+/// placeholder error and by `--embed-info`.
+const REBUILD_HINT: &str =
+    "run `cargo xtask build-agents-docs`, then rebuild with `cargo build --bin q2`";
+
+/// What `q2 docs llms` (or its `q2 agents-info` alias) was asked for.
+/// Built by `main.rs` from the mutually-exclusive CLI flags.
+pub enum Mode {
+    /// Bare invocation: the llms.txt index.
+    Index,
+    /// `--full`: llms-full.txt.
+    Full,
+    /// `--list`: href + title per page.
+    List,
+    /// `--embed-info`: provenance of the embedded snapshot.
+    EmbedInfo,
+    /// `<href>`: one page.
+    Page(String),
+}
+
+/// CLI entry point: print the requested view of the embedded docs to
+/// stdout. Lookup failures (and placeholder embeds) come back as
+/// errors, so the process exits nonzero with the message on stderr.
+pub fn execute(mode: Mode) -> anyhow::Result<()> {
+    let embed = DocsEmbed::new(&EMBEDDED_DOCS);
+    let out = match mode {
+        Mode::Index => embed.index()?,
+        Mode::Full => embed.full()?.to_string(),
+        Mode::List => embed
+            .list()?
+            .iter()
+            .map(|p| format!("{}\t{}\n", p.href, p.title))
+            .collect(),
+        Mode::EmbedInfo => embed.embed_info_text(),
+        Mode::Page(href) => embed.page(&href)?.to_string(),
+    };
+    write_stdout(&out)
+}
+
+/// Write to stdout, treating a closed reader as success. This output
+/// exists to be piped — `| head`, `| grep`, an agent's reader that
+/// stops early — and Rust ignores SIGPIPE, so an unguarded `print!`
+/// would abort with "failed printing to stdout: Broken pipe" instead
+/// of ending quietly.
+fn write_stdout(text: &str) -> anyhow::Result<()> {
+    use std::io::Write;
+
+    let stdout = std::io::stdout();
+    let mut lock = stdout.lock();
+    match lock.write_all(text.as_bytes()).and_then(|()| lock.flush()) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => Ok(()),
+        Err(e) => Err(e.into()),
+    }
+}
+
+/// Provenance sidecar written by `cargo xtask build-agents-docs`
+/// (real embeds) or by this crate's `build.rs` (placeholder embeds).
+#[derive(Debug, Default, serde::Deserialize)]
+pub struct EmbedInfo {
+    #[serde(default)]
+    pub placeholder: bool,
+    #[serde(default)]
+    pub commit: Option<String>,
+    #[serde(default)]
+    pub dirty: bool,
+}
+
+/// One page in `--list` output: companion href + page title.
+#[derive(Debug, PartialEq, Eq)]
+pub struct PageEntry {
+    pub href: String,
+    pub title: String,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum DocsLlmsError {
+    /// The binary carries the placeholder embed, not real docs.
+    Placeholder,
+    /// A real embed is missing an artifact it must contain
+    /// (`llms-full.txt`); names the missing piece.
+    Corrupt(String),
+    /// `<href>` lookup miss, with up to five suggested hrefs.
+    PageNotFound {
+        query: String,
+        suggestions: Vec<String>,
+    },
+}
+
+impl std::fmt::Display for DocsLlmsError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DocsLlmsError::Placeholder => write!(
+                f,
+                "this q2 binary was built without the embedded documentation \
+                 (placeholder embed); {REBUILD_HINT}"
+            ),
+            DocsLlmsError::Corrupt(what) => write!(
+                f,
+                "the embedded documentation is missing `{what}`; the embed is \
+                 corrupt — {REBUILD_HINT}"
+            ),
+            DocsLlmsError::PageNotFound { query, suggestions } => {
+                write!(f, "no embedded documentation page matches `{query}`")?;
+                if !suggestions.is_empty() {
+                    write!(f, "; did you mean one of:")?;
+                    for s in suggestions {
+                        write!(f, "\n  {s}")?;
+                    }
+                    writeln!(f)?;
+                } else {
+                    write!(f, ". ")?;
+                }
+                write!(f, "Use `q2 docs llms --list` to see every page.")
+            }
+        }
+    }
+}
+
+impl std::error::Error for DocsLlmsError {}
+
+/// The embedded docs tree plus the lookup/rendering logic over it.
+pub struct DocsEmbed<'a> {
+    dir: &'a Dir<'a>,
+}
+
+impl<'a> DocsEmbed<'a> {
+    pub fn new(dir: &'a Dir<'a>) -> Self {
+        DocsEmbed { dir }
+    }
+
+    /// Placeholder embeds have no `llms.txt` (build.rs only stages the
+    /// real tree when the xtask has produced one).
+    pub fn is_placeholder(&self) -> bool {
+        self.dir.get_file("llms.txt").is_none() || self.embed_info().placeholder
+    }
+
+    fn require_real(&self) -> Result<(), DocsLlmsError> {
+        if self.is_placeholder() {
+            Err(DocsLlmsError::Placeholder)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn text_file(&self, name: &str) -> Result<&'a str, DocsLlmsError> {
+        self.dir
+            .get_file(name)
+            .and_then(|f| f.contents_utf8())
+            .ok_or_else(|| DocsLlmsError::Corrupt(name.to_string()))
+    }
+
+    /// Bare `q2 docs llms`: retrieval preamble + `llms.txt` verbatim.
+    pub fn index(&self) -> Result<String, DocsLlmsError> {
+        self.require_real()?;
+        let llms_txt = self.text_file("llms.txt")?;
+        Ok(format!(
+            "<!--\n\
+             q2 embedded documentation index (llms.txt).\n\
+             Fetch one page:  q2 docs llms <href>   (hrefs listed below)\n\
+             List all pages:  q2 docs llms --list\n\
+             Whole corpus:    q2 docs llms --full\n\
+             -->\n\n{llms_txt}"
+        ))
+    }
+
+    /// `--full`: `llms-full.txt` verbatim.
+    pub fn full(&self) -> Result<&'a str, DocsLlmsError> {
+        self.require_real()?;
+        self.text_file("llms-full.txt")
+    }
+
+    /// Every embedded `.md` companion href, sorted, with file contents.
+    fn pages(&self) -> Vec<(String, &'a str)> {
+        fn walk<'a>(dir: &Dir<'a>, out: &mut Vec<(String, &'a str)>) {
+            for entry in dir.entries() {
+                match entry {
+                    include_dir::DirEntry::Dir(d) => walk(d, out),
+                    include_dir::DirEntry::File(f) => {
+                        if f.path().extension().is_some_and(|e| e == "md")
+                            && let (Some(path), Some(contents)) =
+                                (f.path().to_str(), f.contents_utf8())
+                        {
+                            // include_dir records build-machine
+                            // separators; hrefs are always `/`.
+                            out.push((path.replace('\\', "/"), contents));
+                        }
+                    }
+                }
+            }
+        }
+        let mut pages = Vec::new();
+        walk(self.dir, &mut pages);
+        pages.sort_by(|a, b| a.0.cmp(&b.0));
+        pages
+    }
+
+    /// `--list`: every embedded `.md` companion, sorted by href, with
+    /// the page title (first `#` heading, else the file stem).
+    pub fn list(&self) -> Result<Vec<PageEntry>, DocsLlmsError> {
+        self.require_real()?;
+        Ok(self
+            .pages()
+            .into_iter()
+            .map(|(href, contents)| {
+                let title = title_of(contents).unwrap_or_else(|| stem_of(&href).to_string());
+                PageEntry { href, title }
+            })
+            .collect())
+    }
+
+    /// `<href>`: one page's companion. Exact `.md` hrefs (as printed in
+    /// `llms.txt`) win; otherwise the query is normalized — backslashes
+    /// to slashes, a leading `./` or `/` and a trailing `/` stripped,
+    /// `.qmd`/`.html` mapped to `.md`, and an extensionless path tried
+    /// as `<q>.md` then `<q>/index.md`.
+    pub fn page(&self, query: &str) -> Result<&'a str, DocsLlmsError> {
+        self.require_real()?;
+        let q = normalize_query(query);
+        for candidate in candidates(&q) {
+            if let Some(contents) = self
+                .dir
+                .get_file(&candidate)
+                .and_then(|f| f.contents_utf8())
+            {
+                return Ok(contents);
+            }
+        }
+        Err(DocsLlmsError::PageNotFound {
+            query: query.to_string(),
+            suggestions: self.suggestions(&q),
+        })
+    }
+
+    /// Near-miss help for a failed lookup: pages whose stem shares a
+    /// substring with the query's stem; failing that, pages in the
+    /// query's directory. At most five, sorted.
+    fn suggestions(&self, normalized_query: &str) -> Vec<String> {
+        let pages = self.pages();
+        let q_stem = stem_of(normalized_query).to_lowercase();
+        let mut hits: Vec<String> = pages
+            .iter()
+            .filter(|(href, _)| {
+                let stem = stem_of(href).to_lowercase();
+                !q_stem.is_empty() && (stem.contains(&q_stem) || q_stem.contains(&stem))
+            })
+            .map(|(href, _)| href.clone())
+            .collect();
+        if hits.is_empty()
+            && let Some((parent, _)) = normalized_query.rsplit_once('/')
+        {
+            let prefix = format!("{parent}/");
+            hits = pages
+                .iter()
+                .filter(|(href, _)| href.starts_with(&prefix))
+                .map(|(href, _)| href.clone())
+                .collect();
+        }
+        hits.truncate(5);
+        hits
+    }
+
+    /// Parsed `embed-info.json`; defaults when absent or unreadable.
+    pub fn embed_info(&self) -> EmbedInfo {
+        self.dir
+            .get_file("embed-info.json")
+            .and_then(|f| f.contents_utf8())
+            .and_then(|s| serde_json::from_str(s).ok())
+            .unwrap_or_default()
+    }
+
+    /// `--embed-info`: human-readable provenance report. Works on
+    /// placeholder embeds (that is its job).
+    pub fn embed_info_text(&self) -> String {
+        if self.is_placeholder() {
+            return format!(
+                "source: placeholder\n\
+                 This binary carries no embedded documentation; {REBUILD_HINT}.\n"
+            );
+        }
+        let info = self.embed_info();
+        let commit = match (info.commit.as_deref(), info.dirty) {
+            (Some(c), true) => format!("{c} (dirty)"),
+            (Some(c), false) => c.to_string(),
+            (None, _) => "unknown".to_string(),
+        };
+        format!(
+            "source: real\ncommit: {commit}\npages: {}\n",
+            self.pages().len()
+        )
+    }
+}
+
+/// The page title is the first non-blank line iff it is an ATX `#`
+/// heading (which is how the llms companion writer renders titles).
+fn title_of(contents: &str) -> Option<String> {
+    let first = contents.lines().find(|l| !l.trim().is_empty())?;
+    let title = first.strip_prefix("# ")?.trim();
+    (!title.is_empty()).then(|| title.to_string())
+}
+
+/// Final path segment without its extension (`guides/alpha.md` →
+/// `alpha`).
+fn stem_of(href: &str) -> &str {
+    let base = href.rsplit('/').next().unwrap_or(href);
+    base.rsplit_once('.').map_or(base, |(stem, _)| stem)
+}
+
+fn normalize_query(query: &str) -> String {
+    let mut q = query.trim().replace('\\', "/");
+    loop {
+        if let Some(rest) = q.strip_prefix("./") {
+            q = rest.to_string();
+        } else if let Some(rest) = q.strip_prefix('/') {
+            q = rest.to_string();
+        } else if let Some(rest) = q.strip_suffix('/') {
+            q = rest.to_string();
+        } else {
+            break;
+        }
+    }
+    q
+}
+
+/// Lookup candidates for a normalized query, most-specific first.
+fn candidates(q: &str) -> Vec<String> {
+    if q.is_empty() {
+        return Vec::new();
+    }
+    if q.ends_with(".md") {
+        return vec![q.to_string()];
+    }
+    for source_ext in [".qmd", ".html"] {
+        if let Some(base) = q.strip_suffix(source_ext) {
+            return vec![format!("{base}.md")];
+        }
+    }
+    // Extensionless: a page, or a directory standing for its index.
+    vec![format!("{q}.md"), format!("{q}/index.md")]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use include_dir::{Dir, DirEntry, File};
+
+    // A synthetic real embed:
+    //   llms.txt, llms-full.txt, embed-info.json
+    //   index.md, guides/alpha.md, guides/noheading.md, guides/sub/index.md
+    const LLMS_TXT: &str = "# Test Site\n\n> A test corpus\n\n## Guides\n\n\
+                            - [Alpha](guides/alpha.md)\n\
+                            - [Sub](guides/sub/index.md)\n";
+    const LLMS_FULL: &str = "# Test Site — full corpus\n\nAlpha body. Sub body.\n";
+
+    static REAL_ENTRIES: &[DirEntry<'static>] = &[
+        DirEntry::File(File::new(
+            "embed-info.json",
+            b"{\"commit\":\"abc1234\",\"dirty\":false}",
+        )),
+        DirEntry::File(File::new("index.md", b"\n\n# Home\n\nWelcome.\n")),
+        DirEntry::File(File::new("llms-full.txt", LLMS_FULL.as_bytes())),
+        DirEntry::File(File::new("llms.txt", LLMS_TXT.as_bytes())),
+        DirEntry::Dir(Dir::new(
+            "guides",
+            &[
+                DirEntry::File(File::new(
+                    "guides/alpha.md",
+                    b"# Alpha Page\n\nAlpha body.\n",
+                )),
+                DirEntry::File(File::new("guides/noheading.md", b"no heading here\n")),
+                DirEntry::Dir(Dir::new(
+                    "guides/sub",
+                    &[DirEntry::File(File::new(
+                        "guides/sub/index.md",
+                        b"# Sub Index\n\nSub body.\n",
+                    ))],
+                )),
+            ],
+        )),
+    ];
+    static REAL: Dir<'static> = Dir::new("", REAL_ENTRIES);
+
+    static PLACEHOLDER_ENTRIES: &[DirEntry<'static>] = &[DirEntry::File(File::new(
+        "embed-info.json",
+        b"{\"placeholder\":true}",
+    ))];
+    static PLACEHOLDER: Dir<'static> = Dir::new("", PLACEHOLDER_ENTRIES);
+
+    // Real embed with a dirty commit and no llms-full.txt (corrupt).
+    static DIRTY_ENTRIES: &[DirEntry<'static>] = &[
+        DirEntry::File(File::new(
+            "embed-info.json",
+            b"{\"commit\":\"beef999\",\"dirty\":true}",
+        )),
+        DirEntry::File(File::new("llms.txt", b"# Dirty\n")),
+    ];
+    static DIRTY: Dir<'static> = Dir::new("", DIRTY_ENTRIES);
+
+    // Real embed with no embed-info.json at all.
+    static NOINFO_ENTRIES: &[DirEntry<'static>] =
+        &[DirEntry::File(File::new("llms.txt", b"# NoInfo\n"))];
+    static NOINFO: Dir<'static> = Dir::new("", NOINFO_ENTRIES);
+
+    fn real() -> DocsEmbed<'static> {
+        DocsEmbed::new(&REAL)
+    }
+    fn placeholder() -> DocsEmbed<'static> {
+        DocsEmbed::new(&PLACEHOLDER)
+    }
+
+    // ---- placeholder detection -------------------------------------
+
+    #[test]
+    fn placeholder_detected_by_missing_llms_txt() {
+        assert!(!real().is_placeholder());
+        assert!(placeholder().is_placeholder());
+    }
+
+    #[test]
+    fn placeholder_blocks_content_modes_and_names_the_xtask() {
+        let e = placeholder();
+        for err in [
+            e.index().unwrap_err(),
+            e.full().map(|_| ()).unwrap_err(),
+            e.list().map(|_| ()).unwrap_err(),
+            e.page("index.md").map(|_| ()).unwrap_err(),
+        ] {
+            assert_eq!(err, DocsLlmsError::Placeholder);
+            let msg = err.to_string();
+            assert!(
+                msg.contains("cargo xtask build-agents-docs"),
+                "placeholder error must name the xtask: {msg}"
+            );
+            assert!(
+                msg.contains("cargo build --bin q2"),
+                "placeholder error must name the rebuild step: {msg}"
+            );
+        }
+    }
+
+    // ---- index / full ----------------------------------------------
+
+    #[test]
+    fn index_is_preamble_then_llms_txt_verbatim() {
+        let out = real().index().unwrap();
+        assert!(
+            out.starts_with("<!--"),
+            "preamble must be an HTML comment so the payload stays valid \
+             markdown: {out}"
+        );
+        assert!(out.contains("q2 docs llms <href>"), "{out}");
+        assert!(out.contains("q2 docs llms --list"), "{out}");
+        assert!(out.contains("q2 docs llms --full"), "{out}");
+        let end_of_comment = out.find("-->").expect("preamble comment must close");
+        assert_eq!(
+            &out[end_of_comment..],
+            format!("-->\n\n{LLMS_TXT}"),
+            "llms.txt must follow the preamble verbatim"
+        );
+    }
+
+    #[test]
+    fn full_is_llms_full_txt_verbatim() {
+        assert_eq!(real().full().unwrap(), LLMS_FULL);
+    }
+
+    #[test]
+    fn full_missing_from_real_embed_is_corrupt() {
+        let e = DocsEmbed::new(&DIRTY);
+        assert_eq!(
+            e.full().map(|_| ()).unwrap_err(),
+            DocsLlmsError::Corrupt("llms-full.txt".to_string())
+        );
+    }
+
+    // ---- list -------------------------------------------------------
+
+    #[test]
+    fn list_returns_all_md_pages_sorted_with_titles() {
+        let pages = real().list().unwrap();
+        let expect = [
+            ("guides/alpha.md", "Alpha Page"),
+            ("guides/noheading.md", "noheading"),
+            ("guides/sub/index.md", "Sub Index"),
+            ("index.md", "Home"),
+        ];
+        let got: Vec<(&str, &str)> = pages
+            .iter()
+            .map(|p| (p.href.as_str(), p.title.as_str()))
+            .collect();
+        assert_eq!(got, expect);
+    }
+
+    // ---- page lookup + normalization -------------------------------
+
+    #[test]
+    fn page_lookup_normalization_table() {
+        let e = real();
+        let alpha = "# Alpha Page\n\nAlpha body.\n";
+        let sub = "# Sub Index\n\nSub body.\n";
+        for (query, want) in [
+            ("guides/alpha.md", alpha), // exact
+            ("./guides/alpha.md", alpha),
+            ("/guides/alpha.md", alpha),
+            ("guides/alpha.qmd", alpha),
+            ("guides/alpha.html", alpha),
+            ("guides/alpha", alpha),
+            ("guides\\alpha.md", alpha), // windows-pasted path
+            ("guides/sub", sub),         // dir -> index.md
+            ("guides/sub/", sub),        // trailing slash
+            ("guides/sub/index.qmd", sub),
+        ] {
+            assert_eq!(e.page(query).unwrap(), want, "query: {query}");
+        }
+    }
+
+    #[test]
+    fn page_miss_suggests_by_stem_substring() {
+        let err = real().page("guides/alph").unwrap_err();
+        let DocsLlmsError::PageNotFound { query, suggestions } = &err else {
+            panic!("expected PageNotFound, got {err:?}");
+        };
+        assert_eq!(query, "guides/alph");
+        assert_eq!(suggestions, &["guides/alpha.md".to_string()]);
+        let msg = err.to_string();
+        assert!(msg.contains("guides/alpha.md"), "{msg}");
+        assert!(msg.contains("--list"), "{msg}");
+    }
+
+    #[test]
+    fn page_miss_suggests_same_directory_pages() {
+        let err = real().page("guides/zzz.md").unwrap_err();
+        let DocsLlmsError::PageNotFound { suggestions, .. } = &err else {
+            panic!("expected PageNotFound, got {err:?}");
+        };
+        assert_eq!(
+            suggestions,
+            &[
+                "guides/alpha.md".to_string(),
+                "guides/noheading.md".to_string(),
+                "guides/sub/index.md".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn page_miss_with_no_near_matches_points_at_list() {
+        let err = real().page("zzz/yyy.md").unwrap_err();
+        let DocsLlmsError::PageNotFound { suggestions, .. } = &err else {
+            panic!("expected PageNotFound, got {err:?}");
+        };
+        assert!(suggestions.is_empty());
+        assert!(err.to_string().contains("--list"));
+    }
+
+    // ---- embed-info -------------------------------------------------
+
+    #[test]
+    fn embed_info_parses_sidecar() {
+        let info = real().embed_info();
+        assert!(!info.placeholder);
+        assert_eq!(info.commit.as_deref(), Some("abc1234"));
+        assert!(!info.dirty);
+    }
+
+    #[test]
+    fn embed_info_text_real() {
+        assert_eq!(
+            real().embed_info_text(),
+            "source: real\ncommit: abc1234\npages: 4\n"
+        );
+    }
+
+    #[test]
+    fn embed_info_text_dirty_commit_is_flagged() {
+        assert_eq!(
+            DocsEmbed::new(&DIRTY).embed_info_text(),
+            "source: real\ncommit: beef999 (dirty)\npages: 0\n"
+        );
+    }
+
+    #[test]
+    fn embed_info_text_missing_sidecar_reads_unknown() {
+        assert_eq!(
+            DocsEmbed::new(&NOINFO).embed_info_text(),
+            "source: real\ncommit: unknown\npages: 0\n"
+        );
+    }
+
+    #[test]
+    fn embed_info_text_placeholder_names_the_fix() {
+        let text = placeholder().embed_info_text();
+        assert!(text.starts_with("source: placeholder\n"), "{text}");
+        assert!(text.contains("cargo xtask build-agents-docs"), "{text}");
+    }
+}

--- a/crates/quarto/src/commands/mod.rs
+++ b/crates/quarto/src/commands/mod.rs
@@ -10,6 +10,7 @@ pub mod check;
 pub mod common;
 pub mod convert;
 pub mod create;
+pub mod docs_llms;
 pub mod get_config;
 pub mod hub;
 pub mod install;

--- a/crates/quarto/src/main.rs
+++ b/crates/quarto/src/main.rs
@@ -698,6 +698,79 @@ enum Commands {
         #[arg(long, env = "QUARTO_HUB_ADDITIONAL_AUDIENCES", value_delimiter = ',')]
         additional_audiences: Vec<String>,
     },
+
+    /// Documentation embedded in this binary
+    ///
+    /// A namespace, not a command: `q2 docs` alone prints this help.
+    /// `q2 docs llms` serves the machine-readable (llms.txt) mirror of
+    /// the Quarto 2 documentation site for AI agents and tooling.
+    // Bare `q2 docs` shows the namespace help rather than a terse
+    // missing-subcommand error — it must never dump document content.
+    #[command(arg_required_else_help = true)]
+    Docs {
+        #[command(subcommand)]
+        command: DocsCommands,
+    },
+
+    /// Alias for `q2 docs llms`: embedded docs for AI agents
+    #[command(name = "agents-info")]
+    AgentsInfo(DocsLlmsArgs),
+}
+
+/// Subcommands under `q2 docs` — documentation embedded in the binary
+/// (bd-hwop1zii). `llms` is the machine-readable surface; the namespace
+/// deliberately leaves room for a future human-facing offline-docs
+/// mechanism (e.g. `docs serve`).
+#[derive(clap::Subcommand)]
+enum DocsCommands {
+    /// Machine-readable documentation (llms.txt) for AI agents
+    ///
+    /// With no arguments, prints the llms.txt index of the embedded
+    /// Quarto 2 documentation; each listed href can be fetched with
+    /// `q2 docs llms <href>`.
+    Llms(DocsLlmsArgs),
+}
+
+/// Arguments shared by `q2 docs llms` and its `q2 agents-info` alias.
+/// The four modes are mutually exclusive; bare invocation prints the
+/// llms.txt index.
+#[derive(clap::Args)]
+struct DocsLlmsArgs {
+    /// Documentation page to print, as an href from the index or
+    /// `--list` (e.g. `guides/authoring/figures.md`). The `.qmd` and
+    /// `.html` spellings, and extensionless paths, work too
+    href: Option<String>,
+
+    /// Print every page in one stream (llms-full.txt)
+    #[arg(long, conflicts_with_all = ["href", "list", "embed_info"])]
+    full: bool,
+
+    /// List every embedded page, one `href<TAB>title` per line
+    #[arg(long, conflicts_with_all = ["href", "embed_info"])]
+    list: bool,
+
+    /// Report provenance of the embedded docs snapshot (source commit,
+    /// page count)
+    #[arg(long = "embed-info", conflicts_with = "href")]
+    embed_info: bool,
+}
+
+impl DocsLlmsArgs {
+    fn mode(self) -> commands::docs_llms::Mode {
+        use commands::docs_llms::Mode;
+        // clap enforces mutual exclusion; the order here is arbitrary.
+        if self.full {
+            Mode::Full
+        } else if self.list {
+            Mode::List
+        } else if self.embed_info {
+            Mode::EmbedInfo
+        } else if let Some(href) = self.href {
+            Mode::Page(href)
+        } else {
+            Mode::Index
+        }
+    }
 }
 
 /// Subcommands under `quarto call` — the Q1-parity `call` group.
@@ -855,6 +928,82 @@ mod cli_parse_tests {
         match cli.command {
             cmd @ Commands::Preview { .. } => cmd,
             _ => panic!("expected a Preview command from {args:?}"),
+        }
+    }
+
+    /// Extract the `DocsLlmsArgs` from either the canonical `docs llms`
+    /// spelling or the top-level `agents-info` alias (bd-hwop1zii).
+    fn parse_docs_llms(args: &[&str]) -> super::DocsLlmsArgs {
+        let cli = try_parse(args).expect("args should parse");
+        match cli.command {
+            Commands::Docs {
+                command: super::DocsCommands::Llms(a),
+            } => a,
+            Commands::AgentsInfo(a) => a,
+            _ => panic!("expected docs llms / agents-info from {args:?}"),
+        }
+    }
+
+    #[test]
+    fn docs_llms_and_agents_info_parse_identically() {
+        for tail in [
+            &[][..],
+            &["--list"],
+            &["--full"],
+            &["--embed-info"],
+            &["guides/authoring/figures.md"],
+        ] {
+            let canonical: Vec<&str> = ["docs", "llms"]
+                .iter()
+                .copied()
+                .chain(tail.iter().copied())
+                .collect();
+            let alias: Vec<&str> = std::iter::once("agents-info")
+                .chain(tail.iter().copied())
+                .collect();
+            let c = parse_docs_llms(&canonical);
+            let a = parse_docs_llms(&alias);
+            assert_eq!(
+                (c.href, c.full, c.list, c.embed_info),
+                (a.href, a.full, a.list, a.embed_info),
+                "alias must parse identically to canonical for tail {tail:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn bare_docs_shows_help_not_content() {
+        let err = match try_parse(&["docs"]) {
+            Ok(_) => panic!("bare `q2 docs` must not parse into a runnable command"),
+            Err(e) => e,
+        };
+        assert_eq!(
+            err.kind(),
+            clap::error::ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand,
+            "bare `q2 docs` must display the namespace help"
+        );
+    }
+
+    #[test]
+    fn docs_llms_modes_are_mutually_exclusive() {
+        for args in [
+            &["docs", "llms", "--full", "--list"][..],
+            &["docs", "llms", "--full", "--embed-info"],
+            &["docs", "llms", "--list", "--embed-info"],
+            &["docs", "llms", "--full", "x.md"],
+            &["docs", "llms", "--list", "x.md"],
+            &["docs", "llms", "--embed-info", "x.md"],
+            &["agents-info", "--full", "--list"],
+        ] {
+            let err = match try_parse(args) {
+                Ok(_) => panic!("conflicting modes must not parse: {args:?}"),
+                Err(e) => e,
+            };
+            assert_eq!(
+                err.kind(),
+                clap::error::ErrorKind::ArgumentConflict,
+                "args: {args:?}"
+            );
         }
     }
 
@@ -1300,6 +1449,10 @@ fn main() -> Result<()> {
             compact,
             profile,
         }),
+        Commands::Docs { command } => match command {
+            DocsCommands::Llms(args) => commands::docs_llms::execute(args.mode()),
+        },
+        Commands::AgentsInfo(args) => commands::docs_llms::execute(args.mode()),
         Commands::Mcp { args } => commands::mcp::run(&args),
 
         Commands::ProvideHub {

--- a/crates/quarto/tests/integration/docs_llms_cli.rs
+++ b/crates/quarto/tests/integration/docs_llms_cli.rs
@@ -1,0 +1,207 @@
+/*
+ * tests/integration/docs_llms_cli.rs
+ * Copyright (c) 2026 Posit, PBC
+ *
+ * `q2 docs llms` / `q2 agents-info` e2e (bd-hwop1zii, Phase 3).
+ */
+
+//! Drives the real `q2` binary. The embedded docs tree depends on
+//! whether `cargo xtask build-agents-docs` has staged
+//! `agents-docs-dist/` before this binary was built, so every test
+//! here must pass in BOTH embed states: a fresh clone (placeholder
+//! embed — content modes fail with instructions) and a staged tree
+//! (real embed — content modes serve the docs). `--embed-info` is the
+//! state oracle: it succeeds in both states and names the state on
+//! its first line.
+
+use std::process::{Command, Output};
+
+const Q2_BIN: &str = env!("CARGO_BIN_EXE_q2");
+
+fn q2(args: &[&str]) -> Output {
+    Command::new(Q2_BIN)
+        .args(args)
+        .output()
+        .expect("spawn q2 binary")
+}
+
+fn stdout(out: &Output) -> String {
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+fn stderr(out: &Output) -> String {
+    String::from_utf8_lossy(&out.stderr).into_owned()
+}
+
+/// Whether this binary carries the real embed, per `--embed-info`.
+fn embed_is_real() -> bool {
+    let out = q2(&["docs", "llms", "--embed-info"]);
+    assert!(
+        out.status.success(),
+        "--embed-info must succeed in every embed state; stderr: {}",
+        stderr(&out)
+    );
+    let text = stdout(&out);
+    if text.starts_with("source: real\n") {
+        true
+    } else if text.starts_with("source: placeholder\n") {
+        false
+    } else {
+        panic!("--embed-info must name the embed state on line 1: {text}");
+    }
+}
+
+#[test]
+fn embed_info_names_state_and_fix_or_provenance() {
+    let text = stdout(&q2(&["docs", "llms", "--embed-info"]));
+    if embed_is_real() {
+        assert!(text.contains("\ncommit: "), "{text}");
+        assert!(text.contains("\npages: "), "{text}");
+    } else {
+        assert!(text.contains("cargo xtask build-agents-docs"), "{text}");
+    }
+}
+
+#[test]
+fn index_serves_llms_txt_or_names_the_fix() {
+    let out = q2(&["docs", "llms"]);
+    if embed_is_real() {
+        assert!(out.status.success(), "stderr: {}", stderr(&out));
+        let text = stdout(&out);
+        assert!(text.starts_with("<!--"), "preamble must lead: {text}");
+        assert!(text.contains("q2 docs llms --list"), "{text}");
+        // The docs site's llms.txt index opens with the site H1.
+        assert!(text.contains("\n# "), "llms.txt body must follow: {text}");
+    } else {
+        assert!(!out.status.success(), "placeholder embed must fail");
+        assert!(
+            stderr(&out).contains("cargo xtask build-agents-docs"),
+            "stderr must name the xtask: {}",
+            stderr(&out)
+        );
+    }
+}
+
+#[test]
+fn list_then_fetch_first_page_roundtrips() {
+    let list = q2(&["docs", "llms", "--list"]);
+    if !embed_is_real() {
+        assert!(!list.status.success(), "placeholder embed must fail");
+        assert!(stderr(&list).contains("cargo xtask build-agents-docs"));
+        return;
+    }
+    assert!(list.status.success(), "stderr: {}", stderr(&list));
+    let text = stdout(&list);
+    let first = text.lines().next().expect("--list must print pages");
+    let (href, title) = first
+        .split_once('\t')
+        .expect("--list lines are href<TAB>title");
+    assert!(href.ends_with(".md"), "href must be a companion: {href}");
+    assert!(!title.is_empty(), "title must be non-empty: {first}");
+
+    let page = q2(&["docs", "llms", href]);
+    assert!(page.status.success(), "stderr: {}", stderr(&page));
+    assert!(!stdout(&page).trim().is_empty(), "page must have content");
+}
+
+#[test]
+fn full_serves_corpus_or_names_the_fix() {
+    let out = q2(&["docs", "llms", "--full"]);
+    if embed_is_real() {
+        assert!(out.status.success(), "stderr: {}", stderr(&out));
+        assert!(
+            stdout(&out).len() > stdout(&q2(&["docs", "llms"])).len(),
+            "llms-full.txt must be larger than the index"
+        );
+    } else {
+        assert!(!out.status.success());
+        assert!(stderr(&out).contains("cargo xtask build-agents-docs"));
+    }
+}
+
+#[test]
+fn page_miss_exits_nonzero_and_points_at_list() {
+    let out = q2(&["docs", "llms", "no/such/page.md"]);
+    assert!(!out.status.success(), "missing page must fail");
+    if embed_is_real() {
+        assert!(stderr(&out).contains("--list"), "stderr: {}", stderr(&out));
+    } else {
+        assert!(stderr(&out).contains("cargo xtask build-agents-docs"));
+    }
+}
+
+#[test]
+fn agents_info_is_an_exact_alias() {
+    for tail in [&["--embed-info"][..], &["--list"], &[]] {
+        let canonical: Vec<&str> = ["docs", "llms"]
+            .iter()
+            .copied()
+            .chain(tail.iter().copied())
+            .collect();
+        let alias: Vec<&str> = std::iter::once("agents-info")
+            .chain(tail.iter().copied())
+            .collect();
+        let c = q2(&canonical);
+        let a = q2(&alias);
+        assert_eq!(c.status.code(), a.status.code(), "tail: {tail:?}");
+        assert_eq!(stdout(&c), stdout(&a), "tail: {tail:?}");
+    }
+}
+
+#[test]
+fn bare_docs_prints_namespace_help_never_content() {
+    let out = q2(&["docs"]);
+    // clap's help-on-missing-subcommand exits nonzero (usage error).
+    assert!(!out.status.success());
+    let combined = format!("{}{}", stdout(&out), stderr(&out));
+    assert!(combined.contains("llms"), "help must list llms: {combined}");
+    assert!(
+        !combined.contains("<!--"),
+        "bare `q2 docs` must never dump document content"
+    );
+}
+
+/// A command whose output is meant to be piped (`| head`, `| grep`,
+/// into an agent's reader) must not panic when the reader goes away.
+/// Rust ignores SIGPIPE, so an unguarded `print!` aborts with "failed
+/// printing to stdout: Broken pipe".
+#[test]
+fn closed_stdout_exits_quietly_without_panicking() {
+    use std::io::Read;
+    use std::process::Stdio;
+
+    if !embed_is_real() {
+        return; // placeholder embeds print nothing to close early on
+    }
+    let mut child = Command::new(Q2_BIN)
+        .args(["docs", "llms", "--full"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn q2");
+
+    // Read a little, then drop the pipe. `--full` is far larger than a
+    // pipe buffer, so the child is still writing when the reader dies.
+    let mut out = child.stdout.take().expect("piped stdout");
+    let mut buf = [0u8; 128];
+    out.read_exact(&mut buf).expect("read a first chunk");
+    drop(out);
+
+    let finished = child.wait_with_output().expect("wait for q2");
+    let err = String::from_utf8_lossy(&finished.stderr);
+    assert!(
+        !err.contains("panicked"),
+        "closed stdout must not panic; stderr: {err}"
+    );
+    assert!(
+        finished.status.success(),
+        "closed stdout is not an error; status: {:?}, stderr: {err}",
+        finished.status
+    );
+}
+
+#[test]
+fn conflicting_modes_are_a_usage_error() {
+    let out = q2(&["docs", "llms", "--full", "--list"]);
+    assert_eq!(out.status.code(), Some(2), "clap usage errors exit 2");
+}

--- a/crates/quarto/tests/integration/main.rs
+++ b/crates/quarto/tests/integration/main.rs
@@ -8,6 +8,7 @@ pub mod coalesced_diagnostics;
 pub mod conditional_content_cli;
 pub mod create;
 pub mod diagnostic_render_panic_boundary;
+pub mod docs_llms_cli;
 pub mod engine_diagnostics_cli;
 pub mod extension_config_spans;
 pub mod founding_crash_config_span_e2e;

--- a/crates/xtask/src/build_agents_docs.rs
+++ b/crates/xtask/src/build_agents_docs.rs
@@ -1,0 +1,246 @@
+//! `cargo xtask build-agents-docs` — stage the docs-site llms.txt
+//! artifacts for embedding into the `q2` binary (bd-hwop1zii).
+//!
+//! Steps:
+//!
+//! 1. Render `docs/` in place with `q2` (via `cargo run --bin q2`),
+//!    exactly like CI's docs build. The render's llms-txt pass writes
+//!    `docs/_site/llms.txt`, `docs/_site/llms-full.txt`, one `.md`
+//!    companion per page, and the ledger
+//!    `docs/.quarto/llms-manifest.json`.
+//! 2. Copy the ledger-listed artifacts (and only those — a
+//!    user-authored resource `.md` in `_site/` is not ours to embed)
+//!    into a fresh `agents-docs-dist/` at the workspace root.
+//! 3. Write `agents-docs-dist/embed-info.json` recording the staging
+//!    checkout's git commit + dirty flag, for `q2 docs llms
+//!    --embed-info`.
+//!
+//! The next `cargo build --bin q2` embeds the staged tree via the
+//! `quarto` crate's `build.rs` (`include_dir!`). Like the preview SPA
+//! and the MCP bundle, a plain rebuild does NOT re-render the docs —
+//! rerun this xtask to refresh the embed.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+
+use crate::util::nested_command;
+
+pub fn run() -> Result<()> {
+    let root = find_project_root()?;
+
+    // Capture provenance BEFORE rendering: the render writes into
+    // `docs/_site` and `docs/.quarto` and can leave generated siblings
+    // (e.g. `*_files/`) in the source tree, so a post-render `git
+    // status` would report a clean checkout as dirty. What we want to
+    // record is the state of the sources the docs were built from.
+    let info = embed_info(&root)?;
+
+    println!("━━━ Rendering docs/ (llms.txt artifacts) ━━━");
+    render_docs(&root)?;
+
+    println!("━━━ Staging agents-docs-dist/ ━━━");
+    let manifest_path = root.join("docs").join(".quarto").join("llms-manifest.json");
+    let manifest_json = std::fs::read_to_string(&manifest_path).with_context(|| {
+        format!(
+            "reading {} — did the docs render run its llms-txt pass? \
+             (docs/_quarto.yml must set `website.llms-txt: true`)",
+            manifest_path.display()
+        )
+    })?;
+    let site_dir = root.join("docs").join("_site");
+    let dist_dir = root.join("agents-docs-dist");
+    let staged = stage_files(&manifest_json, &site_dir, &dist_dir)?;
+
+    std::fs::write(dist_dir.join("embed-info.json"), &info)
+        .with_context(|| format!("writing {}/embed-info.json", dist_dir.display()))?;
+
+    println!(
+        "✓ agents-docs-dist/ staged: {staged} artifacts, embed-info {}",
+        info.trim()
+    );
+    println!("  Rebuild to embed: cargo build --bin q2");
+    Ok(())
+}
+
+/// Render the docs website in place (`docs/_site`), the same render CI
+/// runs. `q2` is invoked through a nested cargo so a stale or
+/// placeholder-embed binary is fine — the render doesn't consume the
+/// embed.
+fn render_docs(root: &Path) -> Result<()> {
+    let mut cmd = nested_command("cargo");
+    cmd.current_dir(root)
+        .args(["run", "--bin", "q2", "--", "render", "docs"]);
+    let status = cmd
+        .status()
+        .context("spawning `cargo run --bin q2 -- render docs`")?;
+    if !status.success() {
+        bail!("`q2 render docs` failed (exit {:?})", status.code());
+    }
+    Ok(())
+}
+
+/// Copy the ledger-listed artifacts from `site_dir` into a fresh
+/// `dist_dir`, preserving the directory tree. Returns the number of
+/// files staged. The dist is rebuilt from scratch so files removed
+/// from the docs can never linger in the embed.
+fn stage_files(manifest_json: &str, site_dir: &Path, dist_dir: &Path) -> Result<usize> {
+    #[derive(serde::Deserialize)]
+    struct LlmsManifest {
+        generated: Vec<String>,
+    }
+
+    let manifest: LlmsManifest =
+        serde_json::from_str(manifest_json).context("parsing llms-manifest.json")?;
+    if manifest.generated.is_empty() {
+        bail!("llms-manifest.json lists no generated artifacts");
+    }
+    if !manifest.generated.iter().any(|rel| rel == "llms.txt") {
+        bail!("llms-manifest.json does not list llms.txt; refusing to stage");
+    }
+
+    if dist_dir.exists() {
+        std::fs::remove_dir_all(dist_dir)
+            .with_context(|| format!("clearing stale {}", dist_dir.display()))?;
+    }
+    std::fs::create_dir_all(dist_dir)
+        .with_context(|| format!("creating {}", dist_dir.display()))?;
+
+    for rel in &manifest.generated {
+        // Ledger paths are output-dir-relative with forward slashes.
+        let src = site_dir.join(rel.replace('/', std::path::MAIN_SEPARATOR_STR));
+        let dest = dist_dir.join(rel.replace('/', std::path::MAIN_SEPARATOR_STR));
+        if let Some(parent) = dest.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("creating {}", parent.display()))?;
+        }
+        std::fs::copy(&src, &dest).with_context(|| {
+            format!(
+                "copying {} — the ledger lists it but the render did not \
+                 produce it",
+                src.display()
+            )
+        })?;
+    }
+    Ok(manifest.generated.len())
+}
+
+/// Provenance sidecar for `q2 docs llms --embed-info`: the staging
+/// checkout's HEAD commit and whether the working tree was dirty.
+fn embed_info(root: &Path) -> Result<String> {
+    let commit = git_stdout(root, &["rev-parse", "HEAD"])?;
+    let dirty = !git_stdout(root, &["status", "--porcelain"])?.is_empty();
+    Ok(format!(
+        "{}\n",
+        serde_json::json!({ "commit": commit, "dirty": dirty })
+    ))
+}
+
+fn git_stdout(root: &Path, args: &[&str]) -> Result<String> {
+    let out = std::process::Command::new("git")
+        .args(args)
+        .current_dir(root)
+        .output()
+        .with_context(|| format!("running git {args:?}"))?;
+    if !out.status.success() {
+        bail!(
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+    Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
+fn find_project_root() -> Result<PathBuf> {
+    let mut dir = std::env::current_dir().context("Failed to get current directory")?;
+    loop {
+        let cargo_toml = dir.join("Cargo.toml");
+        if cargo_toml.exists() {
+            let content = std::fs::read_to_string(&cargo_toml)?;
+            if content.contains("[workspace]") {
+                return Ok(dir);
+            }
+        }
+        if !dir.pop() {
+            bail!("Could not find workspace root (Cargo.toml with [workspace])");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::stage_files;
+
+    fn manifest(entries: &[&str]) -> String {
+        serde_json::json!({ "version": 1, "generated": entries }).to_string()
+    }
+
+    #[test]
+    fn stages_listed_files_preserving_tree_and_clearing_stale() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let site = tmp.path().join("_site");
+        let dist = tmp.path().join("dist");
+        std::fs::create_dir_all(site.join("guides")).unwrap();
+        std::fs::write(site.join("llms.txt"), "# Index\n").unwrap();
+        std::fs::write(site.join("llms-full.txt"), "full\n").unwrap();
+        std::fs::write(site.join("guides").join("a.md"), "# A\n").unwrap();
+        // An unlisted _site file (user resource) must NOT be staged.
+        std::fs::write(site.join("guides").join("stray.md"), "stray\n").unwrap();
+        // A stale file from a previous staging must be cleared.
+        std::fs::create_dir_all(&dist).unwrap();
+        std::fs::write(dist.join("removed-page.md"), "old\n").unwrap();
+
+        let n = stage_files(
+            &manifest(&["guides/a.md", "llms.txt", "llms-full.txt"]),
+            &site,
+            &dist,
+        )
+        .unwrap();
+
+        assert_eq!(n, 3);
+        assert_eq!(
+            std::fs::read_to_string(dist.join("llms.txt")).unwrap(),
+            "# Index\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(dist.join("guides").join("a.md")).unwrap(),
+            "# A\n"
+        );
+        assert!(dist.join("llms-full.txt").is_file());
+        assert!(
+            !dist.join("guides").join("stray.md").exists(),
+            "unlisted _site files must not be staged"
+        );
+        assert!(
+            !dist.join("removed-page.md").exists(),
+            "stale staged files must be cleared"
+        );
+    }
+
+    #[test]
+    fn refuses_manifest_without_llms_txt() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let err = stage_files(
+            &manifest(&["guides/a.md"]),
+            &tmp.path().join("_site"),
+            &tmp.path().join("dist"),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("llms.txt"), "{err}");
+    }
+
+    #[test]
+    fn missing_listed_file_is_an_error_naming_the_file() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let site = tmp.path().join("_site");
+        std::fs::create_dir_all(&site).unwrap();
+        std::fs::write(site.join("llms.txt"), "# Index\n").unwrap();
+        let err = stage_files(
+            &manifest(&["llms.txt", "ghost.md"]),
+            &site,
+            &tmp.path().join("dist"),
+        )
+        .unwrap_err();
+        assert!(format!("{err:#}").contains("ghost.md"), "{err:#}");
+    }
+}

--- a/crates/xtask/src/build_all.rs
+++ b/crates/xtask/src/build_all.rs
@@ -13,10 +13,18 @@
 //! 6. Build the hub MCP bundle (q2-mcp embed artifact; bd-81cfshmw)
 //! 7. Build the engine-host-deno bundle (quarto-core embed artifact; Plan 1b)
 //! 8. Build the Rust workspace (`cargo build --workspace`)
+//! 9. Stage the docs embed for `q2 docs llms` and re-embed it into the
+//!    `q2` binary (bd-hwop1zii)
 //!
 //! Both SPAs (trace-viewer + q2-preview-spa) must build *before* the
 //! Rust workspace because `quarto-trace-server` and `quarto-preview`
 //! embed their respective `dist/` directories via `include_dir!`.
+//!
+//! The docs embed is the one artifact that must come *after* the Rust
+//! build instead: staging it renders `docs/` with the freshly built
+//! `q2`, so the binary has to exist first. That is why step 9 ends with
+//! a second, narrower `cargo build --bin q2` — the run that actually
+//! embeds the staged tree.
 
 use anyhow::{Context, Result, bail};
 use std::path::Path;
@@ -42,6 +50,10 @@ pub struct BuildAllConfig {
     pub skip_q2_preview_spa_build: bool,
     /// Skip the final `cargo build --workspace` step.
     pub skip_rust_build: bool,
+    /// Skip staging + embedding the docs for `q2 docs llms`. Implied by
+    /// `skip_rust_build` (staging needs a built `q2`, and the embed
+    /// needs a rebuild to take effect).
+    pub skip_agents_docs: bool,
     /// Pass `--release` to `cargo build`.
     pub release: bool,
 }
@@ -75,6 +87,10 @@ pub fn run(config: &BuildAllConfig) -> Result<()> {
             !config.skip_engine_host_bundle && engine_host_exists(&project_root),
         ),
         ("Rust workspace build", !config.skip_rust_build),
+        (
+            "docs embed for `q2 docs llms`",
+            !config.skip_agents_docs && !config.skip_rust_build,
+        ),
     ];
 
     let enabled_count = steps.iter().filter(|(_, enabled)| *enabled).count();
@@ -210,6 +226,32 @@ pub fn run(config: &BuildAllConfig) -> Result<()> {
         }
         run_command("cargo", &args, &project_root, None, "Rust build failed")?;
         println!("✓ Rust build complete");
+    }
+
+    // Step: docs embed for `q2 docs llms` (bd-hwop1zii). Unlike every
+    // other embed artifact this one runs *after* the Rust build — it
+    // renders `docs/` with the `q2` that build just produced — so it
+    // ends with a second `cargo build --bin q2` that embeds the result.
+    if !config.skip_agents_docs && !config.skip_rust_build {
+        step_idx += 1;
+        banner(
+            step_idx,
+            total,
+            "Staging + embedding docs for `q2 docs llms`",
+        );
+        crate::build_agents_docs::run()?;
+        let mut args: Vec<&str> = vec!["build", "--bin", "q2"];
+        if config.release {
+            args.push("--release");
+        }
+        run_command(
+            "cargo",
+            &args,
+            &project_root,
+            None,
+            "q2 docs re-embed build failed",
+        )?;
+        println!("✓ docs embed complete");
     }
 
     println!("\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -18,9 +18,11 @@
 //! - `build-hub-client-embed`: Build the hub-client editor bundle for `q2 preview --ui editor`
 //! - `build-hub-mcp-bundle`: Build the self-contained hub MCP server bundle
 //! - `build-engine-host-bundle`: Build the committed engine-host-deno.js bundle
+//! - `build-agents-docs`: Stage the docs-site llms.txt artifacts for `q2 docs llms`
 //! - `stage-doc-examples`: Render `examples/manifest.yml` projects into `docs/examples/`
 
 mod braid_snapshot;
+mod build_agents_docs;
 mod build_all;
 mod build_engine_host_bundle;
 mod build_hub_client_embed;
@@ -237,6 +239,16 @@ enum Command {
     /// build -p quarto-trace-server` (via `include_dir!`).
     BuildTraceViewer {},
 
+    /// Stage the docs-site llms.txt artifacts for `q2 docs llms`.
+    ///
+    /// Renders `docs/` and copies the llms-txt output (index, per-page
+    /// `.md` companions, llms-full.txt) into `agents-docs-dist/`, which
+    /// is generated and gitignored — regenerate with this command; never
+    /// commit it. The tree is picked up on the next `cargo build --bin
+    /// q2` (via `include_dir!`); without it the binary embeds a
+    /// placeholder. See bd-hwop1zii.
+    BuildAgentsDocs {},
+
     /// Build just the q2-preview SPA.
     ///
     /// Faster than `build-all` when only the SPA source has changed. The
@@ -315,6 +327,10 @@ enum Command {
         #[arg(long)]
         skip_rust_build: bool,
 
+        /// Skip staging + embedding the docs for `q2 docs llms`.
+        #[arg(long)]
+        skip_agents_docs: bool,
+
         /// Pass `--release` to `cargo build`.
         #[arg(long)]
         release: bool,
@@ -389,6 +405,7 @@ fn main() -> Result<()> {
             verify::run(&config)
         }
         Command::PandocCheck {} => pandoc_check::run(),
+        Command::BuildAgentsDocs {} => build_agents_docs::run(),
         Command::StageDocExamples {} => stage_doc_examples::run(),
         Command::BuildTraceViewer {} => build_trace_viewer::run(),
         Command::BuildQ2PreviewSpa {} => build_q2_preview_spa::run(),
@@ -404,9 +421,11 @@ fn main() -> Result<()> {
             skip_hub_mcp_bundle,
             skip_engine_host_bundle,
             skip_rust_build,
+            skip_agents_docs,
             release,
         } => {
             let config = build_all::BuildAllConfig {
+                skip_agents_docs,
                 skip_npm_install,
                 skip_ts_packages_build,
                 skip_hub_build,

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -5,3 +5,8 @@
 # the example projects for `.embed-example-iframe` embeds (bd-z1smhvuo).
 # Regenerate it; never commit it.
 /examples/
+# Engine cell output (figures etc.) written next to a computational page on
+# every render. No `*_files/` directory here has ever been tracked; leaving
+# them unignored made each docs render report a dirty tree, which
+# `cargo xtask build-agents-docs` then recorded as the embed's provenance.
+**/*_files/

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -36,6 +36,7 @@ website:
             - guides/projects/render-list.qmd
             - guides/projects/aliases.qmd
             - guides/projects/llms-txt.qmd
+            - guides/embedded-docs.qmd
             - guides/projects/scripts.qmd
             - guides/projects/environment.qmd
             - guides/projects/profiles.qmd

--- a/docs/guides/embedded-docs.qmd
+++ b/docs/guides/embedded-docs.qmd
@@ -1,0 +1,108 @@
+---
+title: "Embedded documentation for AI agents"
+description: "Read the Quarto 2 documentation straight from the q2 binary, with no network access, using `q2 docs llms`."
+---
+
+## Overview
+
+Every `q2` binary carries a markdown copy of this documentation site
+inside it. AI coding agents — and any tool that prefers plain text to
+rendered HTML — can read it directly from the command line, offline:
+
+```bash
+q2 docs llms
+```
+
+That prints an index of every documentation page, in the
+[llms.txt](https://llmstxt.org) format. The index is small enough to
+paste into a prompt; each entry names a page you can then fetch on
+demand.
+
+The docs are the ones this site was built from, so an agent reading
+them is reading documentation for **the version of Quarto it is
+actually running** — not whatever it remembers, and not a newer or
+older website.
+
+::: {.callout-tip}
+## Point your agent here
+
+If you use an AI coding assistant, telling it once that
+`q2 docs llms` exists is usually enough. Many agents will then
+discover the pages they need without further help.
+:::
+
+## Fetching a page
+
+Each entry in the index is an href. Pass one to fetch that page's
+markdown:
+
+```bash
+q2 docs llms guides/authoring/figures.md
+```
+
+Paths are forgiving: the `.qmd` and `.html` spellings of a page work
+too, as does leaving the extension off entirely, and naming a
+directory gets you its index page.
+
+```bash
+q2 docs llms guides/authoring/figures      # same page
+q2 docs llms guides/authoring              # the section's index
+```
+
+If a path doesn't match anything, `q2` suggests near matches and exits
+with an error rather than printing nothing.
+
+## Listing every page
+
+```bash
+q2 docs llms --list
+```
+
+prints one line per page — the href, a tab, and the page title — which
+is the convenient form for scripts and for agents that want to search
+titles before fetching:
+
+```
+guides/authoring/figures.md	Figures
+guides/authoring/tables.md	Tables
+guides/projects/llms-txt.md	llms.txt: a markdown mirror for AI tools
+```
+
+## The whole corpus at once
+
+```bash
+q2 docs llms --full
+```
+
+concatenates every page into a single stream. It is far too large for
+most models to read in one prompt — expect several hundred kilobytes —
+but it is the right input for building a search index, a vector store,
+or any other downstream tool that wants everything at once.
+
+## Which docs are embedded?
+
+```bash
+q2 docs llms --embed-info
+```
+
+reports where the embedded snapshot came from:
+
+```
+source: real
+commit: e3b3d7d4aae422274a7f3ff1c781019c24bfbb07
+pages: 255
+```
+
+Released binaries always carry the documentation built from that
+release's source. A `q2` you built yourself may report
+`source: placeholder`, meaning no documentation was embedded; the
+command tells you how to build and embed it.
+
+## Related
+
+- [llms.txt: a markdown mirror for AI tools](projects/llms-txt.qmd)
+  publishes the same kind of markdown mirror for **your own**
+  website. `q2 docs llms` is that feature turned on Quarto's own
+  documentation and shipped inside the binary.
+- `q2 agents-info` is an alias for `q2 docs llms` — the two are
+  interchangeable.


### PR DESCRIPTION
Every `q2` binary now carries a markdown copy of the Quarto 2 documentation site, readable offline from the command line — so an AI agent driving `q2` reads documentation for **the version it is actually running**, not whatever it remembers.

The generation side already shipped in v0.26.0 (`website.llms-txt`, bd-llms-txt-unimplemented-oih6z6j7). This PR stages those artifacts at build time, embeds them, and serves them.

## The command

```bash
q2 docs llms                  # llms.txt index + a retrieval preamble
q2 docs llms --list           # href<TAB>title per page
q2 docs llms <href>           # one page's markdown
q2 docs llms --full           # the whole corpus (~560 KB)
q2 docs llms --embed-info     # provenance of the embedded snapshot
q2 agents-info ...            # visible alias for `q2 docs llms`
```

`docs` is a namespace, not a command: bare `q2 docs` prints help, so a human is never handed the agent-facing dump thinking it is the docs. It reserves room for a future human-facing `docs serve`/`open` (bd-x248xpyh).

Href lookup accepts the `.qmd`/`.html` spellings and extensionless paths, and resolves a directory to its index page; a miss suggests near matches and exits nonzero.

```
$ q2 docs llms --embed-info        $ q2 docs llms guides/embedded-docs.qmd | head -1
source: real                       # Embedded documentation for AI agents
commit: e3b3d7d4…
pages: 256                         $ q2 docs llms guides/embedded
                                   Error: no embedded documentation page matches `guides/embedded`; did you mean one of:
                                     guides/embedded-docs.md
                                   Use `q2 docs llms --list` to see every page.
```

## Build mechanics

Follows the established embed pattern (`quarto-trace-server`, `quarto-preview`): `cargo xtask build-agents-docs` renders `docs/` and stages the artifacts into a gitignored `agents-docs-dist/`; the `quarto` crate's new `build.rs` embeds that tree via `include_dir!`, or a placeholder plus a cargo warning on a fresh clone. **1.7 MB against a 143 MB debug binary (~1.2%).** Plain `include_dir!`, no tar.zst — text that small doesn't justify the archive layer.

Staging reads the llms ledger (`.quarto/llms-manifest.json`) rather than globbing `_site/*.md`, so a user-authored resource `.md` cannot leak into the embed.

**The one twist versus every other embed:** staging renders the docs with `q2` itself, so it must run *after* a Rust build.

- `cargo xtask build-all` reflects that — docs step last, ending in its own `cargo build --bin q2`; opt out with `--skip-agents-docs`.
- The release workflow stages it **once in `web-payloads`** (target-independent, and a cross-compiled leg could not run the binary that renders it), ships it in that job's artifact, and each build leg's verify gate asserts the embed is real and from the tag's commit. That job's timeout went 45 → 75 min because it now compiles a host `q2`.
- A `(dirty)` marker **warns** rather than fails: the docs still came from the right commit, and blocking a real shipment over a cosmetic tree-state signal is a bad trade.

## A real bug, found by hand-verification

`q2 docs llms --full | head` panicked with `failed printing to stdout: Broken pipe` — Rust ignores SIGPIPE. For a command whose entire purpose is being piped into agents and `grep`, that's a defect. Regression test written first (it reproduced the panic), then all output routed through a helper that treats a closed reader as success. Every unit test passed while the command was broken for its primary use — exactly the case the end-to-end rule in `CLAUDE.md` exists for.

## Testing

27 new tests: 15 unit (lookup/normalization/placeholder/embed-info over synthetic `include_dir` trees), 3 xtask (staging skips unlisted files, clears stale trees, errors informatively), 9 integration driving the real binary. **The integration tests pass in both embed states** — confirmed by running them before staging (placeholder, 8/8) and after (real, 9/9), so fresh-clone CI stays green.

- Full workspace suite: **13028 passing**.
- `cargo xtask verify --skip-hub-build`: **all 14 steps green**. Nothing under `quarto-core` moved, so the WASM leg is unaffected; changed crates are `quarto` (bin) and `xtask` only.
- No snapshot files added or modified.

## Also riding along

`docs/.gitignore` now ignores `*_files/` engine cell output. No such directory has ever been tracked, but leaving them unignored meant every docs render dirtied the tree — which the new staging step would then record as the embed's provenance.

## Notes for review

- The docs page landed at `docs/guides/embedded-docs.qmd` in the flat Guides sidebar right after `projects/llms-txt.qmd`. It isn't a project feature, so `projects/` felt wrong — happy to move it.
- Follow-ups filed as `discovered-from`: **bd-x248xpyh** (`docs serve`/`open`), **bd-b6cocsxw** (`--json` output), **bd-dn81ol95** (expose the corpus as `q2 mcp` tools).

Plan: `claude-notes/plans/2026-08-24-agents-info-command.md`
Strand: bd-hwop1zii

🤖 Generated with [Claude Code](https://claude.com/claude-code)