### PR TITLE
bd-wcz4x7y0: comment bubbles no longer drop Quoted (and other non-Str) inlines

### DIFF
--- a/claude-notes/plans/2026-08-26-comment-bubble-quoted-inlines.md
+++ b/claude-notes/plans/2026-08-26-comment-bubble-quoted-inlines.md
@@ -1,0 +1,206 @@
+# Comment bubbles drop Quoted (and all non-Str) inlines
+
+**Strand:** bd-wcz4x7y0 (follow-up for rich bubble rendering: bd-y66gbfs4)
+**Date:** 2026-08-26
+**Status:** implemented on `braid/bd-wcz4x7y0-comment-bubbles-drop-quoted`; e2e verified
+
+## Symptom
+
+On quarto-hub.com (live) and in `q2 preview`, an editorial comment
+`[>> Hello "world"]` renders its bubble as just `Hello` — the quoted
+word is silently gone. Minimal reproduction:
+`~/Desktop/daily-log/2026/08/26/hello.qmd`:
+
+```qmd
+---
+title: hello
+---
+
+Stuff.[>> Hello "world"]
+```
+
+## Diagnosis
+
+The parse is **correct**. `pampa -t native` on the fixture gives:
+
+```
+[ Para [Str "Stuff.", Span ( "" , ["quarto-edit-comment"] , [] )
+    [Str "Hello", Space, Quoted DoubleQuote [Str "world"]]] ]
+```
+
+and pampa's own HTML writer emits
+`<span class="quarto-edit-comment">Hello “world”</span>` — fine.
+Smart typography turns `"world"` into `Quoted DoubleQuote [Str "world"]`;
+that's expected.
+
+The bug is in the React preview renderer (confirmed by Carlos).
+`CommentBlock.tsx` extracts `quarto-edit-comment` spans from the block
+and renders their text in the bubble via a local stringifier,
+`commentSpanText` (`ts-packages/preview-renderer/src/q2-preview/custom/CommentBlock.tsx:133-141`):
+
+```ts
+function commentSpanText(span: InlineNode): string {
+    return (span as SpanInline).c[1]
+        .map((o: InlineNode) => {
+            if (o.t === 'Str') return (o as StrInline).c;
+            if (o.t === 'Space') return ' ';
+            return '';          // <-- Quoted, Emph, Code, Link, ... vanish
+        })
+        .join('');
+}
+```
+
+Any inline that is not `Str`/`Space` contributes the **empty string,
+without recursing into its content**. So this is not a quotes-only bug:
+`[>> use *this* one]` drops "this", `[>> see `code`]` drops the code,
+links drop their text, etc. Quotes are just the most common trigger
+because smart typography rewrites every `"..."` into a `Quoted` node.
+
+### Why the rest of the document is unaffected
+
+Comment spans stripped from the block are the only inlines routed
+through `commentSpanText`. Normal document content goes through the
+per-node dispatchers, whose `Quoted` renderer
+(`q2-preview/inlines/Quoted.tsx`) correctly emits `“…”`/`‘…’` around
+recursively rendered children.
+
+### The near-miss: a shared, almost-correct helper already exists
+
+`framework/plainText.ts` exports `inlinesToPlainText`, the
+"Pandoc-Stringify equivalent" used for image alt text, Note tooltips,
+title-block and meta-string coercion. It **recurses correctly** into
+`Quoted` (and Emph/Code/Link/...), but it currently drops the quote
+*marks*: `Quoted DoubleQuote [Str "q"]` → `q`, not `“q”` (the unit test
+at `plainText.test.ts:65` pins this: expects `'hiq'`).
+
+Pandoc's real `stringify` (Text.Pandoc.Shared) de-sugars `Quoted` via
+`deQuote` into `“ … ”` / `‘ … ’` (U+201C/D, U+2018/9) — the quote marks
+are part of the plain text. The preview's own `Quoted.tsx` renderer uses
+the same characters. So `plainText.ts` deviates from both its stated
+contract and the visual renderer.
+
+## Affected surfaces
+
+1. **`CommentBlock.tsx` `commentSpanText`** — the shipped bug: both the
+   compact bubble preview (line ~999) and the expanded rows (line ~912).
+2. **`framework/plainText.ts` `Quoted` case** — quote marks missing
+   from alt text / tooltips / meta strings (secondary, low-visibility,
+   but same "quotes disappear" class; fixing it makes helper and
+   renderer agree).
+3. **Experimental render-component examples** (same shallow pattern,
+   copy-pasted): `hub-client/src/components/render/experimental-components/comments.tsx.txt`
+   (lines ~40, ~298) and `.../new/comments_rc.jsx` (lines ~40, ~309).
+   These are user-facing example components, not compiled into the app.
+
+Not affected: pampa HTML writer, `q2 render` output, the AST, the qmd
+round-trip (add/resolve commits go through the qmd writer, which
+serializes `Quoted` correctly).
+
+## Proposed fix
+
+Replace the local `commentSpanText` with the shared walk, and teach the
+shared walk to emit quote marks (Pandoc-stringify parity):
+
+**A. `framework/plainText.ts`** — in `inlineText`, split `Quoted` out
+of the `Span` case and wrap the recursed content in the kind-appropriate
+curly quotes:
+
+```ts
+case 'Quoted': {
+    const [kind, inlines] = n.c as [{ t: string }, InlineNode[]];
+    const [open, close] =
+        kind?.t === 'SingleQuote' ? ['‘', '’'] : ['“', '”'];
+    return open + inlinesToPlainText(inlines ?? []) + close;
+}
+```
+
+(Reuse/mirror the `QUOTE_CHARS` table from `inlines/Quoted.tsx`; decide
+during implementation whether to export it from one place.)
+
+**B. `CommentBlock.tsx`** — delete `commentSpanText`; both call sites
+become `inlinesToPlainText((span as SpanInline).c[1])`.
+
+**C. Experimental examples** — apply the same substitution in
+`comments.tsx.txt` / `comments_rc.jsx`. The render-components runtime
+already exposes `inlinesToPlainText` (`q2-preview/entry.tsx:89,140`),
+so the examples can call it instead of carrying a private stringifier.
+
+### Why extend the shared helper rather than patch locally
+
+- The helper's documented contract is "Pandoc Stringify-equivalent";
+  Pandoc stringify includes quote marks. This is a fidelity fix, not a
+  behavior fork.
+- A local fix in CommentBlock would leave alt text / tooltips / meta
+  strings silently dropping quote marks — the same user-visible class.
+- One recursive walk, one truth; the copy-pasted local stringifier is
+  exactly how this bug shipped.
+
+### Blast radius of (A)
+
+Consumers of `inlinesToPlainText`/`blocksToPlainText`: `framework/meta.ts`
+(meta-string coercion), `Image.tsx` (alt text), `Note.tsx`,
+`PreviewTitleBlock.tsx`, plus the render-components runtime export.
+The only behavior change is quote characters now appearing where quoted
+text already appeared — strictly closer to both Pandoc and the visual
+renderer. Risk: snapshot/unit-test churn (at minimum
+`plainText.test.ts:65`'s `'hiq'` expectation, deliberately updated to
+`'hi“q”'`). Will run the full hub-client + preview-renderer suites and
+report any other snapshot deltas explicitly.
+
+## Test plan (TDD — tests first, verify they fail)
+
+- [x] Update `framework/plainText.test.ts` Quoted expectation to
+      include curly quotes (Double and Single kinds); ran, failed as
+      expected (`'hiq'` / `'tis'` without quote marks).
+- [x] Add `CommentBlock.bubbleText.integration.test.tsx` rendering a
+      block whose comment span contains `Str + Space + Quoted` (plus
+      SingleQuote and `Emph`/`Code` cases); ran, all 3 failed as
+      expected (`'Hello '`, `''`, `'use  '`).
+- [x] Implement (A) and (B); both tests pass.
+- [x] Apply (C) to the two example files, via the debug-renderer
+      global (which now exposes the plain-text helpers; the
+      framework-primitive parity test locks them on both globals).
+- [x] preview-renderer `npm test` (578 passed) + `npm run
+      test:integration` (609 passed); hub-client `npm run test:ci`
+      (exit 0: unit + integration + wasm suites).
+- [x] `cd hub-client && npm run build:all` — exit 0.
+- [x] End-to-end (see record below).
+
+### End-to-end verification record
+
+- Rebuilt the preview chain: `npm run build:all` (includes WASM) →
+  `cargo xtask build-q2-preview-spa` → `cargo build --bin q2`.
+- Invocation: `cargo run --bin q2 -- preview
+  ~/Desktop/daily-log/2026/08/26/hello.qmd --no-browser` →
+  `http://127.0.0.1:61594/?page=hello.qmd`, inspected in Chrome via
+  the devtools MCP.
+- Observed DOM inside the preview iframe (output was inspected):
+  the bubble `div[title="1 comment"]` has
+  `textContent === 'Hello “world”'` (curly quotes present), and the
+  stripped paragraph reads `Stuff.`. Before the fix the bubble read
+  `Hello ` with the quoted word missing.
+
+## Work items
+
+- [x] Phase 1: failing tests (plainText Quoted marks; CommentBlock bubble text)
+- [x] Phase 2: `plainText.ts` Quoted fix (+ shared `QUOTE_CHARS`,
+      now also imported by `inlines/Quoted.tsx`)
+- [x] Phase 3: `CommentBlock.tsx` uses `inlinesToPlainText`
+- [x] Phase 4: experimental example components updated
+      (`comments.tsx.txt`, `new/comments_rc.jsx`); debug-renderer
+      global gained `inlinesToPlainText`/`blocksToPlainText`;
+      parity test extended to lock them
+- [x] Phase 5: full verification (vitest, build:all, e2e preview inspection)
+- [ ] Phase 6: close bd-wcz4x7y0; note whether a hub deploy is needed for the live site
+
+## Open questions for review
+
+1. **Quote marks in alt text / meta strings**: agree that (A) extending
+   the shared helper is right, vs. keeping the helper as-is and doing a
+   comment-local wrapper? (I recommend (A) for Pandoc parity.)
+2. **Emphasis etc. in bubbles stays plain text** — the bubble is a
+   plain-text surface; `*this*` will show as `this` (content kept,
+   styling dropped). Rendering rich inlines inside the bubble is out of
+   scope here; file a follow-up strand if wanted.
+3. The `.txt`/`.jsx` example files: fix in the same PR (proposed) or
+   file a separate low-priority strand?

--- a/hub-client/changelog.md
+++ b/hub-client/changelog.md
@@ -23,6 +23,10 @@ WASM rebuild is needed for a changelog-only edit.
 
 -->
 
+### 2026-08-26
+
+- [`00e0617a`](https://github.com/quarto-dev/q2/commits/00e0617a): Comment bubbles now show the comment's full text — quoted words, emphasis, and inline code inside a comment were previously dropped from the bubble.
+
 ### 2026-08-25
 
 - [`d124b72f`](https://github.com/quarto-dev/q2/commits/d124b72f): The comment-display toggle in the bottom bar now shows a count badge with the number of outstanding comments on the current document, so you can see at a glance whether a page has open comments without scanning it.

--- a/hub-client/src/components/render/experimental-components/comments.tsx.txt
+++ b/hub-client/src/components/render/experimental-components/comments.tsx.txt
@@ -1,6 +1,7 @@
 const React = window.React;
 const {
-  Block: B
+  Block: B,
+  inlinesToPlainText
 } = window.__REACT_AST_DEBUG_RENDERER__;
 
 function isComment(inline: InlineNode): boolean {
@@ -36,11 +37,7 @@ export const Block = (args: NodeArgs<BlockNode>) => {
         }
     }
 
-    const commentContents = comments.map((c) => (c as SpanInline).c[1].map((o: InlineNode) => {
-        if (o.t === 'Str') return (o as StrInline).c;
-        if (o.t === 'Space') return ' ';
-        return '';
-    }).join(''))
+    const commentContents = comments.map((c) => inlinesToPlainText((c as SpanInline).c[1]))
     const reactions = commentContents.filter(c => splitEmoji(c).length === 1)
     const reactionCounts = reactions.reduce((acc, emoji) =>
         acc.set(emoji, (acc.get(emoji) || 0) + 1),
@@ -293,13 +290,7 @@ const CommentWrapper = ({ children, comments, reactionCounts, setLocalAst, block
                                 zIndex: '9999'
                             }}>
                                 {comments.map((comment, i) => {
-                                    const commentContent = (comment as SpanInline).c[1]
-                                        .map((inline: InlineNode) => {
-                                            if (inline.t === 'Str') return (inline as StrInline).c;
-                                            if (inline.t === 'Space') return ' ';
-                                            return '';
-                                        })
-                                        .join('');
+                                    const commentContent = inlinesToPlainText((comment as SpanInline).c[1]);
 
                                     return (
                                         <div

--- a/hub-client/src/components/render/experimental-components/new/comments_rc.jsx
+++ b/hub-client/src/components/render/experimental-components/new/comments_rc.jsx
@@ -1,6 +1,7 @@
 const React = window.React;
 const {
-    Block: B
+    Block: B,
+    inlinesToPlainText
 } = window.__REACT_AST_DEBUG_RENDERER__;
 
 function isComment(inline: InlineNode): boolean {
@@ -36,11 +37,7 @@ export const Block = (args: NodeArgs<BlockNode>) => {
         }
     }
 
-    const commentContents = comments.map((c) => (c as SpanInline).c[1].map((o: InlineNode) => {
-        if (o.t === 'Str') return (o as StrInline).c;
-        if (o.t === 'Space') return ' ';
-        return '';
-    }).join(''))
+    const commentContents = comments.map((c) => inlinesToPlainText((c as SpanInline).c[1]))
     const reactions = commentContents.filter(c => splitEmoji(c).length === 1)
     const reactionCounts = reactions.reduce((acc, emoji) =>
         acc.set(emoji, (acc.get(emoji) || 0) + 1),
@@ -304,13 +301,7 @@ const CommentWrapper = ({ children, comments, reactionCounts, setLocalAst, block
                                 zIndex: '9999'
                             }}>
                                 {comments.map((comment, i) => {
-                                    const commentContent = (comment as SpanInline).c[1]
-                                        .map((inline: InlineNode) => {
-                                            if (inline.t === 'Str') return (inline as StrInline).c;
-                                            if (inline.t === 'Space') return ' ';
-                                            return '';
-                                        })
-                                        .join('');
+                                    const commentContent = inlinesToPlainText((comment as SpanInline).c[1]);
 
                                     return (
                                         <div

--- a/hub-client/src/components/render/parity.integration.test.tsx
+++ b/hub-client/src/components/render/parity.integration.test.tsx
@@ -50,7 +50,16 @@ beforeAll(async () => {
     await import('./q2-preview/entry');
 });
 
-const FRAMEWORK_PRIMITIVES = ['renderChildren', 'renderNode', 'Node'] as const;
+const FRAMEWORK_PRIMITIVES = [
+    'renderChildren',
+    'renderNode',
+    'Node',
+    // Plain-text walks (bd-wcz4x7y0): the experimental comment examples
+    // stringify comment spans via the debug global, so the helpers must
+    // stay on both surfaces.
+    'inlinesToPlainText',
+    'blocksToPlainText',
+] as const;
 
 describe('framework-primitive parity across iframe globals', () => {
     test.each(FRAMEWORK_PRIMITIVES)(

--- a/hub-client/src/components/render/q2-debug/entry.tsx
+++ b/hub-client/src/components/render/q2-debug/entry.tsx
@@ -26,7 +26,14 @@ import '../../../../../resources/revealjs/quarto-reveal.css';
 import katex from 'katex';
 import 'katex/dist/katex.min.css';
 
-import { Ast, Node, renderChildren, renderNode } from '@quarto/preview-renderer/framework';
+import {
+    Ast,
+    Node,
+    renderChildren,
+    renderNode,
+    inlinesToPlainText,
+    blocksToPlainText,
+} from '@quarto/preview-renderer/framework';
 import type { FormatRegistry } from '@quarto/preview-renderer/framework';
 import {
     Block,
@@ -53,6 +60,7 @@ import {
 // tied to dynamic user-TSX imports (the right time to set them).
 (window as any).__REACT_AST_DEBUG_RENDERER__ = {
     renderChildren, renderNode, Node,
+    inlinesToPlainText, blocksToPlainText,
     Block, Inline,
     Para, Plain, Header, CodeBlock, BulletList, OrderedList,
     BlockQuote, Div, HorizontalRule, RawBlock, Figure,

--- a/ts-packages/preview-renderer/src/framework/plainText.test.ts
+++ b/ts-packages/preview-renderer/src/framework/plainText.test.ts
@@ -62,7 +62,9 @@ describe('inlinesToPlainText', () => {
         ).toBe('click');
     });
 
-    it('walks Span / Quoted inlines', () => {
+    it('walks Span / Quoted inlines (Quoted keeps its quote marks)', () => {
+        // Pandoc's stringify de-sugars Quoted into curly quote characters
+        // (Text.Pandoc.Shared `deQuote`) — bd-wcz4x7y0.
         expect(
             inlinesToPlainText([
                 {
@@ -77,7 +79,18 @@ describe('inlinesToPlainText', () => {
                     c: [{ t: 'DoubleQuote' }, [{ t: 'Str', c: 'q' }]],
                 },
             ] as InlineNode[]),
-        ).toBe('hiq');
+        ).toBe('hi“q”');
+    });
+
+    it('single-quoted inlines get single curly quotes', () => {
+        expect(
+            inlinesToPlainText([
+                {
+                    t: 'Quoted',
+                    c: [{ t: 'SingleQuote' }, [{ t: 'Str', c: 'tis' }]],
+                },
+            ] as InlineNode[]),
+        ).toBe('‘tis’');
     });
 
     it('emits the LaTeX source for Math', () => {

--- a/ts-packages/preview-renderer/src/framework/plainText.ts
+++ b/ts-packages/preview-renderer/src/framework/plainText.ts
@@ -18,6 +18,16 @@
 import type { BlockNode, InlineNode } from './types';
 
 /**
+ * Opening/closing characters for `Quoted` inlines — the same de-sugaring
+ * Pandoc's stringify applies (Text.Pandoc.Shared `deQuote`), and the same
+ * characters the q2-preview `Quoted` renderer emits.
+ */
+export const QUOTE_CHARS = {
+    SingleQuote: ['‘', '’'] as const,
+    DoubleQuote: ['“', '”'] as const,
+};
+
+/**
  * Pandoc Stringify-equivalent for a list of inlines.
  */
 export function inlinesToPlainText(inlines: InlineNode[]): string {
@@ -54,9 +64,16 @@ function inlineText(node: InlineNode): string {
             return inlinesToPlainText(c[1] ?? []);
         }
         case 'Span':
-        case 'Quoted':
-            // c = [meta, inlines]
+            // c = [attr, inlines]
             return inlinesToPlainText(((n.c as [unknown, InlineNode[]]) ?? [null, []])[1] ?? []);
+        case 'Quoted': {
+            // c = [{t: quoteKind}, inlines]; the quote marks are part of
+            // the plain text (Pandoc stringify parity — bd-wcz4x7y0).
+            const [kind, inlines] = (n.c as [{ t: string } | null, InlineNode[]]) ?? [null, []];
+            const [open, close] =
+                kind?.t === 'SingleQuote' ? QUOTE_CHARS.SingleQuote : QUOTE_CHARS.DoubleQuote;
+            return open + inlinesToPlainText(inlines ?? []) + close;
+        }
         case 'Math':
             // c = [{t: '…Math'}, latex]
             return ((n.c as [unknown, string]) ?? [null, ''])[1] ?? '';

--- a/ts-packages/preview-renderer/src/q2-preview/custom/CommentBlock.bubbleText.integration.test.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/custom/CommentBlock.bubbleText.integration.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * bd-wcz4x7y0 — comment bubbles must show the comment's full text.
+ *
+ * `[>> Hello "world"]` parses (with smart typography) to a
+ * `quarto-edit-comment` span containing
+ * `[Str "Hello", Space, Quoted DoubleQuote [Str "world"]]`. The bubble
+ * used a local stringifier that mapped every non-Str/Space inline to
+ * the empty string, so quoted words (and Emph/Code/... content)
+ * silently vanished from the rendered comment. The bubble must render
+ * the Pandoc-stringify text of the span: `Hello “world”`.
+ *
+ * Plan: claude-notes/plans/2026-08-26-comment-bubble-quoted-inlines.md
+ */
+
+// @vitest-environment jsdom
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import React from 'react';
+import { Ast } from '../../framework';
+import { previewRegistry } from '../registry';
+
+afterEach(() => {
+    cleanup();
+    document.body.innerHTML = '';
+});
+
+function commentSpan(inlines: unknown[]): unknown {
+    return { t: 'Span', c: [['', ['quarto-edit-comment'], []], inlines] };
+}
+
+function astJson(commentInlines: unknown[]): string {
+    const blocks = [
+        {
+            t: 'Para',
+            s: 0,
+            c: [{ t: 'Str', c: 'Stuff.' }, commentSpan(commentInlines)],
+        },
+    ];
+    return JSON.stringify({
+        'pandoc-api-version': [1, 23, 0],
+        meta: {},
+        blocks,
+        astContext: { p: [{ t: 0, r: [0, 24], d: 0 }] },
+    });
+}
+
+function mountWithComment(commentInlines: unknown[]) {
+    return render(
+        <Ast
+            astJson={astJson(commentInlines)}
+            currentFilePath="/project/test.qmd"
+            onNavigateToDocument={() => {}}
+            setAst={() => {}}
+            registry={previewRegistry}
+        />,
+    );
+}
+
+/** The compact bubble div carries title="1 comment". */
+function bubbleText(container: HTMLElement): string {
+    const bubble = container.querySelector('[title="1 comment"]');
+    expect(bubble).not.toBeNull();
+    return bubble!.textContent ?? '';
+}
+
+describe('CommentBlock bubble text (bd-wcz4x7y0)', () => {
+    it('renders Quoted inline content with its quote marks', () => {
+        const { container } = mountWithComment([
+            { t: 'Str', c: 'Hello' },
+            { t: 'Space' },
+            { t: 'Quoted', c: [{ t: 'DoubleQuote' }, [{ t: 'Str', c: 'world' }]] },
+        ]);
+        expect(bubbleText(container)).toBe('Hello “world”');
+        // The stripped paragraph keeps its own text and not the comment's.
+        expect(container.querySelector('p')!.textContent).toBe('Stuff.');
+    });
+
+    it('renders single-quoted content with single quote marks', () => {
+        const { container } = mountWithComment([
+            { t: 'Quoted', c: [{ t: 'SingleQuote' }, [{ t: 'Str', c: 'tis' }]] },
+        ]);
+        expect(bubbleText(container)).toBe('‘tis’');
+    });
+
+    it('keeps the text of Emph and Code inlines', () => {
+        const { container } = mountWithComment([
+            { t: 'Str', c: 'use' },
+            { t: 'Space' },
+            { t: 'Emph', c: [{ t: 'Str', c: 'this' }] },
+            { t: 'Space' },
+            { t: 'Code', c: [['', [], []], 'now()'] },
+        ]);
+        expect(bubbleText(container)).toBe('use this now()');
+    });
+});

--- a/ts-packages/preview-renderer/src/q2-preview/custom/CommentBlock.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/custom/CommentBlock.tsx
@@ -33,7 +33,7 @@
  * `__Q2_PREVIEW_RENDERER__.Block`, exactly as before).
  */
 import React from 'react';
-import { AttributionLookupContext } from '../../framework';
+import { AttributionLookupContext, inlinesToPlainText } from '../../framework';
 import type {
     BlockNode,
     DivBlock,
@@ -43,7 +43,6 @@ import type {
     ParaBlock,
     PlainBlock,
     SpanInline,
-    StrInline,
 } from '../../framework';
 import { Block as B } from '../dispatchers';
 import { PreviewContext } from '../PreviewContext';
@@ -130,14 +129,10 @@ function sameCommentableKind(rendered: BlockNode, source: BlockNode): boolean {
     return false;
 }
 
+// Pandoc-stringify walk of the span's content: recurses into Quoted /
+// Emph / Code / Link / ... instead of dropping them (bd-wcz4x7y0).
 function commentSpanText(span: InlineNode): string {
-    return (span as SpanInline).c[1]
-        .map((o: InlineNode) => {
-            if (o.t === 'Str') return (o as StrInline).c;
-            if (o.t === 'Space') return ' ';
-            return '';
-        })
-        .join('');
+    return inlinesToPlainText((span as SpanInline).c[1]);
 }
 
 export const CommentBlock = (args: NodeArgs<BlockNode>) => {

--- a/ts-packages/preview-renderer/src/q2-preview/inlines/Quoted.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/inlines/Quoted.tsx
@@ -1,10 +1,5 @@
-import { renderChildren } from '../../framework';
+import { QUOTE_CHARS, renderChildren } from '../../framework';
 import type { NodeArgs, QuotedInline } from '../../framework';
-
-const QUOTE_CHARS = {
-    SingleQuote: ['‘', '’'] as const, // ‘ ’
-    DoubleQuote: ['“', '”'] as const, // “ ”
-};
 
 export const Quoted = (args: NodeArgs<QuotedInline>) => {
     const [{ t: kind }] = args.node.c;


### PR DESCRIPTION
## Summary

A `[>> Hello "world"]` editorial comment rendered its bubble as just `Hello ` on quarto-hub.com and in `q2 preview`: `CommentBlock`'s local `commentSpanText` mapped every non-`Str`/`Space` inline to the empty string, so `Quoted` (what smart typography turns every `"..."` into), `Emph`, `Code`, and `Link` content silently vanished from comment bubbles.

The parse and pampa's HTML writer were always correct — the AST carries `Quoted DoubleQuote [Str "world"]` inside the comment span; only the React bubble stringifier dropped it.

## Changes

- **`framework/plainText.ts`**: `Quoted` now emits its curly quote marks (`“…”` / `‘…’`), matching Pandoc's `stringify` (`Text.Pandoc.Shared` `deQuote`) and the preview's own `Quoted` renderer. `QUOTE_CHARS` is exported and shared with `inlines/Quoted.tsx`.
- **`CommentBlock.tsx`**: `commentSpanText` delegates to the shared `inlinesToPlainText` walk instead of a shallow Str/Space-only map.
- **q2-debug entry**: exposes `inlinesToPlainText`/`blocksToPlainText` on `__REACT_AST_DEBUG_RENDERER__`; the framework-primitive parity test now locks the plain-text helpers on both renderer globals.
- **Experimental comment examples** (`comments.tsx.txt`, `new/comments_rc.jsx`): same shallow stringifier replaced with `inlinesToPlainText` via the debug global.
- hub-client changelog entry (second commit, per the two-commit workflow).

## Testing

- TDD: all 5 new/updated vitest cases were run and confirmed failing first — `plainText.test.ts` (Quoted keeps quote marks, single-quote case) and new `CommentBlock.bubbleText.integration.test.tsx` (Quoted double/single, Emph+Code).
- preview-renderer unit (578) + integration (609) suites, hub-client `test:ci`, `npm run build:all`, full workspace `cargo nextest` (13447 passed), and `cargo xtask verify` — all green.
- End-to-end: rebuilt the preview chain and ran `q2 preview` on the reproduction doc; inspected via devtools — the bubble `div[title="1 comment"]` now has `textContent === 'Hello “world”'` (previously `Hello `).

Plan: `claude-notes/plans/2026-08-26-comment-bubble-quoted-inlines.md`. Strand: bd-wcz4x7y0. Follow-up (rich inline rendering in bubbles): bd-y66gbfs4.

Note: the live quarto-hub.com fix requires a hub-client deploy after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)