### PR TITLE
Style the footer copy of repo-actions (bd-repo-actions-footer-unstyled-80xtt35y)

### DIFF
--- a/claude-notes/plans/2026-08-25-repo-actions-footer-css.md
+++ b/claude-notes/plans/2026-08-25-repo-actions-footer-css.md
@@ -1,0 +1,123 @@
+# repo-actions footer copy ships no CSS
+
+**Strand:** bd-repo-actions-footer-unstyled-80xtt35y
+**Discovered from:** bd-repo-actions-missing-99ezd2fe (closed — shipped in 0.27.0)
+**Branch:** `braid/bd-repo-actions-footer-unstyled-80xtt35y-repo-actions-footer-unstyled`
+
+## Overview
+
+repo-actions emits two copies of the `.toc-actions` block: one in the TOC
+sidebar, one in the page footer. The markup for both is byte-for-byte Q1's.
+The *footer* copy, however, inherits no styles — every `.toc-actions` rule
+q2 ships is scoped under `.sidebar` — so those links render as a
+browser-default bulleted list instead of Q1's centred horizontal row.
+
+The missing source is one self-contained block in Q1's
+`src/resources/projects/website/navigation/quarto-nav.scss:770-802`, inside
+that file's `/*-- scss:rules --*/` layer. **No SCSS variables are involved** —
+every value is a literal, so it ports verbatim with nothing lost.
+
+### Why this is not a dedup opportunity
+
+q2 already has `.toc-actions` rules at
+`resources/scss/bootstrap/_bootstrap-rules.scss:1816-1948`, but they are all
+`.sidebar .toc-actions` and are variable-driven/themed. The sidebar and footer
+treatments are **deliberately different in kind** — a vertical themed list vs.
+a centred flex row. They must not be unified.
+
+### Scope is exactly these rules
+
+Checked before starting, so the fix does not land in a broken shell: q2 already
+has the surrounding three-column footer layout. Rendered-CSS selector counts,
+q2 vs Q1: `.nav-footer-center` 8 vs 8, `.footer-items` 7 vs 7. The one
+difference, `.nav-footer-contents` (0 vs 1), appears in zero HTML files in
+either engine and is inert. The `d-sm-block d-md-none` responsive behaviour is
+stock Bootstrap utility classes, not Quarto CSS.
+
+## Work items
+
+- [x] Reproduce: confirm the markup/CSS asymmetry at current `main`, not just
+      at the 0.27.0 release build
+- [x] Extend the `repo_actions_pipeline` harness to expose the `_site` root so
+      a test can read the compiled theme CSS
+- [x] **Failing test first**: `footer_repo_actions_ship_their_css` asserts each
+      of the eight rules reaches the rendered CSS; a second test asserts the
+      sidebar rules are undisturbed and that no footer rule leaks into `.sidebar`
+- [x] Verify the tests fail at HEAD for the right reason
+- [x] Port `quarto-nav.scss:770-802` verbatim into the page-footer section of
+      `resources/scss/bootstrap/_bootstrap-rules.scss`
+- [x] Verify the tests pass
+- [x] End-to-end: render the strand's repro website with `q2 render` and inspect
+      the emitted CSS and the rendered page
+- [x] Workspace verify (`cargo xtask verify --skip-hub-build --skip-hub-tests`)
+- [x] Re-capture the `phase5-single-doc-baseline` styles.css hash (see below)
+
+## Test strategy
+
+The defect is invisible to markup assertions — the existing suite passes while
+the bug ships, which is precisely how it escaped. The regression test therefore
+reads the *compiled CSS* out of a real rendered `_site`, parses the rule blocks
+whose selector mentions both `.nav-footer` and `toc-action`, and asserts on the
+declarations. Matching is structural (`selector{decls}`) rather than on
+formatting, because the emitted CSS is minified.
+
+## End-to-end verification (2026-08-25)
+
+Rendered a two-page website fixture with `repo-actions: [edit, source, issue]`
+through the real binary:
+
+    cargo run --bin q2 -- render <fixture>
+    Rendered 2 of 2 files to <fixture>/_site
+
+The strand's own repro measurement, run against that output:
+
+    toc-action links             6      (was 6 — markup was never the problem)
+    toc-actions containers       2      (was 2)
+    .nav-footer …toc-action rules  8    (was 0)
+
+The eight emitted rules were diffed against Q1's compiled
+`bootstrap-*.min.css` from the strand's repro and are **byte-for-byte
+identical**:
+
+    .nav-footer .toc-actions a,.nav-footer .toc-actions a:hover{text-decoration:none}
+    .nav-footer .toc-actions ul :first-child{margin-left:auto}
+    .nav-footer .toc-actions ul :last-child{margin-right:auto}
+    .nav-footer .toc-actions ul li i.bi{padding-right:.4em}
+    .nav-footer .toc-actions ul li:last-of-type{padding-right:0}
+    .nav-footer .toc-actions ul li{padding-right:1.5em}
+    .nav-footer .toc-actions ul{display:flex;list-style:none}
+    .nav-footer .toc-actions{padding-bottom:.5em;padding-top:.5em}
+
+The rendered footer markup was inspected and every selector matches it:
+`.nav-footer > .nav-footer-center > .toc-actions.d-sm-block.d-md-none > ul >
+li > a.toc-action > i.bi`.
+
+No regression to the sidebar treatment: 9 `.sidebar …toc-actions` rules are
+still emitted, 0 of the new footer rules mention `.sidebar`, and the TOC copy's
+container is still present in the HTML.
+
+## Pinned-hash re-capture
+
+`artifact_scoping_pipeline::single_doc_render_unchanged_under_scope_refactor`
+pins a sha256 of the compiled `doc_files/styles.css` against
+`tests/fixtures/phase5-single-doc-baseline/expected_hashes.txt`. Adding rules
+to the SCSS necessarily shifts it, so the baseline was re-captured with a
+documented note, per that file's standing convention for every prior SCSS port:
+
+    doc_files/styles.css  60291dc1…  ->  a184a291…
+
+`doc.html` is **unchanged**, and that was confirmed empirically rather than
+assumed: it is the first entry the test checks, and it passed before the
+styles.css assertion fired. A single-doc render has no footer at all, so the
+new selectors match nothing in the fixture.
+
+Note on attribution: the first post-fix verify reported all tests passing, which
+was misleading — SCSS is embedded via `include_dir!` at compile time, and that
+run's test binary had been built before the SCSS edit. Only the second run,
+which recompiled, surfaced the hash shift.
+
+## Final verification
+
+`cargo xtask verify --skip-hub-build --skip-hub-tests` — **all 14 steps green**,
+13426 tests passed, 199 skipped, custom lints + clippy clean under `-D warnings`.
+

--- a/crates/quarto-core/tests/fixtures/phase5-single-doc-baseline/expected_hashes.txt
+++ b/crates/quarto-core/tests/fixtures/phase5-single-doc-baseline/expected_hashes.txt
@@ -396,5 +396,19 @@
 # secondary nav, so the header partial emits nothing, no `nav-fixed`
 # body class is composed, and QuartoNavJsTransform ships no scripts —
 # the template/JS side of the strand is byte-neutral outside websites.
+# Re-captured 2026-08-25 (bd-repo-actions-footer-unstyled-80xtt35y):
+# styles.css hash updated because the footer copy of repo-actions gained the
+# eight rules it had been shipping without. `.nav-footer .toc-actions` (and its
+# `a`/`ul`/`li`/`i.bi`/`:first-child`/`:last-child`/`li:last-of-type` children)
+# was ported verbatim from Q1's `quarto-nav.scss:770-802` into the page-footer
+# section of `_bootstrap-rules.scss`. No SCSS variables are involved, so the
+# port is literal; the compiled rules are byte-for-byte identical to Q1's.
+# repo-actions' markup half shipped complete in 0.27.0
+# (bd-repo-actions-missing-99ezd2fe) but every `.toc-actions` rule q2 had was
+# scoped under `.sidebar`, so the footer links rendered as a browser-default
+# bulleted list instead of a centred flex row. The sidebar rules are untouched
+# and deliberately NOT unified with these — the two treatments differ in kind.
+# doc.html hash unchanged: CSS-only change, and a single-doc render has no
+# footer at all, so the new selectors match nothing in the fixture's body.
 doc.html a0540297514ad41734a23e91c9511134b1fa469281ec470339571ffd5d404494
-doc_files/styles.css 60291dc134c93743c6ac174f12324c07f3ad7d2fe7e060f8869541cf5583b8db
+doc_files/styles.css a184a29137e14e4b35c4c791156314888268503c3d313889e94177295f0c5c2d

--- a/crates/quarto-core/tests/integration/repo_actions_pipeline.rs
+++ b/crates/quarto-core/tests/integration/repo_actions_pipeline.rs
@@ -42,6 +42,15 @@ fn read(path: &std::path::Path) -> String {
 /// `project-relative output href → rendered HTML` (href, not stem —
 /// breadcrumb fixtures have several `index.html` at different depths).
 fn render_project(fixture: impl FnOnce(&std::path::Path)) -> Vec<(String, String)> {
+    render_project_to_site(fixture).1
+}
+
+/// As `render_project`, but also hands back the `_site` root so a test
+/// can inspect the non-HTML artifacts (`site_libs/**`, notably the
+/// compiled theme CSS).
+fn render_project_to_site(
+    fixture: impl FnOnce(&std::path::Path),
+) -> (PathBuf, Vec<(String, String)>) {
     let temp = TempDir::new().unwrap();
     let project_dir = canonical(temp.path());
     fixture(&project_dir);
@@ -73,7 +82,7 @@ fn render_project(fixture: impl FnOnce(&std::path::Path)) -> Vec<(String, String
     std::mem::forget(temp); // keep files alive for inspection
 
     let site_root = project_dir.join("_site");
-    summary
+    let outputs = summary
         .outputs
         .iter()
         .map(|out| {
@@ -85,7 +94,8 @@ fn render_project(fixture: impl FnOnce(&std::path::Path)) -> Vec<(String, String
                 .replace('\\', "/");
             (href, read(&out.output_path))
         })
-        .collect()
+        .collect();
+    (site_root, outputs)
 }
 
 fn find_html<'a>(outputs: &'a [(String, String)], href: &str) -> &'a str {
@@ -363,4 +373,175 @@ fn no_repo_actions_configured_changes_nothing() {
     let html = find_html(&outputs, "index.html");
     assert!(!html.contains("toc-actions"));
     assert!(!html.contains("<footer class=\"footer\""));
+}
+
+// ---------------------------------------------------------------------------
+// Footer styling (bd-repo-actions-footer-unstyled-80xtt35y)
+//
+// The markup half of repo-actions shipped complete, but the page-footer
+// copy inherited no CSS: q2 scoped every `.toc-actions` rule under
+// `.sidebar`, so the footer links rendered as a browser-default bulleted
+// list instead of Q1's centred flex row. The rules live in Q1 at
+// `src/resources/projects/website/navigation/quarto-nav.scss:770-798`.
+// ---------------------------------------------------------------------------
+
+/// Concatenate every `.css` file the render dropped under `_site`.
+fn site_css(site_root: &std::path::Path) -> String {
+    fn walk(dir: &std::path::Path, out: &mut String) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                walk(&path, out);
+            } else if path.extension().is_some_and(|e| e == "css") {
+                out.push_str(&read(&path));
+                out.push('\n');
+            }
+        }
+    }
+    let mut out = String::new();
+    walk(site_root, &mut out);
+    assert!(!out.is_empty(), "render emitted no CSS at all");
+    out
+}
+
+/// Declaration blocks of every rule whose selector list mentions
+/// `.nav-footer` *and* `toc-action`. The emitted CSS is minified, so we
+/// match on structure (`selector{decls}`) rather than on formatting.
+fn footer_action_rules(css: &str) -> Vec<(String, String)> {
+    let mut rules = Vec::new();
+    let mut rest = css;
+    while let Some(open) = rest.find('{') {
+        let selector = rest[..open].rsplit('}').next().unwrap_or("").trim();
+        let Some(close) = rest[open..].find('}') else {
+            break;
+        };
+        let decls = &rest[open + 1..open + close];
+        if selector.contains(".nav-footer") && selector.contains("toc-action") {
+            rules.push((selector.to_string(), decls.to_string()));
+        }
+        rest = &rest[open + close..];
+    }
+    rules
+}
+
+#[test]
+fn footer_repo_actions_ship_their_css() {
+    let (site_root, outputs) = render_project_to_site(|dir| {
+        fixture(dir, "  repo-actions: [edit, source, issue]\n", "");
+    });
+
+    // Precondition: the markup is there. If this fires, the test is
+    // measuring the wrong thing.
+    let html = find_html(&outputs, "index.html");
+    assert!(
+        html.contains("toc-actions d-sm-block d-md-none"),
+        "fixture should emit the footer copy of the actions"
+    );
+
+    let css = site_css(&site_root);
+    let rules = footer_action_rules(&css);
+    assert!(
+        !rules.is_empty(),
+        "no `.nav-footer … toc-action…` rule reached the rendered CSS — the \
+         footer links fall back to a bulleted list (bd-repo-actions-footer-unstyled)"
+    );
+
+    let find = |needle: &str| -> Option<&(String, String)> {
+        rules.iter().find(|(sel, _)| sel.contains(needle))
+    };
+
+    // The two declarations that produce the visible symptom: without
+    // them the `<ul>` is a bulleted block, not a horizontal row.
+    let ul = find("toc-actions ul").expect("a rule scoped to `.nav-footer .toc-actions ul`");
+    assert!(
+        ul.1.contains("display:flex"),
+        "`{}` must set display:flex, got `{{{}}}`",
+        ul.0,
+        ul.1
+    );
+    assert!(
+        ul.1.contains("list-style:none"),
+        "`{}` must set list-style:none, got `{{{}}}`",
+        ul.0,
+        ul.1
+    );
+
+    // The `auto` margin pair is what centres the row.
+    let first = find(":first-child").expect("a `:first-child` rule centring the row");
+    assert!(
+        first.1.contains("margin-left:auto"),
+        "`{}` must set margin-left:auto, got `{{{}}}`",
+        first.0,
+        first.1
+    );
+    let last = find(":last-child").expect("a `:last-child` rule centring the row");
+    assert!(
+        last.1.contains("margin-right:auto"),
+        "`{}` must set margin-right:auto, got `{{{}}}`",
+        last.0,
+        last.1
+    );
+
+    // Inter-item spacing, the icon gap, and the trailing-item reset.
+    let li = find("toc-actions ul li").expect("a rule spacing the `li`s");
+    assert!(
+        li.1.contains("padding-right:1.5em"),
+        "`{}` must set padding-right:1.5em, got `{{{}}}`",
+        li.0,
+        li.1
+    );
+    assert!(
+        find("i.bi").is_some_and(|(_, d)| d.contains("padding-right:.4em")),
+        "the footer `i.bi` icon gap is missing; rules: {:?}",
+        rules.iter().map(|(s, _)| s).collect::<Vec<_>>()
+    );
+    assert!(
+        find("li:last-of-type").is_some_and(|(_, d)| d.contains("padding-right:0")),
+        "the last item's padding reset is missing; rules: {:?}",
+        rules.iter().map(|(s, _)| s).collect::<Vec<_>>()
+    );
+
+    // Link underlines off, and the block's own vertical padding.
+    assert!(
+        find("toc-actions a").is_some_and(|(_, d)| d.contains("text-decoration:none")),
+        "footer action links must not be underlined; rules: {:?}",
+        rules.iter().map(|(s, _)| s).collect::<Vec<_>>()
+    );
+    let block = rules
+        .iter()
+        .find(|(sel, _)| sel.trim_end().ends_with(".toc-actions"))
+        .expect("a rule on `.nav-footer .toc-actions` itself");
+    assert!(
+        block.1.contains("padding-top:.5em") && block.1.contains("padding-bottom:.5em"),
+        "`{}` must carry the 0.5em vertical padding, got `{{{}}}`",
+        block.0,
+        block.1
+    );
+}
+
+/// The sidebar and footer `.toc-actions` treatments are deliberately
+/// different in kind — a vertical themed list vs. a centred flex row.
+/// Adding the footer rules must not disturb the sidebar ones.
+#[test]
+fn footer_css_does_not_disturb_the_sidebar_rules() {
+    let (site_root, _) = render_project_to_site(|dir| {
+        fixture(dir, "  repo-actions: [edit, source, issue]\n", "");
+    });
+    let css = site_css(&site_root);
+
+    assert!(
+        css.contains(".sidebar .toc-actions"),
+        "the sidebar `.toc-actions` rules must still be present"
+    );
+    for (selector, decls) in footer_action_rules(&css) {
+        assert!(
+            !selector.contains(".sidebar"),
+            "footer rule `{}` must not also target the sidebar (`{{{}}}`)",
+            selector,
+            decls
+        );
+    }
 }

--- a/resources/scss/bootstrap/_bootstrap-rules.scss
+++ b/resources/scss/bootstrap/_bootstrap-rules.scss
@@ -3235,6 +3235,50 @@ body .nav-footer {
   }
 }
 
+// Repo-actions, footer copy (bd-repo-actions-footer-unstyled-80xtt35y).
+// Ported verbatim from `quarto-nav.scss:770-802`; no SCSS variables are
+// involved, so nothing is lost in the port.
+//
+// This is deliberately NOT shared with the `.sidebar .toc-actions` rules
+// above (~line 1816): the two treatments differ in kind — the sidebar copy
+// is a themed vertical list, this one a centred horizontal row — so they
+// must not be unified. `display: flex` + `list-style: none` is what stops
+// the links rendering as a browser-default bulleted list; the
+// `:first-child`/`:last-child` `auto` margin pair centres the row.
+.nav-footer .toc-actions {
+  a,
+  a:hover {
+    text-decoration: none;
+  }
+
+  ul {
+    display: flex;
+    list-style: none;
+
+    :first-child {
+      margin-left: auto;
+    }
+    :last-child {
+      margin-right: auto;
+    }
+
+    li {
+      padding-right: 1.5em;
+
+      i.bi {
+        padding-right: 0.4em;
+      }
+    }
+
+    li:last-of-type {
+      padding-right: 0;
+    }
+  }
+
+  padding-bottom: 0.5em;
+  padding-top: 0.5em;
+}
+
 // Task lists (bd-obkvhlam). The HTML writer renders `- [ ]`/`- [x]` items as
 // `<ul class="task-list"><li><label><input type="checkbox" …/>…</label></li>`.
 // ported from _quarto-rules.scss:338-340


### PR DESCRIPTION
## The defect

`repo-actions` shipped in 0.27.0 ([bd-repo-actions-missing-99ezd2fe](https://github.com/quarto-dev/q2/pull/524)) with its markup half complete and correct. The **page-footer copy, however, had no styles**: every `.toc-actions` rule q2 carried was scoped under `.sidebar`, so those links rendered as a browser-default bulleted list instead of Q1's centred horizontal row.

Measured on a two-page website with `repo-actions: [edit, source, issue]`:

|                                   | q2 0.27.0 | Q1 99.9.9 | q2 after |
| --------------------------------- | --------: | --------: | -------: |
| `toc-action` links                |         6 |         6 |        6 |
| `toc-actions` containers          |         2 |         2 |        2 |
| `.nav-footer …toc-action` rules   |     **0** |     **8** |    **8** |

The markup columns were already identical — the emitted HTML is byte-for-byte Q1's. The entire defect was the last column.

Every page of the Positron website docs with a footer was affected.

## The fix

Port the eight rules verbatim from Q1's `src/resources/projects/website/navigation/quarto-nav.scss:770-802` into the page-footer section of `_bootstrap-rules.scss`.

**No SCSS variables are involved** — every value is a literal, so the port is exact and nothing is lost. `display: flex` + `list-style: none` fixes the visible symptom; the `:first-child`/`:last-child` `auto` margin pair centres the row.

The sidebar `.toc-actions` rules are **deliberately not unified** with these. The two treatments differ in kind — a themed vertical list vs. a centred flex row — and the sidebar's live in a variable-driven block while these are literal. The commit leaves a comment saying so, since "these look like duplicates" is the obvious wrong refactor here.

## Why it was missed

The implementation plan cited q2's existing `.toc-actions` rules under a heading "What q2 already has" — true of the TOC copy, not of the footer copy. Nothing in the plan mentioned footer styling, so the second emission site got markup and inherited no styles.

It was also invisible to the port's entire sweep toolkit: visible-text diffing cannot distinguish a bulleted list from a flex row, and the asset/link checkers do not read CSS. It was found by looking at the rendered page.

## Tests

The existing suite asserted only markup — which is exactly how this shipped. The two new tests therefore read the **compiled CSS out of a real rendered `_site`** and assert on parsed rule blocks (structurally, since the emitted CSS is minified):

- `footer_repo_actions_ship_their_css` — each of the eight rules reaches the rendered CSS.
- `footer_css_does_not_disturb_the_sidebar_rules` — the sidebar rules survive, and no footer rule leaks into `.sidebar`.

`render_project` gained a `render_project_to_site` variant that exposes the site root so a test can reach `site_libs/**`.

Confirmed **red first**, with the right message (`no .nav-footer … toc-action… rule reached the rendered CSS`), after its precondition assertions (markup present, CSS non-empty) had passed.

## End-to-end verification

Via the real binary, not just in-process tests:

```
cargo run --bin q2 -- render <fixture>
Rendered 2 of 2 files to <fixture>/_site
```

The eight emitted rules were diffed against Q1's compiled `bootstrap-*.min.css` and are **byte-for-byte identical**:

```
.nav-footer .toc-actions a,.nav-footer .toc-actions a:hover{text-decoration:none}
.nav-footer .toc-actions ul :first-child{margin-left:auto}
.nav-footer .toc-actions ul :last-child{margin-right:auto}
.nav-footer .toc-actions ul li i.bi{padding-right:.4em}
.nav-footer .toc-actions ul li:last-of-type{padding-right:0}
.nav-footer .toc-actions ul li{padding-right:1.5em}
.nav-footer .toc-actions ul{display:flex;list-style:none}
.nav-footer .toc-actions{padding-bottom:.5em;padding-top:.5em}
```

The rendered footer markup was inspected and every selector matches it: `.nav-footer > .nav-footer-center > .toc-actions.d-sm-block.d-md-none > ul > li > a.toc-action > i.bi`. Sidebar unaffected — 9 `.sidebar …toc-actions` rules still emitted, 0 footer rules mentioning `.sidebar`.

## ⚠️ Pinned-hash re-capture (please review)

This changes the `doc_files/styles.css` sha256 in `tests/fixtures/phase5-single-doc-baseline/expected_hashes.txt`:

```
60291dc134c93743…  ->  a184a29137e14e4b…
```

Adding rules to the SCSS necessarily shifts it. Re-captured with a documented note, per that file's standing convention for every prior SCSS port.

`doc.html` is **unchanged** — confirmed empirically, not assumed: it is the first entry the test checks and it passed before the `styles.css` assertion fired. A single-doc render has no footer at all, so the new selectors match nothing in the fixture.

**No `.snap` snapshot files are affected by this PR.**

One attribution note for reviewers, since it is a trap worth knowing: SCSS is embedded via `include_dir!` at *compile* time. A verify run whose test binary was built before an SCSS edit will report all-green while silently testing the old stylesheet. Only a recompiled run surfaces the hash shift.

## Verification

`cargo xtask verify --skip-hub-build --skip-hub-tests` — **all 14 steps green**, 13426 tests passed, 199 skipped, custom lints + clippy clean under `-D warnings`.

Rust-only change plus SCSS; the hub-client/WASM leg is untouched.

Plan: `claude-notes/plans/2026-08-25-repo-actions-footer-css.md`
Strand: `bd-repo-actions-footer-unstyled-80xtt35y` (discovered-from `bd-repo-actions-missing-99ezd2fe`)
Origin strand in the Positron-docs porting skein: `br-repo-actions-footer-unstyled-ty1os83n`
