### PR TITLE
Classify any URI scheme as external, not a 7-entry allowlist

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5215,6 +5215,7 @@ dependencies = [
  "quarto-config",
  "quarto-pandoc-types",
  "quarto-source-map",
+ "quarto-util",
  "yaml-rust2",
 ]
 

--- a/claude-notes/designs/path-resolution-model.md
+++ b/claude-notes/designs/path-resolution-model.md
@@ -32,8 +32,14 @@ Quarto 2 interprets a path written in source (`.qmd` front matter,
    the #455 discussion). It is never an OS-absolute filesystem path. What
    "resolve" then means depends on the space (next section).
 
-Carve-outs rule 2 must not swallow: protocol-relative `//host/x` URLs,
-`data:` URIs, full URLs (all classified external before any path handling);
+Carve-outs rule 2 must not swallow: anything with an RFC-3986 scheme
+(`https:`, `data:`, `mailto:`, `positron:`, `javascript:`, …) or the
+protocol-relative `//host/x` form — all classified external before any
+path handling. **`quarto_util::is_external_url` is the sole classifier;
+never write a prefix list** (`starts_with("http://") || …`). Every such
+list drifts to a different subset and the schemes it omits get
+path-normalized — `//` collapsed, `../` prepended
+(bd-scheme-href-path-normalized-w5zya82r replaced seven of them);
 WASM VFS `/project/...` paths (a filesystem-space *internal* convention,
 never authored config); genuinely OS-absolute *input-file* paths where a key
 documents that it accepts them (checked with `quarto_util::is_rooted`, not

--- a/claude-notes/plans/2026-08-25-scheme-href-path-normalized.md
+++ b/claude-notes/plans/2026-08-25-scheme-href-path-normalized.md
@@ -20,9 +20,13 @@ Quarto 1 emits all of these unchanged (its classifier is `/^\w+:/`,
 ## Investigation findings
 
 The strand names one predicate, `navigation_href::is_external`. The tree
-actually carries **seven** hand-rolled copies of the same allowlist, each a
-slightly different subset (some have `data:`, one has `javascript:`, two use
-`contains("://")`):
+actually carries **seven** hand-rolled copies of the same allowlist on the
+*href* side, each a slightly different subset (some have `data:`, one has
+`javascript:`, two use `contains("://")`). (Five more copies gate image /
+font *`src`* values — `listing/helpers.rs`, `feed/binding.rs`,
+`resource_collector.rs`, `brand_layer.rs`, `project/mod.rs`; scoped out
+here as low runtime risk and tracked in bd-pa394mk7, linked to bd-oejuizi9 per the
+path-resolution contract.)
 
 | # | Site | Consumers | Same defect? |
 |---|------|-----------|--------------|
@@ -111,7 +115,16 @@ gets its own regression test written first.
   observable through the real binary. The fixture therefore asserts
   symptom 1 (and the absence of `../<scheme>` as a guard); symptom 2 is
   pinned by the unit test. Whether the runner *should* relativize like
-  `q2 render` is a separate question, not pursued here.
+  `q2 render` is a separate question — filed as bd-sqa9h5ne.
+- **Code review** (post-commit, blank-slate reviewer): no Critical or
+  logic issues. Acted on: filed bd-pa394mk7 (src-side sweep) and bd-sqa9h5ne (runner
+  divergence); reworded the contract's carve-out in
+  `claude-notes/designs/path-resolution-model.md` to name
+  `quarto_util::is_external_url` as the sole classifier instead of
+  enumerating schemes; corrected the fixture comment that overstated what
+  the `../<scheme>` guards pin. Declined: trimming the `is_external` doc
+  comment (it already defers to `quarto_util`'s docs for the rule; the
+  bug-class sentence is the part worth keeping at the seam).
 
 ## End-to-end record
 

--- a/claude-notes/plans/2026-08-25-scheme-href-path-normalized.md
+++ b/claude-notes/plans/2026-08-25-scheme-href-path-normalized.md
@@ -1,0 +1,95 @@
+# Non-http URI schemes are path-normalized (bd-scheme-href-path-normalized-w5zya82r)
+
+**Strand:** `bd-scheme-href-path-normalized-w5zya82r` (P1 bug, labels `navigation`, `parity`)
+**Branch:** `braid/bd-scheme-href-path-normalized-w5zya82r-scheme-href-path-normalized` (workspace-3, off `main` @ d05e96ee8 = v0.27.0)
+**Verdict:** Ready — fix direction is unambiguous; implemented in this plan.
+
+## Overview
+
+Any href whose scheme is not on a hardcoded prefix allowlist is classified as
+project-relative and run through path normalization. Two symptoms, one cause:
+
+1. `[x](positron://settings/foo)` → `href="positron:/settings/foo"` (`//` collapsed).
+   Body links and nav hrefs alike. 241 dead deep links on the Positron docs port.
+2. Nav hrefs on a subdirectory page additionally gain `../` per level:
+   `javascript:void(0);` → `../javascript:void(0);`.
+
+Quarto 1 emits all of these unchanged (its classifier is `/^\w+:/`,
+`src/core/url.ts:13`).
+
+## Investigation findings
+
+The strand names one predicate, `navigation_href::is_external`. The tree
+actually carries **seven** hand-rolled copies of the same allowlist, each a
+slightly different subset (some have `data:`, one has `javascript:`, two use
+`contains("://")`):
+
+| # | Site | Consumers | Same defect? |
+|---|------|-----------|--------------|
+| 1 | `quarto-core/src/transforms/navigation_href.rs::is_external` | 5 resolvers (nav + body + static + metadata paths) and `navigation_active::mark_active` | **Yes — both symptoms** |
+| 2 | `quarto-core/src/project/sidebar_membership.rs::is_external_or_anchor` | sidebar member-path collection | Yes — a `positron://` sidebar entry is collected as a project page path |
+| 3 | `quarto-navigation/src/sidebar.rs::is_external_href` | `flatten_for_page_nav` (prev/next page nav) | Yes — a `javascript:` sidebar link becomes a navigable prev/next target |
+| 4 | `quarto-core/src/project/llms_post_render.rs::resolve_href` | llms.txt nav resolution | `contains("://")` saves `positron://`; `javascript:`/`tel:` are looked up in the index (harmless miss) |
+| 5 | `quarto-core/src/transforms/llms.rs::retarget_href` | llms `.md` companion link retargeting | same as 4 |
+| 6 | `quarto-core/src/project/listing/post_render_upgrade/substitute.rs::is_absolute_url` | listing item href relativization | Yes — `positron://` gets path-joined |
+| 7 | `quarto-core/src/project/listing/feed/reader_ext.rs::is_external_url` (local) | feed href absolutization | Has `javascript:` but not `positron:`/`vscode:` — yes |
+
+The `data:` arm in #1 was added by bd-root-relative-paths-design-fc5pvkcv
+with a comment that already diagnoses this exact class; that fix appended an
+allowlist entry rather than generalizing. This plan generalizes.
+
+The generic classifier already exists: `quarto_util::is_external_url`
+(`crates/quarto-util/src/path.rs:43`) — real RFC-3986 scheme detection
+(first `:`, ≥2-char scheme, ASCII-letter start, `[A-Za-z0-9+.-]*`), plus
+the `//host` form. Already used at 10 sites. Its documented trade-off — a
+relative path with a colon in its first segment (`my:file.qmd`) reads as a
+URL — is the same trade-off Q1 makes and is accepted here. Its 2-char
+minimum means `C:\…` stays a path (safer than Q1). Paths like
+`docs/foo:bar.qmd`, `page.qmd#sec:intro`, `page.qmd?k=a:b` are correctly
+*not* URLs (`/`, `#`, `?`, `=` are not scheme characters).
+
+`quarto-util` depends only on `dirs`/`thiserror`/`serde`, so
+`quarto-navigation` (#3) can take it with no cycle.
+
+Repros (external, not in tree): `/Users/gordon/src/q2-positron-docs/llms-info/repros/{custom-scheme-slash-collapsed,nav-scheme-href-relativized}/`.
+
+## Scope decision
+
+The strand's suggested fix is #1 only. This plan replaces **all seven** with
+`quarto_util::is_external_url` (keeping each site's `#`-anchor handling).
+Rationale: every copy is the same defect class, three of them (#2, #3, #6)
+produce user-visible misbehaviour for the same inputs, and leaving six
+behind invites the next "append an eighth prefix" fix. Each replaced site
+gets its own regression test written first.
+
+## Work items
+
+### Phase 1 — failing tests (TDD)
+
+- [ ] `navigation_href.rs` `is_external_classification`: add `positron://…`, `vscode://…`, `javascript:void(0);`, `tel:`-style scheme without `//`, and negatives (`docs/a:b.qmd`, `page.qmd#sec:x`, `C:\x`) — run, confirm fails
+- [ ] `navigation_href.rs`: `resolve_href_for_html` at depth one passes `javascript:void(0);` and `positron://settings/x` through unchanged (symptom 2 + 1 for nav)
+- [ ] `navigation_href.rs`: `resolve_doc_relative_href` passes `positron://settings/x` unchanged (symptom 1 for body links)
+- [ ] `quarto-navigation/src/sidebar.rs`: `flatten_for_page_nav` skips a `javascript:void(0);` link
+- [ ] `sidebar_membership.rs`: a `positron://` entry is not a member path
+- [ ] `llms_post_render.rs` / `llms.rs`: `javascript:void(0);` passes through / resolves to nothing
+- [ ] `substitute.rs` / `reader_ext.rs`: `positron://x` treated as absolute
+- [ ] Smoke-all fixture `crates/quarto/tests/smoke-all/navigation/scheme-hrefs/` (navbar with `javascript:`, `mailto:`, `positron://` items; `index.qmd` + `sub/page.qmd` + body links) — `ensureFileRegexMatches` on intact `positron://` and absent `positron:/s`, `\.\./javascript:` — run, confirm fails
+
+### Phase 2 — fix
+
+- [ ] Replace the body of `navigation_href::is_external` with `quarto_util::is_external_url`; rewrite doc comment (drop the false "matches Q1's cheap heuristic"; cite this strand + the class)
+- [ ] #2 `sidebar_membership.rs` → `is_external_url(href) || href.starts_with('#')`
+- [ ] #3 `quarto-navigation` → add `quarto-util` dep, use `is_external_url`
+- [ ] #4, #5 llms → `is_external_url`
+- [ ] #6, #7 listing → `is_external_url` (drop the local shadowing copy in `reader_ext.rs`)
+- [ ] All Phase 1 tests pass; `cargo clippy -p quarto-core -p quarto-navigation -p quarto --all-targets -- -D warnings`
+
+### Phase 3 — verification
+
+- [ ] `cargo nextest run --workspace` — report delta vs pre-flight baseline
+- [ ] End-to-end: `cargo run --bin q2 -- render` on both external repro projects; inspect `_site/index.html` and `_site/sub/page.html`; record snippets below
+- [ ] Reconcile this checklist; commit
+
+## End-to-end record
+
+(filled in at Phase 3)

--- a/claude-notes/plans/2026-08-25-scheme-href-path-normalized.md
+++ b/claude-notes/plans/2026-08-25-scheme-href-path-normalized.md
@@ -66,30 +66,78 @@ gets its own regression test written first.
 
 ### Phase 1 — failing tests (TDD)
 
-- [ ] `navigation_href.rs` `is_external_classification`: add `positron://…`, `vscode://…`, `javascript:void(0);`, `tel:`-style scheme without `//`, and negatives (`docs/a:b.qmd`, `page.qmd#sec:x`, `C:\x`) — run, confirm fails
-- [ ] `navigation_href.rs`: `resolve_href_for_html` at depth one passes `javascript:void(0);` and `positron://settings/x` through unchanged (symptom 2 + 1 for nav)
-- [ ] `navigation_href.rs`: `resolve_doc_relative_href` passes `positron://settings/x` unchanged (symptom 1 for body links)
-- [ ] `quarto-navigation/src/sidebar.rs`: `flatten_for_page_nav` skips a `javascript:void(0);` link
-- [ ] `sidebar_membership.rs`: a `positron://` entry is not a member path
-- [ ] `llms_post_render.rs` / `llms.rs`: `javascript:void(0);` passes through / resolves to nothing
-- [ ] `substitute.rs` / `reader_ext.rs`: `positron://x` treated as absolute
-- [ ] Smoke-all fixture `crates/quarto/tests/smoke-all/navigation/scheme-hrefs/` (navbar with `javascript:`, `mailto:`, `positron://` items; `index.qmd` + `sub/page.qmd` + body links) — `ensureFileRegexMatches` on intact `positron://` and absent `positron:/s`, `\.\./javascript:` — run, confirm fails
+- [x] `navigation_href.rs` `is_external_classification`: add `positron://…`, `vscode://…`, `javascript:void(0);`, `tel:`-style scheme without `//`, and negatives (`docs/a:b.qmd`, `page.qmd#sec:x`, `C:\x`) — run, confirm fails
+- [x] `navigation_href.rs`: `resolve_href_for_html` at depth one passes `javascript:void(0);` and `positron://settings/x` through unchanged (symptom 2 + 1 for nav)
+- [x] `navigation_href.rs`: `resolve_doc_relative_href` passes `positron://settings/x` unchanged (symptom 1 for body links)
+- [x] `quarto-navigation/src/sidebar.rs`: `flatten_for_page_nav` skips a `javascript:void(0);` link
+- [x] `sidebar_membership.rs`: a `positron://` entry is not a member path
+- [x] `llms_post_render.rs` / `llms.rs`: `javascript:void(0);` passes through / resolves to nothing
+- [x] `substitute.rs` / `reader_ext.rs`: `positron://x` treated as absolute
+- [x] Smoke-all fixture `crates/quarto/tests/smoke-all/navigation/scheme-hrefs/` (navbar with `javascript:`, `mailto:`, `positron://` items; `index.qmd` + `sub/page.qmd` + body links) — `ensureFileRegexMatches` on intact `positron://` and absent `positron:/s`, `\.\./javascript:` — run, confirm fails
 
 ### Phase 2 — fix
 
-- [ ] Replace the body of `navigation_href::is_external` with `quarto_util::is_external_url`; rewrite doc comment (drop the false "matches Q1's cheap heuristic"; cite this strand + the class)
-- [ ] #2 `sidebar_membership.rs` → `is_external_url(href) || href.starts_with('#')`
-- [ ] #3 `quarto-navigation` → add `quarto-util` dep, use `is_external_url`
-- [ ] #4, #5 llms → `is_external_url`
-- [ ] #6, #7 listing → `is_external_url` (drop the local shadowing copy in `reader_ext.rs`)
-- [ ] All Phase 1 tests pass; `cargo clippy -p quarto-core -p quarto-navigation -p quarto --all-targets -- -D warnings`
+- [x] Replace the body of `navigation_href::is_external` with `quarto_util::is_external_url`; rewrite doc comment (drop the false "matches Q1's cheap heuristic"; cite this strand + the class)
+- [x] #2 `sidebar_membership.rs` → `is_external_url(href) || href.starts_with('#')`
+- [x] #3 `quarto-navigation` → add `quarto-util` dep, use `is_external_url`
+- [x] #4, #5 llms → `is_external_url`
+- [x] #6, #7 listing → `is_external_url` (drop the local shadowing copy in `reader_ext.rs`)
+- [x] All Phase 1 tests pass; `cargo clippy -p quarto-core -p quarto-navigation -p quarto --all-targets -- -D warnings`
 
 ### Phase 3 — verification
 
-- [ ] `cargo nextest run --workspace` — report delta vs pre-flight baseline
-- [ ] End-to-end: `cargo run --bin q2 -- render` on both external repro projects; inspect `_site/index.html` and `_site/sub/page.html`; record snippets below
-- [ ] Reconcile this checklist; commit
+- [x] `cargo nextest run --workspace` — 13377 run / 13377 passed / 199 skipped / 0 failed; +10 unit tests vs `main` (all new here), fixture adds pages to the single `smoke_all` test
+- [x] End-to-end: `cargo run --bin q2 -- render` on both external repro projects; inspect `_site/index.html` and `_site/sub/page.html`; record snippets below
+- [x] Reconcile this checklist; commit
+
+## Notes from execution
+
+- **TDD red run:** 7 of the 10 new unit tests failed before the fix
+  (`is_external_recognizes_any_scheme`,
+  `nav_href_with_custom_scheme_passes_through_at_depth` — actual
+  `"../javascript:void(0);"`, `static_href_custom_scheme_passes_through`,
+  `flatten_excludes_any_scheme_href`, `any_scheme_href_excluded`,
+  `resolve_preview_url_passes_any_scheme_through`,
+  `extract_full_contents_passes_any_scheme_through`) plus both pages of
+  the smoke-all fixture. The two llms tests (#4, #5) passed before the
+  fix as predicted — those sites were `contains("://")`-tolerant; they
+  are unified for consistency and their tests pin the behaviour.
+  `body_href_custom_scheme_keeps_double_slash` initially passed because
+  it passed `index: None`, which short-circuits to verbatim; it now
+  passes an index and failed red before the fix.
+- **Smoke-all runner vs `q2 render`:** the smoke-all runner renders
+  `sub/page.qmd` *without* nav-href relativization (no `../index.html`
+  in its output, and no `../javascript:` either), so symptom 2 is only
+  observable through the real binary. The fixture therefore asserts
+  symptom 1 (and the absence of `../<scheme>` as a guard); symptom 2 is
+  pinned by the unit test. Whether the runner *should* relativize like
+  `q2 render` is a separate question, not pursued here.
 
 ## End-to-end record
 
-(filled in at Phase 3)
+Invocation (from the worktree root, after the fix):
+
+```
+cargo run -q --bin q2 -- render crates/quarto/tests/smoke-all/navigation/scheme-hrefs
+cargo run -q --bin q2 -- render /Users/gordon/src/q2-positron-docs/llms-info/repros/custom-scheme-slash-collapsed
+cargo run -q --bin q2 -- render /Users/gordon/src/q2-positron-docs/llms-info/repros/nav-scheme-href-relativized
+```
+
+Observed hrefs (`grep -o 'href="[^"]*"'`, minus css/js), **inspected**:
+
+```
+nav-scheme-href-relativized/_site/index.html          before fix                      after fix
+  JS navbar item                                       javascript:void(0);            javascript:void(0);
+  Custom-scheme navbar item                            positron:/settings/...         positron://settings/positron.notebook.enabled
+nav-scheme-href-relativized/_site/sub/page.html
+  JS navbar item                                       ../javascript:void(0);         javascript:void(0);
+  Custom-scheme navbar item                            ../positron:/settings/...      positron://settings/positron.notebook.enabled
+  Home (real page link, still relativized)             ../index.html                  ../index.html
+custom-scheme-slash-collapsed/_site/index.html (body links)
+  positron                                             positron:/settings/...         positron://settings/positron.notebook.enabled
+  vscode                                               vscode:/schemas/settings       vscode://schemas/settings
+  https / mailto controls                              unchanged                      unchanged
+```
+
+After the fix every scheme href on every page is byte-identical to the
+Q1 baseline in `_site-q1/`.

--- a/crates/quarto-core/src/project/listing/feed/reader_ext.rs
+++ b/crates/quarto-core/src/project/listing/feed/reader_ext.rs
@@ -194,6 +194,7 @@ fn strip_title_block_header(html: &str) -> String {
 /// - All other paths are resolved against `sibling_dir`
 ///   (forward-slashed; empty = output-dir root).
 fn rewrite_relative_urls(html: &str, site_url: &str, sibling_dir: &str) -> String {
+    use quarto_util::is_external_url;
     use regex::{Captures, RegexBuilder};
     let base = site_url.trim_end_matches('/');
 
@@ -241,21 +242,6 @@ fn rewrite_relative_urls(html: &str, site_url: &str, sibling_dir: &str) -> Strin
             format!(r#"<{}{}src="{}"{}>"#, tag, pre, rewrite_url(url), post)
         })
         .into_owned()
-}
-
-/// True if `s` is already an absolute reference. Includes the
-/// scheme-relative `//host/path` form and the common pseudo-
-/// schemes (`mailto:`, `javascript:`, `data:`) that should pass
-/// through unchanged.
-fn is_external_url(s: &str) -> bool {
-    s.starts_with("http://")
-        || s.starts_with("https://")
-        || s.starts_with("//")
-        || s.starts_with("mailto:")
-        || s.starts_with("javascript:")
-        || s.starts_with("data:")
-        || s.starts_with("tel:")
-        || s.starts_with("ftp://")
 }
 
 /// Collapse `..` / `.` segments in a forward-slash path. Naive
@@ -455,6 +441,25 @@ mod tests {
         assert!(
             out.contains(r#"href="mailto:hi@example.com""#),
             "mailto must pass through; got: {}",
+            out
+        );
+    }
+
+    /// bd-scheme-href-path-normalized-w5zya82r — any scheme passes
+    /// through, not just the allowlisted few.
+    #[test]
+    fn extract_full_contents_passes_any_scheme_through() {
+        let html = r#"<html><body><main class="content"><p><a href="positron://settings/x">p</a> <a href="vscode://schemas/settings">v</a></p></main></body></html>"#;
+        let out = extract_full_contents(html, "https://example.com", "posts/foo.html")
+            .expect("main.content found");
+        assert!(
+            out.contains(r#"href="positron://settings/x""#),
+            "custom scheme must pass through; got: {}",
+            out
+        );
+        assert!(
+            out.contains(r#"href="vscode://schemas/settings""#),
+            "custom scheme must pass through; got: {}",
             out
         );
     }

--- a/crates/quarto-core/src/project/listing/post_render_upgrade/substitute.rs
+++ b/crates/quarto-core/src/project/listing/post_render_upgrade/substitute.rs
@@ -330,7 +330,7 @@ fn escape_attr(s: &str) -> String {
 ///
 /// Returns the URL to embed in the host page's `<img src=...>`.
 fn resolve_preview_url(host_path: &Path, sibling_abs: &Path, preview_src: &str) -> String {
-    if is_absolute_url(preview_src) {
+    if quarto_util::is_external_url(preview_src) {
         return preview_src.to_string();
     }
     let host_dir = host_path.parent().unwrap_or(Path::new(""));
@@ -358,14 +358,6 @@ fn resolve_preview_url(host_path: &Path, sibling_abs: &Path, preview_src: &str) 
                 .join("/")
         },
     )
-}
-
-fn is_absolute_url(s: &str) -> bool {
-    s.starts_with("http://")
-        || s.starts_with("https://")
-        || s.starts_with("data:")
-        || s.starts_with("//")
-        || s.starts_with("mailto:")
 }
 
 // ─────────────────────────────────────────────────────────────────
@@ -430,6 +422,22 @@ mod tests {
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use tempfile::TempDir;
+
+    /// bd-scheme-href-path-normalized-w5zya82r — a preview `src` with
+    /// any scheme is already absolute and passes through untouched.
+    #[test]
+    fn resolve_preview_url_passes_any_scheme_through() {
+        let host = Path::new("/site/index.html");
+        let sibling = Path::new("/site/posts/foo.html");
+        for src in [
+            "positron://settings/x",
+            "vscode://schemas/settings",
+            "data:image/png;base64,AAAA",
+            "https://example.com/x.png",
+        ] {
+            assert_eq!(resolve_preview_url(host, sibling, src), src);
+        }
+    }
 
     /// Build a minimal ProjectContext rooted in a tempdir.
     fn make_project(output_dir: &Path) -> ProjectContext {

--- a/crates/quarto-core/src/project/llms_post_render.rs
+++ b/crates/quarto-core/src/project/llms_post_render.rs
@@ -592,12 +592,7 @@ fn collect_nav_items(
 /// (`about.qmd`) or output href (`about.html`) — to its profile.
 /// External URLs and anchors resolve to nothing.
 fn resolve_href<'i>(href: &str, index: &'i ProjectIndex) -> Option<&'i DocumentProfile> {
-    if href.is_empty()
-        || href.starts_with('#')
-        || href.starts_with("//")
-        || href.contains("://")
-        || href.starts_with("mailto:")
-    {
+    if href.is_empty() || href.starts_with('#') || quarto_util::is_external_url(href) {
         return None;
     }
     let clean = href.strip_prefix('/').unwrap_or(href);
@@ -647,4 +642,38 @@ fn assemble_llms_full(
         out.push('\n');
     }
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn index_with(source: &str, href: &str) -> ProjectIndex {
+        ProjectIndex::new(vec![DocumentProfile {
+            source_path: PathBuf::from(source),
+            output_href: href.to_string(),
+            format_id: "html".to_string(),
+            ..Default::default()
+        }])
+    }
+
+    /// Any scheme is external and resolves to nothing — not just the
+    /// allowlisted few (bd-scheme-href-path-normalized-w5zya82r).
+    #[test]
+    fn resolve_href_any_scheme_is_external() {
+        let index = index_with("about.qmd", "about.html");
+        assert!(resolve_href("about.qmd", &index).is_some());
+        assert!(resolve_href("about.html#sec", &index).is_some());
+        for href in [
+            "https://example.com/about.html",
+            "mailto:someone@example.com",
+            "javascript:void(0);",
+            "positron://settings/about.html",
+            "//cdn.example.com/about.html",
+            "#sec",
+            "",
+        ] {
+            assert!(resolve_href(href, &index).is_none(), "{href}");
+        }
+    }
 }

--- a/crates/quarto-core/src/project/sidebar_membership.rs
+++ b/crates/quarto-core/src/project/sidebar_membership.rs
@@ -125,18 +125,11 @@ fn collect_member_paths(entries: &[SidebarEntry]) -> Vec<PathBuf> {
 }
 
 /// Cheap classifier: a sidebar entry's `href` that *isn't* a
-/// project page. Mirrors the rule used by
-/// [`crate::transforms::navigation_href::is_external`] but
-/// duplicated here so this helper has zero non-project-internal
-/// dependencies.
+/// project page — any URI scheme or `//host` form (same rule as
+/// [`crate::transforms::navigation_href::is_external`]), or a
+/// fragment-only anchor.
 fn is_external_or_anchor(href: &str) -> bool {
-    href.starts_with("http://")
-        || href.starts_with("https://")
-        || href.starts_with("mailto:")
-        || href.starts_with("tel:")
-        || href.starts_with("ftp://")
-        || href.starts_with("//")
-        || href.starts_with('#')
+    quarto_util::is_external_url(href) || href.starts_with('#')
 }
 
 #[cfg(test)]
@@ -339,6 +332,28 @@ mod tests {
         let resolved = resolve_sidebar_membership(&meta, &index, &mut diags);
 
         // External URL is dropped from membership; only project pages remain.
+        assert_eq!(resolved[0].members, vec![PathBuf::from("a.qmd")]);
+    }
+
+    /// bd-scheme-href-path-normalized-w5zya82r — any scheme is external,
+    /// not just the allowlisted few.
+    #[test]
+    fn any_scheme_href_excluded() {
+        let mut meta = ConfigValue::default();
+        let sidebar = config_map(vec![(
+            "contents",
+            arr(vec![
+                s("a.qmd"),
+                s("javascript:void(0);"),
+                s("positron://settings/x"),
+            ]),
+        )]);
+        meta.insert_path(&["website", "sidebar"], sidebar);
+
+        let index = make_index_with(&["a.qmd"]);
+        let mut diags = Vec::new();
+        let resolved = resolve_sidebar_membership(&meta, &index, &mut diags);
+
         assert_eq!(resolved[0].members, vec![PathBuf::from("a.qmd")]);
     }
 

--- a/crates/quarto-core/src/transforms/llms.rs
+++ b/crates/quarto-core/src/transforms/llms.rs
@@ -885,13 +885,7 @@ fn retarget_href(href: &str, cx: &ViewContext) -> String {
         return href.to_string();
     };
     // External / non-path targets pass through.
-    if href.is_empty()
-        || href.starts_with('#')
-        || href.starts_with("//")
-        || href.contains("://")
-        || href.starts_with("mailto:")
-        || href.starts_with("data:")
-    {
+    if href.is_empty() || href.starts_with('#') || quarto_util::is_external_url(href) {
         return href.to_string();
     }
     let (path, fragment) = match href.split_once('#') {
@@ -1202,6 +1196,15 @@ mod tests {
             "https://example.com/x.html"
         );
         assert_eq!(retarget_href("#local", &cx), "#local");
+        // Any scheme is external (bd-scheme-href-path-normalized-w5zya82r).
+        assert_eq!(
+            retarget_href("javascript:void(0);", &cx),
+            "javascript:void(0);"
+        );
+        assert_eq!(
+            retarget_href("positron://settings/about.html", &cx),
+            "positron://settings/about.html"
+        );
         assert_eq!(retarget_href("data.csv", &cx), "data.csv");
         // Unknown page keeps .html.
         assert_eq!(retarget_href("missing.html", &cx), "missing.html");

--- a/crates/quarto-core/src/transforms/navigation_href.rs
+++ b/crates/quarto-core/src/transforms/navigation_href.rs
@@ -222,20 +222,18 @@ pub fn resolve_href_for_html(
 
 /// Classify an href as external (not project-relative).
 ///
-/// Matches Quarto 1's cheap heuristic: anything with a recognizable
-/// scheme, plus protocol-relative `//host/…` which bypasses the
-/// project entirely.
+/// Any href carrying an RFC-3986 scheme (`https:`, `mailto:`, `data:`,
+/// `positron:`, `javascript:`, …), plus protocol-relative `//host/…`
+/// which bypasses the project entirely. Delegates to
+/// [`quarto_util::is_external_url`], the workspace's one scheme
+/// classifier, rather than keeping a prefix allowlist: any scheme an
+/// allowlist omits falls through to path normalization, which collapses
+/// `//` to `/` and, on a nested page, prepends `../` per level
+/// (bd-scheme-href-path-normalized-w5zya82r — the same class earlier
+/// hit `data:`, bd-root-relative-paths-design-fc5pvkcv). Quarto 1's
+/// equivalent is `/^\w+:/`.
 pub fn is_external(href: &str) -> bool {
-    href.starts_with("http://")
-        || href.starts_with("https://")
-        || href.starts_with("mailto:")
-        || href.starts_with("tel:")
-        || href.starts_with("ftp://")
-        || href.starts_with("//")
-        // data: URIs are URL-shaped, not path-shaped — running one
-        // through path normalization would mangle it into a relative
-        // URL (bd-root-relative-paths-design-fc5pvkcv).
-        || href.starts_with("data:")
+    quarto_util::is_external_url(href)
 }
 
 /// Pass-1 / static counterpart to [`resolve_doc_relative_href`].
@@ -1358,6 +1356,27 @@ mod tests {
         assert!(!is_external("#fragment"));
     }
 
+    /// bd-scheme-href-path-normalized-w5zya82r — *any* RFC-3986 scheme
+    /// is external, not just the seven that used to be allowlisted. A
+    /// scheme href run through path normalization loses its `//`
+    /// (`positron://x` → `positron:/x`) and, on a nested page, gains
+    /// `../` per level.
+    #[test]
+    fn is_external_recognizes_any_scheme() {
+        assert!(is_external("positron://settings/positron.notebook.enabled"));
+        assert!(is_external("vscode://schemas/settings"));
+        assert!(is_external("javascript:void(0);"));
+        assert!(is_external("ms-settings:display"));
+        assert!(is_external("x-custom+v1.0:payload"));
+        // A colon past the first path segment, or after `#` / `?`, is
+        // not a scheme delimiter.
+        assert!(!is_external("docs/a:b.qmd"));
+        assert!(!is_external("page.qmd#sec:intro"));
+        assert!(!is_external("page.qmd?k=a:b"));
+        // A Windows drive letter is a path, not a one-letter scheme.
+        assert!(!is_external("C:\\docs\\page.qmd"));
+    }
+
     // ---- Phase 6: `resolve_to_project_root` (path normalization) ----
     //
     // Tests 8-15 from the Phase 6 sub-plan. Body-content link hrefs
@@ -1477,6 +1496,32 @@ mod tests {
             ),
             "https://example.com"
         );
+        assert!(diags.is_empty());
+    }
+
+    /// bd-scheme-href-path-normalized-w5zya82r symptom 1 — a body link
+    /// with a non-http scheme keeps its `//` on a nested page.
+    #[test]
+    fn body_href_custom_scheme_keeps_double_slash() {
+        let mut diags = Vec::new();
+        let idx = ProjectIndex::new(vec![profile("docs/page.qmd", "docs/page.html")]);
+        let r = website_resolver("docs/page.html");
+        for href in [
+            "positron://settings/positron.notebook.enabled",
+            "vscode://schemas/settings",
+        ] {
+            assert_eq!(
+                resolve_doc_relative_href(
+                    href,
+                    "docs/page.qmd",
+                    Some(&r),
+                    Some(&idx),
+                    None,
+                    &mut diags
+                ),
+                href
+            );
+        }
         assert!(diags.is_empty());
     }
 
@@ -1895,6 +1940,27 @@ mod tests {
         assert!(diags.is_empty());
     }
 
+    /// bd-scheme-href-path-normalized-w5zya82r symptom 2 — a nav href
+    /// with a non-http scheme on a depth-1 page must not be relativized
+    /// to `../javascript:void(0);`, and (symptom 1) must keep its `//`.
+    #[test]
+    fn nav_href_with_custom_scheme_passes_through_at_depth() {
+        let idx = ProjectIndex::new(vec![profile("about.qmd", "about.html")]);
+        let r = website_resolver("docs/api.html");
+        let mut diags = Vec::new();
+        for href in [
+            "javascript:void(0);",
+            "positron://settings/positron.notebook.enabled",
+            "vscode://schemas/settings",
+        ] {
+            assert_eq!(
+                resolve_href_for_html(href, Some(&r), Some(&idx), surf(), None, &mut diags),
+                href
+            );
+        }
+        assert!(diags.is_empty());
+    }
+
     /// bd-swpy test 2 — depth-2 page links to a target one
     /// directory deep. Output walks up two levels then descends.
     #[test]
@@ -2018,6 +2084,17 @@ mod tests {
         assert_eq!(
             resolve_static_resource_href("#sec", "index.qmd", Some(&r)),
             "#sec"
+        );
+    }
+
+    /// bd-scheme-href-path-normalized-w5zya82r — static-resource hrefs
+    /// with a non-http scheme pass through on a nested page.
+    #[test]
+    fn static_href_custom_scheme_passes_through() {
+        let r = website_resolver("docs/page.html");
+        assert_eq!(
+            resolve_static_resource_href("positron://settings/x", "docs/page.qmd", Some(&r)),
+            "positron://settings/x"
         );
     }
 

--- a/crates/quarto-navigation/Cargo.toml
+++ b/crates/quarto-navigation/Cargo.toml
@@ -10,6 +10,7 @@ description = "Document-model types for Quarto navigation (navbar, page footer, 
 quarto-config.workspace = true
 quarto-pandoc-types.workspace = true
 quarto-source-map.workspace = true
+quarto-util.workspace = true
 yaml-rust2.workspace = true
 
 [lints]

--- a/crates/quarto-navigation/src/sidebar.rs
+++ b/crates/quarto-navigation/src/sidebar.rs
@@ -1001,16 +1001,11 @@ fn collect_section_text_conflicts(
     }
 }
 
-/// External-URL classifier. Local copy here so `quarto-navigation`
-/// stays free of a `quarto-core` dep; semantics match
-/// `quarto-core::transforms::navigation_href::is_external`.
+/// External-URL classifier: any URI scheme or `//host` form. Same
+/// rule as `quarto-core::transforms::navigation_href::is_external`,
+/// via the shared `quarto_util` implementation.
 fn is_external_href(href: &str) -> bool {
-    href.starts_with("http://")
-        || href.starts_with("https://")
-        || href.starts_with("mailto:")
-        || href.starts_with("tel:")
-        || href.starts_with("ftp://")
-        || href.starts_with("//")
+    quarto_util::is_external_url(href)
 }
 
 #[cfg(test)]
@@ -1994,6 +1989,29 @@ mod tests {
             flat.len(),
             1,
             "external link should be excluded; got {:?}",
+            flat
+        );
+        assert_eq!(item_href(&flat[0]), Some("about.qmd"));
+    }
+
+    /// bd-scheme-href-path-normalized-w5zya82r — any scheme is external,
+    /// not just the allowlisted few: a `javascript:` or custom-scheme
+    /// link must not become a prev/next target.
+    #[test]
+    fn flatten_excludes_any_scheme_href() {
+        let cv = map(vec![(
+            "contents",
+            arr(vec![
+                s("about.qmd"),
+                s("javascript:void(0);"),
+                s("positron://settings/x"),
+            ]),
+        )]);
+        let flat = flatten_yaml(cv);
+        assert_eq!(
+            flat.len(),
+            1,
+            "scheme hrefs should be excluded; got {:?}",
             flat
         );
         assert_eq!(item_href(&flat[0]), Some("about.qmd"));

--- a/crates/quarto/tests/smoke-all/navigation/scheme-hrefs/_quarto.yml
+++ b/crates/quarto/tests/smoke-all/navigation/scheme-hrefs/_quarto.yml
@@ -1,0 +1,16 @@
+project:
+  type: website
+website:
+  title: Scheme hrefs
+  navbar:
+    left:
+      - text: Home
+        href: index.qmd
+      - text: Deep page
+        href: sub/page.qmd
+      - text: JS
+        href: "javascript:void(0);"
+      - text: Mail
+        href: "mailto:someone@example.com"
+      - text: Custom scheme
+        href: "positron://settings/positron.notebook.enabled"

--- a/crates/quarto/tests/smoke-all/navigation/scheme-hrefs/index.qmd
+++ b/crates/quarto/tests/smoke-all/navigation/scheme-hrefs/index.qmd
@@ -1,0 +1,32 @@
+---
+title: Scheme hrefs (top level)
+format: html
+_quarto:
+  tests:
+    html:
+      noErrors: true
+      ensureFileRegexMatches:
+        - [
+            # Body links: any URI scheme passes through byte-for-byte.
+            'href="positron://settings/positron\.notebook\.enabled"',
+            'href="vscode://schemas/settings"',
+            'href="https://example\.com/settings/x"',
+            'href="mailto:someone@example\.com"',
+            # Navbar items likewise.
+            'href="javascript:void\(0\);"',
+          ]
+        - [
+            # bd-scheme-href-path-normalized-w5zya82r symptom 1:
+            # `//` must not collapse to `/`.
+            'positron:/settings',
+            'vscode:/schemas',
+          ]
+---
+
+Every link below must reach the rendered HTML byte-for-byte
+(bd-scheme-href-path-normalized-w5zya82r).
+
+- [positron settings](positron://settings/positron.notebook.enabled)
+- [vscode settings](vscode://schemas/settings)
+- [https](https://example.com/settings/x)
+- [mailto](mailto:someone@example.com)

--- a/crates/quarto/tests/smoke-all/navigation/scheme-hrefs/sub/page.qmd
+++ b/crates/quarto/tests/smoke-all/navigation/scheme-hrefs/sub/page.qmd
@@ -13,12 +13,15 @@ _quarto:
             'href="positron://settings/positron\.notebook\.enabled"',
           ]
         - [
-            # bd-scheme-href-path-normalized-w5zya82r symptom 2: nav
-            # hrefs with a scheme must not gain `../` per level ...
+            # Guard only: the smoke-all runner does not relativize nav
+            # hrefs on nested pages (bd-sqa9h5ne), so these cannot fail here.
+            # Symptom 2 (`../javascript:void(0);` under `q2 render`) is
+            # pinned by the unit test
+            # nav_href_with_custom_scheme_passes_through_at_depth.
             '\.\./javascript:',
             '\.\./mailto:',
             '\.\./positron:',
-            # ... and (symptom 1) must keep their `//`.
+            # Symptom 1: the `//` must survive at depth too.
             'positron:/settings',
           ]
 ---

--- a/crates/quarto/tests/smoke-all/navigation/scheme-hrefs/sub/page.qmd
+++ b/crates/quarto/tests/smoke-all/navigation/scheme-hrefs/sub/page.qmd
@@ -1,0 +1,26 @@
+---
+title: Scheme hrefs (one level deep)
+format: html
+_quarto:
+  tests:
+    html:
+      noErrors: true
+      ensureFileRegexMatches:
+        - [
+            # Navbar items with a scheme are emitted unchanged at depth.
+            'href="javascript:void\(0\);"',
+            'href="mailto:someone@example\.com"',
+            'href="positron://settings/positron\.notebook\.enabled"',
+          ]
+        - [
+            # bd-scheme-href-path-normalized-w5zya82r symptom 2: nav
+            # hrefs with a scheme must not gain `../` per level ...
+            '\.\./javascript:',
+            '\.\./mailto:',
+            '\.\./positron:',
+            # ... and (symptom 1) must keep their `//`.
+            'positron:/settings',
+          ]
+---
+
+A page one directory deep; the navbar above is what's under test.


### PR DESCRIPTION
Fixes `bd-scheme-href-path-normalized-w5zya82r`.

While porting the Positron docs I noticed every `positron://settings/…` deep link came out of q2 as `positron:/settings/…` — 241 of them across 52 pages, and none of the sweeps (text diff, asset checker, lychee) can see an href. Quarto 1 emits them unchanged. On a page one directory deep, navbar hrefs like `javascript:void(0);` also came out as `../javascript:void(0);`.

Both turn out to be the same bug. `navigation_href::is_external` was a hardcoded prefix list — `http://`, `https://`, `mailto:`, `tel:`, `ftp://`, `//`, `data:` — and anything not on it was treated as a project-relative path and normalized: `//` collapses to `/`, and the nav call sites additionally relativize against page depth. The `data:` entry had been added by an earlier fix whose comment already diagnosed this exact failure mode; it just fixed one scheme rather than the class.

We already had the right primitive: `quarto_util::is_external_url` does real RFC-3986 scheme detection (first `:`, scheme of at least two chars, letter start, `[A-Za-z0-9+.-]*`, plus the `//host` form) and is used at ten other sites. So the change is mostly deletion. What I hadn't expected is that the tree had *seven* hand-rolled copies of the allowlist, each a slightly different subset — one had `javascript:`, two used `contains("://")`, none agreed. All seven now delegate to the one classifier:

- `navigation_href::is_external` (five href resolvers plus `navigation_active::mark_active`)
- `sidebar_membership::is_external_or_anchor`
- `quarto-navigation`'s `is_external_href` for prev/next page nav — this adds a `quarto-util` dep, which has no in-tree deps of its own, so no cycle
- the two llms sites (`llms_post_render::resolve_href`, `llms::retarget_href`) — these were `contains("://")` and so already tolerated `positron://`; they're unified for consistency and their tests pin rather than fix behaviour
- the listing `substitute.rs` and `feed/reader_ext.rs` copies, both deleted (the latter was a local `fn is_external_url` shadowing the real one)

The one ambiguity this introduces is already documented on the classifier: a relative path whose first segment contains a colon (`ab:cd.qmd`, legal on Unix) reads as a URL. That's Q1's trade-off too, and a colon isn't a legal filename character on Windows anyway. `C:\…` is unaffected — the two-char scheme minimum exists precisely so drive letters stay paths, and none of the old lists matched them either. I also reworded the carve-out in `claude-notes/designs/path-resolution-model.md`, which described the external set as "`//host`, `data:`, full URLs" — an allowlist in prose — to name `is_external_url` as the sole classifier.

Tests: ten unit tests across the seven sites, seven of which were red before the fix (the nav one failed with exactly `../javascript:void(0);`), plus a small website fixture under `smoke-all/navigation/scheme-hrefs/` with a top-level page and a `sub/` page. Workspace suite is 13377 passed, 0 failed; clippy and `xtask lint` clean. I also rendered the fixture and both repro projects from the strand through `q2 render` and diffed the hrefs against the Q1 output: byte-identical on every page, and real page links (`../index.html`) still relativize.

Two things I scoped out and filed:

- `bd-pa394mk7`: five more copies of the same pattern gate image/font `src` values (`listing/helpers.rs`, `feed/binding.rs`, `resource_collector.rs`, `brand_layer.rs`, `project/mod.rs`). A custom-scheme image `src` is rare enough that I didn't want to widen this PR, but it's the same class and should get the same treatment.
- `bd-sqa9h5ne`: the smoke-all runner renders nested project pages without nav-href relativization, unlike `q2 render`, so the fixture can only pin the `//` collapse; the `../` symptom is pinned by the unit test instead. Worth fixing in the runner — no project fixture with subdirectories can currently catch that class of bug.

Plan and end-to-end record: `claude-notes/plans/2026-08-25-scheme-href-path-normalized.md`.
