### PR TITLE
Enforce the Node pin: xtask preflight, engine-strict, docs (bd-lh30hlvd)

### DIFF
--- a/.claude/rules/worktrees.md
+++ b/.claude/rules/worktrees.md
@@ -96,6 +96,10 @@ npm install                              # only if hub-client work is in scope
 cargo xtask verify --skip-hub-build      # confirm green at branch HEAD
 ```
 
+`npm install` and `cargo xtask verify` both require the Node major pinned in
+`.nvmrc` / `engines.node`; with fnm's `--use-on-cd`, the `cd` into the worktree
+selects it (see `claude-notes/instructions/node-version.md`).
+
 `--base` defaults to `main` when omitted. **If the strand has an
 open parent epic, the command prints a warning** nudging you toward
 the epic's integration branch (e.g. `feature/<name>`). Pass

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,7 @@
+; Refuse to install under a Node outside the range declared in package.json
+; (`engines.node`, mirrored in .nvmrc). Without this, npm only *warns* about a
+; wrong Node, and the pin is silently ignored — which is how a Homebrew
+; `brew upgrade` relinked `node` to a newer major and broke the hub-client test
+; suite months later (bd-lh30hlvd). `cargo xtask verify` enforces the same
+; pin at test time. Setup: claude-notes/instructions/node-version.md
+engine-strict=true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -352,6 +352,8 @@ npm run local-prod # Run hub + static server with proxy (requires built client)
 
 **Important:** Never run `npm install` from hub-client directly - dependencies are hoisted to the root `node_modules/`.
 
+**Node version is pinned** (`.nvmrc` + `engines.node`, currently Node 24, same as CI). `npm install`/`npm ci` refuse other majors (`engine-strict` in `.npmrc`) and `cargo xtask verify` checks the Node on `PATH` before anything else. Use a version manager (fnm/mise/nvm) so `.nvmrc` selects it — do not rely on Homebrew's `node`, which `brew upgrade` relinks to the newest major. Setup and rationale: `claude-notes/instructions/node-version.md`.
+
 **Local production mode:**
 
 `npm run local-prod` runs a setup that mirrors the production deployment:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,7 +168,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8454c8a44ce2cb9cc7e7fae67fc6128465b343b92c6631e94beca3c8d1524ea5"
 dependencies = [
- "unicode-width",
+ "unicode-width 0.2.2",
  "yansi",
 ]
 
@@ -600,6 +600,12 @@ checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 dependencies = [
  "allocator-api2",
 ]
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "byteorder"
@@ -2046,7 +2052,7 @@ version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
 dependencies = [
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -2826,7 +2832,7 @@ dependencies = [
  "dyn-clone",
  "fuzzy-matcher",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -3462,6 +3468,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "miette"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
+dependencies = [
+ "cfg-if",
+ "miette-derive",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3764,6 +3792,19 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nodejs-semver"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "364dd919c4d6feef8c3a3f3e2b64af729187902156e17481618622cbbf1353a1"
+dependencies = [
+ "bytecount",
+ "miette",
+ "smallvec",
+ "thiserror 2.0.18",
+ "winnow 0.7.15",
+]
 
 [[package]]
 name = "noq"
@@ -7196,7 +7237,7 @@ dependencies = [
  "indexmap",
  "toml_datetime",
  "toml_parser",
- "winnow",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -7205,7 +7246,7 @@ version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
- "winnow",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -7624,6 +7665,12 @@ name = "unicode-segmentation"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -8702,6 +8749,15 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
@@ -8874,6 +8930,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "nodejs-semver",
  "proc-macro2",
  "serde",
  "serde_json",

--- a/claude-notes/instructions/node-version.md
+++ b/claude-notes/instructions/node-version.md
@@ -1,0 +1,123 @@
+# Node version: the pin, what enforces it, and how to set up your machine
+
+The repo pins one Node major for everything npm-driven (hub-client, ts-packages,
+the preview SPA, the MCP bundle). CI runs that major; local machines must too, or
+tests fail in ways that look unrelated to Node.
+
+## The pin
+
+| Where | Value (2026-09) | Read by |
+| --- | --- | --- |
+| `.nvmrc` (repo root) | `24` | fnm, nvm, mise, and other version managers |
+| `package.json` → `engines.node` | `^24.0.0` | npm (`engine-strict`), `cargo xtask verify`, `cargo xtask dev-setup` |
+| `.github/workflows/*.yml` → `actions/setup-node` | `node-version: '24'` | CI |
+
+These three must agree. When bumping the major, change all three in one commit
+(see § Bumping the pin).
+
+## What enforces it
+
+A pin that nothing reads is advisory, and advisory pins get undone by the next
+package-manager upgrade — that is exactly what happened here (May 2026 pin
+`ca6d47c8`, undone by a `brew upgrade` on 2026-09-04, found on 2026-09-08 as 23
+vitest failures; bd-lh30hlvd). Three layers now make the drift fail fast, with
+the cause named:
+
+1. **`cargo xtask verify`** runs a preflight before anything else: it reads
+   `engines.node`, runs `node --version`, and **fails** on a mismatch or a
+   missing `node` — before the Rust build, so the wait is seconds. On success
+   it prints the version it found, so a verify log always names the toolchain.
+   The check is skipped only when every npm-driven step is disabled.
+   Implementation: `crates/xtask/src/node_version.rs` (npm's own range grammar
+   via the `nodejs-semver` crate; an unparsable range is an error, not a pass).
+2. **`.npmrc` → `engine-strict=true`** makes `npm install` / `npm ci` fail with
+   `EBADENGINE` under a Node outside the range, instead of printing a warning
+   that scrolls past. It applies to the whole dependency tree, so a dependency
+   that declares an incompatible `engines` range also fails loudly.
+3. **`cargo xtask dev-setup`** reports the Node it finds and, on a mismatch,
+   prints version-manager install hints. Warn-only.
+
+### Escape hatches (deliberate experiments only)
+
+- `Q2_ALLOW_NODE_MISMATCH=1 cargo xtask verify …` — runs the preflight, prints
+  a warning, and continues on the mismatched Node. Use it to *try* the next
+  Node major; do not leave it set in a shell profile.
+- `npm install --engine-strict=false` — one-off override of `.npmrc`.
+
+## Setting up your machine
+
+Use a version manager that reads `.nvmrc`; do not fight your OS package
+manager. **fnm** is the smallest one and what this note assumes; **mise** and
+**nvm** work the same way.
+
+### macOS (zsh)
+
+```bash
+brew install fnm
+# in ~/.zprofile (see the note below on why not ~/.zshenv):
+eval "$(fnm env --use-on-cd --version-file-strategy=recursive)"
+# then, from anywhere inside the repo:
+fnm install          # installs the .nvmrc version
+node --version       # v24.x
+```
+
+`--use-on-cd` switches Node whenever you `cd`, and once at shell start;
+`--version-file-strategy=recursive` finds `.nvmrc` from subdirectories, so
+`cd hub-client` gets the pin too. `fnm default system` keeps Homebrew's Node in
+effect outside pinned projects, if you want it for other tools.
+
+**Why `~/.zprofile`, not `~/.zshenv`.** On macOS, login shells run
+`/etc/zprofile`, which calls `path_helper`. `path_helper` rebuilds `PATH` from
+`/etc/paths` and `/etc/paths.d/*` (Homebrew registers `/opt/homebrew/bin`
+there) and *appends* whatever was already in `PATH`. An fnm init in
+`~/.zshenv` runs before that and ends up behind `/opt/homebrew/bin`, so
+Homebrew's `node` wins anyway. `~/.zprofile` and `~/.zshrc` run after
+`/etc/zprofile`; `~/.zprofile` covers every login shell (Terminal, iTerm, VS
+Code's integrated terminal, Claude Code's tool shell).
+
+Shells started *before* you edit the profile keep their old `PATH`. Open a new
+terminal (or restart the Claude Code session) after setup.
+
+### Linux
+
+```bash
+curl -fsSL https://fnm.vercel.app/install | bash   # or your distro's package
+eval "$(fnm env --use-on-cd --version-file-strategy=recursive)"   # in ~/.bashrc / ~/.zshrc
+fnm install
+```
+
+### Windows (PowerShell)
+
+```powershell
+winget install Schniz.fnm
+fnm env --use-on-cd | Out-String | Invoke-Expression   # in $PROFILE
+fnm install
+```
+
+## The Homebrew relink trap
+
+Homebrew's unversioned `node` formula tracks the *current* Node release, not
+the LTS. Every `brew upgrade` that touches it relinks `/opt/homebrew/bin/node`
+to the new major, silently displacing a `node@24` you linked by hand
+(`brew link --overwrite node@24` does not survive the next upgrade). If
+something else on the machine depends on the unversioned formula (here:
+`bitwarden-cli`), you cannot uninstall it either. A version manager sidesteps
+all of this: Homebrew's Node stays where it is, and the repo gets the pinned
+one from `~/.local/share/fnm`.
+
+## Bumping the pin
+
+Do it deliberately, in one PR:
+
+1. `.nvmrc`, `engines.node` in the root `package.json`, and every
+   `node-version:` in `.github/workflows/`.
+2. Run `cargo xtask verify` on the new major and fix what breaks. Known item
+   for **Node ≥ 25**: Node defines a `localStorage` global that vitest 4.x's
+   jsdom environment refuses to overwrite, so every jsdom test touching
+   `localStorage` fails. The fix is vitest ≥ 5.0.0 (allowlists
+   `localStorage`/`sessionStorage`) or a `setupFiles` shim that re-points the
+   global at `globalThis.jsdom.window.localStorage` — a verified prototype is
+   in `claude-notes/plans/node26-vitest-localstorage-investigation/`. Details:
+   `claude-notes/plans/2026-09-08-node26-vitest-localstorage.md`.
+3. `npm ci` under the new major: `engine-strict` also validates every
+   dependency's `engines`.

--- a/claude-notes/plans/2026-09-08-node26-vitest-localstorage.md
+++ b/claude-notes/plans/2026-09-08-node26-vitest-localstorage.md
@@ -58,53 +58,60 @@ Concretely:
 
 Module `crates/xtask/src/node_version.rs`. Pure functions unit-tested; process/IO at the edge.
 
-- [ ] B0 tests (written first, must fail before implementation):
-  - [ ] `parse_node_version("v24.20.0")` → `24.20.0`; rejects garbage; tolerates trailing newline
-  - [ ] `engines_node_requirement(package_json_text)` → `VersionReq` for `^24.0.0`; error when
+- [x] B0 tests (written first; all 17 failed on `todo!()` stubs, then passed):
+  - [x] `parse_node_version("v24.20.0")` → `24.20.0`; rejects garbage; tolerates trailing newline
+  - [x] `engines_node_requirement(package_json_text)` → `VersionReq` for `^24.0.0`; error when
         `engines`/`engines.node` missing; error (not silent pass) on an unparsable range
-  - [ ] `evaluate(requirement, Some(version))` → `Satisfied` / `Mismatch`; `None` → `NotFound`
-  - [ ] `Mismatch`/`NotFound` render an actionable message naming the found version, the
+  - [x] `evaluate(requirement, Some(version))` → `Satisfied` / `Mismatch`; `None` → `NotFound`
+  - [x] `Mismatch`/`NotFound` render an actionable message naming the found version, the
         requirement, its source file, and the fnm/`.nvmrc` remedy
-  - [ ] escape hatch: `enforcement(outcome, allow_mismatch: bool)` → `Proceed` / `Fail`
-- [ ] B1 implement: `semver` crate (`VersionReq`, already in `Cargo.lock`) for the range;
+  - [x] escape hatch: `enforcement(outcome, allow_mismatch: bool)` → `Proceed` / `Fail`
+- [x] B1 implement — **decision changed during B1:** Cargo's `semver` crate rejects npm's
+      space-separated `>=24 <25`; switched to `nodejs-semver` 5.0.0 (npm's own grammar; adds
+      `miette`/`winnow`/`bytecount` to xtask only). Range via `Range::parse`/`satisfies`;
       `node --version` via `crate::util::nested_command` (Windows `.cmd` shims); read
       `engines.node` from `<root>/package.json`
-- [ ] B2 wire into `verify::run`: before Step 1, when any npm-driven step will run, fail on
+- [x] B2 wire into `verify::run`: before Step 1, when any npm-driven step will run, fail on
       mismatch unless `Q2_ALLOW_NODE_MISMATCH=1` (then print a loud warning); print
       `Node vX.Y.Z satisfies engines.node ^24.0.0` on success so a log names the toolchain
-- [ ] B3 wire into `dev_setup::run`: warn-only `check_node()` mirroring `check_wasm_opt`,
+- [x] B3 wire into `dev_setup::run`: warn-only `check_node()` mirroring `check_wasm_opt`,
       with per-platform install hints (fnm / mise / nvm; `.nvmrc` selects the version)
-- [ ] B4 `cargo nextest run -p xtask`; `cargo xtask lint`; clippy clean under `-D warnings`
+- [x] B4 `cargo nextest run -p xtask`; `cargo xtask lint`; clippy clean under `-D warnings`
 
 ## Phase C — `engine-strict` at install time
 
-- [ ] C1 root `.npmrc`: `engine-strict=true` with a comment pointing at `engines.node` and
+- [x] C1 root `.npmrc`: `engine-strict=true` with a comment pointing at `engines.node` and
       the instructions note
-- [ ] C2 verify: under Node 26 `npm install --dry-run` fails with `EBADENGINE`; under Node 24
+- [x] C2 verify: under Node 26 `npm install --dry-run` fails with `EBADENGINE`; under Node 24
       `npm ci` in the worktree succeeds (also proves no *dependency* declares an
       incompatible `engines` range — `engine-strict` applies to the whole tree)
-- [ ] C3 confirm CI is unaffected: every workflow's `setup-node` uses `node-version: '24'`
+- [x] C3 confirm CI is unaffected: every workflow's `setup-node` uses `node-version: '24'`
       (checked 2026-09-08: hub-client-e2e, ts-test-suite ×2, release ×3, deploy-sandboxed-preview)
 
 ## Phase D — Docs
 
-- [ ] D1 `claude-notes/instructions/node-version.md`: the pin (`.nvmrc` + `engines`), what
+- [x] D1 `claude-notes/instructions/node-version.md`: the pin (`.nvmrc` + `engines`), what
       enforces it (xtask check, `engine-strict`), the Homebrew relink trap, fnm setup
       (`.zprofile` vs `.zshenv` on macOS), the escape hatch, and how the pin gets bumped
-- [ ] D2 `CLAUDE.md`: two-line pointer under hub-client Development
-- [ ] D3 `.claude/rules/worktrees.md` fresh-worktree bootstrap: mention `npm ci` runs under the
+- [x] D2 `CLAUDE.md`: two-line pointer under hub-client Development
+- [x] D3 `.claude/rules/worktrees.md` fresh-worktree bootstrap: mention `npm ci` runs under the
       pinned Node (one line)
 
 ## Phase E — End-to-end verification and hand-off
 
-- [ ] E1 `cargo xtask verify` in the worktree under Node 26 (`PATH` override): must stop at the
-      preflight with the Node message, before any Rust build
-- [ ] E2 `cargo xtask verify` in the worktree under Node 24 (full, including hub build + tests):
-      green
-- [ ] E3 `cargo xtask dev-setup` output under both Nodes inspected
-- [ ] E4 pre-commit checklist (`claude-notes/instructions/review.md`) per commit
-- [ ] E5 file the deferred strand (vitest 5 / shim at the Node 26 LTS bump), link
-      `related:bd-lh30hlvd`; comment on bd-lh30hlvd; leave the strand open until the PR merges
+- [x] E1 `cargo xtask verify` in the worktree under Node 26: stops at the preflight (exit 1)
+      before any Rust build; `Q2_ALLOW_NODE_MISMATCH=1` warns and continues; with every
+      npm-driven step skipped the preflight reports itself skipped (see § End-to-end record)
+- [x] E2 `cargo xtask verify` (full: WASM + hub build + every test leg) in the worktree under
+      fnm's Node 24.20.0: `✓ All verification steps passed!` — 13,757 Rust tests, hub-client
+      1084/119/133, trace-viewer, shared preview-* and hub MCP suites all green (2026-09-08)
+- [x] E3 `cargo xtask dev-setup` output under both Nodes inspected
+- [x] E4 pre-commit checklist: no `HashMap`/`FxHashMap` in changed Rust; no TODOs; `cargo fmt`
+      clean; clippy `-D warnings` clean; `cargo xtask lint` clean; new module's decision logic
+      fully unit-tested, IO edges exercised end-to-end (E1/E3)
+- [x] E5 deferred strand filed: **bd-s84z961e** (vitest 5 / shim at the Node 26 LTS bump,
+      `related:bd-lh30hlvd`); progress comment left on bd-lh30hlvd; bd-lh30hlvd stays open
+      until the PR merges
 - [ ] E6 report: exact invocations + observed output for E1/E2, the machine changes made,
       and the branch/PR handoff (push only with the user's permission)
 
@@ -179,3 +186,27 @@ The investigation was done in the main checkout on `braid/bd-ve916wr8-brand-file
 (commit `9dd12112`, cherry-picked here as `57360606`); that branch's pre-flight verify was
 red only because another session was writing bd-ve916wr8's tests there. When that branch
 lands first, `git rebase main` on this branch drops the patch-identical plan commit.
+
+## End-to-end record (2026-09-08, worktree, xtask at this branch)
+
+`cargo xtask verify --skip-rust-build --skip-rust-tests --skip-treesitter-tests` under
+Homebrew's Node 26.8.1 (output inspected):
+
+```
+━━━ Preflight: Node toolchain ━━━
+
+Error: Node v26.8.1 does not satisfy engines.node ^24.0.0 (package.json).
+  This repository pins Node to ^24.0.0 (package.json `engines.node`, mirrored in `.nvmrc`).
+  With fnm, mise, or nvm installed, `.nvmrc` selects the pinned version automatically;
+  see claude-notes/instructions/node-version.md for setup (and for the Homebrew relink trap).
+  To run against this Node anyway, as a deliberate experiment: Q2_ALLOW_NODE_MISMATCH=1
+exit=1
+```
+
+Same under fnm's Node 24.20.0: `✓ Node v24.20.0 satisfies engines.node ^24.0.0 (package.json)`,
+then Step 1 runs. `cargo xtask dev-setup` prints the same message as a `Warning:` plus the
+three fnm install lines under Node 26, and the one-line confirmation under Node 24.
+
+`npm install --dry-run` with the new `.npmrc`: Node 26 → `npm error code EBADENGINE`,
+exit 1; Node 24 → exit 0. `npm ci` in the fresh worktree under Node 24 → exit 0 (so no
+dependency declares an incompatible `engines` range).

--- a/claude-notes/plans/2026-09-08-node26-vitest-localstorage.md
+++ b/claude-notes/plans/2026-09-08-node26-vitest-localstorage.md
@@ -51,7 +51,7 @@ Concretely:
 - [x] Verified from fresh shells: `zsh -l` in repo → v24.20.0; in `hub-client/` → v24.20.0
       (recursive strategy); outside repo → "Bypassing fnm: using system node" v26.8.1;
       `zsh -l -i` (Terminal.app shape) → v24.20.0, npm 11.19.0
-- [ ] Note for the user: shells started *before* `~/.zprofile` existed (including the Claude
+- [x] Told the user: shells started *before* `~/.zprofile` existed (including the Claude
       Code session that did this work) keep Node 26 until restarted
 
 ## Phase B — Node toolchain check in xtask (TDD)
@@ -112,8 +112,7 @@ Module `crates/xtask/src/node_version.rs`. Pure functions unit-tested; process/I
 - [x] E5 deferred strand filed: **bd-s84z961e** (vitest 5 / shim at the Node 26 LTS bump,
       `related:bd-lh30hlvd`); progress comment left on bd-lh30hlvd; bd-lh30hlvd stays open
       until the PR merges
-- [ ] E6 report: exact invocations + observed output for E1/E2, the machine changes made,
-      and the branch/PR handoff (push only with the user's permission)
+- [x] E6 reported to the user 2026-09-08 (commit `1c0fe1c6`); push/PR awaits the user's go-ahead
 
 ## Investigation record (2026-09-08)
 

--- a/claude-notes/plans/2026-09-08-node26-vitest-localstorage.md
+++ b/claude-notes/plans/2026-09-08-node26-vitest-localstorage.md
@@ -1,0 +1,200 @@
+# hub-client vitest: 23 tests fail under Node 26 — `localStorage` global undefined (bd-lh30hlvd)
+
+**Date:** 2026-09-08
+**Braid:** bd-lh30hlvd
+**Checkout:** invoked in the main checkout on `braid/bd-ve916wr8-brand-file-fonts` @ `89c580f1` (no worktree created — see § Notes on the checkout)
+**Status:** Investigation — pending design alignment with user. **Do not start implementation until the user gives the go-ahead.**
+
+## Triage verdict
+
+**Ready to design.** Root cause is fully understood and reproduced at HEAD; three fix
+candidates were tried empirically and one flag-free candidate passes all 62 affected
+tests under Node 26.8.1. The remaining decisions are about *which* layers to fix
+(test config, dependency version, environment enforcement) — not about what is wrong.
+
+The user also asked *why this started happening recently* and *how to avoid the class*.
+Both are answered below (§ Timeline, § Why the May pin did not hold, § Avoiding the class).
+
+## Issue context
+
+Filed 2026-09-08 by Carlos (bug, P2, labels `hub-client`, `testing`), discovered during
+the bd-jsvetdea pre-flight verify. Under Node v26.8.1, `npm run test` in `hub-client`
+prints `ExperimentalWarning: localStorage is not available because --localstorage-file
+was not provided` and every test touching `localStorage` fails with
+`TypeError: Cannot read properties of undefined (reading 'clear')`. 23 tests across 6
+files; `cargo xtask verify`'s hub-client leg is red on Node 26 machines; CI (Node 24) is
+green.
+
+## Dependency graph
+
+- **discovered-from** bd-jsvetdea (closed) — "User theme .scss compile error is
+  swallowed". Its pre-flight `cargo xtask verify` tripped over this. No other context
+  carried; the parent is unrelated to Node.
+- **related** (incoming) bd-202u5bld — "Add a Rust grammar to quarto-highlight".
+  Unrelated in substance; the edge looks like a same-session link. Ignore.
+- No `blocks` edges either way. No incoming pressure beyond "verify is red locally".
+
+## What the code looks like today — root cause
+
+Reproduced at HEAD (`89c580f1`) with Node 26.8.1, vitest 4.1.8, jsdom 26:
+
+```
+$ cd hub-client && npx vitest run src/hooks/usePreference.test.tsx src/services/branchService.test.ts
+ FAIL  src/hooks/usePreference.test.tsx > ... 
+TypeError: Cannot read properties of undefined (reading 'clear')
+ ❯ src/hooks/usePreference.test.tsx:10:16
+      10|   localStorage.clear();
+ Test Files  2 failed (2)   Tests  12 failed (12)
+```
+
+The six failing files all carry `@vitest-environment jsdom` (60 files in hub-client do).
+They never polyfill `localStorage` themselves — they rely on vitest's jsdom environment
+copying `window.localStorage` onto `globalThis`. That copy is what Node 26 breaks:
+
+1. **Node ≥ 25 defines a `localStorage` accessor on `globalThis`** (Web Storage was
+   unflagged in v25.0.0). Without `--localstorage-file` the getter emits the
+   ExperimentalWarning and returns `undefined` — but the *property exists*:
+   `'localStorage' in globalThis === true`. (Probe output in the investigation README.)
+   Node 24 has no such property at all.
+2. **vitest's jsdom environment skips window keys that already exist on the global**
+   unless they are in its explicit allowlist (`KEYS`). In vitest 4.1.8
+   (`node_modules/vitest/dist/chunks/index.DC7d2Pf8.js`, `getWindowKeys`):
+
+   ```js
+   if (k in global) return keysArray.includes(k);
+   ```
+
+   `KEYS` contains `"Storage"` but **not** `"localStorage"`/`"sessionStorage"`. So on
+   Node 26 jsdom's storage is never installed; Node's undefined-returning accessor stays.
+3. Every `localStorage.clear()` / `getItem()` in a test then dereferences `undefined`.
+
+**Upstream status.** vitest `main` now lists `localStorage` and `sessionStorage` in the
+jsdom keys allowlist, but that change shipped only in **vitest 5.0.0** — I unpacked
+4.1.9, 4.1.10, 4.1.11 and 5.0.0 from npm: the key is absent in every 4.1.x and present
+in 5.0.0. Nothing in the 4.x line will fix this. (vitest-dev/vitest#8757 is the
+upstream issue; workspace pins `^4.0.17`, vite `^7.2.4`, and vitest 5 peers on
+`vite ^6.4 || ^7 || ^8`, so an upgrade is at least dependency-compatible.)
+
+### Fix candidates tried (Node 26.8.1, hub-client)
+
+| Candidate | Result | Notes |
+| --- | --- | --- |
+| `NODE_OPTIONS=--no-webstorage` | unit suite green: 96 files / 1084 tests | **`--no-webstorage` is a bad option on Node 24** (`node: bad option`), so it cannot go unconditionally into shared config or CI. |
+| `NODE_OPTIONS=--localstorage-file=<tmp>` | 2 probe files green | Makes Node's *file-backed* Storage the one tests use (jsdom's is still skipped). Persists across runs and workers; wrong semantics for tests. Reject. |
+| `PATH` → node@24 | green | Confirms the environment, not a fix. |
+| **setupFiles shim using jsdom's own Storage** | **6 affected files green: 62/62** | vitest sets `globalThis.jsdom` to the JSDOM instance; the shim re-points `localStorage`/`sessionStorage` at `jsdom.window.<key>` when the global reads `undefined`. No flags, works on 24 and 26, becomes a no-op after a vitest 5 upgrade. Prototype: `node26-vitest-localstorage-investigation/webstorage-shim.ts`. |
+
+Full `npm run test:ci` under the `--no-webstorage` candidate: unit 1084/1084 and
+integration 119/119 pass; one **wasm** smoke-all test fails — identically under Node 24.
+That failure is a stale local `wasm_quarto_hub_client_bg.wasm` (built Sep 1; commit
+`813850ee` on Sep 3 changed include-error semantics). Not part of this strand; a
+`npm run build:wasm` clears it.
+
+## Timeline — why it started "recently" in this environment
+
+All Node on this machine comes from Homebrew; `/opt/homebrew/bin/node` is whatever
+`brew` last linked. There is **no version manager** (no nvm/fnm/volta/asdf/mise), so
+`.nvmrc` is inert, and `engine-strict` is off, so `engines` only warns.
+
+| Date | Event | Evidence |
+| --- | --- | --- |
+| 2026-04-28 | `brew` installs unversioned `node` 25.9.0_2 (Node 25 already unflags Web Storage) | `INSTALL_RECEIPT.json` time |
+| 2026-05-18 | Same symptom hit; commit `ca6d47c8` "chore(node): pin to Node 24 LTS" adds `.nvmrc` = `24` and `engines.node = ^24.0.0`; `node@24` brew formula installed the same afternoon (15:41) and evidently linked, since local tests were green all summer | commit message; `node@24` receipt |
+| 2026-06-01 / 06-10 | CI e2e briefly pinned to 24.15.0 for an unrelated Playwright/yauzl hang, then unpinned back to `'24'` | `55fad91d`, `4a446d85` |
+| 2026-09-04 11:10 | `brew upgrade` installs `node` 26.8.1 and **relinks `/opt/homebrew/bin/node` → 26.8.1**, silently displacing `node@24` | `Cellar/node/26.8.1` receipt; `var/homebrew/linked/node` symlink dated Sep 4 |
+| 2026-09-08 | First `cargo xtask verify` after the upgrade: hub-client leg red; bd-lh30hlvd filed | strand |
+
+So this is a **recurrence** of the May incident, not a new failure mode. The May fix
+aligned the pin with CI but installed nothing that could *enforce* it; the next routine
+`brew upgrade` undid the manual link.
+
+## Why the May pin did not hold
+
+- `.nvmrc` only acts through a version manager; none is installed here.
+- `engines.node` only acts at `npm install`, and only warns unless `engine-strict` is
+  set. (Verified: `npm install --engine-strict --dry-run` under Node 26 fails with
+  `EBADENGINE … Required: {"node":"^24.0.0"}`.) `npm test` never consults `engines`.
+- `cargo xtask verify` and `dev-setup` never look at the Node version; `dev-setup` checks
+  `wasm-opt` but not `node`.
+- The test config itself depended on an accident of Node 24 (no `localStorage` global)
+  rather than stating the requirement.
+
+## Avoiding the class (draft — to be confirmed in design)
+
+Three independent layers, cheapest first:
+
+1. **Make the test config independent of the Node version.** The shim (or the vitest 5
+   upgrade) removes the implicit assumption. This is the only layer that fixes the
+   *symptom* for whoever runs the tests on whatever Node.
+2. **Make the pin bite.** `.npmrc` with `engine-strict=true` turns the wrong Node into an
+   install-time error, and a Node-version check in `cargo xtask verify` (hub leg) and
+   `cargo xtask dev-setup` turns it into an actionable message at the point people
+   actually hit it (`Node 26.8.1 does not satisfy engines.node ^24.0.0 — brew link
+   --overwrite node@24, or install fnm to honor .nvmrc`). Also print the Node version at
+   the top of the hub leg so a red log names the culprit immediately.
+3. **Document the local convention** (`claude-notes/instructions/` or CLAUDE.md): Node is
+   pinned to the current LTS in `.nvmrc`/`engines`; Homebrew users should use `node@24`
+   and expect `brew upgrade` to relink the unversioned `node`; a version manager is the
+   robust option.
+
+Generalisation: any dependency that arrives via the machine's package manager rather
+than the lockfile (Node, wasm-opt, rustup toolchain, tree-sitter CLI) needs an
+*enforced* pin or a self-contained config; an advisory pin recurs on the next upgrade.
+
+## Proposed phases (draft)
+
+- Phase 0 — Test plan. A regression test that fails under Node ≥ 25 without the shim:
+  a small `*.test.ts` under jsdom asserting `typeof localStorage.getItem === 'function'`
+  and `Object.keys(localStorage)` behaviour (branchService relies on key enumeration).
+  Verify it fails at HEAD on Node 26 (done informally above; make it a named test).
+- Phase 1 — Shim: promote `webstorage-shim.ts` into `hub-client/src/test-utils/`,
+  wire it as `setupFiles` in `vitest.config.ts` and `vitest.integration.config.ts`;
+  switch the undefined-check to a descriptor check so Node's ExperimentalWarning is not
+  triggered by the shim's own read. Run `npm run test:ci` on Node 26 and Node 24.
+- Phase 2 — Enforcement: `.npmrc` `engine-strict=true`; Node-version check + version
+  banner in `xtask verify` hub leg and `xtask dev-setup`. Test the check's range parsing.
+- Phase 3 — Docs: local Node convention note; CLAUDE.md pointer.
+- Phase 4 (separate strand, optional) — vitest 5 upgrade across the 11 `^4.0.17`
+  packages + `@vitest/coverage-v8`; afterwards the shim is dead code and can be removed.
+
+## Open design questions for the user
+
+1. **Config fix: shim now, vitest 5 later, or vitest 5 only?** Recommendation: land the
+   shim (small, no-flag, verified) and file the vitest 5 upgrade as its own strand — a
+   major bump across 11 packages is a different risk profile than this bug.
+2. **Should a wrong Node make `cargo xtask verify` fail or only warn?** Recommendation:
+   fail, with an env-var escape hatch (e.g. `Q2_ALLOW_NODE_MISMATCH=1`) for deliberate
+   experiments like the Node 26 runs in this investigation.
+3. **`engine-strict=true` in a committed `.npmrc`?** It fails `npm install` on any Node
+   outside `^24.0.0` for every contributor, including CI if the runner drifts. That is the
+   point, but it is a visible behaviour change — OK?
+4. **Local machine remedy**: re-link `node@24` (`brew link --overwrite node@24`, which
+   `brew upgrade` will undo again) or install a version manager (fnm/mise) so `.nvmrc`
+   is honoured? Not a repo change; asking so the docs recommend what you actually do.
+5. **Scope of the shim**: hub-client only, or also the other jsdom-using packages
+   (`preview-renderer` 38 files, `q2-preview-spa`, `preview-runtime`, `kanban`)? None of
+   their tests reference `localStorage` today, so I'd keep it hub-client-only and note
+   the pattern.
+
+## Risks / tradeoffs (draft)
+
+- The shim reaches into `globalThis.jsdom`, an implementation detail of vitest's jsdom
+  environment (present in 4.1.8; still present upstream). If it disappears the shim
+  no-ops and the Phase 0 regression test fires — acceptable.
+- `engine-strict` also blocks Node 25/26 users who have no interest in hub-client tests;
+  the `engines` range should track the LTS bump deliberately (next: Node 26 becomes LTS
+  in Oct 2026, at which point vitest 5 removes the need for the shim anyway).
+- A Node-version check in xtask must not break on non-Homebrew layouts or on Windows;
+  read `process.version` via `node -p`, don't inspect paths.
+
+## Notes on the checkout
+
+- Pre-flight `cargo xtask verify --skip-hub-build` was **red**, but not because of HEAD:
+  during this session another agent began writing tests in this same checkout
+  (`crates/quarto-sass/tests/integration/brand_compile_test.rs`,
+  `crates/quarto-brand/tests/integration/font_files_test.rs`,
+  `crates/quarto-core/tests/integration/brand_fonts.rs`, mtimes 14:47–14:49) for
+  bd-ve916wr8, and those call `brand_to_layers` with a not-yet-implemented signature.
+  `main` and the committed HEAD compile. This commit therefore stages **only** the plan
+  and investigation files, not `git add -A`.
+- The wasm smoke-all failure noted above is a stale local artifact, not a regression.

--- a/claude-notes/plans/2026-09-08-node26-vitest-localstorage.md
+++ b/claude-notes/plans/2026-09-08-node26-vitest-localstorage.md
@@ -2,199 +2,180 @@
 
 **Date:** 2026-09-08
 **Braid:** bd-lh30hlvd
-**Checkout:** invoked in the main checkout on `braid/bd-ve916wr8-brand-file-fonts` @ `89c580f1` (no worktree created — see § Notes on the checkout)
-**Status:** Investigation — pending design alignment with user. **Do not start implementation until the user gives the go-ahead.**
+**Worktree:** `.worktrees/bd-lh30hlvd-node-version-guard` (branch `braid/bd-lh30hlvd-node-version-guard`, based on `main` @ `b7e7c96a`)
+**Status:** Executing — direction agreed with the user on 2026-09-08 (see § Decision).
 
-## Triage verdict
+## Overview
 
-**Ready to design.** Root cause is fully understood and reproduced at HEAD; three fix
-candidates were tried empirically and one flag-free candidate passes all 62 affected
-tests under Node 26.8.1. The remaining decisions are about *which* layers to fix
-(test config, dependency version, environment enforcement) — not about what is wrong.
+`cargo xtask verify`'s hub-client leg went red on this machine because a routine
+`brew upgrade` on 2026-09-04 relinked `/opt/homebrew/bin/node` from node@24 to node 26.8.1.
+Node ≥ 25 defines a `localStorage` accessor on `globalThis` (returning `undefined` without
+`--localstorage-file`), and vitest 4.x's jsdom environment skips window keys that already
+exist on the global unless allowlisted — `localStorage` is not allowlisted until vitest 5.0.0.
+So jsdom's storage is never installed and every `localStorage.clear()` dereferences `undefined`.
 
-The user also asked *why this started happening recently* and *how to avoid the class*.
-Both are answered below (§ Timeline, § Why the May pin did not hold, § Avoiding the class).
+This is a **recurrence** of the May 2026 incident (`ca6d47c8` pinned Node 24 via `.nvmrc` +
+`engines`). The pin was advisory: no version manager on the machine, `engine-strict` off,
+and nothing in `xtask` looks at the Node version.
 
-## Issue context
+Full root-cause narrative, timeline, candidate table and probe artifacts are preserved in
+§ Investigation record below and in `node26-vitest-localstorage-investigation/`.
 
-Filed 2026-09-08 by Carlos (bug, P2, labels `hub-client`, `testing`), discovered during
-the bd-jsvetdea pre-flight verify. Under Node v26.8.1, `npm run test` in `hub-client`
-prints `ExperimentalWarning: localStorage is not available because --localstorage-file
-was not provided` and every test touching `localStorage` fails with
-`TypeError: Cannot read properties of undefined (reading 'clear')`. 23 tests across 6
-files; `cargo xtask verify`'s hub-client leg is red on Node 26 machines; CI (Node 24) is
-green.
+## Decision (2026-09-08)
 
-## Dependency graph
+The user's top-level decision: **do not move the repo to Node 26 yet**. Keep `engines.node`
+at `^24.0.0`. Fix the local machine so the existing pin is honoured, and make the pin
+*enforced* in the repo so the next drift fails fast with the cause named. Defer the vitest
+shim / vitest 5 upgrade to the deliberate LTS bump (Node 26 becomes LTS in Oct 2026).
 
-- **discovered-from** bd-jsvetdea (closed) — "User theme .scss compile error is
-  swallowed". Its pre-flight `cargo xtask verify` tripped over this. No other context
-  carried; the parent is unrelated to Node.
-- **related** (incoming) bd-202u5bld — "Add a Rust grammar to quarto-highlight".
-  Unrelated in substance; the edge looks like a same-session link. Ignore.
-- No `blocks` edges either way. No incoming pressure beyond "verify is red locally".
+Concretely:
 
-## What the code looks like today — root cause
+1. **Machine**: fnm, initialised in `~/.zprofile`, selects Node 24 from `.nvmrc` on `cd`.
+   Homebrew's `node` stays for `bitwarden-cli`; fnm's default is `system`, so nothing
+   changes outside pinned projects.
+2. **Repo**: a Node-version check in `cargo xtask verify` (fail, with an explicit escape
+   hatch) and `cargo xtask dev-setup` (warn + install hints); `engine-strict=true` in a
+   committed root `.npmrc`; a short instructions note.
+3. **Deferred** (own strand): vitest 5 / jsdom-Storage shim, when `engines` moves to 26.
 
-Reproduced at HEAD (`89c580f1`) with Node 26.8.1, vitest 4.1.8, jsdom 26:
+## Phase A — Local machine (done 2026-09-08)
+
+- [x] `brew install fnm` (1.39.0)
+- [x] `fnm install 24` → v24.20.0 (newer than Homebrew's node@24 24.15.0)
+- [x] `fnm default system` — outside pinned projects `node` stays Homebrew's 26.8.1
+- [x] `~/.zprofile` (new file): `eval "$(fnm env --use-on-cd --version-file-strategy=recursive)"`
+      with a comment explaining why `.zprofile` and not `.zshenv` (`/etc/zprofile`'s
+      `path_helper` would reorder `/opt/homebrew/bin` ahead of fnm — `/etc/paths.d/homebrew`
+      exists on this machine)
+- [x] `~/.zshrc`: pointer comment next to the PATH section
+- [x] Verified from fresh shells: `zsh -l` in repo → v24.20.0; in `hub-client/` → v24.20.0
+      (recursive strategy); outside repo → "Bypassing fnm: using system node" v26.8.1;
+      `zsh -l -i` (Terminal.app shape) → v24.20.0, npm 11.19.0
+- [ ] Note for the user: shells started *before* `~/.zprofile` existed (including the Claude
+      Code session that did this work) keep Node 26 until restarted
+
+## Phase B — Node toolchain check in xtask (TDD)
+
+Module `crates/xtask/src/node_version.rs`. Pure functions unit-tested; process/IO at the edge.
+
+- [ ] B0 tests (written first, must fail before implementation):
+  - [ ] `parse_node_version("v24.20.0")` → `24.20.0`; rejects garbage; tolerates trailing newline
+  - [ ] `engines_node_requirement(package_json_text)` → `VersionReq` for `^24.0.0`; error when
+        `engines`/`engines.node` missing; error (not silent pass) on an unparsable range
+  - [ ] `evaluate(requirement, Some(version))` → `Satisfied` / `Mismatch`; `None` → `NotFound`
+  - [ ] `Mismatch`/`NotFound` render an actionable message naming the found version, the
+        requirement, its source file, and the fnm/`.nvmrc` remedy
+  - [ ] escape hatch: `enforcement(outcome, allow_mismatch: bool)` → `Proceed` / `Fail`
+- [ ] B1 implement: `semver` crate (`VersionReq`, already in `Cargo.lock`) for the range;
+      `node --version` via `crate::util::nested_command` (Windows `.cmd` shims); read
+      `engines.node` from `<root>/package.json`
+- [ ] B2 wire into `verify::run`: before Step 1, when any npm-driven step will run, fail on
+      mismatch unless `Q2_ALLOW_NODE_MISMATCH=1` (then print a loud warning); print
+      `Node vX.Y.Z satisfies engines.node ^24.0.0` on success so a log names the toolchain
+- [ ] B3 wire into `dev_setup::run`: warn-only `check_node()` mirroring `check_wasm_opt`,
+      with per-platform install hints (fnm / mise / nvm; `.nvmrc` selects the version)
+- [ ] B4 `cargo nextest run -p xtask`; `cargo xtask lint`; clippy clean under `-D warnings`
+
+## Phase C — `engine-strict` at install time
+
+- [ ] C1 root `.npmrc`: `engine-strict=true` with a comment pointing at `engines.node` and
+      the instructions note
+- [ ] C2 verify: under Node 26 `npm install --dry-run` fails with `EBADENGINE`; under Node 24
+      `npm ci` in the worktree succeeds (also proves no *dependency* declares an
+      incompatible `engines` range — `engine-strict` applies to the whole tree)
+- [ ] C3 confirm CI is unaffected: every workflow's `setup-node` uses `node-version: '24'`
+      (checked 2026-09-08: hub-client-e2e, ts-test-suite ×2, release ×3, deploy-sandboxed-preview)
+
+## Phase D — Docs
+
+- [ ] D1 `claude-notes/instructions/node-version.md`: the pin (`.nvmrc` + `engines`), what
+      enforces it (xtask check, `engine-strict`), the Homebrew relink trap, fnm setup
+      (`.zprofile` vs `.zshenv` on macOS), the escape hatch, and how the pin gets bumped
+- [ ] D2 `CLAUDE.md`: two-line pointer under hub-client Development
+- [ ] D3 `.claude/rules/worktrees.md` fresh-worktree bootstrap: mention `npm ci` runs under the
+      pinned Node (one line)
+
+## Phase E — End-to-end verification and hand-off
+
+- [ ] E1 `cargo xtask verify` in the worktree under Node 26 (`PATH` override): must stop at the
+      preflight with the Node message, before any Rust build
+- [ ] E2 `cargo xtask verify` in the worktree under Node 24 (full, including hub build + tests):
+      green
+- [ ] E3 `cargo xtask dev-setup` output under both Nodes inspected
+- [ ] E4 pre-commit checklist (`claude-notes/instructions/review.md`) per commit
+- [ ] E5 file the deferred strand (vitest 5 / shim at the Node 26 LTS bump), link
+      `related:bd-lh30hlvd`; comment on bd-lh30hlvd; leave the strand open until the PR merges
+- [ ] E6 report: exact invocations + observed output for E1/E2, the machine changes made,
+      and the branch/PR handoff (push only with the user's permission)
+
+## Investigation record (2026-09-08)
+
+### Root cause
+
+Reproduced at `89c580f1` with Node 26.8.1, vitest 4.1.8, jsdom 26:
 
 ```
 $ cd hub-client && npx vitest run src/hooks/usePreference.test.tsx src/services/branchService.test.ts
- FAIL  src/hooks/usePreference.test.tsx > ... 
 TypeError: Cannot read properties of undefined (reading 'clear')
  ❯ src/hooks/usePreference.test.tsx:10:16
-      10|   localStorage.clear();
  Test Files  2 failed (2)   Tests  12 failed (12)
 ```
 
-The six failing files all carry `@vitest-environment jsdom` (60 files in hub-client do).
-They never polyfill `localStorage` themselves — they rely on vitest's jsdom environment
-copying `window.localStorage` onto `globalThis`. That copy is what Node 26 breaks:
+1. Node ≥ 25 defines a `localStorage` accessor on `globalThis`; without `--localstorage-file`
+   it warns and returns `undefined`, but `'localStorage' in globalThis === true`. Node 24 has
+   no such property (probe output in the investigation README).
+2. vitest 4.1.8 jsdom environment (`getWindowKeys` in
+   `node_modules/vitest/dist/chunks/index.DC7d2Pf8.js`): `if (k in global) return
+   keysArray.includes(k);` — `KEYS` has `"Storage"` but not `"localStorage"`, so jsdom's
+   storage is never copied onto the global.
+3. Upstream added `localStorage`/`sessionStorage` to the allowlist in **vitest 5.0.0** only
+   (verified by unpacking 4.1.9, 4.1.10, 4.1.11, 5.0.0 from npm). vitest-dev/vitest#8757.
 
-1. **Node ≥ 25 defines a `localStorage` accessor on `globalThis`** (Web Storage was
-   unflagged in v25.0.0). Without `--localstorage-file` the getter emits the
-   ExperimentalWarning and returns `undefined` — but the *property exists*:
-   `'localStorage' in globalThis === true`. (Probe output in the investigation README.)
-   Node 24 has no such property at all.
-2. **vitest's jsdom environment skips window keys that already exist on the global**
-   unless they are in its explicit allowlist (`KEYS`). In vitest 4.1.8
-   (`node_modules/vitest/dist/chunks/index.DC7d2Pf8.js`, `getWindowKeys`):
-
-   ```js
-   if (k in global) return keysArray.includes(k);
-   ```
-
-   `KEYS` contains `"Storage"` but **not** `"localStorage"`/`"sessionStorage"`. So on
-   Node 26 jsdom's storage is never installed; Node's undefined-returning accessor stays.
-3. Every `localStorage.clear()` / `getItem()` in a test then dereferences `undefined`.
-
-**Upstream status.** vitest `main` now lists `localStorage` and `sessionStorage` in the
-jsdom keys allowlist, but that change shipped only in **vitest 5.0.0** — I unpacked
-4.1.9, 4.1.10, 4.1.11 and 5.0.0 from npm: the key is absent in every 4.1.x and present
-in 5.0.0. Nothing in the 4.x line will fix this. (vitest-dev/vitest#8757 is the
-upstream issue; workspace pins `^4.0.17`, vite `^7.2.4`, and vitest 5 peers on
-`vite ^6.4 || ^7 || ^8`, so an upgrade is at least dependency-compatible.)
-
-### Fix candidates tried (Node 26.8.1, hub-client)
+### Fix candidates tried (Node 26.8.1)
 
 | Candidate | Result | Notes |
 | --- | --- | --- |
-| `NODE_OPTIONS=--no-webstorage` | unit suite green: 96 files / 1084 tests | **`--no-webstorage` is a bad option on Node 24** (`node: bad option`), so it cannot go unconditionally into shared config or CI. |
-| `NODE_OPTIONS=--localstorage-file=<tmp>` | 2 probe files green | Makes Node's *file-backed* Storage the one tests use (jsdom's is still skipped). Persists across runs and workers; wrong semantics for tests. Reject. |
-| `PATH` → node@24 | green | Confirms the environment, not a fix. |
-| **setupFiles shim using jsdom's own Storage** | **6 affected files green: 62/62** | vitest sets `globalThis.jsdom` to the JSDOM instance; the shim re-points `localStorage`/`sessionStorage` at `jsdom.window.<key>` when the global reads `undefined`. No flags, works on 24 and 26, becomes a no-op after a vitest 5 upgrade. Prototype: `node26-vitest-localstorage-investigation/webstorage-shim.ts`. |
+| `NODE_OPTIONS=--no-webstorage` | unit suite green (96 files / 1084 tests) | **Node 24 rejects the flag** (`bad option`) — cannot be shared config. |
+| `NODE_OPTIONS=--localstorage-file=<tmp>` | green | Substitutes Node's file-backed Storage for jsdom's; persists across runs/workers. Rejected. |
+| `PATH` → node@24 | green | Confirms the environment. |
+| setupFiles shim via `globalThis.jsdom.window.localStorage` | 6 files / 62 tests green | Flag-free, Node-agnostic; **deferred** by decision (would enable Node 26). Prototype kept in the investigation dir. |
 
-Full `npm run test:ci` under the `--no-webstorage` candidate: unit 1084/1084 and
-integration 119/119 pass; one **wasm** smoke-all test fails — identically under Node 24.
-That failure is a stale local `wasm_quarto_hub_client_bg.wasm` (built Sep 1; commit
-`813850ee` on Sep 3 changed include-error semantics). Not part of this strand; a
-`npm run build:wasm` clears it.
+`npm run test:ci` under the `--no-webstorage` candidate: unit 1084/1084, integration 119/119;
+one wasm smoke-all failure identical under Node 24 — a stale local WASM (built Sep 1; `813850ee`
+on Sep 3 changed include-error semantics). Unrelated.
 
-## Timeline — why it started "recently" in this environment
-
-All Node on this machine comes from Homebrew; `/opt/homebrew/bin/node` is whatever
-`brew` last linked. There is **no version manager** (no nvm/fnm/volta/asdf/mise), so
-`.nvmrc` is inert, and `engine-strict` is off, so `engines` only warns.
+### Timeline — why "recently"
 
 | Date | Event | Evidence |
 | --- | --- | --- |
-| 2026-04-28 | `brew` installs unversioned `node` 25.9.0_2 (Node 25 already unflags Web Storage) | `INSTALL_RECEIPT.json` time |
-| 2026-05-18 | Same symptom hit; commit `ca6d47c8` "chore(node): pin to Node 24 LTS" adds `.nvmrc` = `24` and `engines.node = ^24.0.0`; `node@24` brew formula installed the same afternoon (15:41) and evidently linked, since local tests were green all summer | commit message; `node@24` receipt |
-| 2026-06-01 / 06-10 | CI e2e briefly pinned to 24.15.0 for an unrelated Playwright/yauzl hang, then unpinned back to `'24'` | `55fad91d`, `4a446d85` |
-| 2026-09-04 11:10 | `brew upgrade` installs `node` 26.8.1 and **relinks `/opt/homebrew/bin/node` → 26.8.1**, silently displacing `node@24` | `Cellar/node/26.8.1` receipt; `var/homebrew/linked/node` symlink dated Sep 4 |
-| 2026-09-08 | First `cargo xtask verify` after the upgrade: hub-client leg red; bd-lh30hlvd filed | strand |
+| 2026-04-28 | Homebrew installs unversioned `node` 25.9.0_2 | `INSTALL_RECEIPT.json` |
+| 2026-05-18 | Same symptom; `ca6d47c8` pins Node 24 (`.nvmrc`, `engines`); `node@24` installed 15:41 and linked | commit; receipt |
+| 2026-06-01/10 | CI e2e pinned to 24.15.0 for an unrelated Playwright hang, then unpinned to `'24'` | `55fad91d`, `4a446d85` |
+| 2026-09-04 11:10 | `brew upgrade` (manual — no autoupdate agent) installs `node` 26.8.1 and relinks `bin/node` over node@24 | receipt; `var/homebrew/linked/node` |
+| 2026-09-08 | First `cargo xtask verify` after the upgrade is red; bd-lh30hlvd filed | strand |
 
-So this is a **recurrence** of the May incident, not a new failure mode. The May fix
-aligned the pin with CI but installed nothing that could *enforce* it; the next routine
-`brew upgrade` undid the manual link.
+`brew uninstall node` is not an option: `bitwarden-cli` depends on the unversioned formula.
 
-## Why the May pin did not hold
+### Why the May pin did not hold
 
-- `.nvmrc` only acts through a version manager; none is installed here.
-- `engines.node` only acts at `npm install`, and only warns unless `engine-strict` is
-  set. (Verified: `npm install --engine-strict --dry-run` under Node 26 fails with
-  `EBADENGINE … Required: {"node":"^24.0.0"}`.) `npm test` never consults `engines`.
-- `cargo xtask verify` and `dev-setup` never look at the Node version; `dev-setup` checks
-  `wasm-opt` but not `node`.
-- The test config itself depended on an accident of Node 24 (no `localStorage` global)
-  rather than stating the requirement.
+- `.nvmrc` acts only through a version manager; none was installed.
+- `engines.node` acts only at `npm install`, and only warns unless `engine-strict`
+  (`npm install --engine-strict --dry-run` under Node 26 → `EBADENGINE`, verified).
+- `xtask verify` / `dev-setup` never checked Node (`dev-setup` checks `wasm-opt`, not `node`).
 
-## Avoiding the class (draft — to be confirmed in design)
+Generalisation: a dependency that arrives via the machine's package manager rather than the
+lockfile (Node, wasm-opt, the rustup toolchain, tree-sitter CLI) needs an *enforced* pin;
+an advisory pin recurs on the next upgrade.
 
-Three independent layers, cheapest first:
+### Dependency graph
 
-1. **Make the test config independent of the Node version.** The shim (or the vitest 5
-   upgrade) removes the implicit assumption. This is the only layer that fixes the
-   *symptom* for whoever runs the tests on whatever Node.
-2. **Make the pin bite.** `.npmrc` with `engine-strict=true` turns the wrong Node into an
-   install-time error, and a Node-version check in `cargo xtask verify` (hub leg) and
-   `cargo xtask dev-setup` turns it into an actionable message at the point people
-   actually hit it (`Node 26.8.1 does not satisfy engines.node ^24.0.0 — brew link
-   --overwrite node@24, or install fnm to honor .nvmrc`). Also print the Node version at
-   the top of the hub leg so a red log names the culprit immediately.
-3. **Document the local convention** (`claude-notes/instructions/` or CLAUDE.md): Node is
-   pinned to the current LTS in `.nvmrc`/`engines`; Homebrew users should use `node@24`
-   and expect `brew upgrade` to relink the unversioned `node`; a version manager is the
-   robust option.
+- **discovered-from** bd-jsvetdea (closed): its pre-flight verify surfaced this; unrelated in substance.
+- **related** (incoming) bd-202u5bld (Rust highlight grammar): same-session link, unrelated.
+- No `blocks` edges.
 
-Generalisation: any dependency that arrives via the machine's package manager rather
-than the lockfile (Node, wasm-opt, rustup toolchain, tree-sitter CLI) needs an
-*enforced* pin or a self-contained config; an advisory pin recurs on the next upgrade.
+### Notes on the original checkout
 
-## Proposed phases (draft)
-
-- Phase 0 — Test plan. A regression test that fails under Node ≥ 25 without the shim:
-  a small `*.test.ts` under jsdom asserting `typeof localStorage.getItem === 'function'`
-  and `Object.keys(localStorage)` behaviour (branchService relies on key enumeration).
-  Verify it fails at HEAD on Node 26 (done informally above; make it a named test).
-- Phase 1 — Shim: promote `webstorage-shim.ts` into `hub-client/src/test-utils/`,
-  wire it as `setupFiles` in `vitest.config.ts` and `vitest.integration.config.ts`;
-  switch the undefined-check to a descriptor check so Node's ExperimentalWarning is not
-  triggered by the shim's own read. Run `npm run test:ci` on Node 26 and Node 24.
-- Phase 2 — Enforcement: `.npmrc` `engine-strict=true`; Node-version check + version
-  banner in `xtask verify` hub leg and `xtask dev-setup`. Test the check's range parsing.
-- Phase 3 — Docs: local Node convention note; CLAUDE.md pointer.
-- Phase 4 (separate strand, optional) — vitest 5 upgrade across the 11 `^4.0.17`
-  packages + `@vitest/coverage-v8`; afterwards the shim is dead code and can be removed.
-
-## Open design questions for the user
-
-1. **Config fix: shim now, vitest 5 later, or vitest 5 only?** Recommendation: land the
-   shim (small, no-flag, verified) and file the vitest 5 upgrade as its own strand — a
-   major bump across 11 packages is a different risk profile than this bug.
-2. **Should a wrong Node make `cargo xtask verify` fail or only warn?** Recommendation:
-   fail, with an env-var escape hatch (e.g. `Q2_ALLOW_NODE_MISMATCH=1`) for deliberate
-   experiments like the Node 26 runs in this investigation.
-3. **`engine-strict=true` in a committed `.npmrc`?** It fails `npm install` on any Node
-   outside `^24.0.0` for every contributor, including CI if the runner drifts. That is the
-   point, but it is a visible behaviour change — OK?
-4. **Local machine remedy**: re-link `node@24` (`brew link --overwrite node@24`, which
-   `brew upgrade` will undo again) or install a version manager (fnm/mise) so `.nvmrc`
-   is honoured? Not a repo change; asking so the docs recommend what you actually do.
-5. **Scope of the shim**: hub-client only, or also the other jsdom-using packages
-   (`preview-renderer` 38 files, `q2-preview-spa`, `preview-runtime`, `kanban`)? None of
-   their tests reference `localStorage` today, so I'd keep it hub-client-only and note
-   the pattern.
-
-## Risks / tradeoffs (draft)
-
-- The shim reaches into `globalThis.jsdom`, an implementation detail of vitest's jsdom
-  environment (present in 4.1.8; still present upstream). If it disappears the shim
-  no-ops and the Phase 0 regression test fires — acceptable.
-- `engine-strict` also blocks Node 25/26 users who have no interest in hub-client tests;
-  the `engines` range should track the LTS bump deliberately (next: Node 26 becomes LTS
-  in Oct 2026, at which point vitest 5 removes the need for the shim anyway).
-- A Node-version check in xtask must not break on non-Homebrew layouts or on Windows;
-  read `process.version` via `node -p`, don't inspect paths.
-
-## Notes on the checkout
-
-- Pre-flight `cargo xtask verify --skip-hub-build` was **red**, but not because of HEAD:
-  during this session another agent began writing tests in this same checkout
-  (`crates/quarto-sass/tests/integration/brand_compile_test.rs`,
-  `crates/quarto-brand/tests/integration/font_files_test.rs`,
-  `crates/quarto-core/tests/integration/brand_fonts.rs`, mtimes 14:47–14:49) for
-  bd-ve916wr8, and those call `brand_to_layers` with a not-yet-implemented signature.
-  `main` and the committed HEAD compile. This commit therefore stages **only** the plan
-  and investigation files, not `git add -A`.
-- The wasm smoke-all failure noted above is a stale local artifact, not a regression.
+The investigation was done in the main checkout on `braid/bd-ve916wr8-brand-file-fonts`
+(commit `9dd12112`, cherry-picked here as `57360606`); that branch's pre-flight verify was
+red only because another session was writing bd-ve916wr8's tests there. When that branch
+lands first, `git rebase main` on this branch drops the patch-identical plan commit.

--- a/claude-notes/plans/node26-vitest-localstorage-investigation/README.md
+++ b/claude-notes/plans/node26-vitest-localstorage-investigation/README.md
@@ -1,0 +1,44 @@
+# bd-lh30hlvd investigation artifacts
+
+Companion to `../2026-09-08-node26-vitest-localstorage.md`.
+
+| File | What it is |
+| --- | --- |
+| `probe-localstorage.mjs` | Prints how a given Node binary defines the `localStorage` global (descriptor, `typeof`, whether assignment / `defineProperty` succeed). Run with any `node` binary: `node probe-localstorage.mjs`. |
+| `webstorage-shim.ts` | Prototype vitest `setupFiles` entry: when Node's own `localStorage`/`sessionStorage` accessor shadows jsdom's, re-point the global at the jsdom window's real `Storage` (vitest exposes the JSDOM instance as `globalThis.jsdom`). |
+| `vitest.probe.config.ts` | hub-client's unit-test config plus the shim as a setup file, for trying the shim without touching hub-client. |
+
+## Reproduce / verify (from `hub-client/`)
+
+```bash
+node --version                       # v26.8.1 here
+npx vitest run src/hooks/usePreference.test.tsx src/services/branchService.test.ts
+#  -> 12 failed: TypeError: Cannot read properties of undefined (reading 'clear')
+
+npx vitest run --config ../claude-notes/plans/node26-vitest-localstorage-investigation/vitest.probe.config.ts \
+  src/hooks/usePreference.test.tsx src/services/branchService.test.ts \
+  src/components/tabs/AboutTab.test.tsx src/services/debugApi.test.ts \
+  src/components/SyncStatusBadge.test.tsx src/components/ProjectSelector.import.test.tsx
+#  -> Test Files 6 passed (6), Tests 62 passed (62)   (2026-09-08, Node 26.8.1, vitest 4.1.8)
+```
+
+## Probe output (2026-09-08)
+
+```
+##### /opt/homebrew/opt/node@24/bin/node   (v24.15.0)
+descriptor NONE
+typeof localStorage undefined
+after assign -> assigned
+after defineProperty -> defined
+
+##### /opt/homebrew/Cellar/node/26.8.1/bin/node   (v26.8.1)
+descriptor { get: true, set: true, configurable: true, enumerable: false }
+typeof localStorage undefined
+read -> undefined
+after assign -> assigned
+after defineProperty -> defined
+(node:59729) ExperimentalWarning: localStorage is not available because --localstorage-file was not provided.
+```
+
+The difference that matters is the first line: on Node 26 `'localStorage' in globalThis`
+is **true** (an accessor exists) even though reading it yields `undefined`.

--- a/claude-notes/plans/node26-vitest-localstorage-investigation/probe-localstorage.mjs
+++ b/claude-notes/plans/node26-vitest-localstorage-investigation/probe-localstorage.mjs
@@ -1,0 +1,7 @@
+const d = Object.getOwnPropertyDescriptor(globalThis, 'localStorage');
+console.log('version', process.version);
+console.log('descriptor', d ? {get: !!d.get, set: !!d.set, writable: d.writable, configurable: d.configurable, enumerable: d.enumerable, hasValue: 'value' in d} : 'NONE');
+console.log('typeof localStorage', typeof localStorage);
+let v; try { v = globalThis.localStorage; console.log('read ->', v === undefined ? 'undefined' : typeof v); } catch (e) { console.log('read throws', e.message); }
+try { globalThis.localStorage = { clear(){}, tag: 'assigned' }; console.log('after assign ->', globalThis.localStorage && globalThis.localStorage.tag); } catch (e) { console.log('assign throws', e.message); }
+try { Object.defineProperty(globalThis, 'localStorage', { value: { tag: 'defined' }, configurable: true, writable: true }); console.log('after defineProperty ->', globalThis.localStorage.tag); } catch (e) { console.log('defineProperty throws', e.message); }

--- a/claude-notes/plans/node26-vitest-localstorage-investigation/vitest.probe.config.ts
+++ b/claude-notes/plans/node26-vitest-localstorage-investigation/vitest.probe.config.ts
@@ -1,0 +1,12 @@
+// Probe config: hub-client's unit-test config + the prototype shim as a setup file.
+// Run from hub-client/:  npx vitest run --config ../claude-notes/plans/node26-vitest-localstorage-investigation/vitest.probe.config.ts <files>
+import path from 'path';
+import { mergeConfig } from 'vitest/config';
+import base from '../../../hub-client/vitest.config';
+const hubClient = path.resolve(__dirname, '../../../hub-client');
+export default mergeConfig(base, {
+  test: {
+    root: hubClient,
+    setupFiles: [path.resolve(__dirname, 'webstorage-shim.ts')],
+  },
+});

--- a/claude-notes/plans/node26-vitest-localstorage-investigation/webstorage-shim.ts
+++ b/claude-notes/plans/node26-vitest-localstorage-investigation/webstorage-shim.ts
@@ -1,0 +1,10 @@
+// Prototype: when Node >= 25 shadows `localStorage`/`sessionStorage` with its own
+// (undefined-returning) accessor, vitest's jsdom environment skips copying jsdom's
+// Storage onto the global. Re-point the globals at the jsdom window's real Storage.
+type G = typeof globalThis & { jsdom?: { window: Window } };
+const g = globalThis as G;
+for (const key of ['localStorage', 'sessionStorage'] as const) {
+  if (g[key] === undefined && g.jsdom?.window?.[key]) {
+    Object.defineProperty(g, key, { value: g.jsdom.window[key], configurable: true, writable: true, enumerable: true });
+  }
+}

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }
+nodejs-semver = "5"
 proc-macro2 = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/crates/xtask/src/dev_setup.rs
+++ b/crates/xtask/src/dev_setup.rs
@@ -146,11 +146,23 @@ pub fn run() -> Result<()> {
     }
 
     check_cmake();
+    check_node();
     check_pandoc();
     check_deno();
     check_wasm_opt();
 
     Ok(())
+}
+
+/// Check that the `node` on PATH satisfies the repo's pin (`engines.node` in
+/// the root `package.json`, mirrored in `.nvmrc`). Warn-only here; `cargo
+/// xtask verify` enforces it. See `node_version.rs` for why the pin needs
+/// enforcing at all (bd-lh30hlvd).
+fn check_node() {
+    match crate::verify::find_project_root() {
+        Ok(root) => crate::node_version::report_dev_setup(&root),
+        Err(e) => println!("\n  Warning: cannot locate the project root to check Node: {e:#}"),
+    }
 }
 
 /// Check for cmake (required — `cargo build --workspace` pulls in

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -32,6 +32,7 @@ mod build_trace_viewer;
 mod create_worktree;
 mod dev_setup;
 mod lint;
+mod node_version;
 mod pandoc_check;
 mod stage_doc_examples;
 mod switch_task;
@@ -144,6 +145,8 @@ enum Command {
     /// Run full project verification (mirrors CI checks).
     ///
     /// This runs all build and test steps to ensure the entire project is healthy:
+    /// 0. Preflight: the `node` on PATH satisfies `engines.node` in package.json
+    ///    (fails early; override with Q2_ALLOW_NODE_MISMATCH=1 for experiments)
     /// 1. Run custom lint checks (cargo xtask lint)
     /// 2. Check Rust formatting (cargo fmt --check)
     /// 3. Build all Rust crates (cargo build --workspace, with -D warnings)

--- a/crates/xtask/src/node_version.rs
+++ b/crates/xtask/src/node_version.rs
@@ -1,0 +1,470 @@
+//! Node toolchain check — makes the repo's Node pin *enforced* rather than
+//! advisory.
+//!
+//! The pin lives in two places that tooling reads: `engines.node` in the root
+//! `package.json` (npm; this module) and `.nvmrc` (version managers such as
+//! fnm/nvm/mise). Neither does anything on its own: `engines` only warns at
+//! `npm install` unless `engine-strict` is set, and `.nvmrc` needs a version
+//! manager to be installed. That is how the May 2026 pin (`ca6d47c8`) was
+//! silently undone by a `brew upgrade` that relinked `node` to a newer major,
+//! surfacing months later as 23 unrelated-looking vitest failures
+//! (bd-lh30hlvd). This module turns the drift into an immediate, named
+//! failure at the two places people actually hit it: `cargo xtask verify`
+//! (fails, with an explicit escape hatch) and `cargo xtask dev-setup` (warns
+//! with install hints).
+//!
+//! Design: the process/IO edge (`node --version`, reading `package.json`) is
+//! kept thin; everything that decides or explains is a pure function with
+//! unit tests. The range is interpreted with `nodejs-semver`, a Rust
+//! implementation of npm's own range grammar (node-semver), so
+//! `engines.node` means here exactly what it means to npm — including the
+//! space-separated `>=24 <25` form that Cargo's `semver` crate rejects. A
+//! range that does not parse is an *error*, never a silent pass, so a future
+//! `engines` edit cannot disable the check by accident.
+
+use anyhow::{Context, Result, bail};
+use nodejs_semver::{Range, Version};
+use std::path::Path;
+
+/// Environment variable that lets a deliberate experiment run `cargo xtask
+/// verify` against a Node outside the pinned range. Set to `1` or `true`.
+pub const ALLOW_MISMATCH_ENV: &str = "Q2_ALLOW_NODE_MISMATCH";
+
+/// Where the pin is documented for humans.
+pub const DOCS_PATH: &str = "claude-notes/instructions/node-version.md";
+
+/// The Node requirement declared by the repo.
+#[derive(Debug, Clone)]
+pub struct NodeRequirement {
+    /// Parsed range (npm grammar).
+    pub range: Range,
+    /// The range exactly as written in `package.json`, for messages.
+    pub raw: String,
+    /// Human-readable provenance of the range, e.g. `package.json`.
+    pub source: String,
+}
+
+/// Result of comparing the installed Node against the requirement.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Outcome {
+    /// The installed Node is inside the pinned range.
+    Satisfied { found: Version },
+    /// A Node was found, but outside the pinned range.
+    Mismatch { found: Version },
+    /// No usable `node` on `PATH` (missing, failed to run, or unparsable
+    /// `--version` output). `detail` says which.
+    NotFound { detail: String },
+}
+
+/// What `verify` should do with an [`Outcome`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Enforcement {
+    /// Continue (possibly after printing a warning).
+    Proceed,
+    /// Stop before running anything that needs Node.
+    Fail,
+}
+
+/// Parse the output of `node --version` (`v24.20.0\n`) into a [`Version`].
+/// A missing leading `v` is tolerated.
+pub fn parse_node_version(output: &str) -> Result<Version> {
+    let trimmed = output.trim();
+    let bare = trimmed.strip_prefix('v').unwrap_or(trimmed);
+    Version::parse(bare).with_context(|| {
+        format!("cannot parse `node --version` output {output:?} as a semantic version")
+    })
+}
+
+/// Extract and parse `engines.node` from the text of a `package.json`.
+///
+/// Errors when the field is absent or the range is not interpretable — both
+/// are configuration bugs that must surface, not pass.
+pub fn engines_node_requirement(package_json: &str) -> Result<NodeRequirement> {
+    let value: serde_json::Value =
+        serde_json::from_str(package_json).context("package.json is not valid JSON")?;
+    let raw = value
+        .get("engines")
+        .and_then(|engines| engines.get("node"))
+        .and_then(|node| node.as_str())
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "package.json declares no `engines.node` range — the Node pin is missing"
+            )
+        })?;
+    let range = Range::parse(raw).with_context(|| {
+        format!(
+            "cannot interpret the engines.node range {raw:?} in package.json \
+             (expected npm range syntax, e.g. `^24.0.0`, `>=24 <25`, `24.x`)"
+        )
+    })?;
+    Ok(NodeRequirement {
+        range,
+        raw: raw.to_string(),
+        source: "package.json".to_string(),
+    })
+}
+
+/// Compare a probe result (`Ok(version)` from `node --version`, or
+/// `Err(detail)` describing why none was obtained) against the requirement.
+pub fn outcome(requirement: &NodeRequirement, probe: Result<Version, String>) -> Outcome {
+    match probe {
+        Ok(found) if requirement.range.satisfies(&found) => Outcome::Satisfied { found },
+        Ok(found) => Outcome::Mismatch { found },
+        Err(detail) => Outcome::NotFound { detail },
+    }
+}
+
+/// Decide whether `verify` proceeds. `allow_mismatch` is the parsed
+/// [`ALLOW_MISMATCH_ENV`] escape hatch.
+pub fn enforcement(outcome: &Outcome, allow_mismatch: bool) -> Enforcement {
+    match outcome {
+        Outcome::Satisfied { .. } => Enforcement::Proceed,
+        Outcome::Mismatch { .. } | Outcome::NotFound { .. } if allow_mismatch => {
+            Enforcement::Proceed
+        }
+        Outcome::Mismatch { .. } | Outcome::NotFound { .. } => Enforcement::Fail,
+    }
+}
+
+/// Interpret the raw value of [`ALLOW_MISMATCH_ENV`]: `1` or `true`
+/// (case-insensitive) enable the escape hatch; anything else, including an
+/// unset variable, does not.
+pub fn allow_mismatch_from_env(value: Option<&str>) -> bool {
+    matches!(
+        value.map(str::trim),
+        Some(v) if v == "1" || v.eq_ignore_ascii_case("true")
+    )
+}
+
+/// Human-readable explanation of an outcome: what was found, what is
+/// required and where that is declared, and — for anything but
+/// `Satisfied` — how to fix it and how to override it.
+pub fn describe(requirement: &NodeRequirement, outcome: &Outcome) -> String {
+    let required = format!("engines.node {} ({})", requirement.raw, requirement.source);
+    match outcome {
+        Outcome::Satisfied { found } => format!("Node v{found} satisfies {required}"),
+        Outcome::Mismatch { found } => format!(
+            "Node v{found} does not satisfy {required}.\n{}",
+            remedy(requirement)
+        ),
+        Outcome::NotFound { detail } => format!(
+            "Node not found: {detail}. This repository requires {required}.\n{}",
+            remedy(requirement)
+        ),
+    }
+}
+
+/// The fix-it paragraph shared by the non-`Satisfied` messages.
+fn remedy(requirement: &NodeRequirement) -> String {
+    format!(
+        "  This repository pins Node to {raw} (package.json `engines.node`, mirrored in `.nvmrc`).\n  \
+         With fnm, mise, or nvm installed, `.nvmrc` selects the pinned version automatically;\n  \
+         see {DOCS_PATH} for setup (and for the Homebrew relink trap).\n  \
+         To run against this Node anyway, as a deliberate experiment: {ALLOW_MISMATCH_ENV}=1",
+        raw = requirement.raw
+    )
+}
+
+/// Read the requirement from `<project_root>/package.json`.
+pub fn load_requirement(project_root: &Path) -> Result<NodeRequirement> {
+    let path = project_root.join("package.json");
+    let text =
+        std::fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
+    engines_node_requirement(&text).with_context(|| format!("in {}", path.display()))
+}
+
+/// Run `node --version` and parse it. `Err(detail)` explains the failure in
+/// one line suitable for [`Outcome::NotFound`].
+pub fn installed_node_version() -> Result<Version, String> {
+    // `nested_command` strips the inherited cargo package env (see util.rs);
+    // `node` is a real executable on every platform, so no `.cmd` shim.
+    let output = crate::util::nested_command("node")
+        .arg("--version")
+        .output()
+        .map_err(|e| format!("could not run `node --version` ({e})"))?;
+    if !output.status.success() {
+        return Err(format!("`node --version` exited with {}", output.status));
+    }
+    parse_node_version(&String::from_utf8_lossy(&output.stdout)).map_err(|e| format!("{e:#}"))
+}
+
+/// `cargo xtask verify` preflight: fail on a mismatched or missing Node
+/// unless the escape hatch is set, in which case warn loudly and continue.
+/// Prints a one-line confirmation on success so a verify log names the
+/// toolchain it ran with.
+pub fn preflight_verify(project_root: &Path) -> Result<()> {
+    let requirement = load_requirement(project_root)?;
+    let result = outcome(&requirement, installed_node_version());
+    let allow = allow_mismatch_from_env(std::env::var(ALLOW_MISMATCH_ENV).ok().as_deref());
+    let text = describe(&requirement, &result);
+    match enforcement(&result, allow) {
+        Enforcement::Proceed if matches!(result, Outcome::Satisfied { .. }) => {
+            println!("  ✓ {text}");
+            Ok(())
+        }
+        Enforcement::Proceed => {
+            println!(
+                "  ⚠ {text}\n  ⚠ {ALLOW_MISMATCH_ENV} is set — continuing on an unsupported Node; \
+                 results may not match CI."
+            );
+            Ok(())
+        }
+        Enforcement::Fail => bail!("{text}"),
+    }
+}
+
+/// `cargo xtask dev-setup` report: warn-only, mirroring the other tool checks.
+pub fn report_dev_setup(project_root: &Path) {
+    let requirement = match load_requirement(project_root) {
+        Ok(requirement) => requirement,
+        Err(e) => {
+            println!("\n  Warning: cannot read the repository's Node pin: {e:#}");
+            return;
+        }
+    };
+    let result = outcome(&requirement, installed_node_version());
+    let text = describe(&requirement, &result);
+    if matches!(result, Outcome::Satisfied { .. }) {
+        println!("\n  {text}");
+        return;
+    }
+    println!("\n  Warning: {text}");
+    println!("  Install a version manager so `.nvmrc` is honoured, e.g.:");
+    for line in version_manager_install_hints() {
+        println!("    {line}");
+    }
+}
+
+/// Platform-specific fnm install commands. `fnm install` with no version
+/// reads `.nvmrc` when run inside the repository.
+fn version_manager_install_hints() -> &'static [&'static str] {
+    #[cfg(target_os = "macos")]
+    {
+        &[
+            "brew install fnm",
+            "eval \"$(fnm env --use-on-cd --version-file-strategy=recursive)\"   # in ~/.zprofile",
+            "fnm install    # inside the repo: installs the .nvmrc version",
+        ]
+    }
+    #[cfg(windows)]
+    {
+        &[
+            "winget install Schniz.fnm",
+            "fnm env --use-on-cd | Out-String | Invoke-Expression   # in $PROFILE",
+            "fnm install    # inside the repo: installs the .nvmrc version",
+        ]
+    }
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        &[
+            "curl -fsSL https://fnm.vercel.app/install | bash",
+            "eval \"$(fnm env --use-on-cd --version-file-strategy=recursive)\"   # in your shell rc",
+            "fnm install    # inside the repo: installs the .nvmrc version",
+        ]
+    }
+    #[cfg(not(any(windows, unix)))]
+    {
+        &["install fnm (https://github.com/Schniz/fnm) and run `fnm install` inside the repo"]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn req(raw: &str) -> NodeRequirement {
+        engines_node_requirement(&format!(r#"{{"engines":{{"node":"{raw}"}}}}"#))
+            .expect("requirement parses")
+    }
+
+    fn v(s: &str) -> Version {
+        Version::parse(s).unwrap()
+    }
+
+    // --- parse_node_version -------------------------------------------------
+
+    #[test]
+    fn parses_node_version_output_with_leading_v_and_newline() {
+        assert_eq!(parse_node_version("v24.20.0\n").unwrap(), v("24.20.0"));
+    }
+
+    #[test]
+    fn parses_node_version_without_leading_v() {
+        assert_eq!(parse_node_version("26.8.1").unwrap(), v("26.8.1"));
+    }
+
+    #[test]
+    fn rejects_garbage_node_version_output() {
+        assert!(parse_node_version("garbage").is_err());
+        assert!(parse_node_version("").is_err());
+        assert!(parse_node_version("v24").is_err());
+    }
+
+    // --- engines_node_requirement --------------------------------------------
+
+    #[test]
+    fn reads_caret_range_from_engines() {
+        let r = req("^24.0.0");
+        assert_eq!(r.raw, "^24.0.0");
+        assert_eq!(r.source, "package.json");
+        assert!(r.range.satisfies(&v("24.0.0")));
+        assert!(r.range.satisfies(&v("24.20.0")));
+        assert!(!r.range.satisfies(&v("26.8.1")));
+        assert!(!r.range.satisfies(&v("23.11.0")));
+    }
+
+    #[test]
+    fn reads_other_range_forms_used_by_npm() {
+        assert!(req(">=24 <25").range.satisfies(&v("24.5.0")));
+        assert!(!req(">=24 <25").range.satisfies(&v("25.0.0")));
+        assert!(req("24.x").range.satisfies(&v("24.20.0")));
+        assert!(!req("24.x").range.satisfies(&v("26.8.1")));
+    }
+
+    #[test]
+    fn errors_when_engines_node_is_missing() {
+        let err = engines_node_requirement(r#"{"name":"x"}"#).unwrap_err();
+        assert!(err.to_string().contains("engines.node"), "{err:#}");
+        let err = engines_node_requirement(r#"{"engines":{}}"#).unwrap_err();
+        assert!(err.to_string().contains("engines.node"), "{err:#}");
+    }
+
+    #[test]
+    fn errors_instead_of_passing_on_unparsable_range() {
+        let err = engines_node_requirement(r#"{"engines":{"node":"latest-ish"}}"#).unwrap_err();
+        assert!(err.to_string().contains("latest-ish"), "{err:#}");
+    }
+
+    #[test]
+    fn errors_on_invalid_package_json() {
+        assert!(engines_node_requirement("{not json").is_err());
+    }
+
+    #[test]
+    fn repo_package_json_engines_node_is_parsable() {
+        // Guards the real pin: if someone rewrites `engines.node` into a form
+        // the check cannot interpret, this test fails before the check
+        // starts failing everyone's `verify`.
+        let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+        let r = load_requirement(&root).expect("root package.json declares engines.node");
+        assert!(!r.raw.is_empty());
+    }
+
+    // --- outcome ---------------------------------------------------------------
+
+    #[test]
+    fn outcome_classifies_probe_results() {
+        let r = req("^24.0.0");
+        assert_eq!(
+            outcome(&r, Ok(v("24.20.0"))),
+            Outcome::Satisfied {
+                found: v("24.20.0")
+            }
+        );
+        assert_eq!(
+            outcome(&r, Ok(v("26.8.1"))),
+            Outcome::Mismatch { found: v("26.8.1") }
+        );
+        assert_eq!(
+            outcome(&r, Err("no `node` on PATH".to_string())),
+            Outcome::NotFound {
+                detail: "no `node` on PATH".to_string()
+            }
+        );
+    }
+
+    // --- enforcement -----------------------------------------------------------
+
+    #[test]
+    fn satisfied_always_proceeds() {
+        let ok = Outcome::Satisfied {
+            found: v("24.20.0"),
+        };
+        assert_eq!(enforcement(&ok, false), Enforcement::Proceed);
+        assert_eq!(enforcement(&ok, true), Enforcement::Proceed);
+    }
+
+    #[test]
+    fn mismatch_fails_unless_escape_hatch_is_set() {
+        let bad = Outcome::Mismatch { found: v("26.8.1") };
+        assert_eq!(enforcement(&bad, false), Enforcement::Fail);
+        assert_eq!(enforcement(&bad, true), Enforcement::Proceed);
+    }
+
+    #[test]
+    fn not_found_fails_unless_escape_hatch_is_set() {
+        let missing = Outcome::NotFound {
+            detail: "x".to_string(),
+        };
+        assert_eq!(enforcement(&missing, false), Enforcement::Fail);
+        assert_eq!(enforcement(&missing, true), Enforcement::Proceed);
+    }
+
+    #[test]
+    fn escape_hatch_env_parsing() {
+        assert!(allow_mismatch_from_env(Some("1")));
+        assert!(allow_mismatch_from_env(Some("true")));
+        assert!(allow_mismatch_from_env(Some("TRUE")));
+        assert!(!allow_mismatch_from_env(Some("0")));
+        assert!(!allow_mismatch_from_env(Some("")));
+        assert!(!allow_mismatch_from_env(Some("yes")));
+        assert!(!allow_mismatch_from_env(None));
+    }
+
+    // --- describe --------------------------------------------------------------
+
+    #[test]
+    fn describe_satisfied_names_version_and_requirement() {
+        let r = req("^24.0.0");
+        let text = describe(
+            &r,
+            &Outcome::Satisfied {
+                found: v("24.20.0"),
+            },
+        );
+        assert_eq!(
+            text,
+            "Node v24.20.0 satisfies engines.node ^24.0.0 (package.json)"
+        );
+    }
+
+    #[test]
+    fn describe_mismatch_is_actionable() {
+        let r = req("^24.0.0");
+        let text = describe(&r, &Outcome::Mismatch { found: v("26.8.1") });
+        assert!(
+            text.starts_with("Node v26.8.1 does not satisfy engines.node ^24.0.0"),
+            "{text}"
+        );
+        for needle in [
+            "(package.json)",
+            ".nvmrc",
+            "fnm",
+            DOCS_PATH,
+            ALLOW_MISMATCH_ENV,
+        ] {
+            assert!(text.contains(needle), "missing {needle:?} in:\n{text}");
+        }
+    }
+
+    #[test]
+    fn describe_not_found_carries_detail_and_remedy() {
+        let r = req("^24.0.0");
+        let text = describe(
+            &r,
+            &Outcome::NotFound {
+                detail: "no `node` on PATH".to_string(),
+            },
+        );
+        assert!(text.starts_with("Node not found"), "{text}");
+        for needle in [
+            "no `node` on PATH",
+            "^24.0.0",
+            ".nvmrc",
+            DOCS_PATH,
+            ALLOW_MISMATCH_ENV,
+        ] {
+            assert!(text.contains(needle), "missing {needle:?} in:\n{text}");
+        }
+    }
+}

--- a/crates/xtask/src/verify.rs
+++ b/crates/xtask/src/verify.rs
@@ -2,6 +2,8 @@
 //!
 //! Runs all build and test steps to ensure the entire project is healthy,
 //! matching the CI environment as closely as possible:
+//! 0. Preflight: the `node` on PATH satisfies `engines.node` (see
+//!    `node_version.rs`; skipped only when every npm-driven step is off)
 //! 1. Run custom lint checks
 //! 2. Check Rust formatting (cargo fmt --check)
 //! 3. Build all Rust crates (with -D warnings, matching CI)
@@ -69,6 +71,27 @@ pub fn run(config: &VerifyConfig) -> Result<()> {
     } else {
         Some("-D warnings")
     };
+
+    // Preflight: Node toolchain. Every npm-driven step below (6–14) runs
+    // whatever `node` is first on PATH, and the repo pins a Node major in
+    // `engines.node` / `.nvmrc`. Drift surfaces late and misleadingly (23
+    // unrelated-looking vitest failures under Node 26 — bd-lh30hlvd), so check
+    // first: a mismatch fails in seconds, before the Rust build, with the
+    // cause named. Nothing to check when every npm-driven step is disabled.
+    let needs_node = !(config.skip_ts_packages_build
+        && config.skip_hub_build
+        && config.skip_hub_tests
+        && config.skip_trace_viewer_build
+        && config.skip_trace_viewer_tests
+        && config.skip_shared_package_tests
+        && config.skip_q2_preview_spa_build
+        && config.skip_hub_mcp_tests);
+    println!("\n━━━ Preflight: Node toolchain ━━━\n");
+    if needs_node {
+        crate::node_version::preflight_verify(&project_root)?;
+    } else {
+        println!("  (skipped — every npm-driven step is disabled)");
+    }
 
     // Step 1: Custom lint checks + clippy gate
     {
@@ -590,7 +613,7 @@ pub fn run(config: &VerifyConfig) -> Result<()> {
 }
 
 /// Find the project root directory (where Cargo.toml with [workspace] lives).
-fn find_project_root() -> Result<std::path::PathBuf> {
+pub(crate) fn find_project_root() -> Result<std::path::PathBuf> {
     let mut dir = std::env::current_dir().context("Failed to get current directory")?;
 
     loop {


### PR DESCRIPTION
## Summary

The repo has pinned Node 24 since `ca6d47c8` (`.nvmrc` + `engines.node`), but the pin was advisory: `.nvmrc` needs a version manager, `engines` only warns at `npm install`, and xtask never looked. A `brew upgrade` on 2026-09-04 relinked `node` to 26.8.1 on a dev machine and the hub-client vitest suite went red four days later with 23 unrelated-looking `localStorage` failures (Node ≥ 25 defines a `localStorage` accessor that vitest 4.x's jsdom environment refuses to overwrite; fixed upstream only in vitest 5).

Decision: keep `engines.node` at `^24.0.0` for now and make the pin **enforced**.

- **`crates/xtask/src/node_version.rs`** (new): reads `engines.node` from the root `package.json`, probes `node --version`, classifies the result. Ranges use npm's own grammar (`nodejs-semver`) — Cargo's `semver` crate rejects the space-separated `>=24 <25` form. An unparsable range is an error, never a silent pass. 17 unit tests, written first.
- **`cargo xtask verify`**: "Preflight: Node toolchain" before Step 1 — fails in seconds on a mismatch or missing `node` with an actionable message; prints the version found on success; skips itself when every npm-driven step is disabled. `Q2_ALLOW_NODE_MISMATCH=1` warns and continues (deliberate experiments only).
- **`cargo xtask dev-setup`**: warn-only check with per-platform fnm install hints.
- **`.npmrc`**: `engine-strict=true` — `npm install`/`npm ci` fail with `EBADENGINE` under a Node outside the range (verified under 26.8.1) and succeed under 24 (fresh `npm ci`).
- **Docs**: `claude-notes/instructions/node-version.md` (the pin, what enforces it, fnm setup incl. why `~/.zprofile` not `~/.zshenv` on macOS, the Homebrew relink trap, bump procedure); pointers from `CLAUDE.md` and `.claude/rules/worktrees.md`.

Investigation record, timeline and fix-candidate table: `claude-notes/plans/2026-09-08-node26-vitest-localstorage.md`. Deferred vitest 5 / shim work for the eventual Node 26 bump: bd-s84z961e.

## Verification

- Full `cargo xtask verify` under Node 24.20.0: all 14 steps green (13,757 Rust tests; hub-client 1084/119/133; trace-viewer, shared preview-*, hub MCP suites).
- Under Node 26.8.1, `cargo xtask verify` stops at the preflight with exit 1 before any Rust build.
- Clippy (`-D warnings`), `cargo fmt`, `cargo xtask lint` clean.

CI runs `actions/setup-node` with `node-version: '24'` in every workflow, so `engine-strict` and the preflight are no-ops there — this PR is mainly to confirm that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Gr8MUcZtbVAz8wzokihQV