### PR TITLE
Add a qmd-syntax-helper rule for Q-2-52

### DIFF
--- a/crates/qmd-syntax-helper/src/conversions/mod.rs
+++ b/crates/qmd-syntax-helper/src/conversions/mod.rs
@@ -23,5 +23,6 @@ pub mod q_2_26;
 pub mod q_2_28;
 pub mod q_2_33;
 pub mod q_2_5;
+pub mod q_2_52;
 pub mod q_2_7;
 pub mod reference_links;

--- a/crates/qmd-syntax-helper/src/conversions/q_2_52.rs
+++ b/crates/qmd-syntax-helper/src/conversions/q_2_52.rs
@@ -1,0 +1,383 @@
+// Q-2-52: Shortcode delimiter not separated by a space
+//
+// A shortcode's delimiters take a space on the inside: `{{< fa plus >}}`,
+// not `{{<fa plus>}}`. Quarto 1 matched shortcodes with a regular
+// expression and tolerated the tight spelling, so documents ported from
+// it arrive full of them.
+//
+// Error catalog entry: crates/quarto-error-catalog/error_catalog.json
+// Error code: Q-2-52
+//
+// Example:
+//   Input:  Click the {{<fa plus>}} icon.
+//   Output: Click the {{< fa plus >}} icon.
+//
+// Both delimiters matter. Spacing only the opening one leaves
+// `{{< fa plus>}}`, which is still a parse error — so this rule keeps
+// going until the file has no Q-2-52 left rather than fixing one side.
+
+use anyhow::{Context, Result};
+use std::path::Path;
+
+use crate::rule::{CheckResult, ConvertResult, Rule, SourceLocation};
+use crate::utils::file_io::read_file;
+
+pub struct Q252Converter {}
+
+#[derive(Debug, Clone)]
+struct Q252Violation {
+    /// Offset in the *original* content where a space is missing.
+    offset: usize,
+    location: SourceLocation,
+}
+
+/// A missing separator leaves the parser desynchronised, so Quarto reports
+/// one Q-2-52 per parse and stops — see `desynchronizes` in the error
+/// corpus. A file with seven tight shortcodes therefore needs seven passes
+/// to enumerate them, which is what `analyze` does. The bound only exists
+/// so that a diagnostic which somehow survives its own fix cannot spin.
+///
+/// One pass is one full parse, so the cost is quadratic in the number of
+/// violations: roughly 0.12s for ten of them in a debug build, 1.4s for
+/// eighty. That is the right trade for a one-shot migration tool, but it
+/// is worth knowing before pointing it at something enormous.
+const MAX_PASSES: usize = 10_000;
+
+impl Q252Converter {
+    pub fn new() -> Result<Self> {
+        Ok(Self {})
+    }
+
+    /// Find every missing separator, and return the corrected content.
+    ///
+    /// Both spellings are fixed by the same edit: Quarto blames the
+    /// character where the space belongs — the one right after `{{<`, or
+    /// the `>` of `>}}` — so inserting a single space at the reported
+    /// offset is the whole repair. Re-parsing after each insertion is
+    /// what keeps a code span such as `` `{{<fa plus>}}` `` untouched:
+    /// its contents are not parsed as a shortcode, so they never produce
+    /// a diagnostic to act on.
+    fn analyze(&self, content: &str, filename: &str) -> Result<(Vec<Q252Violation>, String)> {
+        let mut violations: Vec<Q252Violation> = Vec::new();
+        let mut working = content.to_string();
+
+        for _ in 0..MAX_PASSES {
+            let Some(offset) = first_missing_separator(&working, filename) else {
+                break;
+            };
+            // Inserting at, or slicing on, a byte that is not a character
+            // boundary would panic. Tree-sitter reports boundaries, so
+            // this is a guard rather than an expected path.
+            debug_assert!(
+                working.is_char_boundary(offset),
+                "tree-sitter reported an offset inside a character: {offset}"
+            );
+            if !working.is_char_boundary(offset) {
+                break;
+            }
+
+            // Offsets are monotone across passes: the earliest remaining
+            // Q-2-52 is reported each time, and fixing one never creates
+            // an earlier one. That is what makes `offset - inserted` the
+            // position in the original content. Bail rather than record a
+            // wrong location if the assumption is ever violated.
+            let inserted = violations.len();
+            let Some(original_offset) = offset.checked_sub(inserted) else {
+                break;
+            };
+            debug_assert!(
+                content.is_char_boundary(original_offset),
+                "mapped offset {original_offset} is inside a character"
+            );
+            if !content.is_char_boundary(original_offset) {
+                break;
+            }
+            debug_assert!(
+                violations
+                    .last()
+                    .is_none_or(|previous| original_offset >= previous.offset),
+                "offsets went backwards at {original_offset}"
+            );
+            if violations
+                .last()
+                .is_some_and(|previous| original_offset < previous.offset)
+            {
+                break;
+            }
+
+            violations.push(Q252Violation {
+                offset: original_offset,
+                location: SourceLocation {
+                    row: row_of(content, original_offset),
+                    column: column_of(content, original_offset),
+                },
+            });
+            working.insert(offset, ' ');
+        }
+
+        Ok((violations, working))
+    }
+
+    fn violations_for(&self, file_path: &Path) -> Result<(Vec<Q252Violation>, String)> {
+        let content = read_file(file_path)?;
+        self.analyze(&content, &file_path.to_string_lossy())
+            .with_context(|| format!("Failed to analyze {}", file_path.display()))
+    }
+}
+
+/// The offset of the first missing shortcode separator in `content` that
+/// this rule is willing to repair, if any.
+fn first_missing_separator(content: &str, filename: &str) -> Option<usize> {
+    let fenced = fenced_code_ranges(content);
+    let result = pampa::readers::qmd::read(
+        content.as_bytes(),
+        false, // not loose mode
+        filename,
+        &mut std::io::sink(),
+        // Don't prune. Pruning keeps one diagnostic per ERROR node, so an
+        // unrelated error earlier in the file hides every Q-2-52 after it,
+        // and the rule reports a document with real violations as clean.
+        // `q-2-28` makes the same call for the same reason.
+        false,
+        None,
+    );
+
+    let diagnostics = match result {
+        Ok(_) => return None,
+        Err(diagnostics) => diagnostics,
+    };
+
+    diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.code.as_deref() == Some("Q-2-52"))
+        .filter_map(|diagnostic| diagnostic.location.as_ref()?.resolve_byte_range())
+        // The file id is discarded: this rule parses exactly one file with
+        // no parent context, so any resolved span is necessarily in it and
+        // the offset applies to `content` directly.
+        .map(|(_file_id, start_offset, _end_offset)| start_offset)
+        .filter(|offset| {
+            !fenced
+                .iter()
+                .any(|(start, end)| offset >= start && offset < end)
+        })
+        .min()
+}
+
+/// Byte ranges covered by fenced code blocks, found by scanning lines
+/// rather than by asking the parser.
+///
+/// A tight shortcode inside a fence is someone showing the syntax, and it
+/// must survive the conversion. In a document whose only fault is the
+/// missing separator the parser already protects it — fence content is
+/// not parsed as inline, so it raises no diagnostic. But one unrelated
+/// error anywhere in the file (a literal brace run, a space in a link
+/// target) desynchronises the parser far enough that the fence stops
+/// being recognised as a fence, and its contents begin reporting Q-2-52.
+/// Editing them would silently rewrite a documented example. A line scan
+/// still sees the fence in that case, which is the point of not going
+/// through the parser here.
+///
+/// The scan is deliberately generous — any line whose first non-space run
+/// is three or more backticks or tildes toggles the state — because
+/// over-including means the rule declines to fix something, while
+/// under-including means it rewrites something it should not.
+fn fenced_code_ranges(content: &str) -> Vec<(usize, usize)> {
+    let mut ranges = Vec::new();
+    let mut open: Option<(char, usize, usize)> = None; // fence char, run length, start offset
+    let mut offset = 0;
+
+    for line in content.split_inclusive('\n') {
+        let trimmed = line.trim_start_matches(' ');
+        let indent = line.len() - trimmed.len();
+        let fence = if indent <= 3 {
+            trimmed
+                .chars()
+                .next()
+                .filter(|c| *c == '`' || *c == '~')
+                .map(|c| (c, trimmed.chars().take_while(|d| *d == c).count()))
+        } else {
+            None
+        };
+
+        match (&open, fence) {
+            (None, Some((marker, run))) if run >= 3 => {
+                open = Some((marker, run, offset));
+            }
+            (Some((marker, run, start)), Some((closing, closing_run)))
+                if *marker == closing && closing_run >= *run =>
+            {
+                ranges.push((*start, offset + line.len()));
+                open = None;
+            }
+            _ => {}
+        }
+        offset += line.len();
+    }
+
+    // An unclosed fence runs to the end of the document.
+    if let Some((_, _, start)) = open {
+        ranges.push((start, content.len()));
+    }
+
+    ranges
+}
+
+/// Row of `offset`, 0-indexed.
+fn row_of(content: &str, offset: usize) -> usize {
+    content[..offset].matches('\n').count()
+}
+
+/// Column of `offset`, 0-indexed, in bytes from the start of its line.
+fn column_of(content: &str, offset: usize) -> usize {
+    let line_start = content[..offset].rfind('\n').map_or(0, |pos| pos + 1);
+    offset - line_start
+}
+
+impl Rule for Q252Converter {
+    fn name(&self) -> &str {
+        "q-2-52"
+    }
+
+    fn description(&self) -> &str {
+        "Fix Q-2-52: Put a space inside both shortcode delimiters ({{< name args >}})"
+    }
+
+    fn check(&self, file_path: &Path, _verbose: bool) -> Result<Vec<CheckResult>> {
+        let (violations, _fixed) = self.violations_for(file_path)?;
+
+        Ok(violations
+            .into_iter()
+            .map(|violation| CheckResult {
+                rule_name: self.name().to_string(),
+                file_path: file_path.to_string_lossy().to_string(),
+                has_issue: true,
+                issue_count: 1,
+                message: Some(format!(
+                    "Q-2-52 shortcode delimiter missing its space at line {}, column {}",
+                    violation.location.row + 1,
+                    violation.location.column + 1
+                )),
+                location: Some(violation.location),
+                error_code: Some("Q-2-52".to_string()),
+                error_codes: None,
+                ..Default::default()
+            })
+            .collect())
+    }
+
+    fn convert(
+        &self,
+        file_path: &Path,
+        in_place: bool,
+        check_mode: bool,
+        _verbose: bool,
+    ) -> Result<ConvertResult> {
+        let (violations, fixed_content) = self.violations_for(file_path)?;
+        let name = self.name().to_string();
+        let path = file_path.to_string_lossy().to_string();
+
+        if violations.is_empty() {
+            return Ok(ConvertResult {
+                rule_name: name,
+                file_path: path,
+                fixes_applied: 0,
+                message: Some("No Q-2-52 shortcode delimiter issues found".to_string()),
+            });
+        }
+
+        if check_mode {
+            return Ok(ConvertResult {
+                rule_name: name,
+                file_path: path,
+                fixes_applied: violations.len(),
+                message: Some(format!(
+                    "Would fix {} Q-2-52 shortcode delimiter violation(s)",
+                    violations.len()
+                )),
+            });
+        }
+
+        if in_place {
+            crate::utils::file_io::write_file(file_path, &fixed_content)?;
+            Ok(ConvertResult {
+                rule_name: name,
+                file_path: path,
+                fixes_applied: violations.len(),
+                message: Some(format!(
+                    "Fixed {} Q-2-52 shortcode delimiter violation(s)",
+                    violations.len()
+                )),
+            })
+        } else {
+            Ok(ConvertResult {
+                rule_name: name,
+                file_path: path,
+                fixes_applied: violations.len(),
+                message: Some(fixed_content),
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::fenced_code_ranges;
+
+    fn spans(content: &str) -> Vec<&str> {
+        fenced_code_ranges(content)
+            .into_iter()
+            .map(|(start, end)| &content[start..end])
+            .collect()
+    }
+
+    #[test]
+    fn finds_a_backtick_fence() {
+        assert_eq!(spans("a\n```\nx\n```\nb\n"), vec!["```\nx\n```\n"]);
+    }
+
+    #[test]
+    fn finds_a_tilde_fence() {
+        assert_eq!(spans("a\n~~~\nx\n~~~\nb\n"), vec!["~~~\nx\n~~~\n"]);
+    }
+
+    /// A fence closes only on its own marker, so a run of the other
+    /// character inside it is content.
+    #[test]
+    fn a_tilde_run_does_not_close_a_backtick_fence() {
+        assert_eq!(spans("```\n~~~\n```\n"), vec!["```\n~~~\n```\n"]);
+    }
+
+    /// A shorter run does not close a longer fence, which is what makes a
+    /// fence containing a fence work.
+    #[test]
+    fn a_shorter_run_does_not_close_a_longer_fence() {
+        assert_eq!(
+            spans("````\n```\nx\n```\n````\n"),
+            vec!["````\n```\nx\n```\n````\n"]
+        );
+    }
+
+    /// An unclosed fence swallows the rest of the document. Declining to
+    /// edit there is the safe reading.
+    #[test]
+    fn an_unclosed_fence_runs_to_the_end() {
+        assert_eq!(spans("a\n```\nx\ny\n"), vec!["```\nx\ny\n"]);
+    }
+
+    #[test]
+    fn up_to_three_spaces_of_indent_still_opens_a_fence() {
+        assert_eq!(spans("   ```\nx\n   ```\n"), vec!["   ```\nx\n   ```\n"]);
+    }
+
+    /// Four spaces is an indented code block, not a fence. Its contents
+    /// are not parsed as inline either way, so nothing is at risk.
+    #[test]
+    fn four_spaces_of_indent_is_not_a_fence() {
+        assert!(spans("    ```\nx\n    ```\n").is_empty());
+    }
+
+    #[test]
+    fn a_document_without_fences_has_no_ranges() {
+        assert!(spans("Click the {{<fa plus>}} icon.\n").is_empty());
+    }
+}

--- a/crates/qmd-syntax-helper/src/rule.rs
+++ b/crates/qmd-syntax-helper/src/rule.rs
@@ -158,6 +158,7 @@ impl RuleRegistry {
         registry.register(Arc::new(crate::conversions::q_2_26::Q226Converter::new()?));
         registry.register(Arc::new(crate::conversions::q_2_28::Q228Converter::new()?));
         registry.register(Arc::new(crate::conversions::q_2_33::Q233Converter::new()?));
+        registry.register(Arc::new(crate::conversions::q_2_52::Q252Converter::new()?));
 
         Ok(registry)
     }

--- a/crates/qmd-syntax-helper/tests/integration/main.rs
+++ b/crates/qmd-syntax-helper/tests/integration/main.rs
@@ -24,6 +24,7 @@ pub mod q_2_24_test;
 pub mod q_2_25_test;
 pub mod q_2_26_test;
 pub mod q_2_28_test;
+pub mod q_2_52_test;
 pub mod q_2_5_test;
 pub mod reference_links_test;
 

--- a/crates/qmd-syntax-helper/tests/integration/q_2_52_test.rs
+++ b/crates/qmd-syntax-helper/tests/integration/q_2_52_test.rs
@@ -1,0 +1,272 @@
+use qmd_syntax_helper::rule::RuleRegistry;
+use qmd_syntax_helper::utils::resources::ResourceManager;
+use std::fs;
+
+fn convert(source: &str) -> (usize, String) {
+    let rm = ResourceManager::new().unwrap();
+    let test_file = rm.temp_dir().join("test.qmd");
+    fs::write(&test_file, source).unwrap();
+
+    let registry = RuleRegistry::new().unwrap();
+    let rule = registry.get("q-2-52").unwrap();
+    let result = rule.convert(&test_file, false, false, false).unwrap();
+    (result.fixes_applied, result.message.unwrap())
+}
+
+fn check_count(source: &str) -> usize {
+    let rm = ResourceManager::new().unwrap();
+    let test_file = rm.temp_dir().join("test.qmd");
+    fs::write(&test_file, source).unwrap();
+
+    let registry = RuleRegistry::new().unwrap();
+    let rule = registry.get("q-2-52").unwrap();
+    rule.check(&test_file, false).unwrap().len()
+}
+
+/// The converted document must parse. Every assertion below about the
+/// exact output is only worth anything if the result is actually valid.
+fn assert_parses(source: &str) {
+    let result = pampa::readers::qmd::read(
+        source.as_bytes(),
+        false,
+        "converted.qmd",
+        &mut std::io::sink(),
+        true,
+        None,
+    );
+    assert!(
+        result.is_ok(),
+        "converted document should parse:\n{source}\n{:#?}",
+        result.err()
+    );
+}
+
+#[test]
+fn correctly_spaced_shortcode_is_left_alone() {
+    let source = "Click the {{< fa plus >}} icon.\n";
+    assert_eq!(check_count(source), 0);
+    assert_eq!(convert(source).0, 0);
+}
+
+#[test]
+fn spaces_the_opening_delimiter() {
+    let (fixes, converted) = convert("Click the {{<fa plus >}} icon.\n");
+    assert_eq!(fixes, 1);
+    assert_eq!(converted, "Click the {{< fa plus >}} icon.\n");
+    assert_parses(&converted);
+}
+
+#[test]
+fn spaces_the_closing_delimiter() {
+    let (fixes, converted) = convert("Click the {{< fa plus>}} icon.\n");
+    assert_eq!(fixes, 1);
+    assert_eq!(converted, "Click the {{< fa plus >}} icon.\n");
+    assert_parses(&converted);
+}
+
+/// The one that matters: spacing only the opening delimiter turns an
+/// uncoded parse failure into a different parse failure. Both sides have
+/// to be fixed for the document to parse at all.
+#[test]
+fn spaces_both_delimiters_of_one_shortcode() {
+    let (fixes, converted) = convert("Click the {{<fa plus>}} icon.\n");
+    assert_eq!(fixes, 2, "both delimiters are missing a space");
+    assert_eq!(converted, "Click the {{< fa plus >}} icon.\n");
+    assert_parses(&converted);
+}
+
+/// Quarto reports one Q-2-52 per parse — the mistake desynchronises the
+/// parser, so later errors are suppressed as recovery debris. The rule
+/// has to keep going to find the rest. The Positron docs page that
+/// motivated this had seven in one file.
+#[test]
+fn fixes_every_occurrence_in_a_file() {
+    let source = concat!(
+        "Click the {{<fa plus>}} icon.\n",
+        "\n",
+        "Then the {{<fa gear>}} icon.\n",
+        "\n",
+        "Finally {{< fa minus>}} and {{<fa check >}}.\n",
+    );
+    let (fixes, converted) = convert(source);
+    assert_eq!(fixes, 6);
+    assert_eq!(
+        converted,
+        concat!(
+            "Click the {{< fa plus >}} icon.\n",
+            "\n",
+            "Then the {{< fa gear >}} icon.\n",
+            "\n",
+            "Finally {{< fa minus >}} and {{< fa check >}}.\n",
+        )
+    );
+    assert_parses(&converted);
+    assert_eq!(check_count(source), 6);
+}
+
+#[test]
+fn spaces_escaped_shortcode_delimiters() {
+    let (fixes, converted) = convert("Show the {{{<fa plus>}}} syntax.\n");
+    assert_eq!(fixes, 2);
+    assert_eq!(converted, "Show the {{{< fa plus >}}} syntax.\n");
+    assert_parses(&converted);
+}
+
+/// A tight shortcode inside a code span is literal text, not a shortcode,
+/// and is not a parse error. Documentation that shows the wrong spelling
+/// on purpose must survive the conversion unchanged.
+#[test]
+fn leaves_a_code_span_alone() {
+    let source = "Do not write `{{<fa plus>}}` in a document.\n";
+    assert_eq!(check_count(source), 0);
+    assert_eq!(convert(source).0, 0);
+}
+
+#[test]
+fn leaves_a_fenced_code_block_alone() {
+    let source = "Bad:\n\n```markdown\n{{<fa plus>}}\n```\n";
+    assert_eq!(check_count(source), 0);
+    assert_eq!(convert(source).0, 0);
+}
+
+/// Positions are reported in the original document's coordinates, not in
+/// the partially-repaired copy the rule works on.
+#[test]
+fn reports_positions_in_the_original_document() {
+    let rm = ResourceManager::new().unwrap();
+    let test_file = rm.temp_dir().join("test.qmd");
+    fs::write(&test_file, "one\ntwo {{<fa>}} three\n").unwrap();
+
+    let registry = RuleRegistry::new().unwrap();
+    let rule = registry.get("q-2-52").unwrap();
+    let results = rule.check(&test_file, false).unwrap();
+
+    assert_eq!(results.len(), 2);
+    let opening = results[0].location.as_ref().unwrap();
+    assert_eq!((opening.row, opening.column), (1, 7)); // the `f` of `fa`
+    let closing = results[1].location.as_ref().unwrap();
+    assert_eq!((closing.row, closing.column), (1, 9)); // the `>` of `>}}`
+    assert_eq!(results[0].error_code.as_deref(), Some("Q-2-52"));
+}
+
+#[test]
+fn in_place_conversion_rewrites_the_file() {
+    let rm = ResourceManager::new().unwrap();
+    let test_file = rm.temp_dir().join("test.qmd");
+    fs::write(&test_file, "Click the {{<fa plus>}} icon.\n").unwrap();
+
+    let registry = RuleRegistry::new().unwrap();
+    let rule = registry.get("q-2-52").unwrap();
+    let result = rule.convert(&test_file, true, false, false).unwrap();
+
+    assert_eq!(result.fixes_applied, 2);
+    assert_eq!(
+        fs::read_to_string(&test_file).unwrap(),
+        "Click the {{< fa plus >}} icon.\n"
+    );
+}
+
+#[test]
+fn check_mode_reports_without_writing() {
+    let rm = ResourceManager::new().unwrap();
+    let test_file = rm.temp_dir().join("test.qmd");
+    let original = "Click the {{<fa plus>}} icon.\n";
+    fs::write(&test_file, original).unwrap();
+
+    let registry = RuleRegistry::new().unwrap();
+    let rule = registry.get("q-2-52").unwrap();
+    let result = rule.convert(&test_file, true, true, false).unwrap();
+
+    assert_eq!(result.fixes_applied, 2);
+    assert_eq!(fs::read_to_string(&test_file).unwrap(), original);
+}
+
+/// Offsets are bytes, and the rule maps them back through its own
+/// insertions to report positions in the original document. Multi-byte
+/// text before and inside the shortcode is where that arithmetic would
+/// show up as a panic or an off-by-several.
+#[test]
+fn handles_multi_byte_text() {
+    let (fixes, converted) = convert("Drücken Sie {{<fa größe>}} für „mehr“.\n");
+    assert_eq!(fixes, 2);
+    assert_eq!(converted, "Drücken Sie {{< fa größe >}} für „mehr“.\n");
+    assert_parses(&converted);
+}
+
+/// Quarto prunes to one diagnostic per ERROR node, so an unrelated error
+/// earlier in a file hides every Q-2-52 after it. A document full of
+/// Quarto 1 spellings — which is the only kind this rule is ever pointed
+/// at — almost always has one. The rule reads unpruned diagnostics so a
+/// file with real violations is not reported as clean.
+#[test]
+fn finds_violations_masked_by_an_earlier_unrelated_error() {
+    let source = concat!(
+        "a {{< fa 2plus >}} b\n", // Q-2-34, and the earlier error
+        "\n",
+        "c {{<fa plus>}} d\n",
+    );
+    assert!(
+        check_count(source) > 0,
+        "a file with a Q-2-52 must not be reported as clean"
+    );
+    assert!(convert(source).1.contains("plus >}}"));
+}
+
+/// A tight shortcode inside a fence is someone showing the syntax. In a
+/// document whose only fault is the separator, fence content raises no
+/// diagnostic and is safe for free — but one unrelated error elsewhere
+/// desynchronises the parser far enough that the fence stops being a
+/// fence, and its contents start reporting Q-2-52. The rule finds fences
+/// by scanning lines so that they survive either way.
+#[test]
+fn leaves_a_fenced_block_alone_in_a_document_with_other_errors() {
+    let source = concat!(
+        "Text with {guid} braces and {{<fa plus>}} here.\n",
+        "\n",
+        "```markdown\n",
+        "{{<fa fenced>}}\n",
+        "```\n",
+    );
+    let (_fixes, converted) = convert(source);
+    assert!(
+        converted.contains("{{<fa fenced>}}"),
+        "the fenced example must survive:\n{converted}"
+    );
+    assert!(
+        converted.contains("{{< fa plus >}}"),
+        "the prose occurrence should still be fixed:\n{converted}"
+    );
+}
+
+#[test]
+fn leaves_a_tilde_fenced_block_alone_in_a_document_with_other_errors() {
+    let source = concat!(
+        "Text with {guid} braces.\n",
+        "\n",
+        "~~~markdown\n",
+        "{{<fa tilde>}}\n",
+        "~~~\n",
+    );
+    assert_eq!(convert(source).0, 0);
+    assert_eq!(check_count(source), 0);
+}
+
+#[test]
+fn leaves_a_nested_fence_alone_in_a_document_with_other_errors() {
+    let source = concat!(
+        "Text with {guid} braces.\n",
+        "\n",
+        "````markdown\n",
+        "```\n",
+        "{{<fa inner>}}\n",
+        "```\n",
+        "````\n",
+    );
+    assert_eq!(convert(source).0, 0);
+}
+
+#[test]
+fn leaves_a_code_span_alone_in_a_document_with_other_errors() {
+    let source = "Text with {guid} braces and `{{<fa lit>}}` literal.\n";
+    assert_eq!(convert(source).0, 0);
+}


### PR DESCRIPTION
Stacked on #640 — this rule is named after the code that PR introduces, and reads its diagnostics. Review and merge that one first; the diff shown here against `main` will collapse to just `crates/qmd-syntax-helper/` once it lands.

---

```
qmd-syntax-helper convert -r q-2-52 -i path/to/document.qmd
```

puts the space back on both sides of every shortcode delimiter in a document.

```diff
-Click the {{<fa plus>}} button in the top right.
+Click the {{< fa plus >}} button in the top right.

-Use {{<fa gear>}} to open settings, then {{< fa refresh>}} to reload.
+Use {{< fa gear >}} to open settings, then {{< fa refresh >}} to reload.
```

The spaced form is what Quarto 1 emits and what both versions accept, so a converted document still builds under Quarto 1 — which matters, because the moment this rule is useful is mid-migration, when a project has to keep rendering under both.

Both delimiters have to move. Spacing only the opening one leaves `{{< fa plus>}}`, which is still an error — so the rule works a document until no Q-2-52 remains rather than making a single pass.

That iteration is also how it finds the occurrences. A missing separator leaves the parser desynchronised, so Quarto reports one Q-2-52 per parse and suppresses everything after it as recovery debris; a file with seven tight shortcodes, which is the shape a ported Quarto 1 page arrives in, takes seven passes to enumerate. Both spellings need the same edit — Quarto blames the character where the space belongs, whether that is the one after `{{<` or the `>` of `>}}` — so each pass inserts a single space at the reported offset.

`check` lists every occurrence with its position in the original document:

```
$ qmd-syntax-helper check -r q-2-52 managing-interpreters.qmd
managing-interpreters.qmd
  ✗ Q-2-52 shortcode delimiter missing its space at line 5, column 14
  ✗ Q-2-52 shortcode delimiter missing its space at line 5, column 21
  ✗ Q-2-52 shortcode delimiter missing its space at line 7, column 8
  …
```

## Unpruned diagnostics, and what that costs

Diagnostics are read unpruned. Pruning keeps one per ERROR node, so an unrelated error earlier in the file hides every Q-2-52 after it — and a document with several different Quarto 1 spellings, which is the only kind this rule is pointed at, always has one. Pruned, `check` reported such a file as clean, which is the worst answer available: it does not self-heal under `convert -r all`, because no Q-2-34 converter exists to clear the mask.

Reading them unpruned costs something the pruned view was hiding. One unrelated error — a literal `{guid}` brace run, a space in a link target — is enough to desynchronise the parser past the point where a fenced code block is still recognised as a fence, and its contents then report Q-2-52 like ordinary text. Rewriting them would silently edit a documented example, in exactly the projects most likely to run this tool.

Fenced ranges are therefore found by scanning lines rather than by asking the parser, so the fence is seen whether or not the parse recovered. The scan is deliberately generous — any line whose first non-space run is three or more backticks or tildes toggles the state — because over-including means the rule declines to fix something, while under-including means it rewrites something it should not. Code spans and indented code blocks need no such guard; they survive a broken parse already.

```
[brace error + backtick fence]              UNCHANGED
[brace error + tilde fence]                 UNCHANGED
[nested fence inside deeper fence]          UNCHANGED
[prose fixed, fence spared, broken doc]     Text with {guid} braces and {{< fa plus >}} here.
```

Positions are reported in the original document's coordinates, mapped back through the rule's own insertions. One pass is one full parse, so the cost is quadratic in the number of violations — about 0.12s for ten in a debug build, 1.4s for eighty, which is the right trade for a one-shot migration tool but worth knowing before pointing it at something enormous.

## Known limitation

In a document with an unrelated error upstream, the rule fixes what Quarto can still diagnose. Given `{{< fa 2plus >}}` on line 1 and `{{<fa plus>}}` on line 3, it repairs the closing delimiter but not the opening one, because the upstream error pushes that opening delimiter into a recovery-induced parser state carrying no code. Re-running after fixing the upstream error completes it. That is inherent to reading diagnostics from a document the parser has already lost its place in, not something this rule can work around.
