### PR TITLE
Accept fenced divs whose colons are not followed by whitespace

### DIFF
--- a/crates/pampa/tests/integration/main.rs
+++ b/crates/pampa/tests/integration/main.rs
@@ -47,6 +47,7 @@ pub mod test_editorial_mark_spacing;
 pub mod test_email_autolink;
 pub mod test_emphasis_opening_mark;
 pub mod test_error_corpus;
+pub mod test_fenced_div_no_space;
 pub mod test_figure_figcaption_synthesis;
 pub mod test_grid_table_error;
 pub mod test_hard_soft_break;

--- a/crates/pampa/tests/integration/test_fenced_div_no_space.rs
+++ b/crates/pampa/tests/integration/test_fenced_div_no_space.rs
@@ -1,0 +1,157 @@
+/*
+ * test_fenced_div_no_space.rs
+ * Copyright (c) 2026 Posit, PBC
+ *
+ * A fenced div's colons do not have to be followed by whitespace. Pandoc and
+ * Quarto 1 accept `:::{.foo}` and `:::foo` as readily as `::: {.foo}`, and so
+ * must we. The scanner used to swallow a paragraph-following colon run into
+ * the soft-line-break token, which erased the opening line — silently when no
+ * closing fence followed it, and as a parse error at the *closing* fence when
+ * one did (bd-div-attr-no-space-ne0fudkw).
+ */
+
+use pampa::pandoc::{Block, Inline};
+use pampa::readers;
+
+fn parse(input: &str) -> Vec<Block> {
+    let (pandoc, _context, _warnings) = readers::qmd::read(
+        input.as_bytes(),
+        false,
+        "test.qmd",
+        &mut std::io::sink(),
+        true,
+        None,
+    )
+    .unwrap_or_else(|diags| {
+        panic!(
+            "expected a clean parse, got: {:?}",
+            diags
+                .iter()
+                .map(|d| (d.code.clone(), d.problem.clone()))
+                .collect::<Vec<_>>()
+        )
+    });
+    pandoc.blocks
+}
+
+/// The classes of the first top-level `Div`. The bug's signature is that the
+/// opening line disappears and the body degrades to a bare paragraph, so
+/// insisting on a *top-level* div is the point of the assertion.
+fn first_div_classes(blocks: &[Block]) -> Vec<String> {
+    for block in blocks {
+        if let Block::Div(div) = block {
+            return div.attr.1.clone();
+        }
+    }
+    panic!("no Div among the top-level blocks: {blocks:#?}");
+}
+
+fn plain_text(blocks: &[Block]) -> String {
+    fn walk(inlines: &[Inline], out: &mut String) {
+        for inline in inlines {
+            match inline {
+                Inline::Str(s) => out.push_str(&s.text),
+                Inline::Space(_) | Inline::SoftBreak(_) | Inline::LineBreak(_) => out.push(' '),
+                Inline::Code(c) => out.push_str(&c.text),
+                Inline::Emph(e) => walk(&e.content, out),
+                Inline::Strong(s) => walk(&s.content, out),
+                Inline::Span(s) => walk(&s.content, out),
+                _ => {}
+            }
+        }
+    }
+    let mut out = String::new();
+    for block in blocks {
+        match block {
+            Block::Paragraph(p) => {
+                walk(&p.content, &mut out);
+                out.push('\n');
+            }
+            Block::Plain(p) => {
+                walk(&p.content, &mut out);
+                out.push('\n');
+            }
+            Block::Div(d) => out.push_str(&plain_text(&d.content)),
+            _ => {}
+        }
+    }
+    out
+}
+
+#[test]
+fn attribute_block_with_no_space_opens_a_div() {
+    let blocks = parse("Before.\n\n:::{.myclass}\nInside.\n:::\n");
+    assert_eq!(first_div_classes(&blocks), vec!["myclass".to_string()]);
+}
+
+#[test]
+fn bare_info_string_with_no_space_opens_a_div() {
+    let blocks = parse("Before.\n\n:::foo\nInside.\n:::\n");
+    assert_eq!(first_div_classes(&blocks), vec!["foo".to_string()]);
+}
+
+#[test]
+fn spaced_forms_still_open_a_div() {
+    assert_eq!(
+        first_div_classes(&parse("Before.\n\n::: {.foo}\nInside.\n:::\n")),
+        vec!["foo".to_string()]
+    );
+    assert_eq!(
+        first_div_classes(&parse("Before.\n\n::: foo\nInside.\n:::\n")),
+        vec!["foo".to_string()]
+    );
+}
+
+/// The silent half of the bug: with no closing fence the parse succeeded, the
+/// class vanished, and the body came out as bare prose.
+#[test]
+fn no_space_and_no_closing_fence_still_opens_a_div() {
+    let blocks = parse("Before.\n\n:::{.myclass}\nInside.\n");
+    assert_eq!(first_div_classes(&blocks), vec!["myclass".to_string()]);
+    let text = plain_text(&blocks);
+    assert!(text.contains("Inside."), "body text was dropped: {text:?}");
+}
+
+/// A div opened without a space still fences off what follows it, so a code
+/// block after the div is a code block and not a cascade of parse errors
+/// pointing into its contents.
+#[test]
+fn a_code_fence_after_a_tight_div_is_unaffected() {
+    let blocks = parse("Before.\n\n:::{.foo}\nInside.\n:::\n\n```json\n{ \"a\": 1 }\n```\n");
+    assert_eq!(first_div_classes(&blocks), vec!["foo".to_string()]);
+    assert!(
+        blocks
+            .iter()
+            .any(|b| matches!(b, Block::CodeBlock(c) if c.text.contains("\"a\": 1"))),
+        "expected a json code block among {blocks:#?}"
+    );
+}
+
+/// Colon runs that open nothing are ordinary text and must survive verbatim.
+/// The same swallow that ate `:::` ate these — `:hello` rendered as `hello`.
+#[test]
+fn colon_runs_that_open_no_block_stay_in_the_paragraph() {
+    let text = plain_text(&parse("Before.\n\n:hello\n::world\n"));
+    assert!(
+        text.contains(":hello"),
+        "leading colon was dropped: {text:?}"
+    );
+    assert!(
+        text.contains("::world"),
+        "leading colons were dropped: {text:?}"
+    );
+}
+
+/// A single colon followed by a space is a caption marker, and must keep
+/// interrupting the paragraph above it rather than being absorbed as
+/// continuation text. (A caption with nothing to attach to is reported and
+/// dropped downstream, which is why this asserts on what does *not* reach the
+/// paragraph.)
+#[test]
+fn a_caption_still_interrupts_a_paragraph() {
+    let text = plain_text(&parse("Before.\n\n: A caption\n"));
+    assert!(
+        !text.contains("A caption"),
+        "the caption line was absorbed into the paragraph: {text:?}"
+    );
+}

--- a/crates/tree-sitter-qmd/tree-sitter-markdown/src/scanner.c
+++ b/crates/tree-sitter-qmd/tree-sitter-markdown/src/scanner.c
@@ -2846,17 +2846,25 @@ static bool scan(Scanner *s, TSLexer *lexer, const bool *valid_symbols) {
             // but the pipe_table_row rule's "single cell, no `|`" alternative
             // will otherwise eat `:::` as cell content (3 × pandoc_str).
             //
-            // To avoid that, peek (without mark_end) for a `:::` run followed
-            // by inline whitespace / newline / EOF. If we see one, fall
-            // through to the LINE_ENDING path below so the pipe_table
-            // terminates via its `choice(_newline, _eof)` tail. The parser
-            // then proceeds to a state where FENCED_DIV_END is valid and
-            // parse_fenced_div_marker can emit it on the next scan call —
-            // for bare `:::` outside a fenced div, FENCED_DIV_END is not
-            // valid and the line errors out at a sensible place rather than
-            // silently producing a phantom row.
+            // To avoid that, peek (without mark_end) for a `:::` run. If we
+            // see one, fall through to the LINE_ENDING path below so the
+            // pipe_table terminates via its `choice(_newline, _eof)` tail.
+            // The parser then proceeds to a state where FENCED_DIV_END is
+            // valid and parse_fenced_div_marker can emit it on the next scan
+            // call — for bare `:::` outside a fenced div, FENCED_DIV_END is
+            // not valid and the line errors out at a sensible place rather
+            // than silently producing a phantom row.
             bool next_line_is_fenced_div_marker = false;
+            // Whether the peek below consumed a colon run, and whether that
+            // run opens a block. Both soft-break gates need these because the
+            // peek advances the lexer: after it, `lexer->lookahead` is the
+            // character AFTER the colons, so the gates' own `!= ':'` tests
+            // can no longer see that the line started with one (bd-div-attr-
+            // no-space-ne0fudkw).
+            bool peeked_colon_run = false;
+            bool colon_run_opens_block = false;
             if (lexer->lookahead == ':') {
+                peeked_colon_run = true;
                 int level = 0;
                 // Match parse_fenced_div_marker's unbounded colon-run count.
                 // pandoc allows arbitrary fence widths for nested divs.
@@ -2864,13 +2872,27 @@ static bool scan(Scanner *s, TSLexer *lexer, const bool *valid_symbols) {
                     advance(s, lexer);
                     level++;
                 }
-                if (level >= 3 && (lexer->eof(lexer) ||
-                                   lexer->lookahead == ' ' ||
-                                   lexer->lookahead == '\t' ||
-                                   lexer->lookahead == '\n' ||
-                                   lexer->lookahead == '\r')) {
+                bool followed_by_ws_or_eol = (lexer->eof(lexer) ||
+                                              lexer->lookahead == ' ' ||
+                                              lexer->lookahead == '\t' ||
+                                              lexer->lookahead == '\n' ||
+                                              lexer->lookahead == '\r');
+                // A run of three or more colons is a fenced-div marker
+                // whatever follows it: `:::{.foo}`, `:::foo` and `::: foo`
+                // are all div openers (pandoc and Quarto 1 accept all three),
+                // and a bare `:::` is a closer. Requiring whitespace here
+                // used to make the tight forms invisible to the gates below.
+                if (level >= 3) {
                     next_line_is_fenced_div_marker = true;
                 }
+                // The colon run opens a block when it is a fenced-div marker
+                // or a caption start (`: caption`, matched by
+                // parse_fenced_div_marker's level == 1 branch). Anything else
+                // — `::`, or a single `:` glued to a word — is ordinary text
+                // and must stay inside the paragraph.
+                colon_run_opens_block =
+                    next_line_is_fenced_div_marker ||
+                    (level == 1 && followed_by_ws_or_eol);
                 // No mark_end past the peeked colons: tree-sitter rewinds to
                 // the last mark_end (set at line 2341, post-newline /
                 // pre-indent) between scan calls, so the advance is undone
@@ -2919,8 +2941,22 @@ static bool scan(Scanner *s, TSLexer *lexer, const bool *valid_symbols) {
             // markers — see OrderedMarkerPeek.
             bool first_starts_with_marker_block = false;
             bool first_marker_interrupts = false;
+            // Set when the line's first character is ':' and the colon run
+            // opens a block. Both gates test this instead of comparing
+            // first_lookahead against ':', because the colon peek above has
+            // already advanced past the run.
+            bool first_starts_with_colon_block = false;
             bool first_peeked = false;
-            if (lexer->lookahead == '`') {
+            if (peeked_colon_run) {
+                // Restore the line's real first character for the gates, and
+                // take the PEEKED emission path so the mark_end below cannot
+                // absorb the colon run into the SOFT_LINE_ENDING token. That
+                // absorption is how `:::{.foo}` after a paragraph used to
+                // vanish from the tree entirely, opening line and all.
+                first_lookahead = ':';
+                first_starts_with_colon_block = colon_run_opens_block;
+                first_peeked = true;
+            } else if (lexer->lookahead == '`') {
                 int level = 0;
                 while (lexer->lookahead == '`' && level < 3) {
                     advance(s, lexer);
@@ -3054,7 +3090,7 @@ static bool scan(Scanner *s, TSLexer *lexer, const bool *valid_symbols) {
                  (first_lookahead != '*' || !first_starts_with_star_block) &&
                  !first_starts_with_marker_block &&
                  first_lookahead != '>' &&
-                 first_lookahead != ':' && first_lookahead != '#' &&
+                 !first_starts_with_colon_block && first_lookahead != '#' &&
                  !first_starts_with_fence &&
                  first_lookahead > ' ')) {
                 s->state |= STATE_WAS_SOFT_LINE_BREAK;
@@ -3149,6 +3185,8 @@ static bool scan(Scanner *s, TSLexer *lexer, const bool *valid_symbols) {
             bool second_starts_with_fence;
             bool second_starts_with_star_block;
             bool second_starts_with_marker_block;
+            // Mirrors first_starts_with_colon_block; see gate 1.
+            bool second_starts_with_colon_block;
             // True when a peek (here or in the first gate) advanced the lexer
             // past the line's opening run. Gates the mark_end below.
             bool second_peeked;
@@ -3163,12 +3201,17 @@ static bool scan(Scanner *s, TSLexer *lexer, const bool *valid_symbols) {
                 // s->indentation holds exactly that residual.
                 second_starts_with_marker_block =
                     first_marker_interrupts && s->indentation <= 3;
+                second_starts_with_colon_block = first_starts_with_colon_block;
                 second_peeked = true;
             } else {
                 second_lookahead = lexer->lookahead;
                 second_starts_with_fence = false;
                 second_starts_with_star_block = false;
                 second_starts_with_marker_block = false;
+                // Nothing peeked past a colon run on this path (match_line
+                // only consumes block prefixes like `> `), so the lookahead
+                // still shows the line's first content character.
+                second_starts_with_colon_block = (second_lookahead == ':');
                 second_peeked = false;
                 if (lexer->lookahead == '`') {
                     int level = 0;
@@ -3246,7 +3289,7 @@ static bool scan(Scanner *s, TSLexer *lexer, const bool *valid_symbols) {
                  ((second_lookahead != '*' || !second_starts_with_star_block) &&
                   !second_starts_with_marker_block &&
                   second_lookahead != '>' &&
-                  second_lookahead != ':' && second_lookahead != '#' &&
+                  !second_starts_with_colon_block && second_lookahead != '#' &&
                   !second_starts_with_fence &&
                   second_lookahead > ' '))) {
                 s->indentation = 0;

--- a/crates/tree-sitter-qmd/tree-sitter-markdown/test/corpus/div.txt
+++ b/crates/tree-sitter-qmd/tree-sitter-markdown/test/corpus/div.txt
@@ -101,3 +101,84 @@ div.txt: 5 Interruption closes many many blocks
                       (pandoc_paragraph
                         (pandoc_str)
                         (block_continuation)))))))))))
+================================================================================
+div.txt: 6 No whitespace after the colons, attribute block, after a paragraph
+================================================================================
+Before.
+
+:::{.foo}
+Inside.
+:::
+--------------------------------------------------------------------------------
+    (document
+      (section
+        (pandoc_paragraph
+          (pandoc_str))
+        (pandoc_div
+          (attribute_specifier
+            (commonmark_specifier
+              (attribute_class)))
+          (block_continuation)
+          (pandoc_paragraph
+            (pandoc_str)
+            (block_continuation)))))
+
+================================================================================
+div.txt: 7 No whitespace after the colons, bare info string
+================================================================================
+Before.
+
+:::foo
+Inside.
+:::
+--------------------------------------------------------------------------------
+    (document
+      (section
+        (pandoc_paragraph
+          (pandoc_str))
+        (pandoc_div
+          (info_string)
+          (block_continuation)
+          (pandoc_paragraph
+            (pandoc_str)
+            (block_continuation)))))
+
+================================================================================
+div.txt: 8 No whitespace and no closing fence
+================================================================================
+Before.
+
+:::{.myclass}
+Inside.
+--------------------------------------------------------------------------------
+    (document
+      (section
+        (pandoc_paragraph
+          (pandoc_str))
+        (pandoc_div
+          (attribute_specifier
+            (commonmark_specifier
+              (attribute_class)))
+          (block_continuation)
+          (pandoc_paragraph
+            (pandoc_str)))))
+
+================================================================================
+div.txt: 9 A colon run that opens no block stays in the paragraph
+================================================================================
+Before.
+
+:hello
+::world
+--------------------------------------------------------------------------------
+    (document
+      (section
+        (pandoc_paragraph
+          (pandoc_str))
+        (pandoc_paragraph
+          (pandoc_str)
+          (pandoc_str)
+          (pandoc_soft_break)
+          (pandoc_str)
+          (pandoc_str)
+          (pandoc_str))))


### PR DESCRIPTION
`:::{.callout-note}` and `:::foo` are valid fenced-div openers in pandoc and Quarto 1. q2 accepted only the spaced forms, and what it did with the tight form depended on whether a closing fence followed.

With one, the render died with an uncoded `unexpected character or token here` reported at the *closing* `:::` — several lines past the line that actually differed — and the error cascaded into unrelated code fences below it, producing errors that pointed at JSON and JavaScript inside code blocks and read like "q2 parses markdown inside code blocks."

With no closing fence, the render succeeded. Exit 0, no diagnostics, and no div: the opening line, its classes and its attributes were gone from the output, and the body survived as bare prose. A callout became an unstyled paragraph with nothing anywhere to say so.

The cause is in the block scanner's soft-line-break handling, not in the grammar. Before deciding whether a line break ends the paragraph above it, the scanner peeks at the next line to see whether it opens a block. For a line starting with `:` that peek walks the whole colon run, and it did so without restoring the lexer — so by the time the two soft-break gates read the lookahead, they saw the character *after* the colons. For `::: {.foo}` that is a space, which fails the gates and correctly ends the paragraph. For `:::{.foo}` it is `{`, which passes them, and the scanner emitted a soft line break whose token range had been extended over the colons, swallowing the fence marker whole.

The peek now records what it consumed and hands both gates the line's real first character, and the emission takes the path that leaves peeked text outside the token — the same `first_peeked` convention the backtick, `*`, `-`/`+`, digit and `[` peeks in that block already follow. No new lookahead is introduced. The fenced-div test also drops its "followed by whitespace" requirement: three or more colons open a div whatever comes next.

All four spellings now produce the div, matching pandoc and Quarto 1:

| | before | after |
|---|---|---|
| `:::{.foo}` | 1 error | `<div class="foo">` |
| `:::foo` | 1 error | `<div class="foo">` |
| `::: {.foo}` | `<div class="foo">` | `<div class="foo">` |
| `::: foo` | `<div class="foo">` | `<div class="foo">` |

The same swallow ate colon runs that open nothing at all, which is a second silent content loss on the same code path: `:hello` in the middle of a paragraph rendered as `hello`, and `::world` as `world`. Those runs now stay in the paragraph verbatim, while `: caption` keeps interrupting it as before.

## Verification

The minimal repro's five fixtures all render clean, where before they were 3 errors / clean / 1 error / no block emitted:

```
repro.qmd        clean   <div class="callout callout-style-default callout-note ...
control.qmd      clean   <div class="callout callout-style-default callout-note ...
infostring.qmd   clean   <div class="foo">
silent.qmd       clean   <div class="myclass">
codefence.qmd    clean   <pre class="foo code-with-copy">; <pre class="foo ...
```

Checked by hand through the binary as well: nested tight divs, a tight div in a blockquote, in a list item, and immediately after a pipe-table row.

`tree-sitter test` 613/613. `cargo nextest run --workspace` 13490 passed, 0 failed — `main` lists 13483, so the delta is exactly the 7 tests added here. `cargo clippy --workspace --all-targets -- -D warnings` clean, `cargo xtask lint` clean, `cargo xtask verify` (including the WASM and hub-client legs) all steps passed.

## Tests

Four corpus cases in `div.txt` — tight attribute block, tight info string, tight opener with no closer, and a colon run that opens nothing — plus seven reader-level cases in pampa covering all four spellings, the no-closing-fence path, a code fence following a tight div, colon-run preservation, and caption interruption.

## Not in scope

A genuinely malformed attribute block (`:::{.foo` with no closing brace) still produces an uncoded "unexpected character or token here" pointing one line past the opener. That is identical for `::: {.foo`, so it is not a whitespace divergence — pre-existing and unchanged here.

Fixes bd-div-attr-no-space-ne0fudkw. Does not touch the shortcode path (bd-shortcode-no-space-gspu6l5s).
