### PR TITLE
hub-client: UI/UX Phase 5 review adjustments (fullscreen fix, sidebar toggle, smallest header)

### DIFF
--- a/claude-notes/plans/2026-08-25-hub-client-uiux-modernization.md
+++ b/claude-notes/plans/2026-08-25-hub-client-uiux-modernization.md
@@ -605,7 +605,13 @@ commit, and can be individually approved, held, or reverted.
       first). (2) The drawer toggle was drawer-only and undiscoverable —
       now permanent header chrome that hides/shows the static sidebar
       above 900px too, in muted grey with a sidebar-tinted active state
-      (38922590d).
+      (38922590d). (3) Round 2 (e3a86d053): view-mode switcher hidden at
+      ≤700px (the Preview pill covers switching), Share + Preview back
+      inline (kebab menu retired), the toggle is a grey chip in the
+      sidebar's own tint, and switch-project is teal (the one
+      exit-to-another-view action). **Note:** PR #622 merged before these
+      adjustments; they ride the follow-up branch
+      `hub-client-uiux-phase5-review`.
 - [x] Off-palette token values (00e577087): outline icons + replay me-chip
       re-mapped onto Posit ramps — one hue family per meaning (header blue,
       code teal, function orange), each theme picking the ramp step that

--- a/claude-notes/plans/2026-08-25-hub-client-uiux-modernization.md
+++ b/claude-notes/plans/2026-08-25-hub-client-uiux-modernization.md
@@ -599,6 +599,13 @@ commit, and can be individually approved, held, or reverted.
       tooltip capture needed a page-region clip — Playwright element
       screenshots of the portaled position:fixed bubble capture it
       unstyled (tooling artifact, computed styles verified correct).
+      **Review adjustments landed:** (1) fullscreen preview went blank at
+      ≤700px — the split-collapse rule hid the fullscreen pane; fixed by
+      excluding `.fullscreen` (60b156d43, regression spec watched red
+      first). (2) The drawer toggle was drawer-only and undiscoverable —
+      now permanent header chrome that hides/shows the static sidebar
+      above 900px too, in muted grey with a sidebar-tinted active state
+      (38922590d).
 - [x] Off-palette token values (00e577087): outline icons + replay me-chip
       re-mapped onto Posit ramps — one hue family per meaning (header blue,
       code teal, function orange), each theme picking the ramp step that

--- a/hub-client/changelog.md
+++ b/hub-client/changelog.md
@@ -25,6 +25,7 @@ WASM rebuild is needed for a changelog-only edit.
 
 ### 2026-08-27
 
+- [`38922590`](https://github.com/quarto-dev/q2/commits/38922590): A sidebar toggle button now sits at the left of the editor header at every window size — click it to hide or show the sidebar (in narrow windows it opens the sidebar as an overlay drawer). The button is muted grey so it reads as sidebar chrome, not a title-bar action.
 - [`c5c5f23d`](https://github.com/quarto-dev/q2/commits/c5c5f23d): Corners are now consistent across the app — buttons, menus, cards, and dialogs share one radius scale (buttons and cards are slightly rounder).
 - [`b95d5e18`](https://github.com/quarto-dev/q2/commits/b95d5e18): Narrow windows now get a designed layout: the sidebar becomes an overlay drawer (open it from the new header button, dismiss with Escape or by clicking outside), split view collapses to the editor when the window is too narrow for two panes, and the header's Share and Preview actions move into a "More actions" menu.
 - [`0c751c75`](https://github.com/quarto-dev/q2/commits/0c751c75): The projects home now shows a skeleton of the page while projects load (instead of a spinner), and empty states ("No projects yet", "No files yet") gained a guiding icon.

--- a/hub-client/changelog.md
+++ b/hub-client/changelog.md
@@ -25,6 +25,7 @@ WASM rebuild is needed for a changelog-only edit.
 
 ### 2026-08-27
 
+- [`e3a86d05`](https://github.com/quarto-dev/q2/commits/e3a86d05): Small-window header tidied up: at the smallest widths the view-mode switcher is hidden (the Preview button covers switching) and Share + Preview stay as plain buttons instead of a "..." menu. The sidebar toggle is now a grey chip in the sidebar's own colour, clearly separate from the title-bar buttons, and the switch-project icon is teal to mark it as the way out to your projects.
 - [`38922590`](https://github.com/quarto-dev/q2/commits/38922590): A sidebar toggle button now sits at the left of the editor header at every window size — click it to hide or show the sidebar (in narrow windows it opens the sidebar as an overlay drawer). The button is muted grey so it reads as sidebar chrome, not a title-bar action.
 - [`c5c5f23d`](https://github.com/quarto-dev/q2/commits/c5c5f23d): Corners are now consistent across the app — buttons, menus, cards, and dialogs share one radius scale (buttons and cards are slightly rounder).
 - [`b95d5e18`](https://github.com/quarto-dev/q2/commits/b95d5e18): Narrow windows now get a designed layout: the sidebar becomes an overlay drawer (open it from the new header button, dismiss with Escape or by clicking outside), split view collapses to the editor when the window is too narrow for two panes, and the header's Share and Preview actions move into a "More actions" menu.

--- a/hub-client/e2e/viewport-matrix.visual.spec.ts
+++ b/hub-client/e2e/viewport-matrix.visual.spec.ts
@@ -429,3 +429,14 @@ test('header actions inline at 1280px (counter-check)', async ({ page }) => {
   await expect(page.locator('.minimal-header .header-share-btn')).toBeVisible();
   await expect(page.getByRole('button', { name: 'More actions' })).toHaveCount(0);
 });
+
+/* ---- fullscreen preview at narrow widths (regression: the ≤700px
+   split-collapse rule must not hide the fullscreen preview pane) ---- */
+
+for (const width of [700, 320] as const) {
+  test(`fullscreen preview shows the preview pane at ${width}px`, async ({ page }) => {
+    await bootAt(page, width, 'editor-shell-fullscreen', '.editor-main');
+    await expect(page.locator('.preview-pane.fullscreen')).toBeVisible();
+    await expectNoHorizontalScroll(page, '.editor-main');
+  });
+}

--- a/hub-client/e2e/viewport-matrix.visual.spec.ts
+++ b/hub-client/e2e/viewport-matrix.visual.spec.ts
@@ -222,22 +222,12 @@ for (const { route, mode } of SHELL_ROUTES) {
       // paint on, ending up *under* .header-right — an internal overlap
       // no viewport assertion catches. Its own scrollWidth reports it.
       await expectNoHorizontalScroll(page, '.header-left');
-      // Header controls stay reachable. At ≤700px the preview button
-      // collapses into the overflow menu (Phase 5) — the kebab is the
-      // reachable control.
-      if (width > 700) {
-        await expectInsideViewport(
-          page,
-          page.getByRole('button', { name: 'Fullscreen preview' }),
-          'preview button',
-        );
-      } else {
-        await expectInsideViewport(
-          page,
-          page.getByRole('button', { name: 'More actions' }),
-          'overflow menu button',
-        );
-      }
+      // Header controls stay reachable.
+      await expectInsideViewport(
+        page,
+        page.getByRole('button', { name: 'Fullscreen preview' }),
+        'preview button',
+      );
       await expectInsideViewport(
         page,
         page.locator('.connection-indicator'),
@@ -336,6 +326,33 @@ test('sidebar is an off-canvas drawer at 800px, static at 1280px', async ({ page
   await expect(page.locator('.sidebar-sections')).toBeVisible();
 });
 
+test('sidebar toggle is a distinct chip in both states', async ({ page }) => {
+  await bootAt(page, 1280, 'editor-shell', '.editor-main');
+  const toggle = page.getByRole('button', { name: 'Toggle sidebar' });
+  const bare = page.getByRole('button', { name: 'Switch project' });
+  const styleOf = (el: HTMLElement) => {
+    const cs = getComputedStyle(el);
+    return { bg: cs.backgroundColor, border: cs.borderTopColor };
+  };
+  // The toggle wears the sidebar's own grey tint in both states — never
+  // bare/transparent like the title-bar buttons. Open deepens the tint.
+  const on = await toggle.evaluate(styleOf);
+  const bareStyle = await bare.evaluate(styleOf);
+  expect(on.bg).not.toBe(bareStyle.bg);
+  expect(on.bg).not.toBe('rgba(0, 0, 0, 0)');
+  // The switch-project button is the header's teal one: it exits the
+  // editor for the projects view. The toggle stays grey.
+  const switchColor = await bare.evaluate((el) => getComputedStyle(el).color);
+  expect(switchColor).toBe('rgb(65, 149, 153)'); // --posit-teal
+  // Sidebar off: still a visible chip (background + border), just greyer.
+  await toggle.click();
+  await expect(page.locator('.sidebar-sections')).toBeHidden();
+  const off = await toggle.evaluate(styleOf);
+  expect(off.bg).not.toBe('rgba(0, 0, 0, 0)');
+  expect(off.border).not.toBe('rgba(0, 0, 0, 0)');
+  expect(off.bg).not.toBe(on.bg);
+});
+
 test('sidebar toggle hides and restores the sidebar at 1280px', async ({ page }) => {
   await bootAt(page, 1280, 'editor-shell', '.editor-main');
   const toggle = page.getByRole('button', { name: 'Toggle sidebar' });
@@ -427,7 +444,8 @@ test('split view collapses to the editor pane at 700px', async ({ page }) => {
   await expect(page.locator('.preview-pane')).toBeHidden();
   await expect(page.locator('.pane-divider')).toBeHidden();
   await expect(page.locator('.editor-pane')).toBeVisible();
-  await expect(page.getByRole('button', { name: 'Split view' })).toBeDisabled();
+  // The view toggle itself is hidden this narrow (the header composition
+  // specs own that assertion); the Preview pill covers editor⇄preview.
   await expectNoHorizontalScroll(page, '.editor-main');
 });
 
@@ -437,27 +455,35 @@ test('split view intact at 900px (counter-check)', async ({ page }) => {
   await expect(page.getByRole('button', { name: 'Split view' })).toBeEnabled();
 });
 
-/* ---- header overflow menu (≤700px) ---- */
+/* ---- smallest-header composition (≤700px, Phase 5 review) ----
+   Review feedback: the view-mode buttons are hidden this narrow (split
+   is collapsed anyway; the Preview pill covers editor⇄preview), and
+   Share + Preview stay inline — the kebab overflow menu is retired. */
 
-test('header secondary actions collapse into an overflow menu at 700px', async ({ page }) => {
+test('header at 700px: inline share + preview, no view toggle, no kebab', async ({ page }) => {
   await bootAt(page, 700, 'editor-shell', '.editor-main');
-  await expect(page.locator('.minimal-header .preview-btn')).toBeHidden();
-  await expect(page.locator('.minimal-header .header-share-btn')).toBeHidden();
-  const overflow = page.getByRole('button', { name: 'More actions' });
-  await expect(overflow).toBeVisible();
-  await overflow.click();
-  const menu = page.locator('[role="menu"]');
-  await expect(menu).toBeVisible();
-  await expect(menu.getByRole('menuitem', { name: 'Share this project' })).toBeVisible();
-  await expect(menu.getByRole('menuitem', { name: 'Fullscreen preview' })).toBeVisible();
-  await menu.getByRole('menuitem', { name: 'Share this project' }).click();
+  await expect(page.locator('.minimal-header .preview-btn')).toBeVisible();
+  await expect(page.locator('.minimal-header .header-share-btn')).toBeVisible();
+  await expect(page.locator('.minimal-header .view-toggle-control')).toBeHidden();
+  await expect(page.getByRole('button', { name: 'More actions' })).toHaveCount(0);
+  // The inline actions still fire.
+  await page.locator('.minimal-header .header-share-btn').click();
   await expect(page.getByTestId('header-last-action')).toHaveText('share');
+});
+
+test('header at 320px: same composition, nothing clipped', async ({ page }) => {
+  await bootAt(page, 320, 'editor-shell', '.editor-main');
+  await expect(page.locator('.minimal-header .preview-btn')).toBeVisible();
+  await expect(page.locator('.minimal-header .header-share-btn')).toBeVisible();
+  await expect(page.locator('.minimal-header .view-toggle-control')).toBeHidden();
+  await expectNoHorizontalScroll(page, '.minimal-header');
 });
 
 test('header actions inline at 1280px (counter-check)', async ({ page }) => {
   await bootAt(page, 1280, 'editor-shell', '.editor-main');
   await expect(page.locator('.minimal-header .preview-btn')).toBeVisible();
   await expect(page.locator('.minimal-header .header-share-btn')).toBeVisible();
+  await expect(page.locator('.minimal-header .view-toggle-control')).toBeVisible();
   await expect(page.getByRole('button', { name: 'More actions' })).toHaveCount(0);
 });
 

--- a/hub-client/e2e/viewport-matrix.visual.spec.ts
+++ b/hub-client/e2e/viewport-matrix.visual.spec.ts
@@ -328,8 +328,39 @@ test('sidebar is an off-canvas drawer at 800px, static at 1280px', async ({ page
   await expectNoHorizontalScroll(page, '.editor-main');
 
   await bootAt(page, 1280, 'editor-shell', '.editor-main');
-  await expect(page.getByRole('button', { name: 'Toggle sidebar' })).toHaveCount(0);
+  // The toggle is permanent chrome (Phase 5 review feedback): visible at
+  // every width, and the sidebar starts visible at 1280px.
+  const toggle = page.getByRole('button', { name: 'Toggle sidebar' });
+  await expect(toggle).toBeVisible();
+  await expect(toggle).toHaveAttribute('aria-expanded', 'true');
   await expect(page.locator('.sidebar-sections')).toBeVisible();
+});
+
+test('sidebar toggle hides and restores the sidebar at 1280px', async ({ page }) => {
+  await bootAt(page, 1280, 'editor-shell', '.editor-main');
+  const toggle = page.getByRole('button', { name: 'Toggle sidebar' });
+  await toggle.click();
+  await expect(page.locator('.sidebar-sections')).toBeHidden();
+  await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+  await expectNoHorizontalScroll(page, '.editor-main');
+  await toggle.click();
+  await expect(page.locator('.sidebar-sections')).toBeVisible();
+  await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+});
+
+test('sidebar hidden at 1280px stays closed as a drawer at 800px', async ({ page }) => {
+  await bootAt(page, 1280, 'editor-shell', '.editor-main');
+  const toggle = page.getByRole('button', { name: 'Toggle sidebar' });
+  await toggle.click();
+  await expect(page.locator('.sidebar-sections')).toBeHidden();
+  // Narrowing across the breakpoint must not pop the sidebar back: the
+  // drawer opens only when the user asks.
+  await page.setViewportSize({ width: 800, height: 720 });
+  await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+  await expect(page.locator('.sidebar-drawer')).not.toBeInViewport();
+  await toggle.click();
+  await expect(page.locator('.sidebar-drawer')).toBeInViewport();
+  await expect(toggle).toHaveAttribute('aria-expanded', 'true');
 });
 
 test('sidebar drawer opens with scrim and moves focus in', async ({ page }) => {

--- a/hub-client/src/components/DevHarness.tsx
+++ b/hub-client/src/components/DevHarness.tsx
@@ -591,6 +591,33 @@ const DEV_PAGES: Record<string, () => React.ReactNode> = {
   'editor-shell': () => <EditorShellHarness viewMode="both" />,
   'editor-shell-markup': () => <EditorShellHarness viewMode="markup" />,
   'editor-shell-preview': () => <EditorShellHarness viewMode="preview" />,
+  // Fullscreen preview (Editor.tsx: header/editor-pane/divider unmount,
+  // the preview pane gains .fullscreen) — regression cover for the
+  // ≤700px split-collapse rule hiding the fullscreen pane.
+  'editor-shell-fullscreen': () => (
+    <EditorChrome>
+      <main className="editor-main view-mode-both">
+        <div className="pane preview-pane fullscreen">
+          <button className="fullscreen-close-btn" aria-label="Exit fullscreen preview">
+            ✕
+          </button>
+          <div
+            style={{
+              height: '100%',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              color: 'var(--editor-text-muted)',
+              fontFamily: 'var(--font-mono)',
+              fontSize: 12,
+            }}
+          >
+            Preview pane (fullscreen)
+          </div>
+        </div>
+      </main>
+    </EditorChrome>
+  ),
   // The About tab standalone (sidebar width) — covers the shortcuts
   // reference, which the sidebar route's collapsed ABOUT section hides.
   'about-tab': () => (

--- a/hub-client/src/components/DevHarness.tsx
+++ b/hub-client/src/components/DevHarness.tsx
@@ -281,8 +281,8 @@ function EditorShellHarness({ viewMode }: { viewMode: 'markup' | 'both' | 'previ
         onToggleFullscreenPreview={() => setLastAction('fullscreen-preview')}
         isFullscreenPreview={false}
         isOnline={true}
-        sidebarOpen={drawer.drawerOpen}
-        onToggleSidebar={drawer.isDrawer ? drawer.toggle : undefined}
+        sidebarOpen={drawer.sidebarVisible}
+        onToggleSidebar={drawer.toggle}
         sidebarToggleRef={drawer.toggleRef}
       />
       <main className={`editor-main view-mode-${viewMode}`}>
@@ -637,6 +637,11 @@ const DEV_PAGES: Record<string, () => React.ReactNode> = {
         onToggleFullscreenPreview={() => {}}
         isFullscreenPreview={false}
         isOnline={true}
+        // The sidebar toggle is permanent chrome (Phase 5 review); the
+        // header route has no sidebar, so a static open state + dummy ref.
+        sidebarOpen={true}
+        onToggleSidebar={() => {}}
+        sidebarToggleRef={{ current: null }}
       />
     </EditorChrome>
   ),

--- a/hub-client/src/components/DevHarness.tsx
+++ b/hub-client/src/components/DevHarness.tsx
@@ -643,6 +643,10 @@ const DEV_PAGES: Record<string, () => React.ReactNode> = {
         onToggleSidebar={() => {}}
         sidebarToggleRef={{ current: null }}
       />
+      {/* The toggle's aria-controls points at the drawer's id; in the
+          real app the drawer always exists, so the route stubs it
+          (axe's aria-valid-attr-value flags a dangling reference). */}
+      <div id="sidebar-drawer" hidden />
     </EditorChrome>
   ),
   notifications: () => (

--- a/hub-client/src/components/Editor.css
+++ b/hub-client/src/components/Editor.css
@@ -312,9 +312,10 @@
 
   /* Split-view collapse (Phase 5): two ~350px panes are useless this
      narrow — the editor takes the width and the preview is one tap away
-     on the view toggle (whose split button is disabled at ≤700px). The
-     fullscreen preview pane keeps its place: collapsing must not hide
-     the one surface fullscreen mode exists to show. */
+     on the header's Preview button (the view toggle is hidden ≤700px —
+     MinimalHeader.css). The fullscreen preview pane keeps its place:
+     collapsing must not hide the one surface fullscreen mode exists to
+     show. */
   .editor-main.view-mode-both .preview-pane:not(.fullscreen),
   .editor-main.view-mode-both .pane-divider {
     display: none;

--- a/hub-client/src/components/Editor.css
+++ b/hub-client/src/components/Editor.css
@@ -190,6 +190,12 @@
   display: contents;
 }
 
+/* Static layout, sidebar hidden via the header toggle: the wrapper
+   leaves the layout entirely (the panes take the width). */
+.sidebar-drawer.hidden {
+  display: none;
+}
+
 @media (max-width: 900px) {
   .sidebar-drawer {
     display: block;

--- a/hub-client/src/components/Editor.css
+++ b/hub-client/src/components/Editor.css
@@ -306,8 +306,10 @@
 
   /* Split-view collapse (Phase 5): two ~350px panes are useless this
      narrow — the editor takes the width and the preview is one tap away
-     on the view toggle (whose split button is disabled at ≤700px). */
-  .editor-main.view-mode-both .preview-pane,
+     on the view toggle (whose split button is disabled at ≤700px). The
+     fullscreen preview pane keeps its place: collapsing must not hide
+     the one surface fullscreen mode exists to show. */
+  .editor-main.view-mode-both .preview-pane:not(.fullscreen),
   .editor-main.view-mode-both .pane-divider {
     display: none;
   }

--- a/hub-client/src/components/Editor.tsx
+++ b/hub-client/src/components/Editor.tsx
@@ -1078,8 +1078,8 @@ export default function Editor({ project, files, fileContents, onDisconnect, onC
             onToggleFullscreenPreview={handleToggleFullscreenPreview}
             isFullscreenPreview={isFullscreenPreview}
             isOnline={isOnline}
-            sidebarOpen={sidebarDrawer.drawerOpen}
-            onToggleSidebar={sidebarDrawer.isDrawer ? sidebarDrawer.toggle : undefined}
+            sidebarOpen={sidebarDrawer.sidebarVisible}
+            onToggleSidebar={sidebarDrawer.toggle}
             sidebarToggleRef={sidebarDrawer.toggleRef}
           />
           {replayState.isActive && (

--- a/hub-client/src/components/MinimalHeader.css
+++ b/hub-client/src/components/MinimalHeader.css
@@ -94,6 +94,18 @@
   display: none;
 }
 
+/* Sidebar toggle (Phase 5, after design review): permanent chrome, but
+   it must read as belonging to the sidebar, not as a title-bar action —
+   muted grey at rest. A faint sidebar-tinted background appears while
+   the sidebar is open, tying the button to its surface. */
+.minimal-header .sidebar-toggle-btn {
+  color: var(--editor-text-muted);
+}
+
+.minimal-header .sidebar-toggle-btn[aria-expanded='true'] {
+  background: var(--sidebar-bg);
+}
+
 @media (max-width: 700px) {
   .header-doc .project-name {
     flex-shrink: 1;

--- a/hub-client/src/components/MinimalHeader.css
+++ b/hub-client/src/components/MinimalHeader.css
@@ -88,22 +88,31 @@
    Scoped to the media query because overflow != visible changes the
    span's baseline alignment, and the 1280px baselines must stay
    pixel-identical. */
-/* Header overflow menu (Phase 5): hidden by default; at ≤700px the
-   secondary actions (share, fullscreen preview) collapse into it. */
-.header-overflow {
-  display: none;
-}
-
-/* Sidebar toggle (Phase 5, after design review): permanent chrome, but
-   it must read as belonging to the sidebar, not as a title-bar action —
-   muted grey at rest. A faint sidebar-tinted background appears while
-   the sidebar is open, tying the button to its surface. */
+/* Sidebar toggle (Phase 5, design review): permanent chrome that reads
+   as the sidebar's own — the sidebar's background tint and border.
+   Grey in both states; opening the sidebar deepens the tint to the
+   sidebar's content layer. Never teal — teal marks the switch-project
+   action, which exits to another view. */
 .minimal-header .sidebar-toggle-btn {
   color: var(--editor-text-muted);
+  background: var(--sidebar-bg);
+  border-color: var(--sidebar-border);
 }
 
 .minimal-header .sidebar-toggle-btn[aria-expanded='true'] {
-  background: var(--sidebar-bg);
+  color: var(--text-secondary);
+  background: var(--input-bg-alpha);
+}
+
+.minimal-header .sidebar-toggle-btn:hover {
+  color: var(--text-primary);
+  background: var(--sidebar-section-hover);
+}
+
+/* The switch-project button is the header's one teal icon: it exits the
+   editor for the projects view. */
+.minimal-header .header-switch-btn {
+  color: var(--posit-teal);
 }
 
 @media (max-width: 700px) {
@@ -114,13 +123,12 @@
     text-overflow: ellipsis;
   }
 
-  .minimal-header .header-share-btn,
-  .minimal-header .preview-btn {
+  /* Smallest-header composition (Phase 5 review): the view-mode buttons
+     are hidden this narrow — split view is collapsed (Editor.css) and
+     the Preview pill covers the editor⇄preview switch — leaving room for
+     the inline Share and Preview buttons. */
+  .minimal-header .view-toggle-control {
     display: none;
-  }
-
-  .minimal-header .header-overflow {
-    display: block;
   }
 }
 

--- a/hub-client/src/components/MinimalHeader.tsx
+++ b/hub-client/src/components/MinimalHeader.tsx
@@ -5,11 +5,9 @@
  * Right: online status, layout toggle, fullscreen-preview action.
  */
 
-import { useRef, useState } from 'react';
 import ViewToggleControl from './ViewToggleControl';
-import { SwitchIcon, ShareIcon, PreviewIcon, PanelLeftIcon, MoreIcon } from './icons';
+import { SwitchIcon, ShareIcon, PreviewIcon, PanelLeftIcon } from './icons';
 import Tooltip from './Tooltip';
-import { Menu, MenuItem } from './Menu';
 import { header } from '../strings';
 import './MinimalHeader.css';
 
@@ -47,14 +45,6 @@ export default function MinimalHeader({
   onToggleSidebar,
   sidebarToggleRef,
 }: MinimalHeaderProps) {
-  const [overflowOpen, setOverflowOpen] = useState(false);
-  const overflowTriggerRef = useRef<HTMLButtonElement | null>(null);
-  // Secondary actions collapse into the overflow menu at ≤700px (CSS
-  // hides the inline buttons and reveals the kebab). Rendered only when
-  // at least one collapsible action exists.
-  const hasCollapsibleActions =
-    !!onShare || !!(onToggleFullscreenPreview && !isFullscreenPreview);
-
   return (
     <header className="minimal-header">
       <div className="header-left">
@@ -74,7 +64,7 @@ export default function MinimalHeader({
         )}
         <Tooltip content={header.switchProject}>
           <button
-            className="qh-icon-btn boxed"
+            className="qh-icon-btn boxed header-switch-btn"
             onClick={onChooseNewProject}
             aria-label={header.switchProject}
           >
@@ -129,50 +119,6 @@ export default function MinimalHeader({
               <span>{header.preview}</span>
             </button>
           </Tooltip>
-        )}
-        {hasCollapsibleActions && (
-          <div className="qh-menu-anchor header-overflow">
-            <Tooltip content={header.moreActions}>
-              <button
-                ref={overflowTriggerRef}
-                className="qh-icon-btn boxed"
-                onClick={() => setOverflowOpen((v) => !v)}
-                aria-label={header.moreActions}
-                aria-expanded={overflowOpen}
-              >
-                <MoreIcon />
-              </button>
-            </Tooltip>
-            {overflowOpen && (
-              <Menu
-                className="qh-menu-right"
-                triggerRef={overflowTriggerRef}
-                onClose={() => setOverflowOpen(false)}
-                aria-label={header.moreActions}
-              >
-                {onShare && (
-                  <MenuItem
-                    onSelect={() => {
-                      setOverflowOpen(false);
-                      onShare();
-                    }}
-                  >
-                    {header.shareProject}
-                  </MenuItem>
-                )}
-                {onToggleFullscreenPreview && !isFullscreenPreview && (
-                  <MenuItem
-                    onSelect={() => {
-                      setOverflowOpen(false);
-                      onToggleFullscreenPreview();
-                    }}
-                  >
-                    {header.fullscreenPreview}
-                  </MenuItem>
-                )}
-              </Menu>
-            )}
-          </div>
         )}
       </div>
     </header>

--- a/hub-client/src/components/MinimalHeader.tsx
+++ b/hub-client/src/components/MinimalHeader.tsx
@@ -24,9 +24,11 @@ interface MinimalHeaderProps {
   /** Whether the project is connected to the sync server */
   isOnline?: boolean;
   /**
-   * Sidebar drawer toggle (Phase 5): rendered only at ≤900px, when the
-   * sidebar is a drawer — the caller (Editor) gates on the breakpoint
-   * via onToggleSidebar's presence. The ref gets focus on drawer close.
+   * Sidebar toggle (Phase 5, made permanent after design review):
+   * visible at every width — hides/shows the static sidebar above
+   * 900px, opens/closes the overlay drawer at ≤900px. `sidebarOpen`
+   * reflects the sidebar's current on-screen presence (aria-expanded).
+   * The ref gets focus on drawer close.
    */
   sidebarOpen?: boolean;
   onToggleSidebar?: () => void;

--- a/hub-client/src/components/SidebarDrawer.tsx
+++ b/hub-client/src/components/SidebarDrawer.tsx
@@ -2,14 +2,16 @@ import { header } from '../strings';
 import type { useSidebarDrawer } from '../hooks/useSidebarDrawer';
 
 /**
- * Responsive sidebar wrapper (Phase 5 narrow-viewport design). Above
- * 900px the wrapper is `display: contents` — layout-transparent, the
- * sidebar sits in the flex row as always. At ≤900px it becomes a modal
+ * Responsive sidebar wrapper (Phase 5 narrow-viewport design, extended
+ * after design review). Above 900px the wrapper is `display: contents` —
+ * layout-transparent — unless the user hid the sidebar via the header
+ * toggle, when it is `display: none`. At ≤900px it becomes a modal
  * overlay drawer: off-canvas until opened, with a scrim, dialog
  * semantics, and (via useSidebarDrawer) Escape close + focus management.
  *
  * The wrapper stays mounted when the drawer is closed — `inert` keeps
- * its controls out of the tab order and AT tree while off-canvas.
+ * its controls out of the tab order and AT tree while off-canvas or
+ * hidden.
  */
 export default function SidebarDrawer({
   drawer,
@@ -18,17 +20,20 @@ export default function SidebarDrawer({
   drawer: ReturnType<typeof useSidebarDrawer>;
   children: React.ReactNode;
 }) {
-  const { isDrawer, drawerOpen, close, drawerRef, drawerKeyDown } = drawer;
+  const { isDrawer, drawerOpen, visible, close, drawerRef, drawerKeyDown } = drawer;
+  const cls = isDrawer
+    ? `sidebar-drawer${drawerOpen ? ' open' : ''}`
+    : `sidebar-drawer${visible ? '' : ' hidden'}`;
   return (
     <>
       <div
         ref={drawerRef}
         id="sidebar-drawer"
-        className={`sidebar-drawer${drawerOpen ? ' open' : ''}`}
+        className={cls}
         role={isDrawer ? 'dialog' : undefined}
         aria-modal={isDrawer || undefined}
         aria-label={isDrawer ? header.sidebarDrawerLabel : undefined}
-        inert={isDrawer && !drawerOpen}
+        inert={isDrawer ? !drawerOpen : !visible}
         onKeyDown={drawerKeyDown}
       >
         {children}

--- a/hub-client/src/components/ViewToggleControl.tsx
+++ b/hub-client/src/components/ViewToggleControl.tsx
@@ -1,20 +1,17 @@
 import { useViewMode } from './ViewModeContext';
 import { LayoutMarkupIcon, LayoutSplitIcon, LayoutPreviewIcon } from './icons';
 import Tooltip from './Tooltip';
-import { useMediaQuery } from '../hooks/useMediaQuery';
 import { viewToggle } from '../strings';
 import './ViewToggleControl.css';
 
 /**
  * Compact horizontal view toggle in the header.
  * Three small square buttons with layout-split icons.
+ * Hidden by CSS at ≤700px (MinimalHeader) — split view is collapsed
+ * there and the Preview pill covers the editor⇄preview switch.
  */
 export default function ViewToggleControl() {
   const { viewMode, setViewMode } = useViewMode();
-  // Phase 5: split view collapses to the editor pane at ≤700px
-  // (Editor.css), so the split option is disabled this narrow. The mode
-  // itself is left untouched — widening the window restores the split.
-  const splitUnavailable = useMediaQuery('(max-width: 700px)');
 
   return (
     <div className="view-toggle-control">
@@ -28,15 +25,12 @@ export default function ViewToggleControl() {
           <LayoutMarkupIcon />
         </button>
       </Tooltip>
-      <Tooltip
-        content={splitUnavailable ? viewToggle.splitUnavailable : viewToggle.splitEqually}
-      >
+      <Tooltip content={viewToggle.splitEqually}>
         <button
           className={`view-toggle-btn${viewMode === 'both' ? ' active' : ''}`}
           onClick={() => setViewMode('both')}
           aria-label={viewToggle.splitView}
           aria-pressed={viewMode === 'both'}
-          disabled={splitUnavailable}
         >
           <LayoutSplitIcon />
         </button>

--- a/hub-client/src/hooks/useSidebarDrawer.ts
+++ b/hub-client/src/hooks/useSidebarDrawer.ts
@@ -2,19 +2,25 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { useMediaQuery } from './useMediaQuery';
 
 /**
- * Sidebar drawer behavior (Phase 5 narrow-viewport design): at ≤900px the
- * sidebar leaves the flex layout and becomes a modal overlay drawer (the
- * CSS lives in Editor.css — `.sidebar-drawer` is `display: contents`
- * above the breakpoint, so the wrapper is layout-transparent there).
+ * Sidebar visibility + drawer behavior (Phase 5 narrow-viewport design,
+ * extended after design review): the header toggle is permanent chrome.
+ * Above 900px it hides/shows the static sidebar (VS Code style); at
+ * ≤900px the sidebar leaves the flex layout and becomes a modal overlay
+ * drawer the toggle opens/closes (the CSS lives in Editor.css —
+ * `.sidebar-drawer` is `display: contents` in the static layout, so the
+ * wrapper is layout-transparent there).
  *
- * The hook owns the open state, Escape close, focus-into-drawer on open,
- * focus return to the toggle on close, and the Tab trap while open.
+ * The two modes keep separate state: hiding the static sidebar does not
+ * open the drawer on a narrow resize, and vice versa. The hook owns the
+ * open state, Escape close, focus-into-drawer on open, focus return to
+ * the toggle on close, and the Tab trap while the drawer is open.
  * `SidebarDrawer` (components/SidebarDrawer.tsx) renders the wrapper +
  * scrim from these values; MinimalHeader renders the toggle button.
  */
 export function useSidebarDrawer() {
   const isDrawer = useMediaQuery('(max-width: 900px)');
   const [open, setOpen] = useState(false);
+  const [visible, setVisible] = useState(true);
   const toggleRef = useRef<HTMLButtonElement | null>(null);
   const drawerRef = useRef<HTMLDivElement | null>(null);
 
@@ -23,6 +29,8 @@ export function useSidebarDrawer() {
   // means the drawer reopens as the user left it (VS Code's sidebar
   // behaves the same way).
   const drawerOpen = isDrawer && open;
+  /** Whether the sidebar is on screen right now (drives aria-expanded). */
+  const sidebarVisible = isDrawer ? drawerOpen : visible;
 
   // Focus into the drawer on open. On close, return focus to the toggle
   // only when focus is still inside the drawer — don't steal it back
@@ -73,7 +81,15 @@ export function useSidebarDrawer() {
   return {
     isDrawer,
     drawerOpen,
-    toggle: useCallback(() => setOpen((v) => !v), []),
+    visible,
+    sidebarVisible,
+    toggle: useCallback(() => {
+      if (isDrawer) {
+        setOpen((v) => !v);
+      } else {
+        setVisible((v) => !v);
+      }
+    }, [isDrawer]),
     close: useCallback(() => setOpen(false), []),
     toggleRef,
     drawerRef,

--- a/hub-client/src/strings.ts
+++ b/hub-client/src/strings.ts
@@ -50,7 +50,6 @@ export const header = {
   preview: 'Preview',
   toggleSidebar: 'Toggle sidebar',
   sidebarDrawerLabel: 'Sidebar',
-  moreActions: 'More actions',
   noFileSelected: 'No file selected',
   online: 'Online',
   offline: 'Offline',
@@ -210,7 +209,6 @@ export const viewToggle = {
   markupView: 'Markup view',
   splitEqually: 'Split equally',
   splitView: 'Split view',
-  splitUnavailable: 'Split view needs a wider window',
   expandPreview: 'Expand preview',
   previewView: 'Preview view',
 } as const;


### PR DESCRIPTION
Follow-up to #622 (merged before the design review finished): the adjustments from your review feedback.

## Before → after

| Change | Before | After |
|---|---|---|
| Fullscreen preview at ≤ 700 px | Blank pane (the split-collapse rule hid the fullscreen pane too) | Preview shows; regression specs at 700/320 px |
| Sidebar toggle | Only existed at ≤ 900 px, easy to miss | Permanent header button at every width; hides/shows the sidebar above 900 px too |
| Toggle styling | Looked like a title-bar button | Grey chip in the sidebar's own tint, deepening while the sidebar is open. The switch-project icon is now teal — the one action that exits to another view |
| Header at ≤ 700 px | Share/Preview hidden in a "..." menu; view-mode switcher visible with split disabled | View-mode switcher hidden (the Preview button covers switching); Share + Preview back inline; the "..." menu is gone |

## Screenshots (light theme)

### Header at 1280 px

| Before | After |
|---|---|
| ![header before](https://raw.githubusercontent.com/quarto-dev/q2/phase5-review-assets/round2/header-1280-light-before.png) | ![header after](https://raw.githubusercontent.com/quarto-dev/q2/phase5-review-assets/round2/header-1280-light-after.png) |

### Editor at 700 px

| Before | After |
|---|---|
| ![700 px before](https://raw.githubusercontent.com/quarto-dev/q2/phase5-review-assets/round2/shell-700-light-before.png) | ![700 px after](https://raw.githubusercontent.com/quarto-dev/q2/phase5-review-assets/round2/shell-700-light-after.png) |

### Editor at 320 px

| Before | After |
|---|---|
| ![320 px before](https://raw.githubusercontent.com/quarto-dev/q2/phase5-review-assets/round2/shell-320-light-before.png) | ![320 px after](https://raw.githubusercontent.com/quarto-dev/q2/phase5-review-assets/round2/shell-320-light-after.png) |

## Tests

- Visual suite: 231/231 (screenshots, axe-core, keyboard, reduced-motion, viewport matrix).
- Unit (1049), integration (114), WASM (133): all pass.
- `lint:css` + typecheck: clean.

## CI note

The header captures changed, so the linux baselines need one more regeneration: dispatch `hub-client-e2e.yml` with `recreate-all-snapshots=true` on this branch.

---

*Images load from the `phase5-review-assets` branch (same as #622).*
