### PR TITLE
Unblock the v0.27.0 release: docs embed on a fresh checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,6 +202,9 @@ jobs:
       # `q2` that renders the docs anyway. `build-agents-docs` builds a
       # host `q2` itself (via `cargo run --bin q2`); a debug binary is
       # fine, it only has to render.
+      # The xtask also stages `docs/examples/` (a gitignored resource the
+      # docs declare) first — on this fresh checkout nothing else does,
+      # and `q2 render docs` fails hard without it (v0.27.0 attempt 1).
       - name: Stage docs embed (q2 docs llms)
         run: cargo xtask build-agents-docs
 

--- a/claude-notes/instructions/release-runbook.md
+++ b/claude-notes/instructions/release-runbook.md
@@ -293,6 +293,26 @@ still matches.
   and `install.sh` parse `${output##* }`. `q2 --version` prints
   `q2 (quarto 2) X.Y.Z`; anything appended to that string must keep the
   version last (guarded by `crates/quarto/tests/integration/version_cli.rs`).
+- **The docs embed needs `docs/examples/` staged, and only the xtask does it.**
+  `docs/_quarto.yml` declares the gitignored `docs/examples/` tree (output of
+  `cargo xtask stage-doc-examples`) as a project resource, and `q2 render`
+  fails hard on a missing declared resource. A dev checkout usually has the
+  tree lying around from some earlier run, so `cargo xtask build-agents-docs`
+  passes locally and nobody notices; the release runner is a fresh clone. The
+  first v0.27.0 run (32809606624) died in `web-payloads` on exactly this —
+  the docs-embed step was new in that release (bd-hwop1zii landed after
+  v0.26.0) and had never run on a clean checkout. `build-agents-docs` now
+  stages the examples itself before rendering; if you ever move that render
+  elsewhere, carry the staging with it. To reproduce the fresh-clone
+  condition locally: `mv docs/examples /tmp/` and rerun the xtask.
+  The same run then exposed a second fresh-machine assumption: the docs
+  render must not need an *optional runtime*. `docs/guides/authoring/figures.qmd`
+  shows cells with Quarto 1's ```` ```{{python}} ```` escape, and the engine
+  resolver was treating those as real `{python}` cells — fine on a laptop
+  with Jupyter, a hard "runtime is not available" error on the runner
+  (bd-3tq5u8vm, fixed in `engine_cell_lang`). If the docs render ever
+  fails only on CI, check the runner for a runtime it lacks before
+  installing one: the docs should render with nothing but `q2`.
 - **Pin the embedded TS-extension-build jsr specifiers before shipping.**
   `resources/extension-build/deno.json` (the shipped tier-4 config `q2
   build-ts-extension` embeds via `include_str!` for installed binaries —

--- a/crates/quarto-core/src/engine/capture_splice.rs
+++ b/crates/quarto-core/src/engine/capture_splice.rs
@@ -75,7 +75,12 @@ use quarto_pandoc_types::{Block, Blocks, CodeBlock, Div, Pandoc};
 /// braces are preserved by the pampa parser into the CodeBlock's
 /// class list, which is what we match against. Plain language tags
 /// (` ```r `) — used for syntax highlighting only — don't have the
-/// braces and aren't matched.
+/// braces and aren't matched. Neither is a *doubled*-brace opener
+/// (` ```{{python}} `, Quarto 1's "show, don't run" escape): pampa keeps
+/// that class verbatim, warns Q-2-50, and the block is documented to
+/// render as literal code (bd-escaped-executable-fence-uuvv37pk) — so
+/// it must not resolve to an engine either, or a page that merely
+/// *shows* a cell demands a Jupyter runtime (bd-3tq5u8vm).
 ///
 /// Returns the language token (without braces) when matched.
 pub fn engine_cell_lang(block: &Block) -> Option<&str> {
@@ -84,6 +89,10 @@ pub fn engine_cell_lang(block: &Block) -> Option<&str> {
     };
     for class in attr.1.iter() {
         if let Some(stripped) = class.strip_prefix('{').and_then(|s| s.strip_suffix('}')) {
+            // `{{lang}}` strips to `{lang}` — still braced, so not a cell.
+            if stripped.contains(['{', '}']) {
+                continue;
+            }
             return Some(stripped);
         }
     }
@@ -1051,6 +1060,26 @@ mod tests {
         let block = Block::CodeBlock(CodeBlock {
             attr,
             text: "x <- 1".to_string(),
+            source_info: SourceInfo::for_test(),
+            attr_source: AttrSourceInfo::empty(),
+        });
+        assert_eq!(engine_cell_lang(&block), None);
+    }
+
+    #[test]
+    fn doubled_brace_display_fence_is_not_an_engine_cell() {
+        // ```{{python}} — Quarto 1's display escape — reaches us with the
+        // class `{{python}}` intact (pampa warns Q-2-50 and renders it as
+        // literal code). Stripping one brace layer must not turn it into
+        // an engine cell for `{python}` (bd-3tq5u8vm).
+        let attr = (
+            String::new(),
+            vec!["{{python}}".to_string()],
+            LinkedHashMap::new(),
+        );
+        let block = Block::CodeBlock(CodeBlock {
+            attr,
+            text: "import matplotlib.pyplot as plt".to_string(),
             source_info: SourceInfo::for_test(),
             attr_source: AttrSourceInfo::empty(),
         });

--- a/crates/quarto-core/src/engine/resolution.rs
+++ b/crates/quarto-core/src/engine/resolution.rs
@@ -3559,4 +3559,39 @@ mod tests {
         )]);
         assert_same(&tabled_meta, &python_ast, &tabled_registry, None);
     }
+
+    /// A doubled-brace fence (Quarto 1's "display, don't run" escape) is
+    /// NOT an engine cell in Q2: pampa keeps the class as `{{python}}`, warns
+    /// Q-2-50, and the block renders as literal code
+    /// (bd-escaped-executable-fence-uuvv37pk). The resolver must agree, or a
+    /// docs page that merely *shows* a cell drags jupyter into the sequence
+    /// and fails hard wherever Jupyter is absent (bd-3tq5u8vm).
+    #[test]
+    fn test_doubled_brace_display_fence_is_not_computational() {
+        let registry = mock_registry(vec![mock_knitr(), mock_jupyter()]);
+        let display_cell = Block::CodeBlock(CodeBlock {
+            attr: (
+                String::new(),
+                vec!["{{python}}".to_string()],
+                LinkedHashMap::new(),
+            ),
+            text: "#| label: fig-line-plot\nimport matplotlib.pyplot as plt".to_string(),
+            source_info: si(),
+            attr_source: AttrSourceInfo::empty(),
+        });
+        let ast = ast_with_blocks(vec![display_cell]);
+        let meta = empty_meta();
+
+        let res = resolve_engines(&meta, &ast, &registry, None);
+
+        assert!(
+            res.sequence.is_empty(),
+            "a {{{{python}}}} display fence must resolve to no engines; got {:?}",
+            res.sequence
+                .iter()
+                .map(|e| e.name.as_str())
+                .collect::<Vec<_>>()
+        );
+        assert!(res.ownership.is_empty(), "got {:?}", res.ownership);
+    }
 }

--- a/crates/xtask/src/build_agents_docs.rs
+++ b/crates/xtask/src/build_agents_docs.rs
@@ -3,15 +3,20 @@
 //!
 //! Steps:
 //!
-//! 1. Render `docs/` in place with `q2` (via `cargo run --bin q2`),
+//! 1. Stage the embedded example projects into `docs/examples/` (the
+//!    `stage-doc-examples` xtask). `docs/_quarto.yml` declares that
+//!    gitignored tree as a project resource and `q2 render` fails hard on
+//!    a missing declared resource, so on a fresh checkout (the release
+//!    workflow) the docs render cannot even start without this.
+//! 2. Render `docs/` in place with `q2` (via `cargo run --bin q2`),
 //!    exactly like CI's docs build. The render's llms-txt pass writes
 //!    `docs/_site/llms.txt`, `docs/_site/llms-full.txt`, one `.md`
 //!    companion per page, and the ledger
 //!    `docs/.quarto/llms-manifest.json`.
-//! 2. Copy the ledger-listed artifacts (and only those — a
+//! 3. Copy the ledger-listed artifacts (and only those — a
 //!    user-authored resource `.md` in `_site/` is not ours to embed)
 //!    into a fresh `agents-docs-dist/` at the workspace root.
-//! 3. Write `agents-docs-dist/embed-info.json` recording the staging
+//! 4. Write `agents-docs-dist/embed-info.json` recording the staging
 //!    checkout's git commit + dirty flag, for `q2 docs llms
 //!    --embed-info`.
 //!
@@ -35,6 +40,17 @@ pub fn run() -> Result<()> {
     // status` would report a clean checkout as dirty. What we want to
     // record is the state of the sources the docs were built from.
     let info = embed_info(&root)?;
+
+    // `docs/_quarto.yml` declares the gitignored `docs/examples/` tree as
+    // a project resource, and `q2 render` refuses to run when a declared
+    // resource is missing. Stage it first so this works on a fresh
+    // checkout (the release workflow's `web-payloads` job), not only on a
+    // dev machine that happened to run `stage-doc-examples` at some point.
+    // Ordered after `embed_info` on purpose: staging renders the example
+    // projects in place, which would otherwise make the provenance read
+    // as dirty.
+    println!("━━━ Staging docs/examples/ (embedded example projects) ━━━");
+    crate::stage_doc_examples::run()?;
 
     println!("━━━ Rendering docs/ (llms.txt artifacts) ━━━");
     render_docs(&root)?;


### PR DESCRIPTION
The first v0.27.0 release run ([32809606624](https://github.com/quarto-dev/q2/actions/runs/32809606624)) failed in `web-payloads` at **Stage docs embed (q2 docs llms)** — the docs-embed step is new since v0.26.0 (bd-hwop1zii) and had never rendered `docs/` on a fresh checkout. Two fresh-machine assumptions surfaced, one per commit:

1. **`docs/examples/` was never staged.** `docs/_quarto.yml` declares that gitignored tree as a project resource and `q2 render` fails hard when it is missing. `cargo xtask build-agents-docs` now runs `stage-doc-examples` first (after capturing provenance). Runbook gotcha added; release.yml comment updated.
2. **The docs render demanded Jupyter** (bd-3tq5u8vm). `docs/guides/authoring/figures.qmd` shows cells with Quarto 1's ``````{{python}}``` escape, which Q2 deliberately treats as literal code (Q-2-50) — but `engine_cell_lang` stripped one brace layer and the resolver put jupyter in the sequence, so a Jupyter-less machine got *"Engine 'jupyter' is registered but its runtime is not available"*. `engine_cell_lang` now rejects doubled braces. TDD: unit test + resolver test, both red before the fix.

**End-to-end** (this machine has no `jupyter`): removed `docs/examples/` and `agents-docs-dist/`, ran `cargo xtask build-agents-docs` → exit 0, `Rendered 265 of 265 files — 36 warnings`, 267 artifacts staged, `guides/authoring/figures.md` present. A single-file `{{python}}` fixture now renders with only the Q-2-50 warning.

**Tests:** `cargo clippy -p quarto-core -p xtask --all-targets -- -D warnings` clean; `cargo nextest run --workspace` → 13368 passed, 199 skipped (+2 new tests).

After merge: re-tag `v0.27.0` on the new main HEAD (runbook §5).