### PR TITLE
fix(html): stop reserving the right margin column on pages with no TOC

### DIFF
--- a/crates/quarto-core/src/template.rs
+++ b/crates/quarto-core/src/template.rs
@@ -191,16 +191,28 @@ $endfor$
 ///   exists (same transform); gates the `<header>` emission
 /// - `$date$` - publication date
 /// - `$abstract$` - document abstract (rendered as HTML blocks)
-/// - `$body-classes$` - CSS classes for body element. When set, replaces
-///   the `fullcontent` default entirely. Typically computed by
-///   `SidebarRenderTransform` (which writes `rendered.navigation.body-classes`)
-///   and copied into `body-classes` by `render_with_compiled_template`,
-///   but a user filter or template variable can override it. When unset
-///   and `rendered.navigation.toc` is present, `render_with_compiled_template`
-///   sets it to the empty string so the body falls through to the default
-///   (no-class) wide layout — needed because `fullcontent` allocates only
-///   `0.14*margin-width` for the right margin and squashes a TOC to ~70px.
-///   Mirrors TS Quarto's `format-html-bootstrap.ts` body-class logic.
+/// - `$body-classes$` - CSS classes for body element. A top-level
+///   `body-classes` supplied by the author or a filter is kept
+///   wholesale and suppresses the compose below. Otherwise
+///   `render_with_compiled_template` accumulates: the structural base
+///   from `rendered.navigation.body-classes` (written by
+///   `SidebarRenderTransform`, e.g. `nav-sidebar docked`), then
+///   `fullcontent` when nothing occupies the right margin, then
+///   `nav-fixed` when a navbar is rendered, then the color-mode class.
+///   `fullcontent` shrinks the right margin to near-nothing (to
+///   `0.14*margin-width` per segment without a sidebar; to zero in the
+///   docked/floating variants), so it is withheld whenever a TOC or
+///   margin categories render there — and under `page-layout: full`,
+///   where `$main-column$` is the remedy instead. Mirrors TS Quarto's
+///   `format-html-bootstrap.ts` body-class logic.
+/// - `$main-column$` - grid column class for `<main>` and the banner
+///   title, set only under `page-layout: full`: one of `column-body`,
+///   `column-page-right`, `column-page-left` or `column-page`,
+///   chosen from whether the left sidebar and the right margin
+///   actually carry content. Q2's port of Q1's `suggestColumn` /
+///   `setMainColumn`; computed in `render_with_compiled_template` and
+///   never author-settable. Unset on every other layout, where
+///   `<main>` stays bare and `$body-classes$` carries the remedy.
 /// - `$page-layout$` - page layout type (article, full, etc.)
 /// - `$version$` - Quarto version for generator meta tag
 /// - `$rendered.navigation.toc$` - Rendered TOC HTML (if toc: true)
@@ -321,7 +333,7 @@ $endif$
 $endif$
 $endif$
 
-<main class="content$if(rendered.title-block-banner)$ quarto-banner-title-block$endif$" id="quarto-document-content">
+<main class="content$if(main-column)$ $main-column$$endif$$if(rendered.title-block-banner)$ quarto-banner-title-block$endif$" id="quarto-document-content">
 
 $if(rendered.title-block-banner)$
 $else$
@@ -427,7 +439,7 @@ $endif$
 $elseif(rendered.title-block-banner)$
 <header id="title-block-header" class="quarto-title-block default page-columns page-full$if(quarto-template-params.banner-header-class)$ $quarto-template-params.banner-header-class$$endif$">
 <div class="quarto-title-banner page-columns page-full">
-<div class="quarto-title column-body">
+<div class="quarto-title $if(main-column)$$main-column$$else$column-body$endif$">
 $if(rendered.navigation.breadcrumbs)$
 $rendered.navigation.breadcrumbs$
 $endif$
@@ -820,6 +832,10 @@ pub fn render_with_compiled_template(
             "header-includes",
             "include-before",
             "include-after",
+            // Computed below from `page-layout` + margin occupancy;
+            // Q1 offers no author override, so a stray metadata key
+            // must not reach `$main-column$`.
+            "main-column",
         ],
     );
 
@@ -932,18 +948,25 @@ pub fn render_with_compiled_template(
     //   2. `rendered.navigation.body-classes` (written by
     //      `SidebarRenderTransform`, e.g. `"nav-sidebar floating"`) —
     //      promoted to the top-level template variable. See bd-mgoh.
-    //   3. TOC present but no sidebar → empty class. The body falls
-    //      through to the default (no-class) wide grid, whose right
-    //      margin column is `minmax(0.3*mw, 0.58*mw)` and has room for
-    //      the TOC.
-    //   4. Otherwise → `"fullcontent"`. That mixin's margin-seg{1,2}
-    //      sum to only `0.28 * margin-width` (~70px at the default
-    //      250px), which is intentional for content-heavy pages with
-    //      no TOC — but would squash a TOC if one were present, which
-    //      is why case (3) exists.
+    //   3. no sidebar → empty base. The body falls through to the
+    //      default (no-class) wide grid, whose right margin column is
+    //      `minmax(0.3*mw, 0.58*mw)` and has room for a TOC.
     //
     // Onto the structural base, in order:
     //
+    //   - `fullcontent` when nothing occupies the right margin
+    //     (bd-no-toc-reserves-margin-column-s8nonx0w). How much it
+    //     reclaims depends on the variant: without a sidebar,
+    //     `page-columns-fullcontent-wide` shrinks margin-seg{1,2} to
+    //     `0.14 * margin-width` each (~70px combined at the default
+    //     250px); with one, `page-columns-{docked,floating}-fullcontent-wide`
+    //     collapse `body-end body-end-outset page-end-inset page-end`
+    //     to a single grid line, so the margin tracks go to zero. Either
+    //     way it is what we want for a page with no TOC and would squash
+    //     a TOC if one were present. It is orthogonal to the structural
+    //     base — Q1 `classList.add`s it on top of the navigation
+    //     postprocessor's classes, so a page in a sidebar gets
+    //     `nav-sidebar docked … fullcontent`.
     //   - `nav-fixed` when a navbar is rendered (bd-ersobfbt): the
     //     header is `fixed-top`, and `body.nav-fixed { padding-top }`
     //     is the pre-JS anti-flash compensation for it. Same condition
@@ -961,19 +984,119 @@ pub fn render_with_compiled_template(
     // Mirrors TS Quarto's body-class logic in
     // `src/format/html/format-html-bootstrap.ts` plus the
     // `website-navigation.ts` postprocessor classes.
+    // Which margins the page actually fills
+    // (bd-no-toc-reserves-margin-column-s8nonx0w). Q1 answers this by
+    // querying the rendered DOM (`format-html-bootstrap.ts`); Q2 has no
+    // DOM pass, so the same facts come from the `rendered.navigation.*`
+    // keys that gate the sidebars in the markup above.
+    let has_toc = meta
+        .get_path(&["rendered", "navigation", "toc"])
+        .and_then(|v| v.as_plain_text())
+        .is_some_and(|s| !s.is_empty());
+    let has_margin_categories = meta
+        .get_path(&["rendered", "navigation", "margin_categories"])
+        .and_then(|v| v.as_plain_text())
+        .is_some_and(|s| !s.is_empty());
+    let toc_relocated = meta
+        .get_path(&["rendered", "navigation", "toc-relocated"])
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let page_layout_full = meta
+        .get("page-layout")
+        .and_then(|v| v.as_plain_text())
+        .is_some_and(|s| s == "full");
+
+    // `page-layout: full` widens `<main>` across whichever margins are
+    // free, via Q1's `suggestColumn` / `setMainColumn`
+    // (`format-html-bootstrap.ts:1008-1019` and `:1959-1983`). The
+    // preview's twin is `suggestMainColumn` in
+    // `ts-packages/preview-renderer/src/q2-preview/mainColumn.ts`; keep
+    // the two in sync. Unlike
+    // the `fullcontent` decision below, this one follows where the TOC
+    // is actually *rendered*: a relocated TOC (`toc-location: left` or
+    // `body`) leaves the right margin free and so must not count as
+    // right-margin content.
+    //
+    // Q1 also consults authored `.column-*` / `.margin-caption` /
+    // `.margin-ref` elements in the body. Q2 has no margin-column
+    // layout feature yet — nothing in the pipeline places content there
+    // — so that input has no Q2 equivalent to read.
+    //
+    // The suggestion is applied to `<main>` and to the banner title
+    // (`div.quarto-title`, TITLE_BLOCK_PARTIAL), which must track it:
+    // `.page-columns > *` and `.page-columns .column-body` resolve to
+    // the same `body-content-start / body-content-end` tracks
+    // (`_bootstrap-rules.scss`), so an unmoved banner would fall out of
+    // alignment with a moved `<main>` — visible on the default blog
+    // scaffold, which is `page-layout: full` + `title-block-banner`.
+    // Q1 keeps them together for the same reason: its `setMainColumn`
+    // selector list includes `.quarto-title-banner .quarto-title`.
+    //
+    // Q1's `setMainColumn` selector list has six entries; here is how
+    // each lands in Q2. Set explicitly: `main.content` (below) and
+    // `.quarto-title-banner .quarto-title` (TITLE_BLOCK_PARTIAL).
+    // Covered structurally, because Q2 emits them *inside* `<main>` and
+    // they inherit its box: `.page-navigation`, and the non-banner
+    // title block with its `.quarto-title-meta{,-author}` grids.
+    // Not applicable: `div[class^=quarto-about-]` — Q2 has no about
+    // pages. That leaves exactly one gap: in banner mode
+    // `$title-metadata()$` renders inside `header#title-block-header`,
+    // which sits outside `#quarto-content`, and carries no column class
+    // in Q2 at all — so there is nothing to rewrite there today.
+    //
+    // Scope: `has_toc` means "the rendered TOC HTML is non-empty",
+    // whereas Q1's `suggestColumn` asks `hasContents(kMarginSidebarId)`,
+    // which is true for a `nav#TOC` element even with no entries. So a
+    // `toc: true` page with no headings reads as right-margin-free here
+    // and right-margin-used in Q1. That is the same deliberate
+    // divergence the strand scopes out for `fullcontent` (the `404.html`
+    // case, where Q2 is arguably the more correct of the two); this
+    // extends it to the column suggestion.
+    if page_layout_full {
+        // `toc-left` is the *standalone* regime's flag
+        // (`TocLocationTransform`); a website page with
+        // `toc-location: left` gets `toc-in-sidebar` instead and the TOC
+        // is merged into `rendered.navigation.sidebar` by
+        // `SidebarRenderTransform` (which synthesizes a TOC-only
+        // floating sidebar when no nav sidebar is configured). That case
+        // is therefore already covered by the `sidebar` term below.
+        let left_toc = has_toc
+            && toc_relocated
+            && meta
+                .get_path(&["rendered", "navigation", "toc-left"])
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+        let left_used = left_toc
+            || meta
+                .get_path(&["rendered", "navigation", "sidebar"])
+                .and_then(|v| v.as_plain_text())
+                .is_some_and(|s| !s.is_empty());
+        // `#quarto-margin-sidebar` carries content only when the TOC
+        // lands there, or when listing categories do.
+        let right_used = has_margin_categories || (has_toc && !toc_relocated);
+        let column = match (left_used, right_used) {
+            (true, true) => "column-body",
+            (true, false) => "column-page-right",
+            (false, true) => "column-page-left",
+            (false, false) => "column-page",
+        };
+        ctx.insert("main-column", TemplateValue::String(column.to_string()));
+    }
+
     if ctx.get("body-classes").is_none() {
-        let from_meta = meta
-            .get_path(&["rendered", "navigation", "body-classes"])
-            .and_then(|v| v.as_plain_text());
-        let has_toc = meta
-            .get_path(&["rendered", "navigation", "toc"])
-            .and_then(|v| v.as_plain_text())
-            .is_some_and(|s| !s.is_empty());
         let mut classes: Vec<String> = Vec::new();
-        match (from_meta, has_toc) {
-            (Some(s), _) if !s.is_empty() => classes.push(s),
-            (Some(_), _) | (None, true) => {}
-            (None, false) => classes.push("fullcontent".to_string()),
+        if let Some(base) = meta
+            .get_path(&["rendered", "navigation", "body-classes"])
+            .and_then(|v| v.as_plain_text())
+            .filter(|s| !s.is_empty())
+        {
+            classes.push(base);
+        }
+        // Q1: `!hasRightContent && !hasMarginContent && !hasToc`. Under
+        // `page-layout: full` the main-column suggestion above is the
+        // remedy instead — Q1 takes one route or the other, never both.
+        if !has_toc && !has_margin_categories && !page_layout_full {
+            classes.push("fullcontent".to_string());
         }
         let navbar_rendered = meta
             .get_path(&["rendered", "navigation", "navbar"])
@@ -2449,7 +2572,10 @@ mod tests {
             render_with_compiled_template(&template, "<p>Content</p>", &meta, &[], &[]).unwrap();
 
         assert!(
-            html.contains("<body class=\"docked quarto-light\">"),
+            // No TOC and no margin content, so the structural base also
+            // picks up `fullcontent` since
+            // bd-no-toc-reserves-margin-column-s8nonx0w.
+            html.contains("<body class=\"docked fullcontent quarto-light\">"),
             "expected user body-classes + quarto-light; got: {}",
             &html[..html.len().min(800)]
         );
@@ -2484,10 +2610,13 @@ mod tests {
     }
 
     /// bd-ersobfbt: `nav-fixed` accumulates onto sidebar-produced body
-    /// classes rather than replacing them — a site with both a sidebar
-    /// and a navbar gets `nav-sidebar floating nav-fixed quarto-light`
-    /// (matching Q1's postprocessor, which classList.add's nav-sidebar,
-    /// floating, then nav-fixed).
+    /// classes rather than replacing them (matching Q1's postprocessor,
+    /// which classList.add's nav-sidebar, floating, then nav-fixed).
+    ///
+    /// This fixture renders no TOC and no margin content, so since
+    /// bd-no-toc-reserves-margin-column-s8nonx0w it also picks up
+    /// `fullcontent` — the class that used to be unreachable for any
+    /// page in a sidebar.
     #[test]
     fn test_full_template_nav_fixed_composes_with_sidebar_body_classes() {
         let template = full_html_template().unwrap();
@@ -2505,9 +2634,374 @@ mod tests {
             render_with_compiled_template(&template, "<p>Content</p>", &meta, &[], &[]).unwrap();
 
         assert!(
-            html.contains("<body class=\"nav-sidebar floating nav-fixed quarto-light\">"),
+            html.contains(
+                "<body class=\"nav-sidebar floating fullcontent nav-fixed quarto-light\">"
+            ),
             "nav-fixed must accumulate onto sidebar body classes; got: {}",
             &html[..html.len().min(800)]
+        );
+    }
+
+    /// bd-no-toc-reserves-margin-column-s8nonx0w GAP 1: `fullcontent`
+    /// and the sidebar-supplied structural classes are orthogonal.
+    /// Q1 decides `fullcontent` purely on whether the right margin has
+    /// content (`format-html-bootstrap.ts:1044-1071`) and `classList.add`s
+    /// it on top of whatever the navigation postprocessor already put
+    /// there, producing `nav-sidebar docked nav-fixed fullcontent`.
+    /// Q2 used to `match` on `(from_meta, has_toc)`, so a page in a
+    /// sidebar could never reach the `fullcontent` arm and kept ~150-200px
+    /// of empty right margin reserved.
+    #[test]
+    fn test_full_template_fullcontent_composes_with_sidebar_body_classes() {
+        let template = full_html_template().unwrap();
+        let mut meta = ConfigValue::null(dummy_source_info());
+        meta.insert_path(
+            &["rendered", "navigation", "body-classes"],
+            ConfigValue::new_string("nav-sidebar docked", dummy_source_info()),
+        );
+        meta.insert_path(
+            &["rendered", "navigation", "navbar"],
+            ConfigValue::new_string("<nav class=\"navbar\">N</nav>", dummy_source_info()),
+        );
+
+        let (html, _diags) =
+            render_with_compiled_template(&template, "<p>Content</p>", &meta, &[], &[]).unwrap();
+
+        assert!(
+            html.contains("<body class=\"nav-sidebar docked fullcontent nav-fixed quarto-light\">"),
+            "a sidebar page with no TOC must still get `fullcontent`; got: {}",
+            &html[..html.len().min(800)]
+        );
+    }
+
+    /// bd-no-toc-reserves-margin-column-s8nonx0w GAP 1 (negative): a
+    /// sidebar page that *does* render a TOC occupies the right margin,
+    /// so `fullcontent` must stay off — the same rule that already held
+    /// for sidebar-less pages.
+    #[test]
+    fn test_full_template_no_fullcontent_with_sidebar_and_toc() {
+        let template = full_html_template().unwrap();
+        let mut meta = ConfigValue::null(dummy_source_info());
+        meta.insert_path(
+            &["rendered", "navigation", "body-classes"],
+            ConfigValue::new_string("nav-sidebar docked", dummy_source_info()),
+        );
+        meta.insert_path(
+            &["rendered", "navigation", "toc"],
+            ConfigValue::new_string("<ul><li>x</li></ul>", dummy_source_info()),
+        );
+
+        let (html, _diags) =
+            render_with_compiled_template(&template, "<p>Content</p>", &meta, &[], &[]).unwrap();
+
+        assert!(
+            html.contains("<body class=\"nav-sidebar docked quarto-light\">"),
+            "a sidebar page with a TOC keeps the default wide-margin grid; got: {}",
+            &html[..html.len().min(800)]
+        );
+    }
+
+    /// bd-no-toc-reserves-margin-column-s8nonx0w GAP 1: the TOC is not
+    /// the only thing that can occupy the right margin. Listing
+    /// categories render into `#quarto-margin-sidebar` too, so a page
+    /// with `toc: false` plus margin categories must not collapse the
+    /// column out from under them. Q1's condition is
+    /// `!hasRightContent && !hasMarginContent && !hasToc`.
+    #[test]
+    fn test_full_template_no_fullcontent_with_margin_categories() {
+        let template = full_html_template().unwrap();
+        let mut meta = ConfigValue::null(dummy_source_info());
+        meta.insert_path(
+            &["rendered", "navigation", "margin_categories"],
+            ConfigValue::new_string(
+                "<div class=\"quarto-listing-category\">C</div>",
+                dummy_source_info(),
+            ),
+        );
+
+        let (html, _diags) =
+            render_with_compiled_template(&template, "<p>Content</p>", &meta, &[], &[]).unwrap();
+
+        assert!(
+            html.contains("<body class=\"quarto-light\">"),
+            "margin categories occupy the right margin, so no `fullcontent`; got: {}",
+            &html[..html.len().min(800)]
+        );
+    }
+
+    /// bd-no-toc-reserves-margin-column-s8nonx0w GAP 2: under
+    /// `page-layout: full` the left sidebar is occupied and the right
+    /// margin is not, so `<main>` spans from the content start to the
+    /// page end (Q1's `suggestColumn` → `column-page-right`). The body
+    /// keeps the default grid: Q1 applies one remedy or the other, never
+    /// both.
+    #[test]
+    fn test_full_template_full_layout_main_column_page_right() {
+        let template = full_html_template().unwrap();
+        let mut meta = ConfigValue::null(dummy_source_info());
+        meta.insert_path(
+            &["page-layout"],
+            ConfigValue::new_string("full", dummy_source_info()),
+        );
+        meta.insert_path(
+            &["rendered", "navigation", "body-classes"],
+            ConfigValue::new_string("nav-sidebar docked", dummy_source_info()),
+        );
+        meta.insert_path(
+            &["rendered", "navigation", "sidebar"],
+            ConfigValue::new_string("<nav id=\"quarto-sidebar\">S</nav>", dummy_source_info()),
+        );
+
+        let (html, _diags) =
+            render_with_compiled_template(&template, "<p>Content</p>", &meta, &[], &[]).unwrap();
+
+        assert!(
+            html.contains("<main class=\"content column-page-right\""),
+            "full layout with an occupied left margin only → column-page-right; got: {}",
+            &html[..html.len().min(2000)]
+        );
+        assert!(
+            html.contains("<body class=\"nav-sidebar docked quarto-light\">"),
+            "full layout takes the main-column remedy, not `fullcontent`; got: {}",
+            &html[..html.len().min(800)]
+        );
+    }
+
+    /// bd-no-toc-reserves-margin-column-s8nonx0w GAP 2: neither margin
+    /// occupied → `<main>` spans the whole page.
+    #[test]
+    fn test_full_template_full_layout_main_column_page() {
+        let template = full_html_template().unwrap();
+        let mut meta = ConfigValue::null(dummy_source_info());
+        meta.insert_path(
+            &["page-layout"],
+            ConfigValue::new_string("full", dummy_source_info()),
+        );
+
+        let (html, _diags) =
+            render_with_compiled_template(&template, "<p>Content</p>", &meta, &[], &[]).unwrap();
+
+        assert!(
+            html.contains("<main class=\"content column-page\""),
+            "full layout with both margins free → column-page; got: {}",
+            &html[..html.len().min(2000)]
+        );
+    }
+
+    /// bd-no-toc-reserves-margin-column-s8nonx0w GAP 2: both margins
+    /// occupied → `<main>` stays in the body column.
+    #[test]
+    fn test_full_template_full_layout_main_column_body() {
+        let template = full_html_template().unwrap();
+        let mut meta = ConfigValue::null(dummy_source_info());
+        meta.insert_path(
+            &["page-layout"],
+            ConfigValue::new_string("full", dummy_source_info()),
+        );
+        meta.insert_path(
+            &["rendered", "navigation", "sidebar"],
+            ConfigValue::new_string("<nav id=\"quarto-sidebar\">S</nav>", dummy_source_info()),
+        );
+        meta.insert_path(
+            &["rendered", "navigation", "toc"],
+            ConfigValue::new_string("<ul><li>x</li></ul>", dummy_source_info()),
+        );
+
+        let (html, _diags) =
+            render_with_compiled_template(&template, "<p>Content</p>", &meta, &[], &[]).unwrap();
+
+        assert!(
+            html.contains("<main class=\"content column-body\""),
+            "full layout with both margins occupied → column-body; got: {}",
+            &html[..html.len().min(2000)]
+        );
+    }
+
+    /// bd-no-toc-reserves-margin-column-s8nonx0w GAP 2: right margin
+    /// occupied and left free → `<main>` spans leftward.
+    #[test]
+    fn test_full_template_full_layout_main_column_page_left() {
+        let template = full_html_template().unwrap();
+        let mut meta = ConfigValue::null(dummy_source_info());
+        meta.insert_path(
+            &["page-layout"],
+            ConfigValue::new_string("full", dummy_source_info()),
+        );
+        meta.insert_path(
+            &["rendered", "navigation", "toc"],
+            ConfigValue::new_string("<ul><li>x</li></ul>", dummy_source_info()),
+        );
+
+        let (html, _diags) =
+            render_with_compiled_template(&template, "<p>Content</p>", &meta, &[], &[]).unwrap();
+
+        assert!(
+            html.contains("<main class=\"content column-page-left\""),
+            "full layout with an occupied right margin only → column-page-left; got: {}",
+            &html[..html.len().min(2000)]
+        );
+    }
+
+    /// bd-no-toc-reserves-margin-column-s8nonx0w GAP 2: a relocated TOC
+    /// (`toc-location: left`) leaves the right margin free and occupies
+    /// the left one, so the column suggestion follows the *rendered*
+    /// placement rather than the mere presence of a TOC.
+    #[test]
+    fn test_full_template_full_layout_main_column_with_left_toc() {
+        let template = full_html_template().unwrap();
+        let mut meta = ConfigValue::null(dummy_source_info());
+        meta.insert_path(
+            &["page-layout"],
+            ConfigValue::new_string("full", dummy_source_info()),
+        );
+        meta.insert_path(
+            &["rendered", "navigation", "toc"],
+            ConfigValue::new_string("<ul><li>x</li></ul>", dummy_source_info()),
+        );
+        meta.insert_path(
+            &["rendered", "navigation", "toc-relocated"],
+            ConfigValue::new_bool(true, dummy_source_info()),
+        );
+        meta.insert_path(
+            &["rendered", "navigation", "toc-left"],
+            ConfigValue::new_bool(true, dummy_source_info()),
+        );
+
+        let (html, _diags) =
+            render_with_compiled_template(&template, "<p>Content</p>", &meta, &[], &[]).unwrap();
+
+        assert!(
+            html.contains("<main class=\"content column-page-right\""),
+            "a left-relocated TOC occupies the left margin only; got: {}",
+            &html[..html.len().min(2000)]
+        );
+    }
+
+    /// bd-no-toc-reserves-margin-column-s8nonx0w GAP 2 (negative): the
+    /// column suggestion is a `page-layout: full` feature. An article
+    /// page keeps a bare `main.content` and reclaims the margin through
+    /// `fullcontent` on the body instead.
+    #[test]
+    fn test_full_template_article_layout_sets_no_main_column() {
+        let template = full_html_template().unwrap();
+        let mut meta = ConfigValue::null(dummy_source_info());
+        meta.insert_path(
+            &["rendered", "navigation", "sidebar"],
+            ConfigValue::new_string("<nav id=\"quarto-sidebar\">S</nav>", dummy_source_info()),
+        );
+
+        let (html, _diags) =
+            render_with_compiled_template(&template, "<p>Content</p>", &meta, &[], &[]).unwrap();
+
+        assert!(
+            html.contains("<main class=\"content\""),
+            "article layout leaves `<main>` uncolumned; got: {}",
+            &html[..html.len().min(2000)]
+        );
+    }
+
+    /// bd-no-toc-reserves-margin-column-s8nonx0w: the banner title must
+    /// track `<main>`'s suggested column. `.page-columns > *` and
+    /// `.page-columns .column-body` resolve to the same
+    /// `body-content-start / body-content-end` tracks, so a banner left
+    /// at `column-body` while `<main>` moves would be visibly
+    /// misaligned — and the default blog scaffold
+    /// (`quarto-project-create`'s `website/blog/index.qmd.template`) is
+    /// exactly `page-layout: full` + `title-block-banner` + margin
+    /// categories. Q1 keeps the pair together via `setMainColumn`'s
+    /// `.quarto-title-banner .quarto-title` selector.
+    #[test]
+    fn test_full_template_banner_title_tracks_main_column() {
+        let template = full_html_template().unwrap();
+        let mut meta = ConfigValue::null(dummy_source_info());
+        meta.insert_path(
+            &["page-layout"],
+            ConfigValue::new_string("full", dummy_source_info()),
+        );
+        meta.insert_path(
+            &["rendered", "has-title-block"],
+            ConfigValue::new_bool(true, dummy_source_info()),
+        );
+        meta.insert_path(
+            &["rendered", "title-block-banner"],
+            ConfigValue::new_bool(true, dummy_source_info()),
+        );
+        // Listing categories occupy the right margin; the left is free.
+        meta.insert_path(
+            &["rendered", "navigation", "margin_categories"],
+            ConfigValue::new_string(
+                "<div class=\"quarto-listing-category\">C</div>",
+                dummy_source_info(),
+            ),
+        );
+
+        let (html, _diags) =
+            render_with_compiled_template(&template, "<p>Content</p>", &meta, &[], &[]).unwrap();
+
+        assert!(
+            html.contains("<main class=\"content column-page-left"),
+            "right margin occupied, left free → column-page-left; got: {}",
+            &html[..html.len().min(2000)]
+        );
+        assert!(
+            html.contains("<div class=\"quarto-title column-page-left\">"),
+            "banner title must carry the same column as `<main>`; got: {}",
+            &html[..html.len().min(2000)]
+        );
+        assert!(
+            !html.contains("<div class=\"quarto-title column-body\">"),
+            "banner title must not stay at column-body under full layout; got: {}",
+            &html[..html.len().min(2000)]
+        );
+    }
+
+    /// bd-no-toc-reserves-margin-column-s8nonx0w: on every other layout
+    /// the banner keeps Q1's `column-body`, since `$main-column$` is
+    /// unset and the `$else$` branch supplies the default.
+    #[test]
+    fn test_full_template_banner_title_column_body_on_article_layout() {
+        let template = full_html_template().unwrap();
+        let mut meta = ConfigValue::null(dummy_source_info());
+        meta.insert_path(
+            &["rendered", "has-title-block"],
+            ConfigValue::new_bool(true, dummy_source_info()),
+        );
+        meta.insert_path(
+            &["rendered", "title-block-banner"],
+            ConfigValue::new_bool(true, dummy_source_info()),
+        );
+
+        let (html, _diags) =
+            render_with_compiled_template(&template, "<p>Content</p>", &meta, &[], &[]).unwrap();
+
+        assert!(
+            html.contains("<div class=\"quarto-title column-body\">"),
+            "article layout keeps the banner at column-body; got: {}",
+            &html[..html.len().min(2000)]
+        );
+    }
+
+    /// bd-no-toc-reserves-margin-column-s8nonx0w: `main-column` is
+    /// computed, never author-settable — it is excluded from the
+    /// metadata copied into the template context, so a stray front
+    /// matter key cannot reach `$main-column$`. (Q1 offers no such
+    /// override.)
+    #[test]
+    fn test_full_template_main_column_not_settable_from_metadata() {
+        let template = full_html_template().unwrap();
+        let mut meta = ConfigValue::null(dummy_source_info());
+        meta.insert_path(
+            &["main-column"],
+            ConfigValue::new_string("column-screen", dummy_source_info()),
+        );
+
+        let (html, _diags) =
+            render_with_compiled_template(&template, "<p>Content</p>", &meta, &[], &[]).unwrap();
+
+        assert!(
+            html.contains("<main class=\"content\""),
+            "author metadata must not reach `$main-column$`; got: {}",
+            &html[..html.len().min(2000)]
         );
     }
 

--- a/crates/quarto-core/tests/integration/sidebar_pipeline.rs
+++ b/crates/quarto-core/tests/integration/sidebar_pipeline.rs
@@ -182,11 +182,16 @@ fn pipeline_renders_sidebar_for_two_page_website() {
     // sidebar, the body must carry `nav-sidebar floating`; without these
     // classes the grid mixin produces no left sidebar column and the
     // sidebar falls below the page content. bd-mtzry appends a color-mode
-    // class (`quarto-light`) after the structural classes, so the full
-    // expected body class is `"nav-sidebar floating quarto-light"`.
+    // class (`quarto-light`) after the structural classes. Neither page
+    // renders a TOC or margin content, so since
+    // bd-no-toc-reserves-margin-column-s8nonx0w `fullcontent` also
+    // composes in — the class that reclaims the empty right margin
+    // column, previously unreachable for any page in a sidebar. The
+    // full expected body class is
+    // `"nav-sidebar floating fullcontent quarto-light"`.
     assert!(
-        index_html.contains("<body class=\"nav-sidebar floating quarto-light\">"),
-        "index page body must carry nav-sidebar+floating+quarto-light classes; \
+        index_html.contains("<body class=\"nav-sidebar floating fullcontent quarto-light\">"),
+        "index page body must carry nav-sidebar+floating+fullcontent+quarto-light classes; \
          got body tag: {}",
         index_html
             .find("<body")
@@ -194,8 +199,8 @@ fn pipeline_renders_sidebar_for_two_page_website() {
                 [i..(i + 80).min(index_html.len())])
     );
     assert!(
-        about_html.contains("<body class=\"nav-sidebar floating quarto-light\">"),
-        "about page body must carry nav-sidebar+floating+quarto-light classes; \
+        about_html.contains("<body class=\"nav-sidebar floating fullcontent quarto-light\">"),
+        "about page body must carry nav-sidebar+floating+fullcontent+quarto-light classes; \
          got body tag: {}",
         about_html
             .find("<body")

--- a/ts-packages/preview-renderer/src/q2-preview/PreviewDocument.integration.test.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/PreviewDocument.integration.test.tsx
@@ -155,6 +155,97 @@ describe('PreviewDocument body container', () => {
         expect(document.body.className).toBe('quarto-light');
     });
 
+    it('sidebar page with no TOC → fullcontent composes with the sidebar classes', () => {
+        // bd-no-toc-reserves-margin-column-s8nonx0w: `fullcontent` and
+        // the sidebar-supplied structural classes are orthogonal. The
+        // preview mirrors the Rust compose
+        // (`test_full_template_fullcontent_composes_with_sidebar_body_classes`).
+        mount({
+            rendered: mm({
+                navigation: mm({ 'body-classes': ms('nav-sidebar docked') }),
+            }),
+        });
+        expect(document.body.className).toBe(
+            'nav-sidebar docked fullcontent quarto-light',
+        );
+    });
+
+    it('sidebar page with a TOC → no fullcontent', () => {
+        mount({
+            rendered: mm({
+                navigation: mm({
+                    'body-classes': ms('nav-sidebar docked'),
+                    toc: ms('<ul><li>x</li></ul>'),
+                }),
+            }),
+        });
+        expect(document.body.className).toBe('nav-sidebar docked quarto-light');
+    });
+
+    it('margin categories occupy the right margin → no fullcontent', () => {
+        mount({
+            rendered: mm({
+                navigation: mm({
+                    margin_categories: ms('<div class="quarto-listing-category"></div>'),
+                }),
+            }),
+        });
+        expect(document.body.className).toBe('quarto-light');
+    });
+
+    it('page-layout: full with a left sidebar → main.column-page-right, no fullcontent', () => {
+        // bd-no-toc-reserves-margin-column-s8nonx0w: the full-layout
+        // remedy is a column class on <main>, not a body class — Q1
+        // applies one or the other, never both.
+        const { container } = mount({
+            'page-layout': ms('full'),
+            rendered: mm({
+                navigation: mm({
+                    'body-classes': ms('nav-sidebar docked'),
+                    sidebar: ms('<nav id="quarto-sidebar">S</nav>'),
+                }),
+            }),
+        });
+        expect(
+            container.querySelector(
+                'main.content.column-page-right#quarto-document-content',
+            ),
+        ).not.toBeNull();
+        expect(document.body.className).toBe('nav-sidebar docked quarto-light');
+    });
+
+    it('page-layout: full with both margins free → main.column-page', () => {
+        const { container } = mount({ 'page-layout': ms('full') });
+        expect(
+            container.querySelector('main.content.column-page#quarto-document-content'),
+        ).not.toBeNull();
+    });
+
+    it('page-layout: full with both margins occupied → main.column-body', () => {
+        const { container } = mount({
+            'page-layout': ms('full'),
+            rendered: mm({
+                navigation: mm({
+                    sidebar: ms('<nav id="quarto-sidebar">S</nav>'),
+                    toc: ms('<ul><li>x</li></ul>'),
+                }),
+            }),
+        });
+        expect(
+            container.querySelector('main.content.column-body#quarto-document-content'),
+        ).not.toBeNull();
+    });
+
+    it('page-layout: article sets no column class on main', () => {
+        const { container } = mount({
+            rendered: mm({
+                navigation: mm({ sidebar: ms('<nav id="quarto-sidebar">S</nav>') }),
+            }),
+        });
+        const main = container.querySelector('main#quarto-document-content');
+        expect(main!.className).toBe('content');
+    });
+
     it('cleanup: unmount restores the pre-mount body.className', () => {
         document.body.className = 'pre-existing';
         const { unmount } = mount({ 'body-classes': ms('mid') });
@@ -590,7 +681,11 @@ describe('PreviewDocument chrome injection (Phase F.2)', () => {
                 },
             ]),
         });
-        expect(document.body.className).toBe('nav-sidebar floating quarto-light');
+        // No TOC and no margin content, so `fullcontent` composes on
+        // top since bd-no-toc-reserves-margin-column-s8nonx0w.
+        expect(document.body.className).toBe(
+            'nav-sidebar floating fullcontent quarto-light',
+        );
     });
 
     it('user-set top-level body-classes still wins over sidebar-render', () => {

--- a/ts-packages/preview-renderer/src/q2-preview/PreviewDocument.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/PreviewDocument.tsx
@@ -20,6 +20,7 @@ import {
     HeaderIncludesEffect,
 } from './chromeSlots';
 import { useBlockEditHover } from './useBlockEditHover';
+import { suggestMainColumn } from './mainColumn';
 
 /**
  * bd-elgxx (D6 react): mirror of Rust
@@ -102,13 +103,19 @@ export const PreviewDocument = ({
     //      `SidebarRenderTransform` (e.g. `nav-sidebar floating`,
     //      `nav-sidebar docked`) — required for Bootstrap's
     //      sidebar-aware grid layout to take effect.
-    //   3. TOC rendered but no sidebar → empty class. Falls through
-    //      to the default (no-class) wide grid, whose right margin
-    //      column is `minmax(0.3*mw, 0.58*mw)` and has room for the
-    //      TOC. The `fullcontent` mixin's margin column is only
-    //      `0.28*mw` (~70px at the default 250px) and squashes a TOC.
-    //   4. Otherwise → literal `fullcontent`.
-    // Onto the structural base: `nav-fixed` when a navbar is rendered
+    //   3. no sidebar → empty base. Falls through to the default
+    //      (no-class) wide grid, whose right margin column is
+    //      `minmax(0.3*mw, 0.58*mw)` and has room for a TOC.
+    // Onto the structural base: `fullcontent` when nothing occupies
+    // the right margin — the TOC, listing categories in the margin, or
+    // the `page-layout: full` main-column remedy below
+    // (bd-no-toc-reserves-margin-column-s8nonx0w). It is orthogonal to
+    // the structural base, so it appends rather than replaces: a page
+    // in a sidebar gets `nav-sidebar docked … fullcontent`. The
+    // `fullcontent` mixin shrinks the right margin to ~70px without a
+    // sidebar (`0.14*mw` per segment) and to zero in the docked/floating
+    // variants; either would squash a TOC.
+    // Then: `nav-fixed` when a navbar is rendered
     // (bd-ersobfbt — the `#quarto-header` is `fixed-top`, and
     // `body.nav-fixed { padding-top }` is its pre-JS compensation;
     // same condition as Q1's postprocessor and the Rust compose in
@@ -125,10 +132,22 @@ export const PreviewDocument = ({
         getMetaPath(meta, ['rendered', 'navigation', 'toc']),
     );
     const hasToc = tocRendered !== undefined && tocRendered !== '';
+    const marginCategoriesHtml = extractMetaString(
+        getMetaPath(meta, ['rendered', 'navigation', 'margin_categories']),
+    );
+    const hasMarginCategories =
+        marginCategoriesHtml !== undefined && marginCategoriesHtml !== '';
+    const pageLayoutFull = pageLayout === 'full';
     const structuralBodyClasses =
         userBodyClasses ??
-        renderedBodyClasses ??
-        (hasToc ? '' : 'fullcontent');
+        [
+            renderedBodyClasses,
+            !hasToc && !hasMarginCategories && !pageLayoutFull
+                ? 'fullcontent'
+                : undefined,
+        ]
+            .filter((c): c is string => c !== undefined && c !== '')
+            .join(' ');
     const composedBodyClasses =
         userBodyClasses === undefined && navbarHtml
             ? [structuralBodyClasses, 'nav-fixed']
@@ -195,6 +214,10 @@ export const PreviewDocument = ({
     const pageNavHtml = extractMetaString(
         getMetaPath(meta, ['rendered', 'navigation', 'page_navigation']),
     );
+    // Q2's port of Q1's `suggestColumn` / `setMainColumn`, shared with
+    // `PreviewTitleBlock` so the banner title tracks `<main>`. Mirrors
+    // the Rust `$main-column$` computation in template.rs.
+    const mainColumn = suggestMainColumn(meta);
     const tocHtml = extractMetaString(
         getMetaPath(meta, ['rendered', 'navigation', 'toc']),
     );
@@ -363,7 +386,7 @@ export const PreviewDocument = ({
                 {tocHtml ? <TocSlot html={tocHtml} titleHtml={tocTitleHtml} /> : null}
 
                 <main
-                    className={`content${bannerTitleBlock ? ' quarto-banner-title-block' : ''}`}
+                    className={`content${mainColumn ? ` ${mainColumn}` : ''}${bannerTitleBlock ? ' quarto-banner-title-block' : ''}`}
                     id="quarto-document-content"
                 >
                     {!bannerTitleBlock ? (

--- a/ts-packages/preview-renderer/src/q2-preview/custom/PreviewTitleBlock.integration.test.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/custom/PreviewTitleBlock.integration.test.tsx
@@ -653,6 +653,37 @@ describe('PreviewTitleBlock — banner mode (P5, bd-364ol5lu)', () => {
         ).not.toBeNull();
     });
 
+    it('banner under page-layout: full tracks the suggested main column', () => {
+        // bd-no-toc-reserves-margin-column-s8nonx0w: `.page-columns > *`
+        // and `.page-columns .column-body` resolve to the same tracks, so
+        // the banner title has to move with `<main>` or the two grids fall
+        // out of alignment. The default blog scaffold is exactly this
+        // shape: page-layout full + banner + margin categories.
+        const { container } = mount({
+            title: ms('Doc'),
+            'page-layout': ms('full'),
+            rendered: mm({
+                'has-title-block': mb(true),
+                'title-block-banner': mb(true),
+                navigation: mm({
+                    margin_categories: ms(
+                        '<div class="quarto-listing-category"></div>',
+                    ),
+                }),
+            }),
+        });
+        expect(
+            container.querySelector(
+                'div.quarto-title-banner > div.quarto-title.column-page-left',
+            ),
+        ).not.toBeNull();
+        expect(
+            container.querySelector(
+                'div.quarto-title-banner > div.quarto-title.column-body',
+            ),
+        ).toBeNull();
+    });
+
     it('banner → description and categories render inside the banner div', () => {
         const { container } = mount(
             bannerDerived({

--- a/ts-packages/preview-renderer/src/q2-preview/custom/PreviewTitleBlock.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/custom/PreviewTitleBlock.tsx
@@ -1,4 +1,5 @@
 import type { AstProps, BlockNode, InlineNode } from '../../framework';
+import { suggestMainColumn } from '../mainColumn';
 import {
     extractMetaBool,
     extractMetaString,
@@ -139,7 +140,7 @@ export const PreviewTitleBlock = ({ ast }: AstProps) => {
     // Banner mode (P5, bd-364ol5lu): `TitleBannerTransform` writes the
     // flag; the markup mirrors TITLE_BLOCK_PARTIAL's banner branch —
     // title/subtitle/description/categories inside
-    // div.quarto-title-banner > div.quarto-title.column-body, the meta
+    // div.quarto-title-banner > div.quarto-title.<main-column>, the meta
     // grids below the banner, page-columns page-full on header +
     // banner div, and (Q1 banner-partial parity) NO hide-description
     // gate.
@@ -147,6 +148,11 @@ export const PreviewTitleBlock = ({ ast }: AstProps) => {
         extractMetaBool(
             getMetaPath(meta, ['rendered', 'title-block-banner']),
         ) === true;
+    // Under `page-layout: full` the banner title tracks `<main>`'s
+    // suggested column, or the two grids fall out of alignment — see
+    // `suggestMainColumn` and its Rust twin in template.rs
+    // (bd-no-toc-reserves-margin-column-s8nonx0w).
+    const bannerColumn = suggestMainColumn(meta) ?? 'column-body';
 
     const categoryChips =
         categories.length > 0 ? (
@@ -172,7 +178,7 @@ export const PreviewTitleBlock = ({ ast }: AstProps) => {
                 className="quarto-title-block default page-columns page-full"
             >
                 <div className="quarto-title-banner page-columns page-full">
-                    <div className="quarto-title column-body">
+                    <div className={`quarto-title ${bannerColumn}`}>
                         {title ? <h1 className="title">{title}</h1> : null}
                         {subtitle ? (
                             <p className="subtitle lead">{subtitle}</p>

--- a/ts-packages/preview-renderer/src/q2-preview/headroom-header.integration.test.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/headroom-header.integration.test.tsx
@@ -167,8 +167,10 @@ describe('q2-preview nav-fixed body class (bd-ersobfbt)', () => {
                 'body-classes': ms('nav-sidebar floating'),
             }),
         );
+        // No TOC and no margin content, so `fullcontent` composes on
+        // top since bd-no-toc-reserves-margin-column-s8nonx0w.
         expect(document.body.className).toBe(
-            'nav-sidebar floating nav-fixed quarto-light',
+            'nav-sidebar floating fullcontent nav-fixed quarto-light',
         );
     });
 

--- a/ts-packages/preview-renderer/src/q2-preview/mainColumn.ts
+++ b/ts-packages/preview-renderer/src/q2-preview/mainColumn.ts
@@ -1,0 +1,80 @@
+/**
+ * Q2's port of Quarto 1's `suggestColumn` / `setMainColumn`
+ * (`format-html-bootstrap.ts:1008-1019` and `:1959-1983`), mirroring the
+ * Rust twin in `render_with_compiled_template`
+ * (`crates/quarto-core/src/template.rs`), which feeds the same rule into
+ * the `$main-column$` template variable — keep the two in sync
+ * (bd-no-toc-reserves-margin-column-s8nonx0w).
+ *
+ * Under `page-layout: full`, `<main>` spans whichever margins are free
+ * instead of the body reclaiming them with `fullcontent`; Quarto 1 applies
+ * one remedy or the other, never both. The banner title tracks the same
+ * class, because `.page-columns > *` and `.page-columns .column-body`
+ * resolve to the same tracks — an unmoved banner would fall out of
+ * alignment with a moved `<main>`.
+ *
+ * Lives in its own module so `PreviewDocument` and `PreviewTitleBlock`
+ * cannot drift apart, and so the Rust twin has a single counterpart to
+ * stay in sync with.
+ */
+import { extractMetaBool, extractMetaString, getMetaPath } from '../framework';
+
+const nonEmpty = (v: string | undefined): boolean =>
+    v !== undefined && v !== '';
+
+export function suggestMainColumn(
+    meta: Record<string, unknown>,
+): string | undefined {
+    const pageLayout = extractMetaString(meta['page-layout']) ?? 'article';
+    if (pageLayout !== 'full') return undefined;
+
+    const hasToc = nonEmpty(
+        extractMetaString(getMetaPath(meta, ['rendered', 'navigation', 'toc'])),
+    );
+    const hasMarginCategories = nonEmpty(
+        extractMetaString(
+            getMetaPath(meta, ['rendered', 'navigation', 'margin_categories']),
+        ),
+    );
+    // A relocated TOC (`toc-location: left`/`body`) leaves the right
+    // margin free, so the suggestion follows where the TOC is actually
+    // rendered — unlike the `fullcontent` decision, which follows Quarto
+    // 1 in keying on whether a TOC exists at all.
+    //
+    // The preview's own markup does not yet honour `toc-relocated` —
+    // `PreviewDocument` renders `TocSlot` into the right margin whenever
+    // a TOC exists (a pre-existing gap, unrelated to this computation).
+    // Mirroring the Rust is still the right call: the sync contract is
+    // that both engines derive the same classes from the same metadata,
+    // so closing that markup gap will make the preview agree without
+    // touching this file.
+    const tocRelocated =
+        extractMetaBool(
+            getMetaPath(meta, ['rendered', 'navigation', 'toc-relocated']),
+        ) === true;
+    // `toc-left` is the standalone regime's flag; a website page with
+    // `toc-location: left` gets `toc-in-sidebar` and its TOC merged into
+    // `rendered.navigation.sidebar`, so that case is covered by the
+    // sidebar term below. Mirrors the Rust comment in template.rs.
+    const leftToc =
+        hasToc &&
+        tocRelocated &&
+        extractMetaBool(
+            getMetaPath(meta, ['rendered', 'navigation', 'toc-left']),
+        ) === true;
+    const leftUsed =
+        leftToc ||
+        nonEmpty(
+            extractMetaString(
+                getMetaPath(meta, ['rendered', 'navigation', 'sidebar']),
+            ),
+        );
+    // `#quarto-margin-sidebar` carries content only when the TOC lands
+    // there, or when listing categories do.
+    const rightUsed = hasMarginCategories || (hasToc && !tocRelocated);
+
+    if (leftUsed && rightUsed) return 'column-body';
+    if (leftUsed) return 'column-page-right';
+    if (rightUsed) return 'column-page-left';
+    return 'column-page';
+}


### PR DESCRIPTION
A page that renders no table of contents still held the right margin column open for one. Roughly 150-200px of grid track stayed permanently empty, so the content column was narrower than it should have been and the page sat off-centre — a visible difference from Quarto 1 on any website page with `toc: false`.

The stylesheet was never the problem. The grid rules that reclaim that space are byte-identical between Quarto 1's compiled Bootstrap CSS and q2's theme CSS; the `body.docked.fullcontent` and `body.floating.fullcontent` mixins were simply unreachable. What was missing were the classes that select them, and they were missing for two unrelated reasons.

## `fullcontent` could not reach a page in a sidebar

The body-class computation *chose between* the sidebar-supplied structural classes (`nav-sidebar docked`) and `fullcontent`, so any page listed in a sidebar lost `fullcontent` outright — while the same page outside the sidebar got it correctly. Quarto 1 treats the two as orthogonal: it decides `fullcontent` purely on whether anything occupies the right margin, and adds it on top of whatever the navigation pass already applied. They now compose the same way. Margin listing categories also count as right-margin content, which q2 previously ignored.

## `page-layout: full` never set a column class on `<main>`

Quarto 1 has a second, different remedy for full-layout pages: rather than collapsing the margin on the body, it widens `<main>` across whichever margins are actually free (`suggestColumn` / `setMainColumn`). q2 had no equivalent pass at all. That port is now in place — under `page-layout: full`, `<main>` gets `column-page-right`, `column-page-left`, `column-page` or `column-body` depending on whether the left sidebar and the right margin carry content. The two remedies stay mutually exclusive, as in Quarto 1: a full-layout page takes the main-column route and its body keeps the default grid.

The banner title carries the same class. `.page-columns > *` and `.page-columns .column-body` resolve to identical tracks, so a banner left behind would fall out of alignment with a moved `<main>` — visible on the default `quarto create` blog scaffold, which is exactly `page-layout: full` + `title-block-banner` + margin categories. Quarto 1 keeps the pair together for the same reason. Of its six `setMainColumn` selectors, those two are set explicitly; three more (`.page-navigation`, the non-banner title block and its meta grids) are covered structurally because q2 emits them inside `<main>`; `quarto-about-*` has no q2 counterpart. Only banner-mode `$title-metadata()$` remains, and it carries no column class in q2 to rewrite.

## A deliberate asymmetry

The two remedies ask "is the right margin occupied?" slightly differently, mirroring Quarto 1. `fullcontent` keys on whether a TOC exists at all (Quarto 1 reads `format.pandoc.toc`, a config read); the column suggestion follows where the TOC is actually *rendered* (Quarto 1 reads the DOM), so a `toc-location: left` page reads as left-used / right-free. Preserving that keeps both engines in step, including on relocated-TOC pages, where I verified q2 and Quarto 1 now agree on `<body>` and `<main>` alike.

## Preview

`suggestMainColumn` in `q2-preview/mainColumn.ts` is the shared twin of the Rust computation, used by both `PreviewDocument` and `PreviewTitleBlock`, so `q2 preview` and `q2 render` continue to agree on `<body>` and `<main>`.

`main-column` is computed rather than author-settable — it is excluded from the metadata copied into the template context.

## Verification

Checked against the reproduction in the Positron docs port, which renders a docked-sidebar site under both engines: the two previously-diverging pages now match Quarto 1, and the two control pages still agree. The banner fix was separately confirmed on a real `quarto create` blog scaffold, where `<main>` and `div.quarto-title` now both emit `column-page-left`.

Full `cargo xtask verify` passes all 14 steps: 13,562 Rust tests, the WASM and hub-client builds and tests, and the TypeScript suites.

Four existing assertions changed expectation rather than behaviour — fixtures with a sidebar but no TOC and no margin content now correctly carry `fullcontent`. No snapshot files changed.

Closes `bd-no-toc-reserves-margin-column-s8nonx0w`.
