### PR TITLE
hub-client: fix latent contrast pairs + dark focus ring (bd-uue5voml, bd-v56raxds)

### DIFF
--- a/claude-notes/plans/2026-08-28-hub-client-latent-contrast.md
+++ b/claude-notes/plans/2026-08-28-hub-client-latent-contrast.md
@@ -21,7 +21,7 @@ light/dark theme.
 
 ### Phase 1 — token and CSS fixes
 
-- [ ] Editor.css text usages → per-theme text tokens (all verified
+- [x] Editor.css text usages → per-theme text tokens (all verified
   failing L, several D; fixed ≥4.95:1 everywhere):
   - `.diagnostic-item.diagnostic-error/-warning` (banner text, 3.20/2.46 L)
     → `--editor-error-text` / `--editor-warning-text`
@@ -38,46 +38,46 @@ light/dark theme.
   - `.preview-error-diagnostics .diagnostic-line`,
     `.diagnostic-source-file` (2.94 L) → `--editor-warning-text`
   - `.preview-error-diagnostics .diagnostic-title` → `--editor-error-text`
-- [ ] Audit finding beyond the strand's enumerated lines:
+- [x] Audit finding beyond the strand's enumerated lines:
   `.diagnostic-info` (4.38 L on banner) and `.diagnostic-note` (2.66 L /
   4.48 D) fail too; `--editor-info`/`--editor-note` are consumed only by
   diagnostic text, so fix at the token level: light `--editor-info` →
   `--posit-blue-dark-1` (6.41 banner), `--editor-note` →
   `var(--editor-text-muted)` both themes (4.60 L / 4.99 D banner).
-- [ ] `:root.dark --accent-secondary`: `--posit-blue` (#447099, 2.18:1 on
+- [x] `:root.dark --accent-secondary`: `--posit-blue` (#447099, 2.18:1 on
   navy modal #213D4F) → `#93b3d0` (5.20:1 navy, 7.10 page-bg; matches
   the slate-ramp value). Consumers are all text/border (qh-btn.outline,
   qh-link, spinner, link-browser hover border) — no fills.
-- [ ] ErrorBoundary fallback: hardcoded `#fee/#fcc/#900` inline styles →
+- [x] ErrorBoundary fallback: hardcoded `#fee/#fcc/#900` inline styles →
   theme tokens (`--error-bg-subtle`/`--diagnostics-border`/`--error-text`)
   so the dark `--accent-secondary` bump doesn't regress its outline
   buttons (and the fallback finally follows the theme).
-- [ ] Teal text → `--accent-action-text` (3.5:1 → ≥5.3:1):
+- [x] Teal text → `--accent-action-text` (3.5:1 → ≥5.3:1):
   ProjectTab `.export-zip-btn` color + `.screenshot-btn:hover` color
   (borders keep `--posit-teal`), MinimalHeader `.header-switch-btn`,
   ProjectsHome `.qh-fork-btn:hover`/`.qh-peek-btn:hover`/
   `.qh-join-kicker`/`.qh-join-collection-name`, ui.css
   `.qh-menu-item.accent`, ProjectSelector `.connecting` color.
-- [ ] ReplayDrawer `.replay-drawer__attribution--on:hover`: text
+- [x] ReplayDrawer `.replay-drawer__attribution--on:hover`: text
   `--editor-bg` on `--editor-success` fill (3.02 L) →
   `var(--posit-blue-dark-3)` (4.95:1 on #72994E in both themes).
 
 ### Phase 2 — axe coverage for the editor shell
 
-- [ ] New harness route `editor-status-states`: diagnostics banner (all
+- [x] New harness route `editor-status-states`: diagnostics banner (all
   four kinds, mirroring Editor.tsx markup), PreviewStatusBar in error
   state, PreviewErrorOverlay expanded + collapsed, replay-mode-banner —
   inside EditorChrome so the editor token scope applies.
-- [ ] Add `editor-shell` and `editor-status-states` to SCAN_PAGES in
+- [x] Add `editor-shell` and `editor-status-states` to SCAN_PAGES in
   baseline-a11y.harness.spec.ts; regenerate baseline (expect no new
   entries — pages scan clean after Phase 1).
 
 ### Phase 3 — verification
 
-- [ ] `npm run lint:css`, unit tests, `npm run build:all`
-- [ ] Harness suite green incl. baseline-a11y read-mode
-- [ ] Two-commit workflow + hub-client/changelog.md entry
-- [ ] Report; do NOT push without approval
+- [x] `npm run lint:css`, unit tests, `npm run build:all`
+- [x] Harness suite green incl. baseline-a11y read-mode
+- [x] Two-commit workflow + hub-client/changelog.md entry
+- [x] Report; do NOT push without approval
 
 ## Details
 

--- a/claude-notes/plans/2026-08-28-hub-client-latent-contrast.md
+++ b/claude-notes/plans/2026-08-28-hub-client-latent-contrast.md
@@ -1,0 +1,91 @@
+# hub-client: fix latent contrast pairs outside the axe scan set
+
+Strand: bd-uue5voml (discovered-from bd-7byucvr6)
+Branch: `fix/bd-uue5voml-latent-contrast` (stacked on
+`fix/bd-7byucvr6-contrast-baseline-burndown`)
+Date: 2026-08-28
+
+## Overview
+
+bd-7byucvr6 burned the axe baseline to zero, but the harness scan set
+does not cover every surface. This plan fixes the known latent <4.5:1
+pairs (WCAG 1.4.3) enumerated in the strand, plus two same-class pairs
+found during the audit (`.diagnostic-info` / `.diagnostic-note` banner
+text), and adds axe coverage for the editor-shell + status surfaces so
+the class cannot regress silently.
+
+All ratios verified by computation (WCAG rel-luminance); "L"/"D" =
+light/dark theme.
+
+## Work Items
+
+### Phase 1 — token and CSS fixes
+
+- [ ] Editor.css text usages → per-theme text tokens (all verified
+  failing L, several D; fixed ≥4.95:1 everywhere):
+  - `.diagnostic-item.diagnostic-error/-warning` (banner text, 3.20/2.46 L)
+    → `--editor-error-text` / `--editor-warning-text`
+  - `.sync-status.connected/.disconnected` (dead CSS — no consumers;
+    fixed anyway) → `--editor-success-text` / `--editor-error-text`
+  - `.disconnect-btn:hover` color (dead CSS) → `--editor-error-text`
+    (border keeps `--editor-error`)
+  - `.preview-status-error` (3.45 L / 3.49 D) → `--editor-error-text`
+  - `.preview-status-clear-confirm-btn` color → `--editor-error-text`
+    (border keeps `--editor-error`)
+  - `.replay-mode-banner` (3.02 L) → `--editor-success-text`
+  - `.preview-error-title`, `.preview-error-expand-btn` (~3.5 L / 3.6 D)
+    → `--editor-error-text`
+  - `.preview-error-diagnostics .diagnostic-line`,
+    `.diagnostic-source-file` (2.94 L) → `--editor-warning-text`
+  - `.preview-error-diagnostics .diagnostic-title` → `--editor-error-text`
+- [ ] Audit finding beyond the strand's enumerated lines:
+  `.diagnostic-info` (4.38 L on banner) and `.diagnostic-note` (2.66 L /
+  4.48 D) fail too; `--editor-info`/`--editor-note` are consumed only by
+  diagnostic text, so fix at the token level: light `--editor-info` →
+  `--posit-blue-dark-1` (6.41 banner), `--editor-note` →
+  `var(--editor-text-muted)` both themes (4.60 L / 4.99 D banner).
+- [ ] `:root.dark --accent-secondary`: `--posit-blue` (#447099, 2.18:1 on
+  navy modal #213D4F) → `#93b3d0` (5.20:1 navy, 7.10 page-bg; matches
+  the slate-ramp value). Consumers are all text/border (qh-btn.outline,
+  qh-link, spinner, link-browser hover border) — no fills.
+- [ ] ErrorBoundary fallback: hardcoded `#fee/#fcc/#900` inline styles →
+  theme tokens (`--error-bg-subtle`/`--diagnostics-border`/`--error-text`)
+  so the dark `--accent-secondary` bump doesn't regress its outline
+  buttons (and the fallback finally follows the theme).
+- [ ] Teal text → `--accent-action-text` (3.5:1 → ≥5.3:1):
+  ProjectTab `.export-zip-btn` color + `.screenshot-btn:hover` color
+  (borders keep `--posit-teal`), MinimalHeader `.header-switch-btn`,
+  ProjectsHome `.qh-fork-btn:hover`/`.qh-peek-btn:hover`/
+  `.qh-join-kicker`/`.qh-join-collection-name`, ui.css
+  `.qh-menu-item.accent`, ProjectSelector `.connecting` color.
+- [ ] ReplayDrawer `.replay-drawer__attribution--on:hover`: text
+  `--editor-bg` on `--editor-success` fill (3.02 L) →
+  `var(--posit-blue-dark-3)` (4.95:1 on #72994E in both themes).
+
+### Phase 2 — axe coverage for the editor shell
+
+- [ ] New harness route `editor-status-states`: diagnostics banner (all
+  four kinds, mirroring Editor.tsx markup), PreviewStatusBar in error
+  state, PreviewErrorOverlay expanded + collapsed, replay-mode-banner —
+  inside EditorChrome so the editor token scope applies.
+- [ ] Add `editor-shell` and `editor-status-states` to SCAN_PAGES in
+  baseline-a11y.harness.spec.ts; regenerate baseline (expect no new
+  entries — pages scan clean after Phase 1).
+
+### Phase 3 — verification
+
+- [ ] `npm run lint:css`, unit tests, `npm run build:all`
+- [ ] Harness suite green incl. baseline-a11y read-mode
+- [ ] Two-commit workflow + hub-client/changelog.md entry
+- [ ] Report; do NOT push without approval
+
+## Details
+
+- Contrast model: WCAG 2.x relative luminance; alpha backgrounds
+  composited over their actual surface (banner = error-bg-subtle over
+  editor-bg; status bar = input-bg-alpha over bg-modal; etc.).
+- `.qh-menu-item.accent` on the dark navy ramp lands at 4.67:1 with
+  `--accent-action-text` — passes, tightest of the set.
+- Dark `--border-focus` (#447099, 2.18:1 on navy — WCAG 1.4.11 non-text)
+  is the same hue family but a different criterion and strand; file
+  follow-up, do not fix here.

--- a/hub-client/changelog.md
+++ b/hub-client/changelog.md
@@ -25,6 +25,7 @@ WASM rebuild is needed for a changelog-only edit.
 
 ### 2026-08-28
 
+- [`6f2ca7ff`](https://github.com/quarto-dev/q2/commits/6f2ca7ff1): The keyboard focus ring in dark mode is now clearly visible on every surface — it was previously too close in color to dark backgrounds to see on dialogs and cards.
 - [`99846282`](https://github.com/quarto-dev/q2/commits/99846282b): More text now meets WCAG AA contrast in both themes — error and warning text in the editor's diagnostics banner, preview status line, and render-error overlay; teal accent text in menus, buttons, and the join screen; links and outline buttons in dark-mode dialogs; and the replay attribution pill's hover state.
 - [`7308c973`](https://github.com/quarto-dev/q2/commits/7308c9730): Buttons, status messages, and muted label text throughout the app now meet WCAG AA contrast guidelines in both themes — primary actions use a darker teal, danger buttons a deeper red, and status/warning/success text uses purpose-built shades — and the accessibility baseline is now completely clean (zero accepted violations).
 - [`0c08f15d`](https://github.com/quarto-dev/q2/commits/0c08f15d4): The dev-harness test suite now runs against the production bundle (about 10x faster in CI), and the dev-harness code is no longer included in production builds or the preview app embedded in the q2 binary.

--- a/hub-client/changelog.md
+++ b/hub-client/changelog.md
@@ -25,6 +25,7 @@ WASM rebuild is needed for a changelog-only edit.
 
 ### 2026-08-28
 
+- [`99846282`](https://github.com/quarto-dev/q2/commits/99846282b): More text now meets WCAG AA contrast in both themes — error and warning text in the editor's diagnostics banner, preview status line, and render-error overlay; teal accent text in menus, buttons, and the join screen; links and outline buttons in dark-mode dialogs; and the replay attribution pill's hover state.
 - [`7308c973`](https://github.com/quarto-dev/q2/commits/7308c9730): Buttons, status messages, and muted label text throughout the app now meet WCAG AA contrast guidelines in both themes — primary actions use a darker teal, danger buttons a deeper red, and status/warning/success text uses purpose-built shades — and the accessibility baseline is now completely clean (zero accepted violations).
 - [`0c08f15d`](https://github.com/quarto-dev/q2/commits/0c08f15d4): The dev-harness test suite now runs against the production bundle (about 10x faster in CI), and the dev-harness code is no longer included in production builds or the preview app embedded in the q2 binary.
 - [`4c137558`](https://github.com/quarto-dev/q2/commits/4c137558b): Fixed a test-harness race that could stall app boot on a fresh profile — the cause of the intermittent beforeEach timeouts in CI.

--- a/hub-client/e2e/baseline-a11y.harness.spec.ts
+++ b/hub-client/e2e/baseline-a11y.harness.spec.ts
@@ -64,6 +64,12 @@ const SCAN_PAGES: { page: string; label: string; selector: string }[] = [
   { page: 'status-tab-error', label: 'status-tab-error', selector: '.status-tab' },
   // Phase 5: replay drawer surface (actor chips, transport controls).
   { page: 'replay', label: 'replay-drawer', selector: '.replay-drawer' },
+  // bd-uue5voml: the composed editor shell and the editor status
+  // surfaces (diagnostics banner, preview status bar, error overlay,
+  // replay banner) — regression cover for the --editor-*-text token
+  // mapping, which no previously-scanned page renders.
+  { page: 'editor-shell', label: 'editor-shell', selector: '.editor-container' },
+  { page: 'editor-status-states', label: 'editor-status-states', selector: '.diagnostics-banner' },
 ];
 
 /** key → { ruleId: nodeCount } */

--- a/hub-client/e2e/viewport-matrix.harness.spec.ts
+++ b/hub-client/e2e/viewport-matrix.harness.spec.ts
@@ -280,7 +280,9 @@ test('sidebar toggle is a distinct chip in both states', async ({ page }) => {
   // The switch-project button is the header's teal one: it exits the
   // editor for the projects view. The toggle stays grey.
   const switchColor = await bare.evaluate((el) => getComputedStyle(el).color);
-  expect(switchColor).toBe('rgb(65, 149, 153)'); // --posit-teal
+  // --accent-action-text (the contrast-safe teal text token; --posit-teal
+  // itself is only 3.5:1 on white — bd-uue5voml).
+  expect(switchColor).toBe('rgb(46, 110, 113)');
   // Sidebar off: still a visible chip (background + border), just greyer.
   await toggle.click();
   await expect(page.locator('.sidebar-sections')).toBeHidden();

--- a/hub-client/src/components/DevHarness.tsx
+++ b/hub-client/src/components/DevHarness.tsx
@@ -29,6 +29,9 @@ import DevTokensPage from './DevTokensPage';
 import DevGalleryPage from './DevGalleryPage';
 import AboutTab from './tabs/AboutTab';
 import ReplayDrawer from './ReplayDrawer';
+import { PreviewStatusBar } from './render/PreviewStatusBar';
+import { PreviewErrorOverlay } from '@quarto/preview-renderer/overlays/PreviewErrorOverlay';
+import type { Diagnostic, Pass1Failure } from '@quarto/preview-renderer/types/diagnostic';
 import SidebarDrawer from './SidebarDrawer';
 import { useSidebarDrawer } from '../hooks/useSidebarDrawer';
 import { ViewModeProvider } from './ViewModeContext';
@@ -246,6 +249,104 @@ function SidebarHarness({ files = FAKE_FILES }: { files?: FileEntry[] }) {
     <EditorChrome>
       <div style={{ width: 280, height: '100%', borderRight: '1px solid var(--sidebar-border)' }}>
         <StatefulSidebarSections files={files} />
+      </div>
+    </EditorChrome>
+  );
+}
+
+/**
+ * Editor status surfaces (bd-uue5voml): the diagnostics banner, the
+ * preview status bar in its error state, the preview error overlay
+ * (expanded and collapsed), and the replay-mode banner — every surface
+ * whose status text consumes the --editor-*-text tokens. The banner
+ * markup mirrors Editor.tsx (unlocatedErrors); the overlay and status
+ * bar are the real components with canned error state. Exists so the
+ * axe baseline scans these surfaces — the real-app e2e cannot reach
+ * them without a failing render.
+ */
+const HARNESS_BANNER_DIAGNOSTICS: Pick<Diagnostic, 'kind' | 'code' | 'title' | 'problem'>[] = [
+  { kind: 'error', code: 'Q-1-1', title: 'Render failed', problem: 'something broke' },
+  { kind: 'warning', title: 'Unresolved cross-reference', problem: '@fig-missing not found' },
+  { kind: 'info', title: 'Using default format', problem: 'html' },
+  { kind: 'note', title: 'Execution skipped', problem: 'no executable cells' },
+];
+
+const HARNESS_OVERLAY_DIAGNOSTICS: Diagnostic[] = [
+  {
+    kind: 'error',
+    title: 'Unknown cell option',
+    problem: 'cell uses an option that does not exist',
+    start_line: 12,
+    hints: [],
+    details: [],
+  },
+];
+
+const HARNESS_PASS1_FAILURES: Pass1Failure[] = [
+  {
+    source_file: 'notes.qmd',
+    error: 'parse error',
+    diagnostics: [
+      {
+        kind: 'error',
+        title: 'Malformed YAML metadata',
+        problem: 'unexpected end of stream',
+        start_line: 3,
+        hints: [],
+        details: [],
+      },
+    ],
+  },
+];
+
+function EditorStatusStatesHarness() {
+  return (
+    <EditorChrome>
+      {/* Mirrors the diagnostics-banner markup in Editor.tsx. */}
+      <div className="diagnostics-banner">
+        {HARNESS_BANNER_DIAGNOSTICS.map((diag, i) => (
+          <div key={i} className={`diagnostic-item diagnostic-${diag.kind}`}>
+            {diag.code && <span className="diagnostic-code">[{diag.code}]</span>}
+            <span className="diagnostic-title">{diag.title}</span>
+            {diag.problem && <span className="diagnostic-problem">: {diag.problem}</span>}
+          </div>
+        ))}
+      </div>
+      <PreviewStatusBar
+        path="index.qmd"
+        executorsOnline={true}
+        hasExecutableCells={true}
+        capture={{
+          captureDocId: 'automerge:cap-1',
+          state: 'error',
+          lastError: 'Execution failed: something broke',
+        }}
+        onRun={() => {}}
+        onClear={() => {}}
+      />
+      {/* The overlays are position:absolute; each gets a relative box. */}
+      <div style={{ position: 'relative', height: 300 }}>
+        <PreviewErrorOverlay
+          error={{
+            message: 'Render failed with 1 diagnostic',
+            diagnostics: HARNESS_OVERLAY_DIAGNOSTICS,
+            pass1Failures: HARNESS_PASS1_FAILURES,
+          }}
+          visible={true}
+          collapsed={false}
+          onToggleCollapsed={() => {}}
+        />
+      </div>
+      <div style={{ position: 'relative', height: 56 }}>
+        <PreviewErrorOverlay
+          error={{ message: 'Render failed with 1 diagnostic' }}
+          visible={true}
+          collapsed={true}
+          onToggleCollapsed={() => {}}
+        />
+      </div>
+      <div style={{ position: 'relative', height: 24 }}>
+        <div className="replay-mode-banner">REPLAY MODE</div>
       </div>
     </EditorChrome>
   );
@@ -651,6 +752,11 @@ const DEV_PAGES: Record<string, () => React.ReactNode> = {
   sidebar: () => <SidebarHarness />,
   /* ---- Phase 5: replay drawer (actor-chip token review) ---- */
   replay: () => <ReplayHarness />,
+  /* ---- bd-uue5voml: editor status surfaces (diagnostics banner, preview
+     status bar, error overlay, replay banner) so the axe baseline scans
+     the --editor-*-text token mapping — the real-app e2e can't reach
+     these states without a failing render. ---- */
+  'editor-status-states': () => <EditorStatusStatesHarness />,
   /* ---- Phase 4: composed editor shell for the viewport matrix ---- */
   'editor-shell': () => <EditorShellHarness viewMode="both" />,
   'editor-shell-markup': () => <EditorShellHarness viewMode="markup" />,

--- a/hub-client/src/components/Editor.css
+++ b/hub-client/src/components/Editor.css
@@ -26,11 +26,11 @@
 }
 
 .diagnostic-item.diagnostic-error {
-  color: var(--editor-error);
+  color: var(--editor-error-text);
 }
 
 .diagnostic-item.diagnostic-warning {
-  color: var(--editor-warning);
+  color: var(--editor-warning-text);
 }
 
 .diagnostic-item.diagnostic-info {
@@ -50,9 +50,9 @@
   font-weight: 500;
 }
 
-.diagnostic-problem {
-  opacity: 0.85;
-}
+/* No opacity de-emphasis on .diagnostic-problem: opacity composites the
+   text toward the background and drops the status colors below 4.5:1
+   (WCAG 1.4.3) — same failure as the projects-home footer note. */
 
 .editor-header {
   display: flex;
@@ -91,12 +91,12 @@
 
 .sync-status.connected {
   background: var(--editor-success-bg);
-  color: var(--editor-success);
+  color: var(--editor-success-text);
 }
 
 .sync-status.disconnected {
   background: var(--editor-error-bg);
-  color: var(--editor-error);
+  color: var(--editor-error-text);
 }
 
 .user-count {
@@ -171,7 +171,7 @@
 
 .disconnect-btn:hover {
   border-color: var(--editor-error);
-  color: var(--editor-error);
+  color: var(--editor-error-text);
 }
 
 .editor-main {
@@ -382,7 +382,7 @@
 }
 
 .preview-status-error {
-  color: var(--editor-error);
+  color: var(--editor-error-text);
 }
 
 /* Right-aligned action group; Run is last so it stays pinned to the far
@@ -412,7 +412,7 @@
 
 .preview-status-bar .preview-status-clear-confirm-btn {
   border-color: var(--editor-error);
-  color: var(--editor-error);
+  color: var(--editor-error-text);
 }
 
 /* Green liveness dot, shown only while an executor is online. */
@@ -504,7 +504,7 @@
     transparent 4px,
     transparent 8px
   );
-  color: var(--editor-success);
+  color: var(--editor-success-text);
   text-align: center;
   padding: 2px 0;
   font-size: 10px;
@@ -557,7 +557,7 @@
 }
 
 .preview-error-title {
-  color: var(--editor-error);
+  color: var(--editor-error-text);
   font-weight: 600;
   display: flex;
   align-items: center;
@@ -582,7 +582,7 @@
 }
 
 .preview-error-expand-btn {
-  color: var(--editor-error);
+  color: var(--editor-error-text);
   font-weight: 600;
 }
 
@@ -620,12 +620,12 @@
 }
 
 .preview-error-diagnostics .diagnostic-line {
-  color: var(--editor-warning);
+  color: var(--editor-warning-text);
   font-weight: 500;
 }
 
 .preview-error-diagnostics .diagnostic-title {
-  color: var(--editor-error);
+  color: var(--editor-error-text);
 }
 
 .preview-error-diagnostics .diagnostic-problem {
@@ -650,7 +650,7 @@
 .preview-error-pass1-failure .diagnostic-source-file {
   font-size: 12px;
   font-weight: 600;
-  color: var(--editor-warning);
+  color: var(--editor-warning-text);
   margin-bottom: 4px;
 }
 

--- a/hub-client/src/components/ErrorBoundary.tsx
+++ b/hub-client/src/components/ErrorBoundary.tsx
@@ -58,12 +58,12 @@ function DefaultFallback({ error, onReset }: { error: Error; onReset: () => void
       style={{
         padding: '24px',
         margin: '16px',
-        backgroundColor: '#fee',
-        border: '1px solid #fcc',
+        backgroundColor: 'var(--error-bg-subtle)',
+        border: '1px solid var(--diagnostics-border)',
         borderRadius: '6px',
         fontFamily: 'system-ui, sans-serif',
         fontSize: '14px',
-        color: '#900',
+        color: 'var(--error-text)',
       }}
     >
       <h3 style={{ margin: '0 0 8px 0' }}>Something went wrong</h3>

--- a/hub-client/src/components/MinimalHeader.css
+++ b/hub-client/src/components/MinimalHeader.css
@@ -112,7 +112,7 @@
 /* The switch-project button is the header's one teal icon: it exits the
    editor for the projects view. */
 .minimal-header .header-switch-btn {
-  color: var(--posit-teal);
+  color: var(--accent-action-text);
 }
 
 @media (max-width: 700px) {

--- a/hub-client/src/components/ProjectSelector.css
+++ b/hub-client/src/components/ProjectSelector.css
@@ -655,13 +655,21 @@
 
 .project-selector .connecting {
   background: var(--input-bg-alpha);
-  color: var(--posit-teal);
+  color: var(--accent-action-text);
   padding: 12px;
   border-radius: 6px;
   margin-bottom: 16px;
   text-align: center;
   border: 1px solid var(--posit-teal);
   font-weight: 500;
+}
+
+/* --accent-action-text (#2E6E71) is 3.89:1 on this banner's light
+   background (input-alpha over the 95% bg-overlay composite);
+   --selector-connecting-text clears WCAG 1.4.3 at 4.76:1. Dark passes
+   as-is (5.27:1). */
+:root.light .project-selector .connecting {
+  color: var(--selector-connecting-text);
 }
 
 /* User Identity Section */

--- a/hub-client/src/components/ProjectsHome.css
+++ b/hub-client/src/components/ProjectsHome.css
@@ -276,7 +276,7 @@
   padding: 3px 5px 1px;
 }
 
-.qh-fork-btn:hover { background: var(--input-bg-alpha); color: var(--posit-teal); }
+.qh-fork-btn:hover { background: var(--input-bg-alpha); color: var(--accent-action-text); }
 .qh-fork-btn:disabled { opacity: 0.4; cursor: default; }
 
 /* Hover-to-peek: the magnifying-glass icon and its floating popover live in
@@ -285,7 +285,7 @@
    static) so the popover anchors to the nearest positioned ancestor — the
    card or row — and stays on-screen regardless of the icon's spot. */
 .qh-peek-anchor { display: inline-flex; align-items: center; }
-.qh-peek-btn:hover { background: var(--input-bg-alpha); color: var(--posit-teal); }
+.qh-peek-btn:hover { background: var(--input-bg-alpha); color: var(--accent-action-text); }
 
 .qh-card .qh-menu { top: 34px; left: auto; right: 8px; }
 
@@ -471,7 +471,7 @@
   font-size: 11px;
   font-weight: 700;
   letter-spacing: 0.06em;
-  color: var(--posit-teal);
+  color: var(--accent-action-text);
   margin-bottom: 10px;
 }
 
@@ -482,7 +482,7 @@
   line-height: 1.3;
 }
 
-.qh-join-collection-name { color: var(--posit-teal); }
+.qh-join-collection-name { color: var(--accent-action-text); }
 
 .qh-join-sub {
   font-size: var(--text-md);

--- a/hub-client/src/components/ReplayDrawer.css
+++ b/hub-client/src/components/ReplayDrawer.css
@@ -356,7 +356,9 @@
 
 .replay-drawer__attribution--on:hover {
   background: var(--editor-success);
-  color: var(--editor-bg);
+  /* Dark text on the solid green fill: --editor-bg was 3.02:1 in light
+     (WCAG 1.4.3 failure); #17212B is 4.95:1 on #72994E in both themes. */
+  color: var(--posit-blue-dark-3);
 }
 
 .replay-drawer__attribution-dot {

--- a/hub-client/src/components/tabs/ProjectTab.css
+++ b/hub-client/src/components/tabs/ProjectTab.css
@@ -83,7 +83,7 @@
   background: none;
   border: 1px solid var(--posit-teal);
   border-radius: var(--radius-sm);
-  color: var(--posit-teal);
+  color: var(--accent-action-text);
   font-size: 13px;
   cursor: pointer;
   transition: all 0.2s;
@@ -122,7 +122,7 @@
 
 .screenshot-btn:hover {
   border-color: var(--posit-teal);
-  color: var(--posit-teal);
+  color: var(--accent-action-text);
 }
 
 .screenshot-btn:disabled {

--- a/hub-client/src/theme.css
+++ b/hub-client/src/theme.css
@@ -393,7 +393,11 @@
   --text-secondary: var(--posit-blue-light-2);
   --text-muted: var(--posit-blue-light-3);
   --border-color: var(--posit-blue-dark-1);
-  --border-focus: var(--posit-blue);
+  /* #93b3d0 instead of --posit-blue: #447099 fails WCAG 1.4.11's 3:1
+     focus-indicator minimum on most dark surfaces (1.47:1 on bg-card,
+     2.18:1 on the navy modal). #93b3d0 clears it everywhere (worst
+     3.50:1 on bg-card) and matches dark --accent-secondary. */
+  --border-focus: #93b3d0;
   --accent-primary: var(--posit-orange);
   /* #93b3d0 (the slate-ramp value) instead of --posit-blue: #447099 is
      2.18:1 on the navy modal bg — outline buttons/links in root-level

--- a/hub-client/src/theme.css
+++ b/hub-client/src/theme.css
@@ -115,6 +115,11 @@
   --selector-accent: #5ab5b8;
   --selector-accent-subtle: #bacad8;
   --selector-success: #4a6a32;
+  /* "Connecting…" banner text on the classic selector's light
+     background (--input-bg-alpha over the 95% --bg-overlay composite):
+     --accent-action-text is only 3.89:1 there; this clears 4.5:1
+     (4.76:1). */
+  --selector-connecting-text: #276061;
 
   /* ---- Scales ---- */
 
@@ -260,8 +265,12 @@
   --editor-error-text: #b0392e; /* 4.83:1 on the --error-bg-subtle composite */
   --editor-warning-text: #92400e; /* 6.37:1 on --warning-bg */
   --editor-success-text: #4a6a32; /* 5.06:1 on --editor-success-bg */
-  --editor-info: var(--accent-secondary);
-  --editor-note: var(--posit-blue-light-3);
+  /* Info/note are consumed only by diagnostic text (Editor.css), so they
+     must clear 4.5:1 on the diagnostics-banner and error-overlay
+     backgrounds: the accent blue is 4.38:1 on the banner composite and
+     the light-3 ramp step 2.66:1 — both fail WCAG 1.4.3. */
+  --editor-info: var(--posit-blue-dark-1); /* 6.41:1 on the banner composite */
+  --editor-note: var(--editor-text-muted); /* 4.60:1 on the banner composite */
   --editor-drag-accent: var(--posit-teal);
   --editor-disconnected-border: var(--border-color);
 
@@ -386,7 +395,10 @@
   --border-color: var(--posit-blue-dark-1);
   --border-focus: var(--posit-blue);
   --accent-primary: var(--posit-orange);
-  --accent-secondary: var(--posit-blue);
+  /* #93b3d0 (the slate-ramp value) instead of --posit-blue: #447099 is
+     2.18:1 on the navy modal bg — outline buttons/links in root-level
+     dark dialogs failed WCAG 1.4.3 severely. 5.20:1 on #213D4F. */
+  --accent-secondary: #93b3d0;
   /* 6.37:1 on --page-bg #242424; the brand teal is only 4.42:1 there. */
   --accent-action-text: #5fb3b7;
   --error-bg: var(--posit-red);
@@ -427,7 +439,7 @@
   --editor-warning-text: #fbbf24; /* 7.66:1 on --warning-bg */
   --editor-success-text: #9dc183; /* 5.99:1 on --editor-success-bg */
   --editor-info: var(--accent-secondary);
-  --editor-note: var(--posit-blue-light-3);
+  --editor-note: var(--editor-text-muted); /* 4.99:1 on the banner composite */
   --editor-drag-accent: var(--posit-teal);
   --editor-disconnected-border: var(--border-color);
 

--- a/hub-client/src/ui.css
+++ b/hub-client/src/ui.css
@@ -249,7 +249,7 @@
 .qh-menu-item[aria-disabled="true"] { opacity: 0.5; cursor: default; }
 .qh-menu-item[aria-disabled="true"]:hover { background: none; }
 .qh-menu-item.strong { font-weight: 600; }
-.qh-menu-item.accent { color: var(--posit-teal); font-weight: 600; }
+.qh-menu-item.accent { color: var(--accent-action-text); font-weight: 600; }
 .qh-menu-item.danger { color: var(--error-text); }
 
 .qh-menu-item.with-hint {


### PR DESCRIPTION
## Summary

Follow-up to #632 (which burned the axe contrast baseline to zero): fixes the known latent <4.5:1 pairs on surfaces the scan set didn't cover (bd-uue5voml), and the dark-mode focus ring (bd-v56raxds, filed during the audit). Adds axe coverage for the editor shell and editor status surfaces so this class can't regress silently. No snapshot changes.

## bd-uue5voml — latent contrast pairs

- **Editor.css status/diagnostic text** (13 rules) now uses the per-theme `--editor-error-text`/`--editor-warning-text`/`--editor-success-text` tokens: diagnostics banner items, preview-status-error, clear-confirm button, replay-mode-banner, error-overlay title/expand/diagnostic lines/source files. All were 2.4–4.4:1; now ≥4.95:1.
- **`.diagnostic-problem` loses `opacity: 0.85`** — the opacity composited text toward the background below 4.5:1 (same failure mode as the footer note in #632; caught by the new scan page).
- **Audit findings beyond the strand's line list**: `.diagnostic-info` (4.38:1) and `.diagnostic-note` (2.66:1) failed too — fixed at the token level (`--editor-info`/`--editor-note` are consumed only by diagnostic text).
- **`:root.dark --accent-secondary`** → `#93b3d0` (the slate-ramp value): `#447099` was 2.18:1 on the navy modal bg, so any `qh-btn.outline`/`qh-link` in a root-level dark dialog failed severely. Consumers are all text/border; no fills.
- **ErrorBoundary fallback** uses theme tokens instead of hardcoded `#fee/#fcc/#900` — follows the theme and keeps its outline buttons passing under the dark accent bump.
- **Teal text → `--accent-action-text`**: ProjectTab export/screenshot buttons, MinimalHeader switch-project, ProjectsHome fork/peek hovers + join kicker/collection name, `.qh-menu-item.accent`, ProjectSelector connecting banner (which also needed a new `--selector-connecting-text` token for its overlaid light background).
- **ReplayDrawer attribution hover**: dark text on the solid green fill — 4.95:1 in both themes (was 3.02:1 in light).

## bd-v56raxds — dark focus ring (WCAG 1.4.11)

- `:root.dark --border-focus` → `#93b3d0`: was `#447099`, 1.47–2.97:1 on dark surfaces (below the 3:1 non-text minimum for focus indicators). Worst case now 3.50:1 (dark card). One token covers every dark scope. Light unchanged (already passing).

## Axe regression coverage

- New `editor-status-states` harness route renders the surfaces no e2e can reach without a failing render: diagnostics banner (all four kinds), PreviewStatusBar error state, PreviewErrorOverlay expanded+collapsed, replay-mode-banner.
- `editor-shell` and `editor-status-states` join the baseline scan set; the baseline stays `{}` — both pages scan clean in both themes.
- One test update: viewport-matrix pinned the old switch-project teal `rgb(65,149,153)` → now asserts the `--accent-action-text` value.

## Verification

- `lint:css` clean; unit 1066, integration 114, test:wasm 133 pass
- Harness suite: 164 pass, including 46 axe scans (23 pages × 2 themes)
- `npm run build:all` and VITE_E2E=1 build succeed
- `cargo xtask verify`: the only failure was a stale local `node_modules` (katex 0.17.0 vs lockfile 0.18.1) breaking a preview-renderer KaTeX test on a package this PR doesn't touch; after `npm install` re-sync, that suite passes 53/53. Gate treated as passed per maintainer direction.