### PR TITLE
Withhold the listing default sort from record-only listings

### DIFF
--- a/crates/quarto-core/src/transforms/listing_generate.rs
+++ b/crates/quarto-core/src/transforms/listing_generate.rs
@@ -37,6 +37,8 @@ use quarto_error_reporting::{DiagnosticMessage, DiagnosticMessageBuilder};
 use quarto_pandoc_types::pandoc::Pandoc;
 use quarto_source_map::SourceInfo;
 
+use std::collections::BTreeSet;
+
 use crate::Result;
 use crate::document_profile::DocumentProfile;
 use crate::glob::{
@@ -218,6 +220,12 @@ impl AstTransform for ListingGenerateTransform {
             // stay global — a `!` entry excludes a candidate no
             // matter where it appears in `contents:`.
             let mut ordered: Vec<((usize, u8), ListingItem)> = Vec::new();
+            // Which kinds of item this listing ended up with — the
+            // only consumer is the default-sort decision below
+            // (bd-listing-inline-records-order-eq8n2usm). Recorded
+            // during construction, like Q1's `sources` set, so that
+            // `include:`/`exclude:` filters cannot change it.
+            let mut sources: BTreeSet<ListingItemSource> = BTreeSet::new();
             if let Some(index) = ctx.project_index.as_deref() {
                 for profile in index.profiles() {
                     let candidate_path_str = path_to_forward_slashes(&profile.source_path);
@@ -238,6 +246,7 @@ impl AstTransform for ListingGenerateTransform {
                         }
                     }
                     if let Some(pattern_idx) = first_match {
+                        sources.insert(ListingItemSource::Document);
                         ordered.push(((pattern_idx, 1), hydrate_item(profile)));
                     }
                 }
@@ -306,7 +315,10 @@ impl AstTransform for ListingGenerateTransform {
                 let rec = parse_record(value, &mut diags);
                 let base_dir = base_ctx.base_dir_for(&rec.source);
                 let item = match rec.path.clone() {
-                    None => record_item(rec, ItemTarget::None, &base_dir),
+                    None => {
+                        sources.insert(ListingItemSource::Metadata);
+                        record_item(rec, ItemTarget::None, &base_dir)
+                    }
                     Some((raw, path_source)) => match resolve_record_path(
                         &raw,
                         &path_source,
@@ -318,9 +330,11 @@ impl AstTransform for ListingGenerateTransform {
                             if !item_visible(profile) {
                                 continue;
                             }
+                            sources.insert(ListingItemSource::MetadataDocument);
                             overlay_record(hydrate_item(profile), rec, &base_dir)
                         }
                         RecordPath::Href(href) => {
+                            sources.insert(ListingItemSource::Metadata);
                             record_item(rec, ItemTarget::Href(href), &base_dir)
                         }
                     },
@@ -360,7 +374,7 @@ impl AstTransform for ListingGenerateTransform {
                 // `apply_sort` treats as a no-op — declared
                 // `contents:` order flows through untouched.
                 apply_sort(&mut items, sort, &mut diags);
-            } else {
+            } else if sources.iter().any(|s| s.arms_default_sort()) {
                 // Default sort (Q1 parity): `order asc, title asc`,
                 // uniformly across listing types — Q1 applies its
                 // default whenever `title` is among the hydrated
@@ -368,6 +382,13 @@ impl AstTransform for ListingGenerateTransform {
                 // (table included). Items without `order:` sort
                 // after curated ones, in title order
                 // (bd-listing-declared-order-3ixcvc4o).
+                //
+                // Withheld when no item source arms it — see
+                // `ListingItemSource::arms_default_sort`. A listing
+                // built purely from inline records then keeps the
+                // order the author wrote, which is what `ordered`
+                // already holds
+                // (bd-listing-inline-records-order-eq8n2usm).
                 use crate::project::listing::config::{ListingSort, SortDirection};
                 let default_sort = vec![
                     ListingSort {
@@ -411,6 +432,56 @@ impl AstTransform for ListingGenerateTransform {
         ctx.resolved_listings = resolved;
         ctx.diagnostics = diags;
         Ok(())
+    }
+}
+
+/// Where a listing item came from.
+///
+/// Mirrors Q1's `ListingItemSource`
+/// (`src/project/types/website/listing/website-listing-read.ts`), and
+/// exists for exactly one reason: to decide whether a listing that
+/// declared no `sort:` gets the default one. Nothing else branches on
+/// it, so it deliberately does not travel on `ListingItem`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum ListingItemSource {
+    /// A project document matched by a `contents:` glob — Q1's
+    /// `ListingItemSource.document`.
+    Document,
+    /// An inline record whose `path:` resolved to a project document —
+    /// Q1's `metadataDocument` upgrade (`website-listing-read.ts:1044`).
+    MetadataDocument,
+    /// An inline record not backed by a project document: no `path:`,
+    /// an external URL, a non-markdown path, or a path naming nothing
+    /// the project renders — Q1's plain `metadata`
+    /// (`website-listing-read.ts:1008`).
+    Metadata,
+}
+
+impl ListingItemSource {
+    /// Whether an item from this source arms the default
+    /// `order asc, title asc` sort for its listing.
+    ///
+    /// Q1 applies that default only when the listing's sources include
+    /// `document` or `metadataDocument`
+    /// (`website-listing-read.ts:645-648`); a metadata-only listing is
+    /// returned untouched (`:286-288`), so the order the author wrote
+    /// in `contents:` survives. q2 applied the default unconditionally
+    /// and silently alphabetised hand-curated card lists — records have
+    /// no front matter, hence no `order:`, so every item tied on the
+    /// primary key and fell through to `title asc`
+    /// (bd-listing-inline-records-order-eq8n2usm).
+    ///
+    /// **The `match` is exhaustive on purpose — no wildcard arm.** The
+    /// bug above was not a coding error in either the record path or
+    /// the sort path; it was the *interaction* between a newly added
+    /// item source and a pre-existing default, which no phase of
+    /// either plan owned. A new source variant should not compile
+    /// until someone answers this question for it.
+    fn arms_default_sort(self) -> bool {
+        match self {
+            Self::Document | Self::MetadataDocument => true,
+            Self::Metadata => false,
+        }
     }
 }
 
@@ -1224,6 +1295,135 @@ mod tests {
         .await;
         assert!(diags.is_empty(), "{diags:?}");
         assert_eq!(titles(&resolved), vec!["First record", "A", "Last record"]);
+    }
+
+    // bd-listing-inline-records-order-eq8n2usm. Q1 applies its default
+    // `order asc, title asc` sort only when a listing's item sources
+    // include `document` or `metadataDocument`
+    // (`website-listing-read.ts:645-648`). A listing built purely from
+    // inline records has neither — every record is plain `metadata` —
+    // so Q1 leaves `items` untouched and declared YAML order survives.
+    // q2 applied the default unconditionally, and since a record has no
+    // front matter it has no `order`, so every item tied on the primary
+    // key and fell through to `title asc`: the author's curated order
+    // was silently alphabetised.
+    #[tokio::test]
+    async fn all_record_listing_keeps_declared_order_under_default_sort() {
+        let (resolved, diags) = run_transform(
+            contents_listing(vec![
+                map(vec![("title", s("Zulu"))]),
+                map(vec![("title", s("Alpha"))]),
+                map(vec![("title", s("Mike"))]),
+            ]),
+            "index.qmd",
+            vec![make_profile("index.qmd", "index.html", "Home")],
+        )
+        .await;
+        assert!(diags.is_empty(), "{diags:?}");
+        assert_eq!(titles(&resolved), vec!["Zulu", "Alpha", "Mike"]);
+    }
+
+    // The withholding is keyed on item *sources*, not on the absence of
+    // globs: a record whose `path:` resolves to a project document is
+    // Q1's `metadataDocument` (`website-listing-read.ts:1044`), which
+    // does qualify. So one such record re-arms the default sort for the
+    // whole listing — including the path-less records beside it.
+    #[tokio::test]
+    async fn record_path_to_a_document_re_arms_the_default_sort() {
+        let (resolved, diags) = run_transform(
+            contents_listing(vec![
+                map(vec![("title", s("Zulu"))]),
+                map(vec![("title", s("Alpha")), ("path", s("posts/a.qmd"))]),
+                map(vec![("title", s("Mike"))]),
+            ]),
+            "index.qmd",
+            vec![
+                make_profile("index.qmd", "index.html", "Home"),
+                make_profile("posts/a.qmd", "posts/a.html", "A"),
+            ],
+        )
+        .await;
+        assert!(diags.is_empty(), "{diags:?}");
+        assert_eq!(titles(&resolved), vec!["Alpha", "Mike", "Zulu"]);
+    }
+
+    // A record `path:` that is NOT a markdown document stays Q1's plain
+    // `metadata` (it never reaches the `metadataDocument` upgrade), so
+    // it must not re-arm the sort. Same for an external URL.
+    #[tokio::test]
+    async fn record_href_paths_do_not_re_arm_the_default_sort() {
+        let (resolved, diags) = run_transform(
+            contents_listing(vec![
+                map(vec![("title", s("Zulu")), ("path", s("assets/z.pdf"))]),
+                map(vec![
+                    ("title", s("Alpha")),
+                    ("path", s("https://example.com/a")),
+                ]),
+                map(vec![("title", s("Mike"))]),
+            ]),
+            "index.qmd",
+            vec![make_profile("index.qmd", "index.html", "Home")],
+        )
+        .await;
+        assert!(diags.is_empty(), "{diags:?}");
+        assert_eq!(titles(&resolved), vec!["Zulu", "Alpha", "Mike"]);
+    }
+
+    // A glob item is Q1's `document` source, so a mixed listing keeps
+    // the default sort — records alphabetise among the glob's documents
+    // exactly as in Q1. This is the deliberate limit of the fix: it
+    // restores Q1 parity, it does not extend declared-position ordering
+    // past what Q1 does.
+    #[tokio::test]
+    async fn mixed_record_and_glob_listing_still_gets_the_default_sort() {
+        let (resolved, diags) = run_transform(
+            contents_listing(vec![
+                map(vec![("title", s("Zulu"))]),
+                s("posts/*.qmd"),
+                map(vec![("title", s("Alpha"))]),
+            ]),
+            "index.qmd",
+            vec![
+                make_profile("index.qmd", "index.html", "Home"),
+                make_profile("posts/a.qmd", "posts/a.html", "Post One"),
+                make_profile("posts/b.qmd", "posts/b.html", "Post Two"),
+            ],
+        )
+        .await;
+        assert!(diags.is_empty(), "{diags:?}");
+        assert_eq!(
+            titles(&resolved),
+            vec!["Alpha", "Post One", "Post Two", "Zulu"]
+        );
+    }
+
+    // Withholding the *default* sort must not withhold an *explicit*
+    // one: Q1's condition is `!listingHydrated.sort`, so an author who
+    // writes `sort:` on an all-records listing still gets it applied.
+    #[tokio::test]
+    async fn explicit_sort_still_applies_to_an_all_record_listing() {
+        let (resolved, diags) = run_transform(
+            map(vec![(
+                "listing",
+                map(vec![
+                    ("id", s("l")),
+                    ("sort", arr(vec![s("title asc")])),
+                    (
+                        "contents",
+                        arr(vec![
+                            map(vec![("title", s("Zulu"))]),
+                            map(vec![("title", s("Alpha"))]),
+                            map(vec![("title", s("Mike"))]),
+                        ]),
+                    ),
+                ]),
+            )]),
+            "index.qmd",
+            vec![make_profile("index.qmd", "index.html", "Home")],
+        )
+        .await;
+        assert!(diags.is_empty(), "{diags:?}");
+        assert_eq!(titles(&resolved), vec!["Alpha", "Mike", "Zulu"]);
     }
 
     #[tokio::test]

--- a/docs/guides/projects/listings.qmd
+++ b/docs/guides/projects/listings.qmd
@@ -61,9 +61,27 @@ and keeps the link as written, and warns
 ### Order
 
 Items are sorted by the listing's `sort:`. **With no `sort:` key, the
-default is `order asc, title asc`** — since records usually carry neither
-an `order:` nor a `date:`, this alphabetizes a hand-curated `contents:`
-list by title. To keep a curated list in the order you wrote it, set
+default is `order asc, title asc`** — but that default applies only to a
+listing that contains at least one *document*: an item matched by a
+`contents:` glob, or a record whose `path:` names a document the project
+renders.
+
+A listing built entirely from records — the usual shape of a
+hand-curated card list — gets no default sort, and its items appear in
+the order you wrote them:
+
+```yaml
+listing:
+  contents:
+    - title: "Get started"     # renders first
+    - title: "Explore features"
+    - title: "Advanced usage"
+```
+
+Add one glob, or one record whose `path:` points at a page in the
+project, and the default sort applies to the whole listing again —
+alphabetizing the records along with it, since records carry no `order:`
+of their own. To keep such a list in the order you wrote it, set
 `sort: false`, or give each record an explicit `order:`.
 
 With `sort: false`, items appear in the order of the `contents:` entries


### PR DESCRIPTION
A listing whose `contents:` is a list of inline records renders them
alphabetically by title. Records written as Zulu, Alpha, Mike come out
Alpha, Mike, Zulu. There's no diagnostic — every field renders correctly,
so nothing signals that the authoring order was discarded.

Quarto 1 renders them in the order they're written.

## Cause

Not the declared-position code. `ListingGenerateTransform` tags each item
with a `(globs_before, is_glob)` key and stable-sorts, which in an
all-records listing leaves push order — i.e. declared order — intact.

`apply_sort` then runs with the default `order asc, title asc`. An inline
record isn't a document and has no front matter, so `ListingItem.order` is
`None` for every item; they all tie on the primary key and fall through to
`title asc`.

That also explains the two known workarounds: `sort: false` skips
`apply_sort` entirely, and an explicit `order:` on each record breaks the
tie.

## What Q1 does

Q1 has the same default sort, but only applies it when the listing's item
sources include a document (`website-listing-read.ts:645-648`). An inline
record is `ListingItemSource.metadata`, upgraded to `metadataDocument`
only when its `path:` resolves to a real document (`:1044`). A listing
built purely from records has neither, so `sortedAndFiltered` returns
`items` untouched and the declared order survives — by omission, not by
construction. Which is why porting the ordering logic faithfully still
lost it: the default sort was never part of that logic.

## Change

Mirror Q1. A new `ListingItemSource` classifies each item as it's built:

- `Document` — matched by a `contents:` glob
- `MetadataDocument` — a record whose `path:` resolved to a project
  document (markdown extension + a project-index hit, the same two
  conditions as Q1's upgrade)
- `Metadata` — any other record: no `path:`, an external URL, a
  non-markdown path, or a path naming nothing the project renders

The default sort applies only if some source arms it. Sources are recorded
during construction, before `apply_filters`, so `include:`/`exclude:`
can't change the decision — that's where Q1 computes its set too.

`arms_default_sort` matches exhaustively with no wildcard arm. This bug
wasn't an error in the record path or in the sort path; it was the
interaction between a newly added item source and a pre-existing default.
A fourth variant shouldn't compile until someone answers the question for
it.

## Deliberately unchanged

**Mixed listings.** A record + glob + record listing still sorts
`order asc, title asc`. The glob contributes a document source, which arms
the default in Q1 too — verified against 99.9.9, which renders that case
identically to q2 both before and after this change. It differs from the
declared-position intent in §D3 of the inline-contents plan, and D3 says
so itself ("differs from Q1 ... only under `sort: false`"). Where the plan
and Q1 disagree, Q1 wins.

**Ordinary listings.** An absent `contents:` defaults to a `*.qmd` glob
(`config.rs:996`), so blog-style listings are untouched.

**Explicit `sort:`.** Q1's condition is `sort && !listingHydrated.sort` —
withholding the *default* must not withhold an author's. An all-records
listing with a `sort:` key still gets it.

## Alternative considered

Giving each record an implicit `order` of its declaration index is a
smaller change and fixes the all-records case, but documents carry no
`order` and missing values sort last, so every record would float above
every glob-matched document in a mixed listing — diverging from Q1 and
from §D3's interleave intent alike.

## Docs

`docs/guides/projects/listings.qmd` §Order described the old behaviour as
intended ("since records usually carry neither an `order:` nor a `date:`,
this alphabetizes a hand-curated `contents:` list by title"). Rewritten to
state the source rule.

## Effect on a real site

Rendering the Positron docs port (105 pages, 11 listings, 42 records, all
of them path-less) with a binary built from this branch's parent and one
built from this branch:

| page | before | after |
| --- | --- | --- |
| ai-features | 16 | 0 |
| welcome | 12 | 0 |
| assistant-getting-started | 8 | 0 |
| tutorials | 4 | 0 |
| features | 42 | 1 |
| assistant | 4 | 2 |
| older-releases | 1 | 1 |
| 19 other pages | unchanged | unchanged |

Lines of text differing from the Quarto 1 baseline. Four pages reach exact
text parity. The residuals are unrelated: a smart quote on each (count is
identical under both binaries), and a heading dropped by an id collision
between a listing div and a preceding heading's auto-id. Broken references
and chrome diffs are identical under both binaries.

Closes bd-listing-inline-records-order-eq8n2usm.
