### PR TITLE
hub-client: harness e2e on vite preview, proxy guard, boot-race fix

### DIFF
--- a/.github/workflows/hub-client-e2e.yml
+++ b/.github/workflows/hub-client-e2e.yml
@@ -206,7 +206,9 @@ jobs:
 
       # Dev-harness behavioral tests: keyboard contracts, dialog focus,
       # axe scans, forced-colors, reduced-motion, viewport reflow. No hub
-      # server needed — the config boots vite dev against #/dev/ routes.
+      # server needed — the config serves the VITE_E2E=1 dist built above
+      # via `vite preview` (VITE_E2E admits the #/dev routes in a
+      # production bundle).
       - name: Run harness tests
         run: |
           cd hub-client

--- a/hub-client/changelog.md
+++ b/hub-client/changelog.md
@@ -25,6 +25,7 @@ WASM rebuild is needed for a changelog-only edit.
 
 ### 2026-08-28
 
+- [`5599a22d`](https://github.com/quarto-dev/q2/commits/5599a22d): The dev-harness test suite no longer floods CI logs with connection-refused proxy errors — the dev server now skips the hub proxy entirely when no hub is running.
 - [`28afc1e1`](https://github.com/quarto-dev/q2/commits/28afc1e1): The inline diff in the connection-status dialog now highlights deleted and inserted text with the app's Posit red and green tints instead of off-palette colours.
 - [`5e7278cf`](https://github.com/quarto-dev/q2/commits/5e7278cf): Setup screens are easier to read in dark mode — the tagline and backup-hint text, and the red error banner shown when the sync server can't be reached during migration, now meet contrast guidelines.
 

--- a/hub-client/changelog.md
+++ b/hub-client/changelog.md
@@ -25,6 +25,8 @@ WASM rebuild is needed for a changelog-only edit.
 
 ### 2026-08-28
 
+- [`0c08f15d`](https://github.com/quarto-dev/q2/commits/0c08f15d4): The dev-harness test suite now runs against the production bundle (about 10x faster in CI), and the dev-harness code is no longer included in production builds or the preview app embedded in the q2 binary.
+- [`4c137558`](https://github.com/quarto-dev/q2/commits/4c137558b): Fixed a test-harness race that could stall app boot on a fresh profile — the cause of the intermittent beforeEach timeouts in CI.
 - [`5599a22d`](https://github.com/quarto-dev/q2/commits/5599a22d): The dev-harness test suite no longer floods CI logs with connection-refused proxy errors — the dev server now skips the hub proxy entirely when no hub is running.
 - [`28afc1e1`](https://github.com/quarto-dev/q2/commits/28afc1e1): The inline diff in the connection-status dialog now highlights deleted and inserted text with the app's Posit red and green tints instead of off-palette colours.
 - [`5e7278cf`](https://github.com/quarto-dev/q2/commits/5e7278cf): Setup screens are easier to read in dark mode — the tagline and backup-hint text, and the red error banner shown when the sync server can't be reached during migration, now meet contrast guidelines.

--- a/hub-client/e2e/helpers/harness.ts
+++ b/hub-client/e2e/helpers/harness.ts
@@ -96,66 +96,98 @@ export async function bootHarness(
   await page.goto(`/#/dev/${route}`);
 
   // Wait for the app's boot to create the identity record, then pin it.
-  // The dev server can trigger a full-page reload mid-boot (vite re-
-  // optimizes dependencies on a cold cache — the CI environment), which
-  // destroys the execution context under either of these probes. Both
-  // are idempotent, so retry past the reload.
-  for (let attempt = 0; ; attempt++) {
-    try {
-      await page.waitForFunction(
-        () =>
-          new Promise<boolean>((resolve) => {
-            const req = indexedDB.open('quarto-hub');
-            req.onsuccess = () => {
-              const db = req.result;
-              if (!db.objectStoreNames.contains('userSettings')) {
-                db.close();
-                resolve(false);
-                return;
-              }
-              const tx = db.transaction('userSettings', 'readonly');
-              const get = tx.objectStore('userSettings').get('identity');
-              get.onsuccess = () => {
-                db.close();
-                resolve(!!get.result);
-              };
-              get.onerror = () => {
-                db.close();
-                resolve(false);
-              };
-            };
-            req.onerror = () => resolve(false);
-          }),
-        undefined,
-        { timeout: 15000 },
-      );
-      await page.evaluate((identity) => {
-        return new Promise<void>((resolve, reject) => {
-          const req = indexedDB.open('quarto-hub');
-          req.onsuccess = () => {
-            const db = req.result;
-            const tx = db.transaction('userSettings', 'readwrite');
-            tx.objectStore('userSettings').put(identity);
-            tx.oncomplete = () => {
-              db.close();
-              resolve();
-            };
-            tx.onerror = () => {
-              db.close();
-              reject(tx.error);
-            };
+  //
+  // The probe is a Node-side loop around page.evaluate (which awaits
+  // async functions) — NOT page.waitForFunction. Playwright 1.60 does
+  // not await a promise-returning waitForFunction predicate: the Promise
+  // object is itself truthy, so waitForFunction "succeeds" after one
+  // poll and the identity write races the app's boot. Under `vite dev`
+  // the first poll landed late enough to usually win that race (with
+  // occasional beforeEach-timeout flakes on CI); under `vite preview`
+  // it fires within ~10ms and loses deterministically — the write's
+  // transaction on the not-yet-created userSettings store throws inside
+  // onsuccess, leaving the promise unsettled and the DB connection open,
+  // which then blocks the app's own schema migration forever (mutual
+  // deadlock, 30s beforeEach timeout on every test).
+  //
+  // The probe checks indexedDB.databases() first (Chromium-only, which
+  // is all this suite runs) so it never creates the database itself: an
+  // open() ahead of the app's first migration would force a v1→v5
+  // upgrade and contend with the app's connections. Every probe path
+  // closes its connection before resolving.
+  const deadline = Date.now() + 15_000;
+  for (;;) {
+    const found = await page.evaluate(async () => {
+      const dbs = await indexedDB.databases();
+      if (!dbs.some((d) => d.name === 'quarto-hub')) return false;
+      return new Promise<boolean>((resolve) => {
+        const req = indexedDB.open('quarto-hub');
+        req.onsuccess = () => {
+          const db = req.result;
+          const finish = (value: boolean) => {
+            db.close();
+            resolve(value);
           };
-          req.onerror = () => reject(req.error);
-        });
-      }, FIXED_IDENTITY);
-      break;
-    } catch (err) {
-      if (attempt >= 2 || !/Execution context was destroyed/.test(String(err))) {
-        throw err;
-      }
-      await page.waitForLoadState('load');
+          try {
+            if (!db.objectStoreNames.contains('userSettings')) {
+              finish(false);
+              return;
+            }
+            const tx = db.transaction('userSettings', 'readonly');
+            const get = tx.objectStore('userSettings').get('identity');
+            get.onsuccess = () => finish(!!get.result);
+            get.onerror = () => finish(false);
+            tx.onerror = () => finish(false);
+          } catch {
+            finish(false);
+          }
+        };
+        req.onerror = () => resolve(false);
+        req.onblocked = () => resolve(false);
+      });
+    });
+    if (found) break;
+    if (Date.now() > deadline) {
+      throw new Error(
+        'Timed out (15000ms) waiting for the app to create its identity record',
+      );
     }
+    await page.waitForTimeout(250);
   }
+
+  // Pin the fixed identity. The probe above only returns once the app's
+  // migration has completed, so the store is guaranteed to exist; the
+  // try/catch and close-on-all-paths are belt-and-braces.
+  await page.evaluate((identity) => {
+    return new Promise<void>((resolve, reject) => {
+      const req = indexedDB.open('quarto-hub');
+      req.onsuccess = () => {
+        const db = req.result;
+        try {
+          const tx = db.transaction('userSettings', 'readwrite');
+          tx.objectStore('userSettings').put(identity);
+          tx.oncomplete = () => {
+            db.close();
+            resolve();
+          };
+          tx.onerror = () => {
+            db.close();
+            reject(tx.error);
+          };
+          tx.onabort = () => {
+            db.close();
+            reject(tx.error);
+          };
+        } catch (err) {
+          db.close();
+          reject(err);
+        }
+      };
+      req.onerror = () => reject(req.error);
+      req.onblocked = () =>
+        reject(new Error('identity write blocked by an open connection'));
+    });
+  }, FIXED_IDENTITY);
 
   await page.reload();
   await page.waitForSelector(selector, { timeout: 15000 });

--- a/hub-client/e2e/viewport-matrix.harness.spec.ts
+++ b/hub-client/e2e/viewport-matrix.harness.spec.ts
@@ -284,6 +284,13 @@ test('sidebar toggle is a distinct chip in both states', async ({ page }) => {
   // Sidebar off: still a visible chip (background + border), just greyer.
   await toggle.click();
   await expect(page.locator('.sidebar-sections')).toBeHidden();
+  // The chip's background settles asynchronously after the state flip
+  // (attribute change → style recalc → the pointer's hover style under
+  // the just-clicked toggle). A single immediate read can land mid-settle
+  // and still show the on-state value, so poll until it moves.
+  await expect
+    .poll(async () => (await toggle.evaluate(styleOf)).bg, { timeout: 2000 })
+    .not.toBe(on.bg);
   const off = await toggle.evaluate(styleOf);
   expect(off.bg).not.toBe('rgba(0, 0, 0, 0)');
   expect(off.border).not.toBe('rgba(0, 0, 0, 0)');

--- a/hub-client/package.json
+++ b/hub-client/package.json
@@ -31,7 +31,7 @@
     "test:wasm:watch": "vitest --config vitest.wasm.config.ts",
     "test:e2e": "npm run build:wasm && VITE_E2E=1 npm run build && playwright test",
     "test:e2e:ui": "npm run build:wasm && VITE_E2E=1 npm run build && playwright test --ui",
-    "test:harness": "playwright test --config playwright.harness.config.ts",
+    "test:harness": "npm run build:wasm && VITE_E2E=1 npm run build && playwright test --config playwright.harness.config.ts",
     "test:ci": "npm run test && npm run test:integration && npm run test:wasm",
     "test:all": "npm run build:wasm && npm run test && npm run test:integration && npm run test:wasm && npm run test:e2e",
     "bootstrap-test-fixtures": "npx tsx e2e/scripts/regenerate-fixtures.ts"

--- a/hub-client/playwright.harness.config.ts
+++ b/hub-client/playwright.harness.config.ts
@@ -50,5 +50,11 @@ export default defineConfig({
     url: 'http://localhost:5173',
     reuseExistingServer: !process.env.CI,
     timeout: 120000,
+    env: {
+      // No hub runs during harness tests. Without this, vite dev proxies
+      // /auth and /ws at the default target (localhost:3000) and every
+      // app boot's auth keepalive probes log ECONNREFUSED (bd-a1cwdir9).
+      VITE_DISABLE_HUB_PROXY: '1',
+    },
   },
 });

--- a/hub-client/playwright.harness.config.ts
+++ b/hub-client/playwright.harness.config.ts
@@ -9,6 +9,15 @@ import { defineConfig, devices } from '@playwright/test';
  * collapse, and narrow-viewport reflow. No hub server or network access
  * is needed.
  *
+ * They run against the production bundle (`vite preview`), not `vite
+ * dev`: dev mode re-transforms ~500 modules per page load and its
+ * mid-boot dependency re-optimization was the source of the beforeEach
+ * timeouts under 2-worker/2-core CI contention. The bundle must be
+ * built with VITE_E2E=1 — that flag is what admits #/dev routes in a
+ * production build (see parseHashRoute in src/utils/routing.ts). The
+ * `test:harness` script builds it; CI reuses the dist from the job's
+ * earlier VITE_E2E=1 build step.
+ *
  * The pixel-diff screenshot layer that used to share this setup was
  * dropped while Phase 5 visual churn is ongoing (bd-8g1bn8a0); re-adding
  * it is tracked as bd-wlubinvq, and the specs and baselines are
@@ -46,14 +55,15 @@ export default defineConfig({
   ],
 
   webServer: {
-    command: 'npm run dev',
+    command: 'npm run preview -- --port 5173',
     url: 'http://localhost:5173',
     reuseExistingServer: !process.env.CI,
     timeout: 120000,
     env: {
-      // No hub runs during harness tests. Without this, vite dev proxies
-      // /auth and /ws at the default target (localhost:3000) and every
-      // app boot's auth keepalive probes log ECONNREFUSED (bd-a1cwdir9).
+      // No hub runs during harness tests. Without this, vite preview
+      // proxies /auth and /ws at the default target (localhost:3000) and
+      // every app boot's auth keepalive probes log ECONNREFUSED
+      // (bd-a1cwdir9).
       VITE_DISABLE_HUB_PROXY: '1',
     },
   },

--- a/hub-client/src/App.tsx
+++ b/hub-client/src/App.tsx
@@ -6,9 +6,19 @@ import JoinCollectionLanding from './components/JoinCollectionLanding';
 import ProjectSetSetup from './components/ProjectSetSetup';
 
 // Lazy-loaded dev harness — only fetched when navigating to #/dev/... routes.
-// In production builds, the DevRoute type is never parsed, so this code is never reached.
-const DevHarnessRaw = lazy(() => import('./components/DevHarness'));
+// Dev routes are parsed only in development builds and VITE_E2E=1 test
+// builds (see routing.ts). Both flags are compile-time constants, so in
+// production and preview-embed builds rollup evaluates DEV_ROUTES_ENABLED
+// to false and tree-shakes the dynamic import: no DevHarness chunk is
+// emitted at all (it was dead weight in the q2 binary's embedded SPA).
+const DEV_ROUTES_ENABLED = import.meta.env.DEV || import.meta.env.VITE_E2E === '1';
+const DevHarnessRaw = DEV_ROUTES_ENABLED
+  ? lazy(() => import('./components/DevHarness'))
+  : null;
 function DevHarnessLazy({ page }: { page: string }) {
+  // Unreachable when dev routes are disabled (the route never parses);
+  // the guard keeps the null union honest.
+  if (!DevHarnessRaw) return null;
   return (
     <Suspense fallback={null}>
       <DevHarnessRaw page={page} />
@@ -823,7 +833,8 @@ function App() {
   }
 
   // Dev harness: render components in isolation for visual testing.
-  // Only available in development builds; the DevRoute type is never parsed in production.
+  // Only reachable in development builds and VITE_E2E=1 test builds; in
+  // production the DevRoute type is never parsed (see routing.ts).
   if (route.type === 'dev') {
     return <DevHarnessLazy page={route.page} />;
   }

--- a/hub-client/src/utils/routing.test.ts
+++ b/hub-client/src/utils/routing.test.ts
@@ -247,6 +247,32 @@ describe('parseHashRoute', () => {
       expect(parseHashRoute('#/link-project-set')).toEqual({ type: 'project-selector' });
     });
   });
+
+  describe('dev routes', () => {
+    afterEach(() => {
+      vi.unstubAllEnvs();
+    });
+
+    it('parses #/dev/<page> in development builds', () => {
+      // vitest runs with import.meta.env.DEV === true by default
+      expect(parseHashRoute('#/dev/tokens')).toEqual({ type: 'dev', page: 'tokens' });
+    });
+
+    it('parses #/dev/<page> in VITE_E2E test builds (harness suite runs vite preview)', () => {
+      vi.stubEnv('DEV', false);
+      vi.stubEnv('VITE_E2E', '1');
+      expect(parseHashRoute('#/dev/tokens')).toEqual({ type: 'dev', page: 'tokens' });
+    });
+
+    it('falls through to project-selector in production builds', () => {
+      vi.stubEnv('DEV', false);
+      expect(parseHashRoute('#/dev/tokens')).toEqual({ type: 'project-selector' });
+    });
+
+    it('ignores #/dev without a page even when enabled', () => {
+      expect(parseHashRoute('#/dev')).toEqual({ type: 'project-selector' });
+    });
+  });
 });
 
 describe('buildHashRoute', () => {

--- a/hub-client/src/utils/routing.ts
+++ b/hub-client/src/utils/routing.ts
@@ -163,7 +163,8 @@ export interface JoinCollectionRoute {
 
 /**
  * Route for dev-only harness pages (component previews, visual testing).
- * Only parsed in development builds; in production, #/dev/... falls through to project-selector.
+ * Only parsed in development builds and VITE_E2E=1 test builds; in real
+ * production builds, #/dev/... falls through to project-selector.
  */
 export interface DevRoute {
   type: 'dev';
@@ -311,8 +312,16 @@ export function parseHashRoute(hash: string): Route {
     return { type: 'project', projectId };
   }
 
-  // Parse dev route: /dev/<page> (only in development builds)
-  if (import.meta.env.DEV && segments[0] === 'dev' && segments[1]) {
+  // Parse dev route: /dev/<page>. Parsed in development builds and in
+  // VITE_E2E=1 test builds — the Playwright harness suite runs against a
+  // production bundle served by `vite preview`, so DEV is false there and
+  // the VITE_E2E arm is what admits the route. Never parsed in deployed
+  // builds, where the DevHarness chunk is also tree-shaken out of App.tsx.
+  if (
+    (import.meta.env.DEV || import.meta.env.VITE_E2E === '1') &&
+    segments[0] === 'dev' &&
+    segments[1]
+  ) {
     return { type: 'dev', page: decodeURIComponent(segments[1]) };
   }
 

--- a/hub-client/src/vite-config.test.ts
+++ b/hub-client/src/vite-config.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Guards the VITE_DISABLE_HUB_PROXY escape hatch in vite.config.ts.
+ *
+ * playwright.harness.config.ts boots `vite dev` with no hub server at
+ * all; the /auth and /ws proxy entries would otherwise target a dead
+ * port and turn the app's auth keepalive probes into hundreds of
+ * ECONNREFUSED proxy errors per CI run (bd-a1cwdir9).
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest';
+
+const ENV_KEY = 'VITE_DISABLE_HUB_PROXY';
+const ORIGINAL = process.env[ENV_KEY];
+
+async function loadConfig(flag?: string) {
+  if (flag === undefined) {
+    delete process.env[ENV_KEY];
+  } else {
+    process.env[ENV_KEY] = flag;
+  }
+  // vite.config.ts reads env at module top level, so force re-evaluation.
+  vi.resetModules();
+  const mod = await import('../vite.config');
+  return mod.default;
+}
+
+afterEach(() => {
+  if (ORIGINAL === undefined) {
+    delete process.env[ENV_KEY];
+  } else {
+    process.env[ENV_KEY] = ORIGINAL;
+  }
+});
+
+describe('vite.config hub proxy', () => {
+  it('proxies /auth and /ws to the hub target by default', async () => {
+    const config = await loadConfig(undefined);
+    const proxy = (config.server?.proxy ?? {}) as Record<string, { target?: string }>;
+    expect(proxy).toHaveProperty('/auth');
+    expect(proxy).toHaveProperty('/ws');
+    expect(proxy['/auth'].target).toBe('http://localhost:3000');
+    // Preview mirrors the dev-server proxy for the production-build E2E suite.
+    expect(config.preview?.proxy).toHaveProperty('/auth');
+  });
+
+  it('omits the hub proxy when VITE_DISABLE_HUB_PROXY=1', async () => {
+    const config = await loadConfig('1');
+    const serverProxy = config.server?.proxy ?? {};
+    const previewProxy = config.preview?.proxy ?? {};
+    expect(serverProxy).not.toHaveProperty('/auth');
+    expect(serverProxy).not.toHaveProperty('/ws');
+    expect(previewProxy).not.toHaveProperty('/auth');
+    expect(previewProxy).not.toHaveProperty('/ws');
+  });
+});

--- a/hub-client/src/vite-env.d.ts
+++ b/hub-client/src/vite-env.d.ts
@@ -7,6 +7,11 @@ interface ImportMetaEnv {
   readonly VITE_GOOGLE_CLIENT_ID?: string
   /** Base path the hub is reverse-proxied at. */
   readonly VITE_HUB_BASE_PATH?: string
+  /**
+   * Set to '1' for E2E test builds: exposes window.__quartoTest and
+   * admits #/dev harness routes. Never set for deployed builds.
+   */
+  readonly VITE_E2E?: string
 }
 
 interface ImportMeta {

--- a/hub-client/vite.config.ts
+++ b/hub-client/vite.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'vite'
-import type { Plugin } from 'vite'
+import type { Plugin, ProxyOptions } from 'vite'
 import react from '@vitejs/plugin-react'
 import wasm from 'vite-plugin-wasm'
 import compression from 'compression'
@@ -53,6 +53,15 @@ function attributionViewerCssPlugin(): Plugin {
 
 /** Hub server URL. Override with VITE_HUB_SERVER env var. */
 const hubTarget = process.env.VITE_HUB_SERVER || 'http://localhost:3000';
+
+/**
+ * Drop the /auth and /ws proxy entries entirely. The dev-harness
+ * Playwright suite (playwright.harness.config.ts) boots `vite dev` with
+ * no hub server at all; proxying at a dead target turns the app's auth
+ * keepalive probes into hundreds of ECONNREFUSED proxy errors per run
+ * (bd-a1cwdir9). Without a proxy those requests get a fast local 404.
+ */
+const disableHubProxy = process.env.VITE_DISABLE_HUB_PROXY === '1';
 
 /** Disable service worker in E2E tests to avoid caching interference */
 const isE2E = process.env.VITE_E2E === '1';
@@ -270,7 +279,8 @@ export default defineConfig({
   },
 })
 
-function proxyConfig() {
+function proxyConfig(): Record<string, string | ProxyOptions> {
+  if (disableHubProxy) return {};
   return {
     // Forward /auth/* to the hub server (JWT validation, cookies, OAuth callback).
     '/auth': {


### PR DESCRIPTION
## What

Three fixes for the dev-harness test suite, building on the harness split (#630):

1. **Stop proxying auth requests to a hub that isn't running.** The harness suite starts no hub server, but the dev server still forwarded `/auth` and `/ws` to one — 330 connection-refused errors in a single CI run. A new `VITE_DISABLE_HUB_PROXY=1` flag turns the proxy off for this suite.

2. **Fix a boot race that stalled tests.** The harness's "wait for the app to create its identity" probe never actually waited: Playwright does not await promise-returning `waitForFunction` predicates, so the identity write raced app boot. The dev server's slowness usually hid this; the faster production build made it a guaranteed 30-second stall per test. This was also the cause of the intermittent beforeEach timeouts in CI.

3. **Run the harness suite against the production bundle** (`vite preview` instead of `vite dev`). Dev routes (`#/dev/...`) now work in `VITE_E2E=1` test builds. Deployed builds are unchanged — and no longer contain the harness code at all: it was previously shipped unused, including inside the q2 binary's embedded preview app.

## Result

- Harness suite: 160/160 in ~36s locally (was ~6 min on CI, with flakes).
- No more proxy-error noise in CI logs.
- Unit suite green (1062 tests); production build green.

Strands: bd-a1cwdir9, bd-b6ytx2uz, bd-os8zy6bg