### PR TITLE
Bump workspace version to 0.29.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "comrak-to-pandoc"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "comrak",
  "hashlink",
@@ -4806,7 +4806,7 @@ dependencies = [
 
 [[package]]
 name = "quarto"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4854,7 +4854,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-analysis"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "insta",
  "quarto-error-reporting",
@@ -4880,7 +4880,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-brand"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "pathdiff",
  "quarto-util",
@@ -4892,7 +4892,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-citeproc"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "glob",
  "hashlink",
@@ -4926,7 +4926,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-core"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4984,7 +4984,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-csl"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "insta",
  "quarto-error-reporting",
@@ -5012,7 +5012,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-error-catalog"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "once_cell",
  "quarto-error-reporting",
@@ -5048,7 +5048,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-highlight"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "hashlink",
  "insta",
@@ -5077,7 +5077,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-highlight-encoding"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -5085,7 +5085,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-hub"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "automerge",
@@ -5129,7 +5129,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-hub-provider"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "automerge",
  "ciborium",
@@ -5155,7 +5155,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-lsp"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "insta",
@@ -5171,7 +5171,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-lsp-core"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "insta",
  "pampa",
@@ -5194,7 +5194,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-mcp-launcher"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -5210,7 +5210,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-navigation"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "quarto-config",
  "quarto-pandoc-types",
@@ -5221,7 +5221,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-p2p"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "axum",
  "futures",
@@ -5265,7 +5265,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-preview"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "automerge",
@@ -5303,7 +5303,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-project-create"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "quarto-doctemplate",
  "serde",
@@ -5314,7 +5314,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-publish"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5339,7 +5339,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-sass"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "grass",
  "include_dir",
@@ -5362,7 +5362,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-source-fetch"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "flate2",
  "tar",
@@ -5385,7 +5385,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-system-runtime"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5403,7 +5403,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-test"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "quarto-core",
@@ -5420,7 +5420,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-trace"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "flate2",
  "serde",
@@ -5431,7 +5431,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-trace-server"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -5458,7 +5458,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-util"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "dirs",
  "serde",
@@ -5467,7 +5467,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-xml"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "insta",
  "quarto-error-reporting",
@@ -5705,7 +5705,7 @@ dependencies = [
 
 [[package]]
 name = "reconcile-viewer"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "clap",
  "hashlink",
@@ -6712,7 +6712,7 @@ checksum = "ea06cc588e43c632923a55450401b8f25e628131571d4e1baea1bdfdb2b5ed06"
 
 [[package]]
 name = "spa-manifest"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -7961,7 +7961,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-printf-fmt"
-version = "0.28.0"
+version = "0.29.0"
 
 [[package]]
 name = "wasm-streams"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.28.0"
+version = "0.29.0"
 authors = ["Posit Software, PBC"]
 homepage = "https://github.com/posit-dev/quarto-markdown-syntax"
 keywords = ["parser"]

--- a/crates/wasm-quarto-hub-client/Cargo.lock
+++ b/crates/wasm-quarto-hub-client/Cargo.lock
@@ -377,7 +377,7 @@ dependencies = [
 
 [[package]]
 name = "comrak-to-pandoc"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "comrak",
  "hashlink",
@@ -2075,7 +2075,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-analysis"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "quarto-error-reporting",
  "quarto-pandoc-types",
@@ -2097,7 +2097,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-brand"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "pathdiff",
  "quarto-util",
@@ -2108,7 +2108,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-citeproc"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "glob",
  "hashlink",
@@ -2139,7 +2139,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-core"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2191,7 +2191,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-csl"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "quarto-error-reporting",
  "quarto-source-map",
@@ -2242,7 +2242,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-highlight"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "once_cell",
  "quarto-highlight-encoding",
@@ -2268,7 +2268,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-highlight-encoding"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2276,7 +2276,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-lsp-core"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "pampa",
  "pollster",
@@ -2297,7 +2297,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-navigation"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "quarto-config",
  "quarto-pandoc-types",
@@ -2334,7 +2334,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-project-create"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "quarto-doctemplate",
  "serde",
@@ -2344,7 +2344,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-sass"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "include_dir",
  "once_cell",
@@ -2375,7 +2375,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-system-runtime"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -2392,7 +2392,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-trace"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "flate2",
  "serde",
@@ -2410,7 +2410,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-util"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "dirs",
  "serde",
@@ -2419,7 +2419,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-xml"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "quarto-error-reporting",
  "quarto-source-map",
@@ -4026,7 +4026,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-printf-fmt"
-version = "0.28.0"
+version = "0.29.0"
 
 [[package]]
 name = "wasm-quarto-hub-client"


### PR DESCRIPTION
Version bump for the **v0.29.0** release, per `claude-notes/instructions/release-runbook.md` step 2.

The release workflow's preflight job fails unless the git tag exactly equals `[workspace.package].version`, so this has to land on `main` before `v0.29.0` is tagged.

## Changes

- `Cargo.toml`: `[workspace.package].version` 0.28.0 → 0.29.0
- `Cargo.lock`: `cargo update --workspace` (workspace members only; no external dep moved)
- `crates/wasm-quarto-hub-client/Cargo.lock`: the second lockfile — that crate declares its own `[workspace]`, so a root `cargo update` does not reach it. Missing it leaves unrequested churn for the next person to run `cargo xtask verify` (the v0.17.0 bump missed it).

## Verification

- `cargo build --bin q2 --locked` → `q2 (quarto 2) 0.29.0`. The `--locked` build is the real gate; CI builds `--locked`, so both lockfiles must already be in sync.
- `cargo nextest run --workspace` → **13675 passed, 199 skipped, 0 failed**.
- `npm run build:wasm` from `hub-client/` → succeeds and leaves the tree clean, confirming the second lockfile is right.
- No snapshot files added, modified, or removed.

Scope is whatever is on `main` at merge: 142 commits since v0.28.0. PRs #638 and #452 stay open and are **not** in this release.