### PR TITLE
Assert q2 preview and q2 render produce the same article-body DOM (bd-xa4vv9tt)

### DIFF
--- a/.claude/skills/preview-render-parity/SKILL.md
+++ b/.claude/skills/preview-render-parity/SKILL.md
@@ -41,6 +41,17 @@ User says any of:
 
 ## Diagnosis workflow
 
+### 0. Reproduce with the harness first
+
+Before opening Chrome, try to reproduce the divergence with the automated parity runner — it's faster to iterate on and gives you a normalised text diff instead of manual DOM inspection:
+
+1. Write a minimal fixture under `crates/quarto/tests/smoke-all/q2-preview/` (or find an existing one that already shows the symptom).
+2. Add `dom-parity: true` under its `_quarto.tests.html` block.
+3. Run it in isolation: `cd hub-client && SMOKE_FILTER=<fixture-name> npm run test:wasm -- --reporter=verbose`.
+4. Read the normalised output at `hub-client/test-results/parity/<fixture-path-with-__>/{render,preview}.norm.txt` — the diff between these two files usually points straight at the divergent tag/attribute/class.
+
+Reach for Chrome (steps 1-6 below) only when the symptom is a **computed-style** mismatch (margins, colors, layout) that the harness's DOM-only comparison can't see, or when the harness can't reproduce it at all. See `claude-notes/instructions/testing.md` § "4. Preview ↔ render DOM parity" for the runner's full contract (normalisation rules, opt-in policy, known open divergences).
+
 ### 1. Locate the element on both pages
 
 Open both URLs in Chrome via the MCP. Use `mcp__plugin_chrome-devtools-mcp_chrome-devtools__select_page` to switch between them.
@@ -137,7 +148,7 @@ Pipeline stages: `crates/quarto-core/src/stage/stages/<stage>.rs` + the q2-previ
 ```bash
 braid create "q2 preview: <one-line symptom>" \
   -t bug -p 2 \
-  --deps "parent-child:bd-kw93" \
+  -l preview-parity \
   -d "$(cat <<EOF
 <symptom — what the user sees>
 
@@ -151,12 +162,14 @@ EOF
 )"
 # braid prints the new strand id on stdout. Capture it as <id>.
 braid update <id> --status in_progress
-git switch -c braid/<id>-<short-slug>
+git switch -c braid/<id>-<short-slug> main
 ```
 
-bd-kw93 is the q2-preview epic; every parity sub-strand is parent-child to it. (The git branch prefix is `braid/` — a plain git namespace, renamed from the historical `beads/` in bd-yjh1y117.)
+Parity strands branch off `main` directly and carry the `preview-parity` label (no parent-child epic dependency — the former parent epic, bd-kw93, is closed and its branch merged via PR #214). (The git branch prefix is `braid/` — a plain git namespace, renamed from the historical `beads/` in bd-yjh1y117.)
 
 ### Write the failing test FIRST
+
+**Prefer the parity harness's `dom-parity: true` opt-in as the regression test** whenever the fixture from step 0 can be made minimal — it exercises the real render and preview pipelines end-to-end (not a hand-mounted AST fragment) and stays green forever once the fix lands, with no separate assertion to keep in sync. Add/reuse the fixture under `crates/quarto/tests/smoke-all/q2-preview/`, confirm it fails RED before the fix (the parity diff should name the divergent tag/attribute/class), then implement. Fall back to one of the three surfaces below only when the symptom can't be captured as a minimal fixture (e.g. it needs SPA-level state, or a pipeline-stage inclusion check with no DOM to compare).
 
 Three test surfaces, pick the right one:
 
@@ -220,15 +233,12 @@ braid close <id> --reason "Fixed: <one-line>"
 git add <component> <test>
 git commit -m "...(bd-<id>)"
 
-# Merge --no-ff into the integration branch
-git switch feature/q2-preview-command
-git merge --no-ff braid/<id>-<slug> -m "Merge bd-<id>: <one-line>"
-
-# Push (only after explicit user OK, per CLAUDE.md GIT PUSH POLICY)
-git push origin feature/q2-preview-command
+# Push (only after explicit user OK, per CLAUDE.md GIT PUSH POLICY) and open a PR
+# against main — no integration branch to merge into (see worktrees.md § Pushing for PR)
+git push -u origin braid/<id>-<slug>:feature/<id>-<slug>
 ```
 
-**Commit-message style** (per repo convention — read `git log -5 --pretty=format:"%h %s%n%b%n---"` on `feature/q2-preview-command` if in doubt):
+**Commit-message style** (per repo convention — read `git log -5 --pretty=format:"%h %s%n%b%n---"` on `main` if in doubt):
 
 - Title with bd-id: `<imperative one-line summary> (bd-<id>)`.
 - Body: user-visible symptom → root cause (cite native-writer file:line) → fix → verification recipe (include test counts + the `cargo xtask verify N/N green` line + a DOM-snippet from the live browser).
@@ -273,7 +283,7 @@ If diagnosis surfaces a second divergence in the same area, **file a sibling bra
 
 ## Cross-references
 
-- Parent epic: `bd-kw93` — q2 preview.
+- Former parent epic (closed, merged via PR #214): `bd-kw93` — q2 preview. Parity strands no longer depend on it; they branch off `main` and carry the `preview-parity` label.
 - Capture-splice design (separate scope): `claude-notes/plans/2026-05-18-q2-preview-project-replay-engine.md`.
 - Phase F (chrome-rendering parity): `claude-notes/plans/2026-05-14-q2-preview-phase-f.md`.
 - Native HTML writer: `crates/pampa/src/writers/html.rs`. Read this. Often.

--- a/claude-notes/instructions/testing.md
+++ b/claude-notes/instructions/testing.md
@@ -113,11 +113,11 @@ Examples in this repo:
 
 ## Smoke-All Tests
 
-Smoke-all test fixtures live in `crates/quarto/tests/smoke-all/`. Each `.qmd` file embeds assertions in `_quarto.tests` frontmatter. There are **three independent runners** that exercise the same fixtures through different pipelines:
+Smoke-all test fixtures live in `crates/quarto/tests/smoke-all/`. Each `.qmd` file embeds assertions in `_quarto.tests` frontmatter. There are **four independent runners** that exercise the same fixtures through different pipelines:
 
 ### 1. Rust (native renderer)
 ```bash
-cargo nextest run -p quarto --test smoke_all
+cargo nextest run -p quarto --test integration smoke_all
 ```
 Fastest (~1s). Renders via `quarto-core` directly. Runs all assertion types including `ensureHtmlElements` (CSS selectors via `scraper`), `ensureCssRegexMatches`, `ensureFileRegexMatches`, etc.
 
@@ -129,9 +129,9 @@ cd hub-client && npm run test:wasm
 
 ### 3. Playwright E2E (browser)
 ```bash
-cd hub-client && npx playwright test e2e/smoke-all.spec.ts
+cd hub-client && npx playwright test --config=playwright.smoke-all.config.ts e2e/smoke-all.spec.ts
 ```
-~12s. Full pipeline: Automerge sync → hub server → browser → WASM render → preview iframe. Tests the complete hub-client integration.
+~12s. Full pipeline: Automerge sync → hub server → browser → WASM render → preview iframe. Tests the complete hub-client integration. (The base `playwright.config.ts`'s `testIgnore` excludes `smoke-all.spec.ts`, so the dedicated `playwright.smoke-all.config.ts` is required — a bare `npx playwright test e2e/smoke-all.spec.ts` silently runs zero tests.)
 
 **CRITICAL prerequisites for Playwright tests:**
 
@@ -158,6 +158,25 @@ The full e2e command handles the build automatically:
 ```bash
 cd hub-client && npm run test:e2e   # build:wasm + VITE_E2E=1 build + playwright
 ```
+
+### 4. Preview ↔ render DOM parity (WASM + jsdom)
+```bash
+cd hub-client && npm run test:wasm
+```
+Runs in the same `test:wasm` invocation as runner 2 (and therefore in `test:ci` → `cargo xtask verify` — no new CI wiring). For every fixture whose `_quarto.tests.html` carries `dom-parity: true`, renders it twice through the WASM module — `render_page_in_project` (native HTML writer) and `render_page_for_preview` (Pandoc AST, mounted read-only via `<Ast registry={previewRegistry}>` under jsdom) — and requires the canonical form of `main#quarto-document-content` to match on both sides. `SMOKE_FILTER=<substring>` narrows by fixture path, same env var as runner 2 — it also narrows the sibling smoke-all sweep in the same test file.
+
+Under vitest 4 the `Parity results: N compared, M failed, K opted in` summary and per-fixture timings only print for a failing test by default. To see them on a passing run, append `--reporter=verbose`:
+```bash
+cd hub-client && SMOKE_FILTER=simple-default npm run test:wasm -- --reporter=verbose
+```
+
+**Normalisation rules** (and their reasons) live in `ts-packages/preview-renderer/src/test-utils/domParity.ts`: `data-loc`/`data-sid` are stripped (source-tracking, preview-only); `span.math` children are treated opaque (KaTeX vs MathJax — divergent by design until bd-tmb2u5yu closes); `data-hl-spans` leaking to either side is a **hard failure**, never normalised away; attributes are sorted for comparison but class order is preserved; a `<div>` with no attribute surviving the strip list (`data-loc`/`data-sid`) is unwrapped on both sides (React's `RawBlock` needs a host element the native writer never emits); text inside `<pre>` compares verbatim, whitespace elsewhere is collapsed with an inline-neighbour edge rule.
+
+**Opt in** by adding `dom-parity: true` under `html:` in a fixture's `_quarto.tests` block (see the DSL reference below — all four runners accept the key, only this one acts on it). This is a curated allowlist with **no xfail list**: once a fixture opts in, a divergence fails the suite — fix it or remove the opt-in, never mark it expected-to-fail. On a mismatch, normalised text for both sides lands at `hub-client/test-results/parity/<rel-path-with-__-separators>/{render,preview}.norm.txt` (gitignored) for diffing.
+
+Fixtures containing math can't opt in until bd-tmb2u5yu (`Math.tsx` emits no `math inline|display` class) closes; tabsets have no React implementation yet; engine fixtures (jupyter/knitr) can't run under WASM at all. Known open divergences, each tracked by a strand labeled `preview-parity`: bd-294mbrcx (`Link` drops `role`/kv attrs), bd-q88zinyv (`OrderedList` omits `type="1"`), bd-qzwlhrlv (`Strikeout` renders `<s>` on one side, `<del>` on the other), bd-tmb2u5yu (`Math` class, see above). Each fix should end with `dom-parity: true` added to the fixture that reproduced it.
+
+See `.claude/skills/preview-render-parity/SKILL.md` for the diagnosis workflow and `claude-notes/plans/2026-08-24-preview-render-dom-parity-harness.md` for the design.
 
 ### Writing Fixtures
 
@@ -202,6 +221,7 @@ _quarto:
         - ["expected-pattern", "another-expected"]  # must match
         - ["should-not-appear"]                     # must NOT match
       noErrors: true
+      dom-parity: true                      # opt into runner 4 — see "Preview ↔ render DOM parity" above
 ```
 
 ### Running a Single Fixture

--- a/claude-notes/plans/2026-08-24-preview-render-dom-parity-harness.md
+++ b/claude-notes/plans/2026-08-24-preview-render-dom-parity-harness.md
@@ -24,7 +24,7 @@ with `prefer_preview_format: true` → pipeline stopped before
 `<Ast registry={previewRegistry}>` under jsdom, and compares the canonical form
 of `main#quarto-document-content` from both sides. Canonicalisation is a small
 pure module with an explicit, reasoned normalisation table. Fixtures opt in
-with `parity: true` under a format entry of the existing `_quarto: tests:` DSL.
+with `dom-dom-parity: true` under a format entry of the existing `_quarto: tests:` DSL.
 
 **Tech Stack:** vitest 4 (jsdom env via docblock, hub-client
 `vitest.wasm.config.ts`), `wasm-quarto-hub-client`, `@testing-library/react`,
@@ -48,7 +48,7 @@ there is no separate spec document.
 - **HTML article body only.** Comparison root is `main#quarto-document-content`.
   revealjs, tabsets, engine fixtures, math *content*, and hub-client-only
   chrome are non-goals (§ Non-goals).
-- **Curated allowlist, not xfail.** Only fixtures with `parity: true` are
+- **Curated allowlist, not xfail.** Only fixtures with `dom-dom-parity: true` are
   compared; an opted-in fixture that diverges fails the suite. There is no
   expected-failure mechanism — fix the divergence or don't opt in. (Accepted
   cost: a fixture that *finds* a bug carries no regression guard until the
@@ -168,9 +168,9 @@ must mirror that placement.
 | `hub-client/src/test-utils/smokeAllFixtures.ts` | Fixture discovery, front-matter reading, `_quarto.tests` block access, skip logic, project-root discovery, VFS population, user-grammar handle, WASM loader — **extracted** from `smokeAll.wasm.test.ts`, which then imports it. Under `test-utils/` so its Node-builtin imports stay out of the app tsconfig. |
 | `hub-client/src/services/smokeAllParity.wasm.test.tsx` | The runner: per opted-in fixture, render both ways, mount, compare, report. Plus the "harness catches an injected divergence" self-test. `.tsx` because it mounts JSX. |
 | `hub-client/vitest.wasm.config.ts` | `include` widened to `*.wasm.test.{ts,tsx}`. |
-| `crates/quarto-test/src/spec.rs` | Accept `parity` key into `TestSpec.parity: bool` (runner ignores it). |
-| `hub-client/src/services/smokeAll.wasm.test.ts`, `hub-client/e2e/helpers/smokeAllDiscovery.ts` | Accept and ignore `parity`. |
-| Opted-in fixtures under `crates/quarto/tests/smoke-all/` | `parity: true` added under `html:`. |
+| `crates/quarto-test/src/spec.rs` | Accept `dom-parity` key into `TestSpec.dom_parity: bool` (runner ignores it). |
+| `hub-client/src/services/smokeAll.wasm.test.ts`, `hub-client/e2e/helpers/smokeAllDiscovery.ts` | Accept and ignore `dom-parity`. |
+| Opted-in fixtures under `crates/quarto/tests/smoke-all/` | `dom-dom-parity: true` added under `html:`. |
 | `claude-notes/instructions/testing.md`, `.claude/skills/preview-render-parity/SKILL.md` | Document the fourth runner and the harness-first workflow. |
 
 ### Normalisation rules (`PARITY_RULES` + the canonical serialiser)
@@ -257,9 +257,9 @@ sibling's 120 s hang-detection timeout, `vitest.wasm.config.ts`).
 - [x] 1.2 `PARITY_RULES` — strip list, opaque `span.math`, forbidden `data-hl-spans`
 - [x] 1.3 `extractParityRoot` + `compareParity`
 
-### Phase 2 — `parity:` DSL key
-- [x] 2.1 Rust `quarto-test`: parse into `TestSpec.parity`, runner ignores
-- [x] 2.2 Both TS parsers (WASM sibling, Playwright discovery) ignore `parity`; Phase-2 boundary workspace nextest
+### Phase 2 — `dom-parity:` DSL key
+- [x] 2.1 Rust `quarto-test`: parse into `TestSpec.dom_parity`, runner ignores
+- [x] 2.2 Both TS parsers (WASM sibling, Playwright discovery) ignore `dom-parity`; Phase-2 boundary workspace nextest
 
 ### Phase 3 — Runner
 - [x] 3.1 `smokeAllParity.wasm.test.tsx` + first opt-in in one green commit
@@ -412,7 +412,7 @@ function parseTestSpecs(metadata: Record<string, unknown>, options: ParseOptions
 ```
 
 Call sites: `populateVfs(wasm, testFile)`, `buildUserGrammarsHandle(wasm, projectFiles)`.
-Do **not** add a `parity` case yet — this task is behaviour-preserving;
+Do **not** add a `dom-parity` case yet — this task is behaviour-preserving;
 Task 2.2 does that.
 
 - [x] **Step 4: Verify identical results**
@@ -1117,7 +1117,7 @@ git commit -m "Add parity root extraction and comparison"
 
 ---
 
-## Phase 2 — `parity:` DSL key
+## Phase 2 — `dom-parity:` DSL key
 
 ### Task 2.1: Rust `quarto-test` accepts `parity`
 
@@ -1129,7 +1129,7 @@ git commit -m "Add parity root extraction and comparison"
 
 **Interfaces:**
 - Consumes: `parse_test_specs(metadata: &Value, input_path: &Path) -> Result<(Option<RunConfig>, Vec<TestSpec>)>` (`spec.rs:139`) — note it returns a **tuple**.
-- Produces: `TestSpec.parity: bool` — `true` when the fixture opts into the
+- Produces: `TestSpec.dom_parity: bool` — `true` when the fixture opts into the
   preview↔render DOM parity runner. The native runner ignores it; the field
   exists so the DSL stays a single grammar across all four runners.
 
@@ -1144,14 +1144,14 @@ git commit -m "Add parity root extraction and comparison"
               tests:
                 html:
                   noErrors: true
-                  parity: true
+                  dom-parity: true
             "#,
         )
         .unwrap();
 
         let (_run, specs) = parse_test_specs(&yaml, std::path::Path::new("test.qmd")).unwrap();
         let html = specs.iter().find(|s| s.format == "html").expect("html spec");
-        assert!(html.parity, "parity: true must be recorded");
+        assert!(html.dom_parity, "dom-parity: true must be recorded");
         // Only noErrors produced an assertion; parity is not one.
         assert_eq!(html.assertions.len(), 1);
     }
@@ -1168,14 +1168,14 @@ git commit -m "Add parity root extraction and comparison"
         )
         .unwrap();
         let (_run, specs) = parse_test_specs(&yaml, std::path::Path::new("test.qmd")).unwrap();
-        assert!(!specs[0].parity);
+        assert!(!specs[0].dom_parity);
 
         let bad: Value = serde_yaml::from_str(
             r#"
             _quarto:
               tests:
                 html:
-                  parity: "yes"
+                  dom-parity: "yes"
             "#,
         )
         .unwrap();
@@ -1183,7 +1183,7 @@ git commit -m "Add parity root extraction and comparison"
             "{:#}",
             parse_test_specs(&bad, std::path::Path::new("test.qmd")).unwrap_err()
         );
-        assert!(err.contains("parity must be a boolean"), "got: {err}");
+        assert!(err.contains("dom-parity must be a boolean"), "got: {err}");
     }
 ```
 
@@ -1199,26 +1199,26 @@ Expected: compile error — no field `parity` on `TestSpec`.
 In `TestSpec` add:
 
 ```rust
-    /// `parity: true` — opt this format into the preview ↔ render DOM
+    /// `dom-dom-parity: true` — opt this format into the preview ↔ render DOM
     /// parity runner (`hub-client/src/services/smokeAllParity.wasm.test.tsx`).
     /// The native runner ignores it; the field exists so all four
     /// smoke-all runners share one DSL grammar. Plan:
     /// claude-notes/plans/2026-08-24-preview-render-dom-parity-harness.md
-    pub parity: bool,
+    pub dom_parity: bool,
 ```
 
-In `parse_format_spec`, add `let mut parity = false;` beside
+In `parse_format_spec`, add `let mut dom_parity = false;` beside
 `check_warnings`, a match arm before `other =>`:
 
 ```rust
-                "parity" => {
-                    parity = assertion_value
+                "dom-parity" => {
+                    dom_parity = assertion_value
                         .as_bool()
-                        .context("parity must be a boolean")?;
+                        .context("dom-parity must be a boolean")?;
                 }
 ```
 
-and `parity,` in the `Ok(TestSpec { … })` constructor at `:259`.
+and `dom_parity,` in the `Ok(TestSpec { … })` constructor at `:259`.
 
 - [x] **Step 4: Run to verify pass**
 
@@ -1236,7 +1236,7 @@ git add crates/quarto-test/src/spec.rs
 git commit -m "Accept a parity key in the smoke-all test DSL (native runner ignores it)"
 ```
 
-### Task 2.2: Both TS parsers ignore `parity`; Phase-2 boundary
+### Task 2.2: Both TS parsers ignore `dom-parity`; Phase-2 boundary
 
 **Files:**
 - Modify: `hub-client/src/services/smokeAll.wasm.test.ts` — `parseFormatSpec`,
@@ -1245,7 +1245,7 @@ git commit -m "Accept a parity key in the smoke-all test DSL (native runner igno
 - Modify: `hub-client/e2e/helpers/smokeAllDiscovery.ts:234-240` (the
   `fileExists` no-op group + `default: throw`)
 
-Both parsers hard-error on unknown keys, so a fixture with `parity: true`
+Both parsers hard-error on unknown keys, so a fixture with `dom-dom-parity: true`
 would break the WASM sweep and the Playwright sweep until this lands.
 
 - [x] **Step 1: Check for an existing unit test of either parser**
@@ -1257,8 +1257,8 @@ ls hub-client/e2e/helpers/*.test.ts 2>/dev/null; grep -rln "smokeAllDiscovery" h
 If a test file for `smokeAllDiscovery` exists, add there and watch it fail:
 
 ```ts
-it('accepts parity: true as a non-assertion', () => {
-  const { formatSpecs } = parseTestSpecs({ _quarto: { tests: { html: { noErrors: true, parity: true } } } });
+it('accepts dom-parity: true as a non-assertion', () => {
+  const { formatSpecs } = parseTestSpecs({ _quarto: { tests: { html: { noErrors: true, dom-parity: true } } } });
   expect(formatSpecs[0].assertions.map((a) => a.type)).toEqual(['noErrors']);
 });
 ```
@@ -1269,7 +1269,7 @@ plus `npx playwright test --config=playwright.smoke-all.config.ts e2e/smoke-all.
 - [x] **Step 2: Implement — same three lines in both files**
 
 ```ts
-        case 'parity':
+        case 'dom-parity':
           // Opt-in flag for the preview <-> render DOM parity runner
           // (hub-client/src/services/smokeAllParity.wasm.test.tsx). Not an
           // assertion here.
@@ -1311,7 +1311,7 @@ git commit -m "Ignore the parity key in the WASM and Playwright smoke-all parser
 - Create: `hub-client/src/services/smokeAllParity.wasm.test.tsx`
 - Modify: the first opt-in candidate from the Task 0.2 note:
   `crates/quarto/tests/smoke-all/title-block/simple-default.qmd` (byte-identical
-  under the rules even without the unwrap rule) — add `parity: true` under
+  under the rules even without the unwrap rule) — add `dom-dom-parity: true` under
   `_quarto.tests.html`. (`markdown/heading-auto-id.qmd`, the pre-spike guess,
   is blocked by c3 + c4 — see § Findings.)
 
@@ -1340,7 +1340,7 @@ is red.
  * Preview <-> render DOM parity runner (fourth smoke-all runner).
  *
  * For every smoke-all fixture whose `_quarto.tests.html` carries
- * `parity: true`, render it twice through the same WASM module:
+ * `dom-dom-parity: true`, render it twice through the same WASM module:
  *   - `render_page_in_project`   -> native HTML writer -> full page HTML
  *   - `render_page_for_preview`  -> the same Rust function with
  *                                   `prefer_preview_format: true`: pipeline
@@ -1462,7 +1462,7 @@ async function optedInFixtures(): Promise<string[]> {
   for (const f of files) {
     const block = readTestsBlock(readFrontmatter(await readFile(f, 'utf-8')));
     if (!block || shouldSkip(block.run)) continue;
-    if (block.formats['html']?.['parity'] === true) out.push(f);
+    if (block.formats['html']?.['dom-parity'] === true) out.push(f);
   }
   return out;
 }
@@ -1500,7 +1500,7 @@ describe('smoke-all preview <-> render DOM parity', () => {
     }
 
     console.log(`\nParity results: ${compared} compared, ${failures.length} failed, ${fixtures.length} opted in`);
-    expect(fixtures.length, 'at least one fixture must opt in (parity: true)').toBeGreaterThan(0);
+    expect(fixtures.length, 'at least one fixture must opt in (dom-parity: true)').toBeGreaterThan(0);
     expect(failures, `${failures.length} parity failure(s):\n${failures.join('\n\n')}`).toHaveLength(0);
   });
 
@@ -1543,7 +1543,7 @@ _quarto:
   tests:
     html:
       noErrors: true
-      parity: true
+      dom-parity: true
 ```
 
 ```bash
@@ -1625,7 +1625,7 @@ preview: <canonical snippet>
 Native writer: crates/pampa/src/writers/html.rs:<line>
 React: ts-packages/preview-renderer/src/q2-preview/<component>.tsx
 
-Fix should end with \`parity: true\` on the fixture.
+Fix should end with \`dom-parity: true\` on the fixture.
 EOF
 )" --json
 ```
@@ -1643,17 +1643,17 @@ EOF
   - add `### 4. Preview ↔ render DOM parity (WASM + jsdom)` after runner 3:
     command (`cd hub-client && npm run test:wasm`, `SMOKE_FILTER=` works),
     what it compares (`main#quarto-document-content`, read-only mount),
-    how to opt in (`parity: true` under `html:`), the no-xfail policy,
+    how to opt in (`dom-dom-parity: true` under `html:`), the no-xfail policy,
     where artifacts land (`hub-client/test-results/parity/`), and that
     fixtures with math wait on bd-tmb2u5yu;
-  - add `parity` to the DSL reference (search `ensureCssRegexMatches` for the list).
+  - add `dom-parity` to the DSL reference (search `ensureCssRegexMatches` for the list).
 - Modify: `.claude/skills/preview-render-parity/SKILL.md`:
   - in "Diagnosis workflow" insert a step 0: *reproduce with the harness
     first* — write a minimal fixture under `smoke-all/q2-preview/` (or opt in
     an existing one), run `SMOKE_FILTER=<name> npm run test:wasm`, read
     `test-results/parity/…`; go to Chrome only for computed-style symptoms;
   - in "TDD workflow", the regression test for a parity fix is the fixture's
-    `parity: true` opt-in when the fixture can be made minimal;
+    `dom-dom-parity: true` opt-in when the fixture can be made minimal;
   - replace the integration-branch guidance (lines ~140, 224, 228:
     `feature/q2-preview-command`, parent epic bd-kw93): bd-kw93 is closed and
     the branch merged via PR #214 (`git log --grep "q2 preview command"` on
@@ -1696,6 +1696,51 @@ Details and verbatim snippets: `claude-notes/research/2026-08-24-preview-render-
 | c2 | `OrderedList.tsx` omits `type="1"` for `Decimal` | `appendix/footnotes-heading.qmd` | bd-q88zinyv |
 | c3 | `Strikeout.tsx` renders `<s>`, writer `<del>` | `markdown/heading-auto-id.qmd` | bd-qzwlhrlv |
 | c4 | `Math.tsx` emits no `math inline|display` class | `markdown/heading-auto-id.qmd` | bd-tmb2u5yu |
+| s1 | Crossref floats not rendered as `div.quarto-float > figure.quarto-float-*` (figures and tables) | `includes/crossref/crossref.qmd`, `localization/lang-es-crossref.qmd`, `localization/language-inline-override.qmd` | bd-d96axq4a |
+| s2 | Localized UI strings not applied (callout title, theorem "Proof") | `localization/lang-es-callout.qmd`, `localization/lang-es-theorem.qmd` | bd-hamxar01 |
+| s3 | Callout drops `title=` / `data-appearance=` | `quarto-test/callout-title-attribute.qmd`, `quarto-test/callouts-matrix.qmd` | bd-p2cd2ssg |
+| s4 | Callout body heading sectionized on render, not on preview | `toc-containers/callout-body-heading-not-in-toc.qmd` | bd-bg0jze2i |
+| s5 | Inline `<code>` forwards `data-hl-spans` (forbid rule trips) | `highlighting/02-inline-code.qmd` | bd-bda2mbnl |
+| s6 | Included list item wrapped in `<p>` on preview | `includes/nested/nested.qmd` | bd-nrywksil |
+
+All of the above are children of the epic **bd-j3764r9a** "React <-> HTML DOM
+parity (q2 preview vs q2 render)", alongside **bd-xa4vv9tt** (this branch's
+harness work; close on merge), **bd-00iveh46** (`data-filename` dropped from
+`<pre>`, `includes/in-code-fence`), and four earlier-filed strands that are
+specifically about preview/render parity and were promoted to children:
+bd-e3m3rkik (mermaid chrome), bd-47afd5ro (tabsets), bd-2yd37vuk
+(`#quarto-header`), bd-tqijrhsu (toc-location). bd-1tl09 (native code-block
+decorations epic) is `related` only — it does not cover the React mirror.
+
+## Addendum (2026-08-24, after the plan closed)
+
+Full write-up: **`claude-notes/research/2026-08-24-preview-render-parity-survey.md`**
+(survey method and results, rename, bulk opt-in, strand/epic map, harness
+limitations). Summary:
+
+- [x] **Rename the DSL key `parity` → `dom-parity`** everywhere it is a key,
+  field (`TestSpec.dom_parity`), case label, assertion message or doc
+  reference (commit `d750318b7`). File names and the `PARITY_RULES` /
+  `compareParity` / `smokeAllParity` identifiers keep their names.
+- [x] **Whole-corpus survey + bulk opt-in.** A throwaway sweep of all 164
+  fixtures (`hub-client/test-results/parity-survey/`, gitignored, not
+  committed) found **106 byte-identical, 18 mismatching, 29 unreachable
+  (their `_quarto.tests` key is `q2-preview` or an extension format, not
+  `html`), 5 other** (2 intentional — `shouldError`, `run.skip`; 1
+  survey-environment artefact; 1 harness limitation — `theme: none` has no
+  `<main>`; 1 real bug — inline `Code.tsx` forwards `data-hl-spans`). The
+  106 minus the engine fixture `includes/code-cell/code-cell.qmd` were opted
+  in (commit `04bd3c2cf`): **`Parity results: 105 compared, 0 failed, 105
+  opted in`**, ~16.5 s of the sweep's 120 s hang-detection budget. 15 of
+  those fixtures have a `format: html:` block ahead of `_quarto: tests:
+  html:`; the opt-in script had to scope to the `_quarto → tests → html`
+  chain (the first attempt mis-inserted under `format:` and showed up as
+  `90 compared`).
+
+The mismatch → strand map and the harness limitations the survey exposed
+(`dom-parity` only read under `html:`; minimal-template docs have no `<main>`;
+`#main` excludes the page frame) are in the research note above — recorded
+there as notes, deliberately not as strands.
 
 ## Follow-ups (not in this plan)
 
@@ -1704,10 +1749,10 @@ Details and verbatim snippets: `claude-notes/research/2026-08-24-preview-render-
   `.reveal .slides` root selector and a `render_page_in_project` vs
   `RevealDeck` mount.
 - Widen the allowlist as parity strands close: each closing PR should end
-  with `parity: true` on the fixture that reproduced it.
+  with `dom-dom-parity: true` on the fixture that reproduced it.
 - Reconsider the mount configuration once edit chrome stabilises: comparing
   a `PreviewRoot` mount would need strip rules for `data-block-pool-id`,
   `tabIndex`, comment anchors, and asset blob URLs.
 - A lint (`cargo xtask lint`) that a fixture under `smoke-all/q2-preview/`
-  without `parity: true` must cite a reason — only once the allowlist is
+  without `dom-dom-parity: true` must cite a reason — only once the allowlist is
   large enough that omissions are the exception.

--- a/claude-notes/plans/2026-08-24-preview-render-dom-parity-harness.md
+++ b/claude-notes/plans/2026-08-24-preview-render-dom-parity-harness.md
@@ -179,6 +179,7 @@ must mirror that placement.
 |---|---|
 | Strip attributes `data-loc`, `data-sid` | Preview-only source tracking. The writer emits them only when `include_source_locations` is on (`html.rs` doc block ~L743-748) — off for `q2 render`; the preview AST is written with `include_inline_locations: true` (`PreviewAstOutput.ast_json`, `pipeline.rs:195`) and React forwards them via `dataLocProps`. |
 | Replace the children of `span.math` with one opaque text node `⟨opaque⟩` | `math-js` (excluded from preview) leaves TeX in `\(…\)` delimiters for MathJax; React `inlines/Math.tsx:24` emits KaTeX HTML. Divergent by design; the `<span>` and its classes still compare. **Today `Math.tsx` emits no class at all** (bd-tmb2u5yu), so on the preview side the selector matches nothing and the class diverges — no fixture with math can opt in until that strand closes. The rule is written for the fixed state on purpose. |
+| **Unwrap any `<div>` that has no attributes left after the strip rule, on both sides** (added by the Task 0.2 spike) | React cannot inject raw HTML without a host element, so `blocks/RawBlock.tsx:44` wraps every `RawBlock(format: "html")` in a `<div>` (`dangerouslySetInnerHTML`) that the writer (`html.rs`, `Block::RawBlock`) never emits — most visibly the code-copy button. Must be symmetric: a preview-only variant would false-positive on a `Div` block with an empty `Attr` (render `<div>` vs preview `<div data-loc=…>`); `title-block/simple-default.qmd` has two such divs on both sides. **Accepted cost:** a missing/extra attribute-less `<div>` is invisible to the runner (such a div matches no id/class selector; the render side's `ensureHtmlElements` assertions still cover `div.quarto-title-meta > div`-style structure). The alternative — excluding every fixture with a code block — would gut the corpus. Ordering: after the attribute strip (the wrapper carries `data-loc`), before `normalize()` and the whitespace pass. |
 | **Fail** if `data-hl-spans` is present on either side | Consumed attribute — the writer (`write_code_container_attr`, `html.rs:539`; the "reserved" comment at `:517`) and `blocks/CodeBlock.tsx` both decode it into `<span class="hl-…">` and must not forward it. Leakage is a bug (bd-nxslt); the harness must not normalise it away. |
 | Sort attributes by name | Serialisation order is not semantic. |
 | **Do not** sort class tokens; **do** collapse whitespace inside `class` | Class *order* is part of the mirroring contract (`sourceCode` prepend, bd-y1fs3). |
@@ -248,8 +249,8 @@ sibling's 120 s hang-detection timeout, `vitest.wasm.config.ts`).
 ## Checklist
 
 ### Phase 0 — Groundwork + spike
-- [ ] 0.1 Extract `hub-client/src/test-utils/smokeAllFixtures.ts` from `smokeAll.wasm.test.ts` (pure refactor, identical counts)
-- [ ] 0.2 Throwaway spike over 4 fixtures using the extracted helpers; research note with divergence classes + initial allowlist
+- [x] 0.1 Extract `hub-client/src/test-utils/smokeAllFixtures.ts` from `smokeAll.wasm.test.ts` (pure refactor, identical counts)
+- [x] 0.2 Throwaway spike over 4 fixtures using the extracted helpers; research note with divergence classes + initial allowlist
 
 ### Phase 1 — `domParity.ts`
 - [ ] 1.1 `canonicalize` — shape, attribute sorting, text/whitespace rules, `<pre>` verbatim, text-node merging
@@ -314,7 +315,7 @@ sees.
   `smokeAll.wasm.test.ts` — they are that runner's assertion model.
   `readTestsBlock` is the small shared accessor both runners use.
 
-- [ ] **Step 1: Fresh WASM, then record the baseline**
+- [x] **Step 1: Fresh WASM, then record the baseline**
 
 ```bash
 cd hub-client && npm run build:wasm
@@ -322,7 +323,7 @@ cd hub-client && npm run test:wasm 2>&1 | tee /private/tmp/claude-502/-Users-gor
 ```
 Record the `N passed, M skipped, 0 failed` line — the refactor must reproduce it exactly.
 
-- [ ] **Step 2: Create `smokeAllFixtures.ts`**
+- [x] **Step 2: Create `smokeAllFixtures.ts`**
 
 Move the listed items. `__dirname`-relative paths: `SMOKE_ALL_DIR` was
 `resolve(__dirname, '../../../crates/quarto/tests/smoke-all')` from
@@ -393,7 +394,7 @@ export function readTestsBlock(
 `populateVfs` and `buildUserGrammarsHandle` take `wasm: WasmModule` as
 their first parameter instead of closing over a module-level `let wasm`.
 
-- [ ] **Step 3: Rewire `smokeAll.wasm.test.ts`**
+- [x] **Step 3: Rewire `smokeAll.wasm.test.ts`**
 
 Delete the moved definitions; add
 `import { SMOKE_ALL_DIR, loadSmokeWasm, discoverTestFiles, readFrontmatter, readTestsBlock, parseTwoArraySpec, shouldSkip, populateVfs, buildUserGrammarsHandle, type WasmModule, type RunConfig } from '../test-utils/smokeAllFixtures';`.
@@ -414,7 +415,7 @@ Call sites: `populateVfs(wasm, testFile)`, `buildUserGrammarsHandle(wasm, projec
 Do **not** add a `parity` case yet — this task is behaviour-preserving;
 Task 2.2 does that.
 
-- [ ] **Step 4: Verify identical results**
+- [x] **Step 4: Verify identical results**
 
 ```bash
 cd hub-client && npm run test:wasm 2>&1 | tee /private/tmp/claude-502/-Users-gordon-src-q2/6f5c0c8f-a359-437a-87d6-879b0e289c0e/scratchpad/wasm-after.log; grep -E "Smoke-all WASM results|Tests " /private/tmp/claude-502/-Users-gordon-src-q2/6f5c0c8f-a359-437a-87d6-879b0e289c0e/scratchpad/wasm-after.log
@@ -424,7 +425,7 @@ Expected: the `passed/skipped/failed` line is byte-identical to Step 1;
 `typecheck` clean (it proves nothing about the moved file — that is the
 point: the app project must not have grown a Node import).
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add hub-client/src/test-utils/smokeAllFixtures.ts hub-client/src/services/smokeAll.wasm.test.ts
@@ -455,7 +456,7 @@ Fixtures: `markdown/heading-auto-id.qmd`, `highlighting/01-builtin-python.qmd`,
 exists, so this exercises the project branch on both sides),
 `title-block/simple-default.qmd`.
 
-- [ ] **Step 1: Widen the include glob** (positional file arguments only
+- [x] **Step 1: Widen the include glob** (positional file arguments only
   *filter within* `include`; a `.tsx` outside the glob is "no test files
   found")
 
@@ -463,7 +464,7 @@ exists, so this exercises the project branch on both sides),
       include: ['src/**/*.wasm.test.{ts,tsx}'],
 ```
 
-- [ ] **Step 2: Write the spike file**
+- [x] **Step 2: Write the spike file**
 
 ```tsx
 // @vitest-environment jsdom
@@ -538,7 +539,7 @@ describe('parity spike', () => {
 });
 ```
 
-- [ ] **Step 3: Run the spike**
+- [x] **Step 3: Run the spike**
 
 ```bash
 cd hub-client && npx vitest run --config vitest.wasm.config.ts src/services/paritySpike.wasm.test.tsx
@@ -548,7 +549,7 @@ Expected: the test passes (it only dumps) and eight files appear under
 `hub-client/test-results/parity-spike/`. If it fails, that is a Q1–Q3
 answer — record what and how it was worked around; that changes Task 3.1.
 
-- [ ] **Step 4: Inspect and diff each pair**
+- [x] **Step 4: Inspect and diff each pair**
 
 ```bash
 cd hub-client/test-results/parity-spike
@@ -564,7 +565,7 @@ Read every diff. Classify each hunk as one of: **(a)** serialiser noise the
 yet in the table (needs a new rule with a reason); **(c)** a real bug (React
 or writer — bd-tmb2u5yu is a known (c) if a fixture has math).
 
-- [ ] **Step 5: Write the research note**
+- [x] **Step 5: Write the research note**
 
 `claude-notes/research/2026-08-24-preview-render-parity-spike.md` with:
 the exact command run; answers to Q1–Q4; a table
@@ -572,7 +573,7 @@ the exact command run; answers to Q1–Q4; a table
 snippets for every (b) and (c); the amended rules table if any (b) was
 found; and the initial allowlist (fixtures whose only diffs are (a)).
 
-- [ ] **Step 6: Delete the spike, commit the note + the glob change**
+- [x] **Step 6: Delete the spike, commit the note + the glob change**
 
 ```bash
 rm hub-client/src/services/paritySpike.wasm.test.tsx
@@ -604,6 +605,7 @@ the package `tsconfig.json`, so nothing here ships in `dist/`.
     stripAttrs: ReadonlySet<string>;
     forbidAttrs: ReadonlySet<string>;
     opaqueSelectors: readonly string[];
+    unwrapTags: ReadonlySet<string>;                 // added after the Task 0.2 spike
   }
   export const PARITY_RULES: ParityRules;            // empty until Task 1.2
   export const OPAQUE_MARKER = '⟨opaque⟩';
@@ -720,6 +722,13 @@ export interface ParityRules {
    * but have their children replaced by a single OPAQUE_MARKER line.
    */
   opaqueSelectors: readonly string[];
+  /**
+   * Tag names whose elements are replaced by their children when no
+   * attribute survives `stripAttrs`. Applied on the clone before text
+   * nodes are merged, so the unwrapped children take part in the
+   * whitespace pass as siblings of the wrapper's neighbours.
+   */
+  unwrapTags: ReadonlySet<string>;
 }
 
 export const OPAQUE_MARKER = '⟨opaque⟩';
@@ -732,6 +741,7 @@ export const PARITY_RULES: ParityRules = {
   stripAttrs: new Set<string>(),
   forbidAttrs: new Set<string>(),
   opaqueSelectors: [],
+  unwrapTags: new Set<string>(),
 };
 
 /**
@@ -802,13 +812,35 @@ function walk(node: Node, depth: number, rules: ParityRules, out: string[], inPr
   for (const child of Array.from(el.childNodes)) walk(child, depth + 1, rules, out, childInPre);
 }
 
+/** True when every attribute on `el` is in `rules.stripAttrs`. */
+function hasNoSurvivingAttrs(el: Element, rules: ParityRules): boolean {
+  return Array.from(el.attributes).every((a) => rules.stripAttrs.has(a.name));
+}
+
+/**
+ * Replace every `rules.unwrapTags` element that has no surviving
+ * attributes by its children (document order, so nested wrappers unwrap
+ * too). Mutates `root`, which must be the private clone.
+ */
+function unwrapBareElements(root: Element, rules: ParityRules): void {
+  for (const tag of rules.unwrapTags) {
+    for (const el of Array.from(root.querySelectorAll(tag))) {
+      if (hasNoSurvivingAttrs(el, rules)) el.replaceWith(...Array.from(el.childNodes));
+    }
+  }
+}
+
 /**
  * Canonical, line-oriented rendering of `el` and its subtree. Works on a
- * clone so the caller's DOM is untouched (adjacent text nodes are merged
- * with `normalize()` first — React emits one text node per Str/Space).
+ * clone so the caller's DOM is untouched. Order on the clone: unwrap bare
+ * wrapper elements (rules.unwrapTags, judged after the strip list) →
+ * merge adjacent text nodes with `normalize()` (React emits one text
+ * node per Str/Space) → walk (strip/forbid/sort attributes, opaque
+ * subtrees, whitespace).
  */
 export function canonicalize(el: Element, rules: ParityRules = PARITY_RULES): string {
   const clone = el.cloneNode(true) as Element;
+  unwrapBareElements(clone, rules);
   clone.normalize();
   const out: string[] = [];
   walk(clone, 0, rules, out, false);
@@ -870,6 +902,23 @@ describe('PARITY_RULES', () => {
       ParityRuleViolation,
     );
   });
+
+  it("unwraps React's attribute-less RawBlock <div> wrapper (data-loc does not count)", () => {
+    // preview: RawBlock.tsx host element carrying only data-loc; render: the raw HTML inline.
+    const preview = canonicalize(
+      el('<main><div data-loc="f:1:1-2:1"><button class="code-copy-button">c</button></div> <p>x</p></main>'),
+    );
+    const render = canonicalize(el('<main><button class="code-copy-button">c</button>\n<p>x</p></main>'));
+    expect(preview).toBe(render);
+    expect(preview).not.toContain('<div');
+  });
+
+  it('keeps a <div> that has any surviving attribute, and unwraps nested bare divs', () => {
+    expect(canonicalize(el('<div class="k"><p>x</p></div>'))).toBe(['<div class="k">', '  <p>', '    "x"'].join('\n'));
+    expect(canonicalize(el('<main><div><div><p>x</p></div></div></main>'))).toBe(
+      canonicalize(el('<main><p>x</p></main>')),
+    );
+  });
 });
 ```
 
@@ -878,7 +927,7 @@ describe('PARITY_RULES', () => {
 ```bash
 cd ts-packages/preview-renderer && npx vitest run src/test-utils/domParity.test.ts
 ```
-Expected: the four new tests FAIL (attributes present / no opaque marker / no throw).
+Expected: the six new tests FAIL (attributes present / no opaque marker / no throw / `<div` still present).
 
 - [ ] **Step 3: Populate the rules**
 
@@ -919,6 +968,19 @@ export const PARITY_RULES: ParityRules = {
     // close before any fixture containing math can opt in.
     'span.math',
   ],
+  unwrapTags: new Set<string>([
+    // React cannot inject raw HTML without a host element:
+    // q2-preview/blocks/RawBlock.tsx wraps every RawBlock(format:"html")
+    // in a <div dangerouslySetInnerHTML> (carrying only data-loc) that the
+    // native writer (crates/pampa/src/writers/html.rs, Block::RawBlock)
+    // never emits — most visibly the code-copy button. Symmetric on
+    // purpose: a Div block with an empty Attr is a bare <div> on BOTH
+    // sides, so a preview-only unwrap would false-positive. Accepted
+    // cost: a missing/extra bare <div> is invisible to the runner. Found
+    // by the Task 0.2 spike
+    // (claude-notes/research/2026-08-24-preview-render-parity-spike.md).
+    'div',
+  ]),
 };
 ```
 
@@ -927,7 +989,7 @@ export const PARITY_RULES: ParityRules = {
 ```bash
 cd ts-packages/preview-renderer && npx vitest run src/test-utils/domParity.test.ts
 ```
-Expected: 13 passed.
+Expected: 15 passed.
 
 - [ ] **Step 5: Commit**
 
@@ -1043,8 +1105,8 @@ export function compareParity(
 cd ts-packages/preview-renderer && npx vitest run src/test-utils/domParity.test.ts
 cd ts-packages/preview-renderer && npm test && npm run test:integration
 ```
-Expected: 16 passed in the new file; the package suites green with the same
-counts as before plus 16.
+Expected: 18 passed in the new file; the package suites green with the same
+counts as before plus 18.
 
 - [ ] **Step 5: Commit**
 
@@ -1247,9 +1309,11 @@ git commit -m "Ignore the parity key in the WASM and Playwright smoke-all parser
 
 **Files:**
 - Create: `hub-client/src/services/smokeAllParity.wasm.test.tsx`
-- Modify: the first opt-in candidate from the Task 0.2 note (expected:
-  `crates/quarto/tests/smoke-all/markdown/heading-auto-id.qmd`) — add
-  `parity: true` under `_quarto.tests.html`
+- Modify: the first opt-in candidate from the Task 0.2 note:
+  `crates/quarto/tests/smoke-all/title-block/simple-default.qmd` (byte-identical
+  under the rules even without the unwrap rule) — add `parity: true` under
+  `_quarto.tests.html`. (`markdown/heading-auto-id.qmd`, the pre-spike guess,
+  is blocked by c3 + c4 — see § Findings.)
 
 The runner and its first fixture land together so no commit on the branch
 is red.
@@ -1483,7 +1547,7 @@ _quarto:
 ```
 
 ```bash
-cd hub-client && SMOKE_FILTER=heading-auto-id npm run test:wasm
+cd hub-client && SMOKE_FILTER=simple-default npm run test:wasm
 ```
 Expected: `Parity results: 1 compared, 0 failed, 1 opted in`; self-check passes.
 
@@ -1496,16 +1560,17 @@ next candidate from the note; record the divergence for Task 4.1.
 - [ ] **Step 4: Commit (green)**
 
 ```bash
-git add hub-client/src/services/smokeAllParity.wasm.test.tsx crates/quarto/tests/smoke-all/markdown/heading-auto-id.qmd
+git add hub-client/src/services/smokeAllParity.wasm.test.tsx crates/quarto/tests/smoke-all/title-block/simple-default.qmd
 git commit -m "Add preview/render DOM parity runner over opted-in smoke-all fixtures"
 ```
 
 ### Task 3.2: Opt in the remaining green fixtures
 
 **Files:**
-- Modify: each remaining opt-in candidate from the Task 0.2 note. Expected
-  (amend from the note): `highlighting/01-builtin-python.qmd`,
-  `appendix/footnotes-heading.qmd`, `title-block/simple-default.qmd`.
+- Modify: each remaining opt-in candidate from the Task 0.2 note — only
+  `highlighting/01-builtin-python.qmd` (green under the amended rules).
+  `appendix/footnotes-heading.qmd` (c1, c2) and `markdown/heading-auto-id.qmd`
+  (c3, c4) stay out until their strands close — see § Findings.
 
 - [ ] **Step 1: Opt in one at a time, same loop as Task 3.1 Step 3**
 
@@ -1536,7 +1601,13 @@ git commit -m "Opt further smoke-all fixtures into preview/render DOM parity"
 **Files:** none (braid). bd-tmb2u5yu (`Math.tsx` classes) is already filed.
 
 For each further (c)-class divergence recorded in the Task 0.2 note or found
-in Phase 3, create one strand. These are out-of-plan bugs (they are
+in Phase 3, create one strand. The spike found three new ones (c1–c3 in
+`claude-notes/research/2026-08-24-preview-render-parity-spike.md`; c4 is
+bd-tmb2u5yu): c1 `inlines/Link.tsx` drops kv attributes outside a
+`data-*`/`rel`/`target` allowlist (loses `role="doc-noteref"`/`doc-backlink`);
+c2 `blocks/OrderedList.tsx` emits no `type="1"` for `Decimal` (the writer and
+Pandoc do); c3 `inlines/Strikeout.tsx` renders `<s>` where the writer (and
+Pandoc) render `<del>`. These are out-of-plan bugs (they are
 *findings* of this plan, not work items of it):
 
 ```bash
@@ -1605,6 +1676,19 @@ git commit -m "Document the preview/render DOM parity runner and harness-first w
 - [ ] Report; **do not push** without explicit approval (CLAUDE.md).
 
 ---
+
+## Findings
+
+Real divergences the harness (spike + runner) surfaced. Out-of-plan bugs,
+one strand each (label `preview-parity`); ids filled in by Task 4.1.
+Details and verbatim snippets: `claude-notes/research/2026-08-24-preview-render-parity-spike.md`.
+
+| # | Symptom | Fixture | Strand |
+|---|---|---|---|
+| c1 | `Link.tsx` drops `role=` (and every kv attr outside `data-*`/`rel`/`target`) | `appendix/footnotes-heading.qmd` | _pending_ |
+| c2 | `OrderedList.tsx` omits `type="1"` for `Decimal` | `appendix/footnotes-heading.qmd` | _pending_ |
+| c3 | `Strikeout.tsx` renders `<s>`, writer `<del>` | `markdown/heading-auto-id.qmd` | _pending_ |
+| c4 | `Math.tsx` emits no `math inline|display` class | `markdown/heading-auto-id.qmd` | bd-tmb2u5yu |
 
 ## Follow-ups (not in this plan)
 

--- a/claude-notes/plans/2026-08-24-preview-render-dom-parity-harness.md
+++ b/claude-notes/plans/2026-08-24-preview-render-dom-parity-harness.md
@@ -1,0 +1,1622 @@
+# Preview ↔ Render DOM Parity Harness — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Created:** 2026-08-24 (revised the same day after a blank-slate review)
+**Branch:** `explore/react-parity-harness` (worktree `.worktrees/workspace-1`, off `main` @ `cf9c45cc8`)
+**Related strands:** bd-tmb2u5yu (`Math.tsx` drops `math inline|display` —
+found while designing this; blocks opting in any math fixture), bd-qn8yi1su
+(revealjs analogue — *not* in scope, but should extend this harness),
+bd-2yd37vuk, bd-tqijrhsu (open parity gaps opted-in fixtures may surface)
+**Origin:** an external "dual-engine parity testing" spec (Gemini) evaluated
+against this codebase — see § Assessment.
+
+**Goal:** Automatically assert, for opted-in `smoke-all` fixtures, that
+`q2 preview`'s React renderer produces the same article-body DOM as
+`q2 render`'s native HTML writer.
+
+**Architecture:** A fourth `smoke-all` runner,
+`hub-client/src/services/smokeAllParity.wasm.test.tsx`, renders each opted-in
+fixture twice through the same WASM module — `render_page_in_project` (native
+writer → full HTML) and `render_page_for_preview` (the *same* Rust function
+with `prefer_preview_format: true` → pipeline stopped before
+`render-html-body` → Pandoc AST JSON) — mounts the AST read-only with the real
+`<Ast registry={previewRegistry}>` under jsdom, and compares the canonical form
+of `main#quarto-document-content` from both sides. Canonicalisation is a small
+pure module with an explicit, reasoned normalisation table. Fixtures opt in
+with `parity: true` under a format entry of the existing `_quarto: tests:` DSL.
+
+**Tech Stack:** vitest 4 (jsdom env via docblock, hub-client
+`vitest.wasm.config.ts`), `wasm-quarto-hub-client`, `@testing-library/react`,
+`jsdom`. **No new dependencies.**
+
+**Spec:** this file (§ Design). The design was brainstormed, approved, and
+then revised after a blank-slate review in the session that wrote this plan;
+there is no separate spec document.
+
+## Global Constraints
+
+- **No new npm or cargo dependencies.** jsdom + testing-library are already
+  devDeps of `hub-client` and `ts-packages/preview-renderer`; `katex` reaches
+  preview-renderer through the root `package.json` hoist (pre-existing).
+- **Fresh WASM is a prerequisite.** Every `*.wasm.test.*` runs the checked-in
+  `hub-client/wasm-quarto-hub-client/wasm_quarto_hub_client_bg.wasm`. Run
+  `cd hub-client && npm run build:wasm` once at the start of the plan and
+  again after any Rust change (there is one: Task 2.1 touches `quarto-test`,
+  which the WASM does **not** depend on — so no rebuild is needed for it, but
+  rebuild anyway if `main` has moved under you).
+- **HTML article body only.** Comparison root is `main#quarto-document-content`.
+  revealjs, tabsets, engine fixtures, math *content*, and hub-client-only
+  chrome are non-goals (§ Non-goals).
+- **Curated allowlist, not xfail.** Only fixtures with `parity: true` are
+  compared; an opted-in fixture that diverges fails the suite. There is no
+  expected-failure mechanism — fix the divergence or don't opt in. (Accepted
+  cost: a fixture that *finds* a bug carries no regression guard until the
+  bug is fixed and the fixture opts in. That is the chosen trade-off.)
+- **Every normalisation rule cites a reason** (and a strand/file where one
+  exists). A rule without a reason is a bug hiding a bug.
+- **Read-only mount defines the contract.** The preview side is a bare
+  `<Ast registry={previewRegistry}>` with no `PreviewContext` /
+  `AssetManifestContext` / `IncrementalContext` — the component markup the
+  `preview-render-parity` skill's contract is about. Edit chrome, comment
+  chrome, and asset blob-URL rewriting are preview-only by design and are
+  *not* compared.
+- **Zero new CI wiring.** The runner is a `*.wasm.test.tsx` file, picked up by
+  `npm run test:wasm` → `test:ci` → `cargo xtask verify` →
+  `.github/workflows/ts-test-suite.yml:164`.
+- **Test-only Node code stays out of the app build.** Anything importing
+  `fs`/`path`/`url` lives under `hub-client/src/test-utils/` (excluded by
+  `hub-client/tsconfig.app.json:28-35`) or in a `*.test.*` file.
+- **Typechecking scope (pre-existing):** `npm run typecheck` in hub-client
+  runs `tsc -p tsconfig.app.json --noEmit`, which *excludes* tests and
+  `src/test-utils/`; vitest transpiles test files without typechecking.
+  `npx tsc --noEmit -p tsconfig.json` checks **nothing** (solution file) —
+  never use it as a gate.
+- **Gate per CLAUDE.md:** `cargo clippy -p quarto-test --all-targets -- -D
+  warnings` + `cargo nextest run -p quarto-test` after Task 2.1; one
+  `cargo nextest run --workspace` at the Phase 2 boundary (the only Rust
+  phase); full `cargo xtask verify` (hub-client is touched, so no
+  `--skip-hub-*`) before any push.
+- Cross-platform (`.claude/rules/cross-platform.md`): build paths with
+  `path.join`/`resolve`; the harness runs on Linux CI and macOS dev boxes.
+- `.claude/rules/integration-tests.md`: no new Rust test binaries. The
+  smoke-all Rust sweep is invoked as
+  `cargo nextest run -p quarto --test integration smoke_all`
+  (`crates/quarto/tests/integration/main.rs:25`).
+
+---
+
+## Assessment of the originating idea
+
+The external spec proposed a generic "Engine A (Quarto HTML) vs Engine B
+(React `renderToString`) → normalise → tree-diff" harness over `smoke-all`.
+Evaluated against q2:
+
+- **Sound in its core.** The "React component tree" is real:
+  `ts-packages/preview-renderer/src/q2-preview/{blocks,inlines,custom}/` —
+  ~40 components mirroring `crates/pampa/src/writers/html.rs` arm-for-arm
+  (`blocks/CodeBlock.tsx:71` literally says "mirrors `write_highlighted_body`").
+  The repo already states the contract in
+  `.claude/skills/preview-render-parity/SKILL.md:7` and polices it *by hand*
+  in Chrome, one bug at a time (bd-y1fs3, bd-coffj, bd-nxslt, the revealjs
+  audit `claude-notes/plans/2026-06-17-revealjs-preview-render-parity-audit.md`).
+  This harness automates an existing, repeatedly-violated contract — and the
+  review of this very plan found a fresh violation (bd-tmb2u5yu) by reading
+  two files side by side.
+- **The data bridge is not `--to json`.** The preview pipeline is
+  `build_q2_preview_pipeline_stages` = HTML pipeline minus `math-js`,
+  `render-html-body`, `apply-template` (`crates/quarto-core/src/pipeline.rs:394`)
+  and minus seven transforms replicated in React (`Q2_PREVIEW_TRANSFORM_EXCLUDED`,
+  `pipeline.rs:1523`: `callout-resolve`, `crossref-render`, `title-block`,
+  `mermaid-render`, `panel-tabset`, `panel-tabset-resolve`,
+  `attribution-viewer`). Render's post-transform AST already has those
+  lowered; React expects them as CustomNodes. The correct bridge is the WASM
+  export `render_page_for_preview` (`crates/wasm-quarto-hub-client/src/lib.rs:1293`),
+  which returns `ast_json`.
+- **The two sides are one function.** `render_page_in_project`
+  (`lib.rs:1123`) and `render_page_for_preview` both call
+  `render_page_in_project_with_attribution` → `ProjectContext::discover` →
+  the same `is_single_file` branch into `render_single_doc_to_response` /
+  `render_project_active_page_to_response`, differing only in
+  `prefer_preview_format` (`lib.rs:1426`). So **every diff the harness
+  reports is in `html.rs`/template vs React, by construction.** (`render_qmd`,
+  `lib.rs:1001`, is *not* a valid counterpart: it always takes the
+  single-doc path, so project fixtures such as `appendix/` would compare
+  different pipelines.)
+- **Corrections to the spec:** no cheerio/htmlparser2 (jsdom + `scraper`
+  exist); no `renderToString` (components use contexts/hooks — mount with
+  testing-library exactly like `q2-preview.integration.test.tsx:80`); compare
+  `<main>` only, not whole pages (`apply-template` is excluded; navbar,
+  sidebar and footer live outside `<main>` and are Rust HTML strings on both
+  sides anyway); **do not** strip ids or generic `data-*` (ids are part of
+  the contract — the reveal audit's F1 was "section id dropped"); no custom
+  tree-diff (line-oriented canonical text + vitest's diff is enough);
+  `glob(**/*.qmd)` day-one is a wall of red (tabsets have no React
+  implementation) — hence the allowlist.
+- **Existing tooling reused:** `hub-client/src/services/smokeAll.wasm.test.ts`
+  already loads the WASM in vitest, walks `smoke-all/`, parses the DSL, and
+  populates the VFS — the harness is its sibling. Prior art on normalisation:
+  `crates/pampa/tests/integration/test.rs:691` (`normalize_html`, tag-per-line),
+  `hub-client/e2e/helpers/smokeAllAssertions.ts:42` (`stripSourceTrackingSpans`).
+
+## Design
+
+### Contract
+
+For an opted-in fixture `F` with a `html` format entry:
+
+```
+canon(main#quarto-document-content of render_page_in_project(F).html)
+  ===
+canon(main#quarto-document-content of mount(<Ast astJson={render_page_for_preview(F).ast_json} registry={previewRegistry}/>))
+```
+
+where `canon` is `canonicalize()` from § Normalisation and `mount` is a
+bare read-only mount (§ Global Constraints). React-replicated transforms
+(title-block, callouts, crossref, theorems, footnotes) **are** compared —
+that is the point. So are `toc-body` and page-navigation when a fixture
+enables them: the template puts both *inside* `<main>`
+(`crates/quarto-core/src/template.rs:318-331`) and `PreviewDocument.tsx`
+must mirror that placement.
+
+### Components
+
+| File | Responsibility |
+|---|---|
+| `ts-packages/preview-renderer/src/test-utils/domParity.ts` | Pure DOM → canonical text. `canonicalize`, `extractParityRoot`, `compareParity`, `PARITY_RULES`. No WASM, no fixtures, no fs. The directory already exists (`setup.ts` lives there) and is excluded from the package's `tsconfig.json`, so this never reaches `dist/` — consumers import it through vitest's alias only. |
+| `ts-packages/preview-renderer/src/test-utils/domParity.test.ts` | Unit tests for the above (jsdom via docblock). |
+| `hub-client/src/test-utils/smokeAllFixtures.ts` | Fixture discovery, front-matter reading, `_quarto.tests` block access, skip logic, project-root discovery, VFS population, user-grammar handle, WASM loader — **extracted** from `smokeAll.wasm.test.ts`, which then imports it. Under `test-utils/` so its Node-builtin imports stay out of the app tsconfig. |
+| `hub-client/src/services/smokeAllParity.wasm.test.tsx` | The runner: per opted-in fixture, render both ways, mount, compare, report. Plus the "harness catches an injected divergence" self-test. `.tsx` because it mounts JSX. |
+| `hub-client/vitest.wasm.config.ts` | `include` widened to `*.wasm.test.{ts,tsx}`. |
+| `crates/quarto-test/src/spec.rs` | Accept `parity` key into `TestSpec.parity: bool` (runner ignores it). |
+| `hub-client/src/services/smokeAll.wasm.test.ts`, `hub-client/e2e/helpers/smokeAllDiscovery.ts` | Accept and ignore `parity`. |
+| Opted-in fixtures under `crates/quarto/tests/smoke-all/` | `parity: true` added under `html:`. |
+| `claude-notes/instructions/testing.md`, `.claude/skills/preview-render-parity/SKILL.md` | Document the fourth runner and the harness-first workflow. |
+
+### Normalisation rules (`PARITY_RULES` + the canonical serialiser)
+
+| Rule | Why |
+|---|---|
+| Strip attributes `data-loc`, `data-sid` | Preview-only source tracking. The writer emits them only when `include_source_locations` is on (`html.rs` doc block ~L743-748) — off for `q2 render`; the preview AST is written with `include_inline_locations: true` (`PreviewAstOutput.ast_json`, `pipeline.rs:195`) and React forwards them via `dataLocProps`. |
+| Replace the children of `span.math` with one opaque text node `⟨opaque⟩` | `math-js` (excluded from preview) leaves TeX in `\(…\)` delimiters for MathJax; React `inlines/Math.tsx:24` emits KaTeX HTML. Divergent by design; the `<span>` and its classes still compare. **Today `Math.tsx` emits no class at all** (bd-tmb2u5yu), so on the preview side the selector matches nothing and the class diverges — no fixture with math can opt in until that strand closes. The rule is written for the fixed state on purpose. |
+| **Fail** if `data-hl-spans` is present on either side | Consumed attribute — the writer (`write_code_container_attr`, `html.rs:539`; the "reserved" comment at `:517`) and `blocks/CodeBlock.tsx` both decode it into `<span class="hl-…">` and must not forward it. Leakage is a bug (bd-nxslt); the harness must not normalise it away. |
+| Sort attributes by name | Serialisation order is not semantic. |
+| **Do not** sort class tokens; **do** collapse whitespace inside `class` | Class *order* is part of the mirroring contract (`sourceCode` prepend, bd-y1fs3). |
+| Keep `id` and every `data-*` not listed above | Ids are contract (reveal audit F1; heading anchors). `data-qf-*`, `data-cites`, etc. are writer output that React must mirror. |
+| Merge adjacent text nodes before walking (`Node.normalize()` on a clone) | React emits one text node per `Str`/`Space`; the parser emits one per run. Without merging, `"hi"`,`" "`,`"there"` vs `"hi there"` would be a false positive. |
+| Inside `<pre>`: text verbatim (JSON-escaped on one line) | Collapsing would hide code-indentation bugs — the exact bug class `CodeBlock.tsx` exists to mirror. |
+| Outside `<pre>`: collapse whitespace runs to one space; keep a leading/trailing space **only if the neighbouring sibling on that side is inline** (a non-whitespace text node, or an element in `INLINE_TAGS`); drop the node if nothing remains | Distinguishes `<em>a</em> <em>b</em>` from `<em>a</em><em>b</em>` and `hi <em>x</em>` from `hi<em>x</em>` (real preview bugs), while dropping the writer's pretty-printing newlines between block elements (React emits none). |
+| Drop comment nodes | Not rendered. |
+| Lower-case tag names; ignore void-element self-closing | Parser noise. |
+
+Deliberately **not** a rule: `data-block-pool-id` (React edit chrome). Under
+the read-only mount it is never emitted (`usePreviewEdit.ts:21` returns no
+resolver without a `PreviewContext`), so a strip rule would be dead code with
+a false reason. If the mount configuration ever changes, add it then.
+
+### Canonical form
+
+One line per node, two-space indent per depth, no closing lines; text lines
+are JSON string literals:
+
+```
+<main class="content" id="quarto-document-content">
+  <header class="quarto-title-block default" id="title-block-header">
+    <div class="quarto-title">
+      <h1 class="title">
+        "A Simple Document"
+  <p>
+    "hi "
+    <em>
+      "there"
+```
+
+Line-oriented on purpose: vitest's `toBe` diff on two such strings shows the
+divergent node with context, and a `diff` of the two `.norm.txt` artifacts
+reads the same way. No tree-diff engine (YAGNI; `quarto-ast-reconcile`'s
+`find_first_divergence`, `hash.rs:677`, exists if we ever want "first
+divergent node").
+
+### Failure output
+
+On mismatch the runner (a) records `<rel-path> [html]: parity mismatch` with
+vitest's diff text in the aggregated failure list (same single-`it` pattern
+as the sibling runner), and (b) writes
+`hub-client/test-results/parity/<rel-path-with-separators-as-__>/{render,preview}.norm.txt`
+(`test-results/` is already gitignored, `hub-client/.gitignore:18`). Per-fixture
+wall time is logged so runtime growth is visible (the sweep shares the
+sibling's 120 s hang-detection timeout, `vitest.wasm.config.ts`).
+
+### Non-goals (explicit)
+
+- revealjs decks (`.reveal .slides`) — bd-qn8yi1su; should reuse
+  `domParity.ts` when it lands.
+- Tabsets — no React implementation at all (`pipeline.rs:1556`); a fixture
+  containing a tabset cannot be opted in.
+- Engine fixtures (`run.requires: [knitr|jupyter]`, one today:
+  `includes/code-cell/code-cell.qmd`) — WASM has no engines. The WASM
+  `RunConfig` does not model `requires`; the allowlist makes this moot:
+  do not opt them in.
+- Math *content* (opaque by rule), hub-client-only chrome outside `<main>`
+  (navbar/sidebar/footer), attribution badges and edit/comment chrome
+  (preview-only), Q1 ↔ Q2 parity.
+- Computed-style / CSS parity — `crates/quarto-core/tests/integration/preview_render_css_parity.rs`
+  covers theme CSS byte-equality already.
+
+---
+
+## Checklist
+
+### Phase 0 — Groundwork + spike
+- [ ] 0.1 Extract `hub-client/src/test-utils/smokeAllFixtures.ts` from `smokeAll.wasm.test.ts` (pure refactor, identical counts)
+- [ ] 0.2 Throwaway spike over 4 fixtures using the extracted helpers; research note with divergence classes + initial allowlist
+
+### Phase 1 — `domParity.ts`
+- [ ] 1.1 `canonicalize` — shape, attribute sorting, text/whitespace rules, `<pre>` verbatim, text-node merging
+- [ ] 1.2 `PARITY_RULES` — strip list, opaque `span.math`, forbidden `data-hl-spans`
+- [ ] 1.3 `extractParityRoot` + `compareParity`
+
+### Phase 2 — `parity:` DSL key
+- [ ] 2.1 Rust `quarto-test`: parse into `TestSpec.parity`, runner ignores
+- [ ] 2.2 Both TS parsers (WASM sibling, Playwright discovery) ignore `parity`; Phase-2 boundary workspace nextest
+
+### Phase 3 — Runner
+- [ ] 3.1 `smokeAllParity.wasm.test.tsx` + first opt-in in one green commit
+- [ ] 3.2 Opt in the remaining fixtures the spike showed green; all four runners green
+
+### Phase 4 — Triage + docs + gate
+- [ ] 4.1 File a strand per real divergence found (bd-tmb2u5yu already filed)
+- [ ] 4.2 Update `testing.md` and the `preview-render-parity` skill
+- [ ] 4.3 Full `cargo xtask verify`; reconcile this checklist; commit
+
+---
+
+## Phase 0 — Groundwork + spike
+
+### Task 0.1: Extract `smokeAllFixtures.ts` (pure refactor)
+
+**Files:**
+- Create: `hub-client/src/test-utils/smokeAllFixtures.ts`
+- Modify: `hub-client/src/services/smokeAll.wasm.test.ts` (remove the moved code, import it)
+
+Done first so the spike (0.2) and the runner (3.1) use the *same* fixture →
+VFS semantics as the existing sweep (project-root discovery, `/project/`
+prefix relative to the project root, binary files, user grammars). A spike
+that hand-rolls VFS loading would report divergences the real runner never
+sees.
+
+**Interfaces:**
+- Produces (moved verbatim from `smokeAll.wasm.test.ts` unless noted; line
+  numbers are the pre-move locations):
+  ```ts
+  export const SMOKE_ALL_DIR: string;                                   // L88 (test-utils/ and services/ are siblings under src/, so the relative path is unchanged)
+  export interface JsUserGrammarsHandle { … }                           // L24
+  export interface WasmModule {                                          // L32, two methods added:
+    …;
+    render_page_in_project: (path: string, user_grammars?: unknown) => Promise<string>;
+    render_page_for_preview: (path: string, user_grammars?: unknown, capture_gz_json?: Uint8Array) => Promise<string>;
+  }
+  export interface RunConfig { … }                                      // L59
+  export interface FileEntry { … }                                      // L365
+  export async function loadSmokeWasm(): Promise<WasmModule>;           // NEW: body of the beforeAll at L103-133
+  export async function discoverTestFiles(dir: string): Promise<string[]>;       // L139
+  export function readFrontmatter(content: string): Record<string, unknown>;      // L164
+  export function readTestsBlock(metadata: Record<string, unknown>): { run: RunConfig | null; formats: Record<string, Record<string, unknown>> } | null;  // NEW
+  export function parseTwoArraySpec(value: unknown): { matches: string[]; noMatches: string[] };  // L181
+  export function shouldSkip(runConfig: RunConfig | null): string | null;         // L293
+  export async function findProjectRoot(qmdDir: string): Promise<string>;         // L322
+  export async function readAllFiles(dir: string, projectRoot: string): Promise<FileEntry[]>;  // L372
+  export async function populateVfs(wasm: WasmModule, qmdPath: string): Promise<{ vfsPath: string; projectFiles: FileEntry[] }>;  // L404, wasm param added
+  export async function buildUserGrammarsHandle(wasm: WasmModule, files: readonly FileEntry[]): Promise<JsUserGrammarsHandle | undefined>;  // L435, wasm param added
+  ```
+  `parseTestSpecs`/`parseFormatSpec`, `WasmRenderResult`, `JsonDiagnostic`,
+  `FormatSpec`, `AssertionFn` and the assertion factories **stay** in
+  `smokeAll.wasm.test.ts` — they are that runner's assertion model.
+  `readTestsBlock` is the small shared accessor both runners use.
+
+- [ ] **Step 1: Fresh WASM, then record the baseline**
+
+```bash
+cd hub-client && npm run build:wasm
+cd hub-client && npm run test:wasm 2>&1 | tee /private/tmp/claude-502/-Users-gordon-src-q2/6f5c0c8f-a359-437a-87d6-879b0e289c0e/scratchpad/wasm-baseline.log; grep -E "Smoke-all WASM results|Tests " /private/tmp/claude-502/-Users-gordon-src-q2/6f5c0c8f-a359-437a-87d6-879b0e289c0e/scratchpad/wasm-baseline.log
+```
+Record the `N passed, M skipped, 0 failed` line — the refactor must reproduce it exactly.
+
+- [ ] **Step 2: Create `smokeAllFixtures.ts`**
+
+Move the listed items. `__dirname`-relative paths: `SMOKE_ALL_DIR` was
+`resolve(__dirname, '../../../crates/quarto/tests/smoke-all')` from
+`src/services/`; from `src/test-utils/` it is the same depth, so the
+expression is unchanged. The two new functions:
+
+```ts
+/**
+ * Initialise the WASM module from the checked-in build and wire the
+ * dart-sass VFS callbacks. Shared by every `*.wasm.test.*` smoke-all
+ * runner; call once from `beforeAll`.
+ */
+export async function loadSmokeWasm(): Promise<WasmModule> {
+  const wasmDir = join(__dirname, '../../wasm-quarto-hub-client');
+  const wasmBytes = await readFile(join(wasmDir, 'wasm_quarto_hub_client_bg.wasm'));
+  const wasm = (await import('wasm-quarto-hub-client')) as unknown as WasmModule;
+  await wasm.default(wasmBytes);
+  const sassModule = await import('/src/wasm-js-bridge/sass.js');
+  sassModule.setVfsCallbacks(
+    (path: string): string | null => {
+      try {
+        const result = JSON.parse(wasm.vfs_read_file(path)) as { success: boolean; content?: string };
+        return result.success && result.content !== undefined ? result.content : null;
+      } catch {
+        return null;
+      }
+    },
+    (path: string): boolean => {
+      try {
+        const result = JSON.parse(wasm.vfs_read_file(path)) as { success: boolean; content?: string };
+        return result.success && result.content !== undefined;
+      } catch {
+        return false;
+      }
+    },
+  );
+  return wasm;
+}
+
+/**
+ * The `_quarto.tests` block split into its `run` config and its
+ * per-format raw mappings. Returns null when the fixture has no tests
+ * block. A format entry that is not a mapping (e.g. `html: default`) is
+ * normalised to `{}`, matching the Rust parser
+ * (crates/quarto-test/src/spec.rs `parse_format_spec`: `value.as_mapping()`
+ * optional). Runners parse the per-format mapping themselves (their
+ * assertion models differ); this keeps the *shape* of the DSL in one
+ * place.
+ */
+export function readTestsBlock(
+  metadata: Record<string, unknown>,
+): { run: RunConfig | null; formats: Record<string, Record<string, unknown>> } | null {
+  const quarto = metadata['_quarto'] as Record<string, unknown> | undefined;
+  const tests = quarto?.['tests'] as Record<string, unknown> | undefined;
+  if (!tests) return null;
+  const formats: Record<string, Record<string, unknown>> = {};
+  for (const [key, value] of Object.entries(tests)) {
+    if (key === 'run') continue;
+    formats[key] =
+      value !== null && typeof value === 'object' && !Array.isArray(value)
+        ? (value as Record<string, unknown>)
+        : {};
+  }
+  return { run: (tests['run'] as RunConfig) ?? null, formats };
+}
+```
+
+`populateVfs` and `buildUserGrammarsHandle` take `wasm: WasmModule` as
+their first parameter instead of closing over a module-level `let wasm`.
+
+- [ ] **Step 3: Rewire `smokeAll.wasm.test.ts`**
+
+Delete the moved definitions; add
+`import { SMOKE_ALL_DIR, loadSmokeWasm, discoverTestFiles, readFrontmatter, readTestsBlock, parseTwoArraySpec, shouldSkip, populateVfs, buildUserGrammarsHandle, type WasmModule, type RunConfig } from '../test-utils/smokeAllFixtures';`.
+`beforeAll` becomes `wasm = await loadSmokeWasm();`. `parseTestSpecs` becomes:
+
+```ts
+function parseTestSpecs(metadata: Record<string, unknown>, options: ParseOptions = {}) {
+  const block = readTestsBlock(metadata);
+  if (!block) return { runConfig: null, formatSpecs: [] };
+  const formatSpecs = Object.entries(block.formats).map(([format, value]) =>
+    parseFormatSpec(format, value, options),
+  );
+  return { runConfig: block.run, formatSpecs };
+}
+```
+
+Call sites: `populateVfs(wasm, testFile)`, `buildUserGrammarsHandle(wasm, projectFiles)`.
+Do **not** add a `parity` case yet — this task is behaviour-preserving;
+Task 2.2 does that.
+
+- [ ] **Step 4: Verify identical results**
+
+```bash
+cd hub-client && npm run test:wasm 2>&1 | tee /private/tmp/claude-502/-Users-gordon-src-q2/6f5c0c8f-a359-437a-87d6-879b0e289c0e/scratchpad/wasm-after.log; grep -E "Smoke-all WASM results|Tests " /private/tmp/claude-502/-Users-gordon-src-q2/6f5c0c8f-a359-437a-87d6-879b0e289c0e/scratchpad/wasm-after.log
+cd hub-client && npm run typecheck
+```
+Expected: the `passed/skipped/failed` line is byte-identical to Step 1;
+`typecheck` clean (it proves nothing about the moved file — that is the
+point: the app project must not have grown a Node import).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add hub-client/src/test-utils/smokeAllFixtures.ts hub-client/src/services/smokeAll.wasm.test.ts
+git commit -m "Extract smoke-all fixture/VFS helpers for reuse by a parity runner"
+```
+
+### Task 0.2: Spike — dump both sides for four fixtures (throwaway)
+
+**Files:**
+- Create (throwaway, deleted at the end of the task, never committed):
+  `hub-client/src/services/paritySpike.wasm.test.tsx`
+- Modify (kept — Task 3.1 needs it too): `hub-client/vitest.wasm.config.ts:16`
+  → `include: ['src/**/*.wasm.test.{ts,tsx}']`
+- Create: `claude-notes/research/2026-08-24-preview-render-parity-spike.md`
+
+**Purpose:** answer, cheaply and before building anything:
+- **Q1** does the WASM module initialise under `// @vitest-environment jsdom`?
+- **Q2** does `render_page_for_preview` succeed on plain smoke-all fixtures,
+  and does `render_page_in_project` return `html` for them?
+- **Q3** does `<Ast>` from `@quarto/preview-renderer/framework` mount from a
+  hub-client test with no setup file (no `matchMedia`/`ResizeObserver` shims
+  — preview-renderer's non-test sources reference none, but confirm)?
+- **Q4** what do the raw `<main>` subtrees actually differ by, so the rules
+  table in § Design is confirmed or amended *before* Phase 1?
+
+Fixtures: `markdown/heading-auto-id.qmd`, `highlighting/01-builtin-python.qmd`,
+`appendix/footnotes-heading.qmd` (a project — `appendix/_quarto.yml`
+exists, so this exercises the project branch on both sides),
+`title-block/simple-default.qmd`.
+
+- [ ] **Step 1: Widen the include glob** (positional file arguments only
+  *filter within* `include`; a `.tsx` outside the glob is "no test files
+  found")
+
+```ts
+      include: ['src/**/*.wasm.test.{ts,tsx}'],
+```
+
+- [ ] **Step 2: Write the spike file**
+
+```tsx
+// @vitest-environment jsdom
+/**
+ * THROWAWAY spike for claude-notes/plans/2026-08-24-preview-render-dom-parity-harness.md
+ * Task 0.2. Deleted at the end of the task — never committed.
+ */
+import { describe, it, beforeAll } from 'vitest';
+import { mkdir, writeFile } from 'fs/promises';
+import { dirname, join, resolve } from 'path';
+import { fileURLToPath } from 'url';
+import { JSDOM } from 'jsdom';
+import { render, cleanup } from '@testing-library/react';
+import { Ast } from '@quarto/preview-renderer/framework';
+import { previewRegistry } from '@quarto/preview-renderer';
+import {
+  SMOKE_ALL_DIR,
+  loadSmokeWasm,
+  populateVfs,
+  buildUserGrammarsHandle,
+  type WasmModule,
+} from '../test-utils/smokeAllFixtures';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = resolve(__dirname, '../../test-results/parity-spike');
+
+const FIXTURES = [
+  'markdown/heading-auto-id.qmd',
+  'highlighting/01-builtin-python.qmd',
+  'appendix/footnotes-heading.qmd',
+  'title-block/simple-default.qmd',
+];
+
+let wasm: WasmModule;
+
+beforeAll(async () => {
+  wasm = await loadSmokeWasm();
+});
+
+describe('parity spike', () => {
+  it('dumps <main> from both sides', async () => {
+    await mkdir(OUT_DIR, { recursive: true });
+    for (const rel of FIXTURES) {
+      wasm.vfs_clear();
+      cleanup();
+      const { vfsPath, projectFiles } = await populateVfs(wasm, join(SMOKE_ALL_DIR, rel));
+      const grammars = await buildUserGrammarsHandle(wasm, projectFiles);
+
+      const renderRes = JSON.parse(await wasm.render_page_in_project(vfsPath, grammars));
+      const previewRes = JSON.parse(await wasm.render_page_for_preview(vfsPath, grammars, undefined));
+
+      const slug = rel.replace(/[\\/]/g, '__');
+      const renderMain = new JSDOM(renderRes.html ?? '').window.document
+        .querySelector('main#quarto-document-content');
+      const { container } = render(
+        <Ast
+          astJson={previewRes.ast_json ?? '{"pandoc-api-version":[1,23,0],"meta":{},"blocks":[]}'}
+          currentFilePath={vfsPath}
+          onNavigateToDocument={() => {}}
+          setAst={() => {}}
+          registry={previewRegistry}
+        />,
+      );
+      const previewMain = container.querySelector('main#quarto-document-content');
+
+      await writeFile(join(OUT_DIR, `${slug}.render.html`),
+        renderMain?.outerHTML ?? `NO MAIN — success=${renderRes.success} error=${renderRes.error}`);
+      await writeFile(join(OUT_DIR, `${slug}.preview.html`),
+        previewMain?.outerHTML ?? `NO MAIN — success=${previewRes.success} error=${previewRes.error}`);
+    }
+  });
+});
+```
+
+- [ ] **Step 3: Run the spike**
+
+```bash
+cd hub-client && npx vitest run --config vitest.wasm.config.ts src/services/paritySpike.wasm.test.tsx
+```
+
+Expected: the test passes (it only dumps) and eight files appear under
+`hub-client/test-results/parity-spike/`. If it fails, that is a Q1–Q3
+answer — record what and how it was worked around; that changes Task 3.1.
+
+- [ ] **Step 4: Inspect and diff each pair**
+
+```bash
+cd hub-client/test-results/parity-spike
+for f in *.render.html; do
+  b=${f%.render.html}
+  echo "=== $b"
+  diff <(sed 's/></>\n</g' "$f") <(sed 's/></>\n</g' "$b.preview.html") | head -80
+done
+```
+
+Read every diff. Classify each hunk as one of: **(a)** serialiser noise the
+§ Normalisation table already covers; **(b)** a *deliberate* divergence not
+yet in the table (needs a new rule with a reason); **(c)** a real bug (React
+or writer — bd-tmb2u5yu is a known (c) if a fixture has math).
+
+- [ ] **Step 5: Write the research note**
+
+`claude-notes/research/2026-08-24-preview-render-parity-spike.md` with:
+the exact command run; answers to Q1–Q4; a table
+`fixture | (a) hunks | (b) hunks | (c) hunks | opt-in candidate?`; verbatim
+snippets for every (b) and (c); the amended rules table if any (b) was
+found; and the initial allowlist (fixtures whose only diffs are (a)).
+
+- [ ] **Step 6: Delete the spike, commit the note + the glob change**
+
+```bash
+rm hub-client/src/services/paritySpike.wasm.test.tsx
+rm -rf hub-client/test-results/parity-spike
+git add claude-notes/research/2026-08-24-preview-render-parity-spike.md hub-client/vitest.wasm.config.ts
+git commit -m "Record preview/render DOM parity spike findings; accept .tsx wasm tests"
+```
+
+---
+
+## Phase 1 — `domParity.ts`
+
+All three tasks touch the same two files; each ends green and committed.
+`ts-packages/preview-renderer/vitest.config.ts` is `environment: 'node'`
+(line 67) and includes `src/**/*.test.ts`; the test file uses a jsdom
+docblock. The `test-utils/` directory already exists and is excluded from
+the package `tsconfig.json`, so nothing here ships in `dist/`.
+
+### Task 1.1: `canonicalize` — shape, attributes, text and whitespace
+
+**Files:**
+- Create: `ts-packages/preview-renderer/src/test-utils/domParity.ts`
+- Test: `ts-packages/preview-renderer/src/test-utils/domParity.test.ts`
+
+**Interfaces:**
+- Produces:
+  ```ts
+  export interface ParityRules {
+    stripAttrs: ReadonlySet<string>;
+    forbidAttrs: ReadonlySet<string>;
+    opaqueSelectors: readonly string[];
+  }
+  export const PARITY_RULES: ParityRules;            // empty until Task 1.2
+  export const OPAQUE_MARKER = '⟨opaque⟩';
+  export const INLINE_TAGS: ReadonlySet<string>;
+  export class ParityRuleViolation extends Error {}
+  export function canonicalize(el: Element, rules?: ParityRules): string;
+  ```
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { canonicalize } from './domParity';
+
+function el(html: string): Element {
+  const host = document.createElement('div');
+  host.innerHTML = html;
+  return host.firstElementChild!;
+}
+
+describe('canonicalize — shape', () => {
+  it('emits one line per node, indented by depth, no closing lines', () => {
+    const out = canonicalize(el('<main id="x"><p>hi <em>there</em></p></main>'));
+    expect(out).toBe(
+      ['<main id="x">', '  <p>', '    "hi "', '    <em>', '      "there"'].join('\n'),
+    );
+  });
+
+  it('sorts attributes by name and lower-cases tag names', () => {
+    const out = canonicalize(el('<DIV title="t" class="c" id="i"></DIV>'));
+    expect(out).toBe('<div class="c" id="i" title="t">');
+  });
+
+  it('drops pretty-printing whitespace between block elements and drops comments', () => {
+    const out = canonicalize(el('<div>\n  <!-- c -->\n  <p>  a \n b  </p>\n</div>'));
+    expect(out).toBe(['<div>', '  <p>', '    "a b"'].join('\n'));
+  });
+
+  it('collapses whitespace inside class but preserves token order', () => {
+    const out = canonicalize(el('<pre class="  sourceCode   python ">x</pre>'));
+    expect(out).toBe(['<pre class="sourceCode python">', '  "x"'].join('\n'));
+  });
+
+  it('escapes quotes in attribute values so lines stay single-line', () => {
+    const out = canonicalize(el('<a title=\'say "hi"\'></a>'));
+    expect(out).toBe('<a title="say &quot;hi&quot;">');
+  });
+});
+
+describe('canonicalize — inline whitespace is significant', () => {
+  it('distinguishes <em>a</em> <em>b</em> from <em>a</em><em>b</em>', () => {
+    const spaced = canonicalize(el('<p><em>a</em> <em>b</em></p>'));
+    const tight = canonicalize(el('<p><em>a</em><em>b</em></p>'));
+    expect(spaced).not.toBe(tight);
+    expect(spaced).toBe(['<p>', '  <em>', '    "a"', '  " "', '  <em>', '    "b"'].join('\n'));
+  });
+
+  it('keeps a trailing space before an inline sibling but trims before a block sibling', () => {
+    expect(canonicalize(el('<p>hi <em>x</em></p>'))).toContain('"hi "');
+    expect(canonicalize(el('<div>hi <p>x</p></div>'))).toContain('"hi"');
+  });
+
+  it('keeps text verbatim inside <pre>', () => {
+    const out = canonicalize(el('<pre><code>x\n  y\n</code></pre>'));
+    expect(out).toBe(['<pre>', '  <code>', '    "x\\n  y\\n"'].join('\n'));
+  });
+
+  it('merges adjacent text nodes (React emits one per Str/Space)', () => {
+    const p = document.createElement('p');
+    p.appendChild(document.createTextNode('hi'));
+    p.appendChild(document.createTextNode(' '));
+    p.appendChild(document.createTextNode('there'));
+    expect(canonicalize(p)).toBe(canonicalize(el('<p>hi there</p>')));
+    expect(p.childNodes.length).toBe(3); // input not mutated
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+cd ts-packages/preview-renderer && npx vitest run src/test-utils/domParity.test.ts
+```
+Expected: FAIL — cannot resolve `./domParity`.
+
+- [ ] **Step 3: Implement**
+
+```ts
+/**
+ * DOM canonicalisation for preview ↔ render parity.
+ *
+ * Plan: claude-notes/plans/2026-08-24-preview-render-dom-parity-harness.md
+ *
+ * Converts an Element subtree to a line-oriented canonical text so two
+ * independently-produced DOMs (the native HTML writer's, parsed by
+ * jsdom; the React renderer's, mounted by testing-library) can be
+ * compared with a plain string diff. Every normalisation applied here
+ * is listed in the plan's § Normalisation table with its reason; do not
+ * add a rule without one.
+ *
+ * Test-only: this directory is excluded from the package build, and
+ * hub-client reaches it through vitest's `@quarto/preview-renderer`
+ * source alias, not the package exports map.
+ */
+
+export interface ParityRules {
+  /** Attribute names removed from every element before comparison. */
+  stripAttrs: ReadonlySet<string>;
+  /** Attribute names whose presence on either side is an error. */
+  forbidAttrs: ReadonlySet<string>;
+  /**
+   * CSS selectors whose matching elements keep their tag + attributes
+   * but have their children replaced by a single OPAQUE_MARKER line.
+   */
+  opaqueSelectors: readonly string[];
+}
+
+export const OPAQUE_MARKER = '⟨opaque⟩';
+
+/** Thrown when a forbidden attribute is found (see PARITY_RULES.forbidAttrs). */
+export class ParityRuleViolation extends Error {}
+
+export const PARITY_RULES: ParityRules = {
+  // Populated in Task 1.2. Empty rules == pure serialiser normalisation.
+  stripAttrs: new Set<string>(),
+  forbidAttrs: new Set<string>(),
+  opaqueSelectors: [],
+};
+
+/**
+ * Elements whose adjacency to a text node makes that text node's edge
+ * whitespace significant. Whitespace next to anything else (block
+ * elements, or nothing) is the writer's pretty-printing and is dropped.
+ */
+export const INLINE_TAGS: ReadonlySet<string> = new Set([
+  'a', 'abbr', 'b', 'br', 'cite', 'code', 'del', 'em', 'i', 'img', 'ins',
+  'kbd', 'mark', 'q', 's', 'samp', 'small', 'span', 'strong', 'sub', 'sup',
+  'time', 'u', 'var',
+]);
+
+const ELEMENT_NODE = 1;
+const TEXT_NODE = 3;
+
+function escapeAttr(value: string): string {
+  return value.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/\n/g, ' ');
+}
+
+function isInlineNeighbor(n: Node | null): boolean {
+  if (!n) return false;
+  if (n.nodeType === TEXT_NODE) return (n.textContent ?? '').trim().length > 0;
+  if (n.nodeType === ELEMENT_NODE) return INLINE_TAGS.has((n as Element).tagName.toLowerCase());
+  return false;
+}
+
+/** Whitespace-normalised text outside <pre>; '' means "drop this node". */
+function normalizeText(node: Node): string {
+  let s = (node.textContent ?? '').replace(/\s+/g, ' ');
+  if (!isInlineNeighbor(node.previousSibling)) s = s.replace(/^ /, '');
+  if (!isInlineNeighbor(node.nextSibling)) s = s.replace(/ $/, '');
+  return s;
+}
+
+function openTagLine(el: Element, rules: ParityRules): string {
+  const attrs: Array<{ name: string; line: string }> = [];
+  for (const { name, value } of Array.from(el.attributes)) {
+    if (rules.forbidAttrs.has(name)) {
+      throw new ParityRuleViolation(
+        `forbidden attribute '${name}' on <${el.tagName.toLowerCase()}> — see PARITY_RULES.forbidAttrs`,
+      );
+    }
+    if (rules.stripAttrs.has(name)) continue;
+    const v = name === 'class' ? value.replace(/\s+/g, ' ').trim() : value;
+    attrs.push({ name, line: `${name}="${escapeAttr(v)}"` });
+  }
+  attrs.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+  const tag = el.tagName.toLowerCase();
+  return attrs.length ? `<${tag} ${attrs.map((a) => a.line).join(' ')}>` : `<${tag}>`;
+}
+
+function walk(node: Node, depth: number, rules: ParityRules, out: string[], inPre: boolean): void {
+  const pad = '  '.repeat(depth);
+  if (node.nodeType === TEXT_NODE) {
+    const text = inPre ? (node.textContent ?? '') : normalizeText(node);
+    if (text) out.push(pad + JSON.stringify(text));
+    return;
+  }
+  if (node.nodeType !== ELEMENT_NODE) return; // comments, processing instructions
+  const el = node as Element;
+  out.push(pad + openTagLine(el, rules));
+  if (rules.opaqueSelectors.some((sel) => el.matches(sel))) {
+    out.push(`${'  '.repeat(depth + 1)}${OPAQUE_MARKER}`);
+    return;
+  }
+  const childInPre = inPre || el.tagName.toLowerCase() === 'pre';
+  for (const child of Array.from(el.childNodes)) walk(child, depth + 1, rules, out, childInPre);
+}
+
+/**
+ * Canonical, line-oriented rendering of `el` and its subtree. Works on a
+ * clone so the caller's DOM is untouched (adjacent text nodes are merged
+ * with `normalize()` first — React emits one text node per Str/Space).
+ */
+export function canonicalize(el: Element, rules: ParityRules = PARITY_RULES): string {
+  const clone = el.cloneNode(true) as Element;
+  clone.normalize();
+  const out: string[] = [];
+  walk(clone, 0, rules, out, false);
+  return out.join('\n');
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+```bash
+cd ts-packages/preview-renderer && npx vitest run src/test-utils/domParity.test.ts
+```
+Expected: 9 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ts-packages/preview-renderer/src/test-utils/domParity.ts ts-packages/preview-renderer/src/test-utils/domParity.test.ts
+git commit -m "Add DOM canonicaliser for preview/render parity"
+```
+
+### Task 1.2: `PARITY_RULES` — strip list, opaque math, forbidden `data-hl-spans`
+
+**Files:**
+- Modify: `ts-packages/preview-renderer/src/test-utils/domParity.ts` (`PARITY_RULES`)
+- Test: `ts-packages/preview-renderer/src/test-utils/domParity.test.ts`
+
+**Interfaces:**
+- Consumes: `canonicalize`, `OPAQUE_MARKER`, `ParityRuleViolation` from Task 1.1.
+- Produces: the populated `PARITY_RULES` used by the runner.
+
+- [ ] **Step 1: Write the failing tests**
+
+Extend the existing import line to
+`import { canonicalize, OPAQUE_MARKER, ParityRuleViolation } from './domParity';`
+and append:
+
+```ts
+describe('PARITY_RULES', () => {
+  it('strips preview-only source-tracking attributes', () => {
+    const out = canonicalize(el('<p data-loc="f:1:1-1:5" data-sid="7" class="k">x</p>'));
+    expect(out).toBe(['<p class="k">', '  "x"'].join('\n'));
+  });
+
+  it('keeps id and every other data-* attribute', () => {
+    const out = canonicalize(el('<section id="intro" data-qf-ref-type="fig"></section>'));
+    expect(out).toBe('<section data-qf-ref-type="fig" id="intro">');
+  });
+
+  it('makes span.math contents opaque but keeps the span and its classes', () => {
+    const a = canonicalize(el('<span class="math inline">\\(x^2\\)</span>'));
+    const b = canonicalize(el('<span class="math inline"><span class="katex">…</span></span>'));
+    expect(a).toBe(b);
+    expect(a).toBe(['<span class="math inline">', `  ${OPAQUE_MARKER}`].join('\n'));
+  });
+
+  it('throws ParityRuleViolation when data-hl-spans leaks', () => {
+    expect(() => canonicalize(el('<pre data-hl-spans="[]"><code>x</code></pre>'))).toThrow(
+      ParityRuleViolation,
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+cd ts-packages/preview-renderer && npx vitest run src/test-utils/domParity.test.ts
+```
+Expected: the four new tests FAIL (attributes present / no opaque marker / no throw).
+
+- [ ] **Step 3: Populate the rules**
+
+Replace the `PARITY_RULES` constant:
+
+```ts
+export const PARITY_RULES: ParityRules = {
+  stripAttrs: new Set<string>([
+    // Source tracking: emitted only when `include_source_locations` is on
+    // (crates/pampa/src/writers/html.rs, `data-sid`/`data-loc` doc block
+    // ~L743-748). Off for `q2 render`; on for the preview AST
+    // (`PreviewAstOutput.ast_json` is written with
+    // `include_inline_locations: true`, crates/quarto-core/src/pipeline.rs
+    // ~L195) and forwarded by React via `dataLocProps`. Preview-only by
+    // construction.
+    //
+    // NOT listed: `data-block-pool-id` (React edit chrome). The parity
+    // runner mounts read-only (no PreviewContext), so it is never emitted;
+    // add it here only if the mount configuration changes.
+    'data-loc',
+    'data-sid',
+  ]),
+  forbidAttrs: new Set<string>([
+    // Consumed by both writers — `write_code_container_attr`
+    // (crates/pampa/src/writers/html.rs ~L539) and
+    // q2-preview/blocks/CodeBlock.tsx decode it into <span class="hl-…">
+    // markup and must NOT forward it. Leakage is a bug (bd-nxslt), so the
+    // harness errors instead of normalising it away.
+    'data-hl-spans',
+  ]),
+  opaqueSelectors: [
+    // `math-js` is excluded from the preview pipeline
+    // (Q2_PREVIEW_STAGE_EXCLUDED, crates/quarto-core/src/pipeline.rs ~L394):
+    // render leaves TeX in \( \) delimiters for MathJax; React
+    // (q2-preview/inlines/Math.tsx) emits KaTeX HTML. Divergent by design.
+    // The <span> itself and its `math inline|display` classes still
+    // compare — which is why bd-tmb2u5yu (Math.tsx emits no class) must
+    // close before any fixture containing math can opt in.
+    'span.math',
+  ],
+};
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+```bash
+cd ts-packages/preview-renderer && npx vitest run src/test-utils/domParity.test.ts
+```
+Expected: 13 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ts-packages/preview-renderer/src/test-utils/domParity.ts ts-packages/preview-renderer/src/test-utils/domParity.test.ts
+git commit -m "Define preview/render parity normalisation rules with reasons"
+```
+
+### Task 1.3: `extractParityRoot` + `compareParity`
+
+**Files:**
+- Modify: `ts-packages/preview-renderer/src/test-utils/domParity.ts`
+- Test: `ts-packages/preview-renderer/src/test-utils/domParity.test.ts`
+
+**Interfaces:**
+- Produces:
+  ```ts
+  export const PARITY_ROOT_SELECTOR = 'main#quarto-document-content';
+  export function extractParityRoot(scope: ParentNode, label: string): Element;  // throws if absent
+  export interface ParityResult { equal: boolean; render: string; preview: string; }
+  export function compareParity(renderRoot: Element, previewRoot: Element, rules?: ParityRules): ParityResult;
+  ```
+
+- [ ] **Step 1: Write the failing tests**
+
+Extend the import line with `extractParityRoot, compareParity` and append:
+
+```ts
+describe('extractParityRoot / compareParity', () => {
+  it('finds main#quarto-document-content and names the side on failure', () => {
+    const host = document.createElement('div');
+    host.innerHTML =
+      '<div id="quarto-content"><main class="content" id="quarto-document-content"><p>x</p></main></div>';
+    expect(extractParityRoot(host, 'render').tagName).toBe('MAIN');
+    const empty = document.createElement('div');
+    expect(() => extractParityRoot(empty, 'preview')).toThrow(/preview.*main#quarto-document-content/);
+  });
+
+  it('reports equal for identical subtrees modulo rules', () => {
+    const r = compareParity(
+      el('<main id="quarto-document-content" class="content"><p>a</p></main>'),
+      el('<main class="content" id="quarto-document-content"><p data-loc="x">a</p></main>'),
+    );
+    expect(r.equal).toBe(true);
+    expect(r.render).toBe(r.preview);
+  });
+
+  it('reports unequal and exposes both canonical texts for a class divergence', () => {
+    const r = compareParity(
+      el('<main id="quarto-document-content"><pre class="sourceCode python"><code>x</code></pre></main>'),
+      el('<main id="quarto-document-content"><pre class="python"><code>x</code></pre></main>'),
+    );
+    expect(r.equal).toBe(false);
+    expect(r.render).toContain('class="sourceCode python"');
+    expect(r.preview).toContain('class="python"');
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+cd ts-packages/preview-renderer && npx vitest run src/test-utils/domParity.test.ts
+```
+Expected: 3 new FAIL (exports missing).
+
+- [ ] **Step 3: Implement**
+
+Append to `domParity.ts`:
+
+```ts
+/** The subtree both pipelines are contractually required to agree on. */
+export const PARITY_ROOT_SELECTOR = 'main#quarto-document-content';
+
+/**
+ * Locate the parity root inside a document / container. `label` names
+ * the side ("render" / "preview") so a missing root is attributable.
+ */
+export function extractParityRoot(scope: ParentNode, label: string): Element {
+  const root = scope.querySelector(PARITY_ROOT_SELECTOR);
+  if (!root) {
+    throw new Error(`${label}: no element matches ${PARITY_ROOT_SELECTOR}`);
+  }
+  return root;
+}
+
+export interface ParityResult {
+  equal: boolean;
+  /** Canonical text of the render side. */
+  render: string;
+  /** Canonical text of the preview side. */
+  preview: string;
+}
+
+/**
+ * Canonicalise both roots and compare. Never throws for a mismatch; does
+ * throw (ParityRuleViolation) on a forbidden attribute.
+ */
+export function compareParity(
+  renderRoot: Element,
+  previewRoot: Element,
+  rules: ParityRules = PARITY_RULES,
+): ParityResult {
+  const render = canonicalize(renderRoot, rules);
+  const preview = canonicalize(previewRoot, rules);
+  return { equal: render === preview, render, preview };
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+```bash
+cd ts-packages/preview-renderer && npx vitest run src/test-utils/domParity.test.ts
+cd ts-packages/preview-renderer && npm test && npm run test:integration
+```
+Expected: 16 passed in the new file; the package suites green with the same
+counts as before plus 16.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ts-packages/preview-renderer/src/test-utils/domParity.ts ts-packages/preview-renderer/src/test-utils/domParity.test.ts
+git commit -m "Add parity root extraction and comparison"
+```
+
+---
+
+## Phase 2 — `parity:` DSL key
+
+### Task 2.1: Rust `quarto-test` accepts `parity`
+
+**Files:**
+- Modify: `crates/quarto-test/src/spec.rs:124-133` (`TestSpec`), `:180-265`
+  (`parse_format_spec`; the only `Ok(TestSpec {` constructor is at `:259`)
+- Test: `crates/quarto-test/src/spec.rs` tests module (`:472`+), next to
+  `test_unknown_assertion_fails` (`:575`)
+
+**Interfaces:**
+- Consumes: `parse_test_specs(metadata: &Value, input_path: &Path) -> Result<(Option<RunConfig>, Vec<TestSpec>)>` (`spec.rs:139`) — note it returns a **tuple**.
+- Produces: `TestSpec.parity: bool` — `true` when the fixture opts into the
+  preview↔render DOM parity runner. The native runner ignores it; the field
+  exists so the DSL stays a single grammar across all four runners.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+    #[test]
+    fn test_parity_key_is_accepted_and_recorded() {
+        let yaml: Value = serde_yaml::from_str(
+            r#"
+            _quarto:
+              tests:
+                html:
+                  noErrors: true
+                  parity: true
+            "#,
+        )
+        .unwrap();
+
+        let (_run, specs) = parse_test_specs(&yaml, std::path::Path::new("test.qmd")).unwrap();
+        let html = specs.iter().find(|s| s.format == "html").expect("html spec");
+        assert!(html.parity, "parity: true must be recorded");
+        // Only noErrors produced an assertion; parity is not one.
+        assert_eq!(html.assertions.len(), 1);
+    }
+
+    #[test]
+    fn test_parity_defaults_false_and_rejects_non_bool() {
+        let yaml: Value = serde_yaml::from_str(
+            r#"
+            _quarto:
+              tests:
+                html:
+                  noErrors: true
+            "#,
+        )
+        .unwrap();
+        let (_run, specs) = parse_test_specs(&yaml, std::path::Path::new("test.qmd")).unwrap();
+        assert!(!specs[0].parity);
+
+        let bad: Value = serde_yaml::from_str(
+            r#"
+            _quarto:
+              tests:
+                html:
+                  parity: "yes"
+            "#,
+        )
+        .unwrap();
+        let err = format!(
+            "{:#}",
+            parse_test_specs(&bad, std::path::Path::new("test.qmd")).unwrap_err()
+        );
+        assert!(err.contains("parity must be a boolean"), "got: {err}");
+    }
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+cargo nextest run -p quarto-test test_parity
+```
+Expected: compile error — no field `parity` on `TestSpec`.
+
+- [ ] **Step 3: Implement**
+
+In `TestSpec` add:
+
+```rust
+    /// `parity: true` — opt this format into the preview ↔ render DOM
+    /// parity runner (`hub-client/src/services/smokeAllParity.wasm.test.tsx`).
+    /// The native runner ignores it; the field exists so all four
+    /// smoke-all runners share one DSL grammar. Plan:
+    /// claude-notes/plans/2026-08-24-preview-render-dom-parity-harness.md
+    pub parity: bool,
+```
+
+In `parse_format_spec`, add `let mut parity = false;` beside
+`check_warnings`, a match arm before `other =>`:
+
+```rust
+                "parity" => {
+                    parity = assertion_value
+                        .as_bool()
+                        .context("parity must be a boolean")?;
+                }
+```
+
+and `parity,` in the `Ok(TestSpec { … })` constructor at `:259`.
+
+- [ ] **Step 4: Run to verify pass**
+
+```bash
+cargo clippy -p quarto-test --all-targets -- -D warnings
+cargo nextest run -p quarto-test
+cargo nextest run -p quarto --test integration smoke_all
+```
+Expected: all green; the smoke_all sweep is unchanged (no fixture opts in yet).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/quarto-test/src/spec.rs
+git commit -m "Accept a parity key in the smoke-all test DSL (native runner ignores it)"
+```
+
+### Task 2.2: Both TS parsers ignore `parity`; Phase-2 boundary
+
+**Files:**
+- Modify: `hub-client/src/services/smokeAll.wasm.test.ts` — `parseFormatSpec`,
+  the filesystem no-op group (~L270-276 after Task 0.1's move) + `default:`
+  which today throws `Unknown assertion type` (was `:277` before the move)
+- Modify: `hub-client/e2e/helpers/smokeAllDiscovery.ts:234-240` (the
+  `fileExists` no-op group + `default: throw`)
+
+Both parsers hard-error on unknown keys, so a fixture with `parity: true`
+would break the WASM sweep and the Playwright sweep until this lands.
+
+- [ ] **Step 1: Check for an existing unit test of either parser**
+
+```bash
+ls hub-client/e2e/helpers/*.test.ts 2>/dev/null; grep -rln "smokeAllDiscovery" hub-client/e2e hub-client/src | head
+```
+
+If a test file for `smokeAllDiscovery` exists, add there and watch it fail:
+
+```ts
+it('accepts parity: true as a non-assertion', () => {
+  const { formatSpecs } = parseTestSpecs({ _quarto: { tests: { html: { noErrors: true, parity: true } } } });
+  expect(formatSpecs[0].assertions.map((a) => a.type)).toEqual(['noErrors']);
+});
+```
+
+If none exists, do not create one for a one-line case; Task 3.1's opt-in
+plus `npx playwright test e2e/smoke-all.spec.ts --list` is the check.
+
+- [ ] **Step 2: Implement — same three lines in both files**
+
+```ts
+        case 'parity':
+          // Opt-in flag for the preview <-> render DOM parity runner
+          // (hub-client/src/services/smokeAllParity.wasm.test.tsx). Not an
+          // assertion here.
+          break;
+```
+
+- [ ] **Step 3: Verify**
+
+```bash
+cd hub-client && npm run test:wasm      # counts identical to Task 0.1 Step 1
+cd hub-client && npx playwright test e2e/smoke-all.spec.ts --list | tail -3
+```
+Expected: WASM counts unchanged; Playwright lists the same number of tests
+as on `main` (`--list` does not launch a browser or the web server).
+
+- [ ] **Step 4: Phase-2 boundary — workspace nextest**
+
+```bash
+cargo nextest run --workspace 2>&1 | tee /private/tmp/claude-502/-Users-gordon-src-q2/6f5c0c8f-a359-437a-87d6-879b0e289c0e/scratchpad/nextest-phase2.log; grep -E "Summary|passed|failed|skipped" /private/tmp/claude-502/-Users-gordon-src-q2/6f5c0c8f-a359-437a-87d6-879b0e289c0e/scratchpad/nextest-phase2.log | tail -3
+```
+Expected: green; delta vs the live baseline on `main` @ `cf9c45cc8` is
+exactly +2 passed (Task 2.1's two tests). If no baseline log exists, run the
+same command on `main` first and record it.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add hub-client/src/services/smokeAll.wasm.test.ts hub-client/e2e/helpers/smokeAllDiscovery.ts
+git commit -m "Ignore the parity key in the WASM and Playwright smoke-all parsers"
+```
+
+---
+
+## Phase 3 — Runner
+
+### Task 3.1: `smokeAllParity.wasm.test.tsx` + first opt-in (one green commit)
+
+**Files:**
+- Create: `hub-client/src/services/smokeAllParity.wasm.test.tsx`
+- Modify: the first opt-in candidate from the Task 0.2 note (expected:
+  `crates/quarto/tests/smoke-all/markdown/heading-auto-id.qmd`) — add
+  `parity: true` under `_quarto.tests.html`
+
+The runner and its first fixture land together so no commit on the branch
+is red.
+
+**Interfaces:**
+- Consumes: everything exported by `smokeAllFixtures.ts` (Task 0.1);
+  `extractParityRoot`, `compareParity`, `ParityRuleViolation` from
+  `@quarto/preview-renderer/test-utils/domParity` — resolved by the
+  `@quarto/preview-renderer` → `../ts-packages/preview-renderer/src` alias
+  in `vitest.wasm.config.ts` (prefix match, the same mechanism the sibling
+  uses for `@quarto/preview-runtime/userGrammar/Discovery`). **vitest-only**:
+  this path is not in the package exports map and `tsc` never sees this
+  file (§ Global Constraints). `Ast` from
+  `@quarto/preview-renderer/framework` (it is **not** re-exported from the
+  package root — `src/index.ts` re-exports `./q2-preview` only; the sibling
+  test imports it from `../framework`, `q2-preview.integration.test.tsx:35`);
+  `previewRegistry` from `@quarto/preview-renderer`.
+
+- [ ] **Step 1: Write the runner with its two tests (the second is the self-check)**
+
+```tsx
+// @vitest-environment jsdom
+/**
+ * Preview <-> render DOM parity runner (fourth smoke-all runner).
+ *
+ * For every smoke-all fixture whose `_quarto.tests.html` carries
+ * `parity: true`, render it twice through the same WASM module:
+ *   - `render_page_in_project`   -> native HTML writer -> full page HTML
+ *   - `render_page_for_preview`  -> the same Rust function with
+ *                                   `prefer_preview_format: true`: pipeline
+ *                                   stopped before `render-html-body`
+ *                                   -> Pandoc AST JSON
+ * Mount the AST read-only with the real q2-preview React registry under
+ * jsdom, and require the canonical form of `main#quarto-document-content`
+ * to be identical on both sides. Normalisation rules and their reasons
+ * live in `ts-packages/preview-renderer/src/test-utils/domParity.ts`.
+ *
+ * Opt-in is curated: an opted-in fixture that diverges FAILS. There is
+ * no expected-failure list — fix the divergence or remove the opt-in.
+ *
+ * Plan: claude-notes/plans/2026-08-24-preview-render-dom-parity-harness.md
+ * Manual predecessor: .claude/skills/preview-render-parity/SKILL.md
+ */
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import { readFile, mkdir, writeFile } from 'fs/promises';
+import { join, relative, resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { JSDOM } from 'jsdom';
+import { render, cleanup } from '@testing-library/react';
+import { Ast } from '@quarto/preview-renderer/framework';
+import { previewRegistry } from '@quarto/preview-renderer';
+import {
+  extractParityRoot,
+  compareParity,
+  ParityRuleViolation,
+} from '@quarto/preview-renderer/test-utils/domParity';
+import {
+  SMOKE_ALL_DIR,
+  loadSmokeWasm,
+  discoverTestFiles,
+  readFrontmatter,
+  readTestsBlock,
+  shouldSkip,
+  populateVfs,
+  buildUserGrammarsHandle,
+  type WasmModule,
+} from '../test-utils/smokeAllFixtures';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = resolve(__dirname, '../../test-results/parity');
+
+let wasm: WasmModule;
+
+beforeAll(async () => {
+  wasm = await loadSmokeWasm();
+});
+
+beforeEach(() => {
+  wasm.vfs_clear();
+  cleanup();
+});
+
+interface Sides {
+  renderMain: Element;
+  previewMain: Element;
+}
+
+/** Render one fixture both ways and return the two parity roots. */
+async function renderBothSides(testFile: string): Promise<Sides> {
+  const { vfsPath, projectFiles } = await populateVfs(wasm, testFile);
+  const grammars = await buildUserGrammarsHandle(wasm, projectFiles);
+
+  const renderRes = JSON.parse(await wasm.render_page_in_project(vfsPath, grammars)) as {
+    success: boolean; html?: string; error?: string;
+  };
+  if (!renderRes.success || !renderRes.html) {
+    throw new Error(`render_page_in_project failed: ${renderRes.error ?? 'no html'}`);
+  }
+
+  const previewRes = JSON.parse(
+    await wasm.render_page_for_preview(vfsPath, grammars, undefined),
+  ) as { success: boolean; ast_json?: string; error?: string };
+  if (!previewRes.success || !previewRes.ast_json) {
+    throw new Error(`render_page_for_preview failed: ${previewRes.error ?? 'no ast_json'}`);
+  }
+
+  const renderDoc = new JSDOM(renderRes.html).window.document;
+  // Read-only mount: no PreviewContext / AssetManifestContext /
+  // IncrementalContext on purpose (plan § Global Constraints).
+  const { container } = render(
+    <Ast
+      astJson={previewRes.ast_json}
+      currentFilePath={vfsPath}
+      onNavigateToDocument={() => {}}
+      setAst={() => {}}
+      registry={previewRegistry}
+    />,
+  );
+  return {
+    renderMain: extractParityRoot(renderDoc, 'render'),
+    previewMain: extractParityRoot(container, 'preview'),
+  };
+}
+
+async function writeArtifacts(relPath: string, renderText: string, previewText: string) {
+  const dir = join(OUT_DIR, relPath.replace(/[\\/]/g, '__'));
+  await mkdir(dir, { recursive: true });
+  await writeFile(join(dir, 'render.norm.txt'), renderText);
+  await writeFile(join(dir, 'preview.norm.txt'), previewText);
+  return dir;
+}
+
+/** Produce vitest's own diff text for two strings without throwing. */
+function diffText(expected: string, actual: string): string {
+  try {
+    expect(actual).toBe(expected);
+    return '';
+  } catch (e) {
+    return (e as Error).message;
+  }
+}
+
+async function optedInFixtures(): Promise<string[]> {
+  const files = await discoverTestFiles(SMOKE_ALL_DIR);
+  const out: string[] = [];
+  for (const f of files) {
+    const block = readTestsBlock(readFrontmatter(await readFile(f, 'utf-8')));
+    if (!block || shouldSkip(block.run)) continue;
+    if (block.formats['html']?.['parity'] === true) out.push(f);
+  }
+  return out;
+}
+
+describe('smoke-all preview <-> render DOM parity', () => {
+  // Same single-`it` shape as smokeAll.wasm.test.ts: vitest collects tests
+  // synchronously, and discovery is async.
+  it('every opted-in fixture has identical <main> DOM on both sides', async () => {
+    const fixtures = await optedInFixtures();
+    const smokeFilter = process.env.SMOKE_FILTER || '';
+    const failures: string[] = [];
+    let compared = 0;
+
+    for (const testFile of fixtures) {
+      const relPath = relative(SMOKE_ALL_DIR, testFile);
+      if (smokeFilter && !relPath.includes(smokeFilter)) continue;
+      wasm.vfs_clear();
+      cleanup();
+      const started = performance.now();
+      try {
+        const { renderMain, previewMain } = await renderBothSides(testFile);
+        const result = compareParity(renderMain, previewMain);
+        compared++;
+        if (!result.equal) {
+          const dir = await writeArtifacts(relPath, result.render, result.preview);
+          failures.push(
+            `${relPath} [html]: parity mismatch (artifacts: ${dir})\n${diffText(result.render, result.preview)}`,
+          );
+        }
+      } catch (e) {
+        const kind = e instanceof ParityRuleViolation ? 'rule violation' : 'error';
+        failures.push(`${relPath} [html]: ${kind}: ${(e as Error).message}`);
+      }
+      console.log(`  parity ${relPath}: ${Math.round(performance.now() - started)} ms`);
+    }
+
+    console.log(`\nParity results: ${compared} compared, ${failures.length} failed, ${fixtures.length} opted in`);
+    expect(fixtures.length, 'at least one fixture must opt in (parity: true)').toBeGreaterThan(0);
+    expect(failures, `${failures.length} parity failure(s):\n${failures.join('\n\n')}`).toHaveLength(0);
+  });
+
+  it('reports an injected divergence (harness self-check)', async () => {
+    const [first] = await optedInFixtures();
+    expect(first, 'needs one opted-in fixture').toBeDefined();
+    const { renderMain, previewMain } = await renderBothSides(first);
+    expect(compareParity(renderMain, previewMain).equal).toBe(true);
+
+    // Inject: add a class to the first element on the preview side.
+    const victim = previewMain.querySelector('p, h1, h2, pre, div, section');
+    expect(victim).not.toBeNull();
+    victim!.classList.add('injected-divergence');
+
+    const result = compareParity(renderMain, previewMain);
+    expect(result.equal).toBe(false);
+    expect(result.preview).toContain('injected-divergence');
+    expect(result.render).not.toContain('injected-divergence');
+  });
+});
+```
+
+- [ ] **Step 2: Run before opting anything in — verify the right failure**
+
+```bash
+cd hub-client && npm run test:wasm
+```
+Expected: the sibling runner still green; the new file FAILS on
+`at least one fixture must opt in` and `needs one opted-in fixture`. Any
+*other* failure (module resolution, JSX transform, WASM under jsdom,
+`render` complaining) is a harness bug — fix it here. (No setup file is
+loaded for this config; Task 0.2's Q3 established none is needed. If that
+turns out wrong, add `setupFiles` to `vitest.wasm.config.ts` pointing at a
+new `src/test-utils/parity-setup.ts` with only the shim that is missing.)
+
+- [ ] **Step 3: Opt in the first fixture**
+
+```yaml
+_quarto:
+  tests:
+    html:
+      noErrors: true
+      parity: true
+```
+
+```bash
+cd hub-client && SMOKE_FILTER=heading-auto-id npm run test:wasm
+```
+Expected: `Parity results: 1 compared, 0 failed, 1 opted in`; self-check passes.
+
+If it fails with a *mismatch*, the spike note was wrong or a rule is
+missing: read the artifacts under `hub-client/test-results/parity/`, classify
+(a)/(b)/(c) as in Task 0.2 Step 4. (b) → add the rule with a reason in
+`domParity.ts` + a unit test (a Task-1.2-shaped mini-step). (c) → pick the
+next candidate from the note; record the divergence for Task 4.1.
+
+- [ ] **Step 4: Commit (green)**
+
+```bash
+git add hub-client/src/services/smokeAllParity.wasm.test.tsx crates/quarto/tests/smoke-all/markdown/heading-auto-id.qmd
+git commit -m "Add preview/render DOM parity runner over opted-in smoke-all fixtures"
+```
+
+### Task 3.2: Opt in the remaining green fixtures
+
+**Files:**
+- Modify: each remaining opt-in candidate from the Task 0.2 note. Expected
+  (amend from the note): `highlighting/01-builtin-python.qmd`,
+  `appendix/footnotes-heading.qmd`, `title-block/simple-default.qmd`.
+
+- [ ] **Step 1: Opt in one at a time, same loop as Task 3.1 Step 3**
+
+- [ ] **Step 2: All four runners green**
+
+```bash
+cargo nextest run -p quarto --test integration smoke_all           # Rust: parity key accepted
+cd hub-client && npm run test:wasm                                 # WASM sibling + parity
+cd hub-client && npx playwright test e2e/smoke-all.spec.ts --list  # discovery parses the key
+```
+Expected: Rust sweep unchanged; WASM sibling counts unchanged from Task 0.1
+Step 1; parity `N compared, 0 failed, N opted in`; Playwright lists the same
+tests as before.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/quarto/tests/smoke-all
+git commit -m "Opt further smoke-all fixtures into preview/render DOM parity"
+```
+
+---
+
+## Phase 4 — Triage, docs, gate
+
+### Task 4.1: File strands for real divergences
+
+**Files:** none (braid). bd-tmb2u5yu (`Math.tsx` classes) is already filed.
+
+For each further (c)-class divergence recorded in the Task 0.2 note or found
+in Phase 3, create one strand. These are out-of-plan bugs (they are
+*findings* of this plan, not work items of it):
+
+```bash
+braid create "preview parity: <one-line symptom>" -t bug -p 2 -l preview-parity \
+  -d "$(cat <<EOF
+Found by the preview<->render DOM parity harness
+(hub-client/src/services/smokeAllParity.wasm.test.tsx) on fixture
+crates/quarto/tests/smoke-all/<path>.qmd.
+
+render:  <canonical snippet>
+preview: <canonical snippet>
+
+Native writer: crates/pampa/src/writers/html.rs:<line>
+React: ts-packages/preview-renderer/src/q2-preview/<component>.tsx
+
+Fix should end with \`parity: true\` on the fixture.
+EOF
+)" --json
+```
+
+- [ ] Create one strand per divergence; list their ids in this plan under a
+  new § Findings section and in the research note.
+
+### Task 4.2: Documentation
+
+**Files:**
+- Modify: `claude-notes/instructions/testing.md:116-140`:
+  - line 116 "three independent runners" → "four";
+  - line 120's stale `cargo nextest run -p quarto --test smoke_all` →
+    `cargo nextest run -p quarto --test integration smoke_all`;
+  - add `### 4. Preview ↔ render DOM parity (WASM + jsdom)` after runner 3:
+    command (`cd hub-client && npm run test:wasm`, `SMOKE_FILTER=` works),
+    what it compares (`main#quarto-document-content`, read-only mount),
+    how to opt in (`parity: true` under `html:`), the no-xfail policy,
+    where artifacts land (`hub-client/test-results/parity/`), and that
+    fixtures with math wait on bd-tmb2u5yu;
+  - add `parity` to the DSL reference (search `ensureCssRegexMatches` for the list).
+- Modify: `.claude/skills/preview-render-parity/SKILL.md`:
+  - in "Diagnosis workflow" insert a step 0: *reproduce with the harness
+    first* — write a minimal fixture under `smoke-all/q2-preview/` (or opt in
+    an existing one), run `SMOKE_FILTER=<name> npm run test:wasm`, read
+    `test-results/parity/…`; go to Chrome only for computed-style symptoms;
+  - in "TDD workflow", the regression test for a parity fix is the fixture's
+    `parity: true` opt-in when the fixture can be made minimal;
+  - replace the integration-branch guidance (lines ~140, 224, 228:
+    `feature/q2-preview-command`, parent epic bd-kw93): bd-kw93 is closed and
+    the branch merged via PR #214 (`git log --grep "q2 preview command"` on
+    `main`); parity strands branch off `main` and carry the `preview-parity`
+    label instead of a parent-child dep.
+
+- [ ] Make both edits; commit:
+
+```bash
+git add claude-notes/instructions/testing.md .claude/skills/preview-render-parity/SKILL.md
+git commit -m "Document the preview/render DOM parity runner and harness-first workflow"
+```
+
+### Task 4.3: Gate and reconcile
+
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
+- [ ] `cargo xtask verify` (full — hub-client and preview-renderer changed;
+  this reruns the workspace nextest, so report its pass/skip counts against
+  the Phase-2 baseline: the delta must still be exactly +2).
+- [ ] Re-read this checklist; verify every `[x]` against the commits; fix
+  stale marks; commit the plan file.
+- [ ] Report; **do not push** without explicit approval (CLAUDE.md).
+
+---
+
+## Follow-ups (not in this plan)
+
+- bd-tmb2u5yu: fix `Math.tsx` classes, then opt in a math fixture.
+- bd-qn8yi1su: revealjs deck parity — extend `domParity.ts` with a
+  `.reveal .slides` root selector and a `render_page_in_project` vs
+  `RevealDeck` mount.
+- Widen the allowlist as parity strands close: each closing PR should end
+  with `parity: true` on the fixture that reproduced it.
+- Reconsider the mount configuration once edit chrome stabilises: comparing
+  a `PreviewRoot` mount would need strip rules for `data-block-pool-id`,
+  `tabIndex`, comment anchors, and asset blob URLs.
+- A lint (`cargo xtask lint`) that a fixture under `smoke-all/q2-preview/`
+  without `parity: true` must cite a reason — only once the allowlist is
+  large enough that omissions are the exception.

--- a/claude-notes/plans/2026-08-24-preview-render-dom-parity-harness.md
+++ b/claude-notes/plans/2026-08-24-preview-render-dom-parity-harness.md
@@ -253,22 +253,22 @@ sibling's 120 s hang-detection timeout, `vitest.wasm.config.ts`).
 - [x] 0.2 Throwaway spike over 4 fixtures using the extracted helpers; research note with divergence classes + initial allowlist
 
 ### Phase 1 — `domParity.ts`
-- [ ] 1.1 `canonicalize` — shape, attribute sorting, text/whitespace rules, `<pre>` verbatim, text-node merging
-- [ ] 1.2 `PARITY_RULES` — strip list, opaque `span.math`, forbidden `data-hl-spans`
-- [ ] 1.3 `extractParityRoot` + `compareParity`
+- [x] 1.1 `canonicalize` — shape, attribute sorting, text/whitespace rules, `<pre>` verbatim, text-node merging
+- [x] 1.2 `PARITY_RULES` — strip list, opaque `span.math`, forbidden `data-hl-spans`
+- [x] 1.3 `extractParityRoot` + `compareParity`
 
 ### Phase 2 — `parity:` DSL key
-- [ ] 2.1 Rust `quarto-test`: parse into `TestSpec.parity`, runner ignores
-- [ ] 2.2 Both TS parsers (WASM sibling, Playwright discovery) ignore `parity`; Phase-2 boundary workspace nextest
+- [x] 2.1 Rust `quarto-test`: parse into `TestSpec.parity`, runner ignores
+- [x] 2.2 Both TS parsers (WASM sibling, Playwright discovery) ignore `parity`; Phase-2 boundary workspace nextest
 
 ### Phase 3 — Runner
-- [ ] 3.1 `smokeAllParity.wasm.test.tsx` + first opt-in in one green commit
-- [ ] 3.2 Opt in the remaining fixtures the spike showed green; all four runners green
+- [x] 3.1 `smokeAllParity.wasm.test.tsx` + first opt-in in one green commit
+- [x] 3.2 Opt in the remaining fixtures the spike showed green; all four runners green
 
 ### Phase 4 — Triage + docs + gate
-- [ ] 4.1 File a strand per real divergence found (bd-tmb2u5yu already filed)
-- [ ] 4.2 Update `testing.md` and the `preview-render-parity` skill
-- [ ] 4.3 Full `cargo xtask verify`; reconcile this checklist; commit
+- [x] 4.1 File a strand per real divergence found (bd-tmb2u5yu already filed)
+- [x] 4.2 Update `testing.md` and the `preview-render-parity` skill
+- [x] 4.3 Full `cargo xtask verify`; reconcile this checklist; commit
 
 ---
 
@@ -614,7 +614,7 @@ the package `tsconfig.json`, so nothing here ships in `dist/`.
   export function canonicalize(el: Element, rules?: ParityRules): string;
   ```
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 ```ts
 // @vitest-environment jsdom
@@ -685,14 +685,14 @@ describe('canonicalize — inline whitespace is significant', () => {
 });
 ```
 
-- [ ] **Step 2: Run to verify failure**
+- [x] **Step 2: Run to verify failure**
 
 ```bash
 cd ts-packages/preview-renderer && npx vitest run src/test-utils/domParity.test.ts
 ```
 Expected: FAIL — cannot resolve `./domParity`.
 
-- [ ] **Step 3: Implement**
+- [x] **Step 3: Implement**
 
 ```ts
 /**
@@ -848,14 +848,14 @@ export function canonicalize(el: Element, rules: ParityRules = PARITY_RULES): st
 }
 ```
 
-- [ ] **Step 4: Run to verify pass**
+- [x] **Step 4: Run to verify pass**
 
 ```bash
 cd ts-packages/preview-renderer && npx vitest run src/test-utils/domParity.test.ts
 ```
 Expected: 9 passed.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add ts-packages/preview-renderer/src/test-utils/domParity.ts ts-packages/preview-renderer/src/test-utils/domParity.test.ts
@@ -872,7 +872,7 @@ git commit -m "Add DOM canonicaliser for preview/render parity"
 - Consumes: `canonicalize`, `OPAQUE_MARKER`, `ParityRuleViolation` from Task 1.1.
 - Produces: the populated `PARITY_RULES` used by the runner.
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 Extend the existing import line to
 `import { canonicalize, OPAQUE_MARKER, ParityRuleViolation } from './domParity';`
@@ -922,14 +922,14 @@ describe('PARITY_RULES', () => {
 });
 ```
 
-- [ ] **Step 2: Run to verify failure**
+- [x] **Step 2: Run to verify failure**
 
 ```bash
 cd ts-packages/preview-renderer && npx vitest run src/test-utils/domParity.test.ts
 ```
 Expected: the six new tests FAIL (attributes present / no opaque marker / no throw / `<div` still present).
 
-- [ ] **Step 3: Populate the rules**
+- [x] **Step 3: Populate the rules**
 
 Replace the `PARITY_RULES` constant:
 
@@ -984,14 +984,14 @@ export const PARITY_RULES: ParityRules = {
 };
 ```
 
-- [ ] **Step 4: Run to verify pass**
+- [x] **Step 4: Run to verify pass**
 
 ```bash
 cd ts-packages/preview-renderer && npx vitest run src/test-utils/domParity.test.ts
 ```
 Expected: 15 passed.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add ts-packages/preview-renderer/src/test-utils/domParity.ts ts-packages/preview-renderer/src/test-utils/domParity.test.ts
@@ -1013,7 +1013,7 @@ git commit -m "Define preview/render parity normalisation rules with reasons"
   export function compareParity(renderRoot: Element, previewRoot: Element, rules?: ParityRules): ParityResult;
   ```
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 Extend the import line with `extractParityRoot, compareParity` and append:
 
@@ -1049,14 +1049,14 @@ describe('extractParityRoot / compareParity', () => {
 });
 ```
 
-- [ ] **Step 2: Run to verify failure**
+- [x] **Step 2: Run to verify failure**
 
 ```bash
 cd ts-packages/preview-renderer && npx vitest run src/test-utils/domParity.test.ts
 ```
 Expected: 3 new FAIL (exports missing).
 
-- [ ] **Step 3: Implement**
+- [x] **Step 3: Implement**
 
 Append to `domParity.ts`:
 
@@ -1099,7 +1099,7 @@ export function compareParity(
 }
 ```
 
-- [ ] **Step 4: Run to verify pass**
+- [x] **Step 4: Run to verify pass**
 
 ```bash
 cd ts-packages/preview-renderer && npx vitest run src/test-utils/domParity.test.ts
@@ -1108,7 +1108,7 @@ cd ts-packages/preview-renderer && npm test && npm run test:integration
 Expected: 18 passed in the new file; the package suites green with the same
 counts as before plus 18.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add ts-packages/preview-renderer/src/test-utils/domParity.ts ts-packages/preview-renderer/src/test-utils/domParity.test.ts
@@ -1133,7 +1133,7 @@ git commit -m "Add parity root extraction and comparison"
   preview↔render DOM parity runner. The native runner ignores it; the field
   exists so the DSL stays a single grammar across all four runners.
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 ```rust
     #[test]
@@ -1187,14 +1187,14 @@ git commit -m "Add parity root extraction and comparison"
     }
 ```
 
-- [ ] **Step 2: Run to verify failure**
+- [x] **Step 2: Run to verify failure**
 
 ```bash
 cargo nextest run -p quarto-test test_parity
 ```
 Expected: compile error — no field `parity` on `TestSpec`.
 
-- [ ] **Step 3: Implement**
+- [x] **Step 3: Implement**
 
 In `TestSpec` add:
 
@@ -1220,7 +1220,7 @@ In `parse_format_spec`, add `let mut parity = false;` beside
 
 and `parity,` in the `Ok(TestSpec { … })` constructor at `:259`.
 
-- [ ] **Step 4: Run to verify pass**
+- [x] **Step 4: Run to verify pass**
 
 ```bash
 cargo clippy -p quarto-test --all-targets -- -D warnings
@@ -1229,7 +1229,7 @@ cargo nextest run -p quarto --test integration smoke_all
 ```
 Expected: all green; the smoke_all sweep is unchanged (no fixture opts in yet).
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add crates/quarto-test/src/spec.rs
@@ -1248,7 +1248,7 @@ git commit -m "Accept a parity key in the smoke-all test DSL (native runner igno
 Both parsers hard-error on unknown keys, so a fixture with `parity: true`
 would break the WASM sweep and the Playwright sweep until this lands.
 
-- [ ] **Step 1: Check for an existing unit test of either parser**
+- [x] **Step 1: Check for an existing unit test of either parser**
 
 ```bash
 ls hub-client/e2e/helpers/*.test.ts 2>/dev/null; grep -rln "smokeAllDiscovery" hub-client/e2e hub-client/src | head
@@ -1264,9 +1264,9 @@ it('accepts parity: true as a non-assertion', () => {
 ```
 
 If none exists, do not create one for a one-line case; Task 3.1's opt-in
-plus `npx playwright test e2e/smoke-all.spec.ts --list` is the check.
+plus `npx playwright test --config=playwright.smoke-all.config.ts e2e/smoke-all.spec.ts --list` is the check.
 
-- [ ] **Step 2: Implement — same three lines in both files**
+- [x] **Step 2: Implement — same three lines in both files**
 
 ```ts
         case 'parity':
@@ -1276,16 +1276,16 @@ plus `npx playwright test e2e/smoke-all.spec.ts --list` is the check.
           break;
 ```
 
-- [ ] **Step 3: Verify**
+- [x] **Step 3: Verify**
 
 ```bash
 cd hub-client && npm run test:wasm      # counts identical to Task 0.1 Step 1
-cd hub-client && npx playwright test e2e/smoke-all.spec.ts --list | tail -3
+cd hub-client && npx playwright test --config=playwright.smoke-all.config.ts e2e/smoke-all.spec.ts --list | tail -3   # base config's testIgnore excludes this spec
 ```
 Expected: WASM counts unchanged; Playwright lists the same number of tests
 as on `main` (`--list` does not launch a browser or the web server).
 
-- [ ] **Step 4: Phase-2 boundary — workspace nextest**
+- [x] **Step 4: Phase-2 boundary — workspace nextest**
 
 ```bash
 cargo nextest run --workspace 2>&1 | tee /private/tmp/claude-502/-Users-gordon-src-q2/6f5c0c8f-a359-437a-87d6-879b0e289c0e/scratchpad/nextest-phase2.log; grep -E "Summary|passed|failed|skipped" /private/tmp/claude-502/-Users-gordon-src-q2/6f5c0c8f-a359-437a-87d6-879b0e289c0e/scratchpad/nextest-phase2.log | tail -3
@@ -1294,7 +1294,7 @@ Expected: green; delta vs the live baseline on `main` @ `cf9c45cc8` is
 exactly +2 passed (Task 2.1's two tests). If no baseline log exists, run the
 same command on `main` first and record it.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add hub-client/src/services/smokeAll.wasm.test.ts hub-client/e2e/helpers/smokeAllDiscovery.ts
@@ -1332,7 +1332,7 @@ is red.
   test imports it from `../framework`, `q2-preview.integration.test.tsx:35`);
   `previewRegistry` from `@quarto/preview-renderer`.
 
-- [ ] **Step 1: Write the runner with its two tests (the second is the self-check)**
+- [x] **Step 1: Write the runner with its two tests (the second is the self-check)**
 
 ```tsx
 // @vitest-environment jsdom
@@ -1523,7 +1523,7 @@ describe('smoke-all preview <-> render DOM parity', () => {
 });
 ```
 
-- [ ] **Step 2: Run before opting anything in — verify the right failure**
+- [x] **Step 2: Run before opting anything in — verify the right failure**
 
 ```bash
 cd hub-client && npm run test:wasm
@@ -1536,7 +1536,7 @@ loaded for this config; Task 0.2's Q3 established none is needed. If that
 turns out wrong, add `setupFiles` to `vitest.wasm.config.ts` pointing at a
 new `src/test-utils/parity-setup.ts` with only the shim that is missing.)
 
-- [ ] **Step 3: Opt in the first fixture**
+- [x] **Step 3: Opt in the first fixture**
 
 ```yaml
 _quarto:
@@ -1550,6 +1550,8 @@ _quarto:
 cd hub-client && SMOKE_FILTER=simple-default npm run test:wasm
 ```
 Expected: `Parity results: 1 compared, 0 failed, 1 opted in`; self-check passes.
+(vitest 4 hides `console.log` from passing tests by default — append
+`-- --reporter=verbose` to see the parity summary on a green run.)
 
 If it fails with a *mismatch*, the spike note was wrong or a rule is
 missing: read the artifacts under `hub-client/test-results/parity/`, classify
@@ -1557,7 +1559,7 @@ missing: read the artifacts under `hub-client/test-results/parity/`, classify
 `domParity.ts` + a unit test (a Task-1.2-shaped mini-step). (c) → pick the
 next candidate from the note; record the divergence for Task 4.1.
 
-- [ ] **Step 4: Commit (green)**
+- [x] **Step 4: Commit (green)**
 
 ```bash
 git add hub-client/src/services/smokeAllParity.wasm.test.tsx crates/quarto/tests/smoke-all/title-block/simple-default.qmd
@@ -1572,20 +1574,20 @@ git commit -m "Add preview/render DOM parity runner over opted-in smoke-all fixt
   `appendix/footnotes-heading.qmd` (c1, c2) and `markdown/heading-auto-id.qmd`
   (c3, c4) stay out until their strands close — see § Findings.
 
-- [ ] **Step 1: Opt in one at a time, same loop as Task 3.1 Step 3**
+- [x] **Step 1: Opt in one at a time, same loop as Task 3.1 Step 3**
 
-- [ ] **Step 2: All four runners green**
+- [x] **Step 2: All four runners green**
 
 ```bash
 cargo nextest run -p quarto --test integration smoke_all           # Rust: parity key accepted
 cd hub-client && npm run test:wasm                                 # WASM sibling + parity
-cd hub-client && npx playwright test e2e/smoke-all.spec.ts --list  # discovery parses the key
+cd hub-client && npx playwright test --config=playwright.smoke-all.config.ts e2e/smoke-all.spec.ts --list  # discovery parses the key
 ```
 Expected: Rust sweep unchanged; WASM sibling counts unchanged from Task 0.1
 Step 1; parity `N compared, 0 failed, N opted in`; Playwright lists the same
 tests as before.
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```bash
 git add crates/quarto/tests/smoke-all
@@ -1628,7 +1630,7 @@ EOF
 )" --json
 ```
 
-- [ ] Create one strand per divergence; list their ids in this plan under a
+- [x] Create one strand per divergence; list their ids in this plan under a
   new § Findings section and in the research note.
 
 ### Task 4.2: Documentation
@@ -1658,7 +1660,7 @@ EOF
     `main`); parity strands branch off `main` and carry the `preview-parity`
     label instead of a parent-child dep.
 
-- [ ] Make both edits; commit:
+- [x] Make both edits; commit:
 
 ```bash
 git add claude-notes/instructions/testing.md .claude/skills/preview-render-parity/SKILL.md
@@ -1667,27 +1669,32 @@ git commit -m "Document the preview/render DOM parity runner and harness-first w
 
 ### Task 4.3: Gate and reconcile
 
-- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
-- [ ] `cargo xtask verify` (full — hub-client and preview-renderer changed;
+- [x] `cargo clippy --workspace --all-targets -- -D warnings` (clean at 1ce54e55e)
+- [x] `cargo xtask verify` (full — hub-client and preview-renderer changed;
   this reruns the workspace nextest, so report its pass/skip counts against
   the Phase-2 baseline: the delta must still be exactly +2).
-- [ ] Re-read this checklist; verify every `[x]` against the commits; fix
+  **Result (58a8d22e6):** all steps passed; workspace nextest 13217 passed /
+  199 skipped vs baseline 13215 / 199 on `main` @ cf9c45cc8 (= +2, Task 2.1's
+  tests). Final whole-branch review found two one-line Importants
+  (`INLINE_TAGS` missing `label`/`input`/`button`/`svg`; stale Playwright
+  command in testing.md), fixed in 58a8d22e6; `domParity.test.ts` is 19 tests.
+- [x] Re-read this checklist; verify every `[x]` against the commits; fix
   stale marks; commit the plan file.
-- [ ] Report; **do not push** without explicit approval (CLAUDE.md).
+- [x] Report; **do not push** without explicit approval (CLAUDE.md).
 
 ---
 
 ## Findings
 
 Real divergences the harness (spike + runner) surfaced. Out-of-plan bugs,
-one strand each (label `preview-parity`); ids filled in by Task 4.1.
+one strand each (label `preview-parity`); filed by Task 4.1.
 Details and verbatim snippets: `claude-notes/research/2026-08-24-preview-render-parity-spike.md`.
 
 | # | Symptom | Fixture | Strand |
 |---|---|---|---|
-| c1 | `Link.tsx` drops `role=` (and every kv attr outside `data-*`/`rel`/`target`) | `appendix/footnotes-heading.qmd` | _pending_ |
-| c2 | `OrderedList.tsx` omits `type="1"` for `Decimal` | `appendix/footnotes-heading.qmd` | _pending_ |
-| c3 | `Strikeout.tsx` renders `<s>`, writer `<del>` | `markdown/heading-auto-id.qmd` | _pending_ |
+| c1 | `Link.tsx` drops `role=` (and every kv attr outside `data-*`/`rel`/`target`) | `appendix/footnotes-heading.qmd` | bd-294mbrcx |
+| c2 | `OrderedList.tsx` omits `type="1"` for `Decimal` | `appendix/footnotes-heading.qmd` | bd-q88zinyv |
+| c3 | `Strikeout.tsx` renders `<s>`, writer `<del>` | `markdown/heading-auto-id.qmd` | bd-qzwlhrlv |
 | c4 | `Math.tsx` emits no `math inline|display` class | `markdown/heading-auto-id.qmd` | bd-tmb2u5yu |
 
 ## Follow-ups (not in this plan)

--- a/claude-notes/research/2026-08-24-preview-render-parity-spike.md
+++ b/claude-notes/research/2026-08-24-preview-render-parity-spike.md
@@ -1,0 +1,435 @@
+# Preview ↔ render DOM parity spike (Task 0.2)
+
+**Date:** 2026-08-24
+**Branch:** `explore/react-parity-harness`
+**Plan:** `claude-notes/plans/2026-08-24-preview-render-dom-parity-harness.md` (Phase 0, Task 0.2)
+
+A throwaway spike rendered four smoke-all fixtures through **both** sides —
+the native HTML writer (`render_page_in_project`) and the React preview
+renderer (`render_page_for_preview` → `<Ast>`) — dumped each side's
+`main#quarto-document-content` subtree, and diffed them. Its purpose was to
+answer Q1–Q4 *before* any harness code is written, and in particular to
+confirm or amend the plan's § Design normalisation rules table.
+
+The spike file (`hub-client/src/services/paritySpike.wasm.test.tsx`) and its
+output (`hub-client/test-results/parity-spike/`) were deleted at the end of
+the task. Only this note and the `vitest.wasm.config.ts` glob widening are
+committed.
+
+---
+
+## Command run
+
+```bash
+cd hub-client && npx vitest run --config vitest.wasm.config.ts \
+  src/services/paritySpike.wasm.test.tsx
+```
+
+Result — **passed on the first attempt, no shims, no setup file**:
+
+```
+ RUN  v4.1.8 /Users/gordon/src/q2/.worktrees/workspace-1/hub-client
+ Test Files  1 passed (1)
+      Tests  1 passed (1)
+   Duration  2.06s (transform 453ms, setup 0ms, import 780ms, tests 850ms, environment 333ms)
+```
+
+One prerequisite change was needed and is **kept** (Task 3.1 needs it too):
+`hub-client/vitest.wasm.config.ts:16` widened from
+`include: ['src/**/*.wasm.test.ts']` to
+`include: ['src/**/*.wasm.test.{ts,tsx}']`. Positional file arguments only
+*filter within* `include`; without the widening a `.tsx` file reports "no test
+files found" rather than running.
+
+Comparison root on each side:
+
+| Side | Element | Source |
+|---|---|---|
+| render | `main#quarto-document-content` | `crates/quarto-core/src/template.rs:318` |
+| preview | `main#quarto-document-content` | `ts-packages/preview-renderer/src/q2-preview/PreviewDocument.tsx:307-309` |
+
+---
+
+## Q1–Q4
+
+**Q1 — does the WASM module initialise under `// @vitest-environment jsdom`?**
+**Yes.** `loadSmokeWasm()` from `hub-client/src/test-utils/smokeAllFixtures.ts`
+initialised unchanged under jsdom; the dart-sass VFS callbacks wired up and
+themed CSS compiled (all four fixtures returned a `theme_fingerprint`). No
+jsdom-specific workaround was required.
+
+**Q2 — does `render_page_for_preview` succeed on plain smoke-all fixtures, and
+does `render_page_in_project` return `html` for them?**
+**Yes, for all four**, including the project fixture (`appendix/` has a
+`_quarto.yml`, so this exercised the project branch on both sides). Observed
+response shapes:
+
+```
+render  keys: success,html,warnings,theme_fingerprint      success=true error=undefined
+preview keys: success,ast_json,untransformed_ast_json,warnings,theme_fingerprint
+                                                            success=true error=undefined
+```
+
+(`title-block/simple-default.qmd` returned no `warnings` key at all — that key
+is present only when there are warnings.)
+
+**Q3 — does `<Ast>` from `@quarto/preview-renderer/framework` mount from a
+hub-client test with no setup file?**
+**Yes.** No `matchMedia` / `ResizeObserver` shim, no setup file, and no
+context providers were needed. The mount was bare and read-only — no
+`PreviewContext`, `AssetManifestContext`, or `IncrementalContext` provider —
+and every component degraded correctly on the `ctx == null` path.
+`vitest.wasm.config.ts` has no `setupFiles`, and neither does the `vite.config.ts`
+it merges (the run reports `setup 0ms`). All four preview mounts produced a
+`main#quarto-document-content`.
+
+Two consequences worth carrying into Task 3.1:
+
+- **The plan's claim about `data-block-pool-id` is confirmed empirically.** It
+  never appears as an *attribute* anywhere under the read-only mount. It does
+  appear twice per fixture as a **CSS selector inside a `<style>` block**
+  (`[data-block-pool-id] { … }`), but that `<style>` sits *outside* `<main>`
+  and so never enters the comparison. It correctly stays out of the rules table.
+- **No `data-hl-spans` and no `data-sid` appeared on either side, in any
+  fixture.** The plan's "**fail** if `data-hl-spans` is present" rule is a
+  live guard against a regression, not a workaround for a current leak.
+
+**Q4 — what do the raw `<main>` subtrees actually differ by?**
+Far less than expected. The plan's rules table is **substantially correct and
+needs exactly one addition**. Concretely:
+
+- `title-block/simple-default.qmd` is **byte-identical** after applying only
+  the plan's *existing* rules — the whole title block, meta grid, abstract and
+  body section match exactly.
+- `highlighting/01-builtin-python.qmd` becomes byte-identical once one new
+  rule is added (see (b) below). Notably its `<pre>` contents — including the
+  `hl-keyword` / `hl-function` / `hl-function-builtin` / `hl-string` spans and
+  the four-space indent — matched **verbatim**, validating both the
+  "inside `<pre>`: text verbatim" rule and the absence of `data-hl-spans` leakage.
+- The remaining two fixtures differ by **five genuine bugs** (see (c) below),
+  not by serialiser noise.
+
+---
+
+## Classification
+
+Hunk counts below are *raw* `diff` hunks from the brief's Step 4 command;
+the (a)/(b)/(c) columns count **distinct causes**, since a single cause
+(e.g. `data-loc`) accounts for many raw hunks.
+
+| fixture | raw hunks | (a) | (b) | (c) | opt-in candidate? |
+|---|---:|---:|---:|---:|---|
+| `title-block/simple-default.qmd` | 6 | 3 | 0 | 0 | **Yes** — identical under the *current* rules |
+| `highlighting/01-builtin-python.qmd` | 6 | 2 | 1 | 0 | **Yes** — identical under the *amended* rules |
+| `appendix/footnotes-heading.qmd` | 10 | 2 | 0 | 3 | No — 3 (c) from 2 root causes |
+| `markdown/heading-auto-id.qmd` | 13 | 3 | 0 | 2 | No — 2 (c); also contains math |
+
+The (a) causes observed, all already covered by the plan's table:
+
+- `data-loc` on preview-side elements (2, 4, 6 and 9 occurrences respectively) —
+  covered by "strip `data-loc`, `data-sid`".
+- The writer's pretty-printing newlines between blocks, absent in React —
+  covered by "outside `<pre>`: collapse whitespace runs to one space; … drop
+  the node if nothing remains".
+- A soft-wrapped source line inside a `<p>`: render emits
+  `so we can\nsee how`, preview emits `so we can see how` — the same rule.
+- Attribute order: render `<img src="img.png" alt="">` vs preview
+  `<img alt="" src="img.png">` — covered by "sort attributes by name".
+
+### (b) — deliberate divergence, needs a new rule
+
+**One found.** React's `RawBlock` component **cannot** inject raw HTML without
+a host element, so every `RawBlock(format: "html")` gains a wrapper `<div>`
+that the Rust writer does not emit. This is architectural, not an oversight —
+the component's own doc comment states it, and the same constraint drove
+bd-xfw2omlt (mirroring `r-stretch` onto the wrapper).
+
+Preview side — `ts-packages/preview-renderer/src/q2-preview/blocks/RawBlock.tsx:41-44`:
+
+```tsx
+    if (format === 'html' || format === 'html5') {
+        const className = rootHasClass(content, 'r-stretch') ? 'r-stretch' : undefined;
+        return <div className={className} {...affordanceAttr} {...locProps} dangerouslySetInnerHTML={{ __html: content }} />;
+    }
+```
+
+Render side — `crates/pampa/src/writers/html.rs:1482-1487`, no wrapper at all:
+
+```rust
+        Block::RawBlock(raw) => {
+            // Only output raw HTML if format is "html"
+            if raw.format == "html" {
+                writeln!(ctx, "{}", raw.text)?;
+            }
+        }
+```
+
+(the inline `Inline::RawInline` arm at `html.rs:990-995` behaves the same way).
+
+Observed in `highlighting/01-builtin-python.qmd`, where the copy button is a
+`RawBlock` produced by `wrap_with_copy_scaffold`
+(`crates/quarto-core/src/transforms/code_block_render.rs:206-220`):
+
+```html
+<!-- render -->
+<div class="code-copy-outer-scaffold">
+  <div class="sourceCode code-with-copy">…</div>
+  <button title="Copy to Clipboard" class="code-copy-button" aria-label="Copy code"><i class="bi"></i></button>
+</div>
+
+<!-- preview -->
+<div class="code-copy-outer-scaffold" data-loc="0:23:1-27:1">
+  <div class="sourceCode code-with-copy" data-loc="0:23:1-27:1">…</div>
+  <div data-loc="0:23:1-27:1">
+    <button title="Copy to Clipboard" class="code-copy-button" aria-label="Copy code"><i class="bi"></i></button>
+  </div>
+</div>
+```
+
+**Proposed rule: unwrap an attribute-less `<div>` — on *both* sides.**
+
+The rule must be a pure function of one side (each side is normalised
+independently, then serialised and compared), which rules out "unwrap the
+div that the other side lacks". Applied *symmetrically* to both sides it is
+sound: after the `data-loc` strip the React `RawBlock` wrapper has no
+attributes and disappears, while any attribute-less `<div>` that **both**
+sides emit disappears from both and parity is preserved.
+
+This was validated empirically, not assumed. `title-block/simple-default.qmd`
+contains two attribute-less `<div>`s that *both* sides emit (the meta-grid
+cell and the abstract wrapper); adding the rule leaves that fixture
+byte-identical, and makes `highlighting/01-builtin-python.qmd`
+byte-identical.
+
+Preview-only variants were considered and rejected as unsound: "unwrap a
+preview `<div>` whose only attribute is `data-loc`" happens to work on these
+four fixtures but would produce a false diff on any document containing a
+`Div` block with an empty `Attr` — render emits a bare `<div>`, preview emits
+`<div data-loc=…>`, and unwrapping only the preview side would delete a
+wrapper the render side keeps.
+
+**Known cost, to record in the plan:** the runner can no longer detect a
+missing or extra attribute-less `<div>`. Such a div carries no id and no
+class, so it is invisible to `ensureHtmlElements` selectors and to almost all
+CSS — but not to structural selectors like `div.quarto-title-meta > div`,
+which the title-block fixture's own smoke-all assertion uses. That assertion
+still runs on the render side; the parity runner simply does not duplicate it.
+This is a bounded blind spot, and the only alternative is excluding every
+fixture with a code block (the copy button is a `RawBlock`), which would gut
+the corpus.
+
+### (c) — real bugs
+
+**Five hunks from four root causes.** None are covered by any rule, and none
+should be — each is an accidental mirroring gap, not a designed divergence.
+
+#### (c1) `Link` drops every key-value attribute outside a narrow allowlist
+
+Two hunks in `appendix/footnotes-heading.qmd` (`role="doc-noteref"` and
+`role="doc-backlink"`), one root cause.
+
+React — `ts-packages/preview-renderer/src/q2-preview/inlines/Link.tsx:10-12`:
+
+```tsx
+    for (const [k, v] of kvs) {
+        if (k.startsWith('data-') || k === 'rel' || k === 'target') props[k] = v;
+    }
+```
+
+Writer — `crates/pampa/src/writers/html.rs:968` calls `write_attr`, which at
+`html.rs:520-529` emits **every** kv, `data-`-prefixing only those
+`should_prefix_attribute` (`html.rs:463-481`) says are non-standard. `role` is
+an RDFa attribute, so it passes through bare.
+
+The attribute is set by the footnotes transform
+(`crates/quarto-core/src/transforms/footnotes.rs:483` and `:578`), so it is
+present in the preview AST and simply not forwarded:
+
+```html
+<!-- render -->  <a href="#fn1" class="footnote-ref" role="doc-noteref">1</a>
+<!-- preview --> <a href="#fn1" class="footnote-ref">1</a>
+
+<!-- render -->  <a href="#fnref1" class="footnote-back" role="doc-backlink">↩︎</a>
+<!-- preview --> <a href="#fnref1" class="footnote-back">↩︎</a>
+```
+
+This is an accessibility regression in the preview, not just a DOM
+difference. Note the allowlist is general: any `role`, `aria-*`, `hreflang`,
+`type`, `download`, … on a Link is dropped by the preview, so this is broader
+than footnotes.
+
+#### (c2) `OrderedList` omits `type` for `Decimal`
+
+One hunk in `appendix/footnotes-heading.qmd`.
+
+React — `ts-packages/preview-renderer/src/q2-preview/blocks/OrderedList.tsx:28-32`
+has no `Decimal` key, and its doc comment (`:16`) explicitly claims
+"DefaultStyle / Decimal: no `type` attr (browser default)":
+
+```tsx
+const styleToType: Record<string, string | undefined> = {
+    LowerRoman: 'i',
+    UpperRoman: 'I',
+    LowerAlpha: 'a',
+    UpperAlpha: 'A',
+};
+```
+
+Writer — `crates/pampa/src/writers/html.rs:1502-1510` emits `type`
+**unconditionally**, with `Decimal` → `"1"` and a `_ => "1"` catch-all:
+
+```rust
+            let list_type = match style {
+                crate::pandoc::ListNumberStyle::Decimal => "1",
+                …
+                _ => "1",
+            };
+            write!(ctx, " type=\"{}\"", list_type)?;
+```
+
+The footnotes transform builds its list with
+`ListNumberStyle::Decimal` (`crates/quarto-core/src/transforms/footnotes.rs:542`), so:
+
+```html
+<!-- render -->  <ol type="1">
+<!-- preview --> <ol>
+```
+
+The two sides disagree about their shared reference (Pandoc's HTML writer
+emits `type` whenever the style is not `DefaultStyle`, so `Decimal` → `type="1"`;
+that matches the writer, not React). Whichever way it is resolved, one side
+must change — the React comment describes behaviour the writer does not have.
+
+#### (c3) `Strikeout` renders `<s>`, the writer renders `<del>`
+
+One hunk in `markdown/heading-auto-id.qmd`.
+
+React — `ts-packages/preview-renderer/src/q2-preview/inlines/Strikeout.tsx:4-6`:
+
+```tsx
+export const Strikeout = (args: NodeArgs<StrikeoutInline>) => (
+    <s>{renderChildren(args)}</s>
+);
+```
+
+Writer — `crates/pampa/src/writers/html.rs:901-906`:
+
+```rust
+        Inline::Strikeout(s) => {
+            write!(ctx, "<del")?;
+```
+
+```html
+<!-- render -->  <h2>Use <del>strike</del> here</h2>
+<!-- preview --> <h2>Use <s>strike</s> here</h2>
+```
+
+Pandoc's HTML writer emits `<del>`, so the writer is right and React is the
+side to change.
+
+#### (c4) `Math` emits no `math inline` / `math display` class — bd-tmb2u5yu
+
+One hunk in `markdown/heading-auto-id.qmd`. This is the already-filed bug, and
+the spike confirms its exact consequence for the harness.
+
+React — `ts-packages/preview-renderer/src/q2-preview/inlines/Math.tsx:29`:
+
+```tsx
+        return <span dangerouslySetInnerHTML={{ __html: html }} />;
+```
+
+Writer — `crates/pampa/src/writers/html.rs:952-965` emits
+`<span class="math inline">\(…\)</span>`.
+
+```html
+<!-- render -->  <h2>Math <span class="math inline">\(x+y\)</span> inline</h2>
+<!-- preview --> <h2>Math <span><span class="katex">…</span></span> inline</h2>
+```
+
+**The important harness consequence:** the plan's math rule is written as
+"replace the children of `span.math` with one opaque text node". The preview
+span carries **no class at all**, so that selector does not match and the rule
+cannot fire — the KaTeX subtree would be compared verbatim against `\(x+y\)`.
+The plan's own note is therefore exactly right: no math fixture can opt in
+until bd-tmb2u5yu adds the class. **The rule itself needs no change** — it
+becomes correct the moment the class lands. Keeping it in the table as-is is
+the right call, since it documents the target contract.
+
+---
+
+## Amended rules table
+
+One rule added (marked **NEW**); everything else is unchanged and confirmed by
+the spike. Paste-ready for the plan's § Design.
+
+| Rule | Why |
+|---|---|
+| Strip attributes `data-loc`, `data-sid` | Preview-only source tracking (writer emits them only with `include_source_locations`, off for `q2 render`; preview AST has `include_inline_locations: true` and React forwards via `dataLocProps`). |
+| Replace the children of `span.math` with one opaque text node `⟨opaque⟩` | `math-js` excluded from preview: render leaves TeX in `\(…\)`; React `inlines/Math.tsx` emits KaTeX HTML. Divergent by design. Today `Math.tsx` emits no class at all (bd-tmb2u5yu) so no math fixture can opt in yet. |
+| **NEW — Unwrap any `<div>` with no attributes, on both sides** | React cannot inject raw HTML without a host element, so `blocks/RawBlock.tsx` wraps every `RawBlock(format: "html")` in a `<div>` the writer (`html.rs`, `Block::RawBlock`) does not emit — most visibly the code-copy button. Must be applied symmetrically: a preview-only variant would false-positive on a `Div` block with an empty `Attr`. Cost: a missing/extra attribute-less `<div>` is invisible to the runner; such a div matches no id/class selector, and the render side's own `ensureHtmlElements` assertions still cover structural cases like `div.quarto-title-meta > div`. |
+| **Fail** if `data-hl-spans` is present on either side | Consumed attribute; leakage is a bug (bd-nxslt). |
+| Sort attributes by name | Serialisation order is not semantic. |
+| Do not sort class tokens; do collapse whitespace inside `class` | Class order is part of the contract (bd-y1fs3). |
+| Keep `id` and every `data-*` not listed above | Ids are contract; `data-qf-*`, `data-cites` etc. are writer output React must mirror. |
+| Merge adjacent text nodes (`Node.normalize()` on a clone) | React emits one text node per Str/Space. |
+| Inside `<pre>`: text verbatim | Collapsing would hide code-indentation bugs. |
+| Outside `<pre>`: collapse whitespace runs to one space; keep a leading/trailing space only if the neighbouring sibling on that side is inline (non-whitespace text node or element in INLINE_TAGS); drop the node if nothing remains | Distinguishes `<em>a</em> <em>b</em>` from `<em>a</em><em>b</em>` while dropping the writer's pretty-printing newlines between blocks. |
+| Drop comment nodes | Not rendered. |
+| Lower-case tag names; ignore void-element self-closing | Parser noise. |
+
+Deliberately NOT a rule: `data-block-pool-id` (React edit chrome; never emitted
+under the read-only mount — **confirmed empirically**, see Q3).
+
+**Ordering note for Task 1.x:** the bare-`<div>` unwrap must run *after* the
+`data-loc` strip (the wrapper carries `data-loc`) and *before* the whitespace
+pass (unwrapping merges the wrapper's surrounding whitespace into its
+parent's run). The order used and validated in the spike was: drop comments →
+math opacity → strip/sort attributes → unwrap bare `<div>` → `normalize()` →
+whitespace → `normalize()`.
+
+---
+
+## Initial allowlist
+
+Fixtures whose `<main>` subtrees are **byte-identical** under the amended
+rules — verified, not predicted:
+
+```
+highlighting/01-builtin-python.qmd
+title-block/simple-default.qmd
+```
+
+`title-block/simple-default.qmd` also passes under the *current* (unamended)
+rules, so it is the safe first entry if the new rule is deferred.
+
+Not opted in, with the blocking (c):
+
+| fixture | blocked by |
+|---|---|
+| `appendix/footnotes-heading.qmd` | (c1) Link kv allowlist, (c2) `<ol type>` |
+| `markdown/heading-auto-id.qmd` | (c3) `<s>` vs `<del>`, (c4) math class (bd-tmb2u5yu) |
+
+## Fixture eligibility audit
+
+Requested check on the four fixtures for content that bars opt-in regardless
+of diffs:
+
+- **Math:** only `markdown/heading-auto-id.qmd` (`## Math $x+y$ inline`). Barred
+  until bd-tmb2u5yu.
+- **Tabsets:** none of the four.
+- **`_quarto.tests.run`:** none of the four has a `run:` block at all, so no
+  `skip`, `ci`, `os`/`not_os` or `requires_js` gate applies.
+
+## Follow-up strands to file
+
+Four, all (c), none previously tracked except the last:
+
+1. Preview `Link` drops non-allowlisted kv attributes (`role`, `aria-*`, …) —
+   `inlines/Link.tsx:10-12` vs `html.rs:520-529`.
+2. Preview `OrderedList` omits `type` for `Decimal`/`DefaultStyle` while the
+   writer always emits it — `blocks/OrderedList.tsx:28-32` vs `html.rs:1502-1510`.
+   Needs a decision on which side matches Pandoc (the writer does).
+3. Preview `Strikeout` renders `<s>`, writer renders `<del>` —
+   `inlines/Strikeout.tsx:4-6` vs `html.rs:901-906`.
+4. bd-tmb2u5yu (already filed) — `Math.tsx` emits no `math inline` /
+   `math display` class.

--- a/claude-notes/research/2026-08-24-preview-render-parity-spike.md
+++ b/claude-notes/research/2026-08-24-preview-render-parity-spike.md
@@ -424,7 +424,9 @@ of diffs:
 
 Four, all (c), none previously tracked except the last. Filed by the plan's
 Task 4.1 (label `preview-parity`): 1 → bd-294mbrcx, 2 → bd-q88zinyv,
-3 → bd-qzwlhrlv, 4 → bd-tmb2u5yu (pre-existing).
+3 → bd-qzwlhrlv, 4 → bd-tmb2u5yu (pre-existing). All are children of the
+parity epic bd-j3764r9a; the later whole-corpus survey added six more
+(bd-d96axq4a, bd-hamxar01, bd-p2cd2ssg, bd-bg0jze2i, bd-bda2mbnl, bd-nrywksil).
 
 1. Preview `Link` drops non-allowlisted kv attributes (`role`, `aria-*`, …) —
    `inlines/Link.tsx:10-12` vs `html.rs:520-529`.

--- a/claude-notes/research/2026-08-24-preview-render-parity-spike.md
+++ b/claude-notes/research/2026-08-24-preview-render-parity-spike.md
@@ -422,7 +422,9 @@ of diffs:
 
 ## Follow-up strands to file
 
-Four, all (c), none previously tracked except the last:
+Four, all (c), none previously tracked except the last. Filed by the plan's
+Task 4.1 (label `preview-parity`): 1 → bd-294mbrcx, 2 → bd-q88zinyv,
+3 → bd-qzwlhrlv, 4 → bd-tmb2u5yu (pre-existing).
 
 1. Preview `Link` drops non-allowlisted kv attributes (`role`, `aria-*`, …) —
    `inlines/Link.tsx:10-12` vs `html.rs:520-529`.

--- a/claude-notes/research/2026-08-24-preview-render-parity-survey.md
+++ b/claude-notes/research/2026-08-24-preview-render-parity-survey.md
@@ -1,0 +1,208 @@
+# Preview ↔ render DOM parity — whole-corpus survey and post-plan work
+
+**Date:** 2026-08-24 (same day the harness plan closed)
+**Branch:** `explore/react-parity-harness` (worktree `.worktrees/workspace-1`)
+**Plan:** `claude-notes/plans/2026-08-24-preview-render-dom-parity-harness.md`
+(§ Addendum links here) · **Spike:** `2026-08-24-preview-render-parity-spike.md`
+**Epic:** bd-j3764r9a "React <-> HTML DOM parity (q2 preview vs q2 render)"
+
+This note records everything done *after* the plan's four phases closed at
+`119f9faac`: the whole-corpus survey, the `parity` → `dom-parity` rename,
+the bulk opt-in, the strands filed, the epic, and the harness limitations
+the survey exposed (kept here as notes, deliberately **not** strands).
+
+## 1. The survey
+
+**Question:** the plan opted in only the two fixtures its four-fixture spike
+proved green. How many of the 164 smoke-all fixtures already pass?
+
+**Method.** A throwaway vitest file (never committed; it lived under the
+gitignored `hub-client/test-results/parity-survey/`, outside the runner's
+`src/**` include glob, with its own config extending
+`hub-client/vitest.wasm.config.ts` and a 900 s timeout). It reused the real
+runner's pieces — `smokeAllFixtures.ts` for discovery/VFS,
+`render_page_in_project` + `render_page_for_preview`, the bare read-only
+`<Ast registry={previewRegistry}>` mount, `compareParity` — over *every*
+fixture regardless of opt-in, wrote `render.norm.txt`/`preview.norm.txt`
+for each mismatch, and classified each fixture by status. Differences from
+the real runner that matter when reading the numbers: it did not honour
+`shouldError`, it keyed only on the literal `html` tests entry, and its
+"has math" detector was a crude `$` regex (two false positives on `$` in
+comments). Wall time: 126 fixtures rendered in ~16 s of a 22 s run.
+
+**Results (164 fixtures):**
+
+| status | n | meaning |
+|---|---:|---|
+| PASS | 106 | canonical `<main>` byte-identical under the rules |
+| mismatch | 18 | real divergence (§ 3) |
+| non-`html` tests key | 29 | unreachable by the runner as designed (§ 5.1) |
+| skipped | 1 | `run.skip` (`extensions/contract-escape-comment`, bd-kmo1pzc2) |
+| render-error | 1 | `quarto-test/expected-error.qmd` — intentional (`shouldError`) |
+| rule-violation | 1 | `highlighting/02-inline-code.qmd` — the `data-hl-spans` forbid rule fired: a real bug (bd-bda2mbnl) |
+| exception | 1 | `highlighting/03-user-grammar/03-user-grammar-toml.qmd` — survey-environment artefact: `web-tree-sitter.wasm` did not resolve from a file outside `src/`; the real sibling runner passes it |
+| no render `<main>` | 1 | `highlighting/05-theme-none.qmd` — `theme: none` selects the minimal template (`crates/quarto-core/src/format.rs` `is_minimal_html`), which has no `main#quarto-document-content` (§ 5.2) |
+
+So the smoke-all corpus was not erring anywhere; every non-PASS row is
+either a real divergence, intentional, or a limit of the harness/survey.
+
+## 2. Rename and bulk opt-in
+
+- **`parity` → `dom-parity`** (commit `d750318b7`): the DSL key, the Rust
+  field `TestSpec.dom_parity` and its error text (`dom-parity must be a
+  boolean`), both TS parsers' no-op case, the runner's lookup and assertion
+  message, the two already-opted-in fixtures, `testing.md`, and the
+  preview-render-parity skill. File names and the
+  `PARITY_RULES`/`compareParity`/`smokeAllParity` identifiers were kept.
+- **Opt-in** (commit `04bd3c2cf`): the 106 PASS fixtures minus the engine
+  fixture `includes/code-cell/code-cell.qmd` (WASM has no engines; the WASM
+  `RunConfig` does not model `run.requires`), minus the two already in →
+  103 new, **105 total**. Result:
+  `Parity results: 105 compared, 0 failed, 105 opted in`; sweep ≈16.5 s
+  against the single-`it` 120 s hang-detection timeout; the other three
+  runners unchanged (Rust `smoke_all` 1 passed / 298 skipped, WASM sibling
+  23 files / 133 tests, Playwright discovery 148 tests via
+  `--config=playwright.smoke-all.config.ts`).
+- **Gotcha worth remembering:** 15 fixtures have a `format:\n  html:` block
+  *before* `_quarto:\n  tests:\n    html:`. A script that inserts under the
+  first `html:` line puts the key under `format:` where it is silently
+  ignored — the symptom was `90 compared` instead of 105. Scope any such
+  edit to the `_quarto → tests → html` chain by indentation.
+
+Verification of the branch after the addendum: `cargo nextest run
+--workspace` 13217 passed / 199 skipped (baseline on `main` @ `cf9c45cc8`:
+13215 / 199 — the +2 are the two `quarto-test` DSL tests); full
+`cargo xtask verify` green (the first attempt failed in the tree-sitter leg
+because `~/.cache/tree-sitter/lib/markdown.dylib` — a cache keyed only by
+grammar name, rebuilt only when `parser.c` is newer — had been rebuilt by
+another checkout with a different grammar; `touch src/parser.c` in this
+worktree and re-running fixed it: 609/609).
+
+**A real bug the bulk opt-in exposed.** `hub-client/vitest.config.ts` excluded
+only `src/**/*.wasm.test.ts` from the default unit-test config, so the `.tsx`
+parity runner had been collected by plain `npm run test` (5 s timeout) *as
+well as* by `npm run test:wasm` since it landed — invisible with 2 fixtures
+(< 5 s), a hard `Test timed out in 5000ms` with 105. Fixed in `a7d13a3f9` by
+widening the exclude to `src/**/*.wasm.test.{ts,tsx}`; `npm run test` is
+89 files / 1001 tests without the runner, `test:wasm` unchanged. Lesson for
+the next `*.wasm.test.tsx`: the wasm config's `include` and the default
+config's `exclude` must be widened together (Task 0.2 widened only the
+former).
+
+## 3. The 18 mismatches, classified
+
+First divergent canonical lines are in the survey artifacts (regenerate with
+the method in § 1); the strands carry verbatim snippets.
+
+### Covered by strands filed while designing/spiking the harness
+
+| divergence | fixtures | strand |
+|---|---|---|
+| footnote links lose `role="doc-noteref"` (Link drops every kv attr outside `data-*`/`rel`/`target`) | `appendix/footnotes-heading`, `appendix/footnotes-heading-style-none`, `localization/lang-es-appendix-headings` | bd-294mbrcx |
+| `<ol>` lacks `type="1"` for `Decimal` | `quarto-test/output-files` | bd-q88zinyv |
+| `<s>` vs `<del>` | `markdown/heading-auto-id` (also math → bd-tmb2u5yu) | bd-qzwlhrlv |
+
+### Covered by pre-existing parity strands (promoted to children of the epic)
+
+| divergence | fixture | strand |
+|---|---|---|
+| mermaid block gets copy-button chrome / `div.mermaid-diagram-container` instead of `<pre class="mermaid">` | `mermaid/basic` | bd-e3m3rkik (also excluded from preview by design; bd-c3dtpe36) |
+| tabsets have no React implementation | `toc-containers/tabset-pane-heading-not-in-toc` | bd-47afd5ro |
+| `data-filename` dropped from `<pre>` | `includes/in-code-fence/in-code-fence` | bd-00iveh46 (new; bd-1tl09 is the *native* decorations epic and does not cover the React mirror — linked `related`) |
+
+### New strands from the survey (children of bd-j3764r9a)
+
+| # | divergence | fixtures | strand |
+|---|---|---|---|
+| s1 | crossref floats: preview emits bare `<figure id="fig-…">` / `<div id="tbl-…"><table>`; render emits `div.quarto-float.quarto-figure… > figure.quarto-float.quarto-float-fig > div[aria-describedby]…` (figures *and* tables) | `includes/crossref/crossref`, `localization/lang-es-crossref`, `localization/language-inline-override` | bd-d96axq4a |
+| s2 | localized UI strings not applied: callout title "Note" vs "Nota", theorem "Proof." vs "Demostración." | `localization/lang-es-callout`, `localization/lang-es-theorem` | bd-hamxar01 |
+| s3 | callout outer div drops `title=` and `data-appearance=` | `quarto-test/callout-title-attribute`, `quarto-test/callouts-matrix` | bd-p2cd2ssg |
+| s4 | callout body heading: render `<section class="section level4 callout-body-container callout-body" id=…><h4>`, preview `<div class="callout-body-container callout-body"><h4 id=…>` — which side is right needs a decision | `toc-containers/callout-body-heading-not-in-toc` | bd-bg0jze2i |
+| s5 | inline `<code>` forwards `data-hl-spans` instead of decoding it (`inlines/Code.tsx` forwards all `data-*`; writer `html.rs` `Inline::Code` decodes); bd-nxslt fixed `CodeBlock.tsx` only | `highlighting/02-inline-code` | bd-bda2mbnl |
+| s6 | included list item content wrapped in `<p>` on preview, bare text on render — Plain-vs-Para or include splicing, unresolved | `includes/nested/nested` | bd-nrywksil |
+
+### Not a bug — a rule question
+
+`extensions/builtin-kbd-shortcode/test.qmd`: the preview wraps the
+shortcode's `RawInline` html in an attribute-less `<span>` — the same
+host-element constraint that made `RawBlock`'s bare `<div>` an unwrap rule.
+A symmetric "unwrap attribute-less `<span>`" rule is the obvious analogue,
+but spans are inline: unwrapping changes which siblings the whitespace-edge
+rule sees, so it needs the same reasoning the `<div>` rule got before it is
+added. Left un-opted-in for now.
+
+## 4. The epic
+
+bd-j3764r9a groups the work. Children (open children block the epic's close):
+bd-xa4vv9tt (this branch's harness work — close on merge), bd-tmb2u5yu,
+bd-294mbrcx, bd-q88zinyv, bd-qzwlhrlv, bd-d96axq4a, bd-hamxar01,
+bd-p2cd2ssg, bd-bg0jze2i, bd-bda2mbnl, bd-nrywksil, bd-00iveh46, and — promoted
+after checking their descriptions are specifically about preview/render
+parity — bd-e3m3rkik (mermaid chrome), bd-47afd5ro (tabsets), bd-2yd37vuk
+(`#quarto-header`), bd-tqijrhsu (toc-location). Only bd-1tl09 (the native
+code-block decorations epic) stays `related`. Note the four promoted strands
+are larger features and will hold the epic open until they land. Every child
+fix should end with `dom-parity: true` on the fixture that reproduced it.
+
+## 5. Harness limitations the survey exposed (notes, not strands)
+
+### 5.1 The key is only read under `html:`
+
+`smokeAllParity.wasm.test.tsx` (`optedInFixtures`) reads
+`block.formats['html']?.['dom-parity']`. All three DSL parsers accept the key
+under *any* format entry (Rust records it per format), so `dom-parity: true`
+under `q2-preview:` or `fancyfmt-html:` parses and is silently a no-op. The
+29 unreachable fixtures split into two different problems:
+
+- **Extension html-derived formats** (8: `format: fancyfmt-html`,
+  `custom-tmpl-html`, `test-meta-html`, …). `render_page_in_project` renders
+  whatever `detect_format_from_content` finds, so the render side *is* an
+  HTML page and the preview side maps it via `map_format_for_preview`.
+  Widening the lookup to "any format entry carrying `dom-parity: true`" would
+  probably just work (plus the `[html]` label and docs).
+- **`format: q2-preview`** (17 fixtures in `q2-preview/`, ironically the ones
+  written for the preview). Both calls detect `q2-preview`, so
+  `render_page_in_project` runs the preview pipeline and yields AST, not an
+  HTML page — there is no native side. Comparing them means forcing the
+  render side to `html` (a format override on the WASM entry point), and
+  deciding whether a document that declares `q2-preview` should be judged
+  against html's template. Design work, not a one-liner.
+
+### 5.2 Minimal-template documents have no `<main>`
+
+`theme: none` / `theme: pandoc` / `minimal: true` select the minimal
+template, which has no `main#quarto-document-content`, so `extractParityRoot`
+throws on the render side. Such fixtures cannot opt in unless the harness
+grows a documented fallback root (e.g. `body`), with rules for what to ignore
+there.
+
+### 5.3 `#main` excludes the page frame
+
+The chrome *content* (navbar, sidebar, footer) is the same Rust HTML string
+on both sides: `PreviewDocument.tsx` injects `meta.rendered.navigation.*`
+verbatim through `NavbarSlot`/`SidebarSlot`/`FooterSlot`. What the harness
+does not see is the hand-mirrored *placement*: the `#quarto-content` wrapper
+and its classes, the `quarto-margin-sidebar` div (TOC when not `toc-body`,
+margin categories), the banner title block above `#quarto-content`,
+navbar-before/footer-after ordering, and the `<body>` class list.
+`PreviewDocument.tsx` mirrors `crates/quarto-core/src/template.rs` by hand
+with line-number comments — exactly the mirroring the harness exists to
+police, and what the `q2-preview/body-container-*` / `body-classes-*`
+fixtures test (also blocked by § 5.1). A body-rooted comparison would need a
+second root selector plus ignore rules for `<script>`/`<style>`/`<link>` and
+any chrome state the writer sets that a read-only mount does not
+(`aria-current`, active link). The already-open bd-2yd37vuk
+(`#quarto-header`) and bd-tqijrhsu (toc-location) are frame-level gaps such
+a comparison would catch.
+
+### 5.4 Smaller notes
+
+- The runner's `Parity results:` line and per-fixture timings are printed by
+  `console.log`; vitest 4 hides them for passing tests — use
+  `npm run test:wasm -- --reporter=verbose`.
+- "opted in" in that line is corpus-wide, not `SMOKE_FILTER`-scoped, and a
+  `SMOKE_FILTER` that matches nothing is a green run (deferred minor from the
+  branch's final review, together with: `forbidAttrs` not enforced inside
+  opaque subtrees; `escapeAttr` ignores `\r`/U+2028; `optedInFixtures()`
+  re-walks the corpus per `it`; the self-check only injects an *added*
+  class; `svg` has no dedicated unit assertion).

--- a/crates/quarto-test/src/spec.rs
+++ b/crates/quarto-test/src/spec.rs
@@ -130,6 +130,12 @@ pub struct TestSpec {
     pub check_warnings: bool,
     /// Whether render failure is expected (shouldError).
     pub expects_error: bool,
+    /// `dom-parity: true` — opt this format into the preview ↔ render DOM
+    /// parity runner (`hub-client/src/services/smokeAllParity.wasm.test.tsx`).
+    /// The native runner ignores it; the field exists so all four
+    /// smoke-all runners share one DSL grammar. Plan:
+    /// claude-notes/plans/2026-08-24-preview-render-dom-parity-harness.md
+    pub dom_parity: bool,
 }
 
 /// Parse test specifications from document YAML metadata.
@@ -181,6 +187,7 @@ fn parse_format_spec(format: &str, value: &Value, _input_path: &Path) -> Result<
     let mut assertions: Vec<Box<dyn Assertion>> = Vec::new();
     let mut check_warnings = true;
     let mut expects_error = false;
+    let mut dom_parity = false;
 
     if let Some(map) = value.as_mapping() {
         for (key, assertion_value) in map {
@@ -249,6 +256,11 @@ fn parse_format_spec(format: &str, value: &Value, _input_path: &Path) -> Result<
                         .to_string();
                     assertions.push(Box::new(FolderExists::new(path)));
                 }
+                "dom-parity" => {
+                    dom_parity = assertion_value
+                        .as_bool()
+                        .context("dom-parity must be a boolean")?;
+                }
                 other => {
                     anyhow::bail!("Unknown assertion type: '{}' in format '{}'", other, format);
                 }
@@ -261,6 +273,7 @@ fn parse_format_spec(format: &str, value: &Value, _input_path: &Path) -> Result<
         assertions,
         check_warnings,
         expects_error,
+        dom_parity,
     })
 }
 
@@ -591,6 +604,59 @@ mod tests {
             "Expected error about unknown assertion, got: {}",
             err
         );
+    }
+
+    #[test]
+    fn test_dom_parity_key_is_accepted_and_recorded() {
+        let yaml: Value = serde_yaml::from_str(
+            r#"
+            _quarto:
+              tests:
+                html:
+                  noErrors: true
+                  dom-parity: true
+            "#,
+        )
+        .unwrap();
+
+        let (_run, specs) = parse_test_specs(&yaml, std::path::Path::new("test.qmd")).unwrap();
+        let html = specs
+            .iter()
+            .find(|s| s.format == "html")
+            .expect("html spec");
+        assert!(html.dom_parity, "dom-parity: true must be recorded");
+        // Only noErrors produced an assertion; dom-parity is not one.
+        assert_eq!(html.assertions.len(), 1);
+    }
+
+    #[test]
+    fn test_dom_parity_defaults_false_and_rejects_non_bool() {
+        let yaml: Value = serde_yaml::from_str(
+            r#"
+            _quarto:
+              tests:
+                html:
+                  noErrors: true
+            "#,
+        )
+        .unwrap();
+        let (_run, specs) = parse_test_specs(&yaml, std::path::Path::new("test.qmd")).unwrap();
+        assert!(!specs[0].dom_parity);
+
+        let bad: Value = serde_yaml::from_str(
+            r#"
+            _quarto:
+              tests:
+                html:
+                  dom-parity: "yes"
+            "#,
+        )
+        .unwrap();
+        let err = format!(
+            "{:#}",
+            parse_test_specs(&bad, std::path::Path::new("test.qmd")).unwrap_err()
+        );
+        assert!(err.contains("dom-parity must be a boolean"), "got: {err}");
     }
 
     #[test]

--- a/crates/quarto/tests/smoke-all/drafts/draft-banner.qmd
+++ b/crates/quarto/tests/smoke-all/drafts/draft-banner.qmd
@@ -5,6 +5,7 @@ format: html
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       # Quarto 1 parity (bd-draft-banner-missing-hgx1gkqm). Q1 emits
       # `<div id="quarto-draft-alert" class="alert alert-warning">

--- a/crates/quarto/tests/smoke-all/drafts/draft-false.qmd
+++ b/crates/quarto/tests/smoke-all/drafts/draft-false.qmd
@@ -5,6 +5,7 @@ format: html
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       # `draft: false` must behave exactly like an absent key. This is a
       # distinct case from not-a-draft.qmd: a truthiness bug that keyed

--- a/crates/quarto/tests/smoke-all/drafts/not-a-draft.qmd
+++ b/crates/quarto/tests/smoke-all/drafts/not-a-draft.qmd
@@ -4,6 +4,7 @@ format: html
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       # A page with no `draft` key must be untouched: no banner, and no
       # `quarto:status` meta tag either. The positive selector keeps this

--- a/crates/quarto/tests/smoke-all/extensions/block-shortcode-inline-warns/test.qmd
+++ b/crates/quarto/tests/smoke-all/extensions/block-shortcode-inline-warns/test.qmd
@@ -4,6 +4,7 @@ format: html
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       printsMessage:
         level: WARN

--- a/crates/quarto/tests/smoke-all/extensions/block-shortcode/test.qmd
+++ b/crates/quarto/tests/smoke-all/extensions/block-shortcode/test.qmd
@@ -4,6 +4,7 @@ format: html
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureHtmlElements:
         - ["hr.ext-break"]

--- a/crates/quarto/tests/smoke-all/extensions/builtin-lipsum-shortcode/test.qmd
+++ b/crates/quarto/tests/smoke-all/extensions/builtin-lipsum-shortcode/test.qmd
@@ -4,6 +4,7 @@ format: html
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureFileRegexMatches:
         - ["Lorem ipsum dolor sit amet"]

--- a/crates/quarto/tests/smoke-all/extensions/builtin-placeholder-shortcode/test.qmd
+++ b/crates/quarto/tests/smoke-all/extensions/builtin-placeholder-shortcode/test.qmd
@@ -4,6 +4,7 @@ format: html
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureFileRegexMatches:
         - ["data:image/svg"]

--- a/crates/quarto/tests/smoke-all/extensions/builtin-version-shortcode/test.qmd
+++ b/crates/quarto/tests/smoke-all/extensions/builtin-version-shortcode/test.qmd
@@ -4,6 +4,7 @@ format: html
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureFileRegexMatches:
         - ["0\\.1\\.0"]

--- a/crates/quarto/tests/smoke-all/extensions/builtin-video-local/test.qmd
+++ b/crates/quarto/tests/smoke-all/extensions/builtin-video-local/test.qmd
@@ -4,6 +4,7 @@ format: html
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureFileRegexMatches:
         - ["video-js\\.css", "video\\.min\\.js", "quarto-video", "video-js vjs-default-skin"]

--- a/crates/quarto/tests/smoke-all/extensions/builtin-video-youtube/test.qmd
+++ b/crates/quarto/tests/smoke-all/extensions/builtin-video-youtube/test.qmd
@@ -4,6 +4,7 @@ format: html
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureFileRegexMatches:
         - ["youtube\\.com/embed", "quarto-video"]

--- a/crates/quarto/tests/smoke-all/extensions/contract-args-kwargs/test.qmd
+++ b/crates/quarto/tests/smoke-all/extensions/contract-args-kwargs/test.qmd
@@ -4,6 +4,7 @@ format: html
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureFileRegexMatches:
         - ["A1=hello;MODE=fast;MISSING=EMPTY;NRAW=2"]

--- a/crates/quarto/tests/smoke-all/extensions/contract-doc-shortcodes/test.qmd
+++ b/crates/quarto/tests/smoke-all/extensions/contract-doc-shortcodes/test.qmd
@@ -6,6 +6,7 @@ shortcodes:
 _quarto:
   tests:
     html:
+      dom-parity: true
       ensureFileRegexMatches:
         # `strong[^>]*>` not `strong>`: the hub preview renders with
         # `source-location: full`, which puts data-sid/data-loc on the opening

--- a/crates/quarto/tests/smoke-all/extensions/contract-env/test.qmd
+++ b/crates/quarto/tests/smoke-all/extensions/contract-env/test.qmd
@@ -4,6 +4,7 @@ format: html
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureFileRegexMatches:
         - ["ENV-FALLBACK-VALUE"]

--- a/crates/quarto/tests/smoke-all/extensions/contract-escape-braces/test.qmd
+++ b/crates/quarto/tests/smoke-all/extensions/contract-escape-braces/test.qmd
@@ -4,6 +4,7 @@ format: html
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureFileRegexMatches:
         - ["fakename"]

--- a/crates/quarto/tests/smoke-all/extensions/contract-global-fn/test.qmd
+++ b/crates/quarto/tests/smoke-all/extensions/contract-global-fn/test.qmd
@@ -4,6 +4,7 @@ format: html
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureFileRegexMatches:
         - ["GREET-World"]

--- a/crates/quarto/tests/smoke-all/extensions/contract-meta-dotted/test.qmd
+++ b/crates/quarto/tests/smoke-all/extensions/contract-meta-dotted/test.qmd
@@ -12,6 +12,7 @@ authors:
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureFileRegexMatches:
         - ["META\\[top-val\\]", "META\\[deep-val\\]", "META-NIL", "CHAIN\\[deep-val\\]", "BOOL\\[false\\]", "META\\[Grace\\]"]

--- a/crates/quarto/tests/smoke-all/extensions/contract-nested-arg/test.qmd
+++ b/crates/quarto/tests/smoke-all/extensions/contract-nested-arg/test.qmd
@@ -4,6 +4,7 @@ format: html
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureFileRegexMatches:
         - ["OUTER\\[IN\\]"]

--- a/crates/quarto/tests/smoke-all/extensions/contract-pagebreak/test.qmd
+++ b/crates/quarto/tests/smoke-all/extensions/contract-pagebreak/test.qmd
@@ -4,6 +4,7 @@ format: html
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureFileRegexMatches:
         - ["page-break-after: always"]

--- a/crates/quarto/tests/smoke-all/extensions/contract-passthrough/test.qmd
+++ b/crates/quarto/tests/smoke-all/extensions/contract-passthrough/test.qmd
@@ -6,6 +6,7 @@ shortcode-passthrough:
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureFileRegexMatches:
         - ["\\{\\{&lt; hugoref foo &gt;\\}\\}"]

--- a/crates/quarto/tests/smoke-all/extensions/contract-require/test.qmd
+++ b/crates/quarto/tests/smoke-all/extensions/contract-require/test.qmd
@@ -4,6 +4,7 @@ format: html
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureFileRegexMatches:
         - ["REQ&lt;&lt;sib&gt;&gt;"]

--- a/crates/quarto/tests/smoke-all/extensions/contract-return-coercions/test.qmd
+++ b/crates/quarto/tests/smoke-all/extensions/contract-return-coercions/test.qmd
@@ -4,6 +4,7 @@ format: html
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureFileRegexMatches:
         # `strong[^>]*>` not `strong>`: the hub preview renders with

--- a/crates/quarto/tests/smoke-all/extensions/contract-table-return/test.qmd
+++ b/crates/quarto/tests/smoke-all/extensions/contract-table-return/test.qmd
@@ -4,6 +4,7 @@ format: html
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureFileRegexMatches:
         - ["DASH-OK", "CTX-block", "CTX-inline"]

--- a/crates/quarto/tests/smoke-all/extensions/contract-var-unknown/test.qmd
+++ b/crates/quarto/tests/smoke-all/extensions/contract-var-unknown/test.qmd
@@ -4,6 +4,7 @@ format: html
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       printsMessage:
         level: WARN

--- a/crates/quarto/tests/smoke-all/extensions/contract-var/test.qmd
+++ b/crates/quarto/tests/smoke-all/extensions/contract-var/test.qmd
@@ -4,6 +4,7 @@ format: html
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureFileRegexMatches:
         - ["simple-value", "nested-value", "href=\"https://example.com/vartarget\"", "VarLink"]

--- a/crates/quarto/tests/smoke-all/extensions/filter-extension/test.qmd
+++ b/crates/quarto/tests/smoke-all/extensions/filter-extension/test.qmd
@@ -6,6 +6,7 @@ filters:
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureFileRegexMatches:
         - ["EXTENSION-FILTER-ACTIVE"]

--- a/crates/quarto/tests/smoke-all/extensions/image-shortcode-extension/test.qmd
+++ b/crates/quarto/tests/smoke-all/extensions/image-shortcode-extension/test.qmd
@@ -4,6 +4,7 @@ format: html
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureFileRegexMatches:
         - ["data:image/png;base64,", "<img"]

--- a/crates/quarto/tests/smoke-all/extensions/lipsum-override/test.qmd
+++ b/crates/quarto/tests/smoke-all/extensions/lipsum-override/test.qmd
@@ -4,6 +4,7 @@ format: html
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureFileRegexMatches:
         - ["Λόρεμ ίψουμ δόλορ σιτ αμέτ"]

--- a/crates/quarto/tests/smoke-all/extensions/q1-compat-minimal-manifest/test.qmd
+++ b/crates/quarto/tests/smoke-all/extensions/q1-compat-minimal-manifest/test.qmd
@@ -4,6 +4,7 @@ format: html
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureFileRegexMatches:
         - ["MINIMAL-MANIFEST-OK"]

--- a/crates/quarto/tests/smoke-all/extensions/quarto-doc-api-extension/test.qmd
+++ b/crates/quarto/tests/smoke-all/extensions/quarto-doc-api-extension/test.qmd
@@ -4,6 +4,7 @@ format: html
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureFileRegexMatches:
         - - "IS-HTML-FORMAT"

--- a/crates/quarto/tests/smoke-all/extensions/shortcode-extension/test.qmd
+++ b/crates/quarto/tests/smoke-all/extensions/shortcode-extension/test.qmd
@@ -4,6 +4,7 @@ format: html
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureFileRegexMatches:
         - ["HELLO-SHORTCODE-ACTIVE"]

--- a/crates/quarto/tests/smoke-all/filters/meta-handler.qmd
+++ b/crates/quarto/tests/smoke-all/filters/meta-handler.qmd
@@ -6,6 +6,7 @@ filters:
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureHtmlElements:
         - ["p.subtitle"]

--- a/crates/quarto/tests/smoke-all/filters/post-filter.qmd
+++ b/crates/quarto/tests/smoke-all/filters/post-filter.qmd
@@ -7,6 +7,7 @@ filters:
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureFileRegexMatches:
         - ["HELLO WORLD"]

--- a/crates/quarto/tests/smoke-all/filters/pre-filter.qmd
+++ b/crates/quarto/tests/smoke-all/filters/pre-filter.qmd
@@ -6,6 +6,7 @@ filters:
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureFileRegexMatches:
         - ["HELLO WORLD"]

--- a/crates/quarto/tests/smoke-all/highlighting/01-builtin-python.qmd
+++ b/crates/quarto/tests/smoke-all/highlighting/01-builtin-python.qmd
@@ -5,6 +5,7 @@ _quarto:
   tests:
     html:
       noErrors: true
+      dom-parity: true
       ensureFileRegexMatches:
         # Code block: outer container carries `sourceCode python` and
         # keyword / builtin tokens wrap in `<span class="hl-*">`.

--- a/crates/quarto/tests/smoke-all/highlighting/04-filter/04-filter-authored-spans.qmd
+++ b/crates/quarto/tests/smoke-all/highlighting/04-filter/04-filter-authored-spans.qmd
@@ -6,6 +6,7 @@ filters:
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureFileRegexMatches:
         # The filter produces `hl-error` and `hl-warning` spans around

--- a/crates/quarto/tests/smoke-all/highlighting/06-filter-severity/06-filter-severity.qmd
+++ b/crates/quarto/tests/smoke-all/highlighting/06-filter-severity/06-filter-severity.qmd
@@ -6,6 +6,7 @@ filters:
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureFileRegexMatches:
         - ["hl-severity-err\">&lt;err&gt;</span>",

--- a/crates/quarto/tests/smoke-all/highlighting/07-adaptive-pair-github-arrow.qmd
+++ b/crates/quarto/tests/smoke-all/highlighting/07-adaptive-pair-github-arrow.qmd
@@ -11,6 +11,7 @@ highlight-style:
 _quarto:
   tests:
     html:
+      dom-parity: true
       # The whole point: both palette names are Q1 built-ins that the
       # .theme translator now ships, so the render is warning-free
       # (regression guard for the Q-14-5 fallback both names used to

--- a/crates/quarto/tests/smoke-all/highlighting/08-code-block-bg-override.qmd
+++ b/crates/quarto/tests/smoke-all/highlighting/08-code-block-bg-override.qmd
@@ -9,6 +9,7 @@ code-block-color: "#e0e1e2"
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrorsOrWarnings: true
       ensureCssRegexMatches:
         # The document metadata wins over github-light's translated

--- a/crates/quarto/tests/smoke-all/includes/basic/basic.qmd
+++ b/crates/quarto/tests/smoke-all/includes/basic/basic.qmd
@@ -4,6 +4,7 @@ format: html
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureFileRegexMatches:
         - ["BASIC-CHILD-MARKER-XYZ"]

--- a/crates/quarto/tests/smoke-all/includes/circular/circular.qmd
+++ b/crates/quarto/tests/smoke-all/includes/circular/circular.qmd
@@ -4,6 +4,7 @@ format: html
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: default
       printsMessage:
         level: WARN

--- a/crates/quarto/tests/smoke-all/includes/missing/missing.qmd
+++ b/crates/quarto/tests/smoke-all/includes/missing/missing.qmd
@@ -4,6 +4,7 @@ format: html
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: default
       printsMessage:
         level: WARN

--- a/crates/quarto/tests/smoke-all/localization/lang-es-authors-plural.qmd
+++ b/crates/quarto/tests/smoke-all/localization/lang-es-authors-plural.qmd
@@ -8,6 +8,7 @@ format: html
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureFileRegexMatches:
         - ["Autores/as<"]

--- a/crates/quarto/tests/smoke-all/localization/lang-es-draft-banner.qmd
+++ b/crates/quarto/tests/smoke-all/localization/lang-es-draft-banner.qmd
@@ -6,6 +6,7 @@ format: html
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       # The banner label comes from the `draft` language term, not an
       # English literal (bd-draft-banner-missing-hgx1gkqm). Quarto 1 uses

--- a/crates/quarto/tests/smoke-all/localization/lang-es-title-block.qmd
+++ b/crates/quarto/tests/smoke-all/localization/lang-es-title-block.qmd
@@ -9,6 +9,7 @@ format: html
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureFileRegexMatches:
         - ["<html lang=\"es\"", "Autor/a<", "Fecha de publicación", ">Resumen<"]

--- a/crates/quarto/tests/smoke-all/localization/lang-fr-toc.qmd
+++ b/crates/quarto/tests/smoke-all/localization/lang-fr-toc.qmd
@@ -6,6 +6,7 @@ toc: true
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureFileRegexMatches:
         - ["Table des matières"]

--- a/crates/quarto/tests/smoke-all/mermaid/no-mermaid.qmd
+++ b/crates/quarto/tests/smoke-all/mermaid/no-mermaid.qmd
@@ -6,6 +6,7 @@ title: "No Mermaid, No Script"
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureHtmlElements:
         - []

--- a/crates/quarto/tests/smoke-all/metadata/appendix-style-inheritance/chapters/dir-appendix-none.qmd
+++ b/crates/quarto/tests/smoke-all/metadata/appendix-style-inheritance/chapters/dir-appendix-none.qmd
@@ -4,6 +4,7 @@ format: html
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureHtmlElements:
         - []

--- a/crates/quarto/tests/smoke-all/metadata/appendix-style-inheritance/doc-override-default.qmd
+++ b/crates/quarto/tests/smoke-all/metadata/appendix-style-inheritance/doc-override-default.qmd
@@ -5,6 +5,7 @@ format: html
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureHtmlElements:
         - ["div#quarto-appendix.default", "section#quarto-reuse"]

--- a/crates/quarto/tests/smoke-all/metadata/appendix-style-inheritance/project-appendix-plain.qmd
+++ b/crates/quarto/tests/smoke-all/metadata/appendix-style-inheritance/project-appendix-plain.qmd
@@ -4,6 +4,7 @@ format: html
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureHtmlElements:
         - ["div#quarto-appendix.plain", "section#quarto-reuse"]

--- a/crates/quarto/tests/smoke-all/metadata/dir-metadata-hierarchy/chapters/intro/deep-doc.qmd
+++ b/crates/quarto/tests/smoke-all/metadata/dir-metadata-hierarchy/chapters/intro/deep-doc.qmd
@@ -4,6 +4,7 @@ format: html
 _quarto:
   tests:
     html:
+      dom-parity: true
       ensureHtmlElements:
         - ["nav#TOC"]
       ensureFileRegexMatches:

--- a/crates/quarto/tests/smoke-all/metadata/dir-metadata-override/chapters/override-test.qmd
+++ b/crates/quarto/tests/smoke-all/metadata/dir-metadata-override/chapters/override-test.qmd
@@ -6,6 +6,7 @@ format: html
 _quarto:
   tests:
     html:
+      dom-parity: true
       ensureFileRegexMatches:
         - ["Document Author"]
         - ["Directory Author"]

--- a/crates/quarto/tests/smoke-all/metadata/dir-metadata-paths/chapters/intro/doc.qmd
+++ b/crates/quarto/tests/smoke-all/metadata/dir-metadata-paths/chapters/intro/doc.qmd
@@ -4,6 +4,7 @@ format: html
 _quarto:
   tests:
     html:
+      dom-parity: true
       ensureHtmlElements:
         # The CSS link should point to the adjusted path
         # From chapters/intro/, the path to shared/styles.css

--- a/crates/quarto/tests/smoke-all/metadata/dir-metadata/chapters/chapter1.qmd
+++ b/crates/quarto/tests/smoke-all/metadata/dir-metadata/chapters/chapter1.qmd
@@ -4,6 +4,7 @@ format: html
 _quarto:
   tests:
     html:
+      dom-parity: true
       ensureHtmlElements:
         - ["nav#TOC"]
       ensureFileRegexMatches:

--- a/crates/quarto/tests/smoke-all/metadata/doc-overrides/overrides-title.qmd
+++ b/crates/quarto/tests/smoke-all/metadata/doc-overrides/overrides-title.qmd
@@ -4,6 +4,7 @@ format: html
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureFileRegexMatches:
         - ["<title>Document Title Override</title>", "Project Author"]

--- a/crates/quarto/tests/smoke-all/metadata/environment-files/index.qmd
+++ b/crates/quarto/tests/smoke-all/metadata/environment-files/index.qmd
@@ -4,6 +4,7 @@ format: html
 _quarto:
   tests:
     html:
+      dom-parity: true
       ensureFileRegexMatches:
         - ["value-from-environment-file", "local-override-wins"]
         - ["\\?env:", "base-value-should-lose"]

--- a/crates/quarto/tests/smoke-all/metadata/format-specific/doc-format-overrides.qmd
+++ b/crates/quarto/tests/smoke-all/metadata/format-specific/doc-format-overrides.qmd
@@ -5,6 +5,7 @@ format:
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureFileRegexMatches:
         - ["Format Specific Test Project"]

--- a/crates/quarto/tests/smoke-all/metadata/format-specific/format-html-toc.qmd
+++ b/crates/quarto/tests/smoke-all/metadata/format-specific/format-html-toc.qmd
@@ -3,6 +3,7 @@ format: html
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureFileRegexMatches:
         - ["<nav[^>]*id=\"TOC\"", "toc-title", "First Section", "Second Section"]

--- a/crates/quarto/tests/smoke-all/metadata/project-inherits/inherits-title.qmd
+++ b/crates/quarto/tests/smoke-all/metadata/project-inherits/inherits-title.qmd
@@ -3,6 +3,7 @@ format: html
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureFileRegexMatches:
         - ["<title>Project Title From Config</title>", "Project Author"]

--- a/crates/quarto/tests/smoke-all/metadata/project-profiles/index.qmd
+++ b/crates/quarto/tests/smoke-all/metadata/project-profiles/index.qmd
@@ -2,6 +2,7 @@
 _quarto:
   tests:
     html:
+      dom-parity: true
       ensureFileRegexMatches:
         - ["PROD-VISIBLE", "BETA-VISIBLE", "Production Title"]
         - ["PROD-HIDDEN", "when-profile"]

--- a/crates/quarto/tests/smoke-all/metadata/theme-inheritance/appendix/appendix-doc.qmd
+++ b/crates/quarto/tests/smoke-all/metadata/theme-inheritance/appendix/appendix-doc.qmd
@@ -4,6 +4,7 @@ format: html
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureCssRegexMatches:
         - ["--bs-primary:.*#375a7f"]

--- a/crates/quarto/tests/smoke-all/metadata/theme-inheritance/appendix/custom/custom-doc.qmd
+++ b/crates/quarto/tests/smoke-all/metadata/theme-inheritance/appendix/custom/custom-doc.qmd
@@ -4,6 +4,7 @@ format: html
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureCssRegexMatches:
         - ["Neucha"]

--- a/crates/quarto/tests/smoke-all/metadata/theme-inheritance/chapters/chapter1.qmd
+++ b/crates/quarto/tests/smoke-all/metadata/theme-inheritance/chapters/chapter1.qmd
@@ -4,6 +4,7 @@ format: html
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureCssRegexMatches:
         - ["--bs-primary:.*#2c3e50"]

--- a/crates/quarto/tests/smoke-all/metadata/theme-inheritance/chapters/chapter2.qmd
+++ b/crates/quarto/tests/smoke-all/metadata/theme-inheritance/chapters/chapter2.qmd
@@ -5,6 +5,7 @@ theme: cosmo
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureCssRegexMatches:
         - ["--bs-primary:.*#2780e3"]

--- a/crates/quarto/tests/smoke-all/metadata/theme-inheritance/chapters/deep/deep-doc.qmd
+++ b/crates/quarto/tests/smoke-all/metadata/theme-inheritance/chapters/deep/deep-doc.qmd
@@ -4,6 +4,7 @@ format: html
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureCssRegexMatches:
         - ["--bs-primary:.*#2c3e50"]

--- a/crates/quarto/tests/smoke-all/metadata/theme-inheritance/root-doc.qmd
+++ b/crates/quarto/tests/smoke-all/metadata/theme-inheritance/root-doc.qmd
@@ -4,6 +4,7 @@ format: html
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureCssRegexMatches:
         - ["--bs-primary:.*#375a7f"]

--- a/crates/quarto/tests/smoke-all/quarto-test/basic-render.qmd
+++ b/crates/quarto/tests/smoke-all/quarto-test/basic-render.qmd
@@ -4,6 +4,7 @@ format: html
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureFileRegexMatches:
         - ["<!DOCTYPE html>", "<title>Basic Render Test</title>", "This is a test paragraph"]

--- a/crates/quarto/tests/smoke-all/quarto-test/callout-note.qmd
+++ b/crates/quarto/tests/smoke-all/quarto-test/callout-note.qmd
@@ -4,6 +4,7 @@ format: html
 _quarto:
   tests:
     html:
+      dom-parity: true
       ensureFileRegexMatches:
         - ["callout", "callout-note", "This is a note"]
 ---

--- a/crates/quarto/tests/smoke-all/quarto-test/clean-render.qmd
+++ b/crates/quarto/tests/smoke-all/quarto-test/clean-render.qmd
@@ -4,6 +4,7 @@ format: html
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureFileRegexMatches:
         - ["<title>Clean Render Test</title>"]

--- a/crates/quarto/tests/smoke-all/quarto-test/code-block.qmd
+++ b/crates/quarto/tests/smoke-all/quarto-test/code-block.qmd
@@ -4,6 +4,7 @@ format: html
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureFileRegexMatches:
         # Syntax highlighting is applied on the CLI render path: the

--- a/crates/quarto/tests/smoke-all/quarto-test/named-entities.qmd
+++ b/crates/quarto/tests/smoke-all/quarto-test/named-entities.qmd
@@ -4,6 +4,7 @@ format: html
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureFileRegexMatches:
         - ["Named: A &gt; B &lt; C &amp; D", "Nbsp: F G", "Copy: © H", "Multi: x ≂̸ y", "Numeric: A &gt; B"]

--- a/crates/quarto/tests/smoke-all/quarto-test/no-extra-files.qmd
+++ b/crates/quarto/tests/smoke-all/quarto-test/no-extra-files.qmd
@@ -4,6 +4,7 @@ format: html
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       fileExists:
         outputPath: "no-extra-files.html"

--- a/crates/quarto/tests/smoke-all/themes/theme-array/subdir/theme-array-subdir.qmd
+++ b/crates/quarto/tests/smoke-all/themes/theme-array/subdir/theme-array-subdir.qmd
@@ -8,6 +8,7 @@ format:
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureCssRegexMatches:
         - ["#170229", "smoke-test-subdir-rule", "#def456"]

--- a/crates/quarto/tests/smoke-all/themes/theme-array/theme-array.qmd
+++ b/crates/quarto/tests/smoke-all/themes/theme-array/theme-array.qmd
@@ -8,6 +8,7 @@ format:
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureCssRegexMatches:
         - ["#170229", "smoke-test-custom-rule", "#abc123"]

--- a/crates/quarto/tests/smoke-all/themes/theme-cascade-three-layer/chapters/chapter.qmd
+++ b/crates/quarto/tests/smoke-all/themes/theme-cascade-three-layer/chapters/chapter.qmd
@@ -8,6 +8,7 @@ format:
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureCssRegexMatches:
         - ["#170229", "cascade-marker", "#f0e0d0"]

--- a/crates/quarto/tests/smoke-all/themes/theme-crossdir-scss/chapters/crossdir-doc.qmd
+++ b/crates/quarto/tests/smoke-all/themes/theme-crossdir-scss/chapters/crossdir-doc.qmd
@@ -8,6 +8,7 @@ format:
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureCssRegexMatches:
         - ["#170229", "crossdir-scss-marker", "#789abc"]

--- a/crates/quarto/tests/smoke-all/themes/theme-metadata-scss-relpath/chapters/chapter-relpath.qmd
+++ b/crates/quarto/tests/smoke-all/themes/theme-metadata-scss-relpath/chapters/chapter-relpath.qmd
@@ -3,6 +3,7 @@ title: Metadata Relative SCSS Path (Same Dir)
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureCssRegexMatches:
         - ["#170229", "metadata-relpath-marker", "#cc5501"]

--- a/crates/quarto/tests/smoke-all/themes/theme-metadata-scss-relpath/chapters/deep/deep-relpath.qmd
+++ b/crates/quarto/tests/smoke-all/themes/theme-metadata-scss-relpath/chapters/deep/deep-relpath.qmd
@@ -3,6 +3,7 @@ title: Metadata Relative SCSS Path (Deeper Subdir)
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureCssRegexMatches:
         - ["#170229", "metadata-relpath-marker", "#cc5501"]

--- a/crates/quarto/tests/smoke-all/themes/theme-metadata-scss/chapters/chapter-doc.qmd
+++ b/crates/quarto/tests/smoke-all/themes/theme-metadata-scss/chapters/chapter-doc.qmd
@@ -3,6 +3,7 @@ title: Metadata Theme with Custom SCSS (Same Dir)
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureCssRegexMatches:
         - ["#170229", "metadata-scss-marker", "#d4e5f6"]

--- a/crates/quarto/tests/smoke-all/themes/theme-metadata-scss/chapters/deep/deep-doc.qmd
+++ b/crates/quarto/tests/smoke-all/themes/theme-metadata-scss/chapters/deep/deep-doc.qmd
@@ -3,6 +3,7 @@ title: Metadata Theme with Custom SCSS (Deeper Subdir)
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureCssRegexMatches:
         - ["#170229", "metadata-scss-marker", "#d4e5f6"]

--- a/crates/quarto/tests/smoke-all/themes/theme-project-scss-relpath/chapters/subdir-relpath.qmd
+++ b/crates/quarto/tests/smoke-all/themes/theme-project-scss-relpath/chapters/subdir-relpath.qmd
@@ -3,6 +3,7 @@ title: Project Relative SCSS Path (Subdirectory)
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureCssRegexMatches:
         - ["#170229", "project-relpath-marker", "#aabb12"]

--- a/crates/quarto/tests/smoke-all/themes/theme-project-scss-relpath/root-relpath.qmd
+++ b/crates/quarto/tests/smoke-all/themes/theme-project-scss-relpath/root-relpath.qmd
@@ -3,6 +3,7 @@ title: Project Relative SCSS Path (Root)
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureCssRegexMatches:
         - ["#170229", "project-relpath-marker", "#aabb12"]

--- a/crates/quarto/tests/smoke-all/themes/theme-project-scss/chapters/doc-inherits-project-theme.qmd
+++ b/crates/quarto/tests/smoke-all/themes/theme-project-scss/chapters/doc-inherits-project-theme.qmd
@@ -3,6 +3,7 @@ title: Project Theme with Custom SCSS (Subdirectory)
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureCssRegexMatches:
         - ["#170229", "project-scss-marker", "#a1b2c3"]

--- a/crates/quarto/tests/smoke-all/themes/theme-project-scss/root-doc.qmd
+++ b/crates/quarto/tests/smoke-all/themes/theme-project-scss/root-doc.qmd
@@ -3,6 +3,7 @@ title: Project Theme with Custom SCSS (Root)
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureCssRegexMatches:
         - ["#170229", "project-scss-marker", "#a1b2c3"]

--- a/crates/quarto/tests/smoke-all/themes/theme-subdir-doc-override/subdir/doc.qmd
+++ b/crates/quarto/tests/smoke-all/themes/theme-subdir-doc-override/subdir/doc.qmd
@@ -8,6 +8,7 @@ format:
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureCssRegexMatches:
         - ["#170229", "subdir-override-marker", "#e1d2c3"]

--- a/crates/quarto/tests/smoke-all/title-block/banner-color.qmd
+++ b/crates/quarto/tests/smoke-all/title-block/banner-color.qmd
@@ -11,6 +11,7 @@ title-block-banner-color: "#111111"
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureHtmlElements:
         - [

--- a/crates/quarto/tests/smoke-all/title-block/banner-image.qmd
+++ b/crates/quarto/tests/smoke-all/title-block/banner-image.qmd
@@ -11,6 +11,7 @@ title-block-banner: banner.png
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureHtmlElements:
         - [

--- a/crates/quarto/tests/smoke-all/title-block/banner-true.qmd
+++ b/crates/quarto/tests/smoke-all/title-block/banner-true.qmd
@@ -13,6 +13,7 @@ title-block-banner: true
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureHtmlElements:
         - [

--- a/crates/quarto/tests/smoke-all/title-block/categories-disabled.qmd
+++ b/crates/quarto/tests/smoke-all/title-block/categories-disabled.qmd
@@ -11,6 +11,7 @@ title-block-categories: false
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureHtmlElements:
         - ["header#title-block-header.quarto-title-block.default"]

--- a/crates/quarto/tests/smoke-all/title-block/date-default-long.qmd
+++ b/crates/quarto/tests/smoke-all/title-block/date-default-long.qmd
@@ -9,6 +9,7 @@ date: "2026-07-01"
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureFileRegexMatches:
         - [

--- a/crates/quarto/tests/smoke-all/title-block/date-format.qmd
+++ b/crates/quarto/tests/smoke-all/title-block/date-format.qmd
@@ -12,6 +12,7 @@ date-format: "MMM D, YYYY"
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureHtmlElements:
         - [

--- a/crates/quarto/tests/smoke-all/title-block/date-no-author.qmd
+++ b/crates/quarto/tests/smoke-all/title-block/date-no-author.qmd
@@ -7,6 +7,7 @@ date: "2026-07-01"
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureHtmlElements:
         - [

--- a/crates/quarto/tests/smoke-all/title-block/label-overrides.qmd
+++ b/crates/quarto/tests/smoke-all/title-block/label-overrides.qmd
@@ -11,6 +11,7 @@ abstract-title: "Summary"
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureHtmlElements:
         - [

--- a/crates/quarto/tests/smoke-all/title-block/metadata-grid.qmd
+++ b/crates/quarto/tests/smoke-all/title-block/metadata-grid.qmd
@@ -17,6 +17,7 @@ categories:
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureHtmlElements:
         - [

--- a/crates/quarto/tests/smoke-all/title-block/rich-authors.qmd
+++ b/crates/quarto/tests/smoke-all/title-block/rich-authors.qmd
@@ -24,6 +24,7 @@ author:
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureHtmlElements:
         - [

--- a/crates/quarto/tests/smoke-all/title-block/simple-default.qmd
+++ b/crates/quarto/tests/smoke-all/title-block/simple-default.qmd
@@ -14,6 +14,7 @@ _quarto:
   tests:
     html:
       noErrors: true
+      dom-parity: true
       ensureHtmlElements:
         - [
             "header#title-block-header.quarto-title-block.default",

--- a/crates/quarto/tests/smoke-all/title-block/style-none.qmd
+++ b/crates/quarto/tests/smoke-all/title-block/style-none.qmd
@@ -11,6 +11,7 @@ title-block-style: none
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureHtmlElements:
         - [

--- a/crates/quarto/tests/smoke-all/title-block/style-plain.qmd
+++ b/crates/quarto/tests/smoke-all/title-block/style-plain.qmd
@@ -11,6 +11,7 @@ title-block-style: plain
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureHtmlElements:
         - [

--- a/crates/quarto/tests/smoke-all/title-block/two-authors.qmd
+++ b/crates/quarto/tests/smoke-all/title-block/two-authors.qmd
@@ -10,6 +10,7 @@ date: "2026-07-01"
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureHtmlElements:
         - [

--- a/crates/quarto/tests/smoke-all/toc-containers/blockquote-heading-not-in-toc.qmd
+++ b/crates/quarto/tests/smoke-all/toc-containers/blockquote-heading-not-in-toc.qmd
@@ -6,6 +6,7 @@ format:
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureHtmlElements:
         - ["nav#TOC a[data-scroll-target=\"#outer\"]", "blockquote h4#quoted"]

--- a/crates/quarto/tests/smoke-all/toc-containers/callout-title-not-in-toc.qmd
+++ b/crates/quarto/tests/smoke-all/toc-containers/callout-title-not-in-toc.qmd
@@ -6,6 +6,7 @@ format:
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureHtmlElements:
         - ["nav#TOC a[data-scroll-target=\"#outer\"]", "div.callout-note"]

--- a/crates/quarto/tests/smoke-all/toc-containers/column-margin-heading-in-toc.qmd
+++ b/crates/quarto/tests/smoke-all/toc-containers/column-margin-heading-in-toc.qmd
@@ -6,6 +6,7 @@ format:
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureHtmlElements:
         - ["nav#TOC a[data-scroll-target=\"#outer\"]",

--- a/crates/quarto/tests/smoke-all/toc-containers/content-visible-div-unwrapped.qmd
+++ b/crates/quarto/tests/smoke-all/toc-containers/content-visible-div-unwrapped.qmd
@@ -6,6 +6,7 @@ format:
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureHtmlElements:
         - ["nav#TOC a[data-scroll-target=\"#outer\"]",

--- a/crates/quarto/tests/smoke-all/toc-containers/content-visible-span-kept.qmd
+++ b/crates/quarto/tests/smoke-all/toc-containers/content-visible-span-kept.qmd
@@ -4,6 +4,7 @@ format:
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureHtmlElements:
         - ["span.keep-me"]

--- a/crates/quarto/tests/smoke-all/toc-containers/div-heading-becomes-section.qmd
+++ b/crates/quarto/tests/smoke-all/toc-containers/div-heading-becomes-section.qmd
@@ -6,6 +6,7 @@ format:
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureHtmlElements:
         - ["section.level4.wrap-a#case-a",

--- a/crates/quarto/tests/smoke-all/toc-containers/plain-div-heading-in-toc.qmd
+++ b/crates/quarto/tests/smoke-all/toc-containers/plain-div-heading-in-toc.qmd
@@ -6,6 +6,7 @@ format:
 _quarto:
   tests:
     html:
+      dom-parity: true
       noErrors: true
       ensureHtmlElements:
         - ["nav#TOC a[data-scroll-target=\"#outer\"]",

--- a/hub-client/e2e/helpers/smokeAllDiscovery.ts
+++ b/hub-client/e2e/helpers/smokeAllDiscovery.ts
@@ -237,6 +237,11 @@ function parseFormatSpec(
         case 'folderExists':
           // Filesystem assertions are no-ops in browser
           break;
+        case 'dom-parity':
+          // Opt-in flag for the preview <-> render DOM parity runner
+          // (hub-client/src/services/smokeAllParity.wasm.test.tsx). Not an
+          // assertion here.
+          break;
         default:
           throw new Error(`Unknown assertion type: '${key}' in format '${format}'`);
       }

--- a/hub-client/src/services/smokeAll.wasm.test.ts
+++ b/hub-client/src/services/smokeAll.wasm.test.ts
@@ -8,37 +8,26 @@
  */
 
 import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
-import { readFile, readdir, stat } from 'fs/promises';
-import { dirname, join, relative, resolve } from 'path';
-import { fileURLToPath } from 'url';
-import { parse as parseYaml } from 'yaml';
+import { readFile } from 'fs/promises';
+import { relative } from 'path';
 import { JSDOM } from 'jsdom';
 
-import { discoverUserGrammars } from '@quarto/preview-runtime/userGrammar/Discovery';
-import { loadUserGrammar } from '@quarto/preview-runtime/userGrammar/Highlight';
+import {
+  SMOKE_ALL_DIR,
+  loadSmokeWasm,
+  discoverTestFiles,
+  readFrontmatter,
+  readTestsBlock,
+  parseTwoArraySpec,
+  shouldSkip,
+  populateVfs,
+  buildUserGrammarsHandle,
+  type WasmModule,
+} from '../test-utils/smokeAllFixtures';
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
-
-interface JsUserGrammarsHandle {
-  register(
-    languageClass: string,
-    highlightFn: (class_: string, source: string) => string | null | undefined,
-  ): void;
-  free(): void;
-}
-
-interface WasmModule {
-  default: (input?: BufferSource) => Promise<void>;
-  vfs_add_file: (path: string, content: string) => string;
-  vfs_add_binary_file: (path: string, content: Uint8Array) => string;
-  vfs_clear: () => string;
-  vfs_list_files: () => string;
-  vfs_read_file: (path: string) => string;
-  render_qmd: (path: string, user_grammars?: unknown) => Promise<string>;
-  JsUserGrammars: new () => JsUserGrammarsHandle;
-}
 
 interface JsonDiagnostic {
   kind: string;
@@ -56,21 +45,6 @@ interface WasmRenderResult {
   diagnostics?: JsonDiagnostic[];
 }
 
-interface RunConfig {
-  skip?: string | boolean;
-  ci?: boolean;
-  os?: string[];
-  not_os?: string[];
-  /**
-   * Set on fixtures whose format requires a JS runtime to render. Parsed
-   * for consistency with the Rust runner, which uses it to skip CLI runs.
-   * Not enforced here — the WASM unit test already filters by
-   * `format !== 'html'`, so q2-debug fixtures are skipped at the format
-   * gate before this matters.
-   */
-  requires_js?: boolean;
-}
-
 interface FormatSpec {
   format: string;
   assertions: AssertionFn[];
@@ -83,9 +57,6 @@ type AssertionFn = (result: WasmRenderResult) => void;
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const SMOKE_ALL_DIR = resolve(__dirname, '../../../crates/quarto/tests/smoke-all');
 
 // Tests where printsMessage assertions are skipped in WASM because the error
 // message format differs between native render_to_file and WASM render_qmd.
@@ -101,89 +72,12 @@ const SKIP_PRINTS_MESSAGE: Set<string> = new Set([
 let wasm: WasmModule;
 
 beforeAll(async () => {
-  const wasmDir = join(__dirname, '../../wasm-quarto-hub-client');
-  const wasmPath = join(wasmDir, 'wasm_quarto_hub_client_bg.wasm');
-  const wasmBytes = await readFile(wasmPath);
-
-  wasm = (await import('wasm-quarto-hub-client')) as unknown as WasmModule;
-  await wasm.default(wasmBytes);
-
-  // Set up VFS callbacks for the SASS importer so that dart-sass can resolve
-  // @use/@import directives against the VFS (Bootstrap SCSS files, etc.)
-  const sassModule = await import('/src/wasm-js-bridge/sass.js');
-  sassModule.setVfsCallbacks(
-    (path: string): string | null => {
-      try {
-        const result = JSON.parse(wasm.vfs_read_file(path)) as { success: boolean; content?: string };
-        return result.success && result.content !== undefined ? result.content : null;
-      } catch {
-        return null;
-      }
-    },
-    (path: string): boolean => {
-      try {
-        const result = JSON.parse(wasm.vfs_read_file(path)) as { success: boolean; content?: string };
-        return result.success && result.content !== undefined;
-      } catch {
-        return false;
-      }
-    },
-  );
+  wasm = await loadSmokeWasm();
 });
-
-// ---------------------------------------------------------------------------
-// Discovery
-// ---------------------------------------------------------------------------
-
-/** Recursively find all .qmd files under a directory, skipping files starting with _. */
-async function discoverTestFiles(dir: string): Promise<string[]> {
-  const results: string[] = [];
-
-  async function walk(d: string) {
-    const entries = await readdir(d, { withFileTypes: true });
-    for (const entry of entries) {
-      const full = join(d, entry.name);
-      if (entry.isDirectory()) {
-        await walk(full);
-      } else if (entry.isFile() && entry.name.endsWith('.qmd') && !entry.name.startsWith('_')) {
-        results.push(full);
-      }
-    }
-  }
-
-  await walk(dir);
-  results.sort();
-  return results;
-}
-
-// ---------------------------------------------------------------------------
-// Frontmatter parsing
-// ---------------------------------------------------------------------------
-
-/** Extract and parse YAML frontmatter from QMD content. */
-function readFrontmatter(content: string): Record<string, unknown> {
-  const trimmed = content.trimStart();
-  if (!trimmed.startsWith('---')) return {};
-
-  const rest = trimmed.slice(3);
-  const end = rest.indexOf('\n---');
-  if (end === -1) return {};
-
-  const yamlStr = rest.slice(0, end);
-  return (parseYaml(yamlStr) as Record<string, unknown>) ?? {};
-}
 
 // ---------------------------------------------------------------------------
 // Test spec parsing
 // ---------------------------------------------------------------------------
-
-/** Parse a two-array spec (used by ensureFileRegexMatches and ensureHtmlElements). */
-function parseTwoArraySpec(value: unknown): { matches: string[]; noMatches: string[] } {
-  if (!Array.isArray(value)) return { matches: [], noMatches: [] };
-  const matches = Array.isArray(value[0]) ? (value[0] as string[]) : [];
-  const noMatches = value.length > 1 && Array.isArray(value[1]) ? (value[1] as string[]) : [];
-  return { matches, noMatches };
-}
 
 interface ParseOptions {
   /** Skip printsMessage assertions (for tests where WASM error messages differ). */
@@ -191,30 +85,13 @@ interface ParseOptions {
 }
 
 /** Parse test specs from document metadata. Returns run config and format specs. */
-function parseTestSpecs(
-  metadata: Record<string, unknown>,
-  options: ParseOptions = {},
-): {
-  runConfig: RunConfig | null;
-  formatSpecs: FormatSpec[];
-} {
-  const quarto = metadata['_quarto'] as Record<string, unknown> | undefined;
-  if (!quarto) return { runConfig: null, formatSpecs: [] };
-
-  const tests = quarto['tests'] as Record<string, unknown> | undefined;
-  if (!tests) return { runConfig: null, formatSpecs: [] };
-
-  // Parse run config
-  const runConfig = (tests['run'] as RunConfig) ?? null;
-
-  // Parse format specs
-  const formatSpecs: FormatSpec[] = [];
-  for (const [key, value] of Object.entries(tests)) {
-    if (key === 'run') continue;
-    formatSpecs.push(parseFormatSpec(key, value as Record<string, unknown>, options));
-  }
-
-  return { runConfig, formatSpecs };
+function parseTestSpecs(metadata: Record<string, unknown>, options: ParseOptions = {}) {
+  const block = readTestsBlock(metadata);
+  if (!block) return { runConfig: null, formatSpecs: [] };
+  const formatSpecs = Object.entries(block.formats).map(([format, value]) =>
+    parseFormatSpec(format, value, options),
+  );
+  return { runConfig: block.run, formatSpecs };
 }
 
 /** Parse a single format's test specification. */
@@ -284,180 +161,6 @@ function parseFormatSpec(format: string, value: Record<string, unknown>, options
   }
 
   return { format, assertions, checkWarnings, expectsError };
-}
-
-// ---------------------------------------------------------------------------
-// Skip logic
-// ---------------------------------------------------------------------------
-
-function shouldSkip(runConfig: RunConfig | null): string | null {
-  if (!runConfig) return null;
-
-  if (runConfig.skip) {
-    return typeof runConfig.skip === 'string' ? runConfig.skip : 'skip: true';
-  }
-
-  if (runConfig.ci === false && (process.env.CI || process.env.GITHUB_ACTIONS)) {
-    return 'tests.run.ci is false';
-  }
-
-  // os/not_os: WASM is platform-independent, but implement for completeness
-  const currentOs = process.platform === 'darwin' ? 'darwin' : process.platform === 'win32' ? 'windows' : 'linux';
-
-  if (runConfig.os && !runConfig.os.includes(currentOs)) {
-    return `tests.run.os does not include ${currentOs}`;
-  }
-  if (runConfig.not_os && runConfig.not_os.includes(currentOs)) {
-    return `tests.run.not_os includes ${currentOs}`;
-  }
-
-  return null;
-}
-
-// ---------------------------------------------------------------------------
-// VFS population
-// ---------------------------------------------------------------------------
-
-/** Find the project root by walking upward from qmdDir looking for _quarto.yml. */
-async function findProjectRoot(qmdDir: string): Promise<string> {
-  let dir = qmdDir;
-  while (dir.startsWith(SMOKE_ALL_DIR)) {
-    try {
-      await stat(join(dir, '_quarto.yml'));
-      return dir;
-    } catch {
-      const parent = dirname(dir);
-      if (parent === dir) break;
-      dir = parent;
-    }
-  }
-  // No _quarto.yml found — use the QMD file's own directory
-  return qmdDir;
-}
-
-/**
- * File extensions routed through `vfs_add_binary_file` rather than
- * `vfs_add_file`. Reading these as UTF-8 corrupts their bytes (and in
- * the `.wasm` case makes the user-grammar loader fail silently).
- */
-const BINARY_EXTENSIONS = new Set<string>([
-  '.wasm',
-  '.png',
-  '.jpg',
-  '.jpeg',
-  '.gif',
-  '.pdf',
-  '.ico',
-  '.webp',
-  '.ttf',
-  '.woff',
-  '.woff2',
-  '.zip',
-]);
-
-function isBinaryFilename(filename: string): boolean {
-  const lower = filename.toLowerCase();
-  const dot = lower.lastIndexOf('.');
-  if (dot < 0) return false;
-  return BINARY_EXTENSIONS.has(lower.slice(dot));
-}
-
-interface FileEntry {
-  path: string; // absolute on disk
-  projectRelPath: string; // relative to the smoke-all project root, no leading slash
-  content: string | Uint8Array;
-}
-
-/** Recursively read every file under `dir`, binary-aware. */
-async function readAllFiles(dir: string, projectRoot: string): Promise<FileEntry[]> {
-  const files: FileEntry[] = [];
-
-  async function walk(d: string) {
-    const entries = await readdir(d, { withFileTypes: true });
-    for (const entry of entries) {
-      const full = join(d, entry.name);
-      if (entry.isDirectory()) {
-        await walk(full);
-      } else if (entry.isFile()) {
-        const content: string | Uint8Array = isBinaryFilename(entry.name)
-          ? new Uint8Array(await readFile(full))
-          : await readFile(full, 'utf-8');
-        files.push({
-          path: full,
-          projectRelPath: relative(projectRoot, full),
-          content,
-        });
-      }
-    }
-  }
-
-  await walk(dir);
-  return files;
-}
-
-/**
- * Populate the WASM VFS with all files from the project root. Returns
- * both the `/project/`-prefixed VFS path for the QMD being rendered,
- * and the flat list of project-relative file paths (consumed by the
- * user-grammar discovery step downstream).
- */
-async function populateVfs(
-  qmdPath: string,
-): Promise<{ vfsPath: string; projectFiles: FileEntry[] }> {
-  const qmdDir = dirname(qmdPath);
-  const projectRoot = await findProjectRoot(qmdDir);
-
-  const files = await readAllFiles(projectRoot, projectRoot);
-  for (const file of files) {
-    const vfsPath = `/project/${file.projectRelPath}`;
-    if (typeof file.content === 'string') {
-      wasm.vfs_add_file(vfsPath, file.content);
-    } else {
-      wasm.vfs_add_binary_file(vfsPath, file.content);
-    }
-  }
-
-  const relQmd = relative(projectRoot, qmdPath);
-  return { vfsPath: `/project/${relQmd}`, projectFiles: files };
-}
-
-/**
- * Given the project's file list, discover any user-defined tree-sitter
- * grammars under `_quarto/grammars/<name>/`, load them, and return a
- * `JsUserGrammars` handle ready to pass into `render_qmd`. Returns
- * `undefined` when the project has no grammars, which lets callers
- * pass `undefined` to the render and take the built-ins-only path.
- *
- * This mirrors the runtime flow in `wasmRenderer.ts:prepareUserGrammarsHandle`
- * but without the long-lived cache — smokeAll renders each fixture
- * once per test invocation, so loading on demand is fine.
- */
-async function buildUserGrammarsHandle(
-  files: readonly FileEntry[],
-): Promise<JsUserGrammarsHandle | undefined> {
-  const paths = files.map((f) => f.projectRelPath);
-  const descriptors = discoverUserGrammars(paths);
-  if (descriptors.length === 0) return undefined;
-
-  const byPath = new Map<string, FileEntry>();
-  for (const f of files) byPath.set(f.projectRelPath, f);
-
-  const handle = new wasm.JsUserGrammars();
-  for (const desc of descriptors) {
-    const wasmEntry = byPath.get(desc.wasmPath);
-    const scmEntry = byPath.get(desc.highlightsPath);
-    if (!wasmEntry || !scmEntry) continue;
-    if (!(wasmEntry.content instanceof Uint8Array)) continue;
-    if (typeof scmEntry.content !== 'string') continue;
-
-    const highlighter = await loadUserGrammar({
-      name: desc.class,
-      wasmBytes: wasmEntry.content,
-      highlightsScm: scmEntry.content,
-    });
-    handle.register(desc.class, (_cls, source) => highlighter.highlight(source));
-  }
-  return handle;
 }
 
 // ---------------------------------------------------------------------------
@@ -701,8 +404,8 @@ describe('smoke-all WASM tests', () => {
 
         try {
           wasm.vfs_clear();
-          const { vfsPath, projectFiles } = await populateVfs(testFile);
-          const grammarsHandle = await buildUserGrammarsHandle(projectFiles);
+          const { vfsPath, projectFiles } = await populateVfs(wasm, testFile);
+          const grammarsHandle = await buildUserGrammarsHandle(wasm, projectFiles);
           const resultJson = await wasm.render_qmd(vfsPath, grammarsHandle);
           const result: WasmRenderResult = JSON.parse(resultJson);
 

--- a/hub-client/src/services/smokeAll.wasm.test.ts
+++ b/hub-client/src/services/smokeAll.wasm.test.ts
@@ -154,6 +154,11 @@ function parseFormatSpec(format: string, value: Record<string, unknown>, options
         case 'folderExists':
           // Parse but don't check — filesystem assertions are no-ops in WASM
           break;
+        case 'dom-parity':
+          // Opt-in flag for the preview <-> render DOM parity runner
+          // (hub-client/src/services/smokeAllParity.wasm.test.tsx). Not an
+          // assertion here.
+          break;
         default:
           throw new Error(`Unknown assertion type: '${key}' in format '${format}'`);
       }

--- a/hub-client/src/services/smokeAllParity.wasm.test.tsx
+++ b/hub-client/src/services/smokeAllParity.wasm.test.tsx
@@ -1,0 +1,191 @@
+// @vitest-environment jsdom
+/**
+ * Preview <-> render DOM parity runner (fourth smoke-all runner).
+ *
+ * For every smoke-all fixture whose `_quarto.tests.html` carries
+ * `dom-parity: true`, render it twice through the same WASM module:
+ *   - `render_page_in_project`   -> native HTML writer -> full page HTML
+ *   - `render_page_for_preview`  -> the same Rust function with
+ *                                   `prefer_preview_format: true`: pipeline
+ *                                   stopped before `render-html-body`
+ *                                   -> Pandoc AST JSON
+ * Mount the AST read-only with the real q2-preview React registry under
+ * jsdom, and require the canonical form of `main#quarto-document-content`
+ * to be identical on both sides. Normalisation rules and their reasons
+ * live in `ts-packages/preview-renderer/src/test-utils/domParity.ts`.
+ *
+ * Opt-in is curated: an opted-in fixture that diverges FAILS. There is
+ * no expected-failure list — fix the divergence or remove the opt-in.
+ *
+ * Plan: claude-notes/plans/2026-08-24-preview-render-dom-parity-harness.md
+ * Manual predecessor: .claude/skills/preview-render-parity/SKILL.md
+ */
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import { readFile, mkdir, writeFile } from 'fs/promises';
+import { join, relative, resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { JSDOM } from 'jsdom';
+import { render, cleanup } from '@testing-library/react';
+import { Ast } from '@quarto/preview-renderer/framework';
+import { previewRegistry } from '@quarto/preview-renderer';
+import {
+  extractParityRoot,
+  compareParity,
+  ParityRuleViolation,
+} from '@quarto/preview-renderer/test-utils/domParity';
+import {
+  SMOKE_ALL_DIR,
+  loadSmokeWasm,
+  discoverTestFiles,
+  readFrontmatter,
+  readTestsBlock,
+  shouldSkip,
+  populateVfs,
+  buildUserGrammarsHandle,
+  type WasmModule,
+} from '../test-utils/smokeAllFixtures';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = resolve(__dirname, '../../test-results/parity');
+
+let wasm: WasmModule;
+
+beforeAll(async () => {
+  wasm = await loadSmokeWasm();
+});
+
+beforeEach(() => {
+  wasm.vfs_clear();
+  cleanup();
+});
+
+interface Sides {
+  renderMain: Element;
+  previewMain: Element;
+}
+
+/** Render one fixture both ways and return the two parity roots. */
+async function renderBothSides(testFile: string): Promise<Sides> {
+  const { vfsPath, projectFiles } = await populateVfs(wasm, testFile);
+  const grammars = await buildUserGrammarsHandle(wasm, projectFiles);
+
+  const renderRes = JSON.parse(await wasm.render_page_in_project(vfsPath, grammars)) as {
+    success: boolean; html?: string; error?: string;
+  };
+  if (!renderRes.success || !renderRes.html) {
+    throw new Error(`render_page_in_project failed: ${renderRes.error ?? 'no html'}`);
+  }
+
+  const previewRes = JSON.parse(
+    await wasm.render_page_for_preview(vfsPath, grammars, undefined),
+  ) as { success: boolean; ast_json?: string; error?: string };
+  if (!previewRes.success || !previewRes.ast_json) {
+    throw new Error(`render_page_for_preview failed: ${previewRes.error ?? 'no ast_json'}`);
+  }
+
+  const renderDoc = new JSDOM(renderRes.html).window.document;
+  // Read-only mount: no PreviewContext / AssetManifestContext /
+  // IncrementalContext on purpose (plan § Global Constraints).
+  const { container } = render(
+    <Ast
+      astJson={previewRes.ast_json}
+      currentFilePath={vfsPath}
+      onNavigateToDocument={() => {}}
+      setAst={() => {}}
+      registry={previewRegistry}
+    />,
+  );
+  return {
+    renderMain: extractParityRoot(renderDoc, 'render'),
+    previewMain: extractParityRoot(container, 'preview'),
+  };
+}
+
+async function writeArtifacts(relPath: string, renderText: string, previewText: string) {
+  const dir = join(OUT_DIR, relPath.replace(/[\\/]/g, '__'));
+  await mkdir(dir, { recursive: true });
+  await writeFile(join(dir, 'render.norm.txt'), renderText);
+  await writeFile(join(dir, 'preview.norm.txt'), previewText);
+  return dir;
+}
+
+/**
+ * Produce vitest's own diff text for two strings without throwing. Vitest
+ * doesn't expose its differ as a standalone function, so this harvests it by
+ * catching `expect` — the thrown assertion error's message is the same
+ * pretty diff the reporter prints.
+ */
+function diffText(expected: string, actual: string): string {
+  try {
+    expect(actual).toBe(expected);
+    return '';
+  } catch (e) {
+    return (e as Error).message;
+  }
+}
+
+async function optedInFixtures(): Promise<string[]> {
+  const files = await discoverTestFiles(SMOKE_ALL_DIR);
+  const out: string[] = [];
+  for (const f of files) {
+    const block = readTestsBlock(readFrontmatter(await readFile(f, 'utf-8')));
+    if (!block || shouldSkip(block.run)) continue;
+    if (block.formats['html']?.['dom-parity'] === true) out.push(f);
+  }
+  return out;
+}
+
+describe('smoke-all preview <-> render DOM parity', () => {
+  // Same single-`it` shape as smokeAll.wasm.test.ts: vitest collects tests
+  // synchronously, and discovery is async.
+  it('every opted-in fixture has identical <main> DOM on both sides', async () => {
+    const fixtures = await optedInFixtures();
+    const smokeFilter = process.env.SMOKE_FILTER || '';
+    const failures: string[] = [];
+    let compared = 0;
+
+    for (const testFile of fixtures) {
+      const relPath = relative(SMOKE_ALL_DIR, testFile);
+      if (smokeFilter && !relPath.includes(smokeFilter)) continue;
+      wasm.vfs_clear();
+      cleanup();
+      const started = performance.now();
+      try {
+        const { renderMain, previewMain } = await renderBothSides(testFile);
+        const result = compareParity(renderMain, previewMain);
+        compared++;
+        if (!result.equal) {
+          const dir = await writeArtifacts(relPath, result.render, result.preview);
+          failures.push(
+            `${relPath} [html]: parity mismatch (artifacts: ${dir})\n${diffText(result.render, result.preview)}`,
+          );
+        }
+      } catch (e) {
+        const kind = e instanceof ParityRuleViolation ? 'rule violation' : 'error';
+        failures.push(`${relPath} [html]: ${kind}: ${(e as Error).message}`);
+      }
+      console.log(`  parity ${relPath}: ${Math.round(performance.now() - started)} ms`);
+    }
+
+    console.log(`\nParity results: ${compared} compared, ${failures.length} failed, ${fixtures.length} opted in`);
+    expect(fixtures.length, 'at least one fixture must opt in (dom-parity: true)').toBeGreaterThan(0);
+    expect(failures, `${failures.length} parity failure(s):\n${failures.join('\n\n')}`).toHaveLength(0);
+  });
+
+  it('reports an injected divergence (harness self-check)', async () => {
+    const [first] = await optedInFixtures();
+    expect(first, 'needs one opted-in fixture').toBeDefined();
+    const { renderMain, previewMain } = await renderBothSides(first);
+    expect(compareParity(renderMain, previewMain).equal).toBe(true);
+
+    // Inject: add a class to the first element on the preview side.
+    const victim = previewMain.querySelector('p, h1, h2, pre, div, section');
+    expect(victim).not.toBeNull();
+    victim!.classList.add('injected-divergence');
+
+    const result = compareParity(renderMain, previewMain);
+    expect(result.equal).toBe(false);
+    expect(result.preview).toContain('injected-divergence');
+    expect(result.render).not.toContain('injected-divergence');
+  });
+});

--- a/hub-client/src/test-utils/smokeAllFixtures.ts
+++ b/hub-client/src/test-utils/smokeAllFixtures.ts
@@ -1,0 +1,363 @@
+/**
+ * Smoke-all fixture / VFS helpers shared by every `*.wasm.test.*` runner.
+ *
+ * Exercises the same smoke-all test fixtures used by the native Rust test
+ * runner (crates/quarto/tests/integration/smoke_all.rs): project-root
+ * discovery, `/project/`-prefixed VFS population, binary files, and user
+ * grammars. Kept in one place so a spike or a new runner (e.g. a
+ * preview↔render parity runner) uses the exact same fixture → VFS
+ * semantics as the existing smoke-all sweep, rather than hand-rolling VFS
+ * loading and reporting divergences the real runner never sees.
+ */
+
+import { readFile, readdir, stat } from 'fs/promises';
+import { dirname, join, relative, resolve } from 'path';
+import { fileURLToPath } from 'url';
+import { parse as parseYaml } from 'yaml';
+
+import { discoverUserGrammars } from '@quarto/preview-runtime/userGrammar/Discovery';
+import { loadUserGrammar } from '@quarto/preview-runtime/userGrammar/Highlight';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface JsUserGrammarsHandle {
+  register(
+    languageClass: string,
+    highlightFn: (class_: string, source: string) => string | null | undefined,
+  ): void;
+  free(): void;
+}
+
+export interface WasmModule {
+  default: (input?: BufferSource) => Promise<void>;
+  vfs_add_file: (path: string, content: string) => string;
+  vfs_add_binary_file: (path: string, content: Uint8Array) => string;
+  vfs_clear: () => string;
+  vfs_list_files: () => string;
+  vfs_read_file: (path: string) => string;
+  render_qmd: (path: string, user_grammars?: unknown) => Promise<string>;
+  render_page_in_project: (path: string, user_grammars?: unknown) => Promise<string>;
+  render_page_for_preview: (
+    path: string,
+    user_grammars?: unknown,
+    capture_gz_json?: Uint8Array,
+  ) => Promise<string>;
+  JsUserGrammars: new () => JsUserGrammarsHandle;
+}
+
+export interface RunConfig {
+  skip?: string | boolean;
+  ci?: boolean;
+  os?: string[];
+  not_os?: string[];
+  /**
+   * Set on fixtures whose format requires a JS runtime to render. Parsed
+   * for consistency with the Rust runner, which uses it to skip CLI runs.
+   * Not enforced here — the WASM unit test already filters by
+   * `format !== 'html'`, so q2-debug fixtures are skipped at the format
+   * gate before this matters.
+   */
+  requires_js?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+export const SMOKE_ALL_DIR = resolve(__dirname, '../../../crates/quarto/tests/smoke-all');
+
+// ---------------------------------------------------------------------------
+// WASM setup
+// ---------------------------------------------------------------------------
+
+/**
+ * Initialise the WASM module from the checked-in build and wire the
+ * dart-sass VFS callbacks. Shared by every `*.wasm.test.*` smoke-all
+ * runner; call once from `beforeAll`.
+ */
+export async function loadSmokeWasm(): Promise<WasmModule> {
+  const wasmDir = join(__dirname, '../../wasm-quarto-hub-client');
+  const wasmBytes = await readFile(join(wasmDir, 'wasm_quarto_hub_client_bg.wasm'));
+  const wasm = (await import('wasm-quarto-hub-client')) as unknown as WasmModule;
+  await wasm.default(wasmBytes);
+  const sassModule = await import('/src/wasm-js-bridge/sass.js');
+  sassModule.setVfsCallbacks(
+    (path: string): string | null => {
+      try {
+        const result = JSON.parse(wasm.vfs_read_file(path)) as { success: boolean; content?: string };
+        return result.success && result.content !== undefined ? result.content : null;
+      } catch {
+        return null;
+      }
+    },
+    (path: string): boolean => {
+      try {
+        const result = JSON.parse(wasm.vfs_read_file(path)) as { success: boolean; content?: string };
+        return result.success && result.content !== undefined;
+      } catch {
+        return false;
+      }
+    },
+  );
+  return wasm;
+}
+
+// ---------------------------------------------------------------------------
+// Discovery
+// ---------------------------------------------------------------------------
+
+/** Recursively find all .qmd files under a directory, skipping files starting with _. */
+export async function discoverTestFiles(dir: string): Promise<string[]> {
+  const results: string[] = [];
+
+  async function walk(d: string) {
+    const entries = await readdir(d, { withFileTypes: true });
+    for (const entry of entries) {
+      const full = join(d, entry.name);
+      if (entry.isDirectory()) {
+        await walk(full);
+      } else if (entry.isFile() && entry.name.endsWith('.qmd') && !entry.name.startsWith('_')) {
+        results.push(full);
+      }
+    }
+  }
+
+  await walk(dir);
+  results.sort();
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Frontmatter parsing
+// ---------------------------------------------------------------------------
+
+/** Extract and parse YAML frontmatter from QMD content. */
+export function readFrontmatter(content: string): Record<string, unknown> {
+  const trimmed = content.trimStart();
+  if (!trimmed.startsWith('---')) return {};
+
+  const rest = trimmed.slice(3);
+  const end = rest.indexOf('\n---');
+  if (end === -1) return {};
+
+  const yamlStr = rest.slice(0, end);
+  return (parseYaml(yamlStr) as Record<string, unknown>) ?? {};
+}
+
+// ---------------------------------------------------------------------------
+// Test spec parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * The `_quarto.tests` block split into its `run` config and its
+ * per-format raw mappings. Returns null when the fixture has no tests
+ * block. A format entry that is not a mapping (e.g. `html: default`) is
+ * normalised to `{}`, matching the Rust parser
+ * (crates/quarto-test/src/spec.rs `parse_format_spec`: `value.as_mapping()`
+ * optional). Runners parse the per-format mapping themselves (their
+ * assertion models differ); this keeps the *shape* of the DSL in one
+ * place.
+ */
+export function readTestsBlock(
+  metadata: Record<string, unknown>,
+): { run: RunConfig | null; formats: Record<string, Record<string, unknown>> } | null {
+  const quarto = metadata['_quarto'] as Record<string, unknown> | undefined;
+  const tests = quarto?.['tests'] as Record<string, unknown> | undefined;
+  if (!tests) return null;
+  const formats: Record<string, Record<string, unknown>> = {};
+  for (const [key, value] of Object.entries(tests)) {
+    if (key === 'run') continue;
+    formats[key] =
+      value !== null && typeof value === 'object' && !Array.isArray(value)
+        ? (value as Record<string, unknown>)
+        : {};
+  }
+  return { run: (tests['run'] as RunConfig) ?? null, formats };
+}
+
+/** Parse a two-array spec (used by ensureFileRegexMatches and ensureHtmlElements). */
+export function parseTwoArraySpec(value: unknown): { matches: string[]; noMatches: string[] } {
+  if (!Array.isArray(value)) return { matches: [], noMatches: [] };
+  const matches = Array.isArray(value[0]) ? (value[0] as string[]) : [];
+  const noMatches = value.length > 1 && Array.isArray(value[1]) ? (value[1] as string[]) : [];
+  return { matches, noMatches };
+}
+
+// ---------------------------------------------------------------------------
+// Skip logic
+// ---------------------------------------------------------------------------
+
+export function shouldSkip(runConfig: RunConfig | null): string | null {
+  if (!runConfig) return null;
+
+  if (runConfig.skip) {
+    return typeof runConfig.skip === 'string' ? runConfig.skip : 'skip: true';
+  }
+
+  if (runConfig.ci === false && (process.env.CI || process.env.GITHUB_ACTIONS)) {
+    return 'tests.run.ci is false';
+  }
+
+  // os/not_os: WASM is platform-independent, but implement for completeness
+  const currentOs = process.platform === 'darwin' ? 'darwin' : process.platform === 'win32' ? 'windows' : 'linux';
+
+  if (runConfig.os && !runConfig.os.includes(currentOs)) {
+    return `tests.run.os does not include ${currentOs}`;
+  }
+  if (runConfig.not_os && runConfig.not_os.includes(currentOs)) {
+    return `tests.run.not_os includes ${currentOs}`;
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// VFS population
+// ---------------------------------------------------------------------------
+
+/** Find the project root by walking upward from qmdDir looking for _quarto.yml. */
+export async function findProjectRoot(qmdDir: string): Promise<string> {
+  let dir = qmdDir;
+  while (dir.startsWith(SMOKE_ALL_DIR)) {
+    try {
+      await stat(join(dir, '_quarto.yml'));
+      return dir;
+    } catch {
+      const parent = dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
+    }
+  }
+  // No _quarto.yml found — use the QMD file's own directory
+  return qmdDir;
+}
+
+/**
+ * File extensions routed through `vfs_add_binary_file` rather than
+ * `vfs_add_file`. Reading these as UTF-8 corrupts their bytes (and in
+ * the `.wasm` case makes the user-grammar loader fail silently).
+ */
+const BINARY_EXTENSIONS = new Set<string>([
+  '.wasm',
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.gif',
+  '.pdf',
+  '.ico',
+  '.webp',
+  '.ttf',
+  '.woff',
+  '.woff2',
+  '.zip',
+]);
+
+function isBinaryFilename(filename: string): boolean {
+  const lower = filename.toLowerCase();
+  const dot = lower.lastIndexOf('.');
+  if (dot < 0) return false;
+  return BINARY_EXTENSIONS.has(lower.slice(dot));
+}
+
+export interface FileEntry {
+  path: string; // absolute on disk
+  projectRelPath: string; // relative to the smoke-all project root, no leading slash
+  content: string | Uint8Array;
+}
+
+/** Recursively read every file under `dir`, binary-aware. */
+export async function readAllFiles(dir: string, projectRoot: string): Promise<FileEntry[]> {
+  const files: FileEntry[] = [];
+
+  async function walk(d: string) {
+    const entries = await readdir(d, { withFileTypes: true });
+    for (const entry of entries) {
+      const full = join(d, entry.name);
+      if (entry.isDirectory()) {
+        await walk(full);
+      } else if (entry.isFile()) {
+        const content: string | Uint8Array = isBinaryFilename(entry.name)
+          ? new Uint8Array(await readFile(full))
+          : await readFile(full, 'utf-8');
+        files.push({
+          path: full,
+          projectRelPath: relative(projectRoot, full),
+          content,
+        });
+      }
+    }
+  }
+
+  await walk(dir);
+  return files;
+}
+
+/**
+ * Populate the WASM VFS with all files from the project root. Returns
+ * both the `/project/`-prefixed VFS path for the QMD being rendered,
+ * and the flat list of project-relative file paths (consumed by the
+ * user-grammar discovery step downstream).
+ */
+export async function populateVfs(
+  wasm: WasmModule,
+  qmdPath: string,
+): Promise<{ vfsPath: string; projectFiles: FileEntry[] }> {
+  const qmdDir = dirname(qmdPath);
+  const projectRoot = await findProjectRoot(qmdDir);
+
+  const files = await readAllFiles(projectRoot, projectRoot);
+  for (const file of files) {
+    const vfsPath = `/project/${file.projectRelPath}`;
+    if (typeof file.content === 'string') {
+      wasm.vfs_add_file(vfsPath, file.content);
+    } else {
+      wasm.vfs_add_binary_file(vfsPath, file.content);
+    }
+  }
+
+  const relQmd = relative(projectRoot, qmdPath);
+  return { vfsPath: `/project/${relQmd}`, projectFiles: files };
+}
+
+/**
+ * Given the project's file list, discover any user-defined tree-sitter
+ * grammars under `_quarto/grammars/<name>/`, load them, and return a
+ * `JsUserGrammars` handle ready to pass into `render_qmd`. Returns
+ * `undefined` when the project has no grammars, which lets callers
+ * pass `undefined` to the render and take the built-ins-only path.
+ *
+ * This mirrors the runtime flow in `wasmRenderer.ts:prepareUserGrammarsHandle`
+ * but without the long-lived cache — smokeAll renders each fixture
+ * once per test invocation, so loading on demand is fine.
+ */
+export async function buildUserGrammarsHandle(
+  wasm: WasmModule,
+  files: readonly FileEntry[],
+): Promise<JsUserGrammarsHandle | undefined> {
+  const paths = files.map((f) => f.projectRelPath);
+  const descriptors = discoverUserGrammars(paths);
+  if (descriptors.length === 0) return undefined;
+
+  const byPath = new Map<string, FileEntry>();
+  for (const f of files) byPath.set(f.projectRelPath, f);
+
+  const handle = new wasm.JsUserGrammars();
+  for (const desc of descriptors) {
+    const wasmEntry = byPath.get(desc.wasmPath);
+    const scmEntry = byPath.get(desc.highlightsPath);
+    if (!wasmEntry || !scmEntry) continue;
+    if (!(wasmEntry.content instanceof Uint8Array)) continue;
+    if (typeof scmEntry.content !== 'string') continue;
+
+    const highlighter = await loadUserGrammar({
+      name: desc.class,
+      wasmBytes: wasmEntry.content,
+      highlightsScm: scmEntry.content,
+    });
+    handle.register(desc.class, (_cls, source) => highlighter.highlight(source));
+  }
+  return handle;
+}

--- a/hub-client/vitest.config.ts
+++ b/hub-client/vitest.config.ts
@@ -27,7 +27,7 @@ export default mergeConfig(
       exclude: [
         'src/**/*.integration.test.ts',
         'src/**/*.integration.test.tsx',
-        'src/**/*.wasm.test.ts',
+        'src/**/*.wasm.test.{ts,tsx}',
       ],
       // Pass even when no test files are found
       passWithNoTests: true,

--- a/hub-client/vitest.wasm.config.ts
+++ b/hub-client/vitest.wasm.config.ts
@@ -13,7 +13,7 @@ export default mergeConfig(
   defineConfig({
     test: {
       // Include only WASM test files
-      include: ['src/**/*.wasm.test.ts'],
+      include: ['src/**/*.wasm.test.{ts,tsx}'],
       // Use node environment - WASM doesn't need DOM
       environment: 'node',
       // Pass even when no test files are found (initially)

--- a/ts-packages/preview-renderer/src/test-utils/domParity.test.ts
+++ b/ts-packages/preview-renderer/src/test-utils/domParity.test.ts
@@ -1,0 +1,144 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import {
+  canonicalize,
+  OPAQUE_MARKER,
+  ParityRuleViolation,
+  extractParityRoot,
+  compareParity,
+} from './domParity';
+
+function el(html: string): Element {
+  const host = document.createElement('div');
+  host.innerHTML = html;
+  return host.firstElementChild!;
+}
+
+describe('canonicalize — shape', () => {
+  it('emits one line per node, indented by depth, no closing lines', () => {
+    const out = canonicalize(el('<main id="x"><p>hi <em>there</em></p></main>'));
+    expect(out).toBe(
+      ['<main id="x">', '  <p>', '    "hi "', '    <em>', '      "there"'].join('\n'),
+    );
+  });
+
+  it('sorts attributes by name and lower-cases tag names', () => {
+    const out = canonicalize(el('<DIV title="t" class="c" id="i"></DIV>'));
+    expect(out).toBe('<div class="c" id="i" title="t">');
+  });
+
+  it('drops pretty-printing whitespace between block elements and drops comments', () => {
+    const out = canonicalize(el('<div>\n  <!-- c -->\n  <p>  a \n b  </p>\n</div>'));
+    expect(out).toBe(['<div>', '  <p>', '    "a b"'].join('\n'));
+  });
+
+  it('collapses whitespace inside class but preserves token order', () => {
+    const out = canonicalize(el('<pre class="  sourceCode   python ">x</pre>'));
+    expect(out).toBe(['<pre class="sourceCode python">', '  "x"'].join('\n'));
+  });
+
+  it('escapes quotes in attribute values so lines stay single-line', () => {
+    const out = canonicalize(el('<a title=\'say "hi"\'></a>'));
+    expect(out).toBe('<a title="say &quot;hi&quot;">');
+  });
+});
+
+describe('canonicalize — inline whitespace is significant', () => {
+  it('distinguishes <em>a</em> <em>b</em> from <em>a</em><em>b</em>', () => {
+    const spaced = canonicalize(el('<p><em>a</em> <em>b</em></p>'));
+    const tight = canonicalize(el('<p><em>a</em><em>b</em></p>'));
+    expect(spaced).not.toBe(tight);
+    expect(spaced).toBe(['<p>', '  <em>', '    "a"', '  " "', '  <em>', '    "b"'].join('\n'));
+  });
+
+  it('keeps a trailing space before an inline sibling but trims before a block sibling', () => {
+    expect(canonicalize(el('<p>hi <em>x</em></p>'))).toContain('"hi "');
+    expect(canonicalize(el('<div>hi <p>x</p></div>'))).toContain('"hi"');
+  });
+
+  it('keeps text verbatim inside <pre>', () => {
+    const out = canonicalize(el('<pre><code>x\n  y\n</code></pre>'));
+    expect(out).toBe(['<pre>', '  <code>', '    "x\\n  y\\n"'].join('\n'));
+  });
+
+  it('merges adjacent text nodes (React emits one per Str/Space)', () => {
+    const p = document.createElement('p');
+    p.appendChild(document.createTextNode('hi'));
+    p.appendChild(document.createTextNode(' '));
+    p.appendChild(document.createTextNode('there'));
+    expect(canonicalize(p)).toBe(canonicalize(el('<p>hi there</p>')));
+    expect(p.childNodes.length).toBe(3); // input not mutated
+  });
+});
+
+describe('PARITY_RULES', () => {
+  it('strips preview-only source-tracking attributes', () => {
+    const out = canonicalize(el('<p data-loc="f:1:1-1:5" data-sid="7" class="k">x</p>'));
+    expect(out).toBe(['<p class="k">', '  "x"'].join('\n'));
+  });
+
+  it('keeps id and every other data-* attribute', () => {
+    const out = canonicalize(el('<section id="intro" data-qf-ref-type="fig"></section>'));
+    expect(out).toBe('<section data-qf-ref-type="fig" id="intro">');
+  });
+
+  it('makes span.math contents opaque but keeps the span and its classes', () => {
+    const a = canonicalize(el('<span class="math inline">\\(x^2\\)</span>'));
+    const b = canonicalize(el('<span class="math inline"><span class="katex">…</span></span>'));
+    expect(a).toBe(b);
+    expect(a).toBe(['<span class="math inline">', `  ${OPAQUE_MARKER}`].join('\n'));
+  });
+
+  it('throws ParityRuleViolation when data-hl-spans leaks', () => {
+    expect(() => canonicalize(el('<pre data-hl-spans="[]"><code>x</code></pre>'))).toThrow(
+      ParityRuleViolation,
+    );
+  });
+
+  it("unwraps React's attribute-less RawBlock <div> wrapper (data-loc does not count)", () => {
+    // preview: RawBlock.tsx host element carrying only data-loc; render: the raw HTML inline.
+    const preview = canonicalize(
+      el('<main><div data-loc="f:1:1-2:1"><button class="code-copy-button">c</button></div> <p>x</p></main>'),
+    );
+    const render = canonicalize(el('<main><button class="code-copy-button">c</button>\n<p>x</p></main>'));
+    expect(preview).toBe(render);
+    expect(preview).not.toContain('<div');
+  });
+
+  it('keeps a <div> that has any surviving attribute, and unwraps nested bare divs', () => {
+    expect(canonicalize(el('<div class="k"><p>x</p></div>'))).toBe(['<div class="k">', '  <p>', '    "x"'].join('\n'));
+    expect(canonicalize(el('<main><div><div><p>x</p></div></div></main>'))).toBe(
+      canonicalize(el('<main><p>x</p></main>')),
+    );
+  });
+});
+
+describe('extractParityRoot / compareParity', () => {
+  it('finds main#quarto-document-content and names the side on failure', () => {
+    const host = document.createElement('div');
+    host.innerHTML =
+      '<div id="quarto-content"><main class="content" id="quarto-document-content"><p>x</p></main></div>';
+    expect(extractParityRoot(host, 'render').tagName).toBe('MAIN');
+    const empty = document.createElement('div');
+    expect(() => extractParityRoot(empty, 'preview')).toThrow(/preview.*main#quarto-document-content/);
+  });
+
+  it('reports equal for identical subtrees modulo rules', () => {
+    const r = compareParity(
+      el('<main id="quarto-document-content" class="content"><p>a</p></main>'),
+      el('<main class="content" id="quarto-document-content"><p data-loc="x">a</p></main>'),
+    );
+    expect(r.equal).toBe(true);
+    expect(r.render).toBe(r.preview);
+  });
+
+  it('reports unequal and exposes both canonical texts for a class divergence', () => {
+    const r = compareParity(
+      el('<main id="quarto-document-content"><pre class="sourceCode python"><code>x</code></pre></main>'),
+      el('<main id="quarto-document-content"><pre class="python"><code>x</code></pre></main>'),
+    );
+    expect(r.equal).toBe(false);
+    expect(r.render).toContain('class="sourceCode python"');
+    expect(r.preview).toContain('class="python"');
+  });
+});

--- a/ts-packages/preview-renderer/src/test-utils/domParity.test.ts
+++ b/ts-packages/preview-renderer/src/test-utils/domParity.test.ts
@@ -69,6 +69,15 @@ describe('canonicalize — inline whitespace is significant', () => {
     expect(canonicalize(p)).toBe(canonicalize(el('<p>hi there</p>')));
     expect(p.childNodes.length).toBe(3); // input not mutated
   });
+
+  it('treats label/input (task items) and button/svg (code-copy scaffold) as inline neighbours', () => {
+    // <label><input …/> text</label> is how the writer renders task items (html.rs ~L1347).
+    const spaced = canonicalize(el('<li><label><input type="checkbox"> Do it</label></li>'));
+    const tight = canonicalize(el('<li><label><input type="checkbox">Do it</label></li>'));
+    expect(spaced).not.toBe(tight);
+    expect(spaced).toContain('" Do it"');
+    expect(canonicalize(el('<p>x <button>c</button></p>'))).toContain('"x "');
+  });
 });
 
 describe('PARITY_RULES', () => {

--- a/ts-packages/preview-renderer/src/test-utils/domParity.ts
+++ b/ts-packages/preview-renderer/src/test-utils/domParity.ts
@@ -92,17 +92,27 @@ export const PARITY_RULES: ParityRules = {
  * Elements whose adjacency to a text node makes that text node's edge
  * whitespace significant. Whitespace next to anything else (block
  * elements, or nothing) is the writer's pretty-printing and is dropped.
+ *
+ * `button`, `input`, `label`, `svg` are listed even though they aren't
+ * classically "inline" HTML: `label`/`input` are how the writer renders
+ * task items (`<label><input type="checkbox">…</label>`,
+ * crates/pampa/src/writers/html.rs ~L1347), and `button`/`svg` are the
+ * code-copy scaffold — both sit directly next to significant text.
  */
 export const INLINE_TAGS: ReadonlySet<string> = new Set([
-  'a', 'abbr', 'b', 'br', 'cite', 'code', 'del', 'em', 'i', 'img', 'ins',
-  'kbd', 'mark', 'q', 's', 'samp', 'small', 'span', 'strong', 'sub', 'sup',
-  'time', 'u', 'var',
+  'a', 'abbr', 'b', 'br', 'button', 'cite', 'code', 'del', 'em', 'i', 'img',
+  'input', 'ins', 'kbd', 'label', 'mark', 'q', 's', 'samp', 'small', 'span',
+  'strong', 'sub', 'sup', 'svg', 'time', 'u', 'var',
 ]);
 
 const ELEMENT_NODE = 1;
 const TEXT_NODE = 3;
 
 function escapeAttr(value: string): string {
+  // Newline → space keeps the canonical form one-line-per-node (a literal
+  // newline in an attribute value would break the line-oriented diff);
+  // attribute newlines are not semantic in HTML, so this is lossless for
+  // comparison purposes.
   return value.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/\n/g, ' ');
 }
 

--- a/ts-packages/preview-renderer/src/test-utils/domParity.ts
+++ b/ts-packages/preview-renderer/src/test-utils/domParity.ts
@@ -1,0 +1,229 @@
+/**
+ * DOM canonicalisation for preview ↔ render parity.
+ *
+ * Plan: claude-notes/plans/2026-08-24-preview-render-dom-parity-harness.md
+ *
+ * Converts an Element subtree to a line-oriented canonical text so two
+ * independently-produced DOMs (the native HTML writer's, parsed by
+ * jsdom; the React renderer's, mounted by testing-library) can be
+ * compared with a plain string diff. Every normalisation applied here
+ * is listed in the plan's § Normalisation table with its reason; do not
+ * add a rule without one.
+ *
+ * Test-only: this directory is excluded from the package build, and
+ * hub-client reaches it through vitest's `@quarto/preview-renderer`
+ * source alias, not the package exports map.
+ */
+
+export interface ParityRules {
+  /** Attribute names removed from every element before comparison. */
+  stripAttrs: ReadonlySet<string>;
+  /** Attribute names whose presence on either side is an error. */
+  forbidAttrs: ReadonlySet<string>;
+  /**
+   * CSS selectors whose matching elements keep their tag + attributes
+   * but have their children replaced by a single OPAQUE_MARKER line.
+   */
+  opaqueSelectors: readonly string[];
+  /**
+   * Tag names whose elements are replaced by their children when no
+   * attribute survives `stripAttrs`. Applied on the clone before text
+   * nodes are merged, so the unwrapped children take part in the
+   * whitespace pass as siblings of the wrapper's neighbours.
+   */
+  unwrapTags: ReadonlySet<string>;
+}
+
+export const OPAQUE_MARKER = '⟨opaque⟩';
+
+/** Thrown when a forbidden attribute is found (see PARITY_RULES.forbidAttrs). */
+export class ParityRuleViolation extends Error {}
+
+export const PARITY_RULES: ParityRules = {
+  stripAttrs: new Set<string>([
+    // Source tracking: emitted only when `include_source_locations` is on
+    // (crates/pampa/src/writers/html.rs, `data-sid`/`data-loc` doc block
+    // ~L743-748). Off for `q2 render`; on for the preview AST
+    // (`PreviewAstOutput.ast_json` is written with
+    // `include_inline_locations: true`, crates/quarto-core/src/pipeline.rs
+    // ~L195) and forwarded by React via `dataLocProps`. Preview-only by
+    // construction.
+    //
+    // NOT listed: `data-block-pool-id` (React edit chrome). The parity
+    // runner mounts read-only (no PreviewContext), so it is never emitted;
+    // add it here only if the mount configuration changes.
+    'data-loc',
+    'data-sid',
+  ]),
+  forbidAttrs: new Set<string>([
+    // Consumed by both writers — `write_code_container_attr`
+    // (crates/pampa/src/writers/html.rs ~L539) and
+    // q2-preview/blocks/CodeBlock.tsx decode it into <span class="hl-…">
+    // markup and must NOT forward it. Leakage is a bug (bd-nxslt), so the
+    // harness errors instead of normalising it away.
+    'data-hl-spans',
+  ]),
+  opaqueSelectors: [
+    // `math-js` is excluded from the preview pipeline
+    // (Q2_PREVIEW_STAGE_EXCLUDED, crates/quarto-core/src/pipeline.rs ~L394):
+    // render leaves TeX in \( \) delimiters for MathJax; React
+    // (q2-preview/inlines/Math.tsx) emits KaTeX HTML. Divergent by design.
+    // The <span> itself and its `math inline|display` classes still
+    // compare — which is why bd-tmb2u5yu (Math.tsx emits no class) must
+    // close before any fixture containing math can opt in.
+    'span.math',
+  ],
+  unwrapTags: new Set<string>([
+    // React cannot inject raw HTML without a host element:
+    // q2-preview/blocks/RawBlock.tsx wraps every RawBlock(format:"html")
+    // in a <div dangerouslySetInnerHTML> (carrying only data-loc) that the
+    // native writer (crates/pampa/src/writers/html.rs, Block::RawBlock)
+    // never emits — most visibly the code-copy button. Symmetric on
+    // purpose: a Div block with an empty Attr is a bare <div> on BOTH
+    // sides, so a preview-only unwrap would false-positive. Accepted
+    // cost: a missing/extra bare <div> is invisible to the runner. Found
+    // by the Task 0.2 spike
+    // (claude-notes/research/2026-08-24-preview-render-parity-spike.md).
+    'div',
+  ]),
+};
+
+/**
+ * Elements whose adjacency to a text node makes that text node's edge
+ * whitespace significant. Whitespace next to anything else (block
+ * elements, or nothing) is the writer's pretty-printing and is dropped.
+ */
+export const INLINE_TAGS: ReadonlySet<string> = new Set([
+  'a', 'abbr', 'b', 'br', 'cite', 'code', 'del', 'em', 'i', 'img', 'ins',
+  'kbd', 'mark', 'q', 's', 'samp', 'small', 'span', 'strong', 'sub', 'sup',
+  'time', 'u', 'var',
+]);
+
+const ELEMENT_NODE = 1;
+const TEXT_NODE = 3;
+
+function escapeAttr(value: string): string {
+  return value.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/\n/g, ' ');
+}
+
+function isInlineNeighbor(n: Node | null): boolean {
+  if (!n) return false;
+  if (n.nodeType === TEXT_NODE) return (n.textContent ?? '').trim().length > 0;
+  if (n.nodeType === ELEMENT_NODE) return INLINE_TAGS.has((n as Element).tagName.toLowerCase());
+  return false;
+}
+
+/** Whitespace-normalised text outside <pre>; '' means "drop this node". */
+function normalizeText(node: Node): string {
+  let s = (node.textContent ?? '').replace(/\s+/g, ' ');
+  if (!isInlineNeighbor(node.previousSibling)) s = s.replace(/^ /, '');
+  if (!isInlineNeighbor(node.nextSibling)) s = s.replace(/ $/, '');
+  return s;
+}
+
+function openTagLine(el: Element, rules: ParityRules): string {
+  const attrs: Array<{ name: string; line: string }> = [];
+  for (const { name, value } of Array.from(el.attributes)) {
+    if (rules.forbidAttrs.has(name)) {
+      throw new ParityRuleViolation(
+        `forbidden attribute '${name}' on <${el.tagName.toLowerCase()}> — see PARITY_RULES.forbidAttrs`,
+      );
+    }
+    if (rules.stripAttrs.has(name)) continue;
+    const v = name === 'class' ? value.replace(/\s+/g, ' ').trim() : value;
+    attrs.push({ name, line: `${name}="${escapeAttr(v)}"` });
+  }
+  attrs.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+  const tag = el.tagName.toLowerCase();
+  return attrs.length ? `<${tag} ${attrs.map((a) => a.line).join(' ')}>` : `<${tag}>`;
+}
+
+function walk(node: Node, depth: number, rules: ParityRules, out: string[], inPre: boolean): void {
+  const pad = '  '.repeat(depth);
+  if (node.nodeType === TEXT_NODE) {
+    const text = inPre ? (node.textContent ?? '') : normalizeText(node);
+    if (text) out.push(pad + JSON.stringify(text));
+    return;
+  }
+  if (node.nodeType !== ELEMENT_NODE) return; // comments, processing instructions
+  const el = node as Element;
+  out.push(pad + openTagLine(el, rules));
+  if (rules.opaqueSelectors.some((sel) => el.matches(sel))) {
+    out.push(`${'  '.repeat(depth + 1)}${OPAQUE_MARKER}`);
+    return;
+  }
+  const childInPre = inPre || el.tagName.toLowerCase() === 'pre';
+  for (const child of Array.from(el.childNodes)) walk(child, depth + 1, rules, out, childInPre);
+}
+
+/** True when every attribute on `el` is in `rules.stripAttrs`. */
+function hasNoSurvivingAttrs(el: Element, rules: ParityRules): boolean {
+  return Array.from(el.attributes).every((a) => rules.stripAttrs.has(a.name));
+}
+
+/**
+ * Replace every `rules.unwrapTags` element that has no surviving
+ * attributes by its children (document order, so nested wrappers unwrap
+ * too). Mutates `root`, which must be the private clone.
+ */
+function unwrapBareElements(root: Element, rules: ParityRules): void {
+  for (const tag of rules.unwrapTags) {
+    for (const el of Array.from(root.querySelectorAll(tag))) {
+      if (hasNoSurvivingAttrs(el, rules)) el.replaceWith(...Array.from(el.childNodes));
+    }
+  }
+}
+
+/**
+ * Canonical, line-oriented rendering of `el` and its subtree. Works on a
+ * clone so the caller's DOM is untouched. Order on the clone: unwrap bare
+ * wrapper elements (rules.unwrapTags, judged after the strip list) →
+ * merge adjacent text nodes with `normalize()` (React emits one text
+ * node per Str/Space) → walk (strip/forbid/sort attributes, opaque
+ * subtrees, whitespace).
+ */
+export function canonicalize(el: Element, rules: ParityRules = PARITY_RULES): string {
+  const clone = el.cloneNode(true) as Element;
+  unwrapBareElements(clone, rules);
+  clone.normalize();
+  const out: string[] = [];
+  walk(clone, 0, rules, out, false);
+  return out.join('\n');
+}
+
+/** The subtree both pipelines are contractually required to agree on. */
+export const PARITY_ROOT_SELECTOR = 'main#quarto-document-content';
+
+/**
+ * Locate the parity root inside a document / container. `label` names
+ * the side ("render" / "preview") so a missing root is attributable.
+ */
+export function extractParityRoot(scope: ParentNode, label: string): Element {
+  const root = scope.querySelector(PARITY_ROOT_SELECTOR);
+  if (!root) {
+    throw new Error(`${label}: no element matches ${PARITY_ROOT_SELECTOR}`);
+  }
+  return root;
+}
+
+export interface ParityResult {
+  equal: boolean;
+  /** Canonical text of the render side. */
+  render: string;
+  /** Canonical text of the preview side. */
+  preview: string;
+}
+
+/**
+ * Canonicalise both roots and compare. Never throws for a mismatch; does
+ * throw (ParityRuleViolation) on a forbidden attribute.
+ */
+export function compareParity(
+  renderRoot: Element,
+  previewRoot: Element,
+  rules: ParityRules = PARITY_RULES,
+): ParityResult {
+  const render = canonicalize(renderRoot, rules);
+  const preview = canonicalize(previewRoot, rules);
+  return { equal: render === preview, render, preview };
+}


### PR DESCRIPTION
`q2 preview` renders documents with a React component tree that mirrors the native HTML writer arm-for-arm, and until now the only thing keeping the two in sync was someone noticing in Chrome. This adds a test that asserts it: for opted-in smoke-all fixtures, the article body `q2 render` produces and the article body the preview renders must be the same DOM.

## What it does

A fourth smoke-all runner, `hub-client/src/services/smokeAllParity.wasm.test.tsx`, renders each opted-in fixture twice through the same WASM module — `render_page_in_project` (native writer → full HTML) and `render_page_for_preview` (the same function with `prefer_preview_format`, stopping before `render-html-body` → Pandoc AST) — mounts the AST read-only with the real `<Ast registry={previewRegistry}>` under jsdom, and compares the canonical form of `main#quarto-document-content` from both sides. Because both paths go through `render_page_in_project_with_attribution` → `ProjectContext::discover`, every difference the runner reports is in `html.rs`/template vs React by construction; project fixtures (`appendix/`, `metadata/*`) exercise the project branch on both sides.

Canonicalisation lives in `ts-packages/preview-renderer/src/test-utils/domParity.ts` (test-only; never in `dist/`, reached from hub-client via vitest's source alias). Every normalisation has a reason in a comment:

- strip `data-loc`/`data-sid` (preview-only source tracking);
- children of `span.math` are opaque (`math-js` is excluded from the preview pipeline, React uses KaTeX) — the span and its classes still compare;
- **fail** if `data-hl-spans` appears on either side (it's a consumed attribute; leaking it is the bd-nxslt bug class);
- sort attributes, keep class *order*, keep `id` and every other `data-*`;
- text verbatim inside `<pre>`, collapsed elsewhere with an inline-neighbour edge rule so `<em>a</em> <em>b</em>` ≠ `<em>a</em><em>b</em>`;
- unwrap a `<div>` with no attribute surviving the strip list, on both sides — React can't inject raw HTML without a host element, and `Div` blocks with empty attrs are bare divs on both sides.

Opt-in is `dom-parity: true` under `html:` in a fixture's `_quarto: tests:` block. The Rust parser records it (`TestSpec.dom_parity`), the WASM and Playwright parsers ignore it, so all four runners share one grammar. There is deliberately **no xfail list**: an opted-in fixture that diverges fails the suite — fix it or don't opt it in. On a mismatch you get vitest's diff plus `render.norm.txt`/`preview.norm.txt` under `hub-client/test-results/parity/`.

## State of the corpus

105 of 164 fixtures are opted in and pass byte-identically. The runner adds ~16 s to `npm run test:wasm` and runs inside the existing hub-client CI step; no new workflow.

Of the rest: 18 diverge for real, 29 can't be reached because their tests key is `q2-preview` or an extension format rather than `html`, and a handful are intentional errors/skips or use the minimal template (no `<main>`). The divergences are filed under epic **bd-j3764r9a** — Link dropping `role=`, `<ol>` without `type="1"`, `<s>` vs `<del>`, Math without its classes, crossref floats, localized callout/theorem strings, callout attributes, inline `<code>` leaking `data-hl-spans`, and a few more. Each fix should end by opting in the fixture that reproduced it. Full survey, mismatch→strand map and harness limits: `claude-notes/research/2026-08-24-preview-render-parity-survey.md`.

## Also in here

- `hub-client/src/test-utils/smokeAllFixtures.ts`: the existing WASM smoke-all runner's fixture discovery / VFS / grammar-handle / WASM-loading code, extracted so both runners share the same fixture→VFS semantics (its pass/skip counts are unchanged).
- `hub-client/vitest.config.ts` now excludes `*.wasm.test.{ts,tsx}` from the default unit-test run, not just `.ts` — the `.tsx` runner had been collected by plain `npm run test` too, which the 105-fixture sweep turned into a 5 s timeout.
- Docs: `claude-notes/instructions/testing.md` (runner 4 + DSL key) and `.claude/skills/preview-render-parity/SKILL.md` (reproduce with the harness before reaching for Chrome).

Not covered, on purpose: revealjs (bd-qn8yi1su), tabsets (no React implementation), math *content*, anything outside `<main>` — the navbar/sidebar/footer are the same Rust HTML strings on both sides; only their placement is hand-mirrored, and a body-rooted comparison is a possible follow-up.

## Try it

```
cd hub-client && SMOKE_FILTER=simple-default npm run test:wasm -- --reporter=verbose
  parity title-block/simple-default.qmd: 627 ms
  Parity results: 1 compared, 0 failed, 105 opted in
```

`cargo nextest run --workspace`: 13217 passed / 199 skipped (+2 vs main: the two DSL tests). `cargo xtask verify` green.
