### PR TITLE
hub-client: Edit pill in the bottom bar toggles q2-preview block editing (bd-ew0vak6b)

### DIFF
--- a/claude-notes/plans/2026-09-09-q2-preview-edit-toggle.md
+++ b/claude-notes/plans/2026-09-09-q2-preview-edit-toggle.md
@@ -1,0 +1,316 @@
+# hub-client `q2-preview`: editable / read-only toggle in the bottom status bar
+
+**Strand:** bd-ew0vak6b
+**Status:** design reviewed 2026-09-09 — D1–D9 accepted as written (see
+*Review decisions*). Awaiting the go-ahead to execute.
+**Related:** bd-ov4gqk3m (`q2 preview --allow-edit`, the plan at
+`2026-06-10-q2-preview-edit-writeback.md`, which built the `editingDisabled`
+plumbing this work reuses); bd-0rsk07il (the Comments toggle in the same bar).
+
+## Overview
+
+`format: q2-preview` in hub-client is always editable. That makes links
+hard to follow: the block-edit hover surface treats a mouse click on any
+editable block as "open the editor for this block", so a click on a link
+inside a paragraph both follows the link *and* activates the block editor
+(details under *Why links are hard to click*). `q2 preview` already has the
+editable/read-only distinction via `--allow-edit`, and the renderer already
+implements read-only mode behind a single flag. hub-client just never sets
+it.
+
+The deliverable is an **Edit** pill in the bar at the bottom of the document
+view (the replay bar, which already carries the **Authors** pill and the
+**Comments** three-way toggle) that turns block editing on and off. The
+choice is persisted as a user preference. When editing is off the preview
+behaves like a read-only `q2 preview`: no hover outlines, no edit
+affordances, links are plain links.
+
+## What the source study found
+
+### The read-only flag already exists end to end inside the renderer
+
+`ts-packages/preview-renderer` implements read-only mode as
+`editingDisabled`, introduced for `q2 preview` without `--allow-edit`
+(bd-ov4gqk3m):
+
+- `Q2PreviewIframe` takes `editingDisabled?: boolean`
+  (`ts-packages/preview-renderer/src/iframe/Q2PreviewIframe.tsx:95`) and
+  ships it inside the `UPDATE_AST` payload. The flag is in the effect's
+  dependency array, so **flipping the prop re-posts `UPDATE_AST`** — no new
+  message type is needed for a live toggle.
+- `entry.tsx` unpacks it from the payload and hands it to `PreviewRoot`,
+  which puts it on `PreviewContext.editingDisabled`
+  (`PreviewRoot.tsx:1574`).
+- Consumers: `Para`, `Header`, `BulletList`, `OrderedList`,
+  `DefinitionList`, `taskList`, `listBorrow` all fold `!ctx?.editingDisabled`
+  into `isEditable`, so no `data-block-pool-id` is emitted; and
+  `useBlockEditHover` returns an inert surface (`{ hostProps: {},
+  stylesheet: null }`) — no pointer handlers, no affordance CSS, no roving
+  tabindex (`useBlockEditHover.tsx:341`).
+- Existing tests: "Affordance gate — global editingDisabled" in
+  `q2-preview.integration.test.tsx:1145`.
+
+The `q2-preview-spa` is the reference host: it passes
+`editingDisabled={!state.allowEdit}` to the iframe
+(`q2-preview-spa/src/PreviewApp.tsx:1389`) **and** drops any stray
+`setAst` payload in `handleSetAst` when `allowEdit` is false
+(`PreviewApp.tsx:609`, "defense in depth").
+
+### The hub-client prop path stops one hop short
+
+The iframe is reached from `Editor.tsx` through three components. Every
+sibling toggle already threads this way; `editingDisabled` is simply
+absent from the hub-client half:
+
+| Component | `commentsMode` (model) | `richText` (model) | `editingDisabled` today |
+|---|---|---|---|
+| `Editor.tsx` | `useState`, passed to `ReplayDrawer` + `PreviewRouter` | — | — |
+| `PreviewRouter.tsx` | forwarded | — | — |
+| `ReactPreview.tsx` | forwarded | `usePreference('richText')` read here (`:508`) | — |
+| `ReactRenderer.tsx` | forwarded (`:332`) | forwarded | — |
+| `Q2PreviewIframe` | in `UPDATE_AST` | in `UPDATE_AST` | **prop exists, never passed** |
+
+Two precedents for where the state lives: the **Authors** and **Comments**
+toggles are session-only `useState` in `Editor.tsx` (treated as
+inspection modes), while `richText` / `unlockNestingCursor` are persisted
+preferences in `services/preferences/schema.ts` read directly by
+`ReactPreview` via `usePreference`. `usePreference` instances sync across
+the window through `PREFERENCE_CHANGE_EVENT`, so a toggle in one component
+takes effect in a sibling without threading.
+
+### The bottom bar
+
+`ReplayDrawer.tsx` renders the right-hand cluster twice (collapsed and
+expanded states), in DOM order `{statusSlot} <AttributionToggle>
+<CommentsModeToggle>` (`ReplayDrawer.tsx:376-386` and `:443-453`). Each
+toggle renders only when both of its props are supplied. The Authors pill
+(`AttributionToggle`) is the closest visual model: a bordered pill with a
+dot and a label, `aria-pressed`, a `Tooltip`, `e.stopPropagation()` on
+click so the bar's own click doesn't enter replay, and a `disabled` state
+for formats that don't support it (`attributionDisabled`, computed in
+`Editor.tsx:1436` as "not q2-debug and not q2-preview"). Its styles live in
+`ReplayDrawer.css:320-460` (`.replay-drawer__attribution*`,
+`.replay-drawer__authors-cell`).
+
+### Why links are hard to click (the mechanism)
+
+`useBlockEditHover.onPointerUp` (`useBlockEditHover.tsx:262`) activates the
+block under the pointer on **any mouse pointer-up** whose target is inside
+a `[data-block-pool-id]` element. `findEditTarget` is
+`target.closest('[data-block-pool-id]')` with no exclusion for anchors.
+Link navigation is handled separately by a document-level click handler
+(`installLinkHandlers`, `PreviewRoot.tsx:1368`), so a click on a link fires
+both: the link handler navigates (or scrolls), and the pointer-up opens the
+editor for the paragraph. With `editingDisabled` there are no pool ids and
+no pointer handlers, so the click is a plain link click.
+
+(A narrower fix — make `findEditTarget` ignore clicks whose target is
+inside an `<a>` — is a separate, complementary improvement to editable
+mode. It is deliberately **out of scope** here; see *Out of scope*.)
+
+### One gap to close in the renderer
+
+Nothing in `PreviewRoot` reacts to `editingDisabled` **changing** while an
+edit session is open (`editTarget != null`). Today the flag is fixed for
+the life of a `q2 preview` session, so this never arose. With a live
+toggle, flipping to read-only mid-edit would leave the editor mounted
+inside a block that no longer advertises editability. In practice clicking
+the pill in the parent document moves focus out of the iframe, which fires
+the editor's blur → `commitIfDirty` path, but that is incidental. The plan
+adds an explicit effect (decision D6).
+
+## Design decisions (to iterate on)
+
+- **D1 — State: persisted preference, not session-only.** Add
+  `previewEditing: boolean` to `UserPreferencesSchema` with
+  `.default(true)` so stored prefs from before the key parse cleanly (same
+  treatment as `richText`). *Rationale:* read mode is a way of working
+  (reviewing, following links) rather than a one-off inspection like the
+  Authors overlay, and `q2 preview`'s equivalent is a per-session setting;
+  someone who turns editing off wants it to stay off across reloads.
+  *Alternative:* session-only `useState` like Authors/Comments — one less
+  schema change, but resets on every reload.
+- **D2 — Default: editing ON (unchanged).** Existing users see no
+  behaviour change until they flip the pill. *Alternative:* default OFF
+  would make links work out of the box but would silently remove the edit
+  affordance everyone has today. Your call.
+- **D3 — Read path: `ReactPreview` reads the preference directly** via
+  `usePreference('previewEditing')`, exactly like `richText` and
+  `unlockNestingCursor`, and forwards `editingDisabled={!previewEditing}`
+  through `ReactRenderer` to `Q2PreviewIframe`. `Editor.tsx` reads the same
+  preference to drive the pill; the two stay in sync through
+  `PREFERENCE_CHANGE_EVENT`. *Rationale:* no changes to `PreviewRouter`,
+  and it matches the precedent for persisted iframe-bound flags.
+  *Alternative:* thread it from `Editor.tsx` like `commentsMode` (one
+  owner, explicit props, two more files). If D1 flips to session-only,
+  threading becomes mandatory.
+- **D4 — Pill placement and look.** A new `EditToggle` in `ReplayDrawer`,
+  rendered **before** the Authors pill in both bar states:
+  `{statusSlot} [Edit] [Authors] [Comments]`. Same pill anatomy as Authors
+  (dot + label, `aria-pressed`, tooltip, `stopPropagation`), sharing the
+  off-state look. On-state colour: reuse the Authors green (`--editor-success*`)
+  for consistency — one visual language for "this mode is on". Tooltip copy:
+  "Turn off editing — links become plain links" / "Turn on editing".
+  *Alternative:* a two-button segmented control like Comments ("Edit" /
+  "Read"). The pill is smaller and matches Authors; a segmented control is
+  more explicit about there being two modes.
+- **D5 — Format gating.** The pill is `disabled` (greyed, tooltip "Editing
+  is not available for this format") unless `currentFormat === 'q2-preview'`.
+  `q2-debug` and `q2-slides` have no block-edit surface, and `q2-debug`
+  ignores `editingDisabled`. Note this is stricter than
+  `attributionDisabled`, which also allows `q2-debug`. The stored
+  preference is untouched while disabled, so switching back to a
+  `q2-preview` document restores the user's choice.
+- **D6 — Closing an open editor when editing is switched off.** Add a
+  small effect in `PreviewRoot`: when `editingDisabled` transitions to
+  `true` and `editTarget != null`, run the existing commit-if-dirty path
+  and clear the edit target. Prefer the existing blur/close helper over a
+  new code path (to be located during implementation; candidates are the
+  `commitIfDirty` / plain-close helpers referenced around
+  `PreviewRoot.tsx:113` and `:1083`). This is the only change inside
+  `ts-packages/preview-renderer`.
+- **D7 — Defense in depth in the host.** `ReactPreview.handleSetAst` drops
+  `PreviewNodeEditPayload`s while editing is off, mirroring the SPA. Cheap,
+  and it makes the invariant "read-only never writes" hold even if a
+  payload is in flight when the toggle flips.
+- **D8 — Not in the Settings tab (v1).** The pill is the control. Adding a
+  row to `SettingsTab` is trivial later if wanted; skipping it keeps the
+  change focused on what was asked.
+- **D9 — Independent of `q2 preview --ui editor` without `--allow-edit`.**
+  In that mode hub-client is served by a read-only `q2 preview` session
+  (`previewSession.allowEdit === false`, which today only shows the
+  ephemeral banner). Monaco edits are already ephemeral there; block edits
+  go to the same in-memory document, so the pill stays functional and is
+  not forced off. No coupling.
+
+## Work items
+
+### Phase 1 — tests first (all red before Phase 2)
+
+- [ ] `services/preferences/schema.test.ts`: `previewEditing` defaults to
+      `true`; a stored prefs object without the key still parses and
+      preserves the other settings (same shape as the `richText` tests).
+- [ ] `components/ReplayDrawer.test.tsx`, new `describe('Edit toggle')`
+      mirroring the Attribution block: renders in collapsed and expanded
+      states only when both `previewEditing` + `onPreviewEditingChange` are
+      supplied; `aria-pressed` reflects state; click calls the callback
+      with the negation; click does not call `controls.enter`; `disabled`
+      renders non-interactive and drops `aria-pressed`.
+- [ ] `components/render/ReactRenderer.integration.test.tsx` (or a new
+      focused test alongside it): `editingDisabled` given to
+      `ReactRenderer` for `q2-preview` appears in the `UPDATE_AST` payload
+      posted to the iframe (use the `postMessage` spy + `IFRAME_READY`
+      pattern from `Q2PreviewIframe.integration.test.tsx:266`). Assert both
+      `true` and `false`, and that a rerender with the other value re-posts.
+- [ ] `components/render/ReactPreview.*.integration.test.tsx`: with the
+      `usePreference` mock returning `previewEditing: false`, a
+      `PreviewNodeEditPayload` passed to `setAst` neither calls
+      `applyNodeEdit` nor `onContentRewrite` (D7). With `true`, the existing
+      path runs.
+- [ ] `ts-packages/preview-renderer` `q2-preview.integration.test.tsx`:
+      with an open edit target, rerendering `PreviewRoot` with
+      `editingDisabled: true` closes the session (edit target cleared; a
+      dirty draft is committed through the normal path) (D6).
+- [ ] Playwright, new `hub-client/e2e/q2-preview-edit-toggle.spec.ts`
+      (model: `q2-preview-locked-hover.spec.ts`): a `q2-preview` document
+      with a paragraph containing a link to a second document. (a) Default:
+      `[data-block-pool-id]` present; (b) click the Edit pill → no
+      `[data-block-pool-id]` in the iframe, hovering a paragraph adds no
+      outline; clicking the link navigates to the second document without
+      opening an editor; (c) reload → still off (D1); (d) click the pill
+      again → affordances return.
+
+### Phase 2 — implementation
+
+- [ ] `services/preferences/schema.ts`: add `previewEditing` with
+      `.default(true)` and the matching `DEFAULT_PREFERENCES` entry; update
+      the seeded prefs object in `AboutTab.test.tsx:43` if its shape is
+      asserted exactly.
+- [ ] `ReplayDrawer.tsx`: `EditToggle` component + `previewEditing` /
+      `onPreviewEditingChange` / `previewEditingDisabled` props; render in
+      both bar states before `AttributionToggle` (D4, D5).
+- [ ] `ReplayDrawer.css`: pill styles. Either extract the shared pill
+      rules from `.replay-drawer__attribution` into a `.replay-drawer__pill`
+      base used by both, or add a sibling `.replay-drawer__edit` block —
+      decide when touching the file; no alpha colours (see
+      `.claude/rules/hub-client-theme.md`).
+- [ ] `Editor.tsx`: `const [previewEditing, setPreviewEditing] =
+      usePreference('previewEditing')`; pass to `ReplayDrawer` with
+      `previewEditingDisabled={currentFormat !== 'q2-preview'}`.
+- [ ] `ReactPreview.tsx`: read the preference (D3); pass
+      `editingDisabled={!previewEditing}` to `ReactRenderer`; early-return in
+      `handleSetAst` when off (D7).
+- [ ] `ReactRenderer.tsx`: `editingDisabled?: boolean` prop, forwarded to
+      `Q2PreviewIframe` only (documented like `commentsMode`).
+- [ ] `PreviewRoot.tsx` (preview-renderer): the close-on-disable effect
+      (D6).
+- [ ] `DevHarness.tsx` replay-drawer fixture: pass the new props so the dev
+      gallery shows the pill (optional but cheap; keeps the a11y harness
+      specs covering it).
+
+### Phase 3 — verification and bookkeeping
+
+- [ ] `cd hub-client && npm run test:ci` and `npm run build:all` (the
+      production build is stricter than vitest).
+- [ ] `ts-packages/preview-renderer` tests (`npm test -w
+      ts-packages/preview-renderer`).
+- [ ] Run the new Playwright spec (`VITE_E2E=1 npm run build`, then
+      `npx playwright test e2e/q2-preview-edit-toggle.spec.ts
+      --project=chromium --workers=1`).
+- [ ] **End-to-end in a real browser** against a running hub (`npm run
+      dev`, or `cargo build --bin hub && npm run build:local-prod && npm run
+      local-prod`): open a `q2-preview` document with a link, toggle the
+      pill, follow the link, reload, toggle back. Record the invocation, a
+      screenshot or DOM snippet, and an explicit "inspected" note here.
+- [ ] `cargo xtask verify` (full, since `hub-client` and
+      `ts-packages/preview-renderer` change).
+- [ ] Two-commit workflow: code commit, then `hub-client/changelog.md`
+      entry under `### 2026-09-09` with the hash.
+- [ ] `braid close bd-ew0vak6b`.
+
+## Files touched (expected)
+
+| File | Change |
+|---|---|
+| `hub-client/src/services/preferences/schema.ts` (+ test) | `previewEditing` preference |
+| `hub-client/src/components/ReplayDrawer.tsx` (+ test, `.css`) | `EditToggle` pill |
+| `hub-client/src/components/Editor.tsx` | read pref, wire pill, format gating |
+| `hub-client/src/components/render/ReactPreview.tsx` (+ test) | read pref → `editingDisabled`; drop guard |
+| `hub-client/src/components/render/ReactRenderer.tsx` (+ test) | forward `editingDisabled` |
+| `hub-client/src/components/DevHarness.tsx` | fixture props |
+| `hub-client/e2e/q2-preview-edit-toggle.spec.ts` | new |
+| `ts-packages/preview-renderer/src/q2-preview/PreviewRoot.tsx` (+ test) | close open editor on disable |
+| `hub-client/changelog.md` | entry |
+
+No Rust changes. No changes to `Q2PreviewIframe`, `entry.tsx`,
+`PreviewContext`, or the block components — the renderer side is already
+complete.
+
+## Out of scope (file as follow-ups if wanted)
+
+- **Links clickable while editing is on.** Making `findEditTarget` (or
+  `onPointerUp`) ignore clicks whose target is inside an `<a>` would fix
+  the link problem *without* leaving edit mode. It changes the edit
+  surface's click semantics for everyone and needs its own e2e; worth a
+  separate strand linked `related` to bd-ew0vak6b.
+- **Settings-tab row** for the preference (D8).
+- **Per-document or per-project default** for editability (e.g. a YAML
+  key). The preference is per browser, like the others.
+- **`q2-preview-spa` status bar.** The SPA has no bottom bar; its mode is
+  fixed by `--allow-edit`. Nothing changes there.
+
+## Review decisions (2026-09-09)
+
+All of D1–D9 accepted as written:
+
+- D1 persisted preference; D2 default ON (navigation is expected to be
+  less common than editing); D3 direct `usePreference` read in
+  `ReactPreview`; D4 pill before Authors, Authors green for the on state;
+  D5 `q2-preview`-only gating; D6 commit-if-dirty then close on disable;
+  D7 drop guard in `handleSetAst`; D9 no coupling to `--allow-edit`.
+- D8 confirmed: the pill is the only control, no Settings-tab row. This
+  matches the header's view-mode toggle (markup / split / preview,
+  `ViewModeContext.tsx`), which is likewise persisted and controlled only
+  from the chrome. The one difference is storage: view mode uses its own
+  bare localStorage key, while `previewEditing` lives in the versioned
+  preferences schema, so it gets validation and cross-component sync.

--- a/claude-notes/plans/2026-09-09-q2-preview-edit-toggle.md
+++ b/claude-notes/plans/2026-09-09-q2-preview-edit-toggle.md
@@ -1,8 +1,8 @@
 # hub-client `q2-preview`: editable / read-only toggle in the bottom status bar
 
 **Strand:** bd-ew0vak6b
-**Status:** design reviewed 2026-09-09 — D1–D9 accepted as written (see
-*Review decisions*). Awaiting the go-ahead to execute.
+**Status:** implemented 2026-09-09 (commit `93b146c`); strand open pending
+review/merge.
 **Related:** bd-ov4gqk3m (`q2 preview --allow-edit`, the plan at
 `2026-06-10-q2-preview-edit-writeback.md`, which built the `editingDisabled`
 plumbing this work reuses); bd-0rsk07il (the Comments toggle in the same bar).
@@ -257,14 +257,14 @@ adds an explicit effect (decision D6).
 - [x] Run the new Playwright spec (`VITE_E2E=1 npm run build`, then
       `npx playwright test e2e/q2-preview-edit-toggle.spec.ts
       --project=chromium --workers=1`).
-- [ ] **End-to-end in a real browser** against a running hub (`npm run
+- [x] **End-to-end in a real browser** against a running hub (`npm run
       dev`, or `cargo build --bin hub && npm run build:local-prod && npm run
       local-prod`): open a `q2-preview` document with a link, toggle the
       pill, follow the link, reload, toggle back. Record the invocation, a
       screenshot or DOM snippet, and an explicit "inspected" note here.
-- [ ] `cargo xtask verify` (full, since `hub-client` and
+- [x] `cargo xtask verify` (full, since `hub-client` and
       `ts-packages/preview-renderer` change).
-- [ ] Two-commit workflow: code commit, then `hub-client/changelog.md`
+- [x] Two-commit workflow: code commit, then `hub-client/changelog.md`
       entry under `### 2026-09-09` with the hash.
 - [ ] `braid close bd-ew0vak6b`.
 
@@ -314,3 +314,36 @@ All of D1–D9 accepted as written:
   from the chrome. The one difference is storage: view mode uses its own
   bare localStorage key, while `previewEditing` lives in the versioned
   preferences schema, so it gets validation and cross-component sync.
+
+## End-to-end verification record (2026-09-09)
+
+Real Chromium against a real hub (Playwright's e2e harness: `globalSetup`
+starts `cargo run --bin hub` on port 3031 and serves the `VITE_E2E=1`
+build):
+
+```
+cd hub-client && VITE_E2E=1 npm run build
+npx playwright test e2e/q2-preview-edit-toggle.spec.ts --project=chromium --workers=1
+# ✓ 1 passed
+```
+
+Observed (asserted by the spec, and inspected via full-page screenshots of
+the same session): with the pill on, both paragraphs carry
+`data-block-pool-id` and hovering a paragraph draws the edit outline; after
+clicking the pill (aria-pressed → false, label "Editing off") the iframe
+has zero `[data-block-pool-id]` elements, hovering draws no outline, and
+clicking "link to the other page" changes the route to `/file/other.qmd`
+with no `<textarea>` and no `.q2-rt-toolbar` in the iframe; after
+`page.reload()` the pill still reads "Editing off" and the page is still
+read-only; clicking the pill again restores one `p[data-block-pool-id]`.
+Gates: `cargo xtask verify --skip-rust-tests` (Rust untouched) and
+`cargo xtask lint` green.
+
+Note on ordering: the unit/integration tests were written and run red
+before implementation; the Playwright spec was written after and run green
+only (its failure mode without the implementation is trivially the pill not
+existing).
+
+Not covered by tests: a *dirty* rich-text session closed by the toggle
+(no existing test makes the tiptap editor dirty in jsdom; the rich
+`commit` is the same function the blur path uses).

--- a/claude-notes/plans/2026-09-09-q2-preview-edit-toggle.md
+++ b/claude-notes/plans/2026-09-09-q2-preview-edit-toggle.md
@@ -1,8 +1,8 @@
 # hub-client `q2-preview`: editable / read-only toggle in the bottom status bar
 
 **Strand:** bd-ew0vak6b
-**Status:** implemented 2026-09-09 (commit `93b146c`); strand open pending
-review/merge.
+**Status:** implemented 2026-09-09 (commit `93b146c`); PR #667 open,
+pending CI and review.
 **Related:** bd-ov4gqk3m (`q2 preview --allow-edit`, the plan at
 `2026-06-10-q2-preview-edit-writeback.md`, which built the `editingDisabled`
 plumbing this work reuses); bd-0rsk07il (the Comments toggle in the same bar).

--- a/claude-notes/plans/2026-09-09-q2-preview-edit-toggle.md
+++ b/claude-notes/plans/2026-09-09-q2-preview-edit-toggle.md
@@ -187,31 +187,31 @@ adds an explicit effect (decision D6).
 
 ### Phase 1 — tests first (all red before Phase 2)
 
-- [ ] `services/preferences/schema.test.ts`: `previewEditing` defaults to
+- [x] `services/preferences/schema.test.ts`: `previewEditing` defaults to
       `true`; a stored prefs object without the key still parses and
       preserves the other settings (same shape as the `richText` tests).
-- [ ] `components/ReplayDrawer.test.tsx`, new `describe('Edit toggle')`
+- [x] `components/ReplayDrawer.test.tsx`, new `describe('Edit toggle')`
       mirroring the Attribution block: renders in collapsed and expanded
       states only when both `previewEditing` + `onPreviewEditingChange` are
       supplied; `aria-pressed` reflects state; click calls the callback
       with the negation; click does not call `controls.enter`; `disabled`
       renders non-interactive and drops `aria-pressed`.
-- [ ] `components/render/ReactRenderer.integration.test.tsx` (or a new
+- [x] `components/render/ReactRenderer.integration.test.tsx` (or a new
       focused test alongside it): `editingDisabled` given to
       `ReactRenderer` for `q2-preview` appears in the `UPDATE_AST` payload
       posted to the iframe (use the `postMessage` spy + `IFRAME_READY`
       pattern from `Q2PreviewIframe.integration.test.tsx:266`). Assert both
       `true` and `false`, and that a rerender with the other value re-posts.
-- [ ] `components/render/ReactPreview.*.integration.test.tsx`: with the
+- [x] `components/render/ReactPreview.*.integration.test.tsx`: with the
       `usePreference` mock returning `previewEditing: false`, a
       `PreviewNodeEditPayload` passed to `setAst` neither calls
       `applyNodeEdit` nor `onContentRewrite` (D7). With `true`, the existing
       path runs.
-- [ ] `ts-packages/preview-renderer` `q2-preview.integration.test.tsx`:
+- [x] `ts-packages/preview-renderer` `q2-preview.integration.test.tsx`:
       with an open edit target, rerendering `PreviewRoot` with
       `editingDisabled: true` closes the session (edit target cleared; a
       dirty draft is committed through the normal path) (D6).
-- [ ] Playwright, new `hub-client/e2e/q2-preview-edit-toggle.spec.ts`
+- [x] Playwright, new `hub-client/e2e/q2-preview-edit-toggle.spec.ts`
       (model: `q2-preview-locked-hover.spec.ts`): a `q2-preview` document
       with a paragraph containing a link to a second document. (a) Default:
       `[data-block-pool-id]` present; (b) click the Edit pill → no
@@ -222,39 +222,39 @@ adds an explicit effect (decision D6).
 
 ### Phase 2 — implementation
 
-- [ ] `services/preferences/schema.ts`: add `previewEditing` with
+- [x] `services/preferences/schema.ts`: add `previewEditing` with
       `.default(true)` and the matching `DEFAULT_PREFERENCES` entry; update
       the seeded prefs object in `AboutTab.test.tsx:43` if its shape is
       asserted exactly.
-- [ ] `ReplayDrawer.tsx`: `EditToggle` component + `previewEditing` /
+- [x] `ReplayDrawer.tsx`: `EditToggle` component + `previewEditing` /
       `onPreviewEditingChange` / `previewEditingDisabled` props; render in
       both bar states before `AttributionToggle` (D4, D5).
-- [ ] `ReplayDrawer.css`: pill styles. Either extract the shared pill
+- [x] `ReplayDrawer.css`: pill styles. Either extract the shared pill
       rules from `.replay-drawer__attribution` into a `.replay-drawer__pill`
       base used by both, or add a sibling `.replay-drawer__edit` block —
       decide when touching the file; no alpha colours (see
       `.claude/rules/hub-client-theme.md`).
-- [ ] `Editor.tsx`: `const [previewEditing, setPreviewEditing] =
+- [x] `Editor.tsx`: `const [previewEditing, setPreviewEditing] =
       usePreference('previewEditing')`; pass to `ReplayDrawer` with
       `previewEditingDisabled={currentFormat !== 'q2-preview'}`.
-- [ ] `ReactPreview.tsx`: read the preference (D3); pass
+- [x] `ReactPreview.tsx`: read the preference (D3); pass
       `editingDisabled={!previewEditing}` to `ReactRenderer`; early-return in
       `handleSetAst` when off (D7).
-- [ ] `ReactRenderer.tsx`: `editingDisabled?: boolean` prop, forwarded to
+- [x] `ReactRenderer.tsx`: `editingDisabled?: boolean` prop, forwarded to
       `Q2PreviewIframe` only (documented like `commentsMode`).
-- [ ] `PreviewRoot.tsx` (preview-renderer): the close-on-disable effect
+- [x] `PreviewRoot.tsx` (preview-renderer): the close-on-disable effect
       (D6).
-- [ ] `DevHarness.tsx` replay-drawer fixture: pass the new props so the dev
+- [x] `DevHarness.tsx` replay-drawer fixture: pass the new props so the dev
       gallery shows the pill (optional but cheap; keeps the a11y harness
       specs covering it).
 
 ### Phase 3 — verification and bookkeeping
 
-- [ ] `cd hub-client && npm run test:ci` and `npm run build:all` (the
+- [x] `cd hub-client && npm run test:ci` and `npm run build:all` (the
       production build is stricter than vitest).
-- [ ] `ts-packages/preview-renderer` tests (`npm test -w
+- [x] `ts-packages/preview-renderer` tests (`npm test -w
       ts-packages/preview-renderer`).
-- [ ] Run the new Playwright spec (`VITE_E2E=1 npm run build`, then
+- [x] Run the new Playwright spec (`VITE_E2E=1 npm run build`, then
       `npx playwright test e2e/q2-preview-edit-toggle.spec.ts
       --project=chromium --workers=1`).
 - [ ] **End-to-end in a real browser** against a running hub (`npm run

--- a/hub-client/changelog.md
+++ b/hub-client/changelog.md
@@ -25,6 +25,7 @@ WASM rebuild is needed for a changelog-only edit.
 
 ### 2026-09-09
 
+- [`93b146c`](https://github.com/quarto-dev/q2/commits/93b146c): Edit pill in the document bottom bar turns q2-preview block editing on/off (off makes links plain links); the choice persists
 - [`0242ab91`](https://github.com/quarto-dev/q2/commits/0242ab91): Resolving the last comment on a block in the q2-preview no longer leaves an empty bubble behind or a block glow that never clears
 
 ### 2026-09-08

--- a/hub-client/e2e/q2-preview-edit-toggle.spec.ts
+++ b/hub-client/e2e/q2-preview-edit-toggle.spec.ts
@@ -1,0 +1,136 @@
+/**
+ * Edit pill in the document bottom bar (bd-ew0vak6b) — real browser.
+ *
+ * `format: q2-preview` used to be always editable: a mouse click on any
+ * editable paragraph opens that paragraph's editor, so a click on a link
+ * inside a paragraph also opened an editor. The Edit pill in the replay bar
+ * turns block editing off, which makes the preview behave like a read-only
+ * `q2 preview` (no `--allow-edit`): no edit affordances, no hover outline,
+ * and links are plain links. The choice persists as the `previewEditing`
+ * preference.
+ *
+ * Coverage (one document with a link to a second document):
+ *   1. default: editing ON — every top-level block carries a pool-id;
+ *   2. click the pill → OFF: no pool-ids in the iframe, hovering a paragraph
+ *      adds no outline, and clicking the link navigates to the second
+ *      document without opening an editor;
+ *   3. reload → still OFF (persisted), pill reads "Editing off";
+ *   4. click the pill again → ON: affordances return.
+ *
+ * Run via:
+ *   cd hub-client && VITE_E2E=1 npm run build
+ *   npx playwright test e2e/q2-preview-edit-toggle.spec.ts --project=chromium --workers=1
+ */
+
+import { test, expect, type Page, type FrameLocator } from '@playwright/test';
+import type {} from './helpers/testHooks';
+import {
+    bootstrapProjectSet,
+    createProjectOnServer,
+    seedProjectInBrowser,
+    getServerUrl,
+} from './helpers/projectFactory';
+import { waitForPreviewRender } from './helpers/previewExtraction';
+
+const IFRAME_SELECTOR = 'iframe[src*="q2-preview.html"]';
+
+async function openProjectFile(
+    page: Page,
+    serverUrl: string,
+    docId: string,
+    filename: string,
+): Promise<FrameLocator> {
+    await bootstrapProjectSet(page, serverUrl);
+    const localId = await seedProjectInBrowser(page, docId, serverUrl);
+    await page.goto(`/#/p/${localId}/file/${filename}`);
+    await waitForPreviewRender(page, { kind: 'q2-preview', timeout: 30000 });
+    return page.frameLocator(IFRAME_SELECTOR);
+}
+
+const MAIN_QMD = [
+    '---',
+    'format: q2-preview',
+    '---',
+    '',
+    'First paragraph with a [link to the other page](other.qmd) inside it.',
+    '',
+    'Second paragraph, plain text.',
+    '',
+].join('\n');
+
+const OTHER_QMD = [
+    '---',
+    'format: q2-preview',
+    '---',
+    '',
+    'The other page.',
+    '',
+].join('\n');
+
+const pill = (page: Page) => page.getByRole('button', { name: /^Editing (on|off)$/ });
+
+test.describe('Edit pill — q2-preview editable / read-only toggle (real browser)', () => {
+    test.setTimeout(150000);
+
+    test.beforeEach(async ({ page }, testInfo) => {
+        if (testInfo.workerIndex > 0) await page.waitForTimeout(1000);
+    });
+
+    test('turns edit affordances off, makes links plain, persists across reload, and turns back on', async ({ page }) => {
+        const serverUrl = getServerUrl();
+        const docId = await createProjectOnServer(serverUrl, [
+            { path: '_quarto.yml', content: 'project:\n  type: default\n', contentType: 'text' },
+            { path: 'main.qmd', content: MAIN_QMD, contentType: 'text' },
+            { path: 'other.qmd', content: OTHER_QMD, contentType: 'text' },
+        ]);
+        let iframe = await openProjectFile(page, serverUrl, docId, 'main.qmd');
+
+        // 1. Default: editing ON. Both paragraphs advertise editability and
+        //    the pill reads "on".
+        await iframe.locator('p[data-block-pool-id]').first().waitFor({ timeout: 15_000 });
+        expect(await iframe.locator('p[data-block-pool-id]').count()).toBe(2);
+        await expect(pill(page)).toHaveAttribute('aria-pressed', 'true');
+        await expect(pill(page)).toHaveAccessibleName('Editing on');
+
+        // 2. Click the pill → OFF. The iframe re-renders with no affordance
+        //    at all (this is the same `editingDisabled` path as a read-only
+        //    `q2 preview`).
+        await pill(page).click();
+        await expect(pill(page)).toHaveAttribute('aria-pressed', 'false');
+        await expect(iframe.locator('[data-block-pool-id]')).toHaveCount(0, { timeout: 10_000 });
+
+        // Hovering a paragraph adds no outline (the hover surface is inert).
+        await iframe.getByText('Second paragraph', { exact: false }).hover();
+        const outlined = await iframe.locator('p').evaluateAll((els) =>
+            (els as HTMLElement[]).filter((e) => e.style.boxShadow !== '').length,
+        );
+        expect(outlined, 'no paragraph is outlined on hover while editing is off').toBe(0);
+
+        // Clicking the link navigates to the other document — and opens no
+        // editor along the way (with editing on, the same click would also
+        // open the paragraph's editor).
+        await iframe.getByRole('link', { name: 'link to the other page' }).click();
+        await page.waitForURL(/\/file\/other\.qmd/, { timeout: 15_000 });
+        await waitForPreviewRender(page, { kind: 'q2-preview', timeout: 30000 });
+        iframe = page.frameLocator(IFRAME_SELECTOR);
+        await iframe.getByText('The other page.').waitFor({ timeout: 15_000 });
+        expect(await iframe.locator('textarea').count(), 'no plain editor opened').toBe(0);
+        expect(await iframe.locator('.q2-rt-toolbar').count(), 'no rich editor opened').toBe(0);
+        expect(await iframe.locator('[data-block-pool-id]').count(), 'still read-only on the other page').toBe(0);
+
+        // 3. Reload: the preference persisted, so the preview comes back
+        //    read-only and the pill still reads "off".
+        await page.reload();
+        await waitForPreviewRender(page, { kind: 'q2-preview', timeout: 30000 });
+        iframe = page.frameLocator(IFRAME_SELECTOR);
+        await iframe.getByText('The other page.').waitFor({ timeout: 15_000 });
+        await expect(pill(page)).toHaveAttribute('aria-pressed', 'false');
+        await expect(pill(page)).toHaveAccessibleName('Editing off');
+        expect(await iframe.locator('[data-block-pool-id]').count()).toBe(0);
+
+        // 4. Click the pill again → ON: the affordance returns.
+        await pill(page).click();
+        await expect(pill(page)).toHaveAttribute('aria-pressed', 'true');
+        await expect(iframe.locator('p[data-block-pool-id]')).toHaveCount(1, { timeout: 10_000 });
+    });
+});

--- a/hub-client/src/components/DevHarness.tsx
+++ b/hub-client/src/components/DevHarness.tsx
@@ -505,6 +505,9 @@ const REPLAY_FIXTURE_TIMESTAMP = (Date.now() - 42 * 60_000) / 1000;
  * ReplayDrawer.tsx.
  */
 function ReplayHarness() {
+  // Local stand-in for the persisted `previewEditing` preference so the
+  // Edit pill (bd-ew0vak6b) is interactive in the gallery.
+  const [previewEditing, setPreviewEditing] = useState(true);
   const state: ReplayState = {
     isActive: true,
     historyLength: 100,
@@ -572,6 +575,8 @@ function ReplayHarness() {
             state={state}
             controls={controls}
             identities={{ 'b3f7c2a1-remote': { name: 'Grace Hopper', color: '#E91E63' } }}
+            previewEditing={previewEditing}
+            onPreviewEditingChange={setPreviewEditing}
           />
         </div>
       </div>

--- a/hub-client/src/components/Editor.tsx
+++ b/hub-client/src/components/Editor.tsx
@@ -325,6 +325,12 @@ export default function Editor({ project, files, fileContents, onDisconnect, onC
   // Scroll sync state (persisted in localStorage)
   const [scrollSyncEnabled, setScrollSyncEnabled] = usePreference('scrollSyncEnabled');
 
+  // q2-preview block editing on/off (bd-ew0vak6b) — the Edit pill in the
+  // replay bar. Persisted; `ReactPreview` reads the same preference
+  // directly (like `richText`) and forwards it to the iframe as
+  // `editingDisabled`, so nothing is threaded through PreviewRouter.
+  const [previewEditing, setPreviewEditing] = usePreference('previewEditing');
+
   // Attribution overlay — session-only useState (not persisted).
   // Owned here, surfaced via the toggle in the replay bar, and
   // threaded into ReactPreview where `useAttribution` consumes it
@@ -1431,6 +1437,11 @@ export default function Editor({ project, files, fileContents, onDisconnect, onC
             onAttributionChange={setAttributionOn}
             commentsMode={commentsMode}
             onCommentsModeChange={setCommentsMode}
+            previewEditing={previewEditing}
+            onPreviewEditingChange={setPreviewEditing}
+            // Only q2-preview has a block-edit surface (q2-debug ignores
+            // editingDisabled; slides have no editor).
+            previewEditingDisabled={currentFormat !== 'q2-preview'}
             commentsCount={outstandingCommentCount}
             attributionGenerating={attributionGenerating}
             attributionDisabled={

--- a/hub-client/src/components/ReplayDrawer.css
+++ b/hub-client/src/components/ReplayDrawer.css
@@ -314,10 +314,11 @@
   pointer-events: none;
 }
 
-/* Attribution overlay toggle — sits flush-right in both collapsed and
-   expanded states. Off-state matches the dim transport-button look;
-   on-state lights up with the editor accent. */
-.replay-drawer__attribution {
+/* Mode pills — the Authors and Edit toggles in the bar's right-hand
+   cluster share one pill: off-state matches the dim transport-button
+   look; on-state lights up with the editor success colour, so "this
+   mode is on" reads the same for every pill. */
+.replay-drawer__pill {
   display: inline-flex;
   align-items: center;
   gap: 6px;
@@ -338,13 +339,13 @@
   user-select: none;
 }
 
-.replay-drawer__attribution:hover {
+.replay-drawer__pill:hover {
   color: var(--editor-text);
   border-color: var(--editor-text-dim);
 }
 
-.replay-drawer__attribution:disabled,
-.replay-drawer__attribution:disabled:hover {
+.replay-drawer__pill:disabled,
+.replay-drawer__pill:disabled:hover {
   cursor: not-allowed;
   opacity: 0.4;
   color: var(--editor-text-dim);
@@ -352,20 +353,20 @@
   background: var(--editor-accent-bg);
 }
 
-.replay-drawer__attribution--on {
+.replay-drawer__pill--on {
   color: var(--editor-success-text);
   border-color: var(--editor-success);
   background: var(--editor-success-bg);
 }
 
-.replay-drawer__attribution--on:hover {
+.replay-drawer__pill--on:hover {
   background: var(--editor-success);
   /* Dark text on the solid green fill: --editor-bg was 3.02:1 in light
      (WCAG 1.4.3 failure); #17212B is 4.95:1 on #72994E in both themes. */
   color: var(--posit-blue-dark-3);
 }
 
-.replay-drawer__attribution-dot {
+.replay-drawer__pill-dot {
   display: inline-block;
   width: 7px;
   height: 7px;
@@ -375,8 +376,13 @@
   transition: opacity 0.15s;
 }
 
-.replay-drawer__attribution--on .replay-drawer__attribution-dot {
+.replay-drawer__pill--on .replay-drawer__pill-dot {
   opacity: 1;
+}
+
+/* Adjacent pills (Edit, then Authors) — collapse the doubled gap. */
+.replay-drawer__pill-cell + .replay-drawer__pill-cell .replay-drawer__pill {
+  margin-left: 0;
 }
 
 /* Rotating-gradient sweep around the pill while attribution data
@@ -449,8 +455,8 @@
    (bd-0rsk07il, GH #445). One badge for the whole group; hidden at
    zero (the element is simply not rendered). Reuses the view-toggle
    palette so it reads as part of the control. */
-/* Authors pill container: a full-height cell (pill centered inside). */
-.replay-drawer__authors-cell {
+/* Pill container: a full-height cell (pill centered inside). */
+.replay-drawer__pill-cell {
   align-self: stretch;
   display: inline-flex;
   align-items: center;
@@ -459,7 +465,7 @@
 /* Expanded drawer: bottom border on the header's status / authors /
    comments containers, separating them from the controls row below. */
 .replay-drawer--expanded .sync-status-badge,
-.replay-drawer--expanded .replay-drawer__authors-cell,
+.replay-drawer--expanded .replay-drawer__pill-cell,
 .replay-drawer--expanded .comments-mode-box {
   border-bottom: 1px solid var(--editor-header-border);
 }

--- a/hub-client/src/components/ReplayDrawer.css
+++ b/hub-client/src/components/ReplayDrawer.css
@@ -382,7 +382,7 @@
 
 /* Adjacent pills (Edit, then Authors) — collapse the doubled gap. */
 .replay-drawer__pill-cell + .replay-drawer__pill-cell .replay-drawer__pill {
-  margin-left: 0;
+  margin-inline-start: 0;
 }
 
 /* Rotating-gradient sweep around the pill while attribution data

--- a/hub-client/src/components/ReplayDrawer.test.tsx
+++ b/hub-client/src/components/ReplayDrawer.test.tsx
@@ -462,4 +462,159 @@ describe('ReplayDrawer', () => {
       expect(onChange).not.toHaveBeenCalled();
     });
   });
+
+  // bd-ew0vak6b: the Edit pill turns q2-preview block editing on/off.
+  // Same anatomy as the Authors pill; rendered only when both props are
+  // supplied. Labels: "Editing on" / "Editing off" / "Editing unavailable…".
+  describe('Edit toggle', () => {
+    it('is hidden when the props are not supplied', () => {
+      render(<ReplayDrawer state={makeState()} controls={controls} />);
+      expect(screen.queryByLabelText(/Editing/)).toBeNull();
+    });
+
+    it('renders in collapsed state when previewEditing + onPreviewEditingChange are passed', () => {
+      render(
+        <ReplayDrawer
+          state={makeState()}
+          controls={controls}
+          previewEditing={true}
+          onPreviewEditingChange={vi.fn()}
+        />,
+      );
+      expect(screen.getByLabelText(/Editing on/)).toBeDefined();
+    });
+
+    it('renders in expanded state', () => {
+      const activeState = makeState({
+        isActive: true,
+        historyLength: 100,
+        currentIndex: 42,
+        currentContent: 'hello',
+        timestamp: 1710000000,
+        actor: 'abcdef0123456789abcdef0123456789',
+        chunkActors: [],
+      });
+      render(
+        <ReplayDrawer
+          state={activeState}
+          controls={controls}
+          previewEditing={true}
+          onPreviewEditingChange={vi.fn()}
+        />,
+      );
+      expect(screen.getByLabelText(/Editing on/)).toBeDefined();
+    });
+
+    it('reflects previewEditing via aria-pressed and the on-class', () => {
+      const { rerender } = render(
+        <ReplayDrawer
+          state={makeState()}
+          controls={controls}
+          previewEditing={true}
+          onPreviewEditingChange={vi.fn()}
+        />,
+      );
+      const on = screen.getByLabelText(/Editing on/);
+      expect(on.getAttribute('aria-pressed')).toBe('true');
+      expect(on.className).toContain('replay-drawer__edit--on');
+
+      rerender(
+        <ReplayDrawer
+          state={makeState()}
+          controls={controls}
+          previewEditing={false}
+          onPreviewEditingChange={vi.fn()}
+        />,
+      );
+      const off = screen.getByLabelText(/Editing off/);
+      expect(off.getAttribute('aria-pressed')).toBe('false');
+      expect(off.className).not.toContain('replay-drawer__edit--on');
+    });
+
+    it('clicking calls onPreviewEditingChange with the negation', () => {
+      const onChange = vi.fn();
+      const { rerender } = render(
+        <ReplayDrawer
+          state={makeState()}
+          controls={controls}
+          previewEditing={true}
+          onPreviewEditingChange={onChange}
+        />,
+      );
+      fireEvent.click(screen.getByLabelText(/Editing on/));
+      expect(onChange).toHaveBeenCalledWith(false);
+
+      rerender(
+        <ReplayDrawer
+          state={makeState()}
+          controls={controls}
+          previewEditing={false}
+          onPreviewEditingChange={onChange}
+        />,
+      );
+      fireEvent.click(screen.getByLabelText(/Editing off/));
+      expect(onChange).toHaveBeenLastCalledWith(true);
+    });
+
+    it('clicking does not trigger replay enter', () => {
+      render(
+        <ReplayDrawer
+          state={makeState()}
+          controls={controls}
+          previewEditing={true}
+          onPreviewEditingChange={vi.fn()}
+        />,
+      );
+      fireEvent.click(screen.getByLabelText(/Editing on/));
+      expect(controls.enter).not.toHaveBeenCalled();
+    });
+
+    it('renders disabled (no aria-pressed, no on-class) for unsupported formats', () => {
+      render(
+        <ReplayDrawer
+          state={makeState()}
+          controls={controls}
+          previewEditing={true}
+          onPreviewEditingChange={vi.fn()}
+          previewEditingDisabled={true}
+        />,
+      );
+      const pill = screen.getByLabelText(/Editing unavailable/) as HTMLButtonElement;
+      expect(pill.disabled).toBe(true);
+      expect(pill.getAttribute('aria-pressed')).toBeNull();
+      expect(pill.className).not.toContain('replay-drawer__edit--on');
+    });
+
+    it('does not fire onPreviewEditingChange when clicked while disabled', () => {
+      const onChange = vi.fn();
+      render(
+        <ReplayDrawer
+          state={makeState()}
+          controls={controls}
+          previewEditing={true}
+          onPreviewEditingChange={onChange}
+          previewEditingDisabled={true}
+        />,
+      );
+      fireEvent.click(screen.getByLabelText(/Editing unavailable/));
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('renders before the Authors pill in the right-hand cluster', () => {
+      render(
+        <ReplayDrawer
+          state={makeState()}
+          controls={controls}
+          previewEditing={true}
+          onPreviewEditingChange={vi.fn()}
+          attributionOn={false}
+          onAttributionChange={vi.fn()}
+        />,
+      );
+      const edit = screen.getByLabelText(/Editing on/);
+      const authors = screen.getByLabelText(/Authors/);
+      // DOCUMENT_POSITION_FOLLOWING (4): `authors` comes after `edit`.
+      expect(edit.compareDocumentPosition(authors) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    });
+  });
 });

--- a/hub-client/src/components/ReplayDrawer.tsx
+++ b/hub-client/src/components/ReplayDrawer.tsx
@@ -53,6 +53,21 @@ interface Props {
   commentsMode?: CommentsMode;
   onCommentsModeChange?: (next: CommentsMode) => void;
   /**
+   * q2-preview block editing on/off (bd-ew0vak6b) — the Edit pill,
+   * rendered before the Authors pill. Both props must be supplied to
+   * render it. Backed by the persisted `previewEditing` preference
+   * (owned by `Editor.tsx`), unlike the session-only Authors/Comments
+   * toggles: read mode is a way of working, and should survive reloads.
+   */
+  previewEditing?: boolean;
+  onPreviewEditingChange?: (next: boolean) => void;
+  /**
+   * When true the Edit pill renders greyed-out and non-interactive —
+   * formats without a block-edit surface (everything but q2-preview).
+   * The stored preference is untouched while disabled.
+   */
+  previewEditingDisabled?: boolean;
+  /**
    * Optional status element (the document sync-status badge) rendered
    * in the bar's right-side cluster, to the left of the Authors pill.
    */
@@ -185,7 +200,9 @@ function AttributionToggle({ attributionOn, onAttributionChange, generating, dis
     return () => cancelAnimationFrame(raf);
   }, [generating, disabled]);
   const classes = [
+    'replay-drawer__pill',
     'replay-drawer__attribution',
+    attributionOn && !disabled && 'replay-drawer__pill--on',
     attributionOn && !disabled && 'replay-drawer__attribution--on',
     generating && !disabled && 'replay-drawer__attribution--generating',
   ]
@@ -202,7 +219,7 @@ function AttributionToggle({ attributionOn, onAttributionChange, generating, dis
   return (
     // Full-height cell around the pill — border/divider styling lands
     // here, never on the pill itself.
-    <span className="replay-drawer__authors-cell">
+    <span className="replay-drawer__pill-cell">
     <Tooltip content={titleText}>
       <button
         ref={btnRef}
@@ -217,8 +234,61 @@ function AttributionToggle({ attributionOn, onAttributionChange, generating, dis
         aria-label={ariaLabel}
         aria-busy={generating && !disabled || undefined}
       >
-        <span className="replay-drawer__attribution-dot" />
-        <span className="replay-drawer__attribution-label">Authors</span>
+        <span className="replay-drawer__pill-dot" />
+        <span className="replay-drawer__pill-label">Authors</span>
+      </button>
+    </Tooltip>
+    </span>
+  );
+}
+
+interface EditToggleProps {
+  previewEditing: boolean;
+  onPreviewEditingChange: (next: boolean) => void;
+  disabled: boolean;
+}
+
+/**
+ * The Edit pill (bd-ew0vak6b): q2-preview block editing on/off. Same
+ * anatomy as the Authors pill. With editing off the preview behaves
+ * like a read-only `q2 preview` — no hover outlines, no edit
+ * affordances, and links are plain links (with editing on, a click on
+ * a link inside a paragraph also opens that paragraph's editor).
+ */
+function EditToggle({ previewEditing, onPreviewEditingChange, disabled }: EditToggleProps) {
+  const on = previewEditing && !disabled;
+  const classes = [
+    'replay-drawer__pill',
+    'replay-drawer__edit',
+    on && 'replay-drawer__pill--on',
+    on && 'replay-drawer__edit--on',
+  ]
+    .filter(Boolean)
+    .join(' ');
+  const titleText = disabled
+    ? 'Editing is not available for this format'
+    : previewEditing
+      ? 'Turn off editing — links become plain links'
+      : 'Turn on editing';
+  const ariaLabel = disabled
+    ? 'Editing unavailable for this format'
+    : `Editing ${previewEditing ? 'on' : 'off'}`;
+  return (
+    <span className="replay-drawer__pill-cell">
+    <Tooltip content={titleText}>
+      <button
+        type="button"
+        className={classes}
+        onClick={(e) => {
+          e.stopPropagation();
+          onPreviewEditingChange(!previewEditing);
+        }}
+        disabled={disabled}
+        aria-pressed={disabled ? undefined : previewEditing}
+        aria-label={ariaLabel}
+      >
+        <span className="replay-drawer__pill-dot" />
+        <span className="replay-drawer__pill-label">Edit</span>
       </button>
     </Tooltip>
     </span>
@@ -263,9 +333,14 @@ export default function ReplayDrawer({
   attributionDisabled,
   commentsMode,
   onCommentsModeChange,
+  previewEditing,
+  onPreviewEditingChange,
+  previewEditingDisabled,
   commentsCount,
   statusSlot,
 }: Props) {
+  const showEditToggle =
+    previewEditing !== undefined && onPreviewEditingChange !== undefined;
   const showAttributionToggle =
     attributionOn !== undefined && onAttributionChange !== undefined;
   const showCommentsToggle =
@@ -373,6 +448,13 @@ export default function ReplayDrawer({
           <span>{replay.title}</span>
         </button>
         {statusSlot}
+        {showEditToggle && (
+          <EditToggle
+            previewEditing={previewEditing!}
+            onPreviewEditingChange={onPreviewEditingChange!}
+            disabled={!!previewEditingDisabled}
+          />
+        )}
         {showAttributionToggle && (
           <AttributionToggle
             attributionOn={attributionOn!}
@@ -440,6 +522,13 @@ export default function ReplayDrawer({
         </div>
 
         {statusSlot}
+        {showEditToggle && (
+          <EditToggle
+            previewEditing={previewEditing!}
+            onPreviewEditingChange={onPreviewEditingChange!}
+            disabled={!!previewEditingDisabled}
+          />
+        )}
         {showAttributionToggle && (
           <AttributionToggle
             attributionOn={attributionOn!}

--- a/hub-client/src/components/render/ReactPreview.editToggle.integration.test.tsx
+++ b/hub-client/src/components/render/ReactPreview.editToggle.integration.test.tsx
@@ -1,0 +1,154 @@
+/**
+ * Edit toggle at the hub-client boundary (bd-ew0vak6b).
+ *
+ * The bottom-bar Edit pill persists as the `previewEditing` preference.
+ * `ReactPreview` reads it directly (like `richText`) and must:
+ *
+ *  1. forward `editingDisabled={!previewEditing}` to `ReactRenderer`, so the
+ *     q2-preview iframe drops every edit affordance when editing is off; and
+ *  2. drop any `PreviewNodeEditPayload` that still arrives through `setAst`
+ *     while editing is off (defense in depth, mirroring the q2-preview SPA's
+ *     `handleSetAst` guard) — no `applyNodeEdit`, no `onContentRewrite`.
+ *
+ * With editing on, the existing commit path runs unchanged.
+ *
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, waitFor, act } from '@testing-library/react';
+import React from 'react';
+
+const AST = '{"pandoc-api-version":[1,23,1],"meta":{},"blocks":[]}';
+
+const { renderPageInProjectWithAttribution, applyNodeEdit } = vi.hoisted(() => ({
+  renderPageInProjectWithAttribution: vi.fn(async () => ({
+    success: true,
+    ast_json: '{"pandoc-api-version":[1,23,1],"meta":{},"blocks":[]}',
+    untransformed_ast_json: '{"pandoc-api-version":[1,23,1],"meta":{},"blocks":[]}',
+    theme_fingerprint: 'fp-1',
+    diagnostics: [],
+    warnings: [],
+  })),
+  applyNodeEdit: vi.fn(() => 'rewritten qmd'),
+}));
+
+vi.mock('@quarto/preview-runtime', () => ({
+  renderPageInProjectWithAttribution,
+  getBinaryDocById: vi.fn(),
+  renderPageForPreview: vi.fn(),
+  parseQmdToAstWithAttribution: vi.fn(async () => ({ success: true, ast: '{}', diagnostics: [] })),
+  isWasmReady: () => true,
+  incrementalWriteQmd: vi.fn(),
+  applyNodeEdit,
+  parseQmdContentSync: vi.fn(() => ({ success: true, ast: '{}' })),
+  getActorId: () => 'actor-1',
+  regenerateNestedBuffers: vi.fn(() => ({})),
+  pipelineKindForFormat: (f: string) => (f === 'q2-preview' ? 'preview' : undefined),
+}));
+
+vi.mock('../../hooks/useAttribution', () => ({
+  useAttribution: () => ({ payload: null, generating: false }),
+}));
+
+// Per-key preference values so `previewEditing` can be varied per test
+// while the other persisted flags keep their production defaults.
+const prefs: Record<string, unknown> = {
+  errorOverlayCollapsed: true,
+  unlockNestingCursor: false,
+  richText: true,
+  previewEditing: true,
+};
+vi.mock('../../hooks/usePreference', () => ({
+  usePreference: (key: string) => [prefs[key], vi.fn()],
+}));
+
+// Capture the props ReactPreview hands to ReactRenderer so the test can
+// both read `editingDisabled` and drive `setAst` the way the iframe would.
+const rendererProps: any[] = [];
+vi.mock('./ReactRenderer', () => ({
+  default: (props: any) => {
+    rendererProps.push(props);
+    return <div data-testid="react-renderer" />;
+  },
+}));
+
+import ReactPreview from './ReactPreview';
+
+function baseProps(onContentRewrite: (qmd: string) => void) {
+  return {
+    content: '---\nformat: q2-preview\n---\n\nhello\n',
+    currentFile: { path: 'doc.qmd', name: 'doc.qmd' } as any,
+    files: [],
+    fileContents: new Map([['doc.qmd', 'x']]),
+    scrollSyncEnabled: false,
+    editorRef: { current: null } as any,
+    editorReady: true,
+    editorHasFocusRef: { current: false } as any,
+    onFileChange: () => {},
+    onOpenNewFileDialog: () => {},
+    onDiagnosticsChange: () => {},
+    onContentRewrite,
+    format: 'q2-preview',
+    attributionOn: false,
+  };
+}
+
+const EDIT_PAYLOAD = {
+  __isPreviewNodeEdit: true,
+  channel: 'text',
+  newText: 'hello edited',
+  destinationSourceInfoJson: '{"t":0,"r":[0,5],"d":0}',
+};
+
+async function mountAndSettle(onContentRewrite: (qmd: string) => void) {
+  render(<ReactPreview {...baseProps(onContentRewrite)} />);
+  // The renderer mounts once the first render lands (previewState GOOD).
+  await waitFor(() => expect(rendererProps.length).toBeGreaterThan(0));
+  return () => rendererProps.at(-1);
+}
+
+describe('ReactPreview edit toggle (bd-ew0vak6b)', () => {
+  beforeEach(() => {
+    rendererProps.length = 0;
+    applyNodeEdit.mockClear();
+    renderPageInProjectWithAttribution.mockClear();
+    prefs.previewEditing = true;
+  });
+
+  it('forwards editingDisabled=false to ReactRenderer when previewEditing is on', async () => {
+    const latest = await mountAndSettle(() => {});
+    expect(latest().editingDisabled).toBe(false);
+  });
+
+  it('forwards editingDisabled=true to ReactRenderer when previewEditing is off', async () => {
+    prefs.previewEditing = false;
+    const latest = await mountAndSettle(() => {});
+    expect(latest().editingDisabled).toBe(true);
+  });
+
+  it('drops a PreviewNodeEditPayload while editing is off (no applyNodeEdit, no rewrite)', async () => {
+    prefs.previewEditing = false;
+    const onContentRewrite = vi.fn();
+    const latest = await mountAndSettle(onContentRewrite);
+
+    await act(async () => {
+      latest().setAst(EDIT_PAYLOAD);
+    });
+
+    expect(applyNodeEdit).not.toHaveBeenCalled();
+    expect(onContentRewrite).not.toHaveBeenCalled();
+  });
+
+  it('applies a PreviewNodeEditPayload while editing is on (regression baseline)', async () => {
+    const onContentRewrite = vi.fn();
+    const latest = await mountAndSettle(onContentRewrite);
+
+    await act(async () => {
+      latest().setAst(EDIT_PAYLOAD);
+    });
+
+    expect(applyNodeEdit).toHaveBeenCalledOnce();
+    expect(onContentRewrite).toHaveBeenCalledWith('rewritten qmd');
+  });
+});

--- a/hub-client/src/components/render/ReactPreview.tsx
+++ b/hub-client/src/components/render/ReactPreview.tsx
@@ -506,6 +506,10 @@ export default function ReactPreview({
   // q2-preview iframe so editable paragraphs/headings open the tiptap editor
   // instead of the monospaced textarea.
   const [richText] = usePreference('richText');
+  // bd-ew0vak6b: the bottom-bar Edit pill. Off ⇒ the iframe runs read-only
+  // (`editingDisabled`), and `handleSetAst` below drops any edit payload
+  // that still arrives (defense in depth, mirroring the q2-preview SPA).
+  const [previewEditing] = usePreference('previewEditing');
   // Track previewState in a ref for use in callbacks
   const previewStateRef = useRef<PreviewState>('START');
   useEffect(() => {
@@ -822,6 +826,10 @@ export default function ReactPreview({
           );
           return;
         }
+        // bd-ew0vak6b: read-only mode never writes. The iframe renders no
+        // edit surface while editing is off, but a payload can still be in
+        // flight from a session that was open when the pill was flipped.
+        if (!previewEditing) return;
         if (!rendered.untransformedAstJson) {
           console.warn(
             'q2-preview setAst: no untransformedAstJson retained; render first',
@@ -873,7 +881,7 @@ export default function ReactPreview({
         console.error('Failed to write AST back to QMD:', err);
       }
     },
-    [content, onContentRewrite, format, rendered.untransformedAstJson, rendered.renderedContent, beginCommitStatus, settleCommitStatus],
+    [content, onContentRewrite, format, rendered.untransformedAstJson, rendered.renderedContent, beginCommitStatus, settleCommitStatus, previewEditing],
   );
 
   return (
@@ -900,6 +908,7 @@ export default function ReactPreview({
             commentsMode={commentsMode}
             unlockNestingCursor={unlockNestingCursor}
             richText={richText}
+            editingDisabled={!previewEditing}
             nestedEditBuffers={nestedEditBuffers}
             scrollHandleRef={previewScrollRef}
             onPreviewScroll={handlePreviewScroll}

--- a/hub-client/src/components/render/ReactRenderer.integration.test.tsx
+++ b/hub-client/src/components/render/ReactRenderer.integration.test.tsx
@@ -262,6 +262,27 @@ describe('ReactRenderer format routing', () => {
     expect(capturedPreviewIframeProps.at(-1)?.richText).toBe(true);
   });
 
+  it('forwards editingDisabled to Q2PreviewIframe (bd-ew0vak6b)', () => {
+    // The bottom-bar Edit pill (via the previewEditing preference) reaches
+    // the iframe as `editingDisabled`; the renderer already honours it
+    // (bd-ov4gqk3m). Both values must pass through, and a rerender with the
+    // other value must reach the iframe too (the live toggle case).
+    const common = {
+      astJson: EMPTY_AST,
+      currentFilePath: '/project/index.qmd',
+      files: [],
+      fileContents: new Map<string, string>(),
+      onNavigateToDocument: () => {},
+      setAst: () => {},
+      format: 'q2-preview',
+    };
+    const { rerender } = render(<ReactRenderer {...common} editingDisabled={true} />);
+    expect(capturedPreviewIframeProps.at(-1)?.editingDisabled).toBe(true);
+
+    rerender(<ReactRenderer {...common} editingDisabled={false} />);
+    expect(capturedPreviewIframeProps.at(-1)?.editingDisabled).toBe(false);
+  });
+
   it('does not route q2-slides through any AST iframe', () => {
     const { queryByTestId } = mountForRouting('q2-slides');
     expect(capturedAstIframeProps.length).toBe(0);

--- a/hub-client/src/components/render/ReactRenderer.tsx
+++ b/hub-client/src/components/render/ReactRenderer.tsx
@@ -124,6 +124,12 @@ interface ReactRendererProps {
    */
   richText?: boolean;
   /**
+   * bd-ew0vak6b: read-only mode (the bottom-bar Edit pill off). Forwarded
+   * to `Q2PreviewIframe` only, which ships it in `UPDATE_AST`; the renderer
+   * already honours it (bd-ov4gqk3m). Absent/false ⇒ editable.
+   */
+  editingDisabled?: boolean;
+  /**
    * P3.2: per-siKey clean QMD buffers for nested blocks, produced by
    * `regenerateNestedBuffers` in `ReactPreview` (gated on
    * `unlockNestingCursor`). Forwarded to `Q2PreviewIframe` only.
@@ -170,6 +176,7 @@ function ReactRenderer({
   commentsMode,
   unlockNestingCursor,
   richText,
+  editingDisabled,
   nestedEditBuffers,
   scrollHandleRef,
   onPreviewScroll,
@@ -332,6 +339,7 @@ function ReactRenderer({
             commentsMode={commentsMode}
             unlockNestingCursor={unlockNestingCursor}
             richText={richText}
+            editingDisabled={editingDisabled}
             nestedEditBuffers={nestedEditBuffers}
             currentSlideIndex={currentSlideIndex}
             onSlideChange={onSlideChange}

--- a/hub-client/src/services/preferences/schema.test.ts
+++ b/hub-client/src/services/preferences/schema.test.ts
@@ -67,4 +67,36 @@ describe('validatePreferences', () => {
     // Missing richText fills in its ON default:
     expect(result.richText).toBe(true);
   });
+
+  // bd-ew0vak6b: the q2-preview Edit pill in the bottom bar persists its
+  // state as `previewEditing`. Same migration-safety shape as richText —
+  // a required key would wipe stored prefs that predate it.
+  it('defaults previewEditing to ON (block editing enabled by default)', () => {
+    expect(DEFAULT_PREFERENCES.previewEditing).toBe(true);
+  });
+
+  it('round-trips an explicit previewEditing: false', () => {
+    const result = validatePreferences({
+      ...DEFAULT_PREFERENCES,
+      previewEditing: false,
+    });
+    expect(result.previewEditing).toBe(false);
+  });
+
+  it('preserves other settings when previewEditing is absent (prefs from before it existed)', () => {
+    const oldPrefs = {
+      version: 1,
+      scrollSyncEnabled: false,
+      errorOverlayCollapsed: false,
+      colorScheme: 'dark',
+      unlockNestingCursor: false,
+      richText: false,
+    };
+    const result = validatePreferences(oldPrefs);
+    expect(result.scrollSyncEnabled).toBe(false);
+    expect(result.richText).toBe(false);
+    expect(result.colorScheme).toBe('dark');
+    // Missing previewEditing fills in its ON default:
+    expect(result.previewEditing).toBe(true);
+  });
 });

--- a/hub-client/src/services/preferences/schema.ts
+++ b/hub-client/src/services/preferences/schema.ts
@@ -38,6 +38,16 @@ export const UserPreferencesSchema = z.object({
    * keeps prefs written before this key existed parsing cleanly.
    */
   documentBranches: z.boolean().default(false),
+  /**
+   * bd-ew0vak6b: q2-preview block editing on/off (default-ON) — the Edit
+   * pill in the document bottom bar. When false the preview iframe runs
+   * read-only (`editingDisabled`), exactly like `q2 preview` without
+   * `--allow-edit`: no edit affordances, links are plain links. Persisted
+   * (unlike the session-only Authors/Comments toggles) because read mode
+   * is a way of working that should survive reloads. `.default(true)`
+   * keeps prefs written before this key existed parsing cleanly.
+   */
+  previewEditing: z.boolean().default(true),
 });
 
 // Infer TypeScript type from schema
@@ -55,6 +65,7 @@ export const DEFAULT_PREFERENCES: UserPreferences = {
   unlockNestingCursor: true,    // nesting-cursor ON by default (P3.2)
   richText: true,               // rich-text editor ON by default (bd-j1nto6eq)
   documentBranches: false,      // experimental branch bar OFF by default
+  previewEditing: true,         // q2-preview block editing ON by default (bd-ew0vak6b)
 };
 
 // Validation function - returns valid preferences or defaults

--- a/ts-packages/preview-renderer/src/q2-preview/dispatchers.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/dispatchers.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState, useRef, useLayoutEffect } from 'react';
+import React, { useContext, useState, useRef, useEffect, useLayoutEffect } from 'react';
 import { RegistryContext, AttributionWrap, renderChildren } from '../framework';
 import type {
     BlockNode,
@@ -330,6 +330,18 @@ function EditTextarea({
         ctx.commitTextEdit!(dest, newText);
         ctx.setEditTarget!(null);
     };
+
+    // bd-ew0vak6b: the host turned editing off mid-session (the Edit pill).
+    // The dispatcher's edit-target gate keeps this editor mounted, so close
+    // it the way a blur would — commit if dirty, else cancel — without a
+    // focus-restore (the tile is no longer focusable once editing is off).
+    // `commitIfDirty` is recreated every render, so the closure holds the
+    // draft of the render in which the flag flipped.
+    useEffect(() => {
+        if (!ctx.editingDisabled) return;
+        commitIfDirty(draft);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [ctx.editingDisabled]);
 
     return (
         <textarea

--- a/ts-packages/preview-renderer/src/q2-preview/edit-toggle-close.integration.test.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/edit-toggle-close.integration.test.tsx
@@ -1,0 +1,208 @@
+/**
+ * Live edit toggle: switching `editingDisabled` on while an edit session is
+ * open must close the session through the editor's own commit path
+ * (bd-ew0vak6b, plan decision D6).
+ *
+ * Until now `editingDisabled` was fixed for the life of a host session
+ * (`q2 preview` without `--allow-edit`), so nothing reacted to it changing.
+ * hub-client's bottom-bar Edit pill flips it live. The dispatcher's
+ * edit-target gate (`isBlockEditTarget`) does not consult the flag, so an
+ * open editor stays mounted with its draft intact when the flag turns on —
+ * which is exactly what lets the editor commit as a blur would:
+ *
+ *   - dirty textarea  → commit once via setAst, then close;
+ *   - unchanged       → close without a commit;
+ *   - rich editor     → same contract through its own `commit`;
+ *   - after the close, no block advertises editability, and turning editing
+ *     back on restores the affordance.
+ *
+ * Real production path through PreviewRoot (same harness shape as
+ * p2-4d.integration.test.tsx). jsdom gotchas handled the same way: tile
+ * rects are mocked so enumerateOuterBlocks sees the tiles, and PointerEvent
+ * pointerType is forced via defineProperty.
+ */
+
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup, act, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { PreviewRoot } from './PreviewRoot';
+import type { PreviewRootProps } from './PreviewRoot';
+
+afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+});
+
+function ptrEvent(
+    type: string,
+    opts: PointerEventInit & { clientX?: number; clientY?: number } = {},
+): Event {
+    const PE = (window as any).PointerEvent ?? Event;
+    const evt = new PE(type, { bubbles: true, cancelable: true, ...opts });
+    for (const [key, val] of Object.entries({
+        ...(opts.pointerType !== undefined ? { pointerType: opts.pointerType } : {}),
+        ...(opts.clientX !== undefined ? { clientX: opts.clientX } : {}),
+        ...(opts.clientY !== undefined ? { clientY: opts.clientY } : {}),
+    } as Record<string, unknown>)) {
+        Object.defineProperty(evt, key, { value: val, configurable: true });
+    }
+    return evt;
+}
+
+// Two paragraphs: pool[0] "para0\n" and pool[1] "para1\n".
+const CONTENT = 'para0\npara1\n';
+const POOL = [
+    { t: 0, r: [0, 6], d: 0 },
+    { t: 0, r: [6, 12], d: 0 },
+];
+
+function makeAstJson(): string {
+    const blocks = POOL.map((entry, i) => {
+        const text = CONTENT.slice(entry.r[0], entry.r[1]).replace(/\n/g, '');
+        return { t: 'Para', c: [{ t: 'Str', c: text }], s: i };
+    });
+    return JSON.stringify({
+        'pandoc-api-version': [1, 23, 0],
+        meta: {},
+        blocks,
+        astContext: { p: POOL },
+    });
+}
+
+function makeProps(overrides: Partial<PreviewRootProps> = {}): PreviewRootProps {
+    const astJson = makeAstJson();
+    return {
+        astJson,
+        untransformedAstJson: astJson,
+        renderedContent: CONTENT,
+        currentFilePath: '/test.qmd',
+        assetManifest: {},
+        setAst: vi.fn(),
+        onNavigateToDocument: () => {},
+        ...overrides,
+    };
+}
+
+function mockTileRects(container: HTMLElement) {
+    container.querySelectorAll<HTMLElement>('[data-block-pool-id]').forEach((tile) => {
+        const pid = Number(tile.getAttribute('data-block-pool-id'));
+        vi.spyOn(tile, 'getBoundingClientRect').mockReturnValue({
+            left: 0, top: pid * 60, right: 200, bottom: pid * 60 + 40,
+            width: 200, height: 40, x: 0, y: pid * 60, toJSON: () => ({}),
+        } as DOMRect);
+    });
+}
+
+async function openEditor(container: HTMLElement, poolId: string) {
+    const tile = container.querySelector<HTMLElement>(`[data-block-pool-id="${poolId}"]`);
+    expect(tile, `tile ${poolId} must be editable before the toggle`).not.toBeNull();
+    await act(async () => {
+        fireEvent(tile!, ptrEvent('pointerdown', { pointerType: 'mouse' }));
+        fireEvent(tile!, ptrEvent('pointerup', { pointerType: 'mouse' }));
+    });
+}
+
+const textarea = (c: HTMLElement) => c.querySelector<HTMLTextAreaElement>('textarea');
+const richToolbar = (c: HTMLElement) => c.querySelector<HTMLElement>('.q2-rt-toolbar');
+const poolTiles = (c: HTMLElement) => c.querySelectorAll('[data-block-pool-id]');
+
+describe('editingDisabled flipped on while editing (bd-ew0vak6b, D6)', () => {
+    it('commits a dirty textarea draft exactly once and closes the session', async () => {
+        const setAst = vi.fn();
+        const props = makeProps({ setAst });
+        const { container, rerender } = render(<PreviewRoot {...props} />);
+        await act(async () => {});
+        mockTileRects(container);
+
+        await openEditor(container, '1');
+        const ta = textarea(container);
+        expect(ta).not.toBeNull();
+        expect(ta!.value).toBe('para1');
+
+        await act(async () => {
+            fireEvent.change(ta!, { target: { value: 'para1 edited' } });
+        });
+        expect(setAst).not.toHaveBeenCalled();
+
+        // The host turns editing off (the Edit pill).
+        await act(async () => {
+            rerender(<PreviewRoot {...props} editingDisabled={true} />);
+        });
+
+        expect(setAst, 'the dirty draft is committed, once').toHaveBeenCalledOnce();
+        const payload = setAst.mock.calls[0][0] as any;
+        expect(payload.__isPreviewNodeEdit).toBe(true);
+        expect(payload.channel).toBe('text');
+        expect(payload.newText).toContain('para1 edited');
+
+        expect(textarea(container), 'the editor is closed').toBeNull();
+        expect(poolTiles(container).length, 'no block advertises editability').toBe(0);
+    });
+
+    it('closes an unchanged textarea session without committing', async () => {
+        const setAst = vi.fn();
+        const props = makeProps({ setAst });
+        const { container, rerender } = render(<PreviewRoot {...props} />);
+        await act(async () => {});
+        mockTileRects(container);
+
+        await openEditor(container, '0');
+        expect(textarea(container)).not.toBeNull();
+
+        await act(async () => {
+            rerender(<PreviewRoot {...props} editingDisabled={true} />);
+        });
+
+        expect(setAst).not.toHaveBeenCalled();
+        expect(textarea(container)).toBeNull();
+        expect(poolTiles(container).length).toBe(0);
+    });
+
+    it('closes an unchanged rich-text session without committing', async () => {
+        const setAst = vi.fn();
+        const props = makeProps({ setAst, richText: true });
+        const { container, rerender } = render(<PreviewRoot {...props} />);
+        await act(async () => {});
+        mockTileRects(container);
+
+        await openEditor(container, '1');
+        expect(richToolbar(container), 'the rich editor is the surface for a Para').not.toBeNull();
+
+        await act(async () => {
+            rerender(<PreviewRoot {...props} editingDisabled={true} />);
+        });
+
+        expect(setAst).not.toHaveBeenCalled();
+        expect(richToolbar(container), 'the rich editor is closed').toBeNull();
+        expect(poolTiles(container).length).toBe(0);
+    });
+
+    it('turning editing back on restores the affordance and a new session can open', async () => {
+        const setAst = vi.fn();
+        const props = makeProps({ setAst });
+        const { container, rerender } = render(<PreviewRoot {...props} />);
+        await act(async () => {});
+        mockTileRects(container);
+
+        await openEditor(container, '1');
+        expect(textarea(container)).not.toBeNull();
+
+        await act(async () => {
+            rerender(<PreviewRoot {...props} editingDisabled={true} />);
+        });
+        expect(textarea(container)).toBeNull();
+        expect(poolTiles(container).length).toBe(0);
+
+        await act(async () => {
+            rerender(<PreviewRoot {...props} editingDisabled={false} />);
+        });
+        expect(poolTiles(container).length).toBe(2);
+        mockTileRects(container);
+
+        await openEditor(container, '0');
+        expect(textarea(container)).not.toBeNull();
+        expect(textarea(container)!.value).toBe('para0');
+    });
+});

--- a/ts-packages/preview-renderer/src/q2-preview/richtext/RichTextEditor.tsx
+++ b/ts-packages/preview-renderer/src/q2-preview/richtext/RichTextEditor.tsx
@@ -180,6 +180,18 @@ export function RichTextEditor({
     ctx.setEditTarget?.(null);
   };
 
+  // bd-ew0vak6b: the host turned editing off mid-session (the Edit pill).
+  // The dispatcher's edit-target gate keeps this editor mounted, so close it
+  // the way a blur would — `commit` is a no-op close when unchanged and a
+  // real commit when dirty — without a focus-restore (the tile is no longer
+  // focusable once editing is off). `commit` is recreated every render, so
+  // the closure is the one from the render in which the flag flipped.
+  useEffect(() => {
+    if (!ctx.editingDisabled || !editor) return;
+    commit(editor);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ctx.editingDisabled, editor]);
+
   // Keep the commit keymap's handlers pointed at the current closures. Assigned
   // during render (idempotent, no external effect) so a keypress after any
   // render calls fresh `commit`/`cancel` — no stale-closure window.


### PR DESCRIPTION
## Summary

`format: q2-preview` in hub-client was always editable, which made links hard to follow: a mouse click on any editable paragraph opens that paragraph's editor, so a click on a link inside a paragraph also opened an editor. `q2 preview` already has this distinction via `--allow-edit`, and the renderer already implements read-only mode behind `editingDisabled` (bd-ov4gqk3m); hub-client never set it.

This adds an **Edit** pill to the document bottom bar (before **Authors**) that turns block editing on and off. Off makes the preview behave like a read-only `q2 preview`: no edit affordances, no hover outline, links are plain links. The choice persists as the `previewEditing` preference (default on).

- `previewEditing` preference (`.default(true)`, migration-safe like `richText`), read by `ReactPreview` and forwarded through `ReactRenderer` to the iframe as `editingDisabled`; `handleSetAst` also drops edit payloads while off (defense in depth, as in the q2-preview SPA).
- `ReplayDrawer`: `EditToggle` pill, disabled for formats other than q2-preview. Authors and Edit share a `.replay-drawer__pill*` CSS base; the rainbow ring stays attribution-only.
- preview-renderer: when `editingDisabled` turns on while an edit session is open, both editor surfaces (textarea, rich text) close through their own commit path — commit if dirty, else cancel.

Design and decisions: `claude-notes/plans/2026-09-09-q2-preview-edit-toggle.md`.

## Tests

- Unit/integration (written red first): schema defaults + migration; ReplayDrawer pill (states, disabled, ordering); ReactRenderer forwarding; ReactPreview forwarding + drop guard; preview-renderer close-on-disable (dirty textarea commits once; unchanged textarea/rich close without commit; re-enable restores the affordance).
- Playwright `hub-client/e2e/q2-preview-edit-toggle.spec.ts`: off removes affordances and hover outline, a link navigates to the other document without opening an editor, the choice survives a reload, on restores. Passed in Chromium against a real hub.
- `cargo xtask verify --skip-rust-tests` and `cargo xtask lint` green (no Rust changes).

Not covered: a *dirty* rich-text session closed by the toggle (nothing makes the tiptap editor dirty in jsdom today; it uses the same `commit` the blur path does).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019HurMzS5oc3w2yLYPsEA78
