### PR TITLE
Stop the knitr inline-R regex from eating R display fences

### DIFF
--- a/claude-notes/plans/2026-08-25-r-display-fence-parse-error-investigation/fixture/_quarto.yml
+++ b/claude-notes/plans/2026-08-25-r-display-fence-parse-error-investigation/fixture/_quarto.yml
@@ -1,0 +1,2 @@
+project:
+  type: default

--- a/claude-notes/plans/2026-08-25-r-display-fence-parse-error-investigation/fixture/index.qmd
+++ b/claude-notes/plans/2026-08-25-r-display-fence-parse-error-investigation/fixture/index.qmd
@@ -1,0 +1,15 @@
+---
+title: "Display fence next to an executable cell"
+---
+
+```{r}
+1 + 1
+```
+
+A display block, written the way Pandoc and Quarto 1 accept it:
+
+``` r
+pak::pak(c("usethis", "cli"))
+```
+
+Text after the block.

--- a/claude-notes/plans/2026-08-25-r-display-fence-parse-error-investigation/knitr-upstream-pattern.md
+++ b/claude-notes/plans/2026-08-25-r-display-fence-parse-error-investigation/knitr-upstream-pattern.md
@@ -1,0 +1,55 @@
+# knitr's own inline-code pattern (upstream ground truth)
+
+Captured from the local R installation, knitr 1.50:
+
+```
+$ Rscript -e 'cat(knitr::all_patterns$md$inline.code)'
+(?<!(^``))(?<!(
+``))`r[ #]([^`]+)\s*`
+```
+
+i.e. with the newline written as an escape:
+
+```
+(?<!(^``))(?<!(\n``))`r[ #]([^`]+)\s*`
+```
+
+Three defenses, none of which q2's `` `r\s+([^`]+)` `` has:
+
+1. `(?<!(^``))` — the backtick that opens the match must not be the third
+   backtick of a fence at start-of-string.
+2. `(?<!(\n``))` — same, for a fence at start-of-line.
+3. `[ #]` — a *single* space or hash. A newline can never open the
+   expression. This is the defense that stops a 4+-backtick fence, which
+   neither lookbehind catches.
+
+Also captured, for reference — knitr's executable-chunk opener, which is
+what `` ```{r} `` matches and which tolerates whitespace before the brace:
+
+```
+^[\t >]*```+\s*\{([a-zA-Z0-9_]+( *[ ,].*)?)\}\s*$
+```
+
+## Why we should NOT port knitr's pattern literally
+
+Rust's `regex` crate has no lookbehind, so the lookbehinds have to be
+re-expressed anyway. The natural re-expression is Quarto 1's idiom from
+`quarto-cli/src/core/execute-inline.ts`:
+
+```js
+new RegExp("(^|[^`])`{" + language + "}[ \t]([^`]+)`", "g")
+```
+
+— capture the preceding character and re-emit it. That form is *strictly
+stronger* than knitr's two lookbehinds: it rejects a backtick prefix
+anywhere, not just at line start. Measured difference on the strand's
+`yaml-title/` fixture (a `` ```r `` inside a front-matter scalar, mid-line):
+
+| pattern | matches the YAML fence? |
+|---|---|
+| q2 today (`` `r\s+ ``) | yes — fatal |
+| knitr upstream | **yes** — knitr itself has this hole |
+| `(^\|[^`])` port | no |
+
+So the `(^|[^`])` guard is not merely a port; it fixes a case knitr
+upstream still gets wrong. See `regex-candidates.out` for the full run.

--- a/claude-notes/plans/2026-08-25-r-display-fence-parse-error-investigation/regex-candidates.out
+++ b/claude-notes/plans/2026-08-25-r-display-fence-parse-error-investigation/regex-candidates.out
@@ -1,0 +1,58 @@
+--- repro
+    current="`r\n# if you're a pak person (we are!)\npa"
+    knitr=none
+    proposed=none
+--- nospace
+    current="`r\n# if you're a pak person (we are!)\npa"
+    knitr=none
+    proposed=none
+--- attr-fence
+    current="`r\n# if you're a pak person (we are!)\npa"
+    knitr=none
+    proposed=none
+--- yaml-title
+    current='`r blocks"\n---\n\nAn executable cell, so t'
+    knitr='`r blocks"\n---\n\nAn executable cell, so t'
+    proposed=none
+--- control
+    current=none
+    knitr=none
+    proposed=none
+--- workaround
+    current=none
+    knitr=none
+    proposed=none
+
+--- inline-R sanity (must still match) ---
+'The answer is `r 1+1`.'
+     current  : ['`r 1+1`']
+     knitr    : ['`r 1+1`']
+     proposed : [' `r 1+1`']
+'`r x` at start'
+     current  : ['`r x`']
+     knitr    : ['`r x`']
+     proposed : ['`r x`']
+'a `r  x + 1  `.'
+     current  : ['`r  x + 1  `']
+     knitr    : ['`r  x + 1  `']
+     proposed : [' `r  x + 1  `']
+'text `r#c` hash'
+     current  : []
+     knitr    : ['`r#c`']
+     proposed : [' `r#c`']
+'```r\nbody\n```'
+     current  : ['`r\nbody\n`']
+     knitr    : []
+     proposed : []
+'````r\nbody with ` tick\n````'
+     current  : ['`r\nbody with `']
+     knitr    : []
+     proposed : []
+'title: "```r blocks"'
+     current  : []
+     knitr    : []
+     proposed : []
+'Backtick prefix ``r x`'
+     current  : ['`r x`']
+     knitr    : ['`r x`']
+     proposed : []

--- a/claude-notes/plans/2026-08-25-r-display-fence-parse-error-investigation/regex-candidates.py
+++ b/claude-notes/plans/2026-08-25-r-display-fence-parse-error-investigation/regex-candidates.py
@@ -1,0 +1,32 @@
+import re, pathlib
+CUR = re.compile(r"`r\s+([^`]+)`")                 # q2 today
+KNITR = re.compile(r"(?<!(^``))(?<!(\n``))`r[ #]([^`]+)\s*`", re.M)  # knitr upstream
+Q1LIKE = re.compile(r"(^|[^`])`r[ #]([^`]+)`", re.M)                # proposed port
+
+R = pathlib.Path("/Users/gordon/src/q2-positron-docs/llms-info/repros/knitr-inline-r-eats-fence")
+# Simulate STAGE 1: qmd writer collapses "``` r" and "```{.r}" to "```r"
+def stage1(s):
+    s = re.sub(r"^``` r$", "```r", s, flags=re.M)
+    s = re.sub(r"^```\{\.r\}$", "```r", s, flags=re.M)
+    return s
+
+for fx in ["repro","nospace","attr-fence","yaml-title","control","workaround"]:
+    src = (R/fx/"index.qmd").read_text()
+    s = stage1(src)
+    def show(rx,name):
+        ms = list(rx.finditer(s))
+        if not ms: return f"{name}=none"
+        return f"{name}=" + "; ".join(repr(m.group(0)[:40]) for m in ms)
+    print(f"--- {fx}")
+    print("   ", show(CUR,"current"))
+    print("   ", show(KNITR,"knitr"))
+    print("   ", show(Q1LIKE,"proposed"))
+
+print("\n--- inline-R sanity (must still match) ---")
+for probe in ["The answer is `r 1+1`.", "`r x` at start", "a `r  x + 1  `.", "text `r#c` hash",
+              "```r\nbody\n```", "````r\nbody with ` tick\n````", 'title: "```r blocks"',
+              "Backtick prefix ``r x`"]:
+    print(repr(probe))
+    for rx,name in ((CUR,"current"),(KNITR,"knitr"),(Q1LIKE,"proposed")):
+        ms=[m.group(0)[:40] for m in rx.finditer(probe)]
+        print(f"     {name:9}: {ms}")

--- a/claude-notes/plans/2026-08-25-r-display-fence-parse-error-investigation/repro-at-head.txt
+++ b/claude-notes/plans/2026-08-25-r-display-fence-parse-error-investigation/repro-at-head.txt
@@ -1,0 +1,16 @@
+Rendering project: /Users/gordon/src/q2/.worktrees/workspace-1/claude-notes/plans/2026-08-25-r-display-fence-parse-error-investigation/fixture (type: default)
+
+
+processing file: index.rmarkdown
+output file: index.knit.md
+
+error: while rendering /Users/gordon/src/q2/.worktrees/workspace-1/claude-notes/plans/2026-08-25-r-display-fence-parse-error-investigation/fixture/index.qmd
+Error: Parse error
+     ╭─[ /Users/gordon/src/q2/.worktrees/workspace-1/claude-notes/plans/2026-08-25-r-display-fence-parse-error-investigation/fixture/index.knitr.rmarkdown:151:1 ]
+     │
+ 151 │ ```r .QuartoInlineRender(pak::pak(c("usethis", "cli")))```
+     │ ┬  
+     │ ╰── unexpected character or token here
+─────╯
+
+Rendered 0 of 1 files to /Users/gordon/src/q2/.worktrees/workspace-1/claude-notes/plans/2026-08-25-r-display-fence-parse-error-investigation/fixture — 1 error

--- a/claude-notes/plans/2026-08-25-r-display-fence-parse-error.md
+++ b/claude-notes/plans/2026-08-25-r-display-fence-parse-error.md
@@ -1,0 +1,411 @@
+# R display fences (``` r) are a fatal parse error (bd-knitr-inline-r-eats-fence-2ofk91x1)
+
+**Date:** 2026-08-25
+**Braid:** bd-knitr-inline-r-eats-fence-2ofk91x1 (P0, bug, labels `engine` `parity`)
+**Worktree:** `.worktrees/workspace-1` (branch `braid/bd-knitr-inline-r-eats-fence-2ofk91x1-r-display-fence-parse-error`, based on `main` @ `d05e96ee8`)
+**Status:** **Implemented** on branch `braid/bd-knitr-inline-r-eats-fence-2ofk91x1-r-display-fence-parse-error` (`7e6e479ba`). All phases done; not yet pushed.
+
+## Triage verdict
+
+**Was: ready to design. Now: done.** The defect was one regex in one function
+with no callers outside its own module. The fix direction came from upstream
+ground truth (knitr's own pattern, captured below), and one thing the
+investigation did *not* predict — that the guard must also exclude a
+backslash, because the YAML-syntax-error fallback separates a fence's
+backticks with escapes. See *Phase 2 discovery*.
+
+All six of the strand's fixtures render; workspace 13385 passed / 199 skipped
+against a 13368 / 199 baseline, the +17 fully accounted for by this branch's
+new tests.
+
+## Issue context
+
+Filed today (2026-08-25) by Gordon at P0. An R **display** fence — a fence
+carrying a language but no braces — is a fatal parse error in any document the
+knitr engine runs, and the whole page is lost. Q1 renders all spellings. Two
+stages compound:
+
+- **Stage 1** — `crates/pampa/src/writers/qmd.rs:783-786` (`write_codeblock`)
+  writes a single-class code block's language as a bare word, so `` ``` r ``,
+  `` ```{.r} `` and `` ```r `` all re-serialize to `` ```r ``.
+- **Stage 2** — `crates/quarto-core/src/engine/knitr/preprocess.rs:43`
+  runs `` `r\s+([^`]+)` `` over the whole serialized document. Against
+  `` ```r `` it anchors on the fence's *third* backtick, `\s+` consumes the
+  newline, and `[^`]+` swallows the block body.
+
+Real-world cost is in the strand: the Positron docs port loses `download.qmd`
+entirely, which breaks 85 site-wide references because every page's navbar
+carries one.
+
+The strand is unusually complete — it already contains the two-stage analysis,
+the history (`748856f50`, byte-identical since), the Q1 reference, the
+`` ```R `` workaround and its cost, and a six-fixture repro at
+`/Users/gordon/src/q2-positron-docs/llms-info/repros/knitr-inline-r-eats-fence/`.
+This investigation adds the upstream-knitr ground truth, a measured comparison
+of candidate patterns, and a recommendation *against* the AST-based direction
+the strand floats.
+
+## Dependency graph
+
+**Empty.** `braid dep tree` and `braid dep list` return the strand alone — no
+`discovered-from` parent in this skein, no blockers, nothing blocked. The
+origin strand lives in a different skein (the Positron-docs porting project,
+`br-knitr-inline-r-eats-fence-oqr1n5im`) and is not reachable from here.
+
+Practical consequence: no incoming pressure to date the urgency, and no sibling
+context to inherit. The P0 rests entirely on the strand's own argument —
+whole-page loss, unavoidable by the author, universal idiom — which the
+investigation confirms.
+
+## What the code looks like today
+
+Every path in the strand is current at `d05e96ee8`; nothing has been refactored
+out from under it.
+
+- `preprocess.rs:43` — `Regex::new(r"`r\s+([^`]+)`")`, byte-identical to the
+  strand's quote.
+- The only callers are `knitr/mod.rs:158-159` (`has_inline_r_expressions` as a
+  fast path, then `resolve_inline_r_expressions`). Nothing else in the
+  workspace references either function or the pattern. **Blast radius is one
+  module.**
+- No sibling engine has an equivalent pass — the jupyter and ts engines do no
+  inline-expression preprocessing at all. (Q1 *does* support `` `{python} x` ``
+  via `execute-inline.ts`; that q2 doesn't is a separate parity gap, not this
+  bug.)
+- Stage 1 is likewise unchanged: `qmd.rs:783` still takes the bare-word branch
+  under `classes.len() == 1 && id.is_empty() && keyvals.is_empty()`.
+
+### Reproduced at HEAD, at the pattern level
+
+`2026-08-25-r-display-fence-parse-error-investigation/regex-candidates.py` runs three patterns over all six of
+the strand's fixtures, with stage 1's collapse simulated. Full output in
+`regex-candidates.out`. Summary:
+
+| fixture | q2 today | knitr upstream | proposed `(^\|[^`])` port |
+|---|---|---|---|
+| `repro/` (``` r) | **matches → fatal** | no | no |
+| `nospace/` (```r) | **matches → fatal** | no | no |
+| `attr-fence/` (```{.r}) | **matches → fatal** | no | no |
+| `yaml-title/` (```r in a YAML scalar) | **matches → fatal** | **matches** | no |
+| `control/` (```bash) | no | no | no |
+| `workaround/` (```R) | no | no | no |
+
+Every inline form the existing 15 unit tests pin still matches under the
+proposed pattern.
+
+### Reproduced at HEAD, end-to-end through the binary
+
+Minimal fixture at `2026-08-25-r-display-fence-parse-error-investigation/fixture/`
+— one executable `` ```{r} `` cell and one `` ``` r `` display fence, 15 lines:
+
+```
+$ cd claude-notes/plans/2026-08-25-r-display-fence-parse-error-investigation/fixture
+$ q2 render
+```
+
+Observed (full capture in `../repro-at-head.txt`):
+
+```
+Error: Parse error
+     ╭─[ .../fixture/index.knitr.rmarkdown:151:1 ]
+ 151 │ ```r .QuartoInlineRender(pak::pak(c("usethis", "cli")))```
+     │ ╰── unexpected character or token here
+
+Rendered 0 of 1 files ... — 1 error
+```
+
+That one line is the whole bug made visible: the opening fence's third
+backtick, the language `r`, the newline eaten by `\s+`, and the entire block
+body pulled inside `.QuartoInlineRender(...)`.
+
+Two of the strand's secondary claims are confirmed in passing. The cited
+`index.knitr.rmarkdown` **is not on disk** after the failure (the fixture
+directory holds only `_quarto.yml` and `index.qmd`), and the cited line 151
+is meaningless against a 15-line source — the author can neither open the
+file the error names nor map its line back.
+
+### Upstream ground truth: knitr's own pattern
+
+Captured from knitr 1.50 on this machine (details and reasoning in
+`2026-08-25-r-display-fence-parse-error-investigation/knitr-upstream-pattern.md`):
+
+```
+(?<!(^``))(?<!(\n``))`r[ #]([^`]+)\s*`
+```
+
+This is the single most useful thing the investigation turned up, and it is
+**better evidence than the Q1 source the strand cites**. Q1's
+`execute-inline.ts` handles the *braced* `` `{r} expr` `` form used by the
+jupyter/julia engines; it is a cousin, not the thing that actually consumes
+this text. knitr's pattern *is* the contract — after q2 rewrites, knitr
+re-scans the same string with the pattern above and evaluates what it finds.
+
+knitr carries three defenses q2 has none of: two negative lookbehinds against a
+fence's third backtick, and `[ #]` — a **single** space or hash, so a newline
+can never open an expression. That third defense is what stops a 4+-backtick
+fence, which neither lookbehind catches.
+
+### Why not port knitr's pattern literally
+
+Rust's `regex` crate has no lookbehind, so the guard must be re-expressed
+regardless. The natural re-expression is Q1's idiom — capture the preceding
+character and re-emit it:
+
+```
+(^|[^`])`r[ \t]([^`]+)`
+```
+
+That form is *strictly stronger* than knitr's lookbehinds: it rejects a
+backtick prefix anywhere, not only at line start. The `yaml-title/` row above
+is the measured consequence — a `` ```r `` inside a front-matter scalar is
+mid-line, so knitr's lookbehinds miss it and **knitr upstream would eat it
+too**. The proposed guard does not. We would be fixing a case knitr still gets
+wrong.
+
+Relative to today's pattern the change is a **pure narrowing**: it removes
+newline-opened and backtick-prefixed matches and adds nothing. No existing test
+covers either removed case.
+
+### Recommendation: reject the AST-based direction
+
+The strand suggests "better still, do the substitution over parsed block
+structure rather than raw text." I recommend explicitly **not** doing that:
+
+1. **It would silently drop a real feature.** Inline R in front-matter scalars
+   (`` title: "Report for `r params$name`" ``) works in Q1 because knitr scans
+   the whole file including the YAML. Excluding metadata to fix `yaml-title/`
+   would trade a crash for a regression. The text-level guard fixes the bad
+   case *and* keeps the good one — verified in the table above.
+2. **The contract is textual, because knitr is textual.** q2's pass exists only
+   to hand knitr a string knitr will then re-scan with its own regex. The
+   correctness condition is "q2's pattern agrees with knitr's", which is a
+   statement about text. An AST pass could wrap something knitr's regex won't
+   match (or miss something it will) and reintroduce divergence in a new place.
+3. **It costs a trait change.** `ExecutionEngine::execute` takes `&str`
+   (`engine/traits.rs:61`). AST-level preprocessing needs either a new trait
+   method or knitr-specific logic in `EngineExecutionStage` — a real
+   architectural surface, for a defect a five-character guard closes.
+
+One genuine point in the AST direction's favour, recorded so it isn't lost:
+because the regex runs *after* `serialize_ast_to_qmd`, the `SourceInfo` handed
+to `ExecutionContext` (`engine_execution.rs:432,467`) describes the
+**pre**-substitution string while knitr executes the post-substitution one, so
+every offset after a wrapped expression is short by 21 bytes. This is
+**currently harmless** — `ctx.source_info` is consumed only by the jupyter/ts
+engines, never by knitr — but it is a live trap for anyone who later tries to
+give knitr errors real source locations, which is exactly what the strand's
+"undiagnosable" complaint asks for. Note it in the code; don't fix it here.
+
+## Phases
+
+Implementation began 2026-08-25 after Gordon's go-ahead. Baseline before any
+change: 13368 passed / 199 skipped at `d05e96ee8`.
+
+- [x] **Phase 0 — Test plan (TDD, tests written and watched failing first).**
+  - 11 unit tests added to `preprocess.rs`: each fence spelling, a 4-backtick
+    fence, a fence spelling inside a YAML scalar, a backtick-prefixed
+    `` ``r x` ``, a newline after `r`, the escaped-backtick form (below), plus
+    three regression guards (inline R beside a fence, a tab separator, a body
+    spanning lines). **8 failed against the old pattern**; the three guards
+    passed before and after, which is what makes them guards.
+  - `crates/quarto-core/tests/integration/knitr_display_fence.rs` — 6 tests
+    through `render_document_to_file`, the entry `q2 render` itself uses,
+    gated on `knitr_available()`. **Verified red by stashing the fix**: all
+    six failed, five with `Error: Parse error` and the YAML one with
+    `Execution failed in knitr: R process failed` — the two shapes the strand
+    describes. Registered in `tests/integration/main.rs` per
+    `.claude/rules/integration-tests.md`.
+- [x] **Phase 1 — Replace `INLINE_R_PATTERN`** with
+  `` (^|[^`\\])`r[ \t]([^`]+)` ``, re-emitting the captured prefix. The doc
+  comment, which claimed a guard the code never had, is replaced by one that
+  explains each guard and cites its provenance.
+- ~~**Phase 2 — Stage-1 writer parity.**~~ **Out of scope** (Q2, decided
+  2026-08-25). The qmd writer keeps emitting `` ```r `` for a bare display
+  language. Recorded for whoever revisits it: Pandoc's own markdown writer
+  emits `` ``` r `` (verified), and exactly one `.snap` in the repo contains
+  any bare-word fence, so the churn would have been near-zero — but the fix
+  is not needed once stage 2 is guarded.
+- [x] **Phase 3 — Verification against the strand's fixtures.** See below.
+- [x] **Phase 4 — Docs: none required.** The docs site documents usage, and
+  nothing an author writes changes: `` ``` r `` was always the correct
+  spelling and simply works now. No error page is implicated either — the
+  failure was uncoded, and adding a `Q-` code is finding (b), deliberately
+  not filed.
+
+### Mid-implementation discovery: the guard also has to exclude a backslash
+
+`fence_spelling_in_yaml_scalar_renders` stayed red after Phase 1, and the
+reason was **not** the one the strand describes. When a YAML scalar fails to
+parse as markdown, q2 warns `Q-1-20` and the `.yaml-markdown-syntax-error`
+fallback re-serializes the scalar with every backtick **backslash-escaped**.
+Confirmed with `pampa -t qmd`:
+
+```
+title: "[Backtick r in the title: \\`\\`\\`r blocks]{.yaml-markdown-syntax-error}"
+```
+
+The three backticks are no longer adjacent — each is preceded by a backslash —
+so the third is preceded by `\`, a non-backtick, and a guard that excludes
+only backticks lets it anchor. **Neither Quarto 1 nor knitr excludes the
+backslash, and neither survives this input.**
+
+The fix extends the class to `` [^`\\] ``, on the general ground that an
+escaped backtick cannot open a code span and therefore cannot open an inline R
+expression. Still a pure narrowing. Known cost, recorded in the doc comment:
+`` \\`r x` `` — an escaped *backslash* followed by a genuine expression — is
+declined. Telling that from `` \`r x` `` needs a count of preceding
+backslashes, which this shape of regex cannot express; declining a vanishingly
+rare expression is much the cheaper failure than losing the page.
+
+### Phase 3 — all six of the strand's fixtures, through the binary
+
+Copied to a scratch dir (a Q1 run mutates the originals) and rendered with
+`q2 render` from the branch build:
+
+| fixture | before | after | last `<pre class=…>` |
+|---|---|---|---|
+| `repro/` (``` r) | fatal | **renders** | `sourceCode r` |
+| `nospace/` (```r) | fatal | **renders** | `sourceCode r` |
+| `attr-fence/` (```{.r}) | fatal | **renders** | `sourceCode r` |
+| `yaml-title/` | fatal | **renders** (1 pre-existing `Q-1-20` warning) | — |
+| `control/` (```bash) | renders | renders | `sourceCode bash` |
+| `workaround/` (```R) | renders unhighlighted | unchanged | `R code-with-copy` |
+
+`grep -c QuartoInlineRender` is **0** in all six outputs. The `workaround/` row
+is unchanged on purpose — that is finding (a), deliberately not filed, and the
+fix must not disturb it.
+
+Output inspected, not inferred. The display block in `repro/index.html`:
+
+```html
+<pre class="sourceCode r"><code class="sourceCode r"><span class="hl-comment">
+# if you're a pak person (we are!)</span>
+<span class="hl-namespace">pak</span><span class="hl-operator">::</span>…
+```
+
+Q1 renders the same block as `<pre class="sourceCode r code-with-copy">` with
+skylighting's `co`/`fu` span classes. The span vocabulary differs between the
+two highlighters — not part of this bug; what matters is that the block is a
+highlighted, non-executed R block in both.
+
+### Code review (2026-08-25)
+
+Reviewed over `c9f4023f0..32c1f0407`. No Critical issues; the reviewer could
+construct no input that still eats a fence and no reachable input where a
+legitimate expression is lost, and confirmed via a guard-mutation matrix that
+every guard is independently pinned by a test.
+
+Two Important findings, both fixed:
+
+1. **The doc comment inverted which guard defends against a fence.** It said
+   `[ \t]` was "the one that stops a four-backtick fence, which the prefix
+   guard alone does not". That is false, and it is false in the dangerous
+   direction — a maintainer could have deleted the load-bearing guard on its
+   authority. Verified independently before fixing:
+
+   | input | old | prefix guard only | class only | shipped |
+   |---|---|---|---|---|
+   | 3-backtick fence | eats | ok | ok | ok |
+   | 4-backtick fence | eats | ok | ok | ok |
+   | fence in YAML scalar | eats | ok | **eats** | ok |
+   | escaped-backtick fence | eats | ok | **eats** | ok |
+
+   The prefix guard covers **every** fence shape, because the backtick that
+   would anchor a match is always itself preceded by a backtick; `[ \t]` is
+   knitr parity plus defense-in-depth, and its own regression case is a
+   mid-prose `` `r\nx` ``. The claim came from the knitr analysis — where
+   `[ #]` genuinely *is* what stops a fourth backtick, since knitr's
+   lookbehinds are line-anchored — and was mis-transposed onto q2's guard.
+   Corrected in all three places it appeared, now naming the test that
+   reddens when each guard is removed.
+
+2. **Two integration assertions were satisfiable by an empty block.** The
+   four-backtick and YAML-scalar tests asserted only "renders" and "no
+   wrapper", neither of which fails if the content were swallowed. This is
+   not hypothetical: knitr re-scans the string we hand it, and its
+   lookbehinds check for *adjacent* backticks, so it would not reject the
+   escaped form on its own. Both now pin the surviving text.
+
+Minor findings also applied: the `` ```R `` note pointed at bd-ps046hi3 (which
+tracks finding (c)) rather than §(a) here, and this section's heading said
+"Phase 2", which is the struck-out writer phase. Declined: aligning the skip
+message wording with `engine_visibility.rs` — the mechanism already matches
+and naming the test is more useful in a six-test file.
+
+The reviewer also asked for the `SourceInfo` byte-offset skew to be recorded
+in `preprocess.rs` rather than only here, since that file is where someone
+giving knitr real source locations would be standing. Added to its module doc.
+
+## Open design questions for the user
+
+1. **Which character class after `` `r ``?** — **DECIDED 2026-08-25: `[ \t]`.**
+   - `[ \t]` — Q1's idiom; a pure narrowing of today's `\s+`; keeps the tab
+     form working. **Chosen.**
+   - `[ ]` — space only; makes q2's matches a strict subset of knitr's.
+   - `[ #]` — knitr-exact, but it *widens* q2: `` `r#x` `` doesn't match today
+     and would start being wrapped as `.QuartoInlineRender(#x)`, which is
+     broken R (the comment eats the closing paren). I'd avoid this.
+
+2. **Is stage 1 (the qmd writer) in scope?** — **DECIDED 2026-08-25: out of scope.** Fixing stage 2 alone closes the
+   bug. But `write_codeblock` writing `` ```r `` where Pandoc writes
+   `` ``` r `` is a round-trip parity divergence in its own right, and fixing
+   it is independent defense-in-depth. Measured cost looks near-zero — no
+   `.snap` file in the workspace contains a bare-word `r` fence. The care
+   needed is that the same branch also emits `` ```{r} `` for executable
+   cells, which must not gain a space. In scope as Phase 2, or a separate
+   strand?
+
+3. **Which of these become follow-up strands rather than part of this fix?**
+   — **DECIDED 2026-08-25: file (c) only; (a) and (b) deliberately not filed.**
+   All three were verified during this investigation and are genuinely separate
+   defects. Only the third became a strand — **bd-ps046hi3**
+   (`discovered-from` this one). The other two are recorded here so the
+   evidence isn't lost, but are not tracked:
+   - **(a) NOT FILED — `` ```R `` renders unhighlighted.** Verified: q2 emits
+     `<pre class="R code-with-copy">` for `` ```R `` but
+     `<pre class="sourceCode bash">` for a `` ```bash `` control, so the
+     degradation is specific to the capital, not to display fences. Cause is
+     mechanical: `quarto-highlight/src/registry.rs:87` resolves a language by
+     exact `HashMap` hit, and `:148` registers `("r", &[])` — no aliases — so
+     `"R"` misses, no highlight spans are produced, and
+     `pampa/src/writers/html.rs:539` only prepends `sourceCode` when spans
+     exist. Q1 emits `sourceCode r`, i.e. it normalizes case. **Its urgency
+     drops once this strand lands** — `` ```R `` stops being the only working
+     spelling. Keep the strand's warning visible: do not make
+     `INLINE_R_PATTERN` case-insensitive, which would make `` ```R `` fatal
+     too; fixing the *highlighter* has the opposite sign and is safe in either
+     order.
+   - **(b) NOT FILED — uncoded `Parse error` citing a generated intermediate.**
+     Two problems in one message: no `Q-` code (so no docs page, nothing to
+     search for), and a file/line the author cannot act on. The source-mapping
+     half is the expensive one and must start from the `SourceInfo` skew noted
+     above; adding a code is independently cheap. See bd-ps046hi3, which
+     records the skew warning for whoever picks this up.
+   - **(c) FILED as bd-ps046hi3** — `--debug` does not retain the intermediate.
+     Verified: after a `--debug` run the project holds only
+     `.quarto/render-manifest.json` and a cache profile, with nothing matching
+     `*knitr*`. This is what makes (b) unsurvivable rather than merely
+     annoying, and it is the cheapest of the three.
+
+## Risks / tradeoffs (draft)
+
+- **Low blast radius.** One regex, one module, two callers, 15 existing tests
+  that all keep passing under the proposed pattern.
+- **The `` ```R `` trap.** The strand flags it and it is worth repeating: do
+  not make the pattern case-insensitive as part of "tidying". `` ```R `` is
+  currently the only way authors can ship a working document, and the
+  highlighter is case-sensitive too, so a case-insensitive regex would turn the
+  workaround fatal.
+- **Testing needs R.** The end-to-end leg only runs where `Rscript` and the
+  knitr package are installed. The unit tests carry the real regression
+  coverage; the e2e test is the CLAUDE.md-mandated proof, gated on the standard
+  skip.
+- **Pre-flight note (environment, not code).** The first
+  `cargo xtask verify --skip-hub-build --skip-hub-tests` in this worktree
+  failed with 10 tree-sitter corpus failures, several named after open strands.
+  That was a **stale gitignored `markdown.dylib`** left from the worktree's
+  previous branch, not a red main: after `tree-sitter generate && tree-sitter
+  build` the corpus is 609/609. Worth remembering whenever a worktree is
+  repurposed onto a new branch. The re-run was green — **13368 passed, 199
+  skipped** at `d05e96ee8`; that is the live baseline to compare any
+  phase-boundary workspace run against.

--- a/crates/quarto-core/src/engine/knitr/preprocess.rs
+++ b/crates/quarto-core/src/engine/knitr/preprocess.rs
@@ -20,27 +20,120 @@
 //! Before: The answer is `r 1+1`.
 //! After:  The answer is `r .QuartoInlineRender(1+1)`.
 //! ```
+//!
+//! # This pass shifts byte offsets
+//!
+//! It runs on the output of `serialize_ast_to_qmd`, *after* the `SourceInfo`
+//! handed to `ExecutionContext` was built from that string
+//! (`stage/stages/engine_execution.rs:432,467`). Every wrapped expression
+//! makes the text 21 bytes longer, so offsets past it no longer agree with
+//! that `SourceInfo`. This is harmless today — `ctx.source_info` is read by
+//! the jupyter/ts engines and never by knitr — but anyone giving knitr real
+//! source locations must reconcile the two first, or the locations will be
+//! silently wrong in exactly the documents that use inline R.
 
 use regex::Regex;
 use std::sync::LazyLock;
 
-/// Regex pattern for inline R code: `r expression`
+/// Regex pattern for inline R code: `` `r expression` ``
 ///
 /// Matches:
+/// - Start of input, or a single character that is neither a backtick nor a
+///   backslash (captured group 1, re-emitted verbatim by the replacement)
 /// - Opening backtick
-/// - Literal 'r' followed by one or more whitespace characters
-/// - The expression (captured group 1) - any characters except backticks
+/// - Literal 'r' followed by exactly one space or tab
+/// - The expression (captured group 2) — any characters except backticks,
+///   which may span lines
 /// - Closing backtick
 ///
-/// This pattern intentionally avoids matching inside fenced code blocks
-/// because we process the entire markdown string and inline R is not valid
-/// inside code blocks.
+/// # Why the guard on group 1, and why `[ \t]` rather than `\s+`
+///
+/// This pass runs over the **entire** serialized document — front matter
+/// included — so it must not mistake a fenced code block for an inline
+/// expression. Without both guards it does exactly that: against a display
+/// fence `` ```r `` the match anchors on the fence's *third* backtick, `\s+`
+/// consumes the newline, and `[^`]+` swallows the block body up to the
+/// closing fence, producing `` ```r .QuartoInlineRender(<entire body>)`` ``
+/// and a fatal parse error that costs the whole page
+/// (bd-knitr-inline-r-eats-fence-2ofk91x1).
+///
+/// That is not avoidable upstream: the qmd writer collapses `` ``` r ``,
+/// `` ```{.r} `` and `` ```r `` into the single spelling `` ```r ``, so
+/// every author spelling arrives here as the dangerous one.
+///
+/// The two guards are independent, and they are **not** interchangeable —
+/// each defends cases the other does not:
+///
+/// - `(^|[^`\\])` — neither a backtick nor a backslash may precede the match.
+///   The backtick half is Quarto 1's guard from `src/core/execute-inline.ts`.
+///   **This is the load-bearing fence defense, and it covers every fence
+///   shape**, three backticks or forty: the backtick that would anchor a
+///   match is always itself preceded by a backtick. The backslash half is
+///   ours, for the case where a fence spelling does *not* reach us with its
+///   backticks adjacent — see below. Removing this guard reddens
+///   `test_fence_inside_yaml_scalar_not_matched`,
+///   `test_escaped_backtick_fence_not_matched` and
+///   `test_backtick_prefixed_not_matched`.
+/// - `[ \t]` — a single space or tab, so a newline can never open an
+///   expression. This is knitr parity (its class is `[ #]`) plus
+///   defense-in-depth; it is *not* what stops a fence. Its own regression
+///   case is a mid-prose `` `r\nx` ``, which no fence guard would catch:
+///   removing it reddens `test_newline_after_r_not_matched` and nothing else.
+///
+/// knitr implements the same idea with two negative lookbehinds plus a
+/// `[ #]` class (`knitr::all_patterns$md$inline.code`). Rust's `regex` crate
+/// has no lookbehind, and the prefix-capture form above is in fact *stronger*
+/// than knitr's: knitr anchors its lookbehinds to line starts, so a fence
+/// spelling inside a front-matter scalar is mid-line and knitr still eats it,
+/// while `(^|[^`])` rejects it.
+///
+/// # Why a backslash also disqualifies
+///
+/// An escaped backtick cannot open a code span, so it cannot open an inline R
+/// expression. That would be reason enough, but there is a concrete case:
+/// when a YAML scalar fails to parse as markdown, the
+/// `.yaml-markdown-syntax-error` fallback re-serializes it with every
+/// backtick escaped, so
+///
+/// ```text
+/// title: "In the title: ```r blocks"
+/// ```
+///
+/// reaches this pass as
+///
+/// ```text
+/// title: "[In the title: \`\`\`r blocks]{.yaml-markdown-syntax-error}"
+/// ```
+///
+/// The three backticks are no longer adjacent — each is preceded by a
+/// backslash — so a guard that only excludes backticks lets the third one
+/// anchor a match that runs into the resolved YAML. Neither Quarto 1 nor
+/// knitr excludes the backslash, and neither survives this input.
+///
+/// The known cost is a false negative on `` \\`r x` `` — an escaped
+/// *backslash* followed by a genuine inline expression — which this pattern
+/// declines to evaluate. Distinguishing that from `` \`r x` `` needs a count
+/// of preceding backslashes, which a regex of this shape cannot express;
+/// declining a vanishingly rare expression is much the cheaper failure than
+/// losing the page.
+///
+/// Note `^` is start-of-input, not start-of-line — deliberately, matching
+/// Quarto 1. A line-initial expression is preceded by `\n`, which the
+/// `[^`]` branch accepts and the replacement re-emits.
+///
+/// **Do not make this case-insensitive.** `` ```R `` currently renders,
+/// unhighlighted: the highlight registry resolves a language by exact map
+/// hit and knows only `r` (a separate, deliberately unfiled defect — see
+/// `claude-notes/plans/2026-08-25-r-display-fence-parse-error.md` §(a)).
+/// A case-insensitive pattern here would make that spelling fatal too.
 static INLINE_R_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
     // Pattern breakdown:
-    // `r\s+   - Opening backtick, 'r', whitespace
-    // ([^`]+) - Capture the expression (anything except backticks)
-    // `       - Closing backtick
-    Regex::new(r"`r\s+([^`]+)`").expect("Invalid regex pattern for inline R")
+    // (^|[^`\\]) - Start of input, or one character that is neither a
+    //              backtick nor a backslash (re-emitted verbatim)
+    // `r[ \t]    - Opening backtick, 'r', exactly one space or tab
+    // ([^`]+)    - Capture the expression (anything except backticks)
+    // `          - Closing backtick
+    Regex::new(r"(^|[^`\\])`r[ \t]([^`]+)`").expect("Invalid regex pattern for inline R")
 });
 
 /// Resolve inline R expressions by wrapping them with `.QuartoInlineRender()`.
@@ -71,14 +164,18 @@ static INLINE_R_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
 pub fn resolve_inline_r_expressions(markdown: &str) -> String {
     INLINE_R_PATTERN
         .replace_all(markdown, |caps: &regex::Captures| {
-            let expr = caps.get(1).map_or("", |m| m.as_str());
+            // Group 1 is the guard character (empty at start of input); it is
+            // part of the match only so that a backtick or backslash can be
+            // excluded, so it must be re-emitted verbatim.
+            let prefix = caps.get(1).map_or("", |m| m.as_str());
+            let expr = caps.get(2).map_or("", |m| m.as_str());
             // Trim the expression to normalize whitespace
             let trimmed = expr.trim();
             if trimmed.is_empty() {
                 // Empty expressions are left as-is (they'll produce an R error)
                 caps[0].to_string()
             } else {
-                format!("`r .QuartoInlineRender({})`", trimmed)
+                format!("{}`r .QuartoInlineRender({})`", prefix, trimmed)
             }
         })
         .into_owned()
@@ -216,6 +313,121 @@ mod tests {
         assert_eq!(output, input);
     }
 
+    // === fenced-code-block guard tests (bd-knitr-inline-r-eats-fence-2ofk91x1) ===
+    //
+    // A fence's third backtick must never anchor an inline-R match. The qmd
+    // writer collapses `` ``` r ``, `` ```{.r} `` and `` ```r `` to the same
+    // `` ```r ``, so this is the only spelling the preprocessor ever sees and
+    // there is no source form an author could migrate to.
+
+    #[test]
+    fn test_display_fence_not_matched() {
+        let input = "```r\npak::pak(c(\"usethis\", \"cli\"))\n```";
+        let output = resolve_inline_r_expressions(input);
+        assert_eq!(output, input, "a display fence must be left untouched");
+    }
+
+    #[test]
+    fn test_display_fence_with_following_text_not_matched() {
+        // The realistic shape: a fence, then prose. Without the guard the
+        // match runs from the fence's third backtick to the closing fence's
+        // first, swallowing the whole body.
+        let input = "Before.\n\n```r\n1 + 1\n```\n\nAfter.";
+        let output = resolve_inline_r_expressions(input);
+        assert_eq!(output, input);
+    }
+
+    #[test]
+    fn test_four_backtick_display_fence_not_matched() {
+        // The writer widens the fence when the body contains a backtick.
+        // knitr's own lookbehinds miss this shape — they are anchored to
+        // ``^`` `` / ``\n`` ``, which a *fourth* backtick does not satisfy.
+        // Our prefix guard is not anchored, so it covers this like any other
+        // fence; the case is here as a recurrence guard, not to pin a
+        // particular guard.
+        let input = "````r\nx <- `y`\n````";
+        let output = resolve_inline_r_expressions(input);
+        assert_eq!(output, input);
+    }
+
+    #[test]
+    fn test_fence_inside_yaml_scalar_not_matched() {
+        // The pass runs over the whole serialized document, front matter
+        // included. A fence spelling inside a scalar is mid-line, so knitr's
+        // line-anchored lookbehinds would miss it — the non-backtick prefix
+        // guard does not.
+        // Needs a later backtick in the document for the runaway match to
+        // find a closing delimiter — the executable cell every such document
+        // has, which is what makes this reachable in practice.
+        let input = "---\ntitle: \"In the title: ```r blocks\"\n---\n\n```{r}\n1 + 1\n```";
+        let output = resolve_inline_r_expressions(input);
+        assert_eq!(output, input);
+    }
+
+    #[test]
+    fn test_escaped_backtick_fence_not_matched() {
+        // The shape the preprocessor actually receives when a YAML scalar
+        // fails to parse as markdown: the `.yaml-markdown-syntax-error`
+        // fallback re-serializes the text with every backtick
+        // backslash-escaped, so the third backtick is preceded by `\` rather
+        // than by a backtick. An escaped backtick cannot open a code span, so
+        // it cannot open an inline R expression either.
+        let input = "---\ntitle: \"[In the title: \\`\\`\\`r blocks]{.yaml-markdown-syntax-error}\"\n---\n\n```{r}\n1 + 1\n```";
+        let output = resolve_inline_r_expressions(input);
+        assert_eq!(output, input);
+    }
+
+    #[test]
+    fn test_backtick_prefixed_not_matched() {
+        // A backtick immediately before `` `r `` can never open a legitimate
+        // inline expression. Matches Quarto 1's `(^|[^`])` guard.
+        let input = "Text ``r x` more.";
+        let output = resolve_inline_r_expressions(input);
+        assert_eq!(output, input);
+    }
+
+    #[test]
+    fn test_newline_after_r_not_matched() {
+        // `\s+` let a newline open the expression; a single space or tab
+        // cannot. This is the defect's proximate cause.
+        let input = "Text `r\nx` more.";
+        let output = resolve_inline_r_expressions(input);
+        assert_eq!(output, input);
+    }
+
+    #[test]
+    fn test_inline_r_still_matched_next_to_a_fence() {
+        // The guard must not cost us a real expression that shares a
+        // document with a display fence.
+        let input = "```r\n1 + 1\n```\n\nThe answer is `r 1+1`.";
+        let output = resolve_inline_r_expressions(input);
+        assert_eq!(
+            output,
+            "```r\n1 + 1\n```\n\nThe answer is `r .QuartoInlineRender(1+1)`."
+        );
+    }
+
+    #[test]
+    fn test_inline_r_with_tab_separator_still_matched() {
+        // `[ \t]`, not `[ ]`: a tab keeps working, so the change is a pure
+        // narrowing of the old `\s+`.
+        let input = "Value: `r\tx`.";
+        let output = resolve_inline_r_expressions(input);
+        assert_eq!(output, "Value: `r .QuartoInlineRender(x)`.");
+    }
+
+    #[test]
+    fn test_multiline_expression_body_still_matched() {
+        // Only the *first* character after `r` is constrained; the body may
+        // still span lines.
+        let input = "Value: `r sum(\n  c(1, 2)\n)`.";
+        let output = resolve_inline_r_expressions(input);
+        assert_eq!(
+            output,
+            "Value: `r .QuartoInlineRender(sum(\n  c(1, 2)\n))`."
+        );
+    }
+
     // === has_inline_r_expressions tests ===
 
     #[test]
@@ -232,5 +444,13 @@ mod tests {
     #[test]
     fn test_has_inline_r_empty_string() {
         assert!(!has_inline_r_expressions(""));
+    }
+
+    #[test]
+    fn test_has_inline_r_false_for_display_fence() {
+        // The fast path must agree with the replacement pass, or a document
+        // whose only "match" is a fence still pays for a full scan.
+        assert!(!has_inline_r_expressions("```r\n1 + 1\n```"));
+        assert!(!has_inline_r_expressions("````r\nx <- `y`\n````"));
     }
 }

--- a/crates/quarto-core/tests/integration/knitr_display_fence.rs
+++ b/crates/quarto-core/tests/integration/knitr_display_fence.rs
@@ -1,0 +1,236 @@
+//! bd-knitr-inline-r-eats-fence-2ofk91x1: an R **display** fence — a fence
+//! carrying a language but no braces — must render as a highlighted,
+//! non-executed code block in a document the knitr engine runs, exactly as
+//! Quarto 1 does.
+//!
+//! Before the fix it was a fatal parse error that cost the whole page. Two
+//! stages compounded: the qmd writer collapses `` ``` r ``, `` ```{.r} `` and
+//! `` ```r `` into the single spelling `` ```r ``, and the knitr inline-R
+//! preprocessor's `` `r\s+([^`]+)` `` then anchored on that fence's *third*
+//! backtick, let `\s+` eat the newline, and swallowed the block body up to
+//! the closing fence.
+//!
+//! **Why this lives at the render level rather than in `preprocess.rs`.** The
+//! unit tests there pin the regex against the collapsed spelling directly.
+//! They cannot see stage 1 — that all three author spellings *become* that
+//! one spelling is a property of the writer, and only a real render exercises
+//! writer and preprocessor together. This file therefore renders each
+//! spelling through `render_document_to_file`, the entry `q2 render` itself
+//! uses, and asserts on the HTML.
+//!
+//! Every fixture carries an executable `` ```{r} `` cell: the knitr engine
+//! must actually run for the bug to be reachable at all.
+//!
+//! Tests skip when knitr isn't installed.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::Path;
+use std::sync::Arc;
+
+use tempfile::TempDir;
+
+use quarto_core::ProjectContext;
+use quarto_core::engine::EngineRegistry;
+use quarto_core::render_to_file::{RenderToFileOptions, render_document_to_file};
+use quarto_system_runtime::{NativeRuntime, SystemRuntime};
+
+fn knitr_available() -> bool {
+    EngineRegistry::default()
+        .get("knitr")
+        .is_some_and(|e| e.is_available())
+}
+
+/// A document with one executable R cell followed by a display fence written
+/// as `fence` (the whole opening line, e.g. ``"``` r"``).
+fn doc_with_display_fence(fence: &str) -> String {
+    format!(
+        "---\ntitle: Display fence\nengine: knitr\n---\n\nBefore.\n\n\
+         ```{{r}}\ncat(paste0(\"O\", \"UT\"), \"\\n\")\n```\n\n\
+         {fence}\npak::pak(c(\"usethis\", \"cli\"))\n```\n\nAfter.\n"
+    )
+}
+
+/// Render `content` to HTML through the real render path and return the HTML.
+/// Panics with the render error on failure — which is the assertion for the
+/// whole-page-loss symptom.
+fn render_html(tmp: &TempDir, name: &str, content: &str) -> String {
+    let input = tmp.path().join(name);
+    std::fs::write(&input, content).unwrap();
+
+    let runtime: Arc<dyn SystemRuntime> = Arc::new(NativeRuntime::new());
+    let project = ProjectContext::discover(&input, runtime.as_ref())
+        .expect("project discovery for the display-fence fixture");
+
+    let result = render_document_to_file(
+        &input,
+        "html",
+        &RenderToFileOptions::default(),
+        Some(&project),
+        runtime.clone(),
+        None,
+        None,
+        None,
+    )
+    .unwrap_or_else(|e| panic!("render must succeed, but the display fence made it fail: {e}"));
+
+    read_html(&result.output_path)
+}
+
+fn read_html(path: &Path) -> String {
+    std::fs::read_to_string(path).expect("read rendered HTML")
+}
+
+/// Assert the display fence survived as a *non-executed*, highlighted block,
+/// and that the executable cell next to it still ran.
+fn assert_fence_rendered(html: &str, spelling: &str) {
+    // The engine ran: `OUT` exists only at runtime (the source says
+    // `paste0("O", "UT")`), so this cannot be satisfied by an echo.
+    assert!(
+        html.contains("OUT"),
+        "{spelling}: the executable cell must still run"
+    );
+    // The display block is highlighted as R, i.e. the highlighter resolved
+    // the language rather than the block arriving mangled.
+    assert!(
+        html.contains("sourceCode r"),
+        "{spelling}: display fence must render as a highlighted R block; html:\n{html}"
+    );
+    // Its body survived intact.
+    assert!(
+        html.contains("pak"),
+        "{spelling}: display fence body must survive"
+    );
+    // The smoking gun of the old failure, in case it ever returns in a
+    // non-fatal form: the wrapper must never appear in the output.
+    assert!(
+        !html.contains("QuartoInlineRender"),
+        "{spelling}: the inline-R wrapper must not reach the output"
+    );
+}
+
+/// The spelling Pandoc and Quarto 1 accept, and the one knitr's own `.Rmd`
+/// output writes: three backticks, a space, the language.
+#[test]
+fn display_fence_with_space_renders() {
+    if !knitr_available() {
+        eprintln!("SKIP: knitr not available — display_fence_with_space_renders");
+        return;
+    }
+    let tmp = TempDir::new().unwrap();
+    let html = render_html(&tmp, "space.qmd", &doc_with_display_fence("``` r"));
+    assert_fence_rendered(&html, "``` r");
+}
+
+/// The no-space spelling — the one every other spelling collapses to.
+#[test]
+fn display_fence_without_space_renders() {
+    if !knitr_available() {
+        eprintln!("SKIP: knitr not available — display_fence_without_space_renders");
+        return;
+    }
+    let tmp = TempDir::new().unwrap();
+    let html = render_html(&tmp, "nospace.qmd", &doc_with_display_fence("```r"));
+    assert_fence_rendered(&html, "```r");
+}
+
+/// The canonical Pandoc attribute spelling.
+#[test]
+fn display_fence_with_pandoc_attr_renders() {
+    if !knitr_available() {
+        eprintln!("SKIP: knitr not available — display_fence_with_pandoc_attr_renders");
+        return;
+    }
+    let tmp = TempDir::new().unwrap();
+    let html = render_html(&tmp, "attr.qmd", &doc_with_display_fence("```{.r}"));
+    assert_fence_rendered(&html, "```{.r}");
+}
+
+/// A four-backtick fence, which the writer emits when the body contains a
+/// backtick. knitr's own lookbehinds are anchored to a line's first two
+/// backticks and so miss this shape entirely; our prefix guard is not
+/// anchored and covers it like any other fence.
+#[test]
+fn four_backtick_display_fence_renders() {
+    if !knitr_available() {
+        eprintln!("SKIP: knitr not available — four_backtick_display_fence_renders");
+        return;
+    }
+    let tmp = TempDir::new().unwrap();
+    let content = "---\ntitle: Wide fence\nengine: knitr\n---\n\n\
+                   ```{r}\ncat(paste0(\"O\", \"UT\"), \"\\n\")\n```\n\n\
+                   ````r\nx <- `y`\n````\n\nAfter.\n";
+    let html = render_html(&tmp, "wide.qmd", content);
+    assert!(html.contains("OUT"), "the executable cell must still run");
+    // Without this the test passes even if the fence body were swallowed:
+    // "renders at all" and "wrapper absent" are both satisfied by an empty
+    // block. Assert on the backtick *inside* the body — the thing that makes
+    // the writer widen the fence in the first place, and the byte the old
+    // pattern used as its closing delimiter. (Not on `x <- `: the highlighter
+    // splits that across spans.)
+    assert!(
+        html.contains("sourceCode r"),
+        "the wide fence must render as a highlighted R block; html:\n{html}"
+    );
+    assert!(
+        html.contains("`y`"),
+        "the wide fence's body, backtick and all, must survive; html:\n{html}"
+    );
+    assert!(
+        !html.contains("QuartoInlineRender"),
+        "the inline-R wrapper must not reach the output"
+    );
+}
+
+/// A fence spelling inside a front-matter scalar. This one is mid-line, so
+/// knitr's line-anchored lookbehinds would still eat it; the non-backtick
+/// prefix guard is what rejects it.
+#[test]
+fn fence_spelling_in_yaml_scalar_renders() {
+    if !knitr_available() {
+        eprintln!("SKIP: knitr not available — fence_spelling_in_yaml_scalar_renders");
+        return;
+    }
+    let tmp = TempDir::new().unwrap();
+    let content = "---\ntitle: \"In the title: ```r blocks\"\nengine: knitr\n---\n\n\
+                   ```{r}\ncat(paste0(\"O\", \"UT\"), \"\\n\")\n```\n\nProse.\n";
+    let html = render_html(&tmp, "yamltitle.qmd", content);
+    assert!(html.contains("OUT"), "the executable cell must still run");
+    // knitr re-scans the string we hand it, and its lookbehinds check for
+    // adjacent backticks rather than escaped ones — so it would not reject
+    // this scalar on its own. Pin the surviving text, or the two assertions
+    // either side of this one would still hold if knitr mangled the title.
+    assert!(
+        html.contains("```r blocks"),
+        "the title scalar must survive intact; html:\n{html}"
+    );
+    assert!(
+        !html.contains("QuartoInlineRender"),
+        "the inline-R wrapper must not reach the output"
+    );
+}
+
+/// The guard must not cost us a real inline expression sharing a document
+/// with a display fence — the case that makes a naive "skip everything near a
+/// backtick" fix wrong.
+#[test]
+fn inline_r_still_evaluated_next_to_a_display_fence() {
+    if !knitr_available() {
+        eprintln!("SKIP: knitr not available — inline_r_still_evaluated_next_to_a_display_fence");
+        return;
+    }
+    let tmp = TempDir::new().unwrap();
+    let content = "---\ntitle: Both\nengine: knitr\n---\n\n\
+                   ```{r}\nvalue <- 6 * 7\n```\n\n\
+                   ``` r\ninstall.packages(\"cli\")\n```\n\n\
+                   The answer is `r value`.\n";
+    let html = render_html(&tmp, "both.qmd", content);
+    assert!(
+        html.contains("42"),
+        "the inline expression must still be evaluated; html:\n{html}"
+    );
+    assert!(
+        html.contains("sourceCode r"),
+        "the display fence must still render as an R block"
+    );
+}

--- a/crates/quarto-core/tests/integration/main.rs
+++ b/crates/quarto-core/tests/integration/main.rs
@@ -44,6 +44,7 @@ pub mod incremental_rebuild;
 pub mod julia_engine_e2e;
 pub mod jupyter_integration;
 pub mod jupyter_kernel_cleanup;
+pub mod knitr_display_fence;
 pub mod language_catalog;
 pub mod language_pipeline;
 pub mod language_resolve;


### PR DESCRIPTION
Any R **display** fence — one carrying a language but no braces — was a fatal parse error in a document the knitr engine runs, and the whole page was lost. Quarto 1 renders every spelling. The Positron docs port loses `download.qmd` to this, which breaks 85 site-wide references because every page's navbar carries one.

Closes bd-knitr-inline-r-eats-fence-2ofk91x1 (P0).

## The bug

Two stages compounded, and neither alone explains it:

1. **The qmd writer collapses every spelling into one.** ``` ``` r ```, ``` ```{.r} ``` and ``` ```r ``` all re-serialize to ``` ```r ``` (`crates/pampa/src/writers/qmd.rs:783`).
2. **The inline-R preprocessor then eats that one spelling.** `` `r\s+([^`]+)` `` ran over the whole serialized document, front matter included. Against ``` ```r ``` it anchored on the fence's *third* backtick, `\s+` consumed the newline, and `[^`]+` swallowed the block body up to the closing fence:

```
```r .QuartoInlineRender(# if you're a pak person (we are!)
```

Authors could not route around it. Every spelling arrives at the preprocessor as the dangerous one, so there was no source form to migrate to and nothing to lint for. The only escape was capital ``` ```R ```, which renders unhighlighted.

The doc comment claimed a fenced-code-block guard that the code had never had — it was untrue from the commit that introduced it (`748856f50`, Jan 7), and the pattern is byte-identical since.

## The fix

```rust
Regex::new(r"(^|[^`\\])`r[ \t]([^`]+)`")
```

Two guards, not interchangeable:

- **The guard character** is the load-bearing fence defense and covers every fence shape, three backticks or forty, because the backtick that would anchor a match is always itself preceded by a backtick. Its backtick half is Quarto 1's idiom from `src/core/execute-inline.ts`.
- **`[ \t]` rather than `\s+`** means a newline can never open an expression — knitr parity (its own class is `[ #]`) plus defense in depth. It is *not* what stops a fence; its regression case is a `` `r\nx` `` in ordinary prose.

Relative to the old pattern this is a **pure narrowing**: nothing new matches, and all 16 pre-existing tests pass unchanged.

### Why the backslash goes beyond both reference implementations

knitr's own pattern (`knitr::all_patterns$md$inline.code`, captured from knitr 1.50) is the real contract — knitr re-scans the string we hand it:

```
(?<!(^``))(?<!(\n``))`r[ #]([^`]+)\s*`
```

Its lookbehinds are line-anchored, so a fence spelling inside a front-matter scalar is mid-line and **knitr itself still eats it**. Worse, when a YAML scalar fails to parse as markdown, q2's `.yaml-markdown-syntax-error` fallback re-serializes it with every backtick escaped:

```
title: "[Backtick r in the title: \`\`\`r blocks]{.yaml-markdown-syntax-error}"
```

The backticks are no longer adjacent, so the third is preceded by `\`. Quarto 1's `(^|[^`])` and knitr's lookbehinds both let that through. Excluding the backslash rejects it, on the general ground that an escaped backtick cannot open a code span. The cost — declining an escaped *backslash* followed by a genuine expression — is documented at the pattern.

## Verification

Every test was watched failing first.

- **11 unit tests** in `preprocess.rs`; 8 failed against the old pattern. The three that pass before *and* after are regression guards (inline R beside a fence, a tab separator, a body spanning lines).
- **6 render-level tests** in `crates/quarto-core/tests/integration/knitr_display_fence.rs`, through `render_document_to_file` — the entry `q2 render` uses — gated on knitr availability. Proved red by stashing the fix: all six failed, five with `Parse error` and the YAML one inside R.

End-to-end, all six repro fixtures through the real binary:

| fixture | before | after |
|---|---|---|
| ``` ``` r ``` | fatal | renders, `sourceCode r` |
| ``` ```r ``` | fatal | renders, `sourceCode r` |
| ``` ```{.r} ``` | fatal | renders, `sourceCode r` |
| ``` ```r ``` in a YAML scalar | fatal | renders |
| ``` ```bash ``` (control) | renders | unchanged |
| ``` ```R ``` (workaround) | renders unhighlighted | unchanged |

`QuartoInlineRender` appears in none of the six outputs.

`cargo xtask verify` (full, including the WASM leg) was green on the same tree. Workspace **13385 passed / 199 skipped** against a 13368 / 199 baseline — the +17 is exactly this branch's new tests.

## Deliberately out of scope

- **The qmd writer's bare-word fence.** Pandoc writes ``` ``` r ``` where q2 writes ``` ```r ```; fixing that would be independent defense-in-depth and near-zero churn, but it isn't needed once the regex is guarded.
- **``` ```R ``` renders unhighlighted.** The highlight registry resolves a language by exact map hit and registers `("r", &[])` with no aliases. It is currently the only spelling authors can ship, so this fix must not disturb it — and **the pattern must never be made case-insensitive**, which would turn that spelling fatal too. Noted at the code.
- **The error is uncoded and cites an unopenable intermediate.** Filed the retention half as bd-ps046hi3; the `Q-` code and real source mapping are not filed.

A latent trap is recorded in the module doc rather than fixed: this pass runs *after* `serialize_ast_to_qmd`, so the `SourceInfo` on `ExecutionContext` describes the pre-substitution string. Harmless today (only the jupyter/ts engines read it), but whoever gives knitr real source locations must reconcile the two first.
