### PR TITLE
Fix sync-client test mocks missing repo.handles (TS suite red on main)

### DIFF
--- a/ts-packages/quarto-sync-client/src/applyEditorOperations.test.ts
+++ b/ts-packages/quarto-sync-client/src/applyEditorOperations.test.ts
@@ -127,6 +127,8 @@ async function setupClientWithFile(initialText: string) {
       import: vi.fn().mockReturnValue(indexHandle),
       create: vi.fn().mockReturnValue(fileHandle),
       networkSubsystem: mockNetworkSubsystem,
+      // client.ts trackPeers() sweeps repo.handles on connect
+      handles: {},
     });
     return this as Repo;
   } as unknown as typeof Repo);

--- a/ts-packages/quarto-sync-client/src/client.connect-options.test.ts
+++ b/ts-packages/quarto-sync-client/src/client.connect-options.test.ts
@@ -137,6 +137,8 @@ function installRepo<T>(
       import: vi.fn().mockReturnValue(handle),
       create: vi.fn().mockReturnValue(handle),
       networkSubsystem: net,
+      // client.ts trackPeers() sweeps repo.handles on connect
+      handles: {},
     });
     return this as Repo;
   } as unknown as typeof Repo);
@@ -213,12 +215,13 @@ describe('connect() options bag', () => {
     await flushMicrotasks();
 
     // The whole point: no deadline timer exists. (A finite budget
-    // would have scheduled exactly one setTimeout by now.)
-    expect(vi.getTimerCount()).toBe(0);
+    // would have scheduled exactly one setTimeout by now.) The one
+    // live timer is trackPeers' handle-watch interval, not a deadline.
+    expect(vi.getTimerCount()).toBe(1);
 
     // Simulate the peer arriving far later than any old budget.
     await vi.advanceTimersByTimeAsync(60_000);
-    expect(vi.getTimerCount()).toBe(0); // still no timer, still waiting
+    expect(vi.getTimerCount()).toBe(1); // still no deadline timer, still waiting
     net.emit('peer', { peerId: 'peer-1' });
     await flushMicrotasks();
 
@@ -242,7 +245,8 @@ describe('connect() options bag', () => {
       { peerTimeoutMs: 5000 },
     );
     await flushMicrotasks();
-    expect(vi.getTimerCount()).toBe(1);
+    // The deadline timer plus trackPeers' handle-watch interval.
+    expect(vi.getTimerCount()).toBe(2);
 
     await vi.advanceTimersByTimeAsync(5001);
     await expect(connectPromise).resolves.toEqual([]); // offline fallback

--- a/ts-packages/quarto-sync-client/src/client.test.ts
+++ b/ts-packages/quarto-sync-client/src/client.test.ts
@@ -122,6 +122,8 @@ function installMockRepo<T>(
       import: vi.fn().mockReturnValue(createHandle),
       create: vi.fn().mockReturnValue(createHandle),
       networkSubsystem: mockNetworkSubsystem,
+      // client.ts trackPeers() sweeps repo.handles on connect
+      handles: {},
     });
     return this as Repo;
   } as unknown as typeof Repo);
@@ -356,6 +358,8 @@ describe('createSyncClient.getBinaryDocById URL normalization (bd-4uvv)', () => 
         import: vi.fn().mockReturnValue(binaryHandle),
         create: vi.fn().mockReturnValue(binaryHandle),
         networkSubsystem: mockNetworkSubsystem,
+        // client.ts trackPeers() sweeps repo.handles on connect
+        handles: {},
       });
       return this as Repo;
     } as unknown as typeof Repo);
@@ -392,6 +396,8 @@ describe('createSyncClient.getBinaryDocById URL normalization (bd-4uvv)', () => 
         import: vi.fn().mockReturnValue(indexHandle),
         create: vi.fn().mockReturnValue(indexHandle),
         networkSubsystem: { on: vi.fn(), off: vi.fn() },
+        // client.ts trackPeers() sweeps repo.handles on connect
+        handles: {},
       });
       return this as Repo;
     } as unknown as typeof Repo);
@@ -432,6 +438,8 @@ describe('createSyncClient.getBinaryDocById URL normalization (bd-4uvv)', () => 
         import: vi.fn().mockReturnValue(indexHandle),
         create: vi.fn().mockReturnValue(indexHandle),
         networkSubsystem: { on: vi.fn(), off: vi.fn() },
+        // client.ts trackPeers() sweeps repo.handles on connect
+        handles: {},
       });
       return this as Repo;
     } as unknown as typeof Repo);


### PR DESCRIPTION
## Summary

The TS Test Suite `workspace-ts-suites` job has been red on main since 5d31edf6b ("Add connection modal and fix small isOnline bug") — 29 failing tests across three quarto-sync-client files, all with `TypeError: Cannot convert undefined or null to object`.

## Root cause

5d31edf6b added a `trackPeers` handle-sweep to `client.ts` that reads `repo.handles` (a documented, always-initialized getter on the real automerge `Repo`) and re-sweeps on a 2s `setInterval`. The six `Repo` mock implementations in the test files were never updated:

- `Object.values(repo.handles)` threw in every test using those mocks (9/9 in `applyEditorOperations.test.ts`, 9/9 in `client.test.ts`, 11/12 in `client.connect-options.test.ts`).
- Two `connect-options` tests asserted exact fake-timer counts (`toBe(0)` / `toBe(1)`) that the new always-on watch interval broke.

## Fix (test-only, 18 insertions / 4 deletions)

- Add `handles: {}` to the six `Repo` mock implementations — fixing the mocks rather than making production code defensive, since the real `Repo` guarantees the property.
- Update the two timer-count assertions to account for the watch interval, with comments explaining the timer breakdown.

## Verification

- `npm test -w ts-packages/quarto-sync-client -- --retry=2` (the exact CI step): **137/137 tests pass across 21 files** (was 29 failures).
- `tsc --noEmit` clean.
- No other CI leg affected: test-only change, no `src/` or dist impact.

Tracked as bd-iscjjhx8.