### PR TITLE
Bump workspace version to 0.28.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "comrak-to-pandoc"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "comrak",
  "hashlink",
@@ -4806,7 +4806,7 @@ dependencies = [
 
 [[package]]
 name = "quarto"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4854,7 +4854,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-analysis"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "insta",
  "quarto-error-reporting",
@@ -4880,7 +4880,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-brand"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "pathdiff",
  "quarto-util",
@@ -4892,7 +4892,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-citeproc"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "glob",
  "hashlink",
@@ -4926,7 +4926,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-core"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4984,7 +4984,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-csl"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "insta",
  "quarto-error-reporting",
@@ -5012,7 +5012,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-error-catalog"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "once_cell",
  "quarto-error-reporting",
@@ -5048,7 +5048,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-highlight"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "hashlink",
  "insta",
@@ -5077,7 +5077,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-highlight-encoding"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -5085,7 +5085,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-hub"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "automerge",
@@ -5129,7 +5129,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-hub-provider"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "automerge",
  "ciborium",
@@ -5155,7 +5155,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-lsp"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "insta",
@@ -5171,7 +5171,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-lsp-core"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "insta",
  "pampa",
@@ -5194,7 +5194,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-mcp-launcher"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -5210,7 +5210,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-navigation"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "quarto-config",
  "quarto-pandoc-types",
@@ -5221,7 +5221,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-p2p"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "axum",
  "futures",
@@ -5264,7 +5264,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-preview"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "automerge",
@@ -5302,7 +5302,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-project-create"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "quarto-doctemplate",
  "serde",
@@ -5313,7 +5313,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-publish"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5338,7 +5338,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-sass"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "grass",
  "include_dir",
@@ -5361,7 +5361,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-source-fetch"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "flate2",
  "tar",
@@ -5384,7 +5384,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-system-runtime"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5402,7 +5402,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-test"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "quarto-core",
@@ -5419,7 +5419,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-trace"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "flate2",
  "serde",
@@ -5430,7 +5430,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-trace-server"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -5457,7 +5457,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-util"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "dirs",
  "serde",
@@ -5466,7 +5466,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-xml"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "insta",
  "quarto-error-reporting",
@@ -5704,7 +5704,7 @@ dependencies = [
 
 [[package]]
 name = "reconcile-viewer"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "clap",
  "hashlink",
@@ -6711,7 +6711,7 @@ checksum = "ea06cc588e43c632923a55450401b8f25e628131571d4e1baea1bdfdb2b5ed06"
 
 [[package]]
 name = "spa-manifest"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -7960,7 +7960,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-printf-fmt"
-version = "0.27.0"
+version = "0.28.0"
 
 [[package]]
 name = "wasm-streams"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.27.0"
+version = "0.28.0"
 authors = ["Posit Software, PBC"]
 homepage = "https://github.com/posit-dev/quarto-markdown-syntax"
 keywords = ["parser"]

--- a/crates/wasm-quarto-hub-client/Cargo.lock
+++ b/crates/wasm-quarto-hub-client/Cargo.lock
@@ -377,7 +377,7 @@ dependencies = [
 
 [[package]]
 name = "comrak-to-pandoc"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "comrak",
  "hashlink",
@@ -2075,7 +2075,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-analysis"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "quarto-error-reporting",
  "quarto-pandoc-types",
@@ -2097,7 +2097,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-brand"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "pathdiff",
  "quarto-util",
@@ -2108,7 +2108,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-citeproc"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "glob",
  "hashlink",
@@ -2139,7 +2139,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-core"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2191,7 +2191,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-csl"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "quarto-error-reporting",
  "quarto-source-map",
@@ -2242,7 +2242,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-highlight"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "once_cell",
  "quarto-highlight-encoding",
@@ -2268,7 +2268,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-highlight-encoding"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2276,7 +2276,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-lsp-core"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "pampa",
  "pollster",
@@ -2297,7 +2297,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-navigation"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "quarto-config",
  "quarto-pandoc-types",
@@ -2333,7 +2333,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-project-create"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "quarto-doctemplate",
  "serde",
@@ -2343,7 +2343,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-sass"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "include_dir",
  "once_cell",
@@ -2374,7 +2374,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-system-runtime"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -2391,7 +2391,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-trace"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "flate2",
  "serde",
@@ -2409,7 +2409,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-util"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "dirs",
  "serde",
@@ -2418,7 +2418,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-xml"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "quarto-error-reporting",
  "quarto-source-map",
@@ -4025,7 +4025,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-printf-fmt"
-version = "0.27.0"
+version = "0.28.0"
 
 [[package]]
 name = "wasm-quarto-hub-client"


### PR DESCRIPTION
Version bump for the v0.28.0 release, per `claude-notes/instructions/release-runbook.md`:

- `[workspace.package].version` → `0.28.0`
- `cargo update --workspace` (root lockfile)
- `cargo update --manifest-path crates/wasm-quarto-hub-client/Cargo.toml --workspace` (second lockfile)

Verified locally: no surprise dependency bumps in either lockfile diff; `cargo build --bin q2 --locked` succeeds and `./target/debug/q2 --version` prints `q2 (quarto 2) 0.28.0`.

Once merged, `main` HEAD will be tagged `v0.28.0` to fire the Release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)