### PR TITLE
Attribute render failures to the page that failed

### DIFF
--- a/claude-notes/plans/2026-08-24-render-failure-unattributed.md
+++ b/claude-notes/plans/2026-08-24-render-failure-unattributed.md
@@ -1,0 +1,223 @@
+# Render failures with no attribution (bd-render-failure-unattributed-yxe0v7th)
+
+## Overview
+
+A page can fail during a project render and the output never names the file.
+The strand reports two shapes; investigation confirmed both and found a third,
+worse face of shape 1.
+
+### Shape 1 — engine-output parse errors are bound to the wrong buffer
+
+`EngineExecutionStage` parses the engine's executed markdown
+(`result.markdown`, e.g. knitr's `.knit.md`) at
+`crates/quarto-core/src/stage/stages/engine_execution.rs:611-621`. On the
+**Ok** path it carefully registers the intermediate as a new `SourceContext`
+slot and remaps `FileId(0)` into it. On the **Err** path it throws that
+context away:
+
+```rust
+.map_err(|diagnostics| {
+    PipelineError::stage_error_with_diagnostics(self.name(), diagnostics)
+})?;
+```
+
+`pampa::readers::qmd::read` returns only `Vec<DiagnosticMessage>` on failure,
+so the `SourceContext` that gave those spans meaning is dropped. The generic
+`StageError -> QuartoError::Parse` conversion at
+`crates/quarto-core/src/pipeline.rs:725-741` then **fabricates** a
+`SourceContext` from the *original document's* bytes and binds the
+engine-output spans to it.
+
+Measured, `q2 render` on a 106-byte `knit.qmd` whose R chunk emits a bad
+shortcode:
+
+```
+DBG conv: source_name=.../knit.qmd content_len=106
+          diags=[("Unquoted shortcode parameter starting with digit",
+                  Some((4716, "Original { file_id: FileId(0),
+                               start_offset: 4716, end_offset: 4717 }")))]
+```
+
+Offset 4716 indexes the `.knit.md`; the bound buffer is 106 bytes. Two
+outcomes follow from where the offset lands:
+
+- **Past EOF** (the common case — engine output is much larger than the
+  source): `map_offset` fails, so ariadne renders nothing *and*
+  `to_text_with_renderer`'s `at <file>:<row>:<col>` fallback is skipped too.
+  Output is a bare title + problem with no file, line, or frame. This is the
+  shape the strand reports.
+- **Inside the source file** (a long `.qmd`): a fully-formed, confident
+  ariadne frame is printed against an **arbitrary wrong location**. Measured
+  on a 14576-byte `big.qmd`: the error was reported at `big.qmd:68:100`,
+  caret on the letter `e` of a filler paragraph containing no shortcode at
+  all. **Not in the strand** — silently wrong attribution is worse than
+  missing attribution, because nothing signals it is wrong.
+
+Same defect class as the `add-file-with-id` lint rule's rationale
+(bd-m6wmztln): binding an *assumed* file to a diagnostic's resolved id
+renders byte offsets against the wrong text.
+
+### Shape 2 — the render summary drops `FileFailure.input`
+
+`print_render_diagnostics_text` in `crates/quarto/src/commands/render.rs:1330-1355`
+prints `error: {input}: {error}` only for `legacy_failures` (failures whose
+`diagnostics` vec is empty). Any failure that *does* carry structured
+diagnostics is routed through `coalesce_by_source` and rendered by
+`CoalescedDiagnostic::to_text()`, which relies entirely on the diagnostic's
+own span to name the file — and deliberately omits the `Affected files:`
+tail for singleton groups. So when the span is absent or unresolvable, the
+known-good `failure.input` is discarded and nothing names the file.
+
+Confirmed on the committed repro
+(`q2-positron-docs/.../silent-failure/repro`): a chunk calling `stop()` in a
+project render prints `Error: Execution failed in knitr: R process failed`
+with the `.qmd` name absent from the whole transcript. Same for a
+location-less engine-availability failure (`location: None` verified by
+instrumentation).
+
+Note the `--json-errors` path already emits `"source_file": ".../knit.qmd"`
+correctly — it reads `failure.input` structurally. Only the text path loses it.
+
+## Scope
+
+Decided with Gordon 2026-08-24:
+
+- **In scope**: shape 1's root cause, and a structural attribution guarantee
+  so every per-file failure names its `.qmd`.
+- **In scope**: the attribution line is added **only where today's output goes
+  silent about which page failed**, so existing well-attributed output and its
+  snapshots are untouched. (Sketched as "only when the diagnostic is
+  unlocatable"; Fix A changed what that covers — see Outcome.)
+- **Out of scope**: remapping knitr's `failing.rmarkdown:133-135` traceback
+  line numbers back to `.qmd` lines. That needs a line map from the
+  serialized intermediate plus per-engine stderr parsing. To be filed as a
+  separate strand.
+
+## Phase 1 — Tests (TDD, must fail first)
+
+- [x] `engine_execution.rs`: fake `ExecutionEngine` returning markdown with a
+      parse error; assert the stage returns `PipelineError::Structured` whose
+      `SourceContext` resolves the diagnostic span against the **engine
+      output**, under the intermediate filename.
+- [x] `engine_execution.rs`: assert the diagnostic's offset is in range for
+      the registered content (guards the wrong-frame face directly).
+- [x] `render.rs`: unit tests for the attribution helper — (a) location-less
+      diagnostic gains the line, (b) resolvable location is left untouched,
+      (c) location that does not resolve in its context gains the line,
+      (d) a span resolving to an engine intermediate gains the line,
+      (e) multi-file groups are left to their `Affected files:` tail,
+      (f) matching survives mixed path separators (Windows).
+- [x] knitr-gated e2e (following `marimo_engine_e2e.rs`'s
+      `rscript_available()` / `knitr_r_package_available()` pattern): project
+      render whose R chunk emits a bad shortcode names the `.qmd`.
+
+## Phase 2 — Fix A: engine-output parse errors keep their own context
+
+- [x] Build a `SourceContext` holding the engine output under the
+      intermediate name and return `PipelineError::Structured(ParseError)`.
+- [x] Audit the sibling site `serialize_ast_to_qmd`
+      (`engine_execution.rs:734`) for the same defect.
+
+## Phase 3 — Fix B: structural attribution in the render summary
+
+- [x] Add an "is this diagnostic locatable in its context" predicate.
+      (Landed as `failure_attribution_line`; see Outcome for the refinement.)
+- [x] Prefix `error: while rendering <path>` for unlocatable pass1/pass2
+      failures; leave locatable ones byte-identical.
+
+## Phase 4 — Verification
+
+- [x] `cargo clippy` + per-crate `nextest` for touched crates.
+- [x] Workspace `cargo nextest run --workspace`; report delta vs live baseline.
+- [x] End-to-end via the real binary on the knitr repro and the Positron
+      shape-2 repro; record invocation + observed output here.
+- [x] Reconcile this checklist against reality before handoff.
+
+## Outcome
+
+### Predicate refinement (deviation from the pre-implementation sketch)
+
+The agreed rule was "add the attribution line only when the diagnostic is
+unlocatable". Implementing Fix A changed what "unlocatable" covers: engine
+output parse errors now resolve *perfectly well* — against
+`<stem>.<engine>.rmarkdown`. A pure unlocatable test would therefore have gone
+quiet again on exactly the case the strand was filed for.
+
+`failure_attribution_line` uses the intended rule instead: **add the line when
+the rendered output does not name the page that failed.** That is unlocatable
+spans *plus* spans resolving to a file other than `FileFailure.input`. The
+no-churn property Gordon asked for is preserved — an ordinary parse error in
+the `.qmd` resolves to the `.qmd`, so nothing is added.
+
+### Audit result: `serialize_ast_to_qmd`
+
+No change needed. Its `Err` carries either the location-less `Q-3-1` IO
+diagnostic (now covered by Fix B) or `ctx.errors`, whose spans index the
+original AST's source — so the generic conversion binds them correctly.
+
+The same `stage_error_with_diagnostics` shape also appears at
+`crates/quarto-core/src/engine/preview_record.rs:241`
+(`preview-record/compute-input-qmd`). That feeds the q2-preview frontend, not
+the CLI render summary, so it is untouched here and unverified.
+
+### Verification
+
+`cargo clippy -p quarto-core -p quarto --all-targets -- -D warnings` — clean.
+
+Workspace, measured live on this branch:
+
+| run | tests | result |
+| --- | --- | --- |
+| baseline (changes stashed) | 13130 | 1 failed: `quarto-core engine::ts_engine::tests::test_race_free_instance_exclusive` |
+| with changes | 13140 | 13140 passed, 199 skipped |
+
+Delta **+10**, fully accounted for: 2 (`engine_execution.rs`) + 6
+(`render.rs` unit) + 2 (`render_cli_e2e.rs`). Skipped count unchanged at 199.
+
+The baseline failure is a pre-existing flake, not a regression: it timed out at
+15.152s under full-workspace contention, passes in 0.295s in isolation, and
+passed in the with-changes workspace run.
+
+### End-to-end, through the real binary
+
+`q2 render` in a project whose R chunk emits `{{< fa envelope size=1x >}}`.
+
+Before — the page dies unnamed:
+
+```
+Error [Q-2-34]: Unquoted shortcode parameter starting with digit
+Shortcode parameter values starting with digits must be quoted.
+```
+
+After — output inspected, both the page and the offending line are named:
+
+```
+error: while rendering /…/t2/knit.qmd
+Error: [Q-2-34] Unquoted shortcode parameter starting with digit
+     ╭─[ /…/t2/knit.knitr.rmarkdown:138:23 ]
+     │
+ 138 │ {{< fa envelope size=1x >}}
+     │                       ┬
+     │                       ╰── Shortcode parameter values starting with digits must be quoted.
+─────╯
+```
+
+Shape 2, on the committed Positron repro
+(`q2-positron-docs/.../silent-failure/repro`, `q2 render failing.qmd`):
+
+```
+error: while rendering /…/repro/failing.qmd
+Error: Execution failed in knitr: R process failed
+```
+
+The scoped-out half remains: the traceback above it still cites
+`failing.rmarkdown:133-135`.
+
+Regression check — an ordinary parse error in a `.qmd` is byte-identical to
+before, with no `while rendering` line added.
+
+## Follow-up
+
+- [ ] File a strand for remapping engine-intermediate line numbers
+      (`<stem>.<engine>.rmarkdown:NNN`) back to `.qmd` lines, covering both
+      knitr's stderr traceback and the ariadne frame's file/line.

--- a/crates/quarto-core/src/stage/stages/engine_execution.rs
+++ b/crates/quarto-core/src/stage/stages/engine_execution.rs
@@ -617,7 +617,30 @@ impl PipelineStage for EngineExecutionStage {
                     None, // file_id
                 )
                 .map_err(|diagnostics| {
-                    PipelineError::stage_error_with_diagnostics(self.name(), diagnostics)
+                    // bd-render-failure-unattributed-yxe0v7th shape 1:
+                    // these spans index into `result.markdown`, NOT into the
+                    // original document. Returning a bare `StageError` here
+                    // drops the only context that gives them meaning, and
+                    // `run_pipeline`'s generic `StageError -> QuartoError::Parse`
+                    // conversion then rebinds `FileId(0)` to the *source*
+                    // document's bytes. Engine output is normally much larger
+                    // than its source, so the offset lands past EOF and the
+                    // renderer emits neither an ariadne frame nor its
+                    // `at <file>:<row>:<col>` fallback — the page dies with no
+                    // attribution at all. When the source happens to be long
+                    // enough, the offset instead resolves to arbitrary
+                    // unrelated text and is reported with full confidence.
+                    //
+                    // So bind the spans here, to the buffer they actually
+                    // index, and hand back a `Structured` error that
+                    // `run_pipeline` passes through untouched.
+                    let mut source_context = quarto_source_map::SourceContext::new();
+                    source_context
+                        .add_file(intermediate_name.clone(), Some(result.markdown.clone()));
+                    PipelineError::Structured(crate::error::ParseError::new(
+                        diagnostics,
+                        source_context,
+                    ))
                 })?;
 
             // Register this engine's intermediate as a new file slot, using
@@ -979,6 +1002,177 @@ mod tests {
             warnings,
             recorded_includes: Vec::new(),
         }
+    }
+
+    /// bd-render-failure-unattributed-yxe0v7th, shape 1.
+    ///
+    /// An engine whose *output* fails to parse. The parse runs against
+    /// `result.markdown` (the engine's executed markdown), so the resulting
+    /// diagnostic spans index into that buffer — NOT into the original
+    /// `.qmd`. The stage must therefore hand back an error that carries the
+    /// engine output as its `SourceContext`.
+    ///
+    /// Revert binding: change the `map_err` on the `read` of
+    /// `result.markdown` back to `PipelineError::stage_error_with_diagnostics`
+    /// and this test reds — the error becomes a bare `StageError` with no
+    /// context, and `run_pipeline`'s generic conversion then rebinds the
+    /// spans to the original document's bytes (past EOF → no frame at all;
+    /// inside EOF → a confident frame at an arbitrary wrong location).
+    struct FaultyOutputEngine;
+
+    impl ExecutionEngine for FaultyOutputEngine {
+        fn name(&self) -> &str {
+            "faulty"
+        }
+        fn execute(
+            &self,
+            _input: &str,
+            _ctx: &ExecutionContext,
+        ) -> Result<crate::engine::ExecuteResult, crate::engine::ExecutionError> {
+            // Deliberately longer than the source document, so a span into
+            // this buffer lands past the end of the `.qmd` — the shape the
+            // strand reports.
+            let mut markdown = String::from("---\ntitle: Test\n---\n\n");
+            for _ in 0..40 {
+                markdown.push_str("Engine-produced filler paragraph.\n\n");
+            }
+            markdown.push_str("{{< fa envelope size=1x >}}\n");
+            Ok(crate::engine::ExecuteResult::new(markdown))
+        }
+        fn is_available(&self) -> bool {
+            true
+        }
+        fn claims_language(
+            &self,
+            language: &str,
+            _first_class: Option<&str>,
+        ) -> crate::engine::LanguageClaim {
+            if language == "faulty" {
+                crate::engine::LanguageClaim::Primary(1)
+            } else {
+                crate::engine::LanguageClaim::None
+            }
+        }
+    }
+
+    fn faulty_engine_context(input: &str) -> StageContext {
+        use crate::format::Format;
+        use crate::project::{DocumentInfo, ProjectContext};
+
+        let mut reg = EngineRegistry::new();
+        reg.register(Arc::new(FaultyOutputEngine));
+
+        let project = ProjectContext {
+            dir: PathBuf::from("/project"),
+            registry: Arc::new(reg),
+            is_single_file: true,
+            output_dir: PathBuf::from("/project"),
+            ..Default::default()
+        };
+        StageContext::new(
+            Arc::new(MockRuntime),
+            Format::html(),
+            project,
+            DocumentInfo::from_path(input),
+        )
+        .unwrap()
+    }
+
+    /// The failure must arrive as `PipelineError::Structured`, carrying a
+    /// `SourceContext` in which the diagnostic's span resolves.
+    #[tokio::test]
+    async fn engine_output_parse_error_carries_its_own_source_context() {
+        let stage = EngineExecutionStage::new();
+        let mut ctx = faulty_engine_context("/project/test.qmd");
+
+        let content = b"---\ntitle: Test\n---\n\n```{faulty}\nx\n```\n";
+        let doc_ast = parse_qmd_to_ast(content, "/project/test.qmd");
+
+        let err = stage
+            .run(PipelineData::DocumentAst(doc_ast), &mut ctx)
+            .await
+            .expect_err("engine output has an unparseable shortcode");
+
+        let PipelineError::Structured(parse_error) = err else {
+            panic!("expected PipelineError::Structured, got {:?}", err);
+        };
+
+        let diagnostic = parse_error
+            .diagnostics
+            .first()
+            .expect("a parse diagnostic should be present");
+        let location = diagnostic
+            .location
+            .as_ref()
+            .expect("the parse diagnostic should carry a span");
+
+        // The span must resolve to a real file in the attached context.
+        // `map_offset` takes an offset *relative* to the SourceInfo, so 0 is
+        // the start of the span — this is the same call the ariadne renderer
+        // makes to decide whether it can draw a frame at all.
+        let mapped = location
+            .map_offset(0, &parse_error.source_context)
+            .expect("span must resolve in the attached source context");
+        let file = parse_error
+            .source_context
+            .get_file(mapped.file_id)
+            .expect("resolved file id must exist in the attached context");
+
+        assert_eq!(
+            file.path, "/project/test.faulty.rmarkdown",
+            "the span belongs to the engine intermediate, so that is what \
+             must be named"
+        );
+    }
+
+    /// The registered content must be the *engine output*, and the span must
+    /// fall inside it. This is the assertion that fails loudly for the
+    /// wrong-frame face of the bug: binding these offsets to the original
+    /// `.qmd` puts them past its end (or, for a long document, over
+    /// unrelated text).
+    #[tokio::test]
+    async fn engine_output_parse_error_span_is_in_range_for_engine_output() {
+        let stage = EngineExecutionStage::new();
+        let mut ctx = faulty_engine_context("/project/test.qmd");
+
+        let content = b"---\ntitle: Test\n---\n\n```{faulty}\nx\n```\n";
+        let doc_ast = parse_qmd_to_ast(content, "/project/test.qmd");
+
+        let err = stage
+            .run(PipelineData::DocumentAst(doc_ast), &mut ctx)
+            .await
+            .expect_err("engine output has an unparseable shortcode");
+
+        let PipelineError::Structured(parse_error) = err else {
+            panic!("expected PipelineError::Structured, got {:?}", err);
+        };
+
+        let diagnostic = &parse_error.diagnostics[0];
+        let location = diagnostic.location.as_ref().unwrap();
+        let mapped = location.map_offset(0, &parse_error.source_context).unwrap();
+        let file = parse_error.source_context.get_file(mapped.file_id).unwrap();
+        let registered = file
+            .content
+            .as_ref()
+            .expect("the intermediate must be registered WITH its content");
+
+        assert!(
+            registered.contains("Engine-produced filler paragraph."),
+            "registered content must be the engine output, not the source \
+             document"
+        );
+        assert!(
+            location.start_offset() < registered.len(),
+            "span offset {} must fall inside the {}-byte engine output",
+            location.start_offset(),
+            registered.len()
+        );
+        assert!(
+            location.start_offset() >= content.len(),
+            "sanity: this span is past the end of the {}-byte source \
+             document, which is exactly why binding it there loses the frame",
+            content.len()
+        );
     }
 
     #[test]

--- a/crates/quarto/src/commands/render.rs
+++ b/crates/quarto/src/commands/render.rs
@@ -1307,6 +1307,75 @@ fn render_diagnostic_guarded<T>(
     }
 }
 
+/// The path to name in a `while rendering <file>` line for a failed page,
+/// or `None` when the rendered diagnostic already names it.
+///
+/// bd-render-failure-unattributed-yxe0v7th. A failed page is rendered by
+/// [`CoalescedDiagnostic::to_text`], which names files *only* through the
+/// diagnostic's own span — and deliberately omits the `Affected files:` tail
+/// for singleton groups. So a page can die without the transcript containing
+/// its name anywhere. Two ways that happens:
+///
+/// - **The span does not resolve.** Either the diagnostic carries no location
+///   (an engine execution failure — `Error: Execution failed in knitr: R
+///   process failed`), or it is bound to a buffer whose length it exceeds. The
+///   ariadne renderer bails, *and* `to_text`'s `at <file>:<row>:<col>` fallback
+///   is skipped along with it, leaving a bare title and problem statement.
+/// - **The span resolves to a different file.** Engine-output parse errors
+///   legitimately point into `<stem>.<engine>.rmarkdown`, not the `.qmd` the
+///   author wrote. The frame is correct and worth showing, but on its own it
+///   never tells the author which page to open.
+///
+/// Returns `None` for the ordinary case — a span resolving to the page being
+/// rendered — so well-attributed output stays byte-identical. Also `None` for
+/// multi-file groups, which already list their pages in the `Affected files:`
+/// tail.
+///
+/// The resolution performed here mirrors `render_ariadne_source_context`:
+/// root file id, then `map_offset(0, ctx)` (a *relative* offset — 0 is the
+/// start of the span). If that pair succeeds, a frame renders; if it fails,
+/// nothing does.
+fn failure_attribution_line(group: &quarto_error_reporting::CoalescedDiagnostic) -> Option<String> {
+    // A multi-file group prints an `Affected files:` tail already.
+    if group.affected_files.len() != 1 {
+        return None;
+    }
+    let input = group.affected_files.first()?;
+
+    // Mirror `to_text_with_renderer`'s choice of location: the main one, else
+    // the first located detail.
+    let location = group.representative.location.as_ref().or_else(|| {
+        group
+            .representative
+            .details
+            .iter()
+            .find_map(|d| d.location.as_ref())
+    });
+
+    let named = location
+        .zip(group.source_context.as_ref())
+        .and_then(|(loc, ctx)| {
+            // Both must succeed for a frame to render.
+            loc.map_offset(0, ctx)?;
+            let file = ctx.get_file(loc.root_file_id()?)?;
+            Some(file.path.clone())
+        });
+
+    // Compare on forward-slashed strings, not raw `Path`s. Registered paths
+    // reach the source context in mixed conventions — the engine intermediate
+    // is normalized through `quarto_util::to_forward_slashes`, while
+    // `FileFailure.input` is a native `PathBuf`. On Windows a raw comparison
+    // would never match, so every ordinary parse error would sprout a
+    // redundant attribution line there and nowhere else.
+    let input_key = quarto_util::to_forward_slashes(input);
+    match named {
+        // The frame names the very page that failed — nothing to add.
+        Some(path) if path.replace('\\', "/") == input_key => None,
+        // Resolves elsewhere (an engine intermediate), or not at all.
+        _ => Some(input.display().to_string()),
+    }
+}
+
 fn print_render_diagnostics_text(
     summary: &quarto_core::project::orchestrator::ProjectRenderSummary,
     quiet: bool,
@@ -1347,6 +1416,12 @@ fn print_render_diagnostics_text(
         for group in coalesce_by_source(entries) {
             let code = group.representative.code.as_deref();
             if let Some(text) = render_diagnostic_guarded(code, || group.to_text()) {
+                // bd-render-failure-unattributed-yxe0v7th: guarantee the
+                // failing page is named even when the diagnostic's own span
+                // cannot do it (or names an engine intermediate instead).
+                if let Some(path) = failure_attribution_line(&group) {
+                    eprintln!("error: while rendering {}", path);
+                }
                 eprintln!("{}", text);
             }
         }
@@ -1705,6 +1780,141 @@ fn emit_json_line<T: serde::Serialize>(value: &T) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use quarto_error_reporting::DiagnosticMessageBuilder;
+    use quarto_error_reporting::coalesce::CoalescedDiagnostic;
+    use quarto_source_map::SourceContext;
+
+    /// bd-render-failure-unattributed-yxe0v7th.
+    ///
+    /// `print_render_diagnostics_text` names the failing file only for
+    /// `legacy_failures` (failures with no structured diagnostics). Every
+    /// other failure is rendered by `CoalescedDiagnostic::to_text()`, which
+    /// relies entirely on the diagnostic's own span — and deliberately omits
+    /// the `Affected files:` tail for singleton groups. So when the span
+    /// cannot be resolved, or resolves to a file that is *not* the document
+    /// being rendered (an engine intermediate), the known-good
+    /// `FileFailure.input` is discarded and nothing names the page.
+    ///
+    /// These tests pin `failure_attribution_line`, the predicate that
+    /// decides when to restore it.
+    fn group(
+        diagnostic: quarto_error_reporting::DiagnosticMessage,
+        ctx: Option<SourceContext>,
+        files: &[&str],
+    ) -> CoalescedDiagnostic {
+        CoalescedDiagnostic {
+            representative: diagnostic,
+            source_context: ctx,
+            affected_files: files.iter().map(PathBuf::from).collect(),
+        }
+    }
+
+    fn located_in(
+        path: &str,
+        content: &str,
+        offset: usize,
+    ) -> (quarto_error_reporting::DiagnosticMessage, SourceContext) {
+        let mut ctx = SourceContext::new();
+        let id = ctx.add_file(path.to_string(), Some(content.to_string()));
+        let info = quarto_source_map::SourceInfo::from_range(
+            id,
+            quarto_source_map::Range {
+                start: quarto_source_map::Location {
+                    offset,
+                    row: 0,
+                    column: offset,
+                },
+                end: quarto_source_map::Location {
+                    offset: offset + 1,
+                    row: 0,
+                    column: offset + 1,
+                },
+            },
+        );
+        let diag = DiagnosticMessageBuilder::error("Boom")
+            .with_location(info)
+            .build();
+        (diag, ctx)
+    }
+
+    /// A diagnostic with no location at all (shape 2: the knitr
+    /// execution failure, `location: None`). Nothing in the rendered text
+    /// can name the page, so the attribution line must be supplied.
+    #[test]
+    fn attribution_added_for_location_less_diagnostic() {
+        let diag =
+            DiagnosticMessageBuilder::error("Execution failed in knitr: R process failed").build();
+        let g = group(diag, None, &["/project/failing.qmd"]);
+
+        assert_eq!(
+            failure_attribution_line(&g).as_deref(),
+            Some("/project/failing.qmd"),
+        );
+    }
+
+    /// A diagnostic whose span resolves to the very file being rendered —
+    /// the ordinary parse error. The ariadne frame already names it, so no
+    /// extra line (existing output and its snapshots stay byte-identical).
+    #[test]
+    fn attribution_omitted_when_frame_already_names_the_file() {
+        let (diag, ctx) = located_in("/project/bad.qmd", "hello world\n", 3);
+        let g = group(diag, Some(ctx), &["/project/bad.qmd"]);
+
+        assert_eq!(failure_attribution_line(&g), None);
+    }
+
+    /// Shape 1 after the engine-execution fix: the span legitimately
+    /// resolves, but to the engine's `.rmarkdown` intermediate rather than
+    /// the `.qmd` the user wrote. The frame is correct and useful, but the
+    /// user still needs to be told which page died.
+    #[test]
+    fn attribution_added_when_frame_names_an_engine_intermediate() {
+        let (diag, ctx) = located_in("/project/knit.knitr.rmarkdown", "{{< fa size=1x >}}\n", 3);
+        let g = group(diag, Some(ctx), &["/project/knit.qmd"]);
+
+        assert_eq!(
+            failure_attribution_line(&g).as_deref(),
+            Some("/project/knit.qmd"),
+        );
+    }
+
+    /// A span pointing past the end of the file it is bound to does not
+    /// resolve, so no frame renders — the exact silent-failure shape the
+    /// strand reports. Attribution must be supplied.
+    #[test]
+    fn attribution_added_when_span_does_not_resolve() {
+        let (diag, ctx) = located_in("/project/knit.qmd", "short\n", 4716);
+        let g = group(diag, Some(ctx), &["/project/knit.qmd"]);
+
+        assert_eq!(
+            failure_attribution_line(&g).as_deref(),
+            Some("/project/knit.qmd"),
+        );
+    }
+
+    /// Registered paths reach the source context in mixed separator
+    /// conventions — the engine intermediate is normalized through
+    /// `to_forward_slashes`, while `FileFailure.input` stays a native
+    /// `PathBuf`. Matching must survive that, or on Windows every ordinary
+    /// parse error would gain a redundant attribution line.
+    #[test]
+    fn attribution_matching_is_separator_insensitive() {
+        let (diag, ctx) = located_in("C:/project/bad.qmd", "hello world\n", 3);
+        let g = group(diag, Some(ctx), &[r"C:\project\bad.qmd"]);
+
+        assert_eq!(failure_attribution_line(&g), None);
+    }
+
+    /// A multi-file group already lists its pages in the `Affected files:`
+    /// tail, so it needs no additional attribution line.
+    #[test]
+    fn attribution_omitted_for_multi_file_group() {
+        let diag = DiagnosticMessageBuilder::error("Shared problem").build();
+        let g = group(diag, None, &["/project/a.qmd", "/project/b.qmd"]);
+
+        assert_eq!(failure_attribution_line(&g), None);
+    }
     use quarto_core::FormatIdentifier;
     use quarto_system_runtime::NativeRuntime;
     use std::sync::Arc;

--- a/crates/quarto/tests/integration/coalesced_diagnostics.rs
+++ b/crates/quarto/tests/integration/coalesced_diagnostics.rs
@@ -38,7 +38,7 @@ fn write_file(path: &Path, contents: &str) {
 /// Strip ANSI escape sequences (CSI color codes and OSC-8 hyperlinks)
 /// so assertions can match the plain text of ariadne-rendered
 /// snippets, which interleave color codes inside highlighted spans.
-fn strip_ansi(s: &str) -> String {
+pub fn strip_ansi(s: &str) -> String {
     let mut out = String::new();
     let mut chars = s.chars();
     while let Some(c) = chars.next() {

--- a/crates/quarto/tests/integration/render_cli_e2e.rs
+++ b/crates/quarto/tests/integration/render_cli_e2e.rs
@@ -999,3 +999,121 @@ fn render_preserves_source_image_and_copies_to_site() {
         "rendered HTML must reference elephant.png; html:\n{html}",
     );
 }
+
+// ====================================================================
+// bd-render-failure-unattributed-yxe0v7th — a failed page must name
+// itself.
+//
+// Both tests are gated on a real R + knitr toolchain, following the
+// `rscript_available()` / `knitr_r_package_available()` pattern in
+// `quarto-core/tests/integration/marimo_engine_e2e.rs`. A skip here is
+// an environment signal, not a pass.
+// ====================================================================
+
+/// `true` when `Rscript` is on PATH.
+fn rscript_available() -> bool {
+    Command::new("Rscript")
+        .arg("--version")
+        .output()
+        .is_ok_and(|o| o.status.success())
+}
+
+/// `true` when the R `knitr` package is installed. Checked separately
+/// from [`rscript_available`] — `KnitrEngine::is_available()` only looks
+/// for the binary, not the package.
+fn knitr_r_package_available() -> bool {
+    Command::new("Rscript")
+        .args([
+            "-e",
+            "if (!requireNamespace(\"knitr\", quietly = TRUE)) quit(status = 1)",
+        ])
+        .output()
+        .is_ok_and(|o| o.status.success())
+}
+
+/// Shape 1. A chunk that *executes successfully* but emits markdown q2
+/// cannot parse. The parse runs against knitr's output buffer, so the
+/// diagnostic's span indexes into the intermediate — not the `.qmd`.
+///
+/// Before the fix, `run_pipeline`'s generic `StageError` conversion
+/// rebound that span to the source document's bytes. The engine output is
+/// far larger than this 5-line source, so the offset landed past EOF, the
+/// ariadne renderer bailed, *and* its `at <file>:<row>:<col>` fallback was
+/// skipped with it: the page died with a bare title and problem statement
+/// and its name appeared nowhere in the transcript.
+///
+/// Two independent guarantees are asserted: the frame renders against the
+/// engine intermediate (Fix A, `engine_execution.rs`), and the `.qmd` is
+/// named anyway (Fix B, `failure_attribution_line`).
+#[test]
+fn engine_output_parse_failure_names_the_qmd() {
+    if !rscript_available() || !knitr_r_package_available() {
+        eprintln!("skipping: R toolchain with knitr not available");
+        return;
+    }
+
+    let tmp = TempDir::new().unwrap();
+    let dir = tmp.path();
+    write_file(&dir.join("_quarto.yml"), "project:\n  type: default\n");
+    write_file(
+        &dir.join("boom.qmd"),
+        "---\ntitle: Boom\n---\n\n```{r}\n#| output: asis\ncat(\"{{< fa envelope size=1x >}}\\n\")\n```\n",
+    );
+
+    let out = run_q2(dir, &[]);
+    // ariadne interleaves color codes *inside* highlighted spans, so the
+    // offending source line is not a contiguous substring of raw stderr.
+    let stderr = crate::coalesced_diagnostics::strip_ansi(&String::from_utf8_lossy(&out.stderr));
+
+    assert!(
+        stderr.contains("boom.qmd"),
+        "a failed page must name itself; stderr was:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("while rendering"),
+        "the span resolves to the engine intermediate, so the attribution \
+         line is what supplies the .qmd name; stderr was:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("size=1x"),
+        "the frame must show the offending source line from the engine \
+         output; stderr was:\n{stderr}"
+    );
+}
+
+/// Shape 2. A chunk that calls `stop()`. The engine failure carries no
+/// span at all (`location: None`), so nothing in the diagnostic can name
+/// the page — before the fix, `print_render_diagnostics_text` discarded
+/// the known-good `FileFailure.input` and printed a bare
+/// `Error: Execution failed in knitr: R process failed`.
+///
+/// Note this asserts attribution only. Remapping knitr's traceback line
+/// numbers (`failing.rmarkdown:NNN`) back to `.qmd` lines is deliberately
+/// out of scope; see the plan doc.
+#[test]
+fn engine_execution_failure_names_the_qmd() {
+    if !rscript_available() || !knitr_r_package_available() {
+        eprintln!("skipping: R toolchain with knitr not available");
+        return;
+    }
+
+    let tmp = TempDir::new().unwrap();
+    let dir = tmp.path();
+    write_file(&dir.join("_quarto.yml"), "project:\n  type: default\n");
+    write_file(
+        &dir.join("failing.qmd"),
+        "---\ntitle: Failing\n---\n\n```{r}\nstop(\"boom: this chunk always fails\")\n```\n",
+    );
+
+    let out = run_q2(dir, &[]);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+
+    assert!(
+        stderr.contains("while rendering"),
+        "a span-less engine failure must still be attributed; stderr was:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("failing.qmd"),
+        "the .qmd name must appear in the transcript; stderr was:\n{stderr}"
+    );
+}


### PR DESCRIPTION
A failed page now always names itself.

Two independent defects meant a page could die during a project render with the
`.qmd` name absent from the entire transcript, and — in one case — with a
confident diagnostic pointing at the wrong place.

## Engine-output parse errors are rendered against the wrong buffer

`EngineExecutionStage` parses the engine's executed markdown, so the resulting
diagnostic spans index into `result.markdown` — knitr's `.knit.md`, not the
author's `.qmd`. On success the stage registers that buffer as its own
`SourceContext` slot and remaps `FileId(0)` into it. On failure it returned a
bare `StageError`, dropping the context:

```rust
.map_err(|diagnostics| {
    PipelineError::stage_error_with_diagnostics(self.name(), diagnostics)
})?;
```

`run_pipeline`'s generic `StageError → QuartoError::Parse` conversion then
synthesizes a `SourceContext` from the *original document's* bytes and binds the
engine-output spans to it. For a 106-byte `knit.qmd` whose R chunk emits a bad
shortcode, that is a span at offset 4716 bound to a 106-byte buffer.

What the user saw depended on where the offset landed, and both outcomes were
bad.

**Past EOF** — the usual case, since engine output is much larger than its
source. `map_offset` fails, so ariadne renders nothing. The
`at <file>:<row>:<col>` fallback in `to_text_with_renderer` needs the same
resolution, so it is skipped too, and the file name goes with it:

```
Error [Q-2-34]: Unquoted shortcode parameter starting with digit
Shortcode parameter values starting with digits must be quoted.
```

**Inside the source file** — when the `.qmd` is long enough to contain the
offset. The error is then reported with a full frame at an unrelated location.
On a 14576-byte document this pointed at `big.qmd:68:100`, the letter `e` in a
filler paragraph with no shortcode anywhere near it. Nothing distinguishes that
from a real diagnostic.

This is the failure mode the `add-file-with-id` lint rule exists to prevent
(bd-m6wmztln): binding an assumed file to a diagnostic's resolved id renders
byte offsets against text they don't belong to.

The stage now binds those spans to the buffer they actually index and returns
`PipelineError::Structured`, which `run_pipeline` forwards untouched.

## The render summary drops the failing file's name

`print_render_diagnostics_text` prints `error: {input}: {error}` only for
`legacy_failures` — failures carrying no structured diagnostics. Everything else
goes through `coalesce_by_source`, and `CoalescedDiagnostic::to_text()` names
files purely through the diagnostic's own span, deliberately omitting the
`Affected files:` tail for single-file groups. So `FileFailure.input` — a
known-good path, sitting right there — was discarded, and a span-less diagnostic
printed with no file name at all:

```
Error: Execution failed in knitr: R process failed
```

`--json-errors` was never affected; it reads `input` structurally as
`source_file`. Only the text path lost it.

`failure_attribution_line` restores it. It asks whether the text about to be
printed names the page that failed, resolving the span the same way
`render_ariadne_source_context` does (`root_file_id`, then `map_offset(0, ctx)`),
and prefixes `error: while rendering <path>` when the answer is no. That covers
unresolvable spans and spans resolving to a file other than the one being
rendered. An ordinary parse error resolves to its own `.qmd`, so existing output
is byte-identical and no snapshots change. Path matching is separator-insensitive:
the intermediate goes through `to_forward_slashes` while `FileFailure.input`
stays native, so a raw `Path` comparison would miss on Windows and add a
redundant line to every parse error there.

## Result

```
error: while rendering /…/knit.qmd
Error: [Q-2-34] Unquoted shortcode parameter starting with digit
     ╭─[ /…/knit.knitr.rmarkdown:138:23 ]
     │
 138 │ {{< fa envelope size=1x >}}
     │                       ┬
     │                       ╰── Shortcode parameter values starting with digits must be quoted.
─────╯
```

Both the page and the offending line are named, and the frame shows real text
from the buffer the error came from.

The motivating case was `download.qmd` in the Positron docs port — one of four
pages still failing to render there, and the most linked-to page on the site
(83 of 89 rendered pages reference `download.html`). With no file name in the
output it was read as a freeze problem for several days.

## Not addressed

Line numbers still refer to the engine intermediate rather than the source.
knitr's traceback continues to say `failing.rmarkdown:133-135`, and the frame
above is anchored at `knit.knitr.rmarkdown:138`. For content the engine
*generated* there is no `.qmd` line to point at, but for content it merely
passed through — a shortcode the author typed — the reported line is unhelpful.
Fixing it needs a line map from the serialized intermediate plus per-engine
stderr parsing. Tracked as **bd-1ng2ivis**; `serialize_ast_to_qmd` already
computes a `SourceInfo` that may be most of the raw material.

`crates/quarto-core/src/engine/preview_record.rs:241` uses the same
`stage_error_with_diagnostics` shape and may share the defect. It feeds
q2-preview rather than the CLI summary and is unexamined here.
`serialize_ast_to_qmd`, the other sibling site, is fine — its spans index the
original AST's source, so the generic conversion binds them correctly.

## Testing

Ten new tests. Two drive `EngineExecutionStage` with a fake `ExecutionEngine`
that emits unparseable markdown, asserting the error carries a context in which
the span resolves, and that the span falls inside the engine output rather than
past the end of the source. Six cover `failure_attribution_line` directly:
location-less diagnostics, spans resolving to the failing page, spans resolving
to an engine intermediate, spans past EOF, multi-file groups, and mixed path
separators. Two exercise the real binary end to end, gated on `Rscript` plus the
`knitr` package following the pattern in `marimo_engine_e2e.rs`.

Workspace: 13140 passed, 199 skipped, against a baseline of 13130. The
baseline's single failure, `quarto-core
engine::ts_engine::tests::test_race_free_instance_exclusive`, is a pre-existing
flake — it times out at 15s under full contention and passes in 0.3s alone.

Closes bd-render-failure-unattributed-yxe0v7th.
