### PR TITLE
lua: require/current-path contract — resolve_path parity (#588), require in filters (#587), script-dir stack hygiene

### DIFF
--- a/claude-notes/plans/2026-08-24-lua-require-current-path.md
+++ b/claude-notes/plans/2026-08-24-lua-require-current-path.md
@@ -74,26 +74,31 @@ Implementation:
 
 Tests first:
 
-- [ ] Smoke-all fixture `extensions/contract-filter-require/` mirroring
+- [x] Smoke-all fixture `extensions/contract-filter-require/` mirroring
       mcanouil's #587 repro: extension contributes a Lua *filter* whose
       top-level script does `require("_modules/greet")`. Verify it fails
-      today with the stock-Lua "module not found" error.
-- [ ] Same fixture (or a sibling) also exercises the absolute form
+      today with the stock-Lua "module not found" error. *(Verified failing:
+      `[C]: in function 'require'` at fr.lua:7 before the fix.)*
+- [x] Same fixture (or a sibling) also exercises the absolute form
       extensions use: `require(quarto.utils.resolve_path("_modules/greet.lua"):gsub("%.lua$", ""))`.
       (The scoped require handles this by accident of `PathBuf::join`
       semantics with a rooted argument — pin it with a test so it stays.)
-- [ ] Fixture asserts resolve_path parity *inside the filter-required
+      *(`fr-abs=OK` row; asserts on module contents, not table identity,
+      to stay robust to key-format differences across platforms.)*
+- [x] Fixture asserts resolve_path parity *inside the filter-required
       module* too — the #588 contract must hold on the filter path, not
-      just the shortcode path.
+      just the shortcode path. *(`fr-resolve=OK` row.)*
 
 Implementation:
 
-- [ ] Call `register_scoped_require(&lua, runtime.clone())` in
+- [x] Call `register_scoped_require(&lua, runtime.clone())` in
       `create_filter_environment` (`filter.rs`) — the runtime `Arc` is
       already a parameter. On native, the captured original `require`
       remains the fallback (filters get the full stdlib); on WASM there is
       no `package` lib, matching the shortcode state today.
-- [ ] Note (doc-only, acceptable divergence): filter states are per-filter,
+      *(`create_filter_environment` is the single filter-state constructor;
+      `apply_lua_filter` reaches it at filter.rs:256.)*
+- [x] Note (doc-only, acceptable divergence): filter states are per-filter,
       so the require cache is per-filter-state; Q1's single emulated state
       shares one module cache. No action, record it in the research doc.
 

--- a/claude-notes/plans/2026-08-24-lua-require-current-path.md
+++ b/claude-notes/plans/2026-08-24-lua-require-current-path.md
@@ -106,18 +106,25 @@ Implementation:
 
 Tests first:
 
-- [ ] Unit test (shortcode.rs tests): load two shortcode scripts into one
+- [x] Unit test (shortcode.rs tests): load two shortcode scripts into one
       registry; assert the script-dir stack depth returns to its baseline
       after each load (fails today — one leaked entry per script).
+      *(Two tests, both verified failing before the fix:
+      `test_load_script_restores_script_dir_stack` and
+      `..._on_error` for the eval-error exit path.)*
 
 Implementation:
 
-- [ ] Pop the load-time push in `load_script` after script evaluation —
+- [x] Pop the load-time push in `load_script` after script evaluation —
       on **all** exit paths (the current code has `?`-early-returns between
       push and end; use a guard or restructure so the pop always runs).
       Handler registration bookkeeping (`handler_script_dirs`) is
       unaffected; call-time push/pop already covers handler execution.
-- [ ] Write the contract statement (Overview above) as the header comment
+      *(Added `ScriptDirGuard` / `push_script_dir_scoped` (RAII, owns a
+      cloned `Lua` handle) in quarto_api.rs; `load_script` holds the guard
+      for the whole load, and the call-time push/pop in `call` was
+      converted to the same guard for panic-safety.)*
+- [x] Write the contract statement (Overview above) as the header comment
       of the script-dir-stack section in `quarto_api.rs`; point
       `dofile_wasm.rs`'s header at it instead of restating it.
 

--- a/claude-notes/plans/2026-08-24-lua-require-current-path.md
+++ b/claude-notes/plans/2026-08-24-lua-require-current-path.md
@@ -130,19 +130,43 @@ Implementation:
 
 ## Phase 4 — verification and wrap-up
 
-- [ ] WASM smoke coverage per `.claude/rules/wasm.md`: add a
+- [x] WASM smoke coverage per `.claude/rules/wasm.md`: add a
       `crates/pampa/tests/wasm_lua.rs` case exercising require-then-
       resolve_path under the `/project/` VFS prefix (shortcode and filter
       environments both instantiate the scoped require there).
-- [ ] `cargo build --workspace` && `cargo nextest run --workspace`.
-- [ ] Full `cargo xtask verify` (pampa is in wasm-quarto-hub-client's
+      *(`scoped_require_and_resolve_path_wasm`; ran locally on the real
+      wasm32-unknown-unknown target — needs homebrew LLVM clang, Apple
+      clang rejects `-fwasm-exceptions` — 8 passed, 0 failed.)*
+- [x] `cargo build --workspace` && `cargo nextest run --workspace`.
+      *(Green at every phase boundary; final counts 13258 passed.)*
+- [x] Full `cargo xtask verify` (pampa is in wasm-quarto-hub-client's
       closure — the hub/WASM leg is affected; `--skip-hub-build` is not
-      enough for the final gate).
-- [ ] End-to-end per repo policy: `cargo run --bin q2 -- render` on the two
+      enough for the final gate). *(Passed clean 2026-08-24. First run
+      failed on preview-renderer's KaTeX `.katex-tag` assertion — stale
+      local node_modules (katex 0.17 installed vs 0.18.1 in the lockfile),
+      pure-TS test, unrelated to this branch; fixed by `npm install` from
+      the repo root. Incidental lockfile `peer:` churn reverted.)*
+- [x] End-to-end per repo policy: `cargo run --bin q2 -- render` on the two
       new fixtures; inspect the emitted HTML; record invocation + output
-      snippet here.
-- [ ] Close bd-sr0nipl7, bd-9uqdoy0e, bd-9xa0yui7 with reasons; comment on
-      GH #587/#588 (Carlos posts or approves wording).
+      snippet here. *(Verified 2026-08-24, output inspected:*
+
+      ```
+      $ cargo run --bin q2 -- render crates/quarto/tests/smoke-all/extensions/contract-resolve-path/test.qmd
+      $ grep -o "rp-top=[^<]*" .../contract-resolve-path/test.html
+      rp-top=OK;rp-require=SAME;rp-dofile=SAME
+
+      $ cargo run --bin q2 -- render crates/quarto/tests/smoke-all/extensions/contract-filter-require/test.qmd
+      $ grep -o "fr-require=[^<]*" .../contract-filter-require/test.html
+      fr-require=OK;fr-abs=OK;fr-resolve=OK
+      ```
+
+      *All three #588 rows agree through the real render path, and the
+      #587 filter loads its module via both require forms.)*
+- [x] Strand bookkeeping: bd-sr0nipl7, bd-9uqdoy0e, bd-9xa0yui7 moved to
+      `in_review` (close at PR merge, matching repo practice — e.g.
+      bd-8b0af414). GH #587/#588 comment wording drafted for Carlos in the
+      session summary; posting awaits his approval, as does pushing the
+      branch / opening the PR.
 
 ## Design decisions already settled
 

--- a/claude-notes/plans/2026-08-24-lua-require-current-path.md
+++ b/claude-notes/plans/2026-08-24-lua-require-current-path.md
@@ -1,0 +1,136 @@
+# Lua require + "current path" contract: GH #587, GH #588, shortcode stack leak
+
+**Strands:**
+- bd-sr0nipl7 — GH #588: `resolve_path` returns module dir inside a required file (primary)
+- bd-9uqdoy0e — GH #587: `require` unavailable in Lua filters (blocked-by bd-sr0nipl7)
+- bd-9xa0yui7 — shortcode load-time `push_script_dir` never popped
+
+**Design/assessment doc:** `claude-notes/research/2026-08-24-lua-current-path-gh588.md`
+(read it first — it holds the full Q1/Q2 mechanism inventory and the rationale
+for the chosen approach).
+
+## Overview
+
+All three bugs live in the same subsystem — pampa's Lua script-dir machinery
+(`crates/pampa/src/lua/{quarto_api.rs,filter.rs,shortcode.rs,dofile_wasm.rs}`)
+— and are fixed under one contract, so they ship as one coherent PR:
+
+> The script-dir stack moves only at top-level script boundaries: filter
+> script load, shortcode script load, and shortcode handler invocation.
+> Loaders — `require`, `dofile`, `loadfile` — never move it. A loader that
+> needs the location of the file it is currently executing tracks that
+> privately.
+
+Chosen approach (avenue A of the research doc, confirmed with Carlos):
+**split the stacks.** `_quarto_script_dir_stack` becomes the exact analogue
+of Q1's `scriptFile` stack; `register_scoped_require` gets a private
+module-dir stack that only its own candidate walk consults (module stack
+top-down, then script stack top-down — byte-identical search order to today,
+so #450's shipped require behavior is unchanged).
+
+Phase order matters: #588 first, so that when #587 installs the scoped
+require into filter environments, filters get the *corrected* require and
+never inherit the resolve_path breakage.
+
+## Phase 1 — GH #588: split the stacks (bd-sr0nipl7)
+
+Tests first:
+
+- [ ] Unit test (quarto_api.rs tests): a module loaded via the scoped
+      require calls `quarto.utils.resolve_path("_modules/x.lua")` at module
+      load time; assert it resolves against the *extension root* (script
+      stack top), not the module's dir. Run, verify it fails with the
+      doubled `_modules/_modules/` segment.
+- [ ] Unit test: nested-require candidate order is preserved — a module can
+      still require a sibling by bare name (today's #450 behavior). Should
+      pass before AND after (regression guard).
+- [ ] Smoke-all fixture `extensions/contract-resolve-path/` mirroring
+      mcanouil's #588 repro: shortcode extension whose top-level script
+      computes `top` / `via_require` / `via_dofile` (the issue's three-row
+      table) and emits them; `ensureFileRegexMatches` asserts all three are
+      the same root-resolved path. Verify it fails.
+
+Implementation:
+
+- [ ] In `register_scoped_require`: push/pop the module's dir on a **private**
+      stack (registry-held table or Rust-side state in the closure), not on
+      `_quarto_script_dir_stack`. Candidate walk = private stack top-down,
+      then script-dir stack top-down, deduped — same effective order as
+      today. Keep the existing pop-before-`?` discipline on the error path.
+- [ ] All Phase-1 tests pass; existing `contract-require` fixture and the
+      #450 contract corpus (`crates/quarto/tests/smoke-all/extensions/contract-*`)
+      stay green.
+
+## Phase 2 — GH #587: scoped require in filter environments (bd-9uqdoy0e)
+
+Tests first:
+
+- [ ] Smoke-all fixture `extensions/contract-filter-require/` mirroring
+      mcanouil's #587 repro: extension contributes a Lua *filter* whose
+      top-level script does `require("_modules/greet")`. Verify it fails
+      today with the stock-Lua "module not found" error.
+- [ ] Same fixture (or a sibling) also exercises the absolute form
+      extensions use: `require(quarto.utils.resolve_path("_modules/greet.lua"):gsub("%.lua$", ""))`.
+      (The scoped require handles this by accident of `PathBuf::join`
+      semantics with a rooted argument — pin it with a test so it stays.)
+- [ ] Fixture asserts resolve_path parity *inside the filter-required
+      module* too — the #588 contract must hold on the filter path, not
+      just the shortcode path.
+
+Implementation:
+
+- [ ] Call `register_scoped_require(&lua, runtime.clone())` in
+      `create_filter_environment` (`filter.rs`) — the runtime `Arc` is
+      already a parameter. On native, the captured original `require`
+      remains the fallback (filters get the full stdlib); on WASM there is
+      no `package` lib, matching the shortcode state today.
+- [ ] Note (doc-only, acceptable divergence): filter states are per-filter,
+      so the require cache is per-filter-state; Q1's single emulated state
+      shares one module cache. No action, record it in the research doc.
+
+## Phase 3 — shortcode load-push leak + contract comment (bd-9xa0yui7)
+
+Tests first:
+
+- [ ] Unit test (shortcode.rs tests): load two shortcode scripts into one
+      registry; assert the script-dir stack depth returns to its baseline
+      after each load (fails today — one leaked entry per script).
+
+Implementation:
+
+- [ ] Pop the load-time push in `load_script` after script evaluation —
+      on **all** exit paths (the current code has `?`-early-returns between
+      push and end; use a guard or restructure so the pop always runs).
+      Handler registration bookkeeping (`handler_script_dirs`) is
+      unaffected; call-time push/pop already covers handler execution.
+- [ ] Write the contract statement (Overview above) as the header comment
+      of the script-dir-stack section in `quarto_api.rs`; point
+      `dofile_wasm.rs`'s header at it instead of restating it.
+
+## Phase 4 — verification and wrap-up
+
+- [ ] WASM smoke coverage per `.claude/rules/wasm.md`: add a
+      `crates/pampa/tests/wasm_lua.rs` case exercising require-then-
+      resolve_path under the `/project/` VFS prefix (shortcode and filter
+      environments both instantiate the scoped require there).
+- [ ] `cargo build --workspace` && `cargo nextest run --workspace`.
+- [ ] Full `cargo xtask verify` (pampa is in wasm-quarto-hub-client's
+      closure — the hub/WASM leg is affected; `--skip-hub-build` is not
+      enough for the final gate).
+- [ ] End-to-end per repo policy: `cargo run --bin q2 -- render` on the two
+      new fixtures; inspect the emitted HTML; record invocation + output
+      snippet here.
+- [ ] Close bd-sr0nipl7, bd-9uqdoy0e, bd-9xa0yui7 with reasons; comment on
+      GH #587/#588 (Carlos posts or approves wording).
+
+## Design decisions already settled
+
+- Avenue A (split stacks) over Q1-literal (B) and tagged entries (C) —
+  rationale in the research doc; confirmed by Carlos 2026-08-24.
+- Keep Q2's bare-name sibling require (superset of Q1) and module-first
+  candidate order; document the theoretical shadowing divergence
+  (`<root>/util.lua` vs `<root>/_modules/util.lua`) rather than chase it.
+- Q2 innermost-first vs Q1 outermost-first multi-script search order:
+  document, don't chase.
+- No `debug`-lib dependency anywhere (unavailable on WASM); all
+  calling-file tracking is Rust-side.

--- a/claude-notes/plans/2026-08-24-lua-require-current-path.md
+++ b/claude-notes/plans/2026-08-24-lua-require-current-path.md
@@ -36,30 +36,39 @@ never inherit the resolve_path breakage.
 
 Tests first:
 
-- [ ] Unit test (quarto_api.rs tests): a module loaded via the scoped
+- [x] Unit test (quarto_api.rs tests): a module loaded via the scoped
       require calls `quarto.utils.resolve_path("_modules/x.lua")` at module
       load time; assert it resolves against the *extension root* (script
       stack top), not the module's dir. Run, verify it fails with the
-      doubled `_modules/_modules/` segment.
-- [ ] Unit test: nested-require candidate order is preserved — a module can
+      doubled `_modules/_modules/` segment. *(Verified failing with exactly
+      the doubled segment before the fix:
+      `test_resolve_path_inside_required_module_uses_script_root`.)*
+- [x] Unit test: nested-require candidate order is preserved — a module can
       still require a sibling by bare name (today's #450 behavior). Should
-      pass before AND after (regression guard).
-- [ ] Smoke-all fixture `extensions/contract-resolve-path/` mirroring
+      pass before AND after (regression guard). *(Two guards:
+      `test_require_bare_sibling_name_from_nested_module`,
+      `test_require_root_relative_name_from_nested_module`, plus
+      `test_script_dir_stack_unchanged_across_require`.)*
+- [x] Smoke-all fixture `extensions/contract-resolve-path/` mirroring
       mcanouil's #588 repro: shortcode extension whose top-level script
       computes `top` / `via_require` / `via_dofile` (the issue's three-row
       table) and emits them; `ensureFileRegexMatches` asserts all three are
-      the same root-resolved path. Verify it fails.
+      the same root-resolved path. Verify it fails. *(Verified failing:
+      `rp-require=DIFF` before the fix, dofile row SAME as expected.)*
 
 Implementation:
 
-- [ ] In `register_scoped_require`: push/pop the module's dir on a **private**
+- [x] In `register_scoped_require`: push/pop the module's dir on a **private**
       stack (registry-held table or Rust-side state in the closure), not on
       `_quarto_script_dir_stack`. Candidate walk = private stack top-down,
       then script-dir stack top-down, deduped — same effective order as
       today. Keep the existing pop-before-`?` discipline on the error path.
-- [ ] All Phase-1 tests pass; existing `contract-require` fixture and the
+      *(Implemented as a named-registry-value table,
+      `REQUIRE_DIR_STACK_KEY` — invisible to user Lua code.)*
+- [x] All Phase-1 tests pass; existing `contract-require` fixture and the
       #450 contract corpus (`crates/quarto/tests/smoke-all/extensions/contract-*`)
-      stay green.
+      stay green. *(Full pampa suite 4600 passed; SMOKE_FILTER=contract all
+      green.)*
 
 ## Phase 2 — GH #587: scoped require in filter environments (bd-9uqdoy0e)
 

--- a/claude-notes/research/2026-08-24-lua-current-path-gh588.md
+++ b/claude-notes/research/2026-08-24-lua-current-path-gh588.md
@@ -243,6 +243,20 @@ strictly messier (every consumer needs to know about the tag, and the
 structure). Mentioned only because it is the smallest diff; A is the smallest
 *honest* diff.
 
+### Retained divergences (recorded during implementation, 2026-08-24)
+
+- **Per-filter require cache.** Q2 creates one Lua state per filter script,
+  so each filter has its own module cache; Q1's single emulated state shares
+  one cache across all wrapped filters. A module required by two different
+  filters loads twice in Q2 (two instances of its module table). Acceptable:
+  module-level mutable state shared *across* filters was never a supported
+  contract, and shortcodes (one shared state) match Q1 already.
+- **Bare-name sibling require** from a nested module keeps working in Q2
+  (superset of Q1), and the module-first candidate order means a name
+  colliding between `<root>/` and `<root>/_modules/` resolves to the module's
+  sibling in Q2 vs the root file in Q1. Both retained deliberately; see
+  avenue A discussion.
+
 ### Cross-cutting work, same contract
 
 1. **#587 (require missing in filters):** install `register_scoped_require`

--- a/claude-notes/research/2026-08-24-lua-current-path-gh588.md
+++ b/claude-notes/research/2026-08-24-lua-current-path-gh588.md
@@ -1,0 +1,293 @@
+# Lua "current path": Q1's mechanism, Q2's divergence, and design avenues (GH #588)
+
+**Strand:** bd-sr0nipl7
+**Issue:** https://github.com/quarto-dev/q2/issues/588 (`resolve_path` returns a
+different directory inside a loaded file)
+**Sibling issue:** https://github.com/quarto-dev/q2/issues/587 (`require`
+unavailable in Lua filters) — same subsystem, and any fix here should be
+designed with #587's fix in mind.
+
+## The bug, in one paragraph
+
+`quarto.utils.resolve_path("_modules/greet.lua")` called from an extension's
+top-level script returns `<ext-root>/_modules/greet.lua` in both engines. The
+same call made at load time *inside* a file the script `require`d returns
+`<ext-root>/_modules/_modules/greet.lua` in Q2 — the module's own directory
+leaked into "current path". Quarto 1 returns the extension root from both call
+sites. Nothing errors; the wrong path surfaces later, elsewhere. The `dofile`
+path in Q2 is already correct (contract settled in #112); `require` broke it
+because `register_scoped_require` (added by #450, commit `6ff4221e`) pushes the
+loaded module's directory onto the *same* stack `resolve_path` reads.
+
+## How Quarto 1 represents "current path"
+
+All references are to `external-sources/quarto-cli` at the checkout in this
+repo. The machinery lives in `src/resources/pandoc/datadir/init.lua` plus two
+filter-infra files.
+
+Q1 has **three distinct layers**, and the key to its behavior is that they are
+*separate*:
+
+### 1. Process cwd (ground truth fallback)
+
+Pandoc runs with the OS working directory set for the render.
+`resolvePath` (`init.lua:313`) joins a still-relative path onto
+`pandoc.system.get_working_directory()` as the last step. This is a real OS
+cwd; nothing in Lua mutates it during filter execution.
+
+### 2. `PANDOC_SCRIPT_FILE` (per-state constant, shadowed per extension)
+
+Pandoc sets `PANDOC_SCRIPT_FILE` once per Lua state to the filter script it
+loaded (for Q1's single emulated state, that is quarto's own `main.lua`).
+Extension scripts are loaded into a sandbox env whose `PANDOC_SCRIPT_FILE` is
+the extension script (`wrapped-filter.lua:48`), but `init.lua`'s own machinery
+reads the state-global one — it serves only as the *bottom fallback* of
+`scriptDir()`.
+
+### 3. The `scriptFile` stack (the actual "current script" notion)
+
+`init.lua:167-186`:
+
+```lua
+local scriptFile = {}                     -- stack of file paths
+local function scriptDir()
+   if #scriptFile > 0 then
+      return pandoc.path.directory(scriptFile[#scriptFile])
+   else
+      return pandoc.path.directory(PANDOC_SCRIPT_FILE)   -- fallback
+   end
+end
+```
+
+`_quarto.withScriptFile(file, callback)` (`init.lua:776`) push/pops around a
+callback. **The complete inventory of push sites** — every one is a
+*top-level-script boundary*, never a module load:
+
+| Push site | Event |
+| --- | --- |
+| `wrapped-filter.lua:157` (`makeWrappedLuaFilter`) | extension filter script **load** |
+| `ast/runemulation.lua:98` | each **filter pass** whose filter carries a `scriptFile` |
+| `quarto-pre/shortcodes-handlers.lua:70` | shortcode script **load** |
+| `customnodes/shortcodes.lua:417` | shortcode handler **call** |
+
+`require` and `dofile` **never touch the stack**. That is the invariant #588
+asks Q2 to honor: *"current path" = the extension's top-level script
+directory, stable across module loads.*
+
+### Consumers of `scriptDir()` in Q1
+
+- `quarto.utils.resolve_path` = `resolvePathExt` (`init.lua:322`):
+  relative → `join(scriptDir(), path)`, then cwd-join if somehow still
+  relative.
+- All `quarto.doc.add_html_dependency`/`attach_to_dependency`/
+  `add_format_resource`-style path normalization (`init.lua:898-934`).
+
+### Q1's `require` patch — calling-file resolution WITHOUT stack movement
+
+`init.lua:259-305`. Two cases:
+
+1. **`./`-relative modname** (`require("./sibling")`): resolved against the
+   *calling chunk's* file, obtained via `debug.getinfo(2, "S").source` — Lua
+   debug introspection, not mutable state. Falls back to `scriptDir()`, then
+   cwd. Re-enters `require` with the fully-qualified path so caching keys are
+   canonical.
+2. **Bare modname** (`require("_modules/greet")`): temporarily appends every
+   dir in `scriptDirs()` (the `PANDOC_SCRIPT_FILE` dir plus each stack entry,
+   **bottom-up** — outermost first) to `package.path`, calls the original
+   `require`, restores `package.path`.
+
+Plus an `absolute_searcher` (`init.lua:212`) so `require("/abs/path/mod")`
+works via `dofile`.
+
+Note what this design achieves: the "which file is executing right now"
+question is answered *inside `require` itself, at call time, via
+introspection* — it never leaks into the shared "current script" state that
+`resolve_path` reads. Q1 therefore has **two notions** that Q2 currently
+conflates:
+
+- **script root** — mutable stack, moves at script boundaries only;
+- **calling file** — derived on demand from `debug.getinfo`, no state.
+
+## How Q2 represents "current path"
+
+One stack per Lua state: `_quarto_script_dir_stack`
+(`crates/pampa/src/lua/quarto_api.rs:179-335`), holding *directory strings*
+(Q1 holds file paths and derives dirs).
+
+**Pushers:**
+
+| Site | Event | Popped? |
+| --- | --- | --- |
+| `filter.rs:181` | filter script load (fresh Lua state per filter) | never (state dies with the filter) |
+| `shortcode.rs:165` | shortcode script load (shared state, one push per extension script) | **never — leaks** (see below) |
+| `shortcode.rs:249/255` | shortcode handler call | yes |
+| `quarto_api.rs:265/271` (`register_scoped_require`) | **required module execution** | yes |
+
+The first three mirror Q1's inventory (Q2 has no per-pass filter push because
+each filter owns its state; the load-time push is still in effect at call
+time — equivalent outcome). The fourth is the divergence: Q1 has no analogue.
+
+**Consumers of `current_script_dir` (stack top):**
+
+| Consumer | Q1 analogue |
+| --- | --- |
+| `quarto.utils.resolve_path` (`quarto_api.rs:490-511`) | `resolvePathExt` |
+| `quarto.doc` dependency path resolution (`quarto_doc.rs:137`) | `init.lua:898-934` |
+| WASM `dofile`/`loadfile` relative resolution (`dofile_wasm.rs:39`) | native cwd semantics |
+| the scoped `require`'s candidate walk (`quarto_api.rs:222-240`) | Q1 `scriptDirs()` in `package.path` |
+
+The scoped `require` (only installed in the **shortcode** state,
+`shortcode.rs:117` — filters lack it entirely, which is #587) resolves a
+modname by walking the stack **top-down** (innermost first; Q1 searches
+outermost first — a second, minor divergence), trying `<dir>/<name>.lua`,
+dot-to-slash, and `<dir>/<name>/init.lua`; executes the module sandboxed
+**with the module's own dir pushed**, "so nested requires resolve relative to
+the module"; caches by resolved absolute path.
+
+### Why the push exists, and what it actually buys
+
+#450's intent: a loaded module can `require` a sibling **by bare name**
+(`require("greet")` from inside `_modules/probe.lua`). Q1 does *not* support
+that — in Q1 a nested module must write `require("_modules/greet")`
+(root-relative, since `scriptDirs()` only contains script dirs) or
+`require("./greet")` (calling-file-relative via `debug.getinfo`). So the push
+gives Q2 a *superset* of Q1's require behavior — paid for by breaking the
+`resolve_path` invariant, because the "calling file" notion was implemented by
+mutating the "script root" state.
+
+### The shortcode load-time push leak (discovered)
+
+`shortcode.rs:165` pushes at script load and never pops, so the shared
+shortcode state accumulates one stack entry per loaded extension script.
+Masked in practice by the call-time push/pop, but it means "stack bottom"
+isn't a meaningful fallback, and any future consumer walking the whole stack
+(as `require` does) sees stale dirs from unrelated extensions. Worth fixing
+alongside, or at least deciding deliberately. Filed as a discovered strand
+from bd-sr0nipl7.
+
+## WASM constraints on any design
+
+This is where Q2 genuinely cannot copy Q1:
+
+1. **No process cwd.** In the browser/VFS world there is no OS working
+   directory; "absolute" means a rooted VFS path under `/project/`. Q1's
+   final cwd-join fallback has no equivalent; Q2's existing answer (return
+   the path unchanged when the stack is empty, treat rooted paths as final —
+   `quarto_util::is_rooted`, bd-picv) is the right shape. Any design must be
+   expressible purely as explicit state + rooted-path checks.
+2. **No `debug` stdlib on WASM.** The restricted lib set is
+   `COROUTINE | TABLE | STRING | UTF8 | MATH` (`filter.rs:145`,
+   `shortcode.rs:94`). Q1's `debug.getinfo(2).source` trick for
+   calling-file-relative requires is unavailable; a "calling file" notion
+   must be tracked on the Rust side (which is fine — Q2's `require` is a Rust
+   closure and already knows exactly which file it is executing).
+3. **All file access goes through `SystemRuntime`** — the scoped require and
+   `dofile_wasm` already do this, so candidate probing works identically on
+   native and VFS. Any fix stays inside this abstraction.
+4. **One shared Lua state for all shortcode extensions** (unlike Q1-pandoc's
+   state-per-filter for top-level filters, and unlike Q2 filters). The stack
+   discipline is what isolates extensions from each other; sloppy pushes are
+   cross-extension contamination, not just wrong paths.
+
+None of these block Q1-compatible *observable* behavior. The stack-of-dirs
+design is already the WASM-compatible replacement for "current directory";
+the bug is only about *which events* move it.
+
+## Design avenues
+
+### A. Split the two notions into two stacks (recommended)
+
+Keep `_quarto_script_dir_stack` as the exact analogue of Q1's `scriptFile`
+stack: pushed **only** at top-level script boundaries (filter load, shortcode
+load, shortcode call). Give `require` a private module-dir stack (Lua registry
+table or Rust-side state in the closure) that only `require` itself consults:
+
+- `require` push/pops the *module* stack around module execution;
+- candidate walk = module stack top-down, then script stack top-down —
+  **byte-for-byte the same candidate order as today**, since today's module
+  pushes sit on top of the same stack;
+- `resolve_path`, `quarto.doc` deps, and WASM `dofile`/`loadfile` read only
+  the script stack.
+
+Outcome: all three rows of #588's table return `<ext-root>/_modules/greet.lua`;
+`require` behavior is completely unchanged (no risk to #450's shipped corpus);
+the #112 `dofile` contract generalizes to `require`. Small, local to
+`quarto_api.rs`.
+
+One knowingly-retained superset: bare-name sibling require from a nested
+module keeps working (Q1 would error). And one knowingly-retained shadowing
+divergence: if `<root>/util.lua` and `<root>/_modules/util.lua` both exist,
+a `require("util")` from inside `_modules/probe.lua` loads the `_modules` one
+in Q2 (module dir searched first) and the root one in Q1. If we care, search
+the script stack first and the module stack as fallback — that maximizes Q1
+agreement at the cost of changing current Q2 resolution order. Recommendation:
+keep current order (module-first) unless a real extension surfaces the
+shadowing case; document the divergence.
+
+### B. Q1-literal: no module-dir state at all
+
+Remove the push entirely; support `./`-relative requires by tracking the
+currently-executing chunk on the Rust side (the `require` closure knows the
+file it is loading — no `debug` lib needed); bare names search script dirs
+only. This is maximal compatibility — including *failing* where Q1 fails
+(bare sibling name from a nested module) — but it is strictly less capable
+than A, would break any extension that started relying on #450's behavior,
+and buys nothing #588 asks for. Not recommended; noted for completeness.
+
+### C. Tag stack entries and skip them in `current_script_dir`
+
+Keep one stack but mark require-pushed entries so `resolve_path` (and the
+other non-require consumers) skip them. Observationally identical to A;
+strictly messier (every consumer needs to know about the tag, and the
+"one stack, two meanings" confusion that caused the bug survives in the data
+structure). Mentioned only because it is the smallest diff; A is the smallest
+*honest* diff.
+
+### Cross-cutting work, same contract
+
+1. **#587 (require missing in filters):** install `register_scoped_require`
+   in `create_filter_environment` (`filter.rs`) — the runtime handle is
+   already in scope. Doing #588 first (or together) matters: if #587 lands on
+   today's require, filters inherit the same `resolve_path` breakage.
+2. **Shortcode load-push leak** (`shortcode.rs:165`): pop after script
+   evaluation. Load-time `resolve_path`/`require` still see the loading
+   script's dir; call-time is covered by the existing call push. This makes
+   the script stack's invariant crisp: *at rest, the stack holds exactly the
+   scripts currently executing.*
+3. **Search-order divergence** (Q2 innermost-first vs Q1 outermost-first when
+   multiple script dirs are on the stack): only observable with nested
+   shortcode invocation across extensions with colliding module names.
+   Document; don't chase.
+
+## Proposed contract statement
+
+Generalizing the #112 `dofile` decision (recorded in `dofile_wasm.rs:1-14`):
+
+> The script-dir stack moves only at top-level script boundaries: filter
+> script load, shortcode script load, and shortcode handler invocation.
+> **Loaders — `require`, `dofile`, `loadfile` — never move it.** A loader
+> that needs the location of the file it is currently executing tracks that
+> privately; it must not publish it through the script-dir stack, because
+> `quarto.utils.resolve_path`, `quarto.doc` dependency resolution, and WASM
+> `dofile` all define "current path" as *the innermost running script's
+> directory*, exactly as Quarto 1's `scriptFile` stack does.
+
+This should land as the header comment of the script-dir-stack section in
+`quarto_api.rs` (and `dofile_wasm.rs`'s header can point at it).
+
+## Test plan sketch (TDD, per repo policy)
+
+1. **Unit (fails first):** in `quarto_api.rs` tests — module loaded via the
+   scoped require calls `resolve_path("_modules/greet.lua")` at load time;
+   assert extension root, not doubled segment. Model on
+   `test_script_dir_stack_resolve_path_uses_top`.
+2. **The three-row table from #588 as an end-to-end fixture:** a smoke-all
+   extension mirroring mcanouil's repro (`top`/`via_require`/`via_dofile`
+   emitted into the document); assert all three equal. This pins the contract
+   through the real `q2 render` path per the end-to-end verification policy.
+3. **`require`-preservation tests:** existing #450 contract corpus must stay
+   green (bare sibling require from nested module still resolves).
+4. **WASM smoke:** the scoped require is shared native/WASM via
+   `SystemRuntime`, and `.claude/rules/wasm.md` requires `wasm_lua.rs`
+   coverage when this area moves — add a case exercising require-then-
+   resolve_path under the VFS `/project/` prefix.

--- a/crates/pampa/src/lua/dofile_wasm.rs
+++ b/crates/pampa/src/lua/dofile_wasm.rs
@@ -8,9 +8,10 @@
  * Rust implementations backed by SystemRuntime.
  *
  * These overrides handle file I/O only. They do NOT modify the script-dir
- * stack — path resolution during execution uses whatever script dir was
- * set by the caller (filter.rs or shortcode.rs), matching native Lua and
- * Pandoc/TS Quarto behavior.
+ * stack — loaders never do; see THE CONTRACT in the script-dir-stack
+ * section of quarto_api.rs (#112, GH #588). Path resolution during
+ * execution uses whatever script dir was set by the caller (filter.rs or
+ * shortcode.rs), matching native Lua and Pandoc/TS Quarto behavior.
  */
 
 use std::path::Path;

--- a/crates/pampa/src/lua/filter.rs
+++ b/crates/pampa/src/lua/filter.rs
@@ -158,10 +158,16 @@ pub fn create_filter_environment(
     let mediabag = create_shared_mediabag();
 
     // Register pandoc namespace with constructors (also registers quarto namespace)
-    register_pandoc_namespace(&lua, runtime, mediabag)?;
+    register_pandoc_namespace(&lua, runtime.clone(), mediabag)?;
 
     // Register quarto.json, quarto.log, quarto.utils
     register_quarto_api(&lua)?;
+
+    // Script-dir-aware `require` so filter scripts can load sibling modules
+    // (Q1 parity, GH #587) — same loader the shortcode environment installs.
+    // On native the stock `require` remains the fallback for anything not
+    // found relative to the script dirs.
+    super::quarto_api::register_scoped_require(&lua, runtime.clone())?;
 
     // Register quarto.attribution.{lookup, lookup_range, identities}.
     // When `attribution` is `None`, registers no-op stubs:

--- a/crates/pampa/src/lua/quarto_api.rs
+++ b/crates/pampa/src/lua/quarto_api.rs
@@ -184,18 +184,31 @@ pub fn init_script_dir_stack(lua: &Lua) -> Result<()> {
     Ok(())
 }
 
+/// Registry key for the require-private module-dir stack: the directories
+/// of the modules currently being loaded by the scoped `require`, innermost
+/// last. Lives in the Lua registry (not globals) because it is an
+/// implementation detail of `require`'s candidate search — per the
+/// script-dir contract (see the section comment above), loaders must not
+/// publish the location of the file they are executing through the
+/// script-dir stack that `resolve_path` and friends read (GH #588).
+const REQUIRE_DIR_STACK_KEY: &str = "quarto_require_dir_stack";
+
 /// Replace the global `require` with a script-dir-aware loader.
 ///
 /// Q1 extensions `require` sibling modules relative to the requiring
 /// script's directory (TS Quarto patches `require` through its script-file
 /// stack, `init.lua:259-305`). This loader:
 ///
-/// 1. resolves `name` against the top of the script-dir stack, trying
-///    `<dir>/<name>.lua`, `<dir>/<name with . -> />.lua`, and
-///    `<dir>/<name>/init.lua`;
+/// 1. resolves `name` against the require-private module-dir stack
+///    (innermost loading module first) and then the script-dir stack
+///    top-down, trying `<dir>/<name>.lua`, `<dir>/<name with . -> />.lua`,
+///    and `<dir>/<name>/init.lua`;
 /// 2. executes the module in a sandboxed environment (globals-inheriting,
 ///    like shortcode scripts) with the module's own directory pushed on the
-///    script-dir stack, so nested `require`s resolve relative to the module;
+///    private module-dir stack — NOT the script-dir stack — so nested
+///    `require`s resolve relative to the module while
+///    `quarto.utils.resolve_path` (and every other script-dir consumer)
+///    keeps seeing the requiring script's root (GH #588);
 /// 3. caches by resolved absolute path (a module evaluating to `nil` caches
 ///    as `true`, matching Lua's `require`);
 /// 4. falls back to the original `require` (when the target has one — the
@@ -210,17 +223,29 @@ pub fn register_scoped_require(
     let globals = lua.globals();
     let original: Option<mlua::Function> = globals.get("require").ok();
     globals.set("_quarto_require_cache", lua.create_table()?)?;
+    lua.set_named_registry_value(REQUIRE_DIR_STACK_KEY, lua.create_table()?)?;
 
     let require = lua.create_function(move |lua, name: String| {
         let cache: Table = lua.globals().get("_quarto_require_cache")?;
 
-        // Candidate paths, walking the script-dir stack top-down: the
-        // currently-executing module's dir first (sibling-relative
-        // requires), then the dirs of the scripts that required it
-        // (Q1-style extension-root-relative paths like
-        // `require("modules/brand/brand")` from a nested module).
-        let stack: Table = lua.globals().get("_quarto_script_dir_stack")?;
+        // Candidate dirs: the private module-dir stack top-down (the
+        // currently-loading module's dir first — sibling-relative
+        // requires), then the script-dir stack top-down (Q1-style
+        // extension-root-relative paths like
+        // `require("modules/brand/brand")` from a nested module). This is
+        // the same effective order as when module dirs lived on the shared
+        // stack; only the storage moved.
         let mut dirs: Vec<String> = Vec::new();
+        let module_stack: Table = lua.named_registry_value(REQUIRE_DIR_STACK_KEY)?;
+        for i in (1..=module_stack.raw_len()).rev() {
+            if let Ok(d) = module_stack.get::<String>(i)
+                && !d.is_empty()
+                && !dirs.contains(&d)
+            {
+                dirs.push(d);
+            }
+        }
+        let stack: Table = lua.globals().get("_quarto_script_dir_stack")?;
         for i in (1..=stack.raw_len()).rev() {
             if let Ok(d) = stack.get::<String>(i)
                 && !d.is_empty()
@@ -262,13 +287,16 @@ pub fn register_scoped_require(
                 .unwrap_or(Path::new(""))
                 .to_string_lossy()
                 .to_string();
-            push_script_dir(lua, &module_dir)?;
+            // Push on the require-private stack only: the script-dir stack
+            // must not move while a module loads (GH #588).
+            let len = module_stack.raw_len();
+            module_stack.set(len + 1, module_dir)?;
             let result = lua
                 .load(&source)
                 .set_name(key.clone())
                 .set_environment(env)
                 .eval::<Value>();
-            pop_script_dir(lua)?;
+            module_stack.set(len + 1, Value::Nil)?;
 
             let value = result?;
             // A module that returns nothing caches as `true`, like Lua.
@@ -1004,6 +1032,121 @@ mod tests {
         // Should not error
         pop_script_dir(&lua).unwrap();
         assert_eq!(current_script_dir(&lua).unwrap(), "");
+    }
+
+    // =========================================================================
+    // Scoped require × script-dir contract tests (GH #588, bd-sr0nipl7)
+    //
+    // Loaders never move the script-dir stack: `resolve_path` called from
+    // inside a module loaded via the scoped `require` must resolve against
+    // the requiring script's root, exactly as it does from the top-level
+    // script (Q1's scriptFile stack moves only at script boundaries).
+    // =========================================================================
+
+    fn create_require_test_lua() -> Lua {
+        let lua = create_test_lua();
+        let runtime = Arc::new(NativeRuntime::new());
+        register_scoped_require(&lua, runtime).unwrap();
+        lua
+    }
+
+    fn write_file(dir: &Path, name: &str, content: &str) {
+        let path = dir.join(name);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, content).unwrap();
+    }
+
+    #[test]
+    fn test_resolve_path_inside_required_module_uses_script_root() {
+        let lua = create_require_test_lua();
+        let tmp = tempfile::TempDir::new().unwrap();
+        let root = quarto_util::to_forward_slashes(tmp.path());
+
+        // The module resolves an extension-root-relative path at load time.
+        write_file(
+            tmp.path(),
+            "_modules/probe.lua",
+            r#"return { resolved = quarto.utils.resolve_path("_modules/greet.lua") }"#,
+        );
+        write_file(tmp.path(), "_modules/greet.lua", r#"return "GREET""#);
+
+        push_script_dir(&lua, &root).unwrap();
+        let top: String = lua
+            .load(r#"return quarto.utils.resolve_path("_modules/greet.lua")"#)
+            .eval()
+            .unwrap();
+        let via_require: String = lua
+            .load(r#"return require("_modules/probe").resolved"#)
+            .eval()
+            .unwrap();
+
+        assert_eq!(top, format!("{}/_modules/greet.lua", root));
+        // GH #588: this used to come back as .../_modules/_modules/greet.lua
+        // because the scoped require pushed the module's own dir onto the
+        // script-dir stack that resolve_path reads.
+        assert_eq!(via_require, top);
+    }
+
+    #[test]
+    fn test_script_dir_stack_unchanged_across_require() {
+        let lua = create_require_test_lua();
+        let tmp = tempfile::TempDir::new().unwrap();
+        let root = quarto_util::to_forward_slashes(tmp.path());
+
+        write_file(tmp.path(), "_modules/noop.lua", r#"return true"#);
+
+        push_script_dir(&lua, &root).unwrap();
+        lua.load(r#"require("_modules/noop")"#).exec().unwrap();
+        assert_eq!(current_script_dir(&lua).unwrap(), root);
+    }
+
+    #[test]
+    fn test_require_bare_sibling_name_from_nested_module() {
+        // Regression guard for #450's behavior: a loaded module can require
+        // a file in its own directory by bare name. This must keep working
+        // when the module dir moves off the shared script-dir stack.
+        let lua = create_require_test_lua();
+        let tmp = tempfile::TempDir::new().unwrap();
+        let root = quarto_util::to_forward_slashes(tmp.path());
+
+        write_file(tmp.path(), "_modules/greet.lua", r#"return "GREET""#);
+        write_file(
+            tmp.path(),
+            "_modules/probe.lua",
+            r#"return { sib = require("greet") }"#,
+        );
+
+        push_script_dir(&lua, &root).unwrap();
+        let sib: String = lua
+            .load(r#"return require("_modules/probe").sib"#)
+            .eval()
+            .unwrap();
+        assert_eq!(sib, "GREET");
+    }
+
+    #[test]
+    fn test_require_root_relative_name_from_nested_module() {
+        // Q1-style extension-root-relative require from inside a nested
+        // module (`require("_modules/x")` written in a file under
+        // `_modules/`): resolved via the script-dir stack, not the module
+        // dir.
+        let lua = create_require_test_lua();
+        let tmp = tempfile::TempDir::new().unwrap();
+        let root = quarto_util::to_forward_slashes(tmp.path());
+
+        write_file(tmp.path(), "_modules/greet.lua", r#"return "GREET""#);
+        write_file(
+            tmp.path(),
+            "_modules/probe.lua",
+            r#"return { sib = require("_modules/greet") }"#,
+        );
+
+        push_script_dir(&lua, &root).unwrap();
+        let sib: String = lua
+            .load(r#"return require("_modules/probe").sib"#)
+            .eval()
+            .unwrap();
+        assert_eq!(sib, "GREET");
     }
 
     // =========================================================================

--- a/crates/pampa/src/lua/quarto_api.rs
+++ b/crates/pampa/src/lua/quarto_api.rs
@@ -174,6 +174,24 @@ fn stringify_table(lua: &Lua, table: &Table, depth: usize) -> Result<String> {
 
 // =========================================================================
 // Script-dir stack
+//
+// THE CONTRACT (settled for `dofile` in #112, generalized in GH #588 /
+// bd-sr0nipl7): the script-dir stack moves only at top-level script
+// boundaries — filter script load (`filter.rs`), shortcode script load and
+// shortcode handler invocation (`shortcode.rs`). Loaders — `require`,
+// `dofile`, `loadfile` — never move it. A loader that needs the location of
+// the file it is currently executing tracks that privately (see
+// `REQUIRE_DIR_STACK_KEY`); it must not publish it through this stack,
+// because `quarto.utils.resolve_path`, `quarto.doc` dependency resolution,
+// and the WASM `dofile`/`loadfile` overrides all define "current path" as
+// *the innermost running script's directory*, exactly as Quarto 1's
+// `scriptFile` stack does (quarto-cli `init.lua:167-186`).
+//
+// Corollary: at rest — no script executing — the stack holds exactly the
+// load-time entries of the states that keep their script for their
+// lifetime (the per-filter state's single entry). The shared shortcode
+// state balances every push with a pop (`ScriptDirGuard`), so entries
+// from one extension never linger while another runs (bd-9xa0yui7).
 // =========================================================================
 
 /// Initialize the script-dir stack in the Lua state.
@@ -339,6 +357,27 @@ pub fn push_script_dir(lua: &Lua, dir: &str) -> Result<()> {
     let len = stack.raw_len();
     stack.set(len + 1, dir)?;
     Ok(())
+}
+
+/// RAII guard that pops the script-dir stack when dropped, so a push is
+/// balanced on every exit path (early `?` returns, errors, panics). Obtain
+/// via [`push_script_dir_scoped`]. Owns a cheap clone of the `Lua` handle
+/// so it can outlive borrows of the caller's fields.
+pub struct ScriptDirGuard {
+    lua: Lua,
+}
+
+impl Drop for ScriptDirGuard {
+    fn drop(&mut self) {
+        let _ = pop_script_dir(&self.lua);
+    }
+}
+
+/// Push a directory onto the script-dir stack for the lifetime of the
+/// returned guard.
+pub fn push_script_dir_scoped(lua: &Lua, dir: &str) -> Result<ScriptDirGuard> {
+    push_script_dir(lua, dir)?;
+    Ok(ScriptDirGuard { lua: lua.clone() })
 }
 
 /// Pop the top entry from the script-dir stack.

--- a/crates/pampa/src/lua/shortcode.rs
+++ b/crates/pampa/src/lua/shortcode.rs
@@ -156,13 +156,18 @@ impl LuaShortcodeEngine {
             )
         })?;
 
-        // Push script dir for quarto.utils.resolve_path
+        // Push script dir for quarto.utils.resolve_path while the script
+        // loads. The guard pops on every exit path: the shared shortcode
+        // state must not accumulate one entry per loaded extension script
+        // (bd-9xa0yui7) — at rest the stack holds only currently-executing
+        // scripts (see the contract in quarto_api.rs). Call-time resolution
+        // is handled by the push in `call`.
         let script_dir = script_path
             .parent()
             .unwrap_or(Path::new(""))
             .to_string_lossy()
             .to_string();
-        super::quarto_api::push_script_dir(&self.lua, &script_dir)
+        let _script_dir_guard = super::quarto_api::push_script_dir_scoped(&self.lua, &script_dir)
             .map_err(LuaShortcodeError::LuaError)?;
 
         // Execute script in a sandboxed environment that inherits globals
@@ -244,16 +249,14 @@ impl LuaShortcodeEngine {
         let reg_key = self.handlers.get(name)?;
         let func: Function = self.lua.registry_value(reg_key).ok()?;
 
-        // Push script dir for this handler's extension, pop after call
-        if let Some(dir) = self.handler_script_dirs.get(name) {
-            let _ = super::quarto_api::push_script_dir(&self.lua, dir);
-        }
+        // Push script dir for this handler's extension for the duration of
+        // the call (guard pops on drop, error paths included).
+        let _script_dir_guard = self
+            .handler_script_dirs
+            .get(name)
+            .and_then(|dir| super::quarto_api::push_script_dir_scoped(&self.lua, dir).ok());
 
         let result = self.call_handler(name, func, args, context).await;
-
-        if self.handler_script_dirs.contains_key(name) {
-            let _ = super::quarto_api::pop_script_dir(&self.lua);
-        }
 
         Some(result)
     }
@@ -1116,6 +1119,67 @@ return {
             }
             other => panic!("Expected Text, got {:?}", other),
         }
+    }
+
+    fn script_dir_stack_depth(lua: &Lua) -> usize {
+        lua.globals()
+            .get::<Table>("_quarto_script_dir_stack")
+            .unwrap()
+            .raw_len()
+    }
+
+    #[tokio::test]
+    async fn test_load_script_restores_script_dir_stack() {
+        // The script-dir stack must hold only the scripts currently
+        // executing (bd-9xa0yui7): the shared shortcode state must not
+        // accumulate one entry per loaded extension script.
+        let tmp = TempDir::new().unwrap();
+        let first = write_script(
+            tmp.path(),
+            "first.lua",
+            r#"return { a = function() return "A" end }"#,
+        );
+        let second = write_script(
+            tmp.path(),
+            "second.lua",
+            r#"return { b = function() return "B" end }"#,
+        );
+
+        let runtime = make_runtime();
+        let mut engine = LuaShortcodeEngine::new("html", runtime).unwrap();
+        let baseline = script_dir_stack_depth(&engine.lua);
+
+        engine.load_script(&first).await.unwrap();
+        assert_eq!(script_dir_stack_depth(&engine.lua), baseline);
+
+        engine.load_script(&second).await.unwrap();
+        assert_eq!(script_dir_stack_depth(&engine.lua), baseline);
+
+        // Handlers still work after the loads (call-time push/pop is
+        // responsible for the handler's script dir).
+        let result = engine
+            .call("a", &make_empty_args(), ShortcodeCallContext::Inline)
+            .await
+            .unwrap();
+        match result {
+            LuaShortcodeResult::Text(s) => assert_eq!(s, "A"),
+            other => panic!("Expected Text, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_load_script_restores_script_dir_stack_on_error() {
+        // The pop must run on the error path too: a script that fails to
+        // evaluate must not leave its dir on the stack.
+        let tmp = TempDir::new().unwrap();
+        let bad = write_script(tmp.path(), "bad.lua", r#"this is not valid lua ("#);
+
+        let runtime = make_runtime();
+        let mut engine = LuaShortcodeEngine::new("html", runtime).unwrap();
+        let baseline = script_dir_stack_depth(&engine.lua);
+
+        assert!(engine.load_script(&bad).await.is_err());
+        assert_eq!(script_dir_stack_depth(&engine.lua), baseline);
     }
 
     #[tokio::test]

--- a/crates/pampa/tests/wasm_lua.rs
+++ b/crates/pampa/tests/wasm_lua.rs
@@ -122,6 +122,94 @@ end
 }
 
 // ============================================================================
+// Scoped require + resolve_path contract on WASM (GH #587 / GH #588)
+// ============================================================================
+
+/// A filter loads a sibling module with the scoped `require` through the
+/// VFS, and `quarto.utils.resolve_path` inside that module resolves against
+/// the extension root under the `/project/` prefix — the script-dir
+/// contract (quarto_api.rs) on the WASM path.
+#[wasm_bindgen_test]
+async fn scoped_require_and_resolve_path_wasm() {
+    use pampa::lua::apply_lua_filters;
+    use pampa::lua::runtime::{VirtualFileSystem, WasmRuntime};
+    use pampa::pandoc::{ASTContext, Block, Inline, Pandoc, Paragraph, Str};
+    use std::path::PathBuf;
+    use std::sync::Arc;
+
+    let mut vfs = VirtualFileSystem::new();
+    vfs.add_file(
+        std::path::Path::new("/project/_extensions/fr/_modules/greet.lua"),
+        br#"
+return {
+  greeting = "greet-module-loaded",
+  resolved = quarto.utils.resolve_path("_modules/greet.lua"),
+}
+"#
+        .to_vec(),
+    );
+    vfs.add_file(
+        std::path::Path::new("/project/_extensions/fr/fr.lua"),
+        br#"
+local top = quarto.utils.resolve_path("_modules/greet.lua")
+local mod = require("_modules/greet")
+local verdict
+if top == "/project/_extensions/fr/_modules/greet.lua"
+    and mod.resolved == top
+    and mod.greeting == "greet-module-loaded" then
+  verdict = "REQUIRE-RESOLVE-OK"
+else
+  verdict = "MISMATCH:" .. tostring(top) .. "|" .. tostring(mod.resolved)
+end
+
+function Str(elem)
+    return pandoc.Str(verdict)
+end
+"#
+        .to_vec(),
+    );
+
+    let runtime: Arc<dyn pampa::lua::runtime::SystemRuntime> = Arc::new(WasmRuntime::with_vfs(vfs));
+
+    let pandoc = Pandoc {
+        meta: quarto_pandoc_types::ConfigValue::default(),
+        blocks: vec![Block::Paragraph(Paragraph {
+            content: vec![Inline::Str(Str {
+                text: "hello".to_string(),
+                source_info: quarto_source_map::SourceInfo::for_test(),
+            })],
+            source_info: quarto_source_map::SourceInfo::for_test(),
+        })],
+    };
+    let context = ASTContext::new();
+
+    let output = apply_lua_filters(
+        pandoc,
+        context,
+        &[PathBuf::from("/project/_extensions/fr/fr.lua")],
+        "html",
+        runtime,
+        None,
+    )
+    .await
+    .expect("filter execution failed");
+
+    assert!(
+        output.diagnostics.is_empty(),
+        "unexpected diagnostics: {:?}",
+        output.diagnostics
+    );
+
+    match &output.pandoc.blocks[0] {
+        Block::Paragraph(p) => match &p.content[0] {
+            Inline::Str(s) => assert_eq!(s.text, "REQUIRE-RESOLVE-OK"),
+            other => panic!("Expected Str, got {other:?}"),
+        },
+        other => panic!("Expected Paragraph, got {other:?}"),
+    }
+}
+
+// ============================================================================
 // Doc-level handlers (function Meta / function Pandoc) on WASM
 // ============================================================================
 

--- a/crates/quarto/tests/smoke-all/extensions/contract-filter-require/_extensions/fr/_extension.yml
+++ b/crates/quarto/tests/smoke-all/extensions/contract-filter-require/_extensions/fr/_extension.yml
@@ -1,0 +1,5 @@
+title: Filter Require Contract
+author: Test
+contributes:
+  filters:
+    - fr.lua

--- a/crates/quarto/tests/smoke-all/extensions/contract-filter-require/_extensions/fr/_modules/greet.lua
+++ b/crates/quarto/tests/smoke-all/extensions/contract-filter-require/_extensions/fr/_modules/greet.lua
@@ -1,0 +1,8 @@
+-- Loaded from the extension's filter via require. `resolved` records what
+-- resolve_path returns at module load time: per the script-dir contract
+-- (GH #588) it must be the extension-root-resolved path, identical to what
+-- the top-level filter script gets.
+return {
+  greeting = "greet-module-loaded",
+  resolved = quarto.utils.resolve_path("_modules/greet.lua"),
+}

--- a/crates/quarto/tests/smoke-all/extensions/contract-filter-require/_extensions/fr/fr.lua
+++ b/crates/quarto/tests/smoke-all/extensions/contract-filter-require/_extensions/fr/fr.lua
@@ -1,0 +1,27 @@
+-- GH #587 contract fixture: an extension's Lua *filter* can load sibling
+-- modules with require, both by extension-root-relative name and by the
+-- absolute form extensions commonly use. Also pins the GH #588 contract on
+-- the filter path: resolve_path inside the required module returns the
+-- extension-root-resolved path.
+local top = quarto.utils.resolve_path("_modules/greet.lua")
+local mod = require("_modules/greet")
+local abs = require(quarto.utils.resolve_path("_modules/greet.lua"):gsub("%.lua$", ""))
+
+local function tag(ok)
+  if ok then
+    return "OK"
+  end
+  return "BAD"
+end
+
+return {
+  {
+    Pandoc = function(doc)
+      local line = "fr-require=" .. tag(mod.greeting == "greet-module-loaded")
+        .. ";fr-abs=" .. tag(abs.greeting == "greet-module-loaded")
+        .. ";fr-resolve=" .. tag(mod.resolved == top)
+      doc.blocks:insert(pandoc.Para(pandoc.Str(line)))
+      return doc
+    end,
+  },
+}

--- a/crates/quarto/tests/smoke-all/extensions/contract-filter-require/test.qmd
+++ b/crates/quarto/tests/smoke-all/extensions/contract-filter-require/test.qmd
@@ -1,0 +1,15 @@
+---
+title: Extension filter requires sibling modules
+format: html
+filters:
+  - fr
+_quarto:
+  tests:
+    html:
+      noErrors: true
+      ensureFileRegexMatches:
+        - ["fr-require=OK;fr-abs=OK;fr-resolve=OK"]
+        - ["fr-require=BAD", "fr-abs=BAD", "fr-resolve=BAD"]
+---
+
+Filter require contract fixture.

--- a/crates/quarto/tests/smoke-all/extensions/contract-resolve-path/_extensions/rp/_extension.yml
+++ b/crates/quarto/tests/smoke-all/extensions/contract-resolve-path/_extensions/rp/_extension.yml
@@ -1,0 +1,3 @@
+contributes:
+  shortcodes:
+    - rp.lua

--- a/crates/quarto/tests/smoke-all/extensions/contract-resolve-path/_extensions/rp/_modules/greet.lua
+++ b/crates/quarto/tests/smoke-all/extensions/contract-resolve-path/_extensions/rp/_modules/greet.lua
@@ -1,0 +1,1 @@
+return { greeting = "greet-module-loaded" }

--- a/crates/quarto/tests/smoke-all/extensions/contract-resolve-path/_extensions/rp/_modules/probe.lua
+++ b/crates/quarto/tests/smoke-all/extensions/contract-resolve-path/_extensions/rp/_modules/probe.lua
@@ -1,0 +1,5 @@
+-- Records what resolve_path returns at module load time. Per the
+-- script-dir contract (GH #588), this must resolve against the extension
+-- root -- the same answer the top-level script gets -- not against this
+-- file's own directory.
+return { resolved = quarto.utils.resolve_path("_modules/greet.lua") }

--- a/crates/quarto/tests/smoke-all/extensions/contract-resolve-path/_extensions/rp/rp.lua
+++ b/crates/quarto/tests/smoke-all/extensions/contract-resolve-path/_extensions/rp/rp.lua
@@ -1,0 +1,19 @@
+-- GH #588 contract fixture: quarto.utils.resolve_path must return the same
+-- extension-root-resolved path from the top-level script, from a file loaded
+-- with require, and from a file loaded with dofile.
+local top = quarto.utils.resolve_path("_modules/greet.lua")
+local by_require = require("_modules/probe").resolved
+local by_dofile = dofile(quarto.utils.resolve_path("_modules/probe.lua")).resolved
+
+local function tag(p)
+  if p == top then
+    return "SAME"
+  end
+  return "DIFF"
+end
+
+return {
+  rp = function()
+    return "rp-top=OK;rp-require=" .. tag(by_require) .. ";rp-dofile=" .. tag(by_dofile)
+  end,
+}

--- a/crates/quarto/tests/smoke-all/extensions/contract-resolve-path/test.qmd
+++ b/crates/quarto/tests/smoke-all/extensions/contract-resolve-path/test.qmd
@@ -1,0 +1,13 @@
+---
+title: resolve_path agrees between top-level, require, and dofile call sites
+format: html
+_quarto:
+  tests:
+    html:
+      noErrors: true
+      ensureFileRegexMatches:
+        - ["rp-top=OK;rp-require=SAME;rp-dofile=SAME"]
+        - ["rp-require=DIFF", "rp-dofile=DIFF"]
+---
+
+{{< rp >}}


### PR DESCRIPTION
Fixes #588. Fixes #587.

Strands: bd-sr0nipl7 (#588), bd-9uqdoy0e (#587), bd-9xa0yui7 (stack leak).
Plan: `claude-notes/plans/2026-08-24-lua-require-current-path.md` · Assessment (full Q1/Q2 mechanism inventory): `claude-notes/research/2026-08-24-lua-current-path-gh588.md`

## The contract

All three fixes land under one rule, now stated as the header of the script-dir-stack section in `quarto_api.rs`:

> The script-dir stack moves only at top-level script boundaries — filter script load, shortcode script load, shortcode handler invocation. Loaders (`require`, `dofile`, `loadfile`) never move it. A loader that needs the location of the file it is executing tracks that privately.

This is Quarto 1's `scriptFile`-stack semantics (its stack moves only at script boundaries; `require` resolves the calling file via `debug.getinfo`, never via shared state), and it generalizes the contract #112 already settled for `dofile`.

## Commits

- **#588** — `register_scoped_require` pushed the loaded module's directory onto the shared script-dir stack while the module executed, so `resolve_path("_modules/greet.lua")` inside a required file came back as `_modules/_modules/greet.lua`. The module dir now lives on a require-private stack (a named registry value, invisible to user Lua) consulted only by require's candidate walk, in the same order as before — require behavior is unchanged, including #450's bare-name sibling requires; `resolve_path` now agrees with Quarto 1 from all three call sites (top-level, via require, via dofile).
- **#587** — `create_filter_environment` never installed the scoped require, so extension Lua filters ran with stock Lua `require` and failed to load sibling modules that the same extension's shortcodes load fine. One call installs the same loader; on native the stock `require` remains the fallback. Ordered after the #588 fix so filters inherit the corrected loader.
- **Stack leak (bd-9xa0yui7)** — `load_script` pushed the loading script's dir and never popped, accumulating one stale entry per extension script in the shared shortcode state. New `ScriptDirGuard` RAII pop balances every exit path (eval errors included); the call-time push/pop is converted to the same guard.
- **WASM smoke test** — require-then-`resolve_path` under the `/project/` VFS prefix on the real wasm32 target.

## Tests

TDD throughout — every fix's test was observed failing first (doubled `_modules` segment; stock-require "module not found"; leaked stack entries):

- 4 unit tests in `quarto_api.rs` (the #588 reproduction, stack invariance across require, two nested-require regression guards), 2 in `shortcode.rs` (leak, success + eval-error paths).
- New smoke-all fixtures `extensions/contract-resolve-path` (mirrors the #588 three-row table: top-level / via-require / via-dofile must agree) and `extensions/contract-filter-require` (root-relative require, the absolute `resolve_path(...):gsub("%.lua$","")` form, and resolve_path parity inside the filter-required module).
- `wasm_lua.rs::scoped_require_and_resolve_path_wasm` on wasm32-unknown-unknown.

## Verification

- Full workspace suite green (13,258 tests); full `cargo xtask verify` passed.
- `wasm_lua` suite: 8 passed on the real wasm32 target (local run, LLVM clang).
- End-to-end through the real binary, output inspected:
  - `cargo run --bin q2 -- render .../contract-resolve-path/test.qmd` → `rp-top=OK;rp-require=SAME;rp-dofile=SAME`
  - `cargo run --bin q2 -- render .../contract-filter-require/test.qmd` → `fr-require=OK;fr-abs=OK;fr-resolve=OK`

## Known, deliberate divergences from Quarto 1 (documented in the research note)

- Bare-name sibling require from a nested module keeps working (superset of Q1), and the module-first candidate order can shadow a root-level file of the same name — retained; documented rather than chased.
- Per-filter require cache (Q2 has one Lua state per filter; Q1's single emulated state shares one cache).

🤖 Generated with [Claude Code](https://claude.com/claude-code)