### PR TITLE
Bump workspace version to 0.30.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "comrak-to-pandoc"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "comrak",
  "hashlink",
@@ -4806,7 +4806,7 @@ dependencies = [
 
 [[package]]
 name = "quarto"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4854,7 +4854,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-analysis"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "insta",
  "quarto-error-reporting",
@@ -4880,7 +4880,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-brand"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "pathdiff",
  "quarto-util",
@@ -4892,7 +4892,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-citeproc"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "glob",
  "hashlink",
@@ -4926,7 +4926,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-core"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4984,7 +4984,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-csl"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "insta",
  "quarto-error-reporting",
@@ -5012,7 +5012,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-error-catalog"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "once_cell",
  "quarto-error-reporting",
@@ -5048,7 +5048,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-highlight"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "hashlink",
  "insta",
@@ -5078,7 +5078,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-highlight-encoding"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -5086,7 +5086,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-hub"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "automerge",
@@ -5130,7 +5130,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-hub-provider"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "automerge",
  "ciborium",
@@ -5156,7 +5156,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-lsp"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "insta",
@@ -5172,7 +5172,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-lsp-core"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "insta",
  "pampa",
@@ -5195,7 +5195,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-mcp-launcher"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -5211,7 +5211,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-navigation"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "quarto-config",
  "quarto-pandoc-types",
@@ -5222,7 +5222,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-p2p"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "axum",
  "futures",
@@ -5266,7 +5266,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-preview"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "automerge",
@@ -5304,7 +5304,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-project-create"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "quarto-doctemplate",
  "serde",
@@ -5315,7 +5315,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-publish"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5340,7 +5340,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-sass"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "grass",
  "include_dir",
@@ -5364,7 +5364,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-source-fetch"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "flate2",
  "tar",
@@ -5387,7 +5387,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-system-runtime"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5405,7 +5405,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-test"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "quarto-core",
@@ -5422,7 +5422,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-trace"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "flate2",
  "serde",
@@ -5433,7 +5433,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-trace-server"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -5460,7 +5460,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-util"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "dirs",
  "serde",
@@ -5469,7 +5469,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-xml"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "insta",
  "quarto-error-reporting",
@@ -5707,7 +5707,7 @@ dependencies = [
 
 [[package]]
 name = "reconcile-viewer"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "clap",
  "hashlink",
@@ -6714,7 +6714,7 @@ checksum = "ea06cc588e43c632923a55450401b8f25e628131571d4e1baea1bdfdb2b5ed06"
 
 [[package]]
 name = "spa-manifest"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -7973,7 +7973,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-printf-fmt"
-version = "0.29.0"
+version = "0.30.0"
 
 [[package]]
 name = "wasm-streams"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.29.0"
+version = "0.30.0"
 authors = ["Posit Software, PBC"]
 homepage = "https://github.com/posit-dev/quarto-markdown-syntax"
 keywords = ["parser"]

--- a/crates/wasm-quarto-hub-client/Cargo.lock
+++ b/crates/wasm-quarto-hub-client/Cargo.lock
@@ -377,7 +377,7 @@ dependencies = [
 
 [[package]]
 name = "comrak-to-pandoc"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "comrak",
  "hashlink",
@@ -2075,7 +2075,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-analysis"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "quarto-error-reporting",
  "quarto-pandoc-types",
@@ -2097,7 +2097,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-brand"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "pathdiff",
  "quarto-util",
@@ -2108,7 +2108,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-citeproc"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "glob",
  "hashlink",
@@ -2139,7 +2139,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-core"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2191,7 +2191,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-csl"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "quarto-error-reporting",
  "quarto-source-map",
@@ -2242,7 +2242,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-highlight"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "once_cell",
  "quarto-highlight-encoding",
@@ -2269,7 +2269,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-highlight-encoding"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2277,7 +2277,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-lsp-core"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "pampa",
  "pollster",
@@ -2298,7 +2298,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-navigation"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "quarto-config",
  "quarto-pandoc-types",
@@ -2335,7 +2335,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-project-create"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "quarto-doctemplate",
  "serde",
@@ -2345,7 +2345,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-sass"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "include_dir",
  "once_cell",
@@ -2377,7 +2377,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-system-runtime"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -2394,7 +2394,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-trace"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "flate2",
  "serde",
@@ -2412,7 +2412,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-util"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "dirs",
  "serde",
@@ -2421,7 +2421,7 @@ dependencies = [
 
 [[package]]
 name = "quarto-xml"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "quarto-error-reporting",
  "quarto-source-map",
@@ -4038,7 +4038,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-printf-fmt"
-version = "0.29.0"
+version = "0.30.0"
 
 [[package]]
 name = "wasm-quarto-hub-client"


### PR DESCRIPTION
Version bump for the **v0.30.0** release, per `claude-notes/instructions/release-runbook.md` step 2.

The release workflow's preflight job fails unless the git tag exactly equals `[workspace.package].version`, so this has to land on `main` before `v0.30.0` is tagged.

## Changes

- `Cargo.toml`: `[workspace.package].version` 0.29.0 → 0.30.0
- `Cargo.lock`: `cargo update --workspace` (workspace members only; no external dep moved)
- `crates/wasm-quarto-hub-client/Cargo.lock`: the second lockfile — that crate declares its own `[workspace]`, so a root `cargo update` does not reach it.

## Verification

- `cargo build --bin q2 --locked` → `q2 (quarto 2) 0.30.0`.
- `cargo nextest run --workspace` → **13798 passed (1 leaky), 199 skipped, 0 failed**.
- `npm run build:wasm` from `hub-client/` → succeeds and leaves the tree clean, confirming the second lockfile is right.
- No snapshot files added, modified, or removed.
- The jsr-pinning gotcha in the runbook still does not apply: `jsr:@quarto/api` / `jsr:@quarto/types` are not yet published (jsr.io returns 404).

Scope is whatever is on `main` at merge: 11 first-parent commits since v0.29.0 (PRs #661, #662, #663 plus direct commits). PR #664 stays open and is **not** in this release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0112cioipQzGf118XbJwg7L1
