### PR TITLE
Fix New File dialog Enter-submit reopening itself (GH #635)

### DIFF
--- a/claude-notes/plans/2026-08-31-newfile-dialog-enter-reopen.md
+++ b/claude-notes/plans/2026-08-31-newfile-dialog-enter-reopen.md
@@ -1,0 +1,161 @@
+# NewFileDialog: Enter-submit reopens the dialog (GH #635)
+
+**GitHub issue:** https://github.com/quarto-dev/q2/issues/635
+**Braid strand:** bd-zcv0iea4
+**Status:** planned, not yet implemented. Root cause confirmed empirically in a real
+browser; fix hypothesis verified end-to-end and then reverted pending TDD.
+
+## Overview
+
+In hub-client's "New file" dialog:
+
+- **Click "Create"** → file created, dialog closes. Correct.
+- **Press Enter in the filename input** → file created, dialog **reappears**
+  (empty, focused) instead of staying closed.
+
+During investigation a second, worse defect was confirmed in the same handler:
+
+- **Tab to "Cancel", press Enter** → the file **is created anyway** (and the
+  dialog also reappears). The user asked to cancel and got a file.
+
+Both defects live in `hub-client/src/components/NewFileDialog.tsx`'s
+dialog-level Enter handler; neither requires any change to `ModalDialog`'s
+focus-restore machinery, which is working as designed.
+
+## Root cause (confirmed, not hypothesized)
+
+`NewFileDialog` handles Enter via `ModalDialog`'s `onKeyDown` delegation — a
+handler on the dialog **container div**, reached by bubbling from whatever is
+focused (lines 113–120). On Enter it calls `handleCreateTextFile()`, which
+creates the file and calls `onClose()`. It never calls `e.preventDefault()`.
+
+Per the UI Events spec, an unprevented Enter keydown has a **default action**:
+the browser synthesizes a `click` on the focused element, dispatched *after*
+the keydown listeners and the microtask checkpoint. The sequence, captured
+with capture-phase event logging in headless Chromium (dev server + local hub):
+
+```
+keydown target=INPUT.qh-input  key=Enter        ← handler creates file, closes dialog
+focusin target=BUTTON.new-file-btn              ← ModalDialog's queueMicrotask focus restore
+click   target=BUTTON.new-file-btn detail=0 isTrusted=true   ← Enter's DEFAULT ACTION
+keyup   target=BUTTON.new-file-btn key=Enter
+focusin target=INPUT.qh-input                   ← dialog reopened, autofocus
+```
+
+The dialog unmounts inside the keydown handler; `ModalDialog` restores focus
+to the sidebar's "New file" button (its correct WCAG contract); the browser
+then delivers the keydown's synthesized click to the **newly focused** button
+— which is `onNewFile`, reopening the dialog. `detail=0, isTrusted=true` is
+the signature of a keyboard-activation click.
+
+The Cancel defect is independent of focus restore: the keydown from the
+focused Cancel button **bubbles up** to the container handler, which submits;
+the button's own native Enter activation then also fires Cancel's `onClick`.
+Create-then-close both run.
+
+Verified fix hypothesis: adding `e.preventDefault()` to the Enter branch
+suppresses the synthesized click; the same instrumented run then shows no
+`click` event, `dialog-count=0`, and focus resting on the "New file" button.
+(The edit was reverted; it lands via TDD below.)
+
+### Why the Create-button path is unaffected
+
+A pointer click has no pending default keydown action, so close + focus
+restore complete with nothing left to deliver. Confirmed: after click-create,
+`dialog-count=0`, focus on `.new-file-btn`.
+
+### Sibling audit (same session)
+
+| Site | Enter handling | Affected? |
+| --- | --- | --- |
+| `ShareDialog.tsx:78` | dialog-level Enter → copy, then `onClose` **deferred 500 ms** | Not today — by the time it closes, the default click already fired inside the still-open dialog. Fragile: removing the delay would recreate #635 here. Hygiene `preventDefault` recommended while in the area. |
+| `NewAssetDialog.tsx:297` | per-row rename inputs; Enter just blurs | No |
+| `FileSidebar.tsx:540` (rename) | non-modal inline input | No — no modal close/focus-restore pair |
+| `ProjectsHome.tsx:1644`, `ProjectSelector.tsx:880` | inline rename saves | No — same shape as above |
+
+## Design decision
+
+Two viable shapes for the fix:
+
+- **(A) Keep the dialog-level handler, guard + prevent** *(recommended)*:
+  ```tsx
+  if (e.key === 'Enter') {
+    if (e.target instanceof HTMLButtonElement) return; // let buttons be buttons
+    e.preventDefault();
+    handleCreateTextFile();
+  }
+  ```
+  Preserves today's "Enter submits from anywhere in the form" behavior
+  (including the template `<select>`), fixes both defects, one site.
+
+- **(B) Move Enter handling onto the filename input** (drop the `onKeyDown`
+  delegation): semantically cleanest, but changes behavior — Enter on the
+  template select would no longer submit. Not recommended for a minimal fix.
+
+Either way, document the contract on `ModalDialog`'s `onKeyDown` prop doc:
+*a delegated handler that synchronously closes the dialog must call
+`e.preventDefault()` on Enter, or the keydown's default-action click lands on
+the focus-restore target.* This is what makes the bug a class rather than a
+one-off.
+
+## Work items (TDD order)
+
+### Phase 1 — tests first (must fail before the fix)
+
+- [ ] **Unit (jsdom)**, in `NewFileDialog.integration.test.tsx`:
+      jsdom does not synthesize keyboard-activation clicks, so the *reopen*
+      cannot reproduce there; instead assert the mechanism directly —
+      `fireEvent.keyDown(input, { key: 'Enter' })` returns `false`
+      (i.e. `defaultPrevented`) **and** `onCreateTextFile` + `onClose` were
+      called. Fails today (fireEvent returns `true`).
+- [ ] **Unit (jsdom), Cancel path**: focus the Cancel button,
+      `fireEvent.keyDown(cancelButton, { key: 'Enter' })` → expect
+      `onCreateTextFile` **not** called. Fails today.
+- [ ] **Browser-level regression (harness e2e)** — the only tier where the
+      real mechanism reproduces: add a *stateful* DevHarness route (e.g.
+      `dialog-new-file-stateful`) mirroring the Editor wiring — a trigger
+      `<button>` that sets `isOpen`, `onClose` clearing it, a visible list of
+      created files. New `*.harness.spec.ts` (pattern:
+      `sidebar-keyboard.harness.spec.ts` / `bootHarness`): open via the
+      button, type a name, press Enter → expect file recorded once, dialog
+      **not** visible, focus on the trigger. Fails today. Note the existing
+      `dialog-new-file` route is static-props and cannot express this.
+      (Harness specs run via `playwright.harness.config.ts` — no hub tier
+      needed. Mind the `ci-test-suite-unwired` lint note: harness specs ride
+      the existing `test:harness` wiring, no new package/test script.)
+
+### Phase 2 — fix
+
+- [ ] Apply design (A) in `NewFileDialog.handleKeyDown`.
+- [ ] Extend `ModalDialog`'s `onKeyDown` prop docstring with the
+      preventDefault-on-close contract (comment-only change).
+- [ ] All Phase-1 tests green.
+
+### Phase 3 — hardening + verification
+
+- [ ] `ShareDialog`: add `e.preventDefault()` to its Enter branch (behavior
+      unchanged today, removes the latent trap). Covered by an assertion in
+      its existing test file if one exists; otherwise a one-line unit test.
+- [ ] `cd hub-client && npm run test:ci` and `npm run build:all` (production
+      tsc is stricter — required by CLAUDE.md before claiming done).
+- [ ] End-to-end check per CLAUDE.md: real browser against the dev server —
+      New file → type name → Enter → dialog stays closed, file appears;
+      Tab-to-Cancel → Enter → no file created. (Repro scripts from the
+      investigation session can be re-run; see below.)
+- [ ] Changelog: two-commit workflow — code commit first, then
+      `hub-client/changelog.md` entry with the hash.
+
+## Reproduction recipe (for the implementing session)
+
+Local-only, nothing touches the public sync server:
+
+1. `cargo build --bin hub && target/debug/hub --data-dir <tmp> --port 3799 --allow-insecure-auth`
+2. `cd hub-client && VITE_DEFAULT_SYNC_SERVER=ws://127.0.0.1:9/ws npm run dev -- --port 5199`
+   (the unreachable default is fine; the setup form takes `ws://127.0.0.1:3799/ws`)
+3. Playwright (workspace dep) headless: create project set → "+ New project" →
+   "Default" → name it → editor. Click "New file" (sidebar, aria-label),
+   fill `#filename`, `keyboard.press('Enter')` → observe
+   `.qh-dialog.new-file-dialog` count is 1 again and the file exists.
+
+Investigation scripts (session-scratchpad, not committed): `repro.mjs`,
+`mechanism.mjs`, `cancel-enter.mjs` under the 2026-08-31 session scratchpad.

--- a/claude-notes/plans/2026-08-31-newfile-dialog-enter-reopen.md
+++ b/claude-notes/plans/2026-08-31-newfile-dialog-enter-reopen.md
@@ -102,16 +102,18 @@ one-off.
 
 ### Phase 1 — tests first (must fail before the fix)
 
-- [ ] **Unit (jsdom)**, in `NewFileDialog.integration.test.tsx`:
+- [x] **Unit (jsdom)**, in `NewFileDialog.integration.test.tsx`:
       jsdom does not synthesize keyboard-activation clicks, so the *reopen*
       cannot reproduce there; instead assert the mechanism directly —
       `fireEvent.keyDown(input, { key: 'Enter' })` returns `false`
       (i.e. `defaultPrevented`) **and** `onCreateTextFile` + `onClose` were
       called. Fails today (fireEvent returns `true`).
-- [ ] **Unit (jsdom), Cancel path**: focus the Cancel button,
+- [x] **Unit (jsdom), Cancel path**: focus the Cancel button,
       `fireEvent.keyDown(cancelButton, { key: 'Enter' })` → expect
-      `onCreateTextFile` **not** called. Fails today.
-- [ ] **Browser-level regression (harness e2e)** — the only tier where the
+      `onCreateTextFile` **not** called. Fails today. (Also added: the
+      Create-button variant — no double-submit — and an empty-filename
+      guard pin; 3 of the 4 failed pre-fix as predicted.)
+- [x] **Browser-level regression (harness e2e)** — the only tier where the
       real mechanism reproduces: add a *stateful* DevHarness route (e.g.
       `dialog-new-file-stateful`) mirroring the Editor wiring — a trigger
       `<button>` that sets `isOpen`, `onClose` clearing it, a visible list of
@@ -126,22 +128,23 @@ one-off.
 
 ### Phase 2 — fix
 
-- [ ] Apply design (A) in `NewFileDialog.handleKeyDown`.
-- [ ] Extend `ModalDialog`'s `onKeyDown` prop docstring with the
+- [x] Apply design (A) in `NewFileDialog.handleKeyDown`.
+- [x] Extend `ModalDialog`'s `onKeyDown` prop docstring with the
       preventDefault-on-close contract (comment-only change).
-- [ ] All Phase-1 tests green.
+- [x] All Phase-1 tests green (19/19 unit, 3/3 harness).
 
 ### Phase 3 — hardening + verification
 
-- [ ] `ShareDialog`: add `e.preventDefault()` to its Enter branch (behavior
-      unchanged today, removes the latent trap). Covered by an assertion in
-      its existing test file if one exists; otherwise a one-line unit test.
+- [x] `ShareDialog`: add `e.preventDefault()` + button-target guard to its
+      Enter branch (behavior unchanged today, removes the latent trap).
+      Two tests added to `ShareDialog.test.tsx` (clipboard stubbed).
 - [ ] `cd hub-client && npm run test:ci` and `npm run build:all` (production
       tsc is stricter — required by CLAUDE.md before claiming done).
-- [ ] End-to-end check per CLAUDE.md: real browser against the dev server —
-      New file → type name → Enter → dialog stays closed, file appears;
-      Tab-to-Cancel → Enter → no file created. (Repro scripts from the
-      investigation session can be re-run; see below.)
+- [x] End-to-end check per CLAUDE.md: real browser against the dev server —
+      New file → type name → Enter → `dialog-count=0`, focus on the trigger,
+      `hello-635.qmd` visible in the sidebar; Cancel-focused Enter →
+      `count=0` files created, dialog closed. (Repro scripts re-run
+      post-fix, 2026-08-31 session.)
 - [ ] Changelog: two-commit workflow — code commit first, then
       `hub-client/changelog.md` entry with the hash.
 

--- a/hub-client/changelog.md
+++ b/hub-client/changelog.md
@@ -25,6 +25,7 @@ WASM rebuild is needed for a changelog-only edit.
 
 ### 2026-08-31
 
+- [`1bb90e78`](https://github.com/quarto-dev/q2/commits/1bb90e78): Pressing Enter in the New File dialog no longer reopens the dialog after creating the file, and pressing Enter on its Cancel button no longer creates the file.
 - [`ccaa8cc9`](https://github.com/quarto-dev/q2/commits/ccaa8cc9): Math rendering now uses KaTeX 0.18.2 everywhere — the sandboxed preview bundle, the hub client, and the CDN link rendering emits for `html-math-method: katex` were all realigned onto one version.
 - [`ec152307`](https://github.com/quarto-dev/q2/commits/ec152307): The "opening…" label beside a project name now uses a writing-direction-aware offset, so it will sit on the correct side under right-to-left languages.
 

--- a/hub-client/e2e/new-file-dialog.harness.spec.ts
+++ b/hub-client/e2e/new-file-dialog.harness.spec.ts
@@ -1,0 +1,71 @@
+/**
+ * Enter-key interaction spec for the New File dialog (GH #635,
+ * bd-zcv0iea4), against the stateful `#/dev/dialog-new-file-stateful`
+ * harness route (trigger button + created-files record, mirroring the
+ * Editor wiring).
+ *
+ * This is the only tier where the reopen bug reproduces: the browser's
+ * default action for an un-prevented Enter keydown is a synthesized
+ * click on whatever holds focus once listeners and microtasks have run —
+ * by which time ModalDialog's focus restore has moved focus to the
+ * trigger button. jsdom performs no keyboard activation, so the unit
+ * tests in NewFileDialog.integration.test.tsx can only pin
+ * defaultPrevented; these specs pin the observable behavior.
+ */
+
+import { test, expect, type Page } from '@playwright/test';
+import { bootHarness } from './helpers/harness';
+
+// bootHarness does two page loads (identity pinning) against a shared dev
+// server; under full parallelism the default 30s budget is too tight.
+test.setTimeout(60_000);
+
+const TRIGGER = 'button.new-file-btn';
+const DIALOG = '.qh-dialog.new-file-dialog';
+
+async function openDialog(page: Page) {
+  await page.locator(TRIGGER).click();
+  await expect(page.locator(DIALOG)).toBeVisible();
+  // The dialog focuses the filename input on a 100ms timer; type through
+  // the locator (which waits) rather than racing the focus shift.
+  await page.locator('#filename').fill('notes.qmd');
+}
+
+test.beforeEach(async ({ page }) => {
+  await bootHarness(page, 'dialog-new-file-stateful', TRIGGER, 'light');
+});
+
+test('Enter in the filename input creates the file once and the dialog stays closed', async ({
+  page,
+}) => {
+  await openDialog(page);
+  await page.keyboard.press('Enter');
+
+  const created = page.getByTestId('created-files').locator('li');
+  await expect(created).toHaveText(['notes.qmd']);
+  // The bug: the keydown's default-action click lands on the focus-restored
+  // trigger and reopens the dialog within the same task — so by the time
+  // press() resolves, a buggy build already shows the dialog again.
+  await expect(page.locator(DIALOG)).toHaveCount(0);
+  await expect(page.locator(TRIGGER)).toBeFocused();
+});
+
+test('Enter on the Cancel button cancels without creating a file', async ({ page }) => {
+  await openDialog(page);
+  await page.getByRole('button', { name: 'Cancel' }).focus();
+  await page.keyboard.press('Enter');
+
+  await expect(page.locator(DIALOG)).toHaveCount(0);
+  await expect(page.getByTestId('created-files').locator('li')).toHaveCount(0);
+  await expect(page.locator(TRIGGER)).toBeFocused();
+});
+
+test('Enter on the Create button creates the file exactly once and closes', async ({ page }) => {
+  await openDialog(page);
+  await page.getByRole('button', { name: 'Create' }).focus();
+  await page.keyboard.press('Enter');
+
+  await expect(page.getByTestId('created-files').locator('li')).toHaveText(['notes.qmd']);
+  await expect(page.locator(DIALOG)).toHaveCount(0);
+  await expect(page.locator(TRIGGER)).toBeFocused();
+});

--- a/hub-client/src/components/DevHarness.tsx
+++ b/hub-client/src/components/DevHarness.tsx
@@ -580,6 +580,43 @@ function ReplayHarness() {
   );
 }
 
+/**
+ * Stateful NewFileDialog fixture (GH #635, bd-zcv0iea4): a real trigger
+ * button that owns `isOpen` state plus a visible record of created files,
+ * mirroring the Editor/FileSidebar wiring. Exists because the Enter-submit
+ * reopen bug is a browser-level interaction — close, focus-restore to the
+ * trigger, then the keydown's default-action click — that the static-props
+ * `dialog-new-file` route (and jsdom, which performs no keyboard
+ * activation) cannot express.
+ */
+function NewFileDialogStatefulHarness() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [created, setCreated] = useState<string[]>([]);
+  return (
+    <EditorChrome>
+      <div style={{ padding: 16 }}>
+        <button
+          className="qh-btn small outline new-file-btn"
+          onClick={() => setIsOpen(true)}
+        >
+          New file
+        </button>
+        <ul data-testid="created-files">
+          {created.map((path, i) => (
+            <li key={`${path}-${i}`}>{path}</li>
+          ))}
+        </ul>
+      </div>
+      <NewFileDialog
+        isOpen={isOpen}
+        existingPaths={FAKE_FILES.map((f) => f.path)}
+        onClose={() => setIsOpen(false)}
+        onCreateTextFile={(path) => setCreated((prev) => [...prev, path])}
+      />
+    </EditorChrome>
+  );
+}
+
 function EditorChrome({ children }: { children: React.ReactNode }) {
   return (
     <ViewModeProvider>
@@ -730,6 +767,7 @@ const DEV_PAGES: Record<string, () => React.ReactNode> = {
       />
     </EditorChrome>
   ),
+  'dialog-new-file-stateful': () => <NewFileDialogStatefulHarness />,
   'dialog-share': () => (
     <EditorChrome>
       <ShareDialog

--- a/hub-client/src/components/ModalDialog.tsx
+++ b/hub-client/src/components/ModalDialog.tsx
@@ -24,7 +24,19 @@ export interface ModalDialogProps {
   onClose: () => void;
   /** Extra class for the dialog element, e.g. 'new-file-dialog'. */
   className?: string;
-  /** Dialog-specific key handling (e.g. Enter to submit). Escape and Tab are owned by ModalDialog. */
+  /**
+   * Dialog-specific key handling (e.g. Enter to submit). Escape and Tab
+   * are owned by ModalDialog.
+   *
+   * Contract for Enter-submit handlers: a handler that synchronously
+   * closes the dialog MUST call `e.preventDefault()`. Enter's default
+   * action is a synthesized click delivered after listeners and
+   * microtasks — by which point the close has run and this component has
+   * restored focus to the trigger, so the un-prevented click lands on
+   * the trigger and reopens the dialog (GH #635). Handlers should also
+   * ignore keydowns whose target is a button, or the button's own
+   * activation runs on top of the submit (Enter on Cancel would submit).
+   */
   onKeyDown?: (e: KeyboardEvent<HTMLDivElement>) => void;
   /** Extra attributes forwarded to the dialog element (e.g. drag/drop handlers). */
   dialogProps?: HTMLAttributes<HTMLDivElement>;

--- a/hub-client/src/components/NewFileDialog.integration.test.tsx
+++ b/hub-client/src/components/NewFileDialog.integration.test.tsx
@@ -318,6 +318,70 @@ describe('NewFileDialog', () => {
     });
   });
 
+  describe('Enter key handling (GH #635, bd-zcv0iea4)', () => {
+    // The browser's default action for an un-prevented Enter keydown is a
+    // synthesized click on whatever is focused when the default action is
+    // processed. Because closing the dialog restores focus to the trigger
+    // button (ModalDialog's WCAG contract), an un-prevented Enter-submit
+    // reopens the dialog. jsdom performs no keyboard activation, so the
+    // reopen itself can't reproduce here; instead these tests pin the
+    // mechanism: fireEvent returns `!event.defaultPrevented`.
+    it('submits on Enter in the filename input, closes, and prevents the default action', () => {
+      render(<NewFileDialog {...defaultProps} />);
+
+      const filenameInput = screen.getByLabelText('Filename:');
+      fireEvent.change(filenameInput, { target: { value: 'notes.qmd' } });
+      const notPrevented = fireEvent.keyDown(filenameInput, { key: 'Enter' });
+
+      expect(defaultProps.onCreateTextFile).toHaveBeenCalledWith('notes.qmd', '');
+      expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
+      expect(notPrevented).toBe(false);
+    });
+
+    it('does not submit when Enter is pressed on the Cancel button', () => {
+      render(<NewFileDialog {...defaultProps} />);
+
+      const filenameInput = screen.getByLabelText('Filename:');
+      fireEvent.change(filenameInput, { target: { value: 'notes.qmd' } });
+
+      // The user tabs to Cancel and presses Enter: the keydown bubbles to
+      // the dialog container, whose Enter handler must not treat it as a
+      // submit — the button's own (native) activation is the intent.
+      const cancelButton = screen.getByRole('button', { name: 'Cancel' });
+      cancelButton.focus();
+      fireEvent.keyDown(cancelButton, { key: 'Enter' });
+
+      expect(defaultProps.onCreateTextFile).not.toHaveBeenCalled();
+    });
+
+    it('does not double-submit when Enter is pressed on the Create button', () => {
+      render(<NewFileDialog {...defaultProps} />);
+
+      const filenameInput = screen.getByLabelText('Filename:');
+      fireEvent.change(filenameInput, { target: { value: 'notes.qmd' } });
+
+      // Enter on the focused Create button activates it natively (a click,
+      // which jsdom doesn't synthesize); the bubbled keydown must not ALSO
+      // run the submit handler, or real browsers create the file twice.
+      const createButton = screen.getByRole('button', { name: 'Create' });
+      createButton.focus();
+      fireEvent.keyDown(createButton, { key: 'Enter' });
+
+      expect(defaultProps.onCreateTextFile).not.toHaveBeenCalled();
+    });
+
+    it('shows the validation error and stays open on Enter with an empty filename', () => {
+      render(<NewFileDialog {...defaultProps} />);
+
+      const filenameInput = screen.getByLabelText('Filename:');
+      fireEvent.keyDown(filenameInput, { key: 'Enter' });
+
+      expect(defaultProps.onCreateTextFile).not.toHaveBeenCalled();
+      expect(defaultProps.onClose).not.toHaveBeenCalled();
+      expect(screen.getByText('Filename is required')).toBeInTheDocument();
+    });
+  });
+
   describe('accessibility semantics', () => {
     it('exposes role="dialog" with aria-modal and the title as accessible name', () => {
       render(<NewFileDialog {...defaultProps} />);

--- a/hub-client/src/components/NewFileDialog.tsx
+++ b/hub-client/src/components/NewFileDialog.tsx
@@ -113,6 +113,14 @@ export default function NewFileDialog({
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if (e.key === 'Enter') {
+        // Keydowns from a focused button bubble here too; those belong to
+        // the button's own activation (Cancel must not create a file, and
+        // Create must not fire twice).
+        if (e.target instanceof HTMLButtonElement) return;
+        // Un-prevented, Enter's default action is a synthesized click on
+        // whatever is focused after close — the focus-restored trigger
+        // button — which reopens the dialog (GH #635).
+        e.preventDefault();
         handleCreateTextFile();
       }
     },

--- a/hub-client/src/components/ShareDialog.test.tsx
+++ b/hub-client/src/components/ShareDialog.test.tsx
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { render, screen, cleanup } from '@testing-library/react';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
 import ShareDialog from './ShareDialog';
 
 afterEach(cleanup);
@@ -38,5 +38,43 @@ describe('ShareDialog accessibility', () => {
   it('does not render when closed', () => {
     render(<ShareDialog {...defaultProps} isOpen={false} />);
     expect(screen.queryByRole('dialog')).toBeNull();
+  });
+});
+
+describe('ShareDialog Enter handling (GH #635 hardening)', () => {
+  // Same contract as NewFileDialog (see ModalDialog's onKeyDown docs):
+  // prevent Enter's default-action click, and leave button keydowns to
+  // the button's own activation. ShareDialog's close is deferred 500ms
+  // so the reopen bug can't bite today; these tests keep it that way if
+  // the delay ever goes away.
+  const stubClipboard = () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+    return writeText;
+  };
+
+  it('copies on Enter in the URL input and prevents the default action', () => {
+    const writeText = stubClipboard();
+    render(<ShareDialog {...defaultProps} />);
+
+    const urlInput = screen.getByDisplayValue(defaultProps.shareableUrl);
+    const notPrevented = fireEvent.keyDown(urlInput, { key: 'Enter' });
+
+    expect(writeText).toHaveBeenCalledWith(defaultProps.shareableUrl);
+    expect(notPrevented).toBe(false);
+  });
+
+  it('does not copy when Enter is pressed on the close button', () => {
+    const writeText = stubClipboard();
+    render(<ShareDialog {...defaultProps} />);
+
+    const closeButton = screen.getByRole('button', { name: 'Close' });
+    closeButton.focus();
+    fireEvent.keyDown(closeButton, { key: 'Enter' });
+
+    expect(writeText).not.toHaveBeenCalled();
   });
 });

--- a/hub-client/src/components/ShareDialog.tsx
+++ b/hub-client/src/components/ShareDialog.tsx
@@ -76,6 +76,13 @@ export default function ShareDialog({
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if (e.key === 'Enter') {
+        // Buttons handle their own Enter activation (see the onKeyDown
+        // contract in ModalDialog). The copy path only closes after a
+        // 500ms success-state delay, but prevent the default anyway so
+        // the synthesized click can never land on the restore target if
+        // that delay ever goes away (GH #635 hardening).
+        if (e.target instanceof HTMLButtonElement) return;
+        e.preventDefault();
         handleCopyLink();
       }
     },


### PR DESCRIPTION
Fixes #635. Braid strand: bd-zcv0iea4.

## The bug

- **Enter in the filename input**: the file was created and the dialog closed — then immediately **reopened**, empty.
- **Bonus defect found while root-causing**: **Enter with focus on the Cancel button created the file anyway** (the dialog-level keydown handler fires on bubble regardless of target).

## Root cause

The Enter handler in `NewFileDialog` never called `e.preventDefault()`. An un-prevented Enter keydown has a browser *default action*: a synthesized click delivered after listeners and microtasks — by which point the close had run and `ModalDialog`'s (correct, WCAG-mandated) focus restore had moved focus to the sidebar's New-file trigger. The click landed on the trigger and reopened the dialog. Captured event trace in headless Chromium:

```
keydown Enter on filename input          ← handler creates file, closes dialog
focusin on .new-file-btn                 ← ModalDialog focus restore (microtask)
click on .new-file-btn (detail=0, trusted) ← Enter's default action → reopens
```

## The fix

- `NewFileDialog`: ignore Enter keydowns whose target is a button (their own activation is the intent — fixes the Cancel defect), and `preventDefault()` before submitting (fixes the reopen).
- `ModalDialog`: document the preventDefault-on-close contract on the `onKeyDown` prop so the bug class doesn't recur.
- `ShareDialog`: same guard as hardening — its 500 ms deferred close currently masks the reopen; the guard removes the latent trap. (Other Enter handlers audited: inline renames are non-modal and unaffected.)

## Tests (written first, verified failing)

- 4 jsdom unit tests in `NewFileDialog.integration.test.tsx` (jsdom performs no keyboard activation, so these pin the mechanism via `defaultPrevented` plus the no-submit-from-buttons guard); 2 in `ShareDialog.test.tsx`.
- A stateful DevHarness route (`dialog-new-file-stateful`) + 3-test browser-level spec `e2e/new-file-dialog.harness.spec.ts` — the only tier where the real reopen reproduces (all 3 failed pre-fix). Auto-wired into CI's existing harness-test step.

## Verification

- `cargo xtask verify`: all 14 steps green.
- Full harness suite: 165/165.
- End-to-end in the real editor (Playwright against `vite dev` + local hub): Enter creates the file once, dialog stays closed, focus returns to the trigger; Cancel-focused Enter creates nothing.

Plan with full investigation notes: `claude-notes/plans/2026-08-31-newfile-dialog-enter-reopen.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lx6stJWPKRZhzkWKnjEqJG