### PR TITLE
Fail the document when an include cannot supply its content

### DIFF
--- a/claude-notes/plans/2026-09-02-failed-include-fails-document.md
+++ b/claude-notes/plans/2026-09-02-failed-include-fails-document.md
@@ -1,0 +1,144 @@
+# A failed include fails the document
+
+**Strand:** `bd-include-parse-failure-dropped-u4rdjxru`
+**Repro:** `q2-positron-docs/llms-info/repros/include-parse-failure-dropped/`
+
+## Overview
+
+When an `{{< include >}}` could not be expanded, `IncludeExpansionStage`
+removed the block from the AST, pushed a diagnostic, and let the render
+carry on. The page landed on disk missing the content the include was
+supposed to supply and counted toward `Rendered N of M`.
+
+The clearest evidence that this was a defect rather than a policy is q2's
+own behaviour on the *same* parse error placed inline instead of in an
+included file:
+
+| page          | shape                                              | before: HTML written | before: included content |
+| ------------- | -------------------------------------------------- | -------------------- | ------------------------ |
+| `index.qmd`   | includes `_broken.qmd`, which has a `Q-2-11`        | **yes**              | **missing**              |
+| `direct.qmd`  | the identical `Q-2-11` inline on the page           | no                   | —                        |
+| `good.qmd`    | includes a file that parses                         | yes                  | present                  |
+| `missing.qmd` | includes a file that does not exist                 | **yes**              | **missing**              |
+
+Same diagnostic, same severity, opposite outcome depending only on which
+file it lived in. The missing-file case was the more alarming half: a
+nonexistent include target was only a *warning* (`Q-17-2`), so a project
+containing just that page rendered **exit 0, no errors at all** — a page
+that quietly lost its main content and reported nothing wrong.
+
+## Root cause
+
+`crates/quarto-core/src/stage/stages/include_expansion.rs`. Every failure
+arm ended the same way:
+
+```rust
+// See the circular-include arm for why the block is
+// removed rather than skipped.
+blocks.remove(i);
+continue;
+```
+
+Removing the block is deliberate and correct — it is the `bd-qpvoamvu` /
+PR #465 fix, which stopped the leftover shortcode from being misreported
+downstream as an unrecognized `include`. What was missing is the other
+half of that story: nothing downstream distinguished "expanded every
+include" from "expanded some and deleted the rest", so the writer produced
+the page as if the document were whole.
+
+## Decisions
+
+**D1 — the failure is fatal, not a louder warning.** The stage returns
+`PipelineError::Structured(ParseError)` carrying the collected diagnostics
+plus the document's own `SourceContext`. `Structured` (rather than
+`StageError`) is what preserves ariadne's ability to draw the snippet
+*inside the included file*: the `StageError` bridge synthesizes a
+`SourceContext` from the including document's bytes only.
+
+**D2 — all three arms abort, not only the parse failure.** The strand
+flagged the circular-include arm (`Q-17-1`) as a separate judgement. What
+settles it is internal consistency: leaving one arm non-fatal reintroduces
+exactly the inconsistency this change exists to remove, and `Q-17-1` is
+emitted from two sites (see D3), so its severity cannot be decided
+independently of `Q-17-2`'s.
+
+Quarto 1 is only weak corroboration here, and the PR should not claim more.
+Measured against `~/bin/quarto` (99.9.9):
+
+| condition | Q1 | q2 after this change |
+| --- | --- | --- |
+| include target missing | `Include directive failed. … could not find file …`, exit 1, no HTML — and it aborts the **whole project**, writing no `_site` at all | error on that page, exit 1, no HTML for it; sibling pages still render |
+| circular include | `RangeError: Maximum call stack size exceeded`, exit 1, no HTML | `Q-17-1`, exit 1, no HTML for that page |
+| included file fails to parse | **no analogue** — Q1's include is a *textual* splice, so there is no "parse the included file" step to fail; the repro's `5" gap` is ordinary text to Q1 and the page renders with its content | `Q-17-3` + the inner diagnostics, exit 1, no HTML for that page |
+
+So the missing-target case is genuine parity in outcome (differing in
+blast radius: Q1 fails the project, q2 fails the page — q2's established
+per-page model, the same one `direct.qmd` already follows). The circular
+case reaches exit 1 by *crashing*, not by its intended error:
+`retrieveInclude` compares the resolved `path` against `retrievedFiles`
+(`include-standalone.ts:41`) but pushes the raw `filename` (`:63`), so the
+guard never matches and the recursion blows the stack. Its own
+`Include directive found circular include` message is unreachable for a
+relatively-written include. And the parse-failure case has no Q1
+counterpart at all.
+
+**D3 — the code-fence (listing) include arms move with them.** `Q-17-1`
+and `Q-17-2` are each emitted from two sites: the block-level expander and
+`splice_fence_text`. Raising the severity at one site only would give a
+single error code two severities and two outcomes. A listing whose source
+file is missing is the same silent hole as a missing block include.
+
+**D4 — `Q-17-1` and `Q-17-2` become errors.** A page silently missing its
+content is not a warning-grade outcome, and error severity is what makes
+the diagnostic unsuppressable (`DiagnosticPolicy::suppresses` returns false
+for errors) — a render that aborts must never abort for a reason the user
+cannot see.
+
+**D5 — expansion runs to completion before failing.** The `unresolved`
+flag is set and the walk continues, so a document with several broken
+includes reports all of them in one pass rather than one per re-render.
+
+**D6 — `Q-17-4` stays a warning.** An include that is not the sole content
+of its paragraph is a *placement* mistake — the expander was never asked to
+serve that position — not an include that tried to supply content and
+failed. Q1 leaves the shortcode text in place there rather than treating it
+as an error.
+
+**D7 — the suppression policy now applies on the error exit too.** A
+failing stage can carry warnings collected before it out through its error;
+`run_pipeline` applies `DiagnosticPolicy` to both exits so a suppressed
+warning does not reappear just because the document later failed. Errors
+are never suppressible, so the failure itself always survives.
+
+**D8 — a failed render must not empty `q2 preview`'s watch set.**
+`quarto_preview::config::resolve_single_file_deps` derives the
+watch/sync set by running the real parse + include-expansion stages, and
+it discarded everything when the stage returned `Err` — so one broken
+include would strand the preview on the broken version, with the file
+the author is editing no longer watched. The stage body is now factored
+into a public `expand_document_includes(&mut DocumentAst, &mut
+StageContext)`, which walks and records identically but hands the
+document back regardless of the verdict. The render pipeline propagates
+the `Err`; the dependency collector ignores it. Pinned by
+`single_file_deps_survive_an_unresolvable_include`.
+
+## Work items
+
+- [x] Failing tests first: integration contracts in
+      `include_expansion_diagnostics.rs` + `include_code_fence.rs`
+      (7 failing on the pre-change binary, all with
+      "expected the render to fail, but it produced a document")
+- [x] `unresolved` flag on `IncludeExpander`, set by all five failure arms
+- [x] `expand_includes_in_blocks` returns `PipelineError::Structured`
+- [x] `Q-17-1` / `Q-17-2` raised from warning to error at both sites
+- [x] `DiagnosticPolicy` applied on `run_pipeline`'s error exit
+- [x] Unit tests reworked to assert the failure while keeping the
+      block-removal (`bd-qpvoamvu`) assertions
+- [x] Error-catalog message templates for `Q-17-1` / `Q-17-2` / `Q-17-3`
+- [x] Docs pages `docs/errors/include/Q-17-{1,2,3}.qmd`
+- [x] `expand_document_includes` seam so `q2 preview`'s dependency
+      collector keeps the watch set when the render fails (D8)
+- [x] smoke-all fixtures `includes/circular` + `includes/missing` moved
+      from `noErrors` + WARN to `shouldError` + ERROR
+- [x] End-to-end verification against the repro project
+- [x] `cargo nextest run --workspace` green

--- a/crates/quarto-core/src/pipeline.rs
+++ b/crates/quarto-core/src/pipeline.rs
@@ -719,16 +719,40 @@ pub async fn run_pipeline(
     // render. `None` for pipelines that stop before the unwrap stage.
     ctx.document_profile = stage_ctx.document_profile;
 
+    // Apply the `diagnostics:` suppression policy resolved by
+    // `MetadataMergeStage`. This is deliberately the *only* place
+    // suppression happens: every per-document diagnostic — from stages,
+    // transforms, pampa, or Lua filters — leaves the pipeline through
+    // here, and every frontend (`quarto render`, `q2 preview`,
+    // hub-client) reads it from here. Doing it inside the render also
+    // puts it strictly before `--strict`'s promotion at the CLI summary
+    // boundary, so a suppressed warning stays suppressed rather than
+    // reappearing as an error (bd-lone-bracket-diagnostic-mxu41qbt).
+    //
+    // Both exits pass through it. A failing stage can carry warnings
+    // collected before it out through its error — an unexpandable
+    // include does exactly that
+    // (bd-include-parse-failure-dropped-u4rdjxru) — and a suppressed
+    // warning must not reappear just because the document later failed.
+    // Errors are never suppressible, so the failure itself always
+    // survives.
+    let policy = stage_ctx.diagnostic_policy;
+
     result
         .map_err(|e| match e {
             // Already-structured errors (built by stages that know
             // their span lives outside the document — see
-            // `theme_diagnostic`). Pass through verbatim so the
-            // ariadne renderer can resolve cross-file references.
-            crate::stage::PipelineError::Structured(pe) => crate::error::QuartoError::Parse(pe),
-            crate::stage::PipelineError::StageError { diagnostics, .. }
-                if !diagnostics.is_empty() =>
-            {
+            // `theme_diagnostic`). Pass through with the stage's own
+            // SourceContext so the ariadne renderer can resolve
+            // cross-file references.
+            crate::stage::PipelineError::Structured(mut pe) => {
+                policy.apply(&mut pe.diagnostics);
+                crate::error::QuartoError::Parse(pe)
+            }
+            crate::stage::PipelineError::StageError {
+                mut diagnostics, ..
+            } if !diagnostics.is_empty() => {
+                policy.apply(&mut diagnostics);
                 // Create a SourceContext for the parse error
                 let mut source_context = SourceContext::new();
                 let content_str = String::from_utf8_lossy(content).to_string();
@@ -741,18 +765,8 @@ pub async fn run_pipeline(
             other => crate::error::QuartoError::Other(other.to_string()),
         })
         .map(|d| {
-            // Apply the `diagnostics:` suppression policy resolved by
-            // `MetadataMergeStage`. This is deliberately the *only* place
-            // suppression happens: every per-document diagnostic — from
-            // stages, transforms, pampa, or Lua filters — leaves the
-            // pipeline through this expression, and every frontend
-            // (`quarto render`, `q2 preview`, hub-client) reads it from
-            // here. Doing it inside the render also puts it strictly
-            // before `--strict`'s promotion at the CLI summary boundary,
-            // so a suppressed warning stays suppressed rather than
-            // reappearing as an error (bd-lone-bracket-diagnostic-mxu41qbt).
             let mut diagnostics = stage_ctx.diagnostics;
-            stage_ctx.diagnostic_policy.apply(&mut diagnostics);
+            policy.apply(&mut diagnostics);
             (d, diagnostics)
         })
 }

--- a/crates/quarto-core/src/stage/mod.rs
+++ b/crates/quarto-core/src/stage/mod.rs
@@ -119,7 +119,7 @@ pub use stages::{
     IncludeResolveStage, LanguageResolveStage, LinkResolutionStage, ListingItemInfoStage,
     MathJsStage, MetadataMergeStage, ParseDocumentStage, PreEngineSugaringStage,
     RenderHtmlBodyStage, ResourceReportStage, SourceConversionStage, UnwrapProfileStage,
-    UserFiltersStage,
+    UserFiltersStage, expand_document_includes,
 };
 
 // Re-export the trace_event macro

--- a/crates/quarto-core/src/stage/stages/include_expansion.rs
+++ b/crates/quarto-core/src/stage/stages/include_expansion.rs
@@ -21,6 +21,28 @@
 //! directory (at every nesting level); a leading `/` is
 //! **project-root-relative** per the Quarto path convention
 //! (bd-w9koo1i2, see [`resolve_include_target`]).
+//!
+//! **An include that cannot supply its content fails the document.**
+//! A missing target, an unparseable target, or an include cycle leaves
+//! a hole where the included content should be. The failed block is
+//! still removed from the AST — that is the bd-qpvoamvu fix, and it
+//! keeps a dead shortcode from being misreported downstream — but the
+//! stage then returns the collected diagnostics as an error, so no
+//! output is written for a document that is missing content it asked
+//! for (bd-include-parse-failure-dropped-u4rdjxru). It matches what q2
+//! already does when the same parse error is written inline on the page
+//! instead of one file away. Expansion continues after a failure so that
+//! every broken include in the document is reported in one pass, not one
+//! per re-render.
+//!
+//! Quarto 1 reaches a comparable outcome for a *missing* target
+//! (`Include directive failed`, no output), though it aborts the whole
+//! project rather than the page. Its circular-include path only gets
+//! there by crashing — `standaloneInclude` checks the resolved path
+//! against a list it fills with raw filenames, so the guard never fires
+//! and the recursion overflows the stack. Do not read Q1 as a designed
+//! precedent for the cycle case; the argument for it here is internal
+//! consistency (see the plan's D2/D3).
 
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
@@ -33,6 +55,7 @@ use quarto_pandoc_types::{Block, Inline};
 use quarto_source_map::SourceInfo;
 
 use crate::document_profile::IncludeEntry;
+use crate::error::ParseError;
 use crate::stage::data::DocumentAst;
 use crate::stage::{PipelineData, PipelineDataKind, PipelineError, PipelineStage, StageContext};
 
@@ -77,43 +100,66 @@ impl PipelineStage for IncludeExpansionStage {
             ));
         };
 
-        let mut include_stack = HashSet::new();
-        let doc_path = doc.path.clone();
-        include_stack.insert(doc_path.clone());
-
-        let injected_file_ids =
-            expand_includes_in_blocks(&mut doc, ctx, &doc_path, &mut include_stack)?;
-
-        // Post-expansion invariant (bd-duplicate-heading-ids-mou5z7ux):
-        // auto-generated ids of include-injected headers are unique
-        // against the whole document, via pandoc's `uniqueIdent` probe.
-        // Only injected headers are ever renamed — ids assigned before
-        // this stage (the reader's per-parse dedup) are stable, so the
-        // stage is a strict no-op on documents without includes, and a
-        // future post-engine pass can re-run the same routine scoped to
-        // engine-inserted headers without invalidating ids downstream
-        // consumers (DocumentProfileStage's outline, cross-doc links)
-        // have already observed (bd-4qjl87ax). Known gap, by that same
-        // decision: a heading emitted by a code cell can still collide
-        // (engines run after this stage).
-        if !injected_file_ids.is_empty() {
-            let ast = std::mem::replace(
-                &mut doc.ast,
-                quarto_pandoc_types::pandoc::Pandoc {
-                    meta: quarto_pandoc_types::config_value::ConfigValue::default(),
-                    blocks: Vec::new(),
-                },
-            );
-            doc.ast = pampa::utils::autoid::dedup_scoped_heading_ids(ast, |header| {
-                header
-                    .source_info
-                    .root_file_id()
-                    .is_some_and(|id| injected_file_ids.contains(&id))
-            });
-        }
+        expand_document_includes(&mut doc, ctx)?;
 
         Ok(PipelineData::DocumentAst(doc))
     }
+}
+
+/// Expand every include in `doc`, in place.
+///
+/// This is the stage's whole body, factored out so a caller can keep the
+/// document when expansion fails. `Err` means an include could not
+/// supply its content (see the module docs), but `doc` is fully walked
+/// either way and its `recorded_includes` side-channel is populated with
+/// every file the walk touched — including the one that failed.
+///
+/// That distinction is what a **dependency collector** needs. `q2
+/// preview` derives its watch/sync set from `recorded_includes`
+/// (`quarto_preview::config::resolve_single_file_deps`), and a document
+/// with a broken include is exactly when the author is editing the
+/// included file: dropping it from the watch set would mean the fix
+/// never re-triggers a render. Such a caller runs this function and
+/// ignores the `Err`; the render pipeline propagates it.
+pub fn expand_document_includes(
+    doc: &mut DocumentAst,
+    ctx: &mut StageContext,
+) -> Result<(), PipelineError> {
+    let mut include_stack = HashSet::new();
+    let doc_path = doc.path.clone();
+    include_stack.insert(doc_path.clone());
+
+    let injected_file_ids = expand_includes_in_blocks(doc, ctx, &doc_path, &mut include_stack)?;
+
+    // Post-expansion invariant (bd-duplicate-heading-ids-mou5z7ux):
+    // auto-generated ids of include-injected headers are unique
+    // against the whole document, via pandoc's `uniqueIdent` probe.
+    // Only injected headers are ever renamed — ids assigned before
+    // this stage (the reader's per-parse dedup) are stable, so the
+    // stage is a strict no-op on documents without includes, and a
+    // future post-engine pass can re-run the same routine scoped to
+    // engine-inserted headers without invalidating ids downstream
+    // consumers (DocumentProfileStage's outline, cross-doc links)
+    // have already observed (bd-4qjl87ax). Known gap, by that same
+    // decision: a heading emitted by a code cell can still collide
+    // (engines run after this stage).
+    if !injected_file_ids.is_empty() {
+        let ast = std::mem::replace(
+            &mut doc.ast,
+            quarto_pandoc_types::pandoc::Pandoc {
+                meta: quarto_pandoc_types::config_value::ConfigValue::default(),
+                blocks: Vec::new(),
+            },
+        );
+        doc.ast = pampa::utils::autoid::dedup_scoped_heading_ids(ast, |header| {
+            header
+                .source_info
+                .root_file_id()
+                .is_some_and(|id| injected_file_ids.contains(&id))
+        });
+    }
+
+    Ok(())
 }
 
 /// Document-level entry point: expand include shortcodes at every
@@ -139,15 +185,34 @@ fn expand_includes_in_blocks(
         ..
     } = doc;
     let mut injected_file_ids = HashSet::new();
-    let mut expander = IncludeExpander {
-        ctx,
-        ast_context,
-        source_context,
-        recorded_includes,
-        include_stack,
-        injected_file_ids: &mut injected_file_ids,
-    };
-    expander.expand_blocks(&mut ast.blocks, current_file)?;
+    let mut unresolved = false;
+    {
+        let mut expander = IncludeExpander {
+            ctx: &mut *ctx,
+            ast_context,
+            source_context: &mut *source_context,
+            recorded_includes,
+            include_stack,
+            injected_file_ids: &mut injected_file_ids,
+            unresolved: &mut unresolved,
+        };
+        expander.expand_blocks(&mut ast.blocks, current_file)?;
+    }
+
+    if unresolved {
+        // Carry every diagnostic collected so far — the include
+        // failures plus anything earlier stages reported — out through
+        // the error, together with the document's own `SourceContext`.
+        // `Structured` is the variant that keeps that context, which is
+        // what lets ariadne draw the snippet inside the *included*
+        // file rather than only at the include site.
+        let diagnostics = std::mem::take(&mut ctx.diagnostics);
+        return Err(PipelineError::Structured(ParseError::new(
+            diagnostics,
+            source_context.clone(),
+        )));
+    }
+
     Ok(injected_file_ids)
 }
 
@@ -169,6 +234,13 @@ struct IncludeExpander<'a> {
     /// injected by this stage (bd-duplicate-heading-ids-mou5z7ux).
     /// Lookup-only set — never iterated.
     injected_file_ids: &'a mut HashSet<quarto_source_map::FileId>,
+    /// Set when an include could not supply its content — a cycle, an
+    /// unreadable target, or one that failed to parse. The walk runs
+    /// to completion regardless (so one pass reports every broken
+    /// include); [`expand_includes_in_blocks`] turns the flag into the
+    /// stage's error afterwards
+    /// (bd-include-parse-failure-dropped-u4rdjxru).
+    unresolved: &'a mut bool,
 }
 
 impl IncludeExpander<'_> {
@@ -214,7 +286,7 @@ impl IncludeExpander<'_> {
             // Check for circular includes
             if self.include_stack.contains(&canonical) {
                 self.ctx.diagnostics.push(
-                    quarto_error_reporting::DiagnosticMessageBuilder::warning("Circular include")
+                    quarto_error_reporting::DiagnosticMessageBuilder::error("Circular include")
                         .with_code("Q-17-1")
                         .with_location(blocks[i].source_info().clone())
                         .problem(format!(
@@ -227,7 +299,9 @@ impl IncludeExpander<'_> {
                 // Remove the failed include's paragraph: the failure is
                 // reported; leaving the shortcode in the AST would make
                 // the shortcode-resolve transform misreport it as an
-                // unknown shortcode (bd-qpvoamvu).
+                // unknown shortcode (bd-qpvoamvu). The document still
+                // fails — see the module docs.
+                *self.unresolved = true;
                 blocks.remove(i);
                 continue;
             }
@@ -237,7 +311,7 @@ impl IncludeExpander<'_> {
                 Ok(bytes) => bytes,
                 Err(e) => {
                     self.ctx.diagnostics.push(
-                        quarto_error_reporting::DiagnosticMessageBuilder::warning(
+                        quarto_error_reporting::DiagnosticMessageBuilder::error(
                             "Include file not found",
                         )
                         .with_code("Q-17-2")
@@ -251,6 +325,7 @@ impl IncludeExpander<'_> {
                     );
                     // See the circular-include arm for why the block is
                     // removed rather than skipped.
+                    *self.unresolved = true;
                     blocks.remove(i);
                     continue;
                 }
@@ -321,6 +396,7 @@ impl IncludeExpander<'_> {
 
                     // See the circular-include arm for why the block is
                     // removed rather than skipped.
+                    *self.unresolved = true;
                     blocks.remove(i);
                     continue;
                 }
@@ -446,9 +522,12 @@ impl IncludeExpander<'_> {
     /// opt-out cannot fire here (the engine writes that class later),
     /// but `shortcodes="false"` is authored and does.
     ///
-    /// Errors are non-fatal: a diagnostic is pushed and the offending
-    /// line is dropped. Dropping rather than leaving it matters for the
-    /// same `?include` reason.
+    /// A target that cannot be read, or one that would recurse, drops
+    /// the offending line — dropping rather than leaving it matters for
+    /// the same `?include` reason — and fails the document, exactly as
+    /// a block-position include does. A listing whose source is missing
+    /// is the same silent hole as a missing block include; the two
+    /// arms emit the same codes and so must carry the same severity.
     fn expand_code_fence(
         &mut self,
         code_block: &mut quarto_pandoc_types::block::CodeBlock,
@@ -489,7 +568,7 @@ impl IncludeExpander<'_> {
             // forever: the spliced copy carries the same include line.
             if self.include_stack.contains(&canonical) {
                 self.ctx.diagnostics.push(
-                    quarto_error_reporting::DiagnosticMessageBuilder::warning("Circular include")
+                    quarto_error_reporting::DiagnosticMessageBuilder::error("Circular include")
                         .with_code("Q-17-1")
                         .with_location(location.clone())
                         .problem(format!(
@@ -499,6 +578,7 @@ impl IncludeExpander<'_> {
                         .add_hint("Check for files that include each other, directly or indirectly")
                         .build(),
                 );
+                *self.unresolved = true;
                 replacements.push((line_idx, None));
                 continue;
             }
@@ -524,7 +604,7 @@ impl IncludeExpander<'_> {
                 }
                 Err(e) => {
                     self.ctx.diagnostics.push(
-                        quarto_error_reporting::DiagnosticMessageBuilder::warning(
+                        quarto_error_reporting::DiagnosticMessageBuilder::error(
                             "Include file not found",
                         )
                         .with_code("Q-17-2")
@@ -536,6 +616,7 @@ impl IncludeExpander<'_> {
                         ))
                         .build(),
                     );
+                    *self.unresolved = true;
                     replacements.push((line_idx, None));
                 }
             }
@@ -1392,53 +1473,30 @@ mod tests {
 
     #[test]
     fn missing_file_produces_diagnostic() {
-        let runtime = Arc::new(MockFileRuntime::new(vec![]));
-        let mut ctx = make_stage_context(runtime);
+        let (_doc, _ctx, result) = try_expand("{{< include nonexistent.qmd >}}", vec![]);
+        let error = failure(result);
 
-        let mut doc = parse_to_doc_ast("{{< include nonexistent.qmd >}}", "/project/doc.qmd");
-
-        let mut include_stack = HashSet::new();
-        include_stack.insert(PathBuf::from("/project/doc.qmd"));
-
-        expand_includes_in_blocks(
-            &mut doc,
-            &mut ctx,
-            &PathBuf::from("/project/doc.qmd"),
-            &mut include_stack,
-        )
-        .unwrap();
-
-        assert_eq!(ctx.diagnostics.len(), 1);
-        assert!(ctx.diagnostics[0].title.contains("not found"));
+        assert_eq!(error.diagnostics.len(), 1);
+        assert!(error.diagnostics[0].title.contains("not found"));
     }
 
     #[test]
     fn circular_include_produces_diagnostic() {
         // doc.qmd includes circular.qmd, which includes doc.qmd
-        let runtime = Arc::new(MockFileRuntime::new(vec![(
-            "/project/circular.qmd",
-            "{{< include doc.qmd >}}",
-        )]));
-        let mut ctx = make_stage_context(runtime);
-
-        let mut doc = parse_to_doc_ast("{{< include circular.qmd >}}", "/project/doc.qmd");
-
-        let mut include_stack = HashSet::new();
-        include_stack.insert(PathBuf::from("/project/doc.qmd"));
-
-        expand_includes_in_blocks(
-            &mut doc,
-            &mut ctx,
-            &PathBuf::from("/project/doc.qmd"),
-            &mut include_stack,
-        )
-        .unwrap();
+        let (_doc, _ctx, result) = try_expand(
+            "{{< include circular.qmd >}}",
+            vec![("/project/circular.qmd", "{{< include doc.qmd >}}")],
+        );
+        let error = failure(result);
 
         // Should have a circular include diagnostic
         assert!(
-            ctx.diagnostics.iter().any(|d| d.title.contains("Circular")),
+            error
+                .diagnostics
+                .iter()
+                .any(|d| d.title.contains("Circular")),
             "Expected circular include diagnostic, got: {:?}",
-            ctx.diagnostics
+            error.diagnostics
         );
     }
 
@@ -1606,28 +1664,12 @@ mod tests {
     }
 
     #[test]
-    fn parse_error_include_removes_block_and_surfaces_inner_diagnostics() {
-        let runtime = Arc::new(MockFileRuntime::new(vec![(
-            "/project/bad.qmd",
-            UNPARSEABLE_QMD,
-        )]));
-        let mut ctx = make_stage_context(runtime);
-
-        let mut doc = parse_to_doc_ast(
+    fn parse_error_include_fails_and_surfaces_inner_diagnostics() {
+        let (doc, _ctx, result) = try_expand(
             "Before\n\n{{< include bad.qmd >}}\n\nAfter",
-            "/project/doc.qmd",
+            vec![("/project/bad.qmd", UNPARSEABLE_QMD)],
         );
-
-        let mut include_stack = HashSet::new();
-        include_stack.insert(PathBuf::from("/project/doc.qmd"));
-
-        expand_includes_in_blocks(
-            &mut doc,
-            &mut ctx,
-            &PathBuf::from("/project/doc.qmd"),
-            &mut include_stack,
-        )
-        .unwrap();
+        let error = failure(result);
 
         // The failed include's paragraph is removed: only Before/After
         // remain, and no include shortcode survives to later transforms.
@@ -1641,20 +1683,22 @@ mod tests {
 
         // Wrapper first, then the included file's own diagnostics.
         assert!(
-            ctx.diagnostics.len() >= 2,
+            error.diagnostics.len() >= 2,
             "expected wrapper + inner diagnostics, got: {:?}",
-            ctx.diagnostics
+            error.diagnostics
         );
-        assert_eq!(ctx.diagnostics[0].code.as_deref(), Some("Q-17-3"));
+        assert_eq!(error.diagnostics[0].code.as_deref(), Some("Q-17-3"));
 
         // The inner diagnostic's location must resolve — through the
-        // parent document's SourceContext — to the included file.
-        let inner = &ctx.diagnostics[1];
+        // SourceContext the error carries — to the included file. This
+        // is why the failure travels as `Structured` and not as a bare
+        // stage error.
+        let inner = &error.diagnostics[1];
         let loc = inner.location.as_ref().expect("inner has a location");
         let mapped = loc
-            .map_offset(0, &doc.source_context)
-            .expect("inner location resolves in the parent SourceContext");
-        let file = doc
+            .map_offset(0, &error.source_context)
+            .expect("inner location resolves in the error's SourceContext");
+        let file = error
             .source_context
             .get_file(mapped.file_id)
             .expect("mapped file registered");
@@ -1676,28 +1720,18 @@ mod tests {
     }
 
     #[test]
-    fn missing_include_removes_block() {
-        let runtime = Arc::new(MockFileRuntime::new(vec![]));
-        let mut ctx = make_stage_context(runtime);
+    fn missing_include_fails_and_removes_block() {
+        let (doc, _ctx, result) =
+            try_expand("Before\n\n{{< include nonexistent.qmd >}}\n\nAfter", vec![]);
+        let error = failure(result);
 
-        let mut doc = parse_to_doc_ast(
-            "Before\n\n{{< include nonexistent.qmd >}}\n\nAfter",
-            "/project/doc.qmd",
+        assert_eq!(failure_codes(&error), vec!["Q-17-2".to_string()]);
+        // Error, not warning: the page would otherwise ship missing the
+        // content it asked for, and a warning can be suppressed.
+        assert_eq!(
+            error.diagnostics[0].kind,
+            quarto_error_reporting::DiagnosticKind::Error
         );
-
-        let mut include_stack = HashSet::new();
-        include_stack.insert(PathBuf::from("/project/doc.qmd"));
-
-        expand_includes_in_blocks(
-            &mut doc,
-            &mut ctx,
-            &PathBuf::from("/project/doc.qmd"),
-            &mut include_stack,
-        )
-        .unwrap();
-
-        assert_eq!(ctx.diagnostics.len(), 1);
-        assert_eq!(ctx.diagnostics[0].code.as_deref(), Some("Q-17-2"));
         assert_eq!(
             doc.ast.blocks.len(),
             2,
@@ -1708,32 +1742,55 @@ mod tests {
     }
 
     #[test]
-    fn circular_include_removes_block() {
-        let runtime = Arc::new(MockFileRuntime::new(vec![(
-            "/project/circular.qmd",
-            "In the loop\n\n{{< include doc.qmd >}}",
-        )]));
-        let mut ctx = make_stage_context(runtime);
+    fn circular_include_fails_and_removes_block() {
+        let (doc, _ctx, result) = try_expand(
+            "{{< include circular.qmd >}}",
+            vec![(
+                "/project/circular.qmd",
+                "In the loop\n\n{{< include doc.qmd >}}",
+            )],
+        );
+        let error = failure(result);
 
-        let mut doc = parse_to_doc_ast("{{< include circular.qmd >}}", "/project/doc.qmd");
-
-        let mut include_stack = HashSet::new();
-        include_stack.insert(PathBuf::from("/project/doc.qmd"));
-
-        expand_includes_in_blocks(
-            &mut doc,
-            &mut ctx,
-            &PathBuf::from("/project/doc.qmd"),
-            &mut include_stack,
-        )
-        .unwrap();
-
-        assert_eq!(ctx.diagnostics.len(), 1);
-        assert_eq!(ctx.diagnostics[0].code.as_deref(), Some("Q-17-1"));
+        assert_eq!(failure_codes(&error), vec!["Q-17-1".to_string()]);
+        assert_eq!(
+            error.diagnostics[0].kind,
+            quarto_error_reporting::DiagnosticKind::Error
+        );
         assert!(
             !has_include_shortcode_block(&doc.ast.blocks),
             "the cyclic include block must be removed, got {:?}",
             doc.ast.blocks
+        );
+    }
+
+    #[test]
+    fn every_broken_include_is_reported_in_one_pass() {
+        // Expansion runs to completion after a failure so that a
+        // document with several broken includes reports all of them,
+        // rather than one per re-render.
+        let (_doc, _ctx, result) = try_expand(
+            "{{< include gone-a.qmd >}}\n\n{{< include gone-b.qmd >}}",
+            vec![],
+        );
+        let error = failure(result);
+        assert_eq!(
+            failure_codes(&error),
+            vec!["Q-17-2".to_string(), "Q-17-2".to_string()]
+        );
+    }
+
+    #[test]
+    fn working_include_does_not_fail_the_document() {
+        let (doc, ctx, result) = try_expand(
+            "Before\n\n{{< include good.qmd >}}\n\nAfter",
+            vec![("/project/good.qmd", "Included content\n")],
+        );
+        assert!(result.is_ok(), "a resolvable include must not fail");
+        assert!(ctx.diagnostics.is_empty(), "{:?}", ctx.diagnostics);
+        assert_eq!(
+            texts(&doc.ast.blocks),
+            vec!["Before", "Included content", "After"]
         );
     }
 
@@ -1749,6 +1806,23 @@ mod tests {
     const WARNING_QMD: &str = "<div>\n\nhello\n\n</div>\n";
 
     fn expand(main: &str, files: Vec<(&str, &str)>) -> (DocumentAst, StageContext) {
+        let (doc, ctx, result) = try_expand(main, files);
+        result.expect("expansion succeeds");
+        (doc, ctx)
+    }
+
+    /// `expand` without the success expectation. The AST is still fully
+    /// walked and mutated when expansion fails, so the block-removal
+    /// contract (bd-qpvoamvu) stays assertable alongside the failure.
+    #[allow(clippy::type_complexity)]
+    fn try_expand(
+        main: &str,
+        files: Vec<(&str, &str)>,
+    ) -> (
+        DocumentAst,
+        StageContext,
+        Result<HashSet<quarto_source_map::FileId>, PipelineError>,
+    ) {
         let runtime = Arc::new(MockFileRuntime::new(files));
         let mut ctx = make_stage_context(runtime);
         let mut doc = parse_to_doc_ast(main, "/project/doc.qmd");
@@ -1756,14 +1830,32 @@ mod tests {
         let mut include_stack = HashSet::new();
         include_stack.insert(PathBuf::from("/project/doc.qmd"));
 
-        expand_includes_in_blocks(
+        let result = expand_includes_in_blocks(
             &mut doc,
             &mut ctx,
             &PathBuf::from("/project/doc.qmd"),
             &mut include_stack,
-        )
-        .unwrap();
-        (doc, ctx)
+        );
+        (doc, ctx, result)
+    }
+
+    /// The diagnostics a failed expansion carries out through its
+    /// error, which is where they live now that they no longer stay on
+    /// the context (bd-include-parse-failure-dropped-u4rdjxru).
+    fn failure(result: Result<HashSet<quarto_source_map::FileId>, PipelineError>) -> ParseError {
+        match result {
+            Err(PipelineError::Structured(parse_error)) => parse_error,
+            Err(other) => panic!("expected a structured error, got {other:?}"),
+            Ok(_) => panic!("expected expansion to fail"),
+        }
+    }
+
+    fn failure_codes(error: &ParseError) -> Vec<String> {
+        error
+            .diagnostics
+            .iter()
+            .filter_map(|d| d.code.clone())
+            .collect()
     }
 
     /// Collapse a block to its plain-text content (Str/Space only) for
@@ -1898,12 +1990,12 @@ mod tests {
     fn cycle_through_container_reports_and_removes() {
         // doc → (div) loop.qmd → doc: the cyclic include is removed
         // from loop.qmd's spliced blocks, inside the div.
-        let (doc, ctx) = expand(
+        let (doc, _ctx, result) = try_expand(
             "::: {.d}\n{{< include loop.qmd >}}\n:::",
             vec![("/project/loop.qmd", "{{< include doc.qmd >}}")],
         );
-        assert_eq!(ctx.diagnostics.len(), 1, "{:?}", ctx.diagnostics);
-        assert_eq!(ctx.diagnostics[0].code.as_deref(), Some("Q-17-1"));
+        let error = failure(result);
+        assert_eq!(failure_codes(&error), vec!["Q-17-1".to_string()]);
         let Block::Div(div) = &doc.ast.blocks[0] else {
             panic!("expected Div, got {:?}", doc.ast.blocks[0]);
         };
@@ -1916,16 +2008,17 @@ mod tests {
 
     #[test]
     fn parse_error_inside_div_reports_and_removes() {
-        let (doc, ctx) = expand(
+        let (doc, _ctx, result) = try_expand(
             "::: {.d}\n{{< include bad.qmd >}}\n:::",
             vec![("/project/bad.qmd", UNPARSEABLE_QMD)],
         );
+        let error = failure(result);
         assert!(
-            ctx.diagnostics.len() >= 2,
+            error.diagnostics.len() >= 2,
             "expected wrapper + inner diagnostics, got {:?}",
-            ctx.diagnostics
+            error.diagnostics
         );
-        assert_eq!(ctx.diagnostics[0].code.as_deref(), Some("Q-17-3"));
+        assert_eq!(error.diagnostics[0].code.as_deref(), Some("Q-17-3"));
         let Block::Div(div) = &doc.ast.blocks[0] else {
             panic!("expected Div, got {:?}", doc.ast.blocks[0]);
         };
@@ -2123,14 +2216,11 @@ mod tests {
     }
 
     #[test]
-    fn code_fence_include_missing_file_reports_and_drops_line() {
-        let (doc, ctx) = expand("```{.python}\nkept\n{{< include gone.py >}}\n```", vec![]);
-        let codes: Vec<_> = ctx
-            .diagnostics
-            .iter()
-            .filter_map(|d| d.code.clone())
-            .collect();
-        assert_eq!(codes, vec!["Q-17-2".to_string()]);
+    fn code_fence_include_missing_file_fails_and_drops_line() {
+        let (doc, _ctx, result) =
+            try_expand("```{.python}\nkept\n{{< include gone.py >}}\n```", vec![]);
+        let error = failure(result);
+        assert_eq!(failure_codes(&error), vec!["Q-17-2".to_string()]);
         // The unresolved shortcode must not survive into the fence:
         // ShortcodeResolveTransform would later render it as the
         // `?include` token this strand exists to remove.
@@ -2200,22 +2290,18 @@ mod tests {
     }
 
     #[test]
-    fn code_fence_include_cycle_reports_and_drops_line() {
+    fn code_fence_include_cycle_fails_and_drops_line() {
         // A file that embeds itself as a listing would recurse forever:
         // the spliced copy carries the same include line.
-        let (doc, ctx) = expand(
+        let (doc, _ctx, result) = try_expand(
             "```{.markdown}\n{{< include a.qmd >}}\n```",
             vec![
                 ("/project/a.qmd", "A-TOP\n{{< include b.qmd >}}\n"),
                 ("/project/b.qmd", "B-TOP\n{{< include a.qmd >}}\n"),
             ],
         );
-        let codes: Vec<_> = ctx
-            .diagnostics
-            .iter()
-            .filter_map(|d| d.code.clone())
-            .collect();
-        assert_eq!(codes, vec!["Q-17-1".to_string()]);
+        let error = failure(result);
+        assert_eq!(failure_codes(&error), vec!["Q-17-1".to_string()]);
         // Expansion stops at the cycle; the offending line is dropped
         // rather than left to become `?include`.
         assert_eq!(first_code_text(&doc.ast.blocks), "A-TOP\nB-TOP");
@@ -2224,16 +2310,12 @@ mod tests {
     #[test]
     fn code_fence_include_of_self_reports_cycle() {
         // The document itself is already on the include stack.
-        let (doc, ctx) = expand(
+        let (doc, _ctx, result) = try_expand(
             "```{.markdown}\n{{< include doc.qmd >}}\n```",
             vec![("/project/doc.qmd", "anything\n")],
         );
-        let codes: Vec<_> = ctx
-            .diagnostics
-            .iter()
-            .filter_map(|d| d.code.clone())
-            .collect();
-        assert_eq!(codes, vec!["Q-17-1".to_string()]);
+        let error = failure(result);
+        assert_eq!(failure_codes(&error), vec!["Q-17-1".to_string()]);
         assert_eq!(first_code_text(&doc.ast.blocks), "");
     }
 

--- a/crates/quarto-core/src/stage/stages/mod.rs
+++ b/crates/quarto-core/src/stage/stages/mod.rs
@@ -87,7 +87,9 @@ pub use code_highlight::CodeHighlightStage;
 pub use compile_theme_css::{CompileThemeCssStage, theme_fingerprint};
 pub use document_profile::DocumentProfileStage;
 pub use engine_execution::{ENGINE_CAPTURE_KIND, EngineExecutionStage};
-pub use include_expansion::{IncludeExpansionStage, collect_include_paths, extract_include_path};
+pub use include_expansion::{
+    IncludeExpansionStage, collect_include_paths, expand_document_includes, extract_include_path,
+};
 pub use include_resolve::IncludeResolveStage;
 pub use language_resolve::LanguageResolveStage;
 pub use link_resolution::LinkResolutionStage;

--- a/crates/quarto-core/tests/integration/include_code_fence.rs
+++ b/crates/quarto-core/tests/integration/include_code_fence.rs
@@ -21,7 +21,9 @@
 //!
 //! Plan: `claude-notes/plans/2026-08-10-include-in-code-block.md`.
 
-use crate::include_expansion_diagnostics::{codes, render_fixture};
+use crate::include_expansion_diagnostics::{
+    codes, error_codes, render_fixture, render_fixture_err,
+};
 
 const APP_PY: &str = "import os\n\nprint(\"hello from app.py\")\n";
 
@@ -282,8 +284,10 @@ async fn nested_code_fence_include_expands_without_token() {
 #[tokio::test]
 async fn self_including_code_fence_reports_a_cycle() {
     // Embedding a document in its own listing would recurse forever:
-    // the spliced copy carries the same include line.
-    let output = render_fixture(
+    // the spliced copy carries the same include line. The listing
+    // cannot be produced, so the document fails rather than shipping
+    // an empty fence.
+    let error = render_fixture_err(
         &[(
             "index.qmd",
             "---\ntitle: Listing\n---\n\n```{.markdown}\n{{< include index.qmd >}}\n```\n",
@@ -293,20 +297,18 @@ async fn self_including_code_fence_reports_a_cycle() {
     .await;
 
     assert!(
-        codes(&output).contains(&"Q-17-1"),
-        "expected a circular-include warning, got {:?}",
-        codes(&output)
-    );
-    assert!(
-        !output.html.contains("?include"),
-        "cycle leaked the error token:\n{}",
-        output.html
+        error_codes(&error).contains(&"Q-17-1"),
+        "expected a circular-include error, got {:?}",
+        error_codes(&error)
     );
 }
 
 #[tokio::test]
-async fn missing_code_fence_include_reports_q_17_2_without_token() {
-    let output = render_fixture(
+async fn missing_code_fence_include_fails_the_document() {
+    // A listing whose source file is gone is the same silent hole as a
+    // missing block-level include: the fence would render with the
+    // included lines simply absent.
+    let error = render_fixture_err(
         &[(
             "index.qmd",
             "---\ntitle: Listing\n---\n\n```{.python}\nkept = 1\n{{< include gone.py >}}\n```\n",
@@ -316,17 +318,8 @@ async fn missing_code_fence_include_reports_q_17_2_without_token() {
     .await;
 
     assert!(
-        codes(&output).contains(&"Q-17-2"),
-        "expected a missing-file warning, got {:?}",
-        codes(&output)
+        error_codes(&error).contains(&"Q-17-2"),
+        "expected a missing-file error, got {:?}",
+        error_codes(&error)
     );
-    // The unresolved line is dropped rather than left to become
-    // `?include` downstream.
-    assert!(
-        !output.html.contains("?include"),
-        "unresolved include leaked the error token:\n{}",
-        output.html
-    );
-    let body = listing_body(&output.html);
-    assert!(body.contains("kept"), "lost the surrounding code:\n{body}");
 }

--- a/crates/quarto-core/tests/integration/include_expansion_diagnostics.rs
+++ b/crates/quarto-core/tests/integration/include_expansion_diagnostics.rs
@@ -6,28 +6,37 @@
  * (bd-qpvoamvu).
  */
 
-//! Full-pipeline integration tests pinning the diagnostics a failing
-//! `{{< include file.qmd >}}` produces. Two contracts:
+//! Full-pipeline integration tests pinning what a failing
+//! `{{< include file.qmd >}}` produces. Three contracts:
 //!
-//! 1. **Inner parse errors surface.** When the included file fails to
+//! 1. **An include that cannot supply its content fails the
+//!    document.** A missing target, an unparseable target, or an
+//!    include cycle leaves a hole where the included content should
+//!    be, so the render aborts instead of writing a page with the
+//!    hole in it (bd-include-parse-failure-dropped-u4rdjxru). This is
+//!    the same outcome the identical parse error already gets when it
+//!    is written inline on the page rather than one file away.
+//!
+//! 2. **Inner parse errors surface.** When the included file fails to
 //!    parse, the Q-17-3 wrapper at the include site is followed by the
 //!    included file's own parse diagnostics, whose locations resolve —
-//!    through the returned `SourceContext` — to the *included* file,
+//!    through the error's `SourceContext` — to the *included* file,
 //!    not the includer. (Previously the wrapper reported only an error
 //!    count and the inner diagnostics were discarded.)
 //!
-//! 2. **No spurious "Unknown shortcode".** A failed include (parse
-//!    error, missing file, or include cycle) must not additionally
-//!    produce Q-16-3 "Shortcode `include` is not recognized" from the
-//!    downstream shortcode-resolve transform. These tests drive the
-//!    full HTML pipeline — through `AstTransformsStage` — precisely so
-//!    that regression is visible.
+//! 3. **No spurious "Unknown shortcode".** A failed include must not
+//!    additionally produce Q-16-3 "Shortcode `include` is not
+//!    recognized" from the downstream shortcode-resolve transform.
+//!    These tests drive the full HTML pipeline — through
+//!    `AstTransformsStage` — precisely so that regression is visible.
 //!
-//! Plan: `claude-notes/plans/2026-08-07-include-error-diagnostics.md`.
+//! Plans: `claude-notes/plans/2026-08-07-include-error-diagnostics.md`,
+//! `claude-notes/plans/2026-09-02-failed-include-fails-document.md`.
 
 use std::path::Path;
 use std::sync::Arc;
 
+use quarto_core::error::{ParseError, QuartoError};
 use quarto_core::format::Format;
 use quarto_core::pipeline::{HtmlRenderConfig, RenderOutput, render_qmd_to_html};
 use quarto_core::project::{DocumentInfo, ProjectConfig, ProjectContext};
@@ -42,8 +51,11 @@ const BAD_QMD: &str = "Some text before the error.\n\
     This line mentions the groups' Unique IDs instead of their names.\n";
 
 /// Write `files` into a temp dir and render `main` through the real
-/// HTML pipeline, returning the collected diagnostics + source context.
-pub async fn render_fixture(files: &[(&str, &str)], main: &str) -> RenderOutput {
+/// HTML pipeline, returning whatever the pipeline returned.
+pub async fn try_render_fixture(
+    files: &[(&str, &str)],
+    main: &str,
+) -> Result<RenderOutput, QuartoError> {
     let tmp = tempfile::TempDir::new().unwrap();
     let project_dir = tmp.path().to_path_buf();
 
@@ -78,15 +90,35 @@ pub async fn render_fixture(files: &[(&str, &str)], main: &str) -> RenderOutput 
         runtime,
     )
     .await
-    .expect("render completes (include failures are diagnostics, not fatal)")
 }
 
-/// Resolve a diagnostic's primary location to `(file_name, row)` via
-/// the render output's `SourceContext`.
-fn resolved_location(d: &DiagnosticMessage, output: &RenderOutput) -> Option<(String, usize)> {
+/// Render `main`, expecting it to succeed.
+pub async fn render_fixture(files: &[(&str, &str)], main: &str) -> RenderOutput {
+    match try_render_fixture(files, main).await {
+        Ok(output) => output,
+        Err(e) => panic!("expected the render to complete, got: {e}"),
+    }
+}
+
+/// Render `main`, expecting the failure a broken include now produces,
+/// and hand back the diagnostics it carries.
+pub async fn render_fixture_err(files: &[(&str, &str)], main: &str) -> ParseError {
+    match try_render_fixture(files, main).await {
+        Err(QuartoError::Parse(parse_error)) => parse_error,
+        Err(other) => panic!("expected a structured parse error, got: {other}"),
+        Ok(_) => panic!("expected the render to fail, but it produced a document"),
+    }
+}
+
+/// Resolve a diagnostic's primary location to `(file_name, row)`
+/// against `source_context`.
+fn resolved_location(
+    d: &DiagnosticMessage,
+    source_context: &quarto_source_map::SourceContext,
+) -> Option<(String, usize)> {
     let loc = d.location.as_ref()?;
-    let mapped = loc.map_offset(0, &output.source_context)?;
-    let file = output.source_context.get_file(mapped.file_id)?;
+    let mapped = loc.map_offset(0, source_context)?;
+    let file = source_context.get_file(mapped.file_id)?;
     let name = Path::new(&file.path)
         .file_name()?
         .to_string_lossy()
@@ -95,15 +127,22 @@ fn resolved_location(d: &DiagnosticMessage, output: &RenderOutput) -> Option<(St
 }
 
 pub fn codes(output: &RenderOutput) -> Vec<&str> {
-    output
-        .diagnostics
+    diagnostic_codes(&output.diagnostics)
+}
+
+pub fn error_codes(error: &ParseError) -> Vec<&str> {
+    diagnostic_codes(&error.diagnostics)
+}
+
+fn diagnostic_codes(diagnostics: &[DiagnosticMessage]) -> Vec<&str> {
+    diagnostics
         .iter()
         .filter_map(|d| d.code.as_deref())
         .collect()
 }
 
-fn assert_no_unknown_shortcode(output: &RenderOutput) {
-    for d in &output.diagnostics {
+fn assert_no_unknown_shortcode_in(diagnostics: &[DiagnosticMessage]) {
+    for d in diagnostics {
         assert_ne!(
             d.code.as_deref(),
             Some("Q-16-3"),
@@ -118,9 +157,38 @@ fn assert_no_unknown_shortcode(output: &RenderOutput) {
     }
 }
 
+pub fn assert_no_unknown_shortcode_err(error: &ParseError) {
+    assert_no_unknown_shortcode_in(&error.diagnostics);
+}
+
+#[tokio::test]
+async fn parse_error_include_fails_the_document() {
+    // The control this bug turns on: the identical parse error written
+    // inline on the page already aborts the document. One file away it
+    // must too — otherwise the page ships with a hole where the
+    // included content should be.
+    let error = render_fixture_err(
+        &[
+            (
+                "index.qmd",
+                "---\ntitle: Repro\n---\n\nBefore.\n\n{{< include \"_bad.qmd\" >}}\n\nAfter.\n",
+            ),
+            ("_bad.qmd", BAD_QMD),
+        ],
+        "index.qmd",
+    )
+    .await;
+
+    assert!(
+        error_codes(&error).contains(&"Q-17-3"),
+        "parse failure must be reported: {:?}",
+        error_codes(&error)
+    );
+}
+
 #[tokio::test]
 async fn parse_error_include_surfaces_inner_diagnostic() {
-    let output = render_fixture(
+    let error = render_fixture_err(
         &[
             (
                 "index.qmd",
@@ -134,39 +202,46 @@ async fn parse_error_include_surfaces_inner_diagnostic() {
 
     // The wrapper: anchored at the include site in index.qmd (line 7,
     // 0-indexed row 6).
-    let wrapper = output
+    let wrapper = error
         .diagnostics
         .iter()
         .find(|d| d.code.as_deref() == Some("Q-17-3"))
-        .unwrap_or_else(|| panic!("expected Q-17-3 wrapper, got codes {:?}", codes(&output)));
+        .unwrap_or_else(|| {
+            panic!(
+                "expected Q-17-3 wrapper, got codes {:?}",
+                error_codes(&error)
+            )
+        });
     assert_eq!(
-        resolved_location(wrapper, &output),
+        resolved_location(wrapper, &error.source_context),
         Some(("index.qmd".to_string(), 6)),
         "wrapper must point at the include site"
     );
 
     // The inner diagnostic: the included file's own parse error, with
     // a location that resolves to _bad.qmd row 2 (the apostrophe line).
-    let inner = output
+    let inner = error
         .diagnostics
         .iter()
-        .find(|d| resolved_location(d, &output).is_some_and(|(name, _)| name == "_bad.qmd"))
+        .find(|d| {
+            resolved_location(d, &error.source_context).is_some_and(|(name, _)| name == "_bad.qmd")
+        })
         .unwrap_or_else(|| {
             panic!(
                 "expected an inner diagnostic located in _bad.qmd; got: {:?}",
-                output
+                error
                     .diagnostics
                     .iter()
                     .map(|d| (
                         d.code.clone(),
                         d.title.clone(),
-                        resolved_location(d, &output)
+                        resolved_location(d, &error.source_context)
                     ))
                     .collect::<Vec<_>>()
             )
         });
     assert_eq!(
-        resolved_location(inner, &output).unwrap().1,
+        resolved_location(inner, &error.source_context).unwrap().1,
         2,
         "inner diagnostic must point at the offending line of _bad.qmd"
     );
@@ -179,7 +254,7 @@ async fn parse_error_include_surfaces_inner_diagnostic() {
 
 #[tokio::test]
 async fn parse_error_include_no_unknown_shortcode_warning() {
-    let output = render_fixture(
+    let error = render_fixture_err(
         &[
             (
                 "index.qmd",
@@ -192,16 +267,16 @@ async fn parse_error_include_no_unknown_shortcode_warning() {
     .await;
 
     assert!(
-        codes(&output).contains(&"Q-17-3"),
+        error_codes(&error).contains(&"Q-17-3"),
         "parse failure must be reported: {:?}",
-        codes(&output)
+        error_codes(&error)
     );
-    assert_no_unknown_shortcode(&output);
+    assert_no_unknown_shortcode_err(&error);
 }
 
 #[tokio::test]
-async fn missing_include_reports_not_found_without_unknown_shortcode() {
-    let output = render_fixture(
+async fn missing_include_fails_the_document() {
+    let error = render_fixture_err(
         &[(
             "index.qmd",
             "---\ntitle: Repro\n---\n\n{{< include \"_nonexistent.qmd\" >}}\n",
@@ -211,16 +286,25 @@ async fn missing_include_reports_not_found_without_unknown_shortcode() {
     .await;
 
     assert!(
-        codes(&output).contains(&"Q-17-2"),
+        error_codes(&error).contains(&"Q-17-2"),
         "missing include must be reported: {:?}",
-        codes(&output)
+        error_codes(&error)
     );
-    assert_no_unknown_shortcode(&output);
+    // Error severity, not warning: a page that quietly lost its main
+    // content is not a warning-grade outcome, and an error is the one
+    // severity `diagnostics:` suppression cannot silence.
+    let missing = error
+        .diagnostics
+        .iter()
+        .find(|d| d.code.as_deref() == Some("Q-17-2"))
+        .unwrap();
+    assert_eq!(missing.kind, quarto_error_reporting::DiagnosticKind::Error);
+    assert_no_unknown_shortcode_err(&error);
 }
 
 #[tokio::test]
-async fn circular_include_reports_cycle_without_unknown_shortcode() {
-    let output = render_fixture(
+async fn circular_include_fails_the_document() {
+    let error = render_fixture_err(
         &[
             (
                 "index.qmd",
@@ -233,11 +317,45 @@ async fn circular_include_reports_cycle_without_unknown_shortcode() {
     .await;
 
     assert!(
-        codes(&output).contains(&"Q-17-1"),
+        error_codes(&error).contains(&"Q-17-1"),
         "include cycle must be reported: {:?}",
+        error_codes(&error)
+    );
+    let cycle = error
+        .diagnostics
+        .iter()
+        .find(|d| d.code.as_deref() == Some("Q-17-1"))
+        .unwrap();
+    assert_eq!(cycle.kind, quarto_error_reporting::DiagnosticKind::Error);
+    assert_no_unknown_shortcode_err(&error);
+}
+
+#[tokio::test]
+async fn good_include_still_renders() {
+    // The other side of the contract: an include that *can* supply its
+    // content is untouched by any of this.
+    let output = render_fixture(
+        &[
+            (
+                "index.qmd",
+                "---\ntitle: Repro\n---\n\nBefore.\n\n{{< include \"_good.qmd\" >}}\n\nAfter.\n",
+            ),
+            ("_good.qmd", "Included content.\n"),
+        ],
+        "index.qmd",
+    )
+    .await;
+
+    assert!(
+        codes(&output).is_empty(),
+        "a working include must render clean: {:?}",
         codes(&output)
     );
-    assert_no_unknown_shortcode(&output);
+    assert!(
+        output.html.contains("Included content."),
+        "included content missing from the page:\n{}",
+        output.html
+    );
 }
 
 #[tokio::test]
@@ -246,6 +364,10 @@ async fn inline_include_reports_not_expanded_not_unknown() {
     // expanded by IncludeExpansionStage. It must NOT be reported as an
     // unknown shortcode ("check for typos" — the name is fine); it
     // gets the dedicated Q-17-4 "include not expanded here" warning.
+    //
+    // This one stays non-fatal: the shortcode is in a position the
+    // expander does not serve, which is an authoring mistake about
+    // placement rather than an include that tried and failed.
     let output = render_fixture(
         &[
             (
@@ -263,5 +385,5 @@ async fn inline_include_reports_not_expanded_not_unknown() {
         "unexpanded include must get the dedicated diagnostic: {:?}",
         codes(&output)
     );
-    assert_no_unknown_shortcode(&output);
+    assert_no_unknown_shortcode_in(&output.diagnostics);
 }

--- a/crates/quarto-error-catalog/error_catalog.json
+++ b/crates/quarto-error-catalog/error_catalog.json
@@ -1381,21 +1381,21 @@
   "Q-17-1": {
     "subsystem": "include",
     "title": "Circular Include",
-    "message_template": "An `{{< include >}}` chain leads back to a file that is already being included, directly or indirectly. The cyclic include is skipped and its content is omitted from the output. Break the cycle by removing one of the includes in the chain.",
+    "message_template": "An `{{< include >}}` chain leads back to a file that is already being included, directly or indirectly. The cyclic include cannot supply any content, so the document fails to render rather than being written with the content missing. Break the cycle by removing one of the includes in the chain.",
     "docs_url": "https://quarto.org/docs/errors/include/Q-17-1",
     "since_version": "99.9.9"
   },
   "Q-17-2": {
     "subsystem": "include",
     "title": "Include File Not Found",
-    "message_template": "The file named by an `{{< include >}}` shortcode could not be read. The include is skipped and its content is omitted from the output. The path is resolved relative to the directory of the file containing the shortcode — check it for typos and check that the file exists.",
+    "message_template": "The file named by an `{{< include >}}` shortcode could not be read. Its content cannot be supplied, so the document fails to render rather than being written with the content missing. The path is resolved relative to the directory of the file containing the shortcode — check it for typos and check that the file exists.",
     "docs_url": "https://quarto.org/docs/errors/include/Q-17-2",
     "since_version": "99.9.9"
   },
   "Q-17-3": {
     "subsystem": "include",
     "title": "Include File Parse Error",
-    "message_template": "The file named by an `{{< include >}}` shortcode was read but could not be parsed as qmd. The include is skipped and its content is omitted from the output. The included file's own parse errors are reported alongside this one — fix those and the include will succeed.",
+    "message_template": "The file named by an `{{< include >}}` shortcode was read but could not be parsed as qmd. Its content cannot be supplied, so the document fails to render rather than being written with the content missing. The included file's own parse errors are reported alongside this one — fix those and the include will succeed.",
     "docs_url": "https://quarto.org/docs/errors/include/Q-17-3",
     "since_version": "99.9.9"
   },

--- a/crates/quarto-preview/src/config.rs
+++ b/crates/quarto-preview/src/config.rs
@@ -267,8 +267,8 @@ pub fn resolve_single_file_deps(
 
     use quarto_core::project::{DocumentInfo, ProjectContext};
     use quarto_core::stage::{
-        IncludeExpansionStage, LoadedSource, ParseDocumentStage, PipelineData, PipelineStage,
-        StageContext,
+        LoadedSource, ParseDocumentStage, PipelineData, PipelineStage, StageContext,
+        expand_document_includes,
     };
 
     let abs_deck = project_root.join(single_file_rel);
@@ -296,19 +296,22 @@ pub fn resolve_single_file_deps(
     // tokio runtime (the same pattern `quarto-preview` uses elsewhere). Include
     // expansion reads included files through `ctx.runtime` (the native FS).
     let parse = ParseDocumentStage;
-    let expand = IncludeExpansionStage::new();
-    let expanded = pollster::block_on(async {
-        let parsed = parse
-            .run(
-                PipelineData::LoadedSource(LoadedSource::new(abs_deck.clone(), source)),
-                &mut ctx,
-            )
-            .await?;
-        expand.run(parsed, &mut ctx).await
-    });
-    let Ok(PipelineData::DocumentAst(doc)) = expanded else {
+    let parsed = pollster::block_on(parse.run(
+        PipelineData::LoadedSource(LoadedSource::new(abs_deck.clone(), source)),
+        &mut ctx,
+    ));
+    let Ok(PipelineData::DocumentAst(mut doc)) = parsed else {
         return SingleFileDeps::default();
     };
+
+    // An include that cannot supply its content fails the *render*
+    // (bd-include-parse-failure-dropped-u4rdjxru) but must not empty the
+    // *watch set*: a broken include is precisely when the author is
+    // editing the included file, and dropping it here would mean the fix
+    // never re-triggers a render. `expand_document_includes` populates
+    // `recorded_includes` for every file the walk touched either way, so
+    // the failure is deliberately ignored.
+    let _ = expand_document_includes(&mut doc, &mut ctx);
 
     let canonical_root = project_root
         .canonicalize()
@@ -676,6 +679,38 @@ mod tests {
             deps.qmd_files.is_empty(),
             "missing/escaping/non-tsx entries must all be dropped; got {:?}",
             deps.qmd_files,
+        );
+    }
+
+    /// A document whose include cannot be resolved still yields its other
+    /// dependencies. The render fails in that state
+    /// (bd-include-parse-failure-dropped-u4rdjxru), but the watch set is
+    /// what lets the author's fix re-trigger a render — emptying it would
+    /// strand the preview on the broken version.
+    #[test]
+    fn single_file_deps_survive_an_unresolvable_include() {
+        let temp = TempDir::new().unwrap();
+        let root = temp.path();
+        std::fs::write(root.join("good.qmd"), "![pic](logo.png)\n").unwrap();
+        std::fs::write(root.join("logo.png"), b"\x89PNG\r\n").unwrap();
+        std::fs::write(
+            root.join("main.qmd"),
+            "{{< include good.qmd >}}\n\n{{< include gone.qmd >}}\n",
+        )
+        .unwrap();
+
+        let deps = resolve_single_file_deps(root, std::path::Path::new("main.qmd"), native_arc());
+        assert_eq!(
+            deps.qmd_files,
+            vec![std::path::PathBuf::from("good.qmd")],
+            "the resolvable include must still be watched; got {:?}",
+            deps.qmd_files,
+        );
+        assert_eq!(
+            deps.binary_files,
+            vec![std::path::PathBuf::from("logo.png")],
+            "deps reached through the resolvable include must survive too; got {:?}",
+            deps.binary_files,
         );
     }
 

--- a/crates/quarto/tests/smoke-all/includes/circular/circular.qmd
+++ b/crates/quarto/tests/smoke-all/includes/circular/circular.qmd
@@ -4,10 +4,9 @@ format: html
 _quarto:
   tests:
     html:
-      dom-parity: true
-      noErrors: default
+      shouldError: default
       printsMessage:
-        level: WARN
+        level: ERROR
         regex: "Circular include"
 ---
 

--- a/crates/quarto/tests/smoke-all/includes/missing/missing.qmd
+++ b/crates/quarto/tests/smoke-all/includes/missing/missing.qmd
@@ -4,10 +4,9 @@ format: html
 _quarto:
   tests:
     html:
-      dom-parity: true
-      noErrors: default
+      shouldError: default
       printsMessage:
-        level: WARN
+        level: ERROR
         regex: "Include file not found"
 ---
 

--- a/docs/errors/include/Q-17-1.qmd
+++ b/docs/errors/include/Q-17-1.qmd
@@ -19,9 +19,13 @@ categories:
 An `{{{< include >}}}` shortcode names a file that is already part of
 the chain of includes being expanded — either the file includes
 itself, or two or more files include each other in a loop. Expanding
-the include would never terminate, so Quarto skips it: the cyclic
-include contributes nothing to the output, and the rest of the
-document renders normally.
+the include would never terminate, so Quarto cannot supply the
+content it asks for.
+
+The document therefore **fails to render**, and no output file is
+written for it. A page written without the included content would
+look complete while quietly missing a section, so Quarto reports the
+problem instead of shipping the hole.
 
 ## Why this happens
 

--- a/docs/errors/include/Q-17-2.qmd
+++ b/docs/errors/include/Q-17-2.qmd
@@ -17,8 +17,13 @@ categories:
 
 An `{{{< include >}}}` shortcode names a file that Quarto could not
 read — most often because no file exists at the resolved path. The
-include is skipped: its content is omitted from the output, and the
-rest of the document renders normally.
+content the include asks for cannot be supplied.
+
+The document therefore **fails to render**, and no output file is
+written for it. A page written without the included content would
+look complete while quietly missing a section, so Quarto reports the
+problem instead of shipping the hole. (Quarto 1 also treats an
+unreadable include as fatal.)
 
 ## Why this happens
 

--- a/docs/errors/include/Q-17-3.qmd
+++ b/docs/errors/include/Q-17-3.qmd
@@ -17,8 +17,13 @@ categories:
 ## What this means
 
 An `{{{< include >}}}` shortcode names a file that exists and was
-read, but the file's content is not valid qmd. The include is
-skipped: its content is omitted from the output.
+read, but the file's content is not valid qmd, so the content the
+include asks for cannot be supplied.
+
+The document therefore **fails to render**, and no output file is
+written for it — the same outcome the identical parse error would
+get if it were written directly on the page instead of one file
+away.
 
 This error is a *wrapper*: it marks the include site in the
 including document, and the included file's own parse errors are


### PR DESCRIPTION
An `{{< include >}}` that could not be expanded was dropped from the AST and the render carried on. The page landed on disk missing the content the include was supposed to supply, and counted toward `Rendered N of M`.

The clearest way to see that this was a defect and not a policy is q2's own behaviour on the *same* parse error placed inline instead of in an included file:

| page | shape | HTML written | included content |
| --- | --- | --- | --- |
| `index.qmd` | includes `_broken.qmd`, which has a `Q-2-11` | **yes** | **missing** |
| `direct.qmd` | the identical `Q-2-11` inline on the page | no | — |
| `good.qmd` | includes a file that parses | yes | present |
| `missing.qmd` | includes a file that does not exist | **yes** | **missing** |

Same diagnostic, same severity, opposite outcome depending only on which file it lived in. q2 summarised that four-page project as `Rendered 3 of 4 files`, with `index.qmd` counted among the three successes.

The missing-file half was the worse one. A nonexistent include target was only a warning (`Q-17-2`), so a project containing just that page rendered **exit 0 with nothing reported at all** — a page that had quietly lost its main content and said nothing about it.

## What changes

An include that cannot supply its content now fails the document: no output file is written for it, and it counts against `Rendered N of M`. That covers all three conditions — a target that cannot be read (`Q-17-2`), one that exists but does not parse (`Q-17-3`), and an include cycle (`Q-17-1`) — and both positions an include can appear in, block-level and inside a fenced code block. `Q-17-1` and `Q-17-2` become errors rather than warnings; error severity is also what keeps them out of reach of `diagnostics:` suppression, since a render that aborts must not abort for a reason the author cannot see.

On the same four-page project:

```
Rendered 1 of 4 files — 4 errors, 1 warning
  page      written   included
  index     NO        -
  direct    NO        -
  good      yes       yes
  missing   NO        -
```

No new diagnostic codes.

## What the author sees

The diagnostics keep their existing shape. A broken include produces a **pair**: a `Q-17-3` wrapper anchored at the include site in the *including* file, followed by the included file's own parse errors, each with a snippet drawn from *that* file. Given

```markdown
::: index.qmd
---
title: "B1 — include whose target fails to parse"
---

Before the include.

{{< include "_broken.qmd" >}}

After the include.
:::
```

```markdown
::: _broken.qmd
## Keybindings

This line has an unmatched double quote: a 5" gap.

| Action | Shortcut |
|--------|----------|
| Run    | Ctrl-R   |
| Quit   | Ctrl-Q   |
:::
```

`q2 render` now reports both halves and writes nothing:

```
Error: [Q-17-3] Include file parse error
   ╭─[ index.qmd:7:1 ]
   │
 7 │ {{< include "_broken.qmd" >}}
   │ ───────────────┬──────────────
   │                ╰──────────────── Included file '_broken.qmd' has 1 parse error(s), reported below
───╯

Error: [Q-2-11] Unclosed Double Quote
   ╭─[ _broken.qmd:3:46 ]
   │
 3 │ This line has an unmatched double quote: a 5" gap.
   │                                             ┬┬
   │                                             ╰─── This is the opening quote mark.
   │                                              │
   │                                              ╰── I reached the end of the block before finding a closing '"' for the quote.
───╯
```

Preserving that second snippet across the abort is why the failure travels as `PipelineError::Structured`, which carries the document's own `SourceContext`. The plain `StageError` bridge synthesizes a context from the *including* file's bytes only, and the inner span would render against the wrong text.

The catalog `message_template`s for all three codes, and their `docs/errors/include/` pages, previously said the include was "skipped" and the rest of the document rendered normally. Those are corrected.

## On Quarto 1

Only the missing-target case is genuine parity, and even there the blast radius differs. Measured against `~/bin/quarto`:

| condition | Quarto 1 | q2 after this change |
| --- | --- | --- |
| target missing | `Include directive failed. … could not find file …`, exit 1, no HTML — aborts the **whole project** | error on that page, exit 1, no HTML for it; siblings still render |
| circular include | `RangeError: Maximum call stack size exceeded`, exit 1, no HTML | `Q-17-1`, exit 1, no HTML for that page |
| included file fails to parse | **no analogue** | `Q-17-3` + inner diagnostics, exit 1, no HTML for that page |

Q1's circular path reaches exit 1 by crashing rather than by its own guard: `retrieveInclude` compares the resolved `path` against `retrievedFiles` (`include-standalone.ts:41`) but pushes the raw `filename` (`:63`), so for any relatively-written include the guard never fires and the recursion overflows the stack — its `Include directive found circular include` message is unreachable. And the parse-failure case has no Q1 counterpart at all: Q1's include is a *textual* splice, so there is no separate "parse the included file" step; the repro's `5" gap` is ordinary text to Q1 and that page renders with its content.

So Q1 is corroboration for the missing-target case, not the argument for the rest. The argument for making the cycle case fatal is internal consistency: `Q-17-1` and `Q-17-2` are each emitted from two sites (block-level expander and `splice_fence_text`), and raising severity at one only would give a single error code two severities and two outcomes. A listing whose source file is missing is the same silent hole as a missing block include.

## What deliberately does not change

Removing the failed block from the AST is still what happens; that is the fix from #465, and it is what keeps a dead shortcode from being misreported downstream as an unrecognized `include`. This adds the half that was missing from it — something downstream that knows the document is incomplete.

`Q-17-4` — an include written in a position the expander does not serve, such as mid-paragraph — stays a warning. That is a placement mistake, not an include that tried to supply content and failed.

## Two consequences handled along the way

`q2 preview` derives its watch/sync set from the same stage, and discarded the whole set when the stage errs. One broken include would have stranded the preview on the broken version, with the very file the author is editing no longer watched. The stage body is factored into a public `expand_document_includes()`, which walks and records identically but hands the document back regardless of the verdict — the render pipeline propagates the error, the dependency collector ignores it.

`DiagnosticPolicy` now applies to diagnostics that leave the pipeline through an error, not only through a successful render. A failing stage can carry earlier warnings out with it, and a suppressed warning should not reappear just because the document later failed.

## Verification

- Workspace `13595 passed / 0 failed / 199 skipped`, against `13590 / 199` on `main` — +5, exactly the tests added.
- `cargo clippy --all-targets -- -D warnings` clean on the touched crates; `cargo xtask lint` clean; `cargo xtask verify` green.
- Exercised end to end through `q2 render` on the four-page repro and on isolated single-file fixtures for the missing-target, listing, and working-include cases; output inspected in each.
- Two smoke-all fixtures (`includes/circular`, `includes/missing`) moved from `noErrors` + WARN to `shouldError` + ERROR.

Closes `bd-include-parse-failure-dropped-u4rdjxru`.
