### PR TITLE
Theme compile failures are structured hard errors, not silent DEFAULT_CSS (bd-jsvetdea)

### DIFF
--- a/claude-notes/plans/2026-09-08-theme-scss-compile-error-swallowed.md
+++ b/claude-notes/plans/2026-09-08-theme-scss-compile-error-swallowed.md
@@ -147,6 +147,22 @@ explicit `theme: none` opt-out.
       conditions that should be `ctx.add_diagnostic`; fix the `-v` filter
       so `quarto_core` warnings are visible. Filed as bd-e1psgogt.
 
+## CI finding: WASM tests relied on the masked failure (2026-09-08)
+
+PR #661's first CI run failed 20 hub-client WASM tests in four files
+(`changelogRender`, `projectContext`, `runtimeMetadata`,
+`vfsArtifactReflush` `.wasm.test.ts`). Each loads the WASM module by hand
+and renders without calling `setVfsCallbacks`, so dart-sass cannot resolve
+the bundle's `@import "vendor/rfs"`. That is exactly the failure the
+`DEFAULT_CSS` fallback used to mask: the tests only inspected HTML, so they
+passed against an unstyled page. With the default-bundle compile now a
+`Q-14-6` hard error (design decision 1) they fail honestly. Fix: a shared
+`hub-client/src/test-utils/wasmSassVfs.ts` (`wireSassVfs(wasm)`) mirroring
+the production wiring in `preview-runtime`'s `wasmRenderer.ts`, called from
+each file's `beforeAll`. This is the "surfacing currently-masked failures"
+risk from bd-36vmz7nk, realised in the test suite rather than in a user
+project. `npm run test:wasm`: 133/133 after the fix.
+
 ## End-to-end verification record (2026-09-08)
 
 Invocation, after the fix, on the repro fixture (`theme: [cosmo, theme.scss]`,

--- a/claude-notes/plans/2026-09-08-theme-scss-compile-error-swallowed.md
+++ b/claude-notes/plans/2026-09-08-theme-scss-compile-error-swallowed.md
@@ -1,0 +1,254 @@
+# User theme .scss compile error is swallowed: page silently ships DEFAULT_CSS (bd-jsvetdea)
+
+**Date:** 2026-09-08
+**Braid:** bd-jsvetdea (bug, p2, labels: css, diagnostics, theming)
+**Checkout:** main checkout, branch `main` @ `b7e7c96a` (no worktree/branch created by the investigation)
+**Status:** Investigation — pending design alignment with user. **Do not start implementation until the user gives the go-ahead.**
+
+## Triage verdict
+
+**Ready to design.** The symptom reproduces at HEAD exactly as filed, the
+swallow site is a single `Err` arm with an established structured-diagnostic
+neighbour (Q-14-4) two screens above it, and the two related strands
+(bd-36vmz7nk, bd-qmpygp02) are both resolved by the same change. The open
+questions are posture (hard error vs. loud warning) and how much source
+location to promise, not feasibility.
+
+## Issue context
+
+Filed 2026-09-08 by Carlos while setting up `_brand.yml` + custom SCSS for
+cscheid-net-2026. A theme file containing only
+
+```scss
+/*-- scss:defaults --*/
+$grid-body-width: 52rem;
+```
+
+makes the Bootstrap grid arithmetic fail in grass (`Incompatible units px and
+rem`). The theme stage catches the error, emits a `Warn` trace event, and
+returns the static ~7KB `DEFAULT_CSS`. The render reports "Rendered 1 of 1
+files" with zero warnings; nothing is visible at `-v`, `-vv`, or via
+`RUST_LOG`. Brand fonts, colors, and the user's rules are all gone.
+
+## Dependency graph
+
+No `blocks` edges in either direction; no `discovered-from` parent (the
+strand *is* the discovery record). Three `related` edges:
+
+- **bd-36vmz7nk** (question, p2, cderv, 2026-07-03) — "Decide: silent
+  theme-compile fallback vs hard error." The policy strand. It was scoped out
+  of the CRLF layer-marker fix (bd-3fgnmlco, closed) because the fallback had
+  masked that bug for months. Two later comments (2026-08-14 light/dark audit,
+  2026-09-08 this strand) both push toward a hard error; the light/dark note
+  points out the fallback is now *per variant*, so a failing dark compile
+  ships light `DEFAULT_CSS` under the dark key.
+- **bd-qmpygp02** (bug, p3, 2026-08-08) — `InvalidScssFile` (existing file,
+  no layer markers) is swallowed by the same `Err` arm. Its fix shape is the
+  same wrapper change this strand needs: stop stringifying `SassError` in
+  `compile_with_doc_vars_via_runtime`, match variants, route through
+  `theme_diagnostic`. Discovered from bd-of20unsb (format-extension theme
+  rebase, still `in_progress`), which added the up-front Q-14-4 check.
+- **bd-5fseopxy** (bug, p2, same session) — brand font weight ranges collapse
+  to 400; its typography-slot case emits `$font-weight-base: 400..700` and
+  then hits *this* fallback, so two silent failures stack. Independent fix,
+  but a useful second regression fixture for this strand.
+
+Related plans: `claude-notes/plans/2026-08-08-format-ext-theme-rebase.md`
+(Q-14-4 precedent), `claude-notes/plans/2026-08-14-light-dark-theme-epic.md`
+(variant_css split, phase E audit).
+
+## What the code looks like today
+
+All paths in the strand still exist; the area was refactored into
+`variant_css` by the light/dark epic but the swallow arm is unchanged.
+
+- `crates/quarto-core/src/stage/stages/compile_theme_css.rs:727-736` — the
+  `Err` arm: `trace_event!(Warn, "theme CSS compilation failed: {e}, using
+  default CSS")` then `Ok(DEFAULT_CSS)`.
+- `compile_theme_css.rs:1010-1032` — `compile_with_doc_vars_via_runtime`
+  (native + wasm cfgs) maps `SassError` to `String`, discarding the variant.
+- `compile_theme_css.rs:617-630` — the *default bundle* path has its own
+  identical fallback (`compile_default` failure → `DEFAULT_CSS`).
+- `compile_theme_css.rs:355-370` — the reveal path has a third one (compile
+  failure → vendored stock theme CSS). Same posture question.
+- `compile_theme_css.rs:636-670` — the Q-14-4 precedent: up-front check,
+  `SassError::CustomThemeNotFound { location }` →
+  `theme_diagnostic::sass_error_to_parse_error` → `PipelineError::Structured`.
+- `crates/quarto-sass/src/error.rs:17-19` — `SassError::CompilationFailed {
+  message: String }` carries only the stringified grass error; no location
+  field, so `with_location` cannot attach a YAML span to it today.
+- `crates/quarto-sass/src/compile.rs:263-274` / `547-556` — the grass/dart
+  error is stringified into `CompilationFailed` at the crate boundary.
+- `crates/quarto-core/src/theme_diagnostic.rs` — handles Q-14-1/2/4; the
+  catch-all arm for other variants renders a code-less error. Q-14-3 was
+  retired and removed from the catalog; Q-14-5 is the latest code.
+
+### Why nothing surfaces at any verbosity
+
+Two independent gaps, both confirmed by reading the wiring:
+
+1. `RenderContext` defaults to `NoopObserver`
+   (`crates/quarto-core/src/render.rs:462`), and the CLI never installs
+   another one. The only way to get a real observer is `trace: true` /
+   `trace: summary` in document metadata
+   (`stage/stages/metadata_merge.rs:505-551`). So `trace_event!(Warn, …)` is
+   discarded before any log filter sees it.
+2. Even with `TracingObserver` (which maps `Warn` to `tracing::warn!`), the
+   `-v` filters are `quarto=warn,q2=warn` etc.
+   (`crates/quarto-util/src/verbose.rs:34-41`); those directives match the
+   `quarto` and `q2` targets, not `quarto_core`, so a warning emitted from
+   `quarto_core::stage::observer` would still be filtered.
+
+This means every "graceful fallback with a warning trace" in the stage is
+silent on the CLI, not just this one. Worth its own strand (see open
+question 6).
+
+### Repro at HEAD (confirmed 2026-09-08)
+
+Fixture: `claude-notes/plans/theme-scss-compile-error-swallowed-investigation/repro/`
+(`theme: [cosmo, theme.scss]`, no brand — the brand is not needed to trigger it).
+
+```
+$ cargo run -q --bin q2 -- render claude-notes/plans/theme-scss-compile-error-swallowed-investigation/repro
+Rendering project: …/repro (type: website)
+Rendered 1 of 1 files to …/repro/_site
+$ ls -l repro/_site/site_libs/quarto/*.css
+-rw-r--r--  6996  quarto-theme-e6964ef56c8a5065.css      # "styles.css / Default styles for Quarto HTML documents"
+```
+
+With `-vv`: only the `render_to_file` debug lines; no mention of the theme.
+Control (`$grid-body-width: 830px`): 325166-byte compiled bundle.
+
+With `trace: summary` added to `_quarto.yml`, the swallowed text is:
+
+```
+[trace] [warn] theme CSS compilation failed: SASS compilation failed: SASS compilation error: Error: Incompatible units px and rem.
+     ╷
+3269 │ $grid-body-column-min: quarto-math.min(500px, $grid-body-column-max) !default;
+     │                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     ╵
+./stdin:3269:24
+, using default CSS
+```
+
+**Important nuance for the design:** the strand says the grass error has "a
+precise Sass location". It does — but the location is line 3269 of the
+*assembled* bundle (`./stdin`), and the failing line is Quarto's own
+`$grid-body-column-min` default, not the user's `$grid-body-width` line.
+The user's file is not named anywhere in the message. Mapping the assembled
+line back to (layer, source file, line) would need provenance bookkeeping in
+`quarto_sass::bundle::assemble_scss`, which today just `push_str`s the layer
+sections in order. Q1 has the same limitation and deliberately truncates the
+dart-sass pointer to its temp file
+(`external-sources/quarto-cli/src/core/dart-sass.ts:141-146`), but Q1 *does*
+throw `"Theme file compilation failed:\n\n" + errMsg` — a hard error.
+
+### Pre-flight verify
+
+`cargo xtask verify --skip-hub-build` at `b7e7c96a`: Rust build clean,
+**13740 Rust tests passed**. The hub-client vitest leg failed with 23 tests
+in 6 files, all `localStorage` undefined under Node v26.8.1 — environmental
+and unrelated to this strand; filed as **bd-lh30hlvd** (discovered-from this
+strand).
+
+## Proposed phases (draft)
+
+Skeleton only — contents wait on the design discussion.
+
+- **Phase 0 — Test plan (TDD).**
+  - Unit tests in `compile_theme_css.rs`: a custom theme whose `defaults`
+    break the grid arithmetic (`$grid-body-width: 52rem`) makes
+    `stage.run` return `Err(PipelineError::Structured)` with the new code and
+    a message containing the grass text (`Incompatible units`); the dark
+    variant (`theme: {light: cosmo, dark: [darkly, bad.scss]}`) fails the same
+    way and never stores `DEFAULT_CSS` under the dark key; an existing file
+    with no layer markers → its own code (folds in bd-qmpygp02); the
+    no-theme default bundle path is unchanged.
+  - `theme_diagnostic.rs` tests: new codes render with code + YAML span
+    (candidate: the `theme:` entry span) and span-less when no location.
+  - Integration test driving the real project render with the repro fixture
+    (copied under `crates/quarto-core/tests/fixtures/`), asserting the render
+    fails, the diagnostic carries the code, and no `DEFAULT_CSS`-sized
+    `quarto-theme-*.css` is written.
+  - Catalog/docs lint (`cargo xtask lint`) passes with the new codes.
+- **Phase 1 — Preserve `SassError` through the wrapper.** Change
+  `compile_with_doc_vars_via_runtime` (both cfgs) to
+  `Result<String, SassError>`; give `CompilationFailed` a `location:
+  Option<SourceInfo>` (and possibly a separate `excerpt`/`sass_location`
+  field) so `with_location` works for it.
+- **Phase 2 — Route the `Err` arm through `theme_diagnostic`.** Classify:
+  compile failure on the themed / brand / doc-vars path → structured hard
+  error with the first custom theme entry's span (from
+  `theme_locations`) as the location; `InvalidScssFile` → its own code;
+  decide the fate of the default-bundle and reveal fallbacks per question 1.
+- **Phase 3 — Catalog + docs.** New `Q-14-6` (and `Q-14-7` if split) in
+  `error_catalog.json`, pages under `docs/errors/theme/`, sidebar entries in
+  `docs/_quarto.yml`. Do not reuse retired `Q-14-3`.
+- **Phase 4 — End-to-end verification.** Re-run the repro through `q2
+  render`; record the diagnostic output here. Update bd-36vmz7nk with the
+  decision and close it; close bd-qmpygp02 if folded in.
+- **Phase 5 (optional, per question 2) — Layer provenance.** Track each
+  layer's line range in `assemble_scss` so a grass line inside a user layer
+  renders as `theme.scss:2`, and a line inside Quarto's layers renders as
+  "in Quarto's Bootstrap layer (triggered by your theme's defaults)".
+
+## Open design questions for the user
+
+1. **Posture (resolves bd-36vmz7nk).** Hard error for *any* compile failure
+   on the themed / brand / doc-vars path, i.e. whenever user-authored SCSS or
+   user-derived variables are in the bundle? I recommend yes (Q1 parity:
+   `Theme file compilation failed` is fatal there). And the two other
+   fallbacks — the no-user-input default bundle (`compile_default` →
+   `DEFAULT_CSS`) and the reveal path (→ vendored stock theme) — can only
+   fail on a Quarto bug or a broken install. Keep those as fallbacks but make
+   them a real `ctx.add_diagnostic` warning so the summary is not clean, or
+   make them hard errors too?
+2. **How much location to promise.** grass points at line 3269 of the
+   assembled bundle, at a Quarto-internal line, and never names the user's
+   file. Minimum viable: the diagnostic carries the grass message + excerpt
+   verbatim, with the YAML span of the `theme:` entry (or the whole `theme:`
+   list) as its location and a hint that the failing expression may be in
+   Quarto's own layer reacting to the theme's variables. Better: Phase 5's
+   provenance mapping so user-layer lines render as `theme.scss:N`. Do the
+   minimum now and file Phase 5 as a follow-up strand, or do both here?
+3. **Codes.** One new code `Q-14-6` "Theme SCSS compilation failed" for grass
+   errors, plus `Q-14-7` "Theme file has no layer boundary markers" for
+   `InvalidScssFile` / `NoBoundaryMarkers` (folding bd-qmpygp02 into this
+   strand since the wrapper change is shared)? Or keep bd-qmpygp02 separate
+   and ship only Q-14-6 here?
+4. **Which YAML span.** When the bundle has several custom entries
+   (`[cosmo, a.scss, b.scss]`) we cannot tell which one caused the failure.
+   Point at the first custom entry, at the whole `theme:` value, or emit no
+   span and rely on the message? (Q-14-4 points at the exact entry because it
+   knows which file is missing; here we do not.)
+5. **Multi-file projects.** The stage runs per document, and only successful
+   compiles are cached, so a 40-page website would print the same diagnostic
+   40 times. Accept for now (Q-14-4 already behaves this way), or dedupe by
+   fingerprint at the project level?
+6. **The silent-observer gap.** Every `trace_event!(Warn, …)` in the stage
+   is invisible on the CLI (no observer installed; `-v` filters do not match
+   `quarto_core` anyway). Separate strand to route `Warn` events to
+   `tracing::warn!` by default and widen the `-v` filter, or leave the
+   observer as a trace-only channel and require `ctx.add_diagnostic` for
+   anything user-facing?
+7. **Preview / WASM.** The same stage runs in the hub-client preview; a hard
+   error there replaces the unstyled-but-rendered page with an error card, as
+   Q-14-4 already does. Confirm that is acceptable for the preview too.
+
+## Risks / tradeoffs (draft)
+
+- **Surfacing currently-masked failures.** bd-36vmz7nk warned that flipping
+  the fallback may expose other silent compile failures on all platforms
+  (that was the reason for scoping it out of the CRLF fix). Rendering the
+  docs site and the in-tree fixtures with the change is the audit; anything
+  that turns red is a real bug we are shipping unstyled today.
+- **Misleading location.** If we attach the `theme:` span without the
+  "may be in Quarto's layer" hint, users will stare at a correct-looking
+  entry. The message must make the assembled-bundle nature clear.
+- **Cache interaction.** Only successful compiles are cached, so no stale-CSS
+  risk; but the fingerprinted `quarto-theme-<fp>.css` name means a previously
+  good render leaves an old file in `_site/site_libs` that the failed render
+  no longer references. Cosmetic.
+- **WASM cfg duplication.** The wrapper exists twice (native sync, wasm
+  async); both must change identically, and the wasm side cannot be run
+  locally on Windows (see `.claude/rules/wasm.md`).

--- a/claude-notes/plans/2026-09-08-theme-scss-compile-error-swallowed.md
+++ b/claude-notes/plans/2026-09-08-theme-scss-compile-error-swallowed.md
@@ -1,18 +1,194 @@
 # User theme .scss compile error is swallowed: page silently ships DEFAULT_CSS (bd-jsvetdea)
 
 **Date:** 2026-09-08
-**Braid:** bd-jsvetdea (bug, p2, labels: css, diagnostics, theming)
-**Checkout:** main checkout, branch `main` @ `b7e7c96a` (no worktree/branch created by the investigation)
-**Status:** Investigation — pending design alignment with user. **Do not start implementation until the user gives the go-ahead.**
+**Braid:** bd-jsvetdea (bug, p2, labels: css, diagnostics, theming). Folds in bd-qmpygp02; resolves bd-36vmz7nk.
+**Checkout:** main checkout, branch `main` @ `b7e7c96a`
+**Status:** Design settled with user 2026-09-08 (answers recorded below). Implemented and verified 2026-09-08; strands closed.
 
-## Triage verdict
+## Overview
 
-**Ready to design.** The symptom reproduces at HEAD exactly as filed, the
-swallow site is a single `Err` arm with an established structured-diagnostic
-neighbour (Q-14-4) two screens above it, and the two related strands
-(bd-36vmz7nk, bd-qmpygp02) are both resolved by the same change. The open
-questions are posture (hard error vs. loud warning) and how much source
-location to promise, not feasibility.
+A grass failure while compiling the theme bundle is caught in
+`variant_css` (`crates/quarto-core/src/stage/stages/compile_theme_css.rs`),
+logged as a `Warn` trace event, and replaced by the static ~7KB
+`DEFAULT_CSS`. The render reports success. The trace event goes to a
+`NoopObserver`, so nothing reaches the CLI at any verbosity. The same
+`Err` arm swallows `InvalidScssFile` (bd-qmpygp02), and the per-variant
+split means a failing dark compile ships *light* default CSS under the dark
+key.
+
+Fix: every theme compile failure becomes a structured hard error through
+`theme_diagnostic`, with two new codes. `DEFAULT_CSS` remains only for the
+explicit `theme: none` opt-out.
+
+## Design decisions (user answers, 2026-09-08)
+
+1. **Posture.** Compile errors are fatal. That includes the no-user-input
+   default bundle and the reveal path: those can only fail on a Quarto bug
+   or broken install, and a hard error is the right signal. Resolves
+   bd-36vmz7nk.
+2. **Location.** Minimum viable now: the diagnostic carries the grass
+   message and excerpt verbatim, anchored at the whole `theme:` value, with
+   a hint that the reported line is in Quarto's assembled bundle and may sit
+   in Quarto's own layer reacting to a theme variable. Layer-provenance line
+   mapping (assembled line → user file:line) is a follow-up strand; the
+   cross-tool source-tracking infrastructure is not there yet.
+3. **Codes.** `Q-14-6` "Theme SCSS compilation failed" (grass / dart-sass
+   errors and any other unclassified compile-path `SassError`), and
+   `Q-14-7` "Theme file has no layer boundary markers" (`InvalidScssFile`,
+   folding bd-qmpygp02 in). `Q-14-3` is retired and is not reused.
+4. **Span.** Point at the whole `theme:` value. For `Q-14-7` we know the
+   offending path, so point at that entry when it can be matched against
+   `theme_locations`, falling back to the whole value.
+5. **Multi-file projects.** `quarto-error-reporting::coalesce_by_source`
+   (bd-9hlja) already groups structured pass2 failures by resolved source
+   location, and `q2 render` runs it over `pass2_failures`. A `_quarto.yml`
+   span therefore collapses N pages into one report with an "Affected files"
+   tail. Phase 4 verifies this end to end; if it does not coalesce, file a
+   follow-up rather than hand-rolling dedup here.
+6. **Silent-observer gap.** Keep `trace_event!` as a trace-only channel and
+   use `ctx.add_diagnostic` for anything user-facing. The noise concern is
+   not really about volume (only 10 `Warn` sites exist, each fires only on a
+   failure); the stronger reason is that `add_diagnostic` feeds the summary
+   counts, `--warnings-as-errors`, JSON output, and coalescing, none of
+   which a routed `tracing::warn!` would. Follow-up strand: audit the
+   remaining `Warn` sites (bootstrap_js / tabsets_js "skipping", capture
+   splice parse failures) and the `-v` filter mismatch (`quarto=warn` does
+   not match `quarto_core` targets).
+7. **Preview / WASM.** A hard error in the hub-client preview replaces the
+   page with an error card, as Q-14-4 already does. Accepted.
+
+## Work items
+
+### Phase 0 — Tests (TDD; written first, verified failing)
+
+- [x] `theme_diagnostic.rs`: `Q-14-6` renders with code, grass text, and a
+      span at a `_quarto.yml` `theme:` value; span-less without a location.
+- [x] `theme_diagnostic.rs`: `Q-14-7` renders with code, the file path, and
+      a span; span-less without a location.
+- [x] `theme_diagnostic.rs`: catalog-registration test covers the new codes.
+- [x] `compile_theme_css.rs` unit: `theme: [cosmo, bad.scss]` where
+      `bad.scss` sets `$grid-body-width: 52rem` → `Err(Structured)` with
+      `Q-14-6`, message contains `Incompatible units`, no `css:theme:*`
+      artifact stored.
+- [x] `compile_theme_css.rs` unit: dark variant (`light: cosmo`,
+      `dark: [darkly, bad.scss]`) → same error; no `css:theme-dark:*`
+      artifact and no light artifact either.
+- [x] `compile_theme_css.rs` unit: an existing `.scss` with no layer markers
+      → `Err(Structured)` with `Q-14-7` naming the file.
+- [x] CLI e2e `crates/quarto/tests/integration/theme_compile_error.rs`
+      (registered in `main.rs`): single doc → exit non-zero, `Q-14-6` and
+      `Incompatible units` on stderr, no `doc.html`; no-markers file →
+      `Q-14-7`; two-page website with the theme in `_quarto.yml` → the grass
+      excerpt appears exactly once on stderr (coalesced).
+- [x] Run the new tests; confirm each fails for the expected reason
+      (exit 0 / `Ok(DEFAULT_CSS)` / code missing).
+
+### Phase 1 — Preserve `SassError` through the wrappers
+
+- [x] `compile_with_doc_vars_via_runtime`, `compile_default`,
+      `compile_reveal` (both cfgs each) return `Result<String, SassError>`.
+- [x] `SassError::InvalidScssFile` gains `location: Option<SourceInfo>`;
+      `with_location` covers it; the one constructor in `themes.rs` passes
+      `None`.
+- [x] `theme_diagnostic`: new arms for `InvalidScssFile` (`Q-14-7`) and the
+      compile-failure catch-all (`Q-14-6`), plus a
+      `sass_error_to_parse_error_at(err, fallback_location, candidates)`
+      entry point so the stage can anchor location-less variants at the
+      `theme:` value without adding a field to every `CompilationFailed`
+      constructor (32 sites).
+
+### Phase 2 — Route every compile `Err` arm to a structured error
+
+- [x] `run` computes the whole-`theme:` location from
+      `doc.ast.meta.get("theme")` and passes it into `variant_css` and the
+      reveal branch.
+- [x] `variant_css` themed path: `Err` → `PipelineError::Structured` via
+      `theme_diagnostic`; for `InvalidScssFile`, match the path against the
+      variant's custom entries to pick the precise `theme_locations[i]`.
+- [x] `variant_css` default-bundle path: `compile_default` `Err` →
+      `Q-14-6` hard error (hint says no user theme is configured, likely a
+      Quarto bug).
+- [x] Reveal branch: `compile_reveal` `Err` → `Q-14-6` hard error instead of
+      the vendored stock theme.
+- [x] Remove the now-dead `DEFAULT_CSS` fallbacks and update the doc
+      comments on `variant_css` / the module header.
+- [x] `cargo build --workspace` clean; `cargo xtask lint` clean.
+
+### Phase 3 — Catalog + docs
+
+- [x] `error_catalog.json`: `Q-14-6`, `Q-14-7` (subsystem `theme`).
+- [x] `docs/errors/theme/Q-14-6.qmd`, `Q-14-7.qmd` (template in
+      `docs/errors/README.md`).
+- [x] `docs/_quarto.yml` errors sidebar: add both entries in code order.
+- [x] `cargo xtask lint` (error-docs-page-missing, error-docs-sidebar-unlisted).
+
+### Phase 4 — End-to-end verification
+
+- [x] `cargo run --bin q2 -- render <repro>` fails with `Q-14-6`; record the
+      stderr in this plan.
+- [x] Two-page website repro: the diagnostic appears once with an "Affected
+      files" tail (coalescing works) — or file a follow-up.
+- [x] Render `docs/` with Q2 to check nothing currently masked turns red
+      (bd-36vmz7nk's audit concern). 271 of 271 pages render; the 36
+      warnings are pre-existing Q-13-4 missing-link warnings, no Q-14-6.
+- [x] `cargo nextest run --workspace` (13753 passed); clippy clean;
+      `cargo xtask lint` clean; hub-client `npm run build:all` (WASM leg)
+      succeeded. The hub-client vitest leg of `cargo xtask verify` is red
+      for the unrelated Node 26 `localStorage` issue (bd-lh30hlvd).
+- [x] Update bd-36vmz7nk (decision: fatal) and close; close bd-qmpygp02;
+      close bd-jsvetdea.
+
+### Follow-ups to file
+
+- [x] Layer provenance: map grass's assembled-bundle line back to
+      (layer, user file, line) so `Q-14-6` can say `theme.scss:2`.
+      Filed as bd-c1gf9xmk.
+- [x] Audit the remaining `trace_event!(Warn, …)` sites for user-facing
+      conditions that should be `ctx.add_diagnostic`; fix the `-v` filter
+      so `quarto_core` warnings are visible. Filed as bd-e1psgogt.
+
+## End-to-end verification record (2026-09-08)
+
+Invocation, after the fix, on the repro fixture (`theme: [cosmo, theme.scss]`,
+`$grid-body-width: 52rem`):
+
+```
+$ cargo run --bin q2 -- render claude-notes/plans/theme-scss-compile-error-swallowed-investigation/repro
+Rendering project: …/repro (type: website)
+error: while rendering …/repro/index.qmd
+Error: [Q-14-6] Theme SCSS compilation failed
+   ╭─[ …/repro/_quarto.yml:5:12 ]
+   │
+ 5 │     theme: [cosmo, theme.scss]
+   │            ─────────┬─────────
+   │                     ╰─────────── compiling the theme SCSS bundle failed:
+Error: Incompatible units px and rem.
+     ╷
+3269 │ $grid-body-column-min: quarto-math.min(500px, $grid-body-column-max) !default;
+     │                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     ╵
+./stdin:3269:24
+───╯
+ℹ Does a variable in a theme file set a value Bootstrap's arithmetic cannot use (…)? …
+
+Rendered 0 of 1 files to …/repro/_site — 1 error
+$ echo $?
+1
+```
+
+`_site/site_libs/quarto/` contains no `quarto-theme-*.css` (previously a
+6996-byte `DEFAULT_CSS`). Output inspected.
+
+Two-page website (same `_quarto.yml`, `index.qmd` + `about.qmd`): the block
+above prints **once**, followed by
+
+```
+Affected files: …/two/about.qmd, …/two/index.qmd
+Rendered 0 of 2 files to …/two/_site — 2 errors
+```
+
+so the source-location coalescing (bd-9hlja) covers this diagnostic with no
+extra work; no follow-up needed for design question 5.
 
 ## Issue context
 
@@ -44,69 +220,49 @@ strand *is* the discovery record). Three `related` edges:
   ships light `DEFAULT_CSS` under the dark key.
 - **bd-qmpygp02** (bug, p3, 2026-08-08) — `InvalidScssFile` (existing file,
   no layer markers) is swallowed by the same `Err` arm. Its fix shape is the
-  same wrapper change this strand needs: stop stringifying `SassError` in
-  `compile_with_doc_vars_via_runtime`, match variants, route through
-  `theme_diagnostic`. Discovered from bd-of20unsb (format-extension theme
-  rebase, still `in_progress`), which added the up-front Q-14-4 check.
+  same wrapper change this strand needs. Discovered from bd-of20unsb
+  (format-extension theme rebase, still `in_progress`), which added the
+  up-front Q-14-4 check.
 - **bd-5fseopxy** (bug, p2, same session) — brand font weight ranges collapse
   to 400; its typography-slot case emits `$font-weight-base: 400..700` and
-  then hits *this* fallback, so two silent failures stack. Independent fix,
-  but a useful second regression fixture for this strand.
+  then hits *this* fallback, so two silent failures stack. Independent fix.
 
 Related plans: `claude-notes/plans/2026-08-08-format-ext-theme-rebase.md`
 (Q-14-4 precedent), `claude-notes/plans/2026-08-14-light-dark-theme-epic.md`
 (variant_css split, phase E audit).
 
-## What the code looks like today
+## What the code looked like at investigation time
 
-All paths in the strand still exist; the area was refactored into
-`variant_css` by the light/dark epic but the swallow arm is unchanged.
-
-- `crates/quarto-core/src/stage/stages/compile_theme_css.rs:727-736` — the
-  `Err` arm: `trace_event!(Warn, "theme CSS compilation failed: {e}, using
-  default CSS")` then `Ok(DEFAULT_CSS)`.
+- `compile_theme_css.rs:727-736` — the `Err` arm: `trace_event!(Warn, "theme
+  CSS compilation failed: {e}, using default CSS")` then `Ok(DEFAULT_CSS)`.
 - `compile_theme_css.rs:1010-1032` — `compile_with_doc_vars_via_runtime`
   (native + wasm cfgs) maps `SassError` to `String`, discarding the variant.
 - `compile_theme_css.rs:617-630` — the *default bundle* path has its own
   identical fallback (`compile_default` failure → `DEFAULT_CSS`).
 - `compile_theme_css.rs:355-370` — the reveal path has a third one (compile
-  failure → vendored stock theme CSS). Same posture question.
+  failure → vendored stock theme CSS).
 - `compile_theme_css.rs:636-670` — the Q-14-4 precedent: up-front check,
   `SassError::CustomThemeNotFound { location }` →
   `theme_diagnostic::sass_error_to_parse_error` → `PipelineError::Structured`.
 - `crates/quarto-sass/src/error.rs:17-19` — `SassError::CompilationFailed {
-  message: String }` carries only the stringified grass error; no location
-  field, so `with_location` cannot attach a YAML span to it today.
-- `crates/quarto-sass/src/compile.rs:263-274` / `547-556` — the grass/dart
-  error is stringified into `CompilationFailed` at the crate boundary.
+  message: String }` carries only the stringified grass error.
 - `crates/quarto-core/src/theme_diagnostic.rs` — handles Q-14-1/2/4; the
-  catch-all arm for other variants renders a code-less error. Q-14-3 was
-  retired and removed from the catalog; Q-14-5 is the latest code.
+  catch-all arm renders a code-less error.
 
 ### Why nothing surfaces at any verbosity
-
-Two independent gaps, both confirmed by reading the wiring:
 
 1. `RenderContext` defaults to `NoopObserver`
    (`crates/quarto-core/src/render.rs:462`), and the CLI never installs
    another one. The only way to get a real observer is `trace: true` /
    `trace: summary` in document metadata
-   (`stage/stages/metadata_merge.rs:505-551`). So `trace_event!(Warn, …)` is
-   discarded before any log filter sees it.
-2. Even with `TracingObserver` (which maps `Warn` to `tracing::warn!`), the
-   `-v` filters are `quarto=warn,q2=warn` etc.
-   (`crates/quarto-util/src/verbose.rs:34-41`); those directives match the
-   `quarto` and `q2` targets, not `quarto_core`, so a warning emitted from
-   `quarto_core::stage::observer` would still be filtered.
-
-This means every "graceful fallback with a warning trace" in the stage is
-silent on the CLI, not just this one. Worth its own strand (see open
-question 6).
+   (`stage/stages/metadata_merge.rs:505-551`).
+2. Even with `TracingObserver`, the `-v` filters are `quarto=warn,q2=warn`
+   etc. (`crates/quarto-util/src/verbose.rs:34-41`); those match the
+   `quarto` and `q2` targets, not `quarto_core`.
 
 ### Repro at HEAD (confirmed 2026-09-08)
 
-Fixture: `claude-notes/plans/theme-scss-compile-error-swallowed-investigation/repro/`
-(`theme: [cosmo, theme.scss]`, no brand — the brand is not needed to trigger it).
+Fixture: `claude-notes/plans/theme-scss-compile-error-swallowed-investigation/repro/`.
 
 ```
 $ cargo run -q --bin q2 -- render claude-notes/plans/theme-scss-compile-error-swallowed-investigation/repro
@@ -116,10 +272,8 @@ $ ls -l repro/_site/site_libs/quarto/*.css
 -rw-r--r--  6996  quarto-theme-e6964ef56c8a5065.css      # "styles.css / Default styles for Quarto HTML documents"
 ```
 
-With `-vv`: only the `render_to_file` debug lines; no mention of the theme.
-Control (`$grid-body-width: 830px`): 325166-byte compiled bundle.
-
-With `trace: summary` added to `_quarto.yml`, the swallowed text is:
+Control (`$grid-body-width: 830px`): 325166-byte compiled bundle. With
+`trace: summary` in `_quarto.yml`, the swallowed text is:
 
 ```
 [trace] [warn] theme CSS compilation failed: SASS compilation failed: SASS compilation error: Error: Incompatible units px and rem.
@@ -131,124 +285,29 @@ With `trace: summary` added to `_quarto.yml`, the swallowed text is:
 , using default CSS
 ```
 
-**Important nuance for the design:** the strand says the grass error has "a
-precise Sass location". It does — but the location is line 3269 of the
-*assembled* bundle (`./stdin`), and the failing line is Quarto's own
-`$grid-body-column-min` default, not the user's `$grid-body-width` line.
-The user's file is not named anywhere in the message. Mapping the assembled
-line back to (layer, source file, line) would need provenance bookkeeping in
-`quarto_sass::bundle::assemble_scss`, which today just `push_str`s the layer
-sections in order. Q1 has the same limitation and deliberately truncates the
-dart-sass pointer to its temp file
-(`external-sources/quarto-cli/src/core/dart-sass.ts:141-146`), but Q1 *does*
-throw `"Theme file compilation failed:\n\n" + errMsg` — a hard error.
+The location is line 3269 of the *assembled* bundle (`./stdin`), at Quarto's
+own `$grid-body-column-min` default; the user's file is never named. Q1 has
+the same limitation and truncates the dart-sass pointer
+(`external-sources/quarto-cli/src/core/dart-sass.ts:141-146`) but throws
+`"Theme file compilation failed:\n\n" + errMsg` — a hard error.
 
 ### Pre-flight verify
 
 `cargo xtask verify --skip-hub-build` at `b7e7c96a`: Rust build clean,
-**13740 Rust tests passed**. The hub-client vitest leg failed with 23 tests
-in 6 files, all `localStorage` undefined under Node v26.8.1 — environmental
-and unrelated to this strand; filed as **bd-lh30hlvd** (discovered-from this
-strand).
+13740 Rust tests passed. The hub-client vitest leg failed with 23 tests in
+6 files, all `localStorage` undefined under Node v26.8.1 — environmental
+and unrelated; filed as bd-lh30hlvd.
 
-## Proposed phases (draft)
+## Risks / tradeoffs
 
-Skeleton only — contents wait on the design discussion.
-
-- **Phase 0 — Test plan (TDD).**
-  - Unit tests in `compile_theme_css.rs`: a custom theme whose `defaults`
-    break the grid arithmetic (`$grid-body-width: 52rem`) makes
-    `stage.run` return `Err(PipelineError::Structured)` with the new code and
-    a message containing the grass text (`Incompatible units`); the dark
-    variant (`theme: {light: cosmo, dark: [darkly, bad.scss]}`) fails the same
-    way and never stores `DEFAULT_CSS` under the dark key; an existing file
-    with no layer markers → its own code (folds in bd-qmpygp02); the
-    no-theme default bundle path is unchanged.
-  - `theme_diagnostic.rs` tests: new codes render with code + YAML span
-    (candidate: the `theme:` entry span) and span-less when no location.
-  - Integration test driving the real project render with the repro fixture
-    (copied under `crates/quarto-core/tests/fixtures/`), asserting the render
-    fails, the diagnostic carries the code, and no `DEFAULT_CSS`-sized
-    `quarto-theme-*.css` is written.
-  - Catalog/docs lint (`cargo xtask lint`) passes with the new codes.
-- **Phase 1 — Preserve `SassError` through the wrapper.** Change
-  `compile_with_doc_vars_via_runtime` (both cfgs) to
-  `Result<String, SassError>`; give `CompilationFailed` a `location:
-  Option<SourceInfo>` (and possibly a separate `excerpt`/`sass_location`
-  field) so `with_location` works for it.
-- **Phase 2 — Route the `Err` arm through `theme_diagnostic`.** Classify:
-  compile failure on the themed / brand / doc-vars path → structured hard
-  error with the first custom theme entry's span (from
-  `theme_locations`) as the location; `InvalidScssFile` → its own code;
-  decide the fate of the default-bundle and reveal fallbacks per question 1.
-- **Phase 3 — Catalog + docs.** New `Q-14-6` (and `Q-14-7` if split) in
-  `error_catalog.json`, pages under `docs/errors/theme/`, sidebar entries in
-  `docs/_quarto.yml`. Do not reuse retired `Q-14-3`.
-- **Phase 4 — End-to-end verification.** Re-run the repro through `q2
-  render`; record the diagnostic output here. Update bd-36vmz7nk with the
-  decision and close it; close bd-qmpygp02 if folded in.
-- **Phase 5 (optional, per question 2) — Layer provenance.** Track each
-  layer's line range in `assemble_scss` so a grass line inside a user layer
-  renders as `theme.scss:2`, and a line inside Quarto's layers renders as
-  "in Quarto's Bootstrap layer (triggered by your theme's defaults)".
-
-## Open design questions for the user
-
-1. **Posture (resolves bd-36vmz7nk).** Hard error for *any* compile failure
-   on the themed / brand / doc-vars path, i.e. whenever user-authored SCSS or
-   user-derived variables are in the bundle? I recommend yes (Q1 parity:
-   `Theme file compilation failed` is fatal there). And the two other
-   fallbacks — the no-user-input default bundle (`compile_default` →
-   `DEFAULT_CSS`) and the reveal path (→ vendored stock theme) — can only
-   fail on a Quarto bug or a broken install. Keep those as fallbacks but make
-   them a real `ctx.add_diagnostic` warning so the summary is not clean, or
-   make them hard errors too?
-2. **How much location to promise.** grass points at line 3269 of the
-   assembled bundle, at a Quarto-internal line, and never names the user's
-   file. Minimum viable: the diagnostic carries the grass message + excerpt
-   verbatim, with the YAML span of the `theme:` entry (or the whole `theme:`
-   list) as its location and a hint that the failing expression may be in
-   Quarto's own layer reacting to the theme's variables. Better: Phase 5's
-   provenance mapping so user-layer lines render as `theme.scss:N`. Do the
-   minimum now and file Phase 5 as a follow-up strand, or do both here?
-3. **Codes.** One new code `Q-14-6` "Theme SCSS compilation failed" for grass
-   errors, plus `Q-14-7` "Theme file has no layer boundary markers" for
-   `InvalidScssFile` / `NoBoundaryMarkers` (folding bd-qmpygp02 into this
-   strand since the wrapper change is shared)? Or keep bd-qmpygp02 separate
-   and ship only Q-14-6 here?
-4. **Which YAML span.** When the bundle has several custom entries
-   (`[cosmo, a.scss, b.scss]`) we cannot tell which one caused the failure.
-   Point at the first custom entry, at the whole `theme:` value, or emit no
-   span and rely on the message? (Q-14-4 points at the exact entry because it
-   knows which file is missing; here we do not.)
-5. **Multi-file projects.** The stage runs per document, and only successful
-   compiles are cached, so a 40-page website would print the same diagnostic
-   40 times. Accept for now (Q-14-4 already behaves this way), or dedupe by
-   fingerprint at the project level?
-6. **The silent-observer gap.** Every `trace_event!(Warn, …)` in the stage
-   is invisible on the CLI (no observer installed; `-v` filters do not match
-   `quarto_core` anyway). Separate strand to route `Warn` events to
-   `tracing::warn!` by default and widen the `-v` filter, or leave the
-   observer as a trace-only channel and require `ctx.add_diagnostic` for
-   anything user-facing?
-7. **Preview / WASM.** The same stage runs in the hub-client preview; a hard
-   error there replaces the unstyled-but-rendered page with an error card, as
-   Q-14-4 already does. Confirm that is acceptable for the preview too.
-
-## Risks / tradeoffs (draft)
-
-- **Surfacing currently-masked failures.** bd-36vmz7nk warned that flipping
-  the fallback may expose other silent compile failures on all platforms
-  (that was the reason for scoping it out of the CRLF fix). Rendering the
-  docs site and the in-tree fixtures with the change is the audit; anything
-  that turns red is a real bug we are shipping unstyled today.
-- **Misleading location.** If we attach the `theme:` span without the
-  "may be in Quarto's layer" hint, users will stare at a correct-looking
-  entry. The message must make the assembled-bundle nature clear.
-- **Cache interaction.** Only successful compiles are cached, so no stale-CSS
-  risk; but the fingerprinted `quarto-theme-<fp>.css` name means a previously
-  good render leaves an old file in `_site/site_libs` that the failed render
-  no longer references. Cosmetic.
-- **WASM cfg duplication.** The wrapper exists twice (native sync, wasm
-  async); both must change identically, and the wasm side cannot be run
-  locally on Windows (see `.claude/rules/wasm.md`).
+- **Surfacing currently-masked failures.** Flipping the fallback may expose
+  other silent compile failures. Rendering `docs/` and the in-tree fixtures
+  is the audit (Phase 4); anything that turns red is a real bug shipping
+  unstyled today.
+- **Misleading location.** The `theme:` span is where the user *configured*
+  the theme, not where the failure is. The hint must make the
+  assembled-bundle nature clear.
+- **Cache interaction.** Only successful compiles are cached, so no
+  stale-CSS risk.
+- **WASM cfg duplication.** Each wrapper exists twice; both must change
+  identically.

--- a/claude-notes/plans/theme-scss-compile-error-swallowed-investigation/repro/.gitignore
+++ b/claude-notes/plans/theme-scss-compile-error-swallowed-investigation/repro/.gitignore
@@ -1,0 +1,2 @@
+_site/
+.quarto/

--- a/claude-notes/plans/theme-scss-compile-error-swallowed-investigation/repro/README.md
+++ b/claude-notes/plans/theme-scss-compile-error-swallowed-investigation/repro/README.md
@@ -1,0 +1,13 @@
+# Repro fixture for bd-jsvetdea
+
+`theme.scss` sets `$grid-body-width: 52rem`. The Bootstrap grid mixins do
+`calc(... - 3em)`-style arithmetic that grass rejects for `rem`, so the theme
+compile fails. At HEAD the render reports success and ships the ~7KB
+`DEFAULT_CSS` instead of the compiled Bootstrap bundle.
+
+Run from the repo root:
+
+    cargo run --bin q2 -- render claude-notes/plans/theme-scss-compile-error-swallowed-investigation/repro
+    ls -l claude-notes/plans/theme-scss-compile-error-swallowed-investigation/repro/_site/site_libs/quarto/
+
+`_site/` is gitignored via the `.gitignore` next to this file.

--- a/claude-notes/plans/theme-scss-compile-error-swallowed-investigation/repro/_quarto.yml
+++ b/claude-notes/plans/theme-scss-compile-error-swallowed-investigation/repro/_quarto.yml
@@ -1,0 +1,5 @@
+project:
+  type: website
+format:
+  html:
+    theme: [cosmo, theme.scss]

--- a/claude-notes/plans/theme-scss-compile-error-swallowed-investigation/repro/index.qmd
+++ b/claude-notes/plans/theme-scss-compile-error-swallowed-investigation/repro/index.qmd
@@ -1,0 +1,5 @@
+---
+title: Repro for bd-jsvetdea
+---
+
+A one-line unit mistake in `theme.scss` should surface as a diagnostic.

--- a/claude-notes/plans/theme-scss-compile-error-swallowed-investigation/repro/theme.scss
+++ b/claude-notes/plans/theme-scss-compile-error-swallowed-investigation/repro/theme.scss
@@ -1,0 +1,2 @@
+/*-- scss:defaults --*/
+$grid-body-width: 52rem;

--- a/crates/quarto-core/src/stage/stages/compile_theme_css.rs
+++ b/crates/quarto-core/src/stage/stages/compile_theme_css.rs
@@ -304,6 +304,12 @@ impl PipelineStage for CompileThemeCssStage {
             ));
         };
 
+        // The span of the whole `theme:` value. Compile failures carry
+        // no location of their own (grass points into the assembled
+        // bundle), so their structured diagnostic anchors here
+        // (bd-jsvetdea). `None` for documents without a `theme:` key.
+        let theme_location = doc.ast.meta.get("theme").map(|v| v.source_info.clone());
+
         // `format: revealjs` uses its own reveal.js CSS + theme, not Bootstrap.
         // A reveal theme name like `white` is not a Bootswatch theme — running
         // the Bootstrap path would mis-validate it. Instead, register reveal's
@@ -353,22 +359,13 @@ impl PipelineStage for CompileThemeCssStage {
 
             // Compile Quarto's reveal theme (single unified SCSS pass, D1) and
             // register it as the theme-slot artifact (keyed by content
-            // fingerprint). On a *compile* failure we fall back to the vendored
-            // stock theme CSS so the deck still renders (mirrors the Bootstrap
-            // path's graceful fallback).
-            let compiled =
-                match compile_reveal(ctx, true, &resolution.layers, &resolution.load_paths).await {
-                    Ok(css) => Some(css),
-                    Err(e) => {
-                        trace_event!(
-                            ctx,
-                            EventLevel::Warn,
-                            "reveal theme compilation failed: {}, using vendored stock theme",
-                            e
-                        );
-                        None
-                    }
-                };
+            // fingerprint). A compile failure is a structured hard error
+            // (Q-14-6), same as the Bootstrap path — it used to fall back
+            // to the vendored stock theme with only a trace-level warning,
+            // which no CLI observer receives (bd-jsvetdea).
+            let compiled = compile_reveal(ctx, true, &resolution.layers, &resolution.load_paths)
+                .await
+                .map_err(|e| structured_compile_error(ctx, &e, theme_location.clone()))?;
             // Render (`revealjs`) links the full vendored asset set
             // (reset/reveal/theme/quarto-reveal + reveal.js) via `site_libs`;
             // the assembler emits `<link>`s in cascade order. Preview
@@ -380,11 +377,9 @@ impl PipelineStage for CompileThemeCssStage {
             // preview's theme transport verbatim — no preview-specific WASM
             // plumbing (bd-y259zb57).
             if ctx.format.target_format == "q2-slides" {
-                let theme_css = compiled
-                    .unwrap_or_else(|| crate::revealjs::stock_reveal_theme_css().to_string());
-                store_css(ctx, theme_css);
+                store_css(ctx, compiled);
             } else {
-                crate::revealjs::register_reveal_assets(&mut ctx.artifacts, compiled.as_deref());
+                crate::revealjs::register_reveal_assets(&mut ctx.artifacts, Some(&compiled));
             }
             return Ok(PipelineData::DocumentAst(doc));
         }
@@ -513,7 +508,15 @@ impl PipelineStage for CompileThemeCssStage {
             theme_context = theme_context.with_brand(&rb.brand, brand_dir);
         }
 
-        let light_css = variant_css(ctx, theme_config, &theme_context, &doc_vars, cache_ok).await?;
+        let light_css = variant_css(
+            ctx,
+            theme_config,
+            &theme_context,
+            &doc_vars,
+            cache_ok,
+            theme_location.as_ref(),
+        )
+        .await?;
 
         if let Some(dark_cfg) = theme_config.dark_variant() {
             let mut dark_context = ThemeContext::new(document_dir, runtime.as_ref());
@@ -521,7 +524,15 @@ impl PipelineStage for CompileThemeCssStage {
                 let brand_dir = rb.dir.clone().unwrap_or_else(|| ctx.project.dir.clone());
                 dark_context = dark_context.with_brand(&rb.brand, brand_dir);
             }
-            let dark_css = variant_css(ctx, &dark_cfg, &dark_context, &doc_vars, cache_ok).await?;
+            let dark_css = variant_css(
+                ctx,
+                &dark_cfg,
+                &dark_context,
+                &doc_vars,
+                cache_ok,
+                theme_location.as_ref(),
+            )
+            .await?;
             let dark_is_default = theme_config.dark.as_ref().is_some_and(|d| d.is_default);
             store_variant_pair(ctx, light_css, dark_css, dark_is_default);
             // Record the pair decision where the downstream consumers
@@ -553,15 +564,23 @@ impl PipelineStage for CompileThemeCssStage {
 /// result under the variant's key — but reads/writes the runtime CSS
 /// cache and emits trace events.
 ///
-/// Error contract mirrors the pre-A2 single-variant behavior:
-/// dangling custom themes are structured Q-14-4 errors; compile
-/// failures degrade to `DEFAULT_CSS` with a warning trace.
+/// Error contract: every failure is a structured hard error.
+/// Dangling custom themes are Q-14-4; a theme file without layer
+/// markers is Q-14-7; any other compile failure (grass / dart-sass,
+/// on the themed *or* the default-bundle path) is Q-14-6, anchored at
+/// `theme_location` — the whole `theme:` value — since the compiler
+/// only knows lines of the assembled bundle. Compile failures used to
+/// degrade to `DEFAULT_CSS` with a trace-level warning that no CLI
+/// observer receives, so a one-line unit mistake in a user theme
+/// silently shipped an unstyled page (bd-jsvetdea, bd-qmpygp02,
+/// decision recorded in bd-36vmz7nk).
 async fn variant_css(
     ctx: &mut StageContext,
     variant_config: &ThemeConfig,
     theme_context: &ThemeContext<'_>,
     doc_vars: &SassLayer,
     cache_ok: bool,
+    theme_location: Option<&quarto_source_map::SourceInfo>,
 ) -> Result<String, PipelineError> {
     // `theme: none` (for this variant) → the static lightweight
     // DEFAULT_CSS without compiling Bootstrap. Explicit opt-out.
@@ -619,15 +638,10 @@ async fn variant_css(
                 }
                 Ok(css)
             }
-            Err(e) => {
-                trace_event!(
-                    ctx,
-                    EventLevel::Warn,
-                    "default Bootstrap compilation failed: {}, using static DEFAULT_CSS",
-                    e
-                );
-                Ok(DEFAULT_CSS.to_string())
-            }
+            // No user input is in this bundle, so a failure here is a
+            // Quarto bug or a broken install — still a hard error, not
+            // a silent downgrade to the static DEFAULT_CSS.
+            Err(e) => Err(structured_compile_error(ctx, &e, theme_location.cloned())),
         };
     }
 
@@ -726,14 +740,56 @@ async fn variant_css(
             Ok(css)
         }
         Err(e) => {
-            trace_event!(
-                ctx,
-                EventLevel::Warn,
-                "theme CSS compilation failed: {}, using default CSS",
-                e
-            );
-            Ok(DEFAULT_CSS.to_string())
+            let e = attach_entry_location(e, variant_config, theme_context);
+            Err(structured_compile_error(ctx, &e, theme_location.cloned()))
         }
+    }
+}
+
+/// Lift a compile-path [`quarto_sass::SassError`] into the structured
+/// hard error every theme failure is (bd-jsvetdea): Q-14-6 / Q-14-7
+/// via `theme_diagnostic`, anchored at `location` (the whole `theme:`
+/// value) when the error carries no span of its own.
+fn structured_compile_error(
+    ctx: &StageContext,
+    err: &quarto_sass::SassError,
+    location: Option<quarto_source_map::SourceInfo>,
+) -> PipelineError {
+    let pe = crate::theme_diagnostic::sass_error_to_parse_error_at(
+        err,
+        location,
+        &theme_error_candidates(ctx),
+    );
+    PipelineError::Structured(pe)
+}
+
+/// Give an [`quarto_sass::SassError::InvalidScssFile`] the span of the
+/// `theme:` entry that named it, when its resolved path matches one of
+/// the variant's custom entries (the loader only knows the path). Any
+/// other error, or an unmatched path, passes through unchanged and
+/// falls back to the whole-`theme:` anchor.
+fn attach_entry_location(
+    err: quarto_sass::SassError,
+    config: &ThemeConfig,
+    context: &ThemeContext<'_>,
+) -> quarto_sass::SassError {
+    let entry_location = match &err {
+        quarto_sass::SassError::InvalidScssFile {
+            path,
+            location: None,
+        } => config.themes.iter().enumerate().find_map(|(i, spec)| {
+            let custom = spec.as_custom()?;
+            if context.resolve_path(custom) == *path {
+                config.theme_locations.get(i).cloned().flatten()
+            } else {
+                None
+            }
+        }),
+        _ => None,
+    };
+    match entry_location {
+        Some(loc) => err.with_location(loc),
+        None => err,
     }
 }
 
@@ -966,15 +1022,19 @@ fn store_variant_pair(
 /// Native uses `grass` in-process (sync); WASM uses the dart-sass JS bridge
 /// (async). This wrapper gives the stage one call site.
 #[cfg(not(target_arch = "wasm32"))]
-async fn compile_default(ctx: &StageContext, minified: bool) -> Result<String, String> {
-    compile_default_css(ctx.runtime.as_ref(), minified).map_err(|e| e.to_string())
+async fn compile_default(
+    ctx: &StageContext,
+    minified: bool,
+) -> Result<String, quarto_sass::SassError> {
+    compile_default_css(ctx.runtime.as_ref(), minified)
 }
 
 #[cfg(target_arch = "wasm32")]
-async fn compile_default(ctx: &StageContext, minified: bool) -> Result<String, String> {
-    compile_default_css(ctx.runtime.as_ref(), minified)
-        .await
-        .map_err(|e| e.to_string())
+async fn compile_default(
+    ctx: &StageContext,
+    minified: bool,
+) -> Result<String, quarto_sass::SassError> {
+    compile_default_css(ctx.runtime.as_ref(), minified).await
 }
 
 /// Compile Quarto's reveal.js theme CSS. Native uses `grass` in-process (sync);
@@ -986,9 +1046,8 @@ async fn compile_reveal(
     minified: bool,
     theme_layers: &[SassLayer],
     load_paths: &[PathBuf],
-) -> Result<String, String> {
+) -> Result<String, quarto_sass::SassError> {
     quarto_sass::compile_reveal_theme_css(ctx.runtime.as_ref(), minified, theme_layers, load_paths)
-        .map_err(|e| e.to_string())
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -997,10 +1056,9 @@ async fn compile_reveal(
     minified: bool,
     theme_layers: &[SassLayer],
     load_paths: &[PathBuf],
-) -> Result<String, String> {
+) -> Result<String, quarto_sass::SassError> {
     quarto_sass::compile_reveal_theme_css(ctx.runtime.as_ref(), minified, theme_layers, load_paths)
         .await
-        .map_err(|e| e.to_string())
 }
 
 /// Compile a (possibly themed) bundle plus an optional doc-derived
@@ -1012,10 +1070,9 @@ async fn compile_with_doc_vars_via_runtime(
     theme_config: &ThemeConfig,
     theme_context: &ThemeContext<'_>,
     doc_vars: &SassLayer,
-) -> Result<String, String> {
+) -> Result<String, quarto_sass::SassError> {
     let _ = ctx; // runtime is captured inside theme_context
     quarto_sass::compile_with_doc_vars(theme_config, theme_context, doc_vars)
-        .map_err(|e| e.to_string())
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -1024,11 +1081,9 @@ async fn compile_with_doc_vars_via_runtime(
     theme_config: &ThemeConfig,
     theme_context: &ThemeContext<'_>,
     doc_vars: &SassLayer,
-) -> Result<String, String> {
+) -> Result<String, quarto_sass::SassError> {
     let _ = ctx; // runtime is captured inside theme_context
-    quarto_sass::compile_with_doc_vars(theme_config, theme_context, doc_vars)
-        .await
-        .map_err(|e| e.to_string())
+    quarto_sass::compile_with_doc_vars(theme_config, theme_context, doc_vars).await
 }
 
 #[cfg(test)]
@@ -1918,6 +1973,186 @@ mod tests {
             css.contains(".custom-rule"),
             "compiled CSS should contain .custom-rule from override.scss"
         );
+    }
+
+    // ── Compile failures are structured hard errors (bd-jsvetdea) ────
+
+    /// A well-formed layered theme whose one variable breaks the
+    /// Bootstrap grid arithmetic (`calc(... - 3em)` on a `rem` value
+    /// makes grass raise "Incompatible units px and rem"). This is the
+    /// bd-jsvetdea repro verbatim.
+    const BAD_UNITS_SCSS: &str = "/*-- scss:defaults --*/\n$grid-body-width: 52rem;\n";
+
+    /// A file that exists but has no `/*-- scss:... --*/` layer marker
+    /// (bd-qmpygp02).
+    const NO_MARKERS_SCSS: &str = ".plain-marker { color: #0a1b2c; }\n";
+
+    /// Write theme files into a fresh temp dir; returns the guard and
+    /// the canonical dir path (macOS `/tmp` is a symlink, and the stage
+    /// resolves custom themes against the document dir).
+    fn temp_theme_dir(files: &[(&str, &str)]) -> (tempfile::TempDir, PathBuf) {
+        let temp = tempfile::TempDir::new().unwrap();
+        let dir = temp.path().canonicalize().unwrap();
+        for (name, contents) in files {
+            std::fs::write(dir.join(name), contents).unwrap();
+        }
+        (temp, dir)
+    }
+
+    /// `theme: {light: [..], dark: [..]}` with arbitrary lists on each
+    /// side (the single-name helper above cannot express a custom
+    /// entry in the dark half).
+    fn meta_with_light_dark_theme_lists(light: &[&str], dark: &[&str]) -> ConfigValue {
+        let list = |names: &[&str]| ConfigValue {
+            value: ConfigValueKind::Array(
+                names
+                    .iter()
+                    .map(|s| ConfigValue {
+                        value: ConfigValueKind::scalar(Yaml::String(s.to_string())),
+                        source_info: SourceInfo::for_test(),
+                        merge_op: quarto_pandoc_types::MergeOp::Concat,
+                    })
+                    .collect(),
+            ),
+            source_info: SourceInfo::for_test(),
+            merge_op: quarto_pandoc_types::MergeOp::Concat,
+        };
+        let entry = |key: &str, value: ConfigValue| ConfigMapEntry {
+            key: key.to_string(),
+            key_source: SourceInfo::for_test(),
+            value,
+        };
+        let theme_value = ConfigValue {
+            value: ConfigValueKind::Map(vec![
+                entry("light", list(light)),
+                entry("dark", list(dark)),
+            ]),
+            source_info: SourceInfo::for_test(),
+            merge_op: quarto_pandoc_types::MergeOp::Concat,
+        };
+        ConfigValue {
+            value: ConfigValueKind::Map(vec![entry("theme", theme_value)]),
+            source_info: SourceInfo::for_test(),
+            merge_op: quarto_pandoc_types::MergeOp::Concat,
+        }
+    }
+
+    /// Unwrap a `PipelineError::Structured` carrying exactly one
+    /// diagnostic with the given code; returns its rendered text.
+    fn expect_structured(err: PipelineError, code: &str) -> String {
+        match err {
+            PipelineError::Structured(pe) => {
+                assert_eq!(
+                    pe.diagnostics.len(),
+                    1,
+                    "expected exactly one diagnostic, got {:?}",
+                    pe.diagnostics
+                );
+                let d = &pe.diagnostics[0];
+                assert_eq!(
+                    d.code.as_deref(),
+                    Some(code),
+                    "diagnostic: {}",
+                    d.to_text(None)
+                );
+                let opts = quarto_error_reporting::TextRenderOptions {
+                    enable_hyperlinks: false,
+                };
+                d.to_text_with_options(Some(&pe.source_context), &opts)
+            }
+            other => panic!("expected PipelineError::Structured, got: {other}"),
+        }
+    }
+
+    fn assert_no_theme_artifacts(ctx: &StageContext) {
+        assert!(
+            ctx.artifacts.get_by_prefix("css:theme:").is_empty(),
+            "a failed compile must not store a css:theme:* artifact"
+        );
+        assert!(
+            ctx.artifacts.get_by_prefix("css:theme-dark:").is_empty(),
+            "a failed compile must not store a css:theme-dark:* artifact"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_theme_compile_error_is_structured_q146() {
+        // bd-jsvetdea: before the fix the Err arm returned
+        // Ok(DEFAULT_CSS) and the render reported success. A grass
+        // failure with a user theme in the bundle must be a Q-14-6
+        // hard error carrying the grass text.
+        let (_temp, dir) = temp_theme_dir(&[("bad.scss", BAD_UNITS_SCSS)]);
+        let runtime: Arc<dyn quarto_system_runtime::SystemRuntime> =
+            Arc::new(quarto_system_runtime::NativeRuntime::new());
+        let mut ctx = make_stage_context_at(runtime, dir.to_str().unwrap());
+        let stage = CompileThemeCssStage::new();
+
+        let meta = meta_with_theme_array(&["cosmo", "bad.scss"]);
+        let input = make_doc_ast_at(dir.join("test.qmd").to_str().unwrap(), meta);
+        let err = stage
+            .run(input, &mut ctx)
+            .await
+            .expect_err("a theme compile failure must fail the stage");
+
+        let text = expect_structured(err, "Q-14-6");
+        assert!(
+            text.contains("Incompatible units px and rem"),
+            "diagnostic must carry the grass message:\n{text}"
+        );
+        assert_no_theme_artifacts(&ctx);
+    }
+
+    #[tokio::test]
+    async fn test_dark_variant_compile_error_is_structured_q146() {
+        // The per-variant split (bd-0pic6 A2) used to ship *light*
+        // DEFAULT_CSS under the dark key when the dark half failed.
+        // A dark-half failure is the same hard error, and neither
+        // variant's artifact is stored.
+        let (_temp, dir) = temp_theme_dir(&[("bad.scss", BAD_UNITS_SCSS)]);
+        let runtime: Arc<dyn quarto_system_runtime::SystemRuntime> =
+            Arc::new(quarto_system_runtime::NativeRuntime::new());
+        let mut ctx = make_stage_context_at(runtime, dir.to_str().unwrap());
+        let stage = CompileThemeCssStage::new();
+
+        let meta = meta_with_light_dark_theme_lists(&["cosmo"], &["darkly", "bad.scss"]);
+        let input = make_doc_ast_at(dir.join("test.qmd").to_str().unwrap(), meta);
+        let err = stage
+            .run(input, &mut ctx)
+            .await
+            .expect_err("a dark-variant compile failure must fail the stage");
+
+        let text = expect_structured(err, "Q-14-6");
+        assert!(
+            text.contains("Incompatible units px and rem"),
+            "diagnostic must carry the grass message:\n{text}"
+        );
+        assert_no_theme_artifacts(&ctx);
+    }
+
+    #[tokio::test]
+    async fn test_theme_without_layer_markers_is_structured_q147() {
+        // bd-qmpygp02: a theme file that exists but has no layer
+        // markers was swallowed by the same Err arm. It is a Q-14-7
+        // hard error naming the file.
+        let (_temp, dir) = temp_theme_dir(&[("nomarkers.scss", NO_MARKERS_SCSS)]);
+        let runtime: Arc<dyn quarto_system_runtime::SystemRuntime> =
+            Arc::new(quarto_system_runtime::NativeRuntime::new());
+        let mut ctx = make_stage_context_at(runtime, dir.to_str().unwrap());
+        let stage = CompileThemeCssStage::new();
+
+        let meta = meta_with_theme_array(&["cosmo", "nomarkers.scss"]);
+        let input = make_doc_ast_at(dir.join("test.qmd").to_str().unwrap(), meta);
+        let err = stage
+            .run(input, &mut ctx)
+            .await
+            .expect_err("a theme file without layer markers must fail the stage");
+
+        let text = expect_structured(err, "Q-14-7");
+        assert!(
+            text.contains("nomarkers.scss"),
+            "diagnostic must name the offending file:\n{text}"
+        );
+        assert_no_theme_artifacts(&ctx);
     }
 
     fn make_builtin_config(theme: &str, minified: bool) -> ThemeConfig {

--- a/crates/quarto-core/src/theme_diagnostic.rs
+++ b/crates/quarto-core/src/theme_diagnostic.rs
@@ -42,10 +42,13 @@ use crate::error::ParseError;
 /// candidate whose FileId equals the one on the diagnostic and
 /// loads its file content into the [`SourceContext`].
 ///
-/// Handles [`SassError::InvalidThemeConfig`] (Q-14-1) and
-/// [`SassError::UnknownTheme`] (Q-14-2) specifically; other
-/// variants fall back to a span-less diagnostic carrying the raw
-/// error message.
+/// Handles [`SassError::InvalidThemeConfig`] (Q-14-1),
+/// [`SassError::UnknownTheme`] (Q-14-2),
+/// [`SassError::CustomThemeNotFound`] (Q-14-4), and
+/// [`SassError::InvalidScssFile`] (Q-14-7) specifically; every other
+/// variant is a compile failure and renders as Q-14-6 carrying the
+/// compiler's text (see [`sass_error_to_parse_error_at`] for how it
+/// gets a location).
 ///
 /// If no candidate matches the diagnostic's FileId, or the error
 /// has no `location`, the diagnostic still renders — just without
@@ -54,7 +57,26 @@ pub fn sass_error_to_parse_error(
     err: &SassError,
     candidate_sources: &[(FileId, PathBuf)],
 ) -> ParseError {
-    let location = sass_error_location(err);
+    sass_error_to_parse_error_at(err, None, candidate_sources)
+}
+
+/// [`sass_error_to_parse_error`] with a fallback location for
+/// variants that carry none of their own.
+///
+/// A compile failure ([`SassError::CompilationFailed`]) is the
+/// crate-boundary stringification of a grass / dart-sass error: it
+/// points into the *assembled* SCSS bundle, never into user YAML, so
+/// the variant has no `location` field. The stage that knows which
+/// `theme:` value triggered the compile passes that value's span as
+/// `fallback_location`, and the diagnostic anchors there
+/// (bd-jsvetdea). A variant that already carries a span keeps it —
+/// the fallback only fills in `None`.
+pub fn sass_error_to_parse_error_at(
+    err: &SassError,
+    fallback_location: Option<quarto_source_map::SourceInfo>,
+    candidate_sources: &[(FileId, PathBuf)],
+) -> ParseError {
+    let location = sass_error_location(err).or(fallback_location);
 
     // Candidate-matched binding via the shared helper (this function
     // was the original precedent for it; bd-m6wmztln → bd-r64mj1aa):
@@ -115,16 +137,74 @@ pub fn sass_error_to_parse_error(
             }
             b.build()
         }
-        // Fallback for SassError variants we haven't migrated yet.
-        // Returning *something* structured is better than the legacy
-        // plain `e.to_string()` form — no code is assigned because
-        // the catalog only covers migrated variants.
-        other => DiagnosticMessageBuilder::error("SASS error")
-            .problem(other.to_string())
-            .build(),
+        SassError::InvalidScssFile { path, .. } => {
+            let mut b = DiagnosticMessageBuilder::error("Theme file has no layer boundary markers")
+                .with_code("Q-14-7")
+                .problem(format!(
+                    "the `theme:` entry resolves to `{}`, which contains none of the \
+                     `/*-- scss:... --*/` layer boundary markers Quarto needs to merge it \
+                     into the Bootstrap bundle.",
+                    path.display()
+                ))
+                .add_hint(
+                    "Should the file start with a layer marker such as \
+                     `/*-- scss:defaults --*/` (variables) or `/*-- scss:rules --*/` (CSS \
+                     rules)? The other markers are `scss:uses`, `scss:functions`, and \
+                     `scss:mixins`. A plain stylesheet with no Sass in it can be listed \
+                     under `css:` instead of `theme:`.",
+                );
+            if let Some(loc) = &location {
+                b = b.with_location(loc.clone());
+            }
+            b.build()
+        }
+        // Everything else reaches us from the compile call itself:
+        // `CompilationFailed` (the grass / dart-sass error, pointing
+        // into the assembled bundle), `NoBoundaryMarkers` from a
+        // built-in layer, `ThemeNotFound` for a missing embedded
+        // resource, `Io`. None of these carry a span of their own, so
+        // the caller's fallback location (the `theme:` value) is the
+        // anchor (bd-jsvetdea).
+        other => {
+            let mut b = DiagnosticMessageBuilder::error("Theme SCSS compilation failed")
+                .with_code("Q-14-6")
+                .problem(format!(
+                    "compiling the theme SCSS bundle failed:\n{}",
+                    compile_failure_text(other)
+                ))
+                .add_hint(
+                    "Does a variable in a theme file set a value Bootstrap's arithmetic \
+                     cannot use (a `rem` layout width, a non-numeric font weight)? The \
+                     reported line counts lines of the SCSS bundle Quarto assembles from \
+                     Bootstrap, its own layers, and the files under `theme:`, so it often \
+                     points into Quarto's own code reacting to a theme variable rather than \
+                     at your file. If no custom theme or brand is configured, this is likely \
+                     a Quarto bug; please report it.",
+                );
+            if let Some(loc) = &location {
+                b = b.with_location(loc.clone());
+            }
+            b.build()
+        }
     };
 
     ParseError::new(vec![diagnostic], source_context)
+}
+
+/// The text a compile failure shows the user: the grass / dart-sass
+/// output verbatim (message, excerpt, and its `./stdin:LINE:COL`
+/// pointer into the assembled bundle), minus the runtime's own
+/// `SASS compilation error:` prefix, which would otherwise repeat
+/// the diagnostic title. Other variants render their `Display` form.
+fn compile_failure_text(err: &SassError) -> String {
+    match err {
+        SassError::CompilationFailed { message } => message
+            .strip_prefix("SASS compilation error: ")
+            .unwrap_or(message)
+            .trim_end()
+            .to_string(),
+        other => other.to_string(),
+    }
 }
 
 /// Extract the source location carried by a [`SassError`], if any.
@@ -136,6 +216,7 @@ fn sass_error_location(err: &SassError) -> Option<quarto_source_map::SourceInfo>
         SassError::InvalidThemeConfig { location, .. } => location.clone(),
         SassError::UnknownTheme { location, .. } => location.clone(),
         SassError::CustomThemeNotFound { location, .. } => location.clone(),
+        SassError::InvalidScssFile { location, .. } => location.clone(),
         _ => None,
     }
 }
@@ -294,7 +375,7 @@ mod tests {
         // (Q-14-3, the interim dark-theme-ignored warning from
         // bd-o76p01wb, was retired when dual light/dark compilation
         // landed — bd-0pic6 phase A2.)
-        for code in ["Q-14-1", "Q-14-2", "Q-14-4", "Q-14-5"] {
+        for code in ["Q-14-1", "Q-14-2", "Q-14-4", "Q-14-5", "Q-14-6", "Q-14-7"] {
             let info = quarto_error_catalog::ERROR_CATALOG.get(code);
             assert!(
                 info.is_some(),
@@ -459,5 +540,217 @@ mod tests {
         let d = &parse_err.diagnostics[0];
         assert_eq!(d.code.as_deref(), Some("Q-14-4"));
         assert_eq!(d.location, None);
+    }
+
+    /// The grass text the stage sees for the bd-jsvetdea repro
+    /// (`$grid-body-width: 52rem` in a user theme). Note the location
+    /// is a line of the *assembled* bundle (`./stdin`), at Quarto's own
+    /// `$grid-body-column-min` default — the user's file is never named.
+    const GRASS_UNITS_ERROR: &str = "SASS compilation error: Error: Incompatible units px and rem.\n     \u{2577}\n3269 \u{2502} $grid-body-column-min: quarto-math.min(500px, $grid-body-column-max) !default;\n     \u{2502}                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n     \u{2575}\n./stdin:3269:24\n";
+
+    #[test]
+    fn compilation_failed_renders_with_q146_code_and_span() {
+        // bd-jsvetdea: a grass failure while compiling the theme
+        // bundle carries no location of its own (`CompilationFailed`
+        // is the crate-boundary stringification of the grass error),
+        // so the stage anchors it at the whole `theme:` value via the
+        // fallback location. The diagnostic must carry Q-14-6, the
+        // grass text verbatim, and a span on the `theme:` line.
+        let temp = TempDir::new().unwrap();
+        let root = temp.path().canonicalize().unwrap();
+        let yaml_path = root.join("_quarto.yml");
+        let contents =
+            "project:\n  type: website\nformat:\n  html:\n    theme: [cosmo, bad.scss]\n";
+        std::fs::write(&yaml_path, contents).unwrap();
+
+        let value_start = contents.find("[cosmo").unwrap();
+        let value_end = contents.find(']').unwrap() + 1;
+        let location = SourceInfo::Original {
+            file_id: file_id_for(&yaml_path),
+            start_offset: value_start,
+            end_offset: value_end,
+        };
+
+        let err = SassError::CompilationFailed {
+            message: GRASS_UNITS_ERROR.to_string(),
+        };
+        let parse_err = sass_error_to_parse_error_at(
+            &err,
+            Some(location.clone()),
+            &[(file_id_for(&yaml_path), yaml_path.clone())],
+        );
+        assert_eq!(parse_err.diagnostics.len(), 1);
+        let d = &parse_err.diagnostics[0];
+        assert_eq!(d.code.as_deref(), Some("Q-14-6"));
+        assert!(
+            d.title.contains("Theme SCSS compilation failed"),
+            "title was: {}",
+            d.title,
+        );
+        assert_eq!(d.location.as_ref(), Some(&location));
+
+        let opts = quarto_error_reporting::TextRenderOptions {
+            enable_hyperlinks: false,
+        };
+        let rendered = d.to_text_with_options(Some(&parse_err.source_context), &opts);
+        assert!(
+            rendered.contains("Q-14-6"),
+            "rendered output missing code Q-14-6:\n{}",
+            rendered,
+        );
+        assert!(
+            rendered.contains("Incompatible units px and rem"),
+            "rendered output must carry the grass message verbatim:\n{}",
+            rendered,
+        );
+        assert!(
+            rendered.contains("$grid-body-column-min"),
+            "rendered output must carry the grass excerpt verbatim:\n{}",
+            rendered,
+        );
+        let stripped = strip_ansi(&rendered);
+        assert!(
+            stripped.contains("5 \u{2502}"),
+            "rendered output missing line marker for the `theme:` line:\n{}",
+            stripped,
+        );
+    }
+
+    #[test]
+    fn compilation_failed_without_location_renders_span_less() {
+        // No user theme configured (the default-bundle path) → no
+        // `theme:` value to anchor at; the diagnostic still carries the
+        // code and the grass text.
+        let err = SassError::CompilationFailed {
+            message: GRASS_UNITS_ERROR.to_string(),
+        };
+        let parse_err =
+            sass_error_to_parse_error(&err, &[(FileId(0), PathBuf::from("/nonexistent"))]);
+        let d = &parse_err.diagnostics[0];
+        assert_eq!(d.code.as_deref(), Some("Q-14-6"));
+        assert_eq!(d.location, None);
+        let rendered = d.to_text(None);
+        assert!(
+            rendered.contains("Incompatible units px and rem"),
+            "rendered output must carry the grass message:\n{}",
+            rendered,
+        );
+    }
+
+    #[test]
+    fn invalid_scss_file_renders_with_q147_code_and_span() {
+        // bd-qmpygp02: a `theme:` entry naming a file that exists but
+        // has no `/*-- scss:... --*/` layer markers must lift into a
+        // Q-14-7 diagnostic pointing at that entry and naming the
+        // resolved path.
+        let temp = TempDir::new().unwrap();
+        let root = temp.path().canonicalize().unwrap();
+        let yaml_path = root.join("doc.qmd");
+        let contents = "---\nformat:\n  html:\n    theme: [cosmo, nomarkers.scss]\n---\n";
+        std::fs::write(&yaml_path, contents).unwrap();
+
+        let entry_start = contents.find("nomarkers.scss").unwrap();
+        let entry_end = entry_start + "nomarkers.scss".len();
+        let location = SourceInfo::Original {
+            file_id: file_id_for(&yaml_path),
+            start_offset: entry_start,
+            end_offset: entry_end,
+        };
+
+        let err = SassError::InvalidScssFile {
+            path: root.join("nomarkers.scss"),
+            location: Some(location.clone()),
+        };
+        let parse_err =
+            sass_error_to_parse_error(&err, &[(file_id_for(&yaml_path), yaml_path.clone())]);
+        assert_eq!(parse_err.diagnostics.len(), 1);
+        let d = &parse_err.diagnostics[0];
+        assert_eq!(d.code.as_deref(), Some("Q-14-7"));
+        assert!(
+            d.title.contains("no layer boundary markers"),
+            "title was: {}",
+            d.title,
+        );
+        assert_eq!(d.location.as_ref(), Some(&location));
+
+        let opts = quarto_error_reporting::TextRenderOptions {
+            enable_hyperlinks: false,
+        };
+        let rendered = d.to_text_with_options(Some(&parse_err.source_context), &opts);
+        assert!(
+            rendered.contains("Q-14-7"),
+            "rendered output missing code Q-14-7:\n{}",
+            rendered,
+        );
+        assert!(
+            rendered.contains("nomarkers.scss"),
+            "rendered output missing resolved path:\n{}",
+            rendered,
+        );
+        assert!(
+            rendered.contains("scss:defaults"),
+            "hint must name at least one layer marker:\n{}",
+            rendered,
+        );
+        let stripped = strip_ansi(&rendered);
+        assert!(
+            stripped.contains("4 \u{2502}"),
+            "rendered output missing line marker for the `theme:` line:\n{}",
+            stripped,
+        );
+    }
+
+    #[test]
+    fn invalid_scss_file_falls_back_to_theme_value_location() {
+        // The loader constructs `InvalidScssFile` without a location;
+        // when the stage cannot match the path to a `theme:` entry it
+        // anchors at the whole `theme:` value instead.
+        let fallback = SourceInfo::Original {
+            file_id: FileId(7),
+            start_offset: 10,
+            end_offset: 30,
+        };
+        let err = SassError::InvalidScssFile {
+            path: PathBuf::from("/somewhere/nomarkers.scss"),
+            location: None,
+        };
+        let parse_err = sass_error_to_parse_error_at(&err, Some(fallback.clone()), &[]);
+        let d = &parse_err.diagnostics[0];
+        assert_eq!(d.code.as_deref(), Some("Q-14-7"));
+        assert_eq!(d.location.as_ref(), Some(&fallback));
+    }
+
+    #[test]
+    fn invalid_scss_file_without_location_renders_span_less() {
+        let err = SassError::InvalidScssFile {
+            path: PathBuf::from("/somewhere/nomarkers.scss"),
+            location: None,
+        };
+        let parse_err = sass_error_to_parse_error(&err, &[]);
+        let d = &parse_err.diagnostics[0];
+        assert_eq!(d.code.as_deref(), Some("Q-14-7"));
+        assert_eq!(d.location, None);
+    }
+
+    #[test]
+    fn explicit_location_wins_over_fallback() {
+        // A variant that already carries its own span keeps it; the
+        // fallback only fills in a `None`.
+        let own = SourceInfo::Original {
+            file_id: FileId(1),
+            start_offset: 0,
+            end_offset: 4,
+        };
+        let fallback = SourceInfo::Original {
+            file_id: FileId(2),
+            start_offset: 0,
+            end_offset: 4,
+        };
+        let err = SassError::CustomThemeNotFound {
+            path: PathBuf::from("/x/nope.scss"),
+            location: Some(own.clone()),
+        };
+        let parse_err = sass_error_to_parse_error_at(&err, Some(fallback), &[]);
+        assert_eq!(parse_err.diagnostics[0].location.as_ref(), Some(&own));
     }
 }

--- a/crates/quarto-error-catalog/error_catalog.json
+++ b/crates/quarto-error-catalog/error_catalog.json
@@ -1573,5 +1573,19 @@
     "message_template": "A page's front matter sets `repo-actions: true`. This key does not enable repository actions — the action list always comes from `website.repo-actions` — it asks only that a page with no table of contents show the actions in the margin rather than the page footer. Quarto 2 does not implement that placement, so the value is ignored and the actions render in the page footer at every width. Page-level `repo-actions: false`, which suppresses the actions for a single page, is supported.",
     "docs_url": "https://quarto.org/docs/errors/navigation/Q-13-13",
     "since_version": "99.9.9"
+  },
+  "Q-14-6": {
+    "subsystem": "theme",
+    "title": "Theme SCSS compilation failed",
+    "message_template": "Compiling the theme SCSS bundle failed. The reported line refers to the bundle Quarto assembles from Bootstrap, its own layers, and the files under `theme:`, so it may point into Quarto's own code reacting to a variable set by a theme. Check the variables and rules in the theme files; if no custom theme or brand is configured, this is likely a Quarto bug.",
+    "docs_url": "https://quarto.org/docs/errors/theme/Q-14-6",
+    "since_version": "99.9.9"
+  },
+  "Q-14-7": {
+    "subsystem": "theme",
+    "title": "Theme file has no layer boundary markers",
+    "message_template": "A `theme:` entry names an `.scss` file that contains none of the `/*-- scss:... --*/` layer boundary markers Quarto needs to merge it into the Bootstrap bundle. Start the file with a marker such as `/*-- scss:defaults --*/` or `/*-- scss:rules --*/`, or list a plain stylesheet under `css:` instead.",
+    "docs_url": "https://quarto.org/docs/errors/theme/Q-14-7",
+    "since_version": "99.9.9"
   }
 }

--- a/crates/quarto-sass/src/error.rs
+++ b/crates/quarto-sass/src/error.rs
@@ -49,9 +49,17 @@ pub enum SassError {
         location: Option<SourceInfo>,
     },
 
-    /// Custom SCSS file doesn't have layer boundary markers
+    /// Custom SCSS file doesn't have layer boundary markers.
+    ///
+    /// `location` is the SourceInfo of the `theme:` entry that named
+    /// the file, when the caller can match the path back to one
+    /// (quarto-core's compile stage); `None` from the loader, which
+    /// only knows the resolved path (bd-qmpygp02).
     #[error("Custom SCSS file doesn't have layer boundary markers: {path}")]
-    InvalidScssFile { path: PathBuf },
+    InvalidScssFile {
+        path: PathBuf,
+        location: Option<SourceInfo>,
+    },
 
     /// Invalid theme configuration in document/project config.
     ///
@@ -93,6 +101,7 @@ impl SassError {
             SassError::UnknownTheme { location, .. }
             | SassError::InvalidThemeConfig { location, .. }
             | SassError::CustomThemeNotFound { location, .. }
+            | SassError::InvalidScssFile { location, .. }
                 if location.is_none() =>
             {
                 *location = Some(loc);

--- a/crates/quarto-sass/src/themes.rs
+++ b/crates/quarto-sass/src/themes.rs
@@ -602,6 +602,7 @@ pub fn load_custom_theme(
         match e {
             SassError::NoBoundaryMarkers { .. } => SassError::InvalidScssFile {
                 path: resolved_path.clone(),
+                location: None,
             },
             other => other,
         }
@@ -1128,7 +1129,7 @@ mod tests {
 
         assert!(result.is_err());
         match result {
-            Err(SassError::InvalidScssFile { path }) => {
+            Err(SassError::InvalidScssFile { path, .. }) => {
                 assert!(path.ends_with("no_boundaries.scss"));
             }
             _ => panic!("Expected InvalidScssFile error"),

--- a/crates/quarto/tests/integration/main.rs
+++ b/crates/quarto/tests/integration/main.rs
@@ -24,6 +24,7 @@ pub mod render_scripts_cli;
 pub mod revealjs_cli;
 pub mod smoke_all;
 pub mod strict_mode;
+pub mod theme_compile_error;
 pub mod theme_missing_file;
 pub mod trace_cli;
 pub mod unknown_project_type;

--- a/crates/quarto/tests/integration/theme_compile_error.rs
+++ b/crates/quarto/tests/integration/theme_compile_error.rs
@@ -1,0 +1,177 @@
+/*
+ * tests/integration/theme_compile_error.rs
+ * Copyright (c) 2026 Posit, PBC
+ *
+ * End-to-end CLI tests for theme compile failures as hard errors
+ * (bd-jsvetdea Q-14-6, bd-qmpygp02 Q-14-7).
+ */
+
+//! A user theme whose SCSS fails to compile must fail the render with
+//! a structured diagnostic, not silently ship the static default CSS.
+//!
+//! Before the fix, `compile_theme_css` caught every grass error,
+//! emitted a `Warn` trace event that no CLI observer receives, and
+//! returned `DEFAULT_CSS` — exit 0, "Rendered N of N files", and a
+//! 7 KB stylesheet in place of the ~330 KB Bootstrap bundle.
+//!
+//! TDD note: written before the fix; the failure mode observed on the
+//! unfixed tree is exit 0 with `doc.html` written.
+
+use std::path::Path;
+use std::process::Command;
+
+use tempfile::TempDir;
+
+const Q2_BIN: &str = env!("CARGO_BIN_EXE_q2");
+
+/// A well-formed layered theme whose one variable breaks the
+/// Bootstrap grid arithmetic (grass: "Incompatible units px and rem").
+const BAD_UNITS_SCSS: &str = "/*-- scss:defaults --*/\n$grid-body-width: 52rem;\n";
+
+/// A file that exists but has no `/*-- scss:... --*/` layer marker.
+const NO_MARKERS_SCSS: &str = ".plain-marker { color: #0a1b2c; }\n";
+
+fn write_file(path: &Path, contents: &str) {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(path, contents).unwrap();
+}
+
+fn run_q2_render(cwd: &Path, args: &[&str]) -> std::process::Output {
+    let mut cmd = Command::new(Q2_BIN);
+    cmd.current_dir(cwd);
+    cmd.arg("render");
+    cmd.args(args);
+    cmd.output().expect("spawn q2 binary")
+}
+
+/// The bd-jsvetdea repro: a one-line unit mistake in the user's theme
+/// fails the render with Q-14-6 carrying the grass message.
+#[test]
+fn theme_compile_error_fails_with_q_14_6() {
+    let temp = TempDir::new().unwrap();
+    let dir = temp.path();
+    write_file(
+        &dir.join("doc.qmd"),
+        "---\ntitle: Bad units\nformat:\n  html:\n    theme: [cosmo, bad.scss]\n---\n\nBody.\n",
+    );
+    write_file(&dir.join("bad.scss"), BAD_UNITS_SCSS);
+
+    let output = run_q2_render(dir, &["doc.qmd"]);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !output.status.success(),
+        "a theme compile failure must exit non-zero; stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("Q-14-6"),
+        "expected the Q-14-6 diagnostic on stderr; got:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("Incompatible units px and rem"),
+        "diagnostic must carry the grass message; got:\n{stderr}"
+    );
+    assert!(
+        !dir.join("doc.html").exists(),
+        "no HTML output must be written when the theme fails to compile"
+    );
+}
+
+/// bd-qmpygp02: an existing theme file with no layer markers fails
+/// with Q-14-7 naming the file.
+#[test]
+fn theme_without_layer_markers_fails_with_q_14_7() {
+    let temp = TempDir::new().unwrap();
+    let dir = temp.path();
+    write_file(
+        &dir.join("doc.qmd"),
+        "---\ntitle: No markers\nformat:\n  html:\n    theme: [cosmo, nomarkers.scss]\n---\n\nBody.\n",
+    );
+    write_file(&dir.join("nomarkers.scss"), NO_MARKERS_SCSS);
+
+    let output = run_q2_render(dir, &["doc.qmd"]);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !output.status.success(),
+        "a theme file without layer markers must exit non-zero; stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("Q-14-7"),
+        "expected the Q-14-7 diagnostic on stderr; got:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("nomarkers.scss"),
+        "diagnostic must name the offending file; got:\n{stderr}"
+    );
+    assert!(
+        !dir.join("doc.html").exists(),
+        "no HTML output must be written when the theme fails to compile"
+    );
+}
+
+/// In a website, the theme compiles once per page and only successes
+/// are cached, so every page fails with the same diagnostic. Because
+/// the diagnostic is anchored at the `theme:` value in `_quarto.yml`,
+/// the render summary's source-location coalescing (bd-9hlja) must
+/// print the grass block once with both pages listed as affected.
+#[test]
+fn project_theme_compile_error_is_reported_once() {
+    let temp = TempDir::new().unwrap();
+    let dir = temp.path();
+    write_file(
+        &dir.join("_quarto.yml"),
+        "project:\n  type: website\nformat:\n  html:\n    theme: [cosmo, bad.scss]\n",
+    );
+    write_file(&dir.join("bad.scss"), BAD_UNITS_SCSS);
+    write_file(&dir.join("index.qmd"), "---\ntitle: Home\n---\n\nHome.\n");
+    write_file(&dir.join("about.qmd"), "---\ntitle: About\n---\n\nAbout.\n");
+
+    let output = run_q2_render(dir, &[]);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !output.status.success(),
+        "a theme compile failure must fail the project render; stderr:\n{stderr}"
+    );
+    assert_eq!(
+        stderr.matches("Incompatible units px and rem").count(),
+        1,
+        "the grass block must be printed once for the whole project; got:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("index.qmd") && stderr.contains("about.qmd"),
+        "the coalesced report must list both affected pages; got:\n{stderr}"
+    );
+}
+
+/// Control: the same theme with a `px` value compiles and renders.
+#[test]
+fn well_formed_custom_theme_still_renders() {
+    let temp = TempDir::new().unwrap();
+    let dir = temp.path();
+    write_file(
+        &dir.join("doc.qmd"),
+        "---\ntitle: Good units\nformat:\n  html:\n    theme: [cosmo, good.scss]\n---\n\nBody.\n",
+    );
+    write_file(
+        &dir.join("good.scss"),
+        "/*-- scss:defaults --*/\n$grid-body-width: 830px;\n/*-- scss:rules --*/\n.good-marker { color: #0a1b2c; }\n",
+    );
+
+    let output = run_q2_render(dir, &["doc.qmd"]);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "a well-formed custom theme must render; stderr:\n{stderr}"
+    );
+    let css = std::fs::read_to_string(dir.join("doc_files/styles.css"))
+        .expect("themed render must write doc_files/styles.css");
+    assert!(
+        css.contains("good-marker"),
+        "compiled CSS must contain the custom theme rule"
+    );
+}

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -314,6 +314,8 @@ website:
             - errors/theme/Q-14-2.qmd
             - errors/theme/Q-14-4.qmd
             - errors/theme/Q-14-5.qmd
+            - errors/theme/Q-14-6.qmd
+            - errors/theme/Q-14-7.qmd
         - section: "lua"
           contents:
             - errors/lua/Q-11-1.qmd

--- a/docs/errors/theme/Q-14-6.qmd
+++ b/docs/errors/theme/Q-14-6.qmd
@@ -1,0 +1,67 @@
+---
+title: "Theme SCSS compilation failed"
+description: "Compiling the theme SCSS bundle failed; the Sass compiler's message and excerpt are shown, but the reported line is in the bundle Quarto assembles, not in your file."
+code: Q-14-6
+subsystem: theme
+status: stub
+since: "99.9.9"
+categories:
+  - theme
+---
+
+# `Q-14-6` — Theme SCSS Compilation Failed
+
+> Compiling the theme SCSS bundle failed. The Sass compiler's
+> message and excerpt are shown verbatim; the reported line is in
+> the bundle Quarto assembles, not in your file.
+
+## What this means
+
+Quarto builds one SCSS bundle from Bootstrap, its own layers, any
+`brand:` settings, and every file listed under `theme:`, then
+compiles it to CSS. That compile failed. The render stops rather
+than shipping a page with a stripped-down default stylesheet in
+place of your theme.
+
+The error shows the Sass compiler's own message, the failing line,
+and a pointer of the form `./stdin:LINE:COL`. That line number
+counts lines of the **assembled bundle**, and the excerpt is often
+one of Quarto's or Bootstrap's own lines reacting to a variable
+your theme set. The diagnostic's source span points at the
+`theme:` value that configured the bundle, which is where to start
+looking, but it is not the precise location of the mistake.
+
+## Why this happens
+
+Common causes:
+
+- **A variable set to a value Bootstrap's arithmetic cannot use.**
+  For example `$grid-body-width: 52rem;` makes the grid mixins fail
+  with `Incompatible units px and rem`, because they subtract a
+  pixel value from it. The excerpt shows Quarto's
+  `$grid-body-column-min` line, not yours.
+- **A Sass syntax error** in a theme file: an unbalanced brace, a
+  missing semicolon, a misspelled function.
+- **A `brand.yml` value that is not valid Sass**, such as a font
+  weight written as a range, which reaches the bundle as
+  `$font-weight-base: 400..700`.
+- **No custom theme or brand at all.** If you have not configured
+  any theme and this error still fires, the default bundle itself
+  failed to compile. That is a Quarto bug; please report it with the
+  full message.
+
+## How to fix
+
+- Read the Sass message first; it names the operation that failed.
+  Then look for the variable it mentions in your theme files.
+- Try the theme with the suspect variable commented out to confirm
+  which line triggers the failure.
+- Match the unit Bootstrap expects. Layout variables such as
+  `$grid-body-width` take pixel values.
+
+## Related
+
+- `Q-14-4` — theme file not found: the `theme:` entry names a file
+  that does not exist.
+- `Q-14-7` — the theme file exists but has no layer boundary
+  markers.

--- a/docs/errors/theme/Q-14-7.qmd
+++ b/docs/errors/theme/Q-14-7.qmd
@@ -1,0 +1,65 @@
+---
+title: "Theme file has no layer boundary markers"
+description: "A `theme:` entry names an `.scss` file that contains none of the `/*-- scss:... --*/` layer boundary markers Quarto needs to merge it into the Bootstrap bundle."
+code: Q-14-7
+subsystem: theme
+status: stub
+since: "99.9.9"
+categories:
+  - theme
+---
+
+# `Q-14-7` — Theme File Has No Layer Boundary Markers
+
+> A `theme:` entry names an `.scss` file that contains none of the
+> `/*-- scss:... --*/` layer boundary markers Quarto needs to merge
+> it into the Bootstrap bundle.
+
+## What this means
+
+A custom theme file is not compiled on its own. Quarto splits it
+into layers and merges each layer into the matching section of the
+Bootstrap bundle: variables go before Bootstrap's defaults so they
+take precedence, rules go after Bootstrap's rules so they override
+them. The split is driven by comment markers in the file:
+
+```scss
+/*-- scss:defaults --*/
+$primary: #2c5f8a;
+
+/*-- scss:rules --*/
+.sidebar { border-right: 1px solid $primary; }
+```
+
+The named file has none of these markers, so Quarto cannot tell
+which section anything belongs to. The render stops with this error
+instead of silently dropping the theme.
+
+## Why this happens
+
+Common causes:
+
+- **A plain CSS or SCSS file listed under `theme:`.** A stylesheet
+  that only contains rules belongs under `css:`, which links it as
+  is, or needs a `/*-- scss:rules --*/` marker at the top to become a
+  theme layer.
+- **A marker with the wrong spelling.** The marker must be exactly
+  `/*-- scss:<layer> --*/`, where `<layer>` is one of `uses`,
+  `functions`, `defaults`, `mixins`, or `rules`.
+- **A file that was meant to be `@import`ed** from another theme
+  file rather than listed directly.
+
+## How to fix
+
+- Add a marker before the first line of the file: `/*-- scss:defaults --*/`
+  for variable assignments, `/*-- scss:rules --*/` for CSS rules.
+  A file can have several sections in any order.
+- If the file is a finished stylesheet with no Sass in it, move it
+  from `theme:` to `css:`.
+
+## Related
+
+- `Q-14-4` — theme file not found: the `theme:` entry names a file
+  that does not exist.
+- `Q-14-6` — the theme file was merged but the bundle failed to
+  compile.

--- a/hub-client/changelog.md
+++ b/hub-client/changelog.md
@@ -23,6 +23,10 @@ WASM rebuild is needed for a changelog-only edit.
 
 -->
 
+### 2026-09-08
+
+- [`c0a6230e`](https://github.com/quarto-dev/q2/commits/c0a6230e): WASM tests that render now wire the dart-sass VFS importer, since a theme compile failure is a hard error (Q-14-6) instead of a silent fallback to default CSS
+
 ### 2026-09-03
 
 - [`546fdd37`](https://github.com/quarto-dev/q2/commits/546fdd37): The sandboxed preview bundle is rebuilt from its current sources — math rendering there is back on KaTeX 0.18.4, which a later bundle rebuild had quietly reverted to 0.18.2, and the preview's service worker no longer caches assets for offline use.

--- a/hub-client/src/services/changelogRender.wasm.test.ts
+++ b/hub-client/src/services/changelogRender.wasm.test.ts
@@ -13,9 +13,11 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import { readFile } from 'fs/promises';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
+import { wireSassVfs } from '../test-utils/wasmSassVfs';
 
 interface WasmModule {
   default: (input?: BufferSource) => Promise<void>;
+  vfs_read_file: (path: string) => string;
   render_qmd_content: (content: string, templateBundle: string) => Promise<string>;
 }
 
@@ -34,6 +36,9 @@ beforeAll(async () => {
   const wasmBytes = await readFile(wasmPath);
   wasm = (await import('wasm-quarto-hub-client')) as unknown as WasmModule;
   await wasm.default(wasmBytes);
+  // The theme stage compiles Bootstrap through dart-sass, which needs
+  // the VFS importer; an unwired importer is a Q-14-6 hard error.
+  wireSassVfs(wasm);
 });
 
 describe('About tab markdown files render without errors', () => {

--- a/hub-client/src/services/projectContext.wasm.test.ts
+++ b/hub-client/src/services/projectContext.wasm.test.ts
@@ -11,9 +11,11 @@ import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
 import { readFile } from 'fs/promises';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
+import { wireSassVfs } from '../test-utils/wasmSassVfs';
 
 interface WasmModule {
   default: (input?: BufferSource) => Promise<void>;
+  vfs_read_file: (path: string) => string;
   vfs_add_file: (path: string, content: string) => string;
   vfs_clear: () => string;
   render_qmd: (path: string) => Promise<string>;
@@ -37,6 +39,9 @@ beforeAll(async () => {
 
   wasm = (await import('wasm-quarto-hub-client')) as unknown as WasmModule;
   await wasm.default(wasmBytes);
+  // The theme stage compiles Bootstrap through dart-sass, which needs
+  // the VFS importer; an unwired importer is a Q-14-6 hard error.
+  wireSassVfs(wasm);
 });
 
 beforeEach(() => {

--- a/hub-client/src/services/runtimeMetadata.wasm.test.ts
+++ b/hub-client/src/services/runtimeMetadata.wasm.test.ts
@@ -12,9 +12,11 @@ import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
 import { readFile } from 'fs/promises';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
+import { wireSassVfs } from '../test-utils/wasmSassVfs';
 
 interface WasmModule {
   default: (input?: BufferSource) => Promise<void>;
+  vfs_read_file: (path: string) => string;
   vfs_add_file: (path: string, content: string) => string;
   vfs_clear: () => string;
   vfs_set_runtime_metadata: (yaml: string) => string;
@@ -46,6 +48,9 @@ beforeAll(async () => {
 
   wasm = (await import('wasm-quarto-hub-client')) as unknown as WasmModule;
   await wasm.default(wasmBytes);
+  // The theme stage compiles Bootstrap through dart-sass, which needs
+  // the VFS importer; an unwired importer is a Q-14-6 hard error.
+  wireSassVfs(wasm);
 });
 
 beforeEach(() => {

--- a/hub-client/src/services/vfsArtifactReflush.wasm.test.ts
+++ b/hub-client/src/services/vfsArtifactReflush.wasm.test.ts
@@ -31,6 +31,7 @@ import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
 import { readFile } from 'fs/promises';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
+import { wireSassVfs } from '../test-utils/wasmSassVfs';
 
 interface WasmModule {
   default: (input?: BufferSource) => Promise<void>;
@@ -63,6 +64,9 @@ beforeAll(async () => {
 
   wasm = (await import('wasm-quarto-hub-client')) as unknown as WasmModule;
   await wasm.default(wasmBytes);
+  // The theme stage compiles Bootstrap through dart-sass, which needs
+  // the VFS importer; an unwired importer is a Q-14-6 hard error.
+  wireSassVfs(wasm);
 });
 
 beforeEach(() => {

--- a/hub-client/src/test-utils/wasmSassVfs.ts
+++ b/hub-client/src/test-utils/wasmSassVfs.ts
@@ -1,0 +1,40 @@
+/**
+ * Wire the dart-sass importer to the WASM module's VFS for a
+ * `*.wasm.test.ts` file.
+ *
+ * Every render through the WASM pipeline compiles a Bootstrap SCSS
+ * bundle, and dart-sass resolves that bundle's `@import`s by calling
+ * back into the VFS via `setVfsCallbacks`. A test that renders without
+ * wiring this fails with `Q-14-6` ("Can't find stylesheet to import
+ * vendor/rfs"). Before bd-jsvetdea the failure was masked: the theme
+ * stage silently shipped the static DEFAULT_CSS instead, so tests
+ * that only looked at the HTML passed with an unwired importer. It is
+ * a hard error now, matching what `q2 render` does, so call this from
+ * `beforeAll` right after `wasm.default(bytes)`.
+ *
+ * The production wiring lives in
+ * `ts-packages/preview-runtime/src/wasmRenderer.ts`; this mirrors it
+ * for tests that load the module by hand.
+ */
+
+// `/src/wasm-js-bridge` is aliased to `@quarto/wasm-js-bridge/src` in
+// hub-client's vite + vitest configs (the same alias the Rust WASM
+// module's `raw_module` annotation uses).
+import { setVfsCallbacks } from '/src/wasm-js-bridge/sass.js';
+
+/** The one WASM export the importer needs. */
+export interface VfsReader {
+  vfs_read_file: (path: string) => string;
+}
+
+export function wireSassVfs(wasm: VfsReader): void {
+  const read = (path: string): string | null => {
+    try {
+      const result = JSON.parse(wasm.vfs_read_file(path)) as { success: boolean; content?: string };
+      return result.success && result.content !== undefined ? result.content : null;
+    } catch {
+      return null;
+    }
+  };
+  setVfsCallbacks(read, (path: string): boolean => read(path) !== null);
+}


### PR DESCRIPTION
## Summary

A grass failure while compiling the theme bundle used to be caught in `variant_css`, logged as a `Warn` trace event (which no CLI observer receives), and replaced by the static 7 KB `DEFAULT_CSS`. The render reported success. A one-line unit mistake in a user theme (`$grid-body-width: 52rem`) silently shipped an unstyled page.

Every theme compile failure is now a `PipelineError::Structured` through `theme_diagnostic`:

- **Q-14-6 "Theme SCSS compilation failed"**: the grass / dart-sass text verbatim, anchored at the whole `theme:` value (the compiler only knows lines of the assembled bundle), with a hint saying so. Applies to the themed path, the no-user-input default bundle, and the reveal path (which used to fall back to the vendored stock theme).
- **Q-14-7 "Theme file has no layer boundary markers"**: `InvalidScssFile`, anchored at the offending `theme:` entry when its resolved path matches one, else at the whole value.

Plumbing: the three compile wrappers keep `SassError` instead of stringifying it; `InvalidScssFile` gains a `location` field; `theme_diagnostic` gains `sass_error_to_parse_error_at(err, fallback_location, candidates)`. Because the anchor is a `_quarto.yml` span, the render summary's source-location coalescing prints one report per project with an "Affected files" tail.

Closes bd-jsvetdea and bd-qmpygp02; resolves bd-36vmz7nk (decision: fatal). Follow-ups filed: bd-c1gf9xmk (layer provenance so Q-14-6 can name `theme.scss:2`), bd-e1psgogt (audit remaining `Warn` trace sites; `-v` filter never matches `quarto_core`).

Plan: `claude-notes/plans/2026-09-08-theme-scss-compile-error-swallowed.md`.

## Verification

- Unit, diagnostic, and CLI e2e tests written first and observed failing on the old tree (exit 0 / `Ok(DEFAULT_CSS)` / no code).
- `cargo nextest run --workspace`: 13753 passed. Clippy and `cargo xtask lint` clean. hub-client `npm run build:all` (WASM leg) succeeds.
- End to end on the repro fixture (`claude-notes/plans/theme-scss-compile-error-swallowed-investigation/repro/`):

```
$ cargo run --bin q2 -- render <repro>
error: while rendering …/repro/index.qmd
Error: [Q-14-6] Theme SCSS compilation failed
   ╭─[ …/repro/_quarto.yml:5:12 ]
 5 │     theme: [cosmo, theme.scss]
   │            ─────────┬─────────
   │                     ╰─────────── compiling the theme SCSS bundle failed:
Error: Incompatible units px and rem.
3269 │ $grid-body-column-min: quarto-math.min(500px, $grid-body-column-max) !default;
./stdin:3269:24
ℹ Does a variable in a theme file set a value Bootstrap's arithmetic cannot use (…)? …
Rendered 0 of 1 files … — 1 error
```

  A two-page site prints the block once, followed by `Affected files: …/about.qmd, …/index.qmd`.
- `docs/` renders 271/271 pages with no Q-14-6 (nothing previously masked turns red).

Note: the hub-client vitest leg of `cargo xtask verify` is red locally under Node 26 (`localStorage` undefined), unrelated to this change — filed as bd-lh30hlvd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xwth8pr6ewSbExXRBNpQWY
