### PR TITLE
Report Q-2-50 on doubled-brace fence openers nested in a display fence

### DIFF
--- a/crates/pampa/src/pandoc/treesitter.rs
+++ b/crates/pampa/src/pandoc/treesitter.rs
@@ -1760,7 +1760,7 @@ pub fn treesitter_to_pandoc<T: Write>(
         );
         return Err(vec![diagnostic]);
     };
-    let result = match postprocess(pandoc, error_collector) {
+    let result = match postprocess(pandoc, input_bytes, error_collector) {
         Ok(doc) => doc,
         Err(()) => {
             // Postprocess found errors, return the diagnostics from the collector

--- a/crates/pampa/src/pandoc/treesitter_utils/postprocess.rs
+++ b/crates/pampa/src/pandoc/treesitter_utils/postprocess.rs
@@ -953,8 +953,76 @@ pub fn transform_divs(doc: Pandoc, error_collector: &mut DiagnosticCollector) ->
     topdown_traverse(doc, &mut filter, &mut ctx)
 }
 
+/// Is `line` a fence opener carrying Quarto 1's doubled-brace escape?
+///
+/// This is the narrow predicate `^\s*`{3,}\{\{` — a line that is *itself* a
+/// fence opener whose info string starts with doubled braces. Matching the
+/// opener **position** rather than "the body contains `{{`" is what keeps the
+/// false-positive surface empty: the Jinja/template counter-case that shaped
+/// the original design (`{{ name }}`, `{{ request.headers[...] }}`) always
+/// sits on ordinary content lines, never at an opener.
+fn is_doubled_brace_fence_opener(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    let backticks = trimmed.bytes().take_while(|b| *b == b'`').count();
+    backticks >= 3 && trimmed[backticks..].starts_with("{{")
+}
+
+/// The language named by a doubled-brace opener line, e.g. `python` for
+/// ```` ```{{python}} ````. Returns `None` when the braces wrap something
+/// that is not a bare identifier-ish token, in which case the caller falls
+/// back to generic advice.
+fn doubled_brace_opener_language(line: &str) -> Option<String> {
+    let trimmed = line.trim_start();
+    let backticks = trimmed.bytes().take_while(|b| *b == b'`').count();
+    let info = trimmed[backticks..].trim_end();
+    let lang = info.trim_start_matches('{').trim_end_matches('}');
+    if lang.is_empty() || lang.contains(['{', '}', '`']) || lang.contains(char::is_whitespace) {
+        None
+    } else {
+        Some(lang.to_string())
+    }
+}
+
+/// The block's byte range **in this parse's own input buffer**, or `None`
+/// when the span is not a direct slice of it.
+///
+/// `resolve_byte_range` is deliberately *not* used here. Under a recursive
+/// parse of an embedded string (config values, `!md` metadata, Lua-filter
+/// config values) spans are rerooted through a parent `SourceInfo`, and
+/// resolving would compose the offsets into the **parent's** file — a
+/// different buffer from the `input_bytes` we are about to index, which
+/// would slice unrelated text and point the diagnostic at the wrong place.
+/// The uncomposed `start_offset`/`end_offset` are the offsets into this
+/// parse's input in both cases.
+fn parse_local_range(info: &SourceInfo) -> Option<(usize, usize)> {
+    match info {
+        SourceInfo::Original {
+            start_offset,
+            end_offset,
+            ..
+        }
+        | SourceInfo::Substring {
+            start_offset,
+            end_offset,
+            ..
+        } => Some((*start_offset, *end_offset)),
+        // Concat/Generated have no single contiguous slice of the input.
+        SourceInfo::Concat { .. } | SourceInfo::Generated { .. } => None,
+    }
+}
+
 /// Apply post-processing transformations to the Pandoc AST
-pub fn postprocess(doc: Pandoc, error_collector: &mut DiagnosticCollector) -> Result<Pandoc, ()> {
+///
+/// `input_bytes` is the document text the AST's offsets are relative to. It
+/// is needed to locate diagnostics *inside* a block's body — a `CodeBlock`
+/// carries its body in `text`, but `text` has no offset relationship to the
+/// block's span (the span includes the fence lines), so pointing at a body
+/// line means reading the block's own source slice.
+pub fn postprocess(
+    doc: Pandoc,
+    input_bytes: &[u8],
+    error_collector: &mut DiagnosticCollector,
+) -> Result<Pandoc, ()> {
     let result = {
         // Wrap error_collector in RefCell for interior mutability across multiple closures
         let error_collector_ref = RefCell::new(error_collector);
@@ -1149,6 +1217,7 @@ pub fn postprocess(doc: Pandoc, error_collector: &mut DiagnosticCollector) -> Re
             // (bd-escaped-executable-fence-uuvv37pk); the block is left as-is
             // and renders as literal code.
             .with_code_block(|code_block, _ctx| {
+                let mut warned = false;
                 for (i, class) in code_block.attr.1.iter().enumerate() {
                     if !class.starts_with("{{") {
                         continue;
@@ -1181,8 +1250,88 @@ pub fn postprocess(doc: Pandoc, error_collector: &mut DiagnosticCollector) -> Re
                         )
                         .build(),
                     );
+                    warned = true;
                     break;
                 }
+
+                // Second site: a doubled-brace opener *nested inside* a
+                // display fence. This is the form the real corpus uses --- the
+                // escape exists to SHOW a cell without running it, and showing
+                // a cell means wrapping it in an outer fence, so the escape
+                // essentially only ever appears nested. Measured on the Posit
+                // Connect docs port: 61 openers in 7 files, 61 of 61 nested,
+                // 0 top level (bd-q250-nested-fence-blind-spot-t68z1lsw).
+                //
+                // Nested openers are fence *content*, so they never become a
+                // class and the loop above cannot see them. We scan the
+                // block's own source slice rather than `code_block.text`
+                // because an offset into `text` has no relationship to the
+                // block's span --- the span includes the fence lines --- and a
+                // confidently wrong location is worse than none.
+                //
+                // The scan is deliberately NOT gated on the outer block's
+                // language. Gating on `markdown` would be tighter in
+                // principle, but on the measured corpus it selects exactly the
+                // same set, and an author who writes a doubled-brace opener
+                // inside a `text` or unlabelled display fence has the same
+                // problem.
+                if !warned
+                    && let Some((start, end)) = parse_local_range(&code_block.source_info)
+                    && let Some(block_src) = input_bytes.get(start..end)
+                    && let Ok(block_src) = std::str::from_utf8(block_src)
+                {
+                    // Skip the block's own opening fence line: if *it* carried
+                    // doubled braces the class loop above already reported it.
+                    let body_start = match block_src.find('\n') {
+                        Some(nl) => nl + 1,
+                        None => block_src.len(),
+                    };
+                    let mut offset = body_start;
+                    for line in block_src[body_start..].split_inclusive('\n') {
+                        let line_text = line.strip_suffix('\n').unwrap_or(line);
+                        if is_doubled_brace_fence_opener(line_text) {
+                            let lang = doubled_brace_opener_language(line_text);
+                            let execute_hint = match &lang {
+                                Some(lang) => format!(
+                                    "Write single braces: `{{{}}}`. The enclosing display block already shows the cell verbatim, so it will not run.",
+                                    lang
+                                ),
+                                None => "Write the language with single braces, e.g. `{python}`. The enclosing display block already shows the cell verbatim, so it will not run.".to_string(),
+                            };
+                            error_collector_ref.borrow_mut().add(
+                                DiagnosticMessageBuilder::warning(
+                                    "Doubled curly braces are not supported",
+                                )
+                                .with_code("Q-2-50")
+                                .with_location(SourceInfo::substring(
+                                    code_block.source_info.clone(),
+                                    offset,
+                                    offset + line_text.len(),
+                                ))
+                                // The opener is NOT wrapped in backticks here:
+                                // it begins with backticks itself, and nesting
+                                // them renders as ````{{python}}` --- noise
+                                // exactly where the message needs to be clear.
+                                // The snippet underlines the line anyway.
+                                .problem(format!(
+                                    "Quarto 2 does not treat doubled curly braces as an escape, so the opener {} is displayed exactly as written; readers are shown a fence opener that is not valid Quarto syntax.",
+                                    line_text.trim()
+                                ))
+                                .add_hint(execute_hint)
+                                .add_hint(
+                                    "Quarto 1 doubled the braces to keep a displayed cell from running. Quarto 2 does not need the escape: a fenced block's contents are displayed verbatim.",
+                                )
+                                .build(),
+                            );
+                            // One warning per block, matching the class path:
+                            // a page showing several cells should not produce
+                            // a wall of identical diagnostics.
+                            break;
+                        }
+                        offset += line.len();
+                    }
+                }
+
                 Unchanged(code_block)
             })
             // Remove single empty spans from bullet list items

--- a/crates/pampa/tests/integration/test_doubled_brace.rs
+++ b/crates/pampa/tests/integration/test_doubled_brace.rs
@@ -10,10 +10,21 @@
 //   error corpus (previously an uncoded "Parse error");
 // - a top-level fence opener whose info string is a doubled-brace form parses
 //   into a CodeBlock with a literal `{{lang}}` class — that class shape can
-//   only arise from a doubled-brace opener, and gets a Q-2-50 *warning*.
+//   only arise from a doubled-brace opener, and gets a Q-2-50 *warning*;
+// - a doubled-brace fence opener *nested inside a display fence* is fence
+//   content rather than a class, and gets the same Q-2-50 warning located at
+//   the nested opener line.
+//
+// The nested form is the one the real corpus uses. The doubled brace is
+// Quarto 1's escape for *displaying* a cell without running it, and
+// displaying a cell means wrapping it in an outer fence — so the escape
+// essentially only ever appears nested. Measured across the Posit Connect
+// docs port: 61 openers in 7 files, 61 of 61 nested, 0 top level
+// (bd-q250-nested-fence-blind-spot-t68z1lsw).
 //
 // Design: claude-notes/plans/2026-08-17-doubled-brace-escape.md
-// (bd-escaped-executable-fence-uuvv37pk).
+// (bd-escaped-executable-fence-uuvv37pk); nested form added for
+// bd-q250-nested-fence-blind-spot-t68z1lsw.
 
 use pampa::readers;
 
@@ -194,24 +205,59 @@ fn test_toplevel_triple_brace_fence_warns_q250() {
     );
 }
 
-#[test]
-fn test_displayed_fence_content_does_not_warn() {
-    // A doubled-brace opener *inside* a displayed fence is fence content,
-    // not a class — it must stay verbatim and must NOT warn. (This is the
-    // documented way to show literal doubled braces, and also what protects
-    // Jinja-style content; decision 1 in the plan.)
-    let (pandoc, _context, warnings) = parse("````markdown\n```{{python}}\n1 + 1\n```\n````\n")
-        .expect("displayed fence should parse");
+// ---------------------------------------------------------------------------
+// Nested openers: a doubled-brace fence opener inside a display fence.
+//
+// The predicate is deliberately narrow — a line of fence *content* that is
+// itself a fence opener carrying doubled braces:
+//
+//     ^\s*`{3,}\{\{
+//
+// That is what separates this case from the Jinja counter-case further down,
+// where doubled braces sit on ordinary content lines and must stay silent.
+// Matching the opener *position* rather than "a doubled brace appears in the
+// content" is what keeps the false-positive surface empty.
+// ---------------------------------------------------------------------------
 
-    assert!(
-        q250_warnings(&warnings).is_empty(),
-        "Doubled braces inside a displayed fence body must not warn; got: {:?}",
+/// Byte offset in the original source that a diagnostic points at.
+fn start_offset(w: &quarto_error_reporting::DiagnosticMessage) -> usize {
+    w.location
+        .as_ref()
+        .expect("Q-2-50 warning must carry a location")
+        .resolve_byte_range()
+        .expect("Q-2-50 location must resolve to a byte range")
+        .1
+}
+
+#[test]
+fn test_nested_doubled_brace_opener_warns_q250() {
+    // NOTE: this reverses `test_displayed_fence_content_does_not_warn`, which
+    // pinned the original decision to diagnose only the top-level spelling.
+    // That decision was made against an estimate of 8 occurrences; the
+    // measured corpus is 61, all nested. Rendering this block silently shows
+    // the reader ```{{python}} as the syntax to copy, which is not valid
+    // Quarto 2 (or Quarto 1 output) syntax.
+    let source = "````markdown\n```{{python}}\n1 + 1\n```\n````\n";
+    let (pandoc, _context, warnings) = parse(source).expect("displayed fence should parse");
+
+    let q250 = q250_warnings(&warnings);
+    assert_eq!(
+        q250.len(),
+        1,
+        "A nested doubled-brace opener should produce exactly one Q-2-50 warning; got: {:?}",
         warnings
             .iter()
-            .map(|w| w.code.as_deref())
+            .map(|w| (w.code.as_deref(), w.kind))
             .collect::<Vec<_>>()
     );
+    assert_eq!(
+        q250[0].kind,
+        quarto_error_reporting::DiagnosticKind::Warning,
+        "The nested diagnostic is a warning: the render proceeds"
+    );
 
+    // The block is still left completely as-is — this change adds a
+    // diagnostic, it does not rewrite or unescape anything.
     use pampa::pandoc::Block;
     let code_block = match &pandoc.blocks[0] {
         Block::CodeBlock(cb) => cb,
@@ -222,6 +268,172 @@ fn test_displayed_fence_content_does_not_warn() {
         code_block.text.contains("```{{python}}"),
         "Displayed fence body must keep the doubled braces verbatim; got: {}",
         code_block.text
+    );
+}
+
+#[test]
+fn test_nested_warning_points_at_the_opener_line_not_the_block() {
+    // The whole value of the diagnostic is telling the author *which* line to
+    // fix; a block-level location would point at the outer fence, which is
+    // not the thing that is wrong.
+    let source = "````markdown\n```{{python}}\n1 + 1\n```\n````\n";
+    let (_pandoc, _context, warnings) = parse(source).expect("displayed fence should parse");
+
+    let q250 = q250_warnings(&warnings);
+    assert_eq!(q250.len(), 1);
+
+    let offset = start_offset(q250[0]);
+    assert!(
+        source[offset..].starts_with("```{{python}}"),
+        "Warning should point at the nested opener; it points at {:?}",
+        &source[offset..(offset + 20).min(source.len())]
+    );
+}
+
+#[test]
+fn test_indented_nested_doubled_brace_opener_warns() {
+    // Display fences inside list items indent their content.
+    let source = "````markdown\n  ```{{r}}\n  1 + 1\n  ```\n````\n";
+    let (_pandoc, _context, warnings) = parse(source).expect("indented display fence should parse");
+
+    assert_eq!(
+        q250_warnings(&warnings).len(),
+        1,
+        "An indented nested opener should still warn; got: {:?}",
+        warnings
+            .iter()
+            .map(|w| w.code.as_deref())
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn test_nested_triple_brace_opener_warns() {
+    // Quarto 1 honors deeper nesting too; any 2-or-more brace form is the
+    // same migration hit, matching the top-level behaviour.
+    let source = "````markdown\n```{{{python}}}\n1 + 1\n```\n````\n";
+    let (_pandoc, _context, warnings) = parse(source).expect("triple-brace nesting should parse");
+
+    assert_eq!(
+        q250_warnings(&warnings).len(),
+        1,
+        "A nested triple-brace opener should warn; got: {:?}",
+        warnings
+            .iter()
+            .map(|w| w.code.as_deref())
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn test_multiple_nested_openers_warn_once_per_block() {
+    // Mirrors the top-level path's `break`: one warning per block, so a
+    // documentation page showing several cells does not produce a wall of
+    // identical diagnostics.
+    let source = "````markdown\n```{{python}}\n1\n```\n\n```{{r}}\n2\n```\n````\n";
+    let (_pandoc, _context, warnings) = parse(source).expect("two nested openers should parse");
+
+    assert_eq!(
+        q250_warnings(&warnings).len(),
+        1,
+        "Two nested openers in one block should still warn once; got: {:?}",
+        warnings
+            .iter()
+            .map(|w| w.code.as_deref())
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn test_toplevel_doubled_brace_with_nested_opener_warns_once() {
+    // Both paths can match the same block. The class path already warns, so
+    // the content scan must not add a second diagnostic for the same block.
+    let source = "```{{python}}\n```{{r}}\n```\n";
+    let (_pandoc, _context, warnings) = parse(source).expect("should parse");
+
+    assert_eq!(
+        q250_warnings(&warnings).len(),
+        1,
+        "A block matching both paths should warn once; got: {:?}",
+        warnings
+            .iter()
+            .map(|w| w.code.as_deref())
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn test_nested_single_brace_does_not_warn() {
+    // The sanctioned Quarto 2 spelling: nesting a single-brace cell inside a
+    // display fence. This is what the diagnostic's hint points authors at.
+    let source = "````markdown\n```{python}\n1 + 1\n```\n````\n";
+    let (_pandoc, _context, warnings) = parse(source).expect("should parse");
+
+    assert!(
+        q250_warnings(&warnings).is_empty(),
+        "The sanctioned nested single-brace spelling must not warn; got: {:?}",
+        warnings
+            .iter()
+            .map(|w| w.code.as_deref())
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn test_nested_plain_language_fence_does_not_warn() {
+    let source = "````markdown\n```python\n1 + 1\n```\n````\n";
+    let (_pandoc, _context, warnings) = parse(source).expect("should parse");
+
+    assert!(
+        q250_warnings(&warnings).is_empty(),
+        "A nested plain-language fence must not warn; got: {:?}",
+        warnings
+            .iter()
+            .map(|w| w.code.as_deref())
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn test_jinja_braces_inside_a_display_fence_do_not_warn() {
+    // The counter-case that shaped the original design, in its hardest form:
+    // doubled braces on ordinary content lines *inside a markdown display
+    // fence*. Matching on opener position rather than on "contains {{" is
+    // exactly what keeps this silent.
+    let source = concat!(
+        "````markdown\n",
+        "```{.html filename=\"template.html\"}\n",
+        "<h1>Hello {{ name }}</h1>\n",
+        "<p>Agent: {{ request.headers['user-agent'] }}</p>\n",
+        "```\n",
+        "````\n"
+    );
+    let (_pandoc, _context, warnings) = parse(source).expect("should parse");
+
+    assert!(
+        q250_warnings(&warnings).is_empty(),
+        "Jinja braces on content lines must not warn, even inside a display fence; got: {:?}",
+        warnings
+            .iter()
+            .map(|w| w.code.as_deref())
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn test_backticks_with_doubled_braces_mid_line_do_not_warn() {
+    // A doubled brace that follows backticks but is not at an opener
+    // position — prose about the Quarto 1 idiom inside a display fence.
+    let source = "````markdown\nSee ```{{python}}``` in Quarto 1.\n````\n";
+    let (_pandoc, _context, warnings) = parse(source).expect("should parse");
+
+    assert!(
+        q250_warnings(&warnings).is_empty(),
+        "Backticks mid-line are not a fence opener and must not warn; got: {:?}",
+        warnings
+            .iter()
+            .map(|w| w.code.as_deref())
+            .collect::<Vec<_>>()
     );
 }
 
@@ -276,5 +488,57 @@ fn test_plain_language_fence_does_not_warn() {
             .iter()
             .map(|w| w.code.as_deref())
             .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn test_nested_warning_locates_correctly_under_a_recursive_parse() {
+    // Embedded strings (config values, `!md` metadata, Lua-filter config
+    // values) are parsed recursively with a `parent_source_info`, and their
+    // spans are rerooted through that parent. The content scan indexes this
+    // parse's OWN input buffer, so it must use the block's parse-local
+    // offsets; resolving the span first would compose offsets into the
+    // parent's file and slice an unrelated buffer.
+    use quarto_source_map::FileId;
+
+    let text = "````markdown\n```{{python}}\n1 + 1\n```\n````\n";
+    const PARENT_START: usize = 50;
+    let parent =
+        quarto_source_map::SourceInfo::original(FileId(3), PARENT_START, PARENT_START + text.len());
+
+    let (_pandoc, _context, warnings) = readers::qmd::read(
+        text.as_bytes(),
+        false,
+        "<metadata>",
+        &mut std::io::sink(),
+        true,
+        Some(parent),
+    )
+    .expect("embedded display fence should parse");
+
+    let q250 = q250_warnings(&warnings);
+    assert_eq!(
+        q250.len(),
+        1,
+        "A nested opener in an embedded string should warn once; got: {:?}",
+        warnings
+            .iter()
+            .map(|w| w.code.as_deref())
+            .collect::<Vec<_>>()
+    );
+
+    let (file_id, start, _end) = q250[0]
+        .location
+        .as_ref()
+        .expect("warning must carry a location")
+        .resolve_byte_range()
+        .expect("location must resolve");
+
+    let opener_offset_in_text = text.find("```{{python}}").unwrap();
+    assert_eq!(file_id, 3, "location must resolve into the parent's file");
+    assert_eq!(
+        start,
+        PARENT_START + opener_offset_in_text,
+        "location must land on the opener as seen from the parent file"
     );
 }

--- a/docs/errors/markdown/Q-2-50.qmd
+++ b/docs/errors/markdown/Q-2-50.qmd
@@ -30,6 +30,13 @@ have this escape, in either place it used to appear:
   code block whose language reads `{{python}}`, and Quarto 2 reports
   this error so the doubled braces don't silently end up in your
   output.
+- **Inside a display block**, a nested ```` ```{{python}} ```` opener
+  is reported too. This is where the Quarto 1 escape almost always
+  appears, because doubling the braces was how you *showed* a cell
+  without running it — and showing a cell means wrapping it in an
+  outer fence. Quarto 2 displays fence contents verbatim, so the
+  doubled braces reach the page and your readers are shown a fence
+  opener that is not valid Quarto syntax.
 
 ## Why this happens
 
@@ -56,7 +63,10 @@ verbatim in Quarto 2, so no escape is needed:
 ````
 `````
 
-This shows the reader exactly what they should type.
+This shows the reader exactly what they should type. If you are
+porting a Quarto 1 page, the fix is usually just to remove the extra
+braces from the *inner* opener — the outer fence is already doing the
+work the escape used to do.
 
 **To write literal braces in prose**, escape each brace, or use a
 code span:

--- a/docs/errors/markdown/Q-2-50.qmd
+++ b/docs/errors/markdown/Q-2-50.qmd
@@ -7,6 +7,13 @@ status: stub
 since: "99.9.9"
 categories:
   - markdown
+diagnostics:
+  # This page teaches the Quarto 1 idiom, so its "Bad input" example is a
+  # doubled-brace opener on purpose. Without this the page reports the very
+  # warning it documents.
+  Q-2-50:
+    level: off
+    reason: "This page documents the Quarto 1 doubled-brace idiom; its examples are deliberate."
 ---
 
 # `Q-2-50` — Doubled curly braces are not supported

--- a/docs/guides/authoring/figures.qmd
+++ b/docs/guides/authoring/figures.qmd
@@ -275,7 +275,7 @@ You can provide a short caption that is used in the "List of Figures" using the 
 You can specify `fig-scap` as an executable code block option or as an attribute on an image:
 
 ````markdown
-```{{python}}
+```{python}
 #| fig-cap: "Long caption"
 #| fig-scap: "Short caption"
 

--- a/docs/guides/formats/latex/index.qmd
+++ b/docs/guides/formats/latex/index.qmd
@@ -44,7 +44,7 @@ format:
     fig-pos: 'h'
 ---
 
-```{{python}}
+```{python}
 #| fig-pos: 't'
 
 ```


### PR DESCRIPTION
`Q-2-50` matched on the fence's **class**. A nested opener is fence *content* and never
becomes a class, so the check only ever fired on a top-level ```` ```{{python}} ```` —
the one spelling nobody writes. The doubled brace exists to display a cell without
running it, and displaying a cell means wrapping it in an outer fence, so the escape is
always nested in practice: 61 openers across 7 files in the Posit Connect docs port, all
61 nested, none top level, and not one `Q-2-50` in a 352-page render. The pages carrying
them are the ones teaching how to write Quarto cells, so ```` ```{{python}} ```` is
served to readers as the syntax to copy.

The `Q-2-50` site in `postprocess` gains a second path: scan a code block's own source
slice for a line that is itself a fence opener carrying doubled braces, warn once per
block, located at that line. The class path is unchanged and nothing is rewritten.

**Predicate:** `^\s*` + three-or-more backticks + `{{`. Keying on opener *position*
rather than "the body contains `{{`" is what keeps template languages quiet — Jinja's
`{{ name }}` sits on content lines, never at an opener, and neither single-brace nesting
nor a plain fence trips it. Not gated on the outer block's language: gating on `markdown`
selects an identical set on the corpus, and a doubled-brace opener inside a `text` or
unlabelled display fence is the same defect.

**Offsets** are the block's uncomposed parse-local `start_offset`/`end_offset`,
restricted to `Original`/`Substring` — not `resolve_byte_range()`. Under a recursive
parse of an embedded string (config values, `!md` metadata, Lua-filter config values)
spans are rerooted through a parent, so resolving composes into the parent's file and
indexes a different buffer than the one being scanned, putting the caret on unrelated
text. `postprocess` takes `input_bytes` for the same reason: a `CodeBlock`'s `text` has
no offset relationship to its span, which includes the fence lines, so locating anything
inside a body means slicing the block's own source.

The message names the language read off the opener — `Write single braces: {python}` —
and falls back to generic advice when the braces wrap something that isn't a bare
identifier. `test_displayed_fence_content_does_not_warn` pinned the old silence on fence
content and is reversed; the replacement carries the reasoning.

This is orthogonal to the masking in #650. Every partitioner (knitr `[a-zA-Z0-9_]`,
jupyter `\w`, TS `[=A-Za-z]`) requires an identifier character straight after `{`, which
is why the Quarto 1 escape worked at all — `{{python}}` is not an executable opener for
anyone, `mask()` leaves it alone by construction, and this branch only adds a diagnostic
over the top.

### Docs

Two pages here taught the Quarto 1 idiom; both are fixed by dropping the extra braces,
since the enclosing display fence already does the work the escape used to do:

- `docs/guides/authoring/figures.qmd:278` (fig-cap / fig-scap)
- `docs/guides/formats/latex/index.qmd:47` (fig-pos)

Every opener on both pages is nested, so no engine starts for either and the change
cannot cause execution; both render with the opener verbatim and no cell scaffolding.

`docs/errors/markdown/Q-2-50.qmd` shows the idiom deliberately under "Bad input", so it
reported the warning it documents. It uses the diagnostics policy that already exists
rather than a new opt-out:

```yaml
diagnostics:
  Q-2-50:
    level: off
    reason: "This page documents the Quarto 1 doubled-brace idiom; its examples are deliberate."
```

Untouched: the five **top-level** doubled-brace blocks in `figures.qmd` (387, 405, 427,
447, 466). Different defect — a top-level opener becomes the block's class, so the reader
gets the cell body with no fence line at all — and the fix is to rewrap each in a display
fence, editorial rather than a brace swap. bd-yz98sxg6.

Closes bd-q250-nested-fence-blind-spot-t68z1lsw. Stacked on #650, which the docs fixes
depend on: single braces are exactly what knitr still executes without masking in place.
