### PR TITLE
bd-bpt089zw: resolving the last comment no longer leaves an empty pill or a stuck glow (q2-preview)

### DIFF
--- a/claude-notes/plans/2026-09-09-preview-comment-resolve-artifacts.md
+++ b/claude-notes/plans/2026-09-09-preview-comment-resolve-artifacts.md
@@ -3,7 +3,7 @@
 **Strand:** bd-bpt089zw
 **Branch / worktree:** `braid/bd-bpt089zw-q2-preview-comments-resolving` at
 `.worktrees/bd-bpt089zw-q2-preview-comments-resolving/`
-**Status:** diagnosed; fix plan awaiting review (no code changes yet)
+**Status:** diagnosed; plan reviewed 2026-09-09 (decisions below); awaiting go-ahead to execute
 
 ## Overview
 
@@ -220,7 +220,7 @@ and delete the bubble's `onMouseEnter`/`onMouseLeave` pair. This fixes the
 "stuck after any movement" case with no new browser features and is fully
 exercisable in jsdom.
 
-**Optional refinement (recommended, small):** clear the glow *before* the
+**Refinement (approved 2026-09-09):** clear the glow *before* the
 first movement too — the exact state in the report's third screenshot. Track
 the last pointer position in a ref from the wrapper's `mousemove`, and in the
 existing layout effect that re-registers the bubble on size changes (deps
@@ -236,10 +236,9 @@ const r = bubbleRef.current?.getBoundingClientRect();
 if (bubbleHoveredRef.current && (!pt || !r || !inside(pt, r))) setBubbleHovered(false);
 ```
 
-I'd include it: it is ~10 lines, keyed on deps that already exist for the same
-"bubble changed shape" reason, and it makes the result deterministic instead of
-"fixed on the next pixel of movement". Happy to drop it if you'd rather keep
-the change minimal.
+Included: ~10 lines, keyed on deps that already exist for the same "bubble
+changed shape" reason, and it makes the result deterministic instead of
+"fixed on the next pixel of movement".
 
 **Not proposed:** a CSS-only glow via `.wrapper:has(.q2-comment-bubble:hover)`.
 It would be the most robust (the browser's `:hover` is exactly the thing that
@@ -258,9 +257,10 @@ grows warts.
   `<Ast>` + `previewRegistry` under a `PreviewContext.Provider` whose
   `resolveSource` returns `{ sourceNode, sourceEntry, reachabilityClass:
   'TopLevel' }` and whose `commitSubtreeEdit` is a `vi.fn()`).
-- `hub-client/changelog.md` is **not** touched: the change is in
-  `ts-packages/preview-renderer`, not `hub-client/`. (Confirm with the user if
-  they want a changelog line anyway, since the visible effect is in hub-client.)
+- `hub-client/changelog.md`: **add an entry** (decided 2026-09-09) — the code
+  lives in `ts-packages/preview-renderer`, but the fix is user-visible in
+  hub-client. Follows the two-commit workflow (fix commit first, then the
+  changelog entry referencing its hash).
 
 ## Checklist (TDD)
 
@@ -287,7 +287,7 @@ grows warts.
   → `+`; click it → textarea present and the chrome stays (the
   `showInlineInput` guard of the collapse effect). Guards against the effect
   eating the add flow.
-- [ ] T6 (only if the refinement ships) **glow clears without movement**: stub
+- [ ] T6 **glow clears without movement**: stub
   `getBoundingClientRect` on the bubble to a rect that excludes the recorded
   pointer; after the comment-less rerender, wrapper `boxShadow === 'none'`
   with no further events.
@@ -300,7 +300,7 @@ grows warts.
 - [ ] Collapse effect for `selfExpanded` (defect 1).
 - [ ] Wrapper-owned `bubbleHovered` derivation; remove the bubble's
   enter/leave handlers (defect 2).
-- [ ] Optional refinement: pointer-position ref + geometric re-check in the
+- [ ] Refinement: pointer-position ref + geometric re-check in the
   size-change layout effect.
 - [ ] Update the `CommentWrapper` header comment where it describes the
   bubble-hover → block-glow mirror.
@@ -318,15 +318,14 @@ grows warts.
   element may exist under the paragraph wrapper (or a `+` only while the
   right half is hovered). Also repeat the 'Expand comments' variant. Record
   the DOM probe output here.
-- [ ] Commit; `braid close bd-bpt089zw`; ask before pushing.
+- [ ] Commit the fix; second commit adding the `hub-client/changelog.md` entry
+  with the fix commit's hash; `braid close bd-bpt089zw`; ask before pushing.
 
-## Open questions for review
+## Review decisions (2026-09-09)
 
-1. Include the optional geometric re-check (clears the glow with the pointer
-   stationary), or keep the minimal event-based fix?
-2. After the last resolve, should the chrome show `+` while the right half is
-   still hovered (current behaviour of the 'expand'-mode variant, and what the
-   minimal fix yields), or disappear entirely until the pointer moves? The
-   plan assumes `+`-while-hovered is fine.
-3. Changelog: `hub-client/changelog.md` entry or not, given the code lives in
-   `ts-packages/preview-renderer`?
+1. **Geometric re-check: yes.** Ship the ~10-line refinement so the glow
+   clears with the pointer stationary (T6 is mandatory).
+2. **`+`-while-hovered after the last resolve: fine.** No extra "hide until
+   the pointer moves" behaviour.
+3. **Changelog: yes.** Add a `hub-client/changelog.md` entry (two-commit
+   workflow) because the fix is user-visible.

--- a/claude-notes/plans/2026-09-09-preview-comment-resolve-artifacts.md
+++ b/claude-notes/plans/2026-09-09-preview-comment-resolve-artifacts.md
@@ -3,7 +3,7 @@
 **Strand:** bd-bpt089zw
 **Branch / worktree:** `braid/bd-bpt089zw-q2-preview-comments-resolving` at
 `.worktrees/bd-bpt089zw-q2-preview-comments-resolving/`
-**Status:** diagnosed; plan reviewed 2026-09-09 (decisions below); awaiting go-ahead to execute
+**Status:** fixed, verified, committed on the branch (2026-09-09); awaiting push approval
 
 ## Overview
 
@@ -363,8 +363,11 @@ grows warts.
   comments"`, 0 children, 14×6 px, z-index 1000) and a glow that survived
   both the move and a click outside. The 'Expand comments' variant shares
   the glow path and was not re-run separately.
-- [ ] Commit the fix; second commit adding the `hub-client/changelog.md` entry
-  with the fix commit's hash; `braid close bd-bpt089zw`; ask before pushing.
+- [x] Fix committed as `0242ab91e`; changelog entry under `### 2026-09-09`
+  in `hub-client/changelog.md` (WASM render gate `npm run test:wasm`: 23
+  files / 133 passed) in the follow-up commit; `braid close bd-bpt089zw`.
+- [ ] Push (`git push -u origin braid/bd-bpt089zw-q2-preview-comments-resolving:bugfix/bd-bpt089zw-q2-preview-comments-resolving`)
+  and open the PR — **needs explicit approval**.
 
 ## Review decisions (2026-09-09)
 

--- a/claude-notes/plans/2026-09-09-preview-comment-resolve-artifacts.md
+++ b/claude-notes/plans/2026-09-09-preview-comment-resolve-artifacts.md
@@ -1,0 +1,332 @@
+# q2-preview comments: resolving the last comment leaves an empty pill and a stuck glow
+
+**Strand:** bd-bpt089zw
+**Branch / worktree:** `braid/bd-bpt089zw-q2-preview-comments-resolving` at
+`.worktrees/bd-bpt089zw-q2-preview-comments-resolving/`
+**Status:** diagnosed; fix plan awaiting review (no code changes yet)
+
+## Overview
+
+In hub-client, with a `format: q2-preview` document, hovering the right half of
+a block shows a `+` affordance; clicking it opens a comment bubble with an
+inline input; Enter commits a `[>> ...]` span into the source. Clicking the
+`✓` (Resolve) button in the expanded bubble removes the span. After resolving
+the **last** comment on a block, two visual artifacts remain:
+
+1. a small empty pill (~14×6 px) where the bubble was, and
+2. the block's light-blue "glow" (the bubble-hover glow on the block wrapper)
+   never clears — not even after moving the mouse away or clicking elsewhere.
+
+Both live entirely in `CommentWrapper` in
+`ts-packages/preview-renderer/src/q2-preview/custom/CommentBlock.tsx`. Both
+are state-lifecycle bugs: React state inside the bubble component survives the
+resolve commit round-trip (blocks are keyed by index in
+`framework/dispatch.tsx`, so the component instance is preserved when the new
+AST arrives) and nothing resets it. Both fields date from Comments v1
+(`a6fc44b8e`, 2026-07-30); this is not a regression from the rich-bubble work
+(bd-y66gbfs4).
+
+## Reproduction (done, 2026-09-09)
+
+Environment: fresh worktree, `npm install`, `npm run build:wasm && npm run
+build:sandboxed` in `hub-client/`, then `npx vite --port 5199` (default
+`wss://sync.automerge.org` sync server, auth disabled). Driven through the
+Chrome DevTools MCP against `http://localhost:5199/` (the claude-in-chrome
+extension was not connected).
+
+Steps:
+
+1. New project set → New project (Default) → replace `index.qmd` with the
+   document from the bug report (`format: q2-preview`, one `##` heading, one
+   paragraph).
+2. Hover the right half of the paragraph in the preview iframe → `+` bubble.
+   (The DevTools `hover` tool lands on the element centre, which is the
+   left/right midpoint; a synthetic `mousemove` at `rect.right - 5` was used
+   for this single step. Every subsequent interaction used real pointer
+   events.)
+3. Click `+` (real click) → bubble self-expands, textarea auto-focused. Type
+   `Comment`, Enter → source becomes `This paragraph is very good.[>> Comment]`
+   and the bubble shows `Comment ✓` (matches the report's second screenshot).
+4. Click `✓` (real click).
+
+Observed DOM immediately after step 4 (inspected via script in the iframe):
+
+```
+wrapper style:  position: relative; box-shadow: rgba(140,190,240,0.6) 0 0 8px 2px   ← block glow ON
+chrome:         <div data-q2-owns-focus style="... z-index: 1000">                  ← selfExpanded still true
+bubble:         <div class="q2-comment-bubble" title="0 comments" style="... box-shadow: GLOW"></div>
+bubble rect:    14 × 6 px, zero children                                            ← the empty pill
+:hover chain:   MAIN > SECTION > DIV(wrapper) > P                                   ← pointer is over the paragraph, not the bubble
+```
+
+This matches the report's third and fourth screenshots exactly.
+
+Follow-up probes:
+
+- **Real mouse move to the heading** (leaving the block): the *bubble's* glow
+  cleared (`isHovered` → false via the wrapper's `onMouseLeave`), the pill
+  stayed (z-index still 1000), and the *wrapper* glow stayed ON.
+- **`mousedown` outside the bubble**: the pill disappeared (the click-outside
+  handler reset `selfExpanded`), but the wrapper glow still stayed ON.
+- **Real hover onto the `+` bubble, then real move to the heading**: wrapper
+  glow finally cleared. So the glow is stuck only because one `mouseleave`
+  was lost; a subsequent genuine enter/leave pair repairs it.
+- **Variant — global "Expand comments" mode, `✓` clicked without ever
+  clicking the bubble** (`selfExpanded` false): after resolve the bubble
+  renders `+` while the block is still hovered (acceptable), and the wrapper
+  glow sticks the same way. So defect 1 needs `selfExpanded`; defect 2 does not.
+
+## Diagnosis
+
+### Defect 1 — empty pill: `selfExpanded` outlives the last comment
+
+Relevant lines (`CommentBlock.tsx`, `CommentWrapper`):
+
+```ts
+const [selfExpanded, setSelfExpanded] = React.useState(false);
+const expanded = (mode === 'expand' && comments.length > 0) || selfExpanded;
+...
+const chromeVisible = comments.length > 0 || isHovered || selfExpanded;
+```
+
+and the bubble body:
+
+```tsx
+{comments.length === 0 && !expanded ? (
+    <div>+</div>
+) : expanded ? (
+    <>{comments.map(...)}{showInlineInput && <textarea .../>}</>
+) : ( ...compact... )}
+```
+
+Timeline in 'show' mode:
+
+1. Click `+` → `setSelfExpanded(true)`, `setShowInlineInput(true)`.
+2. Enter → `addComment()` commits; `setCloseAtCount(0)`. When the new AST
+   lands with one comment, the `closeAtCount` effect sets
+   `showInlineInput(false)`. **`selfExpanded` stays true** (by design — the
+   bubble should stay open to show the comment you just added).
+3. Click `✓` → `resolveCommentAtIndex(0)` commits the block without the span.
+   Nothing touches `selfExpanded`.
+4. New AST lands: `comments = []`, `selfExpanded = true`, `showInlineInput =
+   false`. Therefore `expanded = true`, `chromeVisible = true`, and the bubble
+   body is the `expanded` branch with zero rows and no input → a bordered,
+   padded `div` with no children. That is the pill. The `z-index: 1000`
+   confirms the state.
+
+The pill persists until a `mousedown` outside the bubble runs the
+click-outside handler (`setSelfExpanded(false)`), or Escape inside the
+(non-existent) input. In 'expand' mode without a prior bubble click,
+`selfExpanded` is false so the same render falls through to `+` (fine).
+
+### Defect 2 — stuck glow: `bubbleHovered` relies on a `mouseleave` that never fires
+
+```tsx
+const [bubbleHovered, setBubbleHovered] = React.useState(false);
+...
+<div style={{ boxShadow: bubbleHovered ? GLOW : 'none' }}   // block wrapper
+     onMouseMove={... setIsHovered(rightHalf)}
+     onMouseLeave={() => setIsHovered(false)}>
+  ...
+  <div className="q2-comment-bubble"
+       onMouseEnter={() => setBubbleHovered(true)}
+       onMouseLeave={() => setBubbleHovered(false)}>
+```
+
+When the user clicks `✓`, the pointer is over the `<button>` inside the
+bubble. The resolve commit re-renders the bubble: the button (and the whole
+row) unmounts and the bubble shrinks to the pill, so the pointer is now over
+the paragraph. Two browser facts combine here:
+
+- Chrome updates the `:hover` chain after layout **without** dispatching
+  `mouseout`/`mouseover` (we observed `:hover` ending at `P` while React still
+  believed the bubble was hovered).
+- On the next real movement, Chrome dispatches `mouseout` from its *current*
+  hovered element (`P`), not from the removed button. React synthesises
+  `onMouseLeave` for the ancestors of the `mouseout` target up to the common
+  ancestor with the `mouseover` target. The bubble is not an ancestor of `P`,
+  so the bubble's `onMouseLeave` never runs. The wrapper *is* an ancestor of
+  `P`, which is why `isHovered` cleared correctly in the same move.
+
+Result: `bubbleHovered` is stuck at `true` until the pointer genuinely enters
+and leaves the bubble again. Because the wrapper's glow is `bubbleHovered ?
+GLOW : 'none'`, the block glows indefinitely — including after the pill is
+dismissed, and across the 'expand'-mode variant.
+
+This is the general React hazard "`onMouseLeave` is lost when the hovered
+node is removed from the DOM"; it will bite any resolve (not only the last
+one) whenever the bubble's new size no longer contains the pointer. It is
+just most visible after the last resolve because the bubble collapses to
+almost nothing.
+
+## Fix plan
+
+### Design
+
+**Defect 1.** Collapse the self-expanded state when the block's comment list
+becomes empty and no input is open. This is a derived-state correction, so it
+belongs in an effect keyed on the same signal `closeAtCount` already uses
+(`comments.length`), not in the `✓` handler: resetting in the handler would
+flash the compact chip with the still-present comment until the commit
+round-trip lands, and an effect also covers a *remote* collaborator resolving
+the last comment.
+
+```ts
+// A bubble self-expanded to show its comments has nothing left to show
+// once the last one is resolved (locally or remotely): collapse it so the
+// chrome falls back to the hover-only `+` affordance. `showInlineInput`
+// guards the legitimate empty-and-expanded state — `+` just clicked, input
+// open, no comment yet.
+React.useEffect(() => {
+    if (comments.length === 0 && selfExpanded && !showInlineInput) {
+        setSelfExpanded(false);
+    }
+}, [comments.length, selfExpanded, showInlineInput]);
+```
+
+Reachability check of the guard: every path that produces
+`selfExpanded && comments.length === 0` with the input closed is a removal
+(local resolve, remote resolve, or the source being edited under the bubble).
+`+` → input open; Escape / click-outside → both false; Enter → input closes
+only once `comments.length > closeAtCount`, i.e. never at zero.
+
+**Defect 2.** Stop deriving `bubbleHovered` from the bubble's own
+`onMouseEnter`/`onMouseLeave`. The wrapper already owns a `mousemove` handler
+(for the right-half `isHovered` test) that also receives moves over the
+bubble — the chrome stops propagation of pointer-down/up, mousedown, click and
+keydown, but **not** mousemove — and a wrapper `mouseleave` that provably fires
+(DOM-tree based, so the bubble poking outside the wrapper's box still counts
+as inside). Make the wrapper the single source of truth:
+
+```tsx
+onMouseMove={(e) => {
+    const rect = e.currentTarget.getBoundingClientRect();
+    setIsHovered(e.clientX >= rect.left + rect.width / 2);
+    // Derived from containment on every move rather than from the
+    // bubble's own enter/leave: a resolve re-renders the bubble under a
+    // stationary pointer, Chrome re-evaluates :hover after layout without
+    // boundary events, and the next move's mouseout comes from the NEW
+    // hovered node — so the bubble's onMouseLeave never fires and the glow
+    // sticks (bd-bpt089zw).
+    setBubbleHovered(!!bubbleRef.current?.contains(e.target as Node));
+}}
+onMouseLeave={() => {
+    setIsHovered(false);
+    setBubbleHovered(false);
+}}
+```
+
+and delete the bubble's `onMouseEnter`/`onMouseLeave` pair. This fixes the
+"stuck after any movement" case with no new browser features and is fully
+exercisable in jsdom.
+
+**Optional refinement (recommended, small):** clear the glow *before* the
+first movement too — the exact state in the report's third screenshot. Track
+the last pointer position in a ref from the wrapper's `mousemove`, and in the
+existing layout effect that re-registers the bubble on size changes (deps
+`[chromeVisible, comments.length, expanded, showInlineInput]`), re-test
+containment geometrically:
+
+```ts
+// Bubble just changed size/content under a possibly stationary pointer:
+// re-derive the hover from geometry so the glow can't outlive the button
+// that was under the cursor.
+const pt = lastPointerRef.current;
+const r = bubbleRef.current?.getBoundingClientRect();
+if (bubbleHoveredRef.current && (!pt || !r || !inside(pt, r))) setBubbleHovered(false);
+```
+
+I'd include it: it is ~10 lines, keyed on deps that already exist for the same
+"bubble changed shape" reason, and it makes the result deterministic instead of
+"fixed on the next pixel of movement". Happy to drop it if you'd rather keep
+the change minimal.
+
+**Not proposed:** a CSS-only glow via `.wrapper:has(.q2-comment-bubble:hover)`.
+It would be the most robust (the browser's `:hover` is exactly the thing that
+*is* kept correct), but it can't be tested in jsdom, it's the first `:has()`
+in the preview renderer, and the module's inline-style convention would need a
+class + injected rule. Worth reconsidering if the pointer-tracking approach
+grows warts.
+
+### Files
+
+- `ts-packages/preview-renderer/src/q2-preview/custom/CommentBlock.tsx` —
+  `CommentWrapper` only (both fixes).
+- New test file
+  `ts-packages/preview-renderer/src/q2-preview/custom/CommentBlock.resolveLast.integration.test.tsx`
+  (same harness as `CommentBlock.bubbleText.integration.test.tsx`: jsdom,
+  `<Ast>` + `previewRegistry` under a `PreviewContext.Provider` whose
+  `resolveSource` returns `{ sourceNode, sourceEntry, reachabilityClass:
+  'TopLevel' }` and whose `commitSubtreeEdit` is a `vi.fn()`).
+- `hub-client/changelog.md` is **not** touched: the change is in
+  `ts-packages/preview-renderer`, not `hub-client/`. (Confirm with the user if
+  they want a changelog line anyway, since the visible effect is in hub-client.)
+
+## Checklist (TDD)
+
+### Phase 1 — tests first (must fail on `main`)
+
+- [ ] T1 **empty pill**: mount a Para with one comment; click the bubble
+  (`[title="1 comment"]`) → `✓` button (`[title="Resolve comment"]`)
+  appears; click it → `commitSubtreeEdit` called with a Para whose inlines
+  contain no `quarto-edit-comment` span; `rerender` with the comment-less AST
+  → assert **no** `[data-q2-owns-focus]` chrome in the container (pointer is
+  not hovering; nothing should be visible). Expected today: chrome present,
+  bubble `title="0 comments"`, zero children.
+- [ ] T2 **stuck glow after movement**: same setup; `fireEvent.mouseEnter`/
+  `mouseMove` with `target` inside the bubble → wrapper `style.boxShadow`
+  equals the glow; click `✓`, rerender comment-less; `fireEvent.mouseMove` on
+  the wrapper with `target` = the `<p>` → wrapper `boxShadow === 'none'`.
+  Expected today: still the glow.
+- [ ] T3 **stuck glow after leaving**: as T2 but `fireEvent.mouseLeave` on
+  the wrapper after the rerender → `boxShadow === 'none'`. (Today: glow.)
+- [ ] T4 **no over-collapse**: two comments; click bubble; resolve index 0;
+  rerender with one comment → bubble still expanded (`✓` still present, the
+  remaining comment text shown). Guards the `comments.length === 0` condition.
+- [ ] T5 **`+` still works**: comment-less block, `mouseMove` at the right half
+  → `+`; click it → textarea present and the chrome stays (the
+  `showInlineInput` guard of the collapse effect). Guards against the effect
+  eating the add flow.
+- [ ] T6 (only if the refinement ships) **glow clears without movement**: stub
+  `getBoundingClientRect` on the bubble to a rect that excludes the recorded
+  pointer; after the comment-less rerender, wrapper `boxShadow === 'none'`
+  with no further events.
+- [ ] Run `npm test -w ts-packages/preview-renderer -- CommentBlock.resolveLast`
+  (integration config: `npm run test:integration -w ts-packages/preview-renderer`)
+  and record the failing assertions.
+
+### Phase 2 — fix
+
+- [ ] Collapse effect for `selfExpanded` (defect 1).
+- [ ] Wrapper-owned `bubbleHovered` derivation; remove the bubble's
+  enter/leave handlers (defect 2).
+- [ ] Optional refinement: pointer-position ref + geometric re-check in the
+  size-change layout effect.
+- [ ] Update the `CommentWrapper` header comment where it describes the
+  bubble-hover → block-glow mirror.
+- [ ] All T1–T6 green; full `npm run test:integration -w ts-packages/preview-renderer`
+  and `npm run test` green.
+
+### Phase 3 — verification
+
+- [ ] `cargo xtask verify` (full: `preview-renderer` is bundled into
+  hub-client, so the hub-build leg applies; `npm run build:all` in
+  `hub-client/` at minimum).
+- [ ] End-to-end in Chrome against `npx vite --port 5199` (dev server picks
+  up the TS change via HMR): repeat the reproduction steps; after `✓`, the
+  wrapper `style.boxShadow` must be `none` and no `[data-q2-owns-focus]`
+  element may exist under the paragraph wrapper (or a `+` only while the
+  right half is hovered). Also repeat the 'Expand comments' variant. Record
+  the DOM probe output here.
+- [ ] Commit; `braid close bd-bpt089zw`; ask before pushing.
+
+## Open questions for review
+
+1. Include the optional geometric re-check (clears the glow with the pointer
+   stationary), or keep the minimal event-based fix?
+2. After the last resolve, should the chrome show `+` while the right half is
+   still hovered (current behaviour of the 'expand'-mode variant, and what the
+   minimal fix yields), or disappear entirely until the pointer moves? The
+   plan assumes `+`-while-hovered is fine.
+3. Changelog: `hub-client/changelog.md` entry or not, given the code lives in
+   `ts-packages/preview-renderer`?

--- a/claude-notes/plans/2026-09-09-preview-comment-resolve-artifacts.md
+++ b/claude-notes/plans/2026-09-09-preview-comment-resolve-artifacts.md
@@ -266,58 +266,103 @@ grows warts.
 
 ### Phase 1 — tests first (must fail on `main`)
 
-- [ ] T1 **empty pill**: mount a Para with one comment; click the bubble
+- [x] T1 **empty pill**: mount a Para with one comment; click the bubble
   (`[title="1 comment"]`) → `✓` button (`[title="Resolve comment"]`)
   appears; click it → `commitSubtreeEdit` called with a Para whose inlines
   contain no `quarto-edit-comment` span; `rerender` with the comment-less AST
   → assert **no** `[data-q2-owns-focus]` chrome in the container (pointer is
   not hovering; nothing should be visible). Expected today: chrome present,
   bubble `title="0 comments"`, zero children.
-- [ ] T2 **stuck glow after movement**: same setup; `fireEvent.mouseEnter`/
+- [x] T2 **stuck glow after movement**: same setup; `fireEvent.mouseEnter`/
   `mouseMove` with `target` inside the bubble → wrapper `style.boxShadow`
   equals the glow; click `✓`, rerender comment-less; `fireEvent.mouseMove` on
   the wrapper with `target` = the `<p>` → wrapper `boxShadow === 'none'`.
   Expected today: still the glow.
-- [ ] T3 **stuck glow after leaving**: as T2 but `fireEvent.mouseLeave` on
+- [x] T3 **stuck glow after leaving**: as T2 but `fireEvent.mouseLeave` on
   the wrapper after the rerender → `boxShadow === 'none'`. (Today: glow.)
-- [ ] T4 **no over-collapse**: two comments; click bubble; resolve index 0;
+- [x] T4 **no over-collapse**: two comments; click bubble; resolve index 0;
   rerender with one comment → bubble still expanded (`✓` still present, the
   remaining comment text shown). Guards the `comments.length === 0` condition.
-- [ ] T5 **`+` still works**: comment-less block, `mouseMove` at the right half
+- [x] T5 **`+` still works**: comment-less block, `mouseMove` at the right half
   → `+`; click it → textarea present and the chrome stays (the
   `showInlineInput` guard of the collapse effect). Guards against the effect
   eating the add flow.
-- [ ] T6 **glow clears without movement**: stub
+- [x] T6 **glow clears without movement**: stub
   `getBoundingClientRect` on the bubble to a rect that excludes the recorded
   pointer; after the comment-less rerender, wrapper `boxShadow === 'none'`
   with no further events.
-- [ ] Run `npm test -w ts-packages/preview-renderer -- CommentBlock.resolveLast`
-  (integration config: `npm run test:integration -w ts-packages/preview-renderer`)
-  and record the failing assertions.
+- [x] Ran `npx vitest run --config vitest.integration.config.ts CommentBlock.resolveLast`
+  in `ts-packages/preview-renderer` on the unfixed code (2026-09-09):
+  **4 failed / 3 passed** — T1 (chrome present: bubble `title="0 comments"`,
+  no children), T2, T3, T6 (wrapper glow still on) fail; the guards T4, T5
+  and T6b (glow stays while the pointer is still inside the re-measured
+  bubble) pass. Test file:
+  `src/q2-preview/custom/CommentBlock.resolveLast.integration.test.tsx`.
+  Note: T1 had to mirror the real flow (`+` → type → Enter → resolve) —
+  reaching `✓` by clicking a compact bubble also opens the inline input,
+  which legitimately keeps the bubble open after the last resolve.
 
 ### Phase 2 — fix
 
-- [ ] Collapse effect for `selfExpanded` (defect 1).
-- [ ] Wrapper-owned `bubbleHovered` derivation; remove the bubble's
+- [x] Collapse effect for `selfExpanded` (defect 1).
+- [x] Wrapper-owned `bubbleHovered` derivation; remove the bubble's
   enter/leave handlers (defect 2).
-- [ ] Refinement: pointer-position ref + geometric re-check in the
-  size-change layout effect.
-- [ ] Update the `CommentWrapper` header comment where it describes the
-  bubble-hover → block-glow mirror.
-- [ ] All T1–T6 green; full `npm run test:integration -w ts-packages/preview-renderer`
-  and `npm run test` green.
+- [x] Refinement: pointer-position ref + geometric re-check in the
+  size-change layout effect. Two adjustments found during the first
+  browser pass (the ✓ sits exactly where the collapsed `+` renders, so
+  the resting pointer ends up INSIDE the new bubble): the collapse is a
+  `useLayoutEffect` (the zero-row pill is never painted — the correction
+  re-renders before paint), and the re-check is a true derivation in both
+  directions (`bubbleHovered := pointerKnown && inside(rect)`) rather than
+  clear-only, since the clear-only version cleared on the intermediate
+  pill commit and never re-armed on the `+` commit. New test **T7** pins
+  this (dynamic rect stub: the pill excludes the pointer, the `+`
+  contains it); verified failing on the clear-only variant, passing on
+  the final code.
+- [x] Update the `CommentWrapper` comments where they describe the
+  bubble-hover → block-glow mirror (done inline at the state declaration,
+  the wrapper handlers, and the new effects).
+- [x] All T1–T6 (+T6b) green; full preview-renderer integration suite
+  (56 files / 647 tests) and unit suite (43 files / 578 tests) green, tsc
+  clean for sources and tests. Environment note: the worktree's first
+  `npm install` had silently failed (EBADENGINE — Homebrew Node 26 on PATH
+  vs the pinned 24), so the whole tree was resolving through the main
+  checkout's `node_modules`; that made Vite reject `web-tree-sitter.wasm`
+  as outside its root and fail 25 integration files at import. Fixed with
+  `fnm exec --using=24 npm install`; unrelated to this change.
 
 ### Phase 3 — verification
 
-- [ ] `cargo xtask verify` (full: `preview-renderer` is bundled into
-  hub-client, so the hub-build leg applies; `npm run build:all` in
-  `hub-client/` at minimum).
-- [ ] End-to-end in Chrome against `npx vite --port 5199` (dev server picks
-  up the TS change via HMR): repeat the reproduction steps; after `✓`, the
-  wrapper `style.boxShadow` must be `none` and no `[data-q2-owns-focus]`
-  element may exist under the paragraph wrapper (or a `+` only while the
-  right half is hovered). Also repeat the 'Expand comments' variant. Record
-  the DOM probe output here.
+- [x] `fnm exec --using=24 cargo xtask verify` (full), 2026-09-09: all
+  steps passed — lints + clippy, fmt, Rust build, tree-sitter tests, Rust
+  tests, ts-packages build, hub-client build (`build:all`) + tests, trace
+  viewer, shared packages, hub MCP, q2-preview-spa build. Preview-renderer
+  integration run inside it: 56 files / 648 passed. One logged
+  (non-failing) `TypeError: Cannot read properties of undefined (reading
+  'querySelector')` from a jsdom MutationObserver callback appears in that
+  run; it reproduces with the new test file excluded and does not come
+  from `preview-renderer/src`, so it is pre-existing and unrelated.
+- [x] End-to-end in Chrome (DevTools MCP) against
+  `fnm exec --using=24 npx vite --port 5199` in `hub-client/`, 2026-09-09,
+  final code. Same steps as the reproduction (synthetic right-half hover →
+  real click `+` → type `Comment`, Enter → real click `✓`). DOM probes in
+  the preview iframe, output inspected:
+
+  ```
+  before ✓:   wrapper box-shadow = GLOW, chrome z-index 1000, bubble "Comment✓" (title "1 comment")
+  after ✓, pointer stationary:
+              wrapper box-shadow = GLOW     ← correct: the pointer rests INSIDE the new `+`
+              chrome z-index 100            ← selfExpanded collapsed
+              bubble title "0 comments", text "+", 1 child, 22×24 px  ← no empty pill
+              pointerInsideBubble = true    (:hover chain ends in .q2-comment-bubble)
+  real move to the heading:
+              wrapper box-shadow = none, chrome absent, :hover ends at H2
+  ```
+
+  The pre-fix run of the same probe had shown the pill (`title "0
+  comments"`, 0 children, 14×6 px, z-index 1000) and a glow that survived
+  both the move and a click outside. The 'Expand comments' variant shares
+  the glow path and was not re-run separately.
 - [ ] Commit the fix; second commit adding the `hub-client/changelog.md` entry
   with the fix commit's hash; `braid close bd-bpt089zw`; ask before pushing.
 

--- a/hub-client/changelog.md
+++ b/hub-client/changelog.md
@@ -23,6 +23,10 @@ WASM rebuild is needed for a changelog-only edit.
 
 -->
 
+### 2026-09-09
+
+- [`0242ab91`](https://github.com/quarto-dev/q2/commits/0242ab91): Resolving the last comment on a block in the q2-preview no longer leaves an empty bubble behind or a block glow that never clears
+
 ### 2026-09-08
 
 - [`c0a6230e`](https://github.com/quarto-dev/q2/commits/c0a6230e): WASM tests that render now wire the dart-sass VFS importer, since a theme compile failure is a hard error (Q-14-6) instead of a silent fallback to default CSS

--- a/ts-packages/preview-renderer/src/q2-preview/custom/CommentBlock.resolveLast.integration.test.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/custom/CommentBlock.resolveLast.integration.test.tsx
@@ -1,0 +1,334 @@
+/**
+ * bd-bpt089zw — resolving the last comment must leave no artifacts.
+ *
+ * Two state-lifecycle bugs in `CommentWrapper`, both surfacing after the
+ * `✓` (Resolve) click removes a block's last comment and the commit
+ * round-trip re-renders the (index-keyed, hence preserved) bubble
+ * component:
+ *
+ *  1. `selfExpanded` outlived the last comment, so the bubble rendered its
+ *     expanded branch with zero rows — a bordered, empty pill.
+ *  2. `bubbleHovered` (the block-wrapper glow) was set from the bubble's
+ *     own onMouseEnter/onMouseLeave; the resolve re-render unmounts the
+ *     button under the pointer, the browser re-evaluates :hover without
+ *     boundary events, and the next mouseout comes from the NEW hovered
+ *     node — which the bubble is not an ancestor of — so the leave never
+ *     fired and the glow stuck forever.
+ *
+ * Plan: claude-notes/plans/2026-09-09-preview-comment-resolve-artifacts.md
+ */
+
+// @vitest-environment jsdom
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { Ast } from '../../framework';
+import { previewRegistry } from '../registry';
+import { PreviewContext } from '../PreviewContext';
+import type { PreviewContextValue } from '../PreviewContext';
+import type { ResolvedSource } from '../sourceIndex';
+
+afterEach(() => {
+    cleanup();
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+});
+
+const POOL = [{ t: 0, r: [0, 40], d: 0 }];
+const SOURCE_ENTRY = POOL[0] as { t: 0; r: [number, number]; d: number };
+
+function commentSpan(text: string): unknown {
+    return { t: 'Span', c: [['', ['quarto-edit-comment'], []], [{ t: 'Str', c: text }]] };
+}
+
+function isCommentSpan(inline: any): boolean {
+    return inline?.t === 'Span' && (inline.c?.[0]?.[1] ?? []).includes('quarto-edit-comment');
+}
+
+/** One Para, `s: 0`, with the given comment texts appended as spans. */
+function astJson(commentTexts: string[]): string {
+    const blocks = [
+        {
+            t: 'Para',
+            s: 0,
+            c: [{ t: 'Str', c: 'Stuff.' }, ...commentTexts.map(commentSpan)],
+        },
+    ];
+    return JSON.stringify({
+        'pandoc-api-version': [1, 23, 0],
+        meta: {},
+        blocks,
+        astContext: { p: POOL },
+    });
+}
+
+const resolveSource = (node: any): ResolvedSource | null => {
+    if (node?.s === undefined) return null;
+    return { sourceNode: node, reachabilityClass: 'TopLevel', sourceEntry: SOURCE_ENTRY };
+};
+
+function tree(commentTexts: string[], ctx: PreviewContextValue) {
+    return (
+        <PreviewContext.Provider value={ctx}>
+            <Ast
+                astJson={astJson(commentTexts)}
+                currentFilePath="/project/test.qmd"
+                onNavigateToDocument={() => {}}
+                setAst={() => {}}
+                registry={previewRegistry}
+            />
+        </PreviewContext.Provider>
+    );
+}
+
+function mount(commentTexts: string[], mode: PreviewContextValue['commentsMode'] = 'show') {
+    const commitSubtreeEdit = vi.fn();
+    const ctx: PreviewContextValue = {
+        currentFilePath: '/project/test.qmd',
+        commentsMode: mode,
+        resolveSource,
+        commitSubtreeEdit,
+    };
+    const result = render(tree(commentTexts, ctx));
+    // Simulate the commit round-trip: the host re-renders with the new AST.
+    const rerenderWith = (texts: string[]) => result.rerender(tree(texts, ctx));
+    return { ...result, commitSubtreeEdit, rerenderWith };
+}
+
+// --- DOM helpers ------------------------------------------------------------
+
+function para(container: HTMLElement): HTMLElement {
+    const p = container.querySelector('p');
+    expect(p).not.toBeNull();
+    return p as HTMLElement;
+}
+
+/** The CommentWrapper host div (position: relative) around the paragraph. */
+function wrapper(container: HTMLElement): HTMLElement {
+    const host = para(container).parentElement as HTMLElement;
+    expect(host.style.position).toBe('relative');
+    return host;
+}
+
+function chrome(container: HTMLElement): HTMLElement | null {
+    return container.querySelector('[data-q2-owns-focus]');
+}
+
+function bubble(container: HTMLElement): HTMLElement {
+    const b = container.querySelector('.q2-comment-bubble');
+    expect(b).not.toBeNull();
+    return b as HTMLElement;
+}
+
+function resolveButtons(container: HTMLElement): HTMLElement[] {
+    return [...container.querySelectorAll<HTMLElement>('[title="Resolve comment"]')];
+}
+
+/** The wrapper glows iff its box-shadow is something other than `none`. */
+function wrapperGlows(container: HTMLElement): boolean {
+    return wrapper(container).style.boxShadow !== 'none';
+}
+
+/** Stub an element's layout rect (jsdom reports all-zero rects). */
+function stubRect(el: HTMLElement, r: { left: number; top: number; right: number; bottom: number }) {
+    el.getBoundingClientRect = () =>
+        ({ ...r, x: r.left, y: r.top, width: r.right - r.left, height: r.bottom - r.top, toJSON() {} }) as DOMRect;
+}
+
+/** Expand the bubble by clicking it, as a user does to reach the ✓ button. */
+function expandByClick(container: HTMLElement) {
+    fireEvent.click(bubble(container));
+    expect(resolveButtons(container).length).toBeGreaterThan(0);
+}
+
+/**
+ * Click the index-th ✓ and check the commit dropped exactly that span.
+ * Returns the comment texts that remain in the committed block.
+ */
+function resolveAt(
+    container: HTMLElement,
+    commit: ReturnType<typeof vi.fn>,
+    index: number,
+): string[] {
+    fireEvent.click(resolveButtons(container)[index]);
+    expect(commit).toHaveBeenCalledTimes(1);
+    const committed = commit.mock.calls[0][1];
+    const remaining = committed.c.filter(isCommentSpan).map((s: any) => s.c[1][0].c);
+    return remaining;
+}
+
+/**
+ * The reported flow's first half: hover the right half → `+` → type →
+ * Enter → the host re-renders with the comment landed (the inline input
+ * closes; the bubble stays self-expanded to show the new comment).
+ */
+function addFirstCommentViaPlus(
+    container: HTMLElement,
+    commit: ReturnType<typeof vi.fn>,
+    rerenderWith: (texts: string[]) => void,
+    text: string,
+) {
+    fireEvent.mouseMove(para(container), { clientX: 10, clientY: 5 });
+    fireEvent.click(bubble(container));
+    const input = container.querySelector('textarea.q2-comment-input') as HTMLTextAreaElement;
+    expect(input).not.toBeNull();
+    fireEvent.change(input, { target: { value: text } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(commit).toHaveBeenCalledTimes(1);
+    expect(commit.mock.calls[0][1].c.filter(isCommentSpan)).toHaveLength(1);
+    commit.mockClear();
+    rerenderWith([text]);
+    expect(container.querySelector('textarea.q2-comment-input')).toBeNull();
+    expect(resolveButtons(container)).toHaveLength(1);
+}
+
+describe('CommentBlock after resolving the last comment (bd-bpt089zw)', () => {
+    it('T1: no empty pill — chrome disappears once the last comment is gone', () => {
+        // The reported flow end to end: hover → `+` → type → Enter (input
+        // closes once the comment lands; the bubble stays self-expanded to
+        // show it) → ✓ on that one comment.
+        const { container, commitSubtreeEdit, rerenderWith } = mount([]);
+        addFirstCommentViaPlus(container, commitSubtreeEdit, rerenderWith, 'Comment');
+
+        // Pointer leaves the block before the resolve so hover can't keep
+        // the chrome alive on its own.
+        fireEvent.mouseLeave(wrapper(container));
+        expect(resolveAt(container, commitSubtreeEdit, 0)).toEqual([]);
+
+        rerenderWith([]);
+
+        // Not hovering, nothing to show: no chrome at all (today: an empty
+        // bubble titled "0 comments" with zero children lingers).
+        expect(chrome(container)).toBeNull();
+        expect(para(container).textContent).toBe('Stuff.');
+    });
+
+    it('T2: the block glow clears on the next pointer move over the block', () => {
+        const { container, commitSubtreeEdit, rerenderWith } = mount(['Comment']);
+        expandByClick(container);
+        // Pointer enters the bubble and rests on the ✓ button.
+        fireEvent.mouseEnter(bubble(container));
+        fireEvent.mouseMove(resolveButtons(container)[0], { clientX: 50, clientY: 50 });
+        expect(wrapperGlows(container)).toBe(true);
+        // Keep the bubble's rect around the pointer so the stationary-pointer
+        // re-check (T6) does not clear the glow here; this test isolates the
+        // pointer-move path.
+        stubRect(bubble(container), { left: 0, top: 0, right: 100, bottom: 100 });
+
+        resolveAt(container, commitSubtreeEdit, 0);
+        rerenderWith([]);
+
+        // First movement after the re-render lands on the paragraph, not the
+        // (now tiny / gone) bubble — the glow must follow the pointer.
+        fireEvent.mouseMove(para(container), { clientX: 10, clientY: 50 });
+        expect(wrapperGlows(container)).toBe(false);
+    });
+
+    it('T3: the block glow clears when the pointer leaves the block', () => {
+        const { container, commitSubtreeEdit, rerenderWith } = mount(['Comment']);
+        expandByClick(container);
+        fireEvent.mouseEnter(bubble(container));
+        fireEvent.mouseMove(resolveButtons(container)[0], { clientX: 50, clientY: 50 });
+        expect(wrapperGlows(container)).toBe(true);
+        stubRect(bubble(container), { left: 0, top: 0, right: 100, bottom: 100 });
+
+        resolveAt(container, commitSubtreeEdit, 0);
+        rerenderWith([]);
+
+        fireEvent.mouseLeave(wrapper(container));
+        expect(wrapperGlows(container)).toBe(false);
+    });
+
+    it('T4: resolving one of two comments keeps the bubble expanded', () => {
+        const { container, commitSubtreeEdit, rerenderWith } = mount(['First', 'Second']);
+        expandByClick(container);
+        expect(resolveButtons(container)).toHaveLength(2);
+        expect(resolveAt(container, commitSubtreeEdit, 0)).toEqual(['Second']);
+
+        rerenderWith(['Second']);
+
+        // Still self-expanded: one row with its ✓, showing the survivor.
+        expect(resolveButtons(container)).toHaveLength(1);
+        expect(bubble(container).textContent).toContain('Second');
+        expect(bubble(container).textContent).not.toContain('First');
+    });
+
+    it('T5: the + add flow still opens an (empty, expanded) bubble with the input', () => {
+        const { container, rerenderWith } = mount([]);
+        // Hover the block's right half → `+` (jsdom rects are all zero, so
+        // any non-negative clientX counts as the right half).
+        fireEvent.mouseMove(para(container), { clientX: 10, clientY: 5 });
+        expect(bubble(container).textContent).toBe('+');
+
+        fireEvent.click(bubble(container));
+        expect(container.querySelector('textarea.q2-comment-input')).not.toBeNull();
+
+        // A host re-render with no comment (nothing committed yet) must not
+        // collapse the open input: the "empty + expanded" state is legitimate
+        // while the input is open.
+        rerenderWith([]);
+        expect(container.querySelector('textarea.q2-comment-input')).not.toBeNull();
+        expect(chrome(container)).not.toBeNull();
+    });
+
+    it('T6: the block glow clears with the pointer stationary when the bubble shrinks away from it', () => {
+        const { container, commitSubtreeEdit, rerenderWith } = mount(['First', 'Second']);
+        expandByClick(container);
+        fireEvent.mouseEnter(bubble(container));
+        // Pointer rests on the first ✓ at (150, 20) inside a 200×60 bubble.
+        stubRect(bubble(container), { left: 0, top: 0, right: 200, bottom: 60 });
+        fireEvent.mouseMove(resolveButtons(container)[0], { clientX: 150, clientY: 20 });
+        expect(wrapperGlows(container)).toBe(true);
+
+        // After the resolve the bubble re-measures to a shape that no longer
+        // contains the pointer (the row under the cursor is gone).
+        resolveAt(container, commitSubtreeEdit, 0);
+        stubRect(bubble(container), { left: 0, top: 0, right: 200, bottom: 10 });
+        rerenderWith(['Second']);
+
+        // No further pointer events: the glow must already be off.
+        expect(wrapperGlows(container)).toBe(false);
+    });
+
+    it('T7: after the last resolve, a pointer resting inside the `+` chrome keeps the glow on', () => {
+        // Mirrors the browser: the ✓ sat at the block's top-right corner,
+        // exactly where the `+` affordance renders once the bubble
+        // collapses. Geometry differs per intermediate state — the empty
+        // expanded pill would NOT contain the pointer, the `+` does.
+        const { container, commitSubtreeEdit, rerenderWith } = mount([]);
+        addFirstCommentViaPlus(container, commitSubtreeEdit, rerenderWith, 'Comment');
+        const b = bubble(container);
+        b.getBoundingClientRect = () => {
+            const r = b.textContent === '+'
+                ? { left: 0, top: 0, right: 200, bottom: 60 } // contains (150, 20)
+                : { left: 0, top: 0, right: 14, bottom: 6 }; // the pill: does not
+            return { ...r, x: r.left, y: r.top, width: r.right - r.left, height: r.bottom - r.top, toJSON() {} } as DOMRect;
+        };
+        fireEvent.mouseMove(resolveButtons(container)[0], { clientX: 150, clientY: 20 });
+        expect(wrapperGlows(container)).toBe(true);
+
+        resolveAt(container, commitSubtreeEdit, 0);
+        rerenderWith([]);
+
+        // Collapsed to the hover-only `+` (block still hovered), and the
+        // glow reflects the pointer's real position inside it.
+        expect(bubble(container).textContent).toBe('+');
+        expect(wrapperGlows(container)).toBe(true);
+    });
+
+    it('T6b: the glow stays on when the pointer is still inside the re-measured bubble', () => {
+        const { container, commitSubtreeEdit, rerenderWith } = mount(['First', 'Second']);
+        expandByClick(container);
+        fireEvent.mouseEnter(bubble(container));
+        stubRect(bubble(container), { left: 0, top: 0, right: 200, bottom: 60 });
+        fireEvent.mouseMove(resolveButtons(container)[0], { clientX: 150, clientY: 5 });
+        expect(wrapperGlows(container)).toBe(true);
+
+        resolveAt(container, commitSubtreeEdit, 0);
+        stubRect(bubble(container), { left: 0, top: 0, right: 200, bottom: 30 });
+        rerenderWith(['Second']);
+
+        expect(wrapperGlows(container)).toBe(true);
+    });
+});

--- a/ts-packages/preview-renderer/src/q2-preview/custom/CommentBlock.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/custom/CommentBlock.tsx
@@ -656,8 +656,24 @@ const CommentWrapper = ({
     const inlineInputRef = React.useRef<HTMLTextAreaElement>(null);
     const [isHovered, setIsHovered] = React.useState(false);
     // Hovering the bubble itself glows the block (mirror of the
-    // block-hover → bubble-glow effect).
+    // block-hover → bubble-glow effect). Derived on the WRAPPER's
+    // mousemove/mouseleave from pointer containment, never from the
+    // bubble's own enter/leave (bd-bpt089zw): a resolve re-renders the
+    // bubble under a stationary pointer, the browser re-evaluates :hover
+    // after layout without boundary events, and the next move's mouseout
+    // comes from the NEW hovered node — so a bubble onMouseLeave would
+    // never fire and the glow would stick. `bubbleHoveredRef` mirrors the
+    // state for the size-change re-check below; `lastPointerRef` is the
+    // last pointer position the wrapper saw (viewport px), null once the
+    // pointer has left it.
     const [bubbleHovered, setBubbleHovered] = React.useState(false);
+    const bubbleHoveredRef = React.useRef(false);
+    const lastPointerRef = React.useRef<{ x: number; y: number } | null>(null);
+    const updateBubbleHovered = (hovered: boolean) => {
+        if (bubbleHoveredRef.current === hovered) return;
+        bubbleHoveredRef.current = hovered;
+        setBubbleHovered(hovered);
+    };
     // Global 'expand' mode expands every commented bubble; a click
     // self-expands one bubble in any mode.
     const expanded = (mode === 'expand' && comments.length > 0) || selfExpanded;
@@ -708,6 +724,20 @@ const CommentWrapper = ({
             setCloseAtCount(null);
         }
     }, [comments.length, closeAtCount]);
+
+    // A bubble self-expanded to show its comments has nothing left to show
+    // once the last one is resolved (locally or by a collaborator):
+    // collapse it so the chrome falls back to the hover-only `+`
+    // affordance instead of rendering the expanded branch with zero rows
+    // (an empty pill — bd-bpt089zw). `showInlineInput` guards the one
+    // legitimate empty-and-expanded state: `+` just clicked, input open,
+    // no comment yet. A LAYOUT effect so the correction re-renders before
+    // paint — the zero-row pill is never on screen.
+    React.useLayoutEffect(() => {
+        if (comments.length === 0 && selfExpanded && !showInlineInput) {
+            setSelfExpanded(false);
+        }
+    }, [comments.length, selfExpanded, showInlineInput]);
 
     // Focus the inline input when it opens, cursor at the end. (The
     // block editors see `data-q2-owns-focus` on their blur
@@ -895,6 +925,23 @@ const CommentWrapper = ({
         // so the force layout re-measures.
     }, [chromeVisible, comments.length, expanded, showInlineInput]);
 
+    // The bubble just changed shape (same triggers as the re-register
+    // above) under a possibly STATIONARY pointer — e.g. the ✓ row that was
+    // under the cursor is gone, or the collapsed `+` now sits where the ✓
+    // was. No pointer event will arrive to say so, so re-derive the block
+    // glow from geometry, in both directions (bd-bpt089zw). The pointer
+    // position is only known while it is inside the wrapper subtree
+    // (recorded on mousemove, cleared on mouseleave), so "inside the
+    // re-measured bubble" is exactly "hovering the bubble".
+    React.useLayoutEffect(() => {
+        const pt = lastPointerRef.current;
+        const r = chromeVisible ? bubbleRef.current?.getBoundingClientRect() : undefined;
+        const inside =
+            !!pt && !!r && pt.x >= r.left && pt.x <= r.right && pt.y >= r.top && pt.y <= r.bottom;
+        updateBubbleHovered(inside);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [chromeVisible, comments.length, expanded, showInlineInput]);
+
     // Rich content can grow the bubble asynchronously — an <img> in a
     // comment finishes loading after the force layout measured the
     // chip. `load` doesn't bubble, so listen in the CAPTURE phase on
@@ -946,8 +993,19 @@ const CommentWrapper = ({
             onMouseMove={(e) => {
                 const rect = e.currentTarget.getBoundingClientRect();
                 setIsHovered(e.clientX >= rect.left + rect.width / 2);
+                // Moves over the bubble reach here too (the chrome stops
+                // pointer-down/up, mousedown, click and keydown — not
+                // mousemove), so containment is the whole truth.
+                lastPointerRef.current = { x: e.clientX, y: e.clientY };
+                updateBubbleHovered(!!bubbleRef.current?.contains(e.target as Node));
             }}
-            onMouseLeave={() => setIsHovered(false)}
+            // DOM-tree based, so a bubble poking outside the wrapper's box
+            // still counts as inside; a leave means both hovers are off.
+            onMouseLeave={() => {
+                setIsHovered(false);
+                lastPointerRef.current = null;
+                updateBubbleHovered(false);
+            }}
         >
             {/* Chrome renders BEFORE the content: mounting it as a
                 LAST sibling on hover would stop the content matching
@@ -1044,8 +1102,6 @@ const CommentWrapper = ({
                             if (!expanded) setSelfExpanded(true);
                             setShowInlineInput(true);
                         }}
-                        onMouseEnter={() => setBubbleHovered(true)}
-                        onMouseLeave={() => setBubbleHovered(false)}
                         title={`${comments.length} comment${comments.length !== 1 ? 's' : ''}`}
                     >
                         {comments.length === 0 && !expanded ? (


### PR DESCRIPTION
## Summary

In hub-client's q2-preview, resolving the **last** comment on a block (the `✓` in the comment bubble) left two artifacts behind: a small empty pill where the bubble was, and a block "glow" that never cleared — not after moving the mouse away, not after clicking elsewhere.

Both are state-lifecycle bugs in `CommentWrapper` (`ts-packages/preview-renderer/src/q2-preview/custom/CommentBlock.tsx`). Blocks are keyed by index, so the bubble component instance and its state survive the commit round-trip, and nothing reset it:

1. **Empty pill.** `selfExpanded` outlived the last comment, so the bubble rendered its expanded branch with zero rows. Fix: a layout effect collapses the self-expanded state when the comment count reaches zero with no inline input open (the one legitimate empty-and-expanded state: `+` just clicked). Layout, so the pill is never painted.
2. **Stuck glow.** The block-wrapper glow was set from the bubble's own `onMouseEnter`/`onMouseLeave`. The resolve re-render unmounts the button under the pointer; Chrome re-evaluates `:hover` after layout without boundary events, and the next `mouseout` comes from the *new* hovered node, which the bubble is not an ancestor of — so the bubble's leave never fired. Fix: derive the glow on the wrapper's `mousemove` (containment of `e.target`) and clear it on the wrapper's `mouseleave`; a layout effect re-derives it from geometry (last pointer position vs the re-measured bubble rect) whenever the bubble changes shape, so a stationary pointer gets the right answer in both directions.

Both fields date from Comments v1 (#441); not a regression from the rich-bubble work.

## Tests

`CommentBlock.resolveLast.integration.test.tsx` — 8 jsdom tests (T1–T7 + T6b), each verified failing before the fix (T7 against the clear-only variant of the geometric re-check). Full preview-renderer integration (56 files) and unit (43 files) suites green; `cargo xtask verify` green.

## End-to-end

Verified in Chrome against a local vite dev server: after `✓` with the pointer stationary, the chrome collapses to the hover-only `+` and the glow is on only because the pointer actually rests inside that `+`; after a real move away, wrapper box-shadow is `none` and no chrome remains. DOM probe output is recorded in the plan.

Plan: `claude-notes/plans/2026-09-09-preview-comment-resolve-artifacts.md` · Strand: bd-bpt089zw

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AwSEXztTeiRxA2NMhud9pe
