### PR TITLE
Don't execute a cell that is being displayed (bd-knitr-executes-nested-display-fence-atbtktdj)

### DIFF
--- a/claude-notes/plans/2026-09-02-nested-cell-masking.md
+++ b/claude-notes/plans/2026-09-02-nested-cell-masking.md
@@ -541,9 +541,39 @@ Phase 1 cannot pin this — a correct-looking render is achievable with the
 provenance wrong, so an implementer who skips this phase gets a green suite
 and ships the drift. These tests are the only thing guarding it.
 
-- [ ] Changed blocks, and the top-level ancestor of a changed nested block, get `Generated` + the `Other("nested-cell-mask/origin")` anchor
-- [ ] Test: `map_offset` into a masked block returns `None`; an unmasked sibling in the same document still resolves to its true offset
-- [ ] Test: a document with no nested fences yields a `SourceInfo::Concat` whose pieces are identical to an unmasked run (compare piece `offset_in_concat`/`length` pairs)
+- [x] Changed blocks, and the top-level ancestor of a changed nested block, get `Generated` + the `Other("nested-cell-mask/origin")` anchor
+- [x] Test: `map_offset` into a masked block returns `None`; an unmasked sibling in the same document still resolves to its true offset
+- [x] Test: a document with no nested fences yields a `SourceInfo::Concat` whose pieces are identical to an unmasked run (compare piece `offset_in_concat`/`length` pairs)
+
+**Phase 3 findings (2026-09-03).** All stamping lives inside `mask` (R1) — no
+second entry point. Two call sites produce the `Generated { by: { kind:
+"nested-cell-mask" }, from: [Other("nested-cell-mask/origin")] }` node: (a)
+`mask_block`'s direct-`CodeBlock` arm stamps the block itself the moment
+`mask_code_block_text` reports a change; (b) `mask`'s top-level loop captures
+each top-level block's pre-mutation `SourceInfo` before recursing, and — only
+if that top-level block is not already `Generated` from (a) — stamps it too
+after `mask_block` returns `true`. This covers both shapes the writer's
+top-level-only piece loop needs to see: a display block that *is* the
+top-level block (T15), and one nested inside a container whose top-level
+ancestor must carry the marking instead (T17), without double-stamping the
+same-object case. A private `mark_generated` helper (not a public API)
+factors the shared construction.
+
+Verified (`nested_cell_mask.rs` only touched; `cargo clippy -p quarto-core
+--all-targets -- -D warnings` clean): `quarto-core` 4329 run / 4319 passed /
+10 failed / 31 skipped — down from Phase 2's 12 failures by exactly T15 and
+T17, the Phase 3 gate. The remaining 10 (T1, T2, T4–T8, T19, T20, T22) are
+render/capture-tier, expected red pending Phase 4's seam wiring. T3 and the
+render-tier control (over-masking guards) reconfirmed still green, as are T16
+and T18 (Phase 2's writer-tier guards against over-application).
+
+Workspace boundary: `cargo nextest run --workspace` → 13581 run / 13570
+passed / 11 failed / 199 skipped. Delta against the Phase 2 boundary (13581
+run / 13568 passed / 13 failed / 199 skipped): +2 passed, −2 failed, run and
+skipped counts unchanged — exactly T15 and T17 flipping green, no other test
+moved. The 11 remaining failures are precisely the expected-red set carried
+forward: T1, T2, T4–T8, T19, T20, T22 in `quarto-core`, plus T21 in
+`quarto-hub-provider` (Phase 4's job).
 
 ### Phase 4 — Wire the seam
 

--- a/claude-notes/plans/2026-09-02-nested-cell-masking.md
+++ b/claude-notes/plans/2026-09-02-nested-cell-masking.md
@@ -577,13 +577,43 @@ forward: T1, T2, T4–T8, T19, T20, T22 in `quarto-core`, plus T21 in
 
 ### Phase 4 — Wire the seam
 
-- [ ] Mask the clone inside the per-engine loop, before `serialize_ast_to_qmd`; unmask `result.markdown` before the capture emit
-- [ ] `compute_input_qmd` masks; `write_review_file` unmasks before writing the consent artifact
-- [ ] Test: `compute_input_qmd` bytes equal `capture.input_qmd` for a document **containing a display block** — the gap in the existing invariant fixture
-- [ ] Test: `write_review_file`'s output contains `{r}` and not the marker
-- [ ] Test: the display block lands in `blocks_kept` and retains its original source_info (not the intermediate's)
-- [ ] Test: two engines in sequence both receive masked input
-- [ ] Phase 1 render-level tests green
+- [x] Mask the clone inside the per-engine loop, before `serialize_ast_to_qmd`; unmask `result.markdown` before the capture emit
+- [x] `compute_input_qmd` masks; `write_review_file` unmasks before writing the consent artifact
+- [x] Test: `compute_input_qmd` bytes equal `capture.input_qmd` for a document **containing a display block** — the gap in the existing invariant fixture
+- [x] Test: `write_review_file`'s output contains `{r}` and not the marker
+- [x] Test: the display block lands in `blocks_kept` and retains its original source_info (not the intermediate's)
+- [x] Test: two engines in sequence both receive masked input
+- [x] Phase 1 render-level tests green
+
+**Phase 4 findings (2026-09-03).** The seam is wired at four sites across three crates
+(`engine_execution.rs`, `preview_record.rs`, `quarto-hub-provider/execute.rs`), 46 insertions
+total, no test edited. `EngineExecutionStage` masks a **clone** of the AST *inside* the
+per-engine loop, per iteration, before `serialize_ast_to_qmd`, and unmasks `result.markdown`
+immediately after `engine.execute()` — before the capture emit, the reparse and reconcile. The
+capture's `input_qmd` stays masked, so `ReplayEngine`'s byte-compare still holds.
+`compute_input_qmd` masks before serializing, which covers *both* its masked-wanting consumers
+(the staleness compare in `capture_driver.rs` and the cache key in `cache.rs`) with no change at
+either site; `write_review_file` unmasks those bytes before writing the operator-facing consent
+artifact.
+
+*The four test bullets above are satisfied by frozen tests, not new ones* (controller ruling
+R2): they restate T20, T21, T19 and T22, which Phase 1 already wrote. No duplicates were added.
+
+*Result:* **every test in the plan is now green.** `quarto-core` 4329/4329/0/31,
+`quarto-preview` 145/145/0/1, `quarto-hub-provider` 40/40/0/4. Workspace phase boundary:
+**13581 run / 13581 passed / 0 failed / 199 skipped** — +11 passed / −11 failed against the
+Phase-3 baseline, exactly the eleven target rows, with run and skip counts unchanged and no
+other crate moved. Against the pre-plan live baseline of 13550 passed / 199 skipped, the branch
+adds 31 tests and no failures.
+
+*Process defect found here, worth recording because it nearly lost this reconciliation.* The
+SDD scratch directory held a `phases.md` — a copy of this section taken at setup — and a
+`spec.md` copy of everything above it. Both were **stale snapshots** that never tracked this
+document's amendments (T8's fixture, vacuity note 2, T23/T24, the normative `by.kind`). Task 7
+ticked the *copy*, so its reconciliation landed in gitignored scratch and would have vanished
+with the workspace. The implementer noticed the copy showed Phases 0–3 unchecked and flagged it
+rather than backfilling, which is what surfaced it. Both copies are now neutralized and this
+file is the single checklist of record.
 
 ### Phase 5 — Documentation
 

--- a/claude-notes/plans/2026-09-02-nested-cell-masking.md
+++ b/claude-notes/plans/2026-09-02-nested-cell-masking.md
@@ -304,6 +304,8 @@ assertions and harness are frozen — never edited to go green.
 | H9 | `unmask(result.markdown)` runs **before** the capture emit |
 | H10 | `compute_input_qmd` masks |
 | H11 | `write_review_file` unmasks before writing |
+| H12 | `MASK_OPENER_RE` carries the regex `R` (CRLF) flag, so a `\r\n`-terminated opener line still matches `$` |
+| H13 | `mask_table` recurses into `table.caption.long`, mirroring the `Figure` arm |
 
 ### Tiers
 
@@ -347,6 +349,8 @@ outright vacuous.
 | T20 | C | capture | doc **with** a display block → `compute_input_qmd` bytes == `capture.input_qmd` | **H10** → RED. *Existing invariant fixture has no display block, so it stays green either way* |
 | T21 | C | `write_review_file` | doc with a display block → review file contents | **H11** → contains the marker, not `{r}` → RED |
 | T22 | C | two engines | `FixtureEngine` ×2 in sequence → second engine's received input | **H8** (hoist mask out of the loop) → second input unmasked → RED |
+| T23 | U | `mask`+`unmask` | `\r\n`-terminated display block → `unmask(mask(x)) == x` bytes | **H12** (drop the `R` flag) → `mask` reports no change → RED. *Found in task 5 review (round 1): CRLF reaches the pipeline unnormalized, and plain `(?m)`'s `$` never matches before a bare `\r`, so masking silently became a no-op on any CRLF checkout* |
+| T24 | U | `mask` | display block nested in a table's long-form caption → block text carries the marker | **H13** (drop the `table.caption.long` walk) → RED. *Found in task 5 review (round 1): `mask_table` walked head/bodies/foot but not the table's own `Caption`, unlike the `Figure` arm which does walk its caption* |
 
 ### Vacuity notes
 
@@ -502,11 +506,34 @@ implementation that does not exist yet.
 
 ### Phase 2 — The transform
 
-- [ ] `crates/quarto-core/src/engine/nested_cell_mask.rs`. Pin the API in the module doc: `mask(&mut Pandoc) -> Vec<usize>` (indices of top-level blocks that changed) and `unmask(&str) -> String`
-- [ ] Mask rewrites openers in in-scope blocks; unmask is prefix-tolerant and not `^`-anchored
-- [ ] Walker recurses containers (Div, lists, blockquotes, table cells)
-- [ ] Walker maps each changed nested block to its top-level ancestor index
-- [ ] Phase 1 unit tests green
+- [x] `crates/quarto-core/src/engine/nested_cell_mask.rs`. Pin the API in the module doc: `mask(&mut Pandoc) -> Vec<usize>` (indices of top-level blocks that changed) and `unmask(&str) -> String`
+- [x] Mask rewrites openers in in-scope blocks; unmask is prefix-tolerant and not `^`-anchored
+- [x] Walker recurses containers (Div, lists, blockquotes, table cells, table captions, Figure captions, NoteDefinitionFencedBlock, Custom slots)
+- [x] Walker maps each changed nested block to its top-level ancestor index
+- [x] Phase 1 unit tests green
+
+**Phase 2 findings (2026-09-02).** Implemented as two `LazyLock<Regex>`s (`MASK_OPENER_RE`,
+`UNMASK_OPENER_RE`) plus a recursive container walker. Because neither regex ever touches
+anything outside the `{...}` opener span, byte-exactness (leading/trailing whitespace,
+inter-token spacing, arbitrary backtick width) fell out of the design for free — only the
+blockquote asymmetry (H4: `unmask` must not be `^`-anchored, since it runs on the writer's
+`> `-reprefixed output while `mask` only ever sees the reader's already-stripped text) needed
+deliberate handling.
+
+Review round 1 found two gaps invisible to the frozen T9–T22 suite (added as H12/H13, tested as
+T23/T24 above): `MASK_OPENER_RE` lacked the regex `R` (CRLF) flag, so a `\r\n`-terminated opener
+line's trailing `\r` was never consumed by `[ \t]*$` under plain `(?m)` — `mask` silently became
+a no-op on any CRLF checkout, corrupting nothing and failing no frozen test (since
+`unmask(mask(x)) == x` holds trivially when neither function did anything). And `mask_table`
+recursed into head/bodies/foot rows but not `table.caption.long`, even though the `Figure` arm
+thirty lines above already walked its own (same-typed) caption — an oversight, not a scope
+decision. Both fixed; T23/T24 added to close the gap. No existing test was edited.
+
+Verified (`nested_cell_mask.rs` only touched; `cargo clippy -p quarto-core --all-targets -- -D
+warnings` clean): `quarto-core` 4329 run / 4317 passed / 12 failed / 31 skipped — the 12
+failures are exactly T15, T17 (writer tier, need Phase 3 provenance) and T1, T2, T4–T8, T19, T20,
+T22 (render/capture tier, need Phase 4 wiring). T3 and the render-tier control (over-masking
+guards) confirmed still green.
 
 ### Phase 3 — Provenance
 

--- a/claude-notes/plans/2026-09-02-nested-cell-masking.md
+++ b/claude-notes/plans/2026-09-02-nested-cell-masking.md
@@ -617,15 +617,199 @@ file is the single checklist of record.
 
 ### Phase 5 — Documentation
 
-- [ ] Expand `docs/guides/authoring/computations.qmd`: the rule, the nesting requirement, cell options, deeper nesting, and the existing Quarto 1 migration callout
-- [ ] No live executable cell on the page (see **Documentation** above)
-- [ ] `cargo run --bin q2 -- render docs/` succeeds and the page's own displayed examples render verbatim
-- [ ] Check the page against `cargo xtask lint` (error-docs rules touch `docs/`)
+- [x] Expand `docs/guides/authoring/computations.qmd`: the rule, the nesting requirement, cell options, deeper nesting, and the existing Quarto 1 migration callout
+- [x] No live executable cell on the page (see **Documentation** above)
+- [x] `cargo run --bin q2 -- render docs/` succeeds and the page's own displayed examples render verbatim
+- [x] Check the page against `cargo xtask lint` (error-docs rules touch `docs/`)
+
+**Phase 5 findings (2026-09-03).** `docs/guides/authoring/computations.qmd` grew from a 35-line
+`TBD.` stub to 103 lines covering: the Overview (what an executable cell is, with a `{r}` example
+described only hypothetically — "would, if run, produce `55`" — never asserted as actually run on
+this page); the display rule (fenced code blocks are verbatim); the outer-fence-must-be-longer
+rule; cell options (`#|` comments) displayed along with the cell; deeper nesting (a block that
+itself displays a cell, using the page's own structure as the example); and the pre-existing
+Quarto 1 / `Q-2-50` migration callout, left untouched. No fence on the page opens at top level —
+every `{r}`/`{python}` opener is nested inside a display fence, so the page has zero live
+executable cells, per the hard constraint (`docs/` is rendered only in the release workflow,
+which installs no R/Python/Jupyter/Julia; an unavailable engine is a hard error, not a fallback).
+
+Rebuilt `q2` from clean (`cargo build --bin q2`, 1m40s) before rendering — the specific hazard
+Phase 0 exists to guard against. `cargo run --bin q2 -- render docs/` → **268 of 268 files
+rendered, 36 warnings**, none mentioning `computations.qmd`; the warnings are pre-existing
+(missing images on unrelated pages, tracked separately, not this page's concern). Inspected
+`docs/_site/guides/authoring/computations.html` directly: `grep -c 'q2-nested-executable'` → 0,
+`grep -c 'class="cell'` → 0, and every `{r}`/`{python}` example appears verbatim inside
+`<pre class="markdown code-with-copy">` with single braces intact, e.g.:
+
+```html
+<pre class="markdown code-with-copy"><code>```{r}
+sum(1:10)
+```</code></pre>
+```
+
+This is the page proving Q-2-50's hint true: the escape hatch the hint describes is the same
+construct this page uses to document itself, and the rendered output shows it working.
+
+`cargo xtask lint` → **all checks passed, 1065 files checked** (the `error-docs-*` repo-level
+checks run unconditionally as part of `run_check`, independent of the "Running lint checks on
+.../crates" banner; this page adds no error catalog entry, so nothing new for them to check).
+
+This page was authored by a prior implementer (task 8) before going unresponsive; this phase's
+verification — build, render, HTML inspection, lint, and this reconciliation — was done by a
+follow-up session which read the page but did not rewrite it. One wording point was checked
+against the brief's editorial callout (Overview's "would, if run, produce `55`" phrasing already
+reads unambiguously conditional — nothing to change).
+
+**Fix round 1 (2026-09-03).** Review found the "Cell options are displayed too" section asserted
+both fence-header options and `#|` comment options are displayed, but only demonstrated the `#|`
+form — the fence-header form (` ```{r, echo=FALSE} `), the plan's own worked example for the
+transform and the exact case T4 tests (`echo=FALSE` is where the bug was worst: it consumed the
+author's source entirely), was asserted in prose but never shown. Added a short fence-header
+example (` ```{r, echo=FALSE}\nplot(1:10)\n``` `) immediately before the existing `#|` example, no
+other changes. Re-verified: `cargo run --bin q2 -- render docs/` → 268/268, 36 warnings (same
+pre-existing set, none on this page); `cargo xtask lint` → all checks passed, 1065 files. Inspected
+the new example in `docs/_site/guides/authoring/computations.html`: renders verbatim inside
+`<pre class="markdown code-with-copy">` with `echo=FALSE` intact, and the section still has 0
+`.cell` divs and 0 `q2-nested-executable` occurrences.
 
 ### Phase 6 — End-to-end verification
 
-- [ ] `q2 render` each fixture through the real binary; inspect the HTML; record the exact invocations and observed output in this plan, per CLAUDE.md
-- [ ] Confirm a real cell still executes and highlights in the same document
+- [x] `q2 render` each fixture through the real binary; inspect the HTML; record the exact invocations and observed output in this plan, per CLAUDE.md
+- [x] Confirm a real cell still executes and highlights in the same document
+
+**Rebuilt first:** `cargo build --bin q2` (fresh compile after the previous commit, `Finished
+dev profile ... in 46.85s`) — confirmed not stale before measuring, per CLAUDE.md's two logged
+incidents of stale-binary measurement.
+
+For each fixture below the invocation is `cargo run --bin q2 -- render .scratch/nested/<name>.qmd`
+(exit 0 in every case), followed by direct inspection of the produced `.scratch/nested/<name>.html`
+(grep counts plus reading the surrounding markup with a short Python snippet — not inferred from
+absence of errors).
+
+**r1.qmd** — baseline (pre-fix, task-0-report.md): `REAL-CELL-RAN`=2, `DISPLAY-BLOCK-RAN`=2 (wrong,
+displayed example executed), `DISPLAY-OPTS-RAN`=1 (wrong, author's `echo=FALSE` source vanished,
+only output left). After the fix: `REAL-CELL-RAN`=2 (unchanged — one syntax-highlighted source
+span + one `.cell-output-stdout` block, both correct), `DISPLAY-BLOCK-RAN`=1 (the marker now
+appears exactly once, as literal text inside `<pre class="markdown code-with-copy">`, not
+executed), `DISPLAY-OPTS-RAN`=1 (same count as baseline but for the opposite, correct reason — the
+author's full source `` ```{r, echo=FALSE}\ncat("DISPLAY-OPTS-RAN\n")\n``` `` is now shown verbatim
+instead of being replaced by knitr output). Inspected snippet:
+
+```html
+<p>A displayed example the reader should see verbatim:</p>
+<div class="code-copy-outer-scaffold">
+<pre class="markdown code-with-copy"><code>```{r}
+cat(&quot;DISPLAY-BLOCK-RAN\n&quot;)
+```</code></pre>
+```
+
+The `DISPLAY-OPTS-RAN` count alone (1 before, 1 after) is worthless as a discriminator — before
+the fix it was output-only with the source consumed; after, it is source-only with nothing run.
+What actually discriminates the two states is that the author's fence header is now visible at all
+(`r1.html:51-54`):
+
+```html
+<pre class="markdown code-with-copy"><code>```{r, echo=FALSE}
+cat(&quot;DISPLAY-OPTS-RAN\n&quot;)
+```</code></pre>
+```
+
+`echo=FALSE` could not appear in the output before the fix, because knitr consumed the source
+entirely — its presence here is the evidence, not the marker-count coincidence.
+
+**pyfail.qmd** — baseline: whole render hard-failed (`Execution halted`, `Error: Execution failed
+in knitr: R process failed`, reticulate's `python_not_found`), because knitr handed the displayed
+`{python}` example to reticulate. After the fix: exit 0, no error. The real `{r}` cell still
+executes and highlights (`REAL` appears twice: once inside `<span class="hl-function">cat</span>`
+source highlighting, once in `.cell-output-stdout`). The displayed `{python}` fence renders as
+inert verbatim text and is never handed to any engine:
+
+```html
+<div class="code-copy-outer-scaffold">
+<pre class="markdown code-with-copy"><code>```{python}
+1 + 1
+```</code></pre>
+```
+
+**bq.qmd** — baseline: the blockquoted display block rendered **empty** and two `.cell` divs were
+emitted (`grep -c 'class="cell"'` → 2; the nested cell escaped the blockquote and rendered as its
+own sibling cell). After the fix: `grep -c 'class="cell"'` → **1** (only the real top-level cell),
+and the blockquote is non-empty, holding the author's verbatim `{r}` source:
+
+```html
+<blockquote>
+<div class="code-copy-outer-scaffold">
+<pre class="markdown code-with-copy"><code>```{r}
+cat(&quot;IN-QUOTE\n&quot;)
+```</code></pre>
+</div>
+</blockquote>
+```
+
+**shapes.qmd** (whitespace/backtick-width/nesting shapes, not in the pre-fix baseline table — new
+coverage) — bare display fence (no backtick-fence wrapper, just a plain fenced code block with no
+info-string annotation), a nested display fence indented inside a list item, and a doubled-brace
+`{{python}}` shortcode-style opener. All three markers (`BARE`, `INDENTED`, `DOUBLED`) appear
+exactly once each, as literal verbatim text, never executed, e.g. the indented case stays nested
+correctly inside its `<li>`:
+
+```html
+<li>item
+<div class="code-copy-outer-scaffold">
+<pre class="markdown code-with-copy"><code>```{r}
+cat(&quot;INDENTED\n&quot;)
+```</code></pre>
+```
+
+`REAL`=2 in the same document, confirming the real cell executes and highlights alongside three
+different nested-display shapes.
+
+**stress.qmd** (whitespace/collision stress cases, not in the pre-fix baseline table — new
+coverage) — `SPACE-BEFORE-BRACE`, `TRAILING-WS`, `AUTHOR-DOTTED`, `NESTED-PY` all appear exactly
+once each, verbatim and unexecuted, e.g. the author's own dotted-class fence (`` ```{.r} ``) is
+left byte-for-byte untouched:
+
+```html
+<pre class="markdown code-with-copy"><code>```{.r}
+cat(&quot;AUTHOR-DOTTED\n&quot;)
+```</code></pre>
+```
+
+The final case in this fixture — "Author writes our marker verbatim (collision probe)",
+`` ```{.r q2-nested-executable} `` — is the one documented, deliberately-accepted limitation in
+`crates/quarto-core/src/engine/nested_cell_mask.rs`'s module doc ("Known limitation": `unmask`
+pattern-matches on the marker text; an author who writes it verbatim inside a display block gets
+it rewritten as if it were one of ours; "measured negligible in practice... not fixed here; not
+tested here"). Confirmed exactly that behaviour and nothing worse: the fence header is rewritten
+from `` ```{.r q2-nested-executable} `` to `` ```{r} ``, but `COLLISION` itself still appears
+exactly once (never executed, never duplicated), and the marker string does not leak into the
+final HTML — `unmask` consumes its own trigger text as part of the rewrite. This is pre-existing,
+already-scoped-out behaviour, not a regression introduced by this phase; it is not re-opened here.
+Inspected snippet showing the source's `{.r q2-nested-executable}` rewritten to `` ```{r} ``
+(`stress.html:63-69`), so the actual behaviour is on record rather than only a characterisation
+of it:
+
+```html
+<p>Author writes our marker verbatim (collision probe):</p>
+<div class="code-copy-outer-scaffold">
+<pre class="markdown code-with-copy"><code>```{r}
+cat(&quot;COLLISION\n&quot;)
+```</code></pre>
+```
+
+**Marker-leak check (all five fixtures):** `grep -c q2-nested-executable <name>.html` → **0** in
+every case (`r1`, `pyfail`, `bq`, `shapes`, `stress`). The mask marker never reaches a reader,
+including on the stress fixture that writes the marker string as literal author text.
+
+**Real-cell-still-works check:** every fixture with a real top-level cell (`r1`, `pyfail`, `bq`,
+`shapes`, `stress`) shows `REAL`/`REAL-CELL-RAN` twice — once inside `<span class="hl-function">`
+(or equivalent highlighted-source spans) confirming syntax highlighting ran, once inside
+`.cell-output-stdout` confirming execution ran — in the same document as one or more masked
+display blocks. Under-masking (the pre-fix bug) and over-masking (marker leakage, or the real cell
+itself getting masked) are both absent.
+
+All HTML was read directly (via `grep -c` counts plus short inline Python snippets printing
+surrounding context), not inferred from a clean exit code.
 
 ### Phase 7 — Wrap up
 

--- a/claude-notes/plans/2026-09-02-nested-cell-masking.md
+++ b/claude-notes/plans/2026-09-02-nested-cell-masking.md
@@ -813,7 +813,63 @@ surrounding context), not inferred from a clean exit code.
 
 ### Phase 7 — Wrap up
 
-- [ ] `cargo nextest run --workspace`, delta accounted for against the live baseline
-- [ ] `cargo xtask verify --skip-hub-build --skip-hub-tests`
-- [ ] Reconcile this checklist against what landed; commit
-- [ ] Comment the outcome on the strand
+- [x] `cargo nextest run --workspace`, delta accounted for against the live baseline
+- [x] `cargo xtask verify` (full, no skip flags — **corrected from an earlier
+      draft of this item that read `--skip-hub-build --skip-hub-tests`**; per
+      CLAUDE.md's Git Push Policy, the full run is required "when the WASM leg
+      could be affected (any change under `quarto-core`, `quarto-pandoc-types`,
+      or anything else hub-client depends on)", and this plan's entire
+      implementation is in `quarto-core`. The skip-flag form would never have
+      compiled `quarto-core` to `wasm32-unknown-unknown` and would have shipped
+      a broken hub build undetected — see Phase 7 findings below)
+- [x] Reconcile this checklist against what landed; commit
+- [x] Comment the outcome on the strand
+
+**Phase 7 findings (2026-09-03).**
+
+*The WASM leg is not optional — the skip-flag form of this item was wrong.*
+The full `cargo xtask verify` turned the branch red at the hub-build leg.
+`nested_cell_mask.rs` uses `regex::Regex`, but `quarto-core`'s `Cargo.toml`
+declared `regex` only under
+`[target.'cfg(not(target_arch = "wasm32"))'.dependencies]` — a native-only
+dependency for a module the WASM preview pipeline also runs, since it must
+mask displayed cells too. Fixed by making the declaration unconditional,
+which costs nothing in payload: `pampa` already declares `regex`
+unconditionally and `quarto-core` depends on `pampa` unconditionally, so
+regex was already compiled into the WASM image. Had the item kept its
+original `--skip-hub-build --skip-hub-tests` form, `quarto-core` would never
+have been compiled to `wasm32-unknown-unknown` and this would have shipped
+as a broken hub build.
+
+*Gate results.* `cargo xtask verify` — full, no skip flags —
+passed all **14 steps** on this branch rebased onto `b93c62c74`
+(`.scratch/phase7-verify-rebased.log`). Its step 5 is the workspace test run:
+**13621 passed, 199 skipped, 0 failed** (480.7s). The hub-build leg left the
+worktree clean, reproducing the committed sandboxed-preview bundles
+byte-for-byte.
+
+*Baseline delta, accounted.* Phase 0 measured the live baseline at **13550
+passed, 199 skipped** against base `85e98fb02`. `main` has since advanced two
+commits — `f14cd4963` (no-TOC margin column, +12 tests) and `9ad1d4420` (body
+image width, +28 tests) — moving the live baseline to **13590**. This branch
+contributes **31** tests: 17 unit/writer-tier in the module, 9 render-tier, 4
+capture-tier (engine-execution ×2, preview-record, hub-provider), and 1 in the
+jupyter text engine. 13590 + 31 = **13621**, which is exactly the run above. No stray or duplicated
+tests.
+
+*Checklist audit.* Every `- [x]` in Phases 0–6 was re-checked against the
+tree rather than trusted: the pinned `mask`/`unmask` signatures
+(`nested_cell_mask.rs:128,166`), all eight container arms of the walker, and
+each named test of Phases 1, 3 and 4 exist as the plan describes. T14 lives
+in `engine/jupyter/text_execute.rs`, not the module, which the seam table
+already says.
+
+*Scope note.* The hub-build leg also regenerated two checked-in artifacts of
+`hub-client/quarto-hub-sandboxed-preview` that were stale on `main` — the
+service worker still carried an offline cache its source had dropped, and the
+sandboxed-preview bundle embedded KaTeX 0.18.2 against a lockfile pinning
+0.18.4. Unrelated to this plan; landed directly on `main` as `546fdd374` +
+`b93c62c74` rather than riding this branch. The recurring failure mode — a
+committed bundle rebuilt from stale `node_modules`, with nothing reconciling
+the embedded version against the pin — is **bd-jhe3xnq9**, filed out of this
+plan's scope rather than absorbed into it.

--- a/claude-notes/plans/2026-09-02-nested-cell-masking.md
+++ b/claude-notes/plans/2026-09-02-nested-cell-masking.md
@@ -1,0 +1,548 @@
+# Make q2 self-documenting again: don't execute a cell that is being displayed
+
+**Strand:** bd-knitr-executes-nested-display-fence-atbtktdj (epic: bd-98m98wg8)
+**Branch:** `braid/bd-knitr-executes-nested-display-fence-atbtktdj-mask` off
+`origin/main` @ `85e98fb02`.
+
+The **minimal, forward-compatible slice** of a larger epic. The epic plan, the
+full design-decision table, the open questions and the
+engine-hand-off-assembler design live on
+`braid/bd-98m98wg8-self-documenting-cells-epic` and are reviewed separately.
+Nothing here has to be undone by any of it.
+
+## The bug
+
+A `{r}` fence *displayed* inside another code block is executed by knitr, and
+the author's example is replaced by knitr's own cell scaffolding.
+
+Measured at `eac0c7acf` and **independently reproduced at `85e98fb02`** on
+`.scratch/nested/r1.qmd` — one real cell plus two display blocks:
+
+| marker | occurrences | meaning |
+| --- | --- | --- |
+| `REAL-CELL-RAN` | 2 | correct: source echo + output |
+| `DISPLAY-BLOCK-RAN` | 2 | **wrong** — the displayed example ran |
+| `DISPLAY-OPTS-RAN` | 1 | **wrong** — with `echo=FALSE` the author's source vanished entirely, leaving only output |
+
+The reader is shown knitr's intermediate markup instead of the example:
+
+    ::: {.cell}
+    ...{.r .cell-code}
+    ::: {.cell-output .cell-output-stdout}
+
+### Two symptoms worse than "wrong output"
+
+**A displayed example in a language you don't have installed kills the whole
+render.** Verified at `85e98fb02`: a document with one live `{r}` cell and a
+` ````markdown ` block displaying a `{python}` example exits with
+
+    reticulate (local) python_not_found("Installation of Python not found…")
+    Quitting from pyfail.rmarkdown:131-133 [unnamed-chunk-2]
+    Execution halted
+    error: while rendering pyfail.qmd
+
+knitr hands the *displayed* example to reticulate. This is the most
+user-visible face of the defect and the one a documentation page hits first.
+
+**A blockquoted display block loses its contents entirely.** The cell escapes
+the blockquote — two `.cell` divs are emitted and the display block renders
+**empty**.
+
+### Why this matters beyond the bug
+
+Q-2-50's own hint tells authors:
+
+> To display the cell, wrap it in a `markdown` code block and write single
+> braces; fenced code blocks are displayed verbatim.
+
+That is the construct this bug breaks. The documented escape hatch and the
+defect are the same thing, so **today there is no way to write Quarto
+documentation about the execution feature.** This plan makes the hint true.
+
+Reachable only when the engine is already live: AST-based resolution
+(`computational_languages`, `resolution.rs:249`) correctly declines to start
+knitr for a document whose only `{r}` fence is displayed. One real cell
+anywhere turns every displayed example into a live one.
+
+## Approach
+
+One seam — `crates/quarto-core/src/stage/stages/engine_execution.rs`, **inside
+the per-engine loop**:
+
+```
+mask(ast clone) -> serialize_ast_to_qmd -> engine.execute -> unmask -> capture -> reparse -> reconcile
+```
+
+Mask needs the AST (only it knows what is inside a code block). Unmask does
+not — the marker is self-identifying — so it runs textually on the engine's
+returned markdown.
+
+**The mask must be applied inside the loop, per iteration.** `to_run` is
+iterated with `ast` re-serialized each time and left *unmasked* between
+iterations; masking once before the loop would silently leave the second
+engine unprotected.
+
+The `qmd_source_info` passed to `.with_source_info(...)` is the one produced by
+serializing the **masked** clone — not a separate unmasked serialization.
+
+Because every engine goes through this one `serialize_ast_to_qmd` call, this
+covers knitr, q2's jupyter text engine, and TS extensions with no per-engine
+work.
+
+### The transform
+
+Line-wise on the block's text:
+
+```
+```{r}              ->  ```{.r q2-nested-executable}
+```{r, echo=FALSE}  ->  ```{.r q2-nested-executable, echo=FALSE}
+```
+
+The leading `.` is what does the work. All three partitioners require an
+alphanumeric first character after `{`:
+
+| scanner | pattern fragment | source |
+| --- | --- | --- |
+| knitr `all_patterns$md$chunk.begin` | `\{([a-zA-Z0-9_]+( *[ ,].*)?)\}` | knitr 1.50, read live from R |
+| q2 jupyter `parse_code_blocks` | `\{(\w+)\}` | `engine/jupyter/text_execute.rs:128` |
+| TS `breakQuartoMd` `startCodeCellRegEx` | `\{([=A-Za-z][=A-Za-z0-9._]*)…\}` | `ts-packages/quarto-api/src/markdownRegex/index.ts:779` |
+
+The marker exists only so the unmask knows which openers were ours, and never
+rewrites an author's own `{.r}`.
+
+**Prefix handling is asymmetric, and the asymmetry is the point.** Mask
+operates on a `CodeBlock`'s `text`, from which the reader has *already
+stripped* any blockquote `> ` — the writer re-adds it on serialize. Only
+**unmask**, which runs textually over engine output, ever sees a `> `. So the
+mask side needs no prefix handling; the unmask side must not be `^`-anchored,
+or it will miss every blockquoted fence (knitr's own pattern is `^[\t >]*`,
+so those fences really do execute).
+
+**Byte-exactness is a requirement, not an aspiration** — see "Reconcile"
+below. The unmask must restore leading whitespace, inter-token spacing
+(` ``` {r} `), trailing whitespace, and fences of any backtick width exactly.
+
+### Scope
+
+**In:** executable fence openers inside a *markdown-displaying* `CodeBlock` —
+one whose attr classes are **empty** (no info string) or `["markdown"]`. Use
+`engine_cell_lang` (`engine/capture_splice.rs:86`) to skip blocks that are
+themselves executable cells.
+
+**Correction (found during task 2, bd-rbpkzqjo):** the empty-classes case
+does **not** include a 4-space indented code block — qmd has no
+indented-code-block grammar production at all. `grammar.js`'s
+`_indented_code_block_error` (~1223-1231) documents this as a deliberate,
+blanket known limitation, and the scanner emits
+`INDENTED_CODE_BLOCK_DISALLOWED` (`scanner.c:2664`) rather than an
+indented-code-block node — verified to fire in every context (top-level and
+inside a list item alike), never producing a `CodeBlock` at all. So a
+4-space-indented display block is not a second way to reach the
+empty-classes AST shape; it cannot reach the AST at all. The only way to
+construct an empty-classes `CodeBlock` is a bare fenced block with no info
+string.
+
+**Language predicate — every braced opener, engine-agnostic.** Mask any
+`{word}` opener regardless of language, not only languages the current engine
+claims. This is what fixes the fatal `{python}`-in-an-R-document case above:
+knitr hands unclaimed languages to reticulate rather than ignoring them. The
+seam is engine-agnostic, so the predicate should be too.
+
+**Display classes — empty or `markdown` only.** An author writing ` ````qmd `
+gets nothing. Deliberate: Q-2-50's hint names `markdown`. Widening is a
+separate decision.
+
+**Out, deliberately:**
+
+- **`RawBlock`.** A spike measured that masking a `{=markdown}` RawBlock
+  converts "wrongly executed" into *silently mangled*: the writer emits such
+  blocks **unfenced** (verified — `pampa -t qmd` drops the wrapper), so the
+  inner cell becomes a genuine top-level cell in the engine input. Masking it
+  would free a never-executed cell that renders with classes
+  `.r q2-nested-executable` — unhighlighted and undiagnosed (bd-4gzwls31). A
+  downgrade, not a fix. The assembler owns RawBlock.
+- **Doubled-brace `{{lang}}`** — no scanner executes them (verified untouched
+  at baseline); that is a diagnostic problem
+  (bd-q250-nested-fence-blind-spot-t68z1lsw).
+- **`{=html}`-style openers** — only `breakQuartoMd` matches `=`, and it
+  mis-*partitions* rather than executes.
+- **A cell nested inside another executable cell** — rewriting there would
+  corrupt code that is about to run.
+
+### Provenance
+
+Masked text is longer than its source. The writer's map is *output*-indexed —
+`pieces.push((block.source_info().clone(), buf.len() - start))`
+(`pampa/src/writers/qmd.rs:3104`) — so a longer block shifts nothing for any
+*other* block. But *within* a lengthened block the mapping goes silently
+wrong: `Concat::map_offset` finds the piece, then the `Original` arm computes
+`start_offset + offset` with **no clamp to `end_offset`**
+(quarto-source-map 0.1.3, `mapping.rs:29`), so an offset near the block's end
+resolves past it into the next block's source text.
+
+On the masked clone only, give each changed block `Generated` source_info with
+`by.kind = "nested-cell-mask"` (pinned here, normatively — the mask's own
+kebab-case kind, not left to whatever string the implementation happens to
+pick) and an `Other("nested-cell-mask/origin")` anchor. `map_offset` on
+`Generated` returns `None` (`mapping.rs:74`) — *location unknown* rather than
+a confident wrong answer — and `build_source_map` already tolerates that
+(`.and_then`, emits `source: None`). `Other` rather than `Invocation` is
+deliberate:
+`preimage_in`'s `Generated` arm walks only `Invocation`
+(`source_info.rs:500`), so the anchor is provably inert to any byte-copying
+writer. That inertness means no test can observe the anchor *choice* except by
+inspecting the `SourceInfo` directly.
+
+The writer's piece loop is `for block in &pandoc.blocks` — top-level only — so
+a masked block nested in a list or div must also mark its **top-level
+ancestor**, or the drift returns. Cost, accepted: that container reads as
+location-unknown, including unrelated prose in it. Unknown beats wrong.
+
+The marking lives only on the short-lived clone; the reparsed AST gets fresh
+source_info, so nothing `Generated` persists into the document.
+
+### Reconcile — why byte-exactness is load-bearing
+
+The seam ends `… → reparse → reconcile(ast, executed_ast)`, with `ast` the
+**unmasked** original. That only works if unmask restores byte-identically. If
+it drifts by one byte, reconcile treats the display block as *changed* and
+**replaces** it, so it inherits the `.rmarkdown` intermediate's source_info —
+quietly undoing the provenance work above and attributing the author's example
+to a temp file. Phase 4 asserts the block lands in `blocks_kept` and keeps its
+original source_info, not merely that its text looks right.
+
+### The engine capture — asymmetric, by necessity
+
+The capture at `engine_execution.rs:534` records `input_qmd` (the masked
+`qmd`) and the engine result. `ReplayEngine` (`replay.rs:129`) byte-compares
+its **live** input against `input_qmd`, and the live input is masked — so
+`input_qmd` must stay **masked**. `CaptureSpliceStage` splices
+`result.markdown` into a live AST for `q2 preview`, so that must be
+**unmasked**, or preview renders the marker.
+
+So: unmask `result.markdown` before the capture emit; leave `input_qmd`
+masked.
+
+**`compute_input_qmd` (`preview_record.rs:211`) has three consumers, and they
+do not all want the same thing:**
+
+| consumer | role | treatment |
+| --- | --- | --- |
+| `quarto-preview/src/capture_driver.rs:283` | the real staleness compare (`current_input_qmd != recorded_input_qmd`) | **masked** — else every affected document reads perpetually stale |
+| `quarto-preview/src/cache.rs:162` | capture cache key | **masked**; one-time invalidation of existing entries for affected docs, benign |
+| `quarto-hub-provider/src/execute.rs:392` | `write_review_file` — *"the artifact the operator reviews before consenting"* | **unmasked** |
+
+The third is security-facing: an operator deciding whether to permit execution
+must see the `{r}` they wrote, not `{.r q2-nested-executable}`. **Decision:
+`compute_input_qmd` masks; `write_review_file` unmasks before writing.**
+
+Its pinned invariant test `compute_input_qmd_matches_capture_input_qmd`
+(`preview_record.rs:494`) uses a fixture with **no display block** (verified),
+so it would stay green through a regression here — Phase 4 adds a fixture that
+has one.
+
+## Documentation
+
+`docs/guides/authoring/computations.qmd` already exists (35 lines, body
+`TBD.`) and already asserts the behaviour this bug breaks: *"the inner cell is
+shown exactly as written (single braces and all) and is not executed."* That
+claim is false today whenever the page has a live cell. This PR expands the
+page and makes the claim true.
+
+**The page gets no live executable cell**, on evidence:
+
+- `docs/` is rendered in CI in exactly one place — `release.yml:209`,
+  `cargo xtask build-agents-docs` → `cargo run --bin q2 -- render docs`.
+- **No workflow in the repo installs R, Python, Jupyter or Julia.**
+- An unavailable engine is a hard error, not a fallback:
+  `ExecutionError::runtime_not_found` propagates through
+  `engine_execution.rs:495` via `?`.
+
+So a live cell would fail the **release** build, not a PR check — surfacing
+late, and `release.yml:207` records that this has already cost a release
+(*"`q2 render docs` fails hard without it (v0.27.0 attempt 1)"*). No page in
+`docs/` executes code today, and this PR keeps it that way.
+
+The live-cell case is covered by the regression tests instead, gated on knitr
+availability. Docs prove the feature to a human; tests prove it to CI.
+
+A scratch draft of the expanded page is at `.scratch/docs-draft/`.
+
+## Known limitation
+
+The unmask pattern-matches, so an author who writes `q2-nested-executable`
+verbatim inside a display block gets it rewritten. Measured, negligible in
+practice, and removed later in the epic when the assembler restores from
+retained bytes rather than by matching. Documented, not fixed here.
+
+## Forward-compatibility
+
+Every mechanism here is replaced rather than contradicted by later epic work:
+the reversible-edit restore becomes a minted-token lookup; the `Generated`
+provenance becomes exact `Patched` provenance; applying the mask to all
+engines narrows to knitr once our own partitioners are nesting-correct. The
+fixture suite below is what those later plans get measured against.
+
+## Test seam spec (frozen)
+
+Bound before dispatch. Every row names the production hunk whose revert turns
+that assertion RED. A row without one is theatre. Once a test is green, its
+assertions and harness are frozen — never edited to go green.
+
+### Production hunks
+
+| id | hunk |
+| --- | --- |
+| H1 | `mask` rewrites an opener: `{r}` → `{.r q2-nested-executable}` |
+| H2 | the in-scope predicate: classes empty or `["markdown"]`, and `engine_cell_lang(block).is_none()` |
+| H3 | `unmask` restores an opener carrying the marker |
+| H4 | `unmask` is prefix-tolerant (not `^`-anchored), so `> ` fences restore |
+| H5 | `unmask` replays whitespace/backtick-width exactly |
+| H6 | changed blocks get `Generated` + `Other("nested-cell-mask/origin")` |
+| H7 | the top-level ancestor of a changed *nested* block is also marked |
+| H8 | mask is applied **inside** the per-engine loop, before `serialize_ast_to_qmd` |
+| H9 | `unmask(result.markdown)` runs **before** the capture emit |
+| H10 | `compute_input_qmd` masks |
+| H11 | `write_review_file` unmasks before writing |
+
+### Tiers
+
+- **U — unit**, in `nested_cell_mask.rs`. Pure functions over `Pandoc`/`&str`. No engine, no writer.
+- **W — writer**, in-crate. Real `pampa::writers::qmd::write_with_source_info` over a real AST. No engine.
+- **R — render**, `tests/integration/`. Real `render_document_to_file`, real knitr. Gated on Rscript **and** the knitr package (`marimo_engine_e2e.rs:76-94`), not `KnitrEngine::is_available()`, which checks only the binary.
+- **C — capture**, in-crate. Real `compute_input_qmd` / `record_capture` with `PassthroughTestEngine` (`preview_record.rs:265`). No external runtime.
+
+### The runtime-only marker rule
+
+**Every render-tier fixture must make its executed marker impossible to satisfy
+by an echo**, following `assert_fence_rendered`'s existing trick: the source
+says `cat(paste0("DISPLAY", "-RAN"))`, so the string `DISPLAY-RAN` exists in
+the HTML **only if the cell actually ran**. Counting occurrences of a literal
+that appears in both source and output is fragile and, in one case below,
+outright vacuous.
+
+### Seam table
+
+| # | tier | unit mounted | seam: input → assertion surface | revert → RED |
+| --- | --- | --- | --- | --- |
+| T1 | R | full render | live `{r}` + ` ````markdown ` displaying `{r}` → HTML | **H1** → `DISPLAY-RAN` present → RED |
+| T2 | R | full render | same → HTML | **H3** → display `<pre>` shows `{.r q2-nested-executable}` → RED |
+| T3 | R | full render | same → HTML | **H2** (widen to all blocks) → `REAL-RAN` absent, real cell masked → RED |
+| T4 | R | full render | `echo=FALSE` display block → HTML | **H1** → `OPTS-RAN` present → RED. *See vacuity note 1* |
+| T5 | R | full render | live `{r}` + displayed `{python}` → HTML | **H1** → render errors (`python_not_found`) → RED |
+| T6 | R | full render | blockquoted display block → HTML | **H4** → block renders empty, two `.cell` divs → RED |
+| T7 | R | full render | ` ``` {r} ` and ` ```{r}   ` → HTML | **H1** → `WS-RAN` present → RED |
+| T8 | R | full render | bare fenced display block, no info string (not literally 4-space-indented — see Scope's correction: qmd has no indented-code-block grammar production, so this is the only way to reach the empty-classes AST shape) → HTML | **H1** → `IND-RAN` present → RED |
+| T9 | U | `mask`+`unmask` | every shape → `unmask(mask(x)) == x` bytes | **H5** → whitespace/wide-fence rows → RED |
+| T10 | U | `mask` | `{{python}}` in a display block → block text | **H1** (widen pattern past `[A-Za-z0-9_]`) → RED |
+| T11 | U | `unmask` | author's `{.r}` in a display block → block text | **H3** (drop marker requirement) → RED |
+| T12 | U | `mask` | `{=markdown}` **RawBlock** containing `{r}` → unchanged | **H2** (extend to RawBlock) → RED. *Guards the spike's measured downgrade* |
+| T13 | U | `mask` | `{r}` nested inside a real `{r}` cell → unchanged | **H2** (drop the classes-empty-or-`["markdown"]` conjunct) → RED |
+| T14 | U | `mask` | masked text → `parse_code_blocks` yields 0 cells | **H1** → RED. *`parse_code_blocks` is private (`text_execute.rs:124`) — put this test in that module or expose it; decide and note which* |
+| T15 | W | writer | masked AST → `map_offset` into the masked block | **H6** → returns `Some(wrong)` not `None` → RED |
+| T16 | W | writer | same → `map_offset` into an *unmasked sibling* | **H6** over-applied (mark all) → RED |
+| T17 | W | writer | display block nested in a `Div` → ancestor's `SourceInfo` | **H7** → ancestor stays `Original` → RED |
+| T18 | W | writer | doc with a highlight block whose body embeds a fence-opener-shaped substring + a real cell, **no** nested fence → piece `(offset_in_concat, length)` pairs identical to unmasked run | **H2** (mask everything) → RED. *See vacuity note 2 (corrected)* |
+| T19 | R | full render | display block → reconcile result | **H5** → block drifts, lands in replaced not `blocks_kept`, inherits intermediate `source_info` → RED |
+| T20 | C | capture | doc **with** a display block → `compute_input_qmd` bytes == `capture.input_qmd` | **H10** → RED. *Existing invariant fixture has no display block, so it stays green either way* |
+| T21 | C | `write_review_file` | doc with a display block → review file contents | **H11** → contains the marker, not `{r}` → RED |
+| T22 | C | two engines | `FixtureEngine` ×2 in sequence → second engine's received input | **H8** (hoist mask out of the loop) → second input unmasked → RED |
+
+### Vacuity notes
+
+**1. The `echo=FALSE` discriminator collapses if you count.** Before the fix
+the marker appears once (output only, source consumed); after the fix it
+appears once (source only, no output). **A count assertion passes in both
+states.** T4 must therefore assert on two surfaces that genuinely differ:
+`!html.contains("OPTS-RAN")` — the runtime-only string — **and**
+`html.contains("paste0(\"OPTS\"")` — the author's source, absent before the
+fix because knitr consumed it.
+
+**2. A "no nested fences" document is vacuous if scanning an out-of-scope
+block would find nothing to rewrite — not merely if the document has no code
+at all.** The original wording of this note was itself wrong, caught in task
+3's review round: a bare, empty-bodied ` ```python ` highlight block gives an
+over-broad predicate (H2 reverted to "mask everything") *nothing to change*
+even once it wrongly scans that block, so the piece pairs stay identical
+either way and the test would pass under the revert too — vacuous, just one
+level deeper than "no code at all". The fixture must instead embed a
+fence-opener-shaped substring (` ```{r} `) *inside* the highlight block's own
+body text, via a wider outer fence (the same technique T13 uses to embed a
+literal-looking opener inside a real cell's source without it being mistaken
+for a fence boundary). Under a correct H2 the highlight block's classes keep
+it out of scope, so the embedded substring is never touched and the pieces
+match; under H2 reverted to "mask everything" the block *is* scanned, the
+embedded opener gets rewritten, and the pieces diverge — a real RED. The
+fixture also keeps a real `{r}` cell as the second block, covering both
+out-of-scope class shapes (a non-markdown highlight class, and a braced
+executable cell).
+
+**3. T5 is environment-sensitive.** "The render succeeds" passes before the
+fix on any machine that has Python. Assert on content instead: the display
+`<pre>` contains the literal ` ```{python} ` and the HTML contains no
+`.cell-output` inside it. That discriminates whether or not Python is
+installed.
+
+### Accepted untested, with rationale
+
+- **The marker collision** (an author writes `q2-nested-executable` verbatim in
+  a display block and it is rewritten). Deliberate known limitation; the
+  assembler removes the class later. A test would pin behaviour we intend to
+  change. *Not* silently omitted — recorded here.
+- **`{=html}`-style `{=lang}` openers nested in a display block.** Only
+  `breakQuartoMd` matches `=`, and it mis-partitions rather than executes; no
+  in-tree consumer exercises it.
+- **Capture cache-key invalidation** (`cache.rs:162`). A one-time
+  recomputation for affected documents, benign and self-healing; asserting on
+  a hash adds coupling without protecting a behaviour.
+- **Mask idempotence.** Structurally unreachable — `mask` runs on the AST,
+  which is never masked between loop iterations. T22 guards the ordering that
+  makes this true.
+- **H2's `engine_cell_lang` conjunct, as an independent discriminator.**
+  `engine_cell_lang` (`capture_splice.rs:86-100`) returns `Some` only when a
+  block carries a brace-shaped class (`{lang}`). H2's *other* conjunct admits
+  only blocks whose classes are empty or exactly `["markdown"]` — neither
+  shape can contain a brace-shaped class. So for every block that passes the
+  classes conjunct, `engine_cell_lang(block) == None` **necessarily**: no
+  fixture, parser-built or hand-built, can make the two conjuncts disagree.
+  T13 still guards the real property ("mask must never touch a genuine
+  executable cell"), bound to the classes conjunct instead (revert-bound hunk
+  above). The `engine_cell_lang` check is retained deliberately — see the
+  scope note in `nested_cell_mask.rs`'s module doc — because it becomes
+  load-bearing the moment the display-class predicate widens (e.g. to
+  ` ```qmd `, flagged above as a separate decision), not because it does
+  anything today.
+
+## Phases
+
+Per-task gate: `cargo clippy -p quarto-core --all-targets -- -D warnings` and
+`cargo nextest run -p quarto-core`. Phase boundary: `cargo nextest run
+--workspace`, reported against the live baseline.
+
+### Phase 0 — Don't measure the wrong binary
+
+- [x] **`cargo build --bin q2` from a clean tree at this branch's HEAD before measuring anything.** `target/` in this worktree has held binaries built from a spike branch that already contains the fix; measuring without rebuilding records the fix as the baseline. Confirm `.scratch/nested/r1.qmd` gives `DISPLAY-BLOCK-RAN` = **2**.
+- [x] Investigate the QNR risk before committing to the top-level-ancestor rule: `build_source_map`'s doc warns that an all-unmappable input makes the Julia engine send an empty `sourceRanges`, crashing QuartoNotebookRunner. A document that is one top-level Div containing one display block would mark its only body piece `Generated`. Determine whether that can actually reach QNR; record the finding here and mitigate only if it can.
+
+**Phase 0 findings (2026-09-02).**
+
+*Baseline.* Rebuilt at branch HEAD `a6374f6f4` before measuring. `.scratch/nested/r1.qmd`
+gives `REAL-CELL-RAN` = 2, `DISPLAY-BLOCK-RAN` = **2**, `DISPLAY-OPTS-RAN` = 1 — the plan's
+claimed 2/2/1, independently reproduced. `pyfail.qmd` hard-fails with `python_not_found`
+(note: python3 3.14.2 *is* installed on this machine; reticulate's own discovery misses it via
+a stale uv build-cache path — same observable failure, premise intact). `bq.qmd` emits two
+`.cell` divs with the display blockquote empty. Live workspace baseline for later phase
+boundaries: **13550 passed, 199 skipped, 0 failed** (119.3s).
+
+*QNR risk: **REACHABLE**.* `build_source_map` (`engine/ts_engine.rs:671`) maps each line via
+`ctx.source_info.map_offset(...)`; its doc comment records that an all-unmappable input makes
+the Julia engine's `buildSourceRanges` send an empty `sourceRanges`, "which crashes QNR's
+`compute_line_file_lookup` (`maximum` over an empty collection)". A document whose sole
+top-level block is a `Div` containing both a live `{julia}` cell and a nested display block
+would have its only top-level piece marked `Generated` by the H7 ancestor rule, making every
+line unmappable. Unverified link: QuartoNotebookRunner is not vendored here, so
+`compute_line_file_lookup` was not read directly; the in-repo doc comment is the authority.
+
+*Decision (Gordon, 2026-09-02): **ship the ancestor rule as planned and defend that invariant
+separately**.* It is `build_source_map`'s own documented contract, not the mask's job. Filed as
+**bd-quydz82t**. Phase 3 therefore implements H7 unchanged — no guard in `build_source_map`,
+no degenerate-case special-casing. A mitigation that was considered and rejected: anchoring
+the first entry at file offset 0 when every entry is unmappable, which fixes the class but
+emits a location that is not true, contradicting the "unknown beats wrong" principle the rest
+of the provenance work is built on.
+
+### Phase 1 — Failing tests (RED)
+
+Implement the frozen **Test seam spec** above, T1–T22. Do not invent a harness:
+each row names its tier, its mounted unit, its assertion surface and the hunk
+whose revert reddens it.
+
+Create `nested_cell_mask.rs` with `unimplemented!()` stubs **first**, so the
+unit tier compiles and genuinely goes red. A test that fails to *compile* is
+not a RED.
+
+- [x] Render tier T1–T8 — inline fixtures + `TempDir` through `render_document_to_file`, following `knitr_display_fence.rs`; runtime-only markers per the spec
+- [x] Unit tier T9–T14
+- [x] Writer tier T15–T18
+- [x] Capture tier T19–T22
+- [x] Render-tier control (not revert-bound, logged as characterization): a display block in a document with **no** live cell renders unchanged, pinning "reachable only when the engine is live"
+- [x] Confirm every render/writer/capture test fails, and every unit test compiles and fails — **except T3 and the render-tier control, which are green-at-baseline guards, not REDs.** T3 (real cell still executes) is bound to hunk H2 (widening the scope predicate to all blocks), which does not exist until Phase 2; the current bug only under-masks (executes displays) and never over-masks (blocks the real cell), so T3's assertion is already true with zero masking in place — structurally the same as the control (a guard against a regression the fix could introduce, not a symptom of the bug being fixed). Both are re-checked, still green, at the Phase 4 all-green gate.
+
+**Phase 1 findings (2026-09-02).** 22 seam rows written across four tasks; 26 tests RED in
+`quarto-core` and 1 in `quarto-hub-provider`, none skipped, no previously-green test regressed.
+`cargo build --workspace` clean at the phase boundary. No workspace *test* run: the suite is
+red by design until Phase 4, so its pass count carries no signal yet — the compile check is
+what guards downstream crates here.
+
+*T19 moved tiers.* The row above originally read "Render tier T1–T8, T19". T19 asserts the
+display block survives reconcile with its original `FileId`, and `reconciliation_plan` is a
+stage-local at `engine_execution.rs:699` that is never exposed on the stage's output — so
+`blocks_kept` is unobservable from a render. T19 is therefore an in-crate stage test, gated on
+Rscript + knitr, landed with the capture tier.
+
+*Three seam rows were vacuous as specified, and all three are now corrected in this document.*
+This is worth recording because the pattern is consistent: the plan reasoned correctly about
+what each test should *mean*, and slipped when reasoning about what it would *do* against an
+implementation that does not exist yet.
+
+- **T8** named a 4-space indented display block. qmd has no indented-code-block production at
+  all, so the fixture was unconstructible — see the Scope correction above.
+- **T18** followed vacuity note 2, whose own wording was wrong: a bare ` ```python ` block gives
+  an over-broad predicate nothing to rewrite, so the test passed with the predicate correct
+  *or* broken. Note 2 is rewritten above.
+- **T20 and T21** were vacuously green at baseline: with nothing masking yet,
+  `compute_input_qmd`'s bytes and `capture.input_qmd` are identical unmasked bytes, so the
+  equality assertion held for the wrong reason — likewise "the review file shows `{r}`, not the
+  marker". Each test keeps its literal invariant assertion (which discriminates its hunk once
+  the transform lands) and gained a second, currently-false assertion so it is genuinely RED
+  now. Verified by review to hold in both directions.
+
+*Baseline for Phase 2.* `quarto-core` 4327 run / 4301 passed / 26 failed / 31 skipped;
+`quarto-hub-provider` 40 run / 39 passed / 1 failed / 4 skipped.
+
+### Phase 2 — The transform
+
+- [ ] `crates/quarto-core/src/engine/nested_cell_mask.rs`. Pin the API in the module doc: `mask(&mut Pandoc) -> Vec<usize>` (indices of top-level blocks that changed) and `unmask(&str) -> String`
+- [ ] Mask rewrites openers in in-scope blocks; unmask is prefix-tolerant and not `^`-anchored
+- [ ] Walker recurses containers (Div, lists, blockquotes, table cells)
+- [ ] Walker maps each changed nested block to its top-level ancestor index
+- [ ] Phase 1 unit tests green
+
+### Phase 3 — Provenance
+
+Phase 1 cannot pin this — a correct-looking render is achievable with the
+provenance wrong, so an implementer who skips this phase gets a green suite
+and ships the drift. These tests are the only thing guarding it.
+
+- [ ] Changed blocks, and the top-level ancestor of a changed nested block, get `Generated` + the `Other("nested-cell-mask/origin")` anchor
+- [ ] Test: `map_offset` into a masked block returns `None`; an unmasked sibling in the same document still resolves to its true offset
+- [ ] Test: a document with no nested fences yields a `SourceInfo::Concat` whose pieces are identical to an unmasked run (compare piece `offset_in_concat`/`length` pairs)
+
+### Phase 4 — Wire the seam
+
+- [ ] Mask the clone inside the per-engine loop, before `serialize_ast_to_qmd`; unmask `result.markdown` before the capture emit
+- [ ] `compute_input_qmd` masks; `write_review_file` unmasks before writing the consent artifact
+- [ ] Test: `compute_input_qmd` bytes equal `capture.input_qmd` for a document **containing a display block** — the gap in the existing invariant fixture
+- [ ] Test: `write_review_file`'s output contains `{r}` and not the marker
+- [ ] Test: the display block lands in `blocks_kept` and retains its original source_info (not the intermediate's)
+- [ ] Test: two engines in sequence both receive masked input
+- [ ] Phase 1 render-level tests green
+
+### Phase 5 — Documentation
+
+- [ ] Expand `docs/guides/authoring/computations.qmd`: the rule, the nesting requirement, cell options, deeper nesting, and the existing Quarto 1 migration callout
+- [ ] No live executable cell on the page (see **Documentation** above)
+- [ ] `cargo run --bin q2 -- render docs/` succeeds and the page's own displayed examples render verbatim
+- [ ] Check the page against `cargo xtask lint` (error-docs rules touch `docs/`)
+
+### Phase 6 — End-to-end verification
+
+- [ ] `q2 render` each fixture through the real binary; inspect the HTML; record the exact invocations and observed output in this plan, per CLAUDE.md
+- [ ] Confirm a real cell still executes and highlights in the same document
+
+### Phase 7 — Wrap up
+
+- [ ] `cargo nextest run --workspace`, delta accounted for against the live baseline
+- [ ] `cargo xtask verify --skip-hub-build --skip-hub-tests`
+- [ ] Reconcile this checklist against what landed; commit
+- [ ] Comment the outcome on the strand

--- a/crates/quarto-core/Cargo.toml
+++ b/crates/quarto-core/Cargo.toml
@@ -24,6 +24,12 @@ pathdiff.workspace = true
 sha2 = "0.11"
 hex = "0.4"
 glob = "0.3"
+# Nested-cell-mask opener/closer matching (engine/nested_cell_mask.rs) runs on
+# both native and wasm32 (the WASM preview pipeline must mask displayed cells
+# too). Unconditional here costs nothing: `pampa` already declares `regex`
+# unconditionally and `quarto-core` depends on `pampa` unconditionally, so
+# regex is already compiled into the WASM payload.
+regex = "1.12"
 # `time` for date formatting (used by L1 ListingItemInfoStage; see
 # claude-notes/plans/2026-05-05-listings-L1-autofill-stage.md §D12).
 # `formatting` enables `OffsetDateTime::format`; `parsing` enables
@@ -87,7 +93,6 @@ clap = ["dep:clap"]
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tempfile = "3"
 which = "8"
-regex = "1.12"
 # `scraper` (CSS-selector HTML reader) for the L7 post-render upgrade
 # (`bd-qf7r`). Native-only by construction: post_render runs only
 # under `quarto render`, never in the WASM hub-client preview. The

--- a/crates/quarto-core/src/engine/fixture.rs
+++ b/crates/quarto-core/src/engine/fixture.rs
@@ -46,6 +46,8 @@
 //! [`new`]: FixtureEngine::new
 //! [`with_results`]: FixtureEngine::with_results
 
+use std::sync::{Arc, Mutex};
+
 use super::LanguageClaim;
 use super::context::{ExecuteResult, ExecutionContext};
 use super::error::ExecutionError;
@@ -60,6 +62,18 @@ pub struct FixtureEngine {
     /// In-memory results, used when `Some`. When `None`, results are read
     /// from the JSON file named by the engine config `results` key.
     results: Option<Vec<String>>,
+    /// Test-only: every `input` string this engine's [`execute`] has been
+    /// called with, in call order. Shared (not per-clone) so a caller can
+    /// take a handle via [`received_inputs`] *before* registering the
+    /// engine (registration erases it into `Arc<dyn ExecutionEngine>`) and
+    /// still observe what the running stage fed it. Added for bd-knitr /
+    /// T22 (nested-cell-masking plan): asserting that a *second* engine in
+    /// a sequence receives a masked input requires inspecting what it
+    /// actually received, which `ExecuteResult` alone doesn't expose.
+    ///
+    /// [`execute`]: ExecutionEngine::execute
+    /// [`received_inputs`]: FixtureEngine::received_inputs
+    received_inputs: Arc<Mutex<Vec<String>>>,
 }
 
 impl FixtureEngine {
@@ -70,6 +84,7 @@ impl FixtureEngine {
         Self {
             name: name.into(),
             results: None,
+            received_inputs: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
@@ -79,7 +94,18 @@ impl FixtureEngine {
         Self {
             name: name.into(),
             results: Some(results),
+            received_inputs: Arc::new(Mutex::new(Vec::new())),
         }
+    }
+
+    /// Test-only: a shared handle onto every `input` string passed to
+    /// [`execute`](ExecutionEngine::execute) so far, in call order. Clone
+    /// (or hold) this *before* wrapping the engine in `Arc<dyn
+    /// ExecutionEngine>` and registering it — the handle stays valid
+    /// because the backing `Arc<Mutex<_>>` is shared across `Clone`s of
+    /// `FixtureEngine`, not reset by them.
+    pub fn received_inputs(&self) -> Arc<Mutex<Vec<String>>> {
+        self.received_inputs.clone()
     }
 
     /// Resolve the ordered results list: in-memory if present, else from
@@ -158,6 +184,10 @@ impl ExecutionEngine for FixtureEngine {
         input: &str,
         ctx: &ExecutionContext,
     ) -> Result<ExecuteResult, ExecutionError> {
+        self.received_inputs
+            .lock()
+            .expect("received_inputs mutex poisoned")
+            .push(input.to_string());
         let results = self.resolve_results(ctx)?;
         let output = splice_cells(input, &self.name, &results)
             .map_err(|msg| ExecutionError::execution_failed(&self.name, msg))?;

--- a/crates/quarto-core/src/engine/jupyter/text_execute.rs
+++ b/crates/quarto-core/src/engine/jupyter/text_execute.rs
@@ -891,6 +891,42 @@ mod tests {
         }
     }
 
+    // ── T14 (H1): mask's opener-widening reddens this ───────────────────────
+    //
+    // `parse_code_blocks` is private, so this seam lives in this module
+    // rather than exposing it (controller ruling R5). Runs the real
+    // `nested_cell_mask::mask` end to end — parse a display block containing
+    // a nested `{python}` opener, mask it, serialize the masked AST back to
+    // qmd — and asserts jupyter's own partitioner finds nothing to execute
+    // in the result. Reverting H1 (mask stops rewriting the opener) leaves
+    // the literal `{python}` opener in the masked text, which
+    // `parse_code_blocks` *would* then match — turning this RED.
+    #[test]
+    fn t14_masked_display_block_yields_no_jupyter_cells() {
+        let qmd = "````markdown\n```{python}\nprint(\"x\")\n````\n";
+        let mut output = Vec::<u8>::new();
+        let (doc, _ast_context, _warnings) =
+            pampa::readers::qmd::read(qmd.as_bytes(), false, "test.qmd", &mut output, true, None)
+                .expect("parse qmd fixture");
+
+        let mut masked_doc = doc;
+        let changed = crate::engine::nested_cell_mask::mask(&mut masked_doc);
+        assert!(
+            !changed.is_empty(),
+            "fixture must actually get masked for this test to be meaningful"
+        );
+
+        let mut buf = Vec::new();
+        pampa::writers::qmd::write(&masked_doc, &mut buf).expect("serialize masked qmd fixture");
+        let masked_text = String::from_utf8(buf).expect("qmd writer must emit valid utf8");
+
+        let cells = parse_code_blocks(&masked_text);
+        assert!(
+            cells.is_empty(),
+            "masked text must yield 0 cells from jupyter's partitioner, got: {cells:?}"
+        );
+    }
+
     // ── partition_cells tests ────────────────────────────────────────────────
 
     // -----------------------------------------------------------------------

--- a/crates/quarto-core/src/engine/mod.rs
+++ b/crates/quarto-core/src/engine/mod.rs
@@ -59,6 +59,7 @@ mod context;
 mod detection;
 mod error;
 mod markdown;
+pub mod nested_cell_mask;
 pub mod preview_record;
 mod registry;
 mod replay;

--- a/crates/quarto-core/src/engine/nested_cell_mask.rs
+++ b/crates/quarto-core/src/engine/nested_cell_mask.rs
@@ -3,7 +3,53 @@
  * Copyright (c) 2025 Posit, PBC
  */
 
-use quarto_pandoc_types::Pandoc;
+use quarto_pandoc_types::{Block, CodeBlock, Pandoc};
+use regex::Regex;
+use std::sync::LazyLock;
+
+/// The class that marks a masked opener as ours, and the sole thing `unmask`
+/// looks for. Never emitted by an author writing their own `{.lang}`.
+const MASK_MARKER: &str = "q2-nested-executable";
+
+/// Matches a whole line that is an executable-fence *opener*: optional
+/// leading whitespace (indentation), a run of 3+ backticks, optional
+/// whitespace, a brace-delimited info string whose first character is
+/// alphanumeric/underscore (the union of what knitr, q2's jupyter text
+/// engine, and the TS `breakQuartoMd` partitioner all accept), optional
+/// trailing whitespace, end of line.
+///
+/// Deliberately excludes:
+/// - `{{lang}}` (doubled brace): the char after `{` is `{`, not
+///   `[A-Za-z0-9_]` — T10.
+/// - `{.lang}` (an author's own dot-class): the char after `{` is `.` —
+///   T11 relies on `unmask`'s marker check, but `mask` itself also never
+///   matches a dot-prefixed opener, so it can't double-mask one.
+/// - `{=lang}` (raw-format openers): `=` is not in the allowed first-char set.
+///
+/// `(?m)` makes `^`/`$` match at line boundaries within the block's `text`,
+/// not just the start/end of the whole string. `R` additionally puts `$`
+/// (and `^`) in CRLF mode, so `\r\n`-terminated lines are recognized as
+/// line boundaries too — without it, `$` only ever matches before a bare
+/// `\n`, so a `\r\n`-saved file (or any Windows checkout) leaves every
+/// trailing `\r` unconsumed, the line never matches, and masking silently
+/// becomes a no-op (T23).
+static MASK_OPENER_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?mR)^([ \t]*)(`{3,})([ \t]*)\{([A-Za-z0-9_]+)([^}\r\n]*)\}([ \t]*)$")
+        .expect("MASK_OPENER_RE must compile")
+});
+
+/// Matches a masked opener anywhere in a string — **not** anchored to line
+/// start, so a blockquote's `> ` prefix (which `unmask` sees but `mask`
+/// never does — see module doc) doesn't prevent the match (H4). Captures
+/// the language and the verbatim "rest" (e.g. `, echo=FALSE`) that `mask`
+/// preserved unchanged.
+static UNMASK_OPENER_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(&format!(
+        r"\{{\.([A-Za-z0-9_]+) {}([^}}\r\n]*)\}}",
+        regex::escape(MASK_MARKER)
+    ))
+    .expect("UNMASK_OPENER_RE must compile")
+});
 
 /// Rewrite executable fence openers that appear *inside* a markdown-displaying
 /// code block so no engine's cell scanner claims them, and restore them
@@ -33,13 +79,176 @@ use quarto_pandoc_types::Pandoc;
 /// question) — at that point a widened classes conjunct could admit a real
 /// executable cell whose language happens to also be a display-class name,
 /// and only the `engine_cell_lang` check would still exclude it.
+///
+/// ## Known limitation
+///
+/// `unmask` pattern-matches on the `q2-nested-executable` marker text. An
+/// author who writes that string verbatim inside a display block — not as
+/// an opener, just as prose or code — gets it rewritten by `unmask` as if
+/// it were one of ours. Measured negligible in practice; removed later in
+/// the epic when an assembler restores from retained bytes rather than by
+/// matching. Not fixed here; not tested here (a test would pin behaviour
+/// this plan intends to change).
 pub fn mask(doc: &mut Pandoc) -> Vec<usize> {
-    let _ = doc;
-    unimplemented!("mask: task 5")
+    let mut changed = Vec::new();
+    for (idx, block) in doc.blocks.iter_mut().enumerate() {
+        if mask_block(block) {
+            changed.push(idx);
+        }
+    }
+    changed
 }
+
 pub fn unmask(s: &str) -> String {
-    let _ = s;
-    unimplemented!("unmask: task 5")
+    UNMASK_OPENER_RE.replace_all(s, "{$1$2}").into_owned()
+}
+
+/// True iff `block` is a `CodeBlock` eligible for masking: attr classes
+/// empty or exactly `["markdown"]`, and not itself a genuine executable
+/// cell (H2). See the module doc for why the `engine_cell_lang` conjunct is
+/// kept even though it is currently implied by the classes conjunct.
+fn is_in_scope_for_masking(block: &Block) -> bool {
+    let Block::CodeBlock(cb) = block else {
+        return false;
+    };
+    let classes = &cb.attr.1;
+    let classes_ok = classes.is_empty() || (classes.len() == 1 && classes[0] == "markdown");
+    classes_ok && crate::engine::capture_splice::engine_cell_lang(block).is_none()
+}
+
+/// Rewrite every masking-eligible fence opener in `cb.text`. Returns
+/// whether anything actually changed.
+fn mask_code_block_text(cb: &mut CodeBlock) -> bool {
+    let replacement = "${1}${2}${3}{.${4} ".to_string() + MASK_MARKER + "${5}}${6}";
+    let new_text = MASK_OPENER_RE.replace_all(&cb.text, replacement.as_str());
+    if new_text == cb.text {
+        false
+    } else {
+        cb.text = new_text.into_owned();
+        true
+    }
+}
+
+/// Recurse into `block`, masking any in-scope nested `CodeBlock`s in place.
+/// Returns whether `block` itself, or anything nested inside it, changed —
+/// the top-level caller uses this to report the *ancestor's* index (H7),
+/// since the qmd writer's piece loop is top-level-only.
+fn mask_block(block: &mut Block) -> bool {
+    if let Block::CodeBlock(_) = block {
+        if !is_in_scope_for_masking(block) {
+            return false;
+        }
+        let Block::CodeBlock(cb) = block else {
+            unreachable!("matched CodeBlock above");
+        };
+        return mask_code_block_text(cb);
+    }
+
+    match block {
+        // Out of scope, deliberately (spec § Scope): masking a RawBlock's
+        // `{=markdown}` text would free its nested cell as a genuine
+        // top-level cell once the writer emits the RawBlock unfenced.
+        Block::RawBlock(_) => false,
+        Block::BlockQuote(b) => mask_blocks(&mut b.content),
+        Block::Div(b) => mask_blocks(&mut b.content),
+        Block::OrderedList(b) => {
+            let mut changed = false;
+            for item in &mut b.content {
+                changed |= mask_blocks(item);
+            }
+            changed
+        }
+        Block::BulletList(b) => {
+            let mut changed = false;
+            for item in &mut b.content {
+                changed |= mask_blocks(item);
+            }
+            changed
+        }
+        Block::DefinitionList(b) => {
+            let mut changed = false;
+            for (_term, defs) in &mut b.content {
+                for item in defs {
+                    changed |= mask_blocks(item);
+                }
+            }
+            changed
+        }
+        Block::Table(t) => mask_table(t),
+        Block::Figure(f) => {
+            let mut changed = mask_blocks(&mut f.content);
+            if let Some(long) = f.caption.long.as_mut() {
+                changed |= mask_blocks(long);
+            }
+            changed
+        }
+        Block::NoteDefinitionFencedBlock(b) => mask_blocks(&mut b.content),
+        Block::Custom(c) => mask_custom(c),
+        _ => false,
+    }
+}
+
+/// Mask every block in a container's block list; returns whether any of
+/// them (or their descendants) changed. Does not short-circuit — every
+/// element is visited regardless of earlier results, since masking has
+/// side effects on each element independently.
+fn mask_blocks(blocks: &mut [Block]) -> bool {
+    let mut changed = false;
+    for block in blocks.iter_mut() {
+        if mask_block(block) {
+            changed = true;
+        }
+    }
+    changed
+}
+
+fn mask_table(table: &mut quarto_pandoc_types::Table) -> bool {
+    let mut changed = false;
+    // T24: the table's own long-form caption, mirroring the Figure arm above
+    // (`Caption.long: Option<Blocks>` — same type as Figure's caption).
+    if let Some(long) = table.caption.long.as_mut() {
+        changed |= mask_blocks(long);
+    }
+    for row in &mut table.head.rows {
+        changed |= mask_row(row);
+    }
+    for body in &mut table.bodies {
+        for row in &mut body.head {
+            changed |= mask_row(row);
+        }
+        for row in &mut body.body {
+            changed |= mask_row(row);
+        }
+    }
+    for row in &mut table.foot.rows {
+        changed |= mask_row(row);
+    }
+    changed
+}
+
+fn mask_row(row: &mut quarto_pandoc_types::Row) -> bool {
+    let mut changed = false;
+    for cell in &mut row.cells {
+        changed |= mask_blocks(&mut cell.content);
+    }
+    changed
+}
+
+fn mask_custom(custom: &mut quarto_pandoc_types::CustomNode) -> bool {
+    let mut changed = false;
+    for slot in custom.slots.values_mut() {
+        match slot {
+            quarto_pandoc_types::Slot::Block(b) => {
+                changed |= mask_block(b);
+            }
+            quarto_pandoc_types::Slot::Blocks(bs) => {
+                changed |= mask_blocks(bs);
+            }
+            // Inline/Inlines slots can't contain a CodeBlock.
+            quarto_pandoc_types::Slot::Inline(_) | quarto_pandoc_types::Slot::Inlines(_) => {}
+        }
+    }
+    changed
 }
 
 #[cfg(test)]
@@ -533,6 +742,102 @@ mod tests {
             before_pairs, after_pairs,
             "piece (offset_in_concat, length) pairs must be identical to the unmasked run \
              when no block is in scope for masking"
+        );
+    }
+
+    // ── T23 (MASK_OPENER_RE's `R` flag): a CRLF-authored display block must
+    // still be masked, and unmask must restore every `\r\n` byte-exactly.
+    // Built with explicit `\r\n` escapes (not relying on the source file's
+    // own line endings) so the fixture is CRLF regardless of how this file
+    // is checked out. Reverting the `R` flag back to plain `(?m)` leaves
+    // the fence's trailing `\r` unconsumed by `[ \t]*$`, so the opener line
+    // never matches `$` and `mask` silently becomes a no-op — `changed`
+    // comes back empty and `assert_mask_unmask_roundtrip`'s first
+    // assertion catches it directly.
+    #[test]
+    fn t23_crlf_display_block_round_trips_byte_exactly() {
+        let qmd = "````markdown\r\n```{r}\r\ncat(\"x\")\r\n```\r\n````\r\n";
+        assert_mask_unmask_roundtrip(qmd, "CRLF display block");
+    }
+
+    // ── T24 (mask_table's caption recursion): a display block nested
+    // inside a table's long-form caption must also be masked.
+    // `Table.caption` is the same `Caption` type `Figure.caption` uses
+    // (`table.rs` vs `block.rs`), and the `Figure` arm already walks
+    // `caption.long` — this guards that `mask_table` does too. Built
+    // directly as a `Pandoc`/`Table` (rather than parsed from qmd) since
+    // the qmd surface syntax for a table's block-level long caption isn't
+    // needed to exercise the walker itself, mirroring the
+    // `quarto-ast-reconcile` test suite's own `make_table` helper.
+    #[test]
+    fn t24_display_block_in_table_long_caption_is_masked() {
+        let source = quarto_source_map::SourceInfo::original(quarto_source_map::FileId(0), 0, 1);
+        let attr = || quarto_pandoc_types::empty_attr();
+        let attr_source = quarto_pandoc_types::AttrSourceInfo::empty;
+
+        let display_block = Block::CodeBlock(CodeBlock {
+            attr: attr(),
+            text: "```{r}\ncat(\"x\")\n```".to_string(),
+            source_info: source.clone(),
+            attr_source: attr_source(),
+        });
+
+        let table = Block::Table(quarto_pandoc_types::Table {
+            attr: attr(),
+            caption: quarto_pandoc_types::Caption {
+                short: None,
+                long: Some(vec![display_block]),
+                source_info: source.clone(),
+            },
+            colspec: vec![(
+                quarto_pandoc_types::Alignment::Default,
+                quarto_pandoc_types::ColWidth::Default,
+            )],
+            head: quarto_pandoc_types::TableHead {
+                attr: attr(),
+                rows: vec![],
+                source_info: source.clone(),
+                attr_source: attr_source(),
+            },
+            bodies: vec![],
+            foot: quarto_pandoc_types::TableFoot {
+                attr: attr(),
+                rows: vec![],
+                source_info: source.clone(),
+                attr_source: attr_source(),
+            },
+            source_info: source.clone(),
+            attr_source: attr_source(),
+        });
+
+        let mut doc = Pandoc {
+            blocks: vec![table],
+            ..Default::default()
+        };
+
+        let changed = mask(&mut doc);
+        assert_eq!(
+            changed,
+            vec![0],
+            "the table's top-level index must be reported as changed when its \
+             caption's display block is masked"
+        );
+
+        let Block::Table(t) = &doc.blocks[0] else {
+            panic!("fixture must remain a Table, got: {:?}", doc.blocks[0]);
+        };
+        let long = t
+            .caption
+            .long
+            .as_ref()
+            .expect("caption.long must survive masking");
+        let Block::CodeBlock(cb) = &long[0] else {
+            panic!("caption.long[0] must remain a CodeBlock, got: {long:?}");
+        };
+        assert!(
+            cb.text.contains("q2-nested-executable"),
+            "the display block inside the table's long caption must be masked, got: {}",
+            cb.text
         );
     }
 }

--- a/crates/quarto-core/src/engine/nested_cell_mask.rs
+++ b/crates/quarto-core/src/engine/nested_cell_mask.rs
@@ -4,8 +4,22 @@
  */
 
 use quarto_pandoc_types::{Block, CodeBlock, Pandoc};
+use quarto_source_map::{Anchor, AnchorRole, By, SourceInfo};
 use regex::Regex;
+use smallvec::smallvec;
+use std::sync::Arc;
 use std::sync::LazyLock;
+
+/// `by.kind` for every `SourceInfo::Generated` node this module produces
+/// (spec § Provenance, pinned normative string — T15/T17 assert it verbatim).
+const GENERATED_BY_KIND: &str = "nested-cell-mask";
+
+/// `AnchorRole::Other` tag for the anchor pointing back at a masked block's
+/// pre-mask `SourceInfo` (spec § Provenance). Deliberately `Other`, not
+/// `Invocation`: `SourceInfo::preimage_in`'s `Generated` arm only walks
+/// `Invocation` anchors, so this anchor is provably inert to any
+/// byte-copying writer — see the module doc's Provenance section.
+const ORIGIN_ANCHOR_ROLE: &str = "nested-cell-mask/origin";
 
 /// The class that marks a masked opener as ours, and the sole thing `unmask`
 /// looks for. Never emitted by an author writing their own `{.lang}`.
@@ -89,14 +103,64 @@ static UNMASK_OPENER_RE: LazyLock<Regex> = LazyLock::new(|| {
 /// the epic when an assembler restores from retained bytes rather than by
 /// matching. Not fixed here; not tested here (a test would pin behaviour
 /// this plan intends to change).
+///
+/// ## Provenance (spec § Provenance)
+///
+/// Masked text is longer than its source, and the qmd writer's map is
+/// output-indexed per top-level block — so a changed block's own
+/// `SourceInfo` would silently resolve offsets past its end into the next
+/// block's source text if left `Original`. `mask` stamps every block it
+/// actually rewrites, and separately its **top-level ancestor** (the writer's
+/// piece loop is top-level-only), with `SourceInfo::Generated { by.kind:
+/// "nested-cell-mask", from: [Other("nested-cell-mask/origin")] }` so
+/// `map_offset` returns "location unknown" instead of a confidently wrong
+/// offset. See `mark_generated` below.
+///
+/// ## Interaction with QuartoNotebookRunner (do not mitigate here — bd-quydz82t)
+///
+/// A document whose sole top-level block is a container with both a live
+/// executable cell and a nested display block ends up with that lone
+/// top-level piece marked `Generated`, so every offset in it — including the
+/// live cell's — maps to `None`. That can starve a downstream engine
+/// (QuartoNotebookRunner) of `sourceRanges` it doesn't expect to be empty.
+/// This is `build_source_map`'s contract to defend, not this mask's job:
+/// the ancestor rule here is deliberate and unconditional. See bd-quydz82t.
 pub fn mask(doc: &mut Pandoc) -> Vec<usize> {
     let mut changed = Vec::new();
     for (idx, block) in doc.blocks.iter_mut().enumerate() {
+        let original = block.source_info().clone();
         if mask_block(block) {
+            // `mask_block`'s direct-CodeBlock branch already stamps `block`
+            // itself when the top-level block *is* the changed CodeBlock
+            // (T15). Otherwise `block` is a container ancestor (Div, List,
+            // ...) whose own SourceInfo is still Original even though a
+            // descendant changed — stamp it now using the pre-mutation
+            // original, so the writer's top-level-only piece loop sees
+            // Generated for the whole ancestor's piece (T17).
+            if !matches!(block.source_info(), SourceInfo::Generated { .. }) {
+                mark_generated(block, original);
+            }
             changed.push(idx);
         }
     }
     changed
+}
+
+/// Stamp `block`'s `SourceInfo` as `Generated`, anchored back at `original`
+/// (the block's pre-mask `SourceInfo`) via an `Other("nested-cell-mask/origin")`
+/// anchor. `Other` rather than `Invocation` is deliberate — see the module
+/// doc's Provenance section and the spec.
+fn mark_generated(block: &mut Block, original: SourceInfo) {
+    *block.source_info_mut() = SourceInfo::Generated {
+        by: By {
+            kind: GENERATED_BY_KIND.to_string(),
+            data: serde_json::Value::Null,
+        },
+        from: smallvec![Anchor {
+            role: AnchorRole::Other(ORIGIN_ANCHOR_ROLE.to_string()),
+            source_info: Arc::new(original),
+        }],
+    };
 }
 
 pub fn unmask(s: &str) -> String {
@@ -138,10 +202,19 @@ fn mask_block(block: &mut Block) -> bool {
         if !is_in_scope_for_masking(block) {
             return false;
         }
+        let original = block.source_info().clone();
         let Block::CodeBlock(cb) = block else {
             unreachable!("matched CodeBlock above");
         };
-        return mask_code_block_text(cb);
+        if !mask_code_block_text(cb) {
+            return false;
+        }
+        // This block's own text changed — stamp its SourceInfo directly
+        // (spec § Provenance). If this CodeBlock is itself the top-level
+        // block, `mask`'s caller sees it already Generated and skips its
+        // own ancestor-stamping step.
+        mark_generated(block, original);
+        return true;
     }
 
     match block {

--- a/crates/quarto-core/src/engine/nested_cell_mask.rs
+++ b/crates/quarto-core/src/engine/nested_cell_mask.rs
@@ -1,0 +1,538 @@
+/*
+ * engine/nested_cell_mask.rs
+ * Copyright (c) 2025 Posit, PBC
+ */
+
+use quarto_pandoc_types::Pandoc;
+
+/// Rewrite executable fence openers that appear *inside* a markdown-displaying
+/// code block so no engine's cell scanner claims them, and restore them
+/// byte-exactly afterwards.
+///
+/// API (pinned by the plan):
+///   `mask(&mut Pandoc) -> Vec<usize>` — rewrites in-scope blocks in place and
+///     returns the indices of the **top-level** blocks that changed.
+///   `unmask(&str) -> String` — restores masked openers textually.
+///
+/// ## Scope: the in-scope predicate (H2)
+///
+/// A block is in scope for masking iff its attr classes are empty or exactly
+/// `["markdown"]`, **and** `engine_cell_lang(block).is_none()`
+/// (`capture_splice.rs`) — a block that is itself a genuine executable cell
+/// must never be masked.
+///
+/// The `engine_cell_lang` conjunct is, today, provably implied by the
+/// classes conjunct: `engine_cell_lang` returns `Some` only for a block
+/// carrying a brace-shaped class (`{lang}`), and neither "empty" nor
+/// `["markdown"]` can be brace-shaped. So no fixture can currently make the
+/// two conjuncts disagree (see T13's proof, in this module's test suite,
+/// and the plan's "Accepted untested" list). **It is kept anyway** — do not
+/// delete it as dead code. It becomes load-bearing the moment the
+/// display-class predicate widens past `["markdown"]` (e.g. to admit
+/// ` ```qmd `, a widening the plan calls out as a separate, undecided
+/// question) — at that point a widened classes conjunct could admit a real
+/// executable cell whose language happens to also be a display-class name,
+/// and only the `engine_cell_lang` check would still exclude it.
+pub fn mask(doc: &mut Pandoc) -> Vec<usize> {
+    let _ = doc;
+    unimplemented!("mask: task 5")
+}
+pub fn unmask(s: &str) -> String {
+    let _ = s;
+    unimplemented!("unmask: task 5")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use pampa::readers::qmd;
+
+    /// Parse a qmd fragment directly with pampa and return the raw
+    /// Pandoc AST. Copied idiom from `document_profile.rs`'s test module.
+    fn parse_qmd(qmd_text: &str) -> Pandoc {
+        let mut output = Vec::<u8>::new();
+        let (ast, _ast_context, _warnings) = qmd::read(
+            qmd_text.as_bytes(),
+            false,
+            "test.qmd",
+            &mut output,
+            true,
+            None,
+        )
+        .expect("parse qmd fixture");
+        ast
+    }
+
+    /// Serialize a `Pandoc` back to qmd text with the plain (non-tracked)
+    /// writer — the unit tier has no writer/source-map concerns (that's
+    /// tier W, in `pampa::writers::qmd`'s own tests).
+    fn serialize(doc: &Pandoc) -> String {
+        let mut buf = Vec::new();
+        pampa::writers::qmd::write(doc, &mut buf).expect("serialize qmd fixture");
+        String::from_utf8(buf).expect("qmd writer must emit valid utf8")
+    }
+
+    /// Like `parse_qmd`, but also returns the `SourceContext` the parse
+    /// produced — needed by the writer tier (T15–T18) to call
+    /// `SourceInfo::map_offset`, which `parse_qmd`'s callers (T9–T14) never
+    /// need.
+    fn parse_qmd_with_context(qmd_text: &str) -> (Pandoc, quarto_source_map::SourceContext) {
+        let mut output = Vec::<u8>::new();
+        let (ast, ast_context, _warnings) = qmd::read(
+            qmd_text.as_bytes(),
+            false,
+            "test.qmd",
+            &mut output,
+            true,
+            None,
+        )
+        .expect("parse qmd fixture");
+        (ast, ast_context.source_context)
+    }
+
+    // ── T9 (H5): unmask replays whitespace / backtick-width exactly ────────
+    //
+    // Not vacuous (a no-op `mask` would trivially satisfy `unmask(mask(x)) ==
+    // x`): every case asserts both (a) `mask` actually changed the document
+    // — the serialized masked text carries the marker — and (b) `unmask` of
+    // that masked text restores the pre-mask serialization byte-exactly.
+    //
+    // The baseline for "x" is the document serialized *before* masking
+    // (rather than the hand-authored fixture string) so this test isolates
+    // mask/unmask fidelity from unrelated qmd-writer normalization (e.g.
+    // `determine_backticks` picking a fence width independently of what the
+    // fixture literal used).
+    fn assert_mask_unmask_roundtrip(qmd_text: &str, case: &str) {
+        let doc = parse_qmd(qmd_text);
+        let original = serialize(&doc);
+
+        let mut masked_doc = doc.clone();
+        let changed = mask(&mut masked_doc);
+        assert!(
+            !changed.is_empty(),
+            "{case}: mask must report at least one changed top-level block"
+        );
+
+        let masked_text = serialize(&masked_doc);
+        assert!(
+            masked_text.contains("q2-nested-executable"),
+            "{case}: masked text must carry the marker, got:\n{masked_text}"
+        );
+
+        let restored = unmask(&masked_text);
+        assert_eq!(
+            restored, original,
+            "{case}: unmask must restore the pre-mask serialization byte-exactly"
+        );
+    }
+
+    // T9 (H5): unmask replays whitespace / backtick-width exactly.
+    #[test]
+    fn t9_plain_opener() {
+        let qmd = "````markdown\n```{r}\ncat(\"x\")\n```\n````\n";
+        assert_mask_unmask_roundtrip(qmd, "plain opener");
+    }
+
+    // T9 (H5): unmask replays whitespace / backtick-width exactly.
+    #[test]
+    fn t9_opener_with_options() {
+        let qmd = "````markdown\n```{r, echo=FALSE}\ncat(\"x\")\n```\n````\n";
+        assert_mask_unmask_roundtrip(qmd, "opener with options");
+    }
+
+    // T9 (H5): unmask replays whitespace / backtick-width exactly.
+    #[test]
+    fn t9_space_before_brace() {
+        let qmd = "````markdown\n``` {r}\ncat(\"x\")\n```\n````\n";
+        assert_mask_unmask_roundtrip(qmd, "space between fence and brace");
+    }
+
+    // T9 (H5): unmask replays whitespace / backtick-width exactly.
+    // Trailing spaces after `{r}`, before the newline — written via an
+    // explicit escape so they can't be silently stripped as end-of-line
+    // whitespace by an editor or formatter.
+    #[test]
+    fn t9_trailing_whitespace_after_opener() {
+        let qmd = "````markdown\n```{r}   \ncat(\"x\")\n```\n````\n";
+        assert_mask_unmask_roundtrip(qmd, "trailing whitespace after opener");
+    }
+
+    // T9 (H5): unmask replays whitespace / backtick-width exactly.
+    // The inner (nested, displayed) fence itself uses four backticks; the
+    // outer display fence must use more (five) to contain it.
+    #[test]
+    fn t9_wide_inner_fence() {
+        let qmd = "`````markdown\n````{r}\ncat(\"x\")\n````\n`````\n";
+        assert_mask_unmask_roundtrip(qmd, "four-backtick inner fence");
+    }
+
+    // T9 (H5): unmask replays whitespace / backtick-width exactly.
+    #[test]
+    fn t9_indented_in_list_item() {
+        let qmd = "1. item\n\n   ````markdown\n   ```{r}\n   cat(\"x\")\n   ```\n   ````\n";
+        assert_mask_unmask_roundtrip(qmd, "leading-indented fence inside a list item");
+    }
+
+    // T9 (H5): unmask replays whitespace / backtick-width exactly.
+    #[test]
+    fn t9_blockquoted_display_block() {
+        let qmd = "> ````markdown\n> ```{r}\n> cat(\"x\")\n> ```\n> ````\n";
+        assert_mask_unmask_roundtrip(qmd, "blockquoted display block");
+    }
+
+    // ── T10 (H1): widening the opener pattern past [A-Za-z0-9_] reddens this ──
+    #[test]
+    fn t10_doubled_brace_is_out_of_scope() {
+        // Doubled-brace `{{python}}` openers are deliberately out of scope
+        // (spec § Scope, "Out, deliberately"): the first character after
+        // `{` is `{`, not alphanumeric, so mask's opener pattern must not
+        // match it. Reverting H1 to widen the pattern past
+        // `[A-Za-z0-9_]` would make this go RED.
+        let qmd = "````markdown\n```{{python}}\nprint(\"x\")\n```\n````\n";
+        let doc = parse_qmd(qmd);
+        let before = serialize(&doc);
+
+        let mut masked_doc = doc.clone();
+        let changed = mask(&mut masked_doc);
+        assert!(
+            changed.is_empty(),
+            "a doubled-brace {{{{python}}}} opener must not be masked"
+        );
+
+        let after = serialize(&masked_doc);
+        assert_eq!(
+            after, before,
+            "block text must be byte-identical when nothing was masked"
+        );
+    }
+
+    // ── T11 (H3): dropping the marker requirement from unmask reddens this ──
+    #[test]
+    fn t11_authors_own_dot_class_is_untouched() {
+        // An author who writes their own `{.r}` (not our marked
+        // `{.r q2-nested-executable}`) inside a display block must be left
+        // exactly as written. `unmask` only reverts openers carrying the
+        // `q2-nested-executable` marker — dropping that requirement (H3)
+        // would make this go RED.
+        let text = "Some prose.\n\n````markdown\n```{.r}\ncat(\"x\")\n```\n````\n";
+        assert_eq!(unmask(text), text);
+    }
+
+    // ── T12 (H2): extending the predicate to RawBlock reddens this ─────────
+    #[test]
+    fn t12_rawblock_markdown_is_out_of_scope() {
+        // A `{=markdown}` RawBlock containing a nested `{r}` opener must be
+        // left completely unchanged. Per the spec's "Out, deliberately"
+        // list: masking a RawBlock converts "wrongly executed" into
+        // "silently mangled", because the qmd writer emits `{=markdown}`
+        // RawBlocks unfenced — the inner cell would become a genuine
+        // top-level cell. Guards the spike's measured downgrade.
+        let qmd = "````{=markdown}\n```{r}\ncat(\"x\")\n```\n````\n";
+        let doc = parse_qmd(qmd);
+        assert!(
+            matches!(
+                doc.blocks.as_slice(),
+                [quarto_pandoc_types::Block::RawBlock(_)]
+            ),
+            "fixture must parse to a single RawBlock, got: {:?}",
+            doc.blocks
+        );
+        let before = serialize(&doc);
+
+        let mut masked_doc = doc.clone();
+        let changed = mask(&mut masked_doc);
+        assert!(
+            changed.is_empty(),
+            "a {{=markdown}} RawBlock must not be touched by mask"
+        );
+
+        let after = serialize(&masked_doc);
+        assert_eq!(
+            after, before,
+            "a {{=markdown}} RawBlock must be byte-identical after mask"
+        );
+    }
+
+    // ── T13 (H2): dropping the classes-empty-or-["markdown"] conjunct reddens this ──
+    #[test]
+    fn t13_nested_opener_inside_a_real_cell_is_untouched() {
+        // `{r}` text appearing inside the *source* of a real, executable
+        // `{r}` cell must not be rewritten — rewriting inside a cell that
+        // is about to run would corrupt code that executes. The outer real
+        // cell uses four backticks so the nested three-backtick-looking
+        // lines in its own source can't be mistaken for (or accidentally
+        // close) the outer fence.
+        //
+        // Bound to H2's *classes* conjunct (empty or `["markdown"]`), not
+        // its `engine_cell_lang` conjunct: `engine_cell_lang` (see
+        // `capture_splice.rs`) only returns `Some` for a block carrying a
+        // brace-shaped class, and the classes conjunct admits only empty or
+        // `["markdown"]` — neither can be brace-shaped. So for every block
+        // that passes the classes conjunct, `engine_cell_lang(block) ==
+        // None` necessarily; dropping the `engine_cell_lang` check alone
+        // (leaving the classes conjunct in place) cannot be discriminated
+        // by any fixture, so no test binds to it. See the module doc's
+        // scope note for why that check is kept anyway.
+        let qmd = "````{r}\n# ```{r}\ncat(1)\n# ```\ncat(2)\n````\n";
+        let doc = parse_qmd(qmd);
+        assert!(
+            matches!(
+                doc.blocks.as_slice(),
+                [quarto_pandoc_types::Block::CodeBlock(_)]
+            ),
+            "fixture must parse to a single CodeBlock, got: {:?}",
+            doc.blocks
+        );
+        assert_eq!(
+            crate::engine::capture_splice::engine_cell_lang(&doc.blocks[0]),
+            Some("r"),
+            "fixture must be a real, executable {{r}} cell"
+        );
+        let before = serialize(&doc);
+
+        let mut masked_doc = doc.clone();
+        let changed = mask(&mut masked_doc);
+        assert!(
+            changed.is_empty(),
+            "a real executable cell's own source must not be masked"
+        );
+
+        let after = serialize(&masked_doc);
+        assert_eq!(
+            after, before,
+            "a real executable cell must be byte-identical after mask"
+        );
+    }
+
+    // ── W tier: writer/source-map provenance (T15–T18) ─────────────────────
+    //
+    // These drive the real qmd writer (`write_with_source_info`) and the
+    // real `SourceInfo::map_offset` over a real `Pandoc` produced by
+    // `mask`. No engine is involved.
+
+    // ── T15 (H6): reverting the Generated + Other("nested-cell-mask/origin")
+    // marking gives `Some(wrong)`, not `None`. ─────────────────────────────
+    #[test]
+    fn t15_masked_block_map_offset_is_none() {
+        let qmd = "````markdown\n```{r}\ncat(\"x\")\n```\n````\n\nSome unrelated prose.\n";
+        let (mut doc, ctx) = parse_qmd_with_context(qmd);
+
+        let changed = mask(&mut doc);
+        assert_eq!(
+            changed,
+            vec![0],
+            "expected the display block (top-level index 0) to be masked"
+        );
+
+        // Assert the anchor precisely: `by.kind` is the mask's own
+        // kebab-case kind, and `from` carries exactly the
+        // `Other("nested-cell-mask/origin")` anchor (not `Invocation` —
+        // `preimage_in`'s `Generated` arm only walks `Invocation`, so this
+        // anchor must be provably inert to any byte-copying writer).
+        match doc.blocks[0].source_info() {
+            quarto_source_map::SourceInfo::Generated { by, from } => {
+                assert_eq!(
+                    by.kind, "nested-cell-mask",
+                    "Generated.by.kind must be the mask's own kebab-case kind"
+                );
+                assert!(
+                    from.iter().any(|a| a.role
+                        == quarto_source_map::AnchorRole::Other(
+                            "nested-cell-mask/origin".to_string()
+                        )),
+                    "Generated.from must carry an Other(\"nested-cell-mask/origin\") anchor, got: {from:?}"
+                );
+            }
+            other => panic!("masked block's source_info must be Generated, got: {other:?}"),
+        }
+
+        let (buf, source_info) =
+            pampa::writers::qmd::write_with_source_info(&doc).expect("masked doc must serialize");
+        let masked_text = String::from_utf8(buf).expect("qmd writer must emit valid utf8");
+
+        let marker_offset = masked_text
+            .find("q2-nested-executable")
+            .expect("masked text must carry the marker");
+
+        let mapped = source_info.map_offset(marker_offset, &ctx);
+        assert_eq!(
+            mapped, None,
+            "map_offset into a masked block must return None (location unknown), \
+             not a confidently wrong location"
+        );
+    }
+
+    // ── T16 (H6 over-applied): if `mask` marked every top-level block
+    // Generated instead of only the changed one, the unmasked sibling below
+    // would also map to `None` instead of its true offset. ────────────────
+    #[test]
+    fn t16_unmasked_sibling_map_offset_still_resolves() {
+        let qmd = "````markdown\n```{r}\ncat(\"x\")\n```\n````\n\nSome unrelated prose.\n";
+        let (doc, ctx) = parse_qmd_with_context(qmd);
+
+        // Baseline: where "unrelated" maps *before* masking touches anything.
+        let (unmasked_buf, unmasked_source_info) =
+            pampa::writers::qmd::write_with_source_info(&doc).expect("unmasked doc must serialize");
+        let unmasked_text =
+            String::from_utf8(unmasked_buf).expect("qmd writer must emit valid utf8");
+        let baseline_offset = unmasked_text
+            .find("unrelated")
+            .expect("fixture must contain the sibling's 'unrelated' text");
+        let expected = unmasked_source_info
+            .map_offset(baseline_offset, &ctx)
+            .expect("the sibling paragraph must resolve before any masking happens");
+
+        let mut masked_doc = doc.clone();
+        let changed = mask(&mut masked_doc);
+        assert_eq!(
+            changed,
+            vec![0],
+            "only the display block (index 0) should be masked; the sibling (index 1) must stay untouched"
+        );
+
+        let (masked_buf, masked_source_info) =
+            pampa::writers::qmd::write_with_source_info(&masked_doc)
+                .expect("masked doc must serialize");
+        let masked_text = String::from_utf8(masked_buf).expect("qmd writer must emit valid utf8");
+        let masked_offset = masked_text
+            .find("unrelated")
+            .expect("sibling text must survive masking unchanged");
+
+        let mapped = masked_source_info.map_offset(masked_offset, &ctx).expect(
+            "map_offset into the unmasked sibling must still resolve; an over-applied \
+                 H6 that marks every top-level block Generated would return None here",
+        );
+
+        assert_eq!(
+            mapped, expected,
+            "the unmasked sibling must map to the same original location it did before masking"
+        );
+    }
+
+    // ── T17 (H7): reverting the top-level-ancestor marking leaves the Div
+    // `Original`, so a masked block nested inside it would still drift. ────
+    #[test]
+    fn t17_nested_display_block_marks_top_level_ancestor() {
+        let qmd = "::: {.note}\n````markdown\n```{r}\ncat(\"x\")\n```\n````\n:::\n";
+        let (mut doc, ctx) = parse_qmd_with_context(qmd);
+        assert!(
+            matches!(doc.blocks.as_slice(), [quarto_pandoc_types::Block::Div(_)]),
+            "fixture must parse to a single top-level Div, got: {:?}",
+            doc.blocks
+        );
+
+        let changed = mask(&mut doc);
+        assert_eq!(
+            changed,
+            vec![0],
+            "the nested block's top-level ancestor (the Div, index 0) must be reported as changed"
+        );
+
+        // The writer's piece loop is top-level only, so the *ancestor's*
+        // SourceInfo — not just the nested block's — must be Generated with
+        // the same precise anchor as T15.
+        match doc.blocks[0].source_info() {
+            quarto_source_map::SourceInfo::Generated { by, from } => {
+                assert_eq!(
+                    by.kind, "nested-cell-mask",
+                    "the ancestor Div's Generated.by.kind must be the mask's own kebab-case kind"
+                );
+                assert!(
+                    from.iter().any(|a| a.role
+                        == quarto_source_map::AnchorRole::Other(
+                            "nested-cell-mask/origin".to_string()
+                        )),
+                    "the ancestor Div's Generated.from must carry an \
+                     Other(\"nested-cell-mask/origin\") anchor, got: {from:?}"
+                );
+            }
+            other => panic!(
+                "the top-level ancestor of a changed nested block must be Generated, got: {other:?}"
+            ),
+        }
+
+        // And the writer/map_offset contract follows from that: any offset
+        // inside the ancestor's piece — including the unrelated prose the
+        // spec accepts as collateral — resolves to `None`.
+        let (buf, source_info) =
+            pampa::writers::qmd::write_with_source_info(&doc).expect("masked doc must serialize");
+        let masked_text = String::from_utf8(buf).expect("qmd writer must emit valid utf8");
+        let marker_offset = masked_text
+            .find("q2-nested-executable")
+            .expect("masked text must carry the marker");
+        assert_eq!(
+            source_info.map_offset(marker_offset, &ctx),
+            None,
+            "map_offset into the masked ancestor Div must return None"
+        );
+    }
+
+    // ── T18 (H2): reverting the in-scope predicate to "mask everything"
+    // changes the (offset_in_concat, length) pairs below, even though
+    // neither block is *itself* in scope. See spec's vacuity note 2 (as
+    // corrected — the original note conflated "a block an over-broad
+    // predicate would *scan*" with "a block whose scan would *change*
+    // something"): a bare, empty-bodied ` ```python ` block gives an
+    // over-broad predicate nothing to rewrite even when it wrongly scans
+    // it, so the piece pairs would stay identical either way and the test
+    // would pass under a reverted H2 too. The fixture below instead embeds
+    // a fence-opener-shaped substring (` ```{r} `) *inside* the python
+    // block's body text — same trick T13 uses for a real cell's own
+    // source, via a wider (4-backtick) outer fence so the embedded
+    // 3-backtick lines are literal text, not a fence boundary. Under a
+    // correct H2 the python block's classes (`["python"]`, neither empty
+    // nor `["markdown"]`) keep it out of scope, so the embedded substring
+    // is never touched and the pieces match. Under H2 reverted to "mask
+    // everything", the block *is* scanned, the embedded opener gets
+    // rewritten, and the piece pairs diverge — a real RED. ───────────────
+    #[test]
+    fn t18_no_nested_fence_pieces_match_unmasked_run() {
+        let qmd =
+            "````python\nprint(\"hi\")\n```{r}\ncat(\"y\")\n```\n````\n\n```{r}\ncat(\"x\")\n```\n";
+        let (doc, _ctx) = parse_qmd_with_context(qmd);
+        assert_eq!(
+            crate::engine::capture_splice::engine_cell_lang(&doc.blocks[1]),
+            Some("r"),
+            "fixture's second block must be a real, executable {{r}} cell"
+        );
+
+        let (_before_buf, before_source_info) =
+            pampa::writers::qmd::write_with_source_info(&doc).expect("unmasked doc must serialize");
+
+        let mut masked_doc = doc.clone();
+        let changed = mask(&mut masked_doc);
+        assert!(
+            changed.is_empty(),
+            "a document with no nested display fence must report no changed top-level blocks"
+        );
+
+        let (_after_buf, after_source_info) =
+            pampa::writers::qmd::write_with_source_info(&masked_doc)
+                .expect("masked doc must serialize");
+
+        let before_pieces = match &before_source_info {
+            quarto_source_map::SourceInfo::Concat { pieces } => pieces,
+            other => panic!("writer must produce a Concat SourceInfo, got: {other:?}"),
+        };
+        let after_pieces = match &after_source_info {
+            quarto_source_map::SourceInfo::Concat { pieces } => pieces,
+            other => panic!("writer must produce a Concat SourceInfo, got: {other:?}"),
+        };
+
+        let before_pairs: Vec<(usize, usize)> = before_pieces
+            .iter()
+            .map(|p| (p.offset_in_concat, p.length))
+            .collect();
+        let after_pairs: Vec<(usize, usize)> = after_pieces
+            .iter()
+            .map(|p| (p.offset_in_concat, p.length))
+            .collect();
+
+        assert_eq!(
+            before_pairs, after_pairs,
+            "piece (offset_in_concat, length) pairs must be identical to the unmasked run \
+             when no block is in scope for masking"
+        );
+    }
+}

--- a/crates/quarto-core/src/engine/preview_record.rs
+++ b/crates/quarto-core/src/engine/preview_record.rs
@@ -518,6 +518,52 @@ mod tests {
         );
     }
 
+    /// T20 (hunk H10): `compute_input_qmd` must mask executable fence
+    /// openers nested inside a *displayed* code block — the same masked
+    /// bytes the engine-execution loop hands to the engine as `input_qmd`
+    /// (once H8 lands there too). `compute_input_qmd_matches_capture_input_qmd`
+    /// above uses a fixture with **no** display block, so it stays green
+    /// through a regression here; this fixture adds one, closing that gap.
+    ///
+    /// The first assertion (masked marker present) is what makes this test
+    /// genuinely red today: neither `compute_input_qmd` nor `record_capture`
+    /// masks anything yet, so today's bytes carry the bare `{r}` opener, not
+    /// `q2-nested-executable`. The second assertion protects the
+    /// fully-implemented invariant (compute == capture) once H8 and H10 both
+    /// land.
+    #[tokio::test]
+    async fn compute_input_qmd_masks_nested_display_fence() {
+        let (_tmp, path, project, runtime) = fixture(
+            "---\nengine: test-passthrough\n---\n\n```{test-passthrough}\nSENTINEL\n```\n\n```markdown\n```{r}\n1 + 1\n```\n```\n",
+        );
+
+        let mut registry = EngineRegistry::new();
+        registry.register(Arc::new(PassthroughTestEngine));
+
+        let captures = record_capture(&path, &project, runtime.clone(), Some(Arc::new(registry)))
+            .await
+            .expect("record_capture");
+        let capture = captures.first().expect("capture present");
+
+        let computed = compute_input_qmd(&path, &project, runtime)
+            .await
+            .expect("compute_input_qmd");
+        let computed_str = String::from_utf8(computed).expect("UTF-8");
+
+        assert!(
+            computed_str.contains("q2-nested-executable"),
+            "compute_input_qmd must mask the nested `{{r}}` opener inside the \
+             display block so quarto-preview's staleness compare and cache key \
+             see masked bytes (spec: \"The engine capture — asymmetric, by \
+             necessity\"); got:\n{computed_str}"
+        );
+        assert_eq!(
+            computed_str, capture.input_qmd,
+            "compute_input_qmd must yield the same (masked) bytes the engine \
+             receives, even for docs with a display block"
+        );
+    }
+
     #[tokio::test]
     async fn compute_input_qmd_is_stable_for_equal_inputs() {
         // Plan §C.2 unit test #1: "the canonicalization function

--- a/crates/quarto-core/src/engine/preview_record.rs
+++ b/crates/quarto-core/src/engine/preview_record.rs
@@ -230,11 +230,21 @@ pub async fn compute_input_qmd(
     let input = PipelineData::LoadedSource(LoadedSource::new(path.to_path_buf(), content));
     let final_data = pipeline.run(input, &mut ctx).await?;
 
-    let doc_ast = final_data.into_document_ast().ok_or_else(|| {
+    let mut doc_ast = final_data.into_document_ast().ok_or_else(|| {
         PipelineError::other(
             "pre-engine pipeline did not produce DocumentAst — unexpected output kind".to_string(),
         )
     })?;
+
+    // nested-cell-masking (spec § "The engine capture — asymmetric, by
+    // necessity" / `compute_input_qmd`'s three-consumer table): these bytes
+    // must match what `EngineExecutionStage` hands the engine as
+    // `input_qmd` — masked. The two consumers that read this function's
+    // output directly (the staleness compare in `capture_driver.rs` and the
+    // cache key in `cache.rs`) both want masked bytes; only
+    // `write_review_file` (`quarto-hub-provider/src/execute.rs`) unmasks,
+    // and it does so itself after calling this function.
+    crate::engine::nested_cell_mask::mask(&mut doc_ast.ast);
 
     let mut buf = Vec::new();
     pampa::writers::qmd::write(&doc_ast.ast, &mut buf).map_err(|diagnostics| {

--- a/crates/quarto-core/src/stage/stages/engine_execution.rs
+++ b/crates/quarto-core/src/stage/stages/engine_execution.rs
@@ -2041,6 +2041,72 @@ mod tests {
         );
     }
 
+    /// T22 (hunk H8): mask must be applied **inside** the per-engine loop,
+    /// once per iteration, not once before the loop starts. `fixture-a`'s
+    /// spliced-in result introduces a *brand-new* display block (a
+    /// `markdown`-classed block containing a nested `{r}` opener) that did
+    /// not exist in the original AST handed to the stage — only a
+    /// per-iteration mask (re-run against the reconciled `ast` before each
+    /// `serialize_ast_to_qmd` call) catches it before `fixture-b` runs.
+    /// Hoisting the mask out of the loop (reverting H8) would mask once
+    /// against the *original* AST, before fixture-a's block exists, leaving
+    /// fixture-b's input unmasked — this test goes RED under that revert.
+    /// It is RED today too: nothing masks anything yet, so fixture-b
+    /// receives the raw `{r}` opener unchanged.
+    ///
+    /// `FixtureEngine` is extended with a test-only `received_inputs()`
+    /// handle (see `engine/fixture.rs`) so this test can inspect what the
+    /// second engine actually received — `ExecuteResult` alone only carries
+    /// what an engine *produced*, not what it was *given*.
+    #[tokio::test]
+    async fn test_second_engine_in_sequence_receives_masked_nested_fence() {
+        use crate::engine::FixtureEngine;
+
+        let fixture_a = FixtureEngine::with_results(
+            "fixture-a",
+            vec!["````markdown\n```{r}\n1 + 1\n```\n````".to_string()],
+        );
+        let fixture_b =
+            FixtureEngine::with_results("fixture-b", vec!["Final output from B.".to_string()]);
+        let received_by_b = fixture_b.received_inputs();
+
+        let mut registry = EngineRegistry::new();
+        registry.register(Arc::new(fixture_a));
+        registry.register(Arc::new(fixture_b));
+
+        let stage = EngineExecutionStage::new();
+        let mut ctx = make_test_context();
+        ctx.registry = Arc::new(registry);
+
+        let content = b"---\nengine: [fixture-a, fixture-b]\n---\n\n```{fixture-a}\nseed\n```\n\n```{fixture-b}\nseed-b\n```\n";
+        let doc_ast = parse_qmd_to_ast(content, "/project/test.qmd");
+
+        let input = PipelineData::DocumentAst(doc_ast);
+        let _output = stage.run(input, &mut ctx).await.unwrap();
+
+        let received = received_by_b
+            .lock()
+            .expect("received_inputs mutex poisoned");
+        assert_eq!(
+            received.len(),
+            1,
+            "fixture-b should run exactly once; got {received:?}"
+        );
+        let second_input = &received[0];
+
+        assert!(
+            second_input.contains("q2-nested-executable"),
+            "the display block fixture-a introduced must be masked before \
+             fixture-b runs — mask must be reapplied every loop iteration, \
+             not hoisted out of it; fixture-b received:\n{second_input}"
+        );
+        assert!(
+            !second_input.contains("```{r}"),
+            "the raw `{{r}}` opener must not survive unmasked into \
+             fixture-b's input; fixture-b received:\n{second_input}"
+        );
+    }
+
     /// FileId coherence across a two-engine sequence: kept original blocks
     /// keep `FileId(0)` (the `.qmd`), blocks produced by the first engine
     /// get `FileId(1)` (its intermediate), and blocks produced by the
@@ -3059,6 +3125,173 @@ mod tests {
             DEFAULT_EXECUTE_TIMEOUT.as_secs(),
             300,
             "DEFAULT_EXECUTE_TIMEOUT must be 300 s"
+        );
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // nested-cell-masking plan, T19 (hunk H5)
+    // ──────────────────────────────────────────────────────────────
+
+    /// Return `true` when `Rscript` is on PATH. Copied from
+    /// `tests/integration/marimo_engine_e2e.rs:76-82` per the task brief —
+    /// T19 must run *in-crate* (Controller ruling R7: `reconciliation_plan`
+    /// is a stage-local, not observable through a render, so this test
+    /// drives `EngineExecutionStage` directly rather than living in
+    /// `tests/integration/`), and the integration file's helper isn't
+    /// reachable from here.
+    fn rscript_available() -> bool {
+        std::process::Command::new("Rscript")
+            .arg("--version")
+            .output()
+            .is_ok_and(|o| o.status.success())
+    }
+
+    /// Return `true` when the R `knitr` package is installed. Copied from
+    /// `tests/integration/marimo_engine_e2e.rs:84-94` — gating on
+    /// `KnitrEngine::is_available()` alone is insufficient, since it only
+    /// checks for the `Rscript` binary, not the package.
+    fn knitr_r_package_available() -> bool {
+        std::process::Command::new("Rscript")
+            .args([
+                "-e",
+                "if (!requireNamespace(\"knitr\", quietly = TRUE)) quit(status = 1)",
+            ])
+            .output()
+            .is_ok_and(|o| o.status.success())
+    }
+
+    /// T19 (hunk H5): the display block must survive `reconcile` unchanged
+    /// — i.e. keep the original `.qmd`'s FileId — after a real knitr run
+    /// over a document with both a live `{r}` cell and a displayed one.
+    ///
+    /// **Controller ruling (R7), superseding the plan's tier for this row.**
+    /// The plan lists T19 as a render-tier test asserting "the block lands
+    /// in `blocks_kept`" — not observable from a render, since
+    /// `reconciliation_plan` is a local inside this stage's `run` (never on
+    /// its output). So this test runs `EngineExecutionStage` directly and
+    /// inspects the reconciled AST's `SourceInfo`, following
+    /// `test_engine_execution_remaps_new_blocks_to_intermediate`'s idiom: a
+    /// *kept* block resolves to FileId(0) (the original `.qmd`); a
+    /// *replaced* one inherits the engine's `.rmarkdown` intermediate's
+    /// FileId instead.
+    ///
+    /// **Why this matters (spec, "Reconcile — why byte-exactness is
+    /// load-bearing"):** if `unmask` drifts by a single byte restoring the
+    /// masked opener, reconcile treats the display block as *changed* and
+    /// **replaces** it — silently attributing the author's own example to a
+    /// temp file. Revert **H5** (byte-exact whitespace/backtick-width
+    /// replay in `unmask`) and this goes RED. It is RED today too: nothing
+    /// masks or unmasks anything yet, so the live `{r}` cell dispatches
+    /// knitr *over the raw, unmasked nested `{r}` opener* — knitr's own
+    /// chunk-begin pattern (`^[\t >]*```{r}`) matches it and executes it as
+    /// a second cell, which both defeats the "display, don't execute"
+    /// contract this plan exists to fix and (separately) changes the
+    /// reconciled AST's block count/shape enough that this test's
+    /// find-the-display-block step legitimately fails to find an
+    /// *unexecuted* display block at all.
+    ///
+    /// Gated on Rscript **and** the R `knitr` package, following the idiom
+    /// of `tests/integration/marimo_engine_e2e.rs:989`: skip *loudly* on a
+    /// machine that lacks them. No workflow in this repo installs R (see the
+    /// plan's Documentation section), so this row is exercised on developer
+    /// machines and not in CI — the printed `SKIP:` line is the signal that
+    /// the row went unproven, which is why it names the row and says so.
+    #[tokio::test]
+    async fn test_display_block_survives_reconcile_unchanged() {
+        if !rscript_available() {
+            eprintln!(
+                "SKIP: Rscript not on PATH — T19 \
+                 test_display_block_survives_reconcile_unchanged (a skip here is a \
+                 signal that the row went unproven, not a pass)"
+            );
+            return;
+        }
+        if !knitr_r_package_available() {
+            eprintln!(
+                "SKIP: R package 'knitr' not installed — T19 \
+                 test_display_block_survives_reconcile_unchanged (a skip here is a \
+                 signal that the row went unproven, not a pass)"
+            );
+            return;
+        }
+
+        use crate::format::Format;
+        use crate::project::{DocumentInfo, ProjectContext};
+        use quarto_pandoc_types::Block;
+        use quarto_source_map::FileId;
+        use quarto_system_runtime::{NativeRuntime, SystemRuntime};
+
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let qmd_path = dir.path().join("doc.qmd");
+        // A live cell (so knitr enters the sequence at all — AST-based
+        // resolution declines to start an engine for a doc whose only
+        // `{r}` fence is displayed) plus a displayed one, marked with a
+        // string ("nested-marker") that can only appear in the *source*,
+        // never in knitr's output, so finding the block by its text proves
+        // it was never executed.
+        let content = "---\ntitle: T19\n---\n\n\
+             ```{r}\n1 + 1\n```\n\n\
+             ````markdown\n```{r}\ncat(\"nested-marker\")\n```\n````\n";
+        std::fs::write(&qmd_path, content).expect("write fixture");
+
+        let runtime: Arc<dyn SystemRuntime> = Arc::new(NativeRuntime::new());
+        let project = ProjectContext::discover(&qmd_path, runtime.as_ref())
+            .expect("discover single-file project");
+        let document = DocumentInfo::from_path(&qmd_path);
+        let format = Format::html();
+        let mut ctx =
+            StageContext::new(runtime, format, project, document).expect("StageContext::new");
+
+        let path_str = qmd_path.to_string_lossy().into_owned();
+        let doc_ast = parse_qmd_to_ast(content.as_bytes(), &path_str);
+
+        let stage = EngineExecutionStage::new();
+        let input = PipelineData::DocumentAst(doc_ast);
+        let output = stage
+            .run(input, &mut ctx)
+            .await
+            .expect("EngineExecutionStage::run over a real knitr document");
+        let result = output.into_document_ast().expect("DocumentAst");
+
+        // The intermediate (.rmarkdown) slot: any filename in the merged
+        // context other than the original .qmd's.
+        let intermediate_id = result
+            .ast_context
+            .filenames
+            .iter()
+            .position(|f| f != &path_str)
+            .map(FileId)
+            .expect("expected a knitr .rmarkdown intermediate file slot");
+
+        let display_block_source_info = result
+            .ast
+            .blocks
+            .iter()
+            .find_map(|b| match b {
+                Block::CodeBlock(cb) if cb.text.contains("nested-marker") => {
+                    Some(cb.source_info.clone())
+                }
+                _ => None,
+            })
+            .expect(
+                "expected the display block (containing the never-executed \
+                 nested-marker source line) to survive in the reconciled AST",
+            );
+
+        let mut ids = std::collections::HashSet::new();
+        display_block_source_info.collect_file_ids(&mut ids);
+
+        assert!(
+            ids.contains(&FileId(0)),
+            "display block must resolve to the original .qmd's FileId(0) \
+             (i.e. reconcile kept it, not replaced it); got {ids:?}"
+        );
+        assert!(
+            !ids.contains(&intermediate_id),
+            "display block must NOT resolve to the .rmarkdown intermediate \
+             FileId({intermediate_id:?}) — that would mean reconcile \
+             replaced it, attributing the author's own example to a temp \
+             file; got {ids:?}"
         );
     }
 }

--- a/crates/quarto-core/src/stage/stages/engine_execution.rs
+++ b/crates/quarto-core/src/stage/stages/engine_execution.rs
@@ -428,8 +428,23 @@ impl PipelineStage for EngineExecutionStage {
         let multi_engine = to_run.len() > 1;
 
         for (run_index, (engine, engine_config)) in to_run.into_iter().enumerate() {
-            // Serialize the current AST to QMD for this engine.
-            let (qmd, qmd_source_info) = serialize_ast_to_qmd(&ast)?;
+            // nested-cell-masking (spec § Approach): mask executable-fence
+            // openers nested inside markdown-displaying blocks before this
+            // engine ever sees them, on a clone of `ast` — never `ast`
+            // itself, since `reconcile` below needs the unmasked original.
+            // Re-run every iteration (T22): `ast` is reconciled and
+            // re-serialized each time, and a second engine in the sequence
+            // can see a display block a *prior* engine just introduced
+            // (e.g. spliced-in preview results), so masking once before the
+            // loop would leave it unprotected.
+            let mut masked_ast = ast.clone();
+            crate::engine::nested_cell_mask::mask(&mut masked_ast);
+
+            // Serialize the masked AST to QMD for this engine. Every engine
+            // goes through this one call, so knitr, q2's jupyter text
+            // engine, and TS extensions are all covered with no per-engine
+            // work.
+            let (qmd, qmd_source_info) = serialize_ast_to_qmd(&masked_ast)?;
             trace_event!(
                 ctx,
                 EventLevel::Debug,
@@ -494,6 +509,14 @@ impl PipelineStage for EngineExecutionStage {
             let mut result = engine
                 .execute(&qmd, &exec_context)
                 .map_err(|e| PipelineError::stage_error(self.name(), e.to_string()))?;
+            // nested-cell-masking (spec § "The engine capture — asymmetric,
+            // by necessity"): unmask does not need the AST — the marker is
+            // self-identifying — so it runs textually over the engine's
+            // returned markdown. Restore it before anything downstream
+            // (the capture emit's `result_json`, the reparse, reconcile)
+            // ever sees it, so a masked marker never reaches the reparsed
+            // AST or `q2 preview`'s spliced-in `result.markdown`.
+            result.markdown = crate::engine::nested_cell_mask::unmask(&result.markdown);
             trace_event!(
                 ctx,
                 EventLevel::Debug,

--- a/crates/quarto-core/tests/integration/main.rs
+++ b/crates/quarto-core/tests/integration/main.rs
@@ -62,6 +62,7 @@ pub mod metadata_path_resolution;
 pub mod navbar_footer_pipeline;
 pub mod navigation_e2e;
 pub mod navigation_merge;
+pub mod nested_cell_mask_render;
 pub mod page_navigation_pipeline;
 pub mod pass1_engine_resolution_pipeline;
 pub mod preview_render_css_parity;

--- a/crates/quarto-core/tests/integration/nested_cell_mask_render.rs
+++ b/crates/quarto-core/tests/integration/nested_cell_mask_render.rs
@@ -1,0 +1,529 @@
+//! bd-knitr-executes-nested-display-fence-atbtktdj — render-tier (tier R)
+//! failing tests for the nested-cell-masking fix, plan
+//! `.superpowers/sdd/2026-09-02-nested-cell-masking/spec.md`.
+//!
+//! Every fixture is a document with a **live** `{r}` cell (the bug is
+//! unreachable without one — AST-based resolution declines to start knitr
+//! for a document whose only `{r}` fence is displayed) plus a display
+//! construct under test. All fixtures render through the real per-document
+//! path (`render_document_to_file`, the same entry `q2 render` uses), with
+//! real knitr — no mocks.
+//!
+//! **These tests are RED by design and stay RED until a later task wires
+//! `nested_cell_mask::mask`/`unmask` into `engine_execution.rs`.** Nothing
+//! here calls `mask`/`unmask` directly (that's tier U, in
+//! `crates/quarto-core/src/engine/nested_cell_mask.rs`); these assert on the
+//! rendered HTML of the *current, unfixed* pipeline, so they fail on wrong
+//! output rather than on a stub panic.
+//!
+//! **The runtime-only marker rule** (spec, "Test seam spec (frozen)"):
+//! every executed marker is written `paste0("WORD", "-RAN")` rather than a
+//! single string literal, so the substring `WORD-RAN` exists in the
+//! rendered HTML *only* if the cell actually ran — never as an echo of the
+//! (HTML-escaped, comma-split) source.
+//!
+//! **Gate.** Unlike `knitr_display_fence.rs`, which gates on
+//! `EngineRegistry::default().get("knitr").is_some_and(|e| e.is_available())`
+//! (binary only), these tests gate on both the `Rscript` binary and the R
+//! `knitr` package — copied from `marimo_engine_e2e.rs:76-94`
+//! (`rscript_available` / `knitr_r_package_available`). On this machine both
+//! are present (knitr 1.50), so no test here should skip.
+//!
+//! **T8 deviation, recorded up front.** The seam table's T8 row calls for "a
+//! four-space-indented display block (no info string)". qmd has **no**
+//! CommonMark indented-code-block production at all — it is a deliberate,
+//! documented, blanket known limitation (`grammar.js` `_indented_code_block_error`
+//! / scanner.c's `INDENTED_CODE_BLOCK_DISALLOWED`, diagnostic Q-2-35),
+//! verified here to fire regardless of nesting context (top-level and
+//! inside a list item both error; there is no grammar path that accepts
+//! raw 4-space-indented text as a code block). The only way to construct a
+//! `CodeBlock` with **empty** classes — the AST shape T8's row actually
+//! targets, per `nested_cell_mask.rs`'s own scope doc: "classes empty (no
+//! info string, which also covers a 4-space indented code block)" — is a
+//! bare fenced block with no info string at all (` ``` ` / ` ``` `, no
+//! language). T8 below uses that. Verified empirically (this task) to
+//! reproduce the bug identically to the `["markdown"]`-classed fixtures.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::Path;
+use std::process::Command;
+use std::sync::Arc;
+
+use tempfile::TempDir;
+
+use quarto_core::ProjectContext;
+use quarto_core::render_to_file::{RenderToFileOptions, render_document_to_file};
+use quarto_system_runtime::{NativeRuntime, SystemRuntime};
+
+/// Return `true` when `Rscript` is on PATH. Copied from
+/// `marimo_engine_e2e.rs:76-81` per the task brief — the binary check alone
+/// (`KnitrEngine::is_available()` / `knitr_display_fence.rs`'s
+/// `knitr_available()`) is not sufficient; we also need the R package.
+fn rscript_available() -> bool {
+    Command::new("Rscript")
+        .arg("--version")
+        .output()
+        .is_ok_and(|o| o.status.success())
+}
+
+/// Return `true` when the R `knitr` package is installed. Copied from
+/// `marimo_engine_e2e.rs:87-95`.
+fn knitr_r_package_available() -> bool {
+    Command::new("Rscript")
+        .args([
+            "-e",
+            "if (!requireNamespace(\"knitr\", quietly = TRUE)) quit(status = 1)",
+        ])
+        .output()
+        .is_ok_and(|o| o.status.success())
+}
+
+/// The gate every test in this file uses. A skip here is a signal something
+/// is wrong on the machine, not a pass (task brief).
+fn knitr_render_available() -> bool {
+    rscript_available() && knitr_r_package_available()
+}
+
+/// Render `content` to HTML through the real render path
+/// (`render_document_to_file`, the same entry `q2 render` uses) and return
+/// the rendered HTML. Panics with the render error on failure.
+fn render_html(tmp: &TempDir, name: &str, content: &str) -> String {
+    render_html_result(tmp, name, content).unwrap_or_else(|e| panic!("render must succeed: {e}"))
+}
+
+/// Same as `render_html`, but surfaces a render failure as `Err` instead of
+/// panicking. Used only by T5, whose fixture is expected to hard-fail the
+/// render on this machine (vacuity note 3) — a render error there is a
+/// legitimate RED, not a harness bug.
+fn render_html_result(tmp: &TempDir, name: &str, content: &str) -> Result<String, String> {
+    let input = tmp.path().join(name);
+    std::fs::write(&input, content).unwrap();
+
+    let runtime: Arc<dyn SystemRuntime> = Arc::new(NativeRuntime::new());
+    let project = ProjectContext::discover(&input, runtime.as_ref())
+        .expect("project discovery for the nested-cell-mask render fixture");
+
+    let result = render_document_to_file(
+        &input,
+        "html",
+        &RenderToFileOptions::default(),
+        Some(&project),
+        runtime.clone(),
+        None,
+        None,
+        None,
+    )
+    .map_err(|e| e.to_string())?;
+
+    Ok(read_html(&result.output_path))
+}
+
+fn read_html(path: &Path) -> String {
+    std::fs::read_to_string(path).expect("read rendered HTML")
+}
+
+/// The T1/T2/T3 fixture: a live `{r}` cell plus a ` ````markdown ` block
+/// displaying `{r}`. The real cell's marker is `REAL-RAN`; the display
+/// block's is `DISPLAY-RAN` — both runtime-only (`paste0`-split).
+fn t1_t2_t3_fixture() -> String {
+    "---\ntitle: T1-T2-T3\nengine: knitr\n---\n\n\
+     ```{r}\ncat(paste0(\"REAL\", \"-RAN\"), \"\\n\")\n```\n\n\
+     ````markdown\n```{r}\ncat(paste0(\"DISPLAY\", \"-RAN\"), \"\\n\")\n```\n````\n"
+        .to_string()
+}
+
+// ── T1 (H1): mask rewrites an opener ────────────────────────────────────
+//
+// `mask` rewriting `{r}` -> `{.r q2-nested-executable}` is what stops
+// knitr's own chunk scanner from claiming the *displayed* `{r}` opener.
+// Reverting H1 leaves the opener bare, knitr's `all_patterns$md$chunk.begin`
+// matches it, and the displayed example executes -- `DISPLAY-RAN` appears.
+#[test]
+fn t1_displayed_r_fence_does_not_execute() {
+    if !knitr_render_available() {
+        eprintln!(
+            "SKIP: knitr (Rscript + package) not available — t1_displayed_r_fence_does_not_execute"
+        );
+        return;
+    }
+    let tmp = TempDir::new().unwrap();
+    let html = render_html(&tmp, "t1.qmd", &t1_t2_t3_fixture());
+
+    assert!(
+        !html.contains("DISPLAY-RAN"),
+        "the displayed {{r}} example must not execute (DISPLAY-RAN is \
+         runtime-only — it cannot appear from an echo of the source); \
+         html:\n{html}"
+    );
+}
+
+// ── T2 (H3): unmask restores a marked opener ────────────────────────────
+//
+// Even once masking stops the displayed fence from executing, the reader
+// must still see the *original* `{r}` opener, not our internal
+// `{.r q2-nested-executable}` marker or knitr's cell scaffolding. That
+// restoration is `unmask`'s job; reverting H3 (dropping the marker
+// requirement, or not restoring at all) leaves the marked/mangled opener in
+// the rendered `<pre>`.
+#[test]
+fn t2_displayed_r_fence_shows_original_opener_no_marker_anywhere() {
+    if !knitr_render_available() {
+        eprintln!(
+            "SKIP: knitr (Rscript + package) not available — t2_displayed_r_fence_shows_original_opener_no_marker_anywhere"
+        );
+        return;
+    }
+    let tmp = TempDir::new().unwrap();
+    let html = render_html(&tmp, "t2.qmd", &t1_t2_t3_fixture());
+
+    // The display <pre> must show the literal, unmangled opener line. At
+    // baseline knitr replaces it with cell scaffolding
+    // (` ```{.r .cell-code} `), so this substring is absent pre-fix.
+    assert!(
+        html.contains("```{r}"),
+        "the display block must show the original `{{r}}` opener, \
+         unmangled; html:\n{html}"
+    );
+    assert!(
+        !html.contains("q2-nested-executable"),
+        "the internal masking marker must never reach rendered output; \
+         html:\n{html}"
+    );
+}
+
+// ── T3 (H2): the in-scope predicate must not widen to the real cell ────
+//
+// Green-at-baseline guard, like the Control below — NOT a RED. The current
+// bug only under-masks (it executes displayed fences); it never over-masks
+// (blocks the real cell), so this assertion is already true with zero
+// masking in place. It is bound to H2 (a hunk that does not exist until
+// Phase 2), not to a symptom of the present bug. Do not "fix" this test to
+// force a failure.
+//
+// The real, executable `{r}` cell sitting next to the display block must
+// keep running. This guards against an over-broad fix that masks *every*
+// CodeBlock (widening H2's classes-empty-or-["markdown"] predicate to all
+// blocks) — that would also mask the real cell.
+#[test]
+fn t3_real_cell_still_executes() {
+    if !knitr_render_available() {
+        eprintln!("SKIP: knitr (Rscript + package) not available — t3_real_cell_still_executes");
+        return;
+    }
+    let tmp = TempDir::new().unwrap();
+    let html = render_html(&tmp, "t3.qmd", &t1_t2_t3_fixture());
+
+    assert!(
+        html.contains("REAL-RAN"),
+        "the real {{r}} cell must still execute; html:\n{html}"
+    );
+}
+
+// ── T4 (H1): echo=FALSE display block — two-surface, non-vacuous check ──
+//
+// Vacuity note 1: a *count* of the marker collapses (it appears once
+// before the fix — output only, source consumed — and once after — source
+// only, no output). This asserts on the two surfaces that genuinely
+// differ: the runtime-only string (must be absent) AND the author's own
+// source literal (must be present — knitr consumes it pre-fix).
+#[test]
+fn t4_echo_false_display_block_neither_runs_nor_loses_its_source() {
+    if !knitr_render_available() {
+        eprintln!(
+            "SKIP: knitr (Rscript + package) not available — t4_echo_false_display_block_neither_runs_nor_loses_its_source"
+        );
+        return;
+    }
+    let tmp = TempDir::new().unwrap();
+    let content = "---\ntitle: T4\nengine: knitr\n---\n\n\
+                   ```{r}\ncat(paste0(\"REAL\", \"-RAN\"), \"\\n\")\n```\n\n\
+                   ````markdown\n```{r, echo=FALSE}\ncat(paste0(\"OPTS\", \"-RAN\"), \"\\n\")\n```\n````\n";
+    let html = render_html(&tmp, "t4.qmd", content);
+
+    assert!(
+        !html.contains("OPTS-RAN"),
+        "the echo=FALSE displayed example must not execute (runtime-only \
+         marker must be absent); html:\n{html}"
+    );
+    // The author's source, HTML-escaped as plain (non-highlighted) text —
+    // verified empirically: the writer escapes `"` to `&quot;` even inside
+    // an unexecuted `markdown`-classed <pre>. Pre-fix, knitr consumes the
+    // echo=FALSE chunk's source entirely (only its output survives), so
+    // this substring is absent before the fix and present after.
+    assert!(
+        html.contains("paste0(&quot;OPTS&quot;"),
+        "the author's own source must survive (echo=FALSE must not cost \
+         the reader the example) — this is what a naive occurrence-count \
+         cannot discriminate (vacuity note 1); html:\n{html}"
+    );
+}
+
+// ── T5 (H1): a displayed {python} example must not kill the whole render ─
+//
+// The most user-visible face of the bug: knitr hands the *displayed*
+// {python} example to reticulate, which fails outright on this machine
+// (python3 is installed, but reticulate's own discovery misses it via a
+// stale uv build-cache path) and the ENTIRE render dies. Vacuity note 3:
+// "the render succeeds" is not assertable here (it would be vacuous on a
+// machine with a working reticulate/Python), so we assert on content: the
+// display <pre> literally contains ```{python}`, and nothing inside it
+// looks like it executed. A render failure here (as currently, on this
+// machine) is itself a legitimate RED — the fix's job is precisely to stop
+// the fatal failure, not just to fix content once rendering happens to
+// succeed.
+#[test]
+fn t5_displayed_python_in_r_document_does_not_kill_the_render() {
+    if !knitr_render_available() {
+        eprintln!(
+            "SKIP: knitr (Rscript + package) not available — t5_displayed_python_in_r_document_does_not_kill_the_render"
+        );
+        return;
+    }
+    let tmp = TempDir::new().unwrap();
+    let content = "---\ntitle: T5\nengine: knitr\n---\n\n\
+                   ```{r}\ncat(paste0(\"REAL\", \"-RAN\"), \"\\n\")\n```\n\n\
+                   ````markdown\n```{python}\nprint(\"hi\")\n```\n````\n";
+
+    match render_html_result(&tmp, "t5.qmd", content) {
+        Err(e) => {
+            // The fatal symptom itself: knitr handed the displayed
+            // {python} fence to reticulate and the whole render died.
+            // This is exactly the bug the fix must eliminate (spec, "Two
+            // symptoms worse than 'wrong output'") — a legitimate RED, not
+            // a harness bug. But not *any* error qualifies: an unrelated
+            // environment breakage (a broken R install, say) must not be
+            // silently misattributed to this bug, and — once the fix
+            // lands — a CI runner with independently-broken reticulate
+            // would otherwise keep this test red for a reason the fix
+            // cannot address. So check the error names the expected
+            // cause before treating it as this bug's RED.
+            //
+            // Structural gap, discovered implementing this check (see the
+            // report addendum): `render_document_to_file`'s
+            // `ExecutionContext` defaults `quiet: false`
+            // (`engine/context.rs:179`), and nothing in the render call
+            // chain (`render_to_file.rs` / `pipeline.rs` /
+            // `engine_execution.rs`) ever calls `with_quiet(true)` —
+            // `RenderToFileOptions::quiet` is a *logging* flag, never
+            // threaded into `ExecutionContext`. With `quiet: false`,
+            // `knitr/subprocess.rs` pipes R's stderr to `Stdio::inherit()`
+            // rather than `Stdio::piped()` (`subprocess.rs:373-374`), so
+            // `convert_r_error_to_execution_error`'s classifier always
+            // receives an EMPTY stderr string for this failure and can
+            // only produce the bare fallback `"R process failed"`
+            // (`subprocess.rs:487`) — never `"python"`/`"reticulate"`. The
+            // real reticulate detail genuinely exists (verified verbatim
+            // in this task's evidence, streamed straight to this
+            // process's own inherited stderr) but structurally cannot
+            // reach the Rust-level error string through this public API
+            // today. Filed as bd-jxhvy3pi ("Engine subprocess failures
+            // lose their stderr detail in the normal render path"), which
+            // names this test as its acceptance test — when that strand
+            // lands (fix direction: capture stderr always, tee it when
+            // not quiet, rather than choosing one or the other), TIGHTEN
+            // this back to requiring the detailed python/reticulate
+            // message and drop the bare-fallback acceptance below. Until
+            // then: accept either the detailed message or today's
+            // documented bare-fallback shape. This still rejects the
+            // failure modes Finding 2 is actually guarding against — a
+            // missing-package, a missing-runtime, a spawn failure, or a
+            // well-formed knitr execution message all classify distinctly
+            // and do not produce this exact bare text.
+            let lower = e.to_lowercase();
+            let names_python_reticulate = lower.contains("python") || lower.contains("reticulate");
+            let is_documented_bare_fallback = lower.contains("r process failed");
+            assert!(
+                names_python_reticulate || is_documented_bare_fallback,
+                "T5 (H1) render failed, but with neither the expected \
+                 displayed-{{python}}-handed-to-reticulate symptom (no \
+                 \"python\"/\"reticulate\") nor the documented bare-fallback \
+                 shape (\"R process failed\" — the only shape this specific \
+                 failure can take through render_document_to_file's \
+                 default, non-quiet ExecutionContext; see the comment \
+                 above) — this failure looks unrelated to the \
+                 nested-cell-masking bug and must be investigated \
+                 separately, not attributed to this task: {e}"
+            );
+            panic!(
+                "T5 (H1): render of a document with a live {{r}} cell and a \
+                 displayed {{python}} example failed outright — this fatal \
+                 failure mode is exactly what the fix must eliminate: {e}"
+            );
+        }
+        Ok(html) => {
+            // After the fix, `mask` rewrites the displayed {python}
+            // opener before knitr ever sees it, so knitr never hands it
+            // to reticulate and this branch becomes the one that runs.
+            //
+            // UNREACHED as of this task: on this machine the render
+            // always takes the `Err` branch above (reticulate can't find
+            // the installed python3), so these two assertions — the
+            // exact ones vacuity note 3 calls for — have never actually
+            // executed. A bug in the `split_once("REAL-RAN")` scoping or
+            // the substring checks would not surface here; it will
+            // surface the first time this branch runs for real, which is
+            // after the fix lands. Re-verify this branch by hand (or with
+            // a temporary working-tree Python shim) the first time T5
+            // takes this path, rather than trusting it on faith.
+            let after_real_cell = html
+                .split_once("REAL-RAN")
+                .map_or(html.as_str(), |(_, rest)| rest);
+            assert!(
+                after_real_cell.contains("```{python}"),
+                "the display block must show the literal ```{{python}} \
+                 opener, unexecuted; html:\n{html}"
+            );
+            assert!(
+                !after_real_cell.contains("cell-output"),
+                "the display block must contain no .cell-output — nothing \
+                 inside it may look like it executed; html:\n{html}"
+            );
+        }
+    }
+}
+
+// ── T6 (H4): unmask must be prefix-tolerant, not `^`-anchored ──────────
+//
+// A blockquoted display block: mask never sees the `> ` prefix (the reader
+// strips it before mask ever sees the block's text), but unmask runs
+// textually over the engine's *output*, which still carries `> `. An
+// `^`-anchored unmask misses every blockquoted fence, and (per the spec's
+// measured baseline) the cell escapes the blockquote entirely: two `.cell`
+// divs are emitted and the display block renders empty.
+#[test]
+fn t6_blockquoted_display_block_stays_inside_the_blockquote() {
+    if !knitr_render_available() {
+        eprintln!(
+            "SKIP: knitr (Rscript + package) not available — t6_blockquoted_display_block_stays_inside_the_blockquote"
+        );
+        return;
+    }
+    let tmp = TempDir::new().unwrap();
+    let content = "---\ntitle: T6\nengine: knitr\n---\n\n\
+                   ```{r}\ncat(paste0(\"REAL\", \"-RAN\"), \"\\n\")\n```\n\n\
+                   > ````markdown\n> ```{r}\n> cat(paste0(\"QUOTE\", \"-RAN\"), \"\\n\")\n> ```\n> ````\n";
+    let html = render_html(&tmp, "t6.qmd", content);
+
+    // The display block's body text must survive, non-empty, inside the
+    // blockquote — checked as the author's own source literal (plain,
+    // unhighlighted escaping: `&quot;` around each string). Pre-fix this
+    // text is only ever seen *highlighted* (span-wrapped, because knitr
+    // executed it as a real cell), so this contiguous substring is absent
+    // before the fix.
+    assert!(
+        html.contains("paste0(&quot;QUOTE&quot;"),
+        "the blockquoted display block's body must survive intact, \
+         unexecuted, inside the blockquote; html:\n{html}"
+    );
+    // Exactly one `.cell` div — the real cell's. Pre-fix the nested `{r}`
+    // escapes the blockquote as its own second cell (measured baseline: 2).
+    let cell_count = html.matches("class=\"cell\"").count();
+    assert_eq!(
+        cell_count, 1,
+        "exactly one `.cell` div (the real cell's) must be present — the \
+         blockquoted display block must not escape as a second cell; \
+         html:\n{html}"
+    );
+}
+
+// ── T7 (H1): fence-opener whitespace variants ───────────────────────────
+//
+// A space between the fence and the brace (` ``` {r} `), and trailing
+// whitespace after the closing brace (` ```{r}   `), must both stay
+// unexecuted. knitr's own `all_patterns$md$chunk.begin` matches both
+// spellings; mask's opener pattern must too.
+#[test]
+fn t7_whitespace_variant_openers_do_not_execute() {
+    if !knitr_render_available() {
+        eprintln!(
+            "SKIP: knitr (Rscript + package) not available — t7_whitespace_variant_openers_do_not_execute"
+        );
+        return;
+    }
+    let tmp = TempDir::new().unwrap();
+    let content = "---\ntitle: T7\nengine: knitr\n---\n\n\
+                   ```{r}\ncat(paste0(\"REAL\", \"-RAN\"), \"\\n\")\n```\n\n\
+                   ````markdown\n``` {r}\ncat(paste0(\"WS\", \"-RAN\"), \"\\n\")\n```\n````\n\n\
+                   ````markdown\n```{r}   \ncat(paste0(\"WS\", \"-RAN\"), \"\\n\")\n```\n````\n";
+    let html = render_html(&tmp, "t7.qmd", content);
+
+    assert!(
+        !html.contains("WS-RAN"),
+        "neither whitespace-variant opener (space-before-brace or \
+         trailing-whitespace) may execute; html:\n{html}"
+    );
+}
+
+// ── T8 (H1): classes-empty display block (no info string) ──────────────
+//
+// See this file's top-level doc comment for why this uses a bare fenced
+// block with no info string (` ``` `) rather than a literal 4-space-indented
+// block: qmd has no indented-code-block grammar production at all (Q-2-35,
+// a deliberate blanket known limitation, verified to fire both at document
+// top level and inside a list item — there is no context in which raw
+// indentation parses as code). Both shapes produce the identical AST target
+// H2 actually predicates on: a `CodeBlock` with **empty** classes.
+#[test]
+fn t8_bare_fenced_no_info_string_display_block_does_not_execute() {
+    if !knitr_render_available() {
+        eprintln!(
+            "SKIP: knitr (Rscript + package) not available — t8_bare_fenced_no_info_string_display_block_does_not_execute"
+        );
+        return;
+    }
+    let tmp = TempDir::new().unwrap();
+    let content = "---\ntitle: T8\nengine: knitr\n---\n\n\
+                   ```{r}\ncat(paste0(\"REAL\", \"-RAN\"), \"\\n\")\n```\n\n\
+                   ````\n```{r}\ncat(paste0(\"IND\", \"-RAN\"), \"\\n\")\n```\n````\n";
+    let html = render_html(&tmp, "t8.qmd", content);
+
+    assert!(
+        !html.contains("IND-RAN"),
+        "a bare fenced (no info string) display block must not execute; \
+         html:\n{html}"
+    );
+}
+
+// Control: characterization only, not revert-bound.
+//
+// A document containing a display block and NO live cell at all renders
+// unchanged. This pins the plan's claim that the bug is "reachable only
+// when the engine is already live" — AST-based resolution declines to
+// start knitr for a document whose only `{r}` fence is displayed, so this
+// test is expected to be GREEN both before and after the fix. It does not
+// gate on knitr availability in the same load-bearing way as T1-T8 (no
+// engine ever runs for this fixture), but we keep the same gate for
+// consistency with the rest of this file and because the fixture declares
+// no `engine:` field at all (nothing to check availability of, but a
+// skipped run here would still hide a regression on a knitr-equipped CI
+// runner).
+#[test]
+fn control_display_block_with_no_live_cell_renders_unchanged() {
+    if !knitr_render_available() {
+        eprintln!(
+            "SKIP: knitr (Rscript + package) not available — control_display_block_with_no_live_cell_renders_unchanged"
+        );
+        return;
+    }
+    let tmp = TempDir::new().unwrap();
+    let content = "---\ntitle: Control\n---\n\n\
+                   ````markdown\n```{r}\ncat(paste0(\"CTRL\", \"-RAN\"), \"\\n\")\n```\n````\n";
+    let html = render_html(&tmp, "control.qmd", content);
+
+    assert!(
+        html.contains("```{r}"),
+        "with no live cell anywhere, knitr must never start, so the \
+         display block's opener must survive untouched; html:\n{html}"
+    );
+    assert!(
+        !html.contains("CTRL-RAN"),
+        "with no live cell anywhere, the displayed example must not \
+         execute; html:\n{html}"
+    );
+    assert!(
+        html.matches("class=\"cell\"").count() == 0,
+        "with no live cell anywhere, no `.cell` div may appear at all; \
+         html:\n{html}"
+    );
+}

--- a/crates/quarto-hub-provider/src/execute.rs
+++ b/crates/quarto-hub-provider/src/execute.rs
@@ -392,6 +392,15 @@ async fn write_review_file(
     let bytes = compute_input_qmd(abs_path, project, runtime)
         .await
         .map_err(|e| format!("computing the resolved document for review: {e}"))?;
+    // nested-cell-masking (spec § "The engine capture — asymmetric, by
+    // necessity" / `compute_input_qmd`'s three-consumer table): this is the
+    // one security-facing consumer — the artifact a human operator reads
+    // before consenting to execution — so, unlike the staleness compare and
+    // cache key, it must show the author's own `{r}`, not the internal
+    // mask marker. `compute_input_qmd` returns masked bytes; unmask them
+    // here before writing.
+    let text = String::from_utf8_lossy(&bytes);
+    let unmasked = quarto_core::engine::nested_cell_mask::unmask(&text);
 
     let base = Path::new(rel_path).file_name().map_or_else(
         || std::ffi::OsString::from("document"),
@@ -401,7 +410,7 @@ async fn write_review_file(
     file_name.push(".resolved.qmd");
     let review_file = review_dir.join(file_name);
 
-    std::fs::write(&review_file, &bytes)
+    std::fs::write(&review_file, &unmasked)
         .map_err(|e| format!("writing the review file {}: {e}", review_file.display()))?;
     Ok(review_file)
 }

--- a/crates/quarto-hub-provider/src/execute.rs
+++ b/crates/quarto-hub-provider/src/execute.rs
@@ -477,4 +477,67 @@ mod tests {
             "markdown must not be advertised: {engines:?}"
         );
     }
+
+    /// T21 (hunk H11): `write_review_file` is the artifact a human operator
+    /// reads before consenting to execution (see this module's doc comment,
+    /// "Consent"). The operator must see the `{r}` they actually wrote, not
+    /// `q2-nested-executable` — the one *security-facing* consumer of
+    /// `compute_input_qmd`, deliberately unmasked while the staleness compare
+    /// (`quarto-preview/src/capture_driver.rs`) and cache key
+    /// (`quarto-preview/src/cache.rs`) deliberately stay masked. Do not
+    /// "fix" this test by masking the review file to match those two.
+    ///
+    /// The discriminating assertion is `assert_ne!` against
+    /// `compute_input_qmd`'s own (masked, per H10) bytes: today, with neither
+    /// H10 nor H11 implemented, `compute_input_qmd` and `write_review_file`
+    /// produce byte-identical unmasked output, so the two are *equal* and the
+    /// test is genuinely red. It only goes green once `write_review_file`
+    /// unmasks what `compute_input_qmd` masked, making the two outputs
+    /// differ for a doc with a display block.
+    #[tokio::test]
+    async fn write_review_file_shows_the_authors_r_not_the_mask() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let qmd_path = dir.path().join("doc.qmd");
+        std::fs::write(
+            &qmd_path,
+            "---\ntitle: Review\n---\n\n```markdown\n```{r}\n1 + 1\n```\n```\n",
+        )
+        .expect("write fixture");
+
+        let runtime: Arc<dyn SystemRuntime> = Arc::new(NativeRuntime::new());
+        let project = ProjectContext::discover(&qmd_path, runtime.as_ref())
+            .expect("discover single-file project");
+
+        let review_dir = dir.path().join("review");
+        std::fs::create_dir_all(&review_dir).expect("create review dir");
+
+        let review_file =
+            write_review_file(&qmd_path, &project, runtime.clone(), &review_dir, "doc.qmd")
+                .await
+                .expect("write_review_file");
+
+        let contents = std::fs::read_to_string(&review_file).expect("read review file");
+
+        let masked = compute_input_qmd(&qmd_path, &project, runtime)
+            .await
+            .expect("compute_input_qmd");
+        let masked_str = String::from_utf8(masked).expect("UTF-8");
+
+        assert_ne!(
+            contents, masked_str,
+            "write_review_file must unmask what compute_input_qmd masks — the \
+             review file and the (masked) engine-input bytes must not be \
+             identical for a doc with a display block; got:\n{contents}"
+        );
+        assert!(
+            contents.contains("{r}"),
+            "review file must show the author's `{{r}}` opener verbatim so the \
+             operator reviews the actual bytes that will run; got:\n{contents}"
+        );
+        assert!(
+            !contents.contains("q2-nested-executable"),
+            "review file must NOT contain the internal masking marker — an \
+             operator can't consent to code they can't recognize; got:\n{contents}"
+        );
+    }
 }

--- a/crates/wasm-quarto-hub-client/Cargo.lock
+++ b/crates/wasm-quarto-hub-client/Cargo.lock
@@ -2326,6 +2326,7 @@ dependencies = [
  "quarto-error-message-macros",
  "quarto-error-reporting",
  "quarto-source-map",
+ "regex",
  "serde",
  "serde_json",
  "tree-sitter",

--- a/docs/guides/authoring/computations.qmd
+++ b/docs/guides/authoring/computations.qmd
@@ -2,14 +2,91 @@
 title: Computations
 ---
 
-TBD.
+## Overview
+
+A Quarto document can contain **executable cells**: fenced code blocks whose
+info string is a language name wrapped in braces. Quarto hands each cell to
+an [engine](engines.qmd), runs it, and splices the results into the rendered
+document. For example, a cell written like this:
+
+````markdown
+```{r}
+sum(1:10)
+```
+````
+
+would, if run, produce `55` underneath it in the rendered page. (This page
+only *shows* cells like this one — see the next section — so nothing on it
+actually runs.)
 
 ## Displaying code cells without running them
 
-To show readers an executable cell — for example, in a document that
-teaches Quarto itself — wrap the cell in a fenced code block with more
-backticks:
+Writing *about* Quarto means showing readers what a cell looks like without
+running it — for example, in a tutorial or in this documentation. The rule is
+the ordinary Markdown one: **a fenced code block is displayed verbatim**, so a
+cell written inside one is shown, not executed.
 
+To display the cell above instead of running it, wrap it in a fence with
+*more backticks* than the cell uses:
+
+`````markdown
+````markdown
+```{r}
+sum(1:10)
+```
+````
+`````
+
+which renders as:
+
+````markdown
+```{r}
+sum(1:10)
+```
+````
+
+The braces stay single. Nothing about the inner cell changes — it is shown
+exactly as an author would type it, which is the point: a reader can copy it
+straight into their own document.
+
+### The outer fence must be longer
+
+Markdown decides where a fenced code block ends by matching the length of its
+opening fence. So the wrapping fence only needs to be *longer* than the
+longest run of backticks inside it — one backtick longer is enough. A cell
+written with the ordinary three backticks is displayed by wrapping it in four;
+if the content being displayed already contains a four-backtick fence, wrap
+that in five, and so on.
+
+### Cell options are displayed too
+
+Options on the fence header, and Quarto's `#|` comment options, are part of
+the cell and are displayed along with it — nothing needs to be stripped or
+adjusted. A fence-header option:
+
+````markdown
+```{r, echo=FALSE}
+plot(1:10)
+```
+````
+
+and a `#|` comment option:
+
+````markdown
+```{r}
+#| echo: false
+#| label: fig-example
+plot(1:10)
+```
+````
+
+### Displaying a block that itself displays a cell
+
+The same rule applies at any depth: each layer's fence just needs to be
+longer than the longest fence nested inside it. To show a document like this
+page — one that itself displays a cell — add one more layer of backticks:
+
+``````markdown
 `````markdown
 ````markdown
 ```{python}
@@ -17,9 +94,7 @@ backticks:
 ```
 ````
 `````
-
-Fenced code blocks are displayed verbatim, so the inner cell is shown
-exactly as written (single braces and all) and is not executed.
+``````
 
 ::: callout-note
 ## Migrating from Quarto 1


### PR DESCRIPTION
## The bug


Consider a page that both *runs* an executable code block and *shows* one:

`````qmd
---
title: Using R in Quarto
engine: knitr
---

Summing the first ten integers gives:

```{r}
sum(1:10)
```

To write a cell like that yourself, wrap it in a longer fence so it is
displayed rather than run:

````markdown
```{r}
sum(1:10)
```
````
`````


A four-backtick markdown display block whose content is a three-backtick `{r}` fence gets executed by knitr, and the displayed example is *replaced* by knitr's own cell scaffolding. The author writes ```` ```{r} ````; the reader is shown `::: {.cell}` and `{.r .cell-code}`.

It is reachable only when the engine is already live. With no real cell in the document, AST-based resolution correctly declines to start knitr — so one added real cell anywhere turns every displayed example on the page into a live cell.

Two symptoms are worse than "wrong output":

- **A displayed `{python}` example in an R document kills the render.** knitr hands the unclaimed language to reticulate: `python_not_found`, Execution halted. This is the most user-visible face of the defect, and it settles the language predicate — masking only the current engine's languages would not fix it.
- **A blockquoted display block loses its contents entirely,** rendering empty. knitr's own pattern is `^[\t >]*`, so those fences really do execute.

Inherited from Quarto 1; not a q2 regression. Sibling engines differ: the Julia engine gets this right (QuartoNotebookRunner parses in Julia, nesting- and indentation-correct) and marimo gets the top-level case right via `breakQuartoMd`'s length guard.

The strand was filed **wontfix-candidate**, on the grounds that q2 "has no seam short of escaping nested fences before hand-off, which would corrupt the display content a different way." This PR is that seam, with the corruption avoided by a byte-exact round trip.

## The fix

One seam in `engine_execution.rs`, inside the per-engine loop:

```
mask -> serialize_ast_to_qmd -> engine.execute -> unmask -> capture -> reparse -> reconcile
```

Mask rewrites ```` ```{r} ```` to ```` ```{.r q2-nested-executable} ````. **The leading dot is what does the work** — all three partitioners that could execute the fence require an alphanumeric first character after `{`:

| scanner | pattern fragment |
| --- | --- |
| knitr `all_patterns$md$chunk.begin` | `\{([a-zA-Z0-9_]+( *[ ,].*)?)\}` |
| q2 jupyter `parse_code_blocks` | `\{(\w+)\}` |
| TS `breakQuartoMd` | `\{([=A-Za-z][=A-Za-z0-9._]*)...\}` |

The marker class exists only so `unmask` knows which openers were ours, and is never produced by an author writing their own `{.lang}`.

Four things worth a reviewer's attention:

**It must be inside the loop.** `to_run` is iterated with the AST re-serialized each time and left unmasked between iterations, so masking once beforehand would leave a second engine unprotected. Because every engine reaches this one serialize call, knitr, q2's jupyter text engine, and TS extensions are all covered with no per-engine work.

**Prefix handling is asymmetric on purpose.** `mask` sees a `CodeBlock`'s text, from which the reader has already stripped any blockquote `> `; only `unmask`, running textually over engine output, ever meets one. So mask needs no prefix logic and unmask must not be `^`-anchored.

**Byte-exactness is load-bearing, not cosmetic.** Reconcile compares against the unmasked original. One byte of drift and it treats the display block as *changed* and replaces it — handing the author's example the `.rmarkdown` intermediate's `source_info`. A test asserts the block lands in `blocks_kept` with its original `source_info`, not merely that its text looks right.

**The capture is asymmetric by necessity.** `input_qmd` stays masked (ReplayEngine byte-compares it against a live input that is itself masked); `result.markdown` is unmasked before the emit, or `q2 preview` renders the marker. `compute_input_qmd` has three consumers that want different bytes — the staleness compare and cache key need masked, while `write_review_file` is security-facing and unmasks, because an operator deciding whether to permit execution must see the `{r}` they actually wrote.

## Provenance

Masked text is longer than its source. The qmd writer's map is output-indexed, so a lengthened block shifts nothing for any *other* block — but within it, `Concat::map_offset`'s `Original` arm computes `start_offset + offset` with no clamp to `end_offset`, so an offset near the end resolves past it into the next block's source text.

Changed blocks therefore get `SourceInfo::Generated` (`by.kind = "nested-cell-mask"`), for which `map_offset` returns `None` — location unknown rather than a confident wrong answer, which `build_source_map` already tolerates. The origin anchor is `Other`, not `Invocation`: `preimage_in`'s `Generated` arm walks only `Invocation`, so the anchor is provably inert to any byte-copying writer.

**Accepted cost:** the writer's piece loop is top-level only, so a masked block nested in a div or list marks its top-level ancestor too — that container reads as location-unknown, unrelated prose inside it included. Unknown beats wrong. The marking lives only on the short-lived clone; the reparsed AST gets fresh `source_info`, so nothing `Generated` reaches the document.

## Scope

**In:** braced executable openers inside a markdown-displaying `CodeBlock` — attr classes empty or `["markdown"]`. Every braced opener, regardless of language.

**Out, deliberately:**

- **`RawBlock`** — a spike measured that masking a `{=markdown}` RawBlock converts "wrongly executed" into *silently mangled*: the writer emits those unfenced, so the inner cell becomes a genuine top-level cell. A downgrade, not a fix (bd-4gzwls31).
- **Doubled-brace `{{lang}}`** — no scanner executes them; that is a diagnostics gap (bd-q250-nested-fence-blind-spot-t68z1lsw).
- **`{=html}`-style openers** — only `breakQuartoMd` matches `=`, and it mis-*partitions* rather than executes.
- **A cell nested inside another executable cell** — rewriting there would corrupt code that is about to run.
- **` ````qmd `** — display classes stay empty-or-`markdown`; Q-2-50's hint names `markdown`, and widening is a separate decision.

Also corrected during implementation: a 4-space indented display block is **not** a second route to the empty-classes AST shape. qmd has no indented-code-block production at all — the scanner emits `INDENTED_CODE_BLOCK_DISALLOWED` and never produces a `CodeBlock`.

**Known limitation:** unmask pattern-matches, so an author who writes `q2-nested-executable` verbatim inside a display block gets it rewritten. Measured, negligible, and removed later in the epic when the assembler restores from retained bytes instead of matching. Every mechanism here is replaced rather than contradicted by later epic work.

## Docs

`docs/guides/authoring/computations.qmd` already asserted the behaviour this bug breaks — *"the inner cell is shown exactly as written (single braces and all) and is not executed"* — above a body that read `TBD.`. Now expanded with the rule, the nesting requirement, cell options in the fence header, deeper nesting, and the Quarto 1 migration callout.

**The page deliberately gets no live executable cell.** `docs/` is rendered in CI in exactly one place (`release.yml`, via `build-agents-docs`), no workflow installs R, Python, Jupyter or Julia, and an unavailable engine is a hard error rather than a fallback — so a live cell would fail the *release* build rather than a PR check, and `release.yml` already records that a hard docs-render failure cost a release. The regression tests carry the live case, gated on knitr.

## Tests

31 new tests across four tiers, each of the plan's 22 seam rows bound before dispatch to the production hunk whose revert turns it RED:

- 17 unit- and writer-tier in the module
- 9 render-tier through `render_document_to_file`
- 4 capture-tier at the engine-execution, preview-record, and hub-provider seams
- 1 in the jupyter text engine

Two rows are green-at-baseline **guards**, labelled as such rather than passed off as REDs: T3 (a real cell still executes) and the render-tier control (a display block in a document with no live cell renders unchanged). The bug only under-masks, never over-masks, so both already hold with zero masking in place — they guard against a regression the fix could introduce.

## Verification

- `cargo xtask verify` (full, no skip flags) — all 14 steps passed, run on this branch as rebased onto `b93c62c74`
- its workspace test run — **13621 passed, 199 skipped, 0 failed** (480.7s)

The delta is accounted: the plan's Phase 0 measured a live baseline of 13550; `main` has since added 40 tests (`f14cd4963` +12, `9ad1d4420` +28), and this branch adds 31, giving 13621 exactly. No stray or duplicated tests. The hub-build leg also left the worktree clean, reproducing the committed sandboxed-preview bundles byte-for-byte.

The full verify is what caught the one dependency bug: `quarto-core` declared `regex` only under `cfg(not(target_arch = "wasm32"))`, so the WASM preview pipeline — which must mask displayed cells too — would not compile. `--skip-hub-build` never compiles `quarto-core` to wasm32 and would have shipped that undetected.

End-to-end output was inspected per CLAUDE.md; the exact invocations and observed HTML excerpts are recorded in the plan, including the two discriminators that separate a masked display block from an executed one.

## Not in this PR

The bundle-rebuild commit that `cargo xtask verify`'s hub-build leg produced along the way is unrelated to this strand and went straight to `main` instead: `546fdd374` + `b93c62c74`. It corrects two checked-in artifacts that were already wrong there — `serviceWorker.js` still carried the offline cache that `103af4445` commented out of its source, and `q2-sandboxed-preview.html` embedded KaTeX 0.18.2 although the lockfile pins 0.18.4 (#637 bumped it; `6549a98ae` rebuilt against a stale `node_modules` and reverted it).

## Plan

`claude-notes/plans/2026-09-02-nested-cell-masking.md` is reconciled: every phase ticked, each `- [x]` re-checked against the tree rather than trusted, and the Phase 7 findings recorded. The outcome is commented on the strand.

