### PR TITLE
ci: fix 'Commit new baselines' push on pull_request builds

### DIFF
--- a/.github/workflows/hub-client-e2e.yml
+++ b/.github/workflows/hub-client-e2e.yml
@@ -243,12 +243,30 @@ jobs:
       # not one directory deeper.
       - name: Commit new baselines
         if: steps.visual.outcome == 'failure' && steps.visual-retry.outcome == 'success'
+        env:
+          PR_HEAD_REF: ${{ github.head_ref }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          if [ -n "$PR_HEAD_REF" ]; then
+            # PR builds run on a detached merge-commit HEAD, where plain
+            # `git push` fails ("not currently on a branch") — and pushing
+            # the merge commit to the branch would be wrong anyway. Commit
+            # the baselines on top of the real branch tip instead. The
+            # generated PNGs are gitignored, so they survive this checkout.
+            # The default fetch-depth-1 checkout only has the merge commit,
+            # so fetch the head SHA explicitly.
+            git fetch --depth=1 origin "$PR_HEAD_SHA"
+            git checkout -B ci-baseline-commit "$PR_HEAD_SHA"
+          fi
           find hub-client/e2e -type d -name '*-snapshots' -exec git add -f {} +
           git diff --cached --quiet || git commit -m "Add missing Playwright visual regression baselines"
-          git push
+          if [ -n "$PR_HEAD_REF" ]; then
+            git push origin "HEAD:refs/heads/$PR_HEAD_REF"
+          else
+            git push
+          fi
 
       # Fail the workflow if visual retry also failed (real regression)
       - name: Fail on visual regression


### PR DESCRIPTION
The `Commit new baselines` step in `hub-client-e2e.yml` ran plain `git push`, but PR builds check out a detached merge-commit HEAD, so the push fails with `fatal: You are not currently on a branch` ([run 32953026576](https://github.com/quarto-dev/q2/actions/runs/32953026576/job/98138122260), on the hub-client-uiux-phase0 PR — the first to hit the missing-baseline path on a PR).

**Fix:** on PRs, fetch the PR head SHA (the default fetch-depth-1 checkout only has the merge commit), commit the generated baselines on top of it, and push to `HEAD:refs/heads/<head_ref>`. The gitignored snapshot PNGs survive the checkout. Push events on main keep the existing behavior.

Once this lands, the next phase-0 PR run will auto-commit the 16 missing linux visual baselines that the failed run generated.