### PR TITLE
Keep the open preview editor mounted across offset-shifting remote CRDT changes

### DIFF
--- a/claude-notes/plans/2026-08-26-gh420-editor-focus-crdt.md
+++ b/claude-notes/plans/2026-08-26-gh420-editor-focus-crdt.md
@@ -1,0 +1,164 @@
+# GH #420 — rich-text editor loses focus on incoming CRDT changes
+
+**Strand:** bd-84ljmbaf
+**Issue:** https://github.com/quarto-dev/q2/issues/420
+**Status:** diagnosed + fix validated by prototype (2026-08-26); implementation pending (TDD)
+
+## Overview
+
+In `q2 preview --allow-edit` (and hub-client, which uses the same
+`preview-renderer` `PreviewRoot`), clicking into the rich-text editor and then
+receiving an unrelated remote CRDT change disturbs the editor. Diagnosed live
+against `q2 preview` with chrome-devtools (fixture: 3-paragraph project;
+remote changes simulated by editing the file on disk, which the server syncs
+into the CRDT).
+
+### Observed behavior matrix (current main, browser-verified)
+
+| Remote change | Editor fate | Focus | Caret | Uncommitted draft |
+|---|---|---|---|---|
+| After active block (no offset shift) | survives, same DOM node | kept | kept | kept |
+| Before active block (offset shift, same block count) | **unmount + remount** | ~30ms blip (focusout→focusin) | **reset to end** | **rich: silently DISCARDED**; plain textarea: kept |
+| Whole block inserted/deleted above | unmount + remount (index keys shift) | blip | reset | rich: discarded |
+| Active block itself edited remotely | DROP: editor **closes** | moves to nearby block | — | discarded (by design, commit-on-drop guard) |
+
+The reporter's "loses focus on any document edit" corresponds to rows 2–3:
+*any* length-changing edit anywhere before the active block shifts its byte
+offsets. The transient blip also drops keystrokes typed during the window, and
+the rich surface loses all uncommitted edits — strictly worse than focus loss.
+
+## Root cause
+
+1. An incoming change bumps `contentTick` → WASM re-render → new
+   `astJson`/`renderedContent` props reach `PreviewRoot`.
+2. That render still carries the **stale** `editTarget` (old `anchorR0`). The
+   dispatcher's edit-surface predicate
+   (`ctx.editTarget.anchorR0 === resolved.sourceEntry.r[0]`,
+   `dispatchers.tsx` ~line 134) fails for every block when offsets shifted →
+   the block renders as normal content → `RichTextEditor` **unmounts** in that
+   commit (tiptap instance destroyed).
+3. The P2.3b self-heal `useLayoutEffect` (`PreviewRoot.tsx` ~line 388) then
+   runs `findReanchorCandidate` (content-first, symmetric — robust), calls
+   `setEditTargetRaw(reanchored)` → a second render **mounts a fresh editor**.
+4. The fresh `RichTextEditor` seeds from the AST (`astToDoc`), not from the
+   preserved `editDraftRef`, and its mount effect focuses `'end'` — so focus
+   is programmatically restored but caret position, selection, undo history,
+   and uncommitted doc content are gone. (`EditTextarea` reseeds from
+   `editDraftRef`, which the self-heal deliberately preserves — that's why
+   plain mode only blips. The rich surface never got the equivalent.)
+
+The re-anchor *logic* is fine; the *timing* is the bug: it runs one render too
+late, after React has already torn the editor down.
+
+## Fix (validated by prototype)
+
+Derive the re-anchored edit target **during render**, before children render,
+so the first post-change render already matches the new offsets and React
+reconciles the mounted editor in place (same position, same type, index key
+unchanged for same-block-count edits):
+
+```tsx
+// in PreviewRoot render body, after the pool useMemo:
+const effectiveEditTarget = useMemo(() => {
+    if (editTarget === null) return null;
+    const cand = findReanchorCandidate(
+        pool, props.renderedContent ?? '',
+        editTarget.anchorR0, editTarget.anchorSlice);
+    if (cand && (cand.r0 !== editTarget.anchorR0 || cand.r1 !== editTarget.anchorR1)) {
+        return { ...editTarget, anchorR0: cand.r0, anchorR1: cand.r1 };
+    }
+    return editTarget;
+}, [editTarget, pool, props.renderedContent]);
+editTargetRef.current = effectiveEditTarget;  // guards/commits agree with render
+// ...and pass `editTarget: effectiveEditTarget` into PreviewContext.
+```
+
+The self-heal layout effect stays: it persists the re-anchor into state (KEEP,
+now a same-values no-op render) and still owns the DROP path (content
+mismatch → close + drop-focus). DROP behavior is unchanged.
+
+Full prototype diff: `gh420-prototype.patch` (43 lines, 2 hunks, session
+scratchpad — reproduce from this plan if lost; the memo above is the whole
+change plus `editTarget: effectiveEditTarget` in the context value).
+
+**Prototype verification (2026-08-26):**
+- Invocation: `q2 preview --allow-edit --preview-dir q2-preview-spa/dist` on a
+  3-paragraph fixture; editor opened on paragraph 1 with ` PROTO-DRAFT` typed;
+  title in front matter edited on disk (offset shrink — the harder direction).
+- Observed: same ProseMirror DOM node (instance marker survived), zero
+  focusin/focusout events, caret offset unchanged (58), typed draft intact,
+  remote change rendered. Output inspected via devtools script evaluation.
+- `npm test` (578 passed) and `npm run test:integration` (628 passed) in
+  `ts-packages/preview-renderer` — green with the prototype applied.
+
+## Work items (TDD — test first)
+
+- [x] Integration test (preview-renderer, jsdom):
+      `editor-survives-remote-shift.integration.test.tsx` — real PreviewRoot,
+      real pointer-event activation. Rich surface: element identity (`toBe`)
+      + `document.activeElement` retention across forward AND backward
+      offset shifts, plus a passes-before-the-fix baseline (edit after the
+      block) proving the harness. Textarea surface: identity + dirty draft +
+      focus. Verified FAILING first on the unfixed tree (3 failed / 1
+      baseline passed, each on the remount assertions), then passing after
+      the fix. (jsdom can't synthesize ProseMirror typing, so the rich
+      dirty-doc guarantee is carried by element identity — a remount cannot
+      preserve the element.)
+- [x] Same-shape test for the textarea surface — included above.
+- [x] Implement the derived `effectiveEditTarget` (PreviewRoot.tsx, after the
+      pool useMemo; context gets the derived value; `editTargetRef` re-pointed
+      at it).
+- [x] Audit other `editTarget.anchorR0` consumers: dispatchers.tsx:135/402/
+      464/474 and useBlockEditHover.tsx:232 read `ctx.editTarget` (context —
+      derived); every PreviewRoot-internal callback reads `editTargetRef`
+      (re-pointed at derived). The only state-value reader left is the reland
+      fade effect, which tests null-ness only (identical between state and
+      derived). No stale-vs-derived window remains.
+- [x] Full gates: preview-renderer unit (578) + integration (632, incl. the 4
+      new) suites green; `cargo xtask verify` full run + fresh browser e2e —
+      see verification record below.
+
+## Final verification record (2026-08-26, worktree bd-84ljmbaf)
+
+- **TDD**: `editor-survives-remote-shift.integration.test.tsx` failed on the
+  unfixed tree (3 failed: rich forward-shift, rich backward-shift, textarea —
+  each on element identity/focus; the after-block baseline passed), then all 4
+  passed after the fix.
+- **Suites**: preview-renderer `npm test` 578 passed, `npm run
+  test:integration` 632 passed. Full `cargo xtask verify` (all 14 steps,
+  including hub-client `build:all` + `test:ci`): exit 0.
+- **End-to-end** (real binary, output inspected): worktree
+  `cargo run --bin q2 -- preview --allow-edit --no-browser --port 7481
+  --preview-dir q2-preview-spa/dist <fixture>`; opened the rich editor on
+  paragraph 1 in Chrome, typed ` E2E-DRAFT`; applied TWO offset-shifting
+  remote edits on disk (front-matter title grow, then shrink). Observed via
+  devtools scripting: same ProseMirror DOM instance (marker survived both),
+  zero focusin/focusout events, caret unchanged (offset 49), draft intact,
+  both remote changes rendered. Then committed with Cmd-Enter: the draft
+  landed on the correct paragraph on disk with the remote title edit
+  preserved — the commit destination is correct after two re-anchors.
+
+## Follow-ups (separate strands, discovered-from bd-84ljmbaf)
+
+1. **Block insert/delete above the active block still remounts** — the
+   framework keys blocks by index (`key={i}` in `framework/dispatch.tsx`), so
+   the active block's key shifts. Options: stable keys (hard — needs
+   content-stable identity), or make an unavoidable rich-editor remount
+   draft-preserving: keep the tiptap doc JSON + selection in a session ref
+   (updated in `onUpdate`), reseed from it on remount instead of `astToDoc`,
+   and restore selection — mirroring what `editDraftRef` already does for the
+   textarea.
+2. **Remote edit to the actively-edited block DROPs the editor** (focus loss
+   the reporter flagged as "extremely cool" follow-up): merge remote content
+   into the open editor instead of closing. Requires a 3-way story
+   (base slice / local doc / remote slice); today's commit-on-drop guard is
+   the safe default.
+
+## Repro recipe (for regression checking)
+
+1. Fixture: `_quarto.yml` + `index.qmd` with title front matter and 3 paragraphs.
+2. `cargo run --bin q2 -- preview --allow-edit --no-browser --port 7480 <fixture>`
+3. Open in Chrome; click into paragraph 1 (rich editor opens, focused). Type.
+4. `sed -i '' 's/title: .*/title: something longer/' index.qmd` (offset shift).
+5. Bug: editor remounts — focus blip, caret to end, typed text gone.
+   Fixed: same node, caret and text intact.

--- a/ts-packages/preview-renderer/src/q2-preview/PreviewRoot.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/PreviewRoot.tsx
@@ -318,6 +318,8 @@ export function PreviewRoot(props: PreviewRootProps) {
     // ---------------------------------------------------------------------------
 
     // Keep editTarget in a ref so the layout effect reads it without depending on it.
+    // Re-pointed at `effectiveEditTarget` further down the render body (after the
+    // pool useMemo), so every post-render consumer sees render-consistent offsets.
     const editTargetRef = useRef<typeof editTarget>(editTarget);
     editTargetRef.current = editTarget;
 
@@ -1452,6 +1454,37 @@ export function PreviewRoot(props: PreviewRootProps) {
     renderedContentRef.current = props.renderedContent ?? '';
     nestedEditBuffersRef.current = props.nestedEditBuffers;
 
+    // bd-84ljmbaf (GH #420): re-anchor the edit target DURING render, not only in
+    // the self-heal layout effect. An external re-render (collaborator CRDT
+    // change) that shifts the active block's byte offsets would otherwise render
+    // one frame against the STALE anchorR0 — no block matches, the mounted
+    // editor unmounts, and the self-heal's re-anchor then mounts a FRESH one:
+    // a focus blip, caret reset, and (rich surface) loss of the uncommitted
+    // tiptap doc. Deriving the shifted anchors here makes the first post-change
+    // render match, so React reconciles the open editor in place. The layout
+    // effect still persists the re-anchor into state (a same-values follow-up
+    // render) and still owns the DROP path — findReanchorCandidate returns null
+    // exactly when it would there, leaving the target untouched for the effect
+    // to close.
+    const effectiveEditTarget = useMemo(() => {
+        if (editTarget === null) return null;
+        const cand = findReanchorCandidate(
+            pool,
+            props.renderedContent ?? '',
+            editTarget.anchorR0,
+            editTarget.anchorSlice,
+        );
+        if (cand && (cand.r0 !== editTarget.anchorR0 || cand.r1 !== editTarget.anchorR1)) {
+            return { ...editTarget, anchorR0: cand.r0, anchorR1: cand.r1 };
+        }
+        return editTarget;
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [editTarget, pool, props.renderedContent]);
+    // Re-point the shared ref at the derived target so post-render consumers
+    // (commit destinations, the stale-unmount guards, the self-heal effect)
+    // agree with the offsets the dispatcher just rendered against.
+    editTargetRef.current = effectiveEditTarget;
+
     const astProps = parsed
         ? { ast: parsed }
         : { astJson: props.astJson };
@@ -1529,7 +1562,7 @@ export function PreviewRoot(props: PreviewRootProps) {
                 commitTextEdit,
                 commitSubtreeEdit,
                 content: props.renderedContent,
-                editTarget,
+                editTarget: effectiveEditTarget,
                 setEditTarget,
                 editDraftRef,
                 pendingOpenSelectionRef,

--- a/ts-packages/preview-renderer/src/q2-preview/editor-survives-remote-shift.integration.test.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/editor-survives-remote-shift.integration.test.tsx
@@ -1,0 +1,268 @@
+/**
+ * bd-84ljmbaf / GH #420 — the open editor must SURVIVE (not remount across)
+ * an external re-render that shifts the active block's byte offsets.
+ *
+ * A collaborator's CRDT change anywhere BEFORE the active block changes the
+ * block's `r[0]`. Before the fix, the first render after such a change still
+ * carried the stale `editTarget.anchorR0`, so the dispatcher's anchor match
+ * failed and the editor unmounted for one render; the P2.3b self-heal layout
+ * effect then re-anchored and a SECOND render mounted a fresh editor. The
+ * existing p2-3b-real KEEP tests assert "editor stays open / draft preserved"
+ * — which a remount satisfies (the textarea reseeds from editDraftRef) — so
+ * they cannot catch the remount itself. Its user-visible cost: a focus blip
+ * (keystrokes dropped), caret reset to end, and for the RICH surface loss of
+ * the uncommitted tiptap doc (it reseeds from the AST, not the draft).
+ *
+ * These tests pin the stronger contract: across an offset-shifting external
+ * re-render the editor's DOM element is IDENTICAL (`toBe`), and focus never
+ * leaves it. Element identity is the precise observable — a remount cannot
+ * preserve it — and it is what guarantees caret/selection/undo/doc survival.
+ *
+ * Fix under test: PreviewRoot derives the re-anchored edit target DURING
+ * render (`effectiveEditTarget`), so the first post-change render already
+ * matches the new offsets. See
+ * claude-notes/plans/2026-08-26-gh420-editor-focus-crdt.md.
+ *
+ * Out of scope (follow-ups filed from bd-84ljmbaf): whole-block insert/delete
+ * above the active block (index-keyed `key={i}` still remounts), and remote
+ * edits to the active block itself (self-heal DROP closes the editor).
+ *
+ * Harness mirrors p2-3b-real.integration.test.tsx (real PreviewRoot, real
+ * pointer-event activation) + plain-list-item-richtext.integration.test.tsx
+ * (rich surface via `richText: true`).
+ */
+
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup, act, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { PreviewRoot } from './PreviewRoot';
+import type { PreviewRootProps } from './PreviewRoot';
+
+afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+});
+
+/* ─── PointerEvent helper (verbatim from p2-3b-real) ────────────────────────── */
+function ptrEvent(
+    type: string,
+    opts: PointerEventInit & { clientX?: number; clientY?: number } = {},
+): Event {
+    const PE = (window as any).PointerEvent ?? Event;
+    const evt = new PE(type, { bubbles: true, cancelable: true, ...opts });
+    for (const [key, val] of Object.entries({
+        ...(opts.pointerType !== undefined ? { pointerType: opts.pointerType } : {}),
+        ...(opts.clientX !== undefined ? { clientX: opts.clientX } : {}),
+        ...(opts.clientY !== undefined ? { clientY: opts.clientY } : {}),
+    } as Record<string, unknown>)) {
+        Object.defineProperty(evt, key, { value: val, configurable: true });
+    }
+    return evt;
+}
+
+/* ─── Pool / content helpers (shape shared with p2-3b-real) ─────────────────── */
+
+type PoolEntry = { t: 0; r: [number, number]; d: 0 };
+type Pool = readonly PoolEntry[];
+
+function makeAstJson(pool: Pool, content: string): string {
+    const blocks = pool.map((entry, i) => {
+        const raw = content.slice(entry.r[0], entry.r[1]);
+        const text = raw.replace(/\n/g, '').trim() || `tile${i}`;
+        return { t: 'Para', c: [{ t: 'Str', c: text }], s: i };
+    });
+    return JSON.stringify({
+        'pandoc-api-version': [1, 23, 0],
+        meta: {},
+        blocks,
+        astContext: { p: pool },
+    });
+}
+
+function buildProps(pool: Pool, content: string, richText: boolean): PreviewRootProps {
+    const astJson = makeAstJson(pool, content);
+    return {
+        astJson,
+        untransformedAstJson: astJson,
+        renderedContent: content,
+        currentFilePath: '/test.qmd',
+        assetManifest: {},
+        setAst: vi.fn(),
+        richText,
+        onNavigateToDocument: () => {},
+    };
+}
+
+function mockTileRects(container: HTMLElement) {
+    container.querySelectorAll<HTMLElement>('[data-block-pool-id]').forEach((tile) => {
+        const pid = Number(tile.getAttribute('data-block-pool-id'));
+        vi.spyOn(tile, 'getBoundingClientRect').mockReturnValue({
+            left: 0, top: pid * 60, right: 200, bottom: pid * 60 + 40,
+            width: 200, height: 40, x: 0, y: pid * 60, toJSON: () => ({}),
+        } as DOMRect);
+    });
+}
+
+async function activateTile(container: HTMLElement, poolId: number) {
+    const tile = container.querySelector<HTMLElement>(`[data-block-pool-id="${poolId}"]`);
+    expect(tile, `tile with pool-id ${poolId} should be in DOM`).not.toBeNull();
+    await act(async () => {
+        fireEvent(tile!, ptrEvent('pointerdown', { pointerType: 'mouse' }));
+        fireEvent(tile!, ptrEvent('pointerup', { pointerType: 'mouse' }));
+    });
+}
+
+/** Flush one animation frame (RichTextEditor places its opening caret in rAF). */
+async function flushRaf() {
+    await act(async () => {
+        await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+    });
+}
+
+/* ─── Fixtures ──────────────────────────────────────────────────────────────── */
+
+// Base doc, three paragraphs. The edit target is para1 (pool[1]).
+//   "para0\npara1\npara2\n\n"
+const BASE_CONTENT = 'para0\npara1\npara2\n\n';
+const BASE_POOL: Pool = [
+    { t: 0, r: [0, 6], d: 0 },   // "para0\n"
+    { t: 0, r: [6, 12], d: 0 },  // "para1\n"  ← active editor
+    { t: 0, r: [12, 19], d: 0 }, // "para2\n\n"
+];
+
+// Collaborator GROWS para0 ("para0" → "para0-grown-longer"): every later
+// block shifts FORWARD (+13 bytes). para1's content is unchanged.
+const GROWN_CONTENT = 'para0-grown-longer\npara1\npara2\n\n';
+const GROWN_POOL: Pool = [
+    { t: 0, r: [0, 19], d: 0 },  // "para0-grown-longer\n"
+    { t: 0, r: [19, 25], d: 0 }, // "para1\n"  (shifted +13)
+    { t: 0, r: [25, 32], d: 0 }, // "para2\n\n"
+];
+
+// Collaborator SHRINKS para0 ("para0" → "p0"): every later block shifts
+// BACK (−3 bytes) — the direction a strictly at/after re-anchor would miss.
+const SHRUNK_CONTENT = 'p0\npara1\npara2\n\n';
+const SHRUNK_POOL: Pool = [
+    { t: 0, r: [0, 3], d: 0 },  // "p0\n"
+    { t: 0, r: [3, 9], d: 0 },  // "para1\n"  (shifted −3)
+    { t: 0, r: [9, 16], d: 0 }, // "para2\n\n"
+];
+
+// Collaborator edits para2 (AFTER the active block): para1's offsets are
+// untouched. This always worked; it validates the harness baseline so the
+// shift tests fail for the right reason.
+const AFTER_CONTENT = 'para0\npara1\npara2-edited\n\n';
+const AFTER_POOL: Pool = [
+    { t: 0, r: [0, 6], d: 0 },
+    { t: 0, r: [6, 12], d: 0 },
+    { t: 0, r: [12, 26], d: 0 }, // "para2-edited\n\n"
+];
+
+const pmEl = (c: HTMLElement) => c.querySelector<HTMLElement>('.tiptap.ProseMirror');
+
+/* ─── Rich surface ──────────────────────────────────────────────────────────── */
+
+describe('bd-84ljmbaf — rich editor survives offset-shifting external re-render', () => {
+    async function openRichOnPara1(pool: Pool, content: string) {
+        const props = buildProps(pool, content, true);
+        const view = render(<PreviewRoot {...props} />);
+        await act(async () => {});
+        mockTileRects(view.container);
+        await activateTile(view.container, 1);
+        await flushRaf(); // opening caret placement (focus('end') fallback)
+        const pm = pmEl(view.container);
+        expect(pm, 'rich editor should open on para1').not.toBeNull();
+        return { view, pm: pm! };
+    }
+
+    function externalRerender(
+        view: ReturnType<typeof render>,
+        pool: Pool,
+        content: string,
+    ) {
+        const next = buildProps(pool, content, true);
+        act(() => {
+            view.rerender(<PreviewRoot {...next} />);
+        });
+    }
+
+    it('baseline: edit AFTER the active block — same element, focus kept', async () => {
+        const { view, pm } = await openRichOnPara1(BASE_POOL, BASE_CONTENT);
+        pm.focus();
+        expect(document.activeElement).toBe(pm);
+
+        externalRerender(view, AFTER_POOL, AFTER_CONTENT);
+
+        const pmAfter = pmEl(view.container);
+        expect(pmAfter).toBe(pm);
+        expect(document.activeElement).toBe(pm);
+    });
+
+    it('forward shift (collaborator grows an earlier block): SAME element, focus kept', async () => {
+        const { view, pm } = await openRichOnPara1(BASE_POOL, BASE_CONTENT);
+        pm.focus();
+        expect(document.activeElement).toBe(pm);
+
+        externalRerender(view, GROWN_POOL, GROWN_CONTENT);
+
+        const pmAfter = pmEl(view.container);
+        expect(pmAfter, 'rich editor should still be open').not.toBeNull();
+        // The identity assertion is the point: a remount (unmount + fresh
+        // mount) can re-open an editor but never return the same element.
+        expect(pmAfter).toBe(pm);
+        // Focus must never have left the editor (the GH #420 symptom).
+        expect(document.activeElement).toBe(pm);
+    });
+
+    it('backward shift (collaborator shrinks an earlier block): SAME element, focus kept', async () => {
+        const { view, pm } = await openRichOnPara1(BASE_POOL, BASE_CONTENT);
+        pm.focus();
+        expect(document.activeElement).toBe(pm);
+
+        externalRerender(view, SHRUNK_POOL, SHRUNK_CONTENT);
+
+        const pmAfter = pmEl(view.container);
+        expect(pmAfter, 'rich editor should still be open').not.toBeNull();
+        expect(pmAfter).toBe(pm);
+        expect(document.activeElement).toBe(pm);
+    });
+});
+
+/* ─── Plain textarea surface ────────────────────────────────────────────────── */
+
+describe('bd-84ljmbaf — textarea survives offset-shifting external re-render', () => {
+    async function openTextareaOnPara1() {
+        const props = buildProps(BASE_POOL, BASE_CONTENT, false);
+        const view = render(<PreviewRoot {...props} />);
+        await act(async () => {});
+        mockTileRects(view.container);
+        await activateTile(view.container, 1);
+        const ta = view.container.querySelector<HTMLTextAreaElement>('textarea');
+        expect(ta, 'textarea should open on para1').not.toBeNull();
+        return { view, ta: ta! };
+    }
+
+    it('forward shift: SAME element, dirty draft and focus kept', async () => {
+        const { view, ta } = await openTextareaOnPara1();
+        ta.focus();
+        // Dirty the draft — trivially possible on the textarea surface.
+        await act(async () => {
+            fireEvent.change(ta, { target: { value: 'para1 EDITED-LOCALLY' } });
+        });
+        expect(document.activeElement).toBe(ta);
+
+        const next = buildProps(GROWN_POOL, GROWN_CONTENT, false);
+        act(() => {
+            view.rerender(<PreviewRoot {...next} />);
+        });
+
+        const taAfter = view.container.querySelector<HTMLTextAreaElement>('textarea');
+        expect(taAfter, 'textarea should still be open').not.toBeNull();
+        expect(taAfter).toBe(ta);
+        expect(taAfter!.value).toBe('para1 EDITED-LOCALLY');
+        expect(document.activeElement).toBe(ta);
+    });
+});


### PR DESCRIPTION
Fixes #420 (braid bd-84ljmbaf).

## Problem

With the rich-text editor open in `q2 preview --allow-edit` (or hub-client), any remote CRDT change that shifts the active block's byte offsets — i.e. any length-changing edit anywhere earlier in the document — disturbed the editor:

- a focusout/focusin blip (~30 ms) that drops keystrokes typed in the window,
- caret reset to end-of-block, undo history lost,
- on the rich surface, **silent loss of the uncommitted draft** (it reseeds from the AST; the textarea reseeds from the preserved `editDraftRef` and only blips).

## Root cause

The first render after an external re-render still carried the **stale** `editTarget.anchorR0`. The dispatcher's anchor match (`editTarget.anchorR0 === resolved.sourceEntry.r[0]`) then failed for every block, unmounting the editor for one frame; the P2.3b self-heal `useLayoutEffect` re-anchored one render too late and mounted a fresh editor. The re-anchor *logic* (`findReanchorCandidate`, content-first and symmetric) was fine — only its timing was wrong.

## Fix

`PreviewRoot` now derives the re-anchored target **during render** (`effectiveEditTarget`, a `useMemo` running `findReanchorCandidate` over the freshly-parsed pool/content) and feeds it to the context and `editTargetRef`. The first post-change render already matches the shifted offsets, so React reconciles the mounted editor in place — same DOM node, focus never leaves, caret/selection/doc untouched. The self-heal effect still persists the re-anchor into state and still owns the DROP path (a remote edit to the active block itself closes the editor, unchanged).

## Testing

- New `editor-survives-remote-shift.integration.test.tsx` (real `PreviewRoot`, real pointer-event activation) pins **element identity** (`toBe`) and `document.activeElement` retention across forward and backward shifts, for the rich surface and the textarea (the textarea test also pins the dirty draft). Written first per TDD: 3 tests failed on the unfixed tree exactly on the remount assertions; all 4 pass with the fix.
- preview-renderer suites: 578 unit + 632 integration passing. Full `cargo xtask verify` (including hub-client `build:all` + `test:ci`): green.
- End-to-end through the real binary: `q2 preview --allow-edit` in Chrome — typed a draft into the rich editor, applied two offset-shifting edits to the file on disk (title grow, then shrink); the ProseMirror DOM instance survived both, zero focus events, caret and draft intact, and a subsequent Cmd-Enter commit landed on the correct paragraph with the remote edits preserved.

## Out of scope (follow-up strands filed)

- bd-vrdglm6m — a whole-block insert/delete *above* the active block still remounts (index-based `key={i}` shifts).
- bd-yu5uj8am — merge remote content into the open editor instead of the self-heal DROP when the *active* block is edited remotely.

Plan/diagnosis: `claude-notes/plans/2026-08-26-gh420-editor-focus-crdt.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)