### PR TITLE
Q-2-45/46/49: quote the whole bracket label, not just its plain text

### DIFF
--- a/crates/pampa/src/writers/qmd.rs
+++ b/crates/pampa/src/writers/qmd.rs
@@ -61,6 +61,19 @@ pub struct QmdWriterContext {
     /// caller emits a leading `\` and the dashes stay Unicode so the reader
     /// recovers them rather than reading a HorizontalRule.
     pub suppress_dash_canonicalization: bool,
+
+    /// When true, this run is being written as a fragment embedded *inside* a
+    /// line of surrounding text rather than as a document of its own, so
+    /// `escape_markdown` may consult [`Self::at_line_start`] instead of
+    /// escaping the line-start-only specials (`#`, `>`) everywhere. Set only
+    /// by [`write_inlines_fragment`].
+    pub inline_fragment: bool,
+
+    /// Whether the next byte written begins a line. Maintained by
+    /// `write_inline` alongside `prev_emitted_alnum`, and read only when
+    /// [`Self::inline_fragment`] is set. Starts `false` because a fragment is
+    /// embedded mid-line; a SoftBreak or LineBreak sets it back to `true`.
+    pub at_line_start: bool,
 }
 
 impl Default for QmdWriterContext {
@@ -76,6 +89,8 @@ impl QmdWriterContext {
             emphasis_stack: Vec::new(),
             prev_emitted_alnum: false,
             suppress_dash_canonicalization: false,
+            inline_fragment: false,
+            at_line_start: false,
         }
     }
 
@@ -1553,6 +1568,23 @@ fn line_is_dash_only_hazard(line: &[Inline]) -> bool {
 // `---`) apart from genuinely-literal hyphens (`--` → `\-\-`). A run short
 // enough to be inert (a lone hyphen, or one/two dots) is emitted verbatim.
 //
+/// How [`escape_markdown`] treats the two characters that are markdown-special
+/// only at the *start of a line*: `#` (ATX heading) and `>` (blockquote).
+///
+/// Every other entry in the escape table is special mid-line as well and is
+/// always escaped.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum LineStartEscapes {
+    /// Escape `#` and `>` wherever they appear. The whole-document writer
+    /// cannot know where in a line a given `Str` will land, so it escapes
+    /// conservatively.
+    Always,
+    /// Escape `#` and `>` only where they actually begin a line. The payload
+    /// says whether the text being escaped starts one; newlines *within* the
+    /// text move the position along.
+    WhereMeaningful { starts_line: bool },
+}
+
 // The ASCII apostrophe `'` (and its Unicode form `’`) is escaped whenever the
 // reader would otherwise misclassify it as a smart-quote open/close. The
 // reader's smart-quote classifier accepts `'` as an apostrophe only when it sits
@@ -1563,8 +1595,24 @@ fn line_is_dash_only_hazard(line: &[Inline]) -> bool {
 // `start_prev_is_alnum` (carried in from `QmdWriterContext` so the rule can see
 // across inline boundaries — e.g. a closing backtick from a preceding `Code`
 // span; see bd-nsb9 / issue #205), and the next char in the `Str` body.
-fn escape_markdown(text: &str, start_prev_is_alnum: bool) -> String {
+fn escape_markdown(
+    text: &str,
+    start_prev_is_alnum: bool,
+    line_start_escapes: LineStartEscapes,
+) -> String {
     let chars: Vec<char> = text.chars().collect();
+    // Whether `chars[i]` is the first character of a line. Only consulted for
+    // `#` and `>`, and only under `WhereMeaningful`.
+    let begins_line = |i: usize| match line_start_escapes {
+        LineStartEscapes::Always => true,
+        LineStartEscapes::WhereMeaningful { starts_line } => {
+            if i == 0 {
+                starts_line
+            } else {
+                chars[i - 1] == '\n'
+            }
+        }
+    };
     let mut result = String::new();
     let mut i = 0;
     while i < chars.len() {
@@ -1573,18 +1621,21 @@ fn escape_markdown(text: &str, start_prev_is_alnum: bool) -> String {
             // Characters that must be escaped to avoid triggering markdown syntax:
             '\\' => result.push_str("\\\\"), // Escape character itself
             '<' => result.push_str("\\<"),   // HTML tags, autolinks
-            '>' => result.push_str("\\>"),   // Blockquotes (at line start)
-            '#' => result.push_str("\\#"),   // Headers (at line start)
-            '$' => result.push_str("\\$"),   // Math delimiters
-            '*' => result.push_str("\\*"),   // Emphasis, strong, lists
-            '_' => result.push_str("\\_"),   // Emphasis, strong
-            '[' => result.push_str("\\["),   // Links
-            ']' => result.push_str("\\]"),   // Links
-            '`' => result.push_str("\\`"),   // Code spans
-            '|' => result.push_str("\\|"),   // Tables
-            '~' => result.push_str("\\~"),   // Subscript, strikeout
-            '^' => result.push_str("\\^"),   // Superscript
-            '@' => result.push_str("\\@"),   // Citations: every bare @ in
+            // Blockquotes and headings exist only at the start of a line.
+            '>' if begins_line(i) => result.push_str("\\>"),
+            '>' => result.push('>'),
+            '#' if begins_line(i) => result.push_str("\\#"),
+            '#' => result.push('#'),
+            '$' => result.push_str("\\$"), // Math delimiters
+            '*' => result.push_str("\\*"), // Emphasis, strong, lists
+            '_' => result.push_str("\\_"), // Emphasis, strong
+            '[' => result.push_str("\\["), // Links
+            ']' => result.push_str("\\]"), // Links
+            '`' => result.push_str("\\`"), // Code spans
+            '|' => result.push_str("\\|"), // Tables
+            '~' => result.push_str("\\~"), // Subscript, strikeout
+            '^' => result.push_str("\\^"), // Superscript
+            '@' => result.push_str("\\@"), // Citations: every bare @ in
             // a Str is either a citation start (when followed by alnum/_/{)
             // or an outright parse error (any other position). Always escape.
             '{' => result.push_str("\\{"), // Attribute span open: bare { in
@@ -1686,7 +1737,14 @@ fn write_str(
         }
         return Ok(());
     }
-    let escaped = escape_markdown(&s.text, ctx.prev_emitted_alnum);
+    let line_start_escapes = if ctx.inline_fragment {
+        LineStartEscapes::WhereMeaningful {
+            starts_line: ctx.at_line_start,
+        }
+    } else {
+        LineStartEscapes::Always
+    };
+    let escaped = escape_markdown(&s.text, ctx.prev_emitted_alnum, line_start_escapes);
     write!(buf, "{}", escaped)
 }
 
@@ -2321,7 +2379,7 @@ fn shortcode_string_looks_like_number(s: &str) -> bool {
 
 #[cfg(test)]
 mod smart_typography_writer_tests {
-    use super::{escape_markdown, line_is_dash_only_hazard};
+    use super::{LineStartEscapes, escape_markdown, line_is_dash_only_hazard};
     use crate::pandoc::inline::{Inline, Space, Str};
     use quarto_source_map::SourceInfo;
 
@@ -2342,23 +2400,53 @@ mod smart_typography_writer_tests {
     fn canonicalizes_unicode_smart_chars_unescaped() {
         // Unicode smart chars become their ASCII spelling, emitted UNescaped so
         // the reader re-converts them.
-        assert_eq!(escape_markdown("\u{2014}", false), "---"); // em → ---
-        assert_eq!(escape_markdown("\u{2013}", false), "--"); // en → --
-        assert_eq!(escape_markdown("\u{2026}", false), "..."); // … → ...
-        assert_eq!(escape_markdown("a\u{2014}b\u{2026}c", false), "a---b...c");
+        assert_eq!(
+            escape_markdown("\u{2014}", false, LineStartEscapes::Always),
+            "---"
+        ); // em → ---
+        assert_eq!(
+            escape_markdown("\u{2013}", false, LineStartEscapes::Always),
+            "--"
+        ); // en → --
+        assert_eq!(
+            escape_markdown("\u{2026}", false, LineStartEscapes::Always),
+            "..."
+        ); // … → ...
+        assert_eq!(
+            escape_markdown("a\u{2014}b\u{2026}c", false, LineStartEscapes::Always),
+            "a---b...c"
+        );
         // ’ between alnums is kept as ', elsewhere escaped.
-        assert_eq!(escape_markdown("don\u{2019}t", false), "don't");
+        assert_eq!(
+            escape_markdown("don\u{2019}t", false, LineStartEscapes::Always),
+            "don't"
+        );
     }
 
     #[test]
     fn escapes_literal_dash_and_dot_runs() {
         // Literal ASCII runs the reader would smart-convert must be escaped so
         // they stay literal (e.g. from escaped input `a\-\-b`).
-        assert_eq!(escape_markdown("a--b", false), "a\\-\\-b");
-        assert_eq!(escape_markdown("a---b", false), "a\\-\\-\\-b");
-        assert_eq!(escape_markdown("a-b", false), "a-b"); // lone hyphen inert
-        assert_eq!(escape_markdown("x...", false), "x\\.\\.\\.");
-        assert_eq!(escape_markdown("x..", false), "x.."); // two dots inert
+        assert_eq!(
+            escape_markdown("a--b", false, LineStartEscapes::Always),
+            "a\\-\\-b"
+        );
+        assert_eq!(
+            escape_markdown("a---b", false, LineStartEscapes::Always),
+            "a\\-\\-\\-b"
+        );
+        assert_eq!(
+            escape_markdown("a-b", false, LineStartEscapes::Always),
+            "a-b"
+        ); // lone hyphen inert
+        assert_eq!(
+            escape_markdown("x...", false, LineStartEscapes::Always),
+            "x\\.\\.\\."
+        );
+        assert_eq!(
+            escape_markdown("x..", false, LineStartEscapes::Always),
+            "x.."
+        ); // two dots inert
     }
 
     #[test]
@@ -2594,13 +2682,25 @@ fn write_inline(
     match inline {
         crate::pandoc::Inline::Str(s) => {
             ctx.prev_emitted_alnum = s.text.chars().last().is_some_and(|c| c.is_alphanumeric());
+            // A `Str` body normally holds no newline (the reader emits
+            // SoftBreak nodes instead), but honour one if it does.
+            ctx.at_line_start = s.text.ends_with('\n');
         }
         crate::pandoc::Inline::Custom(_) => {
             // No bytes emitted; preserve prior state.
         }
+        // Both break kinds end their output with a newline, so whatever
+        // follows them begins a line.
+        crate::pandoc::Inline::SoftBreak(_) | crate::pandoc::Inline::LineBreak(_) => {
+            ctx.prev_emitted_alnum = false;
+            ctx.at_line_start = true;
+        }
         // Every other inline kind closes with a non-alphanumeric byte
         // (delimiter, bracket, backtick, newline, space, ...).
-        _ => ctx.prev_emitted_alnum = false,
+        _ => {
+            ctx.prev_emitted_alnum = false;
+            ctx.at_line_start = false;
+        }
     }
 
     result
@@ -2834,6 +2934,48 @@ pub fn write_inlines<T: std::io::Write>(
     Ok(())
 }
 
+/// Write a sequence of inlines as a fragment embedded *inside* a line of
+/// surrounding text.
+///
+/// Like [`write_inlines`], but for output that will be spliced into a larger
+/// line rather than stand as a document of its own — quoting a bracket label
+/// back to the author inside a diagnostic message, for instance.
+///
+/// The difference is escaping. `#` and `>` are markdown-special only at the
+/// start of a line; [`write_inlines`] cannot know where in a line its output
+/// will land, so it escapes them everywhere, turning `[#7380](url)` into
+/// `[\#7380](url)`. This entry point tracks line position and escapes them
+/// only where a reader would really see a heading or a blockquote — so a
+/// fragment round-trips to the author's own spelling, and a `#` that follows
+/// a SoftBreak inside the run is still escaped. Every other escape is
+/// identical between the two.
+///
+/// Introduced for `Q-2-45`/`Q-2-46`/`Q-2-49`, whose messages quote the
+/// offending source and print a remedy the author is expected to copy
+/// (bd-q249-message-drops-inline-content-pacg3qeu).
+pub fn write_inlines_fragment<T: std::io::Write>(
+    inlines: &[crate::pandoc::Inline],
+    buf: &mut T,
+) -> Result<(), Vec<quarto_error_reporting::DiagnosticMessage>> {
+    let mut ctx = QmdWriterContext::new();
+    ctx.inline_fragment = true;
+    ctx.at_line_start = false;
+    for inline in inlines {
+        if let Err(e) = write_inline(inline, buf, &mut ctx) {
+            return Err(vec![
+                quarto_error_reporting::DiagnosticMessageBuilder::error("IO error during write")
+                    .with_code("Q-3-1")
+                    .problem(format!("Failed to write inline: {}", e))
+                    .build(),
+            ]);
+        }
+    }
+    if !ctx.errors.is_empty() {
+        return Err(ctx.errors);
+    }
+    Ok(())
+}
+
 /// Write metadata (YAML front matter) to the given buffer.
 ///
 /// This is a public wrapper around `write_config_value_meta`, intended for use
@@ -2964,4 +3106,99 @@ fn write_impl_tracked(
     }
 
     Ok(quarto_source_map::SourceInfo::concat(pieces))
+}
+
+#[cfg(test)]
+mod inline_fragment_escaping_tests {
+    //! `#` and `>` are markdown-special only at the start of a line. The
+    //! whole-document writer has no line-position context and so escapes
+    //! them everywhere; the fragment entry point tracks position and
+    //! escapes them only where a reader would actually see a heading or a
+    //! blockquote. See `write_inlines_fragment`.
+
+    use super::write_inlines_fragment;
+
+    /// Parse `source` as a document and render its first block's inlines
+    /// back as an embedded fragment.
+    fn fragment(source: &str) -> String {
+        let mut sink = std::io::sink();
+        let (ast, _ctx, _warnings) =
+            crate::readers::qmd::read(source.as_bytes(), false, "t.qmd", &mut sink, true, None)
+                .expect("fixture must parse");
+        let inlines = match &ast.blocks[0] {
+            crate::pandoc::Block::Paragraph(p) => &p.content,
+            crate::pandoc::Block::Plain(p) => &p.content,
+            other => panic!("fixture must be a paragraph, got {other:?}"),
+        };
+        let mut buf = Vec::new();
+        write_inlines_fragment(inlines, &mut buf).expect("fragment must write");
+        String::from_utf8(buf).expect("fragment must be utf-8")
+    }
+
+    /// The same inlines through the whole-document entry point, which must
+    /// keep escaping conservatively.
+    fn whole_document(source: &str) -> String {
+        let mut sink = std::io::sink();
+        let (ast, _ctx, _warnings) =
+            crate::readers::qmd::read(source.as_bytes(), false, "t.qmd", &mut sink, true, None)
+                .expect("fixture must parse");
+        let inlines = match &ast.blocks[0] {
+            crate::pandoc::Block::Paragraph(p) => &p.content,
+            crate::pandoc::Block::Plain(p) => &p.content,
+            other => panic!("fixture must be a paragraph, got {other:?}"),
+        };
+        let mut buf = Vec::new();
+        super::write_inlines(inlines, &mut buf).expect("inlines must write");
+        String::from_utf8(buf).expect("output must be utf-8")
+    }
+
+    #[test]
+    fn hash_mid_line_is_not_escaped() {
+        assert_eq!(fragment("issue #1234 here\n"), "issue #1234 here");
+    }
+
+    #[test]
+    fn hash_opening_the_fragment_is_not_escaped() {
+        // A fragment is embedded *inside* a line, so its first byte is
+        // never the first byte of a line.
+        assert_eq!(fragment("#1234\n"), "#1234");
+    }
+
+    #[test]
+    fn angle_bracket_mid_line_is_not_escaped() {
+        assert_eq!(fragment("a > b\n"), "a > b");
+    }
+
+    #[test]
+    fn a_link_keeps_its_hash_unescaped() {
+        assert_eq!(
+            fragment("[#7380](https://example.com/7380)\n"),
+            "[#7380](https://example.com/7380)"
+        );
+    }
+
+    /// The escape is dropped only for the two line-start-only characters.
+    /// Everything else in the escape table is special mid-line too.
+    #[test]
+    fn other_escapes_are_unaffected() {
+        assert_eq!(fragment("a\\*b\\_c\\[d\\]e\n"), "a\\*b\\_c\\[d\\]e");
+    }
+
+    /// After a soft break the fragment really is at the start of a line, so
+    /// a leading `#` would be read as a heading and must stay escaped.
+    #[test]
+    fn hash_after_a_soft_break_is_still_escaped() {
+        assert_eq!(fragment("a\n\\#b\n"), "a\n\\#b");
+    }
+
+    /// The whole-document entry point is unchanged: it still has no
+    /// line-position context and still escapes conservatively.
+    #[test]
+    fn whole_document_writer_still_escapes_hash_everywhere() {
+        assert_eq!(whole_document("issue #1234 here\n"), "issue \\#1234 here");
+        assert_eq!(
+            whole_document("[#7380](https://example.com/7380)\n"),
+            "[\\#7380](https://example.com/7380)"
+        );
+    }
 }

--- a/crates/quarto-core/src/transforms/reference_link_diagnostics.rs
+++ b/crates/quarto-core/src/transforms/reference_link_diagnostics.rs
@@ -133,22 +133,99 @@ fn source_info(inline: &Inline) -> Option<quarto_source_map::SourceInfo> {
     }
 }
 
-/// Plain text of a bracket group's contents, for the warning message.
-fn label_text(inline: &Inline) -> String {
-    let content = match inline {
-        Inline::Span(span) => &span.content,
-        Inline::Image(image) => &image.content,
-        _ => return String::new(),
+/// The inlines inside a bracket group — `[…]`'s content, or `![…]`'s alt.
+fn label_content(inline: &Inline) -> Option<&Inlines> {
+    match inline {
+        Inline::Span(span) => Some(&span.content),
+        Inline::Image(image) => Some(&image.content),
+        _ => None,
+    }
+}
+
+/// The label as the **author wrote it**: markdown surface form.
+///
+/// This is the string for every slot that quotes source — the offending
+/// text echoed back, and the remedies the author is expected to copy into
+/// the file. It must therefore be complete: a label holding a link has to
+/// come back as `[#7380](url)`, because a remedy built from anything less
+/// tells the author to delete content
+/// (bd-q249-message-drops-inline-content-pacg3qeu).
+///
+/// Rendered with the qmd writer's *fragment* entry point rather than
+/// [`pampa::writers::qmd::write_inlines`]: the result is spliced into the
+/// middle of a sentence, so the line-start-only escapes (`#`, `>`) would be
+/// noise — and `#` is near-universal here, since the shape that motivated
+/// this is `[#1234](issue-url)`.
+fn label_source(inline: &Inline) -> String {
+    let Some(content) = label_content(inline) else {
+        return String::new();
     };
-    content
-        .iter()
-        .map(|i| match i {
-            Inline::Str(s) => s.text.clone(),
-            Inline::Space(_) => " ".to_string(),
-            Inline::Code(c) => c.text.clone(),
-            _ => String::new(),
-        })
-        .collect()
+    let mut buf = Vec::new();
+    match pampa::writers::qmd::write_inlines_fragment(content, &mut buf) {
+        // Writing into a `Vec` cannot fail for I/O reasons; a writer
+        // diagnostic would mean an inline kind it cannot spell. Falling back
+        // to the reader-visible text loses the markup but never invents a
+        // remedy that deletes content.
+        Ok(()) => String::from_utf8_lossy(&buf).into_owned(),
+        Err(_) => label_rendered(inline),
+    }
+}
+
+/// The label as a **reader perceives it**: markup resolved away.
+///
+/// This is the string for the one slot that describes output rather than
+/// source — "the reader sees …". It is deliberately *not* the same string
+/// as [`label_source`]: for `[see `config.yml` now]` the author wrote
+/// backticks and the reader sees none, and for `[[#7380](url)]` the author
+/// wrote a whole link and the reader sees `#7380`. Conflating the two is
+/// what made this diagnostic claim the reader saw nothing at all.
+///
+/// Pandoc `stringify` semantics. Neither existing helper fits: the
+/// plaintext writer (`pampa::writers::plaintext`) keeps a `Code` span's
+/// backticks, and pampa's Lua `stringify` maps SoftBreak/LineBreak to `\n`,
+/// which would put a newline inside a one-line warning.
+fn label_rendered(inline: &Inline) -> String {
+    let Some(content) = label_content(inline) else {
+        return String::new();
+    };
+    let mut out = String::new();
+    push_rendered(content, &mut out);
+    out
+}
+
+fn push_rendered(inlines: &Inlines, out: &mut String) {
+    for inline in inlines {
+        match inline {
+            Inline::Str(s) => out.push_str(&s.text),
+            // Every break is a space to the reader: HTML collapses it, and
+            // the warning is a single line.
+            Inline::Space(_) | Inline::SoftBreak(_) | Inline::LineBreak(_) => out.push(' '),
+            Inline::Code(c) => out.push_str(&c.text),
+            Inline::Math(m) => out.push_str(&m.text),
+            Inline::Quoted(q) => {
+                out.push('"');
+                push_rendered(&q.content, out);
+                out.push('"');
+            }
+            Inline::Emph(i) => push_rendered(&i.content, out),
+            Inline::Strong(i) => push_rendered(&i.content, out),
+            Inline::Underline(i) => push_rendered(&i.content, out),
+            Inline::Strikeout(i) => push_rendered(&i.content, out),
+            Inline::Superscript(i) => push_rendered(&i.content, out),
+            Inline::Subscript(i) => push_rendered(&i.content, out),
+            Inline::SmallCaps(i) => push_rendered(&i.content, out),
+            Inline::Link(i) => push_rendered(&i.content, out),
+            Inline::Image(i) => push_rendered(&i.content, out),
+            Inline::Span(i) => push_rendered(&i.content, out),
+            Inline::Cite(i) => push_rendered(&i.content, out),
+            Inline::Insert(i) => push_rendered(&i.content, out),
+            Inline::Delete(i) => push_rendered(&i.content, out),
+            Inline::Highlight(i) => push_rendered(&i.content, out),
+            // Raw inlines, notes, shortcodes and edit comments contribute
+            // nothing a reader sees in the surrounding run of text.
+            _ => {}
+        }
+    }
 }
 
 /// Walk every `Inlines` list in the document, warning on the two shapes.
@@ -209,7 +286,7 @@ fn scan_inlines(inlines: &Inlines, diagnostics: &mut Vec<DiagnosticMessage>) {
 }
 
 fn definition_warning(span: &Inline) -> DiagnosticMessage {
-    let label = label_text(span);
+    let label = label_source(span);
     let mut diagnostic = DiagnosticMessage::warning(format!(
         "`[{label}]:` looks like a link reference definition, which quarto-markdown \
          does not support. The line renders as visible text. Use inline links — \
@@ -221,8 +298,8 @@ fn definition_warning(span: &Inline) -> DiagnosticMessage {
 }
 
 fn reference_use_warning(label: &Inline, reference: &Inline) -> DiagnosticMessage {
-    let label_text = label_text(label);
-    let reference_text = label_text_of_reference(reference);
+    let label_text = label_source(label);
+    let reference_text = label_source(reference);
     let bang = if is_empty_image(label) { "!" } else { "" };
 
     let mut diagnostic = DiagnosticMessage::warning(format!(
@@ -242,19 +319,19 @@ fn reference_use_warning(label: &Inline, reference: &Inline) -> DiagnosticMessag
 }
 
 fn lone_bracket_warning(span: &Inline) -> DiagnosticMessage {
-    let label = label_text(span);
+    // Two different strings: `source` quotes what the author wrote (and is
+    // what the remedies are built from), `rendered` describes what a reader
+    // ends up seeing. They coincide only for an all-text label.
+    let source = label_source(span);
+    let rendered = label_rendered(span);
     let mut diagnostic = DiagnosticMessage::warning(format!(
-        "`[{label}]` has no attribute block, so it renders as an empty span and \
-         the brackets are discarded — the reader sees `{label}`. Write `\\[{label}\\]` \
-         to keep the brackets literal, or `[{label}]{{.class}}` if a span was intended."
+        "`[{source}]` has no attribute block, so it renders as an empty span and \
+         the brackets are discarded — the reader sees `{rendered}`. Write `\\[{source}\\]` \
+         to keep the brackets literal, or `[{source}]{{.class}}` if a span was intended."
     ))
     .with_code(CODE_LONE_BRACKETS);
     diagnostic.location = source_info(span);
     diagnostic
-}
-
-fn label_text_of_reference(reference: &Inline) -> String {
-    label_text(reference)
 }
 
 /// Every `Inlines` list in the document, in document order.
@@ -529,6 +606,138 @@ mod tests {
         assert_eq!(
             codes("Text before [label]: after\n"),
             vec![CODE_LONE_BRACKETS]
+        );
+    }
+
+    /// The Positron release-notes shape. Before
+    /// bd-q249-message-drops-inline-content-pacg3qeu the label walk mapped
+    /// `Link` to the empty string, so this printed ``[]`` and claimed "the
+    /// reader sees ``" — false, and its remedy `\[\]` deleted the link.
+    #[test]
+    fn lone_bracket_warning_keeps_a_link_in_the_label() {
+        let messages = messages("- [[#7380](https://example.com/7380)] Console: cleaned up.\n");
+        assert_eq!(messages.len(), 1);
+        let m = &messages[0];
+        assert!(
+            m.contains("`[[#7380](https://example.com/7380)]` has no attribute block"),
+            "the quoted source must be the author's own text, got: {m}"
+        );
+        assert!(
+            m.contains("the reader sees `#7380`."),
+            "the reader sees the link's text, not nothing, got: {m}"
+        );
+        assert!(
+            m.contains("Write `\\[[#7380](https://example.com/7380)\\]`"),
+            "the remedy must escape only the outer pair and keep the link, got: {m}"
+        );
+    }
+
+    #[test]
+    fn lone_bracket_warning_keeps_two_links_in_the_label() {
+        let messages = messages(
+            "- [[#13991](https://example.com/13991), [#11772](https://example.com/11772)] Two.\n",
+        );
+        assert_eq!(messages.len(), 1);
+        let m = &messages[0];
+        assert!(
+            m.contains(
+                "`[[#13991](https://example.com/13991), \
+                 [#11772](https://example.com/11772)]` has no attribute block"
+            ),
+            "both links must survive the quote, got: {m}"
+        );
+        assert!(
+            m.contains("the reader sees `#13991, #11772`."),
+            "the reader sees both link texts and the separator, got: {m}"
+        );
+    }
+
+    #[test]
+    fn lone_bracket_warning_keeps_emphasis_in_the_label() {
+        let messages = messages("- [*emphasised*] Emphasis inside brackets.\n");
+        assert_eq!(messages.len(), 1);
+        let m = &messages[0];
+        assert!(
+            m.contains("`[*emphasised*]` has no attribute block"),
+            "the quote must keep the emphasis markers, got: {m}"
+        );
+        assert!(
+            m.contains("the reader sees `emphasised`."),
+            "the reader sees the emphasised text without its markers, got: {m}"
+        );
+        assert!(
+            m.contains("Write `\\[*emphasised*\\]`"),
+            "the remedy must keep the emphasis, got: {m}"
+        );
+    }
+
+    /// A code span is markup too: the quoted source keeps its backticks
+    /// (so the printed remedy does not delete them) while "the reader
+    /// sees" drops them, because that is what a reader sees.
+    #[test]
+    fn lone_bracket_warning_keeps_a_code_span_in_the_label() {
+        let messages = messages("- [see `config.yml` now] Text and code.\n");
+        assert_eq!(messages.len(), 1);
+        let m = &messages[0];
+        assert!(
+            m.contains("`[see `config.yml` now]` has no attribute block"),
+            "the quoted source must keep the backticks, got: {m}"
+        );
+        assert!(
+            m.contains("the reader sees `see config.yml now`."),
+            "the reader sees the code text without backticks, got: {m}"
+        );
+        assert!(
+            m.contains("Write `\\[see `config.yml` now\\]`"),
+            "the remedy must keep the code span, got: {m}"
+        );
+    }
+
+    /// The all-text case was correct before this fix and must stay correct:
+    /// no stray escaping introduced by rendering the label through the
+    /// markdown writer.
+    #[test]
+    fn lone_bracket_warning_leaves_plain_text_labels_alone() {
+        let messages = messages("- [#1234] Bare bracket, plain text.\n");
+        assert_eq!(messages.len(), 1);
+        let m = &messages[0];
+        assert!(
+            m.contains("`[#1234]` has no attribute block"),
+            "a plain-text label must not gain escapes, got: {m}"
+        );
+        assert!(m.contains("the reader sees `#1234`."), "got: {m}");
+        assert!(
+            m.contains("Write `\\[#1234\\]`"),
+            "the remedy must escape only the brackets, got: {m}"
+        );
+    }
+
+    /// `reference_use_warning` shares the label walk, so it had the same
+    /// defect: `[*the docs*][gcc]` was reported as `[][gcc]`.
+    #[test]
+    fn reference_use_warning_keeps_markup_in_the_label() {
+        let messages = messages("See [*the docs*][gcc].\n");
+        assert_eq!(messages.len(), 1);
+        let m = &messages[0];
+        assert!(
+            m.contains("`[*the docs*][gcc]` looks like a reference-style link"),
+            "the quoted source must keep the emphasis, got: {m}"
+        );
+        assert!(
+            m.contains("Use the inline form `[*the docs*](url)`"),
+            "the suggested rewrite must keep the emphasis, got: {m}"
+        );
+    }
+
+    /// `definition_warning` shares it too.
+    #[test]
+    fn definition_warning_keeps_markup_in_the_label() {
+        let messages = messages("[*gcc*]: https://e.com\n");
+        assert_eq!(messages.len(), 1);
+        assert!(
+            messages[0].contains("`[*gcc*]:` looks like a link reference definition"),
+            "the quoted source must keep the emphasis, got: {}",
+            messages[0]
         );
     }
 

--- a/docs/errors/markdown/Q-2-49.qmd
+++ b/docs/errors/markdown/Q-2-49.qmd
@@ -66,6 +66,18 @@ Both Quarto 1 and Quarto 2 render `\[...\]` as literal brackets, and
 Quarto 2 produces no span node at all for the escaped form — so
 re-running the fix is safe.
 
+If the brackets hold formatting or a link, escape only the outer pair
+and leave the inside alone:
+
+```markdown
+- \[[#7380](https://github.com/posit-dev/positron/issues/7380)\] Console: cleaned up.
+```
+
+This shape — a bracketed issue link at the head of a release-note entry
+— is the most common source of `Q-2-49` in ported documents. The link
+still works; only the brackets around it become literal. Escaping the
+inner brackets as well would turn the link into plain text.
+
 If you meant a span, add the attribute block:
 
 ```markdown


### PR DESCRIPTION
`Q-2-49` warns that a bare `[text]` group loses its brackets, quotes the offending label back, and prints a rewrite for the author to copy. It built every one of those strings from a walk that kept `Str`, `Space` and `Code` and mapped everything else — `Link`, `Emph`, `Strong`, `Math`, `RawInline` — to the empty string.

So for the shape that dominates ported release notes:

```markdown
- [[#7380](https://example.com/7380)] Console: cleaned up.
```

the warning read:

```
`[]` has no attribute block, so it renders as an empty span and the brackets
are discarded — the reader sees ``. Write `\[\]` to keep the brackets
literal, or `[]{.class}` if a span was intended.
```

Three things wrong with that. The quoted source is not what the author wrote. The claim that the reader sees nothing is false — the reader sees `#7380`, a working link; only the brackets were dropped. And the remedy is destructive: an author who follows it and writes `\[\]` deletes the link. It was most confidently wrong on the shape where it mattered most; the Positron docs port hits this 911 times.

Underneath, one lossy string was doing two different jobs. Quoting source and building a remedy needs markdown surface form; saying what a reader sees needs the markup resolved away. Those coincide only when the label is plain text, which is why it went unnoticed — and why the case with a code span was quietly wrong too: ``[see `config.yml` now]`` was quoted as `[see config.yml now]`, so that remedy deleted the backticks.

The diagnostics now build the two strings separately. The same split fixes `Q-2-45` (`[label][ref]`), which reported `[*the docs*][gcc]` as `[][gcc]`, and `Q-2-46` (`[ref]: url`), both of which shared the walk.

```
`[[#7380](https://example.com/7380)]` has no attribute block, so it renders
as an empty span and the brackets are discarded — the reader sees `#7380`.
Write `\[[#7380](https://example.com/7380)\]` to keep the brackets literal,
or `[[#7380](https://example.com/7380)]{.class}` if a span was intended.
```

The remedy is now byte-identical to what `qmd-syntax-helper convert -r literal-brackets` writes for the same source, across every shape in the repro — the two no longer contradict each other. Applying it renders the brackets literally, leaves the link live, and re-rendering is silent.

Getting the source form exact needed one addition to pampa. `write_inlines` escapes `#` and `>` wherever they appear, because it renders whole documents and cannot know where in a line its output will land — it would have spelled the label `[\#7380](url)`. Since `#` is near-universal in these labels, `write_inlines_fragment` renders a run destined to be spliced mid-line and escapes those two only where they would really begin a line. Every other escape is identical, and `write_inlines` itself is untouched.

No change to which documents warn, or to rendered output — only to what the warnings say.

The `Q-2-49` docs page gains the link-in-label example, which is the shape most likely to be escaped wrongly by hand.

---

Strand: `bd-q249-message-drops-inline-content-pacg3qeu`
Repro: `q2-positron-docs/llms-info/repros/q249-message-drops-inline-content/`
Follow-up filed: `bd-0jtai5dh` — five near-copies of pandoc `stringify` with subtly different semantics, found while choosing a renderer here.
