### PR TITLE
Cap body images at their container width (bd-images-no-max-width-e5ywgnma)

### DIFF
--- a/crates/quarto-core/src/pipeline.rs
+++ b/crates/quarto-core/src/pipeline.rs
@@ -79,11 +79,11 @@ use crate::transforms::{
     MermaidRenderTransform, MetadataNormalizeTransform, NavbarGenerateTransform,
     NavbarRenderTransform, PageNavGenerateTransform, PageNavRenderTransform, ProofSugarTransform,
     ReferenceLinkDiagnosticsTransform, RepoActionsRenderTransform, ResourceCollectorTransform,
-    SectionizeTransform, ShortcodeResolveTransform, SidebarGenerateTransform,
-    SidebarRenderTransform, TableBootstrapClassTransform, TheoremSugarTransform,
-    TitleBannerTransform, TitleBlockTransform, TocGenerateTransform, TocLocationTransform,
-    TocRenderTransform, WebsiteBootstrapIconsTransform, WebsiteCanonicalUrlTransform,
-    WebsiteFaviconTransform, WebsiteTitlePrefixTransform,
+    ResponsiveImageTransform, SectionizeTransform, ShortcodeResolveTransform,
+    SidebarGenerateTransform, SidebarRenderTransform, TableBootstrapClassTransform,
+    TheoremSugarTransform, TitleBannerTransform, TitleBlockTransform, TocGenerateTransform,
+    TocLocationTransform, TocRenderTransform, WebsiteBootstrapIconsTransform,
+    WebsiteCanonicalUrlTransform, WebsiteFaviconTransform, WebsiteTitlePrefixTransform,
 };
 
 /// Well-known path for the default CSS artifact in WASM context.
@@ -1493,6 +1493,18 @@ pub fn build_transform_pipeline(
     // user-filter slot inserted before AttributionRender still sees the
     // un-enriched class list. Idempotent.
     pipeline.push(Box::new(TableBootstrapClassTransform::new()));
+
+    // bd-images-no-max-width-e5ywgnma: tag body images with Bootstrap's
+    // `img-fluid` so an image the author never sized is capped at its
+    // container's width instead of laying out at intrinsic pixel width
+    // (matches Quarto 1's `quarto-post/responsive.lua`). Sits next to
+    // the table pass above for the same reason it runs late: every
+    // upstream transform has finished producing images by now, so
+    // crossref-rendered figures are tagged too. Chrome emitted as raw
+    // HTML (listing thumbnails, navbar logos) is not in `ast.blocks`
+    // and stays untagged, as in Quarto 1. Idempotent, and self-gated
+    // to HTML formats excluding revealjs and `minimal: true`.
+    pipeline.push(Box::new(ResponsiveImageTransform::new()));
 
     // llms markdown capture (bd-llms-txt-unimplemented-oih6z6j7).
     // Runs after every content-mutating transform — crossref-render

--- a/crates/quarto-core/src/transforms/llms.rs
+++ b/crates/quarto-core/src/transforms/llms.rs
@@ -352,7 +352,15 @@ fn is_float_div(attr: &Attr) -> bool {
 fn sanitize_attr(attr: &mut Attr, attr_source: &mut AttrSourceInfo) {
     let class_noise = |c: &str| {
         c.starts_with("quarto-")
-            || matches!(c, "anchored" | "code-with-copy" | "cell" | "callout-titled")
+            // `img-fluid` is appended to every body image by
+            // `ResponsiveImageTransform`, which runs immediately
+            // before this capture. It is Bootstrap presentation —
+            // `max-width: 100%` — and carries no meaning for a model
+            // reading the mirror (bd-images-no-max-width-e5ywgnma).
+            || matches!(
+                c,
+                "anchored" | "code-with-copy" | "cell" | "callout-titled" | "img-fluid"
+            )
     };
     if attr.1.len() == attr_source.classes.len() {
         let keep: Vec<bool> = attr.1.iter().map(|c| !class_noise(c)).collect();

--- a/crates/quarto-core/src/transforms/mod.rs
+++ b/crates/quarto-core/src/transforms/mod.rs
@@ -73,6 +73,7 @@ mod proof;
 mod reference_link_diagnostics;
 mod repo_actions_render;
 mod resource_collector;
+mod responsive_image;
 mod secondary_nav_render;
 // Fixed-header JS shipping (bd-ersobfbt). Native-only: the preview
 // excludes ApplyTemplateStage (no <script> emission) and injects the
@@ -149,6 +150,7 @@ pub use quarto_nav_js::QuartoNavJsTransform;
 pub use reference_link_diagnostics::ReferenceLinkDiagnosticsTransform;
 pub use repo_actions_render::RepoActionsRenderTransform;
 pub use resource_collector::{ResourceCollectorTransform, collect_referenced_asset_urls};
+pub use responsive_image::ResponsiveImageTransform;
 pub use secondary_nav_render::SecondaryNavRenderTransform;
 pub use sectionize::SectionizeTransform;
 pub(crate) use shortcode_resolve::code_shortcode_opt_out;

--- a/crates/quarto-core/src/transforms/responsive_image.rs
+++ b/crates/quarto-core/src/transforms/responsive_image.rs
@@ -1,0 +1,832 @@
+/*
+ * transforms/responsive_image.rs
+ * Copyright (c) 2026 Posit, PBC
+ */
+
+//! Make body images responsive by tagging them with Bootstrap's
+//! `img-fluid` class.
+//!
+//! Without this, an image whose author supplied no size lays out at its
+//! intrinsic pixel width. A 2400px-wide screenshot in an 850px content
+//! column renders 2400px wide: it overflows the column, overruns the
+//! margin, and puts a horizontal scrollbar on the page. Bootstrap's
+//! `.img-fluid { max-width: 100%; height: auto }` is what caps it, and
+//! that rule is already in Quarto's compiled theme — only the pass that
+//! applies the class was missing (bd-images-no-max-width-e5ywgnma).
+//!
+//! Mirrors Quarto 1's `quarto-post/responsive.lua`, including both of
+//! its deliberate exclusions:
+//!
+//! - **an explicit `height` attribute.** `img-fluid` carries
+//!   `height: auto`, which would silently override the height the
+//!   author asked for. An author who sized an image vertically has
+//!   opted out of automatic sizing.
+//! - **`data-no-responsive`.** The per-image escape hatch, honored for
+//!   any value; only the key's presence is tested.
+//!
+//! An explicit `width` is *not* an exclusion, and that asymmetry is
+//! Quarto 1's, not an oversight: `max-width: 100%` still lets a
+//! `width=450` image shrink inside a narrower column, so the class
+//! refines the author's width instead of fighting it.
+//!
+//! The document-level switch is `fig-responsive`, default `true` for
+//! HTML (Quarto 1's schema default). `fig-responsive: false` disables
+//! the pass entirely.
+//!
+//! Pipeline placement: **FINALIZATION PHASE**, next to
+//! `TableBootstrapClassTransform` — its sibling in intent, since both
+//! inject the Bootstrap classes the theme is keyed off. Running late
+//! means every image an upstream transform left in the AST — notably
+//! crossref-rendered figures — is in place and gets tagged, which puts
+//! this at the same point in the run as Quarto 1's `quarto-post`
+//! filter. Idempotent, so a second pass over an already-tagged
+//! document is a no-op.
+//!
+//! What this does *not* reach, in either engine, is markup emitted as
+//! raw HTML rather than as AST nodes: listing thumbnails
+//! (`class="thumbnail-image"`), navbar logos and page-footer images
+//! all arrive as `rendered.navigation.*` strings and stay untagged.
+//!
+//! The preview pipeline inherits this pass — `q2 preview` and the
+//! hub-client run the same builder, filtered by deny-list — so a
+//! previewed page constrains its images exactly as the rendered one
+//! does. The class reaches the DOM there: the preview `Image`
+//! component copies AST classes onto the `<img>`, and the iframe loads
+//! the document's compiled Bootstrap theme (which carries
+//! `.img-fluid{max-width:100%;height:auto}`) via `<link data-q2-theme>`.
+//!
+//! Gated to HTML-family formats, but that is only half of Quarto 1's
+//! rule. Its filter tests `isHtmlOutput()` *and* reads
+//! `param('fig-responsive')`, whose default is set per format — so
+//! revealjs, for which `isHtmlOutput()` is true, is nonetheless
+//! **not** tagged, because `createHtmlPresentationFormat` sets that
+//! param `false` for every HTML presentation format. `minimal: true`
+//! is excluded the same way. See `responsive_enabled`.
+//!
+//! Not ported here: the `figure-img` class Quarto 1 also puts on images
+//! inside a `<figure>`. Despite sitting one class away in the output it
+//! comes from somewhere else entirely — the DOM postprocessor in
+//! `format-html-bootstrap.ts`, which adds `figure`/`figure-img`/
+//! `blockquote` classes in one sweep — and it is cosmetic
+//! (`margin-bottom: .5rem; line-height: 1`). It belongs with that
+//! group, not with this one.
+
+use quarto_pandoc_types::ConfigValue;
+use quarto_pandoc_types::Slot;
+use quarto_pandoc_types::attr::Attr;
+use quarto_pandoc_types::block::Block;
+use quarto_pandoc_types::inline::{Inline, Inlines};
+use quarto_pandoc_types::pandoc::Pandoc;
+
+use crate::Result;
+use crate::format::Format;
+use crate::render::RenderContext;
+use crate::transform::{AstTransform, TransformPhase};
+
+/// Bootstrap class that caps an image at its container's width.
+/// Ships in the compiled theme as `max-width: 100%; height: auto`.
+const IMG_FLUID_CLASS: &str = "img-fluid";
+
+/// Document-level switch, default `true`. Matches Quarto 1's
+/// `fig-responsive` schema entry (`document-figures.yml`).
+const FIG_RESPONSIVE_KEY: &str = "fig-responsive";
+
+/// Per-image opt-out. Presence is what counts; the value is ignored.
+const NO_RESPONSIVE_ATTR: &str = "data-no-responsive";
+
+/// Attribute whose presence means the author fixed the vertical size.
+const HEIGHT_ATTR: &str = "height";
+
+pub struct ResponsiveImageTransform;
+
+impl ResponsiveImageTransform {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for ResponsiveImageTransform {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait::async_trait(?Send)]
+impl AstTransform for ResponsiveImageTransform {
+    fn name(&self) -> &str {
+        "responsive-image"
+    }
+
+    fn phase(&self) -> TransformPhase {
+        TransformPhase::Finalization
+    }
+
+    async fn transform(&self, ast: &mut Pandoc, ctx: &mut RenderContext) -> Result<()> {
+        if !responsive_enabled(ctx.format, &ast.meta) {
+            return Ok(());
+        }
+        visit_blocks(&mut ast.blocks);
+        Ok(())
+    }
+}
+
+/// Whether the pass should run at all.
+///
+/// Split out from `transform` so the gate is directly testable — the
+/// same shape as `format_supports_draft_alert` in `draft_alert.rs`.
+///
+/// Quarto 1 spreads this decision across two places, and both matter:
+/// the filter tests `isHtmlOutput()` **and** reads
+/// `param('fig-responsive')`, whose *default* is set per format. So
+/// "HTML output" alone is not the rule — `isHtmlOutput()` is true for
+/// revealjs, yet Q1 does not tag deck images, because
+/// `createHtmlPresentationFormat` (`formats-shared.ts`) sets the param
+/// `false` for every HTML presentation format. `format-html.ts`'s
+/// `resolveFormat` does the same for `minimal: true`.
+///
+/// Both defaults are suppliers of last resort in Q1 (a config merge,
+/// and an `=== undefined` check), so an explicit `fig-responsive` in
+/// the document always wins — hence `unwrap_or(default_on)` rather
+/// than an early return.
+fn responsive_enabled(format: &Format, meta: &ConfigValue) -> bool {
+    if !format.is_html() {
+        return false;
+    }
+    // Reveal is matched on `target_format`, not the identifier: the
+    // preview pseudo-format `q2-slides` is a deck but resolves to
+    // `FormatIdentifier::Html`, so an identifier test would tag deck
+    // images in preview and not in render.
+    //
+    // `q2-slides` covers the live React deck too, even though it is
+    // legacy as a *user-facing* format. Since the bd-vwp4y5ku
+    // convergence, `format: revealjs` in hub-client and `q2 preview`
+    // renders through the shared q2-preview iframe, and the WASM entry
+    // rewrites `revealjs` → `q2-slides` on the way in
+    // (`map_format_for_preview`, `wasm-quarto-hub-client/src/lib.rs`).
+    // So every deck — native render, CLI preview, hub-client — reaches
+    // this gate as either `revealjs` or `q2-slides`.
+    let is_presentation = crate::format::is_revealjs_target(&format.target_format);
+    // The raw `minimal` flag, deliberately NOT `is_minimal_html`:
+    // that helper also returns true for `theme: none` / `theme:
+    // pandoc`, whereas Q1 flips this default only on `minimal: true`.
+    // With a bare `theme: none` both engines tag.
+    let is_minimal = meta.get("minimal").and_then(|v| v.as_bool()) == Some(true);
+    let default_on = !is_presentation && !is_minimal;
+
+    // `as_bool`, not a truthiness check: only an explicit `false` turns
+    // the pass off. An absent key — or a non-boolean like the quoted
+    // string `"false"`, which Quarto 1 also treats as on — falls back
+    // to the format default.
+    meta.get(FIG_RESPONSIVE_KEY)
+        .and_then(|v| v.as_bool())
+        .unwrap_or(default_on)
+}
+
+/// Tag `image` unless it is excluded. Split out so the unit tests can
+/// exercise the per-node rule without building a `RenderContext`.
+fn apply_to_image(attr: &mut Attr) {
+    if attr.2.contains_key(HEIGHT_ATTR) || attr.2.contains_key(NO_RESPONSIVE_ATTR) {
+        return;
+    }
+    if !attr.1.iter().any(|c| c == IMG_FLUID_CLASS) {
+        attr.1.push(IMG_FLUID_CLASS.to_string());
+    }
+}
+
+fn visit_blocks(blocks: &mut [Block]) {
+    for block in blocks.iter_mut() {
+        visit_block(block);
+    }
+}
+
+fn visit_block(block: &mut Block) {
+    match block {
+        Block::Plain(p) => visit_inlines(&mut p.content),
+        Block::Paragraph(p) => visit_inlines(&mut p.content),
+        Block::LineBlock(lb) => {
+            for line in lb.content.iter_mut() {
+                visit_inlines(line);
+            }
+        }
+        Block::BlockQuote(bq) => visit_blocks(&mut bq.content),
+        Block::OrderedList(ol) => {
+            for item in ol.content.iter_mut() {
+                visit_blocks(item);
+            }
+        }
+        Block::BulletList(bl) => {
+            for item in bl.content.iter_mut() {
+                visit_blocks(item);
+            }
+        }
+        Block::DefinitionList(dl) => {
+            for (term, defs) in dl.content.iter_mut() {
+                visit_inlines(term);
+                for def in defs.iter_mut() {
+                    visit_blocks(def);
+                }
+            }
+        }
+        Block::Header(h) => visit_inlines(&mut h.content),
+        Block::Div(d) => visit_blocks(&mut d.content),
+        Block::Figure(f) => {
+            visit_blocks(&mut f.content);
+            if let Some(short) = f.caption.short.as_mut() {
+                visit_inlines(short);
+            }
+            if let Some(long) = f.caption.long.as_mut() {
+                visit_blocks(long);
+            }
+        }
+        Block::Table(t) => {
+            if let Some(short) = t.caption.short.as_mut() {
+                visit_inlines(short);
+            }
+            if let Some(long) = t.caption.long.as_mut() {
+                visit_blocks(long);
+            }
+            for row in t.head.rows.iter_mut().chain(t.foot.rows.iter_mut()) {
+                for cell in row.cells.iter_mut() {
+                    visit_blocks(&mut cell.content);
+                }
+            }
+            for body in t.bodies.iter_mut() {
+                for row in body.head.iter_mut().chain(body.body.iter_mut()) {
+                    for cell in row.cells.iter_mut() {
+                        visit_blocks(&mut cell.content);
+                    }
+                }
+            }
+        }
+        Block::CaptionBlock(cb) => visit_inlines(&mut cb.content),
+        Block::Custom(c) => {
+            for (_name, slot) in c.slots.iter_mut() {
+                visit_slot(slot);
+            }
+        }
+        // Not walked. `CodeBlock` / `RawBlock` / `HorizontalRule` /
+        // `BlockMetadata` are true leaves. The two `NoteDefinition*`
+        // variants do carry content, but `FootnotesTransform` has
+        // already lifted every reachable definition into a trailing
+        // `Div#footnotes` by the time this runs, so anything still in
+        // one is unreferenced and never rendered. Same set
+        // `link_rewrite` skips.
+        Block::CodeBlock(_)
+        | Block::RawBlock(_)
+        | Block::HorizontalRule(_)
+        | Block::BlockMetadata(_)
+        | Block::NoteDefinitionPara(_)
+        | Block::NoteDefinitionFencedBlock(_) => {}
+    }
+}
+
+fn visit_inlines(inlines: &mut Inlines) {
+    for inline in inlines.iter_mut() {
+        visit_inline(inline);
+    }
+}
+
+fn visit_inline(inline: &mut Inline) {
+    match inline {
+        Inline::Image(img) => {
+            apply_to_image(&mut img.attr);
+            // An image's alt-text inlines can themselves hold an image
+            // after a filter pass; keep walking.
+            visit_inlines(&mut img.content);
+        }
+        Inline::Link(l) => visit_inlines(&mut l.content),
+        Inline::Emph(e) => visit_inlines(&mut e.content),
+        Inline::Underline(u) => visit_inlines(&mut u.content),
+        Inline::Strong(s) => visit_inlines(&mut s.content),
+        Inline::Strikeout(s) => visit_inlines(&mut s.content),
+        Inline::Superscript(s) => visit_inlines(&mut s.content),
+        Inline::Subscript(s) => visit_inlines(&mut s.content),
+        Inline::SmallCaps(s) => visit_inlines(&mut s.content),
+        Inline::Quoted(q) => visit_inlines(&mut q.content),
+        Inline::Note(n) => visit_blocks(&mut n.content),
+        Inline::Span(s) => visit_inlines(&mut s.content),
+        Inline::Insert(i) => visit_inlines(&mut i.content),
+        Inline::Delete(d) => visit_inlines(&mut d.content),
+        Inline::Highlight(h) => visit_inlines(&mut h.content),
+        Inline::Custom(c) => {
+            for (_name, slot) in c.slots.iter_mut() {
+                visit_slot(slot);
+            }
+        }
+        // Not walked. Most are true leaves; `Cite` and `EditComment`
+        // do carry inlines, but a `Cite`'s content is generated
+        // citation text and an `EditComment`'s is editorial markup —
+        // neither is authored image content. Same set `link_rewrite`
+        // skips.
+        Inline::Str(_)
+        | Inline::Cite(_)
+        | Inline::Code(_)
+        | Inline::Space(_)
+        | Inline::SoftBreak(_)
+        | Inline::LineBreak(_)
+        | Inline::Math(_)
+        | Inline::RawInline(_)
+        | Inline::Shortcode(_)
+        | Inline::NoteReference(_)
+        | Inline::Attr(_)
+        | Inline::EditComment(_) => {}
+    }
+}
+
+fn visit_slot(slot: &mut Slot) {
+    match slot {
+        Slot::Block(b) => visit_block(b),
+        Slot::Blocks(bs) => visit_blocks(bs),
+        Slot::Inline(i) => visit_inline(i),
+        Slot::Inlines(is) => visit_inlines(is),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hashlink::LinkedHashMap;
+    use quarto_pandoc_types::ConfigMapEntry;
+    use quarto_pandoc_types::attr::{AttrSourceInfo, TargetSourceInfo};
+    use quarto_pandoc_types::block::{
+        Block, BlockQuote, BulletList, CaptionBlock, DefinitionList, Div, Figure, Header,
+        LineBlock, OrderedList, Paragraph, Plain,
+    };
+    use quarto_pandoc_types::caption::Caption;
+    use quarto_pandoc_types::inline::{
+        Emph, Image, Inline, Link, Note, QuoteType, Quoted, Span, Strong,
+    };
+    use quarto_pandoc_types::list::{ListNumberDelim, ListNumberStyle};
+    use quarto_pandoc_types::table::{
+        Alignment, Cell, Row, Table, TableBody, TableFoot, TableHead,
+    };
+    use quarto_source_map::SourceInfo;
+
+    fn si() -> SourceInfo {
+        SourceInfo::for_test()
+    }
+
+    /// Document metadata built from `(key, bool)` pairs.
+    fn meta(entries: &[(&str, bool)]) -> ConfigValue {
+        ConfigValue::new_map(
+            entries
+                .iter()
+                .map(|(k, v)| ConfigMapEntry {
+                    key: k.to_string(),
+                    key_source: SourceInfo::for_test(),
+                    value: ConfigValue::new_bool(*v, SourceInfo::for_test()),
+                })
+                .collect(),
+            SourceInfo::for_test(),
+        )
+    }
+
+    /// Metadata with a bare `theme: <name>` string.
+    fn meta_theme(name: &str) -> ConfigValue {
+        ConfigValue::new_map(
+            vec![ConfigMapEntry {
+                key: "theme".to_string(),
+                key_source: SourceInfo::for_test(),
+                value: ConfigValue::new_string(name.to_string(), SourceInfo::for_test()),
+            }],
+            SourceInfo::for_test(),
+        )
+    }
+
+    fn meta_fig_responsive(value: bool) -> ConfigValue {
+        meta(&[(FIG_RESPONSIVE_KEY, value)])
+    }
+
+    /// A revealjs `Format`. Reveal reaches the pipeline both as the
+    /// native `revealjs` target and as the preview pseudo-format
+    /// `q2-slides`; both must gate the same way.
+    fn reveal_format(target: &str) -> Format {
+        let mut fmt = Format::html();
+        fmt.identifier = crate::format::FormatIdentifier::Revealjs;
+        fmt.target_format = target.to_string();
+        fmt
+    }
+
+    fn attr(classes: &[&str], kvs: &[(&str, &str)]) -> Attr {
+        let mut map = LinkedHashMap::new();
+        for (k, v) in kvs {
+            map.insert(k.to_string(), v.to_string());
+        }
+        (
+            String::new(),
+            classes.iter().map(|c| c.to_string()).collect(),
+            map,
+        )
+    }
+
+    fn image(classes: &[&str], kvs: &[(&str, &str)]) -> Inline {
+        Inline::Image(Image {
+            attr: attr(classes, kvs),
+            content: vec![],
+            target: ("wide.png".to_string(), String::new()),
+            source_info: si(),
+            attr_source: AttrSourceInfo::empty(),
+            target_source: TargetSourceInfo::empty(),
+        })
+    }
+
+    fn para(inlines: Vec<Inline>) -> Block {
+        Block::Paragraph(Paragraph {
+            content: inlines,
+            source_info: si(),
+        })
+    }
+
+    /// Classes of the first image found anywhere under `blocks`.
+    fn first_image_classes(blocks: &[Block]) -> Vec<String> {
+        fn from_block(b: &Block) -> Option<Vec<String>> {
+            match b {
+                Block::Paragraph(p) => p.content.iter().find_map(from_inline),
+                Block::Plain(p) => p.content.iter().find_map(from_inline),
+                Block::Div(d) => d.content.iter().find_map(from_block),
+                Block::BulletList(bl) => bl
+                    .content
+                    .iter()
+                    .find_map(|item| item.iter().find_map(from_block)),
+                _ => None,
+            }
+        }
+        fn from_inline(i: &Inline) -> Option<Vec<String>> {
+            match i {
+                Inline::Image(img) => Some(img.attr.1.clone()),
+                _ => None,
+            }
+        }
+        blocks
+            .iter()
+            .find_map(from_block)
+            .expect("no image in blocks")
+    }
+
+    #[test]
+    fn bare_image_gets_img_fluid() {
+        let mut blocks = vec![para(vec![image(&[], &[])])];
+        visit_blocks(&mut blocks);
+        assert_eq!(first_image_classes(&blocks), vec!["img-fluid".to_string()]);
+    }
+
+    #[test]
+    fn existing_author_classes_are_preserved() {
+        let mut blocks = vec![para(vec![image(&["border", "my-class"], &[])])];
+        visit_blocks(&mut blocks);
+        assert_eq!(
+            first_image_classes(&blocks),
+            vec![
+                "border".to_string(),
+                "my-class".to_string(),
+                "img-fluid".to_string()
+            ],
+            "the class must be appended, never replace what the author wrote"
+        );
+    }
+
+    #[test]
+    fn idempotent_on_second_run() {
+        let mut blocks = vec![para(vec![image(&[], &[])])];
+        visit_blocks(&mut blocks);
+        let first = first_image_classes(&blocks);
+        visit_blocks(&mut blocks);
+        assert_eq!(
+            first_image_classes(&blocks),
+            first,
+            "running twice must not duplicate the class"
+        );
+    }
+
+    #[test]
+    fn author_written_img_fluid_is_not_duplicated() {
+        let mut blocks = vec![para(vec![image(&["img-fluid"], &[])])];
+        visit_blocks(&mut blocks);
+        assert_eq!(first_image_classes(&blocks), vec!["img-fluid".to_string()]);
+    }
+
+    #[test]
+    fn explicit_width_still_gets_img_fluid() {
+        // Not an exclusion: `max-width: 100%` refines a fixed width
+        // rather than fighting it. Quarto 1 tags these too.
+        let mut blocks = vec![para(vec![image(&[], &[("width", "450")])])];
+        visit_blocks(&mut blocks);
+        assert_eq!(first_image_classes(&blocks), vec!["img-fluid".to_string()]);
+    }
+
+    #[test]
+    fn explicit_height_is_excluded() {
+        let mut blocks = vec![para(vec![image(&[], &[("height", "100")])])];
+        visit_blocks(&mut blocks);
+        assert!(
+            first_image_classes(&blocks).is_empty(),
+            "an author-set height must not be overridden by height:auto"
+        );
+    }
+
+    #[test]
+    fn data_no_responsive_is_excluded_whatever_its_value() {
+        for value in ["true", "false", ""] {
+            let mut blocks = vec![para(vec![image(&[], &[("data-no-responsive", value)])])];
+            visit_blocks(&mut blocks);
+            assert!(
+                first_image_classes(&blocks).is_empty(),
+                "data-no-responsive={value:?} must opt the image out; \
+                 only the key's presence is tested"
+            );
+        }
+    }
+
+    /// Number of tagged images anywhere under `blocks`, counted by
+    /// serializing the tree rather than by re-walking it — so this
+    /// assertion cannot share a blind spot with the walk under test.
+    fn tagged_count(blocks: &[Block]) -> usize {
+        serde_json::to_string(blocks)
+            .expect("blocks serialize")
+            .matches("img-fluid")
+            .count()
+    }
+
+    /// Every container the walk claims to descend into, in one
+    /// document. Weakening any arm of `visit_block` / `visit_inline`
+    /// to `{}` drops the count and reddens this test — which the
+    /// div+list test alone did not do for `Table`, `Figure` captions,
+    /// `DefinitionList`, `LineBlock`, `Note`, or `Custom`.
+    #[test]
+    fn every_container_arm_is_walked() {
+        let img = || image(&[], &[]);
+        let blocks = vec![
+            // Block containers
+            Block::Plain(Plain {
+                content: vec![img()],
+                source_info: si(),
+            }),
+            para(vec![img()]),
+            Block::LineBlock(LineBlock {
+                content: vec![vec![img()]],
+                source_info: si(),
+            }),
+            Block::BlockQuote(BlockQuote {
+                content: vec![para(vec![img()])],
+                source_info: si(),
+            }),
+            Block::OrderedList(OrderedList {
+                attr: (1, ListNumberStyle::Decimal, ListNumberDelim::Period),
+                content: vec![vec![para(vec![img()])]],
+                source_info: si(),
+            }),
+            Block::BulletList(BulletList {
+                content: vec![vec![para(vec![img()])]],
+                source_info: si(),
+            }),
+            // Both halves of a definition list: term (inlines) and body (blocks).
+            Block::DefinitionList(DefinitionList {
+                content: vec![(vec![img()], vec![vec![para(vec![img()])]])],
+                source_info: si(),
+            }),
+            Block::Header(Header {
+                level: 1,
+                attr: attr(&[], &[]),
+                content: vec![img()],
+                source_info: si(),
+                attr_source: AttrSourceInfo::empty(),
+            }),
+            Block::Div(Div {
+                attr: attr(&[], &[]),
+                content: vec![para(vec![img()])],
+                source_info: si(),
+                attr_source: AttrSourceInfo::empty(),
+            }),
+            // Figure body plus both caption slots.
+            Block::Figure(Figure {
+                attr: attr(&[], &[]),
+                caption: Caption {
+                    short: Some(vec![img()]),
+                    long: Some(vec![para(vec![img()])]),
+                    source_info: si(),
+                },
+                content: vec![para(vec![img()])],
+                source_info: si(),
+                attr_source: AttrSourceInfo::empty(),
+            }),
+            Block::CaptionBlock(CaptionBlock {
+                content: vec![img()],
+                source_info: si(),
+            }),
+            // Table: long caption, a head cell and a body cell.
+            {
+                let cell = |inner: Inline| Cell {
+                    attr: attr(&[], &[]),
+                    alignment: Alignment::Default,
+                    row_span: 1,
+                    col_span: 1,
+                    content: vec![para(vec![inner])],
+                    source_info: si(),
+                    attr_source: AttrSourceInfo::empty(),
+                };
+                let row = |inner: Inline| Row {
+                    attr: attr(&[], &[]),
+                    cells: vec![cell(inner)],
+                    source_info: si(),
+                    attr_source: AttrSourceInfo::empty(),
+                };
+                Block::Table(Table {
+                    attr: attr(&[], &[]),
+                    caption: Caption {
+                        short: None,
+                        long: Some(vec![para(vec![img()])]),
+                        source_info: si(),
+                    },
+                    colspec: vec![],
+                    head: TableHead {
+                        attr: attr(&[], &[]),
+                        rows: vec![row(img())],
+                        source_info: si(),
+                        attr_source: AttrSourceInfo::empty(),
+                    },
+                    bodies: vec![TableBody {
+                        attr: attr(&[], &[]),
+                        rowhead_columns: 0,
+                        head: vec![],
+                        body: vec![row(img())],
+                        source_info: si(),
+                        attr_source: AttrSourceInfo::empty(),
+                    }],
+                    foot: TableFoot {
+                        attr: attr(&[], &[]),
+                        rows: vec![],
+                        source_info: si(),
+                        attr_source: AttrSourceInfo::empty(),
+                    },
+                    source_info: si(),
+                    attr_source: AttrSourceInfo::empty(),
+                })
+            },
+            // Inline containers, all in one paragraph.
+            para(vec![
+                Inline::Emph(Emph {
+                    content: vec![img()],
+                    source_info: si(),
+                }),
+                Inline::Strong(Strong {
+                    content: vec![img()],
+                    source_info: si(),
+                }),
+                Inline::Quoted(Quoted {
+                    quote_type: QuoteType::DoubleQuote,
+                    content: vec![img()],
+                    source_info: si(),
+                }),
+                Inline::Span(Span {
+                    attr: attr(&[], &[]),
+                    content: vec![img()],
+                    source_info: si(),
+                    attr_source: AttrSourceInfo::empty(),
+                }),
+                Inline::Link(Link {
+                    attr: attr(&[], &[]),
+                    content: vec![img()],
+                    target: ("x".to_string(), String::new()),
+                    source_info: si(),
+                    attr_source: AttrSourceInfo::empty(),
+                    target_source: TargetSourceInfo::empty(),
+                }),
+                Inline::Note(Note {
+                    content: vec![para(vec![img()])],
+                    source_info: si(),
+                }),
+            ]),
+        ];
+        // 12 single-image containers, plus the two definition-list
+        // slots (term + body), the three figure slots (content +
+        // short caption + long caption), the three table slots
+        // (caption + head cell + body cell), and the six inline
+        // containers in the final paragraph.
+        let expected = 23;
+        let mut blocks = blocks;
+        visit_blocks(&mut blocks);
+        assert_eq!(
+            tagged_count(&blocks),
+            expected,
+            "every container arm must be descended into"
+        );
+    }
+
+    #[test]
+    fn image_nested_in_div_and_list_is_reached() {
+        let inner = Block::BulletList(BulletList {
+            content: vec![vec![para(vec![image(&[], &[])])]],
+            source_info: si(),
+        });
+        let mut blocks = vec![Block::Div(Div {
+            attr: attr(&[], &[]),
+            content: vec![inner],
+            source_info: si(),
+            attr_source: AttrSourceInfo::empty(),
+        })];
+        visit_blocks(&mut blocks);
+        assert_eq!(
+            first_image_classes(&blocks),
+            vec!["img-fluid".to_string()],
+            "the walk must reach images nested in containers"
+        );
+    }
+
+    // ── The two gates ─────────────────────────────────────────────────
+
+    #[test]
+    fn gate_is_open_for_html_by_default() {
+        assert!(responsive_enabled(&Format::html(), &ConfigValue::default()));
+    }
+
+    #[test]
+    fn gate_is_closed_for_revealjs() {
+        // Quarto 1's `isHtmlOutput()` IS true for revealjs, but the
+        // filter reads `param('fig-responsive')`, and
+        // `createHtmlPresentationFormat` (formats-shared.ts) sets that
+        // param `false` for every HTML presentation format. So Q1 does
+        // not tag deck images — verified against the real binary, whose
+        // reveal output carries no `img-fluid` at all.
+        assert!(!responsive_enabled(
+            &reveal_format("revealjs"),
+            &ConfigValue::default()
+        ));
+    }
+
+    #[test]
+    fn gate_is_closed_for_the_slides_preview_pseudo_format() {
+        // `q2-slides` is reveal under preview. It maps to
+        // `FormatIdentifier::Html`, so the identifier alone can't see
+        // it — the gate must consult `target_format`, or preview would
+        // disagree with render.
+        assert!(!responsive_enabled(
+            &reveal_format("q2-slides"),
+            &ConfigValue::default()
+        ));
+        // And guard the identifier-only mistake directly: a Format
+        // whose identifier is Html but whose target is a slide deck.
+        let mut fmt = Format::html();
+        fmt.target_format = "q2-slides".to_string();
+        assert!(!responsive_enabled(&fmt, &ConfigValue::default()));
+    }
+
+    #[test]
+    fn gate_is_closed_for_minimal_html() {
+        // `format-html.ts` resolveFormat: `minimal: true` defaults
+        // `fig-responsive` to false. Verified against Q1.
+        assert!(!responsive_enabled(
+            &Format::html(),
+            &meta(&[("minimal", true)])
+        ));
+    }
+
+    #[test]
+    fn gate_is_open_for_theme_none_without_minimal() {
+        // Deliberately NOT `is_minimal_html`, which also returns true
+        // for `theme: none` / `theme: pandoc`. Q1 flips the default
+        // only on `minimal: true`; with a bare `theme: none` both
+        // engines tag. Verified against Q1.
+        assert!(responsive_enabled(&Format::html(), &meta_theme("none")));
+        assert!(responsive_enabled(&Format::html(), &meta_theme("pandoc")));
+    }
+
+    #[test]
+    fn explicit_fig_responsive_true_overrides_the_format_defaults() {
+        // Q1 only supplies these defaults when the user left the key
+        // unset (`=== undefined` / config merge), so an explicit
+        // `fig-responsive: true` wins for both reveal and minimal.
+        // Verified against Q1.
+        assert!(responsive_enabled(
+            &reveal_format("revealjs"),
+            &meta_fig_responsive(true)
+        ));
+        assert!(responsive_enabled(
+            &Format::html(),
+            &meta(&[("minimal", true), (FIG_RESPONSIVE_KEY, true)])
+        ));
+    }
+
+    #[test]
+    fn gate_is_closed_for_non_html_formats() {
+        // `img-fluid` is a Bootstrap class; emitting it into PDF or
+        // any other non-HTML target would be meaningless noise.
+        assert!(!responsive_enabled(&Format::pdf(), &ConfigValue::default()));
+    }
+
+    #[test]
+    fn fig_responsive_false_closes_the_gate() {
+        assert!(!responsive_enabled(
+            &Format::html(),
+            &meta_fig_responsive(false)
+        ));
+    }
+
+    #[test]
+    fn fig_responsive_true_and_absent_both_leave_it_open() {
+        assert!(responsive_enabled(
+            &Format::html(),
+            &meta_fig_responsive(true)
+        ));
+        assert!(responsive_enabled(&Format::html(), &ConfigValue::default()));
+    }
+}

--- a/crates/quarto-core/tests/integration/llms_txt.rs
+++ b/crates/quarto-core/tests/integration/llms_txt.rs
@@ -1097,3 +1097,52 @@ fn llms_undecorated_md_link_stays_static() {
         output_diag_codes(&summary)
     );
 }
+
+/// bd-images-no-max-width-e5ywgnma: `ResponsiveImageTransform` runs
+/// just before the llms capture and appends Bootstrap's `img-fluid`
+/// to every body image. That class is HTML presentation and has no
+/// business in the markdown mirror — `sanitize_attr`'s `class_noise`
+/// predicate must strip it, exactly as it strips `anchored` and
+/// `code-with-copy`.
+///
+/// Without the strip the companion reads
+/// `![A caption](wide.png){.img-fluid}`, which is both noise for a
+/// model reading the mirror and a Bootstrap detail leaking out of the
+/// HTML pipeline.
+#[test]
+fn llms_companion_strips_img_fluid() {
+    let (project_dir, _summary) = render_project(|dir| {
+        write(
+            &dir.join("_quarto.yml"),
+            "project:\n  type: website\n  output-dir: _site\n\
+             website:\n  title: \"Test Site\"\n\
+             \x20 llms-txt: true\n",
+        );
+        write(
+            &dir.join("index.qmd"),
+            "---\ntitle: Home\n---\n\n\
+             ![A caption](wide.png)\n\n\
+             Inline ![i](wide.png) here.\n",
+        );
+        write(&dir.join("wide.png"), "not-really-a-png");
+    });
+
+    let companion = read(&project_dir.join("_site/index.md"));
+    assert_not_contains(
+        &companion,
+        "img-fluid",
+        "the HTML-only responsive class must not reach the markdown companion",
+    );
+    // The images themselves must survive the strip — this is a
+    // sanitize rule, not a drop rule.
+    assert_contains(
+        &companion,
+        "![A caption](wide.png)",
+        "the block image survives with a clean attribute list",
+    );
+    assert_contains(
+        &companion,
+        "![i](wide.png)",
+        "the inline image survives with a clean attribute list",
+    );
+}

--- a/crates/quarto-core/tests/integration/main.rs
+++ b/crates/quarto-core/tests/integration/main.rs
@@ -76,6 +76,7 @@ pub mod render_to_html_captures;
 pub mod render_to_html_user_grammars;
 pub mod replay_engine;
 pub mod repo_actions_pipeline;
+pub mod responsive_images_pipeline;
 pub mod revealjs_features;
 pub mod revealjs_format;
 pub mod secondary_nav_pipeline;

--- a/crates/quarto-core/tests/integration/responsive_images_pipeline.rs
+++ b/crates/quarto-core/tests/integration/responsive_images_pipeline.rs
@@ -1,0 +1,284 @@
+/*
+ * tests/integration/responsive_images_pipeline.rs
+ * Copyright (c) 2026 Posit, PBC
+ *
+ * Integration tests for bd-images-no-max-width-e5ywgnma: body images
+ * carry Bootstrap's `img-fluid` class so an unsized image is capped at
+ * the width of its container instead of laying out at intrinsic width.
+ */
+
+//! End-to-end tests for the responsive-image pass.
+//!
+//! These drive a real `render_to_file` and inspect the emitted `<img>`
+//! tags, mirroring the shared acceptance fixture at
+//! `q2-positron-docs/llms-info/repros/images-no-max-width/`. Its four
+//! cases — plain, `width=`, `height=`, and inline — are reproduced here
+//! as `four_cases_match_quarto_1`, which pins the exact 3-of-4 split
+//! Quarto 1 produces.
+//!
+//! The per-node rules (which images qualify, opt-outs, idempotence) are
+//! unit-tested in `crates/quarto-core/src/transforms/responsive_image.rs`;
+//! what these tests add is proof that the transform is actually wired
+//! into the pipeline the `q2` binary runs.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use tempfile::TempDir;
+
+use quarto_core::render_to_file::{RenderToFileOptions, render_to_file};
+use quarto_system_runtime::{NativeRuntime, SystemRuntime};
+
+fn runtime_arc() -> Arc<dyn SystemRuntime> {
+    Arc::new(NativeRuntime::new())
+}
+
+fn write_file(path: &Path, contents: &str) {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(path, contents).unwrap();
+}
+
+/// Render `source` as a single document and return the emitted HTML.
+fn render_html(source: &str) -> String {
+    let temp = TempDir::new().unwrap();
+    let qmd_path = temp.path().join("doc.qmd");
+    write_file(&qmd_path, source);
+    // The tests reference `wide.png` by name only; nothing reads it,
+    // but resource collection is happier when the file exists.
+    write_file(&temp.path().join("wide.png"), "not-really-a-png");
+
+    let options = RenderToFileOptions::default();
+    let result =
+        render_to_file(&qmd_path, "html", &options, runtime_arc()).expect("single-doc render");
+    std::fs::read_to_string(&result.output_path).expect("read rendered HTML")
+}
+
+/// Every `<img …>` tag in `html`, in document order.
+fn img_tags(html: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut search = html;
+    while let Some(start) = search.find("<img ") {
+        let after = &search[start..];
+        let end = after.find('>').expect("malformed <img>: no closing '>'");
+        out.push(after[..=end].to_string());
+        search = &after[end..];
+    }
+    out
+}
+
+/// The `<img>` tags whose `src` is `wide.png` — i.e. body content,
+/// excluding any navbar/footer chrome.
+fn body_img_tags(html: &str) -> Vec<String> {
+    img_tags(html)
+        .into_iter()
+        .filter(|t| t.contains("src=\"wide.png\""))
+        .collect()
+}
+
+fn has_img_fluid(tag: &str) -> bool {
+    // `class="…"` may hold several classes; match the token, not a
+    // substring of some other class.
+    tag.split("class=\"")
+        .skip(1)
+        .filter_map(|rest| rest.split('"').next())
+        .any(|classes| classes.split_whitespace().any(|c| c == "img-fluid"))
+}
+
+// ── The core regression ───────────────────────────────────────────────────
+
+/// bd-images-no-max-width-e5ywgnma: the bug as reported. A plain image
+/// with no author-supplied sizing must be constrained to its container.
+#[test]
+fn plain_image_gets_img_fluid() {
+    let html = render_html("---\ntitle: T\n---\n\n![A wide screenshot](wide.png)\n");
+    let tags = body_img_tags(&html);
+    assert_eq!(tags.len(), 1, "expected one body <img>; got {tags:?}");
+    assert!(
+        has_img_fluid(&tags[0]),
+        "unsized body image must carry img-fluid; got: {}",
+        tags[0]
+    );
+}
+
+/// The four cases of the shared acceptance fixture, with the exact
+/// split Quarto 1 produces: plain, `width=` and inline are tagged;
+/// `height=` is deliberately skipped.
+#[test]
+fn four_cases_match_quarto_1() {
+    let html = render_html(
+        "---\ntitle: T\n---\n\n\
+         ![A wide screenshot](wide.png)\n\n\
+         ![A wide screenshot, sized](wide.png){width=450}\n\n\
+         ![A wide screenshot, height-sized](wide.png){height=100}\n\n\
+         Text before ![inline](wide.png) text after.\n",
+    );
+    let tags = body_img_tags(&html);
+    assert_eq!(tags.len(), 4, "expected four body <img>; got {tags:?}");
+
+    let tagged: Vec<bool> = tags.iter().map(|t| has_img_fluid(t)).collect();
+    assert_eq!(
+        tagged,
+        vec![true, true, false, true],
+        "img-fluid must land on the plain, width-sized and inline images \
+         but not the height-sized one; got:\n{}",
+        tags.join("\n")
+    );
+}
+
+// ── The two deliberate exclusions ─────────────────────────────────────────
+
+/// An explicit `height` means the author fixed the vertical size;
+/// `max-width:100%; height:auto` would fight it. Quarto 1 skips these
+/// and so must we.
+#[test]
+fn image_with_explicit_height_is_skipped() {
+    let html = render_html("---\ntitle: T\n---\n\n![cap](wide.png){height=100}\n");
+    let tags = body_img_tags(&html);
+    assert_eq!(tags.len(), 1, "expected one body <img>; got {tags:?}");
+    assert!(
+        !has_img_fluid(&tags[0]),
+        "an image with an explicit height must not be made fluid; got: {}",
+        tags[0]
+    );
+}
+
+/// `data-no-responsive` is the per-image opt-out.
+#[test]
+fn data_no_responsive_opts_out() {
+    let html = render_html("---\ntitle: T\n---\n\n![cap](wide.png){data-no-responsive=\"true\"}\n");
+    let tags = body_img_tags(&html);
+    assert_eq!(tags.len(), 1, "expected one body <img>; got {tags:?}");
+    assert!(
+        !has_img_fluid(&tags[0]),
+        "data-no-responsive must suppress img-fluid; got: {}",
+        tags[0]
+    );
+}
+
+// ── The document-level switch ─────────────────────────────────────────────
+
+/// `fig-responsive: false` turns the whole pass off, as in Quarto 1.
+#[test]
+fn fig_responsive_false_disables_the_pass() {
+    let html = render_html(
+        "---\ntitle: T\nfig-responsive: false\n---\n\n![cap](wide.png)\n\n\
+         Inline ![i](wide.png) here.\n",
+    );
+    let tags = body_img_tags(&html);
+    assert_eq!(tags.len(), 2, "expected two body <img>; got {tags:?}");
+    assert!(
+        tags.iter().all(|t| !has_img_fluid(t)),
+        "fig-responsive: false must leave every image untagged; got:\n{}",
+        tags.join("\n")
+    );
+}
+
+/// `fig-responsive: true` is the default, so saying it explicitly
+/// changes nothing.
+#[test]
+fn fig_responsive_true_is_the_default() {
+    let html = render_html("---\ntitle: T\nfig-responsive: true\n---\n\n![cap](wide.png)\n");
+    let tags = body_img_tags(&html);
+    assert_eq!(tags.len(), 1, "expected one body <img>; got {tags:?}");
+    assert!(
+        has_img_fluid(&tags[0]),
+        "fig-responsive: true must behave like the default; got: {}",
+        tags[0]
+    );
+}
+
+// ── The preview pipeline ──────────────────────────────────────────────────
+//
+// `q2 preview` and the hub-client don't run the html render pipeline —
+// they run `build_q2_preview_transform_pipeline` and hand serialized
+// AST to a React renderer. The transform is included there by default
+// (that builder delegates to the same builder and filters by
+// deny-list), but "included" and "reaches the output" are different
+// claims, so these pin the AST the SPA actually receives.
+
+use quarto_core::pipeline::render_qmd_to_preview_ast;
+use quarto_core::project::{DocumentInfo, ProjectContext};
+use quarto_core::render::{BinaryDependencies, RenderContext};
+
+fn preview_test_project() -> ProjectContext {
+    ProjectContext {
+        dir: std::path::PathBuf::from("/project"),
+        config: quarto_core::project::ProjectConfig::default(),
+        is_single_file: true,
+        files: vec![DocumentInfo::from_path("/project/test.qmd")],
+        output_dir: std::path::PathBuf::from("/project"),
+        ..Default::default()
+    }
+}
+
+/// Render `content` through the preview pipeline for `pseudo_format`,
+/// returning the serialized AST JSON the SPA consumes.
+fn render_preview_ast(content: &[u8], pseudo_format: &str) -> String {
+    let project = preview_test_project();
+    let doc = DocumentInfo::from_path("/project/test.qmd");
+    let format = quarto_core::format::Format::from_format_string(pseudo_format)
+        .expect("pseudo-format resolves");
+    let binaries = BinaryDependencies::new();
+    let mut ctx = RenderContext::new(&project, &doc, &format, &binaries);
+    pollster::block_on(render_qmd_to_preview_ast(
+        content,
+        "test.qmd",
+        &mut ctx,
+        runtime_arc(),
+        None,
+        vec![],
+    ))
+    .expect("preview pipeline render")
+    .ast_json
+}
+
+/// `q2-preview` is `format: html` under preview. It must tag images
+/// exactly as the render pipeline does, or the preview shows an
+/// overflowing image for a page that renders correctly.
+#[test]
+fn preview_pipeline_tags_images() {
+    let ast = render_preview_ast(b"---\ntitle: T\n---\n\n![cap](wide.png)\n", "q2-preview");
+    assert!(
+        ast.contains("img-fluid"),
+        "the preview AST must carry img-fluid so preview matches render; got:\n{ast}"
+    );
+}
+
+/// The `height` exclusion holds in preview too — the per-image rules
+/// are pipeline-independent, and a divergence here would be invisible
+/// to every render-path test.
+#[test]
+fn preview_pipeline_honors_the_height_exclusion() {
+    let ast = render_preview_ast(
+        b"---\ntitle: T\n---\n\n![cap](wide.png){height=100}\n",
+        "q2-preview",
+    );
+    assert!(
+        !ast.contains("img-fluid"),
+        "an explicit height must be honored in preview as in render; got:\n{ast}"
+    );
+}
+
+/// `q2-slides` is how every live reveal deck reaches the pipeline.
+/// It is legacy as a user-facing format, but since the bd-vwp4y5ku
+/// convergence `format: revealjs` in hub-client and `q2 preview` is
+/// rewritten to it by `map_format_for_preview` in the WASM entry — so
+/// this is the case that covers the React deck people actually use.
+///
+/// Quarto 1 does not tag deck images, and neither must q2, in either
+/// pipeline. This is also the case an identifier-based format gate
+/// would get wrong, since `q2-slides` resolves to
+/// `FormatIdentifier::Html`.
+#[test]
+fn slides_preview_pipeline_does_not_tag_images() {
+    let ast = render_preview_ast(
+        b"---\ntitle: T\nformat: revealjs\n---\n\n## S\n\nText ![cap](wide.png) here.\n",
+        "q2-slides",
+    );
+    assert!(
+        !ast.contains("img-fluid"),
+        "reveal decks are not tagged in either engine; got:\n{ast}"
+    );
+}


### PR DESCRIPTION
An image with no author-supplied size lays out at its intrinsic pixel width, because q2 emits every body image with no class at all. A 2680×1720 screenshot in an 850px content column renders 2680px wide: it overflows the column, overruns the margin, and puts a horizontal scrollbar on the page. On the Positron docs site this hits 63 images across 20 pages, median intrinsic width 2470px. The images that look fine only escape because their author happened to write an explicit `width=`, which is why the bug hides in a real corpus — about half of any given page is fine and only the unsized images blow out.

`.img-fluid { max-width: 100%; height: auto }` is already in the compiled theme; it arrives with Bootstrap, byte-identical to Quarto 1's. Nothing else in that stylesheet constrains a figure image, and there's no bare `img { max-width }` fallback. The only thing missing was the pass that applies the class.

This adds `ResponsiveImageTransform`, a port of Quarto 1's `quarto-post/responsive.lua`. It runs in the Finalization phase beside `TableBootstrapClassTransform`, its sibling in intent — both inject the Bootstrap classes the theme is keyed off, and both run late enough that crossref-rendered figures are tagged too. Chrome emitted as raw HTML rather than AST nodes (listing thumbnails, navbar logos, page-footer images) stays untagged, as in Quarto 1.

Per-image, both of Quarto 1's exclusions are preserved: an explicit `height`, since `img-fluid` carries `height: auto` and would silently override the size the author asked for; and `data-no-responsive`, honored for any value. An explicit `width` is deliberately *not* an exclusion — `max-width: 100%` still lets a `width=450` image shrink inside a narrower column, so the class refines the author's width rather than fighting it.

## The document-level default is per-format

`fig-responsive` is the switch, but its default is not simply "on for HTML". Quarto 1's filter tests `isHtmlOutput()` *and* reads `param('fig-responsive')`, whose default is set per format: `createHtmlPresentationFormat` sets it `false` for every HTML presentation format, so revealjs is **not** tagged even though `isHtmlOutput()` is true there, and `format-html.ts` does the same for `minimal: true`. Both are suppliers of last resort, so an explicit `fig-responsive: true` still wins.

Verified against the real Quarto 1 binary on all five cases — plain, revealjs, `minimal: true`, `theme: none`, and each with an explicit override. Two details worth knowing if you touch the gate:

- Reveal is matched on `target_format`, not the format identifier. Every live deck arrives as `revealjs` or — since the bd-vwp4y5ku convergence rewrote `format: revealjs` on the way into preview — as `q2-slides`, which resolves to `FormatIdentifier::Html`. An identifier test would tag deck images in preview and not in render.
- The `minimal` check reads the raw metadata flag rather than `is_minimal_html`, which also returns true for `theme: none` / `theme: pandoc` — where both engines *do* tag.

## llms.txt

`img-fluid` is stripped in the llms.txt sanitizer. The transform runs immediately before `LlmsCaptureTransform`, so without the strip every page's `.md` mirror would read `![A caption](wide.png){.img-fluid}` — Bootstrap presentation escaping into output whose whole purpose is clean semantic markdown. `docs/` sets `llms-txt: true` and carries 76 image references, so this is the difference between a clean mirror and 76 pieces of noise in `q2 docs llms`.

## Verification

Against the shared acceptance fixture (`q2-positron-docs/llms-info/repros/images-no-max-width`) — a plain image, one with `width=`, one with `height=`, and one inline. Quarto 1 tags three of four; q2 now tags the same three:

```
== q2 ==                                    == Quarto 1 ==
1  <img src="wide.png" class="img-fluid" />        class="img-fluid figure-img"
2  <img ... class="img-fluid" width="450" />       class="img-fluid figure-img" width="450"
3  <img src="wide.png" height="100" />             height="100" class="figure-img"
4  <img src="wide.png" class="img-fluid" />        class="img-fluid"
   img-fluid: 3 of 4                                  img-fluid: 3 of 4
```

Full `cargo xtask verify` passes (all 14 steps, WASM and hub-client included). Workspace suite: 13578 passed, 199 skipped — +28 against main, exactly the 28 tests added here.

The preview path is covered separately, since `q2 preview` and hub-client hand serialized AST to a React renderer rather than emitting HTML: three tests against `render_qmd_to_preview_ast` pin that `q2-preview` tags, honors the `height` exclusion, and `q2-slides` does not tag. The rest of that chain was traced rather than assumed — `Image.tsx` copies AST classes onto the `<img>` via `className`, and the preview iframe loads the compiled Bootstrap theme through `<link data-q2-theme>`.

## Not included

The `figure-img` class Quarto 1 also puts on figure images. Despite sitting one class away in the output it comes from elsewhere — the DOM postprocessor in `format-html-bootstrap.ts` that sweeps `blockquote`, `figure` and `figure img` in a single pass — and it is cosmetic (`margin-bottom: .5rem; line-height: 1`). Per the repo's no-DOM-postprocessor rule that sweep needs its own AST transform, and splitting one of its three classes off into this one would be worse than deferring all three together. A follow-up should also fold in Quarto 1's third `img-fluid` site (`format-html-bootstrap.ts:333-341`), which force-tags margin-column images, deliberately overriding the `height` exclusion.

Also spotted but out of scope: `TableBootstrapClassTransform` leaks `{.caption-top .table}` into llms companions the same way `img-fluid` did. That predates this branch.

Fixes bd-images-no-max-width-e5ywgnma
