### PR TITLE
Publish source: file brand fonts beside the theme CSS (bd-ve916wr8)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4923,6 +4923,7 @@ dependencies = [
 name = "quarto-brand"
 version = "0.30.0"
 dependencies = [
+ "hashlink",
  "pathdiff",
  "quarto-util",
  "serde",

--- a/claude-notes/designs/path-resolution-model.md
+++ b/claude-notes/designs/path-resolution-model.md
@@ -151,6 +151,7 @@ Update this table when adding keys or migrating sites.
 | `project/mod.rs` fragment rebase; `extension/{paths,read}.rs` | extension-contributed theme/css/include-*/template/filters | (2) force-marked `Path` |
 | `website_config.rs`, `website_post_render.rs` | `favicon`, navbar logo / footer image copy | project-root by construction (`_quarto.yml`-only keys) |
 | `discovery.rs`, `project_resources.rs`, `sidebar_auto.rs`, `quarto-sass/src/config.rs` | `project.render`, `project.resources`, sidebar `auto:`, `brand:` | project-root by construction |
+| `quarto-core/src/brand_fonts.rs` (`resolve_source`) | `_brand.yml` `typography.fonts[].files[].path` (`source: file`) | brand-file dir base; leading `/` = project root; **emitted URL is artifact-relative** (`fonts/<basename>` beside the theme CSS), never a rebased source path (bd-ve916wr8) |
 | URL-space emitters (`link_rewrite`, `navbar/footer_render`, `website_favicon`, `transforms/format_css`, `example_embed`, listing `item.rs`) | emitted hrefs/srcs | `page_url_for` family (rule-2 exit) |
 | `transforms/repo_actions_render.rs` + `quarto-navigation::repo_actions` | `repo-url`, `repo-branch`, `repo-subdir`, `issue-url` | absolute external URLs built from the pivot form (`page_relative_source`); **neither rule-2 exit** — no `page_url_for`, no filesystem read. `repo-subdir` is a *repository*-namespace path, outside this contract entirely. |
 | `include_expansion.rs:689` (`resolve_include_target`) | `{{< include >}}` (markdown space) | project-root leading-`/` + includer-dir |

--- a/claude-notes/plans/2026-09-08-brand-file-fonts-website.md
+++ b/claude-notes/plans/2026-09-08-brand-file-fonts-website.md
@@ -148,8 +148,15 @@ theme CSS and out of scope here.
 - [x] `cargo xtask verify` (full — `quarto-core` changes affect the WASM
       leg; hub-client vitest is currently red on `main` for an unrelated
       `localStorage` environment issue, see NOTES.md).
-- [ ] Rebase over bd-5fseopxy if it has landed; resolve the
-      `file_font_face_block` conflict.
+- [x] Rebase over bd-5fseopxy if it has landed; resolve the
+      `file_font_face_block` conflict. Done 2026-09-09 onto `main` @
+      `9d236060` (after #661, #663, #664–#667): kept #663's weight-range
+      emitter (`font_weight_to_css` + `RangeOk::FontFace`, YAML-path
+      error locations, `Brand::validate`) and #661's structured
+      `sass_error_to_parse_error` mapping in the reveal branch; layered
+      the constant `fonts/<name>` URL, the `BrandFontFileEntry`
+      accessors, and the brand-file tracking on top. `validate.rs` now
+      reads `entry.weight()`. Catalog carries `Q-14-6`..`Q-14-11`.
 
 ### On merge
 

--- a/claude-notes/plans/2026-09-08-brand-file-fonts-website.md
+++ b/claude-notes/plans/2026-09-08-brand-file-fonts-website.md
@@ -2,190 +2,170 @@
 
 **Date:** 2026-09-08
 **Braid:** bd-ve916wr8
-**Checkout:** main @ `b7e7c96a` (investigation ran in the main checkout; no worktree created)
-**Status:** Investigation — pending design alignment with user. **Do not start implementation until the user gives the go-ahead.**
+**Checkout:** main @ `b7e7c96a` (investigation ran in the main checkout)
+**Status:** Design agreed with user 2026-09-08 (decisions below). Ready to implement on a topic branch.
 
-## Triage verdict
+## Overview
 
-**Ready to design.** Every claim in the strand reproduces at HEAD with a
-two-page fixture, and the investigation found two more defects in the same
-mechanism (single-doc renders are equally broken; the SASS cache key omits
-the font prefix, so pages alias onto whichever compiled first). The fix is
-well-bounded — three consumers, one emitter — but there is one real design
-fork (where the font bytes go and therefore what the URL is) that the user
-should pick.
+`source: file` fonts in `_brand.yml` never reach the output, and the
+`@font-face` URL the theme CSS carries is document-relative while the CSS
+itself is relocated (`site_libs/quarto/` for websites, `{stem}_files/` for
+single documents). Every local brand font 404s. Evidence and committed
+repro fixtures: `claude-notes/plans/brand-file-fonts-website-investigation/`
+(NOTES.md has the exact invocations and observed output).
 
-Evidence: `claude-notes/plans/brand-file-fonts-website-investigation/NOTES.md`.
+Fix: publish font files as **project-scope artifacts beside the theme CSS**
+and emit a constant `fonts/<name>` URL. One mechanism serves website,
+single-doc, and the WASM preview; the prefix no longer depends on the
+document, which also removes the per-depth bundle split and the cache-key
+aliasing.
 
-## Issue context
+## Decisions (agreed 2026-09-08)
 
-Filed 2026-09-08 by Carlos, type `bug`, priority 2, labels `css`,
-`theming`, `websites`. Found while moving cscheid-net-2026 from Google
-Fonts to local woff2. Summary of the report:
+1. **Fonts as artifacts.** Font bytes are stored as `ArtifactScope::Project`
+   artifacts at `quarto/fonts/<basename>` (website → `site_libs/quarto/fonts/`)
+   or `fonts/<basename>` (single-doc → `{stem}_files/fonts/`), i.e. always
+   in a `fonts/` dir beside the theme CSS, so the `@font-face` URL is the
+   constant `fonts/<basename>`. Not a source-mirrored copy.
+2. **Name collisions are an error, never a silent overwrite.** Two distinct
+   byte contents claiming the same `fonts/<basename>` (across brands,
+   light/dark variants, or documents) fail the render with a diagnostic
+   naming both source files. Identical bytes dedupe (existing
+   `merge_into_project` semantics).
+3. **Leading `/` in a font path means project root** (path contract), for
+   locating the file. The emitted URL is the constant form regardless. The
+   `/assets/… + resources:` workaround keeps working (the file is now also
+   found via project root and published as an artifact; the explicit
+   `resources:` copy becomes redundant but harmless).
+4. **`format()` hint** derived from the extension (`woff2`, `woff`, `ttf` →
+   `truetype`, `otf` → `opentype`); unknown extension → no hint.
+5. **Unknown keys on a file entry (`format:`, `display:`) warn and are
+   ignored**, not rejected — the brand.yml spec has not settled them.
+6. **bd-5fseopxy** (weight ranges) edits the same emitter concurrently;
+   expect a textual conflict in `file_font_face_block` and resolve at rebase.
+7. **On merge**, comment on **bd-r1y48cx0** (`css:` files never copied)
+   pointing at the artifact mechanism as the one to reuse.
 
-1. `source: file` font files are never copied into the output.
-2. The emitted `src: url("assets/x.woff2")` is relative to the *document*,
-   but the compiled theme CSS is written to `site_libs/quarto/`, so the
-   browser resolves it against the wrong directory.
-3. The prefix is computed per document (`pathdiff(document_dir,
-   brand_dir)`), so a site with pages at different depths ships N theme
-   bundles.
-4. Minor: no `format("woff2")` hint, no `font-display` for file fonts;
-   `format:` on a files entry is silently ignored.
+Why not the resource channel for the copy: the user's answer to Q2 chose
+the resource channel *if* a copy was needed; with fonts as artifacts there
+is no copy step, and artifacts already flush through both the native sink
+and the preview VFS. The render-manifest gap (flushed `site_libs` artifacts
+are not listed in `.quarto/render-manifest.json`) is pre-existing for the
+theme CSS and out of scope here.
 
-Workaround in use: a site-root-absolute `/assets/…` path plus an explicit
-`project.resources` glob — correct only when served from the domain root.
+## Phases
 
-## Dependency graph
+### Phase 0 — Tests (TDD: written first, verified failing)
 
-No `discovered-from`, no incoming `blocks`. Two `related` edges:
+- [ ] `quarto-sass` unit (`brand_layer_test.rs`): `file_font_face_block`
+      emits `src: url('fonts/<basename>') format('woff2')`; `/`-rooted and
+      `../`-style source paths all collapse to `fonts/<basename>`;
+      external URLs pass through unchanged, no `format()`.
+- [ ] `quarto-sass` unit: `font_path_prefix` no longer influences the
+      URL — remove/replace the `"brand/regular.woff2"` assertion in
+      `typography_layer_emits_file_font_face`.
+- [ ] `quarto-brand` unit: an explicit file entry with `format:` /
+      `display:` parses (not an error) and exposes the unknown keys for
+      the warning.
+- [ ] `quarto-core` integration, driving the real render path (project
+      render / `render_document_to_file`, fixture promoted from
+      `brand-file-fonts-website-investigation/repro`):
+  - [ ] website with pages at two depths → exactly one theme bundle in
+        `site_libs/quarto/`, both pages link it, and the font exists at
+        `site_libs/quarto/fonts/<basename>` — i.e. the `@font-face` URL
+        resolves from the bundle's directory to a real file.
+  - [ ] single-doc → `{stem}_files/styles.css` + `{stem}_files/fonts/<basename>`.
+  - [ ] cache-aliasing regression: render the nested page alone, then the
+        whole project (same runtime cache); the root page's bundle has the
+        correct URL. (Passes structurally once the prefix is constant; keep
+        the test so a future document-dependent input can't regress it.)
+  - [ ] missing font file → warning naming the brand file, family and path;
+        render continues (matches `copy_navbar_logo` warn-and-continue).
+  - [ ] collision: two brands / two files with the same basename and
+        different bytes → render error naming both sources.
+  - [ ] unknown key on a file entry → one warning, render continues.
+  - [ ] light/dark brands with distinct font files → both published, no
+        conflict.
 
-- **bd-5fseopxy** (in_progress) — weight ranges `400..700` collapse to
-  400 for google *and* file sources. Touches the same
-  `file_font_face_block` (`font-weight: N M` for variable files). The two
-  strands will conflict textually in `brand_layer.rs:553-584`; whichever
-  lands second rebases. No semantic coupling — the URL/copy work here does
-  not care about the weight value.
-- **bd-qnylgu69** (open) — audit `docs/guides/authoring/brand.qmd` against
-  actual Q2 support. This strand's docs phase should hand it the exact
-  wording for `source: file` (paths are relative to the brand file; files
-  are copied automatically once this lands; until then the `/assets` +
-  `resources:` workaround).
+### Phase 1 — Constant font URL in the SCSS layer
 
-Also relevant, not linked: **bd-r1y48cx0** (open) — `css:` files never
-copied for websites. Same bug class ("theme/CSS side-input is read but
-never published"); the copy mechanism chosen here should be the one that
-strand reuses. And the path-resolution contract
-(`claude-notes/designs/path-resolution-model.md`) lists `brand:` as
-"project-root by construction" — font paths *inside* the brand file are a
-consumer that inventory does not yet mention; add a row.
+- [ ] `brand_layer.rs`: `file_font_face_block` emits `fonts/<basename>` +
+      `format()`; drop `join_url_path` and the `font_path_prefix`
+      parameter from `brand_to_layers` / `typography_layer` (update
+      `config.rs:695` caller and its doc comment).
+- [ ] `themes.rs:777-783`: remove the `pathdiff(document_dir, brand_dir)`
+      prefix; `brand_dir` stays on `ThemeContext` (Phase 2 reads it).
+- [ ] `compile_theme_css.rs` `cache_key()`: document in the comment why
+      `document_dir` is deliberately absent (URL is constant) — and hash
+      the font *basenames* so a renamed file invalidates the CSS.
 
-## What the code looks like today
+### Phase 2 — Publish font artifacts
 
-All file paths in the strand still exist with the described shape
-(spot-checked; line numbers in NOTES.md). Reproduced at HEAD:
+- [ ] In `CompileThemeCssStage::run`, after brand resolution, walk each
+      resolved brand's `typography.fonts` `source: file` entries (light and
+      dark): resolve the path (leading `/` → `ctx.project.dir`, else
+      `brand_dir.join(path)`; external URLs skipped), read bytes via
+      `ctx.runtime`, store `Artifact::from_bytes(bytes, <mime by ext>)`
+      with key `font:<basename>` and path `quarto/fonts/<basename>` /
+      `fonts/<basename>` (mirror `theme_artifact_key_and_path`'s
+      single-doc switch), scope `Project`.
+- [ ] Collision check before `ctx.artifacts.store`: same key already
+      present with different bytes → structured error naming both source
+      paths. Cross-document collisions surface via
+      `ArtifactStore::merge_into_project`'s existing conflict — wrap that
+      error so it names the font sources too (today it prints key + byte
+      lengths only).
+- [ ] Missing file → warning diagnostic; render continues without the
+      artifact (the CSS still references it, matching logo behavior).
+- [ ] Confirm nothing emits a `<link>` for `font:*` keys (link emission
+      selects by `css:` / `js:` prefixes — verify) and that
+      `flush_artifacts_to_vfs` carries binary content to the preview.
+- [ ] New `Q-14-*` catalog entries for the collision error and the
+      missing-file / unknown-key warnings, each with its
+      `docs/errors/theme/<code>.qmd` page **and** sidebar entry in the same
+      commit (`cargo xtask lint`).
 
-| Case | Theme CSS location | Emitted `src` | File copied? |
-|---|---|---|---|
-| website, `index.qmd` | `_site/site_libs/quarto/quarto-theme-<fp>.css` | `assets/…` | no |
-| website, `posts/one.qmd` (cold cache) | second bundle, different `<fp>` | `../assets/…` | no |
-| website, warm cache | one bundle, prefix of whichever page compiled *first* (persistent across sessions) | order-dependent | no |
-| single doc `doc.qmd` | `doc_files/styles.css` | `assets/…` → resolves to `doc_files/assets/…` | no |
+### Phase 3 — Unknown-key warning on file entries
 
-Two corrections to the strand text:
+- [ ] `quarto-brand` `BrandFontFileEntry::Explicit`: capture unrecognised
+      keys (`#[serde(flatten)]` map) so `format:`/`display:` survive parse.
+- [ ] Emit one warning per entry from the stage (has the diagnostics
+      sink); ignore the keys.
 
-- **Single-doc is broken too.** `styles.css` is not "next to the document";
-  it is in `{stem}_files/` (`resource_resolver.rs:113-124`), so the
-  document-relative prefix is wrong there as well.
-- **The N-bundle split only happens on a cold cache.** With the persistent
-  SASS cache warm, `cache_key()` (`compile_theme_css.rs:197`) — which
-  hashes the brand YAML but not `document_dir` — makes every page reuse the
-  first page's bundle, wrong prefix included. Either way the output is
-  wrong; the cache-key omission is a separate correctness bug worth its own
-  regression test.
+### Phase 4 — Docs, contract, verification
 
-Q1 parity: Q1 uses the identical document-relative prefix and does **not**
-copy font files for HTML (only for typst). It works in Q1 only because Q1's
-theme CSS sits beside the page. The `site_libs`/`{stem}_files` relocation
-is the Q2 change that exposed both gaps.
+- [ ] `docs/guides/authoring/brand.qmd`: `source: file` paths resolve
+      relative to the brand file (leading `/` = project root), files are
+      published automatically, `format:`/`display:` are not yet supported.
+      Hand the wording to bd-qnylgu69.
+- [ ] `claude-notes/designs/path-resolution-model.md`: add a row for
+      brand-file font paths (brand-dir base, `/` = project root, emitted
+      URL is artifact-relative).
+- [ ] End-to-end: `cargo run --bin q2 -- render` on both fixtures; inspect
+      `site_libs/quarto/fonts/`, the `@font-face` line, and a browser
+      load; record invocation + output snippet here.
+- [ ] `cargo xtask verify` (full — `quarto-core` changes affect the WASM
+      leg; hub-client vitest is currently red on `main` for an unrelated
+      `localStorage` environment issue, see NOTES.md).
+- [ ] Rebase over bd-5fseopxy if it has landed; resolve the
+      `file_font_face_block` conflict.
 
-## Proposed phases (draft)
+### On merge
 
-Skeleton only — contents depend on the design answers below.
+- [ ] Comment on bd-r1y48cx0 pointing at the font-artifact mechanism as
+      the one for `css:` files to reuse.
+- [ ] Close bd-ve916wr8.
 
-- **Phase 0 — Test plan (TDD).**
-  - `quarto-sass` unit: `file_font_face_block` emits the chosen URL shape
-    (and `format("woff2")` if in scope); `/`-rooted path handling per Q3.
-  - `quarto-core` integration (drive `render_document_to_file` /
-    project render, not `brand_to_layers` directly): (a) website with pages
-    at two depths → exactly one theme bundle, both pages link it, the
-    `@font-face` URL resolves from the bundle's directory to a file that
-    exists in the output; (b) single-doc → same property against
-    `{stem}_files/styles.css`; (c) cache-aliasing regression — render
-    nested page first, then root page, assert the root page's URL is
-    correct; (d) missing font file → warning naming the brand file key.
-  - Fixture: promote `brand-file-fonts-website-investigation/repro` into
-    the test tree.
-- **Phase 1 — Font URL base.** Compute the `@font-face` URL relative to
-  the theme artifact's location (or make it constant — see Q1). Remove
-  `document_dir` from the prefix computation so the fingerprint is
-  site-wide; add whatever *does* feed the URL to `cache_key()`.
-- **Phase 2 — Publish the font bytes.** Per Q1: either emit fonts as
-  project-scope artifacts next to the theme CSS, or register them as
-  implicit resources / a post-render copy hook. Must cover single-doc and
-  website; note WASM preview implications.
-- **Phase 3 — Small emitter fixes (if in scope, Q4).** `format()` from the
-  extension; reject unknown keys on file entries (`format:`/`display:`)
-  instead of dropping them; optionally accept a display hint.
-- **Phase 4 — Docs + contract.** `docs/guides/authoring/brand.qmd`
-  (`source: file` semantics, coordinate with bd-qnylgu69); add the
-  brand-font row to `path-resolution-model.md`'s inventory; end-to-end
-  verification via `cargo run --bin q2 -- render` on the fixture, output
-  inspected.
+## Risks
 
-## Open design questions for the user
-
-1. **Where do the font bytes live, and hence what is the URL?** Two shapes:
-   - **(a) Fonts become project-scope artifacts beside the theme CSS**
-     (`site_libs/quarto/fonts/<name>` / `doc_files/fonts/<name>`), and the
-     `@font-face` URL is the constant `fonts/<name>`. Pros: one mechanism
-     for website, single-doc, *and* the WASM preview (artifacts flush
-     through both transports; the native-only `copy_*` hooks do not);
-     the prefix is constant so the cache-key and per-depth problems vanish
-     structurally; no dependence on how the site is hosted. Cons: font
-     bytes pass through the in-memory artifact store; `_site/assets/`
-     no longer mirrors the source tree for fonts (a user's `/assets/…`
-     workaround keeps working but becomes redundant).
-   - **(b) Copy fonts to their source-mirrored output path** (like logos:
-     `_site/assets/x.woff2`) and emit a URL relative to the theme CSS
-     (`../../assets/x.woff2` from `site_libs/quarto/`; `../assets/…` from
-     `doc_files/`). Keeps the output tree familiar; needs the copy to run in
-     both single-doc and project paths and stays native-only.
-   My recommendation is (a). Do you agree, or do you want the output tree
-   to mirror the source layout?
-2. **Copy channel (only if 1b).** Post-render hook like `copy_navbar_logo`
-   (needs a single-doc twin), or the resource channel
-   (`ResolvedResource` with a brand-file origin, so the render manifest
-   lists the fonts for `quarto publish`)? I'd take the resource channel,
-   and bd-r1y48cx0 (`css:` copy) would reuse it.
-3. **Leading `/` in a font path.** Today `/assets/x` accidentally survives
-   as a site-root URL (`PathBuf::push` drops the prefix). The path contract
-   says a leading `/` means *project root* for resolution. Should the fix
-   (i) resolve `/assets/x` against the project root for the *copy* and
-   emit the normal relative/constant URL like any other path, or (ii)
-   keep `/…` as an explicit "emit verbatim, you host it" escape hatch?
-   (i) is contract-conformant and what I'd do; it changes the workaround's
-   emitted URL from `/assets/…` to the new form, which is still correct.
-4. **Scope of the emitter niceties.** In scope here or a follow-up strand:
-   `format("woff2")` from the extension (cheap, clearly good);
-   `deny_unknown_fields` on the explicit file entry so `format:`/`display:`
-   error instead of vanishing (the brand.yml spec has no `display` for
-   file fonts — accepting one would be a Q2 extension); a `display:` /
-   `font-display` hint for file fonts (spec extension — I'd file it
-   separately).
-5. **Interaction with bd-5fseopxy.** Both edit `file_font_face_block`.
-   Sequence this after it lands, or land this first and let the weight
-   work rebase? (Pure ordering question; either is fine.)
-
-## Risks / tradeoffs (draft)
-
-- **Artifact-store size (1a).** Variable fonts are ~100–500 KB each; a
-  brand with several files puts a few MB through the artifact map per
-  render. Should be fine (images already go this route) but worth one
-  measurement on a real brand.
-- **Fingerprint stability.** Whatever feeds the URL must feed both
-  `theme_fingerprint` (already content-based, fine) and `cache_key()`
-  (currently incomplete). If (1a), the URL is constant and the cache key
-  is correct by construction; if (1b), the key must include the
-  artifact-relative prefix.
-- **Dark brand with different fonts** — the dark bundle's `@font-face`
-  blocks reference the dark brand's files; under (1a) both variants' fonts
-  land in the same `fonts/` dir, so filename collisions across brands
-  need a content-hash or brand-scoped name.
-- **Hub-client preview** — under (1b) fonts would not appear in the WASM
-  preview at all (the copy hooks are native-only); under (1a) they should,
-  but the preview transport's handling of binary project-scope artifacts
-  needs a check before claiming it.
-- **Test environment** — pre-flight's hub-client vitest leg is red on a
-  clean `main` (`localStorage` undefined, Node v26.8.1); Rust legs green.
-  Unrelated but will show up in any full `cargo xtask verify`.
+- **Artifact-store size.** Variable fonts are ~100–500 KB each; a brand
+  with several files puts a few MB through the artifact map per render.
+  Images already take this route; measure once on a real brand.
+- **Collision granularity.** Basename-keyed names mean two *different*
+  brands (per-document `brand:` front matter) with `regular.woff2` each
+  collide by design (decision 2). If that bites in practice, the escape is
+  a content-hash suffix — not silent overwrite.
+- **Preview transport.** Binary project-scope artifacts should flow to the
+  hub-client VFS like images do; verify rather than assume before claiming
+  preview support.
+- **Concurrent edits** with bd-5fseopxy in `brand_layer.rs:553-584`.

--- a/claude-notes/plans/2026-09-08-brand-file-fonts-website.md
+++ b/claude-notes/plans/2026-09-08-brand-file-fonts-website.md
@@ -57,51 +57,51 @@ theme CSS and out of scope here.
 
 ### Phase 0 — Tests (TDD: written first, verified failing)
 
-- [ ] `quarto-sass` unit (`brand_layer_test.rs`): `file_font_face_block`
+- [x] `quarto-sass` unit (`brand_layer_test.rs`): `file_font_face_block`
       emits `src: url('fonts/<basename>') format('woff2')`; `/`-rooted and
       `../`-style source paths all collapse to `fonts/<basename>`;
       external URLs pass through unchanged, no `format()`.
-- [ ] `quarto-sass` unit: `font_path_prefix` no longer influences the
+- [x] `quarto-sass` unit: `font_path_prefix` no longer influences the
       URL — remove/replace the `"brand/regular.woff2"` assertion in
       `typography_layer_emits_file_font_face`.
-- [ ] `quarto-brand` unit: an explicit file entry with `format:` /
+- [x] `quarto-brand` unit: an explicit file entry with `format:` /
       `display:` parses (not an error) and exposes the unknown keys for
       the warning.
-- [ ] `quarto-core` integration, driving the real render path (project
+- [x] `quarto-core` integration, driving the real render path (project
       render / `render_document_to_file`, fixture promoted from
       `brand-file-fonts-website-investigation/repro`):
-  - [ ] website with pages at two depths → exactly one theme bundle in
+  - [x] website with pages at two depths → exactly one theme bundle in
         `site_libs/quarto/`, both pages link it, and the font exists at
         `site_libs/quarto/fonts/<basename>` — i.e. the `@font-face` URL
         resolves from the bundle's directory to a real file.
-  - [ ] single-doc → `{stem}_files/styles.css` + `{stem}_files/fonts/<basename>`.
-  - [ ] cache-aliasing regression: render the nested page alone, then the
+  - [x] single-doc → `{stem}_files/styles.css` + `{stem}_files/fonts/<basename>`.
+  - [x] cache-aliasing regression: render the nested page alone, then the
         whole project (same runtime cache); the root page's bundle has the
         correct URL. (Passes structurally once the prefix is constant; keep
         the test so a future document-dependent input can't regress it.)
-  - [ ] missing font file → warning naming the brand file, family and path;
+  - [x] missing font file → warning naming the brand file, family and path;
         render continues (matches `copy_navbar_logo` warn-and-continue).
-  - [ ] collision: two brands / two files with the same basename and
+  - [x] collision: two brands / two files with the same basename and
         different bytes → render error naming both sources.
-  - [ ] unknown key on a file entry → one warning, render continues.
-  - [ ] light/dark brands with distinct font files → both published, no
+  - [x] unknown key on a file entry → one warning, render continues.
+  - [x] light/dark brands with distinct font files → both published, no
         conflict.
 
 ### Phase 1 — Constant font URL in the SCSS layer
 
-- [ ] `brand_layer.rs`: `file_font_face_block` emits `fonts/<basename>` +
+- [x] `brand_layer.rs`: `file_font_face_block` emits `fonts/<basename>` +
       `format()`; drop `join_url_path` and the `font_path_prefix`
       parameter from `brand_to_layers` / `typography_layer` (update
       `config.rs:695` caller and its doc comment).
-- [ ] `themes.rs:777-783`: remove the `pathdiff(document_dir, brand_dir)`
+- [x] `themes.rs:777-783`: remove the `pathdiff(document_dir, brand_dir)`
       prefix; `brand_dir` stays on `ThemeContext` (Phase 2 reads it).
-- [ ] `compile_theme_css.rs` `cache_key()`: document in the comment why
+- [x] `compile_theme_css.rs` `cache_key()`: document in the comment why
       `document_dir` is deliberately absent (URL is constant) — and hash
       the font *basenames* so a renamed file invalidates the CSS.
 
 ### Phase 2 — Publish font artifacts
 
-- [ ] In `CompileThemeCssStage::run`, after brand resolution, walk each
+- [x] In `CompileThemeCssStage::run`, after brand resolution, walk each
       resolved brand's `typography.fonts` `source: file` entries (light and
       dark): resolve the path (leading `/` → `ctx.project.dir`, else
       `brand_dir.join(path)`; external URLs skipped), read bytes via
@@ -109,42 +109,43 @@ theme CSS and out of scope here.
       with key `font:<basename>` and path `quarto/fonts/<basename>` /
       `fonts/<basename>` (mirror `theme_artifact_key_and_path`'s
       single-doc switch), scope `Project`.
-- [ ] Collision check before `ctx.artifacts.store`: same key already
+- [x] Collision check before `ctx.artifacts.store`: same key already
       present with different bytes → structured error naming both source
       paths. Cross-document collisions surface via
       `ArtifactStore::merge_into_project`'s existing conflict — wrap that
       error so it names the font sources too (today it prints key + byte
       lengths only).
-- [ ] Missing file → warning diagnostic; render continues without the
+- [x] Missing file → warning diagnostic; render continues without the
       artifact (the CSS still references it, matching logo behavior).
-- [ ] Confirm nothing emits a `<link>` for `font:*` keys (link emission
+- [x] Confirm nothing emits a `<link>` for `font:*` keys (link emission
       selects by `css:` / `js:` prefixes — verify) and that
       `flush_artifacts_to_vfs` carries binary content to the preview.
-- [ ] New `Q-14-*` catalog entries for the collision error and the
+- [x] New `Q-14-*` catalog entries for the collision error and the
       missing-file / unknown-key warnings, each with its
       `docs/errors/theme/<code>.qmd` page **and** sidebar entry in the same
       commit (`cargo xtask lint`).
 
 ### Phase 3 — Unknown-key warning on file entries
 
-- [ ] `quarto-brand` `BrandFontFileEntry::Explicit`: capture unrecognised
+- [x] `quarto-brand` `BrandFontFileEntry::Explicit`: capture unrecognised
       keys (`#[serde(flatten)]` map) so `format:`/`display:` survive parse.
-- [ ] Emit one warning per entry from the stage (has the diagnostics
+- [x] Emit one warning per entry from the stage (has the diagnostics
       sink); ignore the keys.
 
 ### Phase 4 — Docs, contract, verification
 
-- [ ] `docs/guides/authoring/brand.qmd`: `source: file` paths resolve
+- [x] `docs/guides/authoring/brand.qmd`: `source: file` paths resolve
       relative to the brand file (leading `/` = project root), files are
       published automatically, `format:`/`display:` are not yet supported.
       Hand the wording to bd-qnylgu69.
-- [ ] `claude-notes/designs/path-resolution-model.md`: add a row for
+- [x] `claude-notes/designs/path-resolution-model.md`: add a row for
       brand-file font paths (brand-dir base, `/` = project root, emitted
       URL is artifact-relative).
-- [ ] End-to-end: `cargo run --bin q2 -- render` on both fixtures; inspect
+- [x] End-to-end: `cargo run --bin q2 -- render` on both fixtures; inspect
       `site_libs/quarto/fonts/`, the `@font-face` line, and a browser
-      load; record invocation + output snippet here.
-- [ ] `cargo xtask verify` (full — `quarto-core` changes affect the WASM
+      load; record invocation + output snippet here. → see
+      "End-to-end verification" below.
+- [x] `cargo xtask verify` (full — `quarto-core` changes affect the WASM
       leg; hub-client vitest is currently red on `main` for an unrelated
       `localStorage` environment issue, see NOTES.md).
 - [ ] Rebase over bd-5fseopxy if it has landed; resolve the
@@ -155,6 +156,14 @@ theme CSS and out of scope here.
 - [ ] Comment on bd-r1y48cx0 pointing at the font-artifact mechanism as
       the one for `css:` files to reuse.
 - [ ] Close bd-ve916wr8.
+
+## Code coordination (2026-09-08)
+
+`Q-14-6`/`Q-14-7` are claimed by PR #661 (bd-jsvetdea, theme-compile
+hard errors) and `Q-14-8` by PR #663 (bd-5fseopxy, weight ranges), both
+open. This work therefore uses **`Q-14-9`** (font file missing),
+**`Q-14-10`** (same-name collision), **`Q-14-11`** (unsupported
+file-entry key). Re-check the catalog at rebase time.
 
 ## Risks
 
@@ -169,3 +178,39 @@ theme CSS and out of scope here.
   hub-client VFS like images do; verify rather than assume before claiming
   preview support.
 - **Concurrent edits** with bd-5fseopxy in `brand_layer.rs:553-584`.
+
+## End-to-end verification (2026-09-08, branch `braid/bd-ve916wr8-brand-file-fonts`)
+
+Output inspected by hand after each invocation; fixture outputs are
+gitignored and were removed afterwards.
+
+```
+cargo run --bin q2 -- render claude-notes/plans/brand-file-fonts-website-investigation/repro
+```
+
+- `find _site -name '*.woff2'` → `_site/site_libs/quarto/fonts/EBGaramond-VariableFont_wght.woff2`
+  (bytes identical to the source, `cmp` clean).
+- `ls _site/site_libs/quarto/ | grep theme` → **one** bundle,
+  `quarto-theme-80c9169f3165fd8b.css`; `index.html` and `posts/one.html`
+  both link it.
+- The bundle's rule:
+
+  ```
+  @font-face{font-family:"EB Garamond";src:url("fonts/EBGaramond-VariableFont_wght.woff2") format("woff2");font-weight:400;font-style:normal}
+  ```
+
+  `fonts/…` resolves from `site_libs/quarto/` to the published file.
+
+```
+cargo run --bin q2 -- render claude-notes/plans/brand-file-fonts-website-investigation/repro-single/doc.qmd
+```
+
+- `doc_files/fonts/EBGaramond-VariableFont_wght.woff2` published;
+  `doc_files/styles.css` carries the same rule; `doc.html` links
+  `doc_files/styles.css`.
+
+Twelve integration tests in
+`crates/quarto-core/tests/integration/brand_fonts.rs` drive the same
+paths (plus reveal, light/dark, collisions, and the three diagnostics)
+through `render_to_file` / `ProjectPipeline`.
+

--- a/claude-notes/plans/2026-09-08-brand-file-fonts-website.md
+++ b/claude-notes/plans/2026-09-08-brand-file-fonts-website.md
@@ -1,0 +1,191 @@
+# `source: file` brand fonts: never copied, `@font-face` URLs resolve against the theme CSS's directory (bd-ve916wr8)
+
+**Date:** 2026-09-08
+**Braid:** bd-ve916wr8
+**Checkout:** main @ `b7e7c96a` (investigation ran in the main checkout; no worktree created)
+**Status:** Investigation — pending design alignment with user. **Do not start implementation until the user gives the go-ahead.**
+
+## Triage verdict
+
+**Ready to design.** Every claim in the strand reproduces at HEAD with a
+two-page fixture, and the investigation found two more defects in the same
+mechanism (single-doc renders are equally broken; the SASS cache key omits
+the font prefix, so pages alias onto whichever compiled first). The fix is
+well-bounded — three consumers, one emitter — but there is one real design
+fork (where the font bytes go and therefore what the URL is) that the user
+should pick.
+
+Evidence: `claude-notes/plans/brand-file-fonts-website-investigation/NOTES.md`.
+
+## Issue context
+
+Filed 2026-09-08 by Carlos, type `bug`, priority 2, labels `css`,
+`theming`, `websites`. Found while moving cscheid-net-2026 from Google
+Fonts to local woff2. Summary of the report:
+
+1. `source: file` font files are never copied into the output.
+2. The emitted `src: url("assets/x.woff2")` is relative to the *document*,
+   but the compiled theme CSS is written to `site_libs/quarto/`, so the
+   browser resolves it against the wrong directory.
+3. The prefix is computed per document (`pathdiff(document_dir,
+   brand_dir)`), so a site with pages at different depths ships N theme
+   bundles.
+4. Minor: no `format("woff2")` hint, no `font-display` for file fonts;
+   `format:` on a files entry is silently ignored.
+
+Workaround in use: a site-root-absolute `/assets/…` path plus an explicit
+`project.resources` glob — correct only when served from the domain root.
+
+## Dependency graph
+
+No `discovered-from`, no incoming `blocks`. Two `related` edges:
+
+- **bd-5fseopxy** (in_progress) — weight ranges `400..700` collapse to
+  400 for google *and* file sources. Touches the same
+  `file_font_face_block` (`font-weight: N M` for variable files). The two
+  strands will conflict textually in `brand_layer.rs:553-584`; whichever
+  lands second rebases. No semantic coupling — the URL/copy work here does
+  not care about the weight value.
+- **bd-qnylgu69** (open) — audit `docs/guides/authoring/brand.qmd` against
+  actual Q2 support. This strand's docs phase should hand it the exact
+  wording for `source: file` (paths are relative to the brand file; files
+  are copied automatically once this lands; until then the `/assets` +
+  `resources:` workaround).
+
+Also relevant, not linked: **bd-r1y48cx0** (open) — `css:` files never
+copied for websites. Same bug class ("theme/CSS side-input is read but
+never published"); the copy mechanism chosen here should be the one that
+strand reuses. And the path-resolution contract
+(`claude-notes/designs/path-resolution-model.md`) lists `brand:` as
+"project-root by construction" — font paths *inside* the brand file are a
+consumer that inventory does not yet mention; add a row.
+
+## What the code looks like today
+
+All file paths in the strand still exist with the described shape
+(spot-checked; line numbers in NOTES.md). Reproduced at HEAD:
+
+| Case | Theme CSS location | Emitted `src` | File copied? |
+|---|---|---|---|
+| website, `index.qmd` | `_site/site_libs/quarto/quarto-theme-<fp>.css` | `assets/…` | no |
+| website, `posts/one.qmd` (cold cache) | second bundle, different `<fp>` | `../assets/…` | no |
+| website, warm cache | one bundle, prefix of whichever page compiled *first* (persistent across sessions) | order-dependent | no |
+| single doc `doc.qmd` | `doc_files/styles.css` | `assets/…` → resolves to `doc_files/assets/…` | no |
+
+Two corrections to the strand text:
+
+- **Single-doc is broken too.** `styles.css` is not "next to the document";
+  it is in `{stem}_files/` (`resource_resolver.rs:113-124`), so the
+  document-relative prefix is wrong there as well.
+- **The N-bundle split only happens on a cold cache.** With the persistent
+  SASS cache warm, `cache_key()` (`compile_theme_css.rs:197`) — which
+  hashes the brand YAML but not `document_dir` — makes every page reuse the
+  first page's bundle, wrong prefix included. Either way the output is
+  wrong; the cache-key omission is a separate correctness bug worth its own
+  regression test.
+
+Q1 parity: Q1 uses the identical document-relative prefix and does **not**
+copy font files for HTML (only for typst). It works in Q1 only because Q1's
+theme CSS sits beside the page. The `site_libs`/`{stem}_files` relocation
+is the Q2 change that exposed both gaps.
+
+## Proposed phases (draft)
+
+Skeleton only — contents depend on the design answers below.
+
+- **Phase 0 — Test plan (TDD).**
+  - `quarto-sass` unit: `file_font_face_block` emits the chosen URL shape
+    (and `format("woff2")` if in scope); `/`-rooted path handling per Q3.
+  - `quarto-core` integration (drive `render_document_to_file` /
+    project render, not `brand_to_layers` directly): (a) website with pages
+    at two depths → exactly one theme bundle, both pages link it, the
+    `@font-face` URL resolves from the bundle's directory to a file that
+    exists in the output; (b) single-doc → same property against
+    `{stem}_files/styles.css`; (c) cache-aliasing regression — render
+    nested page first, then root page, assert the root page's URL is
+    correct; (d) missing font file → warning naming the brand file key.
+  - Fixture: promote `brand-file-fonts-website-investigation/repro` into
+    the test tree.
+- **Phase 1 — Font URL base.** Compute the `@font-face` URL relative to
+  the theme artifact's location (or make it constant — see Q1). Remove
+  `document_dir` from the prefix computation so the fingerprint is
+  site-wide; add whatever *does* feed the URL to `cache_key()`.
+- **Phase 2 — Publish the font bytes.** Per Q1: either emit fonts as
+  project-scope artifacts next to the theme CSS, or register them as
+  implicit resources / a post-render copy hook. Must cover single-doc and
+  website; note WASM preview implications.
+- **Phase 3 — Small emitter fixes (if in scope, Q4).** `format()` from the
+  extension; reject unknown keys on file entries (`format:`/`display:`)
+  instead of dropping them; optionally accept a display hint.
+- **Phase 4 — Docs + contract.** `docs/guides/authoring/brand.qmd`
+  (`source: file` semantics, coordinate with bd-qnylgu69); add the
+  brand-font row to `path-resolution-model.md`'s inventory; end-to-end
+  verification via `cargo run --bin q2 -- render` on the fixture, output
+  inspected.
+
+## Open design questions for the user
+
+1. **Where do the font bytes live, and hence what is the URL?** Two shapes:
+   - **(a) Fonts become project-scope artifacts beside the theme CSS**
+     (`site_libs/quarto/fonts/<name>` / `doc_files/fonts/<name>`), and the
+     `@font-face` URL is the constant `fonts/<name>`. Pros: one mechanism
+     for website, single-doc, *and* the WASM preview (artifacts flush
+     through both transports; the native-only `copy_*` hooks do not);
+     the prefix is constant so the cache-key and per-depth problems vanish
+     structurally; no dependence on how the site is hosted. Cons: font
+     bytes pass through the in-memory artifact store; `_site/assets/`
+     no longer mirrors the source tree for fonts (a user's `/assets/…`
+     workaround keeps working but becomes redundant).
+   - **(b) Copy fonts to their source-mirrored output path** (like logos:
+     `_site/assets/x.woff2`) and emit a URL relative to the theme CSS
+     (`../../assets/x.woff2` from `site_libs/quarto/`; `../assets/…` from
+     `doc_files/`). Keeps the output tree familiar; needs the copy to run in
+     both single-doc and project paths and stays native-only.
+   My recommendation is (a). Do you agree, or do you want the output tree
+   to mirror the source layout?
+2. **Copy channel (only if 1b).** Post-render hook like `copy_navbar_logo`
+   (needs a single-doc twin), or the resource channel
+   (`ResolvedResource` with a brand-file origin, so the render manifest
+   lists the fonts for `quarto publish`)? I'd take the resource channel,
+   and bd-r1y48cx0 (`css:` copy) would reuse it.
+3. **Leading `/` in a font path.** Today `/assets/x` accidentally survives
+   as a site-root URL (`PathBuf::push` drops the prefix). The path contract
+   says a leading `/` means *project root* for resolution. Should the fix
+   (i) resolve `/assets/x` against the project root for the *copy* and
+   emit the normal relative/constant URL like any other path, or (ii)
+   keep `/…` as an explicit "emit verbatim, you host it" escape hatch?
+   (i) is contract-conformant and what I'd do; it changes the workaround's
+   emitted URL from `/assets/…` to the new form, which is still correct.
+4. **Scope of the emitter niceties.** In scope here or a follow-up strand:
+   `format("woff2")` from the extension (cheap, clearly good);
+   `deny_unknown_fields` on the explicit file entry so `format:`/`display:`
+   error instead of vanishing (the brand.yml spec has no `display` for
+   file fonts — accepting one would be a Q2 extension); a `display:` /
+   `font-display` hint for file fonts (spec extension — I'd file it
+   separately).
+5. **Interaction with bd-5fseopxy.** Both edit `file_font_face_block`.
+   Sequence this after it lands, or land this first and let the weight
+   work rebase? (Pure ordering question; either is fine.)
+
+## Risks / tradeoffs (draft)
+
+- **Artifact-store size (1a).** Variable fonts are ~100–500 KB each; a
+  brand with several files puts a few MB through the artifact map per
+  render. Should be fine (images already go this route) but worth one
+  measurement on a real brand.
+- **Fingerprint stability.** Whatever feeds the URL must feed both
+  `theme_fingerprint` (already content-based, fine) and `cache_key()`
+  (currently incomplete). If (1a), the URL is constant and the cache key
+  is correct by construction; if (1b), the key must include the
+  artifact-relative prefix.
+- **Dark brand with different fonts** — the dark bundle's `@font-face`
+  blocks reference the dark brand's files; under (1a) both variants' fonts
+  land in the same `fonts/` dir, so filename collisions across brands
+  need a content-hash or brand-scoped name.
+- **Hub-client preview** — under (1b) fonts would not appear in the WASM
+  preview at all (the copy hooks are native-only); under (1a) they should,
+  but the preview transport's handling of binary project-scope artifacts
+  needs a check before claiming it.
+- **Test environment** — pre-flight's hub-client vitest leg is red on a
+  clean `main` (`localStorage` undefined, Node v26.8.1); Rust legs green.
+  Unrelated but will show up in any full `cargo xtask verify`.

--- a/claude-notes/plans/brand-file-fonts-website-investigation/NOTES.md
+++ b/claude-notes/plans/brand-file-fonts-website-investigation/NOTES.md
@@ -1,0 +1,116 @@
+# Investigation notes — bd-ve916wr8
+
+**Date:** 2026-09-08, main @ `b7e7c96a` (investigation ran in the main checkout; no worktree created).
+
+Fixtures (committed, outputs gitignored):
+
+- `repro/` — website project, `brand: _brand.yml`, `theme: [brand]`, one
+  `source: file` font at `assets/EBGaramond-VariableFont_wght.woff2`
+  (placeholder bytes — the copy/URL defects don't need a real font),
+  pages `index.qmd` and `posts/one.qmd`.
+- `repro-single/` — the same brand + font, single document `doc.qmd`
+  with `brand: _brand.yml` in front matter.
+
+## Repro confirmation at HEAD
+
+### Website
+
+```
+cargo run --bin q2 -- render claude-notes/plans/brand-file-fonts-website-investigation/repro
+find repro/_site -name '*.woff2'          # → (empty)
+```
+
+Observed (inspected by hand):
+
+- **Defect 1 (never copied):** no `.woff2` anywhere under `_site/`.
+- **Defect 2 (wrong base):** the one theme file,
+  `_site/site_libs/quarto/quarto-theme-15564923cb73fc48.css`, contains
+
+  ```
+  @font-face{font-family:"EB Garamond";src:url("assets/EBGaramond-VariableFont_wght.woff2");font-weight:400;font-style:normal}
+  ```
+
+  A browser resolves that against the CSS file's directory →
+  `_site/site_libs/quarto/assets/…` — wrong even if the file had been
+  copied to `_site/assets/`.
+
+- **Defect 3 (per-document prefix)**, refined — see "cache aliasing" below.
+  On a *cold* SASS cache each page compiles with
+  `pathdiff(document_dir, brand_dir)` (`quarto-sass/src/themes.rs:781`),
+  which is `""` for `index.qmd` and `..` for `posts/one.qmd`, so the two
+  pages produce two different theme bundles (the strand's original
+  observation). On a *warm* cache they alias instead (below).
+
+### Single document
+
+```
+cargo run --bin q2 -- render claude-notes/plans/brand-file-fonts-website-investigation/repro-single/doc.qmd
+```
+
+- `doc.html` links `href="doc_files/styles.css"`; that file contains the
+  same `src:url("assets/EBGaramond-VariableFont_wght.woff2")`, which
+  resolves to `doc_files/assets/…` → **404**. The font file is not copied
+  into `doc_files/` either.
+- So the strand's "the document dir for single-doc `styles.css`" is
+  inaccurate: single-doc theme CSS is *also* relocated (into
+  `{stem}_files/`, `resource_resolver.rs:113-124`), and `source: file`
+  fonts are broken for `q2 render doc.qmd` as well, not only websites.
+
+### Cache aliasing (new finding, not in the strand)
+
+`cache_key()` in `compile_theme_css.rs:197` hashes the brand YAML but
+**not** the font URL prefix derived from `document_dir`. The SASS cache
+is persistent across sessions (`cache_get_lru` on the runtime). So the
+first document to compile a given brand pins the `@font-face` URL for
+every later document — in this render and every future render — until
+the brand YAML changes.
+
+Demonstrated by bypassing the cache (temporarily `weight: 400 → 500`),
+rendering the nested page alone, then the whole site:
+
+```
+q2 render repro/posts/one.qmd   # cold key → compiles with prefix ".."
+q2 render repro                 # index.qmd hits the cache
+```
+
+Result: **one** theme bundle `quarto-theme-3a2db3789e5edced.css` linked
+by both `index.html` and `posts/one.html`, with
+`src:url("../assets/EBGaramond-VariableFont_wght.woff2")` — i.e. the
+root page now carries the nested page's prefix. (Reverted the fixture to
+`weight: 400` afterwards.) Whichever prefix wins, both are wrong because
+the CSS lives in `site_libs/quarto/` — but the point is the key is
+incomplete: two compiles with different correct outputs share one entry.
+
+## Related code (spot-checked, still as described)
+
+- `crates/quarto-sass/src/brand_layer.rs:553` `file_font_face_block` —
+  emits `src: url('…')` with no `format()` hint; `join_url_path` (`:592`)
+  is `PathBuf::push`, so a leading `/` discards the prefix (this is why
+  the strand's `/assets/…` workaround yields a stable, site-root URL).
+- `crates/quarto-sass/src/themes.rs:777-783` — prefix =
+  `pathdiff_from_to(context.document_dir(), brand_dir)`.
+- `crates/quarto-core/src/stage/stages/compile_theme_css.rs:482-522` —
+  `document_dir = doc.path.parent()`; `:823-846` — artifact path is
+  `styles.css` (single-doc, lands in `{stem}_files/`) or
+  `quarto/quarto-theme-<fp>.css` (project, lands in `site_libs/`).
+- `crates/quarto-brand/src/types.rs:593-604` — `BrandFontFileEntry` is
+  `#[serde(untagged)]` with no `deny_unknown_fields` on the `Explicit`
+  variant, so `format:`/`display:` on a file entry are silently dropped.
+- Asset copy precedents: `project/website_post_render.rs:128`
+  `copy_navbar_logo` (+ `copy_favicon`, `copy_footer_images`), all native-only
+  post-render hooks keyed off `_quarto.yml`; resource channel
+  `project_resources.rs:814` `resolve_reported_resources` with
+  `ResourceOrigin::ProjectMetadata` (resolved against the project root).
+- Q1: `external-sources/quarto-cli/src/core/sass/brand.ts:155-175` uses
+  the same `relative(projectDir, brandDir)` prefix; its HTML path does not
+  copy font files either (`command/render/pandoc.ts:1536` collects font
+  dirs for **typst only**). Q1 got away with it because its theme CSS is
+  inlined/adjacent to the page.
+
+## Pre-flight
+
+`cargo xtask verify --skip-hub-build` at `b7e7c96a`: Rust build + nextest
+green; the hub-client `test:ci` leg failed with 23 tests all raising
+`TypeError: Cannot read properties of undefined (reading 'clear')` on
+`localStorage.clear()` — a local vitest/jsdom environment problem on a
+clean `main` (Node v26.8.1), unrelated to this Rust-only strand.

--- a/claude-notes/plans/brand-file-fonts-website-investigation/repro-single/.gitignore
+++ b/claude-notes/plans/brand-file-fonts-website-investigation/repro-single/.gitignore
@@ -1,0 +1,4 @@
+_site/
+.quarto/
+*_files/
+*.html

--- a/claude-notes/plans/brand-file-fonts-website-investigation/repro-single/_brand.yml
+++ b/claude-notes/plans/brand-file-fonts-website-investigation/repro-single/_brand.yml
@@ -1,0 +1,9 @@
+typography:
+  fonts:
+    - family: EB Garamond
+      source: file
+      files:
+        - path: assets/EBGaramond-VariableFont_wght.woff2
+          weight: 400
+          style: normal
+  base: EB Garamond

--- a/claude-notes/plans/brand-file-fonts-website-investigation/repro-single/assets/EBGaramond-VariableFont_wght.woff2
+++ b/claude-notes/plans/brand-file-fonts-website-investigation/repro-single/assets/EBGaramond-VariableFont_wght.woff2
@@ -1,0 +1,1 @@
+wOF2placeholder

--- a/claude-notes/plans/brand-file-fonts-website-investigation/repro-single/doc.qmd
+++ b/claude-notes/plans/brand-file-fonts-website-investigation/repro-single/doc.qmd
@@ -1,0 +1,9 @@
+---
+title: Single
+brand: _brand.yml
+format:
+  html:
+    theme: [brand]
+---
+
+Hello.

--- a/claude-notes/plans/brand-file-fonts-website-investigation/repro/.gitignore
+++ b/claude-notes/plans/brand-file-fonts-website-investigation/repro/.gitignore
@@ -1,0 +1,4 @@
+_site/
+.quarto/
+*_files/
+*.html

--- a/claude-notes/plans/brand-file-fonts-website-investigation/repro/_brand.yml
+++ b/claude-notes/plans/brand-file-fonts-website-investigation/repro/_brand.yml
@@ -1,0 +1,9 @@
+typography:
+  fonts:
+    - family: EB Garamond
+      source: file
+      files:
+        - path: assets/EBGaramond-VariableFont_wght.woff2
+          weight: 400
+          style: normal
+  base: EB Garamond

--- a/claude-notes/plans/brand-file-fonts-website-investigation/repro/_quarto.yml
+++ b/claude-notes/plans/brand-file-fonts-website-investigation/repro/_quarto.yml
@@ -1,0 +1,6 @@
+project:
+  type: website
+brand: _brand.yml
+format:
+  html:
+    theme: [brand]

--- a/claude-notes/plans/brand-file-fonts-website-investigation/repro/assets/EBGaramond-VariableFont_wght.woff2
+++ b/claude-notes/plans/brand-file-fonts-website-investigation/repro/assets/EBGaramond-VariableFont_wght.woff2
@@ -1,0 +1,1 @@
+wOF2placeholder

--- a/claude-notes/plans/brand-file-fonts-website-investigation/repro/index.qmd
+++ b/claude-notes/plans/brand-file-fonts-website-investigation/repro/index.qmd
@@ -1,0 +1,5 @@
+---
+title: Home
+---
+
+Hello.

--- a/claude-notes/plans/brand-file-fonts-website-investigation/repro/posts/one.qmd
+++ b/claude-notes/plans/brand-file-fonts-website-investigation/repro/posts/one.qmd
@@ -1,0 +1,5 @@
+---
+title: One
+---
+
+Post.

--- a/crates/quarto-brand/Cargo.toml
+++ b/crates/quarto-brand/Cargo.toml
@@ -9,6 +9,7 @@ description = "Parse and resolve `_brand.yml` brand configuration for Quarto"
 
 [dependencies]
 quarto-util = { workspace = true }
+hashlink = { version = "0.11.0", features = ["serde_impl"] }
 pathdiff = { workspace = true }
 serde = { workspace = true }
 serde_yaml = { workspace = true }

--- a/crates/quarto-brand/src/lib.rs
+++ b/crates/quarto-brand/src/lib.rs
@@ -22,10 +22,10 @@ pub use resolved::ResolvedBrand;
 pub use split::SplitBrand;
 pub use types::{
     Brand, BrandColor, BrandColorLightDark, BrandColorValue, BrandDefaults, BrandFont,
-    BrandFontFile, BrandFontFileEntry, BrandFontGoogle, BrandFontStyle, BrandFontSystem,
-    BrandFontWeight, BrandFontWeightAtom, BrandFontWeightRange, BrandLogo, BrandLogoExplicit,
-    BrandLogoResource, BrandMeta, BrandMetaLink, BrandMetaName, BrandRef, BrandTypography,
-    BrandTypographyOptions, LogoEntry, UnifiedBrand,
+    BrandFontFile, BrandFontFileEntry, BrandFontFileExplicit, BrandFontGoogle, BrandFontStyle,
+    BrandFontSystem, BrandFontWeight, BrandFontWeightAtom, BrandFontWeightRange, BrandLogo,
+    BrandLogoExplicit, BrandLogoResource, BrandMeta, BrandMetaLink, BrandMetaName, BrandRef,
+    BrandTypography, BrandTypographyOptions, LogoEntry, UnifiedBrand, published_font_name,
 };
 pub use validate::{BrandPath, BrandPathSegment, weight_name_to_number};
 

--- a/crates/quarto-brand/src/resolved.rs
+++ b/crates/quarto-brand/src/resolved.rs
@@ -43,12 +43,34 @@ pub struct ResolvedBrand {
     pub brand: Brand,
     /// Directory the brand file was read from; `None` for inline blocks.
     pub dir: Option<PathBuf>,
+    /// The brand file itself, when the brand came from one; `None` for
+    /// inline blocks. Diagnostics about the brand's *contents* (a font
+    /// file that does not exist, say) name this file so the user knows
+    /// where to look.
+    pub file: Option<PathBuf>,
 }
 
 impl ResolvedBrand {
     /// Construct from a brand and the directory it was read from.
     pub fn new(brand: Brand, dir: Option<PathBuf>) -> Self {
-        Self { brand, dir }
+        Self {
+            brand,
+            dir,
+            file: None,
+        }
+    }
+
+    /// Construct from a brand and the file it was read from; `dir` is
+    /// that file's directory.
+    pub fn from_file(brand: Brand, file: PathBuf) -> Self {
+        let dir = file
+            .parent()
+            .map_or_else(|| PathBuf::from("."), Path::to_path_buf);
+        Self {
+            brand,
+            dir: Some(dir),
+            file: Some(file),
+        }
     }
 
     /// The prefix that turns a path written inside this brand into one

--- a/crates/quarto-brand/src/types.rs
+++ b/crates/quarto-brand/src/types.rs
@@ -16,6 +16,7 @@
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
+use hashlink::LinkedHashMap;
 use serde::{Deserialize, Serialize};
 
 /// A reference to a brand configuration in document or project metadata.
@@ -594,21 +595,86 @@ pub enum BrandFontFileEntry {
     /// A bare path string.
     Path(String),
     /// A typed file descriptor with optional weight/style.
-    Explicit {
-        path: String,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        weight: Option<BrandFontWeight>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        style: Option<BrandFontStyle>,
-    },
+    Explicit(BrandFontFileExplicit),
+}
+
+/// The map form of a `source: file` font file entry.
+///
+/// Deliberately **not** `deny_unknown_fields`: the brand.yml spec has
+/// not settled per-file keys such as `format:` and `display:`, so a
+/// brand that uses them must still parse. They are captured in
+/// [`Self::unknown`] so the consumer can warn that they are ignored
+/// (bd-ve916wr8, decision 5) instead of either rejecting the brand or
+/// dropping the keys silently.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct BrandFontFileExplicit {
+    pub path: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub weight: Option<BrandFontWeight>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub style: Option<BrandFontStyle>,
+    /// Keys this entry carried that Quarto does not understand, in
+    /// authored order. Ignored by every consumer; surfaced as a
+    /// warning by the theme stage.
+    #[serde(flatten, skip_serializing_if = "LinkedHashMap::is_empty")]
+    pub unknown: LinkedHashMap<String, serde_yaml::Value>,
 }
 
 impl BrandFontFileEntry {
     pub fn path(&self) -> &str {
         match self {
             BrandFontFileEntry::Path(p) => p,
-            BrandFontFileEntry::Explicit { path, .. } => path,
+            BrandFontFileEntry::Explicit(e) => &e.path,
         }
+    }
+
+    /// The `weight:` of the map form (`None` for a bare path).
+    pub fn weight(&self) -> Option<&BrandFontWeight> {
+        match self {
+            BrandFontFileEntry::Path(_) => None,
+            BrandFontFileEntry::Explicit(e) => e.weight.as_ref(),
+        }
+    }
+
+    /// The `style:` of the map form (`None` for a bare path).
+    pub fn style(&self) -> Option<&BrandFontStyle> {
+        match self {
+            BrandFontFileEntry::Path(_) => None,
+            BrandFontFileEntry::Explicit(e) => e.style.as_ref(),
+        }
+    }
+
+    /// Keys on this entry that Quarto does not understand, in
+    /// authored order (empty for a bare path).
+    pub fn unknown_keys(&self) -> Vec<&str> {
+        match self {
+            BrandFontFileEntry::Path(_) => Vec::new(),
+            BrandFontFileEntry::Explicit(e) => e.unknown.keys().map(String::as_str).collect(),
+        }
+    }
+}
+
+/// The name under which a local `source: file` font is published.
+///
+/// Local font files are copied into a `fonts/` directory beside the
+/// theme CSS that references them, and the `@font-face` URL is the
+/// constant `fonts/<name>` — so `<name>` is the file's basename,
+/// whatever directory the brand authored it in (brand-relative,
+/// `/`-rooted at the project, or a `../` climb). External URLs are
+/// served by whoever hosts them and have no published name.
+///
+/// Returns `None` for an external URL or a path with no basename.
+/// Both `/` and `\` count as separators so a brand authored on
+/// Windows publishes the same name.
+pub fn published_font_name(path: &str) -> Option<String> {
+    if quarto_util::is_external_url(path) {
+        return None;
+    }
+    let name = path.rsplit(['/', '\\']).next().unwrap_or("");
+    if name.is_empty() {
+        None
+    } else {
+        Some(name.to_string())
     }
 }
 

--- a/crates/quarto-brand/src/validate.rs
+++ b/crates/quarto-brand/src/validate.rs
@@ -17,10 +17,7 @@
 use std::fmt;
 
 use crate::BrandError;
-use crate::types::{
-    Brand, BrandFont, BrandFontFileEntry, BrandFontWeight, BrandFontWeightAtom,
-    BrandFontWeightRange,
-};
+use crate::types::{Brand, BrandFont, BrandFontWeight, BrandFontWeightAtom, BrandFontWeightRange};
 
 /// Lowest and highest weight accepted anywhere in a brand, per the
 /// brand.yml specification (CSS itself allows 1–1000, but no brand
@@ -140,10 +137,7 @@ impl<V> Brand<V> {
                 BrandFont::File(f) => {
                     let files = font_path.key("files");
                     for (j, entry) in f.files.iter().enumerate() {
-                        if let BrandFontFileEntry::Explicit {
-                            weight: Some(w), ..
-                        } = entry
-                        {
+                        if let Some(w) = entry.weight() {
                             validate_weight(w, &files.index(j).key("weight"), RangeAllowed::Yes)?;
                         }
                     }

--- a/crates/quarto-brand/tests/integration/font_files_test.rs
+++ b/crates/quarto-brand/tests/integration/font_files_test.rs
@@ -1,0 +1,100 @@
+//! Tests for `source: file` font entries (bd-ve916wr8): the published
+//! name a local font file gets in the output, and tolerance of keys
+//! the brand.yml spec has not settled (`format:`, `display:`).
+
+use quarto_brand::{Brand, BrandFont, BrandFontFileEntry, published_font_name};
+
+fn brand(yaml: &str) -> Brand {
+    quarto_brand::UnifiedBrand::from_yaml_str(yaml)
+        .expect("parse")
+        .split()
+        .light
+}
+
+fn file_entries(b: &Brand) -> &[BrandFontFileEntry] {
+    match b.fonts().first().expect("one font") {
+        BrandFont::File(f) => &f.files,
+        other => panic!("expected a file font, got {other:?}"),
+    }
+}
+
+/// Local font files are published beside the theme CSS as
+/// `fonts/<basename>`, whatever directory they were authored in — a
+/// brand-relative path, a `/`-rooted (project-root) path, or a `../`
+/// climb all collapse to the basename.
+#[test]
+fn published_font_name_is_the_basename_of_any_local_path() {
+    assert_eq!(
+        published_font_name("assets/sub/Regular.woff2").as_deref(),
+        Some("Regular.woff2")
+    );
+    assert_eq!(
+        published_font_name("/assets/Rooted.woff").as_deref(),
+        Some("Rooted.woff")
+    );
+    assert_eq!(
+        published_font_name("../shared/Parent.ttf").as_deref(),
+        Some("Parent.ttf")
+    );
+    assert_eq!(published_font_name("Bare.otf").as_deref(), Some("Bare.otf"));
+    // Backslash-separated paths (authored on Windows) publish the
+    // same way.
+    assert_eq!(
+        published_font_name("assets\\Win.woff2").as_deref(),
+        Some("Win.woff2")
+    );
+}
+
+/// External URLs are served by whoever hosts them: nothing to publish.
+#[test]
+fn published_font_name_is_none_for_external_urls() {
+    assert_eq!(
+        published_font_name("https://fonts.example.com/dir/Remote.woff2"),
+        None
+    );
+    assert_eq!(published_font_name("//cdn.example.com/Remote.woff2"), None);
+}
+
+/// `format:` / `display:` on a file entry are not part of the settled
+/// brand.yml spec. They must not fail the parse (decision 5: warn and
+/// ignore), and the entry must expose them so the consumer can warn.
+#[test]
+fn explicit_file_entry_tolerates_unknown_keys_and_reports_them() {
+    let b = brand(
+        "typography:\n\
+         \x20 fonts:\n\
+         \x20   - source: file\n\
+         \x20     family: F\n\
+         \x20     files:\n\
+         \x20       - path: Regular.woff2\n\
+         \x20         weight: 400\n\
+         \x20         format: woff2\n\
+         \x20         display: swap\n",
+    );
+    let entries = file_entries(&b);
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].path(), "Regular.woff2");
+    assert_eq!(
+        entries[0].unknown_keys(),
+        vec!["format", "display"],
+        "unknown keys, in authored order"
+    );
+}
+
+#[test]
+fn file_entries_without_unknown_keys_report_none() {
+    let b = brand(
+        "typography:\n\
+         \x20 fonts:\n\
+         \x20   - source: file\n\
+         \x20     family: F\n\
+         \x20     files:\n\
+         \x20       - Bare.woff2\n\
+         \x20       - path: Explicit.woff2\n\
+         \x20         style: italic\n",
+    );
+    let entries = file_entries(&b);
+    assert_eq!(entries.len(), 2);
+    assert!(entries[0].unknown_keys().is_empty());
+    assert!(entries[1].unknown_keys().is_empty());
+}

--- a/crates/quarto-brand/tests/integration/main.rs
+++ b/crates/quarto-brand/tests/integration/main.rs
@@ -2,6 +2,7 @@
 //! See bd-xvdop / claude-notes/plans/2026-05-28-integration-test-consolidation.md.
 
 pub mod color_test;
+pub mod font_files_test;
 pub mod font_weight_test;
 pub mod light_dark_test;
 pub mod logo_test;

--- a/crates/quarto-core/src/artifact.rs
+++ b/crates/quarto-core/src/artifact.rs
@@ -395,10 +395,18 @@ impl ArtifactStore {
                     if existing.content == incoming.content {
                         stats.deduped += 1;
                     } else {
+                        let source_of = |a: &Artifact| {
+                            a.metadata
+                                .get("source")
+                                .and_then(serde_json::Value::as_str)
+                                .map(str::to_string)
+                        };
                         return Err(ArtifactMergeConflict {
                             key,
                             existing_len: existing.content.len(),
                             incoming_len: incoming.content.len(),
+                            existing_source: source_of(existing),
+                            incoming_source: source_of(&incoming),
                         });
                     }
                 }
@@ -437,6 +445,11 @@ pub struct ArtifactMergeConflict {
     /// Length in bytes of the new entry that triggered the
     /// conflict.
     pub incoming_len: usize,
+    /// Where the existing entry's bytes came from, when its producer
+    /// recorded a `source` metadata entry (published brand fonts do).
+    pub existing_source: Option<String>,
+    /// Where the incoming entry's bytes came from, likewise.
+    pub incoming_source: Option<String>,
 }
 
 impl std::fmt::Display for ArtifactMergeConflict {
@@ -445,7 +458,11 @@ impl std::fmt::Display for ArtifactMergeConflict {
             f,
             "artifact key '{}' has conflicting content (existing: {} bytes, incoming: {} bytes)",
             self.key, self.existing_len, self.incoming_len
-        )
+        )?;
+        if let (Some(existing), Some(incoming)) = (&self.existing_source, &self.incoming_source) {
+            write!(f, " — existing from {existing}, incoming from {incoming}")?;
+        }
+        Ok(())
     }
 }
 

--- a/crates/quarto-core/src/artifact_flush.rs
+++ b/crates/quarto-core/src/artifact_flush.rs
@@ -200,19 +200,37 @@ pub(crate) fn route_drained_project_artifacts(
 ) -> Result<()> {
     match (accumulator, has_shared_lib) {
         (Some(dest), true) => {
-            dest.merge_into_project(drained).map_err(|e| {
-                QuartoError::other(format!(
-                    "Project-scoped artifact merge failed for {}: {}",
-                    input.display(),
-                    e
-                ))
-            })?;
+            dest.merge_into_project(drained)
+                .map_err(|e| merge_conflict_to_error(input, &e))?;
         }
         _ => {
             enqueue_artifacts(&drained, resolver, ArtifactScope::Project, sink)?;
         }
     }
     Ok(())
+}
+
+/// The error a project-scope artifact merge conflict for `input`
+/// surfaces as.
+///
+/// Two documents' brands publishing different bytes under one font
+/// name is a user-facing configuration error with its own catalog
+/// code (`Q-14-10`, bd-ve916wr8); every other conflict is the generic
+/// internal error. Shared by the serial tail
+/// ([`route_drained_project_artifacts`]) and the parallel Pass-2
+/// reducer so both report a clash the same way.
+pub(crate) fn merge_conflict_to_error(
+    input: &Path,
+    conflict: &crate::artifact::ArtifactMergeConflict,
+) -> QuartoError {
+    match crate::brand_fonts::merge_conflict_error(conflict) {
+        Some(pe) => QuartoError::Parse(pe),
+        None => QuartoError::other(format!(
+            "Project-scoped artifact merge failed for {}: {}",
+            input.display(),
+            conflict
+        )),
+    }
 }
 
 /// Flush every path-bearing, non-empty artifact in `artifacts` into

--- a/crates/quarto-core/src/brand_fonts.rs
+++ b/crates/quarto-core/src/brand_fonts.rs
@@ -1,0 +1,404 @@
+/*
+ * brand_fonts.rs
+ * Copyright (c) 2026 Posit, PBC
+ *
+ * Publish `source: file` brand fonts beside the theme CSS.
+ */
+
+//! Publish `source: file` brand fonts as project-scope artifacts
+//! beside the theme CSS that references them (bd-ve916wr8).
+//!
+//! The SCSS side emits `src: url('fonts/<name>')` for every local font
+//! file a brand declares ([`quarto_sass::brand_to_layers`]). This
+//! module is the other half of that contract: it reads the bytes from
+//! the brand's directory and stores them as artifacts at
+//! `<theme css dir>/fonts/<name>`, so the URL resolves from the CSS's
+//! own directory wherever that CSS is flushed — `site_libs/quarto/`
+//! for a website, `{stem}_files/` for a single document,
+//! `…/revealjs/` for a deck — and on both the native output sink and
+//! the preview VFS. Nothing here depends on the *document*, which is
+//! what lets one compiled theme serve every page of a site.
+//!
+//! Naming is by basename (plan decision 1). Two different files that
+//! would publish under one name are a hard error, never a silent
+//! overwrite (decision 2): within one document the check is
+//! [`publish_brand_fonts`]'s; across documents
+//! [`ArtifactStore::merge_into_project`] reports the clash and
+//! [`merge_conflict_error`] turns it into the same `Q-14-10`
+//! diagnostic. A leading `/` on a declared path means the project
+//! root (decision 3, the path-resolution contract), and keys the
+//! brand.yml spec has not settled (`format:`, `display:`) warn and
+//! are ignored (decision 5).
+//!
+//! Plan: `claude-notes/plans/2026-09-08-brand-file-fonts-website.md`.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use quarto_brand::{BrandFont, ResolvedBrand, published_font_name};
+use quarto_error_reporting::{DiagnosticMessage, DiagnosticMessageBuilder};
+use quarto_source_map::SourceContext;
+use quarto_system_runtime::{PathKind, SystemRuntime};
+
+use crate::artifact::{Artifact, ArtifactMergeConflict, ArtifactScope, ArtifactStore};
+use crate::error::ParseError;
+
+/// Key prefix of every published font artifact
+/// (`font:<theme css dir>/fonts/<name>`). Distinct from the `css:` /
+/// `js:` prefixes so the template never emits a `<link>` for a font.
+pub const FONT_ARTIFACT_KEY_PREFIX: &str = "font:";
+
+/// Artifact metadata key holding the project-relative source path
+/// of a published font — what a collision diagnostic names.
+pub const FONT_SOURCE_METADATA_KEY: &str = "source";
+
+/// Read every `source: file` font declared by `brands` and store each
+/// as a project-scope artifact under `<theme_css_dir>/fonts/`.
+///
+/// `theme_css_dir` is the directory (relative to the lib dir) the
+/// compiled theme CSS is published in: `""` for a single document's
+/// `styles.css`, `"quarto"` for a website's `quarto/quarto-theme-*.css`,
+/// `"revealjs"` for a deck. Light and dark brands that share a file
+/// are walked once.
+///
+/// Returns the warnings raised along the way (`Q-14-9` missing file,
+/// `Q-14-11` unsupported key); the render continues past those. A
+/// same-name / different-bytes collision is the one hard failure
+/// (`Q-14-10`).
+pub fn publish_brand_fonts(
+    artifacts: &mut ArtifactStore,
+    runtime: &dyn SystemRuntime,
+    project_dir: &Path,
+    brands: &[&ResolvedBrand],
+    theme_css_dir: &str,
+) -> Result<Vec<DiagnosticMessage>, ParseError> {
+    let mut warnings = Vec::new();
+    // Lookup-only: dedupes the (brand file, declared path) pairs a
+    // light/dark pair sharing one `_brand.yml` would otherwise walk
+    // twice — never iterated, so ordering does not matter.
+    let mut seen: HashSet<(String, String)> = HashSet::new();
+
+    for brand in brands {
+        let brand_label = brand_label(brand, project_dir);
+        let brand_dir = brand
+            .dir
+            .clone()
+            .unwrap_or_else(|| project_dir.to_path_buf());
+
+        for font in brand.brand.fonts() {
+            let BrandFont::File(file_font) = font else {
+                continue;
+            };
+            for entry in &file_font.files {
+                let declared = entry.path();
+                if !seen.insert((brand_label.clone(), declared.to_string())) {
+                    continue;
+                }
+
+                let unknown = entry.unknown_keys();
+                if !unknown.is_empty() {
+                    warnings.push(unsupported_keys_diagnostic(
+                        &brand_label,
+                        &file_font.family,
+                        declared,
+                        &unknown,
+                    ));
+                }
+
+                // External URLs are served by whoever hosts them.
+                let Some(name) = published_font_name(declared) else {
+                    if !quarto_util::is_external_url(declared) {
+                        warnings.push(missing_file_diagnostic(
+                            &brand_label,
+                            &file_font.family,
+                            declared,
+                            &resolve_source(project_dir, &brand_dir, declared),
+                            None,
+                        ));
+                    }
+                    continue;
+                };
+
+                let source = resolve_source(project_dir, &brand_dir, declared);
+                let exists = runtime
+                    .path_exists(&source, Some(PathKind::File))
+                    .unwrap_or(false);
+                if !exists {
+                    warnings.push(missing_file_diagnostic(
+                        &brand_label,
+                        &file_font.family,
+                        declared,
+                        &source,
+                        None,
+                    ));
+                    continue;
+                }
+                let bytes = match runtime.file_read(&source) {
+                    Ok(bytes) => bytes,
+                    Err(e) => {
+                        warnings.push(missing_file_diagnostic(
+                            &brand_label,
+                            &file_font.family,
+                            declared,
+                            &source,
+                            Some(&e.to_string()),
+                        ));
+                        continue;
+                    }
+                };
+
+                let source_label = display_relative(&source, project_dir);
+                let artifact_path = font_artifact_path(theme_css_dir, &name);
+                let key = format!("{FONT_ARTIFACT_KEY_PREFIX}{artifact_path}");
+                if let Some(existing) = artifacts.get(&key) {
+                    if existing.content == bytes {
+                        // Same bytes under the same name: nothing new.
+                        continue;
+                    }
+                    let existing_source = existing
+                        .metadata
+                        .get(FONT_SOURCE_METADATA_KEY)
+                        .and_then(serde_json::Value::as_str)
+                        .map(str::to_string);
+                    return Err(collision_error(
+                        &name,
+                        existing_source.as_deref(),
+                        Some(&source_label),
+                    ));
+                }
+                artifacts.store(
+                    key,
+                    Artifact::from_bytes(bytes, font_content_type(&name))
+                        .with_path(PathBuf::from(artifact_path))
+                        .with_scope(ArtifactScope::Project)
+                        .with_metadata(
+                            FONT_SOURCE_METADATA_KEY,
+                            serde_json::Value::String(source_label),
+                        ),
+                );
+            }
+        }
+    }
+    Ok(warnings)
+}
+
+/// Turn a cross-document artifact merge conflict into the `Q-14-10`
+/// diagnostic when the conflicting artifact is a published font.
+/// `None` for every other artifact kind (the caller keeps its generic
+/// error).
+pub fn merge_conflict_error(conflict: &ArtifactMergeConflict) -> Option<ParseError> {
+    let artifact_path = conflict.key.strip_prefix(FONT_ARTIFACT_KEY_PREFIX)?;
+    let name = artifact_path.rsplit('/').next().unwrap_or(artifact_path);
+    Some(collision_error(
+        name,
+        conflict.existing_source.as_deref(),
+        conflict.incoming_source.as_deref(),
+    ))
+}
+
+/// Where a font named `name` is published for a theme CSS living in
+/// `theme_css_dir` (forward slashes: this is an artifact path, not an
+/// OS path).
+fn font_artifact_path(theme_css_dir: &str, name: &str) -> String {
+    if theme_css_dir.is_empty() {
+        format!("fonts/{name}")
+    } else {
+        format!("{theme_css_dir}/fonts/{name}")
+    }
+}
+
+/// Locate a declared font path on disk.
+///
+/// A leading `/` names the project root (path-resolution contract);
+/// an OS-absolute path is used as written; anything else is relative
+/// to the brand file's directory.
+fn resolve_source(project_dir: &Path, brand_dir: &Path, declared: &str) -> PathBuf {
+    if let Some(rooted) = declared.strip_prefix('/') {
+        return project_dir.join(rooted);
+    }
+    let path = Path::new(declared);
+    if path.is_absolute() {
+        return path.to_path_buf();
+    }
+    brand_dir.join(path)
+}
+
+/// `path` relative to `project_dir` with forward slashes, or the full
+/// path when it lies outside the project.
+fn display_relative(path: &Path, project_dir: &Path) -> String {
+    path.strip_prefix(project_dir)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+/// How diagnostics refer to the brand: its file (project-relative),
+/// or the inline block when it has none.
+fn brand_label(brand: &ResolvedBrand, project_dir: &Path) -> String {
+    match &brand.file {
+        Some(file) => display_relative(file, project_dir),
+        None => "the inline `brand:` block".to_string(),
+    }
+}
+
+fn font_content_type(name: &str) -> &'static str {
+    let ext = name
+        .rsplit_once('.')
+        .map(|(_, ext)| ext.to_ascii_lowercase())
+        .unwrap_or_default();
+    match ext.as_str() {
+        "woff2" => "font/woff2",
+        "woff" => "font/woff",
+        "ttf" => "font/ttf",
+        "otf" => "font/otf",
+        _ => "application/octet-stream",
+    }
+}
+
+// ── diagnostics ─────────────────────────────────────────────────────
+
+fn missing_file_diagnostic(
+    brand_label: &str,
+    family: &str,
+    declared: &str,
+    resolved: &Path,
+    read_error: Option<&str>,
+) -> DiagnosticMessage {
+    let looked_at = match read_error {
+        Some(e) => format!("`{}` could not be read: {e}.", resolved.display()),
+        None => format!("Nothing exists at `{}`.", resolved.display()),
+    };
+    DiagnosticMessageBuilder::warning("Brand font file not found")
+        .with_code("Q-14-9")
+        .problem(format!(
+            "`{brand_label}` declares the file `{declared}` for the font family \
+             `{family}`, but it could not be published. {looked_at} The \
+             `@font-face` rule was still written, so the browser will fall \
+             back to the next font in the stack."
+        ))
+        .add_hint(
+            "Font paths are relative to the brand file; a leading `/` means the \
+             project root. Check the path, or add the missing file.",
+        )
+        .build()
+}
+
+fn unsupported_keys_diagnostic(
+    brand_label: &str,
+    family: &str,
+    declared: &str,
+    keys: &[&str],
+) -> DiagnosticMessage {
+    let listed = keys
+        .iter()
+        .map(|k| format!("`{k}`"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    DiagnosticMessageBuilder::warning("Unsupported key on a brand font file entry")
+        .with_code("Q-14-11")
+        .problem(format!(
+            "In `{brand_label}`, the `{family}` file entry `{declared}` sets \
+             {listed}, which Quarto does not support on a font file. The \
+             key(s) were ignored."
+        ))
+        .add_hint(
+            "Quarto derives the `format()` hint from the file's extension. \
+             Remove the key(s) to silence this warning.",
+        )
+        .build()
+}
+
+fn collision_error(name: &str, existing: Option<&str>, incoming: Option<&str>) -> ParseError {
+    let describe = |source: Option<&str>| match source {
+        Some(s) => format!("`{s}`"),
+        None => "a font declared by another brand".to_string(),
+    };
+    let diagnostic =
+        DiagnosticMessageBuilder::error("Two brand font files publish under the same name")
+            .with_code("Q-14-10")
+            .problem(format!(
+                "{} and {} would both be published as `fonts/{name}`, but their \
+             contents differ. Quarto publishes every `source: file` brand font \
+             as `fonts/<file name>` beside the theme CSS, so two different \
+             files cannot share a file name.",
+                describe(existing),
+                describe(incoming),
+            ))
+            .add_hint("Rename one of the files and update its `files:` entry in the brand.")
+            .build();
+    ParseError::new(vec![diagnostic], SourceContext::new())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn font_artifact_path_sits_beside_the_theme_css() {
+        assert_eq!(font_artifact_path("", "A.woff2"), "fonts/A.woff2");
+        assert_eq!(
+            font_artifact_path("quarto", "A.woff2"),
+            "quarto/fonts/A.woff2"
+        );
+        assert_eq!(
+            font_artifact_path("revealjs", "A.woff2"),
+            "revealjs/fonts/A.woff2"
+        );
+    }
+
+    #[test]
+    fn resolve_source_follows_the_path_contract() {
+        let project = Path::new("/proj");
+        let brand_dir = Path::new("/proj/brand");
+        assert_eq!(
+            resolve_source(project, brand_dir, "fonts/A.woff2"),
+            PathBuf::from("/proj/brand/fonts/A.woff2"),
+            "relative → brand dir"
+        );
+        assert_eq!(
+            resolve_source(project, brand_dir, "/assets/A.woff2"),
+            PathBuf::from("/proj/assets/A.woff2"),
+            "leading slash → project root"
+        );
+        assert_eq!(
+            resolve_source(project, brand_dir, "../shared/A.woff2"),
+            PathBuf::from("/proj/brand/../shared/A.woff2"),
+            "parent climb stays brand-relative"
+        );
+    }
+
+    #[test]
+    fn merge_conflict_error_only_claims_font_keys() {
+        let font = ArtifactMergeConflict {
+            key: "font:quarto/fonts/R.woff2".into(),
+            existing_len: 1,
+            incoming_len: 2,
+            existing_source: Some("a/R.woff2".into()),
+            incoming_source: Some("b/R.woff2".into()),
+        };
+        let pe = merge_conflict_error(&font).expect("font conflict");
+        let text = pe.render();
+        assert!(text.contains("Q-14-10"), "{text}");
+        assert!(
+            text.contains("a/R.woff2") && text.contains("b/R.woff2"),
+            "{text}"
+        );
+        assert!(text.contains("fonts/R.woff2"), "{text}");
+
+        let other = ArtifactMergeConflict {
+            key: "css:theme:abc".into(),
+            existing_len: 1,
+            incoming_len: 2,
+            existing_source: None,
+            incoming_source: None,
+        };
+        assert!(merge_conflict_error(&other).is_none());
+    }
+
+    #[test]
+    fn content_type_by_extension() {
+        assert_eq!(font_content_type("A.WOFF2"), "font/woff2");
+        assert_eq!(font_content_type("A.ttf"), "font/ttf");
+        assert_eq!(font_content_type("A"), "application/octet-stream");
+    }
+}

--- a/crates/quarto-core/src/lib.rs
+++ b/crates/quarto-core/src/lib.rs
@@ -39,6 +39,7 @@
 pub mod artifact;
 pub mod artifact_flush;
 pub mod attribution;
+pub mod brand_fonts;
 pub mod cell_options;
 pub mod config_sources;
 pub mod crossref;

--- a/crates/quarto-core/src/project/pass2_renderer.rs
+++ b/crates/quarto-core/src/project/pass2_renderer.rs
@@ -546,11 +546,7 @@ fn render_batch_parallel(
                     Ok(_) => outputs.push(*result),
                     Err(e) => failures.push(file_failure_from_error(
                         doc.input.clone(),
-                        crate::error::QuartoError::other(format!(
-                            "Project-scoped artifact merge failed for {}: {}",
-                            doc.input.display(),
-                            e
-                        )),
+                        crate::artifact_flush::merge_conflict_to_error(&doc.input, &e),
                     )),
                 }
             }

--- a/crates/quarto-core/src/stage/stages/compile_theme_css.rs
+++ b/crates/quarto-core/src/stage/stages/compile_theme_css.rs
@@ -233,6 +233,12 @@ fn cache_key(
                 // absent here we still hash the marker — `compile_with_doc_vars`
                 // will fail downstream, and the failure path bypasses
                 // the cache.
+                //
+                // Deliberately NOT keyed on the document's location:
+                // a brand's `@font-face` URLs are the constant
+                // `fonts/<name>` (bd-ve916wr8), so the compiled CSS is
+                // the same for every page. The font *names* are part
+                // of the YAML, so renaming a file does invalidate.
                 if let Some(brand) = theme_context.brand() {
                     let yaml = serde_yaml::to_string(brand)
                         .map_err(|e| format!("serialize brand for cache key: {e}"))?;
@@ -346,18 +352,42 @@ impl PipelineStage for CompileThemeCssStage {
             // against the project dir, mirroring the HTML path. Reveal resolves
             // brand on its own because the Bootstrap `ThemeConfig` theme path
             // rejects reveal theme names.
-            let brand_layers = quarto_sass::resolve_brand_layers(
+            let brand_layers = match quarto_sass::resolve_brand(
                 &doc.ast.meta,
                 ctx.runtime.as_ref(),
                 &ctx.project.dir,
-                std::path::Path::new(""),
             )
             .map_err(|e| {
                 PipelineError::Structured(crate::theme_diagnostic::sass_error_to_parse_error(
                     &e,
                     &theme_error_candidates(ctx),
                 ))
-            })?;
+            })? {
+                Some(brand) => {
+                    // Reveal's theme CSS lives under `revealjs/`, so its
+                    // `source: file` fonts publish to `revealjs/fonts/`
+                    // (bd-ve916wr8) — same contract as the Bootstrap path.
+                    let runtime = ctx.runtime.clone();
+                    let warnings = crate::brand_fonts::publish_brand_fonts(
+                        &mut ctx.artifacts,
+                        runtime.as_ref(),
+                        &ctx.project.dir,
+                        &[&brand],
+                        REVEAL_THEME_ARTIFACT_DIR,
+                    )
+                    .map_err(PipelineError::Structured)?;
+                    ctx.add_diagnostics(warnings);
+                    quarto_sass::brand_to_layers(&brand.brand).map_err(|e| {
+                        PipelineError::Structured(
+                            crate::theme_diagnostic::sass_error_to_parse_error(
+                                &e,
+                                &theme_error_candidates(ctx),
+                            ),
+                        )
+                    })?
+                }
+                None => Vec::new(),
+            };
             resolution.layers.extend(brand_layers);
 
             // Compile Quarto's reveal theme (single unified SCSS pass, D1) and
@@ -511,10 +541,32 @@ impl PipelineStage for CompileThemeCssStage {
         // (not `ctx`) so `ctx` stays mutably borrowable inside
         // `variant_css`.
         let runtime = ctx.runtime.clone();
+        // Publish every `source: file` brand font beside the theme CSS
+        // (bd-ve916wr8): the SCSS layer references `fonts/<name>`, and
+        // these artifacts are what make that URL resolve. Light and
+        // dark brands both contribute; a same-name/different-bytes
+        // clash is a hard `Q-14-10` error, a missing file or an
+        // unsupported key only warns.
+        let brands: Vec<&quarto_brand::ResolvedBrand> = resolved
+            .light_brand
+            .iter()
+            .chain(resolved.dark_brand.iter())
+            .collect();
+        if !brands.is_empty() {
+            let warnings = crate::brand_fonts::publish_brand_fonts(
+                &mut ctx.artifacts,
+                runtime.as_ref(),
+                &ctx.project.dir,
+                &brands,
+                theme_artifact_dir(ctx.project.is_single_file),
+            )
+            .map_err(PipelineError::Structured)?;
+            ctx.add_diagnostics(warnings);
+        }
+
         let mut theme_context = ThemeContext::new(document_dir.clone(), runtime.as_ref());
         if let Some(rb) = resolved.light_brand.as_ref() {
-            let brand_dir = rb.dir.clone().unwrap_or_else(|| ctx.project.dir.clone());
-            theme_context = theme_context.with_brand(&rb.brand, brand_dir);
+            theme_context = theme_context.with_brand(&rb.brand);
         }
 
         let light_css = variant_css(
@@ -530,8 +582,7 @@ impl PipelineStage for CompileThemeCssStage {
         if let Some(dark_cfg) = theme_config.dark_variant() {
             let mut dark_context = ThemeContext::new(document_dir, runtime.as_ref());
             if let Some(rb) = resolved.dark_brand.as_ref() {
-                let brand_dir = rb.dir.clone().unwrap_or_else(|| ctx.project.dir.clone());
-                dark_context = dark_context.with_brand(&rb.brand, brand_dir);
+                dark_context = dark_context.with_brand(&rb.brand);
             }
             let dark_css = variant_css(
                 ctx,
@@ -890,10 +941,27 @@ fn theme_artifact_key_and_path(fingerprint: &str, single_doc: bool) -> (String, 
     let path = if single_doc {
         PathBuf::from("styles.css")
     } else {
-        PathBuf::from(format!("quarto/quarto-theme-{}.css", fingerprint))
+        PathBuf::from(format!(
+            "{}/quarto-theme-{}.css",
+            theme_artifact_dir(false),
+            fingerprint
+        ))
     };
     (key, path)
 }
+
+/// Directory (relative to the lib dir) the Bootstrap theme CSS is
+/// published in: the bare resource dir for a single document, `quarto/`
+/// for a project. Published brand fonts sit in `fonts/` under the same
+/// directory so the theme's `fonts/<name>` URLs resolve
+/// (`crate::brand_fonts`).
+fn theme_artifact_dir(single_doc: bool) -> &'static str {
+    if single_doc { "" } else { "quarto" }
+}
+
+/// The reveal counterpart of [`theme_artifact_dir`]: reveal assets are
+/// registered under `revealjs/` (`crate::revealjs::assemble`).
+const REVEAL_THEME_ARTIFACT_DIR: &str = "revealjs";
 
 /// Dark-variant analog of [`theme_artifact_key_and_path`]. The key
 /// prefix is `css:theme-dark:` — deliberately NOT an extension of

--- a/crates/quarto-core/tests/integration/brand_fonts.rs
+++ b/crates/quarto-core/tests/integration/brand_fonts.rs
@@ -1,0 +1,676 @@
+//! End-to-end tests for `source: file` brand fonts (bd-ve916wr8).
+//!
+//! A local font named in `_brand.yml` must be *published* — as a
+//! project-scope artifact in a `fonts/` directory beside whichever
+//! theme CSS references it — and the `@font-face` URL the theme CSS
+//! carries must resolve from that CSS's own directory. Before this
+//! work, nothing copied the file and the URL was document-relative
+//! while the CSS lived in `site_libs/quarto/` (website) or
+//! `{stem}_files/` (single doc), so every local brand font 404'd.
+//!
+//! Every test here drives the real render entry points
+//! (`render_to_file` / `ProjectPipeline`), not `brand_to_layers`,
+//! because the defects lived in the plumbing between the SCSS layer
+//! and the output tree. Evidence for the original defects:
+//! `claude-notes/plans/brand-file-fonts-website-investigation/NOTES.md`.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use tempfile::TempDir;
+
+use quarto_core::format::Format;
+use quarto_core::project::ProjectContext;
+use quarto_core::project::orchestrator::{ProjectPipeline, ProjectRenderSummary, project_type_for};
+use quarto_core::render_to_file::{RenderToFileOptions, render_to_file};
+use quarto_error_reporting::DiagnosticMessage;
+use quarto_system_runtime::{NativeRuntime, SystemRuntime};
+
+// ── helpers ─────────────────────────────────────────────────────────
+
+const LIGHT_BYTES: &[u8] = b"wOF2-light-placeholder";
+const DARK_BYTES: &[u8] = b"wOF2-dark-placeholder-different-length";
+
+fn canonical(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn write(path: &Path, contents: &str) {
+    write_bytes(path, contents.as_bytes());
+}
+
+fn write_bytes(path: &Path, contents: &[u8]) {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(path, contents).unwrap();
+}
+
+fn read(path: &Path) -> String {
+    std::fs::read_to_string(path).unwrap_or_else(|e| panic!("read {}: {}", path.display(), e))
+}
+
+/// A `_brand.yml` declaring one `source: file` font whose single file
+/// entry is `path` (with weight/style, the shape a real brand uses).
+fn brand_yaml(path: &str) -> String {
+    format!(
+        "typography:\n  fonts:\n    - family: EB Garamond\n      source: file\n      files:\n        - path: {path}\n          weight: 400\n          style: normal\n  base: EB Garamond\n"
+    )
+}
+
+const WEBSITE_CONFIG: &str = "project:\n  type: website\n  output-dir: _site\nbrand: _brand.yml\nformat:\n  html:\n    theme: [brand]\n";
+
+/// Drive a fixture through `ProjectPipeline`; the caller decides
+/// whether failures are expected.
+fn try_render_project(
+    fixture: impl FnOnce(&Path),
+) -> (PathBuf, quarto_core::error::Result<ProjectRenderSummary>) {
+    let temp = TempDir::new().unwrap();
+    let project_dir = canonical(temp.path());
+    fixture(&project_dir);
+
+    let runtime: Arc<dyn SystemRuntime> = Arc::new(NativeRuntime::new());
+    let mut project = ProjectContext::discover(&project_dir, runtime.as_ref()).unwrap();
+    let options = RenderToFileOptions {
+        quiet: true,
+        ..Default::default()
+    };
+    let project_type = project_type_for(&project);
+    let mut pipeline = ProjectPipeline::new(
+        &mut project,
+        project_type,
+        Format::html(),
+        "html",
+        &options,
+        runtime.clone(),
+    );
+    let result = pollster::block_on(pipeline.run());
+    // Leak the temp dir so the test can inspect files after this
+    // function returns (cleanup happens at process exit).
+    std::mem::forget(temp);
+    (project_dir, result)
+}
+
+fn render_project(fixture: impl FnOnce(&Path)) -> (PathBuf, ProjectRenderSummary) {
+    let (dir, result) = try_render_project(fixture);
+    let summary = result.expect("pipeline");
+    assert!(
+        summary.pass1_failures.is_empty() && summary.pass2_failures.is_empty(),
+        "unexpected failures: pass1={:?} pass2={:?}",
+        summary.pass1_failures,
+        summary.pass2_failures
+    );
+    (dir, summary)
+}
+
+/// Every diagnostic raised while rendering any page of the project.
+fn page_diagnostics(summary: &ProjectRenderSummary) -> Vec<&DiagnosticMessage> {
+    summary
+        .outputs
+        .iter()
+        .flat_map(|o| o.render_output.diagnostics.iter())
+        .collect()
+}
+
+fn html_for_stem(summary: &ProjectRenderSummary, stem: &str) -> String {
+    let out = summary
+        .outputs
+        .iter()
+        .find(|o| o.output_path.file_stem().and_then(|s| s.to_str()) == Some(stem))
+        .unwrap_or_else(|| panic!("no output for stem '{stem}'"));
+    read(&out.output_path)
+}
+
+/// The theme bundles in `<dir>` (filenames matching
+/// `quarto-theme-*.css`, light or dark).
+fn theme_css_files(dir: &Path) -> Vec<PathBuf> {
+    let mut files: Vec<PathBuf> = std::fs::read_dir(dir)
+        .unwrap_or_else(|e| panic!("read_dir {}: {e}", dir.display()))
+        .filter_map(Result::ok)
+        .map(|e| e.path())
+        .filter(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.starts_with("quarto-theme-") && n.ends_with(".css"))
+        })
+        .collect();
+    files.sort();
+    files
+}
+
+/// The `@font-face` block(s) in a compiled (minified) theme CSS.
+fn font_face_blocks(css: &str) -> Vec<String> {
+    css.match_indices("@font-face")
+        .map(|(i, _)| {
+            let end = css[i..].find('}').map_or(css.len(), |e| i + e + 1);
+            css[i..end].to_string()
+        })
+        .collect()
+}
+
+fn single_doc_render(
+    root: &Path,
+    input: &str,
+    format: &str,
+) -> quarto_core::render_to_file::RenderToFileResult {
+    let runtime: Arc<dyn SystemRuntime> = Arc::new(NativeRuntime::new());
+    render_to_file(
+        &root.join(input),
+        format,
+        &RenderToFileOptions {
+            quiet: true,
+            ..Default::default()
+        },
+        runtime,
+    )
+    .expect("render_to_file")
+}
+
+// ── website ─────────────────────────────────────────────────────────
+
+/// The headline case: pages at two depths share ONE theme bundle in
+/// `site_libs/quarto/`, its `@font-face` URL is the constant
+/// `fonts/<basename>`, and the file is right there next to it.
+#[test]
+fn website_file_font_published_beside_theme_css_for_every_page_depth() {
+    let (project_dir, summary) = render_project(|dir| {
+        write(&dir.join("_quarto.yml"), WEBSITE_CONFIG);
+        write(
+            &dir.join("_brand.yml"),
+            &brand_yaml("assets/EBGaramond.woff2"),
+        );
+        write_bytes(&dir.join("assets/EBGaramond.woff2"), LIGHT_BYTES);
+        write(&dir.join("index.qmd"), "---\ntitle: Home\n---\n\nHello.\n");
+        write(
+            &dir.join("posts/one.qmd"),
+            "---\ntitle: One\n---\n\nPost.\n",
+        );
+    });
+
+    let lib = project_dir.join("_site/site_libs/quarto");
+    let bundles = theme_css_files(&lib);
+    assert_eq!(
+        bundles.len(),
+        1,
+        "exactly one theme bundle for both depths; got {bundles:?}"
+    );
+    let bundle_name = bundles[0]
+        .file_name()
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_string();
+    for stem in ["index", "one"] {
+        let html = html_for_stem(&summary, stem);
+        assert!(
+            html.contains(&format!("site_libs/quarto/{bundle_name}")),
+            "{stem}.html must link the shared bundle {bundle_name}:\n{html}"
+        );
+    }
+
+    let css = read(&bundles[0]);
+    let blocks = font_face_blocks(&css);
+    assert_eq!(blocks.len(), 1, "one @font-face block:\n{css}");
+    assert!(
+        blocks[0].contains(r#"url("fonts/EBGaramond.woff2")"#),
+        "URL must be the constant fonts/<basename>, resolvable from the bundle's own directory:\n{}",
+        blocks[0]
+    );
+    assert!(
+        blocks[0].contains(r#"format("woff2")"#),
+        "format() hint derived from the extension:\n{}",
+        blocks[0]
+    );
+    assert!(
+        !css.contains("assets/EBGaramond"),
+        "the brand-relative source path must not leak into the CSS:\n{css}"
+    );
+
+    let published = lib.join("fonts/EBGaramond.woff2");
+    assert_eq!(
+        std::fs::read(&published).ok().as_deref(),
+        Some(LIGHT_BYTES),
+        "font bytes published at {}",
+        published.display()
+    );
+    assert!(
+        !project_dir.join("_site/assets/EBGaramond.woff2").exists(),
+        "no source-mirrored copy (fonts are artifacts, not resources)"
+    );
+}
+
+/// A project whose only page is nested: the URL must not depend on
+/// the document's depth (the cache-aliasing regression — the first
+/// page to compile a brand used to pin a `pathdiff(document_dir,
+/// brand_dir)` prefix for every later page).
+#[test]
+fn website_font_url_does_not_depend_on_document_depth() {
+    let (project_dir, _summary) = render_project(|dir| {
+        write(&dir.join("_quarto.yml"), WEBSITE_CONFIG);
+        write(
+            &dir.join("_brand.yml"),
+            &brand_yaml("assets/EBGaramond.woff2"),
+        );
+        write_bytes(&dir.join("assets/EBGaramond.woff2"), LIGHT_BYTES);
+        write(
+            &dir.join("posts/deep/one.qmd"),
+            "---\ntitle: One\n---\n\nPost.\n",
+        );
+    });
+
+    let lib = project_dir.join("_site/site_libs/quarto");
+    let bundles = theme_css_files(&lib);
+    assert_eq!(bundles.len(), 1, "got {bundles:?}");
+    let css = read(&bundles[0]);
+    assert!(
+        css.contains(r#"url("fonts/EBGaramond.woff2")"#),
+        "constant URL regardless of page depth:\n{}",
+        font_face_blocks(&css).join("\n")
+    );
+    assert!(
+        !css.contains("../"),
+        "no document-relative climbing in the bundle:\n{}",
+        font_face_blocks(&css).join("\n")
+    );
+    assert!(lib.join("fonts/EBGaramond.woff2").exists());
+}
+
+/// A leading `/` names the project root (path-resolution contract,
+/// decision 3). The file is found there and published like any other.
+#[test]
+fn website_rooted_font_path_resolves_against_project_root() {
+    let (project_dir, _summary) = render_project(|dir| {
+        write(&dir.join("_quarto.yml"), WEBSITE_CONFIG);
+        write(&dir.join("_brand.yml"), &brand_yaml("/assets/Rooted.woff2"));
+        write_bytes(&dir.join("assets/Rooted.woff2"), LIGHT_BYTES);
+        write(&dir.join("index.qmd"), "---\ntitle: Home\n---\n\nHello.\n");
+    });
+
+    let lib = project_dir.join("_site/site_libs/quarto");
+    let css = read(&theme_css_files(&lib)[0]);
+    assert!(
+        css.contains(r#"url("fonts/Rooted.woff2")"#),
+        "rooted path publishes by basename:\n{}",
+        font_face_blocks(&css).join("\n")
+    );
+    assert_eq!(
+        std::fs::read(lib.join("fonts/Rooted.woff2"))
+            .ok()
+            .as_deref(),
+        Some(LIGHT_BYTES)
+    );
+}
+
+/// A brand file in a subdirectory: font paths are relative to the
+/// brand file, not the project root.
+#[test]
+fn website_font_path_is_relative_to_the_brand_file() {
+    let (project_dir, _summary) = render_project(|dir| {
+        write(
+            &dir.join("_quarto.yml"),
+            "project:\n  type: website\n  output-dir: _site\nbrand: brand/_brand.yml\nformat:\n  html:\n    theme: [brand]\n",
+        );
+        write(
+            &dir.join("brand/_brand.yml"),
+            &brand_yaml("fonts/Nested.woff2"),
+        );
+        write_bytes(&dir.join("brand/fonts/Nested.woff2"), LIGHT_BYTES);
+        write(&dir.join("index.qmd"), "---\ntitle: Home\n---\n\nHello.\n");
+    });
+
+    let lib = project_dir.join("_site/site_libs/quarto");
+    assert_eq!(
+        std::fs::read(lib.join("fonts/Nested.woff2"))
+            .ok()
+            .as_deref(),
+        Some(LIGHT_BYTES)
+    );
+}
+
+/// Light and dark brands with distinct files: both published, no
+/// conflict, each bundle references its own.
+#[test]
+fn website_light_and_dark_brands_publish_distinct_fonts() {
+    let (project_dir, _summary) = render_project(|dir| {
+        write(
+            &dir.join("_quarto.yml"),
+            "project:\n  type: website\n  output-dir: _site\nbrand:\n  light: light/_brand.yml\n  dark: dark/_brand.yml\nformat:\n  html:\n    theme: [brand]\n",
+        );
+        write(&dir.join("light/_brand.yml"), &brand_yaml("Light.woff2"));
+        write_bytes(&dir.join("light/Light.woff2"), LIGHT_BYTES);
+        write(&dir.join("dark/_brand.yml"), &brand_yaml("Dark.woff2"));
+        write_bytes(&dir.join("dark/Dark.woff2"), DARK_BYTES);
+        write(&dir.join("index.qmd"), "---\ntitle: Home\n---\n\nHello.\n");
+    });
+
+    let lib = project_dir.join("_site/site_libs/quarto");
+    assert_eq!(
+        std::fs::read(lib.join("fonts/Light.woff2")).ok().as_deref(),
+        Some(LIGHT_BYTES)
+    );
+    assert_eq!(
+        std::fs::read(lib.join("fonts/Dark.woff2")).ok().as_deref(),
+        Some(DARK_BYTES)
+    );
+    let bundles = theme_css_files(&lib);
+    assert_eq!(bundles.len(), 2, "light + dark bundles; got {bundles:?}");
+    let all: String = bundles.iter().map(|p| read(p)).collect();
+    assert!(all.contains(r#"url("fonts/Light.woff2")"#), "{all}");
+    assert!(all.contains(r#"url("fonts/Dark.woff2")"#), "{all}");
+}
+
+// ── collisions (decision 2: an error, never a silent overwrite) ─────
+
+/// Two documents whose brands publish different bytes under the same
+/// `fonts/<basename>`: the project render fails, and the message names
+/// both source files so the user knows what to rename.
+#[test]
+fn website_same_font_name_different_bytes_across_documents_is_an_error() {
+    let (_project_dir, result) = try_render_project(|dir| {
+        write(
+            &dir.join("_quarto.yml"),
+            "project:\n  type: website\n  output-dir: _site\nformat:\n  html:\n    theme: [brand]\n",
+        );
+        write(&dir.join("a/_brand.yml"), &brand_yaml("Regular.woff2"));
+        write_bytes(&dir.join("a/Regular.woff2"), LIGHT_BYTES);
+        write(&dir.join("b/_brand.yml"), &brand_yaml("Regular.woff2"));
+        write_bytes(&dir.join("b/Regular.woff2"), DARK_BYTES);
+        write(
+            &dir.join("a.qmd"),
+            "---\ntitle: A\nbrand: a/_brand.yml\n---\n\nA.\n",
+        );
+        write(
+            &dir.join("b.qmd"),
+            "---\ntitle: B\nbrand: b/_brand.yml\n---\n\nB.\n",
+        );
+    });
+
+    let message = match result {
+        Err(e) => e.to_string(),
+        Ok(summary) => {
+            assert!(
+                summary.has_failures(),
+                "expected the render to fail on the font-name collision"
+            );
+            summary
+                .pass1_failures
+                .iter()
+                .chain(&summary.pass2_failures)
+                .map(|f| {
+                    let details: Vec<String> = f
+                        .diagnostics
+                        .iter()
+                        .map(|d| format!("{:?} {}", d.code, d.title))
+                        .collect();
+                    format!("{} {}", f.error, details.join(" "))
+                })
+                .collect::<Vec<_>>()
+                .join("\n")
+        }
+    };
+    assert!(
+        message.contains("Q-14-10"),
+        "collision diagnostic carries its catalog code:\n{message}"
+    );
+    assert!(
+        message.contains("Regular.woff2"),
+        "names the colliding published name:\n{message}"
+    );
+    for source in ["a/Regular.woff2", "b/Regular.woff2"] {
+        assert!(
+            message.contains(source),
+            "names both source files ({source}):\n{message}"
+        );
+    }
+}
+
+/// The same collision inside ONE document: light and dark brands
+/// each ship `Regular.woff2` with different bytes.
+#[test]
+fn website_same_font_name_different_bytes_across_light_dark_is_an_error() {
+    let (_project_dir, result) = try_render_project(|dir| {
+        write(
+            &dir.join("_quarto.yml"),
+            "project:\n  type: website\n  output-dir: _site\nbrand:\n  light: light/_brand.yml\n  dark: dark/_brand.yml\nformat:\n  html:\n    theme: [brand]\n",
+        );
+        write(&dir.join("light/_brand.yml"), &brand_yaml("Regular.woff2"));
+        write_bytes(&dir.join("light/Regular.woff2"), LIGHT_BYTES);
+        write(&dir.join("dark/_brand.yml"), &brand_yaml("Regular.woff2"));
+        write_bytes(&dir.join("dark/Regular.woff2"), DARK_BYTES);
+        write(&dir.join("index.qmd"), "---\ntitle: Home\n---\n\nHello.\n");
+    });
+
+    let message = match result {
+        Err(e) => e.to_string(),
+        Ok(summary) => {
+            assert!(summary.has_failures(), "expected a failure");
+            summary
+                .pass1_failures
+                .iter()
+                .chain(&summary.pass2_failures)
+                .map(|f| {
+                    let details: Vec<String> = f
+                        .diagnostics
+                        .iter()
+                        .map(|d| format!("{:?} {}", d.code, d.title))
+                        .collect();
+                    format!("{} {}", f.error, details.join(" "))
+                })
+                .collect::<Vec<_>>()
+                .join("\n")
+        }
+    };
+    assert!(message.contains("Q-14-10"), "{message}");
+    for source in ["light/Regular.woff2", "dark/Regular.woff2"] {
+        assert!(message.contains(source), "names {source}:\n{message}");
+    }
+}
+
+/// Identical bytes under the same name from two brands are not a
+/// collision — they dedupe (same rule as every other project artifact).
+#[test]
+fn website_same_font_name_identical_bytes_dedupes() {
+    let (project_dir, _summary) = render_project(|dir| {
+        write(
+            &dir.join("_quarto.yml"),
+            "project:\n  type: website\n  output-dir: _site\nformat:\n  html:\n    theme: [brand]\n",
+        );
+        write(&dir.join("a/_brand.yml"), &brand_yaml("Regular.woff2"));
+        write_bytes(&dir.join("a/Regular.woff2"), LIGHT_BYTES);
+        write(&dir.join("b/_brand.yml"), &brand_yaml("Regular.woff2"));
+        write_bytes(&dir.join("b/Regular.woff2"), LIGHT_BYTES);
+        write(
+            &dir.join("a.qmd"),
+            "---\ntitle: A\nbrand: a/_brand.yml\n---\n\nA.\n",
+        );
+        write(
+            &dir.join("b.qmd"),
+            "---\ntitle: B\nbrand: b/_brand.yml\n---\n\nB.\n",
+        );
+    });
+    assert_eq!(
+        std::fs::read(project_dir.join("_site/site_libs/quarto/fonts/Regular.woff2"))
+            .ok()
+            .as_deref(),
+        Some(LIGHT_BYTES)
+    );
+}
+
+// ── diagnostics ─────────────────────────────────────────────────────
+
+/// A font file that does not exist: warn (naming the brand file and
+/// the path), keep rendering, publish nothing. The `@font-face` still
+/// references it — a visibly missing font beats a silently absent one,
+/// matching the favicon / navbar-logo rule.
+#[test]
+fn website_missing_font_file_warns_and_continues() {
+    let (project_dir, summary) = render_project(|dir| {
+        write(&dir.join("_quarto.yml"), WEBSITE_CONFIG);
+        write(&dir.join("_brand.yml"), &brand_yaml("assets/Missing.woff2"));
+        write(&dir.join("index.qmd"), "---\ntitle: Home\n---\n\nHello.\n");
+    });
+
+    let lib = project_dir.join("_site/site_libs/quarto");
+    assert!(
+        !lib.join("fonts/Missing.woff2").exists(),
+        "nothing published for a missing source"
+    );
+    let css = read(&theme_css_files(&lib)[0]);
+    assert!(
+        css.contains(r#"url("fonts/Missing.woff2")"#),
+        "the @font-face is still emitted:\n{css}"
+    );
+
+    let warnings: Vec<&DiagnosticMessage> = page_diagnostics(&summary)
+        .into_iter()
+        .filter(|d| d.code.as_deref() == Some("Q-14-9"))
+        .collect();
+    assert_eq!(
+        warnings.len(),
+        1,
+        "one Q-14-9 warning; got: {:?}",
+        page_diagnostics(&summary)
+            .iter()
+            .map(|d| format!("{:?} {}", d.code, d.title))
+            .collect::<Vec<_>>()
+    );
+    let text = format!("{:?}", warnings[0]);
+    assert!(
+        text.contains("assets/Missing.woff2"),
+        "names the path:\n{text}"
+    );
+    assert!(text.contains("_brand.yml"), "names the brand file:\n{text}");
+    assert!(text.contains("EB Garamond"), "names the family:\n{text}");
+}
+
+/// `format:` / `display:` on a file entry (unsettled in the brand.yml
+/// spec) warn once and are ignored — the render, the @font-face and
+/// the published file are all unaffected.
+#[test]
+fn website_unknown_key_on_font_file_entry_warns_once_and_is_ignored() {
+    let (project_dir, summary) = render_project(|dir| {
+        write(&dir.join("_quarto.yml"), WEBSITE_CONFIG);
+        write(
+            &dir.join("_brand.yml"),
+            "typography:\n  fonts:\n    - family: EB Garamond\n      source: file\n      files:\n        - path: assets/EBGaramond.woff2\n          weight: 400\n          format: woff2\n          display: swap\n  base: EB Garamond\n",
+        );
+        write_bytes(&dir.join("assets/EBGaramond.woff2"), LIGHT_BYTES);
+        write(&dir.join("index.qmd"), "---\ntitle: Home\n---\n\nHello.\n");
+    });
+
+    let lib = project_dir.join("_site/site_libs/quarto");
+    assert!(lib.join("fonts/EBGaramond.woff2").exists());
+    let css = read(&theme_css_files(&lib)[0]);
+    assert!(css.contains(r#"url("fonts/EBGaramond.woff2")"#), "{css}");
+    assert!(
+        !css.contains("swap"),
+        "the ignored display: value must not reach the CSS:\n{}",
+        font_face_blocks(&css).join("\n")
+    );
+
+    let warnings: Vec<&DiagnosticMessage> = page_diagnostics(&summary)
+        .into_iter()
+        .filter(|d| d.code.as_deref() == Some("Q-14-11"))
+        .collect();
+    assert_eq!(
+        warnings.len(),
+        1,
+        "exactly one Q-14-11 warning for the entry; got: {:?}",
+        page_diagnostics(&summary)
+            .iter()
+            .map(|d| format!("{:?} {}", d.code, d.title))
+            .collect::<Vec<_>>()
+    );
+    let text = format!("{:?}", warnings[0]);
+    assert!(text.contains("format"), "names the ignored key:\n{text}");
+    assert!(text.contains("display"), "names the ignored key:\n{text}");
+    assert!(text.contains("EB Garamond"), "names the family:\n{text}");
+}
+
+// ── single document ─────────────────────────────────────────────────
+
+/// Single-doc theme CSS lives in `{stem}_files/styles.css`, so the
+/// font goes to `{stem}_files/fonts/` and the same constant URL works.
+#[test]
+fn single_doc_file_font_published_in_files_dir() {
+    let temp = TempDir::new().unwrap();
+    let root = canonical(temp.path());
+    write(
+        &root.join("_brand.yml"),
+        &brand_yaml("assets/EBGaramond.woff2"),
+    );
+    write_bytes(&root.join("assets/EBGaramond.woff2"), LIGHT_BYTES);
+    write(
+        &root.join("doc.qmd"),
+        "---\ntitle: Single\nbrand: _brand.yml\nformat:\n  html:\n    theme: [brand]\n---\n\nHello.\n",
+    );
+
+    let result = single_doc_render(&root, "doc.qmd", "html");
+    let css = read(&result.resources_dir.join("styles.css"));
+    let blocks = font_face_blocks(&css);
+    assert_eq!(blocks.len(), 1, "{css}");
+    assert!(
+        blocks[0].contains(r#"url("fonts/EBGaramond.woff2") format("woff2")"#),
+        "constant URL, resolvable from doc_files/:\n{}",
+        blocks[0]
+    );
+    assert_eq!(
+        std::fs::read(result.resources_dir.join("fonts/EBGaramond.woff2"))
+            .ok()
+            .as_deref(),
+        Some(LIGHT_BYTES),
+        "font published under {}",
+        result.resources_dir.display()
+    );
+}
+
+/// Reveal's theme CSS is a third location (`revealjs/` under the lib
+/// dir); its fonts go to `revealjs/fonts/` so the constant URL still
+/// resolves.
+#[test]
+fn single_doc_revealjs_file_font_published_beside_reveal_theme() {
+    let temp = TempDir::new().unwrap();
+    let root = canonical(temp.path());
+    write(
+        &root.join("_brand.yml"),
+        &brand_yaml("assets/EBGaramond.woff2"),
+    );
+    write_bytes(&root.join("assets/EBGaramond.woff2"), LIGHT_BYTES);
+    write(
+        &root.join("deck.qmd"),
+        "---\ntitle: Deck\nbrand: _brand.yml\nformat: revealjs\n---\n\n## Slide\n\nHello.\n",
+    );
+
+    let result = single_doc_render(&root, "deck.qmd", "revealjs");
+    let reveal_dir = result.resources_dir.join("revealjs");
+    let theme_css: Vec<PathBuf> = std::fs::read_dir(&reveal_dir)
+        .unwrap_or_else(|e| panic!("read_dir {}: {e}", reveal_dir.display()))
+        .filter_map(Result::ok)
+        .map(|e| e.path())
+        .filter(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.starts_with("theme-") && n.ends_with(".css"))
+        })
+        .collect();
+    assert_eq!(
+        theme_css.len(),
+        1,
+        "one compiled reveal theme; got {theme_css:?}"
+    );
+    let css = read(&theme_css[0]);
+    assert!(
+        css.contains(r#"url("fonts/EBGaramond.woff2")"#),
+        "constant URL in the reveal theme:\n{}",
+        font_face_blocks(&css).join("\n")
+    );
+    assert_eq!(
+        std::fs::read(reveal_dir.join("fonts/EBGaramond.woff2"))
+            .ok()
+            .as_deref(),
+        Some(LIGHT_BYTES),
+        "font published beside the reveal theme"
+    );
+}

--- a/crates/quarto-core/tests/integration/main.rs
+++ b/crates/quarto-core/tests/integration/main.rs
@@ -13,6 +13,7 @@ pub mod attribution_viewer;
 pub mod attribution_wasm_invariant;
 pub mod behave_engine_e2e;
 pub mod bootstrap_js_pipeline;
+pub mod brand_fonts;
 pub mod brand_render;
 pub mod breadcrumbs_pipeline;
 pub mod capture_splice_engines;

--- a/crates/quarto-error-catalog/error_catalog.json
+++ b/crates/quarto-error-catalog/error_catalog.json
@@ -1196,6 +1196,27 @@
     "docs_url": "https://quarto.org/docs/errors/theme/Q-14-8",
     "since_version": "99.9.9"
   },
+  "Q-14-9": {
+    "subsystem": "theme",
+    "title": "Brand font file not found",
+    "message_template": "A `source: file` font in the brand names a file that does not exist, so it was not published. The `@font-face` rule was still written; the browser falls back to the next font. Font paths are relative to the brand file (a leading `/` means the project root).",
+    "docs_url": "https://quarto.org/docs/errors/theme/Q-14-9",
+    "since_version": "99.9.9"
+  },
+  "Q-14-10": {
+    "subsystem": "theme",
+    "title": "Two brand font files publish under the same name",
+    "message_template": "Two `source: file` brand fonts with different contents share a file name. Quarto publishes every brand font as `fonts/<file name>` beside the theme CSS, so two different files cannot share a name. Rename one of them.",
+    "docs_url": "https://quarto.org/docs/errors/theme/Q-14-10",
+    "since_version": "99.9.9"
+  },
+  "Q-14-11": {
+    "subsystem": "theme",
+    "title": "Unsupported key on a brand font file entry",
+    "message_template": "A `files:` entry of a `source: file` brand font sets a key Quarto does not support (such as `format:` or `display:`); it was ignored. The `format()` hint is derived from the file's extension.",
+    "docs_url": "https://quarto.org/docs/errors/theme/Q-14-11",
+    "since_version": "99.9.9"
+  },
   "Q-15-1": {
     "subsystem": "crossref",
     "title": "Duplicate Crossref Identifier",

--- a/crates/quarto-sass/src/brand_layer.rs
+++ b/crates/quarto-sass/src/brand_layer.rs
@@ -19,11 +19,9 @@
 //!   bare, which is fragile for multi-word names (`EB Garamond` would
 //!   be parsed as a token list). The Q2 output is more robust.
 
-use std::path::{Path, PathBuf};
-
 use quarto_brand::{
-    Brand, BrandFont, BrandFontFile, BrandFontFileEntry, BrandFontGoogle, BrandFontStyle,
-    BrandFontWeight, BrandFontWeightAtom,
+    Brand, BrandFont, BrandFontFile, BrandFontGoogle, BrandFontStyle, BrandFontWeight,
+    BrandFontWeightAtom, published_font_name,
 };
 
 use crate::error::SassError;
@@ -55,17 +53,16 @@ const DEFAULT_COLOR_NAME_MAP: &[(&str, &str)] = &[
 
 /// Translate a `Brand` into a vector of `SassLayer`s.
 ///
-/// `font_path_prefix` is the directory path used to resolve relative
-/// font-file URLs in `@font-face` blocks — it should be the brand
-/// file's directory relative to the project root. For an empty path,
-/// font files are referenced by their bare names.
+/// `source: file` fonts are referenced as `fonts/<basename>` — the
+/// location the theme stage publishes them to, beside the compiled
+/// theme CSS (see [`quarto_brand::published_font_name`]). The URL is
+/// therefore independent of where the brand file or the document
+/// lives, which is what lets one compiled theme serve every page of a
+/// site (bd-ve916wr8).
 ///
 /// Returns an empty vector if the brand has no color, typography, or
 /// `defaults.bootstrap` content.
-pub fn brand_to_layers(
-    brand: &Brand,
-    font_path_prefix: &Path,
-) -> Result<Vec<SassLayer>, SassError> {
+pub fn brand_to_layers(brand: &Brand) -> Result<Vec<SassLayer>, SassError> {
     let mut layers = Vec::new();
 
     // Semantic validation before any emission (bd-5fseopxy): an
@@ -91,7 +88,7 @@ pub fn brand_to_layers(
 
     // 3. typography layer
     if brand.typography.is_some()
-        && let Some(typography) = typography_layer(brand, font_path_prefix)?
+        && let Some(typography) = typography_layer(brand)?
     {
         layers.push(typography);
     }
@@ -267,10 +264,7 @@ fn yaml_scalar_to_scss(v: &serde_yaml::Value) -> String {
 
 // ── typography layer ────────────────────────────────────────────────
 
-fn typography_layer(
-    brand: &Brand,
-    font_path_prefix: &Path,
-) -> Result<Option<SassLayer>, SassError> {
+fn typography_layer(brand: &Brand) -> Result<Option<SassLayer>, SassError> {
     if brand.typography.is_none() {
         return Ok(None);
     }
@@ -286,7 +280,7 @@ fn typography_layer(
         let line = match font {
             BrandFont::Google(g) => google_font_import_string(g, &font_path)?,
             BrandFont::Bunny(b) => bunny_font_import_string(b, &font_path)?,
-            BrandFont::File(f) => file_font_face_block(f, font_path_prefix, &font_path)?,
+            BrandFont::File(f) => file_font_face_block(f, &font_path)?,
             BrandFont::System(_) => continue,
         };
         if seen_imports.insert(line.clone()) {
@@ -664,29 +658,25 @@ fn weight_spec(
 
 /// One `@font-face` block per file. A per-file weight range renders as
 /// CSS `font-weight: N M`, the declaration for a variable font's axis.
-fn file_font_face_block(
-    font: &BrandFontFile,
-    font_path_prefix: &Path,
-    font_path: &str,
-) -> Result<String, SassError> {
+fn file_font_face_block(font: &BrandFontFile, font_path: &str) -> Result<String, SassError> {
     let mut parts: Vec<String> = Vec::new();
     for (j, entry) in font.files.iter().enumerate() {
-        let (path, weight, style) = match entry {
-            BrandFontFileEntry::Path(p) => (p.clone(), None, None),
-            BrandFontFileEntry::Explicit {
-                path,
-                weight,
-                style,
-            } => (path.clone(), weight.clone(), style.clone()),
+        let path = entry.path();
+
+        // A local file is published beside the theme CSS as
+        // `fonts/<basename>` (the theme stage stores the bytes there);
+        // an external URL is served by whoever hosts it. The URL is
+        // the same for every page of a project, so the compiled theme
+        // is document-independent.
+        let src = match published_font_name(path) {
+            Some(name) => match font_format_hint(&name) {
+                Some(format) => format!("url('fonts/{name}') format('{format}')"),
+                None => format!("url('fonts/{name}')"),
+            },
+            None => format!("url('{path}')"),
         };
 
-        let font_url = if is_external_url(&path) {
-            path.clone()
-        } else {
-            join_url_path(font_path_prefix, &path)
-        };
-
-        let weight_str = match weight.as_ref() {
+        let weight_str = match entry.weight() {
             Some(w) => font_weight_to_css(
                 w,
                 &format!("{font_path}.files[{j}].weight"),
@@ -694,31 +684,31 @@ fn file_font_face_block(
             )?,
             None => "normal".to_string(),
         };
-        let style_str = style
-            .as_ref()
+        let style_str = entry
+            .style()
             .map_or_else(|| "normal".to_string(), font_style_to_scss);
 
         parts.push(format!(
-            "@font-face {{\n    font-family: {family};\n    src: url('{font_url}');\n    font-weight: {weight_str};\n    font-style: {style_str};\n}}",
+            "@font-face {{\n    font-family: {family};\n    src: {src};\n    font-weight: {weight_str};\n    font-style: {style_str};\n}}",
             family = quote_family_name(&font.family),
         ));
     }
     Ok(parts.join("\n"))
 }
 
-fn is_external_url(s: &str) -> bool {
-    s.starts_with("http://") || s.starts_with("https://") || s.starts_with("//")
-}
-
-/// Join a prefix and a relative path with forward slashes (URLs use
-/// `/`, not OS separators).
-fn join_url_path(prefix: &Path, rel: &str) -> String {
-    if prefix.as_os_str().is_empty() {
-        return rel.to_string();
+/// The CSS `format()` hint for a font file, from its extension.
+///
+/// Browsers use the hint to skip downloads they cannot decode. Unknown
+/// extensions get no hint rather than a guess.
+fn font_format_hint(name: &str) -> Option<&'static str> {
+    let ext = name.rsplit_once('.')?.1.to_ascii_lowercase();
+    match ext.as_str() {
+        "woff2" => Some("woff2"),
+        "woff" => Some("woff"),
+        "ttf" => Some("truetype"),
+        "otf" => Some("opentype"),
+        _ => None,
     }
-    let mut combined = PathBuf::from(prefix);
-    combined.push(rel);
-    combined.to_string_lossy().replace('\\', "/")
 }
 
 // ── error mapping ───────────────────────────────────────────────────

--- a/crates/quarto-sass/src/config.rs
+++ b/crates/quarto-sass/src/config.rs
@@ -531,7 +531,7 @@ impl ThemeConfig {
 
         let light_brand = light_split
             .as_ref()
-            .map(|(split, dir)| ResolvedBrand::new(split.light.clone(), dir.clone()));
+            .map(|(split, file)| resolved_brand(split.light.clone(), file.clone()));
 
         let dark_brand = match self.dark.as_ref().and_then(|d| d.brand_ref.as_ref()) {
             None => None,
@@ -541,14 +541,14 @@ impl ThemeConfig {
                 // one parse.
                 light_split
                     .as_ref()
-                    .map(|(split, dir)| ResolvedBrand::new(split.dark.clone(), dir.clone()))
+                    .map(|(split, file)| resolved_brand(split.dark.clone(), file.clone()))
             }
             Some(dark_ref) => {
                 // Two-file form: the dark variant's own file
                 // contributes its dark half (for a plain single-mode
                 // file the halves are identical).
-                let (split, dir) = load_split_brand(dark_ref, runtime, base_dir)?;
-                Some(ResolvedBrand::new(split.dark, dir))
+                let (split, file) = load_split_brand(dark_ref, runtime, base_dir)?;
+                Some(resolved_brand(split.dark, file))
             }
         };
 
@@ -631,12 +631,21 @@ pub fn resolve_brand(
     let Some(brand_ref) = extract_brand_refs(config.get("brand"))?.light else {
         return Ok(None);
     };
-    let (split, dir) = load_split_brand(&brand_ref, runtime, base_dir)?;
-    Ok(Some(ResolvedBrand::new(split.light, dir)))
+    let (split, file) = load_split_brand(&brand_ref, runtime, base_dir)?;
+    Ok(Some(resolved_brand(split.light, file)))
 }
 
-/// Read and parse one [`BrandRef`] into a split brand plus the
-/// directory it was read from (`None` for inline blocks).
+/// A [`ResolvedBrand`] for a half of a split brand: anchored at its
+/// file when it came from one, directory-less for an inline block.
+fn resolved_brand(brand: quarto_brand::Brand, file: Option<PathBuf>) -> ResolvedBrand {
+    match file {
+        Some(file) => ResolvedBrand::from_file(brand, file),
+        None => ResolvedBrand::new(brand, None),
+    }
+}
+
+/// Read and parse one [`BrandRef`] into a split brand plus the file
+/// it was read from (`None` for inline blocks).
 ///
 /// The parse form is [`quarto_brand::UnifiedBrand`] — color values may
 /// be plain strings or `{light:, dark:}` pairs — which is immediately
@@ -672,10 +681,7 @@ fn load_split_brand(
                     Some(full_path.clone()),
                 )
             })?;
-            let dir = full_path
-                .parent()
-                .map_or_else(|| PathBuf::from("."), Path::to_path_buf);
-            Ok((brand.split(), Some(dir)))
+            Ok((brand.split(), Some(full_path)))
         }
         BrandRef::Inline(value) => {
             let brand: quarto_brand::UnifiedBrand = serde_yaml::from_value((**value).clone())
@@ -688,32 +694,6 @@ fn load_split_brand(
                 .map_err(|e| brand_validation_err(e, |_| None, None))?;
             Ok((brand.split(), None))
         }
-    }
-}
-
-/// Resolve a `_brand.yml` (from the `brand:` key) into SCSS layers, independent
-/// of the Bootstrap `theme:` parsing.
-///
-/// `format: html` resolves brand through [`ThemeConfig::from_config_value`] +
-/// the `brand` position marker in `process_theme_specs`, but that path also
-/// parses `theme:` against the Bootswatch theme set — which rejects reveal theme
-/// names. RevealJS therefore resolves brand on its own via this helper: extract
-/// the `brand:` reference, read/parse it into a [`Brand`], and convert it to
-/// SCSS layers with [`crate::brand_to_layers`]. Returns an empty vector when no
-/// brand is configured.
-///
-/// `base_dir` resolves a relative `brand:` path (typically the project root);
-/// `font_path_prefix` is the directory prefix for `@font-face` URLs (pass an
-/// empty path to reference brand-bundled fonts by bare name).
-pub fn resolve_brand_layers(
-    config: &ConfigValue,
-    runtime: &dyn SystemRuntime,
-    base_dir: &Path,
-    font_path_prefix: &Path,
-) -> Result<Vec<crate::SassLayer>, SassError> {
-    match resolve_brand(config, runtime, base_dir)? {
-        Some(resolved) => crate::brand_layer::brand_to_layers(&resolved.brand, font_path_prefix),
-        None => Ok(Vec::new()),
     }
 }
 

--- a/crates/quarto-sass/src/lib.rs
+++ b/crates/quarto-sass/src/lib.rs
@@ -66,10 +66,7 @@ pub use compile::{
     assemble_theme_scss, compile_css_from_config, compile_default_css, compile_reveal_theme_css,
     compile_theme_css, compile_with_doc_vars,
 };
-pub use config::{
-    DarkThemeConfig, HighlightStyle, ResolvedVariants, ThemeConfig, resolve_brand,
-    resolve_brand_layers,
-};
+pub use config::{DarkThemeConfig, HighlightStyle, ResolvedVariants, ThemeConfig, resolve_brand};
 pub use error::SassError;
 pub use layer::{merge_layers, parse_layer, parse_layer_from_parts};
 pub use resources::{

--- a/crates/quarto-sass/src/themes.rs
+++ b/crates/quarto-sass/src/themes.rs
@@ -361,10 +361,6 @@ pub struct ThemeContext<'a> {
     /// [`ThemeConfig::resolve`]. When `None` and a `ThemeSpec::Brand`
     /// is encountered, [`process_theme_specs`] returns an error.
     brand: Option<&'a quarto_brand::Brand>,
-
-    /// Directory containing the brand file (for resolving font URLs
-    /// in `@font-face` blocks).
-    brand_dir: Option<PathBuf>,
 }
 
 impl std::fmt::Debug for ThemeContext<'_> {
@@ -374,7 +370,6 @@ impl std::fmt::Debug for ThemeContext<'_> {
             .field("load_paths", &self.load_paths)
             .field("runtime", &"<SystemRuntime>")
             .field("brand", &self.brand.is_some())
-            .field("brand_dir", &self.brand_dir)
             .finish()
     }
 }
@@ -395,7 +390,6 @@ impl<'a> ThemeContext<'a> {
             load_paths: Vec::new(),
             runtime,
             brand: None,
-            brand_dir: None,
         }
     }
 
@@ -416,30 +410,22 @@ impl<'a> ThemeContext<'a> {
             load_paths,
             runtime,
             brand: None,
-            brand_dir: None,
         }
     }
 
-    /// Builder-style: attach a resolved brand and its directory.
+    /// Builder-style: attach a resolved brand.
     ///
-    /// `brand_dir` is the directory containing the source `_brand.yml`
-    /// (used to resolve relative font-file paths in `@font-face`
-    /// blocks). For inline brand blocks with no source file, pass the
-    /// document directory.
-    pub fn with_brand(mut self, brand: &'a quarto_brand::Brand, brand_dir: PathBuf) -> Self {
+    /// Font-file *locations* are the theme stage's concern (it reads
+    /// and publishes them from the brand directory); the SCSS side
+    /// only needs the brand content.
+    pub fn with_brand(mut self, brand: &'a quarto_brand::Brand) -> Self {
         self.brand = Some(brand);
-        self.brand_dir = Some(brand_dir);
         self
     }
 
     /// The resolved brand, if any.
     pub fn brand(&self) -> Option<&'a quarto_brand::Brand> {
         self.brand
-    }
-
-    /// The brand-file directory, if a brand is attached.
-    pub fn brand_dir(&self) -> Option<&Path> {
-        self.brand_dir.as_deref()
     }
 
     /// Get the document directory.
@@ -775,14 +761,11 @@ pub fn process_theme_specs(
                             .to_string(),
                         location: None,
                     })?;
-                // Path prefix for @font-face URLs: brand_dir relative
-                // to the document_dir (matches Q1's
-                // `relative(projectDir, brandDir)`).
-                let prefix = match context.brand_dir() {
-                    Some(bd) => pathdiff_from_to(context.document_dir(), bd),
-                    None => PathBuf::new(),
-                };
-                let brand_layers = crate::brand_layer::brand_to_layers(brand, &prefix)?;
+                // `@font-face` URLs are the constant `fonts/<name>`
+                // (published beside the theme CSS by the theme stage),
+                // so the layers do not depend on the document's
+                // location — one compiled theme serves every page.
+                let brand_layers = crate::brand_layer::brand_to_layers(brand)?;
                 layers.extend(brand_layers);
             }
         }
@@ -837,47 +820,6 @@ pub fn resolve_theme(name: &str) -> Result<(BuiltInTheme, SassLayer), SassError>
     let theme: BuiltInTheme = name.parse()?;
     let layer = load_theme_layer(theme)?;
     Ok((theme, layer))
-}
-
-/// Compute `to` expressed relative to `from`, used for `@font-face`
-/// URLs in brand-derived SCSS. If the paths share no common prefix
-/// (different roots), we fall back to `to` as-is — the browser will
-/// resolve it from the served HTML's location.
-///
-/// This is a deliberately simple implementation that handles the
-/// common case where both paths are relative to the same project
-/// root or both absolute and share a common ancestor.
-fn pathdiff_from_to(from: &Path, to: &Path) -> PathBuf {
-    use std::path::Component;
-
-    let from_components: Vec<_> = from.components().collect();
-    let to_components: Vec<_> = to.components().collect();
-
-    // Find common prefix length.
-    let common = from_components
-        .iter()
-        .zip(to_components.iter())
-        .take_while(|(a, b)| a == b)
-        .count();
-
-    // Skip components that are equivalent to current-dir.
-    let from_remaining = &from_components[common..];
-    let to_remaining = &to_components[common..];
-
-    let mut result = PathBuf::new();
-    for _ in from_remaining
-        .iter()
-        .filter(|c| !matches!(c, Component::CurDir))
-    {
-        result.push("..");
-    }
-    for c in to_remaining {
-        result.push(c.as_os_str());
-    }
-    if result.as_os_str().is_empty() {
-        return PathBuf::new();
-    }
-    result
 }
 
 #[cfg(test)]

--- a/crates/quarto-sass/tests/integration/brand_compile_test.rs
+++ b/crates/quarto-sass/tests/integration/brand_compile_test.rs
@@ -7,7 +7,7 @@
 
 #![cfg(not(target_arch = "wasm32"))]
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use quarto_brand::Brand;
 use quarto_sass::brand_to_layers;
@@ -61,7 +61,7 @@ fn assert_compiles(scss: &str) {
 #[test]
 fn kitchen_sink_brand_compiles() {
     let brand = load_brand("brand-yaml/kitchen-sink/_brand.yml");
-    let layers = brand_to_layers(&brand, Path::new("")).expect("brand_to_layers");
+    let layers = brand_to_layers(&brand).expect("brand_to_layers");
     let scss = flatten_layers(&layers);
     assert_compiles(&scss);
 }
@@ -69,7 +69,7 @@ fn kitchen_sink_brand_compiles() {
 #[test]
 fn monospace_colors_brand_compiles() {
     let brand = load_brand("brand-yaml/monospace-colors/_brand.yml");
-    let layers = brand_to_layers(&brand, Path::new("")).expect("brand_to_layers");
+    let layers = brand_to_layers(&brand).expect("brand_to_layers");
     let scss = flatten_layers(&layers);
     assert_compiles(&scss);
 }
@@ -77,7 +77,7 @@ fn monospace_colors_brand_compiles() {
 #[test]
 fn palette_colors_brand_compiles() {
     let brand = load_brand("brand-yaml/palette-colors/_brand.yml");
-    let layers = brand_to_layers(&brand, Path::new("")).expect("brand_to_layers");
+    let layers = brand_to_layers(&brand).expect("brand_to_layers");
     let scss = flatten_layers(&layers);
     assert_compiles(&scss);
 }
@@ -85,7 +85,7 @@ fn palette_colors_brand_compiles() {
 #[test]
 fn basic_brand_compiles() {
     let brand = load_brand("use-brand/basic-brand/_brand.yml");
-    let layers = brand_to_layers(&brand, Path::new("")).expect("brand_to_layers");
+    let layers = brand_to_layers(&brand).expect("brand_to_layers");
     let scss = flatten_layers(&layers);
     assert_compiles(&scss);
 }
@@ -93,7 +93,7 @@ fn basic_brand_compiles() {
 #[test]
 fn multi_file_brand_compiles() {
     let brand = load_brand("use-brand/multi-file-brand/_brand.yml");
-    let layers = brand_to_layers(&brand, Path::new("brand")).expect("brand_to_layers");
+    let layers = brand_to_layers(&brand).expect("brand_to_layers");
     let scss = flatten_layers(&layers);
     assert_compiles(&scss);
 }
@@ -101,7 +101,7 @@ fn multi_file_brand_compiles() {
 #[test]
 fn nested_brand_compiles() {
     let brand = load_brand("use-brand/nested-brand/_brand.yml");
-    let layers = brand_to_layers(&brand, Path::new("")).expect("brand_to_layers");
+    let layers = brand_to_layers(&brand).expect("brand_to_layers");
     let scss = flatten_layers(&layers);
     assert_compiles(&scss);
 }
@@ -137,7 +137,7 @@ fn weight_range_brand_compiles() {
          \x20   family: EB Garamond\n\
          \x20   weight: 600\n",
     );
-    let layers = brand_to_layers(&b, Path::new("")).unwrap();
+    let layers = brand_to_layers(&b).unwrap();
     let scss = flatten_layers(&layers);
     assert_compiles(&scss);
 }

--- a/crates/quarto-sass/tests/integration/brand_layer_test.rs
+++ b/crates/quarto-sass/tests/integration/brand_layer_test.rs
@@ -11,8 +11,6 @@
 //! Q1's algorithm; the External Sources Policy forbids reading from
 //! `external-sources/` at test time.
 
-use std::path::Path;
-
 use quarto_brand::Brand;
 use quarto_sass::brand_to_layers;
 
@@ -33,7 +31,7 @@ fn color_layer_emits_brand_palette_sass_vars() {
          \x20   red: \"#FF0000\"\n\
          \x20   black: \"#002040\"\n",
     );
-    let layers = brand_to_layers(&b, Path::new("")).unwrap();
+    let layers = brand_to_layers(&b).unwrap();
     // The color layer is always the first non-empty layer.
     let color = &layers[0];
     assert!(
@@ -55,7 +53,7 @@ fn color_layer_emits_brand_palette_css_custom_props() {
          \x20 palette:\n\
          \x20   red: \"#FF0000\"\n",
     );
-    let layers = brand_to_layers(&b, Path::new("")).unwrap();
+    let layers = brand_to_layers(&b).unwrap();
     let color = &layers[0];
     assert!(
         color.rules.contains(":root {"),
@@ -79,7 +77,7 @@ fn color_layer_emits_named_theme_color_sass_vars_with_resolution() {
          \x20 primary: red\n\
          \x20 foreground: \"#21f\"\n",
     );
-    let layers = brand_to_layers(&b, Path::new("")).unwrap();
+    let layers = brand_to_layers(&b).unwrap();
     let color = &layers[0];
     assert!(
         color.defaults.contains("$primary: #FF0000 !default;"),
@@ -102,7 +100,7 @@ fn color_layer_applies_default_color_name_map() {
          \x20 foreground: \"#21f\"\n\
          \x20 background: \"#e6f8ff\"\n",
     );
-    let layers = brand_to_layers(&b, Path::new("")).unwrap();
+    let layers = brand_to_layers(&b).unwrap();
     let color = &layers[0];
     // foreground maps to body-color and pre-color and body-color.
     assert!(
@@ -130,7 +128,7 @@ fn color_layer_palette_key_sanitization() {
          \x20 palette:\n\
          \x20   \"my color\": \"#abc\"\n",
     );
-    let layers = brand_to_layers(&b, Path::new("")).unwrap();
+    let layers = brand_to_layers(&b).unwrap();
     let color = &layers[0];
     assert!(
         color.defaults.contains("$brand-my-color: #abc !default;"),
@@ -142,7 +140,7 @@ fn color_layer_palette_key_sanitization() {
 #[test]
 fn empty_brand_produces_no_layers() {
     let b = brand("");
-    let layers = brand_to_layers(&b, Path::new("")).unwrap();
+    let layers = brand_to_layers(&b).unwrap();
     assert!(
         layers.is_empty(),
         "empty brand should produce no layers, got {} layer(s)",
@@ -168,7 +166,7 @@ fn bootstrap_defaults_layer_emits_bootstrap_colors_from_palette() {
          \x20   defaults:\n\
          \x20     font-size-base: \"1.1rem\"\n",
     );
-    let layers = brand_to_layers(&b, Path::new("")).unwrap();
+    let layers = brand_to_layers(&b).unwrap();
     // Per Q1's `brandBootstrapSassLayers`, bootstrap-defaults is
     // `unshift`-ed to the front of the user layers — so the order is
     // [bootstrap_defaults, color, typography?].
@@ -205,7 +203,7 @@ fn bootstrap_defaults_layer_emits_passthrough_sections() {
          \x20   mixins: \"@mixin bar { color: red; }\"\n\
          \x20   rules: \".my-class { color: red; }\"\n",
     );
-    let layers = brand_to_layers(&b, Path::new("")).unwrap();
+    let layers = brand_to_layers(&b).unwrap();
     let bs = &layers[0]; // no color/typography, so bootstrap-defaults is first
     assert!(bs.uses.contains("@use 'sass:math';"), "uses: {}", bs.uses);
     assert!(
@@ -222,7 +220,7 @@ fn no_bootstrap_defaults_no_bootstrap_layer() {
     // Brand with color only — no bootstrap defaults — should produce
     // exactly one layer (the color layer).
     let b = brand("color:\n  primary: \"#abc\"\n");
-    let layers = brand_to_layers(&b, Path::new("")).unwrap();
+    let layers = brand_to_layers(&b).unwrap();
     assert_eq!(
         layers.len(),
         1,
@@ -243,7 +241,7 @@ fn typography_layer_emits_google_font_import() {
          \x20     weight: [400, 700]\n\
          \x20     style: [normal, italic]\n",
     );
-    let layers = brand_to_layers(&b, Path::new("")).unwrap();
+    let layers = brand_to_layers(&b).unwrap();
     let typ = layers.last().expect("typography layer");
     // Q1 places font @import lines in `uses` (so they land at the top
     // of the compiled SCSS, before any rules).
@@ -268,11 +266,11 @@ fn typography_layer_emits_file_font_face() {
          \x20   - source: file\n\
          \x20     family: Brand Font\n\
          \x20     files:\n\
-         \x20       - path: regular.woff2\n\
+         \x20       - path: assets/sub/regular.woff2\n\
          \x20         weight: 400\n\
          \x20         style: normal\n",
     );
-    let layers = brand_to_layers(&b, Path::new("brand")).unwrap();
+    let layers = brand_to_layers(&b).unwrap();
     let typ = layers.last().expect("typography layer");
     // @font-face blocks live in `uses` alongside @import lines.
     assert!(
@@ -285,9 +283,18 @@ fn typography_layer_emits_file_font_face() {
         "family in @font-face (quoted):\n{}",
         typ.uses
     );
+    // bd-ve916wr8: the file is published beside the theme CSS as
+    // `fonts/<basename>`, so the URL is that constant — never the
+    // brand-relative source path, and never document-relative.
     assert!(
-        typ.uses.contains("brand/regular.woff2"),
-        "relative path joined with font_path_prefix:\n{}",
+        typ.uses
+            .contains("src: url('fonts/regular.woff2') format('woff2');"),
+        "published-name URL with a format() hint:\n{}",
+        typ.uses
+    );
+    assert!(
+        !typ.uses.contains("assets/sub"),
+        "source directory must not leak into the URL:\n{}",
         typ.uses
     );
     assert!(
@@ -295,6 +302,65 @@ fn typography_layer_emits_file_font_face() {
         "weight:\n{}",
         typ.uses
     );
+}
+
+fn file_font_uses(path: &str) -> String {
+    let b = brand(&format!(
+        "typography:\n\
+         \x20 fonts:\n\
+         \x20   - source: file\n\
+         \x20     family: F\n\
+         \x20     files:\n\
+         \x20       - {path}\n"
+    ));
+    let layers = brand_to_layers(&b).unwrap();
+    layers.last().expect("typography layer").uses.clone()
+}
+
+/// A leading `/` means the project root (path-resolution contract);
+/// `../` climbs out of the brand dir. Both are *source* locations —
+/// the published URL is still `fonts/<basename>` (bd-ve916wr8
+/// decision 3).
+#[test]
+fn file_font_face_rooted_and_parent_source_paths_publish_by_basename() {
+    let rooted = file_font_uses("/assets/Rooted.woff");
+    assert!(
+        rooted.contains("src: url('fonts/Rooted.woff') format('woff');"),
+        "rooted path:\n{rooted}"
+    );
+    let parent = file_font_uses("../shared/Parent.ttf");
+    assert!(
+        parent.contains("src: url('fonts/Parent.ttf') format('truetype');"),
+        "parent path:\n{parent}"
+    );
+    let otf = file_font_uses("Plain.otf");
+    assert!(
+        otf.contains("src: url('fonts/Plain.otf') format('opentype');"),
+        "otf:\n{otf}"
+    );
+}
+
+#[test]
+fn file_font_face_external_url_passes_through_without_format_hint() {
+    let uses = file_font_uses("https://fonts.example.com/dir/Remote.woff2");
+    assert!(
+        uses.contains("src: url('https://fonts.example.com/dir/Remote.woff2');"),
+        "external URL verbatim:\n{uses}"
+    );
+    assert!(
+        !uses.contains("format("),
+        "no format() hint for an external URL:\n{uses}"
+    );
+}
+
+#[test]
+fn file_font_face_unknown_extension_has_no_format_hint() {
+    let uses = file_font_uses("assets/Mystery.font");
+    assert!(
+        uses.contains("src: url('fonts/Mystery.font');"),
+        "unknown extension still published by basename:\n{uses}"
+    );
+    assert!(!uses.contains("format("), "no format() hint:\n{uses}");
 }
 
 #[test]
@@ -306,7 +372,7 @@ fn typography_layer_base_font_assigns_bootstrap_vars() {
          \x20   size: 12pt\n\
          \x20   weight: 400\n",
     );
-    let layers = brand_to_layers(&b, Path::new("")).unwrap();
+    let layers = brand_to_layers(&b).unwrap();
     let typ = layers.last().expect("typography layer");
     assert!(
         typ.defaults
@@ -329,7 +395,7 @@ fn typography_layer_base_font_assigns_bootstrap_vars() {
 #[test]
 fn typography_layer_headings_font_emits_revealjs_vars_too() {
     let b = brand("typography:\n  headings:\n    family: PT Sans\n");
-    let layers = brand_to_layers(&b, Path::new("")).unwrap();
+    let layers = brand_to_layers(&b).unwrap();
     let typ = layers.last().expect("typography layer");
     // Both bootstrap and revealjs targets are emitted.
     assert!(
@@ -356,7 +422,7 @@ fn typography_layer_monospace_propagates_to_inline_and_block() {
          \x20   family: Fira Code\n\
          \x20   color: \"#222\"\n",
     );
-    let layers = brand_to_layers(&b, Path::new("")).unwrap();
+    let layers = brand_to_layers(&b).unwrap();
     let typ = layers.last().expect("typography layer");
     // Bootstrap monospace var
     assert!(
@@ -377,7 +443,7 @@ fn typography_layer_monospace_propagates_to_inline_and_block() {
 
 fn typography_uses(yaml: &str) -> String {
     let b = brand(yaml);
-    let layers = brand_to_layers(&b, Path::new("")).unwrap();
+    let layers = brand_to_layers(&b).unwrap();
     layers.last().expect("typography layer").uses.clone()
 }
 
@@ -528,7 +594,7 @@ fn slot_weight_range_is_an_error_not_scss() {
          \x20   family: A\n\
          \x20   weight: 500..700\n",
     );
-    match brand_to_layers(&b, Path::new("")) {
+    match brand_to_layers(&b) {
         Err(quarto_sass::SassError::InvalidBrandFontWeight { path, value, .. }) => {
             assert_eq!(path, "typography.headings.weight");
             assert_eq!(value, "500..700");
@@ -552,7 +618,7 @@ fn unknown_google_weight_keyword_is_an_error_not_400() {
          \x20     source: google\n\
          \x20     weight: Bold\n",
     );
-    match brand_to_layers(&b, Path::new("")) {
+    match brand_to_layers(&b) {
         Err(quarto_sass::SassError::InvalidBrandFontWeight { path, value, .. }) => {
             assert_eq!(path, "typography.fonts[0].weight");
             assert_eq!(value, "Bold");

--- a/crates/quarto/src/commands/use_cmd/source.rs
+++ b/crates/quarto/src/commands/use_cmd/source.rs
@@ -18,7 +18,7 @@
 
 use std::path::{Path, PathBuf};
 
-use quarto_brand::{Brand, BrandFont, BrandFontFileEntry, BrandLogoResource, LogoEntry};
+use quarto_brand::{Brand, BrandFont, BrandLogoResource, LogoEntry};
 
 use crate::commands::common::plan::CommandFailure;
 
@@ -219,10 +219,7 @@ fn collect_assets(brand: &Brand, brand_dir: &Path) -> Vec<PathBuf> {
             // installed; neither has anything to copy.
             if let BrandFont::File(file_font) = font {
                 for entry in &file_font.files {
-                    match entry {
-                        BrandFontFileEntry::Path(p) => declared.push(p.clone()),
-                        BrandFontFileEntry::Explicit { path, .. } => declared.push(path.clone()),
-                    }
+                    declared.push(entry.path().to_string());
                 }
             }
         }

--- a/crates/wasm-quarto-hub-client/Cargo.lock
+++ b/crates/wasm-quarto-hub-client/Cargo.lock
@@ -2099,6 +2099,7 @@ dependencies = [
 name = "quarto-brand"
 version = "0.30.0"
 dependencies = [
+ "hashlink",
  "pathdiff",
  "quarto-util",
  "serde",

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -317,6 +317,9 @@ website:
             - errors/theme/Q-14-6.qmd
             - errors/theme/Q-14-7.qmd
             - errors/theme/Q-14-8.qmd
+            - errors/theme/Q-14-9.qmd
+            - errors/theme/Q-14-10.qmd
+            - errors/theme/Q-14-11.qmd
         - section: "lua"
           contents:
             - errors/lua/Q-11-1.qmd

--- a/docs/errors/theme/Q-14-10.qmd
+++ b/docs/errors/theme/Q-14-10.qmd
@@ -1,0 +1,64 @@
+---
+title: "Two brand font files publish under the same name"
+description: "Two `source: file` brand fonts with different contents share a file name; Quarto publishes fonts by file name, so one of them must be renamed."
+code: Q-14-10
+subsystem: theme
+status: complete
+since: "99.9.9"
+categories:
+  - theme
+---
+
+# `Q-14-10` — Two Brand Font Files Publish Under the Same Name
+
+> Two `source: file` brand fonts with different contents share a
+> file name. Quarto publishes every brand font as
+> `fonts/<file name>` beside the theme CSS, so two different files
+> cannot share a name.
+
+## What this means
+
+Quarto copies each local brand font into a `fonts/` directory next
+to the compiled theme CSS and refers to it as `fonts/<file name>`,
+where `<file name>` is the last component of the path you wrote —
+the directory part is dropped. Two entries whose paths end in the
+same file name therefore land on the same published file. When
+their bytes are identical that is harmless and Quarto keeps one
+copy. When they differ, one would silently overwrite the other and
+some pages would get the wrong font, so Quarto stops the render
+instead and names both source files.
+
+This applies across everything that publishes into one output tree:
+the light and dark halves of a brand pair, a project brand and a
+document's own `brand:`, or two documents that each bring their own
+brand.
+
+## Why this happens
+
+- **Generic file names in different directories.** `serif/Regular.woff2`
+  and `sans/Regular.woff2` both publish as `fonts/Regular.woff2`.
+- **Light and dark brands** that ship differently-tuned files under
+  the same name.
+- **A stale copy.** The same font was updated in one brand directory
+  but not another, so the "same" file now has different bytes.
+
+## How to fix
+
+Rename one of the files so the two names differ, and update the
+`files:` entry that points at it:
+
+```yaml
+typography:
+  fonts:
+    - family: Serif Brand
+      source: file
+      files:
+        - path: serif/SerifBrand-Regular.woff2
+    - family: Sans Brand
+      source: file
+      files:
+        - path: sans/SansBrand-Regular.woff2
+```
+
+If the two files are meant to be the same font, replace one with a
+copy of the other; identical bytes do not conflict.

--- a/docs/errors/theme/Q-14-11.qmd
+++ b/docs/errors/theme/Q-14-11.qmd
@@ -1,0 +1,56 @@
+---
+title: "Unsupported key on a brand font file entry"
+description: "A `files:` entry of a `source: file` brand font sets a key Quarto does not support, such as `format:` or `display:`; it was ignored."
+code: Q-14-11
+subsystem: theme
+status: complete
+since: "99.9.9"
+categories:
+  - theme
+---
+
+# `Q-14-11` — Unsupported Key on a Brand Font File Entry
+
+> A `files:` entry of a `source: file` brand font sets a key Quarto
+> does not support (such as `format:` or `display:`); it was
+> ignored. The `format()` hint is derived from the file's extension.
+
+## What this means
+
+Each entry under a `source: file` font's `files:` list is either a
+bare path or a map with `path`, `weight`, and `style`. The entry in
+question carries additional keys. The brand.yml specification has
+not settled what those keys mean, so rather than reject the brand
+or drop the keys silently, Quarto warns once per entry and renders
+as if the keys were absent.
+
+The message names the brand file, the font family, the entry's
+path, and the ignored keys.
+
+## Why this happens
+
+- **`format:`** — you wanted a `format("woff2")` hint in the
+  `@font-face` rule. Quarto already derives that hint from the
+  file's extension (`.woff2`, `.woff`, `.ttf`, `.otf`), so the key
+  is redundant.
+- **`display:`** — you wanted a `font-display` value. `display:` is
+  supported on `source: google` and `source: bunny` fonts, where it
+  becomes part of the request URL, but not yet on file fonts.
+- **A typo** for `weight` or `style`.
+
+## How to fix
+
+Remove the key. For a `format()` hint, make sure the file has the
+right extension; for `font-display` on a local font, add the
+declaration in a custom SCSS or CSS file for now:
+
+```yaml
+typography:
+  fonts:
+    - family: EB Garamond
+      source: file
+      files:
+        - path: fonts/EBGaramond-Regular.woff2
+          weight: 400
+          style: normal
+```

--- a/docs/errors/theme/Q-14-9.qmd
+++ b/docs/errors/theme/Q-14-9.qmd
@@ -1,0 +1,67 @@
+---
+title: "Brand font file not found"
+description: "A `source: file` font in the brand names a file that does not exist, so it was not published; the `@font-face` rule was still written."
+code: Q-14-9
+subsystem: theme
+status: complete
+since: "99.9.9"
+categories:
+  - theme
+---
+
+# `Q-14-9` — Brand Font File Not Found
+
+> A `source: file` font in the brand names a file that does not
+> exist, so it was not published. The `@font-face` rule was still
+> written; the browser falls back to the next font in the stack.
+
+## What this means
+
+A font under `typography.fonts` in your `_brand.yml` has
+`source: file`, and one of its `files:` entries points at a path
+Quarto could not find. Quarto publishes every local brand font into
+a `fonts/` directory next to the compiled theme CSS, and writes an
+`@font-face` rule that refers to it there. With the source file
+missing there is nothing to publish, so the rule points at a file
+that does not exist and the browser silently uses the next font in
+`font-family`.
+
+This is a warning: the render completes, and the message names the
+brand file, the font family, the path as written, and the location
+Quarto looked at.
+
+## Why this happens
+
+- **The path is relative to the wrong base.** Font paths are
+  resolved relative to the **brand file's own directory**, not the
+  document or the project root. A brand at `brand/_brand.yml`
+  declaring `fonts/Regular.woff2` expects
+  `brand/fonts/Regular.woff2`.
+- **A leading `/` was meant literally.** `/assets/Regular.woff2`
+  means `<project root>/assets/Regular.woff2`, never the filesystem
+  root.
+- **The file was moved, renamed, or never copied** into the project.
+  `q2 use brand` copies a brand's font files alongside the brand;
+  a hand-written brand needs the files placed by hand.
+- **The file exists but cannot be read** (permissions). The message
+  includes the operating-system error in that case.
+
+## How to fix
+
+Compare the path in the message with where the file actually is,
+and adjust one or the other:
+
+```yaml
+# _brand.yml, next to a fonts/ directory
+typography:
+  fonts:
+    - family: EB Garamond
+      source: file
+      files:
+        - path: fonts/EBGaramond-Regular.woff2
+          weight: 400
+  base: EB Garamond
+```
+
+Remote fonts (`https://…`) are never published and never raise this
+warning; they are fetched by the browser directly.

--- a/docs/guides/authoring/brand.qmd
+++ b/docs/guides/authoring/brand.qmd
@@ -620,6 +620,32 @@ typography:
 
 Range ends are numbers from 100 to 900 with the smaller first; keywords are not accepted as range ends. A weight Quarto does not recognize stops the render with error `Q-14-8`, which names the offending value and its location.
 
+### Local font files {#local-font-files}
+
+A font with `source: file` ships its own files with the project instead of loading them from Google Fonts or Bunny Fonts:
+
+``` {.yaml filename="_brand.yml"}
+typography:
+  fonts:
+    - family: EB Garamond
+      source: file
+      files:
+        - path: fonts/EBGaramond-Regular.woff2
+          weight: 400
+        - path: fonts/EBGaramond-Italic.woff2
+          weight: 400
+          style: italic
+  base: EB Garamond
+```
+
+Each `files` entry is a path (or a map with `path`, `weight`, and `style`). Paths are relative to the **brand file's own directory**, so the example above expects a `fonts/` directory next to `_brand.yml`. A path that starts with `/` is relative to the project root instead.
+
+Quarto publishes the files for you: every local font is copied into a `fonts/` directory next to the compiled theme stylesheet (`site_libs/quarto/fonts/` in a website, `<document>_files/fonts/` for a standalone document), and the generated `@font-face` rule points there. You do not need to list font files under `resources`. The `format()` hint of the rule comes from the file's extension (`.woff2`, `.woff`, `.ttf`, or `.otf`).
+
+Because published fonts are named by their file name only, two different files in one project cannot share a name — `serif/Regular.woff2` and `sans/Regular.woff2` would collide. Quarto stops the render and names both files when that happens; rename one of them. A `files` entry that points at a file which does not exist produces a warning and the render continues without it. Remote fonts (`https://…` paths) are left for the browser to fetch.
+
+Per-file keys beyond `path`, `weight`, and `style` — such as `format` or `display` — are not part of the settled brand.yml specification. Quarto warns and ignores them.
+
 
 You can then refer to fonts by `family` in the remaining typography options:
 


### PR DESCRIPTION
Fixes bd-ve916wr8.

## Problem

Local fonts declared in `_brand.yml` (`source: file`) were never copied into the output, and the `@font-face` URL was document-relative while the compiled theme CSS lives in `site_libs/quarto/` (website) or `{stem}_files/` (single doc). Every local brand font 404'd. The per-document prefix also split a site into one theme bundle per page depth on a cold SASS cache, and aliased pages onto whichever compiled first on a warm one, because the cache key never included it. Evidence and repro fixtures: `claude-notes/plans/brand-file-fonts-website-investigation/NOTES.md`.

## Fix

Fonts are published as project-scope artifacts in a `fonts/` directory beside whichever theme CSS references them (`site_libs/quarto/fonts/`, `{stem}_files/fonts/`, `…/revealjs/fonts/`), and the SCSS layer emits the constant `url('fonts/<basename>') format('woff2')`. The URL no longer depends on the document, so one compiled theme serves every page and the cache key is complete by construction. Artifacts flush through both the native sink and the preview VFS, so the same mechanism covers `q2 preview`.

- **quarto-brand**: `published_font_name`; `BrandFontFileEntry::Explicit` becomes a struct that tolerates unsettled per-file keys (`format:`, `display:`) and exposes them; `ResolvedBrand` remembers its file.
- **quarto-sass**: `brand_to_layers(&Brand)` drops the font-path prefix; `ThemeContext::with_brand` drops `brand_dir`; `resolve_brand_layers` is gone (reveal resolves the brand and publishes fonts itself).
- **quarto-core**: new `brand_fonts` module (publish, leading `/` = project root per the path contract, dedupe identical bytes). `ArtifactMergeConflict` carries the producers' `source` metadata, and font clashes map to `Q-14-10` from both the serial tail and the parallel Pass-2 reducer.
- **Diagnostics**: `Q-14-9` font file missing (warn, continue), `Q-14-10` same name / different bytes (hard error naming both sources), `Q-14-11` unsupported key on a file entry (warn, ignore). Numbered past `Q-14-6/7` (#661) and `Q-14-8` (#663).
- **Docs**: "Local font files" section in the brand guide; three error pages + sidebar; inventory row in `path-resolution-model.md`.

Design decisions (fonts as artifacts, collision is an error, `/` = project root, warn on unknown keys) are recorded in `claude-notes/plans/2026-09-08-brand-file-fonts-website.md`.

## Tests

- 12 end-to-end cases in `crates/quarto-core/tests/integration/brand_fonts.rs` through `render_to_file` / `ProjectPipeline`: website at two depths (one bundle), nested-only page, rooted path, brand in a subdirectory, light/dark distinct fonts, identical-bytes dedupe, both collision shapes, missing file, unknown key, single doc, reveal. All confirmed failing at HEAD first.
- Unit coverage in quarto-brand (`font_files_test.rs`), quarto-sass (`brand_layer_test.rs`), quarto-core (`brand_fonts` module).
- `cargo nextest run --workspace` 13,763 passed; clippy `-D warnings` clean on the touched crates; `cargo xtask verify --skip-hub-tests` green including the WASM leg (hub-client vitest is red on `main` from the Node 26 `localStorage` issue, bd-lh30hlvd).

## End-to-end

```
cargo run --bin q2 -- render claude-notes/plans/brand-file-fonts-website-investigation/repro
```

One bundle `site_libs/quarto/quarto-theme-<fp>.css` linked by `index.html` and `posts/one.html`, containing

```
@font-face{font-family:"EB Garamond";src:url("fonts/EBGaramond-VariableFont_wght.woff2") format("woff2");font-weight:400;font-style:normal}
```

and `site_libs/quarto/fonts/EBGaramond-VariableFont_wght.woff2` byte-identical to the source. The single-doc fixture publishes `doc_files/fonts/…` next to `doc_files/styles.css`.

## Coordination

Expected textual conflict with #663 (bd-5fseopxy) in `file_font_face_block`, `types.rs`, and the theme stage; whichever lands second rebases. On merge: comment on bd-r1y48cx0 (`css:` files never copied) pointing at this mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CoQm2W4rtvPQNDtkYKdb6D
