### PR TITLE
Fix #581: inline brand: in front matter is plain YAML, never markdown (bd-vk4olgv6)

### DIFF
--- a/claude-notes/issue-reports/581/_brand.yml
+++ b/claude-notes/issue-reports/581/_brand.yml
@@ -1,0 +1,2 @@
+color:
+  background: "#b22222"

--- a/claude-notes/issue-reports/581/control-project/_quarto.yml
+++ b/claude-notes/issue-reports/581/control-project/_quarto.yml
@@ -1,0 +1,5 @@
+project:
+  type: default
+brand:
+  color:
+    background: "#b22222"

--- a/claude-notes/issue-reports/581/control-project/index.qmd
+++ b/claude-notes/issue-reports/581/control-project/index.qmd
@@ -1,0 +1,5 @@
+---
+format: html
+---
+
+Hello.

--- a/claude-notes/issue-reports/581/exp-md-tag/_quarto.yml
+++ b/claude-notes/issue-reports/581/exp-md-tag/_quarto.yml
@@ -1,0 +1,7 @@
+project:
+  type: default
+brand:
+  meta:
+    name: !md "Acme *Corp*"
+  color:
+    background: "#b22222"

--- a/claude-notes/issue-reports/581/exp-md-tag/index.qmd
+++ b/claude-notes/issue-reports/581/exp-md-tag/index.qmd
@@ -1,0 +1,5 @@
+---
+format: html
+---
+
+Hello.

--- a/claude-notes/issue-reports/581/exp-meta/_quarto.yml
+++ b/claude-notes/issue-reports/581/exp-meta/_quarto.yml
@@ -1,0 +1,10 @@
+project:
+  type: default
+brand:
+  meta:
+    name: Acme
+    description: |
+      Acme Corporation is a leading provider of innovative solutions.
+    founded: 1952
+  color:
+    background: "#b22222"

--- a/claude-notes/issue-reports/581/exp-meta/index.qmd
+++ b/claude-notes/issue-reports/581/exp-meta/index.qmd
@@ -1,0 +1,5 @@
+---
+format: html
+---
+
+Hello.

--- a/claude-notes/issue-reports/581/repro-file.qmd
+++ b/claude-notes/issue-reports/581/repro-file.qmd
@@ -1,0 +1,6 @@
+---
+format: html
+brand: _brand.yml
+---
+
+Hello.

--- a/claude-notes/issue-reports/581/repro-inline.qmd
+++ b/claude-notes/issue-reports/581/repro-inline.qmd
@@ -1,0 +1,8 @@
+---
+format: html
+brand:
+  color:
+    background: "#b22222"
+---
+
+Hello.

--- a/claude-notes/issue-reports/581/triage.md
+++ b/claude-notes/issue-reports/581/triage.md
@@ -116,7 +116,10 @@ fix below eliminates this too.
   consulted for *untagged* scalars in both contexts; in ProjectConfig context
   `PlainString` is a no-op. Explicit tags (`!md`, `!str`, …) take earlier
   branches and still win — an author writing `!md` inside `brand:` still gets
-  inlines and still gets the (correct) Q-14-1 rejection.
+  inlines. (An earlier draft of this triage said those inlines then hit a
+  "correct" Q-14-1 rejection in the walker; that is superseded — per the
+  user's approval condition, the walker now learns the plain-text
+  projection for `!md` values. See the scope addition in the fix plan.)
 - **Does `format.*.brand` need an entry?** No consumer reads it (see
   Localization); per the table's "small and boring" rule, skip it.
 - **Should any field under `brand:` be excluded from the subtree rule —
@@ -179,6 +182,25 @@ fix below eliminates this too.
 
 ## Fix plan (TDD)
 
+**Scope addition (user-requested, 2026-08-25):** the user approves the
+subtree-PlainString proposal **on the condition that `!md` works** as the
+documented escape hatch for authors who want markdown in a `brand.meta`
+value, and asks that the q2 brand docs reference it. Verified: the tag
+beats the annotation at *load* time by construction (the annotation
+consult lives in the untagged branch, `meta.rs:407`; explicit tags take
+earlier branches at `:369-381`) — but today an `!md` value anywhere under
+`brand:` still **kills the render** at the strict walker, even in
+`_quarto.yml`, even on a known field (reproduced: fixture `exp-md-tag/`,
+`meta.name: !md "Acme *Corp*"` → Q-14-1). So the plan gains a walker
+change and a docs task, below. Projection semantics: the Brand object
+receives the **plain-text projection** of an `!md` value
+(`as_plain_text`, markup consumed); the merged metadata tree retains the
+rich inlines for q2-internal metadata consumers. The untagged path
+(annotation) remains byte-preserving. Note: `!md` on a *custom* meta
+field only fully materializes once bd-8q5o86r1 lifts `BrandMeta`'s
+`deny_unknown_fields`; `!md` on known fields (e.g. `meta.name`) works
+as soon as this fix lands.
+
 Phase 1 — tests first, verify each fails before implementing:
 
 1. `crates/pampa/src/pandoc/meta_annotations.rs` unit tests: a subtree pattern
@@ -198,6 +220,14 @@ Phase 1 — tests first, verify each fails before implementing:
    - `brand: _brand.yml` front matter renders with no Q-1-20 (assert on the
      render result's collected diagnostics; if the harness doesn't expose
      them, capture warnings via the non-quiet path).
+4. Tag-override tests (the user's approval condition):
+   - pampa: `!md`-tagged string under `brand.meta` yields `PandocInlines`
+     in **both** contexts (tag beats annotation); `!str` yields `Scalar`.
+   - quarto-sass unit test: a brand config whose `meta.name` leaf is
+     `PandocInlines` (as `!md` produces) resolves without Q-14-1, and the
+     deserialized Brand carries the plain-text projection.
+   - e2e (the `exp-md-tag/` fixture shape): `meta.name: !md "Acme *Corp*"`
+     in `_quarto.yml` renders successfully — fails today, must pass after.
 
 Phase 2 — implementation:
 
@@ -208,13 +238,28 @@ Phase 2 — implementation:
 5. Add the entry `(&["brand", "**"], Interpretation::PlainString)`, with a
    comment citing GH #581 / bd-vk4olgv6.
 6. Update the module docs' path-semantics section for `**`.
+7. Walker tolerance for explicit `!md`
+   (`crates/quarto-sass/src/config.rs:864`, `config_value_to_yaml_value`):
+   map `PandocInlines` to `serde_yaml::Value::String(<as_plain_text>)`
+   instead of erroring — after step 5 the only way inlines reach a brand
+   block is an explicit `!md`, so this honors the author's tag with the
+   plain-text projection rather than failing the render. Keep the error
+   for `PandocBlocks` (multi-block markdown has no sensible scalar
+   projection; `as_plain_text` doesn't cover it), with the message
+   extended to say single-paragraph `!md` or a plain string is expected.
+8. Docs (`docs/guides/authoring/brand.qmd`): state that `brand:` values
+   are plain YAML — never markdown-parsed, matching the brand-yml spec
+   and standalone `_brand.yml` files, so `!str` is never needed — and
+   that `!md` is available when a `meta` value should be treated as
+   markdown by Quarto's metadata machinery (noting the Brand object sees
+   its plain text). Per repo rules, docs are usage-facing: no internals.
 
 Phase 3 — verification:
 
-7. `cargo nextest run --workspace` (pampa change can affect downstream crates).
-8. `cargo xtask verify` — **full**, not `--skip-hub-build`: pampa is in the
+9. `cargo nextest run --workspace` (pampa change can affect downstream crates).
+10. `cargo xtask verify` — **full**, not `--skip-hub-build`: pampa is in the
    hub-client WASM closure.
-9. End-to-end through the real binary: re-run the three repro commands above;
+11. End-to-end through the real binary: re-run the three repro commands above;
    (a) must render with the color in the theme CSS, (b) must be warning-free,
    (c) must stay unchanged. Inspect outputs, record in the session summary.
 

--- a/claude-notes/issue-reports/581/triage.md
+++ b/claude-notes/issue-reports/581/triage.md
@@ -1,0 +1,196 @@
+# Issue #581 — inline `brand:` block in front matter always fails with Q-14-1
+
+- **GitHub**: https://github.com/quarto-dev/q2/issues/581
+- **Reporter**: @mcanouil (Mickaël Canouil), 2026-08-23
+- **Triage date**: 2026-08-25
+- **Worktree**: `.worktrees/issue-581` (branch `issue-581`, based on `main` @ `05b6fd75c`)
+- **Braid strand**: bd-vk4olgv6
+- **Scope**: both halves of the report — (a) inline `brand:` block in front matter fails with Q-14-1, (b) `brand: _brand.yml` in front matter emits a spurious Q-1-20 warning. The third item the reporter mentions (per-colour `light`/`dark`, GH #580) is already fixed and covered by `unified_brand_light_dark_renders_both_stylesheets` in `crates/quarto-core/tests/integration/brand_render.rs`; it is out of scope here.
+
+## Summary
+
+The reporter's analysis is correct in every particular, and both halves reproduce
+exactly as described at `main` @ `05b6fd75c`. Front matter is converted with
+`InterpretationContext::DocumentMetadata`, which parses every untagged string as
+markdown into `ConfigValueKind::PandocInlines`; the brand deserializer's
+YAML-rebuilding walker rejects that variant, so **any** inline `brand:` block in
+front matter fails with Q-14-1, while the identical block in `_quarto.yml`
+(ProjectConfig context, strings stay `Scalar`) renders fine. Real bug; the fix is
+small and has an established home: the load-time key-path annotation table that
+GH #457 introduced for exactly this class ("protecting a machine-facing key from
+markdown"), extended with subtree matching. Filed as bd-vk4olgv6.
+
+## Reproduction
+
+Fixtures in this directory. All commands run from the repo root with the binary
+built at `05b6fd75c`; outputs inspected by hand.
+
+**(a) Inline block — fails (should render):**
+
+```bash
+cargo run --bin q2 -- render claude-notes/issue-reports/581/repro-inline.qmd
+```
+
+```text
+Error: [Q-14-1] Invalid theme configuration
+ 5 │     background: "#b22222"
+   │                 ────┬────
+   │                     ╰────── brand block must be plain YAML, not Pandoc inlines/blocks
+1 error
+```
+
+**(b) Brand-file form — renders but warns (should be silent):**
+
+```bash
+cargo run --bin q2 -- render claude-notes/issue-reports/581/repro-file.qmd
+```
+
+```text
+Warning: [Q-1-20] Failed to parse metadata value as markdown
+ 3 │ brand: _brand.yml
+   │        ╰──────────── This is the opening '_' mark.
+1 warning
+```
+
+The render succeeds and the brand is applied — `repro-file_files/styles.css`
+contains `b22222` (inspected).
+
+**(c) Control — same block in `_quarto.yml` renders cleanly:**
+`control-project/` here; `q2 render control-project` succeeds with no
+diagnostics, and the compiled theme CSS
+(`index_files/quarto/quarto-theme-*.css`) contains `b22222` (inspected).
+
+## Localization
+
+The reporter's `file:line` pointers all check out:
+
+- `crates/pampa/src/pandoc/meta.rs:433-448` — untagged-string default: in
+  `DocumentMetadata` context the string is parsed as markdown
+  (`parse_yaml_string_as_markdown_to_config`), yielding
+  `ConfigValueKind::PandocInlines` for every string leaf under `brand:`. On
+  parse *failure* (the `_brand.yml` underscore) it warns Q-1-20 and falls back
+  to an error-recovery `Span` whose plain text is the literal — which is why the
+  path form limps through.
+- `crates/pampa/src/pandoc/meta.rs:407-431` — the annotation-table consult
+  (`meta_annotations::annotated_interpretation`) that replaces the untagged
+  default per key path. This is the seam the fix uses.
+- `crates/pampa/src/pandoc/meta_annotations.rs` — the table itself (bd-v7ixzsp5,
+  GH #457). Its own docs say: "protecting a machine-facing key from markdown
+  goes here". Current matching is **exact-length only** (`*` = exactly one
+  segment); it cannot yet express "the whole subtree under `brand`".
+- `crates/quarto-sass/src/config.rs:799-829` (`extract_single_brand_ref`) — path
+  form goes through `config_value_as_text` → `as_plain_text()`, which tolerates
+  `PandocInlines`; inline form goes through `config_value_to_yaml_value`.
+- `crates/quarto-sass/src/config.rs:864-869` (`config_value_to_yaml_value`) —
+  rejects `PandocInlines`/`PandocBlocks` with the Q-14-1 message, anchored at
+  the first string leaf. This is where repro (a) dies.
+- Consumers read only the **top-level** `brand:` key of merged metadata
+  (`config.get("brand")` at `crates/quarto-sass/src/config.rs:304` and `:630`);
+  there is no `format.*.brand` read, so one table entry suffices.
+- Working model to copy from: `_quarto.yml` path,
+  `InterpretationContext::ProjectConfig` (`crates/quarto-core/src/project/mod.rs:169`),
+  which stores `Scalar(String)` leaves — the shape the brand deserializer wants.
+
+A third, quieter defect falls out of the same root cause: a brand string value
+that parses *successfully* as markdown is silently rewritten before
+`as_plain_text()` flattening (e.g. emphasis markers are consumed). The load-time
+fix below eliminates this too.
+
+## Open questions — resolved during triage
+
+- **Where should the fix live — pampa load time, or tolerate `PandocInlines` in
+  quarto-sass?** Load time. `meta_annotations.rs`'s own decision table says
+  machine-facing keys are protected there; a consumer-side
+  `as_plain_text()` flatten in `config_value_to_yaml_value` would be lossy
+  (markdown-mangled values accepted silently) and would leave the Q-1-20
+  warning half unfixed. Keep the walker strict.
+- **Which `Interpretation` for the subtree?** `PlainString`. It reproduces the
+  known-good ProjectConfig behavior exactly, for both the path form and inline
+  block leaves. `Path` was considered for the `brand: <file>` form but would
+  newly enroll the value in metadata-merge path rebasing; the path-resolution
+  contract (`claude-notes/designs/path-resolution-model.md`, consumption-site
+  inventory) already records `brand:` in `quarto-sass/src/config.rs` as
+  "project-root by construction", so `PlainString` + the existing
+  project-dir join is per contract. No behavior change, no scope-out needed.
+- **Does the annotation break `_quarto.yml` or explicit tags?** No. The table is
+  consulted for *untagged* scalars in both contexts; in ProjectConfig context
+  `PlainString` is a no-op. Explicit tags (`!md`, `!str`, …) take earlier
+  branches and still win — an author writing `!md` inside `brand:` still gets
+  inlines and still gets the (correct) Q-14-1 rejection.
+- **Does `format.*.brand` need an entry?** No consumer reads it (see
+  Localization); per the table's "small and boring" rule, skip it.
+- **Was pre-flight verify green?** Effectively yes: one test failed in the full
+  13k run — `quarto-core engine::ts_engine::tests::test_race_free_instance_exclusive`
+  — and passed immediately in isolation (0.3s). Flaky under sibling-checkout
+  load; filed as bd-xxpbo8cf (discovered-from bd-vk4olgv6).
+
+## Fix plan (TDD)
+
+Phase 1 — tests first, verify each fails before implementing:
+
+1. `crates/pampa/src/pandoc/meta_annotations.rs` unit tests: a subtree pattern
+   for `brand` matches `["brand"]`, `["brand","color","background"]`,
+   `["brand","light"]`; does not match `["my","brand"]`, `["brandx"]`;
+   existing exact-length entries unaffected.
+2. `crates/pampa/src/pandoc/meta.rs` tests (module `tests`, ~line 646):
+   DocumentMetadata conversion of `brand: {color: {background: "#b22222"}}`
+   yields `Scalar` string leaves (not `PandocInlines`); `brand: _brand.yml`
+   yields `Scalar("_brand.yml")` with **zero** diagnostics.
+3. `crates/quarto-core/tests/integration/brand_render.rs` e2e regressions,
+   modeled on `unified_brand_light_dark_renders_both_stylesheets` (the GH #580
+   test, which already drives `render_to_file`):
+   - exact GH #581 repro: front matter with inline
+     `brand: {color: {background: "#b22222"}}` renders and the compiled theme
+     CSS contains the color;
+   - `brand: _brand.yml` front matter renders with no Q-1-20 (assert on the
+     render result's collected diagnostics; if the harness doesn't expose
+     them, capture warnings via the non-quiet path).
+
+Phase 2 — implementation:
+
+4. Extend `ANNOTATIONS` matching with a subtree form: a trailing `"**"` pattern
+   segment matches zero or more remaining path segments (so `["brand", "**"]`
+   covers `brand` itself and every descendant). Keep `*` = exactly one segment,
+   exact-length otherwise, no suffix matching.
+5. Add the entry `(&["brand", "**"], Interpretation::PlainString)`, with a
+   comment citing GH #581 / bd-vk4olgv6.
+6. Update the module docs' path-semantics section for `**`.
+
+Phase 3 — verification:
+
+7. `cargo nextest run --workspace` (pampa change can affect downstream crates).
+8. `cargo xtask verify` — **full**, not `--skip-hub-build`: pampa is in the
+   hub-client WASM closure.
+9. End-to-end through the real binary: re-run the three repro commands above;
+   (a) must render with the color in the theme CSS, (b) must be warning-free,
+   (c) must stay unchanged. Inspect outputs, record in the session summary.
+
+## Outcome / recommended next step
+
+Filed **bd-vk4olgv6** (bug, p1) with the fix scope above. Discovered work:
+**bd-xxpbo8cf** (flaky `test_race_free_instance_exclusive` under load).
+Fix can proceed on this branch (`issue-581`) as a follow-up commit.
+
+## Verification commands used
+
+```bash
+gh issue view 581 --repo quarto-dev/q2 --json title,body,author,createdAt,labels,comments
+gh issue view 457 --repo quarto-dev/q2 --json title,state,body   # annotation-table precedent (closed)
+gh issue view 580 --repo quarto-dev/q2 --json title,state,body   # per-colour light/dark (closed)
+cargo xtask verify --skip-hub-build                              # pre-flight (1 flaky fail, see above)
+cargo nextest run -p quarto-core -E 'test(test_race_free_instance_exclusive)'  # isolated: PASS
+cargo xtask create-worktree --issue 581
+cargo run --bin q2 -- render claude-notes/issue-reports/581/repro-inline.qmd   # Q-14-1 error
+cargo run --bin q2 -- render claude-notes/issue-reports/581/repro-file.qmd     # Q-1-20 warning, renders
+cargo run --bin q2 -- render claude-notes/issue-reports/581/control-project    # clean render
+grep -rlo 'b22222' <render outputs>                                            # brand applied
+```
+
+## Cross-references
+
+- bd-vk4olgv6 — this bug; bd-xxpbo8cf — flaky test discovered during pre-flight
+- bd-v7ixzsp5 / GH #456, #457 — the annotation table this fix extends
+- bd-y89ihf0i — the `as_str()` vs `as_plain_text()` audit (same PandocInlines class, consumer side)
+- GH #580 — per-colour light/dark (closed; test at `brand_render.rs:204`)
+- `claude-notes/designs/path-resolution-model.md` — `brand:` is "project-root by construction"
+- `CLAUDE.md` § metadata-as-str lint — related but not implicated (the walker here is not an `as_str()` read)

--- a/claude-notes/issue-reports/581/triage.md
+++ b/claude-notes/issue-reports/581/triage.md
@@ -263,6 +263,47 @@ Phase 3 — verification:
    (a) must render with the color in the theme CSS, (b) must be warning-free,
    (c) must stay unchanged. Inspect outputs, record in the session summary.
 
+## Implementation record (2026-08-25, same branch)
+
+All plan items implemented in TDD order — every new test was run and observed
+failing for the predicted reason before the corresponding change:
+
+- [x] `meta_annotations.rs`: subtree tests (`brand`, descendants, custom
+      `meta` fields; no false positives; exact-length entries unchanged) —
+      failed with `None`, pass after.
+- [x] `meta.rs`: `brand_inline_block_leaves_stay_plain_yaml`,
+      `brand_path_string_is_plain_with_no_warning`,
+      `brand_meta_value_with_markdown_chars_survives_verbatim` (the failure
+      output showed the live mangling: `Acme *Corp*` → `Emph`),
+      `brand_explicit_md_tag_overrides_annotation`.
+- [x] `quarto-sass`: `inline_brand_md_tagged_leaf_projects_to_plain_text` —
+      failed at extraction, passes with the walker projection.
+- [x] `brand_render.rs` e2e: `front_matter_inline_brand_block_renders`,
+      `front_matter_brand_file_renders_without_markdown_warning` (asserts no
+      Q-1-20 in `render_output.diagnostics`),
+      `front_matter_md_tagged_brand_meta_value_renders`.
+- [x] Implementation: `**` subtree matching + `(&["brand", "**"],
+      PlainString)` entry + module-doc update in `meta_annotations.rs`;
+      `PandocInlines` → plain-text projection (PandocBlocks keeps a
+      clearer error) in `config_value_to_yaml_value`.
+- [x] Docs: `docs/guides/authoring/brand.qmd` — new "Brand values are plain
+      YAML" section documenting the semantics and the `!md` escape hatch.
+- [x] E2e through the real binary (`target/debug/q2` at the fix commit):
+      repro-inline renders and `repro-inline_files/styles.css` contains
+      `b22222`; repro-file renders with **zero** warnings (exit 0, no
+      Q-1-20 in output — inspected); control-project unchanged; exp-md-tag
+      (`meta.name: !md "Acme *Corp*"`) renders. exp-meta still fails on
+      `unknown field description` — expected, that is bd-8q5o86r1.
+- [x] `cargo nextest run --workspace`: 13398 passed, 199 skipped.
+- [x] `cargo xtask lint`: clean.
+- [x] Full `cargo xtask verify` (WASM leg included — pampa is in the
+      hub-client closure): all 14 steps passed.
+- [x] Docs page renders (`q2 render docs/guides/authoring/brand.qmd`; the
+      project-level "Declared resource docs/examples" error is the known
+      fresh-worktree staging gap bd-u7kdy6fy, unrelated) and the built HTML
+      contains the new section with the highlighted `!md` example —
+      inspected.
+
 ## Outcome / recommended next step
 
 Filed **bd-vk4olgv6** (bug, p1) with the fix scope above. Discovered work:

--- a/claude-notes/issue-reports/581/triage.md
+++ b/claude-notes/issue-reports/581/triage.md
@@ -119,6 +119,33 @@ fix below eliminates this too.
   inlines and still gets the (correct) Q-14-1 rejection.
 - **Does `format.*.brand` need an entry?** No consumer reads it (see
   Localization); per the table's "small and boring" rule, skip it.
+- **Should any field under `brand:` be excluded from the subtree rule —
+  specifically `brand.meta`?** No — checked against the brand-yml spec
+  (https://posit-dev.github.io/brand-yml/, per-field page
+  `brand/meta.html`, 2026-08-25). `meta` is the spec's loose corner: "Both
+  `name` and `link` are optional fields, and you can add additional fields
+  as needed for your specific use case", and its example carries
+  `description: |` prose and `founded: 1952`. But the spec defines **no
+  markdown semantics anywhere** — `description: |` is a YAML block scalar,
+  and every other consumer of a `_brand.yml` file (Quarto 1, Python, R
+  tooling) reads it as plain YAML. Three reasons `meta` stays inside the
+  PlainString subtree: (1) parity with the file form and with `_quarto.yml`
+  is this issue's expected behavior, and both give literal strings for meta
+  leaves; (2) excluding `meta` would leave its front-matter leaves as
+  `PandocInlines`, which `config_value_to_yaml_value` rejects — the exact
+  Q-14-1 crash, relocated into `meta`; (3) if Quarto ever renders
+  `meta.description` as markdown, the right seam is the transform-time
+  `MARKDOWN_CONFIG_PATHS` re-parse, which consumes `Scalar(String)` — so
+  load-time PlainString is a precondition for that future, not an obstacle.
+  An author who genuinely wants markdown in a custom meta field can still
+  write `!md` (explicit tags beat annotations).
+  Checking this surfaced a separate pre-existing gap: q2's `BrandMeta`
+  (`crates/quarto-brand/src/types.rs:104-112`) is
+  `#[serde(deny_unknown_fields)]` with only `name` + `link`, so the spec's
+  own `meta.description`/`founded` example fails to deserialize even via
+  `_quarto.yml` ("unknown field `description`, expected `name` or `link`" —
+  reproduced, fixture `exp-meta/`). Filed as bd-8q5o86r1
+  (discovered-from bd-vk4olgv6); orthogonal to this fix.
 - **Was pre-flight verify green?** Effectively yes: one test failed in the full
   13k run — `quarto-core engine::ts_engine::tests::test_race_free_instance_exclusive`
   — and passed immediately in isolation (0.3s). Flaky under sibling-checkout
@@ -168,7 +195,8 @@ Phase 3 — verification:
 ## Outcome / recommended next step
 
 Filed **bd-vk4olgv6** (bug, p1) with the fix scope above. Discovered work:
-**bd-xxpbo8cf** (flaky `test_race_free_instance_exclusive` under load).
+**bd-xxpbo8cf** (flaky `test_race_free_instance_exclusive` under load) and
+**bd-8q5o86r1** (`BrandMeta` rejects spec-legal extra meta fields).
 Fix can proceed on this branch (`issue-581`) as a follow-up commit.
 
 ## Verification commands used
@@ -189,6 +217,8 @@ grep -rlo 'b22222' <render outputs>                                            #
 ## Cross-references
 
 - bd-vk4olgv6 — this bug; bd-xxpbo8cf — flaky test discovered during pre-flight
+- bd-8q5o86r1 — `BrandMeta` deny_unknown_fields vs spec's open `meta` (discovered)
+- brand-yml spec: https://posit-dev.github.io/brand-yml/ (meta: `brand/meta.html`)
 - bd-v7ixzsp5 / GH #456, #457 — the annotation table this fix extends
 - bd-y89ihf0i — the `as_str()` vs `as_plain_text()` audit (same PandocInlines class, consumer side)
 - GH #580 — per-colour light/dark (closed; test at `brand_render.rs:204`)

--- a/claude-notes/issue-reports/581/triage.md
+++ b/claude-notes/issue-reports/581/triage.md
@@ -139,6 +139,32 @@ fix below eliminates this too.
   load-time PlainString is a precondition for that future, not an obstacle.
   An author who genuinely wants markdown in a custom meta field can still
   write `!md` (explicit tags beat annotations).
+  **Follow-up question (user): custom fields under `meta` are unknown
+  content — under Pandoc-inherited metadata semantics, shouldn't they be
+  markdown rather than raw strings? Basis for choosing raw strings,
+  verified against Quarto 1** (`external-sources/quarto-cli/src/project/project-shared.ts`,
+  `resolveBrand` / the `fileName !== undefined` branch, ~lines 669-718):
+  Q1 supports inline brand blocks in front matter and reads them via
+  `project.fileMetadata(fileName)` — its own js-yaml front-matter read —
+  then hands the raw object to `new Brand(...)` / `splitUnifiedBrand(...)`.
+  Pandoc's markdown metadata treatment is **not** in that path: in Q1, a
+  custom `meta` leaf like `notice: This is [a link](https://example.com)`
+  reaches the Brand object as the literal string. Pandoc-style markdown
+  semantics apply to metadata that flows into the rendered document
+  (template interpolation); brand is consumed pre-Pandoc as machine
+  config, and no consumer (Q1 or q2) renders `meta` fields into documents
+  — they are passthrough data for other programs. Mechanically, q2 has no
+  lossless channel for `PandocInlines` through the brand pipeline either:
+  the deserialization target is plain data, so markdown interpretation of
+  an unknown leaf can only error (today's Q-14-1) or be flattened back to
+  a mangled string. A raw string is the one representation that preserves
+  the author's bytes for an unknown downstream consumer, which can parse
+  markdown itself if it wants to — exactly as it would when reading a
+  standalone `_brand.yml`. This *is* a policy choice, not a forced move:
+  if `meta` custom fields were ever deemed document-facing prose, the
+  Pandoc-consistent alternative would be to scope the annotation to the
+  typed keys only — but that would today re-crash on `meta` and diverge
+  from both the file form and Q1.
   Checking this surfaced a separate pre-existing gap: q2's `BrandMeta`
   (`crates/quarto-brand/src/types.rs:104-112`) is
   `#[serde(deny_unknown_fields)]` with only `name` + `link`, so the spec's

--- a/crates/pampa/src/pandoc/meta.rs
+++ b/crates/pampa/src/pandoc/meta.rs
@@ -818,6 +818,100 @@ mod tests {
     }
 
     // ─────────────────────────────────────────────────────────────
+    // `brand:` subtree is plain YAML (bd-vk4olgv6, GH #581).
+    //
+    // Brand values are machine-facing configuration, defined by the
+    // brand-yml spec as plain YAML and consumed identically from
+    // `_brand.yml`, `_quarto.yml`, and front matter. The markdown
+    // default either failed the render (inline block → Q-14-1 in
+    // quarto-sass), warned spuriously (`brand: _brand.yml` → Q-1-20
+    // on the underscore), or silently rewrote values that parse as
+    // markdown.
+    // ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn brand_inline_block_leaves_stay_plain_yaml() {
+        let (result, diags) = convert_doc_meta("brand:\n  color:\n    background: \"#b22222\"\n");
+        let bg = result
+            .get("brand")
+            .and_then(|b| b.get("color"))
+            .and_then(|c| c.get("background"))
+            .expect("brand.color.background");
+        assert!(
+            matches!(
+                &bg.value,
+                ConfigValueKind::Scalar { yaml: Yaml::String(s), .. } if s == "#b22222"
+            ),
+            "brand leaves must stay Scalar, never PandocInlines; got {:?}",
+            bg.value
+        );
+        assert!(diags.is_empty(), "got {:?}", diags);
+    }
+
+    #[test]
+    fn brand_path_string_is_plain_with_no_warning() {
+        // The leading underscore of `_brand.yml` used to be read as an
+        // unclosed emphasis mark → spurious Q-1-20.
+        let (result, diags) = convert_doc_meta("brand: _brand.yml\n");
+        let brand = result.get("brand").expect("brand");
+        assert!(
+            matches!(
+                &brand.value,
+                ConfigValueKind::Scalar { yaml: Yaml::String(s), .. } if s == "_brand.yml"
+            ),
+            "got {:?}",
+            brand.value
+        );
+        assert!(
+            diags.is_empty(),
+            "no Q-1-20 markdown-parse warning for a brand path; got {:?}",
+            diags
+        );
+    }
+
+    #[test]
+    fn brand_meta_value_with_markdown_chars_survives_verbatim() {
+        // A value that *succeeds* as markdown used to be silently
+        // rewritten (emphasis markers consumed). Bytes must survive.
+        let (result, diags) = convert_doc_meta("brand:\n  meta:\n    name: \"Acme *Corp*\"\n");
+        let name = result
+            .get("brand")
+            .and_then(|b| b.get("meta"))
+            .and_then(|m| m.get("name"))
+            .expect("brand.meta.name");
+        assert!(
+            matches!(
+                &name.value,
+                ConfigValueKind::Scalar { yaml: Yaml::String(s), .. } if s == "Acme *Corp*"
+            ),
+            "asterisks must survive verbatim; got {:?}",
+            name.value
+        );
+        assert!(diags.is_empty(), "got {:?}", diags);
+    }
+
+    #[test]
+    fn brand_explicit_md_tag_overrides_annotation() {
+        // The documented escape hatch: an author who wants a brand
+        // meta value treated as markdown tags it `!md`; explicit tags
+        // beat the annotation.
+        let (result, _) = convert_doc_meta("brand:\n  meta:\n    name: !md \"Acme *Corp*\"\n");
+        let name = result
+            .get("brand")
+            .and_then(|b| b.get("meta"))
+            .and_then(|m| m.get("name"))
+            .expect("brand.meta.name");
+        assert!(
+            matches!(
+                &name.value,
+                ConfigValueKind::PandocInlines(_) | ConfigValueKind::PandocBlocks(_)
+            ),
+            "!md must still parse as markdown under brand; got {:?}",
+            name.value
+        );
+    }
+
+    // ─────────────────────────────────────────────────────────────
     // Lone-figure unwrap in config strings
     // (bd-page-footer-image-items-stmpikgo).
     //

--- a/crates/pampa/src/pandoc/meta_annotations.rs
+++ b/crates/pampa/src/pandoc/meta_annotations.rs
@@ -46,6 +46,12 @@
 //!   (`format.*.listing.contents` covers per-format nesting).
 //!   Matching is exact-length, never a suffix match, so a user's
 //!   unrelated `my.listing.contents` key is not captured.
+//! - A trailing `**` matches the node at the preceding prefix and
+//!   its whole subtree (zero or more further segments): `brand.**`
+//!   covers `brand` itself (the path-string form) and every leaf of
+//!   an inline block, at any depth. Use it for keys whose entire
+//!   value is machine-facing; explicit tags still win inside the
+//!   subtree.
 //!
 //! ## See also: the *other* key-path table, and when to pick which
 //!
@@ -86,6 +92,13 @@ const ANNOTATIONS: &[(&[&str], Interpretation)] = &[
         &["format", "*", "listing", "contents"],
         Interpretation::Glob,
     ),
+    // Brand values are machine-facing configuration defined by the
+    // brand-yml spec as plain YAML; the same block must mean the same
+    // thing in `_brand.yml`, `_quarto.yml`, and front matter
+    // (bd-vk4olgv6, GH #581). The subtree form covers the
+    // `brand: _brand.yml` path string and every inline-block leaf —
+    // including custom fields under `meta`, which the spec allows.
+    (&["brand", "**"], Interpretation::PlainString),
 ];
 
 /// Interpretation annotated for the value at `path`, if any.
@@ -94,14 +107,27 @@ const ANNOTATIONS: &[(&[&str], Interpretation)] = &[
 pub(crate) fn annotated_interpretation(path: &[String]) -> Option<Interpretation> {
     ANNOTATIONS
         .iter()
-        .find(|(pattern, _)| {
-            pattern.len() == path.len()
-                && pattern
-                    .iter()
-                    .zip(path.iter())
-                    .all(|(p, seg)| *p == "*" || *p == seg.as_str())
-        })
+        .find(|(pattern, _)| pattern_matches(pattern, path))
         .map(|(_, interp)| *interp)
+}
+
+/// Whether `pattern` matches `path`. `*` matches exactly one segment.
+/// A trailing `**` matches the node at the preceding prefix *and* any
+/// of its descendants (zero or more further segments); it is only
+/// meaningful as the final pattern element. Patterns without `**`
+/// match exact-length only — never a suffix or prefix.
+fn pattern_matches(pattern: &[&str], path: &[String]) -> bool {
+    let (min_len, exact) = match pattern.split_last() {
+        Some((&"**", prefix)) => (prefix.len(), false),
+        _ => (pattern.len(), true),
+    };
+    if path.len() < min_len || (exact && path.len() != min_len) {
+        return false;
+    }
+    pattern[..min_len]
+        .iter()
+        .zip(path.iter())
+        .all(|(p, seg)| *p == "*" || *p == seg.as_str())
 }
 
 #[cfg(test)]
@@ -152,5 +178,52 @@ mod tests {
     fn unrelated_paths_do_not_match() {
         assert_eq!(annotated_interpretation(&path(&["title"])), None);
         assert_eq!(annotated_interpretation(&path(&[])), None);
+    }
+
+    // ── brand subtree (bd-vk4olgv6, GH #581) ─────────────────────
+
+    #[test]
+    fn brand_subtree_matches_root_and_descendants() {
+        // `["brand", "**"]` covers the `brand` node itself (the
+        // `brand: _brand.yml` path form) and every descendant leaf
+        // (inline block values), at any depth — including custom
+        // fields under `meta`, which the brand-yml spec allows.
+        for p in [
+            &["brand"][..],
+            &["brand", "color", "background"][..],
+            &["brand", "light"][..],
+            &["brand", "meta", "name"][..],
+            &["brand", "meta", "some-unknown-program", "notice"][..],
+        ] {
+            assert_eq!(
+                annotated_interpretation(&path(p)),
+                Some(Interpretation::PlainString),
+                "path {p:?} must be plain YAML, never markdown"
+            );
+        }
+    }
+
+    #[test]
+    fn brand_subtree_no_false_positives() {
+        // Subtree matching is anchored at the metadata root: user
+        // keys that merely contain or resemble `brand` are not
+        // captured.
+        assert_eq!(annotated_interpretation(&path(&["my", "brand"])), None);
+        assert_eq!(annotated_interpretation(&path(&["brandx"])), None);
+        assert_eq!(
+            annotated_interpretation(&path(&["format", "html", "brand"])),
+            None,
+            "no consumer reads format.*.brand; keep the table minimal"
+        );
+    }
+
+    #[test]
+    fn exact_length_entries_unaffected_by_subtree_support() {
+        // The pre-existing exact-length semantics must not loosen:
+        // `listing.contents` still refuses descendants.
+        assert_eq!(
+            annotated_interpretation(&path(&["listing", "contents", "title"])),
+            None
+        );
     }
 }

--- a/crates/quarto-core/tests/integration/brand_render.rs
+++ b/crates/quarto-core/tests/integration/brand_render.rs
@@ -420,3 +420,121 @@ fn unified_brand_enables_navbar_toggle() {
         "navbar must carry the dark-mode toggle when brand content enables dark mode"
     );
 }
+
+// ── GH #581: front-matter brand (bd-vk4olgv6) ───────────────────────
+
+/// The exact reproduction from GH #581: an inline `brand:` block in a
+/// single-file document's front matter. Front-matter strings default
+/// to markdown (`PandocInlines`), which the brand walker rejects with
+/// Q-14-1 — the block must instead stay plain YAML and render exactly
+/// as it does from `_quarto.yml`.
+#[test]
+fn front_matter_inline_brand_block_renders() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    write(
+        &root.join("index.qmd"),
+        "---\nformat: html\nbrand:\n  color:\n    background: \"#b22222\"\n---\n\nHello.\n",
+    );
+
+    let runtime: Arc<dyn SystemRuntime> = Arc::new(NativeRuntime::new());
+    let result = render_to_file(
+        &root.join("index.qmd"),
+        "html",
+        &RenderToFileOptions {
+            quiet: true,
+            ..Default::default()
+        },
+        runtime,
+    )
+    .expect("an inline brand block in front matter must render (GH #581)");
+
+    let css = read_css(&result.resources_dir);
+    assert!(
+        css.contains("#b22222"),
+        "front-matter brand background must reach the theme CSS"
+    );
+}
+
+/// GH #581, second half: `brand: _brand.yml` in front matter renders
+/// but used to emit a spurious Q-1-20 warning (the leading underscore
+/// read as an unclosed emphasis mark). The path is machine-facing —
+/// no markdown parse, no warning.
+#[test]
+fn front_matter_brand_file_renders_without_markdown_warning() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    write(
+        &root.join("_brand.yml"),
+        "color:\n  background: \"#b22222\"\n",
+    );
+    write(
+        &root.join("index.qmd"),
+        "---\nformat: html\nbrand: _brand.yml\n---\n\nHello.\n",
+    );
+
+    let runtime: Arc<dyn SystemRuntime> = Arc::new(NativeRuntime::new());
+    let result = render_to_file(
+        &root.join("index.qmd"),
+        "html",
+        &RenderToFileOptions {
+            quiet: true,
+            ..Default::default()
+        },
+        runtime,
+    )
+    .expect("brand file named from front matter must render");
+
+    let css = read_css(&result.resources_dir);
+    assert!(css.contains("#b22222"), "brand must be applied");
+    let q_1_20: Vec<_> = result
+        .render_output
+        .diagnostics
+        .iter()
+        .filter(|d| d.code.as_deref() == Some("Q-1-20"))
+        .collect();
+    assert!(
+        q_1_20.is_empty(),
+        "no markdown-parse warning for the brand path; got {q_1_20:?}"
+    );
+}
+
+/// The `!md` escape hatch (user-approved scope of bd-vk4olgv6): an
+/// explicitly tagged markdown value under `brand.meta` beats the
+/// plain-YAML annotation at load time, and the brand walker projects
+/// it to plain text instead of failing the render with Q-14-1.
+#[test]
+fn front_matter_md_tagged_brand_meta_value_renders() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    write(
+        &root.join("index.qmd"),
+        concat!(
+            "---\n",
+            "format: html\n",
+            "brand:\n",
+            "  meta:\n",
+            "    name: !md \"Acme *Corp*\"\n",
+            "  color:\n",
+            "    background: \"#b22222\"\n",
+            "---\n",
+            "\n",
+            "Hello.\n",
+        ),
+    );
+
+    let runtime: Arc<dyn SystemRuntime> = Arc::new(NativeRuntime::new());
+    let result = render_to_file(
+        &root.join("index.qmd"),
+        "html",
+        &RenderToFileOptions {
+            quiet: true,
+            ..Default::default()
+        },
+        runtime,
+    )
+    .expect("!md-tagged brand.meta value must not fail the render");
+
+    let css = read_css(&result.resources_dir);
+    assert!(css.contains("#b22222"), "brand must still be applied");
+}

--- a/crates/quarto-sass/src/config.rs
+++ b/crates/quarto-sass/src/config.rs
@@ -861,9 +861,21 @@ fn config_value_to_yaml_value(value: &ConfigValue) -> Result<serde_yaml::Value, 
             }
             serde_yaml::Value::Mapping(map)
         }
-        ConfigValueKind::PandocInlines(_) | ConfigValueKind::PandocBlocks(_) => {
+        ConfigValueKind::PandocInlines(_) => {
+            // Only reachable via an explicit `!md` tag: untagged
+            // strings under `brand:` stay `Scalar` thanks to the
+            // brand-subtree annotation in pampa's `meta_annotations`
+            // (bd-vk4olgv6). Honor the author's tag with the
+            // plain-text projection rather than failing the render;
+            // the merged metadata tree keeps the rich inlines for
+            // metadata-level consumers.
+            serde_yaml::Value::String(value.as_plain_text().unwrap_or_default())
+        }
+        ConfigValueKind::PandocBlocks(_) => {
             return Err(SassError::InvalidThemeConfig {
-                message: "brand block must be plain YAML, not Pandoc inlines/blocks".to_string(),
+                message: "brand values must be plain YAML; multi-block `!md` markdown has no \
+                          scalar projection — use single-paragraph markdown or a plain string"
+                    .to_string(),
                 location: Some(value.source_info.clone()),
             });
         }
@@ -2576,5 +2588,63 @@ mod tests {
             ThemeConfig::from_config_value(&config_with_theme_value(theme_value)).unwrap();
         assert_eq!(theme_config.themes.len(), 1);
         assert!(theme_config.themes[0].is_builtin());
+    }
+
+    // === `!md`-tagged leaves inside an inline brand block (bd-vk4olgv6) ===
+
+    #[test]
+    fn inline_brand_md_tagged_leaf_projects_to_plain_text() {
+        use quarto_pandoc_types::inline::{Inline, Space, Str};
+
+        // Simulate `brand.meta.name: !md "Acme Corp"`: the explicit
+        // tag yields PandocInlines even though the brand-subtree
+        // annotation keeps *untagged* values plain (GH #581). The
+        // walker must not fail the render; the Brand copy receives
+        // the plain-text projection while the merged metadata keeps
+        // the rich inlines.
+        let name_value = ConfigValue::new_inlines(
+            vec![
+                Inline::Str(Str {
+                    text: "Acme".to_string(),
+                    source_info: SourceInfo::for_test(),
+                }),
+                Inline::Space(Space {
+                    source_info: SourceInfo::for_test(),
+                }),
+                Inline::Str(Str {
+                    text: "Corp".to_string(),
+                    source_info: SourceInfo::for_test(),
+                }),
+            ],
+            SourceInfo::for_test(),
+        );
+        let brand_value = map_value(vec![
+            map_entry("meta", map_value(vec![map_entry("name", name_value)])),
+            map_entry(
+                "color",
+                map_value(vec![map_entry("background", scalar_value("#b22222"))]),
+            ),
+        ]);
+
+        let brand_ref = extract_single_brand_ref(&brand_value)
+            .expect("an !md-tagged leaf must not fail brand extraction");
+        let BrandRef::Inline(yaml) = brand_ref else {
+            panic!("expected an inline brand block");
+        };
+        assert_eq!(
+            yaml["meta"]["name"],
+            serde_yaml::Value::String("Acme Corp".to_string()),
+            "inlines leaf must project to its plain text"
+        );
+
+        let brand: quarto_brand::UnifiedBrand =
+            serde_yaml::from_value((*yaml).clone()).expect("projected block must deserialize");
+        assert_eq!(
+            brand.meta.and_then(|m| m.name).and_then(|n| match n {
+                quarto_brand::BrandMetaName::Short(s) => Some(s),
+                quarto_brand::BrandMetaName::Detailed { full, short } => full.or(short),
+            }),
+            Some("Acme Corp".to_string())
+        );
     }
 }

--- a/docs/guides/authoring/brand.qmd
+++ b/docs/guides/authoring/brand.qmd
@@ -120,6 +120,28 @@ brand:
 ---
 ```
 
+### Brand values are plain YAML
+
+Unlike most document metadata, values under `brand:` are never treated as
+markdown. Whether a brand lives in `_brand.yml`, in `_quarto.yml`, or in a
+document header, every value is read as plain YAML, exactly as written — a
+color like `"#b22222"`, a file name like `_brand.yml`, or a name containing
+`*` or `_` needs no escaping and no `!str` tag.
+
+If you do want a value under `brand.meta` to be processed as markdown, tag it
+explicitly with `!md`:
+
+```{.yaml filename="document.qmd"}
+---
+brand:
+  meta:
+    name: !md "Acme *Corp*"
+---
+```
+
+Brand-aware tools (such as the theme compiler) see the plain text of an `!md`
+value — in this example, `Acme Corp`.
+
 ### Document and Project Brand Configuration
 
 This section covers how to configure brand settings for individual documents and projects. If you're looking to adopt a brand that's maintained externally---such as a shared organizational brand---see [Sharing brands across projects](#sharing-brands-across-projects).


### PR DESCRIPTION
Fixes #581 (bd-vk4olgv6).

## What was broken

Front matter is converted with `InterpretationContext::DocumentMetadata`, which parses every untagged string as markdown into `ConfigValueKind::PandocInlines`. The brand machinery in `quarto-sass` then split three ways:

- **Inline block** (`brand: {color: {background: "#b22222"}}`): `config_value_to_yaml_value` rejected `PandocInlines` outright → every inline `brand:` block in front matter failed with Q-14-1, while the identical block in `_quarto.yml` rendered fine.
- **Path form** (`brand: _brand.yml`): survived via the `as_plain_text()` fallback, but the markdown parse of the leading underscore emitted a spurious Q-1-20 warning.
- **Silent mangling**: a brand value that parsed *successfully* as markdown was rewritten before flattening (`Acme *Corp*` → `Acme Corp`, emphasis consumed).

## The fix

Brand values are machine-facing configuration, defined by the [brand-yml spec](https://posit-dev.github.io/brand-yml/) as plain YAML and consumed identically from `_brand.yml`, `_quarto.yml`, and front matter (verified against Quarto 1, which reads front-matter brand through its own YAML reader, not Pandoc's metadata treatment).

1. **`pampa/src/pandoc/meta_annotations.rs`** — the load-time key-path annotation table (GH #457's mechanism for "protecting a machine-facing key from markdown") gains a subtree pattern form: a trailing `**` matches the node at the prefix and its whole subtree. New entry: `(&["brand", "**"], Interpretation::PlainString)`. Untagged strings anywhere under `brand:` now stay `Scalar`, in both interpretation contexts (a no-op for `ProjectConfig`).
2. **`quarto-sass/src/config.rs`** — `config_value_to_yaml_value` now projects `PandocInlines` to their plain text instead of erroring. After (1), inlines can only reach a brand block via an explicit `!md` tag (tags beat annotations), so the projection honors the author's tag rather than failing the render; the merged metadata tree keeps the rich inlines. Multi-block `!md` keeps an error, with a clearer message.
3. **`docs/guides/authoring/brand.qmd`** — new "Brand values are plain YAML" section documenting the semantics and the `!md` escape hatch.

## Tests (written first, each observed failing for the predicted reason)

- `meta_annotations.rs`: subtree matching (root, descendants, custom `meta` fields), no false positives (`my.brand`, `brandx`, `format.html.brand`), exact-length entries unaffected.
- `meta.rs`: inline-block leaves stay `Scalar`; `brand: _brand.yml` converts with zero diagnostics; markdown-significant characters survive verbatim; `!md` still overrides the annotation.
- `quarto-sass`: an `!md`-produced inlines leaf extracts, projects to plain text, and deserializes into `UnifiedBrand`.
- `brand_render.rs` (e2e via `render_to_file`): the exact GH #581 inline repro renders with the color in the theme CSS; the brand-file form renders with no Q-1-20 in `render_output.diagnostics`; an `!md`-tagged `meta.name` renders.

## End-to-end verification through the real binary

All fixtures under `claude-notes/issue-reports/581/` (committed with the triage record):

```
$ q2 render repro-inline.qmd        # was: Q-14-1 error
Rendering single file: .../repro-inline.qmd
$ grep -c b22222 repro-inline_files/styles.css
1
$ q2 render repro-file.qmd          # was: Q-1-20 warning
Rendering single file: .../repro-file.qmd   (exit 0, zero warnings)
$ q2 render exp-md-tag              # was: Q-14-1 error on `meta.name: !md`
Rendered 1 of 1 files
$ q2 render control-project         # unchanged
Rendered 1 of 1 files
```

Outputs inspected by hand.

## Not in scope (filed as strands)

- **bd-8q5o86r1** — `BrandMeta` is `deny_unknown_fields {name, link}` and rejects the spec's own `meta.description`/`founded` example (even via `_quarto.yml`; pre-existing). Until it lands, `!md` works on known meta fields only.
- **bd-xxpbo8cf** — flaky `test_race_free_instance_exclusive` under sibling-checkout load, found during pre-flight.

Full triage record, spec/Q1 research, and the plan this implements: `claude-notes/issue-reports/581/triage.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
