### PR TITLE
Bump version to 0.27.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "comrak-to-pandoc"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "comrak",
  "hashlink",
@@ -4806,7 +4806,7 @@ dependencies = [
 
 [[package]]
 name = "quarto"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4854,7 +4854,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-analysis"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "insta",
  "quarto-error-reporting",
@@ -4880,7 +4880,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-brand"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "pathdiff",
  "quarto-util",
@@ -4892,7 +4892,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-citeproc"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "glob",
  "hashlink",
@@ -4926,7 +4926,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-core"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4984,7 +4984,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-csl"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "insta",
  "quarto-error-reporting",
@@ -5012,7 +5012,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-error-catalog"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "once_cell",
  "quarto-error-reporting",
@@ -5048,7 +5048,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-highlight"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "hashlink",
  "insta",
@@ -5077,7 +5077,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-highlight-encoding"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -5085,7 +5085,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-hub"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "automerge",
@@ -5129,7 +5129,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-hub-provider"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "automerge",
  "ciborium",
@@ -5155,7 +5155,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-lsp"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "insta",
@@ -5171,7 +5171,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-lsp-core"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "insta",
  "pampa",
@@ -5194,7 +5194,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-mcp-launcher"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -5210,7 +5210,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-navigation"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "quarto-config",
  "quarto-pandoc-types",
@@ -5220,7 +5220,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-p2p"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "axum",
  "futures",
@@ -5263,7 +5263,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-preview"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "automerge",
@@ -5301,7 +5301,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-project-create"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "quarto-doctemplate",
  "serde",
@@ -5312,7 +5312,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-publish"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5337,7 +5337,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-sass"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "grass",
  "include_dir",
@@ -5360,7 +5360,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-source-fetch"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "flate2",
  "tar",
@@ -5383,7 +5383,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-system-runtime"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5401,7 +5401,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-test"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "quarto-core",
@@ -5418,7 +5418,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-trace"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "flate2",
  "serde",
@@ -5429,7 +5429,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-trace-server"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -5456,7 +5456,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-util"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "dirs",
  "serde",
@@ -5465,7 +5465,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-xml"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "insta",
  "quarto-error-reporting",
@@ -5703,7 +5703,7 @@ dependencies = [
 
 [[package]]
 name = "reconcile-viewer"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "clap",
  "hashlink",
@@ -6710,7 +6710,7 @@ checksum = "ea06cc588e43c632923a55450401b8f25e628131571d4e1baea1bdfdb2b5ed06"
 
 [[package]]
 name = "spa-manifest"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -7959,7 +7959,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-printf-fmt"
-version = "0.26.0"
+version = "0.27.0"
 
 [[package]]
 name = "wasm-streams"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.26.0"
+version = "0.27.0"
 authors = ["Posit Software, PBC"]
 homepage = "https://github.com/posit-dev/quarto-markdown-syntax"
 keywords = ["parser"]

--- a/crates/wasm-quarto-hub-client/Cargo.lock
+++ b/crates/wasm-quarto-hub-client/Cargo.lock
@@ -377,7 +377,7 @@ dependencies = [
 
 [[package]]
 name = "comrak-to-pandoc"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "comrak",
  "hashlink",
@@ -2075,7 +2075,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-analysis"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "quarto-error-reporting",
  "quarto-pandoc-types",
@@ -2097,7 +2097,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-brand"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "pathdiff",
  "quarto-util",
@@ -2108,7 +2108,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-citeproc"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "glob",
  "hashlink",
@@ -2139,7 +2139,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-core"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2191,7 +2191,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-csl"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "quarto-error-reporting",
  "quarto-source-map",
@@ -2242,7 +2242,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-highlight"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "once_cell",
  "quarto-highlight-encoding",
@@ -2268,7 +2268,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-highlight-encoding"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2276,7 +2276,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-lsp-core"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "pampa",
  "pollster",
@@ -2297,7 +2297,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-navigation"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "quarto-config",
  "quarto-pandoc-types",
@@ -2332,7 +2332,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-project-create"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "quarto-doctemplate",
  "serde",
@@ -2342,7 +2342,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-sass"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "include_dir",
  "once_cell",
@@ -2373,7 +2373,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-system-runtime"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -2390,7 +2390,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-trace"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "flate2",
  "serde",
@@ -2408,7 +2408,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-util"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "dirs",
  "serde",
@@ -2417,7 +2417,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-xml"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "quarto-error-reporting",
  "quarto-source-map",
@@ -4024,7 +4024,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-printf-fmt"
-version = "0.26.0"
+version = "0.27.0"
 
 [[package]]
 name = "wasm-quarto-hub-client"


### PR DESCRIPTION
Version bump for the v0.27.0 release, per `claude-notes/instructions/release-runbook.md` step 2.

- `[workspace.package].version` 0.26.0 → 0.27.0
- `cargo update --workspace` on both lockfiles (root + `crates/wasm-quarto-hub-client/Cargo.lock`); diff is exactly the 48 workspace-member version lines, no external bumps
- `cargo build --bin q2 --locked` → `q2 (quarto 2) 0.27.0`

Will be tagged `v0.27.0` once merged.