### PR TITLE
cargo xtask verify runs hub-client lint:css in step 1, matching CI (bd-4bu7vwi5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -571,6 +571,10 @@ cargo xtask verify           # Full verification (Rust + hub-client builds + tes
 ```
 
 This runs:
+0. `cargo xtask lint`, `npm run lint:css -w hub-client`, and clippy - the
+   fail-fast lints (step 1 in the xtask's numbering). The CSS lint enforces
+   `hub-client/design-system.md` and runs even under `--skip-hub-build`;
+   disable it with `--skip-css-lint`.
 1. `cargo build --workspace` - Build all Rust crates
 2. `cargo nextest run --workspace` - Run all Rust tests
 3. `npm run build --if-present -w ts-packages/...` - Build the ts-packages
@@ -586,8 +590,18 @@ This runs:
 cargo xtask verify --skip-rust-tests    # Skip Rust tests
 cargo xtask verify --skip-hub-tests     # Skip hub-client tests
 cargo xtask verify --skip-hub-build     # Skip hub-client build entirely
+cargo xtask verify --skip-css-lint      # Skip the hub-client CSS lint
 cargo xtask verify --e2e                # Include slower e2e browser tests
 ```
+
+**Keep `verify` and CI in sync: when you add a gating step to a CI
+workflow, add its `cargo xtask verify` counterpart in the same commit.**
+`verify` is the local mirror of CI, and nothing reconciles the two
+automatically. The CSS lint was wired into `ts-test-suite.yml` twelve days
+before it reached `verify`; in between, PR #667 passed the full local gate
+and failed both CI legs on a `margin-left: 0` (bd-4bu7vwi5). Known
+remaining drift is tracked as bd-l7mcijfe (Node-only test suites) and
+bd-ya2nacaa (legs needing Deno / wasm32 / the hub binary).
 
 **Why this matters**: The `wasm-quarto-hub-client` crate depends on `quarto-core` types like `RenderOutput`. Changes to these types will break the WASM build even if `cargo build --workspace` succeeds (WASM uses a separate build target).
 

--- a/claude-notes/plans/2026-09-09-verify-lint-css.md
+++ b/claude-notes/plans/2026-09-09-verify-lint-css.md
@@ -4,7 +4,7 @@
 **Braid:** bd-4bu7vwi5
 **Branch:** `main` @ `3ecabd28f` (investigated in the main checkout, no worktree)
 **Pre-flight:** `cargo xtask verify --skip-hub-build` green at HEAD (under Node 24 via fnm; the Homebrew `node` on PATH is v26 and trips the preflight).
-**Status:** Investigation — pending design alignment with user. **Do not start implementation until the user gives the go-ahead.**
+**Status:** Approved 2026-09-09 — implementing. Decisions: step 1 placement; add `--skip-css-lint`; lint:css only (wider drift filed as bd-l7mcijfe + bd-ya2nacaa); doc rule, no structural lint.
 
 ## Triage verdict
 
@@ -60,16 +60,55 @@ The strand asks about lint:css only, but the same comparison shows other steps C
 
 Everything `verify` runs, CI also runs, so the drift is one-directional.
 
-## Proposed phases (draft)
+## Work items
 
-Skeleton only — actual phase contents wait on the design discussion.
+Phase 0 — tests first (unit tests in `crates/xtask/src/verify.rs`):
+- [x] `runs_css_lint`: on by default, off with `skip_css_lint`, still on under `--skip-hub-build` (the exact hole from PR #667).
+- [x] `needs_node`: extracted from the inline expression; css lint counts as npm-driven, so "everything else skipped" still preflights Node.
+- [x] `css_lint_command_matches_ci_workflow`: the local `npm` args joined equal a `run:` line in `ts-test-suite.yml`, so the two gates cannot drift silently.
+- [x] Run, confirm failure (functions/field do not exist yet).
 
-- Phase 0 — Test plan. A unit test in `crates/xtask` that fails at HEAD: the `verify` module must invoke `lint:css` (e.g. a step-list/registry the test can inspect, or at minimum a source-level assertion the way `ci_test_wiring` parses workflows). If the answer to Q3 is "yes", the test instead becomes a new repo-level lint rule that parses `ts-test-suite.yml` and asserts each gating step has a `verify` counterpart or an `EXCUSED` entry.
-- Phase 1 — Add the lint:css step to `verify.rs`. Position: with the other fail-fast checks (step 1, next to `cargo xtask lint` + clippy), or at the top of the hub-client leg (step 7) as the strand suggests. Gate it on the same condition as step 7 (`!skip_hub_build`) or on a new `--skip-css-lint`, per Q2. Bump `TOTAL_STEPS` and the module doc.
-- Phase 2 — Optional, per Q3: fold the rest of the drift table in, or file it as separate strands.
-- Phase 3 — Docs: `CLAUDE.md` "Full Project Verification" step list, `hub-client/design-system.md` enforcement sentence, and a note on bd-owmzraf6's plan that the local mirror now exists.
+Phase 1 — implementation:
+- [x] `VerifyConfig.skip_css_lint` + `--skip-css-lint` clap flag in `main.rs`.
+- [x] Step 1 runs `npm run lint:css -w hub-client` from the project root, after `cargo xtask lint` and before clippy (fail-fast, 0.2 s). `TOTAL_STEPS` unchanged (it lives inside step 1).
+- [x] Module doc + `Verify` clap doc updated.
+- [ ] Tests green; `cargo nextest run --workspace`; `cargo xtask verify --skip-hub-build`.
 
-## Open design questions for the user
+Phase 2 — end-to-end:
+- [x] Inject `margin-left: 0;` into a hub-client CSS file, run `cargo xtask verify --skip-hub-build`, observe step 1 fails on lint:css; revert; observe green. Record the invocation + output here.
+
+End-to-end record (2026-09-09, main + this change, Node 24 via fnm). Appended
+`.bd-4bu7vwi5-e2e { margin-left: 0; }` to `hub-client/src/components/ReplayDrawer.css`
+and ran, with every other step skipped:
+
+```
+cargo xtask verify --skip-rust-build --skip-rust-tests --skip-treesitter-tests \
+  --skip-hub-build --skip-hub-tests --skip-ts-packages-build --skip-trace-viewer-build \
+  --skip-trace-viewer-tests --skip-shared-package-tests --skip-q2-preview-spa-build \
+  --skip-hub-mcp-tests
+```
+
+Observed (step 1, before any Rust compile):
+
+```
+lint:css[no-physical-box-props] src/components/ReplayDrawer.css:491  margin-left: 0;
+lint:css: 1 problem(s)
+Error: hub-client lint:css failed (see hub-client/design-system.md)
+```
+
+Reverted the file; same invocation printed `✓ hub-client lint:css clean` and
+`✓ All verification steps passed!`. With `--skip-css-lint` added the preflight
+printed `(skipped — every npm-driven step is disabled)` and step 1 printed
+`↳ Skipping hub-client lint:css`. Output inspected by hand.
+
+Phase 3 — docs:
+- [x] `CLAUDE.md` "Full Project Verification": add the lint:css step and the rule *when you add a CI step, add its verify counterpart in the same commit*.
+- [x] `hub-client/design-system.md`: enforcement sentence names `cargo xtask verify` too.
+- [x] Follow-ups filed: bd-l7mcijfe (Node-only suites), bd-ya2nacaa (Deno/wasm32/harness legs).
+
+## Design questions (answered 2026-09-09)
+
+Answers: (1) step 1; (2) add `--skip-css-lint`; (3) lint:css only, wider drift filed separately; (4) docs are enough.
 
 1. **Placement.** Run lint:css in step 1 with the other fail-fast lints (fails in 0.2 s before the multi-minute Rust build, matching CI's "right after npm ci" placement), or inside the hub-client leg (step 7) as the strand text says? Step 1 means `--skip-hub-build` still runs it, which is what a CSS-only change wants; step 7 means `--skip-hub-build` skips it, which recreates a smaller version of this hole.
 2. **Skip flag.** Does it need its own `--skip-css-lint`, or is it cheap enough to be unconditional (like `cargo xtask lint` and `cargo fmt --check` today)? Note the Node preflight: if it runs unconditionally, `needs_node` must include it, so the "every npm-driven step is disabled" shortcut goes away unless a flag exists.

--- a/claude-notes/plans/2026-09-09-verify-lint-css.md
+++ b/claude-notes/plans/2026-09-09-verify-lint-css.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-09-09
 **Braid:** bd-4bu7vwi5
-**Branch:** `main` @ `3ecabd28f` (investigated in the main checkout, no worktree)
+**Branch:** `braid/bd-4bu7vwi5-verify-lint-css` (remote `chore/bd-4bu7vwi5-verify-lint-css`), rebased onto `main` after #667 merged. **PR:** https://github.com/quarto-dev/q2/pull/669
 **Pre-flight:** `cargo xtask verify --skip-hub-build` green at HEAD (under Node 24 via fnm; the Homebrew `node` on PATH is v26 and trips the preflight).
 **Status:** Approved 2026-09-09 — implementing. Decisions: step 1 placement; add `--skip-css-lint`; lint:css only (wider drift filed as bd-l7mcijfe + bd-ya2nacaa); doc rule, no structural lint.
 

--- a/claude-notes/plans/2026-09-09-verify-lint-css.md
+++ b/claude-notes/plans/2026-09-09-verify-lint-css.md
@@ -1,0 +1,83 @@
+# cargo xtask verify does not run hub-client lint:css (CI does) (bd-4bu7vwi5)
+
+**Date:** 2026-09-09
+**Braid:** bd-4bu7vwi5
+**Branch:** `main` @ `3ecabd28f` (investigated in the main checkout, no worktree)
+**Pre-flight:** `cargo xtask verify --skip-hub-build` green at HEAD (under Node 24 via fnm; the Homebrew `node` on PATH is v26 and trips the preflight).
+**Status:** Investigation — pending design alignment with user. **Do not start implementation until the user gives the go-ahead.**
+
+## Triage verdict
+
+**Ready to design.** The gap is a single missing step in `crates/xtask/src/verify.rs`, the CI step it should mirror is unambiguous, and the fix is small. The only real decision is scope: close just this hole, or also close the other CI-vs-verify drift the investigation turned up.
+
+## Issue context
+
+Filed 2026-09-09 by Carlos Scheidegger, `chore`, priority 3, labels `hub-client` + `tooling`.
+
+> CI's ts-test-suite workflow runs `npm run lint:css -w hub-client` (scripts/lint-css.mjs, e.g. the no-physical-box-props rule), but `cargo xtask verify` does not, so a CSS change can pass the full local gate and still fail CI. Found on PR #667: a `margin-left: 0` passed verify and failed both "Run test suite" jobs. Add the lint:css step to the verify hub-build leg (it is fast) so the local gate matches CI.
+
+## Dependency graph
+
+- **discovered-from bd-ew0vak6b** (in_progress) — "hub-client q2-preview: editable/read-only toggle in the bottom status bar". That strand's PR is #667 (`feature/bd-ew0vak6b-hub-client-q2-preview`). Its author ran the full local gate, got green, pushed, and CI run 34388639694 failed both `Run test suite` matrix legs at the `Lint hub-client CSS` step. No other edges.
+- Context strand (not linked, found via `git log -S`): **bd-owmzraf6** (closed) — "Wire hub-client lint:css into CI". Commit `28afc1e14` added the CI step to `ts-test-suite.yml` and fixed the ConnectionStatusDialog violations. It touched only the workflow file and one CSS file; `verify.rs` was not updated. That is where the drift was introduced: the CI gate got a new step and the local mirror did not.
+
+## What the code looks like today
+
+Confirmed at HEAD (`3ecabd28f`):
+
+- `crates/xtask/src/verify.rs` (14 numbered steps) has no lint:css call. `grep -n 'lint:css' crates/xtask/src/verify.rs` is empty. Its module doc claims it matches "the CI environment as closely as possible".
+- `.github/workflows/ts-test-suite.yml`, job `test-suite`, step `Lint hub-client CSS`: `npm run lint:css -w hub-client`, placed right after `npm ci` and before the WASM build, on both `ubuntu-latest` and `macos-latest`.
+- `hub-client/scripts/lint-css.mjs` is dependency-free Node; it walks `hub-client/src/**/*.css` and applies four rules (`no-hardcoded-color`, `no-bare-z-index`, `no-outline-none-without-focus-visible`, `no-physical-box-props`) against a grandfather list in `scripts/lint-css-exceptions.json`. Stale exceptions also fail.
+- Cost: `npm run lint:css -w hub-client` on main takes about 0.2 s wall clock and is clean.
+- `hub-client/design-system.md` names `lint:css` as the enforcement for its rules; `cargo xtask lint`'s `ci-test-suite-unwired` rule only reconciles `test` scripts against CI, so it cannot see this (its own header says so).
+
+### Reproduction
+
+The PR #667 failure is the repro. Saved log excerpt: `claude-notes/plans/verify-lint-css-investigation/pr-667-run-34388639694-lint-css.log`. The offending line:
+
+```
+lint:css[no-physical-box-props] src/components/ReplayDrawer.css:377  margin-left: 0;
+lint:css: 1 problem(s)
+```
+
+A mechanical repro on main: add `margin-left: 0;` to any file under `hub-client/src/`, run `cargo xtask verify` (full leg), observe it passes; run `npm run lint:css -w hub-client`, observe it fails. Not committed as a fixture because the future regression test lives in xtask (see Phase 0), not in a CSS file.
+
+### Wider drift (found while comparing the two gates)
+
+The strand asks about lint:css only, but the same comparison shows other steps CI runs that `verify` does not. Listed so the scope question below is concrete, not to expand the strand unilaterally:
+
+| CI step (workflow / job) | In `verify`? |
+| --- | --- |
+| `npm run lint:css -w hub-client` (ts-test-suite / test-suite) | **no** — this strand |
+| engine-host-deno vitest suite (ts-test-suite / test-suite) | no |
+| engine-host-deno `deno test` x3 (ts-test-suite / test-suite) | no (needs Deno) |
+| engine-host-deno bundle freshness gate (ts-test-suite / test-suite) | no |
+| quarto-api, quarto-automerge-schema, wasm-js-bridge tests (ts-test-suite / workspace-ts-suites) | no |
+| q2-preview-spa `test` + `test:integration` (ts-test-suite / workspace-ts-suites) | no (verify only builds it, step 13) |
+| kanban demo `test` + `test:integration` (ts-test-suite / workspace-ts-suites) | no |
+| pampa `wasm_lua` tests on wasm32 (test-suite / wasm-tests) | no (needs -Zbuild-std + clang) |
+| sync-test-harness tests (hub-client-e2e) | no |
+
+Everything `verify` runs, CI also runs, so the drift is one-directional.
+
+## Proposed phases (draft)
+
+Skeleton only — actual phase contents wait on the design discussion.
+
+- Phase 0 — Test plan. A unit test in `crates/xtask` that fails at HEAD: the `verify` module must invoke `lint:css` (e.g. a step-list/registry the test can inspect, or at minimum a source-level assertion the way `ci_test_wiring` parses workflows). If the answer to Q3 is "yes", the test instead becomes a new repo-level lint rule that parses `ts-test-suite.yml` and asserts each gating step has a `verify` counterpart or an `EXCUSED` entry.
+- Phase 1 — Add the lint:css step to `verify.rs`. Position: with the other fail-fast checks (step 1, next to `cargo xtask lint` + clippy), or at the top of the hub-client leg (step 7) as the strand suggests. Gate it on the same condition as step 7 (`!skip_hub_build`) or on a new `--skip-css-lint`, per Q2. Bump `TOTAL_STEPS` and the module doc.
+- Phase 2 — Optional, per Q3: fold the rest of the drift table in, or file it as separate strands.
+- Phase 3 — Docs: `CLAUDE.md` "Full Project Verification" step list, `hub-client/design-system.md` enforcement sentence, and a note on bd-owmzraf6's plan that the local mirror now exists.
+
+## Open design questions for the user
+
+1. **Placement.** Run lint:css in step 1 with the other fail-fast lints (fails in 0.2 s before the multi-minute Rust build, matching CI's "right after npm ci" placement), or inside the hub-client leg (step 7) as the strand text says? Step 1 means `--skip-hub-build` still runs it, which is what a CSS-only change wants; step 7 means `--skip-hub-build` skips it, which recreates a smaller version of this hole.
+2. **Skip flag.** Does it need its own `--skip-css-lint`, or is it cheap enough to be unconditional (like `cargo xtask lint` and `cargo fmt --check` today)? Note the Node preflight: if it runs unconditionally, `needs_node` must include it, so the "every npm-driven step is disabled" shortcut goes away unless a flag exists.
+3. **Scope.** Fix lint:css only (the strand as filed), or also close the other one-directional drift in the table above? The cheap, Node-only ones (quarto-api, automerge-schema, wasm-js-bridge, q2-preview-spa tests, kanban) are a few seconds each; the Deno and wasm32 ones need toolchains verify does not assume today. My recommendation: lint:css here, file one strand for the Node-only test suites, and one for the Deno/wasm32 legs with a "needs toolchain detection" note.
+4. **Structural guard.** The drift happened because adding a CI step has no counterpart obligation. Do you want a lint rule (sibling of `ci-test-suite-unwired`) that parses the workflows and fails when a gating `run:` step has no `verify` counterpart, or is a doc rule ("when you add a CI step, add the verify step in the same commit", like the error-docs rules) enough?
+
+## Risks / tradeoffs (draft)
+
+- Unconditional Node use in step 1 interacts with the `needs_node` preflight shortcut; must be handled explicitly or `--skip-*` combinations that today avoid Node will start requiring it.
+- If placed under `!skip_hub_build`, the common Rust-only invocation `cargo xtask verify --skip-hub-build` still misses CSS lint. Low risk in practice (Rust-only changes rarely touch CSS) but it is the same class of gap.
+- A structural lint (Q4) is real work and needs an `EXCUSED` list for the Deno/wasm32 steps from day one; without one it would fail immediately on main.

--- a/claude-notes/plans/verify-lint-css-investigation/pr-667-run-34388639694-lint-css.log
+++ b/claude-notes/plans/verify-lint-css-investigation/pr-667-run-34388639694-lint-css.log
@@ -1,0 +1,26 @@
+Run test suite (macos-latest)	Lint hub-client CSS	﻿2026-09-09T18:27:48.3541140Z ##[group]Run npm run lint:css -w hub-client
+Run test suite (macos-latest)	Lint hub-client CSS	2026-09-09T18:27:48.3541980Z ^[[36;1mnpm run lint:css -w hub-client^[[0m
+Run test suite (macos-latest)	Lint hub-client CSS	2026-09-09T18:27:48.6450670Z > hub-client@0.0.0 lint:css
+Run test suite (macos-latest)	Lint hub-client CSS	2026-09-09T18:27:48.8126160Z lint:css[no-physical-box-props] src/components/ReplayDrawer.css:377  margin-left: 0;
+Run test suite (macos-latest)	Lint hub-client CSS	2026-09-09T18:27:48.8127850Z lint:css: 1 problem(s)
+Run test suite (macos-latest)	Lint hub-client CSS	2026-09-09T18:27:48.8164830Z npm error Lifecycle script `lint:css` failed with error:
+Run test suite (macos-latest)	Lint hub-client CSS	2026-09-09T18:27:48.8165700Z npm error code 1
+Run test suite (macos-latest)	Lint hub-client CSS	2026-09-09T18:27:48.8166120Z npm error path /Users/runner/work/q2/q2/hub-client
+Run test suite (macos-latest)	Lint hub-client CSS	2026-09-09T18:27:48.8166730Z npm error workspace hub-client@0.0.0
+Run test suite (macos-latest)	Lint hub-client CSS	2026-09-09T18:27:48.8167700Z npm error location /Users/runner/work/q2/q2/hub-client
+Run test suite (macos-latest)	Lint hub-client CSS	2026-09-09T18:27:48.8168510Z npm error command failed
+Run test suite (macos-latest)	Lint hub-client CSS	2026-09-09T18:27:48.8169160Z npm error command sh -c node scripts/lint-css.mjs
+Run test suite (macos-latest)	Lint hub-client CSS	2026-09-09T18:27:48.8217600Z ##[error]Process completed with exit code 1.
+Run test suite (ubuntu-latest)	Lint hub-client CSS	﻿2026-09-09T18:25:27.7758089Z ##[group]Run npm run lint:css -w hub-client
+Run test suite (ubuntu-latest)	Lint hub-client CSS	2026-09-09T18:25:27.7758714Z ^[[36;1mnpm run lint:css -w hub-client^[[0m
+Run test suite (ubuntu-latest)	Lint hub-client CSS	2026-09-09T18:25:27.8938243Z > hub-client@0.0.0 lint:css
+Run test suite (ubuntu-latest)	Lint hub-client CSS	2026-09-09T18:25:28.0143606Z lint:css[no-physical-box-props] src/components/ReplayDrawer.css:377  margin-left: 0;
+Run test suite (ubuntu-latest)	Lint hub-client CSS	2026-09-09T18:25:28.0146395Z lint:css: 1 problem(s)
+Run test suite (ubuntu-latest)	Lint hub-client CSS	2026-09-09T18:25:28.0204392Z npm error Lifecycle script `lint:css` failed with error:
+Run test suite (ubuntu-latest)	Lint hub-client CSS	2026-09-09T18:25:28.0205370Z npm error code 1
+Run test suite (ubuntu-latest)	Lint hub-client CSS	2026-09-09T18:25:28.0206145Z npm error path /home/runner/work/q2/q2/hub-client
+Run test suite (ubuntu-latest)	Lint hub-client CSS	2026-09-09T18:25:28.0207037Z npm error workspace hub-client@0.0.0
+Run test suite (ubuntu-latest)	Lint hub-client CSS	2026-09-09T18:25:28.0207839Z npm error location /home/runner/work/q2/q2/hub-client
+Run test suite (ubuntu-latest)	Lint hub-client CSS	2026-09-09T18:25:28.0208518Z npm error command failed
+Run test suite (ubuntu-latest)	Lint hub-client CSS	2026-09-09T18:25:28.0209021Z npm error command sh -c node scripts/lint-css.mjs
+Run test suite (ubuntu-latest)	Lint hub-client CSS	2026-09-09T18:25:28.0285583Z ##[error]Process completed with exit code 1.

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -147,7 +147,7 @@ enum Command {
     /// This runs all build and test steps to ensure the entire project is healthy:
     /// 0. Preflight: the `node` on PATH satisfies `engines.node` in package.json
     ///    (fails early; override with Q2_ALLOW_NODE_MISMATCH=1 for experiments)
-    /// 1. Run custom lint checks (cargo xtask lint)
+    /// 1. Run custom lint checks (cargo xtask lint), hub-client lint:css, clippy
     /// 2. Check Rust formatting (cargo fmt --check)
     /// 3. Build all Rust crates (cargo build --workspace, with -D warnings)
     /// 4. Test tree-sitter grammars (tree-sitter test)
@@ -205,6 +205,11 @@ enum Command {
         /// Skip the quarto-sync-client + quarto-hub-mcp package tests.
         #[arg(long)]
         skip_hub_mcp_tests: bool,
+
+        /// Skip the hub-client CSS lint (npm run lint:css). Independent of
+        /// --skip-hub-build: it runs in step 1 with the other fail-fast lints.
+        #[arg(long)]
+        skip_css_lint: bool,
 
         /// Include hub-client e2e tests (slower, requires browser).
         #[arg(long)]
@@ -386,6 +391,7 @@ fn main() -> Result<()> {
             skip_shared_package_tests,
             skip_q2_preview_spa_build,
             skip_hub_mcp_tests,
+            skip_css_lint,
             e2e,
             no_deny_warnings,
         } => {
@@ -402,6 +408,7 @@ fn main() -> Result<()> {
                 skip_shared_package_tests,
                 skip_q2_preview_spa_build,
                 skip_hub_mcp_tests,
+                skip_css_lint,
                 include_e2e: e2e,
                 no_deny_warnings,
             };

--- a/crates/xtask/src/verify.rs
+++ b/crates/xtask/src/verify.rs
@@ -4,7 +4,7 @@
 //! matching the CI environment as closely as possible:
 //! 0. Preflight: the `node` on PATH satisfies `engines.node` (see
 //!    `node_version.rs`; skipped only when every npm-driven step is off)
-//! 1. Run custom lint checks
+//! 1. Run custom lint checks, hub-client `lint:css`, and clippy
 //! 2. Check Rust formatting (cargo fmt --check)
 //! 3. Build all Rust crates (with -D warnings, matching CI)
 //! 4. Test tree-sitter grammars
@@ -28,6 +28,11 @@ use crate::lint;
 use crate::test;
 
 const TOTAL_STEPS: u32 = 14;
+
+/// The hub-client CSS lint, exactly as CI's `Lint hub-client CSS` step in
+/// `.github/workflows/ts-test-suite.yml` runs it (from the repo root, via the
+/// npm workspace). Kept as a constant so a test can hold the two in sync.
+const CSS_LINT_ARGS: [&str; 4] = ["run", "lint:css", "-w", "hub-client"];
 
 /// Configuration for the verify command.
 #[derive(Default)]
@@ -56,10 +61,35 @@ pub struct VerifyConfig {
     pub skip_q2_preview_spa_build: bool,
     /// Skip the quarto-sync-client + quarto-hub-mcp package tests.
     pub skip_hub_mcp_tests: bool,
+    /// Skip the hub-client CSS lint (`npm run lint:css`).
+    pub skip_css_lint: bool,
     /// Run hub-client e2e tests (slower, requires browser).
     pub include_e2e: bool,
     /// Do not set RUSTFLAGS="-D warnings" (allows warnings during iteration).
     pub no_deny_warnings: bool,
+}
+
+/// Whether step 1 runs the hub-client CSS lint. Deliberately independent of
+/// `skip_hub_build`: a CSS-only change verified with `--skip-hub-build` is
+/// exactly the case that slipped past the local gate in PR #667
+/// (bd-4bu7vwi5).
+fn runs_css_lint(config: &VerifyConfig) -> bool {
+    !config.skip_css_lint
+}
+
+/// Whether any npm-driven step is enabled, so the Node preflight has
+/// something to protect. Must list every step that shells out to `npm` or
+/// `node`; a step missing here can run under a mismatched Node unannounced.
+fn needs_node(config: &VerifyConfig) -> bool {
+    runs_css_lint(config)
+        || !(config.skip_ts_packages_build
+            && config.skip_hub_build
+            && config.skip_hub_tests
+            && config.skip_trace_viewer_build
+            && config.skip_trace_viewer_tests
+            && config.skip_shared_package_tests
+            && config.skip_q2_preview_spa_build
+            && config.skip_hub_mcp_tests)
 }
 
 /// Run the verify command.
@@ -72,31 +102,24 @@ pub fn run(config: &VerifyConfig) -> Result<()> {
         Some("-D warnings")
     };
 
-    // Preflight: Node toolchain. Every npm-driven step below (6–14) runs
-    // whatever `node` is first on PATH, and the repo pins a Node major in
-    // `engines.node` / `.nvmrc`. Drift surfaces late and misleadingly (23
-    // unrelated-looking vitest failures under Node 26 — bd-lh30hlvd), so check
-    // first: a mismatch fails in seconds, before the Rust build, with the
-    // cause named. Nothing to check when every npm-driven step is disabled.
-    let needs_node = !(config.skip_ts_packages_build
-        && config.skip_hub_build
-        && config.skip_hub_tests
-        && config.skip_trace_viewer_build
-        && config.skip_trace_viewer_tests
-        && config.skip_shared_package_tests
-        && config.skip_q2_preview_spa_build
-        && config.skip_hub_mcp_tests);
+    // Preflight: Node toolchain. Every npm-driven step below (the css lint
+    // in step 1, then 6–14) runs whatever `node` is first on PATH, and the
+    // repo pins a Node major in `engines.node` / `.nvmrc`. Drift surfaces
+    // late and misleadingly (23 unrelated-looking vitest failures under Node
+    // 26 — bd-lh30hlvd), so check first: a mismatch fails in seconds, before
+    // the Rust build, with the cause named. Nothing to check when every
+    // npm-driven step is disabled.
     println!("\n━━━ Preflight: Node toolchain ━━━\n");
-    if needs_node {
+    if needs_node(config) {
         crate::node_version::preflight_verify(&project_root)?;
     } else {
         println!("  (skipped — every npm-driven step is disabled)");
     }
 
-    // Step 1: Custom lint checks + clippy gate
+    // Step 1: Custom lint checks + hub-client css lint + clippy gate
     {
         println!(
-            "\n━━━ Step 1/{}: Running custom lints + clippy ━━━\n",
+            "\n━━━ Step 1/{}: Running custom lints + lint:css + clippy ━━━\n",
             TOTAL_STEPS
         );
         let lint_config = lint::LintConfig {
@@ -104,6 +127,25 @@ pub fn run(config: &VerifyConfig) -> Result<()> {
             quiet: false,
         };
         lint::run_check(&lint_config)?;
+
+        // hub-client CSS lint (design-system.md's token / logical-property
+        // rules). CI runs it right after `npm ci`, before the WASM build;
+        // it takes ~0.2 s, so it belongs with the fail-fast lints rather
+        // than the hub-client leg. Added after PR #667 passed the whole
+        // local gate and failed CI on a `margin-left: 0` (bd-4bu7vwi5).
+        if runs_css_lint(config) {
+            println!("  ↳ hub-client lint:css...");
+            run_command(
+                "npm",
+                &CSS_LINT_ARGS,
+                &project_root,
+                None,
+                "hub-client lint:css failed (see hub-client/design-system.md)",
+            )?;
+            println!("  ✓ hub-client lint:css clean");
+        } else {
+            println!("  ↳ Skipping hub-client lint:css");
+        }
 
         // Clippy gate (matches the CI step in test-suite.yml). The workspace
         // policy lives in the root Cargo.toml `[workspace.lints.clippy]` table;
@@ -664,4 +706,65 @@ fn run_command(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every npm-driven step disabled, css lint included.
+    fn all_npm_steps_skipped() -> VerifyConfig {
+        VerifyConfig {
+            skip_ts_packages_build: true,
+            skip_hub_build: true,
+            skip_hub_tests: true,
+            skip_trace_viewer_build: true,
+            skip_trace_viewer_tests: true,
+            skip_shared_package_tests: true,
+            skip_q2_preview_spa_build: true,
+            skip_hub_mcp_tests: true,
+            skip_css_lint: true,
+            ..VerifyConfig::default()
+        }
+    }
+
+    #[test]
+    fn css_lint_runs_by_default_and_honours_skip_flag() {
+        assert!(runs_css_lint(&VerifyConfig::default()));
+        assert!(!runs_css_lint(&VerifyConfig {
+            skip_css_lint: true,
+            ..VerifyConfig::default()
+        }));
+        // --skip-hub-build alone must NOT disable it: that was the hole in
+        // bd-4bu7vwi5 (CSS-only change, Rust-only local gate, red CI).
+        assert!(runs_css_lint(&VerifyConfig {
+            skip_hub_build: true,
+            ..VerifyConfig::default()
+        }));
+    }
+
+    #[test]
+    fn node_preflight_counts_css_lint_as_npm_driven() {
+        assert!(needs_node(&VerifyConfig::default()));
+        assert!(!needs_node(&all_npm_steps_skipped()));
+        // Only the css lint left on: still needs Node.
+        let only_css_lint = VerifyConfig {
+            skip_css_lint: false,
+            ..all_npm_steps_skipped()
+        };
+        assert!(needs_node(&only_css_lint));
+    }
+
+    /// The local step must run the same command CI runs, so the two gates
+    /// cannot drift apart silently again (bd-4bu7vwi5: CI got the step in
+    /// 28afc1e14, verify did not).
+    #[test]
+    fn css_lint_command_matches_ci_workflow() {
+        let workflow = include_str!("../../../.github/workflows/ts-test-suite.yml");
+        let local = format!("npm {}", CSS_LINT_ARGS.join(" "));
+        assert!(
+            workflow.contains(&format!("run: {local}")),
+            "ts-test-suite.yml has no `run: {local}` step; keep CI and verify in sync"
+        );
+    }
 }

--- a/hub-client/design-system.md
+++ b/hub-client/design-system.md
@@ -3,7 +3,8 @@
 The hub-client UI is built from a small set of tokens and primitives.
 This page is the contract: follow it when adding or touching UI, and the
 app stays coherent. The enforcement counterparts are `npm run lint:css`
-(off-token values) and the `#/dev/` gallery (keyboard + axe coverage).
+(off-token values; also run by CI and by step 1 of `cargo xtask verify`)
+and the `#/dev/` gallery (keyboard + axe coverage).
 
 ## Tokens (`src/theme.css`)
 


### PR DESCRIPTION
## Why

CI's `ts-test-suite` has run `npm run lint:css -w hub-client` since 28afc1e14 (bd-owmzraf6, 2026-08-28), but `cargo xtask verify` never did. So a CSS change could pass the whole local gate and still fail CI, which is what happened on #667: a `margin-left: 0` passed verify and failed both `Run test suite` legs.

## What

- `cargo xtask verify` step 1 now runs `npm run lint:css -w hub-client` after the custom lints and before clippy. It takes ~0.2 s and fails before any Rust compile.
- It runs independently of `--skip-hub-build` (the combination that let #667 through). New `--skip-css-lint` opt-out; the Node preflight is refactored into `needs_node()` and counts the lint as npm-driven, so the "every npm step disabled" shortcut still works with the flag set.
- Three unit tests in `crates/xtask/src/verify.rs` (written first, seen failing). One reads `ts-test-suite.yml` and asserts the local npm args appear verbatim as a `run:` line, so CI and verify cannot drift on this step silently.
- Docs: `CLAUDE.md` lists the step and flag and adds the rule that a new gating CI step gets its verify counterpart in the same commit; `hub-client/design-system.md` names verify as an enforcement point.
- Plan + saved CI log excerpt: `claude-notes/plans/2026-09-09-verify-lint-css.md`.

Scope is deliberately lint:css only. The wider one-directional drift found while comparing the two gates is filed as bd-l7mcijfe (Node-only suites) and bd-ya2nacaa (legs needing Deno / wasm32 / the hub binary).

## Verification

- End-to-end: appended `margin-left: 0` to `ReplayDrawer.css`, ran verify with every other step skipped, step 1 failed with the same `no-physical-box-props` message CI printed on #667; reverted, same invocation green; `--skip-css-lint` variant skips it and the preflight. Commands and output recorded in the plan.
- `cargo xtask verify --skip-hub-build` green on this branch rebased onto the merged #667 (13818 Rust tests). No snapshot changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMPEfdeqPm59ERFCzeqBim