### PR TITLE
bd-y66gbfs4: render rich inlines in comment bubbles

### DIFF
--- a/claude-notes/plans/2026-08-26-rich-comment-bubbles.md
+++ b/claude-notes/plans/2026-08-26-rich-comment-bubbles.md
@@ -1,0 +1,332 @@
+# Rich inline rendering in comment bubbles
+
+**Strand:** bd-y66gbfs4 (discovered-from bd-wcz4x7y0, PR #612)
+**Date:** 2026-08-26
+**Status:** in progress on `braid/bd-y66gbfs4-render-rich-inlines-emphasis`
+
+**Decisions locked (Carlos, 2026-08-26):** rich rendering in BOTH
+surfaces (compact + expanded); link handling ships with the
+`scrollIntoView` fallback (no host `scrollToAnchor` wiring); plain-text
+authoring from the bubble input for v1; chip text is the generic
+`[unsupported content]` + `title` tooltip (narrow beats specific).
+
+## Context
+
+After bd-wcz4x7y0, comment bubbles show the *full plain text* of a
+`[>> ...]` comment span via `inlinesToPlainText` — content is no longer
+dropped, but styling is: `*this*` shows as `this`, `` `code` `` as
+`code` without monospace, links as dead text. This strand upgrades the
+bubble to render the comment's inlines through the normal q2-preview
+inline renderers.
+
+Surfaces (all in
+`ts-packages/preview-renderer/src/q2-preview/custom/CommentBlock.tsx`):
+
+1. **Compact bubble** — first comment, single line,
+   `nowrap + ellipsis` (`commentSpanText(comments[0])`, ~line 995).
+2. **Expanded rows** — one row per comment in expand mode / clicked-open
+   bubbles (`commentSpanText(c)`, ~line 908).
+
+Out of scope: the experimental example components
+(`comments.tsx.txt`, `comments_rc.jsx`) stay plain-text — they are
+user-authored examples, and their emoji-reaction detection *needs* the
+plain-text form. The `inlinesToPlainText` helper itself is untouched
+(alt text, tooltips, and meta coercion still want plain text).
+
+## How to render: the framework already has the entry point
+
+The framework's `<Node>` (`framework/dispatch.tsx:402`) is the
+sanctioned recursion entry — it dispatches to the format's `Inline`
+wrapper (registry lookup + attribution wrap + the atomic-subtree gate).
+CommentBlock is rendered inside the `<Ast>` tree, so `RegistryContext`
+is available. The change is essentially:
+
+```tsx
+function commentSpanContent(span: InlineNode, onNavigateToDocument?: …) {
+    return (span as SpanInline).c[1].map((inline, i) => (
+        <Node key={i} node={inline}
+              onNavigateToDocument={onNavigateToDocument}
+              setLocalAst={NOOP} />
+    ));
+}
+```
+
+- **`setLocalAst` is a deliberate no-op**: bubble content is a
+  *display* of the comment, not an edit surface. Comment mutation goes
+  through `addComment`/`resolveCommentAtIndex` on the source node; a
+  live `setLocalAst` here would write into the stripped clone and be
+  lost (or worse). Read-only matches how `<Ast>` treats atomic
+  subtrees.
+- `onNavigateToDocument` is already in CommentBlock's `NodeArgs`; it
+  needs threading into `CommentWrapper` (which currently receives only
+  `comments`/`block`/`edit`/`mode`).
+- Rendering the *content* inlines (not the comment `Span` itself)
+  avoids the Span renderer re-emitting `quarto-edit-comment` markup
+  inside the bubble.
+
+What each inline then does, for free: `Emph`/`Strong`/`Strikeout` etc.
+render their elements; `Code` gets monospace; `Quoted` emits the same
+curly quotes as today's plain text (shared `QUOTE_CHARS`); `Math`
+renders KaTeX; attribution wraps appear when the Authors overlay is on
+(consistent with the row's author dot, which comes from the same span).
+
+## The two real problems
+
+### 1. Links inside the bubble bypass the preview's link interception
+
+The preview intercepts link clicks with a **delegated bubble-phase
+listener on `document.body`** (`installLinkHandlers`,
+`utils/iframeLinkHandlers.ts:82`): external links →
+`window.open(_blank)`, `#frag` → scroll, artifact/qmd hrefs →
+`onQmdLinkClick`. But the comment chrome deliberately calls
+`e.stopPropagation()` on click (CommentBlock ~line 847) so bubble
+clicks don't reach the *other* document-level delegate — click-to-edit.
+A bare `<a>` rendered inside the bubble therefore never reaches the
+body listener, and its click falls through to **native navigation of
+the preview iframe** — the worst outcome (external URL replaces the
+preview; `#frag` does a raw jump).
+
+Letting anchor clicks propagate is not an option (they'd hit
+click-to-edit and open the enclosing block's editor). Proposal:
+
+- Export the per-click routing from `iframeLinkHandlers.ts` as a
+  reusable `routeLinkClick(ev, opts): boolean` (refactor the existing
+  body listener to call it — no behavior change there).
+- In the bubble's click handler, *before* the existing
+  `stopPropagation`: if the click target has an `<a>` ancestor within
+  the bubble, `preventDefault` + `stopPropagation` and call
+  `routeLinkClick`. Cross-document routing uses the threaded
+  `onNavigateToDocument`; same-document `#frag` falls back to
+  `getElementById(frag)?.scrollIntoView({behavior:'smooth'})` (the
+  bubble doesn't have `scrollToAnchor`; note as a known simplification).
+- A link click must also *not* trigger the bubble's own
+  expand/open-input `onClick` (guard: `closest('a')`).
+
+### 2. Un-inline-ish content can break the bubble's geometry
+
+The bubble is a ~140–160px-wide floating chip that participates in the
+force layout (it re-measures on mount/expansion, not on async content
+growth). Two offenders:
+
+- **`Image`**: renders an unconstrained `<img>` (the renderer applies
+  no max sizing) that loads async — the bubble would balloon *after*
+  the relayout pass measured it.
+- **`Note`**: block content in a tiny chip.
+
+**Width containment is NOT automatic** (reviewed with Carlos —
+requirement: image blast radius must end at the bubble border). The
+existing `maxWidth: 140px`/`160px` constraints sit on the *inner text
+containers*, not the chip: the bubble div is a shrink-to-fit
+`position: absolute` box with no width bound of its own, `<img>` has
+no default `max-width`, and `text-overflow: ellipsis` clips text but
+not replaced elements — so an unconstrained image widens the whole
+chip to its intrinsic width. And even a clamped image loads async,
+changing the chip's height *after* the force layout measured it.
+
+Proposal — three-part containment, so no comment content of any kind
+can move layout outside the chip:
+
+1. **Clamp the image**: scoped rule injected alongside the existing
+   `.q2-comment-input` style (idempotent style-tag IIFE, ~line 98);
+   bubble gets a `q2-comment-bubble` class and
+   `.q2-comment-bubble img { max-width: 100%; max-height: 2.5em;
+   object-fit: contain; }` (aspect preserved; `100%` resolves against
+   the 140/160px inner containers).
+2. **Clamp the chip**: the bubble div itself gets a `maxWidth` +
+   `overflow: hidden`, so no descendant — image, KaTeX display box,
+   anything a renderer emits — can widen the chip past its design
+   width. Blast radius ends at the bubble border by construction.
+3. **Re-solve the scaffolding after async growth**: a capture-phase
+   `load` listener on the bubble (`img` load events don't bubble;
+   capture is required) that calls `scheduleBubbleRelayout()`, so the
+   force layout re-solves once the (bounded) growth lands instead of
+   keeping stale overlap geometry until the next hover/mount.
+
+### 3. "Weird" AST content gets an affirmative `[unsupported content]` chip
+
+(Reviewed with Carlos — nested comments / editorial marks must not
+render as if supported; show an explicit indicator instead.)
+
+What the AST allows inside a comment span: nested editorial marks
+parse fine — `[>> outer [>> inner] [!! hl] [++ ins] [-- del] ^[note]]`
+produces a comment span whose content contains more marks and a
+`Note`. **Wire-format fact that shapes the design**: in the JSON the
+preview receives, *all four* editorial marks serialize as plain
+`t: 'Span'` nodes distinguished only by class (`quarto-edit-comment`,
+`quarto-insert`, `quarto-delete`, `quarto-highlight`) — verified with
+`pampa -t json`. So a tag-keyed registry entry can't intercept them;
+interception must be class-aware inside a `Span` override. Note also
+that comment *extraction* only strips top-level spans from the block's
+inline slot — nested marks genuinely reach the bubble renderer.
+
+Mechanism — a **bubble-scoped registry override** (nested
+`RegistryContext.Provider` is an established pattern; RevealDeck does
+it; preserve the outer `sourceInfoPool` when re-providing):
+
+```tsx
+const outer = useContext(RegistryContext);
+const bubbleRegistry = useMemo(() => ({
+    ...outer.registry,
+    Span: BubbleSpan,        // class-aware interceptor
+    Note: UnsupportedChip,   // block content has no place in a chip
+}), [outer.registry]);
+```
+
+- `BubbleSpan`: if the span's classes intersect
+  `EDITORIAL_MARK_CLASSES` (the four above) → `<UnsupportedChip/>`;
+  otherwise delegate to the outer registry's `Span` (ordinary
+  `[text]{.cls}` spans render normally).
+- `UnsupportedChip`: renders the literal `[unsupported content]` in a
+  visibly different typeface — monospace, muted, slightly smaller —
+  with a `title` tooltip naming the node kind (e.g. "nested comment").
+  The unsupported node's *content is not rendered* — affirmative
+  replacement, not partial rendering.
+- Because the provider wraps the whole bubble subtree, arbitrarily
+  *nested* unsupported content (`*emph with [!! mark]*`) is
+  intercepted through normal registry recursion — no per-level
+  checking in CommentBlock itself.
+- Unknown inline tags (future AST additions with no renderer) already
+  hit the Inline dispatcher's muted "(not yet implemented)"
+  placeholder — a same-spirit affirmative indicator; left as-is.
+
+This is the general "weird markdown" valve: anything we later deem
+bubble-unsafe becomes one more entry in the bubble registry override.
+
+`Note` is intercepted as unsupported (block content in a tiny chip);
+its extraction/round-trip behavior is untouched.
+
+The compact bubble keeps `nowrap + ellipsis`; inline elements truncate
+fine. Multi-line content (`LineBreak`, KaTeX display math) is clipped
+to one line there and fully visible in the expanded row — acceptable.
+
+## Proposed changes (summary)
+
+- `utils/iframeLinkHandlers.ts`: extract `routeLinkClick(ev, opts)`
+  from the body listener; export it. No behavior change for existing
+  callers.
+- `CommentBlock.tsx`:
+  - `commentSpanText(span)` (string) → `commentSpanContent(span, nav)`
+    (ReactNode via `<Node>` + noop `setLocalAst`), used at both bubble
+    sites; thread `onNavigateToDocument` into `CommentWrapper`.
+  - Bubble click handler routes `<a>` clicks through `routeLinkClick`
+    (with `onNavigateToDocument` for qmd links) and suppresses the
+    expand/open-input action for them.
+  - Containment: `q2-comment-bubble` class + scoped `img` clamp in
+    the injected style tag, chip-level `maxWidth`/`overflow: hidden`
+    on the bubble div, and a capture-phase `load` listener that
+    schedules a bubble relayout.
+  - Bubble-scoped registry override (`BubbleSpan` class-aware
+    interceptor + `Note`) rendering `[unsupported content]` chips for
+    nested editorial marks and other bubble-unsafe nodes.
+- Tests (see below).
+
+Nothing changes in `framework/plainText.ts`, the qmd writer, the
+add/resolve commit paths, or the Rust side. The DOM-parity harness is
+unaffected (comment chrome only exists on the preview side and parity
+fixtures don't carry comments — verify no `dom-parity: true` fixture
+contains `[>> ...]` before landing).
+
+## Test plan (TDD — tests first, verify they fail)
+
+Extend `CommentBlock.bubbleText.integration.test.tsx` (rename stays;
+it is the bubble-content contract suite):
+
+- [ ] `Emph`/`Code` comment renders `<em>` and `<code>` elements inside
+      the bubble (assert elements, not just text) — fails today
+      (plain text only).
+- [ ] `Quoted` still shows `“world”` (now via the Quoted renderer) —
+      guards against regressing bd-wcz4x7y0.
+- [ ] Expanded mode (`PreviewContext.commentsMode = 'expand'`): each
+      row renders rich content.
+- [ ] Link in a comment: renders `<a href>`; clicking it does **not**
+      collapse/expand the bubble and does not navigate natively
+      (assert `defaultPrevented`; mock `window.open` for the external
+      case).
+- [ ] Image in a comment: `<img>` renders with the clamp class in
+      scope (assert the injected style rule exists and the bubble
+      carries `q2-comment-bubble`); the bubble div carries its own
+      `maxWidth` + `overflow: hidden` (chip-level containment).
+- [ ] Image `load` inside the bubble schedules a force-layout pass
+      (spy on the relayout scheduling; dispatch a synthetic `load`
+      event on the `<img>` under jsdom).
+- [ ] Nested comment span inside a comment renders exactly one
+      `[unsupported content]` chip and none of the inner text.
+- [ ] Each editorial-mark class (`quarto-insert`, `quarto-delete`,
+      `quarto-highlight`) and `Note` renders the chip; the chip is
+      intercepted even when nested inside `Emph` (registry recursion,
+      not top-level filtering).
+- [ ] An ordinary `[text]{.mark}` span in a comment renders normally
+      (interceptor is class-scoped, not all-Spans).
+- [ ] New unit test for `routeLinkClick` (external / `#frag` /
+      qmd-path cases) in `iframeLinkHandlers`' existing test home, plus
+      an assertion that the body listener still works (existing tests).
+
+Verification gates: preview-renderer `npm test` + `test:integration`;
+hub-client `test:ci` + `npm run build:all`; e2e via `q2 preview` on a
+fixture with `[>> see *this* and [a link](https://example.com) and
+"quotes"]`, inspecting the bubble DOM (record here, per the e2e
+policy).
+
+## Work items
+
+- [x] Phase 1: failing tests — 16 new cases across
+      `CommentBlock.bubbleText.integration.test.tsx` (rich elements,
+      expanded rows, link routing, image containment + load relayout,
+      unsupported chips ×6) and
+      `iframeLinkHandlers.integration.test.ts` (`routeLinkClick` ×5);
+      all ran and failed for the intended reasons. Three deliberate
+      pre-fix guards pass (Quoted text, non-link bubble click expands,
+      ordinary classed span renders).
+- [x] Phase 2: `routeLinkClick` extraction in `iframeLinkHandlers.ts`
+      — behavior-identical (all 19 pre-existing delegated-listener
+      tests pass unchanged) + 5 new unit tests. One test expectation
+      fixed during TDD: `resolveRelativePath` returns VFS-absolute
+      paths (`/dir/other.qmd`), matching the delegated listener.
+- [x] Phase 3: implemented — `CommentSpanContent` component (bubble
+      registry override: class-aware `BubbleSpan` + `Note` chip;
+      `<Node>` recursion with noop `setLocalAst`), `CommentWrapper`
+      gains `onNavigateToDocument`, chrome-level `handleBubbleLinkClick`
+      (unroutable hrefs are swallowed — a bubble link never natively
+      navigates the iframe), bubble `q2-comment-bubble` class +
+      `maxWidth: 260px` + `overflow: hidden`, scoped img clamp rule,
+      capture-phase `load` listener → `scheduleBubbleRelayout`.
+      All 17 bubble tests + full preview-renderer suites green
+      (578 unit / 628 integration); `tsc` clean.
+- [x] Phase 4: full verification + e2e record (below). hub-client
+      `test:ci` green (1005 + 114 + 133), `build:all` exit 0.
+- [x] E2E record: rebuilt preview chain (`build:all` →
+      `cargo xtask build-q2-preview-spa` → `cargo build --bin q2`);
+      fixture `Stuff.[>> see *this* and [a link](https://example.com/)
+      and "quotes" and [!! marked]]`; ran `cargo run --bin q2 --
+      preview <fixture> --no-browser` and inspected the DOM in Chrome
+      via the devtools MCP. Observed (output inspected): bubble
+      textContent `see this and a link and “quotes” and [unsupported
+      content]` with a real `<em>this</em>` and
+      `<a href="https://example.com/">`; chip is monospace with
+      tooltip "unsupported in comment bubbles: highlight mark";
+      bubble has class `q2-comment-bubble`, `max-width: 260px`,
+      `overflow: hidden`; clamp rule present in the injected style
+      tag. Live click on the link inside the iframe:
+      `defaultPrevented === true`, `window.open('https://example.com/',
+      '_blank', 'noopener,noreferrer')` called, inline comment input
+      NOT opened.
+- [ ] Phase 5: close bd-y66gbfs4 (hub-client changelog entry;
+      live-site pickup again needs a hub deploy)
+
+## Open questions for review
+
+1. **Compact bubble: rich or plain?** Proposed rich in both surfaces
+   (one code path, consistent look). The alternative — plain text in
+   the compact one-liner, rich only when expanded — keeps the chip
+   maximally simple but forks the code path. I recommend rich in both.
+2. **Link targets**: proposed behavior is external → new tab (same as
+   document links), `.qmd` → `onNavigateToDocument`, `#frag` →
+   `scrollIntoView` fallback. OK to ship without wiring the host's
+   `scrollToAnchor` (smooth-scroll + highlight) into CommentBlock?
+3. ~~Editing round-trip~~ **Resolved (Carlos, 2026-08-26)**: plain-text
+   authoring from the bubble input is fine for v1 — rich comments are
+   authored by editing the `.qmd` source directly.
+4. **Chip wording**: single generic `[unsupported content]` with a
+   `title` tooltip naming the kind, vs. kind-specific text like
+   `[unsupported: nested comment]`. Proposed: generic text + tooltip
+   (keeps the chip narrow in a 140px bubble).

--- a/claude-notes/plans/2026-08-26-rich-comment-bubbles.md
+++ b/claude-notes/plans/2026-08-26-rich-comment-bubbles.md
@@ -310,8 +310,11 @@ policy).
       `defaultPrevented === true`, `window.open('https://example.com/',
       '_blank', 'noopener,noreferrer')` called, inline comment input
       NOT opened.
-- [ ] Phase 5: close bd-y66gbfs4 (hub-client changelog entry;
-      live-site pickup again needs a hub deploy)
+- [ ] Phase 5: close bd-y66gbfs4 after merge (changelog entry
+      committed as 1976f2aa2; live-site pickup again needs a hub
+      deploy). Implementation commit: ca959a674.
+      `cargo xtask verify` passed (all steps); tree clean.
+      Push/PR awaiting approval.
 
 ## Open questions for review
 

--- a/hub-client/changelog.md
+++ b/hub-client/changelog.md
@@ -25,6 +25,7 @@ WASM rebuild is needed for a changelog-only edit.
 
 ### 2026-08-26
 
+- [`ca959a67`](https://github.com/quarto-dev/q2/commits/ca959a67): Comment bubbles now render comments richly — emphasis, inline code, quotes, links (external links open in a new tab, document links navigate the preview), and images (clamped to the bubble). Content that has no sensible bubble form, like nested editorial marks, shows an explicit "unsupported content" chip instead of rendering incorrectly.
 - [`00e0617a`](https://github.com/quarto-dev/q2/commits/00e0617a): Comment bubbles now show the comment's full text — quoted words, emphasis, and inline code inside a comment were previously dropped from the bubble.
 
 ### 2026-08-25

--- a/ts-packages/preview-renderer/src/q2-preview/custom/CommentBlock.bubbleText.integration.test.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/custom/CommentBlock.bubbleText.integration.test.tsx
@@ -14,15 +14,18 @@
 
 // @vitest-environment jsdom
 
-import { describe, it, expect, afterEach } from 'vitest';
-import { render, cleanup } from '@testing-library/react';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup, fireEvent } from '@testing-library/react';
 import React from 'react';
 import { Ast } from '../../framework';
 import { previewRegistry } from '../registry';
+import { PreviewContext } from '../PreviewContext';
+import type { PreviewContextValue } from '../PreviewContext';
 
 afterEach(() => {
     cleanup();
     document.body.innerHTML = '';
+    vi.restoreAllMocks();
 });
 
 function commentSpan(inlines: unknown[]): unknown {
@@ -92,5 +95,223 @@ describe('CommentBlock bubble text (bd-wcz4x7y0)', () => {
             { t: 'Code', c: [['', [], []], 'now()'] },
         ]);
         expect(bubbleText(container)).toBe('use this now()');
+    });
+});
+
+// ---------------------------------------------------------------------
+// bd-y66gbfs4 — rich inline rendering in the bubble.
+// Plan: claude-notes/plans/2026-08-26-rich-comment-bubbles.md
+
+/** The bubble element (compact chip carries title="1 comment"). */
+function bubbleEl(container: HTMLElement): HTMLElement {
+    const bubble = container.querySelector('[title="1 comment"]');
+    expect(bubble).not.toBeNull();
+    return bubble as HTMLElement;
+}
+
+function mountExpandedWithComment(commentInlines: unknown[]) {
+    const ctx: PreviewContextValue = {
+        currentFilePath: '/project/test.qmd',
+        commentsMode: 'expand',
+    };
+    return render(
+        <PreviewContext.Provider value={ctx}>
+            <Ast
+                astJson={astJson(commentInlines)}
+                currentFilePath="/project/test.qmd"
+                onNavigateToDocument={() => {}}
+                setAst={() => {}}
+                registry={previewRegistry}
+            />
+        </PreviewContext.Provider>,
+    );
+}
+
+describe('CommentBlock rich bubble content (bd-y66gbfs4)', () => {
+    it('renders Emph and Code as real elements in the compact bubble', () => {
+        const { container } = mountWithComment([
+            { t: 'Str', c: 'use' },
+            { t: 'Space' },
+            { t: 'Emph', c: [{ t: 'Str', c: 'this' }] },
+            { t: 'Space' },
+            { t: 'Code', c: [['', [], []], 'now()'] },
+        ]);
+        const bubble = bubbleEl(container);
+        const em = bubble.querySelector('em');
+        const code = bubble.querySelector('code');
+        expect(em?.textContent).toBe('this');
+        expect(code?.textContent).toBe('now()');
+        expect(bubble.textContent).toBe('use this now()');
+    });
+
+    it('still shows curly quotes for Quoted (regression guard on bd-wcz4x7y0)', () => {
+        const { container } = mountWithComment([
+            { t: 'Str', c: 'Hello' },
+            { t: 'Space' },
+            { t: 'Quoted', c: [{ t: 'DoubleQuote' }, [{ t: 'Str', c: 'world' }]] },
+        ]);
+        expect(bubbleEl(container).textContent).toBe('Hello “world”');
+    });
+
+    it('renders rich elements in expanded rows too', () => {
+        const { container } = mountExpandedWithComment([
+            { t: 'Emph', c: [{ t: 'Str', c: 'row' }] },
+        ]);
+        const bubble = bubbleEl(container);
+        expect(bubble.querySelector('em')?.textContent).toBe('row');
+    });
+
+    describe('links', () => {
+        it('renders an anchor and routes external clicks to a new tab without expanding the bubble', () => {
+            const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+            const { container } = mountWithComment([
+                { t: 'Str', c: 'see' },
+                { t: 'Space' },
+                {
+                    t: 'Link',
+                    c: [['', [], []], [{ t: 'Str', c: 'docs' }], ['https://example.com/', '']],
+                },
+            ]);
+            const bubble = bubbleEl(container);
+            const a = bubble.querySelector('a');
+            expect(a).not.toBeNull();
+            expect(a!.getAttribute('href')).toBe('https://example.com/');
+
+            const ev = new MouseEvent('click', { bubbles: true, cancelable: true });
+            a!.dispatchEvent(ev);
+            expect(openSpy).toHaveBeenCalledWith(
+                'https://example.com/',
+                '_blank',
+                'noopener,noreferrer',
+            );
+            expect(ev.defaultPrevented).toBe(true);
+            // The link click must not act as a bubble click (which would
+            // self-expand and open the inline comment input).
+            expect(container.querySelector('textarea.q2-comment-input')).toBeNull();
+        });
+
+        it('clicking the bubble chrome away from a link still expands (link guard is scoped)', () => {
+            const { container } = mountWithComment([
+                { t: 'Str', c: 'plain' },
+            ]);
+            fireEvent.click(bubbleEl(container));
+            expect(container.querySelector('textarea.q2-comment-input')).not.toBeNull();
+        });
+    });
+
+    describe('image containment', () => {
+        const IMG_COMMENT = [
+            {
+                t: 'Image',
+                c: [['', [], []], [{ t: 'Str', c: 'alt' }], ['sketch.png', '']],
+            },
+        ];
+
+        it('renders a clamped <img> inside a width-contained bubble', () => {
+            const { container } = mountWithComment(IMG_COMMENT);
+            const bubble = bubbleEl(container);
+            expect(bubble.classList.contains('q2-comment-bubble')).toBe(true);
+            expect(bubble.querySelector('img')).not.toBeNull();
+            // Chip-level containment: no descendant may widen the chip.
+            expect(bubble.style.maxWidth).not.toBe('');
+            expect(bubble.style.overflow).toBe('hidden');
+            // Scoped clamp rule injected once per document.
+            const styles = Array.from(
+                document.head.querySelectorAll('style[data-q2-comment-styles]'),
+            ).map((s) => s.textContent ?? '').join('\n');
+            expect(styles).toContain('.q2-comment-bubble img');
+            expect(styles).toContain('max-width: 100%');
+        });
+
+        it('schedules a bubble relayout when an image loads', async () => {
+            const { container } = mountWithComment(IMG_COMMENT);
+            const img = bubbleEl(container).querySelector('img')!;
+            // Flush the mount-time relayout so its scheduled-guard is clear.
+            await new Promise<void>((r) => requestAnimationFrame(() => r()));
+            const rafSpy = vi.spyOn(window, 'requestAnimationFrame');
+            fireEvent.load(img);
+            expect(rafSpy).toHaveBeenCalled();
+        });
+    });
+
+    describe('unsupported content chips', () => {
+        const CHIP = '[unsupported content]';
+        const chipCount = (bubble: HTMLElement) =>
+            (bubble.textContent ?? '').split(CHIP).length - 1;
+
+        it('replaces a nested comment span with exactly one chip and none of its text', () => {
+            const { container } = mountWithComment([
+                { t: 'Str', c: 'outer' },
+                { t: 'Space' },
+                {
+                    t: 'Span',
+                    c: [['', ['quarto-edit-comment'], []], [{ t: 'Str', c: 'inner-secret' }]],
+                },
+            ]);
+            const bubble = bubbleEl(container);
+            expect(chipCount(bubble)).toBe(1);
+            expect(bubble.textContent).not.toContain('inner-secret');
+            expect(bubble.textContent).toContain('outer');
+        });
+
+        it.each([
+            ['quarto-insert'],
+            ['quarto-delete'],
+            ['quarto-highlight'],
+        ])('replaces a %s span with a chip', (cls) => {
+            const { container } = mountWithComment([
+                {
+                    t: 'Span',
+                    c: [['', [cls], []], [{ t: 'Str', c: 'hidden' }]],
+                },
+            ]);
+            const bubble = bubbleEl(container);
+            expect(chipCount(bubble)).toBe(1);
+            expect(bubble.textContent).not.toContain('hidden');
+        });
+
+        it('replaces a Note with a chip', () => {
+            const { container } = mountWithComment([
+                {
+                    t: 'Note',
+                    c: [{ t: 'Para', c: [{ t: 'Str', c: 'footnote-body' }] }],
+                },
+            ]);
+            const bubble = bubbleEl(container);
+            expect(chipCount(bubble)).toBe(1);
+            expect(bubble.textContent).not.toContain('footnote-body');
+        });
+
+        it('intercepts marks nested inside Emph (registry recursion, not top-level filtering)', () => {
+            const { container } = mountWithComment([
+                {
+                    t: 'Emph',
+                    c: [
+                        { t: 'Str', c: 'emph' },
+                        { t: 'Space' },
+                        {
+                            t: 'Span',
+                            c: [['', ['quarto-highlight'], []], [{ t: 'Str', c: 'hidden' }]],
+                        },
+                    ],
+                },
+            ]);
+            const bubble = bubbleEl(container);
+            expect(chipCount(bubble)).toBe(1);
+            expect(bubble.querySelector('em')).not.toBeNull();
+            expect(bubble.textContent).not.toContain('hidden');
+        });
+
+        it('leaves an ordinary classed span alone (interceptor is class-scoped)', () => {
+            const { container } = mountWithComment([
+                {
+                    t: 'Span',
+                    c: [['', ['mark'], []], [{ t: 'Str', c: 'visible' }]],
+                },
+            ]);
+            const bubble = bubbleEl(container);
+            expect(chipCount(bubble)).toBe(0);
+            expect(bubble.textContent).toContain('visible');
+        });
     });
 });

--- a/ts-packages/preview-renderer/src/q2-preview/custom/CommentBlock.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/custom/CommentBlock.tsx
@@ -14,6 +14,13 @@
  *    inline add-comment input at the bottom.
  *  - 'hide' mode strips comments from the text but renders no chrome.
  *
+ * Comment text renders RICH (bd-y66gbfs4): the span's inlines go
+ * through the normal q2-preview inline renderers via a bubble-scoped
+ * registry override (see `CommentSpanContent`) — emphasis, code,
+ * quotes, links, and clamped images render for real; nested editorial
+ * marks and Notes render an affirmative `[unsupported content]` chip;
+ * link clicks route through `routeLinkClick` at the chrome level.
+ *
  * The three-way mode arrives via `PreviewContext.commentsMode` from the
  * host toolbar. Adds/resolves round-trip through
  * `usePreviewEdit().commitSubtreeEdit` (no-ops where `PreviewContext`
@@ -33,7 +40,7 @@
  * `__Q2_PREVIEW_RENDERER__.Block`, exactly as before).
  */
 import React from 'react';
-import { AttributionLookupContext, inlinesToPlainText } from '../../framework';
+import { AttributionLookupContext, Node as AstNode, RegistryContext } from '../../framework';
 import type {
     BlockNode,
     DivBlock,
@@ -48,6 +55,7 @@ import { Block as B } from '../dispatchers';
 import { PreviewContext } from '../PreviewContext';
 import type { CommentsMode } from '../PreviewContext';
 import { usePreviewEdit } from '../usePreviewEdit';
+import { routeLinkClick } from '../../utils/iframeLinkHandlers';
 
 // Shared palette bits.
 const CHROME_BLUE = '#4a7ba7';
@@ -100,7 +108,11 @@ function inlineSlot(block: BlockNode): InlineNode[] | null {
     const tag = document.createElement('style');
     tag.setAttribute('data-q2-comment-styles', '1');
     tag.textContent =
-        '.q2-comment-input::placeholder { color: #a9c7e8; opacity: 1; }';
+        '.q2-comment-input::placeholder { color: #a9c7e8; opacity: 1; }\n' +
+        // Image containment (bd-y66gbfs4): an unconstrained <img> would
+        // widen the shrink-to-fit bubble to its intrinsic size. `100%`
+        // resolves against the bubble's inner max-width'd containers.
+        '.q2-comment-bubble img { max-width: 100%; max-height: 2.5em; object-fit: contain; }';
     document.head.appendChild(tag);
 })();
 
@@ -129,11 +141,94 @@ function sameCommentableKind(rendered: BlockNode, source: BlockNode): boolean {
     return false;
 }
 
-// Pandoc-stringify walk of the span's content: recurses into Quoted /
-// Emph / Code / Link / ... instead of dropping them (bd-wcz4x7y0).
-function commentSpanText(span: InlineNode): string {
-    return inlinesToPlainText((span as SpanInline).c[1]);
-}
+// ---------------------------------------------------------------------
+// Rich bubble content (bd-y66gbfs4). The bubble renders the comment
+// span's inlines through the normal q2-preview inline renderers via the
+// framework's <Node> dispatch, with two deliberate deviations installed
+// through a bubble-scoped registry override:
+//
+//  - Editorial-mark spans and Notes render an affirmative
+//    `[unsupported content]` chip instead of their content. In the wire
+//    format ALL four editorial marks are `t: 'Span'` distinguished only
+//    by class, so the interception is class-aware inside a Span
+//    override (a tag-keyed entry can't see them). Nesting is handled
+//    for free: the provider wraps the whole bubble subtree, so
+//    recursion through any renderer re-enters the override.
+//  - `setLocalAst` is a no-op: the bubble displays the comment; all
+//    comment mutation goes through addComment / resolveCommentAtIndex
+//    on the resolved source node.
+//
+// Plan: claude-notes/plans/2026-08-26-rich-comment-bubbles.md
+
+const EDITORIAL_MARK_CLASSES = new Map<string, string>([
+    ['quarto-edit-comment', 'nested comment'],
+    ['quarto-insert', 'insertion mark'],
+    ['quarto-delete', 'deletion mark'],
+    ['quarto-highlight', 'highlight mark'],
+]);
+
+// Generic text on purpose — the chip must stay narrow in a 140px
+// bubble; the tooltip carries the kind.
+const UnsupportedChip = ({ kind }: { kind: string }) => (
+    <span
+        title={`unsupported in comment bubbles: ${kind}`}
+        style={{
+            fontFamily: 'monospace',
+            fontSize: '0.9em',
+            fontStyle: 'normal',
+            opacity: 0.65,
+        }}
+    >
+        [unsupported content]
+    </span>
+);
+
+const NOOP_SET_LOCAL_AST = () => {};
+
+/**
+ * Renders one comment span's content inlines for display in the
+ * bubble, under the bubble-scoped registry override described above.
+ */
+const CommentSpanContent = ({
+    span,
+    onNavigateToDocument,
+}: {
+    span: InlineNode;
+    onNavigateToDocument?: (path: string, anchor: string | null) => void;
+}) => {
+    const outer = React.useContext(RegistryContext);
+    const bubbleValue = React.useMemo(() => {
+        const OuterSpan = outer.registry['Span'];
+        const BubbleSpan = (props: NodeArgs<InlineNode>) => {
+            const classes = (props.node as SpanInline).c[0][1] ?? [];
+            const marked = classes.find((c) => EDITORIAL_MARK_CLASSES.has(c));
+            if (marked !== undefined) {
+                return <UnsupportedChip kind={EDITORIAL_MARK_CLASSES.get(marked)!} />;
+            }
+            return OuterSpan ? <OuterSpan {...props} /> : null;
+        };
+        const registry = {
+            ...outer.registry,
+            Span: BubbleSpan,
+            // Block content has no place in the chip-sized bubble.
+            Note: () => <UnsupportedChip kind="footnote" />,
+        };
+        return { registry, sourceInfoPool: outer.sourceInfoPool };
+    }, [outer.registry, outer.sourceInfoPool]);
+
+    return (
+        <RegistryContext.Provider value={bubbleValue}>
+            {(span as SpanInline).c[1].map((inline, i) => (
+                <AstNode
+                    key={i}
+                    node={inline}
+                    onNavigateToDocument={onNavigateToDocument}
+                    setLocalAst={NOOP_SET_LOCAL_AST}
+                />
+            ))}
+        </RegistryContext.Provider>
+    );
+};
 
 export const CommentBlock = (args: NodeArgs<BlockNode>) => {
     const edit = usePreviewEdit();
@@ -227,7 +322,13 @@ export const CommentBlock = (args: NodeArgs<BlockNode>) => {
     // (and no wrapper div) renders at all.
     if (mode === 'hide') return content;
     return (
-        <CommentWrapper comments={comments} block={block} edit={edit} mode={mode}>
+        <CommentWrapper
+            comments={comments}
+            block={block}
+            edit={edit}
+            mode={mode}
+            onNavigateToDocument={onNavigateToDocument}
+        >
             {content}
         </CommentWrapper>
     );
@@ -495,14 +596,59 @@ const CommentWrapper = ({
     block,
     edit,
     mode,
+    onNavigateToDocument,
 }: {
     children: React.ReactNode;
     comments: InlineNode[];
     block: BlockNode;
     edit: EditHandle;
     mode: CommentsMode;
+    onNavigateToDocument?: (path: string, anchor: string | null) => void;
 }) => {
     const [commentText, setCommentText] = React.useState('');
+    const previewCtx = React.useContext(PreviewContext);
+
+    /**
+     * Route an `<a>` click inside the bubble through the preview's
+     * link policy (bd-y66gbfs4). The chrome deliberately
+     * stopPropagation()s clicks (they must not reach the click-to-edit
+     * delegate), which also keeps them from the delegated body link
+     * listener — so the bubble routes its own link clicks through the
+     * same extracted logic. Returns true when the click hit a link
+     * (routed or swallowed) so callers skip the bubble's own
+     * expand/open-input behavior.
+     *
+     * Simplifications vs. PreviewRoot's wiring (agreed for v1): no
+     * `scrollToAnchor` host hook — same-document fragments use a plain
+     * smooth `scrollIntoView`; no `projectFilePaths` — artifact hrefs
+     * fall back to the `.qmd` candidate.
+     */
+    const handleBubbleLinkClick = (e: React.MouseEvent): boolean => {
+        const anchor = (e.target as Element | null)?.closest?.('a');
+        if (!anchor) return false;
+        const scrollToFragment = (frag: string) => {
+            document.getElementById(frag)?.scrollIntoView({ behavior: 'smooth' });
+        };
+        const handled = routeLinkClick(e.nativeEvent, {
+            currentFilePath: previewCtx?.currentFilePath ?? '',
+            onQmdLinkClick: (arg) => {
+                if ('path' in arg) {
+                    if (arg.path === previewCtx?.currentFilePath) {
+                        if (arg.anchor) scrollToFragment(arg.anchor);
+                    } else {
+                        onNavigateToDocument?.(arg.path, arg.anchor);
+                    }
+                } else {
+                    scrollToFragment(arg.anchor);
+                }
+            },
+        });
+        // An unroutable href must still never navigate the preview
+        // iframe from inside a bubble — swallow it.
+        if (!handled) e.preventDefault();
+        return true;
+    };
+
     // Clicking a compact bubble expands it in place (with the inline
     // add-comment input open at its bottom).
     const [selfExpanded, setSelfExpanded] = React.useState(false);
@@ -749,6 +895,20 @@ const CommentWrapper = ({
         // so the force layout re-measures.
     }, [chromeVisible, comments.length, expanded, showInlineInput]);
 
+    // Rich content can grow the bubble asynchronously — an <img> in a
+    // comment finishes loading after the force layout measured the
+    // chip. `load` doesn't bubble, so listen in the CAPTURE phase on
+    // the chrome and re-solve when it fires (growth is bounded by the
+    // .q2-comment-bubble img clamp + the chip's own maxWidth).
+    React.useEffect(() => {
+        if (!chromeVisible) return;
+        const el = chromeRef.current;
+        if (!el) return;
+        const onDescendantLoad = () => scheduleBubbleRelayout();
+        el.addEventListener('load', onDescendantLoad, true);
+        return () => el.removeEventListener('load', onDescendantLoad, true);
+    }, [chromeVisible]);
+
     // Sync hover into the registry entry. Re-layout on hover START
     // only: un-hovering keeps the arrangement as-is (it persists until
     // the next hover or a new bubble mounts).
@@ -839,11 +999,19 @@ const CommentWrapper = ({
                             e.preventDefault();
                         }
                     }}
-                    onClick={(e) => e.stopPropagation()}
+                    onClick={(e) => {
+                        // Link clicks inside the bubble route through
+                        // the preview's link policy here (they can't
+                        // reach the delegated body listener past the
+                        // stopPropagation below).
+                        handleBubbleLinkClick(e);
+                        e.stopPropagation();
+                    }}
                     onKeyDown={(e) => e.stopPropagation()}
                 >
                     <div
                         ref={bubbleRef}
+                        className="q2-comment-bubble"
                         style={{
                             // Near-white with just a hint of blue.
                             backgroundColor: '#f7faff',
@@ -853,13 +1021,24 @@ const CommentWrapper = ({
                             border: `1px solid ${CHROME_BLUE}`,
                             fontSize: '0.7rem',
                             cursor: 'pointer',
+                            // Chip-level containment (bd-y66gbfs4): no
+                            // rendered comment content of any kind may
+                            // widen the chip. Generous vs. the designed
+                            // content widths (expanded rows ≈ 220px) so
+                            // it only bites on oversized content.
+                            maxWidth: '260px',
+                            overflow: 'hidden',
                             // Block hover puts an offset-free light
                             // blue glow on the bubble.
                             boxShadow: isHovered ? GLOW : '0 2px 4px rgba(0,0,0,0.2)',
                             transition: 'box-shadow 0.15s',
                             userSelect: 'none',
                         }}
-                        onClick={() => {
+                        onClick={(e) => {
+                            // A click on a link is a navigation, not a
+                            // bubble interaction — the chrome-level
+                            // handler routes it; skip expand/open.
+                            if ((e.target as Element | null)?.closest?.('a')) return;
                             // Clicking a compact bubble expands it in
                             // place; any click opens the inline input.
                             if (!expanded) setSelfExpanded(true);
@@ -904,7 +1083,7 @@ const CommentWrapper = ({
                                                 maxWidth: '160px',
                                                 overflowWrap: 'break-word',
                                             }}>
-                                                {commentSpanText(c)}
+                                                <CommentSpanContent span={c} onNavigateToDocument={onNavigateToDocument} />
                                             </span>
                                             <button
                                                 onClick={(ev) => {
@@ -991,7 +1170,7 @@ const CommentWrapper = ({
                                     whiteSpace: 'nowrap',
                                     textOverflow: 'ellipsis',
                                 }}>
-                                    {commentSpanText(comments[0])}
+                                    <CommentSpanContent span={comments[0]} onNavigateToDocument={onNavigateToDocument} />
                                 </div>
                                 {comments.length > 1 && (
                                     <div style={{ color: '#6699cc', textAlign: 'right' }}>

--- a/ts-packages/preview-renderer/src/utils/iframeLinkHandlers.integration.test.ts
+++ b/ts-packages/preview-renderer/src/utils/iframeLinkHandlers.integration.test.ts
@@ -12,7 +12,7 @@
  */
 
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
-import { installLinkHandlers } from './iframeLinkHandlers';
+import { installLinkHandlers, routeLinkClick } from './iframeLinkHandlers';
 
 type QmdLinkClickArg = { path: string; anchor: string | null } | { anchor: string };
 
@@ -415,5 +415,75 @@ describe('installLinkHandlers', () => {
 
         expect(onQmdLinkClick).not.toHaveBeenCalled();
         expect(continued).toBe(true);
+    });
+});
+
+// ---------------------------------------------------------------------
+// bd-y66gbfs4 — `routeLinkClick` is the per-click routing extracted
+// from the body listener so non-delegated surfaces (the comment
+// bubble, whose chrome stopPropagation()s clicks before they reach
+// doc.body) can route link clicks through identical logic. Returns
+// true when it handled (and preventDefault'd) the click.
+
+describe('routeLinkClick', () => {
+    const opts = () => ({
+        currentFilePath: 'dir/current.qmd',
+        projectFilePaths: ['dir/other.qmd', 'index.qmd'],
+        onQmdLinkClick,
+    });
+
+    function clickEventOn(el: Element): MouseEvent {
+        const ev = new MouseEvent('click', { bubbles: true, cancelable: true });
+        Object.defineProperty(ev, 'target', { value: el });
+        return ev;
+    }
+
+    test('external link → window.open in a new tab, handled', () => {
+        const a = appendAnchor('https://example.com/x');
+        const ev = clickEventOn(a);
+        expect(routeLinkClick(ev, opts())).toBe(true);
+        expect(openSpy).toHaveBeenCalledWith(
+            'https://example.com/x',
+            '_blank',
+            'noopener,noreferrer',
+        );
+        expect(ev.defaultPrevented).toBe(true);
+    });
+
+    test('same-document #frag → onQmdLinkClick({anchor}), handled', () => {
+        const a = appendAnchor('#sec-2');
+        const ev = clickEventOn(a);
+        expect(routeLinkClick(ev, opts())).toBe(true);
+        expect(onQmdLinkClick).toHaveBeenCalledWith({ anchor: 'sec-2' });
+        expect(ev.defaultPrevented).toBe(true);
+    });
+
+    test('relative .qmd link resolves against currentFilePath, handled', () => {
+        const a = appendAnchor('./other.qmd#top');
+        const ev = clickEventOn(a);
+        expect(routeLinkClick(ev, opts())).toBe(true);
+        // Leading slash matches `resolveRelativePath`'s VFS-absolute
+        // convention (same shape the delegated listener produces).
+        expect(onQmdLinkClick).toHaveBeenCalledWith({
+            path: '/dir/other.qmd',
+            anchor: 'top',
+        });
+    });
+
+    test('click with no anchor ancestor → not handled, nothing called', () => {
+        const span = doc.createElement('span');
+        doc.body.appendChild(span);
+        const ev = clickEventOn(span);
+        expect(routeLinkClick(ev, opts())).toBe(false);
+        expect(onQmdLinkClick).not.toHaveBeenCalled();
+        expect(openSpy).not.toHaveBeenCalled();
+        expect(ev.defaultPrevented).toBe(false);
+    });
+
+    test('unroutable href (bare .html outside artifact root) → not handled', () => {
+        const a = appendAnchor('/about.html');
+        const ev = clickEventOn(a);
+        expect(routeLinkClick(ev, opts())).toBe(false);
+        expect(ev.defaultPrevented).toBe(false);
     });
 });

--- a/ts-packages/preview-renderer/src/utils/iframeLinkHandlers.ts
+++ b/ts-packages/preview-renderer/src/utils/iframeLinkHandlers.ts
@@ -80,47 +80,7 @@ export function installLinkHandlers(
     if (!body) return;
 
     body.addEventListener('click', (ev) => {
-        const anchor = findAnchorAncestor(ev.target as Element | null);
-        if (!anchor) return;
-        const href = anchor.getAttribute('href');
-        if (!href) return;
-
-        if (href.startsWith('http://') || href.startsWith('https://')) {
-            ev.preventDefault();
-            window.open(href, '_blank', 'noopener,noreferrer');
-            return;
-        }
-
-        if (href.startsWith('#')) {
-            const parsed = parseLink(href);
-            if (parsed.anchor && opts.onQmdLinkClick) {
-                ev.preventDefault();
-                opts.onQmdLinkClick({ anchor: parsed.anchor });
-            }
-            return;
-        }
-
-        // Phase F.1: artifact-rooted .html hrefs land here after
-        // LinkRewriteTransform runs. Always intercept; route the
-        // .qmd candidate through onQmdLinkClick (PreviewApp's render
-        // attempt is what surfaces a missing-page error).
-        const artifact = parseArtifactHref(href, opts.projectFilePaths);
-        if (artifact && opts.onQmdLinkClick) {
-            ev.preventDefault();
-            opts.onQmdLinkClick({ path: artifact.sourceCandidate, anchor: artifact.anchor });
-            return;
-        }
-
-        const parsed = parseLink(href);
-        if (
-            parsed.path &&
-            (parsed.path.endsWith('.qmd') || parsed.path.endsWith('.md')) &&
-            opts.onQmdLinkClick
-        ) {
-            ev.preventDefault();
-            const resolved = resolveRelativePath(opts.currentFilePath, parsed.path);
-            opts.onQmdLinkClick({ path: resolved, anchor: parsed.anchor });
-        }
+        routeLinkClick(ev, opts);
     });
 
     doc.addEventListener('keydown', (ev) => {
@@ -129,6 +89,71 @@ export function installLinkHandlers(
             window.parent.postMessage({ type: 'hub-client-save' }, '*');
         }
     });
+}
+
+/**
+ * Route one click event through the link-handling policy (extracted
+ * from the delegated body listener above — bd-y66gbfs4). Exists as a
+ * standalone function so surfaces whose click handling deliberately
+ * stops propagation before `doc.body` (the comment bubble's chrome,
+ * which must keep its clicks away from the click-to-edit delegate)
+ * can still route `<a>` clicks through identical logic.
+ *
+ * Returns true when the click was handled (and default-prevented):
+ * external → new tab; `#frag` / `.qmd` / artifact-rooted `.html` →
+ * `opts.onQmdLinkClick`. Returns false for clicks with no `<a>`
+ * ancestor or with an unroutable href — callers decide what a
+ * fall-through means on their surface (the body listener: native
+ * behavior; the bubble: treat as a plain bubble click).
+ */
+export function routeLinkClick(
+    ev: MouseEvent,
+    opts: InstallLinkHandlersOptions,
+): boolean {
+    const anchor = findAnchorAncestor(ev.target as Element | null);
+    if (!anchor) return false;
+    const href = anchor.getAttribute('href');
+    if (!href) return false;
+
+    if (href.startsWith('http://') || href.startsWith('https://')) {
+        ev.preventDefault();
+        window.open(href, '_blank', 'noopener,noreferrer');
+        return true;
+    }
+
+    if (href.startsWith('#')) {
+        const parsed = parseLink(href);
+        if (parsed.anchor && opts.onQmdLinkClick) {
+            ev.preventDefault();
+            opts.onQmdLinkClick({ anchor: parsed.anchor });
+            return true;
+        }
+        return false;
+    }
+
+    // Phase F.1: artifact-rooted .html hrefs land here after
+    // LinkRewriteTransform runs. Always intercept; route the
+    // .qmd candidate through onQmdLinkClick (PreviewApp's render
+    // attempt is what surfaces a missing-page error).
+    const artifact = parseArtifactHref(href, opts.projectFilePaths);
+    if (artifact && opts.onQmdLinkClick) {
+        ev.preventDefault();
+        opts.onQmdLinkClick({ path: artifact.sourceCandidate, anchor: artifact.anchor });
+        return true;
+    }
+
+    const parsed = parseLink(href);
+    if (
+        parsed.path &&
+        (parsed.path.endsWith('.qmd') || parsed.path.endsWith('.md')) &&
+        opts.onQmdLinkClick
+    ) {
+        ev.preventDefault();
+        const resolved = resolveRelativePath(opts.currentFilePath, parsed.path);
+        opts.onQmdLinkClick({ path: resolved, anchor: parsed.anchor });
+        return true;
+    }
+    return false;
 }
 
 interface ParsedLink {


### PR DESCRIPTION
## Summary

Comment bubbles previously showed `[>> ...]` comments as plain text (via `inlinesToPlainText`, since #612) — emphasis, code, quotes, and links lost their form. The bubble now renders the comment span's inlines through the normal q2-preview inline renderers, in both the compact chip and the expanded rows.

Follow-up to #612; strand bd-y66gbfs4 (discovered-from bd-wcz4x7y0).

## Design

- **Rich rendering**: `CommentSpanContent` maps the span's inlines through the framework's `<Node>` dispatch with a **no-op `setLocalAst`** — the bubble displays a comment, it is not an edit surface. Comment mutation still goes through `addComment`/`resolveCommentAtIndex`.
- **Link routing**: the bubble chrome `stopPropagation()`s clicks (they must not reach the click-to-edit delegate), which also kept them from the delegated body link listener — a bare `<a>` would have natively navigated the preview iframe. The per-click routing is extracted from `installLinkHandlers` as `routeLinkClick()` (behavior-identical; all pre-existing tests pass unchanged) and the bubble routes link clicks through it: external → new tab, `.qmd` → `onNavigateToDocument`, `#frag` → smooth `scrollIntoView`. Unroutable hrefs are swallowed — a bubble link never navigates the iframe — and link clicks don't expand the bubble.
- **Containment**: images (or anything oversized) cannot move layout outside the chip — scoped `.q2-comment-bubble img` clamp (`max-width`/`max-height`/`object-fit`), chip-level `maxWidth: 260px` + `overflow: hidden`, and a capture-phase `load` listener that re-schedules the bubble force layout when async growth lands.
- **Affirmative `[unsupported content]` chip**: nested editorial marks and `Note`s render a narrow monospace chip (kind in the tooltip) instead of their content, via a bubble-scoped registry override. All four editorial marks serialize as `t: 'Span'` distinguished only by class, so the interception is class-aware inside a `Span` override; the provider wraps the whole subtree, so arbitrarily nested marks are caught by normal registry recursion. Ordinary classed spans render normally.

## Testing

- TDD: 16 new cases written first and verified failing — `CommentBlock.bubbleText.integration.test.tsx` (rich elements, expanded rows, link routing, image containment + load relayout, unsupported chips ×6) and `iframeLinkHandlers.integration.test.ts` (`routeLinkClick` ×5). Three deliberate pre-fix guards pass before and after.
- Full gates green: preview-renderer unit (578) + integration (628), hub-client `test:ci` (1005 + 114 + 133) and `build:all`, workspace `cargo nextest` (13447), `cargo xtask verify` (all steps).
- End-to-end: rebuilt the preview chain, ran `q2 preview` on `Stuff.[>> see *this* and [a link](https://example.com/) and "quotes" and [!! marked]]`, inspected via devtools: real `<em>`/`<a>`/curly quotes, monospace chip with "highlight mark" tooltip, containment styles present — and a live in-iframe click on the link was default-prevented, called `window.open(..., '_blank', 'noopener,noreferrer')`, and did not open the comment input.

Plan: `claude-notes/plans/2026-08-26-rich-comment-bubbles.md`.

Notes: comment *authoring* from the bubble input stays plain text for v1 (rich comments are authored in the `.qmd` source); the live quarto-hub.com pickup requires a hub-client deploy after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)